### PR TITLE
fix(agent): fix OpenAI-compat request body serialization and max_tokens

### DIFF
--- a/crates/sprout-agent/src/llm.rs
+++ b/crates/sprout-agent/src/llm.rs
@@ -34,7 +34,6 @@ impl Llm {
                 let v = post(&self.http, &url, &body, |r| {
                     r.header("x-api-key", &cfg.api_key)
                         .header("anthropic-version", &cfg.anthropic_api_version)
-                        .header("content-type", "application/json")
                 })
                 .await?;
                 parse_anthropic(v)
@@ -42,11 +41,7 @@ impl Llm {
             Provider::OpenAi => {
                 let body = openai_body(cfg, history, tools);
                 let url = format!("{}/chat/completions", cfg.base_url.trim_end_matches('/'));
-                let v = post(&self.http, &url, &body, |r| {
-                    r.bearer_auth(&cfg.api_key)
-                        .header("content-type", "application/json")
-                })
-                .await?;
+                let v = post(&self.http, &url, &body, |r| r.bearer_auth(&cfg.api_key)).await?;
                 parse_openai(v)
             }
         }
@@ -74,7 +69,6 @@ impl Llm {
                 let v = post(&self.http, &url, &body, |r| {
                     r.header("x-api-key", &cfg.api_key)
                         .header("anthropic-version", &cfg.anthropic_api_version)
-                        .header("content-type", "application/json")
                 })
                 .await?;
                 Ok(parse_anthropic(v)?.text)
@@ -83,18 +77,14 @@ impl Llm {
                 let body = json!({
                     "model": cfg.model,
                     "stream": false,
-                    "max_tokens": max_output_tokens,
+                    "max_completion_tokens": max_output_tokens,
                     "messages": [
                         { "role": "system", "content": system_prompt },
                         { "role": "user", "content": user_prompt },
                     ],
                 });
                 let url = format!("{}/chat/completions", cfg.base_url.trim_end_matches('/'));
-                let v = post(&self.http, &url, &body, |r| {
-                    r.bearer_auth(&cfg.api_key)
-                        .header("content-type", "application/json")
-                })
-                .await?;
+                let v = post(&self.http, &url, &body, |r| r.bearer_auth(&cfg.api_key)).await?;
                 Ok(parse_openai(v)?.text)
             }
         }
@@ -193,8 +183,8 @@ fn openai_body(cfg: &Config, history: &[HistoryItem], tools: &[ToolDef]) -> Valu
             "parameters": t.input_schema } })
         })
         .collect();
-    let mut body = json!({ "model": cfg.model, "stream": false, "max_tokens": cfg.max_output_tokens,
-        "messages": messages });
+    let mut body = json!({ "model": cfg.model, "stream": false,
+        "max_completion_tokens": cfg.max_output_tokens, "messages": messages });
     if !tools_json.is_empty() {
         body["tools"] = Value::Array(tools_json);
         body["tool_choice"] = json!("auto");
@@ -338,8 +328,17 @@ async fn post<F>(http: &Client, url: &str, body: &Value, apply: F) -> Result<Val
 where
     F: Fn(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
 {
+    let body_bytes =
+        serde_json::to_vec(body).map_err(|e| AgentError::Llm(format!("serialize: {e}")))?;
     for attempt in 0..MAX_RETRIES {
-        let resp = match apply(http.post(url).json(body)).send().await {
+        let resp = match apply(
+            http.post(url)
+                .header("content-type", "application/json")
+                .body(body_bytes.clone()),
+        )
+        .send()
+        .await
+        {
             Ok(r) => r,
             Err(e) => {
                 if attempt + 1 < MAX_RETRIES && (e.is_timeout() || e.is_connect()) {


### PR DESCRIPTION
## Problem

Two issues prevented sprout-agent from working with newer OpenAI models (e.g. gpt-5.5):

1. **`max_tokens` rejected by newer models**: OpenAI's newer models (gpt-5.5, o-series) reject the legacy `max_tokens` parameter and require `max_completion_tokens` instead.

2. **Request body silently dropped**: The `post()` helper used reqwest's `.json(body)` which sets `Content-Type` AND serializes the body. Callers then added `.header("content-type", "application/json")` via the closure, causing reqwest 0.13 to silently drop the request body. OpenAI returned `"you must provide a model parameter"` because it received an empty body.

## Fix

- Replace `max_tokens` with `max_completion_tokens` in both OpenAI request paths (`openai_body()` and `summarize()`)
- Switch `post()` to manual serialization via `serde_json::to_vec()` + `.body()` + explicit `Content-Type` header
- Remove duplicate `content-type` headers from all callers

## Testing

- ✅ All 17 sprout-agent unit tests pass
- ✅ Full workspace `cargo test` passes (2 flaky pair-relay timing tests fail identically on main)
- ✅ `cargo clippy --workspace` clean
- ✅ `cargo fmt` clean
- ✅ Live tested with gpt-5.5: simple prompt + tool use (MCP shell)
- ✅ Anthropic regression test: claude-haiku-4-5 still works correctly

## Notes

- `max_completion_tokens` is the standard for all current OpenAI models. Some older OpenAI-compatible servers (vLLM, Ollama) may still only accept `max_tokens` — if that's a concern, a follow-up could add a config knob or send both.