### PR TITLE
fix(desktop): clean up managed agents when channel is deleted

### DIFF
--- a/desktop/src/features/channels/cleanupChannelAgents.ts
+++ b/desktop/src/features/channels/cleanupChannelAgents.ts
@@ -1,0 +1,51 @@
+/**
+ * Best-effort cleanup of managed agents when a channel is deleted.
+ *
+ * Each agent added via the "Add agents" dialog is a unique process scoped to
+ * the channel. When the channel is deleted these orphaned agents should be
+ * removed — but only if they are not members of any other channel.
+ */
+import {
+  deleteManagedAgent,
+  getChannelMembers,
+  listManagedAgents,
+  listRelayAgents,
+} from "@/shared/api/tauri";
+
+export async function cleanupChannelAgents(channelId: string): Promise<void> {
+  const [members, managedAgents, relayAgents] = await Promise.all([
+    getChannelMembers(channelId),
+    listManagedAgents(),
+    listRelayAgents(),
+  ]);
+
+  const memberPubkeys = new Set(
+    members.map((member) => member.pubkey.toLowerCase()),
+  );
+
+  // Find managed agents that are members of this channel.
+  const agentsInChannel = managedAgents.filter((agent) =>
+    memberPubkeys.has(agent.pubkey.toLowerCase()),
+  );
+
+  // Only delete agents that are NOT members of any other channel.
+  const agentsToDelete = agentsInChannel.filter((agent) => {
+    const relayAgent = relayAgents.find(
+      (ra) => ra.pubkey.toLowerCase() === agent.pubkey.toLowerCase(),
+    );
+    if (!relayAgent) {
+      // Not found in relay — safe to delete.
+      return true;
+    }
+    // Only delete if this is the agent's only channel.
+    const otherChannels = relayAgent.channelIds.filter(
+      (id) => id !== channelId,
+    );
+    return otherChannels.length === 0;
+  });
+
+  // Delete orphaned agents (best-effort — don't block channel deletion).
+  await Promise.allSettled(
+    agentsToDelete.map((agent) => deleteManagedAgent(agent.pubkey)),
+  );
+}

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -25,6 +25,7 @@ import {
   unarchiveChannel,
   updateChannel,
 } from "@/shared/api/tauri";
+import { cleanupChannelAgents } from "@/features/channels/cleanupChannelAgents";
 import type {
   AddChannelMembersInput,
   Channel,
@@ -343,6 +344,13 @@ export function useDeleteChannelMutation(channelId: string | null) {
         throw new Error("No channel selected.");
       }
 
+      // Best-effort cleanup of managed agents scoped to this channel.
+      try {
+        await cleanupChannelAgents(channelId);
+      } catch (error) {
+        console.warn("Failed to clean up managed agents:", error);
+      }
+
       await deleteChannel(channelId);
     },
     onSuccess: () => {
@@ -361,7 +369,11 @@ export function useDeleteChannelMutation(channelId: string | null) {
       });
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: channelsQueryKey }),
+        queryClient.invalidateQueries({ queryKey: ["managed-agents"] }),
+        queryClient.invalidateQueries({ queryKey: ["relay-agents"] }),
+      ]);
     },
   });
 }
@@ -478,7 +490,6 @@ export function useSelectedChannel(
 }
 
 // ── Canvas ────────────────────────────────────────────────────────────────────
-
 export function useCanvasQuery(channelId: string | null, enabled = true) {
   return useQuery({
     queryKey: ["channel-canvas", channelId],


### PR DESCRIPTION
## Summary

When a channel is deleted, managed agents that were created for that channel (via the "Add agents" dialog) are now automatically cleaned up. Previously, these agents would be orphaned — still running and visible in the Agents panel — after the channel was deleted.

## What changed

**New file: `desktop/src/features/channels/cleanupChannelAgents.ts`**
- Extracted helper that handles the cleanup logic
- Fetches channel members, managed agents, and relay agents in parallel
- Cross-references to find managed agents that are members of the channel
- Only deletes agents that are NOT members of any other channel (multi-channel safe)
- Uses `Promise.allSettled` for best-effort cleanup — individual failures don't block others

**Modified: `desktop/src/features/channels/hooks.ts`**
- `useDeleteChannelMutation` now calls `cleanupChannelAgents()` before deleting the channel
- Cleanup is wrapped in try/catch — if it fails, channel deletion still proceeds
- `onSettled` invalidates managed-agents and relay-agents queries so the UI refreshes

## Design decisions

- **Delete, not just stop**: Since each agent is a duplicate created specifically for the channel, deleting it (stop process + remove config) is the right call
- **Multi-channel safe**: Agents that are members of other channels are preserved
- **Best-effort**: Cleanup failures are logged but never prevent channel deletion
- **No backend changes**: This is a pure UI fix — the relay/database are untouched

## Testing

Manually tested by the reporter — confirmed agents are cleaned up after channel deletion.