### PR TITLE
fix(desktop): clear clippy lints in agents/mesh_llm commands

### DIFF
--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -502,9 +502,7 @@ pub async fn create_managed_agent(
             .iter()
             .find(|record| record.pubkey == pubkey)
             .ok_or_else(|| "created agent disappeared unexpectedly".to_string())?;
-        let agent = build_managed_agent_summary(&app, record, &runtimes)?;
-
-        agent
+        build_managed_agent_summary(&app, record, &runtimes)?
     };
 
     // ── Phase 3b: local spawn (async preflight outside store lock) ───────────

--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -73,7 +73,7 @@ pub(crate) async fn ensure_client_node_for_model(
         }
     }
 
-    let availability = match relay::query_relay(&state, &[mesh_llm::mesh_status_filter()]).await {
+    let availability = match relay::query_relay(state, &[mesh_llm::mesh_status_filter()]).await {
         Ok(events) => mesh_llm::availability_from_events(events),
         Err(error) => return Err(format!("failed to read relay mesh status: {error}")),
     };
@@ -96,7 +96,7 @@ pub(crate) async fn ensure_client_node_for_model(
         iroh_relay_url: None,
         iroh_relay_auth: None,
     };
-    hydrate_private_relay_config(&state, &mut start).await?;
+    hydrate_private_relay_config(state, &mut start).await?;
 
     let mut runtime = state.mesh_llm_runtime.lock().await;
     if runtime.is_some() {


### PR DESCRIPTION
## What

Three clippy lints slipped past #798 (mesh-llm)'s merge gate and are currently failing the `desktop-tauri-clippy` pre-push hook on `main` (with `-D warnings`):

- `agents.rs:507` — `let_and_return`: return the expression directly
- `mesh_llm.rs:76` / `mesh_llm.rs:99` — `needless_borrow` (x2): `state` is already `&AppState` at both call sites, so `&state` was a double reference

## Why

`main` is currently red on the desktop-tauri-clippy hook — reproducible by running `just desktop-tauri-clippy` on a clean checkout of `41a3fc1`. This blocks any branch's push hook. Fixing it in a small, correctly-scoped PR (these are main's files, not feature work) unbreaks the hook for everyone.

## Verification

All 6 pre-push gates run by hand and green:
- `just clippy` ✓
- `just desktop-tauri-clippy` ✓
- `just test-unit` ✓
- `just desktop-tauri-test` ✓
- `just desktop-test` (425) ✓
- `just mobile-test` (341) ✓

Idiomatic fixes, no behavior change.

Co-authored-by: Brain
