### PR TITLE
fix(desktop): worktree support — workspace boundary + shared identity

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "sprout"
 version = "0.1.0"

--- a/desktop/src/features/onboarding/hooks.ts
+++ b/desktop/src/features/onboarding/hooks.ts
@@ -33,6 +33,7 @@ type OnboardingGateStage = "blocking" | "onboarding" | "ready";
 
 type UseFirstRunOnboardingGateOptions = {
   currentPubkey: string | null;
+  hasExistingProfile: boolean;
   identityIsFetching: boolean;
   identityStatus: QueryStatus;
   profileStatus: QueryStatus;
@@ -125,6 +126,7 @@ function resolveOnboardingGateStage({
 
 export function useFirstRunOnboardingGate({
   currentPubkey,
+  hasExistingProfile,
   identityIsFetching,
   identityStatus,
   profileStatus,
@@ -166,14 +168,37 @@ export function useFirstRunOnboardingGate({
       return;
     }
 
+    // If the relay already has a real profile for this pubkey, the user has
+    // been onboarded elsewhere — skip the gate and persist the completion so
+    // future launches in this data dir don't re-check.
+    if (hasExistingProfile) {
+      if (typeof window !== "undefined" && currentPubkey) {
+        window.localStorage.setItem(
+          onboardingCompletionStorageKey(currentPubkey),
+          "true",
+        );
+      }
+    }
+
     setGateState((current) =>
-      updateActiveGateState(current, currentPubkey, (activeGateState) => ({
-        ...activeGateState,
-        hasSettledCurrentPubkey: true,
-        isOpen: !activeGateState.hasCompletedCurrentPubkey,
-      })),
+      updateActiveGateState(current, currentPubkey, (activeGateState) => {
+        const alreadyOnboarded =
+          activeGateState.hasCompletedCurrentPubkey || hasExistingProfile;
+        return {
+          ...activeGateState,
+          hasCompletedCurrentPubkey: alreadyOnboarded,
+          hasSettledCurrentPubkey: true,
+          isOpen: !alreadyOnboarded,
+        };
+      }),
     );
-  }, [currentPubkey, hasSettledCurrentPubkey, identityStatus, profileStatus]);
+  }, [
+    currentPubkey,
+    hasExistingProfile,
+    hasSettledCurrentPubkey,
+    identityStatus,
+    profileStatus,
+  ]);
 
   const skipForNow = React.useCallback(() => {
     setGateState((current) =>
@@ -213,6 +238,14 @@ export function useFirstRunOnboardingGate({
   };
 }
 
+function hasRealDisplayName(displayName?: string | null): boolean {
+  if (!displayName) return false;
+  const trimmed = displayName.trim();
+  if (trimmed.length === 0) return false;
+  const lower = trimmed.toLowerCase();
+  return !lower.startsWith("npub1") && !lower.startsWith("nostr:npub1");
+}
+
 export function useAppOnboardingState() {
   const queryClient = useQueryClient();
   const identityQuery = useIdentityQuery();
@@ -221,6 +254,7 @@ export function useAppOnboardingState() {
   const profileQuery = useProfileQuery();
   const onboardingGate = useFirstRunOnboardingGate({
     currentPubkey,
+    hasExistingProfile: hasRealDisplayName(profileQuery.data?.displayName),
     identityIsFetching: identityQuery.fetchStatus === "fetching",
     identityStatus: identityQuery.status,
     profileStatus: profileQuery.status,

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -9,6 +9,10 @@ const BLANK_TYLER_IDENTITY = {
   ...TEST_IDENTITIES.tyler,
   username: "",
 };
+const FIRST_RUN_ALICE = {
+  ...TEST_IDENTITIES.alice,
+  username: "",
+};
 
 type TestIdentity = {
   privateKey: string;
@@ -139,17 +143,16 @@ test("page 1 accepts an avatar URL as the secondary avatar path", async ({
 test("first-run onboarding keeps the shell hidden through both pages and only marks Home seen after finish", async ({
   page,
 }) => {
-  await seedActiveIdentity(page, TEST_IDENTITIES.alice);
+  await seedActiveIdentity(page, FIRST_RUN_ALICE);
   await installMockBridge(page, undefined, { skipOnboardingSeed: true });
   await page.goto("/");
 
   await expect(page.getByTestId("onboarding-gate")).toBeVisible();
   await expect(page.getByTestId("onboarding-page-1")).toBeVisible();
-  await expect(page.getByTestId("onboarding-display-name")).toHaveValue(
-    "alice",
-  );
+  await expect(page.getByTestId("onboarding-display-name")).toHaveValue("");
   await expectNoHomeSeenEntries(page);
 
+  await page.getByTestId("onboarding-display-name").fill("Alice");
   await continueToSetupPage(page);
   await expectShellHidden(page);
   await expect(page.getByTestId("onboarding-provider-goose")).toBeVisible();
@@ -159,6 +162,17 @@ test("first-run onboarding keeps the shell hidden through both pages and only ma
   await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
   await expect(page.getByTestId("chat-title")).toHaveText("Home");
   await expectHomeSeenCount(page, 2);
+});
+
+test("existing relay profile auto-skips onboarding without localStorage completion", async ({
+  page,
+}) => {
+  await seedActiveIdentity(page, TEST_IDENTITIES.alice);
+  await installMockBridge(page, undefined, { skipOnboardingSeed: true });
+  await page.goto("/");
+
+  await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await expect(page.getByTestId("chat-title")).toHaveText("Home");
 });
 
 test("finishing onboarding auto-joins the #general channel for a new member", async ({
@@ -179,7 +193,7 @@ test("finishing onboarding auto-joins the #general channel for a new member", as
 test("page 2 falls back to Doctor guidance when ACP tools are not installed", async ({
   page,
 }) => {
-  await seedActiveIdentity(page, TEST_IDENTITIES.alice);
+  await seedActiveIdentity(page, FIRST_RUN_ALICE);
   await installMockBridge(
     page,
     {
@@ -189,6 +203,7 @@ test("page 2 falls back to Doctor guidance when ACP tools are not installed", as
   );
   await page.goto("/");
 
+  await page.getByTestId("onboarding-display-name").fill("Alice");
   await continueToSetupPage(page);
   await expect(page.getByTestId("onboarding-acp-empty")).toBeVisible();
   await expect(

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -24,12 +24,29 @@ unset VITE_DEV_BRANCH
 
 # In worktrees, extract a label from the branch name and derive a unique app
 # identity and icon so multiple local desktop instances can run side by side.
+#
+# Worktree detection: compare --git-dir to --git-common-dir. In the main
+# working tree these are identical; in any worktree (whether under .worktrees/,
+# .claude/worktrees/, or elsewhere on disk) they differ.
 if git rev-parse --is-inside-work-tree &>/dev/null; then
     GIT_DIR=$(git rev-parse --git-dir)
-    if [[ "$GIT_DIR" == *".git/worktrees/"* ]]; then
+    GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+    if [[ -n "$GIT_COMMON_DIR" && "$GIT_DIR" != "$GIT_COMMON_DIR" ]]; then
         BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
         export SPROUT_WORKTREE_LABEL="${BRANCH_NAME##*/}"
         export SPROUT_INSTANCE_SLUG=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
+
+        # SPROUT_SHARE_IDENTITY=1: reuse the base dev identity and data dir so
+        # worktrees skip onboarding and use the same Nostr key as the main checkout.
+        if [[ "${SPROUT_SHARE_IDENTITY:-0}" == "1" ]]; then
+            CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.sprout.app.dev/identity.key"
+            if [[ -f "$CANONICAL_KEY" ]]; then
+                export SPROUT_PRIVATE_KEY=$(cat "$CANONICAL_KEY")
+            fi
+            WORKTREE_IDENTIFIER="xyz.block.sprout.app.dev"
+        else
+            WORKTREE_IDENTIFIER="xyz.block.sprout.app.dev.${SPROUT_INSTANCE_SLUG}"
+        fi
 
         ICON_DIR="$(pwd)/src-tauri/target/dev-icons"
         mkdir -p "$ICON_DIR"
@@ -38,7 +55,7 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         if swift ../scripts/generate-dev-icon.swift src-tauri/icons/icon.icns "$DEV_ICON" "$SPROUT_WORKTREE_LABEL"; then
             echo "🌳 Worktree: ${SPROUT_WORKTREE_LABEL}"
             export VITE_DEV_BRANCH="$SPROUT_WORKTREE_LABEL"
-            SPROUT_TAURI_CONFIG="{\"build\":{\"devUrl\":\"http://localhost:${SPROUT_VITE_PORT}\",\"beforeDevCommand\":\"exec ./node_modules/.bin/vite --port ${SPROUT_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.sprout.app.dev.${SPROUT_INSTANCE_SLUG}\",\"productName\":\"Sprout Dev (${SPROUT_WORKTREE_LABEL})\",\"bundle\":{\"icon\":[\"$DEV_ICON\"]}}"
+            SPROUT_TAURI_CONFIG="{\"build\":{\"devUrl\":\"http://localhost:${SPROUT_VITE_PORT}\",\"beforeDevCommand\":\"exec ./node_modules/.bin/vite --port ${SPROUT_VITE_PORT} --strictPort\"},\"identifier\":\"${WORKTREE_IDENTIFIER}\",\"productName\":\"Sprout Dev (${SPROUT_WORKTREE_LABEL})\",\"bundle\":{\"icon\":[\"$DEV_ICON\"]}}"
         fi
     fi
 fi

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -36,16 +36,15 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         export SPROUT_WORKTREE_LABEL="${BRANCH_NAME##*/}"
         export SPROUT_INSTANCE_SLUG=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
 
-        # SPROUT_SHARE_IDENTITY=1: reuse the base dev identity and data dir so
-        # worktrees skip onboarding and use the same Nostr key as the main checkout.
+        # SPROUT_SHARE_IDENTITY=1: reuse the main dev checkout's Nostr key so
+        # worktrees skip onboarding and share the same identity. The per-worktree
+        # identifier is kept so concurrent instances don't collide on
+        # tauri-plugin-single-instance or the app data directory.
         if [[ "${SPROUT_SHARE_IDENTITY:-0}" == "1" ]]; then
             CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.sprout.app.dev/identity.key"
             if [[ -f "$CANONICAL_KEY" ]]; then
                 export SPROUT_PRIVATE_KEY=$(cat "$CANONICAL_KEY")
             fi
-            WORKTREE_IDENTIFIER="xyz.block.sprout.app.dev"
-        else
-            WORKTREE_IDENTIFIER="xyz.block.sprout.app.dev.${SPROUT_INSTANCE_SLUG}"
         fi
 
         ICON_DIR="$(pwd)/src-tauri/target/dev-icons"
@@ -55,7 +54,7 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         if swift ../scripts/generate-dev-icon.swift src-tauri/icons/icon.icns "$DEV_ICON" "$SPROUT_WORKTREE_LABEL"; then
             echo "🌳 Worktree: ${SPROUT_WORKTREE_LABEL}"
             export VITE_DEV_BRANCH="$SPROUT_WORKTREE_LABEL"
-            SPROUT_TAURI_CONFIG="{\"build\":{\"devUrl\":\"http://localhost:${SPROUT_VITE_PORT}\",\"beforeDevCommand\":\"exec ./node_modules/.bin/vite --port ${SPROUT_VITE_PORT} --strictPort\"},\"identifier\":\"${WORKTREE_IDENTIFIER}\",\"productName\":\"Sprout Dev (${SPROUT_WORKTREE_LABEL})\",\"bundle\":{\"icon\":[\"$DEV_ICON\"]}}"
+            SPROUT_TAURI_CONFIG="{\"build\":{\"devUrl\":\"http://localhost:${SPROUT_VITE_PORT}\",\"beforeDevCommand\":\"exec ./node_modules/.bin/vite --port ${SPROUT_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.sprout.app.dev.${SPROUT_INSTANCE_SLUG}\",\"productName\":\"Sprout Dev (${SPROUT_WORKTREE_LABEL})\",\"bundle\":{\"icon\":[\"$DEV_ICON\"]}}"
         fi
     fi
 fi

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -5,6 +5,7 @@
 #   SPROUT_RELAY_PORT, SPROUT_RELAY_URL
 #   SPROUT_INSTANCE_SLUG, SPROUT_WORKTREE_LABEL, VITE_DEV_BRANCH (worktrees only)
 #   SPROUT_TAURI_CONFIG
+#   SPROUT_PRIVATE_KEY (worktrees only, when SPROUT_SHARE_IDENTITY=1)
 
 WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
@@ -43,7 +44,9 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         if [[ "${SPROUT_SHARE_IDENTITY:-0}" == "1" ]]; then
             CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.sprout.app.dev/identity.key"
             if [[ -f "$CANONICAL_KEY" ]]; then
-                export SPROUT_PRIVATE_KEY=$(cat "$CANONICAL_KEY")
+                export SPROUT_PRIVATE_KEY="$(cat "$CANONICAL_KEY")"
+            else
+                echo "⚠ SPROUT_SHARE_IDENTITY=1 but no identity found at $CANONICAL_KEY — run Sprout from repo root first" >&2
             fi
         fi
 


### PR DESCRIPTION
## Summary

Three fixes for running Sprout from git worktrees, plus E2E test updates and review feedback:

1. **Cargo workspace boundary** (`desktop/src-tauri/Cargo.toml`) — adds a bare `[workspace]` table so `cargo metadata` (and Tauri CLI) stops walking up the directory tree into the main repo root. Fixes the `"current package believes it's in a workspace when it's not"` error that blocks `just dev`/`just staging` in worktrees.

2. **Opt-in shared identity** (`scripts/instance-env.sh`) — `SPROUT_SHARE_IDENTITY=1` reads the nsec from `~/Library/Application Support/xyz.block.sprout.app.dev/identity.key` and exports it as `SPROUT_PRIVATE_KEY`, so worktrees use the same Nostr identity as the main checkout. Per-worktree Tauri identifiers are preserved so concurrent instances don't collide.

3. **Auto-skip onboarding for existing profiles** (`desktop/src/features/onboarding/hooks.ts`) — when the relay already has a profile with a real display name for the current pubkey, onboarding is auto-completed and persisted to localStorage. Fixes the "half-onboarded" state where fields are prefilled but the user is still forced through the setup flow. Also improves the general UX when importing an existing nsec into a new Sprout installation.

4. **E2E test updates + shell script hardening** (`desktop/tests/e2e/onboarding.spec.ts`, `scripts/instance-env.sh`) — updates two onboarding E2E tests that relied on the old behavior (profile exists on relay but onboarding still shows), adds a new test verifying the auto-skip path, quotes the `SPROUT_PRIVATE_KEY` command substitution, and adds a stderr warning when `SPROUT_SHARE_IDENTITY=1` is set but the canonical identity key doesn't exist.

### Worktree detection improvement

Replaces the fragile `.git/worktrees/` path-pattern check with a `--git-dir` vs `--git-common-dir` comparison. This works for worktrees stored anywhere on disk (`.worktrees/`, `.claude/worktrees/`, or external paths).

### Usage

```bash
# From any worktree — uses your existing identity, skips onboarding
SPROUT_SHARE_IDENTITY=1 just staging

# Or set it permanently
echo 'SPROUT_SHARE_IDENTITY=1' >> .env
```