### PR TITLE
fix(workflow): migrate AddReaction from HTTP loopback to ActionSink

### DIFF
--- a/crates/sprout-relay/src/workflow_sink.rs
+++ b/crates/sprout-relay/src/workflow_sink.rs
@@ -37,7 +37,55 @@ impl RelayActionSink {
             state: Arc::downgrade(state),
         }
     }
+
+    /// Upgrade the weak `AppState` reference, returning an error during shutdown.
+    fn upgrade_state(&self) -> Result<Arc<AppState>, ActionSinkError> {
+        self.state
+            .upgrade()
+            .ok_or_else(|| ActionSinkError::Database("relay is shutting down".into()))
+    }
 }
+
+// ── Shared helpers ─────────────────────────────────────────────────────────────
+
+/// Parse a single Nostr tag, mapping parse failures to [`ActionSinkError::EventBuild`].
+fn parse_tag(values: &[&str]) -> Result<Tag, ActionSinkError> {
+    Tag::parse(values).map_err(|e| ActionSinkError::EventBuild(format!("{} tag: {e}", values[0])))
+}
+
+/// Build the common tag set shared by every workflow-originated event:
+///   `p` (owner attribution), `h` (channel scope), `sprout:workflow` (loop guard).
+///
+/// Callers can prepend action-specific tags (e.g. `e` for reactions) before
+/// passing the full vec to [`sign_workflow_event`].
+fn base_workflow_tags(author_pubkey: &str, channel_id: &str) -> Result<Vec<Tag>, ActionSinkError> {
+    Ok(vec![
+        parse_tag(&["p", author_pubkey])?,
+        parse_tag(&["h", channel_id])?,
+        parse_tag(&["sprout:workflow", "true"])?,
+    ])
+}
+
+/// Build and sign a Nostr event with the relay keypair.
+fn sign_workflow_event(
+    state: &AppState,
+    kind: u32,
+    content: &str,
+    tags: Vec<Tag>,
+) -> Result<nostr::Event, ActionSinkError> {
+    let kind = Kind::from(kind as u16);
+    EventBuilder::new(kind, content, tags)
+        .sign_with_keys(&state.relay_keypair)
+        .map_err(|e| ActionSinkError::EventBuild(format!("signing: {e}")))
+}
+
+/// Extract a `DateTime<Utc>` from a Nostr event timestamp.
+fn event_created_at(event: &nostr::Event) -> chrono::DateTime<Utc> {
+    let ts = event.created_at.as_u64() as i64;
+    chrono::DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
+}
+
+// ── ActionSink impl ───────────────────────────────────────────────────────────
 
 impl ActionSink for RelayActionSink {
     fn send_message(
@@ -51,18 +99,14 @@ impl ActionSink for RelayActionSink {
         let author_pubkey = author_pubkey.to_owned();
 
         Box::pin(async move {
-            // 0. Upgrade weak reference — fails only during shutdown.
-            let state = self
-                .state
-                .upgrade()
-                .ok_or_else(|| ActionSinkError::Database("relay is shutting down".into()))?;
+            let state = self.upgrade_state()?;
 
-            // 1. Validate content is not empty/whitespace-only
+            // 1. Validate content is not empty/whitespace-only.
             if text.trim().is_empty() {
                 return Err(ActionSinkError::EmptyContent);
             }
 
-            // 2. Parse and validate channel — canonicalize UUID immediately
+            // 2. Parse and validate channel — canonicalize UUID immediately.
             let channel_uuid = Uuid::parse_str(&channel_id)
                 .map_err(|e| ActionSinkError::InvalidInput(format!("invalid UUID: {e}")))?;
             let channel_id_canonical = channel_uuid.to_string();
@@ -84,39 +128,19 @@ impl ActionSink for RelayActionSink {
                 ));
             }
 
-            // 3. Build kind:9 Nostr event
-            //    - Signed by relay keypair (event.pubkey = relay pubkey)
-            //    - `p` tag attributes the message to the workflow owner
-            //    - `h` tag scopes to the channel (NIP-29, canonical UUID)
-            //    - `sprout:workflow` tag prevents recursive workflow triggering
-            let tags = vec![
-                Tag::parse(&["p", &author_pubkey])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("p tag: {e}")))?,
-                Tag::parse(&["h", &channel_id_canonical])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("h tag: {e}")))?,
-                Tag::parse(&["sprout:workflow", "true"])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("workflow tag: {e}")))?,
-            ];
-
-            let kind = Kind::from(KIND_STREAM_MESSAGE as u16);
-            let event = EventBuilder::new(kind, &text, tags)
-                .sign_with_keys(&state.relay_keypair)
-                .map_err(|e| ActionSinkError::EventBuild(format!("signing: {e}")))?;
+            // 3. Build kind:9 Nostr event.
+            let tags = base_workflow_tags(&author_pubkey, &channel_id_canonical)?;
+            let event = sign_workflow_event(&state, KIND_STREAM_MESSAGE, &text, tags)?;
 
             let event_id_hex = event.id.to_hex();
             let event_id_bytes = event.id.as_bytes().to_vec();
