### PR TITLE
fix(mobile): improve text contrast by using correct color tokens

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -609,7 +609,7 @@ class _SystemMessageRow extends ConsumerWidget {
                   child: Icon(
                     LucideIcons.arrowLeftRight,
                     size: 12,
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                 ),
                 const SizedBox(width: Grid.xxs),
@@ -624,7 +624,7 @@ class _SystemMessageRow extends ConsumerWidget {
                 Text(
                   formatMessageTime(message.createdAt),
                   style: context.textTheme.labelSmall?.copyWith(
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                 ),
               ],
@@ -821,7 +821,7 @@ class _MessageBubble extends ConsumerWidget {
                           Text(
                             formatMessageTime(message.createdAt),
                             style: context.textTheme.labelSmall?.copyWith(
-                              color: context.colors.outline,
+                              color: context.colors.onSurfaceVariant,
                             ),
                           ),
                           if (message.edited) ...[
@@ -829,7 +829,7 @@ class _MessageBubble extends ConsumerWidget {
                             Text(
                               '(edited)',
                               style: context.textTheme.labelSmall?.copyWith(
-                                color: context.colors.outline,
+                                color: context.colors.onSurfaceVariant,
                                 fontStyle: FontStyle.italic,
                               ),
                             ),

--- a/mobile/lib/features/channels/channels_page.dart
+++ b/mobile/lib/features/channels/channels_page.dart
@@ -471,12 +471,12 @@ class _SectionHeader extends StatelessWidget {
         ),
         child: Row(
           children: [
-            Icon(icon, size: 14, color: context.colors.outline),
+            Icon(icon, size: 14, color: context.colors.onSurfaceVariant),
             const SizedBox(width: Grid.half),
             Text(
               label.toUpperCase(),
               style: context.textTheme.labelSmall?.copyWith(
-                color: context.colors.outline,
+                color: context.colors.onSurfaceVariant,
                 fontWeight: FontWeight.w600,
                 letterSpacing: 0.8,
               ),
@@ -485,7 +485,7 @@ class _SectionHeader extends StatelessWidget {
             Icon(
               expanded ? LucideIcons.chevronDown : LucideIcons.chevronRight,
               size: 14,
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
             ),
           ],
         ),
@@ -531,7 +531,7 @@ class _ChannelTile extends ConsumerWidget {
                 size: 18,
                 color: hasActivity
                     ? context.colors.onSurface
-                    : context.colors.outline,
+                    : context.colors.onSurfaceVariant,
               ),
             const SizedBox(width: Grid.xxs),
             Expanded(


### PR DESCRIPTION
## Summary
- Mobile UI was using `outline` (a border/separator color) for text elements like timestamps, section headers, and inactive channel icons, causing poor contrast and readability
- Swapped to `onSurfaceVariant` — the correct Material 3 equivalent of desktop's `muted-foreground`, both derived from `syntaxComment` in the adaptive theme engine
- Affects all themes equally since the fix is token references, not hardcoded colors

## Changes
- `channel_detail_page.dart` — system message icon, system message timestamp, message timestamp, "(edited)" label
- `channels_page.dart` — section header icon/label/chevron, inactive channel icon

## Test plan
- [x] `dart analyze` — no issues
- [x] All pre-commit hooks pass (desktop-check, desktop-tauri-fmt, mobile-check, rust-fmt)
- [x] All pre-push hooks pass (desktop-build, mobile-test, rust-clippy, rust-tests)
- [ ] Visual verification on device with light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)