### PR TITLE
fix(frontend): remove deprecated baseUrl for TypeScript 6 compatibility

### DIFF
--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## Summary

- Remove `"baseUrl": "."` from both `desktop/tsconfig.json` and `web/tsconfig.json`
- TypeScript 6 deprecated `baseUrl` — `paths` now resolves relative to the tsconfig.json location without it
- The `"@/*": ["./src/*"]` path mapping uses relative paths, so it resolves correctly without `baseUrl`
- No `"types"` array needed — the project intentionally omits `@types/node` (Vite polyfills `process.env` at bundle time, desktop already has a `@ts-expect-error` for the Node global)
- Unblocks Renovate PR #669 (TypeScript ~5.9 → ~6.0)