### PR TITLE
[codex] Tame Renovate dependency grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"]
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "recreateWhen": "never",
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "description": "Keep Rust crate updates isolated because 0.x minor releases often contain breaking changes.",
+      "matchManagers": ["cargo"],
+      "groupName": null,
+      "separateMinorPatch": true,
+      "separateMultipleMinor": true
+    },
+    {
+      "description": "Hold secp256k1 until sprout-pair-relay is migrated from rand-std to rand/std features.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["secp256k1"],
+      "allowedVersions": "<0.31"
+    }
+  ]
 }


### PR DESCRIPTION
🤖 This PR adjusts Renovate so dependency updates can land in smaller, safer batches instead of repeatedly recreating the failing all-non-major PR.

What changed:
- Set `recreateWhen` to `never` so closed unmerged Renovate PRs do not keep coming back unchanged.
- Split minor and patch streams globally.
- Keep Cargo updates isolated because 0.x minor releases can be breaking.
- Temporarily hold `secp256k1` below `0.31` until `sprout-pair-relay` is migrated away from the removed `rand-std` feature.

Why:
PR #523 is failing because Renovate bumps `secp256k1` to `0.31` while the crate still requests `rand-std`, which no longer exists. That breaks artifact generation and most Rust/desktop CI jobs before they do useful work.

Validation:
- `jq empty renovate.json`
- `git diff --check`
- pre-commit hooks: desktop/web checks, Rust format, mobile analyze
- pre-push hooks: web/desktop builds, Tauri check, mobile test/analyze, Rust clippy, Rust unit tests