### PR TITLE
feat: persist identity key to app data dir

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -235,6 +235,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic-write-file"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
+dependencies = [
+ "nix",
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2426,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4086,6 +4108,7 @@ dependencies = [
 name = "sprout"
 version = "0.1.0"
 dependencies = [
+ "atomic-write-file",
  "base64 0.22.1",
  "chrono",
  "hex",
@@ -4104,6 +4127,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-websocket",
  "tauri-plugin-window-state",
+ "tempfile",
  "tokio",
  "url",
  "uuid",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ libc = "0.2"
 windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }
 
 [dependencies]
+atomic-write-file = "0.3"
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-window-state = "2"
@@ -43,3 +44,6 @@ sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 tauri-plugin-notification = "2.3.3"
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -1,6 +1,7 @@
-use std::{collections::HashMap, sync::Mutex};
+use std::{collections::HashMap, io::Write, sync::Mutex};
 
-use nostr::Keys;
+use nostr::{Keys, ToBech32};
+use tauri::{AppHandle, Manager};
 
 use crate::managed_agents::ManagedAgentProcess;
 
@@ -14,7 +15,8 @@ pub struct AppState {
 }
 
 pub fn build_app_state() -> AppState {
-    // GUI app: warn on bad key but don't crash, and fall back to ephemeral.
+    // Env var takes precedence (dev/CI). If absent, resolve_persisted_identity()
+    // in setup() will replace the ephemeral placeholder with a persisted key.
     let (keys, source) = match std::env::var("SPROUT_PRIVATE_KEY") {
         Ok(nsec) => match Keys::parse(nsec.trim()) {
             Ok(keys) => (keys, "configured"),
@@ -30,10 +32,12 @@ pub fn build_app_state() -> AppState {
         Err(std::env::VarError::NotPresent) => (Keys::generate(), "ephemeral"),
     };
 
-    eprintln!(
-        "sprout-desktop: {source} identity pubkey {}",
-        keys.public_key().to_hex()
-    );
+    if source == "configured" {
+        eprintln!(
+            "sprout-desktop: configured identity pubkey {}",
+            keys.public_key().to_hex()
+        );
+    }
 
     let api_token = match std::env::var("SPROUT_API_TOKEN") {
         Ok(token) if !token.trim().is_empty() => Some(token),
@@ -51,5 +55,202 @@ pub fn build_app_state() -> AppState {
         session_token: Mutex::new(None),
         managed_agents_store_lock: Mutex::new(()),
         managed_agent_processes: Mutex::new(HashMap::new()),
+    }
+}
+
+/// Resolve the user's identity key from the app data directory.
+///
+/// Priority: `SPROUT_PRIVATE_KEY` env var (already handled in `build_app_state`)
+/// → `{app_data_dir}/identity.key` file → generate + save.
+///
+/// Writes use `atomic-write-file` which handles temp file creation, fsync,
+/// atomic rename, and directory sync — no partial or corrupt files on disk.
+pub fn resolve_persisted_identity(app: &AppHandle, state: &AppState) -> Result<(), String> {
+    // Only skip file-based resolution if the env var was present AND parsed
+    // successfully. A malformed env var should fall through to the persisted
+    // key rather than leaving the app on an ephemeral identity.
+    if let Ok(nsec) = std::env::var("SPROUT_PRIVATE_KEY") {
+        if Keys::parse(nsec.trim()).is_ok() {
+            return Ok(());
+        }
+    }
+
+    let data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app data dir: {e}"))?;
+    std::fs::create_dir_all(&data_dir)
+        .map_err(|e| format!("create app data dir: {e}"))?;
+    let key_path = data_dir.join("identity.key");
+
+    // Try to load an existing key.
+    if key_path.exists() {
+        match load_key_file(&key_path) {
+            Ok(keys) => {
+                eprintln!(
+                    "sprout-desktop: persisted identity pubkey {}",
+                    keys.public_key().to_hex()
+                );
+                *state.keys.lock().map_err(|e| e.to_string())? = keys;
+                return Ok(());
+            }
+            Err(error) => {
+                // Corrupted — quarantine with a timestamp so prior backups
+                // are never overwritten.
+                let ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                let bad_name = format!("identity.key.bad.{ts}");
+                eprintln!("sprout-desktop: corrupt identity.key ({error}), quarantining to {bad_name}");
+                let bad_path = data_dir.join(bad_name);
+                if std::fs::rename(&key_path, &bad_path).is_err() {
+                    let _ = std::fs::remove_file(&key_path);
+                }
+            }
+        }
+    }
+
+    // First run (or recovery from corruption): generate and save.
+    let keys = Keys::generate();
+    save_key_file(&key_path, &keys)?;
+
+    eprintln!(
+        "sprout-desktop: generated and saved identity pubkey {}",
+        keys.public_key().to_hex()
+    );
+    *state.keys.lock().map_err(|e| e.to_string())? = keys;
+    Ok(())
+}
+
+fn load_key_file(path: &std::path::Path) -> Result<Keys, String> {
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("read identity.key: {e}"))?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Err("empty identity.key".to_string());
+    }
+    Keys::parse(trimmed).map_err(|e| format!("parse identity.key: {e}"))
+}
+
+/// Atomically write the key to disk. Uses `atomic-write-file` which:
+/// 1. Writes to a temp file in the same directory
+/// 2. Calls fsync on the file
+/// 3. Renames temp → target (atomic on POSIX, best-effort on Windows)
+/// 4. Calls fsync on the parent directory
+///
+/// On Unix, the file is created with mode 0600 (owner read/write only).
+/// On Windows, default ACLs apply — the app data directory is already
+/// per-user, so the key is not world-readable in practice.
+fn save_key_file(path: &std::path::Path, keys: &Keys) -> Result<(), String> {
+    use atomic_write_file::AtomicWriteFile;
+
+    let nsec = keys
+        .secret_key()
+        .to_bech32()
+        .map_err(|e| format!("encode nsec: {e}"))?;
+
+    let mut file = AtomicWriteFile::open(path)
+        .map_err(|e| format!("open identity.key for atomic write: {e}"))?;
+
+    // Set owner-only permissions before writing the secret.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("set identity.key permissions: {e}"))?;
+    }
+
+    file.write_all(nsec.as_bytes())
+        .map_err(|e| format!("write identity.key: {e}"))?;
+    file.commit()
+        .map_err(|e| format!("commit identity.key: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_key_eq(a: &Keys, b: &Keys) {
+        assert_eq!(a.public_key().to_hex(), b.public_key().to_hex());
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("identity.key");
+        let keys = Keys::generate();
+
+        save_key_file(&path, &keys).unwrap();
+        let loaded = load_key_file(&path).unwrap();
+        assert_key_eq(&keys, &loaded);
+    }
+
+    #[test]
+    fn load_rejects_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("identity.key");
+        std::fs::write(&path, "").unwrap();
+
+        assert!(load_key_file(&path).is_err());
+    }
+
+    #[test]
+    fn load_rejects_corrupt_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("identity.key");
+        std::fs::write(&path, "not-a-valid-nsec").unwrap();
+
+        assert!(load_key_file(&path).is_err());
+    }
+
+    #[test]
+    fn load_missing_file_is_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.key");
+
+        assert!(load_key_file(&path).is_err());
+    }
+
+    #[test]
+    fn save_creates_file_with_valid_nsec() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("identity.key");
+        let keys = Keys::generate();
+
+        save_key_file(&path, &keys).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.starts_with("nsec1"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_creates_file_with_restricted_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("identity.key");
+        let keys = Keys::generate();
+
+        save_key_file(&path, &keys).unwrap();
+
+        let perms = std::fs::metadata(&path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn save_overwrites_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("identity.key");
+
+        let keys1 = Keys::generate();
+        save_key_file(&path, &keys1).unwrap();
+
+        let keys2 = Keys::generate();
+        save_key_file(&path, &keys2).unwrap();
+
+        let loaded = load_key_file(&path).unwrap();
+        assert_key_eq(&keys2, &loaded);
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod models;
 mod relay;
 mod util;
 
-use app_state::{build_app_state, AppState};
+use app_state::{build_app_state, resolve_persisted_identity, AppState};
 use commands::*;
 use managed_agents::{
     find_managed_agent_mut, load_managed_agents, save_managed_agents, start_managed_agent_process,
@@ -97,6 +97,15 @@ pub fn run() {
         .manage(build_app_state())
         .setup(|app| {
             let app_handle = app.handle().clone();
+
+            // Resolve persisted identity key (env var → file → generate+save).
+            // This is fatal — the app should not start with an ephemeral identity
+            // that will be lost on restart, as that silently breaks channel
+            // memberships, DMs, and relay identity.
+            let state = app_handle.state::<AppState>();
+            resolve_persisted_identity(&app_handle, &state)
+                .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
             if let Err(error) = restore_managed_agents_on_launch(&app_handle) {
                 eprintln!("sprout-desktop: failed to restore managed agents: {error}");
             }


### PR DESCRIPTION
## Summary

The desktop app generates an ephemeral identity key on every restart if `SPROUT_PRIVATE_KEY` is not set. Since macOS/Windows GUI launches don't inherit shell environment variables, double-clicking Sprout.app means a new pubkey every time — losing all channel memberships, DMs, and relay identity.

This PR persists the identity key to the Tauri app data directory so it survives restarts.

## Design

**Priority order:**
1. `SPROUT_PRIVATE_KEY` env var — if present **and valid**, takes precedence (dev/CI)
2. `{app_data_dir}/identity.key` file — loaded on startup
3. Generate new key → save to `identity.key` (first run)

A malformed env var (present but unparseable) falls through to the persisted key rather than leaving the app on an ephemeral identity.

**Fail-closed:** If identity resolution fails entirely (e.g. disk full, permissions), the app refuses to start rather than silently running with an ephemeral key that will be lost on restart.

## Atomic writes via `atomic-write-file`

Uses the [`atomic-write-file`](https://crates.io/crates/atomic-write-file) crate (4.4M downloads) for crash-safe persistence:

1. Writes to a temp file in the same directory
2. `fsync` on file contents
3. Atomic rename to final path
4. `fsync` on parent directory

No hand-rolled temp files, no manual cleanup, no race conditions.

## Security

- **Unix:** File created with `0600` permissions (owner read/write only) via `set_permissions()` on the fd before writing the secret
- **Windows:** Default ACLs apply — the app data directory is already per-user

## Corruption recovery

If `identity.key` exists but is corrupted (empty, invalid nsec), it is:
1. Quarantined by renaming to `identity.key.bad.<timestamp>` (timestamped so prior backups are never overwritten)
2. If rename fails, deleted
3. A fresh key is generated and saved

The user always gets a stable identity — never silently falls back to ephemeral.

## Key paths

- macOS: `~/Library/Application Support/com.wesb.sprout/identity.key`
- Linux: `~/.local/share/com.wesb.sprout/identity.key`
- Windows: `%APPDATA%\com.wesb.sprout\identity.key`

## Tests

7 new unit tests covering the file I/O contract:
- Save/load round-trip
- Empty file rejection
- Corrupt content rejection
- Missing file error
- Valid nsec format verification
- Unix 0600 permissions enforcement
- Overwrite behavior

## Files changed (4)

| File | Change |
|------|--------|
| `desktop/src-tauri/Cargo.toml` | Add `atomic-write-file = "0.3"`, `tempfile` dev-dep |
| `desktop/src-tauri/Cargo.lock` | Lock file update |
| `desktop/src-tauri/src/app_state.rs` | `resolve_persisted_identity()`, `load_key_file()`, `save_key_file()`, 7 tests |
| `desktop/src-tauri/src/lib.rs` | Call `resolve_persisted_identity()` in `setup()` — fatal on failure |

## Review history

Codex crossfire over 8 iterations: 6 → 7 → 7 → 5 → 5 → 8 → 8.7 → **9.4/10 APPROVE**. Early versions hand-rolled atomic file operations; Codex correctly identified race conditions, partial-write visibility, PID-reuse collisions, and missing directory fsync. Switching to `atomic-write-file` resolved the atomicity class of issues. Final round added tests, fail-closed startup, and timestamped quarantine.