### PR TITLE
fix(desktop): show participant names for group DMs

### DIFF
--- a/desktop/src/features/sidebar/lib/channelLabels.ts
+++ b/desktop/src/features/sidebar/lib/channelLabels.ts
@@ -10,7 +10,8 @@ function isGenericDmChannelName(name: string) {
     normalized.length === 0 ||
     normalized === "dm" ||
     normalized === "direct message" ||
-    normalized === "direct messages"
+    normalized === "direct messages" ||
+    /^group dm\s*(\(\d+\))?$/.test(normalized)
   );
 }
 


### PR DESCRIPTION
## Summary
- Group DMs on desktop showed "Group DM (3)" instead of participant names like "Alice, Bob, Charlie"
- The `isGenericDmChannelName` function in `channelLabels.ts` didn't recognize the "Group DM (N)" pattern, so `resolveChannelDisplayLabel` returned the raw channel name instead of resolving participant names
- Added a regex match for `group dm` names to trigger the existing name resolution logic, matching mobile behavior

## Changes
- `desktop/src/features/sidebar/lib/channelLabels.ts`: Added `/^group dm\s*(\(\d+\))?$/` to `isGenericDmChannelName`

This fix applies to both the sidebar and channel header since both use `resolveChannelDisplayLabel`.

## Test plan
- [ ] Open desktop app with a group DM (3+ participants)
- [ ] Verify sidebar shows comma-separated participant names instead of "Group DM (N)"
- [ ] Verify channel header also shows participant names
- [ ] Verify regular 1:1 DMs still show the other person's name
- [ ] Verify custom-named DM channels still show their custom name

🤖 Generated with [Claude Code](https://claude.com/claude-code)