### PR TITLE
feat: add change member role in channel sidebar

### DIFF
--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -203,8 +203,11 @@ pub async fn change_channel_member_role(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let uuid = parse_channel_uuid(&channel_id)?;
+    // Only allow permission-tier roles for humans and bot/guest for bots.
+    // Owner changes require a dedicated transfer-ownership flow.
     let role_str = match role.as_str() {
         "admin" | "member" | "guest" | "bot" => role.as_str(),
+        "owner" => return Err("cannot assign owner role — use transfer ownership".into()),
         other => return Err(format!("invalid role: {other}")),
     };
     let builder = events::build_add_member(uuid, &pubkey, Some(role_str))?;

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -196,6 +196,23 @@ pub async fn remove_channel_member(
 }
 
 #[tauri::command]
+pub async fn change_channel_member_role(
+    channel_id: String,
+    pubkey: String,
+    role: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let uuid = parse_channel_uuid(&channel_id)?;
+    let role_str = match role.as_str() {
+        "admin" | "member" | "guest" | "bot" => role.as_str(),
+        other => return Err(format!("invalid role: {other}")),
+    };
+    let builder = events::build_add_member(uuid, &pubkey, Some(role_str))?;
+    submit_event(builder, &state).await?;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn join_channel(channel_id: String, state: State<'_, AppState>) -> Result<(), String> {
     let uuid = parse_channel_uuid(&channel_id)?;
     let builder = events::build_join(uuid)?;

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -437,6 +437,7 @@ pub fn run() {
             delete_channel,
             add_channel_members,
             remove_channel_member,
+            change_channel_member_role,
             join_channel,
             leave_channel,
             get_canvas,

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -424,9 +424,7 @@ export function useRemoveChannelMemberMutation(channelId: string | null) {
   });
 }
 
-export function useChangeChannelMemberRoleMutation(
-  channelId: string | null,
-) {
+export function useChangeChannelMemberRoleMutation(channelId: string | null) {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -4,7 +4,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   addChannelMembers,
   archiveChannel,
-  changeChannelMemberRole,
   createChannel,
   deleteChannel,
   getCanvas,
@@ -420,23 +419,6 @@ export function useRemoveChannelMemberMutation(channelId: string | null) {
         queryClient.invalidateQueries({ queryKey: ["managed-agents"] }),
         queryClient.invalidateQueries({ queryKey: ["relay-agents"] }),
       ]);
-    },
-  });
-}
-
-export function useChangeChannelMemberRoleMutation(channelId: string | null) {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async ({ pubkey, role }: { pubkey: string; role: string }) => {
-      if (!channelId) {
-        throw new Error("No channel selected.");
-      }
-
-      await changeChannelMemberRole(channelId, pubkey, role);
-    },
-    onSettled: async () => {
-      await invalidateChannelState(queryClient, channelId);
     },
   });
 }

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   addChannelMembers,
   archiveChannel,
+  changeChannelMemberRole,
   createChannel,
   deleteChannel,
   getCanvas,
@@ -419,6 +420,25 @@ export function useRemoveChannelMemberMutation(channelId: string | null) {
         queryClient.invalidateQueries({ queryKey: ["managed-agents"] }),
         queryClient.invalidateQueries({ queryKey: ["relay-agents"] }),
       ]);
