### PR TITLE
fix(composer): prevent phantom newline on Enter by moving submit into Tiptap extension

### DIFF
--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -19,6 +19,11 @@ export type RichTextEditorOptions = {
   editable?: boolean;
   mentionNames?: string[];
   channelNames?: string[];
+  /** Called on plain Enter (submit). Handled inside Tiptap's extension system
+   *  so it fires *before* ProseMirror's default splitBlock behaviour. */
+  onSubmit?: () => void;
+  /** When true, plain Enter is passed through (e.g. to select an autocomplete item). */
+  isAutocompleteOpen?: React.RefObject<boolean>;
 };
 
 /**
@@ -36,9 +41,14 @@ export function useRichTextEditor({
   editable = true,
   mentionNames,
   channelNames,
+  onSubmit,
+  isAutocompleteOpen,
 }: RichTextEditorOptions) {
   const onUpdateRef = React.useRef(onUpdate);
   onUpdateRef.current = onUpdate;
+
+  const onSubmitRef = React.useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
 
   const placeholderRef = React.useRef(placeholder);
   placeholderRef.current = placeholder;
@@ -144,6 +154,24 @@ export function useRichTextEditor({
               ArrowDown: ({ editor: ed }) => {
                 // Empty last list item + Down → exit list to paragraph below.
                 return exitListIfEmptyLast(ed);
+              },
+            };
+          },
+        }),
+        // Plain Enter → submit the message. This runs inside ProseMirror's
+        // keymap pipeline so it fires *before* the default splitBlock command,
+        // preventing the phantom paragraph-split that caused \n\n in messages.
+        Extension.create({
+          name: "submitOnEnter",
+          addKeyboardShortcuts() {
+            return {
+              Enter: () => {
+                // Let autocomplete dropdowns consume Enter first.
+                if (isAutocompleteOpen?.current) return false;
+                // No submit callback → fall through to default behaviour.
+                if (!onSubmitRef.current) return false;
+                onSubmitRef.current();
+                return true; // prevents splitBlock
               },
             };
           },

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -110,6 +110,13 @@ export function MessageComposer({
   editTargetRef.current = editTarget;
   channelIdRef.current = channelId;
 
+  // ── Refs consumed by Tiptap's submitOnEnter extension ──────────────
+  const isAutocompleteOpenRef = React.useRef(false);
+  isAutocompleteOpenRef.current =
+    mentions.isMentionOpen || channelLinks.isChannelOpen;
+
+  const submitMessageRef = React.useRef<() => void>(() => {});
+
   // ── Computed placeholder ─────────────────────────────────────────────
   const computedPlaceholder = editTarget
     ? "Edit your message"
@@ -124,6 +131,8 @@ export function MessageComposer({
     editable: !disabled,
     mentionNames: mentions.knownNames,
     channelNames: channelLinks.knownChannelNames,
+    onSubmit: () => submitMessageRef.current(),
+    isAutocompleteOpen: isAutocompleteOpenRef,
     onUpdate: ({ markdown, text }) => {
       setContent(markdown);
       contentRef.current = markdown;
@@ -361,6 +370,7 @@ export function MessageComposer({
     richText.clearContent,
     richText.setContent,
   ]);
+  submitMessageRef.current = submitMessage;
 
   const handleSubmit = React.useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
@@ -372,8 +382,9 @@ export function MessageComposer({
 
   // ── Keyboard handling ───────────────────────────────────────────────
   // Tiptap handles formatting shortcuts (⌘B, ⌘I, etc.) natively.
-  // We intercept Enter (submit) and arrow keys (autocomplete) via a
-  // keydown listener on the editor wrapper.
+  // Plain Enter → submit is now handled inside the Tiptap `submitOnEnter`
+  // extension (fires before ProseMirror's splitBlock). This wrapper only
+  // handles autocomplete arrow/enter keys and Escape for edit mode.
   const handleEditorKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       // Let autocomplete handle keys first
@@ -399,32 +410,12 @@ export function MessageComposer({
         onCancelEdit();
         return;
       }
-
-      if (event.key !== "Enter" || event.nativeEvent.isComposing) {
-        return;
-      }
-
-      // Shift+Enter or Ctrl+Enter → newline (Tiptap handles this natively
-      // via hard break, so let it through)
-      if (event.shiftKey || event.ctrlKey) {
-        return;
-      }
-
-      // Meta/Alt+Enter → let through (system shortcuts)
-      if (event.metaKey || event.altKey) {
-        return;
-      }
-
-      // Plain Enter → submit
-      event.preventDefault();
-      void submitMessage();
     },
     [
       channelLinks.handleChannelKeyDown,
       applyChannelInsert,
       mentions.handleMentionKeyDown,
       applyMentionInsert,
-      submitMessage,
       onCancelEdit,
     ],
   );


### PR DESCRIPTION
**Category:** fix
**User Impact:** Messages no longer randomly break into two lines when pressing Enter to send.

**Problem:** The Enter→submit handler lived on a React `onKeyDown` on a wrapper `<div>` around `<EditorContent>`. ProseMirror's internal keymap fires *before* the React handler bubbles, so on every Enter press, `splitBlock()` would split the current paragraph before `submitMessage()` ever ran. When the cursor happened to be mid-text (from clicking to reposition, autocomplete placing the cursor, or fast typing), the tiptap-markdown serializer output `\n\n` between the two paragraph nodes — producing a phantom line break in the sent message.

**Solution:** Move the Enter→submit handler into a Tiptap `addKeyboardShortcuts` extension (`submitOnEnter`) so it runs inside ProseMirror's keymap pipeline *before* the default `splitBlock` command. Returns `true` to consume the event and prevent the paragraph split. When an autocomplete dropdown is open, returns `false` so Enter falls through for item selection. Follows the same pattern as the existing `smartShiftEnter` extension.

<details>
<summary>File changes</summary>

**desktop/src/features/messages/lib/useRichTextEditor.ts**
Added `onSubmit` and `isAutocompleteOpen` options to `RichTextEditorOptions`. Created the `submitOnEnter` Tiptap extension using `addKeyboardShortcuts` — intercepts plain Enter inside ProseMirror's keymap pipeline before `splitBlock` can fire. Defers to autocomplete when a dropdown is open.

**desktop/src/features/messages/ui/MessageComposer.tsx**
Removed the Enter→submit branch from `handleEditorKeyDown` on the wrapper div. Added `isAutocompleteOpenRef` and `submitMessageRef` refs, wired into the `useRichTextEditor` hook via the new `onSubmit` / `isAutocompleteOpen` options. Updated the comment block explaining the keyboard handling split.

</details>

## Reproduction Steps

1. Open any channel in the desktop app
2. Type a message, e.g. `check pr 310`
3. Click to place your cursor between "pr " and "310" (mid-text)
4. Press Enter to send
5. **Before this fix:** message sends as two lines (`check pr` / `310`). **After:** sends as one line (`check pr 310`)
