### PR TITLE
fix(mobile): show full channel history when deletion events dominate

### DIFF
--- a/mobile/lib/features/channels/channel_messages_provider.dart
+++ b/mobile/lib/features/channels/channel_messages_provider.dart
@@ -62,7 +62,7 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
             tags: {
               '#h': [channelId],
             },
-            limit: 50,
+            limit: 200,
           ),
           _handleLiveEvent,
         );
@@ -87,7 +87,7 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
           tags: {
             '#h': [channelId],
           },
-          limit: 50,
+          limit: 200,
         ),
       );
       if (!_isCurrentInit(initVersion)) {
@@ -106,6 +106,12 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
       merged.sort((a, b) => a.createdAt.compareTo(b.createdAt));
       _lastKnownMessages = merged;
       state = AsyncData(merged);
+
+      // Auto-prefetch: if deletions/reactions crowded out displayable messages,
+      // loop fetchOlder() until we have enough content to fill the screen.
+      // Must clear _initInFlight first so fetchOlder() doesn't short-circuit.
+      _initInFlight = false;
+      await _ensureMinDisplayable(initVersion);
     } catch (e, st) {
       if (!_isCurrentInit(initVersion)) {
         return;
@@ -146,6 +152,37 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
         content.contains('member_removed');
   }
 
+  /// Kinds that are metadata rather than displayable content (deletions,
+  /// reactions, edits, legacy pre-migration messages).
+  static const _metadataKinds = {5, 7, 40001, 40003};
+
+  /// Minimum displayable messages we want after the initial history load.
+  static const _minDisplayable = 15;
+
+  /// Max extra fetchOlder rounds during auto-prefetch to avoid hammering the
+  /// relay.
+  static const _maxPrefetchRounds = 3;
+
+  /// After the initial history fetch, check whether enough user-visible
+  /// messages were loaded. If deletion/reaction events consumed most of the
+  /// fetch limit, loop [fetchOlder] to backfill displayable content.
+  Future<void> _ensureMinDisplayable(int initVersion) async {
+    for (var i = 0; i < _maxPrefetchRounds; i++) {
+      if (!_isCurrentInit(initVersion) || _reachedOldest) return;
+
+      final events = state.value;
+      if (events == null) return;
+
+      final displayable = events
+          .where((e) => !_metadataKinds.contains(e.kind))
+          .length;
+      if (displayable >= _minDisplayable) return;
+
+      final loaded = await fetchOlder();
+      if (!loaded) return;
+    }
+  }
+
   /// Merge a new event into the sorted list, deduplicating by ID.
   static List<NostrEvent> _mergeEvent(
     List<NostrEvent> current,
@@ -184,7 +221,7 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
         tags: {
           '#h': [channelId],
         },
-        limit: 50,
+        limit: 100,
         until: oldest,
       ),
     );

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -34,18 +34,20 @@ void main() {
           .read(channelMessagesProvider(_channelId))
           .value!;
       expect(messages.map((event) => event.id), ['history', 'live']);
-      expect(relaySession.operations, ['subscribe', 'fetch']);
+      // The auto-prefetch fires an extra fetchOlder because fewer than 15
+      // displayable events were loaded. The deduped result sets _reachedOldest.
+      expect(relaySession.operations, ['subscribe', 'fetch', 'fetch']);
       expect(
         relaySession.liveFilters.single.kinds,
         EventKind.channelEventKinds,
       );
       expect(relaySession.liveFilters.single.tags['#h'], [_channelId]);
-      expect(relaySession.liveFilters.single.limit, 50);
+      expect(relaySession.liveFilters.single.limit, 200);
       expect(
-        relaySession.historyFilters.single.kinds,
+        relaySession.historyFilters.first.kinds,
         EventKind.channelEventKinds,
       );
-      expect(relaySession.historyFilters.single.tags['#h'], [_channelId]);
+      expect(relaySession.historyFilters.first.tags['#h'], [_channelId]);
     },
   );
 
@@ -62,7 +64,7 @@ void main() {
 
     final messages = container.read(channelMessagesProvider(_channelId)).value!;
     expect(messages.map((event) => event.id), ['history']);
-    expect(relaySession.operations, ['subscribe', 'fetch']);
+    expect(relaySession.operations, ['subscribe', 'fetch', 'fetch']);
   });
 
   test(


### PR DESCRIPTION
## Summary
- Increased mobile channel history fetch limits to match desktop (initial: 50→200, pagination: 50→100)
- Added auto-prefetch backstop (`_ensureMinDisplayable`): after initial load, if fewer than 15 displayable messages were fetched (because deletion/reaction events consumed the page), automatically calls `fetchOlder()` up to 3 times to backfill content

## Problem
Channels with many kind=5 deletion events (e.g. `#proj-sprout-grouped-events` with 108 deletions vs 7 messages) would show only 1-2 messages on mobile because the 50-event fetch limit was consumed by non-displayable events. Desktop's 200-event limit avoided this in practice.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 349 tests passing (1 skipped)
- [x] Pre-push hooks green (rust-fmt, desktop-check, mobile-check, desktop-build, mobile-test, rust-clippy, rust-tests)
- [x] Manual verification on `#proj-sprout-grouped-events` — full history now loads on mobile
- [x] Adversarial code review by two independent reviewers — approved with no blocking issues

## Follow-ups (non-blocking)
- Add dedicated tests for auto-prefetch edge cases (max-round cap, mid-loop reconnect, deletion-dominated pages)
- Consider adding `initVersion` guard to `fetchOlder()` for reconnect safety (pre-existing race, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)