### PR TITLE
fix: pre-create index on partitioned table to unblock dev setup

### DIFF
--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -130,6 +130,14 @@ if [[ ! -f "${SCHEMA_FILE}" ]]; then
   warn "No schema.sql found at ${SCHEMA_FILE}. Skipping."
 else
   if [[ -x "${PGSCHEMA}" ]]; then
+    # pgschema uses CREATE INDEX CONCURRENTLY for new indexes, which Postgres
+    # does not support on partitioned tables. Pre-create any such indexes here
+    # so pgschema sees them as already existing and skips the CONCURRENTLY path.
+    log "Pre-creating indexes on partitioned tables (if needed)..."
+    docker exec sprout-postgres psql -U "${PGUSER}" -d "${PGDATABASE}" -q -c \
+      "CREATE INDEX IF NOT EXISTS idx_events_parameterized ON events (kind, pubkey, d_tag, deleted_at) WHERE d_tag IS NOT NULL;" \
+      2>/dev/null || true
+
     log "Using pgschema for migrations..."
     attempts=0
     max_attempts=10


### PR DESCRIPTION
## Overview

**Category:** fix
**User Impact:** `just setup` no longer fails during database migrations for developers with the latest schema changes.

**Problem:** pgschema generates `CREATE INDEX CONCURRENTLY` when applying new indexes to existing tables, but PostgreSQL does not support `CONCURRENTLY` on partitioned tables. This causes `just setup` to fail for every developer picking up the `d_tag` schema migration on the `events` table.

**Solution:** Pre-create the partitioned-table index via `docker exec` (without `CONCURRENTLY`) before pgschema runs. pgschema then sees the index already exists and skips it. The command is idempotent (`IF NOT EXISTS`) and fault-tolerant (`|| true`) so it's safe on fresh databases where the table may not exist yet.

## Changes

<details>
<summary>File changes</summary>

**scripts/dev-setup.sh**
Added a pre-creation step before pgschema migrations that creates `idx_events_parameterized` on the partitioned `events` table using `docker exec` into the Postgres container. This sidesteps pgschema's `CONCURRENTLY` limitation while keeping the index defined in `schema.sql` as the source of truth.

</details>

## Reproduction Steps

1. Start from a database state that does not yet have the `idx_events_parameterized` index (e.g., `./scripts/dev-reset.sh` or a fresh clone).
2. Run `just setup`.
3. Verify it completes successfully with "Sprout dev environment is ready!" instead of the previous `cannot create index on partitioned table "events" concurrently` error.