### PR TITLE
fix(desktop): plug memory leaks causing 37GB+ RAM growth

### DIFF
--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -1126,6 +1126,14 @@ impl Db {
         workflow::get_approval(&self.pool, token).await
     }
 
+    /// Fetch all approvals for a workflow run.
+    pub async fn get_run_approvals(
+        &self,
+        run_id: uuid::Uuid,
+    ) -> Result<Vec<workflow::ApprovalRecord>> {
+        workflow::get_run_approvals(&self.pool, run_id).await
+    }
+
     /// Update an approval's status.
     pub async fn update_approval(
         &self,

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -1129,9 +1129,10 @@ impl Db {
     /// Fetch all approvals for a workflow run.
     pub async fn get_run_approvals(
         &self,
+        workflow_id: uuid::Uuid,
         run_id: uuid::Uuid,
     ) -> Result<Vec<workflow::ApprovalRecord>> {
-        workflow::get_run_approvals(&self.pool, run_id).await
+        workflow::get_run_approvals(&self.pool, workflow_id, run_id).await
     }
 
     /// Update an approval's status.

--- a/crates/sprout-db/src/workflow.rs
+++ b/crates/sprout-db/src/workflow.rs
@@ -662,17 +662,22 @@ pub async fn get_approval(pool: &PgPool, token: &str) -> Result<ApprovalRecord> 
 }
 
 /// Fetch all approval records for a given workflow run.
-pub async fn get_run_approvals(pool: &PgPool, run_id: Uuid) -> Result<Vec<ApprovalRecord>> {
+pub async fn get_run_approvals(
+    pool: &PgPool,
+    workflow_id: Uuid,
+    run_id: Uuid,
+) -> Result<Vec<ApprovalRecord>> {
     let rows = sqlx::query(
         r#"
         SELECT token, workflow_id, run_id, step_id, step_index, approver_spec,
                status::text AS status, approver_pubkey, note, expires_at, created_at
         FROM workflow_approvals
-        WHERE run_id = $1
+        WHERE run_id = $1 AND workflow_id = $2
         ORDER BY step_index, created_at
         "#,
     )
     .bind(run_id)
+    .bind(workflow_id)
     .fetch_all(pool)
     .await?;
 

--- a/crates/sprout-db/src/workflow.rs
+++ b/crates/sprout-db/src/workflow.rs
@@ -661,6 +661,24 @@ pub async fn get_approval(pool: &PgPool, token: &str) -> Result<ApprovalRecord> 
     row_to_approval_record(row)
 }
 
+/// Fetch all approval records for a given workflow run.
+pub async fn get_run_approvals(pool: &PgPool, run_id: Uuid) -> Result<Vec<ApprovalRecord>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT token, workflow_id, run_id, step_id, step_index, approver_spec,
+               status::text AS status, approver_pubkey, note, expires_at, created_at
+        FROM workflow_approvals
+        WHERE run_id = $1
+        ORDER BY step_index, created_at
+        "#,
+    )
+    .bind(run_id)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_approval_record).collect()
+}
+
 /// Update an approval's status, approver pubkey, and optional note.
 /// Also stamps `granted_at` or `denied_at` based on the new status.
 ///

--- a/crates/sprout-relay/src/api/mod.rs
+++ b/crates/sprout-relay/src/api/mod.rs
@@ -67,8 +67,8 @@ pub use users::{
     get_profile, get_user_profile, get_users_batch, put_channel_add_policy, search_users,
 };
 pub use workflows::{
-    create_workflow, delete_workflow, get_workflow, list_channel_workflows, list_workflow_runs,
-    trigger_workflow, update_workflow, workflow_webhook,
+    create_workflow, delete_workflow, get_workflow, list_channel_workflows, list_run_approvals,
+    list_workflow_runs, trigger_workflow, update_workflow, workflow_webhook,
 };
 
 // ── Shared helpers ────────────────────────────────────────────────────────────

--- a/crates/sprout-relay/src/api/workflow_helpers.rs
+++ b/crates/sprout-relay/src/api/workflow_helpers.rs
@@ -46,6 +46,25 @@ pub(crate) fn run_record_to_json(r: &sprout_db::workflow::WorkflowRunRecord) -> 
     })
 }
 
+/// Serialize an [`ApprovalRecord`] to a JSON value.
+pub(crate) fn approval_record_to_json(
+    a: &sprout_db::workflow::ApprovalRecord,
+) -> serde_json::Value {
+    serde_json::json!({
+        "token": a.token,
+        "workflow_id": a.workflow_id.to_string(),
+        "run_id": a.run_id.to_string(),
+        "step_id": a.step_id,
+        "step_index": a.step_index,
+        "approver_spec": a.approver_spec,
+        "status": a.status.to_string(),
+        "approver_pubkey": a.approver_pubkey.as_ref().map(|pk| nostr_hex::encode(pk)),
+        "note": a.note,
+        "expires_at": a.expires_at.to_rfc3339(),
+        "created_at": a.created_at.timestamp(),
+    })
+}
+
 // ── SSRF prevention ───────────────────────────────────────────────────────────
 
 /// Validate all CallWebhook URLs in a workflow definition.

