### PR TITLE
fix(relay): install git in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,10 @@ RUN groupadd -g 1000 sprout && useradd -u 1000 -g sprout -m sprout
 # CAKE: writable dirs
 RUN mkdir -p /cache /tmp && chown sprout:sprout /cache /tmp
 
-# socat for Istio abstract→file socket bridge
+# git: relay shells out to `git` for hydrate/receive-pack/upload-pack (S3-backed repos)
+# socat: Istio abstract→file socket bridge
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates socat && rm -rf /var/lib/apt/lists/*
+    ca-certificates git socat && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/sprout-relay /code/sprout-relay
 COPY --from=web-builder /build/web/dist /code/web


### PR DESCRIPTION
## Problem

The S3-backed git relay (PR #726) shells out to the system `git` binary in ~15 spots across `crates/sprout-relay/src/api/git/{hydrate,cas_publish,transport}.rs` — including `git init --bare`, `receive-pack`, `upload-pack`, and `update-ref`. These run on every clone/fetch/push.

The runtime stage of the Dockerfile installed only `ca-certificates` and `socat`. No `git` binary. So on the `sprout-oss` staging deploy, every git request 500s on the first hydrate step with:

```
ERROR hydrate failed
  error: hydrate: spawn git ["init", "--bare", "--quiet"]:
         No such file or directory (os error 2)
```

Confirmed live on `sprout-oss.stage.blox.sqprod.co` by Eva earlier today (relay pod `sprout-relay-57bf4bf9ff-tjgc2`, `kubectl exec ... -- which git` → not found).

## Why CI missed it

`crates/sprout-relay`'s git tests and the `sprout-test-client` e2e tests run on dev hosts and CI runners that already have `git` on PATH. The Docker image is built but never exercised against a real push in CI. The gap was packaging, not code.

## Fix

One-line: add `git` to the runtime apt-get layer.

```diff
-# socat for Istio abstract→file socket bridge
+# git: relay shells out to `git` for hydrate/receive-pack/upload-pack (S3-backed repos)
+# socat: Istio abstract→file socket bridge
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates socat && rm -rf /var/lib/apt/lists/*
+    ca-certificates git socat && rm -rf /var/lib/apt/lists/*
```

- `--no-install-recommends` keeps it lean (~30MB). Bookworm's `git` core ships `init`, `receive-pack`, `upload-pack`, and `update-ref` — every subcommand the relay calls. Recommends like `git-man`, `patch`, `liberror-perl` are not needed.
- Added a comment so the next person doesn't strip it.

## Verification

After this lands and the image redeploys to `sprout-oss.stage.blox.sqprod.co`, the failing A4 path (clone/push) should work end-to-end. Eva and I have a Space Invaders demo ready to push the moment a fresh image rolls — that's the smoke test.

Co-authored-by: Dawn (sprout agent)
