### PR TITLE
Add profile editing controls

### DIFF
--- a/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
@@ -127,7 +127,7 @@ export function ProfileAvatarEditor({
   } = useAvatarUpload({ onUploadSuccess: handleUploadSuccess });
   const isInputDisabled = disabled || isUploading;
 
-  useEmojiMartStyles(emojiPickerContainerRef);
+  useEmojiMartStyles(emojiPickerContainerRef, mode === "emoji");
 
   React.useEffect(() => {
     onUploadingChange?.(isUploading);
@@ -367,7 +367,7 @@ export function ProfileAvatarEditor({
     <fieldset
       className="mx-auto w-full max-w-[576px] border-0 p-0 text-sm"
       data-testid={`${testIdPrefix}-editor`}
-      disabled={disabled}
+      disabled={isInputDisabled}
       onDragEnter={(event) => {
         if (!dataTransferHasImage(event.dataTransfer)) {
           return;
@@ -423,7 +423,12 @@ export function ProfileAvatarEditor({
         <div className="relative grid w-full gap-4">
           <Tabs
             className="w-full"
-            onValueChange={(nextMode) => setMode(nextMode as AvatarMode)}
+            onValueChange={(nextMode) => {
+              if (isInputDisabled) {
+                return;
+              }
+              setMode(nextMode as AvatarMode);
+            }}
             value={mode}
           >
             <TabsList
@@ -440,12 +445,14 @@ export function ProfileAvatarEditor({
               />
               <TabsTrigger
                 className="relative z-10 h-full rounded-full bg-transparent text-sm font-medium shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                disabled={isInputDisabled}
                 value="image"
               >
                 Image
               </TabsTrigger>
               <TabsTrigger
                 className="relative z-10 h-full rounded-full bg-transparent text-sm font-medium shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                disabled={isInputDisabled}
                 value="emoji"
               >
                 Emoji
@@ -564,6 +571,9 @@ export function ProfileAvatarEditor({
                       emoji: EmojiMartEmoji,
                       event?: MouseEvent,
                     ) => {
+                      if (isInputDisabled) {
+                        return;
+                      }
                       if (!emoji.native) {
                         return;
                       }

--- a/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
@@ -1,0 +1,840 @@
+import emojiData from "@emoji-mart/data";
+import Picker from "@emoji-mart/react";
+import { Link2, Loader2, UploadCloud } from "lucide-react";
+import * as React from "react";
+
+import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
+import { useEmojiBurst } from "@/shared/ui/EmojiBurstProvider";
+import {
+  AVATAR_COLORS,
+  AVATAR_COLOR_SWATCHES,
+  CUSTOM_AVATAR_COLOR_SWATCH,
+  CUSTOM_COLOR_GRID_COLUMNS,
+  CUSTOM_COLOR_GRID_HORIZONTAL_INSET,
+  CUSTOM_COLOR_GRID_ROWS,
+  CUSTOM_COLOR_GRID_VERTICAL_INSET,
+  CUSTOM_HUE_SCRUBBER_INSET,
+  DEFAULT_CUSTOM_HUE,
+  DEFAULT_CUSTOM_SATURATION,
+  DEFAULT_CUSTOM_VALUE,
+  DEFAULT_EMOJI_AVATAR_COLOR,
+  EMOJI_MART_CATEGORIES,
+  type AvatarColorSwatch,
+  clampPercent,
+  contrastColorForBackground,
+  dataTransferHasImage,
+  emojiAvatarDataUrl,
+  gridInsetPosition,
+  hexToHsv,
+  hsvToHex,
+  hueScrubberPosition,
+  normalizeHue,
+  parseEmojiAvatarDataUrl,
+  snapToGrid,
+  useEmojiMartStyles,
+  useEmojiMartThemeVars,
+  visibleUrlDraft,
+} from "./ProfileAvatarEditor.utils";
+
+export { parseEmojiAvatarDataUrl } from "./ProfileAvatarEditor.utils";
+
+type AvatarMode = "image" | "emoji";
+
+type ProfileAvatarEditorProps = {
+  avatarUrl: string;
+  previewName: string;
+  onUrlChange: (url: string) => void;
+  onEmojiAvatarChange?: () => void;
+  onUploadedAvatarChange?: (url: string | null) => void;
+  onUploadingChange?: (isUploading: boolean) => void;
+  onDone?: () => void;
+  donePending?: boolean;
+  hiddenAvatarUrl?: string | null;
+  disabled?: boolean;
+  testIdPrefix?: string;
+};
+
+type EmojiMartEmoji = {
+  native?: string;
+};
+
+export function ProfileAvatarEditor({
+  avatarUrl,
+  donePending = false,
+  hiddenAvatarUrl,
+  onEmojiAvatarChange,
+  onUploadedAvatarChange,
+  onUrlChange,
+  onDone,
+  onUploadingChange,
+  disabled,
+  testIdPrefix = "profile-avatar",
+}: ProfileAvatarEditorProps) {
+  const { burstEmoji } = useEmojiBurst();
+  const initialEmojiAvatar = React.useMemo(
+    () => parseEmojiAvatarDataUrl(avatarUrl),
+    [avatarUrl],
+  );
+  const [mode, setMode] = React.useState<AvatarMode>("image");
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [urlDraft, setUrlDraft] = React.useState(() =>
+    visibleUrlDraft(avatarUrl, hiddenAvatarUrl),
+  );
+  const [selectedEmoji, setSelectedEmoji] = React.useState<string | null>(
+    () => initialEmojiAvatar?.emoji ?? null,
+  );
+  const [selectedColor, setSelectedColor] = React.useState(
+    () => initialEmojiAvatar?.color ?? DEFAULT_EMOJI_AVATAR_COLOR,
+  );
+  const [customHue, setCustomHue] = React.useState(DEFAULT_CUSTOM_HUE);
+  const [customSaturation, setCustomSaturation] = React.useState(
+    DEFAULT_CUSTOM_SATURATION,
+  );
+  const [customValue, setCustomValue] = React.useState(DEFAULT_CUSTOM_VALUE);
+  const [isCustomColorPickerOpen, setIsCustomColorPickerOpen] =
+    React.useState(false);
+  const dragDepthRef = React.useRef(0);
+  const emojiPickerContainerRef = React.useRef<HTMLDivElement | null>(null);
+  const hueDragUserSelectRef = React.useRef<string | null>(null);
+  const isUrlInputFocusedRef = React.useRef(false);
+  const hasUserEditedUrlDraftRef = React.useRef(false);
+  const emojiMartThemeVars = useEmojiMartThemeVars();
+  const customColorDraft = React.useMemo(
+    () => hsvToHex(customHue, customSaturation, customValue),
+    [customHue, customSaturation, customValue],
+  );
+  const shouldShowColorControls = mode === "emoji" && selectedEmoji !== null;
+  const handleUploadSuccess = React.useCallback(
+    (uploadedUrl: string) => {
+      setUrlDraft("");
+      onUploadedAvatarChange?.(uploadedUrl);
+      onUrlChange(uploadedUrl);
+      setMode("image");
+    },
+    [onUploadedAvatarChange, onUrlChange],
+  );
+  const {
+    clearError: clearUploadError,
+    errorMessage: uploadErrorMessage,
+    handleFileChange,
+    inputRef: browseInputRef,
+    isUploading,
+    openPicker,
+    uploadFile,
+  } = useAvatarUpload({ onUploadSuccess: handleUploadSuccess });
+  const isInputDisabled = disabled || isUploading;
+
+  useEmojiMartStyles(emojiPickerContainerRef);
+
+  React.useEffect(() => {
+    onUploadingChange?.(isUploading);
+  }, [isUploading, onUploadingChange]);
+
+  React.useLayoutEffect(() => {
+    if (isUrlInputFocusedRef.current || hasUserEditedUrlDraftRef.current) {
+      return;
+    }
+    setUrlDraft(visibleUrlDraft(avatarUrl, hiddenAvatarUrl));
+  }, [avatarUrl, hiddenAvatarUrl]);
+
+  React.useEffect(() => {
+    const emojiAvatar = parseEmojiAvatarDataUrl(avatarUrl);
+    if (emojiAvatar) {
+      setSelectedEmoji(emojiAvatar.emoji);
+      setSelectedColor(emojiAvatar.color);
+      return;
+    }
+
+    setSelectedEmoji(null);
+    setSelectedColor(DEFAULT_EMOJI_AVATAR_COLOR);
+    setIsCustomColorPickerOpen(false);
+  }, [avatarUrl]);
+
+  React.useEffect(() => {
+    if (!shouldShowColorControls) {
+      setIsCustomColorPickerOpen(false);
+    }
+  }, [shouldShowColorControls]);
+
+  React.useEffect(() => {
+    if (!isCustomColorPickerOpen || !selectedEmoji) {
+      return;
+    }
+
+    onUploadedAvatarChange?.(null);
+    onUrlChange(emojiAvatarDataUrl(selectedEmoji, customColorDraft));
+  }, [
+    customColorDraft,
+    isCustomColorPickerOpen,
+    onUploadedAvatarChange,
+    onUrlChange,
+    selectedEmoji,
+  ]);
+
+  const unlockHueDragSelection = React.useCallback(() => {
+    if (hueDragUserSelectRef.current === null) {
+      return;
+    }
+
+    document.body.style.userSelect = hueDragUserSelectRef.current;
+    hueDragUserSelectRef.current = null;
+  }, []);
+
+  const lockHueDragSelection = React.useCallback(() => {
+    if (hueDragUserSelectRef.current !== null) {
+      return;
+    }
+
+    hueDragUserSelectRef.current = document.body.style.userSelect;
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const handleFiles = React.useCallback(
+    (files: FileList | null) => {
+      const file = files?.[0];
+      if (!file || isInputDisabled) {
+        return;
+      }
+
+      void uploadFile(file);
+      setMode("image");
+    },
+    [isInputDisabled, uploadFile],
+  );
+
+  const applyUrl = React.useCallback(() => {
+    const nextUrl = urlDraft.trim();
+    if (nextUrl.length === 0 || isInputDisabled) {
+      hasUserEditedUrlDraftRef.current = false;
+      return;
+    }
+
+    clearUploadError();
+    onUploadedAvatarChange?.(null);
+    onUrlChange(nextUrl);
+    hasUserEditedUrlDraftRef.current = false;
+    setMode("image");
+  }, [
+    clearUploadError,
+    isInputDisabled,
+    onUploadedAvatarChange,
+    onUrlChange,
+    urlDraft,
+  ]);
+
+  const applyEmojiAvatar = React.useCallback(
+    (emoji: string, color = selectedColor) => {
+      onUploadedAvatarChange?.(null);
+      onUrlChange(emojiAvatarDataUrl(emoji, color));
+      onEmojiAvatarChange?.();
+    },
+    [onEmojiAvatarChange, onUploadedAvatarChange, onUrlChange, selectedColor],
+  );
+
+  const openCustomColorPicker = React.useCallback(() => {
+    const nextColor = hexToHsv(selectedColor);
+    setCustomHue(normalizeHue(nextColor.hue));
+    setCustomSaturation(nextColor.saturation);
+    setCustomValue(nextColor.value);
+    setIsCustomColorPickerOpen(true);
+  }, [selectedColor]);
+
+  const updateCustomColorFromPointer = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const rect = event.currentTarget.getBoundingClientRect();
+      const width = Math.max(
+        rect.width - CUSTOM_COLOR_GRID_HORIZONTAL_INSET * 2,
+        1,
+      );
+      const height = Math.max(
+        rect.height - CUSTOM_COLOR_GRID_VERTICAL_INSET * 2,
+        1,
+      );
+      const rawSaturation = clampPercent(
+        ((event.clientX - rect.left - CUSTOM_COLOR_GRID_HORIZONTAL_INSET) /
+          width) *
+          100,
+      );
+      const rawValue = clampPercent(
+        (1 -
+          (event.clientY - rect.top - CUSTOM_COLOR_GRID_VERTICAL_INSET) /
+            height) *
+          100,
+      );
+      const nextSaturation = Math.round(
+        snapToGrid(rawSaturation, CUSTOM_COLOR_GRID_COLUMNS),
+      );
+      const nextValue = Math.round(
+        snapToGrid(rawValue, CUSTOM_COLOR_GRID_ROWS),
+      );
+
+      setCustomSaturation(nextSaturation);
+      setCustomValue(nextValue);
+    },
+    [],
+  );
+
+  const updateCustomHueFromPointer = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const rect = event.currentTarget.getBoundingClientRect();
+      const trackWidth = Math.max(
+        rect.width - CUSTOM_HUE_SCRUBBER_INSET * 2,
+        1,
+      );
+      const nextPercent = clampPercent(
+        ((event.clientX - rect.left - CUSTOM_HUE_SCRUBBER_INSET) / trackWidth) *
+          100,
+      );
+      setCustomHue(Math.round((nextPercent / 100) * 360));
+    },
+    [],
+  );
+
+  const adjustCustomHue = React.useCallback((delta: number) => {
+    setCustomHue((current) => normalizeHue(current + delta));
+  }, []);
+
+  const commitCustomColor = React.useCallback(() => {
+    setSelectedColor(customColorDraft);
+    if (selectedEmoji) {
+      applyEmojiAvatar(selectedEmoji, customColorDraft);
+    }
+    setIsCustomColorPickerOpen(false);
+  }, [applyEmojiAvatar, customColorDraft, selectedEmoji]);
+
+  const handleColorSelect = React.useCallback(
+    (swatch: AvatarColorSwatch) => {
+      if (disabled) {
+        return;
+      }
+
+      if (swatch === CUSTOM_AVATAR_COLOR_SWATCH) {
+        openCustomColorPicker();
+        return;
+      }
+
+      setSelectedColor(swatch);
+      if (selectedEmoji) {
+        applyEmojiAvatar(selectedEmoji, swatch);
+      }
+    },
+    [applyEmojiAvatar, disabled, openCustomColorPicker, selectedEmoji],
+  );
+
+  const resetDragState = React.useCallback(() => {
+    dragDepthRef.current = 0;
+    setIsDragging(false);
+  }, []);
+
+  React.useEffect(() => {
+    if (!isDragging) {
+      return;
+    }
+
+    const handleWindowDragEnd = () => resetDragState();
+    const handleWindowDrop = () => resetDragState();
+    const handleWindowDragLeave = (event: DragEvent) => {
+      if (event.clientX <= 0 || event.clientY <= 0) {
+        resetDragState();
+        return;
+      }
+
+      if (
+        event.clientX >= window.innerWidth ||
+        event.clientY >= window.innerHeight
+      ) {
+        resetDragState();
+      }
+    };
+
+    window.addEventListener("dragend", handleWindowDragEnd);
+    window.addEventListener("drop", handleWindowDrop);
+    window.addEventListener("dragleave", handleWindowDragLeave);
+
+    return () => {
+      window.removeEventListener("dragend", handleWindowDragEnd);
+      window.removeEventListener("drop", handleWindowDrop);
+      window.removeEventListener("dragleave", handleWindowDragLeave);
+    };
+  }, [isDragging, resetDragState]);
+
+  const isImageDropActive = mode === "image" && isDragging;
+
+  return (
+    <fieldset
+      className="mx-auto w-full max-w-[576px] border-0 p-0 text-sm"
+      data-testid={`${testIdPrefix}-editor`}
+      disabled={disabled}
+      onDragEnter={(event) => {
+        if (!dataTransferHasImage(event.dataTransfer)) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        if (isInputDisabled) {
+          return;
+        }
+        dragDepthRef.current += 1;
+        setMode("image");
+        setIsDragging(true);
+      }}
+      onDragLeave={(event) => {
+        if (!isDragging && !dataTransferHasImage(event.dataTransfer)) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+        if (dragDepthRef.current === 0) {
+          setIsDragging(false);
+        }
+      }}
+      onDragOver={(event) => {
+        if (!dataTransferHasImage(event.dataTransfer)) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        if (isInputDisabled) {
+          return;
+        }
+        event.dataTransfer.dropEffect = "copy";
+        setMode("image");
+        setIsDragging(true);
+      }}
+      onDrop={(event) => {
+        if (!dataTransferHasImage(event.dataTransfer)) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        resetDragState();
+        if (isInputDisabled) {
+          return;
+        }
+        void handleFiles(event.dataTransfer.files);
+      }}
+    >
+      <legend className="sr-only">Avatar image picker</legend>
+      <div className="relative">
+        <div className="relative grid w-full gap-4">
+          <Tabs
+            className="w-full"
+            onValueChange={(nextMode) => setMode(nextMode as AvatarMode)}
+            value={mode}
+          >
+            <TabsList
+              aria-label="Avatar type"
+              className="relative isolate grid h-14 w-full grid-cols-2 overflow-hidden rounded-full bg-muted p-1 text-muted-foreground"
+            >
+              <div
+                aria-hidden="true"
+                className="absolute bottom-1 left-1 top-1 z-0 rounded-full bg-background shadow transition-transform duration-150 ease-out"
+                style={{
+                  transform: `translateX(${mode === "emoji" ? "100%" : "0"})`,
+                  width: "calc((100% - 8px) / 2)",
+                }}
+              />
+              <TabsTrigger
+                className="relative z-10 h-full rounded-full bg-transparent text-sm font-medium shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                value="image"
+              >
+                Image
+              </TabsTrigger>
+              <TabsTrigger
+                className="relative z-10 h-full rounded-full bg-transparent text-sm font-medium shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                value="emoji"
+              >
+                Emoji
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          <div className="overflow-visible">
+            {mode === "image" ? (
+              <div className="grid content-start gap-3">
+                <button
+                  className={cn(
+                    "relative flex h-[120px] flex-col items-center justify-center gap-3 overflow-hidden rounded-xl border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-150 ease-out hover:bg-muted/80 disabled:opacity-60",
+                    isImageDropActive &&
+                      "border-primary bg-primary/10 text-primary ring-1 ring-primary/35 hover:bg-primary/10",
+                  )}
+                  data-dragging={isImageDropActive ? "true" : undefined}
+                  data-testid={`${testIdPrefix}-upload`}
+                  disabled={isInputDisabled}
+                  onClick={openPicker}
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      "pointer-events-none absolute inset-0 rounded-[inherit] bg-primary/10 opacity-0 transition-opacity duration-150 ease-out",
+                      isImageDropActive && "opacity-100",
+                    )}
+                    data-testid={`${testIdPrefix}-drop-mask`}
+                  />
+                  {isUploading ? (
+                    <Loader2 className="relative h-8 w-8 animate-spin text-muted-foreground" />
+                  ) : (
+                    <UploadCloud
+                      className={cn(
+                        "relative h-8 w-8 text-muted-foreground transition-colors duration-150 ease-out",
+                        isImageDropActive && "text-primary",
+                      )}
+                    />
+                  )}
+                  <span className="relative text-sm font-medium">
+                    {isUploading ? (
+                      "Uploading..."
+                    ) : isImageDropActive ? (
+                      "Drop image here"
+                    ) : (
+                      <>
+                        Drop or{" "}
+                        <span className="underline underline-offset-2">
+                          browse
+                        </span>
+                      </>
+                    )}
+                  </span>
+                </button>
+
+                <div className="flex h-16 items-center gap-3 rounded-xl bg-muted px-5 transition-colors focus-within:bg-muted/80">
+                  <Link2 className="h-4 w-4 text-muted-foreground" />
+                  <input
+                    className="min-w-0 flex-1 bg-transparent text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground"
+                    data-testid={`${testIdPrefix}-url`}
+                    disabled={isInputDisabled}
+                    onBlur={() => {
+                      isUrlInputFocusedRef.current = false;
+                      applyUrl();
+                    }}
+                    onChange={(event) => {
+                      clearUploadError();
+                      hasUserEditedUrlDraftRef.current = true;
+                      setUrlDraft(event.target.value);
+                      onUploadedAvatarChange?.(null);
+                      onUrlChange(event.target.value);
+                    }}
+                    onFocus={() => {
+                      isUrlInputFocusedRef.current = true;
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        applyUrl();
+                      }
+                    }}
+                    placeholder="Paste a URL (Slack profile, etc.)"
+                    type="url"
+                    value={urlDraft}
+                  />
+                </div>
+
+                {uploadErrorMessage ? (
+                  <p
+                    className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
+                    data-testid={`${testIdPrefix}-upload-error`}
+                    role="alert"
+                  >
+                    {uploadErrorMessage}
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <div className="relative grid content-start gap-3">
+                <div
+                  className="sprout-emoji-mart relative z-0 h-[316px] overflow-hidden rounded-xl bg-muted"
+                  ref={emojiPickerContainerRef}
+                  style={emojiMartThemeVars}
+                >
+                  <Picker
+                    categories={EMOJI_MART_CATEGORIES}
+                    data={emojiData}
+                    dynamicWidth
+                    emojiButtonRadius="999px"
+                    emojiButtonSize={64}
+                    emojiSize={48}
+                    icons="outline"
+                    navPosition="bottom"
+                    onEmojiSelect={(
+                      emoji: EmojiMartEmoji,
+                      event?: MouseEvent,
+                    ) => {
+                      if (!emoji.native) {
+                        return;
+                      }
+                      burstEmoji(emoji.native, event);
+                      setSelectedEmoji(emoji.native);
+                      applyEmojiAvatar(emoji.native, selectedColor);
+                    }}
+                    previewPosition="none"
+                    searchPosition="none"
+                    set="native"
+                    skinTonePosition="none"
+                    theme="dark"
+                  />
+                </div>
+
+                <div
+                  aria-hidden={!shouldShowColorControls}
+                  className={cn(
+                    "origin-top overflow-hidden transition-[max-height,margin,opacity,transform] duration-150 ease-out",
+                    shouldShowColorControls
+                      ? "mt-3 max-h-64 scale-100 opacity-100"
+                      : "mt-0 max-h-0 scale-[0.96] opacity-0",
+                  )}
+                  data-testid={`${testIdPrefix}-color-grid-shell`}
+                  inert={shouldShowColorControls ? undefined : true}
+                >
+                  <div
+                    className="grid grid-cols-8 justify-items-center gap-3 rounded-xl bg-muted p-4"
+                    data-testid={`${testIdPrefix}-color-grid`}
+                  >
+                    {AVATAR_COLOR_SWATCHES.map((swatch) => {
+                      const isCustomSwatch =
+                        swatch === CUSTOM_AVATAR_COLOR_SWATCH;
+                      const isSelected = isCustomSwatch
+                        ? !AVATAR_COLORS.some(
+                            (color) =>
+                              color.toUpperCase() ===
+                              selectedColor.toUpperCase(),
+                          )
+                        : swatch.toUpperCase() === selectedColor.toUpperCase();
+
+                      return (
+                        <button
+                          aria-label={
+                            isCustomSwatch
+                              ? "Choose custom avatar color"
+                              : `Use ${swatch} background`
+                          }
+                          aria-pressed={isSelected}
+                          className="relative h-10 w-10 rounded-full border border-border transition-transform duration-200 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          data-testid={
+                            isCustomSwatch
+                              ? `${testIdPrefix}-custom-color`
+                              : undefined
+                          }
+                          key={swatch}
+                          onClick={() => handleColorSelect(swatch)}
+                          style={{
+                            background: isCustomSwatch
+                              ? isSelected
+                                ? selectedColor
+                                : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
+                              : swatch,
+                          }}
+                          type="button"
+                        >
+                          {isSelected ? (
+                            <span
+                              className="absolute inset-1 rounded-full border-[3px]"
+                              style={{
+                                borderColor: contrastColorForBackground(
+                                  isCustomSwatch ? selectedColor : swatch,
+                                ),
+                              }}
+                            />
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div
+                  className={cn(
+                    "absolute inset-0 z-40 flex origin-bottom flex-col rounded-xl bg-muted p-4 transition-[opacity,transform] duration-150 ease-out",
+                    isCustomColorPickerOpen && shouldShowColorControls
+                      ? "pointer-events-auto translate-y-0 scale-y-100 opacity-100"
+                      : "pointer-events-none translate-y-8 scale-y-[0.94] opacity-0",
+                  )}
+                >
+                  <div
+                    className="relative min-h-0 w-full flex-1 cursor-pointer overflow-hidden rounded-xl shadow-[inset_0_-18px_34px_rgba(0,0,0,0.18)]"
+                    data-testid={`${testIdPrefix}-custom-color-spectrum`}
+                    onPointerDown={(event) => {
+                      event.preventDefault();
+                      event.currentTarget.setPointerCapture(event.pointerId);
+                      updateCustomColorFromPointer(event);
+                    }}
+                    onPointerMove={(event) => {
+                      if (event.buttons === 1) {
+                        event.preventDefault();
+                        updateCustomColorFromPointer(event);
+                      }
+                    }}
+                    onPointerUp={(event) => {
+                      event.preventDefault();
+                      updateCustomColorFromPointer(event);
+                    }}
+                    style={{
+                      backgroundColor: `hsl(${customHue}, 100%, 50%)`,
+                      backgroundImage:
+                        "linear-gradient(to bottom, transparent 0%, #000000 100%), linear-gradient(to right, #ffffff 0%, rgba(255,255,255,0) 100%)",
+                    }}
+                  >
+                    <div
+                      aria-hidden="true"
+                      className="pointer-events-none absolute"
+                      style={{
+                        inset: `${CUSTOM_COLOR_GRID_VERTICAL_INSET}px ${CUSTOM_COLOR_GRID_HORIZONTAL_INSET}px`,
+                      }}
+                    >
+                      {Array.from({
+                        length:
+                          CUSTOM_COLOR_GRID_COLUMNS * CUSTOM_COLOR_GRID_ROWS,
+                      }).map((_, index) => {
+                        const column = index % CUSTOM_COLOR_GRID_COLUMNS;
+                        const row = Math.floor(
+                          index / CUSTOM_COLOR_GRID_COLUMNS,
+                        );
+                        const gridSaturation = Math.round(
+                          (column / (CUSTOM_COLOR_GRID_COLUMNS - 1)) * 100,
+                        );
+                        const gridValue = Math.round(
+                          100 - (row / (CUSTOM_COLOR_GRID_ROWS - 1)) * 100,
+                        );
+                        const isSelectedGridDot =
+                          gridSaturation === customSaturation &&
+                          gridValue === customValue;
+
+                        return (
+                          <span
+                            className={cn(
+                              "absolute h-1 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/60 shadow-[0_0_4px_rgba(255,255,255,0.24)]",
+                              isSelectedGridDot &&
+                                "h-3 w-3 border-2 border-white shadow-[0_2px_10px_rgba(0,0,0,0.24)]",
+                            )}
+                            key={`${column}-${row}`}
+                            style={{
+                              backgroundColor: isSelectedGridDot
+                                ? customColorDraft
+                                : undefined,
+                              left: `${
+                                (column / (CUSTOM_COLOR_GRID_COLUMNS - 1)) * 100
+                              }%`,
+                              top: `${
+                                (row / (CUSTOM_COLOR_GRID_ROWS - 1)) * 100
+                              }%`,
+                            }}
+                          />
+                        );
+                      })}
+                    </div>
+                    <div
+                      className="pointer-events-none absolute h-8 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full border-[3px] border-white shadow-[0_5px_16px_rgba(0,0,0,0.24),inset_0_0_0_1px_rgba(0,0,0,0.06)]"
+                      style={{
+                        backgroundColor: customColorDraft,
+                        left: gridInsetPosition(
+                          customSaturation,
+                          CUSTOM_COLOR_GRID_HORIZONTAL_INSET,
+                        ),
+                        top: gridInsetPosition(
+                          100 - customValue,
+                          CUSTOM_COLOR_GRID_VERTICAL_INSET,
+                        ),
+                      }}
+                    />
+                  </div>
+
+                  <div
+                    aria-label="Choose custom avatar color hue"
+                    aria-valuemax={360}
+                    aria-valuemin={0}
+                    aria-valuenow={customHue}
+                    className="sprout-avatar-hue-scrubber relative mt-3 h-10 w-full cursor-pointer select-none rounded-full touch-none"
+                    data-testid={`${testIdPrefix}-custom-color-hue`}
+                    onKeyDown={(event) => {
+                      if (
+                        event.key === "ArrowLeft" ||
+                        event.key === "ArrowDown"
+                      ) {
+                        event.preventDefault();
+                        adjustCustomHue(-6);
+                      } else if (
+                        event.key === "ArrowRight" ||
+                        event.key === "ArrowUp"
+                      ) {
+                        event.preventDefault();
+                        adjustCustomHue(6);
+                      } else if (event.key === "Home") {
+                        event.preventDefault();
+                        setCustomHue(0);
+                      } else if (event.key === "End") {
+                        event.preventDefault();
+                        setCustomHue(360);
+                      }
+                    }}
+                    onPointerDown={(event) => {
+                      event.preventDefault();
+                      lockHueDragSelection();
+                      event.currentTarget.setPointerCapture(event.pointerId);
+                      updateCustomHueFromPointer(event);
+                    }}
+                    onPointerMove={(event) => {
+                      if (event.buttons === 1) {
+                        event.preventDefault();
+                        updateCustomHueFromPointer(event);
+                      }
+                    }}
+                    onPointerCancel={unlockHueDragSelection}
+                    onPointerUp={unlockHueDragSelection}
+                    onLostPointerCapture={unlockHueDragSelection}
+                    role="slider"
+                    tabIndex={0}
+                  >
+                    <div
+                      aria-hidden="true"
+                      className="absolute top-1 h-8 w-8 -translate-x-1/2 rounded-full"
+                      data-testid={`${testIdPrefix}-custom-color-hue-thumb`}
+                      style={{
+                        left: hueScrubberPosition((customHue / 360) * 100),
+                      }}
+                    >
+                      <div className="h-full w-full rounded-full bg-white shadow-[0_5px_18px_rgba(0,0,0,0.24),inset_0_0_0_1px_rgba(0,0,0,0.06)]" />
+                    </div>
+                  </div>
+
+                  <button
+                    className="mt-3 h-12 w-full rounded-xl bg-background px-6 text-sm font-medium text-foreground transition-colors hover:bg-background/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    data-testid={`${testIdPrefix}-custom-color-done`}
+                    onClick={commitCustomColor}
+                    type="button"
+                  >
+                    Use color
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {onDone && !isCustomColorPickerOpen ? (
+            <Button
+              className="h-12 w-full rounded-xl"
+              data-testid={`${testIdPrefix}-done`}
+              disabled={disabled || donePending || isUploading}
+              onClick={onDone}
+              type="button"
+            >
+              {donePending ? "Saving..." : "Done"}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <input
+        accept="image/*"
+        className="hidden"
+        data-testid={`${testIdPrefix}-input`}
+        onChange={handleFileChange}
+        ref={browseInputRef}
+        type="file"
+      />
+    </fieldset>
+  );
+}

--- a/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
@@ -107,6 +107,8 @@ export function ProfileAvatarEditor({
     [customHue, customSaturation, customValue],
   );
   const shouldShowColorControls = mode === "emoji" && selectedEmoji !== null;
+  const isCustomColorPickerVisible =
+    isCustomColorPickerOpen && shouldShowColorControls;
   const handleUploadSuccess = React.useCallback(
     (uploadedUrl: string) => {
       setUrlDraft("");
@@ -657,9 +659,10 @@ export function ProfileAvatarEditor({
                 </div>
 
                 <div
+                  aria-hidden={!isCustomColorPickerVisible}
                   className={cn(
                     "absolute inset-0 z-40 flex origin-bottom flex-col rounded-xl bg-muted p-4 transition-[opacity,transform] duration-150 ease-out",
-                    isCustomColorPickerOpen && shouldShowColorControls
+                    isCustomColorPickerVisible
                       ? "pointer-events-auto translate-y-0 scale-y-100 opacity-100"
                       : "pointer-events-none translate-y-8 scale-y-[0.94] opacity-0",
                   )}
@@ -796,7 +799,7 @@ export function ProfileAvatarEditor({
                     onPointerUp={unlockHueDragSelection}
                     onLostPointerCapture={unlockHueDragSelection}
                     role="slider"
-                    tabIndex={0}
+                    tabIndex={isCustomColorPickerVisible ? 0 : -1}
                   >
                     <div
                       aria-hidden="true"
@@ -814,6 +817,7 @@ export function ProfileAvatarEditor({
                     className="mt-3 h-12 w-full rounded-xl bg-background px-6 text-sm font-medium text-foreground transition-colors hover:bg-background/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     data-testid={`${testIdPrefix}-custom-color-done`}
                     onClick={commitCustomColor}
+                    tabIndex={isCustomColorPickerVisible ? 0 : -1}
                     type="button"
                   >
                     Use color

--- a/desktop/src/features/profile/ui/ProfileAvatarEditor.utils.ts
+++ b/desktop/src/features/profile/ui/ProfileAvatarEditor.utils.ts
@@ -1,0 +1,508 @@
+import * as React from "react";
+
+export type EmojiAvatarDescriptor = {
+  color: string;
+  emoji: string;
+};
+
+export const AVATAR_COLORS = [
+  "#FFFFFF",
+  "#FFF4CC",
+  "#FFE75C",
+  "#FFB84D",
+  "#FF8652",
+  "#F6534F",
+  "#FF6B9A",
+  "#FB60C4",
+  "#D66BFF",
+  "#B141FF",
+  "#7C5CFF",
+  "#476CFF",
+  "#3399FF",
+  "#63C6F2",
+  "#41EBC1",
+  "#2ED3A2",
+  "#73EF75",
+  "#9FE870",
+  "#C7D36F",
+  "#CCCCCC",
+  "#8A8F98",
+  "#4B5563",
+  "#000000",
+];
+export const CUSTOM_AVATAR_COLOR_SWATCH = "custom";
+export const AVATAR_COLOR_SWATCHES = [
+  ...AVATAR_COLORS,
+  CUSTOM_AVATAR_COLOR_SWATCH,
+] as const;
+export type AvatarColorSwatch = (typeof AVATAR_COLOR_SWATCHES)[number];
+
+export const DEFAULT_EMOJI_AVATAR_COLOR = "#FFFFFF";
+export const DEFAULT_CUSTOM_HUE = 210;
+export const DEFAULT_CUSTOM_SATURATION = 76;
+export const DEFAULT_CUSTOM_VALUE = 92;
+export const CUSTOM_COLOR_GRID_COLUMNS = 15;
+export const CUSTOM_COLOR_GRID_ROWS = 8;
+export const CUSTOM_COLOR_GRID_HORIZONTAL_INSET = 24;
+export const CUSTOM_COLOR_GRID_VERTICAL_INSET = 24;
+export const CUSTOM_HUE_SCRUBBER_INSET = 20;
+export const EMOJI_MART_CATEGORIES = [
+  "people",
+  "nature",
+  "foods",
+  "activity",
+  "places",
+  "objects",
+  "symbols",
+  "flags",
+];
+
+const EMOJI_AVATAR_DATA_URL_PREFIX = "data:image/svg+xml,";
+const EMOJI_AVATAR_FONT_SIZE = 258;
+
+const EMOJI_MART_SHADOW_CSS = `
+  :host {
+    display: block;
+    height: 100%;
+    max-height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    width: 100%;
+  }
+
+  #root {
+    --padding: 16px;
+    --sidebar-width: 0px;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    max-height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    width: 100% !important;
+  }
+
+  .scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding-left: var(--padding);
+    padding-right: var(--padding);
+    padding-top: 28px;
+    width: 100%;
+  }
+
+  .scroll > div {
+    width: 100% !important;
+  }
+
+  .category {
+    width: 100%;
+  }
+
+  .scroll::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .category .sticky {
+    display: none;
+  }
+
+  .category button .background {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
+  .row {
+    justify-content: space-between;
+  }
+
+  #nav {
+    align-items: center;
+    display: flex;
+    flex: 0 0 auto;
+    justify-content: space-between;
+    padding: 8px 24px 16px;
+  }
+
+  #nav .bar {
+    display: none;
+  }
+
+  #nav > .relative {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  #nav button {
+    align-items: center;
+    border-radius: 999px;
+    color: rgba(var(--em-rgb-color), 0.58);
+    display: flex;
+    flex: 0 0 40px;
+    height: 40px;
+    justify-content: center;
+    transition:
+      background-color var(--duration) var(--easing),
+      color var(--duration) var(--easing),
+      transform var(--duration) var(--easing);
+    width: 40px;
+  }
+
+  #nav button:hover,
+  #nav button[aria-selected] {
+    color: rgb(var(--em-rgb-color));
+  }
+
+  #nav button:hover {
+    background-color: rgba(var(--em-rgb-color), 0.1);
+  }
+
+  #nav button[aria-selected] {
+    background-color: rgba(var(--em-rgb-color), 0.14);
+  }
+
+  #nav svg,
+  #nav img {
+    height: 24px;
+    width: 24px;
+  }
+`;
+
+function escapeSvgText(text: string) {
+  return text
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;");
+}
+
+function unescapeSvgText(text: string) {
+  return text
+    .replace(/&gt;/gu, ">")
+    .replace(/&lt;/gu, "<")
+    .replace(/&amp;/gu, "&");
+}
+
+export function emojiAvatarDataUrl(emoji: string, color: string) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512"><rect width="512" height="512" rx="256" fill="${color}"/><text x="50%" y="56%" dominant-baseline="middle" text-anchor="middle" font-size="${EMOJI_AVATAR_FONT_SIZE}">${escapeSvgText(emoji)}</text></svg>`;
+  return `${EMOJI_AVATAR_DATA_URL_PREFIX}${encodeURIComponent(svg)}`;
+}
+
+export function parseEmojiAvatarDataUrl(
+  avatarUrl: string,
+): EmojiAvatarDescriptor | null {
+  if (!avatarUrl.startsWith(EMOJI_AVATAR_DATA_URL_PREFIX)) {
+    return null;
+  }
+
+  try {
+    const svg = decodeURIComponent(
+      avatarUrl.slice(EMOJI_AVATAR_DATA_URL_PREFIX.length),
+    );
+    const color = svg.match(/<rect\b[^>]*\sfill="([^"]+)"/u)?.[1];
+    const emoji = svg.match(/<text\b[^>]*>(.*?)<\/text>/u)?.[1];
+
+    if (!color || !emoji) {
+      return null;
+    }
+
+    return { color, emoji: unescapeSvgText(emoji) };
+  } catch {
+    return null;
+  }
+}
+
+export function hsvToHex(hue: number, saturation: number, value: number) {
+  const normalizedHue = ((hue % 360) + 360) % 360;
+  const chroma = (value / 100) * (saturation / 100);
+  const huePrime = normalizedHue / 60;
+  const secondary = chroma * (1 - Math.abs((huePrime % 2) - 1));
+  const match = value / 100 - chroma;
+  let red = 0;
+  let green = 0;
+  let blue = 0;
+
+  if (huePrime >= 0 && huePrime < 1) {
+    red = chroma;
+    green = secondary;
+  } else if (huePrime < 2) {
+    red = secondary;
+    green = chroma;
+  } else if (huePrime < 3) {
+    green = chroma;
+    blue = secondary;
+  } else if (huePrime < 4) {
+    green = secondary;
+    blue = chroma;
+  } else if (huePrime < 5) {
+    red = secondary;
+    blue = chroma;
+  } else {
+    red = chroma;
+    blue = secondary;
+  }
+
+  return [red, green, blue]
+    .map((channel) =>
+      Math.round((channel + match) * 255)
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")
+    .toUpperCase()
+    .padStart(6, "0")
+    .replace(/^/, "#");
+}
+
+export function hexToHsv(hexColor: string) {
+  const match = hexColor.match(/^#?([0-9a-f]{6})$/i);
+  if (!match) {
+    return {
+      hue: DEFAULT_CUSTOM_HUE,
+      saturation: DEFAULT_CUSTOM_SATURATION,
+      value: DEFAULT_CUSTOM_VALUE,
+    };
+  }
+
+  const value = match[1];
+  const red = Number.parseInt(value.slice(0, 2), 16) / 255;
+  const green = Number.parseInt(value.slice(2, 4), 16) / 255;
+  const blue = Number.parseInt(value.slice(4, 6), 16) / 255;
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const delta = max - min;
+  let hue = 0;
+
+  if (delta !== 0) {
+    if (max === red) {
+      hue = 60 * (((green - blue) / delta) % 6);
+    } else if (max === green) {
+      hue = 60 * ((blue - red) / delta + 2);
+    } else {
+      hue = 60 * ((red - green) / delta + 4);
+    }
+  }
+
+  return {
+    hue: Math.round((hue + 360) % 360),
+    saturation: max === 0 ? 0 : Math.round((delta / max) * 100),
+    value: Math.round(max * 100),
+  };
+}
+
+export function clampPercent(value: number) {
+  return Math.max(0, Math.min(100, value));
+}
+
+export function snapToGrid(value: number, gridCount: number) {
+  if (gridCount <= 1) {
+    return clampPercent(value);
+  }
+
+  const step = 100 / (gridCount - 1);
+  return Math.round(value / step) * step;
+}
+
+export function gridInsetPosition(value: number, inset: number) {
+  return `calc(${inset}px + (${value} * (100% - ${inset * 2}px) / 100))`;
+}
+
+export function hueScrubberPosition(value: number) {
+  return `calc(${CUSTOM_HUE_SCRUBBER_INSET}px + (${value} * (100% - ${
+    CUSTOM_HUE_SCRUBBER_INSET * 2
+  }px) / 100))`;
+}
+
+export function normalizeHue(hue: number) {
+  return ((hue % 360) + 360) % 360;
+}
+
+function hslToRgbString(hslValue: string) {
+  const [hue, saturation, lightness] = hslValue
+    .trim()
+    .split(/\s+/)
+    .map((part) => Number.parseFloat(part.replace("%", "")));
+
+  if (
+    !Number.isFinite(hue) ||
+    !Number.isFinite(saturation) ||
+    !Number.isFinite(lightness)
+  ) {
+    return null;
+  }
+
+  const normalizedHue = ((hue % 360) + 360) % 360;
+  const saturationRatio = saturation / 100;
+  const lightnessRatio = lightness / 100;
+  const chroma = (1 - Math.abs(2 * lightnessRatio - 1)) * saturationRatio;
+  const huePrime = normalizedHue / 60;
+  const secondary = chroma * (1 - Math.abs((huePrime % 2) - 1));
+  const match = lightnessRatio - chroma / 2;
+  let red = 0;
+  let green = 0;
+  let blue = 0;
+
+  if (huePrime >= 0 && huePrime < 1) {
+    red = chroma;
+    green = secondary;
+  } else if (huePrime < 2) {
+    red = secondary;
+    green = chroma;
+  } else if (huePrime < 3) {
+    green = chroma;
+    blue = secondary;
+  } else if (huePrime < 4) {
+    green = secondary;
+    blue = chroma;
+  } else if (huePrime < 5) {
+    red = secondary;
+    blue = chroma;
+  } else {
+    red = chroma;
+    blue = secondary;
+  }
+
+  return [red, green, blue]
+    .map((channel) => Math.round((channel + match) * 255))
+    .join(", ");
+}
+
+function hexToRgb(hexColor: string) {
+  const match = hexColor.match(/^#?([0-9a-f]{6})$/i);
+  if (!match) {
+    return null;
+  }
+
+  const value = match[1];
+  return {
+    blue: Number.parseInt(value.slice(4, 6), 16),
+    green: Number.parseInt(value.slice(2, 4), 16),
+    red: Number.parseInt(value.slice(0, 2), 16),
+  };
+}
+
+function relativeLuminance(hexColor: string) {
+  const rgb = hexToRgb(hexColor);
+  if (!rgb) {
+    return 0;
+  }
+
+  const channels = [rgb.red, rgb.green, rgb.blue].map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+
+  return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+}
+
+function contrastRatio(colorA: string, colorB: string) {
+  const luminanceA = relativeLuminance(colorA);
+  const luminanceB = relativeLuminance(colorB);
+  const lighter = Math.max(luminanceA, luminanceB);
+  const darker = Math.min(luminanceA, luminanceB);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export function contrastColorForBackground(backgroundColor: string) {
+  return contrastRatio(backgroundColor, "#000000") >=
+    contrastRatio(backgroundColor, "#FFFFFF")
+    ? "#000000"
+    : "#FFFFFF";
+}
+
+export function dataTransferHasImage(dataTransfer: DataTransfer | null) {
+  if (!dataTransfer) {
+    return false;
+  }
+
+  const items = Array.from(dataTransfer.items);
+  if (items.length > 0) {
+    return items.some(
+      (item) => item.kind === "file" && item.type.startsWith("image/"),
+    );
+  }
+
+  return Array.from(dataTransfer.files).some((file) =>
+    file.type.startsWith("image/"),
+  );
+}
+
+export function visibleUrlDraft(
+  avatarUrl: string,
+  hiddenAvatarUrl?: string | null,
+) {
+  if (avatarUrl.startsWith("data:") || avatarUrl === hiddenAvatarUrl) {
+    return "";
+  }
+
+  return avatarUrl;
+}
+
+export function useEmojiMartStyles(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+) {
+  React.useEffect(() => {
+    let animationFrame = 0;
+
+    const installEmojiMartStyles = () => {
+      const host = containerRef.current?.querySelector("em-emoji-picker");
+      const shadowRoot = host?.shadowRoot;
+
+      if (!shadowRoot) {
+        animationFrame = window.requestAnimationFrame(installEmojiMartStyles);
+        return;
+      }
+
+      if (!shadowRoot.querySelector("#sprout-emoji-mart-style")) {
+        const style = document.createElement("style");
+        style.id = "sprout-emoji-mart-style";
+        style.textContent = EMOJI_MART_SHADOW_CSS;
+        shadowRoot.appendChild(style);
+      }
+    };
+
+    animationFrame = window.requestAnimationFrame(installEmojiMartStyles);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+    };
+  }, [containerRef]);
+}
+
+export function useEmojiMartThemeVars() {
+  const [themeVars, setThemeVars] = React.useState<React.CSSProperties>({});
+
+  React.useEffect(() => {
+    const updateThemeVars = () => {
+      const styles = window.getComputedStyle(document.documentElement);
+      const muted = hslToRgbString(styles.getPropertyValue("--muted"));
+      const foreground = hslToRgbString(
+        styles.getPropertyValue("--foreground"),
+      );
+      const background = hslToRgbString(
+        styles.getPropertyValue("--background"),
+      );
+
+      setThemeVars({
+        "--sprout-emoji-picker-rgb-background": muted ?? "54, 58, 79",
+        "--sprout-emoji-picker-rgb-color": foreground ?? "245, 247, 255",
+        "--sprout-emoji-picker-rgb-input": background ?? "47, 51, 68",
+      } as React.CSSProperties);
+    };
+
+    updateThemeVars();
+
+    const observer = new MutationObserver(updateThemeVars);
+    observer.observe(document.documentElement, {
+      attributeFilter: ["class", "style"],
+      attributes: true,
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return themeVars;
+}

--- a/desktop/src/features/profile/ui/ProfileAvatarEditor.utils.ts
+++ b/desktop/src/features/profile/ui/ProfileAvatarEditor.utils.ts
@@ -443,8 +443,13 @@ export function visibleUrlDraft(
 
 export function useEmojiMartStyles(
   containerRef: React.RefObject<HTMLDivElement | null>,
+  enabled: boolean,
 ) {
   React.useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     let animationFrame = 0;
 
     const installEmojiMartStyles = () => {
@@ -469,7 +474,7 @@ export function useEmojiMartStyles(
     return () => {
       window.cancelAnimationFrame(animationFrame);
     };
-  }, [containerRef]);
+  }, [containerRef, enabled]);
 }
 
 export function useEmojiMartThemeVars() {

--- a/desktop/src/features/profile/useAvatarUpload.ts
+++ b/desktop/src/features/profile/useAvatarUpload.ts
@@ -19,6 +19,7 @@ type UseAvatarUploadReturn = {
   errorMessage: string | null;
   clearError: () => void;
   openPicker: () => void;
+  uploadFile: (file: File) => Promise<void>;
   handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
@@ -37,15 +38,8 @@ export function useAvatarUpload({
     inputRef.current?.click();
   }, []);
 
-  const handleFileChange = React.useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      event.target.value = "";
-
-      if (!file) {
-        return;
-      }
-
+  const uploadFile = React.useCallback(
+    async (file: File) => {
       if (!AVATAR_IMAGE_TYPES.includes(file.type)) {
         setErrorMessage("Choose a PNG, JPG, GIF, or WebP image.");
         return;
@@ -79,12 +73,27 @@ export function useAvatarUpload({
     [onUploadSuccess],
   );
 
+  const handleFileChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+
+      if (!file) {
+        return;
+      }
+
+      void uploadFile(file);
+    },
+    [uploadFile],
+  );
+
   return {
     inputRef,
     isUploading,
     errorMessage,
     clearError,
     openPicker,
+    uploadFile,
     handleFileChange,
   };
 }

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -219,9 +219,12 @@ export function ProfileSettingsCard({
     nextDisplayName,
   ]);
 
+  const hasPendingDisplayNameClearRequest =
+    currentDisplayName.length > 0 && nextDisplayName.length === 0;
+  const hasPendingAvatarClearRequest =
+    currentAvatarUrl.length > 0 && nextAvatarUrl.length === 0;
   const hasPendingClearRequest =
-    (currentDisplayName.length > 0 && nextDisplayName.length === 0) ||
-    (currentAvatarUrl.length > 0 && nextAvatarUrl.length === 0);
+    hasPendingDisplayNameClearRequest || hasPendingAvatarClearRequest;
   const hasProfileChanges = Object.keys(updatePayload).length > 0;
   const canSave =
     hasProfileChanges && !updateProfileMutation.isPending && !isUploadingAvatar;
@@ -306,8 +309,10 @@ export function ProfileSettingsCard({
     }
 
     if (!hasProfileChanges) {
-      if (hasPendingClearRequest) {
+      if (hasPendingDisplayNameClearRequest) {
         setDisplayNameDraft(currentDisplayName);
+      }
+      if (hasPendingAvatarClearRequest) {
         setAvatarUrlDraft(currentAvatarUrl);
       }
       setIsEditingProfileMetadata(false);
@@ -318,7 +323,8 @@ export function ProfileSettingsCard({
   }, [
     currentAvatarUrl,
     currentDisplayName,
-    hasPendingClearRequest,
+    hasPendingAvatarClearRequest,
+    hasPendingDisplayNameClearRequest,
     hasProfileChanges,
     isEditingProfileMetadata,
     saveProfile,
@@ -326,6 +332,9 @@ export function ProfileSettingsCard({
 
   const handleAvatarEditorDone = React.useCallback(() => {
     if (!hasProfileChanges) {
+      if (hasPendingAvatarClearRequest) {
+        setAvatarUrlDraft(currentAvatarUrl);
+      }
       setIsAvatarEditorOpen(false);
       return;
     }
@@ -335,7 +344,12 @@ export function ProfileSettingsCard({
         setIsAvatarEditorOpen(false);
       }
     });
-  }, [hasProfileChanges, saveProfile]);
+  }, [
+    currentAvatarUrl,
+    hasPendingAvatarClearRequest,
+    hasProfileChanges,
+    saveProfile,
+  ]);
 
   const animateEmojiAvatarChange = React.useCallback(() => {
     setAvatarSquishKey((key) => key + 1);

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -1,4 +1,4 @@
-import { AtSign, Check, Copy, UserRound } from "lucide-react";
+import { Check, ChevronDown, Copy, Pencil } from "lucide-react";
 import * as React from "react";
 import { toast } from "sonner";
 
@@ -6,10 +6,13 @@ import {
   useProfileQuery,
   useUpdateProfileMutation,
 } from "@/features/profile/hooks";
-import { AvatarUpload } from "@/features/profile/ui/AvatarUpload";
-import { Button } from "@/shared/ui/button";
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import {
+  ProfileAvatarEditor,
+  parseEmojiAvatarDataUrl,
+} from "@/features/profile/ui/ProfileAvatarEditor";
+import { cn } from "@/shared/lib/cn";
 import { Input } from "@/shared/ui/input";
-import { Separator } from "@/shared/ui/separator";
 import { Textarea } from "@/shared/ui/textarea";
 
 type ProfileSettingsCardProps = {
@@ -17,28 +20,9 @@ type ProfileSettingsCardProps = {
   fallbackDisplayName?: string;
 };
 
-function Section({
-  title,
-  description,
-  children,
-}: React.PropsWithChildren<{
-  title: string;
-  description?: string;
-}>) {
-  return (
-    <section className="min-w-0 space-y-3">
-      <div className="space-y-1">
-        <h2 className="text-sm font-semibold tracking-tight">{title}</h2>
-        {description ? (
-          <p className="text-sm text-muted-foreground">{description}</p>
-        ) : null}
-      </div>
-      {children}
-    </section>
-  );
-}
+const AVATAR_EDITOR_TRANSITION_MS = 150;
 
-function ReadOnlyField({
+function IdentityRow({
   label,
   value,
   testId,
@@ -49,16 +33,22 @@ function ReadOnlyField({
   testId: string;
   copyValue?: string;
 }) {
-  const boxClassName =
-    "flex min-w-0 items-center gap-2 rounded-xl border border-border/80 bg-muted/25 px-3 py-2 text-sm text-muted-foreground";
-
   return (
-    <div className="min-w-0 space-y-1.5">
-      <p className="text-sm font-medium">{label}</p>
+    <div className="flex min-h-16 items-center justify-between gap-4 px-4 py-3">
+      <div className="min-w-0 space-y-1">
+        <p className="text-sm font-medium">{label}</p>
+        <p
+          className="min-w-0 truncate text-sm text-muted-foreground"
+          data-testid={testId}
+          title={value}
+        >
+          {value}
+        </p>
+      </div>
       {copyValue ? (
         <button
           aria-label={`Copy ${label}`}
-          className={`${boxClassName} w-full text-left transition-colors hover:bg-muted/50`}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-muted px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           data-testid={`copy-${testId}`}
           onClick={async () => {
             await navigator.clipboard.writeText(copyValue);
@@ -67,17 +57,49 @@ function ReadOnlyField({
           title={`Copy ${label}`}
           type="button"
         >
-          <span className="min-w-0 flex-1 break-all" data-testid={testId}>
-            {value}
-          </span>
           <Copy className="h-3.5 w-3.5 shrink-0" />
+          Copy
         </button>
-      ) : (
-        <div className={`${boxClassName} break-all`} data-testid={testId}>
-          {value}
-        </div>
-      )}
+      ) : null}
     </div>
+  );
+}
+
+function EditProfileMetadataButton({
+  label,
+  testId,
+  onClick,
+  disabled,
+  isEditing,
+}: {
+  label: string;
+  testId: string;
+  onClick: () => void;
+  disabled: boolean;
+  isEditing: boolean;
+}) {
+  const Icon = isEditing ? Check : Pencil;
+  const actionLabel = isEditing ? "Done" : "Edit";
+  const accessibleLabel = isEditing ? `Done editing ${label}` : `Edit ${label}`;
+
+  return (
+    <button
+      aria-label={accessibleLabel}
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60",
+        isEditing
+          ? "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/90"
+          : "border-transparent bg-muted text-foreground hover:bg-muted/80",
+      )}
+      data-testid={testId}
+      disabled={disabled}
+      onClick={onClick}
+      title={accessibleLabel}
+      type="button"
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      {actionLabel}
+    </button>
   );
 }
 
@@ -95,38 +117,122 @@ export function ProfileSettingsCard({
   const [displayNameDraft, setDisplayNameDraft] = React.useState("");
   const [avatarUrlDraft, setAvatarUrlDraft] = React.useState("");
   const [aboutDraft, setAboutDraft] = React.useState("");
+  const [uploadedAvatarUrlDraft, setUploadedAvatarUrlDraft] = React.useState<
+    string | null
+  >(null);
+  const [isAvatarEditorOpen, setIsAvatarEditorOpen] = React.useState(false);
+  const [isUploadingAvatar, setIsUploadingAvatar] = React.useState(false);
+  const [isEditingProfileMetadata, setIsEditingProfileMetadata] =
+    React.useState(false);
+  const [shouldRenderAvatarEditor, setShouldRenderAvatarEditor] =
+    React.useState(false);
+  const [avatarSquishKey, setAvatarSquishKey] = React.useState(0);
+  const displayNameInputRef = React.useRef<HTMLInputElement>(null);
+  const aboutTextareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const isEditingProfileMetadataRef = React.useRef(false);
+  const avatarEditorOpenFrameRef = React.useRef<number | null>(null);
+  const avatarEditClipId = React.useId().replace(/:/g, "");
+  isEditingProfileMetadataRef.current = isEditingProfileMetadata;
 
   React.useEffect(() => {
-    setDisplayNameDraft(currentDisplayName);
-    setAvatarUrlDraft(currentAvatarUrl);
-    setAboutDraft(currentAbout);
-  }, [currentAbout, currentAvatarUrl, currentDisplayName]);
+    if (!isEditingProfileMetadataRef.current) {
+      setDisplayNameDraft(currentDisplayName);
+    }
+  }, [currentDisplayName]);
+
+  React.useEffect(() => {
+    if (!isAvatarEditorOpen) {
+      setAvatarUrlDraft(currentAvatarUrl);
+    }
+  }, [currentAvatarUrl, isAvatarEditorOpen]);
+
+  React.useEffect(() => {
+    if (!isEditingProfileMetadataRef.current) {
+      setAboutDraft(currentAbout);
+    }
+  }, [currentAbout]);
+
+  React.useEffect(() => {
+    if (
+      uploadedAvatarUrlDraft &&
+      currentAvatarUrl &&
+      uploadedAvatarUrlDraft !== currentAvatarUrl &&
+      avatarUrlDraft !== uploadedAvatarUrlDraft
+    ) {
+      setUploadedAvatarUrlDraft(null);
+    }
+  }, [avatarUrlDraft, currentAvatarUrl, uploadedAvatarUrlDraft]);
+
+  React.useEffect(() => {
+    if (isEditingProfileMetadata) {
+      displayNameInputRef.current?.focus();
+    }
+  }, [isEditingProfileMetadata]);
+
+  React.useEffect(() => {
+    if (isAvatarEditorOpen || !shouldRenderAvatarEditor) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShouldRenderAvatarEditor(false);
+    }, AVATAR_EDITOR_TRANSITION_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [isAvatarEditorOpen, shouldRenderAvatarEditor]);
+
+  React.useEffect(() => {
+    return () => {
+      if (avatarEditorOpenFrameRef.current !== null) {
+        window.cancelAnimationFrame(avatarEditorOpenFrameRef.current);
+      }
+    };
+  }, []);
 
   const nextDisplayName = displayNameDraft.trim();
   const nextAvatarUrl = avatarUrlDraft.trim();
   const nextAbout = aboutDraft.trim();
-  const updatePayload: {
-    displayName?: string;
-    avatarUrl?: string;
-    about?: string;
-  } = {};
+  const updatePayload = React.useMemo(() => {
+    const payload: {
+      displayName?: string;
+      avatarUrl?: string;
+      about?: string;
+    } = {};
 
-  if (nextDisplayName.length > 0 && nextDisplayName !== currentDisplayName) {
-    updatePayload.displayName = nextDisplayName;
-  }
-  if (nextAvatarUrl.length > 0 && nextAvatarUrl !== currentAvatarUrl) {
-    updatePayload.avatarUrl = nextAvatarUrl;
-  }
-  if (nextAbout.length > 0 && nextAbout !== currentAbout) {
-    updatePayload.about = nextAbout;
-  }
+    if (nextDisplayName.length > 0 && nextDisplayName !== currentDisplayName) {
+      payload.displayName = nextDisplayName;
+    }
+    if (nextAvatarUrl.length > 0 && nextAvatarUrl !== currentAvatarUrl) {
+      payload.avatarUrl = nextAvatarUrl;
+    }
+    if (nextAbout !== currentAbout) {
+      payload.about = nextAbout;
+    }
+
+    return payload;
+  }, [
+    currentAbout,
+    currentAvatarUrl,
+    currentDisplayName,
+    nextAbout,
+    nextAvatarUrl,
+    nextDisplayName,
+  ]);
 
   const hasPendingClearRequest =
     (currentDisplayName.length > 0 && nextDisplayName.length === 0) ||
-    (currentAvatarUrl.length > 0 && nextAvatarUrl.length === 0) ||
-    (currentAbout.length > 0 && nextAbout.length === 0);
+    (currentAvatarUrl.length > 0 && nextAvatarUrl.length === 0);
+  const hasProfileChanges = Object.keys(updatePayload).length > 0;
   const canSave =
-    Object.keys(updatePayload).length > 0 && !updateProfileMutation.isPending;
+    hasProfileChanges && !updateProfileMutation.isPending && !isUploadingAvatar;
+  const shouldShowSaveArea = hasPendingClearRequest;
+  const readOnlyContentMotionClassName = cn(
+    "min-w-0 w-full origin-top overflow-hidden transition-[opacity,scale] duration-150 ease-out",
+    shouldRenderAvatarEditor ? "absolute inset-x-0 top-0" : "relative",
+    isAvatarEditorOpen
+      ? "pointer-events-none scale-[0.94] opacity-0"
+      : "scale-100 opacity-100",
+  );
 
   const resolvedName =
     nextDisplayName ||
@@ -135,132 +241,392 @@ export function ProfileSettingsCard({
     "Your profile";
   const resolvedPubkey = profile?.pubkey ?? currentPubkey ?? "Unavailable";
   const nip05Handle = profile?.nip05Handle ?? "Not set";
+  const emojiAvatarPreview = React.useMemo(
+    () => parseEmojiAvatarDataUrl(avatarUrlDraft),
+    [avatarUrlDraft],
+  );
+  const avatarEditShellClassName = cn(
+    "absolute right-0 bottom-0 z-10 flex h-[54px] w-[54px] items-center justify-center rounded-full bg-background opacity-100 transition-[opacity,scale,transform] duration-150 ease-out",
+    isAvatarEditorOpen
+      ? "pointer-events-none scale-[0.94] opacity-0"
+      : "scale-100 opacity-100",
+  );
+  const avatarEditButtonClassName = cn(
+    "flex h-11 w-11 items-center justify-center rounded-full bg-sidebar-active text-sidebar-active-foreground shadow-lg transition-[background-color,opacity,scale,transform] duration-150 ease-out hover:scale-[1.04] hover:bg-sidebar-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+  );
+  const avatarClipStyle = React.useMemo<React.CSSProperties | undefined>(
+    () =>
+      !isAvatarEditorOpen
+        ? {
+            clipPath: `url(#${avatarEditClipId})`,
+            transform: "translateZ(0)",
+          }
+        : undefined,
+    [avatarEditClipId, isAvatarEditorOpen],
+  );
+
+  const openAvatarEditor = React.useCallback(() => {
+    setShouldRenderAvatarEditor(true);
+
+    if (avatarEditorOpenFrameRef.current !== null) {
+      window.cancelAnimationFrame(avatarEditorOpenFrameRef.current);
+    }
+
+    avatarEditorOpenFrameRef.current = window.requestAnimationFrame(() => {
+      avatarEditorOpenFrameRef.current = null;
+      setIsAvatarEditorOpen(true);
+    });
+  }, []);
+
+  const saveProfile = React.useCallback(async () => {
+    if (!canSave) {
+      return false;
+    }
+
+    await updateProfileMutation.mutateAsync(updatePayload);
+    setIsEditingProfileMetadata(false);
+    setDisplayNameDraft(updatePayload.displayName ?? currentDisplayName);
+    setAvatarUrlDraft(updatePayload.avatarUrl ?? currentAvatarUrl);
+    setAboutDraft(updatePayload.about ?? currentAbout);
+    toast.success("Profile saved");
+    return true;
+  }, [
+    canSave,
+    currentAbout,
+    currentAvatarUrl,
+    currentDisplayName,
+    updatePayload,
+    updateProfileMutation,
+  ]);
+
+  const handleProfileMetadataEdit = React.useCallback(() => {
+    if (!isEditingProfileMetadata) {
+      setIsEditingProfileMetadata(true);
+      return;
+    }
+
+    if (!hasProfileChanges) {
+      if (!hasPendingClearRequest) {
+        setIsEditingProfileMetadata(false);
+      }
+      return;
+    }
+
+    void saveProfile();
+  }, [
+    hasPendingClearRequest,
+    hasProfileChanges,
+    isEditingProfileMetadata,
+    saveProfile,
+  ]);
+
+  const handleAvatarEditorDone = React.useCallback(() => {
+    if (!hasProfileChanges) {
+      setIsAvatarEditorOpen(false);
+      return;
+    }
+
+    void saveProfile().then((didSave) => {
+      if (didSave) {
+        setIsAvatarEditorOpen(false);
+      }
+    });
+  }, [hasProfileChanges, saveProfile]);
+
+  const animateEmojiAvatarChange = React.useCallback(() => {
+    setAvatarSquishKey((key) => key + 1);
+  }, []);
 
   return (
     <section className="min-w-0" data-testid="settings-profile">
-      <div className="space-y-6">
-        <h2 className="text-2xl font-semibold tracking-tight">Profile</h2>
-
-        {profileQuery.error instanceof Error ? (
-          <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {profileQuery.error.message}
+      <div>
+        <div className="mb-12 space-y-1">
+          <h2 className="text-2xl font-semibold tracking-tight">Profile</h2>
+          <p className="text-base font-normal text-muted-foreground">
+            Update how your name, avatar, and bio appear across Sprout.
           </p>
-        ) : null}
+        </div>
 
-        {updateProfileMutation.error instanceof Error ? (
-          <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {updateProfileMutation.error.message}
-          </p>
-        ) : null}
+        <div className="space-y-3">
+          {profileQuery.error instanceof Error ? (
+            <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {profileQuery.error.message}
+            </p>
+          ) : null}
 
-        {updateProfileMutation.isSuccess ? (
-          <div className="flex items-center gap-2 rounded-xl border border-primary/20 bg-primary/10 px-3 py-2 text-sm text-primary">
-            <Check className="h-4 w-4" />
-            <span>Profile saved.</span>
-          </div>
-        ) : null}
+          {updateProfileMutation.error instanceof Error ? (
+            <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {updateProfileMutation.error.message}
+            </p>
+          ) : null}
 
-        <form
-          className="min-w-0 space-y-4"
-          id="profile-settings-form"
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (!canSave) {
-              return;
-            }
-
-            void updateProfileMutation.mutateAsync(updatePayload);
-          }}
-        >
-          <div className="space-y-1.5">
-            <label
-              className="text-sm font-medium"
-              htmlFor="profile-display-name"
+          <div className="min-w-0">
+            <form
+              className="min-w-0 space-y-3"
+              id="profile-settings-form"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void saveProfile();
+              }}
             >
-              Display name
-            </label>
-            <div className="relative min-w-0">
-              <UserRound className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                className="pl-9"
-                data-testid="profile-display-name"
-                disabled={updateProfileMutation.isPending}
-                id="profile-display-name"
-                onChange={(event) => setDisplayNameDraft(event.target.value)}
-                placeholder="How people should see you"
-                value={displayNameDraft}
-              />
-            </div>
+              <div className="flex min-w-0 flex-col items-center gap-12">
+                <div
+                  className="relative h-48 w-48"
+                  data-testid="profile-avatar-clip-frame"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-0 h-full w-full"
+                    fill="none"
+                    height="192"
+                    viewBox="0 0 192 192"
+                    width="192"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <clipPath
+                      clipPathUnits="userSpaceOnUse"
+                      id={avatarEditClipId}
+                    >
+                      <path
+                        clipRule="evenodd"
+                        d="M100.734 83.3298C102.415 84.1574 104.616 83.8757 105.495 82.2207C109.647 74.3981 112 65.4738 112 56C112 25.0721 86.9279 0 56 0C25.0721 0 0 25.0721 0 56C0 86.9279 25.0721 112 56 112C65.4738 112 74.3981 109.647 82.2207 105.495C83.8757 104.616 84.1574 102.415 83.3298 100.734C82.4783 99.0047 82 97.0582 82 95C82 87.8203 87.8203 82 95 82C97.0582 82 99.0047 82.4783 100.734 83.3298Z"
+                        fillRule="evenodd"
+                        transform="translate(-34.5 -34.5) scale(2.1)"
+                      />
+                    </clipPath>
+                  </svg>
+
+                  <div
+                    className="h-full w-full"
+                    data-testid="profile-avatar-preview-clip"
+                    style={avatarClipStyle}
+                  >
+                    {emojiAvatarPreview ? (
+                      <div
+                        aria-label={`${resolvedName} avatar`}
+                        className="relative flex h-full w-full shrink-0 items-center justify-center overflow-hidden rounded-full shadow-xs"
+                        data-testid="profile-avatar-preview"
+                        role="img"
+                        style={{ backgroundColor: emojiAvatarPreview.color }}
+                      >
+                        <span
+                          className={cn(
+                            "sprout-avatar-emoji-glyph flex h-full w-full items-center justify-center text-[6rem] leading-[100px]",
+                            avatarSquishKey > 0 && "sprout-avatar-squish",
+                          )}
+                          data-testid="profile-avatar-preview-emoji"
+                          key={avatarSquishKey}
+                        >
+                          {emojiAvatarPreview.emoji}
+                        </span>
+                      </div>
+                    ) : (
+                      <ProfileAvatar
+                        avatarUrl={avatarUrlDraft || null}
+                        className="h-full w-full rounded-full text-5xl"
+                        iconClassName="h-14 w-14"
+                        label={resolvedName}
+                        testId="profile-avatar-preview"
+                      />
+                    )}
+                  </div>
+
+                  <div
+                    className={avatarEditShellClassName}
+                    data-testid="profile-avatar-edit-shell"
+                  >
+                    <button
+                      aria-expanded={isAvatarEditorOpen}
+                      aria-label="Edit profile photo"
+                      className={avatarEditButtonClassName}
+                      data-testid="profile-avatar-edit"
+                      onClick={openAvatarEditor}
+                      title="Edit profile photo"
+                      type="button"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+
+                <div className="relative min-w-0 w-full">
+                  <div
+                    className={readOnlyContentMotionClassName}
+                    data-testid="profile-readonly-content"
+                    inert={isAvatarEditorOpen ? true : undefined}
+                  >
+                    <div className="space-y-12">
+                      <div
+                        className="overflow-hidden rounded-xl border border-border/70 bg-background/70 shadow-xs divide-y divide-border/55"
+                        data-testid="profile-metadata-card"
+                      >
+                        <div className="flex min-h-14 items-center justify-between gap-4 px-4 py-3">
+                          <h3 className="text-sm font-medium">Profile info</h3>
+                          <EditProfileMetadataButton
+                            disabled={updateProfileMutation.isPending}
+                            isEditing={isEditingProfileMetadata}
+                            label="profile info"
+                            onClick={handleProfileMetadataEdit}
+                            testId="profile-metadata-edit"
+                          />
+                        </div>
+
+                        <div className="flex min-h-16 items-center gap-4 px-4 py-3">
+                          <div className="min-w-0 flex-1 space-y-1">
+                            <label
+                              className="block text-sm font-medium"
+                              htmlFor="profile-display-name"
+                            >
+                              Display name
+                            </label>
+                            {isEditingProfileMetadata ? (
+                              <Input
+                                className="h-auto border-0 bg-transparent px-0 py-0 text-sm text-muted-foreground shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-0"
+                                data-testid="profile-display-name"
+                                disabled={updateProfileMutation.isPending}
+                                id="profile-display-name"
+                                onChange={(event) =>
+                                  setDisplayNameDraft(event.target.value)
+                                }
+                                placeholder="Display name"
+                                ref={displayNameInputRef}
+                                value={displayNameDraft}
+                              />
+                            ) : (
+                              <p
+                                className="min-w-0 truncate text-sm text-muted-foreground"
+                                data-testid="profile-display-name-value"
+                                title={displayNameDraft || "Not set"}
+                              >
+                                {displayNameDraft || "Not set"}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+
+                        <div className="flex min-h-16 items-center gap-4 px-4 py-3">
+                          <div className="min-w-0 flex-1 space-y-1">
+                            <label
+                              className="block text-sm font-medium"
+                              htmlFor="profile-about"
+                            >
+                              Profile description
+                            </label>
+                            {isEditingProfileMetadata ? (
+                              <Textarea
+                                className="min-h-[72px] resize-none border-0 bg-transparent px-0 py-0 text-sm leading-6 text-muted-foreground shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-0"
+                                data-testid="profile-about"
+                                disabled={updateProfileMutation.isPending}
+                                id="profile-about"
+                                onChange={(event) =>
+                                  setAboutDraft(event.target.value)
+                                }
+                                placeholder="Profile description"
+                                ref={aboutTextareaRef}
+                                value={aboutDraft}
+                              />
+                            ) : (
+                              <p
+                                className={cn(
+                                  "min-w-0 break-words text-sm",
+                                  aboutDraft
+                                    ? "text-muted-foreground"
+                                    : "text-muted-foreground/55",
+                                )}
+                                data-testid="profile-about-value"
+                                title={aboutDraft || "Not set"}
+                              >
+                                {aboutDraft || "Not set"}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div>
+                        <details
+                          className="group overflow-hidden rounded-xl border border-border/70 bg-background/70 shadow-xs"
+                          data-testid="profile-identity-card"
+                        >
+                          <summary
+                            className="group/identity flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 text-sm transition-colors duration-150 ease-out hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden"
+                            data-testid="profile-identity-toggle"
+                          >
+                            <div className="min-w-0">
+                              <h3 className="text-sm font-medium">Identity</h3>
+                              <p className="mt-1 text-sm font-normal text-muted-foreground">
+                                Your keypair and NIP-05 handle are fixed for
+                                this device.
+                              </p>
+                            </div>
+                            <ChevronDown className="h-5 w-5 shrink-0 text-muted-foreground transition-[color,transform] duration-150 ease-out group-open:rotate-180 group-hover/identity:text-foreground group-focus-visible/identity:text-foreground" />
+                          </summary>
+                          <div
+                            className="border-t border-border/55 divide-y divide-border/55"
+                            data-testid="profile-identity-details"
+                          >
+                            <IdentityRow
+                              copyValue={
+                                profile?.pubkey ?? currentPubkey ?? undefined
+                              }
+                              label="Public key"
+                              testId="profile-pubkey"
+                              value={resolvedPubkey}
+                            />
+                            <IdentityRow
+                              copyValue={profile?.nip05Handle ?? undefined}
+                              label="NIP-05 handle"
+                              testId="profile-nip05"
+                              value={nip05Handle}
+                            />
+                          </div>
+                        </details>
+                      </div>
+                    </div>
+                  </div>
+
+                  {shouldRenderAvatarEditor ? (
+                    <div
+                      className={cn(
+                        "relative origin-top transition-[opacity,scale] duration-150 ease-out",
+                        isAvatarEditorOpen
+                          ? "scale-100 opacity-100"
+                          : "pointer-events-none scale-[0.94] opacity-0",
+                      )}
+                      data-testid="profile-avatar-editor-shell"
+                      inert={isAvatarEditorOpen ? undefined : true}
+                    >
+                      <ProfileAvatarEditor
+                        avatarUrl={avatarUrlDraft}
+                        disabled={updateProfileMutation.isPending}
+                        donePending={updateProfileMutation.isPending}
+                        hiddenAvatarUrl={uploadedAvatarUrlDraft}
+                        onDone={handleAvatarEditorDone}
+                        onEmojiAvatarChange={animateEmojiAvatarChange}
+                        onUploadedAvatarChange={setUploadedAvatarUrlDraft}
+                        onUploadingChange={setIsUploadingAvatar}
+                        onUrlChange={(url) => setAvatarUrlDraft(url)}
+                        previewName={resolvedName}
+                        testIdPrefix="profile-avatar"
+                      />
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+
+              {shouldShowSaveArea && !isAvatarEditorOpen ? (
+                <div className="mx-auto w-full max-w-[576px] space-y-2">
+                  {hasPendingClearRequest ? (
+                    <p className="text-sm text-muted-foreground">
+                      Clearing existing profile fields is not supported yet.
+                      Blank display name and avatar values are ignored for now.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+            </form>
           </div>
-
-          <AvatarUpload
-            avatarUrl={avatarUrlDraft}
-            previewName={resolvedName}
-            onUrlChange={(url) => setAvatarUrlDraft(url)}
-            disabled={updateProfileMutation.isPending}
-            idleHint="Upload or paste a URL to change your avatar."
-            testIdPrefix="profile-avatar"
-          />
-
-          <div className="space-y-1.5">
-            <label className="text-sm font-medium" htmlFor="profile-about">
-              About
-            </label>
-            <div className="relative min-w-0">
-              <AtSign className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-              <Textarea
-                className="min-h-28 pl-9"
-                data-testid="profile-about"
-                disabled={updateProfileMutation.isPending}
-                id="profile-about"
-                onChange={(event) => setAboutDraft(event.target.value)}
-                placeholder="A short description for your profile"
-                value={aboutDraft}
-              />
-            </div>
-          </div>
-        </form>
-
-        <Separator />
-
-        <Section
-          description="Your keypair and NIP-05 handle are fixed for this device."
-          title="Identity"
-        >
-          <div className="space-y-3">
-            <ReadOnlyField
-              copyValue={profile?.pubkey ?? currentPubkey ?? undefined}
-              label="Public key"
-              testId="profile-pubkey"
-              value={resolvedPubkey}
-            />
-            <ReadOnlyField
-              copyValue={profile?.nip05Handle ?? undefined}
-              label="NIP-05 handle"
-              testId="profile-nip05"
-              value={nip05Handle}
-            />
-          </div>
-        </Section>
-      </div>
-
-      <div className="sticky bottom-0 z-10 -mx-4 -mb-4 mt-6 flex flex-col gap-2 border-t border-border bg-background px-4 pt-4 pb-4 sm:-mx-6 sm:px-6">
-        <Button
-          data-testid="profile-save"
-          disabled={!canSave}
-          form="profile-settings-form"
-          size="sm"
-          type="submit"
-        >
-          {updateProfileMutation.isPending ? "Saving..." : "Save profile"}
-        </Button>
-
-        {hasPendingClearRequest ? (
-          <p className="text-sm text-muted-foreground">
-            Clearing existing profile fields is not supported yet. Blank display
-            name, avatar, and about values are ignored for now.
-          </p>
-        ) : null}
+        </div>
       </div>
     </section>
   );

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -306,14 +306,18 @@ export function ProfileSettingsCard({
     }
 
     if (!hasProfileChanges) {
-      if (!hasPendingClearRequest) {
-        setIsEditingProfileMetadata(false);
+      if (hasPendingClearRequest) {
+        setDisplayNameDraft(currentDisplayName);
+        setAvatarUrlDraft(currentAvatarUrl);
       }
+      setIsEditingProfileMetadata(false);
       return;
     }
 
     void saveProfile();
   }, [
+    currentAvatarUrl,
+    currentDisplayName,
     hasPendingClearRequest,
     hasProfileChanges,
     isEditingProfileMetadata,

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -5,6 +5,7 @@ import "@/shared/styles/globals.css";
 import { UpdaterProvider } from "@/features/settings/hooks/UpdaterProvider";
 import { WorkspacesProvider } from "@/features/workspaces/useWorkspaces";
 import { ThemeProvider } from "@/shared/theme/ThemeProvider";
+import { EmojiBurstProvider } from "@/shared/ui/EmojiBurstProvider";
 import { Toaster } from "@/shared/ui/sonner";
 import { TooltipProvider } from "@/shared/ui/tooltip";
 
@@ -18,10 +19,12 @@ function renderApp() {
       <WorkspacesProvider>
         <ThemeProvider defaultTheme="houston">
           <TooltipProvider delayDuration={300}>
-            <UpdaterProvider>
-              <App />
-            </UpdaterProvider>
-            <Toaster />
+            <EmojiBurstProvider>
+              <UpdaterProvider>
+                <App />
+              </UpdaterProvider>
+              <Toaster />
+            </EmojiBurstProvider>
           </TooltipProvider>
         </ThemeProvider>
       </WorkspacesProvider>

--- a/desktop/src/shared/styles/globals.css
+++ b/desktop/src/shared/styles/globals.css
@@ -2,6 +2,101 @@
 @import "tw-animate-css";
 @config "../../../tailwind.config.js";
 
+.sprout-emoji-mart {
+  align-items: stretch;
+  display: flex;
+  justify-content: stretch;
+  overflow: hidden;
+  width: 100%;
+}
+
+.sprout-emoji-mart > div {
+  align-items: stretch;
+  display: flex;
+  height: 100%;
+  justify-content: stretch;
+  max-height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.sprout-emoji-mart em-emoji-picker {
+  --border-radius: 12px;
+  --category-icon-size: 24px;
+  --color-border: transparent;
+  --color-border-over: rgb(255 255 255 / 0.1);
+  --font-family: inherit;
+  --font-size: 14px;
+  --rgb-accent: var(--sprout-emoji-picker-rgb-color, 245, 247, 255);
+  --rgb-background: var(--sprout-emoji-picker-rgb-background, 54, 58, 79);
+  --rgb-color: var(--sprout-emoji-picker-rgb-color, 245, 247, 255);
+  --rgb-input: var(--sprout-emoji-picker-rgb-input, 47, 51, 68);
+  --shadow: none;
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+@keyframes sprout-avatar-squish {
+  0% {
+    transform: translate(
+        var(--sprout-avatar-emoji-offset-x, 0px),
+        var(--sprout-avatar-emoji-offset-y, 0px)
+      )
+      scale(1);
+  }
+
+  42% {
+    transform: translate(
+        var(--sprout-avatar-emoji-offset-x, 0px),
+        var(--sprout-avatar-emoji-offset-y, 0px)
+      )
+      scaleX(0.96) scaleY(0.88);
+  }
+
+  100% {
+    transform: translate(
+        var(--sprout-avatar-emoji-offset-x, 0px),
+        var(--sprout-avatar-emoji-offset-y, 0px)
+      )
+      scale(1);
+  }
+}
+
+.sprout-avatar-emoji-glyph {
+  --sprout-avatar-emoji-offset-x: 1px;
+  --sprout-avatar-emoji-offset-y: 7px;
+  transform: translate(
+    var(--sprout-avatar-emoji-offset-x),
+    var(--sprout-avatar-emoji-offset-y)
+  );
+}
+
+.sprout-avatar-squish {
+  animation: sprout-avatar-squish 200ms ease-out;
+  transform-origin: center;
+}
+
+.sprout-avatar-hue-scrubber {
+  background: linear-gradient(
+    90deg,
+    #ff0000 0%,
+    #ffff00 16.67%,
+    #00ff00 33.33%,
+    #00ffff 50%,
+    #0000ff 66.67%,
+    #ff00ff 83.33%,
+    #ff0000 100%
+  );
+  outline: none;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
 /* ── Tiptap rich-text composer ──────────────────────────────────────── */
 .rich-text-composer .tiptap {
   outline: none;

--- a/desktop/src/shared/ui/EmojiBurstProvider.tsx
+++ b/desktop/src/shared/ui/EmojiBurstProvider.tsx
@@ -1,0 +1,488 @@
+import * as React from "react";
+
+type BurstPoint = {
+  x: number;
+  y: number;
+};
+
+type EmojiBurstOrigin =
+  | Element
+  | {
+      clientX?: number;
+      clientY?: number;
+      currentTarget?: EventTarget | null;
+      target?: EventTarget | null;
+    }
+  | null
+  | undefined;
+
+type EmojiBurstContextValue = {
+  burstEmoji: (emoji: string, origin?: EmojiBurstOrigin) => void;
+  celebrateWithEmojiFloatBurst: () => void;
+};
+
+type Particle = {
+  x: number;
+  y: number;
+  xv: number;
+  yv: number;
+  rotation: number;
+  spin: number;
+  scale: number;
+  opacity: number;
+  life: number;
+  maxLife: number;
+  emoji: string;
+  fontSize: number;
+  radius: number;
+  gravity: number;
+};
+
+const NOOP_CONTEXT: EmojiBurstContextValue = {
+  burstEmoji: () => {},
+  celebrateWithEmojiFloatBurst: () => {},
+};
+
+const EmojiBurstContext = React.createContext<EmojiBurstContextValue | null>(
+  null,
+);
+
+const MAX_ACTIVE = 760;
+const MAX_DPR = 2;
+const EMOJI_CACHE_PX = 64;
+const PICKER_PARTICLES_PER_BURST = 5;
+const PICKER_PARTICLE_LIFE_FRAMES = 108;
+const CELEBRATION_PARTICLE_COUNT = 102;
+const HEART_PARTICLE_EMOJIS = [
+  "❤️",
+  "🩷",
+  "🧡",
+  "💛",
+  "💚",
+  "🩵",
+  "💙",
+  "💜",
+  "🤎",
+  "🖤",
+  "🩶",
+  "🤍",
+  "❤️‍🔥",
+  "❤️‍🩹",
+  "💖",
+  "💕",
+  "💗",
+  "💓",
+  "💞",
+  "💘",
+  "💝",
+  "❣️",
+  "♥️",
+];
+const POSITIVE_REACTION_PARTICLE_EMOJIS = [
+  "👍",
+  "👏",
+  "🙌",
+  "🙏",
+  "💯",
+  "🔥",
+  "✨",
+  "⭐",
+  "🌟",
+  "🎉",
+  "🎊",
+  "🥳",
+  "🚀",
+  "💪",
+];
+const POSITIVE_FACE_PARTICLE_EMOJIS = [
+  "😀",
+  "😃",
+  "😄",
+  "😁",
+  "😊",
+  "😇",
+  "🙂",
+  "😍",
+  "🤩",
+  "🥰",
+  "😘",
+  "😋",
+  "😎",
+  "😂",
+  "🤣",
+];
+
+export const POSITIVE_EMOJI_PARTICLES = [
+  ...HEART_PARTICLE_EMOJIS,
+  ...POSITIVE_REACTION_PARTICLE_EMOJIS,
+  ...POSITIVE_FACE_PARTICLE_EMOJIS,
+];
+
+const CELEBRATION_EMOJIS = POSITIVE_EMOJI_PARTICLES;
+const POSITIVE_EMOJI_PARTICLE_SET = new Set(POSITIVE_EMOJI_PARTICLES);
+
+const emojiCanvasCache = new Map<string, HTMLCanvasElement>();
+
+function isElement(value: unknown): value is Element {
+  return typeof Element !== "undefined" && value instanceof Element;
+}
+
+function elementCenter(element: Element): BurstPoint | null {
+  const rect = element.getBoundingClientRect();
+  if (!rect.width && !rect.height) return null;
+  return {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  };
+}
+
+function pointFromOrigin(origin: EmojiBurstOrigin): BurstPoint | null {
+  if (!origin) return null;
+  if (isElement(origin)) return elementCenter(origin);
+
+  if (
+    typeof origin.clientX === "number" &&
+    Number.isFinite(origin.clientX) &&
+    typeof origin.clientY === "number" &&
+    Number.isFinite(origin.clientY) &&
+    (origin.clientX !== 0 || origin.clientY !== 0)
+  ) {
+    return { x: origin.clientX, y: origin.clientY };
+  }
+
+  const target = origin.currentTarget ?? origin.target;
+  return isElement(target) ? elementCenter(target) : null;
+}
+
+function resizeCanvas(canvas: HTMLCanvasElement) {
+  const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  const targetWidth = Math.round(width * dpr);
+  const targetHeight = Math.round(height * dpr);
+
+  if (canvas.width === targetWidth && canvas.height === targetHeight) {
+    return;
+  }
+
+  canvas.width = targetWidth;
+  canvas.height = targetHeight;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+}
+
+function getEmojiCanvas(emoji: string): HTMLCanvasElement {
+  const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);
+  const cacheKey = `${emoji}:${dpr}`;
+  const existing = emojiCanvasCache.get(cacheKey);
+  if (existing) return existing;
+
+  const fontSize = Math.ceil(EMOJI_CACHE_PX * dpr);
+  const size = Math.ceil(fontSize * 1.5);
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+
+  const context = canvas.getContext("2d");
+  if (!context) return canvas;
+
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.font = `${fontSize}px "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif`;
+  context.fillText(emoji, size / 2, size / 2);
+
+  emojiCanvasCache.set(cacheKey, canvas);
+  return canvas;
+}
+
+function updateParticle(particle: Particle): boolean {
+  particle.life -= 1;
+  particle.rotation += particle.spin;
+  particle.yv += particle.gravity;
+  particle.xv *= 0.965;
+  particle.yv *= 0.998;
+  particle.x += particle.xv;
+  particle.y += particle.yv;
+  particle.scale += (1 - particle.scale) * 0.28;
+  particle.radius = particle.fontSize * particle.scale * 0.42;
+
+  const lifeRatio = particle.life / particle.maxLife;
+  if (lifeRatio < 0.24) {
+    particle.opacity = Math.max(0, lifeRatio / 0.24);
+  }
+
+  return particle.life > 0 && particle.opacity > 0.02;
+}
+
+function resolveCollisions(particles: Particle[]) {
+  for (let i = 0; i < particles.length; i += 1) {
+    for (let j = i + 1; j < particles.length; j += 1) {
+      const a = particles[i];
+      const b = particles[j];
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const distanceSquared = dx * dx + dy * dy;
+      const minDistance = a.radius + b.radius;
+
+      if (
+        distanceSquared >= minDistance * minDistance ||
+        distanceSquared < 0.01
+      ) {
+        continue;
+      }
+
+      const distance = Math.sqrt(distanceSquared);
+      const nx = dx / distance;
+      const ny = dy / distance;
+      const separation = (minDistance - distance) * 0.5;
+
+      a.x -= nx * separation;
+      a.y -= ny * separation;
+      b.x += nx * separation;
+      b.y += ny * separation;
+
+      const dvx = a.xv - b.xv;
+      const dvy = a.yv - b.yv;
+      const velocityAlongNormal = dvx * nx + dvy * ny;
+      if (velocityAlongNormal <= 0) continue;
+
+      const impulse = velocityAlongNormal * 0.34;
+      a.xv -= impulse * nx;
+      a.yv -= impulse * ny;
+      b.xv += impulse * nx;
+      b.yv += impulse * ny;
+    }
+  }
+}
+
+function viewportCenter(): BurstPoint {
+  return {
+    x: window.innerWidth / 2,
+    y: window.innerHeight / 2,
+  };
+}
+
+function spawnPickerEmojiBurst(
+  particles: Particle[],
+  point: BurstPoint,
+  emoji: string,
+) {
+  if (particles.length + PICKER_PARTICLES_PER_BURST > MAX_ACTIVE) return;
+
+  for (let i = 0; i < PICKER_PARTICLES_PER_BURST; i += 1) {
+    const horizontalDrift = (Math.random() - 0.5) * 4.4;
+    const initialLift = 2.1 + Math.random() * 2.35;
+
+    particles.push({
+      x: point.x,
+      y: point.y,
+      xv: horizontalDrift,
+      yv: -initialLift,
+      rotation: (Math.random() - 0.5) * 22,
+      spin: (Math.random() - 0.5) * 5.2,
+      scale: 0.25,
+      opacity: 1,
+      life: PICKER_PARTICLE_LIFE_FRAMES,
+      maxLife: PICKER_PARTICLE_LIFE_FRAMES,
+      emoji,
+      fontSize: 18 + Math.ceil(Math.random() * 24),
+      radius: 0,
+      gravity: -(0.018 + Math.random() * 0.018),
+    });
+  }
+}
+
+function spawnEmojiFloatBurst(particles: Particle[]) {
+  const availableSlots = Math.max(0, MAX_ACTIVE - particles.length);
+  const count = Math.min(CELEBRATION_PARTICLE_COUNT, availableSlots);
+  if (count === 0) return;
+
+  const centerX = window.innerWidth / 2;
+  const launchBandWidth = window.innerWidth * 0.78;
+
+  for (let i = 0; i < count; i += 1) {
+    const x = centerX + (Math.random() - 0.5) * launchBandWidth;
+    const y = window.innerHeight + 52 + Math.random() * 88;
+    const life = 142 + Math.floor(Math.random() * 72);
+    const fanDirection = (x - centerX) / Math.max(window.innerWidth / 2, 1);
+    const emoji =
+      CELEBRATION_EMOJIS[Math.floor(Math.random() * CELEBRATION_EMOJIS.length)];
+
+    particles.push({
+      x,
+      y,
+      xv:
+        fanDirection * (4.2 + Math.random() * 3.4) +
+        (Math.random() - 0.5) * 2.2,
+      yv: -(5.4 + Math.random() * 4.8),
+      rotation: (Math.random() - 0.5) * 70,
+      spin: (Math.random() - 0.5) * 7.6,
+      scale: 0.44 + Math.random() * 0.48,
+      opacity: 1,
+      life,
+      maxLife: life,
+      emoji,
+      fontSize: 22 + Math.ceil(Math.random() * 30),
+      radius: 0,
+      gravity: 0,
+    });
+  }
+}
+
+export function EmojiBurstProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const canvasRef = React.useRef<HTMLCanvasElement>(null);
+  const contextRef = React.useRef<CanvasRenderingContext2D | null>(null);
+  const particlesRef = React.useRef<Particle[]>([]);
+  const animationFrameRef = React.useRef<number | null>(null);
+  const reducedMotionRef = React.useRef(false);
+
+  const startLoop = React.useCallback(() => {
+    if (animationFrameRef.current !== null) return;
+
+    const canvas = canvasRef.current;
+    const context = contextRef.current;
+    if (!canvas || !context) return;
+    const activeCanvas = canvas;
+    const activeContext = context;
+
+    function frame() {
+      const particles = particlesRef.current;
+      const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);
+
+      for (let i = particles.length - 1; i >= 0; i -= 1) {
+        if (!updateParticle(particles[i])) {
+          particles[i] = particles[particles.length - 1];
+          particles.pop();
+        }
+      }
+
+      activeContext.setTransform(1, 0, 0, 1, 0, 0);
+      activeContext.clearRect(0, 0, activeCanvas.width, activeCanvas.height);
+
+      if (particles.length === 0) {
+        activeContext.globalAlpha = 1;
+        animationFrameRef.current = null;
+        return;
+      }
+
+      resolveCollisions(particles);
+
+      for (const particle of particles) {
+        activeContext.globalAlpha = particle.opacity;
+
+        const emojiCanvas = getEmojiCanvas(particle.emoji);
+        const drawSize = particle.fontSize * particle.scale * 1.5;
+        const halfSize = drawSize / 2;
+        const radians = (particle.rotation * Math.PI) / 180;
+        const cos = Math.cos(radians) * dpr;
+        const sin = Math.sin(radians) * dpr;
+
+        activeContext.setTransform(
+          cos,
+          sin,
+          -sin,
+          cos,
+          particle.x * dpr,
+          particle.y * dpr,
+        );
+        activeContext.drawImage(
+          emojiCanvas,
+          -halfSize,
+          -halfSize,
+          drawSize,
+          drawSize,
+        );
+      }
+
+      activeContext.globalAlpha = 1;
+      animationFrameRef.current = requestAnimationFrame(frame);
+    }
+
+    animationFrameRef.current = requestAnimationFrame(frame);
+  }, []);
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    contextRef.current = canvas.getContext("2d");
+    resizeCanvas(canvas);
+
+    const handleResize = () => resizeCanvas(canvas);
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+    };
+  }, []);
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const syncReducedMotion = () => {
+      reducedMotionRef.current = mediaQuery.matches;
+    };
+
+    syncReducedMotion();
+    mediaQuery.addEventListener("change", syncReducedMotion);
+
+    return () => {
+      mediaQuery.removeEventListener("change", syncReducedMotion);
+    };
+  }, []);
+
+  const burstEmoji = React.useCallback(
+    (emoji: string, origin?: EmojiBurstOrigin) => {
+      const trimmedEmoji = emoji.trim();
+      if (!trimmedEmoji || reducedMotionRef.current) return;
+
+      spawnPickerEmojiBurst(
+        particlesRef.current,
+        pointFromOrigin(origin) ?? viewportCenter(),
+        trimmedEmoji,
+      );
+      startLoop();
+    },
+    [startLoop],
+  );
+
+  const celebrateWithEmojiFloatBurst = React.useCallback(() => {
+    if (reducedMotionRef.current) return;
+
+    spawnEmojiFloatBurst(particlesRef.current);
+    startLoop();
+  }, [startLoop]);
+
+  const value = React.useMemo<EmojiBurstContextValue>(
+    () => ({ burstEmoji, celebrateWithEmojiFloatBurst }),
+    [burstEmoji, celebrateWithEmojiFloatBurst],
+  );
+
+  return (
+    <EmojiBurstContext.Provider value={value}>
+      {children}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0 select-none"
+        style={{ contain: "strict", zIndex: 2147483000 }}
+      >
+        <canvas className="block" ref={canvasRef} />
+      </div>
+    </EmojiBurstContext.Provider>
+  );
+}
+
+export function useEmojiBurst(): EmojiBurstContextValue {
+  return React.useContext(EmojiBurstContext) ?? NOOP_CONTEXT;
+}
+
+export function isPositiveEmojiParticle(emoji: string): boolean {
+  return POSITIVE_EMOJI_PARTICLE_SET.has(emoji);
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -2597,7 +2597,7 @@ async function handleUpdateProfile(
     if (nextAvatarUrl && nextAvatarUrl !== profile.avatar_url) {
       profile.avatar_url = nextAvatarUrl;
     }
-    if (nextAbout && nextAbout !== profile.about) {
+    if (typeof nextAbout === "string" && nextAbout !== profile.about) {
       profile.about = nextAbout;
     }
     if (

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -377,8 +377,9 @@ test("shows your avatar on your own message when profile avatar is set", async (
 
   await page.goto("/");
   await openSettings(page, "profile");
+  await page.getByTestId("profile-avatar-edit").click();
   await page.getByTestId("profile-avatar-url").fill(avatarUrl);
-  await page.getByTestId("profile-save").click();
+  await page.getByTestId("profile-avatar-done").click();
   await page.getByTestId("settings-back-to-app").click();
 
   await page.getByTestId("channel-general").click();

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -1,10 +1,54 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 import { installMockBridge } from "../helpers/bridge";
 import { openProfileMenu, openSettings } from "../helpers/settings";
 
 async function expectHomeView(page: import("@playwright/test").Page) {
   await expect(page.getByTestId("home-inbox-list")).toBeVisible();
+}
+
+async function expandIdentity(page: import("@playwright/test").Page) {
+  const identity = page.getByTestId("profile-identity-card");
+  const isOpen = await identity.evaluate(
+    (element) => element instanceof HTMLDetailsElement && element.open,
+  );
+  if (!isOpen) {
+    await page.getByTestId("profile-identity-toggle").click();
+  }
+}
+
+async function selectFirstEmojiFromPicker(page: Page) {
+  const picker = page.locator("em-emoji-picker");
+  await expect(picker).toBeVisible();
+  await expect
+    .poll(() =>
+      picker.evaluate((element) =>
+        Boolean(element.shadowRoot?.querySelector(".scroll button")),
+      ),
+    )
+    .toBe(true);
+  await picker.evaluate((element) => {
+    const button = element.shadowRoot?.querySelector(".scroll button");
+    if (!(button instanceof HTMLElement)) {
+      throw new Error("Emoji picker did not render an emoji button.");
+    }
+    button.click();
+  });
+}
+
+async function waitForAvatarEditorToClose(page: Page) {
+  await expect(page.getByTestId("profile-avatar-editor-shell")).toHaveCount(0);
+}
+
+async function waitForReactEffects(page: Page) {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(resolve);
+        });
+      }),
+  );
 }
 
 test.beforeEach(async ({ page }) => {
@@ -26,32 +70,379 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
     }),
   ).toBeVisible();
 
+  await expect(page.getByTestId("profile-identity-details")).toBeHidden();
+  await expandIdentity(page);
   await expect(page.getByTestId("profile-pubkey")).toContainText("deadbeef");
   await expect(page.getByTestId("profile-nip05")).toContainText("Not set");
 
+  await page.getByTestId("profile-metadata-edit").click();
+  await expect(page.getByTestId("profile-metadata-edit")).toHaveText("Done");
+  await expect(page.getByTestId("profile-about")).toBeVisible();
   await page.getByTestId("profile-display-name").fill(displayName);
-  await page.getByTestId("profile-avatar-url").fill(avatarUrl);
   await page.getByTestId("profile-about").fill(about);
-  await page.getByTestId("profile-save").click();
+  await page.getByTestId("profile-metadata-edit").click();
 
-  await expect(page.getByTestId("profile-display-name")).toHaveValue(
+  await expect(page.getByTestId("profile-display-name-value")).toHaveText(
+    displayName,
+  );
+  await expect(page.getByTestId("profile-about-value")).toHaveText(about);
+
+  await page.getByTestId("profile-avatar-edit").click();
+  await page.getByTestId("profile-avatar-url").fill(avatarUrl);
+  await page.getByTestId("profile-avatar-done").click();
+
+  await expect(page.getByTestId("profile-display-name-value")).toHaveText(
     displayName,
   );
   await expect(page.getByTestId("profile-nip05")).toContainText("Not set");
+  await page.getByTestId("profile-avatar-edit").click();
   await expect(page.getByTestId("profile-avatar-url")).toHaveValue(avatarUrl);
-  await expect(page.getByTestId("profile-about")).toHaveValue(about);
+  await page.getByTestId("profile-avatar-done").click();
+  await expandIdentity(page);
 
   await page.getByTestId("settings-back-to-app").click();
   await expectHomeView(page);
   await expect(page.getByTestId("open-settings")).toBeVisible();
 
   await openSettings(page, "profile");
-  await expect(page.getByTestId("profile-display-name")).toHaveValue(
+  await expect(page.getByTestId("profile-display-name-value")).toHaveText(
     displayName,
   );
+  await expandIdentity(page);
   await expect(page.getByTestId("profile-nip05")).toContainText("Not set");
+  await page.getByTestId("profile-avatar-edit").click();
   await expect(page.getByTestId("profile-avatar-url")).toHaveValue(avatarUrl);
-  await expect(page.getByTestId("profile-about")).toHaveValue(about);
+  await expect(page.getByTestId("profile-about-value")).toHaveText(about);
+});
+
+test("saves profile metadata from the block Done button", async ({ page }) => {
+  await page.goto("/");
+
+  await openSettings(page, "profile");
+  await expect(page.getByTestId("profile-display-name-value")).toHaveText(
+    "npub1mock...",
+  );
+  await expect(page.getByTestId("profile-save")).toHaveCount(0);
+
+  await page.getByTestId("profile-metadata-edit").click();
+  await expect(page.getByTestId("profile-metadata-edit")).toHaveText("Done");
+  await expect(page.getByTestId("profile-about")).toBeVisible();
+  await page.getByTestId("profile-display-name").fill("Save Button QA");
+  await page.getByTestId("profile-about").fill("Temporary profile note");
+  await expect(page.getByTestId("profile-save")).toHaveCount(0);
+
+  await page.getByTestId("profile-metadata-edit").click();
+  await waitForReactEffects(page);
+  await expect(page.getByTestId("profile-display-name")).toHaveCount(0);
+  await expect(page.getByTestId("profile-display-name-value")).toHaveText(
+    "Save Button QA",
+  );
+  await expect(page.getByTestId("profile-about-value")).toHaveText(
+    "Temporary profile note",
+  );
+  await expect(page.getByTestId("profile-metadata-edit")).toHaveText("Edit");
+  await expect(page.getByTestId("profile-save")).toHaveCount(0);
+
+  await page.getByTestId("profile-metadata-edit").click();
+  await page.getByTestId("profile-about").fill("");
+  await page.getByTestId("profile-metadata-edit").click();
+  await waitForReactEffects(page);
+  await expect(page.getByTestId("profile-about-value")).toHaveText("Not set");
+  await expect(page.getByTestId("profile-save")).toHaveCount(0);
+
+  await page.getByTestId("profile-metadata-edit").click();
+  await page.getByTestId("profile-display-name").fill("npub1mock...");
+  await page.getByTestId("profile-metadata-edit").click();
+  await expect(page.getByTestId("profile-save")).toHaveCount(0);
+});
+
+test("shows profile save feedback as a toast", async ({ page }) => {
+  await page.goto("/");
+
+  await openSettings(page, "profile");
+  await page.getByTestId("profile-metadata-edit").click();
+  await page.getByTestId("profile-display-name").fill("Toast QA");
+  await page.getByTestId("profile-metadata-edit").click();
+
+  await expect(
+    page.locator("[data-sonner-toast]").filter({ hasText: "Profile saved" }),
+  ).toBeVisible();
+  await expect(page.getByText("Profile saved.", { exact: true })).toHaveCount(
+    0,
+  );
+});
+
+test("nests the avatar edit button in a clipped notch", async ({ page }) => {
+  await page.goto("/");
+
+  await openSettings(page, "profile");
+
+  await expect(page.getByTestId("profile-avatar-preview-clip")).toHaveCSS(
+    "clip-path",
+    /url/,
+  );
+  const editShell = page.getByTestId("profile-avatar-edit-shell");
+  await expect(editShell).toHaveCSS("height", "54px");
+  await expect(editShell).toHaveCSS("width", "54px");
+
+  const editButton = page.getByTestId("profile-avatar-edit");
+  await expect(editButton).toHaveCSS("opacity", "1");
+
+  await expect(editButton).toHaveCSS(
+    "background-color",
+    await page
+      .getByTestId("settings-nav-profile")
+      .evaluate((element) => getComputedStyle(element).backgroundColor),
+  );
+  const transitionProperty = await editButton.evaluate(
+    (element) => getComputedStyle(element).transitionProperty,
+  );
+  expect(transitionProperty).toContain("opacity");
+  expect(transitionProperty).toContain("scale");
+});
+
+test("highlights the avatar drop target while dragging an image", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await openSettings(page, "profile");
+  await page.getByTestId("profile-avatar-edit").click();
+
+  const uploadTarget = page.getByTestId("profile-avatar-upload");
+  await uploadTarget.evaluate((element) => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(
+      new File(["avatar"], "avatar.png", { type: "image/png" }),
+    );
+
+    element.dispatchEvent(
+      new DragEvent("dragenter", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }),
+    );
+  });
+
+  await expect(uploadTarget).toHaveAttribute("data-dragging", "true");
+  await expect(uploadTarget).toContainText("Drop image here");
+
+  await uploadTarget.evaluate((element) => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(
+      new File(["avatar"], "avatar.png", { type: "image/png" }),
+    );
+
+    element.dispatchEvent(
+      new DragEvent("dragleave", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }),
+    );
+  });
+
+  await expect(uploadTarget).not.toHaveAttribute("data-dragging", "true");
+
+  await uploadTarget.evaluate((element) => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(
+      new File(["avatar"], "avatar.png", { type: "image/png" }),
+    );
+
+    element.dispatchEvent(
+      new DragEvent("dragenter", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }),
+    );
+  });
+
+  await expect(uploadTarget).toHaveAttribute("data-dragging", "true");
+
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new DragEvent("dragleave", {
+        bubbles: true,
+        cancelable: true,
+        clientX: -1,
+        clientY: 40,
+      }),
+    );
+  });
+
+  await expect(uploadTarget).not.toHaveAttribute("data-dragging", "true");
+});
+
+test("uploads local profile avatar files before saving", async ({ page }) => {
+  const uploadedAvatarUrl = "https://mock.relay/media/avatar-profile.png";
+  await installMockBridge(page, {
+    uploadDescriptors: [
+      {
+        filename: "avatar-profile.png",
+        sha256: "b".repeat(64),
+        size: 553432,
+        type: "image/png",
+        uploaded: 1_779_900_000,
+        url: uploadedAvatarUrl,
+      },
+    ],
+  });
+  await page.goto("/");
+
+  await openSettings(page, "profile");
+  await page.getByTestId("profile-avatar-edit").click();
+  await page.getByTestId("profile-avatar-input").setInputFiles({
+    buffer: Buffer.from("large-avatar-bytes"),
+    mimeType: "image/png",
+    name: "avatar-profile.png",
+  });
+
+  await expect(page.getByTestId("profile-avatar-url")).toHaveValue("");
+  await page.getByTestId("profile-avatar-done").click();
+  await waitForAvatarEditorToClose(page);
+  await page.getByTestId("profile-avatar-edit").click();
+  await expect(page.getByTestId("profile-avatar-url")).toHaveValue("");
+
+  const pastedAvatarUrl = "https://example.com/change-my-mind.png";
+  await page.getByTestId("profile-avatar-url").click();
+  await page.keyboard.insertText(pastedAvatarUrl);
+  await expect(page.getByTestId("profile-avatar-url")).toHaveValue(
+    pastedAvatarUrl,
+  );
+  await page.getByTestId("profile-avatar-done").click();
+  await waitForAvatarEditorToClose(page);
+  await page.getByTestId("profile-avatar-edit").click();
+  await expect(page.getByTestId("profile-avatar-url")).toHaveValue(
+    pastedAvatarUrl,
+  );
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as Window & { __SPROUT_E2E_COMMANDS__?: string[] })
+            .__SPROUT_E2E_COMMANDS__ ?? [],
+      ),
+    )
+    .toEqual(expect.arrayContaining(["upload_media_bytes", "update_profile"]));
+});
+
+test("renders emoji avatars with a static background layer", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await openSettings(page, "profile");
+  await page.getByTestId("profile-avatar-edit").click();
+  await page.getByRole("tab", { name: "Emoji" }).click();
+  await selectFirstEmojiFromPicker(page);
+  await page.getByRole("button", { name: "Use #FFE75C background" }).click();
+
+  const avatarPreview = page.getByTestId("profile-avatar-preview");
+  await expect(avatarPreview).toHaveCSS(
+    "background-color",
+    "rgb(255, 231, 92)",
+  );
+  await expect(avatarPreview).not.toHaveClass(/sprout-avatar-squish/);
+  await expect(page.getByTestId("profile-avatar-preview-emoji")).toHaveText(
+    "😀",
+  );
+  await expect(page.getByTestId("profile-avatar-preview-emoji")).toHaveCSS(
+    "font-size",
+    "96px",
+  );
+});
+
+test("reveals emoji background colors only after choosing an emoji", async ({
+  page,
+}) => {
+  const imageAvatarUrl = `https://example.com/avatar-color-controls-${Date.now()}.png`;
+  await page.goto("/");
+
+  await openSettings(page, "profile");
+  await page.getByTestId("profile-avatar-edit").click();
+  await page.getByTestId("profile-avatar-url").fill(imageAvatarUrl);
+  await page.getByTestId("profile-avatar-done").click();
+  await waitForAvatarEditorToClose(page);
+
+  await page.getByTestId("profile-avatar-edit").click();
+  await expect(page.getByTestId("profile-avatar-url")).toHaveValue(
+    imageAvatarUrl,
+  );
+  await page.getByRole("tab", { name: "Emoji" }).click();
+
+  const colorGridShell = page.getByTestId("profile-avatar-color-grid-shell");
+  const doneButton = page.getByTestId("profile-avatar-done");
+  await expect(colorGridShell).toHaveAttribute("aria-hidden", "true");
+
+  const doneBeforeEmoji = await doneButton.boundingBox();
+  if (!doneBeforeEmoji) {
+    throw new Error("Avatar Done button did not render bounds.");
+  }
+
+  await selectFirstEmojiFromPicker(page);
+
+  await expect(colorGridShell).toHaveAttribute("aria-hidden", "false");
+  await expect(page.getByTestId("profile-avatar-color-grid")).toBeVisible();
+  await colorGridShell.evaluate((element) =>
+    Promise.all(
+      element
+        .getAnimations()
+        .map((animation) => animation.finished.catch(() => undefined)),
+    ),
+  );
+
+  const doneAfterEmoji = await doneButton.boundingBox();
+  if (!doneAfterEmoji) {
+    throw new Error("Avatar Done button did not render bounds.");
+  }
+  expect(doneAfterEmoji.y).toBeGreaterThan(doneBeforeEmoji.y + 8);
+});
+
+test("snaps custom avatar colors to the dot grid", async ({ page }) => {
+  await page.goto("/");
+
+  await openSettings(page, "profile");
+  await page.getByTestId("profile-avatar-edit").click();
+  await page.getByRole("tab", { name: "Emoji" }).click();
+  await selectFirstEmojiFromPicker(page);
+
+  const customColorSwatch = page.getByTestId("profile-avatar-custom-color");
+  await customColorSwatch.click();
+
+  const spectrum = page.getByTestId("profile-avatar-custom-color-spectrum");
+  await expect(spectrum).toBeVisible();
+  await expect(page.getByTestId("profile-avatar-done")).toHaveCount(0);
+  await expect(
+    page.getByTestId("profile-avatar-custom-color-done"),
+  ).toBeVisible();
+
+  const spectrumBox = await spectrum.boundingBox();
+  if (!spectrumBox) {
+    throw new Error("Custom color spectrum did not render bounds.");
+  }
+
+  await spectrum.click({
+    position: {
+      x: 24 + (spectrumBox.width - 48) * 0.33,
+      y: 24 + (spectrumBox.height - 48) * 0.44,
+    },
+  });
+  await expect(page.getByTestId("profile-avatar-preview")).toHaveCSS(
+    "background-color",
+    "rgb(145, 93, 93)",
+  );
+  await page.getByTestId("profile-avatar-custom-color-done").click();
+
+  await expect(customColorSwatch).toHaveAttribute("aria-pressed", "true");
+  await expect(customColorSwatch).toHaveCSS(
+    "background-color",
+    "rgb(145, 93, 93)",
+  );
+  await expect(page.getByTestId("profile-avatar-done")).toBeVisible();
 });
 
 test("updates presence from the profile menu", async ({ page }) => {

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -319,13 +319,25 @@ test("uploads local profile avatar files before saving", async ({ page }) => {
   await page.getByTestId("profile-avatar-edit").click();
   await expect(page.getByTestId("profile-avatar-url")).toHaveValue("");
 
-  const pastedAvatarUrl = "https://example.com/change-my-mind.png";
+  const pastedAvatarUrl = await page.evaluate(
+    () => new URL("/sprout.svg", window.location.href).href,
+  );
   await page.getByTestId("profile-avatar-url").click();
   await page.keyboard.insertText(pastedAvatarUrl);
   await expect(page.getByTestId("profile-avatar-url")).toHaveValue(
     pastedAvatarUrl,
   );
   await page.getByTestId("profile-avatar-done").click();
+  await waitForAvatarEditorToClose(page);
+  await page.getByTestId("profile-avatar-edit").click();
+  await expect(page.getByTestId("profile-avatar-url")).toHaveValue(
+    pastedAvatarUrl,
+  );
+  await page.getByTestId("profile-avatar-url").fill("");
+  await page.getByTestId("profile-avatar-done").click();
+  await expect(
+    page.getByTestId("profile-avatar-preview").locator("img"),
+  ).toHaveCount(1);
   await waitForAvatarEditorToClose(page);
   await page.getByTestId("profile-avatar-edit").click();
   await expect(page.getByTestId("profile-avatar-url")).toHaveValue(

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -151,6 +151,19 @@ test("saves profile metadata from the block Done button", async ({ page }) => {
   await expect(page.getByTestId("profile-save")).toHaveCount(0);
 
   await page.getByTestId("profile-metadata-edit").click();
+  await page.getByTestId("profile-display-name").fill("");
+  await expect(
+    page.getByText("Clearing existing profile fields is not supported yet."),
+  ).toBeVisible();
+  await page.getByTestId("profile-metadata-edit").click();
+  await waitForReactEffects(page);
+  await expect(page.getByTestId("profile-display-name")).toHaveCount(0);
+  await expect(page.getByTestId("profile-display-name-value")).toHaveText(
+    "Save Button QA",
+  );
+  await expect(page.getByTestId("profile-metadata-edit")).toHaveText("Edit");
+
+  await page.getByTestId("profile-metadata-edit").click();
   await page.getByTestId("profile-display-name").fill("npub1mock...");
   await page.getByTestId("profile-metadata-edit").click();
   await expect(page.getByTestId("profile-save")).toHaveCount(0);


### PR DESCRIPTION
## Summary

- Add edit/done profile metadata controls inside the settings profile page.
- Add a profile avatar editor with upload, image URL, emoji avatar, and color controls while keeping mobile behavior as-is.
- Add the app-wide emoji burst provider used by the avatar picker feedback.
- Split the avatar editor helper logic into `ProfileAvatarEditor.utils.ts` so the editor stays under the file-size gate.
- Expand profile E2E coverage for metadata saves, avatar uploads, emoji avatars, menu presence, and settings shell behavior.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e:integration -- profile.spec.ts`