### PR TITLE
fix: side panel headers hidden by compact app header

### DIFF
--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -64,7 +64,11 @@ export function AgentSessionThreadPanel({
     <>
       {isOverlay && <OverlayPanelBackdrop onClose={onClose} />}
       <aside
-        className={cn(PANEL_BASE_CLASS, isOverlay && PANEL_OVERLAY_CLASS)}
+        className={cn(
+          PANEL_BASE_CLASS,
+          !isOverlay && "pt-11",
+          isOverlay && PANEL_OVERLAY_CLASS,
+        )}
         data-testid="agent-session-thread-panel"
         style={{ width: `${widthPx}px` }}
       >

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -117,7 +117,11 @@ export function UserProfilePanel({
     <>
       {isOverlay && <OverlayPanelBackdrop onClose={onClose} />}
       <aside
-        className={cn(PANEL_BASE_CLASS, isOverlay && PANEL_OVERLAY_CLASS)}
+        className={cn(
+          PANEL_BASE_CLASS,
+          !isOverlay && "pt-11",
+          isOverlay && PANEL_OVERLAY_CLASS,
+        )}
         data-testid="user-profile-panel"
         style={{ width: `${widthPx}px` }}
       >


### PR DESCRIPTION
## Summary
- The compact header PR (#514) added `pt-11` top padding to `MessageThreadPanel` so its header clears the 44px compact app header — but missed `AgentSessionThreadPanel` and `UserProfilePanel`, which occupy the same side-panel slot.
- Added the same `!isOverlay && "pt-11"` pattern to both panels, matching the existing fix in `MessageThreadPanel`.

## Test plan
- [ ] Open a channel with agent activity → click an agent to open the activity sidebar → verify its header ("Agent activity log") is fully visible below the compact app header
- [ ] Click a user avatar to open the profile panel → verify the "Profile" header is fully visible
- [ ] Resize the window to trigger overlay mode → verify both panels still render correctly (no extra padding when overlaid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)