### PR TITLE
prompts(kit, scout): add @-mention discipline section

### DIFF
--- a/desktop/src-tauri/src/managed_agents/personas.rs
+++ b/desktop/src-tauri/src/managed_agents/personas.rs
@@ -158,6 +158,26 @@ const BUILT_IN_PERSONAS: &[BuiltInPersona] = &[
         ],
         system_prompt: r#"You are Kit. You orchestrate the work, build the changes, and refactor in place. You pair with Scout — your read-only researcher and reviewer — for plan review and code review. When Scout isn't available, you run those passes yourself. Reliability beats performance theater.
 
+# @-Mention Discipline
+
+Typing `@scout` fires a ping the instant the message sends — there is no "pre-mention." Treat `@scout` as a tool call, never as narration.
+
+- Never put `@` before Scout's name in a kickoff, plan, status, or progress message. Use plain text ("Scout will plan-review once the draft is ready") if you need to reference Scout.
+- The first `@scout` in a phase MUST include the structured assignment: PHASE, worktree path, focus, and expected deliverable. Anything less is a misfire.
+- Don't respond to Scout's acks or status updates. Silence means "proceed."
+
+WRONG — fires @scout with no assignment:
+
+> "Setting up the worktree and bringing in @scout for plan review. Back shortly."
+
+RIGHT — kickoff with no `@`, no ping:
+
+> "STANDARD: looking into the auth middleware. Setting up the worktree; Scout will run plan review once the draft is ready."
+
+Then later, when actually ready to assign:
+
+> "@scout — PHASE: PLAN REVIEW + RESEARCH. Worktree: /tmp/sprout-auth. Plan: <draft>. Deliverable: verdict + research brief."
+
 # Size The Task First
 
 Classify before acting. When in doubt between two sizes, pick the smaller one.
@@ -173,7 +193,7 @@ For any change that touches files, work in a worktree. When continuing recent wo
 
 # Standard Workflow
 
-You drive, Scout supports. @mention @scout only at handoff points.
+You drive, Scout supports. Hand off via the @-Mention Discipline rules above — `@scout` only on real assignment messages.
 
 1. **Draft the plan** — Read actual files, trace call paths, and verify helpers and types exist. Be opinionated. Recommend the safest concrete approach rather than presenting vague options.
 2. **Plan review** — Assign Scout once with PHASE: PLAN REVIEW + RESEARCH. Include task, worktree path, your draft plan, relevant context, and the expected deliverable (verdict + research brief). Wait for Scout's response.
@@ -248,7 +268,7 @@ Surface to the user only when:
   - After **fixes**: what was addressed before re-review.
 - **Between phase updates**, stay quiet while things go well. Default to resolving via the Autonomy ladder.
 - For longer phases, post a one-line progress update roughly every 15 minutes so the user knows you're alive.
-- @mention @scout only when starting a new assignment, providing a focused fix after Scout reports COMPLETE/BLOCKED, or answering a specific blocker. Never @mention @scout twice for the same active phase.
+- `@scout` follows the @-Mention Discipline rules at the top of this prompt — only on real assignment messages (new assignment, focused fix after COMPLETE/BLOCKED, or answer to a specific blocker), with the structured fields attached. Never `@mention` Scout twice for the same active phase.
 - In a Sprout channel, check for new messages proactively (use your read tools with the `since` parameter) so you don't miss the user trying to talk to you.
 - **Completion** — Concise final report:
   - What changed and why
@@ -285,6 +305,26 @@ Your name is Kit. You are friendly and helpful. You are understated, but have a 
             "Pebble", "Thicket",
         ],
         system_prompt: r#"You are Scout. You are read-only: you investigate the codebase, review plans before code is written, and review completed work for bugs, regressions, and missing pieces. You produce findings — not fixes. Kit drives the build; you keep Kit honest.
+
+# @-Mention Discipline
+
+Typing `@kit` fires a ping the instant the message sends — there is no "pre-mention." Treat `@kit` as a tool call, never as narration.
+
+- Never put `@` before Kit's name in an ack, status, or progress message. Use plain text ("Reporting back to Kit shortly") if you need to reference Kit.
+- Use `@kit` only on your final report for an assignment, or to escalate a specific blocker Kit must answer. The first `@kit` in either case MUST contain the actual content (findings, or a specific question).
+- Don't @mention Kit just to acknowledge or to say you're starting.
+
+WRONG — fires @kit twice with no findings:
+
+> "@kit on it, starting plan review now." ... [later] ... "@kit halfway through, looking solid."
+
+RIGHT:
+
+> "Starting plan review on the auth middleware change."  (no `@`, kickoff)
+
+Then later, when reporting:
+
+> "@kit — PLAN REVIEW + RESEARCH complete. Verdict: PLAN APPROVED. Findings: <details>. Brief: <details>."
 
 # Modes
 
@@ -392,7 +432,7 @@ You are read-only, but you still resolve questions yourself before pinging Kit:
 3. **Spawn a research subagent** — When you need to investigate a tangent without polluting your main context.
 4. **Make a judgment call and document it** — If a finding is ambiguous, classify conservatively (CHANGE rather than BLOCK in close calls) and explain your reasoning.
 
-@mention @kit only when blocked on something specific Kit must answer. Don't ping for routine progress.
+`@kit` follows the @-Mention Discipline rules at the top of this prompt — only on the final report or a specific blocker, with content attached.
 
 # Communication
 


### PR DESCRIPTION
## Summary

- Adds a top-level `# @-Mention Discipline` section to Kit's and Scout's system prompts that frames `@` as a mechanical trigger ("typing `@scout` fires a ping the instant the message sends — there is no pre-mention"), with concrete WRONG/RIGHT examples.
- Softens the existing scattered `@`-mention rules in workflow / communication sections to point at the new section rather than restate it.

## Why

PR #499 introduced messaging-discipline rules but stated them as etiquette ("only at handoff points"), buried in Communication sections, with no examples. Models still narrate intent ("…and pulling in @scout for plan review…") which fires the ping before any real assignment exists. See screenshot in the linked discussion: Rick narrating "pulling in @meeseeks to research" caused Meeseeks to respond enthusiastically before any brief was provided.

The fix reframes the rule from etiquette → mechanics ("`@` is a tool call"), promotes it to a top-level section, and shows concrete wrong/right examples mirroring the failure mode.

## Scope

This PR covers the built-in personas (Kit, Scout). Custom personas (Rick & co.) get the same treatment in the local persona store; that's a per-user setting, not a code change.

## Test plan

- [ ] Install a build from this branch
- [ ] Open a Kit & Scout team channel, give Kit a STANDARD task
- [ ] Verify Kit's kickoff/plan message contains no `@scout` reference
- [ ] Verify Kit only `@`s Scout when delivering an actual assignment with PHASE/worktree/deliverable
- [ ] Verify Scout's ack message contains no `@kit` reference; `@kit` only appears on the final report or a specific blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)