### PR TITLE
feat(desktop): always show channel section search/add buttons

### DIFF
--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -207,7 +207,6 @@ export function ChannelContextMenuItems({
 function SectionHeaderActions({
   browseAriaLabel,
   browseTestId,
-  className,
   createAriaLabel,
   hasUnread,
   onBrowse,
@@ -216,7 +215,6 @@ function SectionHeaderActions({
 }: {
   browseAriaLabel: string;
   browseTestId?: string;
-  className?: string;
   createAriaLabel: string;
   hasUnread?: boolean;
   onBrowse: () => void;
@@ -224,16 +222,14 @@ function SectionHeaderActions({
   onMarkAllRead?: () => void;
 }) {
   return (
-    <div
-      className={cn(
-        "absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5",
-        className,
-      )}
-    >
+    <div className="absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5">
       {hasUnread && onMarkAllRead ? (
         <button
           aria-label="Mark all as read"
-          className={SECTION_ICON_BUTTON_CLASS}
+          className={cn(
+            SECTION_ICON_BUTTON_CLASS,
+            SECTION_ACTION_VISIBILITY_CLASS,
+          )}
           onClick={onMarkAllRead}
           title="Mark all as read"
           type="button"
@@ -410,7 +406,6 @@ export function ChannelGroupSection({
         <SectionHeaderActions
           browseAriaLabel={browseAriaLabel}
           browseTestId={browseTestId}
-          className={SECTION_ACTION_VISIBILITY_CLASS}
           createAriaLabel={createAriaLabel}
           hasUnread={hasUnread}
           onBrowse={onBrowse}


### PR DESCRIPTION
## What

In the desktop left-hand sidebar, the channel section header's **search (browse)** and **add (create)** icon buttons were only revealed on hover/focus. This makes them **always visible**.

## How

The two buttons live in `SectionHeaderActions` (`CustomChannelSection.tsx`), alongside a conditional "Mark all as read" button. The whole cluster was gated by `SECTION_ACTION_VISIBILITY_CLASS` (`opacity-0 … group-hover/sidebar-section:opacity-100`).

- Dropped that class from the cluster wrapper → search + add are now persistent.
- Applied it to just the "Mark all as read" button, which stays hover-revealed (it's already contextual — only renders when there's unread).
- Removed the now-unused `className` prop on `SectionHeaderActions` (it was only ever passed the visibility class).

Scope is precise: only the main Channels/Forums group header. The custom user-section management affordances (drag handle, rename, delete) keep their hover behavior — those aren't search/add and weren't in scope.

## Test

- `tsc --noEmit` clean
- `biome check` clean on the file
- Existing Playwright e2e (`channels.spec.ts`, `channel-browser.spec.ts`, `stream.spec.ts`) click `browse-channels` / "Create a channel" directly; always-visible is a superset of the prior behavior, so no test relies on these being hover-hidden.

+5 / -10, one file.