### PR TITLE
Use dedicated sprout-agent avatar

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -21,7 +21,7 @@ const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
 const SPROUT_AGENT_AVATAR_URL: &str =
-    "https://raw.githubusercontent.com/block/sprout/main/docs/assets/sprout-icon.png";
+    "https://raw.githubusercontent.com/block/sprout/refs/heads/main/crates/sprout-agent/sprout-agent.png";
 
 fn common_binary_paths() -> &'static [PathBuf] {
     use std::sync::OnceLock;


### PR DESCRIPTION
Points the sprout-agent avatar URL to the dedicated `sprout-agent.png` in the crate directory instead of the generic sprout icon from docs/assets.