### PR TITLE
fix(nip11): advertise auth_required: true to match actual enforcement

### DIFF
--- a/crates/sprout-relay/src/config.rs
+++ b/crates/sprout-relay/src/config.rs
@@ -39,7 +39,8 @@ pub struct Config {
     pub send_buffer_size: usize,
     /// Authentication provider configuration.
     pub auth: sprout_auth::AuthConfig,
-    /// Whether clients must authenticate via NIP-42 before sending events.
+    /// Whether REST API requests must present a valid token. Independent of
+    /// WebSocket protocol auth, which is *always* required by REQ/EVENT/COUNT.
     pub require_auth_token: bool,
     /// Comma-separated list of allowed CORS origins.
     /// If empty, permissive CORS is used (dev mode).
@@ -197,8 +198,8 @@ impl Config {
 
         if !require_auth_token {
             warn!(
-                "SPROUT_REQUIRE_AUTH_TOKEN is false — relay accepts unauthenticated connections. \
-                 Set to true for production."
+                "SPROUT_REQUIRE_AUTH_TOKEN is false — REST API requests bypass token auth. \
+                 WebSocket protocol auth is unaffected. Set to true for production."
             );
         }
 

--- a/crates/sprout-relay/src/nip11.rs
+++ b/crates/sprout-relay/src/nip11.rs
@@ -48,7 +48,8 @@ pub struct RelayLimitation {
     pub max_subid_length: Option<u32>,
     /// Minimum proof-of-work difficulty required for events.
     pub min_pow_difficulty: Option<u32>,
-    /// Whether NIP-42 authentication is required before sending events.
+    /// Whether NIP-42 authentication is required before subscribing or
+    /// publishing events.
     pub auth_required: bool,
     /// Whether payment is required to use the relay.
     pub payment_required: bool,
@@ -56,12 +57,32 @@ pub struct RelayLimitation {
     pub restricted_writes: bool,
 }
 
+/// Canonical `RelayLimitation` advertised by this relay.
+///
+/// `auth_required` is always `true`: the REQ, EVENT, and COUNT handlers
+/// unconditionally reject connections that are not in
+/// `AuthState::Authenticated`. This is independent of the REST API token
+/// toggle (`config.require_auth_token`).
+fn relay_limitation() -> RelayLimitation {
+    RelayLimitation {
+        max_message_length: Some(MAX_FRAME_BYTES as u64),
+        max_subscriptions: Some(1024),
+        max_filters: Some(10),
+        max_limit: Some(10_000),
+        max_subid_length: Some(256),
+        min_pow_difficulty: None,
+        auth_required: true,
+        payment_required: false,
+        restricted_writes: true,
+    }
+}
+
 impl RelayInfo {
-    /// Builds a `RelayInfo` document from the relay's runtime config.
+    /// Builds the relay's NIP-11 information document.
     ///
     /// `relay_pubkey` is the relay's own signing pubkey (hex), advertised as the
     /// NIP-11 `self` field for NIP-43 membership verification.
-    pub fn from_config(config: &crate::config::Config, relay_pubkey: Option<&str>) -> Self {
+    pub fn build(relay_pubkey: Option<&str>) -> Self {
         Self {
             name: "Sprout Relay".to_string(),
             description: "Sprout — private team communication relay".to_string(),
@@ -70,17 +91,7 @@ impl RelayInfo {
             supported_nips: SUPPORTED_NIPS.to_vec(),
             software: "https://github.com/sprout-rs/sprout".to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
-            limitation: Some(RelayLimitation {
-                max_message_length: Some(MAX_FRAME_BYTES as u64),
-                max_subscriptions: Some(1024),
-                max_filters: Some(10),
-                max_limit: Some(10_000),
-                max_subid_length: Some(256),
-                min_pow_difficulty: None,
-                auth_required: config.require_auth_token,
-                payment_required: false,
-                restricted_writes: true,
-            }),
+            limitation: Some(relay_limitation()),
             relay_self: relay_pubkey.map(|s| s.to_string()),
         }
     }
@@ -97,10 +108,7 @@ pub async fn relay_info_handler(
     } else {
         None
     };
-    axum::response::Json(RelayInfo::from_config(
-        &state.config,
-        relay_pubkey.as_deref(),
-    ))
+    axum::response::Json(RelayInfo::build(relay_pubkey.as_deref()))
 }
 
 #[cfg(test)]
@@ -127,6 +135,15 @@ mod tests {
             SUPPORTED_NIPS.contains(&38),
             "NIP-38 (user statuses) must be advertised"
         );
+    }
+
+    #[test]
+    fn auth_required_is_advertised_true() {
+        // REQ, EVENT, and COUNT all unconditionally require
+        // `AuthState::Authenticated` (see `crates/sprout-relay/src/handlers/`).
+        // The NIP-11 doc must reflect that or clients (e.g. the desktop pair
+        // flow) misroute unauthenticated peers.
+        assert!(relay_limitation().auth_required);
     }
 
     #[test]

--- a/crates/sprout-relay/src/router.rs
+++ b/crates/sprout-relay/src/router.rs
@@ -160,7 +160,7 @@ async fn nip11_or_ws_handler(
     };
 
     if accept.contains("application/nostr+json") {
-        let info = RelayInfo::from_config(&state.config, relay_pubkey.as_deref());
+        let info = RelayInfo::build(relay_pubkey.as_deref());
         return Json(info).into_response();
     }
 
@@ -179,7 +179,7 @@ async fn nip11_or_ws_handler(
                 }
             }
             // Not a WS request and not asking for nostr+json — serve NIP-11 as fallback.
-            let info = RelayInfo::from_config(&state.config, relay_pubkey.as_deref());
+            let info = RelayInfo::build(relay_pubkey.as_deref());
             Json(info).into_response()
         }
     }

--- a/crates/sprout-test-client/tests/e2e_relay.rs
+++ b/crates/sprout-test-client/tests/e2e_relay.rs
@@ -605,12 +605,12 @@ async fn test_nip11_relay_info() {
         Some(1024),
         "limitation.max_subscriptions must be 1024"
     );
-    assert!(
-        limitation
-            .get("auth_required")
-            .and_then(|v| v.as_bool())
-            .is_some(),
-        "limitation.auth_required must be a boolean"
+    // The REQ, EVENT, and COUNT handlers unconditionally require an
+    // authenticated connection, so the NIP-11 doc must advertise that.
+    assert_eq!(
+        limitation.get("auth_required").and_then(|v| v.as_bool()),
+        Some(true),
+        "limitation.auth_required must be true — REQ/EVENT/COUNT require NIP-42 auth"
     );
 }
 


### PR DESCRIPTION
## Summary

The relay's NIP-11 information document was advertising `limitation.auth_required: false` even though the relay's WebSocket protocol handlers (REQ, EVENT, COUNT) unconditionally require `AuthState::Authenticated`. This caused the desktop pairing flow to omit the `/pair` sidecar path from the QR code URL on NIP-43-enforcing relays, so phones could not pair.

## The bug, traced end-to-end

1. **Relay (the lie):** `crates/sprout-relay/src/nip11.rs` set `auth_required: config.require_auth_token`. But `require_auth_token` is the **REST API token** toggle — it has no effect on WebSocket protocol auth. The protocol handlers (`handlers/req.rs`, `handlers/event.rs`, `handlers/count.rs`) all unconditionally reject connections that are not `AuthState::Authenticated`, regardless of that flag. The NIP-11 doc has been inconsistent with the protocol since the initial commit (`058c4b92`); PR #448 ("relay membership with NIP-43 compliance") added `43` to `supported_nips` and the `self` field but did not revisit `auth_required`.

2. **Desktop (the consumer):** `desktop/src-tauri/src/commands/pairing.rs::probe_relay_requires_auth` reads `limitation.auth_required` to decide whether to append `/pair` to the relay URL embedded in the pairing QR. The `/pair` path is the unauthenticated NIP-AB sidecar that an unpaired phone needs to reach the desktop. With a `false` advertisement, the QR pointed at the bare relay URL and the phone could not connect (NIP-43 membership check fails).

3. **Empirical confirmation against `wss://sprout.up.railway.app`** (production):
   - Anonymous REQ → `AUTH` challenge + `CLOSED auth-required: not authenticated`.
   - AUTH with freshly-generated keypair → `OK <id> false "restricted: not a relay member"` (from `handle_auth` in `crates/sprout-relay/src/handlers/auth.rs`).
   - The relay's NIP-11 doc still says `"auth_required": false`. That's what this PR fixes.

## The fix

- `crates/sprout-relay/src/nip11.rs`: extract `relay_limitation()` (the canonical `RelayLimitation`) so the advertised invariant is testable without going through `Config::from_env()`. Set `auth_required: true`. Rename `RelayInfo::from_config(_unused_config, relay_pubkey)` to `RelayInfo::build(relay_pubkey)` — `Config` was no longer used. New unit test pins the invariant.
- `crates/sprout-relay/src/router.rs`: update two callers to `RelayInfo::build(...)`.
- `crates/sprout-relay/src/config.rs`: correct stale doc on `require_auth_token` and the startup warning — they previously said "NIP-42 / unauthenticated connections," which is the exact confusion that produced this bug.
- `crates/sprout-test-client/tests/e2e_relay.rs`: tighten the existing nip11 assertion from "is a bool" to "== true", with a comment naming the invariant.

## Propagation to the desktop

No desktop changes are needed. Once a relay redeploys with this fix, `probe_relay_requires_auth` in `desktop/src-tauri/src/commands/pairing.rs` will see `auth_required: true` and append `/pair` to the QR URL automatically. The pairing flow then routes the phone through the existing `sprout-pair-relay` sidecar, which has been correctly configured and routed at the nginx layer all along.

## Tests

- New unit test: `nip11::tests::auth_required_is_advertised_true` (runs in `cargo test -p sprout-relay`).
- Tightened e2e assertion in `e2e_relay::test_nip11_relay_info` (runs against a live relay).
- All 147 `sprout-relay` unit tests pass. Clippy clean. Pre-commit hooks (rust-fmt, clippy, rust-tests, desktop-check, desktop-tauri-fmt, desktop-tauri-check, mobile-check, mobile-test, web-check) pass.

## Reviewed with

Iterated with `codex review` until 10/10 on minimalism, elegance, and correctness.
