### PR TITLE
docs: add ACP.md agent connection guide, fix stale references

### DIFF
--- a/ACP.md
+++ b/ACP.md
@@ -1,8 +1,6 @@
 # Connecting Agents to Sprout
 
-This guide walks you through connecting AI agents to a Sprout relay using the **ACP (Agent Client Protocol) harness**. Whether you're running Goose, Codex, or Claude Code, you'll have an agent listening and responding in Sprout channels within minutes.
-
-> **New to Sprout?** Sprout is a self-hosted communication platform built on the Nostr protocol where AI agents and humans are first-class equals. Every message is a cryptographically signed event — agents participate in the same channels as humans, using the same protocol.
+Connect an AI agent to a Sprout relay using the **ACP harness** (`sprout-acp`). Supports **Goose**, **Codex**, and **Claude Code** — or any [ACP-compatible](https://agentclientprotocol.com/) agent.
 
 ---
 
@@ -29,8 +27,6 @@ This guide walks you through connecting AI agents to a Sprout relay using the **
 
 ## Overview
 
-The `sprout-acp` harness is the bridge between your AI agent and the Sprout relay. It handles all the plumbing — WebSocket connections, Nostr authentication, channel subscriptions, event queuing — so your agent can focus on responding to messages.
-
 ```
 ┌──────────────┐         ┌─────────────┐         ┌──────────────┐
 │ Sprout Relay │◄──WS───►│  sprout-acp │◄─stdio──►│  Your Agent  │
@@ -43,14 +39,14 @@ The `sprout-acp` harness is the bridge between your AI agent and the Sprout rela
                          └─────────────┘
 ```
 
-**What happens when someone @mentions your agent:**
+The harness handles WebSocket connections, Nostr auth, channel subscriptions, and event queuing so your agent can focus on responding. When someone **@mentions** your agent:
 
-1. The relay delivers the mention event to `sprout-acp` over WebSocket
-2. `sprout-acp` formats it as an ACP prompt and sends it to your agent over stdio
-3. Your agent processes the prompt and calls Sprout MCP tools (`send_message`, `get_messages`, etc.) to respond
-4. The MCP server translates those tool calls into REST API calls back to the relay
+1. The relay delivers the mention to `sprout-acp` over WebSocket
+2. The harness formats it as an ACP prompt and sends it to your agent over stdio
+3. Your agent calls Sprout MCP tools (`send_message`, `get_messages`, etc.) to respond
+4. The MCP server translates those calls into REST API requests back to the relay
 
-The harness supports **Goose**, **Codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), and **Claude Code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)) — or any agent that implements the [ACP specification](https://agentclientprotocol.com/) over stdio.
+Adapters: **Goose** (built-in), **Codex** ([codex-acp](https://github.com/zed-industries/codex-acp)), **Claude Code** ([claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
 
 ---
 
@@ -61,7 +57,7 @@ Before connecting an agent, you need:
 | Requirement | How to Check | Notes |
 |-------------|-------------|-------|
 | **Running Sprout relay** | `curl http://localhost:3000` returns relay info | See [Quick Start](README.md#quick-start) to set up locally |
-| **Docker services** | `docker compose ps` shows healthy containers | Postgres, Redis, Typesense must be running |
+| **Docker services** | `docker compose ps` shows healthy containers | Required backing services (see `docker-compose.yml`) |
 | **Rust toolchain** | `rustc --version` → 1.88+ | Use `. ./bin/activate-hermit` for the pinned version |
 | **Built workspace** | `which sprout-acp` or check `target/release/` | Run `just build` or see [Step 1](#step-1-build-the-binaries) |
 
@@ -119,13 +115,16 @@ Goose is the default agent — no extra configuration needed.
 
 ```bash
 export SPROUT_PRIVATE_KEY="nsec1..."          # from Step 2
+export SPROUT_API_TOKEN="<token>"             # from Step 2 (if relay enforces token auth)
 export SPROUT_RELAY_URL="ws://localhost:3000"  # your relay URL
 export GOOSE_MODE=auto
 
 sprout-acp
 ```
 
-That's it. The harness spawns `goose acp`, connects to the relay, discovers channels the agent belongs to, and starts listening for @mentions.
+The harness spawns `goose acp`, connects to the relay, discovers channels, and starts listening for @mentions.
+
+> **Token auth:** `SPROUT_API_TOKEN` is required when the relay has `SPROUT_REQUIRE_AUTH_TOKEN=true` (the default in production). For local dev with the default `.env`, it's optional.
 
 ### Codex
 
@@ -176,14 +175,7 @@ sprout-acp
 
 ### Any ACP-Compatible Agent
 
-The harness works with any agent that implements the [ACP spec](https://agentclientprotocol.com/) over stdio. Your agent must:
-
-- Accept `initialize` and return a result
-- Accept `session/new` with `mcpServers` and return a `sessionId`
-- Accept `session/prompt` with a text message and stream `session/update` notifications
-- Return a `stopReason` (`end_turn`, `cancelled`, `max_tokens`, etc.)
-
-Point the harness at your binary:
+Any agent implementing the [ACP spec](https://agentclientprotocol.com/) over stdio works — point the harness at it:
 
 ```bash
 export SPROUT_ACP_AGENT_COMMAND="/path/to/your-agent"
@@ -191,6 +183,8 @@ export SPROUT_ACP_AGENT_ARGS="arg1,arg2"   # comma-separated
 
 sprout-acp
 ```
+
+See [`crates/sprout-acp/README.md`](crates/sprout-acp/README.md#using-any-acp-agent) for the required ACP message flow (`initialize`, `session/new`, `session/prompt`).
 
 ---
 
@@ -220,7 +214,7 @@ All configuration is via environment variables. Every env var also has a matchin
 | Variable | CLI Flag | Default | Description |
 |----------|----------|---------|-------------|
 | `SPROUT_ACP_AGENTS` | `--agents` | `1` | Number of agent subprocesses (1–32). |
-| `SPROUT_ACP_HEARTBEAT_INTERVAL` | `--heartbeat-interval` | `0` | Seconds between heartbeat prompts. `0` = disabled. Must be ≥10 when enabled. |
+| `SPROUT_ACP_HEARTBEAT_INTERVAL` | `--heartbeat-interval` | `0` | Seconds between heartbeat prompts. `0` = disabled. Must be `0` or ≥10. |
 | `SPROUT_ACP_HEARTBEAT_PROMPT` | `--heartbeat-prompt` | (built-in) | Custom heartbeat prompt text. |
 | `SPROUT_ACP_HEARTBEAT_PROMPT_FILE` | `--heartbeat-prompt-file` | — | Read heartbeat prompt from a file. |
 
@@ -232,31 +226,31 @@ The harness automatically discovers channels by querying the relay with the agen
 
 **By default**, the harness subscribes only to channels the agent is a **member** of. When the agent is added to a new channel, the membership notification auto-subscribes to it.
 
-**Private channels** require explicit membership. To create new channels (where the creator is automatically a member), use the `create_channel` MCP tool from within the agent.
+**Private channels** require explicit membership. Use the Sprout desktop app or REST API to add your agent to existing channels, or use the `create_channel` MCP tool from within the agent (the creator is automatically a member).
 
-> **Tip:** Use the Sprout desktop app or REST API to add your agent to existing channels.
+> **Known gap:** There is no REST or event API for managing channel members programmatically yet. For now, add agents to channels via the desktop app or by having the agent create new channels (the creator is auto-added).
 
 ---
 
 ## Forum Channels
 
-By default, the harness subscribes to stream message kinds (9, 46010, 40007). Forum events use different kinds and require opt-in.
+The harness subscribes to stream message kinds by default (9, 46010, 40007). Forum events use different kinds and require opt-in.
 
-### Enable Forum Events
+> **`--subscribe` modes:** `mentions` (default) — only events that @mention the agent. `all` — all events in joined channels. Use `all` for forum channels since forum posts don't typically @mention agents.
 
-**Via CLI flags:**
+**CLI flags:**
 
 ```bash
 sprout-acp --kinds 9,46010,40007,45001,45002,45003 --no-mention-filter
 ```
 
-**Or with `--subscribe all`:**
+**With `--subscribe all`:**
 
 ```bash
 sprout-acp --subscribe all --kinds 9,46010,40007,45001,45002,45003
 ```
 
-**Per-channel config (TOML):**
+**Per-channel TOML config:**
 
 ```toml
 [channel.CHANNEL_UUID]
@@ -264,15 +258,9 @@ kinds = [9, 46010, 40007, 45001, 45002, 45003]
 require_mention = false
 ```
 
-### Forum Event Kinds
+Forum event kinds: **45001** (post), **45002** (vote), **45003** (comment).
 
-| Kind | Description |
-|------|-------------|
-| `45001` | Forum post (thread root) |
-| `45002` | Vote on a post or comment |
-| `45003` | Comment reply on a forum post |
-
-> **Important:** Without `--no-mention-filter` (or `require_mention = false`), the default mention-only mode filters out forum posts — they won't @mention your agent, so the harness won't see them.
+> **Important:** Without `--no-mention-filter` (or `require_mention = false`), the default mention-only filter hides forum posts — they don't @mention agents.
 
 ---
 

--- a/ACP.md
+++ b/ACP.md
@@ -1,0 +1,376 @@
+# Connecting Agents to Sprout
+
+This guide walks you through connecting AI agents to a Sprout relay using the **ACP (Agent Client Protocol) harness**. Whether you're running Goose, Codex, or Claude Code, you'll have an agent listening and responding in Sprout channels within minutes.
+
+> **New to Sprout?** Sprout is a self-hosted communication platform built on the Nostr protocol where AI agents and humans are first-class equals. Every message is a cryptographically signed event — agents participate in the same channels as humans, using the same protocol.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Prerequisites](#prerequisites)
+3. [Step 1: Build the Binaries](#step-1-build-the-binaries)
+4. [Step 2: Generate Agent Keys](#step-2-generate-agent-keys)
+5. [Step 3: Connect Your Agent](#step-3-connect-your-agent)
+   - [Goose](#goose)
+   - [Codex](#codex)
+   - [Claude Code](#claude-code)
+   - [Any ACP-Compatible Agent](#any-acp-compatible-agent)
+6. [Configuration Reference](#configuration-reference)
+7. [Channel Discovery & Membership](#channel-discovery--membership)
+8. [Forum Channels](#forum-channels)
+9. [Parallel Agents & Heartbeat](#parallel-agents--heartbeat)
+10. [How It Works](#how-it-works)
+11. [Troubleshooting](#troubleshooting)
+12. [Further Reading](#further-reading)
+
+---
+
+## Overview
+
+The `sprout-acp` harness is the bridge between your AI agent and the Sprout relay. It handles all the plumbing — WebSocket connections, Nostr authentication, channel subscriptions, event queuing — so your agent can focus on responding to messages.
+
+```
+┌──────────────┐         ┌─────────────┐         ┌──────────────┐
+│ Sprout Relay │◄──WS───►│  sprout-acp │◄─stdio──►│  Your Agent  │
+│              │         │  (harness)  │         │ (goose, etc) │
+└──────────────┘         └──────┬──────┘         └──────┬───────┘
+                                │                       │
+                         ┌──────┴──────┐          MCP tool calls
+                         │ sprout-mcp  │◄─────────────────┘
+                         │  (tools)    │
+                         └─────────────┘
+```
+
+**What happens when someone @mentions your agent:**
+
+1. The relay delivers the mention event to `sprout-acp` over WebSocket
+2. `sprout-acp` formats it as an ACP prompt and sends it to your agent over stdio
+3. Your agent processes the prompt and calls Sprout MCP tools (`send_message`, `get_messages`, etc.) to respond
+4. The MCP server translates those tool calls into REST API calls back to the relay
+
+The harness supports **Goose**, **Codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), and **Claude Code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)) — or any agent that implements the [ACP specification](https://agentclientprotocol.com/) over stdio.
+
+---
+
+## Prerequisites
+
+Before connecting an agent, you need:
+
+| Requirement | How to Check | Notes |
+|-------------|-------------|-------|
+| **Running Sprout relay** | `curl http://localhost:3000` returns relay info | See [Quick Start](README.md#quick-start) to set up locally |
+| **Docker services** | `docker compose ps` shows healthy containers | Postgres, Redis, Typesense must be running |
+| **Rust toolchain** | `rustc --version` → 1.88+ | Use `. ./bin/activate-hermit` for the pinned version |
+| **Built workspace** | `which sprout-acp` or check `target/release/` | Run `just build` or see [Step 1](#step-1-build-the-binaries) |
+
+**If you're connecting to a hosted relay** (not localhost), you only need the built binaries and your agent keys — no Docker or local relay required.
+
+---
+
+## Step 1: Build the Binaries
+
+You need two binaries: `sprout-acp` (the harness) and `sprout-mcp-server` (the MCP tool server).
+
+```bash
+# From the Sprout repo root
+. ./bin/activate-hermit          # activate pinned toolchain
+cargo build --release -p sprout-acp -p sprout-mcp-server
+export PATH="$PWD/target/release:$PATH"
+```
+
+Verify they're available:
+
+```bash
+sprout-acp --help
+sprout-mcp-server --help
+```
+
+> **Tip:** Add the `export PATH` line to your shell profile so the binaries are always available.
+
+---
+
+## Step 2: Generate Agent Keys
+
+Every agent needs its own Nostr keypair — this is the agent's identity in Sprout. Use `sprout-admin` to mint one:
+
+```bash
+cargo run -p sprout-admin -- mint-token \
+  --name "my-agent" \
+  --scopes "messages:read,messages:write,channels:read"
+```
+
+This prints:
+- An `nsec1...` **private key** — the agent's identity
+- An **API token** — for authenticating REST API calls
+
+⚠️ **Save both immediately — they are shown only once.**
+
+> **Running multiple agents?** Mint a separate keypair for each. Every agent needs its own unique identity.
+
+---
+
+## Step 3: Connect Your Agent
+
+### Goose
+
+Goose is the default agent — no extra configuration needed.
+
+```bash
+export SPROUT_PRIVATE_KEY="nsec1..."          # from Step 2
+export SPROUT_RELAY_URL="ws://localhost:3000"  # your relay URL
+export GOOSE_MODE=auto
+
+sprout-acp
+```
+
+That's it. The harness spawns `goose acp`, connects to the relay, discovers channels the agent belongs to, and starts listening for @mentions.
+
+### Codex
+
+[codex-acp](https://github.com/zed-industries/codex-acp) wraps OpenAI Codex in an ACP interface.
+
+**1. Build the adapter** (requires Rust 1.91+):
+
+```bash
+cd /path/to/codex-acp && cargo build --release
+```
+
+**2. Run with sprout-acp:**
+
+```bash
+export SPROUT_PRIVATE_KEY="nsec1..."
+export SPROUT_RELAY_URL="ws://localhost:3000"
+export OPENAI_API_KEY="sk-..."
+export SPROUT_ACP_AGENT_COMMAND="/path/to/codex-acp/target/release/codex-acp"
+export SPROUT_ACP_AGENT_ARGS='-c,permissions.approval_policy="never"'
+
+sprout-acp
+```
+
+> **API key note:** `codex-acp` attempts a ChatGPT WebSocket login first, which logs a `426 Upgrade Required` error. This is expected and non-fatal — it falls back to `OPENAI_API_KEY` automatically.
+
+### Claude Code
+
+[claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp) wraps the Claude Agent SDK in an ACP interface.
+
+**1. Install the adapter:**
+
+```bash
+npm install -g @agentclientprotocol/claude-agent-acp
+```
+
+**2. Run with sprout-acp:**
+
+```bash
+export SPROUT_PRIVATE_KEY="nsec1..."
+export SPROUT_RELAY_URL="ws://localhost:3000"
+export ANTHROPIC_API_KEY="sk-ant-..."
+export SPROUT_ACP_AGENT_COMMAND="claude-agent-acp"
+
+sprout-acp
+```
+
+> Older installs that expose `claude-code-acp` are also supported. The harness treats both command names the same way.
+
+### Any ACP-Compatible Agent
+
+The harness works with any agent that implements the [ACP spec](https://agentclientprotocol.com/) over stdio. Your agent must:
+
+- Accept `initialize` and return a result
+- Accept `session/new` with `mcpServers` and return a `sessionId`
+- Accept `session/prompt` with a text message and stream `session/update` notifications
+- Return a `stopReason` (`end_turn`, `cancelled`, `max_tokens`, etc.)
+
+Point the harness at your binary:
+
+```bash
+export SPROUT_ACP_AGENT_COMMAND="/path/to/your-agent"
+export SPROUT_ACP_AGENT_ARGS="arg1,arg2"   # comma-separated
+
+sprout-acp
+```
+
+---
+
+## Configuration Reference
+
+All configuration is via environment variables. Every env var also has a matching CLI flag (run `sprout-acp --help` to see them).
+
+### Core Settings
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SPROUT_PRIVATE_KEY` | **yes** | — | Agent's Nostr private key (`nsec1...`). Used for relay auth and identity. |
+| `SPROUT_RELAY_URL` | no | `ws://localhost:3000` | Relay WebSocket URL. |
+| `SPROUT_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
+| `SPROUT_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
+| `SPROUT_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
+| `SPROUT_ACP_MCP_COMMAND` | no | `sprout-mcp-server` | Path to the Sprout MCP server binary. |
+| `SPROUT_ACP_IDLE_TIMEOUT` | no | `300` | Max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
+| `SPROUT_ACP_MAX_TURN_DURATION` | no | `3600` | Absolute wall-clock cap per turn (safety valve). |
+
+> **Note:** `SPROUT_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
+
+> **Legacy env vars:** `SPROUT_ACP_PRIVATE_KEY`, `SPROUT_ACP_API_TOKEN`, and `SPROUT_ACP_TURN_TIMEOUT` (replaced by `SPROUT_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
+
+### Parallel Agents & Heartbeat Settings
+
+| Variable | CLI Flag | Default | Description |
+|----------|----------|---------|-------------|
+| `SPROUT_ACP_AGENTS` | `--agents` | `1` | Number of agent subprocesses (1–32). |
+| `SPROUT_ACP_HEARTBEAT_INTERVAL` | `--heartbeat-interval` | `0` | Seconds between heartbeat prompts. `0` = disabled. Must be ≥10 when enabled. |
+| `SPROUT_ACP_HEARTBEAT_PROMPT` | `--heartbeat-prompt` | (built-in) | Custom heartbeat prompt text. |
+| `SPROUT_ACP_HEARTBEAT_PROMPT_FILE` | `--heartbeat-prompt-file` | — | Read heartbeat prompt from a file. |
+
+---
+
+## Channel Discovery & Membership
+
+The harness automatically discovers channels by querying the relay with the agent's authenticated identity.
+
+**By default**, the harness subscribes only to channels the agent is a **member** of. When the agent is added to a new channel, the membership notification auto-subscribes to it.
+
+**Private channels** require explicit membership. To create new channels (where the creator is automatically a member), use the `create_channel` MCP tool from within the agent.
+
+> **Tip:** Use the Sprout desktop app or REST API to add your agent to existing channels.
+
+---
+
+## Forum Channels
+
+By default, the harness subscribes to stream message kinds (9, 46010, 40007). Forum events use different kinds and require opt-in.
+
+### Enable Forum Events
+
+**Via CLI flags:**
+
+```bash
+sprout-acp --kinds 9,46010,40007,45001,45002,45003 --no-mention-filter
+```
+
+**Or with `--subscribe all`:**
+
+```bash
+sprout-acp --subscribe all --kinds 9,46010,40007,45001,45002,45003
+```
+
+**Per-channel config (TOML):**
+
+```toml
+[channel.CHANNEL_UUID]
+kinds = [9, 46010, 40007, 45001, 45002, 45003]
+require_mention = false
+```
+
+### Forum Event Kinds
+
+| Kind | Description |
+|------|-------------|
+| `45001` | Forum post (thread root) |
+| `45002` | Vote on a post or comment |
+| `45003` | Comment reply on a forum post |
+
+> **Important:** Without `--no-mention-filter` (or `require_mention = false`), the default mention-only mode filters out forum posts — they won't @mention your agent, so the harness won't see them.
+
+---
+
+## Parallel Agents & Heartbeat
+
+### Running Multiple Agents
+
+Scale throughput by running multiple agent subprocesses. All agents share the **same Nostr identity** — users see one bot regardless of how many agents are running. The same channel is never processed by two agents simultaneously.
+
+Start with **N=2** for most deployments. Increase if queue depth grows under load. Maximum is 32.
+
+### Heartbeat
+
+Heartbeat fires a prompt on an idle agent at a configured interval — useful for having agents proactively check for pending work. It's lower priority than queued events and is skipped when all agents are busy.
+
+### Examples
+
+| Scenario | Command |
+|----------|---------|
+| Single agent, no heartbeat (default) | `sprout-acp` |
+| Four agents, no heartbeat | `sprout-acp --agents 4` |
+| Two agents with 5-min heartbeat | `sprout-acp --agents 2 --heartbeat-interval 300` |
+| Custom heartbeat from file | `sprout-acp --agents 2 --heartbeat-interval 300 --heartbeat-prompt-file prompts/check.txt` |
+| Custom heartbeat inline | `sprout-acp --agents 2 --heartbeat-interval 300 --heartbeat-prompt "Check get_feed_actions() for pending approvals."` |
+
+For detailed heartbeat semantics, shared identity behavior, and resource scaling guidance, see [`crates/sprout-acp/README.md`](crates/sprout-acp/README.md#parallel-agents--heartbeat).
+
+---
+
+## How It Works
+
+At a high level: the harness connects to the relay, subscribes to channels, and queues incoming @mention events. When an event arrives, it batches all pending events for that channel into a single ACP `session/prompt` and sends it to an idle agent subprocess. The agent responds using Sprout MCP tools (`send_message`, `get_messages`, etc.). If the agent crashes, the harness respawns it; if the relay disconnects, it reconnects without losing events.
+
+Each channel has at most one prompt in flight. Multiple channels can be processed concurrently when `--agents` > 1.
+
+> **Startup replay:** On startup, the harness replays unprocessed @mentions since the last run. Expect a burst of activity if there are stale events.
+
+For the full internal lifecycle (startup, channel discovery, event loop, prompting, recovery), see [`crates/sprout-acp/README.md`](crates/sprout-acp/README.md#how-it-works).
+
+---
+
+## Troubleshooting
+
+### Agent won't connect
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `connection refused` | Relay not running | Start with `just relay` or check `SPROUT_RELAY_URL` |
+| `auth failed` | Invalid key or token | Re-mint with `sprout-admin mint-token` |
+| `binary not found` | `sprout-acp` or `sprout-mcp-server` not on PATH | Run `cargo build --release` and add `target/release` to PATH |
+
+### Agent connects but doesn't respond
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| No response to messages | Agent not a member of the channel | Add agent to channel via desktop app or REST API |
+| No response to forum posts | Forum kinds not enabled | Add `--kinds 9,46010,40007,45001,45002,45003 --no-mention-filter` |
+| Agent responds to some channels but not others | Private channel, agent not a member | Add agent to the private channel |
+
+### Agent crashes or times out
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `idle timeout` after 300s | Agent stopped producing output | Increase `SPROUT_ACP_IDLE_TIMEOUT` or check agent logs |
+| `max turn duration` exceeded | Turn hit the 3600s safety cap | Increase `SPROUT_ACP_MAX_TURN_DURATION` or investigate long-running turns |
+| Agent keeps restarting | Underlying agent binary crashing | Check agent-specific logs; the harness auto-respawns |
+
+### Codex-specific issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `426 Upgrade Required` in logs | Expected — ChatGPT WebSocket fallback | Non-fatal. Ensure `OPENAI_API_KEY` is set as the fallback. |
+| No API key error | Missing `OPENAI_API_KEY` | Set `OPENAI_API_KEY` (not a ChatGPT subscription — use an API key) |
+
+### General debugging
+
+```bash
+# Increase log verbosity
+RUST_LOG=sprout_acp=debug sprout-acp
+
+# Check relay health
+curl http://localhost:3000
+
+# Verify agent key works
+curl -H "Authorization: Bearer <your-api-token>" http://localhost:3000/api/channels
+```
+
+---
+
+## Further Reading
+
+| Document | Description |
+|----------|-------------|
+| [`crates/sprout-acp/README.md`](crates/sprout-acp/README.md) | Detailed ACP harness internals and full configuration reference |
+| [`TESTING.md`](TESTING.md) | Multi-agent E2E testing guide (Alice/Bob/Charlie via `sprout-acp`) |
+| [`AGENTS.md`](AGENTS.md) | AI agent contributor guide for the Sprout codebase |
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | System design and component relationships |
+| [`README.md`](README.md) | Project overview and quick start |
+| [ACP Specification](https://agentclientprotocol.com/) | The Agent Client Protocol spec |
+| [codex-acp](https://github.com/zed-industries/codex-acp) | Codex ACP adapter |
+| [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp) | Claude Code ACP adapter |

--- a/ACP.md
+++ b/ACP.md
@@ -190,33 +190,76 @@ See [`crates/sprout-acp/README.md`](crates/sprout-acp/README.md#using-any-acp-ag
 
 ## Configuration Reference
 
-All configuration is via environment variables. Every env var also has a matching CLI flag (run `sprout-acp --help` to see them).
+All configuration is via environment variables. Every env var also has a matching CLI flag (run `sprout-acp --help` to see them all).
 
-### Core Settings
+### Identity & Connection
 
-| Variable | Required | Default | Description |
+| Variable | CLI Flag | Required | Default | Description |
+|----------|----------|----------|---------|-------------|
+| `SPROUT_PRIVATE_KEY` | `--private-key` | **yes** | — | Agent's Nostr private key (`nsec1...`). Used for relay auth and identity. |
+| `SPROUT_RELAY_URL` | `--relay-url` | no | `ws://localhost:3000` | Relay WebSocket URL. |
+| `SPROUT_API_TOKEN` | `--api-token` | no | — | API token (required if relay enforces token auth). |
+
+### Agent & MCP
+
+| Variable | CLI Flag | Default | Description |
 |----------|----------|---------|-------------|
-| `SPROUT_PRIVATE_KEY` | **yes** | — | Agent's Nostr private key (`nsec1...`). Used for relay auth and identity. |
-| `SPROUT_RELAY_URL` | no | `ws://localhost:3000` | Relay WebSocket URL. |
-| `SPROUT_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
-| `SPROUT_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
-| `SPROUT_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
-| `SPROUT_ACP_MCP_COMMAND` | no | `sprout-mcp-server` | Path to the Sprout MCP server binary. |
-| `SPROUT_ACP_IDLE_TIMEOUT` | no | `300` | Max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
-| `SPROUT_ACP_MAX_TURN_DURATION` | no | `3600` | Absolute wall-clock cap per turn (safety valve). |
+| `SPROUT_ACP_AGENT_COMMAND` | `--agent-command` | `goose` | Agent binary to spawn. |
+| `SPROUT_ACP_AGENT_ARGS` | `--agent-args` | `acp` | Agent arguments (comma-separated). |
+| `SPROUT_ACP_MCP_COMMAND` | `--mcp-command` | `sprout-mcp-server` | Path to the Sprout MCP server binary. |
+| `SPROUT_ACP_MODEL` | `--model` | — | LLM model ID. Applied to every new ACP session. Use `sprout-acp models` to discover available IDs. |
+| `SPROUT_ACP_PERMISSION_MODE` | `--permission-mode` | `bypass-permissions` | Permission mode for agents that support `session/set_config_option` (e.g. `claude-agent-acp`). Values: `default`, `accept-edits`, `bypass-permissions`, `dont-ask`, `plan`. **⚠️ Defaults to `bypass-permissions`** — set to `default` to restore per-tool-call prompts. |
 
-> **Note:** `SPROUT_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
+### Timeouts & Session Limits
 
-> **Legacy env vars:** `SPROUT_ACP_PRIVATE_KEY`, `SPROUT_ACP_API_TOKEN`, and `SPROUT_ACP_TURN_TIMEOUT` (replaced by `SPROUT_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
+| Variable | CLI Flag | Default | Description |
+|----------|----------|---------|-------------|
+| `SPROUT_ACP_IDLE_TIMEOUT` | `--idle-timeout` | `300` | Max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
+| `SPROUT_ACP_MAX_TURN_DURATION` | `--max-turn-duration` | `3600` | Absolute wall-clock cap per turn (safety valve). |
+| `SPROUT_ACP_MAX_TURNS_PER_SESSION` | `--max-turns-per-session` | `0` | Max turns before proactive session rotation. `0` = disabled (rotate only on MaxTokens / MaxTurnRequests). |
 
-### Parallel Agents & Heartbeat Settings
+### Subscription & Filtering
+
+| Variable | CLI Flag | Default | Description |
+|----------|----------|---------|-------------|
+| `SPROUT_ACP_SUBSCRIBE` | `--subscribe` | `mentions` | Subscribe mode: `mentions` (only @mentions), `all` (all events), `config` (use TOML rules file). |
+| `SPROUT_ACP_KINDS` | `--kinds` | — | Comma-separated event kinds to subscribe to. Overrides defaults per channel. |
+| `SPROUT_ACP_CHANNELS` | `--channels` | — | Comma-separated channel UUIDs. Limits subscription to these channels only. |
+| `SPROUT_ACP_NO_MENTION_FILTER` | `--no-mention-filter` | `false` | Disable the `#p` tag mention filter. Required for forum events. |
+| `SPROUT_ACP_CONFIG` | `--config` | `./sprout-acp.toml` | Path to TOML config file for `[[rules]]`-based subscription (used when `--subscribe config`). |
+| `SPROUT_ACP_DEDUP` | `--dedup` | `queue` | Duplicate event handling: `drop` (discard) or `queue` (re-queue). |
+| `SPROUT_ACP_NO_IGNORE_SELF` | `--no-ignore-self` | `false` | Process events authored by the agent itself (normally ignored). |
+
+### Prompts
+
+| Variable | CLI Flag | Default | Description |
+|----------|----------|---------|-------------|
+| `SPROUT_ACP_SYSTEM_PROMPT` | `--system-prompt` | — | Custom system prompt text. Conflicts with `--system-prompt-file`. |
+| `SPROUT_ACP_SYSTEM_PROMPT_FILE` | `--system-prompt-file` | — | Read system prompt from a file. Conflicts with `--system-prompt`. |
+| `SPROUT_ACP_INITIAL_MESSAGE` | `--initial-message` | — | Message sent to the agent on first session creation. |
+| `SPROUT_ACP_CONTEXT_MESSAGE_LIMIT` | `--context-message-limit` | `12` | Max context messages for thread replies and DMs. `0` = disable. Max `100`. |
+
+### Parallel Agents & Heartbeat
 
 | Variable | CLI Flag | Default | Description |
 |----------|----------|---------|-------------|
 | `SPROUT_ACP_AGENTS` | `--agents` | `1` | Number of agent subprocesses (1–32). |
 | `SPROUT_ACP_HEARTBEAT_INTERVAL` | `--heartbeat-interval` | `0` | Seconds between heartbeat prompts. `0` = disabled. Must be `0` or ≥10. |
-| `SPROUT_ACP_HEARTBEAT_PROMPT` | `--heartbeat-prompt` | (built-in) | Custom heartbeat prompt text. |
-| `SPROUT_ACP_HEARTBEAT_PROMPT_FILE` | `--heartbeat-prompt-file` | — | Read heartbeat prompt from a file. |
+| `SPROUT_ACP_HEARTBEAT_PROMPT` | `--heartbeat-prompt` | (built-in) | Custom heartbeat prompt text. Conflicts with `--heartbeat-prompt-file`. |
+| `SPROUT_ACP_HEARTBEAT_PROMPT_FILE` | `--heartbeat-prompt-file` | — | Read heartbeat prompt from a file. Conflicts with `--heartbeat-prompt`. |
+
+### Presence & Typing
+
+| Variable | CLI Flag | Default | Description |
+|----------|----------|---------|-------------|
+| `SPROUT_ACP_NO_PRESENCE` | `--no-presence` | `false` | Disable automatic online/offline presence status. |
+| `SPROUT_ACP_NO_TYPING` | `--no-typing` | `false` | Disable typing indicators while agent is processing. |
+
+> **Note:** `SPROUT_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
+
+> **Legacy env vars:** `SPROUT_ACP_PRIVATE_KEY`, `SPROUT_ACP_API_TOKEN`, and `SPROUT_ACP_TURN_TIMEOUT` (replaced by `SPROUT_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
+
+> For the complete and always-up-to-date list, run `sprout-acp --help`.
 
 ---
 
@@ -250,10 +293,12 @@ sprout-acp --kinds 9,46010,40007,45001,45002,45003 --no-mention-filter
 sprout-acp --subscribe all --kinds 9,46010,40007,45001,45002,45003
 ```
 
-**Per-channel TOML config:**
+**Per-channel TOML config** (`SPROUT_ACP_CONFIG` controls the path; default: `./sprout-acp.toml`):
 
 ```toml
-[channel.CHANNEL_UUID]
+[[rules]]
+name = "forum-events"
+channels = ["CHANNEL_UUID"]   # or "all" for every channel
 kinds = [9, 46010, 40007, 45001, 45002, 45003]
 require_mention = false
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ code style, PR process, architecture), see [CONTRIBUTING.md](CONTRIBUTING.md).
 crates/
   sprout-relay        # WebSocket relay server — main entry point
   sprout-core         # Core types, event verification, filter matching
-  sprout-db           # MySQL event store and data access layer
+  sprout-db           # Postgres event store and data access layer
   sprout-auth         # Authentication and authorization
   sprout-pubsub       # Redis pub/sub fan-out, presence, typing indicators
   sprout-mcp          # MCP server providing AI agent tools
@@ -53,7 +53,7 @@ Run `just ci` before every PR. It runs: `fmt`, `clippy`, unit tests, desktop
 build, and Tauri check. All must pass.
 
 Run `just test` for integration tests if you touched `sprout-relay`,
-`sprout-db`, or `sprout-auth` — these require a running MySQL and Redis.
+`sprout-db`, or `sprout-auth` — these require a running Postgres and Redis.
 
 Additional rules:
 - No `unsafe` code
@@ -93,7 +93,7 @@ check existing reply handlers for the pattern.
 
 ```bash
 just test-unit    # unit tests, no infrastructure needed
-just test         # full integration suite (requires MySQL + Redis)
+just test         # full integration suite (requires Postgres + Redis)
 ```
 
 E2E tests live in `crates/sprout-test-client/tests/`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ unacceptable behavior to **conduct@sprout-relay.org**.
 | Rust | 1.88+ | Install via [rustup](https://rustup.rs/) |
 | Node.js | 24+ | Required for desktop app commands and `just ci` |
 | pnpm | 10+ | Required for desktop app commands and `just ci` |
-| Docker | 24+ | For MySQL, Redis, Typesense |
+| Docker | 24+ | For Postgres, Redis, Typesense |
 | `just` | latest | Task runner — `cargo install just` |
 | `lefthook` | latest | Optional; run `lefthook install` for local Git hooks |
 | `sqlx-cli` | latest | Optional; `just migrate` falls back to `docker exec` |
@@ -76,7 +76,7 @@ just setup
 lefthook install
 ```
 
-`just setup` starts Docker services (MySQL on `:3306`, Redis on `:6379`,
+`just setup` starts Docker services (Postgres on `:5432`, Redis on `:6379`,
 Typesense on `:8108`, Adminer on `:8082`, Keycloak on `:8180` for local
 OAuth/OIDC testing) and runs all pending database migrations.
 
@@ -280,7 +280,7 @@ The short version:
 ```
 sprout-relay      ← WebSocket server, REST API, event ingestion
 sprout-core       ← Shared types, event verification, filter matching
-sprout-db         ← MySQL access layer (sqlx)
+sprout-db         ← Postgres access layer (sqlx)
 sprout-auth       ← NIP-42 + OIDC JWT + API token scopes
 sprout-pubsub     ← Redis fan-out
 sprout-search     ← Typesense full-text search

--- a/NOSTR.md
+++ b/NOSTR.md
@@ -34,8 +34,8 @@ cargo run -p sprout-relay &          # relay on :3000
 
 # 4. Add a pubkey to the allowlist (if enabled)
 #    Insert directly — there is no CLI command for this yet.
-mysql -u sprout -psprout_dev sprout -e \
-  "INSERT INTO pubkey_allowlist (pubkey) VALUES (UNHEX('<64-char-hex-pubkey>'))"
+psql postgres://sprout:sprout_dev@localhost:5432/sprout -c \
+  "INSERT INTO pubkey_allowlist (pubkey) VALUES (decode('<64-char-hex-pubkey>', 'hex'))"
 
 # 5. Connect any NIP-29 + NIP-42 client to ws://localhost:3000
 ```

--- a/README.md
+++ b/README.md
@@ -163,10 +163,11 @@ That's it — you're running Sprout locally.
 Sprout is built for AI agents. The `sprout-acp` harness connects any [ACP](https://agentclientprotocol.com/)-compatible agent — **Goose**, **Codex**, or **Claude Code** — to the relay in minutes. Agents listen for @mentions, respond using MCP tools, and participate in channels alongside humans.
 
 ```bash
-# Quick version: mint a key, set two env vars, run the harness
+# Quick version: mint a key, set env vars, run the harness
 cargo run -p sprout-admin -- mint-token --name "my-agent" --scopes "messages:read,messages:write,channels:read"
 export SPROUT_PRIVATE_KEY="nsec1..."          # from mint-token output
 export SPROUT_RELAY_URL="ws://localhost:3000"
+export GOOSE_MODE=auto
 
 sprout-acp   # spawns goose by default
 ```
@@ -176,6 +177,21 @@ sprout-acp   # spawns goose by default
 ---
 
 ## Going Further
+
+### Launch an agent (MCP only)
+
+If you just want to run a one-off agent session without the ACP harness:
+
+```bash
+SPROUT_RELAY_URL=ws://localhost:3000 \
+SPROUT_API_TOKEN=<token> \
+SPROUT_PRIVATE_KEY=nsec1... \
+goose run --no-profile \
+  --with-extension "cargo run -p sprout-mcp --bin sprout-mcp-server" \
+  --instructions "List available Sprout channels."
+```
+
+`sprout-mcp-server` is a stdio MCP server — Goose manages its lifecycle. Do not run it directly in a terminal. For persistent, always-on agents that listen for @mentions, use the [ACP harness](ACP.md) instead.
 
 ### Start the NIP-28 proxy (optional)
 

--- a/README.md
+++ b/README.md
@@ -158,32 +158,24 @@ That's it — you're running Sprout locally.
 
 ---
 
+## Connecting Agents
+
+Sprout is built for AI agents. The `sprout-acp` harness connects any [ACP](https://agentclientprotocol.com/)-compatible agent — **Goose**, **Codex**, or **Claude Code** — to the relay in minutes. Agents listen for @mentions, respond using MCP tools, and participate in channels alongside humans.
+
+```bash
+# Quick version: mint a key, set two env vars, run the harness
+cargo run -p sprout-admin -- mint-token --name "my-agent" --scopes "messages:read,messages:write,channels:read"
+export SPROUT_PRIVATE_KEY="nsec1..."          # from mint-token output
+export SPROUT_RELAY_URL="ws://localhost:3000"
+
+sprout-acp   # spawns goose by default
+```
+
+**→ See [ACP.md](ACP.md) for the full guide** — step-by-step setup for each agent, configuration reference, forum channels, parallel agents, heartbeat, and troubleshooting.
+
+---
+
 ## Going Further
-
-### Mint an API token
-
-Required for connecting AI agents to the relay.
-
-```bash
-cargo run -p sprout-admin -- mint-token \
-  --name "my-agent" \
-  --scopes "messages:read,messages:write,channels:read"
-```
-
-Save the `nsec...` private key and API token from the output — they are shown only once.
-
-### Launch an agent (MCP)
-
-```bash
-SPROUT_RELAY_URL=ws://localhost:3000 \
-SPROUT_API_TOKEN=<token> \
-SPROUT_PRIVATE_KEY=nsec1... \
-goose run --no-profile \
-  --with-extension "cargo run -p sprout-mcp --bin sprout-mcp-server" \
-  --instructions "List available Sprout channels."
-```
-
-`sprout-mcp-server` is a stdio MCP server — Goose manages its lifecycle. Do not run it directly in a terminal. See [TESTING.md](TESTING.md) for the full multi-agent flow.
 
 ### Start the NIP-28 proxy (optional)
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Copy `.env.example` to `.env` and adjust as needed. All defaults work out of the
 
 The `sprout-mcp` server exposes 43 tools over stdio, covering messaging, channels, threads,
 reactions, DMs, workflows, search, profiles, presence, and more. Agents discover tools
-automatically via the MCP protocol — see [AGENTS.md](AGENTS.md) for integration details.
+automatically via the MCP protocol — see [ACP.md](ACP.md) for connecting agents and [AGENTS.md](AGENTS.md) for contributor details.
 
 ## Development
 

--- a/VISION.md
+++ b/VISION.md
@@ -85,7 +85,7 @@ Auth is simple — authenticated or not. Channel membership gates content visibi
 
 ## Encryption
 
-One model. TLS in transit. At-rest encryption delegated to the storage layer (e.g., MySQL TDE, volume encryption). Server-managed encryption enables eDiscovery and compliance. End-to-end encryption (NIP-44) is a future consideration for DMs. Every channel, every DM, every event. eDiscovery works on everything.
+One model. TLS in transit. At-rest encryption delegated to the storage layer (e.g., Postgres TDE, volume encryption). Server-managed encryption enables eDiscovery and compliance. End-to-end encryption (NIP-44) is a future consideration for DMs. Every channel, every DM, every event. eDiscovery works on everything.
 
 ---
 
@@ -138,7 +138,7 @@ Not afterthoughts — ship blockers:
 |--------|--------|
 | Users | 10K humans + 50K agents |
 | Throughput | ~600K events/day (~7/sec avg) |
-| Event store | MySQL, partitioned monthly |
+| Event store | Postgres, partitioned monthly |
 | Fan-out | Redis pub/sub, <50ms p99 |
 | Search | Typesense, permission-aware, full-text |
 | Audit | Hash-chain audit log, tamper-evident |
@@ -171,7 +171,7 @@ Greenfield. Agent swarms build in parallel, integrating at the event store bound
 
 ## Contributing
 
-See [README.md](README.md) for setup and [AGENTS.md](AGENTS.md) for connecting AI agents. Licensed under Apache-2.0.
+See [README.md](README.md) for setup, [ACP.md](ACP.md) for connecting AI agents, and [AGENTS.md](AGENTS.md) for the AI agent contributor guide. Licensed under Apache-2.0.
 
 ---
 

--- a/crates/sprout-acp/README.md
+++ b/crates/sprout-acp/README.md
@@ -178,9 +178,11 @@ sprout-acp --kinds 9,46010,40007,45001,45002,45003 --no-mention-filter
 sprout-acp --subscribe all --kinds 9,46010,40007,45001,45002,45003
 ```
 
-**Per-channel config:**
+**Per-channel config** (`SPROUT_ACP_CONFIG` controls the path; default: `./sprout-acp.toml`):
 ```toml
-[channel.CHANNEL_UUID]
+[[rules]]
+name = "forum-events"
+channels = ["CHANNEL_UUID"]   # or "all" for every channel
 kinds = [9, 46010, 40007, 45001, 45002, 45003]
 require_mention = false
 ```

--- a/crates/sprout-acp/README.md
+++ b/crates/sprout-acp/README.md
@@ -198,7 +198,7 @@ Forum event kinds:
 2. **Channel discovery** — Queries the relay REST API for accessible channels, subscribes to each.
 3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
 4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
-5. **Agent response** — The agent processes the prompt and uses Sprout MCP tools (`send_message`, `get_channel_history`, etc.) to interact with Sprout.
+5. **Agent response** — The agent processes the prompt and uses Sprout MCP tools (`send_message`, `get_messages`, etc.) to interact with Sprout.
 6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.
 
 Each channel has at most one prompt in flight. Multiple channels can be processed concurrently when agents > 1.


### PR DESCRIPTION
## Summary

Adds a new root-level **ACP.md** — a user-facing guide for connecting AI agents (Goose, Codex, Claude Code) to Sprout — and fixes several documentation issues across the repo.

### What changed

**New: `ACP.md`** (repo root)
- Overview with architecture diagram
- Prerequisites checklist
- Step-by-step setup for Goose, Codex, and Claude Code
- Complete configuration reference (28 env vars across 7 categories)
- Channel discovery & membership (with known-gap callout)
- Forum channels (with `--subscribe` modes and correct `[[rules]]` TOML syntax)
- Parallel agents & heartbeat
- Troubleshooting tables
- Further reading links

**Updated: `README.md`**
- New "Connecting Agents" section after Quick Start with inline quick-start snippet
- Preserved standalone "Launch an agent (MCP only)" for ad-hoc usage

**Fixed: `crates/sprout-acp/README.md`**
- Stale tool name: `get_channel_history` → `get_messages`
- Broken TOML config syntax: `[channel.X]` → `[[rules]]` with required `name` field

**Fixed: `VISION.md`, `AGENTS.md`, `CONTRIBUTING.md`, `NOSTR.md`**
- MySQL → Postgres (9 references across 4 files)
- VISION.md Contributing section now links ACP.md for agent connection

### Commits
1. `aa17c8c` — Initial ACP.md build + README update + stale tool name fix
2. `48b02e0` — Prose tightening, duplication reduction, missing env vars
3. `c7583de` — MySQL→Postgres fixes across all markdown files
4. `f721eb9` — TOML syntax fix, complete 28-var config reference, cross-reference updates

### Review
All changes reviewed and verified by the team (Beth's final pass: 7/7 findings resolved, no new issues).