### PR TITLE
fix(desktop): improve model picker message and runtime dropdown clarity

### DIFF
--- a/desktop/src/features/agents/ui/ModelPicker.tsx
+++ b/desktop/src/features/agents/ui/ModelPicker.tsx
@@ -126,7 +126,16 @@ export function ModelPicker({
             </div>
           ) : !modelsData.supportsSwitching ? (
             <div className="px-3 py-2 text-sm text-muted-foreground">
-              This agent uses the runtime&apos;s default model.
+              {agent.model ? (
+                <>
+                  <p className="font-medium text-foreground">{agent.model}</p>
+                  <p className="mt-0.5 text-xs">
+                    This runtime does not support switching models.
+                  </p>
+                </>
+              ) : (
+                "This agent uses the runtime's default model."
+              )}
             </div>
           ) : (
             <DropdownMenuRadioGroup

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -563,6 +563,11 @@ export function AddChannelBotDialog({
               </DropdownMenuRadioGroup>
             </DropdownMenuContent>
           </DropdownMenu>
+          <p className="text-xs text-muted-foreground">
+            {selectedPersonas.some((p) => p.provider)
+              ? "Personas with a preferred runtime will use their own instead of this selection."
+              : "Default runtime for all deployed agents."}
+          </p>
         </div>
 
         {teams.length > 0 ? (


### PR DESCRIPTION
The model picker dropdown in the agent list showed "This agent uses the runtime's default model" even when a custom model was explicitly set on the agent (e.g., `kgoose-gpt-5-5` via Databricks). This happened because the message was gated solely on whether the ACP runtime supports model switching (`supportsSwitching`), without checking whether `agent.model` was already configured. The dropdown now shows the configured model name with a "switching not supported" note when the runtime doesn't enumerate models via ACP, and falls back to the original default-model message only when no model is set.

The "Add agents" channel dialog's Runtime dropdown had no indication that personas with a preferred runtime would silently override the dropdown selection. Added conditional helper text: when any selected persona has a `provider` set, the text explains that those personas will use their own runtime; otherwise it shows a generic "default runtime" note.

- `ModelPicker.tsx` — split the `!supportsSwitching` branch to check `agent.model` before choosing the message
- `AddChannelBotDialog.tsx` — added `<p>` helper text after the Runtime `<DropdownMenu>`, conditional on `selectedPersonas.some(p => p.provider)`