### PR TITLE
Fix Linux proc name truncation and non-Unix stop path

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -84,10 +84,24 @@ pub(crate) fn process_belongs_to_us(pid: u32) -> bool {
 
 #[cfg(all(unix, not(target_os = "macos")))]
 pub(crate) fn process_belongs_to_us(pid: u32) -> bool {
-    // On Linux, read /proc/<pid>/comm
-    std::fs::read_to_string(format!("/proc/{pid}/comm"))
-        .map(|name| name_matches_known_binary(name.trim()))
-        .unwrap_or(false)
+    // First try /proc/<pid>/comm. Note: comm is truncated to 15 bytes on Linux,
+    // so binaries with names longer than 15 chars (e.g. "claude-agent-acp")
+    // will never match here.
+    if let Ok(name) = std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+        if name_matches_known_binary(name.trim()) {
+            return true;
+        }
+    }
+
+    // Fallback: read /proc/<pid>/exe which is a symlink to the full binary path.
+    // This is not subject to the 15-byte truncation limit.
+    if let Ok(exe_path) = std::fs::read_link(format!("/proc/{pid}/exe")) {
+        if let Some(basename) = exe_path.file_name().and_then(|n| n.to_str()) {
+            return name_matches_known_binary(basename);
+        }
+    }
+
+    false
 }
 
 #[cfg(not(unix))]
@@ -558,7 +572,16 @@ pub fn stop_managed_agent_process(
         return Ok(());
     };
 
+    // On Unix, kill the entire process group via terminate_process.
+    // On non-Unix, fall back to Child::kill() since terminate_process
+    // is not implemented there.
+    #[cfg(unix)]
     terminate_process(runtime.child.id())?;
+    #[cfg(not(unix))]
+    runtime
+        .child
+        .kill()
+        .map_err(|error| format!("failed to kill agent process: {error}"))?;
     let status = runtime
         .child
         .wait()


### PR DESCRIPTION
## Summary
Follow-up to #227 addressing two issues flagged in post-merge review:

- **Linux `/proc/comm` truncation**: `process_belongs_to_us()` only checked `/proc/<pid>/comm` which truncates to 15 bytes on Linux. Binaries with names >15 chars (e.g. `claude-agent-acp`) would never match, causing orphan cleanup to skip them or incorrectly remove their PID receipts. Added `/proc/<pid>/exe` symlink fallback which returns the full binary path.
- **Non-Unix stop path**: `stop_managed_agent_process()` called `terminate_process()` which always returns `Err` on non-Unix. Added `cfg` gate to use `Child::kill()` on non-Unix, restoring the working cross-platform stop behavior.

## Test plan
- [ ] Verify on Linux that agents with long binary names (>15 chars) are correctly identified by `process_belongs_to_us()`
- [ ] Verify on macOS that existing `proc_name()` path still works
- [ ] Verify `cargo check` passes on all targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)