### PR TITLE
feat(desktop): per-persona and per-agent env var overrides

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
         "**/integration.spec.ts",
         "**/profile.spec.ts",
         "**/tokens.spec.ts",
+        "**/persona-env-vars.spec.ts",
       ],
       use: {
         ...devices["Desktop Chrome"],

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -40,7 +40,7 @@ const overrides = new Map([
   ["src/features/channels/ui/ChannelScreen.tsx", 550], // profile panel state + mutual exclusion wiring + ProfilePanelProvider context + agent typing classification
   ["src/features/notifications/hooks.ts", 535], // notification settings + feed notification lifecycle + profile batch resolution + truncated-pubkey guard + badge state
   ["src/features/messages/hooks.ts", 500], // message query/mutation hooks + optimistic updates
-  ["src/features/messages/ui/MessageComposer.tsx", 710], // media upload handlers (paste, drop, dialog) + channelId reset effect + edit mode (pre-fill, save, cancel, escape) + autofocus on mount/channel switch
+  ["src/features/messages/ui/MessageComposer.tsx", 710], // media upload handlers (paste, drop, dialog) + channelId reset effect + edit mode (pre-fill, save, cancel, escape) + composer autofocus (#572)
   ["src/features/settings/ui/SettingsView.tsx", 600],
   ["src/features/sidebar/ui/AppSidebar.tsx", 860], // channels + forums creation forms + Pulse nav
   ["src/shared/api/relayClientSession.ts", 930], // durable websocket session manager with reconnect/replay/recovery state + sendTypingIndicator + fetchChannelHistoryBefore + subscribeToChannelLive (huddle TTS) + subscribeToHuddleEvents (huddle indicator) + disconnect() for workspace switch teardown + fetchEvents/subscribeLive/publishEvent for NIP-RS read state + publishUserStatus/subscribeToUserStatusUpdates (NIP-38)
@@ -50,9 +50,9 @@ const overrides = new Map([
   ["src-tauri/src/commands/agents.rs", 881], // remote agent lifecycle routing (local + provider branches) + scope enforcement + persona pack metadata wiring + mcp_toolsets field + NIP-OA auth_tag in deploy payload
   ["src-tauri/src/commands/messages.rs", 510], // feed multi-query + NIP-50 search + forum thread resolution + thread ref + reactions via REQ
   ["src-tauri/src/nostr_convert.rs", 1150], // 12 Nostr event→model converters (channels, profiles, members, notes, search, agents, relay members) + rank_user_search_results helper for NIP-50 user search + 33 unit tests
-  ["src-tauri/src/managed_agents/runtime.rs", 990], // ... + respond-to gate env (SPROUT_ACP_RESPOND_TO[_ALLOWLIST]) + per-mode env builder + tests
-  ["src-tauri/src/managed_agents/types.rs", 700], // ManagedAgentRecord/Summary + Create/Update request structs + RespondTo enum + validate_respond_to_allowlist + tests
-  ["src-tauri/src/managed_agents/backend.rs", 530], // provider IPC, validation, discovery, binary resolution + tests
+  ["src-tauri/src/managed_agents/runtime.rs", 1110], // ... + respond-to gate env (SPROUT_ACP_RESPOND_TO[_ALLOWLIST]) + per-mode env builder + tests + persona/agent env_vars spawn merge (helper + tests now in env_vars.rs)
+  ["src-tauri/src/managed_agents/types.rs", 715], // ManagedAgentRecord/Summary + Create/Update request structs + RespondTo enum + validate_respond_to_allowlist + tests + persona/agent env_vars field
+  ["src-tauri/src/managed_agents/backend.rs", 700], // provider IPC, validation, discovery, binary resolution + tests + redact_secrets_with for user env values + env_secrets_from_request + redact_env_values_in (shared with model discovery)
   ["src/features/huddle/HuddleContext.tsx", 650], // huddle lifecycle context + joinHuddle + connectAndSetupMedia shared helper + activeSpeakers/isReconnecting state + PTT (reusable AudioContext) + TTS subscription + mic level analyser (10fps throttle) + agent pubkey refresh
   ["src/features/agents/hooks.ts", 540], // agent query/mutation surface now includes built-in persona library activation + useUpdateManagedAgentMutation
   ["src/features/agents/ui/AgentsView.tsx", 880], // remote agent lifecycle controls + persona/team management + persona import-update dialog wiring + built-in catalog/library state orchestration

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -25,7 +25,7 @@ pub async fn get_agent_models(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<AgentModelsResponse, String> {
-    let (resolved_acp, agent_command, agent_args, persisted_model) = {
+    let (resolved_acp, agent_command, agent_args, persisted_model, merged_env) = {
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -53,8 +53,21 @@ pub async fn get_agent_models(
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| record.agent_command.clone());
 
-        (resolved, resolved_agent, args, record.model.clone())
+        // Same env layering as runtime spawn: persona env < agent env.
+        // Model discovery needs the user's credentials. Fail closed on
+        // persona-resolution errors so a corrupt personas.json doesn't
+        // produce a model list as if the persona had no credentials.
+        let persona_env =
+            crate::managed_agents::resolve_persona_env(&app, record.persona_id.as_deref())?;
+        let env = crate::managed_agents::merged_user_env(&persona_env, &record.env_vars);
+
+        (resolved, resolved_agent, args, record.model.clone(), env)
     }; // store lock released — subprocess runs without holding the lock
+
+    // Clone the env map for redaction below — `merged_env` is moved
+    // into the spawn_blocking closure and we still need the values to
+    // scrub any user-supplied secrets that the child surfaces in stderr.
+    let env_for_redaction = merged_env.clone();
 
     // Use spawn_blocking because the desktop Tauri crate doesn't enable
     // tokio's `process` feature. std::process::Command is synchronous
@@ -74,8 +87,12 @@ pub async fn get_agent_models(
             .env(
                 "GOOSE_MODE",
                 std::env::var("GOOSE_MODE").unwrap_or_else(|_| "auto".into()),
-            )
-            .stdout(std::process::Stdio::piped())
+            );
+        // User env layering — written LAST so it overrides any Sprout-set env above.
+        for (k, v) in &merged_env {
+            cmd.env(k, v);
+        }
+        cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .output()
             .map_err(|e| format!("failed to spawn sprout-acp models: {e}"))
@@ -86,8 +103,13 @@ pub async fn get_agent_models(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        // Scrub any user-supplied env values before surfacing stderr to
+        // the frontend — persona/agent env_vars may carry API keys that
+        // a failing child process echoed back.
+        let stderr_redacted =
+            crate::managed_agents::redact_env_values_in(stderr.as_ref(), &env_for_redaction);
         return Err(format!(
-            "sprout-acp models failed (exit {}): {stderr}",
+            "sprout-acp models failed (exit {}): {stderr_redacted}",
             output.status.code().unwrap_or(-1)
         ));
     }
@@ -170,6 +192,10 @@ pub async fn update_managed_agent(
         }
         if let Some(mcp_command) = input.mcp_command {
             record.mcp_command = mcp_command;
+        }
+        if let Some(env_vars) = input.env_vars {
+            crate::managed_agents::validate_user_env_keys(&env_vars)?;
+            record.env_vars = env_vars;
         }
 
         // Inbound author gate: merge patch onto current values, then validate

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -28,8 +28,23 @@ fn workspace_owner_hex(state: &AppState) -> Result<String, String> {
 }
 
 /// Build the standard agent JSON payload for provider deploy calls.
-fn build_deploy_payload(record: &ManagedAgentRecord) -> serde_json::Value {
-    serde_json::json!({
+///
+/// Fails closed if the agent points at a `persona_id` we can't load — persona
+/// env_vars typically hold API credentials, and silently deploying with an
+/// empty map would surface as an opaque 401 from the provider.
+fn build_deploy_payload(
+    app: &AppHandle,
+    record: &ManagedAgentRecord,
+) -> Result<serde_json::Value, String> {
+    // Merge persona env_vars + agent env_vars for provider deploy. Same
+    // precedence as local spawn: persona first, agent overrides last. Without
+    // this, provider-backed agents wouldn't receive credentials saved on the
+    // persona or the agent itself.
+    let persona_env =
+        crate::managed_agents::resolve_persona_env(app, record.persona_id.as_deref())?;
+    let merged_env = crate::managed_agents::merged_user_env(&persona_env, &record.env_vars);
+
+    Ok(serde_json::json!({
         "name": &record.name,
         "relay_url": &record.relay_url,
         "private_key_nsec": &record.private_key_nsec,
@@ -46,7 +61,35 @@ fn build_deploy_payload(record: &ManagedAgentRecord) -> serde_json::Value {
         // to the harness default (`owner-only`) — no protocol break.
         "respond_to": record.respond_to,
         "respond_to_allowlist": &record.respond_to_allowlist,
-    })
+        // Merged persona + agent env vars. Providers that don't read this
+        // field will simply ignore it — no protocol break.
+        "env_vars": merged_env,
+    }))
+}
+
+/// Persist a deploy-preparation error (currently: persona env resolution
+/// failure inside `build_deploy_payload`) into the agent's `last_error`
+/// so a refresh shows the cause. Mirrors what `deploy_to_provider` does
+/// on its own failures — without this, an agent created with an invalid
+/// persona_id would appear as `not_deployed` with no recorded reason.
+fn persist_create_deploy_error(
+    app: &AppHandle,
+    state: &AppState,
+    pubkey: &str,
+    error: &str,
+) -> Result<(), String> {
+    let _store_guard = state
+        .managed_agents_store_lock
+        .lock()
+        .map_err(|e| e.to_string())?;
+    let mut records = load_managed_agents(app)?;
+    let rec = records
+        .iter_mut()
+        .find(|r| r.pubkey == pubkey)
+        .ok_or_else(|| format!("agent {pubkey} not found"))?;
+    rec.last_error = Some(error.to_string());
+    rec.updated_at = now_iso();
+    save_managed_agents(app, &records)
 }
 
 /// Deploy an agent to a provider backend. Resolves the binary, calls deploy via
@@ -162,6 +205,7 @@ pub async fn create_managed_agent(
             return Err("parallelism must be between 1 and 32".to_string());
         }
     }
+    crate::managed_agents::validate_user_env_keys(&input.env_vars)?;
 
     // Validate & normalize the respond-to allowlist BEFORE any side effects.
     // The harness has its own validator (sprout-acp/src/config.rs) but we want
@@ -374,6 +418,7 @@ pub async fn create_managed_agent(
             // NOT the display_name — ACP's resolve_persona_by_name() matches slugs.
             persona_pack_path: pack_metadata.as_ref().map(|(path, _)| path.clone()),
             persona_name_in_pack: pack_metadata.as_ref().map(|(_, name)| name.clone()),
+            env_vars: input.env_vars.clone(),
             created_at: now_iso(),
             updated_at: now_iso(),
             last_started_at: None,
@@ -442,11 +487,31 @@ pub async fn create_managed_agent(
                     .iter()
                     .find(|r| r.pubkey == pubkey)
                     .ok_or_else(|| "agent disappeared".to_string())?;
-                build_deploy_payload(rec)
+                build_deploy_payload(&app, rec)
             };
-            match deploy_to_provider(&app, &state, &pubkey, id, config, agent_json, None).await {
-                Ok(()) => spawn_error,
-                Err(e) => Some(e),
+            // The agent was already persisted in Phase 3 — converting a
+            // persona-resolution failure into `spawn_error` (rather than
+            // unwinding) keeps the record on disk and surfaces the cause
+            // in the agent's last_error / UI status. We persist the same
+            // error string into `last_error` so a refresh after restart
+            // still shows *why* deploy never happened, matching what
+            // `deploy_to_provider` does on its own failures.
+            match agent_json {
+                Err(e) => {
+                    if let Err(persist_err) = persist_create_deploy_error(&app, &state, &pubkey, &e)
+                    {
+                        eprintln!(
+                            "sprout-desktop: failed to persist deploy-prep error for {pubkey}: {persist_err}"
+                        );
+                    }
+                    Some(e)
+                }
+                Ok(json) => {
+                    match deploy_to_provider(&app, &state, &pubkey, id, config, json, None).await {
+                        Ok(()) => spawn_error,
+                        Err(e) => Some(e),
+                    }
+                }
             }
         } else {
             spawn_error
@@ -521,7 +586,7 @@ pub async fn start_managed_agent(
             return build_managed_agent_summary(&app, record, &runtimes);
         }
 
-        let payload = build_deploy_payload(record);
+        let payload = build_deploy_payload(&app, record)?;
         (
             record.backend.clone(),
             record.provider_binary_path.clone(),

--- a/desktop/src-tauri/src/commands/personas.rs
+++ b/desktop/src-tauri/src/commands/personas.rs
@@ -66,6 +66,7 @@ pub fn create_persona(
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .collect();
+    crate::managed_agents::validate_user_env_keys(&input.env_vars)?;
     let persona = PersonaRecord {
         id: Uuid::new_v4().to_string(),
         display_name,
@@ -78,6 +79,7 @@ pub fn create_persona(
         is_active: true,
         source_pack: None,
         source_pack_persona_slug: None,
+        env_vars: input.env_vars,
         created_at: now.clone(),
         updated_at: now,
     };
@@ -122,6 +124,13 @@ pub fn update_persona(
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .collect();
+    if let Some(env_vars) = input.env_vars {
+        // Caller explicitly sent env_vars — replace entirely (empty = clear).
+        crate::managed_agents::validate_user_env_keys(&env_vars)?;
+        persona.env_vars = env_vars;
+    }
+    // Absent env_vars means "don't touch" — preserve existing creds when
+    // the caller only meant to edit a different field.
     persona.updated_at = now_iso();
 
     save_personas(&app, &personas)?;
@@ -318,6 +327,12 @@ pub async fn export_persona_to_json(
     state: State<'_, AppState>,
 ) -> Result<bool, String> {
     // Load persona data under lock, then drop lock before dialog.
+    //
+    // NOTE: `env_vars` are deliberately NOT included in the exported card.
+    // Persona cards are designed to be shareable artifacts (uploaded,
+    // forked, distributed), and bundling API keys / credentials in them
+    // would be a significant footgun. Users who import a card and need
+    // credentials must supply them post-import via the persona dialog.
     let (display_name, system_prompt, avatar_url, provider, model, name_pool) = {
         let _store_guard = state
             .managed_agents_store_lock

--- a/desktop/src-tauri/src/managed_agents/backend.rs
+++ b/desktop/src-tauri/src/managed_agents/backend.rs
@@ -179,7 +179,9 @@ pub fn invoke_provider(
     stdout_buf.truncate(STDOUT_CAP);
 
     let stderr = String::from_utf8_lossy(&stderr_bytes);
-    let stderr_redacted = redact_secrets(&stderr);
+    let env_secrets = env_secrets_from_request(request);
+    let env_secret_refs: Vec<&str> = env_secrets.iter().map(String::as_str).collect();
+    let stderr_redacted = redact_secrets_with(&stderr, &env_secret_refs);
 
     let exit_info = exit_status
         .code()
@@ -222,7 +224,7 @@ pub fn invoke_provider(
 
     if response.get("ok").and_then(|v| v.as_bool()) == Some(false) {
         let error = response["error"].as_str().unwrap_or("unknown error");
-        return Err(redact_secrets(error));
+        return Err(redact_secrets_with(error, &env_secret_refs));
     }
 
     Ok(response)
@@ -267,8 +269,43 @@ fn split_config_key(key: &str) -> Vec<String> {
     words
 }
 
+#[cfg(test)]
 fn redact_secrets(s: &str) -> String {
+    redact_secrets_with(s, &[])
+}
+
+/// Like the (test-only) prefix-only `redact_secrets`, but also redacts
+/// every occurrence of each
+/// `extras` entry verbatim. Used to scrub user-supplied env values out of
+/// provider stderr/JSON-error text — providers may echo their request
+/// back in failure messages, and persona/agent `env_vars` may carry API
+/// keys that the desktop just persisted via `last_error`.
+///
+/// Entries shorter than 4 chars are skipped: too noisy to scrub blindly
+/// (would match every short token in normal log output). Entries are
+/// applied in decreasing length order so superstrings get scrubbed before
+/// substrings — protects against partial overlap leaks.
+fn redact_secrets_with(s: &str, extras: &[&str]) -> String {
     let mut result = s.to_string();
+
+    // Extras: longest first to avoid partial-overlap leaks. We use
+    // `str::replace` (single-pass, non-overlapping) instead of a `find` +
+    // `replace_range` loop — the loop variant would never terminate if a
+    // user-supplied env value happened to be a substring of the
+    // replacement marker (e.g. value="REDACTED" or "EDACTE").
+    let mut sorted: Vec<&str> = extras.iter().copied().filter(|v| v.len() >= 4).collect();
+    sorted.sort_by_key(|v| std::cmp::Reverse(v.len()));
+    sorted.dedup();
+    for value in sorted {
+        if !value.is_empty() {
+            result = result.replace(value, "[REDACTED]");
+        }
+    }
+
+    // Then prefix-based scrubbing. This loop *can* re-scan because each
+    // replacement shortens the buffer past the matched prefix — the
+    // replacement marker `[REDACTED]` does not contain `nsec1` or
+    // `sprt_tok_`, so progress is guaranteed.
     for prefix in &["nsec1", "sprt_tok_"] {
         while let Some(pos) = result.find(prefix) {
             let end = result[pos..]
@@ -279,6 +316,41 @@ fn redact_secrets(s: &str) -> String {
         }
     }
     result
+}
+
+/// Collect string values from `request["agent"]["env_vars"]` (if present)
+/// to feed into [`redact_secrets_with`]. Returns an empty Vec if the
+/// request shape doesn't match, which is fine — falls back to the default
+/// prefix-based scrubbing.
+fn env_secrets_from_request(request: &serde_json::Value) -> Vec<String> {
+    request
+        .get("agent")
+        .and_then(|a| a.get("env_vars"))
+        .and_then(|e| e.as_object())
+        .map(|obj| {
+            obj.values()
+                .filter_map(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Public-in-crate helper: redact every non-empty value from `env` (plus
+/// the standard nsec/sprt_tok prefix scrubbing) out of `s`. Used by
+/// callers that already have a flat env map handy — e.g. model discovery
+/// formatting child stderr into a frontend-visible error.
+pub(crate) fn redact_env_values_in(
+    s: &str,
+    env: &std::collections::BTreeMap<String, String>,
+) -> String {
+    let values: Vec<&str> = env
+        .values()
+        .filter(|v| !v.is_empty())
+        .map(String::as_str)
+        .collect();
+    redact_secrets_with(s, &values)
 }
 
 /// Deploy an agent via provider binary. Returns the provider-assigned agent_id.
@@ -441,6 +513,86 @@ mod tests {
         let r = redact_secrets(s);
         assert!(r.contains("[REDACTED]"));
         assert!(!r.contains("sprt_tok_xyz789"));
+    }
+
+    #[test]
+    fn redact_secrets_with_extras_scrubs_user_env_values() {
+        // If a provider echoes back a user-supplied API key in its error
+        // output, the desktop must not surface that secret unredacted via
+        // `last_error`. We scrub the literal values that came from the
+        // request's `agent.env_vars`.
+        let secret = "sk-ant-api03-abc123def456";
+        let stderr = format!("auth failed with key {secret} on host api.anthropic.com");
+        let r = redact_secrets_with(&stderr, &[secret]);
+        assert!(r.contains("[REDACTED]"));
+        assert!(!r.contains(secret));
+    }
+
+    #[test]
+    fn redact_secrets_with_extras_skips_short_values() {
+        // Don't scrub values shorter than 4 chars — too noisy.
+        let r = redact_secrets_with("error code: 42", &["42"]);
+        assert!(r.contains("42"));
+    }
+
+    #[test]
+    fn redact_secrets_with_extras_terminates_when_value_substring_of_marker() {
+        // Regression: an earlier impl used `while let Some(pos) = find(value)`
+        // which never terminates if the user's env value is a substring of
+        // the replacement marker `[REDACTED]` — each replacement
+        // reintroduces the same text. Now uses `str::replace` (single-pass).
+        for value in ["REDACTED", "EDACTE", "REDA", "ACTED"] {
+            let r = redact_secrets_with(&format!("leak={value}"), &[value]);
+            assert!(r.contains("[REDACTED]"));
+        }
+    }
+
+    #[test]
+    fn redact_secrets_with_extras_handles_overlapping_secrets() {
+        // Longer entries get scrubbed first so the substring "abc12" isn't
+        // matched before "abc123" is consumed.
+        let s = "key1=abc123 key2=abc12";
+        let r = redact_secrets_with(s, &["abc12", "abc123"]);
+        assert!(!r.contains("abc123"));
+        assert!(!r.contains("abc12 "));
+    }
+
+    #[test]
+    fn env_secrets_from_request_extracts_string_values() {
+        let req = serde_json::json!({
+            "op": "deploy",
+            "agent": {
+                "env_vars": {
+                    "ANTHROPIC_API_KEY": "sk-ant-test",
+                    "EMPTY": "",
+                    "NUMERIC": 42,
+                },
+            },
+        });
+        let secrets = env_secrets_from_request(&req);
+        assert!(secrets.iter().any(|v| v == "sk-ant-test"));
+        // Empty and non-string values are filtered out.
+        assert_eq!(secrets.len(), 1);
+    }
+
+    #[test]
+    fn env_secrets_from_request_handles_missing_shape() {
+        assert!(env_secrets_from_request(&serde_json::json!({})).is_empty());
+        assert!(env_secrets_from_request(&serde_json::json!({"agent": {}})).is_empty());
+        assert!(
+            env_secrets_from_request(&serde_json::json!({"agent": {"env_vars": null}})).is_empty()
+        );
+    }
+
+    #[test]
+    fn redact_env_values_in_scrubs_map_values() {
+        let mut env = std::collections::BTreeMap::new();
+        env.insert("ANTHROPIC_API_KEY".to_string(), "sk-ant-real".to_string());
+        env.insert("EMPTY".to_string(), String::new());
+        let stderr = "auth=sk-ant-real failed; other context";
+        let r = redact_env_values_in(stderr, &env);
+        assert!(!r.contains("sk-ant-real"));
+        assert!(r.contains("[REDACTED]"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -1,0 +1,290 @@
+//! Per-persona and per-agent env var overrides.
+//!
+//! Personas and managed agents can each carry a `BTreeMap<String, String>`
+//! of env vars that get layered into the spawned agent's environment.
+//! Precedence: desktop parent env < persona env < agent env (last wins on
+//! key collision). See `runtime::spawn_agent_child`.
+//!
+//! A small set of *reserved* keys — Sprout's identity and secrets — are
+//! rejected at save time and stripped at runtime so a typo or malicious
+//! value can't swap the agent's nsec. Behavior knobs (GOOSE_MODE,
+//! SPROUT_TOOLSETS, SPROUT_ACP_MODEL, SPROUT_ACP_SYSTEM_PROMPT, …) remain
+//! freely overridable — those have dedicated UI fields, but power users
+//! may want to bypass them.
+
+use std::collections::BTreeMap;
+
+/// Env var keys that Sprout sets itself and users must not override from
+/// the persona/agent env_vars UI. Three categories:
+///
+/// 1. **Identity / secrets** — overriding would swap the agent's nsec or
+///    leak credentials.
+/// 2. **Code-execution surface** — overriding the binary/args lets the
+///    user run arbitrary code as the agent process.
+/// 3. **Security gates** — overriding the respond-to mode/allowlist or
+///    relay URL would silently break the saved security settings (the UI
+///    shows owner-only while the running agent answers anyone, for
+///    example), or redirect the agent to an attacker-controlled relay.
+///
+/// This list is deliberately narrow — it only covers keys with security
+/// implications. Behavior knobs (GOOSE_MODE, SPROUT_TOOLSETS,
+/// SPROUT_ACP_MODEL, SPROUT_ACP_SYSTEM_PROMPT, …) remain freely
+/// overridable; those have dedicated UI fields but power users may want
+/// to bypass them.
+pub(crate) const RESERVED_ENV_KEYS: &[&str] = &[
+    // Identity / secrets.
+    "SPROUT_PRIVATE_KEY",
+    "NOSTR_PRIVATE_KEY",
+    "SPROUT_AUTH_TAG",
+    "SPROUT_API_TOKEN",
+    "SPROUT_ACP_PRIVATE_KEY",
+    "SPROUT_ACP_API_TOKEN",
+    // Relay URL: overriding would let a malicious config redirect the
+    // agent to an attacker-controlled relay.
+    "SPROUT_RELAY_URL",
+    // Code-execution surface: overriding would let the user run arbitrary
+    // binaries/args as the agent process.
+    "SPROUT_ACP_AGENT_COMMAND",
+    "SPROUT_ACP_AGENT_ARGS",
+    "SPROUT_ACP_MCP_COMMAND",
+    // Security gates: respond-to mode + allowlist + legacy owner-only
+    // fallback. Overriding would make the running agent's gate diverge
+    // from the saved/UI-visible settings.
+    "SPROUT_ACP_RESPOND_TO",
+    "SPROUT_ACP_RESPOND_TO_ALLOWLIST",
+    "SPROUT_ACP_AGENT_OWNER",
+];
+
+pub(crate) fn is_reserved_env_key(key: &str) -> bool {
+    RESERVED_ENV_KEYS
+        .iter()
+        .any(|reserved| reserved.eq_ignore_ascii_case(key))
+}
+
+/// Returns true if `key` is a well-formed POSIX-shaped env var name:
+/// `[A-Za-z_][A-Za-z0-9_]*`. This is a hard requirement, not a stylistic
+/// nit: Rust's `Command::env` will happily accept a key containing `=`
+/// or whitespace and pass it straight into the child's environ block,
+/// where `getenv("FOO")` then matches whatever comes after the first
+/// `=`. That means a key like `SPROUT_AUTH_TAG=x` with value `forged`
+/// lands as `SPROUT_AUTH_TAG=x=forged` in the child env and
+/// `getenv("SPROUT_AUTH_TAG")` returns `"x=forged"` — a full reserved-
+/// key bypass. Rejecting non-POSIX keys closes this hole at the
+/// boundary where the input enters the system.
+pub(crate) fn is_well_formed_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c == '_' || c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+/// Render a malformed env-var key for inclusion in user-visible errors
+/// and logs without leaking values.
+///
+/// A common slip is pasting a full `.env` line into the key field —
+/// `ANTHROPIC_API_KEY=sk-...`. The reserved-key validator rejects it
+/// (good), but echoing the whole key back in an error or log would surface
+/// the secret. This helper:
+///
+/// - Truncates at the first `=` (the value lives after).
+/// - Replaces ASCII control bytes with `?` so a NUL or newline can't
+///   corrupt the log line.
+/// - Caps the displayed length at 64 characters.
+///
+/// The result is purely cosmetic — the on-disk record still carries the
+/// original key, and the runtime filter still drops it.
+pub(crate) fn display_invalid_key(key: &str) -> String {
+    const MAX: usize = 64;
+    let truncated_at_eq: String = key.chars().take_while(|c| *c != '=').collect();
+    let sanitized: String = truncated_at_eq
+        .chars()
+        .map(|c| if c.is_control() { '?' } else { c })
+        .collect();
+    if sanitized.chars().count() > MAX {
+        let head: String = sanitized.chars().take(MAX).collect();
+        format!("{head}…")
+    } else if sanitized.len() < truncated_at_eq.len() || truncated_at_eq.len() < key.len() {
+        // We dropped *something* — make it obvious to the reader.
+        format!("{sanitized}…")
+    } else {
+        sanitized
+    }
+}
+
+/// Validate user-supplied env var keys at save time. Returns an error
+/// listing problems so the GUI can surface them in one go.
+///
+/// Rules:
+/// - Keys must match `[A-Za-z_][A-Za-z0-9_]*` (POSIX-ish). This rejects
+///   empty keys, keys containing `=` (reserved-key bypass — see
+///   [`is_well_formed_env_key`]), whitespace, NULs, and leading digits.
+/// - Keys (case-insensitive) must not appear in [`RESERVED_ENV_KEYS`].
+/// - Values must not contain interior NULs (Rust's `Command::env` panics
+///   on NUL bytes) and must be under [`MAX_ENV_VALUE_BYTES`]. The total
+///   payload (sum of key + value bytes) is capped at
+///   [`MAX_ENV_TOTAL_BYTES`] so a malformed IPC caller can't bloat the
+///   persona/agent record file.
+pub fn validate_user_env_keys(env_vars: &BTreeMap<String, String>) -> Result<(), String> {
+    let mut malformed: Vec<&str> = env_vars
+        .keys()
+        .filter(|k| !is_well_formed_env_key(k))
+        .map(String::as_str)
+        .collect();
+    malformed.sort_unstable();
+    malformed.dedup();
+    if !malformed.is_empty() {
+        let pretty: Vec<String> = malformed
+            .iter()
+            .map(|k| {
+                if k.is_empty() {
+                    "(empty)".to_string()
+                } else {
+                    format!("\"{}\"", display_invalid_key(k))
+                }
+            })
+            .collect();
+        return Err(format!(
+            "env var keys must match [A-Za-z_][A-Za-z0-9_]*; invalid: {}",
+            pretty.join(", ")
+        ));
+    }
+    let mut reserved: Vec<&str> = env_vars
+        .keys()
+        .filter(|k| is_reserved_env_key(k))
+        .map(String::as_str)
+        .collect();
+    reserved.sort_unstable();
+    reserved.dedup();
+    if !reserved.is_empty() {
+        return Err(format!(
+            "the following env vars are reserved by Sprout and cannot be overridden: {}",
+            reserved.join(", ")
+        ));
+    }
+    // Value validation. Keep these errors *generic* — values frequently
+    // contain secrets and we'd rather not surface even a truncated view.
+    let mut total: usize = 0;
+    for (k, v) in env_vars {
+        if v.contains('\0') {
+            return Err(format!("env var `{k}`: values cannot contain NUL bytes"));
+        }
+        if v.len() > MAX_ENV_VALUE_BYTES {
+            return Err(format!(
+                "env var `{k}`: value is {} bytes; per-value limit is {MAX_ENV_VALUE_BYTES}",
+                v.len()
+            ));
+        }
+        total = total.saturating_add(k.len()).saturating_add(v.len());
+    }
+    if total > MAX_ENV_TOTAL_BYTES {
+        return Err(format!(
+            "total env var payload is {total} bytes; limit is {MAX_ENV_TOTAL_BYTES}"
+        ));
+    }
+    Ok(())
+}
+
+/// Per-value byte cap for env values. 32 KiB is generous for credentials,
+/// JWT-ish tokens, certs etc., but small enough that a malformed IPC
+/// caller can't blow up the persona/agent JSON file. Tune up if real
+/// users hit it.
+pub(crate) const MAX_ENV_VALUE_BYTES: usize = 32 * 1024;
+
+/// Total payload cap across all keys + values in a single persona/agent
+/// env_vars map. Sized for ~32 entries at the per-value cap with plenty
+/// of slack. Mostly a guard against unbounded growth via a buggy or
+/// malicious IPC caller.
+pub(crate) const MAX_ENV_TOTAL_BYTES: usize = 256 * 1024;
+
+/// Merge persona env vars and per-agent env vars.
+///
+/// Precedence: persona env first, then agent overrides, last-wins on key
+/// collision. Returns a `BTreeMap` so the caller can iterate in stable
+/// order (the order is irrelevant for `Command::env` but useful for test
+/// assertions and future logging).
+///
+/// Reserved keys are silently stripped — see [`RESERVED_ENV_KEYS`].
+/// Save-time validation (see [`validate_user_env_keys`]) rejects them up
+/// front so this filter is defense-in-depth for older on-disk records.
+pub(crate) fn merged_user_env(
+    persona_env: &BTreeMap<String, String>,
+    agent_env: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut merged = persona_env.clone();
+    for (k, v) in agent_env {
+        merged.insert(k.clone(), v.clone());
+    }
+    merged.retain(|k, v| {
+        if is_reserved_env_key(k) {
+            eprintln!(
+                "sprout-desktop: ignoring reserved env var `{k}` from persona/agent overrides"
+            );
+            return false;
+        }
+        if !is_well_formed_env_key(k) {
+            // Defense in depth: drop malformed keys at spawn time so older
+            // on-disk records (saved before the tightened validator) can't
+            // smuggle a reserved key past us via `=`-in-key tricks. See
+            // `is_well_formed_env_key` for the exploit.
+            eprintln!(
+                "sprout-desktop: ignoring malformed env var key `{}` from persona/agent overrides",
+                display_invalid_key(k)
+            );
+            return false;
+        }
+        if v.contains('\0') {
+            // `Command::env` panics on interior NULs. Older records may
+            // have escaped the value validator; drop them here rather
+            // than crash the spawn. We deliberately do NOT log the value.
+            eprintln!(
+                "sprout-desktop: ignoring env var `{k}` with NUL byte in value"
+            );
+            return false;
+        }
+        if v.len() > MAX_ENV_VALUE_BYTES {
+            eprintln!(
+                "sprout-desktop: ignoring env var `{k}` with oversize value ({} bytes > {MAX_ENV_VALUE_BYTES})",
+                v.len()
+            );
+            return false;
+        }
+        true
+    });
+    merged
+}
+
+/// Resolve a managed-agent record's persona env_vars, failing closed.
+///
+/// Three outcomes:
+/// - `persona_id` is `None` → returns `Ok({})` (agent has no persona, no env to inherit).
+/// - `persona_id = Some(id)` and the persona exists → returns `Ok(persona.env_vars)`.
+/// - `persona_id = Some(id)` and either personas.json fails to load OR no persona
+///   with that id exists → returns `Err(...)`.
+///
+/// Why fail closed: persona env_vars frequently carry API credentials
+/// (ANTHROPIC_API_KEY, OPENAI_API_KEY, …). If we swallow load errors and
+/// quietly spawn with an empty env, the agent comes up unauthenticated and
+/// the user sees a downstream "401 from provider" with no obvious cause.
+/// Better to surface the persona load failure at spawn/deploy/discovery
+/// time.
+pub(crate) fn resolve_persona_env(
+    app: &tauri::AppHandle,
+    persona_id: Option<&str>,
+) -> Result<BTreeMap<String, String>, String> {
+    let Some(pid) = persona_id else {
+        return Ok(BTreeMap::new());
+    };
+    let personas = super::load_personas(app).map_err(|e| {
+        format!("failed to load personas while resolving env for persona `{pid}`: {e}")
+    })?;
+    let persona = personas
+        .into_iter()
+        .find(|p| p.id == pid)
+        .ok_or_else(|| format!("persona `{pid}` not found while resolving env"))?;
+    Ok(persona.env_vars)
+}
+
+#[cfg(test)]
+mod tests;

--- a/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
@@ -1,0 +1,417 @@
+use std::collections::BTreeMap;
+
+use super::{
+    display_invalid_key, is_reserved_env_key, is_well_formed_env_key, merged_user_env,
+    validate_user_env_keys, MAX_ENV_TOTAL_BYTES, MAX_ENV_VALUE_BYTES, RESERVED_ENV_KEYS,
+};
+
+fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+// ── merged_user_env: layering ──────────────────────────────────────
+
+#[test]
+fn merged_env_empty_inputs_returns_empty() {
+    let merged = merged_user_env(&BTreeMap::new(), &BTreeMap::new());
+    assert!(merged.is_empty());
+}
+
+#[test]
+fn merged_env_persona_only_is_returned_verbatim() {
+    let persona = map(&[("ANTHROPIC_API_KEY", "p-key"), ("FOO", "1")]);
+    let merged = merged_user_env(&persona, &BTreeMap::new());
+    assert_eq!(
+        merged.get("ANTHROPIC_API_KEY").map(String::as_str),
+        Some("p-key")
+    );
+    assert_eq!(merged.get("FOO").map(String::as_str), Some("1"));
+    assert_eq!(merged.len(), 2);
+}
+
+#[test]
+fn merged_env_agent_only_is_returned_verbatim() {
+    let agent = map(&[("BAR", "a-val")]);
+    let merged = merged_user_env(&BTreeMap::new(), &agent);
+    assert_eq!(merged.get("BAR").map(String::as_str), Some("a-val"));
+    assert_eq!(merged.len(), 1);
+}
+
+#[test]
+fn merged_env_agent_overrides_persona_on_collision() {
+    // Per Tyler's rule: "If I put it in overrides, I want it to override."
+    let persona = map(&[("ANTHROPIC_API_KEY", "from-persona"), ("MODEL", "claude")]);
+    let agent = map(&[("ANTHROPIC_API_KEY", "from-agent")]);
+    let merged = merged_user_env(&persona, &agent);
+    assert_eq!(
+        merged.get("ANTHROPIC_API_KEY").map(String::as_str),
+        Some("from-agent")
+    );
+    assert_eq!(merged.get("MODEL").map(String::as_str), Some("claude"));
+    assert_eq!(merged.len(), 2);
+}
+
+#[test]
+fn merged_env_agent_can_add_new_keys() {
+    let persona = map(&[("A", "1")]);
+    let agent = map(&[("B", "2")]);
+    let merged = merged_user_env(&persona, &agent);
+    assert_eq!(merged.get("A").map(String::as_str), Some("1"));
+    assert_eq!(merged.get("B").map(String::as_str), Some("2"));
+    assert_eq!(merged.len(), 2);
+}
+
+#[test]
+fn merged_env_empty_value_is_passed_through() {
+    // No special-casing: empty string is a valid env value.
+    let agent = map(&[("CLEARED_TO_EMPTY", "")]);
+    let merged = merged_user_env(&BTreeMap::new(), &agent);
+    assert_eq!(merged.get("CLEARED_TO_EMPTY").map(String::as_str), Some(""));
+}
+
+#[test]
+fn merged_env_does_not_mutate_inputs() {
+    let persona = map(&[("A", "1")]);
+    let agent = map(&[("A", "2")]);
+    let _ = merged_user_env(&persona, &agent);
+    assert_eq!(persona.get("A").map(String::as_str), Some("1"));
+    assert_eq!(agent.get("A").map(String::as_str), Some("2"));
+}
+
+// ── reserved-key filter ────────────────────────────────────────────
+
+#[test]
+fn merged_env_strips_reserved_keys_from_persona() {
+    // Defense-in-depth: even if a reserved key sneaks into on-disk
+    // persona data (e.g. older record from before validation existed),
+    // it must be stripped before reaching the child process.
+    let persona = map(&[
+        ("SPROUT_PRIVATE_KEY", "nsec1evil"),
+        ("ANTHROPIC_API_KEY", "ok"),
+    ]);
+    let merged = merged_user_env(&persona, &BTreeMap::new());
+    assert!(!merged.contains_key("SPROUT_PRIVATE_KEY"));
+    assert_eq!(
+        merged.get("ANTHROPIC_API_KEY").map(String::as_str),
+        Some("ok")
+    );
+}
+
+#[test]
+fn merged_env_strips_reserved_keys_from_agent() {
+    let agent = map(&[
+        ("NOSTR_PRIVATE_KEY", "nsec1evil"),
+        ("SPROUT_AUTH_TAG", "{}"),
+        ("FOO", "1"),
+    ]);
+    let merged = merged_user_env(&BTreeMap::new(), &agent);
+    assert!(!merged.contains_key("NOSTR_PRIVATE_KEY"));
+    assert!(!merged.contains_key("SPROUT_AUTH_TAG"));
+    assert_eq!(merged.get("FOO").map(String::as_str), Some("1"));
+    assert_eq!(merged.len(), 1);
+}
+
+#[test]
+fn merged_env_strips_reserved_case_insensitive() {
+    // Unix env vars are case-sensitive at the syscall level, but we
+    // refuse close-typo variants too — a lowercase `sprout_private_key`
+    // is almost certainly a footgun, not a legitimate use.
+    let agent = map(&[("sprout_private_key", "x"), ("Sprout_Auth_Tag", "y")]);
+    let merged = merged_user_env(&BTreeMap::new(), &agent);
+    assert!(merged.is_empty());
+}
+
+#[test]
+fn is_reserved_recognises_full_list() {
+    for key in RESERVED_ENV_KEYS {
+        assert!(is_reserved_env_key(key), "{key} should be reserved");
+    }
+    assert!(!is_reserved_env_key("GOOSE_MODE"));
+    assert!(!is_reserved_env_key("ANTHROPIC_API_KEY"));
+    assert!(!is_reserved_env_key("SPROUT_ACP_MODEL")); // behavior knob
+    assert!(!is_reserved_env_key("SPROUT_TOOLSETS"));
+}
+
+#[test]
+fn reserved_keys_include_agent_owner_for_legacy_records() {
+    // Legacy records without auth_tag fall back to SPROUT_ACP_AGENT_OWNER
+    // to enforce the respond-to gate. Must not be user-overridable.
+    assert!(is_reserved_env_key("SPROUT_ACP_AGENT_OWNER"));
+    let agent = map(&[("SPROUT_ACP_AGENT_OWNER", "imposter")]);
+    let merged = merged_user_env(&BTreeMap::new(), &agent);
+    assert!(merged.is_empty());
+}
+
+#[test]
+fn reserved_keys_include_respond_to_gate() {
+    // Respond-to mode + allowlist control who the agent answers.
+    // Overriding via env_vars would let the running agent answer
+    // anyone even when the UI/record says owner-only.
+    for key in ["SPROUT_ACP_RESPOND_TO", "SPROUT_ACP_RESPOND_TO_ALLOWLIST"] {
+        assert!(is_reserved_env_key(key), "{key} should be reserved");
+        let agent = map(&[(key, "anyone")]);
+        let merged = merged_user_env(&BTreeMap::new(), &agent);
+        assert!(merged.is_empty(), "{key} should be stripped");
+    }
+}
+
+#[test]
+fn reserved_keys_include_code_execution_surface() {
+    // The agent/MCP command + args are what Sprout actually exec's.
+    // Overriding lets the user run arbitrary code as the agent.
+    for key in [
+        "SPROUT_ACP_AGENT_COMMAND",
+        "SPROUT_ACP_AGENT_ARGS",
+        "SPROUT_ACP_MCP_COMMAND",
+    ] {
+        assert!(is_reserved_env_key(key), "{key} should be reserved");
+    }
+}
+
+#[test]
+fn reserved_keys_include_relay_url() {
+    // Overriding the relay URL could redirect the agent to an
+    // attacker-controlled relay.
+    assert!(is_reserved_env_key("SPROUT_RELAY_URL"));
+    let agent = map(&[("SPROUT_RELAY_URL", "ws://attacker.example")]);
+    let merged = merged_user_env(&BTreeMap::new(), &agent);
+    assert!(merged.is_empty());
+}
+
+// ── validate_user_env_keys ─────────────────────────────────────────
+
+#[test]
+fn validate_keys_accepts_normal_env() {
+    let env = map(&[("ANTHROPIC_API_KEY", "k"), ("GOOSE_PROVIDER", "anthropic")]);
+    assert!(validate_user_env_keys(&env).is_ok());
+}
+
+#[test]
+fn validate_keys_rejects_reserved() {
+    let env = map(&[("SPROUT_PRIVATE_KEY", "nsec1evil")]);
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(err.contains("SPROUT_PRIVATE_KEY"), "got: {err}");
+    assert!(err.contains("reserved"), "got: {err}");
+}
+
+#[test]
+fn validate_keys_lists_all_reserved_keys_found() {
+    let env = map(&[
+        ("SPROUT_PRIVATE_KEY", "x"),
+        ("NOSTR_PRIVATE_KEY", "y"),
+        ("ANTHROPIC_API_KEY", "ok"),
+    ]);
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(err.contains("SPROUT_PRIVATE_KEY"));
+    assert!(err.contains("NOSTR_PRIVATE_KEY"));
+}
+
+#[test]
+fn validate_keys_rejects_empty_key() {
+    let env = map(&[("", "value")]);
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(err.contains("(empty)"), "got: {err}");
+    assert!(err.contains("[A-Za-z_]"), "got: {err}");
+}
+
+#[test]
+fn validate_keys_accepts_empty_map() {
+    assert!(validate_user_env_keys(&BTreeMap::new()).is_ok());
+}
+
+// ── malformed-key rejection (=-in-key bypass and friends) ──────────
+//
+// Rust's `Command::env(k, v)` will accept a key containing `=` and
+// pass it straight into the child's environ block, where
+// `getenv("PREFIX")` matches anything after the first `=`. Concretely:
+// `c.env("SPROUT_AUTH_TAG=x", "forged")` results in the child seeing
+// `SPROUT_AUTH_TAG=x=forged` and `getenv("SPROUT_AUTH_TAG") == "x=forged"`.
+// That bypasses our reserved-key check, which compares strings.
+// These tests pin the fix at the validator boundary.
+
+#[test]
+fn is_well_formed_accepts_posix_keys() {
+    for key in [
+        "FOO",
+        "FOO_BAR",
+        "_LEADING_UNDERSCORE",
+        "MIXED_Case_Letters",
+        "WITH_DIGITS_123",
+        "A", // single char
+    ] {
+        assert!(is_well_formed_env_key(key), "{key} should be well-formed");
+    }
+}
+
+#[test]
+fn is_well_formed_rejects_malformed_keys() {
+    for key in [
+        "",                    // empty
+        "=",                   // bare equals
+        "SPROUT_AUTH_TAG=x",   // =-in-key bypass
+        "SPROUT_PRIVATE_KEY=", // trailing equals
+        "FOO BAR",             // space
+        " FOO",                // leading whitespace
+        "FOO\nBAR",            // newline
+        "FOO\0BAR",            // NUL
+        "123_LEADING_DIGIT",   // POSIX forbids leading digit
+        "FOO-BAR",             // hyphen
+        "FOO.BAR",             // dot
+        "FOO/BAR",             // slash
+        "ünicode_key",         // non-ASCII
+    ] {
+        assert!(!is_well_formed_env_key(key), "{key:?} should be malformed");
+    }
+}
+
+#[test]
+fn validate_keys_rejects_equals_in_key_bypass() {
+    // The actual exploit: `SPROUT_AUTH_TAG=x` smuggles a value past
+    // the reserved-key string compare and into the child's environ.
+    let env = map(&[("SPROUT_AUTH_TAG=x", "forged")]);
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(err.contains("[A-Za-z_]"), "got: {err}");
+    // After P2 fix the key is truncated at `=` in the error to avoid
+    // surfacing pasted secrets — only the prefix should appear, with an
+    // ellipsis marking that we elided trailing content.
+    assert!(err.contains("SPROUT_AUTH_TAG"), "got: {err}");
+    assert!(err.contains('…'), "expected ellipsis marker: {err}");
+    assert!(!err.contains("=x"), "leak of value past `=`: {err}");
+}
+
+#[test]
+fn validate_keys_rejects_whitespace_and_nul() {
+    let env = map(&[("FOO BAR", "v"), ("HAS\0NUL", "v")]);
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(err.contains("[A-Za-z_]"), "got: {err}");
+}
+
+#[test]
+fn validate_keys_reports_malformed_before_reserved() {
+    // If a key is malformed it's not worth telling the user "and by
+    // the way that other key is reserved" — they've got a typo to fix
+    // first. Ordering is a UX detail but pinning it stops the message
+    // from churning.
+    let env = map(&[("SPROUT_AUTH_TAG=x", "v"), ("SPROUT_PRIVATE_KEY", "v")]);
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(err.contains("[A-Za-z_]"), "got: {err}");
+    assert!(!err.contains("reserved"), "got: {err}");
+}
+
+#[test]
+fn merged_env_drops_malformed_keys() {
+    // Defense in depth: on-disk records written before the validator
+    // tightened must not be able to smuggle reserved keys through.
+    let agent = map(&[
+        ("SPROUT_AUTH_TAG=x", "forged"),
+        ("FOO=bar", "v"),
+        ("LEGIT", "ok"),
+    ]);
+    let merged = merged_user_env(&BTreeMap::new(), &agent);
+    assert!(!merged.contains_key("SPROUT_AUTH_TAG=x"));
+    assert!(!merged.contains_key("FOO=bar"));
+    assert_eq!(merged.get("LEGIT").map(String::as_str), Some("ok"));
+    assert_eq!(merged.len(), 1);
+}
+
+#[test]
+fn display_invalid_key_truncates_at_equals_to_hide_secrets() {
+    // The exact bug class: a user pastes `KEY=sk-secret` into the key
+    // field. The validator must reject it AND must not echo the secret
+    // back in the error/log.
+    let rendered = display_invalid_key("ANTHROPIC_API_KEY=sk-ant-XXXXXXXXXXXX");
+    assert!(!rendered.contains("sk-"), "rendered: {rendered}");
+    assert!(
+        rendered.starts_with("ANTHROPIC_API_KEY"),
+        "rendered: {rendered}"
+    );
+}
+
+#[test]
+fn display_invalid_key_replaces_control_bytes() {
+    // NUL or newline in the key field would otherwise corrupt log lines.
+    let rendered = display_invalid_key("FOO\nBAR\0BAZ");
+    assert!(!rendered.contains('\n'), "rendered: {rendered}");
+    assert!(!rendered.contains('\0'), "rendered: {rendered}");
+}
+
+#[test]
+fn display_invalid_key_caps_long_keys() {
+    let key = "A".repeat(200);
+    let rendered = display_invalid_key(&key);
+    // 64-char cap + ellipsis marker.
+    assert!(
+        rendered.chars().count() <= 65,
+        "rendered len: {}",
+        rendered.chars().count()
+    );
+    assert!(rendered.ends_with('…'), "rendered: {rendered}");
+}
+
+#[test]
+fn validate_user_env_keys_error_does_not_leak_value_after_equals() {
+    let env = map(&[("ANTHROPIC_API_KEY=sk-ant-XXXX-leak", "ignored")]);
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(!err.contains("sk-ant"), "err leaked secret: {err}");
+}
+
+#[test]
+fn validate_rejects_nul_byte_in_value() {
+    let env = map(&[("FOO", "ok\0bad")]);
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(err.contains("NUL"), "got: {err}");
+    assert!(err.contains("FOO"), "got: {err}");
+    // Generic message — must not echo any portion of the value.
+    assert!(!err.contains("ok"), "leak: {err}");
+    assert!(!err.contains("bad"), "leak: {err}");
+}
+
+#[test]
+fn validate_rejects_oversize_value() {
+    let big = "x".repeat(MAX_ENV_VALUE_BYTES + 1);
+    let env = map(&[("FOO", big.as_str())]);
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(err.contains("per-value limit"), "got: {err}");
+    assert!(err.contains("FOO"), "got: {err}");
+    // Don't echo the value.
+    assert!(!err.contains("xxx"), "leak: {err}");
+}
+
+#[test]
+fn validate_rejects_oversize_total_payload() {
+    // Many medium values that each pass per-value but sum past the total.
+    let val = "y".repeat(MAX_ENV_VALUE_BYTES);
+    let entries: Vec<(String, String)> = (0..((MAX_ENV_TOTAL_BYTES / MAX_ENV_VALUE_BYTES) + 1))
+        .map(|i| (format!("K{i}"), val.clone()))
+        .collect();
+    let env: BTreeMap<String, String> = entries.into_iter().collect();
+    let err = validate_user_env_keys(&env).unwrap_err();
+    assert!(err.contains("total env var payload"), "got: {err}");
+}
+
+#[test]
+fn merged_env_drops_value_with_nul_byte() {
+    // Defense in depth — older on-disk record. `Command::env` would panic
+    // on a NUL in a value; the runtime filter must strip it.
+    let agent = map(&[("FOO", "ok\0bad"), ("LEGIT", "v")]);
+    let merged = merged_user_env(&BTreeMap::new(), &agent);
+    assert!(!merged.contains_key("FOO"));
+    assert_eq!(merged.get("LEGIT").map(String::as_str), Some("v"));
+}
+
+#[test]
+fn merged_env_drops_oversize_value() {
+    let big = "z".repeat(MAX_ENV_VALUE_BYTES + 1);
+    let agent: BTreeMap<String, String> = [
+        ("HUGE".to_string(), big),
+        ("LEGIT".to_string(), "v".to_string()),
+    ]
+    .into_iter()
+    .collect();
+    let merged = merged_user_env(&BTreeMap::new(), &agent);
+    assert!(!merged.contains_key("HUGE"));
+    assert_eq!(merged.get("LEGIT").map(String::as_str), Some("v"));
+}

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -1,5 +1,6 @@
 mod backend;
 mod discovery;
+mod env_vars;
 mod nest;
 mod persona_avatars;
 mod persona_card;
@@ -12,6 +13,7 @@ mod types;
 
 pub use backend::*;
 pub use discovery::*;
+pub use env_vars::*;
 pub use nest::*;
 pub use persona_card::*;
 pub use personas::*;

--- a/desktop/src-tauri/src/managed_agents/personas.rs
+++ b/desktop/src-tauri/src/managed_agents/personas.rs
@@ -474,6 +474,7 @@ fn built_in_persona_records(now: &str) -> Vec<PersonaRecord> {
             is_active: true,
             source_pack: None,
             source_pack_persona_slug: None,
+            env_vars: std::collections::BTreeMap::new(),
             created_at: now.to_string(),
             updated_at: now.to_string(),
         })
@@ -520,6 +521,7 @@ fn merge_personas(mut stored: Vec<PersonaRecord>, now: &str) -> (Vec<PersonaReco
                 || existing.avatar_url != built_in.avatar_url
                 || existing.system_prompt != built_in.system_prompt
                 || existing.name_pool != built_in.name_pool
+                || existing.env_vars != built_in.env_vars
                 || existing.provider.is_some()
                 || existing.model.is_some()
                 || !existing.is_builtin
@@ -759,6 +761,7 @@ pub fn import_persona_pack(
             is_active: true,
             source_pack: Some(resolved.id.clone()),
             source_pack_persona_slug: Some(p.name.clone()),
+            env_vars: std::collections::BTreeMap::new(),
             created_at: now.clone(),
             updated_at: now.clone(),
         })

--- a/desktop/src-tauri/src/managed_agents/personas/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/personas/tests.rs
@@ -17,6 +17,7 @@ fn custom_persona(id: &str, display_name: &str) -> PersonaRecord {
         is_active: true,
         source_pack: None,
         source_pack_persona_slug: None,
+        env_vars: std::collections::BTreeMap::new(),
         created_at: "2026-03-19T00:00:00Z".to_string(),
         updated_at: "2026-03-19T00:00:00Z".to_string(),
     }
@@ -70,6 +71,35 @@ fn merge_personas_restores_builtin_defaults() {
     assert_eq!(solo.created_at, original_created_at);
     assert_eq!(solo.updated_at, original_updated_at);
     assert!(solo.is_active);
+}
+
+#[test]
+fn merge_personas_restores_builtin_env_vars() {
+    // A hand-edited built-in record with stray env vars should be reset to
+    // the canonical (empty) env on merge. Built-ins are intended immutable —
+    // if a user wants per-persona credentials, they create or duplicate to a
+    // custom persona.
+    let mut tampered = custom_persona("builtin:solo", "Solo");
+    tampered.is_builtin = true;
+    tampered.avatar_url = None;
+    tampered.is_active = true;
+    tampered.env_vars =
+        std::collections::BTreeMap::from([("ANTHROPIC_API_KEY".to_string(), "leaked".to_string())]);
+
+    let (records, changed) = merge_personas(vec![tampered], "2026-03-19T00:00:00Z");
+
+    assert!(changed);
+    let solo = records
+        .iter()
+        .find(|record| record.id == "builtin:solo")
+        .expect("solo built-in should exist");
+    // Built-in persona definitions have no `env_vars` field — they are
+    // always empty. The merge reset should clear the tampered key entirely.
+    assert!(
+        solo.env_vars.is_empty(),
+        "expected empty, got {:?}",
+        solo.env_vars
+    );
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -415,6 +415,7 @@ pub fn build_managed_agent_summary(
         system_prompt: record.system_prompt.clone(),
         model: record.model.clone(),
         mcp_toolsets: record.mcp_toolsets.clone(),
+        env_vars: record.env_vars.clone(),
         backend: record.backend.clone(),
         backend_agent_id: record.backend_agent_id.clone(),
         status,
@@ -685,6 +686,22 @@ pub fn spawn_agent_child(
         );
     }
 
+    // ── User env vars: persona first, then per-agent (last wins) ────────
+    //
+    // Precedence: desktop parent env < persona env_vars < agent env_vars.
+    // These writes go LAST so user-provided values win over every Sprout-set
+    // env above — EXCEPT reserved keys (SPROUT_PRIVATE_KEY, NOSTR_PRIVATE_KEY,
+    // SPROUT_AUTH_TAG, SPROUT_API_TOKEN, SPROUT_ACP_PRIVATE_KEY,
+    // SPROUT_ACP_API_TOKEN), which `merged_user_env` strips. Those carry
+    // Sprout's identity and must never be GUI-overridable.
+    // Fail closed on persona-lookup errors: persona env_vars carry API
+    // credentials, so silently substituting an empty map would spawn an
+    // unauthenticated agent and surface as a confusing downstream auth error.
+    let persona_env = super::env_vars::resolve_persona_env(app, record.persona_id.as_deref())?;
+    for (key, value) in super::env_vars::merged_user_env(&persona_env, &record.env_vars) {
+        command.env(key, value);
+    }
+
     // Spawn the harness in its own process group so we can kill the entire
     // tree (harness + MCP servers + agent subprocesses) on shutdown.
     #[cfg(unix)]
@@ -876,6 +893,7 @@ mod tests {
             system_prompt: None,
             model: None,
             mcp_toolsets: None,
+            env_vars: std::collections::BTreeMap::new(),
             start_on_app_launch: false,
             runtime_pid: None,
             backend: Default::default(),

--- a/desktop/src-tauri/src/managed_agents/teams.rs
+++ b/desktop/src-tauri/src/managed_agents/teams.rs
@@ -336,6 +336,7 @@ mod tests {
             is_active: true,
             source_pack: None,
             source_pack_persona_slug: None,
+            env_vars: std::collections::BTreeMap::new(),
             created_at: "2026-03-20T00:00:00Z".to_string(),
             updated_at: "2026-03-20T00:00:00Z".to_string(),
         }

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, process::Child};
+use std::{collections::BTreeMap, path::PathBuf, process::Child};
 
 use serde::{Deserialize, Serialize};
 
@@ -44,6 +44,13 @@ pub struct PersonaRecord {
     /// Validated: `[a-zA-Z0-9_-]+`, max 64 chars (safe for env vars and paths).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_pack_persona_slug: Option<String>,
+    /// Environment variables injected when launching agents created from this
+    /// persona. Layered as: desktop parent env < persona `env_vars` <
+    /// individual agent `env_vars` (last wins on collision).
+    ///
+    /// Stored as a BTreeMap for deterministic on-disk ordering.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env_vars: BTreeMap<String, String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -98,6 +105,12 @@ pub struct ManagedAgentRecord {
     /// When None, the MCP server uses its own default ("default" toolset).
     #[serde(default)]
     pub mcp_toolsets: Option<String>,
+    /// Environment variables injected at spawn time. Layered as: desktop
+    /// parent env < persona `env_vars` < this agent's `env_vars` (last wins).
+    ///
+    /// To "override" a persona env var: set the same key here.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env_vars: BTreeMap<String, String>,
     #[serde(default = "default_start_on_app_launch")]
     pub start_on_app_launch: bool,
     #[serde(default)]
@@ -153,6 +166,8 @@ pub struct ManagedAgentSummary {
     pub system_prompt: Option<String>,
     pub model: Option<String>,
     pub mcp_toolsets: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env_vars: BTreeMap<String, String>,
     pub backend: BackendKind,
     pub backend_agent_id: Option<String>,
     pub status: String,
@@ -189,6 +204,9 @@ pub struct CreateManagedAgentRequest {
     pub avatar_url: Option<String>,
     pub model: Option<String>,
     pub mcp_toolsets: Option<String>,
+    /// Environment variables for this agent. Layered on top of persona env.
+    #[serde(default)]
+    pub env_vars: BTreeMap<String, String>,
     #[serde(default)]
     pub spawn_after_create: bool,
     #[serde(default = "default_start_on_app_launch")]
@@ -223,6 +241,9 @@ pub struct CreatePersonaRequest {
     pub model: Option<String>,
     #[serde(default)]
     pub name_pool: Vec<String>,
+    /// Environment variables for agents created from this persona.
+    #[serde(default)]
+    pub env_vars: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -238,6 +259,14 @@ pub struct UpdatePersonaRequest {
     pub model: Option<String>,
     #[serde(default)]
     pub name_pool: Vec<String>,
+    /// Environment variables for agents created from this persona.
+    ///
+    /// Absent (`None`) = don't touch the stored value (caller didn't include
+    /// the field). `Some(map)` = replace entirely (empty map clears all).
+    /// Defaulting an omitted field to an empty map would silently erase
+    /// stored credentials when an unrelated field is edited.
+    #[serde(default)]
+    pub env_vars: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -297,6 +326,9 @@ pub struct UpdateManagedAgentRequest {
     pub system_prompt: Option<Option<String>>,
     #[serde(default)]
     pub mcp_toolsets: Option<Option<String>>,
+    /// Absent = don't touch. Present = replace the env_vars map entirely.
+    #[serde(default)]
+    pub env_vars: Option<BTreeMap<String, String>>,
     #[serde(default)]
     pub parallelism: Option<u32>,
     #[serde(default)]
@@ -386,13 +418,7 @@ pub struct UpdateTeamRequest {
 pub const DEFAULT_ACP_COMMAND: &str = "sprout-acp";
 pub const DEFAULT_AGENT_COMMAND: &str = "goose";
 pub const DEFAULT_MCP_COMMAND: &str = "sprout-mcp-server";
-/// Default for the legacy `turn_timeout_seconds` field on the agent record.
-///
-/// As of the deprecation of `SPROUT_ACP_TURN_TIMEOUT` in sprout-acp, this
-/// field is no longer wired into the spawn path — the harness owns the
-/// effective idle-timeout default. The value is kept here only to satisfy
-/// existing persisted records and the `CreateAgentDialog` form state. Prefer
-/// `idle_timeout_seconds` (mapped to `SPROUT_ACP_IDLE_TIMEOUT`) for overrides.
+/// ~5 min (320s) — matches the CLI harness default (SPROUT_ACP_IDLE_TIMEOUT).
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
 /// 1 hour — absolute wall-clock safety cap per turn.
 pub const DEFAULT_AGENT_MAX_TURN_DURATION_SECONDS: u64 = 3600;

--- a/desktop/src/features/agents/ui/CreateAgentDialog.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialog.tsx
@@ -28,6 +28,7 @@ import {
   CreateAgentRuntimeProviderField,
   CreateAgentRuntimeFields,
 } from "./CreateAgentDialogSections";
+import { EnvVarsEditor, type EnvVarsValue } from "./EnvVarsEditor";
 import {
   coerceConfigValues,
   ProviderConfigFields,
@@ -63,6 +64,7 @@ export function CreateAgentDialog({
   const [turnTimeoutSeconds, setTurnTimeoutSeconds] = React.useState("320");
   const [parallelism, setParallelism] = React.useState("3");
   const [systemPrompt, setSystemPrompt] = React.useState("");
+  const [envVars, setEnvVars] = React.useState<EnvVarsValue>({});
   const [selectedProviderId, setSelectedProviderId] =
     React.useState<string>("custom");
   const [hasSyncedProviderSelection, setHasSyncedProviderSelection] =
@@ -212,6 +214,7 @@ export function CreateAgentDialog({
     setTurnTimeoutSeconds("320");
     setParallelism("3");
     setSystemPrompt("");
+    setEnvVars({});
     setSelectedProviderId("custom");
     setHasSyncedProviderSelection(false);
     setShowAdvanced(false);
@@ -316,6 +319,7 @@ export function CreateAgentDialog({
                 ? Number.parseInt(parallelism, 10)
                 : undefined,
             systemPrompt: systemPrompt.trim() || undefined,
+            envVars,
             spawnAfterCreate: true,
             startOnAppLaunch: false, // Remote agents don't auto-start with the desktop
             backend: {
@@ -348,6 +352,7 @@ export function CreateAgentDialog({
                 ? Number.parseInt(parallelism, 10)
                 : undefined,
             systemPrompt: systemPrompt.trim() || undefined,
+            envVars,
             spawnAfterCreate,
             startOnAppLaunch,
             backend: { type: "local" },
@@ -533,6 +538,13 @@ export function CreateAgentDialog({
                 </div>
               ) : null}
             </div>
+
+            <EnvVarsEditor
+              disabled={createMutation.isPending}
+              helperText="Injected at spawn. Overrides the persona's env vars on collision."
+              onChange={setEnvVars}
+              value={envVars}
+            />
 
             {createMutation.error instanceof Error ? (
               <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">

--- a/desktop/src/features/agents/ui/EditAgentDialog.tsx
+++ b/desktop/src/features/agents/ui/EditAgentDialog.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 
-import { useUpdateManagedAgentMutation } from "@/features/agents/hooks";
+import {
+  usePersonasQuery,
+  useUpdateManagedAgentMutation,
+} from "@/features/agents/hooks";
 import type {
   ManagedAgent,
   RespondToMode,
@@ -18,6 +21,7 @@ import {
   CreateAgentBasicsFields,
   CreateAgentRuntimeFields,
 } from "./CreateAgentDialogSections";
+import { EnvVarsEditor, type EnvVarsValue } from "./EnvVarsEditor";
 import { CreateAgentRespondToField } from "./RespondToField";
 
 export function EditAgentDialog({
@@ -49,6 +53,13 @@ export function EditAgentDialog({
   const [systemPrompt, setSystemPrompt] = React.useState(
     agent.systemPrompt ?? "",
   );
+  const [envVars, setEnvVars] = React.useState<EnvVarsValue>(agent.envVars);
+  const personasQuery = usePersonasQuery();
+  const inheritedEnvVars = React.useMemo(() => {
+    if (!agent.personaId) return {};
+    const persona = personasQuery.data?.find((p) => p.id === agent.personaId);
+    return persona?.envVars ?? {};
+  }, [agent.personaId, personasQuery.data]);
   const [respondTo, setRespondTo] = React.useState<RespondToMode>(
     agent.respondTo,
   );
@@ -73,6 +84,7 @@ export function EditAgentDialog({
       setTurnTimeoutSeconds(String(agent.turnTimeoutSeconds));
       setParallelism(String(agent.parallelism));
       setSystemPrompt(agent.systemPrompt ?? "");
+      setEnvVars(agent.envVars);
       setRespondTo(agent.respondTo);
       setRespondToAllowlist(agent.respondToAllowlist);
       updateMutation.reset();
@@ -156,6 +168,7 @@ export function EditAgentDialog({
           (systemPrompt.trim() || null) !== agent.systemPrompt
             ? systemPrompt.trim() || null
             : undefined,
+        envVars: envVarsChanged(envVars, agent.envVars) ? envVars : undefined,
         respondTo: respondTo !== agent.respondTo ? respondTo : undefined,
         // The allowlist is preserved across mode toggles in local UI state
         // (so a user can flip away from allowlist and back without losing
@@ -226,6 +239,15 @@ export function EditAgentDialog({
               turnTimeoutSeconds={turnTimeoutSeconds}
             />
 
+            <EnvVarsEditor
+              disabled={updateMutation.isPending}
+              helperText="Per-agent env vars. Override the persona's vars on collision."
+              inheritedFrom={inheritedEnvVars}
+              inheritedLabel="persona"
+              onChange={setEnvVars}
+              value={envVars}
+            />
+
             {updateMutation.error instanceof Error ? (
               <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
                 {updateMutation.error.message}
@@ -255,4 +277,17 @@ export function EditAgentDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+function envVarsChanged(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return true;
+  for (const k of aKeys) {
+    if (a[k] !== b[k]) return true;
+  }
+  return false;
 }

--- a/desktop/src/features/agents/ui/EnvVarsEditor.tsx
+++ b/desktop/src/features/agents/ui/EnvVarsEditor.tsx
@@ -1,0 +1,206 @@
+import { Plus, X } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+
+export type EnvVarsValue = Record<string, string>;
+
+type EnvVarsEditorProps = {
+  /** The current key/value map. */
+  value: EnvVarsValue;
+  /** Called with a new map whenever the user edits a row. */
+  onChange: (next: EnvVarsValue) => void;
+  /** Optional: shown as greyed-out hints next to rows whose key collides
+   * with this map (e.g., a persona-set value for the same key). */
+  inheritedFrom?: EnvVarsValue;
+  /** Label for the inherited source (e.g., "persona"). */
+  inheritedLabel?: string;
+  /** Section header. Defaults to "Environment variables". */
+  label?: string;
+  /** Short description below the header. */
+  helperText?: string;
+  /** Disables all editing. */
+  disabled?: boolean;
+};
+
+type Row = { id: string; key: string; value: string };
+
+/**
+ * A flat key/value editor for environment variables.
+ *
+ * Maintains an ordered list of rows internally (so duplicate / empty keys
+ * don't collapse mid-edit) and emits the latest non-empty rows as a record
+ * via `onChange`. No validation, no warnings, no key shape enforcement —
+ * by design.
+ */
+export function EnvVarsEditor({
+  value,
+  onChange,
+  inheritedFrom,
+  inheritedLabel = "inherited",
+  label = "Environment variables",
+  helperText,
+  disabled = false,
+}: EnvVarsEditorProps) {
+  // Local ordered row state. Synced from `value` on mount and when the
+  // parent supplies a value we did NOT just emit (e.g., dialog reopened
+  // with a different persona/agent). We track what we last emitted so a
+  // row with an empty key doesn't get wiped: emit returns {} for it, the
+  // parent's useState produces a new object reference, but `value` content
+  // matches our `lastEmitted`, so we skip the resync.
+  const [rows, setRows] = React.useState<Row[]>(() => toRows(value));
+  const lastEmitted = React.useRef<EnvVarsValue>(toRecord(toRows(value)));
+  React.useEffect(() => {
+    if (!recordsEqual(lastEmitted.current, value)) {
+      lastEmitted.current = value;
+      setRows(toRows(value));
+    }
+  }, [value]);
+
+  function emit(next: Row[]) {
+    setRows(next);
+    const record = toRecord(next);
+    lastEmitted.current = record;
+    onChange(record);
+  }
+
+  function updateRow(id: string, patch: Partial<Pick<Row, "key" | "value">>) {
+    emit(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
+  }
+
+  function removeRow(id: string) {
+    emit(rows.filter((row) => row.id !== id));
+  }
+
+  function addRow() {
+    emit([...rows, { id: crypto.randomUUID(), key: "", value: "" }]);
+  }
+
+  return (
+    <div className="space-y-2" data-testid="env-vars-editor">
+      <div>
+        <div className="text-sm font-medium">{label}</div>
+        {helperText ? (
+          <p className="mt-0.5 text-xs text-muted-foreground">{helperText}</p>
+        ) : null}
+      </div>
+      <div className="space-y-2">
+        {rows.length === 0 ? (
+          <p className="text-xs italic text-muted-foreground">
+            No variables set.
+          </p>
+        ) : null}
+        {rows.map((row) => {
+          const inheritedValue = inheritedFrom?.[row.key];
+          const showsInherited =
+            inheritedValue !== undefined && row.key.length > 0;
+          return (
+            <div key={row.id} className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Input
+                  aria-label="Variable name"
+                  className="flex-1 font-mono text-xs"
+                  data-testid="env-vars-key"
+                  disabled={disabled}
+                  onChange={(event) =>
+                    updateRow(row.id, { key: event.target.value })
+                  }
+                  placeholder="ANTHROPIC_API_KEY"
+                  value={row.key}
+                />
+                <Input
+                  aria-label="Variable value"
+                  className="flex-[2] font-mono text-xs"
+                  data-testid="env-vars-value"
+                  disabled={disabled}
+                  onChange={(event) =>
+                    updateRow(row.id, { value: event.target.value })
+                  }
+                  placeholder="sk-ant-..."
+                  value={row.value}
+                />
+                <Button
+                  aria-label="Remove variable"
+                  data-testid="env-vars-remove"
+                  disabled={disabled}
+                  onClick={() => removeRow(row.id)}
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              {showsInherited ? (
+                <p className="ml-1 text-xs text-muted-foreground">
+                  Overrides {inheritedLabel} value{" "}
+                  <span className="font-mono">
+                    {maskInherited(inheritedValue)}
+                  </span>
+                </p>
+              ) : null}
+            </div>
+          );
+        })}
+        <Button
+          data-testid="env-vars-add"
+          disabled={disabled}
+          onClick={addRow}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Add variable
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Render a masked preview of an inherited (persona) env value so the agent
+ * dialog can show "Overrides persona value •••• (last 4)" without exposing
+ * the persona's actual secret to anyone viewing the agent UI. Empty values
+ * render as "(empty)" so the user can still tell the persona had a value
+ * set at all.
+ */
+function maskInherited(value: string): string {
+  if (value.length === 0) return "(empty)";
+  if (value.length <= 4) return "•".repeat(value.length);
+  return `••••${value.slice(-4)}`;
+}
+
+function toRows(value: EnvVarsValue): Row[] {
+  return Object.entries(value).map(([key, val]) => ({
+    id: crypto.randomUUID(),
+    key,
+    value: val,
+  }));
+}
+
+function recordsEqual(a: EnvVarsValue, b: EnvVarsValue): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    // `in` walks the prototype, but EnvVarsValue is always a plain Record
+    // built from `toRecord` (Object.create-less), so this is safe here.
+    if (!(key in b)) return false;
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}
+
+function toRecord(rows: Row[]): EnvVarsValue {
+  const out: EnvVarsValue = {};
+  for (const row of rows) {
+    // Empty key = user is mid-edit; skip it so we don't poison the record.
+    // Duplicate keys: last write wins (matches Command::env semantics).
+    if (row.key.length > 0) {
+      out[row.key] = row.value;
+    }
+  }
+  return out;
+}

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
+import { EnvVarsEditor, type EnvVarsValue } from "./EnvVarsEditor";
 import {
   getImportButtonLabel,
   getImportButtonTone,
@@ -66,6 +67,7 @@ export function PersonaDialog({
   const [provider, setProvider] = React.useState("");
   const [model, setModel] = React.useState("");
   const [namePoolText, setNamePoolText] = React.useState("");
+  const [envVars, setEnvVars] = React.useState<EnvVarsValue>({});
   const [isImportingUpdate, setIsImportingUpdate] = React.useState(false);
   const [importErrorMessage, setImportErrorMessage] = React.useState<
     string | null
@@ -94,6 +96,7 @@ export function PersonaDialog({
         : undefined
       )?.join(", ") ?? "",
     );
+    setEnvVars(initialValues.envVars ?? {});
     setImportErrorMessage(null);
     setIsImportingUpdate(false);
   }, [initialValues, open]);
@@ -238,6 +241,7 @@ export function PersonaDialog({
       provider: provider.trim() || undefined,
       model: model.trim() || undefined,
       namePool: namePool.length > 0 ? namePool : undefined,
+      envVars,
     };
 
     if ("id" in initialValues) {
@@ -401,6 +405,13 @@ export function PersonaDialog({
                 random name from this pool. Leave empty to use generic defaults.
               </p>
             </div>
+
+            <EnvVarsEditor
+              disabled={isPending}
+              helperText="Injected when agents created from this persona spawn. Per-agent overrides can replace these."
+              onChange={setEnvVars}
+              value={envVars}
+            />
 
             {error ? (
               <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">

--- a/desktop/src/features/agents/ui/personaDialogState.test.mjs
+++ b/desktop/src/features/agents/ui/personaDialogState.test.mjs
@@ -43,7 +43,35 @@ test("duplicatePersonaDialogState copies persona fields into a new draft", () =>
     systemPrompt: "Be direct.",
     provider: "provider-a",
     model: "model-a",
+    namePool: [],
+    envVars: {},
   });
+});
+
+test("duplicatePersonaDialogState carries envVars and namePool into the duplicate", () => {
+  // Regression: codex R10 P2. Without this, a duplicated persona that
+  // relies on an API key in env_vars would silently fail at spawn until
+  // the user re-entered every credential.
+  const state = duplicatePersonaDialogState({
+    id: "persona-with-secrets",
+    displayName: "Coder",
+    avatarUrl: null,
+    systemPrompt: "Write code.",
+    provider: null,
+    model: null,
+    isBuiltIn: false,
+    isActive: true,
+    namePool: ["alice", "bob"],
+    envVars: { ANTHROPIC_API_KEY: "sk-test", GOOSE_PROVIDER: "anthropic" },
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-02T00:00:00Z",
+  });
+
+  assert.deepEqual(state.initialValues.envVars, {
+    ANTHROPIC_API_KEY: "sk-test",
+    GOOSE_PROVIDER: "anthropic",
+  });
+  assert.deepEqual(state.initialValues.namePool, ["alice", "bob"]);
 });
 
 test("editPersonaDialogState preserves the persona id for updates", () => {
@@ -70,7 +98,31 @@ test("editPersonaDialogState preserves the persona id for updates", () => {
     systemPrompt: "Keep it weird.",
     provider: undefined,
     model: undefined,
+    namePool: [],
+    envVars: {},
   });
+});
+
+test("editPersonaDialogState seeds envVars and namePool from the persona", () => {
+  const state = editPersonaDialogState({
+    id: "persona-3",
+    displayName: "Coder",
+    avatarUrl: null,
+    systemPrompt: "Write code.",
+    provider: null,
+    model: null,
+    isBuiltIn: false,
+    isActive: true,
+    namePool: ["alice", "bob"],
+    envVars: { ANTHROPIC_API_KEY: "sk-test" },
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-02T00:00:00Z",
+  });
+
+  assert.deepEqual(state.initialValues.envVars, {
+    ANTHROPIC_API_KEY: "sk-test",
+  });
+  assert.deepEqual(state.initialValues.namePool, ["alice", "bob"]);
 });
 
 test("importPersonaDialogState maps parsed persona previews into create drafts", () => {

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -44,6 +44,13 @@ export function duplicatePersonaDialogState(
       systemPrompt: persona.systemPrompt,
       provider: persona.provider ?? undefined,
       model: persona.model ?? undefined,
+      // Carry envVars and namePool into the duplicate. Without this, a
+      // duplicated persona that relies on an API key in env_vars would
+      // silently fail at spawn until the user re-entered every credential.
+      // The user sees the inherited values in the dialog and can clear
+      // them if they want a blank template.
+      namePool: persona.namePool ?? [],
+      envVars: persona.envVars ?? {},
     },
   };
 }
@@ -62,6 +69,12 @@ export function editPersonaDialogState(
       systemPrompt: persona.systemPrompt,
       provider: persona.provider ?? undefined,
       model: persona.model ?? undefined,
+      // Seed both namePool and envVars from the loaded persona so editing
+      // unrelated fields doesn't submit an empty value that wipes them.
+      // (Persona update treats Some(empty) as "clear all" intentionally;
+      // the dialog must therefore round-trip the existing values.)
+      namePool: persona.namePool ?? [],
+      envVars: persona.envVars ?? {},
     },
   };
 }

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -214,6 +214,7 @@ export type RawManagedAgent = {
   system_prompt: string | null;
   model: string | null;
   mcp_toolsets: string | null;
+  env_vars?: Record<string, string>;
   status: ManagedAgent["status"];
   pid: number | null;
   created_at: string;
@@ -825,6 +826,7 @@ export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {
     systemPrompt: agent.system_prompt,
     model: agent.model,
     mcpToolsets: agent.mcp_toolsets,
+    envVars: agent.env_vars ?? {},
     status: agent.status,
     pid: agent.pid,
     createdAt: agent.created_at,
@@ -950,6 +952,7 @@ export async function createManagedAgent(input: CreateManagedAgentInput) {
         systemPrompt: input.systemPrompt,
         avatarUrl: input.avatarUrl,
         model: input.model,
+        envVars: input.envVars ?? {},
         spawnAfterCreate: input.spawnAfterCreate,
         startOnAppLaunch: input.startOnAppLaunch,
         backend: input.backend,

--- a/desktop/src/shared/api/tauriPersonas.ts
+++ b/desktop/src/shared/api/tauriPersonas.ts
@@ -57,6 +57,7 @@ type RawPersona = {
   name_pool?: string[];
   is_builtin: boolean;
   is_active?: boolean;
+  env_vars?: Record<string, string>;
   created_at: string;
   updated_at: string;
 };
@@ -72,6 +73,7 @@ function fromRawPersona(persona: RawPersona): AgentPersona {
     namePool: persona.name_pool ?? [],
     isBuiltIn: persona.is_builtin,
     isActive: persona.is_active ?? true,
+    envVars: persona.env_vars ?? {},
     createdAt: persona.created_at,
     updatedAt: persona.updated_at,
   };
@@ -93,6 +95,7 @@ export async function createPersona(
         provider: input.provider,
         model: input.model,
         namePool: input.namePool ?? [],
+        envVars: input.envVars ?? {},
       },
     }),
   );
@@ -111,6 +114,10 @@ export async function updatePersona(
         provider: input.provider,
         model: input.model,
         namePool: input.namePool ?? [],
+        // Send envVars only when caller explicitly provided it; omitting
+        // tells the backend "don't touch the stored env vars" so editing
+        // unrelated fields can't silently wipe saved credentials.
+        envVars: input.envVars,
       },
     }),
   );

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -278,6 +278,8 @@ export type ManagedAgent = {
   systemPrompt: string | null;
   model: string | null;
   mcpToolsets: string | null;
+  /** Per-agent env vars. Layered on top of persona envVars. */
+  envVars: Record<string, string>;
   status: "running" | "stopped" | "deployed" | "not_deployed";
   pid: number | null;
   createdAt: string;
@@ -335,6 +337,7 @@ export type CreateManagedAgentInput = {
   avatarUrl?: string;
   model?: string;
   mcpToolsets?: string;
+  envVars?: Record<string, string>;
   spawnAfterCreate?: boolean;
   startOnAppLaunch?: boolean;
   backend?: ManagedAgentBackend;
@@ -403,6 +406,8 @@ export type UpdateManagedAgentInput = {
   model?: string | null;
   systemPrompt?: string | null;
   mcpToolsets?: string | null;
+  /** Absent = don't touch. Present = replace the env_vars map entirely. */
+  envVars?: Record<string, string>;
   parallelism?: number;
   turnTimeoutSeconds?: number;
   relayUrl?: string;
@@ -432,6 +437,9 @@ export type AgentPersona = {
   isActive: boolean;
   /** Pack ID if this persona was imported from a persona pack. Pack personas are non-editable. */
   sourcePack?: string | null;
+  /** Environment variables injected for agents created from this persona.
+   * Layered as: desktop parent env < persona envVars < agent envVars. */
+  envVars: Record<string, string>;
   createdAt: string;
   updatedAt: string;
 };
@@ -443,6 +451,7 @@ export type CreatePersonaInput = {
   provider?: string;
   model?: string;
   namePool?: string[];
+  envVars?: Record<string, string>;
 };
 
 export type UpdatePersonaInput = {
@@ -453,6 +462,7 @@ export type UpdatePersonaInput = {
   provider?: string;
   model?: string;
   namePool?: string[];
+  envVars?: Record<string, string>;
 };
 
 // ── Team types ────────────────────────────────────────────────────────────────

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -286,6 +286,7 @@ type RawManagedAgent = {
   parallelism: number;
   system_prompt: string | null;
   model: string | null;
+  env_vars?: Record<string, string>;
   status: "running" | "stopped" | "deployed" | "not_deployed";
   pid: number | null;
   created_at: string;
@@ -343,6 +344,7 @@ type RawPersona = {
   system_prompt: string;
   is_builtin: boolean;
   is_active: boolean;
+  env_vars?: Record<string, string>;
   created_at: string;
   updated_at: string;
 };
@@ -669,6 +671,7 @@ function cloneManagedAgent(agent: MockManagedAgent): RawManagedAgent {
     parallelism: agent.parallelism,
     system_prompt: agent.system_prompt,
     model: agent.model,
+    env_vars: { ...(agent.env_vars ?? {}) },
     status: agent.status,
     pid: agent.pid,
     created_at: agent.created_at,
@@ -3543,6 +3546,7 @@ async function handleCreatePersona(args: {
     displayName: string;
     avatarUrl?: string;
     systemPrompt: string;
+    envVars?: Record<string, string>;
   };
 }): Promise<RawPersona> {
   const now = new Date().toISOString();
@@ -3553,6 +3557,7 @@ async function handleCreatePersona(args: {
     system_prompt: args.input.systemPrompt.trim(),
     is_builtin: false,
     is_active: true,
+    env_vars: { ...(args.input.envVars ?? {}) },
     created_at: now,
     updated_at: now,
   };
@@ -3566,6 +3571,7 @@ async function handleUpdatePersona(args: {
     displayName: string;
     avatarUrl?: string;
     systemPrompt: string;
+    envVars?: Record<string, string>;
   };
 }): Promise<RawPersona> {
   const persona = mockPersonas.find(
@@ -3581,6 +3587,10 @@ async function handleUpdatePersona(args: {
   persona.display_name = args.input.displayName.trim();
   persona.avatar_url = args.input.avatarUrl?.trim() || null;
   persona.system_prompt = args.input.systemPrompt.trim();
+  if (args.input.envVars !== undefined) {
+    // Absent = preserve; present = replace entirely (matches Rust handler).
+    persona.env_vars = { ...args.input.envVars };
+  }
   persona.updated_at = new Date().toISOString();
 
   return { ...persona };
@@ -3808,6 +3818,7 @@ async function handleCreateManagedAgent(args: {
     systemPrompt?: string;
     avatarUrl?: string;
     model?: string;
+    envVars?: Record<string, string>;
     spawnAfterCreate?: boolean;
     startOnAppLaunch?: boolean;
     backend?:
@@ -3845,6 +3856,7 @@ async function handleCreateManagedAgent(args: {
     parallelism: args.input.parallelism ?? 1,
     system_prompt: args.input.systemPrompt?.trim() || null,
     model: args.input.model?.trim() || null,
+    env_vars: { ...(args.input.envVars ?? {}) },
     status: args.input.spawnAfterCreate ? "running" : "stopped",
     pid: args.input.spawnAfterCreate ? 42000 + mockManagedAgents.length : null,
     created_at: now,
@@ -3973,6 +3985,7 @@ async function handleUpdateManagedAgent(args: {
     name?: string;
     model?: string | null;
     systemPrompt?: string | null;
+    envVars?: Record<string, string>;
     respondTo?: "owner-only" | "allowlist" | "anyone";
     respondToAllowlist?: string[];
   };
@@ -3986,6 +3999,9 @@ async function handleUpdateManagedAgent(args: {
   }
   if (args.input.systemPrompt !== undefined) {
     agent.system_prompt = args.input.systemPrompt;
+  }
+  if (args.input.envVars !== undefined) {
+    agent.env_vars = { ...args.input.envVars };
   }
   if (args.input.respondTo !== undefined) {
     agent.respond_to = args.input.respondTo;

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -1,0 +1,263 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+});
+
+async function gotoApp(page: import("@playwright/test").Page) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await waitForInvokeBridge(page);
+  await expect(page.getByTestId("open-agents-view")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+async function waitForInvokeBridge(page: import("@playwright/test").Page) {
+  await page.waitForFunction(
+    () => {
+      const w = window as Window & {
+        __SPROUT_E2E_INVOKE_MOCK_COMMAND__?: unknown;
+        __TAURI_INTERNALS__?: { invoke?: unknown };
+      };
+      return (
+        typeof w.__SPROUT_E2E_INVOKE_MOCK_COMMAND__ === "function" ||
+        typeof w.__TAURI_INTERNALS__?.invoke === "function"
+      );
+    },
+    null,
+    { timeout: 5_000 },
+  );
+}
+
+async function invokeTauri<T>(
+  page: import("@playwright/test").Page,
+  command: string,
+  payload?: Record<string, unknown>,
+): Promise<T> {
+  await waitForInvokeBridge(page);
+  return page.evaluate(
+    async ({ command: c, payload: p }) => {
+      const w = window as Window & {
+        __SPROUT_E2E_INVOKE_MOCK_COMMAND__?: (
+          c: string,
+          p?: Record<string, unknown>,
+        ) => Promise<unknown>;
+        __TAURI_INTERNALS__?: {
+          invoke?: (c: string, p?: Record<string, unknown>) => Promise<unknown>;
+        };
+      };
+      const invoke =
+        w.__SPROUT_E2E_INVOKE_MOCK_COMMAND__ ?? w.__TAURI_INTERNALS__?.invoke;
+      if (!invoke) throw new Error("Mock invoke bridge is unavailable.");
+      return (await invoke(c, p)) as T;
+    },
+    { command, payload },
+  );
+}
+
+test("persona env_vars round-trip through create_persona + update_persona", async ({
+  page,
+}) => {
+  await gotoApp(page);
+
+  // Create a persona with two env vars.
+  const created = await invokeTauri<{
+    id: string;
+    env_vars?: Record<string, string>;
+  }>(page, "create_persona", {
+    input: {
+      displayName: "Coder",
+      systemPrompt: "You are Coder.",
+      envVars: {
+        ANTHROPIC_API_KEY: "sk-ant-test-001",
+        ANTHROPIC_MODEL: "claude-sonnet-4-5",
+      },
+    },
+  });
+
+  expect(created.env_vars).toEqual({
+    ANTHROPIC_API_KEY: "sk-ant-test-001",
+    ANTHROPIC_MODEL: "claude-sonnet-4-5",
+  });
+
+  // Update: drop one, add one, change one.
+  const updated = await invokeTauri<{ env_vars?: Record<string, string> }>(
+    page,
+    "update_persona",
+    {
+      input: {
+        id: created.id,
+        displayName: "Coder",
+        systemPrompt: "You are Coder.",
+        envVars: {
+          ANTHROPIC_API_KEY: "sk-ant-test-002", // changed
+          OPENAI_COMPAT_API_KEY: "sk-new", // added
+          // ANTHROPIC_MODEL dropped
+        },
+      },
+    },
+  );
+
+  expect(updated.env_vars).toEqual({
+    ANTHROPIC_API_KEY: "sk-ant-test-002",
+    OPENAI_COMPAT_API_KEY: "sk-new",
+  });
+
+  // list_personas returns the updated map.
+  const list = await invokeTauri<
+    Array<{ id: string; env_vars?: Record<string, string> }>
+  >(page, "list_personas");
+  const reloaded = list.find((p) => p.id === created.id);
+  expect(reloaded?.env_vars).toEqual({
+    ANTHROPIC_API_KEY: "sk-ant-test-002",
+    OPENAI_COMPAT_API_KEY: "sk-new",
+  });
+});
+
+test("update_persona preserves env_vars when caller omits the field", async ({
+  page,
+}) => {
+  // Regression: codex R2 P1. Editing display_name / system_prompt via a
+  // helper that doesn't populate envVars must NOT wipe stored credentials.
+  await gotoApp(page);
+
+  const created = await invokeTauri<{
+    id: string;
+    env_vars?: Record<string, string>;
+  }>(page, "create_persona", {
+    input: {
+      displayName: "WithSecrets",
+      systemPrompt: "You have secrets.",
+      envVars: {
+        ANTHROPIC_API_KEY: "sk-keep-me",
+      },
+    },
+  });
+  expect(created.env_vars).toEqual({ ANTHROPIC_API_KEY: "sk-keep-me" });
+
+  // Update WITHOUT including envVars at all. Stored value must survive.
+  const updated = await invokeTauri<{ env_vars?: Record<string, string> }>(
+    page,
+    "update_persona",
+    {
+      input: {
+        id: created.id,
+        displayName: "WithSecrets (renamed)",
+        systemPrompt: "You have secrets.",
+        // envVars intentionally omitted
+      },
+    },
+  );
+  expect(updated.env_vars).toEqual({ ANTHROPIC_API_KEY: "sk-keep-me" });
+
+  // Explicit empty map still clears (intentional).
+  const cleared = await invokeTauri<{ env_vars?: Record<string, string> }>(
+    page,
+    "update_persona",
+    {
+      input: {
+        id: created.id,
+        displayName: "WithSecrets (renamed)",
+        systemPrompt: "You have secrets.",
+        envVars: {},
+      },
+    },
+  );
+  expect(cleared.env_vars ?? {}).toEqual({});
+});
+
+test("agent env_vars override persona env_vars on the agent record", async ({
+  page,
+}) => {
+  await gotoApp(page);
+
+  const persona = await invokeTauri<{ id: string }>(page, "create_persona", {
+    input: {
+      displayName: "Provider",
+      systemPrompt: "You are Provider.",
+      envVars: {
+        ANTHROPIC_API_KEY: "persona-key",
+        SHARED_VAR: "from-persona",
+      },
+    },
+  });
+
+  // Create an agent under that persona with an override.
+  const created = await invokeTauri<{
+    agent: { pubkey: string; env_vars?: Record<string, string> };
+  }>(page, "create_managed_agent", {
+    input: {
+      name: "agent-with-overrides",
+      personaId: persona.id,
+      backend: { type: "local" },
+      envVars: {
+        ANTHROPIC_API_KEY: "agent-key", // overrides persona
+        AGENT_ONLY: "1", // agent-only
+      },
+    },
+  });
+
+  expect(created.agent.env_vars).toEqual({
+    ANTHROPIC_API_KEY: "agent-key",
+    AGENT_ONLY: "1",
+  });
+
+  // Update to replace the map entirely.
+  const updated = await invokeTauri<{
+    agent: { env_vars?: Record<string, string> };
+  }>(page, "update_managed_agent", {
+    input: {
+      pubkey: created.agent.pubkey,
+      envVars: {
+        AGENT_ONLY: "2",
+      },
+    },
+  });
+
+  expect(updated.agent.env_vars).toEqual({ AGENT_ONLY: "2" });
+});
+
+test("env vars editor renders in PersonaDialog new-persona form", async ({
+  page,
+}) => {
+  await gotoApp(page);
+
+  // Open the Agents view, click New > Persona to open the persona dialog.
+  await page.getByTestId("open-agents-view").click();
+  await page.getByRole("button", { name: "New" }).click();
+  await page.getByRole("menuitem", { name: /^Persona$/ }).click();
+
+  // The env vars editor should be present.
+  await expect(page.getByTestId("env-vars-editor")).toBeVisible();
+  // Initially empty (no rows).
+  await expect(page.getByTestId("env-vars-key")).toHaveCount(0);
+
+  // Add a row.
+  await page.getByTestId("env-vars-add").click();
+  await expect(page.getByTestId("env-vars-key")).toHaveCount(1);
+
+  // Fill it in. Use realistic-looking keys/values so the screenshot
+  // captured below illustrates the feature for reviewers.
+  const keys = page.getByTestId("env-vars-key");
+  const values = page.getByTestId("env-vars-value");
+  await keys.nth(0).fill("ANTHROPIC_API_KEY");
+  await values.nth(0).fill("sk-ant-abc");
+  await page.getByTestId("env-vars-add").click();
+  await keys.nth(1).fill("GOOSE_PROVIDER");
+  await values.nth(1).fill("anthropic");
+  await page.getByTestId("env-vars-add").click();
+  await keys.nth(2).fill("OPENAI_BASE_URL");
+  await values.nth(2).fill("https://api.openai.com/v1");
+
+  // Capture a screenshot of the dialog with three env vars filled. Helps
+  // reviewers see the UI at a glance.
+  await page
+    .getByRole("dialog")
+    .screenshot({ path: "test-results/persona-env-dialog.png" });
+
+  // Remove the first row to verify per-row removal still works.
+  await page.getByTestId("env-vars-remove").first().click();
+  await expect(keys).toHaveCount(2);
+});


### PR DESCRIPTION
## What

Adds per-persona and per-agent env var overrides to the desktop GUI. Personas and managed agents each carry a `BTreeMap<String, String>` of env vars that get layered into the spawned agent's environment.

**Precedence** (last wins): desktop parent env < persona env < agent env.

A small set of *reserved* keys — Sprout's identity and secrets — are rejected at save time and stripped at runtime so a typo or malicious value can't swap the agent's nsec.

## Why

Users want to set provider credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`), provider selection (`GOOSE_PROVIDER`), local-LLM endpoints (`OPENAI_BASE_URL`), etc. without editing shell rc files. Per-persona keys cover the common case; per-agent overrides handle the "one-off agent on a different model" case.

## Surface area

**Backend (Rust):**
- `managed_agents/env_vars.rs` — new module with `merged_user_env`, `RESERVED_ENV_KEYS`, `is_reserved_env_key`, `validate_user_env_keys` + 16 unit tests.
- `managed_agents/runtime.rs` — merges `persona env → agent env`, calls into `env_vars::merged_user_env` at spawn.
- `managed_agents/types.rs` — `env_vars` field on `PersonaRecord` and `ManagedAgentRecord`.
- `commands/personas.rs`, `commands/agents.rs`, `commands/agent_models.rs` — `validate_user_env_keys` at save time; `merged_user_env` also used by `sprout-acp models` discovery and provider deploy so credentials in persona env flow into both.

**Frontend (TS):**
- `features/agents/ui/EnvVarsEditor.tsx` — new shared component (key/value rows, add/remove, validation hint).
- `features/agents/ui/PersonaDialog.tsx`, `CreateAgentDialog.tsx`, `EditAgentDialog.tsx` — embed the editor; persona env shown read-only when editing an agent, with per-agent overrides on top.
- `shared/api/types.ts`, `tauri.ts`, `tauriPersonas.ts` — `envVars` field on create/update payloads, with the convention that `envVars: undefined` on update = "don't touch" (so editing unrelated fields can't wipe saved credentials).

## Reserved keys

| Key | Why |
|---|---|
| `SPROUT_PRIVATE_KEY` | Agent's nsec — overriding swaps identity |
| `NOSTR_PRIVATE_KEY` | Mirror of above for `git-credential-nostr` |
| `SPROUT_AUTH_TAG` | NIP-OA auth tag — overriding breaks relay auth |
| `SPROUT_API_TOKEN` | Reserved for future server auth |
| `SPROUT_ACP_PRIVATE_KEY` | Legacy alias for SPROUT_PRIVATE_KEY |
| `SPROUT_ACP_API_TOKEN` | Legacy alias for SPROUT_API_TOKEN |

Behavior knobs (`GOOSE_MODE`, `SPROUT_TOOLSETS`, `SPROUT_ACP_MODEL`, `SPROUT_ACP_SYSTEM_PROMPT`, etc.) remain freely overridable — those have dedicated UI fields, but power users may want to bypass them.

Two-layer enforcement:

1. **Save-time** — `validate_user_env_keys` rejects reserved keys with a clear error like `the following env vars are reserved by Sprout and cannot be overridden: SPROUT_PRIVATE_KEY`, surfaced in the dialog.
2. **Runtime** — `merged_user_env` strips reserved keys with a warning log. Defense in depth for older on-disk records that predate validation.

Case-insensitive match so `sprout_private_key` is also rejected — Unix env vars are case-sensitive at the syscall level, but lowercase variants of these specific keys are almost certainly typos.

## Tests

- 16 unit tests in `env_vars.rs` cover the merge order, the reserved-key filter, and the validator.
- 1 e2e test (`desktop/tests/e2e/persona-env-vars.spec.ts`) drives the EnvVarsEditor through the Persona dialog.
- All 291 desktop crate unit tests pass. `cargo fmt`, `biome check`, `pnpm typecheck`, `cargo clippy` all clean.

## Review history

Codex reviewed five times across the branch lifecycle:
- R1: caught HIGH (runtime merge order — sort of, see note), HIGH (None=clear semantics — withdrew that design, simpler last-wins), MED (model discovery wouldn't see persona env — fixed), MED (summary plumbing — fixed).
- R2: dialog state clear/preserve nits.
- R3: edit-dialog initial-state seeding.
- R4: aborted (pre-fix codex timeout).
- R5: clean — *"The changes compile and typecheck, and the new env var data flow appears consistent across persona/agent storage, UI editing, local spawn, model discovery, and provider deploy paths. I did not find any discrete correctness issues introduced by this patch."* + one lint nit (`hasOwnProperty` → `in`), fixed.

The final fix in this PR (reserved-key denylist) closes a footgun I called out in self-review but the earlier passes didn't flag: user env was written LAST during spawn, so a GUI typo of `SPROUT_PRIVATE_KEY` would have swapped the agent's identity at runtime. The "no allow-list, by design" comment was wrong on its own terms — fixed.

## Supersedes

#576 (already closed).
