### PR TITLE
fix: unblock Renovate PR creation and reduce cargo branch sprawl

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
-  "recreateWhen": "never",
+  "prCreation": "immediate",
+  "automerge": false,
+  "recreateWhen": "always",
   "separateMinorPatch": true,
+  "postUpdateOptions": ["cargo:updateLockfile"],
   "packageRules": [
     {
-      "description": "Keep Rust crate updates isolated because 0.x minor releases often contain breaking changes.",
+      "description": "Keep Rust crate updates isolated because 0.x minor releases often contain breaking changes. Group all minor updates per crate (don't split by individual version).",
       "matchManagers": ["cargo"],
       "groupName": null,
       "separateMinorPatch": true,
-      "separateMultipleMinor": true
+      "separateMultipleMinor": false
     }
   ]
 }


### PR DESCRIPTION
Fix a deadlock that has prevented Renovate from opening any PRs since May 11, leaving 75+ dependency updates queued with no visibility.

The org-inherited config (`block/renovate-config`) sets `prCreation: "not-pending"`, which tells Renovate to wait for CI checks before opening a PR. But CI only triggers on `pull_request` events — so checks never run on `renovate/*` branches, PRs never get created, and the cycle is permanent. Compounding this, `automerge: true` (org) means failures are silent: there are no PRs to review, just stale branches. The Dependency Dashboard (issue #1) has been accumulating updates while `separateMultipleMinor: true` exploded crates like `nostr` into 8 separate branches (one per minor from 0.37 to 0.44).

- Override `prCreation` to `"immediate"` — PRs are created on branch push, CI runs via the `pull_request` trigger
- Override `automerge` to `false` — human review required until the 75-update backlog is cleared and CI is consistently green; re-enable after a few clean weeks
- Switch `recreateWhen` to `"always"` — previously-closed PRs (#469, #300) can be retried
- Add `postUpdateOptions: ["cargo:updateLockfile"]` — Renovate runs `cargo update --workspace` after manifest changes, keeping both `Cargo.lock` files consistent
- Set `separateMultipleMinor: false` for cargo — one PR per crate updating to latest minor, not one PR per intermediate version

Closes the config gap introduced in #531. The 9 stale `renovate/*` branches have already been deleted. After this merges, trigger a manual Renovate run via the Dependency Dashboard (issue #1).