### PR TITLE
fix(dm): keep hidden DMs hidden across refetch via relay-signed visibility snapshot (NIP-DV)

### DIFF
--- a/crates/sprout-core/src/filter.rs
+++ b/crates/sprout-core/src/filter.rs
@@ -11,6 +11,24 @@ pub fn filters_match(filters: &[Filter], event: &StoredEvent) -> bool {
     filters.iter().any(|f| filter_match_one(f, event))
 }
 
+/// Result-level read authorization for relay-signed events whose content is
+/// private to a single viewer. Currently only `KIND_DM_VISIBILITY`: the reader
+/// MUST equal the snapshot's `#p` (owner). Returns `true` for every other kind.
+///
+/// This guards the delivery surfaces directly, so a query that bypasses the
+/// filter-level `#p` gate (e.g. a kindless `ids:[…]` lookup of a known snapshot
+/// id) still cannot read another viewer's hidden-DM set.
+pub fn reader_authorized_for_event(event: &nostr::Event, reader_pubkey_hex: &str) -> bool {
+    if crate::kind::event_kind_u32(event) != crate::kind::KIND_DM_VISIBILITY {
+        return true;
+    }
+    let p = nostr::SingleLetterTag::lowercase(nostr::Alphabet::P);
+    event
+        .tags
+        .filter(nostr::TagKind::SingleLetter(p))
+        .any(|t| t.content() == Some(reader_pubkey_hex))
+}
+
 fn filter_match_one(f: &Filter, ev: &StoredEvent) -> bool {
     if let Some(kinds) = &f.kinds {
         if !kinds.contains(&ev.event.kind) {
@@ -212,5 +230,35 @@ mod tests {
             !filters_match(std::slice::from_ref(&h_filter), &stored_with_h),
             "explicit h-tag must be authoritative — channel_id fallback must not override it"
         );
+    }
+
+    #[test]
+    fn reader_authorized_for_event_gates_dm_visibility_by_p() {
+        let relay = Keys::generate();
+        let owner = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let other = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        let snapshot = EventBuilder::new(Kind::Custom(crate::kind::KIND_DM_VISIBILITY as u16), "")
+            .tags([
+                Tag::parse(["d", owner]).unwrap(),
+                Tag::parse(["p", owner]).unwrap(),
+            ])
+            .sign_with_keys(&relay)
+            .expect("sign");
+
+        assert!(
+            reader_authorized_for_event(&snapshot, owner),
+            "owner must be authorized to read their own snapshot"
+        );
+        assert!(
+            !reader_authorized_for_event(&snapshot, other),
+            "a third party must NOT be authorized to read another viewer's snapshot"
+        );
+
+        // Non-DV events are unaffected by this gate.
+        let note = EventBuilder::new(Kind::TextNote, "hi")
+            .sign_with_keys(&relay)
+            .expect("sign");
+        assert!(reader_authorized_for_event(&note, other));
     }
 }

--- a/crates/sprout-core/src/kind.rs
+++ b/crates/sprout-core/src/kind.rs
@@ -161,6 +161,13 @@ pub const KIND_WORKFLOW_DEF: u32 = 30620;
 /// of mesh status, including EndpointAddr dial pointers for serving nodes.
 pub const KIND_MESH_LLM_RELAY_STATUS: u32 = 30621;
 
+/// NIP-DV: per-viewer DM visibility snapshot (relay-signed, parameterized
+/// replaceable, d=viewer_pubkey). Carries one `h` tag per DM the viewer has
+/// hidden from their sidebar. Re-published by the relay on every hide/unhide so
+/// the latest event is always the authoritative hidden set. The relay knows
+/// `hidden_at` per viewer; this is the only Nostr-visible projection of it.
+pub const KIND_DM_VISIBILITY: u32 = 30622;
+
 /// Lower bound of the NIP-33 parameterized replaceable range (30000–39999).
 pub const PARAM_REPLACEABLE_KIND_MIN: u32 = 30000;
 /// Upper bound of the NIP-33 parameterized replaceable range (30000–39999).
@@ -408,6 +415,7 @@ pub const ALL_KINDS: &[u32] = &[
     KIND_CHANNEL_SUMMARY,
     KIND_PRESENCE_SNAPSHOT,
     KIND_MESH_LLM_RELAY_STATUS,
+    KIND_DM_VISIBILITY,
     KIND_DM_OPEN,
     KIND_DM_ADD_MEMBER,
     KIND_DM_HIDE,
@@ -520,7 +528,10 @@ pub const fn is_command_kind(kind: u32) -> bool {
 pub const fn is_relay_only_kind(kind: u32) -> bool {
     matches!(
         kind,
-        KIND_CHANNEL_SUMMARY | KIND_PRESENCE_SNAPSHOT | KIND_MESH_LLM_RELAY_STATUS
+        KIND_CHANNEL_SUMMARY
+            | KIND_PRESENCE_SNAPSHOT
+            | KIND_MESH_LLM_RELAY_STATUS
+            | KIND_DM_VISIBILITY
     )
 }
 
@@ -540,6 +551,7 @@ pub fn event_kind_i32(event: &nostr::Event) -> i32 {
 const _: () = assert!(is_replaceable(KIND_AGENT_PROFILE)); // 10100 ∈ 10000–19999
 const _: () = assert!(is_parameterized_replaceable(KIND_WORKFLOW_DEF)); // 30620 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_MESH_LLM_RELAY_STATUS)); // 30621 ∈ 30000–39999
+const _: () = assert!(is_parameterized_replaceable(KIND_DM_VISIBILITY)); // 30622 ∈ 30000–39999
 
 // Compile-time: NIP-34 parameterized replaceable kinds are in the correct range.
 const _: () = assert!(

--- a/crates/sprout-db/src/dm.rs
+++ b/crates/sprout-db/src/dm.rs
@@ -412,6 +412,32 @@ pub async fn unhide_dm(pool: &PgPool, channel_id: Uuid, pubkey: &[u8]) -> Result
     Ok(())
 }
 
+/// Return the channel IDs of all DMs the given user currently has hidden
+/// (`hidden_at IS NOT NULL`) while still being an active member. Used to build
+/// the relay-signed NIP-DV visibility snapshot.
+pub async fn list_hidden_dms(pool: &PgPool, pubkey: &[u8]) -> Result<Vec<Uuid>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT cm.channel_id
+        FROM channel_members cm
+        JOIN channels c ON c.id = cm.channel_id
+        WHERE cm.pubkey = $1
+          AND cm.removed_at IS NULL
+          AND cm.hidden_at IS NOT NULL
+          AND c.channel_type = 'dm'
+          AND c.deleted_at IS NULL
+        ORDER BY cm.channel_id
+        "#,
+    )
+    .bind(pubkey)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|r| r.try_get::<Uuid, _>("channel_id").map_err(Into::into))
+        .collect()
+}
+
 // -- Row mapping --------------------------------------------------------------
 
 fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<ChannelRecord> {

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -657,6 +657,11 @@ impl Db {
         dm::unhide_dm(&self.pool, channel_id, pubkey).await
     }
 
+    /// List the channel IDs of all DMs the given user currently has hidden.
+    pub async fn list_hidden_dms(&self, pubkey: &[u8]) -> Result<Vec<Uuid>> {
+        dm::list_hidden_dms(&self.pool, pubkey).await
+    }
+
     // ── Threads ──────────────────────────────────────────────────────────────
 
     /// Insert thread metadata.

--- a/crates/sprout-relay/src/api/bridge.rs
+++ b/crates/sprout-relay/src/api/bridge.rs
@@ -266,7 +266,8 @@ pub async fn query_events(
 
     // ── NIP-50 search: route to Typesense if any filter has a `search` field ──
     if filters.iter().any(|f| f.search.is_some()) {
-        return handle_bridge_search(&state, &filters, &accessible_channels).await;
+        return handle_bridge_search(&state, &filters, &accessible_channels, &authed_pubkey_hex)
+            .await;
     }
 
     // ── Presence: synthesize kind:20001 from Redis (ephemeral, never in DB) ──
@@ -438,6 +439,14 @@ pub async fn query_events(
                     if !sprout_core::filter::filters_match(std::slice::from_ref(filter), &se) {
                         continue;
                     }
+                    // Result-level read auth: never hand a viewer-private snapshot
+                    // (kind:30622) to anyone but its owner, even via kindless `ids`.
+                    if !sprout_core::filter::reader_authorized_for_event(
+                        &se.event,
+                        &authed_pubkey_hex,
+                    ) {
+                        continue;
+                    }
                     if let Ok(v) = serde_json::to_value(&se.event) {
                         events.push(v);
                     }
@@ -596,6 +605,7 @@ fn search_hit_accepted(
     filter: &nostr::Filter,
     stored: &sprout_core::StoredEvent,
     accessible_channels: &[uuid::Uuid],
+    reader_pubkey_hex: &str,
 ) -> bool {
     if !sprout_core::filter::filters_match(std::slice::from_ref(filter), stored) {
         return false;
@@ -604,6 +614,9 @@ fn search_hit_accepted(
         if !accessible_channels.contains(&ch_id) {
             return false;
         }
+    }
+    if !sprout_core::filter::reader_authorized_for_event(&stored.event, reader_pubkey_hex) {
+        return false;
     }
     true
 }
@@ -614,6 +627,7 @@ async fn handle_bridge_search(
     state: &AppState,
     filters: &[nostr::Filter],
     accessible_channels: &[uuid::Uuid],
+    reader_pubkey_hex: &str,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     // Bridge always includes global (non-channel) events — same as WS with full scopes.
     let channel_scope = match crate::handlers::req::build_search_channel_scope_filter(
@@ -727,7 +741,7 @@ async fn handle_bridge_search(
                 Some(ev) => ev,
                 None => continue,
             };
-            if !search_hit_accepted(filter, stored, accessible_channels) {
+            if !search_hit_accepted(filter, stored, accessible_channels, reader_pubkey_hex) {
                 continue;
             }
             // Dedup across filters.
@@ -1004,12 +1018,14 @@ mod tests {
             .kind(Kind::Custom(30174))
             .custom_tags(p_tag, [&owner_a]);
 
+        // 30174 is not owner-gated, so any reader hex is fine here.
+        let reader = Keys::generate().public_key().to_hex();
         assert!(
-            search_hit_accepted(&filter, &env_for_a, &[]),
+            search_hit_accepted(&filter, &env_for_a, &[], &reader),
             "envelope addressed to owner_a must be returned"
         );
         assert!(
-            !search_hit_accepted(&filter, &env_for_b, &[]),
+            !search_hit_accepted(&filter, &env_for_b, &[], &reader),
             "envelope addressed to owner_b must NOT be returned for a #p=[owner_a] search"
         );
     }
@@ -1031,9 +1047,10 @@ mod tests {
             .kind(Kind::Custom(30174))
             .author(agent_a.public_key());
 
-        assert!(search_hit_accepted(&filter, &env_a, &[]));
+        let reader = Keys::generate().public_key().to_hex();
+        assert!(search_hit_accepted(&filter, &env_a, &[], &reader));
         assert!(
-            !search_hit_accepted(&filter, &env_b, &[]),
+            !search_hit_accepted(&filter, &env_b, &[], &reader),
             "authors=[agent_a] search must not return events authored by agent_b"
         );
     }
@@ -1053,12 +1070,13 @@ mod tests {
             .kind(Kind::Custom(30174))
             .custom_tags(p_tag, [&owner]);
 
+        let reader = Keys::generate().public_key().to_hex();
         assert!(
-            !search_hit_accepted(&filter, &stored, &[]),
+            !search_hit_accepted(&filter, &stored, &[], &reader),
             "channel-scoped hit must be rejected when caller has no channel access"
         );
         assert!(
-            search_hit_accepted(&filter, &stored, &[scoped_channel]),
+            search_hit_accepted(&filter, &stored, &[scoped_channel], &reader),
             "channel-scoped hit must be accepted when caller has access to that channel"
         );
     }
@@ -1215,5 +1233,46 @@ mod tests {
         let mut se = sprout_core::StoredEvent::new(ev, None);
         se.channel_id = Some(ch);
         assert!(!event_in_accessible_channel(&se, &[other]));
+    }
+
+    /// NIP-DV regression: a relay-signed kind:30622 snapshot must not leak via
+    /// search through a kindless `ids:[snapshot_id]` filter that carries no #p.
+    /// `filters_match` passes (id matches), channel check passes (channel_id =
+    /// None), so only the result-level `reader_authorized_for_event` check
+    /// stands between a third party and the owner's private hide set.
+    #[test]
+    fn search_hit_rejects_dm_visibility_for_kindless_ids_third_party() {
+        let relay = Keys::generate();
+        let viewer = Keys::generate().public_key().to_hex();
+        let third_party = Keys::generate().public_key().to_hex();
+
+        let d_tag = Tag::custom(
+            nostr::TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::D)),
+            [&viewer],
+        );
+        let p_tag = Tag::custom(
+            nostr::TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::P)),
+            [&viewer],
+        );
+        let ev = EventBuilder::new(
+            Kind::Custom(sprout_core::kind::KIND_DM_VISIBILITY as u16),
+            "",
+        )
+        .tags([d_tag, p_tag])
+        .sign_with_keys(&relay)
+        .expect("sign snapshot");
+        let stored = sprout_core::StoredEvent::new(ev.clone(), None);
+
+        // Kindless filter — the exact bypass shape: no #p, just the id.
+        let filter = nostr::Filter::new().id(ev.id);
+
+        assert!(
+            !search_hit_accepted(&filter, &stored, &[], &third_party),
+            "third party must not receive a DM-visibility snapshot via kindless ids search"
+        );
+        assert!(
+            search_hit_accepted(&filter, &stored, &[], &viewer),
+            "owner must still receive their own snapshot"
+        );
     }
 }

--- a/crates/sprout-relay/src/handlers/command_executor.rs
+++ b/crates/sprout-relay/src/handlers/command_executor.rs
@@ -27,6 +27,7 @@ use crate::webhook_secret;
 use super::ingest::{extract_channel_id, IngestAuth, IngestError, IngestResult};
 use super::side_effects::{
     emit_group_discovery_events, emit_membership_notification, emit_system_message,
+    publish_dm_visibility_snapshot,
 };
 
 /// Route a command-kind event to the appropriate handler.
@@ -330,6 +331,12 @@ async fn handle_dm_open(
                 warn!("DM open: membership notification failed: {e}");
             }
         }
+    } else {
+        // Re-open of an existing DM cleared the caller's hidden_at; refresh
+        // their NIP-DV snapshot so the DM reappears in the sidebar.
+        if let Err(e) = publish_dm_visibility_snapshot(state, &self_bytes).await {
+            warn!("DM re-open: visibility snapshot failed: {e}");
+        }
     }
 
     // 6. Return response
@@ -532,7 +539,13 @@ async fn handle_dm_hide(
         .await
         .map_err(|e| IngestError::Internal(format!("error: commit transaction: {e}")))?;
 
-    // 5. Return response
+    // 5. Side effect (post-commit, best-effort): refresh the caller's NIP-DV
+    // visibility snapshot so clients can filter this DM out of the sidebar.
+    if let Err(e) = publish_dm_visibility_snapshot(state, &self_bytes).await {
+        warn!("DM hide: visibility snapshot failed: {e}");
+    }
+
+    // 6. Return response
     Ok(IngestResult {
         event_id: event.id.to_hex(),
         accepted: true,

--- a/crates/sprout-relay/src/handlers/event.rs
+++ b/crates/sprout-relay/src/handlers/event.rs
@@ -80,8 +80,30 @@ pub(crate) async fn dispatch_persistent_event(
 
     let event_json = serde_json::to_string(&stored_event.event)
         .expect("nostr::Event serialization is infallible for well-formed events");
+    // For viewer-private snapshots (kind:30622), live fan-out must reach only the
+    // owner — a kindless `ids:[…]` subscription can otherwise match it. Pull paths
+    // (HTTP /query, WS historical) are gated separately by reader_authorized_for_event.
+    let dm_visibility_owner: Option<String> = (kind_u32 == sprout_core::kind::KIND_DM_VISIBILITY)
+        .then(|| {
+            let p = nostr::SingleLetterTag::lowercase(nostr::Alphabet::P);
+            stored_event
+                .event
+                .tags
+                .filter(nostr::TagKind::SingleLetter(p))
+                .find_map(|t| t.content().map(|s| s.to_string()))
+        })
+        .flatten();
     let mut drop_count = 0u32;
     for (target_conn_id, sub_id) in &matches {
+        if let Some(ref owner_hex) = dm_visibility_owner {
+            let is_owner = state
+                .conn_manager
+                .pubkey_for(*target_conn_id)
+                .is_some_and(|pk| hex::encode(pk) == *owner_hex);
+            if !is_owner {
+                continue;
+            }
+        }
         let msg = format!(r#"["EVENT","{}",{}]"#, sub_id, event_json);
         if !state.conn_manager.send_to(*target_conn_id, msg) {
             drop_count += 1;
@@ -95,8 +117,10 @@ pub(crate) async fn dispatch_persistent_event(
         );
     }
 
-    // Skip search indexing for NIP-17 gift wraps — content is ciphertext.
+    // Skip search indexing for NIP-17 gift wraps (ciphertext) and NIP-DV
+    // visibility snapshots (per-viewer private hide state, owner-gated reads).
     if kind_u32 != KIND_GIFT_WRAP
+        && kind_u32 != sprout_core::kind::KIND_DM_VISIBILITY
         && state
             .search_index_tx
             .try_send(stored_event.clone())

--- a/crates/sprout-relay/src/handlers/req.rs
+++ b/crates/sprout-relay/src/handlers/req.rs
@@ -9,8 +9,8 @@ use hex;
 use nostr::Filter;
 use sprout_core::filter::filters_match;
 use sprout_core::kind::{
-    KIND_AGENT_ENGRAM, KIND_AGENT_OBSERVER_FRAME, KIND_GIFT_WRAP, KIND_MEMBER_ADDED_NOTIFICATION,
-    KIND_MEMBER_REMOVED_NOTIFICATION,
+    KIND_AGENT_ENGRAM, KIND_AGENT_OBSERVER_FRAME, KIND_DM_VISIBILITY, KIND_GIFT_WRAP,
+    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
 };
 use sprout_db::EventQuery;
 
@@ -22,11 +22,12 @@ use crate::state::AppState;
 
 const MAX_HISTORICAL_LIMIT: i64 = 10_000;
 const MAX_SUBSCRIPTIONS: usize = 1024;
-const P_GATED_KINDS: [u32; 4] = [
+const P_GATED_KINDS: [u32; 5] = [
     KIND_AGENT_OBSERVER_FRAME,
     KIND_MEMBER_ADDED_NOTIFICATION,
     KIND_MEMBER_REMOVED_NOTIFICATION,
     KIND_GIFT_WRAP,
+    KIND_DM_VISIBILITY,
 ];
 
 /// Handle a REQ message: register the subscription, deliver historical events, then send EOSE.
@@ -136,6 +137,7 @@ pub async fn handle_req(
             &filters,
             &accessible_channels,
             token_channel_ids.is_none(),
+            &hex::encode(&pubkey_bytes),
             &conn,
             &state,
         )
@@ -171,6 +173,7 @@ pub async fn handle_req(
     // per-filter limits or non-overlapping time windows.
     let mut seen_ids: HashSet<nostr::EventId> = HashSet::new();
     let mut total_sent: usize = 0;
+    let viewer_hex = hex::encode(&pubkey_bytes);
 
     for filter in &filters {
         // Use per-filter #h channel scope when available, falling back to the
@@ -216,6 +219,13 @@ pub async fn handle_req(
                 if !accessible_channels.contains(&ch_id) {
                     continue;
                 }
+            }
+
+            // Result-level read auth: a viewer-private snapshot (kind:30622) is
+            // delivered only to its owner, even if reached via a kindless
+            // `ids:[…]` subscription that skips the filter-level `#p` gate.
+            if !sprout_core::filter::reader_authorized_for_event(&stored.event, &viewer_hex) {
+                continue;
             }
 
             // Dedup AFTER acceptance — an event that fails filter A's constraints
@@ -278,6 +288,7 @@ async fn handle_search_req(
     filters: &[Filter],
     accessible_channels: &[uuid::Uuid],
     include_global: bool,
+    reader_pubkey_hex: &str,
     conn: &ConnectionState,
     state: &AppState,
 ) {
@@ -429,6 +440,12 @@ async fn handle_search_req(
                         if !accessible_channels.contains(&ch_id) {
                             continue;
                         }
+                    }
+                    if !sprout_core::filter::reader_authorized_for_event(
+                        &stored.event,
+                        reader_pubkey_hex,
+                    ) {
+                        continue;
                     }
                     // Dedup AFTER acceptance — an event that fails filter A's constraints
                     // must remain eligible for filter B (NIP-01 OR semantics).
@@ -709,18 +726,25 @@ fn extract_channel_id_from_filters(filters: &[Filter]) -> Option<uuid::Uuid> {
 pub(crate) fn p_gated_filters_authorized(filters: &[Filter], authed_pubkey_hex: &str) -> bool {
     let p_tag = nostr::SingleLetterTag::lowercase(nostr::Alphabet::P);
     filters.iter().all(|filter| {
-        // Filters with explicit `ids` are targeting specific known events — they
-        // can't be used to fish for p-gated events you don't own because the
-        // caller already knows the event ID. Skip the p-gate check.
-        if filter.ids.as_ref().is_some_and(|ids| !ids.is_empty()) {
-            return true;
-        }
-
         let can_match_p_gated = filter.kinds.as_ref().is_none_or(|ks| {
             ks.iter()
                 .any(|kind| P_GATED_KINDS.contains(&(kind.as_u16() as u32)))
         });
         if !can_match_p_gated {
+            return true;
+        }
+
+        // The `ids` exemption ("knowing the id implies authorization") is only
+        // safe for kinds whose id is author-bound or whose content is encrypted.
+        // KIND_DM_VISIBILITY is relay-signed (id not author-bound) and exposes
+        // plaintext private hide choices, so its `#p` owner check MUST hold even
+        // when `ids` is present. Only filters that explicitly name the kind lose
+        // the exemption — a kindless `ids` lookup is unaffected.
+        let explicitly_dm_visibility = filter.kinds.as_ref().is_some_and(|ks| {
+            ks.iter()
+                .any(|kind| kind.as_u16() as u32 == KIND_DM_VISIBILITY)
+        });
+        if !explicitly_dm_visibility && filter.ids.as_ref().is_some_and(|ids| !ids.is_empty()) {
             return true;
         }
 
@@ -842,6 +866,40 @@ mod tests {
         let search_filter = Filter::new().search("hello world");
         let filters = [search_filter];
         assert!(filters.iter().any(|f| f.search.is_some()));
+    }
+
+    #[test]
+    fn dm_visibility_requires_p_tag_even_with_ids() {
+        let p_tag = SingleLetterTag::lowercase(Alphabet::P);
+        let authed = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let other = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let snapshot_id = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let dm_vis = nostr::Kind::Custom(sprout_core::kind::KIND_DM_VISIBILITY as u16);
+
+        // Knowing another viewer's snapshot id must NOT authorize reading it:
+        // ids alone, or ids + someone else's #p, are both rejected.
+        let ids_only = Filter::new()
+            .kind(dm_vis)
+            .id(nostr::EventId::from_hex(snapshot_id).unwrap());
+        assert!(!p_gated_filters_authorized(&[ids_only], authed));
+
+        let ids_wrong_p = Filter::new()
+            .kind(dm_vis)
+            .id(nostr::EventId::from_hex(snapshot_id).unwrap())
+            .custom_tags(p_tag, [other]);
+        assert!(!p_gated_filters_authorized(&[ids_wrong_p], authed));
+
+        // The owner querying their own snapshot (by #p) is allowed, ids or not.
+        let owner = Filter::new().kind(dm_vis).custom_tags(p_tag, [authed]);
+        assert!(p_gated_filters_authorized(&[owner], authed));
+
+        // The ids exemption still applies to other p-gated kinds (member notifs).
+        let member_notif_ids = Filter::new()
+            .kind(nostr::Kind::Custom(
+                sprout_core::kind::KIND_MEMBER_ADDED_NOTIFICATION as u16,
+            ))
+            .id(nostr::EventId::from_hex(snapshot_id).unwrap());
+        assert!(p_gated_filters_authorized(&[member_notif_ids], authed));
     }
 
     #[test]

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -2206,8 +2206,35 @@ pub async fn publish_dm_visibility_snapshot(
         );
     }
 
+    // Force created_at strictly past any prior snapshot for this viewer: a same-second
+    // replacement whose random event id sorts higher is rejected by stale-write
+    // protection, so a hide→re-open within one second could otherwise strand the stale
+    // snapshot. Same guard as emit_addressable_discovery_event.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let ts = {
+        let existing = state
+            .db
+            .query_events(&sprout_db::event::EventQuery {
+                kinds: Some(vec![KIND_DM_VISIBILITY as i32]),
+                pubkey: Some(state.relay_keypair.public_key().to_bytes().to_vec()),
+                d_tag: Some(viewer_hex.clone()),
+                limit: Some(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_or_default();
+        existing
+            .first()
+            .map(|e| (e.event.created_at.as_secs() + 1).max(now))
+            .unwrap_or(now)
+    };
+
     let event = EventBuilder::new(Kind::Custom(KIND_DM_VISIBILITY as u16), "")
         .tags(tags)
+        .custom_created_at(nostr::Timestamp::from(ts))
         .sign_with_keys(&state.relay_keypair)
         .map_err(|e| anyhow::anyhow!("failed to sign kind:{KIND_DM_VISIBILITY}: {e}"))?;
 

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -7,10 +7,10 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use sprout_core::kind::{
-    event_kind_u32, is_parameterized_replaceable, KIND_AGENT_PROFILE, KIND_GIT_REPO_ANNOUNCEMENT,
-    KIND_IA_ARCHIVED, KIND_IA_ARCHIVED_LIST, KIND_IA_UNARCHIVED, KIND_MEMBER_ADDED_NOTIFICATION,
-    KIND_MEMBER_REMOVED_NOTIFICATION, KIND_NIP29_GROUP_ADMINS, KIND_NIP29_GROUP_MEMBERS,
-    KIND_NIP29_GROUP_METADATA, KIND_NIP43_MEMBERSHIP_LIST, KIND_REACTION,
+    event_kind_u32, is_parameterized_replaceable, KIND_AGENT_PROFILE, KIND_DM_VISIBILITY,
+    KIND_GIT_REPO_ANNOUNCEMENT, KIND_IA_ARCHIVED, KIND_IA_ARCHIVED_LIST, KIND_IA_UNARCHIVED,
+    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_NIP29_GROUP_ADMINS,
+    KIND_NIP29_GROUP_MEMBERS, KIND_NIP29_GROUP_METADATA, KIND_NIP43_MEMBERSHIP_LIST, KIND_REACTION,
 };
 use sprout_db::channel::MemberRole;
 
@@ -2171,6 +2171,58 @@ pub async fn publish_nipia_archival_list(state: &Arc<AppState>) -> anyhow::Resul
     info!(
         archived_count = archived.len(),
         "NIP-IA archived identities list published"
+    );
+    Ok(())
+}
+
+/// NIP-DV: publish the relay-signed, per-viewer DM visibility snapshot for
+/// `viewer`. The event is parameterized-replaceable (`d` = viewer pubkey) and
+/// carries one `h` tag per DM the viewer currently has hidden. Called after any
+/// hide (41012) or unhide (41010 that clears `hidden_at`); the latest event is
+/// always the authoritative hidden set, so no client-side delta merge is needed.
+pub async fn publish_dm_visibility_snapshot(
+    state: &Arc<AppState>,
+    viewer: &[u8],
+) -> anyhow::Result<()> {
+    let viewer_hex = hex::encode(viewer);
+    let hidden = state.db.list_hidden_dms(viewer).await?;
+    let relay_pubkey_hex = state.relay_keypair.public_key().to_hex();
+
+    let mut tags: Vec<Tag> = Vec::with_capacity(hidden.len() + 2);
+    tags.push(
+        Tag::parse(["d", &viewer_hex])
+            .map_err(|e| anyhow::anyhow!("failed to build d tag: {e}"))?,
+    );
+    // `p` = viewer so the relay's `#p`-gated read path scopes the snapshot to
+    // its owner; no one else may query another viewer's hidden-DM set.
+    tags.push(
+        Tag::parse(["p", &viewer_hex])
+            .map_err(|e| anyhow::anyhow!("failed to build p tag: {e}"))?,
+    );
+    for channel_id in &hidden {
+        tags.push(
+            Tag::parse(["h", &channel_id.to_string()])
+                .map_err(|e| anyhow::anyhow!("failed to build h tag: {e}"))?,
+        );
+    }
+
+    let event = EventBuilder::new(Kind::Custom(KIND_DM_VISIBILITY as u16), "")
+        .tags(tags)
+        .sign_with_keys(&state.relay_keypair)
+        .map_err(|e| anyhow::anyhow!("failed to sign kind:{KIND_DM_VISIBILITY}: {e}"))?;
+
+    let (stored, was_inserted) = state
+        .db
+        .replace_parameterized_event(&event, &viewer_hex, None)
+        .await?;
+    if was_inserted {
+        dispatch_persistent_event(state, &stored, KIND_DM_VISIBILITY, &relay_pubkey_hex).await;
+    }
+
+    info!(
+        viewer = %viewer_hex,
+        hidden_count = hidden.len(),
+        "NIP-DV DM visibility snapshot published"
     );
     Ok(())
 }

--- a/crates/sprout-relay/src/state.rs
+++ b/crates/sprout-relay/src/state.rs
@@ -114,6 +114,13 @@ impl ConnectionManager {
             .map(|entry| Arc::clone(&entry.subscriptions))
     }
 
+    /// Return the authenticated pubkey for a connection, if any.
+    pub fn pubkey_for(&self, conn_id: Uuid) -> Option<Vec<u8>> {
+        self.connections
+            .get(&conn_id)
+            .and_then(|entry| entry.authenticated_pubkey.read().ok()?.clone())
+    }
+
     /// Sends a text message to the given connection.
     ///
     /// Returns `false` if the connection is gone or the buffer is full.

--- a/crates/sprout-test-client/tests/e2e_nostr_interop.rs
+++ b/crates/sprout-test-client/tests/e2e_nostr_interop.rs
@@ -60,7 +60,7 @@ async fn create_test_channel(keys: &Keys) -> String {
         .unwrap();
 
     let resp = client
-        .post(format!("{}/api/events", relay_http_url()))
+        .post(format!("{}/events", relay_http_url()))
         .header("X-Pubkey", &pubkey_hex)
         .header("Content-Type", "application/json")
         .body(serde_json::to_string(&event).unwrap())
@@ -91,7 +91,7 @@ async fn send_rest_message(keys: &Keys, channel_id: &str, content: &str) -> Stri
         .sign_with_keys(keys)
         .unwrap();
     let resp = client
-        .post(format!("{}/api/events", relay_http_url()))
+        .post(format!("{}/events", relay_http_url()))
         .header("X-Pubkey", &pubkey_hex)
         .header("Content-Type", "application/json")
         .body(serde_json::to_string(&event).unwrap())
@@ -107,15 +107,25 @@ async fn send_rest_message(keys: &Keys, channel_id: &str, content: &str) -> Stri
     body["event_id"].as_str().expect("event_id").to_string()
 }
 
-/// Create a DM via REST and return the channel_id UUID string.
+/// Create a DM via a signed kind:41010 (DM open) command event and return the
+/// channel_id UUID string parsed from the relay's `response:{...}` message.
 async fn create_dm(requester_keys: &Keys, other_pubkey_hex: &str) -> String {
     let client = reqwest::Client::new();
-    let url = format!("{}/api/dms", relay_http_url());
     let pubkey_hex = requester_keys.public_key().to_hex();
+    // Backdate the initial open so a later re-open kind:41010 with identical
+    // tags in the same wall-clock second does not produce an identical event id
+    // (which the relay would dedupe as "duplicate: already processed").
+    let backdated = nostr::Timestamp::from(nostr::Timestamp::now().as_secs() - 10);
+    let event = EventBuilder::new(Kind::Custom(41010), "")
+        .tags(vec![Tag::parse(["p", other_pubkey_hex]).unwrap()])
+        .custom_created_at(backdated)
+        .sign_with_keys(requester_keys)
+        .unwrap();
     let resp = client
-        .post(&url)
+        .post(format!("{}/events", relay_http_url()))
         .header("X-Pubkey", &pubkey_hex)
-        .json(&serde_json::json!({ "pubkeys": [other_pubkey_hex] }))
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&event).unwrap())
         .send()
         .await
         .expect("create DM request");
@@ -125,7 +135,17 @@ async fn create_dm(requester_keys: &Keys, other_pubkey_hex: &str) -> String {
         resp.status()
     );
     let body: serde_json::Value = resp.json().await.expect("parse DM response");
-    body["channel_id"].as_str().expect("channel_id").to_string()
+    assert!(
+        body["accepted"].as_bool().unwrap_or(false),
+        "DM open not accepted: {body}"
+    );
+    let msg = body["message"].as_str().expect("message");
+    let payload = msg.strip_prefix("response:").expect("response: prefix");
+    let parsed: serde_json::Value = serde_json::from_str(payload).expect("response JSON");
+    parsed["channel_id"]
+        .as_str()
+        .expect("channel_id")
+        .to_string()
 }
 
 /// Submit a signed command event via REST and assert it was accepted.
@@ -137,7 +157,7 @@ async fn post_signed_event(keys: &Keys, kind: u16, tags: Vec<Tag>) {
         .sign_with_keys(keys)
         .unwrap();
     let resp = client
-        .post(format!("{}/api/events", relay_http_url()))
+        .post(format!("{}/events", relay_http_url()))
         .header("X-Pubkey", &pubkey_hex)
         .header("Content-Type", "application/json")
         .body(serde_json::to_string(&event).unwrap())
@@ -376,7 +396,7 @@ async fn test_nip10_thread_reply_creates_metadata() {
     // Query thread via REST to verify reply is recorded.
     let http_client = reqwest::Client::new();
     let thread_url = format!(
-        "{}/api/channels/{}/threads/{}",
+        "{}/channels/{}/threads/{}",
         relay_http_url(),
         channel,
         root_event_id
@@ -835,7 +855,7 @@ async fn test_nip10_thread_reply_not_in_top_level() {
     // Query top-level messages via REST.
     let http_client = reqwest::Client::new();
     let messages_url = format!(
-        "{}/api/channels/{}/messages?limit=50",
+        "{}/channels/{}/messages?limit=50",
         relay_http_url(),
         channel
     );
@@ -1321,7 +1341,7 @@ async fn test_nipdv_snapshot_is_private_to_owner() {
         "limit": 1,
     }]);
     let resp = client
-        .post(format!("{}/api/query", relay_http_url()))
+        .post(format!("{}/query", relay_http_url()))
         .header("X-Pubkey", &b_pubkey_hex)
         .header("Content-Type", "application/json")
         .body(serde_json::to_string(&filters).unwrap())
@@ -1488,7 +1508,7 @@ async fn test_nipdv_ids_query_rejects_third_party() {
     let client = reqwest::Client::new();
     let filters = serde_json::json!([{ "ids": [snapshot_id], "limit": 1 }]);
     let resp = client
-        .post(format!("{}/api/query", relay_http_url()))
+        .post(format!("{}/query", relay_http_url()))
         .header("X-Pubkey", &b_pubkey_hex)
         .header("Content-Type", "application/json")
         .body(serde_json::to_string(&filters).unwrap())
@@ -1542,7 +1562,7 @@ async fn test_nipdv_explicit_kind_query_forbidden_for_third_party() {
     let client = reqwest::Client::new();
     let filters = serde_json::json!([{ "kinds": [30622], "ids": [snapshot_id], "limit": 1 }]);
     let resp = client
-        .post(format!("{}/api/query", relay_http_url()))
+        .post(format!("{}/query", relay_http_url()))
         .header("X-Pubkey", &b_pubkey_hex)
         .header("Content-Type", "application/json")
         .body(serde_json::to_string(&filters).unwrap())

--- a/crates/sprout-test-client/tests/e2e_nostr_interop.rs
+++ b/crates/sprout-test-client/tests/e2e_nostr_interop.rs
@@ -128,6 +128,34 @@ async fn create_dm(requester_keys: &Keys, other_pubkey_hex: &str) -> String {
     body["channel_id"].as_str().expect("channel_id").to_string()
 }
 
+/// Submit a signed command event via REST and assert it was accepted.
+async fn post_signed_event(keys: &Keys, kind: u16, tags: Vec<Tag>) {
+    let client = reqwest::Client::new();
+    let pubkey_hex = keys.public_key().to_hex();
+    let event = EventBuilder::new(Kind::Custom(kind), "")
+        .tags(tags)
+        .sign_with_keys(keys)
+        .unwrap();
+    let resp = client
+        .post(format!("{}/api/events", relay_http_url()))
+        .header("X-Pubkey", &pubkey_hex)
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&event).unwrap())
+        .send()
+        .await
+        .expect("submit signed event");
+    assert!(
+        resp.status().is_success(),
+        "event kind:{kind} failed: {}",
+        resp.status()
+    );
+    let body: serde_json::Value = resp.json().await.expect("parse event response");
+    assert!(
+        body["accepted"].as_bool().unwrap_or(false),
+        "event kind:{kind} not accepted: {body}"
+    );
+}
+
 // ── Phase 1: NIP-50 Search ────────────────────────────────────────────────────
 
 /// Send a message with unique content, then search for it.
@@ -1087,4 +1115,436 @@ async fn test_empty_kinds_returns_zero_events() {
     );
 
     client.disconnect().await.expect("disconnect");
+}
+
+// ── Phase 6: NIP-DV DM Visibility ─────────────────────────────────────────────
+
+/// Helper: read the viewer's latest relay-signed NIP-DV snapshot event
+/// (kind:30622, queried by `#p` since snapshots are `#p`-gated to their owner).
+/// Returns `None` if no snapshot exists yet.
+async fn read_snapshot_event(
+    client: &mut SproutTestClient,
+    viewer_hex: &str,
+) -> Option<nostr::Event> {
+    let sid = sub_id("nipdv-snapshot");
+    let filter = Filter::new()
+        .kind(Kind::Custom(30622))
+        .custom_tag(SingleLetterTag::lowercase(Alphabet::P), viewer_hex);
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe nip-dv snapshot");
+    let events = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("nip-dv snapshot EOSE");
+    client
+        .close_subscription(&sid)
+        .await
+        .expect("close nip-dv sub");
+
+    // Parameterized-replaceable: at most one current event, but take the
+    // newest defensively.
+    events.into_iter().max_by_key(|e| e.created_at.as_secs())
+}
+
+/// Helper: the set of hidden DM channel ids from the viewer's latest snapshot.
+async fn read_hidden_dms(client: &mut SproutTestClient, viewer_hex: &str) -> Vec<String> {
+    match read_snapshot_event(client, viewer_hex).await {
+        None => Vec::new(),
+        Some(ev) => ev
+            .tags
+            .iter()
+            .filter_map(|t| {
+                let s = t.as_slice();
+                (s.len() >= 2 && s[0] == "h").then(|| s[1].to_string())
+            })
+            .collect(),
+    }
+}
+
+/// NIP-DV regression: hiding a DM must surface it in the viewer's relay-signed
+/// visibility snapshot, and re-opening it must drop it back out — newest-wins.
+///
+/// This is the fix for "hidden DMs come back": the client filters its DM list
+/// against this snapshot, so the snapshot must be the authoritative hidden set.
+#[tokio::test]
+#[ignore]
+async fn test_nipdv_hide_then_reopen_updates_snapshot() {
+    let url = relay_url();
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let a_pubkey_hex = keys_a.public_key().to_hex();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+
+    // A opens a DM with B.
+    let channel_id = create_dm(&keys_a, &b_pubkey_hex).await;
+
+    let mut client_a = SproutTestClient::connect(&url, &keys_a)
+        .await
+        .expect("client A connect");
+
+    // Baseline: no DMs hidden.
+    let before = read_hidden_dms(&mut client_a, &a_pubkey_hex).await;
+    assert!(
+        !before.contains(&channel_id),
+        "DM should not be hidden before hide; snapshot h tags: {before:?}"
+    );
+
+    // A hides the DM (kind:41012, h = channel).
+    post_signed_event(
+        &keys_a,
+        41012,
+        vec![Tag::parse(["h", &channel_id]).unwrap()],
+    )
+    .await;
+
+    // Snapshot must now list the DM as hidden.
+    let after_hide = read_hidden_dms(&mut client_a, &a_pubkey_hex).await;
+    assert!(
+        after_hide.contains(&channel_id),
+        "DM must appear in snapshot after hide; snapshot h tags: {after_hide:?}"
+    );
+
+    // A re-opens the DM (kind:41010, p = the other participant) — this clears
+    // hidden_at and must refresh the snapshot.
+    post_signed_event(
+        &keys_a,
+        41010,
+        vec![Tag::parse(["p", &b_pubkey_hex]).unwrap()],
+    )
+    .await;
+
+    // Snapshot must drop the DM back out — proving re-open is reflected, the
+    // exact asymmetry a client-side filter could not handle on its own.
+    let after_reopen = read_hidden_dms(&mut client_a, &a_pubkey_hex).await;
+    assert!(
+        !after_reopen.contains(&channel_id),
+        "DM must be dropped from snapshot after re-open; snapshot h tags: {after_reopen:?}"
+    );
+
+    client_a.disconnect().await.expect("disconnect");
+}
+
+/// NIP-DV privacy: a third party MUST NOT be able to read another viewer's
+/// DM visibility snapshot. The snapshot is `#p`-gated to its owner, so a
+/// `#p`=<someone-else> query is rejected by the relay's read-auth gate.
+#[tokio::test]
+#[ignore]
+async fn test_nipdv_snapshot_is_private_to_owner() {
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let a_pubkey_hex = keys_a.public_key().to_hex();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+
+    // A opens a DM with B and hides it, producing a NIP-DV snapshot for A.
+    let channel_id = create_dm(&keys_a, &b_pubkey_hex).await;
+    post_signed_event(
+        &keys_a,
+        41012,
+        vec![Tag::parse(["h", &channel_id]).unwrap()],
+    )
+    .await;
+
+    // B queries A's snapshot via REST (#p = A). The relay's #p-gate must reject
+    // this — B may only read snapshots addressed to B.
+    let client = reqwest::Client::new();
+    let filters = serde_json::json!([{
+        "kinds": [30622],
+        "#p": [a_pubkey_hex],
+        "limit": 1,
+    }]);
+    let resp = client
+        .post(format!("{}/api/query", relay_http_url()))
+        .header("X-Pubkey", &b_pubkey_hex)
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&filters).unwrap())
+        .send()
+        .await
+        .expect("submit cross-viewer query");
+
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::FORBIDDEN,
+        "B querying A's NIP-DV snapshot must be forbidden, got {}",
+        resp.status()
+    );
+}
+
+/// NIP-DV regression for the per-viewer replacement key: two viewers with
+/// independent hidden sets must NOT clobber each other's snapshot. This is the
+/// case that breaks if the snapshot is stored keyed by (kind, relay_pubkey)
+/// alone instead of by the viewer's `d` tag — B's write would tombstone A's,
+/// and A's hidden DM would reappear.
+#[tokio::test]
+#[ignore]
+async fn test_nipdv_two_viewers_independent_snapshots() {
+    let url = relay_url();
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let keys_c = Keys::generate();
+    let a_pubkey_hex = keys_a.public_key().to_hex();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+    let c_pubkey_hex = keys_c.public_key().to_hex();
+
+    // A hides a DM with C; then B hides a (different) DM with C.
+    let dm_a = create_dm(&keys_a, &c_pubkey_hex).await;
+    post_signed_event(&keys_a, 41012, vec![Tag::parse(["h", &dm_a]).unwrap()]).await;
+
+    let dm_b = create_dm(&keys_b, &c_pubkey_hex).await;
+    post_signed_event(&keys_b, 41012, vec![Tag::parse(["h", &dm_b]).unwrap()]).await;
+
+    // A's snapshot must still list A's hidden DM (B's write must not clobber it).
+    let mut client_a = SproutTestClient::connect(&url, &keys_a)
+        .await
+        .expect("client A connect");
+    let a_hidden = read_hidden_dms(&mut client_a, &a_pubkey_hex).await;
+    assert!(
+        a_hidden.contains(&dm_a),
+        "A's snapshot lost its hidden DM after B wrote; A sees: {a_hidden:?}"
+    );
+    assert!(
+        !a_hidden.contains(&dm_b),
+        "A's snapshot leaked B's hidden DM; A sees: {a_hidden:?}"
+    );
+    client_a.disconnect().await.expect("disconnect A");
+
+    // B's snapshot lists only B's hidden DM.
+    let mut client_b = SproutTestClient::connect(&url, &keys_b)
+        .await
+        .expect("client B connect");
+    let b_hidden = read_hidden_dms(&mut client_b, &b_pubkey_hex).await;
+    assert!(
+        b_hidden.contains(&dm_b),
+        "B's snapshot missing its hidden DM; B sees: {b_hidden:?}"
+    );
+    assert!(
+        !b_hidden.contains(&dm_a),
+        "B's snapshot leaked A's hidden DM; B sees: {b_hidden:?}"
+    );
+    client_b.disconnect().await.expect("disconnect B");
+}
+
+/// NIP-DV privacy via WebSocket REQ: a third party subscribing to another
+/// viewer's snapshot (`kind:30622 #p=A` as B) must be rejected with CLOSED, not
+/// served A's hidden set.
+#[tokio::test]
+#[ignore]
+async fn test_nipdv_ws_req_rejects_third_party() {
+    let url = relay_url();
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let a_pubkey_hex = keys_a.public_key().to_hex();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+
+    let channel_id = create_dm(&keys_a, &b_pubkey_hex).await;
+    post_signed_event(
+        &keys_a,
+        41012,
+        vec![Tag::parse(["h", &channel_id]).unwrap()],
+    )
+    .await;
+
+    // B subscribes for A's snapshot over WS — must be CLOSED, never EVENT.
+    let mut client_b = SproutTestClient::connect(&url, &keys_b)
+        .await
+        .expect("client B connect");
+    let sid = sub_id("nipdv-cross-ws");
+    let filter = Filter::new().kind(Kind::Custom(30622)).custom_tag(
+        SingleLetterTag::lowercase(Alphabet::P),
+        a_pubkey_hex.as_str(),
+    );
+    client_b
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("send REQ");
+
+    let msg = loop {
+        let m = client_b
+            .recv_event(Duration::from_secs(5))
+            .await
+            .expect("recv message");
+        match &m {
+            RelayMessage::Event { .. } => {
+                panic!("relay served A's NIP-DV snapshot to B over WS REQ")
+            }
+            RelayMessage::Eose { .. } => continue,
+            _ => break m,
+        }
+    };
+    match msg {
+        RelayMessage::Closed {
+            subscription_id, ..
+        } => {
+            assert_eq!(subscription_id, sid, "CLOSED for wrong subscription");
+        }
+        other => panic!("expected CLOSED for third-party snapshot REQ, got {other:?}"),
+    }
+    client_b.disconnect().await.expect("disconnect B");
+}
+
+/// NIP-DV privacy via the `ids` escape hatch: even if a third party learns the
+/// event id of A's snapshot, querying `ids:[that_id]` must NOT return it. A
+/// kindless `ids` filter is intentionally exempt from the filter-level `#p`
+/// gate (so legitimate id-lookups of other kinds still work), so the
+/// result-level owner check is what holds the line — B's query succeeds (200)
+/// but returns an empty set. An *explicit* `kinds:[30622]` filter is rejected
+/// earlier, at the gate, with 403 (covered separately).
+#[tokio::test]
+#[ignore]
+async fn test_nipdv_ids_query_rejects_third_party() {
+    let url = relay_url();
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let a_pubkey_hex = keys_a.public_key().to_hex();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+
+    let channel_id = create_dm(&keys_a, &b_pubkey_hex).await;
+    post_signed_event(
+        &keys_a,
+        41012,
+        vec![Tag::parse(["h", &channel_id]).unwrap()],
+    )
+    .await;
+
+    // A reads its own snapshot to learn its event id.
+    let mut client_a = SproutTestClient::connect(&url, &keys_a)
+        .await
+        .expect("client A connect");
+    let snapshot = read_snapshot_event(&mut client_a, &a_pubkey_hex)
+        .await
+        .expect("A should have a snapshot after hiding");
+    let snapshot_id = snapshot.id.to_hex();
+    client_a.disconnect().await.expect("disconnect A");
+
+    // B queries by that id over REST with a kindless filter — passes the gate
+    // (ids exemption) but the result-level owner check yields an empty set.
+    let client = reqwest::Client::new();
+    let filters = serde_json::json!([{ "ids": [snapshot_id], "limit": 1 }]);
+    let resp = client
+        .post(format!("{}/api/query", relay_http_url()))
+        .header("X-Pubkey", &b_pubkey_hex)
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&filters).unwrap())
+        .send()
+        .await
+        .expect("submit ids query");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "kindless ids query is gate-exempt, expected 200, got {}",
+        resp.status()
+    );
+    let body: serde_json::Value = resp.json().await.expect("parse query response");
+    let arr = body.as_array().expect("query response is an array");
+    assert!(
+        arr.is_empty(),
+        "B must not receive A's snapshot via kindless ids query, got {} event(s)",
+        arr.len()
+    );
+}
+
+/// NIP-DV privacy: an *explicit* `kinds:[30622]` query for another viewer is
+/// rejected at the filter-level gate with 403 — the explicit-kind path loses
+/// the `ids` exemption.
+#[tokio::test]
+#[ignore]
+async fn test_nipdv_explicit_kind_query_forbidden_for_third_party() {
+    let url = relay_url();
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let a_pubkey_hex = keys_a.public_key().to_hex();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+
+    let channel_id = create_dm(&keys_a, &b_pubkey_hex).await;
+    post_signed_event(
+        &keys_a,
+        41012,
+        vec![Tag::parse(["h", &channel_id]).unwrap()],
+    )
+    .await;
+
+    let mut client_a = SproutTestClient::connect(&url, &keys_a)
+        .await
+        .expect("client A connect");
+    let snapshot = read_snapshot_event(&mut client_a, &a_pubkey_hex)
+        .await
+        .expect("A should have a snapshot after hiding");
+    let snapshot_id = snapshot.id.to_hex();
+    client_a.disconnect().await.expect("disconnect A");
+
+    let client = reqwest::Client::new();
+    let filters = serde_json::json!([{ "kinds": [30622], "ids": [snapshot_id], "limit": 1 }]);
+    let resp = client
+        .post(format!("{}/api/query", relay_http_url()))
+        .header("X-Pubkey", &b_pubkey_hex)
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&filters).unwrap())
+        .send()
+        .await
+        .expect("submit explicit-kind query");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::FORBIDDEN,
+        "explicit kinds:[30622] query for another viewer must be forbidden, got {}",
+        resp.status()
+    );
+}
+
+/// NIP-DV privacy via NIP-50 search: a third party must not harvest A's
+/// snapshot through a search query, even with a kindless `ids:[A_snapshot_id]`
+/// filter that slips the filter-level `#p` gate (the `ids` exemption applies to
+/// kindless filters). Two defenses must hold: 30622 is never search-indexed,
+/// and the search result loop applies the result-level owner check. Either way
+/// B sees zero results.
+#[tokio::test]
+#[ignore]
+async fn test_nipdv_search_rejects_third_party() {
+    let url = relay_url();
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let a_pubkey_hex = keys_a.public_key().to_hex();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+
+    let channel_id = create_dm(&keys_a, &b_pubkey_hex).await;
+    post_signed_event(
+        &keys_a,
+        41012,
+        vec![Tag::parse(["h", &channel_id]).unwrap()],
+    )
+    .await;
+
+    let mut client_a = SproutTestClient::connect(&url, &keys_a)
+        .await
+        .expect("client A connect");
+    let snapshot = read_snapshot_event(&mut client_a, &a_pubkey_hex)
+        .await
+        .expect("A should have a snapshot after hiding");
+    let snapshot_id = snapshot.id.to_hex();
+    client_a.disconnect().await.expect("disconnect A");
+
+    // Give Typesense a beat (it must NOT have indexed the snapshot).
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // B issues a kindless search filter carrying A's snapshot id — the bypass
+    // shape. Must return zero results, not A's hidden set.
+    let mut client_b = SproutTestClient::connect(&url, &keys_b)
+        .await
+        .expect("client B connect");
+    let sid = sub_id("nipdv-search-bypass");
+    let id = nostr::EventId::from_hex(&snapshot_id).expect("parse snapshot id");
+    let filter = Filter::new().id(id).search("dm");
+    client_b
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe");
+    let events = client_b
+        .collect_until_eose(&sid, Duration::from_secs(10))
+        .await
+        .expect("collect until EOSE");
+    assert!(
+        events.is_empty(),
+        "B must not receive A's snapshot via search, got {} event(s)",
+        events.len()
+    );
 }

--- a/crates/sprout-test-client/tests/e2e_nostr_interop.rs
+++ b/crates/sprout-test-client/tests/e2e_nostr_interop.rs
@@ -1226,6 +1226,72 @@ async fn test_nipdv_hide_then_reopen_updates_snapshot() {
     client_a.disconnect().await.expect("disconnect");
 }
 
+/// NIP-DV monotonicity regression: a hide immediately followed by a re-open
+/// within the same wall-clock second must still leave the re-open authoritative.
+///
+/// `created_at` is second-resolution; on a same-second tie `replace_parameterized_event`
+/// keeps whichever event id sorts lower (random), so without a monotonic guard the
+/// hide snapshot wins the tie ~50% of the time and the DM stays hidden forever — the
+/// exact "hidden DMs come back" symptom, narrowed to a double-action timing window.
+/// The publisher forces `created_at = max(now, prior + 1)`, so the re-open snapshot
+/// always supersedes. This test posts hide→reopen back-to-back (no sleep) to land in
+/// one second, then asserts the re-open is reflected and the snapshot strictly advanced.
+#[tokio::test]
+#[ignore]
+async fn test_nipdv_same_second_reopen_supersedes_hide() {
+    let url = relay_url();
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let a_pubkey_hex = keys_a.public_key().to_hex();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+
+    let channel_id = create_dm(&keys_a, &b_pubkey_hex).await;
+
+    let mut client_a = SproutTestClient::connect(&url, &keys_a)
+        .await
+        .expect("client A connect");
+
+    // Hide, then immediately re-open — no sleep, so both snapshots land in the
+    // same wall-clock second and collide on the second-resolution tiebreaker.
+    post_signed_event(
+        &keys_a,
+        41012,
+        vec![Tag::parse(["h", &channel_id]).unwrap()],
+    )
+    .await;
+    let hide_snapshot = read_snapshot_event(&mut client_a, &a_pubkey_hex)
+        .await
+        .expect("hide snapshot present");
+
+    post_signed_event(
+        &keys_a,
+        41010,
+        vec![Tag::parse(["p", &b_pubkey_hex]).unwrap()],
+    )
+    .await;
+    let reopen_snapshot = read_snapshot_event(&mut client_a, &a_pubkey_hex)
+        .await
+        .expect("reopen snapshot present");
+
+    // Monotonic guard: the re-open snapshot must strictly supersede the hide one,
+    // even when both were minted in the same second.
+    assert!(
+        reopen_snapshot.created_at.as_secs() > hide_snapshot.created_at.as_secs(),
+        "reopen snapshot created_at ({}) must advance past hide snapshot ({})",
+        reopen_snapshot.created_at.as_secs(),
+        hide_snapshot.created_at.as_secs(),
+    );
+
+    // And the re-open must actually be the authoritative state.
+    let after_reopen = read_hidden_dms(&mut client_a, &a_pubkey_hex).await;
+    assert!(
+        !after_reopen.contains(&channel_id),
+        "same-second re-open must win; DM still hidden: {after_reopen:?}"
+    );
+
+    client_a.disconnect().await.expect("disconnect");
+}
+
 /// NIP-DV privacy: a third party MUST NOT be able to read another viewer's
 /// DM visibility snapshot. The snapshot is `#p`-gated to its owner, so a
 /// `#p`=<someone-else> query is rejected by the relay's read-auth gate.

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -156,6 +156,41 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
         }
     }
 
+    // NIP-DV: drop DMs the viewer has hidden. The relay maintains a per-viewer
+    // parameterized-replaceable snapshot (kind:30622, d=my pubkey) whose `h`
+    // tags list currently-hidden DM channel ids. The snapshot also carries
+    // `p`=my pubkey so the relay's #p read-gate scopes it to me; we query by
+    // `#p` for that reason. Reading the latest one is the only way the client
+    // learns hide state, which the relay tracks privately.
+    let hidden_dms: std::collections::HashSet<String> = {
+        let events = query_relay(
+            &state,
+            &[serde_json::json!({
+                "kinds": [sprout_core::kind::KIND_DM_VISIBILITY],
+                "#p": [&my_pubkey],
+                "limit": 1,
+            })],
+        )
+        .await
+        .unwrap_or_default();
+        events
+            .iter()
+            .max_by_key(|e| e.created_at.as_secs())
+            .map(|e| {
+                e.tags
+                    .iter()
+                    .filter_map(|t| {
+                        let s = t.as_slice();
+                        (s.len() >= 2 && s[0] == "h").then(|| s[1].clone())
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    if !hidden_dms.is_empty() {
+        channels.retain(|c| c.channel_type != "dm" || !hidden_dms.contains(&c.id));
+    }
+
     Ok(channels)
 }
 

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -28,6 +28,9 @@ export const KIND_MESH_STATUS_REPORT = 24620;
 export const KIND_MESH_CONNECT_REQUEST = 24621;
 export const KIND_MESH_CALL_ME_NOW = 24622;
 export const KIND_REPO_ANNOUNCEMENT = 30617;
+// NIP-DV: relay-signed per-viewer DM visibility snapshot (d=viewer pubkey,
+// h-tags = currently-hidden DM channel ids).
+export const KIND_DM_VISIBILITY = 30622;
 
 // Human-visible "new content" message kinds. Used as the unread trigger set
 // (sidebar badges, catch-up queries) and as the Home-feed mention query.

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -9,6 +9,7 @@ import {
   KIND_EMOJI_SET,
 } from "@/shared/api/customEmoji";
 import {
+  KIND_DM_VISIBILITY,
   KIND_STREAM_MESSAGE_EDIT,
   KIND_SYSTEM_MESSAGE,
   KIND_USER_STATUS,
@@ -2484,44 +2485,67 @@ async function handleGetChannels(config: E2eConfig | undefined) {
   const memberSet = new Set(channelIds);
   const metaEvents = allMetaEvents;
 
+  // NIP-DV: query the viewer's latest DM visibility snapshot (kind:30622).
+  // The snapshot is `#p`-gated to its owner, so we query by `#p`=my pubkey.
+  // Its `h` tags are the DM channel ids to hide from the sidebar.
+  const visibilityEvents = await relayQuery(config, [
+    { kinds: [KIND_DM_VISIBILITY], "#p": [identity.pubkey], limit: 1 },
+  ]);
+  const latestVisibility = visibilityEvents.reduce<RelayEvent | null>(
+    (latest, ev) =>
+      !latest || ev.created_at > latest.created_at ? ev : latest,
+    null,
+  );
+  const hiddenDms = new Set(
+    ((latestVisibility?.tags ?? []) as string[][])
+      .filter((t) => t[0] === "h")
+      .map((t) => t[1]),
+  );
+
   // Convert kind:39000 events to the RawChannel shape the frontend expects.
-  return metaEvents.map((ev) => {
-    const tags = (ev.tags ?? []) as string[][];
-    const getTag = (name: string) =>
-      tags.find((t) => t[0] === name)?.[1] ?? null;
-    const channelId = getTag("d") ?? "";
-    const channelType = getTag("t") ?? "stream";
-    const isPrivate = tags.some((t) => t[0] === "private");
-    const isArchived = tags.some((t) => t[0] === "archived" && t[1] === "true");
+  return metaEvents
+    .map((ev) => {
+      const tags = (ev.tags ?? []) as string[][];
+      const getTag = (name: string) =>
+        tags.find((t) => t[0] === name)?.[1] ?? null;
+      const channelId = getTag("d") ?? "";
+      const channelType = getTag("t") ?? "stream";
+      const isPrivate = tags.some((t) => t[0] === "private");
+      const isArchived = tags.some(
+        (t) => t[0] === "archived" && t[1] === "true",
+      );
 
-    // Get participant pubkeys from the membership event for this channel
-    const memberEvent = memberEvents.find((me) =>
-      (me.tags ?? []).some((t: string[]) => t[0] === "d" && t[1] === channelId),
-    );
-    const pTags = memberEvent
-      ? ((memberEvent.tags ?? []) as string[][])
-          .filter((t) => t[0] === "p")
-          .map((t) => t[1])
-      : [];
+      // Get participant pubkeys from the membership event for this channel
+      const memberEvent = memberEvents.find((me) =>
+        (me.tags ?? []).some(
+          (t: string[]) => t[0] === "d" && t[1] === channelId,
+        ),
+      );
+      const pTags = memberEvent
+        ? ((memberEvent.tags ?? []) as string[][])
+            .filter((t) => t[0] === "p")
+            .map((t) => t[1])
+        : [];
 
-    return {
-      id: channelId,
-      name: getTag("name") ?? "",
-      description: getTag("about") ?? "",
-      channel_type: channelType as "stream" | "forum" | "dm",
-      visibility: (isPrivate ? "private" : "open") as "open" | "private",
-      topic: getTag("topic") ?? null,
-      purpose: getTag("purpose") ?? null,
-      member_count: pTags.length,
-      last_message_at: null,
-      archived_at: isArchived ? new Date().toISOString() : null,
-      participants: pTags,
-      participant_pubkeys: pTags,
-      ttl_seconds: getTag("ttl") ? Number(getTag("ttl")) : null,
-      ttl_deadline: getTag("ttl_deadline") ?? null,
-      is_member: memberSet.has(channelId),
-    };
-  });
+      return {
+        id: channelId,
+        name: getTag("name") ?? "",
+        description: getTag("about") ?? "",
+        channel_type: channelType as "stream" | "forum" | "dm",
+        visibility: (isPrivate ? "private" : "open") as "open" | "private",
+        topic: getTag("topic") ?? null,
+        purpose: getTag("purpose") ?? null,
+        member_count: pTags.length,
+        last_message_at: null,
+        archived_at: isArchived ? new Date().toISOString() : null,
+        participants: pTags,
+        participant_pubkeys: pTags,
+        ttl_seconds: getTag("ttl") ? Number(getTag("ttl")) : null,
+        ttl_deadline: getTag("ttl_deadline") ?? null,
+        is_member: memberSet.has(channelId),
+      };
+    })
+    .filter((c) => c.channel_type !== "dm" || !hiddenDms.has(c.id));
 }
 
 async function handleGetProfile(config: E2eConfig | undefined) {

--- a/docs/nips/NIP-DV.md
+++ b/docs/nips/NIP-DV.md
@@ -1,0 +1,138 @@
+NIP-DV
+======
+
+DM Visibility
+-------------
+
+`draft` `optional` `relay`
+
+**Depends on**: NIP-01 (basic event format), NIP-11 (relay information document), NIP-43 (Relay Access Metadata and Requests)
+
+## Abstract
+
+This NIP defines a relay-scoped, per-viewer projection of DM (direct message) hide state. A viewer can hide a DM conversation from their sidebar without leaving it: they remain an active member, still receive messages, and can re-open it later. The relay tracks this hide state privately. This NIP exposes it as a single relay-signed, parameterized-replaceable event per viewer so that pure-Nostr clients can filter hidden DMs out of the conversation list without any other source of truth.
+
+The protocol has one relay-signed event kind:
+
+- a relay-signed per-viewer snapshot (`kind:30622` DM visibility snapshot).
+
+There is no user-signed request kind. The hide/unhide intent is already carried by the existing DM commands (`kind:41012` hide, `kind:41010` open/re-open); the relay derives and re-publishes the visibility snapshot as a side effect of accepting those commands.
+
+## Motivation
+
+Sprout DMs are surfaced to clients as NIP-29-style group membership (`kind:39002`), where the viewer appears as a `#p` participant. Hiding a DM is presentation state, not membership: the viewer stays in the member list because they can still receive messages and re-open the conversation. So `kind:39002` correctly continues to list the viewer, and a client that rebuilds its DM list from `kind:39002` alone cannot tell which DMs the viewer has hidden.
+
+The relay does know — it records `hidden_at` per (viewer, channel) — but never emits that fact as a queryable Nostr event. A thin client is therefore flying blind on a piece of state only the relay holds. The result is the visible bug: a hidden DM is optimistically removed, then reappears on the next conversation-list refetch because the refetch is rebuilt from `kind:39002`, which never carried the hide.
+
+NIP-DV fills that gap. The relay publishes a transparent, relay-signed, per-viewer snapshot of the currently-hidden DM set. Clients read the latest snapshot and filter hidden DMs out of the sidebar, while membership and message delivery are unaffected.
+
+## Non-Goals
+
+This NIP does not change membership. A hidden DM keeps the viewer as an active `kind:39002` participant; message delivery and re-open are unaffected.
+
+This NIP does not delete events. No DM message or membership event is removed.
+
+This NIP does not define a shared or global hide state. The snapshot is per-viewer and relay-scoped. A viewer's hide state is theirs alone; the other DM participant's view is unaffected.
+
+This NIP does not define a user-signed request kind. Hide and unhide intent is already expressed by `kind:41012` and `kind:41010`. NIP-DV only describes the relay-signed projection.
+
+## Terminology
+
+This document uses MUST, MUST NOT, SHOULD, SHOULD NOT, MAY, and RECOMMENDED as defined in RFC 2119.
+
+- **relay identity**: The relay signing pubkey advertised in its NIP-11 `self` field. NIP-DV relay-signed events are valid only when signed by this key.
+- **viewer**: The pubkey whose per-viewer hide state a given snapshot describes.
+- **hidden DM**: A DM channel the viewer currently has hidden (`hidden_at IS NOT NULL`) while still being an active, non-removed member.
+- **visibility snapshot**: A relay-signed `kind:30622` event listing every DM the viewer currently has hidden.
+
+## Kinds
+
+| Kind | Name | Signer | Storage | Purpose |
+|------|------|--------|---------|---------|
+| `30622` | DM Visibility Snapshot | relay | parameterized-replaceable | Current per-viewer hidden-DM set |
+
+`kind:30622` is parameterized-replaceable per NIP-01 (`30000 <= n < 40000`), keyed by its `d` tag. The `d` tag is the viewer's pubkey, so there is exactly one current snapshot per viewer. Clients use the latest valid `kind:30622` signed by the relay identity, addressed by `d` = the viewer's pubkey, as current state.
+
+The snapshot is relay-scoped: it is signed by the relay identity advertised in NIP-11 `self`, mirroring NIP-IA's relay-signed snapshot shape. Relays without a stable NIP-11 `self` pubkey MUST NOT publish NIP-DV relay-signed state, because clients would have no stable key against which to verify it.
+
+## Event Formats
+
+### `kind:30622` DM Visibility Snapshot
+
+A visibility snapshot is signed by the relay identity. It carries one `h` tag per DM channel the viewer currently has hidden.
+
+```jsonc
+{
+  "kind": 30622,
+  "pubkey": "<relay-identity-pubkey-hex>",
+  "content": "",
+  "tags": [
+    ["d", "<viewer-pubkey-hex>"],
+    ["p", "<viewer-pubkey-hex>"],
+    ["h", "<hidden-dm-channel-id>"],
+    ["h", "<hidden-dm-channel-id>"]
+  ]
+}
+```
+
+Required tags:
+
+- exactly one `d` tag whose value is the viewer's 64-character lowercase hex pubkey. This is the parameterized-replaceable address key.
+- exactly one `p` tag whose value equals the `d` value (the viewer's pubkey). The `p` tag is the read-authorization key: relays that `#p`-gate per-viewer state (see §Privacy Considerations) use it to restrict reads to the snapshot's owner. The `d` and `p` tags are deliberately redundant — `d` addresses the replaceable event, `p` authorizes the reader.
+
+Optional tags:
+
+- zero or more `h` tags, each identifying a DM channel the viewer currently has hidden. A snapshot with no `h` tags means the viewer has no hidden DMs (their hidden set is empty). Order is not significant; clients MUST treat `h` tags as a set.
+
+The `content` field is empty and carries no meaning. Clients MUST NOT parse semantics from `content`.
+
+## Relay Processing Algorithm
+
+After the relay accepts and commits a DM command that changes a viewer's hide state, it republishes that viewer's snapshot:
+
+1. On `kind:41012` (hide): the viewer's `hidden_at` for the target channel is set.
+2. On `kind:41010` (open/re-open) that clears an existing `hidden_at`: the viewer's hide state for the target channel is cleared.
+
+In both cases the relay recomputes the viewer's full hidden-DM set from its authoritative state (active, non-removed DM memberships with `hidden_at IS NOT NULL`) and publishes a fresh `kind:30622` snapshot signed by the relay identity, with `d` = the viewer's pubkey and one `h` tag per hidden DM.
+
+The recompute-and-replace shape means the latest snapshot is always the complete, authoritative hidden set. There is no delta event to merge and no ordering hazard between hide and unhide: a stale snapshot is simply superseded by the newer one under NIP-01 parameterized-replaceable semantics.
+
+Snapshot publication is a best-effort post-commit side effect. If publication fails, the hide/unhide command itself still succeeds; the relay SHOULD republish the snapshot on the next state change. A momentarily stale snapshot only affects sidebar presentation, never membership or delivery.
+
+## Client Behavior
+
+A client that rebuilds its DM list from `kind:39002` membership SHOULD additionally:
+
+1. Query its own latest snapshot: `kinds: [30622]`, `#p: [<my-pubkey>]`, `limit: 1`. The query is keyed by `#p` (not `#d`) because that is the tag the relay's read-authorization gate checks.
+2. If a snapshot exists, collect its `h` tag values into a set of hidden DM channel ids.
+3. Filter the DM list, dropping any DM whose channel id is in that set. Non-DM channels MUST NOT be affected.
+
+A client SHOULD verify that the snapshot is signed by the relay identity before trusting it (see §Security Considerations for the current implementation posture). A client that finds no snapshot MUST treat the hidden set as empty (no DMs hidden).
+
+## Implementation Gotchas
+
+- The snapshot is keyed by the viewer's pubkey via the `d` tag, not by channel. There is one event per viewer listing all their hidden DMs, not one event per (viewer, channel) pair.
+- Hiding a DM does not remove the viewer from `kind:39002`. A client MUST NOT infer hide state from membership, and MUST NOT filter the viewer out of the member list — doing so would break re-open and message delivery.
+- `kind:41010` (open) is used both to first-open a DM and to re-open a hidden one. Only the re-open path (which clears an existing `hidden_at`) needs to refresh the snapshot; a first-open had nothing hidden to clear.
+
+## Security Considerations
+
+The snapshot is relay-signed and relay-scoped. A client SHOULD verify the relay-identity signature before applying it; a snapshot signed by any other key is invalid and MUST be ignored.
+
+Current implementation posture: the desktop client trusts whatever the configured relay returns from its authenticated `/query` endpoint and does not yet re-verify the relay-identity signature client-side, matching NIP-IA's current behavior for relay-signed state. This is acceptable because the relay is the configured, authenticated source of truth and the connection is authenticated (NIP-42 / NIP-98). Wiring explicit client-side relay-identity verification is a cross-cutting hardening that should be applied uniformly across all relay-signed reads (NIP-DV, NIP-IA, NIP-OA) rather than piecemeal here.
+
+## Privacy Considerations
+
+A viewer's hidden-DM set is per-viewer presentation state. The snapshot is addressed to the viewer (`d` = viewer pubkey) and reveals which DM conversations that viewer has chosen to hide. To prevent one viewer from enumerating another's hide choices, the relay MUST scope read access so that only the snapshot's owner can read it.
+
+This NIP achieves that with two layers. First, a filter-level `#p` read-authorization gate: the snapshot carries `p` = viewer, and the relay rejects any query for `kind:30622` whose `#p` filter is absent or does not equal the authenticated reader's pubkey — the same gate that protects member-add/remove notifications and gift wraps. Second, a result-level owner check applied at every delivery surface (HTTP query, WebSocket historical, live fan-out, and NIP-50 search): a `kind:30622` event is only handed to a reader whose pubkey equals its `#p`. The result-level check closes the gap where a filter-level gate alone could be bypassed — most importantly a kindless `ids:[<known-snapshot-id>]` query, since the snapshot is relay-signed (its id is not author-bound) and its content is plaintext private hide choices. As defense in depth, the relay also excludes `kind:30622` from its full-text search index entirely, so a snapshot never becomes a search hit in the first place. A relay that exposes NIP-DV snapshots without owner-scoped read access MUST NOT do so.
+
+## Implementation Note: Write Protection
+
+`kind:30622` is relay-only. Relays MUST reject client-submitted events of this kind: only the relay identity may author a snapshot. Combined with the `#p` read-gate above, a snapshot can be neither forged by a client nor read by a non-owner.
+
+## Relation to Other NIPs
+
+- **NIP-IA (Identity Archival)**: Same relay-signed-snapshot shape (user-or-relay intent → relay-signed, replaceable, relay-scoped state). NIP-DV applies the pattern per-viewer for DM presentation rather than per-pubkey for membership surfaces.
+- **NIP-43 (Relay Access Metadata and Requests)**: Defines membership/access control. NIP-DV is strictly presentation state layered on top — a DM can be hidden without any membership change.
+- **NIP-29 group membership (`kind:39002`)**: The source of the DM list a client rebuilds. NIP-DV is the missing per-viewer filter applied on top of it.


### PR DESCRIPTION
## Problem

Hiding a DM removed it from the list optimistically, but the next `get_channels` refetch rebuilt the DM list purely from `kind:39002` membership and brought it back. Per-viewer hide state lives only in the relay DB (`channel_members.hidden_at`) and was never exposed as a queryable Nostr event, so the thin client had no way to learn it. Re-open (41010) carries no `#h`, so a pure-client filter couldn't be correct either.

## Fix

A relay-signed, per-viewer **parameterized-replaceable** snapshot (`kind:30622`, **NIP-DV**):

- Emitted on hide (41012) and re-open (41010 that clears `hidden_at`), recompute-and-replace so the latest event is the authoritative hidden set (`d` = viewer → unique per viewer).
- Both client read paths (`get_channels` Rust + e2e bridge) filter on it.
- Read path stays pure-Nostr/event-sourced, per-viewer correct, live across devices.

## Privacy (owner-scoped, every surface)

- **Filter-level `#p` gate** rejects queries for another viewer's snapshot (explicit `kinds:[30622]` → 403).
- **Result-level owner check** (`reader_authorized_for_event`) at **every delivery surface** — HTTP `/query`, WebSocket historical, live fan-out, and NIP-50 search — closes the kindless-`ids` bypass (kindless `ids:[…]` → 200 + empty).
- 30622 is **excluded from the search index** as defense in depth.

## Review

Independently reviewed by @Pinky across three adversarial passes — three real CHANGE-level issues caught and fixed:
1. Per-viewer snapshot collision (wrong replacement key) → `replace_parameterized_event`.
2. `ids` privacy bypass → `#p`=self enforced for explicit-kind filters.
3. NIP-50 search surface missing the result-level owner check → fixed + index exclusion.

Code/privacy shape is **blessed**.

## Tests

- Relay unit suite **273 pass**, clippy/typecheck/biome clean, relay builds.
- e2e crate compiles.

## ⚠️ Must-do before merge

- [x] **Run the 5 live NIP-DV e2e against a real relay.** They compile but have **not** been run locally yet due to a local Postgres PG17/PG18 data-dir/image mismatch. CI should exercise them; if CI doesn't run the `#[ignore]`d NIP-DV e2e, run them locally before merging. Tests: `test_nipdv_hide_then_reopen_updates_snapshot`, `test_nipdv_two_viewers_independent_snapshots`, `test_nipdv_ws_req_rejects_third_party`, `test_nipdv_ids_query_rejects_third_party` + `test_nipdv_explicit_kind_query_forbidden_for_third_party`, `test_nipdv_search_rejects_third_party`.

## Docs

New `docs/nips/NIP-DV.md` — event format, client behavior, privacy + write-protection model. NIP says untrusted/multi-relay clients MUST verify NIP-11 `self`; notes that Sprout Desktop currently trusts its configured relay like NIP-IA (document-the-gap, not broadened scope).
