### PR TITLE
feat: Channel management, messaging, threads, DMs, reactions, and NIP-29 support

### DIFF
--- a/crates/sprout-core/src/kind.rs
+++ b/crates/sprout-core/src/kind.rs
@@ -86,6 +86,8 @@ pub const KIND_STREAM_MESSAGE_SCHEDULED: u32 = 40006;
 pub const KIND_STREAM_REMINDER: u32 = 40007;
 /// Canvas (shared document) for a channel.
 pub const KIND_CANVAS: u32 = 40100;
+/// System message for channel state changes (join, leave, rename, etc.).
+pub const KIND_SYSTEM_MESSAGE: u32 = 40099;
 
 // Direct messages (41000–41999)
 /// A new direct-message conversation was created.
@@ -225,6 +227,7 @@ pub const ALL_KINDS: &[u32] = &[
     KIND_STREAM_MESSAGE_SCHEDULED,
     KIND_STREAM_REMINDER,
     KIND_CANVAS,
+    KIND_SYSTEM_MESSAGE,
     KIND_DM_CREATED,
     KIND_DM_MEMBER_ADDED,
     KIND_DM_MEMBER_REMOVED,

--- a/crates/sprout-db/src/channel.rs
+++ b/crates/sprout-db/src/channel.rs
@@ -166,6 +166,18 @@ pub struct ChannelRecord {
     pub topic_required: bool,
     /// Optional cap on the number of members.
     pub max_members: Option<i32>,
+    /// Current channel topic (short, visible in header).
+    pub topic: Option<String>,
+    /// Compressed public key bytes of the user who last set the topic.
+    pub topic_set_by: Option<Vec<u8>>,
+    /// When the topic was last set.
+    pub topic_set_at: Option<DateTime<Utc>>,
+    /// Channel purpose / description of intent.
+    pub purpose: Option<String>,
+    /// Compressed public key bytes of the user who last set the purpose.
+    pub purpose_set_by: Option<Vec<u8>>,
+    /// When the purpose was last set.
+    pub purpose_set_at: Option<DateTime<Utc>>,
 }
 
 /// A channel membership row as returned from the database.
@@ -241,7 +253,9 @@ pub async fn create_channel(
         r#"
         SELECT id, name, channel_type, visibility, description, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
-               nip29_group_id, topic_required, max_members
+               nip29_group_id, topic_required, max_members,
+               topic, topic_set_by, topic_set_at,
+               purpose, purpose_set_by, purpose_set_at
         FROM channels WHERE id = ?
         "#,
     )
@@ -262,7 +276,9 @@ pub async fn get_channel(pool: &MySqlPool, channel_id: Uuid) -> Result<ChannelRe
         r#"
         SELECT id, name, channel_type, visibility, description, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
-               nip29_group_id, topic_required, max_members
+               nip29_group_id, topic_required, max_members,
+               topic, topic_set_by, topic_set_at,
+               purpose, purpose_set_by, purpose_set_at
         FROM channels WHERE id = ? AND deleted_at IS NULL
         "#,
     )
@@ -450,6 +466,26 @@ pub async fn remove_member(
         }
     }
 
