### PR TITLE
fix: resolve app hang from memory leaks and de-virtualized DOM

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -48,6 +48,7 @@
     "react-diff-view": "^3.3.2",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
+    "react-virtuoso": "^4.18.4",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      react-virtuoso:
+        specifier: ^4.18.4
+        version: 4.18.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
@@ -925,6 +928,7 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
@@ -935,21 +939,25 @@ packages:
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
@@ -960,11 +968,13 @@ packages:
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
@@ -975,11 +985,13 @@ packages:
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
@@ -1790,6 +1802,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-virtuoso@4.18.4:
+    resolution: {integrity: sha512-DNM4Wy2tMA/J6ejMaDdqecOug31rOwgSRg4C/Dw6Iox4dJe9qwcx32M8HdhkE5uHEVVZh7h0koYwAsCSNdxGfQ==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -3724,6 +3742,11 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  react-virtuoso@4.18.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
 

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -32,7 +32,7 @@ const rules = [
 const overrides = new Map([
   ["src-tauri/src/managed_agents/personas.rs", 600], // built-in persona system prompts (Solo, Ralph, Strategist) are long string literals
   ["src-tauri/src/managed_agents/persona_card.rs", 772], // PNG/ZIP persona card codec + provider/model fields + 27 unit tests (~350 lines of tests); rustfmt adds line breaks around long literals/builders
-  ["src/app/AppShell.tsx", 820], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination
+  ["src/app/AppShell.tsx", 825], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + ancestor cap
   ["src/features/channels/hooks.ts", 550], // canvas query + mutation hooks + DM hide mutation
   ["src/features/channels/ui/ChannelManagementSheet.tsx", 800],
   ["src/features/messages/hooks.ts", 500], // message query/mutation hooks + optimistic updates

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -5,8 +5,8 @@ use tauri::AppHandle;
 use crate::{
     managed_agents::{
         append_log_marker, managed_agent_log_path, missing_command_message, normalize_agent_args,
-        open_log_file, resolve_command, ManagedAgentProcess, ManagedAgentRecord,
-        ManagedAgentSummary,
+        open_log_file, resolve_command, rotate_log_if_needed, ManagedAgentProcess,
+        ManagedAgentRecord, ManagedAgentSummary,
     },
     util::now_iso,
 };
@@ -260,6 +260,7 @@ pub fn start_managed_agent_process(
     }
 
     let log_path = managed_agent_log_path(app, &record.pubkey)?;
+    rotate_log_if_needed(&log_path)?;
     append_log_marker(
         &log_path,
         &format!(

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{self, File, OpenOptions},
-    io::{BufRead, BufReader, Write},
+    io::{Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
 };
 
@@ -71,18 +71,83 @@ pub(crate) fn append_log_marker(path: &Path, message: &str) -> Result<(), String
     writeln!(file, "{message}").map_err(|error| format!("failed to write log marker: {error}"))
 }
 
+/// Read the last `max_lines` lines from a log file by seeking from the end.
+///
+/// Instead of loading the entire file into memory, we read backwards in chunks
+/// until we've found enough newline characters (or reached the start of the file).
+/// This keeps memory usage proportional to the returned tail, not the file size.
 pub fn read_log_tail(path: &Path, max_lines: usize) -> Result<String, String> {
-    if !path.exists() {
+    if max_lines == 0 || !path.exists() {
         return Ok(String::new());
     }
 
-    let file = File::open(path)
+    let mut file = File::open(path)
         .map_err(|error| format!("failed to read log file {}: {error}", path.display()))?;
-    let reader = BufReader::new(file);
-    let lines = reader
-        .lines()
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| format!("failed to read log lines: {error}"))?;
+
+    let file_size = file
+        .seek(SeekFrom::End(0))
+        .map_err(|error| format!("failed to seek log file: {error}"))?;
+
+    if file_size == 0 {
+        return Ok(String::new());
+    }
+
+    // Read backwards in 8 KB chunks, collecting bytes until we have enough newlines.
+    const CHUNK_SIZE: u64 = 8 * 1024;
+    let mut buf = Vec::new();
+    let mut remaining = file_size;
+    let mut newline_count: usize = 0;
+    // We need max_lines+1 newlines to delimit max_lines lines (the leading newline
+    // before the first returned line acts as the boundary).
+    let target_newlines = max_lines + 1;
+
+    while remaining > 0 {
+        let chunk_len = remaining.min(CHUNK_SIZE);
+        remaining -= chunk_len;
+
+        file.seek(SeekFrom::Start(remaining))
+            .map_err(|error| format!("failed to seek log file: {error}"))?;
+
+        let mut chunk = vec![0u8; chunk_len as usize];
+        file.read_exact(&mut chunk)
+            .map_err(|error| format!("failed to read log chunk: {error}"))?;
+
+        // Count newlines in this chunk (iterate backwards so we can bail early).
+        for &byte in chunk.iter().rev() {
+            if byte == b'\n' {
+                newline_count += 1;
+                if newline_count >= target_newlines {
+                    break;
+                }
+            }
+        }
+
+        // Prepend this chunk to our buffer.
+        chunk.append(&mut buf);
+        buf = chunk;
+
+        if newline_count >= target_newlines {
+            break;
+        }
+    }
+
+    // Convert to a string. If we landed on a UTF-8 boundary mid-character,
+    // skip forward to the next valid boundary.
+    let text = match String::from_utf8(buf) {
+        Ok(s) => s,
+        Err(err) => {
+            let bytes = err.into_bytes();
+            // Find the first valid UTF-8 start by skipping continuation bytes.
+            let start = bytes
+                .iter()
+                .position(|b| (*b as i8) >= -64) // not a continuation byte (0b10xxxxxx)
+                .unwrap_or(0);
+            String::from_utf8_lossy(&bytes[start..]).into_owned()
+        }
+    };
+
+    // Extract the last max_lines lines from the text we read.
+    let lines: Vec<&str> = text.lines().collect();
     let start = lines.len().saturating_sub(max_lines);
     Ok(lines[start..].join("\n"))
 }

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -58,6 +58,43 @@ pub fn save_managed_agents(app: &AppHandle, records: &[ManagedAgentRecord]) -> R
     fs::write(&path, payload).map_err(|error| format!("failed to write agent store: {error}"))
 }
 
+const LOG_ROTATION_THRESHOLD: u64 = 10 * 1024 * 1024; // 10 MB
+const LOG_ROTATION_KEEP: u32 = 3;
+
+/// Rotate the log file if it exceeds the size threshold.
+///
+/// Called BEFORE the agent process starts (before `open_log_file`) so the child
+/// process gets a fresh fd. Existing rotations shift: `.log` → `.log.1`,
+/// `.log.1` → `.log.2`, `.log.2` → `.log.3`. Keeps the last 3 rotations.
+pub(crate) fn rotate_log_if_needed(path: &Path) -> Result<(), String> {
+    let metadata = match fs::metadata(path) {
+        Ok(m) => m,
+        Err(_) => return Ok(()), // File doesn't exist yet — nothing to rotate.
+    };
+
+    if metadata.len() < LOG_ROTATION_THRESHOLD {
+        return Ok(());
+    }
+
+    let path_str = path.display().to_string();
+
+    // Shift older rotations: .3 is dropped, .2→.3, .1→.2, current→.1
+    for i in (1..LOG_ROTATION_KEEP).rev() {
+        let src = format!("{path_str}.{i}");
+        let dst = format!("{path_str}.{}", i + 1);
+        if Path::new(&src).exists() {
+            let _ = fs::rename(&src, &dst);
+        }
+    }
+
+    // Rotate current log to .1
+    let rotated = format!("{path_str}.1");
+    fs::rename(path, &rotated)
+        .map_err(|error| format!("failed to rotate log file {}: {error}", path.display()))?;
+
+    Ok(())
+}
+
 pub(crate) fn open_log_file(path: &Path) -> Result<File, String> {
     OpenOptions::new()
         .create(true)

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -65,6 +65,7 @@ import { useWebviewZoomShortcuts } from "@/app/useWebviewZoomShortcuts";
 
 type AppView = "home" | "channel" | "settings" | "agents";
 type MainView = Exclude<AppView, "settings">;
+
 export function AppShell() {
   useWebviewZoomShortcuts();
   const [selectedView, setSelectedView] = React.useState<AppView>("home");
@@ -471,6 +472,9 @@ export function AppShell() {
       return;
     }
 
+    if (requestedAncestorIdsRef.current.size + missingAncestorIds.size > 500) {
+      requestedAncestorIdsRef.current.clear();
+    }
     for (const eventId of missingAncestorIds) {
       requestedAncestorIdsRef.current.add(eventId);
     }

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -66,7 +66,6 @@ import { useWebviewZoomShortcuts } from "@/app/useWebviewZoomShortcuts";
 
 type AppView = "home" | "channel" | "settings" | "agents";
 type MainView = Exclude<AppView, "settings">;
-
 export function AppShell() {
   useWebviewZoomShortcuts();
   const [selectedView, setSelectedView] = React.useState<AppView>("home");
@@ -474,11 +473,10 @@ export function AppShell() {
       }
     }
 
-    if (missingAncestorIds.size === 0) {
-      return;
-    }
-
-    if (requestedAncestorIdsRef.current.size >= 500) {
+    if (
+      missingAncestorIds.size === 0 ||
+      requestedAncestorIdsRef.current.size >= 500
+    ) {
       return;
     }
     for (const eventId of missingAncestorIds) {

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -472,8 +472,8 @@ export function AppShell() {
       return;
     }
 
-    if (requestedAncestorIdsRef.current.size + missingAncestorIds.size > 500) {
-      requestedAncestorIdsRef.current.clear();
+    if (requestedAncestorIdsRef.current.size >= 500) {
+      return;
     }
     for (const eventId of missingAncestorIds) {
       requestedAncestorIdsRef.current.add(eventId);

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -139,7 +139,7 @@ export function useChannelMessagesQuery(channel: Channel | null) {
       return mergedHistory;
     },
     staleTime: Number.POSITIVE_INFINITY,
-    gcTime: 30 * 60 * 1_000,
+    gcTime: 5 * 60 * 1_000,
   });
 }
 

--- a/desktop/src/features/messages/lib/formatTimelineMessages.ts
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.ts
@@ -158,14 +158,11 @@ export function formatTimelineMessages(
     (event) => isTimelineContentEvent(event) && !deletedEventIds.has(event.id),
   );
   const eventsById = new Map(visibleEvents.map((event) => [event.id, event]));
-  const reactionPresence = new Map<
-    string,
-    {
-      targetId: string;
-      actorPubkey: string;
-      emoji: string;
-    }
-  >();
+  // Build reaction aggregations in a single pass, eliminating the intermediate
+  // reactionPresence Map. Deduplicate with a Set of composite keys and aggregate
+  // directly into reactionsByEventId to reduce allocation pressure.
+  const reactionsByEventId = new Map<string, Map<string, TimelineReaction>>();
+  const seenReactions = new Set<string>();
 
   for (const event of events) {
     if (event.kind !== KIND_REACTION || deletedEventIds.has(event.id)) {
@@ -184,17 +181,20 @@ export function formatTimelineMessages(
       requireChannelTagForPTags: true,
     }).toLowerCase();
     const emoji = event.content.trim() || "+";
-    reactionPresence.set(`${targetId}:${actorPubkey}:${emoji}`, {
-      targetId,
-      actorPubkey,
-      emoji,
-    });
-  }
+    const dedupeKey = `${targetId}:${actorPubkey}:${emoji}`;
 
-  const reactionsByEventId = new Map<string, Map<string, TimelineReaction>>();
-  for (const { targetId, actorPubkey, emoji } of reactionPresence.values()) {
-    const current = reactionsByEventId.get(targetId) ?? new Map();
-    const existing = current.get(emoji) ?? {
+    if (seenReactions.has(dedupeKey)) {
+      continue;
+    }
+    seenReactions.add(dedupeKey);
+
+    let emojiMap = reactionsByEventId.get(targetId);
+    if (!emojiMap) {
+      emojiMap = new Map();
+      reactionsByEventId.set(targetId, emojiMap);
+    }
+
+    const existing = emojiMap.get(emoji) ?? {
       emoji,
       count: 0,
       reactedByCurrentUser: false,
@@ -213,8 +213,7 @@ export function formatTimelineMessages(
       `${actorPubkey.slice(0, 8)}…`;
     existing.users.push({ pubkey: actorPubkey, displayName });
 
-    current.set(emoji, existing);
-    reactionsByEventId.set(targetId, current);
+    emojiMap.set(emoji, existing);
   }
 
   const authorPubkeyByEventId = new Map<string, string>();

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -41,6 +41,8 @@ type MessageTimelineProps = {
   onTargetReached?: (messageId: string) => void;
 };
 
+const FIRST_ITEM_START = 100_000;
+
 /**
  * Compute day-based groups from a sorted messages array.
  * Returns { groupCounts, groupLabels } for GroupedVirtuoso.
@@ -101,7 +103,6 @@ export const MessageTimeline = React.memo(function MessageTimeline({
   const previousMessageCountRef = React.useRef(0);
   const isFetchingOlderRef = React.useRef(false);
   const handledTargetMessageIdRef = React.useRef<string | null>(null);
-  const FIRST_ITEM_START = 100_000;
   const [firstItemIndex, setFirstItemIndex] = React.useState(FIRST_ITEM_START);
 
   const { groupCounts, groupLabels } = useTimelineGroups(messages);

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -214,7 +214,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     onTargetReached?.(targetMessageId);
 
     virtuosoRef.current?.scrollToIndex({
-      index: targetIndex,
+      index: firstItemIndex + targetIndex,
       align: "center",
       behavior: "smooth",
     });
@@ -228,7 +228,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [isLoading, messages, onTargetReached, targetMessageId]);
+  }, [firstItemIndex, isLoading, messages, onTargetReached, targetMessageId]);
 
   const groupContent = React.useCallback(
     (index: number) => <DayDivider label={groupLabels[index]} />,
@@ -237,7 +237,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
 
   const itemContent = React.useCallback(
     (index: number) => {
-      const message = messages[index];
+      const message = messages[index - firstItemIndex];
       if (!message) {
         return null;
       }
@@ -277,9 +277,11 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     },
     [
       messages,
+      firstItemIndex,
       activeReplyTargetId,
       currentPubkey,
       highlightedMessageId,
+      onDelete,
       onEdit,
       onReply,
       onToggleReaction,

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -1,16 +1,21 @@
 import * as React from "react";
+import { GroupedVirtuoso, type GroupedVirtuosoHandle } from "react-virtuoso";
 import { ArrowDown, Loader2 } from "lucide-react";
 
+import {
+  formatDayHeading,
+  isSameDay,
+} from "@/features/messages/lib/dateFormatters";
 import type { TimelineMessage } from "@/features/messages/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { KIND_SYSTEM_MESSAGE } from "@/shared/constants/kinds";
 import { Button } from "@/shared/ui/button";
 import { Separator } from "@/shared/ui/separator";
 import { TooltipProvider } from "@/shared/ui/tooltip";
+import { DayDivider } from "./DayDivider";
+import { MessageRow } from "./MessageRow";
+import { SystemMessageRow } from "./SystemMessageRow";
 import { TimelineSkeleton } from "./TimelineSkeleton";
-import { TimelineMessageList } from "./TimelineMessageList";
-import { useLoadOlderOnScroll } from "./useLoadOlderOnScroll";
-import { useStickyDayHeader } from "./useStickyDayHeader";
-import { useTimelineScrollManager } from "./useTimelineScrollManager";
 
 type MessageTimelineProps = {
   channelId?: string | null;
@@ -35,6 +40,37 @@ type MessageTimelineProps = {
   onTargetReached?: (messageId: string) => void;
 };
 
+/**
+ * Compute day-based groups from a sorted messages array.
+ * Returns { groupCounts, groupLabels } for GroupedVirtuoso.
+ */
+function useTimelineGroups(messages: TimelineMessage[]) {
+  return React.useMemo(() => {
+    if (messages.length === 0) {
+      return { groupCounts: [] as number[], groupLabels: [] as string[] };
+    }
+
+    const groupCounts: number[] = [];
+    const groupLabels: string[] = [];
+    let currentCount = 1;
+
+    groupLabels.push(formatDayHeading(messages[0].createdAt));
+
+    for (let i = 1; i < messages.length; i++) {
+      if (!isSameDay(messages[i - 1].createdAt, messages[i].createdAt)) {
+        groupCounts.push(currentCount);
+        groupLabels.push(formatDayHeading(messages[i].createdAt));
+        currentCount = 1;
+      } else {
+        currentCount++;
+      }
+    }
+    groupCounts.push(currentCount);
+
+    return { groupCounts, groupLabels };
+  }, [messages]);
+}
+
 export const MessageTimeline = React.memo(function MessageTimeline({
   channelId,
   messages,
@@ -53,85 +89,228 @@ export const MessageTimeline = React.memo(function MessageTimeline({
   targetMessageId = null,
   onTargetReached,
 }: MessageTimelineProps) {
-  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
-  const topSentinelRef = React.useRef<HTMLDivElement>(null);
+  const virtuosoRef = React.useRef<GroupedVirtuosoHandle>(null);
+  const [isAtBottom, setIsAtBottom] = React.useState(true);
+  const [newMessageCount, setNewMessageCount] = React.useState(0);
+  const [highlightedMessageId, setHighlightedMessageId] = React.useState<
+    string | null
+  >(null);
+  const previousLastMessageIdRef = React.useRef<string | undefined>(undefined);
+  const previousMessageCountRef = React.useRef(0);
+  const isFetchingOlderRef = React.useRef(false);
+  const handledTargetMessageIdRef = React.useRef<string | null>(null);
 
-  const {
-    bottomAnchorRef,
-    contentRef,
-    highlightedMessageId,
-    isAtBottom,
-    newMessageCount,
-    restoreScrollPosition,
-    scrollToBottom,
-    syncScrollState,
-  } = useTimelineScrollManager({
-    channelId,
-    isLoading,
-    messages,
-    onTargetReached,
-    scrollContainerRef,
-    targetMessageId,
-  });
+  const { groupCounts, groupLabels } = useTimelineGroups(messages);
 
-  useLoadOlderOnScroll({
-    fetchOlder,
-    hasOlderMessages,
-    isLoading,
-    restoreScrollPosition,
-    scrollContainerRef,
-    sentinelRef: topSentinelRef,
-  });
+  // Reset state on channel change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: channelId is the sole trigger for resetting scroll state
+  React.useEffect(() => {
+    setIsAtBottom(true);
+    setNewMessageCount(0);
+    setHighlightedMessageId(null);
+    previousLastMessageIdRef.current = undefined;
+    previousMessageCountRef.current = 0;
+    handledTargetMessageIdRef.current = null;
+  }, [channelId]);
 
-  const stickyDayLabel = useStickyDayHeader(scrollContainerRef);
+  // Track new messages when scrolled up
+  React.useEffect(() => {
+    if (isLoading || messages.length === 0) {
+      previousLastMessageIdRef.current =
+        messages.length > 0 ? messages[messages.length - 1]?.id : undefined;
+      previousMessageCountRef.current = messages.length;
+      return;
+    }
+
+    const latestMessage = messages[messages.length - 1];
+    const previousLastMessageId = previousLastMessageIdRef.current;
+    const previousMessageCount = previousMessageCountRef.current;
+
+    if (
+      latestMessage.id !== previousLastMessageId &&
+      previousLastMessageId !== undefined
+    ) {
+      if (!isAtBottom && !latestMessage.accent) {
+        const addedMessages = Math.max(
+          1,
+          messages.length - previousMessageCount,
+        );
+        setNewMessageCount((c) => c + addedMessages);
+      }
+    }
+
+    previousLastMessageIdRef.current = latestMessage.id;
+    previousMessageCountRef.current = messages.length;
+  }, [isLoading, messages, isAtBottom]);
+
+  const handleAtBottomStateChange = React.useCallback((atBottom: boolean) => {
+    setIsAtBottom(atBottom);
+    if (atBottom) {
+      setNewMessageCount(0);
+    }
+  }, []);
+
+  // followOutput: auto-scroll to bottom when new messages arrive (if already at bottom)
+  const followOutput = React.useCallback((isAtBottomParam: boolean) => {
+    if (isAtBottomParam) {
+      return "smooth";
+    }
+    return false;
+  }, []);
+
+  // Load older messages when scrolling to top
+  const handleStartReached = React.useCallback(() => {
+    if (!fetchOlder || !hasOlderMessages || isFetchingOlderRef.current) {
+      return;
+    }
+    isFetchingOlderRef.current = true;
+    void fetchOlder().finally(() => {
+      isFetchingOlderRef.current = false;
+    });
+  }, [fetchOlder, hasOlderMessages]);
+
+  const scrollToBottom = React.useCallback(
+    (behavior: "auto" | "smooth" = "smooth") => {
+      virtuosoRef.current?.scrollToIndex({
+        index: "LAST",
+        behavior,
+      });
+      setNewMessageCount(0);
+    },
+    [],
+  );
+
+  // Handle target message scrolling (e.g. jump-to-message)
+  React.useEffect(() => {
+    if (!targetMessageId) {
+      handledTargetMessageIdRef.current = null;
+      setHighlightedMessageId(null);
+      return;
+    }
+
+    if (handledTargetMessageIdRef.current === targetMessageId || isLoading) {
+      return;
+    }
+
+    const targetIndex = messages.findIndex((m) => m.id === targetMessageId);
+    if (targetIndex === -1) {
+      return;
+    }
+
+    handledTargetMessageIdRef.current = targetMessageId;
+    setHighlightedMessageId(targetMessageId);
+    onTargetReached?.(targetMessageId);
+
+    virtuosoRef.current?.scrollToIndex({
+      index: targetIndex,
+      align: "center",
+      behavior: "smooth",
+    });
+
+    const timeout = window.setTimeout(() => {
+      setHighlightedMessageId((current) =>
+        current === targetMessageId ? null : current,
+      );
+    }, 2_000);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [isLoading, messages, onTargetReached, targetMessageId]);
+
+  const groupContent = React.useCallback(
+    (index: number) => <DayDivider label={groupLabels[index]} />,
+    [groupLabels],
+  );
+
+  const itemContent = React.useCallback(
+    (index: number) => {
+      const message = messages[index];
+      if (!message) {
+        return null;
+      }
+
+      if (message.kind === KIND_SYSTEM_MESSAGE) {
+        return (
+          <SystemMessageRow
+            body={message.body}
+            createdAt={message.createdAt}
+            currentPubkey={currentPubkey}
+            profiles={profiles}
+            time={message.time}
+          />
+        );
+      }
+
+      return (
+        <MessageRow
+          activeReplyTargetId={activeReplyTargetId}
+          highlighted={message.id === highlightedMessageId}
+          message={message}
+          onEdit={
+            onEdit && currentPubkey && message.pubkey === currentPubkey
+              ? onEdit
+              : undefined
+          }
+          onToggleReaction={onToggleReaction}
+          onReply={onReply}
+          profiles={profiles}
+        />
+      );
+    },
+    [
+      messages,
+      activeReplyTargetId,
+      currentPubkey,
+      highlightedMessageId,
+      onEdit,
+      onReply,
+      onToggleReaction,
+      profiles,
+    ],
+  );
+
+  const Header = React.useCallback(() => {
+    if (isFetchingOlder) {
+      return (
+        <div className="flex justify-center py-2">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      );
+    }
+    if (!hasOlderMessages && !isLoading && messages.length > 0) {
+      return (
+        <div
+          className="flex items-center gap-3 py-2"
+          data-testid="message-timeline-beginning"
+        >
+          <Separator className="flex-1" />
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+            Beginning of conversation
+          </p>
+          <Separator className="flex-1" />
+        </div>
+      );
+    }
+    return null;
+  }, [isFetchingOlder, hasOlderMessages, isLoading, messages.length]);
+
+  const showVirtuoso = !isLoading && messages.length > 0;
 
   return (
     <TooltipProvider delayDuration={200}>
       <div className="relative min-h-0 flex-1">
-        {stickyDayLabel && !isAtBottom ? (
-          <div
-            className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center px-4 pt-2 sm:px-6"
-            data-testid="message-timeline-sticky-day"
-          >
-            <p className="rounded-full bg-muted/90 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground shadow-sm backdrop-blur-sm">
-              {stickyDayLabel}
-            </p>
+        {isLoading ? (
+          <div className="h-full overflow-y-auto px-4 py-3 sm:px-6">
+            <div className="mx-auto w-full max-w-4xl">
+              <TimelineSkeleton />
+            </div>
           </div>
         ) : null}
-        <div
-          className="h-full overflow-y-auto overflow-x-hidden overscroll-contain px-4 py-3 [overflow-anchor:none] sm:px-6"
-          data-testid="message-timeline"
-          onScroll={syncScrollState}
-          ref={scrollContainerRef}
-        >
-          <div
-            className="mx-auto flex w-full max-w-4xl flex-col gap-2"
-            ref={contentRef}
-          >
-            <div ref={topSentinelRef} aria-hidden className="h-px" />
 
-            {isFetchingOlder ? (
-              <div className="flex justify-center py-2">
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-              </div>
-            ) : null}
-
-            {!hasOlderMessages && !isLoading && messages.length > 0 ? (
-              <div
-                className="flex items-center gap-3 py-2"
-                data-testid="message-timeline-beginning"
-              >
-                <Separator className="flex-1" />
-                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                  Beginning of conversation
-                </p>
-                <Separator className="flex-1" />
-              </div>
-            ) : null}
-
-            {isLoading ? <TimelineSkeleton /> : null}
-
-            {!isLoading && messages.length === 0 ? (
+        {!isLoading && messages.length === 0 ? (
+          <div className="h-full overflow-y-auto px-4 py-3 sm:px-6">
+            <div className="mx-auto w-full max-w-4xl">
               <div
                 className="rounded-3xl border border-dashed border-border/80 bg-card/70 px-6 py-10 text-center shadow-sm"
                 data-testid="message-empty"
@@ -143,33 +322,38 @@ export const MessageTimeline = React.memo(function MessageTimeline({
                   {emptyDescription}
                 </p>
               </div>
-            ) : null}
-
-            {!isLoading && messages.length > 0 ? (
-              <TimelineMessageList
-                activeReplyTargetId={activeReplyTargetId}
-                currentPubkey={currentPubkey}
-                highlightedMessageId={highlightedMessageId}
-                messages={messages}
-                onEdit={onEdit}
-                onReply={onReply}
-                onToggleReaction={onToggleReaction}
-                profiles={profiles}
-              />
-            ) : null}
-
-            <div aria-hidden className="h-px" ref={bottomAnchorRef} />
+            </div>
           </div>
-        </div>
+        ) : null}
 
-        {!isAtBottom ? (
+        {showVirtuoso ? (
+          <GroupedVirtuoso
+            ref={virtuosoRef}
+            className="h-full overflow-x-hidden overscroll-contain px-4 py-3 sm:px-6"
+            data-testid="message-timeline"
+            groupCounts={groupCounts}
+            groupContent={groupContent}
+            itemContent={itemContent}
+            components={{ Header }}
+            initialTopMostItemIndex={messages.length - 1}
+            followOutput={followOutput}
+            atBottomStateChange={handleAtBottomStateChange}
+            atBottomThreshold={72}
+            startReached={handleStartReached}
+            increaseViewportBy={200}
+            style={{
+              // Outer container needs flex-1 + full height
+              height: "100%",
+            }}
+          />
+        ) : null}
+
+        {!isAtBottom && showVirtuoso ? (
           <div className="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center px-4">
             <Button
               className="pointer-events-auto rounded-full shadow-lg"
               data-testid="message-scroll-to-latest"
-              onClick={() => {
-                scrollToBottom("smooth");
-              }}
+              onClick={() => scrollToBottom("smooth")}
               size="sm"
               type="button"
             >

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -99,6 +99,8 @@ export const MessageTimeline = React.memo(function MessageTimeline({
   const previousMessageCountRef = React.useRef(0);
   const isFetchingOlderRef = React.useRef(false);
   const handledTargetMessageIdRef = React.useRef<string | null>(null);
+  const FIRST_ITEM_START = 100_000;
+  const [firstItemIndex, setFirstItemIndex] = React.useState(FIRST_ITEM_START);
 
   const { groupCounts, groupLabels } = useTimelineGroups(messages);
 
@@ -108,6 +110,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     setIsAtBottom(true);
     setNewMessageCount(0);
     setHighlightedMessageId(null);
+    setFirstItemIndex(FIRST_ITEM_START);
     previousLastMessageIdRef.current = undefined;
     previousMessageCountRef.current = 0;
     handledTargetMessageIdRef.current = null;
@@ -125,16 +128,23 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     const latestMessage = messages[messages.length - 1];
     const previousLastMessageId = previousLastMessageIdRef.current;
     const previousMessageCount = previousMessageCountRef.current;
+    const countDelta = messages.length - previousMessageCount;
+
+    // Detect prepend: message count grew but the latest message didn't change
+    if (
+      countDelta > 0 &&
+      previousLastMessageId !== undefined &&
+      latestMessage.id === previousLastMessageId
+    ) {
+      setFirstItemIndex((prev) => prev - countDelta);
+    }
 
     if (
       latestMessage.id !== previousLastMessageId &&
       previousLastMessageId !== undefined
     ) {
       if (!isAtBottom && !latestMessage.accent) {
-        const addedMessages = Math.max(
-          1,
-          messages.length - previousMessageCount,
-        );
+        const addedMessages = Math.max(1, countDelta);
         setNewMessageCount((c) => c + addedMessages);
       }
     }
@@ -331,6 +341,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
             ref={virtuosoRef}
             className="h-full overflow-x-hidden overscroll-contain px-4 py-3 sm:px-6"
             data-testid="message-timeline"
+            firstItemIndex={firstItemIndex}
             groupCounts={groupCounts}
             groupContent={groupContent}
             itemContent={itemContent}

--- a/desktop/src/features/messages/useChannelTyping.ts
+++ b/desktop/src/features/messages/useChannelTyping.ts
@@ -14,6 +14,7 @@ type TypingState = Record<string, number>;
 const TYPING_INDICATOR_TTL_MS = 8_000;
 const TYPING_PRUNE_INTERVAL_MS = 1_000;
 const TYPING_POST_MESSAGE_SUPPRESS_MS = 2_000;
+const LATEST_MESSAGE_MAX_AGE_S = 5 * 60; // 5 minutes in seconds
 
 function pruneTypingState(state: TypingState, now = Date.now()) {
   let changed = false;
@@ -110,6 +111,18 @@ export function useChannelTyping(
     }
 
     const authorPubkey = latestMessageEvent.pubkey.toLowerCase();
+
+    // Prune stale entries to prevent unbounded growth within a channel session
+    const nowS = Math.floor(Date.now() / 1_000);
+    const cutoff = nowS - LATEST_MESSAGE_MAX_AGE_S;
+    for (const [key, ts] of Object.entries(
+      latestMessageCreatedAtByPubkeyRef.current,
+    )) {
+      if (ts < cutoff) {
+        delete latestMessageCreatedAtByPubkeyRef.current[key];
+      }
+    }
+
     latestMessageCreatedAtByPubkeyRef.current[authorPubkey] = Math.max(
       latestMessageCreatedAtByPubkeyRef.current[authorPubkey] ?? 0,
       latestMessageEvent.created_at,

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -23,6 +23,7 @@ const RECONNECT_BASE_DELAY_MS = 1_000;
 const RECONNECT_MAX_DELAY_MS = 30_000;
 const RECONNECT_REPLAY_SKEW_SECS = 5;
 const EVENT_BATCH_MS = 16;
+const EVENT_BUFFER_MAX_SIZE = 1_000;
 
 export class RelayClient {
   private wsId: number | null = null;
@@ -529,10 +530,19 @@ export class RelayClient {
     );
 
     this.eventBuffer.push({ subId, event });
-    this.flushTimeout ??= window.setTimeout(
-      () => this.flushEventBuffer(),
-      EVENT_BATCH_MS,
-    );
+
+    if (this.eventBuffer.length >= EVENT_BUFFER_MAX_SIZE) {
+      if (this.flushTimeout !== null) {
+        window.clearTimeout(this.flushTimeout);
+        this.flushTimeout = null;
+      }
+      this.flushEventBuffer();
+    } else {
+      this.flushTimeout ??= window.setTimeout(
+        () => this.flushEventBuffer(),
+        EVENT_BATCH_MS,
+      );
+    }
   }
 
   private flushEventBuffer() {


### PR DESCRIPTION
## Summary

- **Virtualize message timeline** with `react-virtuoso` (`GroupedVirtuoso`) — replaces rendering all DOM nodes for every message, which was the primary cause of the app hang in channels with long history
- **Fix unbounded Rust log reads** — `read_log_tail` now seeks from end instead of loading the whole file; adds log rotation on agent start (10MB cap, keep 3)
- **Reduce memory pressure** — lower `gcTime` from 30m→5m, single-pass reaction aggregation, cap `requestedAncestorIdsRef` at 500 entries, prune typing ref map
- **Fix virtual index offset bug** — `GroupedVirtuoso` passes virtual indices (starting at 100,000) to `itemContent`; corrected to `messages[index - firstItemIndex]` and fixed `scrollToIndex` for jump-to-message
- **Integrate delete message support** from main after merge

## Commits

| Commit | Description |
|--------|-------------|
| `1306b77` | Prune typing ref map + reduce message cache gcTime |
| `14348f8` | Single-pass reaction aggregation + buffer cap |
| `64c4b01` | Virtualize message timeline with GroupedVirtuoso |
| `1951a76` | Rewrite `read_log_tail` to seek from end |
| `24b15fe` | Cap `requestedAncestorIdsRef` with early return |
| `b4605c7` | Log rotation on agent start (10MB, keep 3) |
| `6af8a16` | Add `firstItemIndex` for stable prepends |
| `dacd6fc` | Fix virtual index offset in itemContent + scrollToIndex |
| `2a3270f` | Hoist `FIRST_ITEM_START` to module scope |

## Test plan

- [ ] Open a channel with long message history — verify messages render and scroll smoothly
- [ ] Scroll up to load older messages — verify prepend doesn't cause scroll jump
- [ ] Use jump-to-message — verify it scrolls to the correct message
- [ ] Send a new message while scrolled up — verify "new messages" badge appears
- [ ] Delete own message — verify delete works in virtualized list
- [ ] Leave app running for extended period — verify no memory growth from log reads
- [ ] Check agent logs — verify rotation creates `.1`, `.2`, `.3` backups at 10MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)