### PR TITLE
fix(mobile): preserve channel list across background/resume reconnection

### DIFF
--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -48,6 +48,14 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
 
     if (sessionState.status != SessionStatus.connected) {
       _clearLiveSubscriptions();
+      // Preserve the last successfully loaded channels while reconnecting
+      // instead of re-entering a loading/error state. The UI will show cached
+      // channels with a "Reconnecting…" banner overlay, which is far better
+      // than a blank screen.
+      final previous = state.value;
+      if (previous != null && previous.isNotEmpty) {
+        return Future.value(previous);
+      }
     }
 
     return _fetch(
@@ -318,10 +326,13 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
 
   Future<void> refresh() async {
     final sessionState = ref.read(relaySessionProvider);
-    state = await AsyncValue.guard(
-      () =>
-          _fetch(subscribeLive: sessionState.status == SessionStatus.connected),
-    );
+    // Don't attempt to fetch when the session isn't connected — fetchHistory
+    // would send REQs over an unauthenticated socket that either time out
+    // (returning empty results) or get cancelled on disconnect, replacing the
+    // cached channel list with [] or an error. Wait for `build()` to re-run
+    // when the session transitions to connected.
+    if (sessionState.status != SessionStatus.connected) return;
+    state = await AsyncValue.guard(() => _fetch(subscribeLive: true));
   }
 
   void _clearLiveSubscriptions() {

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -231,7 +231,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   /// Called by the app lifecycle provider when the app goes to background.
   void onAppPaused() {
     _backgroundGraceTimer?.cancel();
-    _backgroundGraceTimer = Timer(const Duration(seconds: 30), () {
+    _backgroundGraceTimer = Timer(const Duration(seconds: 5), () {
       _socket?.disconnect();
       state = const SessionState(status: SessionStatus.disconnected);
     });
@@ -241,11 +241,17 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   void onAppResumed() {
     _backgroundGraceTimer?.cancel();
     _backgroundGraceTimer = null;
-    if (state.status == SessionStatus.disconnected) {
-      _reconnectDelayMs = _baseReconnectDelayMs;
-      final config = ref.read(relayConfigProvider);
-      _connect(config);
-    }
+
+    // If still connected, nothing to do — the socket survived the background
+    // grace window.
+    if (state.status == SessionStatus.connected) return;
+
+    // Cancel any in-flight reconnect backoff timer so we reconnect immediately
+    // instead of waiting for the (possibly large) exponential delay.
+    _reconnectTimer?.cancel();
+    _reconnectDelayMs = _baseReconnectDelayMs;
+    final config = ref.read(relayConfigProvider);
+    _connect(config);
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reduced background grace timer from 30s to 5s — the socket now disconnects sooner for a clean reconnect on resume instead of disconnecting right when the user returns
- `onAppResumed()` now force-reconnects immediately in any non-connected state, cancelling any exponential backoff timer
- `refresh()` bails when the session isn't connected — prevents `fetchHistory()` from sending REQs over an unauthenticated socket that either time out (returning empty `[]`) or get cancelled, replacing cached channels with nothing
- `build()` preserves the last successfully loaded channel list during reconnection instead of re-entering a loading state

## Root cause
When the app was backgrounded 30s+ and reopened, the `appLifecycleProvider` listener called `refresh()` during reconnection. `refresh()` called `fetchHistory()` over a socket still authenticating, the REQ timed out or was cancelled, and `AsyncValue.guard` set state to `AsyncData([])` or `AsyncError` — nuking the cached channel list and showing the "Connecting…" blank screen.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 9 existing tests pass (relay_session_test + channels_provider_test)
- [x] Manual testing: background app for 30s+, reopen — channels stay visible with brief "Reconnecting…" banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)