### PR TITLE
fix(ci): use cargo update --workspace instead of generate-lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Patch version
         run: |
           cd desktop && node scripts/set-version-from-tag.mjs "$VERSION"
-          cd src-tauri && cargo generate-lockfile
+          cd src-tauri && cargo update --workspace
 
       - name: Generate release config
         run: cd desktop && node scripts/build-release-config.mjs


### PR DESCRIPTION
## Summary
- Replace `cargo generate-lockfile` with `cargo update --workspace` in the release workflow's version patching step

## Problem
The release workflow's "Patch version" step ran `cargo generate-lockfile`, which regenerates the **entire** `Cargo.lock` from scratch. This resolved `tauri = "2"` to the latest available version (2.11.0), while the npm `@tauri-apps/api` remained locked at 2.10.1 via `pnpm-lock.yaml`. Tauri's build checks for major/minor version alignment between the Rust crate and the npm package, so the build failed with:

```
Found version mismatched Tauri packages:
tauri (v2.11.0) : @tauri-apps/api (v2.10.1)
```

## Fix
`cargo update --workspace` only updates the version metadata for workspace crates (the desktop app version we just patched) without re-resolving third-party dependencies. This preserves the committed lockfile's pinned `tauri = 2.10.3`, which is compatible with `@tauri-apps/api = 2.10.1`.

## Test plan
- [ ] Re-run the release workflow with version `0.0.1-test.1` after merging
- [ ] Verify the "Build Tauri app" step no longer fails with version mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)