### PR TITLE
fix: Anthropic rejects empty text blocks in assistant history

### DIFF
--- a/crates/sprout-agent/src/llm.rs
+++ b/crates/sprout-agent/src/llm.rs
@@ -127,7 +127,9 @@ fn anthropic_body(cfg: &Config, history: &[HistoryItem], tools: &[ToolDef]) -> V
                         "name": c.name, "input": c.arguments }));
                 }
                 if content.is_empty() {
-                    content.push(json!({ "type": "text", "text": "" }));
+                    // Anthropic requires non-empty content arrays AND rejects
+                    // empty text blocks. A single space satisfies both.
+                    content.push(json!({ "type": "text", "text": " " }));
                 }
                 messages.push(json!({ "role": "assistant", "content": content }));
             }


### PR DESCRIPTION
## Problem

Anthropic's Messages API rejects `{"type": "text", "text": ""}` with:

```
400 Bad Request: messages: text content blocks must be non-empty
```

When an assistant turn has no text and no tool calls (rare but possible — e.g. empty end_turn response), the serializer produces an empty text block as a fallback to satisfy the non-empty content array requirement. This creates a **permanent 400 loop**: the corrupted history is preserved in the session, so every subsequent prompt on that session sends the same invalid payload and gets the same rejection.

With the session-preservation fix from #544, this is worse — the harness correctly keeps the session alive (pipe is intact), but the session is now permanently poisoned. The event gets requeued with exponential backoff up to 10 times, all failing identically.

## Fix

Use `" "` (single space) instead of `""` in the empty-content fallback. Satisfies both Anthropic constraints: non-empty content array and non-empty text block.

## Changes

`crates/sprout-agent/src/llm.rs`: 1 character changed (`""` → `" "`), plus a comment explaining why.