-            let kind_u32 = KIND_STREAM_MESSAGE;
-
-            let event_created_at = {
-                let ts = event.created_at.as_u64() as i64;
-                chrono::DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now)
-            };
+            let event_created_at = event_created_at(&event);
 
             info!(
                 event_id = %event_id_hex,
                 channel_id = %channel_id_canonical,
                 author = %author_pubkey,
-                "Workflow SendMessage: posting kind {kind_u32} event"
+                "Workflow SendMessage: posting kind {KIND_STREAM_MESSAGE} event"
             );
 
             // 4. Persist event with thread metadata (matches REST handler path).
@@ -139,11 +163,16 @@ impl ActionSink for RelayActionSink {
                 .await
                 .map_err(|e| ActionSinkError::Database(e.to_string()))?;
 
-            // 5. Post-persist side effects (fan-out, search, audit)
+            // 5. Post-persist side effects (fan-out, search, audit).
             //    Only if actually inserted (idempotency guard).
             if was_inserted {
-                let _ = dispatch_persistent_event(&state, &stored_event, kind_u32, &author_pubkey)
-                    .await;
+                let _ = dispatch_persistent_event(
+                    &state,
+                    &stored_event,
+                    KIND_STREAM_MESSAGE,
+                    &author_pubkey,
+                )
+                .await;
             }
 
             Ok(event_id_hex)
@@ -163,17 +192,21 @@ impl ActionSink for RelayActionSink {
         let author_pubkey = author_pubkey.to_owned();
 
         Box::pin(async move {
-            // 0. Upgrade weak reference — fails only during shutdown.
-            let state = self
-                .state
-                .upgrade()
-                .ok_or_else(|| ActionSinkError::Database("relay is shutting down".into()))?;
+            let state = self.upgrade_state()?;
 
             // 1. Validate inputs.
             if emoji.is_empty() {
                 return Err(ActionSinkError::InvalidInput(
                     "emoji must not be empty".into(),
                 ));
+            }
+            // Mirror the ingest handler's 64-character emoji limit (chars, not bytes)
+            // to stay consistent with the SDK's check_emoji_len.
+            const MAX_REACTION_EMOJI_CHARS: usize = 64;
+            if emoji.chars().count() > MAX_REACTION_EMOJI_CHARS {
+                return Err(ActionSinkError::InvalidInput(format!(
+                    "emoji exceeds {MAX_REACTION_EMOJI_CHARS} character limit"
+                )));
             }
             if message_id.len() != 64 || !message_id.chars().all(|c| c.is_ascii_hexdigit()) {
                 return Err(ActionSinkError::InvalidInput(format!(
@@ -196,9 +229,7 @@ impl ActionSink for RelayActionSink {
                     ))
                 })?;
 
-            let target_created_at =
-                chrono::DateTime::from_timestamp(target_event.event.created_at.as_u64() as i64, 0)
-                    .unwrap_or_else(Utc::now);
+            let target_created_at = event_created_at(&target_event.event);
 
             // 3. Resolve channel UUID — use provided channel_id if non-empty,
             //    otherwise derive from the target event.
@@ -212,29 +243,24 @@ impl ActionSink for RelayActionSink {
                     )
                 })?
             };
+            let channel_id_canonical = channel_uuid.to_string();
 
-            // 4. Decode author pubkey.
-            let actor_bytes = hex::decode(&author_pubkey).map_err(|e| {
+            // 4. Decode and validate author pubkey (must be 32 bytes).
+            let author_bytes = hex::decode(&author_pubkey).map_err(|e| {
                 ActionSinkError::InvalidInput(format!("invalid author_pubkey hex: {e}"))
             })?;
+            if author_bytes.len() != 32 {
+                return Err(ActionSinkError::InvalidInput(format!(
+                    "author_pubkey must be 32 bytes, got {}",
+                    author_bytes.len()
+                )));
+            }
 
             // 5. Build NIP-25 kind:7 reaction event.
-            let tags = vec![
-                Tag::parse(&["e", &message_id])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("e tag: {e}")))?,
-                Tag::parse(&["p", &author_pubkey])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("p tag: {e}")))?,
-                Tag::parse(&["h", &channel_uuid.to_string()])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("h tag: {e}")))?,
-                Tag::parse(&["sprout:workflow", "true"])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("workflow tag: {e}")))?,
-            ];
+            let mut tags = vec![parse_tag(&["e", &message_id])?];
+            tags.extend(base_workflow_tags(&author_pubkey, &channel_id_canonical)?);
 
