### PR TITLE
Fix unread channel badge state

### DIFF
--- a/crates/sprout-db/src/event.rs
+++ b/crates/sprout-db/src/event.rs
@@ -59,10 +59,6 @@ const CHANNEL_ACTIVITY_KINDS: &[i32] = &[
     KIND_FORUM_COMMENT as i32,
 ];
 
-fn is_channel_activity_kind(kind: i32) -> bool {
-    CHANNEL_ACTIVITY_KINDS.contains(&kind)
-}
-
 /// Extract the `d_tag` value for storage.
 ///
 /// For NIP-33 parameterized replaceable events (kind 30000–39999): returns the first
@@ -829,7 +825,7 @@ mod tests {
     fn channel_activity_kinds_include_readable_timeline_events() {
         for kind in [9, 40001, 40003, 40008, 40099, 45001, 45003] {
             assert!(
-                is_channel_activity_kind(kind),
+                CHANNEL_ACTIVITY_KINDS.contains(&kind),
                 "expected kind {kind} to count toward channel unread state"
             );
         }
@@ -839,7 +835,7 @@ mod tests {
     fn channel_activity_kinds_exclude_discovery_and_admin_events() {
         for kind in [39000, 39001, 39002, 9002, 44100, 46010] {
             assert!(
-                !is_channel_activity_kind(kind),
+                !CHANNEL_ACTIVITY_KINDS.contains(&kind),
                 "expected kind {kind} to be ignored for channel unread state"
             );
         }

--- a/crates/sprout-db/src/event.rs
+++ b/crates/sprout-db/src/event.rs
@@ -9,7 +9,11 @@ use nostr::Event;
 use sqlx::{PgPool, QueryBuilder, Row};
 use uuid::Uuid;
 
-use sprout_core::kind::{event_kind_i32, is_ephemeral, is_parameterized_replaceable, KIND_AUTH};
+use sprout_core::kind::{
+    event_kind_i32, is_ephemeral, is_parameterized_replaceable, KIND_AUTH, KIND_DELETION,
+    KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_REACTION, KIND_STREAM_MESSAGE,
+    KIND_STREAM_MESSAGE_DIFF, KIND_STREAM_MESSAGE_EDIT, KIND_SYSTEM_MESSAGE,
+};
 use sprout_core::StoredEvent;
 
 use crate::error::{DbError, Result};
@@ -42,6 +46,22 @@ pub struct EventQuery {
 /// Maximum length for a `d_tag` value (bytes). NIP-33 d-tags are short identifiers;
 /// anything beyond this is either a bug or abuse.
 pub const D_TAG_MAX_LEN: usize = 1024;
+
+const CHANNEL_ACTIVITY_KINDS: &[i32] = &[
+    KIND_DELETION as i32,
+    KIND_REACTION as i32,
+    KIND_STREAM_MESSAGE as i32,
+    40001, // legacy stream message kind still surfaced in desktop timelines
+    KIND_STREAM_MESSAGE_EDIT as i32,
+    KIND_STREAM_MESSAGE_DIFF as i32,
+    KIND_SYSTEM_MESSAGE as i32,
+    KIND_FORUM_POST as i32,
+    KIND_FORUM_COMMENT as i32,
+];
+
+fn is_channel_activity_kind(kind: i32) -> bool {
+    CHANNEL_ACTIVITY_KINDS.contains(&kind)
+}
 
 /// Extract the `d_tag` value for storage.
 ///
@@ -333,6 +353,34 @@ pub async fn get_last_message_at(
     }
 }
 
+/// Returns the latest unread-relevant activity timestamp for a channel.
+///
+/// This excludes discovery/admin-only events so channel unread markers match
+/// the activity users can actually read in the desktop app.
+pub async fn get_last_channel_activity_at(
+    pool: &PgPool,
+    channel_id: uuid::Uuid,
+) -> Result<Option<DateTime<Utc>>> {
+    let mut qb: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
+        "SELECT created_at FROM events \
+         WHERE channel_id = ",
+    );
+    qb.push_bind(channel_id);
+    qb.push(" AND deleted_at IS NULL AND kind IN (");
+    let mut kind_sep = qb.separated(", ");
+    for kind in CHANNEL_ACTIVITY_KINDS {
+        kind_sep.push_bind(*kind);
+    }
+    qb.push(") ORDER BY created_at DESC LIMIT 1");
+
+    let row = qb.build().fetch_optional(pool).await?;
+
+    match row {
+        Some(r) => Ok(Some(r.try_get("created_at")?)),
+        None => Ok(None),
+    }
+}
+
 /// Bulk-fetch the most recent `created_at` for a set of channel IDs.
 ///
 /// Returns a map of `channel_id → last_message_at`. Channels with no events are omitted.
@@ -352,6 +400,44 @@ pub async fn get_last_message_at_bulk(
     let mut sep = qb.separated(", ");
     for id in channel_ids {
         sep.push_bind(*id);
+    }
+    qb.push(") GROUP BY channel_id");
+
+    let rows = qb.build().fetch_all(pool).await?;
+
+    let mut map = std::collections::HashMap::with_capacity(rows.len());
+    for row in rows {
+        let id: Uuid = row.try_get("channel_id")?;
+        let last_at: DateTime<Utc> = row.try_get("last_at")?;
+        map.insert(id, last_at);
+    }
+    Ok(map)
+}
+
+/// Bulk-fetch the latest unread-relevant activity timestamp for a set of channels.
+///
+/// Returns a map of `channel_id → last_activity_at`. Channels with no
+/// unread-relevant activity are omitted.
+pub async fn get_last_channel_activity_at_bulk(
+    pool: &PgPool,
+    channel_ids: &[uuid::Uuid],
+) -> Result<std::collections::HashMap<uuid::Uuid, DateTime<Utc>>> {
+    if channel_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+
+    let mut qb: QueryBuilder<sqlx::Postgres> = QueryBuilder::new(
+        "SELECT channel_id, MAX(created_at) as last_at FROM events \
+         WHERE deleted_at IS NULL AND kind IN (",
+    );
+    let mut kind_sep = qb.separated(", ");
+    for kind in CHANNEL_ACTIVITY_KINDS {
+        kind_sep.push_bind(*kind);
+    }
+    qb.push(") AND channel_id IN (");
+    let mut channel_sep = qb.separated(", ");
+    for id in channel_ids {
+        channel_sep.push_bind(*id);
     }
     qb.push(") GROUP BY channel_id");
 
@@ -737,5 +823,25 @@ mod tests {
         let result = extract_d_tag(&event).unwrap();
         assert_eq!(result.len(), 2048);
         assert_eq!(result, long_val);
+    }
+
+    #[test]
+    fn channel_activity_kinds_include_readable_timeline_events() {
+        for kind in [9, 40001, 40003, 40008, 40099, 45001, 45003] {
+            assert!(
+                is_channel_activity_kind(kind),
+                "expected kind {kind} to count toward channel unread state"
+            );
+        }
+    }
+
+    #[test]
+    fn channel_activity_kinds_exclude_discovery_and_admin_events() {
+        for kind in [39000, 39001, 39002, 9002, 44100, 46010] {
+            assert!(
+                !is_channel_activity_kind(kind),
+                "expected kind {kind} to be ignored for channel unread state"
+            );
+        }
     }
 }

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -265,6 +265,22 @@ impl Db {
         event::get_last_message_at_bulk(&self.pool, channel_ids).await
     }
 
+    /// Returns the latest unread-relevant activity timestamp for a channel.
+    pub async fn get_last_channel_activity_at(
+        &self,
+        channel_id: Uuid,
+    ) -> Result<Option<DateTime<Utc>>> {
+        event::get_last_channel_activity_at(&self.pool, channel_id).await
+    }
+
+    /// Bulk-fetch the latest unread-relevant activity timestamp for a set of channels.
+    pub async fn get_last_channel_activity_at_bulk(
+        &self,
+        channel_ids: &[Uuid],
+    ) -> Result<std::collections::HashMap<Uuid, DateTime<Utc>>> {
+        event::get_last_channel_activity_at_bulk(&self.pool, channel_ids).await
+    }
+
     /// Batch-fetch non-deleted events by their raw IDs.
     pub async fn get_events_by_ids(&self, ids: &[&[u8]]) -> Result<Vec<StoredEvent>> {
         event::get_events_by_ids(&self.pool, ids).await

--- a/crates/sprout-relay/src/api/channels.rs
+++ b/crates/sprout-relay/src/api/channels.rs
@@ -57,7 +57,7 @@ pub async fn channels_handler(
         .unwrap_or_default();
     let last_messages = state
         .db
-        .get_last_message_at_bulk(&channel_ids)
+        .get_last_channel_activity_at_bulk(&channel_ids)
         .await
         .unwrap_or_default();
 

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -160,6 +160,14 @@ export function AppShell() {
       onLiveMention: refetchHomeFeedOnLiveMention,
     },
   );
+  const unreadSidebarChannelCount = React.useMemo(
+    () =>
+      sidebarChannels.reduce(
+        (count, channel) => count + (unreadChannelIds.has(channel.id) ? 1 : 0),
+        0,
+      ),
+    [sidebarChannels, unreadChannelIds],
+  );
 
   const createChannelMutation = useCreateChannelMutation();
   const createForumMutation = useCreateChannelMutation();
@@ -262,8 +270,8 @@ export function AppShell() {
   }, []);
 
   React.useEffect(() => {
-    void setDesktopAppBadgeCount(homeBadgeCount);
-  }, [homeBadgeCount]);
+    void setDesktopAppBadgeCount(unreadSidebarChannelCount);
+  }, [unreadSidebarChannelCount]);
 
   React.useEffect(() => {
     let isCancelled = false;

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { updateChannelLastMessageAt } from "@/features/channels/lib/channelCache";
 import { channelsQueryKey } from "@/features/channels/hooks";
+import { forumPostsQueryKey } from "@/features/forum/hooks";
 import { mergeTimelineCacheMessages } from "@/features/messages/hooks";
 import { channelMessagesKey } from "@/features/messages/lib/messageQueryKeys";
 import { getChannelIdFromTags } from "@/features/messages/lib/threading";
@@ -15,6 +16,8 @@ export type UseLiveChannelUpdatesOptions = {
 };
 
 const LIVE_MENTION_SUBSCRIPTION_RETRY_MS = 1_000;
+const forumThreadQueryKeyPrefix = (channelId: string) =>
+  ["forum-thread", channelId] as const;
 
 function getMessageTimestamp(event: RelayEvent) {
   return new Date(event.created_at * 1_000).toISOString();
@@ -51,6 +54,18 @@ async function disposeLiveSubscriptions(
   await Promise.allSettled(subscriptions.map((dispose) => dispose()));
 }
 
+function invalidateForumChannelQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  channelId: string,
+) {
+  void queryClient.invalidateQueries({
+    queryKey: forumPostsQueryKey(channelId),
+  });
+  void queryClient.invalidateQueries({
+    queryKey: forumThreadQueryKeyPrefix(channelId),
+  });
+}
+
 export function useLiveChannelUpdates(
   channels: Channel[],
   activeChannelId: string | null,
@@ -60,13 +75,8 @@ export function useLiveChannelUpdates(
   const normalizedCurrentPubkey =
     options.currentPubkey?.trim().toLowerCase() ?? "";
   const seenMentionEventIdsRef = React.useRef(new Set<string>());
-  const liveChannelIds = React.useMemo(
-    () =>
-      new Set(
-        channels
-          .filter((channel) => channel.channelType !== "forum")
-          .map((channel) => channel.id),
-      ),
+  const channelsById = React.useMemo(
+    () => new Map(channels.map((channel) => [channel.id, channel])),
     [channels],
   );
   const mentionChannelIds = React.useMemo(
@@ -74,20 +84,31 @@ export function useLiveChannelUpdates(
     [channels],
   );
 
-  const handleIncomingMessage = React.useEffectEvent((event: RelayEvent) => {
+  const handleIncomingActivity = React.useEffectEvent((event: RelayEvent) => {
     const channelId = getChannelIdFromTags(event.tags);
-    if (!channelId || channelId === activeChannelId) {
+    if (!channelId) {
       return;
     }
 
-    if (!liveChannelIds.has(channelId)) {
+    const channel = channelsById.get(channelId);
+    if (!channel) {
       void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
       return;
     }
 
     const messageTimestamp = getMessageTimestamp(event);
+    const isActiveChannel = channelId === activeChannelId;
 
     updateChannelLastMessageAt(queryClient, channelId, messageTimestamp);
+    if (channel.channelType === "forum") {
+      invalidateForumChannelQueries(queryClient, channelId);
+      return;
+    }
+
+    if (isActiveChannel) {
+      return;
+    }
+
     queryClient.setQueryData<RelayEvent[]>(
       channelMessagesKey(channelId),
       (current) => {
@@ -119,17 +140,13 @@ export function useLiveChannelUpdates(
   }, [queryClient]);
 
   React.useEffect(() => {
-    if (liveChannelIds.size === 0) {
-      return;
-    }
-
     let isDisposed = false;
     let cleanup: (() => Promise<void>) | undefined;
 
     relayClient
-      .subscribeToAllStreamMessages((event) => {
+      .subscribeToUnreadChannelActivity((event) => {
         if (!isDisposed) {
-          handleIncomingMessage(event);
+          handleIncomingActivity(event);
         }
       })
       .then((dispose) => {
@@ -150,7 +167,7 @@ export function useLiveChannelUpdates(
         void cleanup();
       }
     };
-  }, [liveChannelIds]);
+  }, []);
 
   React.useEffect(() => {
     if (

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -6,8 +6,10 @@ import {
 import type { Channel } from "@/shared/api/types";
 
 const CHANNEL_READ_STATE_STORAGE_KEY = "sprout.channel-read-state.v1";
+const LEGACY_CHANNEL_READ_STATE_STORAGE_KEY = CHANNEL_READ_STATE_STORAGE_KEY;
+const CHANNEL_READ_STATE_STORAGE_KEY_V2 = "sprout.channel-read-state.v2";
 
-type ChannelReadState = Record<string, string | null>;
+type ChannelReadState = Record<string, string>;
 type UseUnreadChannelsOptions = UseLiveChannelUpdatesOptions;
 
 function parseTimestamp(value: string | null | undefined) {
@@ -37,12 +39,13 @@ function isNewerTimestamp(
   return currentTimestamp === null || candidateTimestamp > currentTimestamp;
 }
 
-function readStoredChannelReadState(): ChannelReadState {
-  if (typeof window === "undefined") {
-    return {};
-  }
+function channelReadStateStorageKey(pubkey: string) {
+  return `${CHANNEL_READ_STATE_STORAGE_KEY_V2}:${pubkey}`;
+}
 
-  const rawState = window.localStorage.getItem(CHANNEL_READ_STATE_STORAGE_KEY);
+function parseStoredChannelReadState(
+  rawState: string | null,
+): ChannelReadState {
   if (!rawState) {
     return {};
   }
@@ -54,16 +57,86 @@ function readStoredChannelReadState(): ChannelReadState {
     }
 
     return Object.fromEntries(
-      Object.entries(parsed).map(([channelId, value]) => [
-        channelId,
-        typeof value === "string" || value === null
-          ? normalizeTimestamp(value)
-          : null,
-      ]),
+      Object.entries(parsed)
+        .map(([channelId, value]) => [
+          channelId,
+          typeof value === "string" ? normalizeTimestamp(value) : null,
+        ])
+        .filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string",
+        ),
     );
   } catch {
     return {};
   }
+}
+
+function readStoredChannelReadState(pubkey: string): ChannelReadState {
+  if (typeof window === "undefined" || pubkey.length === 0) {
+    return {};
+  }
+
+  const scopedValue = window.localStorage.getItem(
+    channelReadStateStorageKey(pubkey),
+  );
+  if (scopedValue) {
+    return parseStoredChannelReadState(scopedValue);
+  }
+
+  return parseStoredChannelReadState(
+    window.localStorage.getItem(LEGACY_CHANNEL_READ_STATE_STORAGE_KEY),
+  );
+}
+
+function writeStoredChannelReadState(
+  pubkey: string,
+  lastReadByChannel: ChannelReadState,
+) {
+  if (typeof window === "undefined" || pubkey.length === 0) {
+    return;
+  }
+
+  window.localStorage.setItem(
+    channelReadStateStorageKey(pubkey),
+    JSON.stringify(lastReadByChannel),
+  );
+}
+
+function reconcileChannelReadState(
+  current: ChannelReadState,
+  channels: Channel[],
+  initializeUnknownChannels: boolean,
+) {
+  const knownChannelIds = new Set(channels.map((channel) => channel.id));
+  const nextReadState: ChannelReadState = {};
+  let didChange = false;
+
+  for (const channel of channels) {
+    const existingReadAt = current[channel.id];
+    if (typeof existingReadAt === "string") {
+      nextReadState[channel.id] = existingReadAt;
+      continue;
+    }
+
+    if (initializeUnknownChannels) {
+      const initialReadAt = normalizeTimestamp(channel.lastMessageAt);
+      if (typeof initialReadAt === "string") {
+        nextReadState[channel.id] = initialReadAt;
+        didChange = true;
+      }
+    }
+  }
+
+  for (const channelId of Object.keys(current)) {
+    if (!knownChannelIds.has(channelId)) {
+      didChange = true;
+    }
+  }
+
+  return {
+    didChange,
+    nextReadState,
+  };
 }
 
 export function useUnreadChannels(
@@ -72,34 +145,32 @@ export function useUnreadChannels(
   activeReadAt?: string | null,
   options: UseUnreadChannelsOptions = {},
 ) {
+  const normalizedPubkey = options.currentPubkey?.trim().toLowerCase() ?? "";
   const [lastReadByChannel, setLastReadByChannel] =
-    React.useState<ChannelReadState>(readStoredChannelReadState);
+    React.useState<ChannelReadState>(() =>
+      readStoredChannelReadState(normalizedPubkey),
+    );
   const hasInitializedChannelsRef = React.useRef(false);
+  const hydratedPubkeyRef = React.useRef(normalizedPubkey);
   const activeChannelId = activeChannel?.id ?? null;
   const activeChannelLastMessageAt = activeChannel?.lastMessageAt ?? null;
   // Let callers pass `null` to intentionally suppress the optimistic
   // channel-metadata fallback until a real timeline position is known.
   const effectiveActiveReadAt =
     activeReadAt === undefined ? activeChannelLastMessageAt : activeReadAt;
+  const hasHydratedCurrentPubkey =
+    hydratedPubkeyRef.current === normalizedPubkey;
 
   const markChannelRead = React.useCallback(
     (channelId: string, readAt: string | null | undefined) => {
       const normalizedReadAt = normalizeTimestamp(readAt);
 
       setLastReadByChannel((current) => {
-        const previousReadAt = current[channelId] ?? null;
-
         if (normalizedReadAt === null) {
-          if (channelId in current) {
-            return current;
-          }
-
-          return {
-            ...current,
-            [channelId]: null,
-          };
+          return current;
         }
 
+        const previousReadAt = current[channelId];
         if (!isNewerTimestamp(normalizedReadAt, previousReadAt)) {
           return current;
         }
@@ -114,15 +185,31 @@ export function useUnreadChannels(
   );
 
   React.useEffect(() => {
-    if (typeof window === "undefined") {
+    // Identity loads asynchronously on app startup. Skip persistence until
+    // we've rehydrated the current user's stored state, otherwise we can
+    // overwrite it with pre-hydration defaults from a previous render.
+    if (!hasHydratedCurrentPubkey) {
       return;
     }
 
-    window.localStorage.setItem(
-      CHANNEL_READ_STATE_STORAGE_KEY,
-      JSON.stringify(lastReadByChannel),
-    );
-  }, [lastReadByChannel]);
+    writeStoredChannelReadState(normalizedPubkey, lastReadByChannel);
+  }, [hasHydratedCurrentPubkey, lastReadByChannel, normalizedPubkey]);
+
+  React.useEffect(() => {
+    if (hydratedPubkeyRef.current === normalizedPubkey) {
+      return;
+    }
+
+    hydratedPubkeyRef.current = normalizedPubkey;
+
+    const storedState = readStoredChannelReadState(normalizedPubkey);
+    const nextReadState =
+      channels.length > 0
+        ? reconcileChannelReadState(storedState, channels, true).nextReadState
+        : storedState;
+    hasInitializedChannelsRef.current = channels.length > 0;
+    setLastReadByChannel(nextReadState);
+  }, [channels, normalizedPubkey]);
 
   React.useEffect(() => {
     if (channels.length === 0) {
@@ -130,28 +217,11 @@ export function useUnreadChannels(
     }
 
     setLastReadByChannel((current) => {
-      const knownChannelIds = new Set(channels.map((channel) => channel.id));
-      const nextReadState: ChannelReadState = {};
-      let didChange = false;
-
-      for (const channel of channels) {
-        if (channel.id in current) {
-          nextReadState[channel.id] = current[channel.id] ?? null;
-          continue;
-        }
-
-        nextReadState[channel.id] = hasInitializedChannelsRef.current
-          ? null
-          : normalizeTimestamp(channel.lastMessageAt);
-        didChange = true;
-      }
-
-      for (const channelId of Object.keys(current)) {
-        if (!knownChannelIds.has(channelId)) {
-          didChange = true;
-        }
-      }
-
+      const { didChange, nextReadState } = reconcileChannelReadState(
+        current,
+        channels,
+        !hasInitializedChannelsRef.current,
+      );
       return didChange ? nextReadState : current;
     });
 

--- a/desktop/src/features/settings/ui/NotificationSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/NotificationSettingsCard.tsx
@@ -194,8 +194,9 @@ export function NotificationSettingsCard({
       ) : null}
 
       <p className="mt-4 text-sm text-muted-foreground">
-        The Home badge is an in-app signal. Desktop alerts only fire for new
-        feed items after you enable them.
+        The Home badge is an in-app signal. The app icon badge follows unread
+        channels, and desktop alerts only fire for new feed items after you
+        enable them.
       </p>
     </section>
   );

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -8,6 +8,7 @@ import {
 import type { PresenceStatus, RelayEvent } from "@/shared/api/types";
 import {
   CHANNEL_EVENT_KINDS,
+  CHANNEL_UNREAD_EVENT_KINDS,
   HOME_MENTION_EVENT_KINDS,
   KIND_STREAM_MESSAGE,
   KIND_TYPING_INDICATOR,
@@ -171,8 +172,8 @@ export class RelayClient {
     );
   }
 
-  async subscribeToAllStreamMessages(onEvent: (event: RelayEvent) => void) {
-    return this.subscribe(this.buildGlobalStreamFilter(50), onEvent);
+  async subscribeToUnreadChannelActivity(onEvent: (event: RelayEvent) => void) {
+    return this.subscribe(this.buildUnreadChannelActivityFilter(50), onEvent);
   }
 
   async subscribeToChannelMentionEvents(
@@ -280,9 +281,11 @@ export class RelayClient {
     return filter;
   }
 
-  private buildGlobalStreamFilter(limit: number): RelaySubscriptionFilter {
+  private buildUnreadChannelActivityFilter(
+    limit: number,
+  ): RelaySubscriptionFilter {
     return {
-      kinds: [...CHANNEL_EVENT_KINDS],
+      kinds: [...CHANNEL_UNREAD_EVENT_KINDS],
       limit,
     };
   }

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -26,3 +26,10 @@ export const CHANNEL_EVENT_KINDS = [
   KIND_STREAM_MESSAGE_DIFF, // 40008 — message diffs
   KIND_SYSTEM_MESSAGE, // 40099 — system messages (join, leave, etc.)
 ] as const;
+
+// Keep this in sync with the unread-activity query in sprout-db.
+export const CHANNEL_UNREAD_EVENT_KINDS = [
+  ...CHANNEL_EVENT_KINDS,
+  KIND_FORUM_POST,
+  KIND_FORUM_COMMENT,
+] as const;

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -366,9 +366,13 @@ declare global {
     __SPROUT_E2E__?: E2eConfig;
     __SPROUT_E2E_COMMANDS__?: string[];
     __SPROUT_E2E_WEBVIEW_ZOOM__?: number;
+    __SPROUT_E2E_HAS_MOCK_SUBSCRIPTION__?: (input?: {
+      channelName?: string;
+    }) => boolean;
     __SPROUT_E2E_EMIT_MOCK_MESSAGE__?: (input: {
       channelName: string;
       content: string;
+      kind?: number;
       pubkey?: string;
     }) => RelayEvent;
     __SPROUT_E2E_EMIT_MOCK_TYPING__?: (input: {
@@ -1588,11 +1592,33 @@ function emitMockChannelMessage(
   channelId: string,
   content: string,
   pubkey?: string,
+  kind = 9,
 ) {
-  const event = createMockEvent(9, content, [["h", channelId]], pubkey);
+  const event = createMockEvent(kind, content, [["h", channelId]], pubkey);
   recordMockMessage(channelId, event);
   emitMockLiveEvent(channelId, event);
   return event;
+}
+
+function hasMockSubscription(channelName?: string) {
+  const subscribedChannelId =
+    typeof channelName === "string"
+      ? mockChannels.find((channel) => channel.name === channelName)?.id
+      : GLOBAL_MOCK_SUBSCRIPTION;
+
+  if (!subscribedChannelId) {
+    return false;
+  }
+
+  for (const socket of mockSockets.values()) {
+    for (const candidateChannelId of socket.subscriptions.values()) {
+      if (candidateChannelId === subscribedChannelId) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 function emitMockTypingIndicator(channelId: string, pubkey: string) {
@@ -3681,9 +3707,12 @@ export function maybeInstallE2eTauriMocks() {
   mockWindows("main");
   window.__SPROUT_E2E_COMMANDS__ = [];
   window.__SPROUT_E2E_WEBVIEW_ZOOM__ = 1;
+  window.__SPROUT_E2E_HAS_MOCK_SUBSCRIPTION__ = ({ channelName } = {}) =>
+    hasMockSubscription(channelName);
   window.__SPROUT_E2E_EMIT_MOCK_MESSAGE__ = ({
     channelName,
     content,
+    kind,
     pubkey,
   }) => {
     const channel = mockChannels.find(
@@ -3693,7 +3722,7 @@ export function maybeInstallE2eTauriMocks() {
       throw new Error(`Mock channel ${channelName} not found.`);
     }
 
-    return emitMockChannelMessage(channel.id, content, pubkey);
+    return emitMockChannelMessage(channel.id, content, pubkey, kind);
   };
   window.__SPROUT_E2E_EMIT_MOCK_TYPING__ = ({ channelName, pubkey }) => {
     const channel = mockChannels.find(

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1,8 +1,13 @@
 import { expect, test } from "@playwright/test";
 
-import { TEST_IDENTITIES, installMockBridge } from "../helpers/bridge";
+import {
+  TEST_IDENTITIES,
+  installMockBridge,
+  waitForMockSubscription,
+} from "../helpers/bridge";
 
 const MOCK_IDENTITY_PUBKEY = "deadbeef".repeat(8);
+const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
 
 async function openChannelManagement(
   page: import("@playwright/test").Page,
@@ -27,6 +32,16 @@ async function openMembersSidebar(
   await expect(page.getByTestId("chat-title")).toHaveText(channelName);
   await page.getByTestId("channel-members-trigger").click();
   await expect(page.getByTestId("members-sidebar")).toBeVisible();
+}
+
+async function getAppBadgeCount(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const win = window as Window & {
+      __SPROUT_E2E_APP_BADGE_COUNT__?: number;
+    };
+
+    return win.__SPROUT_E2E_APP_BADGE_COUNT__ ?? 0;
+  });
 }
 
 test.beforeEach(async ({ page }) => {
@@ -235,16 +250,23 @@ test("sidebar shows unread indicator for newly active channels", async ({
 }) => {
   await page.goto("/");
 
+  await expect(page.getByTestId("channel-random")).toBeVisible();
   await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
+  await waitForMockSubscription(page);
+  const initialAppBadgeCount = await getAppBadgeCount(page);
 
-  await page.evaluate(() => {
+  await page.evaluate((pubkey) => {
     window.__SPROUT_E2E_EMIT_MOCK_MESSAGE__?.({
       channelName: "random",
       content: "Unread update for #random",
+      pubkey,
     });
-  });
+  }, TEST_IDENTITIES.alice.pubkey);
 
   await expect(page.getByTestId("channel-unread-random")).toBeVisible();
+  await expect
+    .poll(() => getAppBadgeCount(page))
+    .toBe(initialAppBadgeCount + 1);
 
   await page.getByTestId("channel-random").click();
   await expect(page.getByTestId("chat-title")).toHaveText("random");
@@ -252,12 +274,73 @@ test("sidebar shows unread indicator for newly active channels", async ({
     "Unread update for #random",
   );
   await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
+  await expect.poll(() => getAppBadgeCount(page)).toBe(initialAppBadgeCount);
+});
+
+test("sidebar restores stored unread state after reopening", async ({
+  page,
+}) => {
+  const seededReadAt = new Date(
+    Date.now() - 24 * 60 * 60 * 1_000,
+  ).toISOString();
+
+  await page.goto("/");
+  await page.evaluate(
+    ({ channelId, pubkey, readAt }) => {
+      window.localStorage.setItem(
+        `sprout.channel-read-state.v2:${pubkey}`,
+        JSON.stringify({ [channelId]: readAt }),
+      );
+    },
+    {
+      channelId: GENERAL_CHANNEL_ID,
+      pubkey: MOCK_IDENTITY_PUBKEY,
+      readAt: seededReadAt,
+    },
+  );
+  await page.reload();
+
+  await expect(page.getByTestId("channel-general")).toBeVisible();
+  await expect(page.getByTestId("channel-unread-general")).toBeVisible();
+  await expect.poll(() => getAppBadgeCount(page)).toBe(1);
+});
+
+test("sidebar shows unread indicator for newly active forums", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await expect(page.getByTestId("channel-watercooler")).toBeVisible();
+  await expect(page.getByTestId("channel-unread-watercooler")).toHaveCount(0);
+  await waitForMockSubscription(page);
+  const initialAppBadgeCount = await getAppBadgeCount(page);
+
+  await page.evaluate((pubkey) => {
+    window.__SPROUT_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "watercooler",
+      content: "Unread forum post",
+      kind: 45001,
+      pubkey,
+    });
+  }, TEST_IDENTITIES.alice.pubkey);
+
+  await expect(page.getByTestId("channel-unread-watercooler")).toBeVisible();
+  await expect
+    .poll(() => getAppBadgeCount(page))
+    .toBe(initialAppBadgeCount + 1);
+
+  await page.getByTestId("channel-watercooler").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("watercooler");
+  await expect(page.getByText("Unread forum post")).toBeVisible();
+  await expect(page.getByTestId("channel-unread-watercooler")).toHaveCount(0);
+  await expect.poll(() => getAppBadgeCount(page)).toBe(initialAppBadgeCount);
 });
 
 test("sidebar clears unread indicator after opening a DM", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByTestId("channel-unread-alice-tyler")).toHaveCount(0);
+  await waitForMockSubscription(page);
 
   await page.evaluate((pubkey) => {
     window.__SPROUT_E2E_EMIT_MOCK_MESSAGE__?.({

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -69,19 +69,8 @@ test("updates presence from the profile menu", async ({ page }) => {
 test("notification settings drive the Home badge and desktop alerts", async ({
   page,
 }) => {
-  async function getAppBadgeCount() {
-    return page.evaluate(() => {
-      const win = window as Window & {
-        __SPROUT_E2E_APP_BADGE_COUNT__?: number;
-      };
-
-      return win.__SPROUT_E2E_APP_BADGE_COUNT__ ?? 0;
-    });
-  }
-
   await page.goto("/");
   await expect(page.getByTestId("sidebar-home-count")).toHaveCount(0);
-  await expect.poll(getAppBadgeCount).toBe(0);
 
   await openSettings(page, "notifications");
   await expect(page.getByTestId("settings-notifications")).toBeVisible();
@@ -133,7 +122,6 @@ test("notification settings drive the Home badge and desktop alerts", async ({
   });
 
   await expect(page.getByTestId("sidebar-home-count")).toHaveText("1");
-  await expect.poll(getAppBadgeCount).toBe(1);
 
   await expect
     .poll(() =>
@@ -187,18 +175,15 @@ test("notification settings drive the Home badge and desktop alerts", async ({
   await page.getByTestId("settings-close").click();
   await expect(page.getByTestId("chat-title")).toHaveText("engineering");
   await expect(page.getByTestId("sidebar-home-count")).toHaveCount(0);
-  await expect.poll(getAppBadgeCount).toBe(0);
 
   await openSettings(page, "notifications");
   await page.getByTestId("notifications-home-badge-toggle").click();
   await page.getByTestId("settings-close").click();
   await expect(page.getByTestId("sidebar-home-count")).toHaveText("1");
-  await expect.poll(getAppBadgeCount).toBe(1);
 
   await page.getByRole("button", { name: "Home" }).click();
   await expect(page.getByTestId("chat-title")).toHaveText("Home");
   await expect(page.getByTestId("sidebar-home-count")).toHaveCount(0);
-  await expect.poll(getAppBadgeCount).toBe(0);
 });
 
 test("desktop notification clicks open the matching forum thread", async ({
@@ -280,6 +265,7 @@ test("opens settings with the keyboard shortcut and updates theme", async ({
   page,
 }) => {
   await page.goto("/");
+  await expect(page.getByTestId("open-settings")).toBeVisible();
 
   await page.keyboard.press(
     process.platform === "darwin" ? "Meta+," : "Control+,",
@@ -347,6 +333,7 @@ test("opens settings with the keyboard shortcut and updates theme", async ({
 
 test("supports webview zoom keyboard shortcuts", async ({ page }) => {
   await page.goto("/");
+  await expect(page.getByTestId("open-settings")).toBeVisible();
 
   await page.keyboard.press(
     process.platform === "darwin" ? "Meta+Shift+Equal" : "Control+Shift+Equal",

--- a/desktop/tests/e2e/smoke.spec.ts
+++ b/desktop/tests/e2e/smoke.spec.ts
@@ -171,6 +171,7 @@ test("search results use your resolved profile label instead of You", async ({
 }) => {
   await page.goto("/");
 
+  await expect(page.getByTestId("open-search")).toBeVisible();
   await page.keyboard.press(
     process.platform === "darwin" ? "Meta+K" : "Control+K",
   );
@@ -189,6 +190,7 @@ test("opens accessible unjoined channels from search in read-only mode", async (
 }) => {
   await page.goto("/");
 
+  await expect(page.getByTestId("open-search")).toBeVisible();
   await page.keyboard.press(
     process.platform === "darwin" ? "Meta+K" : "Control+K",
   );

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -156,3 +156,22 @@ export async function installRelayBridge(
 ) {
   await installBridge(page, { mode: "relay", user });
 }
+
+export async function waitForMockSubscription(
+  page: Page,
+  channelName?: string,
+) {
+  await page.waitForFunction((targetChannelName) => {
+    const testWindow = window as Window & {
+      __SPROUT_E2E_HAS_MOCK_SUBSCRIPTION__?: (input?: {
+        channelName?: string;
+      }) => boolean;
+    };
+
+    return (
+      testWindow.__SPROUT_E2E_HAS_MOCK_SUBSCRIPTION__?.({
+        channelName: targetChannelName ?? undefined,
+      }) ?? false
+    );
+  }, channelName ?? null);
+}


### PR DESCRIPTION
## Summary
- fix unread channel persistence so read state is rehydrated per user without being overwritten on channel refresh or reopen
- make channel unread activity and the app icon badge follow unread/read state instead of unrelated home-feed counts or non-readable channel events
- stabilize relay-backed and smoke unread coverage, including reopen persistence and shortcut timing in related desktop integration tests

## Verification
- `cargo test -p sprout-db channel_activity_kinds`
- `cd desktop && pnpm check`
- `cd desktop && pnpm build`
- `cd desktop && pnpm exec playwright test --project=smoke`
- `cd desktop && pnpm exec playwright test --project=integration`
- pre-push hook passed: rust fmt, desktop check, desktop tauri check, rust clippy, unit tests, desktop build