### PR TITLE
fix: add direct fan-out for ephemeral typing events and tune frontend timing

### DIFF
--- a/crates/sprout-relay/src/handlers/event.rs
+++ b/crates/sprout-relay/src/handlers/event.rs
@@ -360,8 +360,34 @@ async fn handle_ephemeral_event(
             return;
         }
 
+        // Mark as local before Redis publish to prevent double-delivery when
+        // the event comes back through the Redis subscriber loop.
+        state.mark_local_event(&event.id);
+
         if let Err(e) = state.pubsub.publish_event(ch_id, &event).await {
+            state.local_event_ids.invalidate(&event.id.to_bytes());
             warn!(conn_id = %conn_id, event_id = %event_id_hex, "Ephemeral publish failed: {e}");
+        }
+
+        // Direct fan-out to local WS subscribers.
+        // Pass the channel_id so fan_out() uses the channel-kind index.
+        let stored_event = StoredEvent::new(event.clone(), Some(ch_id));
+        let matches = state.sub_registry.fan_out(&stored_event);
+        let event_json = serde_json::to_string(&event)
+            .expect("nostr::Event serialization is infallible for well-formed events");
+        let mut drop_count = 0u32;
+        for (target_conn_id, sub_id) in &matches {
+            let msg = format!(r#"["EVENT","{}",{}]"#, sub_id, event_json);
+            if !state.conn_manager.send_to(*target_conn_id, msg) {
+                drop_count += 1;
+            }
+        }
+        if drop_count > 0 {
+            tracing::warn!(
+                event_id = %event_id_hex,
+                drop_count,
+                "fan-out: {drop_count} connection(s) cancelled due to full/closed buffers"
+            );
         }
     }
 

--- a/desktop/src/features/messages/useChannelTyping.ts
+++ b/desktop/src/features/messages/useChannelTyping.ts
@@ -11,9 +11,9 @@ import {
 
 type TypingState = Record<string, number>;
 
-const TYPING_INDICATOR_TTL_MS = 5_500;
+const TYPING_INDICATOR_TTL_MS = 8_000;
 const TYPING_PRUNE_INTERVAL_MS = 1_000;
-const TYPING_POST_MESSAGE_SUPPRESS_MS = 4_000;
+const TYPING_POST_MESSAGE_SUPPRESS_MS = 2_000;
 
 function pruneTypingState(state: TypingState, now = Date.now()) {
   let changed = false;


### PR DESCRIPTION
## Summary

Fixes flaky chat status indicators (💬, 👀, "is typing...") that would show and hide inconsistently, making it appear agents weren't working when they actually were.

## Root Cause

Typing indicator events (kind 20002) were missing direct WebSocket fan-out in `handle_ephemeral_event`. Unlike persistent events and presence events (kind 20001), typing indicators were ONLY published to Redis pub/sub — requiring a round-trip through Redis before reaching connected clients. This caused:

1. **Latency** — typing events arrived late, creating gaps where the indicator disappeared
2. **Double-delivery** — no `mark_local_event()` dedup, so single-node deploys could deliver the same event twice (once via direct fan-out from Redis subscriber, once from the Redis round-trip)
3. **Race conditions** — typing events arriving out of order relative to actual messages

Additionally, the frontend timing constants were too tight for the backend's 3-second typing refresh interval.

## Changes

### Backend — `crates/sprout-relay/src/handlers/event.rs`
- Added `mark_local_event()` before Redis publish for ephemeral events (prevents double-delivery)
- Added cache invalidation on Redis publish failure (matches `dispatch_persistent_event` pattern)
- Added direct `sub_registry.fan_out()` to local WS subscribers (matches presence event pattern)

### Frontend — `desktop/src/features/messages/useChannelTyping.ts`
- `TYPING_INDICATOR_TTL_MS`: 5,500ms → 8,000ms (5s buffer for Redis latency vs previous 2.5s)
- `TYPING_POST_MESSAGE_SUPPRESS_MS`: 4,000ms → 2,000ms (reduces false "stopped working" gaps)

## Testing
- `cargo fmt` ✅
- `cargo clippy -D warnings` ✅
- 148/148 relay unit tests ✅

## Follow-up
The fan-out block (StoredEvent → fan_out → serialize → send loop → drop warning) is now duplicated 3 times in `event.rs`. Could be extracted into a helper function in a future cleanup PR.