### PR TITLE
Polish sidebar toggle alignment and avatar light-mode backgrounds

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -484,7 +484,7 @@ export function AppShell() {
         </div>
       ) : (
         <React.Fragment>
-          <SidebarTrigger className="fixed left-[80px] top-[9px] z-50 h-6 w-6 text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" />
+          <SidebarTrigger className="fixed left-[80px] top-[8px] z-50 h-6 w-6 text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground" />
           <AppSidebar
             channels={memberChannels}
             currentPubkey={identityQuery.data?.pubkey}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -140,7 +140,7 @@ export function MessageRow({
               {message.avatarUrl && !hasAvatarError ? (
                 <img
                   alt={`${message.author} avatar`}
-                  className="h-8 w-8 rounded-lg object-cover shadow-sm"
+                  className="h-8 w-8 rounded-lg bg-secondary object-cover shadow-sm"
                   data-testid="message-avatar-image"
                   onError={() => {
                     setHasAvatarError(true);
@@ -166,7 +166,7 @@ export function MessageRow({
         ) : message.avatarUrl && !hasAvatarError ? (
           <img
             alt={`${message.author} avatar`}
-            className="h-8 w-8 shrink-0 rounded-lg object-cover shadow-sm"
+            className="h-8 w-8 shrink-0 rounded-lg bg-secondary object-cover shadow-sm"
             data-testid="message-avatar-image"
             onError={() => {
               setHasAvatarError(true);

--- a/desktop/src/features/profile/ui/ProfileAvatar.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatar.tsx
@@ -30,7 +30,7 @@ export function ProfileAvatar({
     .slice(0, 2)
     .toUpperCase();
   const baseClassName = cn(
-    "flex shrink-0 items-center justify-center overflow-hidden bg-primary/10 text-primary shadow-sm",
+    "flex shrink-0 items-center justify-center overflow-hidden bg-primary/20 text-primary shadow-sm",
     className,
   );
 


### PR DESCRIPTION
## Summary
- Nudge sidebar toggle button up 1px (`top-[9px]` → `top-[8px]`) to align with macOS window controls
- Add `bg-secondary` to message avatar `<img>` elements so transparent-background avatars are visible in light mode
- Bump `ProfileAvatar` fallback background from `bg-primary/10` to `bg-primary/20` for better contrast

## Test plan
- [x] Verify sidebar toggle aligns with macOS traffic light buttons
- [x] Check transparent-background avatars (e.g. goose) are visible in light mode chat
- [x] Confirm dark mode avatars are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)