### PR TITLE
desktop: opt-out 'huddle' feature for lighter builds (no TTS/STT/ORT/opus)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,10 @@ jobs:
         run: just desktop-tauri-check
         env:
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+      - name: Desktop Tauri light check (no huddle)
+        run: just desktop-light-check
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
       - name: Upload desktop e2e artifacts
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -23,3 +23,34 @@ Desktop chat shell with:
 - `src/shared` - reusable app-wide code (`ui`, `lib`, `styles`)
 - `src/features` - feature modules (vertical slices)
 - `src/app` - top-level app composition
+
+## Light builds (no huddle / TTS / STT)
+
+For wimpy machines, CI lanes, or anyone who doesn't need voice, the
+`huddle` Cargo feature can be disabled at compile time. With it off, the
+following native deps are dropped from the build entirely:
+
+- `sherpa-onnx` (STT, Parakeet)
+- `ort` (ONNX Runtime, Kokoro TTS — also skips its ~100 MB binary download)
+- `opus`, `rodio`, `ndarray`, `rubato`, `earshot`, `audioadapter-buffers`
+- `tauri-plugin-global-shortcut` (push-to-talk shortcut)
+
+The first-run model download (~187 MB of Parakeet + Kokoro weights) is
+also skipped.
+
+From the repo root:
+
+```bash
+just desktop-light           # dev mode without huddle
+just desktop-light-build     # packaged release without huddle
+just desktop-light-check     # cargo check the light path
+```
+
+Under the hood these set `VITE_SPROUT_HUDDLE=0`, pass
+`--no-default-features` to cargo, and layer the
+`src-tauri/tauri.light.conf.json` capability override. The Rust huddle
+module is replaced by `src-tauri/src/huddle_stub.rs` and the frontend
+huddle module by `src/features/huddle/index.light.ts` — both expose the
+same public API as the originals so the rest of the app compiles and
+renders without any changes. Voice-only Tauri commands return
+`voice/huddle is disabled in this build`; the huddle UI is hidden.

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -41,7 +41,6 @@ tokio = { version = "1", features = ["fs", "sync", "rt", "macros", "time"] }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 futures-util = "0.3"
-opus = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 nostr = { version = "0.37", features = ["nip44"] }
@@ -57,20 +56,41 @@ sha2 = "0.11"
 tar = "0.4"
 bzip2 = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
-tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2.3.3"
 uuid = { version = "1", features = ["v4"] }
 png = "0.18"
 zip = "2"
-sherpa-onnx = "1.12"
-ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "tls-native", "copy-dylibs", "api-23", "coreml"] }
-ndarray = { version = "0.17", features = ["rayon"] }
 regex = "1"
 axum = "0.8"
-rodio = "0.22"
-earshot = "1.0"
-rubato = "2.0"
-audioadapter-buffers = "3.0"
 tempfile = "3"
+
+# Huddle-only dependencies. Pulled in only when the `huddle` feature is on.
+opus = { version = "0.3", optional = true }
+sherpa-onnx = { version = "1.12", optional = true }
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "tracing", "download-binaries", "tls-native", "copy-dylibs", "api-23", "coreml"], optional = true }
+ndarray = { version = "0.17", features = ["rayon"], optional = true }
+rodio = { version = "0.22", optional = true }
+earshot = { version = "1.0", optional = true }
+rubato = { version = "2.0", optional = true }
+audioadapter-buffers = { version = "3.0", optional = true }
+tauri-plugin-global-shortcut = { version = "2", optional = true }
+
+[features]
+default = ["huddle"]
+# Voice/huddle stack: TTS (Kokoro via ort/ONNX Runtime), STT (Parakeet via
+# sherpa-onnx), audio I/O (rodio/cpal), VAD (earshot), resampling (rubato),
+# Opus codec, and the global-shortcut plugin used for push-to-talk.
+# Disabling drops all native model deps from the build — see desktop-light.
+huddle = [
+    "dep:opus",
+    "dep:sherpa-onnx",
+    "dep:ort",
+    "dep:ndarray",
+    "dep:rodio",
+    "dep:earshot",
+    "dep:rubato",
+    "dep:audioadapter-buffers",
+    "dep:tauri-plugin-global-shortcut",
+]
 
 [dev-dependencies]

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -26,5 +26,17 @@ fn main() {
         println!("cargo:rustc-cfg=sprout_updater_enabled");
     }
 
-    tauri_build::build()
+    // When the `huddle` feature is off, restrict the ACL pattern to base
+    // capabilities only. The huddle capability declares permissions for
+    // `tauri-plugin-global-shortcut`, which isn't compiled in the light build —
+    // leaving it in the scan path triggers `Permission global-shortcut:* not
+    // found` from tauri-build's ACL validator. Cargo exposes enabled features
+    // to build scripts via CARGO_FEATURE_<UPPER> env vars.
+    let huddle_enabled = std::env::var_os("CARGO_FEATURE_HUDDLE").is_some();
+    let attrs = if huddle_enabled {
+        tauri_build::Attributes::default()
+    } else {
+        tauri_build::Attributes::default().capabilities_path_pattern("./capabilities/default.json")
+    };
+    tauri_build::try_build(attrs).expect("tauri-build failed");
 }

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -20,9 +20,6 @@
     "dialog:default",
     "updater:allow-check",
     "updater:allow-download-and-install",
-    "process:allow-restart",
-    "global-shortcut:allow-register",
-    "global-shortcut:allow-unregister",
-    "global-shortcut:allow-is-registered"
+    "process:allow-restart"
   ]
 }

