### PR TITLE
fix(ci): add verbose output and fix release config double-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           ./scripts/bundle-sidecars.sh
 
       - name: Build Tauri app
-        run: cd desktop && pnpm tauri build --config src-tauri/tauri.release.conf.json
+        run: cd desktop && pnpm tauri build --verbose --config src-tauri/tauri.release.conf.json
         env:
           SPROUT_UPDATER_PUBLIC_KEY: ${{ secrets.SPROUT_UPDATER_PUBLIC_KEY }}
           SPROUT_UPDATER_ENDPOINT: https://github.com/block/sprout/releases/download/sprout-desktop-latest/latest.json

--- a/desktop/scripts/build-release-config.mjs
+++ b/desktop/scripts/build-release-config.mjs
@@ -1,24 +1,24 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-// Write a tauri.release.conf.json alongside sprout's base tauri.conf.json.
+// Write a tauri.release.conf.json with release-only overrides.
 //
-// For OSS release builds this script:
-// 1. Sets bundle.macOS.minimumSystemVersion = "10.15" for broad compatibility.
-// 2. Configures plugins.updater with the public key and endpoint from env vars.
+// Tauri's --config flag merges the provided JSON on top of the base
+// tauri.conf.json, so this file must contain ONLY the delta fields —
+// not a copy of the base config.
+//
+// For OSS release builds this script emits:
+// 1. bundle.macOS.minimumSystemVersion = "10.15" for broad compatibility.
+// 2. bundle.createUpdaterArtifacts = true so Tauri produces the .tar.gz
+//    archive and .sig signature during the build.
+// 3. plugins.updater with the public key and endpoint from env vars.
 //    Both SPROUT_UPDATER_PUBLIC_KEY and SPROUT_UPDATER_ENDPOINT are required —
 //    the script fails if either is missing (OSS builds always ship with updater).
-// 3. Sets bundle.createUpdaterArtifacts = true so Tauri automatically produces
-//    the .tar.gz archive and .sig signature during the build.
 
-const baseConfigPath = resolve(process.cwd(), "src-tauri/tauri.conf.json");
 const outputConfigPath = resolve(
   process.cwd(),
   "src-tauri/tauri.release.conf.json",
 );
-const baseConfig = JSON.parse(readFileSync(baseConfigPath, "utf-8"));
-
-const releaseConfig = { ...baseConfig };
 
 const updaterPubkey = process.env.SPROUT_UPDATER_PUBLIC_KEY;
 const updaterEndpoint = process.env.SPROUT_UPDATER_ENDPOINT;
@@ -33,20 +33,18 @@ if (missing.length > 0) {
   process.exit(1);
 }
 
-releaseConfig.bundle = {
-  ...(releaseConfig.bundle ?? {}),
-  macOS: {
-    ...(releaseConfig.bundle?.macOS ?? {}),
-    minimumSystemVersion: "10.15",
+const releaseConfig = {
+  bundle: {
+    macOS: {
+      minimumSystemVersion: "10.15",
+    },
+    createUpdaterArtifacts: true,
   },
-  createUpdaterArtifacts: true,
-};
-
-releaseConfig.plugins = {
-  ...(releaseConfig.plugins ?? {}),
-  updater: {
-    pubkey: updaterPubkey,
-    endpoints: [updaterEndpoint],
+  plugins: {
+    updater: {
+      pubkey: updaterPubkey,
+      endpoints: [updaterEndpoint],
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `--verbose` to `pnpm tauri build` in the release workflow so the actual `bundle_dmg.sh` error is surfaced on failure instead of Tauri's opaque "failed to run" message
- Rewrite `build-release-config.mjs` to emit only delta/override fields instead of copying the entire base `tauri.conf.json` — Tauri's `--config` flag already merges on top of the base config, so passing a full copy caused every field to be applied twice and triggered the `.app` identifier suffix warning

## Test plan
- [x] Re-run the release workflow with a test version — the `--verbose` flag should show the actual DMG script output
- [x] Verify the identifier `.app` suffix warning is gone from the build logs
- [x] If DMG bundling still fails, the verbose output will reveal the root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)