### PR TITLE
docs: add VISION_MESH.md — the compute-commons vision

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -102,6 +102,12 @@ Voice, room lifecycle, and lifecycle events are wired. Recording and per-track p
 
 ---
 
+## Sprout Mesh
+
+Relay communities can pool opted-in member hardware into shared AI compute. Existing agents see it as a local OpenAI-compatible provider; the relay gates discovery and trust with the same membership model it already uses for messages, code, and workflows. Models too large for any single machine split across several. See [VISION_MESH.md](VISION_MESH.md) for the full compute-commons vision.
+
+---
+
 ## Workflows
 
 Channel-scoped YAML-as-code automation with conditional logic — the feature Slack paywalled for 5 years. Message triggers, reaction triggers, scheduled runs, webhooks. Every step traced. Agents manage workflows through MCP tools.
@@ -204,6 +210,7 @@ Greenfield. Agent swarms build in parallel, integrating at the event store bound
 | ✅ | Agent personas and teams — desktop-managed, built-in defaults, operator-defined |
 | 🚧 | Workflow approval gates — infrastructure exists (DB, API, UI); executor doesn't persist/resume (WF-08) |
 | ✅ | Huddles — WebSocket Opus voice relay + lifecycle events (recording/tracks planned) |
+| ✅ | Sprout Mesh — relay-gated shared AI compute (mesh-llm over iroh); members pool GPUs, agents consume via a local OpenAI-compatible endpoint |
 | 🚧 | Mobile client — Flutter app (channels, forum, search, profile, pairing); in active development |
 | 📋 | Developer portal, push notifications, culture features |
 

--- a/VISION_MESH.md
+++ b/VISION_MESH.md
@@ -1,0 +1,53 @@
+# 🕸️ Sprout Mesh — Your community is your compute
+
+> A small team runs their project on one Sprout relay. Three of them have GPUs that sit idle most of the day — a gaming PC, a laptop, a workstation under a desk. One flips a toggle: *Share compute.* The others point their agents at it. Now the whole team's coding agents answer from a capable model running on hardware they already own. No API keys. No cloud bill. Every prompt runs inside the relay community they already chose to trust.
+
+A Sprout relay is a trust group. The people in it already know each other — that shared membership is a decision they've already made. Sprout Mesh turns that decision into shared AI compute: the idle GPUs scattered across your community become one pool, usable by every agent on the relay, gated by the membership you already have. And because the pool is many machines, not one, the community can run models larger and more capable than any one member could load alone. More intelligence becomes reachable when the group works as a group.
+
+Nothing here is new on its own. Pooling GPUs across machines is solved. Nostr identity is solved. Relay-gated membership is how Sprout already works. The insight is that the tool that pools the GPUs already speaks the same protocol Sprout is built on — so the mesh's admission gate and your relay's membership gate are the same gate.
+
+Each piece is boring. The combination is the thing.
+
+---
+
+## What You See
+
+You open Sprout and flip on **Share compute.** Your machine loads a model your GPU can hold and starts answering requests from other members of your relay. A consent panel is honest about the deal: prompts from other members run on your hardware, and what you're serving is visible to the people you share the relay with.
+
+On another machine, you point an agent at the mesh and pick from whatever models your community is serving. The agent talks to a normal local AI endpoint; the work routes to whoever's hosting that model — the workstation down the hall, or a teammate three timezones away. The agent neither knows nor cares which.
+
+When an agent needs a model, Sprout helps it find a member machine already serving one: the relay coordinates the trust, the machines do the work, and the request runs directly between them — the relay never sees a token of it.
+
+And when a model is too large for any single machine, the mesh can split it across several, each holding a slice. A model no one's laptop could run alone runs because the community ran it together.
+
+Non-members see none of this. They can't find the mesh, can't join it, can't serve to it or use it.
+
+---
+
+## Why It's Yours
+
+Membership is the only gate, and it's a gate you already control. The same decision that lets someone read your channels and push to your repos now lets them share and use compute — and when membership ends, their path back to the mesh ends too. There is no separate access list to maintain, no new account, no new login. One trust decision covers your conversation, your code, and now your compute.
+
+This is why it matters most for agents. An agent on your relay isn't reaching out to a vendor with your prompts and your credit card. It's using hardware owned by people you already chose to work with, reachable only because they're inside the same circle you are.
+
+---
+
+## Honest Costs
+
+Your prompts go to people, not a vendor. For a trust group that's a feature — far better than handing them to a stranger's cloud — but it is a different promise than "your data never leaves your machine," and the consent screen says so plainly. A relay is only as private as its membership is trustworthy.
+
+The mesh is opt-in, so it's only as capable as your community's participation. A relay where nobody shares compute has an empty mesh. That's the right default — you give willingly or not at all — but the value compounds with how many people turn it on.
+
+These are honest costs. They're worth it if you want capable AI for your community, on hardware you already own, gated by a trust group you already have. They're not worth it if you'd rather hand a vendor your prompts and your card. Know which one you are.
+
+---
+
+## The Point
+
+The relay is the workspace. Sprout Mesh makes it the compute commons too.
+
+Your community is not just where agents talk, plan, and leave records. It is where they can run.
+
+---
+
+*Sprout 🕸️ — your community is your compute.*


### PR DESCRIPTION
Adds `VISION_MESH.md` as the fifth root vision doc, companion to `VISION.md` / `VISION_SOVEREIGN.md` / `VISION_PROJECTS.md` / `VISION_AGENT.md`.

**What it is:** the human-facing, vision-focused (not implementation) story of Sprout Mesh — pooling relay members' idle GPUs into shared AI compute, gated by the membership the community already has. Including models too large for any single machine, run by the community together.

**Voice & constraints:** matches the existing vision docs — cold-open vignette, "each piece is boring, the combination is the thing," an Honest Costs section in the SOVEREIGN "What You Give Up" mold. No protocol kinds, no implementation walk, no privacy overclaim. 53 lines.

**Process:** drafted and refined jointly by Eva and Max across the `sprout-mesh-vision-6-5-26` thread, reconciled to a single 9/10+ version, then revised per Tyler's note to elevate the "many machines unlock intelligence no member could run alone" promise. Co-authored.