### PR TITLE
fix(desktop): scroll activity panel to bottom on open

### DIFF
--- a/desktop/src/shared/hooks/useStickToBottom.ts
+++ b/desktop/src/shared/hooks/useStickToBottom.ts
@@ -27,6 +27,9 @@ export function useStickToBottom<T extends HTMLElement = HTMLDivElement>() {
     const el = ref.current;
     if (!el) return;
 
+    // Start at the bottom; the observer below only reacts to later changes.
+    el.scrollTop = el.scrollHeight;
+
     let rafId: number | null = null;
 
     const scrollIfSticky = () => {


### PR DESCRIPTION
## What

When the **View activity** sidebar opens, it now scrolls to the latest message instead of sitting at the top.

## Why

The panel (`AgentSessionThreadPanel`) uses the `useStickToBottom` hook, whose `MutationObserver` only reacts to *subsequent* DOM changes. Content already present when the container mounts — e.g. opening the panel onto an existing thread — stayed scrolled at the top.

## Change

One-line fix in `useStickToBottom`: on mount, do an instant `el.scrollTop = el.scrollHeight` jump so the newest content is in view. Instant (not smooth) because it's an initial position, not an animated update. The existing observer continues to handle content that streams in later (`isNearBottom` starts true).

## Testing

- Typecheck ✅
- Desktop e2e smoke ✅ (the activity-panel test passes; the one unrelated failure is a pre-existing keyboard-focus flake in `smoke.spec.ts:269`, passes in isolation)
- Full pre-push suite (rust, desktop, mobile, tauri) ✅
