### PR TITLE
feat(acp): default SPROUT_ACP_MEMORY to on

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -215,7 +215,7 @@ sprout channels add-member --channel "$CHANNEL" --pubkey "$AGENT_PUBKEY" --role 
 export SPROUT_PRIVATE_KEY="$AGENT_SK"
 export SPROUT_RELAY_URL=ws://localhost:3000   # match step 3 (e.g. ws://localhost:3030 if overridden)
 export SPROUT_ACP_RESPOND_TO=anyone           # default is owner-only; opens the gate for testing
-export SPROUT_ACP_MEMORY=true                 # opt in to NIP-AE core-memory prompt injection
+# NIP-AE core-memory prompt injection is on by default; set SPROUT_ACP_NO_MEMORY=true to opt out.
 export SPROUT_ACP_MCP_COMMAND="$PWD/target/release/sprout-mcp-server"  # explicit path beats $PATH
 export GOOSE_MODE=auto                        # must be 'auto' or goose hangs on prompts
 

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -330,26 +330,25 @@ pub struct CliArgs {
 
     /// Enable NIP-AE agent core memory injection.
     ///
-    /// Memory injection is off by default for now. When enabled, the harness
+    /// Memory injection is on by default. When enabled, the harness
     /// fetches the agent's per-session core engram and renders it as an
     /// `[Agent Memory — core]` prompt section (or renders the onboarding nudge
     /// when the relay confirms no core engram exists). The `sprout mem` CLI
     /// and the relay's acceptance of kind:30174 engrams are unaffected — this
     /// flag controls prompt-time injection in the ACP harness only.
-    #[arg(long, env = "SPROUT_ACP_MEMORY", conflicts_with = "no_memory")]
+    /// Pass `--no-memory` / `SPROUT_ACP_NO_MEMORY=true` to disable.
+    #[arg(
+        long,
+        env = "SPROUT_ACP_MEMORY",
+        conflicts_with = "no_memory",
+        default_value_t = true
+    )]
     pub memory: bool,
 
     /// Disable NIP-AE agent core memory injection.
     ///
-    /// Deprecated compatibility alias for the previous default-on behavior.
-    /// The flag/env var is still accepted, but memory injection is already off
-    /// unless `--memory` / `SPROUT_ACP_MEMORY=true` is provided.
-    #[arg(
-        long,
-        env = "SPROUT_ACP_NO_MEMORY",
-        conflicts_with = "memory",
-        hide = true
-    )]
+    /// Memory injection is on by default; set this flag/env var to opt out.
+    #[arg(long, env = "SPROUT_ACP_NO_MEMORY", conflicts_with = "memory")]
     pub no_memory: bool,
 
     /// Disable the [Base] platform-context section prepended to every prompt.
