### PR TITLE
feat(sprout-acp): auto-presence and typing indicators

### DIFF
--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -596,6 +596,8 @@ mod tests {
             no_mention_filter: false,
             config_path: PathBuf::from("./sprout-acp.toml"),
             context_message_limit: 12,
+            presence_enabled: true,
+            typing_enabled: true,
         }
     }
 

--- a/crates/sprout-acp/src/main.rs
+++ b/crates/sprout-acp/src/main.rs
@@ -201,6 +201,7 @@ async fn main() -> Result<()> {
         None
     };
     let mut typing_channels: HashSet<Uuid> = HashSet::new();
+    let mut presence_task: Option<tokio::task::JoinHandle<()>> = None;
 
     // ── Step 7: Shutdown signal ───────────────────────────────────────────────
     let (shutdown_tx, mut shutdown_rx) = watch::channel(());
@@ -361,6 +362,7 @@ async fn main() -> Result<()> {
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
+                                    typing_channels.remove(&ch);
                                     if drained > 0 || invalidated > 0 {
                                         tracing::info!(
                                             channel_id = %ch,
@@ -429,12 +431,16 @@ async fn main() -> Result<()> {
                     }
                 } => {
                     let _ = result_rx;
+                    // Abort previous heartbeat if still in flight (prevents race on shutdown).
+                    if let Some(h) = presence_task.take() {
+                        h.abort();
+                    }
                     let rc = rest_client_for_presence.clone();
-                    tokio::spawn(async move {
+                    presence_task = Some(tokio::spawn(async move {
                         if let Err(e) = rc.put_json("/api/presence", &serde_json::json!({"status": "online"})).await {
                             tracing::warn!("presence heartbeat failed: {e}");
                         }
-                    });
+                    }));
                     None
                 }
                 _ = async {
@@ -485,6 +491,7 @@ async fn main() -> Result<()> {
                     &config,
                     &mut heartbeat_in_flight,
                     &removed_channels,
+                    &mut typing_channels,
                 )
                 .await
                     == LoopAction::Exit
@@ -502,6 +509,7 @@ async fn main() -> Result<()> {
                     join_error,
                     &mut heartbeat_in_flight,
                     &removed_channels,
+                    &mut typing_channels,
                 )
                 .await;
                 if pool.live_count() == 0 {
@@ -531,15 +539,24 @@ async fn main() -> Result<()> {
     }
     drop(pool);
 
+    // Cancel any in-flight presence heartbeat before sending offline.
+    if let Some(h) = presence_task.take() {
+        h.abort();
+    }
+
     // Best-effort: set presence to offline before exiting.
     if config.presence_enabled {
-        let _ = tokio::time::timeout(
+        match tokio::time::timeout(
             Duration::from_secs(2),
             rest_client_for_presence
                 .put_json("/api/presence", &serde_json::json!({"status": "offline"})),
         )
-        .await;
-        tracing::info!("presence set to offline");
+        .await
+        {
+            Ok(Ok(_)) => tracing::info!("presence set to offline"),
+            Ok(Err(e)) => tracing::warn!("failed to set offline presence: {e}"),
+            Err(_) => tracing::warn!("offline presence timed out"),
+        }
     }
 
     tracing::info!("sprout-acp stopped");
@@ -708,6 +725,7 @@ async fn recover_panicked_agent(
     join_error: tokio::task::JoinError,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
+    typing_channels: &mut HashSet<Uuid>,
 ) {
     let task_id = join_error.id();
     let Some(meta) = pool.task_map_mut().remove(&task_id) else {
@@ -718,6 +736,7 @@ async fn recover_panicked_agent(
 
     if let Some(ch) = meta.channel_id {
         queue.mark_complete(ch);
+        typing_channels.remove(&ch);
         tracing::warn!("cleared wedged in-flight channel {ch} from panicked agent {i}");
     } else {
         *heartbeat_in_flight = false;
@@ -761,6 +780,7 @@ async fn drain_ready_join_results(
     config: &Config,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
+    typing_channels: &mut HashSet<Uuid>,
 ) -> LoopAction {
     while let Some(Some(join_result)) = pool.join_set.join_next().now_or_never() {
         if let Err(join_error) = join_result {
@@ -772,6 +792,7 @@ async fn drain_ready_join_results(
                 join_error,
                 heartbeat_in_flight,
                 removed_channels,
+                typing_channels,
             )
             .await;
             if pool.live_count() == 0 {

--- a/crates/sprout-acp/src/relay.rs
+++ b/crates/sprout-acp/src/relay.rs
@@ -1,12 +1,9 @@
 //! Harness-side Sprout relay client.
 //!
 //! Connects to the Sprout relay via NIP-01 WebSocket, authenticates via NIP-42,
-//! discovers channels via REST API, and streams matching events back to the
-//! harness main loop.
-//!
-//! This is a simplified receive-only client adapted from `sprout-mcp`'s
-//! `relay_client.rs`. It does not publish events or perform queries — it only
-//! subscribes and receives.
+//! discovers channels via REST API, and streams events back to the harness main
+//! loop. Also publishes ephemeral events (typing indicators) via the same
+//! WebSocket connection.
 //!
 //! ## Architecture
 //!
@@ -15,6 +12,7 @@
 //! - Forwards `SproutEvent`s through an `mpsc` channel
 //! - Handles reconnection with `since` filters to avoid event loss
 //! - Responds to mid-session AUTH challenges
+//! - Publishes ephemeral events (typing indicators) via `PublishEvent` commands
 //!
 //! `HarnessRelay` communicates with the background task via a `RelayCommand`
 //! channel. `next_event()` reads from the event receiver.
@@ -51,7 +49,9 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 use futures_util::{SinkExt, StreamExt};
 use nostr::{Event, EventBuilder, Keys, Kind, Tag, Url as NostrUrl};
 use serde_json::{json, Value};
-use sprout_core::kind::{KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION};
+use sprout_core::kind::{
+    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_TYPING_INDICATOR,
+};
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
@@ -107,6 +107,8 @@ impl RestClient {
     }
 
     /// PUT a JSON body to an endpoint, returning the parsed response.
+    ///
+    /// Returns `Value::Null` for empty response bodies (e.g. 204 No Content).
     pub async fn put_json(&self, path: &str, body: &Value) -> Result<Value, RelayError> {
         let url = format!("{}{}", self.base_url, path);
         let builder = self.http.put(&url).json(body);
@@ -125,9 +127,14 @@ impl RestClient {
             )));
         }
 
-        resp.json()
+        let text = resp
+            .text()
             .await
-            .map_err(|e| RelayError::Http(e.to_string()))
+            .map_err(|e| RelayError::Http(e.to_string()))?;
+        if text.is_empty() {
+            return Ok(Value::Null);
+        }
+        serde_json::from_str(&text).map_err(|e| RelayError::Http(e.to_string()))
     }
 }
 
@@ -437,12 +444,12 @@ impl HarnessRelay {
             .map_err(|_| RelayError::ConnectionClosed)
     }
 
-    /// Build a kind:20002 typing indicator event for a channel.
+    /// Build a typing indicator event (kind:20002) for a channel.
     pub fn build_typing_event(&self, channel_id: Uuid) -> Result<Event, RelayError> {
         let h_tag = Tag::parse(&["h", &channel_id.to_string()])
             .map_err(|e| RelayError::AuthFailed(e.to_string()))?;
-        let event =
-            EventBuilder::new(Kind::Custom(20002), "", [h_tag]).sign_with_keys(&self.keys)?;
+        let event = EventBuilder::new(Kind::Custom(KIND_TYPING_INDICATOR as u16), "", [h_tag])
+            .sign_with_keys(&self.keys)?;
         Ok(event)
     }
 


### PR DESCRIPTION
## Summary

Harness-level presence and typing indicator support. The harness now automatically manages the agent's online status and shows typing indicators when processing prompts — no agent-side changes needed.

```
Startup ──→ PUT /api/presence {"status":"online"}
             │
Every 60s ──→ PUT /api/presence {"status":"online"}  (refreshes 90s TTL)
             │
Dispatch ───→ kind:20002 typing event via WebSocket
             │    ↑ refreshed every 3s while processing
             │
Result ─────→ stop typing for that channel
             │
Shutdown ───→ PUT /api/presence {"status":"offline"}
```

## Changes

**3 files, ~210 lines added**

### `relay.rs`
- `RestClient::put_json()` — PUT with JSON body, handles empty response bodies (204)
- `RelayCommand::PublishEvent` — new command variant for WebSocket event publishing
- `HarnessRelay::publish_event()` / `build_typing_event()` — public API for typing events
- Background task handles `PublishEvent` in all three command paths (connected, reconnect drain, wait-for-reconnect)
- Module doc updated to reflect bidirectional capability

### `config.rs`
- `--no-presence` / `SPROUT_ACP_NO_PRESENCE` — disable auto-presence (default: enabled)
- `--no-typing` / `SPROUT_ACP_NO_TYPING` — disable typing indicators (default: enabled)

### `main.rs`
- Presence lifecycle: online at startup → 60s heartbeat → offline on shutdown
- Typing lifecycle: publish on dispatch → 3s refresh → stop on result/panic/removal
- `dispatch_pending()` returns dispatched channel IDs for typing state tracking
- Presence heartbeat tracked via `JoinHandle` (aborted before shutdown offline PUT to prevent race)

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Presence via REST | `RestClient` already has auth; simpler than WebSocket for request/response |
| Typing via WebSocket | No REST endpoint exists; ephemeral events are the correct protocol path |
| `--no-*` flags | Matches existing `--no-ignore-self` pattern; features on by default |
| `PublishEvent` dropped during disconnect | Ephemeral events are meaningless while disconnected |
| Tracked presence `JoinHandle` | Prevents race where heartbeat completes after shutdown offline PUT |

## Testing

- **Unit tests**: 151 pass, 0 fail (includes new `test_config()` fields)
- **Live testing**: startup presence ✅, 60s heartbeat (Redis TTL verified) ✅, SIGTERM → offline ✅
- **Clippy**: clean
- **Review**: 3-model crossfire (opus, codex, gemini) — all 9/10 APPROVE after fixes