### PR TITLE
fix: surface swallowed errors across crates and emit turn failures to activity log

### DIFF
--- a/crates/sprout-acp/src/lib.rs
+++ b/crates/sprout-acp/src/lib.rs
@@ -474,7 +474,7 @@ async fn publish_relay_observer_event(
         }
     };
     if let Err(error) = publisher.publish_event(signed).await {
-        tracing::debug!("relay observer event dropped: {error}");
+        tracing::warn!("relay observer event dropped: {error}");
     }
 }
 
@@ -2032,6 +2032,24 @@ fn handle_prompt_result(
     };
     let agent_index = result.agent.index;
 
+    let channel_id = match &result.source {
+        PromptSource::Channel(ch) => Some(*ch),
+        PromptSource::Heartbeat => None,
+    };
+    let emit_turn_error = |error_msg: &str| {
+        if let Some(ref observer) = observer {
+            observer.emit(
+                "turn_error",
+                Some(agent_index),
+                &observer::context_for(channel_id, None, None),
+                serde_json::json!({
+                    "outcome": outcome_label,
+                    "error": error_msg,
+                }),
+            );
+        }
+    };
+
     match result.outcome {
         // Successful prompt — return agent to pool.
         PromptOutcome::Ok(_) => {
@@ -2044,11 +2062,15 @@ fn handle_prompt_result(
         }
         // Fatal outcomes: the agent subprocess is dead or poisoned — respawn it.
         PromptOutcome::AgentExited | PromptOutcome::Timeout => {
-            tracing::debug!(
+            tracing::warn!(
                 agent = agent_index,
                 outcome = outcome_label,
                 "agent_returned — respawning"
             );
+            emit_turn_error(match outcome_label {
+                "exited" => "Agent process exited unexpectedly",
+                _ => "Agent timed out",
+            });
             let index = result.agent.index;
             let slot_history = &mut crash_history[index];
             if !spawn_respawn_task(
@@ -2104,6 +2126,7 @@ fn handle_prompt_result(
                     error = %e,
                     "transport/protocol error — respawning agent"
                 );
+                emit_turn_error(&e.to_string());
                 let index = result.agent.index;
                 let slot_history = &mut crash_history[index];
                 if !spawn_respawn_task(
@@ -2126,6 +2149,7 @@ fn handle_prompt_result(
                     error = %e,
                     "agent_returned (application error — pipe intact)"
                 );
+                emit_turn_error(&e.to_string());
                 pool.return_agent(result.agent);
             }
         }
@@ -2178,6 +2202,18 @@ fn recover_panicked_agent(
     } else {
         *heartbeat_in_flight = false;
         tracing::warn!("cleared wedged heartbeat_in_flight from panicked agent {i}");
+    }
+
+    if let Some(ref observer) = observer {
+        observer.emit(
+            "agent_panic",
+            Some(i),
+            &observer::context_for(meta.channel_id, None, None),
+            serde_json::json!({
+                "outcome": "panic",
+                "error": format!("Agent task panicked: {join_error}"),
+            }),
+        );
     }
 
     // Panics count as crashes for the circuit breaker.

--- a/crates/sprout-acp/src/lib.rs
+++ b/crates/sprout-acp/src/lib.rs
@@ -2101,6 +2101,7 @@ fn handle_prompt_result(
                 tracing::warn!(
                     agent = agent_index,
                     outcome = outcome_label,
+                    error = %e,
                     "transport/protocol error — respawning agent"
                 );
                 let index = result.agent.index;
@@ -2119,9 +2120,10 @@ fn handle_prompt_result(
                     return LoopAction::Exit;
                 }
             } else {
-                tracing::debug!(
+                tracing::warn!(
                     agent = agent_index,
                     outcome = outcome_label,
+                    error = %e,
                     "agent_returned (application error — pipe intact)"
                 );
                 pool.return_agent(result.agent);

--- a/crates/sprout-acp/src/pool.rs
+++ b/crates/sprout-acp/src/pool.rs
@@ -1945,14 +1945,14 @@ pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str
     let builder = match sprout_sdk::build_reaction(target_id, emoji) {
         Ok(b) => b,
         Err(e) => {
-            tracing::debug!(event_id, emoji, "reaction add: build failed: {e}");
+            tracing::warn!(event_id, emoji, "reaction add: build failed: {e}");
             return;
         }
     };
     let event = match builder.sign_with_keys(&rest.keys) {
         Ok(e) => e,
         Err(e) => {
-            tracing::debug!(event_id, emoji, "reaction add: sign failed: {e}");
+            tracing::warn!(event_id, emoji, "reaction add: sign failed: {e}");
             return;
         }
     };
@@ -2026,14 +2026,14 @@ pub(crate) async fn reaction_remove(rest: &crate::relay::RestClient, event_id: &
     let builder = match sprout_sdk::build_remove_reaction(target_id) {
         Ok(b) => b,
         Err(e) => {
-            tracing::debug!(event_id, emoji, "reaction remove: build failed: {e}");
+            tracing::warn!(event_id, emoji, "reaction remove: build failed: {e}");
             return;
         }
     };
     let event = match builder.sign_with_keys(&rest.keys) {
         Ok(e) => e,
         Err(e) => {
-            tracing::debug!(event_id, emoji, "reaction remove: sign failed: {e}");
+            tracing::warn!(event_id, emoji, "reaction remove: sign failed: {e}");
             return;
         }
     };

--- a/crates/sprout-media/src/upload.rs
+++ b/crates/sprout-media/src/upload.rs
@@ -82,7 +82,7 @@ pub async fn process_upload(
             uploaded_at,
         )),
         Err(e) => {
-            tracing::warn!(sha256 = %sha256, "metadata generation failed; orphan blob left for GC");
+            tracing::warn!(sha256 = %sha256, error = %e, "metadata generation failed; orphan blob left for GC");
             Err(e)
         }
     }

--- a/crates/sprout-relay/src/api/mod.rs
+++ b/crates/sprout-relay/src/api/mod.rs
@@ -34,7 +34,7 @@ pub(crate) fn not_found(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
 /// `git/transport.rs`, and `audio/handler.rs`.
 pub mod relay_members {
     use axum::{http::StatusCode, response::Json};
-    use tracing::debug;
+    use tracing::{debug, info};
 
     use crate::state::AppState;
 
@@ -95,7 +95,7 @@ pub mod relay_members {
                         }
                     }
                     Err(e) => {
-                        debug!(agent = %pubkey_hex, "NIP-OA auth tag invalid: {e}");
+                        info!(agent = %pubkey_hex, "NIP-OA auth tag invalid: {e}");
                     }
                 }
             }
@@ -126,7 +126,7 @@ pub mod relay_members {
         match sprout_sdk::nip_oa::verify_auth_tag(tag_json, &agent_pubkey) {
             Ok(owner) => Some(owner),
             Err(e) => {
-                debug!("extract_nip_oa_owner: invalid auth tag: {e}");
+                info!("extract_nip_oa_owner: invalid auth tag: {e}");
                 None
             }
         }

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -118,8 +118,8 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             .await
             {
                 Ok(owner) => owner,
-                Err(_) => {
-                    warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), "not a relay member");
+                Err(e) => {
+                    warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), error = ?e, "not a relay member");
                     metrics::counter!("sprout_auth_failures_total", "reason" => "not_relay_member")
                         .increment(1);
                     *conn.auth_state.write().await = AuthState::Failed;

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -1472,10 +1472,16 @@ async fn handle_standard_deletion_event(
                                 0,
                             )
                             .unwrap_or_else(chrono::Utc::now);
-                            let _ = state
+                            if let Err(e) = state
                                 .db
                                 .remove_reaction(&react_target_id, react_target_ts, &actor, emoji)
-                                .await;
+                                .await
+                            {
+                                tracing::warn!(
+                                    error = %e,
+                                    "failed to remove reaction from DB during NIP-09 deletion"
+                                );
+                            }
                         }
                     }
                 }
@@ -1763,7 +1769,7 @@ async fn handle_git_repo_announcement(event: &Event, state: &Arc<AppState>) -> a
         ("uploadpack.allowTipSHA1InWant", "true"),
         ("uploadpack.allowReachableSHA1InWant", "true"),
     ] {
-        let _ = Command::new("git")
+        match Command::new("git")
             .args(["config", "--file"])
             .arg(repo_dir.join("config"))
             .args([key, value])
@@ -1773,7 +1779,26 @@ async fn handle_git_repo_announcement(event: &Event, state: &Arc<AppState>) -> a
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("HOME", "/dev/null")
             .output()
-            .await;
+            .await
+        {
+            Ok(output) if !output.status.success() => {
+                tracing::warn!(
+                    key,
+                    value,
+                    status = %output.status,
+                    "git config failed for bare repo"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    key,
+                    value,
+                    error = %e,
+                    "git config command failed for bare repo"
+                );
+            }
+            _ => {}
+        }
     }
 
     // Install pre-receive hook for permission enforcement.
