### PR TITLE
fix(desktop): expand ACP discovery to include version-manager shim dirs

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -26,12 +26,27 @@ const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
 
-const COMMON_BINARY_PATHS: &[&str] = &[
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
-    "/usr/bin",
-    "/home/linuxbrew/.linuxbrew/bin",
-];
+fn common_binary_paths() -> &'static [PathBuf] {
+    use std::sync::OnceLock;
+    static PATHS: OnceLock<Vec<PathBuf>> = OnceLock::new();
+    PATHS.get_or_init(|| {
+        let mut paths = vec![
+            PathBuf::from("/opt/homebrew/bin"),
+            PathBuf::from("/usr/local/bin"),
+            PathBuf::from("/usr/bin"),
+            PathBuf::from("/home/linuxbrew/.linuxbrew/bin"),
+        ];
+        if let Some(home) = dirs::home_dir() {
+            paths.extend([
+                home.join(".local/share/mise/shims"),
+                home.join(".local/bin"),
+                home.join(".volta/bin"),
+                home.join(".asdf/shims"),
+            ]);
+        }
+        paths
+    })
+}
 
 const KNOWN_ACP_PROVIDERS: &[KnownAcpProvider] = &[
     KnownAcpProvider {
@@ -240,9 +255,8 @@ fn resolve_command_uncached(command: &str, app: Option<&AppHandle>) -> Option<Pa
     if let Some(path) = find_via_login_shell(command) {
         return Some(path);
     }
-
-    for dir in COMMON_BINARY_PATHS {
-        let candidate = PathBuf::from(dir).join(executable_basename(command));
+    for dir in common_binary_paths() {
+        let candidate = dir.join(executable_basename(command));
         if candidate.exists() {
             return Some(candidate);
         }


### PR DESCRIPTION
## Summary
- Replaces static `COMMON_BINARY_PATHS` const with an `OnceLock`-cached `common_binary_paths()` function that includes version-manager shim directories (`~/.local/share/mise/shims`, `~/.local/bin`, `~/.volta/bin`, `~/.asdf/shims`)
- Resolves `$HOME` at runtime via `dirs::home_dir()` (already a dependency)
- Fixes ACP discovery for DMG users whose binaries are installed via mise, volta, asdf, pip, etc.

## Context
Users running the release DMG couldn't discover Claude ACP when installed via version managers (e.g. `~/.local/share/mise/installs/node/23.11.0/bin/claude-agent-acp`). PR #372 fixed the spawn-side PATH but not discovery. This adds the common shim directories as a last-resort fallback in the existing resolution chain.

## Test plan
- [x] All Rust tests pass (including discovery tests)
- [x] `cargo check` compiles cleanly
- [x] `cargo clippy` clean
- [x] File stays within 500-line limit
- [ ] Manual: install claude-agent-acp via mise, verify DMG build discovers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)