### PR TITLE
feat: replace presence polling with WS subscription + targeted cache updates

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -27,7 +27,10 @@ import {
   setDesktopAppBadgeCount,
   type DesktopNotificationTarget,
 } from "@/features/notifications/lib/desktop";
-import { usePresenceSession } from "@/features/presence/hooks";
+import {
+  usePresenceSession,
+  usePresenceSubscription,
+} from "@/features/presence/hooks";
 import { useProfileQuery } from "@/features/profile/hooks";
 import {
   DEFAULT_SETTINGS_SECTION,
@@ -147,6 +150,7 @@ export function AppShell() {
   const identityQuery = useIdentityQuery();
   const profileQuery = useProfileQuery();
   const deferredPubkey = startupReady ? identityQuery.data?.pubkey : undefined;
+  usePresenceSubscription();
   const presenceSession = usePresenceSession(deferredPubkey);
   const { homeBadgeCount, homeFeedQuery, notificationSettings } =
     useHomeFeedNotifications(

--- a/desktop/src/features/presence/hooks.ts
+++ b/desktop/src/features/presence/hooks.ts
@@ -82,9 +82,78 @@ export function usePresenceQuery(
     enabled,
     queryKey: presenceQueryKey(normalizedPubkeys),
     queryFn: () => getPresence(normalizedPubkeys),
-    staleTime: 15_000,
-    refetchInterval: 30_000,
+    staleTime: 30_000,
+    // Backstop poll: catches REST-only writers (ACP agents) and TTL expiry
+    // (crashed clients). WS events handle the fast path.
+    refetchInterval: 60_000,
   });
+}
+
+/**
+ * Subscribe to kind:20001 presence events over WebSocket and update the
+ * TanStack Query presence cache in-place when updates arrive. Call once
+ * in AppShell. Uses setQueriesData for targeted per-pubkey updates without
+ * triggering refetches. Retries with exponential backoff on failure.
+ */
+export function usePresenceSubscription() {
+  const queryClient = useQueryClient();
+
+  React.useEffect(() => {
+    let unsub: (() => Promise<void>) | null = null;
+    let isCancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function handlePresenceEvent(event: { pubkey: string; content: string }) {
+      if (isCancelled) return;
+      const status = event.content;
+      if (status !== "online" && status !== "away" && status !== "offline")
+        return;
+      const pubkey = event.pubkey.toLowerCase();
+      queryClient.setQueriesData<PresenceLookup>(
+        { queryKey: ["presence"] },
+        (old) => {
+          if (!old || !(pubkey in old)) return old;
+          if (old[pubkey] === status) return old;
+          return { ...old, [pubkey]: status };
+        },
+      );
+    }
+
+    function subscribeWithRetry(attempt = 0) {
+      if (isCancelled) return;
+      void relayClient
+        .subscribeToPresenceUpdates(handlePresenceEvent)
+        .then((unsubFn) => {
+          if (isCancelled) {
+            void unsubFn();
+            return;
+          }
+          unsub = unsubFn;
+        })
+        .catch(() => {
+          if (!isCancelled) {
+            const delay = Math.min(1000 * 2 ** attempt, 30_000);
+            retryTimer = setTimeout(
+              () => subscribeWithRetry(attempt + 1),
+              delay,
+            );
+          }
+        });
+    }
+    subscribeWithRetry();
+
+    const unsubReconnect = relayClient.subscribeToReconnects(() => {
+      if (!isCancelled)
+        void queryClient.invalidateQueries({ queryKey: ["presence"] });
+    });
+
+    return () => {
+      isCancelled = true;
+      unsubReconnect();
+      if (retryTimer) clearTimeout(retryTimer);
+      if (unsub) void unsub();
+    };
+  }, [queryClient]);
 }
 
 export function useSetPresenceMutation(pubkey?: string) {
@@ -93,40 +162,33 @@ export function useSetPresenceMutation(pubkey?: string) {
 
   return useMutation({
     mutationFn: async (status: PresenceStatus) => {
+      // Prefer WS — triggers fan-out to subscribers. REST fallback if WS fails.
       try {
-        return await setPresence(status);
-      } catch (error) {
-        if (
-          !(error instanceof Error) ||
-          (!error.message.includes("relay returned 404") &&
-            !error.message.includes("relay returned 405"))
-        ) {
-          throw error;
-        }
-
         await relayClient.sendPresence(status);
-
         return {
           status,
           ttlSeconds: status === "offline" ? 0 : PRESENCE_TTL_SECONDS,
+          viaWs: true,
         };
+      } catch {
+        const result = await setPresence(status);
+        return { ...result, viaWs: false };
       }
     },
-    onSuccess: ({ status }) => {
-      if (normalizedPubkey.length === 0) {
-        return;
-      }
-
-      queryClient.setQueryData<PresenceLookup>(
-        presenceQueryKey([normalizedPubkey]),
-        (current = {}) => ({
-          ...current,
-          [normalizedPubkey]: status,
-        }),
+    onSuccess: ({ status, viaWs }) => {
+      if (normalizedPubkey.length === 0) return;
+      // Update all cached presence queries containing this pubkey.
+      queryClient.setQueriesData<PresenceLookup>(
+        { queryKey: ["presence"] },
+        (old) => {
+          if (!old || !(normalizedPubkey in old)) return old;
+          if (old[normalizedPubkey] === status) return old;
+          return { ...old, [normalizedPubkey]: status };
+        },
       );
-    },
-    onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: ["presence"] });
+      // REST fallback: no WS echo will arrive, invalidate for full refresh.
+      if (!viaWs)
+        void queryClient.invalidateQueries({ queryKey: ["presence"] });
     },
   });
 }

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -281,6 +281,11 @@ export class RelayClient {
     );
   }
 