+    // Defense-in-depth: prevent removing the last owner regardless of caller.
+    // Callers (REST handlers, NIP-29 handlers) also check this, but the DB
+    // layer enforces it as the final safety net.
+    let target_role = get_active_role_tx(&mut tx, channel_id, pubkey).await?;
+    if target_role.as_deref() == Some("owner") {
+        let row = sqlx::query(
+            "SELECT COUNT(*) as cnt FROM channel_members \
+             WHERE channel_id = ? AND role = 'owner' AND removed_at IS NULL",
+        )
+        .bind(&channel_id_bytes)
+        .fetch_one(&mut *tx)
+        .await?;
+        let owner_count: i64 = row.try_get("cnt")?;
+        if owner_count <= 1 {
+            return Err(DbError::AccessDenied(
+                "cannot remove the last owner — transfer ownership first".to_string(),
+            ));
+        }
+    }
+
     let result = sqlx::query(
         r#"
         UPDATE channel_members
@@ -543,7 +579,9 @@ pub async fn list_channels(
             r#"
             SELECT id, name, channel_type, visibility, description, canvas,
                    created_by, created_at, updated_at, archived_at, deleted_at,
-                   nip29_group_id, topic_required, max_members
+                   nip29_group_id, topic_required, max_members,
+                   topic, topic_set_by, topic_set_at,
+                   purpose, purpose_set_by, purpose_set_at
             FROM channels
             WHERE deleted_at IS NULL AND visibility = ?
             ORDER BY created_at DESC
@@ -558,7 +596,9 @@ pub async fn list_channels(
             r#"
             SELECT id, name, channel_type, visibility, description, canvas,
                    created_by, created_at, updated_at, archived_at, deleted_at,
-                   nip29_group_id, topic_required, max_members
+                   nip29_group_id, topic_required, max_members,
+                   topic, topic_set_by, topic_set_at,
+                   purpose, purpose_set_by, purpose_set_at
             FROM channels
             WHERE deleted_at IS NULL
             ORDER BY created_at DESC
@@ -600,7 +640,9 @@ async fn get_channel_tx(
         r#"
         SELECT id, name, channel_type, visibility, description, canvas,
                created_by, created_at, updated_at, archived_at, deleted_at,
-               nip29_group_id, topic_required, max_members
+               nip29_group_id, topic_required, max_members,
+               topic, topic_set_by, topic_set_at,
+               purpose, purpose_set_by, purpose_set_at
         FROM channels WHERE id = ? AND deleted_at IS NULL
         "#,
     )
@@ -650,7 +692,9 @@ pub async fn get_accessible_channels(
         r#"
         SELECT DISTINCT c.id, c.name, c.channel_type, c.visibility, c.description, c.canvas,
                c.created_by, c.created_at, c.updated_at, c.archived_at, c.deleted_at,
-               c.nip29_group_id, c.topic_required, c.max_members
+               c.nip29_group_id, c.topic_required, c.max_members,
+               c.topic, c.topic_set_by, c.topic_set_at,
+               c.purpose, c.purpose_set_by, c.purpose_set_at
         FROM channels c
         LEFT JOIN channel_members cm
             ON c.id = cm.channel_id AND cm.pubkey = ? AND cm.removed_at IS NULL
@@ -744,6 +788,15 @@ fn row_to_channel_record(row: sqlx::mysql::MySqlRow) -> Result<ChannelRecord> {
     let id = uuid_from_bytes(&id_bytes)?;
     let topic_required: bool = row.try_get("topic_required")?;
 
+    // topic/purpose fields are new — use try_get and fall back to None if the
+    // column is absent (e.g. queries that don't SELECT these columns yet).
+    let topic: Option<String> = row.try_get("topic").unwrap_or(None);
+    let topic_set_by: Option<Vec<u8>> = row.try_get("topic_set_by").unwrap_or(None);
+    let topic_set_at: Option<DateTime<Utc>> = row.try_get("topic_set_at").unwrap_or(None);
+    let purpose: Option<String> = row.try_get("purpose").unwrap_or(None);
+    let purpose_set_by: Option<Vec<u8>> = row.try_get("purpose_set_by").unwrap_or(None);
+    let purpose_set_at: Option<DateTime<Utc>> = row.try_get("purpose_set_at").unwrap_or(None);
+
     Ok(ChannelRecord {
         id,
         name: row.try_get("name")?,
@@ -759,6 +812,12 @@ fn row_to_channel_record(row: sqlx::mysql::MySqlRow) -> Result<ChannelRecord> {
         nip29_group_id: row.try_get("nip29_group_id")?,
         topic_required,
         max_members: row.try_get("max_members")?,
+        topic,
+        topic_set_by,
+        topic_set_at,
+        purpose,
+        purpose_set_by,
+        purpose_set_at,
     })
 }
 
@@ -774,4 +833,208 @@ fn row_to_member_record(row: sqlx::mysql::MySqlRow) -> Result<MemberRecord> {
         invited_by: row.try_get("invited_by")?,
         removed_at: row.try_get("removed_at")?,
     })
+}
+
+// ── Phase 2: Channel Metadata ─────────────────────────────────────────────────
+
+/// Partial update for channel name/description.
+pub struct ChannelUpdate {
+    /// New channel name, or `None` to leave unchanged.
+    pub name: Option<String>,
+    /// New channel description, or `None` to leave unchanged.
+    pub description: Option<String>,
+}
+
+/// Updates channel name and/or description dynamically.
+///
+/// At least one field must be `Some`; returns `InvalidData` otherwise.
+/// Returns the updated `ChannelRecord` on success.
+pub async fn update_channel(
+    pool: &MySqlPool,
+    channel_id: Uuid,
+    updates: ChannelUpdate,
+) -> Result<ChannelRecord> {
+    if updates.name.is_none() && updates.description.is_none() {
+        return Err(DbError::InvalidData(
+            "at least one field must be provided for update".to_string(),
+        ));
+    }
+
+    let id_bytes = channel_id.as_bytes().as_slice().to_vec();
+
+    // Build SET clause dynamically — only include fields that are Some.
+    let mut set_parts: Vec<&str> = Vec::new();
+    if updates.name.is_some() {
+        set_parts.push("name = ?");
+    }
+    if updates.description.is_some() {
+        set_parts.push("description = ?");
+    }
+    let sql = format!(
+        "UPDATE channels SET {}, updated_at = NOW(6) WHERE id = ? AND deleted_at IS NULL",
+        set_parts.join(", ")
+    );
+
+    let mut q = sqlx::query(&sql);
+    if let Some(ref name) = updates.name {
+        q = q.bind(name);
+    }
+    if let Some(ref desc) = updates.description {
+        q = q.bind(desc);
+    }
+    q = q.bind(&id_bytes);
+
+    let result = q.execute(pool).await?;
+    if result.rows_affected() == 0 {
+        return Err(DbError::ChannelNotFound(channel_id));
+    }
+
+    get_channel(pool, channel_id).await
+}
+
+/// Sets the topic for a channel, recording who set it and when.
+pub async fn set_topic(
+    pool: &MySqlPool,
+    channel_id: Uuid,
+    topic: &str,
+    set_by: &[u8],
+) -> Result<()> {
+    let id_bytes = channel_id.as_bytes().as_slice().to_vec();
+    let result = sqlx::query(
+        "UPDATE channels SET topic = ?, topic_set_by = ?, topic_set_at = NOW(6) \
+         WHERE id = ? AND deleted_at IS NULL",
+    )
+    .bind(topic)
+    .bind(set_by)
+    .bind(&id_bytes)
+    .execute(pool)
+    .await?;
+    if result.rows_affected() == 0 {
+        return Err(DbError::ChannelNotFound(channel_id));
+    }
+    Ok(())
+}
+
+/// Sets the purpose for a channel, recording who set it and when.
+pub async fn set_purpose(
+    pool: &MySqlPool,
+    channel_id: Uuid,
+    purpose: &str,
+    set_by: &[u8],
+) -> Result<()> {
+    let id_bytes = channel_id.as_bytes().as_slice().to_vec();
+    let result = sqlx::query(
+        "UPDATE channels SET purpose = ?, purpose_set_by = ?, purpose_set_at = NOW(6) \
+         WHERE id = ? AND deleted_at IS NULL",
+    )
+    .bind(purpose)
+    .bind(set_by)
+    .bind(&id_bytes)
+    .execute(pool)
+    .await?;
+    if result.rows_affected() == 0 {
+        return Err(DbError::ChannelNotFound(channel_id));
+    }
+    Ok(())
+}
+
+/// Archives a channel.
+///
+/// Returns `AccessDenied` if the channel is already archived.
+/// Returns `ChannelNotFound` if the channel does not exist or is deleted.
+pub async fn archive_channel(pool: &MySqlPool, channel_id: Uuid) -> Result<()> {
+    let id_bytes = channel_id.as_bytes().as_slice().to_vec();
+
+    // First check: does the channel exist and what is its state?
+    let row = sqlx::query("SELECT archived_at FROM channels WHERE id = ? AND deleted_at IS NULL")
+        .bind(&id_bytes)
+        .fetch_optional(pool)
+        .await?;
+
+    match row {
+        None => return Err(DbError::ChannelNotFound(channel_id)),
+        Some(r) => {
+            let archived_at: Option<DateTime<Utc>> = r.try_get("archived_at")?;
+            if archived_at.is_some() {
+                return Err(DbError::AccessDenied(
+                    "channel is already archived".to_string(),
+                ));
+            }
+        }
+    }
+
+    sqlx::query(
+        "UPDATE channels SET archived_at = NOW(6) \
+         WHERE id = ? AND deleted_at IS NULL AND archived_at IS NULL",
+    )
+    .bind(&id_bytes)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Unarchives a channel.
+///
+/// Returns `AccessDenied` if the channel is not currently archived.
+/// Returns `ChannelNotFound` if the channel does not exist or is deleted.
+pub async fn unarchive_channel(pool: &MySqlPool, channel_id: Uuid) -> Result<()> {
+    let id_bytes = channel_id.as_bytes().as_slice().to_vec();
+
+    // First check: does the channel exist and what is its state?
+    let row = sqlx::query("SELECT archived_at FROM channels WHERE id = ? AND deleted_at IS NULL")
+        .bind(&id_bytes)
+        .fetch_optional(pool)
+        .await?;
+
+    match row {
+        None => return Err(DbError::ChannelNotFound(channel_id)),
+        Some(r) => {
+            let archived_at: Option<DateTime<Utc>> = r.try_get("archived_at")?;
+            if archived_at.is_none() {
+                return Err(DbError::AccessDenied("channel is not archived".to_string()));
+            }
+        }
+    }
+
+    sqlx::query(
+        "UPDATE channels SET archived_at = NULL \
+         WHERE id = ? AND deleted_at IS NULL AND archived_at IS NOT NULL",
+    )
+    .bind(&id_bytes)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Returns the count of active (non-removed) members in a channel.
+pub async fn get_member_count(pool: &MySqlPool, channel_id: Uuid) -> Result<i64> {
+    let id_bytes = channel_id.as_bytes().as_slice().to_vec();
+    let row = sqlx::query(
+        "SELECT COUNT(*) as cnt FROM channel_members WHERE channel_id = ? AND removed_at IS NULL",
+    )
+    .bind(&id_bytes)
+    .fetch_one(pool)
+    .await?;
+    Ok(row.try_get("cnt")?)
+}
+
+/// Get the active role of a pubkey in a channel.
+///
+/// Returns `None` if the pubkey is not an active member.
+pub async fn get_member_role(
+    pool: &MySqlPool,
+    channel_id: Uuid,
+    pubkey: &[u8],
+) -> Result<Option<String>> {
+    let channel_id_bytes = channel_id.as_bytes().as_slice().to_vec();
+    let row = sqlx::query(
+        "SELECT role FROM channel_members WHERE channel_id = ? AND pubkey = ? AND removed_at IS NULL",
+    )
+    .bind(&channel_id_bytes)
+    .bind(pubkey)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|r| r.try_get("role")).transpose()?)
 }

--- a/crates/sprout-db/src/dm.rs
+++ b/crates/sprout-db/src/dm.rs
@@ -1,0 +1,443 @@
+//! Direct message channel persistence.
+//!
+//! DMs are channels with channel_type='dm' and visibility='private'.
+//! Participant sets are immutable — adding a member creates a NEW DM.
+
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use sqlx::{MySqlPool, Row};
+use uuid::Uuid;
+
+use crate::channel::ChannelRecord;
+use crate::error::{DbError, Result};
+use crate::event::uuid_from_bytes;
+
+// ── Public structs ────────────────────────────────────────────────────────────
+
+/// A DM conversation with its participant list.
+#[derive(Debug, Clone)]
+pub struct DmRecord {
+    /// The underlying channel ID.
+    pub channel_id: Uuid,
+    /// All active participants in this DM.
+    pub participants: Vec<DmParticipant>,
+    /// When the last message was sent (approximated by channel updated_at).
+    pub last_message_at: Option<DateTime<Utc>>,
+    /// When the DM was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// A single participant in a DM.
+#[derive(Debug, Clone)]
+pub struct DmParticipant {
+    /// Compressed public key bytes.
+    pub pubkey: Vec<u8>,
+    /// Optional display name from the users table.
+    pub display_name: Option<String>,
+    /// Member role string (always "member" for DMs).
+    pub role: String,
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+/// Compute a stable SHA-256 fingerprint for a set of participant pubkeys.
+///
+/// Pubkeys are sorted lexicographically before hashing so that the same set
+/// of participants always produces the same hash regardless of input order.
+/// No separator is used because all pubkeys are fixed-width 32-byte values.
+pub fn compute_participant_hash(pubkeys: &[&[u8]]) -> [u8; 32] {
+    let mut sorted: Vec<&[u8]> = pubkeys.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+
+    let mut hasher = Sha256::new();
+    for pk in sorted {
+        hasher.update(pk);
+    }
+    hasher.finalize().into()
+}
+
+// ── DB functions ──────────────────────────────────────────────────────────────
+
+/// Find an existing DM by its participant hash.
+///
+/// Returns `None` if no matching DM exists or if it has been deleted.
+pub async fn find_dm_by_participants(
+    pool: &MySqlPool,
+    participant_hash: &[u8],
+) -> Result<Option<ChannelRecord>> {
+    let row = sqlx::query(
+        r#"
+        SELECT id, name, channel_type, visibility, description, canvas,
+               created_by, created_at, updated_at, archived_at, deleted_at,
+               nip29_group_id, topic_required, max_members,
+               topic, topic_set_by, topic_set_at,
+               purpose, purpose_set_by, purpose_set_at
+        FROM channels
+        WHERE participant_hash = ?
+          AND channel_type = 'dm'
+          AND deleted_at IS NULL
+        LIMIT 1
+        "#,
+    )
+    .bind(participant_hash)
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_channel_record).transpose()
+}
+
+/// Create a new DM channel for the given participant pubkeys, or return the
+/// existing one if a DM with the same participant set already exists.
+///
+/// Rules:
+/// - `participants` must contain 2–9 entries (enforced here).
+/// - `created_by` must be one of the participants.
+/// - The operation is idempotent: same participant set → same channel returned.
+pub async fn create_dm(
+    pool: &MySqlPool,
+    participants: &[&[u8]],
+    created_by: &[u8],
+) -> Result<ChannelRecord> {
+    if participants.len() < 2 {
+        return Err(DbError::InvalidData(
+            "DM requires at least 2 participants".to_string(),
+        ));
+    }
+    if participants.len() > 9 {
+        return Err(DbError::InvalidData(
+            "DM supports at most 9 participants".to_string(),
+        ));
+    }
+    for pk in participants {
+        if pk.len() != 32 {
+            return Err(DbError::InvalidData(format!(
+                "pubkey must be 32 bytes, got {}",
+                pk.len()
+            )));
+        }
+    }
+
+    let hash = compute_participant_hash(participants);
+
+    let mut tx = pool.begin().await?;
+
+    // Idempotency check inside the transaction.
+    let existing = sqlx::query(
+        r#"
+        SELECT id, name, channel_type, visibility, description, canvas,
+               created_by, created_at, updated_at, archived_at, deleted_at,
+               nip29_group_id, topic_required, max_members,
+               topic, topic_set_by, topic_set_at,
+               purpose, purpose_set_by, purpose_set_at
+        FROM channels
+        WHERE participant_hash = ?
+          AND channel_type = 'dm'
+          AND deleted_at IS NULL
+        LIMIT 1
+        "#,
+    )
+    .bind(hash.as_slice())
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    if let Some(row) = existing {
+        tx.commit().await?;
+        return row_to_channel_record(row);
+    }
+
+    // Name the DM based on participant count.
+    let name = if participants.len() == 2 {
+        "DM".to_string()
+    } else {
+        format!("Group DM ({})", participants.len())
+    };
+
+    let id = Uuid::new_v4();
+    let id_bytes = id.as_bytes().as_slice().to_vec();
+
+    sqlx::query(
+        r#"
+        INSERT INTO channels
+            (id, name, channel_type, visibility, created_by, participant_hash)
+        VALUES (?, ?, 'dm', 'private', ?, ?)
+        "#,
+    )
+    .bind(&id_bytes)
+    .bind(&name)
+    .bind(created_by)
+    .bind(hash.as_slice())
+    .execute(&mut *tx)
+    .await?;
+
+    // Add all participants as members with role='member'.
+    for pk in participants {
+        sqlx::query(
+            r#"
+            INSERT INTO channel_members (channel_id, pubkey, role, invited_by)
+            VALUES (?, ?, 'member', ?)
+            ON DUPLICATE KEY UPDATE
+                removed_at = NULL,
+                removed_by = NULL,
+                role = VALUES(role)
+            "#,
+        )
+        .bind(&id_bytes)
+        .bind(*pk)
+        .bind(created_by)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    let row = sqlx::query(
+        r#"
+        SELECT id, name, channel_type, visibility, description, canvas,
+               created_by, created_at, updated_at, archived_at, deleted_at,
+               nip29_group_id, topic_required, max_members,
+               topic, topic_set_by, topic_set_at,
+               purpose, purpose_set_by, purpose_set_at
+        FROM channels WHERE id = ?
+        "#,
+    )
+    .bind(&id_bytes)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    let record = row_to_channel_record(row)?;
+    tx.commit().await?;
+    Ok(record)
+}
+
+/// List all DM conversations for a given user, ordered by most recent activity.
+///
+/// Includes participant details for each DM. Supports cursor-based pagination
+/// using `updated_at` ordering.
+pub async fn list_dms_for_user(
+    pool: &MySqlPool,
+    pubkey: &[u8],
+    limit: u32,
+    cursor: Option<Uuid>,
+) -> Result<Vec<DmRecord>> {
+    let limit = limit.min(200) as i64;
+
+    // Resolve cursor to a timestamp for keyset pagination.
+    let cursor_ts: Option<DateTime<Utc>> = if let Some(cid) = cursor {
+        let cid_bytes = cid.as_bytes().as_slice().to_vec();
+        let row = sqlx::query("SELECT updated_at FROM channels WHERE id = ?")
+            .bind(&cid_bytes)
+            .fetch_optional(pool)
+            .await?;
+        row.map(|r| r.try_get::<DateTime<Utc>, _>("updated_at"))
+            .transpose()?
+    } else {
+        None
+    };
+
+    // Fetch DM channel IDs where this user is an active member.
+    let channel_rows = if let Some(ts) = cursor_ts {
+        sqlx::query(
+            r#"
+            SELECT c.id, c.created_at, c.updated_at
+            FROM channels c
+            JOIN channel_members cm
+                ON c.id = cm.channel_id
+               AND cm.pubkey = ?
+               AND cm.removed_at IS NULL
+            WHERE c.channel_type = 'dm'
+              AND c.deleted_at IS NULL
+              AND c.updated_at < ?
+            ORDER BY c.updated_at DESC
+            LIMIT ?
+            "#,
+        )
+        .bind(pubkey)
+        .bind(ts)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?
+    } else {
+        sqlx::query(
+            r#"
+            SELECT c.id, c.created_at, c.updated_at
+            FROM channels c
+            JOIN channel_members cm
+                ON c.id = cm.channel_id
+               AND cm.pubkey = ?
+               AND cm.removed_at IS NULL
+            WHERE c.channel_type = 'dm'
+              AND c.deleted_at IS NULL
+            ORDER BY c.updated_at DESC
+            LIMIT ?
+            "#,
+        )
+        .bind(pubkey)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?
+    };
+
+    let mut results = Vec::with_capacity(channel_rows.len());
+
+    for row in channel_rows {
+        let id_bytes: Vec<u8> = row.try_get("id")?;
+        let channel_id = uuid_from_bytes(&id_bytes)?;
+        let created_at: DateTime<Utc> = row.try_get("created_at")?;
+        let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
+
+        // Fetch participants for this DM.
+        let member_rows = sqlx::query(
+            r#"
+            SELECT cm.pubkey, cm.role, u.display_name
+            FROM channel_members cm
+            LEFT JOIN users u ON cm.pubkey = u.pubkey
+            WHERE cm.channel_id = ?
+              AND cm.removed_at IS NULL
+            ORDER BY cm.joined_at ASC
+            "#,
+        )
+        .bind(&id_bytes)
+        .fetch_all(pool)
+        .await?;
+
+        let participants: Vec<DmParticipant> = member_rows
+            .into_iter()
+            .map(|r| -> Result<DmParticipant> {
+                Ok(DmParticipant {
+                    pubkey: r.try_get("pubkey")?,
+                    display_name: r.try_get("display_name")?,
+                    role: r.try_get("role")?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        results.push(DmRecord {
+            channel_id,
+            participants,
+            last_message_at: Some(updated_at),
+            created_at,
+        });
+    }
+
+    Ok(results)
+}
+
+/// Open or retrieve a DM for the given set of participants.
+///
+/// `created_by` is automatically added to `pubkeys` if not already present,
+/// ensuring the caller is always a participant in their own DM.
+///
+/// Returns `(channel, was_created)`:
+/// - `was_created = true`  — a new DM was created.
+/// - `was_created = false` — an existing DM was returned.
+pub async fn open_dm(
+    pool: &MySqlPool,
+    pubkeys: &[&[u8]],
+    created_by: &[u8],
+) -> Result<(ChannelRecord, bool)> {
+    // Merge created_by into the participant set (dedup handled by compute_participant_hash).
+    let mut all: Vec<&[u8]> = pubkeys.to_vec();
+    if !all.contains(&created_by) {
+        all.push(created_by);
+    }
+
+    // Enforce max before hitting the DB.
+    if all.len() > 9 {
+        return Err(DbError::InvalidData(
+            "DM supports at most 9 participants".to_string(),
+        ));
+    }
+
+    let hash = compute_participant_hash(&all);
+
+    // Check for existing DM first (fast path, no transaction).
+    if let Some(existing) = find_dm_by_participants(pool, &hash).await? {
+        return Ok((existing, false));
+    }
+
+    // Create new DM.
+    let channel = create_dm(pool, &all, created_by).await?;
+
+    // Determine if we actually created it by checking the created_at/updated_at delta.
+    // A simpler approach: re-check the hash. If created_at == updated_at it's brand new.
+    // But the most reliable signal is whether find_dm returned None above.
+    // Since create_dm is idempotent (returns existing if race occurred), we check
+    // whether the channel was just created by comparing created_at ≈ now.
+    // For simplicity, we return true here — the caller treats it as "just created".
+    // In the race case (two concurrent open_dm calls), one will get true and one false
+    // (the second call's create_dm returns the existing record, but we already checked
+    // above and got None). This is an acceptable edge case for idempotent DM creation.
+    Ok((channel, true))
+}
+
+// ── Row mapping ───────────────────────────────────────────────────────────────
+
+fn row_to_channel_record(row: sqlx::mysql::MySqlRow) -> Result<ChannelRecord> {
+    let id_bytes: Vec<u8> = row.try_get("id")?;
+    let id = uuid_from_bytes(&id_bytes)?;
+    let topic_required: bool = row.try_get("topic_required")?;
+
+    Ok(ChannelRecord {
+        id,
+        name: row.try_get("name")?,
+        channel_type: row.try_get("channel_type")?,
+        visibility: row.try_get("visibility")?,
+        description: row.try_get("description")?,
+        canvas: row.try_get("canvas")?,
+        created_by: row.try_get("created_by")?,
+        created_at: row.try_get("created_at")?,
+        updated_at: row.try_get("updated_at")?,
+        archived_at: row.try_get("archived_at")?,
+        deleted_at: row.try_get("deleted_at")?,
+        nip29_group_id: row.try_get("nip29_group_id")?,
+        topic_required,
+        max_members: row.try_get("max_members")?,
+        topic: row.try_get("topic").unwrap_or(None),
+        topic_set_by: row.try_get("topic_set_by").unwrap_or(None),
+        topic_set_at: row.try_get("topic_set_at").unwrap_or(None),
+        purpose: row.try_get("purpose").unwrap_or(None),
+        purpose_set_by: row.try_get("purpose_set_by").unwrap_or(None),
+        purpose_set_at: row.try_get("purpose_set_at").unwrap_or(None),
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn participant_hash_is_order_independent() {
+        let a = [1u8; 32];
+        let b = [2u8; 32];
+        let h1 = compute_participant_hash(&[&a, &b]);
+        let h2 = compute_participant_hash(&[&b, &a]);
+        assert_eq!(h1, h2, "hash must be the same regardless of input order");
+    }
+
+    #[test]
+    fn participant_hash_deduplicates() {
+        let a = [1u8; 32];
+        let h1 = compute_participant_hash(&[&a, &a]);
+        let h2 = compute_participant_hash(&[&a]);
+        assert_eq!(h1, h2, "duplicate pubkeys should be deduped before hashing");
+    }
+
+    #[test]
+    fn participant_hash_differs_for_different_sets() {
+        let a = [1u8; 32];
+        let b = [2u8; 32];
+        let c = [3u8; 32];
+        let h_ab = compute_participant_hash(&[&a, &b]);
+        let h_ac = compute_participant_hash(&[&a, &c]);
+        assert_ne!(h_ab, h_ac);
+    }
+
+    #[test]
+    fn participant_hash_returns_32_bytes() {
+        let a = [0u8; 32];
+        let b = [255u8; 32];
+        let h = compute_participant_hash(&[&a, &b]);
+        assert_eq!(h.len(), 32);
+    }
+}

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -13,6 +13,8 @@
 pub mod api_token;
 /// Channel and membership persistence.
 pub mod channel;
+/// Direct message channel persistence.
+pub mod dm;
 /// Database error types.
 pub mod error;
 /// Event storage and retrieval.
@@ -21,6 +23,10 @@ pub mod event;
 pub mod feed;
 /// Monthly table partition management.
 pub mod partition;
+/// Reaction persistence.
+pub mod reaction;
+/// Thread metadata persistence.
+pub mod thread;
 /// User profile persistence.
 pub mod user;
 /// Workflow, run, and approval persistence.
@@ -272,11 +278,207 @@ impl Db {
         channel::get_users_bulk(&self.pool, pubkeys).await
     }
 
+    // ── Channel Metadata ─────────────────────────────────────────────────────
+
+    /// Updates a channel's name and/or description.
+    pub async fn update_channel(
+        &self,
+        channel_id: Uuid,
+        updates: channel::ChannelUpdate,
+    ) -> Result<channel::ChannelRecord> {
+        channel::update_channel(&self.pool, channel_id, updates).await
+    }
+
+    /// Sets the topic for a channel.
+    pub async fn set_topic(&self, channel_id: Uuid, topic: &str, set_by: &[u8]) -> Result<()> {
+        channel::set_topic(&self.pool, channel_id, topic, set_by).await
+    }
+
+    /// Sets the purpose for a channel.
+    pub async fn set_purpose(&self, channel_id: Uuid, purpose: &str, set_by: &[u8]) -> Result<()> {
+        channel::set_purpose(&self.pool, channel_id, purpose, set_by).await
+    }
+
+    /// Archives a channel.
+    pub async fn archive_channel(&self, channel_id: Uuid) -> Result<()> {
+        channel::archive_channel(&self.pool, channel_id).await
+    }
+
+    /// Unarchives a channel.
+    pub async fn unarchive_channel(&self, channel_id: Uuid) -> Result<()> {
+        channel::unarchive_channel(&self.pool, channel_id).await
+    }
+
+    /// Returns the count of active members in a channel.
+    pub async fn get_member_count(&self, channel_id: Uuid) -> Result<i64> {
+        channel::get_member_count(&self.pool, channel_id).await
+    }
+
+    /// Returns the active role of a pubkey in a channel.
+    pub async fn get_member_role(&self, channel_id: Uuid, pubkey: &[u8]) -> Result<Option<String>> {
+        channel::get_member_role(&self.pool, channel_id, pubkey).await
+    }
+
+    // ── Threads ───────────────────────────────────────────────────────────────
+
+    /// Insert a row into `thread_metadata`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn insert_thread_metadata(
+        &self,
+        event_id: &[u8],
+        event_created_at: DateTime<Utc>,
+        channel_id: Uuid,
+        parent_event_id: Option<&[u8]>,
+        parent_event_created_at: Option<DateTime<Utc>>,
+        root_event_id: Option<&[u8]>,
+        root_event_created_at: Option<DateTime<Utc>>,
+        depth: i32,
+        broadcast: bool,
+    ) -> Result<()> {
+        thread::insert_thread_metadata(
+            &self.pool,
+            event_id,
+            event_created_at,
+            channel_id,
+            parent_event_id,
+            parent_event_created_at,
+            root_event_id,
+            root_event_created_at,
+            depth,
+            broadcast,
+        )
+        .await
+    }
+
+    /// Fetch replies within a thread, optionally limited by depth.
+    pub async fn get_thread_replies(
+        &self,
+        root_event_id: &[u8],
+        depth_limit: Option<u32>,
+        limit: u32,
+        cursor: Option<&[u8]>,
+    ) -> Result<Vec<thread::ThreadReply>> {
+        thread::get_thread_replies(&self.pool, root_event_id, depth_limit, limit, cursor).await
+    }
+
+    /// Get aggregated thread statistics for a root message.
+    pub async fn get_thread_summary(
+        &self,
+        event_id: &[u8],
+    ) -> Result<Option<thread::ThreadSummary>> {
+        thread::get_thread_summary(&self.pool, event_id).await
+    }
+
+    /// Get top-level channel messages with optional thread summaries.
+    pub async fn get_channel_messages_top_level(
+        &self,
+        channel_id: Uuid,
+        limit: u32,
+        before: Option<DateTime<Utc>>,
+    ) -> Result<Vec<thread::TopLevelMessage>> {
+        thread::get_channel_messages_top_level(&self.pool, channel_id, limit, before).await
+    }
+
+    /// Fetch a raw thread_metadata row by event ID.
+    pub async fn get_thread_metadata_by_event(
+        &self,
+        event_id: &[u8],
+    ) -> Result<Option<thread::ThreadMetadataRecord>> {
+        thread::get_thread_metadata_by_event(&self.pool, event_id).await
+    }
+
+    // ── DMs ───────────────────────────────────────────────────────────────────
+
+    /// Open (or find existing) a DM channel for the given set of pubkeys.
+    pub async fn open_dm(
+        &self,
+        pubkeys: &[&[u8]],
+        created_by: &[u8],
+    ) -> Result<(channel::ChannelRecord, bool)> {
+        dm::open_dm(&self.pool, pubkeys, created_by).await
+    }
+
+    /// List all DM conversations for a given user.
+    pub async fn list_dms_for_user(
+        &self,
+        pubkey: &[u8],
+        limit: u32,
+        cursor: Option<Uuid>,
+    ) -> Result<Vec<dm::DmRecord>> {
+        dm::list_dms_for_user(&self.pool, pubkey, limit, cursor).await
+    }
+
+    /// Find an existing DM by its participant hash.
+    pub async fn find_dm_by_participants(
+        &self,
+        participant_hash: &[u8],
+    ) -> Result<Option<channel::ChannelRecord>> {
+        dm::find_dm_by_participants(&self.pool, participant_hash).await
+    }
+
+    // ── Reactions ─────────────────────────────────────────────────────────────
+
+    /// Add (or re-activate) a reaction.
+    pub async fn add_reaction(
+        &self,
+        event_id: &[u8],
+        event_created_at: DateTime<Utc>,
+        pubkey: &[u8],
+        emoji: &str,
+    ) -> Result<bool> {
+        reaction::add_reaction(&self.pool, event_id, event_created_at, pubkey, emoji).await
+    }
+
+    /// Soft-delete a reaction.
+    pub async fn remove_reaction(
+        &self,
+        event_id: &[u8],
+        event_created_at: DateTime<Utc>,
+        pubkey: &[u8],
+        emoji: &str,
+    ) -> Result<bool> {
+        reaction::remove_reaction(&self.pool, event_id, event_created_at, pubkey, emoji).await
+    }
+
+    /// Get all active reactions for an event, grouped by emoji.
+    pub async fn get_reactions(
+        &self,
+        event_id: &[u8],
+        event_created_at: DateTime<Utc>,
+        limit: u32,
+        cursor: Option<&str>,
+    ) -> Result<Vec<reaction::ReactionGroup>> {
+        reaction::get_reactions(&self.pool, event_id, event_created_at, limit, cursor).await
+    }
+
+    /// Batch-fetch emoji counts for a set of (event_id, event_created_at) pairs.
+    pub async fn get_reactions_bulk(
+        &self,
+        event_ids: &[(&[u8], DateTime<Utc>)],
+    ) -> Result<Vec<reaction::BulkReactionEntry>> {
+        reaction::get_reactions_bulk(&self.pool, event_ids).await
+    }
+
     // ── Users ────────────────────────────────────────────────────────────────
 
     /// Ensures a user row exists for the given pubkey (upsert).
     pub async fn ensure_user(&self, pubkey: &[u8]) -> Result<()> {
         user::ensure_user(&self.pool, pubkey).await
+    }
+
+    /// Fetch a user profile by pubkey.
+    pub async fn get_user(&self, pubkey: &[u8]) -> Result<Option<user::UserProfile>> {
+        user::get_user(&self.pool, pubkey).await
+    }
+
+    /// Update a user's display_name and/or avatar_url.
+    pub async fn update_user_profile(
+        &self,
+        pubkey: &[u8],
+        display_name: Option<&str>,
+        avatar_url: Option<&str>,
+    ) -> Result<()> {
+        user::update_user_profile(&self.pool, pubkey, display_name, avatar_url).await
     }
 
     // ── API Tokens ───────────────────────────────────────────────────────────

--- a/crates/sprout-db/src/reaction.rs
+++ b/crates/sprout-db/src/reaction.rs
@@ -1,0 +1,262 @@
+//! Reaction persistence.
+//!
+//! One reaction per user per emoji per event. Soft-delete via removed_at.
+
+use chrono::{DateTime, Utc};
+use sqlx::{MySqlPool, Row};
+
+use crate::error::Result;
+
+// ── Public structs ────────────────────────────────────────────────────────────
+
+/// A grouped set of reactions for a single emoji on an event.
+#[derive(Debug, Clone)]
+pub struct ReactionGroup {
+    /// The emoji character or shortcode used in this reaction group.
+    pub emoji: String,
+    /// Total number of active reactions with this emoji.
+    pub count: i64,
+    /// Individual users who reacted with this emoji.
+    pub users: Vec<ReactionUser>,
+}
+
+/// A single user who reacted with a given emoji.
+#[derive(Debug, Clone)]
+pub struct ReactionUser {
+    /// Compressed 33-byte public key of the reacting user.
+    pub pubkey: Vec<u8>,
+    /// Optional display name resolved from the users table.
+    pub display_name: Option<String>,
+}
+
+/// Bulk reaction entry for embedding in message lists.
+#[derive(Debug, Clone)]
+pub struct BulkReactionEntry {
+    /// The event this reaction entry belongs to.
+    pub event_id: Vec<u8>,
+    /// Partition key timestamp for the event.
+    pub event_created_at: DateTime<Utc>,
+    /// Emoji + count summaries for this event.
+    pub reactions: Vec<ReactionSummary>,
+}
+
+/// Emoji + count summary (no user list) for bulk fetches.
+#[derive(Debug, Clone)]
+pub struct ReactionSummary {
+    /// The emoji character or shortcode.
+    pub emoji: String,
+    /// Number of active reactions with this emoji.
+    pub count: i64,
+}
+
+// ── Write operations ──────────────────────────────────────────────────────────
+
+/// Add (or re-activate) a reaction.
+///
+/// Returns `Ok(true)` if the reaction was added or re-activated, `Ok(false)` if
+/// the reaction is already active (duplicate, no change made).
+///
+/// Uses `INSERT ... ON DUPLICATE KEY UPDATE` to eliminate the TOCTOU race where
+/// two concurrent adds both see no existing row and then race to INSERT.
+/// MySQL rows_affected semantics (CLIENT_FOUND_ROWS off):
+///   1 = new row inserted → added
+///   2 = existing row updated (reactivated from soft-delete) → re-added
+///   0 = duplicate key matched but no values changed (already active) → no-op
+pub async fn add_reaction(
+    pool: &MySqlPool,
+    event_id: &[u8],
+    event_created_at: DateTime<Utc>,
+    pubkey: &[u8],
+    emoji: &str,
+) -> Result<bool> {
+    let result = sqlx::query(
+        r#"
+        INSERT INTO reactions (event_created_at, event_id, pubkey, emoji)
+        VALUES (?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+            created_at = IF(removed_at IS NOT NULL, NOW(6), created_at),
+            removed_at = NULL
+        "#,
+    )
+    .bind(event_created_at)
+    .bind(event_id)
+    .bind(pubkey)
+    .bind(emoji)
+    .execute(pool)
+    .await?;
+
+    // rows_affected = 0 means the row already existed and was already active
+    // (removed_at was already NULL, so no values changed).
+    Ok(result.rows_affected() != 0)
+}
+
+/// Soft-delete a reaction by setting `removed_at`.
+///
+/// Returns `true` if a row was updated, `false` if not found or already removed.
+pub async fn remove_reaction(
+    pool: &MySqlPool,
+    event_id: &[u8],
+    event_created_at: DateTime<Utc>,
+    pubkey: &[u8],
+    emoji: &str,
+) -> Result<bool> {
+    let result = sqlx::query(
+        r#"
+        UPDATE reactions
+        SET removed_at = NOW(6)
+        WHERE event_created_at = ?
+          AND event_id = ?
+          AND pubkey = ?
+          AND emoji = ?
+          AND removed_at IS NULL
+        "#,
+    )
+    .bind(event_created_at)
+    .bind(event_id)
+    .bind(pubkey)
+    .bind(emoji)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+// ── Read operations ───────────────────────────────────────────────────────────
+
+/// Get all active reactions for an event, grouped by emoji.
+///
+/// Returns one [`ReactionGroup`] per emoji, each containing the list of reacting
+/// user pubkeys. Display names are NOT resolved here — callers should enrich via
+/// `get_users_bulk` if needed.
+///
+/// `cursor` is reserved for future keyset pagination (currently unused).
+pub async fn get_reactions(
+    pool: &MySqlPool,
+    event_id: &[u8],
+    event_created_at: DateTime<Utc>,
+    limit: u32,
+    _cursor: Option<&str>,
+) -> Result<Vec<ReactionGroup>> {
+    // Raise the GROUP_CONCAT length limit for this session. The default (1024 bytes)
+    // truncates at ~15 users with 64-char hex pubkeys. 1 MiB handles any realistic load.
+    sqlx::query("SET SESSION group_concat_max_len = 1048576")
+        .execute(pool)
+        .await?;
+
+    let rows = sqlx::query(
+        r#"
+        SELECT emoji,
+               COUNT(*) AS count,
+               GROUP_CONCAT(HEX(pubkey) ORDER BY created_at SEPARATOR ',') AS pubkeys_hex
+        FROM reactions
+        WHERE event_id = ?
+          AND event_created_at = ?
+          AND removed_at IS NULL
+        GROUP BY emoji
+        ORDER BY emoji
+        LIMIT ?
+        "#,
+    )
+    .bind(event_id)
+    .bind(event_created_at)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    let mut groups = Vec::with_capacity(rows.len());
+
+    for row in rows {
+        let emoji: String = row.try_get("emoji")?;
+        let count: i64 = row.try_get("count")?;
+        // GROUP_CONCAT(HEX(pubkey)) returns comma-separated hex strings.
+        // Using HEX avoids corruption from 0x2C bytes inside binary pubkeys.
+        let pubkeys_hex: Option<String> = row.try_get("pubkeys_hex")?;
+
+        let users = parse_pubkeys_hex(pubkeys_hex.as_deref().unwrap_or(""));
+
+        groups.push(ReactionGroup {
+            emoji,
+            count,
+            users,
+        });
+    }
+
+    Ok(groups)
+}
+
+/// Batch-fetch emoji counts for a set of (event_id, event_created_at) pairs.
+///
+/// Returns one [`BulkReactionEntry`] per input pair that has at least one
+/// active reaction. Pairs with no reactions are omitted.
+pub async fn get_reactions_bulk(
+    pool: &MySqlPool,
+    event_ids: &[(&[u8], DateTime<Utc>)],
+) -> Result<Vec<BulkReactionEntry>> {
+    if event_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Run one query per event. For typical message-list sizes (≤100 events)
+    // this is acceptable; a single-query approach with dynamic IN clauses over
+    // composite keys is complex in MySQL and can be added later if needed.
+    let mut entries = Vec::new();
+
+    for (event_id, event_created_at) in event_ids {
+        let rows = sqlx::query(
+            r#"
+            SELECT emoji, COUNT(*) AS count
+            FROM reactions
+            WHERE event_id = ?
+              AND event_created_at = ?
+              AND removed_at IS NULL
+            GROUP BY emoji
+            ORDER BY emoji
+            "#,
+        )
+        .bind(*event_id)
+        .bind(event_created_at)
+        .fetch_all(pool)
+        .await?;
+
+        if rows.is_empty() {
+            continue;
+        }
+
+        let mut reactions = Vec::with_capacity(rows.len());
+        for row in rows {
+            let emoji: String = row.try_get("emoji")?;
+            let count: i64 = row.try_get("count")?;
+            reactions.push(ReactionSummary { emoji, count });
+        }
+
+        entries.push(BulkReactionEntry {
+            event_id: event_id.to_vec(),
+            event_created_at: *event_created_at,
+            reactions,
+        });
+    }
+
+    Ok(entries)
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Parse a `GROUP_CONCAT(HEX(pubkey))` string into individual pubkeys.
+///
+/// MySQL's `HEX()` encodes each byte as two uppercase hex characters, so a
+/// 32-byte pubkey becomes a 64-character hex string. The comma separator is
+/// safe because hex output never contains 0x2C bytes.
+fn parse_pubkeys_hex(hex_str: &str) -> Vec<ReactionUser> {
+    if hex_str.is_empty() {
+        return Vec::new();
+    }
+    hex_str
+        .split(',')
+        .filter_map(|h| hex::decode(h.trim()).ok())
+        .filter(|b| b.len() == 32)
+        .map(|pubkey| ReactionUser {
+            pubkey,
+            display_name: None,
+        })
+        .collect()
+}

--- a/crates/sprout-db/src/thread.rs
+++ b/crates/sprout-db/src/thread.rs
@@ -1,0 +1,567 @@
+//! Thread metadata persistence.
+//!
+//! Tracks parent/root relationships, depth, and reply counts for infinitely
+//! nested threads. The `thread_metadata` table is populated when events are
+//! ingested and updated as replies arrive or are deleted.
+
+use chrono::{DateTime, Utc};
+use sqlx::{MySqlPool, Row};
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::event::uuid_from_bytes;
+
+// ── Structs ───────────────────────────────────────────────────────────────────
+
+/// A single reply within a thread, joined with event content.
+#[derive(Debug, Clone)]
+pub struct ThreadReply {
+    /// The Nostr event ID of this reply.
+    pub event_id: Vec<u8>,
+    /// The event ID of the direct parent (one level up), if any.
+    pub parent_event_id: Option<Vec<u8>>,
+    /// The event ID of the thread root (top-level message), if any.
+    pub root_event_id: Option<Vec<u8>>,
+    /// The channel this reply belongs to.
+    pub channel_id: Uuid,
+    /// Compressed public key of the reply author.
+    pub pubkey: Vec<u8>,
+    /// Text content of the reply.
+    pub content: String,
+    /// Nostr event kind number.
+    pub kind: i32,
+    /// Nesting depth within the thread (root = 0, direct reply = 1, etc.).
+    pub depth: i32,
+    /// When the reply was created.
+    pub created_at: DateTime<Utc>,
+    /// Whether this reply is also broadcast to the channel timeline.
+    pub broadcast: bool,
+}
+
+/// Aggregated thread statistics for a root message.
+#[derive(Debug, Clone)]
+pub struct ThreadSummary {
+    /// Number of direct replies to the root message.
+    pub reply_count: i32,
+    /// Total number of replies at all nesting levels.
+    pub descendant_count: i32,
+    /// Timestamp of the most recent reply in the thread.
+    pub last_reply_at: Option<DateTime<Utc>>,
+    /// Compressed public keys of all participants who have replied.
+    pub participants: Vec<Vec<u8>>,
+}
+
+/// A top-level channel message with optional thread summary.
+#[derive(Debug, Clone)]
+pub struct TopLevelMessage {
+    /// The Nostr event ID of this message.
+    pub event_id: Vec<u8>,
+    /// Compressed public key of the message author.
+    pub pubkey: Vec<u8>,
+    /// Text content of the message.
+    pub content: String,
+    /// Nostr event kind number.
+    pub kind: i32,
+    /// When the message was created.
+    pub created_at: DateTime<Utc>,
+    /// The channel this message belongs to.
+    pub channel_id: Uuid,
+    /// Thread statistics for this message, if it has replies.
+    pub thread_summary: Option<ThreadSummary>,
+}
+
+/// Raw thread_metadata row — used when processing deletes or computing ancestry.
+#[derive(Debug, Clone)]
+pub struct ThreadMetadataRecord {
+    /// The Nostr event ID this metadata row tracks.
+    pub event_id: Vec<u8>,
+    /// Partition key timestamp for the event.
+    pub event_created_at: DateTime<Utc>,
+    /// The channel this event belongs to.
+    pub channel_id: Uuid,
+    /// Event ID of the direct parent, if this is a reply.
+    pub parent_event_id: Option<Vec<u8>>,
+    /// Event ID of the thread root, if this is a nested reply.
+    pub root_event_id: Option<Vec<u8>>,
+    /// Nesting depth (root = 0).
+    pub depth: i32,
+    /// Number of direct replies to this event.
+    pub reply_count: i32,
+    /// Total number of descendants at all nesting levels.
+    pub descendant_count: i32,
+    /// Whether this event is broadcast to the channel timeline.
+    pub broadcast: bool,
+}
+
+// ── Write operations ──────────────────────────────────────────────────────────
+
+/// Insert a row into `thread_metadata`.
+///
+/// If `parent_event_id` is `Some`, also increments the parent's reply count
+/// and the root's descendant count (always, including when root == parent).
+///
+/// The INSERT and all counter UPDATEs are wrapped in a single transaction so a
+/// crash between them cannot leave reply_count / descendant_count inconsistent
+/// with the actual number of reply rows (F9).
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_thread_metadata(
+    pool: &MySqlPool,
+    event_id: &[u8],
+    event_created_at: DateTime<Utc>,
+    channel_id: Uuid,
+    parent_event_id: Option<&[u8]>,
+    parent_event_created_at: Option<DateTime<Utc>>,
+    root_event_id: Option<&[u8]>,
+    root_event_created_at: Option<DateTime<Utc>>,
+    depth: i32,
+    broadcast: bool,
+) -> Result<()> {
+    let channel_id_bytes = channel_id.as_bytes().as_slice().to_vec();
+    let broadcast_val: i8 = if broadcast { 1 } else { 0 };
+
+    let mut tx = pool.begin().await?;
+
+    let result = sqlx::query(
+        r#"
+        INSERT IGNORE INTO thread_metadata
+            (event_created_at, event_id, channel_id,
+             parent_event_id, parent_event_created_at,
+             root_event_id, root_event_created_at,
+             depth, broadcast)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind(event_created_at)
+    .bind(event_id)
+    .bind(channel_id_bytes.as_slice())
+    .bind(parent_event_id)
+    .bind(parent_event_created_at)
+    .bind(root_event_id)
+    .bind(root_event_created_at)
+    .bind(depth)
+    .bind(broadcast_val)
+    .execute(&mut *tx)
+    .await?;
+
+    // Only bump reply counts if the row was actually inserted (not a duplicate).
+    // INSERT IGNORE on a duplicate key returns rows_affected = 0.
+    if result.rows_affected() > 0 {
+        if let Some(pid) = parent_event_id {
+            // Increment parent's direct reply count and last_reply_at.
+            sqlx::query(
+                r#"
+                UPDATE thread_metadata
+                SET reply_count   = reply_count + 1,
+                    last_reply_at = NOW(6)
+                WHERE event_id = ?
+                "#,
+            )
+            .bind(pid)
+            .execute(&mut *tx)
+            .await?;
+
+            // Increment root's total descendant count.
+            if let Some(root_id) = root_event_id {
+                sqlx::query(
+                    r#"
+                    UPDATE thread_metadata
+                    SET descendant_count = descendant_count + 1
+                    WHERE event_id = ?
+                    "#,
+                )
+                .bind(root_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+    }
+
+    tx.commit().await?;
+
+    Ok(())
+}
+
+/// Increment `reply_count` (and `last_reply_at`) on the parent event.
+/// If `root_event_id` is provided, also increments `descendant_count` on the
+/// root — even when root == parent (direct reply to root). This is correct
+/// because `reply_count` tracks direct children only, while `descendant_count`
+/// tracks ALL descendants at every nesting level.
+pub async fn increment_reply_count(
+    pool: &MySqlPool,
+    parent_event_id: &[u8],
+    root_event_id: Option<&[u8]>,
+) -> Result<()> {
+    // Always bump the parent's direct reply count and last-reply timestamp.
+    sqlx::query(
+        r#"
+        UPDATE thread_metadata
+        SET reply_count  = reply_count + 1,
+            last_reply_at = NOW(6)
+        WHERE event_id = ?
+        "#,
+    )
+    .bind(parent_event_id)
+    .execute(pool)
+    .await?;
+
+    // Always bump root's descendant_count, regardless of whether root == parent.
+    // - Direct reply (root == parent): root row gets reply_count+1 AND descendant_count+1.
+    // - Nested reply (root != parent): parent gets reply_count+1, root gets descendant_count+1.
+    if let Some(root_id) = root_event_id {
+        sqlx::query(
+            r#"
+            UPDATE thread_metadata
+            SET descendant_count = descendant_count + 1
+            WHERE event_id = ?
+            "#,
+        )
+        .bind(root_id)
+        .execute(pool)
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// Decrement `reply_count` on the parent event (floor at 0).
+/// If `root_event_id` is provided, also decrements `descendant_count` on the
+/// root — even when root == parent. Mirrors the increment logic exactly.
+pub async fn decrement_reply_count(
+    pool: &MySqlPool,
+    parent_event_id: &[u8],
+    root_event_id: Option<&[u8]>,
+) -> Result<()> {
+    // Always decrement the parent's direct reply count (floor at 0).
+    sqlx::query(
+        r#"
+        UPDATE thread_metadata
+        SET reply_count = GREATEST(reply_count - 1, 0)
+        WHERE event_id = ?
+        "#,
+    )
+    .bind(parent_event_id)
+    .execute(pool)
+    .await?;
+
+    // Always decrement root's descendant_count, regardless of whether root == parent.
+    if let Some(root_id) = root_event_id {
+        sqlx::query(
+            r#"
+            UPDATE thread_metadata
+            SET descendant_count = GREATEST(descendant_count - 1, 0)
+            WHERE event_id = ?
+            "#,
+        )
+        .bind(root_id)
+        .execute(pool)
+        .await?;
+    }
+
+    Ok(())
+}
+
+// ── Read operations ───────────────────────────────────────────────────────────
+
+/// Fetch all replies under a root event, ordered chronologically.
+///
+/// - `depth_limit` — if `Some(n)`, only returns replies at depth ≤ n.
+/// - `cursor` — if `Some(ts_bytes)`, returns replies with `event_created_at`
+///   strictly after the timestamp encoded in `ts_bytes`. The bytes must be an
+///   8-byte big-endian i64 Unix timestamp in seconds. The caller (REST handler)
+///   encodes the last reply's `created_at` as the next-page cursor.
+///   Binary event IDs do NOT correlate with chronological order, so the old
+///   `event_id > cursor` condition produced non-deterministic pagination (F8).
+/// - `limit` — maximum rows returned (caller should cap this).
+pub async fn get_thread_replies(
+    pool: &MySqlPool,
+    root_event_id: &[u8],
+    depth_limit: Option<u32>,
+    limit: u32,
+    cursor: Option<&[u8]>,
+) -> Result<Vec<ThreadReply>> {
+    // Decode cursor bytes → DateTime<Utc> for the keyset condition.
+    // Bytes are an 8-byte big-endian i64 Unix timestamp (seconds).
+    let cursor_ts: Option<DateTime<Utc>> = match cursor {
+        Some(bytes) if bytes.len() == 8 => {
+            let secs = i64::from_be_bytes(bytes.try_into().expect("length checked"));
+            DateTime::from_timestamp(secs, 0)
+        }
+        _ => None,
+    };
+
+    // Build the query dynamically based on optional filters.
+    let mut sql = String::from(
+        r#"
+        SELECT
+            tm.event_id,
+            tm.parent_event_id,
+            tm.root_event_id,
+            tm.channel_id,
+            e.pubkey,
+            e.content,
+            e.kind,
+            tm.depth,
+            tm.event_created_at,
+            tm.broadcast
+        FROM thread_metadata tm
+        JOIN events e
+            ON e.created_at = tm.event_created_at
+           AND e.id         = tm.event_id
+        WHERE tm.root_event_id = ?
+          AND e.deleted_at IS NULL
+        "#,
+    );
+
+    if depth_limit.is_some() {
+        sql.push_str(" AND tm.depth <= ?");
+    }
+    if cursor_ts.is_some() {
+        sql.push_str(" AND tm.event_created_at > ?");
+    }
+
+    sql.push_str(" ORDER BY tm.event_created_at ASC LIMIT ?");
+
+    let mut q = sqlx::query(&sql).bind(root_event_id);
+
+    if let Some(dl) = depth_limit {
+        q = q.bind(dl);
+    }
+    if let Some(ts) = cursor_ts {
+        q = q.bind(ts);
+    }
+    q = q.bind(limit);
+
+    let rows = q.fetch_all(pool).await?;
+
+    let mut replies = Vec::with_capacity(rows.len());
+    for row in rows {
+        let event_id: Vec<u8> = row.try_get("event_id")?;
+        let parent_event_id: Option<Vec<u8>> = row.try_get("parent_event_id")?;
+        let root_event_id_col: Option<Vec<u8>> = row.try_get("root_event_id")?;
+        let channel_id_bytes: Vec<u8> = row.try_get("channel_id")?;
+        let pubkey: Vec<u8> = row.try_get("pubkey")?;
+        let content: String = row.try_get("content")?;
+        let kind: i32 = row.try_get("kind")?;
+        let depth: i32 = row.try_get("depth")?;
+        let created_at: DateTime<Utc> = row.try_get("event_created_at")?;
+        let broadcast_val: i8 = row.try_get("broadcast")?;
+
+        let channel_id = uuid_from_bytes(&channel_id_bytes)?;
+
+        replies.push(ThreadReply {
+            event_id,
+            parent_event_id,
+            root_event_id: root_event_id_col,
+            channel_id,
+            pubkey,
+            content,
+            kind,
+            depth,
+            created_at,
+            broadcast: broadcast_val != 0,
+        });
+    }
+
+    Ok(replies)
+}
+
+/// Fetch aggregated thread stats for a single event, plus up to 10 participant pubkeys.
+pub async fn get_thread_summary(
+    pool: &MySqlPool,
+    event_id: &[u8],
+) -> Result<Option<ThreadSummary>> {
+    let row = sqlx::query(
+        r#"
+        SELECT reply_count, descendant_count, last_reply_at
+        FROM thread_metadata
+        WHERE event_id = ?
+        LIMIT 1
+        "#,
+    )
+    .bind(event_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let row = match row {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+
+    let reply_count: i32 = row.try_get("reply_count")?;
+    let descendant_count: i32 = row.try_get("descendant_count")?;
+    let last_reply_at: Option<DateTime<Utc>> = row.try_get("last_reply_at")?;
+
+    // Collect distinct participant pubkeys from the thread, most recent first (M1).
+    // Without ORDER BY the result is non-deterministic across MySQL restarts/replicas.
+    // Wrapping in a subquery lets us ORDER BY after DISTINCT.
+    let participant_rows = sqlx::query(
+        r#"
+        SELECT pubkey FROM (
+            SELECT DISTINCT e.pubkey, MAX(e.created_at) AS last_seen
+            FROM thread_metadata tm
+            JOIN events e
+                ON e.created_at = tm.event_created_at
+               AND e.id         = tm.event_id
+            WHERE tm.root_event_id = ?
+              AND e.deleted_at IS NULL
+            GROUP BY e.pubkey
+        ) sub
+        ORDER BY last_seen DESC
+        LIMIT 10
+        "#,
+    )
+    .bind(event_id)
+    .fetch_all(pool)
+    .await?;
+
+    let participants: Vec<Vec<u8>> = participant_rows
+        .into_iter()
+        .map(|r| r.try_get::<Vec<u8>, _>("pubkey"))
+        .collect::<std::result::Result<_, _>>()?;
+
+    Ok(Some(ThreadSummary {
+        reply_count,
+        descendant_count,
+        last_reply_at,
+        participants,
+    }))
+}
+
+/// Fetch top-level messages for a channel (depth = 0, or broadcast replies).
+///
+/// Returns events that are either:
+/// - Not in thread_metadata at all (no thread context set yet), OR
+/// - At depth 0 (root messages), OR
+/// - At depth 1 with `broadcast = 1` (replies surfaced to the channel)
+///
+/// Results are ordered newest-first for a standard channel view.
+/// `before_cursor` enables keyset pagination (pass the `created_at` of the
+/// last item from the previous page).
+pub async fn get_channel_messages_top_level(
+    pool: &MySqlPool,
+    channel_id: Uuid,
+    limit: u32,
+    before_cursor: Option<DateTime<Utc>>,
+) -> Result<Vec<TopLevelMessage>> {
+    let channel_id_bytes = channel_id.as_bytes().as_slice().to_vec();
+
+    let mut sql = String::from(
+        r#"
+        SELECT
+            e.id          AS event_id,
+            e.pubkey,
+            e.content,
+            e.kind,
+            e.created_at,
+            e.channel_id  AS channel_id_bytes
+        FROM events e
+        LEFT JOIN thread_metadata tm
+            ON tm.event_created_at = e.created_at
+           AND tm.event_id         = e.id
+        WHERE e.channel_id = ?
+          AND e.deleted_at IS NULL
+          AND (
+                tm.depth IS NULL
+             OR tm.depth = 0
+             OR (tm.depth = 1 AND tm.broadcast = 1)
+          )
+        "#,
+    );
+
+    if before_cursor.is_some() {
+        sql.push_str(" AND e.created_at < ?");
+    }
+
+    sql.push_str(" ORDER BY e.created_at DESC LIMIT ?");
+
+    let mut q = sqlx::query(&sql).bind(channel_id_bytes.as_slice());
+
+    if let Some(cursor) = before_cursor {
+        q = q.bind(cursor);
+    }
+    q = q.bind(limit);
+
+    let rows = q.fetch_all(pool).await?;
+
+    let mut messages = Vec::with_capacity(rows.len());
+    for row in rows {
+        let event_id: Vec<u8> = row.try_get("event_id")?;
+        let pubkey: Vec<u8> = row.try_get("pubkey")?;
+        let content: String = row.try_get("content")?;
+        let kind: i32 = row.try_get("kind")?;
+        let created_at: DateTime<Utc> = row.try_get("created_at")?;
+        let channel_id_col: Vec<u8> = row.try_get("channel_id_bytes")?;
+        let ch_id = uuid_from_bytes(&channel_id_col)?;
+
+        messages.push(TopLevelMessage {
+            event_id,
+            pubkey,
+            content,
+            kind,
+            created_at,
+            channel_id: ch_id,
+            thread_summary: None, // Populated by caller if needed
+        });
+    }
+
+    Ok(messages)
+}
+
+/// Look up a single thread_metadata row by event_id.
+///
+/// Used when processing soft-deletes to find the parent/root so reply counts
+/// can be decremented.
+pub async fn get_thread_metadata_by_event(
+    pool: &MySqlPool,
+    event_id: &[u8],
+) -> Result<Option<ThreadMetadataRecord>> {
+    let row = sqlx::query(
+        r#"
+        SELECT
+            event_id,
+            event_created_at,
+            channel_id,
+            parent_event_id,
+            root_event_id,
+            depth,
+            reply_count,
+            descendant_count,
+            broadcast
+        FROM thread_metadata
+        WHERE event_id = ?
+        LIMIT 1
+        "#,
+    )
+    .bind(event_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let row = match row {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+
+    let event_id_col: Vec<u8> = row.try_get("event_id")?;
+    let event_created_at: DateTime<Utc> = row.try_get("event_created_at")?;
+    let channel_id_bytes: Vec<u8> = row.try_get("channel_id")?;
+    let parent_event_id: Option<Vec<u8>> = row.try_get("parent_event_id")?;
+    let root_event_id: Option<Vec<u8>> = row.try_get("root_event_id")?;
+    let depth: i32 = row.try_get("depth")?;
+    let reply_count: i32 = row.try_get("reply_count")?;
+    let descendant_count: i32 = row.try_get("descendant_count")?;
+    let broadcast_val: i8 = row.try_get("broadcast")?;
+
+    let channel_id = uuid_from_bytes(&channel_id_bytes)?;
+
+    Ok(Some(ThreadMetadataRecord {
+        event_id: event_id_col,
+        event_created_at,
+        channel_id,
+        parent_event_id,
+        root_event_id,
+        depth,
+        reply_count,
+        descendant_count,
+        broadcast: broadcast_val != 0,
+    }))
+}

--- a/crates/sprout-db/src/user.rs
+++ b/crates/sprout-db/src/user.rs
@@ -3,6 +3,19 @@
 use crate::error::Result;
 use sqlx::MySqlPool;
 
+/// A user's profile fields.
+#[derive(Debug, Clone)]
+pub struct UserProfile {
+    /// Raw 32-byte compressed public key.
+    pub pubkey: Vec<u8>,
+    /// Human-readable display name chosen by the user.
+    pub display_name: Option<String>,
+    /// URL of the user's avatar image.
+    pub avatar_url: Option<String>,
+    /// NIP-05 identifier (user@domain).
+    pub nip05_handle: Option<String>,
+}
+
 /// Ensure a user record exists for the given pubkey (upsert).
 /// Creates with minimal fields if not present; no-op if already exists.
 pub async fn ensure_user(pool: &MySqlPool, pubkey: &[u8]) -> Result<()> {
@@ -15,5 +28,67 @@ pub async fn ensure_user(pool: &MySqlPool, pubkey: &[u8]) -> Result<()> {
     .bind(pubkey)
     .execute(pool)
     .await?;
+    Ok(())
+}
+
+/// Get a single user record by pubkey.
+pub async fn get_user(pool: &MySqlPool, pubkey: &[u8]) -> Result<Option<UserProfile>> {
+    let row = sqlx::query_as::<_, (Vec<u8>, Option<String>, Option<String>, Option<String>)>(
+        r#"
+        SELECT pubkey, display_name, avatar_url, nip05_handle
+        FROM users
+        WHERE pubkey = ?
+        "#,
+    )
+    .bind(pubkey)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(
+        |(pubkey, display_name, avatar_url, nip05_handle)| UserProfile {
+            pubkey,
+            display_name,
+            avatar_url,
+            nip05_handle,
+        },
+    ))
+}
+
+/// Update a user's profile fields (display_name, avatar_url).
+/// Only updates fields that are Some — None fields are left unchanged.
+/// At least one field must be Some, otherwise returns Ok(()) without touching the DB.
+pub async fn update_user_profile(
+    pool: &MySqlPool,
+    pubkey: &[u8],
+    display_name: Option<&str>,
+    avatar_url: Option<&str>,
+) -> Result<()> {
+    match (display_name, avatar_url) {
+        (Some(name), Some(url)) => {
+            sqlx::query(r#"UPDATE users SET display_name = ?, avatar_url = ? WHERE pubkey = ?"#)
+                .bind(name)
+                .bind(url)
+                .bind(pubkey)
+                .execute(pool)
+                .await?;
+        }
+        (Some(name), None) => {
+            sqlx::query(r#"UPDATE users SET display_name = ? WHERE pubkey = ?"#)
+                .bind(name)
+                .bind(pubkey)
+                .execute(pool)
+                .await?;
+        }
+        (None, Some(url)) => {
+            sqlx::query(r#"UPDATE users SET avatar_url = ? WHERE pubkey = ?"#)
+                .bind(url)
+                .bind(pubkey)
+                .execute(pool)
+                .await?;
+        }
+        (None, None) => {
+            // Nothing to update — caller should have validated at least one field.
+        }
+    }
     Ok(())
 }

--- a/crates/sprout-mcp/src/server.rs
+++ b/crates/sprout-mcp/src/server.rs
@@ -1,4 +1,4 @@
-use sprout_core::kind::{event_kind_u32, KIND_CANVAS};
+use sprout_core::kind::KIND_CANVAS;
 
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -55,6 +55,9 @@ pub struct SendMessageParams {
     /// Nostr event kind. Defaults to 40001 (channel message).
     #[serde(default = "default_kind")]
     pub kind: Option<u16>,
+    /// Optional parent event ID. If provided, sends a reply via REST instead of WebSocket.
+    #[serde(default)]
+    pub parent_event_id: Option<String>,
 }
 fn default_kind() -> Option<u16> {
     Some(40001)
@@ -68,6 +71,9 @@ pub struct GetChannelHistoryParams {
     /// Maximum number of messages to return (default 50, max 200).
     #[serde(default)]
     pub limit: Option<u32>,
+    /// If true, fetch messages with thread metadata via REST instead of WebSocket.
+    #[serde(default)]
+    pub with_threads: Option<bool>,
 }
 
 /// Parameters for the `list_channels` tool.
@@ -176,6 +182,193 @@ pub struct ApproveWorkflowStepParams {
 
 // ── Feed tool parameter structs ───────────────────────────────────────────────
 
+// ── Membership tool parameter structs ────────────────────────────────────────
+
+/// Parameters for the `add_channel_member` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AddChannelMemberParams {
+    /// UUID of the channel.
+    pub channel_id: String,
+    /// Hex-encoded public key of the user to add.
+    pub pubkey: String,
+    /// Role to assign: `"member"` (default) or `"admin"`.
+    #[serde(default)]
+    pub role: Option<String>,
+}
+
+/// Parameters for the `remove_channel_member` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct RemoveChannelMemberParams {
+    /// UUID of the channel.
+    pub channel_id: String,
+    /// Hex-encoded public key of the user to remove.
+    pub pubkey: String,
+}
+
+/// Parameters for the `list_channel_members` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListChannelMembersParams {
+    /// UUID of the channel whose members to list.
+    pub channel_id: String,
+}
+
+/// Parameters for the `join_channel` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct JoinChannelParams {
+    /// UUID of the channel to join.
+    pub channel_id: String,
+}
+
+/// Parameters for the `leave_channel` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct LeaveChannelParams {
+    /// UUID of the channel to leave.
+    pub channel_id: String,
+}
+
+/// Parameters for the `get_channel` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetChannelParams {
+    /// UUID of the channel to retrieve.
+    pub channel_id: String,
+}
+
+// ── Metadata tool parameter structs ──────────────────────────────────────────
+
+/// Parameters for the `update_channel` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UpdateChannelParams {
+    /// UUID of the channel to update.
+    pub channel_id: String,
+    /// New display name for the channel.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// New description for the channel.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Parameters for the `set_channel_topic` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SetChannelTopicParams {
+    /// UUID of the channel.
+    pub channel_id: String,
+    /// New topic string.
+    pub topic: String,
+}
+
+/// Parameters for the `set_channel_purpose` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SetChannelPurposeParams {
+    /// UUID of the channel.
+    pub channel_id: String,
+    /// New purpose string.
+    pub purpose: String,
+}
+
+/// Parameters for the `archive_channel` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ArchiveChannelParams {
+    /// UUID of the channel to archive.
+    pub channel_id: String,
+}
+
+/// Parameters for the `unarchive_channel` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UnarchiveChannelParams {
+    /// UUID of the channel to unarchive.
+    pub channel_id: String,
+}
+
+// ── Thread tool parameter structs ─────────────────────────────────────────────
+
+/// Parameters for the `send_reply` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SendReplyParams {
+    /// UUID of the channel containing the parent message.
+    pub channel_id: String,
+    /// Event ID of the message being replied to.
+    pub parent_event_id: String,
+    /// Reply message body text.
+    pub content: String,
+    /// If true, the reply is also broadcast to the main channel timeline.
+    #[serde(default)]
+    pub broadcast_to_channel: Option<bool>,
+}
+
+/// Parameters for the `get_thread` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetThreadParams {
+    /// UUID of the channel containing the thread.
+    pub channel_id: String,
+    /// Event ID of the root (or any ancestor) message of the thread.
+    pub event_id: String,
+    /// Maximum nesting depth to return (default: unlimited).
+    #[serde(default)]
+    pub depth_limit: Option<u32>,
+    /// Maximum number of replies to return (default 50).
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+// ── DM tool parameter structs ─────────────────────────────────────────────────
+
+/// Parameters for the `open_dm` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct OpenDmParams {
+    /// Hex-encoded public keys of the other participants (1–8).
+    pub pubkeys: Vec<String>,
+}
+
+/// Parameters for the `add_dm_member` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AddDmMemberParams {
+    /// UUID of the DM channel.
+    pub channel_id: String,
+    /// Hex-encoded public key of the user to add.
+    pub pubkey: String,
+}
+
+// ── Reaction tool parameter structs ──────────────────────────────────────────
+
+/// Parameters for the `add_reaction` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AddReactionParams {
+    /// Event ID of the message to react to.
+    pub event_id: String,
+    /// Emoji to react with (e.g. `"👍"` or `":thumbsup:"`).
+    pub emoji: String,
+}
+
+/// Parameters for the `remove_reaction` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct RemoveReactionParams {
+    /// Event ID of the message whose reaction to remove.
+    pub event_id: String,
+    /// Emoji to remove.
+    pub emoji: String,
+}
+
+/// Parameters for the `get_reactions` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetReactionsParams {
+    /// Event ID of the message whose reactions to fetch.
+    pub event_id: String,
+}
+
+// ── User profile tool parameter structs ──────────────────────────────────────
+
+/// Parameters for the `set_profile` tool.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SetProfileParams {
+    /// New display name for the agent's profile.
+    #[serde(default)]
+    pub display_name: Option<String>,
+    /// URL of the agent's avatar image.
+    #[serde(default)]
+    pub avatar_url: Option<String>,
+}
+
 /// Parameters for the `get_feed` tool.
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct GetFeedParams {
@@ -236,7 +429,7 @@ impl SproutMcpServer {
     /// Send a message to a Sprout channel.
     #[tool(
         name = "send_message",
-        description = "Send a message to a Sprout channel"
+        description = "Send a message to a Sprout channel. Optionally supply parent_event_id to send as a threaded reply via REST."
     )]
     pub async fn send_message(&self, Parameters(p): Parameters<SendMessageParams>) -> String {
         if let Err(e) = validate_uuid(&p.channel_id) {
@@ -251,20 +444,37 @@ impl SproutMcpServer {
             );
         }
 
+        // If a parent_event_id is provided, route through REST (thread reply).
+        if let Some(ref parent_id) = p.parent_event_id {
+            let body = serde_json::json!({
+                "content": p.content,
+                "parent_event_id": parent_id,
+            });
+            return match self
+                .client
+                .post(&format!("/api/channels/{}/messages", p.channel_id), &body)
+                .await
+            {
+                Ok(b) => b,
+                Err(e) => format!("Error: {e}"),
+            };
+        }
+
         let kind = p.kind.unwrap_or(40001);
 
-        let e_tag = match nostr::Tag::parse(&["e", &p.channel_id]) {
+        let channel_tag = match nostr::Tag::parse(&["channel", &p.channel_id]) {
             Ok(t) => t,
             Err(e) => return format!("Error building tag: {e}"),
         };
 
         let keys = self.client.keys().clone();
-        let event = match nostr::EventBuilder::new(nostr::Kind::Custom(kind), &p.content, [e_tag])
-            .sign_with_keys(&keys)
-        {
-            Ok(e) => e,
-            Err(e) => return format!("Error signing event: {e}"),
-        };
+        let event =
+            match nostr::EventBuilder::new(nostr::Kind::Custom(kind), &p.content, [channel_tag])
+                .sign_with_keys(&keys)
+            {
+                Ok(e) => e,
+                Err(e) => return format!("Error signing event: {e}"),
+            };
 
         match self.client.send_event(event).await {
             Ok(ok) if ok.accepted => format!("Message sent. Event ID: {}", ok.event_id),
@@ -276,7 +486,7 @@ impl SproutMcpServer {
     /// Get recent messages from a Sprout channel.
     #[tool(
         name = "get_channel_history",
-        description = "Get recent messages from a Sprout channel"
+        description = "Get recent messages from a Sprout channel. Set with_threads=true to include thread metadata via REST."
     )]
     pub async fn get_channel_history(
         &self,
@@ -289,34 +499,21 @@ impl SproutMcpServer {
         const MAX_HISTORY_LIMIT: u32 = 200;
         let limit = p.limit.unwrap_or(50).min(MAX_HISTORY_LIMIT);
 
-        let filter = nostr::Filter::new()
-            .custom_tag(
-                nostr::SingleLetterTag::lowercase(nostr::Alphabet::E),
-                [p.channel_id.as_str()],
+        // Always use the REST endpoint — the channel tag is multi-character ("channel")
+        // and cannot be filtered via WebSocket subscription SingleLetterTag filters.
+        let with_threads = p.with_threads.unwrap_or(false);
+        let path = if with_threads {
+            format!(
+                "/api/channels/{}/messages?with_threads=true&limit={}",
+                p.channel_id, limit
             )
-            .limit(limit as usize);
-
-        let sub_id = format!("history-{}", uuid::Uuid::new_v4());
-        let events = match self.client.subscribe(&sub_id, vec![filter]).await {
-            Ok(e) => e,
-            Err(e) => return format!("Subscribe error: {e}"),
+        } else {
+            format!("/api/channels/{}/messages?limit={}", p.channel_id, limit)
         };
-        let _ = self.client.close_subscription(&sub_id).await;
-
-        let messages: Vec<serde_json::Value> = events
-            .iter()
-            .map(|event| {
-                serde_json::json!({
-                    "id": event.id.to_hex(),
-                    "pubkey": event.pubkey.to_hex(),
-                    "content": event.content,
-                    "kind": event_kind_u32(event),
-                    "created_at": event.created_at.as_u64(),
-                })
-            })
-            .collect();
-
-        serde_json::to_string_pretty(&messages).unwrap_or_default()
+        match self.client.get(&path).await {
+            Ok(body) => body,
+            Err(e) => format!("Error: {e}"),
+        }
     }
 
     /// List Sprout channels accessible to this agent.
@@ -376,13 +573,12 @@ impl SproutMcpServer {
             return format!("Error: {e}");
         }
 
+        // The "channel" tag is multi-character and cannot be used in WebSocket
+        // subscription filters (nostr::Filter::custom_tag only accepts SingleLetterTag).
+        // Subscribe to all KIND_CANVAS events and filter client-side by channel tag.
         let filter = nostr::Filter::new()
-            .custom_tag(
-                nostr::SingleLetterTag::lowercase(nostr::Alphabet::E),
-                [p.channel_id.as_str()],
-            )
             .kind(nostr::Kind::Custom(KIND_CANVAS as u16))
-            .limit(1);
+            .limit(50);
 
         let sub_id = format!("canvas-{}", uuid::Uuid::new_v4());
         let events = match self.client.subscribe(&sub_id, vec![filter]).await {
@@ -391,7 +587,17 @@ impl SproutMcpServer {
         };
         let _ = self.client.close_subscription(&sub_id).await;
 
-        if let Some(event) = events.last() {
+        // Filter client-side: find the most recent canvas event for this channel.
+        let canvas_event = events.iter().rev().find(|event| {
+            event
+                .tags
+                .find(nostr::TagKind::custom("channel"))
+                .and_then(|t| t.content())
+                .map(|v| v == p.channel_id.as_str())
+                .unwrap_or(false)
+        });
+
+        if let Some(event) = canvas_event {
             event.content.clone()
         } else {
             "No canvas set for this channel.".to_string()
@@ -410,7 +616,7 @@ impl SproutMcpServer {
 
         let keys = self.client.keys().clone();
 
-        let e_tag = match nostr::Tag::parse(&["e", &p.channel_id]) {
+        let channel_tag = match nostr::Tag::parse(&["channel", &p.channel_id]) {
             Ok(t) => t,
             Err(e) => return format!("Error building tag: {e}"),
         };
@@ -418,7 +624,7 @@ impl SproutMcpServer {
         let event = match nostr::EventBuilder::new(
             nostr::Kind::Custom(KIND_CANVAS as u16),
             &p.content,
-            [e_tag],
+            [channel_tag],
         )
         .sign_with_keys(&keys)
         {
@@ -672,6 +878,466 @@ impl SproutMcpServer {
         match self.client.get_api(&url).await {
             Ok(body) => body,
             Err(e) => format!("Error fetching action items: {e}"),
+        }
+    }
+
+    // ── Membership tools ──────────────────────────────────────────────────────
+
+    /// Add a member to a channel.
+    #[tool(
+        name = "add_channel_member",
+        description = "Add a member to a Sprout channel. Optionally specify a role (default: \"member\")."
+    )]
+    pub async fn add_channel_member(
+        &self,
+        Parameters(p): Parameters<AddChannelMemberParams>,
+    ) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let body = serde_json::json!({
+            "pubkeys": [p.pubkey],
+            "role": p.role.unwrap_or_else(|| "member".to_string()),
+        });
+        match self
+            .client
+            .post(&format!("/api/channels/{}/members", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Remove a member from a channel.
+    #[tool(
+        name = "remove_channel_member",
+        description = "Remove a member from a Sprout channel by their public key."
+    )]
+    pub async fn remove_channel_member(
+        &self,
+        Parameters(p): Parameters<RemoveChannelMemberParams>,
+    ) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let encoded_pubkey = percent_encode(&p.pubkey);
+        match self
+            .client
+            .delete(&format!(
+                "/api/channels/{}/members/{}",
+                p.channel_id, encoded_pubkey
+            ))
+            .await
+        {
+            Ok(_) => "Member removed.".to_string(),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// List all members of a channel.
+    #[tool(
+        name = "list_channel_members",
+        description = "List all members of a Sprout channel."
+    )]
+    pub async fn list_channel_members(
+        &self,
+        Parameters(p): Parameters<ListChannelMembersParams>,
+    ) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        match self
+            .client
+            .get(&format!("/api/channels/{}/members", p.channel_id))
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Join a channel (add yourself as a member).
+    #[tool(
+        name = "join_channel",
+        description = "Join a Sprout channel (adds the agent as a member)."
+    )]
+    pub async fn join_channel(&self, Parameters(p): Parameters<JoinChannelParams>) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let body = serde_json::json!({});
+        match self
+            .client
+            .post(&format!("/api/channels/{}/join", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Leave a channel (remove yourself as a member).
+    #[tool(
+        name = "leave_channel",
+        description = "Leave a Sprout channel (removes the agent as a member)."
+    )]
+    pub async fn leave_channel(&self, Parameters(p): Parameters<LeaveChannelParams>) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let body = serde_json::json!({});
+        match self
+            .client
+            .post(&format!("/api/channels/{}/leave", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get details for a single channel.
+    #[tool(
+        name = "get_channel",
+        description = "Get metadata and details for a single Sprout channel by ID."
+    )]
+    pub async fn get_channel(&self, Parameters(p): Parameters<GetChannelParams>) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        match self
+            .client
+            .get(&format!("/api/channels/{}", p.channel_id))
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ── Metadata tools ────────────────────────────────────────────────────────
+
+    /// Update a channel's name and/or description.
+    #[tool(
+        name = "update_channel",
+        description = "Update a Sprout channel's name and/or description."
+    )]
+    pub async fn update_channel(&self, Parameters(p): Parameters<UpdateChannelParams>) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let body = serde_json::json!({
+            "name": p.name,
+            "description": p.description,
+        });
+        match self
+            .client
+            .put(&format!("/api/channels/{}", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Set the topic for a channel.
+    #[tool(
+        name = "set_channel_topic",
+        description = "Set the topic for a Sprout channel."
+    )]
+    pub async fn set_channel_topic(
+        &self,
+        Parameters(p): Parameters<SetChannelTopicParams>,
+    ) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let body = serde_json::json!({ "topic": p.topic });
+        match self
+            .client
+            .put(&format!("/api/channels/{}/topic", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Set the purpose for a channel.
+    #[tool(
+        name = "set_channel_purpose",
+        description = "Set the purpose for a Sprout channel."
+    )]
+    pub async fn set_channel_purpose(
+        &self,
+        Parameters(p): Parameters<SetChannelPurposeParams>,
+    ) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let body = serde_json::json!({ "purpose": p.purpose });
+        match self
+            .client
+            .put(&format!("/api/channels/{}/purpose", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Archive a channel (makes it read-only).
+    #[tool(
+        name = "archive_channel",
+        description = "Archive a Sprout channel, making it read-only."
+    )]
+    pub async fn archive_channel(&self, Parameters(p): Parameters<ArchiveChannelParams>) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let body = serde_json::json!({});
+        match self
+            .client
+            .post(&format!("/api/channels/{}/archive", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Unarchive a channel (restores it to active).
+    #[tool(
+        name = "unarchive_channel",
+        description = "Unarchive a Sprout channel, restoring it to active status."
+    )]
+    pub async fn unarchive_channel(
+        &self,
+        Parameters(p): Parameters<UnarchiveChannelParams>,
+    ) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let body = serde_json::json!({});
+        match self
+            .client
+            .post(&format!("/api/channels/{}/unarchive", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ── Thread tools ──────────────────────────────────────────────────────────
+
+    /// Send a reply to a message in a thread.
+    #[tool(
+        name = "send_reply",
+        description = "Send a reply to a message in a Sprout channel thread. \
+                       Optionally set broadcast_to_channel=true to also surface the reply in the main channel timeline."
+    )]
+    pub async fn send_reply(&self, Parameters(p): Parameters<SendReplyParams>) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+
+        if p.content.len() > MAX_CONTENT_BYTES {
+            return format!(
+                "Error: content exceeds maximum size of {} bytes (got {})",
+                MAX_CONTENT_BYTES,
+                p.content.len()
+            );
+        }
+
+        let body = serde_json::json!({
+            "content": p.content,
+            "parent_event_id": p.parent_event_id,
+            "broadcast_to_channel": p.broadcast_to_channel.unwrap_or(false),
+        });
+        match self
+            .client
+            .post(&format!("/api/channels/{}/messages", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get a message thread (replies to a message).
+    #[tool(
+        name = "get_thread",
+        description = "Get a message thread from a Sprout channel. Returns the root message and all nested replies."
+    )]
+    pub async fn get_thread(&self, Parameters(p): Parameters<GetThreadParams>) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+
+        let mut query_parts: Vec<String> = Vec::new();
+        if let Some(depth) = p.depth_limit {
+            query_parts.push(format!("depth_limit={depth}"));
+        }
+        if let Some(limit) = p.limit {
+            query_parts.push(format!("limit={}", limit.min(200)));
+        }
+
+        let encoded_event_id = percent_encode(&p.event_id);
+        let path = if query_parts.is_empty() {
+            format!(
+                "/api/channels/{}/threads/{}",
+                p.channel_id, encoded_event_id
+            )
+        } else {
+            format!(
+                "/api/channels/{}/threads/{}?{}",
+                p.channel_id,
+                encoded_event_id,
+                query_parts.join("&")
+            )
+        };
+
+        match self.client.get(&path).await {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ── DM tools ──────────────────────────────────────────────────────────────
+
+    /// Open or retrieve a direct message channel with one or more participants.
+    #[tool(
+        name = "open_dm",
+        description = "Open (or retrieve an existing) direct message channel with 1–8 other participants. \
+                       Returns the DM channel details including its ID."
+    )]
+    pub async fn open_dm(&self, Parameters(p): Parameters<OpenDmParams>) -> String {
+        if p.pubkeys.is_empty() {
+            return "Error: pubkeys must contain at least one participant".to_string();
+        }
+        if p.pubkeys.len() > 8 {
+            return format!(
+                "Error: too many participants (max 8, got {})",
+                p.pubkeys.len()
+            );
+        }
+        let body = serde_json::json!({ "pubkeys": p.pubkeys });
+        match self.client.post("/api/dms", &body).await {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Add a participant to an existing DM channel.
+    #[tool(
+        name = "add_dm_member",
+        description = "Add a participant to an existing Sprout DM channel."
+    )]
+    pub async fn add_dm_member(&self, Parameters(p): Parameters<AddDmMemberParams>) -> String {
+        if let Err(e) = validate_uuid(&p.channel_id) {
+            return format!("Error: {e}");
+        }
+        let body = serde_json::json!({ "pubkeys": [p.pubkey] });
+        match self
+            .client
+            .post(&format!("/api/dms/{}/members", p.channel_id), &body)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// List all DM channels the agent is a participant in.
+    #[tool(
+        name = "list_dms",
+        description = "List all direct message channels the agent is a participant in."
+    )]
+    pub async fn list_dms(&self) -> String {
+        match self.client.get("/api/dms").await {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ── Reaction tools ────────────────────────────────────────────────────────
+
+    /// Add an emoji reaction to a message.
+    #[tool(
+        name = "add_reaction",
+        description = "Add an emoji reaction to a Sprout message."
+    )]
+    pub async fn add_reaction(&self, Parameters(p): Parameters<AddReactionParams>) -> String {
+        let body = serde_json::json!({ "emoji": p.emoji });
+        let encoded_event_id = percent_encode(&p.event_id);
+        match self
+            .client
+            .post(
+                &format!("/api/messages/{}/reactions", encoded_event_id),
+                &body,
+            )
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Remove an emoji reaction from a message.
+    #[tool(
+        name = "remove_reaction",
+        description = "Remove an emoji reaction from a Sprout message."
+    )]
+    pub async fn remove_reaction(&self, Parameters(p): Parameters<RemoveReactionParams>) -> String {
+        let encoded_event_id = percent_encode(&p.event_id);
+        let encoded_emoji = percent_encode(&p.emoji);
+        match self
+            .client
+            .delete(&format!(
+                "/api/messages/{}/reactions/{}",
+                encoded_event_id, encoded_emoji
+            ))
+            .await
+        {
+            Ok(_) => "Reaction removed.".to_string(),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get all reactions for a message.
+    #[tool(
+        name = "get_reactions",
+        description = "Get all emoji reactions for a Sprout message."
+    )]
+    pub async fn get_reactions(&self, Parameters(p): Parameters<GetReactionsParams>) -> String {
+        let encoded_event_id = percent_encode(&p.event_id);
+        match self
+            .client
+            .get(&format!("/api/messages/{}/reactions", encoded_event_id))
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ── User profile tools ────────────────────────────────────────────────────
+
+    /// Update the agent's user profile.
+    #[tool(
+        name = "set_profile",
+        description = "Update the agent's user profile (display name and/or avatar URL)."
+    )]
+    pub async fn set_profile(&self, Parameters(p): Parameters<SetProfileParams>) -> String {
+        let body = serde_json::json!({
+            "display_name": p.display_name,
+            "avatar_url": p.avatar_url,
+        });
+        match self.client.put("/api/users/me/profile", &body).await {
+            Ok(b) => b,
+            Err(e) => format!("Error: {e}"),
         }
     }
 }

--- a/crates/sprout-relay/src/api/channels_metadata.rs
+++ b/crates/sprout-relay/src/api/channels_metadata.rs
@@ -1,0 +1,430 @@
+//! Channel metadata REST API handlers.
+//!
+//! Endpoints:
+//!   GET  /api/channels/{channel_id}           — Get channel details
+//!   PUT  /api/channels/{channel_id}           — Update channel name/description
+//!   PUT  /api/channels/{channel_id}/topic     — Set channel topic
+//!   PUT  /api/channels/{channel_id}/purpose   — Set channel purpose
+//!   POST /api/channels/{channel_id}/archive   — Archive a channel
+//!   POST /api/channels/{channel_id}/unarchive — Unarchive a channel
+//!
+//! NOTE: These handlers call `state.db.*` methods that are wired through
+//! `sprout-db/src/lib.rs` by the orchestrator:
+//!   - `state.db.get_channel_detail(channel_id)` → channel::get_channel
+//!   - `state.db.update_channel(channel_id, updates)` → channel::update_channel
+//!   - `state.db.set_topic(channel_id, topic, set_by)` → channel::set_topic
+//!   - `state.db.set_purpose(channel_id, purpose, set_by)` → channel::set_purpose
+//!   - `state.db.archive_channel(channel_id)` → channel::archive_channel
+//!   - `state.db.unarchive_channel(channel_id)` → channel::unarchive_channel
+//!   - `state.db.get_member_count(channel_id)` → channel::get_member_count
+//!   - `state.db.get_member_role(channel_id, pubkey)` → channel::get_member_role
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Json as ExtractJson, Path, State},
+    http::{HeaderMap, StatusCode},
+    response::Json,
+};
+use nostr::util::hex as nostr_hex;
+use serde::Deserialize;
+use sprout_db::channel::{ChannelRecord, ChannelUpdate};
+
+use crate::handlers::side_effects::emit_system_message;
+use crate::state::AppState;
+
+use super::{
+    api_error, check_channel_access, extract_auth_pubkey, forbidden, internal_error, not_found,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Parse a channel_id path parameter as a UUID.
+fn parse_channel_id(raw: &str) -> Result<uuid::Uuid, (StatusCode, Json<serde_json::Value>)> {
+    uuid::Uuid::parse_str(raw).map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel_id"))
+}
+
+/// Serialize a `ChannelRecord` to JSON, including topic, purpose, and member_count.
+fn channel_detail_to_json(record: &ChannelRecord, member_count: i64) -> serde_json::Value {
+    serde_json::json!({
+        "id": record.id.to_string(),
+        "name": record.name,
+        "channel_type": record.channel_type,
+        "visibility": record.visibility,
+        "description": record.description,
+        "topic": record.topic,
+        "topic_set_by": record.topic_set_by.as_deref().map(nostr_hex::encode),
+        "topic_set_at": record.topic_set_at.map(|t| t.to_rfc3339()),
+        "purpose": record.purpose,
+        "purpose_set_by": record.purpose_set_by.as_deref().map(nostr_hex::encode),
+        "purpose_set_at": record.purpose_set_at.map(|t| t.to_rfc3339()),
+        "created_by": nostr_hex::encode(&record.created_by),
+        "created_at": record.created_at.to_rfc3339(),
+        "updated_at": record.updated_at.to_rfc3339(),
+        "archived_at": record.archived_at.map(|t| t.to_rfc3339()),
+        "member_count": member_count,
+        "topic_required": record.topic_required,
+        "max_members": record.max_members,
+        "nip29_group_id": record.nip29_group_id,
+    })
+}
+
+/// Check that the actor is an owner or admin of the channel.
+///
+/// Returns `Err(403)` if the actor is not a member or lacks an elevated role.
+async fn require_owner_or_admin(
+    state: &AppState,
+    channel_id: uuid::Uuid,
+    pubkey_bytes: &[u8],
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    let role = state
+        .db
+        .get_member_role(channel_id, pubkey_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    match role.as_deref() {
+        Some("owner") | Some("admin") => Ok(()),
+        Some(_) => Err(forbidden("owner or admin role required")),
+        None => Err(forbidden("not a member of this channel")),
+    }
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// GET /api/channels/{channel_id} — Get full channel details.
+///
+/// Requires the caller to be a member or the channel to be open.
+pub async fn get_channel_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id_str): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+    let channel_id = parse_channel_id(&channel_id_str)?;
+
+    check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+
+    let record = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|e| match e {
+            sprout_db::error::DbError::ChannelNotFound(_) => not_found("channel not found"),
+            other => internal_error(&format!("db error: {other}")),
+        })?;
+
+    let member_count = state
+        .db
+        .get_member_count(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    Ok(Json(channel_detail_to_json(&record, member_count)))
+}
+
+/// Request body for updating channel name/description.
+#[derive(Debug, Deserialize)]
+pub struct UpdateChannelBody {
+    /// New channel name (optional).
+    pub name: Option<String>,
+    /// New channel description (optional).
+    pub description: Option<String>,
+}
+
+/// PUT /api/channels/{channel_id} — Update channel name and/or description.
+///
+/// Requires owner or admin role.
+pub async fn update_channel_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id_str): Path<String>,
+    ExtractJson(body): ExtractJson<UpdateChannelBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+    let channel_id = parse_channel_id(&channel_id_str)?;
+
+    require_owner_or_admin(&state, channel_id, &pubkey_bytes).await?;
+
+    // Reject writes to archived channels.
+    let channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    if channel.archived_at.is_some() {
+        return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+    }
+
+    if body.name.is_none() && body.description.is_none() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "at least one of name or description must be provided",
+        ));
+    }
+
+    let name = body
+        .name
+        .map(|n| n.trim().to_string())
+        .filter(|n| !n.is_empty());
+    let description = body
+        .description
+        .map(|d| d.trim().to_string())
+        .filter(|d| !d.is_empty());
+
+    // Re-check after trimming: whitespace-only values collapse to None.
+    if name.is_none() && description.is_none() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "at least one field must be provided (non-empty)",
+        ));
+    }
+
+    let name_changed = name.is_some();
+    let new_name = name.clone();
+
+    let record = state
+        .db
+        .update_channel(channel_id, ChannelUpdate { name, description })
+        .await
+        .map_err(|e| match e {
+            sprout_db::error::DbError::ChannelNotFound(_) => not_found("channel not found"),
+            sprout_db::error::DbError::InvalidData(msg) => api_error(StatusCode::BAD_REQUEST, &msg),
+            other => internal_error(&format!("db error: {other}")),
+        })?;
+
+    if name_changed {
+        let actor_hex = nostr_hex::encode(&pubkey_bytes);
+        if let Err(e) = emit_system_message(
+            &state,
+            channel_id,
+            serde_json::json!({
+                "type": "channel_renamed",
+                "actor": actor_hex,
+                "name": new_name,
+            }),
+        )
+        .await
+        {
+            tracing::warn!("Failed to emit system message: {e}");
+        }
+    }
+
+    let member_count = state
+        .db
+        .get_member_count(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    Ok(Json(channel_detail_to_json(&record, member_count)))
+}
+
+/// Request body for setting the channel topic.
+#[derive(Debug, Deserialize)]
+pub struct SetTopicBody {
+    /// The new topic text.
+    pub topic: String,
+}
+
+/// PUT /api/channels/{channel_id}/topic — Set the channel topic.
+///
+/// Any active member may set the topic.
+pub async fn set_topic_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id_str): Path<String>,
+    ExtractJson(body): ExtractJson<SetTopicBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+    let channel_id = parse_channel_id(&channel_id_str)?;
+
+    check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+
+    // Reject writes to archived channels.
+    let channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    if channel.archived_at.is_some() {
+        return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+    }
+
+    let topic = body.topic.trim().to_string();
+    if topic.is_empty() {
+        return Err(api_error(StatusCode::BAD_REQUEST, "topic cannot be empty"));
+    }
+
+    state
+        .db
+        .set_topic(channel_id, &topic, &pubkey_bytes)
+        .await
+        .map_err(|e| match e {
+            sprout_db::error::DbError::ChannelNotFound(_) => not_found("channel not found"),
+            other => internal_error(&format!("db error: {other}")),
+        })?;
+
+    let actor_hex = nostr_hex::encode(&pubkey_bytes);
+    if let Err(e) = emit_system_message(
+        &state,
+        channel_id,
+        serde_json::json!({
+            "type": "topic_changed",
+            "actor": actor_hex,
+            "topic": topic,
+        }),
+    )
+    .await
+    {
+        tracing::warn!("Failed to emit system message: {e}");
+    }
+
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+/// Request body for setting the channel purpose.
+#[derive(Debug, Deserialize)]
+pub struct SetPurposeBody {
+    /// The new purpose text.
+    pub purpose: String,
+}
+
+/// PUT /api/channels/{channel_id}/purpose — Set the channel purpose.
+///
+/// Any active member may set the purpose.
+pub async fn set_purpose_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id_str): Path<String>,
+    ExtractJson(body): ExtractJson<SetPurposeBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+    let channel_id = parse_channel_id(&channel_id_str)?;
+
+    check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+
+    // Reject writes to archived channels.
+    let channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    if channel.archived_at.is_some() {
+        return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+    }
+
+    let purpose = body.purpose.trim().to_string();
+    if purpose.is_empty() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "purpose cannot be empty",
+        ));
+    }
+
+    state
+        .db
+        .set_purpose(channel_id, &purpose, &pubkey_bytes)
+        .await
+        .map_err(|e| match e {
+            sprout_db::error::DbError::ChannelNotFound(_) => not_found("channel not found"),
+            other => internal_error(&format!("db error: {other}")),
+        })?;
+
+    let actor_hex = nostr_hex::encode(&pubkey_bytes);
+    if let Err(e) = emit_system_message(
+        &state,
+        channel_id,
+        serde_json::json!({
+            "type": "purpose_changed",
+            "actor": actor_hex,
+            "purpose": purpose,
+        }),
+    )
+    .await
+    {
+        tracing::warn!("Failed to emit system message: {e}");
+    }
+
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+/// POST /api/channels/{channel_id}/archive — Archive a channel.
+///
+/// Requires owner or admin role.
+/// Returns 409 Conflict if the channel is already archived.
+pub async fn archive_channel_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id_str): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+    let channel_id = parse_channel_id(&channel_id_str)?;
+
+    require_owner_or_admin(&state, channel_id, &pubkey_bytes).await?;
+
+    state
+        .db
+        .archive_channel(channel_id)
+        .await
+        .map_err(|e| match e {
+            sprout_db::error::DbError::ChannelNotFound(_) => not_found("channel not found"),
+            sprout_db::error::DbError::AccessDenied(msg) => api_error(StatusCode::CONFLICT, &msg),
+            other => internal_error(&format!("db error: {other}")),
+        })?;
+
+    let actor_hex = nostr_hex::encode(&pubkey_bytes);
+    if let Err(e) = emit_system_message(
+        &state,
+        channel_id,
+        serde_json::json!({
+            "type": "channel_archived",
+            "actor": actor_hex,
+        }),
+    )
+    .await
+    {
+        tracing::warn!("Failed to emit system message: {e}");
+    }
+
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+/// POST /api/channels/{channel_id}/unarchive — Unarchive a channel.
+///
+/// Requires owner or admin role.
+/// Returns 409 Conflict if the channel is not currently archived.
+pub async fn unarchive_channel_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id_str): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+    let channel_id = parse_channel_id(&channel_id_str)?;
+
+    require_owner_or_admin(&state, channel_id, &pubkey_bytes).await?;
+
+    state
+        .db
+        .unarchive_channel(channel_id)
+        .await
+        .map_err(|e| match e {
+            sprout_db::error::DbError::ChannelNotFound(_) => not_found("channel not found"),
+            sprout_db::error::DbError::AccessDenied(msg) => api_error(StatusCode::CONFLICT, &msg),
+            other => internal_error(&format!("db error: {other}")),
+        })?;
+
+    let actor_hex = nostr_hex::encode(&pubkey_bytes);
+    if let Err(e) = emit_system_message(
+        &state,
+        channel_id,
+        serde_json::json!({
+            "type": "channel_unarchived",
+            "actor": actor_hex,
+        }),
+    )
+    .await
+    {
+        tracing::warn!("Failed to emit system message: {e}");
+    }
+
+    Ok(Json(serde_json::json!({ "ok": true })))
+}

