### PR TITLE
Fix SPROUT_SHARE_IDENTITY worktree dev workflow breaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ doc/
 # Local identity files
 identity.key
 **/identity.key
+
+# Claude Code worktrees
+.claude/worktrees/

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -42,6 +42,10 @@ pub fn is_shared_identity() -> bool {
     std::env::var("SPROUT_SHARE_IDENTITY")
         .map(|v| v == "1")
         .unwrap_or(false)
+        && std::env::var("SPROUT_PRIVATE_KEY")
+            .ok()
+            .and_then(|k| Keys::parse(k.trim()).ok())
+            .is_some()
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -38,6 +38,13 @@ pub fn get_default_relay_url() -> String {
 }
 
 #[tauri::command]
+pub fn is_shared_identity() -> bool {
+    std::env::var("SPROUT_SHARE_IDENTITY")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+#[tauri::command]
 pub fn get_relay_ws_url(state: State<'_, AppState>) -> String {
     relay_ws_url_with_override(&state)
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -461,6 +461,7 @@ pub fn run() {
             get_presence,
             set_presence,
             get_default_relay_url,
+            is_shared_identity,
             get_relay_ws_url,
             get_relay_http_url,
             get_media_proxy_port,

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -16,6 +16,7 @@ import { useWorkspaceInit } from "@/features/workspaces/useWorkspaceInit";
 import { useWorkspaces } from "@/features/workspaces/useWorkspaces";
 import { WelcomeSetup } from "@/features/workspaces/ui/WelcomeSetup";
 import { createSproutQueryClient } from "@/shared/api/queryClient";
+import { isSharedIdentity as isSharedIdentityCmd } from "@/shared/api/tauri";
 import { listenForDeepLinks } from "@/shared/deep-link";
 
 function AppLoadingGate() {
@@ -44,8 +45,8 @@ function WorkspaceQueryProvider({ children }: { children: ReactNode }) {
   );
 }
 
-function AppReady() {
-  const onboarding = useAppOnboardingState();
+function AppReady({ isSharedIdentity }: { isSharedIdentity: boolean }) {
+  const onboarding = useAppOnboardingState(isSharedIdentity);
 
   if (onboarding.stage === "onboarding") {
     return (
@@ -69,6 +70,16 @@ export function App() {
     void getCurrentWindow().show();
   }, []);
 
+  const [sharedIdentity, setSharedIdentity] = useState<boolean | null>(null);
+  useEffect(() => {
+    isSharedIdentityCmd()
+      .then(setSharedIdentity)
+      .catch((err) => {
+        console.warn("is_shared_identity command failed:", err);
+        setSharedIdentity(false);
+      });
+  }, []);
+
   const {
     activeWorkspace,
     reinitKey,
@@ -90,13 +101,20 @@ export function App() {
   // Composite key: changes when workspace ID changes OR when
   // the active workspace's config is updated (relayUrl/token).
   const workspaceKey = `${activeWorkspace?.id ?? "none"}-${reinitKey}`;
-  const workspace = useWorkspaceInit(activeWorkspace, workspaceKey);
+  const workspace = useWorkspaceInit(activeWorkspace, workspaceKey, sharedIdentity ?? false);
 
   const handleSetupComplete = useCallback(() => {
     // Force a full reload so useWorkspaces re-initializes from localStorage.
     // This only runs once — during first-run setup when no workspace existed.
     window.location.reload();
   }, []);
+
+  // Wait for the shared-identity IPC call to resolve before rendering
+  // anything that depends on it. Without this gate, children briefly see
+  // isSharedIdentity=false and may flash WelcomeSetup or the onboarding flow.
+  if (sharedIdentity === null) {
+    return <AppLoadingGate />;
+  }
 
   // Show welcome setup for first-run users with no workspaces
   if (workspace.needsSetup) {
@@ -118,7 +136,7 @@ export function App() {
 
   return (
     <WorkspaceQueryProvider key={workspaceKey}>
-      <AppReady key={workspaceKey} />
+      <AppReady key={workspaceKey} isSharedIdentity={sharedIdentity} />
     </WorkspaceQueryProvider>
   );
 }

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -101,7 +101,11 @@ export function App() {
   // Composite key: changes when workspace ID changes OR when
   // the active workspace's config is updated (relayUrl/token).
   const workspaceKey = `${activeWorkspace?.id ?? "none"}-${reinitKey}`;
-  const workspace = useWorkspaceInit(activeWorkspace, workspaceKey, sharedIdentity ?? false);
+  const workspace = useWorkspaceInit(
+    activeWorkspace,
+    workspaceKey,
+    sharedIdentity ?? false,
+  );
 
   const handleSetupComplete = useCallback(() => {
     // Force a full reload so useWorkspaces re-initializes from localStorage.

--- a/desktop/src/features/onboarding/hooks.ts
+++ b/desktop/src/features/onboarding/hooks.ts
@@ -4,7 +4,7 @@ import { useQueryClient, type QueryStatus } from "@tanstack/react-query";
 import { channelsQueryKey } from "@/features/channels/hooks";
 import { useProfileQuery } from "@/features/profile/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
-import { getChannels, isSharedIdentity, joinChannel } from "@/shared/api/tauri";
+import { getChannels, joinChannel } from "@/shared/api/tauri";
 
 const DEFAULT_AUTO_JOIN_CHANNEL_NAME = "general";
 
@@ -130,14 +130,15 @@ export function useFirstRunOnboardingGate({
   hasExistingProfile,
   identityIsFetching,
   identityStatus,
-  isSharedIdentity: isSharedIdentityProp,
+  isSharedIdentity,
   profileStatus,
 }: UseFirstRunOnboardingGateOptions) {
   const [gateState, setGateState] = React.useState<OnboardingGateState>(() =>
     createOnboardingGateState(currentPubkey),
   );
   const activeGateState = resolveActiveGateState(gateState, currentPubkey);
-  const { hasSettledCurrentPubkey } = activeGateState;
+  const { hasCompletedCurrentPubkey, hasSettledCurrentPubkey } =
+    activeGateState;
 
   React.useEffect(() => {
     setGateState((current) =>
@@ -148,7 +149,34 @@ export function useFirstRunOnboardingGate({
   }, [currentPubkey]);
 
   React.useEffect(() => {
-    if ((hasSettledCurrentPubkey && !isSharedIdentityProp) || !currentPubkey) {
+    // Fast-path: shared identity worktrees have already onboarded in the
+    // main checkout. Skip unconditionally without waiting for the relay
+    // profile query. Guarded by !hasCompletedCurrentPubkey so it fires once.
+    if (
+      isSharedIdentity &&
+      currentPubkey &&
+      identityStatus === "success" &&
+      !hasCompletedCurrentPubkey
+    ) {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(
+          onboardingCompletionStorageKey(currentPubkey),
+          "true",
+        );
+      }
+      setGateState((current) =>
+        updateActiveGateState(current, currentPubkey, (activeGateState) => ({
+          ...activeGateState,
+          hasCompletedCurrentPubkey: true,
+          hasSettledCurrentPubkey: true,
+          isOpen: false,
+        })),
+      );
+      return;
+    }
+
+    // Original guard — restored to simple form.
+    if (hasSettledCurrentPubkey || !currentPubkey) {
       return;
     }
 
@@ -163,26 +191,6 @@ export function useFirstRunOnboardingGate({
     }
 
     if (identityStatus !== "success") {
-      return;
-    }
-
-    // Shared identity worktrees have already onboarded in the main checkout.
-    // Skip unconditionally without waiting for the relay profile query.
-    if (isSharedIdentityProp) {
-      if (typeof window !== "undefined" && currentPubkey) {
-        window.localStorage.setItem(
-          onboardingCompletionStorageKey(currentPubkey),
-          "true",
-        );
-      }
-      setGateState((current) =>
-        updateActiveGateState(current, currentPubkey, (activeGateState) => ({
-          ...activeGateState,
-          hasCompletedCurrentPubkey: true,
-          hasSettledCurrentPubkey: true,
-          isOpen: false,
-        })),
-      );
       return;
     }
 
@@ -216,10 +224,11 @@ export function useFirstRunOnboardingGate({
     );
   }, [
     currentPubkey,
+    hasCompletedCurrentPubkey,
     hasExistingProfile,
     hasSettledCurrentPubkey,
     identityStatus,
-    isSharedIdentityProp,
+    isSharedIdentity,
     profileStatus,
   ]);
 
@@ -269,22 +278,18 @@ function hasRealDisplayName(displayName?: string | null): boolean {
   return !lower.startsWith("npub1") && !lower.startsWith("nostr:npub1");
 }
 
-export function useAppOnboardingState() {
+export function useAppOnboardingState(isSharedIdentity: boolean) {
   const queryClient = useQueryClient();
   const identityQuery = useIdentityQuery();
   const identity = identityQuery.data;
   const currentPubkey = identity?.pubkey ?? null;
   const profileQuery = useProfileQuery();
-  const [sharedIdentity, setSharedIdentity] = React.useState(false);
-  React.useEffect(() => {
-    isSharedIdentity().then(setSharedIdentity).catch(() => {});
-  }, []);
   const onboardingGate = useFirstRunOnboardingGate({
     currentPubkey,
     hasExistingProfile: hasRealDisplayName(profileQuery.data?.displayName),
     identityIsFetching: identityQuery.fetchStatus === "fetching",
     identityStatus: identityQuery.status,
-    isSharedIdentity: sharedIdentity,
+    isSharedIdentity,
     profileStatus: profileQuery.status,
   });
   const gateComplete = onboardingGate.complete;

--- a/desktop/src/features/onboarding/hooks.ts
+++ b/desktop/src/features/onboarding/hooks.ts
@@ -4,7 +4,7 @@ import { useQueryClient, type QueryStatus } from "@tanstack/react-query";
 import { channelsQueryKey } from "@/features/channels/hooks";
 import { useProfileQuery } from "@/features/profile/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
-import { getChannels, joinChannel } from "@/shared/api/tauri";
+import { getChannels, isSharedIdentity, joinChannel } from "@/shared/api/tauri";
 
 const DEFAULT_AUTO_JOIN_CHANNEL_NAME = "general";
 
@@ -36,6 +36,7 @@ type UseFirstRunOnboardingGateOptions = {
   hasExistingProfile: boolean;
   identityIsFetching: boolean;
   identityStatus: QueryStatus;
+  isSharedIdentity: boolean;
   profileStatus: QueryStatus;
 };
 
@@ -129,6 +130,7 @@ export function useFirstRunOnboardingGate({
   hasExistingProfile,
   identityIsFetching,
   identityStatus,
+  isSharedIdentity: isSharedIdentityProp,
   profileStatus,
 }: UseFirstRunOnboardingGateOptions) {
   const [gateState, setGateState] = React.useState<OnboardingGateState>(() =>
@@ -146,7 +148,7 @@ export function useFirstRunOnboardingGate({
   }, [currentPubkey]);
 
   React.useEffect(() => {
-    if (hasSettledCurrentPubkey || !currentPubkey) {
+    if ((hasSettledCurrentPubkey && !isSharedIdentityProp) || !currentPubkey) {
       return;
     }
 
@@ -161,6 +163,26 @@ export function useFirstRunOnboardingGate({
     }
 
     if (identityStatus !== "success") {
+      return;
+    }
+
+    // Shared identity worktrees have already onboarded in the main checkout.
+    // Skip unconditionally without waiting for the relay profile query.
+    if (isSharedIdentityProp) {
+      if (typeof window !== "undefined" && currentPubkey) {
+        window.localStorage.setItem(
+          onboardingCompletionStorageKey(currentPubkey),
+          "true",
+        );
+      }
+      setGateState((current) =>
+        updateActiveGateState(current, currentPubkey, (activeGateState) => ({
+          ...activeGateState,
+          hasCompletedCurrentPubkey: true,
+          hasSettledCurrentPubkey: true,
+          isOpen: false,
+        })),
+      );
       return;
     }
 
@@ -197,6 +219,7 @@ export function useFirstRunOnboardingGate({
     hasExistingProfile,
     hasSettledCurrentPubkey,
     identityStatus,
+    isSharedIdentityProp,
     profileStatus,
   ]);
 
@@ -252,11 +275,16 @@ export function useAppOnboardingState() {
   const identity = identityQuery.data;
   const currentPubkey = identity?.pubkey ?? null;
   const profileQuery = useProfileQuery();
+  const [sharedIdentity, setSharedIdentity] = React.useState(false);
+  React.useEffect(() => {
+    isSharedIdentity().then(setSharedIdentity).catch(() => {});
+  }, []);
   const onboardingGate = useFirstRunOnboardingGate({
     currentPubkey,
     hasExistingProfile: hasRealDisplayName(profileQuery.data?.displayName),
     identityIsFetching: identityQuery.fetchStatus === "fetching",
     identityStatus: identityQuery.status,
+    isSharedIdentity: sharedIdentity,
     profileStatus: profileQuery.status,
   });
   const gateComplete = onboardingGate.complete;

--- a/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
@@ -4,12 +4,9 @@ import { getIdentity } from "@/shared/api/tauri";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 
-import type { Workspace } from "../types";
 import {
+  initFirstWorkspace,
   deriveWorkspaceName,
-  normalizeRelayUrl,
-  saveActiveWorkspaceId,
-  saveWorkspaces,
 } from "../workspaceStorage";
 
 const LOCAL_RELAY_URL = "ws://localhost:3000";
@@ -35,7 +32,6 @@ export function WelcomeSetup({
       return;
     }
 
-    const normalizedUrl = normalizeRelayUrl(trimmedUrl);
     setIsConnecting(true);
     setError(null);
 
@@ -44,17 +40,7 @@ export function WelcomeSetup({
       // labels, etc.). The private key lives on disk in `identity.key` and
       // is the single source of truth — never copied into localStorage.
       const identity = await getIdentity();
-
-      const workspace: Workspace = {
-        id: crypto.randomUUID(),
-        name: deriveWorkspaceName(normalizedUrl),
-        relayUrl: normalizedUrl,
-        pubkey: identity.pubkey,
-        addedAt: new Date().toISOString(),
-      };
-
-      saveWorkspaces([workspace]);
-      saveActiveWorkspaceId(workspace.id);
+      initFirstWorkspace(trimmedUrl, identity.pubkey);
 
       // The reload triggered by onComplete() will re-run useWorkspaceInit,
       // which calls applyWorkspace with the saved config. No need to apply here.

--- a/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
@@ -4,10 +4,7 @@ import { getIdentity } from "@/shared/api/tauri";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 
-import {
-  initFirstWorkspace,
-  deriveWorkspaceName,
-} from "../workspaceStorage";
+import { initFirstWorkspace, deriveWorkspaceName } from "../workspaceStorage";
 
 const LOCAL_RELAY_URL = "ws://localhost:3000";
 

--- a/desktop/src/features/workspaces/useWorkspaceInit.ts
+++ b/desktop/src/features/workspaces/useWorkspaceInit.ts
@@ -1,18 +1,17 @@
 import { useEffect, useRef, useState } from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
-import { applyWorkspace, getDefaultRelayUrl, getIdentity, isSharedIdentity } from "@/shared/api/tauri";
+import {
+  applyWorkspace,
+  getDefaultRelayUrl,
+  getIdentity,
+} from "@/shared/api/tauri";
 import { resetMediaCaches } from "@/shared/lib/mediaUrl";
 import { clearSearchHitEventCache } from "@/app/navigation/searchHitEventCache";
 import { clearAllDrafts } from "@/features/messages/lib/useDrafts";
 import { resetAgentObserverStore } from "@/features/agents/observerRelayStore";
 
-import {
-  deriveWorkspaceName,
-  normalizeRelayUrl,
-  saveActiveWorkspaceId,
-  saveWorkspaces,
-} from "./workspaceStorage";
+import { initFirstWorkspace } from "./workspaceStorage";
 import type { Workspace } from "./types";
 
 /**
@@ -49,6 +48,7 @@ type WorkspaceInitResult =
 export function useWorkspaceInit(
   activeWorkspace: Workspace | null,
   workspaceKey: string,
+  isSharedIdentity: boolean,
 ): WorkspaceInitResult {
   const [result, setResult] = useState<WorkspaceInitResult>({
     isReady: false,
@@ -67,26 +67,15 @@ export function useWorkspaceInit(
     async function init() {
       if (!activeWorkspace) {
         try {
-          const [defaultRelayUrl, sharedIdentity] = await Promise.all([
-            getDefaultRelayUrl(),
-            isSharedIdentity(),
-          ]);
+          const defaultRelayUrl = await getDefaultRelayUrl();
 
-          if (sharedIdentity) {
-            // Shared identity worktree: auto-create workspace from the
-            // default relay URL so the user skips WelcomeSetup entirely.
+          if (isSharedIdentity) {
             const identity = await getIdentity();
-            const normalizedUrl = normalizeRelayUrl(defaultRelayUrl);
-            const workspace: Workspace = {
-              id: crypto.randomUUID(),
-              name: deriveWorkspaceName(normalizedUrl),
-              relayUrl: normalizedUrl,
-              pubkey: identity.pubkey,
-              addedAt: new Date().toISOString(),
-            };
-            saveWorkspaces([workspace]);
-            saveActiveWorkspaceId(workspace.id);
-            window.location.reload();
+            if (cancelled) return;
+            initFirstWorkspace(defaultRelayUrl, identity.pubkey);
+            if (!cancelled) {
+              window.location.reload();
+            }
             return;
           }
 
@@ -163,6 +152,7 @@ export function useWorkspaceInit(
     activeWorkspace?.id,
     activeWorkspace?.relayUrl,
     activeWorkspace?.token,
+    isSharedIdentity,
     workspaceKey,
   ]);
 

--- a/desktop/src/features/workspaces/useWorkspaceInit.ts
+++ b/desktop/src/features/workspaces/useWorkspaceInit.ts
@@ -1,12 +1,18 @@
 import { useEffect, useRef, useState } from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
-import { applyWorkspace, getDefaultRelayUrl } from "@/shared/api/tauri";
+import { applyWorkspace, getDefaultRelayUrl, getIdentity, isSharedIdentity } from "@/shared/api/tauri";
 import { resetMediaCaches } from "@/shared/lib/mediaUrl";
 import { clearSearchHitEventCache } from "@/app/navigation/searchHitEventCache";
 import { clearAllDrafts } from "@/features/messages/lib/useDrafts";
 import { resetAgentObserverStore } from "@/features/agents/observerRelayStore";
 
+import {
+  deriveWorkspaceName,
+  normalizeRelayUrl,
+  saveActiveWorkspaceId,
+  saveWorkspaces,
+} from "./workspaceStorage";
 import type { Workspace } from "./types";
 
 /**
@@ -60,9 +66,30 @@ export function useWorkspaceInit(
 
     async function init() {
       if (!activeWorkspace) {
-        // No workspace — need setup
         try {
-          const defaultRelayUrl = await getDefaultRelayUrl();
+          const [defaultRelayUrl, sharedIdentity] = await Promise.all([
+            getDefaultRelayUrl(),
+            isSharedIdentity(),
+          ]);
+
+          if (sharedIdentity) {
+            // Shared identity worktree: auto-create workspace from the
+            // default relay URL so the user skips WelcomeSetup entirely.
+            const identity = await getIdentity();
+            const normalizedUrl = normalizeRelayUrl(defaultRelayUrl);
+            const workspace: Workspace = {
+              id: crypto.randomUUID(),
+              name: deriveWorkspaceName(normalizedUrl),
+              relayUrl: normalizedUrl,
+              pubkey: identity.pubkey,
+              addedAt: new Date().toISOString(),
+            };
+            saveWorkspaces([workspace]);
+            saveActiveWorkspaceId(workspace.id);
+            window.location.reload();
+            return;
+          }
+
           if (!cancelled) {
             setResult({
               isReady: false,

--- a/desktop/src/features/workspaces/workspaceStorage.ts
+++ b/desktop/src/features/workspaces/workspaceStorage.ts
@@ -79,3 +79,20 @@ export function deriveWorkspaceName(relayUrl: string): string {
     return "Workspace";
   }
 }
+
+export function initFirstWorkspace(
+  relayUrl: string,
+  pubkey: string,
+): Workspace {
+  const normalizedUrl = normalizeRelayUrl(relayUrl);
+  const workspace: Workspace = {
+    id: crypto.randomUUID(),
+    name: deriveWorkspaceName(normalizedUrl),
+    relayUrl: normalizedUrl,
+    pubkey,
+    addedAt: new Date().toISOString(),
+  };
+  saveWorkspaces([workspace]);
+  saveActiveWorkspaceId(workspace.id);
+  return workspace;
+}

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -519,6 +519,10 @@ export function getDefaultRelayUrl(): Promise<string> {
   return invokeTauri<string>("get_default_relay_url");
 }
 
+export function isSharedIdentity(): Promise<boolean> {
+  return invokeTauri<boolean>("is_shared_identity");
+}
+
 export function getRelayWsUrl(): Promise<string> {
   return invokeTauri<string>("get_relay_ws_url");
 }


### PR DESCRIPTION
Two UX breaks made `SPROUT_SHARE_IDENTITY=1` unusable for testing feature branches against the staging relay: every fresh worktree showed the `WelcomeSetup` screen (requiring a manual "Connect to Stage" click), and after connecting, the onboarding gate fired again despite the profile already existing on the relay.

Root cause: each worktree gets a unique Tauri app identifier (`xyz.block.sprout.app.dev.{slug}`), which fully isolates its `localStorage` from the main checkout. `SPROUT_SHARE_IDENTITY=1` bridges the Nostr private key but nothing bridged workspace config or the onboarding completion marker.

**Rust:**
- `is_shared_identity()` requires both `SPROUT_SHARE_IDENTITY=1` AND a parseable nostr key in `SPROUT_PRIVATE_KEY` — prevents auto-skipping onboarding when the flag is set but no key was actually shared (e.g. missing `identity.key`)

**Frontend — single IPC call, gated render:**
- `App.tsx` queries `is_shared_identity` once on mount and gates all child rendering until the call resolves, eliminating the flash-of-WelcomeSetup race where children briefly saw `isSharedIdentity=false`
- The resolved boolean is threaded as a prop to `useWorkspaceInit` and `AppReady` — no more double IPC calls or silent `.catch(() => {})`

**Workspace auto-setup (`useWorkspaceInit`):**
- When shared identity and no workspace in `localStorage`, auto-creates one from `defaultRelayUrl` and reloads — no `WelcomeSetup` interaction needed
- `cancelled` guards before `window.location.reload()` and preceding `localStorage` writes prevent writes after unmount

**Onboarding fast-path (`useFirstRunOnboardingGate`):**
- Shared-identity fast-path moved before the `hasSettledCurrentPubkey` guard, so it runs regardless of identity error state
- Guarded by `!hasCompletedCurrentPubkey` (fires exactly once) instead of the old guard that allowed infinite re-entry

**Dedup:**
- Extracted `initFirstWorkspace(relayUrl, pubkey)` in `workspaceStorage.ts` — used by both `useWorkspaceInit` and `WelcomeSetup`, replacing duplicated normalize→construct→save logic

No behavior change for end users or developers not using `SPROUT_SHARE_IDENTITY=1`.