### PR TITLE
style: add center dot to unread badges (Discord-style)

### DIFF
--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -193,9 +193,11 @@ export function ChannelMenuButton({
       {hasUnread && !isActive && channel.channelType !== "dm" ? (
         <span
           aria-hidden="true"
-          className="ml-auto h-2.5 w-2.5 shrink-0 rounded-full bg-primary"
+          className="ml-auto flex h-2.5 w-2.5 shrink-0 items-center justify-center rounded-full border-[1.5px] border-primary bg-transparent"
           data-testid={`channel-unread-${channel.name}`}
-        />
+        >
+          <span className="h-1 w-1 rounded-full bg-primary" />
+        </span>
       ) : null}
     </SidebarMenuButton>
   );
@@ -304,9 +306,11 @@ export function SidebarSection({
                     !(isActiveChannel && selectedChannelId === channel.id) ? (
                       <span
                         aria-hidden="true"
-                        className="absolute right-[9px] top-1/2 h-2.5 w-2.5 -translate-y-1/2 rounded-full bg-primary"
+                        className="absolute right-[9px] top-1/2 flex h-2.5 w-2.5 -translate-y-1/2 items-center justify-center rounded-full border-[1.5px] border-primary bg-transparent"
                         data-testid={`channel-unread-${channel.name}`}
-                      />
+                      >
+                        <span className="h-1 w-1 rounded-full bg-primary" />
+                      </span>
                     ) : null}
                     {channel.channelType === "dm" && onHideDm ? (
                       <SidebarMenuAction

--- a/mobile/lib/features/channels/channels_page.dart
+++ b/mobile/lib/features/channels/channels_page.dart
@@ -931,9 +931,18 @@ class _ChannelTile extends ConsumerWidget {
                 key: Key('channel-unread-${channel.id}'),
                 width: 8,
                 height: 8,
+                alignment: Alignment.center,
                 decoration: BoxDecoration(
-                  color: context.colors.primary,
+                  border: Border.all(color: context.colors.primary, width: 1.5),
                   shape: BoxShape.circle,
+                ),
+                child: Container(
+                  width: 3,
+                  height: 3,
+                  decoration: BoxDecoration(
+                    color: context.colors.primary,
+                    shape: BoxShape.circle,
+                  ),
                 ),
               ),
             ],


### PR DESCRIPTION
## Summary

Converts the solid-fill unread notification dots in the sidebar to a ring-with-center-dot style, matching Discord's visual pattern. This addresses an optical illusion where the solid fill makes the dot appear larger than it actually is — the center dot anchors the eye and gives it a scale reference.

## Changes

### Desktop (`SidebarSection.tsx`)
- Both unread dot instances (channel list + collapsed section) now render as a `border-primary` ring with a small inner dot
- Uses `flex` centering to position the inner dot

### Mobile (`channels_page.dart`)
- Unread indicator converted from solid fill to a bordered circle with centered inner dot
- Uses `Border.all` + nested `Container` for the inner dot

## Visual
Before: Solid filled circle (appears optically larger)  
After: Ring with center dot (reads at correct size, Discord-style)

## Testing
- Mobile tests pass (`flutter test`)
- Desktop Tauri clippy + tests pass
- Rust clippy + tests pass
