### PR TITLE
fix: use immutable commit-SHA URLs in screenshot PR comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,8 +292,9 @@ just desktop-screenshot --name copy-hover \
 Available mock channels: `general`, `random`, `design`, `sales`, `engineering`,
 `agents`, `watercooler`, `announcements`, `alice-tyler`, `bob-tyler`.
 
-`scripts/post-screenshots.sh` hosts PNGs on a per-developer orphan branch
-(`agent-screenshots/<github-username>`) and posts a PR comment:
+`scripts/post-screenshots.sh` hosts PNGs on a per-developer branch
+(`agent-screenshots/<github-username>`) and posts a PR comment with
+commit-SHA-based image URLs (immutable — safe from later overwrites):
 
 ```bash
 ./scripts/post-screenshots.sh 803 test-results/screenshots

--- a/scripts/post-screenshots.sh
+++ b/scripts/post-screenshots.sh
@@ -18,7 +18,6 @@ fi
 GH_USER=$(gh api user --jq .login)
 BRANCH="agent-screenshots/${GH_USER}"
 REPO="block/sprout"
-RAW_BASE="https://raw.githubusercontent.com/${REPO}/refs/heads/${BRANCH}"
 
 mapfile -t PNGS < <(find "$PNG_DIR" -maxdepth 1 -name "*.png" -type f | sort)
 if [[ ${#PNGS[@]} -eq 0 ]]; then
@@ -32,7 +31,7 @@ if git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/
 fi
 
 NEW_ENTRIES=""
-IMAGE_URLS=()
+TREE_PATHS=()
 for PNG in "${PNGS[@]}"; do
   FILENAME=$(basename "$PNG")
   if ! [[ "$FILENAME" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
@@ -42,19 +41,28 @@ for PNG in "${PNGS[@]}"; do
   BLOB=$(git hash-object -w "$PNG")
   TREE_PATH="pr-${PR}--${FILENAME}"
   NEW_ENTRIES+="$(printf '100644 blob %s\t%s' "$BLOB" "$TREE_PATH")"$'\n'
-  IMAGE_URLS+=("${RAW_BASE}/${TREE_PATH}")
+  TREE_PATHS+=("$TREE_PATH")
 done
 
 COMBINED=$(printf '%s\n' "$EXISTING_ENTRIES" "$NEW_ENTRIES" | grep -v '^$')
 TREE=$(echo "$COMBINED" | git mktree)
 
-COMMIT=$(git commit-tree "$TREE" -m "screenshots: PR #${PR}")
+PARENT_ARGS=()
+if git rev-parse "origin/${BRANCH}" >/dev/null 2>&1; then
+  PARENT_ARGS=(-p "origin/${BRANCH}")
+fi
+COMMIT=$(git commit-tree "$TREE" "${PARENT_ARGS[@]}" -m "screenshots: PR #${PR}")
 git push --force-with-lease origin "${COMMIT}:refs/heads/${BRANCH}"
 
+RAW_BASE="https://raw.githubusercontent.com/${REPO}/${COMMIT}"
+
 declare -A IMAGE_URL_MAP
+IMAGE_URLS=()
 for i in "${!PNGS[@]}"; do
   ORIG_NAME="$(basename "${PNGS[$i]}" .png)"
-  IMAGE_URL_MAP["$ORIG_NAME"]="${IMAGE_URLS[$i]}"
+  URL="${RAW_BASE}/${TREE_PATHS[$i]}"
+  IMAGE_URLS+=("$URL")
+  IMAGE_URL_MAP["$ORIG_NAME"]="$URL"
 done
 
 if [[ -n "$BODY_FILE" ]]; then


### PR DESCRIPTION
Switches `scripts/post-screenshots.sh` to use commit-SHA-based `raw.githubusercontent.com` URLs instead of branch-ref URLs, so screenshot images in PR comments remain reachable permanently.

Previously, image URLs pointed at `refs/heads/agent-screenshots/<user>`, a mutable ref that resolves to whatever the branch HEAD is at read time. When a subsequent push for a different PR failed to preserve an earlier PR's files in the tree (due to a fetch-then-push race), all prior PR comments' images returned 404. This happened to the screenshots on #826 today — the PR #802 agent pushed a new tree with only its own files, silently dropping the #826 blobs.

- Collect tree paths during the blob-writing loop, then construct URLs from `${REPO}/${COMMIT}` after the push — each PR comment now references the exact commit that carries its blobs
- Chain commits with a `-p` parent flag so the `agent-screenshots/<user>` branch has a readable linear history instead of a single-root orphan on every push
- Update `AGENTS.md` to drop the "orphan branch" description and note the immutability guarantee