### PR TITLE
fix(desktop): resolve relay mesh target on saved start

### DIFF
--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -1,8 +1,6 @@
 use nostr::{Keys, ToBech32};
 use tauri::{AppHandle, State};
 
-#[cfg(feature = "mesh-llm")]
-use crate::managed_agents::{relay_mesh_model_id, RELAY_MESH_API_BASE_URL};
 use crate::{
     app_state::AppState,
     managed_agents::{
@@ -31,17 +29,11 @@ fn workspace_owner_hex(state: &AppState) -> Result<String, String> {
 
 #[cfg(feature = "mesh-llm")]
 async fn ensure_relay_mesh_for_record(
-    _state: &AppState,
+    state: &AppState,
     record: &ManagedAgentRecord,
     allow_fresh_create_start: bool,
 ) -> Result<(), String> {
-    if allow_fresh_create_start || relay_mesh_model_id(record).is_none() {
-        return Ok(());
-    }
-
-    Err(format!(
-        "relay mesh agents cannot be started from saved state because the selected serve target is not persisted. Create a new agent with Run on relay mesh selected to refresh the target for {RELAY_MESH_API_BASE_URL}."
-    ))
+    crate::commands::ensure_relay_mesh_for_record(state, record, allow_fresh_create_start).await
 }
 
 #[cfg(not(feature = "mesh-llm"))]

--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -1,6 +1,6 @@
 use tauri::{AppHandle, State};
 
-use crate::{app_state::AppState, mesh_llm, relay};
+use crate::{app_state::AppState, managed_agents::RELAY_MESH_API_BASE_URL, mesh_llm, relay};
 
 const RELAY_MESH_RUNTIME_NO_TARGET: &str =
     "relay mesh client start requires a concrete serve target; reopen the agent with Run on relay mesh selected to refresh its target";
@@ -120,6 +120,85 @@ pub(crate) async fn ensure_client_node_for_model(
     Ok(status)
 }
 
+/// Re-resolve a live serve target's dial pointer for a saved relay-mesh agent.
+///
+/// The serve target's `endpoint_addr` is live discovery state — it comes from
+/// the peer's replaceable kind:30621 status event and rotates when the peer's
+/// iroh endpoint changes — so it is never persisted onto the agent record.
+/// Instead, a saved agent re-resolves a current bootstrap target at start time
+/// by matching its configured model against the targets the relay is gossiping
+/// right now. We only need *any* live target for the model to bootstrap the
+/// client node; mesh-llm's router picks the per-request host afterwards.
+///
+/// `Err` means the relay query itself failed (relay down, auth, network) — we
+/// could not refresh targets at all and must not pretend the peer is offline.
+/// `Ok(None)` means the relay answered but no live target currently serves this
+/// model (genuine peer-offline). `Ok(Some(addr))` is a dialable bootstrap
+/// target.
+pub(crate) async fn resolve_mesh_bootstrap_target(
+    state: &AppState,
+    model_id: &str,
+) -> Result<Option<String>, String> {
+    let model_id = model_id.trim();
+    if model_id.is_empty() {
+        return Ok(None);
+    }
+    let events = relay::query_relay(state, &[mesh_llm::mesh_status_filter()]).await?;
+    Ok(pick_serve_target_for_model(
+        mesh_llm::availability_from_events(events).serve_targets,
+        model_id,
+    ))
+}
+
+/// Pure target-selection used by `resolve_mesh_bootstrap_target`: the first
+/// gossiped serve target that hosts `model_id`. Split out so the matching rule
+/// is unit-testable without a relay round-trip.
+fn pick_serve_target_for_model(
+    targets: Vec<mesh_llm::MeshServeTarget>,
+    model_id: &str,
+) -> Option<String> {
+    targets
+        .into_iter()
+        .find(|target| target.model_id == model_id)
+        .map(|target| target.endpoint_addr)
+}
+
+/// Decide whether a relay-mesh agent may start, and bring up its local mesh
+/// client when needed.
+///
+/// Fresh create (`allow_fresh_create_start`) has just run the client-start flow
+/// from the dialog, so it spawns as-is. For a saved/manual start the serve
+/// target's dial pointer was never persisted (it is live discovery state), so
+/// re-resolve a current bootstrap target from the relay's gossiped targets and
+/// dial it. The two failure modes get distinct, actionable copy: a relay query
+/// failure ("could not refresh targets") is not the same as a relay that
+/// answered with no live target for this model ("peer offline"). Non relay-mesh
+/// records are a no-op.
+pub(crate) async fn ensure_relay_mesh_for_record(
+    state: &AppState,
+    record: &crate::managed_agents::ManagedAgentRecord,
+    allow_fresh_create_start: bool,
+) -> Result<(), String> {
+    if allow_fresh_create_start {
+        return Ok(());
+    }
+    let Some(model_id) = crate::managed_agents::relay_mesh_model_id(record) else {
+        return Ok(());
+    };
+    match resolve_mesh_bootstrap_target(state, &model_id).await {
+        Ok(Some(endpoint_addr)) => {
+            ensure_client_node_for_model(state, &model_id, Some(endpoint_addr)).await?;
+            Ok(())
+        }
+        Ok(None) => Err(format!(
+            "relay mesh agents cannot be started from saved state because no live serve target is available for this model. Start serving on a mesh peer, or create a new agent with Run on relay mesh selected to refresh the target for {RELAY_MESH_API_BASE_URL}."
+        )),
+        Err(error) => Err(format!(
+            "could not refresh relay mesh serve targets to start this agent: {error}"
+        )),
+    }
+}
+
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MeshDialEndpointRequest {
@@ -204,6 +283,41 @@ pub fn mesh_agent_preset(
 mod tests {
     use super::*;
     use crate::app_state::build_app_state;
+
+    fn target(model_id: &str, endpoint_addr: &str) -> mesh_llm::MeshServeTarget {
+        mesh_llm::MeshServeTarget {
+            model_id: model_id.to_string(),
+            model_name: None,
+            endpoint_addr: endpoint_addr.to_string(),
+            node_name: None,
+            capacity: None,
+            reporter_pubkey: None,
+            endpoint_id: None,
+            device_id: None,
+            device_name: None,
+        }
+    }
+
+    #[test]
+    fn pick_serve_target_returns_first_match_for_model() {
+        let targets = vec![
+            target("model-a", "addr-a"),
+            target("model-b", "addr-b1"),
+            target("model-b", "addr-b2"),
+        ];
+        // Matches by model id, returns the first such target's dial pointer.
+        assert_eq!(
+            pick_serve_target_for_model(targets, "model-b"),
+            Some("addr-b1".to_string())
+        );
+    }
+
+    #[test]
+    fn pick_serve_target_none_when_model_not_hosted() {
+        let targets = vec![target("model-a", "addr-a")];
+        // No live target serves this model -> caller falls closed.
+        assert_eq!(pick_serve_target_for_model(targets, "model-missing"), None);
+    }
 
     #[tokio::test]
     async fn cold_client_preflight_requires_explicit_target() {

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -1,9 +1,9 @@
+#[cfg(feature = "mesh-llm")]
+use super::relay_mesh_model_id;
 use super::{
     find_managed_agent_mut, kill_stale_tracked_processes, load_managed_agents, save_managed_agents,
     spawn_agent_child, sync_managed_agent_processes, BackendKind, ManagedAgentProcess,
 };
-#[cfg(feature = "mesh-llm")]
-use super::{relay_mesh_model_id, RELAY_MESH_API_BASE_URL};
 use crate::app_state::AppState;
 use crate::util;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -111,16 +111,15 @@ pub async fn restore_managed_agents_on_launch(
             if relay_mesh_model_id(record).is_none() {
                 continue;
             }
-
-            persist_restore_error(
-                app,
-                &state,
-                &record.pubkey,
-                format!(
-                    "relay mesh agents cannot auto-start because the selected serve target is not persisted. Create a new agent with Run on relay mesh selected to refresh the target for {RELAY_MESH_API_BASE_URL}."
-                ),
-            )?;
-            mesh_preflight_failures.insert(record.pubkey.clone());
+            // Auto-start after relaunch: re-resolve a live bootstrap target and
+            // dial it. Skip (with an actionable error) only when no live target
+            // serves this model right now.
+            if let Err(error) =
+                crate::commands::ensure_relay_mesh_for_record(&state, record, false).await
+            {
+                persist_restore_error(app, &state, &record.pubkey, error)?;
+                mesh_preflight_failures.insert(record.pubkey.clone());
+            }
         }
         agents_to_start
             .into_iter()

--- a/desktop/src-tauri/src/mesh_llm/mod.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod.rs
@@ -4,6 +4,9 @@ mod discovery;
 pub use discovery::{availability_from_events, mesh_status_filter};
 use discovery::{device_name_from_status, endpoint_id_from_status, enrich_status_payload_identity};
 
+mod preset;
+pub use preset::{agent_preset, MeshAgentPreset, MeshAgentPresetRequest};
+
 use mesh_llm_sdk::{client, serve, EmbeddedNodeHandle, MeshDiscoveryMode};
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +16,12 @@ const MESH_STATUS_KIND: u64 = 30_621;
 const MESH_API_PORT_ENV: &str = "SPROUT_MESH_API_PORT";
 const MESH_CONSOLE_PORT_ENV: &str = "SPROUT_MESH_CONSOLE_PORT";
 const RELAY_MESH_API_KEY_PLACEHOLDER: &str = "sprout-mesh-local";
+/// ACP provider relay-mesh agents run on. Sources of truth for its command +
+/// MCP live in the provider catalog (`known_acp_provider_exact`); these are
+/// only the fallbacks. `sprout-agent` reads the `SPROUT_AGENT_PROVIDER` /
+/// `OPENAI_COMPAT_*` env vars below — goose (the global default) does not.
+const MESH_AGENT_PROVIDER_ID: &str = "sprout-agent";
+const MESH_AGENT_MCP_COMMAND: &str = "sprout-dev-mcp";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -440,54 +449,6 @@ pub(super) fn dedupe_models(models: Vec<MeshModelOption>) -> Vec<MeshModelOption
         .into_iter()
         .map(|(id, name)| MeshModelOption { id, name })
         .collect()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct MeshAgentPresetRequest {
-    pub model_id: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct MeshAgentPreset {
-    pub provider_id: String,
-    pub label: String,
-    pub acp_command: String,
-    pub agent_command: String,
-    pub agent_args: Vec<String>,
-    pub mcp_command: String,
-    pub model: String,
-    pub env_vars: BTreeMap<String, String>,
-}
-
-pub fn agent_preset(request: MeshAgentPresetRequest) -> Result<MeshAgentPreset, String> {
-    let model = request.model_id.trim();
-    if model.is_empty() {
-        return Err("modelId is required".to_string());
-    }
-    Ok(MeshAgentPreset {
-        provider_id: "relay-mesh".to_string(),
-        label: "Relay mesh".to_string(),
-        acp_command: crate::managed_agents::DEFAULT_ACP_COMMAND.to_string(),
-        agent_command: crate::managed_agents::DEFAULT_AGENT_COMMAND.to_string(),
-        agent_args: Vec::new(),
-        mcp_command: crate::managed_agents::DEFAULT_MCP_COMMAND.to_string(),
-        model: model.to_string(),
-        env_vars: BTreeMap::from([
-            ("SPROUT_AGENT_PROVIDER".to_string(), "openai".to_string()),
-            (
-                "OPENAI_COMPAT_BASE_URL".to_string(),
-                relay_mesh_api_base_url()?,
-            ),
-            ("OPENAI_COMPAT_MODEL".to_string(), model.to_string()),
-            (
-                "OPENAI_COMPAT_API_KEY".to_string(),
-                RELAY_MESH_API_KEY_PLACEHOLDER.to_string(),
-            ),
-            ("OPENAI_COMPAT_API".to_string(), "chat".to_string()),
-        ]),
-    })
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/mesh_llm/mod_tests.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod_tests.rs
@@ -32,3 +32,35 @@ fn model_ref_is_family_agnostic() {
     assert!(!looks_like_model_ref("Qwen3-35B"));
     assert!(!looks_like_model_ref(""));
 }
+
+#[test]
+fn agent_preset_runs_on_sprout_agent_not_goose() {
+    // Regression (Tyler): the relay-mesh preset used to hand the agent the
+    // global default runtime (goose), which ignores the OpenAI-compat env
+    // vars and falls back to its own provider. Mesh agents must run on
+    // sprout-agent, which reads those vars.
+    let preset = super::agent_preset(super::MeshAgentPresetRequest {
+        model_id: "Qwen3-8B-Q4_K_M".to_string(),
+    })
+    .expect("preset for a valid model id");
+
+    assert_eq!(preset.agent_command, "sprout-agent");
+    assert_ne!(preset.agent_command, "goose");
+    assert_eq!(preset.mcp_command, "sprout-dev-mcp");
+
+    // The env vars sprout-agent's config layer reads (crates/sprout-agent).
+    assert_eq!(
+        preset
+            .env_vars
+            .get("SPROUT_AGENT_PROVIDER")
+            .map(String::as_str),
+        Some("openai")
+    );
+    assert_eq!(
+        preset
+            .env_vars
+            .get("OPENAI_COMPAT_MODEL")
+            .map(String::as_str),
+        Some("Qwen3-8B-Q4_K_M")
+    );
+}

--- a/desktop/src-tauri/src/mesh_llm/preset.rs
+++ b/desktop/src-tauri/src/mesh_llm/preset.rs
@@ -1,0 +1,69 @@
+//! Relay-mesh "Run on relay mesh" agent preset. Kept in a sibling file so
+//! `mod.rs` stays under the 500-line budget; `#[path]`-included from there.
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    relay_mesh_api_base_url, MESH_AGENT_MCP_COMMAND, MESH_AGENT_PROVIDER_ID,
+    RELAY_MESH_API_KEY_PLACEHOLDER,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MeshAgentPresetRequest {
+    pub model_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MeshAgentPreset {
+    pub provider_id: String,
+    pub label: String,
+    pub acp_command: String,
+    pub agent_command: String,
+    pub agent_args: Vec<String>,
+    pub mcp_command: String,
+    pub model: String,
+    pub env_vars: BTreeMap<String, String>,
+}
+
+pub fn agent_preset(request: MeshAgentPresetRequest) -> Result<MeshAgentPreset, String> {
+    let model = request.model_id.trim();
+    if model.is_empty() {
+        return Err("modelId is required".to_string());
+    }
+    // Run on sprout-agent, not the global default (goose). Source command +
+    // MCP from the catalog so this can't drift from the provider definition.
+    let sprout_agent = crate::managed_agents::known_acp_provider_exact(MESH_AGENT_PROVIDER_ID);
+    let agent_command = sprout_agent
+        .and_then(|p| p.commands.first().copied())
+        .unwrap_or(MESH_AGENT_PROVIDER_ID)
+        .to_string();
+    let mcp_command = sprout_agent
+        .and_then(|p| p.mcp_command)
+        .unwrap_or(MESH_AGENT_MCP_COMMAND)
+        .to_string();
+    Ok(MeshAgentPreset {
+        provider_id: "relay-mesh".to_string(),
+        label: "Relay mesh".to_string(),
+        acp_command: crate::managed_agents::DEFAULT_ACP_COMMAND.to_string(),
+        agent_command,
+        agent_args: Vec::new(),
+        mcp_command,
+        model: model.to_string(),
+        env_vars: BTreeMap::from([
+            ("SPROUT_AGENT_PROVIDER".to_string(), "openai".to_string()),
+            (
+                "OPENAI_COMPAT_BASE_URL".to_string(),
+                relay_mesh_api_base_url()?,
+            ),
+            ("OPENAI_COMPAT_MODEL".to_string(), model.to_string()),
+            (
+                "OPENAI_COMPAT_API_KEY".to_string(),
+                RELAY_MESH_API_KEY_PLACEHOLDER.to_string(),
+            ),
+            ("OPENAI_COMPAT_API".to_string(), "chat".to_string()),
+        ]),
+    })
+}


### PR DESCRIPTION
## Summary
- re-resolve a live relay-mesh bootstrap target for saved/manual starts and restore-on-launch
- keep endpoint_addr as live discovery state; do not persist it on the agent record
- distinguish relay refresh failures from a relay response with no live target for the model

## Verification
- `bin/cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- `bin/cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- `bin/cargo check --manifest-path desktop/src-tauri/Cargo.toml --features mesh-llm`
- `bin/cargo test --manifest-path desktop/src-tauri/Cargo.toml --features mesh-llm pick_serve_target --lib`
- pre-commit hooks passed

Stacked on #834 (`max/mesh-connect-p-tag-hardening`).