### PR TITLE
fix(desktop): stop pinning agents to deprecated SPROUT_ACP_TURN_TIMEOUT

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -559,14 +559,14 @@ pub fn spawn_agent_child(
     if known_acp_provider(&record.agent_command).is_some_and(|p| p.mcp_hooks) {
         command.env("MCP_HOOK_SERVERS", "*");
     }
+    // Only emit SPROUT_ACP_IDLE_TIMEOUT when the user has explicitly set an
+    // override. When unset, the sprout-acp harness applies its own default
+    // (see `DEFAULT_IDLE_TIMEOUT_SECS` in crates/sprout-acp/src/config.rs),
+    // which is the single source of truth. The previously-emitted
+    // `SPROUT_ACP_TURN_TIMEOUT` is deprecated upstream and was pinning every
+    // agent to the desktop's stale default (320s), bypassing harness bumps.
     if let Some(idle) = record.idle_timeout_seconds {
         command.env("SPROUT_ACP_IDLE_TIMEOUT", idle.to_string());
-        command.env("SPROUT_ACP_TURN_TIMEOUT", idle.to_string());
-    } else {
-        command.env(
-            "SPROUT_ACP_TURN_TIMEOUT",
-            record.turn_timeout_seconds.to_string(),
-        );
     }
 
     let max_dur = record

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -386,7 +386,13 @@ pub struct UpdateTeamRequest {
 pub const DEFAULT_ACP_COMMAND: &str = "sprout-acp";
 pub const DEFAULT_AGENT_COMMAND: &str = "goose";
 pub const DEFAULT_MCP_COMMAND: &str = "sprout-mcp-server";
-/// ~5 min (320s) — matches the CLI harness default (SPROUT_ACP_IDLE_TIMEOUT).
+/// Default for the legacy `turn_timeout_seconds` field on the agent record.
+///
+/// As of the deprecation of `SPROUT_ACP_TURN_TIMEOUT` in sprout-acp, this
+/// field is no longer wired into the spawn path — the harness owns the
+/// effective idle-timeout default. The value is kept here only to satisfy
+/// existing persisted records and the `CreateAgentDialog` form state. Prefer
+/// `idle_timeout_seconds` (mapped to `SPROUT_ACP_IDLE_TIMEOUT`) for overrides.
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
 /// 1 hour — absolute wall-clock safety cap per turn.
 pub const DEFAULT_AGENT_MAX_TURN_DURATION_SECONDS: u64 = 3600;


### PR DESCRIPTION
## Why

Desktop-launched agents were being killed at **exactly 320s** even after PR #566 raised the sprout-acp idle-timeout default to 620s. The reason: the desktop spawn path always emitted the *deprecated* `SPROUT_ACP_TURN_TIMEOUT` env var with a hard-coded fallback of 320, which the harness's deprecation handler then used as the effective idle timeout — silently overriding the new default.

## What

In `desktop/src-tauri/src/managed_agents/runtime.rs`, only emit `SPROUT_ACP_IDLE_TIMEOUT` when the agent record has an explicit `idle_timeout_seconds` override. When unset, say nothing and let the harness apply its own `DEFAULT_IDLE_TIMEOUT_SECS` (currently 620s).

Net: **-8 / +3** logic lines, plus a doc-comment refresh on `DEFAULT_AGENT_TURN_TIMEOUT_SECONDS`.

```diff
-    if let Some(idle) = record.idle_timeout_seconds {
-        command.env("SPROUT_ACP_IDLE_TIMEOUT", idle.to_string());
-        command.env("SPROUT_ACP_TURN_TIMEOUT", idle.to_string());
-    } else {
-        command.env(
-            "SPROUT_ACP_TURN_TIMEOUT",
-            record.turn_timeout_seconds.to_string(),
-        );
-    }
+    if let Some(idle) = record.idle_timeout_seconds {
+        command.env("SPROUT_ACP_IDLE_TIMEOUT", idle.to_string());
+    }
```

## Effect

- New desktop-launched agents pick up whatever the harness default is. No more drift between desktop and sprout-acp.
- Agents whose users have customized `idle_timeout_seconds` are unchanged.
- The deprecation warning emitted by sprout-acp when it sees `SPROUT_ACP_TURN_TIMEOUT` will stop appearing in desktop agent logs.

## Notes / Follow-ups

- The legacy `turn_timeout_seconds` field on `ManagedAgentRecord` (and its UI exposure in `CreateAgentDialog` with default "320") is now a dead input on the spawn path. Doc comment on `DEFAULT_AGENT_TURN_TIMEOUT_SECONDS` updated to reflect that. Removing the field entirely is a separate change — touches DB schema migrations + the dialog UI + the e2e bridge.
- No tests assert on env-var emission (grepped); existing `managed_agents` tests pass (115/115).

## Verification

- `cargo build --lib` clean
- `cargo test --lib managed_agents` → 115 passed
- Pre-push lefthook (11 hooks: fmt, check, clippy, tests, tauri-check, web-build, mobile-check, mobile-test, desktop-build) all green