### PR TITLE
fix(desktop): resolve unarchive revert and stale member list bugs

### DIFF
--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -323,9 +323,6 @@ export function useUnarchiveChannelMutation(channelId: string | null) {
 
       setChannelArchivedState(queryClient, channelId, null);
     },
-    onSettled: async () => {
-      await invalidateChannelState(queryClient, channelId);
-    },
   });
 }
 

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -22,7 +22,10 @@ import {
   sendChannelMessage,
 } from "@/shared/api/tauri";
 import type { Channel, Identity, RelayEvent } from "@/shared/api/types";
-import { KIND_STREAM_MESSAGE } from "@/shared/constants/kinds";
+import {
+  KIND_STREAM_MESSAGE,
+  KIND_SYSTEM_MESSAGE,
+} from "@/shared/constants/kinds";
 
 type MessageQueryContext = {
   optimisticId: string;
@@ -185,6 +188,27 @@ export function useChannelSubscription(channel: Channel | null) {
       channelMessagesKey(channelId),
       (current = []) => mergeTimelineCacheMessages(current, event),
     );
+
+    if (event.kind === KIND_SYSTEM_MESSAGE) {
+      try {
+        const payload = JSON.parse(event.content) as { type?: string };
+        if (
+          payload.type === "member_joined" ||
+          payload.type === "member_left" ||
+          payload.type === "member_removed"
+        ) {
+          void queryClient.invalidateQueries({
+            queryKey: ["channels", channelId, "members"],
+          });
+          void queryClient.invalidateQueries({
+            queryKey: ["channels"],
+            exact: true,
+          });
+        }
+      } catch {
+        // Non-JSON system message — ignore.
+      }
+    }
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **Unarchive race condition**: Removed the `onSettled` callback from `useUnarchiveChannelMutation` that was eagerly invalidating channel state, causing a stale refetch to overwrite the optimistic `archivedAt: null` update. The `onSuccess` handler already sets the correct state.
- **Stale member list after join/leave**: When a system message (kind 40099) with `member_joined`, `member_left`, or `member_removed` payload arrives via the channel subscription, we now invalidate the members query cache and the channels list so the UI reflects membership changes immediately.

## Files changed
- `desktop/src/features/channels/hooks.ts` — removed 3-line `onSettled` callback
- `desktop/src/features/messages/hooks.ts` — added `KIND_SYSTEM_MESSAGE` import + 21 lines of membership cache invalidation logic

## Test plan
- [ ] Unarchive a channel → verify it stays unarchived (no flicker/revert)
- [ ] Have another user join/leave a channel → verify the member list updates without manual refresh
- [ ] `pnpm typecheck` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)