### PR TITLE
feat(desktop): dock bounce, mark-as-read toggle, and bulk mark-all-read

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -34,7 +34,7 @@ const overrides = new Map([
   ["src-tauri/src/managed_agents/personas.rs", 950], // built-in persona system prompts (Solo + Kit + Scout) + merge_personas inequality checks + persona pack import/uninstall/list + uninstall safety check
   ["src-tauri/src/managed_agents/teams.rs", 580], // built-in team registry (Kit & Scout) + merge_teams + validate_team_deletion + JSON export/import + tests
   ["src-tauri/src/managed_agents/persona_card.rs", 970], // PNG/ZIP/MD persona card codec + pack-zip detection + nested root finder + provider/model/namePool fields + 27 unit tests
-  ["src/app/AppShell.tsx", 830], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view + projects view + memory-leak safeguards + home-badge state lifted here so it consumes the same NIP-RS read-state as the sidebar (single ReadStateManager) + dock bounce wiring + mark-all-read context + channel notification callback
+  ["src/app/AppShell.tsx", 835], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view + projects view + memory-leak safeguards + home-badge state lifted here so it consumes the same NIP-RS read-state as the sidebar (single ReadStateManager) + dock bounce wiring + mark-all-read context + channel notification callback + desktopEnabled guard
   ["src/features/channels/hooks.ts", 550], // canvas query + mutation hooks + DM hide mutation
   ["src/features/channels/ui/ChannelManagementSheet.tsx", 800],
   ["src/features/channels/ui/ChannelPane.tsx", 520], // composer/timeline/sidebar orchestration + anchored agent activity footers

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -34,7 +34,7 @@ const overrides = new Map([
   ["src-tauri/src/managed_agents/personas.rs", 950], // built-in persona system prompts (Solo + Kit + Scout) + merge_personas inequality checks + persona pack import/uninstall/list + uninstall safety check
   ["src-tauri/src/managed_agents/teams.rs", 580], // built-in team registry (Kit & Scout) + merge_teams + validate_team_deletion + JSON export/import + tests
   ["src-tauri/src/managed_agents/persona_card.rs", 970], // PNG/ZIP/MD persona card codec + pack-zip detection + nested root finder + provider/model/namePool fields + 27 unit tests
-  ["src/app/AppShell.tsx", 815], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view + projects view + memory-leak safeguards + home-badge state lifted here so it consumes the same NIP-RS read-state as the sidebar (single ReadStateManager)
+  ["src/app/AppShell.tsx", 830], // message edit state + handlers + ChannelPane edit prop threading + scrollback pagination + workflows view + projects view + memory-leak safeguards + home-badge state lifted here so it consumes the same NIP-RS read-state as the sidebar (single ReadStateManager) + dock bounce wiring + mark-all-read context + channel notification callback
   ["src/features/channels/hooks.ts", 550], // canvas query + mutation hooks + DM hide mutation
   ["src/features/channels/ui/ChannelManagementSheet.tsx", 800],
   ["src/features/channels/ui/ChannelPane.tsx", 520], // composer/timeline/sidebar orchestration + anchored agent activity footers

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:webview:allow-set-webview-zoom",
     "core:window:allow-set-badge-count",
+    "core:window:allow-request-user-attention",
     "core:window:allow-set-focus",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -446,8 +446,8 @@ export function AppShell() {
   }, []);
 
   React.useEffect(() => {
-    void setDesktopAppBadgeCount(homeBadgeCount);
-  }, [homeBadgeCount]);
+    void setDesktopAppBadgeCount(unreadChannelIds.size + homeBadgeCount);
+  }, [homeBadgeCount, unreadChannelIds.size]);
 
   React.useEffect(() => {
     let isCancelled = false;

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -212,6 +212,7 @@ export function AppShell() {
     void homeFeedQuery.refetch();
   });
   const handleChannelNotification = React.useEffectEvent(() => {
+    if (!notificationSettings.settings.desktopEnabled) return;
     void requestDockBounce();
   });
 

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/app/AppShellOverlays";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useBackForwardControls } from "@/app/navigation/useBackForwardControls";
+import { useMarkAsReadShortcuts } from "@/app/useMarkAsReadShortcuts";
 import { useWebviewZoomShortcuts } from "@/app/useWebviewZoomShortcuts";
 import {
   channelsQueryKey,
@@ -26,6 +27,7 @@ import {
 } from "@/features/notifications/hooks";
 import {
   listenForDesktopNotificationActions,
+  requestDockBounce,
   revealDesktopAppWindow,
   sendDesktopNotification,
   setDesktopAppBadgeCount,
@@ -238,9 +240,9 @@ export function AppShell() {
           pubkey: event.pubkey,
         },
       }).then((didSend) => {
-        if (didSend && notificationSettings.settings.soundEnabled) {
-          playNotificationSound();
-        }
+        if (!didSend) return;
+        if (notificationSettings.settings.soundEnabled) playNotificationSound();
+        void requestDockBounce();
       });
     },
   );
