### PR TITLE
fix(ci): add ad-hoc code signing to OSS release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
+      - name: Verify code signature
+        run: |
+          codesign --verify --deep --strict --verbose=2 \
+            desktop/src-tauri/target/release/bundle/macos/Sprout.app
+
       - name: Locate build artifacts
         id: artifacts
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,6 +69,17 @@ The release workflow currently builds for **macOS ARM64 only**
 (`darwin-aarch64`). Intel Mac (`darwin-x86_64`) support would require
 adding a matrix build to the workflow.
 
+## Code Signing (macOS)
+
+OSS release builds use **ad-hoc code signing** (`signingIdentity: "-"`)
+rather than a Developer ID certificate. This means the app is not
+notarized by Apple.
+
+On first launch, macOS Gatekeeper will block the app with a "damaged" or
+"unidentified developer" message. Users can bypass this by
+**right-clicking the app > Open** (or via System Settings > Privacy &
+Security). After the first launch the app will open normally.
+
 ---
 
 ## Auto-Updater

--- a/desktop/scripts/build-release-config.mjs
+++ b/desktop/scripts/build-release-config.mjs
@@ -14,6 +14,10 @@ import { resolve } from "node:path";
 // 3. plugins.updater with the public key and endpoint from env vars.
 //    Both SPROUT_UPDATER_PUBLIC_KEY and SPROUT_UPDATER_ENDPOINT are required —
 //    the script fails if either is missing (OSS builds always ship with updater).
+// 4. bundle.macOS.signingIdentity = "-" for ad-hoc code signing. This
+//    prevents macOS Gatekeeper from rejecting the app as "damaged".
+//    Users will see the standard "unidentified developer" dialog on first
+//    launch, which they can bypass via right-click > Open.
 
 const outputConfigPath = resolve(
   process.cwd(),
@@ -37,6 +41,7 @@ const releaseConfig = {
   bundle: {
     macOS: {
       minimumSystemVersion: "10.15",
+      signingIdentity: "-",
     },
     createUpdaterArtifacts: true,
   },


### PR DESCRIPTION
## Summary
- Add `signingIdentity: "-"` to the release config so Tauri ad-hoc signs the `.app` and all embedded binaries (sidecars) during the build
- Add a post-build `codesign --verify --deep --strict` step that fails the CI build early if signing doesn't take
- Document the ad-hoc signing approach and first-launch workaround in RELEASING.md

**Root cause:** Tauri v2 does not automatically ad-hoc sign when no identity is provided. The OSS build produced a completely unsigned `.app`. When downloaded via browser, macOS applies the quarantine xattr and Gatekeeper blocks it with "Sprout is damaged and can't be opened."

**After this fix:** The "damaged" error goes away. Users will see the standard "unidentified developer" warning on first launch, which they can bypass once via right-click > Open.

## Test plan
- [ ] Merge and trigger the release workflow
- [ ] Download the DMG from the GitHub release
- [ ] Verify the app opens after right-click > Open (no "damaged" error)
- [ ] Verify `codesign --verify --deep --strict Sprout.app` passes on the downloaded app
- [ ] Start a huddle to exercise ONNX/CoreML + microphone entitlement — confirm no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)