### PR TITLE
fix(desktop): editor bug fixes — codeblock escaping, thread edit leak, channel links, and edit cancel

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -224,6 +224,17 @@ export const ChannelPane = React.memo(function ChannelPane({
   const canResetThreadPanelWidth =
     threadPanelWidthPx !== THREAD_PANEL_DEFAULT_WIDTH_PX;
 
+  // Scope the edit target to the correct composer: if the message being edited
+  // lives inside the open thread (thread head or a reply), show the editing UI
+  // only in the thread panel; otherwise show it in the main channel composer.
+  const isEditInThread =
+    editTarget != null &&
+    threadHeadMessage != null &&
+    (editTarget.id === threadHeadMessage.id ||
+      threadMessages.some((entry) => entry.message.id === editTarget.id));
+  const mainEditTarget = editTarget && !isEditInThread ? editTarget : null;
+  const threadEditTarget = editTarget && isEditInThread ? editTarget : null;
+
   const isNonMemberView =
     activeChannel !== null &&
     !activeChannel.isMember &&
@@ -361,7 +372,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                 channelId={activeChannel?.id ?? null}
                 channelName={activeChannel?.name ?? "channel"}
                 disabled={isComposerDisabled}
-                editTarget={editTarget}
+                editTarget={mainEditTarget}
                 isSending={isSending}
                 onCancelEdit={onCancelEdit}
                 onEditSave={onEditSave}
@@ -410,7 +421,7 @@ export const ChannelPane = React.memo(function ChannelPane({
           channelName={activeChannel?.name ?? "channel"}
           currentPubkey={currentPubkey}
           disabled={isComposerDisabled}
-          editTarget={editTarget}
+          editTarget={threadEditTarget}
           isSending={isSending}
           onCancelEdit={onCancelEdit}
           onCancelReply={onCancelThreadReply}

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -426,6 +426,11 @@ function getMarkdownFromEditor(editor: Editor): string {
     // line break syntax). Chat messages are plain text, not rendered markdown,
     // so strip the backslashes to keep clean newlines.
     md = md.replace(/\\\n/g, "\n");
+    // prosemirror-markdown's esc() backslash-escapes markdown special characters
+    // (` * \ ~ [ ] _) in text nodes to prevent them from being interpreted as
+    // formatting. Since our messages ARE rendered as markdown, we want to
+    // preserve the user's original characters so code fences, bold, etc. work.
+    md = md.replace(/\\([`*\\~[\]_])/g, "$1");
     return md;
   }
   // Fallback: plain text

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -98,7 +98,7 @@ export function MessageComposer({
   const drafts = useDrafts();
   const effectiveDraftKey = draftKey ?? channelId;
   const previousDraftKeyRef = React.useRef<string | null>(null);
-
+  const preEditContentRef = React.useRef<string | null>(null);
   const mentions = useMentions(channelId, undefined, profiles);
   const channelLinks = useChannelLinks();
   const emojiAutocomplete = useEmojiAutocomplete();
@@ -127,7 +127,6 @@ export function MessageComposer({
   editTargetRef.current = editTarget;
   channelIdRef.current = channelId;
 
-  // ── Refs consumed by Tiptap's submitOnEnter extension ──────────────
   const isAutocompleteOpenRef = React.useRef(false);
   isAutocompleteOpenRef.current =
     mentions.isMentionOpen ||
@@ -136,7 +135,6 @@ export function MessageComposer({
 
   const submitMessageRef = React.useRef<() => void>(() => {});
 
-  // ── Computed placeholder ─────────────────────────────────────────────
   const computedPlaceholder = editTarget
     ? "Edit your message"
     : (placeholder ??
@@ -204,14 +202,22 @@ export function MessageComposer({
     };
   }, [effectiveDraftKey]);
 
-  // ── Edit mode: pre-fill content ─────────────────────────────────────
+  // ── Edit mode: pre-fill content & restore on cancel ─────────────────
   // biome-ignore lint/correctness/useExhaustiveDependencies: editTarget?.id is the trigger
   React.useEffect(() => {
-    if (!editTarget) return;
-    setContent(editTarget.body);
-    contentRef.current = editTarget.body;
-    richText.setContent(editTarget.body);
-    richText.focus();
+    if (editTarget) {
+      preEditContentRef.current = contentRef.current;
+      setContent(editTarget.body);
+      contentRef.current = editTarget.body;
+      richText.setContent(editTarget.body);
+      richText.focus();
+    } else if (preEditContentRef.current !== null) {
+      const restored = preEditContentRef.current;
+      preEditContentRef.current = null;
+      setContent(restored);
+      contentRef.current = restored;
+      restored ? richText.setContent(restored) : richText.clearContent();
+    }
   }, [editTarget?.id]);
 
   // ── Focus on reply ──────────────────────────────────────────────────

--- a/desktop/src/shared/lib/createRemarkPrefixPlugin.ts
+++ b/desktop/src/shared/lib/createRemarkPrefixPlugin.ts
@@ -38,7 +38,10 @@ function walkChildren(node: any, pattern: RegExp, buildNode: NodeBuilder) {
 
     if (child.type === "text") {
       const parts = splitByPattern(child.value, pattern, buildNode);
-      if (parts.length > 1) {
+      if (
+        parts.length > 1 ||
+        (parts.length === 1 && parts[0].type !== "text")
+      ) {
         node.children.splice(i, 1, ...parts);
       }
     } else {


### PR DESCRIPTION
## Summary
- **Codeblock escaping**: prosemirror-markdown's `esc()` backslash-escapes markdown special characters in text nodes. Added post-processing in `getMarkdownFromEditor()` to unescape them so code fences, inline code, bold/italic survive the editor roundtrip.
- **Thread edit leaks to main composer**: A single `editTarget` was passed to both the main channel composer and thread panel composer. Added `isEditInThread` check to scope `editTarget` to the correct composer based on whether the message lives in the thread or main timeline.
- **Channel link / @mention not rendering as sole content**: `createRemarkPrefixPlugin`'s `walkChildren` only spliced replacements when `parts.length > 1`, skipping single-match text nodes. Fixed the guard.
- **Edit cancel leaves stale content**: When cancelling a message edit, the composer retained the edit content instead of restoring the pre-edit draft. Added `preEditContentRef` to save/restore the draft around edit mode transitions.

## Test plan
- [ ] Edit a message, click Cancel — composer should restore whatever was typed before (or be empty)
- [ ] Edit a message, press Escape — same behavior
- [ ] Edit a message, save — composer clears correctly, no stale content
- [ ] Type a draft, enter edit mode, cancel — draft is preserved
- [ ] Send a message containing only `#channel-name` — renders as a link
- [ ] Send a message with inline code and code blocks — backticks not double-escaped
- [ ] Edit a message in a thread — edit stays scoped to thread composer, not main
- [ ] Edit a message in main timeline while thread is open — edit stays in main composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)