### PR TITLE
fix(infra): pin PGDATA path for forward-compatible Postgres upgrades

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       POSTGRES_USER: sprout
       POSTGRES_PASSWORD: sprout_dev
       POSTGRES_DB: sprout
+      PGDATA: /var/lib/postgresql/data
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
## Summary

- Pin `PGDATA=/var/lib/postgresql/data` explicitly in the postgres service's environment block in `docker-compose.yml`

The repo currently uses `postgres:17-alpine` where this path is already the default, making this a no-op today. The explicit pin ensures volume mounts remain stable when Renovate PR #676 upgrades to Postgres 18, which changes the default `PGDATA` location. Setting it proactively avoids a broken `docker compose up` after the image tag bump.