### PR TITLE
fix(desktop): add admin prereq check to doctor panel

### DIFF
--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -6,7 +6,7 @@ use crate::{
     managed_agents::{
         command_availability, discover_local_acp_providers, AcpProviderInfo,
         DiscoverManagedAgentPrereqsRequest, ManagedAgentPrereqsInfo, RelayAgentInfo,
-        DEFAULT_ACP_COMMAND, DEFAULT_MCP_COMMAND,
+        DEFAULT_ADMIN_COMMAND, DEFAULT_ACP_COMMAND, DEFAULT_MCP_COMMAND,
     },
     relay::{build_authed_request, send_json_request},
 };
@@ -37,6 +37,7 @@ pub fn discover_managed_agent_prereqs(
     ManagedAgentPrereqsInfo {
         acp: command_availability(acp_command, Some(&app)),
         mcp: command_availability(mcp_command, Some(&app)),
+        admin: command_availability(DEFAULT_ADMIN_COMMAND, Some(&app)),
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -193,6 +193,7 @@ pub struct DiscoverManagedAgentPrereqsRequest {
 pub struct ManagedAgentPrereqsInfo {
     pub acp: CommandAvailabilityInfo,
     pub mcp: CommandAvailabilityInfo,
+    pub admin: CommandAvailabilityInfo,
 }
 
 /// Patch request for updating a managed agent's mutable fields.
@@ -268,6 +269,7 @@ pub struct UpdateTeamRequest {
 }
 
 pub const DEFAULT_ACP_COMMAND: &str = "sprout-acp";
+pub const DEFAULT_ADMIN_COMMAND: &str = "sprout-admin";
 pub const DEFAULT_AGENT_COMMAND: &str = "goose";
 pub const DEFAULT_MCP_COMMAND: &str = "sprout-mcp-server";
 pub const DEFAULT_AGENT_ARG: &str = "acp";


### PR DESCRIPTION
## Summary

The Doctor settings panel and TypeScript types already expect an `admin` field on `ManagedAgentPrereqs` to check for the `sprout-admin` binary, but the Rust backend was missing this field — causing the "Token minting" row in the Doctor panel to never report availability.

## Changes

**`desktop/src-tauri/src/managed_agents/types.rs`**
- Add `pub admin: CommandAvailabilityInfo` to `ManagedAgentPrereqsInfo`
- Add `DEFAULT_ADMIN_COMMAND` constant (`"sprout-admin"`)

**`desktop/src-tauri/src/commands/agent_discovery.rs`**
- Import `DEFAULT_ADMIN_COMMAND` and populate the new `admin` field via `command_availability()`

The admin command is not user-configurable (always checks `sprout-admin`), matching the frontend behavior where the Doctor panel notes: *"Token minting always checks the default `sprout-admin` command."*

## Testing

- `just ci` passes (fmt, clippy, unit tests, desktop build, Tauri check)
- Verified the TypeScript types and Doctor panel UI already consume `prereqs.admin` correctly