### PR TITLE
fix(desktop): top-align avatars with display name in chat messages

### DIFF
--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -136,7 +136,7 @@ export const MessageRow = React.memo(
 
         <article
           className={cn(
-            "group/message flex gap-2.5 rounded-2xl px-2 py-1 transition-colors",
+            "group/message flex items-start gap-2.5 rounded-2xl px-2 py-1 transition-colors",
             highlighted ? "bg-primary/10 ring-1 ring-primary/30" : "",
             activeReplyTargetId === message.id
               ? "bg-muted/60 ring-1 ring-border"


### PR DESCRIPTION
## Summary

Fixes avatar alignment in chat messages so that avatars are top-aligned with the display name instead of vertically centered. This was noticeable on longer messages where the avatar would float in the middle of the message content.

## Changes

- Added `items-start` to the `<article>` flex container in `MessageRow.tsx`

## Before/After

**Before:** Avatar vertically centered with message content (looks off on long messages)
**After:** Avatar pinned to the top, aligned with the display name

## Testing

- All pre-push checks pass (rust-fmt, clippy, rust-tests, desktop-tauri-check, desktop-check, desktop-build)
- Refactor check: clean — no conflicting classes, all avatar rendering paths covered
- Code review: approved — correct for all edge cases (short/long messages, nested threads, diff messages, reactions, fallback avatars)