### PR TITLE
fix: derive staging ports from worktree to avoid collisions

### DIFF
--- a/justfile
+++ b/justfile
@@ -151,9 +151,17 @@ dev *ARGS:
 
 # Run the desktop app against the internal staging relay (installs deps + builds agent tools automatically)
 staging *ARGS:
-    cd {{desktop_dir}} && pnpm install
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd {{desktop_dir}}
+    pnpm install
+    cd ..
     cargo build --release -p sprout-acp -p sprout-mcp
-    cd {{desktop_dir}} && SPROUT_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co" pnpm exec tauri dev --config src-tauri/tauri.dev.conf.json {{ARGS}}
+    cd {{desktop_dir}}
+    source ../scripts/instance-env.sh
+    export SPROUT_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co"
+    echo "Starting staging on Vite port ${SPROUT_VITE_PORT}, relay ${SPROUT_RELAY_URL}"
+    pnpm exec tauri dev --config "$SPROUT_TAURI_CONFIG" {{ARGS}}
 
 # Run the desktop frontend dev server (port derived from worktree)
 desktop-dev:


### PR DESCRIPTION
## Summary
- `just staging` hardcoded port 1420 via `tauri.conf.json`, causing "port already in use" errors when running multiple Sprout instances
- Reuses `instance-env.sh` (already used by `just dev`) so staging gets a stable, worktree-derived port and inline Tauri config
- Also adds a startup log line showing the assigned port and relay URL

## Test plan
- [ ] Run `just staging` from the main worktree — should start on a derived port and connect to the staging relay
- [ ] Run `just staging` from a second worktree simultaneously — both should start without port conflicts
- [ ] Verify `just dev` still works as before (no changes to that recipe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)