### PR TITLE
fix(desktop): keep day dividers below header

### DIFF
--- a/desktop/src/features/messages/ui/DayDivider.tsx
+++ b/desktop/src/features/messages/ui/DayDivider.tsx
@@ -2,7 +2,7 @@ export function DayDivider({ label }: { label: string }) {
   return (
     <section
       aria-label={label}
-      className="sticky top-0 z-[1] flex justify-center py-1"
+      className="sticky top-11 z-20 flex justify-center py-1"
       data-testid="message-timeline-day-divider"
       data-day-label={label}
     >


### PR DESCRIPTION
## Summary
- Keeps message timeline day dividers sticky below the overlaid chat header instead of disappearing behind it.
- Raises the day divider within the timeline stacking context so it remains visible while scrolling between dates.

## Test plan
- Pre-commit hooks passed: desktop check, desktop Tauri fmt, mobile check, Rust fmt, web check.
- Pre-push hooks passed: Rust fmt, web check/build, desktop check/build/Tauri check, mobile check/test, Rust clippy/tests.


Made with [Cursor](https://cursor.com)