### PR TITLE
Add Amp as a known ACP provider

### DIFF
--- a/crates/sprout-acp/README.md
+++ b/crates/sprout-acp/README.md
@@ -9,7 +9,7 @@ Sprout Relay ──WS──→ sprout-acp ──stdio──→ Your Agent
                                        (send_message, etc.)
 ```
 
-Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)), and **amp** (via [amp-acp](https://github.com/tao12345666333/amp-acp)).
+Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)), and **amp** (via [acp-amp](https://github.com/SuperagenticAI/acp-amp)).
 
 ## Prerequisites
 
@@ -94,15 +94,15 @@ treats both Claude ACP command names as the same zero-arg runtime.
 
 ## Running with Amp
 
-[amp-acp](https://github.com/tao12345666333/amp-acp) wraps Sourcegraph's Amp coding agent in an ACP interface.
+[acp-amp](https://github.com/SuperagenticAI/acp-amp) wraps Sourcegraph's Amp coding agent in an ACP interface.
 
 ```bash
 # Install the adapter
-npm install -g amp-acp
+npm install -g @superagenticai/acp-amp
 
 # Run
 export AMP_API_KEY="..."   # your Amp API key
-export SPROUT_ACP_AGENT_COMMAND="amp-acp"
+export SPROUT_ACP_AGENT_COMMAND="acp-amp"
 
 sprout-acp
 ```

--- a/crates/sprout-acp/README.md
+++ b/crates/sprout-acp/README.md
@@ -9,7 +9,7 @@ Sprout Relay ──WS──→ sprout-acp ──stdio──→ Your Agent
                                        (send_message, etc.)
 ```
 
-Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
+Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)), and **amp** (via [amp-acp](https://github.com/tao12345666333/amp-acp)).
 
 ## Prerequisites
 
@@ -91,6 +91,21 @@ sprout-acp
 
 Older installs that still expose `claude-code-acp` are also supported. `sprout-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
+
+## Running with Amp
+
+[amp-acp](https://github.com/tao12345666333/amp-acp) wraps Sourcegraph's Amp coding agent in an ACP interface.
+
+```bash
+# Install the adapter
+npm install -g amp-acp
+
+# Run
+export AMP_API_KEY="..."   # your Amp API key
+export SPROUT_ACP_AGENT_COMMAND="amp-acp"
+
+sprout-acp
+```
 
 ## Configuration
 

--- a/crates/sprout-acp/src/acp.rs
+++ b/crates/sprout-acp/src/acp.rs
@@ -287,6 +287,19 @@ impl AcpClient {
         self.send_request("session/set_config_option", params).await
     }
 
+    /// Send `session/set_mode` — newer ACP path used by adapters like amp-acp.
+    pub async fn session_set_mode(
+        &mut self,
+        session_id: &str,
+        mode_id: &str,
+    ) -> Result<serde_json::Value, AcpError> {
+        let params = serde_json::json!({
+            "sessionId": session_id,
+            "modeId": mode_id,
+        });
+        self.send_request("session/set_mode", params).await
+    }
+
     /// Send `session/set_model` (unstable ACP path).
     pub async fn session_set_model(
         &mut self,

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -151,7 +151,7 @@ impl std::fmt::Display for PermissionMode {
     about = "Query available models from the configured agent"
 )]
 pub struct ModelsArgs {
-    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp").
+    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp", "amp-acp").
     #[arg(long, env = "SPROUT_ACP_AGENT_COMMAND", default_value = "goose")]
     pub agent_command: String,
 
@@ -439,7 +439,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" => Some(Vec::new()),
+        | "claudecode" | "amp-acp" => Some(Vec::new()),
         _ => None,
     }
 }

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -151,7 +151,7 @@ impl std::fmt::Display for PermissionMode {
     about = "Query available models from the configured agent"
 )]
 pub struct ModelsArgs {
-    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp", "amp-acp").
+    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp", "acp-amp").
     #[arg(long, env = "SPROUT_ACP_AGENT_COMMAND", default_value = "goose")]
     pub agent_command: String,
 
@@ -439,7 +439,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "amp-acp" => Some(Vec::new()),
+        | "claudecode" | "acp-amp" | "amp-acp" => Some(Vec::new()),
         _ => None,
     }
 }

--- a/crates/sprout-acp/src/pool.rs
+++ b/crates/sprout-acp/src/pool.rs
@@ -416,13 +416,13 @@ async fn create_session_and_apply_model(
     }
 
     // Apply permission mode if not the agent's built-in default AND the agent
-    // advertises the requested mode in session/new. Agents that don't support
+    // advertises a compatible mode in session/new. Agents that don't support
     // the mode (e.g., goose crashes on unrecognized set_config_option values)
     // are safely skipped — the harness auto-approves via handle_permission_request.
-    if !ctx.permission_mode.is_default()
-        && agent_supports_mode(&resp.raw, ctx.permission_mode.as_wire_str())
-    {
-        apply_permission_mode(&mut agent.acp, &resp.session_id, &ctx.permission_mode).await?;
+    if !ctx.permission_mode.is_default() {
+        if let Some(mode_id) = resolve_mode_id(&resp.raw, &ctx.permission_mode) {
+            apply_permission_mode(&mut agent.acp, &resp.session_id, &mode_id).await?;
+        }
     }
 
     Ok(resp.session_id)
@@ -507,20 +507,44 @@ async fn apply_model_switch(
 ///
 /// Non-fatal for most errors: logs and proceeds. The agent falls back
 /// to its default permission mode (`"default"`), which still works via
-/// Check if the agent's `session/new` response advertises a given mode ID
-/// in `result.modes.availableModes[].id`. Returns `false` if the modes
-/// field is absent or the mode isn't listed.
-fn agent_supports_mode(session_new_result: &serde_json::Value, mode_wire: &str) -> bool {
-    session_new_result
-        .get("modes")
-        .and_then(|m| m.get("availableModes"))
-        .and_then(|a| a.as_array())
-        .map(|modes| {
-            modes
-                .iter()
-                .any(|m| m.get("id").and_then(|v| v.as_str()) == Some(mode_wire))
-        })
-        .unwrap_or(false)
+/// Find the agent's advertised mode ID that matches the requested permission
+/// mode.  Tries the canonical ACP wire string first (e.g. `"bypassPermissions"`),
+/// then falls back to known aliases used by other ACP adapters (e.g. amp-acp
+/// advertises `"bypass"` instead of `"bypassPermissions"`).
+///
+/// Returns `None` if the agent doesn't advertise a compatible mode.
+fn resolve_mode_id(
+    session_new_result: &serde_json::Value,
+    mode: &PermissionMode,
+) -> Option<String> {
+    let available = session_new_result
+        .get("modes")?
+        .get("availableModes")?
+        .as_array()?;
+
+    let ids: Vec<&str> = available
+        .iter()
+        .filter_map(|m| m.get("id")?.as_str())
+        .collect();
+
+    // Exact match on the canonical wire string.
+    let wire = mode.as_wire_str();
+    if ids.contains(&wire) {
+        return Some(wire.to_string());
+    }
+
+    // Fallback aliases for known variations across ACP adapters.
+    let aliases: &[&str] = match mode {
+        PermissionMode::BypassPermissions => &["bypass"],
+        PermissionMode::AcceptEdits => &["accept-edits", "accept_edits"],
+        PermissionMode::DontAsk => &["dont-ask", "dont_ask"],
+        _ => &[],
+    };
+
+    aliases
+        .iter()
+        .find(|a| ids.contains(a))
+        .map(|a| a.to_string())
 }
 
 /// per-tool auto-approval in `handle_permission_request`.
@@ -530,11 +554,10 @@ fn agent_supports_mode(session_new_result: &serde_json::Value, mode_wire: &str) 
 async fn apply_permission_mode(
     acp: &mut AcpClient,
     session_id: &str,
-    mode: &PermissionMode,
+    mode_id: &str,
 ) -> Result<(), AcpError> {
-    let wire = mode.as_wire_str();
     let result = tokio::time::timeout(PERMISSION_MODE_TIMEOUT, async {
-        acp.session_set_config_option(session_id, "mode", wire)
+        acp.session_set_config_option(session_id, "mode", mode_id)
             .await
     })
     .await;
@@ -543,7 +566,7 @@ async fn apply_permission_mode(
         Ok(Ok(_)) => {
             tracing::info!(
                 target: "pool::permission",
-                "applied permission mode {wire:?} on session {session_id}"
+                "applied permission mode {mode_id:?} on session {session_id}"
             );
         }
         // Transport-class errors may have corrupted the stdio stream — propagate
@@ -555,7 +578,7 @@ async fn apply_permission_mode(
         | Ok(Err(e @ AcpError::AgentExited)) => {
             tracing::error!(
                 target: "pool::permission",
-                "fatal error setting permission mode {wire:?}: {e}"
+                "fatal error setting permission mode {mode_id:?}: {e}"
             );
             return Err(e);
         }
@@ -563,7 +586,7 @@ async fn apply_permission_mode(
         Ok(Err(e)) => {
             tracing::warn!(
                 target: "pool::permission",
-                "failed to set permission mode {wire:?}: {e} — falling back to per-tool auto-approval"
+                "failed to set permission mode {mode_id:?}: {e} — falling back to per-tool auto-approval"
             );
         }
         Err(_) => {

--- a/crates/sprout-acp/src/pool.rs
+++ b/crates/sprout-acp/src/pool.rs
@@ -549,6 +549,9 @@ fn resolve_mode_id(
 
 /// per-tool auto-approval in `handle_permission_request`.
 ///
+/// Tries `session/set_config_option` first (Claude-style), and if the agent
+/// doesn't support it, falls back to `session/set_mode` (amp-acp style).
+///
 /// **Fatal exception:** if the agent process exits (e.g., goose crashes on
 /// unrecognized methods), returns `Err(AgentExited)` so the caller can respawn.
 async fn apply_permission_mode(
@@ -556,35 +559,59 @@ async fn apply_permission_mode(
     session_id: &str,
     mode_id: &str,
 ) -> Result<(), AcpError> {
-    let result = tokio::time::timeout(PERMISSION_MODE_TIMEOUT, async {
+    // Try session/set_config_option first (Claude-style).
+    let config_result = tokio::time::timeout(PERMISSION_MODE_TIMEOUT, async {
         acp.session_set_config_option(session_id, "mode", mode_id)
             .await
     })
     .await;
 
-    match result {
+    match config_result {
         Ok(Ok(_)) => {
             tracing::info!(
                 target: "pool::permission",
-                "applied permission mode {mode_id:?} on session {session_id}"
+                "applied permission mode {mode_id:?} via set_config_option on session {session_id}"
             );
+            return Ok(());
         }
-        // Transport-class errors may have corrupted the stdio stream — propagate
-        // so the caller can respawn the agent.
+        // Transport-class errors — propagate so the caller can respawn.
         Ok(Err(e @ AcpError::Io(_)))
         | Ok(Err(e @ AcpError::WriteTimeout(_)))
         | Ok(Err(e @ AcpError::Timeout(_)))
         | Ok(Err(e @ AcpError::AgentExited)) => {
-            tracing::error!(
-                target: "pool::permission",
-                "fatal error setting permission mode {mode_id:?}: {e}"
-            );
             return Err(e);
         }
-        // Application-level errors (including JSON-RPC error responses like
-        // "method not found" which surface as AcpError::Protocol) — agent is
-        // fine, just doesn't support this config method. Fall back to
-        // per-tool auto-approval.
+        Err(_) => {
+            return Err(AcpError::Timeout(PERMISSION_MODE_TIMEOUT));
+        }
+        // Application-level error (e.g. "method not found") — try set_mode.
+        Ok(Err(e)) => {
+            tracing::debug!(
+                target: "pool::permission",
+                "set_config_option not supported ({e}), trying session/set_mode"
+            );
+        }
+    }
+
+    // Fallback: session/set_mode (amp-acp style).
+    let mode_result = tokio::time::timeout(PERMISSION_MODE_TIMEOUT, async {
+        acp.session_set_mode(session_id, mode_id).await
+    })
+    .await;
+
+    match mode_result {
+        Ok(Ok(_)) => {
+            tracing::info!(
+                target: "pool::permission",
+                "applied permission mode {mode_id:?} via set_mode on session {session_id}"
+            );
+        }
+        Ok(Err(e @ AcpError::Io(_)))
+        | Ok(Err(e @ AcpError::WriteTimeout(_)))
+        | Ok(Err(e @ AcpError::Timeout(_)))
+        | Ok(Err(e @ AcpError::AgentExited)) => {
+            return Err(e);
+        }
         Ok(Err(e)) => {
             tracing::warn!(
                 target: "pool::permission",
@@ -592,11 +619,6 @@ async fn apply_permission_mode(
             );
         }
         Err(_) => {
-            // Outer timeout fired — stream may be in unknown state.
-            tracing::error!(
-                target: "pool::permission",
-                "permission mode set timed out ({PERMISSION_MODE_TIMEOUT:?}) — treating as fatal"
-            );
             return Err(AcpError::Timeout(PERMISSION_MODE_TIMEOUT));
         }
     }

--- a/crates/sprout-acp/src/pool.rs
+++ b/crates/sprout-acp/src/pool.rs
@@ -574,7 +574,6 @@ async fn apply_permission_mode(
         Ok(Err(e @ AcpError::Io(_)))
         | Ok(Err(e @ AcpError::WriteTimeout(_)))
         | Ok(Err(e @ AcpError::Timeout(_)))
-        | Ok(Err(e @ AcpError::Protocol(_)))
         | Ok(Err(e @ AcpError::AgentExited)) => {
             tracing::error!(
                 target: "pool::permission",
@@ -582,7 +581,10 @@ async fn apply_permission_mode(
             );
             return Err(e);
         }
-        // Application-level errors — agent is fine, just uses default permission mode.
+        // Application-level errors (including JSON-RPC error responses like
+        // "method not found" which surface as AcpError::Protocol) — agent is
+        // fine, just doesn't support this config method. Fall back to
+        // per-tool auto-approval.
         Ok(Err(e)) => {
             tracing::warn!(
                 target: "pool::permission",

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -25,6 +25,7 @@ struct KnownAcpProvider {
 const GOOSE_AVATAR_URL: &str = "https://block.github.io/goose/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const AMP_AVATAR_URL: &str = "https://ampcode.com/img/amp-logo.png";
 
 const COMMON_BINARY_PATHS: &[&str] = &[
     "/opt/homebrew/bin",
@@ -54,6 +55,13 @@ const KNOWN_ACP_PROVIDERS: &[KnownAcpProvider] = &[
         commands: &["codex-acp"],
         aliases: &[],
         avatar_url: CODEX_AVATAR_URL,
+    },
+    KnownAcpProvider {
+        id: "amp",
+        label: "Amp",
+        commands: &["amp-acp"],
+        aliases: &[],
+        avatar_url: AMP_AVATAR_URL,
     },
 ];
 
@@ -121,7 +129,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" => Some(Vec::new()),
+        | "claudecode" | "amp-acp" => Some(Vec::new()),
         _ => None,
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -59,8 +59,8 @@ const KNOWN_ACP_PROVIDERS: &[KnownAcpProvider] = &[
     KnownAcpProvider {
         id: "amp",
         label: "Amp",
-        commands: &["amp-acp"],
-        aliases: &[],
+        commands: &["acp-amp"],
+        aliases: &["amp-acp"],
         avatar_url: AMP_AVATAR_URL,
     },
 ];
@@ -129,7 +129,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "amp-acp" => Some(Vec::new()),
+        | "claudecode" | "acp-amp" | "amp-acp" => Some(Vec::new()),
         _ => None,
     }
 }


### PR DESCRIPTION
Register [acp-amp](https://github.com/SuperagenticAI/acp-amp) as a known ACP provider alongside Goose, Claude Code, and Codex, and fix permission mode handling to work across different ACP adapters.

## Changes

### Amp provider support
- **`desktop/src-tauri/src/managed_agents/discovery.rs`** — Add `Amp` to `KNOWN_ACP_PROVIDERS` with command `acp-amp` and avatar URL; add to `default_agent_args()`
- **`crates/sprout-acp/src/config.rs`** — Add `acp-amp` to `default_agent_args()` match arm; update doc comment
- **`crates/sprout-acp/README.md`** — Add "Running with Amp" section with install and usage instructions; list acp-amp in supported agents

### Permission mode compatibility
- **`crates/sprout-acp/src/pool.rs`** — Replace exact-match `agent_supports_mode()` with `resolve_mode_id()` that tries the canonical ACP wire string first (e.g. `bypassPermissions`), then falls back to known aliases (e.g. Amp advertises `bypass` instead). Fully backwards compatible — existing agents match on the first check.
- **`crates/sprout-acp/src/pool.rs`** — Demote `AcpError::Protocol` from fatal to warn-and-continue in `apply_permission_mode()`. JSON-RPC error responses like `-32601 Method not found` were incorrectly treated as transport errors, causing a respawn loop.
- **`crates/sprout-acp/src/acp.rs`** + **`pool.rs`** — Add `session/set_mode` RPC method and fall back to it when `session/set_config_option` is unsupported. Amp implements `setSessionMode` (newer ACP method) instead of `set_config_option` (Claude-style).

## Install

```bash
npm install -g @superagenticai/acp-amp
```

## Usage

```bash
export AMP_API_KEY="..."
export SPROUT_ACP_AGENT_COMMAND="acp-amp"
sprout-acp
```

The desktop app auto-discovers `acp-amp` if it's on PATH.