### PR TITLE
feat(desktop): reload webview on Cmd/Ctrl+R

### DIFF
--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import { router } from "@/app/router";
+import { useReloadShortcut } from "@/app/useReloadShortcut";
 import { useAppOnboardingState } from "@/features/onboarding/hooks";
 import { OnboardingFlow } from "@/features/onboarding/ui/OnboardingFlow";
 import { useWorkspaceInit } from "@/features/workspaces/useWorkspaceInit";
@@ -66,6 +67,10 @@ function AppReady({ isSharedIdentity }: { isSharedIdentity: boolean }) {
 }
 
 export function App() {
+  // Mounted at the root so Cmd/Ctrl+R reloads in every app state,
+  // including the loading and first-run setup screens below.
+  useReloadShortcut();
+
   useLayoutEffect(() => {
     void getCurrentWindow().show();
   }, []);

--- a/desktop/src/app/useReloadShortcut.ts
+++ b/desktop/src/app/useReloadShortcut.ts
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import { hasPrimaryShortcutModifier } from "@/shared/lib/platform";
+
+/**
+ * Reloads the webview on the platform's reload shortcut (Cmd+R on macOS,
+ * Ctrl+R elsewhere), matching browser behavior.
+ *
+ * `window.location.reload()` is the app's existing reload primitive (see
+ * App.tsx, useWorkspaceInit.ts): it triggers a full reinit that re-reads
+ * localStorage and reconnects relays.
+ */
+export function useReloadShortcut() {
+  React.useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (
+        !hasPrimaryShortcutModifier(event) ||
+        event.altKey ||
+        event.shiftKey
+      ) {
+        return;
+      }
+      if (event.key.toLowerCase() !== "r") {
+        return;
+      }
+
+      event.preventDefault();
+      window.location.reload();
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+}


### PR DESCRIPTION
## What

Adds a Cmd+R (Ctrl+R on Windows/Linux) keyboard shortcut that reloads the desktop window.

## How

- New `desktop/src/app/useReloadShortcut.ts` — a `keydown` hook that fires on the platform's primary modifier + R (rejecting alt/shift), calls `event.preventDefault()`, then `window.location.reload()`.
- Mounted at the `App` root (`desktop/src/app/App.tsx`) so it works in **every** app state, including the loading gate and first-run setup — not just after `AppShell` mounts.

It mirrors the existing renderer-shortcut hooks (`useWebviewZoomShortcuts`, `useMarkAsReadShortcuts`) and reuses `hasPrimaryShortcutModifier` for platform handling. `window.location.reload()` is already the app's reload primitive (see `App.tsx`'s `handleSetupComplete`, `useWorkspaceInit.ts`) — it triggers a full reinit: re-reads localStorage, reconnects relays.

## Alternatives considered (rejected)

- **`tauri-plugin-global-shortcut`** (used for push-to-talk): system-wide scope — wrong for a refresh that should only fire when the app is focused.
- **Native View → Reload menu**: adds a menu the app doesn't currently have; more surface than the task needs.

## Testing

- `pnpm typecheck`, `pnpm lint` (biome), file-size guard, and the full 339-test suite all green.
- No new Rust, no new Tauri permissions.
- No unit test added: the sibling shortcut hooks aren't unit-tested either (DOM/window side-effects are covered by e2e by convention).
