### PR TITLE
feat(desktop): reorder Profile above Identity in settings & remove duplicate NIP-05 input

### DIFF
--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -70,30 +70,23 @@ export function ProfileSettingsCard({
   const currentDisplayName = profile?.displayName ?? "";
   const currentAvatarUrl = profile?.avatarUrl ?? "";
   const currentAbout = profile?.about ?? "";
-  const currentNip05Handle = profile?.nip05Handle ?? "";
-
   const [displayNameDraft, setDisplayNameDraft] = React.useState("");
   const [avatarUrlDraft, setAvatarUrlDraft] = React.useState("");
   const [aboutDraft, setAboutDraft] = React.useState("");
-  const [nip05HandleDraft, setNip05HandleDraft] = React.useState("");
 
   React.useEffect(() => {
     setDisplayNameDraft(currentDisplayName);
     setAvatarUrlDraft(currentAvatarUrl);
     setAboutDraft(currentAbout);
-    setNip05HandleDraft(currentNip05Handle);
-  }, [currentAbout, currentAvatarUrl, currentDisplayName, currentNip05Handle]);
+  }, [currentAbout, currentAvatarUrl, currentDisplayName]);
 
   const nextDisplayName = displayNameDraft.trim();
   const nextAvatarUrl = avatarUrlDraft.trim();
   const nextAbout = aboutDraft.trim();
-  const nextNip05Handle = nip05HandleDraft.trim();
-
   const updatePayload: {
     displayName?: string;
     avatarUrl?: string;
     about?: string;
-    nip05Handle?: string;
   } = {};
 
   if (nextDisplayName.length > 0 && nextDisplayName !== currentDisplayName) {
@@ -104,9 +97,6 @@ export function ProfileSettingsCard({
   }
   if (nextAbout.length > 0 && nextAbout !== currentAbout) {
     updatePayload.about = nextAbout;
-  }
-  if (nextNip05Handle !== currentNip05Handle) {
-    updatePayload.nip05Handle = nextNip05Handle;
   }
 
   const hasPendingClearRequest =
@@ -212,28 +202,6 @@ export function ProfileSettingsCard({
             </div>
 
             <div className="space-y-1.5">
-              <label className="text-sm font-medium" htmlFor="profile-nip05">
-                NIP-05 handle
-              </label>
-              <div className="relative min-w-0">
-                <AtSign className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  className="pl-9"
-                  data-testid="profile-nip05-input"
-                  disabled={updateProfileMutation.isPending}
-                  id="profile-nip05"
-                  onChange={(event) => setNip05HandleDraft(event.target.value)}
-                  placeholder="alice@localhost"
-                  value={nip05HandleDraft}
-                />
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Must match this relay&apos;s domain. Leave blank to clear your
-                current handle.
-              </p>
-            </div>
-
-            <div className="space-y-1.5">
               <label
                 className="text-sm font-medium"
                 htmlFor="profile-avatar-url"
@@ -293,7 +261,7 @@ export function ProfileSettingsCard({
         <Separator />
 
         <Section
-          description="Your keypair is fixed for this device. Profile fields and NIP-05 are editable above."
+          description="Your keypair and NIP-05 handle are fixed for this device."
           title="Identity"
         >
           <div className="space-y-3">

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -11,8 +11,6 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
   const displayName = `Tyler QA ${stamp}`;
   const avatarUrl = `https://example.com/avatar-${stamp}.png`;
   const about = `Coordinating relay profile setup ${stamp}`;
-  const nip05Handle = `tyler-${stamp}@localhost`;
-
   await page.goto("/");
 
   await page.getByTestId("open-settings").click();
@@ -25,7 +23,6 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
   await expect(page.getByTestId("profile-nip05")).toContainText("Not set");
 
   await page.getByTestId("profile-display-name").fill(displayName);
-  await page.getByTestId("profile-nip05-input").fill(nip05Handle);
   await page.getByTestId("profile-avatar-url").fill(avatarUrl);
   await page.getByTestId("profile-about").fill(about);
   await page.getByTestId("profile-save").click();
@@ -33,10 +30,7 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
   await expect(page.getByTestId("profile-display-name")).toHaveValue(
     displayName,
   );
-  await expect(page.getByTestId("profile-nip05")).toContainText(nip05Handle);
-  await expect(page.getByTestId("profile-nip05-input")).toHaveValue(
-    nip05Handle,
-  );
+  await expect(page.getByTestId("profile-nip05")).toContainText("Not set");
   await expect(page.getByTestId("profile-avatar-url")).toHaveValue(avatarUrl);
   await expect(page.getByTestId("profile-about")).toHaveValue(about);
 
@@ -50,10 +44,7 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
   await expect(page.getByTestId("profile-display-name")).toHaveValue(
     displayName,
   );
-  await expect(page.getByTestId("profile-nip05")).toContainText(nip05Handle);
-  await expect(page.getByTestId("profile-nip05-input")).toHaveValue(
-    nip05Handle,
-  );
+  await expect(page.getByTestId("profile-nip05")).toContainText("Not set");
   await expect(page.getByTestId("profile-avatar-url")).toHaveValue(avatarUrl);
   await expect(page.getByTestId("profile-about")).toHaveValue(about);
 });


### PR DESCRIPTION
## Summary

Reorders the user settings card so the **Profile** section (editable fields users change often) appears above the **Identity** section (read-only keypair info). Also removes the duplicate editable NIP-05 handle input from the Profile section, keeping only the read-only display in the Identity section where it conceptually belongs.

## Changes

### Commit 1: `feat(desktop): move Profile section above Identity in settings`
- Swapped the order of the Profile and Identity `<Section>` blocks in `ProfileSettingsCard.tsx`
- Updated the Identity section description from "editable below" to "editable above"

### Commit 2: `refactor(desktop): remove duplicate NIP-05 input from Profile section`
- Removed the editable NIP-05 handle `<Input>` from the Profile form
- Removed all associated draft state (`nip05HandleDraft`, `setNip05HandleDraft`, `nextNip05Handle`, `currentNip05Handle`)
- Removed `nip05Handle` from the local `updatePayload` type and conditional logic
- Updated Identity section description to: *"Your keypair and NIP-05 handle are fixed for this device."*
- Updated E2E test (`profile.spec.ts`) to remove NIP-05 input interactions and update assertions
- API type (`UpdateProfileInput`) intentionally preserved — server/other clients can still set NIP-05 via API

## Rationale

- **Profile above Identity**: Users change display name, avatar, and about far more often than they view their public key. Putting the editable section first reduces scrolling for the common case.
- **NIP-05 deduplication**: Per VISION.md, NIP-05 is an identity field (like a keypair), not a casual profile field. Having it editable in Profile AND displayed read-only in Identity was confusing. Users rarely change their NIP-05 handle — it belongs as a read-only display in the Identity section.

## Files Changed
- `desktop/src/features/settings/ui/ProfileSettingsCard.tsx` — section reorder + NIP-05 input removal
- `desktop/tests/e2e/profile.spec.ts` — updated E2E test assertions

## Testing
- ✅ Biome lint passes on both files
- ✅ Pre-push CI: fmt, clippy, unit tests, desktop build, Tauri check — all green
- ✅ Refactor checks by @summer (2 rounds)
- ✅ Code reviews by @beth (2 rounds, both APPROVED)