### PR TITLE
fix(desktop): consolidate settings page — switch toggles, remove General section

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/desktop/src/features/settings/ui/NotificationSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/NotificationSettingsCard.tsx
@@ -1,86 +1,8 @@
-import {
-  AtSign,
-  BellRing,
-  CircleAlert,
-  Home as HomeIcon,
-  type LucideIcon,
-} from "lucide-react";
-
 import type {
   DesktopNotificationPermissionState,
   NotificationSettings,
 } from "@/features/notifications/hooks";
-import { cn } from "@/shared/lib/cn";
-
-function notificationStatusLabel(
-  desktopEnabled: boolean,
-  permission: DesktopNotificationPermissionState,
-) {
-  if (permission === "unsupported") {
-    return "Unavailable";
-  }
-
-  if (permission === "denied") {
-    return "Blocked";
-  }
-
-  return desktopEnabled ? "On" : "Off";
-}
-
-function notificationStatusClassName(
-  desktopEnabled: boolean,
-  permission: DesktopNotificationPermissionState,
-) {
-  if (permission === "unsupported" || permission === "denied") {
-    return "border-destructive/30 bg-destructive/10 text-destructive";
-  }
-
-  if (desktopEnabled) {
-    return "border-primary/30 bg-primary/10 text-primary";
-  }
-
-  return "border-border/80 bg-muted text-muted-foreground";
-}
-
-function NotificationPreferenceCard({
-  description,
-  disabled = false,
-  enabled,
-  icon: Icon,
-  onToggle,
-  testId,
-  title,
-}: {
-  description: string;
-  disabled?: boolean;
-  enabled: boolean;
-  icon: LucideIcon;
-  onToggle: () => void;
-  testId: string;
-  title: string;
-}) {
-  return (
-    <button
-      aria-pressed={enabled}
-      className={cn(
-        "flex min-h-24 flex-col items-start justify-between rounded-xl border px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        enabled
-          ? "border-primary bg-primary/10 text-foreground"
-          : "border-border/80 bg-background/60 text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-      )}
-      data-testid={testId}
-      disabled={disabled}
-      onClick={onToggle}
-      type="button"
-    >
-      <div className="flex items-center gap-2">
-        <Icon className="h-4 w-4" />
-        <span className="font-medium text-foreground">{title}</span>
-      </div>
-      <p className="text-sm text-muted-foreground">{description}</p>
-    </button>
-  );
-}
+import { Switch } from "@/shared/ui/switch";
 
 export function NotificationSettingsCard({
   isUpdatingDesktopNotifications,
@@ -101,99 +23,134 @@ export function NotificationSettingsCard({
   onSetMentionNotificationsEnabled: (enabled: boolean) => void;
   onSetNeedsActionNotificationsEnabled: (enabled: boolean) => void;
 }) {
+  const permissionBlocked =
+    notificationPermission === "denied" ||
+    notificationPermission === "unsupported";
+
   return (
     <section className="min-w-0" data-testid="settings-notifications">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <h2 className="text-sm font-semibold tracking-tight">
-            Notifications
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            Zero by default. Keep channel noise inside Home, then opt in to
-            desktop alerts only for the items that truly need you.
-          </p>
-        </div>
-        <span
-          className={cn(
-            "inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em]",
-            notificationStatusClassName(
-              notificationSettings.desktopEnabled,
-              notificationPermission,
-            ),
-          )}
-          data-testid="notifications-desktop-state"
-        >
-          {notificationStatusLabel(
-            notificationSettings.desktopEnabled,
-            notificationPermission,
-          )}
-        </span>
+      <div className="mb-3 min-w-0">
+        <h2 className="text-sm font-semibold tracking-tight">Notifications</h2>
+        <p className="text-sm text-muted-foreground">
+          Zero by default. Keep channel noise inside Home, then opt in to
+          desktop alerts only for the items that truly need you.
+        </p>
       </div>
 
-      <div className="mt-4 grid gap-2 md:grid-cols-2">
-        <NotificationPreferenceCard
-          description={
-            notificationSettings.desktopEnabled
-              ? "Native desktop alerts are enabled for the categories you have armed below."
-              : "Request OS permission and surface new mentions or needs-action items outside the app."
-          }
-          disabled={isUpdatingDesktopNotifications}
-          enabled={notificationSettings.desktopEnabled}
-          icon={BellRing}
-          onToggle={() => {
-            void onSetDesktopNotificationsEnabled(
-              !notificationSettings.desktopEnabled,
-            );
-          }}
-          testId="notifications-desktop-toggle"
-          title={
-            isUpdatingDesktopNotifications ? "Requesting..." : "Desktop alerts"
-          }
-        />
-        <NotificationPreferenceCard
-          description="Show a Home badge for mentions and needs-action items in the sidebar."
-          enabled={notificationSettings.homeBadgeEnabled}
-          icon={HomeIcon}
-          onToggle={() => {
-            onSetHomeBadgeEnabled(!notificationSettings.homeBadgeEnabled);
-          }}
-          testId="notifications-home-badge-toggle"
-          title="Home badge"
-        />
-        <NotificationPreferenceCard
-          description="Alert when someone tags your pubkey in a channel you can access."
-          enabled={notificationSettings.mentions}
-          icon={AtSign}
-          onToggle={() => {
-            onSetMentionNotificationsEnabled(!notificationSettings.mentions);
-          }}
-          testId="notifications-mentions-toggle"
-          title="@Mentions"
-        />
-        <NotificationPreferenceCard
-          description="Alert for reminders and workflow approvals that are waiting on you."
-          enabled={notificationSettings.needsAction}
-          icon={CircleAlert}
-          onToggle={() => {
-            onSetNeedsActionNotificationsEnabled(
-              !notificationSettings.needsAction,
-            );
-          }}
-          testId="notifications-needs-action-toggle"
-          title="Needs action"
-        />
+      <span className="sr-only" data-testid="notifications-desktop-state">
+        {notificationPermission === "unsupported"
+          ? "Unavailable"
+          : notificationPermission === "denied"
+            ? "Blocked"
+            : notificationSettings.desktopEnabled
+              ? "On"
+              : "Off"}
+      </span>
+
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <label
+              className="text-sm font-medium"
+              htmlFor="desktop-alerts-switch"
+            >
+              {isUpdatingDesktopNotifications
+                ? "Requesting..."
+                : "Desktop alerts"}
+            </label>
+            <p className="text-sm text-muted-foreground">
+              {notificationSettings.desktopEnabled
+                ? "Native desktop alerts are enabled for the categories you have armed below."
+                : "Request OS permission and surface new mentions or needs-action items outside the app."}
+            </p>
+          </div>
+          <Switch
+            checked={notificationSettings.desktopEnabled}
+            data-testid="notifications-desktop-toggle"
+            disabled={isUpdatingDesktopNotifications}
+            id="desktop-alerts-switch"
+            onCheckedChange={(checked) => {
+              void onSetDesktopNotificationsEnabled(checked);
+            }}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <label className="text-sm font-medium" htmlFor="home-badge-switch">
+              Home badge
+            </label>
+            <p className="text-sm text-muted-foreground">
+              Show a Home badge for mentions and needs-action items in the
+              sidebar.
+            </p>
+          </div>
+          <Switch
+            checked={notificationSettings.homeBadgeEnabled}
+            data-testid="notifications-home-badge-toggle"
+            id="home-badge-switch"
+            onCheckedChange={(checked) => {
+              onSetHomeBadgeEnabled(checked);
+            }}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <label className="text-sm font-medium" htmlFor="mentions-switch">
+              @Mentions
+            </label>
+            <p className="text-sm text-muted-foreground">
+              Alert when someone tags your pubkey in a channel you can access.
+            </p>
+          </div>
+          <Switch
+            checked={notificationSettings.mentions}
+            data-testid="notifications-mentions-toggle"
+            id="mentions-switch"
+            onCheckedChange={(checked) => {
+              onSetMentionNotificationsEnabled(checked);
+            }}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <label
+              className="text-sm font-medium"
+              htmlFor="needs-action-switch"
+            >
+              Needs action
+            </label>
+            <p className="text-sm text-muted-foreground">
+              Alert for reminders and workflow approvals that are waiting on
+              you.
+            </p>
+          </div>
+          <Switch
+            checked={notificationSettings.needsAction}
+            data-testid="notifications-needs-action-toggle"
+            id="needs-action-switch"
+            onCheckedChange={(checked) => {
+              onSetNeedsActionNotificationsEnabled(checked);
+            }}
+          />
+        </div>
       </div>
+
+      {permissionBlocked && (
+        <p className="mt-4 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {notificationPermission === "unsupported"
+            ? "Desktop notifications are not supported in this environment."
+            : "Desktop notifications are blocked. Enable them in your system settings."}
+        </p>
+      )}
 
       {notificationErrorMessage ? (
         <p className="mt-4 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {notificationErrorMessage}
         </p>
       ) : null}
-
-      <p className="mt-4 text-sm text-muted-foreground">
-        The Home badge is an in-app signal. Desktop alerts only fire for new
-        feed items after you enable them.
-      </p>
     </section>
   );
 }

--- a/desktop/src/features/settings/ui/PreventSleepSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/PreventSleepSettingsCard.tsx
@@ -1,16 +1,9 @@
-import { Shield } from "lucide-react";
 import { usePreventSleepContext } from "@/features/agents/usePreventSleep";
-import { cn } from "@/shared/lib/cn";
+import { Switch } from "@/shared/ui/switch";
 
 export function PreventSleepSettingsCard() {
-  const {
-    enabled,
-    setEnabled,
-    active,
-    hasRunningAgents,
-    expired,
-    clearExpired,
-  } = usePreventSleepContext();
+  const { enabled, setEnabled, hasRunningAgents, expired, clearExpired } =
+    usePreventSleepContext();
 
   return (
     <section className="min-w-0" data-testid="settings-agents">
@@ -21,53 +14,40 @@ export function PreventSleepSettingsCard() {
         </p>
       </div>
 
-      <button
-        aria-pressed={enabled}
-        className={cn(
-          "flex w-full flex-col items-start gap-2 rounded-xl border px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-          enabled
-            ? "border-primary bg-primary/10 text-foreground"
-            : "border-border/80 bg-background/60 text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-        )}
-        data-testid="prevent-sleep-toggle"
-        onClick={() => {
-          if (expired) {
-            clearExpired();
-          }
-          setEnabled(!enabled);
-        }}
-        type="button"
-      >
-        <div className="flex items-center gap-2">
-          <Shield className="h-4 w-4" />
-          <span className="font-medium text-foreground">
-            Keep awake while agents are active
-          </span>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <label
+              className="text-sm font-medium"
+              htmlFor="prevent-sleep-switch"
+            >
+              Keep awake while agents are active
+            </label>
+            <p className="text-sm text-muted-foreground">
+              Prevents your computer from sleeping while local agents are
+              running. Automatically releases when all agents stop or after 4
+              hours.
+            </p>
+          </div>
+          <Switch
+            checked={enabled}
+            data-testid="prevent-sleep-toggle"
+            id="prevent-sleep-switch"
+            onCheckedChange={(checked) => {
+              if (expired) {
+                clearExpired();
+              }
+              setEnabled(checked);
+            }}
+          />
         </div>
-        <p className="text-sm text-muted-foreground">
-          Prevents your computer from sleeping while local agents are running.
-          Automatically releases when all agents stop or after 4 hours.
-        </p>
-      </button>
-
-      <div className="mt-3 flex items-center gap-2 text-sm">
-        <span
-          className={cn(
-            "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-[0.18em]",
-            active
-              ? "border-primary/30 bg-primary/10 text-primary"
-              : "border-border/80 bg-muted text-muted-foreground",
-          )}
-          data-testid="prevent-sleep-status"
-        >
-          {active ? "Active" : "Inactive"}
-        </span>
-        {enabled && !hasRunningAgents && (
-          <span className="text-muted-foreground">
-            Waiting for agents to start
-          </span>
-        )}
       </div>
+
+      {enabled && !hasRunningAgents && (
+        <p className="mt-3 text-sm text-muted-foreground">
+          Waiting for agents to start
+        </p>
+      )}
 
       {expired && (
         <p className="mt-3 rounded-xl border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-400">

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -1,4 +1,4 @@
-import { AtSign, Check, Fingerprint, Link2, UserRound } from "lucide-react";
+import { AtSign, Check, Link2, UserRound } from "lucide-react";
 import * as React from "react";
 
 import {
@@ -134,10 +134,6 @@ export function ProfileSettingsCard({
             <p className="text-sm text-muted-foreground">
               Manage how your identity appears across Sprout.
             </p>
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-full border border-border/80 bg-background/70 px-3 py-1 text-xs font-medium text-muted-foreground">
-            <Fingerprint className="h-3.5 w-3.5" />
-            <span>Your relay profile</span>
           </div>
         </div>
       </div>

--- a/desktop/src/shared/ui/switch.tsx
+++ b/desktop/src/shared/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/shared/lib/cn";
+
+const Switch = React.forwardRef<
+  React.ComponentRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/desktop/tests/helpers/settings.ts
+++ b/desktop/tests/helpers/settings.ts
@@ -3,8 +3,13 @@ import { expect, type Page } from "@playwright/test";
 type SettingsSection =
   | "profile"
   | "notifications"
+  | "agents"
   | "appearance"
+  | "shortcuts"
   | "tokens"
+  | "relay-members"
+  | "mobile"
+  | "updates"
   | "doctor";
 
 export async function openProfileMenu(page: Page) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -979,6 +982,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tabs@1.1.13':
@@ -3397,6 +3413,21 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:


### PR DESCRIPTION
## Summary
- Consolidate all notification settings (Desktop alerts, Home badge, @Mentions, Needs action) into a single **Notifications** section — removes the confusing split between General and Notifications
- Convert the Agents "Keep awake" toggle from a large card-style button to a compact inline **Switch** row, matching the Notifications section pattern
- Remove decorative noise: "Your relay profile" pill badge from Profile header and ACTIVE/INACTIVE status badge from Agents section
- Add shared `Switch` component wrapping `@radix-ui/react-switch`

## Test plan
- [x] Verify all 4 notification toggles render in the Notifications section and persist state
- [ ] Verify the Agents "Keep awake" switch toggles correctly
- [ ] Verify Profile section no longer shows "Your relay profile" badge
- [ ] Verify no "General" section appears in the sidebar
- [ ] Run existing E2E settings tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)