### PR TITLE
agent: make max_sessions default unlimited

### DIFF
--- a/crates/sprout-agent/README.md
+++ b/crates/sprout-agent/README.md
@@ -138,7 +138,7 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 | `SPROUT_AGENT_LLM_TIMEOUT_SECS` | `120` | |
 | `SPROUT_AGENT_TOOL_TIMEOUT_SECS` | `660` | Per-tool call timeout in seconds |
 | `SPROUT_AGENT_MAX_PARALLEL_TOOLS` | `8` | Max concurrent tool calls per turn (1 = sequential) |
-| `SPROUT_AGENT_MAX_SESSIONS` | `8` | Max concurrent ACP sessions |
+| `SPROUT_AGENT_MAX_SESSIONS` | unlimited | Max concurrent ACP sessions. Sessions are cheap; default has no cap. |
 | `SPROUT_AGENT_MAX_LINE_BYTES` | `4194304` | 4 MiB. Hard cap on inbound JSON-RPC frames. |
 | `SPROUT_AGENT_MAX_HISTORY_BYTES` | `1048576` | 1 MiB. Old turns are evicted past this. |
 
@@ -205,7 +205,7 @@ The trust boundary is **the operator who launched the agent**. The harness, MCP 
 | Frame size | `SPROUT_AGENT_MAX_LINE_BYTES` (default 4 MiB). Oversize → connection killed. |
 | LLM response size | 16 MiB hard cap. Both `Content-Length` precheck and streaming-buffer cap. |
 | Cancellation | `tokio::select! { biased; _ = cancel.changed() => ... }` at every loop boundary. Cancel always wins the race. |
-| Session isolation | Up to 8 concurrent sessions (configurable). One prompt per session at a time. Each session gets its own MCP servers. |
+| Session isolation | Unlimited concurrent sessions by default (configurable via `SPROUT_AGENT_MAX_SESSIONS`). One prompt per session at a time. Each session gets its own MCP servers. |
 | `tool_use ↔ tool_result` pairing | Encoded in the type system. Every `ToolCall` and `ToolResult` carries a `provider_id: String` (not `Option`). |
 
 ### Bounded Everything

--- a/crates/sprout-agent/src/config.rs
+++ b/crates/sprout-agent/src/config.rs
@@ -103,7 +103,7 @@ impl Config {
             mcp_max_restart_attempts: parse_env("SPROUT_AGENT_MCP_RESTART_MAX_ATTEMPTS", 3u32)?,
             mcp_restart_base_ms: parse_env("SPROUT_AGENT_MCP_RESTART_BASE_MS", 500u64)?,
             mcp_restart_max_ms: parse_env("SPROUT_AGENT_MCP_RESTART_MAX_MS", 30_000u64)?,
-            max_sessions: parse_env("SPROUT_AGENT_MAX_SESSIONS", 8)?,
+            max_sessions: parse_env("SPROUT_AGENT_MAX_SESSIONS", usize::MAX)?,
             max_line_bytes: parse_env("SPROUT_AGENT_MAX_LINE_BYTES", 4 * 1024 * 1024)?,
             max_history_bytes: parse_env("SPROUT_AGENT_MAX_HISTORY_BYTES", 1024 * 1024)?,
             max_handoffs: parse_env("SPROUT_AGENT_MAX_HANDOFFS", 5)?,


### PR DESCRIPTION
Sessions on `sprout-agent` are cheap. The per-channel ACP harness holds one session per active channel for its lifetime, so a small numeric cap (previously 8) just dead-letters new channels once exceeded — neither side has eviction. Bots get restarted often enough in practice that unbounded growth isn't a real concern.

Default `SPROUT_AGENT_MAX_SESSIONS` to unlimited (`usize::MAX`). The env var is still honored for anyone who wants to clamp it.

Supersedes the earlier harness-driven eviction approach on this branch — that work was reverted; this is the whole change now.

- `crates/sprout-agent/src/config.rs`: default → `usize::MAX`
- `crates/sprout-agent/README.md`: doc the new default

No code-path changes; the `>=` cap check in `session/new` remains and simply never trips at the new default.