### PR TITLE
chore(renovate): pin tiptap below 3.23.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,11 @@
       "matchPackageNames": ["redis", "deadpool-redis"],
       "matchManagers": ["cargo"],
       "groupName": "redis"
+    },
+    {
+      "description": "tiptap 3.23.x breaks editor lifecycle under real relay latency — pin until upstream stabilizes.",
+      "matchPackageNames": ["@tiptap/{/,}**"],
+      "allowedVersions": "<3.23.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Pin all `@tiptap/*` packages below `3.23.0` in `renovate.json`

tiptap 3.23.x introduced editor lifecycle changes (`scheduleDestroy` timeout mechanism, `useEditorState` integration in `useEditor`) that cause channel pane rendering failures under real relay latency. With 3.23.6, 15 of 47 Desktop E2E Integration tests fail deterministically — all channel navigation tests that render `MessageComposer` timeout waiting for `chat-title`.

Investigated fixes that were insufficient:
- `immediatelyRender: true` on `useEditor()` — bypasses SSR detection but doesn't fix the lifecycle issue
- Null guards on `EditorContent` — `PureEditorContent` already handles null gracefully; guards added unnecessary mount/unmount cycles

After this merges, close PR #660 (`renovate/tiptap-monorepo`).