### PR TITLE
fix(desktop): prevent-sleep spawn convention + expiry badge

### DIFF
--- a/desktop/src-tauri/src/prevent_sleep.rs
+++ b/desktop/src-tauri/src/prevent_sleep.rs
@@ -7,7 +7,7 @@ use tauri::{AppHandle, Emitter};
 #[derive(Default)]
 pub struct PreventSleepState {
     assertion_id: Option<u32>,
-    timer_abort: Option<tokio::task::AbortHandle>,
+    timer_handle: Option<tauri::async_runtime::JoinHandle<()>>,
 }
 
 // ── macOS implementation ────────────────────────────────────────────────────
@@ -111,12 +111,12 @@ pub fn acquire(
     if guard.assertion_id.is_some() {
         let handle = app_handle.clone();
         let timer_state = Arc::clone(state);
-        let timer_task = tokio::spawn(async move {
+        let timer_task = tauri::async_runtime::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_secs(CAP_SECONDS)).await;
             release(&timer_state);
             let _ = handle.emit("prevent-sleep-expired", ());
         });
-        guard.timer_abort = Some(timer_task.abort_handle());
+        guard.timer_handle = Some(timer_task);
     }
 
     Ok(())
@@ -129,8 +129,8 @@ pub fn release(state: &Arc<Mutex<PreventSleepState>>) {
         Err(_) => return,
     };
 
-    if let Some(abort) = guard.timer_abort.take() {
-        abort.abort();
+    if let Some(handle) = guard.timer_handle.take() {
+        handle.abort();
     }
 
     #[cfg(target_os = "macos")]

--- a/desktop/src/features/agents/usePreventSleep.ts
+++ b/desktop/src/features/agents/usePreventSleep.ts
@@ -56,7 +56,10 @@ function usePreventSleepInternal() {
     [agents],
   );
 
-  const active = enabled && hasRunningAgents;
+  // Listen for 4-hour expiry
+  const [expired, setExpired] = React.useState(false);
+
+  const active = enabled && hasRunningAgents && !expired;
 
   const setEnabled = React.useCallback((value: boolean) => {
     writePreference(value);
@@ -67,9 +70,6 @@ function usePreventSleepInternal() {
   React.useEffect(() => {
     void setPreventSleepActive(active);
   }, [active]);
-
-  // Listen for 4-hour expiry
-  const [expired, setExpired] = React.useState(false);
   React.useEffect(() => {
     const unlisten = listen("prevent-sleep-expired", () => {
       setExpired(true);


### PR DESCRIPTION
## Summary

Follow-up to #484, addressing two findings from the Codex adversarial review:

- **Use `tauri::async_runtime::spawn`** instead of `tokio::spawn` for the 4-hour cap timer. Follows the codebase convention for spawning from non-async contexts (see `huddle/models.rs:381` rationale). Stores the `JoinHandle` directly instead of extracting an `AbortHandle`.
- **Fix "Active" badge after 4-hour expiry.** The `active` derivation now includes `&& !expired`, so the status badge correctly shows "Inactive" after the cap fires and the IOKit assertion is released.

## Test plan

- [ ] `cargo check` passes
- [ ] `pnpm typecheck` passes
- [ ] Toggle on, verify badge shows "Active" when agents run
- [ ] After expiry (or simulated), badge shows "Inactive" and yellow banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)