--- a/desktop/src-tauri/capabilities/huddle.json
+++ b/desktop/src-tauri/capabilities/huddle.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "huddle",
+  "description": "Push-to-talk global shortcut for voice huddles. Only loaded in full builds.",
+  "windows": ["main"],
+  "permissions": [
+    "global-shortcut:allow-register",
+    "global-shortcut:allow-unregister",
+    "global-shortcut:allow-is-registered"
+  ]
+}

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -19,6 +19,7 @@ pub struct AppState {
     pub managed_agents_store_lock: Mutex<()>,
     pub channel_templates_store_lock: Mutex<()>,
     pub managed_agent_processes: Mutex<HashMap<String, ManagedAgentProcess>>,
+    #[cfg_attr(not(feature = "huddle"), allow(dead_code))]
     pub huddle_state: Mutex<HuddleState>,
     /// Tauri app handle — stored after setup so huddle commands can emit
     /// `huddle-state-changed` events without needing the handle threaded
@@ -28,6 +29,7 @@ pub struct AppState {
     pub app_handle: Mutex<Option<AppHandle>>,
     /// Selected audio output device name. `None` = system default.
     /// Used by `connect_audio_relay` and TTS pipeline when opening sinks.
+    #[cfg_attr(not(feature = "huddle"), allow(dead_code))]
     pub audio_output_device: Mutex<Option<String>>,
     /// Port of the localhost media streaming proxy (set during setup).
     pub media_proxy_port: AtomicU16,
@@ -87,6 +89,7 @@ impl AppState {
     /// Convenience wrapper — replaces 15+ instances of
     /// `state.huddle_state.lock().map_err(|e| e.to_string())?` throughout the
     /// huddle module.
+    #[cfg_attr(not(feature = "huddle"), allow(dead_code))]
     pub fn huddle(&self) -> Result<std::sync::MutexGuard<'_, crate::huddle::HuddleState>, String> {
         self.huddle_state.lock().map_err(|e| e.to_string())
     }
@@ -96,6 +99,7 @@ impl AppState {
     /// Acquires both locks (app_handle + huddle_state), clones a snapshot,
     /// releases both, then emits. Best-effort — no-op if either lock is
     /// poisoned or the app_handle hasn't been set yet.
+    #[cfg_attr(not(feature = "huddle"), allow(dead_code))]
     pub fn emit_huddle_state_changed(&self) {
         let app = match self.app_handle.lock() {
             Ok(guard) => guard.clone(),

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -360,6 +360,7 @@ pub fn build_profile(
 
 // ── Huddles ──────────────────────────────────────────────────────────────────
 
+#[cfg(feature = "huddle")]
 /// Validate that a string is a valid UUID (defense-in-depth for `&str` channel IDs).
 fn validate_channel_id(id: &str) -> Result<(), String> {
     uuid::Uuid::parse_str(id).map_err(|_| format!("invalid channel UUID: {id}"))?;
@@ -370,6 +371,7 @@ fn validate_channel_id(id: &str) -> Result<(), String> {
 /// All huddle events share: validate two channel IDs, JSON content with
 /// `ephemeral_channel_id`, an `["h", parent_channel_id]` tag, and an
 /// optional `["p", participant_pubkey]` tag for join/leave identity.
+#[cfg(feature = "huddle")]
 fn build_huddle_event(
     kind: u16,
     parent_channel_id: &str,
@@ -393,6 +395,7 @@ fn build_huddle_event(
 }
 
 /// Kind 48100 — huddle started advisory posted to the parent channel.
+#[cfg(feature = "huddle")]
 pub fn build_huddle_started(
     parent_channel_id: &str,
     ephemeral_channel_id: &str,
@@ -401,6 +404,7 @@ pub fn build_huddle_started(
 }
 
 /// Kind 48103 — huddle ended, posted to the parent channel.
+#[cfg(feature = "huddle")]
 pub fn build_huddle_ended(
     parent_channel_id: &str,
     ephemeral_channel_id: &str,
@@ -413,6 +417,7 @@ pub fn build_huddle_ended(
 /// Posted to the **ephemeral** channel (not the parent) so agents see it
 /// via EOSE replay when they subscribe. Uses a dedicated kind so the TTS
 /// pipeline can filter it out without fragile content-prefix matching.
+#[cfg(feature = "huddle")]
 pub fn build_huddle_guidelines(
     ephemeral_channel_id: &str,
     guidelines_text: &str,

--- a/desktop/src-tauri/src/huddle_stub.rs
+++ b/desktop/src-tauri/src/huddle_stub.rs
@@ -1,0 +1,247 @@
+//! Stub for the `huddle` module — compiled when the `huddle` feature is OFF.
+//!
+//! Mirrors the public surface of `crate::huddle` so that `lib.rs`, `app_state.rs`,
+//! and `generate_handler!` keep compiling and the Tauri command set is unchanged.
+//! All operations that would start audio, download models, or speak return
+//! `Err("voice/huddle is disabled in this build")`; read-only queries return
+//! idle/empty values so the frontend renders gracefully.
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::app_state::AppState;
+
+const DISABLED: &str = "voice/huddle is disabled in this build";
+
+// ── Public types (mirror src/huddle/state.rs) ────────────────────────────────
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum VoiceInputMode {
+    #[default]
+    PushToTalk,
+    VoiceActivity,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum HuddlePhase {
+    #[default]
+    Idle,
+    Creating,
+    Connecting,
+    Connected,
+    Active,
+    Leaving,
+}
+
+/// Idle huddle state — no audio pipelines, no participants. The `Default` impl
+/// is the only state this build ever produces.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HuddleState {
+    pub phase: HuddlePhase,
+    pub parent_channel_id: Option<String>,
+    pub ephemeral_channel_id: Option<String>,
+    pub participants: Vec<String>,
+    pub agent_pubkeys: Vec<String>,
+    pub is_creator: bool,
+    pub tts_enabled: bool,
+    pub voice_input_mode: VoiceInputMode,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HuddleJoinInfo {
+    pub ephemeral_channel_id: String,
+}
+
+// ── Submodule stubs ──────────────────────────────────────────────────────────
+
+pub mod state {
+    use super::HuddleState;
+    /// No-op in the light build — no UI listeners exist for huddle events.
+    /// Kept for API parity with the real module so `app_state` compiles unchanged.
+    #[allow(dead_code)]
+    pub fn emit_huddle_state(_app: &tauri::AppHandle, _state: &HuddleState) {}
+}
+
+pub mod models {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ModelStatus {
+        NotDownloaded,
+        Downloading { progress_percent: u8 },
+        Ready,
+        Error(String),
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct VoiceModelStatus {
+        pub stt: ModelStatus,
+        pub kokoro: ModelStatus,
+    }
+
+    /// Always `None` in the light build. Kept for API parity — the predownload
+    /// call site in `setup()` is itself `#[cfg(feature = "huddle")]` so this is
+    /// never called, but the symbol must exist so non-gated import paths resolve.
+    #[allow(dead_code)]
+    pub fn global_model_manager() -> Option<&'static ()> {
+        None
+    }
+}
+
+pub mod audio_output {
+    use tauri::State;
+
+    use crate::app_state::AppState;
+
+    #[derive(Debug, serde::Serialize)]
+    pub struct AudioOutputDevice {
+        pub name: String,
+        pub is_default: bool,
+    }
+
+    /// Light build has no audio backend — return an empty list so the
+    /// frontend renders an empty picker rather than a hard error.
+    #[tauri::command]
+    pub fn list_audio_output_devices() -> Result<Vec<AudioOutputDevice>, String> {
+        Ok(Vec::new())
+    }
+
+    #[tauri::command]
+    pub fn set_audio_output_device(
+        _name: String,
+        _state: State<'_, AppState>,
+    ) -> Result<(), String> {
+        Err(super::DISABLED.to_string())
+    }
+
+    #[tauri::command]
+    pub fn get_audio_output_device(_state: State<'_, AppState>) -> Result<String, String> {
+        Ok(String::new())
+    }
+}
+
+pub mod agents {
+    use serde::Serialize;
+
+    #[derive(Debug, Serialize)]
+    pub struct AgentAddResult {
+        pub ephemeral_added: bool,
+        pub parent_added: bool,
+        pub parent_error: Option<String>,
+    }
+}
+
+// ── Tauri commands (mirror src/huddle/mod.rs) ────────────────────────────────
+
+#[tauri::command]
+pub async fn set_voice_input_mode(
+    _mode: VoiceInputMode,
+    _state: State<'_, AppState>,
+) -> Result<(), String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub fn get_voice_input_mode(_state: State<'_, AppState>) -> Result<VoiceInputMode, String> {
+    Ok(VoiceInputMode::default())
+}
+
+#[tauri::command]
+pub async fn start_huddle(
+    _parent_channel_id: String,
+    _member_pubkeys: Vec<String>,
+    _state: State<'_, AppState>,
+) -> Result<HuddleJoinInfo, String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub async fn join_huddle(
+    _parent_channel_id: String,
+    _ephemeral_channel_id: String,
+    _state: State<'_, AppState>,
+) -> Result<HuddleJoinInfo, String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub async fn leave_huddle(_state: State<'_, AppState>) -> Result<(), String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub async fn end_huddle(_force: Option<bool>, _state: State<'_, AppState>) -> Result<(), String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub async fn confirm_huddle_active(_state: State<'_, AppState>) -> Result<(), String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub fn get_huddle_state(_state: State<'_, AppState>) -> Result<HuddleState, String> {
+    Ok(HuddleState::default())
+}
+
+#[tauri::command]
+pub async fn get_huddle_agent_pubkeys(_state: State<'_, AppState>) -> Result<Vec<String>, String> {
+    Ok(Vec::new())
+}
+
+#[tauri::command]
+pub fn push_audio_pcm(
+    _request: tauri::ipc::Request<'_>,
+    _state: State<'_, AppState>,
+) -> Result<(), String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub async fn check_pipeline_hotstart(_state: State<'_, AppState>) -> Result<(), String> {
+    // No pipelines to hot-start. Treat as a no-op rather than an error so
+    // periodic frontend polling doesn't spam an error toast.
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn start_stt_pipeline(_state: State<'_, AppState>) -> Result<(), String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub async fn download_voice_models(_state: State<'_, AppState>) -> Result<(), String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub fn get_model_status(_state: State<'_, AppState>) -> Result<models::VoiceModelStatus, String> {
+    Ok(models::VoiceModelStatus {
+        stt: models::ModelStatus::NotDownloaded,
+        kokoro: models::ModelStatus::NotDownloaded,
+    })
+}
+
+#[tauri::command]
+pub async fn set_tts_enabled(_enabled: bool, _state: State<'_, AppState>) -> Result<(), String> {
+    Err(DISABLED.to_string())
+}
+
+#[tauri::command]
+pub async fn speak_agent_message(_text: String, _state: State<'_, AppState>) -> Result<(), String> {
+    // Silent no-op: the frontend may call this for every incoming agent
+    // message in a huddle context. Returning Err would spam the console
+    // with errors the user can't act on.
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn add_agent_to_huddle(
+    _agent_pubkey: String,
+    _state: State<'_, AppState>,
+) -> Result<agents::AgentAddResult, String> {
+    Err(DISABLED.to_string())
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,10 @@
 mod app_state;
 mod commands;
 mod events;
+#[cfg(feature = "huddle")]
+mod huddle;
+#[cfg(not(feature = "huddle"))]
+#[path = "huddle_stub.rs"]
 mod huddle;
 mod managed_agents;
 mod media_proxy;
@@ -234,94 +238,97 @@ pub fn run() {
         )
         .plugin(tauri_plugin_websocket::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_process::init())
-        .plugin({
-            use tauri_plugin_global_shortcut::ShortcutState;
+        .plugin(tauri_plugin_process::init());
 
-            // Generation counter for the release delay task. Incremented on
-            // every press — a delayed release only fires if the generation
-            // hasn't changed (i.e. no new press happened during the delay).
-            // This prevents press→release→press within 200 ms from having
-            // the first release clobber the second press.
-            let ptt_press_gen = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    // Push-to-talk global shortcut handler — only relevant when huddle is
+    // compiled in. Wraps `tauri_plugin_global_shortcut` (an optional dep).
+    #[cfg(feature = "huddle")]
+    let builder = builder.plugin({
+        use tauri_plugin_global_shortcut::ShortcutState;
 
-            tauri_plugin_global_shortcut::Builder::new()
-                .with_handler(move |app, _shortcut, event| {
-                    let state = match app.try_state::<AppState>() {
-                        Some(s) => s,
-                        None => return,
-                    };
+        // Generation counter for the release delay task. Incremented on
+        // every press — a delayed release only fires if the generation
+        // hasn't changed (i.e. no new press happened during the delay).
+        // This prevents press→release→press within 200 ms from having
+        // the first release clobber the second press.
+        let ptt_press_gen = Arc::new(std::sync::atomic::AtomicU64::new(0));
 
-                    // Only act if a huddle is active and mode is PTT.
-                    let (is_ptt_mode, is_active) = match state.huddle_state.lock() {
-                        Ok(hs) => (
-                            hs.voice_input_mode == huddle::VoiceInputMode::PushToTalk,
-                            matches!(
-                                hs.phase,
-                                huddle::HuddlePhase::Connected | huddle::HuddlePhase::Active
-                            ),
+        tauri_plugin_global_shortcut::Builder::new()
+            .with_handler(move |app, _shortcut, event| {
+                let state = match app.try_state::<AppState>() {
+                    Some(s) => s,
+                    None => return,
+                };
+
+                // Only act if a huddle is active and mode is PTT.
+                let (is_ptt_mode, is_active) = match state.huddle_state.lock() {
+                    Ok(hs) => (
+                        hs.voice_input_mode == huddle::VoiceInputMode::PushToTalk,
+                        matches!(
+                            hs.phase,
+                            huddle::HuddlePhase::Connected | huddle::HuddlePhase::Active
                         ),
-                        Err(_) => return,
-                    };
+                    ),
+                    Err(_) => return,
+                };
 
-                    if !is_ptt_mode || !is_active {
-                        return;
-                    }
+                if !is_ptt_mode || !is_active {
+                    return;
+                }
 
-                    match event.state {
-                        ShortcutState::Pressed => {
-                            // Bump generation — invalidates any pending release delay.
-                            ptt_press_gen.fetch_add(1, std::sync::atomic::Ordering::Release);
+                match event.state {
+                    ShortcutState::Pressed => {
+                        // Bump generation — invalidates any pending release delay.
+                        ptt_press_gen.fetch_add(1, std::sync::atomic::Ordering::Release);
 
-                            if let Ok(hs) = state.huddle_state.lock() {
-                                hs.ptt_active
+                        if let Ok(hs) = state.huddle_state.lock() {
+                            hs.ptt_active
+                                .store(true, std::sync::atomic::Ordering::Release);
+                            // Only cancel TTS if it's actually playing — avoids
+                            // a stale cancel flag that drops the next queued message.
+                            if hs.tts_active.load(std::sync::atomic::Ordering::Acquire) {
+                                hs.tts_cancel
                                     .store(true, std::sync::atomic::Ordering::Release);
-                                // Only cancel TTS if it's actually playing — avoids
-                                // a stale cancel flag that drops the next queued message.
-                                if hs.tts_active.load(std::sync::atomic::Ordering::Acquire) {
-                                    hs.tts_cancel
-                                        .store(true, std::sync::atomic::Ordering::Release);
+                            }
+                        }
+                        // Emit ptt-state=true to the frontend.
+                        // The React side plays the press audio cue on this event
+                        // (Web Audio API via HuddleContext). Rust-side rodio audio
+                        // was considered but rejected: the rodio OutputStream must
+                        // outlive the handler and sharing it across the shortcut
+                        // closure adds lifecycle complexity for marginal gain.
+                        // The React implementation is sufficient and simpler.
+                        let _ = app.emit("ptt-state", true);
+                    }
+                    ShortcutState::Released => {
+                        // Capture generation at release time.
+                        let gen_at_release =
+                            ptt_press_gen.load(std::sync::atomic::Ordering::Acquire);
+                        let gen_arc = Arc::clone(&ptt_press_gen);
+                        let app_handle = app.clone();
+                        // 200 ms release delay — captures the tail of the utterance.
+                        // Only applies if no new press happened during the delay.
+                        tauri::async_runtime::spawn(async move {
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                            // Check generation — if it changed, a new press arrived.
+                            if gen_arc.load(std::sync::atomic::Ordering::Acquire) != gen_at_release
+                            {
+                                return; // Superseded by a new press.
+                            }
+                            if let Some(state) = app_handle.try_state::<AppState>() {
+                                if let Ok(hs) = state.huddle_state.lock() {
+                                    hs.ptt_active
+                                        .store(false, std::sync::atomic::Ordering::Release);
                                 }
                             }
-                            // Emit ptt-state=true to the frontend.
-                            // The React side plays the press audio cue on this event
-                            // (Web Audio API via HuddleContext). Rust-side rodio audio
-                            // was considered but rejected: the rodio OutputStream must
-                            // outlive the handler and sharing it across the shortcut
-                            // closure adds lifecycle complexity for marginal gain.
-                            // The React implementation is sufficient and simpler.
-                            let _ = app.emit("ptt-state", true);
-                        }
-                        ShortcutState::Released => {
-                            // Capture generation at release time.
-                            let gen_at_release =
-                                ptt_press_gen.load(std::sync::atomic::Ordering::Acquire);
-                            let gen_arc = Arc::clone(&ptt_press_gen);
-                            let app_handle = app.clone();
-                            // 200 ms release delay — captures the tail of the utterance.
-                            // Only applies if no new press happened during the delay.
-                            tauri::async_runtime::spawn(async move {
-                                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-                                // Check generation — if it changed, a new press arrived.
-                                if gen_arc.load(std::sync::atomic::Ordering::Acquire)
-                                    != gen_at_release
-                                {
-                                    return; // Superseded by a new press.
-                                }
-                                if let Some(state) = app_handle.try_state::<AppState>() {
-                                    if let Ok(hs) = state.huddle_state.lock() {
-                                        hs.ptt_active
-                                            .store(false, std::sync::atomic::Ordering::Release);
-                                    }
-                                }
-                                // Emit ptt-state=false — React plays the release audio cue.
-                                let _ = app_handle.emit("ptt-state", false);
-                            });
-                        }
+                            // Emit ptt-state=false — React plays the release audio cue.
+                            let _ = app_handle.emit("ptt-state", false);
+                        });
                     }
-                })
-                .build()
-        });
+                }
+            })
+            .build()
+    });
 
     // Only register the updater in release builds that were compiled with a
     // real updater configuration. Local unsigned builds omit that config and
@@ -396,6 +403,7 @@ pub fn run() {
             // Pre-download voice models in the background so they're ready
             // when the user starts their first huddle. Idempotent — no-op if
             // already downloaded. ~187 MB total (~100 MB Parakeet STT + ~87 MB Kokoro).
+            #[cfg(feature = "huddle")]
             if let Some(mgr) = huddle::models::global_model_manager() {
                 mgr.start_stt_download(state.http_client.clone());
                 mgr.start_kokoro_download(state.http_client.clone());
@@ -403,7 +411,7 @@ pub fn run() {
 
             // Register PTT global shortcut (Ctrl+Space).
             // Non-fatal: huddle works without the shortcut (user can switch to VAD mode).
-            #[cfg(desktop)]
+            #[cfg(all(desktop, feature = "huddle"))]
             {
                 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
                 let shortcut = Shortcut::new(Some(Modifiers::CONTROL), Code::Space);

--- a/desktop/src-tauri/tauri.light.conf.json
+++ b/desktop/src-tauri/tauri.light.conf.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "security": {
+      "capabilities": ["default"]
+    }
+  }
+}

--- a/desktop/src/features/channels/ui/ChannelMembersBar.tsx
+++ b/desktop/src/features/channels/ui/ChannelMembersBar.tsx
@@ -1,8 +1,7 @@
 import { Plus, Settings2, Users } from "lucide-react";
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useHuddle } from "@/features/huddle";
-import { HuddleIndicator } from "@/features/huddle/components/HuddleIndicator";
+import { HuddleIndicator, useHuddle } from "@/features/huddle";
 import {
   useAcpProvidersQuery,
   useBackendProvidersQuery,

--- a/desktop/src/features/huddle/index.light.ts
+++ b/desktop/src/features/huddle/index.light.ts
@@ -1,0 +1,108 @@
+/**
+ * No-op huddle module — selected via Vite alias when VITE_SPROUT_HUDDLE=0.
+ *
+ * Mirrors the public API of ./index.ts so consumers (AppShell, ChannelMembersBar)
+ * compile and render without changes. Voice/audio code, model downloads, and
+ * the Tauri huddle commands are unavailable in this build; this module gives
+ * the rest of the UI sensible idle values so it doesn't crash.
+ */
+
+import * as React from "react";
+
+type VoiceInputMode = "push_to_talk" | "voice_activity";
+
+interface HuddleContextValue {
+  localAudioTrack: MediaStreamTrack | null;
+  isStarting: boolean;
+  huddleError: string | null;
+  clearHuddleError: () => void;
+  micConnected: boolean;
+  micLevel: number;
+  pttActive: boolean;
+  voiceInputMode: VoiceInputMode;
+  setVoiceInputMode: (mode: VoiceInputMode) => Promise<void>;
+  activeSpeakers: string[];
+  audioDevices: MediaDeviceInfo[];
+  selectedDeviceId: string;
+  setSelectedDeviceId: (id: string) => void;
+  micGain: number;
+  setMicGain: (value: number) => void;
+  outputDevices: { name: string; is_default: boolean }[];
+  selectedOutputDevice: string;
+  setSelectedOutputDevice: (name: string) => void;
+  startHuddle: (
+    parentChannelId: string,
+    memberPubkeys: string[],
+  ) => Promise<void>;
+  joinHuddle: (
+    parentChannelId: string,
+    ephemeralChannelId: string,
+  ) => Promise<void>;
+  leaveHuddle: () => Promise<boolean>;
+  endHuddle: () => Promise<boolean>;
+}
+
+const DISABLED = "voice/huddle is disabled in this build";
+
+const noopValue: HuddleContextValue = {
+  localAudioTrack: null,
+  isStarting: false,
+  huddleError: null,
+  clearHuddleError: () => {},
+  micConnected: false,
+  micLevel: 0,
+  pttActive: false,
+  voiceInputMode: "push_to_talk",
+  setVoiceInputMode: async () => {},
+  activeSpeakers: [],
+  audioDevices: [],
+  selectedDeviceId: "",
+  setSelectedDeviceId: () => {},
+  micGain: 1,
+  setMicGain: () => {},
+  outputDevices: [],
+  selectedOutputDevice: "",
+  setSelectedOutputDevice: () => {},
+  startHuddle: async () => {
+    throw new Error(DISABLED);
+  },
+  joinHuddle: async () => {
+    throw new Error(DISABLED);
+  },
+  leaveHuddle: async () => false,
+  endHuddle: async () => false,
+};
+
+export function HuddleProvider({ children }: { children: React.ReactNode }) {
+  return React.createElement(React.Fragment, null, children);
+}
+
+export function useHuddle(): HuddleContextValue {
+  return noopValue;
+}
+
+export function HuddleBar(): null {
+  return null;
+}
+
+/** No-op stand-in for the channel-bar headphone icon. */
+export function HuddleIndicator(_props: {
+  channelId: string;
+  className?: string;
+  onStart?: () => void;
+  startDisabled?: boolean;
+}): null {
+  return null;
+}
+
+export function ParticipantList(_props: {
+  ephemeralChannelId: string;
+  participants: Set<string>;
+}): null {
+  return null;
+}
+
+/** Audio worklet is unavailable — return a shape compatible with the real one. */
+export async function setupAudioWorklet(): Promise<never> {
+  throw new Error(DISABLED);
+}

--- a/desktop/src/features/huddle/index.ts
+++ b/desktop/src/features/huddle/index.ts
@@ -1,4 +1,5 @@
 export { HuddleProvider, useHuddle } from "./HuddleContext";
 export { setupAudioWorklet } from "./lib/audioWorklet";
 export { HuddleBar } from "./components/HuddleBar";
+export { HuddleIndicator } from "./components/HuddleIndicator";
 export { ParticipantList } from "./components/ParticipantList";

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -22,9 +22,26 @@ export default defineConfig(async () => ({
     react(),
   ],
   resolve: {
-    alias: {
-      "@": "/src",
-    },
+    // Use array form so we control match order: the longer
+    // "@/features/huddle" prefix must be evaluated before the bare "@"
+    // alias, otherwise Vite resolves @-paths via the broader rule first.
+    // When VITE_SPROUT_HUDDLE=0 (desktop-light build), point the huddle
+    // module at a no-op shim that exposes the same exports as
+    // src/features/huddle/index.ts (HuddleProvider, useHuddle, HuddleBar,
+    // HuddleIndicator, ParticipantList, setupAudioWorklet). Pairs with
+    // the `huddle` Cargo feature in desktop/src-tauri/Cargo.toml.
+    alias: [
+      // @ts-expect-error process is a nodejs global
+      ...(process.env.VITE_SPROUT_HUDDLE === "0"
+        ? [
+            {
+              find: /^@\/features\/huddle$/,
+              replacement: "/src/features/huddle/index.light.ts",
+            },
+          ]
+        : []),
+      { find: "@", replacement: "/src" },
+    ],
   },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/justfile
+++ b/justfile
@@ -143,10 +143,12 @@ desktop-light-build target="aarch64-apple-darwin":
     touch "desktop/src-tauri/binaries/sprout-dev-mcp-$TARGET"
     touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET"
     pnpm install
+    # tauri-cli forwards args after `--` to cargo, so --no-default-features
+    # goes after the separator.
     cd {{desktop_dir}} && VITE_SPROUT_HUDDLE=0 pnpm tauri build \
         --target {{target}} \
-        --no-default-features \
-        --config src-tauri/tauri.light.conf.json
+        --config src-tauri/tauri.light.conf.json \
+        -- --no-default-features
 
 # Run desktop checks suitable for CI / pre-push (full + light)
 desktop-ci: desktop-check desktop-tauri-fmt-check desktop-build desktop-tauri-check desktop-light-check
@@ -228,11 +230,14 @@ desktop-light *ARGS: _ensure-sidecar-stubs
     [[ -d node_modules ]] || pnpm install
     source ../scripts/instance-env.sh
     echo "Starting LIGHT (no huddle) on Vite port ${SPROUT_VITE_PORT}, relay ${SPROUT_RELAY_URL}"
+    # tauri-cli forwards args after `--` to cargo, so --no-default-features
+    # goes after the separator. User-supplied {{ARGS}} go before it so they
+    # reach the tauri sub-command (e.g. --release, --no-watch).
     VITE_SPROUT_HUDDLE=0 pnpm exec tauri dev \
         --config "$SPROUT_TAURI_CONFIG" \
         --config src-tauri/tauri.light.conf.json \
-        --no-default-features \
-        {{ARGS}}
+        {{ARGS}} \
+        -- --no-default-features
 
 # Run the desktop app against the internal staging relay (installs deps + builds agent tools automatically)
 staging *ARGS: _ensure-sidecar-stubs

--- a/justfile
+++ b/justfile
@@ -107,6 +107,13 @@ _ensure-sidecar-stubs:
 desktop-tauri-check: _ensure-sidecar-stubs
     cargo check --manifest-path {{desktop_tauri_manifest}}
 
+# Drops sherpa-onnx, ort, opus, rodio, ndarray, rubato, earshot,
+# audioadapter-buffers, and tauri-plugin-global-shortcut from the dep graph.
+# Run on wimpy machines or in CI to keep the no-default-features path green.
+# Check the desktop Tauri Rust crate compiles WITHOUT the huddle feature
+desktop-light-check: _ensure-sidecar-stubs
+    cargo check --manifest-path {{desktop_tauri_manifest}} --no-default-features
+
 # Build the full desktop Tauri app locally (unsigned, for testing)
 desktop-release-build target="aarch64-apple-darwin":
     #!/usr/bin/env bash
@@ -121,8 +128,28 @@ desktop-release-build target="aarch64-apple-darwin":
     pnpm install
     cd {{desktop_dir}} && pnpm tauri build --target {{target}}
 
-# Run desktop checks suitable for CI / pre-push
-desktop-ci: desktop-check desktop-tauri-fmt-check desktop-build desktop-tauri-check
+# Pairs with VITE_SPROUT_HUDDLE=0 on the frontend to swap the huddle
+# module for a no-op shim. Drops sherpa-onnx, ort, opus, rodio, ndarray,
+# rubato, earshot, audioadapter-buffers, and tauri-plugin-global-shortcut.
+# Build the desktop Tauri app locally WITHOUT the huddle feature
+desktop-light-build target="aarch64-apple-darwin":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    TARGET={{target}}
+    mkdir -p desktop/src-tauri/binaries
+    touch "desktop/src-tauri/binaries/sprout-acp-$TARGET"
+    touch "desktop/src-tauri/binaries/sprout-mcp-server-$TARGET"
+    touch "desktop/src-tauri/binaries/sprout-agent-$TARGET"
+    touch "desktop/src-tauri/binaries/sprout-dev-mcp-$TARGET"
+    touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET"
+    pnpm install
+    cd {{desktop_dir}} && VITE_SPROUT_HUDDLE=0 pnpm tauri build \
+        --target {{target}} \
+        --no-default-features \
+        --config src-tauri/tauri.light.conf.json
+
+# Run desktop checks suitable for CI / pre-push (full + light)
+desktop-ci: desktop-check desktop-tauri-fmt-check desktop-build desktop-tauri-check desktop-light-check
 
 # Seed deterministic channel data for desktop Playwright tests
 desktop-e2e-seed:
@@ -188,6 +215,24 @@ dev *ARGS: _ensure-sidecar-stubs
     source ../scripts/instance-env.sh
     echo "Starting on Vite port ${SPROUT_VITE_PORT}, relay ${SPROUT_RELAY_URL}"
     pnpm exec tauri dev --config "$SPROUT_TAURI_CONFIG" {{ARGS}}
+
+# Fast iteration on machines that can't compile the native TTS/STT stack.
+# Drops the heavy deps via --no-default-features, swaps the frontend
+# huddle module for a no-op shim via VITE_SPROUT_HUDDLE=0, and layers
+# a Tauri config override so the global-shortcut ACL isn't required.
+# Run the desktop Tauri app in dev mode WITHOUT the huddle feature
+desktop-light *ARGS: _ensure-sidecar-stubs
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd {{desktop_dir}}
+    [[ -d node_modules ]] || pnpm install
+    source ../scripts/instance-env.sh
+    echo "Starting LIGHT (no huddle) on Vite port ${SPROUT_VITE_PORT}, relay ${SPROUT_RELAY_URL}"
+    VITE_SPROUT_HUDDLE=0 pnpm exec tauri dev \
+        --config "$SPROUT_TAURI_CONFIG" \
+        --config src-tauri/tauri.light.conf.json \
+        --no-default-features \
+        {{ARGS}}
 
 # Run the desktop app against the internal staging relay (installs deps + builds agent tools automatically)
 staging *ARGS: _ensure-sidecar-stubs


### PR DESCRIPTION
## Summary

Adds an opt-out `huddle` Cargo feature so the desktop app can be built without the TTS / STT / push-to-talk stack. Disabling it drops nine native dependencies from the build entirely and skips a ~187 MB first-run model download — turning the desktop app into something a wimpy machine can actually compile.

The full desktop app builds and behaves exactly as before by default; nothing about voice/huddle is changed for normal users.

## Why

The desktop crate currently pulls in a heavy native stack to support agent voice huddles:

- `sherpa-onnx` + `sherpa-onnx-sys` — STT (Parakeet TDT-CTC 110M), C++ build via the -sys crate
- `ort` 2.0-rc.12 with `download-binaries` — ONNX Runtime for the Kokoro TTS model (~100 MB native blob downloaded at build time)
- `ndarray`, `rodio` (pulls cpal + symphonia + coreaudio-rs), `rubato`, `opus`, `earshot` (VAD), `audioadapter-buffers`
- `tauri-plugin-global-shortcut` for push-to-talk

For developers on slow boxes, CI lanes that just need to verify the chat surface, or anyone who doesn't care about voice, this is a lot of compile time for nothing. The huddle code is already a clean vertical slice on both sides of the IPC bridge, so an opt-out compile flag is small and contained.

## How it works

Three coordinated knobs, one user-facing recipe (`just desktop-light`):

### 1. Rust: `huddle` Cargo feature (default-on)

`desktop/src-tauri/Cargo.toml` moves nine heavy deps to `optional = true` and a single `huddle` feature pulls them in. The default features include `huddle` so existing workflows are unaffected.

`src/huddle/` (the full module) is selected on default. With the feature off, a same-name stub module is selected via `#[path]`:

```rust
#[cfg(feature = "huddle")]
mod huddle;
#[cfg(not(feature = "huddle"))]
#[path = "huddle_stub.rs"]
mod huddle;
```

`src/huddle_stub.rs` mirrors the public API one-for-one — same types (`HuddleState`, `HuddlePhase`, `VoiceInputMode`, `HuddleJoinInfo`), same submodule paths (`state::`, `models::`, `audio_output::`, `agents::`), and **same Tauri command names**. Mutating commands return `Err("voice/huddle is disabled in this build")`; read-only queries (`get_huddle_state`, `get_model_status`, `list_audio_output_devices`, etc.) return idle/empty values so the frontend renders gracefully if it ever asks. The `generate_handler!` invocation in `lib.rs` is identical in both modes — no command surface drift.

Only three setup-time call sites touch the optional Tauri plugin directly, so they get inline `#[cfg(feature = "huddle")]`:

- The push-to-talk `tauri_plugin_global_shortcut::Builder` block (now `let builder = builder.plugin(…)` chained on the previous statement)
- The voice-model predownload in `setup()`
- The Ctrl+Space shortcut registration in `setup()`

### 2. Tauri capability split + build.rs ACL pattern

`tauri-build`'s ACL validator scans `capabilities/**/*` by default and **rejects unknown plugin perms** even if `app.security.capabilities` doesn't reference them. `TAURI_CONFIG` env override doesn't help because the scan is purely filesystem-driven.

Fix: split the capability file in two and tell `tauri_build` which to scan from `build.rs`:

- `capabilities/default.json` — base ACL (no `global-shortcut:*`)
- `capabilities/huddle.json` — new, holds the three `global-shortcut:*` perms
- `build.rs` reads `CARGO_FEATURE_HUDDLE` and passes `capabilities_path_pattern("./capabilities/default.json")` to `tauri_build::try_build()` when the feature is off
- `tauri.light.conf.json` — new, sets `app.security.capabilities = ["default"]` for runtime consistency

### 3. Frontend: Vite alias swap for the huddle module

`src/features/huddle/index.light.ts` is a tiny shim (~110 lines) exporting the same six symbols as the full module — `HuddleProvider`, `useHuddle`, `HuddleBar`, `HuddleIndicator`, `ParticipantList`, `setupAudioWorklet` — but as no-op React components and an idle `useHuddle()` context value with the full `HuddleContextValue` shape preserved.

`vite.config.ts` selects the shim via `resolve.alias` when `VITE_SPROUT_HUDDLE=0`, using **array form** so the longer `@/features/huddle` regex prefix is evaluated before the bare `@` catch-all (object-form alias maps fall through to `@` first).

One small refactor in `ChannelMembersBar.tsx`: it now imports `HuddleIndicator` from `@/features/huddle` instead of the deep path `@/features/huddle/components/HuddleIndicator`, so a single alias entry covers every consumer.

### 4. justfile + docs

Three new recipes — `desktop-light` (dev), `desktop-light-build` (packaged), `desktop-light-check` (cargo check) — that combine the three knobs above. `desktop-light-check` is added to `desktop-ci` so the no-huddle path can't bit-rot locally.

`desktop/README.md` gets a short section documenting the build options.

## CI protection

The light path is exercised by a new `Desktop Tauri light check` step in `.github/workflows/ci.yml`, added immediately after the existing `Desktop Tauri check` step:

```yaml
- name: Desktop Tauri light check (no huddle)
  run: just desktop-light-check
  env:
    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
```

So both default and `--no-default-features` cargo checks run on every PR.

## Verification

### Rust dep graph

```
cargo tree --manifest-path desktop/src-tauri/Cargo.toml --edges normal | wc -l
  → 622 unique crates (full)
cargo tree --manifest-path desktop/src-tauri/Cargo.toml --no-default-features --edges normal | wc -l
  → 548 unique crates (light, -74)
```

Light tree contains **none** of: `sherpa-onnx`, `sherpa-onnx-sys`, `ort`, `ort-sys`, `opus`, `rodio`, `cpal`, `coreaudio-rs`, `symphonia*`, `ndarray`, `rubato`, `earshot`, `audioadapter-buffers`, `tauri-plugin-global-shortcut`. Full tree still contains all of them.

### Compile

- `just desktop-tauri-check` (full, default features) — green, zero warnings
- `just desktop-light-check` (`cargo check --no-default-features`) — green, zero warnings

### Frontend

- `pnpm typecheck` — clean
- `pnpm check` (biome lint + format + size-limits) — clean
- `pnpm build` (full) — succeeds
- `VITE_SPROUT_HUDDLE=0 pnpm build` (light) — succeeds; the resulting bundle drops the huddle-specific strings `setupAudioWorklet`, `push_audio_pcm`, `huddle-state-changed`, `kokoro` and the entire useTtsSubscription / audioWorklet codepaths

### Playwright

Smoke suite against the light frontend bundle: **94/95 passing**. The single failure (`channel-browser.spec.ts:19`, a keyboard shortcut timing case) **also fails on the unmodified full build** on this host — pre-existing flake, not introduced by this PR. The full `channels.spec.ts` suite passes, which is the meaningful check because that's where `ChannelMembersBar` (the consumer importing `useHuddle` / `HuddleIndicator`) gets exercised in real navigation flows.

### Review pass

Max code-reviewed the pushed branch independently — confirmed the dep-graph diff, build behavior, capability/ACL fix, alias robustness, and that all three commits carry SSH `gpgsig` headers and DCO signoffs.

## Out of scope (intentional)

- **Splitting `stt`/`tts` into separate features.** Currently overlapping support stack (rodio, opus, audio relay, model lifecycle) and one user-facing surface — false precision today. Easy to split later if a real "voice without TTS" use case appears.
- **Mobile.** This change is desktop-only by design; the mobile crate is untouched.
- **Bundle size.** The full-feature **frontend** bundle barely shrinks (huddle code is a small fraction; React + shiki + tiptap + emoji-mart dominate). The wins here are native compile time, binary size, and the eliminated 187 MB model download — exactly what the request asked for.

## AI Assistance

- [x] This PR was created with AI assistance.

Signed-off-by: Tyler Longwell <tlongwell@squareup.com>
