### PR TITLE
fix: offset pull-to-refresh indicator below frosted app bar

### DIFF
--- a/mobile/lib/features/channels/channels_page.dart
+++ b/mobile/lib/features/channels/channels_page.dart
@@ -185,6 +185,7 @@ class _ChannelsBody extends StatelessWidget {
       return Stack(
         children: [
           RefreshIndicator(
+            edgeOffset: barHeight,
             onRefresh: onRefresh,
             child: CustomScrollView(
               slivers: [


### PR DESCRIPTION
## Summary
- Adds `edgeOffset: barHeight` to the `RefreshIndicator` on the mobile home (channels) page
- The refresh spinner was rendering at its default position (40px from top), which placed it behind the frosted glass app bar
- `edgeOffset` shifts where the pull gesture starts counting from, so the indicator now appears below the bar

**Note:** The forum posts view (`forum_posts_view.dart`) has the same issue — can be addressed in a follow-up.

## Test plan
- [x] `flutter analyze` passes clean
- [x] All 327 mobile tests pass
- [x] All pre-push hooks pass
- [ ] Manual: pull to refresh on Home tab → spinner appears below the frosted bar, not behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)