### PR TITLE
feat: show app version in mobile settings

### DIFF
--- a/mobile/lib/features/settings/settings_page.dart
+++ b/mobile/lib/features/settings/settings_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:nostr/nostr.dart' as nostr;
+import 'package:package_info_plus/package_info_plus.dart';
 
 import '../../shared/auth/auth.dart';
 import '../../shared/relay/relay.dart';
@@ -19,6 +21,8 @@ class SettingsPage extends HookConsumerWidget {
     final config = ref.watch(relayConfigProvider);
     final selectedAccent = ref.watch(accentProvider);
     final selectedScheme = ref.watch(schemeProvider);
+    final packageInfoFuture = useMemoized(() => PackageInfo.fromPlatform());
+    final packageInfo = useFuture(packageInfoFuture);
 
     return FrostedScaffold(
       appBar: const FrostedAppBar(title: Text('Settings')),
@@ -153,6 +157,17 @@ class SettingsPage extends HookConsumerWidget {
                 ),
             ],
           ),
+          if (packageInfo.hasData) ...[
+            const SizedBox(height: Grid.sm),
+            Center(
+              child: Text(
+                'v${packageInfo.data!.version}',
+                style: context.textTheme.bodySmall?.copyWith(
+                  color: context.colors.onSurfaceVariant.withValues(alpha: 0.6),
+                ),
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -768,6 +768,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   uuid: ^4.5.1
   image_picker: ^1.1.2
   video_player: ^2.10.1
+  package_info_plus: ^8.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Adds app version number display to the mobile settings page, matching the desktop pattern
- Shows `v{version}` in subtle, centered text at the bottom of the settings list
- Uses `package_info_plus` with Flutter hooks (`useMemoized` + `useFuture`) for idiomatic async version loading

## Test plan
- [x] `flutter analyze` passes clean
- [x] All 327 mobile tests pass
- [x] All pre-push hooks pass (rust-fmt, desktop-check, mobile-check, mobile-test, desktop-build, rust-clippy, rust-tests)
- [ ] Manual: open mobile app → Settings → verify version string appears at bottom
- [ ] Manual: verify version matches `pubspec.yaml` version field

🤖 Generated with [Claude Code](https://claude.com/claude-code)