### PR TITLE
fix(desktop): refresh DM sidebar in real-time when new messages arrive

### DIFF
--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { updateChannelLastMessageAt } from "@/features/channels/hooks";
+import {
+  channelsQueryKey,
+  updateChannelLastMessageAt,
+} from "@/features/channels/hooks";
 import { getChannelIdFromTags } from "@/features/messages/lib/threading";
 import { mergeTimelineCacheMessages } from "@/features/messages/hooks";
 import { relayClient } from "@/shared/api/relayClient";
@@ -180,11 +183,12 @@ export function useUnreadChannels(
 
   const handleIncomingMessage = React.useEffectEvent((event: RelayEvent) => {
     const channelId = getChannelIdFromTags(event.tags);
-    if (
-      !channelId ||
-      channelId === activeChannelId ||
-      !liveChannelIds.has(channelId)
-    ) {
+    if (!channelId || channelId === activeChannelId) {
+      return;
+    }
+
+    if (!liveChannelIds.has(channelId)) {
+      void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
       return;
     }
 
@@ -202,6 +206,12 @@ export function useUnreadChannels(
       },
     );
   });
+
+  React.useEffect(() => {
+    return relayClient.subscribeToReconnects(() => {
+      void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+    });
+  }, [queryClient]);
 
   React.useEffect(() => {
     if (liveChannelIds.size === 0) {


### PR DESCRIPTION
## Summary
- When a WebSocket event arrives for a DM channel not yet in the sidebar, immediately invalidate the channels query so the sidebar refetches and picks up the new DM
- Also invalidate channels on relay reconnect to catch DMs missed during connection drops
- Root cause: the channel list only polled every 60s, and events for unknown channels were silently dropped in `useUnreadChannels`

## Test plan
- [x] Open the app with user A, have user B send a brand new DM to user A — verify the DM appears in A's sidebar without restarting
- [x] Disconnect from the network briefly, have someone send a DM during the disconnect, reconnect — verify the DM appears
- [x] Verify existing unread indicators still work for known channels
- [x] Verify no excessive network requests when receiving messages (React Query deduplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)