### PR TITLE
fix(desktop): fast parallel agent shutdown with PID ownership validation

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -28,6 +28,26 @@ fn restore_managed_agents_on_launch(app: &tauri::AppHandle) -> Result<(), String
         .lock()
         .map_err(|error| error.to_string())?;
     let mut changed = sync_managed_agent_processes(&mut records, &mut runtimes);
+
+    // Kill stale agent processes left over from a previous session (e.g. if the
+    // app was force-quit or crashed). sync_managed_agent_processes marks records
+    // whose PID is no longer running, but any PID that’s still alive and not in
+    // our runtimes map is an orphan from a previous launch — kill it now.
+    for record in records.iter_mut() {
+        if record.backend != BackendKind::Local {
+            continue;
+        }
+        let Some(pid) = record.runtime_pid else {
+            continue;
+        };
+        if !runtimes.contains_key(&record.pubkey) {
+            let _ = managed_agents::terminate_process(pid);
+            record.runtime_pid = None;
+            record.last_stopped_at = Some(util::now_iso());
+            record.updated_at = util::now_iso();
+            changed = true;
+        }
+    }
     let pubkeys_to_restore = records
         .iter()
         .filter(|record| record.start_on_app_launch && record.backend == BackendKind::Local)
@@ -297,12 +317,13 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    app.run(|app_handle, event| {
-        if matches!(event, RunEvent::ExitRequested { .. }) {
+    app.run(|app_handle, event| match event {
+        RunEvent::ExitRequested { .. } | RunEvent::Exit => {
             if let Err(error) = shutdown_managed_agents(app_handle) {
                 eprintln!("sprout-desktop: failed to stop managed agents: {error}");
             }
         }
+        _ => {}
     });
 }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -88,8 +88,27 @@ fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), String> {
         .map_err(|error| error.to_string())?;
     let mut changed = sync_managed_agent_processes(&mut records, &mut runtimes);
 
+    // First pass: kill stale processes left from a previous session whose PID
+    // is still alive but not tracked in the current runtimes map.
     for record in records.iter_mut() {
-        // Only stop Local agents — Provider agents are managed externally.
+        if record.backend != BackendKind::Local {
+            continue;
+        }
+        let Some(pid) = record.runtime_pid else {
+            continue;
+        };
+        if !runtimes.contains_key(&record.pubkey) {
+            let _ = managed_agents::terminate_process(pid);
+            record.runtime_pid = None;
+            record.last_stopped_at = Some(util::now_iso());
+            record.updated_at = util::now_iso();
+            changed = true;
+        }
+    }
+
+    // Second pass: gracefully stop all tracked agents. Continue on error so
+    // one stuck agent doesn't prevent the rest from being cleaned up.
+    for record in records.iter_mut() {
         if record.backend != BackendKind::Local {
             continue;
         }
@@ -97,7 +116,12 @@ fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), String> {
             continue;
         }
 
-        stop_managed_agent_process(record, &mut runtimes)?;
+        if let Err(error) = stop_managed_agent_process(record, &mut runtimes) {
+            eprintln!(
+                "sprout-desktop: failed to stop agent {} ({}): {error}",
+                record.name, record.pubkey
+            );
+        }
         changed = true;
     }
 
@@ -317,10 +341,13 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    app.run(|app_handle, event| match event {
+    let shutdown_done = std::sync::atomic::AtomicBool::new(false);
+    app.run(move |app_handle, event| match event {
         RunEvent::ExitRequested { .. } | RunEvent::Exit => {
-            if let Err(error) = shutdown_managed_agents(app_handle) {
-                eprintln!("sprout-desktop: failed to stop managed agents: {error}");
+            if !shutdown_done.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                if let Err(error) = shutdown_managed_agents(app_handle) {
+                    eprintln!("sprout-desktop: failed to stop managed agents: {error}");
+                }
             }
         }
         _ => {}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use app_state::{build_app_state, resolve_persisted_identity, AppState};
 use commands::*;
 use managed_agents::{
     find_managed_agent_mut, load_managed_agents, save_managed_agents, start_managed_agent_process,
-    stop_managed_agent_process, sync_managed_agent_processes, BackendKind,
+    sync_managed_agent_processes, BackendKind, ManagedAgentProcess,
 };
 use tauri::{http, Manager, RunEvent};
 use tauri_plugin_window_state::StateFlags;
@@ -41,7 +41,9 @@ fn restore_managed_agents_on_launch(app: &tauri::AppHandle) -> Result<(), String
             continue;
         };
         if !runtimes.contains_key(&record.pubkey) {
-            let _ = managed_agents::terminate_process(pid);
+            if managed_agents::process_belongs_to_us(pid) {
+                let _ = managed_agents::terminate_process(pid);
+            }
             record.runtime_pid = None;
             record.last_stopped_at = Some(util::now_iso());
             record.updated_at = util::now_iso();
@@ -98,7 +100,9 @@ fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), String> {
             continue;
         };
         if !runtimes.contains_key(&record.pubkey) {
-            let _ = managed_agents::terminate_process(pid);
+            if managed_agents::process_belongs_to_us(pid) {
+                let _ = managed_agents::terminate_process(pid);
+            }
             record.runtime_pid = None;
             record.last_stopped_at = Some(util::now_iso());
             record.updated_at = util::now_iso();
@@ -106,23 +110,97 @@ fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), String> {
         }
     }
 
-    // Second pass: gracefully stop all tracked agents. Continue on error so
-    // one stuck agent doesn't prevent the rest from being cleaned up.
-    for record in records.iter_mut() {
+    // Second pass: stop all tracked agents. Send SIGTERM to all process
+    // groups first, then wait for exits in parallel to avoid serial 1s waits.
+    struct AgentToStop {
+        idx: usize,
+        pid: u32,
+        runtime: Option<ManagedAgentProcess>,
+    }
+
+    let mut to_stop: Vec<AgentToStop> = Vec::new();
+    for (idx, record) in records.iter_mut().enumerate() {
         if record.backend != BackendKind::Local {
             continue;
         }
         if record.runtime_pid.is_none() && !runtimes.contains_key(&record.pubkey) {
             continue;
         }
+        let runtime = runtimes.remove(&record.pubkey);
+        let Some(pid) = runtime
+            .as_ref()
+            .map(|rt| rt.child.id())
+            .or(record.runtime_pid)
+        else {
+            continue;
+        };
+        to_stop.push(AgentToStop { idx, pid, runtime });
+    }
 
-        if let Err(error) = stop_managed_agent_process(record, &mut runtimes) {
-            eprintln!(
-                "sprout-desktop: failed to stop agent {} ({}): {error}",
-                record.name, record.pubkey
-            );
-        }
+    if !to_stop.is_empty() {
         changed = true;
+
+        // Fan-out: send SIGTERM to all process groups at once.
+        #[cfg(unix)]
+        for agent in &to_stop {
+            let pgid = -(agent.pid as i32);
+            unsafe {
+                libc::kill(pgid, libc::SIGTERM);
+            }
+        }
+
+        // Wait up to 2s for all to exit, checking in a polling loop.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if to_stop
+                .iter()
+                .all(|a| !managed_agents::process_is_running(a.pid))
+            {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        // Fan-out: SIGKILL any survivors.
+        #[cfg(unix)]
+        for agent in &to_stop {
+            if managed_agents::process_is_running(agent.pid) {
+                let pgid = -(agent.pid as i32);
+                unsafe {
+                    libc::kill(pgid, libc::SIGKILL);
+                }
+            }
+        }
+
+        // Reap children and update records.
+        for mut agent in to_stop {
+            if let Some(ref mut rt) = agent.runtime {
+                // Best-effort reap — don't block shutdown if the child is stuck
+                // in uninterruptible sleep. The zombie will be cleaned up when
+                // our process exits and launchd reaps it.
+                let _ = rt.child.try_wait();
+                // Write log marker (best-effort).
+                let record = &records[agent.idx];
+                let _ = managed_agents::append_log_marker(
+                    &rt.log_path,
+                    &format!(
+                        "=== stopped {} ({}) at {} ===",
+                        record.name,
+                        record.pubkey,
+                        util::now_iso()
+                    ),
+                );
+            }
+            let record = &mut records[agent.idx];
+            record.runtime_pid = None;
+            record.last_stopped_at = Some(util::now_iso());
+            record.updated_at = util::now_iso();
+            record.last_exit_code = None;
+            record.last_error = None;
+        }
     }
 
     if changed {

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -27,7 +27,7 @@ fn process_is_running(_pid: u32) -> bool {
 }
 
 #[cfg(unix)]
-fn terminate_process(pid: u32) -> Result<(), String> {
+pub(crate) fn terminate_process(pid: u32) -> Result<(), String> {
     // The child was spawned with process_group(0), so pid == pgid.
     // Kill the entire process group to avoid orphaning MCP servers
     // and agent subprocesses.
@@ -63,7 +63,7 @@ fn terminate_process(pid: u32) -> Result<(), String> {
 }
 
 #[cfg(not(unix))]
-fn terminate_process(_pid: u32) -> Result<(), String> {
+pub(crate) fn terminate_process(_pid: u32) -> Result<(), String> {
     Err("managed agent shutdown after app restart is only supported on Unix".to_string())
 }
 

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, process::Command};
+use std::collections::HashMap;
 
 use tauri::AppHandle;
 
@@ -12,17 +12,56 @@ use crate::{
 };
 
 #[cfg(unix)]
-fn process_is_running(pid: u32) -> bool {
-    Command::new("kill")
-        .arg("-0")
-        .arg(pid.to_string())
-        .status()
-        .map(|status| status.success())
+pub(crate) fn process_is_running(pid: u32) -> bool {
+    // Use libc::kill with signal 0 instead of forking a subprocess.
+    // Returns true only if the process exists AND we can signal it.
+    // Returns false for non-existent PIDs (ESRCH) and PIDs owned by
+    // other users (EPERM) — callers should not interact with those.
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn process_is_running(_pid: u32) -> bool {
+    false
+}
+
+/// Check if a PID belongs to a sprout-acp process we spawned (macOS only).
+/// Returns false for recycled PIDs that now belong to other processes.
+#[cfg(target_os = "macos")]
+pub(crate) fn process_belongs_to_us(pid: u32) -> bool {
+    // Use proc_name() from libproc to get the process name without spawning
+    // a subprocess.
+    extern "C" {
+        fn proc_name(pid: libc::c_int, buffer: *mut libc::c_void, buffersize: u32) -> libc::c_int;
+    }
+    let mut buf = [0u8; 1024];
+    let len = unsafe {
+        proc_name(
+            pid as i32,
+            buf.as_mut_ptr() as *mut libc::c_void,
+            buf.len() as u32,
+        )
+    };
+    if len <= 0 {
+        return false;
+    }
+    let name = String::from_utf8_lossy(&buf[..len as usize]);
+    name.contains("sprout-acp") || name.contains("sprout_acp")
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) fn process_belongs_to_us(pid: u32) -> bool {
+    // On Linux, read /proc/<pid>/comm
+    std::fs::read_to_string(format!("/proc/{pid}/comm"))
+        .map(|name| {
+            let name = name.trim();
+            name.contains("sprout-acp") || name.contains("sprout_acp")
+        })
         .unwrap_or(false)
 }
 
 #[cfg(not(unix))]
-fn process_is_running(_pid: u32) -> bool {
+pub(crate) fn process_belongs_to_us(_pid: u32) -> bool {
     false
 }
 

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -28,33 +28,35 @@ fn process_is_running(_pid: u32) -> bool {
 
 #[cfg(unix)]
 fn terminate_process(pid: u32) -> Result<(), String> {
-    let pid_arg = pid.to_string();
-    let status = Command::new("kill")
-        .arg("-TERM")
-        .arg(&pid_arg)
-        .status()
-        .map_err(|error| format!("failed to terminate process {pid}: {error}"))?;
-    if !status.success() && process_is_running(pid) {
-        return Err(format!(
-            "failed to terminate process {pid}: signal was rejected"
-        ));
+    // The child was spawned with process_group(0), so pid == pgid.
+    // Kill the entire process group to avoid orphaning MCP servers
+    // and agent subprocesses.
+    let pgid = -(pid as i32);
+
+    // Try graceful shutdown first (SIGTERM to the group).
+    if unsafe { libc::kill(pgid, libc::SIGTERM) } != 0 {
+        // ESRCH means the process is already gone — that's fine.
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::ESRCH) && process_is_running(pid) {
+            return Err(format!("failed to terminate process group {pid}: {err}"));
+        }
+        return Ok(());
     }
 
+    // Wait up to 1s for graceful exit.
     for _ in 0..10 {
         if !process_is_running(pid) {
             return Ok(());
         }
-
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
-    let kill_status = Command::new("kill")
-        .arg("-KILL")
-        .arg(&pid_arg)
-        .status()
-        .map_err(|error| format!("failed to kill process {pid}: {error}"))?;
-    if !kill_status.success() && process_is_running(pid) {
-        return Err(format!("failed to kill process {pid}: signal was rejected"));
+    // Escalate to SIGKILL on the entire group.
+    if unsafe { libc::kill(pgid, libc::SIGKILL) } != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::ESRCH) && process_is_running(pid) {
+            return Err(format!("failed to kill process group {pid}: {err}"));
+        }
     }
 
     Ok(())
@@ -333,6 +335,14 @@ pub fn start_managed_agent_process(
         command.env_remove("SPROUT_API_TOKEN");
     }
 
+    // Spawn the harness in its own process group so we can kill the entire
+    // tree (harness + MCP servers + agent subprocesses) on shutdown.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
     let child = command.spawn().map_err(|error| {
         format!(
             "failed to spawn `{}` for agent {}: {error}",
@@ -376,7 +386,10 @@ pub fn stop_managed_agent_process(
         return Ok(());
     };
 
-    let _ = runtime.child.kill();
+    // Kill the entire process group (harness + MCP servers + agent
+    // subprocesses). The child was spawned with process_group(0), so
+    // its PID == its PGID.
+    terminate_process(runtime.child.id())?;
     let status = runtime
         .child
         .wait()


### PR DESCRIPTION
## Summary

Fixes painfully slow app close (10+ seconds) and "Operation not permitted" errors during shutdown. Builds on #225 (process group kill).

- **Parallel shutdown**: Instead of stopping agents one-by-one (each waiting up to 1s for SIGTERM), sends SIGTERM to all process groups at once, polls in a single 2s loop, then SIGKILL survivors
- **PID ownership validation**: Uses macOS `proc_name()` to verify a stale PID still belongs to `sprout-acp` before attempting to kill it — prevents "Operation not permitted" on recycled PIDs that now belong to system processes
- **Direct syscall for liveness checks**: Replaces `Command::new("kill").arg("-0")` subprocess spawn with `libc::kill(pid, 0)` — eliminates ~100 fork+exec calls during shutdown
- **Non-blocking reap**: Uses `try_wait()` instead of blocking `wait()` to prevent hangs on children stuck in uninterruptible sleep

### Before
N agents × 1s SIGTERM wait = N+ seconds of serial shutdown, plus "Operation not permitted" errors on stale PIDs

### After  
All agents get SIGTERM simultaneously, single 2s max wait, stale PIDs are skipped instantly

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — 85 tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — clean
- [x] `desktop-build` — passes
- [ ] Manual: start app with multiple agents, Cmd+Q — verify fast close, no orphaned processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)