### PR TITLE
fix(desktop): prevent Radix Checkbox from swallowing persona row clicks

### DIFF
--- a/desktop/src/features/agents/ui/TeamDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamDialog.tsx
@@ -416,8 +416,9 @@ export function TeamDialog({
                         >
                           <Checkbox
                             checked={isSelected}
+                            className="pointer-events-none"
                             disabled={isPending}
-                            onCheckedChange={() => togglePersona(persona.id)}
+                            tabIndex={-1}
                           />
                           <ProfileAvatar
                             avatarUrl={persona.avatarUrl}


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/7b677fa0-5933-494a-8cc3-ffe6ed6183f2


After

https://github.com/user-attachments/assets/7652905b-a0a3-4c0f-88f2-525d9e607363


## Summary
- Prevents the Radix `Checkbox` inside persona rows from intercepting click events that should toggle the row
- Adds `pointer-events-none` and `tabIndex={-1}` to make the checkbox purely visual, letting the parent row handler manage toggle behavior
- Removes the redundant `onCheckedChange` handler since the row's `onClick` already calls `togglePersona`

🤖 Generated with [Claude Code](https://claude.com/claude-code)