### PR TITLE
fix(desktop): simplify profile popover header

### DIFF
--- a/desktop/src/features/profile/ui/ProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/ProfilePopover.tsx
@@ -6,7 +6,6 @@ import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
 import { getPresenceLabel } from "@/features/presence/lib/presence";
 import { SetStatusDialog } from "@/features/user-status/ui/SetStatusDialog";
-import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 import type { PresenceStatus } from "@/shared/api/types";
 import { isMacPlatform } from "@/shared/lib/platform";
 
@@ -18,7 +17,6 @@ interface ProfilePopoverProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   displayName: string;
-  nip05?: string | null;
   avatarUrl: string | null;
   currentStatus: PresenceStatus;
   isStatusPending?: boolean;
@@ -56,7 +54,6 @@ export function ProfilePopover({
   open,
   onOpenChange,
   displayName,
-  nip05,
   avatarUrl,
   currentStatus,
   isStatusPending,
@@ -154,31 +151,13 @@ export function ProfilePopover({
                 <p className="truncate text-sm font-semibold leading-tight text-popover-foreground">
                   {displayName}
                 </p>
-                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  {nip05 ? <span className="truncate">@{nip05}</span> : null}
-                  {nip05 ? <span aria-hidden="true">·</span> : null}
-                  <span
-                    className="inline-flex items-center gap-1.5"
-                    data-testid="profile-popover-current-status"
-                  >
-                    <PresenceDot status={currentStatus} />
-                    <span>{getPresenceLabel(currentStatus)}</span>
-                  </span>
+                <div
+                  className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+                  data-testid="profile-popover-current-status"
+                >
+                  <PresenceDot status={currentStatus} />
+                  <span>{getPresenceLabel(currentStatus)}</span>
                 </div>
-                {hasUserStatus ? (
-                  <p
-                    className="mt-0.5 truncate text-xs text-muted-foreground"
-                    data-testid="profile-popover-user-status"
-                  >
-                    {userStatusEmoji ? (
-                      <StatusEmoji
-                        className="mr-1 h-3.5 w-3.5"
-                        value={userStatusEmoji}
-                      />
-                    ) : null}
-                    {userStatusText}
-                  </p>
-                ) : null}
               </div>
             </div>
 

--- a/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
@@ -119,7 +119,6 @@ export function SidebarProfileCard({
             open={profilePopoverOpen}
             onOpenChange={setProfilePopoverOpen}
             displayName={resolvedDisplayName}
-            nip05={profile?.nip05Handle}
             avatarUrl={profile?.avatarUrl ?? null}
             currentStatus={selfPresenceStatus}
             isStatusPending={isPresencePending}


### PR DESCRIPTION
## Summary

The profile menu header no longer repeats custom status or account metadata. It now shows just the user name and current presence, while the editable status control remains available below.

## Test plan

- `bin/just desktop-check`
- `bin/just desktop-screenshot --name profile-popover-header-fix --click open-settings`
