### PR TITLE
feat(pairing): auto-detect NIP-43 relay and route target to /pair sidecar

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -67,7 +67,7 @@ const overrides = new Map([
   ["src-tauri/src/huddle/relay_api.rs", 510], // audio relay recv task + per-peer frame counting for remote human TTS interrupt
   ["src-tauri/src/huddle/tts.rs", 1030], // TTS pipeline + session warmup + cancel/shutdown handling + apply_fades + 18 unit tests for remote interrupt mechanism
   ["src-tauri/src/relay.rs", 510], // +4 lines for NIP-OA auth tag injection in profile sync (build_profile_event) + verification test
-  ["src-tauri/src/commands/pairing.rs", 550], // NIP-AB pairing actor: 3 Tauri commands + background WS task + NIP-42 auth + event parsing helpers
+  ["src-tauri/src/commands/pairing.rs", 600], // NIP-AB pairing actor: 3 Tauri commands + background WS task + NIP-42 auth + NIP-43 probe + event parsing helpers
   ["src-tauri/src/lib.rs", 715], // +4 lines for PairingHandle managed state + 3 pairing command registrations
   ["src/shared/api/tauri.ts", 1210], // pairing command wrappers + applyWorkspace + NIP-44 encrypt/decrypt wrappers + observer_url field + relay member API functions (list/get/add/remove/change-role)
 ]);

