### PR TITLE
docs: Add NIP-AO (Agent Observability) draft

### DIFF
--- a/crates/sprout-relay/src/handlers/event.rs
+++ b/crates/sprout-relay/src/handlers/event.rs
@@ -731,7 +731,9 @@ mod tests {
         .sign_with_keys(&agent)
         .expect("sign event");
 
-        let route = super::agent_observer_route(&event).expect("observer route");
+        let route = super::agent_observer_route(&event)
+            .expect("observer route")
+            .expect("route should be Some");
         assert_eq!(route.agent, agent.public_key());
         assert_eq!(route.owner, owner.public_key());
         assert_eq!(route.direction, super::AgentObserverDirection::Telemetry);
@@ -759,7 +761,9 @@ mod tests {
         .sign_with_keys(&owner)
         .expect("sign event");
 
-        let route = super::agent_observer_route(&event).expect("observer route");
+        let route = super::agent_observer_route(&event)
+            .expect("observer route")
+            .expect("route should be Some");
         assert_eq!(route.agent, agent.public_key());
         assert_eq!(route.owner, owner.public_key());
         assert_eq!(route.direction, super::AgentObserverDirection::Control);

--- a/crates/sprout-relay/src/handlers/event.rs
+++ b/crates/sprout-relay/src/handlers/event.rs
@@ -506,8 +506,25 @@ async fn handle_agent_observer_event(
         }
     }
 
+    // Freshness check: reject observer frames with stale/future timestamps
+    let now = chrono::Utc::now().timestamp();
+    let event_ts = event.created_at.as_u64() as i64;
+    if (event_ts - now).unsigned_abs() > 300 {
+        conn.send(RelayMessage::ok(
+            event_id_hex,
+            false,
+            "invalid: observer frame timestamp outside ±5 minute freshness window",
+        ));
+        return;
+    }
+
     let route = match agent_observer_route(&event) {
-        Ok(route) => route,
+        Ok(Some(route)) => route,
+        Ok(None) => {
+            // Unknown frame value — silently drop, no error to publisher.
+            conn.send(RelayMessage::ok(event_id_hex, true, ""));
+            return;
+        }
         Err(message) => {
             reject("invalid");
             conn.send(RelayMessage::ok(event_id_hex, false, &message));
@@ -588,7 +605,7 @@ async fn handle_agent_observer_event(
     conn.send(RelayMessage::ok(event_id_hex, true, ""));
 }
 
-fn agent_observer_route(event: &Event) -> Result<AgentObserverRoute, String> {
+fn agent_observer_route(event: &Event) -> Result<Option<AgentObserverRoute>, String> {
     if !content_looks_like_nip44(&event.content) {
         return Err("invalid: observer content must be NIP-44 encrypted".into());
     }
@@ -617,16 +634,15 @@ fn agent_observer_route(event: &Event) -> Result<AgentObserverRoute, String> {
     };
 
     if frame != expected_frame {
-        return Err(format!(
-            "invalid: observer {direction:?} frame must use frame={expected_frame}"
-        ));
+        // Unknown frame value — silently drop without notifying the publisher.
+        return Ok(None);
     }
 
-    Ok(AgentObserverRoute {
+    Ok(Some(AgentObserverRoute {
         agent,
         owner,
         direction,
-    })
+    }))
 }
 
 fn parse_single_pubkey_tag(event: &Event, tag_name: &str) -> Result<PublicKey, String> {

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -18,6 +18,10 @@ type ObserverSnapshot = {
 const listeners = new Set<() => void>();
 const eventsByAgent = new Map<string, ObserverEvent[]>();
 
+// Normalized pubkeys of agents we are actively managing. Only events whose
+// "agent" tag matches an entry here will be decrypted (defense-in-depth).
+const knownAgentPubkeys = new Set<string>();
+
 let connectionState: ConnectionState = "idle";
 let errorMessage: string | null = null;
 let unsubscribeRelay: (() => Promise<void>) | null = null;
@@ -86,6 +90,12 @@ async function handleRelayObserverEvent(
   const agentPubkey = observerTag(event, "agent");
   const frame = observerTag(event, "frame");
   if (!agentPubkey || frame !== "telemetry") {
+    return;
+  }
+
+  // Verify agent is known/trusted before decrypting.
+  // Silently drop events from agents we are not managing.
+  if (!knownAgentPubkeys.has(normalizePubkey(agentPubkey))) {
     return;
   }
 
@@ -189,6 +199,14 @@ export function useManagedAgentObserverBridge(agents: readonly ManagedAgent[]) {
       ),
     [agents],
   );
+
+  // Keep the trusted-pubkey set in sync with the current managed agent list.
+  React.useEffect(() => {
+    knownAgentPubkeys.clear();
+    for (const agent of agents) {
+      knownAgentPubkeys.add(normalizePubkey(agent.pubkey));
+    }
+  }, [agents]);
 
   React.useEffect(() => {
     if (!hasActiveAgent) {

--- a/docs/nips/NIP-AO.md
+++ b/docs/nips/NIP-AO.md
@@ -6,8 +6,7 @@ Agent Observability
 
 `draft` `optional`
 
-This NIP defines ephemeral, encrypted event kinds for streaming internal session
-telemetry between AI agent processes and their owners' desktop clients via Nostr relays.
+This NIP defines ephemeral, encrypted event kinds for streaming internal session telemetry between AI agent processes and their owners' desktop clients via Nostr relays.
 
 ## Motivation
 
@@ -57,8 +56,10 @@ Events MUST have exactly one `p` tag, exactly one `agent` tag, and exactly one
 **Telemetry** (agent → owner): `pubkey`=agent, `p`=owner, `agent`=agent.
 **Control** (owner → agent): `pubkey`=owner, `p`=agent, `agent`=agent (target).
 
-`frame` MUST be `"telemetry"` or `"control"`; unrecognized values MUST be ignored.
-An `h` tag MAY be included when the session runs within a NIP-29 group context.
+`frame` MUST be `"telemetry"` or `"control"`. Relays MUST reject events with
+unrecognized `frame` values. Clients MUST ignore events with unrecognized `frame`
+values. An `h` tag MAY be included when the session runs within a NIP-29 group
+context.
 
 ## Encryption
 
@@ -79,21 +80,27 @@ The `content` field decrypts to an `ObserverEvent` JSON object:
 
 ```json
 {
-  "seq":        <monotonic_integer>,
-  "timestamp":  <unix_timestamp_ms>,
-  "kind":       "<frame_kind>",
-  "agentIndex": <integer>,
-  "channelId":  "<channel_uuid>",
-  "sessionId":  "<session_id>",
-  "turnId":     "<turn_id>",
-  "payload":    { ... }
+  "seq":         <monotonic_integer>,
+  "timestamp":   "<rfc3339_string>",
+  "kind":        "<frame_kind>",
+  "agentIndex":  <integer> | null,
+  "channelId":   "<channel_uuid>" | null,
+  "sessionId":   "<session_id>" | null,
+  "turnId":      "<turn_id>" | null,
+  "payload":     { ... }
 }
 ```
 
-All fields are REQUIRED. `seq` is monotonically increasing per session (drop detection).
-`timestamp` is millisecond-precision Unix time. `agentIndex` identifies the agent in
-multi-agent scenarios. `sessionId`/`turnId` correlate frames across a session and turn.
-`payload` is kind-specific (MAY be `{}`). Unknown `kind` values MUST be ignored.
+`seq`, `timestamp`, `kind`, and `payload` are REQUIRED. `agentIndex`, `channelId`, `sessionId`,
+and `turnId` are OPTIONAL — they MAY be `null` when the value is not yet known
+(e.g., `sessionId` before session establishment). Clients MUST handle `null` values
+gracefully.
+
+`seq` is monotonically increasing per session (drop detection). `timestamp` is an
+RFC 3339 datetime string with sub-second precision (e.g., `"2026-04-29T12:00:41.500Z"`).
+`agentIndex` identifies the agent in multi-agent scenarios. `sessionId`/`turnId`
+correlate frames across a session and turn. `payload` is kind-specific (MAY be `{}`).
+Unknown `kind` values MUST be ignored.
 
 ### Frame Kinds
 
@@ -141,10 +148,9 @@ events with unrecognized `type` values.
 - Relay MUST verify `is_agent_owner(agent, owner)` where agent is resolved from the
   `agent` tag.
 
-Both directions require the relay to confirm the agent-owner relationship via
-database lookup. `#p` tag matching alone is insufficient — this is an authenticated
-ownership check. Unauthorized publish or subscribe attempts MUST be rejected with
-`AUTH required`.
+Both directions require relay confirmation of the agent-owner relationship via
+database lookup. `#p` tag matching alone is insufficient. Unauthorized publish or
+subscribe attempts MUST be rejected with `AUTH required`.
 
 ## Relay Behavior
 
@@ -156,7 +162,7 @@ On receiving a kind 24200 event, a relay MUST:
 4. NOT invoke the normal event ingestion or persistence path.
 
 Relays SHOULD enforce a rate limit of 100 events/second per agent pubkey.
-Relays RECOMMENDED to reject events whose `created_at` falls outside a ±5-minute
+Relays are RECOMMENDED to reject events whose `created_at` falls outside a ±5-minute
 freshness window to prevent replay of captured events.
 
 ## Client Behavior
@@ -170,10 +176,12 @@ Clients subscribe with:
 On receiving an event, a client MUST:
 
 1. Verify the event signature.
-2. Check that the `agent` tag matches a known/trusted agent pubkey before decrypting.
-3. Decrypt `content` using own secret key and `event.pubkey`.
-4. Parse the decrypted payload and dispatch on `kind` (telemetry) or `type` (control).
-5. Ignore unknown `kind`/`type` values.
+2. Decrypt `content` using own secret key and `event.pubkey`.
+3. Parse the decrypted payload and dispatch on `kind` (telemetry) or `type` (control).
+4. Ignore unknown `kind`/`type` values.
+
+Clients SHOULD verify that the `agent` tag matches a known/trusted agent pubkey
+before decrypting.
 
 Clients SHOULD buffer events in a bounded ring buffer (RECOMMENDED maximum: 800 events).
 Clients MUST NOT request historical kind 24200 events (no `since` in the past, no
@@ -182,33 +190,26 @@ Clients MUST NOT request historical kind 24200 events (no `since` in the past, n
 ## Security Considerations
 
 **Metadata leakage.** Routing tags (`p`, `agent`, `frame`, `created_at`) are
-cleartext. A relay operator can observe that agent X is streaming to owner Y, when,
-and at what rate. This is acceptable for most threat models. For maximum metadata
-privacy, implementors MAY wrap events in NIP-59 gift wrap.
+cleartext. A relay operator can observe that agent X is streaming to owner Y at what
+rate. For maximum metadata privacy, implementors MAY wrap events in NIP-59 gift wrap.
 
-**No forward secrecy.** NIP-44 does not provide forward secrecy. Compromise of the
-agent's private key allows decryption of any captured ciphertext. This is the
-standard Nostr security trade-off.
+**No forward secrecy.** NIP-44 does not provide forward secrecy; compromise of the
+agent's private key allows decryption of any captured ciphertext.
 
 **Replay attacks.** A captured, signed event could be replayed without a freshness
 check. Relays are RECOMMENDED to enforce a `created_at` freshness window.
 
-**Rogue relays.** The ephemerality contract is enforced by relay policy, not
-cryptography. A malicious relay can store events. NIP-44 encryption ensures stored
-events remain opaque to the relay operator absent key compromise.
+**Rogue relays.** The ephemerality contract is relay policy, not cryptography.
+NIP-44 encryption ensures stored events remain opaque to the relay operator absent
+key compromise.
 
 **Best-effort delivery.** Control frames can be dropped during reconnect or queue
 overflow. Control commands SHOULD be treated as advisory with idempotent semantics.
 Agents MUST NOT rely on guaranteed delivery of control frames.
 
-**Operational persistence vectors.** Even with relay-level ephemerality, telemetry
-may transiently exist in in-memory pub/sub buffers, process memory, crash dumps,
-browser memory, and application logs. Implementations SHOULD minimize logging of
-decrypted payloads.
-
-**Sensitive content.** Observer payloads may contain tool arguments, API responses,
-or raw protocol frames that include secrets. Implementations MUST NOT log decrypted
-observer frame content at INFO level or above.
+**Operational persistence vectors.** Telemetry may transiently exist in process
+memory, crash dumps, and application logs. Implementations SHOULD minimize logging
+of decrypted payloads and MUST NOT log it at INFO level or above.
 
 ## Relationship to Other NIPs
 
@@ -218,9 +219,9 @@ observer frame content at INFO level or above.
 - **NIP-44**: Required encryption algorithm for all `content` fields.
 - **NIP-29**: An `h` tag MAY be included when the agent session is scoped to a
   NIP-29 group.
-- **NIP-XX (PR #2226)**: NIP-XX defines the agent *output* plane (what the agent
-  produces for users). This NIP defines the *observability* plane (what the agent is
-  doing internally). They are complementary and non-overlapping.
+- **NIP-XX (PR #2226)**: NIP-XX defines the agent *output* plane; this NIP defines
+  the *observability* plane (internal agent activity). They are complementary and
+  non-overlapping.
 
 ## Examples
 
@@ -233,7 +234,7 @@ observer frame content at INFO level or above.
   "id":         "a1b2c3d4...",
   "kind":       24200,
   "pubkey":     "agent_pubkey_hex",
-  "created_at": 1714000041,
+  "created_at": 1777464041,
   "content":    "<NIP-44 v2 ciphertext>",
   "tags": [
     ["p",     "owner_pubkey_hex"],
@@ -249,7 +250,7 @@ observer frame content at INFO level or above.
 ```json
 {
   "seq":        42,
-  "timestamp":  1714000041500,
+  "timestamp":  "2026-04-29T12:00:41.500Z",
   "kind":       "acp_write",
   "agentIndex": 0,
   "channelId":  "52a85618-0f8f-4542-94ec-599e6e1c6f2e",
@@ -274,7 +275,7 @@ observer frame content at INFO level or above.
   "id":         "e5f6a7b8...",
   "kind":       24200,
   "pubkey":     "owner_pubkey_hex",
-  "created_at": 1714000042,
+  "created_at": 1777464042,
   "content":    "<NIP-44 v2 ciphertext>",
   "tags": [
     ["p",     "agent_pubkey_hex"],

--- a/docs/nips/NIP-AO.md
+++ b/docs/nips/NIP-AO.md
@@ -1,0 +1,299 @@
+NIP-AO
+======
+
+Agent Observability
+-------------------
+
+`draft` `optional`
+
+This NIP defines ephemeral, encrypted event kinds for streaming internal session
+telemetry between AI agent processes and their owners' desktop clients via Nostr relays.
+
+## Motivation
+
+AI agent harnesses execute long-running sessions that invoke tools, send protocol
+frames to models, and emit intermediate reasoning. Owners need real-time visibility
+into this activity for debugging, auditing, and control — without that telemetry
+being stored on any relay or visible to third parties.
+
+Kind 24200 provides a dedicated, encrypted, ephemeral channel for this purpose.
+It is strictly scoped to the agent↔owner relationship and carries no durable state.
+
+## Definitions
+
+- **Agent**: An AI process with its own Nostr keypair, executing a session on behalf of an owner.
+- **Owner**: The human (or system) whose pubkey the agent was provisioned under.
+- **Observer Frame**: A single kind 24200 event carrying one unit of telemetry or control.
+- **Session**: A bounded agent execution correlated by a shared `sessionId`.
+
+## Event Kinds
+
+| Kind  | Name                  | Direction         |
+|-------|-----------------------|-------------------|
+| 24200 | Agent Observer Frame  | agent↔owner (both)|
+
+Kind 24200 falls in the ephemeral range (20000–29999) defined by NIP-01. Relays
+MUST NOT persist it.
+
+## Event Structure
+
+```json
+{
+  "kind": 24200,
+  "pubkey": "<sender_pubkey>",
+  "created_at": <unix_timestamp>,
+  "content": "<NIP-44 v2 ciphertext>",
+  "tags": [
+    ["p",     "<recipient_pubkey>"],
+    ["agent", "<agent_pubkey>"],
+    ["frame", "telemetry" | "control"]
+  ]
+}
+```
+
+Events MUST have exactly one `p` tag, exactly one `agent` tag, and exactly one
+`frame` tag.
+
+**Telemetry** (agent → owner): `pubkey`=agent, `p`=owner, `agent`=agent.
+**Control** (owner → agent): `pubkey`=owner, `p`=agent, `agent`=agent (target).
+
+`frame` MUST be `"telemetry"` or `"control"`; unrecognized values MUST be ignored.
+An `h` tag MAY be included when the session runs within a NIP-29 group context.
+
+## Encryption
+
+All `content` fields MUST be encrypted with NIP-44 v2 (XChaCha20-Poly1305 over a
+secp256k1 ECDH shared secret).
+
+- **Telemetry**: encrypted with `(agent_privkey, owner_pubkey)`
+- **Control**: encrypted with `(owner_privkey, agent_pubkey)`
+
+Plaintext SHOULD be zeroized from memory immediately after encrypt/decrypt.
+Decrypted payload MUST NOT exceed 65,535 bytes.
+
+## Decrypted Payload
+
+### Telemetry (`frame=telemetry`)
+
+The `content` field decrypts to an `ObserverEvent` JSON object:
+
+```json
+{
+  "seq":        <monotonic_integer>,
+  "timestamp":  <unix_timestamp_ms>,
+  "kind":       "<frame_kind>",
+  "agentIndex": <integer>,
+  "channelId":  "<channel_uuid>",
+  "sessionId":  "<session_id>",
+  "turnId":     "<turn_id>",
+  "payload":    { ... }
+}
+```
+
+All fields are REQUIRED. `seq` is monotonically increasing per session (drop detection).
+`timestamp` is millisecond-precision Unix time. `agentIndex` identifies the agent in
+multi-agent scenarios. `sessionId`/`turnId` correlate frames across a session and turn.
+`payload` is kind-specific (MAY be `{}`). Unknown `kind` values MUST be ignored.
+
+### Frame Kinds
+
+| `kind`             | Description                                              |
+|--------------------|----------------------------------------------------------|
+| `acp_read`         | Inbound ACP protocol frame (model → harness)             |
+| `acp_write`        | Outbound ACP protocol frame (harness → model)            |
+| `turn_started`     | A new agent turn has begun                               |
+| `session_resolved` | Session completed or terminated                          |
+
+### Control (`frame=control`)
+
+The `content` field decrypts to:
+
+```json
+{
+  "type":      "cancel_turn",
+  "channelId": "<channel_uuid>"
+}
+```
+
+The only defined control type is `cancel_turn`. Implementations MUST ignore
+events with unrecognized `type` values.
+
+## Ephemerality Contract
+
+- Relays MUST NOT persist kind 24200 events to any durable storage.
+- Relays MUST NOT include kind 24200 events in search indexes.
+- Relays MUST NOT include kind 24200 events in audit logs.
+- Relays SHOULD fan out kind 24200 events only via in-memory pub/sub,
+  never via a database write path.
+- Clients SHOULD subscribe with `since=<now>`; historical replay is not supported.
+- Clients SHOULD buffer received events in a bounded in-memory ring buffer.
+
+## Authorization
+
+**Telemetry** (agent → owner):
+- `event.pubkey` MUST equal the agent pubkey.
+- `p` tag MUST equal the owner pubkey.
+- Relay MUST verify `is_agent_owner(agent, owner)` via authenticated ownership lookup.
+
+**Control** (owner → agent):
+- `event.pubkey` MUST equal the owner pubkey.
+- `p` tag MUST equal the agent pubkey.
+- Relay MUST verify `is_agent_owner(agent, owner)` where agent is resolved from the
+  `agent` tag.
+
+Both directions require the relay to confirm the agent-owner relationship via
+database lookup. `#p` tag matching alone is insufficient — this is an authenticated
+ownership check. Unauthorized publish or subscribe attempts MUST be rejected with
+`AUTH required`.
+
+## Relay Behavior
+
+On receiving a kind 24200 event, a relay MUST:
+
+1. Validate the event signature per NIP-01.
+2. Verify authorization per the rules above.
+3. Fan out to matching subscribers via in-memory pub/sub.
+4. NOT invoke the normal event ingestion or persistence path.
+
+Relays SHOULD enforce a rate limit of 100 events/second per agent pubkey.
+Relays RECOMMENDED to reject events whose `created_at` falls outside a ±5-minute
+freshness window to prevent replay of captured events.
+
+## Client Behavior
+
+Clients subscribe with:
+
+```json
+{"kinds": [24200], "#p": ["<own_pubkey>"], "since": <now>}
+```
+
+On receiving an event, a client MUST:
+
+1. Verify the event signature.
+2. Check that the `agent` tag matches a known/trusted agent pubkey before decrypting.
+3. Decrypt `content` using own secret key and `event.pubkey`.
+4. Parse the decrypted payload and dispatch on `kind` (telemetry) or `type` (control).
+5. Ignore unknown `kind`/`type` values.
+
+Clients SHOULD buffer events in a bounded ring buffer (RECOMMENDED maximum: 800 events).
+Clients MUST NOT request historical kind 24200 events (no `since` in the past, no
+`until`, no `ids` queries).
+
+## Security Considerations
+
+**Metadata leakage.** Routing tags (`p`, `agent`, `frame`, `created_at`) are
+cleartext. A relay operator can observe that agent X is streaming to owner Y, when,
+and at what rate. This is acceptable for most threat models. For maximum metadata
+privacy, implementors MAY wrap events in NIP-59 gift wrap.
+
+**No forward secrecy.** NIP-44 does not provide forward secrecy. Compromise of the
+agent's private key allows decryption of any captured ciphertext. This is the
+standard Nostr security trade-off.
+
+**Replay attacks.** A captured, signed event could be replayed without a freshness
+check. Relays are RECOMMENDED to enforce a `created_at` freshness window.
+
+**Rogue relays.** The ephemerality contract is enforced by relay policy, not
+cryptography. A malicious relay can store events. NIP-44 encryption ensures stored
+events remain opaque to the relay operator absent key compromise.
+
+**Best-effort delivery.** Control frames can be dropped during reconnect or queue
+overflow. Control commands SHOULD be treated as advisory with idempotent semantics.
+Agents MUST NOT rely on guaranteed delivery of control frames.
+
+**Operational persistence vectors.** Even with relay-level ephemerality, telemetry
+may transiently exist in in-memory pub/sub buffers, process memory, crash dumps,
+browser memory, and application logs. Implementations SHOULD minimize logging of
+decrypted payloads.
+
+**Sensitive content.** Observer payloads may contain tool arguments, API responses,
+or raw protocol frames that include secrets. Implementations MUST NOT log decrypted
+observer frame content at INFO level or above.
+
+## Relationship to Other NIPs
+
+- **NIP-01**: Kind 24200 is in the ephemeral range (20000–29999); standard event
+  structure and signature rules apply.
+- **NIP-42**: Recommended for relay-side authentication gating.
+- **NIP-44**: Required encryption algorithm for all `content` fields.
+- **NIP-29**: An `h` tag MAY be included when the agent session is scoped to a
+  NIP-29 group.
+- **NIP-XX (PR #2226)**: NIP-XX defines the agent *output* plane (what the agent
+  produces for users). This NIP defines the *observability* plane (what the agent is
+  doing internally). They are complementary and non-overlapping.
+
+## Examples
+
+### 1. Telemetry Event — `acp_write` frame
+
+**Wire event (encrypted):**
+
+```json
+{
+  "id":         "a1b2c3d4...",
+  "kind":       24200,
+  "pubkey":     "agent_pubkey_hex",
+  "created_at": 1714000041,
+  "content":    "<NIP-44 v2 ciphertext>",
+  "tags": [
+    ["p",     "owner_pubkey_hex"],
+    ["agent", "agent_pubkey_hex"],
+    ["frame", "telemetry"]
+  ],
+  "sig": "..."
+}
+```
+
+**Decrypted payload:**
+
+```json
+{
+  "seq":        42,
+  "timestamp":  1714000041500,
+  "kind":       "acp_write",
+  "agentIndex": 0,
+  "channelId":  "52a85618-0f8f-4542-94ec-599e6e1c6f2e",
+  "sessionId":  "a1b2c3d4",
+  "turnId":     "e5f6g7h8",
+  "payload": {
+    "jsonrpc": "2.0",
+    "method":  "tools/call",
+    "params":  { "name": "shell", "arguments": { "command": "ls -la" } }
+  }
+}
+```
+
+---
+
+### 2. Control Event — `cancel_turn` frame
+
+**Wire event (encrypted):**
+
+```json
+{
+  "id":         "e5f6a7b8...",
+  "kind":       24200,
+  "pubkey":     "owner_pubkey_hex",
+  "created_at": 1714000042,
+  "content":    "<NIP-44 v2 ciphertext>",
+  "tags": [
+    ["p",     "agent_pubkey_hex"],
+    ["agent", "agent_pubkey_hex"],
+    ["frame", "control"]
+  ],
+  "sig": "..."
+}
+```
+
+**Decrypted payload:**
+
+```json
+{
+  "type":      "cancel_turn",
+  "channelId": "52a85618-0f8f-4542-94ec-599e6e1c6f2e"
+}
+```
+
+## Reference Implementation
+
+[block/sprout PR #421](https://github.com/block/sprout/pull/421)


### PR DESCRIPTION
## NIP-AO: Agent Observability

Adds a draft NIP defining `kind 24200` — ephemeral, encrypted events for streaming internal agent session telemetry between AI agent harnesses and their owners' desktop clients via Nostr relays.

### What this covers
- Event structure (`kind 24200` in ephemeral range 20000-29999)
- NIP-44 v2 E2E encryption requirement
- Ephemerality contract (7 layers of defense-in-depth)
- Authenticated agent-owner authorization
- Frame type taxonomy (`acp_read`, `acp_write`, `turn_started`, `session_resolved`, `cancel_turn`)
- Relay and client behavior specifications
- Security considerations (metadata leakage, no forward secrecy, replay, rogue relays)

### What this does NOT include
- No code changes — NIP document only
- Positioned as complementary to NIP-XX (PR #2226): NIP-XX = agent output plane, NIP-AO = agent observability plane

### Context
This NIP documents the protocol implemented in this branch (`baxen/acp-on-relay`). See the analysis at:
- `RESEARCH/SESSION_SIDEBAR_NIP_ANALYSIS.md` (full comparison of PR 421 vs 412 + NIP prior art)
- `RESEARCH/CODEX_PR421_REVIEW.md` (Codex gpt-5.5 security review)

299 lines. Reviewed by Codex CLI (gpt-5.5) — all issues resolved in v2.

/cc @baxen