### PR TITLE
feat: quick-add agent popover with two entry points

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -34,7 +34,7 @@ const overrides = new Map([
   ["src-tauri/src/managed_agents/teams.rs", 580], // built-in team registry (Kit & Scout) + merge_teams + validate_team_deletion + JSON export/import + tests
   ["src-tauri/src/managed_agents/persona_card.rs", 970], // PNG/ZIP/MD persona card codec + pack-zip detection + nested root finder + provider/model/namePool fields + 27 unit tests
   ["src/app/AppShell.tsx", 815], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view + projects view + memory-leak safeguards + home-badge state lifted here so it consumes the same NIP-RS read-state as the sidebar (single ReadStateManager)
-  ["src/features/channels/hooks.ts", 550], // canvas query + mutation hooks + DM hide mutation
+  ["src/features/channels/hooks.ts", 560], // canvas query + mutation hooks + DM hide mutation + optimistic remove
   ["src/features/channels/ui/ChannelManagementSheet.tsx", 800],
   ["src/features/channels/ui/ChannelPane.tsx", 520], // composer/timeline/sidebar orchestration + anchored agent activity footers
   ["src/features/channels/ui/ChannelScreen.tsx", 550], // profile panel state + mutual exclusion wiring + ProfilePanelProvider context + agent typing classification
@@ -55,7 +55,7 @@ const overrides = new Map([
   ["src-tauri/src/managed_agents/types.rs", 715], // ManagedAgentRecord/Summary + Create/Update request structs + RespondTo enum + validate_respond_to_allowlist + tests + persona/agent env_vars field
   ["src-tauri/src/managed_agents/backend.rs", 700], // provider IPC, validation, discovery, binary resolution + tests + redact_secrets_with for user env values + env_secrets_from_request + redact_env_values_in (shared with model discovery)
   ["src/features/huddle/HuddleContext.tsx", 650], // huddle lifecycle context + joinHuddle + connectAndSetupMedia shared helper + activeSpeakers/isReconnecting state + PTT (reusable AudioContext) + TTS subscription + mic level analyser (10fps throttle) + agent pubkey refresh
-  ["src/features/agents/hooks.ts", 540], // agent query/mutation surface now includes built-in persona library activation + useUpdateManagedAgentMutation
+  ["src/features/agents/hooks.ts", 610], // agent query/mutation surface + optimistic member updates + reuse-guard context fetch
   ["src/features/agents/ui/AgentsView.tsx", 880], // remote agent lifecycle controls + persona/team management + persona import-update dialog wiring + built-in catalog/library state orchestration
   ["src/features/agents/ui/UnifiedAgentsSection.tsx", 570], // unified persona-grouped agent view with collapsible groups, bulk actions, drag-drop import, empty/loading states
   ["src/features/agents/ui/ManagedAgentRow.tsx", 530], // EditAgentDialog integration + provider/local branching

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -13,6 +13,7 @@ import {
   discoverAcpProviders,
   discoverBackendProviders,
   discoverManagedAgentPrereqs,
+  getChannelMembers,
   getManagedAgentLog,
   listManagedAgents,
   listRelayAgents,
@@ -417,7 +418,18 @@ export function useCreateChannelManagedAgentMutation(channelId: string | null) {
         throw new Error("No channel selected.");
       }
 
-      return createChannelManagedAgent(channelId, input);
+      const [managedAgents, members] = await Promise.all([
+        listManagedAgents(),
+        getChannelMembers(channelId),
+      ]);
+      const channelMemberPubkeys = new Set(
+        members.map((m) => normalizePubkey(m.pubkey)),
+      );
+
+      return createChannelManagedAgent(channelId, input, {
+        managedAgents,
+        channelMemberPubkeys,
+      });
     },
     onSuccess: (result) => {
       if (!channelId) return;

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -38,6 +38,7 @@ import {
 import type {
   AgentPersona,
   AgentTeam,
+  ChannelMember,
   CreateManagedAgentInput,
   CreatePersonaInput,
   CreateTeamInput,
@@ -46,6 +47,7 @@ import type {
   UpdatePersonaInput,
   UpdateTeamInput,
 } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import type {
   AttachManagedAgentToChannelInput,
   AttachManagedAgentToChannelResult,
@@ -356,6 +358,29 @@ export function useAttachManagedAgentToChannelMutation(
 
       return attachManagedAgentToChannel(channelId, input);
     },
+    onMutate: async (input) => {
+      if (!channelId) return;
+      const membersKey = ["channels", channelId, "members"];
+      await queryClient.cancelQueries({ queryKey: membersKey });
+      const previous =
+        queryClient.getQueryData<ChannelMember[]>(membersKey) ?? [];
+      const optimistic: ChannelMember = {
+        pubkey: normalizePubkey(input.agent.pubkey),
+        role: input.role ?? "bot",
+        joinedAt: new Date().toISOString(),
+        displayName: input.agent.name,
+      };
+      queryClient.setQueryData<ChannelMember[]>(membersKey, [
+        ...previous,
+        optimistic,
+      ]);
+      return { previous, membersKey };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.membersKey) {
+        queryClient.setQueryData(context.membersKey, context.previous);
+      }
+    },
     onSettled: async () => {
       await invalidateAgentQueries(queryClient, channelId);
     },
@@ -394,6 +419,27 @@ export function useCreateChannelManagedAgentMutation(channelId: string | null) {
 
       return createChannelManagedAgent(channelId, input);
     },
+    onSuccess: (result) => {
+      if (!channelId) return;
+      const membersKey = ["channels", channelId, "members"];
+      const current =
+        queryClient.getQueryData<ChannelMember[]>(membersKey) ?? [];
+      const alreadyPresent = current.some(
+        (m) =>
+          normalizePubkey(m.pubkey) === normalizePubkey(result.agent.pubkey),
+      );
+      if (!alreadyPresent) {
+        queryClient.setQueryData<ChannelMember[]>(membersKey, [
+          ...current,
+          {
+            pubkey: normalizePubkey(result.agent.pubkey),
+            role: "bot",
+            joinedAt: new Date().toISOString(),
+            displayName: result.agent.name,
+          },
+        ]);
+      }
+    },
     onSettled: async () => {
       await invalidateAgentQueries(queryClient, channelId);
     },
@@ -414,6 +460,29 @@ export function useCreateChannelManagedAgentsMutation(
       }
 
       return createChannelManagedAgents(channelId, inputs);
+    },
+    onSuccess: (result) => {
+      if (!channelId) return;
+      const membersKey = ["channels", channelId, "members"];
+      const current =
+        queryClient.getQueryData<ChannelMember[]>(membersKey) ?? [];
+      const existingPubkeys = new Set(
+        current.map((m) => normalizePubkey(m.pubkey)),
+      );
+      const newMembers: ChannelMember[] = result.successes
+        .filter((s) => !existingPubkeys.has(normalizePubkey(s.agent.pubkey)))
+        .map((s) => ({
+          pubkey: normalizePubkey(s.agent.pubkey),
+          role: "bot" as const,
+          joinedAt: new Date().toISOString(),
+          displayName: s.agent.name,
+        }));
+      if (newMembers.length > 0) {
+        queryClient.setQueryData<ChannelMember[]>(membersKey, [
+          ...current,
+          ...newMembers,
+        ]);
+      }
     },
     onSettled: async () => {
       await invalidateAgentQueries(queryClient, channelId);

--- a/desktop/src/features/agents/lib/sortProviders.ts
+++ b/desktop/src/features/agents/lib/sortProviders.ts
@@ -1,0 +1,18 @@
+import type { AcpProvider } from "@/shared/api/types";
+
+/**
+ * Sort ACP providers with "goose" first, then alphabetically by label.
+ * Used by any surface that presents a provider list to the user.
+ */
+export function sortProviders(
+  providers: readonly AcpProvider[],
+): AcpProvider[] {
+  return [...providers].sort((left, right) => {
+    const leftPriority = left.id === "goose" ? 0 : 1;
+    const rightPriority = right.id === "goose" ? 0 : 1;
+    if (leftPriority !== rightPriority) {
+      return leftPriority - rightPriority;
+    }
+    return left.label.localeCompare(right.label);
+  });
+}

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -29,12 +29,14 @@ import type {
   AddChannelMembersInput,
   Channel,
   ChannelDetail,
+  ChannelMember,
   CreateChannelInput,
   OpenDmInput,
   SetChannelPurposeInput,
   SetChannelTopicInput,
   UpdateChannelInput,
 } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 
 export const channelsQueryKey = ["channels"] as const;
 const channelDetailQueryKey = (channelId: string) =>
@@ -409,6 +411,25 @@ export function useRemoveChannelMemberMutation(channelId: string | null) {
       }
 
       await removeChannelMemberWithManagedAgentCleanup(channelId, pubkey);
+    },
+    onMutate: async (pubkey) => {
+      if (!channelId) return;
+      const membersKey = channelMembersQueryKey(channelId);
+      await queryClient.cancelQueries({ queryKey: membersKey });
+      const previous =
+        queryClient.getQueryData<ChannelMember[]>(membersKey) ?? [];
+      queryClient.setQueryData<ChannelMember[]>(
+        membersKey,
+        previous.filter(
+          (m) => normalizePubkey(m.pubkey) !== normalizePubkey(pubkey),
+        ),
+      );
+      return { previous, membersKey };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.membersKey) {
+        queryClient.setQueryData(context.membersKey, context.previous);
+      }
     },
     onSettled: async () => {
       await Promise.all([

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
+import { AlertTriangle, ChevronDown } from "lucide-react";
 import * as React from "react";
 
 import {
@@ -43,7 +43,6 @@ import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { getUsableTeams } from "@/features/agents/lib/teamPersonas";
 import { useLastRuntimeProvider } from "@/features/agents/lib/useLastRuntimeProvider";
 import { CreateAgentRespondToField } from "@/features/agents/ui/RespondToField";
-import { cn } from "@/shared/lib/cn";
 
 type AddChannelBotDialogProps = {
   backendProviders?: BackendProviderCandidate[];
@@ -92,43 +91,6 @@ function formatBatchFailureSummary(
     .map((failure) => `${failure.name}: ${failure.error}`)
     .join("; ");
 }
-
-// ── Collapsible section ─────────────────────────────────────────────────────
-
-function DisclosureSection({
-  children,
-  defaultOpen = false,
-  label,
-  testId,
-}: {
-  children: React.ReactNode;
-  defaultOpen?: boolean;
-  label: string;
-  testId?: string;
-}) {
-  const [isOpen, setIsOpen] = React.useState(defaultOpen);
-
-  return (
-    <div data-testid={testId}>
-      <button
-        className="flex w-full items-center gap-1.5 py-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-        onClick={() => setIsOpen((prev) => !prev)}
-        type="button"
-      >
-        <ChevronRight
-          className={cn(
-            "h-3.5 w-3.5 transition-transform",
-            isOpen && "rotate-90",
-          )}
-        />
-        {label}
-      </button>
-      {isOpen ? <div className="mt-3 space-y-4">{children}</div> : null}
-    </div>
-  );
-}
-
-// ── Main dialog ─────────────────────────────────────────────────────────────
 
 export function AddChannelBotDialog({
   backendProviders,
@@ -456,6 +418,9 @@ export function AddChannelBotDialog({
     }
   }
 
+  // Allowlist mode requires at least one entry, mirroring the harness's own
+  // validation. If we let it through empty, the agent crash-loops at startup
+  // with a config error.
   const respondToValid =
     respondTo !== "allowlist" || respondToAllowlist.length > 0;
 
@@ -488,7 +453,7 @@ export function AddChannelBotDialog({
       <ChooserDialogContent
         className="max-w-3xl"
         data-testid="add-channel-bot-dialog"
-        description="Choose who to bring into this channel. Expand sections below for more control."
+        description="Select any combination of saved personas, or turn on Generic for a one-off custom agent."
         footer={
           <>
             <Button
@@ -516,40 +481,52 @@ export function AddChannelBotDialog({
         scrollAreaTestId="add-channel-bot-dialog-scroll-area"
         title="Add agents"
       >
-        {/* ─── Primary: Who ─────────────────────────────────────────────── */}
-
-        {teams.length > 0 ? (
-          <AddChannelBotTeamsSection
-            canToggleSelections={canToggleSelections}
-            inChannelPersonaIds={inChannelPersonaIds}
-            isLoading={teamsQuery.isLoading}
-            onToggleTeam={handleToggleTeam}
-            personas={personas}
-            selectedPersonaIds={selectedPersonaIds}
-            teams={teams}
-          />
+        {resolvedBackendProviders.length > 0 ? (
+          <div className="space-y-1.5">
+            <div className="text-sm font-medium">Run on</div>
+            <select
+              className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm"
+              disabled={createBotsMutation.isPending}
+              onChange={(e) => handleRunOnChange(e.target.value)}
+              value={runOn}
+            >
+              <option value="local">This computer</option>
+              {resolvedBackendProviders.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.id}
+                </option>
+              ))}
+            </select>
+          </div>
         ) : null}
 
-        <AddChannelBotPersonasSection
-          canToggleSelections={canToggleSelections}
-          inChannelPersonaIds={inChannelPersonaIds}
-          includeGeneric={includeGeneric}
-          isLoading={personasQuery.isLoading}
-          onToggleGeneric={() => {
-            setIncludeGeneric((current) => !current);
-            setSubmissionNotice(null);
-            setSubmissionError(null);
-          }}
-          onTogglePersona={(personaId) => {
-            setSelectedPersonaIds((current) => toggleValue(current, personaId));
-            setSubmissionNotice(null);
-            setSubmissionError(null);
-          }}
-          personas={personas}
-          selectedPersonaIds={selectedPersonaIds}
-        />
+        {isProviderMode && selectedBackendProvider ? (
+          <div className="flex gap-3 rounded-2xl border border-warning/30 bg-warning-bg px-4 py-3">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+            <p className="text-sm text-warning">
+              This provider at{" "}
+              <span className="font-mono font-medium">
+                {selectedBackendProvider.binaryPath}
+              </span>{" "}
+              will receive your agent&apos;s private key. Only use providers
+              from trusted sources.
+            </p>
+          </div>
+        ) : null}
 
-        {/* ─── Primary: Runtime ─────────────────────────────────────────── */}
+        {probeError ? (
+          <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            Could not probe provider: {probeError}
+          </p>
+        ) : null}
+
+        {isProviderMode && probedProvider?.config_schema ? (
+          <ProviderConfigFields
+            config={providerConfig}
+            onChange={setProviderConfig}
+            schema={probedProvider.config_schema}
+          />
+        ) : null}
 
         <div className="space-y-1.5">
           <div className="text-sm font-medium">Runtime</div>
@@ -588,6 +565,50 @@ export function AddChannelBotDialog({
           </DropdownMenu>
         </div>
 
+        {teams.length > 0 ? (
+          <AddChannelBotTeamsSection
+            canToggleSelections={canToggleSelections}
+            inChannelPersonaIds={inChannelPersonaIds}
+            isLoading={teamsQuery.isLoading}
+            onToggleTeam={handleToggleTeam}
+            personas={personas}
+            selectedPersonaIds={selectedPersonaIds}
+            teams={teams}
+          />
+        ) : null}
+
+        <AddChannelBotPersonasSection
+          canToggleSelections={canToggleSelections}
+          inChannelPersonaIds={inChannelPersonaIds}
+          includeGeneric={includeGeneric}
+          isLoading={personasQuery.isLoading}
+          onToggleGeneric={() => {
+            setIncludeGeneric((current) => !current);
+            setSubmissionNotice(null);
+            setSubmissionError(null);
+          }}
+          onTogglePersona={(personaId) => {
+            setSelectedPersonaIds((current) => toggleValue(current, personaId));
+            setSubmissionNotice(null);
+            setSubmissionError(null);
+          }}
+          personas={personas}
+          selectedPersonaIds={selectedPersonaIds}
+        />
+
+        {includeGeneric ? (
+          <AddChannelBotGenericSection
+            disabled={createBotsMutation.isPending}
+            name={customName}
+            onNameChange={(value) => {
+              setHasEditedCustomName(true);
+              setCustomName(value);
+            }}
+            onPromptChange={setCustomPrompt}
+            prompt={customPrompt}
+          />
+        ) : null}
+
         {reusableAgent ? (
           <div className="pt-2">
             <AddChannelBotReuseGuard
@@ -599,95 +620,21 @@ export function AddChannelBotDialog({
           </div>
         ) : null}
 
+        {selectedCount > 0 ? (
+          <CreateAgentRespondToField
+            allowlist={respondToAllowlist}
+            disabled={createBotsMutation.isPending}
+            mode={respondTo}
+            onAllowlistChange={setRespondToAllowlist}
+            onModeChange={setRespondTo}
+          />
+        ) : null}
+
         {selectedCount === 0 ? (
           <div className="rounded-2xl border border-dashed border-border/70 bg-muted/15 px-4 py-4 text-sm text-muted-foreground">
             Pick one or more personas, or enable Generic to add a custom agent.
           </div>
         ) : null}
-
-        {/* ─── Customize (collapsed by default) ─────────────────────────── */}
-
-        <DisclosureSection label="Customize" testId="add-bot-customize-section">
-          {includeGeneric ? (
-            <AddChannelBotGenericSection
-              disabled={createBotsMutation.isPending}
-              name={customName}
-              onNameChange={(value) => {
-                setHasEditedCustomName(true);
-                setCustomName(value);
-              }}
-              onPromptChange={setCustomPrompt}
-              prompt={customPrompt}
-            />
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              Enable Generic above to set a custom name and system prompt.
-            </p>
-          )}
-
-          {selectedCount > 0 ? (
-            <CreateAgentRespondToField
-              allowlist={respondToAllowlist}
-              disabled={createBotsMutation.isPending}
-              mode={respondTo}
-              onAllowlistChange={setRespondToAllowlist}
-              onModeChange={setRespondTo}
-            />
-          ) : null}
-        </DisclosureSection>
-
-        {/* ─── Advanced (collapsed by default) ──────────────────────────── */}
-
-        <DisclosureSection label="Advanced" testId="add-bot-advanced-section">
-          {resolvedBackendProviders.length > 0 ? (
-            <div className="space-y-1.5">
-              <div className="text-sm font-medium">Run on</div>
-              <select
-                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm"
-                disabled={createBotsMutation.isPending}
-                onChange={(e) => handleRunOnChange(e.target.value)}
-                value={runOn}
-              >
-                <option value="local">This computer</option>
-                {resolvedBackendProviders.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.id}
-                  </option>
-                ))}
-              </select>
-            </div>
-          ) : null}
-
-          {isProviderMode && selectedBackendProvider ? (
-            <div className="flex gap-3 rounded-2xl border border-warning/30 bg-warning-bg px-4 py-3">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
-              <p className="text-sm text-warning">
-                This provider at{" "}
-                <span className="font-mono font-medium">
-                  {selectedBackendProvider.binaryPath}
-                </span>{" "}
-                will receive your agent&apos;s private key. Only use providers
-                from trusted sources.
-              </p>
-            </div>
-          ) : null}
-
-          {probeError ? (
-            <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-              Could not probe provider: {probeError}
-            </p>
-          ) : null}
-
-          {isProviderMode && probedProvider?.config_schema ? (
-            <ProviderConfigFields
-              config={providerConfig}
-              onChange={setProviderConfig}
-              schema={probedProvider.config_schema}
-            />
-          ) : null}
-        </DisclosureSection>
-
-        {/* ─── Warnings & errors ────────────────────────────────────────── */}
 
         {providersErrorMessage ? (
           <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -477,7 +477,7 @@ export function AddChannelBotDialog({
         footerClassName="justify-end gap-2"
         footerTestId="add-channel-bot-dialog-footer"
         headerTestId="add-channel-bot-dialog-header"
-        scrollAreaClassName="space-y-5"
+        scrollAreaClassName="space-y-6"
         scrollAreaTestId="add-channel-bot-dialog-scroll-area"
         title="Add agents"
       >

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, ChevronDown } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
 import * as React from "react";
 
 import {
@@ -43,6 +43,7 @@ import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { getUsableTeams } from "@/features/agents/lib/teamPersonas";
 import { useLastRuntimeProvider } from "@/features/agents/lib/useLastRuntimeProvider";
 import { CreateAgentRespondToField } from "@/features/agents/ui/RespondToField";
+import { cn } from "@/shared/lib/cn";
 
 type AddChannelBotDialogProps = {
   backendProviders?: BackendProviderCandidate[];
@@ -91,6 +92,43 @@ function formatBatchFailureSummary(
     .map((failure) => `${failure.name}: ${failure.error}`)
     .join("; ");
 }
+
+// ── Collapsible section ─────────────────────────────────────────────────────
+
+function DisclosureSection({
+  children,
+  defaultOpen = false,
+  label,
+  testId,
+}: {
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  label: string;
+  testId?: string;
+}) {
+  const [isOpen, setIsOpen] = React.useState(defaultOpen);
+
+  return (
+    <div data-testid={testId}>
+      <button
+        className="flex w-full items-center gap-1.5 py-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+        onClick={() => setIsOpen((prev) => !prev)}
+        type="button"
+      >
+        <ChevronRight
+          className={cn(
+            "h-3.5 w-3.5 transition-transform",
+            isOpen && "rotate-90",
+          )}
+        />
+        {label}
+      </button>
+      {isOpen ? <div className="mt-3 space-y-4">{children}</div> : null}
+    </div>
+  );
+}
+
+// ── Main dialog ─────────────────────────────────────────────────────────────
 
 export function AddChannelBotDialog({
   backendProviders,
@@ -418,9 +456,6 @@ export function AddChannelBotDialog({
     }
   }
 
-  // Allowlist mode requires at least one entry, mirroring the harness's own
-  // validation. If we let it through empty, the agent crash-loops at startup
-  // with a config error.
   const respondToValid =
     respondTo !== "allowlist" || respondToAllowlist.length > 0;
 
@@ -453,7 +488,7 @@ export function AddChannelBotDialog({
       <ChooserDialogContent
         className="max-w-3xl"
         data-testid="add-channel-bot-dialog"
-        description="Select any combination of saved personas, or turn on Generic for a one-off custom agent."
+        description="Choose who to bring into this channel. Expand sections below for more control."
         footer={
           <>
             <Button
@@ -481,52 +516,40 @@ export function AddChannelBotDialog({
         scrollAreaTestId="add-channel-bot-dialog-scroll-area"
         title="Add agents"
       >
-        {resolvedBackendProviders.length > 0 ? (
-          <div className="space-y-1.5">
-            <div className="text-sm font-medium">Run on</div>
-            <select
-              className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm"
-              disabled={createBotsMutation.isPending}
-              onChange={(e) => handleRunOnChange(e.target.value)}
-              value={runOn}
-            >
-              <option value="local">This computer</option>
-              {resolvedBackendProviders.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.id}
-                </option>
-              ))}
-            </select>
-          </div>
-        ) : null}
+        {/* ─── Primary: Who ─────────────────────────────────────────────── */}
 
-        {isProviderMode && selectedBackendProvider ? (
-          <div className="flex gap-3 rounded-2xl border border-warning/30 bg-warning-bg px-4 py-3">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
-            <p className="text-sm text-warning">
-              This provider at{" "}
-              <span className="font-mono font-medium">
-                {selectedBackendProvider.binaryPath}
-              </span>{" "}
-              will receive your agent&apos;s private key. Only use providers
-              from trusted sources.
-            </p>
-          </div>
-        ) : null}
-
-        {probeError ? (
-          <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            Could not probe provider: {probeError}
-          </p>
-        ) : null}
-
-        {isProviderMode && probedProvider?.config_schema ? (
-          <ProviderConfigFields
-            config={providerConfig}
-            onChange={setProviderConfig}
-            schema={probedProvider.config_schema}
+        {teams.length > 0 ? (
+          <AddChannelBotTeamsSection
+            canToggleSelections={canToggleSelections}
+            inChannelPersonaIds={inChannelPersonaIds}
+            isLoading={teamsQuery.isLoading}
+            onToggleTeam={handleToggleTeam}
+            personas={personas}
+            selectedPersonaIds={selectedPersonaIds}
+            teams={teams}
           />
         ) : null}
+
+        <AddChannelBotPersonasSection
+          canToggleSelections={canToggleSelections}
+          inChannelPersonaIds={inChannelPersonaIds}
+          includeGeneric={includeGeneric}
+          isLoading={personasQuery.isLoading}
+          onToggleGeneric={() => {
+            setIncludeGeneric((current) => !current);
+            setSubmissionNotice(null);
+            setSubmissionError(null);
+          }}
+          onTogglePersona={(personaId) => {
+            setSelectedPersonaIds((current) => toggleValue(current, personaId));
+            setSubmissionNotice(null);
+            setSubmissionError(null);
+          }}
+          personas={personas}
+          selectedPersonaIds={selectedPersonaIds}
+        />
+
+        {/* ─── Primary: Runtime ─────────────────────────────────────────── */}
 
         <div className="space-y-1.5">
           <div className="text-sm font-medium">Runtime</div>
@@ -565,50 +588,6 @@ export function AddChannelBotDialog({
           </DropdownMenu>
         </div>
 
-        {teams.length > 0 ? (
-          <AddChannelBotTeamsSection
-            canToggleSelections={canToggleSelections}
-            inChannelPersonaIds={inChannelPersonaIds}
-            isLoading={teamsQuery.isLoading}
-            onToggleTeam={handleToggleTeam}
-            personas={personas}
-            selectedPersonaIds={selectedPersonaIds}
-            teams={teams}
-          />
-        ) : null}
-
-        <AddChannelBotPersonasSection
-          canToggleSelections={canToggleSelections}
-          inChannelPersonaIds={inChannelPersonaIds}
-          includeGeneric={includeGeneric}
-          isLoading={personasQuery.isLoading}
-          onToggleGeneric={() => {
-            setIncludeGeneric((current) => !current);
-            setSubmissionNotice(null);
-            setSubmissionError(null);
-          }}
-          onTogglePersona={(personaId) => {
-            setSelectedPersonaIds((current) => toggleValue(current, personaId));
-            setSubmissionNotice(null);
-            setSubmissionError(null);
-          }}
-          personas={personas}
-          selectedPersonaIds={selectedPersonaIds}
-        />
-
-        {includeGeneric ? (
-          <AddChannelBotGenericSection
-            disabled={createBotsMutation.isPending}
-            name={customName}
-            onNameChange={(value) => {
-              setHasEditedCustomName(true);
-              setCustomName(value);
-            }}
-            onPromptChange={setCustomPrompt}
-            prompt={customPrompt}
-          />
-        ) : null}
-
         {reusableAgent ? (
           <div className="pt-2">
             <AddChannelBotReuseGuard
@@ -620,21 +599,95 @@ export function AddChannelBotDialog({
           </div>
         ) : null}
 
-        {selectedCount > 0 ? (
-          <CreateAgentRespondToField
-            allowlist={respondToAllowlist}
-            disabled={createBotsMutation.isPending}
-            mode={respondTo}
-            onAllowlistChange={setRespondToAllowlist}
-            onModeChange={setRespondTo}
-          />
-        ) : null}
-
         {selectedCount === 0 ? (
           <div className="rounded-2xl border border-dashed border-border/70 bg-muted/15 px-4 py-4 text-sm text-muted-foreground">
             Pick one or more personas, or enable Generic to add a custom agent.
           </div>
         ) : null}
+
+        {/* ─── Customize (collapsed by default) ─────────────────────────── */}
+
+        <DisclosureSection label="Customize" testId="add-bot-customize-section">
+          {includeGeneric ? (
+            <AddChannelBotGenericSection
+              disabled={createBotsMutation.isPending}
+              name={customName}
+              onNameChange={(value) => {
+                setHasEditedCustomName(true);
+                setCustomName(value);
+              }}
+              onPromptChange={setCustomPrompt}
+              prompt={customPrompt}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Enable Generic above to set a custom name and system prompt.
+            </p>
+          )}
+
+          {selectedCount > 0 ? (
+            <CreateAgentRespondToField
+              allowlist={respondToAllowlist}
+              disabled={createBotsMutation.isPending}
+              mode={respondTo}
+              onAllowlistChange={setRespondToAllowlist}
+              onModeChange={setRespondTo}
+            />
+          ) : null}
+        </DisclosureSection>
+
+        {/* ─── Advanced (collapsed by default) ──────────────────────────── */}
+
+        <DisclosureSection label="Advanced" testId="add-bot-advanced-section">
+          {resolvedBackendProviders.length > 0 ? (
+            <div className="space-y-1.5">
+              <div className="text-sm font-medium">Run on</div>
+              <select
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm"
+                disabled={createBotsMutation.isPending}
+                onChange={(e) => handleRunOnChange(e.target.value)}
+                value={runOn}
+              >
+                <option value="local">This computer</option>
+                {resolvedBackendProviders.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.id}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {isProviderMode && selectedBackendProvider ? (
+            <div className="flex gap-3 rounded-2xl border border-warning/30 bg-warning-bg px-4 py-3">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+              <p className="text-sm text-warning">
+                This provider at{" "}
+                <span className="font-mono font-medium">
+                  {selectedBackendProvider.binaryPath}
+                </span>{" "}
+                will receive your agent&apos;s private key. Only use providers
+                from trusted sources.
+              </p>
+            </div>
+          ) : null}
+
+          {probeError ? (
+            <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              Could not probe provider: {probeError}
+            </p>
+          ) : null}
+
+          {isProviderMode && probedProvider?.config_schema ? (
+            <ProviderConfigFields
+              config={providerConfig}
+              onChange={setProviderConfig}
+              schema={probedProvider.config_schema}
+            />
+          ) : null}
+        </DisclosureSection>
+
+        {/* ─── Warnings & errors ────────────────────────────────────────── */}
 
         {providersErrorMessage ? (
           <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">

--- a/desktop/src/features/channels/ui/ChannelMembersBar.tsx
+++ b/desktop/src/features/channels/ui/ChannelMembersBar.tsx
@@ -9,6 +9,7 @@ import {
   useManagedAgentsQuery,
   useRelayAgentsQuery,
 } from "@/features/agents/hooks";
+import { sortProviders } from "@/features/agents/lib/sortProviders";
 import { useChannelMembersQuery } from "@/features/channels/hooks";
 import type { Channel } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
@@ -19,6 +20,8 @@ import { QuickAddAgentPopover } from "./QuickAddAgentPopover";
 type ChannelMembersBarProps = {
   channel: Channel;
   currentPubkey?: string;
+  isAddBotDialogOpen?: boolean;
+  onAddBotDialogOpenChange?: (open: boolean) => void;
   onManageChannel: () => void;
   onToggleMembers: () => void;
 };
@@ -26,10 +29,15 @@ type ChannelMembersBarProps = {
 export function ChannelMembersBar({
   channel,
   currentPubkey,
+  isAddBotDialogOpen,
+  onAddBotDialogOpenChange,
   onManageChannel,
   onToggleMembers,
 }: ChannelMembersBarProps) {
-  const [isAddBotOpen, setIsAddBotOpen] = React.useState(false);
+  // Dialog state: controlled externally if props provided, otherwise local.
+  const [localIsAddBotOpen, setLocalIsAddBotOpen] = React.useState(false);
+  const isAddBotOpen = isAddBotDialogOpen ?? localIsAddBotOpen;
+  const setIsAddBotOpen = onAddBotDialogOpenChange ?? setLocalIsAddBotOpen;
   const [isQuickAddOpen, setIsQuickAddOpen] = React.useState(false);
   const { startHuddle, isStarting: isStartingHuddle } = useHuddle();
   const queryClient = useQueryClient();
@@ -41,16 +49,7 @@ export function ChannelMembersBar({
   const members = membersQuery.data ?? [];
   const memberCount = membersQuery.data?.length ?? channel.memberCount;
   const providers = React.useMemo(
-    () =>
-      [...(providersQuery.data ?? [])].sort((left, right) => {
-        const leftPriority = left.id === "goose" ? 0 : 1;
-        const rightPriority = right.id === "goose" ? 0 : 1;
-        if (leftPriority !== rightPriority) {
-          return leftPriority - rightPriority;
-        }
-
-        return left.label.localeCompare(right.label);
-      }),
+    () => sortProviders(providersQuery.data ?? []),
     [providersQuery.data],
   );
   const normalizedCurrentPubkey = currentPubkey
@@ -76,7 +75,7 @@ export function ChannelMembersBar({
     previousChannelIdRef.current = channel.id;
     setIsAddBotOpen(false);
     setIsQuickAddOpen(false);
-  }, [channel.id]);
+  }, [channel.id, setIsAddBotOpen]);
 
   const dialogErrorMessage =
     providersQuery.error instanceof Error

--- a/desktop/src/features/channels/ui/ChannelMembersBar.tsx
+++ b/desktop/src/features/channels/ui/ChannelMembersBar.tsx
@@ -14,6 +14,7 @@ import type { Channel } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { Button } from "@/shared/ui/button";
 import { AddChannelBotDialog } from "./AddChannelBotDialog";
+import { QuickAddAgentPopover } from "./QuickAddAgentPopover";
 
 type ChannelMembersBarProps = {
   channel: Channel;
@@ -29,6 +30,7 @@ export function ChannelMembersBar({
   onToggleMembers,
 }: ChannelMembersBarProps) {
   const [isAddBotOpen, setIsAddBotOpen] = React.useState(false);
+  const [isQuickAddOpen, setIsQuickAddOpen] = React.useState(false);
   const { startHuddle, isStarting: isStartingHuddle } = useHuddle();
   const queryClient = useQueryClient();
   const membersQuery = useChannelMembersQuery(channel.id);
@@ -73,6 +75,7 @@ export function ChannelMembersBar({
 
     previousChannelIdRef.current = channel.id;
     setIsAddBotOpen(false);
+    setIsQuickAddOpen(false);
   }, [channel.id]);
 
   const dialogErrorMessage =
@@ -87,20 +90,24 @@ export function ChannelMembersBar({
   return (
     <React.Fragment>
       <div className="flex items-center gap-1">
-        <Button
-          aria-label="Add agent"
-          className="h-7 w-7 rounded-full"
-          data-testid="channel-add-bot-trigger"
-          disabled={!canAddAgents}
-          onClick={() => {
-            setIsAddBotOpen(true);
-          }}
-          size="icon"
-          type="button"
-          variant="outline"
+        <QuickAddAgentPopover
+          channelId={channel.id}
+          open={isQuickAddOpen}
+          onOpenChange={setIsQuickAddOpen}
+          onMoreOptions={() => setIsAddBotOpen(true)}
         >
-          <Plus className="h-3 w-3" />
-        </Button>
+          <Button
+            aria-label="Add agent"
+            className="h-7 w-7 rounded-full"
+            data-testid="channel-add-bot-trigger"
+            disabled={!canAddAgents}
+            size="icon"
+            type="button"
+            variant="outline"
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+        </QuickAddAgentPopover>
 
         <HuddleIndicator
           className="h-7 w-7"

--- a/desktop/src/features/channels/ui/ChannelMembersBar.tsx
+++ b/desktop/src/features/channels/ui/ChannelMembersBar.tsx
@@ -89,25 +89,6 @@ export function ChannelMembersBar({
   return (
     <React.Fragment>
       <div className="flex items-center gap-1">
-        <QuickAddAgentPopover
-          channelId={channel.id}
-          open={isQuickAddOpen}
-          onOpenChange={setIsQuickAddOpen}
-          onMoreOptions={() => setIsAddBotOpen(true)}
-        >
-          <Button
-            aria-label="Add agent"
-            className="h-7 w-7 rounded-full"
-            data-testid="channel-add-bot-trigger"
-            disabled={!canAddAgents}
-            size="icon"
-            type="button"
-            variant="outline"
-          >
-            <Plus className="h-3 w-3" />
-          </Button>
-        </QuickAddAgentPopover>
-
         <HuddleIndicator
           className="h-7 w-7"
           channelId={channel.id}
@@ -137,6 +118,25 @@ export function ChannelMembersBar({
             {memberCount}
           </span>
         </Button>
+
+        <QuickAddAgentPopover
+          channelId={channel.id}
+          open={isQuickAddOpen}
+          onOpenChange={setIsQuickAddOpen}
+          onMoreOptions={() => setIsAddBotOpen(true)}
+        >
+          <Button
+            aria-label="Add agent"
+            className="h-7 w-7 rounded-full"
+            data-testid="channel-add-bot-trigger"
+            disabled={!canAddAgents}
+            size="icon"
+            type="button"
+            variant="outline"
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+        </QuickAddAgentPopover>
 
         <Button
           aria-label="Manage channel"

--- a/desktop/src/features/channels/ui/ChannelMembersBar.tsx
+++ b/desktop/src/features/channels/ui/ChannelMembersBar.tsx
@@ -89,6 +89,25 @@ export function ChannelMembersBar({
   return (
     <React.Fragment>
       <div className="flex items-center gap-1">
+        <QuickAddAgentPopover
+          channelId={channel.id}
+          open={isQuickAddOpen}
+          onOpenChange={setIsQuickAddOpen}
+          onMoreOptions={() => setIsAddBotOpen(true)}
+        >
+          <Button
+            aria-label="Add agent"
+            className="h-7 w-7 rounded-full"
+            data-testid="channel-add-bot-trigger"
+            disabled={!canAddAgents}
+            size="icon"
+            type="button"
+            variant="outline"
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+        </QuickAddAgentPopover>
+
         <HuddleIndicator
           className="h-7 w-7"
           channelId={channel.id}
@@ -118,25 +137,6 @@ export function ChannelMembersBar({
             {memberCount}
           </span>
         </Button>
-
-        <QuickAddAgentPopover
-          channelId={channel.id}
-          open={isQuickAddOpen}
-          onOpenChange={setIsQuickAddOpen}
-          onMoreOptions={() => setIsAddBotOpen(true)}
-        >
-          <Button
-            aria-label="Add agent"
-            className="h-7 w-7 rounded-full"
-            data-testid="channel-add-bot-trigger"
-            disabled={!canAddAgents}
-            size="icon"
-            type="button"
-            variant="outline"
-          >
-            <Plus className="h-3 w-3" />
-          </Button>
-        </QuickAddAgentPopover>
 
         <Button
           aria-label="Manage channel"

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -85,6 +85,7 @@ export function ChannelScreen({
     string | null
   >(null);
   const [isMembersSidebarOpen, setIsMembersSidebarOpen] = React.useState(false);
+  const [isAddBotDialogOpen, setIsAddBotDialogOpen] = React.useState(false);
   const [openThreadHeadId, setOpenThreadHeadId] = React.useState<string | null>(
     null,
   );
@@ -436,7 +437,9 @@ export function ChannelScreen({
           activeChannelTitle={activeChannelTitle}
           activeDmPresenceStatus={activeDmPresenceStatus}
           currentPubkey={currentPubkey}
+          isAddBotDialogOpen={isAddBotDialogOpen}
           isJoining={joinChannelMutation.isPending}
+          onAddBotDialogOpenChange={setIsAddBotDialogOpen}
           onJoinChannel={joinChannelMutation.mutateAsync}
           onManageChannel={openChannelManagement}
           onToggleMembers={() => setIsMembersSidebarOpen((prev) => !prev)}
@@ -530,6 +533,7 @@ export function ChannelScreen({
           currentPubkey={currentPubkey}
           open={isMembersSidebarOpen}
           onOpenChange={setIsMembersSidebarOpen}
+          onOpenAddBotDialog={() => setIsAddBotDialogOpen(true)}
           onViewActivity={handleOpenAgentSession}
         />
       </ProfilePanelProvider>

--- a/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
@@ -14,7 +14,9 @@ type ChannelScreenHeaderProps = {
   activeChannelTitle: string;
   activeDmPresenceStatus: PresenceStatus | null;
   currentPubkey?: string;
+  isAddBotDialogOpen?: boolean;
   isJoining?: boolean;
+  onAddBotDialogOpenChange?: (open: boolean) => void;
   onJoinChannel?: () => Promise<void>;
   onManageChannel: () => void;
   onToggleMembers: () => void;
@@ -26,7 +28,9 @@ export function ChannelScreenHeader({
   activeChannelTitle,
   activeDmPresenceStatus,
   currentPubkey,
+  isAddBotDialogOpen,
   isJoining = false,
+  onAddBotDialogOpenChange,
   onJoinChannel,
   onManageChannel,
   onToggleMembers,
@@ -56,6 +60,8 @@ export function ChannelScreenHeader({
             <ChannelMembersBar
               channel={activeChannel}
               currentPubkey={currentPubkey}
+              isAddBotDialogOpen={isAddBotDialogOpen}
+              onAddBotDialogOpenChange={onAddBotDialogOpenChange}
               onManageChannel={onManageChannel}
               onToggleMembers={onToggleMembers}
             />

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -281,23 +281,45 @@ export function MembersSidebar({
                 <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
                   {bots.length}
                 </span>
-                {hasControllableManagedBots ? (
-                  <MembersSidebarAgentControls
-                    canBulkRemove={hasRemovableManagedBots}
-                    canBulkRespawn={hasControllableManagedBots}
-                    canBulkStop={hasStoppableManagedBots}
-                    disabled={isActionPending || isArchived}
-                    onRemoveAll={() => {
-                      void handleRemoveAll();
-                    }}
-                    onRespawnAll={() => {
-                      void handleRespawnAll();
-                    }}
-                    onStopAll={() => {
-                      void handleStopAll();
-                    }}
-                  />
-                ) : null}
+                <div className="ml-auto flex items-center gap-0.5">
+                  {canAddAgents ? (
+                    <QuickAddAgentPopover
+                      channelId={channelId}
+                      open={isSidebarQuickAddOpen}
+                      onOpenChange={setIsSidebarQuickAddOpen}
+                      onMoreOptions={() => {
+                        setIsSidebarQuickAddOpen(false);
+                        onOpenAddBotDialog?.();
+                      }}
+                    >
+                      <button
+                        aria-label="Add agent to channel"
+                        className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                        data-testid="sidebar-add-agent-trigger"
+                        type="button"
+                      >
+                        <Plus className="h-4 w-4" />
+                      </button>
+                    </QuickAddAgentPopover>
+                  ) : null}
+                  {hasControllableManagedBots ? (
+                    <MembersSidebarAgentControls
+                      canBulkRemove={hasRemovableManagedBots}
+                      canBulkRespawn={hasControllableManagedBots}
+                      canBulkStop={hasStoppableManagedBots}
+                      disabled={isActionPending || isArchived}
+                      onRemoveAll={() => {
+                        void handleRemoveAll();
+                      }}
+                      onRespawnAll={() => {
+                        void handleRespawnAll();
+                      }}
+                      onStopAll={() => {
+                        void handleStopAll();
+                      }}
+                    />
+                  ) : null}
+                </div>
               </div>
               <div className="space-y-2" data-testid="members-sidebar-bots">
                 {bots.length > 0 ? (
@@ -310,29 +332,6 @@ export function MembersSidebar({
                   </p>
                 )}
               </div>
-              {canAddAgents ? (
-                <QuickAddAgentPopover
-                  channelId={channelId}
-                  open={isSidebarQuickAddOpen}
-                  onOpenChange={setIsSidebarQuickAddOpen}
-                  onMoreOptions={() => {
-                    setIsSidebarQuickAddOpen(false);
-                    onOpenAddBotDialog?.();
-                  }}
-                >
-                  <Button
-                    aria-label="Add agent to channel"
-                    className="mt-2 h-8 w-full justify-start gap-2 text-xs text-muted-foreground"
-                    data-testid="sidebar-add-agent-trigger"
-                    size="sm"
-                    type="button"
-                    variant="ghost"
-                  >
-                    <Plus className="h-3.5 w-3.5" />
-                    Add agent
-                  </Button>
-                </QuickAddAgentPopover>
-              ) : null}
             </section>
 
             {changeRoleError ? (

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -5,13 +5,7 @@ import {
   useAddChannelMembersMutation,
   useChannelMembersQuery,
 } from "@/features/channels/hooks";
-import {
-  useAcpProvidersQuery,
-  useBackendProvidersQuery,
-  useManagedAgentsQuery,
-  useRelayAgentsQuery,
-  useUpdateManagedAgentMutation,
-} from "@/features/agents/hooks";
+import { useUpdateManagedAgentMutation } from "@/features/agents/hooks";
 import { CreateAgentRespondToField } from "@/features/agents/ui/RespondToField";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
 import {
@@ -48,7 +42,6 @@ import { MembersSidebarAgentControls } from "./MembersSidebarAgentControls";
 import { ChannelMemberInviteCard } from "./ChannelMemberInviteCard";
 import { MembersSidebarMemberCard } from "./MembersSidebarMemberCard";
 import { useMembersSidebarActions } from "./useMembersSidebarActions";
-import { AddChannelBotDialog } from "./AddChannelBotDialog";
 import { QuickAddAgentPopover } from "./QuickAddAgentPopover";
 
 type MembersSidebarProps = {
@@ -56,6 +49,7 @@ type MembersSidebarProps = {
   currentPubkey?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onOpenAddBotDialog?: () => void;
   onViewActivity?: (pubkey: string) => void;
 };
 
@@ -64,37 +58,13 @@ export function MembersSidebar({
   currentPubkey,
   open,
   onOpenChange,
+  onOpenAddBotDialog,
   onViewActivity,
 }: MembersSidebarProps) {
   const channelId = channel?.id ?? null;
   const queryClient = useQueryClient();
   const membersQuery = useChannelMembersQuery(channelId, open);
   const addMembersMutation = useAddChannelMembersMutation(channelId);
-  const providersQuery = useAcpProvidersQuery();
-  const backendProvidersQuery = useBackendProvidersQuery();
-  const sidebarManagedAgentsQuery = useManagedAgentsQuery();
-  const sidebarRelayAgentsQuery = useRelayAgentsQuery();
-  const sidebarProviders = React.useMemo(
-    () =>
-      [...(providersQuery.data ?? [])].sort((left, right) => {
-        const leftPriority = left.id === "goose" ? 0 : 1;
-        const rightPriority = right.id === "goose" ? 0 : 1;
-        if (leftPriority !== rightPriority) {
-          return leftPriority - rightPriority;
-        }
-        return left.label.localeCompare(right.label);
-      }),
-    [providersQuery.data],
-  );
-  const sidebarDialogErrorMessage =
-    providersQuery.error instanceof Error
-      ? providersQuery.error.message
-      : sidebarManagedAgentsQuery.error instanceof Error
-        ? sidebarManagedAgentsQuery.error.message
-        : sidebarRelayAgentsQuery.error instanceof Error
-          ? sidebarRelayAgentsQuery.error.message
-          : null;
-
   const changeRoleMutation = useMutation({
     mutationFn: async ({ pubkey, role }: { pubkey: string; role: string }) => {
       if (!channelId) throw new Error("No channel selected.");
@@ -138,8 +108,6 @@ export function MembersSidebar({
     (channel?.visibility === "open" || canManageMembers);
 
   const [isSidebarQuickAddOpen, setIsSidebarQuickAddOpen] =
-    React.useState(false);
-  const [isSidebarFullDialogOpen, setIsSidebarFullDialogOpen] =
     React.useState(false);
 
   const managedAgentByPubkey = React.useMemo(
@@ -347,7 +315,10 @@ export function MembersSidebar({
                   channelId={channelId}
                   open={isSidebarQuickAddOpen}
                   onOpenChange={setIsSidebarQuickAddOpen}
-                  onMoreOptions={() => setIsSidebarFullDialogOpen(true)}
+                  onMoreOptions={() => {
+                    setIsSidebarQuickAddOpen(false);
+                    onOpenAddBotDialog?.();
+                  }}
                 >
                   <Button
                     aria-label="Add agent to channel"
@@ -383,18 +354,6 @@ export function MembersSidebar({
         }}
         open={editRespondToAgent !== null}
       />
-      {canAddAgents ? (
-        <AddChannelBotDialog
-          backendProviders={backendProvidersQuery.data ?? []}
-          backendProvidersLoading={backendProvidersQuery.isLoading}
-          channelId={channelId}
-          onOpenChange={setIsSidebarFullDialogOpen}
-          open={isSidebarFullDialogOpen}
-          providers={sidebarProviders}
-          providersErrorMessage={sidebarDialogErrorMessage}
-          providersLoading={providersQuery.isLoading}
-        />
-      ) : null}
     </>
   );
 }

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -1,10 +1,17 @@
+import { Plus } from "lucide-react";
 import * as React from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   useAddChannelMembersMutation,
   useChannelMembersQuery,
 } from "@/features/channels/hooks";
-import { useUpdateManagedAgentMutation } from "@/features/agents/hooks";
+import {
+  useAcpProvidersQuery,
+  useBackendProvidersQuery,
+  useManagedAgentsQuery,
+  useRelayAgentsQuery,
+  useUpdateManagedAgentMutation,
+} from "@/features/agents/hooks";
 import { CreateAgentRespondToField } from "@/features/agents/ui/RespondToField";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
 import {
@@ -41,6 +48,8 @@ import { MembersSidebarAgentControls } from "./MembersSidebarAgentControls";
 import { ChannelMemberInviteCard } from "./ChannelMemberInviteCard";
 import { MembersSidebarMemberCard } from "./MembersSidebarMemberCard";
 import { useMembersSidebarActions } from "./useMembersSidebarActions";
+import { AddChannelBotDialog } from "./AddChannelBotDialog";
+import { QuickAddAgentPopover } from "./QuickAddAgentPopover";
 
 type MembersSidebarProps = {
   channel: Channel | null;
@@ -61,6 +70,31 @@ export function MembersSidebar({
   const queryClient = useQueryClient();
   const membersQuery = useChannelMembersQuery(channelId, open);
   const addMembersMutation = useAddChannelMembersMutation(channelId);
+  const providersQuery = useAcpProvidersQuery();
+  const backendProvidersQuery = useBackendProvidersQuery();
+  const sidebarManagedAgentsQuery = useManagedAgentsQuery();
+  const sidebarRelayAgentsQuery = useRelayAgentsQuery();
+  const sidebarProviders = React.useMemo(
+    () =>
+      [...(providersQuery.data ?? [])].sort((left, right) => {
+        const leftPriority = left.id === "goose" ? 0 : 1;
+        const rightPriority = right.id === "goose" ? 0 : 1;
+        if (leftPriority !== rightPriority) {
+          return leftPriority - rightPriority;
+        }
+        return left.label.localeCompare(right.label);
+      }),
+    [providersQuery.data],
+  );
+  const sidebarDialogErrorMessage =
+    providersQuery.error instanceof Error
+      ? providersQuery.error.message
+      : sidebarManagedAgentsQuery.error instanceof Error
+        ? sidebarManagedAgentsQuery.error.message
+        : sidebarRelayAgentsQuery.error instanceof Error
+          ? sidebarRelayAgentsQuery.error.message
+          : null;
+
   const changeRoleMutation = useMutation({
     mutationFn: async ({ pubkey, role }: { pubkey: string; role: string }) => {
       if (!channelId) throw new Error("No channel selected.");
@@ -98,6 +132,16 @@ export function MembersSidebar({
     selfMember?.role === "owner" || selfMember?.role === "admin";
   const isArchived =
     channel?.archivedAt !== null && channel?.archivedAt !== undefined;
+  const canAddAgents =
+    channel?.channelType !== "dm" &&
+    !isArchived &&
+    (channel?.visibility === "open" || canManageMembers);
+
+  const [isSidebarQuickAddOpen, setIsSidebarQuickAddOpen] =
+    React.useState(false);
+  const [isSidebarFullDialogOpen, setIsSidebarFullDialogOpen] =
+    React.useState(false);
+
   const managedAgentByPubkey = React.useMemo(
     () =>
       new Map(
@@ -298,6 +342,26 @@ export function MembersSidebar({
                   </p>
                 )}
               </div>
+              {canAddAgents ? (
+                <QuickAddAgentPopover
+                  channelId={channelId}
+                  open={isSidebarQuickAddOpen}
+                  onOpenChange={setIsSidebarQuickAddOpen}
+                  onMoreOptions={() => setIsSidebarFullDialogOpen(true)}
+                >
+                  <Button
+                    aria-label="Add agent to channel"
+                    className="mt-2 h-8 w-full justify-start gap-2 text-xs text-muted-foreground"
+                    data-testid="sidebar-add-agent-trigger"
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Add agent
+                  </Button>
+                </QuickAddAgentPopover>
+              ) : null}
             </section>
 
             {changeRoleError ? (
@@ -319,6 +383,18 @@ export function MembersSidebar({
         }}
         open={editRespondToAgent !== null}
       />
+      {canAddAgents ? (
+        <AddChannelBotDialog
+          backendProviders={backendProvidersQuery.data ?? []}
+          backendProvidersLoading={backendProvidersQuery.isLoading}
+          channelId={channelId}
+          onOpenChange={setIsSidebarFullDialogOpen}
+          open={isSidebarFullDialogOpen}
+          providers={sidebarProviders}
+          providersErrorMessage={sidebarDialogErrorMessage}
+          providersLoading={providersQuery.isLoading}
+        />
+      ) : null}
     </>
   );
 }

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -96,6 +96,17 @@ export function MembersSidebar({
     enabled: open && rawMembers.length > 0,
   });
 
+  const presence = memberPresenceQuery.data;
+  const sortedBots = React.useMemo(() => {
+    if (!presence) return bots;
+    return [...bots].sort((a, b) => {
+      const aOnline = presence[normalizePubkey(a.pubkey)] === "online" ? 0 : 1;
+      const bOnline = presence[normalizePubkey(b.pubkey)] === "online" ? 0 : 1;
+      if (aOnline !== bOnline) return aOnline - bOnline;
+      return formatMemberName(a).localeCompare(formatMemberName(b));
+    });
+  }, [bots, presence]);
+
   const selfMember =
     rawMembers.find((member) => member.pubkey === currentPubkey) ?? null;
   const canManageMembers =
@@ -122,11 +133,11 @@ export function MembersSidebar({
   );
   const controllableManagedBots = React.useMemo(
     () =>
-      bots.flatMap((member) => {
+      sortedBots.flatMap((member) => {
         const agent = managedAgentByPubkey.get(normalizePubkey(member.pubkey));
         return agent ? [agent] : [];
       }),
-    [bots, managedAgentByPubkey],
+    [sortedBots, managedAgentByPubkey],
   );
   const canRemoveMember = React.useCallback(
     (member: ChannelMember) => {
@@ -141,7 +152,7 @@ export function MembersSidebar({
   );
   const removableManagedBots = React.useMemo(
     () =>
-      bots.flatMap((member) => {
+      sortedBots.flatMap((member) => {
         if (!canRemoveMember(member)) {
           return [];
         }
@@ -149,7 +160,7 @@ export function MembersSidebar({
         const agent = managedAgentByPubkey.get(normalizePubkey(member.pubkey));
         return agent ? [agent] : [];
       }),
-    [bots, canRemoveMember, managedAgentByPubkey],
+    [sortedBots, canRemoveMember, managedAgentByPubkey],
   );
   const {
     actionErrorMessage,
@@ -279,7 +290,7 @@ export function MembersSidebar({
               <div className="flex items-center gap-2">
                 <h2 className="text-sm font-semibold tracking-tight">Bots</h2>
                 <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                  {bots.length}
+                  {sortedBots.length}
                 </span>
                 <div className="ml-auto flex items-center gap-0.5">
                   {canAddAgents ? (
@@ -322,8 +333,8 @@ export function MembersSidebar({
                 </div>
               </div>
               <div className="space-y-2" data-testid="members-sidebar-bots">
-                {bots.length > 0 ? (
-                  bots.map((member) => renderMemberCard(member, true))
+                {sortedBots.length > 0 ? (
+                  sortedBots.map((member) => renderMemberCard(member, true))
                 ) : (
                   <p className="text-sm text-muted-foreground">
                     {membersQuery.isLoading

--- a/desktop/src/features/channels/ui/MembersSidebarAgentControls.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarAgentControls.tsx
@@ -31,7 +31,7 @@ export function MembersSidebarAgentControls({
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <button
-          className="ml-auto flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           data-testid="members-sidebar-agent-controls"
           type="button"
         >

--- a/desktop/src/features/channels/ui/QuickAddAgentItemRow.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentItemRow.tsx
@@ -1,0 +1,152 @@
+import { Check, X } from "lucide-react";
+import { motion } from "motion/react";
+import * as React from "react";
+
+import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import { cn } from "@/shared/lib/cn";
+import { Spinner } from "@/shared/ui/spinner";
+import type { QuickAddAgentItem } from "./useQuickAddAgentItems";
+
+// ── Avatar ────────────────────────────────────────────────────────────────────
+
+export function QuickAddAgentAvatar({
+  avatarUrl,
+  label,
+  isRunning,
+}: {
+  avatarUrl: string | null;
+  label: string;
+  isRunning: boolean;
+}) {
+  const initials = label
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30">
+      {avatarUrl ? (
+        <img
+          alt={label}
+          className="h-full w-full rounded-full object-cover"
+          referrerPolicy="no-referrer"
+          src={rewriteRelayUrl(avatarUrl)}
+        />
+      ) : (
+        <span className="text-[10px] font-semibold text-muted-foreground">
+          {initials}
+        </span>
+      )}
+      {isRunning ? (
+        <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-popover bg-emerald-500" />
+      ) : null}
+    </div>
+  );
+}
+
+// ── Item Row ──────────────────────────────────────────────────────────────────
+
+type QuickAddAgentItemRowProps = {
+  item: QuickAddAgentItem;
+  itemKey: string;
+  isSelected: boolean;
+  isPending: boolean;
+  selectMode: boolean;
+  disabled: boolean;
+  onClick: () => void;
+  onRemove: (pubkey: string) => void;
+};
+
+export const QuickAddAgentItemRow = React.memo(function QuickAddAgentItemRow({
+  item,
+  itemKey,
+  isSelected,
+  isPending,
+  selectMode,
+  disabled,
+  onClick,
+  onRemove,
+}: QuickAddAgentItemRowProps) {
+  const isInChannel = item.kind === "running-in-channel";
+
+  return (
+    <motion.div key={itemKey} layout transition={{ duration: 0.2 }}>
+      <button
+        aria-selected={isInChannel || isSelected}
+        className={cn(
+          "flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors",
+          isInChannel
+            ? "cursor-default"
+            : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
+          isPending && "pointer-events-none opacity-60",
+          isSelected && "bg-accent/50",
+        )}
+        data-quick-add-item
+        disabled={!isInChannel && disabled}
+        onClick={onClick}
+        role="option"
+        tabIndex={0}
+        type="button"
+      >
+        {!isInChannel ? (
+          <motion.div
+            animate={{
+              width: selectMode ? 16 : 0,
+              marginRight: selectMode ? 8 : 0,
+              opacity: selectMode ? 1 : 0,
+            }}
+            initial={false}
+            transition={{ duration: 0.15 }}
+            className="shrink-0 overflow-hidden"
+          >
+            <div
+              className={cn(
+                "flex h-4 w-4 items-center justify-center rounded border transition-colors",
+                isSelected
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-muted-foreground/40",
+              )}
+            >
+              {isSelected ? <Check className="h-3 w-3" /> : null}
+            </div>
+          </motion.div>
+        ) : null}
+        <div className="flex min-w-0 flex-1 items-center gap-2.5">
+          <span className={cn("shrink-0", isInChannel && "opacity-50")}>
+            <QuickAddAgentAvatar
+              avatarUrl={item.avatarUrl}
+              label={item.label}
+              isRunning={item.kind !== "persona"}
+            />
+          </span>
+          <span
+            className={cn(
+              "min-w-0 flex-1 truncate font-medium",
+              isInChannel && "opacity-50",
+            )}
+          >
+            {item.label}
+          </span>
+          {isInChannel ? (
+            <button
+              className="flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove(item.agent.pubkey);
+              }}
+              type="button"
+              aria-label={`Remove ${item.label}`}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+          {isPending ? (
+            <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
+          ) : null}
+        </div>
+      </button>
+    </motion.div>
+  );
+});

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -1,4 +1,4 @@
-import { Check, Settings2 } from "lucide-react";
+import { Check, Settings2, X } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import * as React from "react";
 
@@ -12,7 +12,7 @@ import {
   useTeamsQuery,
 } from "@/features/agents/hooks";
 import { Toggle } from "@/shared/ui/toggle";
-import { useChannelMembersQuery } from "@/features/channels/hooks";
+import { useChannelMembersQuery, useRemoveChannelMemberMutation } from "@/features/channels/hooks";
 import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { resolvePersonaProvider } from "@/features/agents/lib/resolvePersonaProvider";
 import { pickBotName } from "@/features/agents/lib/pickBotName";
@@ -106,6 +106,7 @@ export function QuickAddAgentPopover({
   const attachMutation = useAttachManagedAgentToChannelMutation(channelId);
   const createMutation = useCreateChannelManagedAgentMutation(channelId);
   const batchCreateMutation = useCreateChannelManagedAgentsMutation(channelId);
+  const removeMutation = useRemoveChannelMemberMutation(channelId);
   const { recentIds, pushRecent } = useBotRecents();
 
   const [pendingKey, setPendingKey] = React.useState<string | null>(null);
@@ -625,17 +626,17 @@ export function QuickAddAgentPopover({
                       className={cn(
                         "flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors",
                         isInChannel
-                          ? "cursor-default opacity-50"
+                          ? "cursor-default"
                           : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
                         isItemPending && "pointer-events-none opacity-60",
                         isSelected && "bg-accent/50",
                       )}
                       data-quick-add-item
-                      disabled={isInChannel || Boolean(pendingKey)}
+                      disabled={!isInChannel && Boolean(pendingKey)}
                       key={itemKey}
                       onClick={() => handleItemClick(item)}
                       role="option"
-                      tabIndex={isInChannel ? -1 : 0}
+                      tabIndex={0}
                       type="button"
                     >
                       {!isInChannel ? (
@@ -667,7 +668,17 @@ export function QuickAddAgentPopover({
                           {item.label}
                         </span>
                         {isInChannel ? (
-                          <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                          <button
+                            className="flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              removeMutation.mutate(item.agent.pubkey);
+                            }}
+                            type="button"
+                            aria-label={`Remove ${item.label}`}
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </button>
                         ) : null}
                         {isItemPending ? (
                           <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -664,7 +664,7 @@ export function QuickAddAgentPopover({
 
           <div className="border-t">
             <button
-              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="flex w-full items-center gap-2 px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               data-quick-add-item
               data-testid="quick-add-more-options"
               onClick={() => {

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -515,7 +515,7 @@ export function QuickAddAgentPopover({
                       className="shrink-0"
                     >
                       <Toggle
-                        className="h-8 rounded-full px-3 text-xs"
+                        className="h-8 rounded-full px-3 text-xs data-[state=on]:bg-accent data-[state=on]:text-accent-foreground"
                         onPressedChange={(pressed) =>
                           handleTeamToggle(team, pressed)
                         }
@@ -560,7 +560,7 @@ export function QuickAddAgentPopover({
                   }}
                   size="sm"
                   type="button"
-                  variant={selectMode ? "default" : "ghost"}
+                  variant={selectMode ? "secondary" : "ghost"}
                 >
                   Select
                 </Button>

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -591,8 +591,7 @@ export function QuickAddAgentPopover({
                   const isSelected = selectedKeys.has(itemKey);
 
                   return (
-                    <motion.button
-                      layout
+                    <button
                       aria-selected={isInChannel || isSelected}
                       className={cn(
                         "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
@@ -608,42 +607,35 @@ export function QuickAddAgentPopover({
                       onClick={() => handleItemClick(item)}
                       role="option"
                       tabIndex={isInChannel ? -1 : 0}
-                      transition={{ duration: 0.15 }}
                       type="button"
                     >
-                      <AnimatePresence>
-                        {selectMode && !isInChannel ? (
-                          <motion.div
-                            key="checkbox"
-                            initial={{ width: 0, opacity: 0 }}
-                            animate={{ width: 16, opacity: 1 }}
-                            exit={{ width: 0, opacity: 0 }}
-                            transition={{ duration: 0.15 }}
-                            className="shrink-0 overflow-hidden"
+                      {!isInChannel ? (
+                        <motion.div
+                          animate={{ width: selectMode ? 16 : 0, opacity: selectMode ? 1 : 0 }}
+                          initial={false}
+                          transition={{ duration: 0.15 }}
+                          className="shrink-0 overflow-hidden"
+                        >
+                          <div
+                            className={cn(
+                              "flex h-4 w-4 items-center justify-center rounded border transition-colors",
+                              isSelected
+                                ? "border-primary bg-primary text-primary-foreground"
+                                : "border-muted-foreground/40",
+                            )}
                           >
-                            <div
-                              className={cn(
-                                "flex h-4 w-4 items-center justify-center rounded border transition-colors",
-                                isSelected
-                                  ? "border-primary bg-primary text-primary-foreground"
-                                  : "border-muted-foreground/40",
-                              )}
-                            >
-                              {isSelected ? <Check className="h-3 w-3" /> : null}
-                            </div>
-                          </motion.div>
-                        ) : null}
-                      </AnimatePresence>
-                      <motion.div layout="position" transition={{ duration: 0.15 }} className="shrink-0">
-                        <QuickAddAgentAvatar
-                          avatarUrl={item.avatarUrl}
-                          label={item.label}
-                          isRunning={item.kind !== "persona"}
-                        />
-                      </motion.div>
-                      <motion.span layout="position" transition={{ duration: 0.15 }} className="min-w-0 flex-1 truncate font-medium">
+                            {isSelected ? <Check className="h-3 w-3" /> : null}
+                          </div>
+                        </motion.div>
+                      ) : null}
+                      <QuickAddAgentAvatar
+                        avatarUrl={item.avatarUrl}
+                        label={item.label}
+                        isRunning={item.kind !== "persona"}
+                      />
+                      <span className="min-w-0 flex-1 truncate font-medium">
                         {item.label}
-                      </motion.span>
+                      </span>
                       {isInChannel ? (
                         <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       ) : item.kind === "running-available" && !selectMode ? (
@@ -654,7 +646,7 @@ export function QuickAddAgentPopover({
                       {isItemPending ? (
                         <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
                       ) : null}
-                    </motion.button>
+                    </button>
                   );
                 })}
               </div>

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -743,7 +743,7 @@ function QuickAddAgentAvatar({
         </span>
       )}
       {isRunning ? (
-        <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-background bg-emerald-500" />
+        <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-popover bg-emerald-500" />
       ) : null}
     </div>
   );

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -17,22 +17,38 @@ import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { cn } from "@/shared/lib/cn";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/shared/ui/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type QuickAddAgentItem = {
-  kind: "running-available" | "running-in-channel" | "persona";
-  agent?: ManagedAgent;
-  persona?: AgentPersona;
+type RunningAvailableItem = {
+  kind: "running-available";
+  agent: ManagedAgent;
+  persona: AgentPersona | null;
   label: string;
   avatarUrl: string | null;
 };
+
+type RunningInChannelItem = {
+  kind: "running-in-channel";
+  agent: ManagedAgent;
+  persona: AgentPersona | null;
+  label: string;
+  avatarUrl: string | null;
+};
+
+type PersonaItem = {
+  kind: "persona";
+  persona: AgentPersona;
+  label: string;
+  avatarUrl: string | null;
+};
+
+type QuickAddAgentItem =
+  | RunningAvailableItem
+  | RunningInChannelItem
+  | PersonaItem;
 
 type QuickAddAgentPopoverProps = {
   channelId: string | null;
@@ -41,6 +57,27 @@ type QuickAddAgentPopoverProps = {
   onMoreOptions: () => void;
   children: React.ReactNode;
 };
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getItemKey(item: QuickAddAgentItem): string {
+  switch (item.kind) {
+    case "persona":
+      return `persona:${item.persona.id}`;
+    case "running-available":
+    case "running-in-channel":
+      return `agent:${item.agent.pubkey}`;
+  }
+}
+
+function safeBotName(persona: AgentPersona, usedNames: Set<string>): string {
+  const pool = persona.namePool ?? [];
+  const name = pickBotName(pool, usedNames);
+  // pickBotName always returns a string from the universal pool fallback,
+  // but guard defensively in case of edge cases.
+  if (name && name.trim().length > 0) return name;
+  return persona.displayName || "Agent";
+}
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
@@ -51,10 +88,16 @@ export function QuickAddAgentPopover({
   onMoreOptions,
   children,
 }: QuickAddAgentPopoverProps) {
+  // Gate channel members query to only fire when the popover is open.
+  // Managed agents, personas, and providers are globally cached by
+  // ChannelMembersBar (always mounted), so no extra fetch cost here.
   const managedAgentsQuery = useManagedAgentsQuery();
   const personasQuery = usePersonasQuery();
   const providersQuery = useAcpProvidersQuery();
-  const membersQuery = useChannelMembersQuery(channelId, open);
+  const membersQuery = useChannelMembersQuery(
+    channelId,
+    open && channelId !== null,
+  );
   const attachMutation = useAttachManagedAgentToChannelMutation(channelId);
   const createMutation = useCreateChannelManagedAgentMutation(channelId);
   const { recentIds, pushRecent } = useBotRecents();
@@ -94,8 +137,7 @@ export function QuickAddAgentPopover({
         channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
     );
 
-    // Personas that don't have a running agent yet (configured but not running)
-    // Exclude personas whose agent is already in the channel
+    // Personas whose agent is already in the channel (exclude from "available" list)
     const personaIdsInChannel = new Set(
       managedAgents
         .filter((agent) =>
@@ -113,12 +155,8 @@ export function QuickAddAgentPopover({
 
     // Sort running-available by recency
     const sortedRunningAvailable = [...runningAvailable].sort((a, b) => {
-      const aPersonaIdx = a.personaId
-        ? recentIds.indexOf(a.personaId)
-        : -1;
-      const bPersonaIdx = b.personaId
-        ? recentIds.indexOf(b.personaId)
-        : -1;
+      const aPersonaIdx = a.personaId ? recentIds.indexOf(a.personaId) : -1;
+      const bPersonaIdx = b.personaId ? recentIds.indexOf(b.personaId) : -1;
       const aScore = aPersonaIdx >= 0 ? aPersonaIdx : 999;
       const bScore = bPersonaIdx >= 0 ? bPersonaIdx : 999;
       return aScore - bScore;
@@ -126,8 +164,8 @@ export function QuickAddAgentPopover({
 
     for (const agent of sortedRunningAvailable) {
       const persona = agent.personaId
-        ? personas.find((p) => p.id === agent.personaId)
-        : undefined;
+        ? (personas.find((p) => p.id === agent.personaId) ?? null)
+        : null;
       result.push({
         kind: "running-available",
         agent,
@@ -139,8 +177,8 @@ export function QuickAddAgentPopover({
 
     for (const agent of runningInChannel) {
       const persona = agent.personaId
-        ? personas.find((p) => p.id === agent.personaId)
-        : undefined;
+        ? (personas.find((p) => p.id === agent.personaId) ?? null)
+        : null;
       result.push({
         kind: "running-in-channel",
         agent,
@@ -170,12 +208,7 @@ export function QuickAddAgentPopover({
     }
 
     return result;
-  }, [
-    managedAgents,
-    personas,
-    channelMemberPubkeys,
-    recentIds,
-  ]);
+  }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
 
   // Reset state when popover closes
   React.useEffect(() => {
@@ -186,6 +219,7 @@ export function QuickAddAgentPopover({
   }, [open]);
 
   async function handleAddRunningAgent(agent: ManagedAgent) {
+    if (!channelId) return;
     const key = `agent:${agent.pubkey}`;
     setPendingKey(key);
     setErrorMessage(null);
@@ -203,6 +237,7 @@ export function QuickAddAgentPopover({
   }
 
   async function handleAddPersona(persona: AgentPersona) {
+    if (!channelId) return;
     const key = `persona:${persona.id}`;
     setPendingKey(key);
     setErrorMessage(null);
@@ -219,9 +254,8 @@ export function QuickAddAgentPopover({
       return;
     }
 
-    // Pick a name from the persona's pool
     const usedNames = new Set(managedAgents.map((a) => a.name));
-    const instanceName = pickBotName(persona.namePool, usedNames);
+    const instanceName = safeBotName(persona, usedNames);
 
     try {
       await createMutation.mutateAsync({
@@ -245,10 +279,11 @@ export function QuickAddAgentPopover({
   function handleItemClick(item: QuickAddAgentItem) {
     if (item.kind === "running-in-channel") return;
     if (pendingKey) return;
+    if (!channelId) return;
 
-    if (item.kind === "running-available" && item.agent) {
+    if (item.kind === "running-available") {
       void handleAddRunningAgent(item.agent);
-    } else if (item.kind === "persona" && item.persona) {
+    } else {
       void handleAddPersona(item.persona);
     }
   }
@@ -258,15 +293,43 @@ export function QuickAddAgentPopover({
     personasQuery.isLoading ||
     providersQuery.isLoading;
 
+  // Don't render the popover content when there's no channel
+  if (!channelId) {
+    return <>{children}</>;
+  }
+
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent
-        align="end"
-        className="w-72 p-0"
-        sideOffset={6}
-      >
-        <div className="flex max-h-80 flex-col">
+      <PopoverContent align="end" className="w-72 p-0" sideOffset={6}>
+        <div
+          className="flex max-h-80 flex-col"
+          role="listbox"
+          aria-label="Available agents"
+          onKeyDown={(e) => {
+            const container = e.currentTarget;
+            const buttons = Array.from(
+              container.querySelectorAll<HTMLButtonElement>(
+                "[data-quick-add-item]:not([disabled])",
+              ),
+            );
+            if (buttons.length === 0) return;
+            const focused = document.activeElement as HTMLElement | null;
+            const currentIdx = focused
+              ? buttons.indexOf(focused as HTMLButtonElement)
+              : -1;
+
+            if (e.key === "ArrowDown") {
+              e.preventDefault();
+              const next = currentIdx < buttons.length - 1 ? currentIdx + 1 : 0;
+              buttons[next]?.focus();
+            } else if (e.key === "ArrowUp") {
+              e.preventDefault();
+              const prev = currentIdx > 0 ? currentIdx - 1 : buttons.length - 1;
+              buttons[prev]?.focus();
+            }
+          }}
+        >
           <div className="border-b px-3 py-2">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Add agent
@@ -285,15 +348,13 @@ export function QuickAddAgentPopover({
             ) : (
               <div className="py-1">
                 {items.map((item) => {
-                  const itemKey =
-                    item.kind === "persona"
-                      ? `persona:${item.persona?.id}`
-                      : `agent:${item.agent?.pubkey}`;
+                  const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";
                   const isItemPending = pendingKey === itemKey;
 
                   return (
                     <button
+                      aria-selected={isInChannel}
                       className={cn(
                         "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
                         isInChannel
@@ -301,9 +362,12 @@ export function QuickAddAgentPopover({
                           : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
                         isItemPending && "pointer-events-none opacity-60",
                       )}
+                      data-quick-add-item
                       disabled={isInChannel || Boolean(pendingKey)}
                       key={itemKey}
                       onClick={() => handleItemClick(item)}
+                      role="option"
+                      tabIndex={isInChannel ? -1 : 0}
                       type="button"
                     >
                       <QuickAddAgentAvatar
@@ -340,6 +404,8 @@ export function QuickAddAgentPopover({
           <div className="border-t">
             <button
               className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              data-quick-add-item
+              data-testid="quick-add-more-options"
               onClick={() => {
                 onOpenChange(false);
                 onMoreOptions();

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -304,8 +304,6 @@ export function QuickAddAgentPopover({
       <PopoverContent align="end" className="w-72 p-0" sideOffset={6}>
         <div
           className="flex max-h-80 flex-col"
-          role="listbox"
-          aria-label="Available agents"
           onKeyDown={(e) => {
             const container = e.currentTarget;
             const buttons = Array.from(
@@ -346,7 +344,7 @@ export function QuickAddAgentPopover({
                 No agents available.
               </div>
             ) : (
-              <div className="py-1">
+              <div aria-label="Available agents" className="py-1" role="listbox">
                 {items.map((item) => {
                   const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -225,39 +225,44 @@ export function QuickAddAgentPopover({
     return result;
   }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
 
-  // Snapshot item order when popover opens — don't reorder while open
-  const [stableItems, setStableItems] = React.useState<QuickAddAgentItem[]>([]);
-  React.useEffect(() => {
-    if (open) {
-      setStableItems(items);
-    }
-  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Frozen key order — captured once when popover opens, used for rendering
+  const frozenKeysRef = React.useRef<string[]>([]);
+  const prevOpenRef = React.useRef(false);
+  if (open && !prevOpenRef.current) {
+    // Popover just opened — freeze the current key order
+    frozenKeysRef.current = items.map(getItemKey);
+  }
+  prevOpenRef.current = open;
 
-  // Merge live data (kind changes) into stable order while keeping positions
+  // Render items in frozen order, prepend any new ones
   const displayItems = React.useMemo(() => {
     if (!open) return items;
+    const frozenKeys = frozenKeysRef.current;
     const liveMap = new Map(items.map((item) => [getItemKey(item), item]));
-    // Keep stable order, update each item with live data
-    const stable: QuickAddAgentItem[] = [];
-    const seen = new Set<string>();
-    for (const stableItem of stableItems) {
-      const key = getItemKey(stableItem);
+
+    // Existing items in frozen order (with live data)
+    const ordered: QuickAddAgentItem[] = [];
+    for (const key of frozenKeys) {
       const liveItem = liveMap.get(key);
       if (liveItem) {
-        stable.push(liveItem);
-        seen.add(key);
+        ordered.push(liveItem);
       }
     }
-    // Prepend any new items (e.g. newly created agents) at the top
+
+    // New items (not in frozen snapshot) prepend to top
+    const frozenSet = new Set(frozenKeys);
     const newItems: QuickAddAgentItem[] = [];
     for (const item of items) {
       const key = getItemKey(item);
-      if (!seen.has(key)) {
+      if (!frozenSet.has(key)) {
         newItems.push(item);
+        // Add to frozen keys so they stay in position on subsequent renders
+        frozenKeysRef.current = [key, ...frozenKeysRef.current];
       }
     }
-    return [...newItems, ...stable];
-  }, [open, stableItems, items]);
+
+    return [...newItems, ...ordered];
+  }, [open, items]);
 
   // Reset state when popover closes
   React.useEffect(() => {

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -178,12 +178,12 @@ export function QuickAddAgentPopover({
       return aScore - bScore;
     });
 
-    for (const agent of sortedRunningAvailable) {
+    for (const agent of runningInChannel) {
       const persona = agent.personaId
         ? (personas.find((p) => p.id === agent.personaId) ?? null)
         : null;
       result.push({
-        kind: "running-available",
+        kind: "running-in-channel",
         agent,
         persona,
         label: agent.name,
@@ -191,12 +191,12 @@ export function QuickAddAgentPopover({
       });
     }
 
-    for (const agent of runningInChannel) {
+    for (const agent of sortedRunningAvailable) {
       const persona = agent.personaId
         ? (personas.find((p) => p.id === agent.personaId) ?? null)
         : null;
       result.push({
-        kind: "running-in-channel",
+        kind: "running-available",
         agent,
         persona,
         label: agent.name,
@@ -225,44 +225,6 @@ export function QuickAddAgentPopover({
     return result;
   }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
 
-  // Frozen key order — captured once when popover opens, used for rendering
-  const frozenKeysRef = React.useRef<string[]>([]);
-  const prevOpenRef = React.useRef(false);
-  if (open && !prevOpenRef.current) {
-    // Popover just opened — freeze the current key order
-    frozenKeysRef.current = items.map(getItemKey);
-  }
-  prevOpenRef.current = open;
-
-  // Render items in frozen order, prepend any new ones
-  const displayItems = React.useMemo(() => {
-    if (!open) return items;
-    const frozenKeys = frozenKeysRef.current;
-    const liveMap = new Map(items.map((item) => [getItemKey(item), item]));
-
-    // Existing items in frozen order (with live data)
-    const ordered: QuickAddAgentItem[] = [];
-    for (const key of frozenKeys) {
-      const liveItem = liveMap.get(key);
-      if (liveItem) {
-        ordered.push(liveItem);
-      }
-    }
-
-    // New items (not in frozen snapshot) prepend to top
-    const frozenSet = new Set(frozenKeys);
-    const newItems: QuickAddAgentItem[] = [];
-    for (const item of items) {
-      const key = getItemKey(item);
-      if (!frozenSet.has(key)) {
-        newItems.push(item);
-        // Add to frozen keys so they stay in position on subsequent renders
-        frozenKeysRef.current = [key, ...frozenKeysRef.current];
-      }
-    }
-
-    return [...newItems, ...ordered];
-  }, [open, items]);
 
   // Reset state when popover closes
   React.useEffect(() => {
@@ -645,7 +607,7 @@ export function QuickAddAgentPopover({
               <div className="flex items-center justify-center py-6">
                 <Spinner className="h-4 w-4 text-muted-foreground" />
               </div>
-            ) : displayItems.length === 0 ? (
+            ) : items.length === 0 ? (
               <div className="px-3 py-4 text-center text-sm text-muted-foreground">
                 No agents available.
               </div>
@@ -655,7 +617,7 @@ export function QuickAddAgentPopover({
                 className="py-1"
                 role="listbox"
               >
-                {displayItems.map((item) => {
+                {items.map((item) => {
                   const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";
                   const isItemPending =
@@ -663,6 +625,7 @@ export function QuickAddAgentPopover({
                   const isSelected = selectedKeys.has(itemKey);
 
                   return (
+                    <motion.div key={itemKey} layout transition={{ duration: 0.2 }}>
                     <button
                       aria-selected={isInChannel || isSelected}
                       className={cn(
@@ -675,7 +638,6 @@ export function QuickAddAgentPopover({
                       )}
                       data-quick-add-item
                       disabled={!isInChannel && Boolean(pendingKey)}
-                      key={itemKey}
                       onClick={() => handleItemClick(item)}
                       role="option"
                       tabIndex={0}
@@ -729,6 +691,7 @@ export function QuickAddAgentPopover({
                         ) : null}
                       </div>
                     </button>
+                    </motion.div>
                   );
                 })}
               </div>

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -492,10 +492,11 @@ export function QuickAddAgentPopover({
           }}
         >
           {/* Header with animated title / team toggles */}
-          <div className="relative flex min-h-10 items-center gap-2 border-b pl-3 pr-1.5 py-1.5">
-            {/* Title — always visible */}
+          {/* Header */}
+          <div className="flex min-h-10 items-center gap-2 border-b pl-3 pr-1.5 py-1.5">
             <h3 className="shrink-0 text-sm font-semibold text-foreground">
-              Add agent{selectMode ? (
+              Add agent
+              {selectMode ? (
                 <motion.span
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
@@ -507,50 +508,6 @@ export function QuickAddAgentPopover({
               ) : null}
             </h3>
 
-            {/* Team toggles — appear to the right of title */}
-            <AnimatePresence>
-              {selectMode ? (
-                <motion.div
-                  key="team-chips"
-                  className="relative flex min-w-0 flex-1 items-center"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.15 }}
-                >
-                  <div className="flex items-center gap-1.5 overflow-x-auto">
-                    {usableTeams.map((team, index) => (
-                      <motion.div
-                        key={team.id}
-                        initial={{ opacity: 0, x: index === 0 ? 0 : 12 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        transition={{
-                          duration: 0.2,
-                          delay: index * 0.05,
-                        }}
-                        className="shrink-0"
-                      >
-                        <Toggle
-                          className="h-8 rounded-full px-3 text-xs"
-                          onPressedChange={(pressed) =>
-                            handleTeamToggle(team, pressed)
-                          }
-                          pressed={selectedTeamIds.has(team.id)}
-                          size="sm"
-                          variant="outline"
-                        >
-                          {team.name}
-                        </Toggle>
-                      </motion.div>
-                    ))}
-                  </div>
-                  {/* Gradient fade on right edge — scroll affordance */}
-                  <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-popover to-transparent" />
-                </motion.div>
-              ) : null}
-            </AnimatePresence>
-
-            {/* Right side: Select / Cancel button */}
             {usableTeams.length > 0 ? (
               <div className="ml-auto flex shrink-0 items-center">
                 <Button
@@ -572,8 +529,56 @@ export function QuickAddAgentPopover({
             ) : null}
           </div>
 
+          {/* Team toggles row — slides in between header and list */}
+          <AnimatePresence>
+            {selectMode ? (
+              <motion.div
+                key="team-row"
+                className="relative border-b px-3 py-2"
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                style={{ overflow: "hidden" }}
+              >
+                <div className="flex items-center gap-1.5 overflow-x-auto">
+                  {usableTeams.map((team, index) => (
+                    <motion.div
+                      key={team.id}
+                      initial={{ opacity: 0, x: index === 0 ? 0 : 12 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{
+                        duration: 0.2,
+                        delay: index * 0.05,
+                      }}
+                      className="shrink-0"
+                    >
+                      <Toggle
+                        className="h-8 rounded-full px-3 text-xs"
+                        onPressedChange={(pressed) =>
+                          handleTeamToggle(team, pressed)
+                        }
+                        pressed={selectedTeamIds.has(team.id)}
+                        size="sm"
+                        variant="outline"
+                      >
+                        {team.name}
+                      </Toggle>
+                    </motion.div>
+                  ))}
+                </div>
+                {/* Gradient fade on right edge — scroll affordance */}
+                <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-popover to-transparent" />
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+
           {/* Scrollable content — clips mid-item to hint at more */}
-          <div className="max-h-[13.75rem] flex-1 overflow-y-auto">
+          <motion.div
+            className="max-h-[13.75rem] flex-1 overflow-y-auto"
+            layout
+            transition={{ duration: 0.2 }}
+          >
             {isLoading ? (
               <div className="flex items-center justify-center py-6">
                 <Spinner className="h-4 w-4 text-muted-foreground" />
@@ -649,7 +654,7 @@ export function QuickAddAgentPopover({
                 })}
               </div>
             )}
-          </div>
+          </motion.div>
 
           {errorMessage ? (
             <div className="border-t px-3 py-2">

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -77,6 +77,17 @@ function getItemKey(item: QuickAddAgentItem): string {
   }
 }
 
+/** Get the persona ID associated with an item (for team membership checks). */
+function getItemPersonaId(item: QuickAddAgentItem): string | null {
+  switch (item.kind) {
+    case "persona":
+      return item.persona.id;
+    case "running-available":
+    case "running-in-channel":
+      return item.agent.personaId ?? null;
+  }
+}
+
 function safeBotName(persona: AgentPersona, usedNames: Set<string>): string {
   const pool = persona.namePool ?? [];
   const name = pickBotName(pool, usedNames);
@@ -134,7 +145,7 @@ export function QuickAddAgentPopover({
     [teams, personas],
   );
 
-  // Build the sorted item list
+  // Build the full item list (flat, for mutations)
   const items: QuickAddAgentItem[] = React.useMemo(() => {
     const result: QuickAddAgentItem[] = [];
 
@@ -220,6 +231,38 @@ export function QuickAddAgentPopover({
     return result;
   }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
 
+  // ── Grouped layout: team sections + ungrouped ─────────────────────────────
+
+  // Set of all persona IDs that belong to at least one usable team
+  const teamedPersonaIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const team of usableTeams) {
+      for (const pid of team.personaIds) {
+        ids.add(pid);
+      }
+    }
+    return ids;
+  }, [usableTeams]);
+
+  // Items grouped by team
+  const teamGroups = React.useMemo(() => {
+    return usableTeams.map((team) => {
+      const memberItems = items.filter((item) => {
+        const personaId = getItemPersonaId(item);
+        return personaId !== null && team.personaIds.includes(personaId);
+      });
+      return { team, items: memberItems };
+    });
+  }, [usableTeams, items]);
+
+  // Ungrouped items (not in any team)
+  const ungroupedItems = React.useMemo(() => {
+    return items.filter((item) => {
+      const personaId = getItemPersonaId(item);
+      return personaId === null || !teamedPersonaIds.has(personaId);
+    });
+  }, [items, teamedPersonaIds]);
+
   // Reset state when popover closes
   React.useEffect(() => {
     if (!open) {
@@ -292,6 +335,15 @@ export function QuickAddAgentPopover({
 
   // ── Multi-select handlers ─────────────────────────────────────────────────
 
+  function enterMultiSelect(key: string) {
+    setMultiSelectMode(true);
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+  }
+
   function toggleSelection(key: string) {
     setSelectedKeys((prev) => {
       const next = new Set(prev);
@@ -300,7 +352,6 @@ export function QuickAddAgentPopover({
       } else {
         next.add(key);
       }
-      // Exit multi-select mode if nothing selected
       if (next.size === 0) {
         setMultiSelectMode(false);
       }
@@ -310,29 +361,25 @@ export function QuickAddAgentPopover({
 
   function handleTeamClick(team: AgentTeam) {
     const resolution = resolveTeamPersonas(team, personas);
-    const personaKeys = resolution.resolvedPersonas.map(
-      (p) => `persona:${p.id}`,
-    );
 
-    // Enter multi-select mode and select all team personas
     setMultiSelectMode(true);
     setSelectedKeys((prev) => {
       const next = new Set(prev);
-      for (const key of personaKeys) {
-        // Only select if the item is actually in our addable list
-        const item = items.find((i) => getItemKey(i) === key);
-        if (item && item.kind !== "running-in-channel") {
-          next.add(key);
-        }
-      }
-      // Also select running agents that belong to team personas
       for (const persona of resolution.resolvedPersonas) {
+        // Find the matching item (running agent or persona)
         const runningItem = items.find(
           (i) =>
             i.kind === "running-available" && i.agent.personaId === persona.id,
         );
         if (runningItem) {
           next.add(getItemKey(runningItem));
+        } else {
+          const personaItem = items.find(
+            (i) => i.kind === "persona" && i.persona.id === persona.id,
+          );
+          if (personaItem && personaItem.kind !== "running-in-channel") {
+            next.add(getItemKey(personaItem));
+          }
         }
       }
       return next;
@@ -365,13 +412,11 @@ export function QuickAddAgentPopover({
     }
 
     try {
-      // Attach running agents individually
       for (const agent of toAttach) {
         await attachMutation.mutateAsync({ agent, ensureRunning: true });
         if (agent.personaId) pushRecent(agent.personaId);
       }
 
-      // Batch-create new agents
       if (toCreate.length > 0 && defaultProvider) {
         const inputs = toCreate.map(({ persona, instanceName }) => {
           const { provider } = resolvePersonaProvider(
@@ -419,7 +464,6 @@ export function QuickAddAgentPopover({
     if (!channelId) return;
 
     if (multiSelectMode) {
-      // In multi-select mode, toggle selection
       toggleSelection(getItemKey(item));
     } else {
       // Single-click fast path — add immediately
@@ -431,6 +475,20 @@ export function QuickAddAgentPopover({
     }
   }
 
+  function handleCheckboxClick(e: React.MouseEvent, item: QuickAddAgentItem) {
+    e.stopPropagation();
+    if (item.kind === "running-in-channel") return;
+    if (pendingKey) return;
+
+    const key = getItemKey(item);
+    if (multiSelectMode) {
+      toggleSelection(key);
+    } else {
+      // Clicking checkbox enters multi-select mode
+      enterMultiSelect(key);
+    }
+  }
+
   const isLoading =
     managedAgentsQuery.isLoading ||
     personasQuery.isLoading ||
@@ -438,6 +496,75 @@ export function QuickAddAgentPopover({
 
   if (!channelId) {
     return <>{children}</>;
+  }
+
+  // ── Render helpers ────────────────────────────────────────────────────────
+
+  function renderAgentRow(item: QuickAddAgentItem, indented: boolean) {
+    const itemKey = getItemKey(item);
+    const isInChannel = item.kind === "running-in-channel";
+    const isItemPending = pendingKey === itemKey || pendingKey === "batch";
+    const isSelected = selectedKeys.has(itemKey);
+
+    return (
+      <button
+        aria-selected={isInChannel || isSelected}
+        className={cn(
+          "group flex w-full items-center gap-2.5 py-1.5 text-left text-sm transition-colors",
+          indented ? "pl-6 pr-3" : "px-3",
+          isInChannel
+            ? "cursor-default opacity-50"
+            : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
+          isItemPending && "pointer-events-none opacity-60",
+          isSelected && "bg-accent/50",
+        )}
+        data-quick-add-item
+        disabled={isInChannel || Boolean(pendingKey)}
+        key={itemKey}
+        onClick={() => handleItemClick(item)}
+        role="option"
+        tabIndex={isInChannel ? -1 : 0}
+        type="button"
+      >
+        {/* Checkbox: always visible in multi-select, hover-reveal otherwise */}
+        {!isInChannel ? (
+          <div
+            className={cn(
+              "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-all",
+              multiSelectMode
+                ? "opacity-100"
+                : "opacity-0 group-hover:opacity-100",
+              isSelected
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-muted-foreground/40",
+            )}
+            onClick={(e) => handleCheckboxClick(e, item)}
+            onKeyDown={() => {}}
+            aria-hidden="true"
+          >
+            {isSelected ? <Check className="h-3 w-3" /> : null}
+          </div>
+        ) : (
+          <div className="h-4 w-4 shrink-0" />
+        )}
+        <QuickAddAgentAvatar
+          avatarUrl={item.avatarUrl}
+          label={item.label}
+          isRunning={item.kind !== "persona"}
+        />
+        <span className="flex-1 truncate font-medium">{item.label}</span>
+        {isInChannel ? (
+          <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : item.kind === "running-available" && !multiSelectMode ? (
+          <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+            running
+          </span>
+        ) : null}
+        {isItemPending ? (
+          <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
+        ) : null}
+      </button>
+    );
   }
 
   return (
@@ -496,118 +623,61 @@ export function QuickAddAgentPopover({
             ) : null}
           </div>
 
-          {/* Scrollable content area — max-height clips mid-item to hint at more */}
+          {/* Scrollable content — clips mid-item to hint at more */}
           <div className="max-h-[13.75rem] flex-1 overflow-y-auto">
             {isLoading ? (
               <div className="flex items-center justify-center py-6">
                 <Spinner className="h-4 w-4 text-muted-foreground" />
               </div>
+            ) : items.length === 0 ? (
+              <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+                No agents available.
+              </div>
             ) : (
-              <>
-                {/* Teams section */}
-                {usableTeams.length > 0 ? (
-                  <div className="border-b py-1">
-                    {usableTeams.map((team) => {
-                      const resolution = resolveTeamPersonas(team, personas);
-                      return (
-                        <button
-                          className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
-                          data-quick-add-item
-                          key={team.id}
-                          onClick={() => handleTeamClick(team)}
-                          type="button"
-                        >
-                          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30">
-                            <Users className="h-3.5 w-3.5 text-muted-foreground" />
-                          </div>
-                          <span className="flex-1 truncate font-medium">
-                            {team.name}
-                          </span>
-                          <span className="shrink-0 text-[11px] text-muted-foreground">
-                            {resolution.resolvedPersonas.length}
-                          </span>
-                        </button>
-                      );
-                    })}
+              <div
+                aria-label="Available agents"
+                className="py-1"
+                role="listbox"
+              >
+                {/* Team groups */}
+                {teamGroups.map(({ team, items: teamItems }) => (
+                  <div key={team.id} className="mb-1">
+                    {/* Team header */}
+                    <button
+                      className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+                      data-quick-add-item
+                      onClick={() => handleTeamClick(team)}
+                      type="button"
+                    >
+                      <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-muted">
+                        <Users className="h-3 w-3 text-muted-foreground" />
+                      </div>
+                      <span className="flex-1 truncate text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        {team.name}
+                      </span>
+                      <span className="shrink-0 text-[11px] text-muted-foreground">
+                        {teamItems.length}
+                      </span>
+                    </button>
+                    {/* Team members (indented) */}
+                    {teamItems.map((item) => renderAgentRow(item, true))}
+                  </div>
+                ))}
+
+                {/* Ungrouped section */}
+                {ungroupedItems.length > 0 ? (
+                  <div className={cn(teamGroups.length > 0 && "border-t pt-1")}>
+                    {teamGroups.length > 0 ? (
+                      <div className="px-3 py-1">
+                        <span className="text-[11px] font-medium text-muted-foreground">
+                          Ungrouped
+                        </span>
+                      </div>
+                    ) : null}
+                    {ungroupedItems.map((item) => renderAgentRow(item, false))}
                   </div>
                 ) : null}
-
-                {/* Agents section */}
-                {items.length === 0 ? (
-                  <div className="px-3 py-4 text-center text-sm text-muted-foreground">
-                    No agents available.
-                  </div>
-                ) : (
-                  <div
-                    aria-label="Available agents"
-                    className="py-1"
-                    role="listbox"
-                  >
-                    {items.map((item) => {
-                      const itemKey = getItemKey(item);
-                      const isInChannel = item.kind === "running-in-channel";
-                      const isItemPending =
-                        pendingKey === itemKey || pendingKey === "batch";
-                      const isSelected = selectedKeys.has(itemKey);
-
-                      return (
-                        <button
-                          aria-selected={isInChannel || isSelected}
-                          className={cn(
-                            "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
-                            isInChannel
-                              ? "cursor-default opacity-50"
-                              : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
-                            isItemPending && "pointer-events-none opacity-60",
-                            isSelected && "bg-accent/50",
-                          )}
-                          data-quick-add-item
-                          disabled={isInChannel || Boolean(pendingKey)}
-                          key={itemKey}
-                          onClick={() => handleItemClick(item)}
-                          role="option"
-                          tabIndex={isInChannel ? -1 : 0}
-                          type="button"
-                        >
-                          {multiSelectMode && !isInChannel ? (
-                            <div
-                              className={cn(
-                                "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
-                                isSelected
-                                  ? "border-primary bg-primary text-primary-foreground"
-                                  : "border-muted-foreground/40",
-                              )}
-                            >
-                              {isSelected ? (
-                                <Check className="h-3 w-3" />
-                              ) : null}
-                            </div>
-                          ) : null}
-                          <QuickAddAgentAvatar
-                            avatarUrl={item.avatarUrl}
-                            label={item.label}
-                            isRunning={item.kind !== "persona"}
-                          />
-                          <span className="flex-1 truncate font-medium">
-                            {item.label}
-                          </span>
-                          {isInChannel ? (
-                            <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                          ) : item.kind === "running-available" &&
-                            !multiSelectMode ? (
-                            <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
-                              running
-                            </span>
-                          ) : null}
-                          {isItemPending ? (
-                            <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
-                          ) : null}
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
-              </>
+              </div>
             )}
           </div>
 

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -1,4 +1,4 @@
-import { Check, Plus, Settings2, Users } from "lucide-react";
+import { Check, Settings2, Users } from "lucide-react";
 import * as React from "react";
 
 import {
@@ -23,6 +23,7 @@ import type { AgentPersona, AgentTeam, ManagedAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
 
@@ -474,10 +475,25 @@ export function QuickAddAgentPopover({
             }
           }}
         >
-          <div className="border-b px-3 py-2">
+          <div className="flex items-center border-b px-3 py-2">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Add agent
             </h3>
+            {multiSelectMode && selectedKeys.size > 0 ? (
+              <Button
+                className="ml-auto"
+                data-testid="quick-add-batch-confirm"
+                disabled={Boolean(pendingKey)}
+                onClick={() => void handleBatchAdd()}
+                size="sm"
+                type="button"
+              >
+                {pendingKey === "batch" ? (
+                  <Spinner className="h-3 w-3" />
+                ) : null}
+                Add ({selectedKeys.size})
+              </Button>
+            ) : null}
           </div>
 
           {/* Scrollable content area — max-height clips mid-item to hint at more */}
@@ -598,26 +614,6 @@ export function QuickAddAgentPopover({
           {errorMessage ? (
             <div className="border-t px-3 py-2">
               <p className="text-xs text-destructive">{errorMessage}</p>
-            </div>
-          ) : null}
-
-          {/* Multi-select confirm button */}
-          {multiSelectMode && selectedKeys.size > 0 ? (
-            <div className="border-t px-3 py-2">
-              <button
-                className="flex w-full items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
-                data-testid="quick-add-batch-confirm"
-                disabled={Boolean(pendingKey)}
-                onClick={() => void handleBatchAdd()}
-                type="button"
-              >
-                {pendingKey === "batch" ? (
-                  <Spinner className="h-3.5 w-3.5" />
-                ) : (
-                  <Plus className="h-3.5 w-3.5" />
-                )}
-                Add ({selectedKeys.size})
-              </button>
             </div>
           ) : null}
 

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -682,7 +682,7 @@ export function QuickAddAgentPopover({
             {multiSelectActive ? (
               <motion.div
                 key="batch-add"
-                className="pointer-events-none absolute bottom-0 left-0 right-0 px-3 pb-1 pt-8 bg-gradient-to-t from-popover to-transparent"
+                className="pointer-events-none absolute bottom-0 left-0 right-0 px-1 pb-1 pt-8 bg-gradient-to-t from-popover to-transparent"
                 initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: 8 }}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -1,0 +1,396 @@
+import { Check, Settings2 } from "lucide-react";
+import * as React from "react";
+
+import {
+  useAcpProvidersQuery,
+  useAttachManagedAgentToChannelMutation,
+  useCreateChannelManagedAgentMutation,
+  useManagedAgentsQuery,
+  usePersonasQuery,
+} from "@/features/agents/hooks";
+import { useChannelMembersQuery } from "@/features/channels/hooks";
+import { getActivePersonas } from "@/features/agents/lib/catalog";
+import { resolvePersonaProvider } from "@/features/agents/lib/resolvePersonaProvider";
+import { pickBotName } from "@/features/agents/lib/pickBotName";
+import { useBotRecents } from "@/features/agents/lib/useBotRecents";
+import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import { cn } from "@/shared/lib/cn";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/shared/ui/popover";
+import { Spinner } from "@/shared/ui/spinner";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type QuickAddAgentItem = {
+  kind: "running-available" | "running-in-channel" | "persona";
+  agent?: ManagedAgent;
+  persona?: AgentPersona;
+  label: string;
+  avatarUrl: string | null;
+};
+
+type QuickAddAgentPopoverProps = {
+  channelId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onMoreOptions: () => void;
+  children: React.ReactNode;
+};
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function QuickAddAgentPopover({
+  channelId,
+  open,
+  onOpenChange,
+  onMoreOptions,
+  children,
+}: QuickAddAgentPopoverProps) {
+  const managedAgentsQuery = useManagedAgentsQuery();
+  const personasQuery = usePersonasQuery();
+  const providersQuery = useAcpProvidersQuery();
+  const membersQuery = useChannelMembersQuery(channelId, open);
+  const attachMutation = useAttachManagedAgentToChannelMutation(channelId);
+  const createMutation = useCreateChannelManagedAgentMutation(channelId);
+  const { recentIds, pushRecent } = useBotRecents();
+
+  const [pendingKey, setPendingKey] = React.useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  const managedAgents = managedAgentsQuery.data ?? [];
+  const personas = React.useMemo(
+    () => getActivePersonas(personasQuery.data ?? []),
+    [personasQuery.data],
+  );
+  const providers = providersQuery.data ?? [];
+  const defaultProvider = providers[0] ?? null;
+  const members = membersQuery.data ?? [];
+
+  const channelMemberPubkeys = React.useMemo(
+    () => new Set(members.map((m) => normalizePubkey(m.pubkey))),
+    [members],
+  );
+
+  // Build the sorted item list
+  const items: QuickAddAgentItem[] = React.useMemo(() => {
+    const result: QuickAddAgentItem[] = [];
+
+    // Running agents not in this channel
+    const runningAvailable = managedAgents.filter(
+      (agent) =>
+        (agent.status === "running" || agent.status === "deployed") &&
+        !channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
+    );
+
+    // Running agents already in this channel
+    const runningInChannel = managedAgents.filter(
+      (agent) =>
+        (agent.status === "running" || agent.status === "deployed") &&
+        channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
+    );
+
+    // Personas that don't have a running agent yet (configured but not running)
+    // Exclude personas whose agent is already in the channel
+    const personaIdsInChannel = new Set(
+      managedAgents
+        .filter((agent) =>
+          channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
+        )
+        .map((agent) => agent.personaId)
+        .filter((id): id is string => Boolean(id)),
+    );
+
+    const availablePersonas = personas.filter(
+      (persona) =>
+        !personaIdsInChannel.has(persona.id) &&
+        !runningAvailable.some((agent) => agent.personaId === persona.id),
+    );
+
+    // Sort running-available by recency
+    const sortedRunningAvailable = [...runningAvailable].sort((a, b) => {
+      const aPersonaIdx = a.personaId
+        ? recentIds.indexOf(a.personaId)
+        : -1;
+      const bPersonaIdx = b.personaId
+        ? recentIds.indexOf(b.personaId)
+        : -1;
+      const aScore = aPersonaIdx >= 0 ? aPersonaIdx : 999;
+      const bScore = bPersonaIdx >= 0 ? bPersonaIdx : 999;
+      return aScore - bScore;
+    });
+
+    for (const agent of sortedRunningAvailable) {
+      const persona = agent.personaId
+        ? personas.find((p) => p.id === agent.personaId)
+        : undefined;
+      result.push({
+        kind: "running-available",
+        agent,
+        persona,
+        label: agent.name,
+        avatarUrl: persona?.avatarUrl ?? null,
+      });
+    }
+
+    for (const agent of runningInChannel) {
+      const persona = agent.personaId
+        ? personas.find((p) => p.id === agent.personaId)
+        : undefined;
+      result.push({
+        kind: "running-in-channel",
+        agent,
+        persona,
+        label: agent.name,
+        avatarUrl: persona?.avatarUrl ?? null,
+      });
+    }
+
+    // Sort available personas: recents first, then alphabetical
+    const sortedPersonas = [...availablePersonas].sort((a, b) => {
+      const aIdx = recentIds.indexOf(a.id);
+      const bIdx = recentIds.indexOf(b.id);
+      if (aIdx >= 0 && bIdx >= 0) return aIdx - bIdx;
+      if (aIdx >= 0) return -1;
+      if (bIdx >= 0) return 1;
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+    for (const persona of sortedPersonas) {
+      result.push({
+        kind: "persona",
+        persona,
+        label: persona.displayName,
+        avatarUrl: persona.avatarUrl,
+      });
+    }
+
+    return result;
+  }, [
+    managedAgents,
+    personas,
+    channelMemberPubkeys,
+    recentIds,
+  ]);
+
+  // Reset state when popover closes
+  React.useEffect(() => {
+    if (!open) {
+      setPendingKey(null);
+      setErrorMessage(null);
+    }
+  }, [open]);
+
+  async function handleAddRunningAgent(agent: ManagedAgent) {
+    const key = `agent:${agent.pubkey}`;
+    setPendingKey(key);
+    setErrorMessage(null);
+
+    try {
+      await attachMutation.mutateAsync({ agent, ensureRunning: true });
+      if (agent.personaId) pushRecent(agent.personaId);
+      onOpenChange(false);
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to add agent.",
+      );
+      setPendingKey(null);
+    }
+  }
+
+  async function handleAddPersona(persona: AgentPersona) {
+    const key = `persona:${persona.id}`;
+    setPendingKey(key);
+    setErrorMessage(null);
+
+    const { provider } = resolvePersonaProvider(
+      persona.provider,
+      providers,
+      defaultProvider,
+    );
+
+    if (!provider) {
+      setErrorMessage("No agent runtime available.");
+      setPendingKey(null);
+      return;
+    }
+
+    // Pick a name from the persona's pool
+    const usedNames = new Set(managedAgents.map((a) => a.name));
+    const instanceName = pickBotName(persona.namePool, usedNames);
+
+    try {
+      await createMutation.mutateAsync({
+        provider,
+        name: instanceName,
+        systemPrompt: persona.systemPrompt,
+        avatarUrl: persona.avatarUrl ?? undefined,
+        personaId: persona.id,
+        model: persona.model ?? undefined,
+      });
+      pushRecent(persona.id);
+      onOpenChange(false);
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to add agent.",
+      );
+      setPendingKey(null);
+    }
+  }
+
+  function handleItemClick(item: QuickAddAgentItem) {
+    if (item.kind === "running-in-channel") return;
+    if (pendingKey) return;
+
+    if (item.kind === "running-available" && item.agent) {
+      void handleAddRunningAgent(item.agent);
+    } else if (item.kind === "persona" && item.persona) {
+      void handleAddPersona(item.persona);
+    }
+  }
+
+  const isLoading =
+    managedAgentsQuery.isLoading ||
+    personasQuery.isLoading ||
+    providersQuery.isLoading;
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-72 p-0"
+        sideOffset={6}
+      >
+        <div className="flex max-h-80 flex-col">
+          <div className="border-b px-3 py-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Add agent
+            </h3>
+          </div>
+
+          <div className="flex-1 overflow-y-auto">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-6">
+                <Spinner className="h-4 w-4 text-muted-foreground" />
+              </div>
+            ) : items.length === 0 ? (
+              <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+                No agents available.
+              </div>
+            ) : (
+              <div className="py-1">
+                {items.map((item) => {
+                  const itemKey =
+                    item.kind === "persona"
+                      ? `persona:${item.persona?.id}`
+                      : `agent:${item.agent?.pubkey}`;
+                  const isInChannel = item.kind === "running-in-channel";
+                  const isItemPending = pendingKey === itemKey;
+
+                  return (
+                    <button
+                      className={cn(
+                        "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
+                        isInChannel
+                          ? "cursor-default opacity-50"
+                          : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
+                        isItemPending && "pointer-events-none opacity-60",
+                      )}
+                      disabled={isInChannel || Boolean(pendingKey)}
+                      key={itemKey}
+                      onClick={() => handleItemClick(item)}
+                      type="button"
+                    >
+                      <QuickAddAgentAvatar
+                        avatarUrl={item.avatarUrl}
+                        label={item.label}
+                        isRunning={item.kind !== "persona"}
+                      />
+                      <span className="flex-1 truncate font-medium">
+                        {item.label}
+                      </span>
+                      {isInChannel ? (
+                        <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      ) : item.kind === "running-available" ? (
+                        <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                          running
+                        </span>
+                      ) : null}
+                      {isItemPending ? (
+                        <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {errorMessage ? (
+            <div className="border-t px-3 py-2">
+              <p className="text-xs text-destructive">{errorMessage}</p>
+            </div>
+          ) : null}
+
+          <div className="border-t">
+            <button
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              onClick={() => {
+                onOpenChange(false);
+                onMoreOptions();
+              }}
+              type="button"
+            >
+              <Settings2 className="h-3.5 w-3.5" />
+              <span>More options…</span>
+            </button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ── Avatar helper ─────────────────────────────────────────────────────────────
+
+function QuickAddAgentAvatar({
+  avatarUrl,
+  label,
+  isRunning,
+}: {
+  avatarUrl: string | null;
+  label: string;
+  isRunning: boolean;
+}) {
+  const initials = label
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30">
+      {avatarUrl ? (
+        <img
+          alt={label}
+          className="h-full w-full rounded-full object-cover"
+          referrerPolicy="no-referrer"
+          src={rewriteRelayUrl(avatarUrl)}
+        />
+      ) : (
+        <span className="text-[10px] font-semibold text-muted-foreground">
+          {initials}
+        </span>
+      )}
+      {isRunning ? (
+        <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-background bg-emerald-500" />
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -304,6 +304,7 @@ export function QuickAddAgentPopover({
       <PopoverContent align="end" className="w-72 p-0" sideOffset={6}>
         <div
           className="flex max-h-80 flex-col"
+          role="menu"
           onKeyDown={(e) => {
             const container = e.currentTarget;
             const buttons = Array.from(
@@ -344,7 +345,11 @@ export function QuickAddAgentPopover({
                 No agents available.
               </div>
             ) : (
-              <div aria-label="Available agents" className="py-1" role="listbox">
+              <div
+                aria-label="Available agents"
+                className="py-1"
+                role="listbox"
+              >
                 {items.map((item) => {
                   const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -493,53 +493,65 @@ export function QuickAddAgentPopover({
         >
           {/* Header with animated title / team toggles */}
           <div className="relative flex min-h-10 items-center gap-2 border-b pl-3 pr-1.5 py-1.5">
-            <AnimatePresence mode="wait">
+            {/* Title — always visible */}
+            <h3 className="shrink-0 text-sm font-semibold text-foreground">
+              Add agent
+              <AnimatePresence>
+                {selectMode ? (
+                  <motion.span
+                    initial={{ opacity: 0, width: 0 }}
+                    animate={{ opacity: 1, width: "auto" }}
+                    exit={{ opacity: 0, width: 0 }}
+                    transition={{ duration: 0.2 }}
+                    className="inline-block overflow-hidden"
+                  >
+                    s
+                  </motion.span>
+                ) : null}
+              </AnimatePresence>
+            </h3>
+
+            {/* Team toggles — appear to the right of title */}
+            <AnimatePresence>
               {selectMode ? (
                 <motion.div
                   key="team-chips"
-                  className="flex flex-1 items-center gap-1.5 overflow-x-auto"
+                  className="relative flex min-w-0 flex-1 items-center"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}
                   transition={{ duration: 0.15 }}
                 >
-                  {usableTeams.map((team, index) => (
-                    <motion.div
-                      key={team.id}
-                      initial={{ opacity: 0, x: index === 0 ? 0 : 12 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      transition={{
-                        duration: 0.2,
-                        delay: index * 0.05,
-                      }}
-                      className="shrink-0"
-                    >
-                      <Toggle
-                        className="h-8 rounded-full px-3 text-xs"
-                        onPressedChange={(pressed) =>
-                          handleTeamToggle(team, pressed)
-                        }
-                        pressed={selectedTeamIds.has(team.id)}
-                        size="sm"
-                        variant="outline"
+                  <div className="flex items-center gap-1.5 overflow-x-auto">
+                    {usableTeams.map((team, index) => (
+                      <motion.div
+                        key={team.id}
+                        initial={{ opacity: 0, x: index === 0 ? 0 : 12 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        transition={{
+                          duration: 0.2,
+                          delay: index * 0.05,
+                        }}
+                        className="shrink-0"
                       >
-                        {team.name}
-                      </Toggle>
-                    </motion.div>
-                  ))}
+                        <Toggle
+                          className="h-8 rounded-full px-3 text-xs"
+                          onPressedChange={(pressed) =>
+                            handleTeamToggle(team, pressed)
+                          }
+                          pressed={selectedTeamIds.has(team.id)}
+                          size="sm"
+                          variant="outline"
+                        >
+                          {team.name}
+                        </Toggle>
+                      </motion.div>
+                    ))}
+                  </div>
+                  {/* Gradient fade on right edge — scroll affordance */}
+                  <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-popover to-transparent" />
                 </motion.div>
-              ) : (
-                <motion.h3
-                  key="title"
-                  className="text-sm font-semibold text-foreground"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.15 }}
-                >
-                  Add agent
-                </motion.h3>
-              )}
+              ) : null}
             </AnimatePresence>
 
             {/* Right side: Select / Cancel button */}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -11,6 +11,7 @@ import {
   usePersonasQuery,
   useTeamsQuery,
 } from "@/features/agents/hooks";
+import { Toggle } from "@/shared/ui/toggle";
 import { useChannelMembersQuery } from "@/features/channels/hooks";
 import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { resolvePersonaProvider } from "@/features/agents/lib/resolvePersonaProvider";
@@ -111,6 +112,9 @@ export function QuickAddAgentPopover({
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [selectMode, setSelectMode] = React.useState(false);
   const [selectedKeys, setSelectedKeys] = React.useState<Set<string>>(
+    new Set(),
+  );
+  const [selectedTeamIds, setSelectedTeamIds] = React.useState<Set<string>>(
     new Set(),
   );
 
@@ -227,6 +231,7 @@ export function QuickAddAgentPopover({
       setErrorMessage(null);
       setSelectMode(false);
       setSelectedKeys(new Set());
+      setSelectedTeamIds(new Set());
     }
   }, [open]);
 
@@ -292,6 +297,12 @@ export function QuickAddAgentPopover({
 
   // ── Multi-select handlers ─────────────────────────────────────────────────
 
+  function handleCancelSelect() {
+    setSelectMode(false);
+    setSelectedKeys(new Set());
+    setSelectedTeamIds(new Set());
+  }
+
   function toggleSelection(key: string) {
     setSelectedKeys((prev) => {
       const next = new Set(prev);
@@ -307,25 +318,45 @@ export function QuickAddAgentPopover({
     });
   }
 
-  function handleTeamChipClick(team: AgentTeam) {
+  function handleTeamToggle(team: AgentTeam, pressed: boolean) {
     const resolution = resolveTeamPersonas(team, personas);
+    const memberKeys: string[] = [];
+    for (const persona of resolution.resolvedPersonas) {
+      const runningItem = items.find(
+        (i) =>
+          i.kind === "running-available" && i.agent.personaId === persona.id,
+      );
+      if (runningItem) {
+        memberKeys.push(getItemKey(runningItem));
+      } else {
+        const personaItem = items.find(
+          (i) => i.kind === "persona" && i.persona.id === persona.id,
+        );
+        if (personaItem) {
+          memberKeys.push(getItemKey(personaItem));
+        }
+      }
+    }
+
+    setSelectedTeamIds((prev) => {
+      const next = new Set(prev);
+      if (pressed) {
+        next.add(team.id);
+      } else {
+        next.delete(team.id);
+      }
+      return next;
+    });
+
     setSelectedKeys((prev) => {
       const next = new Set(prev);
-      for (const persona of resolution.resolvedPersonas) {
-        // Find matching item (running agent or persona)
-        const runningItem = items.find(
-          (i) =>
-            i.kind === "running-available" && i.agent.personaId === persona.id,
-        );
-        if (runningItem) {
-          next.add(getItemKey(runningItem));
-        } else {
-          const personaItem = items.find(
-            (i) => i.kind === "persona" && i.persona.id === persona.id,
-          );
-          if (personaItem) {
-            next.add(getItemKey(personaItem));
-          }
+      if (pressed) {
+        for (const key of memberKeys) {
+          next.add(key);
+        }
+      } else {
+        for (const key of memberKeys) {
+          next.delete(key);
         }
       }
       return next;
@@ -463,27 +494,31 @@ export function QuickAddAgentPopover({
             }
           }}
         >
-          {/* Header with animated title / team chips */}
-          <div className="relative flex h-10 items-center border-b px-3">
+          {/* Header with animated title / team toggles */}
+          <div className="relative flex min-h-10 items-center border-b px-3">
             <AnimatePresence mode="wait">
               {selectMode ? (
                 <motion.div
                   key="team-chips"
-                  className="flex flex-1 items-center gap-1.5 overflow-x-auto"
+                  className="flex flex-1 items-center gap-1.5 overflow-x-auto py-1.5"
                   initial={{ opacity: 0, x: 20 }}
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: 20 }}
                   transition={{ duration: 0.2 }}
                 >
                   {usableTeams.map((team) => (
-                    <button
-                      className="shrink-0 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    <Toggle
+                      className="h-6 shrink-0 rounded-full px-2.5 text-[11px]"
                       key={team.id}
-                      onClick={() => handleTeamChipClick(team)}
-                      type="button"
+                      onPressedChange={(pressed) =>
+                        handleTeamToggle(team, pressed)
+                      }
+                      pressed={selectedTeamIds.has(team.id)}
+                      size="sm"
+                      variant="outline"
                     >
                       {team.name}
-                    </button>
+                    </Toggle>
                   ))}
                 </motion.div>
               ) : (
@@ -500,31 +535,24 @@ export function QuickAddAgentPopover({
               )}
             </AnimatePresence>
 
-            {/* Right side: Select toggle or Add (N) button */}
-            <div className="ml-auto flex shrink-0 items-center pl-2">
-              {multiSelectActive ? (
-                <Button
-                  data-testid="quick-add-batch-confirm"
-                  disabled={Boolean(pendingKey)}
-                  onClick={() => void handleBatchAdd()}
-                  size="sm"
-                  type="button"
-                >
-                  {pendingKey === "batch" ? (
-                    <Spinner className="h-3 w-3" />
-                  ) : null}
-                  Add ({selectedKeys.size})
-                </Button>
-              ) : usableTeams.length > 0 ? (
+            {/* Right side: Select / Cancel toggle */}
+            {usableTeams.length > 0 ? (
+              <div className="ml-auto flex shrink-0 items-center pl-2">
                 <button
                   className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-                  onClick={() => setSelectMode((prev) => !prev)}
+                  onClick={() => {
+                    if (selectMode) {
+                      handleCancelSelect();
+                    } else {
+                      setSelectMode(true);
+                    }
+                  }}
                   type="button"
                 >
-                  {selectMode ? "Done" : "Select"}
+                  {selectMode ? "Cancel" : "Select"}
                 </button>
-              ) : null}
-            </div>
+              </div>
+            ) : null}
           </div>
 
           {/* Scrollable content — clips mid-item to hint at more */}
@@ -627,6 +655,24 @@ export function QuickAddAgentPopover({
               <span>More options…</span>
             </button>
           </div>
+
+          {multiSelectActive ? (
+            <div className="border-t px-3 py-2">
+              <Button
+                className="w-full"
+                data-testid="quick-add-batch-confirm"
+                disabled={Boolean(pendingKey)}
+                onClick={() => void handleBatchAdd()}
+                size="sm"
+                type="button"
+              >
+                {pendingKey === "batch" ? (
+                  <Spinner className="h-3 w-3" />
+                ) : null}
+                Add ({selectedKeys.size})
+              </Button>
+            </div>
+          ) : null}
         </div>
       </PopoverContent>
     </Popover>

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -225,13 +225,6 @@ export function QuickAddAgentPopover({
     return result;
   }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
 
-  // Debounce item list so rapid query invalidations (name + membership) batch
-  const [debouncedItems, setDebouncedItems] = React.useState(items);
-  React.useEffect(() => {
-    const timer = setTimeout(() => setDebouncedItems(items), 300);
-    return () => clearTimeout(timer);
-  }, [items]);
-
 
   // Reset state when popover closes
   React.useEffect(() => {
@@ -614,7 +607,7 @@ export function QuickAddAgentPopover({
               <div className="flex items-center justify-center py-6">
                 <Spinner className="h-4 w-4 text-muted-foreground" />
               </div>
-            ) : debouncedItems.length === 0 ? (
+            ) : items.length === 0 ? (
               <div className="px-3 py-4 text-center text-sm text-muted-foreground">
                 No agents available.
               </div>
@@ -624,7 +617,7 @@ export function QuickAddAgentPopover({
                 className="py-1"
                 role="listbox"
               >
-                {debouncedItems.map((item) => {
+                {items.map((item) => {
                   const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";
                   const isItemPending =
@@ -632,7 +625,7 @@ export function QuickAddAgentPopover({
                   const isSelected = selectedKeys.has(itemKey);
 
                   return (
-                    <motion.div key={itemKey} layout="position" transition={{ type: "spring", stiffness: 500, damping: 35, mass: 0.8 }}>
+                    <motion.div key={itemKey} layout transition={{ duration: 0.2 }}>
                     <button
                       aria-selected={isInChannel || isSelected}
                       className={cn(

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -682,7 +682,7 @@ export function QuickAddAgentPopover({
             {multiSelectActive ? (
               <motion.div
                 key="batch-add"
-                className="pointer-events-none absolute bottom-0 left-0 right-0 px-3 pb-1.5 pt-8 bg-gradient-to-t from-popover to-transparent"
+                className="pointer-events-none absolute bottom-0 left-0 right-0 px-3 pb-1 pt-8 bg-gradient-to-t from-popover to-transparent"
                 initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: 8 }}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -519,49 +519,50 @@ export function QuickAddAgentPopover({
             ) : null}
           </div>
 
-          {/* Team toggles row — slides in between header and list */}
-          <AnimatePresence>
-            {selectMode ? (
-              <motion.div
-                key="team-row"
-                className="relative border-b px-3 pb-1 pt-0.5"
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: "auto", opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.2 }}
-                style={{ overflow: "hidden" }}
-              >
-                <div className="flex items-center gap-1.5 overflow-x-auto">
-                  {usableTeams.map((team, index) => (
-                    <motion.div
-                      key={team.id}
-                      initial={{ opacity: 0, x: index === 0 ? 0 : 12 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      transition={{
-                        duration: 0.2,
-                        delay: index * 0.05,
-                      }}
-                      className="shrink-0"
+          {/* Team toggles row — always mounted, height animates based on selectMode */}
+          <motion.div
+            className="relative overflow-hidden"
+            initial={false}
+            animate={{
+              height: selectMode ? "auto" : 0,
+              opacity: selectMode ? 1 : 0,
+            }}
+            transition={{ duration: 0.2 }}
+          >
+            <div className="border-b px-3 pb-1 pt-0.5">
+              <div className="flex items-center gap-1.5 overflow-x-auto">
+                {usableTeams.map((team, index) => (
+                  <motion.div
+                    key={team.id}
+                    initial={false}
+                    animate={{
+                      opacity: selectMode ? 1 : 0,
+                      x: selectMode ? 0 : (index === 0 ? 0 : 12),
+                    }}
+                    transition={{
+                      duration: 0.2,
+                      delay: selectMode ? index * 0.05 : 0,
+                    }}
+                    className="shrink-0"
+                  >
+                    <Toggle
+                      className="h-6 rounded-full px-2.5 text-[11px]"
+                      onPressedChange={(pressed) =>
+                        handleTeamToggle(team, pressed)
+                      }
+                      pressed={selectedTeamIds.has(team.id)}
+                      size="sm"
+                      variant="subtle"
                     >
-                      <Toggle
-                        className="h-6 rounded-full px-2.5 text-[11px]"
-                        onPressedChange={(pressed) =>
-                          handleTeamToggle(team, pressed)
-                        }
-                        pressed={selectedTeamIds.has(team.id)}
-                        size="sm"
-                        variant="subtle"
-                      >
-                        {team.name}
-                      </Toggle>
-                    </motion.div>
-                  ))}
-                </div>
-                {/* Gradient fade on right edge — scroll affordance */}
-                <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-popover to-transparent" />
-              </motion.div>
-            ) : null}
-          </AnimatePresence>
+                      {team.name}
+                    </Toggle>
+                  </motion.div>
+                ))}
+              </div>
+              {/* Gradient fade on right edge — scroll affordance */}
+              <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-popover to-transparent" />
+            </div>
+          </motion.div>
 
           {/* Scrollable content — clips mid-item to hint at more */}
           <motion.div

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -659,14 +659,14 @@ export function QuickAddAgentPopover({
                         </motion.div>
                       ) : null}
                       <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                        <span className={cn("shrink-0", isInChannel && "opacity-70")}>
+                        <span className={cn("shrink-0", isInChannel && "opacity-50")}>
                           <QuickAddAgentAvatar
                             avatarUrl={item.avatarUrl}
                             label={item.label}
                             isRunning={item.kind !== "persona"}
                           />
                         </span>
-                        <span className={cn("min-w-0 flex-1 truncate font-medium", isInChannel && "opacity-70")}>
+                        <span className={cn("min-w-0 flex-1 truncate font-medium", isInChannel && "opacity-50")}>
                           {item.label}
                         </span>
                         {isInChannel ? (

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -492,7 +492,7 @@ export function QuickAddAgentPopover({
           }}
         >
           {/* Header with animated title / team toggles */}
-          <div className="relative flex min-h-10 items-center gap-2 border-b px-3 py-1.5">
+          <div className="relative flex min-h-10 items-center gap-2 border-b pl-3 pr-1.5 py-1.5">
             <AnimatePresence mode="wait">
               {selectMode ? (
                 <motion.div

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -640,10 +640,6 @@ export function QuickAddAgentPopover({
                         </span>
                         {isInChannel ? (
                           <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                        ) : item.kind === "running-available" && !selectMode ? (
-                          <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
-                            running
-                          </span>
                         ) : null}
                         {isItemPending ? (
                           <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
@@ -729,7 +725,7 @@ function QuickAddAgentAvatar({
     .toUpperCase();
 
   return (
-    <div className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30">
+    <div className={cn("relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30", !isRunning && "opacity-50")}>
       {avatarUrl ? (
         <img
           alt={label}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -225,6 +225,13 @@ export function QuickAddAgentPopover({
     return result;
   }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
 
+  // Debounce item list so rapid query invalidations (name + membership) batch
+  const [debouncedItems, setDebouncedItems] = React.useState(items);
+  React.useEffect(() => {
+    const timer = setTimeout(() => setDebouncedItems(items), 300);
+    return () => clearTimeout(timer);
+  }, [items]);
+
 
   // Reset state when popover closes
   React.useEffect(() => {
@@ -607,7 +614,7 @@ export function QuickAddAgentPopover({
               <div className="flex items-center justify-center py-6">
                 <Spinner className="h-4 w-4 text-muted-foreground" />
               </div>
-            ) : items.length === 0 ? (
+            ) : debouncedItems.length === 0 ? (
               <div className="px-3 py-4 text-center text-sm text-muted-foreground">
                 No agents available.
               </div>
@@ -617,7 +624,7 @@ export function QuickAddAgentPopover({
                 className="py-1"
                 role="listbox"
               >
-                {items.map((item) => {
+                {debouncedItems.map((item) => {
                   const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";
                   const isItemPending =
@@ -625,7 +632,7 @@ export function QuickAddAgentPopover({
                   const isSelected = selectedKeys.has(itemKey);
 
                   return (
-                    <motion.div key={itemKey} layout transition={{ duration: 0.2 }}>
+                    <motion.div key={itemKey} layout="position" transition={{ type: "spring", stiffness: 500, damping: 35, mass: 0.8 }}>
                     <button
                       aria-selected={isInChannel || isSelected}
                       className={cn(

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -1,19 +1,25 @@
-import { Check, Settings2 } from "lucide-react";
+import { Check, Plus, Settings2, Users } from "lucide-react";
 import * as React from "react";
 
 import {
   useAcpProvidersQuery,
   useAttachManagedAgentToChannelMutation,
   useCreateChannelManagedAgentMutation,
+  useCreateChannelManagedAgentsMutation,
   useManagedAgentsQuery,
   usePersonasQuery,
+  useTeamsQuery,
 } from "@/features/agents/hooks";
 import { useChannelMembersQuery } from "@/features/channels/hooks";
 import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { resolvePersonaProvider } from "@/features/agents/lib/resolvePersonaProvider";
 import { pickBotName } from "@/features/agents/lib/pickBotName";
 import { useBotRecents } from "@/features/agents/lib/useBotRecents";
-import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
+import {
+  getUsableTeams,
+  resolveTeamPersonas,
+} from "@/features/agents/lib/teamPersonas";
+import type { AgentPersona, AgentTeam, ManagedAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { cn } from "@/shared/lib/cn";
@@ -73,8 +79,6 @@ function getItemKey(item: QuickAddAgentItem): string {
 function safeBotName(persona: AgentPersona, usedNames: Set<string>): string {
   const pool = persona.namePool ?? [];
   const name = pickBotName(pool, usedNames);
-  // pickBotName always returns a string from the universal pool fallback,
-  // but guard defensively in case of edge cases.
   if (name && name.trim().length > 0) return name;
   return persona.displayName || "Agent";
 }
@@ -88,22 +92,25 @@ export function QuickAddAgentPopover({
   onMoreOptions,
   children,
 }: QuickAddAgentPopoverProps) {
-  // Gate channel members query to only fire when the popover is open.
-  // Managed agents, personas, and providers are globally cached by
-  // ChannelMembersBar (always mounted), so no extra fetch cost here.
   const managedAgentsQuery = useManagedAgentsQuery();
   const personasQuery = usePersonasQuery();
   const providersQuery = useAcpProvidersQuery();
+  const teamsQuery = useTeamsQuery();
   const membersQuery = useChannelMembersQuery(
     channelId,
     open && channelId !== null,
   );
   const attachMutation = useAttachManagedAgentToChannelMutation(channelId);
   const createMutation = useCreateChannelManagedAgentMutation(channelId);
+  const batchCreateMutation = useCreateChannelManagedAgentsMutation(channelId);
   const { recentIds, pushRecent } = useBotRecents();
 
   const [pendingKey, setPendingKey] = React.useState<string | null>(null);
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+  const [multiSelectMode, setMultiSelectMode] = React.useState(false);
+  const [selectedKeys, setSelectedKeys] = React.useState<Set<string>>(
+    new Set(),
+  );
 
   const managedAgents = managedAgentsQuery.data ?? [];
   const personas = React.useMemo(
@@ -113,31 +120,35 @@ export function QuickAddAgentPopover({
   const providers = providersQuery.data ?? [];
   const defaultProvider = providers[0] ?? null;
   const members = membersQuery.data ?? [];
+  const teams = teamsQuery.data ?? [];
 
   const channelMemberPubkeys = React.useMemo(
     () => new Set(members.map((m) => normalizePubkey(m.pubkey))),
     [members],
   );
 
+  // Usable teams (all personas resolved)
+  const usableTeams = React.useMemo(
+    () => getUsableTeams(teams, personas),
+    [teams, personas],
+  );
+
   // Build the sorted item list
   const items: QuickAddAgentItem[] = React.useMemo(() => {
     const result: QuickAddAgentItem[] = [];
 
-    // Running agents not in this channel
     const runningAvailable = managedAgents.filter(
       (agent) =>
         (agent.status === "running" || agent.status === "deployed") &&
         !channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
     );
 
-    // Running agents already in this channel
     const runningInChannel = managedAgents.filter(
       (agent) =>
         (agent.status === "running" || agent.status === "deployed") &&
         channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
     );
 
-    // Personas whose agent is already in the channel (exclude from "available" list)
     const personaIdsInChannel = new Set(
       managedAgents
         .filter((agent) =>
@@ -153,7 +164,6 @@ export function QuickAddAgentPopover({
         !runningAvailable.some((agent) => agent.personaId === persona.id),
     );
 
-    // Sort running-available by recency
     const sortedRunningAvailable = [...runningAvailable].sort((a, b) => {
       const aPersonaIdx = a.personaId ? recentIds.indexOf(a.personaId) : -1;
       const bPersonaIdx = b.personaId ? recentIds.indexOf(b.personaId) : -1;
@@ -188,7 +198,6 @@ export function QuickAddAgentPopover({
       });
     }
 
-    // Sort available personas: recents first, then alphabetical
     const sortedPersonas = [...availablePersonas].sort((a, b) => {
       const aIdx = recentIds.indexOf(a.id);
       const bIdx = recentIds.indexOf(b.id);
@@ -215,8 +224,12 @@ export function QuickAddAgentPopover({
     if (!open) {
       setPendingKey(null);
       setErrorMessage(null);
+      setMultiSelectMode(false);
+      setSelectedKeys(new Set());
     }
   }, [open]);
+
+  // ── Single-add handlers (preserved fast path) ─────────────────────────────
 
   async function handleAddRunningAgent(agent: ManagedAgent) {
     if (!channelId) return;
@@ -276,15 +289,144 @@ export function QuickAddAgentPopover({
     }
   }
 
+  // ── Multi-select handlers ─────────────────────────────────────────────────
+
+  function toggleSelection(key: string) {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      // Exit multi-select mode if nothing selected
+      if (next.size === 0) {
+        setMultiSelectMode(false);
+      }
+      return next;
+    });
+  }
+
+  function handleTeamClick(team: AgentTeam) {
+    const resolution = resolveTeamPersonas(team, personas);
+    const personaKeys = resolution.resolvedPersonas.map(
+      (p) => `persona:${p.id}`,
+    );
+
+    // Enter multi-select mode and select all team personas
+    setMultiSelectMode(true);
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      for (const key of personaKeys) {
+        // Only select if the item is actually in our addable list
+        const item = items.find((i) => getItemKey(i) === key);
+        if (item && item.kind !== "running-in-channel") {
+          next.add(key);
+        }
+      }
+      // Also select running agents that belong to team personas
+      for (const persona of resolution.resolvedPersonas) {
+        const runningItem = items.find(
+          (i) =>
+            i.kind === "running-available" && i.agent.personaId === persona.id,
+        );
+        if (runningItem) {
+          next.add(getItemKey(runningItem));
+        }
+      }
+      return next;
+    });
+  }
+
+  async function handleBatchAdd() {
+    if (!channelId || selectedKeys.size === 0) return;
+    setPendingKey("batch");
+    setErrorMessage(null);
+
+    const usedNames = new Set(managedAgents.map((a) => a.name));
+    const toAttach: ManagedAgent[] = [];
+    const toCreate: Array<{
+      persona: AgentPersona;
+      instanceName: string;
+    }> = [];
+
+    for (const key of selectedKeys) {
+      const item = items.find((i) => getItemKey(i) === key);
+      if (!item || item.kind === "running-in-channel") continue;
+
+      if (item.kind === "running-available") {
+        toAttach.push(item.agent);
+      } else {
+        const instanceName = safeBotName(item.persona, usedNames);
+        usedNames.add(instanceName);
+        toCreate.push({ persona: item.persona, instanceName });
+      }
+    }
+
+    try {
+      // Attach running agents individually
+      for (const agent of toAttach) {
+        await attachMutation.mutateAsync({ agent, ensureRunning: true });
+        if (agent.personaId) pushRecent(agent.personaId);
+      }
+
+      // Batch-create new agents
+      if (toCreate.length > 0 && defaultProvider) {
+        const inputs = toCreate.map(({ persona, instanceName }) => {
+          const { provider } = resolvePersonaProvider(
+            persona.provider,
+            providers,
+            defaultProvider,
+          );
+          const providerToUse = provider ?? defaultProvider;
+          return {
+            provider: {
+              id: providerToUse.id,
+              label: providerToUse.label,
+              command: providerToUse.command,
+              defaultArgs: providerToUse.defaultArgs,
+              mcpCommand: providerToUse.mcpCommand,
+            },
+            name: instanceName,
+            systemPrompt: persona.systemPrompt,
+            avatarUrl: persona.avatarUrl ?? undefined,
+            personaId: persona.id,
+            model: persona.model ?? undefined,
+          };
+        });
+
+        await batchCreateMutation.mutateAsync(inputs);
+        for (const { persona } of toCreate) {
+          pushRecent(persona.id);
+        }
+      }
+
+      onOpenChange(false);
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to add agents.",
+      );
+      setPendingKey(null);
+    }
+  }
+
+  // ── Item click dispatcher ─────────────────────────────────────────────────
+
   function handleItemClick(item: QuickAddAgentItem) {
     if (item.kind === "running-in-channel") return;
     if (pendingKey) return;
     if (!channelId) return;
 
-    if (item.kind === "running-available") {
-      void handleAddRunningAgent(item.agent);
+    if (multiSelectMode) {
+      // In multi-select mode, toggle selection
+      toggleSelection(getItemKey(item));
     } else {
-      void handleAddPersona(item.persona);
+      // Single-click fast path — add immediately
+      if (item.kind === "running-available") {
+        void handleAddRunningAgent(item.agent);
+      } else {
+        void handleAddPersona(item.persona);
+      }
     }
   }
 
@@ -293,7 +435,6 @@ export function QuickAddAgentPopover({
     personasQuery.isLoading ||
     providersQuery.isLoading;
 
-  // Don't render the popover content when there's no channel
   if (!channelId) {
     return <>{children}</>;
   }
@@ -307,7 +448,7 @@ export function QuickAddAgentPopover({
         sideOffset={6}
       >
         <div
-          className="flex max-h-80 flex-col"
+          className="flex flex-col"
           role="menu"
           onKeyDown={(e) => {
             const container = e.currentTarget;
@@ -339,72 +480,144 @@ export function QuickAddAgentPopover({
             </h3>
           </div>
 
-          <div className="flex-1 overflow-y-auto">
+          {/* Scrollable content area — max-height clips mid-item to hint at more */}
+          <div className="max-h-[13.75rem] flex-1 overflow-y-auto">
             {isLoading ? (
               <div className="flex items-center justify-center py-6">
                 <Spinner className="h-4 w-4 text-muted-foreground" />
               </div>
-            ) : items.length === 0 ? (
-              <div className="px-3 py-4 text-center text-sm text-muted-foreground">
-                No agents available.
-              </div>
             ) : (
-              <div
-                aria-label="Available agents"
-                className="py-1"
-                role="listbox"
-              >
-                {items.map((item) => {
-                  const itemKey = getItemKey(item);
-                  const isInChannel = item.kind === "running-in-channel";
-                  const isItemPending = pendingKey === itemKey;
+              <>
+                {/* Teams section */}
+                {usableTeams.length > 0 ? (
+                  <div className="border-b py-1">
+                    {usableTeams.map((team) => {
+                      const resolution = resolveTeamPersonas(team, personas);
+                      return (
+                        <button
+                          className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+                          data-quick-add-item
+                          key={team.id}
+                          onClick={() => handleTeamClick(team)}
+                          type="button"
+                        >
+                          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30">
+                            <Users className="h-3.5 w-3.5 text-muted-foreground" />
+                          </div>
+                          <span className="flex-1 truncate font-medium">
+                            {team.name}
+                          </span>
+                          <span className="shrink-0 text-[11px] text-muted-foreground">
+                            {resolution.resolvedPersonas.length}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ) : null}
 
-                  return (
-                    <button
-                      aria-selected={isInChannel}
-                      className={cn(
-                        "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
-                        isInChannel
-                          ? "cursor-default opacity-50"
-                          : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
-                        isItemPending && "pointer-events-none opacity-60",
-                      )}
-                      data-quick-add-item
-                      disabled={isInChannel || Boolean(pendingKey)}
-                      key={itemKey}
-                      onClick={() => handleItemClick(item)}
-                      role="option"
-                      tabIndex={isInChannel ? -1 : 0}
-                      type="button"
-                    >
-                      <QuickAddAgentAvatar
-                        avatarUrl={item.avatarUrl}
-                        label={item.label}
-                        isRunning={item.kind !== "persona"}
-                      />
-                      <span className="flex-1 truncate font-medium">
-                        {item.label}
-                      </span>
-                      {isInChannel ? (
-                        <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                      ) : item.kind === "running-available" ? (
-                        <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
-                          running
-                        </span>
-                      ) : null}
-                      {isItemPending ? (
-                        <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
-                      ) : null}
-                    </button>
-                  );
-                })}
-              </div>
+                {/* Agents section */}
+                {items.length === 0 ? (
+                  <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+                    No agents available.
+                  </div>
+                ) : (
+                  <div
+                    aria-label="Available agents"
+                    className="py-1"
+                    role="listbox"
+                  >
+                    {items.map((item) => {
+                      const itemKey = getItemKey(item);
+                      const isInChannel = item.kind === "running-in-channel";
+                      const isItemPending =
+                        pendingKey === itemKey || pendingKey === "batch";
+                      const isSelected = selectedKeys.has(itemKey);
+
+                      return (
+                        <button
+                          aria-selected={isInChannel || isSelected}
+                          className={cn(
+                            "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
+                            isInChannel
+                              ? "cursor-default opacity-50"
+                              : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
+                            isItemPending && "pointer-events-none opacity-60",
+                            isSelected && "bg-accent/50",
+                          )}
+                          data-quick-add-item
+                          disabled={isInChannel || Boolean(pendingKey)}
+                          key={itemKey}
+                          onClick={() => handleItemClick(item)}
+                          role="option"
+                          tabIndex={isInChannel ? -1 : 0}
+                          type="button"
+                        >
+                          {multiSelectMode && !isInChannel ? (
+                            <div
+                              className={cn(
+                                "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
+                                isSelected
+                                  ? "border-primary bg-primary text-primary-foreground"
+                                  : "border-muted-foreground/40",
+                              )}
+                            >
+                              {isSelected ? (
+                                <Check className="h-3 w-3" />
+                              ) : null}
+                            </div>
+                          ) : null}
+                          <QuickAddAgentAvatar
+                            avatarUrl={item.avatarUrl}
+                            label={item.label}
+                            isRunning={item.kind !== "persona"}
+                          />
+                          <span className="flex-1 truncate font-medium">
+                            {item.label}
+                          </span>
+                          {isInChannel ? (
+                            <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                          ) : item.kind === "running-available" &&
+                            !multiSelectMode ? (
+                            <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                              running
+                            </span>
+                          ) : null}
+                          {isItemPending ? (
+                            <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
             )}
           </div>
 
           {errorMessage ? (
             <div className="border-t px-3 py-2">
               <p className="text-xs text-destructive">{errorMessage}</p>
+            </div>
+          ) : null}
+
+          {/* Multi-select confirm button */}
+          {multiSelectMode && selectedKeys.size > 0 ? (
+            <div className="border-t px-3 py-2">
+              <button
+                className="flex w-full items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+                data-testid="quick-add-batch-confirm"
+                disabled={Boolean(pendingKey)}
+                onClick={() => void handleBatchAdd()}
+                type="button"
+              >
+                {pendingKey === "batch" ? (
+                  <Spinner className="h-3.5 w-3.5" />
+                ) : (
+                  <Plus className="h-3.5 w-3.5" />
+                )}
+                Add ({selectedKeys.size})
+              </button>
             </div>
           ) : null}
 

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -515,7 +515,7 @@ export function QuickAddAgentPopover({
                       className="shrink-0"
                     >
                       <Toggle
-                        className="h-6 rounded-full px-2.5 text-[11px]"
+                        className="h-8 rounded-full px-3 text-xs"
                         onPressedChange={(pressed) =>
                           handleTeamToggle(team, pressed)
                         }

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -725,7 +725,7 @@ function QuickAddAgentAvatar({
     .toUpperCase();
 
   return (
-    <div className={cn("relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30", !isRunning && "opacity-50")}>
+    <div className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30">
       {avatarUrl ? (
         <img
           alt={label}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -311,9 +311,6 @@ export function QuickAddAgentPopover({
       } else {
         next.add(key);
       }
-      if (next.size === 0) {
-        setSelectMode(false);
-      }
       return next;
     });
   }
@@ -501,24 +498,34 @@ export function QuickAddAgentPopover({
                 <motion.div
                   key="team-chips"
                   className="flex flex-1 items-center gap-1.5 overflow-x-auto py-1.5"
-                  initial={{ opacity: 0, x: 20 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  exit={{ opacity: 0, x: 20 }}
-                  transition={{ duration: 0.2 }}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.15 }}
                 >
-                  {usableTeams.map((team) => (
-                    <Toggle
-                      className="h-6 shrink-0 rounded-full px-2.5 text-[11px]"
+                  {usableTeams.map((team, index) => (
+                    <motion.div
                       key={team.id}
-                      onPressedChange={(pressed) =>
-                        handleTeamToggle(team, pressed)
-                      }
-                      pressed={selectedTeamIds.has(team.id)}
-                      size="sm"
-                      variant="outline"
+                      initial={{ opacity: 0, x: 12 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{
+                        duration: 0.2,
+                        delay: index * 0.05,
+                      }}
+                      className="shrink-0"
                     >
-                      {team.name}
-                    </Toggle>
+                      <Toggle
+                        className="h-6 rounded-full px-2.5 text-[11px]"
+                        onPressedChange={(pressed) =>
+                          handleTeamToggle(team, pressed)
+                        }
+                        pressed={selectedTeamIds.has(team.id)}
+                        size="sm"
+                        variant="outline"
+                      >
+                        {team.name}
+                      </Toggle>
+                    </motion.div>
                   ))}
                 </motion.div>
               ) : (

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -595,7 +595,7 @@ export function QuickAddAgentPopover({
                     <button
                       aria-selected={isInChannel || isSelected}
                       className={cn(
-                        "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
+                        "flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors",
                         isInChannel
                           ? "cursor-default opacity-50"
                           : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
@@ -612,7 +612,7 @@ export function QuickAddAgentPopover({
                     >
                       {!isInChannel ? (
                         <motion.div
-                          animate={{ width: selectMode ? 16 : 0, opacity: selectMode ? 1 : 0 }}
+                          animate={{ width: selectMode ? 16 : 0, marginRight: selectMode ? 8 : 0, opacity: selectMode ? 1 : 0 }}
                           initial={false}
                           transition={{ duration: 0.15 }}
                           className="shrink-0 overflow-hidden"
@@ -629,24 +629,26 @@ export function QuickAddAgentPopover({
                           </div>
                         </motion.div>
                       ) : null}
-                      <QuickAddAgentAvatar
-                        avatarUrl={item.avatarUrl}
-                        label={item.label}
-                        isRunning={item.kind !== "persona"}
-                      />
-                      <span className="min-w-0 flex-1 truncate font-medium">
-                        {item.label}
-                      </span>
-                      {isInChannel ? (
-                        <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                      ) : item.kind === "running-available" && !selectMode ? (
-                        <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
-                          running
+                      <div className="flex min-w-0 flex-1 items-center gap-2.5">
+                        <QuickAddAgentAvatar
+                          avatarUrl={item.avatarUrl}
+                          label={item.label}
+                          isRunning={item.kind !== "persona"}
+                        />
+                        <span className="min-w-0 flex-1 truncate font-medium">
+                          {item.label}
                         </span>
-                      ) : null}
-                      {isItemPending ? (
-                        <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
-                      ) : null}
+                        {isInChannel ? (
+                          <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                        ) : item.kind === "running-available" && !selectMode ? (
+                          <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                            running
+                          </span>
+                        ) : null}
+                        {isItemPending ? (
+                          <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
+                        ) : null}
+                      </div>
                     </button>
                   );
                 })}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -542,11 +542,10 @@ export function QuickAddAgentPopover({
               )}
             </AnimatePresence>
 
-            {/* Right side: Select / Cancel toggle */}
+            {/* Right side: Select / Cancel button */}
             {usableTeams.length > 0 ? (
               <div className="ml-auto flex shrink-0 items-center pl-2">
-                <button
-                  className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                <Button
                   onClick={() => {
                     if (selectMode) {
                       handleCancelSelect();
@@ -554,10 +553,12 @@ export function QuickAddAgentPopover({
                       setSelectMode(true);
                     }
                   }}
+                  size="sm"
                   type="button"
+                  variant={selectMode ? "default" : "secondary"}
                 >
                   {selectMode ? "Cancel" : "Select"}
-                </button>
+                </Button>
               </div>
             ) : null}
           </div>
@@ -605,23 +606,26 @@ export function QuickAddAgentPopover({
                       type="button"
                     >
                       {selectMode && !isInChannel ? (
-                        <div
+                        <motion.div
                           className={cn(
                             "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
                             isSelected
                               ? "border-primary bg-primary text-primary-foreground"
                               : "border-muted-foreground/40",
                           )}
+                          initial={{ opacity: 0, scale: 0.5 }}
+                          animate={{ opacity: 1, scale: 1 }}
+                          transition={{ duration: 0.15 }}
                         >
                           {isSelected ? <Check className="h-3 w-3" /> : null}
-                        </div>
+                        </motion.div>
                       ) : null}
                       <QuickAddAgentAvatar
                         avatarUrl={item.avatarUrl}
                         label={item.label}
                         isRunning={item.kind !== "persona"}
                       />
-                      <span className="flex-1 truncate font-medium">
+                      <span className="min-w-0 flex-1 truncate font-medium">
                         {item.label}
                       </span>
                       {isInChannel ? (

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -497,7 +497,7 @@ export function QuickAddAgentPopover({
               {selectMode ? (
                 <motion.div
                   key="team-chips"
-                  className="flex flex-1 items-center gap-1.5 overflow-x-auto py-1.5"
+                  className="flex flex-1 items-center gap-1.5 overflow-x-auto"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -534,7 +534,7 @@ export function QuickAddAgentPopover({
             {selectMode ? (
               <motion.div
                 key="team-row"
-                className="relative border-b px-3 py-2"
+                className="relative border-b px-3 py-1"
                 initial={{ height: 0, opacity: 0 }}
                 animate={{ height: "auto", opacity: 1 }}
                 exit={{ height: 0, opacity: 0 }}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -682,7 +682,7 @@ export function QuickAddAgentPopover({
             {multiSelectActive ? (
               <motion.div
                 key="batch-add"
-                className="pointer-events-none absolute bottom-0 left-0 right-0 px-3 pb-2 pt-8 bg-gradient-to-t from-popover to-transparent"
+                className="pointer-events-none absolute bottom-0 left-0 right-0 px-3 pb-1.5 pt-8 bg-gradient-to-t from-popover to-transparent"
                 initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: 8 }}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -1,29 +1,22 @@
-import { Check, Settings2, Users } from "lucide-react";
+import { Check, Settings2 } from "lucide-react";
 import * as React from "react";
 
 import {
   useAcpProvidersQuery,
   useAttachManagedAgentToChannelMutation,
   useCreateChannelManagedAgentMutation,
-  useCreateChannelManagedAgentsMutation,
   useManagedAgentsQuery,
   usePersonasQuery,
-  useTeamsQuery,
 } from "@/features/agents/hooks";
 import { useChannelMembersQuery } from "@/features/channels/hooks";
 import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { resolvePersonaProvider } from "@/features/agents/lib/resolvePersonaProvider";
 import { pickBotName } from "@/features/agents/lib/pickBotName";
 import { useBotRecents } from "@/features/agents/lib/useBotRecents";
-import {
-  getUsableTeams,
-  resolveTeamPersonas,
-} from "@/features/agents/lib/teamPersonas";
-import type { AgentPersona, AgentTeam, ManagedAgent } from "@/shared/api/types";
+import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { cn } from "@/shared/lib/cn";
-import { Button } from "@/shared/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
 
@@ -77,17 +70,6 @@ function getItemKey(item: QuickAddAgentItem): string {
   }
 }
 
-/** Get the persona ID associated with an item (for team membership checks). */
-function getItemPersonaId(item: QuickAddAgentItem): string | null {
-  switch (item.kind) {
-    case "persona":
-      return item.persona.id;
-    case "running-available":
-    case "running-in-channel":
-      return item.agent.personaId ?? null;
-  }
-}
-
 function safeBotName(persona: AgentPersona, usedNames: Set<string>): string {
   const pool = persona.namePool ?? [];
   const name = pickBotName(pool, usedNames);
@@ -107,22 +89,16 @@ export function QuickAddAgentPopover({
   const managedAgentsQuery = useManagedAgentsQuery();
   const personasQuery = usePersonasQuery();
   const providersQuery = useAcpProvidersQuery();
-  const teamsQuery = useTeamsQuery();
   const membersQuery = useChannelMembersQuery(
     channelId,
     open && channelId !== null,
   );
   const attachMutation = useAttachManagedAgentToChannelMutation(channelId);
   const createMutation = useCreateChannelManagedAgentMutation(channelId);
-  const batchCreateMutation = useCreateChannelManagedAgentsMutation(channelId);
   const { recentIds, pushRecent } = useBotRecents();
 
   const [pendingKey, setPendingKey] = React.useState<string | null>(null);
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
-  const [multiSelectMode, setMultiSelectMode] = React.useState(false);
-  const [selectedKeys, setSelectedKeys] = React.useState<Set<string>>(
-    new Set(),
-  );
 
   const managedAgents = managedAgentsQuery.data ?? [];
   const personas = React.useMemo(
@@ -132,20 +108,13 @@ export function QuickAddAgentPopover({
   const providers = providersQuery.data ?? [];
   const defaultProvider = providers[0] ?? null;
   const members = membersQuery.data ?? [];
-  const teams = teamsQuery.data ?? [];
 
   const channelMemberPubkeys = React.useMemo(
     () => new Set(members.map((m) => normalizePubkey(m.pubkey))),
     [members],
   );
 
-  // Usable teams (all personas resolved)
-  const usableTeams = React.useMemo(
-    () => getUsableTeams(teams, personas),
-    [teams, personas],
-  );
-
-  // Build the full item list (flat, for mutations)
+  // Build the sorted item list
   const items: QuickAddAgentItem[] = React.useMemo(() => {
     const result: QuickAddAgentItem[] = [];
 
@@ -231,49 +200,13 @@ export function QuickAddAgentPopover({
     return result;
   }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
 
-  // ── Grouped layout: team sections + ungrouped ─────────────────────────────
-
-  // Set of all persona IDs that belong to at least one usable team
-  const teamedPersonaIds = React.useMemo(() => {
-    const ids = new Set<string>();
-    for (const team of usableTeams) {
-      for (const pid of team.personaIds) {
-        ids.add(pid);
-      }
-    }
-    return ids;
-  }, [usableTeams]);
-
-  // Items grouped by team
-  const teamGroups = React.useMemo(() => {
-    return usableTeams.map((team) => {
-      const memberItems = items.filter((item) => {
-        const personaId = getItemPersonaId(item);
-        return personaId !== null && team.personaIds.includes(personaId);
-      });
-      return { team, items: memberItems };
-    });
-  }, [usableTeams, items]);
-
-  // Ungrouped items (not in any team)
-  const ungroupedItems = React.useMemo(() => {
-    return items.filter((item) => {
-      const personaId = getItemPersonaId(item);
-      return personaId === null || !teamedPersonaIds.has(personaId);
-    });
-  }, [items, teamedPersonaIds]);
-
   // Reset state when popover closes
   React.useEffect(() => {
     if (!open) {
       setPendingKey(null);
       setErrorMessage(null);
-      setMultiSelectMode(false);
-      setSelectedKeys(new Set());
     }
   }, [open]);
-
-  // ── Single-add handlers (preserved fast path) ─────────────────────────────
 
   async function handleAddRunningAgent(agent: ManagedAgent) {
     if (!channelId) return;
@@ -333,159 +266,15 @@ export function QuickAddAgentPopover({
     }
   }
 
-  // ── Multi-select handlers ─────────────────────────────────────────────────
-
-  function enterMultiSelect(key: string) {
-    setMultiSelectMode(true);
-    setSelectedKeys((prev) => {
-      const next = new Set(prev);
-      next.add(key);
-      return next;
-    });
-  }
-
-  function toggleSelection(key: string) {
-    setSelectedKeys((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      if (next.size === 0) {
-        setMultiSelectMode(false);
-      }
-      return next;
-    });
-  }
-
-  function handleTeamClick(team: AgentTeam) {
-    const resolution = resolveTeamPersonas(team, personas);
-
-    setMultiSelectMode(true);
-    setSelectedKeys((prev) => {
-      const next = new Set(prev);
-      for (const persona of resolution.resolvedPersonas) {
-        // Find the matching item (running agent or persona)
-        const runningItem = items.find(
-          (i) =>
-            i.kind === "running-available" && i.agent.personaId === persona.id,
-        );
-        if (runningItem) {
-          next.add(getItemKey(runningItem));
-        } else {
-          const personaItem = items.find(
-            (i) => i.kind === "persona" && i.persona.id === persona.id,
-          );
-          if (personaItem && personaItem.kind !== "running-in-channel") {
-            next.add(getItemKey(personaItem));
-          }
-        }
-      }
-      return next;
-    });
-  }
-
-  async function handleBatchAdd() {
-    if (!channelId || selectedKeys.size === 0) return;
-    setPendingKey("batch");
-    setErrorMessage(null);
-
-    const usedNames = new Set(managedAgents.map((a) => a.name));
-    const toAttach: ManagedAgent[] = [];
-    const toCreate: Array<{
-      persona: AgentPersona;
-      instanceName: string;
-    }> = [];
-
-    for (const key of selectedKeys) {
-      const item = items.find((i) => getItemKey(i) === key);
-      if (!item || item.kind === "running-in-channel") continue;
-
-      if (item.kind === "running-available") {
-        toAttach.push(item.agent);
-      } else {
-        const instanceName = safeBotName(item.persona, usedNames);
-        usedNames.add(instanceName);
-        toCreate.push({ persona: item.persona, instanceName });
-      }
-    }
-
-    try {
-      for (const agent of toAttach) {
-        await attachMutation.mutateAsync({ agent, ensureRunning: true });
-        if (agent.personaId) pushRecent(agent.personaId);
-      }
-
-      if (toCreate.length > 0 && defaultProvider) {
-        const inputs = toCreate.map(({ persona, instanceName }) => {
-          const { provider } = resolvePersonaProvider(
-            persona.provider,
-            providers,
-            defaultProvider,
-          );
-          const providerToUse = provider ?? defaultProvider;
-          return {
-            provider: {
-              id: providerToUse.id,
-              label: providerToUse.label,
-              command: providerToUse.command,
-              defaultArgs: providerToUse.defaultArgs,
-              mcpCommand: providerToUse.mcpCommand,
-            },
-            name: instanceName,
-            systemPrompt: persona.systemPrompt,
-            avatarUrl: persona.avatarUrl ?? undefined,
-            personaId: persona.id,
-            model: persona.model ?? undefined,
-          };
-        });
-
-        await batchCreateMutation.mutateAsync(inputs);
-        for (const { persona } of toCreate) {
-          pushRecent(persona.id);
-        }
-      }
-
-      onOpenChange(false);
-    } catch (err) {
-      setErrorMessage(
-        err instanceof Error ? err.message : "Failed to add agents.",
-      );
-      setPendingKey(null);
-    }
-  }
-
-  // ── Item click dispatcher ─────────────────────────────────────────────────
-
   function handleItemClick(item: QuickAddAgentItem) {
     if (item.kind === "running-in-channel") return;
     if (pendingKey) return;
     if (!channelId) return;
 
-    if (multiSelectMode) {
-      toggleSelection(getItemKey(item));
+    if (item.kind === "running-available") {
+      void handleAddRunningAgent(item.agent);
     } else {
-      // Single-click fast path — add immediately
-      if (item.kind === "running-available") {
-        void handleAddRunningAgent(item.agent);
-      } else {
-        void handleAddPersona(item.persona);
-      }
-    }
-  }
-
-  function handleCheckboxClick(e: React.MouseEvent, item: QuickAddAgentItem) {
-    e.stopPropagation();
-    if (item.kind === "running-in-channel") return;
-    if (pendingKey) return;
-
-    const key = getItemKey(item);
-    if (multiSelectMode) {
-      toggleSelection(key);
-    } else {
-      // Clicking checkbox enters multi-select mode
-      enterMultiSelect(key);
+      void handleAddPersona(item.persona);
     }
   }
 
@@ -496,75 +285,6 @@ export function QuickAddAgentPopover({
 
   if (!channelId) {
     return <>{children}</>;
-  }
-
-  // ── Render helpers ────────────────────────────────────────────────────────
-
-  function renderAgentRow(item: QuickAddAgentItem, indented: boolean) {
-    const itemKey = getItemKey(item);
-    const isInChannel = item.kind === "running-in-channel";
-    const isItemPending = pendingKey === itemKey || pendingKey === "batch";
-    const isSelected = selectedKeys.has(itemKey);
-
-    return (
-      <button
-        aria-selected={isInChannel || isSelected}
-        className={cn(
-          "group flex w-full items-center gap-2.5 py-1.5 text-left text-sm transition-colors",
-          indented ? "pl-6 pr-3" : "px-3",
-          isInChannel
-            ? "cursor-default opacity-50"
-            : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
-          isItemPending && "pointer-events-none opacity-60",
-          isSelected && "bg-accent/50",
-        )}
-        data-quick-add-item
-        disabled={isInChannel || Boolean(pendingKey)}
-        key={itemKey}
-        onClick={() => handleItemClick(item)}
-        role="option"
-        tabIndex={isInChannel ? -1 : 0}
-        type="button"
-      >
-        {/* Checkbox: always visible in multi-select, hover-reveal otherwise */}
-        {!isInChannel ? (
-          <div
-            className={cn(
-              "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-all",
-              multiSelectMode
-                ? "opacity-100"
-                : "opacity-0 group-hover:opacity-100",
-              isSelected
-                ? "border-primary bg-primary text-primary-foreground"
-                : "border-muted-foreground/40",
-            )}
-            onClick={(e) => handleCheckboxClick(e, item)}
-            onKeyDown={() => {}}
-            aria-hidden="true"
-          >
-            {isSelected ? <Check className="h-3 w-3" /> : null}
-          </div>
-        ) : (
-          <div className="h-4 w-4 shrink-0" />
-        )}
-        <QuickAddAgentAvatar
-          avatarUrl={item.avatarUrl}
-          label={item.label}
-          isRunning={item.kind !== "persona"}
-        />
-        <span className="flex-1 truncate font-medium">{item.label}</span>
-        {isInChannel ? (
-          <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        ) : item.kind === "running-available" && !multiSelectMode ? (
-          <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
-            running
-          </span>
-        ) : null}
-        {isItemPending ? (
-          <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
-        ) : null}
-      </button>
-    );
   }
 
   return (
@@ -602,25 +322,10 @@ export function QuickAddAgentPopover({
             }
           }}
         >
-          <div className="flex items-center border-b px-3 py-2">
+          <div className="border-b px-3 py-2">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Add agent
             </h3>
-            {multiSelectMode && selectedKeys.size > 0 ? (
-              <Button
-                className="ml-auto"
-                data-testid="quick-add-batch-confirm"
-                disabled={Boolean(pendingKey)}
-                onClick={() => void handleBatchAdd()}
-                size="sm"
-                type="button"
-              >
-                {pendingKey === "batch" ? (
-                  <Spinner className="h-3 w-3" />
-                ) : null}
-                Add ({selectedKeys.size})
-              </Button>
-            ) : null}
           </div>
 
           {/* Scrollable content — clips mid-item to hint at more */}
@@ -639,44 +344,50 @@ export function QuickAddAgentPopover({
                 className="py-1"
                 role="listbox"
               >
-                {/* Team groups */}
-                {teamGroups.map(({ team, items: teamItems }) => (
-                  <div key={team.id} className="mb-1">
-                    {/* Team header */}
+                {items.map((item) => {
+                  const itemKey = getItemKey(item);
+                  const isInChannel = item.kind === "running-in-channel";
+                  const isItemPending = pendingKey === itemKey;
+
+                  return (
                     <button
-                      className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+                      aria-selected={isInChannel}
+                      className={cn(
+                        "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
+                        isInChannel
+                          ? "cursor-default opacity-50"
+                          : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
+                        isItemPending && "pointer-events-none opacity-60",
+                      )}
                       data-quick-add-item
-                      onClick={() => handleTeamClick(team)}
+                      disabled={isInChannel || Boolean(pendingKey)}
+                      key={itemKey}
+                      onClick={() => handleItemClick(item)}
+                      role="option"
+                      tabIndex={isInChannel ? -1 : 0}
                       type="button"
                     >
-                      <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-muted">
-                        <Users className="h-3 w-3 text-muted-foreground" />
-                      </div>
-                      <span className="flex-1 truncate text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        {team.name}
+                      <QuickAddAgentAvatar
+                        avatarUrl={item.avatarUrl}
+                        label={item.label}
+                        isRunning={item.kind !== "persona"}
+                      />
+                      <span className="flex-1 truncate font-medium">
+                        {item.label}
                       </span>
-                      <span className="shrink-0 text-[11px] text-muted-foreground">
-                        {teamItems.length}
-                      </span>
-                    </button>
-                    {/* Team members (indented) */}
-                    {teamItems.map((item) => renderAgentRow(item, true))}
-                  </div>
-                ))}
-
-                {/* Ungrouped section */}
-                {ungroupedItems.length > 0 ? (
-                  <div className={cn(teamGroups.length > 0 && "border-t pt-1")}>
-                    {teamGroups.length > 0 ? (
-                      <div className="px-3 py-1">
-                        <span className="text-[11px] font-medium text-muted-foreground">
-                          Ungrouped
+                      {isInChannel ? (
+                        <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      ) : item.kind === "running-available" ? (
+                        <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                          running
                         </span>
-                      </div>
-                    ) : null}
-                    {ungroupedItems.map((item) => renderAgentRow(item, false))}
-                  </div>
-                ) : null}
+                      ) : null}
+                      {isItemPending ? (
+                        <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
+                      ) : null}
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -659,12 +659,14 @@ export function QuickAddAgentPopover({
                         </motion.div>
                       ) : null}
                       <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                        <QuickAddAgentAvatar
-                          avatarUrl={item.avatarUrl}
-                          label={item.label}
-                          isRunning={item.kind !== "persona"}
-                        />
-                        <span className="min-w-0 flex-1 truncate font-medium">
+                        <span className={cn("shrink-0", isInChannel && "opacity-70")}>
+                          <QuickAddAgentAvatar
+                            avatarUrl={item.avatarUrl}
+                            label={item.label}
+                            isRunning={item.kind !== "persona"}
+                          />
+                        </span>
+                        <span className={cn("min-w-0 flex-1 truncate font-medium", isInChannel && "opacity-70")}>
                           {item.label}
                         </span>
                         {isInChannel ? (

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -554,13 +554,13 @@ export function QuickAddAgentPopover({
                       className="shrink-0"
                     >
                       <Toggle
-                        className="h-8 rounded-full px-3 text-xs"
+                        className="h-6 rounded-full px-2.5 text-[11px]"
                         onPressedChange={(pressed) =>
                           handleTeamToggle(team, pressed)
                         }
                         pressed={selectedTeamIds.has(team.id)}
                         size="sm"
-                        variant="outline"
+                        variant="subtle"
                       >
                         {team.name}
                       </Toggle>

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -555,9 +555,9 @@ export function QuickAddAgentPopover({
                   }}
                   size="sm"
                   type="button"
-                  variant={selectMode ? "default" : "secondary"}
+                  variant={selectMode ? "default" : "outline"}
                 >
-                  {selectMode ? "Cancel" : "Select"}
+                  Select
                 </Button>
               </div>
             ) : null}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -237,25 +237,26 @@ export function QuickAddAgentPopover({
   const displayItems = React.useMemo(() => {
     if (!open) return items;
     const liveMap = new Map(items.map((item) => [getItemKey(item), item]));
-    // Keep stable order, update each item with live data, add new items at end
-    const result: QuickAddAgentItem[] = [];
+    // Keep stable order, update each item with live data
+    const stable: QuickAddAgentItem[] = [];
     const seen = new Set<string>();
     for (const stableItem of stableItems) {
       const key = getItemKey(stableItem);
       const liveItem = liveMap.get(key);
       if (liveItem) {
-        result.push(liveItem);
+        stable.push(liveItem);
         seen.add(key);
       }
     }
-    // Append any new items that weren't in the snapshot
+    // Prepend any new items (e.g. newly created agents) at the top
+    const newItems: QuickAddAgentItem[] = [];
     for (const item of items) {
       const key = getItemKey(item);
       if (!seen.has(key)) {
-        result.push(item);
+        newItems.push(item);
       }
     }
-    return result;
+    return [...newItems, ...stable];
   }, [open, stableItems, items]);
 
   // Reset state when popover closes

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -515,7 +515,7 @@ export function QuickAddAgentPopover({
                       className="shrink-0"
                     >
                       <Toggle
-                        className="h-8 rounded-full px-3 text-xs data-[state=on]:bg-accent data-[state=on]:text-accent-foreground"
+                        className="h-8 rounded-full px-3 text-xs"
                         onPressedChange={(pressed) =>
                           handleTeamToggle(team, pressed)
                         }
@@ -546,11 +546,7 @@ export function QuickAddAgentPopover({
             {usableTeams.length > 0 ? (
               <div className="ml-auto flex shrink-0 items-center">
                 <Button
-                  className={
-                    selectMode
-                      ? undefined
-                      : "border border-input bg-transparent"
-                  }
+                  className="border border-input bg-transparent"
                   onClick={() => {
                     if (selectMode) {
                       handleCancelSelect();
@@ -560,9 +556,9 @@ export function QuickAddAgentPopover({
                   }}
                   size="sm"
                   type="button"
-                  variant={selectMode ? "secondary" : "ghost"}
+                  variant="ghost"
                 >
-                  Select
+                  {selectMode ? "Cancel" : "Select"}
                 </Button>
               </div>
             ) : null}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -610,6 +610,18 @@ export function QuickAddAgentPopover({
                       tabIndex={isInChannel ? -1 : 0}
                       type="button"
                     >
+                      {selectMode && !isInChannel ? (
+                        <div
+                          className={cn(
+                            "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
+                            isSelected
+                              ? "border-primary bg-primary text-primary-foreground"
+                              : "border-muted-foreground/40",
+                          )}
+                        >
+                          {isSelected ? <Check className="h-3 w-3" /> : null}
+                        </div>
+                      ) : null}
                       <QuickAddAgentAvatar
                         avatarUrl={item.avatarUrl}
                         label={item.label}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -546,6 +546,11 @@ export function QuickAddAgentPopover({
             {usableTeams.length > 0 ? (
               <div className="ml-auto flex shrink-0 items-center pl-2">
                 <Button
+                  className={
+                    selectMode
+                      ? undefined
+                      : "border border-input bg-transparent"
+                  }
                   onClick={() => {
                     if (selectMode) {
                       handleCancelSelect();
@@ -555,7 +560,7 @@ export function QuickAddAgentPopover({
                   }}
                   size="sm"
                   type="button"
-                  variant={selectMode ? "default" : "outline"}
+                  variant={selectMode ? "default" : "ghost"}
                 >
                   Select
                 </Button>

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -492,7 +492,7 @@ export function QuickAddAgentPopover({
           }}
         >
           {/* Header with animated title / team toggles */}
-          <div className="relative flex min-h-10 items-center border-b px-3">
+          <div className="relative flex min-h-10 items-center gap-2 border-b px-3 py-1.5">
             <AnimatePresence mode="wait">
               {selectMode ? (
                 <motion.div
@@ -506,7 +506,7 @@ export function QuickAddAgentPopover({
                   {usableTeams.map((team, index) => (
                     <motion.div
                       key={team.id}
-                      initial={{ opacity: 0, x: 12 }}
+                      initial={{ opacity: 0, x: index === 0 ? 0 : 12 }}
                       animate={{ opacity: 1, x: 0 }}
                       transition={{
                         duration: 0.2,
@@ -544,7 +544,7 @@ export function QuickAddAgentPopover({
 
             {/* Right side: Select / Cancel button */}
             {usableTeams.length > 0 ? (
-              <div className="ml-auto flex shrink-0 items-center pl-2">
+              <div className="ml-auto flex shrink-0 items-center">
                 <Button
                   className={
                     selectMode

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -495,20 +495,16 @@ export function QuickAddAgentPopover({
           <div className="relative flex min-h-10 items-center gap-2 border-b pl-3 pr-1.5 py-1.5">
             {/* Title — always visible */}
             <h3 className="shrink-0 text-sm font-semibold text-foreground">
-              Add agent
-              <AnimatePresence>
-                {selectMode ? (
-                  <motion.span
-                    initial={{ opacity: 0, width: 0 }}
-                    animate={{ opacity: 1, width: "auto" }}
-                    exit={{ opacity: 0, width: 0 }}
-                    transition={{ duration: 0.2 }}
-                    className="inline-block overflow-hidden"
-                  >
-                    s
-                  </motion.span>
-                ) : null}
-              </AnimatePresence>
+              Add agent{selectMode ? (
+                <motion.span
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  s
+                </motion.span>
+              ) : null}
             </h3>
 
             {/* Team toggles — appear to the right of title */}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -304,7 +304,6 @@ export function QuickAddAgentPopover({
       <PopoverContent align="end" className="w-72 p-0" sideOffset={6}>
         <div
           className="flex max-h-80 flex-col"
-          role="menu"
           onKeyDown={(e) => {
             const container = e.currentTarget;
             const buttons = Array.from(
@@ -345,11 +344,7 @@ export function QuickAddAgentPopover({
                 No agents available.
               </div>
             ) : (
-              <div
-                aria-label="Available agents"
-                className="py-1"
-                role="listbox"
-              >
+              <div aria-label="Available agents" className="py-1" role="listbox">
                 {items.map((item) => {
                   const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -311,6 +311,34 @@ export function QuickAddAgentPopover({
       } else {
         next.add(key);
       }
+
+      // Deselect any team whose members are no longer all selected
+      setSelectedTeamIds((prevTeams) => {
+        const nextTeams = new Set(prevTeams);
+        for (const team of usableTeams) {
+          if (!nextTeams.has(team.id)) continue;
+          const resolution = resolveTeamPersonas(team, personas);
+          const allSelected = resolution.resolvedPersonas.every((persona) => {
+            const runningItem = items.find(
+              (i) => i.kind === "running-available" && i.agent.personaId === persona.id,
+            );
+            const itemKey = runningItem
+              ? getItemKey(runningItem)
+              : (() => {
+                  const personaItem = items.find(
+                    (i) => i.kind === "persona" && i.persona.id === persona.id,
+                  );
+                  return personaItem ? getItemKey(personaItem) : null;
+                })();
+            return itemKey ? next.has(itemKey) : true;
+          });
+          if (!allSelected) {
+            nextTeams.delete(team.id);
+          }
+        }
+        return nextTeams;
+      });
+
       return next;
     });
   }

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -465,7 +465,7 @@ export function QuickAddAgentPopover({
         sideOffset={6}
       >
         <div
-          className="flex flex-col"
+          className="relative flex flex-col"
           role="menu"
           onKeyDown={(e) => {
             const container = e.currentTarget;
@@ -496,16 +496,6 @@ export function QuickAddAgentPopover({
           <div className="flex min-h-10 items-center gap-2 border-b pl-3 pr-1.5 py-1.5">
             <h3 className="shrink-0 text-sm font-semibold text-foreground">
               Add agent
-              {selectMode ? (
-                <motion.span
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.3 }}
-                >
-                  s
-                </motion.span>
-              ) : null}
             </h3>
 
             {usableTeams.length > 0 ? (
@@ -601,7 +591,8 @@ export function QuickAddAgentPopover({
                   const isSelected = selectedKeys.has(itemKey);
 
                   return (
-                    <button
+                    <motion.button
+                      layout
                       aria-selected={isInChannel || isSelected}
                       className={cn(
                         "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
@@ -617,28 +608,42 @@ export function QuickAddAgentPopover({
                       onClick={() => handleItemClick(item)}
                       role="option"
                       tabIndex={isInChannel ? -1 : 0}
+                      transition={{ duration: 0.15 }}
                       type="button"
                     >
-                      {selectMode && !isInChannel ? (
-                        <div
-                          className={cn(
-                            "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
-                            isSelected
-                              ? "border-primary bg-primary text-primary-foreground"
-                              : "border-muted-foreground/40",
-                          )}
-                        >
-                          {isSelected ? <Check className="h-3 w-3" /> : null}
-                        </div>
-                      ) : null}
-                      <QuickAddAgentAvatar
-                        avatarUrl={item.avatarUrl}
-                        label={item.label}
-                        isRunning={item.kind !== "persona"}
-                      />
-                      <span className="min-w-0 flex-1 truncate font-medium">
+                      <AnimatePresence>
+                        {selectMode && !isInChannel ? (
+                          <motion.div
+                            key="checkbox"
+                            initial={{ width: 0, opacity: 0 }}
+                            animate={{ width: 16, opacity: 1 }}
+                            exit={{ width: 0, opacity: 0 }}
+                            transition={{ duration: 0.15 }}
+                            className="shrink-0 overflow-hidden"
+                          >
+                            <div
+                              className={cn(
+                                "flex h-4 w-4 items-center justify-center rounded border transition-colors",
+                                isSelected
+                                  ? "border-primary bg-primary text-primary-foreground"
+                                  : "border-muted-foreground/40",
+                              )}
+                            >
+                              {isSelected ? <Check className="h-3 w-3" /> : null}
+                            </div>
+                          </motion.div>
+                        ) : null}
+                      </AnimatePresence>
+                      <motion.div layout="position" transition={{ duration: 0.15 }} className="shrink-0">
+                        <QuickAddAgentAvatar
+                          avatarUrl={item.avatarUrl}
+                          label={item.label}
+                          isRunning={item.kind !== "persona"}
+                        />
+                      </motion.div>
+                      <motion.span layout="position" transition={{ duration: 0.15 }} className="min-w-0 flex-1 truncate font-medium">
                         {item.label}
-                      </span>
+                      </motion.span>
                       {isInChannel ? (
                         <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       ) : item.kind === "running-available" && !selectMode ? (
@@ -649,7 +654,7 @@ export function QuickAddAgentPopover({
                       {isItemPending ? (
                         <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
                       ) : null}
-                    </button>
+                    </motion.button>
                   );
                 })}
               </div>
@@ -678,23 +683,32 @@ export function QuickAddAgentPopover({
             </button>
           </div>
 
-          {multiSelectActive ? (
-            <div className="border-t px-3 py-2">
-              <Button
-                className="w-full"
-                data-testid="quick-add-batch-confirm"
-                disabled={Boolean(pendingKey)}
-                onClick={() => void handleBatchAdd()}
-                size="sm"
-                type="button"
+          <AnimatePresence>
+            {multiSelectActive ? (
+              <motion.div
+                key="batch-add"
+                className="pointer-events-none absolute bottom-0 left-0 right-0 px-3 pb-2 pt-8 bg-gradient-to-t from-popover to-transparent"
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 8 }}
+                transition={{ duration: 0.15 }}
               >
-                {pendingKey === "batch" ? (
-                  <Spinner className="h-3 w-3" />
-                ) : null}
-                Add ({selectedKeys.size})
-              </Button>
-            </div>
-          ) : null}
+                <Button
+                  className="pointer-events-auto w-full"
+                  data-testid="quick-add-batch-confirm"
+                  disabled={Boolean(pendingKey)}
+                  onClick={() => void handleBatchAdd()}
+                  size="sm"
+                  type="button"
+                >
+                  {pendingKey === "batch" ? (
+                    <Spinner className="h-3 w-3" />
+                  ) : null}
+                  Add ({selectedKeys.size})
+                </Button>
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
         </div>
       </PopoverContent>
     </Popover>

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -610,21 +610,6 @@ export function QuickAddAgentPopover({
                       tabIndex={isInChannel ? -1 : 0}
                       type="button"
                     >
-                      {selectMode && !isInChannel ? (
-                        <motion.div
-                          className={cn(
-                            "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
-                            isSelected
-                              ? "border-primary bg-primary text-primary-foreground"
-                              : "border-muted-foreground/40",
-                          )}
-                          initial={{ opacity: 0, scale: 0.5 }}
-                          animate={{ opacity: 1, scale: 1 }}
-                          transition={{ duration: 0.15 }}
-                        >
-                          {isSelected ? <Check className="h-3 w-3" /> : null}
-                        </motion.div>
-                      ) : null}
                       <QuickAddAgentAvatar
                         avatarUrl={item.avatarUrl}
                         label={item.label}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -534,7 +534,7 @@ export function QuickAddAgentPopover({
             {selectMode ? (
               <motion.div
                 key="team-row"
-                className="relative border-b px-3 py-1"
+                className="relative border-b px-3 pb-1 pt-0.5"
                 initial={{ height: 0, opacity: 0 }}
                 animate={{ height: "auto", opacity: 1 }}
                 exit={{ height: 0, opacity: 0 }}

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -301,9 +301,14 @@ export function QuickAddAgentPopover({
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent align="end" className="w-72 p-0" sideOffset={6}>
+      <PopoverContent
+        align="end"
+        className="w-72 overflow-hidden p-0"
+        sideOffset={6}
+      >
         <div
           className="flex max-h-80 flex-col"
+          role="menu"
           onKeyDown={(e) => {
             const container = e.currentTarget;
             const buttons = Array.from(
@@ -344,7 +349,11 @@ export function QuickAddAgentPopover({
                 No agents available.
               </div>
             ) : (
-              <div aria-label="Available agents" className="py-1" role="listbox">
+              <div
+                aria-label="Available agents"
+                className="py-1"
+                role="listbox"
+              >
                 {items.map((item) => {
                   const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -1,22 +1,30 @@
 import { Check, Settings2 } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import * as React from "react";
 
 import {
   useAcpProvidersQuery,
   useAttachManagedAgentToChannelMutation,
   useCreateChannelManagedAgentMutation,
+  useCreateChannelManagedAgentsMutation,
   useManagedAgentsQuery,
   usePersonasQuery,
+  useTeamsQuery,
 } from "@/features/agents/hooks";
 import { useChannelMembersQuery } from "@/features/channels/hooks";
 import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { resolvePersonaProvider } from "@/features/agents/lib/resolvePersonaProvider";
 import { pickBotName } from "@/features/agents/lib/pickBotName";
 import { useBotRecents } from "@/features/agents/lib/useBotRecents";
-import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
+import {
+  getUsableTeams,
+  resolveTeamPersonas,
+} from "@/features/agents/lib/teamPersonas";
+import type { AgentPersona, AgentTeam, ManagedAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
 
@@ -89,16 +97,22 @@ export function QuickAddAgentPopover({
   const managedAgentsQuery = useManagedAgentsQuery();
   const personasQuery = usePersonasQuery();
   const providersQuery = useAcpProvidersQuery();
+  const teamsQuery = useTeamsQuery();
   const membersQuery = useChannelMembersQuery(
     channelId,
     open && channelId !== null,
   );
   const attachMutation = useAttachManagedAgentToChannelMutation(channelId);
   const createMutation = useCreateChannelManagedAgentMutation(channelId);
+  const batchCreateMutation = useCreateChannelManagedAgentsMutation(channelId);
   const { recentIds, pushRecent } = useBotRecents();
 
   const [pendingKey, setPendingKey] = React.useState<string | null>(null);
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+  const [selectMode, setSelectMode] = React.useState(false);
+  const [selectedKeys, setSelectedKeys] = React.useState<Set<string>>(
+    new Set(),
+  );
 
   const managedAgents = managedAgentsQuery.data ?? [];
   const personas = React.useMemo(
@@ -108,10 +122,16 @@ export function QuickAddAgentPopover({
   const providers = providersQuery.data ?? [];
   const defaultProvider = providers[0] ?? null;
   const members = membersQuery.data ?? [];
+  const teams = teamsQuery.data ?? [];
 
   const channelMemberPubkeys = React.useMemo(
     () => new Set(members.map((m) => normalizePubkey(m.pubkey))),
     [members],
+  );
+
+  const usableTeams = React.useMemo(
+    () => getUsableTeams(teams, personas),
+    [teams, personas],
   );
 
   // Build the sorted item list
@@ -205,8 +225,12 @@ export function QuickAddAgentPopover({
     if (!open) {
       setPendingKey(null);
       setErrorMessage(null);
+      setSelectMode(false);
+      setSelectedKeys(new Set());
     }
   }, [open]);
+
+  // ── Single-add handlers ───────────────────────────────────────────────────
 
   async function handleAddRunningAgent(agent: ManagedAgent) {
     if (!channelId) return;
@@ -266,15 +290,130 @@ export function QuickAddAgentPopover({
     }
   }
 
+  // ── Multi-select handlers ─────────────────────────────────────────────────
+
+  function toggleSelection(key: string) {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      if (next.size === 0) {
+        setSelectMode(false);
+      }
+      return next;
+    });
+  }
+
+  function handleTeamChipClick(team: AgentTeam) {
+    const resolution = resolveTeamPersonas(team, personas);
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      for (const persona of resolution.resolvedPersonas) {
+        // Find matching item (running agent or persona)
+        const runningItem = items.find(
+          (i) =>
+            i.kind === "running-available" && i.agent.personaId === persona.id,
+        );
+        if (runningItem) {
+          next.add(getItemKey(runningItem));
+        } else {
+          const personaItem = items.find(
+            (i) => i.kind === "persona" && i.persona.id === persona.id,
+          );
+          if (personaItem) {
+            next.add(getItemKey(personaItem));
+          }
+        }
+      }
+      return next;
+    });
+  }
+
+  async function handleBatchAdd() {
+    if (!channelId || selectedKeys.size === 0) return;
+    setPendingKey("batch");
+    setErrorMessage(null);
+
+    const usedNames = new Set(managedAgents.map((a) => a.name));
+    const toAttach: ManagedAgent[] = [];
+    const toCreate: Array<{ persona: AgentPersona; instanceName: string }> = [];
+
+    for (const key of selectedKeys) {
+      const item = items.find((i) => getItemKey(i) === key);
+      if (!item || item.kind === "running-in-channel") continue;
+
+      if (item.kind === "running-available") {
+        toAttach.push(item.agent);
+      } else {
+        const instanceName = safeBotName(item.persona, usedNames);
+        usedNames.add(instanceName);
+        toCreate.push({ persona: item.persona, instanceName });
+      }
+    }
+
+    try {
+      for (const agent of toAttach) {
+        await attachMutation.mutateAsync({ agent, ensureRunning: true });
+        if (agent.personaId) pushRecent(agent.personaId);
+      }
+
+      if (toCreate.length > 0 && defaultProvider) {
+        const inputs = toCreate.map(({ persona, instanceName }) => {
+          const { provider } = resolvePersonaProvider(
+            persona.provider,
+            providers,
+            defaultProvider,
+          );
+          const providerToUse = provider ?? defaultProvider;
+          return {
+            provider: {
+              id: providerToUse.id,
+              label: providerToUse.label,
+              command: providerToUse.command,
+              defaultArgs: providerToUse.defaultArgs,
+              mcpCommand: providerToUse.mcpCommand,
+            },
+            name: instanceName,
+            systemPrompt: persona.systemPrompt,
+            avatarUrl: persona.avatarUrl ?? undefined,
+            personaId: persona.id,
+            model: persona.model ?? undefined,
+          };
+        });
+
+        await batchCreateMutation.mutateAsync(inputs);
+        for (const { persona } of toCreate) {
+          pushRecent(persona.id);
+        }
+      }
+
+      onOpenChange(false);
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to add agents.",
+      );
+      setPendingKey(null);
+    }
+  }
+
+  // ── Item click dispatcher ─────────────────────────────────────────────────
+
   function handleItemClick(item: QuickAddAgentItem) {
     if (item.kind === "running-in-channel") return;
     if (pendingKey) return;
     if (!channelId) return;
 
-    if (item.kind === "running-available") {
-      void handleAddRunningAgent(item.agent);
+    if (selectMode) {
+      toggleSelection(getItemKey(item));
     } else {
-      void handleAddPersona(item.persona);
+      if (item.kind === "running-available") {
+        void handleAddRunningAgent(item.agent);
+      } else {
+        void handleAddPersona(item.persona);
+      }
     }
   }
 
@@ -282,6 +421,8 @@ export function QuickAddAgentPopover({
     managedAgentsQuery.isLoading ||
     personasQuery.isLoading ||
     providersQuery.isLoading;
+
+  const multiSelectActive = selectMode && selectedKeys.size > 0;
 
   if (!channelId) {
     return <>{children}</>;
@@ -322,10 +463,68 @@ export function QuickAddAgentPopover({
             }
           }}
         >
-          <div className="border-b px-3 py-2">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Add agent
-            </h3>
+          {/* Header with animated title / team chips */}
+          <div className="relative flex h-10 items-center border-b px-3">
+            <AnimatePresence mode="wait">
+              {selectMode ? (
+                <motion.div
+                  key="team-chips"
+                  className="flex flex-1 items-center gap-1.5 overflow-x-auto"
+                  initial={{ opacity: 0, x: 20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 20 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  {usableTeams.map((team) => (
+                    <button
+                      className="shrink-0 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                      key={team.id}
+                      onClick={() => handleTeamChipClick(team)}
+                      type="button"
+                    >
+                      {team.name}
+                    </button>
+                  ))}
+                </motion.div>
+              ) : (
+                <motion.h3
+                  key="title"
+                  className="text-sm font-semibold text-foreground"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.15 }}
+                >
+                  Add agent
+                </motion.h3>
+              )}
+            </AnimatePresence>
+
+            {/* Right side: Select toggle or Add (N) button */}
+            <div className="ml-auto flex shrink-0 items-center pl-2">
+              {multiSelectActive ? (
+                <Button
+                  data-testid="quick-add-batch-confirm"
+                  disabled={Boolean(pendingKey)}
+                  onClick={() => void handleBatchAdd()}
+                  size="sm"
+                  type="button"
+                >
+                  {pendingKey === "batch" ? (
+                    <Spinner className="h-3 w-3" />
+                  ) : null}
+                  Add ({selectedKeys.size})
+                </Button>
+              ) : usableTeams.length > 0 ? (
+                <button
+                  className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                  onClick={() => setSelectMode((prev) => !prev)}
+                  type="button"
+                >
+                  {selectMode ? "Done" : "Select"}
+                </button>
+              ) : null}
+            </div>
           </div>
 
           {/* Scrollable content — clips mid-item to hint at more */}
@@ -347,17 +546,20 @@ export function QuickAddAgentPopover({
                 {items.map((item) => {
                   const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";
-                  const isItemPending = pendingKey === itemKey;
+                  const isItemPending =
+                    pendingKey === itemKey || pendingKey === "batch";
+                  const isSelected = selectedKeys.has(itemKey);
 
                   return (
                     <button
-                      aria-selected={isInChannel}
+                      aria-selected={isInChannel || isSelected}
                       className={cn(
                         "flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors",
                         isInChannel
                           ? "cursor-default opacity-50"
                           : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
                         isItemPending && "pointer-events-none opacity-60",
+                        isSelected && "bg-accent/50",
                       )}
                       data-quick-add-item
                       disabled={isInChannel || Boolean(pendingKey)}
@@ -367,6 +569,18 @@ export function QuickAddAgentPopover({
                       tabIndex={isInChannel ? -1 : 0}
                       type="button"
                     >
+                      {selectMode && !isInChannel ? (
+                        <div
+                          className={cn(
+                            "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
+                            isSelected
+                              ? "border-primary bg-primary text-primary-foreground"
+                              : "border-muted-foreground/40",
+                          )}
+                        >
+                          {isSelected ? <Check className="h-3 w-3" /> : null}
+                        </div>
+                      ) : null}
                       <QuickAddAgentAvatar
                         avatarUrl={item.avatarUrl}
                         label={item.label}
@@ -377,7 +591,7 @@ export function QuickAddAgentPopover({
                       </span>
                       {isInChannel ? (
                         <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                      ) : item.kind === "running-available" ? (
+                      ) : item.kind === "running-available" && !selectMode ? (
                         <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
                           running
                         </span>

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -225,6 +225,39 @@ export function QuickAddAgentPopover({
     return result;
   }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
 
+  // Snapshot item order when popover opens — don't reorder while open
+  const [stableItems, setStableItems] = React.useState<QuickAddAgentItem[]>([]);
+  React.useEffect(() => {
+    if (open) {
+      setStableItems(items);
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Merge live data (kind changes) into stable order while keeping positions
+  const displayItems = React.useMemo(() => {
+    if (!open) return items;
+    const liveMap = new Map(items.map((item) => [getItemKey(item), item]));
+    // Keep stable order, update each item with live data, add new items at end
+    const result: QuickAddAgentItem[] = [];
+    const seen = new Set<string>();
+    for (const stableItem of stableItems) {
+      const key = getItemKey(stableItem);
+      const liveItem = liveMap.get(key);
+      if (liveItem) {
+        result.push(liveItem);
+        seen.add(key);
+      }
+    }
+    // Append any new items that weren't in the snapshot
+    for (const item of items) {
+      const key = getItemKey(item);
+      if (!seen.has(key)) {
+        result.push(item);
+      }
+    }
+    return result;
+  }, [open, stableItems, items]);
+
   // Reset state when popover closes
   React.useEffect(() => {
     if (!open) {
@@ -247,7 +280,7 @@ export function QuickAddAgentPopover({
     try {
       await attachMutation.mutateAsync({ agent, ensureRunning: true });
       if (agent.personaId) pushRecent(agent.personaId);
-      onOpenChange(false);
+      setPendingKey(null);
     } catch (err) {
       setErrorMessage(
         err instanceof Error ? err.message : "Failed to add agent.",
@@ -287,7 +320,7 @@ export function QuickAddAgentPopover({
         model: persona.model ?? undefined,
       });
       pushRecent(persona.id);
-      onOpenChange(false);
+      setPendingKey(null);
     } catch (err) {
       setErrorMessage(
         err instanceof Error ? err.message : "Failed to add agent.",
@@ -447,7 +480,10 @@ export function QuickAddAgentPopover({
         }
       }
 
-      onOpenChange(false);
+      setPendingKey(null);
+      setSelectMode(false);
+      setSelectedKeys(new Set());
+      setSelectedTeamIds(new Set());
     } catch (err) {
       setErrorMessage(
         err instanceof Error ? err.message : "Failed to add agents.",
@@ -603,7 +639,7 @@ export function QuickAddAgentPopover({
               <div className="flex items-center justify-center py-6">
                 <Spinner className="h-4 w-4 text-muted-foreground" />
               </div>
-            ) : items.length === 0 ? (
+            ) : displayItems.length === 0 ? (
               <div className="px-3 py-4 text-center text-sm text-muted-foreground">
                 No agents available.
               </div>
@@ -613,7 +649,7 @@ export function QuickAddAgentPopover({
                 className="py-1"
                 role="listbox"
               >
-                {items.map((item) => {
+                {displayItems.map((item) => {
                   const itemKey = getItemKey(item);
                   const isInChannel = item.kind === "running-in-channel";
                   const isItemPending =

--- a/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
+++ b/desktop/src/features/channels/ui/QuickAddAgentPopover.tsx
@@ -1,63 +1,16 @@
-import { Check, Settings2, X } from "lucide-react";
+import { Settings2 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import * as React from "react";
 
-import {
-  useAcpProvidersQuery,
-  useAttachManagedAgentToChannelMutation,
-  useCreateChannelManagedAgentMutation,
-  useCreateChannelManagedAgentsMutation,
-  useManagedAgentsQuery,
-  usePersonasQuery,
-  useTeamsQuery,
-} from "@/features/agents/hooks";
 import { Toggle } from "@/shared/ui/toggle";
-import { useChannelMembersQuery, useRemoveChannelMemberMutation } from "@/features/channels/hooks";
-import { getActivePersonas } from "@/features/agents/lib/catalog";
-import { resolvePersonaProvider } from "@/features/agents/lib/resolvePersonaProvider";
-import { pickBotName } from "@/features/agents/lib/pickBotName";
-import { useBotRecents } from "@/features/agents/lib/useBotRecents";
-import {
-  getUsableTeams,
-  resolveTeamPersonas,
-} from "@/features/agents/lib/teamPersonas";
-import type { AgentPersona, AgentTeam, ManagedAgent } from "@/shared/api/types";
-import { normalizePubkey } from "@/shared/lib/pubkey";
-import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
-import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
+import { getItemKey, useQuickAddAgentItems } from "./useQuickAddAgentItems";
+import { useQuickAddAgentActions } from "./useQuickAddAgentActions";
+import { QuickAddAgentItemRow } from "./QuickAddAgentItemRow";
 
-// ── Types ─────────────────────────────────────────────────────────────────────
-
-type RunningAvailableItem = {
-  kind: "running-available";
-  agent: ManagedAgent;
-  persona: AgentPersona | null;
-  label: string;
-  avatarUrl: string | null;
-};
-
-type RunningInChannelItem = {
-  kind: "running-in-channel";
-  agent: ManagedAgent;
-  persona: AgentPersona | null;
-  label: string;
-  avatarUrl: string | null;
-};
-
-type PersonaItem = {
-  kind: "persona";
-  persona: AgentPersona;
-  label: string;
-  avatarUrl: string | null;
-};
-
-type QuickAddAgentItem =
-  | RunningAvailableItem
-  | RunningInChannelItem
-  | PersonaItem;
+// ── Component ─────────────────────────────────────────────────────────────────
 
 type QuickAddAgentPopoverProps = {
   channelId: string | null;
@@ -67,27 +20,6 @@ type QuickAddAgentPopoverProps = {
   children: React.ReactNode;
 };
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function getItemKey(item: QuickAddAgentItem): string {
-  switch (item.kind) {
-    case "persona":
-      return `persona:${item.persona.id}`;
-    case "running-available":
-    case "running-in-channel":
-      return `agent:${item.agent.pubkey}`;
-  }
-}
-
-function safeBotName(persona: AgentPersona, usedNames: Set<string>): string {
-  const pool = persona.namePool ?? [];
-  const name = pickBotName(pool, usedNames);
-  if (name && name.trim().length > 0) return name;
-  return persona.displayName || "Agent";
-}
-
-// ── Component ─────────────────────────────────────────────────────────────────
-
 export function QuickAddAgentPopover({
   channelId,
   open,
@@ -95,393 +27,45 @@ export function QuickAddAgentPopover({
   onMoreOptions,
   children,
 }: QuickAddAgentPopoverProps) {
-  const managedAgentsQuery = useManagedAgentsQuery();
-  const personasQuery = usePersonasQuery();
-  const providersQuery = useAcpProvidersQuery();
-  const teamsQuery = useTeamsQuery();
-  const membersQuery = useChannelMembersQuery(
+  const {
+    items,
+    isLoading,
+    managedAgents,
+    personas,
+    providers,
+    defaultProvider,
+    usableTeams,
+    pushRecent,
+  } = useQuickAddAgentItems(channelId, open && channelId !== null);
+
+  const {
+    pendingKey,
+    errorMessage,
+    selectMode,
+    setSelectMode,
+    selectedKeys,
+    selectedTeamIds,
+    reset,
+    handleCancelSelect,
+    handleTeamToggle,
+    handleBatchAdd,
+    handleItemClick,
+    removeMutation,
+  } = useQuickAddAgentActions({
     channelId,
-    open && channelId !== null,
-  );
-  const attachMutation = useAttachManagedAgentToChannelMutation(channelId);
-  const createMutation = useCreateChannelManagedAgentMutation(channelId);
-  const batchCreateMutation = useCreateChannelManagedAgentsMutation(channelId);
-  const removeMutation = useRemoveChannelMemberMutation(channelId);
-  const { recentIds, pushRecent } = useBotRecents();
-
-  const [pendingKey, setPendingKey] = React.useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
-  const [selectMode, setSelectMode] = React.useState(false);
-  const [selectedKeys, setSelectedKeys] = React.useState<Set<string>>(
-    new Set(),
-  );
-  const [selectedTeamIds, setSelectedTeamIds] = React.useState<Set<string>>(
-    new Set(),
-  );
-
-  const managedAgents = managedAgentsQuery.data ?? [];
-  const personas = React.useMemo(
-    () => getActivePersonas(personasQuery.data ?? []),
-    [personasQuery.data],
-  );
-  const providers = providersQuery.data ?? [];
-  const defaultProvider = providers[0] ?? null;
-  const members = membersQuery.data ?? [];
-  const teams = teamsQuery.data ?? [];
-
-  const channelMemberPubkeys = React.useMemo(
-    () => new Set(members.map((m) => normalizePubkey(m.pubkey))),
-    [members],
-  );
-
-  const usableTeams = React.useMemo(
-    () => getUsableTeams(teams, personas),
-    [teams, personas],
-  );
-
-  // Build the sorted item list
-  const items: QuickAddAgentItem[] = React.useMemo(() => {
-    const result: QuickAddAgentItem[] = [];
-
-    const runningAvailable = managedAgents.filter(
-      (agent) =>
-        (agent.status === "running" || agent.status === "deployed") &&
-        !channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
-    );
-
-    const runningInChannel = managedAgents.filter(
-      (agent) =>
-        (agent.status === "running" || agent.status === "deployed") &&
-        channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
-    );
-
-    const personaIdsInChannel = new Set(
-      managedAgents
-        .filter((agent) =>
-          channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
-        )
-        .map((agent) => agent.personaId)
-        .filter((id): id is string => Boolean(id)),
-    );
-
-    const availablePersonas = personas.filter(
-      (persona) =>
-        !personaIdsInChannel.has(persona.id) &&
-        !runningAvailable.some((agent) => agent.personaId === persona.id),
-    );
-
-    const sortedRunningAvailable = [...runningAvailable].sort((a, b) => {
-      const aPersonaIdx = a.personaId ? recentIds.indexOf(a.personaId) : -1;
-      const bPersonaIdx = b.personaId ? recentIds.indexOf(b.personaId) : -1;
-      const aScore = aPersonaIdx >= 0 ? aPersonaIdx : 999;
-      const bScore = bPersonaIdx >= 0 ? bPersonaIdx : 999;
-      return aScore - bScore;
-    });
-
-    for (const agent of runningInChannel) {
-      const persona = agent.personaId
-        ? (personas.find((p) => p.id === agent.personaId) ?? null)
-        : null;
-      result.push({
-        kind: "running-in-channel",
-        agent,
-        persona,
-        label: agent.name,
-        avatarUrl: persona?.avatarUrl ?? null,
-      });
-    }
-
-    for (const agent of sortedRunningAvailable) {
-      const persona = agent.personaId
-        ? (personas.find((p) => p.id === agent.personaId) ?? null)
-        : null;
-      result.push({
-        kind: "running-available",
-        agent,
-        persona,
-        label: agent.name,
-        avatarUrl: persona?.avatarUrl ?? null,
-      });
-    }
-
-    const sortedPersonas = [...availablePersonas].sort((a, b) => {
-      const aIdx = recentIds.indexOf(a.id);
-      const bIdx = recentIds.indexOf(b.id);
-      if (aIdx >= 0 && bIdx >= 0) return aIdx - bIdx;
-      if (aIdx >= 0) return -1;
-      if (bIdx >= 0) return 1;
-      return a.displayName.localeCompare(b.displayName);
-    });
-
-    for (const persona of sortedPersonas) {
-      result.push({
-        kind: "persona",
-        persona,
-        label: persona.displayName,
-        avatarUrl: persona.avatarUrl,
-      });
-    }
-
-    return result;
-  }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
-
+    items,
+    managedAgents,
+    personas,
+    providers,
+    defaultProvider,
+    usableTeams,
+    pushRecent,
+  });
 
   // Reset state when popover closes
   React.useEffect(() => {
-    if (!open) {
-      setPendingKey(null);
-      setErrorMessage(null);
-      setSelectMode(false);
-      setSelectedKeys(new Set());
-      setSelectedTeamIds(new Set());
-    }
-  }, [open]);
-
-  // ── Single-add handlers ───────────────────────────────────────────────────
-
-  async function handleAddRunningAgent(agent: ManagedAgent) {
-    if (!channelId) return;
-    const key = `agent:${agent.pubkey}`;
-    setPendingKey(key);
-    setErrorMessage(null);
-
-    try {
-      await attachMutation.mutateAsync({ agent, ensureRunning: true });
-      if (agent.personaId) pushRecent(agent.personaId);
-      setPendingKey(null);
-    } catch (err) {
-      setErrorMessage(
-        err instanceof Error ? err.message : "Failed to add agent.",
-      );
-      setPendingKey(null);
-    }
-  }
-
-  async function handleAddPersona(persona: AgentPersona) {
-    if (!channelId) return;
-    const key = `persona:${persona.id}`;
-    setPendingKey(key);
-    setErrorMessage(null);
-
-    const { provider } = resolvePersonaProvider(
-      persona.provider,
-      providers,
-      defaultProvider,
-    );
-
-    if (!provider) {
-      setErrorMessage("No agent runtime available.");
-      setPendingKey(null);
-      return;
-    }
-
-    const usedNames = new Set(managedAgents.map((a) => a.name));
-    const instanceName = safeBotName(persona, usedNames);
-
-    try {
-      await createMutation.mutateAsync({
-        provider,
-        name: instanceName,
-        systemPrompt: persona.systemPrompt,
-        avatarUrl: persona.avatarUrl ?? undefined,
-        personaId: persona.id,
-        model: persona.model ?? undefined,
-      });
-      pushRecent(persona.id);
-      setPendingKey(null);
-    } catch (err) {
-      setErrorMessage(
-        err instanceof Error ? err.message : "Failed to add agent.",
-      );
-      setPendingKey(null);
-    }
-  }
-
-  // ── Multi-select handlers ─────────────────────────────────────────────────
-
-  function handleCancelSelect() {
-    setSelectMode(false);
-    setSelectedKeys(new Set());
-    setSelectedTeamIds(new Set());
-  }
-
-  function toggleSelection(key: string) {
-    setSelectedKeys((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-
-      // Deselect any team whose members are no longer all selected
-      setSelectedTeamIds((prevTeams) => {
-        const nextTeams = new Set(prevTeams);
-        for (const team of usableTeams) {
-          if (!nextTeams.has(team.id)) continue;
-          const resolution = resolveTeamPersonas(team, personas);
-          const allSelected = resolution.resolvedPersonas.every((persona) => {
-            const runningItem = items.find(
-              (i) => i.kind === "running-available" && i.agent.personaId === persona.id,
-            );
-            const itemKey = runningItem
-              ? getItemKey(runningItem)
-              : (() => {
-                  const personaItem = items.find(
-                    (i) => i.kind === "persona" && i.persona.id === persona.id,
-                  );
-                  return personaItem ? getItemKey(personaItem) : null;
-                })();
-            return itemKey ? next.has(itemKey) : true;
-          });
-          if (!allSelected) {
-            nextTeams.delete(team.id);
-          }
-        }
-        return nextTeams;
-      });
-
-      return next;
-    });
-  }
-
-  function handleTeamToggle(team: AgentTeam, pressed: boolean) {
-    const resolution = resolveTeamPersonas(team, personas);
-    const memberKeys: string[] = [];
-    for (const persona of resolution.resolvedPersonas) {
-      const runningItem = items.find(
-        (i) =>
-          i.kind === "running-available" && i.agent.personaId === persona.id,
-      );
-      if (runningItem) {
-        memberKeys.push(getItemKey(runningItem));
-      } else {
-        const personaItem = items.find(
-          (i) => i.kind === "persona" && i.persona.id === persona.id,
-        );
-        if (personaItem) {
-          memberKeys.push(getItemKey(personaItem));
-        }
-      }
-    }
-
-    setSelectedTeamIds((prev) => {
-      const next = new Set(prev);
-      if (pressed) {
-        next.add(team.id);
-      } else {
-        next.delete(team.id);
-      }
-      return next;
-    });
-
-    setSelectedKeys((prev) => {
-      const next = new Set(prev);
-      if (pressed) {
-        for (const key of memberKeys) {
-          next.add(key);
-        }
-      } else {
-        for (const key of memberKeys) {
-          next.delete(key);
-        }
-      }
-      return next;
-    });
-  }
-
-  async function handleBatchAdd() {
-    if (!channelId || selectedKeys.size === 0) return;
-    setPendingKey("batch");
-    setErrorMessage(null);
-
-    const usedNames = new Set(managedAgents.map((a) => a.name));
-    const toAttach: ManagedAgent[] = [];
-    const toCreate: Array<{ persona: AgentPersona; instanceName: string }> = [];
-
-    for (const key of selectedKeys) {
-      const item = items.find((i) => getItemKey(i) === key);
-      if (!item || item.kind === "running-in-channel") continue;
-
-      if (item.kind === "running-available") {
-        toAttach.push(item.agent);
-      } else {
-        const instanceName = safeBotName(item.persona, usedNames);
-        usedNames.add(instanceName);
-        toCreate.push({ persona: item.persona, instanceName });
-      }
-    }
-
-    try {
-      for (const agent of toAttach) {
-        await attachMutation.mutateAsync({ agent, ensureRunning: true });
-        if (agent.personaId) pushRecent(agent.personaId);
-      }
-
-      if (toCreate.length > 0 && defaultProvider) {
-        const inputs = toCreate.map(({ persona, instanceName }) => {
-          const { provider } = resolvePersonaProvider(
-            persona.provider,
-            providers,
-            defaultProvider,
-          );
-          const providerToUse = provider ?? defaultProvider;
-          return {
-            provider: {
-              id: providerToUse.id,
-              label: providerToUse.label,
-              command: providerToUse.command,
-              defaultArgs: providerToUse.defaultArgs,
-              mcpCommand: providerToUse.mcpCommand,
-            },
-            name: instanceName,
-            systemPrompt: persona.systemPrompt,
-            avatarUrl: persona.avatarUrl ?? undefined,
-            personaId: persona.id,
-            model: persona.model ?? undefined,
-          };
-        });
-
-        await batchCreateMutation.mutateAsync(inputs);
-        for (const { persona } of toCreate) {
-          pushRecent(persona.id);
-        }
-      }
-
-      setPendingKey(null);
-      setSelectMode(false);
-      setSelectedKeys(new Set());
-      setSelectedTeamIds(new Set());
-    } catch (err) {
-      setErrorMessage(
-        err instanceof Error ? err.message : "Failed to add agents.",
-      );
-      setPendingKey(null);
-    }
-  }
-
-  // ── Item click dispatcher ─────────────────────────────────────────────────
-
-  function handleItemClick(item: QuickAddAgentItem) {
-    if (item.kind === "running-in-channel") return;
-    if (pendingKey) return;
-    if (!channelId) return;
-
-    if (selectMode) {
-      toggleSelection(getItemKey(item));
-    } else {
-      if (item.kind === "running-available") {
-        void handleAddRunningAgent(item.agent);
-      } else {
-        void handleAddPersona(item.persona);
-      }
-    }
-  }
-
-  const isLoading =
-    managedAgentsQuery.isLoading ||
-    personasQuery.isLoading ||
-    providersQuery.isLoading;
+    if (!open) reset();
+  }, [open, reset]);
 
   const multiSelectActive = selectMode && selectedKeys.size > 0;
 
@@ -497,9 +81,11 @@ export function QuickAddAgentPopover({
         className="w-72 overflow-hidden p-0"
         sideOffset={6}
       >
+        {/* biome-ignore lint/a11y/useSemanticElements: composite widget with roving focus */}
         <div
           className="relative flex flex-col"
-          role="menu"
+          role="group"
+          aria-label="Add agent"
           onKeyDown={(e) => {
             const container = e.currentTarget;
             const buttons = Array.from(
@@ -524,23 +110,18 @@ export function QuickAddAgentPopover({
             }
           }}
         >
-          {/* Header with animated title / team toggles */}
           {/* Header */}
           <div className="flex min-h-10 items-center gap-2 border-b pl-3 pr-1.5 py-1.5">
             <h3 className="shrink-0 text-sm font-semibold text-foreground">
               Add agent
             </h3>
-
             {usableTeams.length > 0 ? (
               <div className="ml-auto flex shrink-0 items-center">
                 <Button
                   className="border border-input bg-transparent"
                   onClick={() => {
-                    if (selectMode) {
-                      handleCancelSelect();
-                    } else {
-                      setSelectMode(true);
-                    }
+                    if (selectMode) handleCancelSelect();
+                    else setSelectMode(true);
                   }}
                   size="sm"
                   type="button"
@@ -552,7 +133,7 @@ export function QuickAddAgentPopover({
             ) : null}
           </div>
 
-          {/* Team toggles row — always mounted, height animates based on selectMode */}
+          {/* Team toggles row */}
           <motion.div
             className="relative overflow-hidden"
             initial={false}
@@ -570,7 +151,7 @@ export function QuickAddAgentPopover({
                     initial={false}
                     animate={{
                       opacity: selectMode ? 1 : 0,
-                      x: selectMode ? 0 : (index === 0 ? 0 : 12),
+                      x: selectMode ? 0 : index === 0 ? 0 : 12,
                     }}
                     transition={{
                       duration: 0.2,
@@ -592,12 +173,11 @@ export function QuickAddAgentPopover({
                   </motion.div>
                 ))}
               </div>
-              {/* Gradient fade on right edge — scroll affordance */}
               <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-popover to-transparent" />
             </div>
           </motion.div>
 
-          {/* Scrollable content — clips mid-item to hint at more */}
+          {/* Scrollable content */}
           <motion.div
             className="max-h-[13.75rem] flex-1 overflow-y-auto"
             layout
@@ -619,79 +199,20 @@ export function QuickAddAgentPopover({
               >
                 {items.map((item) => {
                   const itemKey = getItemKey(item);
-                  const isInChannel = item.kind === "running-in-channel";
-                  const isItemPending =
-                    pendingKey === itemKey || pendingKey === "batch";
-                  const isSelected = selectedKeys.has(itemKey);
-
                   return (
-                    <motion.div key={itemKey} layout transition={{ duration: 0.2 }}>
-                    <button
-                      aria-selected={isInChannel || isSelected}
-                      className={cn(
-                        "flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors",
-                        isInChannel
-                          ? "cursor-default"
-                          : "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
-                        isItemPending && "pointer-events-none opacity-60",
-                        isSelected && "bg-accent/50",
-                      )}
-                      data-quick-add-item
-                      disabled={!isInChannel && Boolean(pendingKey)}
+                    <QuickAddAgentItemRow
+                      key={itemKey}
+                      item={item}
+                      itemKey={itemKey}
+                      isSelected={selectedKeys.has(itemKey)}
+                      isPending={
+                        pendingKey === itemKey || pendingKey === "batch"
+                      }
+                      selectMode={selectMode}
+                      disabled={Boolean(pendingKey)}
                       onClick={() => handleItemClick(item)}
-                      role="option"
-                      tabIndex={0}
-                      type="button"
-                    >
-                      {!isInChannel ? (
-                        <motion.div
-                          animate={{ width: selectMode ? 16 : 0, marginRight: selectMode ? 8 : 0, opacity: selectMode ? 1 : 0 }}
-                          initial={false}
-                          transition={{ duration: 0.15 }}
-                          className="shrink-0 overflow-hidden"
-                        >
-                          <div
-                            className={cn(
-                              "flex h-4 w-4 items-center justify-center rounded border transition-colors",
-                              isSelected
-                                ? "border-primary bg-primary text-primary-foreground"
-                                : "border-muted-foreground/40",
-                            )}
-                          >
-                            {isSelected ? <Check className="h-3 w-3" /> : null}
-                          </div>
-                        </motion.div>
-                      ) : null}
-                      <div className="flex min-w-0 flex-1 items-center gap-2.5">
-                        <span className={cn("shrink-0", isInChannel && "opacity-50")}>
-                          <QuickAddAgentAvatar
-                            avatarUrl={item.avatarUrl}
-                            label={item.label}
-                            isRunning={item.kind !== "persona"}
-                          />
-                        </span>
-                        <span className={cn("min-w-0 flex-1 truncate font-medium", isInChannel && "opacity-50")}>
-                          {item.label}
-                        </span>
-                        {isInChannel ? (
-                          <button
-                            className="flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              removeMutation.mutate(item.agent.pubkey);
-                            }}
-                            type="button"
-                            aria-label={`Remove ${item.label}`}
-                          >
-                            <X className="h-3.5 w-3.5" />
-                          </button>
-                        ) : null}
-                        {isItemPending ? (
-                          <Spinner className="h-3.5 w-3.5 shrink-0 text-primary" />
-                        ) : null}
-                      </div>
-                    </button>
-                    </motion.div>
+                      onRemove={(pubkey) => removeMutation.mutate(pubkey)}
+                    />
                   );
                 })}
               </div>
@@ -749,44 +270,5 @@ export function QuickAddAgentPopover({
         </div>
       </PopoverContent>
     </Popover>
-  );
-}
-
-// ── Avatar helper ─────────────────────────────────────────────────────────────
-
-function QuickAddAgentAvatar({
-  avatarUrl,
-  label,
-  isRunning,
-}: {
-  avatarUrl: string | null;
-  label: string;
-  isRunning: boolean;
-}) {
-  const initials = label
-    .split(" ")
-    .map((part) => part[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
-
-  return (
-    <div className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30">
-      {avatarUrl ? (
-        <img
-          alt={label}
-          className="h-full w-full rounded-full object-cover"
-          referrerPolicy="no-referrer"
-          src={rewriteRelayUrl(avatarUrl)}
-        />
-      ) : (
-        <span className="text-[10px] font-semibold text-muted-foreground">
-          {initials}
-        </span>
-      )}
-      {isRunning ? (
-        <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-popover bg-emerald-500" />
-      ) : null}
-    </div>
   );
 }

--- a/desktop/src/features/channels/ui/useQuickAddAgentActions.ts
+++ b/desktop/src/features/channels/ui/useQuickAddAgentActions.ts
@@ -1,0 +1,294 @@
+import * as React from "react";
+
+import {
+  useAttachManagedAgentToChannelMutation,
+  useCreateChannelManagedAgentMutation,
+  useCreateChannelManagedAgentsMutation,
+} from "@/features/agents/hooks";
+import { useRemoveChannelMemberMutation } from "@/features/channels/hooks";
+import { resolvePersonaProvider } from "@/features/agents/lib/resolvePersonaProvider";
+import { pickBotName } from "@/features/agents/lib/pickBotName";
+import { resolveTeamPersonas } from "@/features/agents/lib/teamPersonas";
+import type {
+  AcpProvider,
+  AgentPersona,
+  AgentTeam,
+  ManagedAgent,
+} from "@/shared/api/types";
+import { getItemKey, type QuickAddAgentItem } from "./useQuickAddAgentItems";
+
+function safeBotName(persona: AgentPersona, usedNames: Set<string>): string {
+  const pool = persona.namePool ?? [];
+  const name = pickBotName(pool, usedNames);
+  if (name && name.trim().length > 0) return name;
+  return persona.displayName || "Agent";
+}
+
+type UseQuickAddAgentActionsParams = {
+  channelId: string | null;
+  items: QuickAddAgentItem[];
+  managedAgents: ManagedAgent[];
+  personas: AgentPersona[];
+  providers: AcpProvider[];
+  defaultProvider: AcpProvider | null;
+  usableTeams: AgentTeam[];
+  pushRecent: (personaId: string) => void;
+};
+
+export function useQuickAddAgentActions({
+  channelId,
+  items,
+  managedAgents,
+  personas,
+  providers,
+  defaultProvider,
+  usableTeams,
+  pushRecent,
+}: UseQuickAddAgentActionsParams) {
+  const attachMutation = useAttachManagedAgentToChannelMutation(channelId);
+  const createMutation = useCreateChannelManagedAgentMutation(channelId);
+  const batchCreateMutation = useCreateChannelManagedAgentsMutation(channelId);
+  const removeMutation = useRemoveChannelMemberMutation(channelId);
+
+  const [pendingKey, setPendingKey] = React.useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+  const [selectMode, setSelectMode] = React.useState(false);
+  const [selectedKeys, setSelectedKeys] = React.useState<Set<string>>(
+    new Set(),
+  );
+  const [selectedTeamIds, setSelectedTeamIds] = React.useState<Set<string>>(
+    new Set(),
+  );
+
+  // Reset state when popover closes (caller should pass `open`)
+  const reset = React.useCallback(() => {
+    setPendingKey(null);
+    setErrorMessage(null);
+    setSelectMode(false);
+    setSelectedKeys(new Set());
+    setSelectedTeamIds(new Set());
+  }, []);
+
+  // ── Single-add handlers ─────────────────────────────────────────────────
+
+  async function handleAddRunningAgent(agent: ManagedAgent) {
+    if (!channelId) return;
+    const key = `agent:${agent.pubkey}`;
+    setPendingKey(key);
+    setErrorMessage(null);
+    try {
+      await attachMutation.mutateAsync({ agent, ensureRunning: true });
+      if (agent.personaId) pushRecent(agent.personaId);
+      setPendingKey(null);
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to add agent.",
+      );
+      setPendingKey(null);
+    }
+  }
+
+  async function handleAddPersona(persona: AgentPersona) {
+    if (!channelId) return;
+    const key = `persona:${persona.id}`;
+    setPendingKey(key);
+    setErrorMessage(null);
+    const { provider } = resolvePersonaProvider(
+      persona.provider,
+      providers,
+      defaultProvider,
+    );
+    if (!provider) {
+      setErrorMessage("No agent runtime available.");
+      setPendingKey(null);
+      return;
+    }
+    const usedNames = new Set(managedAgents.map((a) => a.name));
+    const instanceName = safeBotName(persona, usedNames);
+    try {
+      await createMutation.mutateAsync({
+        provider,
+        name: instanceName,
+        systemPrompt: persona.systemPrompt,
+        avatarUrl: persona.avatarUrl ?? undefined,
+        personaId: persona.id,
+        model: persona.model ?? undefined,
+      });
+      pushRecent(persona.id);
+      setPendingKey(null);
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to add agent.",
+      );
+      setPendingKey(null);
+    }
+  }
+
+  // ── Multi-select handlers ───────────────────────────────────────────────
+
+  function handleCancelSelect() {
+    setSelectMode(false);
+    setSelectedKeys(new Set());
+    setSelectedTeamIds(new Set());
+  }
+
+  function toggleSelection(key: string) {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      setSelectedTeamIds((prevTeams) => {
+        const nextTeams = new Set(prevTeams);
+        for (const team of usableTeams) {
+          if (!nextTeams.has(team.id)) continue;
+          const resolution = resolveTeamPersonas(team, personas);
+          const allSelected = resolution.resolvedPersonas.every((p) => {
+            const runningItem = items.find(
+              (i) =>
+                i.kind === "running-available" && i.agent.personaId === p.id,
+            );
+            const ik = runningItem
+              ? getItemKey(runningItem)
+              : (() => {
+                  const pi = items.find(
+                    (i) => i.kind === "persona" && i.persona.id === p.id,
+                  );
+                  return pi ? getItemKey(pi) : null;
+                })();
+            return ik ? next.has(ik) : true;
+          });
+          if (!allSelected) nextTeams.delete(team.id);
+        }
+        return nextTeams;
+      });
+      return next;
+    });
+  }
+
+  function handleTeamToggle(team: AgentTeam, pressed: boolean) {
+    const resolution = resolveTeamPersonas(team, personas);
+    const memberKeys: string[] = [];
+    for (const persona of resolution.resolvedPersonas) {
+      const runningItem = items.find(
+        (i) =>
+          i.kind === "running-available" && i.agent.personaId === persona.id,
+      );
+      if (runningItem) {
+        memberKeys.push(getItemKey(runningItem));
+      } else {
+        const personaItem = items.find(
+          (i) => i.kind === "persona" && i.persona.id === persona.id,
+        );
+        if (personaItem) memberKeys.push(getItemKey(personaItem));
+      }
+    }
+    setSelectedTeamIds((prev) => {
+      const next = new Set(prev);
+      if (pressed) next.add(team.id);
+      else next.delete(team.id);
+      return next;
+    });
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      for (const key of memberKeys) {
+        if (pressed) next.add(key);
+        else next.delete(key);
+      }
+      return next;
+    });
+  }
+
+  async function handleBatchAdd() {
+    if (!channelId || selectedKeys.size === 0) return;
+    setPendingKey("batch");
+    setErrorMessage(null);
+    const usedNames = new Set(managedAgents.map((a) => a.name));
+    const toAttach: ManagedAgent[] = [];
+    const toCreate: Array<{ persona: AgentPersona; instanceName: string }> = [];
+    for (const key of selectedKeys) {
+      const item = items.find((i) => getItemKey(i) === key);
+      if (!item || item.kind === "running-in-channel") continue;
+      if (item.kind === "running-available") {
+        toAttach.push(item.agent);
+      } else {
+        const instanceName = safeBotName(item.persona, usedNames);
+        usedNames.add(instanceName);
+        toCreate.push({ persona: item.persona, instanceName });
+      }
+    }
+    try {
+      for (const agent of toAttach) {
+        await attachMutation.mutateAsync({ agent, ensureRunning: true });
+        if (agent.personaId) pushRecent(agent.personaId);
+      }
+      if (toCreate.length > 0 && defaultProvider) {
+        const inputs = toCreate.map(({ persona, instanceName }) => {
+          const { provider } = resolvePersonaProvider(
+            persona.provider,
+            providers,
+            defaultProvider,
+          );
+          const providerToUse = provider ?? defaultProvider;
+          return {
+            provider: {
+              id: providerToUse.id,
+              label: providerToUse.label,
+              command: providerToUse.command,
+              defaultArgs: providerToUse.defaultArgs,
+              mcpCommand: providerToUse.mcpCommand,
+            },
+            name: instanceName,
+            systemPrompt: persona.systemPrompt,
+            avatarUrl: persona.avatarUrl ?? undefined,
+            personaId: persona.id,
+            model: persona.model ?? undefined,
+          };
+        });
+        await batchCreateMutation.mutateAsync(inputs);
+        for (const { persona } of toCreate) pushRecent(persona.id);
+      }
+      setPendingKey(null);
+      setSelectMode(false);
+      setSelectedKeys(new Set());
+      setSelectedTeamIds(new Set());
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to add agents.",
+      );
+      setPendingKey(null);
+    }
+  }
+
+  // ── Item click dispatcher ───────────────────────────────────────────────
+
+  function handleItemClick(item: QuickAddAgentItem) {
+    if (item.kind === "running-in-channel") return;
+    if (pendingKey) return;
+    if (!channelId) return;
+    if (selectMode) {
+      toggleSelection(getItemKey(item));
+    } else if (item.kind === "running-available") {
+      void handleAddRunningAgent(item.agent);
+    } else {
+      void handleAddPersona(item.persona);
+    }
+  }
+
+  return {
+    pendingKey,
+    errorMessage,
+    selectMode,
+    setSelectMode,
+    selectedKeys,
+    selectedTeamIds,
+    reset,
+    handleCancelSelect,
+    handleTeamToggle,
+    handleBatchAdd,
+    handleItemClick,
+    removeMutation,
+  };
+}

--- a/desktop/src/features/channels/ui/useQuickAddAgentItems.ts
+++ b/desktop/src/features/channels/ui/useQuickAddAgentItems.ts
@@ -1,0 +1,213 @@
+import * as React from "react";
+
+import {
+  useAcpProvidersQuery,
+  useManagedAgentsQuery,
+  usePersonasQuery,
+  useTeamsQuery,
+} from "@/features/agents/hooks";
+import { useChannelMembersQuery } from "@/features/channels/hooks";
+import { getActivePersonas } from "@/features/agents/lib/catalog";
+import { useBotRecents } from "@/features/agents/lib/useBotRecents";
+import {
+  getUsableTeams,
+  resolveTeamPersonas,
+} from "@/features/agents/lib/teamPersonas";
+import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type RunningAvailableItem = {
+  kind: "running-available";
+  agent: ManagedAgent;
+  persona: AgentPersona | null;
+  label: string;
+  avatarUrl: string | null;
+};
+
+export type RunningInChannelItem = {
+  kind: "running-in-channel";
+  agent: ManagedAgent;
+  persona: AgentPersona | null;
+  label: string;
+  avatarUrl: string | null;
+};
+
+export type PersonaItem = {
+  kind: "persona";
+  persona: AgentPersona;
+  label: string;
+  avatarUrl: string | null;
+};
+
+export type QuickAddAgentItem =
+  | RunningAvailableItem
+  | RunningInChannelItem
+  | PersonaItem;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+export function getItemKey(item: QuickAddAgentItem): string {
+  switch (item.kind) {
+    case "persona":
+      return `persona:${item.persona.id}`;
+    case "running-available":
+    case "running-in-channel":
+      return `agent:${item.agent.pubkey}`;
+  }
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useQuickAddAgentItems(
+  channelId: string | null,
+  enabled: boolean,
+) {
+  const managedAgentsQuery = useManagedAgentsQuery();
+  const personasQuery = usePersonasQuery();
+  const providersQuery = useAcpProvidersQuery();
+  const teamsQuery = useTeamsQuery();
+  const membersQuery = useChannelMembersQuery(channelId, enabled);
+  const { recentIds, pushRecent } = useBotRecents();
+
+  const managedAgents = managedAgentsQuery.data ?? [];
+  const personas = React.useMemo(
+    () => getActivePersonas(personasQuery.data ?? []),
+    [personasQuery.data],
+  );
+  const providers = providersQuery.data ?? [];
+  const defaultProvider = providers[0] ?? null;
+  const members = membersQuery.data ?? [];
+  const teams = teamsQuery.data ?? [];
+
+  const channelMemberPubkeys = React.useMemo(
+    () => new Set(members.map((m) => normalizePubkey(m.pubkey))),
+    [members],
+  );
+
+  const usableTeams = React.useMemo(() => {
+    const allUsable = getUsableTeams(teams, personas);
+    // Filter out teams whose members are ALL already in the channel
+    return allUsable.filter((team) => {
+      const resolution = resolveTeamPersonas(team, personas);
+      return resolution.resolvedPersonas.some((persona) => {
+        // Check if this persona has a running agent not in channel, or no agent at all
+        const runningAgent = managedAgents.find(
+          (a) =>
+            a.personaId === persona.id &&
+            (a.status === "running" || a.status === "deployed"),
+        );
+        if (runningAgent) {
+          return !channelMemberPubkeys.has(
+            normalizePubkey(runningAgent.pubkey),
+          );
+        }
+        // Persona has no running agent — it's addable (will create new)
+        return true;
+      });
+    });
+  }, [teams, personas, managedAgents, channelMemberPubkeys]);
+
+  const items: QuickAddAgentItem[] = React.useMemo(() => {
+    const result: QuickAddAgentItem[] = [];
+
+    const runningAvailable = managedAgents.filter(
+      (agent) =>
+        (agent.status === "running" || agent.status === "deployed") &&
+        !channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
+    );
+
+    const runningInChannel = managedAgents.filter(
+      (agent) =>
+        (agent.status === "running" || agent.status === "deployed") &&
+        channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
+    );
+
+    const personaIdsInChannel = new Set(
+      managedAgents
+        .filter((agent) =>
+          channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
+        )
+        .map((agent) => agent.personaId)
+        .filter((id): id is string => Boolean(id)),
+    );
+
+    const availablePersonas = personas.filter(
+      (persona) =>
+        !personaIdsInChannel.has(persona.id) &&
+        !runningAvailable.some((agent) => agent.personaId === persona.id),
+    );
+
+    const sortedRunningAvailable = [...runningAvailable].sort((a, b) => {
+      const aPersonaIdx = a.personaId ? recentIds.indexOf(a.personaId) : -1;
+      const bPersonaIdx = b.personaId ? recentIds.indexOf(b.personaId) : -1;
+      const aScore = aPersonaIdx >= 0 ? aPersonaIdx : 999;
+      const bScore = bPersonaIdx >= 0 ? bPersonaIdx : 999;
+      return aScore - bScore;
+    });
+
+    for (const agent of runningInChannel) {
+      const persona = agent.personaId
+        ? (personas.find((p) => p.id === agent.personaId) ?? null)
+        : null;
+      result.push({
+        kind: "running-in-channel",
+        agent,
+        persona,
+        label: agent.name,
+        avatarUrl: persona?.avatarUrl ?? null,
+      });
+    }
+
+    for (const agent of sortedRunningAvailable) {
+      const persona = agent.personaId
+        ? (personas.find((p) => p.id === agent.personaId) ?? null)
+        : null;
+      result.push({
+        kind: "running-available",
+        agent,
+        persona,
+        label: agent.name,
+        avatarUrl: persona?.avatarUrl ?? null,
+      });
+    }
+
+    const sortedPersonas = [...availablePersonas].sort((a, b) => {
+      const aIdx = recentIds.indexOf(a.id);
+      const bIdx = recentIds.indexOf(b.id);
+      if (aIdx >= 0 && bIdx >= 0) return aIdx - bIdx;
+      if (aIdx >= 0) return -1;
+      if (bIdx >= 0) return 1;
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+    for (const persona of sortedPersonas) {
+      result.push({
+        kind: "persona",
+        persona,
+        label: persona.displayName,
+        avatarUrl: persona.avatarUrl,
+      });
+    }
+
+    return result;
+  }, [managedAgents, personas, channelMemberPubkeys, recentIds]);
+
+  const isLoading =
+    managedAgentsQuery.isLoading ||
+    personasQuery.isLoading ||
+    providersQuery.isLoading;
+
+  return {
+    items,
+    isLoading,
+    managedAgents,
+    personas,
+    providers,
+    defaultProvider,
+    usableTeams,
+    teamsQuery,
+    pushRecent,
+  };
+}

--- a/desktop/src/shared/ui/dropdown-menu.tsx
+++ b/desktop/src/shared/ui/dropdown-menu.tsx
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
         className,
       )}

--- a/desktop/src/shared/ui/toggle.tsx
+++ b/desktop/src/shared/ui/toggle.tsx
@@ -13,7 +13,7 @@ const toggleVariants = cva(
         outline:
           "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
         subtle:
-          "border border-input bg-transparent data-[state=on]:bg-primary/10 data-[state=on]:border-primary data-[state=on]:!text-foreground",
+          "border border-input bg-transparent data-[state=on]:bg-primary/10 data-[state=on]:border-2 data-[state=on]:border-primary data-[state=on]:!text-foreground",
       },
       size: {
         default: "h-9 px-3 min-w-9",

--- a/desktop/src/shared/ui/toggle.tsx
+++ b/desktop/src/shared/ui/toggle.tsx
@@ -12,6 +12,8 @@ const toggleVariants = cva(
         default: "bg-transparent",
         outline:
           "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
+        subtle:
+          "border border-input bg-transparent data-[state=on]:!bg-transparent data-[state=on]:border-accent-foreground data-[state=on]:!text-accent-foreground",
       },
       size: {
         default: "h-9 px-3 min-w-9",

--- a/desktop/src/shared/ui/toggle.tsx
+++ b/desktop/src/shared/ui/toggle.tsx
@@ -13,7 +13,7 @@ const toggleVariants = cva(
         outline:
           "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
         subtle:
-          "border border-input bg-transparent data-[state=on]:!bg-transparent data-[state=on]:border-accent-foreground data-[state=on]:!text-accent-foreground",
+          "border border-input bg-transparent data-[state=on]:!bg-transparent data-[state=on]:border-primary data-[state=on]:!text-foreground",
       },
       size: {
         default: "h-9 px-3 min-w-9",

--- a/desktop/src/shared/ui/toggle.tsx
+++ b/desktop/src/shared/ui/toggle.tsx
@@ -13,7 +13,7 @@ const toggleVariants = cva(
         outline:
           "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
         subtle:
-          "border border-input bg-transparent data-[state=on]:bg-primary/10 data-[state=on]:border-2 data-[state=on]:border-primary data-[state=on]:!text-foreground",
+          "border border-input bg-transparent data-[state=on]:bg-primary/10 data-[state=on]:border-primary data-[state=on]:!text-foreground",
       },
       size: {
         default: "h-9 px-3 min-w-9",

--- a/desktop/src/shared/ui/toggle.tsx
+++ b/desktop/src/shared/ui/toggle.tsx
@@ -13,7 +13,7 @@ const toggleVariants = cva(
         outline:
           "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
         subtle:
-          "border border-input bg-transparent data-[state=on]:!bg-transparent data-[state=on]:border-primary data-[state=on]:!text-foreground",
+          "border border-input bg-transparent data-[state=on]:bg-primary/10 data-[state=on]:border-primary data-[state=on]:!text-foreground",
       },
       size: {
         default: "h-9 px-3 min-w-9",

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -83,6 +83,7 @@ async function addGenericAgent(
   await page.getByTestId(`channel-${channelName}`).click();
   await expect(page.getByTestId("chat-title")).toHaveText(channelName);
   await page.getByTestId("channel-add-bot-trigger").click();
+  await page.getByTestId("quick-add-more-options").click();
   await expect(page.getByRole("heading", { name: "Add agents" })).toBeVisible();
   await page.getByRole("button", { name: "Generic" }).click();
   await page.locator("#channel-generic-name").fill(agentName);
@@ -852,6 +853,7 @@ test("open-channel members can add agents from the header", async ({
   await expect(addAgentTrigger).toBeEnabled();
 
   await addAgentTrigger.click();
+  await page.getByTestId("quick-add-more-options").click();
   await expect(page.getByRole("heading", { name: "Add agents" })).toBeVisible();
   await expect(page.getByTestId("add-channel-bot-dialog-header")).toBeVisible();
   await expect(


### PR DESCRIPTION
## Summary

Replace the "click + → full dialog" flow with a lightweight quick-add popover that makes adding an agent to a channel a one-click action. The full dialog stays as an advanced escape hatch via "More options…".

## What changed

### New: `QuickAddAgentPopover` component
- Lightweight Radix popover (dropdown-menu energy)
- Shows agents sorted by state: running (not in channel) → running (already here, muted) → available personas
- One-click to attach a running agent or spin up a persona
- "More options…" at the bottom opens the existing `AddChannelBotDialog`
- Arrow-key navigation via roving focus
- Valid ARIA: `role="listbox"` scoped to item list only

### Two trigger points, same popover
- The `+` button in `ChannelMembersBar` now opens the popover (not the dialog directly)
- New "Add agent" ghost button at the bottom of the sidebar's Bots section

### Dialog ownership lifted
- Single `AddChannelBotDialog` instance owned by `ChannelScreen`
- Both trigger points share it via props — no duplicate dialog risk

### Extracted utilities
- `sortProviders` — shared "goose first" provider sort
- `safeBotName` — defensive `pickBotName` wrapper with fallback chain

### E2E tests updated
- Tests now click through popover → "More options…" before asserting on the full dialog

## Key decisions
- Uses `useBotRecents` for smart ordering (recents float to top)
- Running agents use `useAttachManagedAgentToChannelMutation`
- Personas use `useCreateChannelManagedAgentMutation` (leverages existing reuse logic from PR #621)
- Force-new-instance stays buried in the full dialog — not in the popover
- Null `channelId` guard: popover renders children-only, handlers early-return
- Discriminated union types enforce valid item states at compile time