### PR TITLE
fix: skip empty assistant turns instead of placeholder space

### DIFF
--- a/crates/sprout-agent/src/llm.rs
+++ b/crates/sprout-agent/src/llm.rs
@@ -127,9 +127,11 @@ fn anthropic_body(cfg: &Config, history: &[HistoryItem], tools: &[ToolDef]) -> V
                         "name": c.name, "input": c.arguments }));
                 }
                 if content.is_empty() {
-                    // Anthropic requires non-empty content arrays AND rejects
-                    // empty text blocks. A single space satisfies both.
-                    content.push(json!({ "type": "text", "text": " " }));
+                    // Empty assistant turn (no text, no tool calls) — skip it.
+                    // Anthropic rejects empty text blocks, and a placeholder
+                    // just defers the problem. No tool_use = no pairing
+                    // constraint, so omitting is safe.
+                    continue;
                 }
                 messages.push(json!({ "role": "assistant", "content": content }));
             }


### PR DESCRIPTION
Follow-up to #559.

Instead of emitting `" "` (single space) as a placeholder for empty assistant turns, skip them entirely. An assistant turn with no text and no tool calls carries zero information — no `tool_use` means no `tool_result` pairing constraint, so omitting is safe.

This matches the canonical pattern used by litellm, goose (`anthropic.rs` line 124), and other Anthropic API consumers: strip empty content at serialization time rather than patching with placeholders.

## Research

The `" "` placeholder from #559 works but is a band-aid. [anthropics/anthropic-sdk-python#461](https://github.com/anthropics/anthropic-sdk-python/issues/461) (April 2024) confirmed this validation is intentional and has existed since the tool use beta. The Anthropic maintainer's guidance: empty text blocks should be filtered, not patched.

## Change

`llm.rs`: replace `content.push(json!({"type":"text","text":" "}))` with `continue` (skip the turn).