### PR TITLE
fix(desktop): prevent URL highlight from bleeding past link boundary

### DIFF
--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -183,7 +183,11 @@ export function useRichTextEditor({
         Placeholder.configure({
           placeholder: () => placeholderRef.current ?? "Write a message…",
         }),
-        Link.configure({
+        Link.extend({
+          inclusive() {
+            return false;
+          },
+        }).configure({
           openOnClick: false,
           autolink: true,
           linkOnPaste: true,


### PR DESCRIPTION
## Summary
- Override TipTap Link extension's `inclusive()` to return `false` so characters typed after a detected URL no longer inherit the link mark styling
- The autolink detection plugin continues to work correctly — it applies marks independently via `appendTransaction` when whitespace follows a URL
- Root cause: TipTap sets `inclusive: true` when `autolink` is enabled, meaning new characters at the mark boundary inherit the link formatting

## Test plan
- [ ] Paste a URL into the composer, then type additional text after it — only the URL should be highlighted
- [ ] Type a URL followed by a space — URL should still be auto-detected and highlighted
- [ ] Paste a URL over selected text — should still create a link
- [ ] Verify clicking inside an existing link and typing still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)