### PR TITLE
fix(agent): keep parallel tool-result messages contiguous on OpenAI Chat (Databricks image fix)

### DIFF
--- a/crates/sprout-agent/src/llm.rs
+++ b/crates/sprout-agent/src/llm.rs
@@ -297,10 +297,28 @@ fn anthropic_tool_result_content(content: &[ToolResultContent]) -> Vec<Value> {
 
 fn openai_body(cfg: &Config, history: &[HistoryItem], tools: &[ToolDef]) -> Value {
     let mut messages: Vec<Value> = vec![json!({ "role": "system", "content": cfg.system_prompt })];
+    // Images returned from tool calls ride on a trailing `role:"user"`
+    // message because OpenAI Chat's `role:"tool"` content is text-only. We
+    // batch them across a run of adjacent ToolResult items so that all
+    // `role:"tool"` messages stay contiguous — splitting them with a user
+    // turn breaks OpenAI-Chat-compatible frontends that translate back to
+    // Anthropic `tool_result` (notably Databricks model serving), since
+    // Anthropic requires every `tool_use` in one assistant turn to be
+    // answered by a single immediately-following user message.
+    let mut pending_images: Vec<Value> = Vec::new();
+    let flush_images = |messages: &mut Vec<Value>, pending: &mut Vec<Value>| {
+        if !pending.is_empty() {
+            messages.push(json!({ "role": "user", "content": std::mem::take(pending) }));
+        }
+    };
     for item in history {
         match item {
-            HistoryItem::User(text) => messages.push(json!({ "role": "user", "content": text })),
+            HistoryItem::User(text) => {
+                flush_images(&mut messages, &mut pending_images);
+                messages.push(json!({ "role": "user", "content": text }));
+            }
             HistoryItem::Assistant { text, tool_calls } => {
+                flush_images(&mut messages, &mut pending_images);
                 let mut msg = serde_json::Map::new();
                 msg.insert("role".into(), json!("assistant"));
                 msg.insert("content".into(), json!(text.as_str()));
@@ -323,13 +341,11 @@ fn openai_body(cfg: &Config, history: &[HistoryItem], tools: &[ToolDef]) -> Valu
                 messages.push(json!({
                     "role": "tool", "tool_call_id": r.provider_id,
                     "content": openai_tool_text_content(&r.content) }));
-                let image_content = openai_image_user_content(&r.content);
-                if !image_content.is_empty() {
-                    messages.push(json!({ "role": "user", "content": image_content }));
-                }
+                pending_images.extend(openai_image_user_content(&r.content));
             }
         }
     }
+    flush_images(&mut messages, &mut pending_images);
     let tools_json: Vec<Value> = tools
         .iter()
         .map(|t| {
@@ -1114,6 +1130,81 @@ mod tests {
             body["messages"][4]["content"][0]["image_url"]["url"],
             "data:image/png;base64,aW1n"
         );
+    }
+
+    /// Regression for Databricks model serving (and any OpenAI-Chat frontend
+    /// that translates to Anthropic on the way to the model). Parallel tool
+    /// calls where one or more return images previously produced an
+    /// interleaved sequence:
+    ///   role:"tool"  (A)
+    ///   role:"user"  (image A)
+    ///   role:"tool"  (B)
+    ///   role:"user"  (image B)
+    /// The intervening user message split the run of tool results, so the
+    /// translator could no longer fold them into a single Anthropic
+    /// `tool_result`-bearing user message — Anthropic then rejected the
+    /// request with "tool_use ids were found without tool_result blocks
+    /// immediately after". Fix: every `role:"tool"` for a run of adjacent
+    /// ToolResults emits contiguously, then a single trailing user message
+    /// carries all of the images from the batch.
+    #[test]
+    fn openai_parallel_image_tool_results_stay_contiguous() {
+        let history = vec![
+            HistoryItem::User("describe both images".into()),
+            HistoryItem::Assistant {
+                text: String::new(),
+                tool_calls: vec![
+                    ToolCall {
+                        provider_id: "toolu_a".into(),
+                        name: "dev__view_image".into(),
+                        arguments: serde_json::json!({"source": "a.png"}),
+                    },
+                    ToolCall {
+                        provider_id: "toolu_b".into(),
+                        name: "dev__view_image".into(),
+                        arguments: serde_json::json!({"source": "b.png"}),
+                    },
+                ],
+            },
+            HistoryItem::ToolResult(ToolResult {
+                provider_id: "toolu_a".into(),
+                content: vec![
+                    ToolResultContent::Text("10×10, 70 B (image/png from a.png)".into()),
+                    ToolResultContent::Image {
+                        data: "aaa".into(),
+                        mime_type: "image/png".into(),
+                    },
+                ],
+                is_error: false,
+            }),
+            HistoryItem::ToolResult(ToolResult {
+                provider_id: "toolu_b".into(),
+                content: vec![
+                    ToolResultContent::Text("10×10, 70 B (image/png from b.png)".into()),
+                    ToolResultContent::Image {
+                        data: "bbb".into(),
+                        mime_type: "image/png".into(),
+                    },
+                ],
+                is_error: false,
+            }),
+        ];
+        let body = openai_body(&cfg(Provider::OpenAi), &history, &[]);
+        let messages = body["messages"].as_array().unwrap();
+        // [0] system, [1] user, [2] assistant(tool_calls), [3] tool A, [4] tool B, [5] user(images)
+        assert_eq!(messages.len(), 6, "messages: {messages:#?}");
+        assert_eq!(messages[3]["role"], "tool");
+        assert_eq!(messages[3]["tool_call_id"], "toolu_a");
+        assert_eq!(
+            messages[4]["role"], "tool",
+            "tool results must stay adjacent; intervening user message breaks Databricks/Anthropic pairing"
+        );
+        assert_eq!(messages[4]["tool_call_id"], "toolu_b");
+        assert_eq!(messages[5]["role"], "user");
+        let imgs = messages[5]["content"].as_array().unwrap();
+        assert_eq!(imgs.len(), 2);
+        assert_eq!(imgs[0]["image_url"]["url"], "data:image/png;base64,aaa");
+        assert_eq!(imgs[1]["image_url"]["url"], "data:image/png;base64,bbb");
     }
 
     /// Regression: a connection that is accepted and then dropped before any


### PR DESCRIPTION
## What

Fix tool-result framing for parallel image-returning tool calls on the OpenAI Chat path so requests via Databricks model serving stop being rejected.

## Why

Reported by Wes in `#sprout-bugs`: agents using Databricks-routed Claude (Opus 4.6/4.7) fail when asked to view multiple images in a thread. Error from Databricks is Anthropic-shaped, despite the agent talking OpenAI Chat:

```
llm: 400 Bad Request: tool_use ids were found without tool_result
blocks immediately after: toolu_bdrk_017tcizkcWrCFzQGQyci3DVr.
Each tool_use block must have a corresponding tool_result block
in the next message.
```

The `toolu_bdrk_` prefix gives it away — Databricks (`config.rs:119`: `OpenAiApi::Chat, // Databricks invocations is chat-shaped`) translates OpenAI Chat back into Anthropic on the way to the model and the translation breaks on this pattern.

## Root cause

`openai_body` emitted images as a `role:"user"` message immediately after each tool result's `role:"tool"` message. With **one** image-returning tool call that's fine. With **two parallel** calls — exactly the case in Wes's screenshot, two stacked `sprout-mcp__view_image` invocations — the wire becomes:

```
role:"tool"  (A text)
role:"user"  (A image)     ← splits the run
role:"tool"  (B text)      ← Databricks: where's B's tool_result?
role:"user"  (B image)
```

Databricks' OpenAI→Anthropic translator folds *consecutive* `role:"tool"` messages into one Anthropic user message of `tool_result` blocks. The intervening `role:"user"` (image) ends the run, so the second tool result lands in a separate user message, leaving `tool_use B` unpaired in the immediately-following user turn. Anthropic rejects.

## Fix

In `openai_body`, defer image content into a `pending_images` accumulator while emitting `role:"tool"` messages. Flush as a single trailing `role:"user"` carrying every image from the batch before any non-`ToolResult` history item (or at end of history). Mirrors the existing Anthropic body's `pending`/`flush` pattern.

OpenAI Chat semantics unchanged: each tool's text result still lands in its own `role:"tool"` message in order; images still ride on a `role:"user"` message after their text results. Only the *grouping* changes — one user message per run of tool results instead of one per result.

## Test

`openai_parallel_image_tool_results_stay_contiguous` constructs the two-parallel-images case and asserts both `role:"tool"` messages are adjacent with a single trailing `role:"user"` carrying both images. Confirmed failing on the prior implementation (7-message interleaved shape) before applying the fix.

All 45 `sprout-agent` lib tests pass. Clippy and fmt clean.

## Scope

- Single file: `crates/sprout-agent/src/llm.rs`
- One function changed (`openai_body`); other paths (Anthropic native, OpenAI Responses) already handled this correctly and are untouched.
