### PR TITLE
Fix backslash escaping in chat messages with hard breaks

### DIFF
--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -370,7 +370,12 @@ function getMarkdownFromEditor(editor: Editor): string {
     | { getMarkdown?: () => string }
     | undefined;
   if (storage?.getMarkdown) {
-    return storage.getMarkdown();
+    let md = storage.getMarkdown();
+    // tiptap-markdown serializes hard breaks as "\" + newline (CommonMark hard
+    // line break syntax). Chat messages are plain text, not rendered markdown,
+    // so strip the backslashes to keep clean newlines.
+    md = md.replace(/\\\n/g, "\n");
+    return md;
   }
   // Fallback: plain text
   return editor.state.doc.textContent;


### PR DESCRIPTION
## Summary
- `tiptap-markdown` serializes hard break nodes as `\` + newline (CommonMark hard line break syntax), but our chat messages are plain text — the literal backslashes were leaking into message content on the relay
- Most visible when a line ends with a colon followed by a numbered list (e.g., `This has a colon:\` instead of `This has a colon:`)
- Strips `\` + newline sequences from `getMarkdownFromEditor()` output before content reaches the composer state

## Test plan
- [ ] Type a message ending with a colon, press Enter, type a numbered list — verify no backslashes appear in the sent message
- [ ] Type a multi-line message with Shift+Enter breaks — verify newlines are preserved without backslashes
- [ ] Paste formatted text with lists — verify clean newlines
- [ ] Forum composer also uses `useRichTextEditor` — verify forum posts are also clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)