### PR TITLE
fix(desktop): fetch open channels for channel browser discovery

### DIFF
--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -45,28 +45,74 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
     channel_ids.sort();
     channel_ids.dedup();
 
-    if channel_ids.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Step 2: fetch channel metadata events (kind:39000) for those ids.
+    // Step 2: fetch channel metadata events (kind:39000) for member channels.
     // kind:39000 is addressable: exactly one event per `d` tag, so a limit
     // equal to the number of ids is both necessary and sufficient. Without
     // an explicit limit, multi-value `#d` filters fall through to the relay's
     // default LIMIT and can drop results when there are many channels.
-    let meta_events = query_relay(
+    let meta_events = if !channel_ids.is_empty() {
+        query_relay(
+            &state,
+            &[serde_json::json!({
+                "kinds": [39000],
+                "#d": channel_ids,
+                "limit": channel_ids.len(),
+            })],
+        )
+        .await?
+    } else {
+        Vec::new()
+    };
+
+    // Step 3: fetch ALL open channel metadata so the channel browser can show
+    // discoverable channels the user hasn't joined yet. The relay's access
+    // control allows reading kind:39000 for open channels regardless of membership.
+    let open_meta_events = query_relay(
         &state,
         &[serde_json::json!({
             "kinds": [39000],
-            "#d": channel_ids,
-            "limit": channel_ids.len(),
+            "limit": 5000,
         })],
     )
     .await?;
 
-    let mut channels = Vec::with_capacity(meta_events.len());
+    // Merge: member channels (marked as member) + open channels (not yet joined).
+    let member_d_tags: std::collections::HashSet<String> = meta_events
+        .iter()
+        .filter_map(|ev| {
+            ev.tags.iter().find_map(|t| {
+                let s = t.as_slice();
+                if s.len() >= 2 && s[0] == "d" {
+                    Some(s[1].clone())
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+
+    let mut channels = Vec::with_capacity(meta_events.len() + open_meta_events.len());
     for ev in &meta_events {
-        if let Ok(info) = nostr_convert::channel_info_from_event(ev, None) {
+        if let Ok(info) = nostr_convert::channel_info_from_event(ev, None, Some(true)) {
+            channels.push(info);
+        }
+    }
+    for ev in &open_meta_events {
+        // Skip channels already included from the member set.
+        let d_tag = ev.tags.iter().find_map(|t| {
+            let s = t.as_slice();
+            if s.len() >= 2 && s[0] == "d" {
+                Some(s[1].clone())
+            } else {
+                None
+            }
+        });
+        if let Some(ref d) = d_tag {
+            if member_d_tags.contains(d) {
+                continue;
+            }
+        }
+        if let Ok(info) = nostr_convert::channel_info_from_event(ev, None, Some(false)) {
             channels.push(info);
         }
     }
@@ -202,7 +248,7 @@ pub async fn create_channel(
 
     events
         .first()
-        .map(|ev| nostr_convert::channel_info_from_event(ev, None))
+        .map(|ev| nostr_convert::channel_info_from_event(ev, None, None))
         .transpose()?
         .ok_or_else(|| "channel created but metadata not yet available".to_string())
 }

--- a/desktop/src-tauri/src/commands/dms.rs
+++ b/desktop/src-tauri/src/commands/dms.rs
@@ -39,7 +39,7 @@ pub async fn open_dm(
 
     metadata
         .first()
-        .map(|ev| nostr_convert::channel_info_from_event(ev, None))
+        .map(|ev| nostr_convert::channel_info_from_event(ev, None, None))
         .transpose()?
         .ok_or_else(|| "DM channel created but metadata not yet available".to_string())
 }

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -58,6 +58,7 @@ fn tags_named<'a>(event: &'a Event, name: &'a str) -> impl Iterator<Item = &'a [
 pub fn channel_info_from_event(
     event: &Event,
     summary: Option<&Event>,
+    is_member: Option<bool>,
 ) -> Result<ChannelInfo, String> {
     let id = first_tag_value(event, "d")
         .ok_or_else(|| "kind:39000 missing required `d` tag".to_string())?
@@ -133,7 +134,7 @@ pub fn channel_info_from_event(
         archived_at,
         participants,
         participant_pubkeys,
-        is_member: true,
+        is_member: is_member.unwrap_or(true),
         ttl_seconds,
         ttl_deadline,
     })
@@ -547,7 +548,7 @@ mod tests {
                 vec!["public"],
             ],
         );
-        let info = channel_info_from_event(&e, None).unwrap();
+        let info = channel_info_from_event(&e, None, None).unwrap();
         assert_eq!(info.id, "chan-uuid-1");
         assert_eq!(info.name, "general");
         assert_eq!(info.description, "main channel");
@@ -570,7 +571,7 @@ mod tests {
                 vec!["private"],
             ],
         );
-        let info = channel_info_from_event(&e, None).unwrap();
+        let info = channel_info_from_event(&e, None, None).unwrap();
         assert_eq!(info.visibility, "private");
         assert_eq!(info.channel_type, "forum");
     }
@@ -583,7 +584,7 @@ mod tests {
             "",
             vec![vec!["d", "u"], vec!["name", "n"], vec!["t", "forum"]],
         );
-        let info = channel_info_from_event(&e, None).unwrap();
+        let info = channel_info_from_event(&e, None, None).unwrap();
         assert_eq!(info.visibility, "open");
     }
 
@@ -595,7 +596,7 @@ mod tests {
             "",
             vec![vec!["d", "u"], vec!["name", "n"], vec!["hidden"]],
         );
-        let info = channel_info_from_event(&e, None).unwrap();
+        let info = channel_info_from_event(&e, None, None).unwrap();
         assert_eq!(info.channel_type, "dm");
     }
 
@@ -607,7 +608,7 @@ mod tests {
             r#"{"member_count": 7, "last_message_at": "2026-01-01T00:00:00Z"}"#,
             vec![vec!["d", "u"]],
         );
-        let info = channel_info_from_event(&chan, Some(&summary)).unwrap();
+        let info = channel_info_from_event(&chan, Some(&summary), None).unwrap();
         assert_eq!(info.member_count, 7);
         assert_eq!(
             info.last_message_at.as_deref(),
@@ -618,7 +619,7 @@ mod tests {
     #[test]
     fn channel_info_missing_d_errors() {
         let e = ev(39000, "", vec![vec!["name", "n"]]);
-        assert!(channel_info_from_event(&e, None).is_err());
+        assert!(channel_info_from_event(&e, None, None).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The channel browser was blank for new/low-membership users (e.g. Alec, pubkey `a4b96c9d...`). The `get_channels` command only fetched kind:39000 metadata for channels where the user appeared in kind:39002 `#p` tags — i.e., channels they're already a member of. Open channels available for joining were never returned.

The `ChannelBrowserDialog` correctly filters for `visibility === "open" || isMember` and separates joined vs not-joined, but it never received non-member channel data.

## Fix

1. After fetching member channel metadata, also fetch all kind:39000 events (the relay's access control already allows reading open channel metadata for any authenticated user).
2. Merge the two sets, marking member channels with `is_member: true` and open non-member channels with `is_member: false`.
3. Remove the early return for users with zero memberships so brand new users can still browse.
4. Add `is_member` parameter to `channel_info_from_event` (defaults to `true` for backward compat).

## Testing

User `Alec` (2 channel memberships) can now see all ~127 open channels in the browser dialog and join them.