### PR TITLE
refactor(just): slim down mobile-dev to just run Flutter

### DIFF
--- a/justfile
+++ b/justfile
@@ -340,34 +340,14 @@ mobile-check:
 mobile-test:
     unset GIT_DIR GIT_WORK_TREE; cd {{mobile_dir}} && flutter test
 
-# Run the mobile app on iOS simulator (starts infra + relay automatically)
+# Run the mobile app on iOS simulator
 mobile-dev:
     #!/usr/bin/env bash
     set -euo pipefail
-    just _ensure-migrations
-    # Start relay in background if not already running
-    RELAY_PID=""
-    if ! lsof -i :3000 -sTCP:LISTEN -t &>/dev/null; then
-        echo "Starting relay in background (log: /tmp/sprout-relay.log)..."
-        cargo run -p sprout-relay &>/tmp/sprout-relay.log &
-        RELAY_PID=$!
-        trap 'if [[ -n "$RELAY_PID" ]]; then kill "$RELAY_PID" 2>/dev/null || true; fi' EXIT
-        echo -n "Waiting for relay"
-        for _ in $(seq 1 30); do
-            lsof -i :3000 -sTCP:LISTEN -t &>/dev/null && break
-            echo -n "."
-            sleep 3
-        done
-        echo " ready"
-    else
-        echo "Relay already running on :3000"
-    fi
-    # Open iOS simulator if not already running
     if ! pgrep -x Simulator &>/dev/null; then
         open -a Simulator
         sleep 3
     fi
-    # Run Flutter
     cd {{mobile_dir}}
     unset GIT_DIR GIT_WORK_TREE
     flutter run


### PR DESCRIPTION
`just mobile-dev` was bundling infra concerns — running migrations, starting Docker services, and compiling and polling for the relay — alongside just launching Flutter. This made it slow and inconsistent with how desktop development works.

The desktop `just dev` recipe doesn't touch the relay at all; it expects the developer to run `just relay` separately. Mobile should follow the same pattern. The relay startup alone could take 30–90 seconds of `cargo run` compilation time, which isn't the mobile developer's problem to manage on every `flutter run`.

- Remove `just _ensure-migrations` call from `mobile-dev`
- Remove the relay auto-start block (port check, background `cargo run`, 90s polling loop, trap)
- `just relay` already covers all the removed functionality (it depends on `_ensure-migrations` → `_ensure-services`)