### PR TITLE
fix: show private channels in channel browser when user is a member

### DIFF
--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -110,7 +110,7 @@ export function ChannelBrowserDialog({
         channel.channelType !== "dm" &&
         (channel.archivedAt
           ? channel.isMember
-          : channel.visibility === "open") &&
+          : channel.visibility === "open" || channel.isMember) &&
         (channelTypeFilter ? channel.channelType === channelTypeFilter : true),
     );
 


### PR DESCRIPTION
## Summary

- The channel browser filter excluded all non-archived private channels, even when the user was already a member
- The database layer (`get_accessible_channels`) correctly returns private channels the user belongs to, but the frontend `browsableChannels` memo in `ChannelBrowserDialog.tsx` only allowed `visibility === "open"` for non-archived channels
- Added `|| channel.isMember` to the filter so joined private channels appear in browse/search results