--- a/crates/sprout-relay/src/api/dms.rs
+++ b/crates/sprout-relay/src/api/dms.rs
@@ -1,0 +1,347 @@
+//! Direct Message REST API.
+//!
+//! Endpoints:
+//!   POST /api/dms                      — Open or create a DM (idempotent)
+//!   POST /api/dms/{channel_id}/members — Add member to group DM (creates new DM)
+//!   GET  /api/dms                      — List user's DM conversations
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Json as ExtractJson, Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::Json,
+};
+use nostr::util::hex as nostr_hex;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::handlers::side_effects::emit_system_message;
+use crate::state::AppState;
+
+use super::{api_error, extract_auth_pubkey, internal_error};
+
+// ── Request / query types ─────────────────────────────────────────────────────
+
+/// Request body for opening a DM.
+#[derive(Debug, Deserialize)]
+pub struct OpenDmBody {
+    /// Hex-encoded pubkeys of the OTHER participants (self is added automatically).
+    /// Must contain 1–8 entries (self brings the total to 2–9).
+    pub pubkeys: Vec<String>,
+}
+
+/// Request body for adding a member to a group DM.
+#[derive(Debug, Deserialize)]
+pub struct AddDmMemberBody {
+    /// Hex-encoded pubkeys of the new participants to add.
+    pub pubkeys: Vec<String>,
+}
+
+/// Query parameters for listing DMs.
+#[derive(Debug, Deserialize)]
+pub struct ListDmsQuery {
+    /// Pagination cursor (channel_id of the last item from the previous page).
+    pub cursor: Option<String>,
+    /// Maximum number of results to return (default 50, max 200).
+    pub limit: Option<u32>,
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// `POST /api/dms` — Open or create a DM conversation.
+///
+/// The caller is automatically added as a participant. The operation is
+/// idempotent: the same participant set always returns the same channel.
+pub async fn open_dm_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    ExtractJson(body): ExtractJson<OpenDmBody>,
+) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, self_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    if body.pubkeys.is_empty() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "pubkeys must contain at least 1 other participant",
+        ));
+    }
+    if body.pubkeys.len() > 8 {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "pubkeys may contain at most 8 other participants (9 total including self)",
+        ));
+    }
+
+    // Decode all provided pubkeys.
+    let mut other_bytes: Vec<Vec<u8>> = Vec::with_capacity(body.pubkeys.len());
+    for hex in &body.pubkeys {
+        let bytes = hex::decode(hex).map_err(|_| {
+            api_error(
+                StatusCode::BAD_REQUEST,
+                &format!("invalid pubkey hex: {hex}"),
+            )
+        })?;
+        if bytes.len() != 32 {
+            return Err(api_error(
+                StatusCode::BAD_REQUEST,
+                &format!("pubkey must be 32 bytes (64 hex chars): {hex}"),
+            ));
+        }
+        other_bytes.push(bytes);
+    }
+
+    // Build the full participant slice (self + others).
+    let mut all_bytes: Vec<Vec<u8>> = vec![self_bytes.clone()];
+    for ob in &other_bytes {
+        if !all_bytes.iter().any(|b| b == ob) {
+            all_bytes.push(ob.clone());
+        }
+    }
+
+    let all_refs: Vec<&[u8]> = all_bytes.iter().map(|b| b.as_slice()).collect();
+
+    let (channel, was_created) = state
+        .db
+        .open_dm(&all_refs, &self_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    if was_created {
+        let actor_hex = nostr_hex::encode(&self_bytes);
+        let participant_hexes: Vec<String> = all_bytes.iter().map(nostr_hex::encode).collect();
+        if let Err(e) = emit_system_message(
+            &state,
+            channel.id,
+            serde_json::json!({
+                "type": "dm_created",
+                "actor": actor_hex,
+                "participants": participant_hexes,
+            }),
+        )
+        .await
+        {
+            tracing::warn!("Failed to emit system message: {e}");
+        }
+    }
+
+    // Resolve participant display names.
+    let participants = resolve_participants(&state, channel.id).await;
+
+    let status = if was_created {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+
+    Ok((
+        status,
+        Json(serde_json::json!({
+            "channel_id": channel.id.to_string(),
+            "created": was_created,
+            "participants": participants,
+        })),
+    ))
+}
+
+/// `POST /api/dms/{channel_id}/members` — Add a member to a group DM.
+///
+/// Because DM participant sets are immutable, this creates a NEW DM with the
+/// expanded participant set. The original DM is not modified.
+pub async fn add_dm_member_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id_str): Path<String>,
+    ExtractJson(body): ExtractJson<AddDmMemberBody>,
+) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, self_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let channel_id = Uuid::parse_str(&channel_id_str)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel_id format"))?;
+
+    if body.pubkeys.is_empty() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "pubkeys must contain at least 1 new participant",
+        ));
+    }
+
+    // Verify caller is a member of the existing DM.
+    let is_member = state
+        .db
+        .is_member(channel_id, &self_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    if !is_member {
+        return Err(super::forbidden("not a member of this DM"));
+    }
+
+    // Verify the channel is actually a DM.
+    let existing_channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|_| super::not_found("DM not found"))?;
+    if existing_channel.channel_type != "dm" {
+        return Err(api_error(StatusCode::BAD_REQUEST, "channel is not a DM"));
+    }
+
+    // Get existing participants.
+    let existing_members = state
+        .db
+        .get_members(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    let mut all_bytes: Vec<Vec<u8>> = existing_members.into_iter().map(|m| m.pubkey).collect();
+
+    // Decode and merge new pubkeys.
+    for hex in &body.pubkeys {
+        let bytes = hex::decode(hex).map_err(|_| {
+            api_error(
+                StatusCode::BAD_REQUEST,
+                &format!("invalid pubkey hex: {hex}"),
+            )
+        })?;
+        if bytes.len() != 32 {
+            return Err(api_error(
+                StatusCode::BAD_REQUEST,
+                &format!("pubkey must be 32 bytes (64 hex chars): {hex}"),
+            ));
+        }
+        if !all_bytes.iter().any(|b| b == &bytes) {
+            all_bytes.push(bytes);
+        }
+    }
+
+    // Enforce max 9 participants.
+    if all_bytes.len() > 9 {
+        return Err(api_error(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "DM supports at most 9 participants",
+        ));
+    }
+
+    let all_refs: Vec<&[u8]> = all_bytes.iter().map(|b| b.as_slice()).collect();
+
+    let (new_channel, was_created) = state
+        .db
+        .open_dm(&all_refs, &self_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    let participants = resolve_participants(&state, new_channel.id).await;
+
+    let status = if was_created {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+
+    Ok((
+        status,
+        Json(serde_json::json!({
+            "channel_id": new_channel.id.to_string(),
+            "created": was_created,
+            "participants": participants,
+            "note": "A new DM was created with the expanded participant set. The original DM is unchanged.",
+        })),
+    ))
+}
+
+/// `GET /api/dms` — List the authenticated user's DM conversations.
+///
+/// Returns DMs ordered by most recent activity (updated_at DESC).
+/// Supports cursor-based pagination.
+pub async fn list_dms_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(params): Query<ListDmsQuery>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, self_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let limit = params.limit.unwrap_or(50).min(200);
+
+    let cursor = params
+        .cursor
+        .as_deref()
+        .map(Uuid::parse_str)
+        .transpose()
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid cursor format"))?;
+
+    let dms = state
+        .db
+        .list_dms_for_user(&self_bytes, limit, cursor)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    let next_cursor = dms.last().map(|d| d.channel_id.to_string());
+
+    let dm_json: Vec<serde_json::Value> = dms
+        .iter()
+        .map(|dm| {
+            let participants: Vec<serde_json::Value> = dm
+                .participants
+                .iter()
+                .map(|p| {
+                    serde_json::json!({
+                        "pubkey": nostr_hex::encode(&p.pubkey),
+                        "display_name": p.display_name,
+                        "role": p.role,
+                    })
+                })
+                .collect();
+
+            serde_json::json!({
+                "channel_id": dm.channel_id.to_string(),
+                "participants": participants,
+                "last_message_at": dm.last_message_at.map(|t| t.to_rfc3339()),
+                "created_at": dm.created_at.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    Ok(Json(serde_json::json!({
+        "dms": dm_json,
+        "next_cursor": next_cursor,
+    })))
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Fetch and format participant info for a DM channel.
+async fn resolve_participants(state: &AppState, channel_id: Uuid) -> Vec<serde_json::Value> {
+    let members = state.db.get_members(channel_id).await.unwrap_or_else(|e| {
+        tracing::error!("dms: failed to load members for channel {channel_id}: {e}");
+        vec![]
+    });
+
+    let member_pubkeys: Vec<Vec<u8>> = members.iter().map(|m| m.pubkey.clone()).collect();
+
+    let user_records = state
+        .db
+        .get_users_bulk(&member_pubkeys)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("dms: failed to load user records for DM participants: {e}");
+            vec![]
+        });
+
+    let user_map: std::collections::HashMap<String, Option<String>> = user_records
+        .into_iter()
+        .map(|u| (nostr_hex::encode(&u.pubkey), u.display_name))
+        .collect();
+
+    members
+        .iter()
+        .map(|m| {
+            let hex = nostr_hex::encode(&m.pubkey);
+            let display_name = user_map.get(&hex).and_then(|n| n.clone());
+            serde_json::json!({
+                "pubkey": hex,
+                "display_name": display_name,
+                "role": m.role,
+            })
+        })
+        .collect()
+}

--- a/crates/sprout-relay/src/api/members.rs
+++ b/crates/sprout-relay/src/api/members.rs
@@ -1,0 +1,422 @@
+//! Channel membership REST API.
+//!
+//! Endpoints:
+//!   POST   /api/channels/{channel_id}/members          — Add member(s)
+//!   DELETE /api/channels/{channel_id}/members/{pubkey} — Remove member
+//!   GET    /api/channels/{channel_id}/members          — List members
+//!   POST   /api/channels/{channel_id}/join             — Self-join (open channels)
+//!   POST   /api/channels/{channel_id}/leave            — Self-leave
+//!   GET    /api/channels/{channel_id}                  — Get channel details
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{
+    extract::{Json as ExtractJson, Path, State},
+    http::{HeaderMap, StatusCode},
+    response::Json,
+};
+use nostr::util::hex as nostr_hex;
+use serde::Deserialize;
+use sprout_db::channel::MemberRole;
+use uuid::Uuid;
+
+use crate::handlers::side_effects::emit_system_message;
+use crate::state::AppState;
+
+use super::{api_error, check_channel_access, extract_auth_pubkey, forbidden, internal_error};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Verify the actor is an owner or admin of the channel. Returns 403 if not.
+async fn require_owner_or_admin(
+    state: &AppState,
+    channel_id: uuid::Uuid,
+    pubkey_bytes: &[u8],
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    let role = state
+        .db
+        .get_member_role(channel_id, pubkey_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    match role.as_deref() {
+        Some("owner") | Some("admin") => Ok(()),
+        _ => Err(forbidden("requires owner or admin role")),
+    }
+}
+
+// ── Request bodies ────────────────────────────────────────────────────────────
+
+/// Request body for adding member(s) to a channel.
+#[derive(Debug, Deserialize)]
+pub struct AddMembersBody {
+    /// Hex-encoded public keys to add.
+    pub pubkeys: Vec<String>,
+    /// Role to assign (`"member"`, `"admin"`, `"guest"`, `"bot"`).
+    #[serde(default = "default_role")]
+    pub role: String,
+}
+
+fn default_role() -> String {
+    "member".to_string()
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// `POST /api/channels/{channel_id}/members` — Add member(s) to a channel.
+///
+/// Actor must be an owner or admin. Returns lists of added pubkeys and any errors.
+pub async fn add_members(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id): Path<String>,
+    ExtractJson(body): ExtractJson<AddMembersBody>,
+) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, actor_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let channel_id = Uuid::parse_str(&channel_id)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel_id"))?;
+
+    // Private channels require owner/admin to add members.
+    let channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    if channel.visibility == "private" {
+        require_owner_or_admin(&state, channel_id, &actor_bytes).await?;
+    }
+
+    // Reject writes to archived channels.
+    if channel.archived_at.is_some() {
+        return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+    }
+
+    let role: MemberRole = body
+        .role
+        .parse()
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid role"))?;
+
+    let actor_hex = nostr_hex::encode(&actor_bytes);
+    let mut added = Vec::new();
+    let mut errors = Vec::new();
+
+    for hex_pk in &body.pubkeys {
+        let pubkey_bytes = match hex::decode(hex_pk) {
+            Ok(b) if b.len() == 32 => b,
+            _ => {
+                errors.push(serde_json::json!({
+                    "pubkey": hex_pk,
+                    "error": "invalid pubkey hex"
+                }));
+                continue;
+            }
+        };
+
+        match state
+            .db
+            .add_member(channel_id, &pubkey_bytes, role.clone(), Some(&actor_bytes))
+            .await
+        {
+            Ok(_) => {
+                let target_hex = nostr_hex::encode(&pubkey_bytes);
+                if let Err(e) = emit_system_message(
+                    &state,
+                    channel_id,
+                    serde_json::json!({
+                        "type": "member_joined",
+                        "actor": actor_hex,
+                        "target": target_hex,
+                    }),
+                )
+                .await
+                {
+                    tracing::warn!("Failed to emit system message: {e}");
+                }
+                added.push(hex_pk.clone());
+            }
+            Err(e) => {
+                errors.push(serde_json::json!({
+                    "pubkey": hex_pk,
+                    "error": e.to_string()
+                }));
+            }
+        }
+    }
+
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "added": added,
+            "errors": errors,
+        })),
+    ))
+}
+
+/// `DELETE /api/channels/{channel_id}/members/{pubkey}` — Remove a member.
+///
+/// Actor must be an owner/admin, or removing themselves.
+pub async fn remove_member(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path((channel_id, pubkey)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_actor_pk, actor_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let channel_id = Uuid::parse_str(&channel_id)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel_id"))?;
+
+    let target_bytes = hex::decode(&pubkey)
+        .ok()
+        .filter(|b| b.len() == 32)
+        .ok_or_else(|| api_error(StatusCode::BAD_REQUEST, "invalid pubkey"))?;
+
+    let is_self_remove = target_bytes == actor_bytes;
+    if !is_self_remove {
+        require_owner_or_admin(&state, channel_id, &actor_bytes).await?;
+    }
+
+    // Reject membership changes on archived channels.
+    // NOTE: This intentionally blocks self-removal too. If a user is stuck in
+    // an archived channel, an admin must unarchive first. The `leave_channel`
+    // endpoint has the same restriction for consistency.
+    let channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    if channel.archived_at.is_some() {
+        return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+    }
+
+    // Prevent last-owner orphaning on self-removal.
+    if is_self_remove {
+        let members = state
+            .db
+            .get_members(channel_id)
+            .await
+            .map_err(|e| internal_error(&format!("db error: {e}")))?;
+        let owner_count = members.iter().filter(|m| m.role == "owner").count();
+        let actor_is_owner = members
+            .iter()
+            .any(|m| m.pubkey == actor_bytes && m.role == "owner");
+        if actor_is_owner && owner_count <= 1 {
+            return Err(api_error(
+                StatusCode::CONFLICT,
+                "cannot remove the last owner — transfer ownership first",
+            ));
+        }
+    }
+
+    state
+        .db
+        .remove_member(channel_id, &target_bytes, &actor_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    let actor_hex = nostr_hex::encode(&actor_bytes);
+    let target_hex = nostr_hex::encode(&target_bytes);
+    let msg_type = if target_bytes == actor_bytes {
+        "member_left"
+    } else {
+        "member_removed"
+    };
+    if let Err(e) = emit_system_message(
+        &state,
+        channel_id,
+        serde_json::json!({
+            "type": msg_type,
+            "actor": actor_hex,
+            "target": target_hex,
+        }),
+    )
+    .await
+    {
+        tracing::warn!("Failed to emit system message: {e}");
+    }
+
+    Ok(Json(serde_json::json!({ "removed": true })))
+}
+
+/// `GET /api/channels/{channel_id}/members` — List members of a channel.
+///
+/// Requires channel membership or open visibility.
+pub async fn list_members(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let channel_id = Uuid::parse_str(&channel_id)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel_id"))?;
+
+    check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+
+    let members = state
+        .db
+        .get_members(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    // Resolve display names in bulk.
+    let member_pubkeys: Vec<Vec<u8>> = members.iter().map(|m| m.pubkey.clone()).collect();
+    let user_records = state
+        .db
+        .get_users_bulk(&member_pubkeys)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!("list_members: failed to load user records: {e}");
+            vec![]
+        });
+
+    let display_name_map: HashMap<String, String> = user_records
+        .into_iter()
+        .filter_map(|u| {
+            let hex = nostr_hex::encode(&u.pubkey);
+            u.display_name.map(|name| (hex, name))
+        })
+        .collect();
+
+    let result: Vec<serde_json::Value> = members
+        .iter()
+        .map(|m| {
+            let hex = nostr_hex::encode(&m.pubkey);
+            let display_name = display_name_map.get(&hex).cloned();
+            serde_json::json!({
+                "pubkey": hex,
+                "role": m.role,
+                "joined_at": m.joined_at.to_rfc3339(),
+                "display_name": display_name,
+            })
+        })
+        .collect();
+
+    Ok(Json(serde_json::json!({
+        "members": result,
+        "next_cursor": serde_json::Value::Null,
+    })))
+}
+
+/// `POST /api/channels/{channel_id}/join` — Self-join an open channel.
+///
+/// Only works for channels with `visibility = "open"`.
+pub async fn join_channel(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let channel_id = Uuid::parse_str(&channel_id)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel_id"))?;
+
+    // Only open channels allow self-join.
+    let channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|_| api_error(StatusCode::NOT_FOUND, "channel not found"))?;
+
+    if channel.visibility != "open" {
+        return Err(api_error(
+            StatusCode::FORBIDDEN,
+            "channel is private — request an invitation",
+        ));
+    }
+
+    // Reject writes to archived channels.
+    if channel.archived_at.is_some() {
+        return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+    }
+
+    state
+        .db
+        .add_member(channel_id, &pubkey_bytes, MemberRole::Member, None)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    let actor_hex = nostr_hex::encode(&pubkey_bytes);
+    if let Err(e) = emit_system_message(
+        &state,
+        channel_id,
+        serde_json::json!({
+            "type": "member_joined",
+            "actor": actor_hex,
+            "target": actor_hex,
+        }),
+    )
+    .await
+    {
+        tracing::warn!("Failed to emit system message: {e}");
+    }
+
+    Ok(Json(serde_json::json!({
+        "joined": true,
+        "role": "member",
+    })))
+}
+
+/// `POST /api/channels/{channel_id}/leave` — Self-leave a channel.
+///
+/// Returns 409 if the actor is the last owner (must transfer ownership first).
+pub async fn leave_channel(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let channel_id = Uuid::parse_str(&channel_id)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel_id"))?;
+
+    let channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    if channel.archived_at.is_some() {
+        return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+    }
+
+    // Guard: if actor is the last owner, block the leave.
+    let members = state
+        .db
+        .get_members(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    let owner_count = members.iter().filter(|m| m.role == "owner").count();
+    let actor_is_owner = members
+        .iter()
+        .any(|m| m.pubkey == pubkey_bytes && m.role == "owner");
+
+    if actor_is_owner && owner_count <= 1 {
+        return Err(api_error(
+            StatusCode::CONFLICT,
+            "owner must transfer ownership before leaving",
+        ));
+    }
+
+    state
+        .db
+        .remove_member(channel_id, &pubkey_bytes, &pubkey_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    let actor_hex = nostr_hex::encode(&pubkey_bytes);
+    if let Err(e) = emit_system_message(
+        &state,
+        channel_id,
+        serde_json::json!({
+            "type": "member_left",
+            "actor": actor_hex,
+        }),
+    )
+    .await
+    {
+        tracing::warn!("Failed to emit system message: {e}");
+    }
+
+    Ok(Json(serde_json::json!({ "left": true })))
+}

--- a/crates/sprout-relay/src/api/messages.rs
+++ b/crates/sprout-relay/src/api/messages.rs
@@ -1,0 +1,488 @@
+//! Channel messages and thread REST API.
+//!
+//! Endpoints:
+//!   POST /api/channels/:channel_id/messages          — send a message or reply
+//!   GET  /api/channels/:channel_id/messages          — list top-level messages
+//!   GET  /api/channels/:channel_id/threads/:event_id — full thread tree
+//!
+//! NOTE: These handlers call `state.db.*` methods that are wired through
+//! `sprout-db/src/lib.rs` by the orchestrator:
+//!   - `state.db.insert_thread_metadata(...)` → thread::insert_thread_metadata
+//!   - `state.db.get_thread_replies(root_id, depth_limit, limit, cursor)` → thread::get_thread_replies
+//!   - `state.db.get_thread_summary(event_id)` → thread::get_thread_summary
+//!   - `state.db.get_channel_messages_top_level(channel_id, limit, before)` → thread::get_channel_messages_top_level
+//!   - `state.db.get_thread_metadata_by_event(event_id)` → thread::get_thread_metadata_by_event
+//!   - `state.db.get_event_by_id(id_bytes)` → event::get_event_by_id  (already exists)
+//!   - `state.db.insert_event(event, channel_id)` → event::insert_event  (already exists)
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::Json,
+};
+use chrono::Utc;
+use nostr::util::hex as nostr_hex;
+use nostr::{EventBuilder, Kind, Tag};
+use serde::Deserialize;
+
+use crate::state::AppState;
+
+use super::{api_error, check_channel_access, extract_auth_pubkey, internal_error, not_found};
+
+// ── POST /api/channels/:channel_id/messages ───────────────────────────────────
+
+/// Request body for sending a channel message or thread reply.
+#[derive(Debug, Deserialize)]
+pub struct SendMessageBody {
+    /// Message text content.
+    pub content: String,
+    /// Hex-encoded event ID of the parent message (for replies).
+    pub parent_event_id: Option<String>,
+    /// When `true`, a reply is also surfaced in the channel feed (broadcast).
+    #[serde(default)]
+    pub broadcast_to_channel: bool,
+    /// Nostr kind for this message. Defaults to `KIND_STREAM_MESSAGE` (40001).
+    pub kind: Option<u32>,
+}
+
+/// Send a new channel message or reply to an existing thread.
+///
+/// The event is signed with the relay keypair and attributed to the
+/// authenticated user via a `p` tag. This is a REST convenience — clients
+/// that want user-signed events should use the WebSocket protocol instead.
+pub async fn send_message(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id_str): Path<String>,
+    Json(body): Json<SendMessageBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let channel_id = uuid::Uuid::parse_str(&channel_id_str)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel UUID"))?;
+
+    check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+
+    let channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+    if channel.archived_at.is_some() {
+        return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+    }
+
+    if body.content.trim().is_empty() {
+        return Err(api_error(StatusCode::BAD_REQUEST, "content is required"));
+    }
+
+    // Resolve kind — default to KIND_STREAM_MESSAGE (40001).
+    let kind_u32 = body.kind.unwrap_or(sprout_core::kind::KIND_STREAM_MESSAGE);
+    let kind = Kind::from(kind_u32 as u16);
+
+    // ── Resolve thread ancestry ───────────────────────────────────────────────
+
+    let (parent_id_bytes, parent_created_at, root_id_bytes, root_created_at, depth) =
+        if let Some(ref parent_hex) = body.parent_event_id {
+            let pid = nostr_hex::decode(parent_hex)
+                .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid parent_event_id hex"))?;
+
+            // Look up the parent's thread metadata to find the root and depth.
+            let parent_meta = state
+                .db
+                .get_thread_metadata_by_event(&pid)
+                .await
+                .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+            // Also need the parent event's created_at for the FK join.
+            let parent_event = state
+                .db
+                .get_event_by_id(&pid)
+                .await
+                .map_err(|e| internal_error(&format!("db error: {e}")))?
+                .ok_or_else(|| not_found("parent event not found"))?;
+
+            // Verify the parent event belongs to the same channel.
+            // Explicitly reject None — a parent with no channel association must not
+            // be used as a thread anchor (F6: silently skipped check allowed cross-channel
+            // or non-channel parents through).
+            match parent_event.channel_id {
+                Some(parent_channel) if parent_channel != channel_id => {
+                    return Err(api_error(
+                        StatusCode::BAD_REQUEST,
+                        "parent event belongs to a different channel",
+                    ));
+                }
+                None => {
+                    return Err(api_error(
+                        StatusCode::BAD_REQUEST,
+                        "parent event has no channel association",
+                    ));
+                }
+                _ => {} // Same channel — OK
+            }
+
+            let parent_ts = parent_event.event.created_at;
+            let parent_created = chrono::DateTime::from_timestamp(parent_ts.as_u64() as i64, 0)
+                .unwrap_or_else(Utc::now);
+
+            let (root_bytes, root_ts, depth) = match parent_meta {
+                Some(meta) => {
+                    // Parent is already in a thread — root propagates, depth increases.
+                    let root = meta.root_event_id.unwrap_or_else(|| pid.clone());
+                    // Look up the actual root event to get its real created_at.
+                    let root_ts =
+                        if let Ok(Some(root_event)) = state.db.get_event_by_id(&root).await {
+                            let ts = root_event.event.created_at.as_u64() as i64;
+                            chrono::DateTime::from_timestamp(ts, 0).unwrap_or(parent_created)
+                        } else {
+                            // Fallback: use parent_created as a safe approximation.
+                            parent_created
+                        };
+                    (root, root_ts, meta.depth + 1)
+                }
+                None => {
+                    // Parent has no thread metadata yet — it becomes the root.
+                    (pid.clone(), parent_created, 1)
+                }
+            };
+
+            (
+                Some(pid),
+                Some(parent_created),
+                Some(root_bytes),
+                Some(root_ts),
+                depth,
+            )
+        } else {
+            (None, None, None, None, 0)
+        };
+
+    // ── Build Nostr event ─────────────────────────────────────────────────────
+
+    // Attribute to the authenticated user via a `p` tag.
+    let user_pubkey_hex = nostr_hex::encode(&pubkey_bytes);
+
+    let mut tags: Vec<Tag> = vec![
+        // Attribution to the actual sender.
+        Tag::parse(&["p", &user_pubkey_hex])
+            .map_err(|e| internal_error(&format!("tag build error: {e}")))?,
+        // Channel tag so Nostr clients can find this event by channel.
+        Tag::custom(nostr::TagKind::custom("channel"), [channel_id.to_string()]),
+    ];
+
+    // Thread reply tags (NIP-10 style).
+    if let (Some(ref root_bytes), Some(ref parent_bytes)) = (&root_id_bytes, &parent_id_bytes) {
+        let root_hex = nostr_hex::encode(root_bytes);
+        let parent_hex = nostr_hex::encode(parent_bytes);
+
+        if root_hex == parent_hex {
+            // Direct reply to root — single `e` tag with "reply" marker.
+            tags.push(
+                Tag::parse(&["e", &root_hex, "", "reply"])
+                    .map_err(|e| internal_error(&format!("tag build error: {e}")))?,
+            );
+        } else {
+            // Nested reply — root tag + reply tag.
+            tags.push(
+                Tag::parse(&["e", &root_hex, "", "root"])
+                    .map_err(|e| internal_error(&format!("tag build error: {e}")))?,
+            );
+            tags.push(
+                Tag::parse(&["e", &parent_hex, "", "reply"])
+                    .map_err(|e| internal_error(&format!("tag build error: {e}")))?,
+            );
+        }
+    }
+
+    if body.broadcast_to_channel {
+        tags.push(
+            Tag::parse(&["broadcast", "1"])
+                .map_err(|e| internal_error(&format!("tag build error: {e}")))?,
+        );
+    }
+
+    let event = EventBuilder::new(kind, &body.content, tags)
+        .sign_with_keys(&state.relay_keypair)
+        .map_err(|e| internal_error(&format!("event signing error: {e}")))?;
+
+    let event_id_hex = event.id.to_hex();
+    let event_id_bytes = event.id.as_bytes().to_vec();
+    let event_created_at = {
+        let ts = event.created_at.as_u64() as i64;
+        chrono::DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
+    };
+
+    // ── Persist event ─────────────────────────────────────────────────────────
+
+    state
+        .db
+        .insert_event(&event, Some(channel_id))
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    // ── Persist thread metadata ───────────────────────────────────────────────
+
+    state
+        .db
+        .insert_thread_metadata(
+            &event_id_bytes,
+            event_created_at,
+            channel_id,
+            parent_id_bytes.as_deref(),
+            parent_created_at,
+            root_id_bytes.as_deref(),
+            root_created_at,
+            depth,
+            body.broadcast_to_channel,
+        )
+        .await
+        .map_err(|e| internal_error(&format!("thread metadata error: {e}")))?;
+
+    // ── Response ──────────────────────────────────────────────────────────────
+
+    Ok(Json(serde_json::json!({
+        "event_id":        event_id_hex,
+        "parent_event_id": body.parent_event_id,
+        "root_event_id":   root_id_bytes.as_ref().map(nostr_hex::encode),
+        "depth":           depth,
+        "created_at":      event_created_at.timestamp(),
+    })))
+}
+
+// ── GET /api/channels/:channel_id/messages ────────────────────────────────────
+
+/// Query parameters for listing top-level channel messages.
+#[derive(Debug, Deserialize)]
+pub struct ListMessagesParams {
+    /// Maximum messages to return. Default: 50, max: 200.
+    pub limit: Option<u32>,
+    /// Pagination cursor — Unix timestamp (seconds). Returns messages created
+    /// strictly before this time.
+    pub before: Option<i64>,
+    /// When `true`, include thread summaries for each message.
+    #[serde(default)]
+    pub with_threads: bool,
+}
+
+/// List top-level messages in a channel (newest first).
+///
+/// Returns root messages and broadcast replies. Thread replies are excluded
+/// unless `with_threads=true`, in which case each message includes a
+/// `thread_summary` with reply counts and participant pubkeys.
+pub async fn list_messages(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(channel_id_str): Path<String>,
+    Query(params): Query<ListMessagesParams>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let channel_id = uuid::Uuid::parse_str(&channel_id_str)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel UUID"))?;
+
+    check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+
+    let limit = params.limit.unwrap_or(50).min(200);
+
+    let before_cursor: Option<chrono::DateTime<Utc>> = params
+        .before
+        .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0));
+
+    let mut messages = state
+        .db
+        .get_channel_messages_top_level(channel_id, limit, before_cursor)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    // Optionally enrich with thread summaries.
+    if params.with_threads {
+        for msg in &mut messages {
+            if let Ok(summary) = state.db.get_thread_summary(&msg.event_id).await {
+                msg.thread_summary = summary;
+            }
+        }
+    }
+
+    // Determine next_cursor from the oldest message in this page.
+    let next_cursor = messages.last().map(|m| m.created_at.timestamp());
+
+    let result: Vec<serde_json::Value> = messages
+        .iter()
+        .map(|m| {
+            let mut obj = serde_json::json!({
+                "event_id":   nostr_hex::encode(&m.event_id),
+                "pubkey":     nostr_hex::encode(&m.pubkey),
+                "content":    m.content,
+                "kind":       m.kind,
+                "created_at": m.created_at.timestamp(),
+                "channel_id": m.channel_id.to_string(),
+            });
+
+            if let Some(ref ts) = m.thread_summary {
+                obj["thread_summary"] = serde_json::json!({
+                    "reply_count":      ts.reply_count,
+                    "descendant_count": ts.descendant_count,
+                    "last_reply_at":    ts.last_reply_at.map(|t| t.timestamp()),
+                    "participants":     ts.participants.iter()
+                        .map(nostr_hex::encode)
+                        .collect::<Vec<_>>(),
+                });
+            }
+
+            obj
+        })
+        .collect();
+
+    Ok(Json(serde_json::json!({
+        "messages":    result,
+        "next_cursor": next_cursor,
+    })))
+}
+
+// ── GET /api/channels/:channel_id/threads/:event_id ──────────────────────────
+
+/// Query parameters for fetching a thread tree.
+#[derive(Debug, Deserialize)]
+pub struct GetThreadParams {
+    /// Maximum reply depth to include. Omit for unlimited.
+    pub depth_limit: Option<u32>,
+    /// Maximum replies to return. Default: 100, max: 500.
+    pub limit: Option<u32>,
+    /// Keyset pagination cursor — hex-encoded event_id of the last seen reply.
+    pub cursor: Option<String>,
+}
+
+/// Fetch the full reply tree for a thread rooted at `event_id`.
+///
+/// Returns the root event details, all replies (optionally depth-limited),
+/// and pagination info.
+pub async fn get_thread(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path((channel_id_str, event_id_hex)): Path<(String, String)>,
+    Query(params): Query<GetThreadParams>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let channel_id = uuid::Uuid::parse_str(&channel_id_str)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid channel UUID"))?;
+
+    check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+
+    let root_id_bytes = nostr_hex::decode(&event_id_hex)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid event_id hex"))?;
+
+    // Fetch the root event.
+    let root_event = state
+        .db
+        .get_event_by_id(&root_id_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?
+        .ok_or_else(|| not_found("event not found"))?;
+
+    // Verify the root event belongs to the requested channel.
+    if let Some(root_channel) = root_event.channel_id {
+        if root_channel != channel_id {
+            return Err(api_error(
+                StatusCode::BAD_REQUEST,
+                "event belongs to a different channel",
+            ));
+        }
+    }
+
+    // Fetch thread summary for the root.
+    let summary = state
+        .db
+        .get_thread_summary(&root_id_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    let limit = params.limit.unwrap_or(100).min(500);
+
+    // Decode optional cursor.
+    // The cursor is a hex-encoded 8-byte big-endian i64 Unix timestamp (seconds),
+    // matching the encoding produced when building next_cursor below (F8).
+    let cursor_bytes: Option<Vec<u8>> = match params.cursor {
+        Some(ref hex) => {
+            let bytes = nostr_hex::decode(hex)
+                .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid cursor hex"))?;
+            if bytes.len() != 8 {
+                return Err(api_error(
+                    StatusCode::BAD_REQUEST,
+                    "cursor must be 8 bytes (timestamp)",
+                ));
+            }
+            Some(bytes)
+        }
+        None => None,
+    };
+
+    let replies = state
+        .db
+        .get_thread_replies(
+            &root_id_bytes,
+            params.depth_limit,
+            limit,
+            cursor_bytes.as_deref(),
+        )
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    // Encode next_cursor as hex of the last reply's created_at timestamp (8-byte big-endian i64).
+    // Using created_at (not event_id) because the ORDER BY is on event_created_at and binary
+    // event IDs do not correlate with chronological order (F8).
+    let next_cursor = replies.last().map(|r| {
+        let secs: i64 = r.created_at.timestamp();
+        nostr_hex::encode(secs.to_be_bytes())
+    });
+
+    let total_replies = summary.as_ref().map(|s| s.descendant_count).unwrap_or(0);
+
+    // Serialize root event.
+    let root_created_at = root_event.event.created_at.as_u64() as i64;
+    let root_obj = serde_json::json!({
+        "event_id":   root_event.event.id.to_hex(),
+        "pubkey":     root_event.event.pubkey.to_hex(),
+        "content":    root_event.event.content,
+        "kind":       root_event.event.kind.as_u16(),
+        "created_at": root_created_at,
+        "channel_id": channel_id.to_string(),
+        "thread_summary": summary.as_ref().map(|s| serde_json::json!({
+            "reply_count":      s.reply_count,
+            "descendant_count": s.descendant_count,
+            "last_reply_at":    s.last_reply_at.map(|t| t.timestamp()),
+            "participants":     s.participants.iter()
+                .map(nostr_hex::encode)
+                .collect::<Vec<_>>(),
+        })),
+    });
+
+    // Serialize replies.
+    let reply_objs: Vec<serde_json::Value> = replies
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "event_id":        nostr_hex::encode(&r.event_id),
+                "parent_event_id": r.parent_event_id.as_ref().map(nostr_hex::encode),
+                "root_event_id":   r.root_event_id.as_ref().map(nostr_hex::encode),
+                "channel_id":      r.channel_id.to_string(),
+                "pubkey":          nostr_hex::encode(&r.pubkey),
+                "content":         r.content,
+                "kind":            r.kind,
+                "depth":           r.depth,
+                "created_at":      r.created_at.timestamp(),
+                "broadcast":       r.broadcast,
+            })
+        })
+        .collect();
+
+    Ok(Json(serde_json::json!({
+        "root":          root_obj,
+        "replies":       reply_objs,
+        "total_replies": total_replies,
+        "next_cursor":   next_cursor,
+    })))
+}

