### PR TITLE
chore: improve chat message layout to left-aligned design

### DIFF
--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -73,11 +73,11 @@ export function MessageActionBar({
     <div
       className={cn(
         "max-w-36 overflow-hidden rounded-full border border-border/70 bg-background/95 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/85 transition-all duration-150 ease-out",
-        "translate-y-0 opacity-100 sm:max-w-0 sm:translate-y-1 sm:opacity-0",
-        "sm:group-hover/message:max-w-36 sm:group-hover/message:translate-y-0 sm:group-hover/message:opacity-100",
-        "sm:group-focus-within/message:max-w-36 sm:group-focus-within/message:translate-y-0 sm:group-focus-within/message:opacity-100",
+        "translate-y-0 opacity-100 sm:max-w-0 sm:h-0 sm:border-0 sm:shadow-none sm:p-0 sm:translate-y-1 sm:opacity-0",
+        "sm:group-hover/message:max-w-36 sm:group-hover/message:h-auto sm:group-hover/message:border sm:group-hover/message:border-border/70 sm:group-hover/message:shadow-sm sm:group-hover/message:translate-y-0 sm:group-hover/message:opacity-100",
+        "sm:group-focus-within/message:max-w-36 sm:group-focus-within/message:h-auto sm:group-focus-within/message:border sm:group-focus-within/message:border-border/70 sm:group-focus-within/message:shadow-sm sm:group-focus-within/message:translate-y-0 sm:group-focus-within/message:opacity-100",
         isReplyingToMessage || isReactionPickerOpen
-          ? "sm:max-w-36 sm:translate-y-0 sm:opacity-100"
+          ? "sm:max-w-36 sm:h-auto sm:border sm:border-border/70 sm:shadow-sm sm:translate-y-0 sm:opacity-100"
           : "",
       )}
       data-testid={`message-action-bar-${message.id}`}

--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -73,11 +73,11 @@ export function MessageActionBar({
     <div
       className={cn(
         "max-w-36 overflow-hidden rounded-full border border-border/70 bg-background/95 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/85 transition-all duration-150 ease-out",
-        "translate-y-0 opacity-100 sm:max-w-0 sm:h-0 sm:border-0 sm:shadow-none sm:p-0 sm:translate-y-1 sm:opacity-0",
-        "sm:group-hover/message:max-w-36 sm:group-hover/message:h-auto sm:group-hover/message:border sm:group-hover/message:border-border/70 sm:group-hover/message:shadow-sm sm:group-hover/message:translate-y-0 sm:group-hover/message:opacity-100",
-        "sm:group-focus-within/message:max-w-36 sm:group-focus-within/message:h-auto sm:group-focus-within/message:border sm:group-focus-within/message:border-border/70 sm:group-focus-within/message:shadow-sm sm:group-focus-within/message:translate-y-0 sm:group-focus-within/message:opacity-100",
+        "translate-y-0 opacity-100 sm:max-w-0 sm:border-0 sm:shadow-none sm:translate-y-1 sm:opacity-0",
+        "sm:group-hover/message:max-w-36 sm:group-hover/message:border sm:group-hover/message:border-border/70 sm:group-hover/message:shadow-sm sm:group-hover/message:translate-y-0 sm:group-hover/message:opacity-100",
+        "sm:group-focus-within/message:max-w-36 sm:group-focus-within/message:border sm:group-focus-within/message:border-border/70 sm:group-focus-within/message:shadow-sm sm:group-focus-within/message:translate-y-0 sm:group-focus-within/message:opacity-100",
         isReplyingToMessage || isReactionPickerOpen
-          ? "sm:max-w-36 sm:h-auto sm:border sm:border-border/70 sm:shadow-sm sm:translate-y-0 sm:opacity-100"
+          ? "sm:max-w-36 sm:border sm:border-border/70 sm:shadow-sm sm:translate-y-0 sm:opacity-100"
           : "",
       )}
       data-testid={`message-action-bar-${message.id}`}

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -496,7 +496,7 @@ export function MessageComposer({
 
   return (
     <footer className="border-t border-border/80 bg-background p-4">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-3">
+      <div className="flex w-full flex-col gap-3">
         <form
           className="relative rounded-2xl border border-input bg-card px-3 py-4 shadow-sm sm:px-4"
           data-testid="message-composer"

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -176,7 +176,7 @@ export const MessageRow = React.memo(
           data-message-id={message.id}
           data-testid="message-row"
         >
-          <div className="mt-px flex shrink-0 items-start gap-1">
+          <div className="flex shrink-0 items-start gap-1">
             {isBotInstance(message.role) ? (
               <BotIdenticon
                 value={message.author}
@@ -193,6 +193,7 @@ export const MessageRow = React.memo(
                   <UserAvatar
                     accent={message.accent}
                     avatarUrl={message.avatarUrl ?? null}
+                    className="!h-[42px] !w-[42px]"
                     displayName={message.author}
                     testId="message-avatar"
                   />
@@ -202,7 +203,7 @@ export const MessageRow = React.memo(
               <UserAvatar
                 accent={message.accent}
                 avatarUrl={message.avatarUrl ?? null}
-                className="shrink-0"
+                className="shrink-0 !h-[42px] !w-[42px]"
                 displayName={message.author}
                 testId="message-avatar"
               />

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -167,7 +167,7 @@ export const MessageRow = React.memo(
 
         <article
           className={cn(
-            "group/message flex items-start gap-2.5 rounded-2xl px-2 py-1 transition-colors",
+            "group/message flex items-start gap-2.5 rounded-2xl px-2 py-1.5 transition-colors",
             highlighted ? "bg-primary/10 ring-1 ring-primary/30" : "",
             activeReplyTargetId === message.id
               ? "bg-muted/60 ring-1 ring-border"
@@ -203,7 +203,7 @@ export const MessageRow = React.memo(
             )}
           </div>
 
-          <div className="min-w-0 flex-1 space-y-0.5">
+          <div className="min-w-0 flex-1 space-y-1">
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
               {message.pubkey ? (
                 <UserProfilePopover pubkey={message.pubkey}>

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -227,8 +227,7 @@ export const MessageRow = React.memo(
                 />
               ) : null}
               {message.personaDisplayName &&
-              message.personaDisplayName !== message.author &&
-              !isBotInstance(message.role) ? (
+              message.personaDisplayName !== message.author ? (
                 <span className="text-xs text-muted-foreground">
                   {message.personaDisplayName}
                 </span>

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -178,7 +178,7 @@ export const MessageRow = React.memo(
         >
           <div className="flex shrink-0 items-start">
             {message.pubkey ? (
-              <UserProfilePopover pubkey={message.pubkey}>
+              <UserProfilePopover pubkey={message.pubkey} role={message.role} botIdenticonValue={message.author}>
                 <button
                   className="shrink-0 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   type="button"
@@ -206,7 +206,7 @@ export const MessageRow = React.memo(
           <div className="min-w-0 flex-1 space-y-1">
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
               {message.pubkey ? (
-                <UserProfilePopover pubkey={message.pubkey}>
+                <UserProfilePopover pubkey={message.pubkey} role={message.role} botIdenticonValue={message.author}>
                   <button
                     className="truncate rounded text-sm font-semibold tracking-tight hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     type="button"
@@ -226,11 +226,13 @@ export const MessageRow = React.memo(
                   className="shrink-0 rounded-sm"
                 />
               ) : null}
-              {message.personaDisplayName ? (
+              {message.personaDisplayName &&
+              message.personaDisplayName !== message.author &&
+              !isBotInstance(message.role) ? (
                 <span className="text-xs text-muted-foreground">
                   {message.personaDisplayName}
                 </span>
-              ) : message.role ? (
+              ) : message.role && !isBotInstance(message.role) ? (
                 <p className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
                   {message.role}
                 </p>

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -178,7 +178,11 @@ export const MessageRow = React.memo(
         >
           <div className="flex shrink-0 items-start">
             {message.pubkey ? (
-              <UserProfilePopover pubkey={message.pubkey} role={message.role} botIdenticonValue={message.author}>
+              <UserProfilePopover
+                pubkey={message.pubkey}
+                role={message.role}
+                botIdenticonValue={message.author}
+              >
                 <button
                   className="shrink-0 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   type="button"
@@ -206,7 +210,11 @@ export const MessageRow = React.memo(
           <div className="min-w-0 flex-1 space-y-1">
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
               {message.pubkey ? (
-                <UserProfilePopover pubkey={message.pubkey} role={message.role} botIdenticonValue={message.author}>
+                <UserProfilePopover
+                  pubkey={message.pubkey}
+                  role={message.role}
+                  botIdenticonValue={message.author}
+                >
                   <button
                     className="truncate rounded text-sm font-semibold tracking-tight hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     type="button"

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -103,7 +103,7 @@ export const MessageRow = React.memo(
           return (
             <Markdown
               channelNames={channelNames}
-              className="max-w-3xl"
+              className="max-w-full"
               content={message.body}
               imetaByUrl={imetaByUrl}
               mentionNames={mentionNames}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -176,7 +176,7 @@ export const MessageRow = React.memo(
           data-message-id={message.id}
           data-testid="message-row"
         >
-          <div className="flex shrink-0 items-center gap-1">
+          <div className="mt-px flex shrink-0 items-start gap-1">
             {isBotInstance(message.role) ? (
               <BotIdenticon
                 value={message.author}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -176,14 +176,7 @@ export const MessageRow = React.memo(
           data-message-id={message.id}
           data-testid="message-row"
         >
-          <div className="flex shrink-0 items-start gap-1">
-            {isBotInstance(message.role) ? (
-              <BotIdenticon
-                value={message.author}
-                size={20}
-                className="rounded"
-              />
-            ) : null}
+          <div className="flex shrink-0 items-start">
             {message.pubkey ? (
               <UserProfilePopover pubkey={message.pubkey}>
                 <button
@@ -226,6 +219,13 @@ export const MessageRow = React.memo(
                   {message.author}
                 </h3>
               )}
+              {isBotInstance(message.role) ? (
+                <BotIdenticon
+                  value={message.author}
+                  size={14}
+                  className="shrink-0 rounded-sm"
+                />
+              ) : null}
               {message.personaDisplayName ? (
                 <span className="text-xs text-muted-foreground">
                   {message.personaDisplayName}
@@ -236,19 +236,23 @@ export const MessageRow = React.memo(
                 </p>
               ) : null}
               <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
-                <MessageActionBar
-                  activeReplyTargetId={activeReplyTargetId}
-                  message={message}
-                  onDelete={onDelete}
-                  onEdit={onEdit}
-                  onReactionSelect={
-                    canToggleReactions ? handleReactionSelect : undefined
-                  }
-                  onReply={onReply}
-                  reactionErrorMessage={reactionErrorMessage}
-                  reactionPending={reactionPending}
-                  reactions={reactions}
-                />
+                <div className="relative">
+                  <div className="absolute right-0 top-1/2 -translate-y-1/2">
+                    <MessageActionBar
+                      activeReplyTargetId={activeReplyTargetId}
+                      message={message}
+                      onDelete={onDelete}
+                      onEdit={onEdit}
+                      onReactionSelect={
+                        canToggleReactions ? handleReactionSelect : undefined
+                      }
+                      onReply={onReply}
+                      reactionErrorMessage={reactionErrorMessage}
+                      reactionPending={reactionPending}
+                      reactions={reactions}
+                    />
+                  </div>
+                </div>
                 {message.pending ? (
                   <p className="font-medium uppercase tracking-[0.14em] text-primary/80">
                     Sending

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -110,10 +110,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
           onScroll={syncScrollState}
           ref={scrollContainerRef}
         >
-          <div
-            className="flex w-full flex-col gap-3 px-4"
-            ref={contentRef}
-          >
+          <div className="flex w-full flex-col gap-3 px-4" ref={contentRef}>
             <div ref={topSentinelRef} aria-hidden className="h-px" />
 
             {isFetchingOlder ? (

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -111,7 +111,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
           ref={scrollContainerRef}
         >
           <div
-            className="mx-auto flex w-full max-w-4xl flex-col gap-2"
+            className="flex w-full flex-col gap-2 px-4"
             ref={contentRef}
           >
             <div ref={topSentinelRef} aria-hidden className="h-px" />

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -111,7 +111,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
           ref={scrollContainerRef}
         >
           <div
-            className="flex w-full flex-col gap-2 px-4"
+            className="flex w-full flex-col gap-3 px-4"
             ref={contentRef}
           >
             <div ref={topSentinelRef} aria-hidden className="h-px" />

--- a/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
+++ b/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
@@ -76,7 +76,7 @@ export function TypingIndicatorRow({
       className="bg-background/95 px-4 py-2 sm:px-6"
       data-testid="message-typing-indicator"
     >
-      <div className="mx-auto flex w-full max-w-4xl items-center gap-2">
+      <div className="flex w-full items-center gap-2">
         <div className="flex flex-shrink-0 items-center">
           {typingPubkeys.map((pubkey, index) => {
             const profile = profiles?.[pubkey];

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -10,10 +10,15 @@ import { formatRelativeTime } from "@/features/forum/lib/time";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { Markdown } from "@/shared/ui/markdown";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import { BotIdenticon } from "@/features/messages/ui/BotIdenticon";
 
 type UserProfilePopoverProps = {
   children: React.ReactNode;
   pubkey: string;
+  /** When set to "bot", a BotIdenticon badge renders next to the display name. */
+  role?: string;
+  /** Value used to generate the BotIdenticon glyph (typically the author name). */
+  botIdenticonValue?: string;
 };
 
 function truncatePubkey(pubkey: string) {
@@ -27,6 +32,8 @@ function truncatePubkey(pubkey: string) {
 export function UserProfilePopover({
   children,
   pubkey,
+  role,
+  botIdenticonValue,
 }: UserProfilePopoverProps) {
   const [open, setOpen] = React.useState(false);
   const [showAllNotes, setShowAllNotes] = React.useState(false);
@@ -64,9 +71,18 @@ export function UserProfilePopover({
             )}
 
             <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-semibold">
-                {profile?.displayName ?? truncatePubkey(pubkey)}
-              </p>
+              <div className="flex items-center gap-1.5">
+                <p className="truncate text-sm font-semibold">
+                  {profile?.displayName ?? truncatePubkey(pubkey)}
+                </p>
+                {role === "bot" && botIdenticonValue ? (
+                  <BotIdenticon
+                    value={botIdenticonValue}
+                    size={20}
+                    className="shrink-0 rounded"
+                  />
+                ) : null}
+              </div>
               {profile?.nip05Handle ? (
                 <p className="truncate text-xs text-muted-foreground">
                   {profile.nip05Handle}

--- a/desktop/src/shared/ui/UserAvatar.tsx
+++ b/desktop/src/shared/ui/UserAvatar.tsx
@@ -8,7 +8,7 @@ type UserAvatarSize = "xs" | "sm" | "md";
 const sizeClasses: Record<UserAvatarSize, string> = {
   xs: "h-5 w-5 text-[8px]",
   sm: "h-6 w-6 text-[9px]",
-  md: "h-8 w-8 text-[11px]",
+  md: "h-10 w-10 text-xs",
 };
 
 type UserAvatarProps = {


### PR DESCRIPTION
## Overview

**Category:** UI Improvement
**User Impact:** Chat messages now use a familiar left-aligned layout with larger avatars, tighter spacing, and no layout shift on hover — matching the feel of Slack and Discord.
**Problem:** The previous centered, max-width-constrained message layout felt cramped and unfamiliar. Avatars were small (32px), the action bar caused layout shift on hover, bot identicons competed with avatars for space, and bot persona names duplicated the author name.
**Solution:** Seven incremental commits rework the message row into a left-aligned, full-width layout with 42px avatars optically centered to the first line, an absolutely-positioned action bar, inline bot badges, refined spacing, and smarter persona-name suppression.

## Changes

<details>
<summary>Changed files (9 files, +101 -114)</summary>

### `desktop/src/shared/ui/UserAvatar.tsx` *(new)*
New shared avatar component with image-loading state, error fallback to initials, accent support, and sm/md size variants. Replaces ad-hoc avatar rendering in MessageRow and ForumPostCard/ForumThreadPanel.

### `desktop/src/features/messages/ui/MessageRow.tsx`
Major refactor — swaps inline avatar markup for UserAvatar (42px), moves BotIdenticon from the avatar column to a 14px inline badge next to the username, wraps MessageActionBar in an absolutely-positioned container to eliminate layout shift, increases vertical padding (py-1 to py-1.5), widens body spacing (space-y-0.5 to space-y-1), removes max-w-3xl on Markdown, and suppresses personaDisplayName when it matches author or when the role is a bot instance.

### `desktop/src/features/messages/ui/MessageActionBar.tsx`
When hidden on desktop the bar now collapses its border and shadow (sm:border-0 sm:shadow-none) and restores them on hover/focus, preventing a 2px layout bump.

### `desktop/src/features/messages/ui/MessageTimeline.tsx`
Removes max-w-4xl mx-auto, adds px-4, and increases inter-message gap from gap-2 to gap-3 for a full-width, breathable timeline.

### `desktop/src/features/messages/ui/MessageComposer.tsx`
Removes max-w-4xl mx-auto from the composer wrapper so it stretches to match the new full-width timeline.

### `desktop/src/features/messages/ui/TypingIndicatorRow.tsx`
Removes max-w-4xl mx-auto to align the typing indicator with the new full-width layout.

### `desktop/src/features/profile/ui/UserProfilePopover.tsx`
Accepts new role and botIdenticonValue props; renders a 20px BotIdenticon next to the display name when the role is "bot". Also adds a "View all / Show less" toggle for the recent-notes section.

### `desktop/src/features/forum/ui/ForumPostCard.tsx`
Replaces ProfileAvatar with the new UserAvatar component (size="sm").

### `desktop/src/features/forum/ui/ForumThreadPanel.tsx`
Same ProfileAvatar to UserAvatar swap for thread replies and the original post header.

</details>

## Reproduction Steps

1. Open any channel with a mix of human and bot messages.
2. **Left-aligned layout** — Verify messages span the full width with no centered max-width constraint. Avatars should be on the left at 42px.
3. **Avatar alignment** — The avatar vertical center should align roughly with the midpoint of the username + first line of body text.
4. **Bot badge** — Bot messages should show a small 14px identicon *inline next to the username*, not in the avatar column.
5. **Action bar hover** — Hover over a message on desktop. The emoji/reply/more actions bar should appear *without* the message content shifting down or sideways.
6. **Spacing** — Confirm comfortable vertical rhythm: slightly more gap between messages, slightly more space between username row and body.
7. **"Two Neds" fix** — For bot messages where personaDisplayName equals the author name, only the author name should show (no duplicate).
8. **Profile popover** — Click a bot avatar; the popover should display a 20px bot identicon next to the display name.
9. **Forum posts** — Navigate to a forum channel and verify post cards and thread replies render avatars correctly via the new UserAvatar component.

## Screenshots / Demos

https://github.com/user-attachments/assets/a203fcd1-694e-474d-bfd4-35a1eee6a933

<img width="2236" height="494" alt="Screenshot 2026-04-13 at 10 06 48 AM" src="https://github.com/user-attachments/assets/d3aff2cb-78c4-4a07-9776-f97b923de739" />

<img width="854" height="304" alt="Screenshot 2026-04-13 at 10 04 29 AM" src="https://github.com/user-attachments/assets/52b1a999-3d2d-4d50-9864-aec7e8df09f9" />

<img width="906" height="131" alt="Screenshot 2026-04-13 at 10 03 14 AM" src="https://github.com/user-attachments/assets/6a9ca25e-0ebc-498c-9c6d-c036e16c9c9e" />