### PR TITLE
fix(ci): work around CMake 3.31+ rejecting audiopus_sys bundled Opus build

### DIFF
--- a/.github/workflows/bundle-desktop-macos.yml
+++ b/.github/workflows/bundle-desktop-macos.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Build Tauri app
         run: cd desktop && pnpm tauri build
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
       - name: Codesign and Notarize
         if: ${{ inputs.signing }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
         run: cd desktop && pnpm exec playwright test --project=smoke
       - name: Desktop Tauri check
         run: just desktop-tauri-check
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
       - name: Upload desktop e2e artifacts
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/sprout-desktop-release.yml
+++ b/.github/workflows/sprout-desktop-release.yml
@@ -85,6 +85,7 @@ jobs:
         working-directory: desktop
         env:
           SPROUT_RELAY_URL: ${{ secrets.SPROUT_RELAY_URL }}
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
         run: pnpm tauri build --config src-tauri/tauri.release.conf.json
 
       - name: Codesign and Notarize


### PR DESCRIPTION
## Summary
- The `macos-latest` GitHub runner's CMake was upgraded past 3.31, which drops compatibility with `cmake_minimum_required` < 3.5
- The `audiopus_sys` v0.2.2 crate (latest available) bundles an Opus source tree with an old `CMakeLists.txt` that triggers this rejection
- Sets `CMAKE_POLICY_VERSION_MINIMUM=3.5` (the CMake-recommended workaround) on every CI step that compiles the desktop Tauri Rust crate:
  - `bundle-desktop-macos.yml` — reusable macOS bundle workflow (canary + release)
  - `ci.yml` — `Desktop Tauri check` step (`cargo check`)
  - `sprout-desktop-release.yml` — tagged desktop release build

## Test plan
- [ ] CI passes on this PR (the `desktop` job's `Desktop Tauri check` step is the one that compiles Rust on Ubuntu — verifies the env var works)
- [ ] Trigger a canary release or manually run `bundle-desktop-macos` workflow to verify macOS arm64 build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)