### PR TITLE
Fix desktop release updater signing flow

### DIFF
--- a/desktop/RELEASING.md
+++ b/desktop/RELEASING.md
@@ -74,7 +74,7 @@ The `sprout-desktop-release.yml` workflow:
    `Cargo.toml` using `set-version-from-tag.mjs`.
 3. **Regenerates `Cargo.lock`** to match the patched `Cargo.toml`.
 4. **Validates** all required secrets are present.
-5. **Builds** the release config with signing and updater settings.
+5. **Builds** the release config with the updater public key and endpoint.
 6. **Builds** the Tauri app (unsigned).
 7. **Signs and notarizes** the macOS bundle via `block/apple-codesign-action`.
 8. **Re-packages** the signed app into a DMG and updater archive.
@@ -89,7 +89,7 @@ The `sprout-desktop-release.yml` workflow:
 
 Local builds will not be codesigned or notarized — that only happens in CI
 via `block/apple-codesign-action`. Local builds are useful for testing the
-updater config and DMG packaging.
+updater runtime config and DMG packaging.
 
 ```bash
 # Set updater env vars
@@ -167,3 +167,8 @@ tag drives the version.
 - **Build failures**: If versions are wrong, check that the tag follows the
   format `desktop/v<semver>` (e.g. `desktop/v0.3.0`). CI extracts the version
   from the tag automatically.
+
+- **"A public key has been found, but no private key"**: The Tauri build should
+  not require `TAURI_SIGNING_PRIVATE_KEY`. If you see this, the build is trying
+  to generate updater artifacts before the signed app bundle exists. The updater
+  archive is supposed to be created and signed later from the notarized app.

--- a/desktop/scripts/build-release-config.mjs
+++ b/desktop/scripts/build-release-config.mjs
@@ -13,17 +13,13 @@ const baseConfig = JSON.parse(readFileSync(baseConfigPath, "utf-8"));
 
 const releaseConfig = { ...baseConfig };
 
-releaseConfig.bundle = {
-  ...(releaseConfig.bundle ?? baseConfig.bundle ?? {}),
-  createUpdaterArtifacts: "v1Compatible",
-};
-
 releaseConfig.bundle.macOS = {
   ...(releaseConfig.bundle?.macOS ?? baseConfig.bundle?.macOS ?? {}),
   minimumSystemVersion: "10.15",
 };
 
 if (publicKey && endpoint) {
+  // Build-time updater artifacts are created later from the signed app bundle.
   releaseConfig.plugins = {
     ...(baseConfig.plugins ?? {}),
     updater: {


### PR DESCRIPTION
## Summary
- stop generating Tauri updater artifacts during the initial desktop release build
- keep the generated release config limited to updater runtime settings and macOS minimum version
- document that updater archives are created and signed later from the notarized app bundle

## Why
The tagged desktop release workflow already rebuilds `Sprout.app.tar.gz` from the signed/notarized app and signs it afterward. Asking Tauri to also create updater artifacts during `tauri build` was redundant and caused release builds to fail when only the updater public key was present at build time.

Canary is unaffected because it uses the default Tauri build path and does not consume `tauri.release.conf.json`.

## Testing
- `cd desktop && SPROUT_UPDATER_PUBLIC_KEY=test-public-key SPROUT_UPDATER_ENDPOINT=https://example.com/latest.json pnpm run tauri:release:config`
- `git push` pre-push checks passed: `desktop-check`, `desktop-build`, `desktop-tauri-check`, `cargo clippy --workspace --all-targets -- -D warnings`, `./scripts/run-tests.sh unit`