### PR TITLE
fix: add default-run to sprout-relay so `cargo run -p sprout-relay` works

### DIFF
--- a/crates/sprout-relay/Cargo.toml
+++ b/crates/sprout-relay/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "sprout-relay"
+default-run = "sprout-relay"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Issue
What changed
PR #569 (9a403d3 — "channel member search via NIP-50 + Typesense indexer fix for kind:0") added a second binary sprout-reindex-kind0 to the sprout-relay crate. Before that commit, sprout-relay had a single [[bin]] target, so cargo run -p sprout-relay worked fine. Now Cargo can't pick which of the two binaries to run.

## Changes
- Adds `default-run = "sprout-relay"` to `crates/sprout-relay/Cargo.toml` so that `cargo run -p sprout-relay` works without needing to specify `--bin sprout-relay`.

## Test plan
- [x] `cargo clippy --workspace --all-targets` passes
- [x] `cargo test -p sprout-core -p sprout-auth` passes
- [x] `cargo check --manifest-path desktop/src-tauri/Cargo.toml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)