### PR TITLE
agent: raise default SPROUT_AGENT_MAX_OUTPUT_TOKENS to 32768

### DIFF
--- a/crates/sprout-agent/README.md
+++ b/crates/sprout-agent/README.md
@@ -134,7 +134,7 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 | `SPROUT_AGENT_SYSTEM_PROMPT` | built-in | Inline system prompt. |
 | `SPROUT_AGENT_SYSTEM_PROMPT_FILE` | — | File path. Mutually exclusive with the above. |
 | `SPROUT_AGENT_MAX_ROUNDS` | `0` | Tool-loop iteration cap. 0 = unlimited. |
-| `SPROUT_AGENT_MAX_OUTPUT_TOKENS` | `4096` | Per LLM call. |
+| `SPROUT_AGENT_MAX_OUTPUT_TOKENS` | `32768` | Per LLM call. Headroom for large tool-call inputs (e.g. file writes via heredoc); Sonnet 4 / Opus 4 cap at 64K. |
 | `SPROUT_AGENT_LLM_TIMEOUT_SECS` | `120` | |
 | `SPROUT_AGENT_TOOL_TIMEOUT_SECS` | `660` | Per-tool call timeout in seconds |
 | `SPROUT_AGENT_MAX_PARALLEL_TOOLS` | `8` | Max concurrent tool calls per turn (1 = sequential) |

--- a/crates/sprout-agent/src/config.rs
+++ b/crates/sprout-agent/src/config.rs
@@ -93,7 +93,7 @@ impl Config {
             base_url,
             anthropic_api_version: env_or("ANTHROPIC_API_VERSION", "2023-06-01"),
             max_rounds: parse_env("SPROUT_AGENT_MAX_ROUNDS", 0)?,
-            max_output_tokens: parse_env("SPROUT_AGENT_MAX_OUTPUT_TOKENS", 4096)?,
+            max_output_tokens: parse_env("SPROUT_AGENT_MAX_OUTPUT_TOKENS", 32_768)?,
             llm_timeout: Duration::from_secs(parse_env("SPROUT_AGENT_LLM_TIMEOUT_SECS", 120)?),
             tool_timeout: Duration::from_secs(parse_env("SPROUT_AGENT_TOOL_TIMEOUT_SECS", 660)?),
             mcp_init_timeout: Duration::from_secs(parse_env(


### PR DESCRIPTION
## Problem

When the sprout-agent's per-response token cap fires *inside* a `tool_use` block (typical for large `shell` `command` values — e.g. file creation via heredoc), the provider returns the block with whatever `input` JSON parsed cleanly so far. That's often `{}` if the cap hit mid-value of the first field. The MCP then rejects the call with:

```
Tool call rejected: Mcp error: -32602: failed to deserialize parameters: missing field `command`
```

From the user's perspective the MCP "errors on file creation," but the trigger is response length, not quoting or content. The session loops because the model has no signal that its emission was truncated.

Reproduced empirically: `command` values up to ~5-7KB succeed; ~10KB+ trigger the truncation. Same MCP, same model, same harness.

## Fix

Raise the default `SPROUT_AGENT_MAX_OUTPUT_TOKENS` from `4096` to `32768`.

- Sonnet 4 and Opus 4 (the models offered in the ACP settings panel at `crates/sprout-acp/src/acp.rs:1530-1531`) both support up to **64K** output tokens, so 32K leaves comfortable headroom.
- Providers bill on tokens *generated*, not on the cap, so **normal-turn cost is unchanged** — only the ceiling moves.
- The env override (`SPROUT_AGENT_MAX_OUTPUT_TOKENS`) still wins for any deployment that wants to pin a lower value.

## Files

- `crates/sprout-agent/src/config.rs` — default literal.
- `crates/sprout-agent/README.md` — env-var table row + a one-line note explaining the value.

## Verification

```
cargo build -p sprout-agent     # clean
cargo test -p sprout-agent       # 17/17 pass
cargo fmt -p sprout-agent --check
cargo clippy -p sprout-agent -- -D warnings
```

Lefthook pre-commit and pre-push hooks ran clean (rust-fmt, rust-clippy, rust-tests, plus the desktop/web/mobile checks).

## Follow-ups (separate PRs, not blocking this one)

- **Agent-side `MaxTokens` guard**: detect `stop_reason: max_tokens` with non-empty tool_calls in `crates/sprout-agent/src/agent.rs` and refuse to forward the partial `tool_use`, returning a corrective synthetic tool-result instead. Defense in depth for sessions that still exceed the new 32K ceiling, or for deployments pinning the env override lower.
- **`write_file` MCP tool in sprout-dev-mcp**: takes `{path, content}` as plain JSON fields, sidestepping bash heredoc quoting footguns entirely (indented EOF, space-indent under `<<-`, unquoted-delimiter `$var` expansion). Removes the dominant "one giant `command` value" usage pattern that creates the truncation pressure in the first place.