### PR TITLE
fix: clean up channel members on channel deletion

### DIFF
--- a/crates/sprout-db/src/channel.rs
+++ b/crates/sprout-db/src/channel.rs
@@ -1048,6 +1048,21 @@ pub async fn soft_delete_channel(pool: &PgPool, channel_id: Uuid) -> Result<bool
     Ok(result.rows_affected() > 0)
 }
 
+/// Soft-remove all active members of a channel.
+///
+/// Called during channel deletion to clean up lingering memberships.
+/// Sets `removed_at = NOW()` on all rows where `removed_at IS NULL`.
+/// Returns the number of members removed.
+pub async fn remove_all_members_on_delete(pool: &PgPool, channel_id: Uuid) -> Result<u64> {
+    let result = sqlx::query(
+        "UPDATE channel_members SET removed_at = NOW() WHERE channel_id = $1 AND removed_at IS NULL",
+    )
+    .bind(channel_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}
+
 /// Returns the count of active (non-removed) members in a channel.
 pub async fn get_member_count(pool: &PgPool, channel_id: Uuid) -> Result<i64> {
     let row = sqlx::query(

--- a/crates/sprout-db/src/channel.rs
+++ b/crates/sprout-db/src/channel.rs
@@ -1034,33 +1034,36 @@ pub async fn unarchive_channel(pool: &PgPool, channel_id: Uuid) -> Result<()> {
     Ok(())
 }
 
-/// Soft-delete a channel by setting `deleted_at = NOW()`.
+/// Atomically soft-delete a channel and remove all its active members.
 ///
-/// Returns `Ok(true)` if the channel was deleted, `Ok(false)` if already
-/// deleted or not found.
-pub async fn soft_delete_channel(pool: &PgPool, channel_id: Uuid) -> Result<bool> {
-    let result =
+/// Sets `deleted_at = NOW()` on the channel and `removed_at = NOW()` on all
+/// active memberships in a single transaction, so there is no window where
+/// the channel is deleted but members are still active.
+///
+/// Returns `Ok((true, removed_count))` if the channel was deleted, or
+/// `Ok((false, 0))` if it was already deleted / not found.
+pub async fn delete_channel_and_members(pool: &PgPool, channel_id: Uuid) -> Result<(bool, u64)> {
+    let mut tx = pool.begin().await?;
+
+    let del =
         sqlx::query("UPDATE channels SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL")
             .bind(channel_id)
-            .execute(pool)
+            .execute(&mut *tx)
             .await?;
 
-    Ok(result.rows_affected() > 0)
-}
+    if del.rows_affected() == 0 {
+        return Ok((false, 0));
+    }
 
-/// Soft-remove all active members of a channel.
-///
-/// Called during channel deletion to clean up lingering memberships.
-/// Sets `removed_at = NOW()` on all rows where `removed_at IS NULL`.
-/// Returns the number of members removed.
-pub async fn remove_all_members_on_delete(pool: &PgPool, channel_id: Uuid) -> Result<u64> {
-    let result = sqlx::query(
+    let members = sqlx::query(
         "UPDATE channel_members SET removed_at = NOW() WHERE channel_id = $1 AND removed_at IS NULL",
     )
     .bind(channel_id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
-    Ok(result.rows_affected())
+
+    tx.commit().await?;
+    Ok((true, members.rows_affected()))
 }
 
 /// Returns the count of active (non-removed) members in a channel.

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -423,6 +423,11 @@ impl Db {
         channel::soft_delete_channel(&self.pool, channel_id).await
     }
 
+    /// Soft-remove all active members of a channel (used during channel deletion).
+    pub async fn remove_all_members_on_delete(&self, channel_id: Uuid) -> Result<u64> {
+        channel::remove_all_members_on_delete(&self.pool, channel_id).await
+    }
+
     /// Returns the count of active members in a channel.
     pub async fn get_member_count(&self, channel_id: Uuid) -> Result<i64> {
         channel::get_member_count(&self.pool, channel_id).await

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -418,14 +418,9 @@ impl Db {
         channel::unarchive_channel(&self.pool, channel_id).await
     }
 
-    /// Soft-delete a channel.
-    pub async fn soft_delete_channel(&self, channel_id: Uuid) -> Result<bool> {
-        channel::soft_delete_channel(&self.pool, channel_id).await
-    }
-
-    /// Soft-remove all active members of a channel (used during channel deletion).
-    pub async fn remove_all_members_on_delete(&self, channel_id: Uuid) -> Result<u64> {
-        channel::remove_all_members_on_delete(&self.pool, channel_id).await
+    /// Atomically soft-delete a channel and remove all its active members.
+    pub async fn delete_channel_and_members(&self, channel_id: Uuid) -> Result<(bool, u64)> {
+        channel::delete_channel_and_members(&self.pool, channel_id).await
     }
 
     /// Returns the count of active members in a channel.

--- a/crates/sprout-relay/src/api/channels_metadata.rs
+++ b/crates/sprout-relay/src/api/channels_metadata.rs
@@ -495,6 +495,14 @@ pub async fn delete_channel_handler(
         return Err(api_error(StatusCode::CONFLICT, "channel already deleted"));
     }
 
+    // Clean up lingering memberships so agents/bots don't appear as orphaned members.
+    match state.db.remove_all_members_on_delete(channel_id).await {
+        Ok(count) => tracing::info!(%channel_id, count, "removed members on channel delete"),
+        Err(e) => {
+            tracing::warn!(%channel_id, error = %e, "failed to remove members on channel delete")
+        }
+    }
+
     let actor_hex = nostr_hex::encode(&pubkey_bytes);
     if let Err(e) = emit_system_message(
         &state,

--- a/crates/sprout-relay/src/api/channels_metadata.rs
+++ b/crates/sprout-relay/src/api/channels_metadata.rs
@@ -485,9 +485,9 @@ pub async fn delete_channel_handler(
         None => return Err(forbidden("not a member of this channel")),
     }
 
-    let deleted = state
+    let (deleted, removed_members) = state
         .db
-        .soft_delete_channel(channel_id)
+        .delete_channel_and_members(channel_id)
         .await
         .map_err(|e| internal_error(&format!("db error: {e}")))?;
 
@@ -495,13 +495,7 @@ pub async fn delete_channel_handler(
         return Err(api_error(StatusCode::CONFLICT, "channel already deleted"));
     }
 
-    // Clean up lingering memberships so agents/bots don't appear as orphaned members.
-    match state.db.remove_all_members_on_delete(channel_id).await {
-        Ok(count) => tracing::info!(%channel_id, count, "removed members on channel delete"),
-        Err(e) => {
-            tracing::warn!(%channel_id, error = %e, "failed to remove members on channel delete")
-        }
-    }
+    tracing::info!(%channel_id, removed_members, "channel deleted with member cleanup");
 
     let actor_hex = nostr_hex::encode(&pubkey_bytes);
     if let Err(e) = emit_system_message(

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -921,6 +921,14 @@ async fn handle_delete_group(event: &Event, state: &Arc<AppState>) -> anyhow::Re
         warn!(channel = %channel_id, "channel already deleted or not found");
     }
 
+    // Clean up lingering memberships so agents/bots don't appear as orphaned members.
+    match state.db.remove_all_members_on_delete(channel_id).await {
+        Ok(count) => info!(channel = %channel_id, count, "removed members on channel delete"),
+        Err(e) => {
+            warn!(channel = %channel_id, error = %e, "failed to remove members on channel delete")
+        }
+    }
+
     // Clean up NIP-29 discovery events for the deleted group.
     if let Err(e) = state
         .db

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -910,23 +910,17 @@ async fn handle_delete_group(event: &Event, state: &Arc<AppState>) -> anyhow::Re
         extract_h_tag_channel(event).ok_or_else(|| anyhow::anyhow!("missing h tag"))?;
     let actor_bytes = event.pubkey.serialize().to_vec();
 
-    // Soft-delete the channel.
-    let deleted = state
+    // Atomically soft-delete the channel and clean up all memberships.
+    let (deleted, removed_members) = state
         .db
-        .soft_delete_channel(channel_id)
+        .delete_channel_and_members(channel_id)
         .await
-        .map_err(|e| anyhow::anyhow!("soft_delete_channel failed: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("delete_channel_and_members failed: {e}"))?;
 
     if !deleted {
         warn!(channel = %channel_id, "channel already deleted or not found");
-    }
-
-    // Clean up lingering memberships so agents/bots don't appear as orphaned members.
-    match state.db.remove_all_members_on_delete(channel_id).await {
-        Ok(count) => info!(channel = %channel_id, count, "removed members on channel delete"),
-        Err(e) => {
-            warn!(channel = %channel_id, error = %e, "failed to remove members on channel delete")
-        }
+    } else {
+        info!(channel = %channel_id, removed_members, "channel deleted with member cleanup");
     }
 
     // Clean up NIP-29 discovery events for the deleted group.

--- a/crates/sprout-test-client/tests/e2e_rest_api.rs
+++ b/crates/sprout-test-client/tests/e2e_rest_api.rs
@@ -95,6 +95,16 @@ async fn authed_put(
         .unwrap_or_else(|e| panic!("HTTP PUT {url} failed: {e}"))
 }
 
+/// Make an authenticated DELETE request using the `X-Pubkey` dev-mode header.
+async fn authed_delete(client: &Client, url: &str, pubkey_hex: &str) -> reqwest::Response {
+    client
+        .delete(url)
+        .header("X-Pubkey", pubkey_hex)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("HTTP DELETE {url} failed: {e}"))
+}
+
 // ── Channel tests ─────────────────────────────────────────────────────────────
 
 /// GET /api/channels returns a non-empty list with the expected fields.
@@ -2361,4 +2371,101 @@ async fn test_rest_mention_pubkeys_normalization_in_emitted_event() {
     }
 
     sub.disconnect().await.expect("disconnect");
+}
+
+/// Deleting a channel should clean up all member records (including bots).
+///
+/// Verifies that after DELETE /api/channels/{id}, the member list for that
+/// channel is empty (or the channel returns 404).
+#[tokio::test]
+#[ignore]
+async fn test_delete_channel_cleans_up_members() {
+    let client = http_client();
+    let owner_keys = Keys::generate();
+    let owner_hex = owner_keys.public_key().to_hex();
+    let bot_keys = Keys::generate();
+    let bot_hex = bot_keys.public_key().to_hex();
+
+    // 1. Create a private channel.
+    let create_resp = authed_post_json(
+        &client,
+        &format!("{}/api/channels", relay_http_url()),
+        &owner_hex,
+        serde_json::json!({
+            "name": format!("cleanup-test-{}", uuid::Uuid::new_v4()),
+            "channel_type": "stream",
+            "visibility": "private",
+        }),
+    )
+    .await;
+    assert_eq!(create_resp.status(), 201);
+    let channel: serde_json::Value = create_resp.json().await.expect("json");
+    let channel_id = channel["id"].as_str().expect("channel id");
+
+    // 2. Add a bot member.
+    let add_resp = authed_post_json(
+        &client,
+        &format!("{}/api/channels/{}/members", relay_http_url(), channel_id),
+        &owner_hex,
+        serde_json::json!({
+            "pubkeys": [bot_hex],
+            "role": "bot",
+        }),
+    )
+    .await;
+    assert_eq!(add_resp.status(), 201, "adding bot member should succeed");
+
+    // 3. Verify bot is in the member list.
+    let members_resp = authed_get(
+        &client,
+        &format!("{}/api/channels/{}/members", relay_http_url(), channel_id),
+        &owner_hex,
+    )
+    .await;
+    assert_eq!(members_resp.status(), 200);
+    let members_body: serde_json::Value = members_resp.json().await.expect("json");
+    let members = members_body["members"].as_array().expect("members array");
+    assert!(
+        members
+            .iter()
+            .any(|m| m["pubkey"].as_str() == Some(&bot_hex)),
+        "bot should be in the member list before deletion"
+    );
+
+    // 4. Delete the channel.
+    let delete_resp = authed_delete(
+        &client,
+        &format!("{}/api/channels/{}", relay_http_url(), channel_id),
+        &owner_hex,
+    )
+    .await;
+    assert_eq!(delete_resp.status(), 200, "channel deletion should succeed");
+
+    // 5. Verify members are cleaned up.
+    // After deletion, get_members returns empty because the channel JOIN
+    // filters on deleted_at IS NULL, and all memberships have removed_at set.
+    let members_after = authed_get(
+        &client,
+        &format!("{}/api/channels/{}/members", relay_http_url(), channel_id),
+        &owner_hex,
+    )
+    .await;
+    // The endpoint may return 404 (channel not found) or 200 with empty members.
+    // Either is acceptable — the key assertion is that no members are returned.
+    let status = members_after.status().as_u16();
+    if status == 200 {
+        let body: serde_json::Value = members_after.json().await.expect("json");
+        let empty = vec![];
+        let members = body["members"].as_array().unwrap_or(&empty);
+        assert!(
+            members.is_empty(),
+            "member list should be empty after channel deletion, got: {members:?}"
+        );
+    } else {
+        // 404 or 403 is also acceptable — channel is gone.
+        assert!(
+            status == 404 || status == 403,
+            "expected 200/404/403 after deletion, got {status}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

When a channel is deleted, bot/agent memberships in `channel_members` were left with `removed_at IS NULL`, causing orphaned agents to linger after channel deletion.

## Changes

### Atomic `delete_channel_and_members()` transaction
- New function in `sprout-db` that wraps channel soft-delete and member cleanup in a single DB transaction
- Eliminates the race window where a channel could be deleted but members remain active
- Returns `(bool, u64)` — whether the channel was deleted and how many members were cleaned up

### Both API surfaces updated
- **REST**: `delete_channel_handler` in `channels_metadata.rs`
- **WebSocket/NIP-29**: `handle_delete_group` in `side_effects.rs`

### E2E test
- New `test_delete_channel_cleans_up_members`: creates channel → adds bot member → deletes channel → verifies membership cleanup
- New `authed_delete` test helper for DELETE requests

## Files changed (5)
| File | Change |
|------|--------|
| `crates/sprout-db/src/channel.rs` | New `delete_channel_and_members()` atomic transaction |
| `crates/sprout-db/src/lib.rs` | `Db` wrapper method |
| `crates/sprout-relay/src/api/channels_metadata.rs` | REST handler uses atomic function |
| `crates/sprout-relay/src/handlers/side_effects.rs` | WS handler uses atomic function |
| `crates/sprout-test-client/tests/e2e_rest_api.rs` | E2E test + `authed_delete` helper |

## Testing
- `cargo check --workspace` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- Pre-commit hooks (lefthook) ✅

## Note
Channels deleted before this fix may still have orphaned `channel_members` rows. A one-time cleanup migration can address this:
```sql
UPDATE channel_members SET removed_at = NOW()
WHERE channel_id IN (SELECT id FROM channels WHERE deleted_at IS NOT NULL)
AND removed_at IS NULL;
```