### PR TITLE
Fix responsive layout breakpoints for small window sizes

### DIFF
--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import * as React from "react";
 import { Activity, Bot, CircleDot, Octagon, X } from "lucide-react";
 import { toast } from "sonner";
 
@@ -35,6 +35,19 @@ export function AgentSessionThreadPanel({
 }: AgentSessionThreadPanelProps) {
   const isLive = agent.status === "running" && Boolean(agent.observerUrl);
   const isOverlay = useIsThreadPanelOverlay();
+
+  React.useEffect(() => {
+    if (!isOverlay) return;
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !event.defaultPrevented) {
+        event.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOverlay, onClose]);
+
   const { ref: scrollRef, onScroll } = useStickToBottom<HTMLDivElement>();
 
   async function handleInterruptTurn() {
@@ -66,7 +79,8 @@ export function AgentSessionThreadPanel({
       <aside
         className={cn(
           "relative flex h-full shrink-0 flex-col border-l border-border/80 bg-background",
-          isOverlay && "fixed inset-y-0 right-0 z-40 shadow-xl",
+          isOverlay &&
+            "fixed inset-y-0 right-0 z-40 shadow-xl max-w-[calc(100vw-2rem)]",
         )}
         data-testid="agent-session-thread-panel"
         style={{ width: `${widthPx}px` }}

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -5,7 +5,9 @@ import { toast } from "sonner";
 import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
 import { cancelManagedAgentTurn } from "@/shared/api/agentControl";
 import type { Channel, ManagedAgent } from "@/shared/api/types";
+import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
 import { useStickToBottom } from "@/shared/hooks/useStickToBottom";
+import { cn } from "@/shared/lib/cn";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
@@ -32,6 +34,7 @@ export function AgentSessionThreadPanel({
   widthPx,
 }: AgentSessionThreadPanelProps) {
   const isLive = agent.status === "running" && Boolean(agent.observerUrl);
+  const isOverlay = useIsThreadPanelOverlay();
   const { ref: scrollRef, onScroll } = useStickToBottom<HTMLDivElement>();
 
   async function handleInterruptTurn() {
@@ -52,99 +55,113 @@ export function AgentSessionThreadPanel({
   }
 
   return (
-    <aside
-      className="relative hidden h-full shrink-0 flex-col border-l border-border/80 bg-background lg:flex"
-      data-testid="agent-session-thread-panel"
-      style={{ width: `${widthPx}px` }}
-    >
-      <button
-        aria-label="Resize agent session panel"
-        className="group absolute inset-y-0 left-0 z-20 w-3 -translate-x-1/2 cursor-col-resize"
-        data-testid="agent-session-resize-handle"
-        onDoubleClick={canResetWidth ? onResetWidth : undefined}
-        onPointerDown={onResizeStart}
-        title={
-          canResetWidth
-            ? "Drag to resize. Double-click to reset width."
-            : "Drag to resize."
-        }
-        type="button"
-      >
-        <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-border/80" />
-      </button>
-
-      <div className="flex items-center gap-3 border-b border-border/70 px-4 py-2.5">
-        <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
-        <div className="min-w-0 flex-1">
-          <h2 className="truncate text-sm font-semibold tracking-tight">
-            {agent.name}
-          </h2>
-          <div className="flex items-center gap-1.5">
-            <Activity className="h-3 w-3 text-muted-foreground" />
-            <p className="truncate text-xs text-muted-foreground">
-              Agent activity log
-            </p>
-          </div>
-        </div>
-        {isLive ? (
-          <Badge className="shrink-0 gap-1" variant="default">
-            <CircleDot className="h-3 w-3" />
-            Live
-          </Badge>
-        ) : (
-          <Badge className="shrink-0" variant="secondary">
-            Idle
-          </Badge>
-        )}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              aria-label="Stop current agent turn"
-              data-testid="agent-session-stop-turn"
-              disabled={!isLive || !isWorking}
-              onClick={() => {
-                void handleInterruptTurn();
-              }}
-              size="sm"
-              type="button"
-              variant="outline"
-            >
-              <Octagon className="h-3.5 w-3.5" />
-              Stop
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" className="text-xs">
-            {isWorking
-              ? "Interrupt the current ACP turn without stopping the agent process."
-              : "No active turn to interrupt."}
-          </TooltipContent>
-        </Tooltip>
-        <Button
-          aria-label="Close activity panel"
-          data-testid="agent-session-close"
+    <>
+      {isOverlay && (
+        <div
+          className="fixed inset-0 z-30 bg-black/20"
           onClick={onClose}
-          size="icon"
-          type="button"
-          variant="ghost"
-        >
-          <X className="h-4 w-4" />
-        </Button>
-      </div>
-
-      <div
-        ref={scrollRef}
-        onScroll={onScroll}
-        className="min-h-0 flex-1 overflow-y-auto px-3 py-4"
-      >
-        <ManagedAgentSessionPanel
-          agent={agent}
-          channelId={channel.id}
-          className="border-0 bg-transparent p-0 shadow-none"
-          emptyDescription={`Mention ${agent.name} in the channel to see its work here.`}
-          showHeader={false}
-          showRaw={false}
+          aria-hidden="true"
         />
-      </div>
-    </aside>
+      )}
+      <aside
+        className={cn(
+          "relative flex h-full shrink-0 flex-col border-l border-border/80 bg-background",
+          isOverlay && "fixed inset-y-0 right-0 z-40 shadow-xl",
+        )}
+        data-testid="agent-session-thread-panel"
+        style={{ width: `${widthPx}px` }}
+      >
+        {!isOverlay && (
+          <button
+            aria-label="Resize agent session panel"
+            className="group absolute inset-y-0 left-0 z-20 w-3 -translate-x-1/2 cursor-col-resize"
+            data-testid="agent-session-resize-handle"
+            onDoubleClick={canResetWidth ? onResetWidth : undefined}
+            onPointerDown={onResizeStart}
+            title={
+              canResetWidth
+                ? "Drag to resize. Double-click to reset width."
+                : "Drag to resize."
+            }
+            type="button"
+          >
+            <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-border/80" />
+          </button>
+        )}
+
+        <div className="flex items-center gap-3 border-b border-border/70 px-4 py-2.5">
+          <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate text-sm font-semibold tracking-tight">
+              {agent.name}
+            </h2>
+            <div className="flex items-center gap-1.5">
+              <Activity className="h-3 w-3 text-muted-foreground" />
+              <p className="truncate text-xs text-muted-foreground">
+                Agent activity log
+              </p>
+            </div>
+          </div>
+          {isLive ? (
+            <Badge className="shrink-0 gap-1" variant="default">
+              <CircleDot className="h-3 w-3" />
+              Live
+            </Badge>
+          ) : (
+            <Badge className="shrink-0" variant="secondary">
+              Idle
+            </Badge>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label="Stop current agent turn"
+                data-testid="agent-session-stop-turn"
+                disabled={!isLive || !isWorking}
+                onClick={() => {
+                  void handleInterruptTurn();
+                }}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                <Octagon className="h-3.5 w-3.5" />
+                Stop
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              {isWorking
+                ? "Interrupt the current ACP turn without stopping the agent process."
+                : "No active turn to interrupt."}
+            </TooltipContent>
+          </Tooltip>
+          <Button
+            aria-label="Close activity panel"
+            data-testid="agent-session-close"
+            onClick={onClose}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div
+          ref={scrollRef}
+          onScroll={onScroll}
+          className="min-h-0 flex-1 overflow-y-auto px-3 py-4"
+        >
+          <ManagedAgentSessionPanel
+            agent={agent}
+            channelId={channel.id}
+            className="border-0 bg-transparent p-0 shadow-none"
+            emptyDescription={`Mention ${agent.name} in the channel to see its work here.`}
+            showHeader={false}
+            showRaw={false}
+          />
+        </div>
+      </aside>
+    </>
   );
 }

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -1,15 +1,21 @@
-import * as React from "react";
+import type * as React from "react";
 import { Activity, Bot, CircleDot, Octagon, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
 import { cancelManagedAgentTurn } from "@/shared/api/agentControl";
 import type { Channel, ManagedAgent } from "@/shared/api/types";
+import { useEscapeKey } from "@/shared/hooks/useEscapeKey";
 import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
 import { useStickToBottom } from "@/shared/hooks/useStickToBottom";
 import { cn } from "@/shared/lib/cn";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
+import {
+  OverlayPanelBackdrop,
+  PANEL_BASE_CLASS,
+  PANEL_OVERLAY_CLASS,
+} from "@/shared/ui/OverlayPanelBackdrop";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 type AgentSessionThreadPanelProps = {
@@ -35,18 +41,7 @@ export function AgentSessionThreadPanel({
 }: AgentSessionThreadPanelProps) {
   const isLive = agent.status === "running" && Boolean(agent.observerUrl);
   const isOverlay = useIsThreadPanelOverlay();
-
-  React.useEffect(() => {
-    if (!isOverlay) return;
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape" && !event.defaultPrevented) {
-        event.preventDefault();
-        onClose();
-      }
-    }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOverlay, onClose]);
+  useEscapeKey(onClose, isOverlay);
 
   const { ref: scrollRef, onScroll } = useStickToBottom<HTMLDivElement>();
 
@@ -69,19 +64,9 @@ export function AgentSessionThreadPanel({
 
   return (
     <>
-      {isOverlay && (
-        <div
-          className="fixed inset-0 z-30 bg-black/20"
-          onClick={onClose}
-          aria-hidden="true"
-        />
-      )}
+      {isOverlay && <OverlayPanelBackdrop onClose={onClose} />}
       <aside
-        className={cn(
-          "relative flex h-full shrink-0 flex-col border-l border-border/80 bg-background",
-          isOverlay &&
-            "fixed inset-y-0 right-0 z-40 shadow-xl max-w-[calc(100vw-2rem)]",
-        )}
+        className={cn(PANEL_BASE_CLASS, isOverlay && PANEL_OVERLAY_CLASS)}
         data-testid="agent-session-thread-panel"
         style={{ width: `${widthPx}px` }}
       >

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -5,9 +5,15 @@ import type { MainTimelineEntry } from "@/features/messages/lib/threadPanel";
 import type { TimelineMessage } from "@/features/messages/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel } from "@/shared/api/types";
+import { useEscapeKey } from "@/shared/hooks/useEscapeKey";
 import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
+import {
+  OverlayPanelBackdrop,
+  PANEL_BASE_CLASS,
+  PANEL_OVERLAY_CLASS,
+} from "@/shared/ui/OverlayPanelBackdrop";
 import { MessageComposer } from "./MessageComposer";
 import { MessageRow } from "./MessageRow";
 import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
@@ -98,18 +104,7 @@ export function MessageThreadPanel({
 }: MessageThreadPanelProps) {
   const threadBodyRef = React.useRef<HTMLDivElement>(null);
   const isOverlay = useIsThreadPanelOverlay();
-
-  React.useEffect(() => {
-    if (!isOverlay) return;
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape" && !event.defaultPrevented) {
-        event.preventDefault();
-        onClose();
-      }
-    }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOverlay, onClose]);
+  useEscapeKey(onClose, isOverlay);
 
   const threadHeadId = threadHead?.id ?? null;
 
@@ -149,19 +144,9 @@ export function MessageThreadPanel({
 
   return (
     <>
-      {isOverlay && (
-        <div
-          className="fixed inset-0 z-30 bg-black/20"
-          onClick={onClose}
-          aria-hidden="true"
-        />
-      )}
+      {isOverlay && <OverlayPanelBackdrop onClose={onClose} />}
       <aside
-        className={cn(
-          "relative flex h-full shrink-0 flex-col border-l border-border/80 bg-background",
-          isOverlay &&
-            "fixed inset-y-0 right-0 z-40 shadow-xl max-w-[calc(100vw-2rem)]",
-        )}
+        className={cn(PANEL_BASE_CLASS, isOverlay && PANEL_OVERLAY_CLASS)}
         data-testid="message-thread-panel"
         style={{ width: `${widthPx}px` }}
       >

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -5,6 +5,8 @@ import type { MainTimelineEntry } from "@/features/messages/lib/threadPanel";
 import type { TimelineMessage } from "@/features/messages/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel } from "@/shared/api/types";
+import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
+import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { MessageComposer } from "./MessageComposer";
 import { MessageRow } from "./MessageRow";
@@ -95,6 +97,7 @@ export function MessageThreadPanel({
   widthPx,
 }: MessageThreadPanelProps) {
   const threadBodyRef = React.useRef<HTMLDivElement>(null);
+  const isOverlay = useIsThreadPanelOverlay();
   const threadHeadId = threadHead?.id ?? null;
 
   const composerReplyTarget =
@@ -132,170 +135,187 @@ export function MessageThreadPanel({
   }
 
   return (
-    <aside
-      className="relative hidden h-full shrink-0 flex-col border-l border-border/80 bg-background lg:flex"
-      data-testid="message-thread-panel"
-      style={{ width: `${widthPx}px` }}
-    >
-      <button
-        aria-label="Resize thread panel"
-        className="group absolute inset-y-0 left-0 z-20 w-3 -translate-x-1/2 cursor-col-resize"
-        data-testid="message-thread-resize-handle"
-        onDoubleClick={canResetWidth ? onResetWidth : undefined}
-        onPointerDown={onResizeStart}
-        title={
-          canResetWidth
-            ? "Drag to resize. Double-click to reset width."
-            : "Drag to resize."
-        }
-        type="button"
-      >
-        <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-border/80" />
-      </button>
-
-      <div className="flex items-center gap-3 px-4 py-3">
-        <div className="min-w-0 flex-1">
-          <h2 className="text-sm font-semibold tracking-tight">Thread</h2>
-        </div>
-        <Button
-          aria-label="Close thread"
-          data-testid="message-thread-close"
+    <>
+      {isOverlay && (
+        <div
+          className="fixed inset-0 z-30 bg-black/20"
           onClick={onClose}
-          size="icon"
-          type="button"
-          variant="ghost"
-        >
-          <X className="h-4 w-4" />
-        </Button>
-      </div>
-
-      <div
-        className="min-h-0 flex-1 overflow-y-auto pb-6"
-        data-testid="message-thread-body"
-        onScroll={syncScrollState}
-        ref={threadBodyRef}
+          aria-hidden="true"
+        />
+      )}
+      <aside
+        className={cn(
+          "relative flex h-full shrink-0 flex-col border-l border-border/80 bg-background",
+          isOverlay && "fixed inset-y-0 right-0 z-40 shadow-xl",
+        )}
+        data-testid="message-thread-panel"
+        style={{ width: `${widthPx}px` }}
       >
-        <div ref={contentRef}>
-          <div className="px-3 pb-1 pt-0" data-testid="message-thread-head">
-            <div className="rounded-2xl">
-              <MessageRow
-                activeReplyTargetId={replyTargetId}
-                layoutVariant="thread-reply"
-                message={threadHead}
-                onDelete={
-                  onDelete && canManageMessage(threadHead, currentPubkey)
-                    ? onDelete
-                    : undefined
-                }
-                onEdit={
-                  onEdit && canManageMessage(threadHead, currentPubkey)
-                    ? onEdit
-                    : undefined
-                }
-                onToggleReaction={onToggleReaction}
-                profiles={profiles}
-              />
-            </div>
-          </div>
-
-          <div className="px-3 pb-3 pt-1" data-testid="message-thread-replies">
-            {threadReplies.length > 0 ? (
-              <div className="space-y-2">
-                {threadReplies.map((entry, index) => {
-                  const nextDepth =
-                    threadReplies[index + 1]?.message.depth ?? -1;
-                  const isExpanded = nextDepth > entry.message.depth;
-
-                  return (
-                    <div key={entry.message.id}>
-                      <MessageRow
-                        activeReplyTargetId={replyTargetId}
-                        layoutVariant="thread-reply"
-                        message={entry.message}
-                        onDelete={
-                          onDelete &&
-                          canManageMessage(entry.message, currentPubkey)
-                            ? onDelete
-                            : undefined
-                        }
-                        onEdit={
-                          onEdit &&
-                          canManageMessage(entry.message, currentPubkey)
-                            ? onEdit
-                            : undefined
-                        }
-                        onReply={onSelectReplyTarget}
-                        onToggleReaction={onToggleReaction}
-                        profiles={profiles}
-                      />
-                      {entry.summary && !isExpanded ? (
-                        <MessageThreadSummaryRow
-                          depth={entry.message.depth}
-                          message={entry.message}
-                          onOpenThread={onExpandReplies}
-                          summary={entry.summary}
-                        />
-                      ) : null}
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="rounded-2xl border border-dashed border-border/70 bg-card/40 px-4 py-6 text-center">
-                <p className="text-sm font-medium text-foreground/80">
-                  No replies in this branch yet
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Reply in the thread to continue this branch.
-                </p>
-              </div>
-            )}
-            <div aria-hidden className="h-px" ref={bottomAnchorRef} />
-          </div>
-        </div>
-      </div>
-
-      {!isAtBottom ? (
-        <div className="pointer-events-none absolute inset-x-0 bottom-16 flex justify-center px-4">
-          <Button
-            className="pointer-events-auto rounded-full shadow-lg"
-            data-testid="thread-scroll-to-latest"
-            onClick={() => scrollToBottom("smooth")}
-            size="sm"
+        {!isOverlay && (
+          <button
+            aria-label="Resize thread panel"
+            className="group absolute inset-y-0 left-0 z-20 w-3 -translate-x-1/2 cursor-col-resize"
+            data-testid="message-thread-resize-handle"
+            onDoubleClick={canResetWidth ? onResetWidth : undefined}
+            onPointerDown={onResizeStart}
+            title={
+              canResetWidth
+                ? "Drag to resize. Double-click to reset width."
+                : "Drag to resize."
+            }
             type="button"
           >
-            <ArrowDown className="h-4 w-4" />
-            {newMessageCount > 0
-              ? `${newMessageCount} new message${newMessageCount === 1 ? "" : "s"}`
-              : "Jump to latest"}
+            <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-border/80" />
+          </button>
+        )}
+
+        <div className="flex items-center gap-3 px-4 py-3">
+          <div className="min-w-0 flex-1">
+            <h2 className="text-sm font-semibold tracking-tight">Thread</h2>
+          </div>
+          <Button
+            aria-label="Close thread"
+            data-testid="message-thread-close"
+            onClick={onClose}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <X className="h-4 w-4" />
           </Button>
         </div>
-      ) : null}
 
-      <div>
-        <MessageComposer
-          channelId={channelId}
-          channelName={channelName}
-          disabled={disabled || isSending || !channelId}
-          draftKey={`thread:${threadHead.id}`}
-          editTarget={editTarget}
-          isSending={isSending}
-          onCancelEdit={onCancelEdit}
-          onCancelReply={composerReplyTarget ? onCancelReply : undefined}
-          onEditSave={onEditSave}
-          onSend={onSend}
-          placeholder={`Reply in thread to ${threadHead.author}`}
-          replyTarget={composerReplyTarget}
-          typingParentEventId={threadHead.id}
-          typingRootEventId={threadHead.rootId}
-        />
-        <TypingIndicatorRow
-          channel={channel}
-          currentPubkey={currentPubkey}
-          profiles={profiles}
-          typingPubkeys={threadTypingPubkeys}
-        />
-      </div>
-    </aside>
+        <div
+          className="min-h-0 flex-1 overflow-y-auto pb-6"
+          data-testid="message-thread-body"
+          onScroll={syncScrollState}
+          ref={threadBodyRef}
+        >
+          <div ref={contentRef}>
+            <div className="px-3 pb-1 pt-0" data-testid="message-thread-head">
+              <div className="rounded-2xl">
+                <MessageRow
+                  activeReplyTargetId={replyTargetId}
+                  layoutVariant="thread-reply"
+                  message={threadHead}
+                  onDelete={
+                    onDelete && canManageMessage(threadHead, currentPubkey)
+                      ? onDelete
+                      : undefined
+                  }
+                  onEdit={
+                    onEdit && canManageMessage(threadHead, currentPubkey)
+                      ? onEdit
+                      : undefined
+                  }
+                  onToggleReaction={onToggleReaction}
+                  profiles={profiles}
+                />
+              </div>
+            </div>
+
+            <div
+              className="px-3 pb-3 pt-1"
+              data-testid="message-thread-replies"
+            >
+              {threadReplies.length > 0 ? (
+                <div className="space-y-2">
+                  {threadReplies.map((entry, index) => {
+                    const nextDepth =
+                      threadReplies[index + 1]?.message.depth ?? -1;
+                    const isExpanded = nextDepth > entry.message.depth;
+
+                    return (
+                      <div key={entry.message.id}>
+                        <MessageRow
+                          activeReplyTargetId={replyTargetId}
+                          layoutVariant="thread-reply"
+                          message={entry.message}
+                          onDelete={
+                            onDelete &&
+                            canManageMessage(entry.message, currentPubkey)
+                              ? onDelete
+                              : undefined
+                          }
+                          onEdit={
+                            onEdit &&
+                            canManageMessage(entry.message, currentPubkey)
+                              ? onEdit
+                              : undefined
+                          }
+                          onReply={onSelectReplyTarget}
+                          onToggleReaction={onToggleReaction}
+                          profiles={profiles}
+                        />
+                        {entry.summary && !isExpanded ? (
+                          <MessageThreadSummaryRow
+                            depth={entry.message.depth}
+                            message={entry.message}
+                            onOpenThread={onExpandReplies}
+                            summary={entry.summary}
+                          />
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="rounded-2xl border border-dashed border-border/70 bg-card/40 px-4 py-6 text-center">
+                  <p className="text-sm font-medium text-foreground/80">
+                    No replies in this branch yet
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Reply in the thread to continue this branch.
+                  </p>
+                </div>
+              )}
+              <div aria-hidden className="h-px" ref={bottomAnchorRef} />
+            </div>
+          </div>
+        </div>
+
+        {!isAtBottom ? (
+          <div className="pointer-events-none absolute inset-x-0 bottom-16 flex justify-center px-4">
+            <Button
+              className="pointer-events-auto rounded-full shadow-lg"
+              data-testid="thread-scroll-to-latest"
+              onClick={() => scrollToBottom("smooth")}
+              size="sm"
+              type="button"
+            >
+              <ArrowDown className="h-4 w-4" />
+              {newMessageCount > 0
+                ? `${newMessageCount} new message${newMessageCount === 1 ? "" : "s"}`
+                : "Jump to latest"}
+            </Button>
+          </div>
+        ) : null}
+
+        <div>
+          <MessageComposer
+            channelId={channelId}
+            channelName={channelName}
+            disabled={disabled || isSending || !channelId}
+            draftKey={`thread:${threadHead.id}`}
+            editTarget={editTarget}
+            isSending={isSending}
+            onCancelEdit={onCancelEdit}
+            onCancelReply={composerReplyTarget ? onCancelReply : undefined}
+            onEditSave={onEditSave}
+            onSend={onSend}
+            placeholder={`Reply in thread to ${threadHead.author}`}
+            replyTarget={composerReplyTarget}
+            typingParentEventId={threadHead.id}
+            typingRootEventId={threadHead.rootId}
+          />
+          <TypingIndicatorRow
+            channel={channel}
+            currentPubkey={currentPubkey}
+            profiles={profiles}
+            typingPubkeys={threadTypingPubkeys}
+          />
+        </div>
+      </aside>
+    </>
   );
 }

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -98,6 +98,19 @@ export function MessageThreadPanel({
 }: MessageThreadPanelProps) {
   const threadBodyRef = React.useRef<HTMLDivElement>(null);
   const isOverlay = useIsThreadPanelOverlay();
+
+  React.useEffect(() => {
+    if (!isOverlay) return;
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !event.defaultPrevented) {
+        event.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOverlay, onClose]);
+
   const threadHeadId = threadHead?.id ?? null;
 
   const composerReplyTarget =
@@ -146,7 +159,8 @@ export function MessageThreadPanel({
       <aside
         className={cn(
           "relative flex h-full shrink-0 flex-col border-l border-border/80 bg-background",
-          isOverlay && "fixed inset-y-0 right-0 z-40 shadow-xl",
+          isOverlay &&
+            "fixed inset-y-0 right-0 z-40 shadow-xl max-w-[calc(100vw-2rem)]",
         )}
         data-testid="message-thread-panel"
         style={{ width: `${widthPx}px` }}

--- a/desktop/src/features/settings/ui/SettingsView.tsx
+++ b/desktop/src/features/settings/ui/SettingsView.tsx
@@ -117,7 +117,7 @@ export function SettingsView({
         aria-labelledby="settings-title"
         aria-modal="true"
         className={cn(
-          "relative mx-auto flex h-[min(600px,calc(100vh-8rem))] w-[calc(100%-4rem)] max-w-3xl flex-col overflow-hidden rounded-xl border border-border bg-background shadow-lg motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-out",
+          "relative mx-auto flex h-[min(600px,calc(100vh-2rem))] w-[calc(100%-4rem)] max-w-3xl flex-col overflow-hidden rounded-xl border border-border bg-background shadow-lg motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-out",
           isLoaded ? "opacity-100 scale-100" : "opacity-0 scale-95",
         )}
         data-testid="settings-view"
@@ -146,10 +146,10 @@ export function SettingsView({
           </button>
         </header>
 
-        <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden lg:grid-cols-[220px_minmax(0,1fr)] lg:grid-rows-1">
+        <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden md:grid-cols-[220px_minmax(0,1fr)] md:grid-rows-1">
           <aside
             className={cn(
-              "flex flex-col border-b border-border/70 bg-muted/20 motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-out lg:border-b-0 lg:border-r",
+              "flex flex-col border-b border-border/70 bg-muted/20 motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-out md:border-b-0 md:border-r",
               isLoaded
                 ? "opacity-100 translate-x-0"
                 : "opacity-0 -translate-x-2",
@@ -157,7 +157,7 @@ export function SettingsView({
           >
             <nav
               aria-label="Settings sections"
-              className="flex gap-1 overflow-x-auto px-3 py-3 lg:flex-1 lg:flex-col lg:overflow-y-auto lg:pt-1"
+              className="flex gap-1 overflow-x-auto px-3 py-3 md:flex-1 md:flex-col md:overflow-y-auto md:pt-1"
             >
               {settingsSections.map((entry) => (
                 <SettingsSectionButton
@@ -170,7 +170,7 @@ export function SettingsView({
               ))}
             </nav>
             {appVersion ? (
-              <p className="hidden px-3 pb-3 text-xs text-muted-foreground/60 lg:block">
+              <p className="hidden px-3 pb-3 text-xs text-muted-foreground/60 md:block">
                 v{appVersion}
               </p>
             ) : null}

--- a/desktop/src/shared/hooks/use-mobile.tsx
+++ b/desktop/src/shared/hooks/use-mobile.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
+const THREAD_PANEL_OVERLAY_BREAKPOINT = 1024;
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
@@ -18,4 +19,26 @@ export function useIsMobile() {
   }, []);
 
   return !!isMobile;
+}
+
+export function useIsThreadPanelOverlay() {
+  const [isOverlay, setIsOverlay] = React.useState<boolean>(() =>
+    typeof window !== "undefined"
+      ? window.innerWidth < THREAD_PANEL_OVERLAY_BREAKPOINT
+      : false,
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(
+      `(max-width: ${THREAD_PANEL_OVERLAY_BREAKPOINT - 1}px)`,
+    );
+    const onChange = () => {
+      setIsOverlay(window.innerWidth < THREAD_PANEL_OVERLAY_BREAKPOINT);
+    };
+    mql.addEventListener("change", onChange);
+    setIsOverlay(window.innerWidth < THREAD_PANEL_OVERLAY_BREAKPOINT);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return isOverlay;
 }

--- a/desktop/src/shared/hooks/use-mobile.tsx
+++ b/desktop/src/shared/hooks/use-mobile.tsx
@@ -3,42 +3,32 @@ import * as React from "react";
 const MOBILE_BREAKPOINT = 768;
 const THREAD_PANEL_OVERLAY_BREAKPOINT = 1024;
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
+/**
+ * Returns `true` when the viewport is narrower than `breakpointPx`.
+ * Uses `matchMedia` for efficient change detection.
+ */
+export function useMediaBreakpoint(breakpointPx: number): boolean {
+  const [isBelow, setIsBelow] = React.useState<boolean>(() =>
+    typeof window !== "undefined" ? window.innerWidth < breakpointPx : false,
   );
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(`(max-width: ${breakpointPx - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsBelow(window.innerWidth < breakpointPx);
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsBelow(window.innerWidth < breakpointPx);
     return () => mql.removeEventListener("change", onChange);
-  }, []);
+  }, [breakpointPx]);
 
-  return !!isMobile;
+  return isBelow;
+}
+
+export function useIsMobile() {
+  return useMediaBreakpoint(MOBILE_BREAKPOINT);
 }
 
 export function useIsThreadPanelOverlay() {
-  const [isOverlay, setIsOverlay] = React.useState<boolean>(() =>
-    typeof window !== "undefined"
-      ? window.innerWidth < THREAD_PANEL_OVERLAY_BREAKPOINT
-      : false,
-  );
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(
-      `(max-width: ${THREAD_PANEL_OVERLAY_BREAKPOINT - 1}px)`,
-    );
-    const onChange = () => {
-      setIsOverlay(window.innerWidth < THREAD_PANEL_OVERLAY_BREAKPOINT);
-    };
-    mql.addEventListener("change", onChange);
-    setIsOverlay(window.innerWidth < THREAD_PANEL_OVERLAY_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-
-  return isOverlay;
+  return useMediaBreakpoint(THREAD_PANEL_OVERLAY_BREAKPOINT);
 }

--- a/desktop/src/shared/hooks/useEscapeKey.ts
+++ b/desktop/src/shared/hooks/useEscapeKey.ts
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+/**
+ * Calls `onEscape` when the Escape key is pressed, unless the event
+ * was already handled (`defaultPrevented`).
+ *
+ * Pass `enabled: false` to skip registering the listener entirely.
+ */
+export function useEscapeKey(onEscape: () => void, enabled: boolean = true) {
+  React.useEffect(() => {
+    if (!enabled) return;
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !event.defaultPrevented) {
+        event.preventDefault();
+        onEscape();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enabled, onEscape]);
+}

--- a/desktop/src/shared/ui/OverlayPanelBackdrop.tsx
+++ b/desktop/src/shared/ui/OverlayPanelBackdrop.tsx
@@ -1,0 +1,26 @@
+/**
+ * Shared constants and backdrop for thread/agent overlay panels
+ * that slide in from the right at narrow viewport widths.
+ */
+
+/** Base classes for every side panel `<aside>`. */
+export const PANEL_BASE_CLASS =
+  "relative flex h-full shrink-0 flex-col border-l border-border/80 bg-background";
+
+/** Extra classes applied when the panel is rendered as a floating overlay. */
+export const PANEL_OVERLAY_CLASS =
+  "fixed inset-y-0 right-0 z-40 shadow-xl max-w-[calc(100vw-2rem)]";
+
+type OverlayPanelBackdropProps = {
+  onClose: () => void;
+};
+
+export function OverlayPanelBackdrop({ onClose }: OverlayPanelBackdropProps) {
+  return (
+    <div
+      className="fixed inset-0 z-30 bg-black/20"
+      onClick={onClose}
+      aria-hidden="true"
+    />
+  );
+}

--- a/desktop/src/shared/ui/ViewLoadingFallback.tsx
+++ b/desktop/src/shared/ui/ViewLoadingFallback.tsx
@@ -128,56 +128,38 @@ function AgentsLoadingBody() {
 
 function WorkflowsLoadingBody() {
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto p-4">
-        <div className="mb-4 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-6 w-28" />
-            <Skeleton className="h-8 w-8 rounded-lg" />
-          </div>
-          <Skeleton className="h-9 w-36 rounded-lg" />
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto p-4">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-6 w-28" />
+          <Skeleton className="h-8 w-8 rounded-lg" />
         </div>
-
-        <div className="space-y-2">
-          {["first", "second", "third", "fourth"].map((card) => (
-            <Card className="p-4" key={card}>
-              <div className="flex items-start justify-between gap-4">
-                <div className="min-w-0 flex-1 space-y-3">
-                  <div className="flex items-center gap-2">
-                    <Skeleton className="h-5 w-44" />
-                    <Skeleton className="h-5 w-16 rounded-full" />
-                  </div>
-                  <Skeleton className="h-4 w-full max-w-2xl" />
-                  <div className="flex flex-wrap gap-2">
-                    <Skeleton className="h-5 w-20 rounded-full" />
-                    <Skeleton className="h-5 w-24 rounded-full" />
-                    <Skeleton className="h-5 w-16 rounded-full" />
-                  </div>
-                </div>
-                <div className="hidden shrink-0 gap-2 sm:flex">
-                  <Skeleton className="h-8 w-8 rounded-lg" />
-                  <Skeleton className="h-8 w-8 rounded-lg" />
-                </div>
-              </div>
-            </Card>
-          ))}
-        </div>
+        <Skeleton className="h-9 w-36 rounded-lg" />
       </div>
 
-      <div className="hidden w-[400px] shrink-0 border-l border-border/60 bg-background/70 lg:block">
-        <div className="space-y-4 p-4">
-          <div className="space-y-2">
-            <Skeleton className="h-5 w-40" />
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-4/5" />
-          </div>
-          <Skeleton className="h-40 w-full rounded-xl" />
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-28" />
-            <Skeleton className="h-16 w-full rounded-xl" />
-            <Skeleton className="h-16 w-full rounded-xl" />
-          </div>
-        </div>
+      <div className="space-y-2">
+        {["first", "second", "third", "fourth"].map((card) => (
+          <Card className="p-4" key={card}>
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1 space-y-3">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-5 w-44" />
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                </div>
+                <Skeleton className="h-4 w-full max-w-2xl" />
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-5 w-20 rounded-full" />
+                  <Skeleton className="h-5 w-24 rounded-full" />
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                </div>
+              </div>
+              <div className="hidden shrink-0 gap-2 sm:flex">
+                <Skeleton className="h-8 w-8 rounded-lg" />
+                <Skeleton className="h-8 w-8 rounded-lg" />
+              </div>
+            </div>
+          </Card>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Settings modal** now adapts to small window sizes — reduced margin from `8rem` to `2rem`, lowered grid breakpoint from `lg` (1024px) to `md` (768px) so the sidebar nav layout activates within the 800px min window width
- **Thread/agent panels** no longer silently disappear at narrow widths — panels render as overlay drawers (fixed position + backdrop) when the window is below 1024px, with Escape key dismiss and `max-w-[calc(100vw-2rem)]` to prevent viewport overflow
- **Extracted shared patterns** — `useMediaBreakpoint(px)` hook consolidates `useIsMobile` and `useIsThreadPanelOverlay`, `useEscapeKey` hook and `OverlayPanelBackdrop` component deduplicate overlay panel logic
- **Removed stale skeleton** thread panel from `ViewLoadingFallback` that had the broken `hidden lg:block` breakpoint

## Root cause
The Tauri min window width is 800px but Tailwind's `lg` breakpoint is 1024px, creating a 224px dead zone where `hidden lg:flex` components vanish from view while remaining open in state.

## Files changed (7)
- `desktop/src/features/settings/ui/SettingsView.tsx`
- `desktop/src/features/messages/ui/MessageThreadPanel.tsx`
- `desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx`
- `desktop/src/shared/hooks/use-mobile.tsx`
- `desktop/src/shared/hooks/useEscapeKey.ts` (new)
- `desktop/src/shared/ui/OverlayPanelBackdrop.tsx` (new)
- `desktop/src/shared/ui/ViewLoadingFallback.tsx`

## Test plan
- [ ] Open Settings at 800×500 window — sidebar nav should be visible (not horizontal tab strip), all content scrollable
- [ ] Open a thread panel, then resize window below 1024px — panel should transition to overlay mode with backdrop
- [ ] Click backdrop or press Escape to close overlay panel
- [ ] Resize window wider than 1024px — panel should return to inline mode with resize handle
- [ ] At narrowest window width (~800px), verify overlay panel doesn't extend past viewport left edge
- [ ] Verify z-index layering: Settings modal (z-50) should appear above thread panel overlay (z-40)

> **NIT from review (not addressed):** z-50 AppShell nav buttons overlap the backdrop near top-left — pre-existing z-index design issue, not introduced by this change. Can be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)