### PR TITLE
fix(desktop): populate member_count in get_channels so channel browser shows real counts

### DIFF
--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -136,35 +136,7 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
         .await
         .unwrap_or_default();
 
-        let mut counts: std::collections::HashMap<String, i64> =
-            std::collections::HashMap::with_capacity(members_events.len());
-        for ev in &members_events {
-            let mut d_value: Option<String> = None;
-            let mut unique_pubkeys: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
-            for tag in ev.tags.iter() {
-                let slice = tag.as_slice();
-                match slice.first().map(String::as_str) {
-                    Some("d") if d_value.is_none() => {
-                        if let Some(v) = slice.get(1) {
-                            d_value = Some(v.clone());
-                        }
-                    }
-                    Some("p") => {
-                        if let Some(pk) = slice.get(1) {
-                            if !pk.is_empty() {
-                                unique_pubkeys.insert(pk.clone());
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            if let Some(d) = d_value {
-                counts.insert(d, unique_pubkeys.len() as i64);
-            }
-        }
-
+        let counts = count_members_by_channel(&members_events);
         for channel in &mut channels {
             if let Some(count) = counts.get(&channel.id) {
                 channel.member_count = *count;
@@ -173,6 +145,28 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
     }
 
     Ok(channels)
+}
+
+/// Build a `channel_id → unique-member-count` map from a batch of kind:39002
+/// events. Events without a `d` tag are skipped; member dedupe is delegated to
+/// [`nostr_convert::channel_members_from_event`] so the parsing rules match the
+/// per-channel `get_channel_members` path.
+fn count_members_by_channel(events: &[nostr::Event]) -> std::collections::HashMap<String, i64> {
+    let mut counts: std::collections::HashMap<String, i64> =
+        std::collections::HashMap::with_capacity(events.len());
+    for ev in events {
+        let Some(d) = ev.tags.iter().find_map(|t| {
+            let s = t.as_slice();
+            (s.len() >= 2 && s[0] == "d").then(|| s[1].clone())
+        }) else {
+            continue;
+        };
+        let Ok(resp) = nostr_convert::channel_members_from_event(ev) else {
+            continue;
+        };
+        counts.insert(d, resp.members.len() as i64);
+    }
+    counts
 }
 
 #[tauri::command]
@@ -471,3 +465,7 @@ pub async fn leave_channel(channel_id: String, state: State<'_, AppState>) -> Re
     submit_event(builder, &state).await?;
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "channels_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -116,6 +116,62 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
             channels.push(info);
         }
     }
+
+    // Populate member_count by batch-fetching kind:39002 for every listed
+    // channel and counting unique p-tag pubkeys. The kind:40901 summary
+    // sidecar that channel_info_from_event prefers isn't emitted by the
+    // relay today, so without this step every channel reports 0 members
+    // in the channel browser (the active-channel top bar masks this with
+    // its own live members query).
+    let all_d_tags: Vec<String> = channels.iter().map(|c| c.id.clone()).collect();
+    if !all_d_tags.is_empty() {
+        let members_events = query_relay(
+            &state,
+            &[serde_json::json!({
+                "kinds": [39002],
+                "#d": all_d_tags,
+                "limit": all_d_tags.len(),
+            })],
+        )
+        .await
+        .unwrap_or_default();
+
+        let mut counts: std::collections::HashMap<String, i64> =
+            std::collections::HashMap::with_capacity(members_events.len());
+        for ev in &members_events {
+            let mut d_value: Option<String> = None;
+            let mut unique_pubkeys: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for tag in ev.tags.iter() {
+                let slice = tag.as_slice();
+                match slice.first().map(String::as_str) {
+                    Some("d") if d_value.is_none() => {
+                        if let Some(v) = slice.get(1) {
+                            d_value = Some(v.clone());
+                        }
+                    }
+                    Some("p") => {
+                        if let Some(pk) = slice.get(1) {
+                            if !pk.is_empty() {
+                                unique_pubkeys.insert(pk.clone());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(d) = d_value {
+                counts.insert(d, unique_pubkeys.len() as i64);
+            }
+        }
+
+        for channel in &mut channels {
+            if let Some(count) = counts.get(&channel.id) {
+                channel.member_count = *count;
+            }
+        }
+    }
+
     Ok(channels)
 }
 

--- a/desktop/src-tauri/src/commands/channels_tests.rs
+++ b/desktop/src-tauri/src/commands/channels_tests.rs
@@ -1,0 +1,85 @@
+// Tests for commands/channels.rs — split into a sibling file to keep
+// channels.rs under the per-file line cap.
+
+use super::*;
+use nostr::{EventBuilder, Keys, Kind, Tag};
+
+/// Build a signed event for testing with the given kind, content, and tags.
+fn ev(kind: u16, content: &str, tags: Vec<Vec<&str>>) -> nostr::Event {
+    let keys = Keys::generate();
+    let parsed: Vec<Tag> = tags
+        .into_iter()
+        .map(|t| Tag::parse(t).expect("parse tag"))
+        .collect();
+    EventBuilder::new(Kind::from_u16(kind), content)
+        .tags(parsed)
+        .sign_with_keys(&keys)
+        .expect("sign")
+}
+
+// A 64-hex pubkey (nostr p-tags require 32-byte hex).
+const PK_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PK_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PK_C: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+#[test]
+fn counts_unique_p_tags_per_channel() {
+    let e1 = ev(
+        39002,
+        "",
+        vec![
+            vec!["d", "chan-1"],
+            vec!["p", PK_A, "", "member"],
+            vec!["p", PK_B, "", "admin"],
+        ],
+    );
+    let e2 = ev(
+        39002,
+        "",
+        vec![vec!["d", "chan-2"], vec!["p", PK_C, "", "member"]],
+    );
+
+    let counts = count_members_by_channel(&[e1, e2]);
+    assert_eq!(counts.get("chan-1"), Some(&2));
+    assert_eq!(counts.get("chan-2"), Some(&1));
+    assert_eq!(counts.len(), 2);
+}
+
+#[test]
+fn dedupes_repeated_pubkeys() {
+    let e = ev(
+        39002,
+        "",
+        vec![
+            vec!["d", "chan-1"],
+            vec!["p", PK_A, "", "member"],
+            vec!["p", PK_A, "", "admin"], // duplicate pubkey, different role
+            vec!["p", PK_B, "", "member"],
+        ],
+    );
+    let counts = count_members_by_channel(&[e]);
+    assert_eq!(counts.get("chan-1"), Some(&2));
+}
+
+#[test]
+fn skips_event_without_d_tag() {
+    let e = ev(39002, "", vec![vec!["p", PK_A, "", "member"]]);
+    let counts = count_members_by_channel(&[e]);
+    assert!(counts.is_empty());
+}
+
+#[test]
+fn zero_member_channel_is_recorded() {
+    // A channel with a members event but no p-tags should report 0,
+    // not be absent from the map (the caller relies on `get` returning
+    // `Some(0)` to overwrite a default).
+    let e = ev(39002, "", vec![vec!["d", "chan-1"]]);
+    let counts = count_members_by_channel(&[e]);
+    assert_eq!(counts.get("chan-1"), Some(&0));
+}
+
+#[test]
+fn empty_input_yields_empty_map() {
+    let counts = count_members_by_channel(&[]);
+    assert!(counts.is_empty());
+}


### PR DESCRIPTION
## Summary

The channel browser dialog shows `0` members for every channel because `get_channels` always returns `member_count: 0`. This PR fixes that by computing the count from kind:39002 events in the same Tauri command.

## Root cause

`ChannelInfo.member_count` is populated in `nostr_convert::channel_info_from_event`, which reads it from a kind:40901 "channel summary" sidecar event. Two problems:

1. Every caller in `commands/channels.rs` passes `None` for the summary.
2. The relay never emits kind:40901 — the const is defined in `sprout-core::kind` but nothing publishes it.

The top bar in `ChannelMembersBar` *appears* to work only because it ignores `channel.memberCount` and does its own live kind:39002 fetch via `useChannelMembersQuery`, counting members client-side. The browser dialog renders `channel.memberCount` directly and so always shows `0`.

## Fix

After `get_channels` assembles the channel list, issue a single batched query for kind:39002 events with `#d` set to every listed channel id, then overwrite `member_count` for each channel from the unique p-tag pubkey count. One extra relay round-trip total, not N.

If the query fails we silently fall back to `0` (the prior behavior) so a sidecar miss can't break the whole channel listing.

## Why fix at the Tauri layer

`channel.memberCount` flows through every channel listing in the UI. Fixing it at the command level means anything that reads the field gets the correct value — not just the browser dialog.

## Future work (not in this PR)

If/when the kind:40901 channel summary sidecar is implemented relay-side, the existing summary path in `channel_info_from_event` can supersede this extra query and it can be removed.

## Verification

- `cargo check` — clean
- `cargo test --lib` — all 245 tests pass
- `cargo clippy` — no new warnings on changed file
- `pnpm build` (desktop) — clean
- All pre-push hooks pass (rust-fmt, desktop-tauri-fmt, rust-clippy, rust-tests, desktop-check, desktop-tauri-check, web-check, web-build, desktop-build, mobile-check, mobile-test)
