### PR TITLE
Fix Codex ACP startup and bot-to-bot mentions

### DIFF
--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -204,12 +204,17 @@ pub struct Config {
 
 fn normalize_agent_command_identity(command: &str) -> String {
     let normalized = command.trim().replace('\\', "/");
-    let basename = normalized.rsplit('/').next().unwrap_or(normalized.as_str());
-    basename
-        .chars()
+    let trimmed = normalized.trim_end_matches('/');
+    let basename = trimmed
+        .rsplit('/')
+        .next()
+        .expect("rsplit always yields at least one element");
+    let lower = basename.to_ascii_lowercase();
+    let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
+    stem.chars()
         .map(|character| match character {
             ' ' | '_' => '-',
-            _ => character.to_ascii_lowercase(),
+            _ => character,
         })
         .collect()
 }
@@ -242,7 +247,8 @@ fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
     // Older callers relied on the Goose-specific default even for runtimes like
     // Codex and Claude. Treat that legacy fallback as "no args" for zero-arg
     // providers so desktop- and env-based launches behave the same way.
-    if normalized.len() == 1 && normalized[0] == "acp" && default_args.is_empty() {
+    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") && default_args.is_empty()
+    {
         return default_args;
     }
 
@@ -743,6 +749,44 @@ mod tests {
         assert_eq!(
             normalize_agent_args("custom-agent", vec!["".into(), "serve".into()]),
             vec!["serve"]
+        );
+    }
+
+    #[test]
+    fn normalize_agent_command_identity_variants() {
+        assert_eq!(normalize_agent_command_identity("goose"), "goose");
+        assert_eq!(
+            normalize_agent_command_identity("C:\\Program Files\\Goose\\goose.exe"),
+            "goose"
+        );
+        assert_eq!(
+            normalize_agent_command_identity("/usr/local/bin/codex-acp"),
+            "codex-acp"
+        );
+        assert_eq!(normalize_agent_command_identity("/usr/local/bin/"), "bin");
+        assert_eq!(
+            normalize_agent_command_identity("Claude_Code"),
+            "claude-code"
+        );
+        assert_eq!(
+            normalize_agent_command_identity("Claude Code"),
+            "claude-code"
+        );
+        assert_eq!(normalize_agent_command_identity("Goose.EXE"), "goose");
+        // Non-ASCII must not panic.
+        assert_eq!(normalize_agent_command_identity("my-agënt"), "my-agënt");
+        // Edge cases: empty, whitespace-only, bare separators.
+        assert_eq!(normalize_agent_command_identity(""), "");
+        assert_eq!(normalize_agent_command_identity("   "), "");
+        assert_eq!(normalize_agent_command_identity("/"), "");
+        assert_eq!(normalize_agent_command_identity("///"), "");
+    }
+
+    #[test]
+    fn strips_legacy_acp_arg_case_insensitively() {
+        assert_eq!(
+            normalize_agent_args("codex-acp", vec!["ACP".into()]),
+            Vec::<String>::new()
         );
     }
 

--- a/crates/sprout-mcp/src/server.rs
+++ b/crates/sprout-mcp/src/server.rs
@@ -65,14 +65,15 @@ fn build_top_level_message_tags(
     sender_pubkey: &str,
     mention_pubkeys: Option<&[String]>,
 ) -> Result<Vec<Tag>, String> {
+    let sender_pubkey = sender_pubkey.to_ascii_lowercase();
     let mut tags = vec![
         Tag::parse(&["h", channel_id]).map_err(|e| format!("failed to build channel tag: {e}"))?,
-        Tag::parse(&["p", sender_pubkey])
+        Tag::parse(&["p", &sender_pubkey])
             .map_err(|e| format!("failed to build sender tag: {e}"))?,
     ];
 
     for mention in mention_pubkeys
-        .map(|mentions| normalize_mention_pubkeys(mentions, sender_pubkey))
+        .map(|mentions| normalize_mention_pubkeys(mentions, &sender_pubkey))
         .unwrap_or_default()
     {
         tags.push(
@@ -1883,6 +1884,52 @@ mod tests {
     }
 
     #[test]
+    fn normalize_mention_pubkeys_skips_mixed_case_sender() {
+        let sender = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let mentions = vec![
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_string(),
+        ];
+
+        assert_eq!(
+            normalize_mention_pubkeys(&mentions, sender),
+            vec!["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),]
+        );
+    }
+
+    #[test]
+    fn normalize_mention_pubkeys_empty_input() {
+        let sender = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assert_eq!(normalize_mention_pubkeys(&[], sender), Vec::<String>::new());
+    }
+
+    #[test]
+    fn build_top_level_message_tags_lowercases_sender() {
+        let sender = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let tags =
+            build_top_level_message_tags("550e8400-e29b-41d4-a716-446655440000", sender, None)
+                .expect("tags should build");
+        let tag_strings = tags
+            .iter()
+            .map(|tag| tag.clone().to_vec())
+            .collect::<Vec<Vec<String>>>();
+
+        assert_eq!(
+            tag_strings,
+            vec![
+                vec![
+                    "h".to_string(),
+                    "550e8400-e29b-41d4-a716-446655440000".to_string()
+                ],
+                vec![
+                    "p".to_string(),
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()
+                ],
+            ]
+        );
+    }
+
+    #[test]
     fn build_top_level_message_tags_includes_mention_p_tags() {
         let sender = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let mention =
@@ -1910,6 +1957,52 @@ mod tests {
                     "p".to_string(),
                     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string()
                 ],
+            ]
+        );
+    }
+
+    #[test]
+    fn build_top_level_message_tags_no_mentions_when_none() {
+        let sender = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let tags =
+            build_top_level_message_tags("550e8400-e29b-41d4-a716-446655440000", sender, None)
+                .expect("tags should build");
+        let tag_strings = tags
+            .iter()
+            .map(|tag| tag.clone().to_vec())
+            .collect::<Vec<Vec<String>>>();
+
+        assert_eq!(
+            tag_strings,
+            vec![
+                vec![
+                    "h".to_string(),
+                    "550e8400-e29b-41d4-a716-446655440000".to_string()
+                ],
+                vec!["p".to_string(), sender.to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn build_top_level_message_tags_no_mentions_when_empty_slice() {
+        let sender = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let tags =
+            build_top_level_message_tags("550e8400-e29b-41d4-a716-446655440000", sender, Some(&[]))
+                .expect("tags should build");
+        let tag_strings = tags
+            .iter()
+            .map(|tag| tag.clone().to_vec())
+            .collect::<Vec<Vec<String>>>();
+
+        assert_eq!(
+            tag_strings,
+            vec![
+                vec![
+                    "h".to_string(),
+                    "550e8400-e29b-41d4-a716-446655440000".to_string()
+                ],
+                vec!["p".to_string(), sender.to_string()],
             ]
         );
     }


### PR DESCRIPTION
## Summary
- normalize sprout-acp agent args by provider so Codex and Claude no longer inherit Goose's `acp` arg or an empty-string arg
- preserve Goose's `acp` default while treating legacy `acp` for zero-arg providers as no args
- fix MCP top-level `send_message` so it emits mention `p` tags on the WebSocket path for bot-to-bot mentions
- add focused unit coverage for both fixes

## Testing
- cargo test -p sprout-acp normalizes_codex_and_claude_args_to_empty
- cargo test -p sprout-mcp build_top_level_message_tags_includes_mention_p_tags
- cargo test -p sprout-mcp normalize_mention_pubkeys_dedupes_and_skips_sender
- pre-commit: desktop check, rust fmt
- pre-push: desktop check, desktop build, desktop tauri check, cargo clippy --workspace --all-targets -- -D warnings, ./scripts/run-tests.sh unit