### PR TITLE
fix(desktop): use public re-export path for ensure_client_node_for_model

### DIFF
--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -112,7 +112,7 @@ pub async fn restore_managed_agents_on_launch(
                 continue;
             };
             if let Err(error) =
-                crate::commands::mesh_llm::ensure_client_node_for_model(&state, model_id).await
+                crate::commands::ensure_client_node_for_model(&state, model_id).await
             {
                 persist_restore_error(app, &state, &record.pubkey, error)?;
                 mesh_preflight_failures.insert(record.pubkey.clone());


### PR DESCRIPTION
One-line fix for a compilation failure with `--features=mesh-llm` introduced in #823. The `mesh_llm` module in `commands/mod.rs` is private — `restore.rs` was referencing `crate::commands::mesh_llm::ensure_client_node_for_model` through the private module path instead of the `pub use mesh_llm::*` re-export at `crate::commands::ensure_client_node_for_model`.

Only affects builds with `--features=mesh-llm` (`just dev`, `just staging`, `just desktop-release-build`). Default builds are unaffected.