### PR TITLE
chore: clean Tauri build artifacts in `just clean`

### DIFF
--- a/justfile
+++ b/justfile
@@ -188,6 +188,7 @@ migrate:
 # Remove build artifacts
 clean:
     cargo clean
+    cargo clean --manifest-path desktop/src-tauri/Cargo.toml
 
 # Check the Rust workspace compiles without producing binaries
 check-compile:


### PR DESCRIPTION
## What

Adds `cargo clean --manifest-path desktop/src-tauri/Cargo.toml` to the `just clean` recipe.

## Why

`desktop/src-tauri` is [explicitly excluded](https://github.com/block/sprout/blob/main/Cargo.toml) from the root Cargo workspace, so `cargo clean` at the root doesn't remove its `target/` directory. Without this, stale Tauri build artifacts survive a `just clean`.