### PR TITLE
agent+acp: preserve session on retriable agent errors

### DIFF
--- a/crates/sprout-acp/src/pool.rs
+++ b/crates/sprout-acp/src/pool.rs
@@ -1157,8 +1157,12 @@ pub async fn run_prompt_task(
         }
         Err(e) => {
             tracing::error!(target: "pool::prompt", "session_prompt error: {e}");
-            // Invalidate only the affected session.
-            agent.state.invalidate(&source);
+            // AgentError means the agent caught a problem before mutating
+            // session state (e.g. bad LLM response). The session is healthy —
+            // don't invalidate it. Other errors may have corrupted state.
+            if !matches!(e, AcpError::AgentError(_)) {
+                agent.state.invalidate(&source);
+            }
             let _ = result_tx.send(PromptResult {
                 agent,
                 source,


### PR DESCRIPTION
Don't invalidate the session when the agent returns an application error (`AgentError`). The agent caught the problem before the session became unusable — the existing requeue mechanism retries on the same session with full context intact.

## What

One change in `pool.rs`: skip `agent.state.invalidate(&source)` when the error is `AcpError::AgentError`.

## Why

Transient LLM glitches (e.g. `stop=tool_use` with zero tool calls) cause sprout-agent to return a JSON-RPC application error. The session is still healthy — MCP servers are running, history is valid, the stdio pipe is intact. Previously the harness invalidated the session on any prompt error, forcing a fresh `session/new` on retry: new MCP server processes, lost history, lost todo state.

Now the harness distinguishes retriable application errors from session-corrupting transport/protocol errors. The session stays alive and the batch retries on the same session via the existing requeue + backoff mechanism.