### PR TITLE
Add server cross-compile and macOS desktop build CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,3 +221,59 @@ jobs:
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
       - name: Dependency policy
         run: cargo-deny check
+
+  server-cross-compile:
+    name: Server Cross-Compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ${{ matrix.target }}
+      - name: Install cross
+        uses: taiki-e/install-action@06203676c62f0d3c765be3f2fcfbebbcb02d09f5 # v2
+        with:
+          tool: cross@0.2.5
+      - name: Build server binaries
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cross build --release --target "$TARGET" \
+            -p sprout-relay \
+            -p sprout-acp \
+            -p sprout-mcp
+
+  desktop-build-macos:
+    name: Desktop Build (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: desktop/src-tauri
+      - name: Install desktop dependencies
+        run: just desktop-install-ci
+      - name: Create sidecar placeholders
+        run: |
+          TARGET=$(rustc -vV | sed -n 's|host: ||p')
+          mkdir -p desktop/src-tauri/binaries
+          touch "desktop/src-tauri/binaries/sprout-acp-$TARGET"
+          touch "desktop/src-tauri/binaries/sprout-mcp-server-$TARGET"
+      - name: Build Tauri app
+        run: cd desktop && pnpm tauri build
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,10 +237,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: ${{ matrix.target }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install cross
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2
         with:
@@ -263,10 +259,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: desktop/src-tauri
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install desktop dependencies
         run: just desktop-install-ci
       - name: Create sidecar placeholders

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,8 +240,9 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install cross
-        uses: taiki-e/install-action@06203676c62f0d3c765be3f2fcfbebbcb02d09f5 # v2
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2
         with:
           tool: cross@0.2.5
       - name: Build server binaries
@@ -265,6 +266,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: desktop/src-tauri
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install desktop dependencies
         run: just desktop-install-ci
       - name: Create sidecar placeholders

--- a/justfile
+++ b/justfile
@@ -95,6 +95,16 @@ desktop-tauri-check:
     touch "desktop/src-tauri/binaries/sprout-mcp-server-$TARGET"
     cargo check --manifest-path {{desktop_tauri_manifest}}
 
+# Build the full desktop Tauri app locally (unsigned, for testing)
+desktop-release-build target="aarch64-apple-darwin":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    TARGET={{target}}
+    mkdir -p desktop/src-tauri/binaries
+    touch "desktop/src-tauri/binaries/sprout-acp-$TARGET"
+    touch "desktop/src-tauri/binaries/sprout-mcp-server-$TARGET"
+    cd {{desktop_dir}} && pnpm install && pnpm tauri build --target {{target}}
+
 # Run desktop checks suitable for CI / pre-push
 desktop-ci: desktop-check desktop-tauri-fmt-check desktop-build desktop-tauri-check
 


### PR DESCRIPTION
## Summary
- Restore server cross-compilation CI job for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets using `cross@0.2.5` — catches musl linking issues that native Ubuntu builds miss
- Restore full macOS desktop Tauri build CI job (unsigned) — validates the Tauri bundle actually compiles, replacing the stub-binary `cargo check` approach
- Add `desktop-release-build` justfile target for local unsigned builds with configurable target triple
- Add sidecar placeholder stubs to `staging` justfile target to prevent Tauri compile-time validation failures

These restore build capabilities accidentally deleted in PR #360.

## What's NOT in this PR
- No signing, notarization, or release publishing
- No artifact uploads
- No changes to existing jobs
- No path filters (can add later if macOS runner costs spike)

## Test plan
- [ ] CI passes on this PR (server cross-compile + macOS desktop build jobs run green)
- [ ] Verify `just desktop-release-build` works locally on macOS
- [ ] Verify `just staging` no longer fails on sidecar validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)