### PR TITLE
Install sprout-cli skill at repo root + fix desktop clippy

### DIFF
--- a/.agents/skills/sprout-cli/SKILL.md
+++ b/.agents/skills/sprout-cli/SKILL.md
@@ -1,0 +1,1 @@
+../../../desktop/src-tauri/src/managed_agents/nest_skill.md

--- a/.claude/skills/sprout-cli/SKILL.md
+++ b/.claude/skills/sprout-cli/SKILL.md
@@ -1,0 +1,1 @@
+../../../desktop/src-tauri/src/managed_agents/nest_skill.md

--- a/.codex/skills/sprout-cli/SKILL.md
+++ b/.codex/skills/sprout-cli/SKILL.md
@@ -1,0 +1,1 @@
+../../../desktop/src-tauri/src/managed_agents/nest_skill.md

--- a/.goose/skills/sprout-cli/SKILL.md
+++ b/.goose/skills/sprout-cli/SKILL.md
@@ -1,0 +1,1 @@
+../../../desktop/src-tauri/src/managed_agents/nest_skill.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,30 @@ check existing reply handlers for the pattern.
 
 `sprout` is the agent-first CLI replacing `sprout-mcp`. Auth env vars
 (`SPROUT_RELAY_URL`, `SPROUT_PRIVATE_KEY`, `SPROUT_AUTH_TAG`) are auto-injected
-by the ACP harness into managed agent subprocesses.
+by the ACP harness into managed agent subprocesses. In development, set
+`SPROUT_PRIVATE_KEY` and `SPROUT_RELAY_URL` in your environment manually.
+
+### Building the CLI
+
+```bash
+cargo build --release -p sprout-cli
+```
+
+Binary location: `./target/release/sprout`. Add `./target/release` to `PATH`
+or invoke with the full path.
+
+### Deep Links
+
+`sprout://message?channel=<uuid>&id=<hex>` links reference a specific message
+thread. To read the linked thread:
+
+```bash
+sprout messages thread --channel <uuid> --event <hex> --format compact
+```
+
+Extract `channel` and `id` from the URL query parameters. The optional
+`thread` parameter (root event ID) can be ignored — `messages thread` resolves
+the full thread from the event ID alone.
 
 All reads return sig-stripped JSON arrays; all writes return
 `{event_id, accepted, message}`; creates add the entity ID. Exit codes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/desktop/src-tauri/src/managed_agents/nest_skill.md
+++ b/desktop/src-tauri/src/managed_agents/nest_skill.md
@@ -10,9 +10,9 @@ version: 1
 
 ## Environment
 
-`SPROUT_PRIVATE_KEY` is pre-set by the harness. Never prompt for it, never read it, never echo it.
+`SPROUT_PRIVATE_KEY` is set by the harness at runtime or by the developer's environment. If missing, tell the user to set it (hex or nsec format). Never read or echo the value.
 
-`SPROUT_RELAY_URL` defaults to `http://localhost:3000`. Override only if explicitly instructed.
+`SPROUT_RELAY_URL` defaults to `http://localhost:3000`. In development, the user may need to set this to a staging or production relay URL.
 
 Run `sprout --help` and `sprout <command> <subcommand> --help` to discover all flags, arguments, and usage. This skill documents only what `--help` cannot tell you.
 


### PR DESCRIPTION
Coding agents working in the Sprout repo have no discoverable CLI instructions and can't act on `sprout://` deep links pasted into a session. Managed agents get these via the desktop app's runtime install, but development sessions don't. This wires up the same skill that managed agents use, with the source file in the repo as the single source of truth.

Four skill symlinks point every agent harness (`.agents/`, `.claude/`, `.goose/`, `.codex/`) at `desktop/src-tauri/src/managed_agents/nest_skill.md` so skill updates propagate everywhere automatically. `CLAUDE.md` symlinks to `AGENTS.md` since Claude Code reads `CLAUDE.md` while other harnesses read `AGENTS.md` natively. `AGENTS.md` gets a new section covering `sprout://message` deep link parsing and CLI build instructions.

- Add skill symlinks for all four harness discovery paths → `nest_skill.md`
- Add `CLAUDE.md` → `AGENTS.md` symlink
- Add deep link parsing + CLI build instructions to `AGENTS.md`
- Adapt `nest_skill.md` env section for dual use (managed agent + development)
- Fix `clippy::let_and_return` in `agents.rs` and `clippy::needless_borrow` in `mesh_llm.rs` that blocked pre-push hooks on all branches