### PR TITLE
fix(desktop): remove stale sprout-admin prereq, add sidecar tooling

### DIFF
--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -6,7 +6,7 @@ use crate::{
     managed_agents::{
         command_availability, discover_local_acp_providers, AcpProviderInfo,
         DiscoverManagedAgentPrereqsRequest, ManagedAgentPrereqsInfo, RelayAgentInfo,
-        DEFAULT_ACP_COMMAND, DEFAULT_ADMIN_COMMAND, DEFAULT_MCP_COMMAND,
+        DEFAULT_ACP_COMMAND, DEFAULT_MCP_COMMAND,
     },
     relay::{build_authed_request, send_json_request},
 };
@@ -37,7 +37,6 @@ pub fn discover_managed_agent_prereqs(
     ManagedAgentPrereqsInfo {
         acp: command_availability(acp_command, Some(&app)),
         mcp: command_availability(mcp_command, Some(&app)),
-        admin: command_availability(DEFAULT_ADMIN_COMMAND, Some(&app)),
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -273,7 +273,6 @@ pub struct DiscoverManagedAgentPrereqsRequest {
 pub struct ManagedAgentPrereqsInfo {
     pub acp: CommandAvailabilityInfo,
     pub mcp: CommandAvailabilityInfo,
-    pub admin: CommandAvailabilityInfo,
 }
 
 /// Patch request for updating a managed agent's mutable fields.
@@ -374,7 +373,6 @@ pub struct UpdateTeamRequest {
 }
 
 pub const DEFAULT_ACP_COMMAND: &str = "sprout-acp";
-pub const DEFAULT_ADMIN_COMMAND: &str = "sprout-admin";
 pub const DEFAULT_AGENT_COMMAND: &str = "goose";
 pub const DEFAULT_MCP_COMMAND: &str = "sprout-mcp-server";
 /// ~5 min (320s) — matches the CLI harness default (SPROUT_ACP_IDLE_TIMEOUT).

--- a/desktop/src/features/agents/ui/CreateAgentDialog.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialog.tsx
@@ -99,11 +99,9 @@ export function CreateAgentDialog({
   // Use this everywhere instead of raw `mintToken` for validation/rendering.
   const effectiveMintToken = isProviderMode || mintToken;
 
-  const isMintSupported = prereqs?.admin.available ?? false;
   const isSpawnSupported =
     prereqs?.acp.available === true && prereqs?.mcp.available === true;
-  const mintToggleDisabled =
-    prereqsQuery.isLoading || (prereqs !== null && !isMintSupported);
+  const mintToggleDisabled = prereqsQuery.isLoading;
   const spawnToggleDisabled =
     prereqsQuery.isLoading || (prereqs !== null && !isSpawnSupported);
   const isDiscoveryPending = providersQuery.isLoading || prereqsQuery.isLoading;
@@ -125,15 +123,6 @@ export function CreateAgentDialog({
     providers,
     providersQuery.isLoading,
   ]);
-
-  React.useEffect(() => {
-    // Don't auto-disable minting in provider mode — it's required.
-    if (!prereqs || prereqs.admin.available || !mintToken || isProviderMode) {
-      return;
-    }
-
-    setMintToken(false);
-  }, [mintToken, prereqs, isProviderMode]);
 
   React.useEffect(() => {
     if (
@@ -305,7 +294,6 @@ export function CreateAgentDialog({
     name.trim().length > 0 &&
     (!effectiveMintToken || selectedScopes.size > 0) &&
     !isDiscoveryPending &&
-    !(effectiveMintToken && prereqs !== null && !isMintSupported) &&
     !(
       !isProviderMode &&
       spawnAfterCreate &&
@@ -464,7 +452,6 @@ export function CreateAgentDialog({
             ) : null}
 
             <CreateAgentOptionToggles
-              isMintSupported={isMintSupported}
               isSpawnSupported={isSpawnSupported}
               mintToken={effectiveMintToken}
               mintToggleDisabled={isProviderMode || mintToggleDisabled}

--- a/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
@@ -325,7 +325,6 @@ export function CreateAgentRuntimeFields({
 }
 
 export function CreateAgentOptionToggles({
-  isMintSupported,
   isSpawnSupported,
   mintToken,
   mintToggleDisabled,
@@ -338,7 +337,6 @@ export function CreateAgentOptionToggles({
   onToggleStartOnAppLaunch,
   onToggleSpawnAfterCreate,
 }: {
-  isMintSupported: boolean;
   isSpawnSupported: boolean;
   mintToken: boolean;
   mintToggleDisabled: boolean;
@@ -369,9 +367,7 @@ export function CreateAgentOptionToggles({
       >
         <p className="text-sm font-semibold tracking-tight">Mint token</p>
         <p className="mt-1 text-sm text-foreground/70">
-          {prereqs !== null && !isMintSupported
-            ? `Unavailable until ${prereqs.admin.command} is installed.`
-            : "Use sprout-admin to create a bearer token for this agent."}
+          Mint a relay API token for this agent.
         </p>
       </button>
 

--- a/desktop/src/features/settings/ui/DoctorSettingsPanel.tsx
+++ b/desktop/src/features/settings/ui/DoctorSettingsPanel.tsx
@@ -141,8 +141,8 @@ function SetupHelpCard() {
           <code className="rounded bg-background px-1.5 py-0.5 font-mono text-[12px]">
             cargo build --release --workspace
           </code>{" "}
-          when you want the desktop app to mint tokens or spawn ACP harnesses
-          from this checkout.
+          when you want the desktop app to spawn ACP harnesses from this
+          checkout.
         </p>
         <p>
           If you keep binaries outside your PATH, use the custom ACP and MCP
@@ -169,13 +169,6 @@ export function DoctorSettingsPanel() {
 
   const toolChecks = [
     {
-      id: "admin",
-      label: "Token minting",
-      purpose:
-        "Desktop uses `sprout-admin` to mint managed-agent bearer tokens.",
-      availability: prereqs?.admin ?? null,
-    },
-    {
       id: "acp",
       label: "ACP harness",
       purpose:
@@ -192,10 +185,7 @@ export function DoctorSettingsPanel() {
   ];
 
   const hasMissingSproutTools =
-    prereqs !== null &&
-    (!prereqs.admin.available ||
-      !prereqs.acp.available ||
-      !prereqs.mcp.available);
+    prereqs !== null && (!prereqs.acp.available || !prereqs.mcp.available);
 
   return (
     <section className="space-y-5" data-testid="settings-doctor">
@@ -306,11 +296,6 @@ export function DoctorSettingsPanel() {
                 />
               </div>
             </div>
-
-            <p className="mt-3 text-xs text-muted-foreground">
-              Token minting always checks the default{" "}
-              <code className="font-mono">sprout-admin</code> command.
-            </p>
           </div>
         </div>
 

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -289,7 +289,6 @@ type RawCommandAvailability = {
 };
 
 type RawManagedAgentPrereqs = {
-  admin: RawCommandAvailability;
   acp: RawCommandAvailability;
   mcp: RawCommandAvailability;
 };
@@ -1046,7 +1045,6 @@ export async function discoverManagedAgentPrereqs(input: {
   );
 
   return {
-    admin: fromRawCommandAvailability(response.admin),
     acp: fromRawCommandAvailability(response.acp),
     mcp: fromRawCommandAvailability(response.mcp),
   };

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -386,7 +386,6 @@ export type CommandAvailability = {
 };
 
 export type ManagedAgentPrereqs = {
-  admin: CommandAvailability;
   acp: CommandAvailability;
   mcp: CommandAvailability;
 };

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -348,7 +348,6 @@ type RawCommandAvailability = {
 };
 
 type RawManagedAgentPrereqs = {
-  admin: RawCommandAvailability;
   acp: RawCommandAvailability;
   mcp: RawCommandAvailability;
 };
@@ -3056,11 +3055,6 @@ async function handleDiscoverManagedAgentPrereqs(args: {
   };
 }): Promise<RawManagedAgentPrereqs> {
   return {
-    admin: {
-      command: "sprout-admin",
-      resolved_path: "/Users/wesb/dev/sprout/target/debug/sprout-admin",
-      available: true,
-    },
     acp: {
       command: args.input?.acpCommand ?? "sprout-acp",
       resolved_path: "/Users/wesb/dev/sprout/target/debug/sprout-acp",

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -393,9 +393,6 @@ test("shows doctor checks for local sprout tooling", async ({ page }) => {
   await openSettings(page, "doctor");
 
   await expect(page.getByTestId("settings-doctor")).toBeVisible();
-  await expect(page.getByTestId("doctor-check-admin")).toContainText(
-    "sprout-admin",
-  );
   await expect(page.getByTestId("doctor-check-acp")).toContainText(
     "sprout-acp",
   );

--- a/justfile
+++ b/justfile
@@ -85,14 +85,18 @@ desktop-tauri-fmt:
 desktop-tauri-fmt-check:
     cargo fmt --manifest-path {{desktop_tauri_manifest}} --all -- --check
 
-# Check the desktop Tauri Rust crate compiles
-desktop-tauri-check:
+# Ensure sidecar placeholder binaries exist (Tauri validates externalBin at compile time)
+_ensure-sidecar-stubs:
     #!/usr/bin/env bash
     set -euo pipefail
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
     mkdir -p desktop/src-tauri/binaries
-    touch "desktop/src-tauri/binaries/sprout-acp-$TARGET"
-    touch "desktop/src-tauri/binaries/sprout-mcp-server-$TARGET"
+    for bin in sprout-acp sprout-mcp-server; do
+        touch "desktop/src-tauri/binaries/${bin}-${TARGET}"
+    done
+
+# Check the desktop Tauri Rust crate compiles
+desktop-tauri-check: _ensure-sidecar-stubs
     cargo check --manifest-path {{desktop_tauri_manifest}}
 
 # Run desktop checks suitable for CI / pre-push
@@ -146,31 +150,21 @@ proxy-release:
     cargo run -p sprout-proxy --release
 
 # Run the desktop Tauri app in dev mode (ports and identity derived from worktree)
-dev *ARGS:
+dev *ARGS: _ensure-sidecar-stubs
     #!/usr/bin/env bash
     set -euo pipefail
     cd {{desktop_dir}}
     [[ -d node_modules ]] || pnpm install
-    # Ensure sidecar placeholder binaries exist (Tauri validates externalBin at compile time)
-    TARGET=$(rustc -vV | sed -n 's|host: ||p')
-    mkdir -p src-tauri/binaries
-    touch "src-tauri/binaries/sprout-acp-$TARGET"
-    touch "src-tauri/binaries/sprout-mcp-server-$TARGET"
     source ../scripts/instance-env.sh
     echo "Starting on Vite port ${SPROUT_VITE_PORT}, relay ${SPROUT_RELAY_URL}"
     pnpm exec tauri dev --config "$SPROUT_TAURI_CONFIG" {{ARGS}}
 
 # Run the desktop app against the internal staging relay (installs deps + builds agent tools automatically)
-staging *ARGS:
+staging *ARGS: _ensure-sidecar-stubs
     #!/usr/bin/env bash
     set -euo pipefail
     cd {{desktop_dir}}
     pnpm install
-    # Ensure sidecar placeholder binaries exist (Tauri validates externalBin at compile time)
-    TARGET=$(rustc -vV | sed -n 's|host: ||p')
-    mkdir -p src-tauri/binaries
-    touch "src-tauri/binaries/sprout-acp-$TARGET"
-    touch "src-tauri/binaries/sprout-mcp-server-$TARGET"
     cd ..
     cargo build --release -p sprout-acp -p sprout-mcp
     cd {{desktop_dir}}

--- a/scripts/bundle-sidecars.sh
+++ b/scripts/bundle-sidecars.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SIDECARS=(sprout-acp sprout-mcp-server)
+TARGET=${1:-$(rustc -vV | sed -n 's|host: ||p')}
+BINARIES_DIR="desktop/src-tauri/binaries"
+
+missing=()
+for bin in "${SIDECARS[@]}"; do
+    [[ -f "target/release/$bin" ]] || missing+=("$bin")
+done
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "Error: missing release binaries: ${missing[*]}" >&2
+    echo "Run 'cargo build --release -p sprout-acp -p sprout-mcp' first." >&2
+    exit 1
+fi
+
+mkdir -p "$BINARIES_DIR"
+for bin in "${SIDECARS[@]}"; do
+    cp "target/release/$bin" "$BINARIES_DIR/${bin}-${TARGET}"
+done
+echo "Sidecars bundled for $TARGET"


### PR DESCRIPTION
## Summary
- Remove the stale `sprout-admin` prerequisite check that gated the mint toggle in the Create Agent dialog. Token minting uses `mint_token_via_api()` (NIP-98 HTTP) — the binary was never invoked, but the UI check prevented minting in release DMG builds where `sprout-admin` wasn't on PATH.
- DRY up justfile sidecar stub creation into a shared `_ensure-sidecar-stubs` recipe.
- Add `scripts/bundle-sidecars.sh` for copying release binaries into the Tauri sidecar directory.

## Changes
**Rust:** Removed `DEFAULT_ADMIN_COMMAND` const and `admin` field from `ManagedAgentPrereqsInfo`
**TypeScript:** Removed `admin` from all type definitions, raw Tauri bridge mappings, and e2e mock data
**UI:** Removed "Token minting" from Doctor panel, removed `isMintSupported` gating from Create Agent dialog
**Build:** DRYed justfile sidecar stubs, added `bundle-sidecars.sh`

## Test plan
- [x] `cargo check` passes
- [x] `tsc --noEmit` passes
- [x] `biome check` passes
- [x] `just desktop-tauri-check` compiles clean
- [x] Verify mint toggle is enabled by default in Create Agent dialog (no longer gated on sprout-admin)
- [x] Verify Doctor panel shows only ACP harness and MCP server checks (no Token minting row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)