--- a/crates/sprout-relay/src/api/workflow_helpers.rs
+++ b/crates/sprout-relay/src/api/workflow_helpers.rs
@@ -58,7 +58,7 @@ pub(crate) fn approval_record_to_json(
         "step_index": a.step_index,
         "approver_spec": a.approver_spec,
         "status": a.status.to_string(),
-        "approver_pubkey": a.approver_pubkey.as_ref().map(|pk| nostr_hex::encode(pk)),
+        "approver_pubkey": a.approver_pubkey.as_ref().map(nostr_hex::encode),
         "note": a.note,
         "expires_at": a.expires_at.to_rfc3339(),
         "created_at": a.created_at.timestamp(),

--- a/crates/sprout-relay/src/api/workflows.rs
+++ b/crates/sprout-relay/src/api/workflows.rs
@@ -22,8 +22,8 @@ use serde::Deserialize;
 use crate::state::AppState;
 
 use super::workflow_helpers::{
-    definition_hash, ensure_webhook_secret, run_record_to_json, spawn_workflow_execution,
-    validate_webhook_urls, workflow_record_to_json,
+    approval_record_to_json, definition_hash, ensure_webhook_secret, run_record_to_json,
+    spawn_workflow_execution, validate_webhook_urls, workflow_record_to_json,
 };
 use super::{
     api_error, check_channel_access, check_token_channel_access, extract_auth_context, forbidden,
@@ -355,6 +355,45 @@ pub async fn list_workflow_runs(
         .map_err(|e| internal_error(&format!("db error: {e}")))?;
 
     let result: Vec<serde_json::Value> = runs.iter().map(run_record_to_json).collect();
+    Ok(Json(serde_json::json!(result)))
+}
+
+// ── GET /api/workflows/:id/runs/:run_id/approvals ────────────────────────────
+
+/// List all approval records for a workflow run.
+pub async fn list_run_approvals(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path((id_str, run_id_str)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let ctx = extract_auth_context(&headers, &state).await?;
+    sprout_auth::require_scope(&ctx.scopes, sprout_auth::Scope::ChannelsRead)
+        .map_err(scope_error)?;
+    let pubkey_bytes = ctx.pubkey_bytes.clone();
+
+    let id = uuid::Uuid::parse_str(&id_str)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid workflow UUID"))?;
+    let run_id = uuid::Uuid::parse_str(&run_id_str)
+        .map_err(|_| api_error(StatusCode::BAD_REQUEST, "invalid run UUID"))?;
+
+    let workflow = state
+        .db
+        .get_workflow(id)
+        .await
+        .map_err(|_| not_found("workflow not found"))?;
+
+    if let Some(channel_id) = workflow.channel_id {
+        check_token_channel_access(&ctx, &channel_id)?;
+        check_channel_access(&state, channel_id, &pubkey_bytes).await?;
+    }
+
+    let approvals = state
+        .db
+        .get_run_approvals(run_id)
+        .await
+        .map_err(|e| internal_error(&format!("db error: {e}")))?;
+
+    let result: Vec<serde_json::Value> = approvals.iter().map(approval_record_to_json).collect();
     Ok(Json(serde_json::json!(result)))
 }
 

--- a/crates/sprout-relay/src/api/workflows.rs
+++ b/crates/sprout-relay/src/api/workflows.rs
@@ -389,7 +389,7 @@ pub async fn list_run_approvals(
 
     let approvals = state
         .db
-        .get_run_approvals(run_id)
+        .get_run_approvals(id, run_id)
         .await
         .map_err(|e| internal_error(&format!("db error: {e}")))?;
 

--- a/crates/sprout-relay/src/router.rs
+++ b/crates/sprout-relay/src/router.rs
@@ -83,6 +83,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
                 .delete(api::delete_workflow),
         )
         .route("/api/workflows/{id}/runs", get(api::list_workflow_runs))
+        .route(
+            "/api/workflows/{id}/runs/{run_id}/approvals",
+            get(api::list_run_approvals),
+        )
         .route("/api/workflows/{id}/trigger", post(api::trigger_workflow))
         .route("/api/workflows/{id}/webhook", post(api::workflow_webhook))
         .route("/api/approvals/{token}/grant", post(api::grant_approval))

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -32,7 +32,7 @@ const rules = [
 const overrides = new Map([
   ["src-tauri/src/managed_agents/personas.rs", 600], // built-in persona system prompts (Solo, Ralph, Strategist) are long string literals
   ["src-tauri/src/managed_agents/persona_card.rs", 772], // PNG/ZIP persona card codec + provider/model fields + 27 unit tests (~350 lines of tests); rustfmt adds line breaks around long literals/builders
-  ["src/app/AppShell.tsx", 820], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination
+  ["src/app/AppShell.tsx", 840], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view
   ["src/features/channels/hooks.ts", 550], // canvas query + mutation hooks + DM hide mutation
   ["src/features/channels/ui/ChannelManagementSheet.tsx", 800],
   ["src/features/messages/hooks.ts", 500], // message query/mutation hooks + optimistic updates

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -32,7 +32,7 @@ const rules = [
 const overrides = new Map([
   ["src-tauri/src/managed_agents/personas.rs", 600], // built-in persona system prompts (Solo, Ralph, Strategist) are long string literals
   ["src-tauri/src/managed_agents/persona_card.rs", 772], // PNG/ZIP persona card codec + provider/model fields + 27 unit tests (~350 lines of tests); rustfmt adds line breaks around long literals/builders
-  ["src/app/AppShell.tsx", 840], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view
+  ["src/app/AppShell.tsx", 860], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view + memory-leak safeguards
   ["src/features/channels/hooks.ts", 550], // canvas query + mutation hooks + DM hide mutation
   ["src/features/channels/ui/ChannelManagementSheet.tsx", 800],
   ["src/features/messages/hooks.ts", 500], // message query/mutation hooks + optimistic updates

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -47,7 +47,7 @@ const overrides = new Map([
   ["src/features/agents/ui/AgentsView.tsx", 790], // remote agent stop/delete + channel UUID resolution + presence-aware delete guard + persona/team import + provider/model fields
   ["src/features/agents/ui/CreateAgentDialog.tsx", 685], // provider selector + config form + schema-typed config coercion + required field validation + locked scopes
   ["src/features/channels/ui/AddChannelBotDialog.tsx", 640], // provider mode: Run on selector, trust warning, probe effect, single-agent enforcement, provider warnings display
-  ["src/shared/api/types.ts", 515], // persona provider/model fields + forum types
+  ["src/shared/api/types.ts", 525], // persona provider/model fields + forum types + workflow type re-exports
 ]);
 
 async function walkFiles(directory) {

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -13,6 +13,7 @@ mod personas;
 mod profile;
 mod teams;
 mod tokens;
+mod workflows;
 
 pub use agent_discovery::*;
 pub use agent_models::*;
@@ -28,3 +29,4 @@ pub use personas::*;
 pub use profile::*;
 pub use teams::*;
 pub use tokens::*;
+pub use workflows::*;

--- a/desktop/src-tauri/src/commands/workflows.rs
+++ b/desktop/src-tauri/src/commands/workflows.rs
@@ -101,6 +101,17 @@ pub async fn trigger_workflow(
 
 // ── Approvals ───────────────────────────────────────────────────────────────
 
+#[tauri::command]
+pub async fn get_run_approvals(
+    workflow_id: String,
+    run_id: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let path = format!("/api/workflows/{workflow_id}/runs/{run_id}/approvals");
+    let request = build_authed_request(&state.http_client, Method::GET, &path, &state)?;
+    send_json_request(request).await
+}
+
 #[derive(Serialize)]
 struct ApprovalBody {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/desktop/src-tauri/src/commands/workflows.rs
+++ b/desktop/src-tauri/src/commands/workflows.rs
@@ -1,0 +1,132 @@
+use reqwest::Method;
+use serde::Serialize;
+use tauri::State;
+
+use crate::{
+    app_state::AppState,
+    relay::{build_authed_request, send_json_request},
+};
+
+// ── Reads ───────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn get_channel_workflows(
+    channel_id: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let path = format!("/api/channels/{channel_id}/workflows");
+    let request = build_authed_request(&state.http_client, Method::GET, &path, &state)?;
+    send_json_request(request).await
+}
+
+#[tauri::command]
+pub async fn get_workflow(
+    workflow_id: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let path = format!("/api/workflows/{workflow_id}");
+    let request = build_authed_request(&state.http_client, Method::GET, &path, &state)?;
+    send_json_request(request).await
+}
+
+#[tauri::command]
+pub async fn get_workflow_runs(
+    workflow_id: String,
+    limit: Option<u32>,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let mut path = format!("/api/workflows/{workflow_id}/runs");
+    if let Some(limit) = limit {
+        path.push_str(&format!("?limit={limit}"));
+    }
+    let request = build_authed_request(&state.http_client, Method::GET, &path, &state)?;
+    send_json_request(request).await
+}
+
+// ── Writes ──────────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct CreateWorkflowBody {
+    yaml_definition: String,
+}
+
+#[tauri::command]
+pub async fn create_workflow(
+    channel_id: String,
+    yaml_definition: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let path = format!("/api/channels/{channel_id}/workflows");
+    let request = build_authed_request(&state.http_client, Method::POST, &path, &state)?
+        .json(&CreateWorkflowBody { yaml_definition });
+    send_json_request(request).await
+}
+
+#[derive(Serialize)]
+struct UpdateWorkflowBody {
+    yaml_definition: String,
+}
+
+#[tauri::command]
+pub async fn update_workflow(
+    workflow_id: String,
+    yaml_definition: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let path = format!("/api/workflows/{workflow_id}");
+    let request = build_authed_request(&state.http_client, Method::PUT, &path, &state)?
+        .json(&UpdateWorkflowBody { yaml_definition });
+    send_json_request(request).await
+}
+
+#[tauri::command]
+pub async fn delete_workflow(
+    workflow_id: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let path = format!("/api/workflows/{workflow_id}");
+    let request = build_authed_request(&state.http_client, Method::DELETE, &path, &state)?;
+    send_json_request(request).await
+}
+
+#[tauri::command]
+pub async fn trigger_workflow(
+    workflow_id: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let path = format!("/api/workflows/{workflow_id}/trigger");
+    let request = build_authed_request(&state.http_client, Method::POST, &path, &state)?;
+    send_json_request(request).await
+}
+
+// ── Approvals ───────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct ApprovalBody {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+}
+
+#[tauri::command]
+pub async fn grant_approval(
+    token: String,
+    note: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let path = format!("/api/approvals/{token}/grant");
+    let request = build_authed_request(&state.http_client, Method::POST, &path, &state)?
+        .json(&ApprovalBody { note });
+    send_json_request(request).await
+}
+
+#[tauri::command]
+pub async fn deny_approval(
+    token: String,
+    note: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let path = format!("/api/approvals/{token}/deny");
+    let request = build_authed_request(&state.http_client, Method::POST, &path, &state)?
+        .json(&ApprovalBody { note });
+    send_json_request(request).await
+}

--- a/desktop/src-tauri/src/commands/workflows.rs
+++ b/desktop/src-tauri/src/commands/workflows.rs
@@ -4,7 +4,7 @@ use tauri::State;
 
 use crate::{
     app_state::AppState,
-    relay::{build_authed_request, send_json_request},
+    relay::{build_authed_request, send_empty_request, send_json_request},
 };
 
 // ── Reads ───────────────────────────────────────────────────────────────────
@@ -83,10 +83,10 @@ pub async fn update_workflow(
 pub async fn delete_workflow(
     workflow_id: String,
     state: State<'_, AppState>,
-) -> Result<serde_json::Value, String> {
+) -> Result<(), String> {
     let path = format!("/api/workflows/{workflow_id}");
     let request = build_authed_request(&state.http_client, Method::DELETE, &path, &state)?;
-    send_json_request(request).await
+    send_empty_request(request).await
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -283,6 +283,15 @@ pub fn run() {
             parse_team_file,
             parse_persona_files,
             export_persona_to_json,
+            get_channel_workflows,
+            get_workflow,
+            create_workflow,
+            update_workflow,
+            delete_workflow,
+            get_workflow_runs,
+            trigger_workflow,
+            grant_approval,
+            deny_approval,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -289,6 +289,7 @@ pub fn run() {
             update_workflow,
             delete_workflow,
             get_workflow_runs,
+            get_run_approvals,
             trigger_workflow,
             grant_approval,
             deny_approval,

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -93,6 +93,11 @@ export function AppShell() {
   const [editTargetId, setEditTargetId] = React.useState<string | null>(null);
   const lastNonSettingsViewRef = React.useRef<MainView>("home");
   const queryClient = useQueryClient();
+  const selectView = React.useCallback((view: AppView | MainView) => {
+    React.startTransition(() => {
+      setSelectedView(view);
+    });
+  }, []);
   const identityQuery = useIdentityQuery();
   const profileQuery = useProfileQuery();
   const presenceSession = usePresenceSession(identityQuery.data?.pubkey);
@@ -340,12 +345,10 @@ export function AppShell() {
         return;
       }
       if (selectedChannel?.id === channelId) {
-        React.startTransition(() => {
-          setSelectedView("home");
-        });
+        selectView("home");
       }
     },
-    [hideDmMutation, selectedChannel?.id],
+    [hideDmMutation, selectView, selectedChannel?.id],
   );
 
   const handleOpenSettings = React.useCallback(
@@ -367,10 +370,8 @@ export function AppShell() {
         ? "home"
         : lastNonSettingsViewRef.current;
 
-    React.startTransition(() => {
-      setSelectedView(nextView);
-    });
-  }, [selectedChannel]);
+    selectView(nextView);
+  }, [selectView, selectedChannel]);
 
   const handleOpenSearchResult = React.useCallback(
     (hit: SearchHit) => {
@@ -626,21 +627,10 @@ export function AppShell() {
                 });
                 openChannelView(directMessage.id);
               }}
-              onSelectAgents={() => {
-                React.startTransition(() => {
-                  setSelectedView("agents");
-                });
-              }}
-              onSelectWorkflows={() => {
-                React.startTransition(() => {
-                  setSelectedView("workflows");
-                });
-              }}
+              onSelectAgents={() => selectView("agents")}
+              onSelectWorkflows={() => selectView("workflows")}
               onSelectHome={() => {
-                React.startTransition(() => {
-                  setSelectedView("home");
-                });
-
+                selectView("home");
                 void homeFeedQuery.refetch();
               }}
               onSelectChannel={handleOpenChannel}
@@ -821,10 +811,8 @@ export function AppShell() {
           channel={activeChannel}
           currentPubkey={identityQuery.data?.pubkey}
           onDeleted={() => {
-            React.startTransition(() => {
-              setIsChannelManagementOpen(false);
-              setSelectedView("home");
-            });
+            setIsChannelManagementOpen(false);
+            selectView("home");
           }}
           onOpenChange={setIsChannelManagementOpen}
           open={isChannelManagementOpen && activeChannel !== null}

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -6,6 +6,7 @@ import { useActiveChannelHeader } from "@/app/useActiveChannelHeader";
 import { useChannelPaneHandlers } from "@/app/useChannelPaneHandlers";
 import { AgentsView } from "@/features/agents/ui/AgentsView";
 import { ForumView } from "@/features/forum/ui/ForumView";
+import { WorkflowsView } from "@/features/workflows/ui/WorkflowsView";
 import { ChatHeader } from "@/features/chat/ui/ChatHeader";
 import {
   channelsQueryKey,
@@ -63,7 +64,7 @@ import {
 } from "@/shared/ui/sidebar";
 import { useWebviewZoomShortcuts } from "@/app/useWebviewZoomShortcuts";
 
-type AppView = "home" | "channel" | "settings" | "agents";
+type AppView = "home" | "channel" | "settings" | "agents" | "workflows";
 type MainView = Exclude<AppView, "settings">;
 export function AppShell() {
   useWebviewZoomShortcuts();
@@ -630,6 +631,11 @@ export function AppShell() {
                   setSelectedView("agents");
                 });
               }}
+              onSelectWorkflows={() => {
+                React.startTransition(() => {
+                  setSelectedView("workflows");
+                });
+              }}
               onSelectHome={() => {
                 React.startTransition(() => {
                   setSelectedView("home");
@@ -657,6 +663,12 @@ export function AppShell() {
                   description="Create local ACP workers, mint agent tokens, and monitor the relay-visible agent directory."
                   mode="agents"
                   title="Agents"
+                />
+              ) : selectedView === "workflows" ? (
+                <ChatHeader
+                  description="Create, manage, and monitor automated workflows across your channels."
+                  mode="workflows"
+                  title="Workflows"
                 />
               ) : (
                 <ChatHeader
@@ -722,7 +734,18 @@ export function AppShell() {
                 </div>
                 <div
                   className={
-                    selectedView !== "home" && selectedView !== "agents"
+                    selectedView === "workflows"
+                      ? "flex min-h-0 flex-1 flex-col"
+                      : "hidden"
+                  }
+                >
+                  <WorkflowsView channels={memberChannels} />
+                </div>
+                <div
+                  className={
+                    selectedView !== "home" &&
+                    selectedView !== "agents" &&
+                    selectedView !== "workflows"
                       ? "flex min-h-0 flex-1 flex-col overflow-hidden"
                       : "hidden"
                   }

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -477,6 +477,21 @@ export function AppShell() {
       requestedAncestorIdsRef.current.add(eventId);
     }
 
+    // Prevent unbounded growth — evict oldest entries when the set exceeds
+    // a reasonable size. Since Set iteration is insertion-ordered we drop
+    // the first (oldest) entries.
+    const MAX_REQUESTED_ANCESTORS = 500;
+    if (requestedAncestorIdsRef.current.size > MAX_REQUESTED_ANCESTORS) {
+      const excess =
+        requestedAncestorIdsRef.current.size - MAX_REQUESTED_ANCESTORS;
+      let removed = 0;
+      for (const id of requestedAncestorIdsRef.current) {
+        if (removed >= excess) break;
+        requestedAncestorIdsRef.current.delete(id);
+        removed++;
+      }
+    }
+
     let isCancelled = false;
 
     void Promise.all(

--- a/desktop/src/features/chat/ui/ChatHeader.tsx
+++ b/desktop/src/features/chat/ui/ChatHeader.tsx
@@ -6,6 +6,7 @@ import {
   Home,
   Lock,
   Settings2,
+  Zap,
 } from "lucide-react";
 import type * as React from "react";
 
@@ -17,7 +18,7 @@ type ChatHeaderProps = {
   description: string;
   channelType?: ChannelType;
   visibility?: ChannelVisibility;
-  mode?: "home" | "channel" | "settings" | "agents";
+  mode?: "home" | "channel" | "settings" | "agents" | "workflows";
   statusBadge?: React.ReactNode;
 };
 
@@ -28,7 +29,7 @@ function ChannelIcon({
 }: {
   channelType?: ChannelType;
   visibility?: ChannelVisibility;
-  mode?: "home" | "channel" | "settings" | "agents";
+  mode?: "home" | "channel" | "settings" | "agents" | "workflows";
 }) {
   if (mode === "home") {
     return <Home className="h-5 w-5 text-primary" />;
@@ -36,6 +37,10 @@ function ChannelIcon({
 
   if (mode === "agents") {
     return <Bot className="h-5 w-5 text-primary" />;
+  }
+
+  if (mode === "workflows") {
+    return <Zap className="h-5 w-5 text-primary" />;
   }
 
   if (mode === "settings") {

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -139,7 +139,7 @@ export function useChannelMessagesQuery(channel: Channel | null) {
       return mergedHistory;
     },
     staleTime: Number.POSITIVE_INFINITY,
-    gcTime: 30 * 60 * 1_000,
+    gcTime: 5 * 60 * 1_000,
   });
 }
 

--- a/desktop/src/features/notifications/hooks.ts
+++ b/desktop/src/features/notifications/hooks.ts
@@ -373,6 +373,19 @@ export function useFeedDesktopNotifications(
     for (const item of currentFeedItems) {
       nextSeenItemIds.add(item.id);
     }
+
+    // Prevent unbounded growth — keep only the most recent entries.
+    const MAX_SEEN_FEED_ITEMS = 500;
+    if (nextSeenItemIds.size > MAX_SEEN_FEED_ITEMS) {
+      const excess = nextSeenItemIds.size - MAX_SEEN_FEED_ITEMS;
+      let removed = 0;
+      for (const id of nextSeenItemIds) {
+        if (removed >= excess) break;
+        nextSeenItemIds.delete(id);
+        removed++;
+      }
+    }
+
     seenItemIdsRef.current = nextSeenItemIds;
 
     for (const item of newItems) {

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Bot, Home, Lock, PenSquare, Plus, Search } from "lucide-react";
+import { Bot, Home, Lock, PenSquare, Plus, Search, Zap } from "lucide-react";
 import * as React from "react";
 
 import { useManagedAgentsQuery } from "@/features/agents/hooks";
@@ -61,7 +61,7 @@ type AppSidebarProps = {
   selfPresenceStatus: PresenceStatus;
   errorMessage?: string;
   selectedChannelId: string | null;
-  selectedView: "home" | "channel" | "settings" | "agents";
+  selectedView: "home" | "channel" | "settings" | "agents" | "workflows";
   unreadChannelIds: Set<string>;
   onCreateChannel: (input: {
     name: string;
@@ -79,6 +79,7 @@ type AppSidebarProps = {
   onHideDm: (channelId: string) => void;
   onOpenDm: (input: { pubkeys: string[] }) => Promise<void>;
   onSelectAgents: () => void;
+  onSelectWorkflows: () => void;
   onSelectHome: () => void;
   onSelectChannel: (channelId: string) => void;
   onSelectSettings: () => void;
@@ -443,6 +444,7 @@ export function AppSidebar({
   onHideDm,
   onOpenDm,
   onSelectAgents,
+  onSelectWorkflows,
   onSelectHome,
   onSelectChannel,
   onSelectSettings,
@@ -538,6 +540,18 @@ export function AppSidebar({
                 {totalAgentCount}
               </SidebarMenuBadge>
             ) : null}
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              data-testid="open-workflows-view"
+              isActive={selectedView === "workflows"}
+              onClick={onSelectWorkflows}
+              tooltip="Workflows"
+              type="button"
+            >
+              <Zap className="h-4 w-4" />
+              <span>Workflows</span>
+            </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -145,7 +145,8 @@ export function useApprovalMutation() {
       void queryClient.invalidateQueries({
         predicate: (query) =>
           query.queryKey[0] === "workflow-runs" ||
-          query.queryKey[0] === "workflow",
+          query.queryKey[0] === "workflow" ||
+          query.queryKey[0] === "run-approvals",
       });
     },
   });

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -12,6 +12,8 @@ import {
   updateWorkflow,
 } from "@/shared/api/tauriWorkflows";
 
+export const allWorkflowsQueryKey = (channelIdKey: string) =>
+  ["workflows-all", channelIdKey] as const;
 export const workflowsQueryKey = (channelId: string) =>
   ["workflows", channelId] as const;
 export const workflowQueryKey = (workflowId: string) =>

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import type { WorkflowRun, WorkflowRunStatus } from "@/shared/api/types";
 import {
   createWorkflow,
   deleteWorkflow,
@@ -24,10 +25,29 @@ export const workflowRunsQueryKey = (workflowId: string) =>
 export const runApprovalsQueryKey = (workflowId: string, runId: string) =>
   ["run-approvals", workflowId, runId] as const;
 
+function invalidateWorkflowListQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  void queryClient.invalidateQueries({
+    predicate: (query) =>
+      query.queryKey[0] === "workflows" ||
+      query.queryKey[0] === "workflows-all",
+  });
+}
+
+function isActiveWorkflowRunStatus(status: WorkflowRunStatus) {
+  return (
+    status === "pending" ||
+    status === "running" ||
+    status === "waiting_approval"
+  );
+}
+
 export function useChannelWorkflowsQuery(channelId: string | null) {
   return useQuery({
     queryKey: workflowsQueryKey(channelId ?? ""),
-    queryFn: () => getChannelWorkflows(channelId!),
+    queryFn: ({ queryKey: [, resolvedChannelId] }) =>
+      getChannelWorkflows(resolvedChannelId),
     enabled: channelId !== null,
     staleTime: 30_000,
     refetchOnWindowFocus: true,
@@ -37,7 +57,8 @@ export function useChannelWorkflowsQuery(channelId: string | null) {
 export function useWorkflowQuery(workflowId: string | null) {
   return useQuery({
     queryKey: workflowQueryKey(workflowId ?? ""),
-    queryFn: () => getWorkflow(workflowId!),
+    queryFn: ({ queryKey: [, resolvedWorkflowId] }) =>
+      getWorkflow(resolvedWorkflowId),
     enabled: workflowId !== null,
     staleTime: 30_000,
   });
@@ -46,10 +67,16 @@ export function useWorkflowQuery(workflowId: string | null) {
 export function useWorkflowRunsQuery(workflowId: string | null) {
   return useQuery({
     queryKey: workflowRunsQueryKey(workflowId ?? ""),
-    queryFn: () => getWorkflowRuns(workflowId!),
+    queryFn: ({ queryKey: [, resolvedWorkflowId] }) =>
+      getWorkflowRuns(resolvedWorkflowId),
     enabled: workflowId !== null,
     staleTime: 10_000,
-    refetchInterval: 10_000,
+    refetchInterval: (query) => {
+      const runs = query.state.data as WorkflowRun[] | undefined;
+      return runs?.some((run) => isActiveWorkflowRunStatus(run.status))
+        ? 1_000
+        : false;
+    },
   });
 }
 
@@ -59,7 +86,8 @@ export function useRunApprovalsQuery(
 ) {
   return useQuery({
     queryKey: runApprovalsQueryKey(workflowId ?? "", runId ?? ""),
-    queryFn: () => getRunApprovals(workflowId!, runId!),
+    queryFn: ({ queryKey: [, resolvedWorkflowId, resolvedRunId] }) =>
+      getRunApprovals(resolvedWorkflowId, resolvedRunId),
     enabled: workflowId !== null && runId !== null,
     staleTime: 10_000,
     refetchInterval: 10_000,
@@ -73,17 +101,12 @@ export function useCreateWorkflowMutation(channelId: string) {
     mutationFn: (yamlDefinition: string) =>
       createWorkflow(channelId, yamlDefinition),
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: workflowsQueryKey(channelId),
-      });
+      invalidateWorkflowListQueries(queryClient);
     },
   });
 }
 
-export function useUpdateWorkflowMutation(
-  workflowId: string,
-  channelId: string,
-) {
+export function useUpdateWorkflowMutation(workflowId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -93,25 +116,18 @@ export function useUpdateWorkflowMutation(
       void queryClient.invalidateQueries({
         queryKey: workflowQueryKey(workflowId),
       });
-      void queryClient.invalidateQueries({
-        queryKey: workflowsQueryKey(channelId),
-      });
+      invalidateWorkflowListQueries(queryClient);
     },
   });
 }
 
-export function useDeleteWorkflowMutation(
-  workflowId: string,
-  channelId: string,
-) {
+export function useDeleteWorkflowMutation(workflowId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: () => deleteWorkflow(workflowId),
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: workflowsQueryKey(channelId),
-      });
+      invalidateWorkflowListQueries(queryClient);
     },
   });
 }

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -27,7 +27,7 @@ export function useChannelWorkflowsQuery(channelId: string | null) {
     queryFn: () => getChannelWorkflows(channelId!),
     enabled: channelId !== null,
     staleTime: 30_000,
-    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -1,0 +1,134 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createWorkflow,
+  deleteWorkflow,
+  denyApproval,
+  getChannelWorkflows,
+  getWorkflow,
+  getWorkflowRuns,
+  grantApproval,
+  triggerWorkflow,
+  updateWorkflow,
+} from "@/shared/api/tauriWorkflows";
+
+export const workflowsQueryKey = (channelId: string) =>
+  ["workflows", channelId] as const;
+export const workflowQueryKey = (workflowId: string) =>
+  ["workflow", workflowId] as const;
+export const workflowRunsQueryKey = (workflowId: string) =>
+  ["workflow-runs", workflowId] as const;
+
+export function useChannelWorkflowsQuery(channelId: string | null) {
+  return useQuery({
+    queryKey: workflowsQueryKey(channelId ?? ""),
+    queryFn: () => getChannelWorkflows(channelId!),
+    enabled: channelId !== null,
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+}
+
+export function useWorkflowQuery(workflowId: string | null) {
+  return useQuery({
+    queryKey: workflowQueryKey(workflowId ?? ""),
+    queryFn: () => getWorkflow(workflowId!),
+    enabled: workflowId !== null,
+    staleTime: 30_000,
+  });
+}
+
+export function useWorkflowRunsQuery(workflowId: string | null) {
+  return useQuery({
+    queryKey: workflowRunsQueryKey(workflowId ?? ""),
+    queryFn: () => getWorkflowRuns(workflowId!),
+    enabled: workflowId !== null,
+    staleTime: 10_000,
+    refetchInterval: 10_000,
+  });
+}
+
+export function useCreateWorkflowMutation(channelId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (yamlDefinition: string) =>
+      createWorkflow(channelId, yamlDefinition),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: workflowsQueryKey(channelId),
+      });
+    },
+  });
+}
+
+export function useUpdateWorkflowMutation(
+  workflowId: string,
+  channelId: string,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (yamlDefinition: string) =>
+      updateWorkflow(workflowId, yamlDefinition),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: workflowQueryKey(workflowId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: workflowsQueryKey(channelId),
+      });
+    },
+  });
+}
+
+export function useDeleteWorkflowMutation(
+  workflowId: string,
+  channelId: string,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => deleteWorkflow(workflowId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: workflowsQueryKey(channelId),
+      });
+    },
+  });
+}
+
+export function useTriggerWorkflowMutation(workflowId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => triggerWorkflow(workflowId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: workflowRunsQueryKey(workflowId),
+      });
+    },
+  });
+}
+
+export function useApprovalMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: {
+      token: string;
+      action: "grant" | "deny";
+      note?: string;
+    }) =>
+      input.action === "grant"
+        ? grantApproval(input.token, input.note)
+        : denyApproval(input.token, input.note),
+    onSuccess: (_data, _variables) => {
+      void queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "workflow-runs" ||
+          query.queryKey[0] === "workflow",
+      });
+    },
+  });
+}

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -5,6 +5,7 @@ import {
   deleteWorkflow,
   denyApproval,
   getChannelWorkflows,
+  getRunApprovals,
   getWorkflow,
   getWorkflowRuns,
   grantApproval,
@@ -20,6 +21,8 @@ export const workflowQueryKey = (workflowId: string) =>
   ["workflow", workflowId] as const;
 export const workflowRunsQueryKey = (workflowId: string) =>
   ["workflow-runs", workflowId] as const;
+export const runApprovalsQueryKey = (workflowId: string, runId: string) =>
+  ["run-approvals", workflowId, runId] as const;
 
 export function useChannelWorkflowsQuery(channelId: string | null) {
   return useQuery({
@@ -45,6 +48,19 @@ export function useWorkflowRunsQuery(workflowId: string | null) {
     queryKey: workflowRunsQueryKey(workflowId ?? ""),
     queryFn: () => getWorkflowRuns(workflowId!),
     enabled: workflowId !== null,
+    staleTime: 10_000,
+    refetchInterval: 10_000,
+  });
+}
+
+export function useRunApprovalsQuery(
+  workflowId: string | null,
+  runId: string | null,
+) {
+  return useQuery({
+    queryKey: runApprovalsQueryKey(workflowId ?? "", runId ?? ""),
+    queryFn: () => getRunApprovals(workflowId!, runId!),
+    enabled: workflowId !== null && runId !== null,
     staleTime: 10_000,
     refetchInterval: 10_000,
   });

--- a/desktop/src/features/workflows/ui/CreateWorkflowDialog.tsx
+++ b/desktop/src/features/workflows/ui/CreateWorkflowDialog.tsx
@@ -1,0 +1,118 @@
+import * as React from "react";
+
+import { useCreateWorkflowMutation } from "@/features/workflows/hooks";
+import type { Channel } from "@/shared/api/types";
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { Textarea } from "@/shared/ui/textarea";
+
+type CreateWorkflowDialogProps = {
+  channels: Channel[];
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+};
+
+export function CreateWorkflowDialog({
+  channels,
+  onOpenChange,
+  open,
+}: CreateWorkflowDialogProps) {
+  const [selectedChannelId, setSelectedChannelId] = React.useState(
+    channels[0]?.id ?? "",
+  );
+  const [yamlDefinition, setYamlDefinition] = React.useState("");
+  const createMutation = useCreateWorkflowMutation(selectedChannelId);
+
+  React.useEffect(() => {
+    if (open && channels.length > 0 && !selectedChannelId) {
+      setSelectedChannelId(channels[0].id);
+    }
+  }, [open, channels, selectedChannelId]);
+
+  function handleCreate() {
+    if (!selectedChannelId || !yamlDefinition.trim()) return;
+
+    createMutation.mutate(yamlDefinition, {
+      onSuccess: () => {
+        setYamlDefinition("");
+        onOpenChange(false);
+      },
+    });
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create Workflow</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <label
+              className="mb-1 block text-sm font-medium"
+              htmlFor="wf-channel-select"
+            >
+              Channel
+            </label>
+            <select
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+              id="wf-channel-select"
+              onChange={(event) => setSelectedChannelId(event.target.value)}
+              value={selectedChannelId}
+            >
+              {channels.map((channel) => (
+                <option key={channel.id} value={channel.id}>
+                  {channel.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label
+              className="mb-1 block text-sm font-medium"
+              htmlFor="wf-yaml-editor"
+            >
+              YAML Definition
+            </label>
+            <Textarea
+              className="min-h-[200px] resize-y font-mono text-xs"
+              id="wf-yaml-editor"
+              onChange={(event) => setYamlDefinition(event.target.value)}
+              placeholder="name: my-workflow&#10;trigger:&#10;  type: manual&#10;steps:&#10;  - id: step-1&#10;    action: ..."
+              value={yamlDefinition}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={() => onOpenChange(false)}
+            type="button"
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={
+              !selectedChannelId ||
+              !yamlDefinition.trim() ||
+              createMutation.isPending
+            }
+            onClick={handleCreate}
+            type="button"
+          >
+            {createMutation.isPending ? "Creating..." : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/desktop/src/features/workflows/ui/CreateWorkflowDialog.tsx
+++ b/desktop/src/features/workflows/ui/CreateWorkflowDialog.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from "lucide-react";
 import * as React from "react";
 
 import { useCreateWorkflowMutation } from "@/features/workflows/hooks";
@@ -6,6 +7,7 @@ import { Button } from "@/shared/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
@@ -17,6 +19,14 @@ type CreateWorkflowDialogProps = {
   open: boolean;
 };
 
+const WORKFLOW_PLACEHOLDER = `name: ui_smoke_delay
+trigger:
+  on: message_posted
+steps:
+  - id: wait_two_seconds
+    action: delay
+    duration: 2s`;
+
 export function CreateWorkflowDialog({
   channels,
   onOpenChange,
@@ -27,6 +37,25 @@ export function CreateWorkflowDialog({
   );
   const [yamlDefinition, setYamlDefinition] = React.useState("");
   const createMutation = useCreateWorkflowMutation(selectedChannelId);
+  const selectedChannel =
+    channels.find((channel) => channel.id === selectedChannelId) ?? null;
+
+  const reset = React.useCallback(() => {
+    setSelectedChannelId(channels[0]?.id ?? "");
+    setYamlDefinition("");
+    createMutation.reset();
+  }, [channels, createMutation]);
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        reset();
+      }
+
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, reset],
+  );
 
   React.useEffect(() => {
     if (open && channels.length > 0 && !selectedChannelId) {
@@ -34,49 +63,69 @@ export function CreateWorkflowDialog({
     }
   }, [open, channels, selectedChannelId]);
 
-  function handleCreate() {
+  async function handleCreate() {
     if (!selectedChannelId || !yamlDefinition.trim()) return;
 
-    createMutation.mutate(yamlDefinition, {
-      onSuccess: () => {
-        setYamlDefinition("");
-        onOpenChange(false);
-      },
-    });
+    try {
+      await createMutation.mutateAsync(yamlDefinition);
+      handleOpenChange(false);
+    } catch {
+      // React Query stores the error; keep the dialog open and render it inline.
+    }
   }
 
   return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
+    <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Create Workflow</DialogTitle>
+          <DialogDescription>
+            Pick a channel, paste YAML, and create a workflow scoped to that
+            channel.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
-          <div>
+          <div className="space-y-1.5">
             <label
-              className="mb-1 block text-sm font-medium"
+              className="block text-sm font-medium"
               htmlFor="wf-channel-select"
             >
               Channel
             </label>
-            <select
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-              id="wf-channel-select"
-              onChange={(event) => setSelectedChannelId(event.target.value)}
-              value={selectedChannelId}
-            >
-              {channels.map((channel) => (
-                <option key={channel.id} value={channel.id}>
-                  {channel.name}
-                </option>
-              ))}
-            </select>
+            <div className="relative">
+              <select
+                className="flex h-11 w-full appearance-none rounded-xl border border-border/70 bg-muted/20 px-3 pr-10 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={channels.length === 0 || createMutation.isPending}
+                id="wf-channel-select"
+                onChange={(event) => {
+                  createMutation.reset();
+                  setSelectedChannelId(event.target.value);
+                }}
+                value={selectedChannelId}
+              >
+                {channels.length === 0 ? (
+                  <option value="">No channels available</option>
+                ) : null}
+                {channels.map((channel) => (
+                  <option key={channel.id} value={channel.id}>
+                    {channel.name} · {channel.channelType} ·{" "}
+                    {channel.visibility}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {selectedChannel
+                ? `New workflows will belong to ${selectedChannel.name}.`
+                : "Join or create a channel before adding a workflow."}
+            </p>
           </div>
 
-          <div>
+          <div className="space-y-1.5">
             <label
-              className="mb-1 block text-sm font-medium"
+              className="block text-sm font-medium"
               htmlFor="wf-yaml-editor"
             >
               YAML Definition
@@ -84,16 +133,30 @@ export function CreateWorkflowDialog({
             <Textarea
               className="min-h-[200px] resize-y font-mono text-xs"
               id="wf-yaml-editor"
-              onChange={(event) => setYamlDefinition(event.target.value)}
-              placeholder="name: my-workflow&#10;trigger:&#10;  type: manual&#10;steps:&#10;  - id: step-1&#10;    action: ..."
+              onChange={(event) => {
+                createMutation.reset();
+                setYamlDefinition(event.target.value);
+              }}
+              placeholder={WORKFLOW_PLACEHOLDER}
               value={yamlDefinition}
             />
+            <p className="text-xs text-muted-foreground">
+              Use <code>trigger.on</code> with values like{" "}
+              <code>message_posted</code>, <code>reaction_added</code>,{" "}
+              <code>webhook</code>, or <code>schedule</code>.
+            </p>
           </div>
         </div>
 
+        {createMutation.error instanceof Error ? (
+          <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {createMutation.error.message}
+          </p>
+        ) : null}
+
         <div className="flex justify-end gap-2 pt-4">
           <Button
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleOpenChange(false)}
             type="button"
             variant="outline"
           >

--- a/desktop/src/features/workflows/ui/CreateWorkflowDialog.tsx
+++ b/desktop/src/features/workflows/ui/CreateWorkflowDialog.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/shared/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
@@ -92,7 +91,7 @@ export function CreateWorkflowDialog({
           </div>
         </div>
 
-        <DialogFooter>
+        <div className="flex justify-end gap-2 pt-4">
           <Button
             onClick={() => onOpenChange(false)}
             type="button"
@@ -111,7 +110,7 @@ export function CreateWorkflowDialog({
           >
             {createMutation.isPending ? "Creating..." : "Create"}
           </Button>
-        </DialogFooter>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/desktop/src/features/workflows/ui/WorkflowApprovalCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowApprovalCard.tsx
@@ -14,8 +14,7 @@ export function WorkflowApprovalCard({ approval }: WorkflowApprovalCardProps) {
   const [note, setNote] = React.useState("");
   const approvalMutation = useApprovalMutation();
 
-  const isExpired =
-    approval.expiresAt && new Date(approval.expiresAt) < new Date();
+  const isExpired = new Date(approval.expiresAt) < new Date();
 
   if (approval.status !== "pending" || isExpired) {
     return null;
@@ -30,11 +29,9 @@ export function WorkflowApprovalCard({ approval }: WorkflowApprovalCardProps) {
       <p className="mb-2 text-xs text-muted-foreground">
         Approver: {approval.approverSpec}
       </p>
-      {approval.expiresAt ? (
-        <p className="mb-2 text-xs text-muted-foreground">
-          Expires: {new Date(approval.expiresAt).toLocaleString()}
-        </p>
-      ) : null}
+      <p className="mb-2 text-xs text-muted-foreground">
+        Expires: {new Date(approval.expiresAt).toLocaleString()}
+      </p>
 
       <Textarea
         className="mb-2 h-16 resize-none text-xs"

--- a/desktop/src/features/workflows/ui/WorkflowApprovalCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowApprovalCard.tsx
@@ -1,0 +1,81 @@
+import { Check, X } from "lucide-react";
+import * as React from "react";
+
+import { useApprovalMutation } from "@/features/workflows/hooks";
+import type { WorkflowApproval } from "@/shared/api/types";
+import { Button } from "@/shared/ui/button";
+import { Textarea } from "@/shared/ui/textarea";
+
+type WorkflowApprovalCardProps = {
+  approval: WorkflowApproval;
+};
+
+export function WorkflowApprovalCard({ approval }: WorkflowApprovalCardProps) {
+  const [note, setNote] = React.useState("");
+  const approvalMutation = useApprovalMutation();
+
+  const isExpired =
+    approval.expiresAt && new Date(approval.expiresAt) < new Date();
+
+  if (approval.status !== "pending" || isExpired) {
+    return null;
+  }
+
+  return (
+    <div
+      className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3"
+      data-testid="workflow-approval-card"
+    >
+      <p className="mb-2 text-sm font-medium">Approval Required</p>
+      <p className="mb-2 text-xs text-muted-foreground">
+        Approver: {approval.approverSpec}
+      </p>
+      {approval.expiresAt ? (
+        <p className="mb-2 text-xs text-muted-foreground">
+          Expires: {new Date(approval.expiresAt).toLocaleString()}
+        </p>
+      ) : null}
+
+      <Textarea
+        className="mb-2 h-16 resize-none text-xs"
+        onChange={(event) => setNote(event.target.value)}
+        placeholder="Optional note..."
+        value={note}
+      />
+
+      <div className="flex gap-2">
+        <Button
+          className="flex-1 bg-green-600 text-white hover:bg-green-700"
+          disabled={approvalMutation.isPending}
+          onClick={() =>
+            approvalMutation.mutate({
+              token: approval.token,
+              action: "grant",
+              note: note || undefined,
+            })
+          }
+          size="sm"
+        >
+          <Check className="mr-1 h-3 w-3" />
+          Approve
+        </Button>
+        <Button
+          className="flex-1 bg-red-600 text-white hover:bg-red-700"
+          disabled={approvalMutation.isPending}
+          onClick={() =>
+            approvalMutation.mutate({
+              token: approval.token,
+              action: "deny",
+              note: note || undefined,
+            })
+          }
+          size="sm"
+          variant="destructive"
+        >
+          <X className="mr-1 h-3 w-3" />
+          Deny
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/workflows/ui/WorkflowApprovalCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowApprovalCard.tsx
@@ -34,6 +34,7 @@ export function WorkflowApprovalCard({ approval }: WorkflowApprovalCardProps) {
       </p>
 
       <Textarea
+        aria-label="Approval note"
         className="mb-2 h-16 resize-none text-xs"
         onChange={(event) => setNote(event.target.value)}
         placeholder="Optional note..."
@@ -57,7 +58,7 @@ export function WorkflowApprovalCard({ approval }: WorkflowApprovalCardProps) {
           Approve
         </Button>
         <Button
-          className="flex-1 bg-red-600 text-white hover:bg-red-700"
+          className="flex-1"
           disabled={approvalMutation.isPending}
           onClick={() =>
             approvalMutation.mutate({

--- a/desktop/src/features/workflows/ui/WorkflowCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowCard.tsx
@@ -1,0 +1,109 @@
+import { Clock, MoreHorizontal, Play, Trash2, Zap } from "lucide-react";
+
+import type { Workflow } from "@/shared/api/types";
+import { Button } from "@/shared/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+
+type WorkflowCardProps = {
+  workflow: Workflow;
+  channelName?: string;
+  onSelect: (workflowId: string) => void;
+  onTrigger: (workflowId: string) => void;
+  onDelete: (workflowId: string) => void;
+};
+
+function StatusBadge({ status }: { status: Workflow["status"] }) {
+  const colors = {
+    active: "bg-green-500/15 text-green-500",
+    disabled: "bg-muted text-muted-foreground",
+    archived: "bg-amber-500/15 text-amber-500",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${colors[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export function WorkflowCard({
+  workflow,
+  channelName,
+  onSelect,
+  onTrigger,
+  onDelete,
+}: WorkflowCardProps) {
+  return (
+    <button
+      className="w-full cursor-pointer rounded-lg border bg-card p-3 text-left transition-colors hover:bg-muted/50"
+      data-testid={`workflow-card-${workflow.id}`}
+      onClick={() => onSelect(workflow.id)}
+      type="button"
+    >
+      <div className="flex items-start justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <Zap className="h-4 w-4 shrink-0 text-amber-500" />
+            <span className="truncate text-sm font-medium">
+              {workflow.name}
+            </span>
+            <StatusBadge status={workflow.status} />
+          </div>
+          {workflow.description ? (
+            <p className="mt-1 truncate pl-6 text-xs text-muted-foreground">
+              {workflow.description}
+            </p>
+          ) : null}
+          <div className="mt-1.5 flex items-center gap-3 pl-6 text-[11px] text-muted-foreground">
+            {channelName ? <span>{channelName}</span> : null}
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {new Date(workflow.updatedAt).toLocaleDateString()}
+            </span>
+          </div>
+        </div>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              className="h-7 w-7 shrink-0"
+              onClick={(event) => event.stopPropagation()}
+              size="icon"
+              variant="ghost"
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={(event) => {
+                event.stopPropagation();
+                onTrigger(workflow.id);
+              }}
+            >
+              <Play className="mr-2 h-4 w-4" />
+              Trigger
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-destructive"
+              onClick={(event) => {
+                event.stopPropagation();
+                onDelete(workflow.id);
+              }}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </button>
+  );
+}

--- a/desktop/src/features/workflows/ui/WorkflowCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowCard.tsx
@@ -41,12 +41,18 @@ export function WorkflowCard({
   onDelete,
 }: WorkflowCardProps) {
   return (
-    <button
-      className="w-full cursor-pointer rounded-lg border bg-card p-3 text-left transition-colors hover:bg-muted/50"
+    <div
+      className="relative w-full rounded-lg border bg-card p-3 text-left transition-colors hover:bg-muted/50"
       data-testid={`workflow-card-${workflow.id}`}
-      onClick={() => onSelect(workflow.id)}
-      type="button"
     >
+      <button
+        className="absolute inset-0 rounded-lg"
+        onClick={() => onSelect(workflow.id)}
+        type="button"
+      >
+        <span className="sr-only">View {workflow.name}</span>
+      </button>
+
       <div className="flex items-start justify-between">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
@@ -68,8 +74,8 @@ export function WorkflowCard({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
-              className="h-7 w-7 shrink-0"
-              onClick={(event) => event.stopPropagation()}
+              aria-label="Workflow actions"
+              className="relative z-10 h-7 w-7 shrink-0"
               size="icon"
               variant="ghost"
             >
@@ -77,21 +83,13 @@ export function WorkflowCard({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              onClick={(event) => {
-                event.stopPropagation();
-                onTrigger(workflow.id);
-              }}
-            >
+            <DropdownMenuItem onClick={() => onTrigger(workflow.id)}>
               <Play className="mr-2 h-4 w-4" />
               Trigger
             </DropdownMenuItem>
             <DropdownMenuItem
               className="text-destructive"
-              onClick={(event) => {
-                event.stopPropagation();
-                onDelete(workflow.id);
-              }}
+              onClick={() => onDelete(workflow.id)}
             >
               <Trash2 className="mr-2 h-4 w-4" />
               Delete
@@ -99,6 +97,6 @@ export function WorkflowCard({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-    </button>
+    </div>
   );
 }

--- a/desktop/src/features/workflows/ui/WorkflowCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowCard.tsx
@@ -56,16 +56,11 @@ export function WorkflowCard({
             </span>
             <StatusBadge status={workflow.status} />
           </div>
-          {workflow.description ? (
-            <p className="mt-1 truncate pl-6 text-xs text-muted-foreground">
-              {workflow.description}
-            </p>
-          ) : null}
           <div className="mt-1.5 flex items-center gap-3 pl-6 text-[11px] text-muted-foreground">
             {channelName ? <span>{channelName}</span> : null}
             <span className="flex items-center gap-1">
               <Clock className="h-3 w-3" />
-              {new Date(workflow.updatedAt).toLocaleDateString()}
+              {new Date(workflow.updatedAt * 1000).toLocaleDateString()}
             </span>
           </div>
         </div>

--- a/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
@@ -57,18 +57,12 @@ export function WorkflowDetailPanel({
       <div className="flex-1 overflow-y-auto">
         {workflow ? (
           <div className="space-y-4 p-4">
-            {workflow.description ? (
-              <p className="text-sm text-muted-foreground">
-                {workflow.description}
-              </p>
-            ) : null}
-
             <div>
               <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                 Definition
               </h4>
               <pre className="max-h-64 overflow-auto rounded-md bg-muted/50 p-3 font-mono text-xs leading-relaxed">
-                {workflow.definition}
+                {JSON.stringify(workflow.definition, null, 2)}
               </pre>
             </div>
 
@@ -98,7 +92,7 @@ export function WorkflowDetailPanel({
                         <RunStatusBadge status={run.status} />
                       </div>
                       <div className="mt-1 text-muted-foreground">
-                        {new Date(run.createdAt).toLocaleString()}
+                        {new Date(run.createdAt * 1000).toLocaleString()}
                       </div>
                     </button>
                   ))}
@@ -132,6 +126,7 @@ function RunStatusBadge({ status }: { status: string }) {
     running: "bg-blue-500/15 text-blue-500",
     pending: "bg-muted text-muted-foreground",
     cancelled: "bg-muted text-muted-foreground",
+    waiting_approval: "bg-amber-500/15 text-amber-500",
   };
 
   return (

--- a/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
@@ -2,6 +2,7 @@ import { Play, X } from "lucide-react";
 import * as React from "react";
 
 import {
+  useRunApprovalsQuery,
   useTriggerWorkflowMutation,
   useWorkflowQuery,
   useWorkflowRunsQuery,
@@ -28,6 +29,7 @@ export function WorkflowDetailPanel({
   const selectedRun = selectedRunId
     ? (runs.find((r) => r.id === selectedRunId) ?? null)
     : null;
+  const approvalsQuery = useRunApprovalsQuery(workflowId, selectedRunId);
 
   return (
     <div
@@ -118,7 +120,10 @@ export function WorkflowDetailPanel({
                 <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                   Execution Trace
                 </h4>
-                <WorkflowRunTrace run={selectedRun} />
+                <WorkflowRunTrace
+                  approvals={approvalsQuery.data}
+                  run={selectedRun}
+                />
               </div>
             ) : null}
           </div>

--- a/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
@@ -46,13 +46,24 @@ export function WorkflowDetailPanel({
             variant="outline"
           >
             <Play className="mr-1 h-3 w-3" />
-            Trigger
+            {triggerMutation.isPending ? "Triggering..." : "Trigger"}
           </Button>
-          <Button onClick={onClose} size="icon" variant="ghost">
+          <Button
+            aria-label="Close detail panel"
+            onClick={onClose}
+            size="icon"
+            variant="ghost"
+          >
             <X className="h-4 w-4" />
           </Button>
         </div>
       </div>
+
+      {triggerMutation.isError ? (
+        <div className="border-b px-4 py-2 text-xs text-red-400">
+          Failed to trigger workflow
+        </div>
+      ) : null}
 
       <div className="flex-1 overflow-y-auto">
         {workflow ? (
@@ -108,6 +119,10 @@ export function WorkflowDetailPanel({
                 <WorkflowRunTrace run={selectedRun} />
               </div>
             ) : null}
+          </div>
+        ) : workflowQuery.isError ? (
+          <div className="flex h-32 flex-col items-center justify-center gap-2">
+            <p className="text-sm text-red-400">Failed to load workflow</p>
           </div>
         ) : (
           <div className="flex h-32 items-center justify-center">

--- a/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
@@ -31,6 +31,15 @@ export function WorkflowDetailPanel({
     : null;
   const approvalsQuery = useRunApprovalsQuery(workflowId, selectedRunId);
 
+  async function handleTrigger() {
+    try {
+      const response = await triggerMutation.mutateAsync();
+      setSelectedRunId(response.runId);
+    } catch {
+      // React Query stores the error; keep the current selection unchanged.
+    }
+  }
+
   return (
     <div
       className="flex h-full flex-col border-l bg-background"
@@ -43,7 +52,7 @@ export function WorkflowDetailPanel({
         <div className="flex items-center gap-1">
           <Button
             disabled={triggerMutation.isPending}
-            onClick={() => triggerMutation.mutate()}
+            onClick={() => void handleTrigger()}
             size="sm"
             variant="outline"
           >

--- a/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
@@ -1,0 +1,144 @@
+import { Play, X } from "lucide-react";
+import * as React from "react";
+
+import {
+  useTriggerWorkflowMutation,
+  useWorkflowQuery,
+  useWorkflowRunsQuery,
+} from "@/features/workflows/hooks";
+import { WorkflowRunTrace } from "@/features/workflows/ui/WorkflowRunTrace";
+import type { WorkflowRun } from "@/shared/api/types";
+import { Button } from "@/shared/ui/button";
+
+type WorkflowDetailPanelProps = {
+  workflowId: string;
+  onClose: () => void;
+};
+
+export function WorkflowDetailPanel({
+  workflowId,
+  onClose,
+}: WorkflowDetailPanelProps) {
+  const workflowQuery = useWorkflowQuery(workflowId);
+  const runsQuery = useWorkflowRunsQuery(workflowId);
+  const triggerMutation = useTriggerWorkflowMutation(workflowId);
+  const [selectedRun, setSelectedRun] = React.useState<WorkflowRun | null>(
+    null,
+  );
+
+  const workflow = workflowQuery.data;
+  const runs = runsQuery.data ?? [];
+
+  return (
+    <div
+      className="flex h-full flex-col border-l bg-background"
+      data-testid="workflow-detail-panel"
+    >
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h3 className="truncate text-sm font-semibold">
+          {workflow?.name ?? "Loading..."}
+        </h3>
+        <div className="flex items-center gap-1">
+          <Button
+            disabled={triggerMutation.isPending}
+            onClick={() => triggerMutation.mutate()}
+            size="sm"
+            variant="outline"
+          >
+            <Play className="mr-1 h-3 w-3" />
+            Trigger
+          </Button>
+          <Button onClick={onClose} size="icon" variant="ghost">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {workflow ? (
+          <div className="space-y-4 p-4">
+            {workflow.description ? (
+              <p className="text-sm text-muted-foreground">
+                {workflow.description}
+              </p>
+            ) : null}
+
+            <div>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Definition
+              </h4>
+              <pre className="max-h-64 overflow-auto rounded-md bg-muted/50 p-3 font-mono text-xs leading-relaxed">
+                {workflow.definition}
+              </pre>
+            </div>
+
+            <div>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Run History
+              </h4>
+              {runs.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No runs yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {runs.map((run) => (
+                    <button
+                      className={`w-full rounded-md border px-3 py-2 text-left text-xs transition-colors hover:bg-muted/50 ${
+                        selectedRun?.id === run.id
+                          ? "border-primary bg-primary/5"
+                          : ""
+                      }`}
+                      key={run.id}
+                      onClick={() =>
+                        setSelectedRun(selectedRun?.id === run.id ? null : run)
+                      }
+                      type="button"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="font-mono">{run.id.slice(0, 8)}</span>
+                        <RunStatusBadge status={run.status} />
+                      </div>
+                      <div className="mt-1 text-muted-foreground">
+                        {new Date(run.createdAt).toLocaleString()}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {selectedRun ? (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Execution Trace
+                </h4>
+                <WorkflowRunTrace run={selectedRun} />
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <div className="flex h-32 items-center justify-center">
+            <p className="text-sm text-muted-foreground">Loading...</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RunStatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    completed: "bg-green-500/15 text-green-500",
+    failed: "bg-red-500/15 text-red-500",
+    running: "bg-blue-500/15 text-blue-500",
+    pending: "bg-muted text-muted-foreground",
+    cancelled: "bg-muted text-muted-foreground",
+  };
+
+  return (
+    <span
+      className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-medium ${colors[status] ?? colors.pending}`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
@@ -7,7 +7,6 @@ import {
   useWorkflowRunsQuery,
 } from "@/features/workflows/hooks";
 import { WorkflowRunTrace } from "@/features/workflows/ui/WorkflowRunTrace";
-import type { WorkflowRun } from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
 
 type WorkflowDetailPanelProps = {
@@ -22,12 +21,13 @@ export function WorkflowDetailPanel({
   const workflowQuery = useWorkflowQuery(workflowId);
   const runsQuery = useWorkflowRunsQuery(workflowId);
   const triggerMutation = useTriggerWorkflowMutation(workflowId);
-  const [selectedRun, setSelectedRun] = React.useState<WorkflowRun | null>(
-    null,
-  );
+  const [selectedRunId, setSelectedRunId] = React.useState<string | null>(null);
 
   const workflow = workflowQuery.data;
   const runs = runsQuery.data ?? [];
+  const selectedRun = selectedRunId
+    ? (runs.find((r) => r.id === selectedRunId) ?? null)
+    : null;
 
   return (
     <div
@@ -88,13 +88,15 @@ export function WorkflowDetailPanel({
                   {runs.map((run) => (
                     <button
                       className={`w-full rounded-md border px-3 py-2 text-left text-xs transition-colors hover:bg-muted/50 ${
-                        selectedRun?.id === run.id
+                        selectedRunId === run.id
                           ? "border-primary bg-primary/5"
                           : ""
                       }`}
                       key={run.id}
                       onClick={() =>
-                        setSelectedRun(selectedRun?.id === run.id ? null : run)
+                        setSelectedRunId(
+                          selectedRunId === run.id ? null : run.id,
+                        )
                       }
                       type="button"
                     >

--- a/desktop/src/features/workflows/ui/WorkflowRunTrace.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowRunTrace.tsx
@@ -24,11 +24,11 @@ function StepStatusIcon({ status }: { status: string }) {
   }
 }
 
-function formatDuration(startedAt: string | null, completedAt: string | null) {
-  if (!startedAt || !completedAt) return null;
-  const ms = new Date(completedAt).getTime() - new Date(startedAt).getTime();
-  if (ms < 1000) return `${ms}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
+function formatDuration(startedAt: number | null, completedAt: number | null) {
+  if (startedAt === null || completedAt === null) return null;
+  const seconds = completedAt - startedAt;
+  if (seconds < 1) return `${Math.round(seconds * 1000)}ms`;
+  return `${seconds.toFixed(1)}s`;
 }
 
 export function WorkflowRunTrace({
@@ -67,9 +67,9 @@ export function WorkflowRunTrace({
                 </span>
               ) : null}
             </div>
-            {step.output ? (
+            {Object.keys(step.output).length > 0 ? (
               <pre className="ml-8 max-h-24 overflow-auto rounded bg-muted/30 px-2 py-1 font-mono text-xs text-muted-foreground">
-                {step.output}
+                {JSON.stringify(step.output, null, 2)}
               </pre>
             ) : null}
             {step.error ? (

--- a/desktop/src/features/workflows/ui/WorkflowRunTrace.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowRunTrace.tsx
@@ -1,0 +1,90 @@
+import { Check, Clock, SkipForward, X } from "lucide-react";
+
+import type { WorkflowApproval, WorkflowRun } from "@/shared/api/types";
+import { WorkflowApprovalCard } from "@/features/workflows/ui/WorkflowApprovalCard";
+
+type WorkflowRunTraceProps = {
+  run: WorkflowRun;
+  approvals?: WorkflowApproval[];
+};
+
+function StepStatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case "completed":
+      return <Check className="h-4 w-4 text-green-500" />;
+    case "failed":
+    case "error":
+      return <X className="h-4 w-4 text-red-500" />;
+    case "skipped":
+      return <SkipForward className="h-4 w-4 text-muted-foreground" />;
+    case "waiting_approval":
+      return <Clock className="h-4 w-4 text-amber-500" />;
+    default:
+      return <Clock className="h-4 w-4 text-blue-500" />;
+  }
+}
+
+function formatDuration(startedAt: string | null, completedAt: string | null) {
+  if (!startedAt || !completedAt) return null;
+  const ms = new Date(completedAt).getTime() - new Date(startedAt).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function WorkflowRunTrace({
+  run,
+  approvals = [],
+}: WorkflowRunTraceProps) {
+  if (run.executionTrace.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-muted-foreground">
+        No steps recorded yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1" data-testid="workflow-run-trace">
+      {run.executionTrace.map((step) => {
+        const duration = formatDuration(step.startedAt, step.completedAt);
+        const pendingApproval = approvals.find(
+          (a) => a.stepId === step.stepId && a.status === "pending",
+        );
+
+        return (
+          <div key={step.stepId}>
+            <div className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50">
+              <StepStatusIcon status={step.status} />
+              <span className="flex-1 truncate font-mono text-xs">
+                {step.stepId}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {step.status}
+              </span>
+              {duration ? (
+                <span className="text-xs text-muted-foreground">
+                  {duration}
+                </span>
+              ) : null}
+            </div>
+            {step.output ? (
+              <pre className="ml-8 max-h-24 overflow-auto rounded bg-muted/30 px-2 py-1 font-mono text-xs text-muted-foreground">
+                {step.output}
+              </pre>
+            ) : null}
+            {step.error ? (
+              <pre className="ml-8 max-h-24 overflow-auto rounded bg-red-500/10 px-2 py-1 font-mono text-xs text-red-400">
+                {step.error}
+              </pre>
+            ) : null}
+            {pendingApproval ? (
+              <div className="ml-8 mt-1">
+                <WorkflowApprovalCard approval={pendingApproval} />
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -55,22 +55,30 @@ export function WorkflowsView({ channels }: WorkflowsViewProps) {
   const allWorkflows = allWorkflowsQuery.data ?? [];
 
   async function handleTrigger(workflowId: string) {
-    await triggerWorkflow(workflowId);
-    void queryClient.invalidateQueries({
-      predicate: (query) => query.queryKey[0] === "workflow-runs",
-    });
+    try {
+      await triggerWorkflow(workflowId);
+      void queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey[0] === "workflow-runs",
+      });
+    } catch {
+      // TODO: surface error via toast or inline feedback
+    }
   }
 
   async function handleDelete(workflowId: string) {
-    await deleteWorkflow(workflowId);
-    if (selectedWorkflowId === workflowId) {
-      setSelectedWorkflowId(null);
+    try {
+      await deleteWorkflow(workflowId);
+      if (selectedWorkflowId === workflowId) {
+        setSelectedWorkflowId(null);
+      }
+      void queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "workflows" ||
+          query.queryKey[0] === "workflows-all",
+      });
+    } catch {
+      // TODO: surface error via toast or inline feedback
     }
-    void queryClient.invalidateQueries({
-      predicate: (query) =>
-        query.queryKey[0] === "workflows" ||
-        query.queryKey[0] === "workflows-all",
-    });
   }
 
   return (
@@ -92,6 +100,17 @@ export function WorkflowsView({ channels }: WorkflowsViewProps) {
             <p className="text-sm text-muted-foreground">
               Loading workflows...
             </p>
+          </div>
+        ) : allWorkflowsQuery.isError ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 text-muted-foreground">
+            <p className="text-sm text-red-400">Failed to load workflows</p>
+            <Button
+              onClick={() => void allWorkflowsQuery.refetch()}
+              size="sm"
+              variant="outline"
+            >
+              Retry
+            </Button>
           </div>
         ) : allWorkflows.length === 0 ? (
           <div className="flex flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">

--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -1,0 +1,142 @@
+import { Plus, Zap } from "lucide-react";
+import * as React from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { CreateWorkflowDialog } from "@/features/workflows/ui/CreateWorkflowDialog";
+import { WorkflowCard } from "@/features/workflows/ui/WorkflowCard";
+import { WorkflowDetailPanel } from "@/features/workflows/ui/WorkflowDetailPanel";
+import type { Channel, Workflow } from "@/shared/api/types";
+import {
+  deleteWorkflow,
+  getChannelWorkflows,
+  triggerWorkflow,
+} from "@/shared/api/tauriWorkflows";
+import { Button } from "@/shared/ui/button";
+
+type WorkflowsViewProps = {
+  channels: Channel[];
+};
+
+type WorkflowWithChannel = {
+  workflow: Workflow;
+  channelName: string;
+};
+
+export function WorkflowsView({ channels }: WorkflowsViewProps) {
+  const [isCreateOpen, setIsCreateOpen] = React.useState(false);
+  const [selectedWorkflowId, setSelectedWorkflowId] = React.useState<
+    string | null
+  >(null);
+  const queryClient = useQueryClient();
+
+  const memberChannels = channels.filter((c) => c.isMember);
+  const channelIds = memberChannels.map((c) => c.id).sort();
+  const channelIdKey = channelIds.join(",");
+
+  const allWorkflowsQuery = useQuery({
+    queryKey: ["workflows-all", channelIdKey],
+    queryFn: async () => {
+      const results: WorkflowWithChannel[] = [];
+      await Promise.all(
+        memberChannels.map(async (channel) => {
+          const workflows = await getChannelWorkflows(channel.id);
+          for (const workflow of workflows) {
+            results.push({ workflow, channelName: channel.name });
+          }
+        }),
+      );
+      return results;
+    },
+    enabled: memberChannels.length > 0,
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+
+  const allWorkflows = allWorkflowsQuery.data ?? [];
+
+  async function handleTrigger(workflowId: string) {
+    await triggerWorkflow(workflowId);
+    void queryClient.invalidateQueries({
+      predicate: (query) => query.queryKey[0] === "workflow-runs",
+    });
+  }
+
+  async function handleDelete(workflowId: string) {
+    await deleteWorkflow(workflowId);
+    if (selectedWorkflowId === workflowId) {
+      setSelectedWorkflowId(null);
+    }
+    void queryClient.invalidateQueries({
+      predicate: (query) =>
+        query.queryKey[0] === "workflows" ||
+        query.queryKey[0] === "workflows-all",
+    });
+  }
+
+  return (
+    <div
+      className="flex min-h-0 flex-1 overflow-hidden"
+      data-testid="workflows-view"
+    >
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Workflows</h2>
+          <Button onClick={() => setIsCreateOpen(true)} size="sm">
+            <Plus className="mr-1 h-4 w-4" />
+            Create Workflow
+          </Button>
+        </div>
+
+        {allWorkflowsQuery.isLoading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <p className="text-sm text-muted-foreground">
+              Loading workflows...
+            </p>
+          </div>
+        ) : allWorkflows.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 text-muted-foreground">
+            <Zap className="h-10 w-10 opacity-30" />
+            <p className="text-sm">No workflows yet</p>
+            <Button
+              onClick={() => setIsCreateOpen(true)}
+              size="sm"
+              variant="outline"
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Create your first workflow
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {allWorkflows.map(({ workflow, channelName }) => (
+              <WorkflowCard
+                channelName={channelName}
+                key={workflow.id}
+                onDelete={handleDelete}
+                onSelect={setSelectedWorkflowId}
+                onTrigger={handleTrigger}
+                workflow={workflow}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {selectedWorkflowId ? (
+        <div className="w-[400px] shrink-0">
+          <WorkflowDetailPanel
+            key={selectedWorkflowId}
+            onClose={() => setSelectedWorkflowId(null)}
+            workflowId={selectedWorkflowId}
+          />
+        </div>
+      ) : null}
+
+      <CreateWorkflowDialog
+        channels={memberChannels}
+        onOpenChange={setIsCreateOpen}
+        open={isCreateOpen}
+      />
+    </div>
+  );
+}

--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -1,11 +1,8 @@
-import { Plus, Zap } from "lucide-react";
+import { Plus, RefreshCw, Zap } from "lucide-react";
 import * as React from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import {
-  allWorkflowsQueryKey,
-  workflowsQueryKey,
-} from "@/features/workflows/hooks";
+import { allWorkflowsQueryKey } from "@/features/workflows/hooks";
 import { CreateWorkflowDialog } from "@/features/workflows/ui/CreateWorkflowDialog";
 import { WorkflowCard } from "@/features/workflows/ui/WorkflowCard";
 import { WorkflowDetailPanel } from "@/features/workflows/ui/WorkflowDetailPanel";
@@ -53,42 +50,42 @@ export function WorkflowsView({ channels }: WorkflowsViewProps) {
     },
     enabled: memberChannels.length > 0,
     staleTime: 30_000,
-    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
   });
 
   const allWorkflows = allWorkflowsQuery.data ?? [];
 
-  const handleTrigger = React.useCallback(
-    async (workflowId: string) => {
-      try {
-        await triggerWorkflow(workflowId);
-        void queryClient.invalidateQueries({
-          predicate: (query) => query.queryKey[0] === "workflow-runs",
-        });
-      } catch {
-        // TODO: surface error via toast or inline feedback
-      }
+  const triggerMutation = useMutation({
+    mutationFn: (workflowId: string) => triggerWorkflow(workflowId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey[0] === "workflow-runs",
+      });
     },
-    [queryClient],
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (workflowId: string) => deleteWorkflow(workflowId),
+    onSuccess: (_data, workflowId) => {
+      setSelectedWorkflowId((current) =>
+        current === workflowId ? null : current,
+      );
+      void queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "workflows" ||
+          query.queryKey[0] === "workflows-all",
+      });
+    },
+  });
+
+  const handleTrigger = React.useCallback(
+    (workflowId: string) => triggerMutation.mutate(workflowId),
+    [triggerMutation],
   );
 
   const handleDelete = React.useCallback(
-    async (workflowId: string) => {
-      try {
-        await deleteWorkflow(workflowId);
-        setSelectedWorkflowId((current) =>
-          current === workflowId ? null : current,
-        );
-        void queryClient.invalidateQueries({
-          predicate: (query) =>
-            query.queryKey[0] === workflowsQueryKey("").at(0) ||
-            query.queryKey[0] === allWorkflowsQueryKey("").at(0),
-        });
-      } catch {
-        // TODO: surface error via toast or inline feedback
-      }
-    },
-    [queryClient],
+    (workflowId: string) => deleteMutation.mutate(workflowId),
+    [deleteMutation],
   );
 
   return (
@@ -98,7 +95,20 @@ export function WorkflowsView({ channels }: WorkflowsViewProps) {
     >
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Workflows</h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold">Workflows</h2>
+            <Button
+              aria-label="Refresh workflows"
+              disabled={allWorkflowsQuery.isFetching}
+              onClick={() => void allWorkflowsQuery.refetch()}
+              size="icon"
+              variant="ghost"
+            >
+              <RefreshCw
+                className={`h-4 w-4 ${allWorkflowsQuery.isFetching ? "animate-spin" : ""}`}
+              />
+            </Button>
+          </div>
           <Button onClick={() => setIsCreateOpen(true)} size="sm">
             <Plus className="mr-1 h-4 w-4" />
             Create Workflow

--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -2,6 +2,10 @@ import { Plus, Zap } from "lucide-react";
 import * as React from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import {
+  allWorkflowsQueryKey,
+  workflowsQueryKey,
+} from "@/features/workflows/hooks";
 import { CreateWorkflowDialog } from "@/features/workflows/ui/CreateWorkflowDialog";
 import { WorkflowCard } from "@/features/workflows/ui/WorkflowCard";
 import { WorkflowDetailPanel } from "@/features/workflows/ui/WorkflowDetailPanel";
@@ -34,7 +38,7 @@ export function WorkflowsView({ channels }: WorkflowsViewProps) {
   const channelIdKey = channelIds.join(",");
 
   const allWorkflowsQuery = useQuery({
-    queryKey: ["workflows-all", channelIdKey],
+    queryKey: allWorkflowsQueryKey(channelIdKey),
     queryFn: async () => {
       const results: WorkflowWithChannel[] = [];
       await Promise.all(
@@ -54,32 +58,38 @@ export function WorkflowsView({ channels }: WorkflowsViewProps) {
 
   const allWorkflows = allWorkflowsQuery.data ?? [];
 
-  async function handleTrigger(workflowId: string) {
-    try {
-      await triggerWorkflow(workflowId);
-      void queryClient.invalidateQueries({
-        predicate: (query) => query.queryKey[0] === "workflow-runs",
-      });
-    } catch {
-      // TODO: surface error via toast or inline feedback
-    }
-  }
-
-  async function handleDelete(workflowId: string) {
-    try {
-      await deleteWorkflow(workflowId);
-      if (selectedWorkflowId === workflowId) {
-        setSelectedWorkflowId(null);
+  const handleTrigger = React.useCallback(
+    async (workflowId: string) => {
+      try {
+        await triggerWorkflow(workflowId);
+        void queryClient.invalidateQueries({
+          predicate: (query) => query.queryKey[0] === "workflow-runs",
+        });
+      } catch {
+        // TODO: surface error via toast or inline feedback
       }
-      void queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[0] === "workflows" ||
-          query.queryKey[0] === "workflows-all",
-      });
-    } catch {
-      // TODO: surface error via toast or inline feedback
-    }
-  }
+    },
+    [queryClient],
+  );
+
+  const handleDelete = React.useCallback(
+    async (workflowId: string) => {
+      try {
+        await deleteWorkflow(workflowId);
+        setSelectedWorkflowId((current) =>
+          current === workflowId ? null : current,
+        );
+        void queryClient.invalidateQueries({
+          predicate: (query) =>
+            query.queryKey[0] === workflowsQueryKey("").at(0) ||
+            query.queryKey[0] === allWorkflowsQueryKey("").at(0),
+        });
+      } catch {
+        // TODO: surface error via toast or inline feedback
+      }
+    },
+    [queryClient],
+  );
 
   return (
     <div

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -14,6 +14,7 @@ const queryClient = new QueryClient({
       retry: 1,
       refetchOnWindowFocus: false,
       networkMode: "always",
+      gcTime: 5 * 60 * 1_000,
     },
     mutations: {
       networkMode: "always",

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -44,6 +44,7 @@ export class RelayClient {
   private reconnectListeners = new Set<() => void>();
   private hasConnectedOnce = false;
   private notifyReconnectListeners = false;
+  private onMessageChannel: Channel<unknown> | null = null;
 
   async fetchChannelHistory(channelId: string, limit = 50) {
     return this.fetchHistory(this.buildChannelFilter(channelId, limit));
@@ -217,13 +218,13 @@ export class RelayClient {
       this.relayUrl = await getRelayWsUrl();
     }
 
-    const onMessageChannel = new Channel<unknown>((message) => {
+    this.onMessageChannel = new Channel<unknown>((message) => {
       void this.handleWsMessage(message);
     });
 
     this.wsId = await invoke<number>("plugin:websocket|connect", {
       url: this.relayUrl,
-      onMessage: onMessageChannel,
+      onMessage: this.onMessageChannel,
       config: {},
     });
 
@@ -700,6 +701,7 @@ export class RelayClient {
       reconnect?: boolean;
     },
   ) {
+    this.onMessageChannel = null;
     if (this.flushTimeout !== null) window.clearTimeout(this.flushTimeout);
     this.flushTimeout = null;
     this.eventBuffer = [];

--- a/desktop/src/shared/api/tauriWorkflows.ts
+++ b/desktop/src/shared/api/tauriWorkflows.ts
@@ -1,0 +1,76 @@
+import { invokeTauri } from "@/shared/api/tauri";
+import type {
+  Workflow,
+  WorkflowApproval,
+  WorkflowRun,
+} from "@/shared/api/types";
+
+export async function getChannelWorkflows(
+  channelId: string,
+): Promise<Workflow[]> {
+  return invokeTauri<Workflow[]>("get_channel_workflows", { channelId });
+}
+
+export async function getWorkflow(workflowId: string): Promise<Workflow> {
+  return invokeTauri<Workflow>("get_workflow", { workflowId });
+}
+
+export async function createWorkflow(
+  channelId: string,
+  yamlDefinition: string,
+): Promise<Workflow> {
+  return invokeTauri<Workflow>("create_workflow", {
+    channelId,
+    yamlDefinition,
+  });
+}
+
+export async function updateWorkflow(
+  workflowId: string,
+  yamlDefinition: string,
+): Promise<Workflow> {
+  return invokeTauri<Workflow>("update_workflow", {
+    workflowId,
+    yamlDefinition,
+  });
+}
+
+export async function deleteWorkflow(workflowId: string): Promise<void> {
+  await invokeTauri("delete_workflow", { workflowId });
+}
+
+export async function getWorkflowRuns(
+  workflowId: string,
+  limit?: number,
+): Promise<WorkflowRun[]> {
+  return invokeTauri<WorkflowRun[]>("get_workflow_runs", {
+    workflowId,
+    limit: limit ?? null,
+  });
+}
+
+export async function triggerWorkflow(
+  workflowId: string,
+): Promise<WorkflowRun> {
+  return invokeTauri<WorkflowRun>("trigger_workflow", { workflowId });
+}
+
+export async function grantApproval(
+  token: string,
+  note?: string,
+): Promise<WorkflowApproval> {
+  return invokeTauri<WorkflowApproval>("grant_approval", {
+    token,
+    note: note ?? null,
+  });
+}
+
+export async function denyApproval(
+  token: string,
+  note?: string,
+): Promise<WorkflowApproval> {
+  return invokeTauri<WorkflowApproval>("deny_approval", {
+    token,
+    note: note ?? null,
+  });
+}

--- a/desktop/src/shared/api/tauriWorkflows.ts
+++ b/desktop/src/shared/api/tauriWorkflows.ts
@@ -199,6 +199,17 @@ export async function getWorkflowRuns(
   return raw.map(fromRawWorkflowRun);
 }
 
+export async function getRunApprovals(
+  workflowId: string,
+  runId: string,
+): Promise<WorkflowApproval[]> {
+  const raw = await invokeTauri<RawWorkflowApproval[]>("get_run_approvals", {
+    workflowId,
+    runId,
+  });
+  return raw.map(fromRawApproval);
+}
+
 export async function triggerWorkflow(
   workflowId: string,
 ): Promise<TriggerWorkflowResponse> {

--- a/desktop/src/shared/api/tauriWorkflows.ts
+++ b/desktop/src/shared/api/tauriWorkflows.ts
@@ -109,6 +109,22 @@ function fromRawWorkflowRun(raw: RawWorkflowRun): WorkflowRun {
   };
 }
 
+export function fromRawApproval(raw: RawWorkflowApproval): WorkflowApproval {
+  return {
+    token: raw.token,
+    workflowId: raw.workflow_id,
+    runId: raw.run_id,
+    stepId: raw.step_id,
+    stepIndex: raw.step_index,
+    approverSpec: raw.approver_spec,
+    status: raw.status,
+    approverPubkey: raw.approver_pubkey,
+    note: raw.note,
+    expiresAt: raw.expires_at,
+    createdAt: raw.created_at,
+  };
+}
+
 function fromRawTriggerResponse(
   raw: RawTriggerWorkflowResponse,
 ): TriggerWorkflowResponse {

--- a/desktop/src/shared/api/tauriWorkflows.ts
+++ b/desktop/src/shared/api/tauriWorkflows.ts
@@ -1,38 +1,171 @@
 import { invokeTauri } from "@/shared/api/tauri";
 import type {
+  ApprovalActionResponse,
+  TriggerWorkflowResponse,
   Workflow,
   WorkflowApproval,
   WorkflowRun,
+  TraceEntry,
 } from "@/shared/api/types";
+
+// ── Raw types (snake_case from backend) ───────────────────────────────────
+
+type RawWorkflow = {
+  id: string;
+  name: string;
+  owner_pubkey: string;
+  channel_id: string | null;
+  definition: Record<string, unknown>;
+  status: Workflow["status"];
+  created_at: number;
+  updated_at: number;
+};
+
+type RawTraceEntry = {
+  step_id: string;
+  status: string;
+  output?: Record<string, unknown>;
+  started_at?: number | null;
+  completed_at?: number | null;
+  error?: string | null;
+};
+
+type RawWorkflowRun = {
+  id: string;
+  workflow_id: string;
+  status: WorkflowRun["status"];
+  current_step: number | null;
+  execution_trace: RawTraceEntry[];
+  started_at: number | null;
+  completed_at: number | null;
+  error_message: string | null;
+  created_at: number;
+};
+
+type RawWorkflowApproval = {
+  token: string;
+  workflow_id: string;
+  run_id: string;
+  step_id: string;
+  step_index: number;
+  approver_spec: string;
+  status: WorkflowApproval["status"];
+  approver_pubkey: string | null;
+  note: string | null;
+  expires_at: string;
+  created_at: number;
+};
+
+type RawTriggerWorkflowResponse = {
+  run_id: string;
+  workflow_id: string;
+  status: string;
+};
+
+type RawApprovalActionResponse = {
+  token: string;
+  status: string;
+  run_id: string;
+  workflow_id: string;
+};
+
+// ── Conversion functions ──────────────────────────────────────────────────
+
+function fromRawWorkflow(raw: RawWorkflow): Workflow {
+  return {
+    id: raw.id,
+    name: raw.name,
+    ownerPubkey: raw.owner_pubkey,
+    channelId: raw.channel_id,
+    definition: raw.definition,
+    status: raw.status,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+  };
+}
+
+function fromRawTraceEntry(raw: RawTraceEntry): TraceEntry {
+  return {
+    stepId: raw.step_id,
+    status: raw.status,
+    output: raw.output ?? {},
+    startedAt: raw.started_at ?? null,
+    completedAt: raw.completed_at ?? null,
+    error: raw.error ?? null,
+  };
+}
+
+function fromRawWorkflowRun(raw: RawWorkflowRun): WorkflowRun {
+  return {
+    id: raw.id,
+    workflowId: raw.workflow_id,
+    status: raw.status,
+    currentStep: raw.current_step,
+    executionTrace: raw.execution_trace.map(fromRawTraceEntry),
+    startedAt: raw.started_at,
+    completedAt: raw.completed_at,
+    errorMessage: raw.error_message,
+    createdAt: raw.created_at,
+  };
+}
+
+function fromRawTriggerResponse(
+  raw: RawTriggerWorkflowResponse,
+): TriggerWorkflowResponse {
+  return {
+    runId: raw.run_id,
+    workflowId: raw.workflow_id,
+    status: raw.status,
+  };
+}
+
+function fromRawApprovalResponse(
+  raw: RawApprovalActionResponse,
+): ApprovalActionResponse {
+  return {
+    token: raw.token,
+    status: raw.status,
+    runId: raw.run_id,
+    workflowId: raw.workflow_id,
+  };
+}
+
+// ── Tauri invoke wrappers ─────────────────────────────────────────────────
 
 export async function getChannelWorkflows(
   channelId: string,
 ): Promise<Workflow[]> {
-  return invokeTauri<Workflow[]>("get_channel_workflows", { channelId });
+  const raw = await invokeTauri<RawWorkflow[]>("get_channel_workflows", {
+    channelId,
+  });
+  return raw.map(fromRawWorkflow);
 }
 
 export async function getWorkflow(workflowId: string): Promise<Workflow> {
-  return invokeTauri<Workflow>("get_workflow", { workflowId });
+  const raw = await invokeTauri<RawWorkflow>("get_workflow", { workflowId });
+  return fromRawWorkflow(raw);
 }
 
 export async function createWorkflow(
   channelId: string,
   yamlDefinition: string,
 ): Promise<Workflow> {
-  return invokeTauri<Workflow>("create_workflow", {
+  const raw = await invokeTauri<RawWorkflow>("create_workflow", {
     channelId,
     yamlDefinition,
   });
+  return fromRawWorkflow(raw);
 }
 
 export async function updateWorkflow(
   workflowId: string,
   yamlDefinition: string,
 ): Promise<Workflow> {
-  return invokeTauri<Workflow>("update_workflow", {
+  const raw = await invokeTauri<RawWorkflow>("update_workflow", {
     workflowId,
     yamlDefinition,
   });
+  return fromRawWorkflow(raw);
 }
 
 export async function deleteWorkflow(workflowId: string): Promise<void> {
@@ -43,34 +176,41 @@ export async function getWorkflowRuns(
   workflowId: string,
   limit?: number,
 ): Promise<WorkflowRun[]> {
-  return invokeTauri<WorkflowRun[]>("get_workflow_runs", {
+  const raw = await invokeTauri<RawWorkflowRun[]>("get_workflow_runs", {
     workflowId,
     limit: limit ?? null,
   });
+  return raw.map(fromRawWorkflowRun);
 }
 
 export async function triggerWorkflow(
   workflowId: string,
-): Promise<WorkflowRun> {
-  return invokeTauri<WorkflowRun>("trigger_workflow", { workflowId });
+): Promise<TriggerWorkflowResponse> {
+  const raw = await invokeTauri<RawTriggerWorkflowResponse>(
+    "trigger_workflow",
+    { workflowId },
+  );
+  return fromRawTriggerResponse(raw);
 }
 
 export async function grantApproval(
   token: string,
   note?: string,
-): Promise<WorkflowApproval> {
-  return invokeTauri<WorkflowApproval>("grant_approval", {
+): Promise<ApprovalActionResponse> {
+  const raw = await invokeTauri<RawApprovalActionResponse>("grant_approval", {
     token,
     note: note ?? null,
   });
+  return fromRawApprovalResponse(raw);
 }
 
 export async function denyApproval(
   token: string,
   note?: string,
-): Promise<WorkflowApproval> {
-  return invokeTauri<WorkflowApproval>("deny_approval", {
+): Promise<ApprovalActionResponse> {
+  const raw = await invokeTauri<RawApprovalActionResponse>("deny_approval", {
     token,
     note: note ?? null,
   });
+  return fromRawApprovalResponse(raw);
 }

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -466,6 +466,7 @@ export type UpdateTeamInput = {
 
 // ── Workflow types (re-exported from workflowTypes.ts) ────────────────────
 export type {
+  ApprovalActionResponse,
   Workflow,
   WorkflowApproval,
   WorkflowApprovalStatus,
@@ -473,6 +474,7 @@ export type {
   WorkflowRunStatus,
   WorkflowStatus,
   TraceEntry,
+  TriggerWorkflowResponse,
 } from "@/shared/api/workflowTypes";
 
 // ── Forum types ───────────────────────────────────────────────────────────────

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -464,6 +464,17 @@ export type UpdateTeamInput = {
   personaIds: string[];
 };
 
+// ── Workflow types (re-exported from workflowTypes.ts) ────────────────────
+export type {
+  Workflow,
+  WorkflowApproval,
+  WorkflowApprovalStatus,
+  WorkflowRun,
+  WorkflowRunStatus,
+  WorkflowStatus,
+  TraceEntry,
+} from "@/shared/api/workflowTypes";
+
 // ── Forum types ───────────────────────────────────────────────────────────────
 
 export type ThreadSummary = {

--- a/desktop/src/shared/api/workflowTypes.ts
+++ b/desktop/src/shared/api/workflowTypes.ts
@@ -1,0 +1,64 @@
+export type WorkflowStatus = "active" | "disabled" | "archived";
+
+export type Workflow = {
+  id: string;
+  name: string;
+  description: string | null;
+  ownerPubkey: string;
+  channelId: string;
+  definition: string;
+  definitionHash: string;
+  status: WorkflowStatus;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type WorkflowRunStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type TraceEntry = {
+  stepId: string;
+  status: string;
+  output: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  error: string | null;
+};
+
+export type WorkflowRun = {
+  id: string;
+  workflowId: string;
+  status: WorkflowRunStatus;
+  currentStep: string | null;
+  executionTrace: TraceEntry[];
+  triggerContext: Record<string, unknown> | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+};
+
+export type WorkflowApprovalStatus =
+  | "pending"
+  | "granted"
+  | "denied"
+  | "expired";
+
+export type WorkflowApproval = {
+  token: string;
+  workflowId: string;
+  runId: string;
+  stepId: string;
+  stepIndex: number;
+  approverSpec: string;
+  status: WorkflowApprovalStatus;
+  approverPubkey: string | null;
+  note: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+};

--- a/desktop/src/shared/api/workflowTypes.ts
+++ b/desktop/src/shared/api/workflowTypes.ts
@@ -3,15 +3,12 @@ export type WorkflowStatus = "active" | "disabled" | "archived";
 export type Workflow = {
   id: string;
   name: string;
-  description: string | null;
   ownerPubkey: string;
-  channelId: string;
-  definition: string;
-  definitionHash: string;
+  channelId: string | null;
+  definition: Record<string, unknown>;
   status: WorkflowStatus;
-  enabled: boolean;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: number;
+  updatedAt: number;
 };
 
 export type WorkflowRunStatus =
@@ -19,14 +16,15 @@ export type WorkflowRunStatus =
   | "running"
   | "completed"
   | "failed"
-  | "cancelled";
+  | "cancelled"
+  | "waiting_approval";
 
 export type TraceEntry = {
   stepId: string;
   status: string;
-  output: string | null;
-  startedAt: string | null;
-  completedAt: string | null;
+  output: Record<string, unknown>;
+  startedAt: number | null;
+  completedAt: number | null;
   error: string | null;
 };
 
@@ -34,13 +32,12 @@ export type WorkflowRun = {
   id: string;
   workflowId: string;
   status: WorkflowRunStatus;
-  currentStep: string | null;
+  currentStep: number | null;
   executionTrace: TraceEntry[];
-  triggerContext: Record<string, unknown> | null;
-  startedAt: string | null;
-  completedAt: string | null;
+  startedAt: number | null;
+  completedAt: number | null;
   errorMessage: string | null;
-  createdAt: string;
+  createdAt: number;
 };
 
 export type WorkflowApprovalStatus =
@@ -59,6 +56,19 @@ export type WorkflowApproval = {
   status: WorkflowApprovalStatus;
   approverPubkey: string | null;
   note: string | null;
-  expiresAt: string | null;
-  createdAt: string;
+  expiresAt: string;
+  createdAt: number;
+};
+
+export type TriggerWorkflowResponse = {
+  runId: string;
+  workflowId: string;
+  status: string;
+};
+
+export type ApprovalActionResponse = {
+  token: string;
+  status: string;
+  runId: string;
+  workflowId: string;
 };


### PR DESCRIPTION
## Problem

After hours of continuous use the desktop app accumulates memory until it goes black and becomes unresponsive. One report measured **37.5 GB** of RAM consumed by the process.

## Root Cause

The primary culprit is a **Tauri `Channel` leak on every WebSocket reconnect**. Each call to `connect()` in `RelayClient` created a new `Channel<unknown>` callback object, but the previous one was never dereferenced. Tauri keeps an internal reference to every `Channel` that has been registered, so the old objects (and the closures they capture — including the entire `RelayClient` instance) were never garbage-collected. Over hours with periodic reconnections this accumulated massively.

Several secondary leaks compounded the issue:
- `requestedAncestorIdsRef` (`Set<string>`) in `AppShell` grew without bound while staying in the same channel.
- `seenItemIdsRef` (`Set<string>`) in the notification dedup hook only grew, never evicted old entries.
- The React Query garbage-collection window for channel-message caches was 30 minutes, keeping up to 2 000 events per channel alive long after leaving the channel.

## Fixes

| File | Change |
|------|--------|
| `relayClientSession.ts` | Store `Channel` as a class field; nullify it in `resetConnection()` so old instances are eligible for GC |
| `AppShell.tsx` | Cap `requestedAncestorIdsRef` at 500 entries with oldest-first eviction |
| `notifications/hooks.ts` | Cap `seenItemIdsRef` at 500 entries with oldest-first eviction |
| `messages/hooks.ts` | Reduce channel-messages `gcTime` from 30 min → 5 min |
| `main.tsx` | Set an explicit default `gcTime` of 5 min on the `QueryClient` |

## What I intentionally left alone

- `typingSuppressUntilByPubkeyRef` / `latestMessageCreatedAtByPubkeyRef` — already cleared on channel change, low cardinality
- `mentionMapRef` / `draftsRef` — tiny per-entry footprint, not meaningful contributors
- The existing 2 000-message timeline cap was already in place ✅

## Testing

- `just ci` passes (Rust fmt/clippy/tests + desktop lint/build + Tauri check)
- Code reviewed for correctness, edge cases, and ordering safety