### PR TITLE
Allow bot owners to remove their agents from any channel

### DIFF
--- a/crates/sprout-db/src/channel.rs
+++ b/crates/sprout-db/src/channel.rs
@@ -405,7 +405,8 @@ pub async fn add_member(
 
 /// Remove a member from a channel (soft delete).
 ///
-/// `actor_pubkey` must be an active owner/admin, or the member removing themselves.
+/// `actor_pubkey` must be an active owner/admin, the agent's owner, or the member
+/// removing themselves.
 ///
 /// Returns `Err(DbError::MemberNotFound)` if the target is not an active member.
 /// The authorization check and the UPDATE run inside a transaction to prevent a
@@ -426,20 +427,12 @@ pub async fn remove_member(
         let actor_role: MemberRole = actor_role_str.parse().map_err(|_| {
             DbError::InvalidData(format!("invalid role in database: {actor_role_str}"))
         })?;
-        if !actor_role.is_elevated() {
-            // Check if actor is the agent owner of the target
-            let is_agent_owner = if let Some((_policy, Some(owner))) =
-                crate::user::get_agent_channel_policy(pool, pubkey).await?
-            {
-                owner == actor_pubkey
-            } else {
-                false
-            };
-            if !is_agent_owner {
-                return Err(DbError::AccessDenied(
-                    "only owners/admins or the agent's owner may remove other members".to_string(),
-                ));
-            }
+        if !actor_role.is_elevated()
+            && !crate::user::is_agent_owner(pool, pubkey, actor_pubkey).await?
+        {
+            return Err(DbError::AccessDenied(
+                "only owners/admins or the agent's owner may remove other members".to_string(),
+            ));
         }
     }
 

--- a/crates/sprout-db/src/channel.rs
+++ b/crates/sprout-db/src/channel.rs
@@ -409,8 +409,10 @@ pub async fn add_member(
 /// removing themselves.
 ///
 /// Returns `Err(DbError::MemberNotFound)` if the target is not an active member.
-/// The authorization check and the UPDATE run inside a transaction to prevent a
+/// The actor's role check and the UPDATE run inside a transaction to prevent a
 /// TOCTOU race where the actor's role changes between the check and the update.
+/// The `is_agent_owner` check runs outside the transaction against the main pool
+/// because `agent_owner_pubkey` is immutable (set once at token mint).
 pub async fn remove_member(
     pool: &PgPool,
     channel_id: Uuid,

--- a/crates/sprout-db/src/channel.rs
+++ b/crates/sprout-db/src/channel.rs
@@ -427,6 +427,8 @@ pub async fn remove_member(
         let actor_role: MemberRole = actor_role_str.parse().map_err(|_| {
             DbError::InvalidData(format!("invalid role in database: {actor_role_str}"))
         })?;
+        // Safe to query outside the transaction: agent_owner_pubkey is immutable
+        // (set once at token mint, first-mint-wins).
         if !actor_role.is_elevated()
             && !crate::user::is_agent_owner(pool, pubkey, actor_pubkey).await?
         {

--- a/crates/sprout-db/src/channel.rs
+++ b/crates/sprout-db/src/channel.rs
@@ -427,9 +427,19 @@ pub async fn remove_member(
             DbError::InvalidData(format!("invalid role in database: {actor_role_str}"))
         })?;
         if !actor_role.is_elevated() {
-            return Err(DbError::AccessDenied(
-                "only owners/admins may remove other members".to_string(),
-            ));
+            // Check if actor is the agent owner of the target
+            let is_agent_owner = if let Some((_policy, Some(owner))) =
+                crate::user::get_agent_channel_policy(pool, pubkey).await?
+            {
+                owner == actor_pubkey
+            } else {
+                false
+            };
+            if !is_agent_owner {
+                return Err(DbError::AccessDenied(
+                    "only owners/admins or the agent's owner may remove other members".to_string(),
+                ));
+            }
         }
     }
 
@@ -1146,4 +1156,127 @@ pub async fn reap_expired_ephemeral_channels(pool: &PgPool) -> Result<Vec<Uuid>>
             Ok(id)
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::user::{ensure_user, set_agent_owner};
+    use nostr::Keys;
+
+    const TEST_DB_URL: &str = "postgres://sprout:sprout_dev@localhost:5432/sprout";
+
+    async fn setup_pool() -> PgPool {
+        PgPool::connect(TEST_DB_URL)
+            .await
+            .expect("connect to test DB")
+    }
+
+    fn random_pubkey() -> Vec<u8> {
+        Keys::generate().public_key().serialize().to_vec()
+    }
+
+    /// Agent owner (non-admin) can remove their own bot from a channel.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn test_agent_owner_can_remove_bot() {
+        let pool = setup_pool().await;
+        let owner_pk = random_pubkey();
+        let agent_pk = random_pubkey();
+
+        // Create users and set agent ownership
+        ensure_user(&pool, &owner_pk).await.expect("ensure owner");
+        ensure_user(&pool, &agent_pk).await.expect("ensure agent");
+        set_agent_owner(&pool, &agent_pk, &owner_pk)
+            .await
+            .expect("set agent owner");
+
+        // Create a channel owned by someone else entirely
+        let channel_owner_pk = random_pubkey();
+        ensure_user(&pool, &channel_owner_pk)
+            .await
+            .expect("ensure channel owner");
+        let channel = create_channel(
+            &pool,
+            "test-bot-remove",
+            ChannelType::Stream,
+            ChannelVisibility::Open,
+            None,
+            &channel_owner_pk,
+            None,
+        )
+        .await
+        .expect("create channel");
+
+        // Add owner and agent as regular members
+        add_member(&pool, channel.id, &owner_pk, MemberRole::Member, None)
+            .await
+            .expect("add owner as member");
+        add_member(&pool, channel.id, &agent_pk, MemberRole::Member, None)
+            .await
+            .expect("add agent as member");
+
+        // Owner should be able to remove their agent
+        remove_member(&pool, channel.id, &agent_pk, &owner_pk)
+            .await
+            .expect("agent owner should be able to remove their bot");
+
+        // Verify the agent is no longer a member
+        assert!(
+            !is_member(&pool, channel.id, &agent_pk)
+                .await
+                .expect("is_member check"),
+            "agent should no longer be a member"
+        );
+    }
+
+    /// A random non-admin, non-owner user cannot remove someone else's bot.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn test_random_user_cannot_remove_bot() {
+        let pool = setup_pool().await;
+        let owner_pk = random_pubkey();
+        let agent_pk = random_pubkey();
+        let random_pk = random_pubkey();
+
+        // Create users and set agent ownership
+        ensure_user(&pool, &owner_pk).await.expect("ensure owner");
+        ensure_user(&pool, &agent_pk).await.expect("ensure agent");
+        ensure_user(&pool, &random_pk).await.expect("ensure random");
+        set_agent_owner(&pool, &agent_pk, &owner_pk)
+            .await
+            .expect("set agent owner");
+
+        // Create a channel
+        let channel_owner_pk = random_pubkey();
+        ensure_user(&pool, &channel_owner_pk)
+            .await
+            .expect("ensure channel owner");
+        let channel = create_channel(
+            &pool,
+            "test-bot-no-remove",
+            ChannelType::Stream,
+            ChannelVisibility::Open,
+            None,
+            &channel_owner_pk,
+            None,
+        )
+        .await
+        .expect("create channel");
+
+        // Add random user and agent as regular members
+        add_member(&pool, channel.id, &random_pk, MemberRole::Member, None)
+            .await
+            .expect("add random as member");
+        add_member(&pool, channel.id, &agent_pk, MemberRole::Member, None)
+            .await
+            .expect("add agent as member");
+
+        // Random user should NOT be able to remove the agent
+        let result = remove_member(&pool, channel.id, &agent_pk, &random_pk).await;
+        assert!(
+            result.is_err(),
+            "random user should not be able to remove someone else's bot"
+        );
+    }
 }

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -557,6 +557,11 @@ impl Db {
         user::get_agent_channel_policy(&self.pool, pubkey).await
     }
 
+    /// Check whether `actor_pubkey` is the agent owner of `target_pubkey`.
+    pub async fn is_agent_owner(&self, target_pubkey: &[u8], actor_pubkey: &[u8]) -> Result<bool> {
+        user::is_agent_owner(&self.pool, target_pubkey, actor_pubkey).await
+    }
+
     /// Set the channel_add_policy for a user.
     pub async fn set_channel_add_policy(&self, pubkey: &[u8], policy: &str) -> Result<()> {
         user::set_channel_add_policy(&self.pool, pubkey, policy).await

--- a/crates/sprout-db/src/user.rs
+++ b/crates/sprout-db/src/user.rs
@@ -325,14 +325,21 @@ pub async fn get_agent_channel_policy(
 }
 
 /// Check whether `actor_pubkey` is the `agent_owner_pubkey` of `target_pubkey`.
+/// Queries `agent_owner_pubkey` directly rather than going through
+/// `get_agent_channel_policy`, which would fetch unrelated fields.
 pub async fn is_agent_owner(
     pool: &PgPool,
     target_pubkey: &[u8],
     actor_pubkey: &[u8],
 ) -> Result<bool> {
-    Ok(
-        matches!(get_agent_channel_policy(pool, target_pubkey).await?, Some((_policy, Some(owner))) if owner == actor_pubkey),
+    let row = sqlx::query_scalar::<_, bool>(
+        "SELECT agent_owner_pubkey = $2 FROM users WHERE pubkey = $1 AND agent_owner_pubkey IS NOT NULL",
     )
+    .bind(target_pubkey)
+    .bind(actor_pubkey)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.unwrap_or(false))
 }
 
 /// Set the channel_add_policy for a user.

--- a/crates/sprout-db/src/user.rs
+++ b/crates/sprout-db/src/user.rs
@@ -324,6 +324,17 @@ pub async fn get_agent_channel_policy(
     .transpose()
 }
 
+/// Check whether `actor_pubkey` is the `agent_owner_pubkey` of `target_pubkey`.
+pub async fn is_agent_owner(
+    pool: &PgPool,
+    target_pubkey: &[u8],
+    actor_pubkey: &[u8],
+) -> Result<bool> {
+    Ok(
+        matches!(get_agent_channel_policy(pool, target_pubkey).await?, Some((_policy, Some(owner))) if owner == actor_pubkey),
+    )
+}
+
 /// Set the channel_add_policy for a user.
 /// Returns an error if the pubkey is not found (rows_affected == 0).
 /// Returns an error if `policy` is not one of the valid ENUM values.

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -216,6 +216,9 @@ pub async fn validate_admin_event(
                             Err(anyhow::anyhow!("actor not authorized"))
                         }
                     }
+                    // Non-members fall here. We intentionally do NOT check
+                    // is_agent_owner for non-members — you must be in the channel
+                    // to remove anyone, even your own bot.
                     _ => Err(anyhow::anyhow!("actor not authorized")),
                 }
             }

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -205,6 +205,17 @@ pub async fn validate_admin_event(
                 let actor_member = members.iter().find(|m| m.pubkey == actor_bytes);
                 match actor_member {
                     Some(m) if m.role == "owner" || m.role == "admin" => Ok(()),
+                    Some(_) => {
+                        // Check if actor is agent owner of target
+                        if let Some((_policy, Some(owner))) =
+                            state.db.get_agent_channel_policy(&target_pubkey).await?
+                        {
+                            if owner == actor_bytes {
+                                return Ok(());
+                            }
+                        }
+                        Err(anyhow::anyhow!("actor not authorized"))
+                    }
                     _ => Err(anyhow::anyhow!("actor not authorized")),
                 }
             }

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -206,15 +206,15 @@ pub async fn validate_admin_event(
                 match actor_member {
                     Some(m) if m.role == "owner" || m.role == "admin" => Ok(()),
                     Some(_) => {
-                        // Check if actor is agent owner of target
-                        if let Some((_policy, Some(owner))) =
-                            state.db.get_agent_channel_policy(&target_pubkey).await?
+                        if state
+                            .db
+                            .is_agent_owner(&target_pubkey, &actor_bytes)
+                            .await?
                         {
-                            if owner == actor_bytes {
-                                return Ok(());
-                            }
+                            Ok(())
+                        } else {
+                            Err(anyhow::anyhow!("actor not authorized"))
                         }
-                        Err(anyhow::anyhow!("actor not authorized"))
                     }
                     _ => Err(anyhow::anyhow!("actor not authorized")),
                 }

--- a/desktop/src/features/channels/lib/useClassifiedMembers.ts
+++ b/desktop/src/features/channels/lib/useClassifiedMembers.ts
@@ -40,6 +40,13 @@ export function useClassifiedMembers(
     [managedAgentPubkeys, relayAgentPubkeys],
   );
 
+  const isMyBot = React.useCallback(
+    (member: ChannelMember) => {
+      return managedAgentPubkeys.has(normalizePubkey(member.pubkey));
+    },
+    [managedAgentPubkeys],
+  );
+
   const { people, bots } = React.useMemo(() => {
     const peopleList: ChannelMember[] = [];
     const botList: ChannelMember[] = [];
@@ -66,6 +73,7 @@ export function useClassifiedMembers(
     peopleCount: people.length,
     botCount: bots.length,
     isBot,
+    isMyBot,
     managedAgentsQuery,
     relayAgentsQuery,
   };

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -81,7 +81,7 @@ export function MembersSidebar({
     const canRemoveMember =
       (selfMember?.role === "admin" && member.pubkey !== currentPubkey) ||
       (selfMember?.role === "owner" && isBot(member)) ||
-      isMyBot(member) ||
+      (selfMember && isMyBot(member)) ||
       (currentPubkey && member.pubkey === currentPubkey);
     const memberLabel = formatMemberName(member, currentPubkey);
     const profile =

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -78,6 +78,7 @@ export function MembersSidebar({
   }
 
   function renderMemberCard(member: ChannelMember, memberIsBot: boolean) {
+    // Any channel member can remove bots they own, regardless of role.
     const canRemoveMember =
       (selfMember?.role === "admin" && member.pubkey !== currentPubkey) ||
       (selfMember?.role === "owner" && isBot(member)) ||

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -50,7 +50,7 @@ export function MembersSidebar({
   const removeMemberMutation = useRemoveChannelMemberMutation(channelId);
 
   const rawMembers = membersQuery.data ?? [];
-  const { people, bots, isBot } = useClassifiedMembers(
+  const { people, bots, isBot, isMyBot } = useClassifiedMembers(
     rawMembers,
     currentPubkey,
   );
@@ -81,6 +81,7 @@ export function MembersSidebar({
     const canRemoveMember =
       (selfMember?.role === "admin" && member.pubkey !== currentPubkey) ||
       (selfMember?.role === "owner" && isBot(member)) ||
+      isMyBot(member) ||
       (currentPubkey && member.pubkey === currentPubkey);
     const memberLabel = formatMemberName(member, currentPubkey);
     const profile =


### PR DESCRIPTION
## Summary
- Adds `is_agent_owner()` DB helper that checks if a user is the owner of a bot agent (via `agent_owner_pubkey`, set immutably at token mint)
- Updates relay kind 9001 validation to allow agent owners to remove their bots even when they're not a channel owner/admin
- Adds `isMyBot()` frontend helper and updates `canRemoveMember` logic in MembersSidebar so bot owners see the Remove button for their agents regardless of channel role

## Motivation
Users can add their bots to other people's channels but previously couldn't remove them unless they were a channel owner/admin. This aligns with the VISION.md principle of letting users manage their own agents.

## Test plan
- [ ] Verify bot owner can see Remove button on their bots in channels they don't own
- [ ] Verify clicking Remove successfully removes the bot (relay accepts the request)
- [ ] Verify non-owners still cannot remove other people's bots
- [ ] Verify existing admin/owner removal permissions still work
- [ ] Integration tests in `channel.rs` cover happy path + negative case

🤖 Generated with [Claude Code](https://claude.com/claude-code)