### PR TITLE
Add Amp as a known ACP provider

### DIFF
--- a/crates/sprout-acp/README.md
+++ b/crates/sprout-acp/README.md
@@ -9,7 +9,7 @@ Sprout Relay ──WS──→ sprout-acp ──stdio──→ Your Agent
                                        (send_message, etc.)
 ```
 
-Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
+Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)), and **amp** (via [amp-acp](https://github.com/tao12345666333/amp-acp)).
 
 ## Prerequisites
 
@@ -91,6 +91,21 @@ sprout-acp
 
 Older installs that still expose `claude-code-acp` are also supported. `sprout-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
+
+## Running with Amp
+
+[amp-acp](https://github.com/tao12345666333/amp-acp) wraps Sourcegraph's Amp coding agent in an ACP interface.
+
+```bash
+# Install the adapter
+npm install -g amp-acp
+
+# Run
+export AMP_API_KEY="..."   # your Amp API key
+export SPROUT_ACP_AGENT_COMMAND="amp-acp"
+
+sprout-acp
+```
 
 ## Configuration
 

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -134,7 +134,7 @@ impl std::fmt::Display for PermissionMode {
     about = "Query available models from the configured agent"
 )]
 pub struct ModelsArgs {
-    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp").
+    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp", "amp-acp").
     #[arg(long, env = "SPROUT_ACP_AGENT_COMMAND", default_value = "goose")]
     pub agent_command: String,
 
@@ -410,7 +410,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" => Some(Vec::new()),
+        | "claudecode" | "amp-acp" => Some(Vec::new()),
         _ => None,
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -25,6 +25,7 @@ struct KnownAcpProvider {
 const GOOSE_AVATAR_URL: &str = "https://block.github.io/goose/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const AMP_AVATAR_URL: &str = "https://ampcode.com/img/amp-logo.png";
 
 const COMMON_BINARY_PATHS: &[&str] = &[
     "/opt/homebrew/bin",
@@ -54,6 +55,13 @@ const KNOWN_ACP_PROVIDERS: &[KnownAcpProvider] = &[
         commands: &["codex-acp"],
         aliases: &[],
         avatar_url: CODEX_AVATAR_URL,
+    },
+    KnownAcpProvider {
+        id: "amp",
+        label: "Amp",
+        commands: &["amp-acp"],
+        aliases: &[],
+        avatar_url: AMP_AVATAR_URL,
     },
 ];
 
@@ -121,7 +129,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" => Some(Vec::new()),
+        | "claudecode" | "amp-acp" => Some(Vec::new()),
         _ => None,
     }
 }


### PR DESCRIPTION
Register [amp-acp](https://github.com/tao12345666333/amp-acp) as a known ACP provider alongside Goose, Claude Code, and Codex.

## Changes

- **`desktop/src-tauri/src/managed_agents/discovery.rs`** — Add `Amp` to `KNOWN_ACP_PROVIDERS` with command `amp-acp` and avatar URL; add `amp-acp` to `default_agent_args()`
- **`crates/sprout-acp/src/config.rs`** — Add `amp-acp` to `default_agent_args()` match arm; update doc comment
- **`crates/sprout-acp/README.md`** — Add "Running with Amp" section with install and usage instructions; list amp-acp in supported agents

## Install

```bash
npm install -g amp-acp
```

## Usage

```bash
export AMP_API_KEY="..."
export SPROUT_ACP_AGENT_COMMAND="amp-acp"
sprout-acp
```

The desktop app auto-discovers `amp-acp` if it's on PATH.