### PR TITLE
Fix onboarding relay membership denial handling

### DIFF
--- a/desktop/src/features/onboarding/ui/MembershipDenied.tsx
+++ b/desktop/src/features/onboarding/ui/MembershipDenied.tsx
@@ -16,7 +16,17 @@ export function MembershipDenied({
   onRetry,
   pubkey,
 }: MembershipDeniedProps) {
-  const npub = React.useMemo(() => pubkeyToNpub(pubkey), [pubkey]);
+  const npub = React.useMemo(() => {
+    if (!pubkey) {
+      return "Unknown public key";
+    }
+
+    try {
+      return pubkeyToNpub(pubkey);
+    } catch {
+      return pubkey;
+    }
+  }, [pubkey]);
   const [copied, setCopied] = React.useState(false);
 
   const handleCopy = React.useCallback(async () => {

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -35,15 +35,25 @@ import type {
  * Returns `true` if denied, `false` if the user is a member (or if the
  * relay doesn't enforce membership / isn't reachable).
  */
+function isRelayMembershipDeniedError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.message.includes("You must be a relay member") ||
+    error.message.includes("relay_membership_required") ||
+    error.message.includes("restricted: not a relay member") ||
+    error.message.includes("invalid: you are not a relay member")
+  );
+}
+
 async function checkMembershipDenied(): Promise<boolean> {
   try {
     const { membership, snapshotFound } = await getMyRelayMembershipLookup();
     return snapshotFound && membership === null;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message.includes("relay returned 403")
-    ) {
+    if (isRelayMembershipDeniedError(error)) {
       return true;
     }
     // Network errors, 401s, 500s — not membership denials.
@@ -271,7 +281,18 @@ export function OnboardingFlow({
     if (Object.keys(updatePayload).length > 0) {
       try {
         await profileUpdateMutation.mutateAsync(updatePayload);
-      } catch {
+      } catch (error) {
+        if (isRelayMembershipDeniedError(error)) {
+          try {
+            const identity = await getIdentity();
+            setDeniedPubkey(identity.pubkey);
+          } catch {
+            setDeniedPubkey("");
+          }
+          setCurrentPage("membership-denied");
+          return;
+        }
+
         // Error falls through to the error banner / recovery buttons.
         return;
       }


### PR DESCRIPTION
## Summary
- Detect relay membership-denied errors by semantic relay messages instead of a brittle 403 prefix
- Route profile-save membership failures to the onboarding membership-required page
- Avoid crashing the membership-required page if the denied pubkey is unavailable

## Test plan
- Confirmed manually by user
- `cd desktop && pnpm exec tsc --noEmit`
- Pre-commit/pre-push hooks ran successfully (`desktop-check`, `desktop-build`, `desktop-tauri-check`, `mobile-check`, `mobile-test`, `rust-fmt`, `rust-clippy`, `rust-tests`, `web-check`, `web-build`)
