### PR TITLE
fix: close race window that dropped active channel messages

### DIFF
--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -133,17 +133,18 @@ export function useLiveChannelUpdates(
     // when the user is already viewing the DM.
     handleDmEvent(event);
 
-    if (channelId === activeChannelId) {
-      return;
-    }
-
     if (!liveChannelIds.has(channelId)) {
-      void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+      if (channelId !== activeChannelId) {
+        void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+      }
       return;
     }
 
+    // Always update the cache — even for the active channel.
+    // useChannelSubscription also writes to this cache, but there's a
+    // race window where it hasn't connected yet. Writes are idempotent
+    // (mergeTimelineCacheMessages deduplicates by event ID).
     const messageTimestamp = getMessageTimestamp(event);
-
     updateChannelLastMessageAt(queryClient, channelId, messageTimestamp);
     queryClient.setQueryData<RelayEvent[]>(
       channelMessagesKey(channelId),


### PR DESCRIPTION
## Summary
- Fixed a race condition where messages for the active channel were silently dropped during the handoff between two subscription layers
- The global stream subscription (`useLiveChannelUpdates`) was skipping cache writes for the active channel, relying on the per-channel subscription (`useChannelSubscription`) — but that subscription connects asynchronously, creating a window where neither path writes to the cache
- Removed the active-channel early return so both subscriptions write to the cache; `mergeTimelineCacheMessages` deduplicates by event ID, making double-writes harmless

## Changes
- `desktop/src/features/channels/useLiveChannelUpdates.ts` — 7 insertions, 6 deletions

## Review notes
- Beth (reviewer): APPROVE — no BLOCK or CHANGE items. Confirmed dedup safety, no notification behavior change, acceptable performance at high message rates
- Summer (refactor): no structural changes needed — code is already clean
- NIT: `if (!current) return current` guard differs from `useChannelSubscription`'s `(current = [])` pattern — intentionally different semantics (global listener should not seed cache for unvisited channels)
- NIT: no regression test added — no existing test infrastructure for this hook

## Test plan
- [x] TypeScript typecheck passes
- [x] Biome lint/check passes (2 pre-existing warnings in unrelated forum files)
- [x] All pre-commit hooks green (desktop-check, desktop-tauri-fmt, mobile-check, rust-fmt)
- [ ] Manual verification: open a channel, confirm messages appear immediately without requiring a second event to trigger re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)