### PR TITLE
cli: add display name lookup to get-users

### DIFF
--- a/crates/sprout-cli/src/commands/users.rs
+++ b/crates/sprout-cli/src/commands/users.rs
@@ -5,10 +5,24 @@ use crate::error::CliError;
 use crate::validate::validate_hex64;
 
 /// Get user profiles (kind:0 metadata events).
-/// 0 pubkeys → query our own profile
-/// 1 pubkey → query that user's profile
-/// 2+ pubkeys → query batch
-pub async fn cmd_get_users(client: &SproutClient, pubkeys: &[String]) -> Result<(), CliError> {
+///
+/// - 0 pubkeys, no name → query our own profile
+/// - 1+ pubkeys → query those users' profiles
+/// - --name "foo" → NIP-50 search on kind:0, then client-side filter
+pub async fn cmd_get_users(
+    client: &SproutClient,
+    pubkeys: &[String],
+    name: Option<&str>,
+) -> Result<(), CliError> {
+    if let Some(query) = name {
+        if !pubkeys.is_empty() {
+            return Err(CliError::Usage(
+                "--name and --pubkey are mutually exclusive".into(),
+            ));
+        }
+        return search_by_name(client, query).await;
+    }
+
     for pk in pubkeys {
         validate_hex64(pk)?;
     }
@@ -30,6 +44,55 @@ pub async fn cmd_get_users(client: &SproutClient, pubkeys: &[String]) -> Result<
     });
     let resp = client.query(&filter).await?;
     println!("{resp}");
+    Ok(())
+}
+
+/// Search for users by display name via NIP-50 full-text search on kind:0 profiles.
+/// Returns [] if the relay does not implement NIP-50 search.
+async fn search_by_name(client: &SproutClient, query: &str) -> Result<(), CliError> {
+    if query.trim().is_empty() {
+        return Err(CliError::Usage("--name cannot be empty".into()));
+    }
+
+    let filter = serde_json::json!({
+        "kinds": [0],
+        "search": query,
+        "limit": 100
+    });
+    let raw = client.query(&filter).await?;
+
+    // Parse and filter client-side for case-insensitive substring match
+    // on display_name or name fields (NIP-50 may return broader matches).
+    let events: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| CliError::Other(format!("failed to parse response: {e}")))?;
+
+    let Some(arr) = events.as_array() else {
+        println!("[]");
+        return Ok(());
+    };
+
+    let lower_query = query.to_ascii_lowercase();
+    let matches: Vec<&serde_json::Value> = arr
+        .iter()
+        .filter(|event| {
+            let Some(content_str) = event.get("content").and_then(|v| v.as_str()) else {
+                return false;
+            };
+            let Ok(content) = serde_json::from_str::<serde_json::Value>(content_str) else {
+                return false;
+            };
+            let display_name = content
+                .get("display_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let name = content.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            display_name.to_ascii_lowercase().contains(&lower_query)
+                || name.to_ascii_lowercase().contains(&lower_query)
+        })
+        .collect();
+
+    let output = serde_json::to_string(&matches).expect("serializing parsed JSON values");
+    println!("{output}");
     Ok(())
 }
 

--- a/crates/sprout-cli/src/lib.rs
+++ b/crates/sprout-cli/src/lib.rs
@@ -332,10 +332,13 @@ enum Cmd {
     },
 
     // ---- Users -------------------------------------------------------------
-    /// Get user profiles (0 = self, 1 = single, 2+ = batch)
+    /// Get user profiles by pubkey or display name
     GetUsers {
         #[arg(long = "pubkey")]
         pubkeys: Vec<String>,
+        /// Search by display name (case-insensitive substring match)
+        #[arg(long = "name")]
+        name: Option<String>,
     },
     /// Update your profile
     SetProfile {
@@ -788,7 +791,9 @@ async fn run(cli: Cli) -> Result<(), CliError> {
         }
 
         // ---- Users ---------------------------------------------------------
-        Cmd::GetUsers { pubkeys } => commands::users::cmd_get_users(&client, &pubkeys).await,
+        Cmd::GetUsers { pubkeys, name } => {
+            commands::users::cmd_get_users(&client, &pubkeys, name.as_deref()).await
+        }
         Cmd::SetProfile {
             name,
             avatar,


### PR DESCRIPTION
Adds `--name` flag to `sprout get-users` for looking up user profiles by display name.

## What

```bash
sprout get-users --name "Bana"
```

Searches kind:0 profile events via NIP-50 full-text search, then filters client-side for case-insensitive substring match on `display_name` and `name` fields.

## Why

Agents and operators frequently need to resolve a human-readable display name to a hex pubkey — for example, to add teammates to a channel via `add_channel_member`. Until now, this required knowing the pubkey upfront or manually inspecting channel member lists.

## Details

- Mutually exclusive with `--pubkey` (returns a clear error if both are provided)
- Rejects empty `--name` queries
- Output format matches the existing `--pubkey` path (raw event array from the relay)
- Client-side re-filtering is defensive against NIP-50 implementations that return broader matches
- Returns `[]` if the relay does not support NIP-50 search on kind:0