### PR TITLE
fix(desktop): kill WebSocket flood and fix Markdown <p><div> nesting

### DIFF
--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -64,10 +64,14 @@ export function useLiveChannelUpdates(
       ),
     [channels],
   );
-  // Effect dep uses a primitive so refetches that produce new Set refs with
-  // identical contents don't churn subscriptions. The Set is still handy for
-  // closure reads via useEffectEvent.
+  // Effect deps use primitive keys so refetches that produce new refs with
+  // identical contents don't churn subscriptions. The Set/array memos are
+  // still handy for closure reads via useEffectEvent.
   const hasLiveChannels = liveChannelIds.size > 0;
+  const mentionChannelIdsKey = React.useMemo(
+    () => [...new Set(channels.map((channel) => channel.id))].sort().join(","),
+    [channels],
+  );
 
   const handleIncomingMessage = React.useEffectEvent((event: RelayEvent) => {
     const channelId = getChannelIdFromTags(event.tags);
@@ -147,62 +151,112 @@ export function useLiveChannelUpdates(
     };
   }, [hasLiveChannels]);
 
+  // Subscribe to mention events per channel with a diff-based manager: only
+  // subscribe newly-added channels and unsubscribe removed ones on each sync.
+  // The ref survives re-renders so churn-with-identical-IDs does zero work.
+  const mentionSubsRef = React.useRef(new Map<string, () => Promise<void>>());
+  const mentionSubsPubkeyRef = React.useRef<string | null>(null);
+
   React.useEffect(() => {
     if (!options.onLiveMention || normalizedCurrentPubkey.length === 0) {
       return;
     }
 
-    let isDisposed = false;
-    let cleanup: (() => Promise<void>) | undefined;
+    let isCancelled = false;
     let retryTimeout: ReturnType<typeof setTimeout> | undefined;
     let retryAttempt = 0;
 
-    const subscribe = async () => {
-      try {
-        const dispose = await relayClient.subscribeToMentionsForPubkey(
-          normalizedCurrentPubkey,
-          (event) => {
-            if (!isDisposed) {
-              handleMentionEvent(event);
-            }
-          },
-        );
-        if (isDisposed) {
-          void dispose();
-          return;
-        }
-        cleanup = dispose;
-        retryAttempt = 0;
-      } catch (error) {
-        if (isDisposed) {
-          return;
-        }
-        const delayMs = Math.min(
-          LIVE_MENTION_SUBSCRIPTION_RETRY_BASE_MS * 2 ** retryAttempt,
-          LIVE_MENTION_SUBSCRIPTION_RETRY_MAX_MS,
-        );
-        retryAttempt += 1;
-        console.error(
-          `Failed to subscribe to Home mention updates; retrying in ${delayMs}ms`,
-          error,
-        );
-        retryTimeout = window.setTimeout(() => {
-          retryTimeout = undefined;
-          void subscribe();
-        }, delayMs);
+    const syncSubs = async (): Promise<boolean> => {
+      const activeSubs = mentionSubsRef.current;
+
+      if (
+        mentionSubsPubkeyRef.current !== null &&
+        mentionSubsPubkeyRef.current !== normalizedCurrentPubkey
+      ) {
+        const stale = Array.from(activeSubs.values());
+        activeSubs.clear();
+        await Promise.allSettled(stale.map((dispose) => dispose()));
+        if (isCancelled) return true;
       }
+      mentionSubsPubkeyRef.current = normalizedCurrentPubkey;
+
+      const targetIds = new Set(
+        mentionChannelIdsKey ? mentionChannelIdsKey.split(",") : [],
+      );
+
+      for (const [channelId, dispose] of activeSubs) {
+        if (!targetIds.has(channelId)) {
+          activeSubs.delete(channelId);
+          void dispose().catch(() => {});
+        }
+      }
+
+      let anyFailed = false;
+      const additions = Array.from(targetIds)
+        .filter((channelId) => !activeSubs.has(channelId))
+        .map(async (channelId) => {
+          try {
+            const dispose = await relayClient.subscribeToChannelMentionEvents(
+              channelId,
+              normalizedCurrentPubkey,
+              (event) => {
+                if (!isCancelled) handleMentionEvent(event);
+              },
+            );
+            if (isCancelled) {
+              void dispose().catch(() => {});
+              return;
+            }
+            activeSubs.set(channelId, dispose);
+          } catch (err) {
+            anyFailed = true;
+            console.error(
+              "Failed to subscribe to mention events",
+              channelId,
+              err,
+            );
+          }
+        });
+      await Promise.allSettled(additions);
+      return !anyFailed;
     };
 
-    void subscribe();
+    const runSync = async () => {
+      const ok = await syncSubs();
+      if (isCancelled) return;
+      if (ok) {
+        retryAttempt = 0;
+        return;
+      }
+      const delayMs = Math.min(
+        LIVE_MENTION_SUBSCRIPTION_RETRY_BASE_MS * 2 ** retryAttempt,
+        LIVE_MENTION_SUBSCRIPTION_RETRY_MAX_MS,
+      );
+      retryAttempt += 1;
+      retryTimeout = window.setTimeout(() => {
+        retryTimeout = undefined;
+        void runSync();
+      }, delayMs);
+    };
+
+    void runSync();
 
     return () => {
-      isDisposed = true;
+      isCancelled = true;
       if (retryTimeout !== undefined) {
         window.clearTimeout(retryTimeout);
       }
-      if (cleanup) {
-        void cleanup();
-      }
     };
-  }, [normalizedCurrentPubkey, options.onLiveMention]);
+  }, [mentionChannelIdsKey, normalizedCurrentPubkey, options.onLiveMention]);
+
+  React.useEffect(() => {
+    return () => {
+      const subs = mentionSubsRef.current;
+      for (const dispose of subs.values()) {
+        void dispose().catch(() => {});
+      }
+      subs.clear();
+      mentionSubsPubkeyRef.current = null;
+    };
+  }, []);
 }

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -14,7 +14,8 @@ export type UseLiveChannelUpdatesOptions = {
   onLiveMention?: () => void;
 };
 
