### PR TITLE
fix(desktop): handle symlinked persona pack directories

### DIFF
--- a/desktop/src-tauri/src/managed_agents/personas.rs
+++ b/desktop/src-tauri/src/managed_agents/personas.rs
@@ -882,12 +882,20 @@ pub fn uninstall_persona_pack(app: &AppHandle, pack_id: &str) -> Result<(), Stri
         ));
     }
 
-    // Remove pack directory
+    // Remove pack directory (or symlink)
     let packs = packs_dir(app)?;
     let pack_dir = packs.join(pack_id);
     if pack_dir.exists() {
-        fs::remove_dir_all(&pack_dir)
-            .map_err(|e| format!("failed to remove pack directory: {e}"))?;
+        let is_symlink = fs::symlink_metadata(&pack_dir)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false);
+        if is_symlink {
+            fs::remove_file(&pack_dir)
+                .map_err(|e| format!("failed to remove pack symlink: {e}"))?;
+        } else {
+            fs::remove_dir_all(&pack_dir)
+                .map_err(|e| format!("failed to remove pack directory: {e}"))?;
+        }
     }
 
     // Remove pack PersonaRecords
@@ -909,10 +917,11 @@ pub fn list_installed_packs(app: &AppHandle) -> Result<Vec<PackSummary>, String>
 
     for entry in fs::read_dir(&packs).map_err(|e| format!("failed to read packs dir: {e}"))? {
         let entry = entry.map_err(|e| format!("dir entry error: {e}"))?;
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        let pack_dir = entry.path();
+        // Use stat (follows symlinks) rather than lstat so symlinked packs are recognised.
+        if !pack_dir.is_dir() {
             continue;
         }
-        let pack_dir = entry.path();
         if let Ok(resolved) = sprout_persona::resolve::resolve_pack(&pack_dir) {
             summaries.push(PackSummary {
                 id: resolved.id,


### PR DESCRIPTION
## Summary

- **`list_installed_packs`** used `entry.file_type()` (`lstat`) to filter directory entries, which returns `is_dir = false` for symlinks — symlinked pack directories were silently skipped. Switched to `Path::is_dir()` (`stat`) which follows symlinks.
- **`uninstall_persona_pack`** called `remove_dir_all` unconditionally, which follows symlinks and recursively deletes the *source* directory contents. Now detects symlinks via `symlink_metadata` and uses `remove_file` (unlink) instead.

Stack: **this PR** → #852