### PR TITLE
fix: update aws-lc-sys to 0.39.0 (RUSTSEC-2026-0048)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary

Bump `aws-lc-rs` 1.16.1 → 1.16.2 and `aws-lc-sys` 0.38.0 → 0.39.0 to resolve **RUSTSEC-2026-0048** (CRL Distribution Point Scope Check Logic Error in AWS-LC).

## Details

- **Advisory**: https://rustsec.org/advisories/RUSTSEC-2026-0048
- **Impact**: Logic error in CRL distribution point matching allows a revoked certificate to bypass revocation checks when CRL checking is enabled with partitioned CRLs using IDP extensions.
- **Practical risk to Sprout**: None — we don't enable CRL checking or use partitioned CRLs. Standard webpki certificate validation is unaffected.
- **Why we have this dep**: `aws-lc-sys` is a transitive dependency pulled in via `rustls` (default crypto provider since v0.23+), which is used by `reqwest`, `sqlx`, `tokio-tungstenite`, `hyper-rustls`, and `rust-s3`.

## Changes

Lockfile-only — no code modifications.

| Package | Before | After |
|---------|--------|-------|
| `aws-lc-rs` | 1.16.1 | 1.16.2 |
| `aws-lc-sys` | 0.38.0 | 0.39.0 |