@@ -1938,7 +1963,7 @@ pub async fn reconcile_channel_events(state: &Arc<AppState>) -> anyhow::Result<(
     for channel in &channels {
         // Check if kind:39000 event already exists for this channel.
         let channel_id_str = channel.id.to_string();
-        let existing = state
+        let existing = match state
             .db
             .query_events(&EventQuery {
                 kinds: Some(vec![39000]),
@@ -1947,12 +1972,22 @@ pub async fn reconcile_channel_events(state: &Arc<AppState>) -> anyhow::Result<(
                 ..Default::default()
             })
             .await
-            .unwrap_or_default();
+        {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    channel_id = %channel.id,
+                    error = %e,
+                    "reconcile: failed to query existing discovery events"
+                );
+                continue;
+            }
+        };
 
         if existing.is_empty() {
             // No discovery event — emit one.
             if let Err(e) = emit_group_discovery_events(state, channel.id).await {
-                tracing::debug!(
+                tracing::warn!(
                     channel_id = %channel.id,
                     error = %e,
                     "reconcile: failed to emit discovery events"

--- a/crates/sprout-relay/src/main.rs
+++ b/crates/sprout-relay/src/main.rs
@@ -261,7 +261,7 @@ async fn main() -> anyhow::Result<()> {
                 {
                     Ok(()) => {}
                     Err(e) => {
-                        tracing::debug!(error = %e, "channel reconciliation attempt failed");
+                        tracing::warn!(error = %e, "channel reconciliation attempt failed");
                     }
                 }
             }

--- a/desktop/src/features/agents/ui/agentSessionTranscript.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.ts
@@ -286,6 +286,21 @@ export function processTranscriptEvent(
       event.timestamp,
       channelId,
     );
+  } else if (event.kind === "turn_error" || event.kind === "agent_panic") {
+    const payload = asRecord(event.payload);
+    const outcome = asString(payload.outcome) ?? "error";
+    const error = asString(payload.error) ?? "Unknown error";
+    const title =
+      event.kind === "agent_panic" ? "Agent error (crash)" : "Turn error";
+    upsertTextItem(
+      d,
+      `${event.kind}:${ch}:${event.turnId ?? event.seq}`,
+      "lifecycle",
+      title,
+      `${outcome}: ${error}`,
+      event.timestamp,
+      channelId,
+    );
   } else if (event.kind === "acp_read" || event.kind === "acp_write") {
     const payload = asRecord(event.payload);
     const method = asString(payload.method);


### PR DESCRIPTION
Fix a systemic pattern of swallowed or under-logged errors across `sprout-acp`, `sprout-relay`, and `sprout-media`, and introduce `turn_error`/`agent_panic` observer events so agent failures appear in the Activity Log UI.

The original trigger was Jim agent silently dead-lettering every batch dispatch because `PromptOutcome::Error` was logged at `debug` without the error value — completely invisible at the default `sprout_acp=info` log level. An audit revealed the same pattern across multiple crates: errors discarded with `let _ =`, logged at `debug` in critical paths, or logged without the actual error content.

**Error logging fixes:**
- `sprout-acp`: upgrade `AgentExited`/`Timeout` and relay observer publish failures from `debug!` → `warn!`; add `error = %e` to error logs that omitted it
- `sprout-acp`: upgrade reaction sign/build failures from `debug!` → `warn!` (code bugs, not transient network errors)
- `sprout-relay`: upgrade channel reconciliation failures from `debug!` → `warn!`; replace silent `let _ =` on DB and `git config` operations with logged errors; fix `.unwrap_or_default()` that hid DB query failures; capture discarded enforcement error in auth handler
- `sprout-relay`: upgrade NIP-OA auth tag validation failures from `debug!` → `info!` for security auditability
- `sprout-media`: add missing `error = %e` to upload metadata `warn!`

**Activity log integration:**
- Emit `turn_error` observer event when a prompt fails (`PromptOutcome::Error`, `AgentExited`, `Timeout`) so failures appear as red lifecycle entries in the Agent Activity Log panel
- Emit `agent_panic` observer event when an agent task panics, with the `JoinError` message
- Frontend handler in `agentSessionTranscript.ts` renders both as `lifecycle` items with error-flagged titles, which the existing `LifecycleItem` component styles in `text-destructive`