### PR TITLE
docs(agents): prefer Nostr events over new REST endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,25 @@ Additional rules:
 relay. Both paths converge on shared DB functions in `sprout-db`. When adding
 a feature, implement the shared DB logic first, then wire up both surfaces.
 
+**Prefer Nostr events over new REST endpoints**: For new feature work, model
+the operation as a Nostr event (new kind in `sprout-core/src/kind.rs`, handler
+in `sprout-relay`) rather than adding a new REST endpoint. REST is reserved
+for things that genuinely need an HTTP-only surface: media upload/download
+(Blossom), OAuth callbacks, health checks, and the existing read endpoints
+that proxy DB queries. Two helpful endpoints already exist and rarely need
+to be duplicated:
+
+- `POST /events` — submit any signed event (same path the WebSocket uses).
+- `POST /query` — Nostr REQ filters over HTTP. NIP-50 `search` filters
+  are routed to `sprout-search` (Typesense-backed) automatically.
+- `POST /count` — Nostr COUNT filters over HTTP.
+
+If you find yourself reaching for a new REST endpoint, first check whether
+an event kind would do the job — it usually will, and you get realtime
+fan-out, NIP-29 scoping, and the existing auth pipeline for free.
+
+Reference https://github.com/nostr-protocol/nips
+
 **Event kinds**: All event kind integers are defined in
 `sprout-core/src/kind.rs`. New features get new kind integers — add them here
 first, then implement handling in the relay.


### PR DESCRIPTION
## Why

Agents working on Sprout keep proposing new REST endpoints when the
operation would be better modeled as a Nostr event. `AGENTS.md` already
describes the dual-API surface but doesn't tell agents which to extend.

## What

Add a `Key Patterns` entry, **Prefer Nostr events over new REST
endpoints**, that:

- Defaults agent feature work to events (new kind in
  `sprout-core/src/kind.rs` → handler in `sprout-relay`).
- Lists which surfaces are legitimately REST-only (Blossom media, OAuth
  callbacks, health probes, existing DB query bridges).
- Points at the three existing generic REST endpoints so agents stop
  reinventing them:
  - `POST /events` — submit signed events.
  - `POST /query` — Nostr REQ filters (NIP-50 search routed through
    `sprout-search` automatically).
  - `POST /count` — Nostr COUNT filters.

Verified each endpoint against `crates/sprout-relay/src/router.rs` and
`crates/sprout-relay/src/api/bridge.rs` before claiming it.

## Risk

None — docs only. No code touched.