### PR TITLE
feat(ios): make app bundle identifier configurable at build time

### DIFF
--- a/mobile/ios/.gitignore
+++ b/mobile/ios/.gitignore
@@ -16,6 +16,7 @@ profile
 xcuserdata
 **/.generated/
 Flutter/App.framework
+Flutter/AppOverrides.xcconfig
 Flutter/Flutter.framework
 Flutter/Flutter.podspec
 Flutter/Generated.xcconfig

--- a/mobile/ios/Flutter/Debug.xcconfig
+++ b/mobile/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,9 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+
+// Default app bundle identifier. Internal/custom builds can override this
+// without patching tracked files by writing
+// `mobile/ios/Flutter/AppOverrides.xcconfig` containing
+// `BUNDLE_IDENTIFIER = your.app.id` (gitignored).
+BUNDLE_IDENTIFIER = com.sprout.sproutMobile
+#include? "AppOverrides.xcconfig"

--- a/mobile/ios/Flutter/Release.xcconfig
+++ b/mobile/ios/Flutter/Release.xcconfig
@@ -1,2 +1,9 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+
+// Default app bundle identifier. Internal/custom builds can override this
+// without patching tracked files by writing
+// `mobile/ios/Flutter/AppOverrides.xcconfig` containing
+// `BUNDLE_IDENTIFIER = your.app.id` (gitignored).
+BUNDLE_IDENTIFIER = com.sprout.sproutMobile
+#include? "AppOverrides.xcconfig"

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -482,7 +482,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.sprout.sproutMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = $(BUNDLE_IDENTIFIER);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -499,7 +499,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sprout.sproutMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = $(BUNDLE_IDENTIFIER).RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -517,7 +517,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sprout.sproutMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = $(BUNDLE_IDENTIFIER).RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -533,7 +533,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.sprout.sproutMobile.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = $(BUNDLE_IDENTIFIER).RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -665,7 +665,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.sprout.sproutMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = $(BUNDLE_IDENTIFIER);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -688,7 +688,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.sprout.sproutMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = $(BUNDLE_IDENTIFIER);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Move the iOS bundle id out of project.pbxproj into a BUNDLE_IDENTIFIER xcconfig variable defaulting to com.sprout.sproutMobile. Builds can override it without touching tracked files by writing mobile/ios/Flutter/AppOverrides.xcconfig (gitignored). Internal Block enterprise builds use this to ship under xyz.block.sproutMobile.