### PR TITLE
Fix zombie agent detection and surface stopped agent cleanup

### DIFF
--- a/crates/sprout-relay/src/api/messages.rs
+++ b/crates/sprout-relay/src/api/messages.rs
@@ -129,11 +129,8 @@ pub fn validate_imeta_tags(tags: &[Vec<String>], media_base_url: &str) -> Result
                         return Err("imeta duration must be a valid float".into());
                     }
                 }
-                "bitrate" => {
-                    // NIP-71 standard field: bits/sec as integer, positive
-                    if value.parse::<u64>().map_or(true, |b| b == 0) {
-                        return Err("imeta bitrate must be a positive integer".into());
-                    }
+                "bitrate" if value.parse::<u64>().map_or(true, |b| b == 0) => {
+                    return Err("imeta bitrate must be a positive integer".into());
                 }
                 "image" => {
                     // NIP-71 poster frame — must be a local media URL with an image extension.

--- a/crates/sprout-relay/src/handlers/ingest.rs
+++ b/crates/sprout-relay/src/handlers/ingest.rs
@@ -703,15 +703,11 @@ fn validate_diff_event(event: &Event) -> Result<(), String> {
                     return Err("parent-commit SHA must be at least 7 hex characters".to_string());
                 }
             }
-            "branch" => {
-                if parts.len() < 3 || parts[1].is_empty() || parts[2].is_empty() {
-                    return Err("branch tag requires both source and target".to_string());
-                }
+            "branch" if (parts.len() < 3 || parts[1].is_empty() || parts[2].is_empty()) => {
+                return Err("branch tag requires both source and target".to_string());
             }
-            "pr" => {
-                if parts[1].parse::<u32>().map(|n| n == 0).unwrap_or(true) {
-                    return Err("pr number must be a positive integer".to_string());
-                }
+            "pr" if parts[1].parse::<u32>().map(|n| n == 0).unwrap_or(true) => {
+                return Err("pr number must be a positive integer".to_string());
             }
             _ => {}
         }

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -321,7 +321,7 @@ pub fn sync_managed_agent_processes(
             continue;
         };
 
-        if process_is_running(pid) {
+        if process_is_running(pid) && process_belongs_to_us(pid) {
             continue;
         }
 
@@ -601,7 +601,7 @@ pub fn start_managed_agent_process(
     }
 
     if let Some(pid) = record.runtime_pid {
-        if process_is_running(pid) {
+        if process_is_running(pid) && process_belongs_to_us(pid) {
             record.updated_at = now_iso();
             record.last_error = None;
             return Ok(());

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -119,7 +119,6 @@ export function ManagedAgentRow({
                 presenceStatus={presenceStatus}
               />
               <StatusBlock
-                lastStartedAt={agent.lastStartedAt}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -140,7 +139,6 @@ export function ManagedAgentRow({
                 presenceStatus={presenceStatus}
               />
               <StatusBlock
-                lastStartedAt={agent.lastStartedAt}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -252,13 +250,11 @@ function AgentSummary({
 }
 
 function StatusBlock({
-  lastStartedAt,
   presenceLoaded,
   presenceStatus,
   processDetail,
   status,
 }: {
-  lastStartedAt: string | null;
   presenceLoaded: boolean;
   presenceStatus: PresenceStatus | undefined;
   processDetail: string;
@@ -270,7 +266,6 @@ function StatusBlock({
         Status
       </p>
       <AgentStatusBadge
-        lastStartedAt={lastStartedAt}
         presenceLoaded={presenceLoaded}
         presenceStatus={presenceStatus}
         status={status}
@@ -462,12 +457,10 @@ function AgentOriginBadge({ agent }: { agent: ManagedAgent }) {
 }
 
 function AgentStatusBadge({
-  lastStartedAt,
   presenceLoaded,
   presenceStatus,
   status,
 }: {
-  lastStartedAt: string | null;
   presenceLoaded: boolean;
   presenceStatus: PresenceStatus | undefined;
   status: ManagedAgent["status"];
@@ -478,25 +471,11 @@ function AgentStatusBadge({
     status === "running" &&
     (!presenceStatus || presenceStatus === "offline");
 
-  const STALE_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes
-  const isStale =
-    isStarting &&
-    (lastStartedAt == null ||
-      Date.now() - new Date(lastStartedAt).getTime() > STALE_THRESHOLD_MS);
+  const variant = isStarting ? "warning" : isActive ? "default" : "secondary";
 
-  const variant = isStale
-    ? "secondary"
-    : isStarting
-      ? "warning"
-      : isActive
-        ? "default"
-        : "secondary";
-
-  const label = isStale
-    ? "Offline"
-    : isStarting
-      ? "Starting\u2026"
-      : status.replace(/_/g, " ");
-
-  return <Badge variant={variant}>{label}</Badge>;
+  return (
+    <Badge variant={variant}>
+      {isStarting ? "Starting\u2026" : status.replace(/_/g, " ")}
+    </Badge>
+  );
 }

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -119,6 +119,7 @@ export function ManagedAgentRow({
                 presenceStatus={presenceStatus}
               />
               <StatusBlock
+                lastStartedAt={agent.lastStartedAt}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -139,6 +140,7 @@ export function ManagedAgentRow({
                 presenceStatus={presenceStatus}
               />
               <StatusBlock
+                lastStartedAt={agent.lastStartedAt}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -250,11 +252,13 @@ function AgentSummary({
 }
 
 function StatusBlock({
+  lastStartedAt,
   presenceLoaded,
   presenceStatus,
   processDetail,
   status,
 }: {
+  lastStartedAt: string | null;
   presenceLoaded: boolean;
   presenceStatus: PresenceStatus | undefined;
   processDetail: string;
@@ -266,6 +270,7 @@ function StatusBlock({
         Status
       </p>
       <AgentStatusBadge
+        lastStartedAt={lastStartedAt}
         presenceLoaded={presenceLoaded}
         presenceStatus={presenceStatus}
         status={status}
@@ -457,10 +462,12 @@ function AgentOriginBadge({ agent }: { agent: ManagedAgent }) {
 }
 
 function AgentStatusBadge({
+  lastStartedAt,
   presenceLoaded,
   presenceStatus,
   status,
 }: {
+  lastStartedAt: string | null;
   presenceLoaded: boolean;
   presenceStatus: PresenceStatus | undefined;
   status: ManagedAgent["status"];
@@ -471,11 +478,25 @@ function AgentStatusBadge({
     status === "running" &&
     (!presenceStatus || presenceStatus === "offline");
 
-  const variant = isStarting ? "warning" : isActive ? "default" : "secondary";
+  const STALE_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes
+  const isStale =
+    isStarting &&
+    (lastStartedAt == null ||
+      Date.now() - new Date(lastStartedAt).getTime() > STALE_THRESHOLD_MS);
 
-  return (
-    <Badge variant={variant}>
-      {isStarting ? "Starting\u2026" : status.replace(/_/g, " ")}
-    </Badge>
-  );
+  const variant = isStale
+    ? "secondary"
+    : isStarting
+      ? "warning"
+      : isActive
+        ? "default"
+        : "secondary";
+
+  const label = isStale
+    ? "Offline"
+    : isStarting
+      ? "Starting\u2026"
+      : status.replace(/_/g, " ");
+
+  return <Badge variant={variant}>{label}</Badge>;
 }

--- a/desktop/src/features/agents/ui/ManagedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentsSection.tsx
@@ -181,6 +181,23 @@ export function ManagedAgentsSection({
         </div>
       ) : null}
 
+      {!isLoading && stoppedCount > 0 ? (
+        <div className="flex items-center justify-between rounded-xl border border-border/60 bg-muted/30 px-4 py-2.5">
+          <p className="text-sm text-muted-foreground">
+            {stoppedCount} stopped {stoppedCount === 1 ? "agent" : "agents"}
+          </p>
+          <Button
+            disabled={isActionPending}
+            onClick={onBulkRemoveStopped}
+            size="sm"
+            variant="ghost"
+          >
+            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+            Remove all
+          </Button>
+        </div>
+      ) : null}
+
       {error ? (
         <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
           {error.message}

--- a/desktop/src/features/agents/ui/ManagedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentsSection.tsx
@@ -187,13 +187,14 @@ export function ManagedAgentsSection({
             {stoppedCount} stopped {stoppedCount === 1 ? "agent" : "agents"}
           </p>
           <Button
+            className="text-destructive"
             disabled={isActionPending}
             onClick={onBulkRemoveStopped}
             size="sm"
             variant="ghost"
           >
             <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-            Remove all
+            Remove stopped
           </Button>
         </div>
       ) : null}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.95.0"
 profile = "default"


### PR DESCRIPTION
## Summary
- **Backend (runtime.rs):** Add `process_belongs_to_us(pid)` guard to `sync_managed_agent_processes` and `start_managed_agent_process` — prevents recycled PIDs from fooling the runtime into thinking dead agents are alive. Matches the existing pattern already used in sweep/kill functions.
- **UI (ManagedAgentsSection.tsx):** Surface an inline cleanup banner when stopped agents exist, showing "N stopped agent(s)" with a "Remove stopped" button. Previously this action was buried in the ⋯ dropdown menu.

## Test plan
- [x] Verify agents with recycled PIDs are correctly detected as stopped on next sync cycle
- [x] Verify "Remove stopped" banner appears in Agents library when stopped agents exist
- [x] Verify banner disappears when all stopped agents are removed
- [x] Verify "Remove stopped" button is disabled during pending operations
- [x] Verify button styling matches destructive intent (red text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)