### PR TITLE
chore(acp): raise default idle timeout from 320s to 620s

### DIFF
--- a/crates/sprout-acp/README.md
+++ b/crates/sprout-acp/README.md
@@ -105,7 +105,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `SPROUT_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
 | `SPROUT_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `SPROUT_ACP_MCP_COMMAND` | no | `sprout-mcp-server` | Path to the Sprout MCP server binary. |
-| `SPROUT_ACP_IDLE_TIMEOUT` | no | `300` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
+| `SPROUT_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `SPROUT_ACP_MAX_TURN_DURATION` | no | `3600` | Absolute wall-clock cap per turn (safety valve). |
 | `SPROUT_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
 

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -13,6 +13,17 @@ use uuid::Uuid;
 
 use crate::filter::SubscriptionRule;
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Default idle timeout (seconds) when neither `--idle-timeout` nor the
+/// deprecated `--turn-timeout` is set.
+///
+/// Sized for slow turns where the agent may go silent on its outer ACP channel
+/// while running long sub-tools (e.g. a sprout-agent running another agent, or
+/// codex/claude doing multi-minute single tool calls). 600s working budget +
+/// 20s buffer. Override via `--idle-timeout` / `SPROUT_ACP_IDLE_TIMEOUT`.
+pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 620;
+
 // ── Errors ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Error)]
@@ -597,7 +608,7 @@ impl Config {
         };
 
         // Resolve idle_timeout_secs with deprecation handling.