+    },
+  });
+}
+
+export function useChangeChannelMemberRoleMutation(
+  channelId: string | null,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ pubkey, role }: { pubkey: string; role: string }) => {
+      if (!channelId) {
+        throw new Error("No channel selected.");
+      }
+
+      await changeChannelMemberRole(channelId, pubkey, role);
+    },
+    onSettled: async () => {
+      await invalidateChannelState(queryClient, channelId);
     },
   });
 }

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -39,9 +39,10 @@ export function MembersSidebar({
   const membersQuery = useChannelMembersQuery(channelId, open);
   const addMembersMutation = useAddChannelMembersMutation(channelId);
   const changeRoleMutation = useChangeChannelMemberRoleMutation(channelId);
-  const changeRoleError = changeRoleMutation.error instanceof Error
-    ? changeRoleMutation.error.message
-    : null;
+  const changeRoleError =
+    changeRoleMutation.error instanceof Error
+      ? changeRoleMutation.error.message
+      : null;
 
   const rawMembers = membersQuery.data ?? [];
   const { people, bots, isBot, isMyBot, managedAgentsQuery } =

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   useAddChannelMembersMutation,
-  useChangeChannelMemberRoleMutation,
   useChannelMembersQuery,
 } from "@/features/channels/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
 import { formatMemberName } from "@/features/channels/lib/memberUtils";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
+import { changeChannelMemberRole } from "@/shared/api/tauri";
 import type { Channel, ChannelMember } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
@@ -36,9 +37,20 @@ export function MembersSidebar({
   onOpenChange,
 }: MembersSidebarProps) {
   const channelId = channel?.id ?? null;
+  const queryClient = useQueryClient();
   const membersQuery = useChannelMembersQuery(channelId, open);
   const addMembersMutation = useAddChannelMembersMutation(channelId);
-  const changeRoleMutation = useChangeChannelMemberRoleMutation(channelId);
+  const changeRoleMutation = useMutation({
+    mutationFn: async ({ pubkey, role }: { pubkey: string; role: string }) => {
+      if (!channelId) throw new Error("No channel selected.");
+      await changeChannelMemberRole(channelId, pubkey, role);
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["channels", channelId],
+      });
+    },
+  });
   const changeRoleError =
     changeRoleMutation.error instanceof Error
       ? changeRoleMutation.error.message

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -39,6 +39,9 @@ export function MembersSidebar({
   const membersQuery = useChannelMembersQuery(channelId, open);
   const addMembersMutation = useAddChannelMembersMutation(channelId);
   const changeRoleMutation = useChangeChannelMemberRoleMutation(channelId);
+  const changeRoleError = changeRoleMutation.error instanceof Error
+    ? changeRoleMutation.error.message
+    : null;
 
   const rawMembers = membersQuery.data ?? [];
   const { people, bots, isBot, isMyBot, managedAgentsQuery } =
@@ -131,7 +134,7 @@ export function MembersSidebar({
       <MembersSidebarMemberCard
         canChangeRole={canManageMembers && member.pubkey !== currentPubkey}
         canRemoveMember={canRemoveMember(member)}
-        isActionPending={isActionPending}
+        isActionPending={isActionPending || changeRoleMutation.isPending}
         isArchived={isArchived}
         key={member.pubkey}
         managedAgent={
@@ -256,12 +259,12 @@ export function MembersSidebar({
             </p>
           ) : null}
 
-          {actionErrorMessage ? (
+          {actionErrorMessage || changeRoleError ? (
             <p
               className="text-sm text-destructive"
               data-testid="members-sidebar-action-error"
             >
-              {actionErrorMessage}
+              {actionErrorMessage ?? changeRoleError}
             </p>
           ) : null}
         </div>

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {
   useAddChannelMembersMutation,
+  useChangeChannelMemberRoleMutation,
   useChannelMembersQuery,
 } from "@/features/channels/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -37,6 +38,7 @@ export function MembersSidebar({
   const channelId = channel?.id ?? null;
   const membersQuery = useChannelMembersQuery(channelId, open);
   const addMembersMutation = useAddChannelMembersMutation(channelId);
+  const changeRoleMutation = useChangeChannelMemberRoleMutation(channelId);
 
   const rawMembers = membersQuery.data ?? [];
   const { people, bots, isBot, isMyBot, managedAgentsQuery } =
@@ -127,6 +129,7 @@ export function MembersSidebar({
   function renderMemberCard(member: ChannelMember, memberIsBot: boolean) {
     return (
       <MembersSidebarMemberCard
+        canChangeRole={canManageMembers && member.pubkey !== currentPubkey}
         canRemoveMember={canRemoveMember(member)}
         isActionPending={isActionPending}
         isArchived={isArchived}
@@ -139,6 +142,9 @@ export function MembersSidebar({
         member={member}
         memberIsBot={memberIsBot}
         memberLabel={formatMemberName(member, currentPubkey)}
+        onChangeRole={(m, role) => {
+          void changeRoleMutation.mutateAsync({ pubkey: m.pubkey, role });
+        }}
         onManagedAgentAction={(agent) => {
           void handleAgentLifecycleAction(agent);
         }}

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -147,7 +147,12 @@ export function MembersSidebarMemberCard({
   );
 }
 
-const ASSIGNABLE_ROLES = ["admin", "member", "guest", "bot"] as const;
+const PEOPLE_ROLES = ["admin", "member", "guest"] as const;
+const BOT_ROLES = ["bot", "guest"] as const;
+
+function getAssignableRoles(memberIsBot: boolean) {
+  return memberIsBot ? BOT_ROLES : PEOPLE_ROLES;
+}
 
 function MemberActionsMenu({
   canChangeRole,
@@ -170,6 +175,10 @@ function MemberActionsMenu({
   onManagedAgentAction: (agent: ManagedAgent) => void;
   onRemoveMember: (member: ChannelMember) => void;
 }) {
+  const assignableRoles = getAssignableRoles(memberIsBot);
+  const showChangeRole =
+    canChangeRole && member.role !== "owner" && assignableRoles.length > 1;
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
@@ -195,12 +204,12 @@ function MemberActionsMenu({
               {getManagedAgentActionIcon(managedAgent)}
               {getManagedAgentPrimaryActionLabel(managedAgent)}
             </DropdownMenuItem>
-            {canRemoveMember || canChangeRole ? (
+            {canRemoveMember || showChangeRole ? (
               <DropdownMenuSeparator />
             ) : null}
           </>
         ) : null}
-        {canChangeRole && member.role !== "owner" ? (
+        {showChangeRole ? (
           <DropdownMenuSub>
             <DropdownMenuSubTrigger
               data-testid={`sidebar-change-role-${member.pubkey}`}
@@ -210,7 +219,7 @@ function MemberActionsMenu({
               Change role
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
-              {ASSIGNABLE_ROLES.map((role) => (
+              {assignableRoles.map((role) => (
                 <DropdownMenuItem
                   data-testid={`sidebar-role-${role}-${member.pubkey}`}
                   disabled={disabled || member.role === role}
@@ -227,9 +236,7 @@ function MemberActionsMenu({
         ) : null}
         {canRemoveMember ? (
           <>
-            {canChangeRole && member.role !== "owner" ? (
-              <DropdownMenuSeparator />
-            ) : null}
+            {showChangeRole ? <DropdownMenuSeparator /> : null}
             <DropdownMenuItem
               className="text-destructive focus:text-destructive"
               data-testid={`sidebar-remove-member-${member.pubkey}`}

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -148,11 +148,6 @@ export function MembersSidebarMemberCard({
 }
 
 const PEOPLE_ROLES = ["admin", "member", "guest"] as const;
-const BOT_ROLES = ["bot", "guest"] as const;
-
-function getAssignableRoles(memberIsBot: boolean) {
-  return memberIsBot ? BOT_ROLES : PEOPLE_ROLES;
-}
 
 function MemberActionsMenu({
   canChangeRole,
@@ -175,9 +170,8 @@ function MemberActionsMenu({
   onManagedAgentAction: (agent: ManagedAgent) => void;
   onRemoveMember: (member: ChannelMember) => void;
 }) {
-  const assignableRoles = getAssignableRoles(memberIsBot);
   const showChangeRole =
-    canChangeRole && member.role !== "owner" && assignableRoles.length > 1;
+    canChangeRole && !memberIsBot && member.role !== "owner";
 
   return (
     <DropdownMenu modal={false}>
@@ -219,7 +213,7 @@ function MemberActionsMenu({
               Change role
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
-              {assignableRoles.map((role) => (
+              {PEOPLE_ROLES.map((role) => (
                 <DropdownMenuItem
                   data-testid={`sidebar-role-${role}-${member.pubkey}`}
                   disabled={disabled || member.role === role}

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -1,4 +1,11 @@
-import { Ellipsis, Play, RotateCcw, Square, Trash2 } from "lucide-react";
+import {
+  Ellipsis,
+  Play,
+  RotateCcw,
+  Shield,
+  Square,
+  Trash2,
+} from "lucide-react";
 
 import {
   getManagedAgentPrimaryActionLabel,
@@ -17,10 +24,14 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 
 type MembersSidebarMemberCardProps = {
+  canChangeRole: boolean;
   canRemoveMember: boolean;
   isActionPending: boolean;
   isArchived: boolean;
@@ -28,6 +39,7 @@ type MembersSidebarMemberCardProps = {
   member: ChannelMember;
   memberIsBot: boolean;
   memberLabel: string;
+  onChangeRole: (member: ChannelMember, role: string) => void;
   onManagedAgentAction: (agent: ManagedAgent) => void;
   onRemoveMember: (member: ChannelMember) => void;
   presenceStatus?: PresenceStatus | null;
@@ -56,6 +68,7 @@ function formatManagedAgentStatus(agent: ManagedAgent) {
 }
 
 export function MembersSidebarMemberCard({
+  canChangeRole,
   canRemoveMember,
   isActionPending,
   isArchived,
@@ -63,6 +76,7 @@ export function MembersSidebarMemberCard({
   member,
   memberIsBot,
   memberLabel,
+  onChangeRole,
   onManagedAgentAction,
   onRemoveMember,
   presenceStatus,
@@ -72,7 +86,7 @@ export function MembersSidebarMemberCard({
   const disabled = isActionPending || isArchived;
   const hasActions = memberIsBot
     ? Boolean(managedAgent) || canRemoveMember
-    : canRemoveMember;
+    : canRemoveMember || canChangeRole;
 
   return (
     <div
@@ -118,11 +132,13 @@ export function MembersSidebarMemberCard({
       </div>
       {hasActions ? (
         <MemberActionsMenu
+          canChangeRole={canChangeRole}
           canRemoveMember={canRemoveMember}
           disabled={disabled}
           managedAgent={managedAgent}
           member={member}
           memberIsBot={memberIsBot}
+          onChangeRole={onChangeRole}
           onManagedAgentAction={onManagedAgentAction}
           onRemoveMember={onRemoveMember}
         />
@@ -131,20 +147,26 @@ export function MembersSidebarMemberCard({
   );
 }
 
+const ASSIGNABLE_ROLES = ["admin", "member", "guest", "bot"] as const;
+
 function MemberActionsMenu({
+  canChangeRole,
   canRemoveMember,
   disabled,
   managedAgent,
   member,
   memberIsBot,
+  onChangeRole,
   onManagedAgentAction,
   onRemoveMember,
 }: {
+  canChangeRole: boolean;
   canRemoveMember: boolean;
   disabled: boolean;
   managedAgent?: ManagedAgent;
   member: ChannelMember;
   memberIsBot: boolean;
+  onChangeRole: (member: ChannelMember, role: string) => void;
   onManagedAgentAction: (agent: ManagedAgent) => void;
   onRemoveMember: (member: ChannelMember) => void;
 }) {
@@ -173,19 +195,51 @@ function MemberActionsMenu({
               {getManagedAgentActionIcon(managedAgent)}
               {getManagedAgentPrimaryActionLabel(managedAgent)}
             </DropdownMenuItem>
-            {canRemoveMember ? <DropdownMenuSeparator /> : null}
+            {canRemoveMember || canChangeRole ? (
+              <DropdownMenuSeparator />
+            ) : null}
           </>
         ) : null}
+        {canChangeRole && member.role !== "owner" ? (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger
+              data-testid={`sidebar-change-role-${member.pubkey}`}
+              disabled={disabled}
+            >
+              <Shield className="h-4 w-4" />
+              Change role
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {ASSIGNABLE_ROLES.map((role) => (
+                <DropdownMenuItem
+                  data-testid={`sidebar-role-${role}-${member.pubkey}`}
+                  disabled={disabled || member.role === role}
+                  key={role}
+                  onClick={() => onChangeRole(member, role)}
+                >
+                  {role[0]?.toUpperCase()}
+                  {role.slice(1)}
+                  {member.role === role ? " (current)" : ""}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        ) : null}
         {canRemoveMember ? (
-          <DropdownMenuItem
-            className="text-destructive focus:text-destructive"
-            data-testid={`sidebar-remove-member-${member.pubkey}`}
-            disabled={disabled}
-            onClick={() => onRemoveMember(member)}
-          >
-            <Trash2 className="h-4 w-4" />
-            Remove from channel
-          </DropdownMenuItem>
+          <>
+            {canChangeRole && member.role !== "owner" ? (
+              <DropdownMenuSeparator />
+            ) : null}
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              data-testid={`sidebar-remove-member-${member.pubkey}`}
+              disabled={disabled}
+              onClick={() => onRemoveMember(member)}
+            >
+              <Trash2 className="h-4 w-4" />
+              Remove from channel
+            </DropdownMenuItem>
+          </>
         ) : null}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -615,6 +615,14 @@ export async function removeChannelMember(
   await invokeTauri("remove_channel_member", { channelId, pubkey });
 }
 
+export async function changeChannelMemberRole(
+  channelId: string,
+  pubkey: string,
+  role: string,
+): Promise<void> {
+  await invokeTauri("change_channel_member_role", { channelId, pubkey, role });
+}
+
 export async function joinChannel(channelId: string): Promise<void> {
   await invokeTauri("join_channel", { channelId });
 }


### PR DESCRIPTION
## Summary

- Added "Change role" submenu to member actions dropdown in the members sidebar
- Owners and admins can change any other human member's role (admin, member, guest)
- Bots cannot have their role changed (bot is an actor type, not a permission tier)
- Owner assignment is blocked (requires a dedicated transfer-ownership flow)
- Reuses the existing `kind:9000` add-member upsert path — no relay or DB changes needed

## Known limitations

- **System message:** Role changes emit a "member added" system message since we reuse `kind:9000`. A dedicated `member_role_changed` system message type in the relay's side effects handler would fix this.
- **Last-owner safety:** The relay's add-member upsert path does not guard against demoting the last owner (the remove path does). This is a pre-existing gap — our Tauri command blocks owner assignment, but a crafted client could still demote an owner via a raw event.

## Test plan

- [ ] Change a member from "member" to "admin" — verify role persists after page reload
- [ ] Verify bots do not show the "Change role" menu
- [ ] Verify owners do not show the "Change role" menu
- [ ] Verify non-owner/admin users do not see "Change role" on other members
- [ ] Attempt to change your own role — should not be available
- [ ] Verify error message surfaces if role change fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)