### PR TITLE
fix: pass profiles to mention autocomplete in threads and forum composers

### DIFF
--- a/desktop/src/features/forum/ui/ForumComposer.tsx
+++ b/desktop/src/features/forum/ui/ForumComposer.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/features/messages/ui/MentionAutocomplete";
 import { MessageComposerToolbar } from "@/features/messages/ui/MessageComposerToolbar";
 import type { ChannelMember } from "@/shared/api/types";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { Button } from "@/shared/ui/button";
 
 type ForumComposerProps = {
@@ -38,6 +39,7 @@ type ForumComposerProps = {
   ) => undefined | Promise<unknown>;
   /** When true, autocomplete renders below the input (for top-of-view composers). */
   autocompleteBelow?: boolean;
+  profiles?: UserProfileLookup;
 };
 
 export function ForumComposer({
@@ -49,6 +51,7 @@ export function ForumComposer({
   onCancel,
   onSubmit,
   autocompleteBelow = false,
+  profiles,
 }: ForumComposerProps) {
   const [content, setContent] = React.useState("");
   const contentRef = React.useRef(content);
@@ -62,7 +65,7 @@ export function ForumComposer({
     setIsFormattingOpen(pressed);
   }, []);
 
-  const mentions = useMentions(channelId, members);
+  const mentions = useMentions(channelId, members, profiles);
   const channelLinks = useChannelLinks();
   const media = useMediaUpload();
 

--- a/desktop/src/features/forum/ui/ForumThreadPanel.tsx
+++ b/desktop/src/features/forum/ui/ForumThreadPanel.tsx
@@ -284,6 +284,7 @@ export function ForumThreadPanel({
           isSending={isSendingReply}
           onSubmit={onReply}
           placeholder="Reply to this post..."
+          profiles={profiles}
         />
       </div>
     </div>

--- a/desktop/src/features/forum/ui/ForumView.tsx
+++ b/desktop/src/features/forum/ui/ForumView.tsx
@@ -161,6 +161,7 @@ export function ForumView({
               setIsComposerOpen(false);
             }}
             placeholder="Write your post..."
+            profiles={profiles}
           />
         ) : (
           <button

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -308,6 +308,7 @@ export function MessageThreadPanel({
               onEditSave={onEditSave}
               onSend={onSend}
               placeholder={`Reply in thread to ${threadHead.author}`}
+              profiles={profiles}
               replyTarget={composerReplyTarget}
               toolbarExtraActions={toolbarExtraActions}
               typingParentEventId={threadHead.id}

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -406,6 +406,7 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
           onSubmit={(content, mentionPubkeys, mediaTags) =>
             publishMutation.mutateAsync({ content, mentionPubkeys, mediaTags })
           }
+          profiles={mentionProfiles}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- The `@` mention autocomplete in thread composers and forum composers showed only initials instead of avatars because the `profiles` prop (carrying avatar URLs) was not being forwarded to `useMentions()`
- Added `profiles` prop passthrough in `MessageThreadPanel`, `ForumComposer`, `ForumThreadPanel`, `ForumView`, and `PulseView`

## Changes
| File | Change |
|------|--------|
| `MessageThreadPanel.tsx` | Added `profiles={profiles}` to `<MessageComposer>` |
| `ForumComposer.tsx` | Added `profiles` prop type + forwarded to `useMentions()` |
| `ForumThreadPanel.tsx` | Added `profiles={profiles}` to `<ForumComposer>` |
| `ForumView.tsx` | Added `profiles={profiles}` to `<ForumComposer>` |
| `PulseView.tsx` | Added `profiles={mentionProfiles}` to `<ForumComposer>` |

## Test plan
- [x] `pnpm exec tsc --noEmit` passes clean
- [x] All pre-commit and pre-push hooks pass (linting, builds, tests)
- [ ] Open a thread in main chat → click `@` → verify avatars appear
- [ ] Open a forum post → reply composer → click `@` → verify avatars appear
- [ ] Open Pulse → post composer → click `@` → verify avatars appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)