### PR TITLE
fix(relay): raise MAX_HISTORICAL_LIMIT from 500 to 10,000

### DIFF
--- a/crates/sprout-relay/src/handlers/req.rs
+++ b/crates/sprout-relay/src/handlers/req.rs
@@ -20,7 +20,7 @@ use crate::connection::{AuthState, ConnectionState};
 use crate::protocol::RelayMessage;
 use crate::state::AppState;
 
-const MAX_HISTORICAL_LIMIT: i64 = 500;
+const MAX_HISTORICAL_LIMIT: i64 = 10_000;
 const MAX_SUBSCRIPTIONS: usize = 1024;
 const P_GATED_KINDS: [u32; 4] = [
     KIND_AGENT_OBSERVER_FRAME,

--- a/crates/sprout-relay/src/nip11.rs
+++ b/crates/sprout-relay/src/nip11.rs
@@ -74,7 +74,7 @@ impl RelayInfo {
                 max_message_length: Some(MAX_FRAME_BYTES as u64),
                 max_subscriptions: Some(1024),
                 max_filters: Some(10),
-                max_limit: Some(500),
+                max_limit: Some(10_000),
                 max_subid_length: Some(256),
                 min_pow_difficulty: None,
                 auth_required: config.require_auth_token,


### PR DESCRIPTION
## Problem

The desktop client's "add member" search fetches all kind:0 profiles (`limit: 2000`) and filters client-side. The relay's `MAX_HISTORICAL_LIMIT = 500` clamps this, so only 500 of ~1,700 profiles are returned — making ~1,200 users invisible to the search.

## Fix

Raise `MAX_HISTORICAL_LIMIT` to 10,000. This is a corporate relay with a bounded user set — 10k rows of kind:0 events (~2-5MB) is trivial for Postgres.

Also updates the NIP-11 `max_limit` advertisement to match.

## Context

The 500 cap was a conservative default appropriate for public relays protecting against abusive queries. For a private team relay with known scale, it's unnecessarily restrictive.