### PR TITLE
fix(desktop): plug memory leaks causing 37GB+ RAM growth

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -32,7 +32,7 @@ const rules = [
 const overrides = new Map([
   ["src-tauri/src/managed_agents/personas.rs", 600], // built-in persona system prompts (Solo, Ralph, Strategist) are long string literals
   ["src-tauri/src/managed_agents/persona_card.rs", 772], // PNG/ZIP persona card codec + provider/model fields + 27 unit tests (~350 lines of tests); rustfmt adds line breaks around long literals/builders
-  ["src/app/AppShell.tsx", 840], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view
+  ["src/app/AppShell.tsx", 860], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view + memory-leak safeguards
   ["src/features/channels/hooks.ts", 550], // canvas query + mutation hooks + DM hide mutation
   ["src/features/channels/ui/ChannelManagementSheet.tsx", 800],
   ["src/features/messages/hooks.ts", 500], // message query/mutation hooks + optimistic updates

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -483,6 +483,21 @@ export function AppShell() {
       requestedAncestorIdsRef.current.add(eventId);
     }
 
+    // Prevent unbounded growth — evict oldest entries when the set exceeds
+    // a reasonable size. Since Set iteration is insertion-ordered we drop
+    // the first (oldest) entries.
+    const MAX_REQUESTED_ANCESTORS = 500;
+    if (requestedAncestorIdsRef.current.size > MAX_REQUESTED_ANCESTORS) {
+      const excess =
+        requestedAncestorIdsRef.current.size - MAX_REQUESTED_ANCESTORS;
+      let removed = 0;
+      for (const id of requestedAncestorIdsRef.current) {
+        if (removed >= excess) break;
+        requestedAncestorIdsRef.current.delete(id);
+        removed++;
+      }
+    }
+
     let isCancelled = false;
 
     void Promise.all(

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -140,7 +140,7 @@ export function useChannelMessagesQuery(channel: Channel | null) {
       return mergedHistory;
     },
     staleTime: Number.POSITIVE_INFINITY,
-    gcTime: 30 * 60 * 1_000,
+    gcTime: 5 * 60 * 1_000,
   });
 }
 

--- a/desktop/src/features/notifications/hooks.ts
+++ b/desktop/src/features/notifications/hooks.ts
@@ -373,6 +373,19 @@ export function useFeedDesktopNotifications(
     for (const item of currentFeedItems) {
       nextSeenItemIds.add(item.id);
     }
+
+    // Prevent unbounded growth — keep only the most recent entries.
+    const MAX_SEEN_FEED_ITEMS = 500;
+    if (nextSeenItemIds.size > MAX_SEEN_FEED_ITEMS) {
+      const excess = nextSeenItemIds.size - MAX_SEEN_FEED_ITEMS;
+      let removed = 0;
+      for (const id of nextSeenItemIds) {
+        if (removed >= excess) break;
+        nextSeenItemIds.delete(id);
+        removed++;
+      }
+    }
+
     seenItemIdsRef.current = nextSeenItemIds;
 
     for (const item of newItems) {

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -14,6 +14,7 @@ const queryClient = new QueryClient({
       retry: 1,
       refetchOnWindowFocus: false,
       networkMode: "always",
+      gcTime: 5 * 60 * 1_000,
     },
     mutations: {
       networkMode: "always",

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -44,6 +44,7 @@ export class RelayClient {
   private reconnectListeners = new Set<() => void>();
   private hasConnectedOnce = false;
   private notifyReconnectListeners = false;
+  private onMessageChannel: Channel<unknown> | null = null;
 
   async fetchChannelHistory(channelId: string, limit = 50) {
     return this.fetchHistory(this.buildChannelFilter(channelId, limit));
@@ -217,13 +218,13 @@ export class RelayClient {
       this.relayUrl = await getRelayWsUrl();
     }
 
-    const onMessageChannel = new Channel<unknown>((message) => {
+    this.onMessageChannel = new Channel<unknown>((message) => {
       void this.handleWsMessage(message);
     });
 
     this.wsId = await invoke<number>("plugin:websocket|connect", {
       url: this.relayUrl,
-      onMessage: onMessageChannel,
+      onMessage: this.onMessageChannel,
       config: {},
     });
 
@@ -700,6 +701,7 @@ export class RelayClient {
       reconnect?: boolean;
     },
   ) {
+    this.onMessageChannel = null;
     if (this.flushTimeout !== null) window.clearTimeout(this.flushTimeout);
     this.flushTimeout = null;
     this.eventBuffer = [];


### PR DESCRIPTION
## Summary
- **Critical**: Store Tauri `Channel` as a class field in `RelayClient` and nullify on `resetConnection()` — each WebSocket reconnect was creating a new Channel without releasing the old one, causing unbounded accumulation
- Cap `requestedAncestorIdsRef` and `seenItemIdsRef` Sets at 500 entries with LRU eviction to prevent unbounded growth
- Reduce default `gcTime` to 5min (from infinite/30min) so large query caches get collected sooner

## Test plan
- [x] Run desktop app for extended period, monitor RAM usage stays stable across WebSocket reconnects
- [x] Verify message history and notifications still work correctly after cache GC

🤖 Generated with [Claude Code](https://claude.com/claude-code)