### PR TITLE
Set the desktop release relay default

### DIFF
--- a/.github/workflows/sprout-desktop-release.yml
+++ b/.github/workflows/sprout-desktop-release.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
     env:
       RELEASE_VERSION: '' # set in the "Extract version from tag" step
+      SPROUT_RELAY_URL: wss://sprout-oss.stage.blox.sqprod.co
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/desktop/RELEASING.md
+++ b/desktop/RELEASING.md
@@ -130,9 +130,12 @@ and signature for the latest version.
 
 The app connects to the relay via the `SPROUT_RELAY_URL` environment variable.
 
-- **Release builds**: Set this to the production relay URL (e.g.
-  `wss://relay.sprout.example.com`). Configure it in the environment before
-  building, or set it in the CI workflow.
+- **Production releases**: The GitHub release workflow currently builds the app
+  with `SPROUT_RELAY_URL=wss://sprout-oss.stage.blox.sqprod.co`, which is baked
+  into the release binary as its default relay URL.
+- **Local release builds**: Export `SPROUT_RELAY_URL` before running
+  `just desktop-release-build` if you want a non-localhost relay URL compiled
+  into the app.
 - **Development**: If not set, it defaults to `ws://localhost:3000`.
 
 ---

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,3 +1,14 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=SPROUT_RELAY_URL");
+    println!("cargo:rerun-if-env-changed=SPROUT_RELAY_HTTP");
+
+    if let Ok(relay_url) = std::env::var("SPROUT_RELAY_URL") {
+        println!("cargo:rustc-env=SPROUT_DESKTOP_BUILD_RELAY_URL={relay_url}");
+    }
+
+    if let Ok(relay_http) = std::env::var("SPROUT_RELAY_HTTP") {
+        println!("cargo:rustc-env=SPROUT_DESKTOP_BUILD_RELAY_HTTP={relay_http}");
+    }
+
     tauri_build::build()
 }

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -7,8 +7,19 @@ use sha2::{Digest, Sha256};
 
 use crate::app_state::AppState;
 
+const DEFAULT_RELAY_WS_URL: &str = "ws://localhost:3000";
+
+fn configured_env_var(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
 pub fn relay_ws_url() -> String {
-    std::env::var("SPROUT_RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string())
+    configured_env_var("SPROUT_RELAY_URL")
+        .or_else(|| option_env!("SPROUT_DESKTOP_BUILD_RELAY_URL").map(str::to_string))
+        .unwrap_or_else(|| DEFAULT_RELAY_WS_URL.to_string())
 }
 
 pub fn relay_http_base_url(relay_url: &str) -> String {
@@ -26,7 +37,11 @@ pub fn relay_http_base_url(relay_url: &str) -> String {
 }
 
 pub fn relay_api_base_url() -> String {
-    if let Ok(base) = std::env::var("SPROUT_RELAY_HTTP") {
+    if let Some(base) = configured_env_var("SPROUT_RELAY_HTTP") {
+        return base.trim_end_matches('/').to_string();
+    }
+
+    if let Some(base) = option_env!("SPROUT_DESKTOP_BUILD_RELAY_HTTP") {
         return base.trim().trim_end_matches('/').to_string();
     }
 


### PR DESCRIPTION
## Summary
- bake the desktop release relay URL into production desktop builds while preserving runtime overrides
- set the desktop release workflow to use the stage relay URL
- update the release docs to describe the shipped default

## Testing
- cargo fmt --all --check
- cargo check --manifest-path desktop/src-tauri/Cargo.toml
- pnpm check
- cargo check --manifest-path desktop/src-tauri/Cargo.toml
- pnpm build
- cargo clippy --workspace --all-targets -- -D warnings
- ./scripts/run-tests.sh unit