### PR TITLE
fix(desktop): allow adding agents in open channels

### DIFF
--- a/desktop/src/features/channels/ui/ChannelMembersBar.tsx
+++ b/desktop/src/features/channels/ui/ChannelMembersBar.tsx
@@ -75,10 +75,12 @@ export function ChannelMembersBar({
     members.find(
       (member) => normalizePubkey(member.pubkey) === normalizedCurrentPubkey,
     ) ?? null;
+  const canManageMembers =
+    selfMember?.role === "owner" || selfMember?.role === "admin";
   const canAddAgents =
     channel.channelType !== "dm" &&
     channel.archivedAt === null &&
-    (selfMember?.role === "owner" || selfMember?.role === "admin");
+    (channel.visibility === "open" || canManageMembers);
   const managedAgentPubkeys = React.useMemo(
     () => new Set(managedAgents.map((agent) => normalizePubkey(agent.pubkey))),
     [managedAgents],

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -378,6 +378,21 @@ test("manage channel can invite and remove members", async ({ page }) => {
   ).toHaveCount(0);
 });
 
+test("open-channel members can add agents from the header", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+
+  const addAgentTrigger = page.getByTestId("channel-add-bot-trigger");
+  await expect(addAgentTrigger).toBeEnabled();
+
+  await addAgentTrigger.click();
+  await expect(page.getByRole("heading", { name: "Add agents" })).toBeVisible();
+});
+
 test("open channel management supports join and leave", async ({ page }) => {
   await page.goto("/");
 


### PR DESCRIPTION
## Summary
- allow the channel header add-agent button for open channels instead of limiting it to owners/admins
- keep the existing restrictions for private channels, archived channels, and DMs
- add a regression test covering a regular member opening the Add agents dialog from an open channel header

## Validation
- cd desktop && pnpm check
- cd desktop && pnpm typecheck
- cd desktop && pnpm test:e2e:smoke tests/e2e/channels.spec.ts -g "open-channel members can add agents from the header"
- pre-push hook: desktop-check, desktop-build, desktop-tauri-check, rust-fmt, rust-clippy, rust-tests