+  /** Subscribe to kind:20001 presence events (live only, no backfill). */
+  async subscribeToPresenceUpdates(onEvent: (event: RelayEvent) => void) {
+    return this.subscribe({ kinds: [20001], limit: 0 }, onEvent);
+  }
+
   async subscribeToAllStreamMessages(onEvent: (event: RelayEvent) => void) {
     return this.subscribe(this.buildGlobalStreamFilter(50), onEvent);
   }


### PR DESCRIPTION
## Summary

Reduces presence HTTP polling from every 30s to a 60s backstop by subscribing to kind:20001 events over the existing WebSocket connection. Presence updates are now real-time for WS-connected clients.

**3 files, +99/-28 lines. No server changes. No new dependencies.**

## Problem

The desktop client has 5 independent `usePresenceQuery` hooks, each polling `GET /api/presence` every 30 seconds — generating ~8.5 req/s (95% of relay HTTP traffic). The server already fans out kind:20001 presence events to WebSocket subscribers, but no client subscribes.

## Solution

- **`usePresenceSubscription()`** — one global WS subscription to kind:20001 events. On each event, uses `setQueriesData` to update the specific pubkey in all cached presence queries (no refetch triggered). Exponential backoff retry on subscription failure. Invalidates on WS reconnect.
- **Reduced polling** — `refetchInterval` from 30s → 60s. This backstop catches REST-only writers (ACP agents heartbeat via REST) and TTL expiry (crashed clients — Redis expires after 90s, no WS event emitted).
- **WS-first heartbeat** — `useSetPresenceMutation` now sends kind:20001 via WS (triggers fan-out to other subscribers). Falls back to REST PUT if WS unavailable, with invalidation to compensate for missing echo.

## Traffic Impact

| Metric | Before | After |
|--------|--------|-------|
| Polling interval | 30s per hook | 60s per hook (backstop only) |
| Real-time updates | None | WS subscription (instant) |
| Heartbeat transport | REST PUT (no fan-out) | WS kind:20001 (fans out to subscribers) |
| REST fallback | N/A | Invalidates all presence queries on REST fallback |

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| 60s backstop kept | ACP agents write via REST only. Redis TTL expiry emits no WS event. |
| `setQueriesData` not `invalidateQueries` | Targeted update per pubkey, no refetch storm. |
| WS-first heartbeat | Triggers fan-out so other subscribers see the change immediately. |
| No server changes | WS fan-out already works. REST writers handled by backstop. |
| No custom store | TanStack Query is already the cache layer. |

## Known Limitations

- `RelayClient` does not handle relay `CLOSED` messages — a silently rejected subscription degrades to backstop polling (pre-existing limitation affecting all subscriptions)
- All-authors WS subscription means every client receives every presence event (acceptable at current scale)
- 5 hooks still make 5 separate REST calls on the 60s backstop (aggregate dedup deferred — adds lifecycle complexity not justified at current scale)

## Testing

- ✅ TypeScript: zero errors
- ✅ Biome lint: passes
- ✅ File size check: passes
- ✅ Relay builds and starts (`cargo build --release`)
- ✅ ACP agent connects, sets presence online, responds to messages
- ✅ Presence API returns correct status
- ✅ Full end-to-end stack verified