### PR TITLE
feat(desktop): use SPROUT_PRIVATE_KEY for stable dev identity

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -686,8 +686,30 @@ async fn get_event(event_id: String, state: tauri::State<'_, AppState>) -> Resul
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // GUI app: warn on bad key but don't crash — fall back to ephemeral.
+    // CLI crates (sprout-mcp, sprout-test-client) use fatal errors instead.
+    let (keys, source) = match std::env::var("SPROUT_PRIVATE_KEY") {
+        Ok(nsec) => match Keys::parse(nsec.trim()) {
+            Ok(k) => (k, "configured"),
+            Err(e) => {
+                eprintln!("sprout-desktop: invalid SPROUT_PRIVATE_KEY: {e}");
+                (Keys::generate(), "ephemeral")
+            }
+        },
+        Err(std::env::VarError::NotUnicode(_)) => {
+            eprintln!("sprout-desktop: SPROUT_PRIVATE_KEY contains invalid UTF-8");
+            (Keys::generate(), "ephemeral")
+        }
+        Err(std::env::VarError::NotPresent) => (Keys::generate(), "ephemeral"),
+    };
+
+    eprintln!(
+        "sprout-desktop: {source} identity pubkey {}",
+        keys.public_key().to_hex()
+    );
+
     let app_state = AppState {
-        keys: Mutex::new(Keys::generate()),
+        keys: Mutex::new(keys),
         http_client: reqwest::Client::new(),
     };
 


### PR DESCRIPTION
## Problem

The desktop app generates a fresh random keypair on every launch via `Keys::generate()`. This means:
- Developers become a different person on every restart
- Display names set in Settings are orphaned when the keypair rotates
- Relay-side profile data becomes unreachable

Every other Sprout component already solves this with `SPROUT_PRIVATE_KEY`:
- `sprout-test-client` — `crates/sprout-test-client/src/main.rs`
- `sprout-mcp` — `crates/sprout-mcp/src/main.rs`
- `sprout-acp` — `crates/sprout-acp/src/config.rs`

The desktop was the only component missing this pattern.

## Solution

Check `SPROUT_PRIVATE_KEY` at startup. If set and valid, use it for a stable identity across restarts. Otherwise fall back to the current random behavior — zero breakage for anyone not using the env var.

### Behavior

| Condition | Result |
|-----------|--------|
| `SPROUT_PRIVATE_KEY` set and valid | Stable configured identity |
| `SPROUT_PRIVATE_KEY` set but invalid | Warning to stderr + ephemeral fallback |
| `SPROUT_PRIVATE_KEY` contains invalid UTF-8 | Warning to stderr + ephemeral fallback |
| `SPROUT_PRIVATE_KEY` not set | Ephemeral random keypair (current behavior) |

### Design Decision: Warn + Fallback (not fatal)

Unlike the CLI crates which crash on invalid keys (`expect` / `?`), the desktop warns to stderr and falls back to ephemeral. This is intentional — GUI apps should not crash on a typo in an env var.

All paths log the active pubkey and its source (`configured` vs `ephemeral`) at startup for debuggability.

## Developer Workflow

```bash
# Generate a key (if you don't have one)
cargo run -p sprout-admin -- mint-token --name "alice-dev" --scopes "messages:read,messages:write"

# Set it in your shell profile
export SPROUT_PRIVATE_KEY=nsec1...

# Launch — identity is now stable across restarts
cargo tauri dev

# Display name set in Settings now persists!
```

## Files Changed

| File | Change |
|------|--------|
| `desktop/src-tauri/src/lib.rs` | Replace `Keys::generate()` with env var check (~22 lines) |

No new dependencies. No new imports. No frontend changes. No relay changes.

## Quality Gates

- [x] `cargo check` (desktop crate) — clean
- [x] `cargo clippy -- -D warnings` (desktop + workspace) — clean
- [x] `cargo test --workspace` — all tests pass, 0 failures
- [x] Crossfire review: Codex CLI 9.2/10 ✅, Claude Opus 9.5/10 ✅