### PR TITLE
fix(renovate): re-enable automerge for non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,11 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "prCreation": "immediate",
-  "automerge": false,
+  "automerge": true,
   "recreateWhen": "always",
   "separateMinorPatch": true,
   "postUpdateOptions": ["cargo:updateLockfile"],
   "packageRules": [
+    {
+      "description": "Major version bumps often require code changes — require human review.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
     {
       "description": "Keep Rust crate updates isolated because 0.x minor releases often contain breaking changes. Group all minor updates per crate (don't split by individual version).",
       "matchManagers": ["cargo"],


### PR DESCRIPTION
## Summary

- Re-enables `automerge: true` so Renovate handles the merge→rebase→merge chain automatically for patch and minor updates
- Adds a `packageRules` entry to keep `automerge: false` for major version bumps, which often require code changes

Manual merge-wait-rebase cycles for 47 queued Renovate PRs is untenable — each merge causes lockfile conflicts on the remaining PRs, requiring a Renovate rebase cycle before the next can merge.