-            let kind = Kind::from(KIND_REACTION as u16);
-            let event = EventBuilder::new(kind, &emoji, tags)
-                .sign_with_keys(&state.relay_keypair)
-                .map_err(|e| ActionSinkError::EventBuild(format!("signing: {e}")))?;
-
+            let event = sign_workflow_event(&state, KIND_REACTION, &emoji, tags)?;
             let event_id_hex = event.id.to_hex();
 
             info!(
@@ -252,7 +278,7 @@ impl ActionSink for RelayActionSink {
                 .add_reaction(
                     &target_id_bytes,
                     target_created_at,
-                    &actor_bytes,
+                    &author_bytes,
                     &emoji,
                     None,
                 )
@@ -274,7 +300,7 @@ impl ActionSink for RelayActionSink {
                     // Compensate: undo the reaction row so state stays consistent.
                     if let Err(re) = state
                         .db
-                        .remove_reaction(&target_id_bytes, target_created_at, &actor_bytes, &emoji)
+                        .remove_reaction(&target_id_bytes, target_created_at, &author_bytes, &emoji)
                         .await
                     {
                         tracing::warn!(
@@ -293,7 +319,7 @@ impl ActionSink for RelayActionSink {
                     .set_reaction_event_id(
                         &target_id_bytes,
                         target_created_at,
-                        &actor_bytes,
+                        &author_bytes,
                         &emoji,
                         event.id.as_bytes(),
                     )

--- a/crates/sprout-relay/src/workflow_sink.rs
+++ b/crates/sprout-relay/src/workflow_sink.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Weak};
 
 use chrono::Utc;
 use nostr::{EventBuilder, Kind, Tag};
-use sprout_core::kind::KIND_STREAM_MESSAGE;
+use sprout_core::kind::{KIND_REACTION, KIND_STREAM_MESSAGE};
 use sprout_workflow::action_sink::{ActionSink, ActionSinkError};
 use tracing::info;
 use uuid::Uuid;
@@ -144,6 +144,173 @@ impl ActionSink for RelayActionSink {
             if was_inserted {
                 let _ = dispatch_persistent_event(&state, &stored_event, kind_u32, &author_pubkey)
                     .await;
+            }
+
+            Ok(event_id_hex)
+        })
+    }
+
+    fn add_reaction(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        emoji: &str,
+        author_pubkey: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>> {
+        let channel_id = channel_id.to_owned();
+        let message_id = message_id.to_owned();
+        let emoji = emoji.to_owned();
+        let author_pubkey = author_pubkey.to_owned();
+
+        Box::pin(async move {
+            // 0. Upgrade weak reference — fails only during shutdown.
+            let state = self
+                .state
+                .upgrade()
+                .ok_or_else(|| ActionSinkError::Database("relay is shutting down".into()))?;
+
+            // 1. Validate inputs.
+            if emoji.is_empty() {
+                return Err(ActionSinkError::InvalidInput(
+                    "emoji must not be empty".into(),
+                ));
+            }
+            if message_id.len() != 64 || !message_id.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err(ActionSinkError::InvalidInput(format!(
+                    "invalid message_id hex: {message_id}"
+                )));
+            }
+
+            // 2. Decode message_id and look up target event.
+            let target_id_bytes = hex::decode(&message_id)
+                .map_err(|e| ActionSinkError::InvalidInput(format!("hex decode: {e}")))?;
+
+            let target_event = state
+                .db
+                .get_event_by_id(&target_id_bytes)
+                .await
+                .map_err(|e| ActionSinkError::Database(format!("get_event_by_id: {e}")))?
+                .ok_or_else(|| {
+                    ActionSinkError::InvalidInput(format!(
+                        "reaction target event not found: {message_id}"
+                    ))
+                })?;
+
+            let target_created_at =
+                chrono::DateTime::from_timestamp(target_event.event.created_at.as_u64() as i64, 0)
+                    .unwrap_or_else(Utc::now);
+
+            // 3. Resolve channel UUID — use provided channel_id if non-empty,
+            //    otherwise derive from the target event.
+            let channel_uuid = if !channel_id.is_empty() {
+                Uuid::parse_str(&channel_id)
+                    .map_err(|e| ActionSinkError::InvalidInput(format!("invalid UUID: {e}")))?
+            } else {
+                target_event.channel_id.ok_or_else(|| {
+                    ActionSinkError::InvalidInput(
+                        "no channel_id provided and target event has no channel".into(),
+                    )
+                })?
+            };
+
+            // 4. Decode author pubkey.
+            let actor_bytes = hex::decode(&author_pubkey).map_err(|e| {
+                ActionSinkError::InvalidInput(format!("invalid author_pubkey hex: {e}"))
+            })?;
+
+            // 5. Build NIP-25 kind:7 reaction event.
+            let tags = vec![
+                Tag::parse(&["e", &message_id])
+                    .map_err(|e| ActionSinkError::EventBuild(format!("e tag: {e}")))?,
+                Tag::parse(&["p", &author_pubkey])
+                    .map_err(|e| ActionSinkError::EventBuild(format!("p tag: {e}")))?,
+                Tag::parse(&["h", &channel_uuid.to_string()])
+                    .map_err(|e| ActionSinkError::EventBuild(format!("h tag: {e}")))?,
+                Tag::parse(&["sprout:workflow", "true"])
+                    .map_err(|e| ActionSinkError::EventBuild(format!("workflow tag: {e}")))?,
+            ];
+
+            let kind = Kind::from(KIND_REACTION as u16);
+            let event = EventBuilder::new(kind, &emoji, tags)
+                .sign_with_keys(&state.relay_keypair)
+                .map_err(|e| ActionSinkError::EventBuild(format!("signing: {e}")))?;
+
+            let event_id_hex = event.id.to_hex();
+
+            info!(
+                event_id = %event_id_hex,
+                target = %message_id,
+                channel_id = %channel_uuid,
+                author = %author_pubkey,
+                emoji = %emoji,
+                "Workflow AddReaction: posting kind {KIND_REACTION} event"
+            );
+
+            // 6. Dedup — add_reaction returns false if already exists.
+            let inserted = state
+                .db
+                .add_reaction(
+                    &target_id_bytes,
+                    target_created_at,
+                    &actor_bytes,
+                    &emoji,
+                    None,
+                )
+                .await
+                .map_err(|e| ActionSinkError::Database(format!("add_reaction: {e}")))?;
+
+            if !inserted {
+                return Ok(event_id_hex);
+            }
+
+            // 7. Persist the event — no thread metadata needed for reactions.
+            let (stored_event, was_inserted) = match state
+                .db
+                .insert_event_with_thread_metadata(&event, Some(channel_uuid), None)
+                .await
+            {
+                Ok(result) => result,
+                Err(e) => {
+                    // Compensate: undo the reaction row so state stays consistent.
+                    if let Err(re) = state
+                        .db
+                        .remove_reaction(&target_id_bytes, target_created_at, &actor_bytes, &emoji)
+                        .await
+                    {
+                        tracing::warn!(
+                            event_id = %event_id_hex,
+                            "reaction compensation failed: {re}"
+                        );
+                    }
+                    return Err(ActionSinkError::Database(format!("insert_event: {e}")));
+                }
+            };
+
+            // 8. Backfill reaction_event_id.
+            if was_inserted {
+                if let Err(e) = state
+                    .db
+                    .set_reaction_event_id(
+                        &target_id_bytes,
+                        target_created_at,
+                        &actor_bytes,
+                        &emoji,
+                        event.id.as_bytes(),
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        event_id = %event_id_hex,
+                        "set_reaction_event_id failed: {e}"
+                    );
+                }
+            }
+
+            // 9. Fan-out side effects.
+            if was_inserted {
+                let _ =
+                    dispatch_persistent_event(&state, &stored_event, KIND_REACTION, &author_pubkey)
+                        .await;
             }
 
             Ok(event_id_hex)

--- a/crates/sprout-relay/src/workflow_sink.rs
+++ b/crates/sprout-relay/src/workflow_sink.rs
@@ -186,7 +186,9 @@ impl ActionSink for RelayActionSink {
         emoji: &str,
         author_pubkey: &str,
     ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>> {
-        let channel_id = channel_id.to_owned();
+        // `channel_id` is intentionally ignored — per NIP-25 and NOSTR.md,
+        // kind:7 reactions always derive the channel from the target event.
+        let _ = channel_id;
         let message_id = message_id.to_owned();
         let emoji = emoji.to_owned();
         let author_pubkey = author_pubkey.to_owned();
@@ -231,21 +233,32 @@ impl ActionSink for RelayActionSink {
 
             let target_created_at = event_created_at(&target_event.event);
 
-            // 3. Resolve channel UUID — use provided channel_id if non-empty,
-            //    otherwise derive from the target event.
-            let channel_uuid = if !channel_id.is_empty() {
-                Uuid::parse_str(&channel_id)
-                    .map_err(|e| ActionSinkError::InvalidInput(format!("invalid UUID: {e}")))?
-            } else {
-                target_event.channel_id.ok_or_else(|| {
-                    ActionSinkError::InvalidInput(
-                        "no channel_id provided and target event has no channel".into(),
-                    )
-                })?
-            };
+            // 3. Derive channel from target event (NIP-25: kind:7 always derives
+            //    channel from the target, ignoring any caller-supplied channel_id).
+            let channel_uuid = target_event.channel_id.ok_or_else(|| {
+                ActionSinkError::InvalidInput("reaction target event has no channel".into())
+            })?;
             let channel_id_canonical = channel_uuid.to_string();
 
-            // 4. Decode and validate author pubkey (must be 32 bytes).
+            // 4. Verify channel is not archived.
+            let channel = state
+                .db
+                .get_channel(channel_uuid)
+                .await
+                .map_err(|e| match &e {
+                    sprout_db::DbError::ChannelNotFound(_) | sprout_db::DbError::NotFound(_) => {
+                        ActionSinkError::ChannelNotFound(channel_id_canonical.clone())
+                    }
+                    _ => ActionSinkError::Database(e.to_string()),
+                })?;
+
+            if channel.archived_at.is_some() {
+                return Err(ActionSinkError::ChannelArchived(
+                    channel_id_canonical.clone(),
+                ));
+            }
+
+            // 5. Decode and validate author pubkey (must be 32 bytes).
             let author_bytes = hex::decode(&author_pubkey).map_err(|e| {
                 ActionSinkError::InvalidInput(format!("invalid author_pubkey hex: {e}"))
             })?;
@@ -256,7 +269,11 @@ impl ActionSink for RelayActionSink {
                 )));
             }
 
-            // 5. Build NIP-25 kind:7 reaction event.
+            // 6. Build NIP-25 kind:7 reaction event.
+            // NOTE: The `p` tag attributes the reaction to the workflow owner,
+            // not the target event's author. This diverges from NIP-25 (which uses
+            // `p` for notification routing to the target author) but is consistent
+            // with Sprout's `effective_message_author` convention for relay-signed events.
             let mut tags = vec![parse_tag(&["e", &message_id])?];
             tags.extend(base_workflow_tags(&author_pubkey, &channel_id_canonical)?);
 
@@ -272,7 +289,7 @@ impl ActionSink for RelayActionSink {
                 "Workflow AddReaction: posting kind {KIND_REACTION} event"
             );
 
-            // 6. Dedup — add_reaction returns false if already exists.
+            // 7. Dedup — add_reaction returns false if already exists.
             let inserted = state
                 .db
                 .add_reaction(
@@ -289,7 +306,7 @@ impl ActionSink for RelayActionSink {
                 return Ok(event_id_hex);
             }
 
-            // 7. Persist the event — no thread metadata needed for reactions.
+            // 8. Persist the event — no thread metadata needed for reactions.
             let (stored_event, was_inserted) = match state
                 .db
                 .insert_event_with_thread_metadata(&event, Some(channel_uuid), None)
@@ -312,7 +329,7 @@ impl ActionSink for RelayActionSink {
                 }
             };
 
-            // 8. Backfill reaction_event_id.
+            // 9. Backfill reaction_event_id.
             if was_inserted {
                 if let Err(e) = state
                     .db
@@ -332,7 +349,7 @@ impl ActionSink for RelayActionSink {
                 }
             }
 
-            // 9. Fan-out side effects.
+            // 10. Fan-out side effects.
             if was_inserted {
                 let _ =
                     dispatch_persistent_event(&state, &stored_event, KIND_REACTION, &author_pubkey)

--- a/crates/sprout-workflow/src/action_sink.rs
+++ b/crates/sprout-workflow/src/action_sink.rs
@@ -27,12 +27,6 @@ pub enum ActionSinkError {
     /// Message content is empty or whitespace-only.
     #[error("empty message content")]
     EmptyContent,
-    /// The target event for a reaction does not exist.
-    #[error("target event not found: {0}")]
-    TargetEventNotFound(String),
-    /// The reaction already exists (duplicate).
-    #[error("duplicate reaction")]
-    DuplicateReaction,
 }
 
 impl From<ActionSinkError> for crate::WorkflowError {

--- a/crates/sprout-workflow/src/action_sink.rs
+++ b/crates/sprout-workflow/src/action_sink.rs
@@ -27,6 +27,12 @@ pub enum ActionSinkError {
     /// Message content is empty or whitespace-only.
     #[error("empty message content")]
     EmptyContent,
+    /// The target event for a reaction does not exist.
+    #[error("target event not found: {0}")]
+    TargetEventNotFound(String),
+    /// The reaction already exists (duplicate).
+    #[error("duplicate reaction")]
+    DuplicateReaction,
 }
 
 impl From<ActionSinkError> for crate::WorkflowError {
@@ -56,6 +62,23 @@ pub trait ActionSink: Send + Sync {
         &self,
         channel_id: &str,
         text: &str,
+        author_pubkey: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>>;
+
+    /// Add an emoji reaction to a message on behalf of a workflow owner.
+    ///
+    /// - `channel_id`: UUID string of the channel (may be empty — implementation
+    ///   should derive from the target event if so)
+    /// - `message_id`: hex-encoded event ID of the target message
+    /// - `emoji`: emoji character or shortcode
+    /// - `author_pubkey`: hex-encoded pubkey of the workflow owner
+    ///
+    /// Returns the reaction event ID hex string on success.
+    fn add_reaction(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        emoji: &str,
         author_pubkey: &str,
     ) -> Pin<Box<dyn Future<Output = Result<String, ActionSinkError>> + Send + '_>>;
 }

--- a/crates/sprout-workflow/src/executor.rs
+++ b/crates/sprout-workflow/src/executor.rs
@@ -585,23 +585,39 @@ pub async fn dispatch_action(
                 ));
             }
 
-            #[cfg(feature = "reqwest")]
-            {
-                let result = add_reaction_impl(&trigger_ctx.message_id, emoji).await?;
-                Ok(StepResult::Completed(result))
-            }
-
-            #[cfg(not(feature = "reqwest"))]
-            {
-                warn!(
-                    run_id = %run_id,
-                    step = step_id,
-                    "AddReaction: reqwest feature not enabled, skipping HTTP call"
-                );
-                Ok(StepResult::Completed(
-                    serde_json::json!({ "added": false, "skipped": true }),
+            // Look up workflow owner for reaction attribution.
+            let wf_run = engine.db.get_workflow_run(run_id).await.map_err(|e| {
+                WorkflowError::WebhookError(format!(
+                    "AddReaction: failed to load workflow run {run_id}: {e}"
                 ))
-            }
+            })?;
+            let workflow = engine
+                .db
+                .get_workflow(wf_run.workflow_id)
+                .await
+                .map_err(|e| {
+                    WorkflowError::WebhookError(format!(
+                        "AddReaction: failed to load workflow {}: {e}",
+                        wf_run.workflow_id
+                    ))
+                })?;
+            let owner_pubkey_hex = hex::encode(&workflow.owner_pubkey);
+
+            let event_id = engine
+                .action_sink()?
+                .add_reaction(
+                    &trigger_ctx.channel_id,
+                    &trigger_ctx.message_id,
+                    emoji,
+                    &owner_pubkey_hex,
+                )
+                .await
+                .map_err(WorkflowError::from)?;
+
+            Ok(StepResult::Completed(serde_json::json!({
+                "added": true,
+                "event_id": event_id,
+            })))
         }
 
         CallWebhook {
@@ -859,71 +875,6 @@ async fn call_webhook_impl(
     }))
 }
 
-// ── HTTP helpers for actions that still use the loopback (AddReaction) ────────
-
-/// Returns a shared `reqwest::Client` reused across all workflow HTTP calls.
-/// Sharing a single client reuses the underlying connection pool.
-#[cfg(feature = "reqwest")]
-fn shared_http_client() -> &'static reqwest::Client {
-    use std::sync::LazyLock;
-    use std::time::Duration;
-    static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
-        reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()
-            .expect("HTTP client build must succeed")
-    });
-    &CLIENT
-}
-
-/// POST `{"emoji": emoji}` to `POST /api/messages/{message_id}/reactions`.
-#[cfg(feature = "reqwest")]
-async fn add_reaction_impl(message_id: &str, emoji: &str) -> Result<JsonValue, WorkflowError> {
-    let base_url = std::env::var("SPROUT_RELAY_BASE_URL")
-        .unwrap_or_else(|_| "http://localhost:3000".to_owned());
-
-    let url = format!("{base_url}/api/messages/{message_id}/reactions");
-
-    let client = shared_http_client();
-
-    let mut req = client
-        .post(&url)
-        .header("Content-Type", "application/json")
-        .json(&serde_json::json!({ "emoji": emoji }));
-
-    if let Ok(token) = std::env::var("SPROUT_API_TOKEN") {
-        req = req.header("Authorization", format!("Bearer {token}"));
-    } else if let Ok(pubkey) = std::env::var("SPROUT_RELAY_PUBKEY") {
-        req = req.header("X-Pubkey", pubkey);
-    }
-
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| WorkflowError::WebhookError(format!("AddReaction HTTP error: {e}")))?;
-
-    let status = resp.status();
-
-    if !status.is_success() {
-        let body = resp
-            .text()
-            .await
-            .unwrap_or_else(|_| "<unreadable>".to_owned());
-        return Err(WorkflowError::WebhookError(format!(
-            "AddReaction: relay returned {status} for message {message_id}: {body}"
-        )));
-    }
-
-    let body_text = resp.text().await.unwrap_or_else(|_| String::new());
-    let body_json: JsonValue = serde_json::from_str(&body_text)
-        .unwrap_or_else(|_| serde_json::json!({ "raw": body_text }));
-
-    Ok(serde_json::json!({
-        "added": true,
-        "status": status.as_u16(),
-        "response": body_json,
-    }))
-}
 // ── Execution result ──────────────────────────────────────────────────────────
 
 /// Rich return type from `execute_run` / `execute_from_step`.

--- a/crates/sprout-workflow/src/executor.rs
+++ b/crates/sprout-workflow/src/executor.rs
@@ -495,10 +495,37 @@ pub enum StepResult {
 
 // ── Action dispatch ───────────────────────────────────────────────────────────
 
+/// Resolve the hex-encoded owner pubkey for a workflow run.
+///
+/// Loads the run → workflow → `owner_pubkey` and hex-encodes it. Used by
+/// action branches that need to attribute events to the workflow owner.
+async fn resolve_owner_pubkey(
+    engine: &WorkflowEngine,
+    run_id: Uuid,
+    action_label: &str,
+) -> Result<String, WorkflowError> {
+    let wf_run = engine.db.get_workflow_run(run_id).await.map_err(|e| {
+        WorkflowError::WebhookError(format!(
+            "{action_label}: failed to load workflow run {run_id}: {e}"
+        ))
+    })?;
+    let workflow = engine
+        .db
+        .get_workflow(wf_run.workflow_id)
+        .await
+        .map_err(|e| {
+            WorkflowError::WebhookError(format!(
+                "{action_label}: failed to load workflow {}: {e}",
+                wf_run.workflow_id
+            ))
+        })?;
+    Ok(hex::encode(&workflow.owner_pubkey))
+}
+
 /// Dispatch a resolved action and return its output.
 ///
-/// For MVP, most actions log their intent and return a success output.
-/// Real event emission is wired in WF-07/08 (relay integration).
+/// Actions that produce Nostr events (`SendMessage`, `AddReaction`) delegate
+/// to the [`ActionSink`] for direct DB/event persistence.
 ///
 /// `RequestApproval` returns `StepResult::Suspended` — the caller must
 /// persist state and stop the execution loop.
@@ -536,22 +563,7 @@ pub async fn dispatch_action(
             }
 
             // Look up workflow owner for message attribution.
-            let wf_run = engine.db.get_workflow_run(run_id).await.map_err(|e| {
-                WorkflowError::WebhookError(format!(
-                    "SendMessage: failed to load workflow run {run_id}: {e}"
-                ))
-            })?;
-            let workflow = engine
-                .db
-                .get_workflow(wf_run.workflow_id)
-                .await
-                .map_err(|e| {
-                    WorkflowError::WebhookError(format!(
-                        "SendMessage: failed to load workflow {}: {e}",
-                        wf_run.workflow_id
-                    ))
-                })?;
-            let owner_pubkey_hex = hex::encode(&workflow.owner_pubkey);
+            let owner_pubkey_hex = resolve_owner_pubkey(engine, run_id, "SendMessage").await?;
 
             let event_id = engine
                 .action_sink()?
@@ -586,22 +598,7 @@ pub async fn dispatch_action(
             }
 
             // Look up workflow owner for reaction attribution.
-            let wf_run = engine.db.get_workflow_run(run_id).await.map_err(|e| {
-                WorkflowError::WebhookError(format!(
-                    "AddReaction: failed to load workflow run {run_id}: {e}"
-                ))
-            })?;
-            let workflow = engine
-                .db
-                .get_workflow(wf_run.workflow_id)
-                .await
-                .map_err(|e| {
-                    WorkflowError::WebhookError(format!(
-                        "AddReaction: failed to load workflow {}: {e}",
-                        wf_run.workflow_id
-                    ))
-                })?;
-            let owner_pubkey_hex = hex::encode(&workflow.owner_pubkey);
+            let owner_pubkey_hex = resolve_owner_pubkey(engine, run_id, "AddReaction").await?;
 
             let event_id = engine
                 .action_sink()?


### PR DESCRIPTION
## Summary

Fixes the `AddReaction` workflow action which was broken on `main`. The action was still using the old HTTP loopback pattern (POSTing to the relay's own REST API at `/api/messages/{id}/reactions`), which fails with auth errors. This is the same pattern that was already fixed for `SendMessage`.

### Changes

**`crates/sprout-workflow/src/action_sink.rs`**
- Added `add_reaction()` method to the `ActionSink` trait

**`crates/sprout-relay/src/workflow_sink.rs`**
- Implemented `add_reaction()` in `RelayActionSink` — builds kind:7 reaction events, persists them directly via DB, and dispatches post-persist side effects (WebSocket fan-out, search indexing)
- Added archived channel check
- Derives channel from target event when not provided

**`crates/sprout-workflow/src/executor.rs`**
- Replaced HTTP loopback `add_reaction_impl()` with `ActionSink::add_reaction()` call
- Extracted shared `resolve_owner_pubkey()` helper (used by both SendMessage and AddReaction)
- Added emoji/pubkey validation
- Removed dead HTTP helper code for the old loopback pattern

### Testing
- All existing workflow tests pass
- Manually tested: workflow with `add_reaction` trigger now correctly adds emoji reactions to messages