### PR TITLE
fix(desktop): kill entire process group on agent shutdown

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -28,6 +28,26 @@ fn restore_managed_agents_on_launch(app: &tauri::AppHandle) -> Result<(), String
         .lock()
         .map_err(|error| error.to_string())?;
     let mut changed = sync_managed_agent_processes(&mut records, &mut runtimes);
+
+    // Kill stale agent processes left over from a previous session (e.g. if the
+    // app was force-quit or crashed). sync_managed_agent_processes marks records
+    // whose PID is no longer running, but any PID that’s still alive and not in
+    // our runtimes map is an orphan from a previous launch — kill it now.
+    for record in records.iter_mut() {
+        if record.backend != BackendKind::Local {
+            continue;
+        }
+        let Some(pid) = record.runtime_pid else {
+            continue;
+        };
+        if !runtimes.contains_key(&record.pubkey) {
+            let _ = managed_agents::terminate_process(pid);
+            record.runtime_pid = None;
+            record.last_stopped_at = Some(util::now_iso());
+            record.updated_at = util::now_iso();
+            changed = true;
+        }
+    }
     let pubkeys_to_restore = records
         .iter()
         .filter(|record| record.start_on_app_launch && record.backend == BackendKind::Local)
@@ -297,12 +317,13 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    app.run(|app_handle, event| {
-        if matches!(event, RunEvent::ExitRequested { .. }) {
+    app.run(|app_handle, event| match event {
+        RunEvent::ExitRequested { .. } | RunEvent::Exit => {
             if let Err(error) = shutdown_managed_agents(app_handle) {
                 eprintln!("sprout-desktop: failed to stop managed agents: {error}");
             }
         }
+        _ => {}
     });
 }
 

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -27,7 +27,7 @@ fn process_is_running(_pid: u32) -> bool {
 }
 
 #[cfg(unix)]
-fn terminate_process(pid: u32) -> Result<(), String> {
+pub(crate) fn terminate_process(pid: u32) -> Result<(), String> {
     // The child was spawned with process_group(0), so pid == pgid.
     // Kill the entire process group to avoid orphaning MCP servers
     // and agent subprocesses.
@@ -63,7 +63,7 @@ fn terminate_process(pid: u32) -> Result<(), String> {
 }
 
 #[cfg(not(unix))]
-fn terminate_process(_pid: u32) -> Result<(), String> {
+pub(crate) fn terminate_process(_pid: u32) -> Result<(), String> {
     Err("managed agent shutdown after app restart is only supported on Unix".to_string())
 }
 

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -28,33 +28,35 @@ fn process_is_running(_pid: u32) -> bool {
 
 #[cfg(unix)]
 fn terminate_process(pid: u32) -> Result<(), String> {
-    let pid_arg = pid.to_string();
-    let status = Command::new("kill")
-        .arg("-TERM")
-        .arg(&pid_arg)
-        .status()
-        .map_err(|error| format!("failed to terminate process {pid}: {error}"))?;
-    if !status.success() && process_is_running(pid) {
-        return Err(format!(
-            "failed to terminate process {pid}: signal was rejected"
-        ));
+    // The child was spawned with process_group(0), so pid == pgid.
+    // Kill the entire process group to avoid orphaning MCP servers
+    // and agent subprocesses.
+    let pgid = -(pid as i32);
+
+    // Try graceful shutdown first (SIGTERM to the group).
+    if unsafe { libc::kill(pgid, libc::SIGTERM) } != 0 {
+        // ESRCH means the process is already gone — that's fine.
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::ESRCH) && process_is_running(pid) {
+            return Err(format!("failed to terminate process group {pid}: {err}"));
+        }
+        return Ok(());
     }
 
+    // Wait up to 1s for graceful exit.
     for _ in 0..10 {
         if !process_is_running(pid) {
             return Ok(());
         }
-
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
-    let kill_status = Command::new("kill")
-        .arg("-KILL")
-        .arg(&pid_arg)
-        .status()
-        .map_err(|error| format!("failed to kill process {pid}: {error}"))?;
-    if !kill_status.success() && process_is_running(pid) {
-        return Err(format!("failed to kill process {pid}: signal was rejected"));
+    // Escalate to SIGKILL on the entire group.
+    if unsafe { libc::kill(pgid, libc::SIGKILL) } != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::ESRCH) && process_is_running(pid) {
+            return Err(format!("failed to kill process group {pid}: {err}"));
+        }
     }
 
     Ok(())
@@ -333,6 +335,14 @@ pub fn start_managed_agent_process(
         command.env_remove("SPROUT_API_TOKEN");
     }
 
+    // Spawn the harness in its own process group so we can kill the entire
+    // tree (harness + MCP servers + agent subprocesses) on shutdown.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
     let child = command.spawn().map_err(|error| {
         format!(
             "failed to spawn `{}` for agent {}: {error}",
@@ -376,7 +386,10 @@ pub fn stop_managed_agent_process(
         return Ok(());
     };
 
-    let _ = runtime.child.kill();
+    // Kill the entire process group (harness + MCP servers + agent
+    // subprocesses). The child was spawned with process_group(0), so
+    // its PID == its PGID.
+    terminate_process(runtime.child.id())?;
     let status = runtime
         .child
         .wait()


### PR DESCRIPTION
## Summary
- `sprout-acp` child processes (`sprout-mcp-server`, `goose`, tool subprocesses) were left dangling after the desktop app closed because the harness wasn't spawned in its own process group and only the direct PID was killed
- Now spawns `sprout-acp` with `process_group(0)` so PID == PGID, and `terminate_process()` sends SIGTERM/SIGKILL to the entire process group via `libc::kill(-pgid, ...)` instead of just the single PID
- Matches the existing pattern in `crates/sprout-acp/src/acp.rs` which already does process-group kills for the same reason

## Test plan
- [ ] Start one or more managed agents from the desktop GUI
- [ ] Confirm `sprout-acp`, `sprout-mcp-server`, and agent processes are running (`pgrep -f sprout-acp`)
- [ ] Quit the desktop app
- [ ] Verify **no** orphaned `sprout-acp`, `sprout-mcp-server`, or agent processes remain (`pgrep -f sprout-acp` should return nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)