### PR TITLE
fix: resolve media proxy relay URL dynamically per-request

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -376,10 +376,9 @@ pub fn run() {
             // client so WARP tunnelling applies. The port is stored in AppState
             // and exposed to the frontend via the `get_media_proxy_port` command.
             let proxy_client = state.http_client.clone();
-            let proxy_base_url = relay::relay_api_base_url_with_override(&state);
             let proxy_handle = app_handle.clone();
             tauri::async_runtime::spawn(async move {
-                let port = media_proxy::spawn_media_proxy(proxy_client, proxy_base_url).await;
+                let port = media_proxy::spawn_media_proxy(proxy_client, proxy_handle.clone()).await;
                 let state = proxy_handle.state::<AppState>();
                 state
                     .media_proxy_port

--- a/desktop/src-tauri/src/media_proxy.rs
+++ b/desktop/src-tauri/src/media_proxy.rs
@@ -7,7 +7,7 @@ use axum::{
     Router,
 };
 use futures_util::TryStreamExt;
-use tauri::http;
+use tauri::{http, Manager};
 use tokio::net::TcpListener;
 
 use crate::app_state::AppState;
@@ -22,7 +22,7 @@ const MAX_PROXY_RESPONSE: u64 = 20 * 1024 * 1024;
 #[derive(Clone)]
 struct ProxyState {
     client: reqwest::Client,
-    base_url: String,
+    app_handle: tauri::AppHandle,
 }
 
 async fn proxy_handler(AxumState(state): AxumState<ProxyState>, req: Request) -> Response {
@@ -44,8 +44,10 @@ async fn proxy_handler(AxumState(state): AxumState<ProxyState>, req: Request) ->
         .map(|pq| pq.as_str())
         .unwrap_or("/");
 
-    // Strip the /media/ prefix check — we only mount on /media/
-    let upstream_url = format!("{}{path_and_query}", state.base_url);
+    // Resolve relay URL dynamically so workspace switches take effect immediately.
+    let app_state = state.app_handle.state::<AppState>();
+    let base_url = relay::relay_api_base_url_with_override(&app_state);
+    let upstream_url = format!("{base_url}{path_and_query}");
 
     let has_range = req.headers().contains_key("range");
 
@@ -111,10 +113,10 @@ async fn proxy_handler(AxumState(state): AxumState<ProxyState>, req: Request) ->
 /// Spawn a localhost HTTP proxy that streams media via reqwest, avoiding the
 /// Tauri protocol handler's requirement to buffer the entire response into
 /// `Vec<u8>`. Returns the OS-assigned port.
-pub async fn spawn_media_proxy(http_client: reqwest::Client, base_url: String) -> u16 {
+pub async fn spawn_media_proxy(http_client: reqwest::Client, app_handle: tauri::AppHandle) -> u16 {
     let proxy_state = ProxyState {
         client: http_client,
-        base_url,
+        app_handle,
     };
 
     let app = Router::new()


### PR DESCRIPTION
## Problem

The axum media proxy bakes in the relay base URL at startup (`spawn_media_proxy` captures a `String`). When the user switches workspaces in the GUI, `apply_workspace()` updates `relay_url_override` in `AppState`, but the proxy still forwards requests to the **old** relay → 404 → broken images.

This only affects users who switch between relays (e.g. running `just staging` then adding a production relay via the GUI).

## Fix

Replace the frozen `base_url: String` in `ProxyState` with `app_handle: tauri::AppHandle`, and resolve the relay URL dynamically per-request via `relay_api_base_url_with_override(&app_state)` — the same pattern already used by `handle_sprout_media` (the `sprout-media://` protocol handler, which doesn't have this bug).

## Changes

- `media_proxy.rs`: Store `AppHandle` instead of `String`; resolve URL in `proxy_handler`
- `lib.rs`: Pass `app_handle.clone()` to `spawn_media_proxy` instead of pre-computed URL

**2 files changed, +9 / -8 lines.**