### PR TITLE
feat: add `just staging` shortcut for desktop app against staging relay

### DIFF
--- a/justfile
+++ b/justfile
@@ -143,6 +143,12 @@ proxy-release:
 dev *ARGS:
     cd {{desktop_dir}} && pnpm tauri dev --config src-tauri/tauri.dev.conf.json {{ARGS}}
 
+# Run the desktop app against the internal staging relay (installs deps + builds agent tools automatically)
+staging *ARGS:
+    cd {{desktop_dir}} && pnpm install
+    cargo build --release -p sprout-acp -p sprout-mcp
+    cd {{desktop_dir}} && SPROUT_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co" pnpm tauri dev {{ARGS}}
+
 # Run the desktop frontend dev server
 desktop-dev:
     cd {{desktop_dir}} && pnpm dev


### PR DESCRIPTION
## What

Adds a `just staging` task that gets someone from clone to running the desktop app against our internal staging relay in one command.

### What it does

1. Installs desktop JS dependencies (`pnpm install`)
2. Builds agent tooling (`sprout-acp` + `sprout-mcp-server`) in release mode
3. Launches the desktop Tauri app with `SPROUT_RELAY_URL` pointed at `wss://sprout-oss.stage.blox.sqprod.co`

Uses the default app identifier (not the dev override) so the user's existing identity key is preserved.

## Usage

```bash
git clone https://github.com/block/sprout.git
cd sprout
. ./bin/activate-hermit
just staging
```

That's it — four commands from zero to running.