### PR TITLE
Remove menu item subtitles and fix persona card overflow

### DIFF
--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -321,14 +321,14 @@ function AgentActionsMenu({
               onClick={() => onStart(agent.pubkey)}
             >
               <Play className="h-4 w-4" />
-              <span>{isActive ? "Redeploy" : "Deploy"}</span>
+              {isActive ? "Redeploy" : "Deploy"}
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={isActionPending}
               onClick={() => onStop(agent.pubkey)}
             >
               <Square className="h-4 w-4" />
-              <span>Shutdown</span>
+              Shutdown
             </DropdownMenuItem>
           </>
         ) : isActive ? (
@@ -337,7 +337,7 @@ function AgentActionsMenu({
             onClick={() => onStop(agent.pubkey)}
           >
             <Square className="h-4 w-4" />
-            <span>Stop</span>
+            Stop
           </DropdownMenuItem>
         ) : (
           <DropdownMenuItem
@@ -345,7 +345,7 @@ function AgentActionsMenu({
             onClick={() => onStart(agent.pubkey)}
           >
             <Play className="h-4 w-4" />
-            <span>Spawn</span>
+            Spawn
           </DropdownMenuItem>
         )}
 
@@ -354,7 +354,7 @@ function AgentActionsMenu({
           onClick={() => onAddToChannel(agent)}
         >
           <UserPlus className="h-4 w-4" />
-          <span>Add to channel</span>
+          Add to channel
         </DropdownMenuItem>
 
         <DropdownMenuItem
@@ -362,20 +362,20 @@ function AgentActionsMenu({
           onClick={() => onMintToken(agent.pubkey, agent.name)}
         >
           <KeyRound className="h-4 w-4" />
-          <span>Mint token</span>
+          Mint token
         </DropdownMenuItem>
 
         <DropdownMenuItem
           onClick={() => navigator.clipboard.writeText(agent.pubkey)}
         >
           <Clipboard className="h-4 w-4" />
-          <span>Copy pubkey</span>
+          Copy pubkey
         </DropdownMenuItem>
 
         {agent.backend.type === "local" ? (
           <DropdownMenuItem onClick={() => onOpenLogs(agent.pubkey)}>
             <FileText className="h-4 w-4" />
-            <span>View logs</span>
+            View logs
           </DropdownMenuItem>
         ) : null}
 
@@ -387,11 +387,9 @@ function AgentActionsMenu({
             }
           >
             <Power className="h-4 w-4" />
-            <span>
-              {agent.startOnAppLaunch
-                ? "Disable auto-start"
-                : "Enable auto-start"}
-            </span>
+            {agent.startOnAppLaunch
+              ? "Disable auto-start"
+              : "Enable auto-start"}
           </DropdownMenuItem>
         ) : null}
 
@@ -403,7 +401,7 @@ function AgentActionsMenu({
           onClick={() => onDelete(agent.pubkey)}
         >
           <Trash2 className="h-4 w-4" />
-          <span>Delete</span>
+          Delete
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -321,26 +321,14 @@ function AgentActionsMenu({
               onClick={() => onStart(agent.pubkey)}
             >
               <Play className="h-4 w-4" />
-              <div className="flex flex-col">
-                <span>{isActive ? "Redeploy" : "Deploy"}</span>
-                <span className="text-xs font-normal text-muted-foreground">
-                  {isActive
-                    ? "Push a new deployment to the provider"
-                    : "Deploy this agent to the provider"}
-                </span>
-              </div>
+              <span>{isActive ? "Redeploy" : "Deploy"}</span>
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={isActionPending}
               onClick={() => onStop(agent.pubkey)}
             >
               <Square className="h-4 w-4" />
-              <div className="flex flex-col">
-                <span>Shutdown</span>
-                <span className="text-xs font-normal text-muted-foreground">
-                  Stop the provider deployment and free its resources
-                </span>
-              </div>
+              <span>Shutdown</span>
             </DropdownMenuItem>
           </>
         ) : isActive ? (
@@ -349,12 +337,7 @@ function AgentActionsMenu({
             onClick={() => onStop(agent.pubkey)}
           >
             <Square className="h-4 w-4" />
-            <div className="flex flex-col">
-              <span>Stop</span>
-              <span className="text-xs font-normal text-muted-foreground">
-                Stop the running ACP harness process
-              </span>
-            </div>
+            <span>Stop</span>
           </DropdownMenuItem>
         ) : (
           <DropdownMenuItem
@@ -362,12 +345,7 @@ function AgentActionsMenu({
             onClick={() => onStart(agent.pubkey)}
           >
             <Play className="h-4 w-4" />
-            <div className="flex flex-col">
-              <span>Spawn</span>
-              <span className="text-xs font-normal text-muted-foreground">
-                Launch the local ACP harness process for this agent
-              </span>
-            </div>
+            <span>Spawn</span>
           </DropdownMenuItem>
         )}
 
@@ -376,13 +354,7 @@ function AgentActionsMenu({
           onClick={() => onAddToChannel(agent)}
         >
           <UserPlus className="h-4 w-4" />
-          <div className="flex flex-col">
-            <span>Add to channel</span>
-            <span className="text-xs font-normal text-muted-foreground">
-              Invite this agent to a channel so it can participate in
-              conversations
-            </span>
-          </div>
+          <span>Add to channel</span>
         </DropdownMenuItem>
 
         <DropdownMenuItem
@@ -390,36 +362,20 @@ function AgentActionsMenu({
           onClick={() => onMintToken(agent.pubkey, agent.name)}
         >
           <KeyRound className="h-4 w-4" />
-          <div className="flex flex-col">
-            <span>Mint token</span>
-            <span className="text-xs font-normal text-muted-foreground">
-              Generate a bearer token this agent uses to authenticate with the
-              relay
-            </span>
-          </div>
+          <span>Mint token</span>
         </DropdownMenuItem>
 
         <DropdownMenuItem
           onClick={() => navigator.clipboard.writeText(agent.pubkey)}
         >
           <Clipboard className="h-4 w-4" />
-          <div className="flex flex-col">
-            <span>Copy pubkey</span>
-            <span className="text-xs font-normal text-muted-foreground">
-              Copy the agent&apos;s public key to the clipboard
-            </span>
-          </div>
+          <span>Copy pubkey</span>
         </DropdownMenuItem>
 
         {agent.backend.type === "local" ? (
           <DropdownMenuItem onClick={() => onOpenLogs(agent.pubkey)}>
             <FileText className="h-4 w-4" />
-            <div className="flex flex-col">
-              <span>View logs</span>
-              <span className="text-xs font-normal text-muted-foreground">
-                Show the ACP harness stdout/stderr log inline
-              </span>
-            </div>
+            <span>View logs</span>
           </DropdownMenuItem>
         ) : null}
 
@@ -431,18 +387,11 @@ function AgentActionsMenu({
             }
           >
             <Power className="h-4 w-4" />
-            <div className="flex flex-col">
-              <span>
-                {agent.startOnAppLaunch
-                  ? "Disable auto-start"
-                  : "Enable auto-start"}
-              </span>
-              <span className="text-xs font-normal text-muted-foreground">
-                {agent.startOnAppLaunch
-                  ? "Stop launching this agent automatically when the desktop app starts"
-                  : "Launch this agent automatically every time the desktop app starts"}
-              </span>
-            </div>
+            <span>
+              {agent.startOnAppLaunch
+                ? "Disable auto-start"
+                : "Enable auto-start"}
+            </span>
           </DropdownMenuItem>
         ) : null}
 
@@ -454,12 +403,7 @@ function AgentActionsMenu({
           onClick={() => onDelete(agent.pubkey)}
         >
           <Trash2 className="h-4 w-4" />
-          <div className="flex flex-col">
-            <span>Delete</span>
-            <span className="text-xs font-normal text-muted-foreground">
-              Permanently remove this agent profile from the desktop app
-            </span>
-          </div>
+          <span>Delete</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/desktop/src/features/agents/ui/PersonaIdentity.tsx
+++ b/desktop/src/features/agents/ui/PersonaIdentity.tsx
@@ -2,6 +2,7 @@ import { Info } from "lucide-react";
 
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import type { AgentPersona } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
 import { promptPreview } from "@/shared/lib/promptPreview";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
@@ -21,7 +22,7 @@ export function PersonaIdentity({
   const preview = promptPreview(persona.systemPrompt);
 
   return (
-    <div className={className}>
+    <div className={cn("min-w-0 flex-1", className)}>
       <div className="flex min-w-0 items-center gap-2.5">
         <ProfileAvatar
           avatarUrl={persona.avatarUrl}
@@ -29,7 +30,7 @@ export function PersonaIdentity({
           label={persona.displayName}
         />
         <div className="min-w-0">
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2">
             <p className="truncate text-sm font-semibold tracking-tight">
               {persona.displayName}
             </p>

--- a/desktop/src/features/agents/ui/PersonasSection.tsx
+++ b/desktop/src/features/agents/ui/PersonasSection.tsx
@@ -155,7 +155,7 @@ export function PersonasSection({
                         onClick={() => onEdit(persona)}
                       >
                         <Pencil className="h-4 w-4" />
-                        <span>Edit</span>
+                        Edit
                       </DropdownMenuItem>
                     ) : null}
                     <DropdownMenuItem
@@ -163,14 +163,14 @@ export function PersonasSection({
                       onClick={() => onDuplicate(persona)}
                     >
                       <CopyPlus className="h-4 w-4" />
-                      <span>Duplicate</span>
+                      Duplicate
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       disabled={isPending}
                       onClick={() => onExport(persona)}
                     >
                       <Download className="h-4 w-4" />
-                      <span>Export</span>
+                      Export
                     </DropdownMenuItem>
                     {persona.isBuiltIn ? (
                       <DropdownMenuItem
@@ -179,7 +179,7 @@ export function PersonasSection({
                         onClick={() => onDeactivate(persona)}
                       >
                         <Trash2 className="h-4 w-4" />
-                        <span>Remove from My Agents</span>
+                        Remove from My Agents
                       </DropdownMenuItem>
                     ) : (
                       <DropdownMenuItem
@@ -188,7 +188,7 @@ export function PersonasSection({
                         onClick={() => onDelete(persona)}
                       >
                         <Trash2 className="h-4 w-4" />
-                        <span>Delete</span>
+                        Delete
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>

--- a/desktop/src/features/agents/ui/PersonasSection.tsx
+++ b/desktop/src/features/agents/ui/PersonasSection.tsx
@@ -155,13 +155,7 @@ export function PersonasSection({
                         onClick={() => onEdit(persona)}
                       >
                         <Pencil className="h-4 w-4" />
-                        <div className="flex flex-col">
-                          <span>Edit</span>
-                          <span className="text-xs font-normal text-muted-foreground">
-                            Edit this persona&apos;s name, avatar, and system
-                            prompt
-                          </span>
-                        </div>
+                        <span>Edit</span>
                       </DropdownMenuItem>
                     ) : null}
                     <DropdownMenuItem
@@ -169,26 +163,14 @@ export function PersonasSection({
                       onClick={() => onDuplicate(persona)}
                     >
                       <CopyPlus className="h-4 w-4" />
-                      <div className="flex flex-col">
-                        <span>Duplicate</span>
-                        <span className="text-xs font-normal text-muted-foreground">
-                          Create a copy of this persona you can customize
-                          independently
-                        </span>
-                      </div>
+                      <span>Duplicate</span>
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       disabled={isPending}
                       onClick={() => onExport(persona)}
                     >
                       <Download className="h-4 w-4" />
-                      <div className="flex flex-col">
-                        <span>Export</span>
-                        <span className="text-xs font-normal text-muted-foreground">
-                          Save this persona as a .persona.json file you can
-                          share or back up
-                        </span>
-                      </div>
+                      <span>Export</span>
                     </DropdownMenuItem>
                     {persona.isBuiltIn ? (
                       <DropdownMenuItem
@@ -197,12 +179,7 @@ export function PersonasSection({
                         onClick={() => onDeactivate(persona)}
                       >
                         <Trash2 className="h-4 w-4" />
-                        <div className="flex flex-col">
-                          <span>Remove from My Agents</span>
-                          <span className="text-xs font-normal text-muted-foreground">
-                            Remove this built-in persona from your agent library
-                          </span>
-                        </div>
+                        <span>Remove from My Agents</span>
                       </DropdownMenuItem>
                     ) : (
                       <DropdownMenuItem
@@ -211,12 +188,7 @@ export function PersonasSection({
                         onClick={() => onDelete(persona)}
                       >
                         <Trash2 className="h-4 w-4" />
-                        <div className="flex flex-col">
-                          <span>Delete</span>
-                          <span className="text-xs font-normal text-muted-foreground">
-                            Permanently delete this persona
-                          </span>
-                        </div>
+                        <span>Delete</span>
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>

--- a/desktop/src/features/agents/ui/PersonasSection.tsx
+++ b/desktop/src/features/agents/ui/PersonasSection.tsx
@@ -127,7 +127,7 @@ export function PersonasSection({
         <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-4">
           {personas.map((persona) => (
             <div
-              className="rounded-xl border border-border/70 bg-card/80 p-2 shadow-sm"
+              className="overflow-hidden rounded-xl border border-border/70 bg-card/80 p-2 shadow-sm"
               data-testid={`library-persona-${persona.id}`}
               key={persona.id}
             >

--- a/desktop/src/features/agents/ui/TeamsSection.tsx
+++ b/desktop/src/features/agents/ui/TeamsSection.tsx
@@ -202,7 +202,7 @@ export function TeamsSection({
                         onClick={() => onAddToChannel(team)}
                       >
                         <Rocket className="h-4 w-4" />
-                        <span>Deploy to channel</span>
+                        Deploy to channel
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
@@ -210,21 +210,21 @@ export function TeamsSection({
                         onClick={() => onEdit(team)}
                       >
                         <Pencil className="h-4 w-4" />
-                        <span>Edit</span>
+                        Edit
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onDuplicate(team)}
                       >
                         <CopyPlus className="h-4 w-4" />
-                        <span>Duplicate</span>
+                        Duplicate
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onExport(team)}
                       >
                         <Download className="h-4 w-4" />
-                        <span>Export</span>
+                        Export
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
@@ -233,7 +233,7 @@ export function TeamsSection({
                         onClick={() => onDelete(team)}
                       >
                         <Trash2 className="h-4 w-4" />
-                        <span>Delete</span>
+                        Delete
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>

--- a/desktop/src/features/agents/ui/TeamsSection.tsx
+++ b/desktop/src/features/agents/ui/TeamsSection.tsx
@@ -202,12 +202,7 @@ export function TeamsSection({
                         onClick={() => onAddToChannel(team)}
                       >
                         <Rocket className="h-4 w-4" />
-                        <div className="flex flex-col">
-                          <span>Deploy to channel</span>
-                          <span className="text-xs font-normal text-muted-foreground">
-                            Add all personas in this team to a channel at once
-                          </span>
-                        </div>
+                        <span>Deploy to channel</span>
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
@@ -215,39 +210,21 @@ export function TeamsSection({
                         onClick={() => onEdit(team)}
                       >
                         <Pencil className="h-4 w-4" />
-                        <div className="flex flex-col">
-                          <span>Edit</span>
-                          <span className="text-xs font-normal text-muted-foreground">
-                            Edit this team&apos;s name, description, and persona
-                            membership
-                          </span>
-                        </div>
+                        <span>Edit</span>
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onDuplicate(team)}
                       >
                         <CopyPlus className="h-4 w-4" />
-                        <div className="flex flex-col">
-                          <span>Duplicate</span>
-                          <span className="text-xs font-normal text-muted-foreground">
-                            Create a copy of this team you can customize
-                            independently
-                          </span>
-                        </div>
+                        <span>Duplicate</span>
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         disabled={isPending || hasMissingPersonas}
                         onClick={() => onExport(team)}
                       >
                         <Download className="h-4 w-4" />
-                        <div className="flex flex-col">
-                          <span>Export</span>
-                          <span className="text-xs font-normal text-muted-foreground">
-                            Save this team as a .team.json file you can share or
-                            back up
-                          </span>
-                        </div>
+                        <span>Export</span>
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
@@ -256,12 +233,7 @@ export function TeamsSection({
                         onClick={() => onDelete(team)}
                       >
                         <Trash2 className="h-4 w-4" />
-                        <div className="flex flex-col">
-                          <span>Delete</span>
-                          <span className="text-xs font-normal text-muted-foreground">
-                            Permanently delete this team
-                          </span>
-                        </div>
+                        <span>Delete</span>
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>


### PR DESCRIPTION
## Summary
- Removed subtitle description text from all DropdownMenuItem components across agent action menus, persona menus, and team menus (3 files, net -114 lines). These looked cluttered in the app UI.
- Fixed persona card overflow where the 3-dot menu button would escape the card boundary at small window widths by adding proper flex shrink constraints to `PersonaIdentity`.

## Changes
- **ManagedAgentRow.tsx** — Stripped subtitles from 10 menu items in AgentActionsMenu
- **PersonasSection.tsx** — Stripped subtitles from 5 menu items + added `overflow-hidden` to card container
- **TeamsSection.tsx** — Stripped subtitles from 5 menu items
- **PersonaIdentity.tsx** — Added `min-w-0 flex-1` to outer div and `min-w-0` to name row so truncation works at small widths

Form field descriptions in `CreateAgentDialogSections.tsx` are intentionally preserved.

## Test plan
- [ ] Verify dropdown menus in My Agents, Personas, and Teams sections show clean `Icon + Label` items with no subtitle text
- [ ] Resize window to small width and confirm persona cards truncate the name instead of overflowing the 3-dot menu outside the card
- [ ] Confirm form field descriptions in the Create Agent dialog still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)