### PR TITLE
fix(desktop): disable mesh-llm auto-build to prevent git config corruption

### DIFF
--- a/desktop/src-tauri/.cargo/config.toml
+++ b/desktop/src-tauri/.cargo/config.toml
@@ -1,0 +1,6 @@
+[env]
+# Workaround for mesh-llm prepare-llama.sh `git -C` directory-escape bug.
+# The script's git commands walk upward into the enclosing Sprout repo when
+# .deps/llama.cpp/.git is missing. Disabling auto-build prevents the script
+# from running. Remove once mesh-llm-sdk is bumped past Mesh-LLM/mesh-llm#780.
+SKIPPY_LLAMA_AUTO_BUILD = "0"

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -502,9 +502,7 @@ pub async fn create_managed_agent(
             .iter()
             .find(|record| record.pubkey == pubkey)
             .ok_or_else(|| "created agent disappeared unexpectedly".to_string())?;
-        let agent = build_managed_agent_summary(&app, record, &runtimes)?;
-
-        agent
+        build_managed_agent_summary(&app, record, &runtimes)?
     };
 
     // ── Phase 3b: local spawn (async preflight outside store lock) ───────────

--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -73,7 +73,7 @@ pub(crate) async fn ensure_client_node_for_model(
         }
     }
 
-    let availability = match relay::query_relay(&state, &[mesh_llm::mesh_status_filter()]).await {
+    let availability = match relay::query_relay(state, &[mesh_llm::mesh_status_filter()]).await {
         Ok(events) => mesh_llm::availability_from_events(events),
         Err(error) => return Err(format!("failed to read relay mesh status: {error}")),
     };
@@ -96,7 +96,7 @@ pub(crate) async fn ensure_client_node_for_model(
         iroh_relay_url: None,
         iroh_relay_auth: None,
     };
-    hydrate_private_relay_config(&state, &mut start).await?;
+    hydrate_private_relay_config(state, &mut start).await?;
 
     let mut runtime = state.mesh_llm_runtime.lock().await;
     if runtime.is_some() {


### PR DESCRIPTION
The `skippy-ffi` build.rs in mesh-llm-sdk auto-runs `prepare-llama.sh` when llama.cpp static archives are missing. That script uses `git -C` which walks upward into the enclosing Sprout repo when `.deps/llama.cpp/.git` doesn't exist, corrupting `origin` remote URL, user identity, and HEAD state for every developer who runs `cargo clippy`/`cargo build` on the desktop Tauri crate.

This adds `desktop/src-tauri/.cargo/config.toml` setting `SKIPPY_LLAMA_AUTO_BUILD=0`, scoped to only the desktop crate. Native inference still works via explicit `just llama-build`. Builds, tests, clippy, and CI are all unaffected — the auto-build path was already broken (it corrupts the repo before completing).

- Add `desktop/src-tauri/.cargo/config.toml` with `SKIPPY_LLAMA_AUTO_BUILD = "0"`
- Scoped to desktop crate only — zero effect on workspace-level cargo commands

Upstream fix: [Mesh-LLM/mesh-llm#780](https://github.com/Mesh-LLM/mesh-llm/pull/780). Remove this workaround once mesh-llm-sdk is bumped past that fix.