### PR TITLE
fix(mobile): complete outline → onSurfaceVariant sweep for text/icons

### DIFF
--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -103,7 +103,7 @@ class _OfflineScreen extends ConsumerWidget {
                 onPressed: () => ref.read(authProvider.notifier).signOut(),
                 child: Text(
                   'Remove workspace and re-pair',
-                  style: TextStyle(color: context.colors.outline),
+                  style: TextStyle(color: context.colors.onSurfaceVariant),
                 ),
               ),
             ],

--- a/mobile/lib/features/activity/activity_page.dart
+++ b/mobile/lib/features/activity/activity_page.dart
@@ -304,7 +304,7 @@ class _FeedItemTile extends ConsumerWidget {
                 Text(
                   _relativeTime(item.createdAt),
                   style: context.textTheme.labelSmall?.copyWith(
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                 ),
               ],
@@ -407,7 +407,11 @@ class _EmptyState extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(LucideIcons.bell, size: Grid.xl, color: context.colors.outline),
+          Icon(
+            LucideIcons.bell,
+            size: Grid.xl,
+            color: context.colors.onSurfaceVariant,
+          ),
           const SizedBox(height: Grid.xs),
           Text(
             'No activity yet',
@@ -419,7 +423,7 @@ class _EmptyState extends StatelessWidget {
           Text(
             'Mentions, replies, and reactions will show up here.',
             style: context.textTheme.bodySmall?.copyWith(
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
             ),
             textAlign: TextAlign.center,
           ),
@@ -451,7 +455,7 @@ class _EmptyFilterState extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(icon, size: Grid.lg, color: context.colors.outline),
+          Icon(icon, size: Grid.lg, color: context.colors.onSurfaceVariant),
           const SizedBox(height: Grid.xxs),
           Text(
             message,

--- a/mobile/lib/features/channels/agent_activity/agent_activity_sheet.dart
+++ b/mobile/lib/features/channels/agent_activity/agent_activity_sheet.dart
@@ -179,7 +179,7 @@ class _EmptyState extends StatelessWidget {
         child: Text(
           'Not connected',
           style: context.textTheme.bodySmall?.copyWith(
-            color: context.colors.outline,
+            color: context.colors.onSurfaceVariant,
           ),
         ),
       );
@@ -195,14 +195,14 @@ class _EmptyState extends StatelessWidget {
             height: 24,
             child: CircularProgressIndicator(
               strokeWidth: 2,
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
             ),
           ),
           const SizedBox(height: Grid.xxs),
           Text(
             'Waiting for activity\u2026',
             style: context.textTheme.bodySmall?.copyWith(
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
             ),
           ),
         ],
@@ -219,7 +219,7 @@ class _ConnectionBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final (color, label) = switch (connection) {
-      ObserverConnectionState.idle => (context.colors.outline, 'Idle'),
+      ObserverConnectionState.idle => (context.colors.onSurfaceVariant, 'Idle'),
       ObserverConnectionState.connecting => (
         context.appColors.warning,
         'Connecting',

--- a/mobile/lib/features/channels/agent_activity/transcript_item_widget.dart
+++ b/mobile/lib/features/channels/agent_activity/transcript_item_widget.dart
@@ -40,7 +40,7 @@ class _MessageItemWidget extends StatelessWidget {
     final isAssistant = item.role == 'assistant';
     final badgeColor = isAssistant
         ? context.colors.primary
-        : context.colors.outline;
+        : context.colors.onSurfaceVariant;
     final badgeLabel = isAssistant ? 'Assistant' : 'User';
 
     return Padding(
@@ -122,14 +122,14 @@ class _ThoughtItemWidget extends HookWidget {
                   Icon(
                     LucideIcons.brain,
                     size: 14,
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                   const SizedBox(width: Grid.half),
                   Expanded(
                     child: Text(
                       item.title,
                       style: context.textTheme.labelMedium?.copyWith(
-                        color: context.colors.outline,
+                        color: context.colors.onSurfaceVariant,
                         fontWeight: FontWeight.w600,
                       ),
                       overflow: TextOverflow.ellipsis,
@@ -140,7 +140,7 @@ class _ThoughtItemWidget extends HookWidget {
                         ? LucideIcons.chevronUp
                         : LucideIcons.chevronDown,
                     size: 14,
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                 ],
               ),
@@ -178,7 +178,7 @@ class _LifecycleItemWidget extends StatelessWidget {
         child: Text(
           '${item.title}${item.text.isNotEmpty ? ' \u2014 ${item.text}' : ''}',
           style: context.textTheme.labelSmall?.copyWith(
-            color: context.colors.outline,
+            color: context.colors.onSurfaceVariant,
           ),
           textAlign: TextAlign.center,
         ),
@@ -226,14 +226,14 @@ class _MetadataItemWidget extends HookWidget {
                   Icon(
                     LucideIcons.fileText,
                     size: 14,
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                   const SizedBox(width: Grid.half),
                   Expanded(
                     child: Text(
                       '${item.title} (${item.sections.length} sections)',
                       style: context.textTheme.labelMedium?.copyWith(
-                        color: context.colors.outline,
+                        color: context.colors.onSurfaceVariant,
                         fontWeight: FontWeight.w600,
                       ),
                       overflow: TextOverflow.ellipsis,
@@ -244,7 +244,7 @@ class _MetadataItemWidget extends HookWidget {
                         ? LucideIcons.chevronUp
                         : LucideIcons.chevronDown,
                     size: 14,
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                 ],
               ),
@@ -265,7 +265,7 @@ class _MetadataItemWidget extends HookWidget {
                           ? '${section.body.substring(0, 500)}\u2026'
                           : section.body,
                       style: context.textTheme.bodySmall?.copyWith(
-                        color: context.colors.outline,
+                        color: context.colors.onSurfaceVariant,
                       ),
                     ),
                   ],
@@ -371,7 +371,7 @@ class _ToolItemWidget extends HookWidget {
                     Text(
                       'Arguments',
                       style: context.textTheme.labelSmall?.copyWith(
-                        color: context.colors.outline,
+                        color: context.colors.onSurfaceVariant,
                       ),
                     ),
                     const SizedBox(width: Grid.half),
@@ -380,7 +380,7 @@ class _ToolItemWidget extends HookWidget {
                           ? LucideIcons.chevronUp
                           : LucideIcons.chevronDown,
                       size: 12,
-                      color: context.colors.outline,
+                      color: context.colors.onSurfaceVariant,
                     ),
                   ],
                 ),
@@ -402,7 +402,7 @@ class _ToolItemWidget extends HookWidget {
                       style: context.textTheme.labelSmall?.copyWith(
                         color: item.isError
                             ? context.colors.error
-                            : context.colors.outline,
+                            : context.colors.onSurfaceVariant,
                       ),
                     ),
                     const SizedBox(width: Grid.half),
@@ -413,7 +413,7 @@ class _ToolItemWidget extends HookWidget {
                       size: 12,
                       color: item.isError
                           ? context.colors.error
-                          : context.colors.outline,
+                          : context.colors.onSurfaceVariant,
                     ),
                   ],
                 ),
@@ -451,7 +451,7 @@ class _ToolItemWidget extends HookWidget {
     return (context.appColors.success, 'Done', LucideIcons.circleCheck);
   }
   if (status == ToolStatus.pending) {
-    return (context.colors.outline, 'Pending', LucideIcons.circleDot);
+    return (context.colors.onSurfaceVariant, 'Pending', LucideIcons.circleDot);
   }
   return (context.appColors.warning, 'Running', LucideIcons.clock3);
 }

--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -395,7 +395,7 @@ class _MessageList extends HookConsumerWidget {
             Icon(
               LucideIcons.messageSquare,
               size: Grid.xl,
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
             ),
             const SizedBox(height: Grid.xxs),
             Text(
@@ -408,7 +408,7 @@ class _MessageList extends HookConsumerWidget {
             Text(
               'Be the first to say something!',
               style: context.textTheme.bodySmall?.copyWith(
-                color: context.colors.outline,
+                color: context.colors.onSurfaceVariant,
               ),
             ),
           ],
@@ -1031,7 +1031,7 @@ class _TypingIndicator extends ConsumerWidget {
       child: Text(
         text,
         style: context.textTheme.labelSmall?.copyWith(
-          color: context.colors.outline,
+          color: context.colors.onSurfaceVariant,
           fontStyle: FontStyle.italic,
         ),
       ),

--- a/mobile/lib/features/channels/channels_page.dart
+++ b/mobile/lib/features/channels/channels_page.dart
@@ -396,7 +396,7 @@ class _ChannelSection extends StatelessWidget {
               child: Text(
                 emptyLabel,
                 style: context.textTheme.bodySmall?.copyWith(
-                  color: context.colors.outline,
+                  color: context.colors.onSurfaceVariant,
                 ),
               ),
             )
@@ -428,7 +428,7 @@ class _EmptyState extends StatelessWidget {
             Icon(
               LucideIcons.messagesSquare,
               size: Grid.xl,
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
             ),
             const SizedBox(height: Grid.xs),
             Text(

--- a/mobile/lib/features/channels/compose_bar.dart
+++ b/mobile/lib/features/channels/compose_bar.dart
@@ -701,7 +701,11 @@ class _MentionSuggestions extends StatelessWidget {
             ),
             title: Text(name, style: context.textTheme.bodyMedium),
             trailing: member.isBot
-                ? Icon(LucideIcons.bot, size: 14, color: context.colors.outline)
+                ? Icon(
+                    LucideIcons.bot,
+                    size: 14,
+                    color: context.colors.onSurfaceVariant,
+                  )
                 : null,
             onTap: () => onSelect(member),
           );
@@ -778,7 +782,7 @@ class _ChannelSuggestions extends StatelessWidget {
             trailing: Text(
               channel.channelType,
               style: context.textTheme.labelSmall?.copyWith(
-                color: context.colors.outline,
+                color: context.colors.onSurfaceVariant,
               ),
             ),
             onTap: () => onSelect(channel),

--- a/mobile/lib/features/channels/manage_channel_sheet.dart
+++ b/mobile/lib/features/channels/manage_channel_sheet.dart
@@ -290,7 +290,7 @@ class _ContextCard extends StatelessWidget {
           Text(
             label,
             style: context.textTheme.labelSmall?.copyWith(
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
               fontWeight: FontWeight.w600,
             ),
           ),

--- a/mobile/lib/features/channels/members_sheet.dart
+++ b/mobile/lib/features/channels/members_sheet.dart
@@ -138,7 +138,7 @@ class MembersSheet extends HookConsumerWidget {
                           child: Text(
                             'No members found.',
                             style: context.textTheme.bodySmall?.copyWith(
-                              color: context.colors.outline,
+                              color: context.colors.onSurfaceVariant,
                             ),
                           ),
                         ),
@@ -176,7 +176,7 @@ class _SectionLabel extends StatelessWidget {
       child: Text(
         label.toUpperCase(),
         style: context.textTheme.labelSmall?.copyWith(
-          color: context.colors.outline,
+          color: context.colors.onSurfaceVariant,
           fontWeight: FontWeight.w600,
           letterSpacing: 0.8,
         ),
@@ -251,7 +251,7 @@ class _MemberTile extends ConsumerWidget {
           : Text(
               _roleLabel(member.role),
               style: context.textTheme.bodySmall?.copyWith(
-                color: context.colors.outline,
+                color: context.colors.onSurfaceVariant,
               ),
             ),
       trailing: showMenu
@@ -391,7 +391,7 @@ class _RoleSelector extends StatelessWidget {
           Text(
             'Role',
             style: context.textTheme.labelMedium?.copyWith(
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
             ),
           ),
           const SizedBox(height: Grid.xxs),

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -415,7 +415,7 @@ class _ThreadMessage extends ConsumerWidget {
                           Text(
                             formatMessageTime(message.createdAt),
                             style: context.textTheme.labelSmall?.copyWith(
-                              color: context.colors.outline,
+                              color: context.colors.onSurfaceVariant,
                             ),
                           ),
                           if (message.edited) ...[
@@ -423,7 +423,7 @@ class _ThreadMessage extends ConsumerWidget {
                             Text(
                               '(edited)',
                               style: context.textTheme.labelSmall?.copyWith(
-                                color: context.colors.outline,
+                                color: context.colors.onSurfaceVariant,
                                 fontStyle: FontStyle.italic,
                               ),
                             ),
@@ -486,7 +486,7 @@ class _ThreadTypingIndicator extends ConsumerWidget {
       child: Text(
         text,
         style: context.textTheme.labelSmall?.copyWith(
-          color: context.colors.outline,
+          color: context.colors.onSurfaceVariant,
           fontStyle: FontStyle.italic,
         ),
       ),

--- a/mobile/lib/features/forum/forum_post_card.dart
+++ b/mobile/lib/features/forum/forum_post_card.dart
@@ -77,7 +77,7 @@ class ForumPostCard extends ConsumerWidget {
                 Text(
                   formatRelativeTime(post.createdAt),
                   style: context.textTheme.labelSmall?.copyWith(
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                 ),
                 const SizedBox(width: Grid.half),
@@ -89,7 +89,7 @@ class ForumPostCard extends ConsumerWidget {
                     icon: Icon(
                       LucideIcons.ellipsis,
                       size: 16,
-                      color: context.colors.outline,
+                      color: context.colors.onSurfaceVariant,
                     ),
                     padding: EdgeInsets.zero,
                     visualDensity: VisualDensity.compact,
@@ -128,13 +128,13 @@ class ForumPostCard extends ConsumerWidget {
                   Icon(
                     LucideIcons.messageSquare,
                     size: 14,
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                   const SizedBox(width: Grid.half),
                   Text(
                     '${summary.replyCount} ${summary.replyCount == 1 ? 'reply' : 'replies'}',
                     style: context.textTheme.labelSmall?.copyWith(
-                      color: context.colors.outline,
+                      color: context.colors.onSurfaceVariant,
                     ),
                   ),
                   if (summary.lastReplyAt != null) ...[
@@ -142,14 +142,16 @@ class ForumPostCard extends ConsumerWidget {
                     Text(
                       '\u00b7',
                       style: context.textTheme.labelSmall?.copyWith(
-                        color: context.colors.outline.withValues(alpha: 0.5),
+                        color: context.colors.onSurfaceVariant.withValues(
+                          alpha: 0.5,
+                        ),
                       ),
                     ),
                     const SizedBox(width: Grid.half),
                     Text(
                       'last ${formatRelativeTime(summary.lastReplyAt!)}',
                       style: context.textTheme.labelSmall?.copyWith(
-                        color: context.colors.outline,
+                        color: context.colors.onSurfaceVariant,
                       ),
                     ),
                   ],

--- a/mobile/lib/features/forum/forum_posts_view.dart
+++ b/mobile/lib/features/forum/forum_posts_view.dart
@@ -186,7 +186,7 @@ class _EmptyState extends StatelessWidget {
             Icon(
               LucideIcons.messageSquareText,
               size: Grid.xl,
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
             ),
             const SizedBox(height: Grid.xxs),
             Text(
@@ -203,7 +203,7 @@ class _EmptyState extends StatelessWidget {
                   ? 'Start a discussion by creating the first post.'
                   : 'Join this forum to create posts.',
               style: context.textTheme.bodySmall?.copyWith(
-                color: context.colors.outline,
+                color: context.colors.onSurfaceVariant,
               ),
               textAlign: TextAlign.center,
             ),

--- a/mobile/lib/features/forum/forum_thread_page.dart
+++ b/mobile/lib/features/forum/forum_thread_page.dart
@@ -237,13 +237,13 @@ class _ThreadContent extends HookConsumerWidget {
                     Icon(
                       LucideIcons.messageSquare,
                       size: 16,
-                      color: context.colors.outline,
+                      color: context.colors.onSurfaceVariant,
                     ),
                     const SizedBox(width: Grid.half),
                     Text(
                       '${replies.length} ${replies.length == 1 ? 'reply' : 'replies'}',
                       style: context.textTheme.labelMedium?.copyWith(
-                        color: context.colors.outline,
+                        color: context.colors.onSurfaceVariant,
                         fontWeight: FontWeight.w600,
                       ),
                     ),
@@ -258,7 +258,7 @@ class _ThreadContent extends HookConsumerWidget {
                   child: Text(
                     'No replies yet. Be the first to respond.',
                     style: context.textTheme.bodyMedium?.copyWith(
-                      color: context.colors.outline,
+                      color: context.colors.onSurfaceVariant,
                     ),
                     textAlign: TextAlign.center,
                   ),
@@ -337,7 +337,7 @@ class _OriginalPost extends ConsumerWidget {
                     Text(
                       formatRelativeTime(post.createdAt),
                       style: context.textTheme.labelSmall?.copyWith(
-                        color: context.colors.outline,
+                        color: context.colors.onSurfaceVariant,
                       ),
                     ),
                   ],
@@ -406,7 +406,7 @@ class _ReplyRow extends ConsumerWidget {
                     Text(
                       formatRelativeTime(reply.createdAt),
                       style: context.textTheme.labelSmall?.copyWith(
-                        color: context.colors.outline,
+                        color: context.colors.onSurfaceVariant,
                       ),
                     ),
                   ],
@@ -420,7 +420,7 @@ class _ReplyRow extends ConsumerWidget {
                   icon: Icon(
                     LucideIcons.ellipsis,
                     size: 16,
-                    color: context.colors.outline,
+                    color: context.colors.onSurfaceVariant,
                   ),
                   padding: EdgeInsets.zero,
                   visualDensity: VisualDensity.compact,

--- a/mobile/lib/features/search/search_page.dart
+++ b/mobile/lib/features/search/search_page.dart
@@ -404,7 +404,7 @@ class _MessageTile extends StatelessWidget {
           Text(
             timeAgo,
             style: context.textTheme.labelSmall?.copyWith(
-              color: context.colors.outline,
+              color: context.colors.onSurfaceVariant,
             ),
           ),
         ],
@@ -450,7 +450,7 @@ class _SectionLabel extends StatelessWidget {
       child: Text(
         label.toUpperCase(),
         style: context.textTheme.labelSmall?.copyWith(
-          color: context.colors.outline,
+          color: context.colors.onSurfaceVariant,
           fontWeight: FontWeight.w600,
           letterSpacing: 0.8,
         ),


### PR DESCRIPTION
## Summary
- Follow-up to #438 — completes the sweep of `context.colors.outline` (border color) → `context.colors.onSurfaceVariant` (muted text color) for all remaining text and icon elements across the mobile app
- 54 token swaps across 14 files covering: activity feed, agent activity, channels, compose bar, forum, members, search, and thread views
- All themes benefit equally since the fix is token references, not hardcoded colors

## Changes
- `app.dart` — button text
- `activity_page.dart` — timestamps, empty state icons/text
- `agent_activity_sheet.dart` — status text, progress indicator, idle badge
- `transcript_item_widget.dart` — activity titles, icons, chevrons, section text, status badges
- `channel_detail_page.dart` — empty state icon/text, typing indicator
- `channels_page.dart` — empty section labels, empty state icon
- `compose_bar.dart` — bot badge icon, channel type label
- `manage_channel_sheet.dart` — section label
- `members_sheet.dart` — empty state, section labels, role labels
- `thread_detail_page.dart` — timestamps, edited label, typing indicator
- `forum_post_card.dart` — timestamps, reply count, menu icon
- `forum_posts_view.dart` — empty state icon/text
- `forum_thread_page.dart` — replies header, timestamps, menu icon
- `search_page.dart` — timestamp, section label

## Test plan
- [x] `dart analyze` — no issues
- [x] `dart format` — clean
- [x] All pre-commit hooks pass
- [x] All pre-push hooks pass (mobile-test, desktop-build, rust-clippy, rust-tests)
- [x] Remaining `outline` usages audited — 5 presence indicator dots, all correct
- [ ] Visual verification on device with light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)