### PR TITLE
fix: use dev Tauri config in `just staging` for consistent app data

### DIFF
--- a/justfile
+++ b/justfile
@@ -147,7 +147,7 @@ dev *ARGS:
 staging *ARGS:
     cd {{desktop_dir}} && pnpm install
     cargo build --release -p sprout-acp -p sprout-mcp
-    cd {{desktop_dir}} && SPROUT_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co" pnpm tauri dev {{ARGS}}
+    cd {{desktop_dir}} && SPROUT_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co" pnpm tauri dev --config src-tauri/tauri.dev.conf.json {{ARGS}}
 
 # Run the desktop frontend dev server
 desktop-dev:


### PR DESCRIPTION
`just staging` was missing `--config src-tauri/tauri.dev.conf.json`, causing it to use the production Tauri identifier (`xyz.block.sprout.app`) while `just dev` uses the dev identifier (`xyz.block.sprout.app.dev`). These map to different app data directories on disk, so personas, teams, identity keys, and managed agents created under one command were invisible to the other.

Adding the flag makes `just staging` and `just dev` share the same app data directory, so you can switch between local and staging relay without losing your agent setup.

- Adds `--config src-tauri/tauri.dev.conf.json` to the `just staging` recipe, matching what `just dev` and `just desktop-app` already do