### PR TITLE
Fix @mention search to use word-boundary prefix matching

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -104,14 +104,13 @@ export function useMentions(channelId: string | null) {
 
     // Score a label against the query using word-boundary prefix matching.
     // Returns 0 if the full label starts with the query (best), 1 if any
-    // word within the label starts with the query, 2 if it's a substring
-    // match anywhere (fallback), or null if there's no match at all.
+    // word within the label starts with the query, or null if there's no
+    // match. No arbitrary substring matching — standard for mention UX.
     const scoreLabel = (label: string): number | null => {
       const lower = label.toLowerCase();
       if (lower.startsWith(lowerQuery)) return 0;
       const words = lower.split(/[\s\-_]+/).filter(Boolean);
       if (words.some((word) => word.startsWith(lowerQuery))) return 1;
-      if (lower.includes(lowerQuery)) return 2;
       return null;
     };
 

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -118,13 +118,9 @@ export function useMentions(channelId: string | null) {
     return (members ?? [])
       .map((member) => {
         const pubkeyLower = member.pubkey.toLowerCase();
-        const fallbackName =
-          managedAgentNamesByPubkey.get(pubkeyLower) ??
-          member.pubkey.slice(0, 8);
 
         const actualName =
-          member.displayName ??
-          managedAgentNamesByPubkey.get(pubkeyLower);
+          member.displayName ?? managedAgentNamesByPubkey.get(pubkeyLower);
         const personaName = personaNameByPubkey.get(pubkeyLower) ?? null;
         const label = actualName ?? member.pubkey.slice(0, 8);
 
@@ -135,10 +131,9 @@ export function useMentions(channelId: string | null) {
             ? Math.min(nameScore, personaScore)
             : (nameScore ?? personaScore);
 
-        const lowerPubkey = member.pubkey.toLowerCase();
-        const pubkeyScore = lowerPubkey.startsWith(lowerQuery)
+        const pubkeyScore = pubkeyLower.startsWith(lowerQuery)
           ? 3
-          : lowerPubkey.includes(lowerQuery)
+          : pubkeyLower.includes(lowerQuery)
             ? 4
             : null;
         const score = labelScore !== null ? labelScore : pubkeyScore;

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -101,6 +101,20 @@ export function useMentions(channelId: string | null) {
     }
 
     const lowerQuery = mentionQuery.toLowerCase();
+
+    // Score a label against the query using word-boundary prefix matching.
+    // Returns 0 if the full label starts with the query (best), 1 if any
+    // word within the label starts with the query, 2 if it's a substring
+    // match anywhere (fallback), or null if there's no match at all.
+    const scoreLabel = (label: string): number | null => {
+      const lower = label.toLowerCase();
+      if (lower.startsWith(lowerQuery)) return 0;
+      const words = lower.split(/[\s\-_]+/).filter(Boolean);
+      if (words.some((word) => word.startsWith(lowerQuery))) return 1;
+      if (lower.includes(lowerQuery)) return 2;
+      return null;
+    };
+
     return (members ?? [])
       .map((member) => {
         const pubkeyLower = member.pubkey.toLowerCase();
@@ -108,18 +122,33 @@ export function useMentions(channelId: string | null) {
           managedAgentNamesByPubkey.get(pubkeyLower) ??
           member.pubkey.slice(0, 8);
 
-        return {
-          member,
-          label: member.displayName ?? fallbackName,
-          personaName: personaNameByPubkey.get(pubkeyLower) ?? null,
-        };
+        const actualName =
+          member.displayName ??
+          managedAgentNamesByPubkey.get(pubkeyLower);
+        const personaName = personaNameByPubkey.get(pubkeyLower) ?? null;
+        const label = actualName ?? member.pubkey.slice(0, 8);
+
+        const nameScore = actualName ? scoreLabel(actualName) : null;
+        const personaScore = personaName ? scoreLabel(personaName) : null;
+        const labelScore =
+          nameScore !== null && personaScore !== null
+            ? Math.min(nameScore, personaScore)
+            : (nameScore ?? personaScore);
+
+        const lowerPubkey = member.pubkey.toLowerCase();
+        const pubkeyScore = lowerPubkey.startsWith(lowerQuery)
+          ? 3
+          : lowerPubkey.includes(lowerQuery)
+            ? 4
+            : null;
+        const score = labelScore !== null ? labelScore : pubkeyScore;
+
+        return { member, label, personaName, score };
       })
       .filter(
-        ({ label, member, personaName }) =>
-          label.toLowerCase().includes(lowerQuery) ||
-          member.pubkey.toLowerCase().includes(lowerQuery) ||
-          personaName?.toLowerCase().includes(lowerQuery),
+        (item): item is typeof item & { score: number } => item.score !== null,
       )
+      .sort((a, b) => a.score - b.score)
       .slice(0, 8)
       .map(({ member, label, personaName }) => ({
         pubkey: member.pubkey,


### PR DESCRIPTION
This PR fixes `@mention` search to eliminate irrelevant results caused by substring matching on short queries.

`String.includes()` matched any substring: `@g` returned "Will Pfleger" (the "g" in Pfleger), and `@c` matched any member whose name or pubkey contained "c" anywhere.

- Replace the `includes()` filter in `useMentions.ts` with `scoreLabel()`, which matches word-boundary prefixes only (no arbitrary mid-word substrings) — standard mention UX matching Slack/Discord/GitHub behavior
- Score against both display names and persona names, taking the best match
- Separate actual display name from the truncated-pubkey fallback label so scoring runs against real names, not the 8-char display stub
- Rank and sort results by match quality before the 8-item cap: full-label prefix (0) > word prefix (1) > pubkey prefix (3) > pubkey substring (4)
- Use a type predicate on the score filter for proper TypeScript narrowing instead of an `as number` cast