### PR TITLE
Fix forum post card bugs on desktop and mobile

### DIFF
--- a/desktop/biome.json
+++ b/desktop/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/desktop/src/features/forum/ui/DeleteActionMenu.tsx
+++ b/desktop/src/features/forum/ui/DeleteActionMenu.tsx
@@ -1,0 +1,57 @@
+import { MoreHorizontal, Trash2 } from "lucide-react";
+import * as React from "react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+
+import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
+
+type DeleteActionMenuProps = {
+  label: string;
+  onConfirm: () => void;
+  iconSize?: "sm" | "md";
+};
+
+export function DeleteActionMenu({
+  label,
+  onConfirm,
+  iconSize = "md",
+}: DeleteActionMenuProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const iconClass = iconSize === "sm" ? "h-3.5 w-3.5" : "h-4 w-4";
+
+  return (
+    <div className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+            tabIndex={-1}
+            type="button"
+          >
+            <MoreHorizontal className={iconClass} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => setIsOpen(true)}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            Delete {label}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <DeleteConfirmDialog
+        label={label}
+        onConfirm={onConfirm}
+        onOpenChange={setIsOpen}
+        open={isOpen}
+      />
+    </div>
+  );
+}

--- a/desktop/src/features/forum/ui/DeleteConfirmDialog.tsx
+++ b/desktop/src/features/forum/ui/DeleteConfirmDialog.tsx
@@ -1,0 +1,48 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/shared/ui/alert-dialog";
+import { Button } from "@/shared/ui/button";
+
+export function DeleteConfirmDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  label,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  label: string;
+}) {
+  return (
+    <AlertDialog onOpenChange={onOpenChange} open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete {label}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete this {label} and cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel asChild>
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+          </AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <Button onClick={onConfirm} type="button" variant="destructive">
+              Delete {label}
+            </Button>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/desktop/src/features/forum/ui/ForumPostCard.tsx
+++ b/desktop/src/features/forum/ui/ForumPostCard.tsx
@@ -76,9 +76,10 @@ export function ForumPostCard({
         </span>
 
         {canDelete && onDelete ? (
+          // biome-ignore lint/a11y/noStaticElementInteractions: presentation wrapper only stops click propagation to parent card link
           <div
             className="ml-auto"
-            onClickCapture={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
             role="presentation"
           >
             <DeleteActionMenu

--- a/desktop/src/features/forum/ui/ForumPostCard.tsx
+++ b/desktop/src/features/forum/ui/ForumPostCard.tsx
@@ -1,5 +1,4 @@
-import { MessageSquare, MoreHorizontal, Trash2 } from "lucide-react";
-import * as React from "react";
+import { MessageSquare } from "lucide-react";
 
 import {
   resolveUserLabel,
@@ -9,16 +8,10 @@ import { UserAvatar } from "@/shared/ui/UserAvatar";
 import type { ForumPost } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { resolveMentionNames } from "@/shared/lib/resolveMentionNames";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/shared/ui/dropdown-menu";
 import { Markdown } from "@/shared/ui/markdown";
 
 import { formatRelativeTime } from "../lib/time";
-import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
+import { DeleteActionMenu } from "./DeleteActionMenu";
 
 type ForumPostCardProps = {
   post: ForumPost;
@@ -41,7 +34,6 @@ export function ForumPostCard({
   onClick,
   onDelete,
 }: ForumPostCardProps) {
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
   const authorLabel = resolveUserLabel({
     pubkey: post.pubkey,
     currentPubkey,
@@ -57,14 +49,22 @@ export function ForumPostCard({
       : post.content;
 
   return (
-    <button
+    // biome-ignore lint/a11y/useSemanticElements: Cannot use <button> because DeleteActionMenu renders a nested <button> via DropdownMenuTrigger, which is invalid HTML
+    <div
+      role="button"
+      tabIndex={0}
       className={cn(
         "group w-full cursor-pointer rounded-xl border border-border/60 bg-card p-4 text-left transition-colors hover:border-border hover:bg-accent/40",
         isActive && "border-primary/40 bg-accent/60",
         isDeleting && "pointer-events-none opacity-50",
       )}
       onClick={() => onClick(post)}
-      type="button"
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick(post);
+        }
+      }}
     >
       <div className="flex items-center gap-2">
         <UserAvatar avatarUrl={avatarUrl} displayName={authorLabel} size="sm" />
@@ -77,36 +77,13 @@ export function ForumPostCard({
 
         {canDelete && onDelete ? (
           <div
-            className="ml-auto opacity-0 transition-opacity group-hover:opacity-100"
+            className="ml-auto"
             onClickCapture={(e) => e.stopPropagation()}
             role="presentation"
           >
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-                  tabIndex={-1}
-                  type="button"
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  className="text-destructive focus:text-destructive"
-                  onClick={() => setIsDeleteDialogOpen(true)}
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Delete post
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-
-            <DeleteConfirmDialog
+            <DeleteActionMenu
               label="post"
               onConfirm={() => onDelete(post.eventId)}
-              onOpenChange={setIsDeleteDialogOpen}
-              open={isDeleteDialogOpen}
             />
           </div>
         ) : null}
@@ -135,6 +112,6 @@ export function ForumPostCard({
           ) : null}
         </div>
       ) : null}
-    </button>
+    </div>
   );
 }

--- a/desktop/src/features/forum/ui/ForumPostCard.tsx
+++ b/desktop/src/features/forum/ui/ForumPostCard.tsx
@@ -10,17 +10,6 @@ import type { ForumPost } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { resolveMentionNames } from "@/shared/lib/resolveMentionNames";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/shared/ui/alert-dialog";
-import { Button } from "@/shared/ui/button";
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -29,6 +18,7 @@ import {
 import { Markdown } from "@/shared/ui/markdown";
 
 import { formatRelativeTime } from "../lib/time";
+import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
 
 type ForumPostCardProps = {
   post: ForumPost;
@@ -112,35 +102,12 @@ export function ForumPostCard({
               </DropdownMenuContent>
             </DropdownMenu>
 
-            <AlertDialog
+            <DeleteConfirmDialog
+              label="post"
+              onConfirm={() => onDelete(post.eventId)}
               onOpenChange={setIsDeleteDialogOpen}
               open={isDeleteDialogOpen}
-            >
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete post?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will permanently delete this post and cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel asChild>
-                    <Button type="button" variant="outline">
-                      Cancel
-                    </Button>
-                  </AlertDialogCancel>
-                  <AlertDialogAction asChild>
-                    <Button
-                      onClick={() => onDelete(post.eventId)}
-                      type="button"
-                      variant="destructive"
-                    >
-                      Delete post
-                    </Button>
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+            />
           </div>
         ) : null}
       </div>

--- a/desktop/src/features/forum/ui/ForumThreadPanel.tsx
+++ b/desktop/src/features/forum/ui/ForumThreadPanel.tsx
@@ -10,16 +10,6 @@ import type { ForumThreadResponse, ThreadReply } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
 import { resolveMentionNames } from "@/shared/lib/resolveMentionNames";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/shared/ui/alert-dialog";
 import { Button } from "@/shared/ui/button";
 import {
   DropdownMenu,
@@ -31,6 +21,7 @@ import { Markdown } from "@/shared/ui/markdown";
 import { Skeleton } from "@/shared/ui/skeleton";
 
 import { formatRelativeTime } from "../lib/time";
+import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
 import { ForumComposer } from "./ForumComposer";
 
 type ForumThreadPanelProps = {
@@ -60,43 +51,6 @@ function canDeleteReply(
 ): boolean {
   if (!currentPubkey) return false;
   return reply.pubkey.toLowerCase() === currentPubkey.toLowerCase();
-}
-
-function DeleteConfirmDialog({
-  open,
-  onOpenChange,
-  onConfirm,
-  label,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onConfirm: () => void;
-  label: string;
-}) {
-  return (
-    <AlertDialog onOpenChange={onOpenChange} open={open}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete {label}?</AlertDialogTitle>
-          <AlertDialogDescription>
-            This will permanently delete this {label} and cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel asChild>
-            <Button type="button" variant="outline">
-              Cancel
-            </Button>
-          </AlertDialogCancel>
-          <AlertDialogAction asChild>
-            <Button onClick={onConfirm} type="button" variant="destructive">
-              Delete {label}
-            </Button>
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
 }
 
 function ReplyRow({

--- a/desktop/src/features/forum/ui/ForumThreadPanel.tsx
+++ b/desktop/src/features/forum/ui/ForumThreadPanel.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, MessageSquare, MoreHorizontal, Trash2 } from "lucide-react";
+import { ArrowLeft, MessageSquare } from "lucide-react";
 import * as React from "react";
 
 import {
@@ -11,17 +11,11 @@ import { cn } from "@/shared/lib/cn";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
 import { resolveMentionNames } from "@/shared/lib/resolveMentionNames";
 import { Button } from "@/shared/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/shared/ui/dropdown-menu";
 import { Markdown } from "@/shared/ui/markdown";
 import { Skeleton } from "@/shared/ui/skeleton";
 
 import { formatRelativeTime } from "../lib/time";
-import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
+import { DeleteActionMenu } from "./DeleteActionMenu";
 import { ForumComposer } from "./ForumComposer";
 
 type ForumThreadPanelProps = {
@@ -66,7 +60,6 @@ function ReplyRow({
   channelNames?: string[];
   onDelete?: (eventId: string) => void;
 }) {
-  const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
   const replyAuthorLabel = resolveUserLabel({
     pubkey: reply.pubkey,
     currentPubkey,
@@ -94,33 +87,11 @@ function ReplyRow({
         </span>
 
         {showDelete ? (
-          <div className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-                  type="button"
-                >
-                  <MoreHorizontal className="h-3.5 w-3.5" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  className="text-destructive focus:text-destructive"
-                  onClick={() => setIsDeleteOpen(true)}
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Delete reply
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <DeleteConfirmDialog
-              label="reply"
-              onConfirm={() => onDelete(reply.eventId)}
-              onOpenChange={setIsDeleteOpen}
-              open={isDeleteOpen}
-            />
-          </div>
+          <DeleteActionMenu
+            iconSize="sm"
+            label="reply"
+            onConfirm={() => onDelete(reply.eventId)}
+          />
         ) : null}
       </div>
       <div className="mt-1.5 pl-8">
@@ -152,7 +123,6 @@ export function ForumThreadPanel({
   targetEventId,
 }: ForumThreadPanelProps) {
   const scrollRef = React.useRef<HTMLDivElement>(null);
-  const [isDeletePostOpen, setIsDeletePostOpen] = React.useState(false);
   const { channels } = useChannelNavigation();
   const channelNames = React.useMemo(
     () => channels.filter((c) => c.channelType !== "dm").map((c) => c.name),
@@ -252,33 +222,10 @@ export function ForumThreadPanel({
             </div>
 
             {canDeletePost && onDeletePost ? (
-              <div className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-                      type="button"
-                    >
-                      <MoreHorizontal className="h-4 w-4" />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onClick={() => setIsDeletePostOpen(true)}
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      Delete post
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-                <DeleteConfirmDialog
-                  label="post"
-                  onConfirm={() => onDeletePost(post.eventId)}
-                  onOpenChange={setIsDeletePostOpen}
-                  open={isDeletePostOpen}
-                />
-              </div>
+              <DeleteActionMenu
+                label="post"
+                onConfirm={() => onDeletePost(post.eventId)}
+              />
             ) : null}
           </div>
           <div className="mt-3">

--- a/mobile/lib/features/forum/forum_post_card.dart
+++ b/mobile/lib/features/forum/forum_post_card.dart
@@ -34,8 +34,11 @@ class ForumPostCard extends ConsumerWidget {
         ref.watch(userCacheProvider.select((cache) => cache[pk])) ??
         ref.read(userCacheProvider.notifier).get(pk);
     final displayName = profile?.label ?? _shortPubkey(post.pubkey);
-    final userCache = ref.watch(userCacheProvider);
-    final mentionNames = _buildMentionNames(post.mentionPubkeys, userCache);
+    final mentionNames = ref.watch(
+      userCacheProvider.select(
+        (cache) => _buildMentionNames(post.mentionPubkeys, cache),
+      ),
+    );
     final preview = post.content.length > 200
         ? '${post.content.substring(0, 200)}...'
         : post.content;
@@ -97,12 +100,21 @@ class ForumPostCard extends ConsumerWidget {
             const SizedBox(height: Grid.xxs),
 
             // Content preview
-            ClipRect(
+            ShaderMask(
+              shaderCallback: (bounds) => const LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [Colors.white, Colors.white, Colors.transparent],
+                stops: [0.0, 0.75, 1.0],
+              ).createShader(bounds),
+              blendMode: BlendMode.dstIn,
               child: ConstrainedBox(
                 constraints: const BoxConstraints(maxHeight: 120),
-                child: MessageContent(
-                  content: preview,
-                  mentionNames: mentionNames,
+                child: IgnorePointer(
+                  child: MessageContent(
+                    content: preview,
+                    mentionNames: mentionNames,
+                  ),
                 ),
               ),
             ),

--- a/mobile/lib/features/forum/forum_post_card.dart
+++ b/mobile/lib/features/forum/forum_post_card.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../shared/theme/theme.dart';
+import '../channels/message_content.dart';
 import '../profile/user_cache_provider.dart';
 import '../profile/user_profile.dart';
 import 'forum_models.dart';
@@ -33,6 +34,8 @@ class ForumPostCard extends ConsumerWidget {
         ref.watch(userCacheProvider.select((cache) => cache[pk])) ??
         ref.read(userCacheProvider.notifier).get(pk);
     final displayName = profile?.label ?? _shortPubkey(post.pubkey);
+    final userCache = ref.watch(userCacheProvider);
+    final mentionNames = _buildMentionNames(post.mentionPubkeys, userCache);
     final preview = post.content.length > 200
         ? '${post.content.substring(0, 200)}...'
         : post.content;
@@ -94,13 +97,14 @@ class ForumPostCard extends ConsumerWidget {
             const SizedBox(height: Grid.xxs),
 
             // Content preview
-            Text(
-              preview,
-              style: context.textTheme.bodyMedium?.copyWith(
-                color: context.colors.onSurface,
+            ClipRect(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 120),
+                child: MessageContent(
+                  content: preview,
+                  mentionNames: mentionNames,
+                ),
               ),
-              maxLines: 4,
-              overflow: TextOverflow.ellipsis,
             ),
 
             // Thread summary
@@ -250,4 +254,18 @@ class _PostAvatar extends StatelessWidget {
 String _shortPubkey(String pubkey) {
   if (pubkey.length > 12) return '${pubkey.substring(0, 8)}\u2026';
   return pubkey;
+}
+
+Map<String, String> _buildMentionNames(
+  List<String> mentionPubkeys,
+  Map<String, UserProfile> userCache,
+) {
+  final names = <String, String>{};
+  for (final pk in mentionPubkeys) {
+    final p = userCache[pk.toLowerCase()];
+    if (p?.displayName != null) {
+      names[pk.toLowerCase()] = p!.displayName!;
+    }
+  }
+  return names;
 }


### PR DESCRIPTION
## Summary
- **Desktop:** Fixed nested `<button>` violation preventing delete menu from working — card root changed to `<div role="button">`. Fixed `ml-auto` placement on delete menu wrapper. Fixed `onClickCapture` killing click events before Radix portal handlers could fire. Extracted `DeleteActionMenu` and `DeleteConfirmDialog` as shared components used by both `ForumPostCard` and `ForumThreadPanel`.
- **Mobile:** Wrapped `MessageContent` in `IgnorePointer` so link taps don't steal card navigation. Scoped `userCacheProvider.select()` to prevent full-map rebuilds. Replaced hard `ClipRect` with `ShaderMask` bottom fade for cleaner preview cutoff.
- **Housekeeping:** Restored `biome.json` schema version to match installed CLI (2.4.11).

## Test plan
- [x] Desktop: 3-dot menu right-aligns on forum post cards
- [x] Desktop: Clicking "Delete post" opens confirmation dialog
- [x] Desktop: Clicking "Delete reply" opens confirmation dialog
- [x] Desktop: Card click still navigates to thread
- [x] Desktop: Keyboard navigation (Enter/Space) still works on cards
- [x] Mobile: Forum post card renders markdown/images in preview
- [x] Mobile: Tapping links in preview doesn't hijack card navigation
- [x] Mobile: Preview has smooth bottom fade instead of hard clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)