--- a/crates/sprout-relay/src/api/mod.rs
+++ b/crates/sprout-relay/src/api/mod.rs
@@ -15,12 +15,24 @@ pub mod agents;
 pub mod approvals;
 /// Channel CRUD and membership endpoints.
 pub mod channels;
+/// Channel metadata endpoints (get, update, topic, purpose, archive).
+pub mod channels_metadata;
+/// Direct message endpoints.
+pub mod dms;
 /// Personalized home feed endpoint.
 pub mod feed;
+/// Channel membership endpoints.
+pub mod members;
+/// Message and thread endpoints.
+pub mod messages;
 /// Presence status endpoints.
 pub mod presence;
+/// Reaction endpoints.
+pub mod reactions;
 /// Full-text search endpoint.
 pub mod search;
+/// User profile endpoints.
+pub mod users;
 /// Shared helpers for workflow API handlers.
 pub mod workflow_helpers;
 /// Workflow CRUD, trigger, and webhook endpoints.
@@ -30,9 +42,18 @@ pub mod workflows;
 pub use agents::agents_handler;
 pub use approvals::{deny_approval, grant_approval};
 pub use channels::{channels_handler, create_channel};
+pub use channels_metadata::{
+    archive_channel_handler, get_channel_handler, set_purpose_handler, set_topic_handler,
+    unarchive_channel_handler, update_channel_handler,
+};
+pub use dms::{add_dm_member_handler, list_dms_handler, open_dm_handler};
 pub use feed::feed_handler;
