### PR TITLE
fix(mobile): rename IOSOptions/MacOsOptions to AppleOptions

### DIFF
--- a/mobile/test/shared/workspace/workspace_storage_test.dart
+++ b/mobile/test/shared/workspace/workspace_storage_test.dart
@@ -12,11 +12,11 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
   @override
   Future<String?> read({
     required String key,
-    IOSOptions? iOptions,
+    AppleOptions? iOptions,
     AndroidOptions? aOptions,
     LinuxOptions? lOptions,
     WebOptions? webOptions,
-    MacOsOptions? mOptions,
+    AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async => _data[key];
 
@@ -24,11 +24,11 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
   Future<void> write({
     required String key,
     required String? value,
-    IOSOptions? iOptions,
+    AppleOptions? iOptions,
     AndroidOptions? aOptions,
     LinuxOptions? lOptions,
     WebOptions? webOptions,
-    MacOsOptions? mOptions,
+    AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
     if (value != null) {
@@ -41,42 +41,42 @@ class FakeSecureStorage extends Fake implements FlutterSecureStorage {
   @override
   Future<void> delete({
     required String key,
-    IOSOptions? iOptions,
+    AppleOptions? iOptions,
     AndroidOptions? aOptions,
     LinuxOptions? lOptions,
     WebOptions? webOptions,
-    MacOsOptions? mOptions,
+    AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async => _data.remove(key);
 
   @override
   Future<Map<String, String>> readAll({
-    IOSOptions? iOptions,
+    AppleOptions? iOptions,
     AndroidOptions? aOptions,
     LinuxOptions? lOptions,
     WebOptions? webOptions,
-    MacOsOptions? mOptions,
+    AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async => Map.from(_data);
 
   @override
   Future<void> deleteAll({
-    IOSOptions? iOptions,
+    AppleOptions? iOptions,
     AndroidOptions? aOptions,
     LinuxOptions? lOptions,
     WebOptions? webOptions,
-    MacOsOptions? mOptions,
+    AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async => _data.clear();
 
   @override
   Future<bool> containsKey({
     required String key,
-    IOSOptions? iOptions,
+    AppleOptions? iOptions,
     AndroidOptions? aOptions,
     LinuxOptions? lOptions,
     WebOptions? webOptions,
-    MacOsOptions? mOptions,
+    AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async => _data.containsKey(key);
 


### PR DESCRIPTION
## Summary

- Rename `IOSOptions` → `AppleOptions` and `MacOsOptions` → `AppleOptions` across 6 method overrides in the `FakeSecureStorage` test mock (12 type annotation changes total)
- `flutter_secure_storage` v10 merged iOS and macOS platform options into a unified `AppleOptions` class under `flutter_secure_storage_darwin`
- Only the test file is affected — no production code changes
- Unblocks Renovate PR #684