### PR TITLE
feat(acp): --no-memory flag to disable NIP-AE core injection

### DIFF
--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -328,6 +328,17 @@ pub struct CliArgs {
     #[arg(long, env = "SPROUT_ACP_NO_TYPING")]
     pub no_typing: bool,
 
+    /// Disable NIP-AE agent core memory injection.
+    ///
+    /// When set, the harness skips the per-session core engram fetch and
+    /// renders prompts with no `[Agent Memory — core]` section, regardless of
+    /// whether a core engram exists on the relay. The `sprout mem` CLI and
+    /// the relay's acceptance of kind:30174 engrams are unaffected — this
+    /// flag is purely an opt-out for prompt-time injection in the ACP
+    /// harness.
+    #[arg(long, env = "SPROUT_ACP_NO_MEMORY")]
+    pub no_memory: bool,
+
     /// Desired LLM model ID. Applied to every new ACP session after creation.
     /// Use `sprout-acp models` to discover available model IDs.
     #[arg(long, env = "SPROUT_ACP_MODEL")]
@@ -416,6 +427,11 @@ pub struct Config {
     pub max_turns_per_session: u32,
     pub presence_enabled: bool,
     pub typing_enabled: bool,
+    /// Whether NIP-AE agent core memory injection is enabled. When false,
+    /// the harness skips the per-session core engram fetch and renders no
+    /// `[Agent Memory — core]` section. Mirrors the `--no-memory` /
+    /// `SPROUT_ACP_NO_MEMORY` opt-out.
+    pub memory_enabled: bool,
     /// Desired LLM model ID. Applied after every `session_new_full()`.
     pub model: Option<String>,
     /// Permission mode to apply after session creation. `Default` = skip.
@@ -761,6 +777,7 @@ impl Config {
             max_turns_per_session: args.max_turns_per_session,
             presence_enabled: !args.no_presence,
             typing_enabled: !args.no_typing,
+            memory_enabled: !args.no_memory,
             model,
             permission_mode: args.permission_mode,
             respond_to: args.respond_to,
@@ -782,7 +799,7 @@ impl Config {
             other => format!("respond_to={other}"),
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} model={} permission_mode={} {}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -800,6 +817,7 @@ impl Config {
             self.max_turns_per_session,
             self.presence_enabled,
             self.typing_enabled,
+            self.memory_enabled,
             self.model.as_deref().unwrap_or("(agent default)"),
             self.permission_mode,
             respond_to_detail,
@@ -1122,6 +1140,7 @@ mod tests {
             max_turns_per_session: 0,
             presence_enabled: true,
             typing_enabled: true,
+            memory_enabled: true,
             model: None,
             permission_mode: PermissionMode::BypassPermissions,
             respond_to: RespondTo::Anyone,
@@ -1702,6 +1721,38 @@ channels = "ALL"
         assert!(
             s.contains("heartbeat=30s"),
             "summary should include heartbeat=30s, got: {s}"
+        );
+    }
+
+    // ── no-memory toggle ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_memory_enabled_default_true() {
+        let config = test_config(SubscribeMode::Mentions);
+        assert!(
+            config.memory_enabled,
+            "memory_enabled should default to true"
+        );
+    }
+
+    #[test]
+    fn test_summary_includes_memory_enabled() {
+        let config = test_config(SubscribeMode::Mentions);
+        let s = config.summary();
+        assert!(
+            s.contains("memory=true"),
+            "summary should include memory=true by default, got: {s}"
+        );
+    }
+
+    #[test]
+    fn test_summary_reflects_memory_disabled() {
+        let mut config = test_config(SubscribeMode::Mentions);
+        config.memory_enabled = false;
+        let s = config.summary();
+        assert!(
+            s.contains("memory=false"),
+            "summary should include memory=false when disabled, got: {s}"
         );
     }
 

--- a/crates/sprout-acp/src/lib.rs
+++ b/crates/sprout-acp/src/lib.rs
@@ -1089,7 +1089,15 @@ async fn tokio_main() -> Result<()> {
         agent_owner_pubkey: startup_owner
             .as_deref()
             .and_then(|hex| nostr::PublicKey::from_hex(hex).ok()),
+        memory_enabled: config.memory_enabled,
     });
+
+    if !config.memory_enabled {
+        tracing::info!(
+            target: "engram::core",
+            "NIP-AE core memory injection disabled (--no-memory / SPROUT_ACP_NO_MEMORY)"
+        );
+    }
 
     // ── Step 6: Heartbeat timer ───────────────────────────────────────────────
     let mut heartbeat = if config.heartbeat_interval_secs > 0 {
@@ -2753,6 +2761,7 @@ mod build_mcp_servers_tests {
             max_turns_per_session: 0,
             presence_enabled: true,
             typing_enabled: true,
+            memory_enabled: true,
             model: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,

--- a/crates/sprout-acp/src/pool.rs
+++ b/crates/sprout-acp/src/pool.rs
@@ -209,6 +209,12 @@ pub struct PromptContext {
     /// Owner pubkey (hex), if resolved at startup. When unset, NIP-AE core
     /// injection is skipped entirely (no owner = no `(agent, owner)` pair).
     pub agent_owner_pubkey: Option<nostr::PublicKey>,
+    /// Whether NIP-AE agent core memory injection is enabled. When false,
+    /// the per-session core engram fetch is skipped and `core_sections`
+    /// remains empty for every channel, so `format_prompt` renders no
+    /// `[Agent Memory — core]` section. Driven by `--no-memory` /
+    /// `SPROUT_ACP_NO_MEMORY`.
+    pub memory_enabled: bool,
 }
 
 // ── AgentPool impl ────────────────────────────────────────────────────────────
@@ -767,7 +773,13 @@ pub async fn run_prompt_task(
     // Per Tyler's locked spec: NO mid-session refreshes. Re-fetch only
     // happens when a session is invalidated and recreated (see
     // `SessionState::invalidate_channel`).
-    if is_new_session {
+    //
+    // Operator opt-out: `--no-memory` / `SPROUT_ACP_NO_MEMORY` disables the
+    // entire NIP-AE injection path. We skip the fetch outright and leave
+    // `state.core_sections` empty, so `format_prompt` renders no core
+    // section. The `sprout mem` CLI and the relay's acceptance of
+    // kind:30174 engrams are unaffected.
+    if is_new_session && ctx.memory_enabled {
         if let (PromptSource::Channel(cid), Some(owner_pk)) =
             (&source, ctx.agent_owner_pubkey.as_ref())
         {


### PR DESCRIPTION
Adds an operator opt-out for the ACP harness's NIP-AE agent core memory injection path, mirroring the existing `--no-presence` / `--no-typing` conventions.

## Flag

- `--no-memory` / `SPROUT_ACP_NO_MEMORY`
- Default: **off** (memory injection enabled — current behavior is unchanged when the flag is not set)

## Effect when set

- `pool.rs`: the per-session core engram fetch + decrypt + render is skipped entirely. No relay request, no timeout window.
- `state.core_sections` stays empty for every channel.
- `format_prompt` renders no `[Agent Core Memory]` section.
- Startup logs an `info` line at target `engram::core` so operators see the toggle is engaged.

## What this flag does **not** touch

- The `sprout mem` CLI — unaffected, still works.
- The relay's acceptance of `kind:30174` engrams — unaffected.
- The on-relay engram itself — never read, never overwritten.

This is purely a prompt-time injection toggle inside the ACP harness.

## Why this shape

Tyler asked for one flag, `--no-memory`. The lookup itself already fails gracefully (transport / decrypt / parse / timeout → `None`, no section); this flag sits on top of that fallback so an operator can fully turn off the path even when it would otherwise succeed. Mirrors how `--no-presence` / `--no-typing` are wired (clap arg → `*_enabled: bool` on `Config` → field on `PromptContext` → gate at the call site).

## Diff

| file | change |
|---|---|
| `crates/sprout-acp/src/config.rs` | `--no-memory` clap arg + `memory_enabled: bool` field on `Config` (default `true`); included in `summary()`; updated test-helper default; 3 new unit tests |
| `crates/sprout-acp/src/pool.rs` | `memory_enabled: bool` on `PromptContext`; gate the `is_new_session` fetch block on `ctx.memory_enabled` |
| `crates/sprout-acp/src/lib.rs` | wire `config.memory_enabled` into the `PromptContext` builder; emit `tracing::info!` at startup when disabled |

Total: 3 files, +74 / −2.

## Verification

```
cargo fmt -p sprout-acp -- --check          # clean
cargo clippy -p sprout-acp --all-targets -- -D warnings   # clean
cargo test -p sprout-acp --lib              # 272 passed (269 existing + 3 new)
cargo run -p sprout-acp -- --help | rg no-memory          # flag visible
```

## Behavior matrix

| `memory_enabled` | result |
|---|---|
| `true` (default) | unchanged from PR #593 base: fetch with 3s bound, fail-open, optional onboarding nudge |
| `false` (`--no-memory` set) | no fetch, no section, no nudge — agent never sees `[Agent Core Memory]` |

## Targeting

Based on PR #593 (`sami/nip-ae-minimal`), since that PR has not yet merged to `main`. Should be merged into #593's branch before #593 lands, so the flag ships in the same release as the feature it gates.