-const LIVE_MENTION_SUBSCRIPTION_RETRY_MS = 1_000;
+const LIVE_MENTION_SUBSCRIPTION_RETRY_BASE_MS = 1_000;
+const LIVE_MENTION_SUBSCRIPTION_RETRY_MAX_MS = 30_000;
 
 function getMessageTimestamp(event: RelayEvent) {
   return new Date(event.created_at * 1_000).toISOString();
@@ -45,12 +46,6 @@ function rememberMentionEvent(
   return true;
 }
 
-async function disposeLiveSubscriptions(
-  subscriptions: Array<() => Promise<void>>,
-) {
-  await Promise.allSettled(subscriptions.map((dispose) => dispose()));
-}
-
 export function useLiveChannelUpdates(
   channels: Channel[],
   activeChannelId: string | null,
@@ -69,10 +64,10 @@ export function useLiveChannelUpdates(
       ),
     [channels],
   );
-  const mentionChannelIds = React.useMemo(
-    () => [...new Set(channels.map((channel) => channel.id))].sort(),
-    [channels],
-  );
+  // Effect dep uses a primitive so refetches that produce new Set refs with
+  // identical contents don't churn subscriptions. The Set is still handy for
+  // closure reads via useEffectEvent.
+  const hasLiveChannels = liveChannelIds.size > 0;
 
   const handleIncomingMessage = React.useEffectEvent((event: RelayEvent) => {
     const channelId = getChannelIdFromTags(event.tags);
@@ -119,7 +114,7 @@ export function useLiveChannelUpdates(
   }, [queryClient]);
 
   React.useEffect(() => {
-    if (liveChannelIds.size === 0) {
+    if (!hasLiveChannels) {
       return;
     }
 
@@ -150,76 +145,64 @@ export function useLiveChannelUpdates(
         void cleanup();
       }
     };
-  }, [liveChannelIds]);
+  }, [hasLiveChannels]);
 
   React.useEffect(() => {
-    if (
-      !options.onLiveMention ||
-      normalizedCurrentPubkey.length === 0 ||
-      mentionChannelIds.length === 0
-    ) {
+    if (!options.onLiveMention || normalizedCurrentPubkey.length === 0) {
       return;
     }
 
     let isDisposed = false;
-    let cleanup: Array<() => Promise<void>> = [];
+    let cleanup: (() => Promise<void>) | undefined;
     let retryTimeout: ReturnType<typeof setTimeout> | undefined;
+    let retryAttempt = 0;
 
-    const subscribeToMentionChannels = async () => {
-      const settled = await Promise.allSettled(
-        mentionChannelIds.map((channelId) =>
-          relayClient.subscribeToChannelMentionEvents(
-            channelId,
-            normalizedCurrentPubkey,
-            (event) => {
-              if (!isDisposed) {
-                handleMentionEvent(event);
-              }
-            },
-          ),
-        ),
-      );
-
-      const nextCleanup = settled.flatMap((result) =>
-        result.status === "fulfilled" ? [result.value] : [],
-      );
-
-      if (isDisposed) {
-        await disposeLiveSubscriptions(nextCleanup);
-        return;
+    const subscribe = async () => {
+      try {
+        const dispose = await relayClient.subscribeToMentionsForPubkey(
+          normalizedCurrentPubkey,
+          (event) => {
+            if (!isDisposed) {
+              handleMentionEvent(event);
+            }
+          },
+        );
+        if (isDisposed) {
+          void dispose();
+          return;
+        }
+        cleanup = dispose;
+        retryAttempt = 0;
+      } catch (error) {
+        if (isDisposed) {
+          return;
+        }
+        const delayMs = Math.min(
+          LIVE_MENTION_SUBSCRIPTION_RETRY_BASE_MS * 2 ** retryAttempt,
+          LIVE_MENTION_SUBSCRIPTION_RETRY_MAX_MS,
+        );
+        retryAttempt += 1;
+        console.error(
+          `Failed to subscribe to Home mention updates; retrying in ${delayMs}ms`,
+          error,
+        );
+        retryTimeout = window.setTimeout(() => {
+          retryTimeout = undefined;
+          void subscribe();
+        }, delayMs);
       }
-
-      const firstFailure = settled.find(
-        (result) => result.status === "rejected",
-      );
-      if (!firstFailure) {
-        cleanup = nextCleanup;
-        return;
-      }
-
-      await disposeLiveSubscriptions(nextCleanup);
-      if (isDisposed) {
-        return;
-      }
-
-      console.error(
-        "Failed to subscribe to all Home mention updates; retrying",
-        firstFailure.reason,
-      );
-      retryTimeout = window.setTimeout(() => {
-        retryTimeout = undefined;
-        void subscribeToMentionChannels();
-      }, LIVE_MENTION_SUBSCRIPTION_RETRY_MS);
     };
 
-    void subscribeToMentionChannels();
+    void subscribe();
 
     return () => {
       isDisposed = true;
       if (retryTimeout !== undefined) {
         window.clearTimeout(retryTimeout);
       }
-      void disposeLiveSubscriptions(cleanup);
+      if (cleanup) {
+        void cleanup();
+      }
     };
-  }, [mentionChannelIds, normalizedCurrentPubkey, options.onLiveMention]);
+  }, [normalizedCurrentPubkey, options.onLiveMention]);
 }

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -192,6 +192,11 @@ export function useLiveChannelUpdates(
       }
 
       let anyFailed = false;
