### PR TITLE
fix(desktop): derive unread state from NIP-RS + relay catch-up only

### DIFF
--- a/desktop/src/features/channels/latestMessageStorage.ts
+++ b/desktop/src/features/channels/latestMessageStorage.ts
@@ -1,0 +1,73 @@
+// Persists the in-session "latest message at" map per pubkey so unread
+// indicators survive an app restart. See useUnreadChannels for the consumer.
+//
+// Without this, the sidebar unread comparison (`latest > readMarker`) has its
+// `latest` side reset to empty on every startup — read markers persist via
+// NIP-RS, but there is nothing to compare them against, and badges silently
+// disappear until a new live message arrives.
+//
+// Stored shape: { [channelId]: unixSeconds }. Per-pubkey. Callers write
+// monotonically; this module validates on read and doesn't trust the file.
+
+const STORAGE_KEY_PREFIX = "sprout.channel-latest-message.v1";
+
+// Cap entries written to localStorage to keep the blob bounded even for users
+// in thousands of channels. Same order of magnitude as readStateFormat's
+// MAX_CONTEXTS.
+const MAX_ENTRIES = 10_000;
+
+function storageKey(pubkey: string): string {
+  return `${STORAGE_KEY_PREFIX}:${pubkey}`;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function readStoredLatestMessages(pubkey: string): Map<string, number> {
+  const result = new Map<string, number>();
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(storageKey(pubkey));
+  } catch {
+    return result;
+  }
+  if (!raw) return result;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return result;
+  }
+  if (!isPlainRecord(parsed)) return result;
+
+  for (const [channelId, value] of Object.entries(parsed)) {
+    if (typeof channelId !== "string" || channelId.length === 0) continue;
+    if (typeof value !== "number" || !Number.isInteger(value)) continue;
+    if (value < 0 || value > 4_294_967_295) continue;
+    result.set(channelId, value);
+  }
+
+  return result;
+}
+
+export function writeStoredLatestMessages(
+  pubkey: string,
+  latest: ReadonlyMap<string, number>,
+): void {
+  const state: Record<string, number> = {};
+  let count = 0;
+  for (const [channelId, timestamp] of latest) {
+    if (count >= MAX_ENTRIES) break;
+    state[channelId] = timestamp;
+    count += 1;
+  }
+
+  try {
+    localStorage.setItem(storageKey(pubkey), JSON.stringify(state));
+  } catch {
+    // Quota/serialization failure — non-fatal. Worst case is that one
+    // restart loses badges, which is the status quo we're fixing.
+  }
+}

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -3,6 +3,10 @@ import {
   useLiveChannelUpdates,
   type UseLiveChannelUpdatesOptions,
 } from "@/features/channels/useLiveChannelUpdates";
+import {
+  readStoredLatestMessages,
+  writeStoredLatestMessages,
+} from "@/features/channels/latestMessageStorage";
 import { useReadState } from "@/features/channels/readState/useReadState";
 import type { RelayClient } from "@/shared/api/relayClientSession";
 import type { Channel, RelayEvent } from "@/shared/api/types";
@@ -72,10 +76,17 @@ export function useUnreadChannels(
   // Track whether channels have been initialized (for first-load seeding)
   const hasInitializedChannelsRef = React.useRef(false);
 
-  // Reset the in-session state when the identity or relay changes.
+  // Reset the in-session state when the identity or relay changes, then
+  // hydrate the per-channel "latest message at" map from localStorage so
+  // unread badges survive an app restart. Without this, the only source for
+  // `latest` is the live subscription (which uses `since: now` and so
+  // doesn't backfill), meaning every channel's latest would be undefined on
+  // startup and the unread comparison would always be false.
   // biome-ignore lint/correctness/useExhaustiveDependencies: pubkey/relayClient are intentional reset signals
   React.useEffect(() => {
-    latestByChannelRef.current = new Map();
+    latestByChannelRef.current = pubkey
+      ? readStoredLatestMessages(pubkey)
+      : new Map();
     forcedUnreadRef.current = new Set();
     hasInitializedChannelsRef.current = false;
     bumpLatestVersion();
@@ -128,8 +139,13 @@ export function useUnreadChannels(
         didAdvance = true;
       }
     }
-    if (didAdvance) bumpLatestVersion();
-  }, [channels]);
+    if (didAdvance) {
+      if (pubkey) {
+        writeStoredLatestMessages(pubkey, latestByChannelRef.current);
+      }
+      bumpLatestVersion();
+    }
+  }, [channels, pubkey]);
 
   // Seed read state on first load so existing channels don't flash as unread
   // when the backend reports a non-null Channel.lastMessageAt. We deliberately
