### PR TITLE
Remove hardcoded internal relay URL from release workflow

### DIFF
--- a/.github/workflows/sprout-desktop-release.yml
+++ b/.github/workflows/sprout-desktop-release.yml
@@ -17,7 +17,6 @@ jobs:
       contents: write
     env:
       RELEASE_VERSION: '' # set in the "Extract version from tag" step
-      SPROUT_RELAY_URL: wss://sprout-oss.stage.blox.sqprod.co
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -46,6 +45,7 @@ jobs:
 
       - name: Validate release secrets
         env:
+          SPROUT_RELAY_URL: ${{ secrets.SPROUT_RELAY_URL }}
           SPROUT_UPDATER_PUBLIC_KEY: ${{ secrets.SPROUT_UPDATER_PUBLIC_KEY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -54,6 +54,7 @@ jobs:
         run: |
           missing=()
           for name in \
+            SPROUT_RELAY_URL \
             SPROUT_UPDATER_PUBLIC_KEY \
             TAURI_SIGNING_PRIVATE_KEY \
             TAURI_SIGNING_PRIVATE_KEY_PASSWORD \
@@ -82,6 +83,8 @@ jobs:
 
       - name: Build Tauri app
         working-directory: desktop
+        env:
+          SPROUT_RELAY_URL: ${{ secrets.SPROUT_RELAY_URL }}
         run: pnpm tauri build --config src-tauri/tauri.release.conf.json
 
       - name: Codesign and Notarize

--- a/desktop/RELEASING.md
+++ b/desktop/RELEASING.md
@@ -12,6 +12,7 @@ release:
 
 | Secret                             | Description                                                        |
 | ---------------------------------- | ------------------------------------------------------------------ |
+| `SPROUT_RELAY_URL`                 | WebSocket relay URL baked into the release binary (for example `wss://...`) |
 | `SPROUT_UPDATER_PUBLIC_KEY`        | Tauri updater public key (generate with `pnpm tauri signer generate`) |
 | `TAURI_SIGNING_PRIVATE_KEY`        | Tauri updater private key                                          |
 | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the private key                                     |
@@ -130,9 +131,9 @@ and signature for the latest version.
 
 The app connects to the relay via the `SPROUT_RELAY_URL` environment variable.
 
-- **Production releases**: The GitHub release workflow currently builds the app
-  with `SPROUT_RELAY_URL=wss://sprout-oss.stage.blox.sqprod.co`, which is baked
-  into the release binary as its default relay URL.
+- **Production releases**: The GitHub release workflow builds the app with
+  `SPROUT_RELAY_URL` sourced from the `SPROUT_RELAY_URL` repository secret,
+  which is baked into the release binary as its default relay URL.
 - **Local release builds**: Export `SPROUT_RELAY_URL` before running
   `just desktop-release-build` if you want a non-localhost relay URL compiled
   into the app.


### PR DESCRIPTION
## Summary
- remove the hardcoded internal staging relay URL from `.github/workflows/sprout-desktop-release.yml`
- require `SPROUT_RELAY_URL` from GitHub Actions secrets and scope it to the validation and Tauri build steps
- update `desktop/RELEASING.md` to document the new secret requirement and baked-in relay behavior

## Testing
- `/bin/zsh -lc 'source ./bin/activate-hermit && /usr/bin/time -p just ci'`

## Notes
- `SPROUT_RELAY_URL` must exist as a repo or org Actions secret before the tagged desktop release workflow can pass.