### PR TITLE
fix(desktop): show real name initial in avatar fallback instead of "Y"

### DIFF
--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -5,7 +5,10 @@ import {
   useChannelMembersQuery,
 } from "@/features/channels/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
-import { formatMemberName } from "@/features/channels/lib/memberUtils";
+import {
+  formatMemberName,
+  formatPubkey,
+} from "@/features/channels/lib/memberUtils";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import { changeChannelMemberRole } from "@/shared/api/tauri";
@@ -162,6 +165,7 @@ export function MembersSidebar({
         }
         member={member}
         memberIsBot={memberIsBot}
+        memberAvatarLabel={member.displayName ?? formatPubkey(member.pubkey)}
         memberLabel={formatMemberName(member, currentPubkey)}
         onChangeRole={(m, role) => {
           void changeRoleMutation.mutateAsync({ pubkey: m.pubkey, role });

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -39,6 +39,7 @@ type MembersSidebarMemberCardProps = {
   isArchived: boolean;
   managedAgent?: ManagedAgent;
   member: ChannelMember;
+  memberAvatarLabel: string;
   memberIsBot: boolean;
   memberLabel: string;
   onChangeRole: (member: ChannelMember, role: string) => void;
@@ -77,6 +78,7 @@ export function MembersSidebarMemberCard({
   isArchived,
   managedAgent,
   member,
+  memberAvatarLabel,
   memberIsBot,
   memberLabel,
   onChangeRole,
@@ -107,7 +109,7 @@ export function MembersSidebarMemberCard({
             avatarUrl={profileAvatarUrl ?? null}
             className="h-9 w-9 rounded-full text-[11px] shadow-none"
             iconClassName="h-4 w-4"
-            label={memberLabel}
+            label={memberAvatarLabel}
           />
           {presenceStatus ? (
             <span

--- a/desktop/src/features/messages/ui/SystemMessageRow.tsx
+++ b/desktop/src/features/messages/ui/SystemMessageRow.tsx
@@ -189,7 +189,14 @@ export const SystemMessageRow = React.memo(function SystemMessageRow({
   }
 
   const avatarPubkey = payload.actor ?? payload.target;
-  const avatarLabel = resolveLabel(avatarPubkey, currentPubkey, profiles);
+  const avatarLabel = avatarPubkey
+    ? resolveUserLabel({
+        pubkey: avatarPubkey,
+        currentPubkey,
+        profiles,
+        preferResolvedSelfLabel: true,
+      })
+    : "Someone";
 
   return (
     <div


### PR DESCRIPTION
Before
<img width="249" height="77" alt="Screenshot 2026-05-08 at 10 32 06 am" src="https://github.com/user-attachments/assets/88ec2233-3a1b-4408-9740-cd4c8c1e60d5" />

After

<img width="216" height="84" alt="Screenshot 2026-05-08 at 12 09 38 pm" src="https://github.com/user-attachments/assets/2ef9f103-ebed-4125-aef6-a51d6bc2cd7c" />


## Summary
- Fixes avatar fallback to display the user's real name initial instead of always showing "Y"
- Updates `MembersSidebar`, `MembersSidebarMemberCard`, and `SystemMessageRow` components to pass and use the member's display name for avatar generation

## Test plan
- Verify avatar fallback in the members sidebar shows the correct initial for each member
- Verify system message avatars show the correct initial
- Confirm that members with profile pictures are unaffected