### PR TITLE
feat(relay): implement NIP-AA agent authentication via NIP-OA credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,6 +3942,7 @@ dependencies = [
  "sprout-db",
  "sprout-media",
  "sprout-pubsub",
+ "sprout-sdk",
  "sprout-search",
  "sprout-workflow",
  "sqlx",

--- a/crates/sprout-auth/src/lib.rs
+++ b/crates/sprout-auth/src/lib.rs
@@ -79,6 +79,11 @@ pub struct AuthContext {
     /// For NIP-AA virtual members: the owner pubkey that granted access.
     /// `None` for direct members.
     pub owner_pubkey: Option<nostr::PublicKey>,
+    /// For NIP-AA virtual members: optional session expiry derived from
+    /// `created_at<T` conditions in the NIP-OA auth tag. Events submitted
+    /// after this Unix timestamp are rejected.
+    /// `None` for direct members or delegations without time bounds.
+    pub session_expiry: Option<u64>,
 }
 
 impl AuthContext {
@@ -199,6 +204,7 @@ impl AuthService {
             channel_ids: None,
             auth_method,
             owner_pubkey: None,
+            session_expiry: None,
         })
     }
 
@@ -431,6 +437,7 @@ mod tests {
             channel_ids: None,
             auth_method: AuthMethod::Nip42PubkeyOnly,
             owner_pubkey: None,
+            session_expiry: None,
         };
         assert!(ctx.has_scope(&Scope::MessagesRead));
         assert!(!ctx.has_scope(&Scope::MessagesWrite));

--- a/crates/sprout-auth/src/lib.rs
+++ b/crates/sprout-auth/src/lib.rs
@@ -59,6 +59,8 @@ pub enum AuthMethod {
     Nip42Okta,
     /// NIP-42 with a `sprout_` API token in the `auth_token` tag.
     Nip42ApiToken,
+    /// NIP-42 with NIP-AA agent authentication — agent proved its owner is a relay member.
+    Nip42AgentAuth,
 }
 
 /// The result of a successful authentication, bound to a WebSocket connection.
@@ -74,6 +76,9 @@ pub struct AuthContext {
     pub channel_ids: Option<Vec<uuid::Uuid>>,
     /// How the connection was authenticated.
     pub auth_method: AuthMethod,
+    /// For NIP-AA virtual members: the owner pubkey that granted access.
+    /// `None` for direct members.
+    pub owner_pubkey: Option<nostr::PublicKey>,
 }
 
 impl AuthContext {
@@ -193,6 +198,7 @@ impl AuthService {
             scopes,
             channel_ids: None,
             auth_method,
+            owner_pubkey: None,
         })
     }
 
@@ -424,6 +430,7 @@ mod tests {
             scopes: vec![Scope::MessagesRead, Scope::ChannelsRead],
             channel_ids: None,
             auth_method: AuthMethod::Nip42PubkeyOnly,
+            owner_pubkey: None,
         };
         assert!(ctx.has_scope(&Scope::MessagesRead));
         assert!(!ctx.has_scope(&Scope::MessagesWrite));

--- a/crates/sprout-auth/src/scope.rs
+++ b/crates/sprout-auth/src/scope.rs
@@ -86,21 +86,18 @@ impl Scope {
         ]
     }
 
-    /// Return the scopes granted to NIP-AA virtual members.
-    ///
-    /// Virtual members get the minimum set needed for messaging and channel
-    /// interaction. Excluded: admin scopes, jobs, subscriptions, `UsersWrite`
-    /// (agents shouldn't modify profiles), and `ReposWrite` (git push requires
-    /// explicit enrollment).
+    /// Minimal scope set for NIP-AA virtual members (agents authenticating via
+    /// NIP-OA credentials). Intentionally excludes write operations beyond
+    /// messaging — agents should not create channels, upload files, or modify
+    /// user profiles. Scope can be further restricted by the NIP-OA credential's
+    /// conditions (intersection applied in auth.rs).
     pub fn nip_aa_virtual_member() -> Vec<Scope> {
         vec![
             Self::MessagesRead,
             Self::MessagesWrite,
             Self::ChannelsRead,
-            Self::ChannelsWrite,
             Self::UsersRead,
             Self::FilesRead,
-            Self::FilesWrite,
             Self::ReposRead,
         ]
     }

--- a/crates/sprout-auth/src/scope.rs
+++ b/crates/sprout-auth/src/scope.rs
@@ -282,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn all_known_returns_all_14_variants() {
+    fn all_known_returns_all_16_variants() {
         let all = Scope::all_known();
         assert_eq!(all.len(), 16, "expected 16 known scope variants");
         // Verify no duplicates

--- a/crates/sprout-auth/src/scope.rs
+++ b/crates/sprout-auth/src/scope.rs
@@ -86,6 +86,15 @@ impl Scope {
         ]
     }
 
+    /// Return the scopes granted to NIP-AA virtual members.
+    ///
+    /// NIP-AA spec: virtual members MUST NOT gain admin privileges. This returns all
+    /// known scopes except `AdminChannels` and `AdminUsers`, which require a real
+    /// operator-minted token even when relay membership is delegated via NIP-AA.
+    pub fn nip_aa_virtual_member() -> Vec<Scope> {
+        Self::all_non_admin()
+    }
+
     /// Return a `Vec` containing every known scope variant except admin scopes.
     ///
     /// Used in dev mode (`require_auth_token=false`) where `X-Pubkey` header auth grants

--- a/crates/sprout-auth/src/scope.rs
+++ b/crates/sprout-auth/src/scope.rs
@@ -88,11 +88,21 @@ impl Scope {
 
     /// Return the scopes granted to NIP-AA virtual members.
     ///
-    /// NIP-AA spec: virtual members MUST NOT gain admin privileges. This returns all
-    /// known scopes except `AdminChannels` and `AdminUsers`, which require a real
-    /// operator-minted token even when relay membership is delegated via NIP-AA.
+    /// Virtual members get the minimum set needed for messaging and channel
+    /// interaction. Excluded: admin scopes, jobs, subscriptions, `UsersWrite`
+    /// (agents shouldn't modify profiles), and `ReposWrite` (git push requires
+    /// explicit enrollment).
     pub fn nip_aa_virtual_member() -> Vec<Scope> {
-        Self::all_non_admin()
+        vec![
+            Self::MessagesRead,
+            Self::MessagesWrite,
+            Self::ChannelsRead,
+            Self::ChannelsWrite,
+            Self::UsersRead,
+            Self::FilesRead,
+            Self::FilesWrite,
+            Self::ReposRead,
+        ]
     }
 
     /// Return a `Vec` containing every known scope variant except admin scopes.

--- a/crates/sprout-mcp/src/relay_client.rs
+++ b/crates/sprout-mcp/src/relay_client.rs
@@ -221,6 +221,7 @@ async fn do_connect(
     relay_url: &str,
     keys: &Keys,
     api_token: Option<&str>,
+    auth_tag: Option<&nostr::Tag>,
 ) -> Result<WsStream, RelayClientError> {
     let parsed = relay_url
         .parse::<url::Url>()
@@ -236,7 +237,7 @@ async fn do_connect(
     // Wait for AUTH challenge (5s timeout).
     let challenge = wait_for_auth_challenge(&mut ws, Duration::from_secs(5)).await?;
 
-    let auth_event = build_auth_event(&challenge, relay_url, keys, api_token)?;
+    let auth_event = build_auth_event(&challenge, relay_url, keys, api_token, auth_tag)?;
     let event_id = auth_event.id.to_hex();
     debug!("sending AUTH event {event_id}");
     let auth_msg = serde_json::to_string(&json!(["AUTH", auth_event]))?;
@@ -324,12 +325,13 @@ fn build_auth_event(
     relay_url: &str,
     keys: &Keys,
     api_token: Option<&str>,
+    auth_tag: Option<&nostr::Tag>,
 ) -> Result<Event, RelayClientError> {
     let relay_nostr_url: Url = relay_url
         .parse()
         .map_err(|e: url::ParseError| RelayClientError::Url(e.to_string()))?;
     if let Some(token) = api_token {
-        let tags = vec![
+        let mut tags = vec![
             Tag::parse(&["relay", relay_url])
                 .map_err(|e| RelayClientError::EventBuilder(e.to_string()))?,
             Tag::parse(&["challenge", challenge])
@@ -337,9 +339,18 @@ fn build_auth_event(
             Tag::parse(&["auth_token", token])
                 .map_err(|e| RelayClientError::EventBuilder(e.to_string()))?,
         ];
+        if let Some(tag) = auth_tag {
+            tags.push(tag.clone());
+        }
         Ok(EventBuilder::new(Kind::Authentication, "", tags).sign_with_keys(keys)?)
     } else {
-        Ok(EventBuilder::auth(challenge, relay_nostr_url).sign_with_keys(keys)?)
+        let builder = EventBuilder::auth(challenge, relay_nostr_url);
+        let builder = if let Some(tag) = auth_tag {
+            builder.add_tags([tag.clone()])
+        } else {
+            builder
+        };
+        Ok(builder.sign_with_keys(keys)?)
     }
 }
 
@@ -353,9 +364,10 @@ async fn send_auth_response(
     relay_url: &str,
     keys: &Keys,
     api_token: Option<&str>,
+    auth_tag: Option<&nostr::Tag>,
 ) {
     let result: Result<(), RelayClientError> = async {
-        let auth_event = build_auth_event(challenge, relay_url, keys, api_token)?;
+        let auth_event = build_auth_event(challenge, relay_url, keys, api_token, auth_tag)?;
         let msg = serde_json::to_string(&json!(["AUTH", auth_event]))?;
         ws.send(Message::Text(msg.into())).await?;
         debug!("sent AUTH response for mid-session challenge");
@@ -377,6 +389,7 @@ async fn handle_ws_message(
     keys: &Keys,
     relay_url: &str,
     api_token: Option<&str>,
+    auth_tag: Option<&nostr::Tag>,
 ) -> bool {
     match msg {
         Message::Text(text) => {
@@ -429,7 +442,7 @@ async fn handle_ws_message(
                 }
                 RelayMessage::Auth { challenge } => {
                     debug!("received mid-session AUTH challenge — re-authenticating");
-                    send_auth_response(ws, &challenge, relay_url, keys, api_token).await;
+                    send_auth_response(ws, &challenge, relay_url, keys, api_token, auth_tag).await;
                 }
             }
             true
@@ -463,13 +476,14 @@ async fn do_reconnect(
     keys: &Keys,
     relay_url: &str,
     api_token: Option<&str>,
+    auth_tag: Option<&nostr::Tag>,
 ) -> bool {
     warn!("relay connection lost — reconnecting…");
     state.cancel_pending();
 
     let mut delay = Duration::from_secs(1);
     loop {
-        match do_connect(relay_url, keys, api_token).await {
+        match do_connect(relay_url, keys, api_token, auth_tag).await {
             Ok(new_ws) => {
                 tracing::info!("reconnected to relay at {relay_url}");
                 *ws = new_ws;
@@ -544,6 +558,7 @@ async fn run_background_task(
     keys: Keys,
     relay_url: String,
     api_token: Option<String>,
+    auth_tag: Option<nostr::Tag>,
 ) {
     let mut state = BgState::new();
     // Ticker for expiring timed-out pending operations (~1s granularity).
@@ -557,14 +572,14 @@ async fn run_background_task(
                 let needs_reconnect = match raw {
                     Some(Ok(msg)) => {
                         !handle_ws_message(
-                            msg, &mut ws, &mut state, &keys, &relay_url, api_token.as_deref(),
+                            msg, &mut ws, &mut state, &keys, &relay_url, api_token.as_deref(), auth_tag.as_ref(),
                         ).await
                     }
                     Some(Err(e)) => { warn!("WebSocket error: {e}"); true }
                     None => { debug!("WebSocket stream ended"); true }
                 };
                 if needs_reconnect
-                    && !do_reconnect(&mut ws, &mut state, &mut cmd_rx, &keys, &relay_url, api_token.as_deref()).await
+                    && !do_reconnect(&mut ws, &mut state, &mut cmd_rx, &keys, &relay_url, api_token.as_deref(), auth_tag.as_ref()).await
                 {
                     return; // Shutdown received during reconnect
                 }
@@ -581,7 +596,7 @@ async fn run_background_task(
                         };
                         if let Err(e) = ws.send(Message::Text(msg.into())).await {
                             let _ = reply.send(Err(RelayClientError::WebSocket(e)));
-                            if !do_reconnect(&mut ws, &mut state, &mut cmd_rx, &keys, &relay_url, api_token.as_deref()).await {
+                            if !do_reconnect(&mut ws, &mut state, &mut cmd_rx, &keys, &relay_url, api_token.as_deref(), auth_tag.as_ref()).await {
                                 return;
                             }
                             continue;
@@ -611,7 +626,7 @@ async fn run_background_task(
                         };
                         if let Err(e) = ws.send(Message::Text(text.into())).await {
                             let _ = reply.send(Err(RelayClientError::WebSocket(e)));
-                            if !do_reconnect(&mut ws, &mut state, &mut cmd_rx, &keys, &relay_url, api_token.as_deref()).await {
+                            if !do_reconnect(&mut ws, &mut state, &mut cmd_rx, &keys, &relay_url, api_token.as_deref(), auth_tag.as_ref()).await {
                                 return;
                             }
                             continue;
@@ -636,7 +651,7 @@ async fn run_background_task(
                         };
                         if let Err(e) = ws.send(Message::Text(msg.into())).await {
                             let _ = reply.send(Err(RelayClientError::WebSocket(e)));
-                            if !do_reconnect(&mut ws, &mut state, &mut cmd_rx, &keys, &relay_url, api_token.as_deref()).await {
+                            if !do_reconnect(&mut ws, &mut state, &mut cmd_rx, &keys, &relay_url, api_token.as_deref(), auth_tag.as_ref()).await {
                                 return;
                             }
                             continue;
@@ -717,16 +732,17 @@ impl RelayClient {
         api_token: Option<&str>,
         auth_tag: Option<nostr::Tag>,
     ) -> Result<Self, RelayClientError> {
-        let ws = do_connect(relay_url, keys, api_token).await?;
+        let ws = do_connect(relay_url, keys, api_token, auth_tag.as_ref()).await?;
 
         let (cmd_tx, cmd_rx) = mpsc::channel(CMD_CHANNEL_CAPACITY);
 
         let bg_keys = keys.clone();
         let bg_relay_url = relay_url.to_string();
         let bg_api_token = api_token.map(|t| t.to_string());
+        let bg_auth_tag = auth_tag.clone();
 
         let handle = tokio::spawn(async move {
-            run_background_task(ws, cmd_rx, bg_keys, bg_relay_url, bg_api_token).await;
+            run_background_task(ws, cmd_rx, bg_keys, bg_relay_url, bg_api_token, bg_auth_tag).await;
         });
 
         Ok(Self {

--- a/crates/sprout-media/src/error.rs
+++ b/crates/sprout-media/src/error.rs
@@ -77,9 +77,6 @@ pub enum MediaError {
     /// I/O error during streaming upload.
     #[error("io error: {0}")]
     Io(String),
-    /// Event contains more than one `auth` tag — NIP-AA requires exactly one.
-    #[error("multiple auth tags: NIP-AA requires exactly one auth tag")]
-    MultipleAuthTags,
 }
 
 impl From<image::ImageError> for MediaError {
@@ -136,7 +133,6 @@ impl IntoResponse for MediaError {
             }
             Self::InsufficientScope => (StatusCode::FORBIDDEN, self.to_string()),
             Self::RelayMembershipRequired => (StatusCode::FORBIDDEN, self.to_string()),
-            Self::MultipleAuthTags => (StatusCode::FORBIDDEN, self.to_string()),
             Self::UnsupportedContainer => (StatusCode::UNSUPPORTED_MEDIA_TYPE, self.to_string()),
             Self::WrongCodec
             | Self::DurationTooLong

--- a/crates/sprout-media/src/error.rs
+++ b/crates/sprout-media/src/error.rs
@@ -77,6 +77,9 @@ pub enum MediaError {
     /// I/O error during streaming upload.
     #[error("io error: {0}")]
     Io(String),
+    /// Event contains more than one `auth` tag — NIP-AA requires exactly one.
+    #[error("multiple auth tags: NIP-AA requires exactly one auth tag")]
+    MultipleAuthTags,
 }
 
 impl From<image::ImageError> for MediaError {
@@ -133,6 +136,7 @@ impl IntoResponse for MediaError {
             }
             Self::InsufficientScope => (StatusCode::FORBIDDEN, self.to_string()),
             Self::RelayMembershipRequired => (StatusCode::FORBIDDEN, self.to_string()),
+            Self::MultipleAuthTags => (StatusCode::FORBIDDEN, self.to_string()),
             Self::UnsupportedContainer => (StatusCode::UNSUPPORTED_MEDIA_TYPE, self.to_string()),
             Self::WrongCodec
             | Self::DurationTooLong

--- a/crates/sprout-relay/Cargo.toml
+++ b/crates/sprout-relay/Cargo.toml
@@ -18,6 +18,7 @@ sprout-auth = { workspace = true }
 sprout-pubsub = { workspace = true }
 sprout-audit = { workspace = true }
 sprout-search = { workspace = true }
+sprout-sdk = { workspace = true }
 axum = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/sprout-relay/src/api/git/transport.rs
+++ b/crates/sprout-relay/src/api/git/transport.rs
@@ -173,14 +173,9 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for GitAuth {
         // Relay membership gate (NIP-43).
         // NIP-AA is a WebSocket-only (NIP-42) mechanism; git HTTP paths use
         // direct membership only.
-        if crate::api::relay_members::enforce_relay_membership(
-            state,
-            &pubkey.serialize(),
-            None,
-            None,
-        )
-        .await
-        .is_err()
+        if crate::api::relay_members::enforce_relay_membership(state, &pubkey.serialize())
+            .await
+            .is_err()
         {
             warn!(pubkey = %pubkey.to_hex(), "git: relay membership denied");
             return Err((StatusCode::FORBIDDEN, "restricted: not a relay member").into_response());

--- a/crates/sprout-relay/src/api/git/transport.rs
+++ b/crates/sprout-relay/src/api/git/transport.rs
@@ -171,9 +171,17 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for GitAuth {
         // replay protection for v1. Per-request signing requires protocol changes.
 
         // Relay membership gate (NIP-43).
-        if crate::api::relay_members::enforce_relay_membership(state, &pubkey.serialize())
-            .await
-            .is_err()
+        // Extract NIP-OA auth tag for NIP-AA if present.
+        let auth_tag_json = extract_auth_tag_from_event_json(&event_json);
+        let nip98_created_at = extract_created_at_from_event_json(&event_json);
+        if crate::api::relay_members::enforce_relay_membership(
+            state,
+            &pubkey.serialize(),
+            auth_tag_json.as_deref(),
+            nip98_created_at,
+        )
+        .await
+        .is_err()
         {
             warn!(pubkey = %pubkey.to_hex(), "git: relay membership denied");
             return Err((StatusCode::FORBIDDEN, "restricted: not a relay member").into_response());
@@ -741,6 +749,37 @@ async fn publish_ref_state(
     }
 
     Ok(())
+}
+
+// ── NIP-AA helpers ────────────────────────────────────────────────────────────
+
+/// Extract the NIP-OA auth tag JSON from a raw event JSON string.
+///
+/// Returns `Some(tag_json)` only when exactly one `auth` tag is present.
+/// Zero or multiple auth tags return `None` (ambiguous or absent).
+fn extract_auth_tag_from_event_json(event_json: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(event_json).ok()?;
+    let tags = v.get("tags")?.as_array()?;
+    let auth_tags: Vec<&serde_json::Value> = tags
+        .iter()
+        .filter(|t| {
+            t.as_array()
+                .and_then(|a| a.first())
+                .and_then(|v| v.as_str())
+                == Some("auth")
+        })
+        .collect();
+    if auth_tags.len() == 1 {
+        Some(auth_tags[0].to_string())
+    } else {
+        None // Zero or multiple auth tags — ambiguous
+    }
+}
+
+/// Extract the `created_at` timestamp from a raw event JSON string.
+fn extract_created_at_from_event_json(event_json: &str) -> Option<u64> {
+    let v: serde_json::Value = serde_json::from_str(event_json).ok()?;
+    v.get("created_at")?.as_u64()
 }
 
 // ── Router Builder ───────────────────────────────────────────────────────────

--- a/crates/sprout-relay/src/api/git/transport.rs
+++ b/crates/sprout-relay/src/api/git/transport.rs
@@ -172,7 +172,14 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for GitAuth {
 
         // Relay membership gate (NIP-43).
         // Extract NIP-OA auth tag for NIP-AA if present.
-        let auth_tag_json = extract_auth_tag_from_event_json(&event_json);
+        // Multiple auth tags are malformed — reject with 403.
+        let auth_tag_json = match extract_auth_tag_from_event_json(&event_json) {
+            Ok(tag) => tag,
+            Err(_) => {
+                warn!(pubkey = %pubkey.to_hex(), "git: multiple auth tags in NIP-98 event");
+                return Err((StatusCode::FORBIDDEN, "invalid: multiple auth tags").into_response());
+            }
+        };
         let nip98_created_at = extract_created_at_from_event_json(&event_json);
         if crate::api::relay_members::enforce_relay_membership(
             state,
@@ -755,11 +762,18 @@ async fn publish_ref_state(
 
 /// Extract the NIP-OA auth tag JSON from a raw event JSON string.
 ///
-/// Returns `Some(tag_json)` only when exactly one `auth` tag is present.
-/// Zero or multiple auth tags return `None` (ambiguous or absent).
-fn extract_auth_tag_from_event_json(event_json: &str) -> Option<String> {
-    let v: serde_json::Value = serde_json::from_str(event_json).ok()?;
-    let tags = v.get("tags")?.as_array()?;
+/// Returns:
+/// - `Ok(Some(tag_json))` — exactly one `auth` tag present
+/// - `Ok(None)`           — zero `auth` tags (not a NIP-AA attempt)
+/// - `Err(reason)`        — multiple `auth` tags (malformed; caller must reject)
+fn extract_auth_tag_from_event_json(event_json: &str) -> Result<Option<String>, String> {
+    let v: serde_json::Value = match serde_json::from_str(event_json) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let Some(tags) = v.get("tags").and_then(|t| t.as_array()) else {
+        return Ok(None);
+    };
     let auth_tags: Vec<&serde_json::Value> = tags
         .iter()
         .filter(|t| {
@@ -769,10 +783,10 @@ fn extract_auth_tag_from_event_json(event_json: &str) -> Option<String> {
                 == Some("auth")
         })
         .collect();
-    if auth_tags.len() == 1 {
-        Some(auth_tags[0].to_string())
-    } else {
-        None // Zero or multiple auth tags — ambiguous
+    match auth_tags.len() {
+        0 => Ok(None),
+        1 => Ok(Some(auth_tags[0].to_string())),
+        _ => Err("multiple auth tags".to_string()),
     }
 }
 

--- a/crates/sprout-relay/src/api/git/transport.rs
+++ b/crates/sprout-relay/src/api/git/transport.rs
@@ -171,21 +171,13 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for GitAuth {
         // replay protection for v1. Per-request signing requires protocol changes.
 
         // Relay membership gate (NIP-43).
-        // Extract NIP-OA auth tag for NIP-AA if present.
-        // Multiple auth tags are malformed — reject with 403.
-        let auth_tag_json = match extract_auth_tag_from_event_json(&event_json) {
-            Ok(tag) => tag,
-            Err(_) => {
-                warn!(pubkey = %pubkey.to_hex(), "git: multiple auth tags in NIP-98 event");
-                return Err((StatusCode::FORBIDDEN, "invalid: multiple auth tags").into_response());
-            }
-        };
-        let nip98_created_at = extract_created_at_from_event_json(&event_json);
+        // NIP-AA is a WebSocket-only (NIP-42) mechanism; git HTTP paths use
+        // direct membership only.
         if crate::api::relay_members::enforce_relay_membership(
             state,
             &pubkey.serialize(),
-            auth_tag_json.as_deref(),
-            nip98_created_at,
+            None,
+            None,
         )
         .await
         .is_err()
@@ -756,44 +748,6 @@ async fn publish_ref_state(
     }
 
     Ok(())
-}
-
-// ── NIP-AA helpers ────────────────────────────────────────────────────────────
-
-/// Extract the NIP-OA auth tag JSON from a raw event JSON string.
-///
-/// Returns:
-/// - `Ok(Some(tag_json))` — exactly one `auth` tag present
-/// - `Ok(None)`           — zero `auth` tags (not a NIP-AA attempt)
-/// - `Err(reason)`        — multiple `auth` tags (malformed; caller must reject)
-fn extract_auth_tag_from_event_json(event_json: &str) -> Result<Option<String>, String> {
-    let v: serde_json::Value = match serde_json::from_str(event_json) {
-        Ok(v) => v,
-        Err(_) => return Ok(None),
-    };
-    let Some(tags) = v.get("tags").and_then(|t| t.as_array()) else {
-        return Ok(None);
-    };
-    let auth_tags: Vec<&serde_json::Value> = tags
-        .iter()
-        .filter(|t| {
-            t.as_array()
-                .and_then(|a| a.first())
-                .and_then(|v| v.as_str())
-                == Some("auth")
-        })
-        .collect();
-    match auth_tags.len() {
-        0 => Ok(None),
-        1 => Ok(Some(auth_tags[0].to_string())),
-        _ => Err("multiple auth tags".to_string()),
-    }
-}
-
-/// Extract the `created_at` timestamp from a raw event JSON string.
-fn extract_created_at_from_event_json(event_json: &str) -> Option<u64> {
-    let v: serde_json::Value = serde_json::from_str(event_json).ok()?;
-    v.get("created_at")?.as_u64()
 }
 
 // ── Router Builder ───────────────────────────────────────────────────────────

--- a/crates/sprout-relay/src/api/media.rs
+++ b/crates/sprout-relay/src/api/media.rs
@@ -87,15 +87,21 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
             .map_err(|_| MediaError::InsufficientScope)?;
 
         // 5. Relay membership gate (NIP-43).
-        // Extract NIP-OA auth tag for NIP-AA if present.
-        let auth_tag_json = auth_event
+        // Extract NIP-OA auth tag for NIP-AA — NIP-AA requires exactly one auth tag.
+        // Zero tags → not a NIP-AA attempt. Multiple tags → malformed, treat as absent.
+        let auth_tags: Vec<_> = auth_event
             .tags
             .iter()
-            .find(|t| {
+            .filter(|t| {
                 let s = t.as_slice();
                 !s.is_empty() && s[0] == "auth"
             })
-            .map(|t| serde_json::to_string(&t.as_slice()).unwrap_or_default());
+            .collect();
+        let auth_tag_json = if auth_tags.len() == 1 {
+            serde_json::to_string(&auth_tags[0].as_slice()).ok()
+        } else {
+            None // Zero or multiple auth tags — NIP-AA requires exactly one
+        };
         let event_created_at = Some(auth_event.created_at.as_u64());
         crate::api::relay_members::enforce_relay_membership(
             state,

--- a/crates/sprout-relay/src/api/media.rs
+++ b/crates/sprout-relay/src/api/media.rs
@@ -89,14 +89,9 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
         // 5. Relay membership gate (NIP-43).
         // NIP-AA is a WebSocket-only (NIP-42) mechanism; Blossom/REST paths use
         // direct membership only.
-        crate::api::relay_members::enforce_relay_membership(
-            state,
-            &auth_event.pubkey.serialize(),
-            None,
-            None,
-        )
-        .await
-        .map_err(|_| MediaError::RelayMembershipRequired)?;
+        crate::api::relay_members::enforce_relay_membership(state, &auth_event.pubkey.serialize())
+            .await
+            .map_err(|_| MediaError::RelayMembershipRequired)?;
 
         Ok(AuthenticatedUpload { auth_event, scopes })
     }

--- a/crates/sprout-relay/src/api/media.rs
+++ b/crates/sprout-relay/src/api/media.rs
@@ -87,30 +87,13 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
             .map_err(|_| MediaError::InsufficientScope)?;
 
         // 5. Relay membership gate (NIP-43).
-        // Extract NIP-OA auth tag for NIP-AA — NIP-AA requires exactly one auth tag.
-        // Zero tags → not a NIP-AA attempt. Multiple tags → malformed, reject with 403.
-        let auth_tags: Vec<_> = auth_event
-            .tags
-            .iter()
-            .filter(|t| {
-                let s = t.as_slice();
-                !s.is_empty() && s[0] == "auth"
-            })
-            .collect();
-        if auth_tags.len() > 1 {
-            return Err(MediaError::MultipleAuthTags);
-        }
-        let auth_tag_json = if auth_tags.len() == 1 {
-            serde_json::to_string(&auth_tags[0].as_slice()).ok()
-        } else {
-            None // Zero auth tags — not a NIP-AA attempt
-        };
-        let event_created_at = Some(auth_event.created_at.as_u64());
+        // NIP-AA is a WebSocket-only (NIP-42) mechanism; Blossom/REST paths use
+        // direct membership only.
         crate::api::relay_members::enforce_relay_membership(
             state,
             &auth_event.pubkey.serialize(),
-            auth_tag_json.as_deref(),
-            event_created_at,
+            None,
+            None,
         )
         .await
         .map_err(|_| MediaError::RelayMembershipRequired)?;

--- a/crates/sprout-relay/src/api/media.rs
+++ b/crates/sprout-relay/src/api/media.rs
@@ -88,7 +88,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
 
         // 5. Relay membership gate (NIP-43).
         // Extract NIP-OA auth tag for NIP-AA — NIP-AA requires exactly one auth tag.
-        // Zero tags → not a NIP-AA attempt. Multiple tags → malformed, treat as absent.
+        // Zero tags → not a NIP-AA attempt. Multiple tags → malformed, reject with 403.
         let auth_tags: Vec<_> = auth_event
             .tags
             .iter()
@@ -97,10 +97,13 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
                 !s.is_empty() && s[0] == "auth"
             })
             .collect();
+        if auth_tags.len() > 1 {
+            return Err(MediaError::MultipleAuthTags);
+        }
         let auth_tag_json = if auth_tags.len() == 1 {
             serde_json::to_string(&auth_tags[0].as_slice()).ok()
         } else {
-            None // Zero or multiple auth tags — NIP-AA requires exactly one
+            None // Zero auth tags — not a NIP-AA attempt
         };
         let event_created_at = Some(auth_event.created_at.as_u64());
         crate::api::relay_members::enforce_relay_membership(

--- a/crates/sprout-relay/src/api/media.rs
+++ b/crates/sprout-relay/src/api/media.rs
@@ -87,9 +87,24 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
             .map_err(|_| MediaError::InsufficientScope)?;
 
         // 5. Relay membership gate (NIP-43).
-        crate::api::relay_members::enforce_relay_membership(state, &auth_event.pubkey.serialize())
-            .await
-            .map_err(|_| MediaError::RelayMembershipRequired)?;
+        // Extract NIP-OA auth tag for NIP-AA if present.
+        let auth_tag_json = auth_event
+            .tags
+            .iter()
+            .find(|t| {
+                let s = t.as_slice();
+                !s.is_empty() && s[0] == "auth"
+            })
+            .map(|t| serde_json::to_string(&t.as_slice()).unwrap_or_default());
+        let event_created_at = Some(auth_event.created_at.as_u64());
+        crate::api::relay_members::enforce_relay_membership(
+            state,
+            &auth_event.pubkey.serialize(),
+            auth_tag_json.as_deref(),
+            event_created_at,
+        )
+        .await
+        .map_err(|_| MediaError::RelayMembershipRequired)?;
 
         Ok(AuthenticatedUpload { auth_event, scopes })
     }

--- a/crates/sprout-relay/src/api/mod.rs
+++ b/crates/sprout-relay/src/api/mod.rs
@@ -157,7 +157,7 @@ pub(crate) async fn extract_auth_context(
     state: &AppState,
 ) -> Result<RestAuthContext, (StatusCode, Json<serde_json::Value>)> {
     let ctx = extract_auth_context_inner(headers, state).await?;
-    relay_members::enforce_relay_membership(state, &ctx.pubkey_bytes, None, None).await?;
+    relay_members::enforce_relay_membership(state, &ctx.pubkey_bytes).await?;
     Ok(ctx)
 }
 

--- a/crates/sprout-relay/src/api/mod.rs
+++ b/crates/sprout-relay/src/api/mod.rs
@@ -157,7 +157,7 @@ pub(crate) async fn extract_auth_context(
     state: &AppState,
 ) -> Result<RestAuthContext, (StatusCode, Json<serde_json::Value>)> {
     let ctx = extract_auth_context_inner(headers, state).await?;
-    relay_members::enforce_relay_membership(state, &ctx.pubkey_bytes).await?;
+    relay_members::enforce_relay_membership(state, &ctx.pubkey_bytes, None, None).await?;
     Ok(ctx)
 }
 

--- a/crates/sprout-relay/src/api/relay_members.rs
+++ b/crates/sprout-relay/src/api/relay_members.rs
@@ -104,7 +104,7 @@ pub async fn enforce_relay_membership(
             .map_err(|e| internal_error(&format!("owner membership check failed: {e}")))?;
 
         if owner_is_member {
-            tracing::debug!(
+            tracing::info!(
                 agent = %pubkey_hex,
                 owner = %owner_hex,
                 "NIP-AA: virtual membership granted (REST)"

--- a/crates/sprout-relay/src/api/relay_members.rs
+++ b/crates/sprout-relay/src/api/relay_members.rs
@@ -23,19 +23,30 @@ use crate::state::AppState;
 
 // ── Enforcement ───────────────────────────────────────────────────────────────
 
-/// Enforce relay membership for a pubkey.
+/// Enforce relay membership for a pubkey, with optional NIP-AA fallback.
 ///
-/// - If `config.require_relay_membership` is false → always Ok (no-op).
-/// - If enabled → checks `relay_members` table. Returns 403 if not a member.
+/// - If `config.require_relay_membership` is false → always `Ok(None)` (no-op).
+/// - If enabled → checks `relay_members` table.
+///   - Direct member → `Ok(None)`.
+///   - Not a direct member and `auth_tag_json` + `event_created_at` provided →
+///     attempts NIP-AA: verifies the auth tag, checks `created_at` conditions,
+///     and confirms the owner is a relay member. Returns `Ok(Some(owner_pubkey))`
+///     on success.
+///   - Otherwise → `Err(403)`.
 ///
 /// `pubkey_bytes` is the 32-byte compressed pubkey; it is hex-encoded before
 /// the DB lookup (the `relay_members` table stores 64-char hex strings).
+///
+/// `auth_tag_json` is the JSON-serialised NIP-OA `auth` tag array (e.g.
+/// `["auth","<owner_hex>","<conditions>","<sig>"]`). Pass `None` to skip NIP-AA.
 pub async fn enforce_relay_membership(
     state: &AppState,
     pubkey_bytes: &[u8],
-) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    auth_tag_json: Option<&str>,
+    event_created_at: Option<u64>,
+) -> Result<Option<nostr::PublicKey>, (StatusCode, Json<serde_json::Value>)> {
     if !state.config.require_relay_membership {
-        return Ok(());
+        return Ok(None);
     }
 
     let pubkey_hex = hex::encode(pubkey_bytes);
@@ -46,16 +57,112 @@ pub async fn enforce_relay_membership(
         .map_err(|e| internal_error(&format!("relay membership check failed: {e}")))?;
 
     if is_member {
-        Ok(())
-    } else {
-        Err((
+        return Ok(None);
+    }
+
+    // Not a direct member — attempt NIP-AA if an auth tag was supplied.
+    if let (Some(tag_json), Some(created_at)) = (auth_tag_json, event_created_at) {
+        let agent_pubkey = nostr::PublicKey::from_slice(pubkey_bytes)
+            .map_err(|e| internal_error(&format!("invalid agent pubkey bytes: {e}")))?;
+
+        // Step 4: Verify the auth tag cryptographically.
+        let owner_pubkey =
+            sprout_sdk::nip_oa::verify_auth_tag(tag_json, &agent_pubkey).map_err(|e| {
+                (
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!({
+                        "error": "nip_aa_invalid",
+                        "message": format!("restricted: invalid auth tag: {e}")
+                    })),
+                )
+            })?;
+
+        // Step 4b: Evaluate created_at conditions embedded in the tag.
+        // Parse the tag array to extract the conditions string (element [2]).
+        let tag_arr: serde_json::Value = serde_json::from_str(tag_json)
+            .map_err(|e| internal_error(&format!("failed to parse auth tag JSON: {e}")))?;
+        if let Some(conditions) = tag_arr.get(2).and_then(|v| v.as_str()) {
+            if !conditions.is_empty() {
+                evaluate_rest_created_at_conditions(conditions, created_at).map_err(|reason| {
+                    (
+                        StatusCode::FORBIDDEN,
+                        Json(serde_json::json!({
+                            "error": "nip_aa_condition_failed",
+                            "message": format!("restricted: {reason}")
+                        })),
+                    )
+                })?;
+            }
+        }
+
+        // Step 5: Check the owner is an active relay member.
+        let owner_hex = owner_pubkey.to_hex();
+        let owner_is_member = state
+            .db
+            .is_relay_member(&owner_hex)
+            .await
+            .map_err(|e| internal_error(&format!("owner membership check failed: {e}")))?;
+
+        if owner_is_member {
+            tracing::debug!(
+                agent = %pubkey_hex,
+                owner = %owner_hex,
+                "NIP-AA: virtual membership granted (REST)"
+            );
+            return Ok(Some(owner_pubkey));
+        }
+
+        return Err((
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({
-                "error": "relay_membership_required",
-                "message": "You must be a relay member to access this relay"
+                "error": "nip_aa_owner_not_member",
+                "message": "restricted: owner is not a relay member"
             })),
-        ))
+        ));
     }
+
+    Err((
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({
+            "error": "relay_membership_required",
+            "message": "You must be a relay member to access this relay"
+        })),
+    ))
+}
+
+/// Evaluate `created_at<t` and `created_at>t` conditions for REST NIP-AA checks.
+/// Returns `Ok(())` if all conditions pass, `Err(reason)` if any fail.
+/// `kind=` conditions are intentionally skipped per NIP-AA spec.
+fn evaluate_rest_created_at_conditions(
+    conditions: &str,
+    event_created_at: u64,
+) -> Result<(), String> {
+    for clause in conditions.split('&') {
+        if clause.is_empty() {
+            continue;
+        }
+        if let Some(val_str) = clause.strip_prefix("created_at<") {
+            let threshold: u64 = val_str
+                .parse()
+                .map_err(|_| format!("malformed created_at< condition: {clause}"))?;
+            if event_created_at >= threshold {
+                return Err(format!(
+                    "created_at condition not satisfied: {event_created_at} >= {threshold}"
+                ));
+            }
+        } else if let Some(val_str) = clause.strip_prefix("created_at>") {
+            let threshold: u64 = val_str
+                .parse()
+                .map_err(|_| format!("malformed created_at> condition: {clause}"))?;
+            if event_created_at <= threshold {
+                return Err(format!(
+                    "created_at condition not satisfied: {event_created_at} <= {threshold}"
+                ));
+            }
+        }
+        // kind= clauses are intentionally skipped at admission per NIP-AA §Kind Conditions
+    }
+    Ok(())
 }
 
 // ── REST read handlers ────────────────────────────────────────────────────────

--- a/crates/sprout-relay/src/api/relay_members.rs
+++ b/crates/sprout-relay/src/api/relay_members.rs
@@ -65,6 +65,41 @@ pub async fn enforce_relay_membership(
         let agent_pubkey = nostr::PublicKey::from_slice(pubkey_bytes)
             .map_err(|e| internal_error(&format!("invalid agent pubkey bytes: {e}")))?;
 
+        // Step 4: Pre-validate lowercase hex requirements before calling verify_auth_tag.
+        // NIP-OA requires 64-char lowercase hex owner pubkey and 128-char lowercase hex sig.
+        // secp256k1's from_hex accepts uppercase, so we enforce the spec constraint here.
+        {
+            let tag_arr: serde_json::Value = serde_json::from_str(tag_json)
+                .map_err(|e| internal_error(&format!("failed to parse auth tag JSON: {e}")))?;
+            if let (Some(owner_hex), Some(sig_hex)) = (
+                tag_arr.get(1).and_then(|v| v.as_str()),
+                tag_arr.get(3).and_then(|v| v.as_str()),
+            ) {
+                let is_lowercase_hex = |s: &str| {
+                    s.chars()
+                        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+                };
+                if owner_hex.len() != 64 || !is_lowercase_hex(owner_hex) {
+                    return Err((
+                        StatusCode::FORBIDDEN,
+                        Json(serde_json::json!({
+                            "error": "nip_aa_invalid",
+                            "message": "restricted: owner pubkey must be 64 lowercase hex chars"
+                        })),
+                    ));
+                }
+                if sig_hex.len() != 128 || !is_lowercase_hex(sig_hex) {
+                    return Err((
+                        StatusCode::FORBIDDEN,
+                        Json(serde_json::json!({
+                            "error": "nip_aa_invalid",
+                            "message": "restricted: signature must be 128 lowercase hex chars"
+                        })),
+                    ));
+                }
+            }
+        }
+
         // Step 4: Verify the auth tag cryptographically.
         let owner_pubkey =
             sprout_sdk::nip_oa::verify_auth_tag(tag_json, &agent_pubkey).map_err(|e| {

--- a/crates/sprout-relay/src/api/relay_members.rs
+++ b/crates/sprout-relay/src/api/relay_members.rs
@@ -1,8 +1,10 @@
 //! Relay membership enforcement and read endpoints.
 //!
 //! ## Enforcement
-//! [`enforce_relay_membership`] is the single gate — called at every authenticated
-//! entry point. When `require_relay_membership` is disabled, it's a no-op.
+//! [`enforce_relay_membership`] is the single gate for REST paths — called at every
+//! authenticated REST entry point. When `require_relay_membership` is disabled, it's
+//! a no-op. NIP-AA (WebSocket/NIP-42 only) is handled exclusively in
+//! `handlers::auth` via `enforce_ws_relay_membership`.
 //!
 //! ## Routes
 //! - `GET /api/relay/members`    — list all relay members (any authenticated member)
@@ -23,41 +25,28 @@ use crate::state::AppState;
 
 // ── Enforcement ───────────────────────────────────────────────────────────────
 
-/// Enforce relay membership for a pubkey, with optional NIP-AA fallback.
+/// Enforce relay membership for a pubkey on REST paths.
 ///
-/// - If `config.require_relay_membership` is false → always `Ok(None)` (no-op).
+/// - If `config.require_relay_membership` is false → always `Ok(())` (no-op).
 /// - If enabled → checks `relay_members` table.
-///   - Direct member → `Ok(None)`.
-///   - Not a direct member and `auth_tag_json` + `event_created_at` provided →
-///     attempts NIP-AA: verifies the auth tag, checks `created_at` conditions,
-///     and confirms the owner is a relay member. Returns `Ok(Some(owner_pubkey))`
-///     on success.
-///   - Otherwise → `Err(403)`.
+///   - Direct member → `Ok(())`.
+///   - Not a direct member → `Err(403)`.
 ///
 /// `pubkey_bytes` is the 32-byte compressed pubkey; it is hex-encoded before
 /// the DB lookup (the `relay_members` table stores 64-char hex strings).
 ///
-/// `auth_tag_json` is the JSON-serialised NIP-OA `auth` tag array (e.g.
-/// `["auth","<owner_hex>","<conditions>","<sig>"]`). Pass `None` to skip NIP-AA.
+/// # NIP-AA is WebSocket-only
 ///
-/// # NIP-AA callers MUST pre-verify the NIP-42 AUTH event
-///
-/// This function only performs NIP-OA credential verification (Steps 3–5 of
-/// NIP-AA). It does NOT verify the NIP-42 `kind:22242` event signature,
-/// challenge binding, relay URL, or freshness window (Step 1). Callers that
-/// pass `auth_tag_json` MUST have already verified the enclosing NIP-42 AUTH
-/// event before calling this function, or they bypass NIP-AA Step 1 entirely.
-///
-/// REST paths (NIP-98, Blossom, git HTTP) MUST pass `None` — NIP-AA is
-/// defined only for NIP-42 WebSocket AUTH flows.
+/// NIP-AA (NIP-42 agent auth) is handled exclusively in `handlers::auth` via
+/// `enforce_ws_relay_membership`. REST paths (NIP-98, Blossom, git HTTP) perform
+/// direct membership checks only — never NIP-AA. Passing NIP-AA credentials to
+/// a REST endpoint is a client error.
 pub async fn enforce_relay_membership(
     state: &AppState,
     pubkey_bytes: &[u8],
-    auth_tag_json: Option<&str>,
-    event_created_at: Option<u64>,
-) -> Result<Option<nostr::PublicKey>, (StatusCode, Json<serde_json::Value>)> {
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
     if !state.config.require_relay_membership {
-        return Ok(None);
+        return Ok(());
     }
 
     let pubkey_hex = hex::encode(pubkey_bytes);
@@ -68,103 +57,7 @@ pub async fn enforce_relay_membership(
         .map_err(|e| internal_error(&format!("relay membership check failed: {e}")))?;
 
     if is_member {
-        return Ok(None);
-    }
-
-    // Not a direct member — attempt NIP-AA if an auth tag was supplied.
-    if let (Some(tag_json), Some(created_at)) = (auth_tag_json, event_created_at) {
-        let agent_pubkey = nostr::PublicKey::from_slice(pubkey_bytes)
-            .map_err(|e| internal_error(&format!("invalid agent pubkey bytes: {e}")))?;
-
-        // Step 4: Pre-validate lowercase hex requirements before calling verify_auth_tag.
-        // NIP-OA requires 64-char lowercase hex owner pubkey and 128-char lowercase hex sig.
-        // secp256k1's from_hex accepts uppercase, so we enforce the spec constraint here.
-        {
-            let tag_arr: serde_json::Value = serde_json::from_str(tag_json)
-                .map_err(|e| internal_error(&format!("failed to parse auth tag JSON: {e}")))?;
-            if let (Some(owner_hex), Some(sig_hex)) = (
-                tag_arr.get(1).and_then(|v| v.as_str()),
-                tag_arr.get(3).and_then(|v| v.as_str()),
-            ) {
-                let is_lowercase_hex = |s: &str| {
-                    s.chars()
-                        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
-                };
-                if owner_hex.len() != 64 || !is_lowercase_hex(owner_hex) {
-                    return Err((
-                        StatusCode::FORBIDDEN,
-                        Json(serde_json::json!({
-                            "error": "nip_aa_invalid",
-                            "message": "restricted: owner pubkey must be 64 lowercase hex chars"
-                        })),
-                    ));
-                }
-                if sig_hex.len() != 128 || !is_lowercase_hex(sig_hex) {
-                    return Err((
-                        StatusCode::FORBIDDEN,
-                        Json(serde_json::json!({
-                            "error": "nip_aa_invalid",
-                            "message": "restricted: signature must be 128 lowercase hex chars"
-                        })),
-                    ));
-                }
-            }
-        }
-
-        // Step 4: Verify the auth tag cryptographically.
-        let owner_pubkey =
-            sprout_sdk::nip_oa::verify_auth_tag(tag_json, &agent_pubkey).map_err(|e| {
-                (
-                    StatusCode::FORBIDDEN,
-                    Json(serde_json::json!({
-                        "error": "nip_aa_invalid",
-                        "message": format!("restricted: invalid auth tag: {e}")
-                    })),
-                )
-            })?;
-
-        // Step 4b: Evaluate created_at conditions embedded in the tag.
-        // Parse the tag array to extract the conditions string (element [2]).
-        let tag_arr: serde_json::Value = serde_json::from_str(tag_json)
-            .map_err(|e| internal_error(&format!("failed to parse auth tag JSON: {e}")))?;
-        if let Some(conditions) = tag_arr.get(2).and_then(|v| v.as_str()) {
-            if !conditions.is_empty() {
-                evaluate_rest_created_at_conditions(conditions, created_at).map_err(|reason| {
-                    (
-                        StatusCode::FORBIDDEN,
-                        Json(serde_json::json!({
-                            "error": "nip_aa_condition_failed",
-                            "message": format!("restricted: {reason}")
-                        })),
-                    )
-                })?;
-            }
-        }
-
-        // Step 5: Check the owner is an active relay member.
-        let owner_hex = owner_pubkey.to_hex();
-        let owner_is_member = state
-            .db
-            .is_relay_member(&owner_hex)
-            .await
-            .map_err(|e| internal_error(&format!("owner membership check failed: {e}")))?;
-
-        if owner_is_member {
-            tracing::info!(
-                agent = %pubkey_hex,
-                owner = %owner_hex,
-                "NIP-AA: virtual membership granted (REST)"
-            );
-            return Ok(Some(owner_pubkey));
-        }
-
-        return Err((
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "nip_aa_owner_not_member",
-                "message": "restricted: owner is not a relay member"
-            })),
-        ));
+        return Ok(());
     }
 
     Err((
@@ -174,41 +67,6 @@ pub async fn enforce_relay_membership(
             "message": "You must be a relay member to access this relay"
         })),
     ))
-}
-
-/// Evaluate `created_at<t` and `created_at>t` conditions for REST NIP-AA checks.
-/// Returns `Ok(())` if all conditions pass, `Err(reason)` if any fail.
-/// `kind=` conditions are intentionally skipped per NIP-AA spec.
-fn evaluate_rest_created_at_conditions(
-    conditions: &str,
-    event_created_at: u64,
-) -> Result<(), String> {
-    for clause in conditions.split('&') {
-        if clause.is_empty() {
-            continue;
-        }
-        if let Some(val_str) = clause.strip_prefix("created_at<") {
-            let threshold: u64 = val_str
-                .parse()
-                .map_err(|_| format!("malformed created_at< condition: {clause}"))?;
-            if event_created_at >= threshold {
-                return Err(format!(
-                    "created_at condition not satisfied: {event_created_at} >= {threshold}"
-                ));
-            }
-        } else if let Some(val_str) = clause.strip_prefix("created_at>") {
-            let threshold: u64 = val_str
-                .parse()
-                .map_err(|_| format!("malformed created_at> condition: {clause}"))?;
-            if event_created_at <= threshold {
-                return Err(format!(
-                    "created_at condition not satisfied: {event_created_at} <= {threshold}"
-                ));
-            }
-        }
-        // kind= clauses are intentionally skipped at admission per NIP-AA §Kind Conditions
-    }
-    Ok(())
 }
 
 // ── REST read handlers ────────────────────────────────────────────────────────

--- a/crates/sprout-relay/src/api/relay_members.rs
+++ b/crates/sprout-relay/src/api/relay_members.rs
@@ -39,6 +39,17 @@ use crate::state::AppState;
 ///
 /// `auth_tag_json` is the JSON-serialised NIP-OA `auth` tag array (e.g.
 /// `["auth","<owner_hex>","<conditions>","<sig>"]`). Pass `None` to skip NIP-AA.
+///
+/// # NIP-AA callers MUST pre-verify the NIP-42 AUTH event
+///
+/// This function only performs NIP-OA credential verification (Steps 3–5 of
+/// NIP-AA). It does NOT verify the NIP-42 `kind:22242` event signature,
+/// challenge binding, relay URL, or freshness window (Step 1). Callers that
+/// pass `auth_tag_json` MUST have already verified the enclosing NIP-42 AUTH
+/// event before calling this function, or they bypass NIP-AA Step 1 entirely.
+///
+/// REST paths (NIP-98, Blossom, git HTTP) MUST pass `None` — NIP-AA is
+/// defined only for NIP-42 WebSocket AUTH flows.
 pub async fn enforce_relay_membership(
     state: &AppState,
     pubkey_bytes: &[u8],

--- a/crates/sprout-relay/src/api/tokens.rs
+++ b/crates/sprout-relay/src/api/tokens.rs
@@ -293,7 +293,20 @@ pub async fn post_tokens(
                     // NIP-98 path builds auth context directly — enforce membership here.
                     // Bearer/JWT paths go through extract_auth_context which already checks.
                     // Extract NIP-OA auth tag for NIP-AA if present.
-                    let auth_tag_json = extract_auth_tag_from_event_json(&event_json);
+                    // Multiple auth tags are malformed — reject with 403.
+                    let auth_tag_json = match extract_auth_tag_from_event_json(&event_json) {
+                        Ok(tag) => tag,
+                        Err(_) => {
+                            tracing::warn!("post_tokens: NIP-98 event has multiple auth tags");
+                            return Err((
+                                StatusCode::FORBIDDEN,
+                                Json(serde_json::json!({
+                                    "error": "invalid_auth",
+                                    "message": "NIP-98 event must not contain multiple auth tags"
+                                })),
+                            ));
+                        }
+                    };
                     let nip98_created_at = extract_created_at_from_event_json(&event_json);
                     let _owner = super::relay_members::enforce_relay_membership(
                         &state,
@@ -827,11 +840,18 @@ pub async fn delete_all_tokens(
 
 /// Extract the NIP-OA auth tag JSON from a raw event JSON string.
 ///
-/// Returns `Some(tag_json)` only when exactly one `auth` tag is present.
-/// Zero or multiple auth tags return `None` (ambiguous or absent).
-fn extract_auth_tag_from_event_json(event_json: &str) -> Option<String> {
-    let v: serde_json::Value = serde_json::from_str(event_json).ok()?;
-    let tags = v.get("tags")?.as_array()?;
+/// Returns:
+/// - `Ok(Some(tag_json))` — exactly one `auth` tag present
+/// - `Ok(None)`           — zero `auth` tags (not a NIP-AA attempt)
+/// - `Err(reason)`        — multiple `auth` tags (malformed; caller must reject)
+fn extract_auth_tag_from_event_json(event_json: &str) -> Result<Option<String>, String> {
+    let v: serde_json::Value = match serde_json::from_str(event_json) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let Some(tags) = v.get("tags").and_then(|t| t.as_array()) else {
+        return Ok(None);
+    };
     let auth_tags: Vec<&serde_json::Value> = tags
         .iter()
         .filter(|t| {
@@ -841,10 +861,10 @@ fn extract_auth_tag_from_event_json(event_json: &str) -> Option<String> {
                 == Some("auth")
         })
         .collect();
-    if auth_tags.len() == 1 {
-        Some(auth_tags[0].to_string())
-    } else {
-        None // Zero or multiple auth tags — ambiguous
+    match auth_tags.len() {
+        0 => Ok(None),
+        1 => Ok(Some(auth_tags[0].to_string())),
+        _ => Err("multiple auth tags".to_string()),
     }
 }
 

--- a/crates/sprout-relay/src/api/tokens.rs
+++ b/crates/sprout-relay/src/api/tokens.rs
@@ -294,13 +294,7 @@ pub async fn post_tokens(
                     // Bearer/JWT paths go through extract_auth_context which already checks.
                     // NIP-AA is a WebSocket-only (NIP-42) mechanism; REST paths use direct
                     // membership only.
-                    super::relay_members::enforce_relay_membership(
-                        &state,
-                        &pubkey_bytes,
-                        None,
-                        None,
-                    )
-                    .await?;
+                    super::relay_members::enforce_relay_membership(&state, &pubkey_bytes).await?;
                     super::RestAuthContext {
                         pubkey,
                         pubkey_bytes,

--- a/crates/sprout-relay/src/api/tokens.rs
+++ b/crates/sprout-relay/src/api/tokens.rs
@@ -292,7 +292,16 @@ pub async fn post_tokens(
                     }
                     // NIP-98 path builds auth context directly — enforce membership here.
                     // Bearer/JWT paths go through extract_auth_context which already checks.
-                    super::relay_members::enforce_relay_membership(&state, &pubkey_bytes).await?;
+                    // Extract NIP-OA auth tag for NIP-AA if present.
+                    let auth_tag_json = extract_auth_tag_from_event_json(&event_json);
+                    let nip98_created_at = extract_created_at_from_event_json(&event_json);
+                    let _owner = super::relay_members::enforce_relay_membership(
+                        &state,
+                        &pubkey_bytes,
+                        auth_tag_json.as_deref(),
+                        nip98_created_at,
+                    )
+                    .await?;
                     super::RestAuthContext {
                         pubkey,
                         pubkey_bytes,
@@ -815,6 +824,35 @@ pub async fn delete_all_tokens(
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Extract the NIP-OA auth tag JSON from a raw event JSON string.
+///
+/// Returns `Some(tag_json)` only when exactly one `auth` tag is present.
+/// Zero or multiple auth tags return `None` (ambiguous or absent).
+fn extract_auth_tag_from_event_json(event_json: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(event_json).ok()?;
+    let tags = v.get("tags")?.as_array()?;
+    let auth_tags: Vec<&serde_json::Value> = tags
+        .iter()
+        .filter(|t| {
+            t.as_array()
+                .and_then(|a| a.first())
+                .and_then(|v| v.as_str())
+                == Some("auth")
+        })
+        .collect();
+    if auth_tags.len() == 1 {
+        Some(auth_tags[0].to_string())
+    } else {
+        None // Zero or multiple auth tags — ambiguous
+    }
+}
+
+/// Extract the `created_at` timestamp from a raw event JSON string.
+fn extract_created_at_from_event_json(event_json: &str) -> Option<u64> {
+    let v: serde_json::Value = serde_json::from_str(event_json).ok()?;
+    v.get("created_at")?.as_u64()
+}
 
 /// Derive the canonical token-mint URL from the configured relay identity.
 fn reconstruct_canonical_url_for_tokens(relay_url: &str) -> String {

--- a/crates/sprout-relay/src/api/tokens.rs
+++ b/crates/sprout-relay/src/api/tokens.rs
@@ -292,27 +292,13 @@ pub async fn post_tokens(
                     }
                     // NIP-98 path builds auth context directly — enforce membership here.
                     // Bearer/JWT paths go through extract_auth_context which already checks.
-                    // Extract NIP-OA auth tag for NIP-AA if present.
-                    // Multiple auth tags are malformed — reject with 403.
-                    let auth_tag_json = match extract_auth_tag_from_event_json(&event_json) {
-                        Ok(tag) => tag,
-                        Err(_) => {
-                            tracing::warn!("post_tokens: NIP-98 event has multiple auth tags");
-                            return Err((
-                                StatusCode::FORBIDDEN,
-                                Json(serde_json::json!({
-                                    "error": "invalid_auth",
-                                    "message": "NIP-98 event must not contain multiple auth tags"
-                                })),
-                            ));
-                        }
-                    };
-                    let nip98_created_at = extract_created_at_from_event_json(&event_json);
-                    let _owner = super::relay_members::enforce_relay_membership(
+                    // NIP-AA is a WebSocket-only (NIP-42) mechanism; REST paths use direct
+                    // membership only.
+                    super::relay_members::enforce_relay_membership(
                         &state,
                         &pubkey_bytes,
-                        auth_tag_json.as_deref(),
-                        nip98_created_at,
+                        None,
+                        None,
                     )
                     .await?;
                     super::RestAuthContext {
@@ -837,42 +823,6 @@ pub async fn delete_all_tokens(
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
-
-/// Extract the NIP-OA auth tag JSON from a raw event JSON string.
-///
-/// Returns:
-/// - `Ok(Some(tag_json))` — exactly one `auth` tag present
-/// - `Ok(None)`           — zero `auth` tags (not a NIP-AA attempt)
-/// - `Err(reason)`        — multiple `auth` tags (malformed; caller must reject)
-fn extract_auth_tag_from_event_json(event_json: &str) -> Result<Option<String>, String> {
-    let v: serde_json::Value = match serde_json::from_str(event_json) {
-        Ok(v) => v,
-        Err(_) => return Ok(None),
-    };
-    let Some(tags) = v.get("tags").and_then(|t| t.as_array()) else {
-        return Ok(None);
-    };
-    let auth_tags: Vec<&serde_json::Value> = tags
-        .iter()
-        .filter(|t| {
-            t.as_array()
-                .and_then(|a| a.first())
-                .and_then(|v| v.as_str())
-                == Some("auth")
-        })
-        .collect();
-    match auth_tags.len() {
-        0 => Ok(None),
-        1 => Ok(Some(auth_tags[0].to_string())),
-        _ => Err("multiple auth tags".to_string()),
-    }
-}
-
-/// Extract the `created_at` timestamp from a raw event JSON string.
-fn extract_created_at_from_event_json(event_json: &str) -> Option<u64> {
-    let v: serde_json::Value = serde_json::from_str(event_json).ok()?;
-    v.get("created_at")?.as_u64()
-}
 
 /// Derive the canonical token-mint URL from the configured relay identity.
 fn reconstruct_canonical_url_for_tokens(relay_url: &str) -> String {

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -138,7 +138,7 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 return;
             }
         };
-    let event_created_at = Some(auth_msg.event.created_at.as_u64());
+    let event_created_at = auth_msg.event.created_at.as_u64();
 
     // Extract auth_token tag before the event is consumed — API tokens and
     // Okta JWTs carry an `auth_token` tag; NIP-AA agents do not.
@@ -257,7 +257,7 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 &state,
                 &candidate_pubkey,
                 &event_tags_slice,
-                event_created_at.unwrap_or(0),
+                event_created_at,
             )
             .await;
 
@@ -267,9 +267,9 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                     // verify_nip_aa already confirmed the owner is an active relay member
                     // (Step 5), so the direct membership gate below must be skipped.
                     //
-                    // owner_pubkey is retained for the audio session lifetime for audit
-                    // and future owner-scoped enumeration/termination/quota aggregation.
-                    // TODO(NIP-AA): Wire audio sessions into ConnectionManager for owner-scoped tracking.
+                    // owner_pubkey is persisted in AudioPeer for the full session lifetime
+                    // for audit, quota aggregation, and future owner-scoped
+                    // enumeration/termination (NIP-AA §6).
                     let nip_aa_owner = result.owner_pubkey;
                     tracing::info!(
                         channel_id = %channel_id,
@@ -342,9 +342,9 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     let pubkey_bytes = pubkey.serialize().to_vec();
     let parent_channel_id = auth_msg.parent_channel_id;
 
-    // owner_pubkey is Some for NIP-AA virtual members; available for the full
-    // session lifetime for audit, quota aggregation, and future owner-scoped
-    // ConnectionManager wiring (see TODO above).
+    // owner_pubkey is Some for NIP-AA virtual members; persisted in AudioPeer
+    // for the full session lifetime for audit, quota aggregation, and future
+    // owner-scoped enumeration/termination.
     if let Some(ref owner) = owner_pubkey {
         debug!(
             channel_id = %channel_id,
@@ -417,7 +417,10 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         Ok(_) => {} // Channel exists and is not archived — proceed.
     }
 
-    let (peer_id, peer_index, audio_rx, peer_ctrl_rx) = match room.add_peer(pubkey_hex.clone()) {
+    let (peer_id, peer_index, audio_rx, peer_ctrl_rx) = match room.add_peer(
+        pubkey_hex.clone(),
+        owner_pubkey.as_ref().map(|pk| pk.to_hex()),
+    ) {
         Some(v) => v,
         None => {
             warn!(channel_id = %channel_id, "audio room full (255 peers exhausted)");

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -361,7 +361,7 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         warn!(channel_id = %channel_id, pubkey = %pubkey_hex, "audio: relay membership denied");
         let _ = ws_send
             .send(WsMessage::Text(
-                serde_json::json!({"type": "error", "message": "restricted: not a relay member"})
+                serde_json::json!({"type": "error", "message": "restricted: agent authentication failed"})
                     .to_string()
                     .into(),
             ))

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -117,6 +117,18 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         }
     };
 
+    // Extract NIP-OA auth tag for NIP-AA before the event is consumed.
+    let auth_tag_json = auth_msg
+        .event
+        .tags
+        .iter()
+        .find(|t| {
+            let s = t.as_slice();
+            !s.is_empty() && s[0] == "auth"
+        })
+        .map(|t| serde_json::to_string(&t.as_slice()).unwrap_or_default());
+    let event_created_at = Some(auth_msg.event.created_at.as_u64());
+
     let relay_url = state.config.relay_url.clone();
     let auth_ctx = match state
         .auth
@@ -143,9 +155,14 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     let parent_channel_id = auth_msg.parent_channel_id;
 
     // ── Relay membership gate (NIP-43) ────────────────────────────────────────
-    if crate::api::relay_members::enforce_relay_membership(&state, &pubkey.serialize())
-        .await
-        .is_err()
+    if crate::api::relay_members::enforce_relay_membership(
+        &state,
+        &pubkey.serialize(),
+        auth_tag_json.as_deref(),
+        event_created_at,
+    )
+    .await
+    .is_err()
     {
         warn!(channel_id = %channel_id, pubkey = %pubkey_hex, "audio: relay membership denied");
         let _ = ws_send

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -202,74 +202,111 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
             }
         }
 
-        // Use nip_aa::verify_nip_aa directly — NIP-42 binding already verified above.
-        // This distinguishes NIP-AA virtual members from direct members without
-        // routing through the generic REST membership helper (which is direct-only).
+        // NIP-AA Step 2: check direct membership first. If the agent is already a
+        // direct member, skip NIP-AA entirely and fall through to verify_auth_event.
+        // This matches the main WS auth handler's ordering.
         let candidate_pubkey = auth_msg.event.pubkey;
-        let event_tags_slice: Vec<nostr::Tag> = auth_msg.event.tags.clone().to_vec();
-        let nip_aa_result = crate::handlers::nip_aa::verify_nip_aa(
-            &state,
-            &candidate_pubkey,
-            &event_tags_slice,
-            event_created_at.unwrap_or(0),
-        )
-        .await;
+        let candidate_pubkey_hex = candidate_pubkey.to_hex();
+        let is_direct_member = if state.config.require_relay_membership {
+            state
+                .db
+                .is_relay_member(&candidate_pubkey_hex)
+                .await
+                .unwrap_or(false)
+        } else {
+            true // membership not required — treat as member
+        };
 
-        match nip_aa_result {
-            Ok(Some(result)) => {
-                // NIP-AA virtual member — NIP-42 binding already verified above.
-                // verify_nip_aa already confirmed the owner is an active relay member
-                // (Step 5), so the direct membership gate below must be skipped.
-                //
-                // NIP-AA requires retaining owner_pubkey for owner-scoped session
-                // enumeration, termination, and quota aggregation. The audio handler
-                // does not maintain a persistent AuthContext, so we log the owner
-                // association for audit purposes. Full owner-scoped session tracking
-                // requires wiring audio sessions into the connection manager.
-                tracing::info!(
-                    channel_id = %channel_id,
-                    agent = %candidate_pubkey.to_hex(),
-                    owner = %result.owner_pubkey.to_hex(),
-                    "NIP-AA: audio virtual membership granted"
-                );
-                (candidate_pubkey, true)
+        if is_direct_member {
+            // Direct member with an auth tag — go through verify_auth_event to
+            // enforce token requirements (same as the Ok(None) branch below).
+            let auth_ctx = match state
+                .auth
+                .verify_auth_event(auth_msg.event, &challenge, &relay_url)
+                .await
+            {
+                Ok(ctx) => ctx,
+                Err(e) => {
+                    warn!(channel_id = %channel_id, "audio auth failed for direct member: {e}");
+                    let _ = ws_send
+                        .send(WsMessage::Text(
+                            serde_json::json!({"type":"error","message":"auth failed"})
+                                .to_string()
+                                .into(),
+                        ))
+                        .await;
+                    return;
+                }
+            };
+            // Direct member — not a NIP-AA virtual member.
+            (auth_ctx.pubkey, false)
+        } else {
+            // Not a direct member — attempt NIP-AA (Steps 3-5).
+            let event_tags_slice: Vec<nostr::Tag> = auth_msg.event.tags.clone().to_vec();
+            let nip_aa_result = crate::handlers::nip_aa::verify_nip_aa(
+                &state,
+                &candidate_pubkey,
+                &event_tags_slice,
+                event_created_at.unwrap_or(0),
+            )
+            .await;
+
+            match nip_aa_result {
+                Ok(Some(result)) => {
+                    // NIP-AA virtual member — NIP-42 binding already verified above.
+                    // verify_nip_aa already confirmed the owner is an active relay member
+                    // (Step 5), so the direct membership gate below must be skipped.
+                    //
+                    // NIP-AA requires retaining owner_pubkey for owner-scoped session
+                    // enumeration, termination, and quota aggregation. The audio handler
+                    // does not maintain a persistent AuthContext, so we log the owner
+                    // association for audit purposes. Full owner-scoped session tracking
+                    // requires wiring audio sessions into the connection manager.
+                    tracing::info!(
+                        channel_id = %channel_id,
+                        agent = %candidate_pubkey.to_hex(),
+                        owner = %result.owner_pubkey.to_hex(),
+                        "NIP-AA: audio virtual membership granted"
+                    );
+                    (candidate_pubkey, true)
+                }
+                Ok(None) => {
+                    // No auth tag (or direct member) — must go through verify_auth_event
+                    // to enforce token requirements.
+                    let auth_ctx = match state
+                        .auth
+                        .verify_auth_event(auth_msg.event, &challenge, &relay_url)
+                        .await
+                    {
+                        Ok(ctx) => ctx,
+                        Err(e) => {
+                            warn!(channel_id = %channel_id, "audio auth failed for direct member: {e}");
+                            let _ = ws_send
+                                .send(WsMessage::Text(
+                                    serde_json::json!({"type":"error","message":"auth failed"})
+                                        .to_string()
+                                        .into(),
+                                ))
+                                .await;
+                            return;
+                        }
+                    };
+                    (auth_ctx.pubkey, false)
+                }
+                Err(reason) => {
+                    // Auth tag present but invalid, or owner not a member — deny.
+                    warn!(channel_id = %candidate_pubkey.to_hex(), reason = %reason, "audio NIP-AA: denied");
+                    let _ = ws_send
+                        .send(WsMessage::Text(
+                            serde_json::json!({"type": "error", "message": reason})
+                                .to_string()
+                                .into(),
+                        ))
+                        .await;
+                    return;
+                }
             }
-            Ok(None) => {
-                // No auth tag (or direct member) — must go through verify_auth_event
-                // to enforce token requirements.
-                let auth_ctx = match state
-                    .auth
-                    .verify_auth_event(auth_msg.event, &challenge, &relay_url)
-                    .await
-                {
-                    Ok(ctx) => ctx,
-                    Err(e) => {
-                        warn!(channel_id = %channel_id, "audio auth failed for direct member: {e}");
-                        let _ = ws_send
-                            .send(WsMessage::Text(
-                                serde_json::json!({"type":"error","message":"auth failed"})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                        return;
-                    }
-                };
-                (auth_ctx.pubkey, false)
-            }
-            Err(reason) => {
-                // Auth tag present but invalid, or owner not a member — deny.
-                warn!(channel_id = %channel_id, pubkey = %candidate_pubkey.to_hex(), reason = %reason, "audio NIP-AA: denied");
-                let _ = ws_send
-                    .send(WsMessage::Text(
-                        serde_json::json!({"type": "error", "message": reason})
-                            .to_string()
-                            .into(),
-                    ))
-                    .await;
-                return;
-            }
-        }
+        } // close else { // Not a direct member — attempt NIP-AA
     } else {
         // ── Standard auth path (Okta JWT / API token / pubkey-only) ─────────
         let auth_ctx = match state

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -137,27 +137,79 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     };
     let event_created_at = Some(auth_msg.event.created_at.as_u64());
 
-    let relay_url = state.config.relay_url.clone();
-    let auth_ctx = match state
-        .auth
-        .verify_auth_event(auth_msg.event, &challenge, &relay_url)
-        .await
-    {
-        Ok(ctx) => ctx,
-        Err(e) => {
-            warn!(channel_id = %channel_id, "audio auth failed: {e}");
-            let _ = ws_send
-                .send(WsMessage::Text(
-                    serde_json::json!({"type":"error","message":"auth failed"})
-                        .to_string()
-                        .into(),
-                ))
-                .await;
-            return;
+    // Extract auth_token tag before the event is consumed — API tokens and
+    // Okta JWTs carry an `auth_token` tag; NIP-AA agents do not.
+    let audio_auth_token = auth_msg.event.tags.iter().find_map(|tag| {
+        let v = tag.as_slice();
+        if v.len() >= 2 && v[0] == "auth_token" {
+            Some(v[1].to_string())
+        } else {
+            None
         }
-    };
+    });
 
-    let pubkey = auth_ctx.pubkey;
+    let relay_url = state.config.relay_url.clone();
+
+    // ── NIP-AA agent auth path ───────────────────────────────────────────────
+    // If there is no auth_token but there IS a NIP-OA auth tag, this is an
+    // agent using NIP-AA. Bypass verify_auth_event (which requires a token in
+    // production mode) and do NIP-42 binding verification directly.
+    let pubkey = if audio_auth_token.is_none() && auth_tag_json.is_some() {
+        let event_for_verify = auth_msg.event.clone();
+        let challenge_owned = challenge.clone();
+        let relay_owned = relay_url.clone();
+        match tokio::task::spawn_blocking(move || {
+            sprout_auth::verify_nip42_event(&event_for_verify, &challenge_owned, &relay_owned)
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!(channel_id = %channel_id, "audio NIP-AA: NIP-42 binding failed: {e}");
+                let _ = ws_send
+                    .send(WsMessage::Text(
+                        serde_json::json!({"type":"error","message":"auth failed"})
+                            .to_string()
+                            .into(),
+                    ))
+                    .await;
+                return;
+            }
+            Err(e) => {
+                warn!(channel_id = %channel_id, "audio NIP-AA: NIP-42 verify task panicked: {e}");
+                let _ = ws_send
+                    .send(WsMessage::Text(
+                        serde_json::json!({"type":"error","message":"auth failed"})
+                            .to_string()
+                            .into(),
+                    ))
+                    .await;
+                return;
+            }
+        }
+        auth_msg.event.pubkey
+    } else {
+        // ── Standard auth path (Okta JWT / API token / pubkey-only) ─────────
+        let auth_ctx = match state
+            .auth
+            .verify_auth_event(auth_msg.event, &challenge, &relay_url)
+            .await
+        {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                warn!(channel_id = %channel_id, "audio auth failed: {e}");
+                let _ = ws_send
+                    .send(WsMessage::Text(
+                        serde_json::json!({"type":"error","message":"auth failed"})
+                            .to_string()
+                            .into(),
+                    ))
+                    .await;
+                return;
+            }
+        };
+        auth_ctx.pubkey
+    };
     let pubkey_hex = pubkey.to_hex();
     let pubkey_bytes = pubkey.serialize().to_vec();
     let parent_channel_id = auth_msg.parent_channel_id;

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -119,8 +119,7 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
 
     // Extract NIP-OA auth tag for NIP-AA before the event is consumed.
     // NIP-AA requires exactly one auth tag — zero means not a NIP-AA attempt,
-    // multiple means malformed (treat as absent so membership check falls through
-    // to the standard path rather than silently picking an arbitrary tag).
+    // multiple means malformed — reject with an explicit error.
     let auth_tags: Vec<_> = auth_msg
         .event
         .tags
@@ -130,10 +129,21 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
             !s.is_empty() && s[0] == "auth"
         })
         .collect();
+    if auth_tags.len() > 1 {
+        warn!(channel_id = %channel_id, "audio: multiple auth tags in NIP-42 event");
+        let _ = ws_send
+            .send(WsMessage::Text(
+                serde_json::json!({"type": "error", "message": "invalid: multiple auth tags"})
+                    .to_string()
+                    .into(),
+            ))
+            .await;
+        return;
+    }
     let auth_tag_json = if auth_tags.len() == 1 {
         serde_json::to_string(&auth_tags[0].as_slice()).ok()
     } else {
-        None // Zero or multiple auth tags — NIP-AA requires exactly one
+        None // Zero auth tags — not a NIP-AA attempt
     };
     let event_created_at = Some(auth_msg.event.created_at.as_u64());
 

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -134,30 +134,61 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     let relay_url = state.config.relay_url.clone();
 
     // ── Auth dispatch ────────────────────────────────────────────────────────
-    // Ordering mirrors the main WS auth handler (auth.rs):
-    //   1. Check direct relay membership first.
-    //   2. Only if NOT a direct member, attempt NIP-AA (which includes auth tag
-    //      extraction and validation). This ensures a direct member who happens
-    //      to have multiple `auth` tags (e.g. misconfigured client) is never
-    //      incorrectly rejected — they're a legitimate member regardless.
+    // Order: (1) verify NIP-42 binding first to avoid unauthenticated DB work,
+    // (2) check direct membership, (3) attempt NIP-AA only for non-members.
+    // owner_pubkey is Some only for NIP-AA virtual members.
     //
-    // Track whether this pubkey was granted access via NIP-AA virtual membership.
-    // Virtual members already passed the relay membership check inside verify_nip_aa
-    // (Step 5), so the direct-only membership gate below must be skipped for them.
-    // owner_pubkey is Some only for NIP-AA virtual members; retained for the
-    // duration of the audio session for audit and future owner-scoped tracking.
-    let (pubkey, is_nip_aa_virtual, owner_pubkey): (
+    // Auth dispatch mirrors the main WS handler's enforce_ws_relay_membership()
+    // (handlers/auth.rs). Changes to the auth flow MUST be kept in sync.
+    // The audio handler cannot reuse enforce_ws_relay_membership directly because
+    // it lacks a ConnectionState (no AuthState RwLock, no subscription management).
+    let (pubkey, is_nip_aa_virtual, owner_pubkey, session_expiry): (
         nostr::PublicKey,
         bool,
         Option<nostr::PublicKey>,
+        Option<u64>,
     ) = if audio_auth_token.is_none() {
-        // No API token — could be a direct member (with or without auth tags)
-        // or a NIP-AA agent. Check direct membership first.
+        // No API token — direct member or NIP-AA agent.
+        // Step 1: verify NIP-42 binding before any DB work.
         let candidate_pubkey = auth_msg.event.pubkey;
         let candidate_pubkey_hex = candidate_pubkey.to_hex();
+        {
+            let event_for_verify = auth_msg.event.clone();
+            let challenge_owned = challenge.clone();
+            let relay_owned = relay_url.clone();
+            match tokio::task::spawn_blocking(move || {
+                sprout_auth::verify_nip42_event(&event_for_verify, &challenge_owned, &relay_owned)
+            })
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    warn!(channel_id = %channel_id, "audio: NIP-42 binding failed: {e}");
+                    let _ = ws_send
+                        .send(WsMessage::Text(
+                            serde_json::json!({"type":"error","message":"auth failed"})
+                                .to_string()
+                                .into(),
+                        ))
+                        .await;
+                    return;
+                }
+                Err(e) => {
+                    warn!(channel_id = %channel_id, "audio: NIP-42 verify task panicked: {e}");
+                    let _ = ws_send
+                        .send(WsMessage::Text(
+                            serde_json::json!({"type":"error","message":"auth failed"})
+                                .to_string()
+                                .into(),
+                        ))
+                        .await;
+                    return;
+                }
+            }
+        }
+
+        // Step 2: check direct relay membership. Fail closed on DB errors.
         let is_direct_member = if state.config.require_relay_membership {
-            // Fail closed on DB errors — a DB failure must not silently grant
-            // access. The main WS auth handler (auth.rs) uses the same pattern.
             match state.db.is_relay_member(&candidate_pubkey_hex).await {
                 Ok(v) => v,
                 Err(e) => {
@@ -177,9 +208,8 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         };
 
         if is_direct_member {
-            // Direct member — go through verify_auth_event to enforce token
-            // requirements. Auth tag count is irrelevant here; verify_auth_event
-            // handles the event normally regardless of extra tags.
+            // Direct member — call verify_auth_event to enforce any remaining token
+            // requirements (e.g. Okta JWT checks).
             let auth_ctx = match state
                 .auth
                 .verify_auth_event(auth_msg.event, &challenge, &relay_url)
@@ -199,23 +229,60 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 }
             };
             // Direct member — not a NIP-AA virtual member.
-            (auth_ctx.pubkey, false, None)
+            (auth_ctx.pubkey, false, None, None)
         } else {
-            // Not a direct member — attempt NIP-AA. Extract and validate the
-            // auth tag now (only for non-direct-member paths). Multiple auth
-            // tags are only rejected here, never for direct members.
-            //
-            // Delegates to the canonical extract_single_auth_tag from nip_aa.rs:
-            //   Ok(None)     → zero auth tags — not a NIP-AA attempt
-            //   Ok(Some(t))  → exactly one auth tag — proceed with NIP-AA
-            //   Err(reason)  → multiple auth tags — malformed, reject
-            let auth_tag_present = match crate::handlers::nip_aa::extract_single_auth_tag(
-                auth_msg.event.tags.as_slice(),
-            ) {
-                Ok(None) => false,
-                Ok(Some(_)) => true,
+            // Step 3: not a direct member — attempt NIP-AA.
+            // NIP-42 binding already verified above (Step 1).
+            // verify_nip_aa internally calls extract_single_auth_tag; no pre-check needed.
+            let event_tags_slice: Vec<nostr::Tag> = auth_msg.event.tags.clone().to_vec();
+            let nip_aa_result = crate::handlers::nip_aa::verify_nip_aa(
+                &state,
+                &candidate_pubkey,
+                &event_tags_slice,
+                event_created_at,
+            )
+            .await;
+
+            match nip_aa_result {
+                Ok(Some(result)) => {
+                    // NIP-AA virtual member — owner already confirmed active.
+                    // owner_pubkey retained for session lifetime for audit.
+                    let nip_aa_owner = result.owner_pubkey;
+                    let nip_aa_expiry = result.session_expiry;
+                    tracing::info!(
+                        channel_id = %channel_id,
+                        agent = %candidate_pubkey.to_hex(),
+                        owner = %nip_aa_owner.to_hex(),
+                        "NIP-AA: audio virtual membership granted"
+                    );
+                    (candidate_pubkey, true, Some(nip_aa_owner), nip_aa_expiry)
+                }
+                Ok(None) => {
+                    // No auth tag — not a NIP-AA agent. Fall through to standard
+                    // auth; verify_auth_event will reject non-members.
+                    let auth_ctx = match state
+                        .auth
+                        .verify_auth_event(auth_msg.event, &challenge, &relay_url)
+                        .await
+                    {
+                        Ok(ctx) => ctx,
+                        Err(e) => {
+                            warn!(channel_id = %channel_id, "audio auth failed (non-member): {e}");
+                            let _ = ws_send
+                                .send(WsMessage::Text(
+                                    serde_json::json!({"type":"error","message":"auth failed"})
+                                        .to_string()
+                                        .into(),
+                                ))
+                                .await;
+                            return;
+                        }
+                    };
+                    (auth_ctx.pubkey, false, None, None)
+                }
                 Err(reason) => {
-                    warn!(channel_id = %channel_id, "audio: multiple auth tags in NIP-42 event");
+                    // Auth tag present but invalid, or owner not a member — deny.
+                    warn!(channel_id = %channel_id, pubkey = %candidate_pubkey.to_hex(), reason = %reason, "audio NIP-AA: denied");
                     let _ = ws_send
                         .send(WsMessage::Text(
                             serde_json::json!({"type": "error", "message": reason})
@@ -225,135 +292,30 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                         .await;
                     return;
                 }
-            };
-
-            if auth_tag_present {
-                // NIP-AA path: verify NIP-42 binding first, then verify_nip_aa.
-                let event_for_verify = auth_msg.event.clone();
-                let challenge_owned = challenge.clone();
-                let relay_owned = relay_url.clone();
-                match tokio::task::spawn_blocking(move || {
-                    sprout_auth::verify_nip42_event(
-                        &event_for_verify,
-                        &challenge_owned,
-                        &relay_owned,
-                    )
-                })
-                .await
-                {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => {
-                        warn!(channel_id = %channel_id, "audio NIP-AA: NIP-42 binding failed: {e}");
-                        let _ = ws_send
-                            .send(WsMessage::Text(
-                                serde_json::json!({"type":"error","message":"auth failed"})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                        return;
-                    }
-                    Err(e) => {
-                        warn!(channel_id = %channel_id, "audio NIP-AA: NIP-42 verify task panicked: {e}");
-                        let _ = ws_send
-                            .send(WsMessage::Text(
-                                serde_json::json!({"type":"error","message":"auth failed"})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                        return;
-                    }
-                }
-
-                let event_tags_slice: Vec<nostr::Tag> = auth_msg.event.tags.clone().to_vec();
-                let nip_aa_result = crate::handlers::nip_aa::verify_nip_aa(
-                    &state,
-                    &candidate_pubkey,
-                    &event_tags_slice,
-                    event_created_at,
-                )
-                .await;
-
-                match nip_aa_result {
-                    Ok(Some(result)) => {
-                        // NIP-AA virtual member — NIP-42 binding already verified above.
-                        // verify_nip_aa already confirmed the owner is an active relay member
-                        // (Step 5), so the direct membership gate below must be skipped.
-                        //
-                        // owner_pubkey is persisted in AudioPeer for the full session lifetime
-                        // for audit, quota aggregation, and future owner-scoped
-                        // enumeration/termination (NIP-AA §6).
-                        let nip_aa_owner = result.owner_pubkey;
-                        tracing::info!(
-                            channel_id = %channel_id,
-                            agent = %candidate_pubkey.to_hex(),
-                            owner = %nip_aa_owner.to_hex(),
-                            "NIP-AA: audio virtual membership granted"
-                        );
-                        (candidate_pubkey, true, Some(nip_aa_owner))
-                    }
-                    Ok(None) => {
-                        // No auth tag — not a NIP-AA agent and not a direct member.
-                        // Fall through to verify_auth_event which will reject.
-                        let auth_ctx = match state
-                            .auth
-                            .verify_auth_event(auth_msg.event, &challenge, &relay_url)
-                            .await
-                        {
-                            Ok(ctx) => ctx,
-                            Err(e) => {
-                                warn!(channel_id = %channel_id, "audio auth failed (non-member): {e}");
-                                let _ = ws_send
-                                    .send(WsMessage::Text(
-                                        serde_json::json!({"type":"error","message":"auth failed"})
-                                            .to_string()
-                                            .into(),
-                                    ))
-                                    .await;
-                                return;
-                            }
-                        };
-                        (auth_ctx.pubkey, false, None)
-                    }
-                    Err(reason) => {
-                        // Auth tag present but invalid, or owner not a member — deny.
-                        warn!(channel_id = %candidate_pubkey.to_hex(), reason = %reason, "audio NIP-AA: denied");
-                        let _ = ws_send
-                            .send(WsMessage::Text(
-                                serde_json::json!({"type": "error", "message": reason})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                        return;
-                    }
-                }
-            } else {
-                // No auth tag and not a direct member — verify_auth_event will reject.
-                let auth_ctx = match state
-                    .auth
-                    .verify_auth_event(auth_msg.event, &challenge, &relay_url)
-                    .await
-                {
-                    Ok(ctx) => ctx,
-                    Err(e) => {
-                        warn!(channel_id = %channel_id, "audio auth failed (non-member, no auth tag): {e}");
-                        let _ = ws_send
-                            .send(WsMessage::Text(
-                                serde_json::json!({"type":"error","message":"auth failed"})
-                                    .to_string()
-                                    .into(),
-                            ))
-                            .await;
-                        return;
-                    }
-                };
-                (auth_ctx.pubkey, false, None)
             }
         }
     } else {
-        // ── Standard auth path (Okta JWT / API token / pubkey-only) ─────────
+        // ── Standard auth path (Okta JWT / pubkey-only) ──────────────────────
+        // TODO(I5): sprout_ API tokens are not yet supported for audio — reject
+        // early rather than letting them fall through to verify_auth_event.
+        if let Some(ref token) = audio_auth_token {
+            if token.starts_with("sprout_") {
+                warn!(channel_id = %channel_id, "audio: sprout_ API token rejected (not supported for audio)");
+                let _ = ws_send
+                    .send(WsMessage::Text(
+                        serde_json::json!({
+                            "type": "error",
+                            "message": "sprout_ API tokens are not supported for audio connections"
+                        })
+                        .to_string()
+                        .into(),
+                    ))
+                    .await;
+                return;
+            }
+        }
+
+        // Okta JWT path — verify_auth_event handles JWT validation.
         let auth_ctx = match state
             .auth
             .verify_auth_event(auth_msg.event, &challenge, &relay_url)
@@ -372,15 +334,12 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 return;
             }
         };
-        (auth_ctx.pubkey, false, None)
+        (auth_ctx.pubkey, false, None, None)
     };
     let pubkey_hex = pubkey.to_hex();
     let pubkey_bytes = pubkey.serialize().to_vec();
     let parent_channel_id = auth_msg.parent_channel_id;
 
-    // owner_pubkey is Some for NIP-AA virtual members; persisted in AudioPeer
-    // for the full session lifetime for audit, quota aggregation, and future
-    // owner-scoped enumeration/termination.
     if let Some(ref owner) = owner_pubkey {
         debug!(
             channel_id = %channel_id,
@@ -453,6 +412,55 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         Ok(_) => {} // Channel exists and is not archived — proceed.
     }
 
+    // ── Register in ConnectionManager ─────────────────────────────────────────
+    // Audio connections are registered in the shared ConnectionManager so that:
+    //   1. `connection_ids_for_owner()` sees NIP-AA audio sessions, enabling
+    //      owner-scoped termination when an owner is removed from the relay.
+    //   2. `connection_ids_for_pubkey()` can enumerate all live sessions for
+    //      a given agent pubkey, including audio-only connections.
+    //
+    // We register using `peer_id` as the connection ID (already a UUIDv4) and
+    // `ctrl_tx` as the outbound sender so that `conn_manager.send_to()` routes
+    // control messages to the priority channel (matching the main WS handler).
+    //
+    // Audio connections carry no Nostr subscriptions — the empty map is correct.
+    //
+    // Scope intersection note: NIP-AA §5 grants virtual members read/write
+    // scopes but not admin. The audio handler only relays binary frames and
+    // emits relay-signed lifecycle events (kinds 48101–48103) — it never
+    // publishes events on behalf of the agent. Scope enforcement is therefore
+    // N/A here; it applies in the main WebSocket event handler.
+    let (ctrl_tx, ctrl_rx) = mpsc::channel::<WsMessage>(8);
+    let cancel = CancellationToken::new();
+
+    // NIP-AA §Expiry: schedule audio session teardown at delegation expiry.
+    // The "already expired" check MUST happen before room.add_peer() to avoid
+    // leaking a peer entry for a session that will never be used.
+    if let Some(expiry_ts) = session_expiry {
+        let now_ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if now_ts >= expiry_ts {
+            // Already expired — close immediately, before touching room state.
+            tracing::warn!(channel_id = %channel_id, "NIP-AA audio session already expired — closing");
+            return;
+        }
+        // Not yet expired — spawn the teardown timer. The peer is added below;
+        // the timer fires in the future and cancels the session cleanly.
+        let duration = std::time::Duration::from_secs(expiry_ts - now_ts);
+        let expiry_cancel = cancel.clone();
+        let expiry_channel_id = channel_id;
+        tokio::spawn(async move {
+            tokio::time::sleep(duration).await;
+            tracing::info!(
+                channel_id = %expiry_channel_id,
+                "NIP-AA audio session expired — closing connection"
+            );
+            expiry_cancel.cancel();
+        });
+    }
+
     let (peer_id, peer_index, audio_rx, peer_ctrl_rx) = match room.add_peer(
         pubkey_hex.clone(),
         owner_pubkey.as_ref().map(|pk| pk.to_hex()),
@@ -477,26 +485,6 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         "audio peer joined"
     );
 
-    // ── Register in ConnectionManager ─────────────────────────────────────────
-    // Audio connections are registered in the shared ConnectionManager so that:
-    //   1. `connection_ids_for_owner()` sees NIP-AA audio sessions, enabling
-    //      owner-scoped termination when an owner is removed from the relay.
-    //   2. `connection_ids_for_pubkey()` can enumerate all live sessions for
-    //      a given agent pubkey, including audio-only connections.
-    //
-    // We register using `peer_id` as the connection ID (already a UUIDv4) and
-    // `ctrl_tx` as the outbound sender so that `conn_manager.send_to()` routes
-    // control messages to the priority channel (matching the main WS handler).
-    //
-    // Audio connections carry no Nostr subscriptions — the empty map is correct.
-    //
-    // Scope intersection note: NIP-AA §5 grants virtual members read/write
-    // scopes but not admin. The audio handler only relays binary frames and
-    // emits relay-signed lifecycle events (kinds 48101–48103) — it never
-    // publishes events on behalf of the agent. Scope enforcement is therefore
-    // N/A here; it applies in the main WebSocket event handler.
-    let (ctrl_tx, ctrl_rx) = mpsc::channel::<WsMessage>(8);
-    let cancel = CancellationToken::new();
     let conn_backpressure = Arc::new(AtomicU8::new(0));
     let conn_subscriptions = Arc::new(Mutex::new(HashMap::<String, Vec<Filter>>::new()));
 

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -165,7 +165,10 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     // be a NIP-AA agent. Verify NIP-42 binding first, then check relay
     // membership to confirm it is a virtual member — not just a direct member
     // with a dummy auth tag trying to bypass verify_auth_event.
-    let pubkey = if audio_auth_token.is_none() && auth_tag_json.is_some() {
+    // Track whether this pubkey was granted access via NIP-AA virtual membership.
+    // Virtual members already passed the relay membership check inside verify_nip_aa
+    // (Step 5), so the direct-only membership gate below must be skipped for them.
+    let (pubkey, is_nip_aa_virtual) = if audio_auth_token.is_none() && auth_tag_json.is_some() {
         let event_for_verify = auth_msg.event.clone();
         let challenge_owned = challenge.clone();
         let relay_owned = relay_url.clone();
@@ -215,6 +218,8 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         match nip_aa_result {
             Ok(Some(result)) => {
                 // NIP-AA virtual member — NIP-42 binding already verified above.
+                // verify_nip_aa already confirmed the owner is an active relay member
+                // (Step 5), so the direct membership gate below must be skipped.
                 //
                 // NIP-AA requires retaining owner_pubkey for owner-scoped session
                 // enumeration, termination, and quota aggregation. The audio handler
@@ -227,7 +232,7 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                     owner = %result.owner_pubkey.to_hex(),
                     "NIP-AA: audio virtual membership granted"
                 );
-                candidate_pubkey
+                (candidate_pubkey, true)
             }
             Ok(None) => {
                 // No auth tag (or direct member) — must go through verify_auth_event
@@ -250,7 +255,7 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                         return;
                     }
                 };
-                auth_ctx.pubkey
+                (auth_ctx.pubkey, false)
             }
             Err(reason) => {
                 // Auth tag present but invalid, or owner not a member — deny.
@@ -285,18 +290,20 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 return;
             }
         };
-        auth_ctx.pubkey
+        (auth_ctx.pubkey, false)
     };
     let pubkey_hex = pubkey.to_hex();
     let pubkey_bytes = pubkey.serialize().to_vec();
     let parent_channel_id = auth_msg.parent_channel_id;
 
     // ── Relay membership gate (NIP-43) ────────────────────────────────────────
-    // NIP-AA virtual members already passed membership via nip_aa::verify_nip_aa above.
-    // This gate is a direct-membership-only check (no NIP-AA fallback needed here).
-    if crate::api::relay_members::enforce_relay_membership(&state, &pubkey.serialize())
-        .await
-        .is_err()
+    // NIP-AA virtual members already passed the relay membership check inside
+    // verify_nip_aa (Step 5 — owner is an active member). Skip the direct gate
+    // for them; only check direct membership for non-virtual-member connections.
+    if !is_nip_aa_virtual
+        && crate::api::relay_members::enforce_relay_membership(&state, &pubkey.serialize())
+            .await
+            .is_err()
     {
         warn!(channel_id = %channel_id, pubkey = %pubkey_hex, "audio: relay membership denied");
         let _ = ws_send

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -168,7 +168,13 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     // Track whether this pubkey was granted access via NIP-AA virtual membership.
     // Virtual members already passed the relay membership check inside verify_nip_aa
     // (Step 5), so the direct-only membership gate below must be skipped for them.
-    let (pubkey, is_nip_aa_virtual) = if audio_auth_token.is_none() && auth_tag_json.is_some() {
+    // owner_pubkey is Some only for NIP-AA virtual members; retained for the
+    // duration of the audio session for audit and future owner-scoped tracking.
+    let (pubkey, is_nip_aa_virtual, owner_pubkey): (
+        nostr::PublicKey,
+        bool,
+        Option<nostr::PublicKey>,
+    ) = if audio_auth_token.is_none() && auth_tag_json.is_some() {
         let event_for_verify = auth_msg.event.clone();
         let challenge_owned = challenge.clone();
         let relay_owned = relay_url.clone();
@@ -239,7 +245,7 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 }
             };
             // Direct member — not a NIP-AA virtual member.
-            (auth_ctx.pubkey, false)
+            (auth_ctx.pubkey, false, None)
         } else {
             // Not a direct member — attempt NIP-AA (Steps 3-5).
             let event_tags_slice: Vec<nostr::Tag> = auth_msg.event.tags.clone().to_vec();
@@ -257,19 +263,17 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                     // verify_nip_aa already confirmed the owner is an active relay member
                     // (Step 5), so the direct membership gate below must be skipped.
                     //
-                    // NIP-AA requires retaining owner_pubkey for owner-scoped session
-                    // enumeration, termination, and quota aggregation. The audio handler
-                    // does not maintain a persistent AuthContext, so we log the owner
-                    // association for audit purposes. Full owner-scoped session tracking
-                    // requires wiring audio sessions into the connection manager.
+                    // owner_pubkey is retained for the audio session lifetime for audit
+                    // and future owner-scoped enumeration/termination/quota aggregation.
                     // TODO(NIP-AA): Wire audio sessions into ConnectionManager for owner-scoped tracking.
+                    let nip_aa_owner = result.owner_pubkey;
                     tracing::info!(
                         channel_id = %channel_id,
                         agent = %candidate_pubkey.to_hex(),
-                        owner = %result.owner_pubkey.to_hex(),
+                        owner = %nip_aa_owner.to_hex(),
                         "NIP-AA: audio virtual membership granted"
                     );
-                    (candidate_pubkey, true)
+                    (candidate_pubkey, true, Some(nip_aa_owner))
                 }
                 Ok(None) => {
                     // No auth tag (or direct member) — must go through verify_auth_event
@@ -292,7 +296,7 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                             return;
                         }
                     };
-                    (auth_ctx.pubkey, false)
+                    (auth_ctx.pubkey, false, None)
                 }
                 Err(reason) => {
                     // Auth tag present but invalid, or owner not a member — deny.
@@ -328,11 +332,23 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 return;
             }
         };
-        (auth_ctx.pubkey, false)
+        (auth_ctx.pubkey, false, None)
     };
     let pubkey_hex = pubkey.to_hex();
     let pubkey_bytes = pubkey.serialize().to_vec();
     let parent_channel_id = auth_msg.parent_channel_id;
+
+    // owner_pubkey is Some for NIP-AA virtual members; available for the full
+    // session lifetime for audit, quota aggregation, and future owner-scoped
+    // ConnectionManager wiring (see TODO above).
+    if let Some(ref owner) = owner_pubkey {
+        debug!(
+            channel_id = %channel_id,
+            agent = %pubkey_hex,
+            owner = %owner.to_hex(),
+            "audio session: NIP-AA owner retained for session"
+        );
+    }
 
     // ── Relay membership gate (NIP-43) ────────────────────────────────────────
     // NIP-AA virtual members already passed the relay membership check inside

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -199,23 +199,22 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
             }
         }
 
-        // Check relay membership to distinguish NIP-AA virtual members from
-        // direct members. Direct members must not bypass verify_auth_event.
+        // Use nip_aa::verify_nip_aa directly — NIP-42 binding already verified above.
+        // This distinguishes NIP-AA virtual members from direct members without
+        // routing through the generic REST membership helper (which is direct-only).
         let candidate_pubkey = auth_msg.event.pubkey;
-        let candidate_pubkey_bytes = candidate_pubkey.serialize().to_vec();
-        let membership = crate::api::relay_members::enforce_relay_membership(
+        let event_tags_slice: Vec<nostr::Tag> = auth_msg.event.tags.clone().to_vec();
+        let nip_aa_result = crate::handlers::nip_aa::verify_nip_aa(
             &state,
-            &candidate_pubkey_bytes,
-            auth_tag_json.as_deref(),
-            event_created_at,
+            &candidate_pubkey,
+            &event_tags_slice,
+            event_created_at.unwrap_or(0),
         )
         .await;
 
-        match membership {
-            Ok(Some(owner_pubkey)) => {
+        match nip_aa_result {
+            Ok(Some(result)) => {
                 // NIP-AA virtual member — NIP-42 binding already verified above.
-                // The relay membership gate below will re-confirm and is a no-op
-                // (membership already proven), but we skip verify_auth_event.
                 //
                 // NIP-AA requires retaining owner_pubkey for owner-scoped session
                 // enumeration, termination, and quota aggregation. The audio handler
@@ -225,14 +224,14 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 tracing::info!(
                     channel_id = %channel_id,
                     agent = %candidate_pubkey.to_hex(),
-                    owner = %owner_pubkey.to_hex(),
+                    owner = %result.owner_pubkey.to_hex(),
                     "NIP-AA: audio virtual membership granted"
                 );
                 candidate_pubkey
             }
             Ok(None) => {
-                // Direct member with a dummy auth tag — must go through
-                // verify_auth_event to enforce token requirements.
+                // No auth tag (or direct member) — must go through verify_auth_event
+                // to enforce token requirements.
                 let auth_ctx = match state
                     .auth
                     .verify_auth_event(auth_msg.event, &challenge, &relay_url)
@@ -253,12 +252,12 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 };
                 auth_ctx.pubkey
             }
-            Err(_) => {
-                // Not a relay member at all — deny.
-                warn!(channel_id = %channel_id, pubkey = %candidate_pubkey.to_hex(), "audio NIP-AA: relay membership denied");
+            Err(reason) => {
+                // Auth tag present but invalid, or owner not a member — deny.
+                warn!(channel_id = %channel_id, pubkey = %candidate_pubkey.to_hex(), reason = %reason, "audio NIP-AA: denied");
                 let _ = ws_send
                     .send(WsMessage::Text(
-                        serde_json::json!({"type": "error", "message": "restricted: not a relay member"})
+                        serde_json::json!({"type": "error", "message": reason})
                             .to_string()
                             .into(),
                     ))
@@ -293,14 +292,11 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     let parent_channel_id = auth_msg.parent_channel_id;
 
     // ── Relay membership gate (NIP-43) ────────────────────────────────────────
-    if crate::api::relay_members::enforce_relay_membership(
-        &state,
-        &pubkey.serialize(),
-        auth_tag_json.as_deref(),
-        event_created_at,
-    )
-    .await
-    .is_err()
+    // NIP-AA virtual members already passed membership via nip_aa::verify_nip_aa above.
+    // This gate is a direct-membership-only check (no NIP-AA fallback needed here).
+    if crate::api::relay_members::enforce_relay_membership(&state, &pubkey.serialize())
+        .await
+        .is_err()
     {
         warn!(channel_id = %channel_id, pubkey = %pubkey_hex, "audio: relay membership denied");
         let _ = ws_send

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -118,15 +118,23 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     };
 
     // Extract NIP-OA auth tag for NIP-AA before the event is consumed.
-    let auth_tag_json = auth_msg
+    // NIP-AA requires exactly one auth tag — zero means not a NIP-AA attempt,
+    // multiple means malformed (treat as absent so membership check falls through
+    // to the standard path rather than silently picking an arbitrary tag).
+    let auth_tags: Vec<_> = auth_msg
         .event
         .tags
         .iter()
-        .find(|t| {
+        .filter(|t| {
             let s = t.as_slice();
             !s.is_empty() && s[0] == "auth"
         })
-        .map(|t| serde_json::to_string(&t.as_slice()).unwrap_or_default());
+        .collect();
+    let auth_tag_json = if auth_tags.len() == 1 {
+        serde_json::to_string(&auth_tags[0].as_slice()).ok()
+    } else {
+        None // Zero or multiple auth tags — NIP-AA requires exactly one
+    };
     let event_created_at = Some(auth_msg.event.created_at.as_u64());
 
     let relay_url = state.config.relay_url.clone();

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -118,33 +118,26 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     };
 
     // Extract NIP-OA auth tag for NIP-AA before the event is consumed.
-    // NIP-AA requires exactly one auth tag — zero means not a NIP-AA attempt,
-    // multiple means malformed — reject with an explicit error.
-    let auth_tags: Vec<_> = auth_msg
-        .event
-        .tags
-        .iter()
-        .filter(|t| {
-            let s = t.as_slice();
-            !s.is_empty() && s[0] == "auth"
-        })
-        .collect();
-    if auth_tags.len() > 1 {
-        warn!(channel_id = %channel_id, "audio: multiple auth tags in NIP-42 event");
-        let _ = ws_send
-            .send(WsMessage::Text(
-                serde_json::json!({"type": "error", "message": "invalid: multiple auth tags"})
-                    .to_string()
-                    .into(),
-            ))
-            .await;
-        return;
-    }
-    let auth_tag_json = if auth_tags.len() == 1 {
-        serde_json::to_string(&auth_tags[0].as_slice()).ok()
-    } else {
-        None // Zero auth tags — not a NIP-AA attempt
-    };
+    // Delegates to the canonical extract_single_auth_tag from nip_aa.rs:
+    //   Ok(None)     → zero auth tags — not a NIP-AA attempt
+    //   Ok(Some(t))  → exactly one auth tag — serialize to JSON for later use
+    //   Err(reason)  → multiple auth tags — malformed, reject immediately
+    let auth_tag_json =
+        match crate::handlers::nip_aa::extract_single_auth_tag(auth_msg.event.tags.as_slice()) {
+            Ok(None) => None,
+            Ok(Some(tag)) => serde_json::to_string(&tag.as_slice()).ok(),
+            Err(reason) => {
+                warn!(channel_id = %channel_id, "audio: multiple auth tags in NIP-42 event");
+                let _ = ws_send
+                    .send(WsMessage::Text(
+                        serde_json::json!({"type": "error", "message": reason})
+                            .to_string()
+                            .into(),
+                    ))
+                    .await;
+                return;
+            }
+        };
     let event_created_at = Some(auth_msg.event.created_at.as_u64());
 
     // Extract auth_token tag before the event is consumed — API tokens and
@@ -214,11 +207,22 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         let candidate_pubkey = auth_msg.event.pubkey;
         let candidate_pubkey_hex = candidate_pubkey.to_hex();
         let is_direct_member = if state.config.require_relay_membership {
-            state
-                .db
-                .is_relay_member(&candidate_pubkey_hex)
-                .await
-                .unwrap_or(false)
+            // Fail closed on DB errors — a DB failure must not silently grant
+            // access. The main WS auth handler (auth.rs) uses the same pattern.
+            match state.db.is_relay_member(&candidate_pubkey_hex).await {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(channel_id = %channel_id, "audio: DB error checking relay membership: {e}");
+                    let _ = ws_send
+                        .send(WsMessage::Text(
+                            serde_json::json!({"type":"error","message":"auth failed"})
+                                .to_string()
+                                .into(),
+                        ))
+                        .await;
+                    return;
+                }
+            }
         } else {
             true // membership not required — treat as member
         };

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -262,6 +262,7 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                     // does not maintain a persistent AuthContext, so we log the owner
                     // association for audit purposes. Full owner-scoped session tracking
                     // requires wiring audio sessions into the connection manager.
+                    // TODO(NIP-AA): Wire audio sessions into ConnectionManager for owner-scoped tracking.
                     tracing::info!(
                         channel_id = %channel_id,
                         agent = %candidate_pubkey.to_hex(),

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -118,27 +118,6 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         }
     };
 
-    // Extract NIP-OA auth tag for NIP-AA before the event is consumed.
-    // Delegates to the canonical extract_single_auth_tag from nip_aa.rs:
-    //   Ok(None)     → zero auth tags — not a NIP-AA attempt
-    //   Ok(Some(t))  → exactly one auth tag — serialize to JSON for later use
-    //   Err(reason)  → multiple auth tags — malformed, reject immediately
-    let auth_tag_json =
-        match crate::handlers::nip_aa::extract_single_auth_tag(auth_msg.event.tags.as_slice()) {
-            Ok(None) => None,
-            Ok(Some(tag)) => serde_json::to_string(&tag.as_slice()).ok(),
-            Err(reason) => {
-                warn!(channel_id = %channel_id, "audio: multiple auth tags in NIP-42 event");
-                let _ = ws_send
-                    .send(WsMessage::Text(
-                        serde_json::json!({"type": "error", "message": reason})
-                            .to_string()
-                            .into(),
-                    ))
-                    .await;
-                return;
-            }
-        };
     let event_created_at = auth_msg.event.created_at.as_u64();
 
     // Extract auth_token tag before the event is consumed — API tokens and
@@ -154,11 +133,14 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
 
     let relay_url = state.config.relay_url.clone();
 
-    // ── NIP-AA agent auth path ───────────────────────────────────────────────
-    // If there is no auth_token but there IS a NIP-OA auth tag, this *might*
-    // be a NIP-AA agent. Verify NIP-42 binding first, then check relay
-    // membership to confirm it is a virtual member — not just a direct member
-    // with a dummy auth tag trying to bypass verify_auth_event.
+    // ── Auth dispatch ────────────────────────────────────────────────────────
+    // Ordering mirrors the main WS auth handler (auth.rs):
+    //   1. Check direct relay membership first.
+    //   2. Only if NOT a direct member, attempt NIP-AA (which includes auth tag
+    //      extraction and validation). This ensures a direct member who happens
+    //      to have multiple `auth` tags (e.g. misconfigured client) is never
+    //      incorrectly rejected — they're a legitimate member regardless.
+    //
     // Track whether this pubkey was granted access via NIP-AA virtual membership.
     // Virtual members already passed the relay membership check inside verify_nip_aa
     // (Step 5), so the direct-only membership gate below must be skipped for them.
@@ -168,43 +150,9 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         nostr::PublicKey,
         bool,
         Option<nostr::PublicKey>,
-    ) = if audio_auth_token.is_none() && auth_tag_json.is_some() {
-        let event_for_verify = auth_msg.event.clone();
-        let challenge_owned = challenge.clone();
-        let relay_owned = relay_url.clone();
-        match tokio::task::spawn_blocking(move || {
-            sprout_auth::verify_nip42_event(&event_for_verify, &challenge_owned, &relay_owned)
-        })
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                warn!(channel_id = %channel_id, "audio NIP-AA: NIP-42 binding failed: {e}");
-                let _ = ws_send
-                    .send(WsMessage::Text(
-                        serde_json::json!({"type":"error","message":"auth failed"})
-                            .to_string()
-                            .into(),
-                    ))
-                    .await;
-                return;
-            }
-            Err(e) => {
-                warn!(channel_id = %channel_id, "audio NIP-AA: NIP-42 verify task panicked: {e}");
-                let _ = ws_send
-                    .send(WsMessage::Text(
-                        serde_json::json!({"type":"error","message":"auth failed"})
-                            .to_string()
-                            .into(),
-                    ))
-                    .await;
-                return;
-            }
-        }
-
-        // NIP-AA Step 2: check direct membership first. If the agent is already a
-        // direct member, skip NIP-AA entirely and fall through to verify_auth_event.
-        // This matches the main WS auth handler's ordering.
+    ) = if audio_auth_token.is_none() {
+        // No API token — could be a direct member (with or without auth tags)
+        // or a NIP-AA agent. Check direct membership first.
         let candidate_pubkey = auth_msg.event.pubkey;
         let candidate_pubkey_hex = candidate_pubkey.to_hex();
         let is_direct_member = if state.config.require_relay_membership {
@@ -229,8 +177,9 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         };
 
         if is_direct_member {
-            // Direct member with an auth tag — go through verify_auth_event to
-            // enforce token requirements (same as the Ok(None) branch below).
+            // Direct member — go through verify_auth_event to enforce token
+            // requirements. Auth tag count is irrelevant here; verify_auth_event
+            // handles the event normally regardless of extra tags.
             let auth_ctx = match state
                 .auth
                 .verify_auth_event(auth_msg.event, &challenge, &relay_url)
@@ -252,60 +201,21 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
             // Direct member — not a NIP-AA virtual member.
             (auth_ctx.pubkey, false, None)
         } else {
-            // Not a direct member — attempt NIP-AA (Steps 3-5).
-            let event_tags_slice: Vec<nostr::Tag> = auth_msg.event.tags.clone().to_vec();
-            let nip_aa_result = crate::handlers::nip_aa::verify_nip_aa(
-                &state,
-                &candidate_pubkey,
-                &event_tags_slice,
-                event_created_at,
-            )
-            .await;
-
-            match nip_aa_result {
-                Ok(Some(result)) => {
-                    // NIP-AA virtual member — NIP-42 binding already verified above.
-                    // verify_nip_aa already confirmed the owner is an active relay member
-                    // (Step 5), so the direct membership gate below must be skipped.
-                    //
-                    // owner_pubkey is persisted in AudioPeer for the full session lifetime
-                    // for audit, quota aggregation, and future owner-scoped
-                    // enumeration/termination (NIP-AA §6).
-                    let nip_aa_owner = result.owner_pubkey;
-                    tracing::info!(
-                        channel_id = %channel_id,
-                        agent = %candidate_pubkey.to_hex(),
-                        owner = %nip_aa_owner.to_hex(),
-                        "NIP-AA: audio virtual membership granted"
-                    );
-                    (candidate_pubkey, true, Some(nip_aa_owner))
-                }
-                Ok(None) => {
-                    // No auth tag (or direct member) — must go through verify_auth_event
-                    // to enforce token requirements.
-                    let auth_ctx = match state
-                        .auth
-                        .verify_auth_event(auth_msg.event, &challenge, &relay_url)
-                        .await
-                    {
-                        Ok(ctx) => ctx,
-                        Err(e) => {
-                            warn!(channel_id = %channel_id, "audio auth failed for direct member: {e}");
-                            let _ = ws_send
-                                .send(WsMessage::Text(
-                                    serde_json::json!({"type":"error","message":"auth failed"})
-                                        .to_string()
-                                        .into(),
-                                ))
-                                .await;
-                            return;
-                        }
-                    };
-                    (auth_ctx.pubkey, false, None)
-                }
+            // Not a direct member — attempt NIP-AA. Extract and validate the
+            // auth tag now (only for non-direct-member paths). Multiple auth
+            // tags are only rejected here, never for direct members.
+            //
+            // Delegates to the canonical extract_single_auth_tag from nip_aa.rs:
+            //   Ok(None)     → zero auth tags — not a NIP-AA attempt
+            //   Ok(Some(t))  → exactly one auth tag — proceed with NIP-AA
+            //   Err(reason)  → multiple auth tags — malformed, reject
+            let auth_tag_present = match crate::handlers::nip_aa::extract_single_auth_tag(
+                auth_msg.event.tags.as_slice(),
+            ) {
+                Ok(None) => false,
+                Ok(Some(_)) => true,
                 Err(reason) => {
-                    // Auth tag present but invalid, or owner not a member — deny.
-                    warn!(channel_id = %candidate_pubkey.to_hex(), reason = %reason, "audio NIP-AA: denied");
+                    warn!(channel_id = %channel_id, "audio: multiple auth tags in NIP-42 event");
                     let _ = ws_send
                         .send(WsMessage::Text(
                             serde_json::json!({"type": "error", "message": reason})
@@ -315,8 +225,133 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                         .await;
                     return;
                 }
+            };
+
+            if auth_tag_present {
+                // NIP-AA path: verify NIP-42 binding first, then verify_nip_aa.
+                let event_for_verify = auth_msg.event.clone();
+                let challenge_owned = challenge.clone();
+                let relay_owned = relay_url.clone();
+                match tokio::task::spawn_blocking(move || {
+                    sprout_auth::verify_nip42_event(
+                        &event_for_verify,
+                        &challenge_owned,
+                        &relay_owned,
+                    )
+                })
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        warn!(channel_id = %channel_id, "audio NIP-AA: NIP-42 binding failed: {e}");
+                        let _ = ws_send
+                            .send(WsMessage::Text(
+                                serde_json::json!({"type":"error","message":"auth failed"})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                        return;
+                    }
+                    Err(e) => {
+                        warn!(channel_id = %channel_id, "audio NIP-AA: NIP-42 verify task panicked: {e}");
+                        let _ = ws_send
+                            .send(WsMessage::Text(
+                                serde_json::json!({"type":"error","message":"auth failed"})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                        return;
+                    }
+                }
+
+                let event_tags_slice: Vec<nostr::Tag> = auth_msg.event.tags.clone().to_vec();
+                let nip_aa_result = crate::handlers::nip_aa::verify_nip_aa(
+                    &state,
+                    &candidate_pubkey,
+                    &event_tags_slice,
+                    event_created_at,
+                )
+                .await;
+
+                match nip_aa_result {
+                    Ok(Some(result)) => {
+                        // NIP-AA virtual member — NIP-42 binding already verified above.
+                        // verify_nip_aa already confirmed the owner is an active relay member
+                        // (Step 5), so the direct membership gate below must be skipped.
+                        //
+                        // owner_pubkey is persisted in AudioPeer for the full session lifetime
+                        // for audit, quota aggregation, and future owner-scoped
+                        // enumeration/termination (NIP-AA §6).
+                        let nip_aa_owner = result.owner_pubkey;
+                        tracing::info!(
+                            channel_id = %channel_id,
+                            agent = %candidate_pubkey.to_hex(),
+                            owner = %nip_aa_owner.to_hex(),
+                            "NIP-AA: audio virtual membership granted"
+                        );
+                        (candidate_pubkey, true, Some(nip_aa_owner))
+                    }
+                    Ok(None) => {
+                        // No auth tag — not a NIP-AA agent and not a direct member.
+                        // Fall through to verify_auth_event which will reject.
+                        let auth_ctx = match state
+                            .auth
+                            .verify_auth_event(auth_msg.event, &challenge, &relay_url)
+                            .await
+                        {
+                            Ok(ctx) => ctx,
+                            Err(e) => {
+                                warn!(channel_id = %channel_id, "audio auth failed (non-member): {e}");
+                                let _ = ws_send
+                                    .send(WsMessage::Text(
+                                        serde_json::json!({"type":"error","message":"auth failed"})
+                                            .to_string()
+                                            .into(),
+                                    ))
+                                    .await;
+                                return;
+                            }
+                        };
+                        (auth_ctx.pubkey, false, None)
+                    }
+                    Err(reason) => {
+                        // Auth tag present but invalid, or owner not a member — deny.
+                        warn!(channel_id = %candidate_pubkey.to_hex(), reason = %reason, "audio NIP-AA: denied");
+                        let _ = ws_send
+                            .send(WsMessage::Text(
+                                serde_json::json!({"type": "error", "message": reason})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                        return;
+                    }
+                }
+            } else {
+                // No auth tag and not a direct member — verify_auth_event will reject.
+                let auth_ctx = match state
+                    .auth
+                    .verify_auth_event(auth_msg.event, &challenge, &relay_url)
+                    .await
+                {
+                    Ok(ctx) => ctx,
+                    Err(e) => {
+                        warn!(channel_id = %channel_id, "audio auth failed (non-member, no auth tag): {e}");
+                        let _ = ws_send
+                            .send(WsMessage::Text(
+                                serde_json::json!({"type":"error","message":"auth failed"})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                        return;
+                    }
+                };
+                (auth_ctx.pubkey, false, None)
             }
-        } // close else { // Not a direct member — attempt NIP-AA
+        }
     } else {
         // ── Standard auth path (Okta JWT / API token / pubkey-only) ─────────
         let auth_ctx = match state

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -151,9 +151,10 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     let relay_url = state.config.relay_url.clone();
 
     // ── NIP-AA agent auth path ───────────────────────────────────────────────
-    // If there is no auth_token but there IS a NIP-OA auth tag, this is an
-    // agent using NIP-AA. Bypass verify_auth_event (which requires a token in
-    // production mode) and do NIP-42 binding verification directly.
+    // If there is no auth_token but there IS a NIP-OA auth tag, this *might*
+    // be a NIP-AA agent. Verify NIP-42 binding first, then check relay
+    // membership to confirm it is a virtual member — not just a direct member
+    // with a dummy auth tag trying to bypass verify_auth_event.
     let pubkey = if audio_auth_token.is_none() && auth_tag_json.is_some() {
         let event_for_verify = auth_msg.event.clone();
         let challenge_owned = challenge.clone();
@@ -187,7 +188,62 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
                 return;
             }
         }
-        auth_msg.event.pubkey
+
+        // Check relay membership to distinguish NIP-AA virtual members from
+        // direct members. Direct members must not bypass verify_auth_event.
+        let candidate_pubkey = auth_msg.event.pubkey;
+        let candidate_pubkey_bytes = candidate_pubkey.serialize().to_vec();
+        let membership = crate::api::relay_members::enforce_relay_membership(
+            &state,
+            &candidate_pubkey_bytes,
+            auth_tag_json.as_deref(),
+            event_created_at,
+        )
+        .await;
+
+        match membership {
+            Ok(Some(_owner_pubkey)) => {
+                // NIP-AA virtual member — NIP-42 binding already verified above.
+                // The relay membership gate below will re-confirm and is a no-op
+                // (membership already proven), but we skip verify_auth_event.
+                candidate_pubkey
+            }
+            Ok(None) => {
+                // Direct member with a dummy auth tag — must go through
+                // verify_auth_event to enforce token requirements.
+                let auth_ctx = match state
+                    .auth
+                    .verify_auth_event(auth_msg.event, &challenge, &relay_url)
+                    .await
+                {
+                    Ok(ctx) => ctx,
+                    Err(e) => {
+                        warn!(channel_id = %channel_id, "audio auth failed for direct member: {e}");
+                        let _ = ws_send
+                            .send(WsMessage::Text(
+                                serde_json::json!({"type":"error","message":"auth failed"})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                        return;
+                    }
+                };
+                auth_ctx.pubkey
+            }
+            Err(_) => {
+                // Not a relay member at all — deny.
+                warn!(channel_id = %channel_id, pubkey = %candidate_pubkey.to_hex(), "audio NIP-AA: relay membership denied");
+                let _ = ws_send
+                    .send(WsMessage::Text(
+                        serde_json::json!({"type": "error", "message": "restricted: not a relay member"})
+                            .to_string()
+                            .into(),
+                    ))
+                    .await;
+                return;
+            }
+        }
     } else {
         // ── Standard auth path (Okta JWT / API token / pubkey-only) ─────────
         let auth_ctx = match state

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -212,10 +212,22 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         .await;
 
         match membership {
-            Ok(Some(_owner_pubkey)) => {
+            Ok(Some(owner_pubkey)) => {
                 // NIP-AA virtual member — NIP-42 binding already verified above.
                 // The relay membership gate below will re-confirm and is a no-op
                 // (membership already proven), but we skip verify_auth_event.
+                //
+                // NIP-AA requires retaining owner_pubkey for owner-scoped session
+                // enumeration, termination, and quota aggregation. The audio handler
+                // does not maintain a persistent AuthContext, so we log the owner
+                // association for audit purposes. Full owner-scoped session tracking
+                // requires wiring audio sessions into the connection manager.
+                tracing::info!(
+                    channel_id = %channel_id,
+                    agent = %candidate_pubkey.to_hex(),
+                    owner = %owner_pubkey.to_hex(),
+                    "NIP-AA: audio virtual membership granted"
+                );
                 candidate_pubkey
             }
             Ok(None) => {

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -11,6 +11,7 @@
 //!        └─ cleanup: remove peer, broadcast left, emit lifecycle events
 //! ```
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -22,9 +23,9 @@ use axum::{
 };
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
-use nostr::{EventBuilder, Kind, Tag};
+use nostr::{EventBuilder, Filter, Kind, Tag};
 use serde::Deserialize;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -441,6 +442,45 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
         "audio peer joined"
     );
 
+    // ── Register in ConnectionManager ─────────────────────────────────────────
+    // Audio connections are registered in the shared ConnectionManager so that:
+    //   1. `connection_ids_for_owner()` sees NIP-AA audio sessions, enabling
+    //      owner-scoped termination when an owner is removed from the relay.
+    //   2. `connection_ids_for_pubkey()` can enumerate all live sessions for
+    //      a given agent pubkey, including audio-only connections.
+    //
+    // We register using `peer_id` as the connection ID (already a UUIDv4) and
+    // `ctrl_tx` as the outbound sender so that `conn_manager.send_to()` routes
+    // control messages to the priority channel (matching the main WS handler).
+    //
+    // Audio connections carry no Nostr subscriptions — the empty map is correct.
+    //
+    // Scope intersection note: NIP-AA §5 grants virtual members read/write
+    // scopes but not admin. The audio handler only relays binary frames and
+    // emits relay-signed lifecycle events (kinds 48101–48103) — it never
+    // publishes events on behalf of the agent. Scope enforcement is therefore
+    // N/A here; it applies in the main WebSocket event handler.
+    let (ctrl_tx, ctrl_rx) = mpsc::channel::<WsMessage>(8);
+    let cancel = CancellationToken::new();
+    let conn_backpressure = Arc::new(AtomicU8::new(0));
+    let conn_subscriptions = Arc::new(Mutex::new(HashMap::<String, Vec<Filter>>::new()));
+
+    state.conn_manager.register(
+        peer_id,
+        ctrl_tx.clone(),
+        cancel.clone(),
+        Arc::clone(&conn_backpressure),
+        conn_subscriptions,
+    );
+    state
+        .conn_manager
+        .set_authenticated_pubkey(peer_id, pubkey_bytes.clone());
+    if let Some(ref owner) = owner_pubkey {
+        state
+            .conn_manager
+            .set_owner_pubkey(peer_id, owner.serialize().to_vec());
+    }
+
     // ── Step 5: broadcast joined + send welcome ───────────────────────────────
     let peers_snapshot: Vec<serde_json::Value> = room
         .peer_pubkeys()
@@ -470,13 +510,13 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     .await;
 
     // ── Step 7: spawn send + heartbeat loops ──────────────────────────────────
-    let cancel = CancellationToken::new();
+    // cancel, ctrl_tx, and ctrl_rx were created above during ConnectionManager
+    // registration. data_tx/data_rx are audio-only and not needed for conn_manager.
     let missed_pongs = Arc::new(AtomicU8::new(0));
 
     // Dual-channel pattern (matches connection.rs): data channel for audio,
     // control channel for Ping/Pong/Close/control JSON with priority drain.
     let (data_tx, data_rx) = mpsc::channel::<WsMessage>(16);
-    let (ctrl_tx, ctrl_rx) = mpsc::channel::<WsMessage>(8);
 
     let send_cancel = cancel.child_token();
     let send_task = tokio::spawn(send_loop(ws_send, data_rx, ctrl_rx, send_cancel));
@@ -511,6 +551,10 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     let _ = send_task.await;
     let _ = heartbeat_task.await;
     let _ = forward_task.await;
+
+    // Deregister from ConnectionManager — mirrors the main WS handler cleanup.
+    // This removes the audio session from owner-scoped and pubkey-scoped lookups.
+    state.conn_manager.deregister(peer_id);
 
     // Atomic remove + end check: remove_peer_and_check_ended holds the
     // AdmissionGuard lock across index recycling AND the is_empty + ended=true

--- a/crates/sprout-relay/src/audio/room.rs
+++ b/crates/sprout-relay/src/audio/room.rs
@@ -18,6 +18,10 @@ use uuid::Uuid;
 pub struct AudioPeer {
     /// Nostr pubkey hex.
     pub pubkey: String,
+    /// Owner pubkey hex for NIP-AA virtual members. `None` for direct members.
+    /// Retained for the audio session lifetime per NIP-AA §6 for owner-scoped
+    /// enumeration, termination, and quota aggregation.
+    pub owner_pubkey: Option<String>,
     /// Audio frames (binary Opus with peer_index prefix). Drops on full — real-time.
     pub audio_tx: mpsc::Sender<Bytes>,
     /// Control messages (joined/left/close JSON). Separate queue so control
@@ -134,6 +138,7 @@ impl Room {
     pub fn add_peer(
         &self,
         pubkey: String,
+        owner_pubkey: Option<String>,
     ) -> Option<(Uuid, u8, mpsc::Receiver<Bytes>, mpsc::Receiver<PeerCtrl>)> {
         if self.peers.len() >= MAX_PEERS_PER_ROOM {
             return None;
@@ -153,6 +158,7 @@ impl Room {
             peer_id,
             AudioPeer {
                 pubkey,
+                owner_pubkey,
                 audio_tx,
                 ctrl_tx,
                 peer_index,

--- a/crates/sprout-relay/src/connection.rs
+++ b/crates/sprout-relay/src/connection.rs
@@ -386,13 +386,40 @@ async fn handle_text_message(
                 }
             };
             if is_auth_frame {
-                warn!(conn_id = %conn.conn_id, error = %e, "malformed AUTH frame — closing connection");
-                let _ = conn.ctrl_tx.try_send(WsMessage::Close(Some(CloseFrame {
-                    code: 4000,
-                    reason: "malformed AUTH".into(),
-                })));
-                conn.cancel.cancel();
-                return false;
+                // NIP-AA spec: only close if no parseable event id can be extracted.
+                // If the event id is present and valid, send OK false instead.
+                let maybe_event_id = serde_json::from_str::<serde_json::Value>(&text)
+                    .ok()
+                    .and_then(|v| {
+                        v.as_array()?
+                            .get(1)?
+                            .as_object()?
+                            .get("id")?
+                            .as_str()
+                            .map(|s| s.to_string())
+                    });
+
+                match maybe_event_id {
+                    Some(id) if id.len() == 64 && id.chars().all(|c| c.is_ascii_hexdigit()) => {
+                        // Parseable event id — reject gracefully without closing.
+                        warn!(conn_id = %conn.conn_id, event_id = %id, error = %e, "malformed AUTH event — sending OK false");
+                        conn.send(RelayMessage::ok(
+                            &id,
+                            false,
+                            "invalid: malformed AUTH event",
+                        ));
+                    }
+                    _ => {
+                        // No parseable event id — close per spec.
+                        warn!(conn_id = %conn.conn_id, error = %e, "malformed AUTH frame (no event id) — closing connection");
+                        let _ = conn.ctrl_tx.try_send(WsMessage::Close(Some(CloseFrame {
+                            code: 4000,
+                            reason: "malformed AUTH".into(),
+                        })));
+                        conn.cancel.cancel();
+                        return false;
+                    }
+                }
             }
             conn.send(RelayMessage::notice(&format!("invalid message: {e}")));
             return true;

--- a/crates/sprout-relay/src/connection.rs
+++ b/crates/sprout-relay/src/connection.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -76,6 +76,11 @@ pub struct ConnectionState {
     /// Shared with `ConnectionManager::ConnEntry` so both direct sends and
     /// fan-out broadcasts track the same counter.
     pub backpressure_count: Arc<AtomicU8>,
+    /// Monotonically increasing counter, bumped on every successful re-auth.
+    /// Used by spawned handlers (REQ) to detect stale auth context.
+    pub auth_epoch: AtomicU64,
+    /// Timestamp of the last auth attempt (successful or not). Rate-limits re-auth.
+    pub last_auth_at: std::sync::Mutex<Option<std::time::Instant>>,
 }
 
 impl ConnectionState {
@@ -146,6 +151,8 @@ pub async fn handle_connection(socket: WebSocket, state: Arc<AppState>, addr: So
         ctrl_tx: ctrl_tx.clone(),
         cancel: cancel.clone(),
         backpressure_count: Arc::clone(&backpressure_count),
+        auth_epoch: AtomicU64::new(0),
+        last_auth_at: std::sync::Mutex::new(None),
     });
 
     info!(conn_id = %conn_id, addr = %addr, "WebSocket connection established");
@@ -379,10 +386,20 @@ async fn handle_text_message(
                         == Some("AUTH")
                 }
                 Err(_) => {
-                    // JSON parse failed — presence of `"AUTH"` (with quotes) in
-                    // the raw frame is a reliable signal that this was an AUTH
-                    // attempt, regardless of where in the frame it appears.
-                    text.contains(r#""AUTH""#)
+                    // JSON parse failed — check if this looks like an AUTH frame
+                    // by verifying it starts with `["AUTH"` (the canonical Nostr
+                    // message envelope). This is stricter than scanning for "AUTH"
+                    // anywhere in the frame, which could false-positive on message
+                    // content containing that string.
+                    // Strip leading whitespace, then check for `[` followed by optional
+                    // whitespace and `"AUTH"` — handles both `["AUTH"` and `[ "AUTH"`.
+                    let trimmed = text.trim_start();
+                    if let Some(after_bracket_raw) = trimmed.strip_prefix('[') {
+                        let after_bracket = after_bracket_raw.trim_start();
+                        after_bracket.starts_with(r#""AUTH""#)
+                    } else {
+                        false
+                    }
                 }
             };
             if is_auth_frame {
@@ -420,6 +437,8 @@ async fn handle_text_message(
                         return false;
                     }
                 }
+                // OK false already carries the error — no NOTICE needed.
+                return true;
             }
             conn.send(RelayMessage::notice(&format!("invalid message: {e}")));
             return true;

--- a/crates/sprout-relay/src/connection.rs
+++ b/crates/sprout-relay/src/connection.rs
@@ -37,9 +37,10 @@ pub enum AuthState {
     },
     /// Client has successfully authenticated.
     ///
-    /// The challenge is retained so that NIP-AA §6 credential replacement can
-    /// re-verify a new AUTH event on the same connection without requiring a
-    /// new challenge round-trip.
+    /// The challenge is retained so that re-auth (same-pubkey credential refresh
+    /// or different-pubkey identity switch) can re-verify a new AUTH event on the
+    /// same connection without requiring a new challenge round-trip. The previous
+    /// identity is replaced on success, or preserved on failure (NIP-AA §6).
     Authenticated {
         /// The auth context established during the initial AUTH handshake.
         ctx: AuthContext,

--- a/crates/sprout-relay/src/connection.rs
+++ b/crates/sprout-relay/src/connection.rs
@@ -36,7 +36,16 @@ pub enum AuthState {
         challenge: String,
     },
     /// Client has successfully authenticated.
-    Authenticated(AuthContext),
+    ///
+    /// The challenge is retained so that NIP-AA §6 credential replacement can
+    /// re-verify a new AUTH event on the same connection without requiring a
+    /// new challenge round-trip.
+    Authenticated {
+        /// The auth context established during the initial AUTH handshake.
+        ctx: AuthContext,
+        /// The original challenge string, retained for re-auth verification.
+        challenge: String,
+    },
     /// Authentication attempt was rejected.
     Failed,
 }

--- a/crates/sprout-relay/src/connection.rs
+++ b/crates/sprout-relay/src/connection.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::ws::{Message as WsMessage, WebSocket};
+use axum::extract::ws::{CloseFrame, Message as WsMessage, WebSocket};
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -304,7 +304,9 @@ async fn recv_loop(
                             break;
                         }
                         trace!(len = text.len(), "frame received");
-                        handle_text_message(text.to_string(), Arc::clone(&conn), Arc::clone(&state)).await;
+                        if !handle_text_message(text.to_string(), Arc::clone(&conn), Arc::clone(&state)).await {
+                            break;
+                        }
                     }
                     Some(Ok(WsMessage::Binary(bytes))) => {
                         if bytes.len() > MAX_FRAME_BYTES {
@@ -315,7 +317,9 @@ async fn recv_loop(
                         // (notably certain Nostr libraries) send text payloads in binary frames.
                         // NIP-01 is text-only, but accepting binary is a common relay extension.
                         if let Ok(text) = String::from_utf8(bytes.to_vec()) {
-                            handle_text_message(text, Arc::clone(&conn), Arc::clone(&state)).await;
+                            if !handle_text_message(text, Arc::clone(&conn), Arc::clone(&state)).await {
+                                break;
+                            }
                         }
                     }
                     Some(Ok(WsMessage::Pong(_))) => {
@@ -346,12 +350,31 @@ async fn recv_loop(
     }
 }
 
-async fn handle_text_message(text: String, conn: Arc<ConnectionState>, state: Arc<AppState>) {
+/// Returns `false` if the connection should be closed (malformed AUTH frame).
+async fn handle_text_message(
+    text: String,
+    conn: Arc<ConnectionState>,
+    state: Arc<AppState>,
+) -> bool {
     let msg = match ClientMessage::parse(&text) {
         Ok(m) => m,
         Err(e) => {
+            // NIP-AA spec: an unparseable AUTH frame MUST close the WebSocket.
+            // Detect by checking if the raw frame looks like an AUTH array.
+            let trimmed = text.trim_start();
+            let is_auth_frame =
+                trimmed.starts_with("[\"AUTH\"") || trimmed.starts_with("[ \"AUTH\"");
+            if is_auth_frame {
+                warn!(conn_id = %conn.conn_id, error = %e, "malformed AUTH frame — closing connection");
+                let _ = conn.ctrl_tx.try_send(WsMessage::Close(Some(CloseFrame {
+                    code: 4000,
+                    reason: "malformed AUTH".into(),
+                })));
+                conn.cancel.cancel();
+                return false;
+            }
             conn.send(RelayMessage::notice(&format!("invalid message: {e}")));
-            return;
+            return true;
         }
     };
 
@@ -368,7 +391,7 @@ async fn handle_text_message(text: String, conn: Arc<ConnectionState>, state: Ar
                     conn.send(RelayMessage::notice(
                         "rate-limited: too many concurrent requests",
                     ));
-                    return;
+                    return true;
                 }
             };
             tokio::spawn(async move {
@@ -385,7 +408,7 @@ async fn handle_text_message(text: String, conn: Arc<ConnectionState>, state: Ar
                     conn.send(RelayMessage::notice(
                         "rate-limited: too many concurrent requests",
                     ));
-                    return;
+                    return true;
                 }
             };
             tokio::spawn(async move {
@@ -397,4 +420,5 @@ async fn handle_text_message(text: String, conn: Arc<ConnectionState>, state: Ar
             handlers::close::handle_close(sub_id, Arc::clone(&conn), Arc::clone(&state)).await;
         }
     }
+    true
 }

--- a/crates/sprout-relay/src/connection.rs
+++ b/crates/sprout-relay/src/connection.rs
@@ -360,17 +360,26 @@ async fn handle_text_message(
         Ok(m) => m,
         Err(e) => {
             // NIP-AA spec: an unparseable AUTH frame MUST close the WebSocket.
-            // Parse as JSON and check if the first element is "AUTH" — this
-            // correctly handles all whitespace variants (e.g. `[  "AUTH", ...]`)
-            // that a naive string-prefix check would miss.
-            let is_auth_frame = serde_json::from_str::<serde_json::Value>(&text)
-                .ok()
-                .as_ref()
-                .and_then(|v| v.as_array())
-                .and_then(|a| a.first())
-                .and_then(|v| v.as_str())
-                .map(|s| s == "AUTH")
-                .unwrap_or(false);
+            // Two cases:
+            //   1. Valid JSON array whose first element is "AUTH" but payload is
+            //      invalid (e.g. bad event fields) — caught by the Ok branch.
+            //   2. Truly broken JSON (e.g. `["AUTH", {broken`) — serde fails
+            //      entirely, so we fall back to a cheap heuristic: the frame
+            //      starts with '[' and contains "AUTH" in the first 20 chars.
+            let is_auth_frame = match serde_json::from_str::<serde_json::Value>(&text) {
+                Ok(val) => {
+                    val.as_array()
+                        .and_then(|a| a.first())
+                        .and_then(|v| v.as_str())
+                        == Some("AUTH")
+                }
+                Err(_) => {
+                    // JSON parse failed — check if it looks like an AUTH attempt.
+                    let trimmed = text.trim_start();
+                    trimmed.starts_with('[')
+                        && trimmed.get(..20).map_or(false, |s| s.contains("AUTH"))
+                }
+            };
             if is_auth_frame {
                 warn!(conn_id = %conn.conn_id, error = %e, "malformed AUTH frame — closing connection");
                 let _ = conn.ctrl_tx.try_send(WsMessage::Close(Some(CloseFrame {

--- a/crates/sprout-relay/src/connection.rs
+++ b/crates/sprout-relay/src/connection.rs
@@ -362,10 +362,14 @@ async fn handle_text_message(
             // NIP-AA spec: an unparseable AUTH frame MUST close the WebSocket.
             // Two cases:
             //   1. Valid JSON array whose first element is "AUTH" but payload is
-            //      invalid (e.g. bad event fields) — caught by the Ok branch.
+            //      invalid (e.g. bad event fields) — serde parses the envelope
+            //      successfully, so we can inspect the first element directly.
             //   2. Truly broken JSON (e.g. `["AUTH", {broken`) — serde fails
-            //      entirely, so we fall back to a cheap heuristic: the frame
-            //      starts with '[' and contains "AUTH" in the first 20 chars.
+            //      entirely. We fall back to scanning the raw text for the
+            //      literal token `"AUTH"` (quotes included). Any well-formed
+            //      Nostr AUTH frame must contain that exact quoted string, and
+            //      no other Nostr message type uses the verb AUTH, so a false
+            //      positive here is essentially impossible in practice.
             let is_auth_frame = match serde_json::from_str::<serde_json::Value>(&text) {
                 Ok(val) => {
                     val.as_array()
@@ -374,10 +378,10 @@ async fn handle_text_message(
                         == Some("AUTH")
                 }
                 Err(_) => {
-                    // JSON parse failed — check if it looks like an AUTH attempt.
-                    let trimmed = text.trim_start();
-                    trimmed.starts_with('[')
-                        && trimmed.get(..20).map_or(false, |s| s.contains("AUTH"))
+                    // JSON parse failed — presence of `"AUTH"` (with quotes) in
+                    // the raw frame is a reliable signal that this was an AUTH
+                    // attempt, regardless of where in the frame it appears.
+                    text.contains(r#""AUTH""#)
                 }
             };
             if is_auth_frame {

--- a/crates/sprout-relay/src/connection.rs
+++ b/crates/sprout-relay/src/connection.rs
@@ -360,10 +360,17 @@ async fn handle_text_message(
         Ok(m) => m,
         Err(e) => {
             // NIP-AA spec: an unparseable AUTH frame MUST close the WebSocket.
-            // Detect by checking if the raw frame looks like an AUTH array.
-            let trimmed = text.trim_start();
-            let is_auth_frame =
-                trimmed.starts_with("[\"AUTH\"") || trimmed.starts_with("[ \"AUTH\"");
+            // Parse as JSON and check if the first element is "AUTH" — this
+            // correctly handles all whitespace variants (e.g. `[  "AUTH", ...]`)
+            // that a naive string-prefix check would miss.
+            let is_auth_frame = serde_json::from_str::<serde_json::Value>(&text)
+                .ok()
+                .as_ref()
+                .and_then(|v| v.as_array())
+                .and_then(|a| a.first())
+                .and_then(|v| v.as_str())
+                .map(|s| s == "AUTH")
+                .unwrap_or(false);
             if is_auth_frame {
                 warn!(conn_id = %conn.conn_id, error = %e, "malformed AUTH frame — closing connection");
                 let _ = conn.ctrl_tx.try_send(WsMessage::Close(Some(CloseFrame {

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -100,14 +100,22 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
         match &*auth {
             AuthState::Pending { challenge } => (challenge.clone(), conn.conn_id),
             AuthState::Authenticated(_) => {
-                // NIP-AA §6: If the same pubkey re-authenticates with a different credential,
-                // the new credential replaces the old one. This is handled naturally — a
-                // successful AUTH always overwrites the previous AuthState::Authenticated.
-                // AuthState::Failed is terminal per NIP-42 (the connection cannot re-auth).
+                // NIP-AA §6 says: "If the same agent pubkey completes NIP-AA authentication
+                // again on the same connection, the relay MUST replace the previously stored
+                // credential with the new one."
                 //
-                // We reject here rather than allowing re-auth because the connection has
-                // already been granted access; re-auth on an authenticated connection is
-                // not a defined NIP-42 flow and could mask credential-swap attacks.
+                // We intentionally do NOT implement credential replacement here. Reasons:
+                // 1. The NIP-42 challenge is only stored in AuthState::Pending; once
+                //    authenticated, the challenge is gone and cannot be used to verify a
+                //    new AUTH event. Supporting re-auth would require restructuring AuthState
+                //    to retain the challenge across the Authenticated transition.
+                // 2. Credential-swap on an already-authenticated connection is a potential
+                //    attack vector (privilege escalation via credential replacement).
+                // 3. NIP-42 itself does not define re-authentication semantics.
+                //
+                // TODO: To fully comply with NIP-AA §6, AuthState::Authenticated should
+                // retain the challenge string and this branch should re-verify + replace
+                // the stored AuthContext when the same pubkey re-auths.
                 debug!(conn_id = %conn.conn_id, "AUTH received but already authenticated");
                 conn.send(RelayMessage::ok(
                     &event_id_hex_early,
@@ -268,14 +276,21 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         None => return,
                     };
 
-                    let (auth_method, owner_pubkey) = match nip_aa_owner {
-                        Some(owner) => (sprout_auth::AuthMethod::Nip42AgentAuth, Some(owner)),
-                        None => (sprout_auth::AuthMethod::Nip42ApiToken, None),
+                    // NIP-AA spec: virtual members MUST NOT be granted admin privileges.
+                    // Intersect token scopes with the NIP-AA virtual member scope set to
+                    // strip any admin scopes the token may have carried.
+                    let (auth_method, owner_pubkey, final_scopes) = match nip_aa_owner {
+                        Some(owner) => (
+                            sprout_auth::AuthMethod::Nip42AgentAuth,
+                            Some(owner),
+                            sprout_auth::Scope::nip_aa_virtual_member(),
+                        ),
+                        None => (sprout_auth::AuthMethod::Nip42ApiToken, None, scopes),
                     };
 
                     let auth_ctx = sprout_auth::AuthContext {
                         pubkey,
-                        scopes,
+                        scopes: final_scopes,
                         channel_ids: record.channel_ids,
                         auth_method,
                         owner_pubkey,
@@ -456,6 +471,9 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             };
 
             // If NIP-AA granted access, upgrade the auth context.
+            // NIP-AA spec: virtual members MUST NOT be granted admin privileges.
+            // Override scopes with the restricted virtual-member set regardless of
+            // what the underlying auth method (Okta JWT / pubkey-only) would have granted.
             let final_ctx = match nip_aa_owner {
                 Some(owner_pubkey) => {
                     info!(
@@ -467,6 +485,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     sprout_auth::AuthContext {
                         owner_pubkey: Some(owner_pubkey),
                         auth_method: sprout_auth::AuthMethod::Nip42AgentAuth,
+                        scopes: sprout_auth::Scope::nip_aa_virtual_member(),
                         ..auth_ctx
                     }
                 }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -382,6 +382,11 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     state
                         .conn_manager
                         .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
+                    if let Some(owner) = final_owner_pubkey {
+                        state
+                            .conn_manager
+                            .set_owner_pubkey(conn_id, owner.serialize().to_vec());
+                    }
                     conn.send(RelayMessage::ok(&event_id_hex, true, ""));
                 }
                 Err(e) => {
@@ -617,6 +622,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 }
             };
 
+            let nip_aa_owner_for_conn = final_ctx.owner_pubkey;
             *conn.auth_state.write().await = AuthState::Authenticated {
                 ctx: final_ctx,
                 challenge: challenge.clone(),
@@ -624,6 +630,11 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             state
                 .conn_manager
                 .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
+            if let Some(owner) = nip_aa_owner_for_conn {
+                state
+                    .conn_manager
+                    .set_owner_pubkey(conn_id, owner.serialize().to_vec());
+            }
             conn.send(RelayMessage::ok(&event_id_hex, true, ""));
         }
         Err(e) => {

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -398,16 +398,18 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         session_expiry: final_session_expiry,
                     };
 
-                    // Clear subscriptions BEFORE setting new identity to prevent privilege-leak window.
-                    clear_subscriptions_on_reauth(&conn, &state, conn_id, &prev_auth_ctx).await;
-                    *conn.auth_state.write().await = AuthState::Authenticated {
-                        ctx: auth_ctx,
-                        challenge: challenge.clone(),
-                    };
+                    // 1. Bump epoch first — invalidates any in-flight REQs using the old epoch.
                     if prev_auth_ctx.is_some() {
                         conn.auth_epoch
                             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                     }
+                    // 2. Clear old subscriptions.
+                    clear_subscriptions_on_reauth(&conn, &state, conn_id, &prev_auth_ctx).await;
+                    // 3. Write new auth state.
+                    *conn.auth_state.write().await = AuthState::Authenticated {
+                        ctx: auth_ctx,
+                        challenge: challenge.clone(),
+                    };
                     state
                         .conn_manager
                         .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
@@ -558,16 +560,18 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     owner = %owner_pubkey.to_hex(),
                     "NIP-AA agent auth successful"
                 );
-                // Clear subscriptions BEFORE setting new identity to prevent privilege-leak window.
-                clear_subscriptions_on_reauth(&conn, &state, conn_id, &prev_auth_ctx).await;
-                *conn.auth_state.write().await = AuthState::Authenticated {
-                    ctx: auth_ctx,
-                    challenge: challenge.clone(),
-                };
+                // 1. Bump epoch first — invalidates any in-flight REQs using the old epoch.
                 if prev_auth_ctx.is_some() {
                     conn.auth_epoch
                         .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 }
+                // 2. Clear old subscriptions.
+                clear_subscriptions_on_reauth(&conn, &state, conn_id, &prev_auth_ctx).await;
+                // 3. Write new auth state.
+                *conn.auth_state.write().await = AuthState::Authenticated {
+                    ctx: auth_ctx,
+                    challenge: challenge.clone(),
+                };
                 state
                     .conn_manager
                     .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
@@ -738,16 +742,18 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
 
             let nip_aa_owner_for_conn = final_ctx.owner_pubkey;
             let final_ctx_session_expiry = final_ctx.session_expiry;
-            // Clear subscriptions BEFORE setting new identity to prevent privilege-leak window.
-            clear_subscriptions_on_reauth(&conn, &state, conn_id, &prev_auth_ctx).await;
-            *conn.auth_state.write().await = AuthState::Authenticated {
-                ctx: final_ctx,
-                challenge: challenge.clone(),
-            };
+            // 1. Bump epoch first — invalidates any in-flight REQs using the old epoch.
             if prev_auth_ctx.is_some() {
                 conn.auth_epoch
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             }
+            // 2. Clear old subscriptions.
+            clear_subscriptions_on_reauth(&conn, &state, conn_id, &prev_auth_ctx).await;
+            // 3. Write new auth state.
+            *conn.auth_state.write().await = AuthState::Authenticated {
+                ctx: final_ctx,
+                challenge: challenge.clone(),
+            };
             state
                 .conn_manager
                 .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -740,7 +740,7 @@ mod tests {
     /// granted through the NIP-AA path.
     #[test]
     fn nip_aa_scope_intersection_strips_admin() {
-        let admin_only = vec![
+        let admin_only = [
             sprout_auth::Scope::AdminChannels,
             sprout_auth::Scope::AdminUsers,
         ];
@@ -760,7 +760,7 @@ mod tests {
     /// virtual member set — NIP-AA agents must retain messaging access.
     #[test]
     fn nip_aa_scope_intersection_preserves_read_write() {
-        let token_scopes = vec![
+        let token_scopes = [
             sprout_auth::Scope::MessagesRead,
             sprout_auth::Scope::MessagesWrite,
         ];

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -294,6 +294,103 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
         }
     }
 
+    // ── NIP-AA agent auth path ──────────────────────────────────────────────
+    // If the event carries a NIP-OA `auth` tag but no `auth_token`, this is an
+    // agent attempting NIP-AA authentication. Handle it directly rather than
+    // going through `verify_auth_event`, which requires a token in production
+    // mode and would reject the event before NIP-AA membership is checked.
+    let has_auth_tag = event.tags.iter().any(|t| {
+        let s = t.as_slice();
+        !s.is_empty() && s[0] == "auth"
+    });
+
+    if auth_token.is_none() && has_auth_tag {
+        // Extract tags and created_at before event is moved into spawn_blocking.
+        let event_tags = event.tags.clone().to_vec();
+        let event_created_at_ts = event.created_at.as_u64();
+        let pubkey = event.pubkey;
+
+        // NIP-42 binding verification (challenge, relay URL, sig, freshness).
+        // CPU-intensive crypto — run on the blocking thread pool.
+        let event_for_verify = event.clone();
+        let challenge_owned = challenge.clone();
+        let relay_owned = relay_url.clone();
+        match tokio::task::spawn_blocking(move || {
+            verify_api_token_nip42_binding(&event_for_verify, &challenge_owned, &relay_owned)
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!(conn_id = %conn_id, error = %e, "NIP-AA: NIP-42 binding verification failed");
+                metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_nip42_invalid")
+                    .increment(1);
+                *conn.auth_state.write().await = AuthState::Failed;
+                conn.send(RelayMessage::ok(
+                    &event_id_hex,
+                    false,
+                    &format!("invalid: {e}"),
+                ));
+                return;
+            }
+            Err(e) => {
+                warn!(conn_id = %conn_id, error = %e, "NIP-AA: NIP-42 verification task panicked");
+                metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_nip42_internal")
+                    .increment(1);
+                *conn.auth_state.write().await = AuthState::Failed;
+                conn.send(RelayMessage::ok(
+                    &event_id_hex,
+                    false,
+                    "auth-required: verification failed",
+                ));
+                return;
+            }
+        }
+
+        // Relay membership + NIP-AA fallback.
+        match enforce_ws_relay_membership(
+            &state,
+            &conn,
+            conn_id,
+            &pubkey,
+            &event_id_hex,
+            &event_tags,
+            event_created_at_ts,
+        )
+        .await
+        {
+            Some(nip_aa_owner) => {
+                let auth_method = if nip_aa_owner.is_some() {
+                    sprout_auth::AuthMethod::Nip42AgentAuth
+                } else {
+                    sprout_auth::AuthMethod::Nip42PubkeyOnly
+                };
+                let auth_ctx = sprout_auth::AuthContext {
+                    pubkey,
+                    scopes: sprout_auth::Scope::all_known(),
+                    channel_ids: None,
+                    auth_method,
+                    owner_pubkey: nip_aa_owner,
+                };
+                info!(
+                    conn_id = %conn_id,
+                    pubkey = %pubkey.to_hex(),
+                    owner = ?nip_aa_owner.map(|p| p.to_hex()),
+                    "NIP-AA agent auth successful"
+                );
+                *conn.auth_state.write().await = AuthState::Authenticated(auth_ctx);
+                state
+                    .conn_manager
+                    .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
+                conn.send(RelayMessage::ok(&event_id_hex, true, ""));
+            }
+            None => {
+                // enforce_ws_relay_membership already sent the rejection message.
+            }
+        }
+        return;
+    }
+
     // ── Okta JWT / pubkey-only path ─────────────────────────────────────────
     // Non-sprout_ tokens (eyJ* JWTs) and no-token (open-relay) fall through here.
     // Extract tags and created_at before event is consumed by verify_auth_event.

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -95,24 +95,40 @@ fn verify_api_token_nip42_binding(
 /// Handle a NIP-42 AUTH message: verify the challenge response and transition the connection to authenticated state.
 pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state: Arc<AppState>) {
     let event_id_hex_early = event.id.to_hex();
+
+    // Extract the challenge and conn_id from the current auth state.
+    //
+    // AuthState::Authenticated: NIP-AA §6 allows the same pubkey to re-auth on an
+    // already-authenticated connection to replace the stored credential. We retain
+    // the challenge in AuthState::Authenticated for exactly this purpose. Only the
+    // same pubkey may re-auth — a different pubkey is rejected to prevent session
+    // hijacking via credential replacement.
     let (challenge, conn_id) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
             AuthState::Pending { challenge } => (challenge.clone(), conn.conn_id),
-            AuthState::Authenticated(_) => {
-                // NIP-AA §6 says same-pubkey re-auth MUST replace the stored credential.
-                // We intentionally do not implement this: the challenge is not retained
-                // after authentication, so there is no way to verify a new AUTH event
-                // without a new challenge round-trip. Supporting re-auth would require
-                // restructuring AuthState to carry the challenge across the Authenticated
-                // transition — deferred as a TODO.
-                debug!(conn_id = %conn.conn_id, "AUTH received but already authenticated");
-                conn.send(RelayMessage::ok(
-                    &event_id_hex_early,
-                    false,
-                    "auth-required: already authenticated",
-                ));
-                return;
+            AuthState::Authenticated { challenge, ctx } => {
+                // NIP-AA §6: same-pubkey re-auth MUST replace the stored credential.
+                if event.pubkey != ctx.pubkey {
+                    warn!(
+                        conn_id = %conn.conn_id,
+                        existing = %ctx.pubkey.to_hex(),
+                        incoming = %event.pubkey.to_hex(),
+                        "NIP-AA §6: re-auth pubkey mismatch — rejecting"
+                    );
+                    conn.send(RelayMessage::ok(
+                        &event_id_hex_early,
+                        false,
+                        "auth-required: pubkey mismatch on re-auth",
+                    ));
+                    return;
+                }
+                debug!(
+                    conn_id = %conn.conn_id,
+                    pubkey = %ctx.pubkey.to_hex(),
+                    "NIP-AA §6: re-auth credential replacement"
+                );
+                (challenge.clone(), conn.conn_id)
             }
             AuthState::Failed => {
                 debug!(conn_id = %conn.conn_id, "AUTH received after failed auth");
@@ -283,7 +299,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     // do NOT replace them. Replacing could widen a read-only token to
                     // full write access. Intersection preserves the token's restrictions
                     // while stripping any admin scopes.
-                    let (auth_method, owner_pubkey, final_scopes) = match nip_aa_owner {
+                    let (auth_method, final_owner_pubkey, final_scopes) = match nip_aa_owner {
                         Some(owner) => {
                             let allowed = sprout_auth::Scope::nip_aa_virtual_member();
                             let intersected: Vec<sprout_auth::Scope> =
@@ -302,10 +318,13 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         scopes: final_scopes,
                         channel_ids: record.channel_ids,
                         auth_method,
-                        owner_pubkey,
+                        owner_pubkey: final_owner_pubkey,
                     };
 
-                    *conn.auth_state.write().await = AuthState::Authenticated(auth_ctx);
+                    *conn.auth_state.write().await = AuthState::Authenticated {
+                        ctx: auth_ctx,
+                        challenge: challenge.clone(),
+                    };
                     state
                         .conn_manager
                         .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
@@ -407,7 +426,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     owner = %owner_pubkey.to_hex(),
                     "NIP-AA agent auth successful"
                 );
-                *conn.auth_state.write().await = AuthState::Authenticated(auth_ctx);
+                *conn.auth_state.write().await = AuthState::Authenticated {
+                    ctx: auth_ctx,
+                    challenge: challenge.clone(),
+                };
                 state
                     .conn_manager
                     .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
@@ -513,7 +535,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 }
             };
 
-            *conn.auth_state.write().await = AuthState::Authenticated(final_ctx);
+            *conn.auth_state.write().await = AuthState::Authenticated {
+                ctx: final_ctx,
+                challenge: challenge.clone(),
+            };
             state
                 .conn_manager
                 .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
@@ -588,5 +613,32 @@ mod tests {
             make_api_token_auth_event(&keys, &challenge, TEST_RELAY, "sprout_test_api_token");
 
         assert!(verify_api_token_nip42_binding(&event, &challenge, TEST_RELAY).is_ok());
+    }
+
+    /// When an AUTH event has BOTH an `auth_token` AND an `auth` (NIP-OA) tag,
+    /// the token path runs first. A bad token must be rejected immediately —
+    /// we must NOT fall through to NIP-AA. This test verifies the NIP-42
+    /// binding check (which runs before the DB lookup) still rejects on a
+    /// wrong challenge even when an `auth` tag is present.
+    #[test]
+    fn token_path_runs_first_when_both_auth_token_and_auth_tag_present() {
+        let keys = Keys::generate();
+        let challenge = sprout_auth::generate_challenge();
+        let url: Url = TEST_RELAY.parse().expect("valid relay url");
+        let auth_token_tag =
+            Tag::parse(&["auth_token", "sprout_test"]).expect("valid auth_token tag");
+        // Craft a dummy NIP-OA auth tag (content doesn't matter for this test).
+        let auth_tag = Tag::parse(&["auth", "owner_hex", "", "sig_hex"]).expect("valid auth tag");
+        let event = EventBuilder::auth(&challenge, url)
+            .add_tags(vec![auth_token_tag, auth_tag])
+            .sign_with_keys(&keys)
+            .expect("signing failed");
+
+        // The token path runs first — wrong challenge must be rejected even
+        // though a (dummy) NIP-OA auth tag is present.
+        assert!(matches!(
+            verify_api_token_nip42_binding(&event, "wrong-challenge", TEST_RELAY),
+            Err(AuthError::ChallengeMismatch)
+        ));
     }
 }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -277,14 +277,21 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     };
 
                     // NIP-AA spec: virtual members MUST NOT be granted admin privileges.
-                    // Intersect token scopes with the NIP-AA virtual member scope set to
-                    // strip any admin scopes the token may have carried.
+                    // Intersect the token's scopes with the NIP-AA virtual member set —
+                    // do NOT replace them. Replacing could widen a read-only token to
+                    // full write access. Intersection preserves the token's restrictions
+                    // while stripping any admin scopes.
                     let (auth_method, owner_pubkey, final_scopes) = match nip_aa_owner {
-                        Some(owner) => (
-                            sprout_auth::AuthMethod::Nip42AgentAuth,
-                            Some(owner),
-                            sprout_auth::Scope::nip_aa_virtual_member(),
-                        ),
+                        Some(owner) => {
+                            let allowed = sprout_auth::Scope::nip_aa_virtual_member();
+                            let intersected: Vec<sprout_auth::Scope> =
+                                scopes.into_iter().filter(|s| allowed.contains(s)).collect();
+                            (
+                                sprout_auth::AuthMethod::Nip42AgentAuth,
+                                Some(owner),
+                                intersected,
+                            )
+                        }
                         None => (sprout_auth::AuthMethod::Nip42ApiToken, None, scopes),
                     };
 
@@ -472,8 +479,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
 
             // If NIP-AA granted access, upgrade the auth context.
             // NIP-AA spec: virtual members MUST NOT be granted admin privileges.
-            // Override scopes with the restricted virtual-member set regardless of
-            // what the underlying auth method (Okta JWT / pubkey-only) would have granted.
+            // Intersect the original scopes with the virtual-member set — do NOT replace
+            // them. Replacing could widen a read-only JWT/pubkey-only session to full
+            // write access. Intersection preserves the original restrictions while
+            // stripping any admin scopes.
             let final_ctx = match nip_aa_owner {
                 Some(owner_pubkey) => {
                     info!(
@@ -482,10 +491,17 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         owner = %owner_pubkey.to_hex(),
                         "NIP-42 auth successful via NIP-AA"
                     );
+                    let allowed = sprout_auth::Scope::nip_aa_virtual_member();
+                    let intersected: Vec<sprout_auth::Scope> = auth_ctx
+                        .scopes
+                        .iter()
+                        .filter(|s| allowed.contains(s))
+                        .cloned()
+                        .collect();
                     sprout_auth::AuthContext {
                         owner_pubkey: Some(owner_pubkey),
                         auth_method: sprout_auth::AuthMethod::Nip42AgentAuth,
-                        scopes: sprout_auth::Scope::nip_aa_virtual_member(),
+                        scopes: intersected,
                         ..auth_ctx
                     }
                 }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -9,19 +9,25 @@ use crate::connection::{AuthState, ConnectionState};
 use crate::protocol::RelayMessage;
 use crate::state::AppState;
 
-/// Check relay membership for a pubkey during NIP-42 auth.
+use super::nip_aa;
+
+/// Check relay membership for a pubkey during NIP-42 auth, with NIP-AA fallback.
 ///
-/// Returns `true` if the pubkey is a relay member (or if membership enforcement
-/// is disabled). Returns `false` and sends a rejection message if not a member.
+/// Returns:
+/// - `Some(None)`              — direct member (or membership not required), access granted
+/// - `Some(Some(owner_pubkey))`— NIP-AA virtual member, access granted
+/// - `None`                    — access denied (rejection message already sent)
 async fn enforce_ws_relay_membership(
     state: &AppState,
     conn: &Arc<ConnectionState>,
     conn_id: uuid::Uuid,
     pubkey: &nostr::PublicKey,
     event_id_hex: &str,
-) -> bool {
+    tags: &[nostr::Tag],
+    event_created_at: u64,
+) -> Option<Option<nostr::PublicKey>> {
     if !state.config.require_relay_membership {
-        return true;
+        return Some(None);
     }
 
     let pubkey_hex = pubkey.to_hex();
@@ -38,20 +44,44 @@ async fn enforce_ws_relay_membership(
         }
     };
 
-    if !is_member {
-        warn!(conn_id = %conn_id, pubkey = %pubkey_hex, "not a relay member");
-        metrics::counter!("sprout_auth_failures_total", "reason" => "not_relay_member")
-            .increment(1);
-        *conn.auth_state.write().await = AuthState::Failed;
-        conn.send(RelayMessage::ok(
-            event_id_hex,
-            false,
-            "restricted: not a relay member",
-        ));
-        return false;
+    if is_member {
+        return Some(None);
     }
 
-    true
+    // Not a direct member — try NIP-AA fallback.
+    match nip_aa::verify_nip_aa(state, pubkey, tags, event_created_at).await {
+        Ok(Some(result)) => {
+            debug!(
+                conn_id = %conn_id,
+                agent = %pubkey_hex,
+                owner = %result.owner_pubkey.to_hex(),
+                "NIP-AA: virtual membership granted"
+            );
+            Some(Some(result.owner_pubkey))
+        }
+        Ok(None) => {
+            // No auth tag — not an agent, plain membership failure.
+            warn!(conn_id = %conn_id, pubkey = %pubkey_hex, "not a relay member");
+            metrics::counter!("sprout_auth_failures_total", "reason" => "not_relay_member")
+                .increment(1);
+            *conn.auth_state.write().await = AuthState::Failed;
+            conn.send(RelayMessage::ok(
+                event_id_hex,
+                false,
+                "restricted: not a relay member",
+            ));
+            None
+        }
+        Err(reason) => {
+            // Auth tag present but invalid.
+            warn!(conn_id = %conn_id, pubkey = %pubkey_hex, reason = %reason, "NIP-AA verification failed");
+            metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_invalid")
+                .increment(1);
+            *conn.auth_state.write().await = AuthState::Failed;
+            conn.send(RelayMessage::ok(event_id_hex, false, &reason));
+            None
+        }
+    }
 }
 
 fn verify_api_token_nip42_binding(
@@ -110,6 +140,9 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
     if let Some(ref token) = auth_token {
         if token.starts_with("sprout_") {
             // ── API token path ──────────────────────────────────────────────
+            // Extract tags and created_at before event is moved into the blocking task.
+            let event_tags = event.tags.clone().to_vec();
+            let event_created_at_ts = event.created_at.as_u64();
             let event_clone = event.clone();
             let challenge_owned = challenge.clone();
             let relay_owned = relay_url.clone();
@@ -207,21 +240,38 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                             warn!("update_token_last_used failed: {e}");
                         }
                     });
+
+                    // API token users have already proven authorization via their token —
+                    // the pubkey allowlist does not apply here.
+
+                    // Relay membership gate — applies to ALL auth methods; NIP-AA fallback included.
+                    let nip_aa_owner = match enforce_ws_relay_membership(
+                        &state,
+                        &conn,
+                        conn_id,
+                        &pubkey,
+                        &event_id_hex,
+                        &event_tags,
+                        event_created_at_ts,
+                    )
+                    .await
+                    {
+                        Some(owner) => owner,
+                        None => return,
+                    };
+
+                    let (auth_method, owner_pubkey) = match nip_aa_owner {
+                        Some(owner) => (sprout_auth::AuthMethod::Nip42AgentAuth, Some(owner)),
+                        None => (sprout_auth::AuthMethod::Nip42ApiToken, None),
+                    };
+
                     let auth_ctx = sprout_auth::AuthContext {
                         pubkey,
                         scopes,
                         channel_ids: record.channel_ids,
-                        auth_method: sprout_auth::AuthMethod::Nip42ApiToken,
+                        auth_method,
+                        owner_pubkey,
                     };
-                    // API token users have already proven authorization via their token —
-                    // the pubkey allowlist does not apply here.
-
-                    // Relay membership gate (NIP-43) — applies to ALL auth methods.
-                    if !enforce_ws_relay_membership(&state, &conn, conn_id, &pubkey, &event_id_hex)
-                        .await
-                    {
-                        return;
-                    }
 
                     *conn.auth_state.write().await = AuthState::Authenticated(auth_ctx);
                     state
@@ -246,6 +296,9 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
 
     // ── Okta JWT / pubkey-only path ─────────────────────────────────────────
     // Non-sprout_ tokens (eyJ* JWTs) and no-token (open-relay) fall through here.
+    // Extract tags and created_at before event is consumed by verify_auth_event.
+    let event_tags = event.tags.clone().to_vec();
+    let event_created_at_ts = event.created_at.as_u64();
     match auth_svc
         .verify_auth_event(event, &challenge, &relay_url)
         .await
@@ -278,13 +331,44 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     return;
                 }
             }
-            // Relay membership gate (NIP-43) — applies to ALL auth methods.
-            if !enforce_ws_relay_membership(&state, &conn, conn_id, &pubkey, &event_id_hex).await {
-                return;
-            }
+            // Relay membership gate — applies to ALL auth methods; NIP-AA fallback included.
+            let nip_aa_owner = match enforce_ws_relay_membership(
+                &state,
+                &conn,
+                conn_id,
+                &pubkey,
+                &event_id_hex,
+                &event_tags,
+                event_created_at_ts,
+            )
+            .await
+            {
+                Some(owner) => owner,
+                None => return,
+            };
 
-            info!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), "NIP-42 auth successful");
-            *conn.auth_state.write().await = AuthState::Authenticated(auth_ctx);
+            // If NIP-AA granted access, upgrade the auth context.
+            let final_ctx = match nip_aa_owner {
+                Some(owner_pubkey) => {
+                    info!(
+                        conn_id = %conn_id,
+                        pubkey = %pubkey.to_hex(),
+                        owner = %owner_pubkey.to_hex(),
+                        "NIP-42 auth successful via NIP-AA"
+                    );
+                    sprout_auth::AuthContext {
+                        owner_pubkey: Some(owner_pubkey),
+                        auth_method: sprout_auth::AuthMethod::Nip42AgentAuth,
+                        ..auth_ctx
+                    }
+                }
+                None => {
+                    info!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), "NIP-42 auth successful");
+                    auth_ctx
+                }
+            };
+
+            *conn.auth_state.write().await = AuthState::Authenticated(final_ctx);
             state
                 .conn_manager
                 .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -100,22 +100,12 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
         match &*auth {
             AuthState::Pending { challenge } => (challenge.clone(), conn.conn_id),
             AuthState::Authenticated(_) => {
-                // NIP-AA §6 says: "If the same agent pubkey completes NIP-AA authentication
-                // again on the same connection, the relay MUST replace the previously stored
-                // credential with the new one."
-                //
-                // We intentionally do NOT implement credential replacement here. Reasons:
-                // 1. The NIP-42 challenge is only stored in AuthState::Pending; once
-                //    authenticated, the challenge is gone and cannot be used to verify a
-                //    new AUTH event. Supporting re-auth would require restructuring AuthState
-                //    to retain the challenge across the Authenticated transition.
-                // 2. Credential-swap on an already-authenticated connection is a potential
-                //    attack vector (privilege escalation via credential replacement).
-                // 3. NIP-42 itself does not define re-authentication semantics.
-                //
-                // TODO: To fully comply with NIP-AA §6, AuthState::Authenticated should
-                // retain the challenge string and this branch should re-verify + replace
-                // the stored AuthContext when the same pubkey re-auths.
+                // NIP-AA §6 says same-pubkey re-auth MUST replace the stored credential.
+                // We intentionally do not implement this: the challenge is not retained
+                // after authentication, so there is no way to verify a new AUTH event
+                // without a new challenge round-trip. Supporting re-auth would require
+                // restructuring AuthState to carry the challenge across the Authenticated
+                // transition — deferred as a TODO.
                 debug!(conn_id = %conn.conn_id, "AUTH received but already authenticated");
                 conn.send(RelayMessage::ok(
                     &event_id_hex_early,
@@ -153,6 +143,18 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
 
     metrics::counter!("sprout_auth_attempts_total", "method" => if auth_token.as_ref().is_some_and(|t| t.starts_with("sprout_")) { "api_token" } else { "nip42" }).increment(1);
 
+    // ── auth_token + auth tag interaction ──────────────────────────────────
+    // If an AUTH event carries BOTH an `auth_token` tag AND an `auth` tag (NIP-OA
+    // credential), the token path runs first:
+    //   1. If the token is valid → use it (the `auth` tag is ignored).
+    //   2. If the token is INVALID (wrong hash, expired, etc.) → reject immediately.
+    //      We do NOT fall through to NIP-AA in this case. A client that supplies a
+    //      token has declared its intent; a bad token is a hard failure, not a cue
+    //      to try a different auth method. This prevents a confused-deputy attack
+    //      where an attacker appends a valid NIP-OA credential to a stolen-but-expired
+    //      token event hoping the relay will accept it via NIP-AA.
+    //
+    // The NIP-AA path (below) only runs when `auth_token` is absent entirely.
     if let Some(ref token) = auth_token {
         if token.starts_with("sprout_") {
             // ── API token path ──────────────────────────────────────────────
@@ -518,14 +520,17 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             conn.send(RelayMessage::ok(&event_id_hex, true, ""));
         }
         Err(e) => {
-            // NIP-42 verification failure — use "auth-required:" prefix per NIP-42 spec.
-            //
-            // NIP-AA spec §Step 1 says to use "invalid:" for Step 1 failures, but that
-            // language applies to the relay's response *after* it has determined this is
-            // a NIP-AA attempt (i.e., after Step 2 fails and Step 3 finds an auth tag).
-            // Standard NIP-42 verification happens *before* NIP-AA is even considered, so
-            // "auth-required:" is the correct prefix here. Changing it would break
-            // standard NIP-42 clients that expect "auth-required:" on verification failure.
+            // NIP-AA spec §Step 1: when the AUTH event contains an `auth` tag (NIP-AA
+            // attempt), Step 1 failures MUST use the "invalid:" prefix. For standard
+            // NIP-42 events without an auth tag, "auth-required:" is the correct prefix.
+            let has_auth_tag_in_event = event_tags
+                .iter()
+                .any(|t| !t.as_slice().is_empty() && t.as_slice()[0] == "auth");
+            let prefix = if has_auth_tag_in_event {
+                "invalid"
+            } else {
+                "auth-required"
+            };
             warn!(conn_id = %conn_id, error = %e, "NIP-42 auth failed");
             metrics::counter!("sprout_auth_failures_total", "reason" => "nip42_invalid")
                 .increment(1);
@@ -533,7 +538,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             conn.send(RelayMessage::ok(
                 &event_id_hex,
                 false,
-                "auth-required: verification failed",
+                &format!("{prefix}: verification failed"),
             ));
         }
     }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -369,9 +369,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
         {
             Some(Some(owner_pubkey)) => {
                 // NIP-AA virtual member — grant access with agent auth method.
+                // NIP-AA spec: virtual members MUST NOT gain admin privileges.
                 let auth_ctx = sprout_auth::AuthContext {
                     pubkey,
-                    scopes: sprout_auth::Scope::all_known(),
+                    scopes: sprout_auth::Scope::nip_aa_virtual_member(),
                     channel_ids: None,
                     auth_method: sprout_auth::AuthMethod::Nip42AgentAuth,
                     owner_pubkey: Some(owner_pubkey),

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -34,13 +34,23 @@ async fn enforce_ws_relay_membership(
     let is_member = match state.db.is_relay_member(&pubkey_hex).await {
         Ok(v) => v,
         Err(e) => {
+            // DB error: fail closed immediately. Do NOT fall through to NIP-AA —
+            // we cannot authoritatively determine membership, so we must deny.
             warn!(
                 conn_id = %conn_id,
                 pubkey = %pubkey_hex,
                 error = %e,
                 "relay membership check failed, denying (fail-closed)"
             );
-            false
+            metrics::counter!("sprout_auth_failures_total", "reason" => "membership_db_error")
+                .increment(1);
+            *conn.auth_state.write().await = AuthState::Failed;
+            conn.send(RelayMessage::ok(
+                event_id_hex,
+                false,
+                "restricted: membership check failed",
+            ));
+            return None;
         }
     };
 
@@ -299,11 +309,28 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     // do NOT replace them. Replacing could widen a read-only token to
                     // full write access. Intersection preserves the token's restrictions
                     // while stripping any admin scopes.
+                    //
+                    // Empty intersection: if the token carries ONLY admin scopes (e.g. a
+                    // sprout_admin token), the intersection is empty. Empty scopes are
+                    // treated as "unrestricted" by some handlers (NIP-98 / dev-mode paths),
+                    // which would widen access. Deny rather than grant with empty scopes.
                     let (auth_method, final_owner_pubkey, final_scopes) = match nip_aa_owner {
                         Some(owner) => {
                             let allowed = sprout_auth::Scope::nip_aa_virtual_member();
                             let intersected: Vec<sprout_auth::Scope> =
                                 scopes.into_iter().filter(|s| allowed.contains(s)).collect();
+                            if intersected.is_empty() {
+                                warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(),
+                                      "NIP-AA: scope intersection is empty — denying (would widen access)");
+                                metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_empty_scope").increment(1);
+                                *conn.auth_state.write().await = AuthState::Failed;
+                                conn.send(RelayMessage::ok(
+                                    &event_id_hex,
+                                    false,
+                                    "restricted: token scopes incompatible with NIP-AA virtual membership",
+                                ));
+                                return;
+                            }
                             (
                                 sprout_auth::AuthMethod::Nip42AgentAuth,
                                 Some(owner),
@@ -507,6 +534,12 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             // them. Replacing could widen a read-only JWT/pubkey-only session to full
             // write access. Intersection preserves the original restrictions while
             // stripping any admin scopes.
+            //
+            // Empty intersection: pubkey-only auth has empty scopes (treated as
+            // unrestricted in dev/NIP-98 paths). For NIP-AA virtual members, we
+            // use the full virtual-member scope set instead of the empty intersection
+            // to avoid the empty-means-unrestricted footgun. This is safe: the
+            // virtual-member set already excludes admin scopes by design.
             let final_ctx = match nip_aa_owner {
                 Some(owner_pubkey) => {
                     info!(
@@ -516,16 +549,35 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         "NIP-42 auth successful via NIP-AA"
                     );
                     let allowed = sprout_auth::Scope::nip_aa_virtual_member();
-                    let intersected: Vec<sprout_auth::Scope> = auth_ctx
-                        .scopes
-                        .iter()
-                        .filter(|s| allowed.contains(s))
-                        .cloned()
-                        .collect();
+                    let final_scopes = if auth_ctx.scopes.is_empty() {
+                        // Pubkey-only / NIP-98 path: no token scopes to intersect.
+                        // Use the full virtual-member set (already excludes admin).
+                        allowed
+                    } else {
+                        let intersected: Vec<sprout_auth::Scope> = auth_ctx
+                            .scopes
+                            .iter()
+                            .filter(|s| allowed.contains(s))
+                            .cloned()
+                            .collect();
+                        if intersected.is_empty() {
+                            warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(),
+                                  "NIP-AA: scope intersection is empty — denying (would widen access)");
+                            metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_empty_scope").increment(1);
+                            *conn.auth_state.write().await = AuthState::Failed;
+                            conn.send(RelayMessage::ok(
+                                &event_id_hex,
+                                false,
+                                "restricted: token scopes incompatible with NIP-AA virtual membership",
+                            ));
+                            return;
+                        }
+                        intersected
+                    };
                     sprout_auth::AuthContext {
                         owner_pubkey: Some(owner_pubkey),
                         auth_method: sprout_auth::AuthMethod::Nip42AgentAuth,
-                        scopes: intersected,
+                        scopes: final_scopes,
                         ..auth_ctx
                     }
                 }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -490,6 +490,9 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 state
                     .conn_manager
                     .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
+                state
+                    .conn_manager
+                    .set_owner_pubkey(conn_id, owner_pubkey.serialize().to_vec());
                 conn.send(RelayMessage::ok(&event_id_hex, true, ""));
                 return;
             }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -367,23 +367,19 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
         )
         .await
         {
-            Some(nip_aa_owner) => {
-                let auth_method = if nip_aa_owner.is_some() {
-                    sprout_auth::AuthMethod::Nip42AgentAuth
-                } else {
-                    sprout_auth::AuthMethod::Nip42PubkeyOnly
-                };
+            Some(Some(owner_pubkey)) => {
+                // NIP-AA virtual member — grant access with agent auth method.
                 let auth_ctx = sprout_auth::AuthContext {
                     pubkey,
                     scopes: sprout_auth::Scope::all_known(),
                     channel_ids: None,
-                    auth_method,
-                    owner_pubkey: nip_aa_owner,
+                    auth_method: sprout_auth::AuthMethod::Nip42AgentAuth,
+                    owner_pubkey: Some(owner_pubkey),
                 };
                 info!(
                     conn_id = %conn_id,
                     pubkey = %pubkey.to_hex(),
-                    owner = ?nip_aa_owner.map(|p| p.to_hex()),
+                    owner = %owner_pubkey.to_hex(),
                     "NIP-AA agent auth successful"
                 );
                 *conn.auth_state.write().await = AuthState::Authenticated(auth_ctx);
@@ -391,12 +387,18 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     .conn_manager
                     .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
                 conn.send(RelayMessage::ok(&event_id_hex, true, ""));
+                return;
+            }
+            Some(None) => {
+                // Direct member with a dummy auth tag — do NOT grant access here.
+                // Fall through to verify_auth_event which enforces token requirements.
             }
             None => {
                 // enforce_ws_relay_membership already sent the rejection message.
+                return;
             }
         }
-        return;
+        // Direct member fell through — continue to verify_auth_event below.
     }
 
     // ── Okta JWT / pubkey-only path ─────────────────────────────────────────

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -125,6 +125,37 @@ fn verify_api_token_nip42_binding(
 pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state: Arc<AppState>) {
     let event_id_hex_early = event.id.to_hex();
 
+    // Rate-limit ALL auth attempts (initial and re-auth) to 500ms per connection.
+    // Acquire the sync mutex briefly to read/update the timestamp, then drop it
+    // before any await so we never hold a sync lock across an await point.
+    {
+        const AUTH_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+        let sleep_for = {
+            let mut last = match conn.last_auth_at.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => {
+                    warn!("last_auth_at mutex poisoned — recovering");
+                    poisoned.into_inner()
+                }
+            };
+            let remaining = last
+                .map(|t| {
+                    let elapsed = t.elapsed();
+                    if elapsed < AUTH_MIN_INTERVAL {
+                        Some(AUTH_MIN_INTERVAL - elapsed)
+                    } else {
+                        None
+                    }
+                })
+                .flatten();
+            *last = Some(std::time::Instant::now());
+            remaining
+        };
+        if let Some(delay) = sleep_for {
+            tokio::time::sleep(delay).await;
+        }
+    }
+
     // Extract challenge, conn_id, and (for re-auth) the previous AuthContext.
     // NIP-AA §6: a failed re-auth must not invalidate the existing identity —
     // we save prev_auth_ctx and restore it on failure instead of going to Failed.

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -386,6 +386,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         state
                             .conn_manager
                             .set_owner_pubkey(conn_id, owner.serialize().to_vec());
+                    } else {
+                        // Direct member re-auth: clear any stale NIP-AA owner from a
+                        // previous virtual-member session on this connection.
+                        state.conn_manager.clear_owner_pubkey(conn_id);
                     }
                     conn.send(RelayMessage::ok(&event_id_hex, true, ""));
                 }
@@ -634,6 +638,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 state
                     .conn_manager
                     .set_owner_pubkey(conn_id, owner.serialize().to_vec());
+            } else {
+                // Direct member re-auth: clear any stale NIP-AA owner from a
+                // previous virtual-member session on this connection.
+                state.conn_manager.clear_owner_pubkey(conn_id);
             }
             conn.send(RelayMessage::ok(&event_id_hex, true, ""));
         }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -375,6 +375,14 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             conn.send(RelayMessage::ok(&event_id_hex, true, ""));
         }
         Err(e) => {
+            // NIP-42 verification failure — use "auth-required:" prefix per NIP-42 spec.
+            //
+            // NIP-AA spec §Step 1 says to use "invalid:" for Step 1 failures, but that
+            // language applies to the relay's response *after* it has determined this is
+            // a NIP-AA attempt (i.e., after Step 2 fails and Step 3 finds an auth tag).
+            // Standard NIP-42 verification happens *before* NIP-AA is even considered, so
+            // "auth-required:" is the correct prefix here. Changing it would break
+            // standard NIP-42 clients that expect "auth-required:" on verification failure.
             warn!(conn_id = %conn_id, error = %e, "NIP-42 auth failed");
             metrics::counter!("sprout_auth_failures_total", "reason" => "nip42_invalid")
                 .increment(1);

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -44,7 +44,8 @@ async fn enforce_ws_relay_membership(
             );
             metrics::counter!("sprout_auth_failures_total", "reason" => "membership_db_error")
                 .increment(1);
-            *conn.auth_state.write().await = AuthState::Failed;
+            // Do NOT set AuthState here — caller uses reauth_fail! to preserve
+            // existing session on re-auth failure per NIP-AA §6.
             conn.send(RelayMessage::ok(
                 event_id_hex,
                 false,
@@ -74,7 +75,8 @@ async fn enforce_ws_relay_membership(
             warn!(conn_id = %conn_id, pubkey = %pubkey_hex, "not a relay member");
             metrics::counter!("sprout_auth_failures_total", "reason" => "not_relay_member")
                 .increment(1);
-            *conn.auth_state.write().await = AuthState::Failed;
+            // Do NOT set AuthState here — caller uses reauth_fail! to preserve
+            // existing session on re-auth failure per NIP-AA §6.
             conn.send(RelayMessage::ok(
                 event_id_hex,
                 false,
@@ -87,7 +89,8 @@ async fn enforce_ws_relay_membership(
             warn!(conn_id = %conn_id, pubkey = %pubkey_hex, reason = %reason, "NIP-AA verification failed");
             metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_invalid")
                 .increment(1);
-            *conn.auth_state.write().await = AuthState::Failed;
+            // Do NOT set AuthState here — caller uses reauth_fail! to preserve
+            // existing session on re-auth failure per NIP-AA §6.
             conn.send(RelayMessage::ok(event_id_hex, false, &reason));
             None
         }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -723,4 +723,68 @@ mod tests {
             Err(AuthError::ChallengeMismatch)
         ));
     }
+
+    /// Verify that intersecting admin-only scopes with the NIP-AA virtual
+    /// member set produces an empty result — admin privileges must never be
+    /// granted through the NIP-AA path.
+    #[test]
+    fn nip_aa_scope_intersection_strips_admin() {
+        let admin_only = vec![
+            sprout_auth::Scope::AdminChannels,
+            sprout_auth::Scope::AdminUsers,
+        ];
+        let allowed = sprout_auth::Scope::nip_aa_virtual_member();
+        let intersected: Vec<_> = admin_only
+            .iter()
+            .filter(|s| allowed.contains(s))
+            .cloned()
+            .collect();
+        assert!(
+            intersected.is_empty(),
+            "admin scopes must not survive NIP-AA intersection"
+        );
+    }
+
+    /// Verify that normal read/write scopes survive intersection with the
+    /// virtual member set — NIP-AA agents must retain messaging access.
+    #[test]
+    fn nip_aa_scope_intersection_preserves_read_write() {
+        let token_scopes = vec![
+            sprout_auth::Scope::MessagesRead,
+            sprout_auth::Scope::MessagesWrite,
+        ];
+        let allowed = sprout_auth::Scope::nip_aa_virtual_member();
+        let intersected: Vec<_> = token_scopes
+            .iter()
+            .filter(|s| allowed.contains(s))
+            .cloned()
+            .collect();
+        assert_eq!(
+            intersected, token_scopes,
+            "read/write scopes must survive NIP-AA intersection"
+        );
+    }
+
+    /// Verify the virtual member scope set itself: admin scopes absent,
+    /// core messaging scopes present.
+    #[test]
+    fn nip_aa_virtual_member_excludes_admin_scopes() {
+        let vm = sprout_auth::Scope::nip_aa_virtual_member();
+        assert!(
+            !vm.contains(&sprout_auth::Scope::AdminChannels),
+            "virtual member must not include AdminChannels"
+        );
+        assert!(
+            !vm.contains(&sprout_auth::Scope::AdminUsers),
+            "virtual member must not include AdminUsers"
+        );
+        assert!(
+            vm.contains(&sprout_auth::Scope::MessagesRead),
+            "virtual member must include MessagesRead"
+        );
+        assert!(
+            vm.contains(&sprout_auth::Scope::MessagesWrite),
+            "virtual member must include MessagesWrite"
+        );
+    }
 }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -100,6 +100,14 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
         match &*auth {
             AuthState::Pending { challenge } => (challenge.clone(), conn.conn_id),
             AuthState::Authenticated(_) => {
+                // NIP-AA §6: If the same pubkey re-authenticates with a different credential,
+                // the new credential replaces the old one. This is handled naturally — a
+                // successful AUTH always overwrites the previous AuthState::Authenticated.
+                // AuthState::Failed is terminal per NIP-42 (the connection cannot re-auth).
+                //
+                // We reject here rather than allowing re-auth because the connection has
+                // already been granted access; re-auth on an authenticated connection is
+                // not a defined NIP-42 flow and could mask credential-swap attacks.
                 debug!(conn_id = %conn.conn_id, "AUTH received but already authenticated");
                 conn.send(RelayMessage::ok(
                     &event_id_hex_early,

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -105,6 +105,12 @@ fn verify_api_token_nip42_binding(
     sprout_auth::verify_nip42_event(event, challenge, relay_url)
 }
 
+// NOTE: NIP-42 technically allows multiple authenticated pubkeys per connection.
+// Sprout currently supports only one authenticated identity per WebSocket connection.
+// This is a known limitation documented in NIP-AA §6. A re-auth with a DIFFERENT
+// pubkey is rejected; re-auth with the SAME pubkey replaces the credential.
+// Future work: per-pubkey auth state map for multi-identity connections.
+
 /// Handle a NIP-42 AUTH message: verify the challenge response and transition the connection to authenticated state.
 pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state: Arc<AppState>) {
     let event_id_hex_early = event.id.to_hex();

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -328,7 +328,12 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     .await
                     {
                         Some(owner) => owner,
-                        None => return,
+                        None => {
+                            // First-auth membership denial is terminal — transition to Failed to
+                            // prevent infinite retry with the same challenge.
+                            reauth_fail!(AuthState::Failed);
+                            return;
+                        }
                     };
 
                     // NIP-AA spec: virtual members MUST NOT be granted admin privileges.
@@ -391,10 +396,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         // previous virtual-member session on this connection.
                         state.conn_manager.clear_owner_pubkey(conn_id);
                     }
-                    // NIP-AA §6: "The relay MUST NOT combine their privileges."
-                    // On identity switch, clear all subscriptions registered under the
-                    // previous identity to prevent privilege leakage.
-                    if prev_auth_ctx.as_ref().map(|p| p.pubkey) != Some(pubkey) {
+                    // NIP-AA §6: re-auth replaces the entire auth context. Clear all
+                    // subscriptions so the client must re-subscribe under the new scope.
+                    // Prevents privilege leakage when re-authing with narrower scopes.
+                    if prev_auth_ctx.is_some() {
                         conn.subscriptions.lock().await.clear();
                         state.sub_registry.remove_connection(conn_id);
                     }
@@ -506,10 +511,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 state
                     .conn_manager
                     .set_owner_pubkey(conn_id, owner_pubkey.serialize().to_vec());
-                // NIP-AA §6: "The relay MUST NOT combine their privileges."
-                // On identity switch, clear all subscriptions registered under the
-                // previous identity to prevent privilege leakage.
-                if prev_auth_ctx.as_ref().map(|p| p.pubkey) != Some(pubkey) {
+                // NIP-AA §6: re-auth replaces the entire auth context. Clear all
+                // subscriptions so the client must re-subscribe under the new scope.
+                // Prevents privilege leakage when re-authing with narrower scopes.
+                if prev_auth_ctx.is_some() {
                     conn.subscriptions.lock().await.clear();
                     state.sub_registry.remove_connection(conn_id);
                 }
@@ -522,6 +527,9 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             }
             None => {
                 // enforce_ws_relay_membership already sent the rejection message.
+                // First-auth membership denial is terminal — transition to Failed to
+                // prevent infinite retry with the same challenge.
+                reauth_fail!(AuthState::Failed);
                 return;
             }
         }
@@ -578,7 +586,12 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             .await
             {
                 Some(owner) => owner,
-                None => return,
+                None => {
+                    // First-auth membership denial is terminal — transition to Failed to
+                    // prevent infinite retry with the same challenge.
+                    reauth_fail!(AuthState::Failed);
+                    return;
+                }
             };
 
             // If NIP-AA granted access, upgrade the auth context.
@@ -657,10 +670,10 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 // previous virtual-member session on this connection.
                 state.conn_manager.clear_owner_pubkey(conn_id);
             }
-            // NIP-AA §6: "The relay MUST NOT combine their privileges."
-            // On identity switch, clear all subscriptions registered under the
-            // previous identity to prevent privilege leakage.
-            if prev_auth_ctx.as_ref().map(|p| p.pubkey) != Some(pubkey) {
+            // NIP-AA §6: re-auth replaces the entire auth context. Clear all
+            // subscriptions so the client must re-subscribe under the new scope.
+            // Prevents privilege leakage when re-authing with narrower scopes.
+            if prev_auth_ctx.is_some() {
                 conn.subscriptions.lock().await.clear();
                 state.sub_registry.remove_connection(conn_id);
             }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -391,6 +391,13 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         // previous virtual-member session on this connection.
                         state.conn_manager.clear_owner_pubkey(conn_id);
                     }
+                    // NIP-AA §6: "The relay MUST NOT combine their privileges."
+                    // On identity switch, clear all subscriptions registered under the
+                    // previous identity to prevent privilege leakage.
+                    if prev_auth_ctx.as_ref().map(|p| p.pubkey) != Some(pubkey) {
+                        conn.subscriptions.lock().await.clear();
+                        state.sub_registry.remove_connection(conn_id);
+                    }
                     conn.send(RelayMessage::ok(&event_id_hex, true, ""));
                 }
                 Err(e) => {
@@ -455,7 +462,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 conn.send(RelayMessage::ok(
                     &event_id_hex,
                     false,
-                    "auth-required: verification failed",
+                    "invalid: verification failed",
                 ));
                 return;
             }
@@ -499,6 +506,13 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 state
                     .conn_manager
                     .set_owner_pubkey(conn_id, owner_pubkey.serialize().to_vec());
+                // NIP-AA §6: "The relay MUST NOT combine their privileges."
+                // On identity switch, clear all subscriptions registered under the
+                // previous identity to prevent privilege leakage.
+                if prev_auth_ctx.as_ref().map(|p| p.pubkey) != Some(pubkey) {
+                    conn.subscriptions.lock().await.clear();
+                    state.sub_registry.remove_connection(conn_id);
+                }
                 conn.send(RelayMessage::ok(&event_id_hex, true, ""));
                 return;
             }
@@ -642,6 +656,13 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 // Direct member re-auth: clear any stale NIP-AA owner from a
                 // previous virtual-member session on this connection.
                 state.conn_manager.clear_owner_pubkey(conn_id);
+            }
+            // NIP-AA §6: "The relay MUST NOT combine their privileges."
+            // On identity switch, clear all subscriptions registered under the
+            // previous identity to prevent privilege leakage.
+            if prev_auth_ctx.as_ref().map(|p| p.pubkey) != Some(pubkey) {
+                conn.subscriptions.lock().await.clear();
+                state.sub_registry.remove_connection(conn_id);
             }
             conn.send(RelayMessage::ok(&event_id_hex, true, ""));
         }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -14,9 +14,9 @@ use super::nip_aa;
 /// Check relay membership for a pubkey during NIP-42 auth, with NIP-AA fallback.
 ///
 /// Returns:
-/// - `Some(None)`              — direct member (or membership not required), access granted
-/// - `Some(Some(owner_pubkey))`— NIP-AA virtual member, access granted
-/// - `None`                    — access denied (rejection message already sent)
+/// - `Some(None)`                              — direct member (or membership not required), access granted
+/// - `Some(Some((owner_pubkey, expiry)))`      — NIP-AA virtual member, access granted; expiry from `created_at<T`
+/// - `None`                                    — access denied (rejection message already sent)
 async fn enforce_ws_relay_membership(
     state: &AppState,
     conn: &Arc<ConnectionState>,
@@ -25,7 +25,7 @@ async fn enforce_ws_relay_membership(
     event_id_hex: &str,
     tags: &[nostr::Tag],
     event_created_at: u64,
-) -> Option<Option<nostr::PublicKey>> {
+) -> Option<Option<(nostr::PublicKey, Option<u64>)>> {
     if !state.config.require_relay_membership {
         return Some(None);
     }
@@ -34,8 +34,8 @@ async fn enforce_ws_relay_membership(
     let is_member = match state.db.is_relay_member(&pubkey_hex).await {
         Ok(v) => v,
         Err(e) => {
-            // DB error: fail closed immediately. Do NOT fall through to NIP-AA —
-            // we cannot authoritatively determine membership, so we must deny.
+            // Fail closed — cannot authoritatively determine membership, must deny.
+            // Do NOT fall through to NIP-AA. Caller uses reauth_fail! per NIP-AA §6.
             warn!(
                 conn_id = %conn_id,
                 pubkey = %pubkey_hex,
@@ -44,8 +44,6 @@ async fn enforce_ws_relay_membership(
             );
             metrics::counter!("sprout_auth_failures_total", "reason" => "membership_db_error")
                 .increment(1);
-            // Do NOT set AuthState here — caller uses reauth_fail! to preserve
-            // existing session on re-auth failure per NIP-AA §6.
             conn.send(RelayMessage::ok(
                 event_id_hex,
                 false,
@@ -60,6 +58,7 @@ async fn enforce_ws_relay_membership(
     }
 
     // Not a direct member — try NIP-AA fallback.
+    // Caller uses reauth_fail! on None returns per NIP-AA §6.
     match nip_aa::verify_nip_aa(state, pubkey, tags, event_created_at).await {
         Ok(Some(result)) => {
             debug!(
@@ -68,15 +67,12 @@ async fn enforce_ws_relay_membership(
                 owner = %result.owner_pubkey.to_hex(),
                 "NIP-AA: virtual membership granted"
             );
-            Some(Some(result.owner_pubkey))
+            Some(Some((result.owner_pubkey, result.session_expiry)))
         }
         Ok(None) => {
-            // No auth tag — not an agent, plain membership failure.
             warn!(conn_id = %conn_id, pubkey = %pubkey_hex, "not a relay member");
             metrics::counter!("sprout_auth_failures_total", "reason" => "not_relay_member")
                 .increment(1);
-            // Do NOT set AuthState here — caller uses reauth_fail! to preserve
-            // existing session on re-auth failure per NIP-AA §6.
             conn.send(RelayMessage::ok(
                 event_id_hex,
                 false,
@@ -85,15 +81,31 @@ async fn enforce_ws_relay_membership(
             None
         }
         Err(reason) => {
-            // Auth tag present but invalid.
             warn!(conn_id = %conn_id, pubkey = %pubkey_hex, reason = %reason, "NIP-AA verification failed");
             metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_invalid")
                 .increment(1);
-            // Do NOT set AuthState here — caller uses reauth_fail! to preserve
-            // existing session on re-auth failure per NIP-AA §6.
             conn.send(RelayMessage::ok(event_id_hex, false, &reason));
             None
         }
+    }
+}
+
+/// Clear all subscriptions for a connection on re-auth.
+///
+/// Must be called BEFORE writing the new `AuthState` to prevent a privilege-leak
+/// window where old subscriptions (potentially wider scopes) could still receive
+/// events after the identity has changed or scopes have narrowed.
+///
+/// No-op on initial auth (`prev_auth_ctx` is `None`).
+async fn clear_subscriptions_on_reauth(
+    conn: &Arc<ConnectionState>,
+    state: &AppState,
+    conn_id: uuid::Uuid,
+    prev_auth_ctx: &Option<sprout_auth::AuthContext>,
+) {
+    if prev_auth_ctx.is_some() {
+        conn.subscriptions.lock().await.clear();
+        state.sub_registry.remove_connection(conn_id);
     }
 }
 
@@ -105,31 +117,17 @@ fn verify_api_token_nip42_binding(
     sprout_auth::verify_nip42_event(event, challenge, relay_url)
 }
 
-// NOTE: NIP-42 allows multiple authenticated pubkeys per connection. Sprout uses a
-// single-pubkey-at-a-time model: re-auth with any pubkey (same or different) replaces
-// the current credential. The previous identity is discarded. This is a valid subset
-// of the spec — the NIP-AA multi-pubkey language describes behavior IF multiple
-// pubkeys are supported, not a mandate to support them.
-//
-// A failed re-auth attempt preserves the existing identity per NIP-AA §6.
-//
-// Future work: per-pubkey auth state map (HashMap<PublicKey, AuthContext>) for
-// simultaneous multi-identity connections.
+// NOTE: Sprout uses a single-pubkey-at-a-time model — re-auth replaces the current
+// credential. A failed re-auth preserves the existing identity per NIP-AA §6.
+// TODO: per-pubkey auth state map for simultaneous multi-identity connections.
 
 /// Handle a NIP-42 AUTH message: verify the challenge response and transition the connection to authenticated state.
 pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state: Arc<AppState>) {
     let event_id_hex_early = event.id.to_hex();
 
-    // Extract the challenge, conn_id, and (for re-auth) the previous AuthContext.
-    //
-    // AuthState::Authenticated: re-auth replaces the stored credential. Both same-pubkey
-    // credential refresh and different-pubkey identity switch are allowed. We retain
-    // the challenge in AuthState::Authenticated for exactly this purpose.
-    //
-    // NIP-AA §6: "A failed NIP-AA AUTH attempt does not necessarily invalidate other
-    // authenticated pubkeys on the same WebSocket connection."
-    // We preserve this by saving the previous AuthContext and restoring it if
-    // re-auth fails, rather than transitioning to AuthState::Failed.
+    // Extract challenge, conn_id, and (for re-auth) the previous AuthContext.
+    // NIP-AA §6: a failed re-auth must not invalidate the existing identity —
+    // we save prev_auth_ctx and restore it on failure instead of going to Failed.
     let (challenge, conn_id, prev_auth_ctx) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
@@ -163,9 +161,36 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
         }
     };
 
-    // Helper: on re-auth failure, restore the previous AuthContext rather than
-    // transitioning to Failed (per NIP-AA §6 — failed re-auth must not invalidate
-    // the existing authenticated identity).
+    /// Minimum interval between auth attempts on an already-authenticated connection.
+    const REAUTH_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+    // Rate-limit re-auth: reject immediately if too soon after the last attempt.
+    // Uses a per-connection Instant rather than a sleep so the recv loop is
+    // never blocked and queued attempts are dropped rather than processed.
+    if prev_auth_ctx.is_some() {
+        let mut last = match conn.last_auth_at.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                // Mutex poisoned (a prior holder panicked). Recover the guard
+                // and continue — rate-limiting is best-effort, not safety-critical.
+                warn!("last_auth_at mutex poisoned — recovering");
+                poisoned.into_inner()
+            }
+        };
+        if let Some(t) = *last {
+            if t.elapsed() < REAUTH_MIN_INTERVAL {
+                conn.send(RelayMessage::ok(
+                    &event_id_hex_early,
+                    false,
+                    "auth-required: re-auth rate limited, try again later",
+                ));
+                return;
+            }
+        }
+        *last = Some(std::time::Instant::now());
+    }
+
+    // On re-auth failure, restore the previous AuthContext (NIP-AA §6).
     macro_rules! reauth_fail {
         ($state:expr) => {
             if let Some(ref prev) = prev_auth_ctx {
@@ -183,8 +208,8 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
     let auth_svc = Arc::clone(&state.auth);
     let event_id_hex = event.id.to_hex();
 
-    // Extract the auth_token tag before dispatching — API tokens (sprout_*) must be
-    // intercepted here because verify_auth_event() has no DB access and rejects them.
+    // Extract auth_token tag — sprout_* API tokens need DB access, so they're
+    // handled here rather than in verify_auth_event().
     let auth_token = event.tags.iter().find_map(|tag| {
         let vec = tag.as_slice();
         if vec.len() >= 2 && vec[0] == "auth_token" {
@@ -196,23 +221,16 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
 
     metrics::counter!("sprout_auth_attempts_total", "method" => if auth_token.as_ref().is_some_and(|t| t.starts_with("sprout_")) { "api_token" } else { "nip42" }).increment(1);
 
-    // ── auth_token + auth tag interaction ──────────────────────────────────
-    // If an AUTH event carries BOTH an `auth_token` tag AND an `auth` tag (NIP-OA
-    // credential), the token path runs first:
-    //   1. If the token is valid → use it (the `auth` tag is ignored).
-    //   2. If the token is INVALID (wrong hash, expired, etc.) → reject immediately.
-    //      We do NOT fall through to NIP-AA in this case. A client that supplies a
-    //      token has declared its intent; a bad token is a hard failure, not a cue
-    //      to try a different auth method. This prevents a confused-deputy attack
-    //      where an attacker appends a valid NIP-OA credential to a stolen-but-expired
-    //      token event hoping the relay will accept it via NIP-AA.
-    //
-    // The NIP-AA path (below) only runs when `auth_token` is absent entirely.
+    // When both `auth_token` and `auth` (NIP-OA) tags are present, the token path
+    // runs first. A bad token is rejected immediately — we do NOT fall through to
+    // NIP-AA. This prevents a confused-deputy attack where an attacker appends a
+    // valid NIP-OA credential to a stolen token hoping the relay accepts it via NIP-AA.
+    // The NIP-AA path only runs when `auth_token` is absent entirely.
     if let Some(ref token) = auth_token {
         if token.starts_with("sprout_") {
             // ── API token path ──────────────────────────────────────────────
-            // Extract tags and created_at before event is moved into the blocking task.
-            let event_tags = event.tags.clone().to_vec();
+            // event_tags intentionally NOT extracted — token path passes empty slice
+            // to enforce_ws_relay_membership (confused-deputy rule).
             let event_created_at_ts = event.created_at.as_u64();
             let event_clone = event.clone();
             let challenge_owned = challenge.clone();
@@ -312,65 +330,64 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         }
                     });
 
-                    // API token users have already proven authorization via their token —
-                    // the pubkey allowlist does not apply here.
-
-                    // Relay membership gate — applies to ALL auth methods; NIP-AA fallback included.
+                    // Relay membership gate — applies to ALL auth methods.
+                    // Confused-deputy rule: pass empty tag slice so verify_nip_aa cannot
+                    // escalate a valid token to NIP-AA virtual membership.
                     let nip_aa_owner = match enforce_ws_relay_membership(
                         &state,
                         &conn,
                         conn_id,
                         &pubkey,
                         &event_id_hex,
-                        &event_tags,
+                        &[], // Token path: auth tag intentionally ignored per confused-deputy rule
                         event_created_at_ts,
                     )
                     .await
                     {
                         Some(owner) => owner,
                         None => {
-                            // First-auth membership denial is terminal — transition to Failed to
-                            // prevent infinite retry with the same challenge.
                             reauth_fail!(AuthState::Failed);
                             return;
                         }
                     };
 
-                    // NIP-AA spec: virtual members MUST NOT be granted admin privileges.
-                    // Intersect the token's scopes with the NIP-AA virtual member set —
-                    // do NOT replace them. Replacing could widen a read-only token to
-                    // full write access. Intersection preserves the token's restrictions
-                    // while stripping any admin scopes.
+                    // NIP-AA: intersect token scopes with virtual-member set — do NOT replace.
+                    // Replacing could widen a read-only token to full write access.
+                    // Empty intersection (e.g. admin-only token) → deny rather than grant.
                     //
-                    // Empty intersection: if the token carries ONLY admin scopes (e.g. a
-                    // sprout_admin token), the intersection is empty. Empty scopes are
-                    // treated as "unrestricted" by some handlers (NIP-98 / dev-mode paths),
-                    // which would widen access. Deny rather than grant with empty scopes.
-                    let (auth_method, final_owner_pubkey, final_scopes) = match nip_aa_owner {
-                        Some(owner) => {
-                            let allowed = sprout_auth::Scope::nip_aa_virtual_member();
-                            let intersected: Vec<sprout_auth::Scope> =
-                                scopes.into_iter().filter(|s| allowed.contains(s)).collect();
-                            if intersected.is_empty() {
-                                warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(),
+                    // NOTE: The Some(owner) arm below is intentionally unreachable in practice.
+                    // The token path always passes `&[]` (empty tags) to enforce_ws_relay_membership
+                    // per the confused-deputy rule, so verify_nip_aa always returns Ok(None) here.
+                    // We retain the full match for defense-in-depth: if the empty-tags invariant is
+                    // ever violated, the scope intersection logic still prevents privilege escalation.
+                    #[allow(unreachable_patterns)]
+                    let (auth_method, final_owner_pubkey, final_scopes, final_session_expiry) =
+                        match nip_aa_owner {
+                            Some((owner, expiry)) => {
+                                let allowed = sprout_auth::Scope::nip_aa_virtual_member();
+                                let intersected: Vec<sprout_auth::Scope> =
+                                    scopes.into_iter().filter(|s| allowed.contains(s)).collect();
+                                if intersected.is_empty() {
+                                    warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(),
                                       "NIP-AA: scope intersection is empty — denying (would widen access)");
-                                metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_empty_scope").increment(1);
-                                reauth_fail!(AuthState::Failed);
-                                conn.send(RelayMessage::ok(
+                                    metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_empty_scope").increment(1);
+                                    reauth_fail!(AuthState::Failed);
+                                    conn.send(RelayMessage::ok(
                                     &event_id_hex,
                                     false,
                                     "restricted: token scopes incompatible with NIP-AA virtual membership",
                                 ));
-                                return;
+                                    return;
+                                }
+                                (
+                                    sprout_auth::AuthMethod::Nip42AgentAuth,
+                                    Some(owner),
+                                    intersected,
+                                    expiry,
+                                )
                             }
-                            (
-                                sprout_auth::AuthMethod::Nip42AgentAuth,
-                                Some(owner),
-                                intersected,
-                            )
-                        }
-                        None => (sprout_auth::AuthMethod::Nip42ApiToken, None, scopes),
-                    };
+                            None => (sprout_auth::AuthMethod::Nip42ApiToken, None, scopes, None),
+                        };
 
                     let auth_ctx = sprout_auth::AuthContext {
                         pubkey,
@@ -378,12 +395,19 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         channel_ids: record.channel_ids,
                         auth_method,
                         owner_pubkey: final_owner_pubkey,
+                        session_expiry: final_session_expiry,
                     };
 
+                    // Clear subscriptions BEFORE setting new identity to prevent privilege-leak window.
+                    clear_subscriptions_on_reauth(&conn, &state, conn_id, &prev_auth_ctx).await;
                     *conn.auth_state.write().await = AuthState::Authenticated {
                         ctx: auth_ctx,
                         challenge: challenge.clone(),
                     };
+                    if prev_auth_ctx.is_some() {
+                        conn.auth_epoch
+                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
                     state
                         .conn_manager
                         .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
@@ -392,16 +416,48 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                             .conn_manager
                             .set_owner_pubkey(conn_id, owner.serialize().to_vec());
                     } else {
-                        // Direct member re-auth: clear any stale NIP-AA owner from a
-                        // previous virtual-member session on this connection.
+                        // Clear stale NIP-AA owner if re-authing as direct member.
                         state.conn_manager.clear_owner_pubkey(conn_id);
                     }
-                    // NIP-AA §6: re-auth replaces the entire auth context. Clear all
-                    // subscriptions so the client must re-subscribe under the new scope.
-                    // Prevents privilege leakage when re-authing with narrower scopes.
-                    if prev_auth_ctx.is_some() {
-                        conn.subscriptions.lock().await.clear();
-                        state.sub_registry.remove_connection(conn_id);
+                    // NIP-AA §Expiry: schedule connection teardown at session expiry.
+                    // This ensures open subscriptions don't survive past the delegation window.
+                    // The connection's CancellationToken triggers graceful shutdown of all loops.
+                    if let Some(expiry_ts) = final_session_expiry {
+                        let now_ts = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs();
+                        if now_ts < expiry_ts {
+                            let duration = std::time::Duration::from_secs(expiry_ts - now_ts);
+                            let cancel_token = conn.cancel.clone();
+                            let conn_id_for_log = conn_id;
+                            let epoch_at_spawn =
+                                conn.auth_epoch.load(std::sync::atomic::Ordering::SeqCst);
+                            let conn_for_expiry = Arc::clone(&conn);
+                            tokio::spawn(async move {
+                                tokio::time::sleep(duration).await;
+                                let current_epoch = conn_for_expiry
+                                    .auth_epoch
+                                    .load(std::sync::atomic::Ordering::SeqCst);
+                                if current_epoch != epoch_at_spawn {
+                                    debug!(
+                                        conn_id = %conn_id_for_log,
+                                        "NIP-AA expiry timer stale (epoch {epoch_at_spawn} → {current_epoch}) — skipping"
+                                    );
+                                    return;
+                                }
+                                info!(
+                                    conn_id = %conn_id_for_log,
+                                    "NIP-AA session expired — closing connection"
+                                );
+                                cancel_token.cancel();
+                            });
+                        } else {
+                            // Already expired — close immediately
+                            warn!(conn_id = %conn_id, "NIP-AA session already expired at auth time — closing");
+                            conn.cancel.cancel();
+                            return;
+                        }
                     }
                     conn.send(RelayMessage::ok(&event_id_hex, true, ""));
                 }
@@ -485,7 +541,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
         )
         .await
         {
-            Some(Some(owner_pubkey)) => {
+            Some(Some((owner_pubkey, session_expiry))) => {
                 // NIP-AA virtual member — grant access with agent auth method.
                 // NIP-AA spec: virtual members MUST NOT gain admin privileges.
                 let auth_ctx = sprout_auth::AuthContext {
@@ -494,6 +550,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     channel_ids: None,
                     auth_method: sprout_auth::AuthMethod::Nip42AgentAuth,
                     owner_pubkey: Some(owner_pubkey),
+                    session_expiry,
                 };
                 info!(
                     conn_id = %conn_id,
@@ -501,34 +558,70 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     owner = %owner_pubkey.to_hex(),
                     "NIP-AA agent auth successful"
                 );
+                // Clear subscriptions BEFORE setting new identity to prevent privilege-leak window.
+                clear_subscriptions_on_reauth(&conn, &state, conn_id, &prev_auth_ctx).await;
                 *conn.auth_state.write().await = AuthState::Authenticated {
                     ctx: auth_ctx,
                     challenge: challenge.clone(),
                 };
+                if prev_auth_ctx.is_some() {
+                    conn.auth_epoch
+                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                }
                 state
                     .conn_manager
                     .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
                 state
                     .conn_manager
                     .set_owner_pubkey(conn_id, owner_pubkey.serialize().to_vec());
-                // NIP-AA §6: re-auth replaces the entire auth context. Clear all
-                // subscriptions so the client must re-subscribe under the new scope.
-                // Prevents privilege leakage when re-authing with narrower scopes.
-                if prev_auth_ctx.is_some() {
-                    conn.subscriptions.lock().await.clear();
-                    state.sub_registry.remove_connection(conn_id);
+                // NIP-AA §Expiry: schedule connection teardown at session expiry.
+                // This ensures open subscriptions don't survive past the delegation window.
+                // The connection's CancellationToken triggers graceful shutdown of all loops.
+                if let Some(expiry_ts) = session_expiry {
+                    let now_ts = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    if now_ts < expiry_ts {
+                        let duration = std::time::Duration::from_secs(expiry_ts - now_ts);
+                        let cancel_token = conn.cancel.clone();
+                        let conn_id_for_log = conn_id;
+                        let epoch_at_spawn =
+                            conn.auth_epoch.load(std::sync::atomic::Ordering::SeqCst);
+                        let conn_for_expiry = Arc::clone(&conn);
+                        tokio::spawn(async move {
+                            tokio::time::sleep(duration).await;
+                            let current_epoch = conn_for_expiry
+                                .auth_epoch
+                                .load(std::sync::atomic::Ordering::SeqCst);
+                            if current_epoch != epoch_at_spawn {
+                                debug!(
+                                    conn_id = %conn_id_for_log,
+                                    "NIP-AA expiry timer stale (epoch {epoch_at_spawn} → {current_epoch}) — skipping"
+                                );
+                                return;
+                            }
+                            info!(
+                                conn_id = %conn_id_for_log,
+                                "NIP-AA session expired — closing connection"
+                            );
+                            cancel_token.cancel();
+                        });
+                    } else {
+                        // Already expired — close immediately
+                        warn!(conn_id = %conn_id, "NIP-AA session already expired at auth time — closing");
+                        conn.cancel.cancel();
+                        return;
+                    }
                 }
                 conn.send(RelayMessage::ok(&event_id_hex, true, ""));
                 return;
             }
             Some(None) => {
-                // Direct member with a dummy auth tag — do NOT grant access here.
-                // Fall through to verify_auth_event which enforces token requirements.
+                // Direct member with a dummy auth tag — fall through to verify_auth_event.
             }
             None => {
                 // enforce_ws_relay_membership already sent the rejection message.
-                // First-auth membership denial is terminal — transition to Failed to
-                // prevent infinite retry with the same challenge.
                 reauth_fail!(AuthState::Failed);
                 return;
             }
@@ -587,27 +680,16 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             {
                 Some(owner) => owner,
                 None => {
-                    // First-auth membership denial is terminal — transition to Failed to
-                    // prevent infinite retry with the same challenge.
                     reauth_fail!(AuthState::Failed);
                     return;
                 }
             };
 
-            // If NIP-AA granted access, upgrade the auth context.
-            // NIP-AA spec: virtual members MUST NOT be granted admin privileges.
-            // Intersect the original scopes with the virtual-member set — do NOT replace
-            // them. Replacing could widen a read-only JWT/pubkey-only session to full
-            // write access. Intersection preserves the original restrictions while
-            // stripping any admin scopes.
-            //
-            // Empty intersection: pubkey-only auth has empty scopes (treated as
-            // unrestricted in dev/NIP-98 paths). For NIP-AA virtual members, we
-            // use the full virtual-member scope set instead of the empty intersection
-            // to avoid the empty-means-unrestricted footgun. This is safe: the
-            // virtual-member set already excludes admin scopes by design.
+            // NIP-AA: intersect original scopes with virtual-member set — do NOT replace.
+            // Pubkey-only auth has empty scopes; use the full virtual-member set to avoid
+            // the empty-means-unrestricted footgun (virtual-member set excludes admin).
             let final_ctx = match nip_aa_owner {
-                Some(owner_pubkey) => {
+                Some((owner_pubkey, session_expiry)) => {
                     info!(
                         conn_id = %conn_id,
                         pubkey = %pubkey.to_hex(),
@@ -616,8 +698,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     );
                     let allowed = sprout_auth::Scope::nip_aa_virtual_member();
                     let final_scopes = if auth_ctx.scopes.is_empty() {
-                        // Pubkey-only / NIP-98 path: no token scopes to intersect.
-                        // Use the full virtual-member set (already excludes admin).
+                        // Pubkey-only / NIP-98: no token scopes to intersect — use full set.
                         allowed
                     } else {
                         let intersected: Vec<sprout_auth::Scope> = auth_ctx
@@ -644,20 +725,29 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                         owner_pubkey: Some(owner_pubkey),
                         auth_method: sprout_auth::AuthMethod::Nip42AgentAuth,
                         scopes: final_scopes,
+                        session_expiry,
                         ..auth_ctx
                     }
                 }
                 None => {
                     info!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), "NIP-42 auth successful");
+                    // Direct member: ensure session_expiry is None (already set by verify_auth_event)
                     auth_ctx
                 }
             };
 
             let nip_aa_owner_for_conn = final_ctx.owner_pubkey;
+            let final_ctx_session_expiry = final_ctx.session_expiry;
+            // Clear subscriptions BEFORE setting new identity to prevent privilege-leak window.
+            clear_subscriptions_on_reauth(&conn, &state, conn_id, &prev_auth_ctx).await;
             *conn.auth_state.write().await = AuthState::Authenticated {
                 ctx: final_ctx,
                 challenge: challenge.clone(),
             };
+            if prev_auth_ctx.is_some() {
+                conn.auth_epoch
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
             state
                 .conn_manager
                 .set_authenticated_pubkey(conn_id, pubkey.serialize().to_vec());
@@ -666,23 +756,53 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     .conn_manager
                     .set_owner_pubkey(conn_id, owner.serialize().to_vec());
             } else {
-                // Direct member re-auth: clear any stale NIP-AA owner from a
-                // previous virtual-member session on this connection.
+                // Clear stale NIP-AA owner if re-authing as direct member.
                 state.conn_manager.clear_owner_pubkey(conn_id);
             }
-            // NIP-AA §6: re-auth replaces the entire auth context. Clear all
-            // subscriptions so the client must re-subscribe under the new scope.
-            // Prevents privilege leakage when re-authing with narrower scopes.
-            if prev_auth_ctx.is_some() {
-                conn.subscriptions.lock().await.clear();
-                state.sub_registry.remove_connection(conn_id);
+            // NIP-AA §Expiry: schedule connection teardown at session expiry.
+            // This ensures open subscriptions don't survive past the delegation window.
+            // The connection's CancellationToken triggers graceful shutdown of all loops.
+            if let Some(expiry_ts) = final_ctx_session_expiry {
+                let now_ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                if now_ts < expiry_ts {
+                    let duration = std::time::Duration::from_secs(expiry_ts - now_ts);
+                    let cancel_token = conn.cancel.clone();
+                    let conn_id_for_log = conn_id;
+                    let epoch_at_spawn = conn.auth_epoch.load(std::sync::atomic::Ordering::SeqCst);
+                    let conn_for_expiry = Arc::clone(&conn);
+                    tokio::spawn(async move {
+                        tokio::time::sleep(duration).await;
+                        let current_epoch = conn_for_expiry
+                            .auth_epoch
+                            .load(std::sync::atomic::Ordering::SeqCst);
+                        if current_epoch != epoch_at_spawn {
+                            debug!(
+                                conn_id = %conn_id_for_log,
+                                "NIP-AA expiry timer stale (epoch {epoch_at_spawn} → {current_epoch}) — skipping"
+                            );
+                            return;
+                        }
+                        info!(
+                            conn_id = %conn_id_for_log,
+                            "NIP-AA session expired — closing connection"
+                        );
+                        cancel_token.cancel();
+                    });
+                } else {
+                    // Already expired — close immediately
+                    warn!(conn_id = %conn_id, "NIP-AA session already expired at auth time — closing");
+                    conn.cancel.cancel();
+                    return;
+                }
             }
             conn.send(RelayMessage::ok(&event_id_hex, true, ""));
         }
         Err(e) => {
-            // NIP-AA spec §Step 1: when the AUTH event contains an `auth` tag (NIP-AA
-            // attempt), Step 1 failures MUST use the "invalid:" prefix. For standard
-            // NIP-42 events without an auth tag, "auth-required:" is the correct prefix.
+            // NIP-AA §Step 1: use "invalid:" prefix when an auth tag is present,
+            // "auth-required:" for standard NIP-42 events without one.
             let has_auth_tag_in_event = event_tags
                 .iter()
                 .any(|t| !t.as_slice().is_empty() && t.as_slice()[0] == "auth");

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -47,7 +47,7 @@ async fn enforce_ws_relay_membership(
             conn.send(RelayMessage::ok(
                 event_id_hex,
                 false,
-                "restricted: membership check failed",
+                "restricted: agent authentication failed",
             ));
             return None;
         }
@@ -191,35 +191,6 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             }
         }
     };
-
-    /// Minimum interval between auth attempts on an already-authenticated connection.
-    const REAUTH_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
-
-    // Rate-limit re-auth: reject immediately if too soon after the last attempt.
-    // Uses a per-connection Instant rather than a sleep so the recv loop is
-    // never blocked and queued attempts are dropped rather than processed.
-    if prev_auth_ctx.is_some() {
-        let mut last = match conn.last_auth_at.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                // Mutex poisoned (a prior holder panicked). Recover the guard
-                // and continue — rate-limiting is best-effort, not safety-critical.
-                warn!("last_auth_at mutex poisoned — recovering");
-                poisoned.into_inner()
-            }
-        };
-        if let Some(t) = *last {
-            if t.elapsed() < REAUTH_MIN_INTERVAL {
-                conn.send(RelayMessage::ok(
-                    &event_id_hex_early,
-                    false,
-                    "auth-required: re-auth rate limited, try again later",
-                ));
-                return;
-            }
-        }
-        *last = Some(std::time::Instant::now());
-    }
 
     // On re-auth failure, restore the previous AuthContext (NIP-AA §6).
     macro_rules! reauth_fail {
@@ -544,7 +515,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 conn.send(RelayMessage::ok(
                     &event_id_hex,
                     false,
-                    &format!("invalid: {e}"),
+                    "invalid: verification failed",
                 ));
                 return;
             }
@@ -702,13 +673,16 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 }
             }
             // Relay membership gate — applies to ALL auth methods; NIP-AA fallback included.
+            // Confused-deputy prevention: pass empty tag slice so a non-agent user who
+            // happens to carry an `auth` tag cannot be escalated via the NIP-AA path.
+            // Only the dedicated NIP-AA agent path (above) passes real event tags.
             let nip_aa_owner = match enforce_ws_relay_membership(
                 &state,
                 &conn,
                 conn_id,
                 &pubkey,
                 &event_id_hex,
-                &event_tags,
+                &[], // Okta/JWT path: auth tags intentionally ignored per confused-deputy rule
                 event_created_at_ts,
             )
             .await

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -105,11 +105,16 @@ fn verify_api_token_nip42_binding(
     sprout_auth::verify_nip42_event(event, challenge, relay_url)
 }
 
-// NOTE: NIP-42 technically allows multiple authenticated pubkeys per connection.
-// Sprout currently supports only one authenticated identity per WebSocket connection.
-// This is a known limitation documented in NIP-AA §6. A re-auth with a DIFFERENT
-// pubkey is rejected; re-auth with the SAME pubkey replaces the credential.
-// Future work: per-pubkey auth state map for multi-identity connections.
+// NOTE: NIP-42 allows multiple authenticated pubkeys per connection. Sprout uses a
+// single-pubkey-at-a-time model: re-auth with any pubkey (same or different) replaces
+// the current credential. The previous identity is discarded. This is a valid subset
+// of the spec — the NIP-AA multi-pubkey language describes behavior IF multiple
+// pubkeys are supported, not a mandate to support them.
+//
+// A failed re-auth attempt preserves the existing identity per NIP-AA §6.
+//
+// Future work: per-pubkey auth state map (HashMap<PublicKey, AuthContext>) for
+// simultaneous multi-identity connections.
 
 /// Handle a NIP-42 AUTH message: verify the challenge response and transition the connection to authenticated state.
 pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state: Arc<AppState>) {
@@ -117,14 +122,12 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
 
     // Extract the challenge, conn_id, and (for re-auth) the previous AuthContext.
     //
-    // AuthState::Authenticated: NIP-AA §6 allows the same pubkey to re-auth on an
-    // already-authenticated connection to replace the stored credential. We retain
-    // the challenge in AuthState::Authenticated for exactly this purpose. Only the
-    // same pubkey may re-auth — a different pubkey is rejected to prevent session
-    // hijacking via credential replacement.
+    // AuthState::Authenticated: re-auth replaces the stored credential. Both same-pubkey
+    // credential refresh and different-pubkey identity switch are allowed. We retain
+    // the challenge in AuthState::Authenticated for exactly this purpose.
     //
-    // NIP-AA §6 also says: "A failed NIP-AA AUTH attempt does not necessarily
-    // invalidate other authenticated pubkeys on the same WebSocket connection."
+    // NIP-AA §6: "A failed NIP-AA AUTH attempt does not necessarily invalidate other
+    // authenticated pubkeys on the same WebSocket connection."
     // We preserve this by saving the previous AuthContext and restoring it if
     // re-auth fails, rather than transitioning to AuthState::Failed.
     let (challenge, conn_id, prev_auth_ctx) = {
@@ -132,26 +135,20 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
         match &*auth {
             AuthState::Pending { challenge } => (challenge.clone(), conn.conn_id, None),
             AuthState::Authenticated { challenge, ctx } => {
-                // NIP-AA §6: same-pubkey re-auth MUST replace the stored credential.
                 if event.pubkey != ctx.pubkey {
-                    warn!(
+                    info!(
                         conn_id = %conn.conn_id,
                         existing = %ctx.pubkey.to_hex(),
                         incoming = %event.pubkey.to_hex(),
-                        "NIP-AA §6: re-auth pubkey mismatch — rejecting"
+                        "re-auth: identity switch (single-pubkey-at-a-time model)"
                     );
-                    conn.send(RelayMessage::ok(
-                        &event_id_hex_early,
-                        false,
-                        "auth-required: pubkey mismatch on re-auth",
-                    ));
-                    return;
+                } else {
+                    debug!(
+                        conn_id = %conn.conn_id,
+                        pubkey = %ctx.pubkey.to_hex(),
+                        "NIP-AA §6: re-auth credential replacement"
+                    );
                 }
-                debug!(
-                    conn_id = %conn.conn_id,
-                    pubkey = %ctx.pubkey.to_hex(),
-                    "NIP-AA §6: re-auth credential replacement"
-                );
                 (challenge.clone(), conn.conn_id, Some(ctx.clone()))
             }
             AuthState::Failed => {

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -106,17 +106,22 @@ fn verify_api_token_nip42_binding(
 pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state: Arc<AppState>) {
     let event_id_hex_early = event.id.to_hex();
 
-    // Extract the challenge and conn_id from the current auth state.
+    // Extract the challenge, conn_id, and (for re-auth) the previous AuthContext.
     //
     // AuthState::Authenticated: NIP-AA §6 allows the same pubkey to re-auth on an
     // already-authenticated connection to replace the stored credential. We retain
     // the challenge in AuthState::Authenticated for exactly this purpose. Only the
     // same pubkey may re-auth — a different pubkey is rejected to prevent session
     // hijacking via credential replacement.
-    let (challenge, conn_id) = {
+    //
+    // NIP-AA §6 also says: "A failed NIP-AA AUTH attempt does not necessarily
+    // invalidate other authenticated pubkeys on the same WebSocket connection."
+    // We preserve this by saving the previous AuthContext and restoring it if
+    // re-auth fails, rather than transitioning to AuthState::Failed.
+    let (challenge, conn_id, prev_auth_ctx) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
-            AuthState::Pending { challenge } => (challenge.clone(), conn.conn_id),
+            AuthState::Pending { challenge } => (challenge.clone(), conn.conn_id, None),
             AuthState::Authenticated { challenge, ctx } => {
                 // NIP-AA §6: same-pubkey re-auth MUST replace the stored credential.
                 if event.pubkey != ctx.pubkey {
@@ -138,7 +143,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     pubkey = %ctx.pubkey.to_hex(),
                     "NIP-AA §6: re-auth credential replacement"
                 );
-                (challenge.clone(), conn.conn_id)
+                (challenge.clone(), conn.conn_id, Some(ctx.clone()))
             }
             AuthState::Failed => {
                 debug!(conn_id = %conn.conn_id, "AUTH received after failed auth");
@@ -151,6 +156,22 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             }
         }
     };
+
+    // Helper: on re-auth failure, restore the previous AuthContext rather than
+    // transitioning to Failed (per NIP-AA §6 — failed re-auth must not invalidate
+    // the existing authenticated identity).
+    macro_rules! reauth_fail {
+        ($state:expr) => {
+            if let Some(ref prev) = prev_auth_ctx {
+                *conn.auth_state.write().await = AuthState::Authenticated {
+                    ctx: prev.clone(),
+                    challenge: challenge.clone(),
+                };
+            } else {
+                *conn.auth_state.write().await = $state;
+            }
+        };
+    }
 
     let relay_url = state.config.relay_url.clone();
     let auth_svc = Arc::clone(&state.auth);
@@ -200,7 +221,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     warn!(conn_id = %conn_id, error = %e, "API token auth failed NIP-42 verification");
                     metrics::counter!("sprout_auth_failures_total", "reason" => "nip42_invalid")
                         .increment(1);
-                    *conn.auth_state.write().await = AuthState::Failed;
+                    reauth_fail!(AuthState::Failed);
                     conn.send(RelayMessage::ok(
                         &event_id_hex,
                         false,
@@ -212,7 +233,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     warn!(conn_id = %conn_id, error = %e, "API token NIP-42 verification task failed");
                     metrics::counter!("sprout_auth_failures_total", "reason" => "nip42_internal")
                         .increment(1);
-                    *conn.auth_state.write().await = AuthState::Failed;
+                    reauth_fail!(AuthState::Failed);
                     conn.send(RelayMessage::ok(
                         &event_id_hex,
                         false,
@@ -230,7 +251,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 Ok(Some(r)) => r,
                 Ok(None) => {
                     warn!(conn_id = %conn_id, "API token not found");
-                    *conn.auth_state.write().await = AuthState::Failed;
+                    reauth_fail!(AuthState::Failed);
                     conn.send(RelayMessage::ok(
                         &event_id_hex,
                         false,
@@ -240,7 +261,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 }
                 Err(e) => {
                     warn!(conn_id = %conn_id, error = %e, "API token lookup failed");
-                    *conn.auth_state.write().await = AuthState::Failed;
+                    reauth_fail!(AuthState::Failed);
                     conn.send(RelayMessage::ok(
                         &event_id_hex,
                         false,
@@ -255,7 +276,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 Ok(pk) => pk,
                 Err(e) => {
                     warn!(conn_id = %conn_id, error = %e, "API token owner pubkey invalid");
-                    *conn.auth_state.write().await = AuthState::Failed;
+                    reauth_fail!(AuthState::Failed);
                     conn.send(RelayMessage::ok(
                         &event_id_hex,
                         false,
@@ -323,7 +344,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                                 warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(),
                                       "NIP-AA: scope intersection is empty — denying (would widen access)");
                                 metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_empty_scope").increment(1);
-                                *conn.auth_state.write().await = AuthState::Failed;
+                                reauth_fail!(AuthState::Failed);
                                 conn.send(RelayMessage::ok(
                                     &event_id_hex,
                                     false,
@@ -360,7 +381,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 Err(e) => {
                     warn!(conn_id = %conn_id, error = %e, "API token verification failed");
                     metrics::counter!("sprout_auth_failures_total", "reason" => "api_token_invalid").increment(1);
-                    *conn.auth_state.write().await = AuthState::Failed;
+                    reauth_fail!(AuthState::Failed);
                     conn.send(RelayMessage::ok(
                         &event_id_hex,
                         false,
@@ -403,7 +424,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 warn!(conn_id = %conn_id, error = %e, "NIP-AA: NIP-42 binding verification failed");
                 metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_nip42_invalid")
                     .increment(1);
-                *conn.auth_state.write().await = AuthState::Failed;
+                reauth_fail!(AuthState::Failed);
                 conn.send(RelayMessage::ok(
                     &event_id_hex,
                     false,
@@ -415,7 +436,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 warn!(conn_id = %conn_id, error = %e, "NIP-AA: NIP-42 verification task panicked");
                 metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_nip42_internal")
                     .increment(1);
-                *conn.auth_state.write().await = AuthState::Failed;
+                reauth_fail!(AuthState::Failed);
                 conn.send(RelayMessage::ok(
                     &event_id_hex,
                     false,
@@ -503,7 +524,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), "pubkey not in allowlist");
                     metrics::counter!("sprout_auth_failures_total", "reason" => "allowlist_denied")
                         .increment(1);
-                    *conn.auth_state.write().await = AuthState::Failed;
+                    reauth_fail!(AuthState::Failed);
                     conn.send(RelayMessage::ok(
                         &event_id_hex,
                         false,
@@ -564,7 +585,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                             warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(),
                                   "NIP-AA: scope intersection is empty — denying (would widen access)");
                             metrics::counter!("sprout_auth_failures_total", "reason" => "nip_aa_empty_scope").increment(1);
-                            *conn.auth_state.write().await = AuthState::Failed;
+                            reauth_fail!(AuthState::Failed);
                             conn.send(RelayMessage::ok(
                                 &event_id_hex,
                                 false,
@@ -611,7 +632,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             warn!(conn_id = %conn_id, error = %e, "NIP-42 auth failed");
             metrics::counter!("sprout_auth_failures_total", "reason" => "nip42_invalid")
                 .increment(1);
-            *conn.auth_state.write().await = AuthState::Failed;
+            reauth_fail!(AuthState::Failed);
             conn.send(RelayMessage::ok(
                 &event_id_hex,
                 false,

--- a/crates/sprout-relay/src/handlers/event.rs
+++ b/crates/sprout-relay/src/handlers/event.rs
@@ -167,7 +167,7 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
     let (conn_id, pubkey_bytes, auth_pubkey, scopes, channel_ids, is_nip_aa_virtual) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
-            AuthState::Authenticated(ctx) => (
+            AuthState::Authenticated { ctx, .. } => (
                 conn.conn_id,
                 ctx.pubkey.serialize().to_vec(),
                 ctx.pubkey,

--- a/crates/sprout-relay/src/handlers/event.rs
+++ b/crates/sprout-relay/src/handlers/event.rs
@@ -164,7 +164,7 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
     metrics::counter!("sprout_events_received_total", "kind" => kind_str.clone()).increment(1);
 
     // ── Extract auth from WS connection state ────────────────────────────
-    let (conn_id, pubkey_bytes, auth_pubkey, scopes, channel_ids) = {
+    let (conn_id, pubkey_bytes, auth_pubkey, scopes, channel_ids, is_nip_aa_virtual) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
             AuthState::Authenticated(ctx) => (
@@ -173,6 +173,7 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
                 ctx.pubkey,
                 ctx.scopes.clone(),
                 ctx.channel_ids.clone(),
+                ctx.auth_method == sprout_auth::AuthMethod::Nip42AgentAuth,
             ),
             _ => {
                 reject("auth");
@@ -191,7 +192,10 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
     // events get a second check inside ingest_event() (step 3), but
     // ephemeral events bypass the pipeline entirely.
     let has_proxy_scope = scopes.contains(&sprout_auth::Scope::ProxySubmit);
-    let is_gift_wrap = kind_u32 == KIND_GIFT_WRAP;
+    // Gift-wrap exception: allows submitting kind:1059 events with an ephemeral
+    // outer pubkey for privacy. NIP-AA virtual members are excluded — they must
+    // only submit events signed by their own authenticated pubkey.
+    let is_gift_wrap = kind_u32 == KIND_GIFT_WRAP && !is_nip_aa_virtual;
     if event.pubkey != auth_pubkey && !has_proxy_scope && !is_gift_wrap {
         reject("invalid");
         conn.send(RelayMessage::ok(

--- a/crates/sprout-relay/src/handlers/event.rs
+++ b/crates/sprout-relay/src/handlers/event.rs
@@ -164,7 +164,15 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
     metrics::counter!("sprout_events_received_total", "kind" => kind_str.clone()).increment(1);
 
     // ── Extract auth from WS connection state ────────────────────────────
-    let (conn_id, pubkey_bytes, auth_pubkey, scopes, channel_ids, is_nip_aa_virtual) = {
+    let (
+        conn_id,
+        pubkey_bytes,
+        auth_pubkey,
+        scopes,
+        channel_ids,
+        is_nip_aa_virtual,
+        session_expiry,
+    ) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
             AuthState::Authenticated { ctx, .. } => (
@@ -174,6 +182,7 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
                 ctx.scopes.clone(),
                 ctx.channel_ids.clone(),
                 ctx.auth_method == sprout_auth::AuthMethod::Nip42AgentAuth,
+                ctx.session_expiry,
             ),
             _ => {
                 reject("auth");
@@ -186,6 +195,25 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
             }
         }
     };
+
+    // ── NIP-AA §Expiry: reject all event submissions after delegation expiry ──
+    // Defense-in-depth — ingest.rs also checks, but catching it here prevents
+    // any processing of events from expired sessions.
+    if let Some(expiry) = session_expiry {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if now >= expiry {
+            let msg = RelayMessage::ok(
+                &event.id.to_hex(),
+                false,
+                "restricted: NIP-AA session expired",
+            );
+            conn.send(msg.to_string());
+            return;
+        }
+    }
 
     // ── Pubkey / auth identity match (all events) ─────────────────────
     // Must run before both ephemeral and persistent branches. Persistent
@@ -272,6 +300,8 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
         scopes,
         channel_ids,
         conn_id,
+        is_nip_aa_virtual,
+        session_expiry,
     };
 
     match super::ingest::ingest_event(&state, event, ingest_auth).await {

--- a/crates/sprout-relay/src/handlers/ingest.rs
+++ b/crates/sprout-relay/src/handlers/ingest.rs
@@ -60,6 +60,12 @@ pub enum IngestAuth {
         channel_ids: Option<Vec<Uuid>>,
         /// WebSocket connection identifier.
         conn_id: Uuid,
+        /// Whether this connection authenticated via NIP-AA (agent-on-behalf-of-owner).
+        /// Virtual members must not use the gift-wrap pubkey bypass.
+        is_nip_aa_virtual: bool,
+        /// For NIP-AA virtual members: optional session expiry from `created_at<T` conditions.
+        /// Events submitted after this Unix timestamp are rejected.
+        session_expiry: Option<u64>,
     },
     /// HTTP REST authenticated request.
     Http {
@@ -104,6 +110,18 @@ impl IngestAuth {
         }
     }
 
+    /// Whether this is a NIP-AA virtual-member connection.
+    /// Virtual members must not use the gift-wrap pubkey bypass.
+    pub fn is_nip_aa_virtual(&self) -> bool {
+        matches!(
+            self,
+            Self::Nip42 {
+                is_nip_aa_virtual: true,
+                ..
+            }
+        )
+    }
+
     /// Token-level channel restriction (Http/ApiToken only).
     pub fn channel_ids(&self) -> Option<&[Uuid]> {
         match self {
@@ -122,6 +140,15 @@ impl IngestAuth {
     /// Whether this auth context is an HTTP request (not WebSocket).
     pub fn is_http(&self) -> bool {
         matches!(self, Self::Http { .. })
+    }
+
+    /// NIP-AA session expiry (Nip42 virtual members only).
+    /// Returns `None` for direct members, HTTP auth, or NIP-AA without a `created_at<T` bound.
+    pub fn session_expiry(&self) -> Option<u64> {
+        match self {
+            Self::Nip42 { session_expiry, .. } => *session_expiry,
+            Self::Http { .. } => None,
+        }
     }
 }
 
@@ -844,11 +871,30 @@ pub async fn ingest_event(
     }
 
     // ── 3. Pubkey match ──────────────────────────────────────────────────
-    let is_gift_wrap = kind_u32 == KIND_GIFT_WRAP;
+    // Gift-wrap exception: kind:1059 allows an ephemeral outer pubkey for privacy.
+    // NIP-AA virtual members are excluded — they must only submit events signed
+    // by their own authenticated pubkey (mirrors the check in handle_event).
+    let is_gift_wrap = kind_u32 == KIND_GIFT_WRAP && !auth.is_nip_aa_virtual();
     if event.pubkey != *auth.pubkey() && !auth.has_proxy_scope() && !is_gift_wrap {
         return Err(IngestError::AuthFailed(
             "invalid: event pubkey does not match authenticated identity".into(),
         ));
+    }
+
+    // ── 3b. NIP-AA session expiry ────────────────────────────────────────
+    // Reject events after the delegation's created_at<T bound. This enforces
+    // the time-limited delegation even after a successful login — an agent
+    // that authenticated before expiry cannot keep publishing indefinitely.
+    if let Some(expiry) = auth.session_expiry() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if now >= expiry {
+            return Err(IngestError::Rejected(
+                "restricted: NIP-AA session expired (created_at< condition exceeded)".into(),
+            ));
+        }
     }
 
     // ── 4. Per-kind scope allowlist ──────────────────────────────────────
@@ -1063,6 +1109,24 @@ pub async fn ingest_event(
                 return Err(IngestError::Internal(
                     "unexpected RoleMismatch from remove_relay_member".into(),
                 ));
+            }
+        }
+
+        // NIP-AA: disconnect agent connections owned by the leaving member.
+        // Agents inherit access from their owner — when the owner leaves, their
+        // agents must be disconnected immediately (mirrors admin removal logic).
+        {
+            let sender_bytes = hex::decode(&sender_hex).unwrap_or_default();
+            let agent_conn_ids = state.conn_manager.connection_ids_for_owner(&sender_bytes);
+            for conn_id in &agent_conn_ids {
+                state.conn_manager.close_connection(*conn_id);
+            }
+            if !agent_conn_ids.is_empty() {
+                tracing::info!(
+                    owner = %sender_hex,
+                    disconnected = agent_conn_ids.len(),
+                    "disconnected NIP-AA agent connections after owner self-leave"
+                );
             }
         }
 
@@ -1512,6 +1576,45 @@ pub async fn ingest_event(
         }
     }
 
+    // ── 21b. NIP-AA: terminate agent sessions for removed/leaving members ─
+    // kind:9001 (remove user) — target is the `p` tag pubkey.
+    // kind:9022 (leave request) — target is the event sender.
+    // Both paths mirror the NIP-43 leave logic above (step 9b).
+    if kind_u32 == KIND_NIP29_REMOVE_USER || kind_u32 == KIND_NIP29_LEAVE_REQUEST {
+        let owner_bytes: Option<Vec<u8>> = if kind_u32 == KIND_NIP29_REMOVE_USER {
+            // Extract target pubkey from first `p` tag (same logic as side_effects::extract_p_tag).
+            event.tags.iter().find_map(|t| {
+                if t.kind().to_string() == "p" {
+                    if let Some(val) = t.content() {
+                        if let Ok(bytes) = hex::decode(val) {
+                            if bytes.len() == 32 {
+                                return Some(bytes);
+                            }
+                        }
+                    }
+                }
+                None
+            })
+        } else {
+            // kind:9022 — sender is removing themselves.
+            Some(event.pubkey.serialize().to_vec())
+        };
+
+        if let Some(owner_bytes) = owner_bytes {
+            let agent_conn_ids = state.conn_manager.connection_ids_for_owner(&owner_bytes);
+            for conn_id in &agent_conn_ids {
+                state.conn_manager.close_connection(*conn_id);
+            }
+            if !agent_conn_ids.is_empty() {
+                tracing::info!(
+                    owner = hex::encode(&owner_bytes),
+                    agent_sessions = agent_conn_ids.len(),
+                    "terminated NIP-AA agent sessions for removed member"
+                );
+            }
+        }
+    }
+
     // ── 22. Fan-out ──────────────────────────────────────────────────────
     let pubkey_hex = auth.pubkey().to_hex();
     dispatch_persistent_event(state, &stored_event, kind_u32, &pubkey_hex).await;
@@ -1727,6 +1830,8 @@ mod tests {
             scopes: vec![],
             channel_ids: None,
             conn_id: uuid::Uuid::new_v4(),
+            is_nip_aa_virtual: false,
+            session_expiry: None,
         };
         assert!(
             !ws_auth.is_http(),

--- a/crates/sprout-relay/src/handlers/mod.rs
+++ b/crates/sprout-relay/src/handlers/mod.rs
@@ -5,6 +5,8 @@ pub mod close;
 pub mod event;
 /// Transport-neutral event ingestion pipeline.
 pub mod ingest;
+/// NIP-AA agent authentication via NIP-OA credentials.
+pub mod nip_aa;
 /// NIP-43 relay membership admin command handler (kinds 9030–9032).
 pub mod relay_admin;
 pub mod req;

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -177,16 +177,19 @@ pub async fn verify_nip_aa(
 
 /// Evaluate `created_at<t` and `created_at>t` conditions against an event's created_at.
 /// Returns Ok(()) if all conditions pass, Err(reason) if any fail.
-/// `kind=` conditions are intentionally skipped per NIP-AA spec.
+/// `kind=` conditions are intentionally skipped per NIP-AA spec — they are valid
+/// but not evaluated at connection admission.
 ///
-/// **Precondition**: This function is only called after `verify_auth_tag` has validated
-/// the conditions string. Empty clauses and unknown clause types are unreachable in
-/// production — they are handled defensively (skipped) rather than rejected, because
-/// the upstream SDK validation is the authoritative guard.
+/// Per NIP-OA spec: verifiers MUST reject an auth tag that contains an unsupported
+/// clause. Empty clauses (from leading/trailing `&`) and unknown clause types are
+/// therefore rejected with an error.
 fn evaluate_created_at_conditions(conditions: &str, event_created_at: u64) -> Result<(), String> {
+    if conditions.is_empty() {
+        return Ok(());
+    }
     for clause in conditions.split('&') {
         if clause.is_empty() {
-            continue;
+            return Err("restricted: malformed conditions string (empty clause)".to_string());
         }
         if let Some(val_str) = clause.strip_prefix("created_at<") {
             let threshold: u64 = val_str
@@ -206,8 +209,13 @@ fn evaluate_created_at_conditions(conditions: &str, event_created_at: u64) -> Re
                     "created_at condition not satisfied: {event_created_at} <= {threshold}"
                 ));
             }
+        } else if clause.starts_with("kind=") {
+            // kind= clauses are intentionally skipped at admission per NIP-AA §Kind Conditions
+        } else {
+            return Err(format!(
+                "restricted: unsupported condition clause: {clause}"
+            ));
         }
-        // kind= clauses are intentionally skipped at admission per NIP-AA §Kind Conditions
     }
     Ok(())
 }
@@ -453,21 +461,22 @@ mod tests {
     }
 
     #[test]
-    fn empty_clause_from_leading_ampersand_is_skipped() {
-        // A leading & produces an empty first clause — must not error.
-        assert!(evaluate_created_at_conditions("&created_at>0", 1000).is_ok());
+    fn empty_clause_from_leading_ampersand_is_rejected() {
+        // A leading & produces an empty first clause — must be rejected per NIP-OA spec.
+        assert!(evaluate_created_at_conditions("&created_at>0", 1000).is_err());
     }
 
     #[test]
-    fn empty_clause_from_trailing_ampersand_is_skipped() {
-        // A trailing & produces an empty last clause — must not error.
-        assert!(evaluate_created_at_conditions("created_at>0&", 1000).is_ok());
+    fn empty_clause_from_trailing_ampersand_is_rejected() {
+        // A trailing & produces an empty last clause — must be rejected per NIP-OA spec.
+        assert!(evaluate_created_at_conditions("created_at>0&", 1000).is_err());
     }
 
     #[test]
-    fn unknown_clause_type_is_skipped() {
-        // Unknown condition types (future extensions) must be ignored, not rejected.
-        assert!(evaluate_created_at_conditions("foo=bar&created_at>0", 1000).is_ok());
+    fn unknown_clause_type_is_rejected() {
+        // Unknown condition types must be rejected — NIP-OA: verifiers MUST reject
+        // auth tags containing unsupported clauses.
+        assert!(evaluate_created_at_conditions("foo=bar&created_at>0", 1000).is_err());
     }
 
     // ── self-attestation rejection ────────────────────────────────────────────

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -40,7 +40,7 @@ fn extract_single_auth_tag(tags: &[nostr::Tag]) -> Result<Option<&nostr::Tag>, S
 /// Extract and verify a NIP-OA auth tag from event tags for NIP-AA authentication.
 ///
 /// Implements NIP-AA Steps 3-5:
-/// - Step 3: Extract exactly one `auth` tag (zero or >1 → None)
+/// - Step 3: Extract exactly one `auth` tag (zero → Ok(None); >1 → Err)
 /// - Step 4: Verify the auth tag cryptographically (reuses sprout-sdk nip_oa)
 /// - Step 4b: Evaluate created_at conditions against the event's created_at
 /// - Step 5: Check that the owner is an active relay member

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -46,6 +46,10 @@ pub fn extract_single_auth_tag(tags: &[nostr::Tag]) -> Result<Option<&nostr::Tag
 /// Only runs when the tag has ≥ 4 elements (the minimum for a well-formed auth
 /// tag). Tags with fewer elements are passed through and will fail the
 /// `verify_auth_tag` element-count check instead.
+///
+/// This is a defense-in-depth check: the SDK's `verify_auth_tag` also validates
+/// these fields, but `secp256k1::from_hex` silently accepts uppercase hex. This
+/// pre-check enforces the NIP-OA lowercase-only constraint before the crypto call.
 fn validate_auth_tag_hex(auth_tag: &nostr::Tag) -> Result<(), String> {
     let tag_slice = auth_tag.as_slice();
     if tag_slice.len() >= 4 {
@@ -174,6 +178,11 @@ pub async fn verify_nip_aa(
 /// Evaluate `created_at<t` and `created_at>t` conditions against an event's created_at.
 /// Returns Ok(()) if all conditions pass, Err(reason) if any fail.
 /// `kind=` conditions are intentionally skipped per NIP-AA spec.
+///
+/// **Precondition**: This function is only called after `verify_auth_tag` has validated
+/// the conditions string. Empty clauses and unknown clause types are unreachable in
+/// production — they are handled defensively (skipped) rather than rejected, because
+/// the upstream SDK validation is the authoritative guard.
 fn evaluate_created_at_conditions(conditions: &str, event_created_at: u64) -> Result<(), String> {
     for clause in conditions.split('&') {
         if clause.is_empty() {

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -350,7 +350,7 @@ mod tests {
 
     fn make_hex(len: usize, uppercase: bool) -> String {
         let ch = if uppercase { 'A' } else { 'a' };
-        std::iter::repeat(ch).take(len).collect()
+        std::iter::repeat_n(ch, len).collect()
     }
 
     #[test]

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -113,13 +113,22 @@ pub async fn verify_nip_aa(
         }
     }
 
-    // Step 5: Check owner is an active relay member
+    // Step 5: Check owner is an active relay member.
+    // Log DB errors server-side; send a sanitized fail-closed message to the client
+    // to avoid leaking internal error details.
     let owner_hex = owner_pubkey.to_hex();
-    let is_member = state
-        .db
-        .is_relay_member(&owner_hex)
-        .await
-        .map_err(|e| format!("restricted: owner membership check failed: {e}"))?;
+    let is_member = match state.db.is_relay_member(&owner_hex).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                agent = %agent_pubkey.to_hex(),
+                owner = %owner_hex,
+                error = %e,
+                "NIP-AA: owner membership DB check failed"
+            );
+            return Err("restricted: membership check failed".to_string());
+        }
+    };
 
     if !is_member {
         return Err("restricted: owner is not a relay member".to_string());

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -4,7 +4,7 @@
 //! carries a valid NIP-OA `auth` tag whose owner is an active member.
 
 use nostr::PublicKey;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::state::AppState;
 
@@ -37,7 +37,10 @@ pub fn extract_single_auth_tag(tags: &[nostr::Tag]) -> Result<Option<&nostr::Tag
     match auth_tags.len() {
         0 => Ok(None),
         1 => Ok(Some(auth_tags[0])),
-        _ => Err("restricted: multiple auth tags present".to_string()),
+        _ => {
+            warn!("NIP-AA: multiple auth tags present in event");
+            Err("restricted: agent authentication failed".to_string())
+        }
     }
 }
 
@@ -58,10 +61,11 @@ fn validate_auth_tag_hex(auth_tag: &nostr::Tag) -> Result<(), String> {
                 .chars()
                 .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
         {
-            return Err(format!(
-                "restricted: owner pubkey must be 64 lowercase hex chars, got {:?}",
-                owner_hex
-            ));
+            warn!(
+                owner_hex = %owner_hex,
+                "NIP-AA: owner pubkey must be 64 lowercase hex chars"
+            );
+            return Err("invalid: malformed agent credential".to_string());
         }
         let sig_hex = &tag_slice[3];
         if sig_hex.len() != 128
@@ -69,10 +73,11 @@ fn validate_auth_tag_hex(auth_tag: &nostr::Tag) -> Result<(), String> {
                 .chars()
                 .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
         {
-            return Err(format!(
-                "restricted: signature must be 128 lowercase hex chars, got length {}",
-                sig_hex.len()
-            ));
+            warn!(
+                sig_len = sig_hex.len(),
+                "NIP-AA: signature must be 128 lowercase hex chars"
+            );
+            return Err("invalid: malformed agent credential".to_string());
         }
     }
     Ok(())
@@ -102,17 +107,17 @@ fn validate_auth_tag_hex(auth_tag: &nostr::Tag) -> Result<(), String> {
 /// | Condition | Return value | Reason prefix |
 /// |-----------|-------------|---------------|
 /// | No `auth` tag | `Ok(None)` | — (not an agent) |
-/// | Multiple `auth` tags | `Err` | `"restricted: multiple auth tags present"` |
-/// | Owner pubkey not 64-char lowercase hex | `Err` | `"restricted: owner pubkey must be 64 lowercase hex chars"` |
-/// | Signature not 128-char lowercase hex | `Err` | `"restricted: signature must be 128 lowercase hex chars"` |
-/// | NIP-OA signature verification fails | `Err` | `"restricted: invalid auth tag: …"` |
-/// | Self-attestation (agent == owner) | `Err` | `"restricted: invalid auth tag: …"` (from sprout-sdk) |
-/// | `kind=` condition present | `Err` | `"restricted: unsupported condition for NIP-AA: kind= restrictions are not yet enforced per-action…"` |
-/// | `created_at<T` condition not satisfied | `Err` | `"restricted: created_at condition not satisfied: …"` |
-/// | `created_at>T` condition not satisfied | `Err` | `"restricted: created_at condition not satisfied: …"` |
-/// | Malformed `created_at` threshold | `Err` | `"restricted: malformed created_at< condition: …"` |
-/// | Owner not an active relay member | `Err` | `"restricted: owner is not a relay member"` |
-/// | DB membership check fails | `Err` | `"restricted: membership check failed"` |
+/// | Multiple `auth` tags | `Err` | `"restricted: agent authentication failed"` |
+/// | Owner pubkey not 64-char lowercase hex | `Err` | `"invalid: malformed agent credential"` |
+/// | Signature not 128-char lowercase hex | `Err` | `"invalid: malformed agent credential"` |
+/// | NIP-OA signature verification fails | `Err` | `"restricted: agent authentication failed"` |
+/// | Self-attestation (agent == owner) | `Err` | `"restricted: agent authentication failed"` |
+/// | `kind=` condition present | `Err` | `"restricted: agent authentication failed"` |
+/// | `created_at<T` condition not satisfied | `Err` | `"restricted: agent authentication failed"` |
+/// | `created_at>T` condition not satisfied | `Err` | `"restricted: agent authentication failed"` |
+/// | Malformed `created_at` threshold | `Err` | `"restricted: agent authentication failed"` |
+/// | Owner not an active relay member | `Err` | `"restricted: agent authentication failed"` |
+/// | DB membership check fails | `Err` | `"restricted: agent authentication failed"` |
 pub async fn verify_nip_aa(
     state: &AppState,
     agent_pubkey: &PublicKey,
@@ -127,8 +132,10 @@ pub async fn verify_nip_aa(
     // Step 4: Pre-validate lowercase hex before the crypto call.
     validate_auth_tag_hex(auth_tag)?;
 
-    let tag_json = serde_json::to_string(&auth_tag.as_slice())
-        .map_err(|e| format!("restricted: failed to serialize auth tag: {e}"))?;
+    let tag_json = serde_json::to_string(&auth_tag.as_slice()).map_err(|e| {
+        warn!(error = %e, "NIP-AA: failed to serialize auth tag");
+        "invalid: malformed agent credential".to_string()
+    })?;
 
     // Step 4: Verify the auth tag — CPU-intensive, run on blocking thread pool.
     let agent_pk_owned = *agent_pubkey;
@@ -140,11 +147,12 @@ pub async fn verify_nip_aa(
     {
         Ok(Ok(pk)) => pk,
         Ok(Err(e)) => {
-            return Err(format!("restricted: invalid auth tag: {e}"));
+            warn!(error = %e, "NIP-AA: auth tag verification failed");
+            return Err("restricted: agent authentication failed".to_string());
         }
         Err(e) => {
-            tracing::warn!(error = %e, "NIP-AA: verify_auth_tag task panicked");
-            return Err("restricted: verification failed".to_string());
+            warn!(error = %e, "NIP-AA: verify_auth_tag task panicked");
+            return Err("restricted: agent authentication failed".to_string());
         }
     };
 
@@ -154,7 +162,8 @@ pub async fn verify_nip_aa(
         let conditions = &tag_slice[2];
         if !conditions.is_empty() {
             if let Err(reason) = evaluate_created_at_conditions(conditions, event_created_at) {
-                return Err(format!("restricted: {reason}"));
+                warn!(reason = %reason, "NIP-AA: created_at condition check failed");
+                return Err("restricted: agent authentication failed".to_string());
             }
             extract_session_expiry(conditions)
         } else {
@@ -175,12 +184,17 @@ pub async fn verify_nip_aa(
                 error = %e,
                 "NIP-AA: owner membership DB check failed"
             );
-            return Err("restricted: membership check failed".to_string());
+            return Err("restricted: agent authentication failed".to_string());
         }
     };
 
     if !is_member {
-        return Err("restricted: owner is not a relay member".to_string());
+        warn!(
+            agent = %agent_pubkey.to_hex(),
+            owner = %owner_hex,
+            "NIP-AA: owner is not a relay member"
+        );
+        return Err("restricted: agent authentication failed".to_string());
     }
 
     debug!(
@@ -402,7 +416,7 @@ mod tests {
             result.is_err(),
             "expected Err for multiple auth tags, got {result:?}"
         );
-        assert!(result.unwrap_err().contains("multiple auth tags"));
+        assert!(result.unwrap_err().contains("agent authentication failed"));
     }
 
     #[test]
@@ -446,7 +460,7 @@ mod tests {
         let tag = nostr::Tag::parse(&["auth", &owner, "", &sig]).expect("valid tag");
         let err = validate_auth_tag_hex(&tag).unwrap_err();
         assert!(
-            err.contains("owner pubkey must be 64 lowercase hex chars"),
+            err.contains("malformed agent credential"),
             "unexpected error: {err}"
         );
     }
@@ -474,7 +488,7 @@ mod tests {
         let tag = nostr::Tag::parse(&["auth", &owner, "", &sig]).expect("valid tag");
         let err = validate_auth_tag_hex(&tag).unwrap_err();
         assert!(
-            err.contains("signature must be 128 lowercase hex chars"),
+            err.contains("malformed agent credential"),
             "unexpected error: {err}"
         );
     }

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -14,6 +14,29 @@ pub struct NipAaResult {
     pub owner_pubkey: PublicKey,
 }
 
+/// Extract exactly one `auth` tag from a slice of event tags.
+///
+/// - Returns `Ok(None)` if no `auth` tag is present (not a NIP-AA attempt).
+/// - Returns `Err` if more than one `auth` tag is present (ambiguous credential).
+/// - Returns `Ok(Some(&tag))` for exactly one match.
+///
+/// Extracted as a pure function so it can be unit-tested without `AppState`.
+fn extract_single_auth_tag(tags: &[nostr::Tag]) -> Result<Option<&nostr::Tag>, String> {
+    let auth_tags: Vec<&nostr::Tag> = tags
+        .iter()
+        .filter(|t| {
+            let s = t.as_slice();
+            !s.is_empty() && s[0] == "auth"
+        })
+        .collect();
+
+    match auth_tags.len() {
+        0 => Ok(None),
+        1 => Ok(Some(auth_tags[0])),
+        _ => Err("restricted: multiple auth tags present".to_string()),
+    }
+}
+
 /// Extract and verify a NIP-OA auth tag from event tags for NIP-AA authentication.
 ///
 /// Implements NIP-AA Steps 3-5:
@@ -32,23 +55,10 @@ pub async fn verify_nip_aa(
     event_created_at: u64,
 ) -> Result<Option<NipAaResult>, String> {
     // Step 3: Extract exactly one auth tag
-    let auth_tags: Vec<&nostr::Tag> = tags
-        .iter()
-        .filter(|t| {
-            let s = t.as_slice();
-            !s.is_empty() && s[0] == "auth"
-        })
-        .collect();
-
-    if auth_tags.is_empty() {
-        return Ok(None); // No auth tag — not an agent, not a NIP-AA attempt
-    }
-
-    if auth_tags.len() > 1 {
-        return Err("restricted: multiple auth tags present".to_string());
-    }
-
-    let auth_tag = auth_tags[0];
+    let auth_tag = match extract_single_auth_tag(tags)? {
+        None => return Ok(None), // No auth tag — not an agent, not a NIP-AA attempt
+        Some(tag) => tag,
+    };
     let tag_json = serde_json::to_string(&auth_tag.as_slice())
         .map_err(|e| format!("restricted: failed to serialize auth tag: {e}"))?;
 
@@ -183,5 +193,52 @@ mod tests {
     #[test]
     fn malformed_threshold_returns_err() {
         assert!(evaluate_created_at_conditions("created_at<notanumber", 1000).is_err());
+    }
+
+    // ── extract_single_auth_tag ───────────────────────────────────────────────
+    // These tests cover the NIP-AA §Step 3 logic (no auth tags → Ok(None),
+    // multiple auth tags → Err) without requiring AppState or async runtime.
+
+    #[test]
+    fn no_auth_tags_returns_ok_none() {
+        // verify_nip_aa returns Ok(None) when no auth tag is present — the
+        // caller treats this as "not an agent" and falls through to a plain
+        // membership failure.
+        let tags: Vec<nostr::Tag> = vec![];
+        assert!(matches!(extract_single_auth_tag(&tags), Ok(None)));
+    }
+
+    #[test]
+    fn non_auth_tags_ignored_returns_ok_none() {
+        // Unrelated tags (e.g. "p", "e") must not be mistaken for auth tags.
+        let tags = vec![
+            nostr::Tag::parse(&["p", "deadbeef"]).expect("valid tag"),
+            nostr::Tag::parse(&["e", "cafebabe"]).expect("valid tag"),
+        ];
+        assert!(matches!(extract_single_auth_tag(&tags), Ok(None)));
+    }
+
+    #[test]
+    fn multiple_auth_tags_returns_err() {
+        // NIP-AA §Step 3: more than one auth tag is ambiguous and must be
+        // rejected. verify_nip_aa propagates this as Err.
+        let tags = vec![
+            nostr::Tag::parse(&["auth", "owner1hex", "", "sig1"]).expect("valid tag"),
+            nostr::Tag::parse(&["auth", "owner2hex", "", "sig2"]).expect("valid tag"),
+        ];
+        let result = extract_single_auth_tag(&tags);
+        assert!(
+            result.is_err(),
+            "expected Err for multiple auth tags, got {result:?}"
+        );
+        assert!(result.unwrap_err().contains("multiple auth tags"));
+    }
+
+    #[test]
+    fn single_auth_tag_returns_ok_some() {
+        let tags = vec![
+            nostr::Tag::parse(&["auth", "ownerhex", "created_at>0", "sig"]).expect("valid tag"),
+        ];
+        assert!(matches!(extract_single_auth_tag(&tags), Ok(Some(_))));
     }
 }

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -37,6 +37,44 @@ fn extract_single_auth_tag(tags: &[nostr::Tag]) -> Result<Option<&nostr::Tag>, S
     }
 }
 
+/// Pre-validate that an `auth` tag's owner pubkey and signature fields are
+/// 64-char and 128-char lowercase hex respectively.
+///
+/// NIP-OA mandates lowercase hex; secp256k1's `from_hex` silently accepts
+/// uppercase, so we enforce the spec constraint here before the crypto call.
+///
+/// Only runs when the tag has ≥ 4 elements (the minimum for a well-formed auth
+/// tag). Tags with fewer elements are passed through and will fail the
+/// `verify_auth_tag` element-count check instead.
+fn validate_auth_tag_hex(auth_tag: &nostr::Tag) -> Result<(), String> {
+    let tag_slice = auth_tag.as_slice();
+    if tag_slice.len() >= 4 {
+        let owner_hex = &tag_slice[1];
+        if owner_hex.len() != 64
+            || !owner_hex
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        {
+            return Err(format!(
+                "restricted: owner pubkey must be 64 lowercase hex chars, got {:?}",
+                owner_hex
+            ));
+        }
+        let sig_hex = &tag_slice[3];
+        if sig_hex.len() != 128
+            || !sig_hex
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        {
+            return Err(format!(
+                "restricted: signature must be 128 lowercase hex chars, got length {}",
+                sig_hex.len()
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Extract and verify a NIP-OA auth tag from event tags for NIP-AA authentication.
 ///
 /// Implements NIP-AA Steps 3-5:
@@ -62,33 +100,7 @@ pub async fn verify_nip_aa(
     // Step 4: Pre-validate lowercase hex requirements before calling verify_auth_tag.
     // NIP-OA requires 64-char lowercase hex owner pubkey and 128-char lowercase hex sig.
     // secp256k1's from_hex accepts uppercase, so we enforce the spec constraint here.
-    {
-        let tag_slice = auth_tag.as_slice();
-        if tag_slice.len() >= 4 {
-            let owner_hex = &tag_slice[1];
-            if owner_hex.len() != 64
-                || !owner_hex
-                    .chars()
-                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
-            {
-                return Err(format!(
-                    "restricted: owner pubkey must be 64 lowercase hex chars, got {:?}",
-                    owner_hex
-                ));
-            }
-            let sig_hex = &tag_slice[3];
-            if sig_hex.len() != 128
-                || !sig_hex
-                    .chars()
-                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
-            {
-                return Err(format!(
-                    "restricted: signature must be 128 lowercase hex chars, got length {}",
-                    sig_hex.len()
-                ));
-            }
-        }
-    }
+    validate_auth_tag_hex(auth_tag)?;
 
     let tag_json = serde_json::to_string(&auth_tag.as_slice())
         .map_err(|e| format!("restricted: failed to serialize auth tag: {e}"))?;
@@ -280,5 +292,196 @@ mod tests {
             nostr::Tag::parse(&["auth", "ownerhex", "created_at>0", "sig"]).expect("valid tag"),
         ];
         assert!(matches!(extract_single_auth_tag(&tags), Ok(Some(_))));
+    }
+
+    #[test]
+    fn three_auth_tags_returns_err() {
+        let tags = vec![
+            nostr::Tag::parse(&["auth", "a", "", "s1"]).expect("valid tag"),
+            nostr::Tag::parse(&["auth", "b", "", "s2"]).expect("valid tag"),
+            nostr::Tag::parse(&["auth", "c", "", "s3"]).expect("valid tag"),
+        ];
+        assert!(extract_single_auth_tag(&tags).is_err());
+    }
+
+    // ── validate_auth_tag_hex ─────────────────────────────────────────────────
+
+    fn make_hex(len: usize, uppercase: bool) -> String {
+        let ch = if uppercase { 'A' } else { 'a' };
+        std::iter::repeat(ch).take(len).collect()
+    }
+
+    #[test]
+    fn validate_hex_passes_for_well_formed_tag() {
+        // A tag with exactly 64-char lowercase owner hex and 128-char lowercase sig hex.
+        let owner = make_hex(64, false);
+        let sig = make_hex(128, false);
+        let tag = nostr::Tag::parse(&["auth", &owner, "", &sig]).expect("valid tag");
+        assert!(validate_auth_tag_hex(&tag).is_ok());
+    }
+
+    #[test]
+    fn validate_hex_rejects_uppercase_owner_pubkey() {
+        // NIP-OA mandates lowercase hex. Uppercase must be rejected even though
+        // secp256k1's from_hex would silently accept it.
+        let owner = make_hex(64, true); // uppercase
+        let sig = make_hex(128, false);
+        let tag = nostr::Tag::parse(&["auth", &owner, "", &sig]).expect("valid tag");
+        let err = validate_auth_tag_hex(&tag).unwrap_err();
+        assert!(
+            err.contains("owner pubkey must be 64 lowercase hex chars"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_hex_rejects_short_owner_pubkey() {
+        let owner = make_hex(32, false); // too short
+        let sig = make_hex(128, false);
+        let tag = nostr::Tag::parse(&["auth", &owner, "", &sig]).expect("valid tag");
+        assert!(validate_auth_tag_hex(&tag).is_err());
+    }
+
+    #[test]
+    fn validate_hex_rejects_long_owner_pubkey() {
+        let owner = make_hex(65, false); // too long
+        let sig = make_hex(128, false);
+        let tag = nostr::Tag::parse(&["auth", &owner, "", &sig]).expect("valid tag");
+        assert!(validate_auth_tag_hex(&tag).is_err());
+    }
+
+    #[test]
+    fn validate_hex_rejects_uppercase_signature() {
+        let owner = make_hex(64, false);
+        let sig = make_hex(128, true); // uppercase
+        let tag = nostr::Tag::parse(&["auth", &owner, "", &sig]).expect("valid tag");
+        let err = validate_auth_tag_hex(&tag).unwrap_err();
+        assert!(
+            err.contains("signature must be 128 lowercase hex chars"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_hex_rejects_short_signature() {
+        let owner = make_hex(64, false);
+        let sig = make_hex(64, false); // too short
+        let tag = nostr::Tag::parse(&["auth", &owner, "", &sig]).expect("valid tag");
+        assert!(validate_auth_tag_hex(&tag).is_err());
+    }
+
+    #[test]
+    fn validate_hex_skips_check_for_tag_with_fewer_than_4_elements() {
+        // Tags with < 4 elements bypass the hex check here and will fail later
+        // in verify_auth_tag's element-count check. We must not panic or error
+        // prematurely on short tags.
+        let tag2 = nostr::Tag::parse(&["auth", "short"]).expect("valid tag");
+        assert!(
+            validate_auth_tag_hex(&tag2).is_ok(),
+            "2-element tag should pass hex check"
+        );
+
+        let tag3 = nostr::Tag::parse(&["auth", "a", "b"]).expect("valid tag");
+        assert!(
+            validate_auth_tag_hex(&tag3).is_ok(),
+            "3-element tag should pass hex check"
+        );
+    }
+
+    // ── evaluate_created_at_conditions — additional edge cases ────────────────
+
+    #[test]
+    fn created_at_lt_passes_one_below_boundary() {
+        // Strict less-than: value one below threshold must pass.
+        assert!(evaluate_created_at_conditions("created_at<1001", 1000).is_ok());
+    }
+
+    #[test]
+    fn created_at_gt_passes_one_above_boundary() {
+        // Strict greater-than: value one above threshold must pass.
+        assert!(evaluate_created_at_conditions("created_at>999", 1000).is_ok());
+    }
+
+    #[test]
+    fn multiple_kind_conditions_are_all_skipped() {
+        // Multiple kind= clauses must all be skipped — none should cause failure.
+        assert!(
+            evaluate_created_at_conditions("kind=9&kind=1&kind=30023&created_at>0", 1000).is_ok()
+        );
+    }
+
+    #[test]
+    fn empty_clause_from_leading_ampersand_is_skipped() {
+        // A leading & produces an empty first clause — must not error.
+        assert!(evaluate_created_at_conditions("&created_at>0", 1000).is_ok());
+    }
+
+    #[test]
+    fn empty_clause_from_trailing_ampersand_is_skipped() {
+        // A trailing & produces an empty last clause — must not error.
+        assert!(evaluate_created_at_conditions("created_at>0&", 1000).is_ok());
+    }
+
+    #[test]
+    fn unknown_clause_type_is_skipped() {
+        // Unknown condition types (future extensions) must be ignored, not rejected.
+        assert!(evaluate_created_at_conditions("foo=bar&created_at>0", 1000).is_ok());
+    }
+
+    // ── self-attestation rejection ────────────────────────────────────────────
+    // verify_auth_tag (sprout-sdk) rejects self-attestation. Verify that
+    // verify_nip_aa propagates this as Err without requiring AppState by
+    // calling sprout_sdk::nip_oa::verify_auth_tag directly.
+
+    #[test]
+    fn self_attestation_rejected_by_verify_auth_tag() {
+        use nostr::Keys;
+
+        let keys = Keys::generate();
+        let agent_pubkey = keys.public_key();
+
+        // Attempt to compute a self-attesting auth tag (owner == agent).
+        // compute_auth_tag itself rejects this — verify the error propagates.
+        let result = sprout_sdk::nip_oa::compute_auth_tag(&keys, &agent_pubkey, "");
+        assert!(
+            result.is_err(),
+            "compute_auth_tag must reject self-attestation"
+        );
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("self-attestation"),
+            "expected self-attestation error, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn verify_auth_tag_rejects_wrong_element_count_2() {
+        use nostr::Keys;
+        let keys = Keys::generate();
+        let agent_pubkey = keys.public_key();
+        // Manually craft a 2-element JSON array (missing conditions and sig).
+        let tag_json = r#"["auth","deadbeef"]"#;
+        let result = sprout_sdk::nip_oa::verify_auth_tag(tag_json, &agent_pubkey);
+        assert!(result.is_err(), "2-element auth tag must be rejected");
+    }
+
+    #[test]
+    fn verify_auth_tag_rejects_wrong_element_count_3() {
+        use nostr::Keys;
+        let keys = Keys::generate();
+        let agent_pubkey = keys.public_key();
+        let tag_json = r#"["auth","deadbeef","conditions"]"#;
+        let result = sprout_sdk::nip_oa::verify_auth_tag(tag_json, &agent_pubkey);
+        assert!(result.is_err(), "3-element auth tag must be rejected");
+    }
+
+    #[test]
+    fn verify_auth_tag_rejects_wrong_element_count_5() {
+        use nostr::Keys;
+        let keys = Keys::generate();
+        let agent_pubkey = keys.public_key();
+        let tag_json = r#"["auth","deadbeef","conditions","sig","extra"]"#;
+        let result = sprout_sdk::nip_oa::verify_auth_tag(tag_json, &agent_pubkey);
+        assert!(result.is_err(), "5-element auth tag must be rejected");
     }
 }

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -21,7 +21,7 @@ pub struct NipAaResult {
 /// - Returns `Ok(Some(&tag))` for exactly one match.
 ///
 /// Extracted as a pure function so it can be unit-tested without `AppState`.
-fn extract_single_auth_tag(tags: &[nostr::Tag]) -> Result<Option<&nostr::Tag>, String> {
+pub fn extract_single_auth_tag(tags: &[nostr::Tag]) -> Result<Option<&nostr::Tag>, String> {
     let auth_tags: Vec<&nostr::Tag> = tags
         .iter()
         .filter(|t| {

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -205,16 +205,22 @@ fn evaluate_created_at_conditions(conditions: &str, event_created_at: u64) -> Re
 
 #[cfg(test)]
 mod tests {
-    // E2E tests needed (requires running relay — implement in sprout-test-client):
+    // E2E tests needed (requires running relay + test client with NIP-42 AUTH):
     // - Valid NIP-AA login → virtual membership granted
     // - Invalid NIP-OA signature → rejected
     // - Self-attestation → rejected
     // - Owner not a relay member → rejected
     // - Stale AUTH event → rejected
-    // - Re-auth replaces credential
+    // - Re-auth replaces credential (same pubkey)
+    // - Re-auth identity switch (different pubkey) — new: single-pubkey-at-a-time
     // - Failed re-auth preserves existing session
     // - Virtual member denied admin commands
     // - Malformed AUTH closes connection
+    //
+    // Unit-tested elsewhere:
+    // - Scope intersection (admin stripped, read/write preserved) — auth.rs tests
+    // - Owner-pubkey tracking in ConnectionManager — state.rs tests
+    // - NIP-OA crypto, tag extraction, conditions — below
 
     use super::*;
 

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -86,6 +86,22 @@ fn validate_auth_tag_hex(auth_tag: &nostr::Tag) -> Result<(), String> {
 /// Returns `Ok(Some(NipAaResult))` if NIP-AA grants access.
 /// Returns `Ok(None)` if no auth tag is present (not an agent).
 /// Returns `Err(reason)` if auth tag is present but invalid.
+///
+/// ## Rejection matrix
+///
+/// | Condition | Return value | Reason prefix |
+/// |-----------|-------------|---------------|
+/// | No `auth` tag | `Ok(None)` | — (not an agent) |
+/// | Multiple `auth` tags | `Err` | `"restricted: multiple auth tags present"` |
+/// | Owner pubkey not 64-char lowercase hex | `Err` | `"restricted: owner pubkey must be 64 lowercase hex chars"` |
+/// | Signature not 128-char lowercase hex | `Err` | `"restricted: signature must be 128 lowercase hex chars"` |
+/// | NIP-OA signature verification fails | `Err` | `"restricted: invalid auth tag: …"` |
+/// | Self-attestation (agent == owner) | `Err` | `"restricted: invalid auth tag: …"` (from sprout-sdk) |
+/// | `created_at<T` condition not satisfied | `Err` | `"restricted: created_at condition not satisfied: …"` |
+/// | `created_at>T` condition not satisfied | `Err` | `"restricted: created_at condition not satisfied: …"` |
+/// | Malformed `created_at` threshold | `Err` | `"restricted: malformed created_at< condition: …"` |
+/// | Owner not an active relay member | `Err` | `"restricted: owner is not a relay member"` |
+/// | DB membership check fails | `Err` | `"restricted: membership check failed"` |
 pub async fn verify_nip_aa(
     state: &AppState,
     agent_pubkey: &PublicKey,
@@ -189,6 +205,17 @@ fn evaluate_created_at_conditions(conditions: &str, event_created_at: u64) -> Re
 
 #[cfg(test)]
 mod tests {
+    // E2E tests needed (requires running relay — implement in sprout-test-client):
+    // - Valid NIP-AA login → virtual membership granted
+    // - Invalid NIP-OA signature → rejected
+    // - Self-attestation → rejected
+    // - Owner not a relay member → rejected
+    // - Stale AUTH event → rejected
+    // - Re-auth replaces credential
+    // - Failed re-auth preserves existing session
+    // - Virtual member denied admin commands
+    // - Malformed AUTH closes connection
+
     use super::*;
 
     #[test]

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -189,7 +189,7 @@ fn evaluate_created_at_conditions(conditions: &str, event_created_at: u64) -> Re
     }
     for clause in conditions.split('&') {
         if clause.is_empty() {
-            return Err("restricted: malformed conditions string (empty clause)".to_string());
+            return Err("malformed conditions string (empty clause)".to_string());
         }
         if let Some(val_str) = clause.strip_prefix("created_at<") {
             let threshold: u64 = val_str
@@ -212,9 +212,7 @@ fn evaluate_created_at_conditions(conditions: &str, event_created_at: u64) -> Re
         } else if clause.starts_with("kind=") {
             // kind= clauses are intentionally skipped at admission per NIP-AA §Kind Conditions
         } else {
-            return Err(format!(
-                "restricted: unsupported condition clause: {clause}"
-            ));
+            return Err(format!("unsupported condition clause: {clause}"));
         }
     }
     Ok(())

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -1,0 +1,187 @@
+//! NIP-AA — Agent Authentication via NIP-OA Credentials
+//!
+//! When a pubkey is not a direct relay member, check if the AUTH event
+//! carries a valid NIP-OA `auth` tag whose owner is an active member.
+
+use nostr::PublicKey;
+use tracing::debug;
+
+use crate::state::AppState;
+
+/// Result of NIP-AA verification.
+pub struct NipAaResult {
+    /// The owner pubkey that granted virtual membership.
+    pub owner_pubkey: PublicKey,
+}
+
+/// Extract and verify a NIP-OA auth tag from event tags for NIP-AA authentication.
+///
+/// Implements NIP-AA Steps 3-5:
+/// - Step 3: Extract exactly one `auth` tag (zero or >1 → None)
+/// - Step 4: Verify the auth tag cryptographically (reuses sprout-sdk nip_oa)
+/// - Step 4b: Evaluate created_at conditions against the event's created_at
+/// - Step 5: Check that the owner is an active relay member
+///
+/// Returns `Ok(Some(NipAaResult))` if NIP-AA grants access.
+/// Returns `Ok(None)` if no auth tag is present (not an agent).
+/// Returns `Err(reason)` if auth tag is present but invalid.
+pub async fn verify_nip_aa(
+    state: &AppState,
+    agent_pubkey: &PublicKey,
+    tags: &[nostr::Tag],
+    event_created_at: u64,
+) -> Result<Option<NipAaResult>, String> {
+    // Step 3: Extract exactly one auth tag
+    let auth_tags: Vec<&nostr::Tag> = tags
+        .iter()
+        .filter(|t| {
+            let s = t.as_slice();
+            !s.is_empty() && s[0] == "auth"
+        })
+        .collect();
+
+    if auth_tags.is_empty() {
+        return Ok(None); // No auth tag — not an agent, not a NIP-AA attempt
+    }
+
+    if auth_tags.len() > 1 {
+        return Err("restricted: multiple auth tags present".to_string());
+    }
+
+    let auth_tag = auth_tags[0];
+    let tag_json = serde_json::to_string(&auth_tag.as_slice())
+        .map_err(|e| format!("restricted: failed to serialize auth tag: {e}"))?;
+
+    // Step 4: Verify the auth tag cryptographically
+    let owner_pubkey = match sprout_sdk::nip_oa::verify_auth_tag(&tag_json, agent_pubkey) {
+        Ok(pk) => pk,
+        Err(e) => {
+            return Err(format!("restricted: invalid auth tag: {e}"));
+        }
+    };
+
+    // Step 4b: Evaluate created_at conditions
+    // Parse conditions from the auth tag (element [2])
+    let tag_slice = auth_tag.as_slice();
+    if tag_slice.len() >= 3 {
+        let conditions = &tag_slice[2];
+        if !conditions.is_empty() {
+            if let Err(reason) = evaluate_created_at_conditions(conditions, event_created_at) {
+                return Err(format!("restricted: {reason}"));
+            }
+        }
+    }
+
+    // Step 5: Check owner is an active relay member
+    let owner_hex = owner_pubkey.to_hex();
+    let is_member = state
+        .db
+        .is_relay_member(&owner_hex)
+        .await
+        .map_err(|e| format!("restricted: owner membership check failed: {e}"))?;
+
+    if !is_member {
+        return Err("restricted: owner is not a relay member".to_string());
+    }
+
+    debug!(
+        agent = %agent_pubkey.to_hex(),
+        owner = %owner_hex,
+        "NIP-AA: virtual membership granted"
+    );
+
+    Ok(Some(NipAaResult { owner_pubkey }))
+}
+
+/// Evaluate `created_at<t` and `created_at>t` conditions against an event's created_at.
+/// Returns Ok(()) if all conditions pass, Err(reason) if any fail.
+/// `kind=` conditions are intentionally skipped per NIP-AA spec.
+fn evaluate_created_at_conditions(conditions: &str, event_created_at: u64) -> Result<(), String> {
+    for clause in conditions.split('&') {
+        if clause.is_empty() {
+            continue;
+        }
+        if let Some(val_str) = clause.strip_prefix("created_at<") {
+            let threshold: u64 = val_str
+                .parse()
+                .map_err(|_| format!("malformed created_at< condition: {clause}"))?;
+            if event_created_at >= threshold {
+                return Err(format!(
+                    "created_at condition not satisfied: {event_created_at} >= {threshold}"
+                ));
+            }
+        } else if let Some(val_str) = clause.strip_prefix("created_at>") {
+            let threshold: u64 = val_str
+                .parse()
+                .map_err(|_| format!("malformed created_at> condition: {clause}"))?;
+            if event_created_at <= threshold {
+                return Err(format!(
+                    "created_at condition not satisfied: {event_created_at} <= {threshold}"
+                ));
+            }
+        }
+        // kind= clauses are intentionally skipped at admission per NIP-AA §Kind Conditions
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_conditions_passes() {
+        assert!(evaluate_created_at_conditions("", 1000).is_ok());
+    }
+
+    #[test]
+    fn created_at_lt_passes() {
+        assert!(evaluate_created_at_conditions("created_at<2000", 1000).is_ok());
+    }
+
+    #[test]
+    fn created_at_lt_fails_when_equal() {
+        assert!(evaluate_created_at_conditions("created_at<1000", 1000).is_err());
+    }
+
+    #[test]
+    fn created_at_lt_fails_when_greater() {
+        assert!(evaluate_created_at_conditions("created_at<500", 1000).is_err());
+    }
+
+    #[test]
+    fn created_at_gt_passes() {
+        assert!(evaluate_created_at_conditions("created_at>500", 1000).is_ok());
+    }
+
+    #[test]
+    fn created_at_gt_fails_when_equal() {
+        assert!(evaluate_created_at_conditions("created_at>1000", 1000).is_err());
+    }
+
+    #[test]
+    fn created_at_gt_fails_when_less() {
+        assert!(evaluate_created_at_conditions("created_at>2000", 1000).is_err());
+    }
+
+    #[test]
+    fn compound_conditions_all_pass() {
+        assert!(evaluate_created_at_conditions("created_at>500&created_at<2000", 1000).is_ok());
+    }
+
+    #[test]
+    fn compound_conditions_one_fails() {
+        assert!(evaluate_created_at_conditions("created_at>500&created_at<900", 1000).is_err());
+    }
+
+    #[test]
+    fn kind_condition_is_skipped() {
+        // kind= clauses must not cause failure — they are skipped per spec
+        assert!(evaluate_created_at_conditions("kind=9&created_at>500", 1000).is_ok());
+    }
+
+    #[test]
+    fn malformed_threshold_returns_err() {
+        assert!(evaluate_created_at_conditions("created_at<notanumber", 1000).is_err());
+    }
+}

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -59,6 +59,37 @@ pub async fn verify_nip_aa(
         None => return Ok(None), // No auth tag — not an agent, not a NIP-AA attempt
         Some(tag) => tag,
     };
+    // Step 4: Pre-validate lowercase hex requirements before calling verify_auth_tag.
+    // NIP-OA requires 64-char lowercase hex owner pubkey and 128-char lowercase hex sig.
+    // secp256k1's from_hex accepts uppercase, so we enforce the spec constraint here.
+    {
+        let tag_slice = auth_tag.as_slice();
+        if tag_slice.len() >= 4 {
+            let owner_hex = &tag_slice[1];
+            if owner_hex.len() != 64
+                || !owner_hex
+                    .chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+            {
+                return Err(format!(
+                    "restricted: owner pubkey must be 64 lowercase hex chars, got {:?}",
+                    owner_hex
+                ));
+            }
+            let sig_hex = &tag_slice[3];
+            if sig_hex.len() != 128
+                || !sig_hex
+                    .chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+            {
+                return Err(format!(
+                    "restricted: signature must be 128 lowercase hex chars, got length {}",
+                    sig_hex.len()
+                ));
+            }
+        }
+    }
+
     let tag_json = serde_json::to_string(&auth_tag.as_slice())
         .map_err(|e| format!("restricted: failed to serialize auth tag: {e}"))?;
 

--- a/crates/sprout-relay/src/handlers/nip_aa.rs
+++ b/crates/sprout-relay/src/handlers/nip_aa.rs
@@ -12,6 +12,10 @@ use crate::state::AppState;
 pub struct NipAaResult {
     /// The owner pubkey that granted virtual membership.
     pub owner_pubkey: PublicKey,
+    /// Optional session expiry derived from `created_at<T` conditions.
+    /// The minimum (most restrictive) `created_at<T` threshold found in the
+    /// auth tag conditions, or `None` if no such condition is present.
+    pub session_expiry: Option<u64>,
 }
 
 /// Extract exactly one `auth` tag from a slice of event tags.
@@ -40,16 +44,11 @@ pub fn extract_single_auth_tag(tags: &[nostr::Tag]) -> Result<Option<&nostr::Tag
 /// Pre-validate that an `auth` tag's owner pubkey and signature fields are
 /// 64-char and 128-char lowercase hex respectively.
 ///
-/// NIP-OA mandates lowercase hex; secp256k1's `from_hex` silently accepts
+/// NIP-OA mandates lowercase hex; `secp256k1::from_hex` silently accepts
 /// uppercase, so we enforce the spec constraint here before the crypto call.
 ///
-/// Only runs when the tag has ≥ 4 elements (the minimum for a well-formed auth
-/// tag). Tags with fewer elements are passed through and will fail the
+/// Tags with fewer than 4 elements are passed through and will fail the
 /// `verify_auth_tag` element-count check instead.
-///
-/// This is a defense-in-depth check: the SDK's `verify_auth_tag` also validates
-/// these fields, but `secp256k1::from_hex` silently accepts uppercase hex. This
-/// pre-check enforces the NIP-OA lowercase-only constraint before the crypto call.
 fn validate_auth_tag_hex(auth_tag: &nostr::Tag) -> Result<(), String> {
     let tag_slice = auth_tag.as_slice();
     if tag_slice.len() >= 4 {
@@ -81,6 +80,13 @@ fn validate_auth_tag_hex(auth_tag: &nostr::Tag) -> Result<(), String> {
 
 /// Extract and verify a NIP-OA auth tag from event tags for NIP-AA authentication.
 ///
+/// ## Performance note — rate-limit re-auth attempts
+///
+/// This function performs CPU-intensive Schnorr signature verification (offloaded
+/// to `spawn_blocking`). Callers **must** apply a per-IP or per-pubkey rate limit
+/// on re-authentication attempts to prevent CPU exhaustion. The rate limiting is
+/// implemented in `auth.rs`, not here.
+///
 /// Implements NIP-AA Steps 3-5:
 /// - Step 3: Extract exactly one `auth` tag (zero → Ok(None); >1 → Err)
 /// - Step 4: Verify the auth tag cryptographically (reuses sprout-sdk nip_oa)
@@ -101,6 +107,7 @@ fn validate_auth_tag_hex(auth_tag: &nostr::Tag) -> Result<(), String> {
 /// | Signature not 128-char lowercase hex | `Err` | `"restricted: signature must be 128 lowercase hex chars"` |
 /// | NIP-OA signature verification fails | `Err` | `"restricted: invalid auth tag: …"` |
 /// | Self-attestation (agent == owner) | `Err` | `"restricted: invalid auth tag: …"` (from sprout-sdk) |
+/// | `kind=` condition present | `Err` | `"restricted: unsupported condition for NIP-AA: kind= restrictions are not yet enforced per-action…"` |
 /// | `created_at<T` condition not satisfied | `Err` | `"restricted: created_at condition not satisfied: …"` |
 /// | `created_at>T` condition not satisfied | `Err` | `"restricted: created_at condition not satisfied: …"` |
 /// | Malformed `created_at` threshold | `Err` | `"restricted: malformed created_at< condition: …"` |
@@ -114,40 +121,50 @@ pub async fn verify_nip_aa(
 ) -> Result<Option<NipAaResult>, String> {
     // Step 3: Extract exactly one auth tag
     let auth_tag = match extract_single_auth_tag(tags)? {
-        None => return Ok(None), // No auth tag — not an agent, not a NIP-AA attempt
+        None => return Ok(None),
         Some(tag) => tag,
     };
-    // Step 4: Pre-validate lowercase hex requirements before calling verify_auth_tag.
-    // NIP-OA requires 64-char lowercase hex owner pubkey and 128-char lowercase hex sig.
-    // secp256k1's from_hex accepts uppercase, so we enforce the spec constraint here.
+    // Step 4: Pre-validate lowercase hex before the crypto call.
     validate_auth_tag_hex(auth_tag)?;
 
     let tag_json = serde_json::to_string(&auth_tag.as_slice())
         .map_err(|e| format!("restricted: failed to serialize auth tag: {e}"))?;
 
-    // Step 4: Verify the auth tag cryptographically
-    let owner_pubkey = match sprout_sdk::nip_oa::verify_auth_tag(&tag_json, agent_pubkey) {
-        Ok(pk) => pk,
-        Err(e) => {
+    // Step 4: Verify the auth tag — CPU-intensive, run on blocking thread pool.
+    let agent_pk_owned = *agent_pubkey;
+    let tag_json_owned = tag_json.clone();
+    let owner_pubkey = match tokio::task::spawn_blocking(move || {
+        sprout_sdk::nip_oa::verify_auth_tag(&tag_json_owned, &agent_pk_owned)
+    })
+    .await
+    {
+        Ok(Ok(pk)) => pk,
+        Ok(Err(e)) => {
             return Err(format!("restricted: invalid auth tag: {e}"));
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "NIP-AA: verify_auth_tag task panicked");
+            return Err("restricted: verification failed".to_string());
         }
     };
 
-    // Step 4b: Evaluate created_at conditions
-    // Parse conditions from the auth tag (element [2])
+    // Step 4b: Evaluate created_at conditions from the auth tag (element [2]).
     let tag_slice = auth_tag.as_slice();
-    if tag_slice.len() >= 3 {
+    let session_expiry = if tag_slice.len() >= 3 {
         let conditions = &tag_slice[2];
         if !conditions.is_empty() {
             if let Err(reason) = evaluate_created_at_conditions(conditions, event_created_at) {
                 return Err(format!("restricted: {reason}"));
             }
+            extract_session_expiry(conditions)
+        } else {
+            None
         }
-    }
+    } else {
+        None
+    };
 
-    // Step 5: Check owner is an active relay member.
-    // Log DB errors server-side; send a sanitized fail-closed message to the client
-    // to avoid leaking internal error details.
+    // Step 5: Check owner is an active relay member. Fail closed on DB errors.
     let owner_hex = owner_pubkey.to_hex();
     let is_member = match state.db.is_relay_member(&owner_hex).await {
         Ok(v) => v,
@@ -172,13 +189,47 @@ pub async fn verify_nip_aa(
         "NIP-AA: virtual membership granted"
     );
 
-    Ok(Some(NipAaResult { owner_pubkey }))
+    Ok(Some(NipAaResult {
+        owner_pubkey,
+        session_expiry,
+    }))
+}
+
+/// Extract the minimum `created_at<T` threshold from a conditions string.
+///
+/// Returns the smallest (most restrictive) upper-bound threshold found, or `None`
+/// if no `created_at<T` condition is present. Used to derive session expiry for
+/// NIP-AA virtual members so the relay can enforce the time bound post-login.
+pub fn extract_session_expiry(conditions: &str) -> Option<u64> {
+    if conditions.is_empty() {
+        return None;
+    }
+    let mut min_expiry: Option<u64> = None;
+    for clause in conditions.split('&') {
+        if let Some(val_str) = clause.strip_prefix("created_at<") {
+            if let Ok(threshold) = val_str.parse::<u64>() {
+                min_expiry = Some(match min_expiry {
+                    Some(prev) => prev.min(threshold),
+                    None => threshold,
+                });
+            }
+        }
+    }
+    min_expiry
 }
 
 /// Evaluate `created_at<t` and `created_at>t` conditions against an event's created_at.
-/// Returns Ok(()) if all conditions pass, Err(reason) if any fail.
-/// `kind=` conditions are intentionally skipped per NIP-AA spec — they are valid
-/// but not evaluated at connection admission.
+/// Returns `Ok(())` if all conditions pass, `Err(reason)` if any fail.
+///
+/// ## `kind=` conditions are rejected (fail-closed)
+///
+/// `kind=` clauses restrict which event kinds the agent may publish. We cannot
+/// enforce these per-action yet — silently skipping them would grant broader
+/// access than the owner intended, which is a privilege escalation vector.
+/// Until per-action enforcement is implemented, we reject any auth tag that
+/// contains a `kind=` clause so that owner intent is always honoured.
+///
+/// ## Other constraints
 ///
 /// Per NIP-OA spec: verifiers MUST reject an auth tag that contains an unsupported
 /// clause. Empty clauses (from leading/trailing `&`) and unknown clause types are
@@ -210,7 +261,14 @@ fn evaluate_created_at_conditions(conditions: &str, event_created_at: u64) -> Re
                 ));
             }
         } else if clause.starts_with("kind=") {
-            // kind= clauses are intentionally skipped at admission per NIP-AA §Kind Conditions
+            // kind= conditions restrict which event kinds the agent may publish.
+            // We cannot enforce these per-action yet — silently skipping them would
+            // grant broader access than the owner intended (privilege escalation).
+            // Reject fail-closed until per-action enforcement is implemented.
+            return Err(format!(
+                "unsupported condition for NIP-AA: kind= restrictions are not yet enforced \
+                 per-action; rejecting to prevent privilege escalation (clause: {clause})"
+            ));
         } else {
             return Err(format!("unsupported condition clause: {clause}"));
         }
@@ -285,9 +343,30 @@ mod tests {
     }
 
     #[test]
-    fn kind_condition_is_skipped() {
-        // kind= clauses must not cause failure — they are skipped per spec
-        assert!(evaluate_created_at_conditions("kind=9&created_at>500", 1000).is_ok());
+    fn kind_condition_is_rejected() {
+        // kind= clauses must be rejected fail-closed to prevent privilege escalation
+        assert!(evaluate_created_at_conditions("kind=9&created_at>500", 1000).is_err());
+    }
+
+    #[test]
+    fn kind_condition_alone_is_rejected() {
+        let result = evaluate_created_at_conditions("kind=9", 1000);
+        assert!(result.is_err(), "expected Err for kind= condition, got Ok");
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("kind="),
+            "expected error to mention kind=, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn kind_and_created_at_conditions_rejected_due_to_kind() {
+        // The kind= clause causes rejection even when created_at would pass.
+        let result = evaluate_created_at_conditions("kind=9&created_at>500", 1000);
+        assert!(
+            result.is_err(),
+            "expected Err because of kind= clause, got Ok"
+        );
     }
 
     #[test]
@@ -296,21 +375,15 @@ mod tests {
     }
 
     // ── extract_single_auth_tag ───────────────────────────────────────────────
-    // These tests cover the NIP-AA §Step 3 logic (no auth tags → Ok(None),
-    // multiple auth tags → Err) without requiring AppState or async runtime.
 
     #[test]
     fn no_auth_tags_returns_ok_none() {
-        // verify_nip_aa returns Ok(None) when no auth tag is present — the
-        // caller treats this as "not an agent" and falls through to a plain
-        // membership failure.
         let tags: Vec<nostr::Tag> = vec![];
         assert!(matches!(extract_single_auth_tag(&tags), Ok(None)));
     }
 
     #[test]
     fn non_auth_tags_ignored_returns_ok_none() {
-        // Unrelated tags (e.g. "p", "e") must not be mistaken for auth tags.
         let tags = vec![
             nostr::Tag::parse(&["p", "deadbeef"]).expect("valid tag"),
             nostr::Tag::parse(&["e", "cafebabe"]).expect("valid tag"),
@@ -320,8 +393,6 @@ mod tests {
 
     #[test]
     fn multiple_auth_tags_returns_err() {
-        // NIP-AA §Step 3: more than one auth tag is ambiguous and must be
-        // rejected. verify_nip_aa propagates this as Err.
         let tags = vec![
             nostr::Tag::parse(&["auth", "owner1hex", "", "sig1"]).expect("valid tag"),
             nostr::Tag::parse(&["auth", "owner2hex", "", "sig2"]).expect("valid tag"),
@@ -370,9 +441,7 @@ mod tests {
 
     #[test]
     fn validate_hex_rejects_uppercase_owner_pubkey() {
-        // NIP-OA mandates lowercase hex. Uppercase must be rejected even though
-        // secp256k1's from_hex would silently accept it.
-        let owner = make_hex(64, true); // uppercase
+        let owner = make_hex(64, true); // uppercase — secp256k1 accepts it, NIP-OA forbids it
         let sig = make_hex(128, false);
         let tag = nostr::Tag::parse(&["auth", &owner, "", &sig]).expect("valid tag");
         let err = validate_auth_tag_hex(&tag).unwrap_err();
@@ -420,9 +489,7 @@ mod tests {
 
     #[test]
     fn validate_hex_skips_check_for_tag_with_fewer_than_4_elements() {
-        // Tags with < 4 elements bypass the hex check here and will fail later
-        // in verify_auth_tag's element-count check. We must not panic or error
-        // prematurely on short tags.
+        // Short tags pass here and fail later in verify_auth_tag's element-count check.
         let tag2 = nostr::Tag::parse(&["auth", "short"]).expect("valid tag");
         assert!(
             validate_auth_tag_hex(&tag2).is_ok(),
@@ -440,47 +507,39 @@ mod tests {
 
     #[test]
     fn created_at_lt_passes_one_below_boundary() {
-        // Strict less-than: value one below threshold must pass.
         assert!(evaluate_created_at_conditions("created_at<1001", 1000).is_ok());
     }
 
     #[test]
     fn created_at_gt_passes_one_above_boundary() {
-        // Strict greater-than: value one above threshold must pass.
         assert!(evaluate_created_at_conditions("created_at>999", 1000).is_ok());
     }
 
     #[test]
-    fn multiple_kind_conditions_are_all_skipped() {
-        // Multiple kind= clauses must all be skipped — none should cause failure.
+    fn multiple_kind_conditions_are_all_rejected() {
+        // Each kind= clause triggers a rejection; the first one encountered returns Err.
         assert!(
-            evaluate_created_at_conditions("kind=9&kind=1&kind=30023&created_at>0", 1000).is_ok()
+            evaluate_created_at_conditions("kind=9&kind=1&kind=30023&created_at>0", 1000).is_err()
         );
     }
 
     #[test]
     fn empty_clause_from_leading_ampersand_is_rejected() {
-        // A leading & produces an empty first clause — must be rejected per NIP-OA spec.
         assert!(evaluate_created_at_conditions("&created_at>0", 1000).is_err());
     }
 
     #[test]
     fn empty_clause_from_trailing_ampersand_is_rejected() {
-        // A trailing & produces an empty last clause — must be rejected per NIP-OA spec.
         assert!(evaluate_created_at_conditions("created_at>0&", 1000).is_err());
     }
 
     #[test]
     fn unknown_clause_type_is_rejected() {
-        // Unknown condition types must be rejected — NIP-OA: verifiers MUST reject
-        // auth tags containing unsupported clauses.
+        // NIP-OA: verifiers MUST reject auth tags with unsupported clauses.
         assert!(evaluate_created_at_conditions("foo=bar&created_at>0", 1000).is_err());
     }
 
     // ── self-attestation rejection ────────────────────────────────────────────
-    // verify_auth_tag (sprout-sdk) rejects self-attestation. Verify that
-    // verify_nip_aa propagates this as Err without requiring AppState by
-    // calling sprout_sdk::nip_oa::verify_auth_tag directly.
 
     #[test]
     fn self_attestation_rejected_by_verify_auth_tag() {

--- a/crates/sprout-relay/src/handlers/relay_admin.rs
+++ b/crates/sprout-relay/src/handlers/relay_admin.rs
@@ -210,6 +210,24 @@ pub async fn handle_relay_admin_event(state: &Arc<AppState>, event: &Event) -> R
                 "relay member removed"
             );
 
+            // TODO(nip-aa): Forcibly disconnect NIP-AA agent connections when owner is removed.
+            // `connection_ids_for_owner` can enumerate them, but ConnectionManager lacks a
+            // close/disconnect method. The cancel token is stored in the private `ConnEntry`
+            // struct and is not accessible from outside `state.rs`. Need to add a public
+            // `close_connection(conn_id: Uuid)` method to ConnectionManager that calls
+            // `conn.cancel.cancel()` — mirroring the slow-client path in `send_to`.
+            {
+                let target_bytes = hex::decode(&target_hex).unwrap_or_default();
+                let agent_conn_ids = state.conn_manager.connection_ids_for_owner(&target_bytes);
+                if !agent_conn_ids.is_empty() {
+                    tracing::warn!(
+                        owner = %target_hex,
+                        orphaned_agents = agent_conn_ids.len(),
+                        "owner removed but NIP-AA agent connections not yet terminated (not implemented)"
+                    );
+                }
+            }
+
             if let Err(e) = publish_nip43_member_removed(state, &target_hex).await {
                 warn!(error = %e, "failed to publish NIP-43 member removed event");
             }

--- a/crates/sprout-relay/src/handlers/relay_admin.rs
+++ b/crates/sprout-relay/src/handlers/relay_admin.rs
@@ -210,20 +210,20 @@ pub async fn handle_relay_admin_event(state: &Arc<AppState>, event: &Event) -> R
                 "relay member removed"
             );
 
-            // TODO(nip-aa): Forcibly disconnect NIP-AA agent connections when owner is removed.
-            // `connection_ids_for_owner` can enumerate them, but ConnectionManager lacks a
-            // close/disconnect method. The cancel token is stored in the private `ConnEntry`
-            // struct and is not accessible from outside `state.rs`. Need to add a public
-            // `close_connection(conn_id: Uuid)` method to ConnectionManager that calls
-            // `conn.cancel.cancel()` — mirroring the slow-client path in `send_to`.
+            // NIP-AA: disconnect agent connections owned by the removed member.
+            // Agents inherit access from their owner — when the owner loses membership,
+            // their agents must be disconnected immediately.
             {
                 let target_bytes = hex::decode(&target_hex).unwrap_or_default();
                 let agent_conn_ids = state.conn_manager.connection_ids_for_owner(&target_bytes);
+                for conn_id in &agent_conn_ids {
+                    state.conn_manager.close_connection(*conn_id);
+                }
                 if !agent_conn_ids.is_empty() {
-                    tracing::warn!(
+                    tracing::info!(
                         owner = %target_hex,
-                        orphaned_agents = agent_conn_ids.len(),
-                        "owner removed but NIP-AA agent connections not yet terminated (not implemented)"
+                        disconnected = agent_conn_ids.len(),
+                        "disconnected NIP-AA agent connections after owner removal"
                     );
                 }
             }

--- a/crates/sprout-relay/src/handlers/req.rs
+++ b/crates/sprout-relay/src/handlers/req.rs
@@ -16,6 +16,8 @@ use sprout_db::EventQuery;
 
 use sprout_auth::Scope;
 
+use std::sync::atomic::Ordering;
+
 use crate::connection::{AuthState, ConnectionState};
 use crate::protocol::RelayMessage;
 use crate::state::AppState;
@@ -36,6 +38,10 @@ pub async fn handle_req(
     conn: Arc<ConnectionState>,
     state: Arc<AppState>,
 ) {
+    // Capture auth epoch before any async work. Checked again just before subscription
+    // registration to detect re-auth that occurred while this task was in-flight.
+    let auth_epoch_at_start = conn.auth_epoch.load(Ordering::Acquire);
+
     let (conn_id, pubkey_bytes, token_channel_ids) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
@@ -47,6 +53,22 @@ pub async fn handle_req(
                         "restricted: insufficient scope",
                     ));
                     return;
+                }
+
+                // NIP-AA §Expiry: reject reads after the delegation's created_at<T bound.
+                // Without this, an agent that authenticated before expiry could keep
+                // reading indefinitely. Writes are separately enforced in ingest.rs.
+                if let Some(expiry) = ctx.session_expiry {
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    if now >= expiry {
+                        let msg =
+                            RelayMessage::closed(&sub_id, "auth-required: NIP-AA session expired");
+                        conn.send(msg);
+                        return;
+                    }
                 }
 
                 let pk_bytes = ctx.pubkey.serialize().to_vec();
@@ -140,6 +162,17 @@ pub async fn handle_req(
             ));
             return;
         }
+    }
+
+    // Guard against in-flight REQ registering a stale subscription after re-auth.
+    // If the epoch changed since we captured it, the auth context we used for
+    // access checks belongs to the old identity — reject to prevent privilege leak.
+    if conn.auth_epoch.load(Ordering::Acquire) != auth_epoch_at_start {
+        conn.send(RelayMessage::closed(
+            &sub_id,
+            "auth-required: identity changed during request",
+        ));
+        return;
     }
 
     {

--- a/crates/sprout-relay/src/handlers/req.rs
+++ b/crates/sprout-relay/src/handlers/req.rs
@@ -39,7 +39,7 @@ pub async fn handle_req(
     let (conn_id, pubkey_bytes, token_channel_ids) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
-            AuthState::Authenticated(ctx) => {
+            AuthState::Authenticated { ctx, .. } => {
                 if !ctx.scopes.is_empty() && !ctx.scopes.contains(&Scope::MessagesRead) {
                     conn.send(RelayMessage::notice("restricted: insufficient scope"));
                     conn.send(RelayMessage::closed(

--- a/crates/sprout-relay/src/state.rs
+++ b/crates/sprout-relay/src/state.rs
@@ -139,6 +139,17 @@ impl ConnectionManager {
         }
     }
 
+    /// Forcibly close a connection by cancelling its token.
+    /// Used for owner-scoped termination when a relay member is removed.
+    pub fn close_connection(&self, conn_id: Uuid) -> bool {
+        if let Some(entry) = self.connections.get(&conn_id) {
+            entry.cancel.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Return all live connection IDs whose NIP-AA owner matches `owner_bytes`.
     pub fn connection_ids_for_owner(&self, owner_bytes: &[u8]) -> Vec<Uuid> {
         self.connections

--- a/crates/sprout-relay/src/state.rs
+++ b/crates/sprout-relay/src/state.rs
@@ -677,4 +677,102 @@ mod tests {
         assert_eq!(mgr.connection_ids_for_pubkey(&pubkey), vec![conn_id]);
         assert!(mgr.subscriptions_for(conn_id).is_some());
     }
+
+    /// Verify that `set_owner_pubkey` makes the connection discoverable via
+    /// `connection_ids_for_owner` — the primary lookup used when an owner is
+    /// removed from the relay and their NIP-AA sessions must be terminated.
+    #[tokio::test]
+    async fn tracks_connections_by_owner_pubkey() {
+        let mgr = ConnectionManager::new();
+        let conn_id = Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel(1);
+        let cancel = CancellationToken::new();
+        let bp = Arc::new(AtomicU8::new(0));
+        let subscriptions = Arc::new(Mutex::new(HashMap::new()));
+        mgr.register(conn_id, tx, cancel, bp, subscriptions);
+
+        let owner = vec![0xAAu8; 32];
+        mgr.set_owner_pubkey(conn_id, owner.clone());
+
+        assert_eq!(mgr.connection_ids_for_owner(&owner), vec![conn_id]);
+    }
+
+    /// Verify that deregistering a connection removes it from the owner-pubkey
+    /// index so stale lookups never return dead connection IDs.
+    #[tokio::test]
+    async fn owner_pubkey_cleared_on_deregister() {
+        let mgr = ConnectionManager::new();
+        let conn_id = Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel(1);
+        let cancel = CancellationToken::new();
+        let bp = Arc::new(AtomicU8::new(0));
+        let subscriptions = Arc::new(Mutex::new(HashMap::new()));
+        mgr.register(conn_id, tx, cancel, bp, subscriptions);
+
+        let owner = vec![0xBBu8; 32];
+        mgr.set_owner_pubkey(conn_id, owner.clone());
+        assert_eq!(mgr.connection_ids_for_owner(&owner), vec![conn_id]);
+
+        mgr.deregister(conn_id);
+        assert!(
+            mgr.connection_ids_for_owner(&owner).is_empty(),
+            "deregistered connection must not appear in owner index"
+        );
+    }
+
+    /// Verify that two distinct connections sharing the same NIP-AA owner are
+    /// both returned by `connection_ids_for_owner` — needed for bulk teardown.
+    #[tokio::test]
+    async fn multiple_connections_same_owner() {
+        let mgr = ConnectionManager::new();
+        let owner = vec![0xCCu8; 32];
+
+        let mut ids = Vec::new();
+        for _ in 0..2 {
+            let conn_id = Uuid::new_v4();
+            let (tx, _rx) = mpsc::channel(1);
+            let cancel = CancellationToken::new();
+            let bp = Arc::new(AtomicU8::new(0));
+            let subscriptions = Arc::new(Mutex::new(HashMap::new()));
+            mgr.register(conn_id, tx, cancel, bp, subscriptions);
+            mgr.set_owner_pubkey(conn_id, owner.clone());
+            ids.push(conn_id);
+        }
+
+        let mut found = mgr.connection_ids_for_owner(&owner);
+        found.sort();
+        ids.sort();
+        assert_eq!(found, ids, "both connections must appear in owner index");
+    }
+
+    /// Verify that calling `set_authenticated_pubkey` a second time with a
+    /// different pubkey removes the connection from the old pubkey's index and
+    /// adds it to the new one — prevents stale fanout after re-auth.
+    #[tokio::test]
+    async fn set_authenticated_pubkey_replaces_previous() {
+        let mgr = ConnectionManager::new();
+        let conn_id = Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel(1);
+        let cancel = CancellationToken::new();
+        let bp = Arc::new(AtomicU8::new(0));
+        let subscriptions = Arc::new(Mutex::new(HashMap::new()));
+        mgr.register(conn_id, tx, cancel, bp, subscriptions);
+
+        let pubkey_a = vec![0x01u8; 32];
+        let pubkey_b = vec![0x02u8; 32];
+
+        mgr.set_authenticated_pubkey(conn_id, pubkey_a.clone());
+        assert_eq!(mgr.connection_ids_for_pubkey(&pubkey_a), vec![conn_id]);
+
+        mgr.set_authenticated_pubkey(conn_id, pubkey_b.clone());
+        assert!(
+            mgr.connection_ids_for_pubkey(&pubkey_a).is_empty(),
+            "old pubkey index must be empty after re-auth"
+        );
+        assert_eq!(
+            mgr.connection_ids_for_pubkey(&pubkey_b),
+            vec![conn_id],
+            "new pubkey index must contain the connection"
+        );
+    }
 }

--- a/crates/sprout-relay/src/state.rs
+++ b/crates/sprout-relay/src/state.rs
@@ -37,6 +37,10 @@ struct ConnEntry {
     backpressure_count: Arc<AtomicU8>,
     subscriptions: ConnectionSubscriptions,
     authenticated_pubkey: Arc<std::sync::RwLock<Option<Vec<u8>>>>,
+    /// Set when a NIP-AA virtual member authenticates. Enables owner-scoped
+    /// enumeration (find all agents authorized by a given owner) and
+    /// termination (disconnect all agents when owner is removed).
+    owner_pubkey: Arc<std::sync::RwLock<Option<Vec<u8>>>>,
 }
 
 /// Tracks active WebSocket connections and provides message routing by connection ID.
@@ -70,6 +74,7 @@ impl ConnectionManager {
                 backpressure_count,
                 subscriptions,
                 authenticated_pubkey: Arc::new(std::sync::RwLock::new(None)),
+                owner_pubkey: Arc::new(std::sync::RwLock::new(None)),
             },
         );
     }
@@ -101,6 +106,38 @@ impl ConnectionManager {
                         value
                             .as_ref()
                             .map(|stored| stored.as_slice() == pubkey_bytes)
+                    })
+                    .unwrap_or(false);
+                matches.then_some(*entry.key())
+            })
+            .collect()
+    }
+
+    /// Record the owner pubkey for a NIP-AA virtual member connection.
+    ///
+    /// Enables owner-scoped enumeration (`connection_ids_for_owner`) and
+    /// bulk termination when an owner is removed from the relay.
+    pub fn set_owner_pubkey(&self, conn_id: Uuid, owner_bytes: Vec<u8>) {
+        if let Some(entry) = self.connections.get(&conn_id) {
+            if let Ok(mut slot) = entry.owner_pubkey.write() {
+                *slot = Some(owner_bytes);
+            }
+        }
+    }
+
+    /// Return all live connection IDs whose NIP-AA owner matches `owner_bytes`.
+    pub fn connection_ids_for_owner(&self, owner_bytes: &[u8]) -> Vec<Uuid> {
+        self.connections
+            .iter()
+            .filter_map(|entry| {
+                let matches = entry
+                    .owner_pubkey
+                    .read()
+                    .ok()
+                    .and_then(|value| {
+                        value
+                            .as_ref()
+                            .map(|stored| stored.as_slice() == owner_bytes)
                     })
                     .unwrap_or(false);
                 matches.then_some(*entry.key())

--- a/crates/sprout-relay/src/state.rs
+++ b/crates/sprout-relay/src/state.rs
@@ -125,6 +125,20 @@ impl ConnectionManager {
         }
     }
 
+    /// Clear the owner pubkey for a connection that has re-authenticated as a
+    /// direct member (API token or Okta JWT without NIP-AA).
+    ///
+    /// Removes the connection from the `owner_to_conns` reverse index so that
+    /// `connection_ids_for_owner` no longer returns stale results for the old
+    /// NIP-AA owner.
+    pub fn clear_owner_pubkey(&self, conn_id: Uuid) {
+        if let Some(entry) = self.connections.get(&conn_id) {
+            if let Ok(mut slot) = entry.owner_pubkey.write() {
+                *slot = None;
+            }
+        }
+    }
+
     /// Return all live connection IDs whose NIP-AA owner matches `owner_bytes`.
     pub fn connection_ids_for_owner(&self, owner_bytes: &[u8]) -> Vec<Uuid> {
         self.connections
@@ -717,6 +731,29 @@ mod tests {
         assert!(
             mgr.connection_ids_for_owner(&owner).is_empty(),
             "deregistered connection must not appear in owner index"
+        );
+    }
+
+    /// Verify that `clear_owner_pubkey` removes the connection from the owner
+    /// index — models re-auth from NIP-AA virtual member to direct member.
+    #[tokio::test]
+    async fn owner_pubkey_cleared_on_reauth_to_direct_member() {
+        let mgr = ConnectionManager::new();
+        let conn_id = Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel(1);
+        let cancel = CancellationToken::new();
+        let bp = Arc::new(AtomicU8::new(0));
+        let subscriptions = Arc::new(Mutex::new(HashMap::new()));
+        mgr.register(conn_id, tx, cancel, bp, subscriptions);
+
+        let owner = vec![0xDDu8; 32];
+        mgr.set_owner_pubkey(conn_id, owner.clone());
+        assert_eq!(mgr.connection_ids_for_owner(&owner), vec![conn_id]);
+
+        mgr.clear_owner_pubkey(conn_id);
+        assert!(
+            mgr.connection_ids_for_owner(&owner).is_empty(),
+            "owner index must be empty after clear_owner_pubkey"
         );
     }
 

--- a/crates/sprout-relay/src/state.rs
+++ b/crates/sprout-relay/src/state.rs
@@ -651,6 +651,8 @@ mod tests {
             ctrl_tx,
             cancel: cancel.clone(),
             backpressure_count: Arc::clone(&bp),
+            auth_epoch: std::sync::atomic::AtomicU64::new(0),
+            last_auth_at: std::sync::Mutex::new(None),
         };
 
         let mgr = ConnectionManager::new();


### PR DESCRIPTION
## Summary

Implements NIP-AA (Agent Authentication), allowing agents to inherit relay access from their owner's membership by presenting a NIP-OA credential during NIP-42 authentication. No separate agent enrollment is required — if the owner is a member, the agent gets a virtual membership scoped to the session. This completes the agent identity stack: NIP-OA (#406) establishes key provenance, NIP-AA activates it at the relay boundary.

## Motivation

Agents acting on behalf of users need relay access, but manually enrolling every agent key is operationally untenable. NIP-AA solves this by piggybacking on the owner's existing membership: the agent presents a signed NIP-OA credential during NIP-42 auth, the relay verifies the credential and the owner's membership, and grants a virtual session — no persistent record, no enrollment step. This is the minimal viable path to first-class agent support without expanding the membership surface.

## What Changed

### Core NIP-AA verification (`crates/sprout-relay/src/handlers/nip_aa.rs`) — **new, 529 lines**
Six-step verification algorithm:
1. Standard NIP-42 checks: `kind=22242`, valid `id`/`sig`, relay tag, challenge match, ±120s freshness
2. Direct membership short-circuit — if the agent pubkey is already a member, skip NIP-AA entirely
3. Extract exactly one `auth` tag — zero means not an agent; more than one is rejected
4. Cryptographic NIP-OA credential verification with `created_at` condition evaluation
5. Owner pubkey active-membership check against the relay's member store
6. Grant virtual membership — no DB write; owner pubkey retained in session state

### NIP-42 auth handler (`crates/sprout-relay/src/handlers/auth.rs`)
- Integrated `verify_nip_aa()` into the main WebSocket auth flow
- Failed re-auth preserves the existing authenticated identity (per NIP-AA §6)
- Malformed `AUTH` frames now close the WebSocket connection (per spec)

### Audio WebSocket (`crates/sprout-relay/src/audio/handler.rs`, `audio/room.rs`)
- NIP-AA verification wired into the audio WebSocket auth path
- `AudioPeer` gains an `owner_pubkey` field for owner-scoped session tracking

### Connection state (`crates/sprout-relay/src/connection.rs`, `state.rs`)
- `ConnectionManager` stores `owner_pubkey` per connection
- Auth state machine updated to handle malformed-AUTH → close transition

### Scopes (`crates/sprout-auth/src/scope.rs`)
- New virtual member scope set: full read/write, `AdminChannels` and `AdminUsers` excluded

## Design Decisions

**Virtual membership, no persistence.** Agent access lives entirely in session state. There is no `agents` table, no enrollment API. If the owner's membership is revoked, the agent's next connection attempt fails. Existing sessions are not terminated (owner-scoped termination is deferred — see below).

**Single shared `verify_nip_aa()`.** All three ingress points (main WebSocket, API-token path, audio WebSocket) call the same function. No duplicated verification logic.

**Scope intersection on token + NIP-AA.** If an agent presents both an API token and a NIP-OA credential, the resulting scope set is the intersection of both. This prevents NIP-AA from widening a restricted token's permissions.

**Single-pubkey-at-a-time model.** Re-authenticating with a different pubkey replaces the current identity. This is a spec-compliant subset of the full multi-pubkey model (HashMap per connection), which is deferred.

**Failed re-auth is non-destructive.** A failed re-auth attempt does not invalidate the current authenticated session. The connection stays authenticated as the previous identity.

**Fail-closed on DB errors.** Any database error during membership lookup results in an auth denial. No partial or optimistic grants.

**Error prefix compliance.** NIP-42 step failures emit `"invalid: <reason>"`; NIP-AA-specific rejections (steps 3–5) emit `"restricted: <reason>"`.

## Testing

**284 unit tests passing, zero Clippy warnings.**

Unit test coverage includes:
- All six verification steps, including boundary conditions (freshness window edges, tag count variants, credential signature tampering)
- Scope intersection logic for token + NIP-AA combinations
- Virtual member scope set correctness (admin scopes excluded)
- Failed re-auth non-destructive behavior
- Malformed AUTH → close transition

**Not covered (deferred):**
- End-to-end integration tests require a running relay instance and a NIP-42-capable test client. Infrastructure is in place; tests are not yet written.
- Owner-scoped session termination on member removal is not wired, so no tests for that path.

## Related PRs

| PR | Description |
|----|-------------|
| #398 | NIP-OA: Owner Attestation for agent key provenance (spec) |
| #406 | feat(nip-oa): Owner Attestation — implementation |
| #448 | feat: relay membership with NIP-43 compliance |
| #465 | NIP-AA: Agent Authentication via NIP-OA Credentials (spec) |

## Future Work

The following are explicitly deferred and documented in code:

- **Per-event `kind=` enforcement** — the NIP-AA spec marks this optional; not implemented
- **Multi-pubkey per connection** — replace the single-pubkey model with a `HashMap<PublicKey, AuthContext>` per connection to support agents that re-auth under multiple identities in one session
- **Owner-scoped session termination** — when a member is removed, terminate all active agent sessions whose `owner_pubkey` matches; the `owner_pubkey` field is already persisted in `ConnectionManager` and `AudioPeer` in anticipation of this
- **E2E integration tests** — need a relay harness + NIP-42 test client; unit coverage is complete
