### PR TITLE
Remove obsolete secp256k1 Renovate hold

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,12 +10,6 @@
       "groupName": null,
       "separateMinorPatch": true,
       "separateMultipleMinor": true
-    },
-    {
-      "description": "Hold secp256k1 until sprout-pair-relay is migrated from rand-std to rand/std features.",
-      "matchManagers": ["cargo"],
-      "matchPackageNames": ["secp256k1"],
-      "allowedVersions": "<0.31"
     }
   ]
 }


### PR DESCRIPTION
🤖

## Summary
- remove the temporary Renovate `secp256k1 <0.31` hold now that `sprout-pair-relay` has been migrated in #534
- keep the safer Renovate behavior from #531: no immortal recreation, split minor/patch updates, and isolated Cargo updates

## Tests
- `jq empty renovate.json`
- pre-commit hook passed
- pre-push hook passed