@@ -171,18 +187,23 @@ export function useUnreadChannels(
   ]);
 
   // Feed the in-session "latest message at" map from live channel events.
-  // Composes with any caller-supplied onChannelMessage handler.
+  // Composes with any caller-supplied onChannelMessage handler. Persists to
+  // localStorage so unread badges survive an app restart — see the hydrate
+  // effect above.
   const callerOnChannelMessage = liveUpdateOptions.onChannelMessage;
   const handleChannelMessage = React.useCallback(
     (channelId: string, event: RelayEvent) => {
       const current = latestByChannelRef.current.get(channelId) ?? 0;
       if (event.created_at > current) {
         latestByChannelRef.current.set(channelId, event.created_at);
+        if (pubkey) {
+          writeStoredLatestMessages(pubkey, latestByChannelRef.current);
+        }
         bumpLatestVersion();
       }
       callerOnChannelMessage?.(channelId, event);
     },
-    [callerOnChannelMessage],
+    [callerOnChannelMessage, pubkey],
   );
 
   useLiveChannelUpdates(channels, activeChannelId, {


### PR DESCRIPTION
## What

Make GUI unread state depend solely on (a) the NIP-RS read marker and (b) a per-channel relay catch-up query that asks "are there messages newer than this marker?" — no localStorage cache, no `Channel.last_message_at` dependency, no schema extension.

## Why

`useUnreadChannels` had two halves: a NIP-RS read marker (which persists fine, locally and cross-device) and an in-memory `latestByChannelRef` Map that got built up only from the live subscription (`since: now`). On every restart the Map reset to empty, the comparison `latest > readMarker` always returned `false`, and badges silently disappeared until new live activity hit the channel.

The original fix in this branch persisted the Map to `localStorage`. Tyler's review surfaced a better model: the relay already knows what's in each channel, so just ask it. The NIP-RS spec is explicit that `contexts` carries read positions — channel "latest" is the wrong shape for that blob. And we don't need any client-side latest cache if we can query "newer than marker?" on demand.

## How

- Delete the `latestMessageStorage.ts` module added earlier in this branch.
- Delete the (no-op) `Channel.lastMessageAt` opportunistic backfill effect and the read-state seeding effect from `useUnreadChannels`. Backend never populated `last_message_at`, both effects were dead branches.
- Add a catch-up effect: once NIP-RS is ready and channels are known, for each channel we haven't already caught up this session, REQ the channel's trigger-kind events with `since: readMarker + 1` (strict-newer; client-side `> readAt` belt-and-suspenders), `limit: 1000`, in parallel. Take the max external-author event timestamp per channel; feed the existing predicate.
- Effect is keyed on a sorted `channelIdsKey` string so React Query refetches with identical contents don't churn. Optimistic claim of `caughtUpChannelsRef` prevents duplicate REQs from re-renders; cleanup releases claims so the next effect run retries; individual failed fetches release their own claim so transient relay errors don't suppress unread for the rest of the session.
- `isCancelled` guard around the post-settle mutation handles identity reset mid-flight.
- `markChannelUnread` falls back to `latestByChannelRef.current.get(channelId)` when `Channel.lastMessageAt` is null (always today), so right-click "mark unread" syncs across devices when we've observed any external message.
- Export `CHANNEL_MESSAGE_EVENT_KINDS` from `shared/constants/kinds` so `useLiveChannelUpdates` and the catch-up share one source of truth for "unread trigger kinds."

The live subscription remains `since: now` — unchanged.

## Verification

- `pnpm --dir desktop typecheck` ✅
- `pnpm --dir desktop check` (biome + file-size) ✅
- All pre-commit and pre-push hooks pass.

## Reviewers

Reviewed in #sprout-bugs by @Max. Two rounds of review caught: (1) `limit: 1` is unsafe when self-author filter discards the only returned event, (2) the original retry path left failed channels permanently "caught up" — both fixed. Approved at v3.

## Closes

The "unread indicators disappear on restart" regression Tyler reported in #sprout-bugs.
