### PR TITLE
feat(desktop): add message more-actions dropdown menu

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -561,6 +561,7 @@ export function AppShell() {
         <AppShellProvider
           value={{
             markChannelRead,
+            markChannelUnread,
             openChannelManagement: () => {
               setIsChannelManagementOpen(true);
             },

--- a/desktop/src/app/AppShellContext.tsx
+++ b/desktop/src/app/AppShellContext.tsx
@@ -5,11 +5,16 @@ type AppShellContextValue = {
     channelId: string,
     readAt: string | null | undefined,
   ) => void;
+  markChannelUnread: (
+    channelId: string,
+    lastMessageAt: string | null | undefined,
+  ) => void;
   openChannelManagement: () => void;
 };
 
 const AppShellContext = React.createContext<AppShellContextValue>({
   markChannelRead: () => {},
+  markChannelUnread: () => {},
   openChannelManagement: () => {},
 });
 

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -82,6 +82,7 @@ type ChannelPaneProps = {
   onDelete?: (message: TimelineMessage) => void;
   onEdit?: (message: TimelineMessage) => void;
   onEditSave?: (content: string) => Promise<void>;
+  onMarkUnread?: (message: TimelineMessage) => void;
   onExpandThreadReplies: (message: TimelineMessage) => void;
   onJoinChannel?: () => Promise<void>;
   onOpenAgentSession: (pubkey: string) => void;
@@ -144,6 +145,7 @@ export const ChannelPane = React.memo(function ChannelPane({
   onDelete,
   onEdit,
   onEditSave,
+  onMarkUnread,
   onExpandThreadReplies,
   onJoinChannel,
   onOpenAgentSession,
@@ -339,6 +341,7 @@ export const ChannelPane = React.memo(function ChannelPane({
           messages={messages}
           onDelete={onDelete}
           onEdit={onEdit}
+          onMarkUnread={onMarkUnread}
           onReply={activeChannel?.archivedAt ? undefined : onOpenThread}
           onTargetReached={onTargetReached}
           onToggleReaction={onToggleReaction}
@@ -444,6 +447,7 @@ export const ChannelPane = React.memo(function ChannelPane({
           onDelete={onDelete}
           onEdit={onEdit}
           onEditSave={onEditSave}
+          onMarkUnread={onMarkUnread}
           onExpandReplies={onExpandThreadReplies}
           onSelectReplyTarget={onSelectThreadReplyTarget}
           onSend={onSendThreadReply}

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -33,6 +33,7 @@ import {
   formatTimelineMessages,
 } from "@/features/messages/lib/formatTimelineMessages";
 import { buildThreadPanelData } from "@/features/messages/lib/threadPanel";
+import type { TimelineMessage } from "@/features/messages/types";
 import { useFetchOlderMessages } from "@/features/messages/useFetchOlderMessages";
 import { useLoadMissingAncestors } from "@/features/messages/useLoadMissingAncestors";
 import { useChannelTyping } from "@/features/messages/useChannelTyping";
@@ -78,7 +79,8 @@ export function ChannelScreen({
   targetMessageEvent,
   targetMessageId,
 }: ChannelScreenProps) {
-  const { markChannelRead, openChannelManagement } = useAppShell();
+  const { markChannelRead, markChannelUnread, openChannelManagement } =
+    useAppShell();
   const [profilePanelPubkey, setProfilePanelPubkey] = React.useState<
     string | null
   >(null);
@@ -330,6 +332,16 @@ export function ChannelScreen({
         : undefined,
     [activeChannel, handleToggleReaction],
   );
+
+  const handleMarkUnread = React.useCallback(
+    (message: TimelineMessage) => {
+      if (!activeChannelId) return;
+      const messageIso = new Date(message.createdAt * 1_000).toISOString();
+      markChannelUnread(activeChannelId, messageIso);
+    },
+    [activeChannelId, markChannelUnread],
+  );
+
   const {
     channelAgentSessionAgents,
     closeAgentSession: handleCloseAgentSession,
@@ -477,6 +489,7 @@ export function ChannelScreen({
                   onEditSave={
                     activeChannel?.archivedAt ? undefined : handleEditSave
                   }
+                  onMarkUnread={handleMarkUnread}
                   onExpandThreadReplies={handleExpandThreadReplies}
                   onOpenAgentSession={handleOpenAgentSession}
                   onOpenDm={handleOpenDm}

--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -1,7 +1,17 @@
 import Picker from "@emoji-mart/react";
 import data from "@emoji-mart/data";
-import { CornerUpLeft, Pencil, SmilePlus, Trash2 } from "lucide-react";
+import {
+  Copy,
+  CornerUpLeft,
+  EllipsisVertical,
+  Link,
+  MailOpen,
+  Pencil,
+  SmilePlus,
+  Trash2,
+} from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 
 import type {
   TimelineMessage,
@@ -19,15 +29,24 @@ import {
   AlertDialogTitle,
 } from "@/shared/ui/alert-dialog";
 import { Button } from "@/shared/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 export function MessageActionBar({
   activeReplyTargetId = null,
+  channelId,
   message,
   onDelete,
   onEdit,
+  onMarkUnread,
   onReactionSelect,
   onReply,
   reactionErrorMessage = null,
@@ -35,9 +54,11 @@ export function MessageActionBar({
   reactionPending = false,
 }: {
   activeReplyTargetId?: string | null;
+  channelId?: string | null;
   message: TimelineMessage;
   onDelete?: (message: TimelineMessage) => void;
   onEdit?: (message: TimelineMessage) => void;
+  onMarkUnread?: (message: TimelineMessage) => void;
   onReactionSelect?: (emoji: string) => Promise<void>;
   onReply?: (message: TimelineMessage) => void;
   reactionErrorMessage?: string | null;
@@ -46,17 +67,19 @@ export function MessageActionBar({
 }) {
   const [isReactionPickerOpen, setIsReactionPickerOpen] = React.useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
   const hasDeleteAction = Boolean(onDelete);
   const hasEditAction = Boolean(onEdit);
   const hasReplyAction = Boolean(onReply);
   const hasReactionAction = Boolean(onReactionSelect);
+  const hasMarkUnreadAction = Boolean(onMarkUnread);
 
-  if (
-    !hasReplyAction &&
-    !hasReactionAction &&
-    !hasEditAction &&
-    !hasDeleteAction
-  ) {
+  // Copy Link and Copy Text are always available for non-pending messages
+  const hasCopyActions = !message.pending;
+  const hasMoreMenuActions =
+    hasEditAction || hasDeleteAction || hasMarkUnreadAction || hasCopyActions;
+
+  if (!hasReplyAction && !hasReactionAction && !hasMoreMenuActions) {
     return null;
   }
 
@@ -65,6 +88,29 @@ export function MessageActionBar({
     (reaction) => reaction.reactedByCurrentUser,
   ).length;
 
+  const handleCopyLink = () => {
+    const link = `${window.location.origin}/#/channels/${channelId}?messageId=${message.id}`;
+    void navigator.clipboard
+      .writeText(link)
+      .then(() => {
+        toast.success("Link copied to clipboard");
+      })
+      .catch(() => {
+        toast.error("Failed to copy link");
+      });
+  };
+
+  const handleCopyText = () => {
+    void navigator.clipboard
+      .writeText(message.body)
+      .then(() => {
+        toast.success("Message copied to clipboard");
+      })
+      .catch(() => {
+        toast.error("Failed to copy message");
+      });
+  };
+
   return (
     <div
       className={cn(
@@ -72,7 +118,7 @@ export function MessageActionBar({
         "translate-y-0 opacity-100 sm:max-w-0 sm:border-0 sm:shadow-none sm:translate-y-1 sm:opacity-0",
         "sm:group-hover/message:max-w-36 sm:group-hover/message:border sm:group-hover/message:border-border/70 sm:group-hover/message:shadow-sm sm:group-hover/message:translate-y-0 sm:group-hover/message:opacity-100",
         "sm:group-focus-within/message:max-w-36 sm:group-focus-within/message:border sm:group-focus-within/message:border-border/70 sm:group-focus-within/message:shadow-sm sm:group-focus-within/message:translate-y-0 sm:group-focus-within/message:opacity-100",
-        isReplyingToMessage || isReactionPickerOpen
+        isReplyingToMessage || isReactionPickerOpen || isDropdownOpen
           ? "sm:max-w-36 sm:border sm:border-border/70 sm:shadow-sm sm:translate-y-0 sm:opacity-100"
           : "",
       )}
@@ -145,81 +191,6 @@ export function MessageActionBar({
           </Popover>
         ) : null}
 
-        {hasEditAction ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label="Edit"
-                className="h-6 w-6 rounded-full p-0"
-                data-testid={`edit-message-${message.id}`}
-                onClick={() => {
-                  onEdit?.(message);
-                }}
-                size="sm"
-                type="button"
-                variant="ghost"
-              >
-                <Pencil className="h-3 w-3" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Edit</TooltipContent>
-          </Tooltip>
-        ) : null}
-
-        {hasDeleteAction ? (
-          <>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  aria-label="Delete"
-                  className="h-6 w-6 rounded-full p-0"
-                  data-testid={`delete-message-${message.id}`}
-                  onClick={() => {
-                    setIsDeleteDialogOpen(true);
-                  }}
-                  size="sm"
-                  type="button"
-                  variant="ghost"
-                >
-                  <Trash2 className="h-3 w-3" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Delete</TooltipContent>
-            </Tooltip>
-
-            <AlertDialog
-              onOpenChange={setIsDeleteDialogOpen}
-              open={isDeleteDialogOpen}
-            >
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete message?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will permanently delete this message and cannot be
-                    undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel asChild>
-                    <Button type="button" variant="outline">
-                      Cancel
-                    </Button>
-                  </AlertDialogCancel>
-                  <AlertDialogAction asChild>
-                    <Button
-                      onClick={() => onDelete?.(message)}
-                      type="button"
-                      variant="destructive"
-                    >
-                      Delete
-                    </Button>
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </>
-        ) : null}
-
         {hasReplyAction ? (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -242,7 +213,115 @@ export function MessageActionBar({
             </TooltipContent>
           </Tooltip>
         ) : null}
+
+        {hasMoreMenuActions ? (
+          <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    aria-label="More actions"
+                    className="h-6 w-6 rounded-full p-0"
+                    data-testid={`more-actions-${message.id}`}
+                    size="sm"
+                    type="button"
+                    variant={isDropdownOpen ? "secondary" : "ghost"}
+                  >
+                    <EllipsisVertical className="h-3 w-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>More actions</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end" side="top" sideOffset={6}>
+              {hasEditAction ? (
+                <DropdownMenuItem
+                  data-testid={`edit-message-${message.id}`}
+                  onClick={() => {
+                    onEdit?.(message);
+                  }}
+                >
+                  <Pencil className="h-4 w-4" />
+                  Edit message
+                </DropdownMenuItem>
+              ) : null}
+
+              {hasMarkUnreadAction ? (
+                <DropdownMenuItem
+                  onClick={() => {
+                    onMarkUnread?.(message);
+                  }}
+                >
+                  <MailOpen className="h-4 w-4" />
+                  Mark unread
+                </DropdownMenuItem>
+              ) : null}
+
+              {hasCopyActions && channelId ? (
+                <DropdownMenuItem onClick={handleCopyLink}>
+                  <Link className="h-4 w-4" />
+                  Copy link
+                </DropdownMenuItem>
+              ) : null}
+
+              {hasCopyActions ? (
+                <DropdownMenuItem onClick={handleCopyText}>
+                  <Copy className="h-4 w-4" />
+                  Copy message
+                </DropdownMenuItem>
+              ) : null}
+
+              {hasDeleteAction ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    data-testid={`delete-message-${message.id}`}
+                    onClick={() => {
+                      setIsDeleteDialogOpen(true);
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    Delete message
+                  </DropdownMenuItem>
+                </>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
       </div>
+
+      {hasDeleteAction ? (
+        <AlertDialog
+          onOpenChange={setIsDeleteDialogOpen}
+          open={isDeleteDialogOpen}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete message?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will permanently delete this message and cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </AlertDialogCancel>
+              <AlertDialogAction asChild>
+                <Button
+                  onClick={() => onDelete?.(message)}
+                  type="button"
+                  variant="destructive"
+                >
+                  Delete
+                </Button>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -4,7 +4,6 @@ import {
   Copy,
   CornerUpLeft,
   EllipsisVertical,
-  Link,
   MailOpen,
   Pencil,
   SmilePlus,
@@ -40,9 +39,154 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
+function copyToClipboard(text: string, successMessage: string) {
+  void navigator.clipboard
+    .writeText(text)
+    .then(() => {
+      toast.success(successMessage);
+    })
+    .catch(() => {
+      toast.error("Failed to copy to clipboard");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// MoreActionsMenu — dropdown with edit, mark unread, copy, and delete actions
+// ---------------------------------------------------------------------------
+
+function MoreActionsMenu({
+  message,
+  onDelete,
+  onEdit,
+  onMarkUnread,
+  onOpenChange,
+  open,
+}: {
+  message: TimelineMessage;
+  onDelete?: (message: TimelineMessage) => void;
+  onEdit?: (message: TimelineMessage) => void;
+  onMarkUnread?: (message: TimelineMessage) => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}) {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
+
+  const hasCopyActions = !message.pending;
+
+  return (
+    <>
+      <DropdownMenu open={open} onOpenChange={onOpenChange}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                aria-label="More actions"
+                className="h-6 w-6 rounded-full p-0"
+                data-testid={`more-actions-${message.id}`}
+                size="sm"
+                type="button"
+                variant={open ? "secondary" : "ghost"}
+              >
+                <EllipsisVertical className="h-3 w-3" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>More actions</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end" side="top" sideOffset={6}>
+          {onEdit ? (
+            <DropdownMenuItem
+              data-testid={`edit-message-${message.id}`}
+              onClick={() => {
+                onEdit(message);
+              }}
+            >
+              <Pencil className="h-4 w-4" />
+              Edit message
+            </DropdownMenuItem>
+          ) : null}
+
+          {onMarkUnread ? (
+            <DropdownMenuItem
+              onClick={() => {
+                onMarkUnread(message);
+              }}
+            >
+              <MailOpen className="h-4 w-4" />
+              Mark unread
+            </DropdownMenuItem>
+          ) : null}
+
+          {hasCopyActions ? (
+            <DropdownMenuItem
+              onClick={() => {
+                copyToClipboard(message.body, "Message copied to clipboard");
+              }}
+            >
+              <Copy className="h-4 w-4" />
+              Copy message
+            </DropdownMenuItem>
+          ) : null}
+
+          {onDelete ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                data-testid={`delete-message-${message.id}`}
+                onClick={() => {
+                  setIsDeleteDialogOpen(true);
+                }}
+              >
+                <Trash2 className="h-4 w-4" />
+                Delete message
+              </DropdownMenuItem>
+            </>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {onDelete ? (
+        <AlertDialog
+          onOpenChange={setIsDeleteDialogOpen}
+          open={isDeleteDialogOpen}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete message?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will permanently delete this message and cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </AlertDialogCancel>
+              <AlertDialogAction asChild>
+                <Button
+                  onClick={() => onDelete(message)}
+                  type="button"
+                  variant="destructive"
+                >
+                  Delete
+                </Button>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : null}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MessageActionBar — reaction picker, reply button, and more-actions menu
+// ---------------------------------------------------------------------------
+
 export function MessageActionBar({
   activeReplyTargetId = null,
-  channelId,
   message,
   onDelete,
   onEdit,
@@ -54,7 +198,6 @@ export function MessageActionBar({
   reactionPending = false,
 }: {
   activeReplyTargetId?: string | null;
-  channelId?: string | null;
   message: TimelineMessage;
   onDelete?: (message: TimelineMessage) => void;
   onEdit?: (message: TimelineMessage) => void;
@@ -66,18 +209,15 @@ export function MessageActionBar({
   reactionPending?: boolean;
 }) {
   const [isReactionPickerOpen, setIsReactionPickerOpen] = React.useState(false);
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
-  const hasDeleteAction = Boolean(onDelete);
-  const hasEditAction = Boolean(onEdit);
   const hasReplyAction = Boolean(onReply);
   const hasReactionAction = Boolean(onReactionSelect);
-  const hasMarkUnreadAction = Boolean(onMarkUnread);
 
-  // Copy Link and Copy Text are always available for non-pending messages
-  const hasCopyActions = !message.pending;
   const hasMoreMenuActions =
-    hasEditAction || hasDeleteAction || hasMarkUnreadAction || hasCopyActions;
+    Boolean(onEdit) ||
+    Boolean(onDelete) ||
+    Boolean(onMarkUnread) ||
+    !message.pending;
 
   if (!hasReplyAction && !hasReactionAction && !hasMoreMenuActions) {
     return null;
@@ -87,29 +227,6 @@ export function MessageActionBar({
   const selectedReactionCount = reactions.filter(
     (reaction) => reaction.reactedByCurrentUser,
   ).length;
-
-  const handleCopyLink = () => {
-    const link = `${window.location.origin}/#/channels/${channelId}?messageId=${message.id}`;
-    void navigator.clipboard
-      .writeText(link)
-      .then(() => {
-        toast.success("Link copied to clipboard");
-      })
-      .catch(() => {
-        toast.error("Failed to copy link");
-      });
-  };
-
-  const handleCopyText = () => {
-    void navigator.clipboard
-      .writeText(message.body)
-      .then(() => {
-        toast.success("Message copied to clipboard");
-      })
-      .catch(() => {
-        toast.error("Failed to copy message");
-      });
-  };
 
   return (
     <div
@@ -215,113 +332,16 @@ export function MessageActionBar({
         ) : null}
 
         {hasMoreMenuActions ? (
-          <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    aria-label="More actions"
-                    className="h-6 w-6 rounded-full p-0"
-                    data-testid={`more-actions-${message.id}`}
-                    size="sm"
-                    type="button"
-                    variant={isDropdownOpen ? "secondary" : "ghost"}
-                  >
-                    <EllipsisVertical className="h-3 w-3" />
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent>More actions</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent align="end" side="top" sideOffset={6}>
-              {hasEditAction ? (
-                <DropdownMenuItem
-                  data-testid={`edit-message-${message.id}`}
-                  onClick={() => {
-                    onEdit?.(message);
-                  }}
-                >
-                  <Pencil className="h-4 w-4" />
-                  Edit message
-                </DropdownMenuItem>
-              ) : null}
-
-              {hasMarkUnreadAction ? (
-                <DropdownMenuItem
-                  onClick={() => {
-                    onMarkUnread?.(message);
-                  }}
-                >
-                  <MailOpen className="h-4 w-4" />
-                  Mark unread
-                </DropdownMenuItem>
-              ) : null}
-
-              {hasCopyActions && channelId ? (
-                <DropdownMenuItem onClick={handleCopyLink}>
-                  <Link className="h-4 w-4" />
-                  Copy link
-                </DropdownMenuItem>
-              ) : null}
-
-              {hasCopyActions ? (
-                <DropdownMenuItem onClick={handleCopyText}>
-                  <Copy className="h-4 w-4" />
-                  Copy message
-                </DropdownMenuItem>
-              ) : null}
-
-              {hasDeleteAction ? (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    className="text-destructive focus:text-destructive"
-                    data-testid={`delete-message-${message.id}`}
-                    onClick={() => {
-                      setIsDeleteDialogOpen(true);
-                    }}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    Delete message
-                  </DropdownMenuItem>
-                </>
-              ) : null}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <MoreActionsMenu
+            message={message}
+            onDelete={onDelete}
+            onEdit={onEdit}
+            onMarkUnread={onMarkUnread}
+            onOpenChange={setIsDropdownOpen}
+            open={isDropdownOpen}
+          />
         ) : null}
       </div>
-
-      {hasDeleteAction ? (
-        <AlertDialog
-          onOpenChange={setIsDeleteDialogOpen}
-          open={isDeleteDialogOpen}
-        >
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Delete message?</AlertDialogTitle>
-              <AlertDialogDescription>
-                This will permanently delete this message and cannot be undone.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel asChild>
-                <Button type="button" variant="outline">
-                  Cancel
-                </Button>
-              </AlertDialogCancel>
-              <AlertDialogAction asChild>
-                <Button
-                  onClick={() => onDelete?.(message)}
-                  type="button"
-                  variant="destructive"
-                >
-                  Delete
-                </Button>
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -27,17 +27,20 @@ export const MessageRow = React.memo(
     message,
     onDelete,
     onEdit,
+    onMarkUnread,
     onToggleReaction,
     onReply,
     profiles,
     searchQuery,
   }: {
     activeReplyTargetId?: string | null;
+    channelId?: string | null;
     highlighted?: boolean;
     layoutVariant?: "default" | "thread-reply";
     message: TimelineMessage;
     onDelete?: (message: TimelineMessage) => void;
     onEdit?: (message: TimelineMessage) => void;
+    onMarkUnread?: (message: TimelineMessage) => void;
     onToggleReaction?: (
       message: TimelineMessage,
       emoji: string,
@@ -184,6 +187,7 @@ export const MessageRow = React.memo(
               message={message}
               onDelete={onDelete}
               onEdit={onEdit}
+              onMarkUnread={onMarkUnread}
               onReactionSelect={
                 canToggleReactions ? handleReactionSelect : undefined
               }

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -35,6 +35,7 @@ type MessageThreadPanelProps = {
   onDelete?: (message: TimelineMessage) => void;
   onEdit?: (message: TimelineMessage) => void;
   onEditSave?: (content: string) => Promise<void>;
+  onMarkUnread?: (message: TimelineMessage) => void;
   onExpandReplies: (message: TimelineMessage) => void;
   onResetWidth: () => void;
   onResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void;
@@ -87,6 +88,7 @@ export function MessageThreadPanel({
   onDelete,
   onEdit,
   onEditSave,
+  onMarkUnread,
   onExpandReplies,
   onResetWidth,
   onResizeStart,
@@ -201,6 +203,7 @@ export function MessageThreadPanel({
               <div className="rounded-2xl">
                 <MessageRow
                   activeReplyTargetId={replyTargetId}
+                  channelId={channelId}
                   layoutVariant="thread-reply"
                   message={threadHead}
                   onDelete={
@@ -213,6 +216,7 @@ export function MessageThreadPanel({
                       ? onEdit
                       : undefined
                   }
+                  onMarkUnread={onMarkUnread}
                   onToggleReaction={onToggleReaction}
                   profiles={profiles}
                 />
@@ -230,6 +234,7 @@ export function MessageThreadPanel({
                       <div key={entry.message.id}>
                         <MessageRow
                           activeReplyTargetId={replyTargetId}
+                          channelId={channelId}
                           layoutVariant="thread-reply"
                           message={entry.message}
                           onDelete={
@@ -244,6 +249,7 @@ export function MessageThreadPanel({
                               ? onEdit
                               : undefined
                           }
+                          onMarkUnread={onMarkUnread}
                           onReply={onSelectReplyTarget}
                           onToggleReaction={onToggleReaction}
                           profiles={profiles}

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -29,6 +29,7 @@ type MessageTimelineProps = {
   profiles?: UserProfileLookup;
   onDelete?: (message: TimelineMessage) => void;
   onEdit?: (message: TimelineMessage) => void;
+  onMarkUnread?: (message: TimelineMessage) => void;
   onReply?: (message: TimelineMessage) => void;
   onToggleReaction?: (
     message: TimelineMessage,
@@ -61,6 +62,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
   profiles,
   onDelete,
   onEdit,
+  onMarkUnread,
   onReply,
   onToggleReaction,
   searchActiveMessageId = null,
@@ -176,12 +178,14 @@ export const MessageTimeline = React.memo(function MessageTimeline({
             {!isLoading && messages.length > 0 ? (
               <TimelineMessageList
                 activeReplyTargetId={activeReplyTargetId}
+                channelId={channelId}
                 currentPubkey={currentPubkey}
                 highlightedMessageId={highlightedMessageId}
                 messageFooters={messageFooters}
                 messages={messages}
                 onDelete={onDelete}
                 onEdit={onEdit}
+                onMarkUnread={onMarkUnread}
                 onReply={onReply}
                 onToggleReaction={onToggleReaction}
                 personaLookup={personaLookup}

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -15,12 +15,14 @@ import { SystemMessageRow } from "./SystemMessageRow";
 
 type TimelineMessageListProps = {
   activeReplyTargetId?: string | null;
+  channelId?: string | null;
   currentPubkey?: string;
   highlightedMessageId?: string | null;
   messageFooters?: Record<string, React.ReactNode>;
   messages: TimelineMessage[];
   onDelete?: (message: TimelineMessage) => void;
   onEdit?: (message: TimelineMessage) => void;
+  onMarkUnread?: (message: TimelineMessage) => void;
   onReply?: (message: TimelineMessage) => void;
   onToggleReaction?: (
     message: TimelineMessage,
@@ -40,12 +42,14 @@ type TimelineMessageListProps = {
 
 export const TimelineMessageList = React.memo(function TimelineMessageList({
   activeReplyTargetId = null,
+  channelId,
   currentPubkey,
   highlightedMessageId = null,
   messageFooters,
   messages,
   onDelete,
   onEdit,
+  onMarkUnread,
   onReply,
   onToggleReaction,
   personaLookup,
@@ -98,6 +102,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
         <div key={message.id} className="flex flex-col gap-0">
           <MessageRow
             activeReplyTargetId={activeReplyTargetId}
+            channelId={channelId}
             highlighted={message.id === highlightedMessageId}
             message={message}
             onDelete={
@@ -110,6 +115,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
                 ? onEdit
                 : undefined
             }
+            onMarkUnread={onMarkUnread}
             onToggleReaction={onToggleReaction}
             onReply={onReply}
             profiles={profiles}
@@ -132,6 +138,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
         <div key={message.id} className="flex flex-col gap-1">
           <MessageRow
             activeReplyTargetId={activeReplyTargetId}
+            channelId={channelId}
             highlighted={message.id === highlightedMessageId || isSearchActive}
             message={message}
             onDelete={
@@ -144,6 +151,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
                 ? onEdit
                 : undefined
             }
+            onMarkUnread={onMarkUnread}
             onToggleReaction={onToggleReaction}
             onReply={onReply}
             profiles={profiles}


### PR DESCRIPTION
## Summary
- Replaces individual edit/delete action buttons with a consolidated "more actions" dropdown menu (⋮) on message hover
- Adds **Mark unread**, **Copy message** actions to the menu
- Removes broken **Copy link** option (was generating web URLs that opened in browser instead of navigating within the app — proper `sprout://` deep link for messages not yet implemented)
- Extracts `MoreActionsMenu` as a dedicated component with its own state management for the delete confirmation dialog

## Test plan
- [ ] Hover over a message → verify ⋮ button appears in the action bar
- [ ] Click ⋮ → verify dropdown shows: Edit message, Mark unread, Copy message, Delete message (for own messages)
- [ ] Click "Copy message" → verify message text is copied to clipboard with success toast
- [ ] Click "Mark unread" → verify channel shows as unread
- [ ] Click "Delete message" → verify confirmation dialog appears and delete works
- [ ] Click "Edit message" → verify inline edit mode activates
- [ ] Verify "Copy link" is no longer present in the menu
- [ ] Verify actions work in thread panel as well as main timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)