### PR TITLE
fix(desktop): add top padding to forum view to clear overlay header

### DIFF
--- a/desktop/src/features/forum/ui/ForumView.tsx
+++ b/desktop/src/features/forum/ui/ForumView.tsx
@@ -143,7 +143,7 @@ export function ForumView({
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col pt-11">
       {/* New post area */}
       <div className="border-b border-border/60 p-4">
         {isComposerOpen ? (


### PR DESCRIPTION
## Summary

Forum posts were colliding with the channel header because `ForumView`'s root container had no top padding, while `ChatHeader` is rendered with `overlaysContent` (`-mb-[44px]`) and expects consumers to leave room.

## Fix

Add `pt-11` to the `ForumView` root, matching the convention used everywhere else `ChatHeader` overlays content (`WorkflowDetailPanel`, `MessageThreadPanel`, `UserProfilePanel`, `AgentSessionThreadPanel`).

## Diff

```diff
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col pt-11">
```

One-line change. Pre-commit + pre-push hooks all green (rust-fmt, biome, desktop/web/mobile checks, builds, clippy, tests).