+pub use members::{add_members, join_channel, leave_channel, list_members, remove_member};
+pub use messages::{get_thread, list_messages, send_message};
 pub use presence::presence_handler;
+pub use reactions::{add_reaction_handler, list_reactions_handler, remove_reaction_handler};
 pub use search::search_handler;
+pub use users::{get_profile, update_profile};
 pub use workflows::{
     create_workflow, delete_workflow, get_workflow, list_channel_workflows, list_workflow_runs,
     trigger_workflow, update_workflow, workflow_webhook,

--- a/crates/sprout-relay/src/api/reactions.rs
+++ b/crates/sprout-relay/src/api/reactions.rs
@@ -1,0 +1,298 @@
+//! Reaction REST API.
+//!
+//! Endpoints:
+//!   POST   /api/messages/:event_id/reactions          — add a reaction
+//!   DELETE /api/messages/:event_id/reactions/:emoji   — remove own reaction
+//!   GET    /api/messages/:event_id/reactions          — list reactions
+//!
+//! NOTE FOR ORCHESTRATOR: `db/lib.rs` needs the following method wrappers on `Db`:
+//!   - `add_reaction(event_id, event_created_at, pubkey, emoji) -> Result<bool>`
+//!   - `remove_reaction(event_id, event_created_at, pubkey, emoji) -> Result<bool>`
+//!   - `get_reactions(event_id, event_created_at, limit, cursor) -> Result<Vec<ReactionGroup>>`
+//!   - `get_reactions_bulk(event_ids) -> Result<Vec<BulkReactionEntry>>`
+//! All delegate to `sprout_db::reaction::*` free functions with `&self.pool`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::Json,
+};
+use chrono::{TimeZone, Utc};
+use nostr::util::hex as nostr_hex;
+use serde::Deserialize;
+
+use crate::state::AppState;
+
+use super::{api_error, check_channel_access, extract_auth_pubkey, internal_error, not_found};
+
+// ── Request / query types ─────────────────────────────────────────────────────
+
+/// Request body for adding a reaction.
+#[derive(Debug, Deserialize)]
+pub struct AddReactionBody {
+    /// The emoji to react with (e.g. "👍", ":thumbsup:", "+1").
+    pub emoji: String,
+}
+
+/// Query parameters for listing reactions.
+#[derive(Debug, Deserialize)]
+pub struct ListReactionsParams {
+    /// Opaque pagination cursor (reserved for future use).
+    pub cursor: Option<String>,
+    /// Maximum number of emoji groups to return. Default: 50. Max: 200.
+    pub limit: Option<u32>,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Decode a hex event_id path segment into 32 bytes.
+///
+/// Returns a 400 error if the string is not valid hex or not exactly 32 bytes.
+fn decode_event_id(hex: &str) -> Result<Vec<u8>, (StatusCode, Json<serde_json::Value>)> {
+    hex::decode(hex)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid event_id: not valid hex"))
+        .and_then(|bytes| {
+            if bytes.len() == 32 {
+                Ok(bytes)
+            } else {
+                Err(api_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid event_id: must be 32 bytes (64 hex chars)",
+                ))
+            }
+        })
+}
+
+// ── POST /api/messages/:event_id/reactions ────────────────────────────────────
+
+/// Add a reaction to a message.
+///
+/// The caller must be authenticated and have access to the channel the message
+/// belongs to (member or open channel). Returns 409 if the reaction already exists.
+pub async fn add_reaction_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(event_id_hex): Path<String>,
+    axum::extract::Json(body): axum::extract::Json<AddReactionBody>,
+) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let emoji = body.emoji.trim().to_string();
+    if emoji.is_empty() {
+        return Err(api_error(StatusCode::BAD_REQUEST, "emoji is required"));
+    }
+
+    let event_id_bytes = decode_event_id(&event_id_hex)?;
+
+    // Look up the event to get its created_at and channel_id.
+    let stored = state
+        .db
+        .get_event_by_id(&event_id_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?
+        .ok_or_else(|| not_found("event not found"))?;
+
+    // Verify channel access if the event belongs to a channel.
+    if let Some(channel_id) = stored.channel_id {
+        check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+        let channel = state
+            .db
+            .get_channel(channel_id)
+            .await
+            .map_err(|e| internal_error(&format!("db error: {e}")))?;
+        if channel.archived_at.is_some() {
+            return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+        }
+    }
+
+    // Convert nostr Timestamp → DateTime<Utc>.
+    let event_created_at = Utc
+        .timestamp_opt(stored.event.created_at.as_u64() as i64, 0)
+        .single()
+        .unwrap_or_default();
+
+    let added = state
+        .db
+        .add_reaction(&event_id_bytes, event_created_at, &pubkey_bytes, &emoji)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    if added {
+        Ok((
+            StatusCode::CREATED,
+            Json(serde_json::json!({ "added": true })),
+        ))
+    } else {
+        // ON DUPLICATE KEY UPDATE fired — reaction already active.
+        Err(api_error(StatusCode::CONFLICT, "reaction already exists"))
+    }
+}
+
+// ── DELETE /api/messages/:event_id/reactions/:emoji ───────────────────────────
+
+/// Remove the authenticated user's reaction from a message.
+///
+/// Returns 404 if the reaction was not found or already removed.
+/// axum's Path extractor URL-decodes the emoji segment automatically.
+pub async fn remove_reaction_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path((event_id_hex, emoji)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let event_id_bytes = decode_event_id(&event_id_hex)?;
+
+    // Look up the event to get its created_at and optionally verify channel access.
+    let stored = state
+        .db
+        .get_event_by_id(&event_id_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?
+        .ok_or_else(|| not_found("event not found"))?;
+
+    // Verify channel access if the event belongs to a channel.
+    if let Some(channel_id) = stored.channel_id {
+        check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+        let channel = state
+            .db
+            .get_channel(channel_id)
+            .await
+            .map_err(|e| internal_error(&format!("db error: {e}")))?;
+        if channel.archived_at.is_some() {
+            return Err(api_error(StatusCode::FORBIDDEN, "channel is archived"));
+        }
+    }
+
+    let event_created_at = Utc
+        .timestamp_opt(stored.event.created_at.as_u64() as i64, 0)
+        .single()
+        .unwrap_or_default();
+
+    let removed = state
+        .db
+        .remove_reaction(&event_id_bytes, event_created_at, &pubkey_bytes, &emoji)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    if removed {
+        Ok(Json(serde_json::json!({ "removed": true })))
+    } else {
+        Err(not_found("reaction not found"))
+    }
+}
+
+// ── GET /api/messages/:event_id/reactions ────────────────────────────────────
+
+/// List all active reactions for a message, grouped by emoji.
+///
+/// Resolves display names for reacting users where available.
+/// Supports optional `cursor` and `limit` query parameters.
+pub async fn list_reactions_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(event_id_hex): Path<String>,
+    Query(params): Query<ListReactionsParams>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let limit = params.limit.unwrap_or(50).min(200);
+    let cursor = params.cursor.as_deref();
+
+    let event_id_bytes = decode_event_id(&event_id_hex)?;
+
+    // Look up the event to get its created_at and channel_id.
+    let stored = state
+        .db
+        .get_event_by_id(&event_id_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?
+        .ok_or_else(|| not_found("event not found"))?;
+
+    // Verify channel access if the event belongs to a channel.
+    if let Some(channel_id) = stored.channel_id {
+        check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+    }
+
+    let event_created_at = Utc
+        .timestamp_opt(stored.event.created_at.as_u64() as i64, 0)
+        .single()
+        .unwrap_or_default();
+
+    let groups = state
+        .db
+        .get_reactions(&event_id_bytes, event_created_at, limit, cursor)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    // Collect all unique pubkeys across all groups for bulk display-name resolution.
+    let all_pubkeys: Vec<Vec<u8>> = {
+        let mut seen = std::collections::HashSet::new();
+        let mut pks = Vec::new();
+        for g in &groups {
+            for u in &g.users {
+                if seen.insert(u.pubkey.clone()) {
+                    pks.push(u.pubkey.clone());
+                }
+            }
+        }
+        pks
+    };
+
+    // Resolve display names via bulk user lookup.
+    let display_names: HashMap<String, String> = if all_pubkeys.is_empty() {
+        HashMap::new()
+    } else {
+        state
+            .db
+            .get_users_bulk(&all_pubkeys)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("reactions: failed to resolve display names: {e}");
+                vec![]
+            })
+            .into_iter()
+            .filter_map(|u| {
+                let hex = nostr_hex::encode(&u.pubkey);
+                u.display_name.map(|name| (hex, name))
+            })
+            .collect()
+    };
+
+    // Build the response, enriching each user with their display name.
+    let reaction_list: Vec<serde_json::Value> = groups
+        .into_iter()
+        .map(|g| {
+            let users: Vec<serde_json::Value> = g
+                .users
+                .into_iter()
+                .map(|u| {
+                    let hex = nostr_hex::encode(&u.pubkey);
+                    let name = display_names
+                        .get(&hex)
+                        .cloned()
+                        .unwrap_or_else(|| hex[..8.min(hex.len())].to_string());
+                    serde_json::json!({
+                        "pubkey": hex,
+                        "display_name": name,
+                    })
+                })
+                .collect();
+
+            serde_json::json!({
+                "emoji": g.emoji,
+                "count": g.count,
+                "users": users,
+            })
+        })
+        .collect();
+
+    // next_cursor is reserved for future keyset pagination.
+    Ok(Json(serde_json::json!({
+        "reactions": reaction_list,
+        "next_cursor": serde_json::Value::Null,
+    })))
+}

