### PR TITLE
Fix flaky desktop smoke tests

### DIFF
--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -396,6 +396,9 @@ declare global {
     __SPROUT_E2E__?: E2eConfig;
     __SPROUT_E2E_COMMANDS__?: string[];
     __SPROUT_E2E_WEBVIEW_ZOOM__?: number;
+    __SPROUT_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+      channelName: string;
+    }) => boolean;
     __SPROUT_E2E_EMIT_MOCK_MESSAGE__?: (input: {
       channelName: string;
       content: string;
@@ -1621,6 +1624,21 @@ function emitMockLiveEvent(channelId: string, event: RelayEvent) {
       }
     }
   }
+}
+
+function hasMockLiveSubscription(channelId: string) {
+  for (const socket of mockSockets.values()) {
+    for (const subscribedChannelId of socket.subscriptions.values()) {
+      if (
+        subscribedChannelId === channelId ||
+        subscribedChannelId === GLOBAL_MOCK_SUBSCRIPTION
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 function recordMockMessage(channelId: string, event: RelayEvent) {
@@ -4006,6 +4024,16 @@ export function maybeInstallE2eTauriMocks() {
 
     return emitMockTypingIndicator(channel.id, pubkey ?? CHARLIE_PUBKEY);
   };
+  window.__SPROUT_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__ = ({ channelName }) => {
+    const channel = mockChannels.find(
+      (candidate) => candidate.name === channelName,
+    );
+    if (!channel) {
+      throw new Error(`Mock channel ${channelName} not found.`);
+    }
+
+    return hasMockLiveSubscription(channel.id);
+  };
   window.__SPROUT_E2E_PUSH_MOCK_FEED_ITEM__ = (item) => {
     const category = item.category === "mention" ? "mentions" : item.category;
     mockFeedOverrides[category].unshift(item);
@@ -4354,6 +4382,11 @@ export function maybeInstallE2eTauriMocks() {
         }
 
         return disconnectMockSocket((payload as { id: number }).id);
+      case "plugin:window|show":
+      case "plugin:window|unminimize":
+      case "plugin:window|set_focus":
+      case "plugin:window|set_badge_count":
+        return null;
       case "get_channel_workflows":
         return handleGetChannelWorkflows(
           payload as Parameters<typeof handleGetChannelWorkflows>[0],

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -29,6 +29,29 @@ async function openMembersSidebar(
   await expect(page.getByTestId("members-sidebar")).toBeVisible();
 }
 
+async function waitForMockLiveSubscription(
+  page: import("@playwright/test").Page,
+  channelName: string,
+) {
+  await expect
+    .poll(async () => {
+      return page.evaluate((currentChannelName) => {
+        return (
+          (
+            window as Window & {
+              __SPROUT_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                channelName: string;
+              }) => boolean;
+            }
+          ).__SPROUT_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+            channelName: currentChannelName,
+          }) ?? false
+        );
+      }, channelName);
+    })
+    .toBe(true);
+}
+
 async function openMemberMenu(
   page: import("@playwright/test").Page,
   pubkey: string,
@@ -452,7 +475,7 @@ test("shows and clears typing indicators for active channel bots", async ({
 
   await page.getByTestId("channel-agents").click();
   await expect(page.getByTestId("chat-title")).toHaveText("agents");
-  await page.waitForTimeout(300);
+  await waitForMockLiveSubscription(page, "agents");
 
   await page.evaluate((pubkey) => {
     window.__SPROUT_E2E_EMIT_MOCK_TYPING__?.({
@@ -495,7 +518,7 @@ test("typing indicator shows avatars and maintains stable name order", async ({
 
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
-  await page.waitForTimeout(300);
+  await waitForMockLiveSubscription(page, "general");
 
   // Alice starts typing first
   await page.evaluate((pubkey) => {

--- a/desktop/tests/e2e/smoke.spec.ts
+++ b/desktop/tests/e2e/smoke.spec.ts
@@ -40,6 +40,37 @@ async function ensureTimelineScrollable(
   expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight + 160);
 }
 
+async function openSearchDialogWithShortcut(
+  page: import("@playwright/test").Page,
+) {
+  const searchDialog = page.getByTestId("search-dialog");
+  const openSearchButton = page.getByTestId("open-search");
+  const shortcut = process.platform === "darwin" ? "Meta+K" : "Control+K";
+
+  await expect(openSearchButton).toBeVisible();
+  await expect
+    .poll(async () => {
+      if (await searchDialog.isVisible()) {
+        return true;
+      }
+
+      await page.keyboard.press(shortcut);
+      return searchDialog.isVisible();
+    })
+    .toBe(true);
+}
+
+async function openSearchDialogWithButton(
+  page: import("@playwright/test").Page,
+) {
+  const searchDialog = page.getByTestId("search-dialog");
+  const openSearchButton = page.getByTestId("open-search");
+
+  await expect(openSearchButton).toBeVisible();
+  await openSearchButton.click();
+  await expect(searchDialog).toBeVisible();
+}
+
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
 });
@@ -141,11 +172,7 @@ test("opens relay-backed search from the sidebar and loads the exact result", as
 }) => {
   await page.goto("/");
 
-  await expect(page.getByTestId("open-search")).toBeVisible();
-  await page.keyboard.press(
-    process.platform === "darwin" ? "Meta+K" : "Control+K",
-  );
-  await expect(page.getByTestId("search-dialog")).toBeVisible();
+  await openSearchDialogWithShortcut(page);
 
   await page.getByTestId("search-input").fill("shipped");
   await expect(page.getByTestId("search-results")).toContainText(
@@ -171,10 +198,7 @@ test("search results use your resolved profile label instead of You", async ({
 }) => {
   await page.goto("/");
 
-  await page.keyboard.press(
-    process.platform === "darwin" ? "Meta+K" : "Control+K",
-  );
-  await expect(page.getByTestId("search-dialog")).toBeVisible();
+  await openSearchDialogWithButton(page);
 
   await page.getByTestId("search-input").fill("welcome");
   const results = page.getByTestId("search-results");
@@ -189,10 +213,7 @@ test("opens accessible unjoined channels from search in read-only mode", async (
 }) => {
   await page.goto("/");
 
-  await page.keyboard.press(
-    process.platform === "darwin" ? "Meta+K" : "Control+K",
-  );
-  await expect(page.getByTestId("search-dialog")).toBeVisible();
+  await openSearchDialogWithButton(page);
 
   await page.getByTestId("search-input").fill("critique");
   const results = page.getByTestId("search-results");


### PR DESCRIPTION
## Summary
- add missing mocked window commands so the desktop app no longer crashes into the generic error screen in mock-mode smoke runs
- wait for the mock live subscription before asserting typing indicators, removing the channel typing race without going back to blind sleeps
- keep search smoke coverage stable while still proving the Cmd/Ctrl+K shortcut path explicitly

## Validation
- `pnpm test:e2e:smoke` (83/83)
- pre-commit and pre-push hooks (`pnpm check`, `pnpm build`, Rust fmt, Rust clippy)

## Review
- ran Codex CLI as an adversarial reviewer against the diff
- addressed the two findings it surfaced: typing subscription readiness and preserving shortcut coverage
