### PR TITLE
feat(desktop): expand default agent toolsets with canvas, forums, dms, and member list

### DIFF
--- a/crates/sprout-mcp/src/lib.rs
+++ b/crates/sprout-mcp/src/lib.rs
@@ -81,10 +81,11 @@
 //! - **`join_channel`** / **`leave_channel`** — Membership management.
 //! - **`update_channel`** / **`set_channel_topic`** / **`set_channel_purpose`** — Metadata.
 //! - **`open_dm`** — Open a direct-message channel.
+//! - **`list_channel_members`** — List members of a channel.
 //!
 //! ### Channel Admin (`channel_admin` toolset)
 //! - **`create_channel`** / **`archive_channel`** / **`unarchive_channel`**
-//! - **`add_channel_member`** / **`remove_channel_member`** / **`list_channel_members`**
+//! - **`add_channel_member`** / **`remove_channel_member`**
 //!
 //! ### Canvas (`canvas` toolset)
 //! - **`get_canvas`** — Retrieve the shared canvas document for a channel.

--- a/crates/sprout-mcp/src/toolsets.rs
+++ b/crates/sprout-mcp/src/toolsets.rs
@@ -19,8 +19,8 @@
 //!
 //! | Name            | Tools |
 //! |-----------------|-------|
-//! | `default`       | 25    |
-//! | `channel_admin` | 6     |
+//! | `default`       | 26    |
+//! | `channel_admin` | 5     |
 //! | `dms`           | 3     |
 //! | `canvas`        | 2     |
 //! | `workflow_admin`| 5     |
@@ -69,13 +69,13 @@ pub const ALL_TOOLS: &[(&str, &str, bool)] = &[
     ("set_presence", "default", false),
     ("trigger_workflow", "default", false),
     ("approve_step", "default", false),
+    ("list_channel_members", "default", true),
     // ── channel_admin ────────────────────────────────────────────────────────
     ("create_channel", "channel_admin", false),
     ("archive_channel", "channel_admin", false),
     ("unarchive_channel", "channel_admin", false),
     ("add_channel_member", "channel_admin", false),
     ("remove_channel_member", "channel_admin", false),
-    ("list_channel_members", "channel_admin", true),
     // ── dms ──────────────────────────────────────────────────────────────────
     ("add_dm_member", "dms", false),
     ("hide_dm", "dms", false),
@@ -317,9 +317,9 @@ mod tests {
     }
 
     #[test]
-    fn default_includes_25_tools() {
+    fn default_includes_26_tools() {
         let tools = enabled_tools("default");
-        assert_eq!(tools.len(), 25);
+        assert_eq!(tools.len(), 26);
         assert!(tools.contains("send_message"));
         assert!(tools.contains("approve_step"));
         assert!(!tools.contains("create_channel"));
@@ -356,7 +356,7 @@ mod tests {
         assert!(!remove.contains("send_message"));
         // create_channel is channel_admin+write → should be removed (ro)
         assert!(remove.contains("create_channel"));
-        // list_channel_members is channel_admin+read → should be kept (ro allows reads)
+        // list_channel_members is default+read → should be kept (rw)
         assert!(!remove.contains("list_channel_members"));
     }
 
@@ -364,7 +364,7 @@ mod tests {
     fn unknown_toolset_is_skipped_gracefully() {
         // Should not panic; unknown toolset is silently ignored
         let tools = enabled_tools("default,nonexistent_toolset");
-        assert_eq!(tools.len(), 25); // only default
+        assert_eq!(tools.len(), 26); // only default
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -550,7 +550,7 @@ pub fn spawn_agent_child(
     if let Some(toolsets) = &record.mcp_toolsets {
         command.env("SPROUT_TOOLSETS", toolsets);
     } else {
-        command.env("SPROUT_TOOLSETS", "default,media");
+        command.env("SPROUT_TOOLSETS", "default,canvas,forums,dms,media");
     }
     command.env_remove("SPROUT_ACP_PRIVATE_KEY");
     command.env_remove("SPROUT_ACP_API_TOKEN");

--- a/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialogSections.tsx
@@ -286,13 +286,14 @@ export function CreateAgentRuntimeFields({
         <Input
           id="agent-mcp-toolsets"
           onChange={(event) => onMcpToolsetsChange(event.target.value)}
-          placeholder="default"
+          placeholder="default,canvas,forums,dms,media"
           value={mcpToolsets}
         />
         <p className="text-xs text-muted-foreground">
           Comma-separated list of toolsets to expose via SPROUT_TOOLSETS.
           Available: default, channel_admin, dms, canvas, workflow_admin,
-          identity, forums, social. Leave blank for the default toolset only.
+          identity, forums, social, media. Leave blank for default toolsets
+          (default, canvas, forums, dms, media).
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds `canvas`, `forums`, and `dms` toolsets to the default `SPROUT_TOOLSETS` for desktop-spawned agents (was `"default,media"`, now `"default,canvas,forums,dms,media"`)
- Moves `list_channel_members` from `channel_admin` to `default` toolset — it's read-only, same risk profile as `list_channels`/`get_channel`

## Why
Desktop agents couldn't read channel canvases, vote on forum posts, manage DMs, or see channel member lists without explicit toolset configuration. These are all fundamental capabilities for agents operating in channels.

Deliberately excluded: `social` (publishes notes, modifies contact lists), `channel_admin` write ops (create/archive/remove members), `workflow_admin`, `identity`.

## Test plan
- [x] `cargo build -p sprout-mcp` passes
- [x] All 17 toolset tests pass (3 updated for new counts)
- [ ] Verify desktop-spawned agents have canvas/forums/dms/list_channel_members tools available

NIT: Test comment on `list_channel_members` assertion says `(rw)` but should say `(ro allows reads)` — cosmetic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)