--- a/crates/sprout-relay/src/api/users.rs
+++ b/crates/sprout-relay/src/api/users.rs
@@ -1,0 +1,93 @@
+//! User profile REST API.
+//!
+//! Endpoints:
+//!   GET /api/users/me/profile  — get own profile
+//!   PUT /api/users/me/profile  — update own profile (display_name, avatar_url)
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Json as ExtractJson, State},
+    http::{HeaderMap, StatusCode},
+    response::Json,
+};
+use nostr::util::hex as nostr_hex;
+use serde::Deserialize;
+
+use crate::state::AppState;
+
+use super::{api_error, extract_auth_pubkey, internal_error};
+
+/// Request body for updating a user's profile.
+/// Both fields are optional — at least one must be present.
+#[derive(Debug, Deserialize)]
+pub struct UpdateProfileBody {
+    /// New display name for the user, or `None` to leave unchanged.
+    pub display_name: Option<String>,
+    /// New avatar URL for the user, or `None` to leave unchanged.
+    pub avatar_url: Option<String>,
+}
+
+/// `PUT /api/users/me/profile` — update the authenticated user's profile.
+///
+/// Body: `{ "display_name": "Alice", "avatar_url": "https://..." }` (both optional, at least one required)
+/// Returns: `{ "updated": true }`
+pub async fn update_profile(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    ExtractJson(body): ExtractJson<UpdateProfileBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let display_name = body
+        .display_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let avatar_url = body
+        .avatar_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    if display_name.is_none() && avatar_url.is_none() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "at least one of display_name or avatar_url is required",
+        ));
+    }
+
+    state
+        .db
+        .update_user_profile(&pubkey_bytes, display_name, avatar_url)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    Ok(Json(serde_json::json!({ "updated": true })))
+}
+
+/// `GET /api/users/me/profile` — get the authenticated user's profile.
+///
+/// Returns: `{ "pubkey": "<hex>", "display_name": "...", "avatar_url": "...", "nip05_handle": "..." }`
+pub async fn get_profile(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let (_pubkey, pubkey_bytes) = extract_auth_pubkey(&headers, &state).await?;
+
+    let profile = state
+        .db
+        .get_user(&pubkey_bytes)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    match profile {
+        Some(p) => Ok(Json(serde_json::json!({
+            "pubkey": nostr_hex::encode(&p.pubkey),
+            "display_name": p.display_name,
+            "avatar_url": p.avatar_url,
+            "nip05_handle": p.nip05_handle,
+        }))),
+        None => Err(api_error(StatusCode::NOT_FOUND, "user not found")),
+    }
+}

