### PR TITLE
Add inline subtitles to menu items and field descriptions

### DIFF
--- a/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
@@ -144,6 +144,10 @@ export function CreateAgentRuntimeFields({
             placeholder="Leave blank to use the desktop relay"
             value={relayUrl}
           />
+          <p className="text-xs text-muted-foreground">
+            WebSocket URL of the relay this agent connects to. Leave blank to
+            use the built-in desktop relay.
+          </p>
         </div>
 
         <div className="space-y-1.5">
@@ -155,6 +159,10 @@ export function CreateAgentRuntimeFields({
             onChange={(event) => onAcpCommandChange(event.target.value)}
             value={acpCommand}
           />
+          <p className="text-xs text-muted-foreground">
+            The `sprout-acp` binary path or alias used to launch the ACP harness
+            process.
+          </p>
         </div>
       </div>
 
@@ -171,6 +179,10 @@ export function CreateAgentRuntimeFields({
             onChange={(event) => onAgentCommandChange(event.target.value)}
             value={agentCommand}
           />
+          <p className="text-xs text-muted-foreground">
+            Full path or shell command for the agent binary when no known ACP
+            runtime was detected.
+          </p>
         </div>
       ) : null}
 
@@ -199,6 +211,10 @@ export function CreateAgentRuntimeFields({
             onChange={(event) => onMcpCommandChange(event.target.value)}
             value={mcpCommand}
           />
+          <p className="text-xs text-muted-foreground">
+            Command the ACP harness uses to start the MCP tool server for this
+            agent.
+          </p>
         </div>
 
         <div className="space-y-1.5">
@@ -211,6 +227,9 @@ export function CreateAgentRuntimeFields({
             placeholder="300"
             value={turnTimeoutSeconds}
           />
+          <p className="text-xs text-muted-foreground">
+            Seconds before an agent turn is cancelled. Defaults to 300.
+          </p>
         </div>
 
         <div className="space-y-1.5">

--- a/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
@@ -22,6 +22,7 @@ export function CreateAgentBasicsFields({
         Agent name
       </label>
       <Input
+        aria-describedby="help-agent-name"
         autoCapitalize="none"
         autoCorrect="off"
         data-testid="agent-name-input"
@@ -31,7 +32,7 @@ export function CreateAgentBasicsFields({
         spellCheck={false}
         value={name}
       />
-      <p className="text-xs text-muted-foreground">
+      <p className="text-xs text-muted-foreground" id="help-agent-name">
         Used as the local label and synced to the agent profile display name
         when the relay accepts the create-time auth.
       </p>
@@ -139,12 +140,16 @@ export function CreateAgentRuntimeFields({
             Relay URL
           </label>
           <Input
+            aria-describedby="help-agent-relay-url"
             id="agent-relay-url"
             onChange={(event) => onRelayUrlChange(event.target.value)}
             placeholder="Leave blank to use the desktop relay"
             value={relayUrl}
           />
-          <p className="text-xs text-muted-foreground">
+          <p
+            className="text-xs text-muted-foreground"
+            id="help-agent-relay-url"
+          >
             WebSocket URL of the relay this agent connects to. Leave blank to
             use the built-in desktop relay.
           </p>
@@ -155,12 +160,16 @@ export function CreateAgentRuntimeFields({
             ACP command
           </label>
           <Input
+            aria-describedby="help-agent-acp-command"
             id="agent-acp-command"
             onChange={(event) => onAcpCommandChange(event.target.value)}
             value={acpCommand}
           />
-          <p className="text-xs text-muted-foreground">
-            The `sprout-acp` binary path or alias used to launch the ACP harness
+          <p
+            className="text-xs text-muted-foreground"
+            id="help-agent-acp-command"
+          >
+            The sprout-acp binary path or alias used to launch the ACP harness
             process.
           </p>
         </div>
@@ -175,11 +184,15 @@ export function CreateAgentRuntimeFields({
             Custom agent runtime command
           </label>
           <Input
+            aria-describedby="help-agent-runtime-command"
             id="agent-runtime-command"
             onChange={(event) => onAgentCommandChange(event.target.value)}
             value={agentCommand}
           />
-          <p className="text-xs text-muted-foreground">
+          <p
+            className="text-xs text-muted-foreground"
+            id="help-agent-runtime-command"
+          >
             Full path or shell command for the agent binary when no known ACP
             runtime was detected.
           </p>
@@ -192,13 +205,17 @@ export function CreateAgentRuntimeFields({
             Agent runtime args
           </label>
           <Input
+            aria-describedby="help-agent-runtime-args"
             id="agent-runtime-args"
             onChange={(event) => onAgentArgsChange(event.target.value)}
             placeholder="Comma-separated"
             value={agentArgs}
           />
-          <p className="text-xs text-muted-foreground">
-            `sprout-acp` splits args on commas, matching the testing guide.
+          <p
+            className="text-xs text-muted-foreground"
+            id="help-agent-runtime-args"
+          >
+            sprout-acp splits args on commas, matching the testing guide.
           </p>
         </div>
 
@@ -207,11 +224,15 @@ export function CreateAgentRuntimeFields({
             MCP command
           </label>
           <Input
+            aria-describedby="help-agent-mcp-command"
             id="agent-mcp-command"
             onChange={(event) => onMcpCommandChange(event.target.value)}
             value={mcpCommand}
           />
-          <p className="text-xs text-muted-foreground">
+          <p
+            className="text-xs text-muted-foreground"
+            id="help-agent-mcp-command"
+          >
             Command the ACP harness uses to start the MCP tool server for this
             agent.
           </p>
@@ -222,12 +243,13 @@ export function CreateAgentRuntimeFields({
             Turn timeout
           </label>
           <Input
+            aria-describedby="help-agent-timeout"
             id="agent-timeout"
             onChange={(event) => onTurnTimeoutChange(event.target.value)}
             placeholder="300"
             value={turnTimeoutSeconds}
           />
-          <p className="text-xs text-muted-foreground">
+          <p className="text-xs text-muted-foreground" id="help-agent-timeout">
             Seconds before an agent turn is cancelled. Defaults to 300.
           </p>
         </div>
@@ -237,6 +259,7 @@ export function CreateAgentRuntimeFields({
             Parallelism
           </label>
           <Input
+            aria-describedby="help-agent-parallelism"
             data-testid="agent-parallelism-input"
             id="agent-parallelism"
             inputMode="numeric"
@@ -248,8 +271,11 @@ export function CreateAgentRuntimeFields({
             type="number"
             value={parallelism}
           />
-          <p className="text-xs text-muted-foreground">
-            Number of ACP worker subprocesses. `sprout-acp` allows 1-32.
+          <p
+            className="text-xs text-muted-foreground"
+            id="help-agent-parallelism"
+          >
+            Number of ACP worker subprocesses. sprout-acp allows 1-32.
           </p>
         </div>
       </div>
@@ -259,15 +285,18 @@ export function CreateAgentRuntimeFields({
           System prompt override
         </label>
         <Textarea
+          aria-describedby="help-agent-system-prompt"
           data-testid="agent-system-prompt-input"
           id="agent-system-prompt"
           onChange={(event) => onSystemPromptChange(event.target.value)}
           placeholder="Leave blank to send no ACP system prompt"
           value={systemPrompt}
         />
-        <p className="text-xs text-muted-foreground">
-          Blank means no override. `sprout-acp` will not add a `[System]`
-          prompt.
+        <p
+          className="text-xs text-muted-foreground"
+          id="help-agent-system-prompt"
+        >
+          Blank means no override. sprout-acp will not add a [System] prompt.
         </p>
       </div>
     </>
@@ -321,7 +350,7 @@ export function CreateAgentOptionToggles({
         <p className="mt-1 text-sm text-foreground/70">
           {prereqs !== null && !isMintSupported
             ? `Unavailable until ${prereqs.admin.command} is installed.`
-            : "Use `sprout-admin` to create a bearer token for this agent."}
+            : "Use sprout-admin to create a bearer token for this agent."}
         </p>
       </button>
 

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -319,6 +319,11 @@ function AgentActionsMenu({
             <DropdownMenuItem
               disabled={isActionPending}
               onClick={() => onStart(agent.pubkey)}
+              title={
+                isActive
+                  ? "Push a new deployment to the provider"
+                  : "Deploy this agent to the provider"
+              }
             >
               <Play className="h-4 w-4" />
               {isActive ? "Redeploy" : "Deploy"}
@@ -326,6 +331,7 @@ function AgentActionsMenu({
             <DropdownMenuItem
               disabled={isActionPending}
               onClick={() => onStop(agent.pubkey)}
+              title="Stop the provider deployment and free its resources"
             >
               <Square className="h-4 w-4" />
               Shutdown
@@ -335,6 +341,7 @@ function AgentActionsMenu({
           <DropdownMenuItem
             disabled={isActionPending}
             onClick={() => onStop(agent.pubkey)}
+            title="Stop the running ACP harness process"
           >
             <Square className="h-4 w-4" />
             Stop
@@ -343,6 +350,7 @@ function AgentActionsMenu({
           <DropdownMenuItem
             disabled={isActionPending}
             onClick={() => onStart(agent.pubkey)}
+            title="Launch the local ACP harness process for this agent"
           >
             <Play className="h-4 w-4" />
             Spawn
@@ -352,6 +360,7 @@ function AgentActionsMenu({
         <DropdownMenuItem
           disabled={isActionPending}
           onClick={() => onAddToChannel(agent)}
+          title="Invite this agent to a channel so it can participate in conversations"
         >
           <UserPlus className="h-4 w-4" />
           Add to channel
@@ -360,6 +369,7 @@ function AgentActionsMenu({
         <DropdownMenuItem
           disabled={isActionPending}
           onClick={() => onMintToken(agent.pubkey, agent.name)}
+          title="Generate a bearer token this agent uses to authenticate with the relay"
         >
           <KeyRound className="h-4 w-4" />
           Mint token
@@ -367,13 +377,17 @@ function AgentActionsMenu({
 
         <DropdownMenuItem
           onClick={() => navigator.clipboard.writeText(agent.pubkey)}
+          title="Copy the agent's public key to the clipboard"
         >
           <Clipboard className="h-4 w-4" />
           Copy pubkey
         </DropdownMenuItem>
 
         {agent.backend.type === "local" ? (
-          <DropdownMenuItem onClick={() => onOpenLogs(agent.pubkey)}>
+          <DropdownMenuItem
+            onClick={() => onOpenLogs(agent.pubkey)}
+            title="Show the ACP harness stdout/stderr log inline"
+          >
             <FileText className="h-4 w-4" />
             View logs
           </DropdownMenuItem>
@@ -384,6 +398,11 @@ function AgentActionsMenu({
             disabled={isActionPending}
             onClick={() =>
               onToggleStartOnAppLaunch(agent.pubkey, !agent.startOnAppLaunch)
+            }
+            title={
+              agent.startOnAppLaunch
+                ? "Stop launching this agent automatically when the desktop app starts"
+                : "Launch this agent automatically every time the desktop app starts"
             }
           >
             <Power className="h-4 w-4" />
@@ -399,6 +418,7 @@ function AgentActionsMenu({
           className="text-destructive focus:text-destructive"
           disabled={isActionPending}
           onClick={() => onDelete(agent.pubkey)}
+          title="Permanently remove this agent profile from the desktop app"
         >
           <Trash2 className="h-4 w-4" />
           Delete

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -319,77 +319,107 @@ function AgentActionsMenu({
             <DropdownMenuItem
               disabled={isActionPending}
               onClick={() => onStart(agent.pubkey)}
-              title={
-                isActive
-                  ? "Push a new deployment to the provider"
-                  : "Deploy this agent to the provider"
-              }
             >
               <Play className="h-4 w-4" />
-              {isActive ? "Redeploy" : "Deploy"}
+              <div className="flex flex-col">
+                <span>{isActive ? "Redeploy" : "Deploy"}</span>
+                <span className="text-xs font-normal text-muted-foreground">
+                  {isActive
+                    ? "Push a new deployment to the provider"
+                    : "Deploy this agent to the provider"}
+                </span>
+              </div>
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={isActionPending}
               onClick={() => onStop(agent.pubkey)}
-              title="Stop the provider deployment and free its resources"
             >
               <Square className="h-4 w-4" />
-              Shutdown
+              <div className="flex flex-col">
+                <span>Shutdown</span>
+                <span className="text-xs font-normal text-muted-foreground">
+                  Stop the provider deployment and free its resources
+                </span>
+              </div>
             </DropdownMenuItem>
           </>
         ) : isActive ? (
           <DropdownMenuItem
             disabled={isActionPending}
             onClick={() => onStop(agent.pubkey)}
-            title="Stop the running ACP harness process"
           >
             <Square className="h-4 w-4" />
-            Stop
+            <div className="flex flex-col">
+              <span>Stop</span>
+              <span className="text-xs font-normal text-muted-foreground">
+                Stop the running ACP harness process
+              </span>
+            </div>
           </DropdownMenuItem>
         ) : (
           <DropdownMenuItem
             disabled={isActionPending}
             onClick={() => onStart(agent.pubkey)}
-            title="Launch the local ACP harness process for this agent"
           >
             <Play className="h-4 w-4" />
-            Spawn
+            <div className="flex flex-col">
+              <span>Spawn</span>
+              <span className="text-xs font-normal text-muted-foreground">
+                Launch the local ACP harness process for this agent
+              </span>
+            </div>
           </DropdownMenuItem>
         )}
 
         <DropdownMenuItem
           disabled={isActionPending}
           onClick={() => onAddToChannel(agent)}
-          title="Invite this agent to a channel so it can participate in conversations"
         >
           <UserPlus className="h-4 w-4" />
-          Add to channel
+          <div className="flex flex-col">
+            <span>Add to channel</span>
+            <span className="text-xs font-normal text-muted-foreground">
+              Invite this agent to a channel so it can participate in
+              conversations
+            </span>
+          </div>
         </DropdownMenuItem>
 
         <DropdownMenuItem
           disabled={isActionPending}
           onClick={() => onMintToken(agent.pubkey, agent.name)}
-          title="Generate a bearer token this agent uses to authenticate with the relay"
         >
           <KeyRound className="h-4 w-4" />
-          Mint token
+          <div className="flex flex-col">
+            <span>Mint token</span>
+            <span className="text-xs font-normal text-muted-foreground">
+              Generate a bearer token this agent uses to authenticate with the
+              relay
+            </span>
+          </div>
         </DropdownMenuItem>
 
         <DropdownMenuItem
           onClick={() => navigator.clipboard.writeText(agent.pubkey)}
-          title="Copy the agent's public key to the clipboard"
         >
           <Clipboard className="h-4 w-4" />
-          Copy pubkey
+          <div className="flex flex-col">
+            <span>Copy pubkey</span>
+            <span className="text-xs font-normal text-muted-foreground">
+              Copy the agent&apos;s public key to the clipboard
+            </span>
+          </div>
         </DropdownMenuItem>
 
         {agent.backend.type === "local" ? (
-          <DropdownMenuItem
-            onClick={() => onOpenLogs(agent.pubkey)}
-            title="Show the ACP harness stdout/stderr log inline"
-          >
+          <DropdownMenuItem onClick={() => onOpenLogs(agent.pubkey)}>
             <FileText className="h-4 w-4" />
-            View logs
+            <div className="flex flex-col">
+              <span>View logs</span>
+              <span className="text-xs font-normal text-muted-foreground">
+                Show the ACP harness stdout/stderr log inline
+              </span>
+            </div>
           </DropdownMenuItem>
         ) : null}
 
@@ -399,16 +429,20 @@ function AgentActionsMenu({
             onClick={() =>
               onToggleStartOnAppLaunch(agent.pubkey, !agent.startOnAppLaunch)
             }
-            title={
-              agent.startOnAppLaunch
-                ? "Stop launching this agent automatically when the desktop app starts"
-                : "Launch this agent automatically every time the desktop app starts"
-            }
           >
             <Power className="h-4 w-4" />
-            {agent.startOnAppLaunch
-              ? "Disable auto-start"
-              : "Enable auto-start"}
+            <div className="flex flex-col">
+              <span>
+                {agent.startOnAppLaunch
+                  ? "Disable auto-start"
+                  : "Enable auto-start"}
+              </span>
+              <span className="text-xs font-normal text-muted-foreground">
+                {agent.startOnAppLaunch
+                  ? "Stop launching this agent automatically when the desktop app starts"
+                  : "Launch this agent automatically every time the desktop app starts"}
+              </span>
+            </div>
           </DropdownMenuItem>
         ) : null}
 
@@ -418,10 +452,14 @@ function AgentActionsMenu({
           className="text-destructive focus:text-destructive"
           disabled={isActionPending}
           onClick={() => onDelete(agent.pubkey)}
-          title="Permanently remove this agent profile from the desktop app"
         >
           <Trash2 className="h-4 w-4" />
-          Delete
+          <div className="flex flex-col">
+            <span>Delete</span>
+            <span className="text-xs font-normal text-muted-foreground">
+              Permanently remove this agent profile from the desktop app
+            </span>
+          </div>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/desktop/src/features/agents/ui/PersonasSection.tsx
+++ b/desktop/src/features/agents/ui/PersonasSection.tsx
@@ -153,6 +153,7 @@ export function PersonasSection({
                       <DropdownMenuItem
                         disabled={isPending}
                         onClick={() => onEdit(persona)}
+                        title="Edit this persona's name, avatar, and system prompt"
                       >
                         <Pencil className="h-4 w-4" />
                         Edit
@@ -161,6 +162,7 @@ export function PersonasSection({
                     <DropdownMenuItem
                       disabled={isPending}
                       onClick={() => onDuplicate(persona)}
+                      title="Create a copy of this persona you can customize independently"
                     >
                       <CopyPlus className="h-4 w-4" />
                       Duplicate
@@ -168,6 +170,7 @@ export function PersonasSection({
                     <DropdownMenuItem
                       disabled={isPending}
                       onClick={() => onExport(persona)}
+                      title="Save this persona as a .persona.json file you can share or back up"
                     >
                       <Download className="h-4 w-4" />
                       Export
@@ -177,6 +180,7 @@ export function PersonasSection({
                         className="text-destructive focus:text-destructive"
                         disabled={isPending}
                         onClick={() => onDeactivate(persona)}
+                        title="Remove this built-in persona from your agent library"
                       >
                         <Trash2 className="h-4 w-4" />
                         Remove from My Agents
@@ -186,6 +190,7 @@ export function PersonasSection({
                         className="text-destructive focus:text-destructive"
                         disabled={isPending}
                         onClick={() => onDelete(persona)}
+                        title="Permanently delete this persona"
                       >
                         <Trash2 className="h-4 w-4" />
                         Delete

--- a/desktop/src/features/agents/ui/PersonasSection.tsx
+++ b/desktop/src/features/agents/ui/PersonasSection.tsx
@@ -153,47 +153,70 @@ export function PersonasSection({
                       <DropdownMenuItem
                         disabled={isPending}
                         onClick={() => onEdit(persona)}
-                        title="Edit this persona's name, avatar, and system prompt"
                       >
                         <Pencil className="h-4 w-4" />
-                        Edit
+                        <div className="flex flex-col">
+                          <span>Edit</span>
+                          <span className="text-xs font-normal text-muted-foreground">
+                            Edit this persona&apos;s name, avatar, and system
+                            prompt
+                          </span>
+                        </div>
                       </DropdownMenuItem>
                     ) : null}
                     <DropdownMenuItem
                       disabled={isPending}
                       onClick={() => onDuplicate(persona)}
-                      title="Create a copy of this persona you can customize independently"
                     >
                       <CopyPlus className="h-4 w-4" />
-                      Duplicate
+                      <div className="flex flex-col">
+                        <span>Duplicate</span>
+                        <span className="text-xs font-normal text-muted-foreground">
+                          Create a copy of this persona you can customize
+                          independently
+                        </span>
+                      </div>
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       disabled={isPending}
                       onClick={() => onExport(persona)}
-                      title="Save this persona as a .persona.json file you can share or back up"
                     >
                       <Download className="h-4 w-4" />
-                      Export
+                      <div className="flex flex-col">
+                        <span>Export</span>
+                        <span className="text-xs font-normal text-muted-foreground">
+                          Save this persona as a .persona.json file you can
+                          share or back up
+                        </span>
+                      </div>
                     </DropdownMenuItem>
                     {persona.isBuiltIn ? (
                       <DropdownMenuItem
                         className="text-destructive focus:text-destructive"
                         disabled={isPending}
                         onClick={() => onDeactivate(persona)}
-                        title="Remove this built-in persona from your agent library"
                       >
                         <Trash2 className="h-4 w-4" />
-                        Remove from My Agents
+                        <div className="flex flex-col">
+                          <span>Remove from My Agents</span>
+                          <span className="text-xs font-normal text-muted-foreground">
+                            Remove this built-in persona from your agent library
+                          </span>
+                        </div>
                       </DropdownMenuItem>
                     ) : (
                       <DropdownMenuItem
                         className="text-destructive focus:text-destructive"
                         disabled={isPending}
                         onClick={() => onDelete(persona)}
-                        title="Permanently delete this persona"
                       >
                         <Trash2 className="h-4 w-4" />
-                        Delete
+                        <div className="flex flex-col">
+                          <span>Delete</span>
+                          <span className="text-xs font-normal text-muted-foreground">
+                            Permanently delete this persona
+                          </span>
+                        </div>
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>

--- a/desktop/src/features/agents/ui/TeamsSection.tsx
+++ b/desktop/src/features/agents/ui/TeamsSection.tsx
@@ -200,6 +200,7 @@ export function TeamsSection({
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onAddToChannel(team)}
+                        title="Add all personas in this team to a channel at once"
                       >
                         <Rocket className="h-4 w-4" />
                         Deploy to channel
@@ -208,6 +209,7 @@ export function TeamsSection({
                       <DropdownMenuItem
                         disabled={isPending}
                         onClick={() => onEdit(team)}
+                        title="Edit this team's name, description, and persona membership"
                       >
                         <Pencil className="h-4 w-4" />
                         Edit
@@ -215,6 +217,7 @@ export function TeamsSection({
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onDuplicate(team)}
+                        title="Create a copy of this team you can customize independently"
                       >
                         <CopyPlus className="h-4 w-4" />
                         Duplicate
@@ -222,6 +225,7 @@ export function TeamsSection({
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onExport(team)}
+                        title="Save this team as a .team.json file you can share or back up"
                       >
                         <Download className="h-4 w-4" />
                         Export
@@ -231,6 +235,7 @@ export function TeamsSection({
                         className="text-destructive focus:text-destructive"
                         disabled={isPending}
                         onClick={() => onDelete(team)}
+                        title="Permanently delete this team"
                       >
                         <Trash2 className="h-4 w-4" />
                         Delete

--- a/desktop/src/features/agents/ui/TeamsSection.tsx
+++ b/desktop/src/features/agents/ui/TeamsSection.tsx
@@ -200,45 +200,68 @@ export function TeamsSection({
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onAddToChannel(team)}
-                        title="Add all personas in this team to a channel at once"
                       >
                         <Rocket className="h-4 w-4" />
-                        Deploy to channel
+                        <div className="flex flex-col">
+                          <span>Deploy to channel</span>
+                          <span className="text-xs font-normal text-muted-foreground">
+                            Add all personas in this team to a channel at once
+                          </span>
+                        </div>
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         disabled={isPending}
                         onClick={() => onEdit(team)}
-                        title="Edit this team's name, description, and persona membership"
                       >
                         <Pencil className="h-4 w-4" />
-                        Edit
+                        <div className="flex flex-col">
+                          <span>Edit</span>
+                          <span className="text-xs font-normal text-muted-foreground">
+                            Edit this team&apos;s name, description, and persona
+                            membership
+                          </span>
+                        </div>
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onDuplicate(team)}
-                        title="Create a copy of this team you can customize independently"
                       >
                         <CopyPlus className="h-4 w-4" />
-                        Duplicate
+                        <div className="flex flex-col">
+                          <span>Duplicate</span>
+                          <span className="text-xs font-normal text-muted-foreground">
+                            Create a copy of this team you can customize
+                            independently
+                          </span>
+                        </div>
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onExport(team)}
-                        title="Save this team as a .team.json file you can share or back up"
                       >
                         <Download className="h-4 w-4" />
-                        Export
+                        <div className="flex flex-col">
+                          <span>Export</span>
+                          <span className="text-xs font-normal text-muted-foreground">
+                            Save this team as a .team.json file you can share or
+                            back up
+                          </span>
+                        </div>
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         className="text-destructive focus:text-destructive"
                         disabled={isPending}
                         onClick={() => onDelete(team)}
-                        title="Permanently delete this team"
                       >
                         <Trash2 className="h-4 w-4" />
-                        Delete
+                        <div className="flex flex-col">
+                          <span>Delete</span>
+                          <span className="text-xs font-normal text-muted-foreground">
+                            Permanently delete this team
+                          </span>
+                        </div>
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>


### PR DESCRIPTION
This PR adds inline subtitle text to dropdown menu items and descriptive helper text to advanced dialog fields, making the agents UI more discoverable.

The agents screen had no contextual help — actions like "Mint token", "Spawn", and "Deploy" gave no hint of what they did. Advanced fields in the create-agent dialog (`relay_url`, ACP command, MCP command, turn timeout) had no descriptions. HTML `title` attributes don't render in Tauri's WKWebView, so a visible approach was needed.

- Add a muted subtitle `<span>` below each action label in `AgentActionsMenu` (`ManagedAgentRow.tsx`), `PersonasSection.tsx`, and `TeamsSection.tsx` — always visible, works with keyboard nav, no Radix portal conflicts
- Add inline `<p>` description text below advanced setup fields in `CreateAgentDialogSections.tsx`
- Wire `aria-describedby` on all form inputs linking to their helper text for screen reader accessibility
- Strip literal backtick characters from JSX help strings (rendered as plain text in the browser, not markdown)