### PR TITLE
fix(huddle): prevent phantom huddle from late-arriving relay events

### DIFF
--- a/desktop/src/features/huddle/components/HuddleIndicator.tsx
+++ b/desktop/src/features/huddle/components/HuddleIndicator.tsx
@@ -74,6 +74,10 @@ export function HuddleIndicator({
       );
 
       let huddle: ActiveHuddle | null = null;
+      // Track ended ephemeral channels so late-arriving join/left events
+      // (e.g. relay-emitted 48102 that lands 1s after a client-emitted 48103)
+      // don't resurrect a phantom huddle via the "infer huddle exists" fallback.
+      const endedChannels = new Set<string>();
 
       for (const ev of sorted) {
         let ephId: string | null = null;
@@ -87,6 +91,8 @@ export function HuddleIndicator({
         switch (ev.kind) {
           case KIND_HUDDLE_STARTED: {
             if (!ephId) break;
+            // A new start supersedes any previous ended state for this channel.
+            endedChannels.delete(ephId);
             huddle = {
               ephemeralChannelId: ephId,
               participants: new Set([ev.pubkey]),
@@ -95,6 +101,9 @@ export function HuddleIndicator({
           }
           case KIND_HUDDLE_PARTICIPANT_JOINED: {
             if (!ephId) break;
+            // Skip if this ephemeral channel has already ended — don't
+            // resurrect a phantom huddle from a late-arriving relay event.
+            if (endedChannels.has(ephId)) break;
             // 48101 events are relay-signed — the actual participant is in the "p" tag.
             const joinedPk =
               ev.tags.find((t) => t[0] === "p")?.[1] ?? ev.pubkey;
@@ -109,6 +118,8 @@ export function HuddleIndicator({
           }
           case KIND_HUDDLE_PARTICIPANT_LEFT: {
             if (!ephId) break;
+            // Skip if this ephemeral channel has already ended.
+            if (endedChannels.has(ephId)) break;
             // 48102 events are relay-signed — the actual participant is in the "p" tag.
             const leftPk = ev.tags.find((t) => t[0] === "p")?.[1] ?? ev.pubkey;
             if (!huddle || ephId !== huddle.ephemeralChannelId) {
@@ -121,8 +132,11 @@ export function HuddleIndicator({
             break;
           }
           case KIND_HUDDLE_ENDED: {
-            if (!huddle || !ephId || ephId !== huddle.ephemeralChannelId) break;
-            huddle = null;
+            if (!ephId) break;
+            endedChannels.add(ephId);
+            if (huddle && ephId === huddle.ephemeralChannelId) {
+              huddle = null;
+            }
             break;
           }
         }


### PR DESCRIPTION
## Problem

After ending a huddle, `HuddleIndicator` shows a phantom huddle with 1 participant — the green headphone icon stays lit indefinitely even though no one is in the huddle.

### Root cause

The relay emits a `48102` (participant left) when the audio WebSocket disconnects, which happens ~1 second **after** the client emits `48103` (huddle ended) via `end_huddle`. When `reconstruct()` replays these events in `created_at` order, the sequence is:

```
48100 started → 48101 joined → ... → 48103 ended → 48102 left
```

The `48103` correctly sets `huddle = null`. But the `48102` that follows hits the "infer huddle exists" fallback — when `huddle` is null, the join/left handlers assume the start event fell out of the subscription window and **re-create the huddle**. This produces an `ActiveHuddle` with an empty participant set, which displays as 1 participant due to `Math.max(1, 0)`.

### Confirmed in staging

The `huddle-test` channel on Blox staging had exactly this event sequence in the DB:
```
48100 started  (21:41:46)
48101 joined   (21:41:47)
48101 joined   (21:53:17)  ← reconnect
48102 left     (21:53:44)
48103 ended    (21:59:56)  ← client-side end_huddle
48102 left     (21:59:57)  ← relay-emitted, 1s later — resurrects phantom
```

## Fix

Track which ephemeral channel IDs have been ended in a local `endedChannels` Set during reconstruction. Join and left events for an ended channel are skipped instead of triggering the inference fallback.

Three changes to `reconstruct()`:

1. **`endedChannels` Set** — tracks ephemeral channel IDs that have received a `48103` event
2. **Guard on join/left handlers** — `if (endedChannels.has(ephId)) break` skips the inference fallback for ended channels
3. **Less restrictive `ENDED` handler** — now records the ended state even when `huddle` is already null (covers the case where the ended event survives in the subscription window but the corresponding started event does not)
4. **`STARTED` clears ended state** — `endedChannels.delete(ephId)` so a new huddle on the same ephemeral channel ID works correctly

The `endedChannels` Set is function-local (rebuilt on every `reconstruct()` call) and bounded by the subscription window (`limit: 100` events).

## Changes

- `desktop/src/features/huddle/components/HuddleIndicator.tsx` — +16/-2 lines

## Testing

- `biome check` — clean
- Codex CLI review: **APPROVED 9/10**
- Verified against the exact event sequence from the staging DB