### PR TITLE
fix(acp): support canonical Claude ACP discovery

### DIFF
--- a/crates/sprout-acp/README.md
+++ b/crates/sprout-acp/README.md
@@ -9,7 +9,7 @@ Sprout Relay ──WS──→ sprout-acp ──stdio──→ Your Agent
                                        (send_message, etc.)
 ```
 
-Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/zed-industries/claude-agent-acp)).
+Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), and **claude code** (via [claude-code-acp](https://github.com/zed-industries/claude-code-acp)).
 
 ## Prerequisites
 
@@ -76,16 +76,16 @@ sprout-acp
 
 ## Running with Claude Code
 
-[claude-agent-acp](https://github.com/zed-industries/claude-agent-acp) wraps the Claude Agent SDK in an ACP interface.
+[claude-code-acp](https://github.com/zed-industries/claude-code-acp) wraps the Claude Agent SDK in an ACP interface.
 
 ```bash
 # Build the adapter
-cd /path/to/claude-agent-acp && npm install && npm run build
+cd /path/to/claude-code-acp && npm install && npm run build
 
 # Run
 export ANTHROPIC_API_KEY="sk-ant-..."
 export SPROUT_ACP_AGENT_COMMAND="node"   # full path if using hermit: /path/to/sprout2/bin/node
