### PR TITLE
Show own status in sidebar footer, remove Recent Notes

### DIFF
--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { getUserNotes } from "@/shared/api/social";
 import {
   getProfile,
   searchUsers,
@@ -12,7 +11,6 @@ import {
 import type {
   Profile,
   UpdateProfileInput,
-  UserNotesResponse,
   UserSearchResult,
   UsersBatchResponse,
 } from "@/shared/api/types";
@@ -73,25 +71,6 @@ export function useUsersBatchQuery(
   }, [query.data, queryClient]);
 
   return query;
-}
-
-export function useUserNotesQuery(
-  pubkey?: string,
-  options?: {
-    enabled?: boolean;
-    limit?: number;
-  },
-) {
-  const resolvedPubkey = typeof pubkey === "string" ? pubkey : "";
-  const enabled = (options?.enabled ?? true) && resolvedPubkey.length > 0;
-
-  return useQuery<UserNotesResponse>({
-    enabled,
-    queryKey: ["user-notes", resolvedPubkey.toLowerCase(), options?.limit ?? 3],
-    queryFn: () => getUserNotes(resolvedPubkey, { limit: options?.limit ?? 3 }),
-    staleTime: 60_000,
-    gcTime: 5 * 60 * 1_000,
-  });
 }
 
 export function useUserSearchQuery(

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
 import { Activity } from "lucide-react";
 
-import {
-  useUserNotesQuery,
-  useUserProfileQuery,
-} from "@/features/profile/hooks";
+import { useUserProfileQuery } from "@/features/profile/hooks";
 import {
   useRelayAgentsQuery,
   useManagedAgentsQuery,
@@ -12,7 +9,6 @@ import {
 import { usePresenceQuery } from "@/features/presence/hooks";
 import { useUserStatusQuery } from "@/features/user-status/hooks";
 import { PresenceBadge } from "@/features/presence/ui/PresenceBadge";
-import { formatRelativeTime } from "@/features/forum/lib/time";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { useAgentSession } from "@/shared/context/AgentSessionContext";
 
@@ -63,9 +59,6 @@ export function UserProfilePopover({
 }: UserProfilePopoverProps) {
   const [open, setOpen] = React.useState(false);
   const profileQuery = useUserProfileQuery(open ? pubkey : undefined);
-  const notesQuery = useUserNotesQuery(open ? pubkey : undefined, {
-    limit: 1,
-  });
   const relayAgentsQuery = useRelayAgentsQuery({
     enabled: open && role === "bot",
   });
@@ -87,7 +80,6 @@ export function UserProfilePopover({
     managedAgent?.backend.type === "local" &&
     Boolean(onOpenAgentSession);
   const profile = profileQuery.data;
-  const latestNote = (notesQuery.data?.notes ?? [])[0] ?? null;
   const presenceStatus = presenceQuery.data?.[pubkey.toLowerCase()];
   const userStatus = userStatusQuery.data?.[pubkey.toLowerCase()];
 
@@ -152,20 +144,6 @@ export function UserProfilePopover({
             </p>
           ) : null}
 
-          {!notesQuery.isLoading && !notesQuery.isError && latestNote ? (
-            <div
-              className="rounded-lg bg-muted/30 px-3 py-2"
-              data-testid="user-profile-latest-note"
-            >
-              <p className="line-clamp-2 text-xs text-foreground">
-                {latestNote.content}
-              </p>
-              <p className="mt-1 text-[10px] text-muted-foreground/70">
-                {formatRelativeTime(latestNote.createdAt)}
-              </p>
-            </div>
-          ) : null}
-
           {role === "bot" && (managedAgent || relayAgent) ? (
             <div className="flex flex-wrap gap-1.5">
               {managedAgent?.agentCommand ? (
@@ -201,12 +179,6 @@ export function UserProfilePopover({
               <Activity className="h-3.5 w-3.5 text-muted-foreground" />
               View activity log
             </button>
-          ) : null}
-
-          {notesQuery.isError ? (
-            <p className="text-xs text-muted-foreground">
-              Recent notes are unavailable right now.
-            </p>
           ) : null}
         </div>
       </PopoverContent>

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -576,6 +576,14 @@ export function AppSidebar({
                     >
                       {resolvedDisplayName}
                     </p>
+                    {selfUserStatus?.text || selfUserStatus?.emoji ? (
+                      <p className="truncate text-xs text-sidebar-foreground/50">
+                        {selfUserStatus.emoji ? (
+                          <span className="mr-1">{selfUserStatus.emoji}</span>
+                        ) : null}
+                        {selfUserStatus.text}
+                      </p>
+                    ) : null}
                   </div>
                 </div>
               </SidebarMenuButton>

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -142,9 +142,9 @@ test("clicking author name opens user profile popover", async ({ page }) => {
   const popover = page.locator("[data-radix-popper-content-wrapper]");
   await expect(popover).toBeVisible();
   await expect(popover).toContainText("deadbeef");
-  await expect(page.getByTestId("user-profile-latest-note")).toContainText(
-    "Shipped the new desktop sidebar polish today.",
-  );
+  // Notes section removed — user status replaces it.
+  // Verify the popover is still functional (pubkey visible confirms data loaded).
+  await expect(popover).toContainText("deadbeef");
 });
 
 test("clicking avatar opens user profile popover", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Display the user's emoji+text status below their name in the desktop sidebar footer for at-a-glance visibility
- Remove the "Recent Notes" section from UserProfilePopover since user status (added in #449) now serves that purpose
- Clean up dead `useUserNotesQuery` hook and unused imports from `profile/hooks.ts`
- Update e2e test to remove `user-profile-latest-note` assertion

## Test plan
- [x] `pnpm check` passes (biome, file sizes)
- [x] All pre-push hooks green (rust fmt/clippy/tests, desktop build/check, mobile check/test)
- [x] Verify sidebar footer shows emoji+text status when set
- [x] Verify sidebar footer hides status line when no status is set
- [x] Verify avatar popover no longer shows Recent Notes
- [x] Verify avatar popover still shows user status

🤖 Generated with [Claude Code](https://claude.com/claude-code)