### PR TITLE
fix(desktop): sidebar button z-index, remember runtime, show agent ACP info

### DIFF
--- a/desktop/src/features/agents/lib/useLastRuntimeProvider.ts
+++ b/desktop/src/features/agents/lib/useLastRuntimeProvider.ts
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+const STORAGE_KEY = "sprout:last-runtime-provider";
+
+export function useLastRuntimeProvider(): {
+  lastProviderId: string | null;
+  setLastProvider: (id: string) => void;
+} {
+  const [lastProviderId, setLastProviderId] = React.useState<string | null>(
+    () => {
+      try {
+        return localStorage.getItem(STORAGE_KEY);
+      } catch {
+        return null;
+      }
+    },
+  );
+
+  const setLastProvider = React.useCallback((id: string) => {
+    setLastProviderId(id);
+    try {
+      localStorage.setItem(STORAGE_KEY, id);
+    } catch {
+      // localStorage full — ignore
+    }
+  }, []);
+
+  return { lastProviderId, setLastProvider };
+}

--- a/desktop/src/features/agents/ui/CreateAgentDialog.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialog.tsx
@@ -34,6 +34,7 @@ import {
   coerceConfigValues,
   ProviderConfigFields,
 } from "./ProviderConfigFields";
+import { useLastRuntimeProvider } from "@/features/agents/lib/useLastRuntimeProvider";
 
 // ── Dialog ────────────────────────────────────────────────────────────────────
 