--- a/desktop/src-tauri/src/commands/pairing.rs
+++ b/desktop/src-tauri/src/commands/pairing.rs
@@ -122,7 +122,15 @@ pub async fn start_pairing(
     let ws_url = relay_ws_url_with_override(&state);
     let http_url = relay_api_base_url_with_override(&state);
 
-    let (session, qr_payload) = PairingSession::new_source(ws_url.clone());
+    // Detect NIP-43: if the relay requires auth, the target device should
+    // connect to the /pair sidecar instead of the main relay.
+    let qr_relay_url = if probe_relay_requires_auth(&ws_url).await {
+        format!("{}/pair", ws_url.trim_end_matches('/'))
+    } else {
+        ws_url.clone()
+    };
+
+    let (session, qr_payload) = PairingSession::new_source(qr_relay_url);
     let qr_uri = encode_qr(&qr_payload);
 
     let payload_json = serde_json::json!({
@@ -443,6 +451,38 @@ fn parse_relay_event(text: &str, sub_id: &str) -> Option<nostr_compat::Event> {
         return None;
     }
     serde_json::from_value(arr[2].clone()).ok()
+}
+
+/// Quick probe: connect to the relay and check if it sends a NIP-42 AUTH
+/// challenge within 3 seconds. Returns `true` if auth is required (NIP-43
+/// locked relay), `false` if no challenge arrives (open relay).
+///
+/// Uses a throwaway connection — the real pairing session connects separately.
+async fn probe_relay_requires_auth(relay_url: &str) -> bool {
+    let ws = match tokio::time::timeout(Duration::from_secs(5), connect_async(relay_url)).await {
+        Ok(Ok((ws, _))) => ws,
+        _ => return false, // connection failed — assume open (will fail later anyway)
+    };
+
+    let (_, mut read) = ws.split();
+
+    // Wait up to 3 seconds for an AUTH challenge.
+    let result = tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            match read.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    if parse_auth_challenge(text.as_str()).is_some() {
+                        return true;
+                    }
+                }
+                Some(Ok(_)) => continue,
+                _ => return false,
+            }
+        }
+    })
+    .await;
+
+    matches!(result, Ok(true))
 }
 
 fn parse_auth_challenge(text: &str) -> Option<String> {

--- a/desktop/src-tauri/src/commands/pairing.rs
+++ b/desktop/src-tauri/src/commands/pairing.rs
@@ -125,7 +125,10 @@ pub async fn start_pairing(
     // Detect NIP-43: if the relay requires auth, the target device should
     // connect to the /pair sidecar instead of the main relay.
     let qr_relay_url = if probe_relay_requires_auth(&ws_url).await {
-        format!("{}/pair", ws_url.trim_end_matches('/'))
+        let mut url = url::Url::parse(&ws_url).map_err(|e| format!("invalid relay URL: {e}"))?;
+        let path = url.path().trim_end_matches('/').to_string();
+        url.set_path(&format!("{path}/pair"));
+        url.to_string()
     } else {
         ws_url.clone()
     };
@@ -453,36 +456,47 @@ fn parse_relay_event(text: &str, sub_id: &str) -> Option<nostr_compat::Event> {
     serde_json::from_value(arr[2].clone()).ok()
 }
 
-/// Quick probe: connect to the relay and check if it sends a NIP-42 AUTH
-/// challenge within 3 seconds. Returns `true` if auth is required (NIP-43
-/// locked relay), `false` if no challenge arrives (open relay).
+/// Check the relay's NIP-11 information document to determine if auth is
+/// required (indicating NIP-43 access control). Returns `true` if the relay
+/// advertises `limitation.auth_required: true`, `false` otherwise.
 ///
-/// Uses a throwaway connection — the real pairing session connects separately.
+/// Converts the WebSocket URL to HTTP(S) and fetches `GET /` with
+/// `Accept: application/nostr+json` per NIP-11.
 async fn probe_relay_requires_auth(relay_url: &str) -> bool {
-    let ws = match tokio::time::timeout(Duration::from_secs(5), connect_async(relay_url)).await {
-        Ok(Ok((ws, _))) => ws,
-        _ => return false, // connection failed — assume open (will fail later anyway)
+    // Convert ws(s):// to http(s):// for the NIP-11 fetch.
+    let http_url = if let Some(rest) = relay_url.strip_prefix("wss://") {
+        format!("https://{rest}")
+    } else if let Some(rest) = relay_url.strip_prefix("ws://") {
+        format!("http://{rest}")
+    } else {
+        return false;
     };
 
-    let (_, mut read) = ws.split();
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap_or_default();
 
-    // Wait up to 3 seconds for an AUTH challenge.
-    let result = tokio::time::timeout(Duration::from_secs(3), async {
-        loop {
-            match read.next().await {
-                Some(Ok(Message::Text(text))) => {
-                    if parse_auth_challenge(text.as_str()).is_some() {
-                        return true;
-                    }
-                }
-                Some(Ok(_)) => continue,
-                _ => return false,
-            }
-        }
-    })
-    .await;
+    let resp = match client
+        .get(&http_url)
+        .header("Accept", "application/nostr+json")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => return false, // can't reach relay — assume open
+    };
 
-    matches!(result, Ok(true))
+    let json: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    // Check limitation.auth_required per NIP-11.
+    json.get("limitation")
+        .and_then(|l| l.get("auth_required"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
 }
 
 fn parse_auth_challenge(text: &str) -> Option<String> {


### PR DESCRIPTION
## What

When the desktop app starts a NIP-AB pairing session, it now checks the relay's NIP-11 information document for `limitation.auth_required: true`. If the relay requires auth (NIP-43 access control), the QR code URL is automatically suffixed with `/pair` so the target device connects to the ephemeral pairing sidecar instead of the auth-locked main relay.

Non-NIP-43 relays continue to work unchanged — the target connects directly to the relay URL without the `/pair` suffix.

## Why

Follows up on #467 (sprout-pair-relay sidecar). The sidecar handles unauthenticated pairing traffic on NIP-43 locked relays, but the desktop client needs to know when to route the target device there.

## How

1. Before generating the QR code, fetch the relay's NIP-11 document (`GET /` with `Accept: application/nostr+json`)
2. Check `limitation.auth_required` — if `true`, the relay is NIP-43 locked
3. Append `/pair` to the relay URL using `url::Url` for proper path handling
4. The source device still connects to the main relay (with auth) for its own WebSocket session

## Change

- **1 file changed**: `desktop/src-tauri/src/commands/pairing.rs` (+55 lines)
- **1 file touched**: `desktop/scripts/check-file-sizes.mjs` (bump limit 550→600)

## Quality

- ✅ Compiles clean
- ✅ Clippy clean (no new warnings)
- ✅ Codex CLI review: **9/10**
- Single low finding: `unwrap_or_default()` on reqwest client builder (infallible in practice)