### PR TITLE
fix(mobile): prevent reconnect empty-state flash and wire agent activity feed

### DIFF
--- a/mobile/lib/features/activity/activity_provider.dart
+++ b/mobile/lib/features/activity/activity_provider.dart
@@ -1,16 +1,26 @@
+import 'dart:async';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../shared/relay/relay.dart';
 import 'feed_item.dart';
 
-/// Builds the home activity feed by issuing two parallel REQs over the relay
-/// websocket: one for mentions of me on user-visible channel kinds, and one
-/// for agent-activity / approval kinds addressed to me.
+/// Builds the home activity feed by issuing three parallel REQs over the relay
+/// websocket: mentions of me on user-visible channel kinds, approval kinds
+/// addressed to me, and NIP-90 agent job events addressed to me.
 class ActivityNotifier extends AsyncNotifier<HomeFeedResponse> {
   @override
   Future<HomeFeedResponse> build() {
     ref.watch(relayConfigProvider);
-    ref.watch(relaySessionProvider);
+    final sessionState = ref.watch(relaySessionProvider);
+
+    if (sessionState.status != SessionStatus.connected) {
+      if (state.value case final cached?) {
+        return Future.value(cached);
+      }
+      return Completer<HomeFeedResponse>().future;
+    }
+
     return _fetch();
   }
 
@@ -27,7 +37,7 @@ class ActivityNotifier extends AsyncNotifier<HomeFeedResponse> {
 
     final session = ref.read(relaySessionProvider.notifier);
 
-    final results = await Future.wait([
+    final [mentionEvents, approvalEvents, agentJobEvents] = await Future.wait([
       // Mentions of me on user-visible channel content.
       session.fetchHistory(
         NostrFilter(
@@ -48,24 +58,39 @@ class ActivityNotifier extends AsyncNotifier<HomeFeedResponse> {
           limit: 20,
         ),
       ),
+      // NIP-90 agent job event kinds: request, accepted, progress, result,
+      // cancelled, failed.
+      session.fetchHistory(
+        NostrFilter(
+          kinds: const [43001, 43002, 43003, 43004, 43005, 43006],
+          tags: {
+            '#p': [myPk],
+          },
+          limit: 20,
+        ),
+      ),
     ]);
 
-    final mentions = results[0]
+    final mentions = mentionEvents
         .where((e) => e.pubkey.toLowerCase() != myPk.toLowerCase())
         .map((e) => _feedItem(e, category: 'mention'))
         .toList();
-    final approvals = results[1]
+    final approvals = approvalEvents
         .map((e) => _feedItem(e, category: 'needs_action'))
+        .toList();
+    final agentJobs = agentJobEvents
+        .map((e) => _feedItem(e, category: 'agent_activity'))
         .toList();
 
     mentions.sort((a, b) => b.createdAt.compareTo(a.createdAt));
     approvals.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    agentJobs.sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
     return HomeFeedResponse(
       mentions: mentions,
       needsAction: approvals,
       activity: const [],
-      agentActivity: const [],
+      agentActivity: agentJobs,
     );
   }
 

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -48,14 +48,26 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
 
     if (sessionState.status != SessionStatus.connected) {
       _clearLiveSubscriptions();
+      // Preserve cached channels during background/resume reconnect.
+      if (state.value case final cached?) {
+        return Future.value(cached);
+      }
+      // Cold start with no cache — stay in AsyncLoading so the UI shows
+      // the connection banner instead of the empty-state. build() will
+      // re-fire when the session connects via ref.watch.
+      return Completer<List<Channel>>().future;
     }
 
-    return _fetch(
-      subscribeLive: sessionState.status == SessionStatus.connected,
-    );
+    // If we have cached channels, this is a reconnect fetch — protect against
+    // transient empty membership responses from the relay during warmup.
+    final isReconnect = state.hasValue && state.value!.isNotEmpty;
+    return _fetch(subscribeLive: true, isReconnect: isReconnect);
   }
 
-  Future<List<Channel>> _fetch({bool subscribeLive = false}) async {
+  Future<List<Channel>> _fetch({
+    bool subscribeLive = false,
+    bool isReconnect = false,
+  }) async {
     final myPk = ref.read(myPubkeyProvider);
     if (myPk == null) throw StateError('No signing identity available');
 
@@ -70,7 +82,14 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
         .whereType<String>()
         .toSet()
         .toList();
-    if (channelIds.isEmpty) return const [];
+    if (channelIds.isEmpty) {
+      if (isReconnect) {
+        // Transient empty membership response during reconnect warmup —
+        // preserve the cached channel list instead of wiping it.
+        return state.value ?? const [];
+      }
+      return const [];
+    }
 
     // Step 2: pull channel metadata in one batched filter.
     final metas = await session.fetchHistory(
@@ -305,11 +324,10 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
 
   /// Backstop refresh that preserves existing state on transient failure.
   Future<void> _backstopRefresh() async {
+    final sessionState = ref.read(relaySessionProvider);
+    if (sessionState.status != SessionStatus.connected) return;
     try {
-      final sessionState = ref.read(relaySessionProvider);
-      final channels = await _fetch(
-        subscribeLive: sessionState.status == SessionStatus.connected,
-      );
+      final channels = await _fetch(subscribeLive: true);
       state = AsyncData(channels);
     } catch (error) {
       debugPrint('[ChannelsNotifier] backstop refresh failed: $error');
@@ -318,10 +336,8 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
 
   Future<void> refresh() async {
     final sessionState = ref.read(relaySessionProvider);
-    state = await AsyncValue.guard(
-      () =>
-          _fetch(subscribeLive: sessionState.status == SessionStatus.connected),
-    );
+    if (sessionState.status != SessionStatus.connected) return;
+    state = await AsyncValue.guard(() => _fetch(subscribeLive: true));
   }
 
   void _clearLiveSubscriptions() {

--- a/mobile/test/features/activity/activity_provider_test.dart
+++ b/mobile/test/features/activity/activity_provider_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sprout_mobile/features/activity/activity_provider.dart';
+import 'package:sprout_mobile/shared/relay/relay.dart';
+
+void main() {
+  const myPk = 'me';
+
+  test('fetches agent job events and populates agentActivity', () async {
+    final session = _FakeRelaySession(
+      mentionEvents: [
+        _event(id: 'mention-1', kind: 9, pubkey: 'alice', createdAt: 100),
+      ],
+      approvalEvents: [
+        _event(id: 'approval-1', kind: 46010, pubkey: 'bot', createdAt: 200),
+      ],
+      agentJobEvents: [
+        _event(id: 'job-1', kind: 43001, pubkey: 'agent', createdAt: 300),
+        _event(id: 'job-2', kind: 43004, pubkey: 'agent', createdAt: 400),
+      ],
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    final feed = await container.read(activityProvider.future);
+
+    // Three parallel fetchHistory calls should have been issued.
+    expect(session.historyFilters, hasLength(3));
+
+    // Third filter should be for agent job kinds.
+    final jobFilter = session.historyFilters[2];
+    expect(jobFilter.kinds, containsAll([43001, 43003, 43004]));
+    expect(jobFilter.tags['#p'], [myPk]);
+
+    // agentActivity should contain the two job events.
+    expect(feed.agentActivity, hasLength(2));
+    expect(feed.agentActivity[0].id, 'job-2'); // newest first
+    expect(feed.agentActivity[1].id, 'job-1');
+    expect(feed.agentActivity[0].category, 'agent_activity');
+
+    // mentions and needsAction should still work.
+    expect(feed.mentions, hasLength(1));
+    expect(feed.needsAction, hasLength(1));
+  });
+
+  test('returns empty agentActivity when no job events exist', () async {
+    final session = _FakeRelaySession(
+      mentionEvents: const [],
+      approvalEvents: const [],
+      agentJobEvents: const [],
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    final feed = await container.read(activityProvider.future);
+
+    expect(feed.agentActivity, isEmpty);
+    expect(feed.isEmpty, isTrue);
+  });
+}
+
+NostrEvent _event({
+  required String id,
+  required int kind,
+  required String pubkey,
+  required int createdAt,
+}) => NostrEvent(
+  id: id,
+  pubkey: pubkey,
+  createdAt: createdAt,
+  kind: kind,
+  tags: const [
+    ['p', 'me'],
+    ['h', 'ch1'],
+  ],
+  content: 'test content',
+  sig: 'sig',
+);
+
+ProviderContainer _buildContainer({required _FakeRelaySession session}) {
+  return ProviderContainer(
+    overrides: [
+      relayConfigProvider.overrideWith(() => _FakeRelayConfigNotifier()),
+      relaySessionProvider.overrideWith(() => session),
+      myPubkeyProvider.overrideWithValue('me'),
+    ],
+  );
+}
+
+class _FakeRelaySession extends RelaySessionNotifier {
+  _FakeRelaySession({
+    required this.mentionEvents,
+    required this.approvalEvents,
+    required this.agentJobEvents,
+  });
+
+  final List<NostrEvent> mentionEvents;
+  final List<NostrEvent> approvalEvents;
+  final List<NostrEvent> agentJobEvents;
+
+  final List<NostrFilter> historyFilters = [];
+  int _callIndex = 0;
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    historyFilters.add(filter);
+    final idx = _callIndex++;
+    switch (idx) {
+      case 0:
+        return mentionEvents;
+      case 1:
+        return approvalEvents;
+      case 2:
+        return agentJobEvents;
+      default:
+        return const [];
+    }
+  }
+
+  @override
+  Future<void Function()> subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) async {
+    return () {};
+  }
+}
+
+class _FakeRelayConfigNotifier extends RelayConfigNotifier {
+  @override
+  RelayConfig build() => const RelayConfig(baseUrl: 'https://fake.relay');
+}

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -215,6 +215,150 @@ void main() {
     },
   );
 
+  test('connecting status returns previous data without fetching', () async {
+    // After a >30s background the session transitions to connecting.
+    // The provider should return its cached channel list — not call
+    // _fetch() which would timeout-resolve with [] and overwrite the
+    // cache, causing an empty-state flash.
+    final session = _FakeRelaySession(
+      memberships: [_membership(_channelA, myPk)],
+      metadata: [_meta(id: _channelA, name: 'general')],
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    // Initial load while connected.
+    final initial = await container.read(channelsProvider.future);
+    expect(initial, hasLength(1));
+    expect(initial.single.name, 'general');
+
+    final fetchCountAfterInit = session.historyFilters.length;
+
+    // Simulate disconnect → connecting: change session state, which
+    // triggers a provider rebuild via ref.watch(relaySessionProvider).
+    session.setStatus(SessionStatus.connecting);
+
+    // Let the provider rebuild settle.
+    await container.read(channelsProvider.future);
+
+    // No new fetchHistory calls should have been issued.
+    expect(session.historyFilters.length, fetchCountAfterInit);
+
+    // The provider should still expose the previous channel data.
+    final channels = container.read(channelsProvider).value;
+    expect(channels, isNotNull);
+    expect(channels, hasLength(1));
+    expect(channels!.single.name, 'general');
+  });
+
+  test('refresh() while connecting does not fetch', () async {
+    // The appLifecycleProvider listener calls refresh() on resume, which
+    // can fire while the session is still connecting after a >30s
+    // background. refresh() must bail out without issuing fetch calls.
+    final session = _FakeRelaySession(
+      memberships: [_membership(_channelA, myPk)],
+      metadata: [_meta(id: _channelA, name: 'general')],
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    // Initial load while connected.
+    await container.read(channelsProvider.future);
+    final fetchCountAfterInit = session.historyFilters.length;
+
+    // Transition to connecting.
+    session.setStatus(SessionStatus.connecting);
+    await container.read(channelsProvider.future);
+
+    // Explicitly call refresh() — simulates the resume listener firing.
+    await container.read(channelsProvider.notifier).refresh();
+
+    // No new fetchHistory calls should have been issued.
+    expect(session.historyFilters.length, fetchCountAfterInit);
+
+    // Previous data still intact.
+    final channels = container.read(channelsProvider).value;
+    expect(channels, isNotNull);
+    expect(channels, hasLength(1));
+    expect(channels!.single.name, 'general');
+  });
+
+  test('cold start with connecting status stays in AsyncLoading', () async {
+    // On fresh launch the session starts as connecting and there's no
+    // cached state. The provider must stay in AsyncLoading so the UI
+    // renders the connection spinner, not "No conversations yet".
+    final session = _FakeRelaySession(
+      memberships: [_membership(_channelA, myPk)],
+      metadata: [_meta(id: _channelA, name: 'general')],
+      initialStatus: SessionStatus.connecting,
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    // Read the provider — it should be loading, not data.
+    final state = container.read(channelsProvider);
+    expect(state.isLoading, isTrue);
+    expect(state.value, isNull);
+
+    // No fetchHistory calls should have been issued.
+    expect(session.historyFilters, isEmpty);
+  });
+
+  test('reconnect with empty membership preserves previous channels', () async {
+    // After reconnect the relay may return empty memberships transiently
+    // during warmup. The reconnect-scoped guard should preserve cached
+    // channels instead of wiping to [].
+    final session = _FakeRelaySession(
+      memberships: [_membership(_channelA, myPk)],
+      metadata: [_meta(id: _channelA, name: 'general')],
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    // Initial load — one channel.
+    final initial = await container.read(channelsProvider.future);
+    expect(initial, hasLength(1));
+    expect(initial.single.name, 'general');
+
+    // Simulate disconnect → reconnect with empty memberships.
+    session.memberships.clear();
+    session.setStatus(SessionStatus.connecting);
+    await container.read(channelsProvider.future);
+    session.setStatus(SessionStatus.connected);
+    final reconnected = await container.read(channelsProvider.future);
+
+    // Previous data should be preserved during reconnect.
+    expect(reconnected, hasLength(1));
+    expect(reconnected.single.name, 'general');
+  });
+
+  test(
+    'normal empty membership returns empty list (user left all channels)',
+    () async {
+      // When already connected (not a reconnect), an empty membership
+      // response means the user genuinely has no channels. Return [].
+      final session = _FakeRelaySession(
+        memberships: [_membership(_channelA, myPk)],
+        metadata: [_meta(id: _channelA, name: 'general')],
+      );
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+
+      // Initial load — one channel.
+      final initial = await container.read(channelsProvider.future);
+      expect(initial, hasLength(1));
+
+      // User leaves all channels — refresh() while connected.
+      session.memberships.clear();
+      await container.read(channelsProvider.notifier).refresh();
+
+      // Should return empty — user genuinely has no channels.
+      final channels = container.read(channelsProvider).value;
+      expect(channels, isNotNull);
+      expect(channels, isEmpty);
+    },
+  );
+
   test('initial fetch issues membership + metadata queries', () async {
     final session = _FakeRelaySession(
       memberships: [_membership(_channelA, myPk)],
@@ -293,17 +437,27 @@ ProviderContainer _buildContainer({required _FakeRelaySession session}) {
 /// Fake [RelaySessionNotifier] that returns canned events from [fetchHistory]
 /// and records subscribe calls.
 class _FakeRelaySession extends RelaySessionNotifier {
-  _FakeRelaySession({required this.memberships, required this.metadata});
+  _FakeRelaySession({
+    required this.memberships,
+    required this.metadata,
+    this.initialStatus = SessionStatus.connected,
+  });
 
   final List<NostrEvent> memberships;
   final List<NostrEvent> metadata;
+  final SessionStatus initialStatus;
 
   final List<NostrFilter> historyFilters = [];
   final List<NostrFilter> subscribeFilters = [];
   final List<void Function(NostrEvent)> _listeners = [];
 
   @override
-  SessionState build() => const SessionState(status: SessionStatus.connected);
+  SessionState build() => SessionState(status: initialStatus);
+
+  /// Simulate a status transition (e.g. connected → connecting).
+  void setStatus(SessionStatus status) {
+    state = SessionState(status: status);
+  }
 
   @override
   Future<List<NostrEvent>> fetchHistory(


### PR DESCRIPTION
## Summary
- Prevents the jarring "No conversations yet" empty-state flash that occurred after backgrounding the app for >30s and resuming. Four connected guards in `ChannelsNotifier` now prevent empty-result cache poisoning across `build()`, `_fetch()`, `refresh()`, and `_backstopRefresh()`.
- Wires up the agent activity feed in `ActivityNotifier` — NIP-90 job event kinds (43001–43006) are now fetched and populated into `agentActivity` instead of being hardcoded to empty arrays.
- Adds the same connected guard pattern to `ActivityNotifier` so the activity feed doesn't flash empty on reconnect.

## Details

### Reconnect empty-state flash (channels_provider.dart)

After a >30s background, the WebSocket disconnects. On resume, `build()` would call `_fetch()` while the session was still connecting. `fetchHistory` timeout-resolved with `[]`, overwriting the cached channel list.

**Guards added:**
1. `build()` — returns cached data on reconnect, `Completer().future` on cold start (stays in `AsyncLoading` so UI shows connection banner, not empty state)
2. `_fetch()` — reconnect-scoped guard preserves cached channels when relay returns transient empty membership during warmup (does NOT block legitimate leave-all-channels)
3. `refresh()` — bails out when disconnected (the `appLifecycleProvider` resume listener calls this)
4. `_backstopRefresh()` — bails out when disconnected

### Agent activity feed (activity_provider.dart)

- Added 3rd parallel `fetchHistory` for NIP-90 job kinds: 43001 (request), 43002 (accepted), 43003 (progress), 43004 (result), 43005 (cancel), 43006 (error)
- `agentActivity` now populated with real data instead of `const []`
- Connected guard matches channels pattern

### Tests

- **channels_provider_test.dart**: 5 new tests covering connecting-status cache, refresh-while-connecting, cold-start AsyncLoading, reconnect-empty-membership preservation, and genuine-empty-membership passthrough
- **activity_provider_test.dart**: New file with 2 tests covering agent job event fetching and empty state

## Test plan
- [x] `flutter test` — 343 passed, 1 skipped
- [x] `dart format` — 0 changes
- [x] `flutter analyze` — no issues
- [ ] Manual: background app >30s, resume — should see "connecting" bar then channels, never "No conversations yet"
- [ ] Manual: verify agent activity items appear in home feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)