### PR TITLE
Run Vite directly from Tauri dev

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -4,7 +4,11 @@
   "version": "0.1.0",
   "identifier": "com.wesb.sprout",
   "build": {
-    "beforeDevCommand": "pnpm dev",
+    "beforeDevCommand": {
+      "script": "exec ./node_modules/.bin/vite",
+      "cwd": "..",
+      "wait": false
+    },
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "pnpm build",
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary
- run the desktop dev server directly from Tauri instead of going through `pnpm dev`
- keep the dev hook in the desktop workspace by setting `cwd` to `..`
- avoid leaving an extra `pnpm` wrapper process behind when the app quits

## Testing
- `cargo fmt --all -- --check`
- `cd desktop && pnpm check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `./scripts/run-tests.sh unit`
- `cd desktop && pnpm build`
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`

## Repro
- start `just dev`
- quit the desktop app
- rerun `just dev` and verify port `1420` is free instead of failing with "Port 1420 is already in use"