-export SPROUT_ACP_AGENT_ARGS="/path/to/claude-agent-acp/dist/index.js"
+export SPROUT_ACP_AGENT_ARGS="/path/to/claude-code-acp/dist/index.js"
 
 sprout-acp
 ```

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -55,7 +55,7 @@ pub enum DedupMode {
     about = "Query available models from the configured agent"
 )]
 pub struct ModelsArgs {
-    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp").
+    /// Agent binary to spawn (e.g. "goose", "claude-code-acp", "codex-acp").
     #[arg(long, env = "SPROUT_ACP_AGENT_COMMAND", default_value = "goose")]
     pub agent_command: String,
 
@@ -268,9 +268,8 @@ fn normalize_agent_command_identity(command: &str) -> String {
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
-        "codex" | "codex-acp" | "claude-agent-acp" | "claude-code" | "claudecode" => {
-            Some(Vec::new())
-        }
+        "codex" | "codex-acp" | "claude-code-acp" | "claude-agent-acp" | "claude-code"
+        | "claudecode" => Some(Vec::new()),
         _ => None,
     }
 }
@@ -790,6 +789,14 @@ mod tests {
             normalize_agent_args("claude-code", vec!["acp".into()]),
             Vec::<String>::new()
         );
+        assert_eq!(
+            normalize_agent_args("claude-code-acp", vec!["acp".into()]),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            normalize_agent_args("claude-agent-acp", vec!["acp".into()]),
+            Vec::<String>::new()
+        );
     }
 
     #[test]
@@ -814,6 +821,10 @@ mod tests {
         assert_eq!(
             normalize_agent_command_identity("/usr/local/bin/codex-acp"),
             "codex-acp"
+        );
+        assert_eq!(
+            normalize_agent_command_identity("/usr/local/bin/claude-code-acp"),
+            "claude-code-acp"
         );
         assert_eq!(normalize_agent_command_identity("/usr/local/bin/"), "bin");
         assert_eq!(

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -46,8 +46,8 @@ const KNOWN_ACP_PROVIDERS: &[KnownAcpProvider] = &[
     KnownAcpProvider {
         id: "claude",
         label: "Claude Code",
-        command: "claude-agent-acp",
-        aliases: &["claude-code", "claudecode"],
+        command: "claude-code-acp",
+        aliases: &["claude-agent-acp", "claude-code", "claudecode"],
         default_args: &[],
         avatar_url: CLAUDE_CODE_AVATAR_URL,
     },
@@ -230,6 +230,29 @@ fn find_command(command: &str) -> Option<PathBuf> {
     resolve_command(command, None)
 }
 
+fn discover_provider_with<F>(provider: &KnownAcpProvider, mut find: F) -> Option<AcpProviderInfo>
+where
+    F: FnMut(&str) -> Option<PathBuf>,
+{
+    std::iter::once(provider.command)
+        .chain(provider.aliases.iter().copied())
+        .find_map(|command| {
+            find(command).map(|binary_path| AcpProviderInfo {
+                id: provider.id.to_string(),
+                label: provider.label.to_string(),
+                // Persist the command we actually found so later launches
+                // keep working for legacy installs as well.
+                command: command.to_string(),
+                binary_path: binary_path.display().to_string(),
+                default_args: provider
+                    .default_args
+                    .iter()
+                    .map(|arg| (*arg).to_string())
+                    .collect(),
+            })
+        })
+}
+
 pub fn command_availability(command: &str, app: Option<&AppHandle>) -> CommandAvailabilityInfo {
     let resolved_path = resolve_command(command, app).map(|path| path.display().to_string());
     CommandAvailabilityInfo {
@@ -252,19 +275,7 @@ pub fn missing_command_message(command: &str, role: &str) -> String {
 pub fn discover_local_acp_providers() -> Vec<AcpProviderInfo> {
     KNOWN_ACP_PROVIDERS
         .iter()
-        .filter_map(|provider| {
-            find_command(provider.command).map(|binary_path| AcpProviderInfo {
-                id: provider.id.to_string(),
-                label: provider.label.to_string(),
-                command: provider.command.to_string(),
-                binary_path: binary_path.display().to_string(),
-                default_args: provider
-                    .default_args
-                    .iter()
-                    .map(|arg| (*arg).to_string())
-                    .collect(),
-            })
-        })
+        .filter_map(|provider| discover_provider_with(provider, find_command))
         .collect()
 }
 
@@ -345,8 +356,10 @@ pub async fn mint_token_via_api(
 #[cfg(test)]
 mod tests {
     use super::{
-        managed_agent_avatar_url, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL, GOOSE_AVATAR_URL,
+        discover_provider_with, managed_agent_avatar_url, CLAUDE_CODE_AVATAR_URL,
+        CODEX_AVATAR_URL, GOOSE_AVATAR_URL, KNOWN_ACP_PROVIDERS,
     };
+    use std::path::PathBuf;
 
     #[test]
     fn resolves_known_avatar_for_bare_command() {
@@ -366,6 +379,10 @@ mod tests {
             Some(CLAUDE_CODE_AVATAR_URL.to_string())
         );
         assert_eq!(
+            managed_agent_avatar_url(r"C:\Tools\claude-code-acp.exe"),
+            Some(CLAUDE_CODE_AVATAR_URL.to_string())
+        );
+        assert_eq!(
             managed_agent_avatar_url(r"C:\Tools\claude-agent-acp.exe"),
             Some(CLAUDE_CODE_AVATAR_URL.to_string())
         );
@@ -374,5 +391,40 @@ mod tests {
     #[test]
     fn returns_none_for_unknown_commands() {
         assert!(managed_agent_avatar_url("custom-agent").is_none());
+    }
+
+    #[test]
+    fn discovery_falls_back_to_legacy_claude_alias() {
+        let provider = KNOWN_ACP_PROVIDERS
+            .iter()
+            .find(|provider| provider.id == "claude")
+            .expect("claude provider should exist");
+
+        let discovered = discover_provider_with(provider, |command| match command {
+            "claude-agent-acp" => Some(PathBuf::from("/tmp/claude-agent-acp")),
+            _ => None,
+        })
+        .expect("legacy claude binary should be discovered");
+
+        assert_eq!(discovered.command, "claude-agent-acp");
+        assert_eq!(discovered.binary_path, "/tmp/claude-agent-acp");
+    }
+
+    #[test]
+    fn discovery_prefers_canonical_command_when_present() {
+        let provider = KNOWN_ACP_PROVIDERS
+            .iter()
+            .find(|provider| provider.id == "claude")
+            .expect("claude provider should exist");
+
+        let discovered = discover_provider_with(provider, |command| match command {
+            "claude-code-acp" => Some(PathBuf::from("/tmp/claude-code-acp")),
+            "claude-agent-acp" => Some(PathBuf::from("/tmp/claude-agent-acp")),
+            _ => None,
+        })
+        .expect("canonical claude binary should be discovered");
+
+        assert_eq!(discovered.command, "claude-code-acp");
+        assert_eq!(discovered.binary_path, "/tmp/claude-code-acp");
     }
 }


### PR DESCRIPTION
Summary:
- treat claude-code-acp as the canonical Claude ACP command while still recognizing legacy names
- persist whichever Claude binary was actually discovered so legacy installs keep launching correctly
- update sprout-acp docs and zero-arg normalization tests for the canonical and fallback Claude names

Testing:
- source ./bin/activate-hermit && cargo test --manifest-path desktop/src-tauri/Cargo.toml managed_agents::discovery::tests -- --nocapture
- source ./bin/activate-hermit && cargo test -p sprout-acp normalizes_goose_args_to_acp -- --nocapture
- git push -u origin rick/claude-acp-check

Notes:
- This PR intentionally stays in the small compatibility/docs lane.
- The Claude permission-policy and non-model-config behavior stays for a separate follow-up PR.