### PR TITLE
fix(desktop): resolve composer cursor drift on multi-line input

### DIFF
--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -578,7 +578,7 @@ export function MessageComposer({
             </div>
             <Textarea
               aria-label="Message channel"
-              className="min-h-0 resize-none overflow-y-hidden border-0 bg-transparent px-0 py-0 text-sm leading-6 shadow-none focus-visible:ring-0 caret-foreground text-transparent selection:bg-primary/20 selection:text-transparent"
+              className="min-h-0 resize-none overflow-y-hidden border-0 bg-transparent px-0 py-0 text-sm leading-6 md:leading-6 shadow-none focus-visible:ring-0 caret-foreground text-transparent selection:bg-primary/20 selection:text-transparent"
               data-testid="message-input"
               disabled={disabled}
               onChange={handleChange}


### PR DESCRIPTION
## Problem

When typing multi-line text in the message composer, the cursor drifts upward from the actual text position. By the 3rd line, the cursor is ~12px above where the text appears, making it difficult to see what you're typing.

## Root Cause

The base `Textarea` component (`shared/ui/textarea.tsx`) includes `md:text-sm` in its default classes. At the `md` breakpoint, `md:text-sm` sets both `font-size: 0.875rem` **and** `line-height: 1.25rem` (20px). The composer overrides with `leading-6` (24px line-height), but the responsive `md:text-sm` has higher CSS specificity and wins at desktop widths.

Meanwhile, the `ComposerMentionOverlay` (a plain `<div>`) uses `text-sm leading-6` without any responsive override, so it keeps `line-height: 24px` at all breakpoints.

This mismatch — textarea at 20px vs overlay at 24px — causes the caret to drift 4px per line away from the overlay's visible text.

## Fix

Add `md:leading-6` to the Textarea className in `MessageComposer.tsx` so the line-height override wins at the `md` breakpoint too. This ensures both the textarea and overlay use a consistent 24px line-height at all breakpoints.

## Follow-up (separate PR)

- Extract shared text classes into a constant for explicit textarea ↔ overlay coupling
- Replace DOM-read `lineHeightRef` with a constant (24px at all breakpoints now)
- Add defensive `md:leading-6` to the overlay for symmetry