### PR TITLE
fix: send x-auth-tag header in agent profile sync

### DIFF
--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -259,11 +259,15 @@ pub async fn sync_managed_agent_profile(
     let url = format!("{}/events", relay_http_base_url(relay_url));
     let auth = build_nip98_auth_header_for_keys(agent_keys, &Method::POST, &url, &body_bytes)?;
 
-    let response = state
+    let mut request = state
         .http_client
         .post(&url)
         .header("Authorization", auth)
-        .header("Content-Type", "application/json")
+        .header("Content-Type", "application/json");
+    if let Some(tag) = auth_tag {
+        request = request.header("x-auth-tag", tag);
+    }
+    let response = request
         .body(body_bytes)
         .send()
         .await


### PR DESCRIPTION
## Problem

When User A creates a bot/agent, User B cannot see the bot's display name — it shows as a truncated pubkey hex. User A sees it fine.

## Root Cause

`sync_managed_agent_profile` in `desktop/src-tauri/src/relay.rs` posts the agent's kind:0 profile event to the relay but never includes the `x-auth-tag` HTTP header. The relay's HTTP bridge checks membership via this header *before* parsing the event body. On a closed relay, the agent isn't a direct member, so without the header the POST is rejected with 403 — the kind:0 is never stored and `display_name` stays NULL.

The bot owner doesn't notice because the desktop client has a local fallback that injects display names from `managedAgentsQuery` (local agent records). Since this only returns the *current user's* agents, User A always sees names while User B falls through to truncated pubkey.

## Fix

Add the `x-auth-tag` header to the HTTP request when `auth_tag` is available. The auth tag was already being passed into the function and embedded in the event body — it just wasn't being sent as an HTTP header for the relay's membership gate.

## Review

- Confirmed independently by Codex (GPT 5.5): traced the full call chain from `sync_managed_agent_profile` → relay `bridge.rs` → `enforce_relay_membership`
- Codex review scores: Minimalism 10/10, Elegance 9/10, Correctness 9/10, Overall 9/10