### PR TITLE
fix: enable double-click-to-maximize on custom title bar regions

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:webview:allow-set-webview-zoom",
     "core:window:allow-start-dragging",
+    "core:window:allow-toggle-maximize",
     "core:window:allow-show",
     "core:window:allow-close",
     "notification:default",

--- a/desktop/src/features/chat/ui/ChatHeader.tsx
+++ b/desktop/src/features/chat/ui/ChatHeader.tsx
@@ -1,4 +1,3 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Bot, CircleDot, FileText, Hash, Home, Settings2 } from "lucide-react";
 import type * as React from "react";
 
@@ -43,20 +42,6 @@ function ChannelIcon({
   return <Hash className="h-5 w-5 text-primary" />;
 }
 
-function handlePointerDown(e: React.PointerEvent) {
-  if (e.button !== 0) return;
-  const target = e.target as HTMLElement;
-  if (
-    target.closest(
-      'button, a, input, textarea, select, [role="button"], [role="textbox"], [contenteditable="true"]',
-    )
-  ) {
-    return;
-  }
-  e.preventDefault();
-  getCurrentWindow().startDragging();
-}
-
 export function ChatHeader({
   actions,
   title,
@@ -69,7 +54,7 @@ export function ChatHeader({
     <header
       className="flex min-w-0 items-center gap-3 border-b border-border/80 bg-background px-4 pb-3 pt-8 sm:px-6"
       data-testid="chat-header"
-      onPointerDown={handlePointerDown}
+      data-tauri-drag-region
     >
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-2">

--- a/desktop/src/features/settings/ui/SettingsView.tsx
+++ b/desktop/src/features/settings/ui/SettingsView.tsx
@@ -1,6 +1,4 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { X } from "lucide-react";
-import type * as React from "react";
 
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
@@ -21,20 +19,6 @@ type SettingsViewProps = SettingsPanelProps & {
   onSectionChange: (section: SettingsSection) => void;
   section: SettingsSection;
 };
-
-function handleSettingsHeaderPointerDown(event: React.PointerEvent) {
-  if (event.button !== 0) {
-    return;
-  }
-
-  const target = event.target as HTMLElement;
-  if (target.closest('button, a, input, textarea, [role="button"]')) {
-    return;
-  }
-
-  event.preventDefault();
-  getCurrentWindow().startDragging();
-}
 
 function SettingsSectionButton({
   active,
@@ -100,7 +84,7 @@ export function SettingsView({
     >
       <header
         className="flex items-start justify-between gap-4 border-b border-border/80 bg-background px-4 pb-4 pt-8 sm:px-6"
-        onPointerDown={handleSettingsHeaderPointerDown}
+        data-tauri-drag-region
       >
         <div className="min-w-0 pt-0.5">
           <h1

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -1,4 +1,3 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Bot, Home, Lock, PenSquare, Plus, Search } from "lucide-react";
 import * as React from "react";
 
@@ -479,30 +478,13 @@ export function AppSidebar({
     fallbackDisplayName?.trim() ||
     "Current identity";
 
-  function handleDragPointerDown(e: React.PointerEvent) {
-    if (e.button !== 0) return;
-    const target = e.target as HTMLElement;
-    if (
-      target.closest(
-        'button, a, input, textarea, select, [role="button"], [role="textbox"], [contenteditable="true"]',
-      )
-    ) {
-      return;
-    }
-    e.preventDefault();
-    getCurrentWindow().startDragging();
-  }
-
   return (
     <Sidebar
       collapsible="offcanvas"
       data-testid="app-sidebar"
       variant="sidebar"
     >
-      <SidebarHeader
-        className="gap-3 pt-10"
-        onPointerDown={handleDragPointerDown}
-      >
+      <SidebarHeader className="gap-3 pt-10" data-tauri-drag-region>
         <Button
           className="w-full justify-between rounded-xl border border-sidebar-border/80 bg-sidebar-accent/60 px-3 text-sidebar-foreground/80 shadow-sm hover:bg-sidebar-accent hover:text-sidebar-foreground"
           data-testid="open-search"


### PR DESCRIPTION
## Problem

Double-clicking the custom title bar / drag regions doesn't maximize or restore the window. This is expected standard behavior for desktop apps.

The three drag regions (chat header, sidebar header, settings header) used manual `onPointerDown` → `startDragging()` handlers, which only handled dragging — no double-click-to-maximize support. The Tauri capability file also didn't grant the maximize permission.

## Fix

Replace the manual `onPointerDown` + `startDragging()` approach with Tauri v2's `data-tauri-drag-region` HTML attribute, which natively handles both drag **and** double-click-to-maximize at the OS level — no JavaScript needed. Interactive children (buttons, inputs, etc.) are automatically excluded by Tauri.

### Changes

| File | What changed |
|------|-------------|
| `ChatHeader.tsx` | Replaced `onPointerDown={handlePointerDown}` with `data-tauri-drag-region`, removed handler + import |
| `AppSidebar.tsx` | Replaced `onPointerDown={handleDragPointerDown}` with `data-tauri-drag-region`, removed handler + import |
| `SettingsView.tsx` | Replaced `onPointerDown={handleSettingsHeaderPointerDown}` with `data-tauri-drag-region`, removed handler + import |
| `default.json` | Added `core:window:allow-toggle-maximize` capability permission |

**+4 / -52 lines** — net deletion of ~48 lines of manual drag handling code.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅  
- `pnpm build` ✅
- Manual: double-click title bar area → window maximizes/restores