### PR TITLE
fix(desktop): ensure all agent dialogs scroll content and keep footer visible

### DIFF
--- a/desktop/src/features/agents/ui/AddAgentToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddAgentToChannelDialog.tsx
@@ -112,7 +112,7 @@ export function AddAgentToChannelDialog({
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent className="max-w-xl overflow-hidden p-0">
         <div className="flex max-h-[85vh] flex-col">
-          <DialogHeader className="border-b border-border/60 px-6 py-5 pr-14">
+          <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
             <DialogTitle>Add agent to channel</DialogTitle>
             <DialogDescription>
               Add {agent?.name ?? "this agent"} to a channel so desktop chat can
@@ -122,7 +122,7 @@ export function AddAgentToChannelDialog({
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-5 px-6 py-5">
+          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-5">
             <div className="space-y-1.5">
               <label className="text-sm font-medium" htmlFor="agent-channel-id">
                 Channel
@@ -208,7 +208,7 @@ export function AddAgentToChannelDialog({
             ) : null}
           </div>
 
-          <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
+          <div className="flex shrink-0 justify-end gap-2 border-t border-border/60 px-6 py-4">
             <Button
               onClick={() => handleOpenChange(false)}
               size="sm"

--- a/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
@@ -153,7 +153,7 @@ export function AddTeamToChannelDialog({
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent className="max-w-xl overflow-hidden p-0">
         <div className="flex max-h-[85vh] flex-col">
-          <DialogHeader className="border-b border-border/60 px-6 py-5 pr-14">
+          <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
             <DialogTitle>Deploy team to channel</DialogTitle>
             <DialogDescription>
               Create and attach one agent per persona in{" "}
@@ -162,7 +162,7 @@ export function AddTeamToChannelDialog({
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-5 px-6 py-5">
+          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-5">
             {resolved.length > 0 ? (
               <div className="space-y-1.5">
                 <span className="text-sm font-medium">
@@ -267,7 +267,7 @@ export function AddTeamToChannelDialog({
             ) : null}
           </div>
 
-          <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
+          <div className="flex shrink-0 justify-end gap-2 border-t border-border/60 px-6 py-4">
             <Button
               onClick={() => handleOpenChange(false)}
               size="sm"

--- a/desktop/src/features/agents/ui/BatchImportDialog.tsx
+++ b/desktop/src/features/agents/ui/BatchImportDialog.tsx
@@ -131,7 +131,7 @@ export function BatchImportDialog({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-2xl overflow-hidden p-0">
         <div className="flex max-h-[85vh] flex-col">
-          <DialogHeader className="border-b border-border/60 px-6 py-5 pr-14">
+          <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
             <DialogTitle>Import Personas</DialogTitle>
             <DialogDescription>
               Found {personas.length} persona
@@ -139,7 +139,7 @@ export function BatchImportDialog({
             </DialogDescription>
           </DialogHeader>
 
-          <div className="flex-1 overflow-y-auto px-6 py-4">
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
             <div className="space-y-1">
               {personas.map((persona, index) => {
                 const isExpanded = expandedIndex === index;
@@ -245,7 +245,7 @@ export function BatchImportDialog({
             ) : null}
           </div>
 
-          <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
+          <div className="flex shrink-0 justify-end gap-2 border-t border-border/60 px-6 py-4">
             <Button
               onClick={() => onOpenChange(false)}
               size="sm"

--- a/desktop/src/features/agents/ui/CreateAgentDialog.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialog.tsx
@@ -384,7 +384,7 @@ export function CreateAgentDialog({
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent className="max-w-3xl overflow-hidden p-0">
         <div className="flex max-h-[85vh] flex-col">
-          <DialogHeader className="border-b border-border/60 px-6 py-5 pr-14">
+          <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
             <DialogTitle>Create agent</DialogTitle>
             <DialogDescription>
               This creates a local agent identity, syncs its display name when
@@ -393,7 +393,7 @@ export function CreateAgentDialog({
             </DialogDescription>
           </DialogHeader>
 
-          <div className="flex-1 space-y-5 overflow-y-auto px-6 py-5">
+          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-5">
             <CreateAgentBasicsFields name={name} onNameChange={setName} />
 
             {/* Run on selector — only shown when backend providers are discovered */}
@@ -573,7 +573,7 @@ export function CreateAgentDialog({
             ) : null}
           </div>
 
-          <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
+          <div className="flex shrink-0 justify-end gap-2 border-t border-border/60 px-6 py-4">
             <Button
               onClick={() => handleOpenChange(false)}
               size="sm"

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -101,12 +101,12 @@ export function PersonaDialog({
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent className="max-w-2xl overflow-hidden p-0">
         <div className="flex max-h-[85vh] flex-col">
-          <DialogHeader className="border-b border-border/60 px-6 py-5 pr-14">
+          <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
             <DialogTitle>{title}</DialogTitle>
             <DialogDescription>{description}</DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-5 overflow-y-auto px-6 py-5">
+          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-5">
             <div className="space-y-1.5">
               <label
                 className="text-sm font-medium"
@@ -219,7 +219,7 @@ export function PersonaDialog({
             ) : null}
           </div>
 
-          <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
+          <div className="flex shrink-0 justify-end gap-2 border-t border-border/60 px-6 py-4">
             <Button
               onClick={() => handleOpenChange(false)}
               size="sm"

--- a/desktop/src/features/agents/ui/TeamDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamDialog.tsx
@@ -100,12 +100,12 @@ export function TeamDialog({
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent className="max-w-2xl overflow-hidden p-0">
         <div className="flex max-h-[85vh] flex-col">
-          <DialogHeader className="border-b border-border/60 px-6 py-5 pr-14">
+          <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
             <DialogTitle>{title}</DialogTitle>
             <DialogDescription>{description}</DialogDescription>
           </DialogHeader>
 
-          <div className="flex-1 space-y-5 overflow-y-auto px-6 py-5">
+          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-5">
             <div className="space-y-1.5">
               <label className="text-sm font-medium" htmlFor="team-name">
                 Name
@@ -205,7 +205,7 @@ export function TeamDialog({
             ) : null}
           </div>
 
-          <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
+          <div className="flex shrink-0 justify-end gap-2 border-t border-border/60 px-6 py-4">
             <Button
               onClick={() => handleOpenChange(false)}
               size="sm"


### PR DESCRIPTION
## Summary
- Adds `min-h-0`, `flex-1`, and `overflow-y-auto` to the scrollable content area of all 6 agent dialog components so tall content scrolls instead of pushing the footer off-screen
- Adds `shrink-0` to dialog headers and footers to prevent them from collapsing under flex pressure
- Aligns all dialogs with the existing `TeamImportDialog` reference pattern (the only one that was already correct)

**Files changed:** `CreateAgentDialog`, `AddAgentToChannelDialog`, `PersonaDialog`, `TeamDialog`, `AddTeamToChannelDialog`, `BatchImportDialog`

## Test plan
- [ ] Open the Create Agent dialog and expand the Advanced section — content should scroll, footer stays pinned
- [ ] Open the Add Agent to Channel dialog with a long description — footer remains visible
- [ ] Open the Persona dialog with a long system prompt — content scrolls properly
- [ ] Open the Team dialog with many personas — content scrolls, footer stays pinned
- [ ] Open the Deploy Team to Channel dialog with many personas — footer remains visible
- [ ] Open the Batch Import dialog with many personas — content scrolls properly
- [ ] Resize browser window to small height — all dialogs cap at 85vh and scroll internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)