### PR TITLE
fix(mesh): run relay-mesh agents on sprout-agent, not goose

### DIFF
--- a/desktop/src-tauri/src/mesh_llm/mod.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod.rs
@@ -4,6 +4,9 @@ mod discovery;
 pub use discovery::{availability_from_events, mesh_status_filter};
 use discovery::{device_name_from_status, endpoint_id_from_status, enrich_status_payload_identity};
 
+mod preset;
+pub use preset::{agent_preset, MeshAgentPreset, MeshAgentPresetRequest};
+
 use mesh_llm_sdk::{client, serve, EmbeddedNodeHandle, MeshDiscoveryMode};
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +16,12 @@ const MESH_STATUS_KIND: u64 = 30_621;
 const MESH_API_PORT_ENV: &str = "SPROUT_MESH_API_PORT";
 const MESH_CONSOLE_PORT_ENV: &str = "SPROUT_MESH_CONSOLE_PORT";
 const RELAY_MESH_API_KEY_PLACEHOLDER: &str = "sprout-mesh-local";
+/// ACP provider relay-mesh agents run on. Sources of truth for its command +
+/// MCP live in the provider catalog (`known_acp_provider_exact`); these are
+/// only the fallbacks. `sprout-agent` reads the `SPROUT_AGENT_PROVIDER` /
+/// `OPENAI_COMPAT_*` env vars below — goose (the global default) does not.
+const MESH_AGENT_PROVIDER_ID: &str = "sprout-agent";
+const MESH_AGENT_MCP_COMMAND: &str = "sprout-dev-mcp";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -440,54 +449,6 @@ pub(super) fn dedupe_models(models: Vec<MeshModelOption>) -> Vec<MeshModelOption
         .into_iter()
         .map(|(id, name)| MeshModelOption { id, name })
         .collect()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct MeshAgentPresetRequest {
-    pub model_id: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct MeshAgentPreset {
-    pub provider_id: String,
-    pub label: String,
-    pub acp_command: String,
-    pub agent_command: String,
-    pub agent_args: Vec<String>,
-    pub mcp_command: String,
-    pub model: String,
-    pub env_vars: BTreeMap<String, String>,
-}
-
-pub fn agent_preset(request: MeshAgentPresetRequest) -> Result<MeshAgentPreset, String> {
-    let model = request.model_id.trim();
-    if model.is_empty() {
-        return Err("modelId is required".to_string());
-    }
-    Ok(MeshAgentPreset {
-        provider_id: "relay-mesh".to_string(),
-        label: "Relay mesh".to_string(),
-        acp_command: crate::managed_agents::DEFAULT_ACP_COMMAND.to_string(),
-        agent_command: crate::managed_agents::DEFAULT_AGENT_COMMAND.to_string(),
-        agent_args: Vec::new(),
-        mcp_command: crate::managed_agents::DEFAULT_MCP_COMMAND.to_string(),
-        model: model.to_string(),
-        env_vars: BTreeMap::from([
-            ("SPROUT_AGENT_PROVIDER".to_string(), "openai".to_string()),
-            (
-                "OPENAI_COMPAT_BASE_URL".to_string(),
-                relay_mesh_api_base_url()?,
-            ),
-            ("OPENAI_COMPAT_MODEL".to_string(), model.to_string()),
-            (
-                "OPENAI_COMPAT_API_KEY".to_string(),
-                RELAY_MESH_API_KEY_PLACEHOLDER.to_string(),
-            ),
-            ("OPENAI_COMPAT_API".to_string(), "chat".to_string()),
-        ]),
-    })
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/mesh_llm/mod_tests.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod_tests.rs
@@ -32,3 +32,35 @@ fn model_ref_is_family_agnostic() {
     assert!(!looks_like_model_ref("Qwen3-35B"));
     assert!(!looks_like_model_ref(""));
 }
+
+#[test]
+fn agent_preset_runs_on_sprout_agent_not_goose() {
+    // Regression (Tyler): the relay-mesh preset used to hand the agent the
+    // global default runtime (goose), which ignores the OpenAI-compat env
+    // vars and falls back to its own provider. Mesh agents must run on
+    // sprout-agent, which reads those vars.
+    let preset = super::agent_preset(super::MeshAgentPresetRequest {
+        model_id: "Qwen3-8B-Q4_K_M".to_string(),
+    })
+    .expect("preset for a valid model id");
+
+    assert_eq!(preset.agent_command, "sprout-agent");
+    assert_ne!(preset.agent_command, "goose");
+    assert_eq!(preset.mcp_command, "sprout-dev-mcp");
+
+    // The env vars sprout-agent's config layer reads (crates/sprout-agent).
+    assert_eq!(
+        preset
+            .env_vars
+            .get("SPROUT_AGENT_PROVIDER")
+            .map(String::as_str),
+        Some("openai")
+    );
+    assert_eq!(
+        preset
+            .env_vars
+            .get("OPENAI_COMPAT_MODEL")
+            .map(String::as_str),
+        Some("Qwen3-8B-Q4_K_M")
+    );
+}

--- a/desktop/src-tauri/src/mesh_llm/preset.rs
+++ b/desktop/src-tauri/src/mesh_llm/preset.rs
@@ -1,0 +1,69 @@
+//! Relay-mesh "Run on relay mesh" agent preset. Kept in a sibling file so
+//! `mod.rs` stays under the 500-line budget; `#[path]`-included from there.
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    relay_mesh_api_base_url, MESH_AGENT_MCP_COMMAND, MESH_AGENT_PROVIDER_ID,
+    RELAY_MESH_API_KEY_PLACEHOLDER,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MeshAgentPresetRequest {
+    pub model_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MeshAgentPreset {
+    pub provider_id: String,
+    pub label: String,
+    pub acp_command: String,
+    pub agent_command: String,
+    pub agent_args: Vec<String>,
+    pub mcp_command: String,
+    pub model: String,
+    pub env_vars: BTreeMap<String, String>,
+}
+
+pub fn agent_preset(request: MeshAgentPresetRequest) -> Result<MeshAgentPreset, String> {
+    let model = request.model_id.trim();
+    if model.is_empty() {
+        return Err("modelId is required".to_string());
+    }
+    // Run on sprout-agent, not the global default (goose). Source command +
+    // MCP from the catalog so this can't drift from the provider definition.
+    let sprout_agent = crate::managed_agents::known_acp_provider_exact(MESH_AGENT_PROVIDER_ID);
+    let agent_command = sprout_agent
+        .and_then(|p| p.commands.first().copied())
+        .unwrap_or(MESH_AGENT_PROVIDER_ID)
+        .to_string();
+    let mcp_command = sprout_agent
+        .and_then(|p| p.mcp_command)
+        .unwrap_or(MESH_AGENT_MCP_COMMAND)
+        .to_string();
+    Ok(MeshAgentPreset {
+        provider_id: "relay-mesh".to_string(),
+        label: "Relay mesh".to_string(),
+        acp_command: crate::managed_agents::DEFAULT_ACP_COMMAND.to_string(),
+        agent_command,
+        agent_args: Vec::new(),
+        mcp_command,
+        model: model.to_string(),
+        env_vars: BTreeMap::from([
+            ("SPROUT_AGENT_PROVIDER".to_string(), "openai".to_string()),
+            (
+                "OPENAI_COMPAT_BASE_URL".to_string(),
+                relay_mesh_api_base_url()?,
+            ),
+            ("OPENAI_COMPAT_MODEL".to_string(), model.to_string()),
+            (
+                "OPENAI_COMPAT_API_KEY".to_string(),
+                RELAY_MESH_API_KEY_PLACEHOLDER.to_string(),
+            ),
+            ("OPENAI_COMPAT_API".to_string(), "chat".to_string()),
+        ]),
+    })
+}


### PR DESCRIPTION
## What

Relay-mesh agents now run on the **sprout-agent** runtime instead of goose.

`mesh_llm::agent_preset` set `agent_command = DEFAULT_AGENT_COMMAND` (goose) and `mcp_command = DEFAULT_MCP_COMMAND` (sprout-mcp-server) while emitting `SPROUT_AGENT_PROVIDER=openai` + `OPENAI_COMPAT_*` env vars. Goose ignores those vars and falls back to its own configured provider, so mesh agents never used the local mesh endpoint.

The env set was already correct — it's exactly what `crates/sprout-agent/src/config.rs` reads. It was just being handed to the wrong runtime.

## Change

- `agent_command` / `mcp_command` now sourced from the `sprout-agent` provider catalog entry (`known_acp_provider_exact`) → `sprout-agent` / `sprout-dev-mcp`, with consts as fallbacks. Can't drift from the provider definition.
- Env vars / base_url / model / api_key: **unchanged** (already correct for sprout-agent).
- Extracted the preset into a sibling `preset.rs` via the existing `#[path]` pattern — `mod.rs` was at 495 lines (the 500-line budget ceiling); this keeps it under and isolates preset logic. Reads as: `mod.rs` −48 (move-out), `preset.rs` +69 (move-in + the fix), `mod_tests.rs` +32 (regression test).
- Added regression test `agent_preset_runs_on_sprout_agent_not_goose`.

Matches the frontend `applyMeshAgentPreset.test.mjs` contract, which already expected `agentCommand: sprout-agent` / `mcpCommand: sprout-dev-mcp`.

## Verification

- Full `cargo test -p sprout-desktop --features mesh-llm --lib`: **441 pass** + new regression test
- No-feature gates (pre-push parity, run sequentially): `desktop-tauri-clippy`, `desktop-tauri-test`, workspace `clippy`, `test-unit` — all green
- Frontend preset tests 10/10
- fmt + clippy clean

Stacked on #846.
