### PR TITLE
[codex] Show recent notes in user popovers

### DIFF
--- a/desktop/src-tauri/src/commands/profile.rs
+++ b/desktop/src-tauri/src/commands/profile.rs
@@ -8,8 +8,8 @@ use crate::{
     app_state::AppState,
     events,
     models::{
-        GetUsersBatchBody, ProfileInfo, SearchUsersResponse, SetPresenceBody, SetPresenceResponse,
-        UsersBatchResponse,
+        GetUserNotesQuery, GetUsersBatchBody, ProfileInfo, SearchUsersResponse, SetPresenceBody,
+        SetPresenceResponse, UserNotesResponse, UsersBatchResponse,
     },
     relay::{build_authed_request, send_json_request, submit_event},
 };
@@ -99,6 +99,26 @@ pub async fn get_users_batch(
                 pubkeys: pubkeys.as_slice(),
             },
         );
+    send_json_request(request).await
+}
+
+#[tauri::command]
+pub async fn get_user_notes(
+    pubkey: String,
+    limit: Option<u32>,
+    before: Option<i64>,
+    before_id: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<UserNotesResponse, String> {
+    let path = format!("/api/users/{pubkey}/notes");
+    let request = build_authed_request(&state.http_client, Method::GET, &path, &state)?.query(
+        &GetUserNotesQuery {
+            limit,
+            before,
+            before_id: before_id.as_deref(),
+        },
+    );
+
     send_json_request(request).await
 }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -347,6 +347,7 @@ pub fn run() {
             update_profile,
             get_user_profile,
             get_users_batch,
+            get_user_notes,
             search_users,
             get_presence,
             set_presence,

--- a/desktop/src-tauri/src/models.rs
+++ b/desktop/src-tauri/src/models.rs
@@ -46,6 +46,26 @@ pub struct SearchUsersResponse {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct UserNoteInfo {
+    pub id: String,
+    pub pubkey: String,
+    pub created_at: i64,
+    pub content: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserNotesCursor {
+    pub before: i64,
+    pub before_id: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserNotesResponse {
+    pub notes: Vec<UserNoteInfo>,
+    pub next_cursor: Option<UserNotesCursor>,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct SetPresenceResponse {
     pub status: PresenceStatus,
     pub ttl_seconds: u64,
@@ -257,6 +277,16 @@ pub struct SendChannelMessageResponse {
 #[derive(Serialize)]
 pub struct GetUsersBatchBody<'a> {
     pub pubkeys: &'a [String],
+}
+
+#[derive(Serialize)]
+pub struct GetUserNotesQuery<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_id: Option<&'a str>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { getUserNotes } from "@/shared/api/social";
 import {
   getProfile,
   searchUsers,
@@ -11,6 +12,7 @@ import {
 import type {
   Profile,
   UpdateProfileInput,
+  UserNotesResponse,
   UserSearchResult,
   UsersBatchResponse,
 } from "@/shared/api/types";
@@ -71,6 +73,25 @@ export function useUsersBatchQuery(
   }, [query.data, queryClient]);
 
   return query;
+}
+
+export function useUserNotesQuery(
+  pubkey?: string,
+  options?: {
+    enabled?: boolean;
+    limit?: number;
+  },
+) {
+  const resolvedPubkey = typeof pubkey === "string" ? pubkey : "";
+  const enabled = (options?.enabled ?? true) && resolvedPubkey.length > 0;
+
+  return useQuery<UserNotesResponse>({
+    enabled,
+    queryKey: ["user-notes", resolvedPubkey.toLowerCase(), options?.limit ?? 3],
+    queryFn: () => getUserNotes(resolvedPubkey, { limit: options?.limit ?? 3 }),
+    staleTime: 60_000,
+    gcTime: 5 * 60 * 1_000,
+  });
 }
 
 export function useUserSearchQuery(

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -1,9 +1,14 @@
 import * as React from "react";
 
-import { useUserProfileQuery } from "@/features/profile/hooks";
-import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import {
+  useUserNotesQuery,
+  useUserProfileQuery,
+} from "@/features/profile/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import { PresenceBadge } from "@/features/presence/ui/PresenceBadge";
+import { formatRelativeTime } from "@/features/forum/lib/time";
+import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import { Markdown } from "@/shared/ui/markdown";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 
 type UserProfilePopoverProps = {
@@ -25,17 +30,21 @@ export function UserProfilePopover({
 }: UserProfilePopoverProps) {
   const [open, setOpen] = React.useState(false);
   const profileQuery = useUserProfileQuery(open ? pubkey : undefined);
+  const notesQuery = useUserNotesQuery(open ? pubkey : undefined, {
+    limit: 3,
+  });
   const presenceQuery = usePresenceQuery(open ? [pubkey] : [], {
     enabled: open,
   });
 
   const profile = profileQuery.data;
+  const notes = notesQuery.data?.notes ?? [];
   const presenceStatus = presenceQuery.data?.[pubkey.toLowerCase()];
 
   return (
     <Popover onOpenChange={setOpen} open={open}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent align="start" className="w-72" side="top" sideOffset={8}>
+      <PopoverContent align="start" className="w-80" side="top" sideOffset={8}>
         <div className="flex flex-col gap-3">
           <div className="flex items-start gap-3">
             {profile?.avatarUrl ? (
@@ -76,6 +85,50 @@ export function UserProfilePopover({
           <p className="truncate font-mono text-[10px] text-muted-foreground/60">
             {truncatePubkey(pubkey)}
           </p>
+
+          {notesQuery.isLoading ? (
+            <div
+              className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground"
+              data-testid="user-profile-notes-loading"
+            >
+              Loading recent notes…
+            </div>
+          ) : null}
+
+          {!notesQuery.isLoading && notes.length > 0 ? (
+            <div
+              className="border-t border-border/60 pt-3"
+              data-testid="user-profile-notes"
+            >
+              <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Recent Notes
+              </p>
+              <div className="space-y-2">
+                {notes.map((note) => (
+                  <article
+                    className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2"
+                    data-testid="user-profile-note"
+                    key={note.id}
+                  >
+                    <p className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground/80">
+                      {formatRelativeTime(note.createdAt)}
+                    </p>
+                    <Markdown
+                      className="max-w-none text-xs text-foreground"
+                      content={note.content}
+                      tight
+                    />
+                  </article>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {notesQuery.isError ? (
+            <p className="text-xs text-muted-foreground">
+              Recent notes are unavailable right now.
+            </p>
+          ) : null}
         </div>
       </PopoverContent>
     </Popover>

--- a/desktop/src/shared/api/social.ts
+++ b/desktop/src/shared/api/social.ts
@@ -1,0 +1,55 @@
+import type { UserNote, UserNotesResponse } from "@/shared/api/socialTypes";
+
+import { invokeTauri } from "./tauri";
+
+type RawUserNote = {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  content: string;
+};
+
+type RawUserNotesCursor = {
+  before: number;
+  before_id: string;
+};
+
+type RawUserNotesResponse = {
+  notes: RawUserNote[];
+  next_cursor: RawUserNotesCursor | null;
+};
+
+function fromRawUserNote(note: RawUserNote): UserNote {
+  return {
+    id: note.id,
+    pubkey: note.pubkey,
+    createdAt: note.created_at,
+    content: note.content,
+  };
+}
+
+export async function getUserNotes(
+  pubkey: string,
+  options?: {
+    limit?: number;
+    before?: number;
+    beforeId?: string;
+  },
+): Promise<UserNotesResponse> {
+  const response = await invokeTauri<RawUserNotesResponse>("get_user_notes", {
+    pubkey,
+    limit: options?.limit ?? null,
+    before: options?.before ?? null,
+    beforeId: options?.beforeId ?? null,
+  });
+
+  return {
+    notes: response.notes.map(fromRawUserNote),
+    nextCursor: response.next_cursor
+      ? {
+          before: response.next_cursor.before,
+          beforeId: response.next_cursor.before_id,
+        }
+      : null,
+  };
+}

--- a/desktop/src/shared/api/socialTypes.ts
+++ b/desktop/src/shared/api/socialTypes.ts
@@ -1,0 +1,16 @@
+export type UserNote = {
+  id: string;
+  pubkey: string;
+  createdAt: number;
+  content: string;
+};
+
+export type UserNotesCursor = {
+  before: number;
+  beforeId: string;
+};
+
+export type UserNotesResponse = {
+  notes: UserNote[];
+  nextCursor: UserNotesCursor | null;
+};

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -389,8 +389,6 @@ export type ManagedAgentPrereqs = {
   mcp: CommandAvailability;
 };
 
-// ── Model discovery types ─────────────────────────────────────────────────────
-
 export type AgentModelsResponse = {
   agentName: string;
   agentVersion: string;
@@ -399,19 +397,16 @@ export type AgentModelsResponse = {
   selectedModel: string | null;
   supportsSwitching: boolean;
 };
-
 export type AgentModelInfo = {
   id: string;
   name: string | null;
   description: string | null;
 };
-
 export type UpdateManagedAgentInput = {
   pubkey: string;
   model?: string | null;
   systemPrompt?: string | null;
 };
-
 export type AgentPersona = {
   id: string;
   displayName: string;
@@ -442,9 +437,6 @@ export type UpdatePersonaInput = {
   provider?: string;
   model?: string;
 };
-
-// ── Team types ────────────────────────────────────────────────────────────────
-
 export type AgentTeam = {
   id: string;
   name: string;
@@ -466,8 +458,6 @@ export type UpdateTeamInput = {
   description?: string;
   personaIds: string[];
 };
-
-// ── Workflow types (re-exported from workflowTypes.ts) ────────────────────
 export type {
   ApprovalActionResponse,
   Workflow,
@@ -480,8 +470,11 @@ export type {
   TraceEntry,
   TriggerWorkflowResponse,
 } from "@/shared/api/workflowTypes";
-
-// ── Forum types ───────────────────────────────────────────────────────────────
+export type {
+  UserNote,
+  UserNotesCursor,
+  UserNotesResponse,
+} from "./socialTypes";
 
 export type ThreadSummary = {
   replyCount: number;

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -207,6 +207,23 @@ type RawForumThreadResponse = {
   next_cursor: string | null;
 };
 
+type RawUserNote = {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  content: string;
+};
+
+type RawUserNotesCursor = {
+  before: number;
+  before_id: string;
+};
+
+type RawUserNotesResponse = {
+  notes: RawUserNote[];
+  next_cursor: RawUserNotesCursor | null;
+};
+
 type RawSearchHit = {
   event_id: string;
   content: string;
@@ -1717,6 +1734,91 @@ async function handleGetForumThread(args: {
     total_replies: replies.length,
     next_cursor: null,
   };
+}
+
+function getMockUserNotes(pubkey: string): RawUserNote[] {
+  const now = Math.floor(Date.now() / 1000);
+
+  if (pubkey === DEFAULT_MOCK_IDENTITY.pubkey) {
+    return [
+      {
+        id: "mock-note-launch",
+        pubkey,
+        created_at: now - 20 * 60,
+        content: "Shipped the new desktop sidebar polish today.",
+      },
+      {
+        id: "mock-note-forum",
+        pubkey,
+        created_at: now - 3 * 60 * 60,
+        content: "Forum threads feel like the right home for slower decisions.",
+      },
+    ];
+  }
+
+  if (pubkey === ALICE_PUBKEY) {
+    return [
+      {
+        id: "mock-alice-note-release",
+        pubkey,
+        created_at: now - 45 * 60,
+        content: "Release checklist is ready for async feedback.",
+      },
+      {
+        id: "mock-alice-note-design",
+        pubkey,
+        created_at: now - 5 * 60 * 60,
+        content: "Trying a lighter forum layout for longer-form notes.",
+      },
+    ];
+  }
+
+  return [];
+}
+
+async function handleGetUserNotes(
+  args: {
+    pubkey: string;
+    limit?: number | null;
+    before?: number | null;
+    beforeId?: string | null;
+  },
+  config: E2eConfig | undefined,
+): Promise<RawUserNotesResponse> {
+  const identity = getIdentity(config);
+  if (!identity) {
+    const notes = getMockUserNotes(args.pubkey)
+      .filter((note) => (args.before ? note.created_at < args.before : true))
+      .sort((left, right) => right.created_at - left.created_at)
+      .slice(0, args.limit ?? 50);
+
+    return {
+      notes,
+      next_cursor: null,
+    };
+  }
+
+  const url = new URL(
+    `/api/users/${args.pubkey}/notes`,
+    getRelayHttpUrl(config),
+  );
+  if (args.limit !== undefined && args.limit !== null) {
+    url.searchParams.set("limit", String(args.limit));
+  }
+  if (args.before !== undefined && args.before !== null) {
+    url.searchParams.set("before", String(args.before));
+  }
+  if (args.beforeId) {
+    url.searchParams.set("before_id", args.beforeId);
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      "X-Pubkey": identity.pubkey,
+    },
+  });
+  await assertOk(response);
+  return response.json();
 }
 
 function createMockEvent(
@@ -3741,6 +3843,11 @@ export function maybeInstallE2eTauriMocks() {
       case "get_users_batch":
         return handleGetUsersBatch(
           payload as Parameters<typeof handleGetUsersBatch>[0],
+          activeConfig,
+        );
+      case "get_user_notes":
+        return handleGetUserNotes(
+          payload as Parameters<typeof handleGetUserNotes>[0],
           activeConfig,
         );
       case "search_users":

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -142,6 +142,9 @@ test("clicking author name opens user profile popover", async ({ page }) => {
   const popover = page.locator("[data-radix-popper-content-wrapper]");
   await expect(popover).toBeVisible();
   await expect(popover).toContainText("deadbeef");
+  await expect(page.getByTestId("user-profile-notes")).toContainText(
+    "Shipped the new desktop sidebar polish today.",
+  );
 });
 
 test("clicking avatar opens user profile popover", async ({ page }) => {


### PR DESCRIPTION
## What changed

This adds a small desktop surface for the backend's new global note support by showing recent kind:1 notes in `UserProfilePopover`.

The change includes:
- a new Tauri command to read `/api/users/{pubkey}/notes`
- shared desktop social-note API/types split into dedicated modules
- a `useUserNotesQuery` hook for profile surfaces
- recent note rendering in the user popover
- e2e bridge support and a desktop test assertion for the new popover content

## Why

The backend now supports global social notes, but the desktop had no user-facing way to inspect them. `VISION.md` still positions Home/Stream/Forum/DMs as the main surfaces, so this keeps the desktop aligned with the current product model while exposing a useful first slice of the new capability.

## User impact

When a user clicks a message author's avatar or name, the popover can now show that author's recent global notes.

## Validation

- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- `cd desktop && pnpm typecheck`
- `cd desktop && pnpm check`
- pre-commit hooks
- pre-push hooks (`rust-clippy`, `desktop-build`, unit tests, `desktop-tauri-check`)

## Manual test

I also verified against a local relay by creating a temporary test author, publishing notes, posting a channel message from that same author, and confirming the notes appeared in the desktop popover.
