### PR TITLE
chore: improve thread panel inline replies and nesting behavior

### DIFF
--- a/desktop/src/features/channels/lib/channelDescription.ts
+++ b/desktop/src/features/channels/lib/channelDescription.ts
@@ -1,0 +1,20 @@
+import type { Channel } from "@/shared/api/types";
+
+export function getChannelDescription(channel: Channel | null): string {
+  if (!channel) {
+    return "Connect to the relay to browse channels and read messages.";
+  }
+
+  return (
+    [
+      channel.archivedAt ? "Archived." : null,
+      !channel.isMember ? "Read-only until you join this open channel." : null,
+      channel.topic,
+      channel.description,
+      channel.purpose,
+      null,
+    ]
+      .filter((value) => value && value.trim().length > 0)
+      .join(" ") || "Channel details and activity."
+  );
+}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -24,14 +24,14 @@ type ChannelPaneProps = {
   isTimelineLoading: boolean;
   messages: TimelineMessage[];
   onCancelEdit?: () => void;
-  onBackThread: () => void;
   onCancelThreadReply: () => void;
   onCloseThread: () => void;
   onDelete?: (message: TimelineMessage) => void;
   onEdit?: (message: TimelineMessage) => void;
   onEditSave?: (content: string) => Promise<void>;
-  onOpenNestedThread: (message: TimelineMessage) => void;
+  onExpandThreadReplies: (message: TimelineMessage) => void;
   onOpenThread: (message: TimelineMessage) => void;
+  onSelectThreadReplyTarget: (message: TimelineMessage) => void;
   onSendMessage: (
     content: string,
     mentionPubkeys: string[],
@@ -48,10 +48,10 @@ type ChannelPaneProps = {
     emoji: string,
     remove: boolean,
   ) => Promise<void>;
+  onThreadScrollTargetResolved: () => void;
   /** Map from lowercase pubkey → persona display name for bot members. */
   personaLookup?: Map<string, string>;
   profiles?: UserProfileLookup;
-  canGoBackThread: boolean;
   openThreadHeadId: string | null;
   threadHeadMessage: TimelineMessage | null;
   threadMessages: MainTimelineEntry[];
@@ -59,6 +59,8 @@ type ChannelPaneProps = {
   threadTotalReplyCount: number;
   threadReplyTargetId: string | null;
   threadReplyTargetMessage: TimelineMessage | null;
+  threadPanelOpenKey: number;
+  threadScrollTargetId: string | null;
   targetMessageId: string | null;
   typingPubkeys: string[];
 };
@@ -73,26 +75,28 @@ export const ChannelPane = React.memo(function ChannelPane({
   isSending,
   isTimelineLoading,
   messages,
-  onBackThread,
   onCancelEdit,
   onCancelThreadReply,
   onCloseThread,
   onDelete,
   onEdit,
   onEditSave,
-  onOpenNestedThread,
+  onExpandThreadReplies,
   onOpenThread,
+  onSelectThreadReplyTarget,
   onSendMessage,
   onSendThreadReply,
+  onThreadScrollTargetResolved,
   onTargetReached,
   onToggleReaction,
-  canGoBackThread,
   personaLookup,
   profiles,
   openThreadHeadId,
   targetMessageId,
   threadHeadMessage,
   threadMessages,
+  threadPanelOpenKey,
+  threadScrollTargetId,
   threadTypingPubkeys,
   threadTotalReplyCount,
   threadReplyTargetId,
@@ -170,23 +174,25 @@ export const ChannelPane = React.memo(function ChannelPane({
 
       {threadHeadMessage ? (
         <MessageThreadPanel
-          canGoBack={canGoBackThread}
           channel={activeChannel}
           channelId={activeChannel?.id ?? null}
           channelName={activeChannel?.name ?? "channel"}
           currentPubkey={currentPubkey}
           disabled={isComposerDisabled}
           isSending={isSending}
-          onBack={onBackThread}
           onCancelReply={onCancelThreadReply}
           onClose={onCloseThread}
           onDelete={onDelete}
-          onOpenNestedThread={onOpenNestedThread}
+          onExpandReplies={onExpandThreadReplies}
+          onSelectReplyTarget={onSelectThreadReplyTarget}
           onSend={onSendThreadReply}
+          onScrollTargetResolved={onThreadScrollTargetResolved}
           onToggleReaction={onToggleReaction}
+          openKey={threadPanelOpenKey}
           profiles={profiles}
           replyTargetId={threadReplyTargetId}
           replyTargetMessage={threadReplyTargetMessage}
+          scrollTargetId={threadScrollTargetId}
           threadHead={threadHeadMessage}
           threadReplies={threadMessages}
           threadTypingPubkeys={threadTypingPubkeys}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -9,6 +9,40 @@ import type { TimelineMessage } from "@/features/messages/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel } from "@/shared/api/types";
 
+const THREAD_PANEL_DEFAULT_WIDTH_PX = 380;
+const THREAD_PANEL_MIN_WIDTH_PX = 320;
+const THREAD_PANEL_MAX_WIDTH_PX = 720;
+const THREAD_PANEL_WIDTH_SESSION_KEY = "sprout.desktop.thread-panel-width";
+
+function clampThreadPanelWidth(width: number): number {
+  return Math.max(
+    THREAD_PANEL_MIN_WIDTH_PX,
+    Math.min(THREAD_PANEL_MAX_WIDTH_PX, width),
+  );
+}
+
+function getInitialThreadPanelWidth(): number {
+  if (typeof window === "undefined") {
+    return THREAD_PANEL_DEFAULT_WIDTH_PX;
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(THREAD_PANEL_WIDTH_SESSION_KEY);
+    if (!raw) {
+      return THREAD_PANEL_DEFAULT_WIDTH_PX;
+    }
+
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) {
+      return THREAD_PANEL_DEFAULT_WIDTH_PX;
+    }
+
+    return clampThreadPanelWidth(parsed);
+  } catch {
+    return THREAD_PANEL_DEFAULT_WIDTH_PX;
+  }
+}
+
 type ChannelPaneProps = {
   activeChannel: Channel | null;
   currentPubkey?: string;
@@ -103,6 +137,62 @@ export const ChannelPane = React.memo(function ChannelPane({
   threadReplyTargetMessage,
   typingPubkeys,
 }: ChannelPaneProps) {
+  const [threadPanelWidthPx, setThreadPanelWidthPx] = React.useState<number>(
+    () => getInitialThreadPanelWidth(),
+  );
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      window.sessionStorage.setItem(
+        THREAD_PANEL_WIDTH_SESSION_KEY,
+        String(threadPanelWidthPx),
+      );
+    } catch {
+      // Ignore storage failures and keep in-memory width for this session.
+    }
+  }, [threadPanelWidthPx]);
+
+  const handleThreadPanelResizeStart = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+
+      const startX = event.clientX;
+      const startWidth = threadPanelWidthPx;
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const deltaX = startX - moveEvent.clientX;
+        const nextWidth = clampThreadPanelWidth(startWidth + deltaX);
+        setThreadPanelWidthPx(nextWidth);
+      };
+
+      const handlePointerUp = () => {
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+        window.removeEventListener("pointermove", handlePointerMove);
+      };
+
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp, { once: true });
+    },
+    [threadPanelWidthPx],
+  );
+
+  const handleThreadPanelWidthReset = React.useCallback(() => {
+    setThreadPanelWidthPx(THREAD_PANEL_DEFAULT_WIDTH_PX);
+  }, []);
+
+  const canResetThreadPanelWidth =
+    threadPanelWidthPx !== THREAD_PANEL_DEFAULT_WIDTH_PX;
+
   const isComposerDisabled =
     !activeChannel ||
     !activeChannel.isMember ||
@@ -193,7 +283,11 @@ export const ChannelPane = React.memo(function ChannelPane({
           replyTargetId={threadReplyTargetId}
           replyTargetMessage={threadReplyTargetMessage}
           scrollTargetId={threadScrollTargetId}
+          canResetWidth={canResetThreadPanelWidth}
+          onResetWidth={handleThreadPanelWidthReset}
+          onResizeStart={handleThreadPanelResizeStart}
           threadHead={threadHeadMessage}
+          widthPx={threadPanelWidthPx}
           threadReplies={threadMessages}
           threadTypingPubkeys={threadTypingPubkeys}
           totalReplyCount={threadTotalReplyCount}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -93,7 +93,6 @@ type ChannelPaneProps = {
   threadTotalReplyCount: number;
   threadReplyTargetId: string | null;
   threadReplyTargetMessage: TimelineMessage | null;
-  threadPanelOpenKey: number;
   threadScrollTargetId: string | null;
   targetMessageId: string | null;
   typingPubkeys: string[];
@@ -129,7 +128,6 @@ export const ChannelPane = React.memo(function ChannelPane({
   targetMessageId,
   threadHeadMessage,
   threadMessages,
-  threadPanelOpenKey,
   threadScrollTargetId,
   threadTypingPubkeys,
   threadTotalReplyCount,
@@ -194,8 +192,7 @@ export const ChannelPane = React.memo(function ChannelPane({
     threadPanelWidthPx !== THREAD_PANEL_DEFAULT_WIDTH_PX;
 
   const isComposerDisabled =
-    !activeChannel ||
-    !activeChannel.isMember ||
+    !activeChannel?.isMember ||
     activeChannel.archivedAt !== null ||
     activeChannel.channelType === "forum" ||
     isSending;
@@ -278,7 +275,6 @@ export const ChannelPane = React.memo(function ChannelPane({
           onSend={onSendThreadReply}
           onScrollTargetResolved={onThreadScrollTargetResolved}
           onToggleReaction={onToggleReaction}
-          openKey={threadPanelOpenKey}
           profiles={profiles}
           replyTargetId={threadReplyTargetId}
           replyTargetMessage={threadReplyTargetMessage}

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -4,6 +4,7 @@ import { ChatHeader } from "@/features/chat/ui/ChatHeader";
 import { useActiveChannelHeader } from "@/features/channels/useActiveChannelHeader";
 import { useChannelPaneHandlers } from "@/features/channels/useChannelPaneHandlers";
 import { useChannelMembersQuery } from "@/features/channels/hooks";
+import { getChannelDescription } from "@/features/channels/lib/channelDescription";
 import { ChannelMembersBar } from "@/features/channels/ui/ChannelMembersBar";
 import { EphemeralChannelBadge } from "@/features/channels/ui/EphemeralChannelBadge";
 import { MembersSidebar } from "@/features/channels/ui/MembersSidebar";
@@ -83,7 +84,6 @@ export function ChannelScreen({
   const [threadScrollTargetId, setThreadScrollTargetId] = React.useState<
     string | null
   >(null);
-  const [threadPanelOpenKey, setThreadPanelOpenKey] = React.useState(0);
   const [threadReplyTargetId, setThreadReplyTargetId] = React.useState<
     string | null
   >(null);
@@ -256,9 +256,6 @@ export function ChannelScreen({
     (messageId: string) => directReplyIdsByParentId.get(messageId)?.[0] ?? null,
     [directReplyIdsByParentId],
   );
-  const handleThreadPanelOpen = React.useCallback(() => {
-    setThreadPanelOpenKey((current) => current + 1);
-  }, []);
   const threadPanelData = React.useMemo(
     () =>
       buildThreadPanelData(
@@ -303,7 +300,6 @@ export function ChannelScreen({
     editTargetId,
     expandedThreadReplyIds,
     getFirstReplyIdForMessage,
-    onThreadPanelOpen: handleThreadPanelOpen,
     openThreadHeadId,
     sendMessageMutation,
     setExpandedThreadReplyIds,
@@ -321,20 +317,7 @@ export function ChannelScreen({
     [canReact, handleToggleReaction],
   );
 
-  const channelDescription = activeChannel
-    ? [
-        activeChannel.archivedAt ? "Archived." : null,
-        !activeChannel.isMember
-          ? "Read-only until you join this open channel."
-          : null,
-        activeChannel.topic,
-        activeChannel.description,
-        activeChannel.purpose,
-        null,
-      ]
-        .filter((value) => value && value.trim().length > 0)
-        .join(" ") || "Channel details and activity."
-    : "Connect to the relay to browse channels and read messages.";
+  const channelDescription = getChannelDescription(activeChannel);
   const shouldLoadTimeline =
     activeChannel !== null && activeChannel.channelType !== "forum";
   const isTimelineLoading =
@@ -383,9 +366,6 @@ export function ChannelScreen({
     editTargetMessage,
     openThreadHeadId,
     openThreadHeadMessage,
-    setExpandedThreadReplyIds,
-    setThreadScrollTargetId,
-    setOpenThreadHeadId,
     threadReplyTargetId,
     threadReplyTargetMessage,
   ]);
@@ -489,7 +469,6 @@ export function ChannelScreen({
                 threadTotalReplyCount={threadTotalReplyCount}
                 threadReplyTargetId={threadReplyTargetId}
                 threadReplyTargetMessage={threadReplyTargetMessage}
-                threadPanelOpenKey={threadPanelOpenKey}
                 threadScrollTargetId={threadScrollTargetId}
                 typingPubkeys={mainTypingPubkeys}
               />

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -74,14 +74,22 @@ export function ChannelScreen({
 }: ChannelScreenProps) {
   const { markChannelRead, openChannelManagement } = useAppShell();
   const [isMembersSidebarOpen, setIsMembersSidebarOpen] = React.useState(false);
-  const [threadHeadPath, setThreadHeadPath] = React.useState<string[]>([]);
+  const [openThreadHeadId, setOpenThreadHeadId] = React.useState<string | null>(
+    null,
+  );
+  const [expandedThreadReplyIds, setExpandedThreadReplyIds] = React.useState<
+    Set<string>
+  >(new Set());
+  const [threadScrollTargetId, setThreadScrollTargetId] = React.useState<
+    string | null
+  >(null);
+  const [threadPanelOpenKey, setThreadPanelOpenKey] = React.useState(0);
   const [threadReplyTargetId, setThreadReplyTargetId] = React.useState<
     string | null
   >(null);
   const [editTargetId, setEditTargetId] = React.useState<string | null>(null);
   const currentPubkey = currentIdentity?.pubkey;
   const activeChannelId = activeChannel?.id ?? null;
-  const openThreadHeadId = threadHeadPath[threadHeadPath.length - 1] ?? null;
 
   const messagesQuery = useChannelMessagesQuery(activeChannel);
   useChannelSubscription(activeChannel);
@@ -229,14 +237,42 @@ export function ChannelScreen({
       resolvedMessages,
     ],
   );
+  const directReplyIdsByParentId = React.useMemo(() => {
+    const map = new Map<string, string[]>();
+
+    for (const message of timelineMessages) {
+      if (!message.parentId) {
+        continue;
+      }
+
+      const currentReplies = map.get(message.parentId) ?? [];
+      currentReplies.push(message.id);
+      map.set(message.parentId, currentReplies);
+    }
+
+    return map;
+  }, [timelineMessages]);
+  const getFirstReplyIdForMessage = React.useCallback(
+    (messageId: string) => directReplyIdsByParentId.get(messageId)?.[0] ?? null,
+    [directReplyIdsByParentId],
+  );
+  const handleThreadPanelOpen = React.useCallback(() => {
+    setThreadPanelOpenKey((current) => current + 1);
+  }, []);
   const threadPanelData = React.useMemo(
     () =>
       buildThreadPanelData(
         timelineMessages,
         openThreadHeadId,
         threadReplyTargetId,
+        expandedThreadReplyIds,
       ),
-    [openThreadHeadId, threadReplyTargetId, timelineMessages],
+    [
+      expandedThreadReplyIds,
+      openThreadHeadId,
+      threadReplyTargetId,
+      timelineMessages,
+    ],
   );
   const openThreadHeadMessage = threadPanelData.threadHead;
   const threadMessages = threadPanelData.visibleReplies;
@@ -251,25 +287,30 @@ export function ChannelScreen({
   const {
     handleCancelEdit,
     handleCancelThreadReply,
-    handleBackThread,
     handleCloseThread,
     handleDelete,
     handleEdit,
     handleEditSave,
-    handleOpenNestedThread,
+    handleExpandThreadReplies,
     handleOpenThread,
     handleSendMessage,
     handleSendThreadReply,
+    handleSelectThreadReplyTarget,
     handleToggleReaction,
   } = useChannelPaneHandlers({
     deleteMessageMutation,
     editMessageMutation,
     editTargetId,
+    expandedThreadReplyIds,
+    getFirstReplyIdForMessage,
+    onThreadPanelOpen: handleThreadPanelOpen,
     openThreadHeadId,
     sendMessageMutation,
+    setExpandedThreadReplyIds,
     setEditTargetId,
-    setThreadHeadPath,
+    setOpenThreadHeadId,
     setThreadReplyTargetId,
+    setThreadScrollTargetId,
     threadReplyTargetId,
     toggleReactionMutation,
   });
@@ -302,12 +343,17 @@ export function ChannelScreen({
       (messagesQuery.isFetching && resolvedMessages.length === 0));
   const resetComposerTargets = React.useCallback(
     (_channelId: string | null) => {
-      setThreadHeadPath([]);
+      setOpenThreadHeadId(null);
+      setExpandedThreadReplyIds(new Set());
+      setThreadScrollTargetId(null);
       setThreadReplyTargetId(null);
       setEditTargetId(null);
     },
     [],
   );
+  const handleThreadScrollTargetResolved = React.useCallback(() => {
+    setThreadScrollTargetId(null);
+  }, []);
 
   React.useEffect(() => {
     resetComposerTargets(activeChannelId);
@@ -315,7 +361,9 @@ export function ChannelScreen({
 
   React.useEffect(() => {
     if (openThreadHeadId && !openThreadHeadMessage) {
-      setThreadHeadPath((current) => current.slice(0, -1));
+      setOpenThreadHeadId(null);
+      setExpandedThreadReplyIds(new Set());
+      setThreadScrollTargetId(null);
       return;
     }
 
@@ -335,6 +383,9 @@ export function ChannelScreen({
     editTargetMessage,
     openThreadHeadId,
     openThreadHeadMessage,
+    setExpandedThreadReplyIds,
+    setThreadScrollTargetId,
+    setOpenThreadHeadId,
     threadReplyTargetId,
     threadReplyTargetMessage,
   ]);
@@ -417,17 +468,17 @@ export function ChannelScreen({
                 messages={timelineMessages}
                 onCancelEdit={handleCancelEdit}
                 onCancelThreadReply={handleCancelThreadReply}
-                onBackThread={handleBackThread}
                 onCloseThread={handleCloseThread}
                 onDelete={handleDelete}
                 onEdit={handleEdit}
                 onEditSave={handleEditSave}
-                onOpenNestedThread={handleOpenNestedThread}
+                onExpandThreadReplies={handleExpandThreadReplies}
                 onOpenThread={handleOpenThread}
+                onSelectThreadReplyTarget={handleSelectThreadReplyTarget}
                 onSendMessage={handleSendMessage}
                 onSendThreadReply={handleSendThreadReply}
+                onThreadScrollTargetResolved={handleThreadScrollTargetResolved}
                 onToggleReaction={effectiveToggleReaction}
-                canGoBackThread={threadHeadPath.length > 1}
                 openThreadHeadId={openThreadHeadId}
                 personaLookup={personaLookup}
                 profiles={messageProfiles}
@@ -438,6 +489,8 @@ export function ChannelScreen({
                 threadTotalReplyCount={threadTotalReplyCount}
                 threadReplyTargetId={threadReplyTargetId}
                 threadReplyTargetMessage={threadReplyTargetMessage}
+                threadPanelOpenKey={threadPanelOpenKey}
+                threadScrollTargetId={threadScrollTargetId}
                 typingPubkeys={mainTypingPubkeys}
               />
             </React.Suspense>

--- a/desktop/src/features/channels/useChannelPaneHandlers.ts
+++ b/desktop/src/features/channels/useChannelPaneHandlers.ts
@@ -21,7 +21,6 @@ export function useChannelPaneHandlers({
   editTargetId,
   expandedThreadReplyIds,
   getFirstReplyIdForMessage,
-  onThreadPanelOpen,
   openThreadHeadId,
   sendMessageMutation,
   setExpandedThreadReplyIds,
@@ -37,7 +36,6 @@ export function useChannelPaneHandlers({
   editTargetId: string | null;
   expandedThreadReplyIds: ReadonlySet<string>;
   getFirstReplyIdForMessage: (messageId: string) => string | null;
-  onThreadPanelOpen: () => void;
   openThreadHeadId: string | null;
   sendMessageMutation: ReturnType<typeof useSendMessageMutation>;
   setExpandedThreadReplyIds: React.Dispatch<React.SetStateAction<Set<string>>>;
@@ -132,7 +130,6 @@ export function useChannelPaneHandlers({
       }
 
       setOpenThreadHeadId(message.id);
-      onThreadPanelOpen();
       setThreadReplyTargetId(message.id);
       setThreadScrollTargetId(null);
       setExpandedThreadReplyIds(new Set());
@@ -141,7 +138,6 @@ export function useChannelPaneHandlers({
     [
       setEditTargetId,
       setExpandedThreadReplyIds,
-      onThreadPanelOpen,
       setOpenThreadHeadId,
       setThreadReplyTargetId,
       setThreadScrollTargetId,
@@ -204,7 +200,8 @@ export function useChannelPaneHandlers({
       mediaTags?: string[][],
     ) => {
       const activeThreadHeadId = openThreadHeadIdRef.current;
-      const parentEventId = threadReplyTargetIdRef.current ?? activeThreadHeadId;
+      const parentEventId =
+        threadReplyTargetIdRef.current ?? activeThreadHeadId;
       if (!parentEventId) {
         return;
       }
@@ -232,7 +229,11 @@ export function useChannelPaneHandlers({
         setThreadScrollTargetId(sentMessage.id);
       }
     },
-    [setExpandedThreadReplyIds, setThreadReplyTargetId, setThreadScrollTargetId],
+    [
+      setExpandedThreadReplyIds,
+      setThreadReplyTargetId,
+      setThreadScrollTargetId,
+    ],
   );
 
   const handleToggleReaction = React.useCallback(

--- a/desktop/src/features/channels/useChannelPaneHandlers.ts
+++ b/desktop/src/features/channels/useChannelPaneHandlers.ts
@@ -19,22 +19,32 @@ export function useChannelPaneHandlers({
   deleteMessageMutation,
   editMessageMutation,
   editTargetId,
+  expandedThreadReplyIds,
+  getFirstReplyIdForMessage,
+  onThreadPanelOpen,
   openThreadHeadId,
   sendMessageMutation,
+  setExpandedThreadReplyIds,
   setEditTargetId,
-  setThreadHeadPath,
+  setOpenThreadHeadId,
   setThreadReplyTargetId,
+  setThreadScrollTargetId,
   threadReplyTargetId,
   toggleReactionMutation,
 }: {
   deleteMessageMutation: ReturnType<typeof useDeleteMessageMutation>;
   editMessageMutation: ReturnType<typeof useEditMessageMutation>;
   editTargetId: string | null;
+  expandedThreadReplyIds: ReadonlySet<string>;
+  getFirstReplyIdForMessage: (messageId: string) => string | null;
+  onThreadPanelOpen: () => void;
   openThreadHeadId: string | null;
   sendMessageMutation: ReturnType<typeof useSendMessageMutation>;
+  setExpandedThreadReplyIds: React.Dispatch<React.SetStateAction<Set<string>>>;
   setEditTargetId: React.Dispatch<React.SetStateAction<string | null>>;
-  setThreadHeadPath: React.Dispatch<React.SetStateAction<string[]>>;
+  setOpenThreadHeadId: React.Dispatch<React.SetStateAction<string | null>>;
   setThreadReplyTargetId: React.Dispatch<React.SetStateAction<string | null>>;
+  setThreadScrollTargetId: React.Dispatch<React.SetStateAction<string | null>>;
   threadReplyTargetId: string | null;
   toggleReactionMutation: ReturnType<typeof useToggleReactionMutation>;
 }) {
@@ -47,6 +57,9 @@ export function useChannelPaneHandlers({
 
   const editTargetIdRef = React.useRef(editTargetId);
   editTargetIdRef.current = editTargetId;
+
+  const expandedThreadReplyIdsRef = React.useRef(expandedThreadReplyIds);
+  expandedThreadReplyIdsRef.current = expandedThreadReplyIds;
 
   const sendMutateRef = React.useRef(sendMessageMutation.mutateAsync);
   sendMutateRef.current = sendMessageMutation.mutateAsync;
@@ -65,20 +78,16 @@ export function useChannelPaneHandlers({
   }, [setThreadReplyTargetId]);
 
   const handleCloseThread = React.useCallback(() => {
-    setThreadHeadPath([]);
+    setOpenThreadHeadId(null);
     setThreadReplyTargetId(null);
-  }, [setThreadHeadPath, setThreadReplyTargetId]);
-
-  const handleBackThread = React.useCallback(() => {
-    setThreadHeadPath((current) => {
-      if (current.length <= 1) {
-        return current;
-      }
-      const nextPath = current.slice(0, -1);
-      setThreadReplyTargetId(nextPath[nextPath.length - 1] ?? null);
-      return nextPath;
-    });
-  }, [setThreadHeadPath, setThreadReplyTargetId]);
+    setThreadScrollTargetId(null);
+    setExpandedThreadReplyIds(new Set());
+  }, [
+    setExpandedThreadReplyIds,
+    setOpenThreadHeadId,
+    setThreadReplyTargetId,
+    setThreadScrollTargetId,
+  ]);
 
   const handleCancelEdit = React.useCallback(() => {
     setEditTargetId(null);
@@ -114,31 +123,63 @@ export function useChannelPaneHandlers({
   const handleOpenThread = React.useCallback(
     (message: { id: string }) => {
       if (openThreadHeadIdRef.current === message.id) {
-        setThreadHeadPath([]);
+        setOpenThreadHeadId(null);
         setThreadReplyTargetId(null);
+        setThreadScrollTargetId(null);
+        setExpandedThreadReplyIds(new Set());
         setEditTargetId(null);
         return;
       }
 
-      setThreadHeadPath([message.id]);
+      setOpenThreadHeadId(message.id);
+      onThreadPanelOpen();
       setThreadReplyTargetId(message.id);
+      setThreadScrollTargetId(null);
+      setExpandedThreadReplyIds(new Set());
       setEditTargetId(null);
     },
-    [setEditTargetId, setThreadHeadPath, setThreadReplyTargetId],
+    [
+      setEditTargetId,
+      setExpandedThreadReplyIds,
+      onThreadPanelOpen,
+      setOpenThreadHeadId,
+      setThreadReplyTargetId,
+      setThreadScrollTargetId,
+    ],
   );
 
-  const handleOpenNestedThread = React.useCallback(
+  const handleSelectThreadReplyTarget = React.useCallback(
     (message: { id: string }) => {
-      setThreadHeadPath((current) => {
-        if (current[current.length - 1] === message.id) {
-          return current;
-        }
-        return [...current, message.id];
-      });
-      setThreadReplyTargetId(message.id);
+      if (threadReplyTargetIdRef.current === message.id) {
+        setThreadReplyTargetId(openThreadHeadIdRef.current);
+      } else {
+        setThreadReplyTargetId(message.id);
+      }
       setEditTargetId(null);
     },
-    [setEditTargetId, setThreadHeadPath, setThreadReplyTargetId],
+    [setEditTargetId, setThreadReplyTargetId],
+  );
+
+  const handleExpandThreadReplies = React.useCallback(
+    (message: { id: string }) => {
+      const firstReplyId = getFirstReplyIdForMessage(message.id);
+      if (!expandedThreadReplyIdsRef.current.has(message.id)) {
+        setExpandedThreadReplyIds((current) => {
+          const next = new Set(current);
+          next.add(message.id);
+          return next;
+        });
+      }
+
+      if (firstReplyId) {
+        setThreadScrollTargetId(firstReplyId);
+      }
+    },
+    [
+      getFirstReplyIdForMessage,
+      setExpandedThreadReplyIds,
+      setThreadScrollTargetId,
+    ],
   );
 
   const handleSendMessage = React.useCallback(
@@ -162,21 +203,36 @@ export function useChannelPaneHandlers({
       mentionPubkeys: string[],
       mediaTags?: string[][],
     ) => {
-      const parentEventId =
-        threadReplyTargetIdRef.current ?? openThreadHeadIdRef.current;
+      const activeThreadHeadId = openThreadHeadIdRef.current;
+      const parentEventId = threadReplyTargetIdRef.current ?? activeThreadHeadId;
       if (!parentEventId) {
         return;
       }
 
-      await sendMutateRef.current({
+      if (
+        activeThreadHeadId &&
+        parentEventId !== activeThreadHeadId &&
+        !expandedThreadReplyIdsRef.current.has(parentEventId)
+      ) {
+        setExpandedThreadReplyIds((current) => {
+          const next = new Set(current);
+          next.add(parentEventId);
+          return next;
+        });
+      }
+
+      const sentMessage = await sendMutateRef.current({
         content,
         mentionPubkeys,
         parentEventId,
         mediaTags,
       });
-      setThreadReplyTargetId(openThreadHeadIdRef.current);
+      setThreadReplyTargetId(activeThreadHeadId);
+      if (activeThreadHeadId && parentEventId !== activeThreadHeadId) {
+        setThreadScrollTargetId(sentMessage.id);
+      }
     },
-    [setThreadReplyTargetId],
+    [setExpandedThreadReplyIds, setThreadReplyTargetId, setThreadScrollTargetId],
   );
 
   const handleToggleReaction = React.useCallback(
@@ -193,15 +249,15 @@ export function useChannelPaneHandlers({
   return {
     handleCancelEdit,
     handleCancelThreadReply,
-    handleBackThread,
     handleCloseThread,
     handleDelete,
     handleEdit,
     handleEditSave,
-    handleOpenNestedThread,
+    handleExpandThreadReplies,
     handleOpenThread,
     handleSendMessage,
     handleSendThreadReply,
+    handleSelectThreadReplyTarget,
     handleToggleReaction,
   };
 }

--- a/desktop/src/features/messages/lib/threadPanel.ts
+++ b/desktop/src/features/messages/lib/threadPanel.ts
@@ -31,11 +31,13 @@ function normalizeHeadMessage(message: TimelineMessage): TimelineMessage {
   };
 }
 
-function normalizeBranchReply(message: TimelineMessage): TimelineMessage {
+function normalizeInlineReplyMessage(
+  message: TimelineMessage,
+  depth: number,
+): TimelineMessage {
   return {
     ...message,
-    // Thread-panel replies render flat like Slack's side thread view.
-    depth: 0,
+    depth,
   };
 }
 
@@ -100,6 +102,60 @@ function buildSummaryForDirectReplies(
   };
 }
 
+function appendExpandedReplies(params: {
+  entries: MainTimelineEntry[];
+  parentId: string;
+  depth: number;
+  directChildrenByParentId: Map<string, TimelineMessage[]>;
+  expandedReplyIds: ReadonlySet<string>;
+}) {
+  const {
+    entries,
+    parentId,
+    depth,
+    directChildrenByParentId,
+    expandedReplyIds,
+  } = params;
+  const directReplies = directChildrenByParentId.get(parentId) ?? [];
+
+  for (const reply of directReplies) {
+    entries.push({
+      message: normalizeInlineReplyMessage(reply, depth),
+      summary: buildSummaryForDirectReplies(reply.id, directChildrenByParentId),
+    });
+
+    if (expandedReplyIds.has(reply.id)) {
+      appendExpandedReplies({
+        entries,
+        parentId: reply.id,
+        depth: depth + 1,
+        directChildrenByParentId,
+        expandedReplyIds,
+      });
+    }
+  }
+}
+
+function buildVisibleThreadReplies(params: {
+  openThreadHeadId: string;
+  directChildrenByParentId: Map<string, TimelineMessage[]>;
+  expandedReplyIds: ReadonlySet<string>;
+}) {
+  const { openThreadHeadId, directChildrenByParentId, expandedReplyIds } =
+    params;
+  const entries: MainTimelineEntry[] = [];
+
+  appendExpandedReplies({
+    entries,
+    parentId: openThreadHeadId,
+    depth: 1,
+    directChildrenByParentId,
+    expandedReplyIds,
+  });
+
+  return entries;
+}
+
 export function buildMainTimelineEntries(
   messages: TimelineMessage[],
 ): MainTimelineEntry[] {
@@ -122,6 +178,7 @@ export function buildThreadPanelData(
   messages: TimelineMessage[],
   openThreadHeadId: string | null,
   threadReplyTargetId: string | null,
+  expandedReplyIds: ReadonlySet<string>,
 ): ThreadPanelData {
   if (!openThreadHeadId) {
     return {
@@ -146,13 +203,11 @@ export function buildThreadPanelData(
 
   const directChildrenByParentId = buildDirectChildrenByParentId(messages);
   const normalizedThreadHead = normalizeHeadMessage(threadHead);
-  const directReplies = (
-    directChildrenByParentId.get(openThreadHeadId) ?? []
-  ).map((message) => normalizeBranchReply(message));
-  const visibleReplies = directReplies.map((message) => ({
-    message,
-    summary: buildSummaryForDirectReplies(message.id, directChildrenByParentId),
-  }));
+  const visibleReplies = buildVisibleThreadReplies({
+    openThreadHeadId,
+    directChildrenByParentId,
+    expandedReplyIds,
+  });
 
   const replyTargetInBranch =
     threadReplyTargetId === threadHead.id
@@ -161,7 +216,7 @@ export function buildThreadPanelData(
 
   return {
     threadHead: normalizedThreadHead,
-    totalReplyCount: directReplies.length,
+    totalReplyCount: directChildrenByParentId.get(openThreadHeadId)?.length ?? 0,
     visibleReplies,
     replyTargetMessage: replyTargetInBranch ?? normalizedThreadHead,
   };

--- a/desktop/src/features/messages/lib/threadPanel.ts
+++ b/desktop/src/features/messages/lib/threadPanel.ts
@@ -24,6 +24,13 @@ export type MainTimelineEntry = {
   summary: TimelineThreadSummary | null;
 };
 
+type ThreadDescendantStats = {
+  descendantCount: number;
+  recentParticipantsNewestFirst: TimelineThreadSummaryParticipant[];
+};
+
+const MAX_SUMMARY_PARTICIPANTS = 3;
+
 function normalizeHeadMessage(message: TimelineMessage): TimelineMessage {
   return {
     ...message,
@@ -39,35 +46,6 @@ function normalizeInlineReplyMessage(
     ...message,
     depth,
   };
-}
-
-function buildSummaryParticipants(
-  replies: TimelineMessage[],
-): TimelineThreadSummaryParticipant[] {
-  const recentUniqueParticipants = new Map<
-    string,
-    TimelineThreadSummaryParticipant
-  >();
-
-  for (let index = replies.length - 1; index >= 0; index -= 1) {
-    const reply = replies[index];
-    const participantKey = reply.pubkey ?? reply.id;
-    if (recentUniqueParticipants.has(participantKey)) {
-      continue;
-    }
-
-    recentUniqueParticipants.set(participantKey, {
-      id: participantKey,
-      author: reply.author,
-      avatarUrl: reply.avatarUrl ?? null,
-    });
-
-    if (recentUniqueParticipants.size >= 3) {
-      break;
-    }
-  }
-
-  return [...recentUniqueParticipants.values()].reverse();
 }
 
 function buildDirectChildrenByParentId(messages: TimelineMessage[]) {
@@ -86,19 +64,82 @@ function buildDirectChildrenByParentId(messages: TimelineMessage[]) {
   return childrenByParentId;
 }
 
+function buildDescendantStatsByMessageId(
+  messages: TimelineMessage[],
+): Map<string, ThreadDescendantStats> {
+  const messageById = new Map(messages.map((message) => [message.id, message]));
+  const descendantStatsByMessageId = new Map<string, ThreadDescendantStats>(
+    messages.map((message) => [
+      message.id,
+      {
+        descendantCount: 0,
+        recentParticipantsNewestFirst: [],
+      },
+    ]),
+  );
+
+  const orderedMessages = messages
+    .map((message, index) => ({ message, index }))
+    .sort((left, right) => {
+      if (left.message.createdAt !== right.message.createdAt) {
+        return left.message.createdAt - right.message.createdAt;
+      }
+
+      return left.index - right.index;
+    });
+
+  for (let index = orderedMessages.length - 1; index >= 0; index -= 1) {
+    const message = orderedMessages[index].message;
+    const participantKey = message.pubkey ?? message.id;
+    const participant: TimelineThreadSummaryParticipant = {
+      id: participantKey,
+      author: message.author,
+      avatarUrl: message.avatarUrl ?? null,
+    };
+
+    let ancestorId = message.parentId ?? null;
+    let hops = 0;
+    const maxHops = messages.length + 1;
+
+    while (ancestorId && hops < maxHops) {
+      const ancestorStats = descendantStatsByMessageId.get(ancestorId);
+      if (!ancestorStats) {
+        break;
+      }
+
+      ancestorStats.descendantCount += 1;
+
+      if (
+        ancestorStats.recentParticipantsNewestFirst.length <
+          MAX_SUMMARY_PARTICIPANTS &&
+        !ancestorStats.recentParticipantsNewestFirst.some(
+          (existingParticipant) => existingParticipant.id === participant.id,
+        )
+      ) {
+        ancestorStats.recentParticipantsNewestFirst.push(participant);
+      }
+
+      ancestorId = messageById.get(ancestorId)?.parentId ?? null;
+      hops += 1;
+    }
+  }
+
+  return descendantStatsByMessageId;
+}
+
 function buildSummaryForDirectReplies(
   messageId: string,
-  directChildrenByParentId: Map<string, TimelineMessage[]>,
+  descendantStatsByMessageId: Map<string, ThreadDescendantStats>,
 ): TimelineThreadSummary | null {
-  const directReplies = directChildrenByParentId.get(messageId) ?? [];
-  if (directReplies.length === 0) {
+  const descendantStats = descendantStatsByMessageId.get(messageId);
+  if (!descendantStats || descendantStats.descendantCount === 0) {
     return null;
   }
 
   return {
     threadHeadId: messageId,
-    replyCount: directReplies.length,
-    participants: buildSummaryParticipants(directReplies),
+    replyCount: descendantStats.descendantCount,
+    participants: [...descendantStats.recentParticipantsNewestFirst].reverse(),
   };
 }
 
@@ -107,6 +148,7 @@ function appendExpandedReplies(params: {
   parentId: string;
   depth: number;
   directChildrenByParentId: Map<string, TimelineMessage[]>;
+  descendantStatsByMessageId: Map<string, ThreadDescendantStats>;
   expandedReplyIds: ReadonlySet<string>;
 }) {
   const {
@@ -114,6 +156,7 @@ function appendExpandedReplies(params: {
     parentId,
     depth,
     directChildrenByParentId,
+    descendantStatsByMessageId,
     expandedReplyIds,
   } = params;
   const directReplies = directChildrenByParentId.get(parentId) ?? [];
@@ -121,7 +164,7 @@ function appendExpandedReplies(params: {
   for (const reply of directReplies) {
     entries.push({
       message: normalizeInlineReplyMessage(reply, depth),
-      summary: buildSummaryForDirectReplies(reply.id, directChildrenByParentId),
+      summary: buildSummaryForDirectReplies(reply.id, descendantStatsByMessageId),
     });
 
     if (expandedReplyIds.has(reply.id)) {
@@ -130,6 +173,7 @@ function appendExpandedReplies(params: {
         parentId: reply.id,
         depth: depth + 1,
         directChildrenByParentId,
+        descendantStatsByMessageId,
         expandedReplyIds,
       });
     }
@@ -139,10 +183,15 @@ function appendExpandedReplies(params: {
 function buildVisibleThreadReplies(params: {
   openThreadHeadId: string;
   directChildrenByParentId: Map<string, TimelineMessage[]>;
+  descendantStatsByMessageId: Map<string, ThreadDescendantStats>;
   expandedReplyIds: ReadonlySet<string>;
 }) {
-  const { openThreadHeadId, directChildrenByParentId, expandedReplyIds } =
-    params;
+  const {
+    openThreadHeadId,
+    directChildrenByParentId,
+    descendantStatsByMessageId,
+    expandedReplyIds,
+  } = params;
   const entries: MainTimelineEntry[] = [];
 
   appendExpandedReplies({
@@ -150,6 +199,7 @@ function buildVisibleThreadReplies(params: {
     parentId: openThreadHeadId,
     depth: 1,
     directChildrenByParentId,
+    descendantStatsByMessageId,
     expandedReplyIds,
   });
 
@@ -159,7 +209,7 @@ function buildVisibleThreadReplies(params: {
 export function buildMainTimelineEntries(
   messages: TimelineMessage[],
 ): MainTimelineEntry[] {
-  const directChildrenByParentId = buildDirectChildrenByParentId(messages);
+  const descendantStatsByMessageId = buildDescendantStatsByMessageId(messages);
 
   return messages
     .filter((message) => message.parentId == null)
@@ -168,7 +218,7 @@ export function buildMainTimelineEntries(
         message,
         summary: buildSummaryForDirectReplies(
           message.id,
-          directChildrenByParentId,
+          descendantStatsByMessageId,
         ),
       };
     });
@@ -202,10 +252,12 @@ export function buildThreadPanelData(
   }
 
   const directChildrenByParentId = buildDirectChildrenByParentId(messages);
+  const descendantStatsByMessageId = buildDescendantStatsByMessageId(messages);
   const normalizedThreadHead = normalizeHeadMessage(threadHead);
   const visibleReplies = buildVisibleThreadReplies({
     openThreadHeadId,
     directChildrenByParentId,
+    descendantStatsByMessageId,
     expandedReplyIds,
   });
 
@@ -216,7 +268,8 @@ export function buildThreadPanelData(
 
   return {
     threadHead: normalizedThreadHead,
-    totalReplyCount: directChildrenByParentId.get(openThreadHeadId)?.length ?? 0,
+    totalReplyCount:
+      descendantStatsByMessageId.get(openThreadHeadId)?.descendantCount ?? 0,
     visibleReplies,
     replyTargetMessage: replyTargetInBranch ?? normalizedThreadHead,
   };

--- a/desktop/src/features/messages/lib/threadPanel.ts
+++ b/desktop/src/features/messages/lib/threadPanel.ts
@@ -164,7 +164,10 @@ function appendExpandedReplies(params: {
   for (const reply of directReplies) {
     entries.push({
       message: normalizeInlineReplyMessage(reply, depth),
-      summary: buildSummaryForDirectReplies(reply.id, descendantStatsByMessageId),
+      summary: buildSummaryForDirectReplies(
+        reply.id,
+        descendantStatsByMessageId,
+      ),
     });
 
     if (expandedReplyIds.has(reply.id)) {

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { EditorContent } from "@tiptap/react";
+import { X } from "lucide-react";
 import { useChannelLinks } from "@/features/messages/lib/useChannelLinks";
 import type { ChannelSuggestion } from "@/features/messages/lib/useChannelLinks";
 import { useDrafts } from "@/features/messages/lib/useDrafts";
@@ -565,13 +566,14 @@ export function MessageComposer({
                 </p>
               </div>
               <Button
-                className="shrink-0"
+                aria-label="Cancel reply"
+                className="h-7 w-7 shrink-0 px-0"
                 onClick={onCancelReply}
-                size="sm"
+                size="icon"
                 type="button"
                 variant="ghost"
               >
-                Cancel
+                <X className="h-4 w-4" />
               </Button>
             </div>
           ) : null}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -21,6 +21,7 @@ export const MessageRow = React.memo(
   function MessageRow({
     activeReplyTargetId = null,
     highlighted = false,
+    layoutVariant = "default",
     message,
     onDelete,
     onEdit,
@@ -30,6 +31,7 @@ export const MessageRow = React.memo(
   }: {
     activeReplyTargetId?: string | null;
     highlighted?: boolean;
+    layoutVariant?: "default" | "thread-reply";
     message: TimelineMessage;
     onDelete?: (message: TimelineMessage) => void;
     onEdit?: (message: TimelineMessage) => void;
@@ -66,6 +68,9 @@ export const MessageRow = React.memo(
 
     const visibleDepth = Math.min(message.depth, 6);
     const indentPx = visibleDepth * 28;
+    const depthGuideOffsets = React.useMemo(() => {
+      return Array.from({ length: visibleDepth }, (_, index) => 14 + index * 28);
+    }, [visibleDepth]);
     const getTag = (name: string) =>
       message.tags?.find((tag) => tag[0] === name)?.[1];
 
@@ -146,160 +151,215 @@ export const MessageRow = React.memo(
       [message, onToggleReaction, reactionPending, reactions],
     );
 
+    const isThreadReplyLayout = layoutVariant === "thread-reply";
+    const guideBleedPx = isThreadReplyLayout ? 4 : 0;
+    const avatarSizeClass = isThreadReplyLayout
+      ? "!h-5 !w-5 !rounded-md"
+      : "!h-[42px] !w-[42px]";
+    const avatarButtonRadiusClass = isThreadReplyLayout ? "rounded-md" : "rounded-xl";
+
+    const avatarNode = message.pubkey ? (
+      <UserProfilePopover
+        pubkey={message.pubkey}
+        role={message.role}
+        botIdenticonValue={message.author}
+      >
+        <button
+          className={cn(
+            "shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            avatarButtonRadiusClass,
+          )}
+          type="button"
+        >
+          <UserAvatar
+            accent={message.accent}
+            avatarUrl={message.avatarUrl ?? null}
+            className={avatarSizeClass}
+            displayName={message.author}
+            testId="message-avatar"
+          />
+        </button>
+      </UserProfilePopover>
+    ) : (
+      <UserAvatar
+        accent={message.accent}
+        avatarUrl={message.avatarUrl ?? null}
+        className={cn("shrink-0", avatarSizeClass)}
+        displayName={message.author}
+        testId="message-avatar"
+      />
+    );
+
+    const authorNode = message.pubkey ? (
+      <UserProfilePopover
+        pubkey={message.pubkey}
+        role={message.role}
+        botIdenticonValue={message.author}
+      >
+        <button
+          className="truncate rounded text-sm font-semibold tracking-tight hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          type="button"
+        >
+          {message.author}
+        </button>
+      </UserProfilePopover>
+    ) : (
+      <h3 className="truncate text-sm font-semibold tracking-tight">
+        {message.author}
+      </h3>
+    );
+
+    const metadataNode = (
+      <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="relative">
+          <div className="absolute right-0 top-1/2 -translate-y-1/2">
+            <MessageActionBar
+              activeReplyTargetId={activeReplyTargetId}
+              message={message}
+              onDelete={onDelete}
+              onEdit={onEdit}
+              onReactionSelect={
+                canToggleReactions ? handleReactionSelect : undefined
+              }
+              onReply={onReply}
+              reactionErrorMessage={reactionErrorMessage}
+              reactionPending={reactionPending}
+              reactions={reactions}
+            />
+          </div>
+        </div>
+        {message.pending ? (
+          <p className="font-medium uppercase tracking-[0.14em] text-primary/80">
+            Sending
+          </p>
+        ) : null}
+        {message.edited ? (
+          <p className="text-muted-foreground/70" title="This message has been edited">
+            (edited)
+          </p>
+        ) : null}
+        <MessageTimestamp createdAt={message.createdAt} time={message.time} />
+      </div>
+    );
+
+    const messageBodyNode = (
+      <>
+        {renderBody()}
+        <MessageReactions
+          messageId={message.id}
+          reactions={reactions}
+          canToggle={canToggleReactions}
+          pending={reactionPending}
+          onSelect={(emoji) => {
+            void handleReactionSelect(emoji).catch(() => {
+              return;
+            });
+          }}
+        />
+        {reactionErrorMessage ? (
+          <p className="mt-1.5 text-xs text-destructive">{reactionErrorMessage}</p>
+        ) : null}
+        {expandedDiffId === message.id ? (
+          <React.Suspense
+            fallback={
+              <div className="p-3 text-sm text-muted-foreground">
+                Loading diff viewer…
+              </div>
+            }
+          >
+            <DiffMessageExpanded
+              content={message.body}
+              filePath={getTag("file")}
+              onClose={() => {
+                setExpandedDiffId(null);
+              }}
+            />
+          </React.Suspense>
+        ) : null}
+      </>
+    );
+
     return (
       <div
         className="relative"
         style={indentPx > 0 ? { paddingLeft: `${indentPx}px` } : undefined}
       >
-        {message.depth > 0 ? (
+        {depthGuideOffsets.length > 0 ? (
           <div
             aria-hidden
-            className="absolute bottom-1.5 left-3 top-1.5 rounded-full border-l border-border/70"
-            style={{ left: `${Math.max(indentPx - 14, 12)}px` }}
-          />
+            className="pointer-events-none absolute left-0"
+            style={{
+              bottom: `${-guideBleedPx}px`,
+              top: `${-guideBleedPx}px`,
+            }}
+          >
+            {depthGuideOffsets.map((offset, index) => (
+              <div
+                className="absolute bottom-0 top-0 border-l border-border/70"
+                key={`${message.id}-depth-guide-${offset}`}
+                style={{
+                  left: `${offset}px`,
+                  opacity: index === depthGuideOffsets.length - 1 ? 0.9 : 0.55,
+                }}
+              />
+            ))}
+          </div>
         ) : null}
 
         <article
           className={cn(
-            "group/message flex items-start gap-2.5 rounded-2xl px-2 py-1.5 transition-colors",
+            "group/message rounded-2xl px-2 py-1.5 transition-colors",
+            isThreadReplyLayout ? "space-y-1.5" : "flex items-start gap-2.5",
             highlighted ? "bg-primary/10 ring-1 ring-primary/30" : "",
           )}
           data-message-id={message.id}
           data-testid="message-row"
         >
-          <div className="flex shrink-0 items-start">
-            {message.pubkey ? (
-              <UserProfilePopover
-                pubkey={message.pubkey}
-                role={message.role}
-                botIdenticonValue={message.author}
-              >
-                <button
-                  className="shrink-0 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  type="button"
-                >
-                  <UserAvatar
-                    accent={message.accent}
-                    avatarUrl={message.avatarUrl ?? null}
-                    className="!h-[42px] !w-[42px]"
-                    displayName={message.author}
-                    testId="message-avatar"
-                  />
-                </button>
-              </UserProfilePopover>
-            ) : (
-              <UserAvatar
-                accent={message.accent}
-                avatarUrl={message.avatarUrl ?? null}
-                className="shrink-0 !h-[42px] !w-[42px]"
-                displayName={message.author}
-                testId="message-avatar"
-              />
-            )}
-          </div>
-
-          <div className="min-w-0 flex-1 space-y-1">
-            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-              {message.pubkey ? (
-                <UserProfilePopover
-                  pubkey={message.pubkey}
-                  role={message.role}
-                  botIdenticonValue={message.author}
-                >
-                  <button
-                    className="truncate rounded text-sm font-semibold tracking-tight hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    type="button"
-                  >
-                    {message.author}
-                  </button>
-                </UserProfilePopover>
-              ) : (
-                <h3 className="truncate text-sm font-semibold tracking-tight">
-                  {message.author}
-                </h3>
-              )}
-              {message.personaDisplayName &&
-              message.personaDisplayName !== message.author ? (
-                <span className="text-xs text-muted-foreground">
-                  {message.personaDisplayName}
-                </span>
-              ) : message.role ? (
-                <p className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                  {message.role}
-                </p>
-              ) : null}
-              <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
-                <div className="relative">
-                  <div className="absolute right-0 top-1/2 -translate-y-1/2">
-                    <MessageActionBar
-                      activeReplyTargetId={activeReplyTargetId}
-                      message={message}
-                      onDelete={onDelete}
-                      onEdit={onEdit}
-                      onReactionSelect={
-                        canToggleReactions ? handleReactionSelect : undefined
-                      }
-                      onReply={onReply}
-                      reactionErrorMessage={reactionErrorMessage}
-                      reactionPending={reactionPending}
-                      reactions={reactions}
-                    />
+          {isThreadReplyLayout ? (
+            <>
+              <div className="flex min-w-0 items-start gap-1.5">
+                <div className="flex shrink-0 items-start">{avatarNode}</div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                    {authorNode}
+                    {message.personaDisplayName &&
+                    message.personaDisplayName !== message.author ? (
+                      <span className="text-xs text-muted-foreground">
+                        {message.personaDisplayName}
+                      </span>
+                    ) : message.role ? (
+                      <p className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                        {message.role}
+                      </p>
+                    ) : null}
+                    {metadataNode}
                   </div>
                 </div>
-                {message.pending ? (
-                  <p className="font-medium uppercase tracking-[0.14em] text-primary/80">
-                    Sending
-                  </p>
-                ) : null}
-                {message.edited ? (
-                  <p
-                    className="text-muted-foreground/70"
-                    title="This message has been edited"
-                  >
-                    (edited)
-                  </p>
-                ) : null}
-                <MessageTimestamp
-                  createdAt={message.createdAt}
-                  time={message.time}
-                />
               </div>
-            </div>
-            {renderBody()}
-            <MessageReactions
-              messageId={message.id}
-              reactions={reactions}
-              canToggle={canToggleReactions}
-              pending={reactionPending}
-              onSelect={(emoji) => {
-                void handleReactionSelect(emoji).catch(() => {
-                  return;
-                });
-              }}
-            />
-            {reactionErrorMessage ? (
-              <p className="mt-1.5 text-xs text-destructive">
-                {reactionErrorMessage}
-              </p>
-            ) : null}
-            {expandedDiffId === message.id ? (
-              <React.Suspense
-                fallback={
-                  <div className="p-3 text-sm text-muted-foreground">
-                    Loading diff viewer…
-                  </div>
-                }
-              >
-                <DiffMessageExpanded
-                  content={message.body}
-                  filePath={getTag("file")}
-                  onClose={() => {
-                    setExpandedDiffId(null);
-                  }}
-                />
-              </React.Suspense>
-            ) : null}
-          </div>
+              <div className="min-w-0 space-y-1">{messageBodyNode}</div>
+            </>
+          ) : (
+            <>
+              <div className="flex shrink-0 items-start">{avatarNode}</div>
+              <div className="min-w-0 flex-1 space-y-1">
+                <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                  {authorNode}
+                  {message.personaDisplayName &&
+                  message.personaDisplayName !== message.author ? (
+                    <span className="text-xs text-muted-foreground">
+                      {message.personaDisplayName}
+                    </span>
+                  ) : message.role ? (
+                    <p className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                      {message.role}
+                    </p>
+                  ) : null}
+                  {metadataNode}
+                </div>
+                {messageBodyNode}
+              </div>
+            </>
+          )}
         </article>
       </div>
     );
@@ -324,6 +384,7 @@ export const MessageRow = React.memo(
     prev.message.personaDisplayName === next.message.personaDisplayName &&
     prev.highlighted === next.highlighted &&
     prev.activeReplyTargetId === next.activeReplyTargetId &&
+    prev.layoutVariant === next.layoutVariant &&
     prev.profiles === next.profiles,
 );
 

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -69,7 +69,10 @@ export const MessageRow = React.memo(
     const visibleDepth = Math.min(message.depth, 6);
     const indentPx = visibleDepth * 28;
     const depthGuideOffsets = React.useMemo(() => {
-      return Array.from({ length: visibleDepth }, (_, index) => 14 + index * 28);
+      return Array.from(
+        { length: visibleDepth },
+        (_, index) => 14 + index * 28,
+      );
     }, [visibleDepth]);
     const getTag = (name: string) =>
       message.tags?.find((tag) => tag[0] === name)?.[1];
@@ -156,7 +159,9 @@ export const MessageRow = React.memo(
     const avatarSizeClass = isThreadReplyLayout
       ? "!h-5 !w-5 !rounded-md"
       : "!h-[42px] !w-[42px]";
-    const avatarButtonRadiusClass = isThreadReplyLayout ? "rounded-md" : "rounded-xl";
+    const avatarButtonRadiusClass = isThreadReplyLayout
+      ? "rounded-md"
+      : "rounded-xl";
 
     const avatarNode = message.pubkey ? (
       <UserProfilePopover
@@ -234,7 +239,10 @@ export const MessageRow = React.memo(
           </p>
         ) : null}
         {message.edited ? (
-          <p className="text-muted-foreground/70" title="This message has been edited">
+          <p
+            className="text-muted-foreground/70"
+            title="This message has been edited"
+          >
             (edited)
           </p>
         ) : null}
@@ -257,7 +265,9 @@ export const MessageRow = React.memo(
           }}
         />
         {reactionErrorMessage ? (
-          <p className="mt-1.5 text-xs text-destructive">{reactionErrorMessage}</p>
+          <p className="mt-1.5 text-xs text-destructive">
+            {reactionErrorMessage}
+          </p>
         ) : null}
         {expandedDiffId === message.id ? (
           <React.Suspense

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -25,7 +25,6 @@ type MessageThreadPanelProps = {
   onExpandReplies: (message: TimelineMessage) => void;
   onResetWidth: () => void;
   onResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void;
-  openKey: number;
   onScrollTargetResolved: () => void;
   onSelectReplyTarget: (message: TimelineMessage) => void;
   onSend: (
@@ -74,7 +73,6 @@ export function MessageThreadPanel({
   onExpandReplies,
   onResetWidth,
   onResizeStart,
-  openKey,
   onScrollTargetResolved,
   onSelectReplyTarget,
   onSend,
@@ -122,7 +120,7 @@ export function MessageThreadPanel({
       cancelAnimationFrame(frame);
       window.clearTimeout(timeoutId);
     };
-  }, [openKey, threadHeadId]);
+  }, [threadHeadId]);
 
   React.useEffect(() => {
     if (!scrollTargetId) {
@@ -152,7 +150,7 @@ export function MessageThreadPanel({
     return () => {
       cancelAnimationFrame(frame);
     };
-  }, [onScrollTargetResolved, scrollTargetId, threadReplies]);
+  }, [onScrollTargetResolved, scrollTargetId]);
 
   if (!threadHead) {
     return null;
@@ -232,7 +230,8 @@ export function MessageThreadPanel({
                       layoutVariant="thread-reply"
                       message={entry.message}
                       onDelete={
-                        onDelete && canManageMessage(entry.message, currentPubkey)
+                        onDelete &&
+                        canManageMessage(entry.message, currentPubkey)
                           ? onDelete
                           : undefined
                       }

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -12,6 +12,7 @@ import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
 import { TypingIndicatorRow } from "./TypingIndicatorRow";
 
 type MessageThreadPanelProps = {
+  canResetWidth: boolean;
   channel: Channel | null;
   channelId: string | null;
   channelName: string;
@@ -22,6 +23,8 @@ type MessageThreadPanelProps = {
   onClose: () => void;
   onDelete?: (message: TimelineMessage) => void;
   onExpandReplies: (message: TimelineMessage) => void;
+  onResetWidth: () => void;
+  onResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void;
   openKey: number;
   onScrollTargetResolved: () => void;
   onSelectReplyTarget: (message: TimelineMessage) => void;
@@ -43,6 +46,7 @@ type MessageThreadPanelProps = {
   threadReplies: MainTimelineEntry[];
   threadTypingPubkeys: string[];
   totalReplyCount: number;
+  widthPx: number;
 };
 
 function canManageMessage(
@@ -57,6 +61,7 @@ function canManageMessage(
 }
 
 export function MessageThreadPanel({
+  canResetWidth,
   channel,
   channelId,
   channelName,
@@ -67,6 +72,8 @@ export function MessageThreadPanel({
   onClose,
   onDelete,
   onExpandReplies,
+  onResetWidth,
+  onResizeStart,
   openKey,
   onScrollTargetResolved,
   onSelectReplyTarget,
@@ -79,6 +86,7 @@ export function MessageThreadPanel({
   threadHead,
   threadReplies,
   threadTypingPubkeys,
+  widthPx,
 }: MessageThreadPanelProps) {
   const threadBodyRef = React.useRef<HTMLDivElement>(null);
   const threadHeadId = threadHead?.id ?? null;
@@ -152,9 +160,26 @@ export function MessageThreadPanel({
 
   return (
     <aside
-      className="hidden h-full w-[380px] shrink-0 flex-col border-l border-border/80 bg-background lg:flex"
+      className="relative hidden h-full shrink-0 flex-col border-l border-border/80 bg-background lg:flex"
       data-testid="message-thread-panel"
+      style={{ width: `${widthPx}px` }}
     >
+      <button
+        aria-label="Resize thread panel"
+        className="group absolute inset-y-0 left-0 z-20 w-3 -translate-x-1/2 cursor-col-resize"
+        data-testid="message-thread-resize-handle"
+        onDoubleClick={canResetWidth ? onResetWidth : undefined}
+        onPointerDown={onResizeStart}
+        title={
+          canResetWidth
+            ? "Drag to resize. Double-click to reset width."
+            : "Drag to resize."
+        }
+        type="button"
+      >
+        <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-border/80" />
+      </button>
+
       <div className="flex items-center gap-3 px-4 py-3">
         <div className="min-w-0 flex-1">
           <h2 className="text-sm font-semibold tracking-tight">Thread</h2>

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -1,4 +1,5 @@
-import { ArrowLeft, X } from "lucide-react";
+import * as React from "react";
+import { X } from "lucide-react";
 
 import type { MainTimelineEntry } from "@/features/messages/lib/threadPanel";
 import type { TimelineMessage } from "@/features/messages/types";
@@ -11,18 +12,19 @@ import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
 import { TypingIndicatorRow } from "./TypingIndicatorRow";
 
 type MessageThreadPanelProps = {
-  canGoBack: boolean;
   channel: Channel | null;
   channelId: string | null;
   channelName: string;
   currentPubkey?: string;
   disabled?: boolean;
   isSending: boolean;
-  onBack: () => void;
   onCancelReply: () => void;
   onClose: () => void;
   onDelete?: (message: TimelineMessage) => void;
-  onOpenNestedThread: (message: TimelineMessage) => void;
+  onExpandReplies: (message: TimelineMessage) => void;
+  openKey: number;
+  onScrollTargetResolved: () => void;
+  onSelectReplyTarget: (message: TimelineMessage) => void;
   onSend: (
     content: string,
     mentionPubkeys: string[],
@@ -36,6 +38,7 @@ type MessageThreadPanelProps = {
   profiles?: UserProfileLookup;
   replyTargetId: string | null;
   replyTargetMessage: TimelineMessage | null;
+  scrollTargetId: string | null;
   threadHead: TimelineMessage | null;
   threadReplies: MainTimelineEntry[];
   threadTypingPubkeys: string[];
@@ -54,33 +57,34 @@ function canManageMessage(
 }
 
 export function MessageThreadPanel({
-  canGoBack,
   channel,
   channelId,
   channelName,
   currentPubkey,
   disabled = false,
   isSending,
-  onBack,
   onCancelReply,
   onClose,
   onDelete,
-  onOpenNestedThread,
+  onExpandReplies,
+  openKey,
+  onScrollTargetResolved,
+  onSelectReplyTarget,
   onSend,
   onToggleReaction,
   profiles,
   replyTargetId,
   replyTargetMessage,
+  scrollTargetId,
   threadHead,
   threadReplies,
   threadTypingPubkeys,
 }: MessageThreadPanelProps) {
-  if (!threadHead) {
-    return null;
-  }
+  const threadBodyRef = React.useRef<HTMLDivElement>(null);
+  const threadHeadId = threadHead?.id ?? null;
 
   const composerReplyTarget =
-    replyTargetMessage && replyTargetMessage.id !== threadHead.id
+    replyTargetMessage && threadHead && replyTargetMessage.id !== threadHead.id
       ? {
           author: replyTargetMessage.author,
           body: replyTargetMessage.body,
@@ -88,24 +92,70 @@ export function MessageThreadPanel({
         }
       : null;
 
+  React.useEffect(() => {
+    if (!threadHeadId) {
+      return;
+    }
+
+    const threadBody = threadBodyRef.current;
+    if (!threadBody) {
+      return;
+    }
+
+    const scrollToBottom = () => {
+      threadBody.scrollTop = threadBody.scrollHeight;
+    };
+    const frame = requestAnimationFrame(() => {
+      scrollToBottom();
+    });
+    const timeoutId = window.setTimeout(scrollToBottom, 300);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.clearTimeout(timeoutId);
+    };
+  }, [openKey, threadHeadId]);
+
+  React.useEffect(() => {
+    if (!scrollTargetId) {
+      return;
+    }
+
+    const threadBody = threadBodyRef.current;
+    if (!threadBody) {
+      return;
+    }
+
+    const target = threadBody.querySelector<HTMLElement>(
+      `[data-message-id="${scrollTargetId}"]`,
+    );
+    if (!target) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      target.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+    onScrollTargetResolved();
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, [onScrollTargetResolved, scrollTargetId, threadReplies]);
+
+  if (!threadHead) {
+    return null;
+  }
+
   return (
     <aside
       className="hidden h-full w-[380px] shrink-0 flex-col border-l border-border/80 bg-background lg:flex"
       data-testid="message-thread-panel"
     >
       <div className="flex items-center gap-3 px-4 py-3">
-        {canGoBack ? (
-          <Button
-            aria-label="Back"
-            data-testid="message-thread-back"
-            onClick={onBack}
-            size="icon"
-            type="button"
-            variant="ghost"
-          >
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-        ) : null}
         <div className="min-w-0 flex-1">
           <h2 className="text-sm font-semibold tracking-tight">Thread</h2>
         </div>
@@ -124,47 +174,58 @@ export function MessageThreadPanel({
       <div
         className="min-h-0 flex-1 overflow-y-auto"
         data-testid="message-thread-body"
+        ref={threadBodyRef}
       >
-        <div className="px-3 py-3" data-testid="message-thread-head">
-          <MessageRow
-            activeReplyTargetId={replyTargetId}
-            message={threadHead}
-            onDelete={
-              onDelete && canManageMessage(threadHead, currentPubkey)
-                ? onDelete
-                : undefined
-            }
-            onToggleReaction={onToggleReaction}
-            profiles={profiles}
-          />
+        <div className="px-3 pb-1 pt-0" data-testid="message-thread-head">
+          <div className="rounded-2xl">
+            <MessageRow
+              activeReplyTargetId={replyTargetId}
+              layoutVariant="thread-reply"
+              message={threadHead}
+              onDelete={
+                onDelete && canManageMessage(threadHead, currentPubkey)
+                  ? onDelete
+                  : undefined
+              }
+              onToggleReaction={onToggleReaction}
+              profiles={profiles}
+            />
+          </div>
         </div>
 
-        <div className="px-3 py-3" data-testid="message-thread-replies">
+        <div className="px-3 pb-3 pt-1" data-testid="message-thread-replies">
           {threadReplies.length > 0 ? (
             <div className="space-y-2">
-              {threadReplies.map((entry) => (
-                <div key={entry.message.id}>
-                  <MessageRow
-                    activeReplyTargetId={replyTargetId}
-                    message={entry.message}
-                    onDelete={
-                      onDelete && canManageMessage(entry.message, currentPubkey)
-                        ? onDelete
-                        : undefined
-                    }
-                    onReply={onOpenNestedThread}
-                    onToggleReaction={onToggleReaction}
-                    profiles={profiles}
-                  />
-                  {entry.summary ? (
-                    <MessageThreadSummaryRow
+              {threadReplies.map((entry, index) => {
+                const nextDepth = threadReplies[index + 1]?.message.depth ?? -1;
+                const isExpanded = nextDepth > entry.message.depth;
+
+                return (
+                  <div key={entry.message.id}>
+                    <MessageRow
+                      activeReplyTargetId={replyTargetId}
+                      layoutVariant="thread-reply"
                       message={entry.message}
-                      onOpenThread={onOpenNestedThread}
-                      summary={entry.summary}
+                      onDelete={
+                        onDelete && canManageMessage(entry.message, currentPubkey)
+                          ? onDelete
+                          : undefined
+                      }
+                      onReply={onSelectReplyTarget}
+                      onToggleReaction={onToggleReaction}
+                      profiles={profiles}
                     />
-                  ) : null}
-                </div>
-              ))}
+                    {entry.summary && !isExpanded ? (
+                      <MessageThreadSummaryRow
+                        depth={entry.message.depth}
+                        message={entry.message}
+                        onOpenThread={onExpandReplies}
+                        summary={entry.summary}
+                      />
+                    ) : null}
+                  </div>
+                );
+              })}
             </div>
           ) : (
             <div className="rounded-2xl border border-dashed border-border/70 bg-card/40 px-4 py-6 text-center">

--- a/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
@@ -25,39 +25,70 @@ function ParticipantAvatar({
 }
 
 export function MessageThreadSummaryRow({
+  depth = 0,
   message,
   onOpenThread,
   summary,
 }: {
+  depth?: number;
   message: TimelineMessage;
   onOpenThread: (message: TimelineMessage) => void;
   summary: TimelineThreadSummary;
 }) {
+  const visibleDepth = Math.min(Math.max(depth, 0), 6);
+  const marginLeftPx = visibleDepth * 28;
+  const depthGuideOffsets = Array.from(
+    { length: visibleDepth },
+    (_, index) => 14 + index * 28,
+  );
+
   return (
-    <button
-      className="ml-8 flex w-fit max-w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-      data-thread-head-id={message.id}
-      data-testid="message-thread-summary"
-      onClick={() => onOpenThread(message)}
-      type="button"
-    >
-      <div className="flex shrink-0 items-center">
-        {summary.participants.map((participant, index) => (
-          <ParticipantAvatar
-            index={index}
-            key={participant.id}
-            participant={participant}
-          />
-        ))}
-      </div>
-      <div className="min-w-0">
-        <div className="font-medium">
-          <span>
-            {summary.replyCount}{" "}
-            {summary.replyCount === 1 ? "reply" : "replies"}
-          </span>
+    <div className="relative">
+      {depthGuideOffsets.length > 0 ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute left-0"
+          style={{ bottom: "-4px", top: "-4px" }}
+        >
+          {depthGuideOffsets.map((offset, index) => (
+            <div
+              className="absolute bottom-0 top-0 border-l border-border/70"
+              key={`${message.id}-summary-depth-guide-${offset}`}
+              style={{
+                left: `${offset}px`,
+                opacity: index === depthGuideOffsets.length - 1 ? 0.9 : 0.55,
+              }}
+            />
+          ))}
         </div>
-      </div>
-    </button>
+      ) : null}
+
+      <button
+        className="flex w-fit max-w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+        data-thread-head-id={message.id}
+        data-testid="message-thread-summary"
+        onClick={() => onOpenThread(message)}
+        style={{ marginLeft: `${marginLeftPx}px` }}
+        type="button"
+      >
+        <div className="flex shrink-0 items-center">
+          {summary.participants.map((participant, index) => (
+            <ParticipantAvatar
+              index={index}
+              key={participant.id}
+              participant={participant}
+            />
+          ))}
+        </div>
+        <div className="min-w-0">
+          <div className="font-medium">
+            <span>
+              {summary.replyCount}{" "}
+              {summary.replyCount === 1 ? "reply" : "replies"}
+            </span>
+          </div>
+        </div>
+      </button>
+    </div>
   );
 }

--- a/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
@@ -13,7 +13,11 @@ function ParticipantAvatar({
   index: number;
 }) {
   return (
-    <div className={index > 0 ? "-ml-2" : ""} style={{ zIndex: 10 - index }}>
+    <div
+      className={index > 0 ? "-ml-2" : ""}
+      data-testid="message-thread-summary-participant"
+      style={{ zIndex: 10 - index }}
+    >
       <UserAvatar
         avatarUrl={participant.avatarUrl}
         className="rounded-full border-2 border-background"

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -402,6 +402,7 @@ declare global {
     __SPROUT_E2E_EMIT_MOCK_MESSAGE__?: (input: {
       channelName: string;
       content: string;
+      parentEventId?: string | null;
       pubkey?: string;
     }) => RelayEvent;
     __SPROUT_E2E_EMIT_MOCK_TYPING__?: (input: {
@@ -1657,9 +1658,38 @@ function recordMockMessage(channelId: string, event: RelayEvent) {
 function emitMockChannelMessage(
   channelId: string,
   content: string,
+  parentEventId?: string | null,
   pubkey?: string,
 ) {
-  const event = createMockEvent(9, content, [["h", channelId]], pubkey);
+  if (!parentEventId) {
+    const event = createMockEvent(9, content, [["h", channelId]], pubkey);
+    recordMockMessage(channelId, event);
+    emitMockLiveEvent(channelId, event);
+    return event;
+  }
+
+  const history = getMockMessageStore(channelId);
+  const parentEvent = history.find((event) => event.id === parentEventId) ?? null;
+  const parentThread = parentEvent
+    ? getThreadReferenceFromTags(parentEvent.tags)
+    : {
+        parentEventId: null,
+        rootEventId: null,
+      };
+  const rootEventId = parentThread.rootEventId ?? parentEventId;
+  const authorPubkey = pubkey ?? DEFAULT_MOCK_IDENTITY.pubkey;
+  const event = createMockEvent(
+    9,
+    content,
+    buildReplyMessageTags(
+      channelId,
+      authorPubkey,
+      parentEventId,
+      rootEventId,
+      undefined,
+    ),
+    authorPubkey,
+  );
   recordMockMessage(channelId, event);
   emitMockLiveEvent(channelId, event);
   return event;
@@ -4007,6 +4037,7 @@ export function maybeInstallE2eTauriMocks() {
   window.__SPROUT_E2E_EMIT_MOCK_MESSAGE__ = ({
     channelName,
     content,
+    parentEventId,
     pubkey,
   }) => {
     const channel = mockChannels.find(
@@ -4016,7 +4047,7 @@ export function maybeInstallE2eTauriMocks() {
       throw new Error(`Mock channel ${channelName} not found.`);
     }
 
-    return emitMockChannelMessage(channel.id, content, pubkey);
+    return emitMockChannelMessage(channel.id, content, parentEventId, pubkey);
   };
   window.__SPROUT_E2E_EMIT_MOCK_TYPING__ = ({ channelName, pubkey }) => {
     const channel = mockChannels.find(

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1669,7 +1669,8 @@ function emitMockChannelMessage(
   }
 
   const history = getMockMessageStore(channelId);
-  const parentEvent = history.find((event) => event.id === parentEventId) ?? null;
+  const parentEvent =
+    history.find((event) => event.id === parentEventId) ?? null;
   const parentThread = parentEvent
     ? getThreadReferenceFromTags(parentEvent.tags)
     : {

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { installMockBridge } from "../helpers/bridge";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
 import { openSettings } from "../helpers/settings";
 
 test.beforeEach(async ({ page }) => {
@@ -271,6 +271,7 @@ test("opens a single-level thread panel with inline expansion", async ({
   const firstReply = `First threaded reply ${timestamp}`;
   const siblingReply = `Sibling threaded reply ${timestamp}`;
   const nestedReply = `Nested threaded reply ${timestamp}`;
+  const nestedReplyFromBob = `Nested reply from Bob ${timestamp}`;
   const fillerReplies = Array.from(
     { length: 14 },
     (_, index) => `Thread filler reply ${index} ${timestamp}`,
@@ -291,6 +292,11 @@ test("opens a single-level thread panel with inline expansion", async ({
   const threadSendButton = threadPanel.getByTestId("send-message");
   const threadReplies = threadPanel.getByTestId("message-thread-replies");
   const rootMessage = timelineRows.first();
+  const rootMessageId = await rootMessage.getAttribute("data-message-id");
+  if (!rootMessageId) {
+    throw new Error("Expected root message row to have a data-message-id.");
+  }
+  const rootSummaryRow = timeline.locator(`[data-thread-head-id="${rootMessageId}"]`);
 
   await rootMessage.hover();
   await rootMessage.getByRole("button", { name: "Reply" }).click();
@@ -329,8 +335,10 @@ test("opens a single-level thread panel with inline expansion", async ({
     timeline.getByTestId("message-row").filter({ hasText: siblingReply }),
   ).toHaveCount(0);
 
-  const rootSummaryRow = timeline.getByTestId("message-thread-summary").first();
-  await expect(rootSummaryRow).toContainText("replies");
+  await expect(rootSummaryRow).toContainText("16 replies");
+  await expect(
+    rootSummaryRow.getByTestId("message-thread-summary-participant"),
+  ).toHaveCount(1);
 
   await threadPanel.getByTestId("message-thread-close").click();
   await expect(threadPanel).toBeHidden();
@@ -390,10 +398,36 @@ test("opens a single-level thread panel with inline expansion", async ({
     throw new Error("Expected first reply row to have a data-message-id.");
   }
 
+  await page.evaluate(
+    ({ content, parentEventId, pubkey }) => {
+      window.__SPROUT_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content,
+        parentEventId,
+        pubkey,
+      });
+    },
+    {
+      content: nestedReplyFromBob,
+      parentEventId: firstReplyId,
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+    },
+  );
+  const nestedReplyFromBobRow = threadReplies
+    .getByTestId("message-row")
+    .filter({ hasText: nestedReplyFromBob })
+    .first();
+  await expect(nestedReplyFromBobRow).toBeVisible();
+
   const firstReplySummaryRow = threadReplies.locator(
     `[data-thread-head-id="${firstReplyId}"]`,
   );
   await expect(firstReplySummaryRow).toHaveCount(0);
+
+  await expect(rootSummaryRow).toContainText("18 replies");
+  await expect(
+    rootSummaryRow.getByTestId("message-thread-summary-participant"),
+  ).toHaveCount(2);
 
   await expect
     .poll(async () => {
@@ -411,4 +445,64 @@ test("opens a single-level thread panel with inline expansion", async ({
       });
     })
     .toBeLessThan(120);
+});
+
+test("thread panel width uses session storage and reset handle", async ({
+  page,
+}) => {
+  const customWidthPx = 520;
+  const defaultWidthPx = 380;
+
+  await page.addInitScript((width) => {
+    window.sessionStorage.setItem("sprout.desktop.thread-panel-width", String(width));
+  }, customWidthPx);
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const timeline = page.getByTestId("message-timeline");
+  const rootMessage = timeline.getByTestId("message-row").first();
+  const threadPanel = page.getByTestId("message-thread-panel");
+  const resizeHandle = threadPanel.getByTestId("message-thread-resize-handle");
+
+  await rootMessage.hover();
+  await rootMessage.getByRole("button", { name: "Reply" }).click();
+  await expect(threadPanel).toBeVisible();
+
+  await expect
+    .poll(async () => {
+      return threadPanel.evaluate((panel) => {
+        const element = panel as HTMLElement;
+        return Math.round(element.getBoundingClientRect().width);
+      });
+    })
+    .toBe(customWidthPx);
+
+  await resizeHandle.dblclick();
+
+  await expect
+    .poll(async () => {
+      return threadPanel.evaluate((panel) => {
+        const element = panel as HTMLElement;
+        return Math.round(element.getBoundingClientRect().width);
+      });
+    })
+    .toBe(defaultWidthPx);
+
+  await threadPanel.getByTestId("message-thread-close").click();
+  await expect(threadPanel).toBeHidden();
+
+  await rootMessage.hover();
+  await rootMessage.getByRole("button", { name: "Reply" }).click();
+  await expect(threadPanel).toBeVisible();
+
+  await expect
+    .poll(async () => {
+      return threadPanel.evaluate((panel) => {
+        const element = panel as HTMLElement;
+        return Math.round(element.getBoundingClientRect().width);
+      });
+    })
+    .toBe(defaultWidthPx);
 });

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -264,12 +264,17 @@ test("shows your avatar on your own message when profile avatar is set", async (
   );
 });
 
-test("opens a branch-only thread panel from the reply action", async ({
+test("opens a single-level thread panel with inline expansion", async ({
   page,
 }) => {
-  const firstReply = `First threaded reply ${Date.now()}`;
-  const siblingReply = `Sibling threaded reply ${Date.now()}`;
-  const nestedReply = `Nested threaded reply ${Date.now()}`;
+  const timestamp = Date.now();
+  const firstReply = `First threaded reply ${timestamp}`;
+  const siblingReply = `Sibling threaded reply ${timestamp}`;
+  const nestedReply = `Nested threaded reply ${timestamp}`;
+  const fillerReplies = Array.from(
+    { length: 14 },
+    (_, index) => `Thread filler reply ${index} ${timestamp}`,
+  );
 
   await page.goto("/");
   await page.getByTestId("channel-general").click();
@@ -281,6 +286,7 @@ test("opens a branch-only thread panel from the reply action", async ({
   const timeline = page.getByTestId("message-timeline");
   const timelineRows = timeline.getByTestId("message-row");
   const threadPanel = page.getByTestId("message-thread-panel");
+  const threadBody = threadPanel.getByTestId("message-thread-body");
   const threadComposer = threadPanel.locator('[data-testid="message-input"]');
   const threadSendButton = threadPanel.getByTestId("send-message");
   const threadReplies = threadPanel.getByTestId("message-thread-replies");
@@ -301,6 +307,21 @@ test("opens a branch-only thread panel from the reply action", async ({
   await threadSendButton.click();
   await expect(threadReplies).toContainText(siblingReply);
 
+  for (const fillerReply of fillerReplies) {
+    await threadComposer.fill(fillerReply);
+    await threadSendButton.click();
+    await expect(threadReplies).toContainText(fillerReply);
+  }
+
+  await expect
+    .poll(async () => {
+      return threadBody.evaluate((element) => {
+        const body = element as HTMLDivElement;
+        return body.scrollHeight - body.clientHeight;
+      });
+    })
+    .toBeGreaterThan(160);
+
   await expect(
     timeline.getByTestId("message-row").filter({ hasText: firstReply }),
   ).toHaveCount(0);
@@ -309,7 +330,7 @@ test("opens a branch-only thread panel from the reply action", async ({
   ).toHaveCount(0);
 
   const rootSummaryRow = timeline.getByTestId("message-thread-summary").first();
-  await expect(rootSummaryRow).toContainText("2 replies");
+  await expect(rootSummaryRow).toContainText("replies");
 
   await threadPanel.getByTestId("message-thread-close").click();
   await expect(threadPanel).toBeHidden();
@@ -327,38 +348,67 @@ test("opens a branch-only thread panel from the reply action", async ({
   await firstReplyRow.hover();
   await firstReplyRow.getByRole("button", { name: "Reply" }).click();
 
-  await expect(threadPanel.getByTestId("message-thread-back")).toBeVisible();
   await expect(threadPanel.getByTestId("message-thread-head")).toContainText(
-    firstReply,
+    "Welcome to #general",
   );
-  await expect(
-    threadPanel.getByTestId("message-thread-head"),
-  ).not.toContainText("Welcome to #general");
-  await expect(threadReplies).not.toContainText(siblingReply);
+  await expect(threadPanel.getByTestId("message-thread-back")).toHaveCount(0);
 
   await threadComposer.fill(nestedReply);
   await threadSendButton.click();
 
-  await expect(threadReplies).toContainText(nestedReply);
-  await expect(threadReplies).not.toContainText(siblingReply);
+  const nestedReplyRow = threadReplies
+    .getByTestId("message-row")
+    .filter({ hasText: nestedReply })
+    .first();
+  await expect(nestedReplyRow).toBeVisible();
   await expect(
     timeline.getByTestId("message-row").filter({ hasText: nestedReply }),
   ).toHaveCount(0);
 
-  await threadPanel.getByTestId("message-thread-back").click();
-  await expect(threadPanel.getByTestId("message-thread-head")).toContainText(
-    "Welcome to #general",
-  );
   await expect(
-    threadReplies.getByTestId("message-row").filter({ hasText: nestedReply }),
-  ).toHaveCount(0);
+    threadReplies.getByTestId("message-row").filter({ hasText: siblingReply }),
+  ).toHaveCount(1);
+  await expect
+    .poll(async () => {
+      return nestedReplyRow.evaluate((row) => {
+        const threadBody = row.closest(
+          '[data-testid="message-thread-body"]',
+        ) as HTMLElement | null;
+        if (!threadBody) {
+          return Number.POSITIVE_INFINITY;
+        }
 
-  const nestedSummaryRow = threadReplies.getByTestId("message-thread-summary");
-  await expect(nestedSummaryRow).toContainText("1 reply");
-  await nestedSummaryRow.click();
+        const rowRect = row.getBoundingClientRect();
+        const bodyRect = threadBody.getBoundingClientRect();
+        return rowRect.top - bodyRect.top;
+      });
+    })
+    .toBeLessThan(120);
 
-  await expect(threadPanel.getByTestId("message-thread-head")).toContainText(
-    firstReply,
+  const firstReplyId = await firstReplyRow.getAttribute("data-message-id");
+  if (!firstReplyId) {
+    throw new Error("Expected first reply row to have a data-message-id.");
+  }
+
+  const firstReplySummaryRow = threadReplies.locator(
+    `[data-thread-head-id="${firstReplyId}"]`,
   );
-  await expect(threadReplies).toContainText(nestedReply);
+  await expect(firstReplySummaryRow).toHaveCount(0);
+
+  await expect
+    .poll(async () => {
+      return nestedReplyRow.evaluate((row) => {
+        const threadBody = row.closest(
+          '[data-testid="message-thread-body"]',
+        ) as HTMLElement | null;
+        if (!threadBody) {
+          return Number.POSITIVE_INFINITY;
+        }
+
+        const rowRect = row.getBoundingClientRect();
+        const bodyRect = threadBody.getBoundingClientRect();
+        return rowRect.top - bodyRect.top;
+      });
+    })
+    .toBeLessThan(120);
 });

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -393,7 +393,7 @@ test("opens a single-level thread panel with inline expansion", async ({
         return rowRect.top - bodyRect.top;
       });
     })
-    .toBeLessThan(120);
+    .toBeLessThan(160);
 
   const firstReplyId = await firstReplyRow.getAttribute("data-message-id");
   if (!firstReplyId) {
@@ -446,7 +446,7 @@ test("opens a single-level thread panel with inline expansion", async ({
         return rowRect.top - bodyRect.top;
       });
     })
-    .toBeLessThan(120);
+    .toBeLessThan(160);
 });
 
 test("thread panel width uses session storage and reset handle", async ({

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -296,7 +296,9 @@ test("opens a single-level thread panel with inline expansion", async ({
   if (!rootMessageId) {
     throw new Error("Expected root message row to have a data-message-id.");
   }
-  const rootSummaryRow = timeline.locator(`[data-thread-head-id="${rootMessageId}"]`);
+  const rootSummaryRow = timeline.locator(
+    `[data-thread-head-id="${rootMessageId}"]`,
+  );
 
   await rootMessage.hover();
   await rootMessage.getByRole("button", { name: "Reply" }).click();
@@ -454,7 +456,10 @@ test("thread panel width uses session storage and reset handle", async ({
   const defaultWidthPx = 380;
 
   await page.addInitScript((width) => {
-    window.sessionStorage.setItem("sprout.desktop.thread-panel-width", String(width));
+    window.sessionStorage.setItem(
+      "sprout.desktop.thread-panel-width",
+      String(width),
+    );
   }, customWidthPx);
 
   await page.goto("/");


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Users can follow complex thread conversations in one place with inline expansion, clearer nested reply context, and a thread pane that remembers their preferred width during the session.
**Problem:** Thread exploration in the side panel could still feel fragmented when nested replies were involved, and reply context was harder to observe in context of other messages during long chains.
**Solution:** Keep the thread panel anchored on one root while expanding nested replies inline, update summary counting/participants to represent descendants, and add session-based pane width persistence with a resize handle reset. The interaction model is reinforced with E2E coverage for descendant summaries, nested mock emission, and width behavior.

<details>
<summary>File changes</summary>

**desktop/src/features/channels/ui/ChannelPane.tsx**
Added thread pane width state with min/max clamping, session storage hydration/persistence, drag-to-resize, and double-click reset wiring. This keeps pane sizing consistent within a session without changing persisted app settings.

**desktop/src/features/channels/ui/ChannelScreen.tsx**
Moved thread state toward a single-root panel flow with explicit expansion/scroll-target coordination. This supports inline nested exploration instead of view swapping.

**desktop/src/features/channels/useChannelPaneHandlers.ts**
Updated thread handlers for inline expansion and reply-target behavior in the panel flow. This keeps nested reply interactions predictable and avoids multi-view navigation state.

**desktop/src/features/messages/lib/threadPanel.ts**
Reworked thread data shaping to compute descendant counts and recent participants per branch, then reuse that for summaries and visible replies. This makes `# replies` and summary avatars reflect threaded descendants accurately.

**desktop/src/features/messages/ui/MessageComposer.tsx**
Replaced the textual “Cancel” action with a close icon in the reply-target chip area. This tightens the composer chrome while keeping the dismiss affordance clear.

**desktop/src/features/messages/ui/MessageRow.tsx**
Refined threaded row layout/variants and depth guide presentation for clearer indentation hierarchy. This improves readability across nested chains and aligns with the updated inline thread behavior.

**desktop/src/features/messages/ui/MessageThreadPanel.tsx**
Added resizable panel affordances (resize handle + reset behavior), while keeping the single thread-root panel and inline expansion experience intact. Also supports the new width prop contract from `ChannelPane`.

**desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx**
Added stable participant avatar test IDs and kept summary row rendering aligned with threaded ingress behavior. This makes participant assertions deterministic in E2E.

**desktop/src/testing/e2eBridge.ts**
Extended the mock message bridge to allow emitting nested replies via `parentEventId`. This enables realistic descendant-branch test setup without manual event construction in each spec.

**desktop/tests/e2e/messaging.spec.ts**
Expanded thread assertions to cover descendant reply counts, participant avatar summaries, nested replies from another identity, and session width reset/persistence behavior. Removed unnecessary expectations tied to the deleted reset button UI.

</details>

### Reproduction Steps
1. Open a channel and click `Reply` on a root message to open the thread panel.
2. Add direct replies, then add nested replies under a mid-chain reply.
3. Confirm the panel stays on the same thread root and nested branches expand inline with depth indentation.
4. Verify `# replies` and participant avatars on summary rows reflect descendant activity (not only direct children).
5. Drag the thread pane resize handle to change width, then close and reopen the panel and confirm width is preserved for the session.
6. Double-click the resize handle and confirm width resets to the default value.
7. In the thread composer reply-target chip, verify dismiss uses an `x` icon.

### Screenshots/Demos
<img width="1379" height="654" alt="Screenshot 2026-04-16 at 9 04 03 AM" src="https://github.com/user-attachments/assets/ba6c03b4-0532-4569-bbaa-9c68882a01a5" />

https://github.com/user-attachments/assets/9a67068e-4219-40f3-8ec0-e771844630b1