### PR TITLE
feat(desktop): reusable AvatarUpload for onboarding and settings

### DIFF
--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -144,6 +144,7 @@ export function OnboardingFlow({
   const [profileDraft, setProfileDraft] =
     React.useState<OnboardingProfileValues>(savedProfile);
   const [deniedPubkey, setDeniedPubkey] = React.useState<string>("");
+  const [isUploadingAvatar, setIsUploadingAvatar] = React.useState(false);
 
   // For displaying the current identity at the top of the profile step and
   // for refreshing the UI in place after `import_identity` completes — the
@@ -269,6 +270,7 @@ export function OnboardingFlow({
       savedUrl: savedProfile.avatarUrl,
     },
     currentNpub,
+    isUploadingAvatar,
     isSaving: isSavingProfile,
     name: {
       draftValue: profileDraft.displayName,
@@ -343,6 +345,7 @@ export function OnboardingFlow({
               advanceWithoutSaving: showSetupPage,
               clearAvatarDraft: resetAvatarDraft,
               importIdentity: handleImportIdentity,
+              onUploadingChange: setIsUploadingAvatar,
               skipForNow,
               submit: () => {
                 void saveProfileAndContinue();

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -9,7 +9,6 @@ import { useWorkspaces } from "@/features/workspaces/useWorkspaces";
 import {
   getIdentity,
   importIdentity as tauriImportIdentity,
-  uploadMediaBytes,
 } from "@/shared/api/tauri";
 import { getMyRelayMembershipLookup } from "@/shared/api/relayMembers";
 import { useIdentityQuery } from "@/shared/api/hooks";
@@ -129,13 +128,6 @@ function resolveProfileSaveRecovery(
   };
 }
 
-const AVATAR_IMAGE_TYPES = [
-  "image/gif",
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-];
-
 export function OnboardingFlow({
   actions,
   initialProfile,
@@ -144,7 +136,6 @@ export function OnboardingFlow({
   const { complete, skipForNow } = actions;
   const { setDesktopEnabled } = notifications;
   const savedProfile = resolveSavedProfile(initialProfile);
-  const avatarInputRef = React.useRef<HTMLInputElement | null>(null);
   const profileUpdateMutation = useUpdateProfileMutation();
   const { error: profileSaveError, isPending: isSavingProfile } =
     profileUpdateMutation;
@@ -152,10 +143,6 @@ export function OnboardingFlow({
     React.useState<OnboardingPage>("profile");
   const [profileDraft, setProfileDraft] =
     React.useState<OnboardingProfileValues>(savedProfile);
-  const [avatarErrorMessage, setAvatarErrorMessage] = React.useState<
-    string | null
-  >(null);
-  const [isUploadingAvatar, setIsUploadingAvatar] = React.useState(false);
   const [deniedPubkey, setDeniedPubkey] = React.useState<string>("");
 
   // For displaying the current identity at the top of the profile step and
@@ -183,67 +170,19 @@ export function OnboardingFlow({
   // labels and similar UI reflect the active identity.
   const { activeWorkspace, updateWorkspace } = useWorkspaces();
 
-  const openAvatarPicker = React.useCallback(() => {
-    avatarInputRef.current?.click();
-  }, []);
-
   const resetProfileSaveError = React.useCallback(() => {
     profileUpdateMutation.reset();
   }, [profileUpdateMutation]);
 
   const updateProfileDraft = React.useCallback(
-    (
-      patch: Partial<OnboardingProfileValues>,
-      options?: { clearAvatarError?: boolean },
-    ) => {
+    (patch: Partial<OnboardingProfileValues>) => {
       resetProfileSaveError();
-      if (options?.clearAvatarError) {
-        setAvatarErrorMessage(null);
-      }
       setProfileDraft((current) => ({
         ...current,
         ...patch,
       }));
     },
     [resetProfileSaveError],
-  );
-
-  const handleAvatarFileChange = React.useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      event.target.value = "";
-
-      if (!file) {
-        return;
-      }
-
-      if (!AVATAR_IMAGE_TYPES.includes(file.type)) {
-        setAvatarErrorMessage("Choose a PNG, JPG, GIF, or WebP image.");
-        return;
-      }
-
-      resetProfileSaveError();
-      setIsUploadingAvatar(true);
-      setAvatarErrorMessage(null);
-
-      try {
-        const buffer = await file.arrayBuffer();
-        const uploaded = await uploadMediaBytes([...new Uint8Array(buffer)]);
-        updateProfileDraft(
-          { avatarUrl: uploaded.url },
-          { clearAvatarError: true },
-        );
-      } catch (error) {
-        setAvatarErrorMessage(
-          error instanceof Error
-            ? error.message
-            : "Could not upload that avatar.",
-        );
-      } finally {
-        setIsUploadingAvatar(false);
-      }
-    },
-    [resetProfileSaveError, updateProfileDraft],
   );
 
   const showSetupPage = React.useCallback(() => {
@@ -310,16 +249,13 @@ export function OnboardingFlow({
 
   const updateAvatarUrlDraft = React.useCallback(
     (value: string) => {
-      updateProfileDraft({ avatarUrl: value }, { clearAvatarError: true });
+      updateProfileDraft({ avatarUrl: value });
     },
     [updateProfileDraft],
   );
 
   const resetAvatarDraft = React.useCallback(() => {
-    updateProfileDraft(
-      { avatarUrl: savedProfile.avatarUrl },
-      { clearAvatarError: true },
-    );
+    updateProfileDraft({ avatarUrl: savedProfile.avatarUrl });
   }, [savedProfile.avatarUrl, updateProfileDraft]);
 
   const handleEnableDesktopNotifications = React.useCallback(() => {
@@ -330,9 +266,6 @@ export function OnboardingFlow({
   const profileStepState: ProfileStepState = {
     avatar: {
       draftUrl: profileDraft.avatarUrl,
-      errorMessage: avatarErrorMessage,
-      inputRef: avatarInputRef,
-      isUploading: isUploadingAvatar,
       savedUrl: savedProfile.avatarUrl,
     },
     currentNpub,
@@ -410,16 +343,12 @@ export function OnboardingFlow({
               advanceWithoutSaving: showSetupPage,
               clearAvatarDraft: resetAvatarDraft,
               importIdentity: handleImportIdentity,
-              openAvatarPicker,
               skipForNow,
               submit: () => {
                 void saveProfileAndContinue();
               },
               updateAvatarUrl: updateAvatarUrlDraft,
               updateDisplayName: updateDisplayNameDraft,
-              uploadAvatarFile: (event) => {
-                void handleAvatarFileChange(event);
-              },
             }}
             state={profileStepState}
           />

--- a/desktop/src/features/onboarding/ui/ProfileStep.tsx
+++ b/desktop/src/features/onboarding/ui/ProfileStep.tsx
@@ -244,14 +244,23 @@ export function ProfileStep({ actions, state }: ProfileStepProps) {
     advanceWithoutSaving,
     clearAvatarDraft,
     importIdentity,
+    onUploadingChange,
     skipForNow,
     submit,
     updateAvatarUrl,
     updateDisplayName,
   } = actions;
-  const { avatar, currentNpub, isSaving, name, saveRecovery } = state;
+  const {
+    avatar,
+    currentNpub,
+    isUploadingAvatar,
+    isSaving,
+    name,
+    saveRecovery,
+  } = state;
   const { draftValue: displayNameDraft, savedValue: savedDisplayName } = name;
-  const canSubmit = displayNameDraft.trim().length > 0 && !isSaving;
+  const canSubmit =
+    displayNameDraft.trim().length > 0 && !isSaving && !isUploadingAvatar;
   const avatarPreviewLabel =
     displayNameDraft.trim() || savedDisplayName || "You";
 
@@ -321,6 +330,7 @@ export function ProfileStep({ actions, state }: ProfileStepProps) {
         previewName={avatarPreviewLabel}
         onUrlChange={updateAvatarUrl}
         onClear={clearAvatarDraft}
+        onUploadingChange={onUploadingChange}
         showClear={
           avatar.draftUrl.length > 0 && avatar.draftUrl !== avatar.savedUrl
         }

--- a/desktop/src/features/onboarding/ui/ProfileStep.tsx
+++ b/desktop/src/features/onboarding/ui/ProfileStep.tsx
@@ -1,15 +1,7 @@
 import * as React from "react";
-import {
-  Camera,
-  Check,
-  KeyRound,
-  Link2,
-  Loader2,
-  Upload,
-  UserRound,
-} from "lucide-react";
+import { Check, KeyRound, Loader2, Upload, UserRound } from "lucide-react";
 
-import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import { AvatarUpload } from "@/features/profile/ui/AvatarUpload";
 import { nsecToNpub, shortenNpub } from "@/shared/lib/nostrUtils";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
@@ -30,120 +22,6 @@ function ErrorBanner({ message }: { message: string | null }) {
     <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
       {message}
     </p>
-  );
-}
-
-type AvatarSectionProps = {
-  actions: Pick<
-    ProfileStepActions,
-    | "clearAvatarDraft"
-    | "openAvatarPicker"
-    | "updateAvatarUrl"
-    | "uploadAvatarFile"
-  >;
-  avatar: ProfileStepState["avatar"];
-  isSaving: boolean;
-  previewName: string;
-};
-
-function AvatarSection({
-  actions,
-  avatar,
-  isSaving,
-  previewName,
-}: AvatarSectionProps) {
-  const {
-    clearAvatarDraft,
-    openAvatarPicker,
-    updateAvatarUrl,
-    uploadAvatarFile,
-  } = actions;
-  const { draftUrl, inputRef, isUploading, savedUrl } = avatar;
-  const hasAvatarDraftChanges = draftUrl.length > 0 && draftUrl !== savedUrl;
-  const isAvatarInputDisabled = isSaving || isUploading;
-
-  return (
-    <div className="rounded-[28px] border border-border/70 bg-muted/20 p-5">
-      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-4">
-          <div className="relative h-20 w-20 shrink-0">
-            <ProfileAvatar
-              avatarUrl={draftUrl || null}
-              className="h-full w-full rounded-3xl text-xl"
-              iconClassName="h-6 w-6"
-              label={previewName}
-              testId="onboarding-avatar-preview"
-            />
-            <div className="absolute -bottom-1 -right-1 flex h-8 w-8 items-center justify-center rounded-full border border-background bg-primary text-primary-foreground shadow-sm">
-              <Camera className="h-4 w-4" />
-            </div>
-          </div>
-          <div className="space-y-2">
-            <p className="text-sm font-medium">Add a profile photo</p>
-            <p className="max-w-sm text-sm text-muted-foreground">
-              Optional, but it makes conversations easier to scan.
-            </p>
-          </div>
-        </div>
-
-        <div className="flex flex-col items-stretch gap-2 sm:min-w-[220px]">
-          <Button
-            className="w-full justify-center"
-            data-testid="onboarding-avatar-upload"
-            disabled={isAvatarInputDisabled}
-            onClick={openAvatarPicker}
-            size="lg"
-            type="button"
-          >
-            {isUploading ? <Loader2 className="animate-spin" /> : <Camera />}
-            {isUploading ? "Uploading..." : "Upload photo"}
-          </Button>
-          {hasAvatarDraftChanges ? (
-            <Button
-              data-testid="onboarding-avatar-clear"
-              onClick={clearAvatarDraft}
-              size="sm"
-              type="button"
-              variant="ghost"
-            >
-              Undo
-            </Button>
-          ) : (
-            <p className="text-xs text-muted-foreground">
-              You can always add one later.
-            </p>
-          )}
-          <input
-            accept="image/gif,image/jpeg,image/png,image/webp"
-            className="hidden"
-            onChange={uploadAvatarFile}
-            ref={inputRef}
-            type="file"
-          />
-        </div>
-      </div>
-
-      <div className="mt-5 space-y-1.5">
-        <label className="text-sm font-medium" htmlFor="onboarding-avatar-url">
-          Avatar URL
-        </label>
-        <div className="relative min-w-0">
-          <Link2 className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            className="pl-9"
-            data-testid="onboarding-avatar-url"
-            disabled={isAvatarInputDisabled}
-            id="onboarding-avatar-url"
-            onChange={(event) => updateAvatarUrl(event.target.value)}
-            placeholder="https://example.com/avatar.png"
-            value={draftUrl}
-          />
-        </div>
-        <p className="text-xs text-muted-foreground">
-          Prefer a link instead? Paste it here and we&apos;ll save that instead.
-        </p>
-      </div>
-    </div>
   );
 }
 
@@ -366,18 +244,14 @@ export function ProfileStep({ actions, state }: ProfileStepProps) {
     advanceWithoutSaving,
     clearAvatarDraft,
     importIdentity,
-    openAvatarPicker,
     skipForNow,
     submit,
     updateAvatarUrl,
     updateDisplayName,
-    uploadAvatarFile,
   } = actions;
   const { avatar, currentNpub, isSaving, name, saveRecovery } = state;
-  const { errorMessage: avatarErrorMessage } = avatar;
   const { draftValue: displayNameDraft, savedValue: savedDisplayName } = name;
-  const isSubmittingDisabled = isSaving || avatar.isUploading;
-  const canSubmit = displayNameDraft.trim().length > 0 && !isSubmittingDisabled;
+  const canSubmit = displayNameDraft.trim().length > 0 && !isSaving;
   const avatarPreviewLabel =
     displayNameDraft.trim() || savedDisplayName || "You";
 
@@ -424,7 +298,7 @@ export function ProfileStep({ actions, state }: ProfileStepProps) {
             autoFocus
             className="pl-9"
             data-testid="onboarding-display-name"
-            disabled={isSubmittingDisabled}
+            disabled={isSaving}
             id="onboarding-display-name"
             onChange={(event) => updateDisplayName(event.target.value)}
             onKeyDown={(event) => {
@@ -442,21 +316,20 @@ export function ProfileStep({ actions, state }: ProfileStepProps) {
         </p>
       </div>
 
-      <AvatarSection
-        actions={{
-          clearAvatarDraft,
-          openAvatarPicker,
-          updateAvatarUrl,
-          uploadAvatarFile,
-        }}
-        avatar={avatar}
-        isSaving={isSaving}
+      <AvatarUpload
+        avatarUrl={avatar.draftUrl}
         previewName={avatarPreviewLabel}
+        onUrlChange={updateAvatarUrl}
+        onClear={clearAvatarDraft}
+        showClear={
+          avatar.draftUrl.length > 0 && avatar.draftUrl !== avatar.savedUrl
+        }
+        disabled={isSaving}
+        testIdPrefix="onboarding-avatar"
       />
 
       <ImportKeySection onImport={importIdentity} />
 
-      <ErrorBanner message={avatarErrorMessage} />
       <ErrorBanner message={saveRecovery.errorMessage} />
 
       <div className="flex flex-wrap items-center justify-end gap-2">

--- a/desktop/src/features/onboarding/ui/types.ts
+++ b/desktop/src/features/onboarding/ui/types.ts
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import type {
   DesktopNotificationPermissionState,
   NotificationSettings,
@@ -43,9 +41,6 @@ export type ProfileStepNameState = {
 
 export type ProfileStepAvatarState = {
   draftUrl: string;
-  errorMessage: string | null;
-  inputRef: React.RefObject<HTMLInputElement | null>;
-  isUploading: boolean;
   savedUrl: string;
 };
 
@@ -63,12 +58,10 @@ export type ProfileStepActions = {
   advanceWithoutSaving: () => void;
   clearAvatarDraft: () => void;
   importIdentity: (nsec: string) => Promise<void>;
-  openAvatarPicker: () => void;
   skipForNow: () => void;
   submit: () => void;
   updateAvatarUrl: (value: string) => void;
   updateDisplayName: (value: string) => void;
-  uploadAvatarFile: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 export type SetupStepActions = {

--- a/desktop/src/features/onboarding/ui/types.ts
+++ b/desktop/src/features/onboarding/ui/types.ts
@@ -49,6 +49,7 @@ export type ProfileStepState = {
   /** Bech32-encoded current pubkey (npub1…), shown so the user can confirm
    *  which identity they're saving the profile for. */
   currentNpub: string | null;
+  isUploadingAvatar: boolean;
   isSaving: boolean;
   name: ProfileStepNameState;
   saveRecovery: ProfileStepSaveRecovery;
@@ -58,6 +59,7 @@ export type ProfileStepActions = {
   advanceWithoutSaving: () => void;
   clearAvatarDraft: () => void;
   importIdentity: (nsec: string) => Promise<void>;
+  onUploadingChange: (isUploading: boolean) => void;
   skipForNow: () => void;
   submit: () => void;
   updateAvatarUrl: (value: string) => void;

--- a/desktop/src/features/profile/ui/AvatarUpload.tsx
+++ b/desktop/src/features/profile/ui/AvatarUpload.tsx
@@ -11,8 +11,10 @@ type AvatarUploadProps = {
   previewName: string;
   onUrlChange: (url: string) => void;
   onClear?: () => void;
+  onUploadingChange?: (isUploading: boolean) => void;
   showClear?: boolean;
   disabled?: boolean;
+  idleHint?: string;
   testIdPrefix?: string;
 };
 
@@ -21,8 +23,10 @@ export function AvatarUpload({
   previewName,
   onUrlChange,
   onClear,
+  onUploadingChange,
   showClear,
   disabled,
+  idleHint = "You can always add one later.",
   testIdPrefix = "avatar",
 }: AvatarUploadProps) {
   const onUploadSuccess = React.useCallback(
@@ -40,6 +44,10 @@ export function AvatarUpload({
     openPicker,
     handleFileChange,
   } = useAvatarUpload({ onUploadSuccess });
+
+  React.useEffect(() => {
+    onUploadingChange?.(isUploading);
+  }, [isUploading, onUploadingChange]);
 
   const isInputDisabled = disabled || isUploading;
 
@@ -90,9 +98,7 @@ export function AvatarUpload({
               Undo
             </Button>
           ) : (
-            <p className="text-xs text-muted-foreground">
-              You can always add one later.
-            </p>
+            <p className="text-xs text-muted-foreground">{idleHint}</p>
           )}
           <input
             accept="image/gif,image/jpeg,image/png,image/webp"

--- a/desktop/src/features/profile/ui/AvatarUpload.tsx
+++ b/desktop/src/features/profile/ui/AvatarUpload.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+import { Camera, Link2, Loader2 } from "lucide-react";
+
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+
+type AvatarUploadProps = {
+  avatarUrl: string;
+  previewName: string;
+  onUrlChange: (url: string) => void;
+  onClear?: () => void;
+  showClear?: boolean;
+  disabled?: boolean;
+  testIdPrefix?: string;
+};
+
+export function AvatarUpload({
+  avatarUrl,
+  previewName,
+  onUrlChange,
+  onClear,
+  showClear,
+  disabled,
+  testIdPrefix = "avatar",
+}: AvatarUploadProps) {
+  const onUploadSuccess = React.useCallback(
+    (url: string) => {
+      onUrlChange(url);
+    },
+    [onUrlChange],
+  );
+
+  const {
+    inputRef,
+    isUploading,
+    errorMessage,
+    clearError,
+    openPicker,
+    handleFileChange,
+  } = useAvatarUpload({ onUploadSuccess });
+
+  const isInputDisabled = disabled || isUploading;
+
+  return (
+    <div className="rounded-[28px] border border-border/70 bg-muted/20 p-5">
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-4">
+          <div className="relative h-20 w-20 shrink-0">
+            <ProfileAvatar
+              avatarUrl={avatarUrl || null}
+              className="h-full w-full rounded-3xl text-xl"
+              iconClassName="h-6 w-6"
+              label={previewName}
+              testId={`${testIdPrefix}-preview`}
+            />
+            <div className="absolute -bottom-1 -right-1 flex h-8 w-8 items-center justify-center rounded-full border border-background bg-primary text-primary-foreground shadow-sm">
+              <Camera className="h-4 w-4" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Add a profile photo</p>
+            <p className="max-w-sm text-sm text-muted-foreground">
+              Optional, but it makes conversations easier to scan.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-stretch gap-2 sm:min-w-[220px]">
+          <Button
+            className="w-full justify-center"
+            data-testid={`${testIdPrefix}-upload`}
+            disabled={isInputDisabled}
+            onClick={openPicker}
+            size="lg"
+            type="button"
+          >
+            {isUploading ? <Loader2 className="animate-spin" /> : <Camera />}
+            {isUploading ? "Uploading..." : "Upload photo"}
+          </Button>
+          {showClear && onClear ? (
+            <Button
+              data-testid={`${testIdPrefix}-clear`}
+              onClick={onClear}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              Undo
+            </Button>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              You can always add one later.
+            </p>
+          )}
+          <input
+            accept="image/gif,image/jpeg,image/png,image/webp"
+            className="hidden"
+            onChange={(event) => {
+              void handleFileChange(event);
+            }}
+            ref={inputRef}
+            type="file"
+          />
+        </div>
+      </div>
+
+      <div className="mt-5 space-y-1.5">
+        <label className="text-sm font-medium" htmlFor={`${testIdPrefix}-url`}>
+          Avatar URL
+        </label>
+        <div className="relative min-w-0">
+          <Link2 className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            className="pl-9"
+            data-testid={`${testIdPrefix}-url`}
+            disabled={isInputDisabled}
+            id={`${testIdPrefix}-url`}
+            onChange={(event) => {
+              clearError();
+              onUrlChange(event.target.value);
+            }}
+            placeholder="https://example.com/avatar.png"
+            value={avatarUrl}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Prefer a link instead? Paste it here and we&apos;ll save that instead.
+        </p>
+      </div>
+
+      {errorMessage ? (
+        <p className="mt-3 rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/features/profile/useAvatarUpload.ts
+++ b/desktop/src/features/profile/useAvatarUpload.ts
@@ -1,0 +1,82 @@
+import * as React from "react";
+
+import { uploadMediaBytes } from "@/shared/api/tauri";
+
+const AVATAR_IMAGE_TYPES = [
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+];
+
+type UseAvatarUploadOptions = {
+  onUploadSuccess: (url: string) => void;
+};
+
+type UseAvatarUploadReturn = {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  isUploading: boolean;
+  errorMessage: string | null;
+  clearError: () => void;
+  openPicker: () => void;
+  handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function useAvatarUpload({
+  onUploadSuccess,
+}: UseAvatarUploadOptions): UseAvatarUploadReturn {
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const [isUploading, setIsUploading] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  const clearError = React.useCallback(() => {
+    setErrorMessage(null);
+  }, []);
+
+  const openPicker = React.useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleFileChange = React.useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+
+      if (!file) {
+        return;
+      }
+
+      if (!AVATAR_IMAGE_TYPES.includes(file.type)) {
+        setErrorMessage("Choose a PNG, JPG, GIF, or WebP image.");
+        return;
+      }
+
+      setIsUploading(true);
+      setErrorMessage(null);
+
+      try {
+        const buffer = await file.arrayBuffer();
+        const uploaded = await uploadMediaBytes([...new Uint8Array(buffer)]);
+        onUploadSuccess(uploaded.url);
+      } catch (error) {
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : "Could not upload that avatar.",
+        );
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [onUploadSuccess],
+  );
+
+  return {
+    inputRef,
+    isUploading,
+    errorMessage,
+    clearError,
+    openPicker,
+    handleFileChange,
+  };
+}

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -6,6 +6,7 @@ import {
   useUpdateProfileMutation,
 } from "@/features/profile/hooks";
 import { AvatarUpload } from "@/features/profile/ui/AvatarUpload";
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Separator } from "@/shared/ui/separator";
@@ -116,13 +117,23 @@ export function ProfileSettingsCard({
 
   return (
     <section className="min-w-0" data-testid="settings-profile">
-      <div className="min-w-0 space-y-2">
-        <h2 className="break-words text-base font-semibold tracking-tight">
-          {resolvedName}
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          Manage how your identity appears across Sprout.
-        </p>
+      <div className="flex min-w-0 items-start gap-4">
+        <ProfileAvatar
+          avatarUrl={profile?.avatarUrl ?? null}
+          className="h-16 w-16 rounded-3xl text-lg"
+          iconClassName="h-6 w-6"
+          label={resolvedName}
+        />
+        <div className="min-w-0 space-y-2">
+          <div>
+            <h2 className="break-words text-base font-semibold tracking-tight">
+              {resolvedName}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Manage how your identity appears across Sprout.
+            </p>
+          </div>
+        </div>
       </div>
 
       <div className="mt-6 space-y-6">
@@ -186,6 +197,7 @@ export function ProfileSettingsCard({
               previewName={resolvedName}
               onUrlChange={(url) => setAvatarUrlDraft(url)}
               disabled={updateProfileMutation.isPending}
+              idleHint="Upload or paste a URL to change your avatar."
               testIdPrefix="profile-avatar"
             />
 

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -1,11 +1,11 @@
-import { AtSign, Check, Link2, UserRound } from "lucide-react";
+import { AtSign, Check, UserRound } from "lucide-react";
 import * as React from "react";
 
 import {
   useProfileQuery,
   useUpdateProfileMutation,
 } from "@/features/profile/hooks";
-import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import { AvatarUpload } from "@/features/profile/ui/AvatarUpload";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Separator } from "@/shared/ui/separator";
@@ -112,30 +112,17 @@ export function ProfileSettingsCard({
     fallbackDisplayName ||
     "Your profile";
   const resolvedPubkey = profile?.pubkey ?? currentPubkey ?? "Unavailable";
-  const resolvedAvatarUrl =
-    nextAvatarUrl.length > 0 ? nextAvatarUrl : (profile?.avatarUrl ?? null);
   const nip05Handle = profile?.nip05Handle ?? "Not set";
 
   return (
     <section className="min-w-0" data-testid="settings-profile">
-      <div className="flex min-w-0 items-start gap-4">
-        <ProfileAvatar
-          avatarUrl={resolvedAvatarUrl}
-          className="h-16 w-16 rounded-3xl text-lg"
-          iconClassName="h-6 w-6"
-          key={resolvedAvatarUrl ?? "profile-fallback-avatar"}
-          label={resolvedName}
-        />
-        <div className="min-w-0 space-y-2">
-          <div>
-            <h2 className="break-words text-base font-semibold tracking-tight">
-              {resolvedName}
-            </h2>
-            <p className="text-sm text-muted-foreground">
-              Manage how your identity appears across Sprout.
-            </p>
-          </div>
-        </div>
+      <div className="min-w-0 space-y-2">
+        <h2 className="break-words text-base font-semibold tracking-tight">
+          {resolvedName}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Manage how your identity appears across Sprout.
+        </p>
       </div>
 
       <div className="mt-6 space-y-6">
@@ -194,26 +181,13 @@ export function ProfileSettingsCard({
               </div>
             </div>
 
-            <div className="space-y-1.5">
-              <label
-                className="text-sm font-medium"
-                htmlFor="profile-avatar-url"
-              >
-                Avatar URL
-              </label>
-              <div className="relative min-w-0">
-                <Link2 className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  className="pl-9"
-                  data-testid="profile-avatar-url"
-                  disabled={updateProfileMutation.isPending}
-                  id="profile-avatar-url"
-                  onChange={(event) => setAvatarUrlDraft(event.target.value)}
-                  placeholder="https://example.com/avatar.png"
-                  value={avatarUrlDraft}
-                />
-              </div>
-            </div>
+            <AvatarUpload
+              avatarUrl={avatarUrlDraft}
+              previewName={resolvedName}
+              onUrlChange={(url) => setAvatarUrlDraft(url)}
+              disabled={updateProfileMutation.isPending}
+              testIdPrefix="profile-avatar"
+            />
 
             <div className="space-y-1.5">
               <label className="text-sm font-medium" htmlFor="profile-about">


### PR DESCRIPTION
## Summary
- Extract avatar upload logic from onboarding into a shared `useAvatarUpload` hook and `AvatarUpload` component in `features/profile/`
- Wire the new component into both the onboarding `ProfileStep` and the Settings `ProfileSettingsCard`
- Settings now supports file upload for avatars (previously URL-only input)
- Simplify onboarding state by removing avatar upload machinery from `OnboardingFlow.tsx` and `types.ts`

## Files changed
- **NEW** `desktop/src/features/profile/useAvatarUpload.ts` — Hook: MIME validation, `uploadMediaBytes` call, loading/error state
- **NEW** `desktop/src/features/profile/ui/AvatarUpload.tsx` — Reusable component: avatar preview + upload button + URL input + error banner
- **MODIFIED** `desktop/src/features/onboarding/ui/ProfileStep.tsx` — Replaced inline `AvatarSection` with `AvatarUpload`
- **MODIFIED** `desktop/src/features/onboarding/ui/OnboardingFlow.tsx` — Removed avatar upload state/callbacks
- **MODIFIED** `desktop/src/features/onboarding/ui/types.ts` — Simplified `ProfileStepAvatarState` and `ProfileStepActions`
- **MODIFIED** `desktop/src/features/settings/ui/ProfileSettingsCard.tsx` — Replaced URL-only input with `AvatarUpload`

## Test plan
- [ ] Verify onboarding avatar upload still works (file pick, upload, preview, undo)
- [ ] Verify Settings page now shows upload button + URL input for avatar
- [ ] Verify existing test IDs preserved (`onboarding-avatar-upload`, `onboarding-avatar-url`, `profile-avatar-url`)
- [ ] `pnpm check` and `tsc --noEmit` pass
- [ ] Desktop and web builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)