@@ -456,8 +455,8 @@ pub struct Config {
     pub typing_enabled: bool,
     /// Whether NIP-AE agent core memory injection is enabled. When false,
     /// the harness skips the per-session core engram fetch and renders no
-    /// `[Agent Memory — core]` section. Mirrors the `--memory` /
-    /// `SPROUT_ACP_MEMORY` opt-in.
+    /// `[Agent Memory — core]` section. On by default; disabled via the
+    /// `--no-memory` / `SPROUT_ACP_NO_MEMORY` opt-out.
     pub memory_enabled: bool,
     /// Desired LLM model ID. Applied after every `session_new_full()`.
     pub model: Option<String>,
@@ -1191,7 +1190,7 @@ mod tests {
             max_turns_per_session: 0,
             presence_enabled: true,
             typing_enabled: true,
-            memory_enabled: false,
+            memory_enabled: true,
             model: None,
             permission_mode: PermissionMode::BypassPermissions,
             respond_to: RespondTo::Anyone,
@@ -1780,21 +1779,21 @@ channels = "ALL"
     // ── memory toggle ───────────────────────────────────────────────────────
 
     #[test]
-    fn test_memory_enabled_default_false() {
+    fn test_memory_enabled_default_true() {
         let config = test_config(SubscribeMode::Mentions);
         assert!(
-            !config.memory_enabled,
-            "memory_enabled should default to false"
+            config.memory_enabled,
+            "memory_enabled should default to true"
         );
     }
 
     #[test]
-    fn test_summary_includes_memory_disabled() {
+    fn test_summary_includes_memory_enabled() {
         let config = test_config(SubscribeMode::Mentions);
         let s = config.summary();
         assert!(
-            s.contains("memory=false"),
-            "summary should include memory=false by default, got: {s}"
+            s.contains("memory=true"),
+            "summary should include memory=true by default, got: {s}"
         );
     }
 

--- a/crates/sprout-acp/src/lib.rs
+++ b/crates/sprout-acp/src/lib.rs
@@ -1104,7 +1104,7 @@ async fn tokio_main() -> Result<()> {
     if !config.memory_enabled {
         tracing::info!(
             target: "engram::core",
-            "NIP-AE core memory injection disabled by default (enable with --memory / SPROUT_ACP_MEMORY)"
+            "NIP-AE core memory injection disabled (re-enable by removing --no-memory / SPROUT_ACP_NO_MEMORY)"
         );
     }
 

--- a/crates/sprout-acp/src/pool.rs
+++ b/crates/sprout-acp/src/pool.rs
@@ -219,8 +219,8 @@ pub struct PromptContext {
     /// Whether NIP-AE agent core memory injection is enabled. When false,
     /// the per-session core engram fetch is skipped and `core_sections`
     /// remains empty for every channel, so `format_prompt` renders no
-    /// `[Agent Memory — core]` section. Driven by `--memory` /
-    /// `SPROUT_ACP_MEMORY`.
+    /// `[Agent Memory — core]` section. On by default; disabled via
+    /// `--no-memory` / `SPROUT_ACP_NO_MEMORY`.
     pub memory_enabled: bool,
 }
 
@@ -760,10 +760,11 @@ pub async fn run_prompt_task(
     // happens when a session is invalidated and recreated (see
     // `SessionState::invalidate_channel`).
     //
-    // Operator opt-in: `--memory` / `SPROUT_ACP_MEMORY` enables the NIP-AE
-    // injection path. By default we skip the fetch outright and leave
-    // `state.core_sections` empty, so `format_prompt` renders no core
-    // section. The `sprout mem` CLI and the relay's acceptance of
+    // Operator opt-out: `--no-memory` / `SPROUT_ACP_NO_MEMORY` disables the
+    // NIP-AE injection path. By default we run the fetch and populate
+    // `state.core_sections`, so `format_prompt` renders the core section.
+    // When disabled we skip the fetch outright and leave `core_sections`
+    // empty. The `sprout mem` CLI and the relay's acceptance of
     // kind:30174 engrams are unaffected.
     if is_new_session && ctx.memory_enabled {
         if let (PromptSource::Channel(cid), Some(owner_pk)) =


### PR DESCRIPTION
## What

Flip NIP-AE core-memory prompt injection to **on by default** in the `sprout-acp` harness.

- `--memory` / `SPROUT_ACP_MEMORY` now defaults to `true` (`default_value_t = true`).
- `--no-memory` / `SPROUT_ACP_NO_MEMORY` becomes the real opt-out and is no longer `hide = true` in `--help`.
- Updated doc comments, the startup log line, `TESTING.md`, and the default-behavior unit tests to match.

## Why

Memory injection was previously opt-in (off by default). This makes it the default behavior, with an explicit opt-out preserved for operators who don't want it.

## Notes

- The resolution `memory_enabled: args.memory && !args.no_memory` is unchanged and stays correct: default → `true && !false = true`; with `--no-memory` → `true && !true = false`. `conflicts_with` keeps the two flags mutually exclusive.
- The `sprout mem` CLI and the relay's acceptance of kind:30174 engrams are unaffected — this only changes prompt-time injection in the harness.

## Test

`cargo test -p sprout-acp` → 271 passed, 0 failed. `cargo clippy -p sprout-acp` clean. Verified via `--help` that the default and opt-out render correctly.