### PR TITLE
feat: show agent type in user profile popover card

### DIFF
--- a/crates/sprout-cli/src/commands/users.rs
+++ b/crates/sprout-cli/src/commands/users.rs
@@ -108,6 +108,7 @@ pub async fn cmd_set_profile(
         merged_picture.as_deref(),
         merged_about.as_deref(),
         merged_nip05.as_deref(),
+        None, // agent_type — not exposed by CLI
     )
     .map_err(|e| CliError::Other(format!("build_profile failed: {e}")))?;
 

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -485,6 +485,7 @@ impl Db {
         avatar_url: Option<&str>,
         about: Option<&str>,
         nip05_handle: Option<&str>,
+        agent_type: Option<&str>,
     ) -> Result<()> {
         user::update_user_profile(
             &self.pool,
@@ -493,6 +494,7 @@ impl Db {
             avatar_url,
             about,
             nip05_handle,
+            agent_type,
         )
         .await
     }

--- a/crates/sprout-db/src/user.rs
+++ b/crates/sprout-db/src/user.rs
@@ -96,6 +96,7 @@ pub async fn update_user_profile(
     avatar_url: Option<&str>,
     about: Option<&str>,
     nip05_handle: Option<&str>,
+    agent_type: Option<&str>,
 ) -> Result<()> {
     let mut set_parts: Vec<String> = Vec::new();
     let mut param_idx = 1u32;
@@ -114,6 +115,10 @@ pub async fn update_user_profile(
     }
     if nip05_handle.is_some() {
         set_parts.push(format!("nip05_handle = ${param_idx}"));
+        param_idx += 1;
+    }
+    if agent_type.is_some() {
+        set_parts.push(format!("agent_type = ${param_idx}"));
         param_idx += 1;
     }
 
@@ -144,6 +149,9 @@ pub async fn update_user_profile(
     }
     if nip05_handle.is_some() {
         query = query.bind(empty_to_none(nip05_handle));
+    }
+    if agent_type.is_some() {
+        query = query.bind(empty_to_none(agent_type));
     }
     query = query.bind(pubkey);
     query.execute(pool).await?;

--- a/crates/sprout-mcp/src/server.rs
+++ b/crates/sprout-mcp/src/server.rs
@@ -2084,10 +2084,11 @@ with kind:45003 comments)."
             .as_deref()
             .or_else(|| current_profile.get("nip05_handle").and_then(|v| v.as_str()));
 
-        let builder = match sprout_sdk::build_profile(display_name, name, picture, about, nip05) {
-            Ok(b) => b,
-            Err(e) => return format!("Error: {e}"),
-        };
+        let builder =
+            match sprout_sdk::build_profile(display_name, name, picture, about, nip05, None) {
+                Ok(b) => b,
+                Err(e) => return format!("Error: {e}"),
+            };
         let event = match builder.sign_with_keys(self.client.keys()) {
             Ok(e) => e,
             Err(e) => return format!("Error: failed to sign profile event: {e}"),

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -581,6 +581,14 @@ async fn handle_kind0_profile(event: &Event, state: &Arc<AppState>) -> anyhow::R
 
     let about = content.get("about").and_then(|v| v.as_str()).unwrap_or("");
 
+    // Only update agent_type when explicitly present in the kind:0 JSON.
+    // Passing None leaves the existing DB value untouched, preventing data loss
+    // when clients that don't know about agent_type publish kind:0 events.
+    let agent_type = content
+        .get("agent_type")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
+
     // Validate NIP-05 handle: must be user@domain where domain matches this relay.
     // Invalid or off-domain handles are silently cleared (treated as absent) rather
     // than stored, since the event is already persisted and can't be rejected.
@@ -606,6 +614,7 @@ async fn handle_kind0_profile(event: &Event, state: &Arc<AppState>) -> anyhow::R
             Some(avatar_url),
             Some(about),
             Some(nip05_handle),
+            agent_type,
         )
         .await;
 
@@ -622,6 +631,7 @@ async fn handle_kind0_profile(event: &Event, state: &Arc<AppState>) -> anyhow::R
                     Some(avatar_url),
                     Some(about),
                     None, // skip contested NIP-05
+                    agent_type,
                 )
                 .await?;
         } else {

--- a/crates/sprout-sdk/src/builders.rs
+++ b/crates/sprout-sdk/src/builders.rs
@@ -309,6 +309,7 @@ pub fn build_profile(
     picture: Option<&str>,
     about: Option<&str>,
     nip05: Option<&str>,
+    agent_type: Option<&str>,
 ) -> Result<EventBuilder, SdkError> {
     let mut map = serde_json::Map::new();
     if let Some(v) = display_name {
@@ -325,6 +326,9 @@ pub fn build_profile(
     }
     if let Some(v) = nip05 {
         map.insert("nip05".into(), serde_json::Value::String(v.into()));
+    }
+    if let Some(v) = agent_type {
+        map.insert("agent_type".into(), serde_json::Value::String(v.into()));
     }
     let content = serde_json::Value::Object(map).to_string();
     Ok(EventBuilder::new(Kind::Custom(0), content, []))
@@ -925,6 +929,7 @@ mod tests {
                 Some("https://example.com/pic.jpg"),
                 Some("Hello world"),
                 Some("alice@example.com"),
+                Some("Goose"),
             )
             .unwrap(),
         );
@@ -933,11 +938,12 @@ mod tests {
         assert_eq!(v["display_name"], "Alice");
         assert_eq!(v["name"], "alice");
         assert_eq!(v["nip05"], "alice@example.com");
+        assert_eq!(v["agent_type"], "Goose");
     }
 
     #[test]
     fn profile_some_fields() {
-        let ev = sign(build_profile(Some("Bob"), None, None, None, None).unwrap());
+        let ev = sign(build_profile(Some("Bob"), None, None, None, None, None).unwrap());
         let v: serde_json::Value = serde_json::from_str(&ev.content).unwrap();
         assert_eq!(v["display_name"], "Bob");
         assert!(
@@ -949,7 +955,7 @@ mod tests {
 
     #[test]
     fn profile_no_fields() {
-        let ev = sign(build_profile(None, None, None, None, None).unwrap());
+        let ev = sign(build_profile(None, None, None, None, None, None).unwrap());
         let v: serde_json::Value = serde_json::from_str(&ev.content).unwrap();
         assert!(v.as_object().unwrap().is_empty());
     }

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -6,7 +6,8 @@ use crate::{
     managed_agents::{
         build_managed_agent_summary, default_token_scopes, discover_provider_candidates,
         find_managed_agent_mut, invoke_provider, load_managed_agents, load_personas,
-        managed_agent_avatar_url, managed_agent_log_path, mint_token_via_api, provider_deploy,
+        managed_agent_avatar_url, managed_agent_log_path, managed_agent_type_label,
+        mint_token_via_api, provider_deploy,
         read_log_tail, resolve_provider_binary, save_managed_agents, start_managed_agent_process,
         stop_managed_agent_process, sync_managed_agent_processes, validate_provider_config,
         BackendKind, BackendProviderInfo, CreateManagedAgentRequest, CreateManagedAgentResponse,
@@ -431,6 +432,7 @@ pub async fn create_managed_agent(
         .filter(|value| !value.is_empty())
         .map(str::to_string)
         .or_else(|| managed_agent_avatar_url(agent.agent_command.as_str()));
+    let agent_type_label = managed_agent_type_label(agent.agent_command.as_str());
     let profile_sync_error = (sync_managed_agent_profile(
         &state,
         &resolved_relay_url,
@@ -439,6 +441,7 @@ pub async fn create_managed_agent(
         &token_scopes,
         &name,
         avatar_url.as_deref(),
+        agent_type_label,
     )
     .await)
         .err();

--- a/desktop/src-tauri/src/commands/profile.rs
+++ b/desktop/src-tauri/src/commands/profile.rs
@@ -60,7 +60,7 @@ pub async fn update_profile(
         .as_deref()
         .or_else(|| current.get("nip05_handle").and_then(|v| v.as_str()));
 
-    let builder = events::build_profile(dn, name, picture, ab, nip05)?;
+    let builder = events::build_profile(dn, name, picture, ab, nip05, None)?;
     submit_event(builder, &state).await?;
 
     // Re-fetch to return the canonical profile the frontend expects.

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -318,6 +318,7 @@ pub fn build_profile(
     picture: Option<&str>,
     about: Option<&str>,
     nip05: Option<&str>,
+    agent_type: Option<&str>,
 ) -> Result<EventBuilder, String> {
     let mut map = serde_json::Map::new();
     if let Some(v) = display_name {
@@ -334,6 +335,9 @@ pub fn build_profile(
     }
     if let Some(v) = nip05 {
         map.insert("nip05".into(), serde_json::Value::String(v.into()));
+    }
+    if let Some(v) = agent_type {
+        map.insert("agent_type".into(), serde_json::Value::String(v.into()));
     }
     let content = serde_json::Value::Object(map).to_string();
     Ok(EventBuilder::new(Kind::Custom(0), content))

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -273,6 +273,12 @@ pub fn managed_agent_avatar_url(command: &str) -> Option<String> {
     Some(provider.avatar_url.to_string())
 }
 
+/// Return the human-readable agent type label (e.g. "Goose", "Claude Code",
+/// "Codex") for a given agent command, if it matches a known ACP provider.
+pub fn managed_agent_type_label(command: &str) -> Option<&'static str> {
+    known_acp_provider(command).map(|p| p.label)
+}
+
 pub fn default_token_scopes() -> Vec<String> {
     vec![
         "messages:read".to_string(),

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -67,9 +67,11 @@ pub async fn sync_managed_agent_profile(
     token_scopes: &[String],
     display_name: &str,
     avatar_url: Option<&str>,
+    agent_type: Option<&str>,
 ) -> Result<(), String> {
     // Build a kind:0 profile event signed by the agent's keys.
-    let builder = crate::events::build_profile(Some(display_name), None, avatar_url, None, None)?;
+    let builder =
+        crate::events::build_profile(Some(display_name), None, avatar_url, None, None, agent_type)?;
 
     // Sign with the agent's keys (not the desktop user's).
     let event = builder

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -142,8 +142,9 @@ export function useManagedAgentPrereqsQuery(
   });
 }
 
-export function useRelayAgentsQuery() {
+export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
   return useQuery({
+    enabled: options?.enabled ?? true,
     queryKey: relayAgentsQueryKey,
     queryFn: listRelayAgents,
     staleTime: 30_000,

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 
+import { useRelayAgentsQuery } from "@/features/agents/hooks";
 import { useUserProfileQuery } from "@/features/profile/hooks";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import { PresenceBadge } from "@/features/presence/ui/PresenceBadge";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
@@ -24,13 +26,26 @@ export function UserProfilePopover({
   pubkey,
 }: UserProfilePopoverProps) {
   const [open, setOpen] = React.useState(false);
+  const normalizedPubkey = React.useMemo(
+    () => normalizePubkey(pubkey),
+    [pubkey],
+  );
   const profileQuery = useUserProfileQuery(open ? pubkey : undefined);
   const presenceQuery = usePresenceQuery(open ? [pubkey] : [], {
     enabled: open,
   });
+  const relayAgentsQuery = useRelayAgentsQuery({ enabled: open });
 
   const profile = profileQuery.data;
   const presenceStatus = presenceQuery.data?.[pubkey.toLowerCase()];
+  const agentType = React.useMemo(() => {
+    const agent = relayAgentsQuery.data?.find(
+      (candidate) => normalizePubkey(candidate.pubkey) === normalizedPubkey,
+    );
+    const nextAgentType = agent?.agentType?.trim();
+
+    return nextAgentType ? nextAgentType : null;
+  }, [normalizedPubkey, relayAgentsQuery.data]);
 
   return (
     <Popover onOpenChange={setOpen} open={open}>
@@ -57,6 +72,15 @@ export function UserProfilePopover({
               <p className="truncate text-sm font-semibold">
                 {profile?.displayName ?? truncatePubkey(pubkey)}
               </p>
+              {agentType ? (
+                <span
+                  className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
+                  data-testid="user-profile-agent-type"
+                >
+                  <span aria-hidden="true">🤖</span>
+                  {agentType}
+                </span>
+              ) : null}
               {profile?.nip05Handle ? (
                 <p className="truncate text-xs text-muted-foreground">
                   {profile.nip05Handle}


### PR DESCRIPTION
## Summary

When you click on an avatar or username, the popover card now shows the agent type (Goose, Claude Code, Codex) as a 🤖 badge right below the display name.

## What changed (13 files, +78/-10)

### Relay (sprout-db + sprout-relay)
- `update_user_profile()` now accepts `agent_type: Option<&str>`
- `handle_kind0_profile()` extracts `agent_type` from kind:0 JSON and writes it to the DB
- **Only writes when present** — clients that don't include `agent_type` in kind:0 events won't clobber existing values

### SDK (sprout-sdk)
- `build_profile()` accepts optional `agent_type` parameter
- Updated tests to cover the new field

### Tauri Desktop
- `sync_managed_agent_profile()` passes agent type through to kind:0 events
- New `managed_agent_type_label()` helper derives human-readable labels from agent commands (goose → "Goose", claude-agent-acp → "Claude Code", codex-acp → "Codex")
- `build_profile()` includes `agent_type` in kind:0 JSON content

### Desktop UI
- `UserProfilePopover` queries relay agents and resolves agent type by pubkey
- Agent type rendered as a styled pill badge with 🤖 emoji
- `useRelayAgentsQuery` now accepts `{ enabled }` option for lazy loading

### Callers updated
- `sprout-mcp` server → passes `None` (MCP set-profile tool)
- `sprout-cli` → passes `None` (CLI profile command)
- `commands/profile.rs` → passes `None` (human user profiles)

## How it works end-to-end
1. Agent creation → Tauri derives type label from command via known provider registry
2. Profile sync → kind:0 event includes `agent_type` in JSON content
3. Relay storage → kind:0 handler extracts and writes to `users.agent_type` (column already exists)
4. UI display → `UserProfilePopover` shows 🤖 badge when agent type is available

## Testing
- All Rust crates compile ✅
- 50 SDK unit tests pass ✅ (including new agent_type coverage)
- Biome lint clean ✅
- Desktop TypeScript build clean ✅
- `just ci` equivalent pre-push hooks all pass ✅

## Review notes
- No DB migration needed — `users.agent_type` column already exists in base schema
- Backward compatible — existing agents without agent_type continue to work (field stays NULL)
- Data-loss protection — kind:0 events without `agent_type` field won't clear existing values