### PR TITLE
feat: default agent parallelism to 3, idle timeout to 320s

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,8 +137,8 @@ RUST_LOG=sprout_relay=debug,sprout_db=debug,sprout_auth=debug,sprout_pubsub=debu
 # SPROUT_ACP_MODEL=
 
 # ── Timeouts & sessions ──────────────────────────────────────────────────────
-# Max seconds per agent turn before timeout (default 300 = 5 min).
-# SPROUT_ACP_TURN_TIMEOUT=300
+# Max seconds per agent turn before timeout (default 320 = ~5 min).
+# SPROUT_ACP_TURN_TIMEOUT=320
 
 # Max turns per session before proactive rotation. 0 = disabled (rotate only
 # on MaxTokens / MaxTurnRequests). Recommended: 50 for long-running agents.

--- a/crates/sprout-acp/src/acp.rs
+++ b/crates/sprout-acp/src/acp.rs
@@ -1373,10 +1373,10 @@ mod tests {
 
     #[test]
     fn idle_timeout_error_includes_duration() {
-        let err = AcpError::IdleTimeout(std::time::Duration::from_secs(300));
+        let err = AcpError::IdleTimeout(std::time::Duration::from_secs(320));
         let msg = err.to_string();
         assert!(
-            msg.contains("300"),
+            msg.contains("320"),
             "IdleTimeout display should include duration: {msg}"
         );
     }

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -448,7 +448,7 @@ impl Config {
             mcp_command: args.mcp_command,
             // Deprecated --turn-timeout is a fallback for backward compat.
             // New deployments should use --idle-timeout exclusively.
-            // Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 300.
+            // Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 320.
             idle_timeout_secs: {
                 let raw = match (args.idle_timeout, args.turn_timeout) {
                     (Some(idle), Some(_turn)) => {
@@ -466,7 +466,7 @@ impl Config {
                         );
                         turn
                     }
-                    (None, None) => 300, // default
+                    (None, None) => 320, // default: 20s buffer over goose's 300s turn timeout
                 };
                 if raw == 0 {
                     tracing::warn!("idle timeout of 0 is invalid — using 1s minimum");
@@ -807,7 +807,7 @@ mod tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "sprout-mcp-server".into(),
-            idle_timeout_secs: 300,
+            idle_timeout_secs: 320,
             max_turn_duration_secs: 3600,
             agents: 1,
             heartbeat_interval_secs: 0,
@@ -1493,13 +1493,13 @@ channels = "ALL"
     // ── Idle timeout config precedence ─────────────────────────────────────
 
     /// Helper: resolve idle_timeout_secs using the same precedence logic as Config::from_args.
-    /// Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 300.
+    /// Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 320.
     fn resolve_idle_timeout(idle: Option<u64>, turn: Option<u64>) -> u64 {
         let raw = match (idle, turn) {
             (Some(idle), Some(_)) => idle,
             (Some(idle), None) => idle,
             (None, Some(turn)) => turn,
-            (None, None) => 300,
+            (None, None) => 320,
         };
         if raw == 0 {
             1
@@ -1519,8 +1519,8 @@ channels = "ALL"
     }
 
     #[test]
-    fn idle_timeout_defaults_to_300_when_neither_set() {
-        assert_eq!(resolve_idle_timeout(None, None), 300);
+    fn idle_timeout_defaults_to_320_when_neither_set() {
+        assert_eq!(resolve_idle_timeout(None, None), 320);
     }
 
     #[test]
@@ -1538,7 +1538,7 @@ channels = "ALL"
         let config = test_config(SubscribeMode::Mentions);
         let summary = config.summary();
         assert!(
-            summary.contains("idle_timeout=300s"),
+            summary.contains("idle_timeout=320s"),
             "summary should include idle_timeout: {summary}"
         );
         assert!(

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -368,7 +368,7 @@ pub async fn create_managed_agent(
                 .turn_timeout_seconds
                 .filter(|seconds| *seconds > 0)
                 .unwrap_or(DEFAULT_AGENT_TURN_TIMEOUT_SECONDS),
-            // 0 or None → harness uses its own default (300s idle, 3600s max), and the CLI also clamps 0 → minimum.
+            // 0 or None → harness uses its own default (320s idle, 3600s max), and the CLI also clamps 0 → minimum.
             idle_timeout_seconds: input.idle_timeout_seconds.filter(|s| *s > 0),
             max_turn_duration_seconds: input.max_turn_duration_seconds.filter(|s| *s > 0),
             parallelism: input

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -319,8 +319,8 @@ pub const DEFAULT_ACP_COMMAND: &str = "sprout-acp";
 pub const DEFAULT_ADMIN_COMMAND: &str = "sprout-admin";
 pub const DEFAULT_AGENT_COMMAND: &str = "goose";
 pub const DEFAULT_MCP_COMMAND: &str = "sprout-mcp-server";
-/// 5 min — matches the CLI harness default (SPROUT_ACP_IDLE_TIMEOUT).
-pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 300;
+/// ~5 min (320s) — matches the CLI harness default (SPROUT_ACP_IDLE_TIMEOUT).
+pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
 /// 1 hour — absolute wall-clock safety cap per turn.
 pub const DEFAULT_AGENT_MAX_TURN_DURATION_SECONDS: u64 = 3600;
 pub const DEFAULT_AGENT_PARALLELISM: u32 = 3;

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -323,7 +323,7 @@ pub const DEFAULT_MCP_COMMAND: &str = "sprout-mcp-server";
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 300;
 /// 1 hour — absolute wall-clock safety cap per turn.
 pub const DEFAULT_AGENT_MAX_TURN_DURATION_SECONDS: u64 = 3600;
-pub const DEFAULT_AGENT_PARALLELISM: u32 = 1;
+pub const DEFAULT_AGENT_PARALLELISM: u32 = 3;
 
 fn default_agent_parallelism() -> u32 {
     DEFAULT_AGENT_PARALLELISM

--- a/desktop/src/features/agents/ui/CreateAgentDialog.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialog.tsx
@@ -63,7 +63,7 @@ export function CreateAgentDialog({
   const [selectedScopes, setSelectedScopes] = React.useState<Set<TokenScope>>(
     () => new Set<TokenScope>(DEFAULT_MANAGED_AGENT_SCOPES),
   );
-  const [turnTimeoutSeconds, setTurnTimeoutSeconds] = React.useState("300");
+  const [turnTimeoutSeconds, setTurnTimeoutSeconds] = React.useState("320");
   const [parallelism, setParallelism] = React.useState("3");
   const [systemPrompt, setSystemPrompt] = React.useState("");
   const [selectedProviderId, setSelectedProviderId] =
@@ -212,7 +212,7 @@ export function CreateAgentDialog({
     setAgentCommand("goose");
     setAgentArgs("acp");
     setMcpCommand("sprout-mcp-server");
-    setTurnTimeoutSeconds("300");
+    setTurnTimeoutSeconds("320");
     setParallelism("3");
     setSystemPrompt("");
     setSelectedProviderId("custom");

--- a/desktop/src/features/agents/ui/CreateAgentDialog.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialog.tsx
@@ -64,7 +64,7 @@ export function CreateAgentDialog({
     () => new Set<TokenScope>(DEFAULT_MANAGED_AGENT_SCOPES),
   );
   const [turnTimeoutSeconds, setTurnTimeoutSeconds] = React.useState("300");
-  const [parallelism, setParallelism] = React.useState("1");
+  const [parallelism, setParallelism] = React.useState("3");
   const [systemPrompt, setSystemPrompt] = React.useState("");
   const [selectedProviderId, setSelectedProviderId] =
     React.useState<string>("custom");
@@ -213,7 +213,7 @@ export function CreateAgentDialog({
     setAgentArgs("acp");
     setMcpCommand("sprout-mcp-server");
     setTurnTimeoutSeconds("300");
-    setParallelism("1");
+    setParallelism("3");
     setSystemPrompt("");
     setSelectedProviderId("custom");
     setHasSyncedProviderSelection(false);

--- a/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
@@ -224,7 +224,7 @@ export function CreateAgentRuntimeFields({
             max="32"
             min="1"
             onChange={(event) => onParallelismChange(event.target.value)}
-            placeholder="1"
+            placeholder="3"
             step="1"
             type="number"
             value={parallelism}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -2578,7 +2578,7 @@ async function handleCreateManagedAgent(args: {
         ? [...args.input.agentArgs]
         : ["acp"],
     mcp_command: args.input.mcpCommand ?? "sprout-mcp-server",
-    turn_timeout_seconds: args.input.turnTimeoutSeconds ?? 300,
+    turn_timeout_seconds: args.input.turnTimeoutSeconds ?? 320,
     idle_timeout_seconds: args.input.idleTimeoutSeconds ?? null,
     max_turn_duration_seconds: args.input.maxTurnDurationSeconds ?? null,
     parallelism: args.input.parallelism ?? 3,

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -2581,7 +2581,7 @@ async function handleCreateManagedAgent(args: {
     turn_timeout_seconds: args.input.turnTimeoutSeconds ?? 300,
     idle_timeout_seconds: args.input.idleTimeoutSeconds ?? null,
     max_turn_duration_seconds: args.input.maxTurnDurationSeconds ?? null,
-    parallelism: args.input.parallelism ?? 1,
+    parallelism: args.input.parallelism ?? 3,
     system_prompt: args.input.systemPrompt?.trim() || null,
     model: args.input.model?.trim() || null,
     has_api_token: token !== null,
@@ -2600,7 +2600,7 @@ async function handleCreateManagedAgent(args: {
     private_key_nsec: `nsec1mock${pubkey.slice(0, 20)}`,
     api_token: token,
     log_lines: [
-      `sprout-acp starting: relay=${args.input.relayUrl ?? DEFAULT_RELAY_WS_URL} agent_pubkey=${pubkey} parallelism=${args.input.parallelism ?? 1}`,
+      `sprout-acp starting: relay=${args.input.relayUrl ?? DEFAULT_RELAY_WS_URL} agent_pubkey=${pubkey} parallelism=${args.input.parallelism ?? 3}`,
       args.input.systemPrompt?.trim()
         ? `system prompt override configured (${args.input.systemPrompt.trim().length} chars)`
         : "system prompt override not set",


### PR DESCRIPTION
## Changes

### Default parallelism: 1 → 3
New GUI-created agents now default to parallelism of 3 instead of 1. This affects:
- Rust default constant (`DEFAULT_AGENT_PARALLELISM`)
- React dialog initial state and reset handler
- Dialog placeholder text
- Test fixtures

**Note:** Existing agents keep their persisted parallelism value. Only newly created agents pick up the new default.

### Idle timeout: 300s → 320s
Goose's turn timeout is 300s. Having the ACP harness idle timeout also at 300s creates a race condition — the harness could kill the agent before goose finishes its own timeout handling. Bumped to 320s (20s buffer) for both `SPROUT_ACP_IDLE_TIMEOUT` and the desktop equivalent.

### Bug fix
Fixed `CreateAgentDialog.tsx` reset handler that was hardcoded to `setParallelism("1")`, which would revert the default on dialog reopen.

## Review
Codex CLI (gpt-5.4) reviewed: **8.5/10**
- Correctness: 9/10
- Completeness: 8/10  
- Safety: 9/10
- Style: 7/10 (suggested extracting a shared TS constant — follow-up)