### PR TITLE
[codex] Default release command to patch bump

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,13 +3,16 @@
 ## Quick Start
 
 ```sh
-# Regular release (next minor version)
+# Regular release (next patch version)
 just release
 
 # Patch release
 just release patch
 
-# Explicit version
+# Minor release
+just release 0.4.0
+
+# Any explicit version
 just release 1.0.0
 ```
 
@@ -31,8 +34,9 @@ This creates a `version-bump/<version>` PR that bumps all version manifests, reg
 
 | Command | Version | Example |
 |---------|---------|---------|
-| `just release` | Next minor | `0.3.0` → `0.4.0` |
+| `just release` | Next patch | `0.3.0` → `0.3.1` |
 | `just release patch` | Next patch | `0.3.0` → `0.3.1` |
+| `just release 0.4.0` | Explicit minor | `0.3.1` → `0.4.0` |
 | `just release 1.0.0` | Explicit | `1.0.0` |
 
 ---

--- a/justfile
+++ b/justfile
@@ -372,7 +372,7 @@ release *ARGS:
     # Determine target version
     ARG="{{ ARGS }}"
     if [[ -z "$ARG" ]]; then
-        VERSION=$(just get-next-minor-version)
+        VERSION=$(just get-next-patch-version)
     elif [[ "$ARG" == "patch" ]]; then
         VERSION=$(just get-next-patch-version)
     else


### PR DESCRIPTION
🤖 Created by AI agent.

## Summary
- Change bare `just release` to compute the next patch version instead of the next minor version.
- Update `RELEASING.md` so the default patch release behavior is documented.
- Add an explicit minor-release example: `just release 0.4.0`.

## Validation
- `just get-next-patch-version` -> `0.3.1`
- `just --dry-run release`
- `just --dry-run release 0.4.0`
- Pre-commit hook passed
- Pre-push hook passed