@@ -49,6 +50,7 @@ export function CreateAgentDialog({
   const createMutation = useCreateManagedAgentMutation();
   const providersQuery = useAcpProvidersQuery();
   const backendProvidersQuery = useBackendProvidersQuery();
+  const { lastProviderId, setLastProvider } = useLastRuntimeProvider();
   const [acpCommand, setAcpCommand] = React.useState("sprout-acp");
   const [agentCommand, setAgentCommand] = React.useState("goose");
   const [agentArgs, setAgentArgs] = React.useState("acp");
@@ -111,15 +113,26 @@ export function CreateAgentDialog({
       return;
     }
 
-    const matchingProvider =
-      providers.find((provider) => provider.command === agentCommand) ?? null;
-    if (matchingProvider) {
-      setSelectedProviderId(matchingProvider.id);
+    // Prefer last-used provider from localStorage
+    const remembered = lastProviderId
+      ? providers.find((provider) => provider.id === lastProviderId)
+      : null;
+    if (remembered) {
+      setSelectedProviderId(remembered.id);
+      setAgentCommand(remembered.command);
+      setAgentArgs(remembered.defaultArgs.join(","));
+    } else {
+      const matchingProvider =
+        providers.find((provider) => provider.command === agentCommand) ?? null;
+      if (matchingProvider) {
+        setSelectedProviderId(matchingProvider.id);
+      }
     }
     setHasSyncedProviderSelection(true);
   }, [
     agentCommand,
     hasSyncedProviderSelection,
+    lastProviderId,
     providers,
     providersQuery.isLoading,
   ]);
@@ -269,6 +282,7 @@ export function CreateAgentDialog({
       return;
     }
 
+    setLastProvider(nextProviderId);
     setAgentCommand(provider.command);
     setAgentArgs(provider.defaultArgs.join(","));
   }

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/features/agents/lib/resolvePersonaProvider";
 import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { getUsableTeams } from "@/features/agents/lib/teamPersonas";
+import { useLastRuntimeProvider } from "@/features/agents/lib/useLastRuntimeProvider";
 
 type AddChannelBotDialogProps = {
   backendProviders?: BackendProviderCandidate[];
@@ -98,6 +99,7 @@ export function AddChannelBotDialog({
   onAdded,
   onOpenChange,
 }: AddChannelBotDialogProps) {
+  const { lastProviderId, setLastProvider } = useLastRuntimeProvider();
   const personasQuery = usePersonasQuery();
   const teamsQuery = useTeamsQuery();
   const inChannelPersonaIds = useInChannelPersonaIds(
@@ -183,10 +185,13 @@ export function AddChannelBotDialog({
       return;
     }
 
-    if (!selectedProviderId && providers[0]) {
-      setSelectedProviderId(providers[0].id);
+    if (!selectedProviderId && providers.length > 0) {
+      const remembered = lastProviderId
+        ? providers.find((p) => p.id === lastProviderId)
+        : null;
+      setSelectedProviderId(remembered ? remembered.id : providers[0].id);
     }
-  }, [open, providers, selectedProviderId]);
+  }, [open, providers, selectedProviderId, lastProviderId]);
 
   React.useEffect(() => {
     if (!selectedProvider || hasEditedCustomName) {
@@ -247,7 +252,7 @@ export function AddChannelBotDialog({
   }, [isProviderMode, selectedBackendProvider]);
 
   function reset() {
-    setSelectedProviderId(providers[0]?.id ?? "");
+    setSelectedProviderId("");
     setSelectedPersonaIds([]);
     setIncludeGeneric(false);
     setCustomName(providers[0] ? defaultBotName(providers[0]) : "");
@@ -503,7 +508,10 @@ export function AddChannelBotDialog({
               onCloseAutoFocus={(event) => event.preventDefault()}
             >
               <DropdownMenuRadioGroup
-                onValueChange={setSelectedProviderId}
+                onValueChange={(id) => {
+                  setSelectedProviderId(id);
+                  setLastProvider(id);
+                }}
                 value={selectedProvider?.id ?? ""}
               >
                 {providers.map((provider) => (

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -25,14 +25,23 @@ type UserProfilePopoverProps = {
   botIdenticonValue?: string;
 };
 
+const RUNTIME_LABELS: Record<string, string> = {
+  goose: "Goose",
+  "claude-code": "Claude Code",
+  "codex-acp": "Codex",
+  aider: "Aider",
+};
+
 function runtimeLabel(command: string): string {
-  const map: Record<string, string> = {
-    goose: "Goose",
-    "claude-code": "Claude Code",
-    "codex-acp": "Codex",
-    aider: "Aider",
-  };
-  return map[command] ?? command;
+  return RUNTIME_LABELS[command] ?? command;
+}
+
+function InfoBadge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-full bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground">
+      {children}
+    </span>
+  );
 }
 
 function truncatePubkey(pubkey: string) {
@@ -120,23 +129,15 @@ export function UserProfilePopover({
           {role === "bot" && (managedAgent || relayAgent) ? (
             <div className="flex flex-wrap gap-1.5">
               {managedAgent?.agentCommand ? (
-                <span className="inline-flex items-center rounded-full bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground">
-                  {runtimeLabel(managedAgent.agentCommand)}
-                </span>
+                <InfoBadge>{runtimeLabel(managedAgent.agentCommand)}</InfoBadge>
               ) : relayAgent?.agentType ? (
-                <span className="inline-flex items-center rounded-full bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground">
-                  {runtimeLabel(relayAgent.agentType)}
-                </span>
+                <InfoBadge>{runtimeLabel(relayAgent.agentType)}</InfoBadge>
               ) : null}
               {managedAgent?.model ? (
-                <span className="inline-flex items-center rounded-full bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground">
-                  {managedAgent.model}
-                </span>
+                <InfoBadge>{managedAgent.model}</InfoBadge>
               ) : null}
               {managedAgent?.acpCommand ? (
-                <span className="inline-flex items-center rounded-full bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground">
-                  ACP: {managedAgent.acpCommand}
-                </span>
+                <InfoBadge>ACP: {managedAgent.acpCommand}</InfoBadge>
               ) : null}
             </div>
           ) : null}

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -4,6 +4,10 @@ import {
   useUserNotesQuery,
   useUserProfileQuery,
 } from "@/features/profile/hooks";
+import {
+  useRelayAgentsQuery,
+  useManagedAgentsQuery,
+} from "@/features/agents/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import { PresenceBadge } from "@/features/presence/ui/PresenceBadge";
 import { formatRelativeTime } from "@/features/forum/lib/time";
@@ -20,6 +24,16 @@ type UserProfilePopoverProps = {
   /** Value used to generate the BotIdenticon glyph (typically the author name). */
   botIdenticonValue?: string;
 };
+
+function runtimeLabel(command: string): string {
+  const map: Record<string, string> = {
+    goose: "Goose",
+    "claude-code": "Claude Code",
+    "codex-acp": "Codex",
+    aider: "Aider",
+  };
+  return map[command] ?? command;
+}
 
 function truncatePubkey(pubkey: string) {
   if (pubkey.length <= 16) {
@@ -41,10 +55,20 @@ export function UserProfilePopover({
   const notesQuery = useUserNotesQuery(open ? pubkey : undefined, {
     limit: showAllNotes ? 20 : 3,
   });
+  const relayAgentsQuery = useRelayAgentsQuery({
+    enabled: open && role === "bot",
+  });
+  const managedAgentsQuery = useManagedAgentsQuery({
+    enabled: open && role === "bot",
+  });
   const presenceQuery = usePresenceQuery(open ? [pubkey] : [], {
     enabled: open,
   });
 
+  const relayAgent = relayAgentsQuery.data?.find((a) => a.pubkey === pubkey);
+  const managedAgent = managedAgentsQuery.data?.find(
+    (a) => a.pubkey === pubkey,
+  );
   const profile = profileQuery.data;
   const notes = notesQuery.data?.notes ?? [];
   const presenceStatus = presenceQuery.data?.[pubkey.toLowerCase()];
@@ -92,6 +116,30 @@ export function UserProfilePopover({
 
             {presenceStatus ? <PresenceBadge status={presenceStatus} /> : null}
           </div>
+
+          {role === "bot" && (managedAgent || relayAgent) ? (
+            <div className="flex flex-wrap gap-1.5">
+              {managedAgent?.agentCommand ? (
+                <span className="inline-flex items-center rounded-full bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground">
+                  {runtimeLabel(managedAgent.agentCommand)}
+                </span>
+              ) : relayAgent?.agentType ? (
+                <span className="inline-flex items-center rounded-full bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground">
+                  {runtimeLabel(relayAgent.agentType)}
+                </span>
+              ) : null}
+              {managedAgent?.model ? (
+                <span className="inline-flex items-center rounded-full bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground">
+                  {managedAgent.model}
+                </span>
+              ) : null}
+              {managedAgent?.acpCommand ? (
+                <span className="inline-flex items-center rounded-full bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground">
+                  ACP: {managedAgent.acpCommand}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
 
           {profile?.about ? (
             <p className="text-xs leading-relaxed text-muted-foreground">

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -112,7 +112,7 @@ function SectionHeaderActions({
   onCreateClick: () => void;
 }) {
   return (
-    <div className="absolute right-1 top-3 flex items-center gap-0.5">
+    <div className="absolute right-1 top-3 z-10 flex items-center gap-0.5">
       <button
         aria-label={browseAriaLabel}
         className={SECTION_ICON_BUTTON_CLASS}

--- a/desktop/src/shared/ui/sidebar.tsx
+++ b/desktop/src/shared/ui/sidebar.tsx
@@ -412,7 +412,7 @@ const SidebarContent = React.forwardRef<
       ref={ref}
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto [scrollbar-gutter:stable] group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
       {...props}
@@ -468,7 +468,7 @@ const SidebarGroupAction = React.forwardRef<
       ref={ref}
       data-sidebar="group-action"
       className={cn(
-        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute right-3 top-3.5 z-10 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 after:md:hidden",
         "group-data-[collapsible=icon]:hidden",


### PR DESCRIPTION
## Summary
- **Sidebar "+" buttons clipped by scrollbar** — Added `z-10` to button containers and `scrollbar-gutter:stable` to `SidebarContent` so the scrollbar never overlaps the buttons
- **Remember last-used Runtime** — New `useLastRuntimeProvider` localStorage hook persists the last-selected runtime provider across AddChannelBotDialog and CreateAgentDialog, falling back to defaults if the stored provider no longer exists
- **Show ACP info in agent message popup** — `UserProfilePopover` now displays runtime, model, and ACP command as info badges when clicking on a bot message (queries only fire when popover is open for a bot)

## Notable review items
- Beth caught and verified two bugs in runtime persistence: stale React state in the hook (fixed by syncing React state + localStorage) and `reset()` defeating the restore logic (fixed by clearing `selectedProviderId` to `""`)
- Summer extracted a shared `InfoBadge` component and hoisted `RUNTIME_LABELS` to module scope

## Test plan
- [ ] Open sidebar with enough items to trigger scrollbar — verify "+" buttons are fully clickable
- [ ] Add an agent with Claude Code runtime → close dialog → reopen → verify Claude Code is pre-selected
- [ ] Add a bot to a channel with Claude Code → close dialog → reopen → verify Claude Code is pre-selected
- [ ] Click on a bot message in chat → verify popover shows runtime, model, and ACP info badges
- [ ] Click on a human message → verify no agent info section appears
- [ ] Build passes (`cd desktop && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)