### PR TITLE
fix(relay): include p tags in kind:39000 for DM channels

### DIFF
--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -603,6 +603,12 @@ pub async fn emit_group_discovery_events(
         // Not a security boundary — access control is handled by channel-scoped storage.
         if channel.channel_type == "dm" {
             tags.push(Tag::parse(&["hidden"])?);
+            // Include participant pubkeys in kind:39000 for DMs so clients can
+            // resolve display names without a separate kind:39002 fetch.
+            for m in &members {
+                let pubkey_hex = hex::encode(&m.pubkey);
+                tags.push(Tag::parse(&["p", &pubkey_hex])?);
+            }
         }
         // Sprout channels always require explicit membership
         tags.push(Tag::parse(&["closed"])?);


### PR DESCRIPTION
## Problem

DM channels need participant pubkeys in the kind:39000 group metadata event so clients can resolve display names without a separate kind:39002 fetch.

The `emit_group_discovery_events` function emits kind:39000 for all channel types but only included `p` tags in kind:39001 (admins) and kind:39002 (members). DM metadata events were missing participant pubkeys, causing DMs to render without names in the desktop and mobile clients.

## Fix

Add `["p", pubkey]` tags for each member when the channel type is `dm` in the kind:39000 emission block. The `members` data is already fetched at the top of the function — this just wires it into the metadata tags for DMs.

## Context

Discovered during the stale-event cleanup for #481. After soft-deleting old ephemeral-key events and re-emitting with the stable dev key via `reconcile_channel_events`, DM channels lost their `p` tags because the reconcile path never included them.

## Testing

Verified on staging — all 37 DM channels now have correct `p` tags in their kind:39000 events.