### PR TITLE
fix(desktop): find bundled sidecars in production DMG builds

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -229,11 +229,9 @@ fn command_search_dirs(app: Option<&AppHandle>) -> Vec<PathBuf> {
         dirs.push(current_dir.join("target/debug"));
     }
 
-    if app.is_some() {
-        if let Ok(exe_path) = std::env::current_exe() {
-            if let Some(parent) = exe_path.parent() {
-                dirs.push(parent.to_path_buf());
-            }
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(parent) = exe_path.parent() {
+            dirs.push(parent.to_path_buf());
         }
     }
 


### PR DESCRIPTION
`command_search_dirs` gated the exe parent directory check behind `if app.is_some()`, but `discover_acp_providers` → `find_command` passes `app: None`. In production DMGs, bundled sidecars (`sprout-agent`, `sprout-mcp-server`, etc.) live in `Sprout.app/Contents/MacOS/` next to the main exe — but that directory was never searched.

This caused the Doctor panel to show "Sprout Agent — Not installed" in released builds even though the binary was correctly bundled in the DMG.

- Remove the `AppHandle` guard so `current_exe().parent()` is always included in the binary search path
- In dev, workspace `target/` paths already work — this only affects production app bundles