### PR TITLE
fix(desktop): let inbox composer fill available width

### DIFF
--- a/desktop/src/features/home/ui/InboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/InboxDetailPane.tsx
@@ -342,7 +342,7 @@ export function InboxDetailPane({
             <MessageComposer
               channelId={item.item.channelId}
               channelName={item.channelLabel ?? "channel"}
-              containerClassName="px-4 pb-4 sm:px-4 [&>div]:mx-auto [&>div]:max-w-4xl"
+              containerClassName="px-4 pb-4 sm:px-4"
               disabled={!canReply}
               draftKey={`inbox-reply:${item.id}`}
               isSending={isSendingReply}


### PR DESCRIPTION
## Summary
- Let the Home inbox reply composer use the full detail pane width instead of stopping at a centered max width.
- Keep the existing composer padding and styling unchanged.

## Test plan
- Pre-push hooks passed during `git push -u origin inbox-composer-width-fix`.
- Desktop tests and Tauri clippy/tests passed in the pre-push output.
