### PR TITLE
docs: mention just build in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Hermit pins Rust, Node.js, pnpm, `just`, and related tooling from `bin/`.
 ```bash
 cp .env.example .env
 just setup
+just build
 ```
 
 `just setup` does the heavy lifting:
@@ -138,6 +139,8 @@ just setup
 - Waits for all services to be healthy
 - Runs database migrations
 - Installs desktop dependencies (`pnpm install`)
+
+Then run `just build` once to compile the Rust workspace so binaries like `sprout-acp` and `sprout-mcp-server` are available when you start connecting agents.
 
 **3. Start the relay and desktop app**
 


### PR DESCRIPTION
## Summary
- add `just build` to the Quick Start flow immediately after `just setup`
- explain that this first build step is needed so binaries like `sprout-acp` and `sprout-mcp-server` are available when connecting agents

## Testing
- `cargo fmt --all -- --check`
- `cd desktop && pnpm check`
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- `cd desktop && pnpm build`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `./scripts/run-tests.sh unit`