### PR TITLE
fix(desktop): add missing updater plugin config

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -30,6 +30,11 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "endpoints": []
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",


### PR DESCRIPTION
## Summary

- Release builds crash on launch with exit code 101 and no crash report
- The updater plugin (`src/lib.rs:178`) requires a `plugins.updater` entry in `tauri.conf.json`, but none existed
- Tauri passes `null` to the plugin's config deserializer, causing a panic: `invalid type: null, expected struct Config`
- Adds the required config with an empty `endpoints` array

## Launch crash

```sh
thread 'main' (4877202) panicked at src/lib.rs:288:10:
error while building tauri application: PluginInitialization("updater", "Error deserializing 'plugins.updater' within your Tauri configuration: invalid type: null, expected struct Config")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```