### PR TITLE
fix: default max_rounds to 0 (unlimited)

### DIFF
--- a/crates/sprout-agent/README.md
+++ b/crates/sprout-agent/README.md
@@ -133,7 +133,7 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 | `OPENAI_COMPAT_BASE_URL` | `https://api.openai.com/v1` | Point at vLLM, llama.cpp, OpenRouter, Ollama, etc. |
 | `SPROUT_AGENT_SYSTEM_PROMPT` | built-in | Inline system prompt. |
 | `SPROUT_AGENT_SYSTEM_PROMPT_FILE` | — | File path. Mutually exclusive with the above. |
-| `SPROUT_AGENT_MAX_ROUNDS` | `16` | Tool-loop iteration cap. |
+| `SPROUT_AGENT_MAX_ROUNDS` | `0` | Tool-loop iteration cap. 0 = unlimited. |
 | `SPROUT_AGENT_MAX_OUTPUT_TOKENS` | `4096` | Per LLM call. |
 | `SPROUT_AGENT_LLM_TIMEOUT_SECS` | `120` | |
 | `SPROUT_AGENT_TOOL_TIMEOUT_SECS` | `660` | Per-tool call timeout in seconds |
@@ -223,7 +223,7 @@ The trust boundary is **the operator who launched the agent**. The harness, MCP 
 | Tool description bytes | 1 KiB | `MAX_DESCRIPTION_BYTES` |
 | Tool schema bytes | 4 KiB | `MAX_SCHEMA_BYTES` (oversize → replaced with `{}`) |
 | Tool calls per turn | 64 | `MAX_TOOL_CALLS_PER_TURN` |
-| Loop rounds | 16 | `SPROUT_AGENT_MAX_ROUNDS` |
+| Loop rounds | 0 (unlimited) | `SPROUT_AGENT_MAX_ROUNDS` |
 | LLM call timeout | 120 s | `SPROUT_AGENT_LLM_TIMEOUT_SECS` |
 | Tool call timeout | 660 s | `SPROUT_AGENT_TOOL_TIMEOUT_SECS` |
 

--- a/crates/sprout-agent/src/config.rs
+++ b/crates/sprout-agent/src/config.rs
@@ -92,7 +92,7 @@ impl Config {
             model,
             base_url,
             anthropic_api_version: env_or("ANTHROPIC_API_VERSION", "2023-06-01"),
-            max_rounds: parse_env("SPROUT_AGENT_MAX_ROUNDS", 16)?,
+            max_rounds: parse_env("SPROUT_AGENT_MAX_ROUNDS", 0)?,
             max_output_tokens: parse_env("SPROUT_AGENT_MAX_OUTPUT_TOKENS", 4096)?,
             llm_timeout: Duration::from_secs(parse_env("SPROUT_AGENT_LLM_TIMEOUT_SECS", 120)?),
             tool_timeout: Duration::from_secs(parse_env("SPROUT_AGENT_TOOL_TIMEOUT_SECS", 660)?),


### PR DESCRIPTION
## Problem

`SPROUT_AGENT_MAX_ROUNDS` defaults to 16. When the agent hits this cap mid-task, it returns `stopReason: "max_turn_requests"` and the harness treats it as a successful completion. From the user's perspective, the agent silently stops responding — no error, no indication anything went wrong.

Real-world tasks routinely exceed 16 tool calls. Even basic code exploration (reading files, searching, orienting) burns 10+ rounds before the agent can act on what it found.

## Fix

Default `max_rounds` to `0` (unlimited), matching the harbor benchmark configuration (`--ae "SPROUT_AGENT_MAX_ROUNDS=0"`).

The harness already enforces idle timeout (default 320s) and hard timeout (default 3600s), which are the appropriate safety valves for runaway agents — not a round counter.

## Changes

- `config.rs`: default `SPROUT_AGENT_MAX_ROUNDS` from `16` → `0`
- `README.md`: update docs to reflect new default