### PR TITLE
Move settings into the app shell

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -173,9 +173,6 @@ export function AppShell() {
   const [settingsSection, setSettingsSection] = React.useState<SettingsSection>(
     DEFAULT_SETTINGS_SECTION,
   );
-  const [settingsMode, setSettingsMode] = React.useState<
-    "profile" | "preferences"
-  >("preferences");
 
   const [isChannelManagementOpen, setIsChannelManagementOpen] =
     React.useState(false);
@@ -423,9 +420,8 @@ export function AppShell() {
   );
 
   const handleOpenSettings = React.useCallback(
-    (section: SettingsSection = "appearance") => {
+    (section: SettingsSection = DEFAULT_SETTINGS_SECTION) => {
       setIsChannelManagementOpen(false);
-      setSettingsMode(section === "profile" ? "profile" : "preferences");
       setSettingsSection(section);
       setSettingsOpen(true);
     },
@@ -684,155 +680,191 @@ export function AppShell() {
         >
           <HuddleProvider>
             <div className="flex h-dvh flex-col overflow-hidden overscroll-none">
-              <SidebarProvider
-                className="min-h-0 flex-1 overflow-hidden"
-                disableRail={settingsOpen}
-              >
-                <AppTopChrome
-                  canGoBack={canGoBack}
-                  canGoForward={canGoForward}
-                  channels={channels}
-                  currentPubkey={identityQuery.data?.pubkey}
-                  onGoBack={goBack}
-                  onGoForward={goForward}
-                  onOpenChannel={(channelId) => {
-                    void goChannel(channelId);
-                  }}
-                  onOpenResult={handleOpenSearchResult}
-                  searchFocusRequest={searchFocusRequest}
-                />
-                <AppSidebar
-                  activeWorkspace={workspacesHook.activeWorkspace}
-                  channels={sidebarChannels}
-                  currentPubkey={identityQuery.data?.pubkey}
-                  errorMessage={
-                    channelsQuery.error instanceof Error
-                      ? channelsQuery.error.message
-                      : undefined
-                  }
-                  fallbackDisplayName={identityQuery.data?.displayName}
-                  homeBadgeCount={homeBadgeCount}
-                  isAddWorkspaceOpen={isAddWorkspaceOpen}
-                  isCreatingChannel={createChannelMutation.isPending}
-                  isCreatingForum={createForumMutation.isPending}
-                  isLoading={channelsQuery.isLoading}
-                  isOpeningDm={openDmMutation.isPending}
-                  isNewDmOpen={isNewDmOpen}
-                  isCreateChannelOpen={isCreateChannelOpen}
-                  isPresencePending={presenceSession.isPending}
-                  onAddWorkspace={(workspace) => {
-                    const id = workspacesHook.addWorkspace(workspace);
-                    workspacesHook.switchWorkspace(id);
-                  }}
-                  onAddWorkspaceOpenChange={setIsAddWorkspaceOpen}
-                  onNewDmOpenChange={setIsNewDmOpen}
-                  onCreateChannelOpenChange={setIsCreateChannelOpen}
-                  onOpenAddWorkspace={() => setIsAddWorkspaceOpen(true)}
-                  onUpdateWorkspace={workspacesHook.updateWorkspace}
-                  onRemoveWorkspace={workspacesHook.removeWorkspace}
-                  onSwitchWorkspace={workspacesHook.switchWorkspace}
-                  selfPresenceStatus={presenceSession.currentStatus}
-                  workspaces={workspacesHook.workspaces}
-                  onCreateChannel={async ({
-                    description,
-                    name,
-                    visibility,
-                    ttlSeconds,
-                    templateId,
-                  }) => {
-                    const createdChannel =
-                      await createChannelMutation.mutateAsync({
-                        name,
+              <SidebarProvider className="min-h-0 flex-1 overflow-hidden">
+                {!settingsOpen ? (
+                  <AppTopChrome
+                    canGoBack={canGoBack}
+                    canGoForward={canGoForward}
+                    channels={channels}
+                    currentPubkey={identityQuery.data?.pubkey}
+                    onGoBack={goBack}
+                    onGoForward={goForward}
+                    onOpenChannel={(channelId) => {
+                      void goChannel(channelId);
+                    }}
+                    onOpenResult={handleOpenSearchResult}
+                    searchFocusRequest={searchFocusRequest}
+                  />
+                ) : null}
+                {settingsOpen ? (
+                  <React.Suspense fallback={null}>
+                    <LazySettingsScreen
+                      currentPubkey={identityQuery.data?.pubkey}
+                      fallbackDisplayName={identityQuery.data?.displayName}
+                      isUpdatingDesktopNotifications={
+                        notificationSettings.isUpdatingDesktopEnabled
+                      }
+                      notificationErrorMessage={
+                        notificationSettings.errorMessage
+                      }
+                      notificationPermission={notificationSettings.permission}
+                      notificationSettings={notificationSettings.settings}
+                      onClose={handleCloseSettings}
+                      onSectionChange={setSettingsSection}
+                      onSetDesktopNotificationsEnabled={
+                        notificationSettings.setDesktopEnabled
+                      }
+                      onSetHomeBadgeEnabled={
+                        notificationSettings.setHomeBadgeEnabled
+                      }
+                      onSetMentionNotificationsEnabled={
+                        notificationSettings.setMentionsEnabled
+                      }
+                      onSetNeedsActionNotificationsEnabled={
+                        notificationSettings.setNeedsActionEnabled
+                      }
+                      onSetSoundEnabled={notificationSettings.setSoundEnabled}
+                      section={settingsSection}
+                    />
+                  </React.Suspense>
+                ) : (
+                  <>
+                    <AppSidebar
+                      activeWorkspace={workspacesHook.activeWorkspace}
+                      channels={sidebarChannels}
+                      currentPubkey={identityQuery.data?.pubkey}
+                      errorMessage={
+                        channelsQuery.error instanceof Error
+                          ? channelsQuery.error.message
+                          : undefined
+                      }
+                      fallbackDisplayName={identityQuery.data?.displayName}
+                      homeBadgeCount={homeBadgeCount}
+                      isAddWorkspaceOpen={isAddWorkspaceOpen}
+                      isCreatingChannel={createChannelMutation.isPending}
+                      isCreatingForum={createForumMutation.isPending}
+                      isLoading={channelsQuery.isLoading}
+                      isOpeningDm={openDmMutation.isPending}
+                      isNewDmOpen={isNewDmOpen}
+                      isCreateChannelOpen={isCreateChannelOpen}
+                      isPresencePending={presenceSession.isPending}
+                      onAddWorkspace={(workspace) => {
+                        const id = workspacesHook.addWorkspace(workspace);
+                        workspacesHook.switchWorkspace(id);
+                      }}
+                      onAddWorkspaceOpenChange={setIsAddWorkspaceOpen}
+                      onNewDmOpenChange={setIsNewDmOpen}
+                      onCreateChannelOpenChange={setIsCreateChannelOpen}
+                      onOpenAddWorkspace={() => setIsAddWorkspaceOpen(true)}
+                      onUpdateWorkspace={workspacesHook.updateWorkspace}
+                      onRemoveWorkspace={workspacesHook.removeWorkspace}
+                      onSwitchWorkspace={workspacesHook.switchWorkspace}
+                      selfPresenceStatus={presenceSession.currentStatus}
+                      workspaces={workspacesHook.workspaces}
+                      onCreateChannel={async ({
                         description,
-                        channelType: "stream",
+                        name,
                         visibility,
                         ttlSeconds,
-                      });
+                        templateId,
+                      }) => {
+                        const createdChannel =
+                          await createChannelMutation.mutateAsync({
+                            name,
+                            description,
+                            channelType: "stream",
+                            visibility,
+                            ttlSeconds,
+                          });
 
-                    await applyCanvas(templateId, createdChannel.id, name);
-                    await goChannel(createdChannel.id);
-                    void applyAgents(templateId, createdChannel.id);
-                  }}
-                  onCreateForum={async ({
-                    description,
-                    name,
-                    visibility,
-                    ttlSeconds,
-                    templateId,
-                  }) => {
-                    const createdForum = await createForumMutation.mutateAsync({
-                      name,
-                      description,
-                      channelType: "forum",
-                      visibility,
-                      ttlSeconds,
-                    });
+                        await applyCanvas(templateId, createdChannel.id, name);
+                        await goChannel(createdChannel.id);
+                        void applyAgents(templateId, createdChannel.id);
+                      }}
+                      onCreateForum={async ({
+                        description,
+                        name,
+                        visibility,
+                        ttlSeconds,
+                        templateId,
+                      }) => {
+                        const createdForum =
+                          await createForumMutation.mutateAsync({
+                            name,
+                            description,
+                            channelType: "forum",
+                            visibility,
+                            ttlSeconds,
+                          });
 
-                    await applyCanvas(templateId, createdForum.id, name);
-                    await goChannel(createdForum.id);
-                    void applyAgents(templateId, createdForum.id);
-                  }}
-                  onHideDm={handleHideDm}
-                  onMarkAllChannelsRead={markAllChannelsRead}
-                  onMarkChannelRead={markChannelRead}
-                  onMarkChannelUnread={markChannelUnread}
-                  onOpenBrowseChannels={handleOpenBrowseChannels}
-                  onOpenBrowseForums={handleOpenBrowseForums}
-                  onOpenDm={async ({ pubkeys }) => {
-                    const directMessage = await openDmMutation.mutateAsync({
-                      pubkeys,
-                    });
-                    await goChannel(directMessage.id);
-                  }}
-                  onSelectAgents={() => {
-                    void goAgents();
-                  }}
-                  onSelectChannel={(channelId) => {
-                    void goChannel(channelId);
-                  }}
-                  onSelectHome={() => {
-                    void goHome();
-                  }}
-                  onSelectProjects={() => {
-                    void goProjects();
-                  }}
-                  onSelectPulse={() => {
-                    void goPulse();
-                  }}
-                  onSelectSettings={handleOpenSettings}
-                  onSelectWorkflows={() => {
-                    void goWorkflows();
-                  }}
-                  onSetPresenceStatus={(status) =>
-                    presenceSession.setStatus(status)
-                  }
-                  onSetUserStatus={(text, emoji) =>
-                    setUserStatusMutation.mutate({ text, emoji })
-                  }
-                  onClearUserStatus={() =>
-                    setUserStatusMutation.mutate({ text: "", emoji: "" })
-                  }
-                  profile={profileQuery.data}
-                  selfUserStatus={
-                    deferredPubkey
-                      ? (selfStatusQuery.data?.[deferredPubkey.toLowerCase()] ??
-                        undefined)
-                      : undefined
-                  }
-                  selectedChannelId={selectedChannelId}
-                  selectedView={selectedView}
-                  unreadChannelIds={unreadChannelIds}
-                  mutedChannelIds={mutedChannelIds}
-                  onMuteChannel={muteChannel}
-                  onUnmuteChannel={unmuteChannel}
-                  starredChannelIds={starredChannelIds}
-                  onStarChannel={starChannel}
-                  onUnstarChannel={unstarChannel}
-                />
+                        await applyCanvas(templateId, createdForum.id, name);
+                        await goChannel(createdForum.id);
+                        void applyAgents(templateId, createdForum.id);
+                      }}
+                      onHideDm={handleHideDm}
+                      onMarkAllChannelsRead={markAllChannelsRead}
+                      onMarkChannelRead={markChannelRead}
+                      onMarkChannelUnread={markChannelUnread}
+                      onOpenBrowseChannels={handleOpenBrowseChannels}
+                      onOpenBrowseForums={handleOpenBrowseForums}
+                      onOpenDm={async ({ pubkeys }) => {
+                        const directMessage = await openDmMutation.mutateAsync({
+                          pubkeys,
+                        });
+                        await goChannel(directMessage.id);
+                      }}
+                      onSelectAgents={() => {
+                        void goAgents();
+                      }}
+                      onSelectChannel={(channelId) => {
+                        void goChannel(channelId);
+                      }}
+                      onSelectHome={() => {
+                        void goHome();
+                      }}
+                      onSelectProjects={() => {
+                        void goProjects();
+                      }}
+                      onSelectPulse={() => {
+                        void goPulse();
+                      }}
+                      onSelectSettings={handleOpenSettings}
+                      onSelectWorkflows={() => {
+                        void goWorkflows();
+                      }}
+                      onSetPresenceStatus={(status) =>
+                        presenceSession.setStatus(status)
+                      }
+                      onSetUserStatus={(text, emoji) =>
+                        setUserStatusMutation.mutate({ text, emoji })
+                      }
+                      onClearUserStatus={() =>
+                        setUserStatusMutation.mutate({ text: "", emoji: "" })
+                      }
+                      profile={profileQuery.data}
+                      selfUserStatus={
+                        deferredPubkey
+                          ? (selfStatusQuery.data?.[
+                              deferredPubkey.toLowerCase()
+                            ] ?? undefined)
+                          : undefined
+                      }
+                      selectedChannelId={selectedChannelId}
+                      selectedView={selectedView}
+                      unreadChannelIds={unreadChannelIds}
+                      mutedChannelIds={mutedChannelIds}
+                      onMuteChannel={muteChannel}
+                      onUnmuteChannel={unmuteChannel}
+                      starredChannelIds={starredChannelIds}
+                      onStarChannel={starChannel}
+                      onUnstarChannel={unstarChannel}
+                    />
 
-                <SidebarInset className="min-h-0 min-w-0 overflow-hidden">
-                  <Outlet />
-                </SidebarInset>
+                    <SidebarInset className="min-h-0 min-w-0 overflow-hidden">
+                      <Outlet />
+                    </SidebarInset>
+                  </>
+                )}
 
                 <AppShellOverlays
                   activeChannel={activeChannel}
@@ -851,40 +883,6 @@ export function AppShell() {
                     void goChannel(channelId);
                   }}
                 />
-
-                {settingsOpen ? (
-                  <React.Suspense fallback={null}>
-                    <LazySettingsScreen
-                      currentPubkey={identityQuery.data?.pubkey}
-                      fallbackDisplayName={identityQuery.data?.displayName}
-                      isUpdatingDesktopNotifications={
-                        notificationSettings.isUpdatingDesktopEnabled
-                      }
-                      notificationErrorMessage={
-                        notificationSettings.errorMessage
-                      }
-                      notificationPermission={notificationSettings.permission}
-                      notificationSettings={notificationSettings.settings}
-                      onClose={handleCloseSettings}
-                      onSectionChange={setSettingsSection}
-                      mode={settingsMode}
-                      onSetDesktopNotificationsEnabled={
-                        notificationSettings.setDesktopEnabled
-                      }
-                      onSetHomeBadgeEnabled={
-                        notificationSettings.setHomeBadgeEnabled
-                      }
-                      onSetMentionNotificationsEnabled={
-                        notificationSettings.setMentionsEnabled
-                      }
-                      onSetNeedsActionNotificationsEnabled={
-                        notificationSettings.setNeedsActionEnabled
-                      }
-                      onSetSoundEnabled={notificationSettings.setSoundEnabled}
-                      section={settingsSection}
-                    />
-                  </React.Suspense>
-                ) : null}
               </SidebarProvider>
               <HuddleBar />
             </div>

--- a/desktop/src/features/profile/ui/ProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/ProfilePopover.tsx
@@ -72,7 +72,7 @@ export function ProfilePopover({
   const [presenceMenuOpen, setPresenceMenuOpen] = React.useState(false);
   const presenceHoverTimer = React.useRef<number | null>(null);
   const hasUserStatus = Boolean(userStatusText || userStatusEmoji);
-  const preferencesShortcutLabel = isMacPlatform() ? "⌘," : "Ctrl+,";
+  const settingsShortcutLabel = isMacPlatform() ? "⌘," : "Ctrl+,";
 
   function clearPresenceHoverTimer() {
     if (presenceHoverTimer.current !== null) {
@@ -249,36 +249,22 @@ export function ProfilePopover({
 
             <hr className="my-1 h-px border-0 bg-border" />
 
-            {/* ── Profile / preferences ──────────────────────────── */}
-            <button
-              className={MENU_ITEM_CLASS}
-              data-testid="profile-popover-profile"
-              onClick={() => {
-                closePopover();
-                window.requestAnimationFrame(() => {
-                  onOpenSettings("profile");
-                });
-              }}
-              role="menuitem"
-              type="button"
-            >
-              <span className="flex-1">Profile</span>
-            </button>
+            {/* ── Settings ───────────────────────────────────────── */}
             <button
               className={MENU_ITEM_CLASS}
               data-testid="profile-popover-settings"
               onClick={() => {
                 closePopover();
                 window.requestAnimationFrame(() => {
-                  onOpenSettings("appearance");
+                  onOpenSettings();
                 });
               }}
               role="menuitem"
               type="button"
             >
-              <span className="flex-1">Preferences</span>
+              <span className="flex-1">Settings</span>
               <kbd className="text-xs text-muted-foreground">
-                {preferencesShortcutLabel}
+                {settingsShortcutLabel}
               </kbd>
             </button>
 

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -139,6 +139,8 @@ export function ProfileSettingsCard({
   return (
     <section className="min-w-0" data-testid="settings-profile">
       <div className="space-y-6">
+        <h2 className="text-2xl font-semibold tracking-tight">Profile</h2>
+
         {profileQuery.error instanceof Error ? (
           <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
             {profileQuery.error.message}

--- a/desktop/src/features/settings/ui/SettingsScreen.tsx
+++ b/desktop/src/features/settings/ui/SettingsScreen.tsx
@@ -7,7 +7,6 @@ type SettingsScreenProps = {
   currentPubkey?: string;
   fallbackDisplayName?: string;
   isUpdatingDesktopNotifications: boolean;
-  mode: "profile" | "preferences";
   notificationErrorMessage: string | null;
   notificationPermission: DesktopNotificationPermissionState;
   notificationSettings: NotificationSettings;
@@ -25,7 +24,6 @@ export function SettingsScreen({
   currentPubkey,
   fallbackDisplayName,
   isUpdatingDesktopNotifications,
-  mode,
   notificationErrorMessage,
   notificationPermission,
   notificationSettings,
@@ -43,7 +41,6 @@ export function SettingsScreen({
       currentPubkey={currentPubkey}
       fallbackDisplayName={fallbackDisplayName}
       isUpdatingDesktopNotifications={isUpdatingDesktopNotifications}
-      mode={mode}
       notificationErrorMessage={notificationErrorMessage}
       notificationPermission={notificationPermission}
       notificationSettings={notificationSettings}

--- a/desktop/src/features/settings/ui/SettingsView.tsx
+++ b/desktop/src/features/settings/ui/SettingsView.tsx
@@ -1,14 +1,29 @@
 import * as React from "react";
 import { getVersion } from "@tauri-apps/api/app";
-import { X } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 
 import { useMyRelayMembershipQuery } from "@/features/relay-members/hooks";
 import { cn } from "@/shared/lib/cn";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+} from "@/shared/ui/sidebar";
 import {
   renderSettingsSection,
   settingsSections,
   type SettingsPanelProps,
   type SettingsSection,
+  type SettingsSectionDescriptor,
 } from "./SettingsPanels";
 
 export {
@@ -17,49 +32,67 @@ export {
 } from "./SettingsPanels";
 
 type SettingsViewProps = SettingsPanelProps & {
-  mode: "profile" | "preferences";
   onClose: () => void;
   onSectionChange: (section: SettingsSection) => void;
   section: SettingsSection;
 };
 
+const settingsNavGroups: Array<{
+  label: string;
+  sections: SettingsSection[];
+}> = [
+  {
+    label: "Personal",
+    sections: [
+      "profile",
+      "appearance",
+      "notifications",
+      "shortcuts",
+      "custom-emoji",
+    ],
+  },
+  {
+    label: "Workspaces",
+    sections: ["channel-templates", "relay-members"],
+  },
+  {
+    label: "App",
+    sections: ["agents", "compute", "mobile", "updates", "doctor"],
+  },
+];
+
 function SettingsSectionButton({
   active,
-  isLoaded,
   onSelect,
   section,
 }: {
   active: boolean;
-  isLoaded: boolean;
   onSelect: (section: SettingsSection) => void;
   section: (typeof settingsSections)[number];
 }) {
   const Icon = section.icon;
 
   return (
-    <button
-      aria-pressed={active}
-      className={cn(
-        "group inline-flex min-w-fit items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium whitespace-nowrap motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-out focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
-        active
-          ? "border-border bg-background text-foreground shadow-xs"
-          : "border-transparent bg-transparent text-muted-foreground hover:bg-background/70 hover:text-foreground",
-        isLoaded ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-2",
-      )}
-      data-testid={`settings-nav-${section.value}`}
-      onClick={() => onSelect(section.value)}
-      type="button"
-    >
-      <Icon
-        className={cn(
-          "h-4 w-4 shrink-0 transition-colors",
-          active
-            ? "text-primary"
-            : "text-muted-foreground group-hover:text-foreground",
-        )}
-      />
-      <span className="truncate">{section.label}</span>
-    </button>
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        aria-pressed={active}
+        data-testid={`settings-nav-${section.value}`}
+        isActive={active}
+        onClick={() => onSelect(section.value)}
+        tooltip={section.label}
+        type="button"
+      >
+        <Icon
+          className={cn(
+            "h-4 w-4 shrink-0 transition-colors",
+            active
+              ? "text-sidebar-active-foreground"
+              : "text-sidebar-foreground/70",
+          )}
+        />
+        <span>{section.label}</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
   );
 }
 
@@ -70,7 +103,6 @@ export function SettingsView({
   notificationErrorMessage,
   notificationPermission,
   notificationSettings,
-  mode,
   onClose,
   onSectionChange,
   onSetDesktopNotificationsEnabled,
@@ -84,9 +116,6 @@ export function SettingsView({
   const visibleSections = React.useMemo(() => {
     const membership = myMembershipQuery.data;
     return settingsSections.filter((s) => {
-      if (mode === "preferences" && s.value === "profile") {
-        return false;
-      }
       if (s.value === "relay-members") {
         return (
           membership != null &&
@@ -95,32 +124,25 @@ export function SettingsView({
       }
       return true;
     });
-  }, [mode, myMembershipQuery.data]);
+  }, [myMembershipQuery.data]);
 
   const [isLoaded, setIsLoaded] = React.useState(false);
   const [appVersion, setAppVersion] = React.useState<string | null>(null);
+
   React.useEffect(() => {
     const frameId = window.requestAnimationFrame(() => setIsLoaded(true));
     return () => window.cancelAnimationFrame(frameId);
   }, []);
+
   React.useEffect(() => {
     void getVersion().then(setAppVersion);
   }, []);
 
   React.useEffect(() => {
-    if (mode === "profile") {
-      if (section !== "profile") {
-        onSectionChange("profile");
-      }
-      return;
-    }
-
     if (!visibleSections.some((entry) => entry.value === section)) {
       onSectionChange(visibleSections[0]?.value ?? "appearance");
     }
-  }, [mode, onSectionChange, section, visibleSections]);
-
-  const showSectionNav = mode === "preferences";
+  }, [onSectionChange, section, visibleSections]);
 
   React.useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -134,96 +156,98 @@ export function SettingsView({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
-  return (
-    <div
-      className={cn(
-        "fixed inset-0 z-50 flex items-center justify-center motion-safe:transition-opacity motion-safe:duration-200",
-        isLoaded ? "opacity-100" : "opacity-0",
-      )}
-      data-testid="settings-overlay"
-    >
-      <div
-        aria-hidden="true"
-        className="absolute inset-0 bg-background/80 backdrop-blur-sm"
-        onClick={onClose}
-      />
+  const visibleSectionByValue = React.useMemo(
+    () => new Map(visibleSections.map((entry) => [entry.value, entry])),
+    [visibleSections],
+  );
+  const visibleNavGroups = React.useMemo(
+    () =>
+      settingsNavGroups
+        .map((group) => ({
+          ...group,
+          sections: group.sections
+            .map((value) => visibleSectionByValue.get(value))
+            .filter(
+              (entry): entry is SettingsSectionDescriptor => entry != null,
+            ),
+        }))
+        .filter((group) => group.sections.length > 0),
+    [visibleSectionByValue],
+  );
 
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: Click stops propagation to backdrop; keyboard dismiss handled by Escape key. */}
-      <div
-        aria-labelledby="settings-title"
-        aria-modal="true"
-        className={cn(
-          "relative mx-auto flex h-[min(600px,calc(100vh-2rem))] w-[calc(100%-4rem)] max-w-3xl flex-col overflow-hidden rounded-xl border border-border bg-background shadow-lg motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-out",
-          isLoaded ? "opacity-100 scale-100" : "opacity-0 scale-95",
-        )}
-        data-testid="settings-view"
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
+  return (
+    <>
+      <Sidebar
+        className="!border-r-0"
+        collapsible="offcanvas"
+        data-testid="settings-sidebar"
+        variant="sidebar"
       >
-        <header
-          className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3"
+        <SidebarHeader
+          className="cursor-default select-none pt-11"
           data-tauri-drag-region
         >
-          <h2
-            className="text-base font-semibold"
-            data-testid="settings-title"
-            id="settings-title"
-          >
-            {mode === "profile" ? "Profile" : "Settings"}
-          </h2>
-          <button
-            aria-label="Close settings"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-            data-testid="settings-close"
-            onClick={onClose}
-            type="button"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </header>
-
-        <div
-          className={cn(
-            "grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] overflow-hidden md:grid-rows-1",
-            showSectionNav
-              ? "md:grid-cols-[220px_minmax(0,1fr)]"
-              : "md:grid-cols-1",
-          )}
-        >
-          {showSectionNav ? (
-            <aside
-              className={cn(
-                "flex flex-col border-b border-border/70 bg-muted/20 motion-safe:transition-all motion-safe:duration-200 motion-safe:ease-out md:border-b-0 md:border-r",
-                isLoaded
-                  ? "opacity-100 translate-x-0"
-                  : "opacity-0 -translate-x-2",
-              )}
-            >
-              <nav
-                aria-label="Settings sections"
-                className="flex gap-1 overflow-x-auto px-3 py-3 md:flex-1 md:flex-col md:overflow-y-auto md:pt-1"
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                data-testid="settings-back-to-app"
+                onClick={onClose}
+                tooltip="Back to app"
+                type="button"
               >
-                {visibleSections.map((entry) => (
-                  <SettingsSectionButton
-                    active={entry.value === section}
-                    isLoaded={isLoaded}
-                    key={entry.value}
-                    onSelect={onSectionChange}
-                    section={entry}
-                  />
-                ))}
-              </nav>
-              {appVersion ? (
-                <p className="hidden px-3 pb-3 text-xs text-muted-foreground/60 md:block">
-                  v{appVersion}
-                </p>
-              ) : null}
-            </aside>
-          ) : null}
+                <ArrowLeft className="h-4 w-4" />
+                <span>Back to app</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarHeader>
 
-          <section className="flex min-h-0 flex-col overflow-y-auto px-4 pt-4 sm:px-6">
+        <SidebarContent>
+          {visibleNavGroups.map((group) => (
+            <SidebarGroup key={group.label}>
+              <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu aria-label={`${group.label} settings sections`}>
+                  {group.sections.map((entry) => (
+                    <SettingsSectionButton
+                      active={entry.value === section}
+                      key={entry.value}
+                      onSelect={onSectionChange}
+                      section={entry}
+                    />
+                  ))}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          ))}
+        </SidebarContent>
+
+        <SidebarFooter>
+          {appVersion ? (
+            <p className="px-2 pb-1 text-xs text-sidebar-foreground/45">
+              v{appVersion}
+            </p>
+          ) : null}
+        </SidebarFooter>
+        <SidebarRail />
+      </Sidebar>
+
+      <SidebarInset
+        className={cn(
+          "relative min-h-0 min-w-0 overflow-hidden motion-safe:transition-opacity motion-safe:duration-200",
+          isLoaded ? "opacity-100" : "opacity-0",
+        )}
+        data-testid="settings-view"
+      >
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-0 top-0 h-11"
+          data-tauri-drag-region
+        />
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden pt-11">
+          <section className="min-h-0 flex-1 overflow-y-auto px-5 pb-5 pt-4 sm:px-6">
             <div
-              className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-4"
+              className="mx-auto flex w-full max-w-4xl flex-col gap-4"
               data-testid={`settings-panel-${section}`}
             >
               {renderSettingsSection(section, {
@@ -242,7 +266,7 @@ export function SettingsView({
             </div>
           </section>
         </div>
-      </div>
-    </div>
+      </SidebarInset>
+    </>
   );
 }

--- a/desktop/src/features/settings/ui/SettingsView.tsx
+++ b/desktop/src/features/settings/ui/SettingsView.tsx
@@ -16,7 +16,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarRail,
+  useSidebar,
 } from "@/shared/ui/sidebar";
 import {
   renderSettingsSection,
@@ -112,6 +112,7 @@ export function SettingsView({
   onSetSoundEnabled,
   section,
 }: SettingsViewProps) {
+  const { isMobile, open: sidebarOpen, setOpen: setSidebarOpen } = useSidebar();
   const myMembershipQuery = useMyRelayMembershipQuery();
   const visibleSections = React.useMemo(() => {
     const membership = myMembershipQuery.data;
@@ -143,6 +144,12 @@ export function SettingsView({
       onSectionChange(visibleSections[0]?.value ?? "appearance");
     }
   }, [onSectionChange, section, visibleSections]);
+
+  React.useEffect(() => {
+    if (!isMobile && !sidebarOpen) {
+      setSidebarOpen(true);
+    }
+  }, [isMobile, setSidebarOpen, sidebarOpen]);
 
   React.useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -229,7 +236,6 @@ export function SettingsView({
             </p>
           ) : null}
         </SidebarFooter>
-        <SidebarRail />
       </Sidebar>
 
       <SidebarInset

--- a/desktop/tests/e2e/integration.spec.ts
+++ b/desktop/tests/e2e/integration.spec.ts
@@ -41,7 +41,7 @@ async function assertDesktopNotificationsEnabled(
   await expect(page.getByTestId("notifications-desktop-state")).toContainText(
     "On",
   );
-  await page.getByTestId("settings-close").click();
+  await page.getByTestId("settings-back-to-app").click();
 }
 
 async function sendChannelMessage(

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -379,7 +379,7 @@ test("shows your avatar on your own message when profile avatar is set", async (
   await openSettings(page, "profile");
   await page.getByTestId("profile-avatar-url").fill(avatarUrl);
   await page.getByTestId("profile-save").click();
-  await page.getByTestId("settings-close").click();
+  await page.getByTestId("settings-back-to-app").click();
 
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -19,7 +19,12 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
   await page.goto("/");
 
   await openSettings(page, "profile");
-  await expect(page.getByTestId("settings-title")).toHaveText("Profile");
+  await expect(
+    page.getByTestId("settings-profile").getByRole("heading", {
+      exact: true,
+      name: "Profile",
+    }),
+  ).toBeVisible();
 
   await expect(page.getByTestId("profile-pubkey")).toContainText("deadbeef");
   await expect(page.getByTestId("profile-nip05")).toContainText("Not set");
@@ -36,7 +41,7 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
   await expect(page.getByTestId("profile-avatar-url")).toHaveValue(avatarUrl);
   await expect(page.getByTestId("profile-about")).toHaveValue(about);
 
-  await page.getByTestId("settings-close").click();
+  await page.getByTestId("settings-back-to-app").click();
   await expectHomeView(page);
   await expect(page.getByTestId("open-settings")).toBeVisible();
 
@@ -72,15 +77,45 @@ test("updates presence from the profile menu", async ({ page }) => {
   ).toContainText("Offline");
 });
 
-test("disables sidebar resize while settings are open", async ({ page }) => {
+test("renders settings in the app shell with a back button", async ({
+  page,
+}) => {
   await page.goto("/");
 
-  const sidebarRail = page.locator('[data-sidebar="rail"]');
-  await expect(sidebarRail).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Home" })).toBeVisible();
 
-  await openSettings(page, "appearance");
-  await expect(sidebarRail).toBeDisabled();
-  await expect(sidebarRail).toHaveCSS("pointer-events", "none");
+  await openSettings(page);
+  await expect(page.getByTestId("settings-sidebar")).toBeVisible();
+  await expect(page.getByTestId("settings-back-to-app")).toBeVisible();
+  await expect(page.getByPlaceholder("Search everything")).toHaveCount(0);
+  await expect(page.getByText("Personal", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("settings-nav-profile")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(page.getByText("Workspaces", { exact: true })).toBeVisible();
+  await expect(
+    page.getByTestId("settings-nav-channel-templates"),
+  ).toBeVisible();
+  await expect(page.getByText("App", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("settings-nav-agents")).toBeVisible();
+  await expect(
+    page.getByTestId("settings-profile").getByRole("heading", {
+      exact: true,
+      name: "Profile",
+    }),
+  ).toBeVisible();
+  await page.getByTestId("settings-nav-appearance").click();
+  await expect(
+    page.getByTestId("settings-theme").getByRole("heading", {
+      name: "Appearance",
+    }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Home" })).toHaveCount(0);
+
+  await page.getByTestId("settings-back-to-app").click();
+  await expectHomeView(page);
+  await expect(page.getByRole("button", { name: "Home" })).toBeVisible();
 });
 
 test("notification settings drive the Home badge and desktop alerts", async ({
@@ -105,7 +140,7 @@ test("notification settings drive the Home badge and desktop alerts", async ({
     "On",
   );
 
-  await page.getByTestId("settings-close").click();
+  await page.getByTestId("settings-back-to-app").click();
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
@@ -201,14 +236,14 @@ test("notification settings drive the Home badge and desktop alerts", async ({
 
   await openSettings(page, "notifications");
   await page.getByTestId("notifications-home-badge-toggle").click();
-  await page.getByTestId("settings-close").click();
+  await page.getByTestId("settings-back-to-app").click();
   await expect(page.getByTestId("chat-title")).toHaveText("engineering");
   await expect(page.getByTestId("sidebar-home-count")).toHaveCount(0);
   await expect.poll(getAppBadgeCount).toBe(baseline);
 
   await openSettings(page, "notifications");
   await page.getByTestId("notifications-home-badge-toggle").click();
-  await page.getByTestId("settings-close").click();
+  await page.getByTestId("settings-back-to-app").click();
   await expect(page.getByTestId("sidebar-home-count")).toHaveText("1");
   await expect.poll(getAppBadgeCount).toBe(baseline + 1);
 
@@ -227,7 +262,7 @@ test("desktop notification clicks open the matching forum thread", async ({
   await expect(page.getByTestId("notifications-desktop-state")).toContainText(
     "On",
   );
-  await page.getByTestId("settings-close").click();
+  await page.getByTestId("settings-back-to-app").click();
   await expectHomeView(page);
 
   await page.evaluate(() => {
@@ -303,7 +338,16 @@ test("opens settings with the keyboard shortcut and updates theme", async ({
   );
 
   await expect(page.getByTestId("settings-view")).toBeVisible();
-  await expect(page.getByTestId("settings-nav-appearance")).toBeVisible();
+  await expect(page.getByTestId("settings-nav-profile")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(
+    page.getByTestId("settings-profile").getByRole("heading", {
+      exact: true,
+      name: "Profile",
+    }),
+  ).toBeVisible();
   await page.getByTestId("settings-nav-appearance").click();
 
   // Default theme is catppuccin-macchiato (dark)

--- a/desktop/tests/helpers/settings.ts
+++ b/desktop/tests/helpers/settings.ts
@@ -21,14 +21,10 @@ export async function openProfileMenu(page: Page) {
 
 export async function openSettings(page: Page, section?: SettingsSection) {
   await openProfileMenu(page);
-  if (section === "profile") {
-    await page.getByTestId("profile-popover-profile").click();
-  } else {
-    await page.getByTestId("profile-popover-settings").click();
-  }
+  await page.getByTestId("profile-popover-settings").click();
   await expect(page.getByTestId("settings-view")).toBeVisible();
 
-  if (section && section !== "profile") {
+  if (section) {
     await page.getByTestId(`settings-nav-${section}`).click();
   }
 }


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/3ee8027d-d4fb-4414-b9f4-2669a139ad9c


- Move settings from the profile popover into a full-page app-shell view with a back-to-app affordance.
- Keep the profile/settings menu as the entry point while routing the content through `AppShell`.
- Update settings helper selectors and affected E2E flows for the new full-page surface.

## Validation

- `pnpm check`
- `pnpm typecheck`