-        // Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 620.
+        // Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > `DEFAULT_IDLE_TIMEOUT_SECS`.
         let idle_timeout_secs = {
             let raw = match (args.idle_timeout, args.turn_timeout) {
                 (Some(idle), Some(_turn)) => {
@@ -615,11 +626,7 @@ impl Config {
                     );
                     turn
                 }
-                // Default sized for slow turns where the agent may go silent on its
-                // outer ACP channel while running long sub-tools (e.g. a sprout-agent
-                // running another agent, codex/claude doing multi-minute tool calls).
-                // 600s working budget + 20s buffer.
-                (None, None) => 620,
+                (None, None) => DEFAULT_IDLE_TIMEOUT_SECS,
             };
             if raw == 0 {
                 tracing::warn!("idle timeout of 0 is invalid — using 1s minimum");
@@ -1096,7 +1103,7 @@ mod tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "sprout-mcp-server".into(),
-            idle_timeout_secs: 620,
+            idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: 3600,
             agents: 1,
             heartbeat_interval_secs: 0,
@@ -1804,13 +1811,13 @@ channels = "ALL"
     // ── Idle timeout config precedence ─────────────────────────────────────
 
     /// Helper: resolve idle_timeout_secs using the same precedence logic as Config::from_args.
-    /// Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 620.
+    /// Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > `DEFAULT_IDLE_TIMEOUT_SECS`.
     fn resolve_idle_timeout(idle: Option<u64>, turn: Option<u64>) -> u64 {
         let raw = match (idle, turn) {
             (Some(idle), Some(_)) => idle,
             (Some(idle), None) => idle,
             (None, Some(turn)) => turn,
-            (None, None) => 620,
+            (None, None) => DEFAULT_IDLE_TIMEOUT_SECS,
         };
         if raw == 0 {
             1
@@ -1830,8 +1837,8 @@ channels = "ALL"
     }
 
     #[test]
-    fn idle_timeout_defaults_to_620_when_neither_set() {
-        assert_eq!(resolve_idle_timeout(None, None), 620);
+    fn idle_timeout_defaults_to_constant_when_neither_set() {
+        assert_eq!(resolve_idle_timeout(None, None), DEFAULT_IDLE_TIMEOUT_SECS);
     }
 
     #[test]
@@ -1848,9 +1855,10 @@ channels = "ALL"
     fn test_config_summary_includes_idle_and_max_turn() {
         let config = test_config(SubscribeMode::Mentions);
         let summary = config.summary();
+        let expected_idle = format!("idle_timeout={DEFAULT_IDLE_TIMEOUT_SECS}s");
         assert!(
-            summary.contains("idle_timeout=620s"),
-            "summary should include idle_timeout: {summary}"
+            summary.contains(&expected_idle),
+            "summary should include {expected_idle}: {summary}"
         );
         assert!(
             summary.contains("max_turn=3600s"),

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -597,7 +597,7 @@ impl Config {
         };
 
         // Resolve idle_timeout_secs with deprecation handling.
-        // Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 320.
+        // Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 620.
         let idle_timeout_secs = {
             let raw = match (args.idle_timeout, args.turn_timeout) {
                 (Some(idle), Some(_turn)) => {
@@ -615,7 +615,11 @@ impl Config {
                     );
                     turn
                 }
-                (None, None) => 320, // default: 20s buffer over goose's 300s turn timeout
+                // Default sized for slow turns where the agent may go silent on its
+                // outer ACP channel while running long sub-tools (e.g. a sprout-agent
+                // running another agent, codex/claude doing multi-minute tool calls).
+                // 600s working budget + 20s buffer.
+                (None, None) => 620,
             };
             if raw == 0 {
                 tracing::warn!("idle timeout of 0 is invalid — using 1s minimum");
@@ -1092,7 +1096,7 @@ mod tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "sprout-mcp-server".into(),
-            idle_timeout_secs: 320,
+            idle_timeout_secs: 620,
             max_turn_duration_secs: 3600,
             agents: 1,
             heartbeat_interval_secs: 0,
@@ -1800,13 +1804,13 @@ channels = "ALL"
     // ── Idle timeout config precedence ─────────────────────────────────────
 
     /// Helper: resolve idle_timeout_secs using the same precedence logic as Config::from_args.
-    /// Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 320.
+    /// Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > default 620.
     fn resolve_idle_timeout(idle: Option<u64>, turn: Option<u64>) -> u64 {
         let raw = match (idle, turn) {
             (Some(idle), Some(_)) => idle,
             (Some(idle), None) => idle,
             (None, Some(turn)) => turn,
-            (None, None) => 320,
+            (None, None) => 620,
         };
         if raw == 0 {
             1
@@ -1826,8 +1830,8 @@ channels = "ALL"
     }
 
     #[test]
-    fn idle_timeout_defaults_to_320_when_neither_set() {
-        assert_eq!(resolve_idle_timeout(None, None), 320);
+    fn idle_timeout_defaults_to_620_when_neither_set() {
+        assert_eq!(resolve_idle_timeout(None, None), 620);
     }
 
     #[test]
@@ -1845,7 +1849,7 @@ channels = "ALL"
         let config = test_config(SubscribeMode::Mentions);
         let summary = config.summary();
         assert!(
-            summary.contains("idle_timeout=320s"),
+            summary.contains("idle_timeout=620s"),
             "summary should include idle_timeout: {summary}"
         );
         assert!(

--- a/crates/sprout-acp/src/main.rs
+++ b/crates/sprout-acp/src/main.rs
@@ -2729,7 +2729,7 @@ mod build_mcp_servers_tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "sprout-mcp-server".into(),
-            idle_timeout_secs: 620,
+            idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: 3600,
             agents: 1,
             heartbeat_interval_secs: 0,

--- a/crates/sprout-acp/src/main.rs
+++ b/crates/sprout-acp/src/main.rs
@@ -2729,7 +2729,7 @@ mod build_mcp_servers_tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "sprout-mcp-server".into(),
-            idle_timeout_secs: 320,
+            idle_timeout_secs: 620,
             max_turn_duration_secs: 3600,
             agents: 1,
             heartbeat_interval_secs: 0,


### PR DESCRIPTION
## Summary

Raise the default ACP idle timeout from **320s → 620s**, and extract the value into a single `DEFAULT_IDLE_TIMEOUT_SECS` constant.

## Why the bump

The default was sized as "goose's 300s turn timeout + 20s buffer". That's no longer a good fit for the agent shapes we actually run:

- A sprout-agent running another agent as a tool naturally goes silent on its **outer** ACP channel while the inner agent works. The harness sees no stdout activity and assumes wedged.
- codex/claude routinely do single tool calls (long compile, long network fetch, long shell command) that exceed 5 minutes with no streaming output on the ACP channel.
- Model providers with slow generation can stall for minutes before the first token, especially for long contexts or reasoning models.

Each of these triggers `idle timeout (320s) — no agent activity` followed by `session/cancel` and a full agent subprocess respawn — losing session state, paying cold-start cost, and counting against the circuit breaker. The agent was healthy the whole time; it just wasn't talking on the outer channel.

## Why the constant

The 620 literal lived at four real call sites: the actual default in `from_args`, the `resolve_idle_timeout` test helper that re-implements precedence, and two `test_config()` fixtures. The helper was a genuine drift hazard — a future bump would update the prod default but silently leave the test helper on the old value, masking the regression. One `pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 620` with the rationale in its docstring fixes that. Two test assertions also now derive from the constant so they auto-track.

## Commits

1. **`chore(acp): raise default idle timeout from 320s to 620s`** — the bump itself, plus a fix for a stale README entry that documented the default as `300` (pre-existing drift).
2. **`refactor(acp): extract DEFAULT_IDLE_TIMEOUT_SECS constant`** — single source of truth, no behavior change.

## What does **not** change

- `max_turn_duration` (the absolute wall-clock cap) stays at `3600s`. A genuinely wedged agent still gets killed at the hard cap.
- The respawn behavior on idle timeout is unchanged. Reducing how often the timeout fires is the goal of this PR; whether we should also stop respawning on clean cancels is being looked at separately.
- The `idle_timeout < max_turn_duration` validation at startup is unchanged.
- `SPROUT_ACP_IDLE_TIMEOUT` / `--idle-timeout` env-var and flag overrides are unchanged.

## Operator-facing notes

**Edge case worth flagging:** operators who have set a custom `--max-turn-duration` ≤ 620 and rely on the default idle timeout will now fail validation at startup with:

```
idle_timeout (620s) must be less than max_turn_duration (Ns)
```

Resolution: either raise `--max-turn-duration` above 620, or set `--idle-timeout` explicitly to a value below your custom max. The default-default combo (`idle=620`, `max=3600`) is well within the constraint.

## Test plan

- `cargo build -p sprout-acp` — clean.
- `cargo clippy -p sprout-acp --all-targets -- -D warnings` — clean.
- `cargo test -p sprout-acp` — 259 passed, 0 failed.

## What I considered and decided against

- **Updating the literal `320` in `idle_timeout_error_includes_duration` (acp.rs:1688).** That test uses 320 as an arbitrary `Duration` value to verify error-message formatting; it doesn't reference the default. Touching it would be unrelated churn.
- **Going to 900s or higher.** Reasonable, but 620 is the conservative bump — strictly better than 320 without entering "is this thing hung forever?" territory. Operators can override via `SPROUT_ACP_IDLE_TIMEOUT` if their workload needs more.
