### PR TITLE
feat(desktop): render GitHub smart link chips + typing indicator popover

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         "**/channel-browser.spec.ts",
         "**/messaging.spec.ts",
         "**/mentions.spec.ts",
+        "**/smart-links.spec.ts",
         "**/workflows.spec.ts",
       ],
       use: {

--- a/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
+++ b/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {
+  useManagedAgentLogQuery,
   useManagedAgentsQuery,
   useStopManagedAgentMutation,
 } from "@/features/agents/hooks";
@@ -71,6 +72,35 @@ function formatElapsed(startIso: string): string {
   return `${totalSeconds}s`;
 }
 
+/** Compact ACP log preview — dark terminal block, last N lines. */
+function AgentLogPreview({ pubkey }: { pubkey: string }) {
+  const { data: logData, isLoading } = useManagedAgentLogQuery(pubkey, 10);
+
+  if (isLoading) {
+    return (
+      <div className="mt-2 rounded-lg bg-[#17171d] px-3 py-2 text-[11px] text-zinc-500">
+        Loading log…
+      </div>
+    );
+  }
+
+  const trimmed = logData?.content?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 overflow-hidden rounded-lg border border-white/5 bg-[#17171d]">
+      <pre
+        className="max-h-[8rem] overflow-auto whitespace-pre-wrap px-3 py-2 font-mono text-[11px] leading-relaxed text-zinc-300"
+        data-testid="typing-popover-log"
+      >
+        {trimmed}
+      </pre>
+    </div>
+  );
+}
+
 type BotTypingPopoverContentProps = {
   botAgents: ManagedAgent[];
 };
@@ -95,14 +125,17 @@ function BotTypingPopoverContent({ botAgents }: BotTypingPopoverContentProps) {
   return (
     <div>
       {botAgents.map((agent) => (
-        <div key={agent.pubkey} className="mb-2 last:mb-0">
-          <div className="font-bold text-sm">{agent.name}</div>
+        <div key={agent.pubkey} className="mb-3 last:mb-0">
+          <div className="flex items-baseline justify-between gap-2">
+            <div className="font-bold text-sm truncate">{agent.name}</div>
+            <div className="flex-shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+              {agent.lastStartedAt ? formatElapsed(agent.lastStartedAt) : "—"}
+            </div>
+          </div>
           {agent.model && (
             <div className="text-xs text-muted-foreground">{agent.model}</div>
           )}
-          <div className="text-xs text-muted-foreground">
-            {agent.lastStartedAt ? formatElapsed(agent.lastStartedAt) : "—"}
-          </div>
+          <AgentLogPreview pubkey={agent.pubkey} />
         </div>
       ))}
       <button
@@ -204,7 +237,7 @@ export function TypingIndicatorRow({
                 {typingText}
               </button>
             </PopoverTrigger>
-            <PopoverContent side="top" align="start" className="w-64 p-3">
+            <PopoverContent side="top" align="start" className="w-96 p-3">
               <BotTypingPopoverContent botAgents={botAgents} />
             </PopoverContent>
           </Popover>

--- a/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
+++ b/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
@@ -1,11 +1,16 @@
 import * as React from "react";
 
 import {
+  useManagedAgentsQuery,
+  useStopManagedAgentMutation,
+} from "@/features/agents/hooks";
+import {
   resolveUserLabel,
   type UserProfileLookup,
 } from "@/features/profile/lib/identity";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
-import type { Channel } from "@/shared/api/types";
+import type { Channel, ManagedAgent } from "@/shared/api/types";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 
 type TypingIndicatorRowProps = {
   channel: Channel | null;
@@ -46,12 +51,91 @@ function formatTypingLabel(names: string[]) {
   return `${names[0]}, ${names[1]}, and ${names.length - 2} others are typing...`;
 }
 
+function formatElapsed(startIso: string): string {
+  const startMs = new Date(startIso).getTime();
+  const nowMs = Date.now();
+  const totalSeconds = Math.max(0, Math.floor((nowMs - startMs) / 1000));
+
+  if (totalSeconds >= 3600) {
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    return `${hours}h ${minutes}m`;
+  }
+
+  if (totalSeconds >= 60) {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}m ${seconds}s`;
+  }
+
+  return `${totalSeconds}s`;
+}
+
+type BotTypingPopoverContentProps = {
+  botAgents: ManagedAgent[];
+};
+
+function BotTypingPopoverContent({ botAgents }: BotTypingPopoverContentProps) {
+  const [, setTick] = React.useState(0);
+  const mutation = useStopManagedAgentMutation();
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setTick((prev) => prev + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  function handleInterrupt() {
+    for (const agent of botAgents) {
+      mutation.mutate(agent.pubkey);
+    }
+  }
+
+  return (
+    <div>
+      {botAgents.map((agent) => (
+        <div key={agent.pubkey} className="mb-2 last:mb-0">
+          <div className="font-bold text-sm">{agent.name}</div>
+          {agent.model && (
+            <div className="text-xs text-muted-foreground">{agent.model}</div>
+          )}
+          <div className="text-xs text-muted-foreground">
+            {agent.lastStartedAt ? formatElapsed(agent.lastStartedAt) : "—"}
+          </div>
+        </div>
+      ))}
+      <button
+        type="button"
+        className="mt-3 w-full rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+        data-testid="typing-interrupt-button"
+        disabled={mutation.isPending}
+        onClick={handleInterrupt}
+      >
+        {mutation.isPending ? "Interrupting…" : "Interrupt"}
+      </button>
+    </div>
+  );
+}
+
 export function TypingIndicatorRow({
   channel,
   currentPubkey,
   profiles,
   typingPubkeys,
 }: TypingIndicatorRowProps) {
+  const { data: managedAgents } = useManagedAgentsQuery();
+
+  const managedAgentMap = React.useMemo(() => {
+    const map = new Map<string, ManagedAgent>();
+    if (managedAgents) {
+      for (const agent of managedAgents) {
+        map.set(agent.pubkey.toLowerCase(), agent);
+      }
+    }
+    return map;
+  }, [managedAgents]);
+
   const labels = React.useMemo(
     () =>
       typingPubkeys.map((pubkey) =>
@@ -66,9 +150,21 @@ export function TypingIndicatorRow({
     [channel, currentPubkey, profiles, typingPubkeys],
   );
 
+  const botAgents = React.useMemo(
+    () =>
+      typingPubkeys
+        .map((pubkey) => managedAgentMap.get(pubkey.toLowerCase()))
+        .filter((agent): agent is ManagedAgent => agent !== undefined),
+    [typingPubkeys, managedAgentMap],
+  );
+
+  const hasBotTypers = botAgents.length > 0;
+
   if (labels.length === 0) {
     return null;
   }
+
+  const typingText = formatTypingLabel(labels);
 
   return (
     <div
@@ -97,12 +193,29 @@ export function TypingIndicatorRow({
             );
           })}
         </div>
-        <p
-          className="truncate text-sm text-muted-foreground"
-          data-testid="message-typing-indicator-label"
-        >
-          {formatTypingLabel(labels)}
-        </p>
+        {hasBotTypers ? (
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="truncate text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
+                data-testid="message-typing-indicator-label"
+              >
+                {typingText}
+              </button>
+            </PopoverTrigger>
+            <PopoverContent side="top" align="start" className="w-64 p-3">
+              <BotTypingPopoverContent botAgents={botAgents} />
+            </PopoverContent>
+          </Popover>
+        ) : (
+          <p
+            className="truncate text-sm text-muted-foreground"
+            data-testid="message-typing-indicator-label"
+          >
+            {typingText}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -1,3 +1,4 @@
+import { GitPullRequest } from "lucide-react";
 import * as React from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkBreaks from "remark-breaks";
@@ -10,6 +11,9 @@ import { cn } from "@/shared/lib/cn";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import remarkChannelLinks from "@/shared/lib/remarkChannelLinks";
 import remarkMentions from "@/shared/lib/remarkMentions";
+
+const GITHUB_PR_RE =
+  /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/;
 
 type MarkdownProps = {
   channelNames?: string[];
@@ -41,17 +45,35 @@ function createMarkdownComponents(
       : "space-y-1 pl-6 marker:text-muted-foreground";
 
   return {
-    a: ({ children, href, ...props }) => (
-      <a
-        {...props}
-        className="font-medium text-primary underline underline-offset-4 transition-colors hover:text-primary/80"
-        href={href}
-        rel="noreferrer"
-        target="_blank"
-      >
-        {children}
-      </a>
-    ),
+    a: ({ children, href, ...props }) => {
+      const prMatch = href ? GITHUB_PR_RE.exec(href) : null;
+      if (prMatch) {
+        const [, owner, repo, number] = prMatch;
+        return (
+          <a
+            {...props}
+            className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-1.5 py-0.5 text-sm font-medium text-primary no-underline transition-colors hover:bg-primary/20"
+            href={href}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <GitPullRequest className="size-3.5" />
+            {owner}/{repo}#{number}
+          </a>
+        );
+      }
+      return (
+        <a
+          {...props}
+          className="font-medium text-primary underline underline-offset-4 transition-colors hover:text-primary/80"
+          href={href}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {children}
+        </a>
+      );
+    },
     blockquote: ({ children }) => (
       <blockquote className="border-l-2 border-border pl-4 italic text-muted-foreground">
         {children}

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -52,13 +52,16 @@ function createMarkdownComponents(
         return (
           <a
             {...props}
-            className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-1.5 py-0.5 text-sm font-medium text-primary no-underline transition-colors hover:bg-primary/20"
+            className="relative inline-flex items-center gap-1 rounded-md bg-primary/10 px-1.5 py-0.5 text-sm font-medium text-primary no-underline transition-colors hover:bg-primary/20"
             href={href}
             rel="noreferrer"
             target="_blank"
           >
-            <GitPullRequest className="size-3.5" />
-            {owner}/{repo}#{number}
+            <span className="pointer-events-none select-none inline-flex items-center gap-1" aria-hidden="true">
+              <GitPullRequest className="size-3.5" />
+              {owner}/{repo}#{number}
+            </span>
+            <span className="absolute w-0 overflow-hidden whitespace-nowrap">{href}</span>
           </a>
         );
       }

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -1,4 +1,4 @@
-import { GitPullRequest } from "lucide-react";
+import { CircleDot, GitCommitHorizontal, GitPullRequest } from "lucide-react";
 import * as React from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkBreaks from "remark-breaks";
@@ -14,6 +14,12 @@ import remarkMentions from "@/shared/lib/remarkMentions";
 
 const GITHUB_PR_RE =
   /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/;
+
+const GITHUB_ISSUE_RE =
+  /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)\/?$/;
+
+const GITHUB_COMMIT_RE =
+  /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/commit\/([0-9a-f]{7,40})\/?$/;
 
 type MarkdownProps = {
   channelNames?: string[];
@@ -46,25 +52,50 @@ function createMarkdownComponents(
 
   return {
     a: ({ children, href, ...props }) => {
-      const prMatch = href ? GITHUB_PR_RE.exec(href) : null;
-      if (prMatch) {
-        const [, owner, repo, number] = prMatch;
-        return (
-          <a
-            {...props}
-            className="relative inline-flex items-center gap-1 rounded-md bg-primary/10 px-1.5 py-0.5 text-sm font-medium text-primary no-underline transition-colors hover:bg-primary/20"
-            href={href}
-            rel="noreferrer"
-            target="_blank"
-          >
-            <span className="pointer-events-none select-none inline-flex items-center gap-1" aria-hidden="true">
-              <GitPullRequest className="size-3.5" />
-              {owner}/{repo}#{number}
-            </span>
-            <span className="absolute w-0 overflow-hidden whitespace-nowrap">{href}</span>
-          </a>
-        );
+      if (href) {
+        let Icon: React.ComponentType<{ className?: string }> | null = null;
+        let label: string | null = null;
+
+        const prMatch = GITHUB_PR_RE.exec(href);
+        if (prMatch) {
+          const [, owner, repo, number] = prMatch;
+          Icon = GitPullRequest;
+          label = `${owner}/${repo}#${number}`;
+        }
+
+        const issueMatch = !Icon ? GITHUB_ISSUE_RE.exec(href) : null;
+        if (issueMatch) {
+          const [, owner, repo, number] = issueMatch;
+          Icon = CircleDot;
+          label = `${owner}/${repo}#${number}`;
+        }
+
+        const commitMatch = !Icon ? GITHUB_COMMIT_RE.exec(href) : null;
+        if (commitMatch) {
+          const [, owner, repo, sha] = commitMatch;
+          Icon = GitCommitHorizontal;
+          label = `${owner}/${repo}@${sha.slice(0, 7)}`;
+        }
+
+        if (Icon && label) {
+          return (
+            <a
+              {...props}
+              className="relative inline-flex items-center gap-1 rounded-md bg-primary/10 px-1.5 py-0.5 text-sm font-medium text-primary no-underline transition-colors hover:bg-primary/20"
+              href={href}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <span className="pointer-events-none select-none inline-flex items-center gap-1" aria-hidden="true">
+                <Icon className="size-3.5" />
+                {label}
+              </span>
+              <span className="absolute w-0 overflow-hidden whitespace-nowrap">{href}</span>
+            </a>
+          );
+        }
       }
+
       return (
         <a
           {...props}

--- a/desktop/tests/e2e/smart-links.spec.ts
+++ b/desktop/tests/e2e/smart-links.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+});
+
+test("GitHub PR URL renders as an inline smart chip", async ({ page }) => {
+  const prUrl = "https://github.com/block/goose2/pull/125";
+  const message = `Check out ${prUrl} for the fix`;
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill(message);
+  await page.getByTestId("send-message").click();
+
+  const lastRow = page.getByTestId("message-row").last();
+
+  // The PR link should render as a styled chip with the repo and PR number
+  const prChip = lastRow.locator("a", { hasText: "block/goose2#125" });
+  await expect(prChip).toBeVisible();
+  await expect(prChip).toHaveAttribute("href", prUrl);
+
+  // Should contain the GitPullRequest icon (rendered as an SVG)
+  await expect(prChip.locator("svg")).toBeVisible();
+});
+
+test("GitHub PR chip links open in new tab", async ({ page }) => {
+  const prUrl = "https://github.com/block/sprout/pull/42";
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill(prUrl);
+  await page.getByTestId("send-message").click();
+
+  const lastRow = page.getByTestId("message-row").last();
+  const prChip = lastRow.locator("a", { hasText: "block/sprout#42" });
+  await expect(prChip).toHaveAttribute("target", "_blank");
+  await expect(prChip).toHaveAttribute("rel", "noreferrer");
+});
+
+test("non-PR GitHub links render as regular links", async ({ page }) => {
+  const repoUrl = "https://github.com/block/sprout";
+  const message = `Check out ${repoUrl}`;
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill(message);
+  await page.getByTestId("send-message").click();
+
+  const lastRow = page.getByTestId("message-row").last();
+
+  // Should render as a normal underlined link, not a chip
+  const link = lastRow.locator("a", { hasText: repoUrl });
+  await expect(link).toBeVisible();
+  // Regular links have underline styling, not the chip background
+  await expect(link.locator("svg")).not.toBeVisible();
+});

--- a/desktop/tests/e2e/smart-links.spec.ts
+++ b/desktop/tests/e2e/smart-links.spec.ts
@@ -72,6 +72,50 @@ test("selecting a PR chip copies the full URL, not the chip label", async ({
   await expect(visibleLabel).toBeVisible();
 });
 
+test("GitHub issue URL renders as an inline smart chip", async ({ page }) => {
+  const issueUrl = "https://github.com/block/sprout/issues/99";
+  const message = `See ${issueUrl} for context`;
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill(message);
+  await page.getByTestId("send-message").click();
+
+  const lastRow = page.getByTestId("message-row").last();
+
+  const issueChip = lastRow.locator("a", { hasText: "block/sprout#99" });
+  await expect(issueChip).toBeVisible();
+  await expect(issueChip).toHaveAttribute("href", issueUrl);
+  await expect(issueChip.locator("svg")).toBeVisible();
+});
+
+test("GitHub commit URL renders as an inline smart chip", async ({ page }) => {
+  const commitUrl =
+    "https://github.com/block/sprout/commit/abc1234def5678901234567890abcdef12345678";
+  const message = `Reverted in ${commitUrl}`;
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill(message);
+  await page.getByTestId("send-message").click();
+
+  const lastRow = page.getByTestId("message-row").last();
+
+  // Should show short SHA
+  const commitChip = lastRow.locator("a", {
+    hasText: "block/sprout@abc1234",
+  });
+  await expect(commitChip).toBeVisible();
+  await expect(commitChip).toHaveAttribute("href", commitUrl);
+  await expect(commitChip.locator("svg")).toBeVisible();
+});
+
 test("non-PR GitHub links render as regular links", async ({ page }) => {
   const repoUrl = "https://github.com/block/sprout";
   const message = `Check out ${repoUrl}`;

--- a/desktop/tests/e2e/smart-links.spec.ts
+++ b/desktop/tests/e2e/smart-links.spec.ts
@@ -46,6 +46,32 @@ test("GitHub PR chip links open in new tab", async ({ page }) => {
   await expect(prChip).toHaveAttribute("rel", "noreferrer");
 });
 
+test("selecting a PR chip copies the full URL, not the chip label", async ({
+  page,
+}) => {
+  const prUrl = "https://github.com/block/goose2/pull/125";
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill(prUrl);
+  await page.getByTestId("send-message").click();
+
+  const lastRow = page.getByTestId("message-row").last();
+  const prChip = lastRow.locator("a", { hasText: "block/goose2#125" });
+  await expect(prChip).toBeVisible();
+
+  // The hidden span should contain the full URL for selection/copy
+  const hiddenUrl = prChip.locator("span.overflow-hidden");
+  await expect(hiddenUrl).toHaveText(prUrl);
+
+  // The visible label should not be selectable
+  const visibleLabel = prChip.locator("span.select-none");
+  await expect(visibleLabel).toBeVisible();
+});
+
 test("non-PR GitHub links render as regular links", async ({ page }) => {
   const repoUrl = "https://github.com/block/sprout";
   const message = `Check out ${repoUrl}`;


### PR DESCRIPTION
## Summary
- GitHub PR, issue, and commit URLs in messages are rendered as inline smart chips with distinct icons (`GitPullRequest`, `CircleDot`, `GitCommitHorizontal`)
- Commit URLs display a 7-character short SHA (`owner/repo@abc1234`)
- Chips copy the full URL on text selection
- Agent typing indicator now shows a popover with runtime details and ACP log preview

## Test plan
- [ ] Send a message containing a GitHub PR URL → renders as chip with PR icon
- [ ] Send a message containing a GitHub issue URL → renders as chip with issue icon
- [ ] Send a message containing a GitHub commit URL → renders as chip with short SHA
- [ ] Verify non-GitHub links still render as regular underlined links
- [ ] Selecting chip text copies the full URL, not the label
- [ ] Click typing indicator avatar → popover shows agent runtime info

🤖 Generated with [Claude Code](https://claude.com/claude-code)