--- a/crates/sprout-relay/src/config.rs
+++ b/crates/sprout-relay/src/config.rs
@@ -42,6 +42,9 @@ pub struct Config {
     /// If empty, permissive CORS is used (dev mode).
     /// Example: "tauri://localhost,http://localhost:3000"
     pub cors_origins: Vec<String>,
+    /// Optional hex-encoded private key for the relay's signing keypair.
+    /// If absent, a fresh keypair is generated at startup.
+    pub relay_private_key: Option<String>,
 }
 
 impl Config {
@@ -113,6 +116,8 @@ impl Config {
             .filter(|s| !s.is_empty())
             .collect();
 
+        let relay_private_key = std::env::var("SPROUT_RELAY_PRIVATE_KEY").ok();
+
         Ok(Self {
             bind_addr,
             database_url,
@@ -126,6 +131,7 @@ impl Config {
             auth,
             require_auth_token,
             cors_origins,
+            relay_private_key,
         })
     }
 }

--- a/crates/sprout-relay/src/handlers/event.rs
+++ b/crates/sprout-relay/src/handlers/event.rs
@@ -178,6 +178,41 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
         }
     }
 
+    // Admin kind validation (9000-9022) must happen BEFORE storage.
+    if crate::handlers::side_effects::is_admin_kind(kind_u32) {
+        if let Err(e) =
+            crate::handlers::side_effects::validate_admin_event(kind_u32, &event, &state).await
+        {
+            conn.send(RelayMessage::ok(
+                &event_id_hex,
+                false,
+                &format!("invalid: {e}"),
+            ));
+            return;
+        }
+    }
+
+    // Reject reactions (kind 7) targeting archived channels before storage.
+    // This prevents invalid events from being stored and fanned out.
+    if kind_u32 == 7 {
+        if let Some(ch_id) = channel_id {
+            match state.db.get_channel(ch_id).await {
+                Ok(channel) if channel.archived_at.is_some() => {
+                    conn.send(RelayMessage::ok(
+                        &event_id_hex,
+                        false,
+                        "invalid: channel is archived",
+                    ));
+                    return;
+                }
+                Err(_) => {
+                    // Channel not found — let it through; the event may still be valid
+                }
+                _ => {} // Channel exists and not archived — OK
+            }
+        }
+    }
+
     let (stored_event, was_inserted) = match state.db.insert_event(&event, channel_id).await {
         Ok(result) => result,
         Err(sprout_db::DbError::AuthEventRejected) => {
@@ -202,6 +237,15 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
     if !was_inserted {
         conn.send(RelayMessage::ok(&event_id_hex, true, "duplicate:"));
         return;
+    }
+
+    // Side effects (reactions, thread metadata, NIP-29 membership changes) run after storage.
+    if crate::handlers::side_effects::is_side_effect_kind(kind_u32) {
+        if let Err(e) =
+            crate::handlers::side_effects::handle_side_effects(kind_u32, &event, &state).await
+        {
+            tracing::warn!(event_id = %event_id_hex, kind = kind_u32, "Side effect failed: {e}");
+        }
     }
 
     if let Some(ch_id) = channel_id {
@@ -494,12 +538,12 @@ async fn derive_reaction_channel(
 
 /// Extract a channel UUID from event tags.
 ///
-/// Checks both `"channel"` custom tags and `"e"` reference tags (clients use
-/// `Tag::parse(&["e", channel_id])` — the value is a UUID, not an event hash).
+/// Checks `"channel"` custom tags and `"h"` NIP-29 group tags for a channel UUID.
+/// The `"e"` tag is intentionally NOT checked — it is reserved for event references only.
 fn extract_channel_id(event: &Event) -> Option<uuid::Uuid> {
     for tag in event.tags.iter() {
         let key = tag.kind().to_string();
-        if key == "channel" || key == "e" {
+        if key == "channel" || key == "h" {
             if let Some(val) = tag.content() {
                 if let Ok(id) = val.parse::<uuid::Uuid>() {
                     return Some(id);

--- a/crates/sprout-relay/src/handlers/mod.rs
+++ b/crates/sprout-relay/src/handlers/mod.rs
@@ -4,3 +4,5 @@ pub mod auth;
 pub mod close;
 pub mod event;
 pub mod req;
+/// NIP-29 and NIP-25 side-effect handlers.
+pub mod side_effects;

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -1,0 +1,592 @@
+//! NIP-29 and NIP-25 side-effect handlers.
+
+use std::sync::Arc;
+
+use nostr::{Event, EventBuilder, Kind, Tag};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use sprout_db::channel::MemberRole;
+
+use crate::state::AppState;
+
+/// Check if a kind is an admin kind (9000-9022) that needs pre-storage validation.
+pub fn is_admin_kind(kind: u32) -> bool {
+    matches!(kind, 9000..=9022)
+}
+
+/// Check if a kind triggers side effects after storage.
+pub fn is_side_effect_kind(kind: u32) -> bool {
+    matches!(kind, 7 | 9000..=9022 | 41001..=41003 | 40099)
+}
+
+/// Dispatch side effects for a stored event.
+pub async fn handle_side_effects(
+    kind: u32,
+    event: &Event,
+    state: &Arc<AppState>,
+) -> anyhow::Result<()> {
+    match kind {
+        9000 => handle_put_user(event, state).await,
+        9001 => handle_remove_user(event, state).await,
+        9002 => handle_edit_metadata(event, state).await,
+        9005 => handle_delete_event_side_effect(event, state).await,
+        9007 => handle_create_group(event, state).await,
+        9008 => handle_delete_group(event, state).await,
+        9009 | 9021 => {
+            warn!(
+                kind = kind,
+                "NIP-29 kind {kind} handler deferred to future phase"
+            );
+            Ok(())
+        }
+        9022 => handle_leave_request(event, state).await,
+        7 => handle_reaction(event, state).await,
+        _ => Ok(()),
+    }
+}
+
+/// Validate an admin kind event BEFORE storage.
+pub async fn validate_admin_event(
+    kind: u32,
+    event: &Event,
+    state: &Arc<AppState>,
+) -> anyhow::Result<()> {
+    // CREATE_GROUP doesn't need an existing channel — skip h-tag extraction
+    if kind == 9007 {
+        return Ok(());
+    }
+
+    // Extract channel from h tag
+    let channel_id =
+        extract_h_tag_channel(event).ok_or_else(|| anyhow::anyhow!("missing or invalid h tag"))?;
+
+    let actor_bytes = event.pubkey.serialize().to_vec();
+
+    // Reject mutations on archived channels.
+    let channel = state
+        .db
+        .get_channel(channel_id)
+        .await
+        .map_err(|_| anyhow::anyhow!("channel not found"))?;
+    if channel.archived_at.is_some() {
+        return Err(anyhow::anyhow!("channel is archived"));
+    }
+
+    match kind {
+        9000 => {
+            // PUT_USER: open channels allow any member; private requires owner/admin
+            if channel.visibility == "private" {
+                // Check actor is owner/admin
+                let members = state.db.get_members(channel_id).await?;
+                let actor_member = members.iter().find(|m| m.pubkey == actor_bytes);
+                match actor_member {
+                    Some(m) if m.role == "owner" || m.role == "admin" => Ok(()),
+                    _ => Err(anyhow::anyhow!("actor not authorized")),
+                }
+            } else {
+                // Open channel: any authenticated user can add
+                Ok(())
+            }
+        }
+        9001 => {
+            // REMOVE_USER: self-remove allowed unless actor is the last owner; removing others requires owner/admin
+            let target_pubkey =
+                extract_p_tag(event).ok_or_else(|| anyhow::anyhow!("missing p tag"))?;
+            if target_pubkey == actor_bytes {
+                // Self-removal: must be an active member, and cannot be the last owner.
+                let members = state.db.get_members(channel_id).await?;
+                let actor_member = members.iter().find(|m| m.pubkey == actor_bytes);
+                match actor_member {
+                    None => {
+                        return Err(anyhow::anyhow!("actor is not an active member"));
+                    }
+                    Some(m) if m.role == "owner" => {
+                        let owner_count = members.iter().filter(|m| m.role == "owner").count();
+                        if owner_count <= 1 {
+                            return Err(anyhow::anyhow!("cannot remove the last owner"));
+                        }
+                    }
+                    _ => {}
+                }
+                Ok(())
+            } else {
+                let members = state.db.get_members(channel_id).await?;
+                let actor_member = members.iter().find(|m| m.pubkey == actor_bytes);
+                match actor_member {
+                    Some(m) if m.role == "owner" || m.role == "admin" => Ok(()),
+                    _ => Err(anyhow::anyhow!("actor not authorized")),
+                }
+            }
+        }
+        9002 => {
+            // EDIT_METADATA: name/about require owner/admin; topic/purpose allow any member
+            let has_name_or_about = event.tags.iter().any(|t| {
+                let k = t.kind().to_string();
+                k == "name" || k == "about"
+            });
+            if has_name_or_about {
+                let members = state.db.get_members(channel_id).await?;
+                let actor_member = members.iter().find(|m| m.pubkey == actor_bytes);
+                match actor_member {
+                    Some(m) if m.role == "owner" || m.role == "admin" => Ok(()),
+                    _ => Err(anyhow::anyhow!(
+                        "actor not authorized for name/about changes"
+                    )),
+                }
+            } else {
+                // topic/purpose: any member
+                let is_member = state.db.is_member(channel_id, &actor_bytes).await?;
+                if is_member {
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!("not a member"))
+                }
+            }
+        }
+        9005 => {
+            // DELETE_EVENT: owner/admin or event author
+            // For now, just check membership
+            let is_member = state.db.is_member(channel_id, &actor_bytes).await?;
+            if is_member {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!("not a member"))
+            }
+        }
+        9008 => {
+            // DELETE_GROUP: owner only
+            let members = state.db.get_members(channel_id).await?;
+            let actor_member = members.iter().find(|m| m.pubkey == actor_bytes);
+            match actor_member {
+                Some(m) if m.role == "owner" => Ok(()),
+                _ => Err(anyhow::anyhow!("only owner can delete group")),
+            }
+        }
+        9022 => {
+            // LEAVE_REQUEST: must be an active member, and cannot be the last owner.
+            let members = state.db.get_members(channel_id).await?;
+            let actor_member = members.iter().find(|m| m.pubkey == actor_bytes);
+            match actor_member {
+                None => {
+                    return Err(anyhow::anyhow!("actor is not an active member"));
+                }
+                Some(m) if m.role == "owner" => {
+                    let owner_count = members.iter().filter(|m| m.role == "owner").count();
+                    if owner_count <= 1 {
+                        return Err(anyhow::anyhow!("cannot remove the last owner"));
+                    }
+                }
+                _ => {}
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Emit a system message (kind 40099) signed by the relay keypair.
+pub async fn emit_system_message(
+    state: &Arc<AppState>,
+    channel_id: Uuid,
+    content: serde_json::Value,
+) -> anyhow::Result<()> {
+    let channel_tag = Tag::custom(nostr::TagKind::custom("channel"), [channel_id.to_string()]);
+
+    let event = EventBuilder::new(Kind::Custom(40099), content.to_string(), [channel_tag])
+        .sign_with_keys(&state.relay_keypair)
+        .map_err(|e| anyhow::anyhow!("failed to sign system message: {e}"))?;
+
+    let _ = state.db.insert_event(&event, Some(channel_id)).await;
+
+    // Fan out to subscribers
+    if let Err(e) = state.pubsub.publish_event(channel_id, &event).await {
+        warn!("System message fan-out failed: {e}");
+    }
+
+    Ok(())
+}
+
+// ── NIP-29 Handlers ──────────────────────────────────────────────────────────
+
+async fn handle_put_user(event: &Event, state: &Arc<AppState>) -> anyhow::Result<()> {
+    let channel_id =
+        extract_h_tag_channel(event).ok_or_else(|| anyhow::anyhow!("missing h tag"))?;
+    let target_pubkey = extract_p_tag(event).ok_or_else(|| anyhow::anyhow!("missing p tag"))?;
+    let role_str = extract_tag_value(event, "role").unwrap_or_else(|| "member".to_string());
+    let role: MemberRole = role_str
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid role: {role_str}"))?;
+
+    let actor_bytes = event.pubkey.serialize().to_vec();
+
+    state
+        .db
+        .add_member(channel_id, &target_pubkey, role, Some(&actor_bytes))
+        .await?;
+
+    let actor_hex = nostr::util::hex::encode(&actor_bytes);
+    let target_hex = nostr::util::hex::encode(&target_pubkey);
+    emit_system_message(
+        state,
+        channel_id,
+        serde_json::json!({
+            "type": "member_joined",
+            "actor": actor_hex,
+            "target": target_hex,
+        }),
+    )
+    .await?;
+
+    info!(channel = %channel_id, target = %target_hex, "NIP-29 PUT_USER processed");
+    Ok(())
+}
+
+async fn handle_remove_user(event: &Event, state: &Arc<AppState>) -> anyhow::Result<()> {
+    let channel_id =
+        extract_h_tag_channel(event).ok_or_else(|| anyhow::anyhow!("missing h tag"))?;
+    let target_pubkey = extract_p_tag(event).ok_or_else(|| anyhow::anyhow!("missing p tag"))?;
+    let actor_bytes = event.pubkey.serialize().to_vec();
+
+    // Guard: prevent last-owner orphaning on self-removal (kind 9001).
+    if target_pubkey == actor_bytes {
+        let members = state.db.get_members(channel_id).await?;
+        let owner_count = members.iter().filter(|m| m.role == "owner").count();
+        let actor_is_owner = members
+            .iter()
+            .any(|m| m.pubkey == actor_bytes && m.role == "owner");
+        if actor_is_owner && owner_count <= 1 {
+            return Err(anyhow::anyhow!(
+                "cannot remove the last owner — transfer ownership first"
+            ));
+        }
+    }
+
+    state
+        .db
+        .remove_member(channel_id, &target_pubkey, &actor_bytes)
+        .await?;
+
+    let actor_hex = nostr::util::hex::encode(&actor_bytes);
+    let target_hex = nostr::util::hex::encode(&target_pubkey);
+    let msg_type = if target_pubkey == actor_bytes {
+        "member_left"
+    } else {
+        "member_removed"
+    };
+    emit_system_message(
+        state,
+        channel_id,
+        serde_json::json!({
+            "type": msg_type,
+            "actor": actor_hex,
+            "target": target_hex,
+        }),
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn handle_edit_metadata(event: &Event, state: &Arc<AppState>) -> anyhow::Result<()> {
+    let channel_id =
+        extract_h_tag_channel(event).ok_or_else(|| anyhow::anyhow!("missing h tag"))?;
+    let actor_bytes = event.pubkey.serialize().to_vec();
+    let actor_hex = nostr::util::hex::encode(&actor_bytes);
+
+    for tag in event.tags.iter() {
+        let key = tag.kind().to_string();
+        if let Some(val) = tag.content() {
+            match key.as_str() {
+                "name" => {
+                    state
+                        .db
+                        .update_channel(
+                            channel_id,
+                            sprout_db::channel::ChannelUpdate {
+                                name: Some(val.to_string()),
+                                description: None,
+                            },
+                        )
+                        .await?;
+                }
+                "about" => {
+                    state
+                        .db
+                        .update_channel(
+                            channel_id,
+                            sprout_db::channel::ChannelUpdate {
+                                name: None,
+                                description: Some(val.to_string()),
+                            },
+                        )
+                        .await?;
+                }
+                "topic" => {
+                    state.db.set_topic(channel_id, val, &actor_bytes).await?;
+                    emit_system_message(
+                        state,
+                        channel_id,
+                        serde_json::json!({
+                            "type": "topic_changed", "actor": actor_hex, "topic": val
+                        }),
+                    )
+                    .await?;
+                }
+                "purpose" => {
+                    state.db.set_purpose(channel_id, val, &actor_bytes).await?;
+                    emit_system_message(
+                        state,
+                        channel_id,
+                        serde_json::json!({
+                            "type": "purpose_changed", "actor": actor_hex, "purpose": val
+                        }),
+                    )
+                    .await?;
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn handle_delete_event_side_effect(
+    event: &Event,
+    state: &Arc<AppState>,
+) -> anyhow::Result<()> {
+    let channel_id =
+        extract_h_tag_channel(event).ok_or_else(|| anyhow::anyhow!("missing h tag"))?;
+
+    // Extract target event ID from e tag
+    let target_id = event
+        .tags
+        .iter()
+        .find_map(|tag| {
+            if tag.kind().to_string() == "e" {
+                tag.content().and_then(|v| {
+                    let bytes = hex::decode(v).ok()?;
+                    if bytes.len() == 32 {
+                        Some(bytes)
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| anyhow::anyhow!("missing e tag for target event"))?;
+
+    // TODO: Add soft_delete_event to Db for full implementation
+    tracing::info!(target_event = %hex::encode(&target_id), "Would soft-delete event");
+
+    let actor_hex = nostr::util::hex::encode(event.pubkey.serialize());
+    emit_system_message(
+        state,
+        channel_id,
+        serde_json::json!({
+            "type": "message_deleted",
+            "actor": actor_hex,
+            "target_event_id": hex::encode(&target_id),
+        }),
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn handle_create_group(event: &Event, state: &Arc<AppState>) -> anyhow::Result<()> {
+    let name =
+        extract_tag_value(event, "name").ok_or_else(|| anyhow::anyhow!("missing name tag"))?;
+    let visibility_str =
+        extract_tag_value(event, "visibility").unwrap_or_else(|| "open".to_string());
+    let channel_type_str =
+        extract_tag_value(event, "channel_type").unwrap_or_else(|| "stream".to_string());
+
+    let visibility: sprout_db::channel::ChannelVisibility = visibility_str
+        .parse()
+        .unwrap_or(sprout_db::channel::ChannelVisibility::Open);
+    let channel_type: sprout_db::channel::ChannelType = channel_type_str
+        .parse()
+        .unwrap_or(sprout_db::channel::ChannelType::Stream);
+
+    let actor_bytes = event.pubkey.serialize().to_vec();
+    let channel = state
+        .db
+        .create_channel(&name, channel_type, visibility, None, &actor_bytes)
+        .await?;
+
+    let actor_hex = nostr::util::hex::encode(&actor_bytes);
+    emit_system_message(
+        state,
+        channel.id,
+        serde_json::json!({
+            "type": "channel_created", "actor": actor_hex
+        }),
+    )
+    .await?;
+
+    info!(channel_id = %channel.id, name = %name, "NIP-29 CREATE_GROUP processed");
+    Ok(())
+}
+
+async fn handle_delete_group(event: &Event, state: &Arc<AppState>) -> anyhow::Result<()> {
+    let channel_id =
+        extract_h_tag_channel(event).ok_or_else(|| anyhow::anyhow!("missing h tag"))?;
+    let actor_bytes = event.pubkey.serialize().to_vec();
+
+    // TODO: Add soft_delete_channel to Db for full implementation
+    let actor_hex = nostr::util::hex::encode(&actor_bytes);
+    emit_system_message(
+        state,
+        channel_id,
+        serde_json::json!({
+            "type": "channel_deleted", "actor": actor_hex
+        }),
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn handle_leave_request(event: &Event, state: &Arc<AppState>) -> anyhow::Result<()> {
+    // Kind 9022: functionally identical to self-remove via kind 9001
+    let channel_id =
+        extract_h_tag_channel(event).ok_or_else(|| anyhow::anyhow!("missing h tag"))?;
+    let actor_bytes = event.pubkey.serialize().to_vec();
+
+    // Guard: prevent last-owner orphaning on leave.
+    let members = state.db.get_members(channel_id).await?;
+    let owner_count = members.iter().filter(|m| m.role == "owner").count();
+    let actor_is_owner = members
+        .iter()
+        .any(|m| m.pubkey == actor_bytes && m.role == "owner");
+    if actor_is_owner && owner_count <= 1 {
+        return Err(anyhow::anyhow!(
+            "cannot remove the last owner — transfer ownership first"
+        ));
+    }
+
+    state
+        .db
+        .remove_member(channel_id, &actor_bytes, &actor_bytes)
+        .await?;
+
+    let actor_hex = nostr::util::hex::encode(&actor_bytes);
+    emit_system_message(
+        state,
+        channel_id,
+        serde_json::json!({
+            "type": "member_left",
+            "actor": actor_hex,
+        }),
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn handle_reaction(event: &Event, state: &Arc<AppState>) -> anyhow::Result<()> {
+    // Extract target event from last e tag (NIP-25)
+    let target_hex = event
+        .tags
+        .iter()
+        .rev()
+        .find_map(|tag| {
+            if tag.kind().to_string() == "e" {
+                tag.content().and_then(|v| {
+                    if v.len() == 64 && v.chars().all(|c| c.is_ascii_hexdigit()) {
+                        Some(v.to_string())
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| anyhow::anyhow!("missing e tag for reaction target"))?;
+
+    let target_id = hex::decode(&target_hex)?;
+
+    // Look up target event to get created_at for partitioned table lookup
+    let target_event = state
+        .db
+        .get_event_by_id(&target_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("reaction target event not found"))?;
+
+    // Reject reactions on archived channels.
+    if let Some(channel_id) = target_event.channel_id {
+        let channel = state
+            .db
+            .get_channel(channel_id)
+            .await
+            .map_err(|_| anyhow::anyhow!("channel not found"))?;
+        if channel.archived_at.is_some() {
+            return Err(anyhow::anyhow!("channel is archived"));
+        }
+    }
+
+    let event_created_at =
+        chrono::DateTime::from_timestamp(target_event.event.created_at.as_u64() as i64, 0)
+            .unwrap_or_else(chrono::Utc::now);
+
+    let pubkey_bytes = event.pubkey.serialize().to_vec();
+    let emoji = if event.content.is_empty() {
+        "+"
+    } else {
+        &event.content
+    };
+
+    state
+        .db
+        .add_reaction(&target_id, event_created_at, &pubkey_bytes, emoji)
+        .await?;
+
+    info!(target = %target_hex, emoji = %emoji, "NIP-25 reaction processed");
+    Ok(())
+}
+
+// ── Tag Helpers ──────────────────────────────────────────────────────────────
+
+/// Extract channel UUID from `h` tag (NIP-29 group ID).
+fn extract_h_tag_channel(event: &Event) -> Option<Uuid> {
+    for tag in event.tags.iter() {
+        if tag.kind().to_string() == "h" {
+            if let Some(val) = tag.content() {
+                if let Ok(id) = val.parse::<Uuid>() {
+                    return Some(id);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract target pubkey from first `p` tag.
+fn extract_p_tag(event: &Event) -> Option<Vec<u8>> {
+    for tag in event.tags.iter() {
+        if tag.kind().to_string() == "p" {
+            if let Some(val) = tag.content() {
+                if let Ok(bytes) = hex::decode(val) {
+                    if bytes.len() == 32 {
+                        return Some(bytes);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract value of a named tag.
+fn extract_tag_value(event: &Event, tag_name: &str) -> Option<String> {
+    for tag in event.tags.iter() {
+        if tag.kind().to_string() == tag_name {
+            return tag.content().map(|s| s.to_string());
+        }
+    }
+    None
+}

--- a/crates/sprout-relay/src/main.rs
+++ b/crates/sprout-relay/src/main.rs
@@ -90,6 +90,14 @@ async fn main() -> anyhow::Result<()> {
     let wf_cron = Arc::clone(&workflow_engine);
     tokio::spawn(async move { wf_cron.run().await });
 
+    let relay_keypair = if let Some(hex) = &config.relay_private_key {
+        nostr::Keys::parse(hex).expect("invalid SPROUT_RELAY_PRIVATE_KEY")
+    } else {
+        let keys = nostr::Keys::generate();
+        tracing::info!("Generated relay keypair: {}", keys.public_key().to_hex());
+        keys
+    };
+
     let state = Arc::new(AppState::new(
         config.clone(),
         db,
@@ -98,6 +106,7 @@ async fn main() -> anyhow::Result<()> {
         auth,
         search,
         workflow_engine,
+        relay_keypair,
     ));
     let router = build_router(Arc::clone(&state));
 

--- a/crates/sprout-relay/src/router.rs
+++ b/crates/sprout-relay/src/router.rs
@@ -6,7 +6,7 @@ use axum::{
     extract::{ConnectInfo, FromRequest, State, WebSocketUpgrade},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Json},
-    routing::{get, post},
+    routing::{delete, get, post, put},
     Router,
 };
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -48,6 +48,70 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/workflows/{id}/webhook", post(api::workflow_webhook))
         .route("/api/approvals/{token}/grant", post(api::grant_approval))
         .route("/api/approvals/{token}/deny", post(api::deny_approval))
+        // Membership routes
+        .route(
+            "/api/channels/{channel_id}/members",
+            get(api::list_members).post(api::add_members),
+        )
+        .route(
+            "/api/channels/{channel_id}/members/{pubkey}",
+            delete(api::remove_member),
+        )
+        .route("/api/channels/{channel_id}/join", post(api::join_channel))
+        .route("/api/channels/{channel_id}/leave", post(api::leave_channel))
+        // Channel detail + metadata routes
+        .route(
+            "/api/channels/{channel_id}",
+            get(api::get_channel_handler).put(api::update_channel_handler),
+        )
+        .route(
+            "/api/channels/{channel_id}/topic",
+            put(api::set_topic_handler),
+        )
+        .route(
+            "/api/channels/{channel_id}/purpose",
+            put(api::set_purpose_handler),
+        )
+        .route(
+            "/api/channels/{channel_id}/archive",
+            post(api::archive_channel_handler),
+        )
+        .route(
+            "/api/channels/{channel_id}/unarchive",
+            post(api::unarchive_channel_handler),
+        )
+        // Message + thread routes
+        .route(
+            "/api/channels/{channel_id}/messages",
+            get(api::list_messages).post(api::send_message),
+        )
+        .route(
+            "/api/channels/{channel_id}/threads/{event_id}",
+            get(api::get_thread),
+        )
+        // DM routes
+        .route(
+            "/api/dms",
+            get(api::list_dms_handler).post(api::open_dm_handler),
+        )
+        .route(
+            "/api/dms/{channel_id}/members",
+            post(api::add_dm_member_handler),
+        )
+        // Reaction routes
+        .route(
+            "/api/messages/{event_id}/reactions",
+            get(api::list_reactions_handler).post(api::add_reaction_handler),
+        )
+        .route(
+            "/api/messages/{event_id}/reactions/{emoji}",
+            delete(api::remove_reaction_handler),
+        )
+        // User profile routes
+        .route(
+            "/api/users/me/profile",
+            get(api::get_profile).put(api::update_profile),
+        )
         // Feed route
         .route("/api/feed", get(api::feed_handler))
         .layer(TraceLayer::new_for_http())

--- a/crates/sprout-relay/src/state.rs
+++ b/crates/sprout-relay/src/state.rs
@@ -82,10 +82,13 @@ pub struct AppState {
     pub handler_semaphore: Arc<Semaphore>,
     /// Workflow engine for background processing.
     pub workflow_engine: Arc<WorkflowEngine>,
+    /// Relay signing keypair — used to sign system messages (kind 40099).
+    pub relay_keypair: nostr::Keys,
 }
 
 impl AppState {
     /// Constructs `AppState` from its component services.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Config,
         db: Db,
@@ -94,6 +97,7 @@ impl AppState {
         auth: AuthService,
         search: SearchService,
         workflow_engine: Arc<WorkflowEngine>,
+        relay_keypair: nostr::Keys,
     ) -> Self {
         let max_connections = config.max_connections;
         let max_concurrent_handlers = config.max_concurrent_handlers;
@@ -109,6 +113,7 @@ impl AppState {
             conn_semaphore: Arc::new(Semaphore::new(max_connections)),
             handler_semaphore: Arc::new(Semaphore::new(max_concurrent_handlers)),
             workflow_engine,
+            relay_keypair,
         }
     }
 }

--- a/migrations/20260310000001_events_id_index.sql
+++ b/migrations/20260310000001_events_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_events_id ON events (id);

--- a/migrations/20260311000001_channel_metadata.sql
+++ b/migrations/20260311000001_channel_metadata.sql
@@ -1,0 +1,16 @@
+-- Add topic and purpose fields to channels table.
+--
+-- topic:       Current channel topic (short, visible in header).
+-- topic_set_by: Pubkey of the user who last set the topic.
+-- topic_set_at: When the topic was last set.
+-- purpose:     Channel purpose / description of intent.
+-- purpose_set_by: Pubkey of the user who last set the purpose.
+-- purpose_set_at: When the purpose was last set.
+
+ALTER TABLE channels
+  ADD COLUMN topic          TEXT          AFTER description,
+  ADD COLUMN topic_set_by   VARBINARY(32) AFTER topic,
+  ADD COLUMN topic_set_at   DATETIME(6)   AFTER topic_set_by,
+  ADD COLUMN purpose        TEXT          AFTER topic_set_at,
+  ADD COLUMN purpose_set_by VARBINARY(32) AFTER purpose,
+  ADD COLUMN purpose_set_at DATETIME(6)   AFTER purpose_set_by;

--- a/migrations/20260312000001_thread_metadata.sql
+++ b/migrations/20260312000001_thread_metadata.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS thread_metadata (
+    event_created_at        DATETIME(6)   NOT NULL,
+    event_id                VARBINARY(32) NOT NULL,
+    channel_id              BINARY(16)    NOT NULL,
+    parent_event_id         VARBINARY(32),
+    parent_event_created_at DATETIME(6),
+    root_event_id           VARBINARY(32),
+    root_event_created_at   DATETIME(6),
+    depth                   INT           NOT NULL DEFAULT 0,
+    reply_count             INT           NOT NULL DEFAULT 0,
+    descendant_count        INT           NOT NULL DEFAULT 0,
+    last_reply_at           DATETIME(6),
+    broadcast               TINYINT(1)    NOT NULL DEFAULT 0,
+    PRIMARY KEY (event_created_at, event_id),
+    CONSTRAINT fk_thread_channel FOREIGN KEY (channel_id) REFERENCES channels(id)
+);
+
+CREATE INDEX idx_thread_parent        ON thread_metadata (parent_event_id);
+CREATE INDEX idx_thread_root          ON thread_metadata (root_event_id);
+CREATE INDEX idx_thread_channel_depth ON thread_metadata (channel_id, depth, event_created_at);
+CREATE INDEX idx_thread_event_id      ON thread_metadata (event_id);

--- a/migrations/20260312000002_events_deleted_at.sql
+++ b/migrations/20260312000002_events_deleted_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE events ADD COLUMN deleted_at DATETIME(6) DEFAULT NULL;
+CREATE INDEX idx_events_deleted ON events (deleted_at);

--- a/migrations/20260313000001_dm_participant_hash.sql
+++ b/migrations/20260313000001_dm_participant_hash.sql
@@ -1,0 +1,10 @@
+-- Add participant_hash column to channels for DM deduplication.
+--
+-- DMs are identified by the SHA-256 of their sorted participant pubkeys.
+-- The unique index ensures that the same participant set maps to exactly one DM.
+
+ALTER TABLE channels
+  ADD COLUMN participant_hash VARBINARY(32) AFTER max_members;
+
+CREATE UNIQUE INDEX idx_channels_dm_hash
+  ON channels (participant_hash);

--- a/migrations/20260314000001_reactions.sql
+++ b/migrations/20260314000001_reactions.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS reactions (
+    event_created_at DATETIME(6)  NOT NULL,
+    event_id         VARBINARY(32) NOT NULL,
+    pubkey           VARBINARY(32) NOT NULL,
+    emoji            VARCHAR(64)   NOT NULL,
+    created_at       DATETIME(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    removed_at       DATETIME(6),
+    PRIMARY KEY (event_created_at, event_id, pubkey, emoji)
+);
+
+CREATE INDEX idx_reactions_event  ON reactions (event_id, event_created_at);
+CREATE INDEX idx_reactions_pubkey ON reactions (pubkey);


### PR DESCRIPTION
## Summary

Adds comprehensive channel features implementing the **REST + NIP-29 dual API** architecture. Both paths converge on shared DB functions as the single source of truth.

## What's New

### REST API (20 endpoints)
- **Channel metadata** — get, update name/description, set topic, set purpose, archive, unarchive
- **Membership** — add members, remove member, list members, join (open channels), leave
- **Messages** — send (with threading), list top-level, get full thread
- **DMs** — open/find DM, add member (creates new DM with expanded set), list DMs
- **Reactions** — add, remove, list per message
- **User profiles** — get, update

### NIP-29 Relay Protocol (9 event handlers)
- Kinds 9000–9022: PUT_USER, REMOVE_USER, EDIT_METADATA, DELETE_EVENT, CREATE_GROUP, DELETE_GROUP, LEAVE_REQUEST
- Kind 7: NIP-25 reactions
- Pre-storage validation for admin kinds (auth + archive checks + last-owner guard)
- Post-storage side-effect dispatch for state mutations

### MCP Tools (19 new + 2 updated)
Full agent interface for all channel features — send messages, manage members, set topics, add reactions, open DMs, etc.

### Infrastructure
- **Relay keypair** — dedicated secp256k1 key for signing system messages (kind 40099), configured via `SPROUT_RELAY_PRIVATE_KEY` env var or auto-generated on first run
- **6 migrations** — channel metadata columns, thread_metadata table, events deleted_at, DM participant_hash, reactions table, events id index

## Architecture

```
REST handler  →  auth  →  DB function  ←  side-effect dispatch  ←  store  ←  handle_event()  ←  NIP-29 event
```

- REST does NOT route through `handle_event()` (would reject relay-signed events)
- Admin kinds (9000–9022) validate before storage; regular kinds store then side-effect
- Tag convention: `channel` = Sprout UUID, `h` = NIP-29 group ID, `e` = event references only

### Key Design Decisions

| Feature | Approach |
|---------|----------|
| **Threads** | Materialized `thread_metadata` table with `reply_count` (direct) and `descendant_count` (all). Partition-pruned joins via stored `parent/root_event_created_at`. |
| **DMs** | Immutable participant sets via `participant_hash` (SHA-256 of sorted concatenated pubkeys). Adding a member creates a new DM. `open_dm` is idempotent. Max 9 participants. |
| **Reactions** | Atomic `INSERT ... ON DUPLICATE KEY UPDATE` — no TOCTOU race. `GROUP_CONCAT(HEX(pubkey))` avoids binary corruption. Session `group_concat_max_len` raised to 1MB. |
| **Archive enforcement** | All write endpoints (REST + NIP-29) check `archived_at`. Pre-storage rejection for kind 7 reactions. |
| **Last-owner guard** | Enforced at 3 layers: pre-storage validation, side-effect handler, and DB transaction. |

## Quality

7 rounds of crossfire review (Claude Opus + OpenAI Codex + Gemini Pro):

| Round | Opus | Codex | Issues Found |
|-------|------|-------|-------------|
| R1 | 6/10 | 2/10 | 12 |
| R2 | 8/10 | 6/10 | 5 |
| R3 | 8.5 | 6.5 | 6 |
| R4 | 7/10 | 7/10 | 9 (+ Gemini 7/10) |
| R5 | **9/10 ✅** | 7/10 | 2 |
| R6 | **9/10 ✅** | 8/10 | 1 |
| R7 | — | **10/10 ✅** | 0 |

32 issues found and fixed across all rounds. All CI checks pass (clippy -D warnings, fmt, unit tests, cargo-deny).

## Files Changed

**16 new files:**
- 3 DB modules: `thread.rs`, `dm.rs`, `reaction.rs`
- 6 REST handlers: `channels_metadata.rs`, `members.rs`, `messages.rs`, `dms.rs`, `reactions.rs`, `users.rs`
- 1 NIP-29 handler: `side_effects.rs`
- 6 migrations

**12 modified files:**
- `kind.rs` (+KIND_SYSTEM_MESSAGE), `channel.rs` (+231 lines), `lib.rs` (+202 lines), `user.rs` (+75 lines)
- `server.rs` (+754 lines — 19 MCP tools), `router.rs` (+66 lines — 16 routes)
- `event.rs` (extract_channel_id fix, admin pre-validation, reaction archive check)
- `config.rs`, `state.rs`, `main.rs` (relay keypair wiring)

## Known Gaps (follow-up PRs)

- `soft_delete_event` / `soft_delete_channel` DB methods (kind 9005/9008 handlers emit system messages but don't delete yet)
- Phase 6 polish: enrich list_channels with member_count/topic/purpose, embed reaction counts and thread summaries in channel history, NIP-11 relay info update
- Cursor-based pagination in some list endpoints (returns `next_cursor: null`)
- Desktop E2E tests for new features
