### PR TITLE
fix(desktop): remove thread comment hover outline

### DIFF
--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -316,8 +316,6 @@ export const MessageRow = React.memo(
           className={cn(
             "group/message relative rounded-2xl px-2 py-1 transition-colors",
             "flex items-start gap-2.5",
-            isThreadReplyLayout &&
-              "hover:ring-1 hover:ring-border/70 focus-within:ring-1 focus-within:ring-border/70",
             highlighted
               ? "-mx-4 rounded-none px-6 before:absolute before:-inset-y-1.5 before:inset-x-0 before:animate-[route-target-highlight-fade_2s_ease-out_forwards] before:bg-primary/10 before:content-[''] motion-reduce:before:animate-none sm:-mx-6 sm:px-8"
               : "",


### PR DESCRIPTION
## Summary

Thread comments no longer show the rounded hover outline that belongs to the replies opener. The replies summary control still keeps its hover treatment for opening a thread.

## Test plan

- `bin/just desktop-check`

Note: attempted `bin/just desktop-screenshot --name thread-row-hover-fix --route /channels/general --click message-thread-summary`, but the default mock `general` route did not include a `message-thread-summary` element to open.