+      // Pass handleMentionEvent directly — it's a stable useEffectEvent
+      // callback. Do NOT wrap in an isCancelled check here: subs persist
+      // across effect runs (that's the point of the diff manager), so a
+      // stale isCancelled flag from a prior run would silently drop events
+      // on long-lived subs.
       const additions = Array.from(targetIds)
         .filter((channelId) => !activeSubs.has(channelId))
         .map(async (channelId) => {
@@ -199,9 +204,7 @@ export function useLiveChannelUpdates(
             const dispose = await relayClient.subscribeToChannelMentionEvents(
               channelId,
               normalizedCurrentPubkey,
-              (event) => {
-                if (!isCancelled) handleMentionEvent(event);
-              },
+              handleMentionEvent,
             );
             if (isCancelled) {
               void dispose().catch(() => {});

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -225,13 +225,12 @@ export class RelayClient {
     return this.subscribe(this.buildGlobalStreamFilter(50), onEvent);
   }
 
-  async subscribeToChannelMentionEvents(
-    channelId: string,
+  async subscribeToMentionsForPubkey(
     pubkey: string,
     onEvent: (event: RelayEvent) => void,
   ) {
     return this.subscribe(
-      this.buildChannelMentionFilter(channelId, pubkey, 50),
+      this.buildMentionsForPubkeyFilter(pubkey, 50),
       onEvent,
     );
   }
@@ -307,8 +306,8 @@ export class RelayClient {
       };
     });
 
-    this.reconnectDelayMs = RECONNECT_BASE_DELAY_MS;
     await this.replayLiveSubscriptions();
+    this.reconnectDelayMs = RECONNECT_BASE_DELAY_MS;
     this.emitReconnectIfNeeded();
   }
 
@@ -337,14 +336,12 @@ export class RelayClient {
     };
   }
 
-  private buildChannelMentionFilter(
-    channelId: string,
+  private buildMentionsForPubkeyFilter(
     pubkey: string,
     limit: number,
   ): RelaySubscriptionFilter {
     return {
       kinds: [...HOME_MENTION_EVENT_KINDS],
-      "#h": [channelId],
       "#p": [pubkey],
       limit,
       since: Math.floor(Date.now() / 1_000),

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -225,12 +225,13 @@ export class RelayClient {
     return this.subscribe(this.buildGlobalStreamFilter(50), onEvent);
   }
 
-  async subscribeToMentionsForPubkey(
+  async subscribeToChannelMentionEvents(
+    channelId: string,
     pubkey: string,
     onEvent: (event: RelayEvent) => void,
   ) {
     return this.subscribe(
-      this.buildMentionsForPubkeyFilter(pubkey, 50),
+      this.buildChannelMentionFilter(channelId, pubkey, 50),
       onEvent,
     );
   }
@@ -306,8 +307,8 @@ export class RelayClient {
       };
     });
 
-    await this.replayLiveSubscriptions();
     this.reconnectDelayMs = RECONNECT_BASE_DELAY_MS;
+    await this.replayLiveSubscriptions();
     this.emitReconnectIfNeeded();
   }
 
@@ -336,12 +337,14 @@ export class RelayClient {
     };
   }
 
-  private buildMentionsForPubkeyFilter(
+  private buildChannelMentionFilter(
+    channelId: string,
     pubkey: string,
     limit: number,
   ): RelaySubscriptionFilter {
     return {
       kinds: [...HOME_MENTION_EVENT_KINDS],
+      "#h": [channelId],
       "#p": [pubkey],
       limit,
       since: Math.floor(Date.now() / 1_000),

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -221,7 +221,7 @@ function createMarkdownComponents(
       }
 
       if (hasBlockMedia(childArray)) {
-        return <div>{children}</div>;
+        return <div className={paragraphClassName}>{children}</div>;
       }
 
       return <p className={paragraphClassName}>{children}</p>;

--- a/desktop/src/shared/ui/markdownUtils.ts
+++ b/desktop/src/shared/ui/markdownUtils.ts
@@ -33,13 +33,14 @@ export function isImageOnlyParagraph(childArray: React.ReactNode[]): boolean {
 }
 
 /**
- * Returns true when a paragraph contains block-level media (1+ image/video
- * component) and no meaningful text content. These paragraphs must render as
- * `<div>` instead of `<p>` to avoid invalid `<p><div>` nesting.
+ * Returns true when a paragraph contains any image/video child. The custom
+ * `img` renderer always emits block-level markup (lightbox/video wrapper),
+ * so any such paragraph must render as `<div>` to avoid invalid `<p><div>`
+ * nesting — even when mixed with text or links.
  */
 export function hasBlockMedia(childArray: React.ReactNode[]): boolean {
-  const { imageChildren, nonImageChildren } = classifyChildren(childArray);
-  return imageChildren.length >= 1 && nonImageChildren.length === 0;
+  const { imageChildren } = classifyChildren(childArray);
+  return imageChildren.length >= 1;
 }
 
 export function shallowArrayEqual(a?: string[], b?: string[]): boolean {


### PR DESCRIPTION
## Summary

Two desktop bugfixes from the same debugging session, with an adversarial-review follow-up that caught regressions in the original approach.

- **Relay flood → unresponsive app**: Home-feed mention subscription was tearing down + resubscribing all N channels (~100 for heavy users) on every channels-query refetch, firing hundreds of `plugin:websocket|send` IPC calls per second and saturating the Tauri WebView. Fixed with a **diff-based subscription manager**: a ref-backed `Map<channelId, dispose>` that only subs/unsubs the delta. Channels refetch with identical IDs does zero network work.
- **Markdown `<p><div>` hydration error**: paragraphs containing an image + text/link rendered as `<p>` wrapping a `<div>` because the renderer only switched to `<div>` when the paragraph had *zero* non-image children. Now switches whenever any image is present.

## Details

### Relay flood fix (`src/features/channels/useLiveChannelUpdates.ts`, `src/shared/api/relayClientSession.ts`)

Diff-based mention sub manager:
- `mentionSubsRef: Map<channelId, dispose>` persists across renders.
- On sync: remove subs whose channel left the target set; subscribe only channels that are new.
- Pubkey change triggers full tear-down + resubscribe (rare).
- Per-channel subscribe failures retry with exponential backoff (1s → 30s capped).
- Dispose all on unmount.

Why not a single global sub: an earlier attempt dropped the `#h` filter for one global `#p: [pubkey]` subscription. Codex review and CI caught that the relay intentionally does not fan out channel-scoped events to global subs (`sprout-relay/src/subscription.rs:136`) — live mentions stopped arriving entirely and the `live forum mentions refetch the home feed` integration test failed. Reverted.

Also:
- Global stream subscription effect now deps on `hasLiveChannels` (boolean) so channels refetches with identical IDs don't cycle it.

### Markdown fix (`src/shared/ui/markdown.tsx`, `src/shared/ui/markdownUtils.ts`)

- `hasBlockMedia` now returns true whenever any image child is present.
- The `<div>` fallback carries `paragraphClassName` so mixed text+media paragraphs keep their line-height.

## Commits

1. `fix(desktop): render Markdown paragraphs with media as <div>…`
2. `fix(desktop): collapse per-channel mention subs into one global subscription` *(original attempt — superseded by #3)*
3. `fix(desktop): use diff-based per-channel mention sub manager`

## Test plan

- [x] `pnpm check`, `pnpm typecheck`, all lefthook pre-push checks (`desktop-build`, `rust-clippy`, `rust-tests`, `mobile-test`, etc.) green
- [x] Codex adversarial review of current diff
- [ ] CI integration suite — specifically `live forum mentions refetch the home feed without waiting for polling` (previously failing)
- [ ] Reviewer sanity-check: open a channel containing a mixed image+text message with a video URL — no `<p><div>` hydration warning in DevTools console
- [ ] Reviewer sanity-check: with multiple channels and active bots, observe `plugin:websocket|send` traffic remains low in steady state

🤖 Generated with [Claude Code](https://claude.com/claude-code)