### PR TITLE
ci: cache Playwright browser binaries across desktop CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
 
 jobs:
   rust-lint:
@@ -77,8 +78,20 @@ jobs:
             wget
       - name: Install desktop dependencies
         run: just desktop-install-ci
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(cd desktop && node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: cd desktop && pnpm exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: cd desktop && pnpm exec playwright install chromium
+      - name: Install Playwright system dependencies
+        run: cd desktop && pnpm exec playwright install-deps chromium
       - name: Desktop lint and format
         run: just desktop-check
       - name: Desktop build
@@ -115,8 +128,20 @@ jobs:
             desktop/src-tauri
       - name: Install desktop dependencies
         run: just desktop-install-ci
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(cd desktop && node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright Chromium
-        run: cd desktop && pnpm exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: cd desktop && pnpm exec playwright install chromium
+      - name: Install Playwright system dependencies
+        run: cd desktop && pnpm exec playwright install-deps chromium
       - name: Desktop build
         run: just desktop-build
       - name: Start integration services

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,9 @@ jobs:
       - name: Get Playwright version
         id: pw-version
         run: echo "version=$(cd desktop && node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
-      - name: Cache Playwright browsers
+      - name: Restore Playwright browser cache
         id: playwright-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
@@ -92,6 +92,12 @@ jobs:
         run: cd desktop && pnpm exec playwright install chromium
       - name: Install Playwright system dependencies
         run: cd desktop && pnpm exec playwright install-deps chromium
+      - name: Save Playwright browser cache
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && github.event_name == 'push'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Desktop lint and format
         run: just desktop-check
       - name: Desktop build
@@ -131,9 +137,9 @@ jobs:
       - name: Get Playwright version
         id: pw-version
         run: echo "version=$(cd desktop && node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
-      - name: Cache Playwright browsers
+      - name: Restore Playwright browser cache
         id: playwright-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
@@ -142,6 +148,12 @@ jobs:
         run: cd desktop && pnpm exec playwright install chromium
       - name: Install Playwright system dependencies
         run: cd desktop && pnpm exec playwright install-deps chromium
+      - name: Save Playwright browser cache
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && github.event_name == 'push'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Desktop build
         run: just desktop-build
       - name: Start integration services


### PR DESCRIPTION
## Summary
- Adds `actions/cache` for Playwright Chromium binaries in the `desktop` and `desktop-e2e-integration` CI jobs
- On cache hit, the ~180MB browser download from Playwright CDN is skipped entirely, eliminating the primary source of CI slowness when the CDN is congested (observed 9+ minutes in slow runs vs ~8 seconds normally)
- Splits `playwright install --with-deps chromium` into conditional `install` (only on cache miss) + unconditional `install-deps` (system packages needed every run on fresh runners)
- Keys cache on exact Playwright version extracted at runtime to avoid over-invalidation from unrelated lockfile changes

## Details

**Problem:** The `desktop` and `desktop-e2e-integration` jobs download Playwright browser binaries from scratch every run. When the Playwright CDN is slow, this balloons from ~8 seconds to ~9 minutes. Combined with slow apt mirrors, total job time can go from 5 min to 23 min.

**Solution:** Cache the Playwright Chromium binary (~180MB) using `actions/cache`. The cache key is based on the exact Playwright version (extracted from `@playwright/test/package.json` at runtime), so it only invalidates when Playwright is actually bumped.

**What stays the same:** System dependencies (`playwright install-deps chromium`) run unconditionally on every run because each GitHub Actions runner is a fresh VM. Apt caching was evaluated and intentionally excluded — the complexity/risk outweighs the benefit given the existing retry/timeout configuration.

**Changes:**
1. Set `PLAYWRIGHT_BROWSERS_PATH` at workflow level for reliable cache path resolution
2. Add "Get Playwright version" step to extract version for cache key
3. Add `actions/cache` step (pinned to SHA, v4.3.0) before Playwright install
4. Make `playwright install chromium` conditional on cache miss
5. Keep `playwright install-deps chromium` unconditional

## Test plan
- [ ] CI passes on this PR (the `desktop` and `desktop-e2e-integration` jobs exercise the new steps)
- [ ] First run should populate the cache (cache miss, normal download)
- [ ] Subsequent runs with same Playwright version should show cache hit and skip Chromium download
- [ ] Bumping Playwright version in `desktop/package.json` should trigger cache miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)