@@ -265,6 +267,7 @@ export function AppShell() {
   );
 
   const {
+    markAllChannelsRead,
     markChannelRead,
     markChannelUnread,
     unreadChannelIds,
@@ -280,6 +283,7 @@ export function AppShell() {
       pubkey: identityQuery.data?.pubkey,
       relayClient,
       currentPubkey: identityQuery.data?.pubkey,
+      onChannelMessage: () => void requestDockBounce(),
       onDmMessage: handleDmNotification,
       onLiveMention: refetchHomeFeedOnLiveMention,
     },
@@ -546,6 +550,13 @@ export function AppShell() {
     };
   }, [handleCloseSettings, handleOpenSettings, settingsOpen]);
 
+  useMarkAsReadShortcuts({
+    activeChannel,
+    markAllChannelsRead,
+    markChannelRead,
+    selectedView,
+  });
+
   React.useEffect(() => {
     function handlePointerDown(event: PointerEvent) {
       if (event.button !== 0 || event.detail > 1) {
@@ -581,6 +592,7 @@ export function AppShell() {
       <ChannelNavigationProvider channels={channels}>
         <AppShellProvider
           value={{
+            markAllChannelsRead,
             markChannelRead,
             markChannelUnread,
             openChannelManagement: () => {
@@ -693,6 +705,8 @@ export function AppShell() {
                     void applyAgents(templateId, createdForum.id);
                   }}
                   onHideDm={handleHideDm}
+                  onMarkAllChannelsRead={markAllChannelsRead}
+                  onMarkChannelRead={markChannelRead}
                   onMarkChannelUnread={markChannelUnread}
                   onOpenBrowseChannels={handleOpenBrowseChannels}
                   onOpenBrowseForums={handleOpenBrowseForums}

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -211,6 +211,9 @@ export function AppShell() {
   const refetchHomeFeedOnLiveMention = React.useEffectEvent(() => {
     void homeFeedQuery.refetch();
   });
+  const handleChannelNotification = React.useEffectEvent(() => {
+    void requestDockBounce();
+  });
 
   const handleDmNotification = React.useEffectEvent(
     (event: RelayEvent, channel: Channel) => {
@@ -283,7 +286,7 @@ export function AppShell() {
       pubkey: identityQuery.data?.pubkey,
       relayClient,
       currentPubkey: identityQuery.data?.pubkey,
-      onChannelMessage: () => void requestDockBounce(),
+      onChannelMessage: handleChannelNotification,
       onDmMessage: handleDmNotification,
       onLiveMention: refetchHomeFeedOnLiveMention,
     },
@@ -551,7 +554,8 @@ export function AppShell() {
   }, [handleCloseSettings, handleOpenSettings, settingsOpen]);
 
   useMarkAsReadShortcuts({
-    activeChannel,
+    activeChannelId: activeChannel?.id ?? null,
+    activeChannelLastMessageAt: activeChannel?.lastMessageAt,
     markAllChannelsRead,
     markChannelRead,
     selectedView,

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -277,7 +277,7 @@ export function AppShell() {
     getEffectiveTimestamp: getChannelReadAt,
     readStateVersion,
   } = useUnreadChannels(
-    channels,
+    sidebarChannels,
     activeChannel,
     // Wait for ChannelScreen to report the latest loaded message before
     // advancing unread state for the active channel.

--- a/desktop/src/app/AppShellContext.tsx
+++ b/desktop/src/app/AppShellContext.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 type AppShellContextValue = {
+  markAllChannelsRead: () => void;
   markChannelRead: (
     channelId: string,
     readAt: string | null | undefined,
@@ -20,6 +21,7 @@ type AppShellContextValue = {
 };
 
 const AppShellContext = React.createContext<AppShellContextValue>({
+  markAllChannelsRead: () => {},
   markChannelRead: () => {},
   markChannelUnread: () => {},
   openChannelManagement: () => {},

--- a/desktop/src/app/useMarkAsReadShortcuts.ts
+++ b/desktop/src/app/useMarkAsReadShortcuts.ts
@@ -1,15 +1,16 @@
 import * as React from "react";
 
-import type { Channel } from "@/shared/api/types";
 import { hasPrimaryShortcutModifier } from "@/shared/lib/platform";
 
 export function useMarkAsReadShortcuts({
-  activeChannel,
+  activeChannelId,
+  activeChannelLastMessageAt,
   markAllChannelsRead,
   markChannelRead,
   selectedView,
 }: {
-  activeChannel: Channel | null;
+  activeChannelId: string | null;
+  activeChannelLastMessageAt: string | null | undefined;
   markAllChannelsRead: () => void;
   markChannelRead: (
     channelId: string,
@@ -17,7 +18,7 @@ export function useMarkAsReadShortcuts({
   ) => void;
   selectedView: string;
 }) {
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key !== "Escape") return;
       if (event.defaultPrevented) return;
@@ -29,9 +30,9 @@ export function useMarkAsReadShortcuts({
         return;
       }
 
-      if (selectedView === "channel" && activeChannel) {
+      if (selectedView === "channel" && activeChannelId) {
         event.preventDefault();
-        markChannelRead(activeChannel.id, activeChannel.lastMessageAt ?? null);
+        markChannelRead(activeChannelId, activeChannelLastMessageAt ?? null);
       }
     }
 
@@ -39,5 +40,11 @@ export function useMarkAsReadShortcuts({
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [activeChannel, markAllChannelsRead, markChannelRead, selectedView]);
+  }, [
+    activeChannelId,
+    activeChannelLastMessageAt,
+    markAllChannelsRead,
+    markChannelRead,
+    selectedView,
+  ]);
 }

--- a/desktop/src/app/useMarkAsReadShortcuts.ts
+++ b/desktop/src/app/useMarkAsReadShortcuts.ts
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+import type { Channel } from "@/shared/api/types";
+import { hasPrimaryShortcutModifier } from "@/shared/lib/platform";
+
+export function useMarkAsReadShortcuts({
+  activeChannel,
+  markAllChannelsRead,
+  markChannelRead,
+  selectedView,
+}: {
+  activeChannel: Channel | null;
+  markAllChannelsRead: () => void;
+  markChannelRead: (
+    channelId: string,
+    lastMessageAt: string | null | undefined,
+  ) => void;
+  selectedView: string;
+}) {
+  React.useLayoutEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      if (event.defaultPrevented) return;
+      if (hasPrimaryShortcutModifier(event) || event.altKey) return;
+
+      if (event.shiftKey) {
+        event.preventDefault();
+        markAllChannelsRead();
+        return;
+      }
+
+      if (selectedView === "channel" && activeChannel) {
+        event.preventDefault();
+        markChannelRead(activeChannel.id, activeChannel.lastMessageAt ?? null);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeChannel, markAllChannelsRead, markChannelRead, selectedView]);
+}

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -150,6 +150,7 @@ export function useLiveChannelUpdates(
     // reactions / edits / system messages aren't "new content".
     if (
       UNREAD_TRIGGER_KINDS.has(event.kind) &&
+      channelId !== activeChannelId &&
       (normalizedCurrentPubkey.length === 0 ||
         event.pubkey.toLowerCase() !== normalizedCurrentPubkey)
     ) {

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -314,17 +314,22 @@ export function useUnreadChannels(
     readStateVersion,
   ]);
 
+  const unreadChannelIdsRef = React.useRef(unreadChannelIds);
+  unreadChannelIdsRef.current = unreadChannelIds;
+
   const markAllChannelsRead = React.useCallback(() => {
-    for (const channelId of unreadChannelIds) {
+    for (const channelId of unreadChannelIdsRef.current) {
       forcedUnreadRef.current.delete(channelId);
       const unixSeconds =
         latestByChannelRef.current.get(channelId) ??
         getEffectiveTimestamp(channelId) ??
-        Math.floor(Date.now() / 1_000);
-      markContextRead(channelId, unixSeconds);
+        null;
+      if (unixSeconds !== null) {
+        markContextRead(channelId, unixSeconds);
+      }
     }
     bumpLatestVersion();
-  }, [getEffectiveTimestamp, markContextRead, unreadChannelIds]);
+  }, [getEffectiveTimestamp, markContextRead]);
 
   return {
     unreadChannelIds,

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -314,8 +314,21 @@ export function useUnreadChannels(
     readStateVersion,
   ]);
 
+  const markAllChannelsRead = React.useCallback(() => {
+    for (const channelId of unreadChannelIds) {
+      forcedUnreadRef.current.delete(channelId);
+      const unixSeconds =
+        latestByChannelRef.current.get(channelId) ??
+        getEffectiveTimestamp(channelId) ??
+        Math.floor(Date.now() / 1_000);
+      markContextRead(channelId, unixSeconds);
+    }
+    bumpLatestVersion();
+  }, [getEffectiveTimestamp, markContextRead, unreadChannelIds]);
+
   return {
     unreadChannelIds,
+    markAllChannelsRead,
     markChannelRead,
     markChannelUnread,
     // Exposed so other surfaces (e.g. Home) can project per-item read state

--- a/desktop/src/features/notifications/lib/desktop.ts
+++ b/desktop/src/features/notifications/lib/desktop.ts
@@ -1,5 +1,5 @@
 import { isTauri } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { UserAttentionType, getCurrentWindow } from "@tauri-apps/api/window";
 import {
   isPermissionGranted,
   onAction,
@@ -201,6 +201,22 @@ export async function setDesktopAppBadgeCount(count: number): Promise<void> {
     await getCurrentWindow().setBadgeCount(count > 0 ? count : undefined);
   } catch {
     // Ignore unsupported platforms and best-effort badge sync failures.
+  }
+}
+
+export async function requestDockBounce(): Promise<void> {
+  if (!isTauri()) {
+    return;
+  }
+  if (!document.hidden) {
+    return;
+  }
+  try {
+    await getCurrentWindow().requestUserAttention(
+      UserAttentionType.Informational,
+    );
+  } catch {
+    // Best effort; ignore unsupported platforms.
   }
 }
 

--- a/desktop/src/features/notifications/lib/desktop.ts
+++ b/desktop/src/features/notifications/lib/desktop.ts
@@ -208,7 +208,7 @@ export async function requestDockBounce(): Promise<void> {
   if (!isTauri()) {
     return;
   }
-  if (!document.hidden) {
+  if (document.hasFocus()) {
     return;
   }
   try {

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -195,6 +195,7 @@ function SectionHeaderActions({
           aria-label="Mark all as read"
           className={SECTION_ICON_BUTTON_CLASS}
           onClick={onMarkAllRead}
+          title="Mark all as read"
           type="button"
         >
           <CheckCheck className="h-3.5 w-3.5" />

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -2,6 +2,8 @@
 import {
   Activity,
   Bot,
+  CheckCheck,
+  CheckCircle2,
   ChevronDown,
   CircleDot,
   FolderGit2,
@@ -130,6 +132,11 @@ type AppSidebarProps = {
     channelId: string,
     lastMessageAt: string | null | undefined,
   ) => void;
+  onMarkChannelRead: (
+    channelId: string,
+    lastMessageAt: string | null | undefined,
+  ) => void;
+  onMarkAllChannelsRead: () => void;
   onOpenDm: (input: { pubkeys: string[] }) => Promise<void>;
   onUpdateWorkspace: (
     id: string,
@@ -162,15 +169,19 @@ function SectionHeaderActions({
   browseTestId,
   className,
   createAriaLabel,
+  hasUnread,
   onBrowse,
   onCreateClick,
+  onMarkAllRead,
 }: {
   browseAriaLabel: string;
   browseTestId?: string;
   className?: string;
   createAriaLabel: string;
+  hasUnread?: boolean;
   onBrowse: () => void;
   onCreateClick: () => void;
+  onMarkAllRead?: () => void;
 }) {
   return (
     <div
@@ -179,6 +190,16 @@ function SectionHeaderActions({
         className,
       )}
     >
+      {hasUnread && onMarkAllRead ? (
+        <button
+          aria-label="Mark all as read"
+          className={SECTION_ICON_BUTTON_CLASS}
+          onClick={onMarkAllRead}
+          type="button"
+        >
+          <CheckCheck className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
       <button
         aria-label={browseAriaLabel}
         className={SECTION_ICON_BUTTON_CLASS}
@@ -209,12 +230,15 @@ function ChannelGroupSection({
   browseTestId,
   createAriaLabel,
   groupClassName,
+  hasUnread,
   isCollapsed,
   isActiveChannel,
   items,
   listTestId,
   onBrowse,
   onCreateClick,
+  onMarkAllRead,
+  onMarkChannelRead,
   onMarkChannelUnread,
   onSelectChannel,
   onToggleCollapsed,
@@ -232,6 +256,10 @@ function ChannelGroupSection({
   listTestId: string;
   onBrowse: () => void;
   onCreateClick: () => void;
+  onMarkChannelRead: (
+    channelId: string,
+    lastMessageAt: string | null | undefined,
+  ) => void;
   onMarkChannelUnread: (
     channelId: string,
     lastMessageAt: string | null | undefined,
@@ -241,6 +269,8 @@ function ChannelGroupSection({
   selectedChannelId: string | null;
   title: string;
   unreadChannelIds: Set<string>;
+  hasUnread?: boolean;
+  onMarkAllRead?: () => void;
 }) {
   const contentId = `sidebar-${listTestId}`;
 
@@ -270,8 +300,10 @@ function ChannelGroupSection({
           browseTestId={browseTestId}
           className={SECTION_ACTION_VISIBILITY_CLASS}
           createAriaLabel={createAriaLabel}
+          hasUnread={hasUnread}
           onBrowse={onBrowse}
           onCreateClick={onCreateClick}
+          onMarkAllRead={onMarkAllRead}
         />
       </div>
       {!isCollapsed ? (
@@ -293,14 +325,25 @@ function ChannelGroupSection({
                     </SidebarMenuItem>
                   </ContextMenuTrigger>
                   <ContextMenuContent>
-                    <ContextMenuItem
-                      onClick={() =>
-                        onMarkChannelUnread(channel.id, channel.lastMessageAt)
-                      }
-                    >
-                      <CircleDot className="h-4 w-4" />
-                      Mark unread
-                    </ContextMenuItem>
+                    {unreadChannelIds.has(channel.id) ? (
+                      <ContextMenuItem
+                        onClick={() =>
+                          onMarkChannelRead(channel.id, channel.lastMessageAt)
+                        }
+                      >
+                        <CheckCircle2 className="h-4 w-4" />
+                        Mark as read
+                      </ContextMenuItem>
+                    ) : (
+                      <ContextMenuItem
+                        onClick={() =>
+                          onMarkChannelUnread(channel.id, channel.lastMessageAt)
+                        }
+                      >
+                        <CircleDot className="h-4 w-4" />
+                        Mark unread
+                      </ContextMenuItem>
+                    )}
                   </ContextMenuContent>
                 </ContextMenu>
               ))}
@@ -344,6 +387,8 @@ export function AppSidebar({
   onOpenSearch,
   onHideDm,
   onMarkChannelUnread,
+  onMarkChannelRead,
+  onMarkAllChannelsRead,
   onOpenDm,
   onUpdateWorkspace,
   onRemoveWorkspace,
@@ -589,12 +634,15 @@ export function AppSidebar({
               browseTestId="browse-channels"
               createAriaLabel="Create a channel"
               groupClassName="pt-1"
+              hasUnread={unreadChannelIds.size > 0}
               isCollapsed={collapsedGroups.channels}
               isActiveChannel={selectedView === "channel"}
               items={streamChannels}
               listTestId="stream-list"
               onBrowse={onOpenBrowseChannels}
               onCreateClick={() => setCreateDialogKind("stream")}
+              onMarkAllRead={onMarkAllChannelsRead}
+              onMarkChannelRead={onMarkChannelRead}
               onMarkChannelUnread={onMarkChannelUnread}
               onSelectChannel={onSelectChannel}
               onToggleCollapsed={() => toggleCollapsedGroup("channels")}
@@ -606,12 +654,15 @@ export function AppSidebar({
               browseAriaLabel="Browse forums"
               browseTestId="browse-forums"
               createAriaLabel="Create a forum"
+              hasUnread={unreadChannelIds.size > 0}
               isCollapsed={collapsedGroups.forums}
               isActiveChannel={selectedView === "channel"}
               items={forumChannels}
               listTestId="forum-list"
               onBrowse={onOpenBrowseForums}
               onCreateClick={() => setCreateDialogKind("forum")}
+              onMarkAllRead={onMarkAllChannelsRead}
+              onMarkChannelRead={onMarkChannelRead}
               onMarkChannelUnread={onMarkChannelUnread}
               onSelectChannel={onSelectChannel}
               onToggleCollapsed={() => toggleCollapsedGroup("forums")}
@@ -643,6 +694,7 @@ export function AppSidebar({
               items={directMessages}
               channelLabels={dmChannelLabels}
               onHideDm={onHideDm}
+              onMarkChannelRead={onMarkChannelRead}
               onMarkChannelUnread={onMarkChannelUnread}
               onSelectChannel={onSelectChannel}
               onToggleCollapsed={() => toggleCollapsedGroup("directMessages")}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -1,5 +1,13 @@
 import type * as React from "react";
-import { ChevronDown, CircleDot, FileText, Hash, Lock, X } from "lucide-react";
+import {
+  CheckCircle2,
+  ChevronDown,
+  CircleDot,
+  FileText,
+  Hash,
+  Lock,
+  X,
+} from "lucide-react";
 
 import {
   ContextMenu,
@@ -207,6 +215,7 @@ export function SidebarSection({
   testId,
   unreadChannelIds,
   onHideDm,
+  onMarkChannelRead,
   onMarkChannelUnread,
   onSelectChannel,
   onToggleCollapsed,
@@ -224,6 +233,10 @@ export function SidebarSection({
   testId: string;
   unreadChannelIds: Set<string>;
   onHideDm?: (channelId: string) => void;
+  onMarkChannelRead?: (
+    channelId: string,
+    lastMessageAt: string | null | undefined,
+  ) => void;
   onMarkChannelUnread?: (
     channelId: string,
     lastMessageAt: string | null | undefined,
@@ -308,18 +321,32 @@ export function SidebarSection({
                   </SidebarMenuItem>
                 );
 
-                return onMarkChannelUnread ? (
+                return onMarkChannelUnread || onMarkChannelRead ? (
                   <ContextMenu key={channel.id}>
                     <ContextMenuTrigger asChild>{menuItem}</ContextMenuTrigger>
                     <ContextMenuContent>
-                      <ContextMenuItem
-                        onClick={() =>
-                          onMarkChannelUnread(channel.id, channel.lastMessageAt)
-                        }
-                      >
-                        <CircleDot className="h-4 w-4" />
-                        Mark unread
-                      </ContextMenuItem>
+                      {unreadChannelIds.has(channel.id) && onMarkChannelRead ? (
+                        <ContextMenuItem
+                          onClick={() =>
+                            onMarkChannelRead(channel.id, channel.lastMessageAt)
+                          }
+                        >
+                          <CheckCircle2 className="h-4 w-4" />
+                          Mark as read
+                        </ContextMenuItem>
+                      ) : onMarkChannelUnread ? (
+                        <ContextMenuItem
+                          onClick={() =>
+                            onMarkChannelUnread(
+                              channel.id,
+                              channel.lastMessageAt,
+                            )
+                          }
+                        >
+                          <CircleDot className="h-4 w-4" />
+                          Mark unread
+                        </ContextMenuItem>
+                      ) : null}
                     </ContextMenuContent>
                   </ContextMenu>
                 ) : (

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -321,7 +321,11 @@ export function SidebarSection({
                   </SidebarMenuItem>
                 );
 
-                return onMarkChannelUnread || onMarkChannelRead ? (
+                const hasContextAction =
+                  (unreadChannelIds.has(channel.id) && onMarkChannelRead) ||
+                  (!unreadChannelIds.has(channel.id) && onMarkChannelUnread);
+
+                return hasContextAction ? (
                   <ContextMenu key={channel.id}>
                     <ContextMenuTrigger asChild>{menuItem}</ContextMenuTrigger>
                     <ContextMenuContent>

--- a/desktop/src/shared/lib/keyboard-shortcuts.ts
+++ b/desktop/src/shared/lib/keyboard-shortcuts.ts
@@ -89,6 +89,22 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     keysWindows: "Ctrl+S",
     category: "Navigation",
   },
+  {
+    id: "mark-current-read",
+    label: "Mark as read",
+    description: "Mark the current conversation as read",
+    keys: "Escape",
+    keysWindows: "Escape",
+    category: "Navigation",
+  },
+  {
+    id: "mark-all-read",
+    label: "Mark all as read",
+    description: "Mark all conversations as read",
+    keys: "⇧Escape",
+    keysWindows: "Shift+Escape",
+    category: "Navigation",
+  },
 
   // Zoom
   {

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -129,7 +129,7 @@ test("notification settings drive the Home badge and desktop alerts", async ({
   });
 
   await expect(page.getByTestId("sidebar-home-count")).toHaveText("1");
-  await expect.poll(getAppBadgeCount).toBe(1);
+  await expect.poll(getAppBadgeCount).toBe(2);
 
   await expect
     .poll(() =>

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -81,7 +81,6 @@ test("notification settings drive the Home badge and desktop alerts", async ({
 
   await page.goto("/");
   await expect(page.getByTestId("sidebar-home-count")).toHaveCount(0);
-  await expect.poll(getAppBadgeCount).toBe(0);
 
   await openSettings(page, "notifications");
   await expect(page.getByTestId("settings-notifications")).toBeVisible();
@@ -92,6 +91,11 @@ test("notification settings drive the Home badge and desktop alerts", async ({
   await page.getByTestId("settings-close").click();
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  // The dock badge sums unreadChannelIds.size + homeBadgeCount. Seeded test
+  // channels may start with unreads, so capture the baseline after navigating
+  // to general (which marks it read) but before injecting the mock mention.
+  const baseline = await getAppBadgeCount();
 
   await page.evaluate(() => {
     const win = window as Window & {
@@ -129,7 +133,7 @@ test("notification settings drive the Home badge and desktop alerts", async ({
   });
 
   await expect(page.getByTestId("sidebar-home-count")).toHaveText("1");
-  await expect.poll(getAppBadgeCount).toBe(2);
+  await expect.poll(getAppBadgeCount).toBe(baseline + 2);
 
   await expect
     .poll(() =>
@@ -183,18 +187,18 @@ test("notification settings drive the Home badge and desktop alerts", async ({
   await page.getByTestId("settings-close").click();
   await expect(page.getByTestId("chat-title")).toHaveText("engineering");
   await expect(page.getByTestId("sidebar-home-count")).toHaveCount(0);
-  await expect.poll(getAppBadgeCount).toBe(0);
+  await expect.poll(getAppBadgeCount).toBe(baseline);
 
   await openSettings(page, "notifications");
   await page.getByTestId("notifications-home-badge-toggle").click();
   await page.getByTestId("settings-close").click();
   await expect(page.getByTestId("sidebar-home-count")).toHaveText("1");
-  await expect.poll(getAppBadgeCount).toBe(1);
+  await expect.poll(getAppBadgeCount).toBe(baseline + 1);
 
   await page.getByRole("button", { name: "Home" }).click();
   await expect(page.getByTestId("chat-title")).toHaveText("Home");
   await expect(page.getByTestId("sidebar-home-count")).toHaveCount(0);
-  await expect.poll(getAppBadgeCount).toBe(0);
+  await expect.poll(getAppBadgeCount).toBe(baseline);
 });
 
 test("desktop notification clicks open the matching forum thread", async ({

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -133,7 +133,7 @@ test("notification settings drive the Home badge and desktop alerts", async ({
   });
 
   await expect(page.getByTestId("sidebar-home-count")).toHaveText("1");
-  await expect.poll(getAppBadgeCount).toBe(baseline + 2);
+  await expect.poll(getAppBadgeCount).toBe(baseline + 1);
 
   await expect
     .poll(() =>


### PR DESCRIPTION
# Summary

Adds three complementary notification UX improvements so unread state is visually obvious and easy to dismiss.

The dock badge was previously driven only by Home Feed items and the unread tracking subscribed to every channel on the relay — including non-member channels that have no NIP-RS read markers and are invisible in the sidebar. This scopes all unread tracking to `sidebarChannels` (member + non-archived), wires `unreadChannelIds.size` into the badge count, and adds dock bounce, bidirectional context menu toggle, bulk mark-all-read, and keyboard shortcuts.

- **Dock bounce**: `requestUserAttention(Informational)` fires when `!document.hasFocus()` for messages in non-active member channels, using a stable `useEffectEvent` callback. Uses `hasFocus()` instead of `document.hidden` because the Page Visibility API only flips when the window is minimized/hidden, not when another app has keyboard focus. `onChannelMessage` is guarded with `channelId !== activeChannelId` (matching the existing DM handler pattern) to suppress bounces for the channel the user is currently viewing
- **Dock badge**: `setDesktopAppBadgeCount(unreadChannelIds.size + homeBadgeCount)` — sums sidebar unread channels with Home Feed notifications. `useUnreadChannels` now receives `sidebarChannels` instead of all channels, so the badge and live subscription are scoped to member + non-archived channels only — no phantom unreads from non-member relay activity
- **Context menu toggle**: right-click an unread channel → "Mark as read" (`CheckCircle2`); right-click a read channel → "Mark unread" (`CircleDot`). Per-channel guard prevents empty context menus when only one handler is provided
- **Mark all as read**: `CheckCheck` button in sidebar section headers (visible on hover when unreads exist) + `markAllChannelsRead` callback that iterates `unreadChannelIds` via a ref for stable identity, skipping channels with no resolvable timestamp to avoid future-dated read markers
- **Keyboard shortcuts**: `Esc` marks current channel as read, `Shift+Esc` marks all. `useEffect` with `window.addEventListener("keydown")` + `event.defaultPrevented` guard so existing Escape handlers (find bar, message editor, settings overlay) always win. Accepts primitive `activeChannelId`/`activeChannelLastMessageAt` instead of the full `Channel` object to avoid listener churn on background query refetches
- Adds `core:window:allow-request-user-attention` capability and `mark-current-read`/`mark-all-read` entries to the keyboard shortcuts registry

# Screenshots
Base/default icon (no unread messages):
<img width="102" height="107" alt="image" src="https://github.com/user-attachments/assets/97b2e284-8159-482e-a3ec-ad083c6d5e26" />

4 unread channels -> 4 unreads in dock icon badge:
<img width="245" height="433" alt="image" src="https://github.com/user-attachments/assets/d41e2a71-5a39-497d-99b0-2c3b8cd50791" />
<img width="103" height="103" alt="image" src="https://github.com/user-attachments/assets/3c62c5cd-5411-41e5-aff2-da86f7d036d5" />

System dock icon bounces and adds unread badge as notifications arrive:
<img width="124" height="138" alt="sprout_icon_bounce" src="https://github.com/user-attachments/assets/8e0344be-3121-408f-a60c-ea876dfbfc5e" />
