### PR TITLE
Read-only channel allowlist for NIP-42/43 viewers

### DIFF
--- a/crates/sprout-auth/src/lib.rs
+++ b/crates/sprout-auth/src/lib.rs
@@ -76,6 +76,42 @@ impl AuthContext {
     pub fn has_scope(&self, scope: &Scope) -> bool {
         self.scopes.contains(scope)
     }
+
+    /// Construct a synthetic read-only context for an *unauthenticated* public
+    /// viewer, scoped to exactly `channel_ids`.
+    ///
+    /// This grants no write capability (read scopes only) and pins access to
+    /// the given channels via [`Self::channel_ids`]. It is minted by the relay
+    /// — without any NIP-42 AUTH event — when a public-viewer channel allowlist
+    /// is configured.
+    ///
+    /// The `pubkey` is a fixed, reserved sentinel derived from a non-secret
+    /// seed. It exists only so the context has a valid identity field; it is
+    /// **never** authenticated against, looked up in `relay_members`, or used
+    /// for accounting. Callers that special-case public viewers must use the
+    /// supplied `channel_ids` directly, not a DB lookup keyed on this pubkey.
+    pub fn anonymous_viewer(channel_ids: Vec<uuid::Uuid>) -> Self {
+        AuthContext {
+            pubkey: public_viewer_sentinel_pubkey(),
+            scopes: Scope::relay_viewer_read_only(),
+            channel_ids: Some(channel_ids),
+            auth_method: AuthMethod::Nip42,
+            agent_owner_pubkey: None,
+        }
+    }
+}
+
+/// The reserved sentinel public key used by [`AuthContext::anonymous_viewer`].
+///
+/// Derived deterministically from a fixed, non-secret seed so it is a valid
+/// x-only Nostr point. It is a synthetic placeholder — never a real principal.
+fn public_viewer_sentinel_pubkey() -> nostr::PublicKey {
+    use sha2::{Digest, Sha256};
+    // Stable, namespaced, non-secret seed. Not used for signing or auth.
+    let hash: [u8; 32] = Sha256::digest(b"sprout-public-viewer-sentinel:v1").into();
+    let secret_key =
+        nostr::SecretKey::from_slice(&hash).expect("32-byte SHA-256 is a valid secret key");
+    nostr::Keys::new(secret_key).public_key()
 }
 
 /// Top-level authentication configuration, typically loaded from the relay's TOML config file.
@@ -186,6 +222,32 @@ mod tests {
         };
         assert!(ctx.has_scope(&Scope::MessagesRead));
         assert!(!ctx.has_scope(&Scope::MessagesWrite));
+    }
+
+    #[test]
+    fn anonymous_viewer_is_read_only_and_channel_scoped() {
+        let channels = vec![uuid::Uuid::new_v4(), uuid::Uuid::new_v4()];
+        let ctx = AuthContext::anonymous_viewer(channels.clone());
+
+        // Pinned to exactly the supplied channels.
+        assert_eq!(ctx.channel_ids.as_deref(), Some(channels.as_slice()));
+
+        // Read-only: has the rendering reads, has NO write/admin scopes.
+        assert!(ctx.has_scope(&Scope::MessagesRead));
+        assert!(!ctx.has_scope(&Scope::MessagesWrite));
+        assert!(!ctx.has_scope(&Scope::ChannelsWrite));
+        assert!(ctx.scopes.iter().all(|sc| sc.as_str().ends_with(":read")));
+        assert_eq!(ctx.scopes, Scope::relay_viewer_read_only());
+
+        // No owner delegation; sentinel pubkey is stable and non-degenerate.
+        assert!(ctx.agent_owner_pubkey.is_none());
+        let again = AuthContext::anonymous_viewer(vec![]);
+        assert_eq!(ctx.pubkey, again.pubkey, "sentinel pubkey must be stable");
+        assert_ne!(
+            ctx.pubkey.to_bytes(),
+            [0u8; 32],
+            "sentinel must not be the all-zero key"
+        );
     }
 
     #[tokio::test]

--- a/crates/sprout-auth/src/scope.rs
+++ b/crates/sprout-auth/src/scope.rs
@@ -112,6 +112,20 @@ impl Scope {
         ]
     }
 
+    /// Return the read-only scope set for relay viewers.
+    ///
+    /// Viewers may read channel messages, channel/user metadata, and files needed
+    /// to render allowed channel content. They intentionally receive no write,
+    /// admin, proxy, job, subscription, or repository scopes.
+    pub fn relay_viewer_read_only() -> Vec<Scope> {
+        vec![
+            Self::MessagesRead,
+            Self::ChannelsRead,
+            Self::UsersRead,
+            Self::FilesRead,
+        ]
+    }
+
     /// Return the canonical wire-format string for this scope (e.g. `"messages:read"`).
     pub fn as_str(&self) -> &str {
         match self {
@@ -233,6 +247,24 @@ mod tests {
             !scopes.contains(&Scope::AdminUsers),
             "all_non_admin() must not contain AdminUsers"
         );
+    }
+
+    #[test]
+    fn relay_viewer_read_only_contains_only_rendering_reads() {
+        let scopes = Scope::relay_viewer_read_only();
+        assert_eq!(
+            scopes,
+            vec![
+                Scope::MessagesRead,
+                Scope::ChannelsRead,
+                Scope::UsersRead,
+                Scope::FilesRead,
+            ]
+        );
+        assert!(scopes.iter().all(|scope| scope.as_str().ends_with(":read")));
+        assert!(!scopes.contains(&Scope::ReposRead));
+        assert!(!scopes.contains(&Scope::MessagesWrite));
+        assert!(!scopes.contains(&Scope::ProxySubmit));
     }
 
     #[test]

--- a/crates/sprout-db/src/channel.rs
+++ b/crates/sprout-db/src/channel.rs
@@ -572,6 +572,30 @@ pub async fn get_accessible_channel_ids(pool: &PgPool, pubkey: &[u8]) -> Result<
         .collect()
 }
 
+/// Filters a candidate set of channel IDs down to those that currently exist
+/// and are not soft-deleted. Used by the unauthenticated public-viewer path so
+/// stale config in `SPROUT_PUBLIC_VIEWER_CHANNELS` can never revive reads on a
+/// channel that has since been soft-deleted. Order and duplicates of the input
+/// are not preserved; callers treat the result as a set.
+pub async fn filter_active_channel_ids(pool: &PgPool, candidates: &[Uuid]) -> Result<Vec<Uuid>> {
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows = sqlx::query(
+        "SELECT id FROM channels WHERE id = ANY($1) AND deleted_at IS NULL ORDER BY id",
+    )
+    .bind(candidates)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|r| {
+            let id: Uuid = r.try_get("id")?;
+            Ok(id)
+        })
+        .collect()
+}
+
 /// Lists channels, optionally filtered by visibility string.
 pub async fn list_channels(pool: &PgPool, visibility: Option<&str>) -> Result<Vec<ChannelRecord>> {
     let rows = if let Some(vis) = visibility {
@@ -1197,6 +1221,61 @@ mod tests {
 
     fn random_pubkey() -> Vec<u8> {
         Keys::generate().public_key().to_bytes().to_vec()
+    }
+
+    /// `filter_active_channel_ids` keeps live channels, drops soft-deleted ones
+    /// and unknown IDs, and returns empty for empty input. This is the guard
+    /// that stops stale public-viewer config from reviving a deleted channel.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn filter_active_channel_ids_excludes_deleted_and_unknown() {
+        let pool = setup_pool().await;
+        let owner = random_pubkey();
+        ensure_user(&pool, &owner).await.expect("ensure owner");
+
+        let live = create_channel(
+            &pool,
+            "active-filter-live",
+            ChannelType::Stream,
+            ChannelVisibility::Private,
+            None,
+            &owner,
+            None,
+        )
+        .await
+        .expect("create live channel");
+
+        let deleted = create_channel(
+            &pool,
+            "active-filter-deleted",
+            ChannelType::Stream,
+            ChannelVisibility::Private,
+            None,
+            &owner,
+            None,
+        )
+        .await
+        .expect("create channel to delete");
+        soft_delete_channel(&pool, deleted.id)
+            .await
+            .expect("soft delete");
+
+        let unknown = Uuid::new_v4();
+
+        // Empty input → empty output, no query.
+        assert!(filter_active_channel_ids(&pool, &[])
+            .await
+            .expect("empty input")
+            .is_empty());
+
+        let got = filter_active_channel_ids(&pool, &[live.id, deleted.id, unknown])
+            .await
+            .expect("filter active");
+        assert_eq!(
+            got,
+            vec![live.id],
+            "only the live channel should survive; deleted and unknown dropped"
+        );
     }
 
     /// Agent owner (non-admin) can remove their own bot from a channel.

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -1364,6 +1364,31 @@ impl Db {
         relay_members::get_relay_member(&self.pool, pubkey).await
     }
 
+    /// Returns the explicit channel allowlist for a relay member.
+    pub async fn get_relay_member_channel_allowlist(&self, pubkey: &str) -> Result<Vec<Uuid>> {
+        relay_members::get_relay_member_channel_allowlist(&self.pool, pubkey).await
+    }
+
+    /// Adds a channel to a relay member's explicit allowlist.
+    pub async fn add_relay_member_channel_allowlist(
+        &self,
+        pubkey: &str,
+        channel_id: Uuid,
+        added_by: Option<&str>,
+    ) -> Result<bool> {
+        relay_members::add_relay_member_channel_allowlist(&self.pool, pubkey, channel_id, added_by)
+            .await
+    }
+
+    /// Removes a channel from a relay member's explicit allowlist.
+    pub async fn remove_relay_member_channel_allowlist(
+        &self,
+        pubkey: &str,
+        channel_id: Uuid,
+    ) -> Result<bool> {
+        relay_members::remove_relay_member_channel_allowlist(&self.pool, pubkey, channel_id).await
+    }
+
     /// Returns all relay members ordered by `created_at` ascending.
     pub async fn list_relay_members(&self) -> Result<Vec<relay_members::RelayMember>> {
         relay_members::list_relay_members(&self.pool).await

--- a/crates/sprout-db/src/lib.rs
+++ b/crates/sprout-db/src/lib.rs
@@ -442,6 +442,11 @@ impl Db {
         channel::get_accessible_channel_ids(&self.pool, pubkey).await
     }
 
+    /// Filters candidate channel IDs to those that exist and are not soft-deleted.
+    pub async fn filter_active_channel_ids(&self, candidates: &[Uuid]) -> Result<Vec<Uuid>> {
+        channel::filter_active_channel_ids(&self.pool, candidates).await
+    }
+
     /// Lists channels, optionally filtered by visibility.
     pub async fn list_channels(
         &self,

--- a/crates/sprout-db/src/relay_members.rs
+++ b/crates/sprout-db/src/relay_members.rs
@@ -5,6 +5,7 @@
 
 use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Row as _};
+use uuid::Uuid;
 
 use crate::error::Result;
 
@@ -13,7 +14,7 @@ use crate::error::Result;
 pub struct RelayMember {
     /// 64-char lowercase hex pubkey.
     pub pubkey: String,
-    /// Role: `"owner"`, `"admin"`, or `"member"`.
+    /// Role: `"owner"`, `"admin"`, `"member"`, or `"viewer"`.
     pub role: String,
     /// Hex pubkey of who added this member, or `None` for bootstrap entries.
     pub added_by: Option<String>,
@@ -53,6 +54,64 @@ pub async fn get_relay_member(pool: &PgPool, pubkey: &str) -> Result<Option<Rela
     })
     .transpose()
     .map_err(crate::error::DbError::from)
+}
+
+/// Returns the explicit channel allowlist for a relay member.
+pub async fn get_relay_member_channel_allowlist(pool: &PgPool, pubkey: &str) -> Result<Vec<Uuid>> {
+    let rows = sqlx::query(
+        "SELECT rmca.channel_id \
+         FROM relay_member_channel_allowlist rmca \
+         JOIN channels c ON c.id = rmca.channel_id AND c.deleted_at IS NULL \
+         WHERE rmca.pubkey = $1 \
+         ORDER BY rmca.created_at ASC, rmca.channel_id ASC",
+    )
+    .bind(pubkey)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|r| {
+            let id: Uuid = r.try_get("channel_id")?;
+            Ok(id)
+        })
+        .collect()
+}
+
+/// Adds a channel to a relay member's explicit allowlist.
+///
+/// Returns `true` if inserted, `false` if the grant already existed.
+pub async fn add_relay_member_channel_allowlist(
+    pool: &PgPool,
+    pubkey: &str,
+    channel_id: Uuid,
+    added_by: Option<&str>,
+) -> Result<bool> {
+    let result = sqlx::query(
+        "INSERT INTO relay_member_channel_allowlist (pubkey, channel_id, added_by) \
+         VALUES ($1, $2, $3) ON CONFLICT (pubkey, channel_id) DO NOTHING",
+    )
+    .bind(pubkey)
+    .bind(channel_id)
+    .bind(added_by)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Removes a channel from a relay member's explicit allowlist.
+pub async fn remove_relay_member_channel_allowlist(
+    pool: &PgPool,
+    pubkey: &str,
+    channel_id: Uuid,
+) -> Result<bool> {
+    let result = sqlx::query(
+        "DELETE FROM relay_member_channel_allowlist WHERE pubkey = $1 AND channel_id = $2",
+    )
+    .bind(pubkey)
+    .bind(channel_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
 }
 
 /// Returns all relay members ordered by `created_at` ascending.

--- a/crates/sprout-relay/src/api/bridge.rs
+++ b/crates/sprout-relay/src/api/bridge.rs
@@ -94,6 +94,44 @@ fn check_nip98_replay(
     Ok(())
 }
 
+/// Enforce relay membership and return any viewer channel restriction.
+///
+/// `None` means the authenticated caller has the normal unrestricted relay member
+/// profile. `Some(ids)` means the caller is a read-only viewer and every bridge
+/// read/write path must be constrained to those explicit channels.
+async fn bridge_viewer_channel_ids(
+    state: &AppState,
+    pubkey_bytes: &[u8],
+    auth_tag: Option<&str>,
+) -> Result<Option<Vec<uuid::Uuid>>, (StatusCode, Json<Value>)> {
+    match super::relay_members::check_relay_membership(state, pubkey_bytes, auth_tag).await {
+        Ok(super::relay_members::MembershipDecision::OpenRelay)
+        | Ok(super::relay_members::MembershipDecision::Member)
+        | Ok(super::relay_members::MembershipDecision::ViaOwner(_)) => Ok(None),
+        Ok(super::relay_members::MembershipDecision::Viewer { channel_ids })
+        | Ok(super::relay_members::MembershipDecision::ViaViewerOwner { channel_ids, .. }) => {
+            Ok(Some(channel_ids))
+        }
+        Ok(super::relay_members::MembershipDecision::Denied) => Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "relay_membership_required",
+                "message": "You must be a relay member to access this relay"
+            })),
+        )),
+        Err(e) => Err(internal_error(&e)),
+    }
+}
+
+fn apply_viewer_channel_scope(
+    accessible_channels: &mut Vec<uuid::Uuid>,
+    viewer_channel_ids: Option<&[uuid::Uuid]>,
+) {
+    if let Some(allowed) = viewer_channel_ids {
+        accessible_channels.retain(|channel_id| allowed.contains(channel_id));
+    }
+}
+
 /// Reconstruct the canonical URL for NIP-98 verification from the relay config.
 fn canonical_url(relay_url: &str, path: &str) -> String {
     let base = relay_url
@@ -181,16 +219,20 @@ pub async fn submit_event(
     check_nip98_replay(&state, event_id_bytes)?;
     let pubkey_bytes = pubkey.to_bytes().to_vec();
 
-    // Enforce relay membership (with NIP-OA fallback via x-auth-tag header).
+    // Enforce relay membership and derive any viewer restriction.
     let auth_tag = headers.get("x-auth-tag").and_then(|v| v.to_str().ok());
-    super::relay_members::enforce_relay_membership(&state, &pubkey_bytes, auth_tag).await?;
+    let viewer_channel_ids = bridge_viewer_channel_ids(&state, &pubkey_bytes, auth_tag).await?;
 
     let event: nostr::Event = serde_json::from_slice(&body)
         .map_err(|e| api_error(StatusCode::BAD_REQUEST, &format!("invalid event JSON: {e}")))?;
 
     let auth = IngestAuth::Http {
         pubkey,
-        scopes: sprout_auth::Scope::all_known(), // Pure Nostr: full scopes, channel access via membership
+        scopes: viewer_channel_ids
+            .as_ref()
+            .map(|_| sprout_auth::Scope::relay_viewer_read_only())
+            .unwrap_or_else(sprout_auth::Scope::all_known),
+        channel_ids: viewer_channel_ids,
         auth_method: crate::handlers::ingest::HttpAuthMethod::Nip98,
     };
 
@@ -230,7 +272,7 @@ pub async fn query_events(
     let pubkey_bytes = pubkey.to_bytes().to_vec();
 
     let auth_tag = headers.get("x-auth-tag").and_then(|v| v.to_str().ok());
-    super::relay_members::enforce_relay_membership(&state, &pubkey_bytes, auth_tag).await?;
+    let viewer_channel_ids = bridge_viewer_channel_ids(&state, &pubkey_bytes, auth_tag).await?;
 
     // Two-pass parse: preserve raw JSON for custom extension fields (before_id,
     // depth_limit, feed_types) that nostr::Filter silently drops.
@@ -259,14 +301,23 @@ pub async fn query_events(
     }
 
     // Get channels this user can access — same enforcement as WS REQ handler.
-    let accessible_channels = state
+    let mut accessible_channels = state
         .get_accessible_channel_ids_cached(&pubkey_bytes)
         .await
         .map_err(|e| internal_error(&format!("channel access lookup: {e}")))?;
+    apply_viewer_channel_scope(&mut accessible_channels, viewer_channel_ids.as_deref());
+
+    let restricted_to_channel_allowlist = viewer_channel_ids.is_some();
 
     // ── NIP-50 search: route to Typesense if any filter has a `search` field ──
     if filters.iter().any(|f| f.search.is_some()) {
-        return handle_bridge_search(&state, &filters, &accessible_channels).await;
+        return handle_bridge_search(
+            &state,
+            &filters,
+            &accessible_channels,
+            !restricted_to_channel_allowlist,
+        )
+        .await;
     }
 
     // ── Presence: synthesize kind:20001 from Redis (ephemeral, never in DB) ──
@@ -279,6 +330,16 @@ pub async fn query_events(
 
     // ── feed_types: route to dedicated feed query functions ──
     for (idx, (raw, filter)) in raw_filters.iter().zip(filters.iter()).enumerate() {
+        if !crate::handlers::req::filter_has_allowed_channel_scope(
+            filter,
+            &accessible_channels,
+            restricted_to_channel_allowlist,
+        ) {
+            return Err(api_error(
+                StatusCode::FORBIDDEN,
+                "restricted: read-only viewers must scope query filters to allowed channels",
+            ));
+        }
         let feed_types = match extract_feed_types(raw) {
             Some(t) => t,
             None => continue,
@@ -409,6 +470,17 @@ pub async fn query_events(
             continue;
         }
 
+        if !crate::handlers::req::filter_has_allowed_channel_scope(
+            filter,
+            &accessible_channels,
+            restricted_to_channel_allowlist,
+        ) {
+            return Err(api_error(
+                StatusCode::FORBIDDEN,
+                "restricted: read-only viewers must scope query filters to allowed channels",
+            ));
+        }
+
         if let Some(ch_id) = extract_channel_from_filter(filter) {
             if !accessible_channels.contains(&ch_id) {
                 continue;
@@ -475,7 +547,7 @@ pub async fn count_events(
     let pubkey_bytes = pubkey.to_bytes().to_vec();
 
     let auth_tag = headers.get("x-auth-tag").and_then(|v| v.to_str().ok());
-    super::relay_members::enforce_relay_membership(&state, &pubkey_bytes, auth_tag).await?;
+    let viewer_channel_ids = bridge_viewer_channel_ids(&state, &pubkey_bytes, auth_tag).await?;
 
     let filters: Vec<nostr::Filter> = serde_json::from_slice(&body)
         .map_err(|e| api_error(StatusCode::BAD_REQUEST, &format!("invalid filters: {e}")))?;
@@ -496,13 +568,26 @@ pub async fn count_events(
     }
 
     // Get channels this user can access.
-    let accessible_channels = state
+    let mut accessible_channels = state
         .get_accessible_channel_ids_cached(&pubkey_bytes)
         .await
         .map_err(|e| internal_error(&format!("channel access lookup: {e}")))?;
+    apply_viewer_channel_scope(&mut accessible_channels, viewer_channel_ids.as_deref());
+    let restricted_to_channel_allowlist = viewer_channel_ids.is_some();
 
     let mut total: u64 = 0;
     for filter in &filters {
+        if !crate::handlers::req::filter_has_allowed_channel_scope(
+            filter,
+            &accessible_channels,
+            restricted_to_channel_allowlist,
+        ) {
+            return Err(api_error(
+                StatusCode::FORBIDDEN,
+                "restricted: read-only viewers must scope count filters to allowed channels",
+            ));
+        }
+
         // If filter targets a specific channel, verify access.
         if let Some(ch_id) = extract_channel_from_filter(filter) {
             if !accessible_channels.contains(&ch_id) {
@@ -614,11 +699,11 @@ async fn handle_bridge_search(
     state: &AppState,
     filters: &[nostr::Filter],
     accessible_channels: &[uuid::Uuid],
+    include_global: bool,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    // Bridge always includes global (non-channel) events — same as WS with full scopes.
     let channel_scope = match crate::handlers::req::build_search_channel_scope_filter(
         accessible_channels,
-        true, // include_global
+        include_global,
     ) {
         Some(f) => f,
         None => return Ok(Json(Value::Array(Vec::new()))),

--- a/crates/sprout-relay/src/api/bridge.rs
+++ b/crates/sprout-relay/src/api/bridge.rs
@@ -321,8 +321,13 @@ pub async fn query_events(
     }
 
     // ── Presence: synthesize kind:20001 from Redis (ephemeral, never in DB) ──
-    if let Some(presence_events) = synthesize_presence(&state, &filters).await {
-        return Ok(Json(Value::Array(presence_events)));
+    // Presence is keyed by pubkey, not channel, so it cannot be channel-scoped.
+    // Restricted viewers must fail closed: skip synthesis and fall through to the
+    // per-filter scope gate, which rejects the no-`#h` presence filter as FORBIDDEN.
+    if !restricted_to_channel_allowlist {
+        if let Some(presence_events) = synthesize_presence(&state, &filters).await {
+            return Ok(Json(Value::Array(presence_events)));
+        }
     }
 
     let mut events: Vec<Value> = Vec::new();

--- a/crates/sprout-relay/src/api/git/transport.rs
+++ b/crates/sprout-relay/src/api/git/transport.rs
@@ -174,15 +174,21 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for GitAuth {
         // The ±60s timestamp window + URL scoping + HTTPS transport provide sufficient
         // replay protection for v1. Per-request signing requires protocol changes.
 
-        // Relay membership gate (NIP-43).
+        // Relay membership gate (NIP-43). Viewer identities have no repo scopes.
         let auth_tag = parts
             .headers
             .get("x-auth-tag")
             .and_then(|v| v.to_str().ok());
-        if crate::api::relay_members::enforce_relay_membership(state, pubkey.as_bytes(), auth_tag)
-            .await
-            .is_err()
-        {
+        let membership =
+            crate::api::relay_members::check_relay_membership(state, pubkey.as_bytes(), auth_tag)
+                .await;
+        let allowed = matches!(
+            membership,
+            Ok(crate::api::relay_members::MembershipDecision::OpenRelay)
+                | Ok(crate::api::relay_members::MembershipDecision::Member)
+                | Ok(crate::api::relay_members::MembershipDecision::ViaOwner(_))
+        );
+        if !allowed {
             warn!(pubkey = %pubkey.to_hex(), "git: relay membership denied");
             return Err((StatusCode::FORBIDDEN, "restricted: not a relay member").into_response());
         }

--- a/crates/sprout-relay/src/api/media.rs
+++ b/crates/sprout-relay/src/api/media.rs
@@ -86,15 +86,24 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
         sprout_auth::require_scope(&scopes, Scope::FilesWrite)
             .map_err(|_| MediaError::InsufficientScope)?;
 
-        // 5. Relay membership gate (NIP-43).
+        // 5. Relay membership gate (NIP-43). Viewer identities may read media
+        // for allowlisted channels via event delivery, but cannot upload.
         let auth_tag = headers.get("x-auth-tag").and_then(|v| v.to_str().ok());
-        crate::api::relay_members::enforce_relay_membership(
+        match crate::api::relay_members::check_relay_membership(
             state,
             auth_event.pubkey.as_bytes(),
             auth_tag,
         )
         .await
-        .map_err(|_| MediaError::RelayMembershipRequired)?;
+        {
+            Ok(crate::api::relay_members::MembershipDecision::OpenRelay)
+            | Ok(crate::api::relay_members::MembershipDecision::Member)
+            | Ok(crate::api::relay_members::MembershipDecision::ViaOwner(_)) => {}
+            Ok(crate::api::relay_members::MembershipDecision::Viewer { .. })
+            | Ok(crate::api::relay_members::MembershipDecision::ViaViewerOwner { .. })
+            | Ok(crate::api::relay_members::MembershipDecision::Denied)
+            | Err(_) => return Err(MediaError::RelayMembershipRequired),
+        }
 
         Ok(AuthenticatedUpload { auth_event, scopes })
     }

--- a/crates/sprout-relay/src/api/mod.rs
+++ b/crates/sprout-relay/src/api/mod.rs
@@ -45,8 +45,20 @@ pub mod relay_members {
         OpenRelay,
         /// Caller is directly present in `relay_members`.
         Member,
+        /// Caller is directly present in `relay_members` with the read-only viewer role.
+        Viewer {
+            /// Explicit channel allowlist for the viewer.
+            channel_ids: Vec<uuid::Uuid>,
+        },
         /// Caller is admitted through a NIP-OA owner that is a relay member.
         ViaOwner(nostr::PublicKey),
+        /// Caller is admitted through a NIP-OA owner with the read-only viewer role.
+        ViaViewerOwner {
+            /// The verified NIP-OA owner pubkey.
+            owner: nostr::PublicKey,
+            /// Explicit channel allowlist inherited from the owner.
+            channel_ids: Vec<uuid::Uuid>,
+        },
         /// Caller is not admitted.
         Denied,
     }
@@ -62,12 +74,20 @@ pub mod relay_members {
         }
 
         let pubkey_hex = hex::encode(pubkey_bytes);
-        let is_member = state
+        let member = state
             .db
-            .is_relay_member(&pubkey_hex)
+            .get_relay_member(&pubkey_hex)
             .await
             .map_err(|e| format!("relay membership check failed: {e}"))?;
-        if is_member {
+        if let Some(member) = member {
+            if member.role == "viewer" {
+                let channel_ids = state
+                    .db
+                    .get_relay_member_channel_allowlist(&pubkey_hex)
+                    .await
+                    .map_err(|e| format!("relay viewer allowlist lookup failed: {e}"))?;
+                return Ok(MembershipDecision::Viewer { channel_ids });
+            }
             return Ok(MembershipDecision::Member);
         }
 
@@ -79,16 +99,29 @@ pub mod relay_members {
                 match sprout_sdk::nip_oa::verify_auth_tag(tag_json, &agent_pubkey) {
                     Ok(owner_pubkey) => {
                         let owner_hex = owner_pubkey.to_hex();
-                        let owner_is_member =
-                            state.db.is_relay_member(&owner_hex).await.map_err(|e| {
+                        let owner_member =
+                            state.db.get_relay_member(&owner_hex).await.map_err(|e| {
                                 format!("relay membership check (owner) failed: {e}")
                             })?;
-                        if owner_is_member {
+                        if let Some(owner_member) = owner_member {
                             debug!(
                                 agent = %pubkey_hex,
                                 owner = %owner_hex,
                                 "NIP-OA membership granted via owner"
                             );
+                            if owner_member.role == "viewer" {
+                                let channel_ids = state
+                                    .db
+                                    .get_relay_member_channel_allowlist(&owner_hex)
+                                    .await
+                                    .map_err(|e| {
+                                        format!("relay viewer allowlist lookup (owner) failed: {e}")
+                                    })?;
+                                return Ok(MembershipDecision::ViaViewerOwner {
+                                    owner: owner_pubkey,
+                                    channel_ids,
+                                });
+                            }
                             return Ok(MembershipDecision::ViaOwner(owner_pubkey));
                         }
                     }
@@ -100,6 +133,25 @@ pub mod relay_members {
         }
 
         Ok(MembershipDecision::Denied)
+    }
+
+    /// Build the restricted scopes/channel allowlist implied by a membership decision.
+    ///
+    /// Returns `(agent_owner_pubkey, channel_ids)`. The caller applies read-only
+    /// scopes when `channel_ids` is `Some`; `None` means an unrestricted relay
+    /// member/open-relay context.
+    pub fn relay_access_profile_from_decision(
+        decision: MembershipDecision,
+    ) -> (Option<nostr::PublicKey>, Option<Vec<uuid::Uuid>>) {
+        match decision {
+            MembershipDecision::OpenRelay | MembershipDecision::Member => (None, None),
+            MembershipDecision::Viewer { channel_ids } => (None, Some(channel_ids)),
+            MembershipDecision::ViaOwner(owner) => (Some(owner), None),
+            MembershipDecision::ViaViewerOwner { owner, channel_ids } => {
+                (Some(owner), Some(channel_ids))
+            }
+            MembershipDecision::Denied => (None, None),
+        }
     }
 
     /// Enforce relay membership for a pubkey, with NIP-OA agent delegation fallback.
@@ -120,7 +172,9 @@ pub mod relay_members {
     ) -> Result<Option<nostr::PublicKey>, (StatusCode, Json<serde_json::Value>)> {
         match check_relay_membership(state, pubkey_bytes, auth_tag_header).await {
             Ok(MembershipDecision::OpenRelay) | Ok(MembershipDecision::Member) => Ok(None),
+            Ok(MembershipDecision::Viewer { .. }) => Ok(None),
             Ok(MembershipDecision::ViaOwner(owner)) => Ok(Some(owner)),
+            Ok(MembershipDecision::ViaViewerOwner { owner, .. }) => Ok(Some(owner)),
             Ok(MembershipDecision::Denied) => Err((
                 StatusCode::FORBIDDEN,
                 Json(serde_json::json!({

--- a/crates/sprout-relay/src/api/mod.rs
+++ b/crates/sprout-relay/src/api/mod.rs
@@ -33,7 +33,6 @@ pub(crate) fn not_found(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
 /// Moved here from the deleted `relay_members` module. Called by `media.rs`, `bridge.rs`,
 /// `git/transport.rs`, and `audio/handler.rs`.
 pub mod relay_members {
-    use axum::{http::StatusCode, response::Json};
     use tracing::{debug, info};
 
     use crate::state::AppState;
@@ -151,41 +150,6 @@ pub mod relay_members {
                 (Some(owner), Some(channel_ids))
             }
             MembershipDecision::Denied => (None, None),
-        }
-    }
-
-    /// Enforce relay membership for a pubkey, with NIP-OA agent delegation fallback.
-    ///
-    /// Returns `Ok(Some(owner_pubkey))` when the agent is not a direct member but
-    /// its NIP-OA owner *is* — access is granted via delegation.
-    ///
-    /// On open relays (`require_relay_membership = false`), returns `Ok(None)`
-    /// immediately — no membership check is performed. Callers that need NIP-OA
-    /// owner extraction on open relays should call [`extract_nip_oa_owner`] directly.
-    ///
-    /// Returns `Ok(None)` when the caller is a direct member (closed relay) or when
-    /// no NIP-OA tag is present/applicable (open relay without auth tag).
-    pub async fn enforce_relay_membership(
-        state: &AppState,
-        pubkey_bytes: &[u8],
-        auth_tag_header: Option<&str>,
-    ) -> Result<Option<nostr::PublicKey>, (StatusCode, Json<serde_json::Value>)> {
-        match check_relay_membership(state, pubkey_bytes, auth_tag_header).await {
-            Ok(MembershipDecision::OpenRelay) | Ok(MembershipDecision::Member) => Ok(None),
-            Ok(MembershipDecision::Viewer { .. }) => Ok(None),
-            Ok(MembershipDecision::ViaOwner(owner)) => Ok(Some(owner)),
-            Ok(MembershipDecision::ViaViewerOwner { owner, .. }) => Ok(Some(owner)),
-            Ok(MembershipDecision::Denied) => Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": "relay_membership_required",
-                    "message": "You must be a relay member to access this relay"
-                })),
-            )),
-            Err(e) => {
-                tracing::error!("relay membership check errored: {e}");
-                Err(super::internal_error(&e))
-            }
         }
     }
 

--- a/crates/sprout-relay/src/api/mod.rs
+++ b/crates/sprout-relay/src/api/mod.rs
@@ -207,6 +207,130 @@ pub mod relay_members {
             assert_eq!(result, None);
         }
 
+        async fn test_pool() -> Option<sqlx::PgPool> {
+            let url = std::env::var("DATABASE_URL")
+                .unwrap_or_else(|_| "postgres://sprout:sprout_dev@localhost:5432/sprout".into());
+            sqlx::PgPool::connect(&url).await.ok()
+        }
+
+        async fn test_state(pool: sqlx::PgPool) -> Option<crate::state::AppState> {
+            let db = sprout_db::Db::from_pool(pool.clone());
+            let mut config = crate::config::Config::from_env().ok()?;
+            config.require_relay_membership = true;
+            config.allow_nip_oa_auth = true;
+            config.redis_url = "redis://127.0.0.1:1".to_string();
+
+            let redis_pool = deadpool_redis::Config::from_url(&config.redis_url)
+                .create_pool(Some(deadpool_redis::Runtime::Tokio1))
+                .ok()?;
+            let pubsub = std::sync::Arc::new(
+                sprout_pubsub::PubSubManager::new(&config.redis_url, redis_pool.clone())
+                    .await
+                    .ok()?,
+            );
+            let audit = sprout_audit::AuditService::new(pool);
+            let auth = sprout_auth::AuthService::new(config.auth.clone());
+            let search = sprout_search::SearchService::new(sprout_search::SearchConfig {
+                url: config.typesense_url.clone(),
+                api_key: config.typesense_key.clone(),
+                collection: "events".to_string(),
+            });
+            let workflow_engine = std::sync::Arc::new(sprout_workflow::WorkflowEngine::new(
+                db.clone(),
+                sprout_workflow::WorkflowConfig::default(),
+            ));
+            let media_storage = sprout_media::MediaStorage::new(&config.media).ok()?;
+            let (state, _audit_shutdown) = crate::state::AppState::new(
+                config,
+                db,
+                redis_pool,
+                audit,
+                pubsub,
+                auth,
+                search,
+                workflow_engine,
+                nostr::Keys::generate(),
+                media_storage,
+            );
+            Some(state)
+        }
+
+        #[tokio::test]
+        async fn viewer_membership_admission_loads_db_backed_channel_allowlist() {
+            let Some(pool) = test_pool().await else {
+                eprintln!("skipping DB-backed viewer admission test: Postgres unavailable");
+                return;
+            };
+
+            let owner_keys = Keys::generate();
+            let viewer_keys = Keys::generate();
+            let agent_keys = Keys::generate();
+            let viewer_hex = viewer_keys.public_key().to_hex();
+            let owner_hex = owner_keys.public_key().to_hex();
+            let channel_owner = Keys::generate().public_key().to_bytes();
+
+            sprout_db::user::ensure_user(&pool, &channel_owner)
+                .await
+                .expect("ensure channel owner");
+            let channel = sprout_db::channel::create_channel(
+                &pool,
+                &format!("viewer-admission-{}", uuid::Uuid::new_v4()),
+                sprout_db::channel::ChannelType::Stream,
+                sprout_db::channel::ChannelVisibility::Private,
+                None,
+                &channel_owner,
+                None,
+            )
+            .await
+            .expect("create allowlisted channel");
+
+            sprout_db::relay_members::add_relay_member(
+                &pool,
+                &viewer_hex,
+                "viewer",
+                Some(&owner_hex),
+            )
+            .await
+            .expect("insert viewer relay member");
+            sprout_db::relay_members::add_relay_member_channel_allowlist(
+                &pool,
+                &viewer_hex,
+                channel.id,
+                Some(&owner_hex),
+            )
+            .await
+            .expect("insert viewer channel allowlist");
+
+            let state = test_state(pool.clone()).await.expect("build test state");
+
+            match check_relay_membership(&state, viewer_keys.public_key().as_bytes(), None)
+                .await
+                .expect("check direct viewer")
+            {
+                MembershipDecision::Viewer { channel_ids } => {
+                    assert_eq!(channel_ids, vec![channel.id]);
+                }
+                other => panic!("expected direct viewer decision, got {other:?}"),
+            }
+
+            let auth_tag = compute_auth_tag(&viewer_keys, &agent_keys.public_key(), "")
+                .expect("compute viewer owner auth tag");
+            match check_relay_membership(
+                &state,
+                agent_keys.public_key().as_bytes(),
+                Some(&auth_tag),
+            )
+            .await
+            .expect("check viewer owner delegation")
+            {
+                MembershipDecision::ViaViewerOwner { owner, channel_ids } => {
+                    assert_eq!(owner, viewer_keys.public_key());
+                    assert_eq!(channel_ids, vec![channel.id]);
+                }
+                other => panic!("expected viewer-owner decision, got {other:?}"),
+            }
+        }
+
         /// Invalid auth tag → returns None.
         #[test]
         fn invalid_auth_tag_returns_none() {

--- a/crates/sprout-relay/src/audio/handler.rs
+++ b/crates/sprout-relay/src/audio/handler.rs
@@ -159,20 +159,50 @@ async fn handle_audio_connection(socket: WebSocket, state: Arc<AppState>, channe
     let pubkey_hex = pubkey.to_hex();
     let pubkey_bytes = pubkey.to_bytes().to_vec();
     let parent_channel_id = auth_msg.parent_channel_id;
+    let viewer_scope_channel_id = parent_channel_id.unwrap_or(channel_id);
 
     // ── Relay membership gate (with NIP-OA fallback) ────────────────────────────
-    if crate::api::relay_members::enforce_relay_membership(
+    let membership_decision = match crate::api::relay_members::check_relay_membership(
         &state,
         pubkey.as_bytes(),
         auth_tag_json.as_deref(),
     )
     .await
-    .is_err()
     {
-        warn!(channel_id = %channel_id, pubkey = %pubkey_hex, "audio: relay membership denied");
+        Ok(crate::api::relay_members::MembershipDecision::Denied) => {
+            warn!(channel_id = %channel_id, pubkey = %pubkey_hex, "audio: relay membership denied");
+            let _ = ws_send
+                .send(WsMessage::Text(
+                    serde_json::json!({"type": "error", "message": "restricted: not a relay member"})
+                        .to_string()
+                        .into(),
+                ))
+                .await;
+            return;
+        }
+        Ok(decision) => decision,
+        Err(e) => {
+            warn!(channel_id = %channel_id, pubkey = %pubkey_hex, error = %e, "audio: relay membership check failed");
+            let _ = ws_send
+                .send(WsMessage::Text(
+                    serde_json::json!({"type": "error", "message": "restricted: not a relay member"})
+                        .to_string()
+                        .into(),
+                ))
+                .await;
+            return;
+        }
+    };
+    let (_, viewer_channel_ids) =
+        crate::api::relay_members::relay_access_profile_from_decision(membership_decision);
+    if viewer_channel_ids
+        .as_ref()
+        .is_some_and(|ids| !ids.contains(&viewer_scope_channel_id))
+    {
+        warn!(channel_id = %channel_id, pubkey = %pubkey_hex, "audio: viewer not allowed for parent channel");
         let _ = ws_send
             .send(WsMessage::Text(
-                serde_json::json!({"type": "error", "message": "restricted: not a relay member"})
+                serde_json::json!({"type": "error", "message": "restricted: not a channel member"})
                     .to_string()
                     .into(),
             ))

--- a/crates/sprout-relay/src/config.rs
+++ b/crates/sprout-relay/src/config.rs
@@ -89,6 +89,20 @@ pub struct Config {
     /// Default: `false`. Set via `SPROUT_ALLOW_NIP_OA_AUTH=true`.
     pub allow_nip_oa_auth: bool,
 
+    /// Channels that unauthenticated ("public") viewers may read.
+    ///
+    /// When non-empty, a WebSocket connection that has not completed NIP-42
+    /// AUTH is granted a synthetic read-only viewer context scoped to exactly
+    /// these channel IDs (read scopes only, no write). Empty (default) means
+    /// public read is disabled and unauthenticated REQ/COUNT are rejected as
+    /// before.
+    ///
+    /// This intentionally opts the listed channels *out* of the NIP-42 gate —
+    /// they become world-readable. Set via `SPROUT_PUBLIC_VIEWER_CHANNELS`
+    /// (comma-separated channel UUIDs). Per-IP abuse protection is assumed to
+    /// be handled by an upstream reverse proxy.
+    pub public_viewer_channel_ids: Vec<uuid::Uuid>,
+
     /// Media storage configuration (S3/MinIO).
     pub media: sprout_media::MediaConfig,
 
@@ -174,6 +188,25 @@ impl Config {
         let allow_nip_oa_auth = std::env::var("SPROUT_ALLOW_NIP_OA_AUTH")
             .map(|v| v == "true" || v == "1")
             .unwrap_or(false);
+
+        // Public (unauthenticated) viewer channel allowlist. Comma-separated
+        // channel UUIDs; malformed entries are rejected loudly (fail-closed:
+        // a typo must not silently widen or narrow public exposure).
+        let public_viewer_channel_ids = match std::env::var("SPROUT_PUBLIC_VIEWER_CHANNELS") {
+            Ok(raw) => raw
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| {
+                    uuid::Uuid::parse_str(s).map_err(|e| {
+                        ConfigError::InvalidValue(format!(
+                            "SPROUT_PUBLIC_VIEWER_CHANNELS: invalid channel UUID {s:?}: {e}"
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            Err(_) => Vec::new(),
+        };
 
         // Note: intentionally not prefixed with SPROUT_ — this is a relay-identity
         // config that may be shared across multiple services (e.g., ACP agent).
@@ -375,6 +408,7 @@ impl Config {
             require_relay_membership,
             relay_owner_pubkey,
             allow_nip_oa_auth,
+            public_viewer_channel_ids,
             media,
             ephemeral_ttl_override,
             git_repo_path,
@@ -430,6 +464,41 @@ mod tests {
         let result = Config::from_env();
         std::env::remove_var("SPROUT_BIND_ADDR");
         assert!(matches!(result, Err(ConfigError::InvalidBindAddr(_))));
+    }
+
+    #[test]
+    fn public_viewer_channels_default_empty() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        std::env::remove_var("SPROUT_PUBLIC_VIEWER_CHANNELS");
+        let config = Config::from_env().expect("default config");
+        assert!(
+            config.public_viewer_channel_ids.is_empty(),
+            "public viewer must be disabled by default"
+        );
+    }
+
+    #[test]
+    fn public_viewer_channels_parse_valid_uuids() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let a = uuid::Uuid::new_v4();
+        let b = uuid::Uuid::new_v4();
+        // Mixed spacing + a trailing empty entry must be tolerated.
+        std::env::set_var("SPROUT_PUBLIC_VIEWER_CHANNELS", format!("{a}, {b} ,"));
+        let config = Config::from_env().expect("config");
+        std::env::remove_var("SPROUT_PUBLIC_VIEWER_CHANNELS");
+        assert_eq!(config.public_viewer_channel_ids, vec![a, b]);
+    }
+
+    #[test]
+    fn public_viewer_channels_reject_malformed() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        std::env::set_var("SPROUT_PUBLIC_VIEWER_CHANNELS", "not-a-uuid");
+        let result = Config::from_env();
+        std::env::remove_var("SPROUT_PUBLIC_VIEWER_CHANNELS");
+        assert!(
+            matches!(result, Err(ConfigError::InvalidValue(ref m)) if m.contains("SPROUT_PUBLIC_VIEWER_CHANNELS")),
+            "malformed UUID must fail-closed, got {result:?}"
+        );
     }
 
     #[test]

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -110,16 +110,28 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
             }
 
             // Relay membership gate — uses the shared helper with NIP-OA fallback.
-            let nip_oa_owner = match crate::api::relay_members::enforce_relay_membership(
+            let membership_decision = match crate::api::relay_members::check_relay_membership(
                 &state,
                 pubkey.as_bytes(),
                 auth_tag_json.as_deref(),
             )
             .await
             {
-                Ok(owner) => owner,
+                Ok(crate::api::relay_members::MembershipDecision::Denied) => {
+                    warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), "not a relay member");
+                    metrics::counter!("sprout_auth_failures_total", "reason" => "not_relay_member")
+                        .increment(1);
+                    *conn.auth_state.write().await = AuthState::Failed;
+                    conn.send(RelayMessage::ok(
+                        &event_id_hex,
+                        false,
+                        "restricted: not a relay member",
+                    ));
+                    return;
+                }
+                Ok(decision) => decision,
                 Err(e) => {
-                    warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), error = ?e, "not a relay member");
+                    warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), error = %e, "relay membership check failed");
                     metrics::counter!("sprout_auth_failures_total", "reason" => "not_relay_member")
                         .increment(1);
                     *conn.auth_state.write().await = AuthState::Failed;
@@ -131,6 +143,12 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     return;
                 }
             };
+            let (nip_oa_owner, viewer_channel_ids) =
+                crate::api::relay_members::relay_access_profile_from_decision(membership_decision);
+            if let Some(channel_ids) = viewer_channel_ids {
+                auth_ctx.scopes = sprout_auth::Scope::relay_viewer_read_only();
+                auth_ctx.channel_ids = Some(channel_ids);
+            }
 
             // Open relay NIP-OA backfill: extract owner for agent→owner DB mapping
             // (needed for observer frame auth). Only runs on open relays — on closed

--- a/crates/sprout-relay/src/handlers/auth.rs
+++ b/crates/sprout-relay/src/handlers/auth.rs
@@ -1,7 +1,7 @@
 //! NIP-42 AUTH handler — verify challenge response, transition auth state.
 //!
 //! Relay membership enforcement uses the shared
-//! [`crate::api::relay_members::enforce_relay_membership`] helper, which supports
+//! [`crate::api::relay_members::check_relay_membership`] helper, which supports
 //! NIP-OA owner-delegation fallback on closed relays. On open relays, the auth
 //! handler calls [`crate::api::relay_members::extract_nip_oa_owner`] directly to
 //! extract the owner pubkey for agent→owner backfill (observer frame auth).
@@ -152,7 +152,7 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
 
             // Open relay NIP-OA backfill: extract owner for agent→owner DB mapping
             // (needed for observer frame auth). Only runs on open relays — on closed
-            // relays, enforce_relay_membership already handles NIP-OA delegation.
+            // relays, check_relay_membership already handles NIP-OA delegation.
             // No feature flag needed: NIP-OA is cryptographically self-proving.
             let nip_oa_owner = nip_oa_owner.or_else(|| {
                 if !state.config.require_relay_membership && auth_tag_json.is_some() {

--- a/crates/sprout-relay/src/handlers/count.rs
+++ b/crates/sprout-relay/src/handlers/count.rs
@@ -30,10 +30,12 @@ pub async fn handle_count(
     state: Arc<AppState>,
 ) {
     // Require auth
-    let pubkey_bytes = {
+    let (pubkey_bytes, token_channel_ids) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
-            AuthState::Authenticated(ctx) => ctx.pubkey.to_bytes().to_vec(),
+            AuthState::Authenticated(ctx) => {
+                (ctx.pubkey.to_bytes().to_vec(), ctx.channel_ids.clone())
+            }
             _ => {
                 conn.send(RelayMessage::closed(
                     &sub_id,
@@ -63,7 +65,8 @@ pub async fn handle_count(
     }
 
     // Get channels this user can access — same enforcement as WS REQ handler.
-    let accessible_channels = match state.get_accessible_channel_ids_cached(&pubkey_bytes).await {
+    let mut accessible_channels = match state.get_accessible_channel_ids_cached(&pubkey_bytes).await
+    {
         Ok(ids) => ids,
         Err(e) => {
             warn!(sub_id = %sub_id, "Failed to get accessible channels: {e}");
@@ -71,10 +74,25 @@ pub async fn handle_count(
             return;
         }
     };
+    if let Some(allowed) = token_channel_ids.as_deref() {
+        accessible_channels.retain(|channel_id| allowed.contains(channel_id));
+    }
+    let restricted_to_channel_allowlist = token_channel_ids.is_some();
 
     // For each filter, count matching events with channel access enforcement.
     let mut total: u64 = 0;
     for filter in &filters {
+        if !super::req::filter_has_allowed_channel_scope(
+            filter,
+            &accessible_channels,
+            restricted_to_channel_allowlist,
+        ) {
+            conn.send(RelayMessage::closed(
+                &sub_id,
+                "restricted: read-only viewers must scope COUNT filters to allowed channels",
+            ));
+            return;
+        }
         if let Some(ch_id) = extract_channel_from_filter(filter) {
             // Filter targets a specific channel — verify access.
             if !accessible_channels.contains(&ch_id) {

--- a/crates/sprout-relay/src/handlers/count.rs
+++ b/crates/sprout-relay/src/handlers/count.rs
@@ -30,11 +30,25 @@ pub async fn handle_count(
     state: Arc<AppState>,
 ) {
     // Require auth
-    let (pubkey_bytes, token_channel_ids) = {
+    let (pubkey_bytes, token_channel_ids, is_public_viewer) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
-            AuthState::Authenticated(ctx) => {
-                (ctx.pubkey.to_bytes().to_vec(), ctx.channel_ids.clone())
+            AuthState::Authenticated(ctx) => (
+                ctx.pubkey.to_bytes().to_vec(),
+                ctx.channel_ids.clone(),
+                false,
+            ),
+            // Unauthenticated public viewer: mint a synthetic read-only viewer
+            // scoped to the configured public channel allowlist, if any.
+            _ if !state.config.public_viewer_channel_ids.is_empty() => {
+                let ctx = sprout_auth::AuthContext::anonymous_viewer(
+                    state.config.public_viewer_channel_ids.clone(),
+                );
+                (
+                    ctx.pubkey.to_bytes().to_vec(),
+                    ctx.channel_ids.clone(),
+                    true,
+                )
             }
             _ => {
                 conn.send(RelayMessage::closed(
@@ -65,13 +79,18 @@ pub async fn handle_count(
     }
 
     // Get channels this user can access — same enforcement as WS REQ handler.
-    let mut accessible_channels = match state.get_accessible_channel_ids_cached(&pubkey_bytes).await
-    {
-        Ok(ids) => ids,
-        Err(e) => {
-            warn!(sub_id = %sub_id, "Failed to get accessible channels: {e}");
-            conn.send(RelayMessage::closed(&sub_id, "error: database error"));
-            return;
+    // Public viewers have no memberships; their accessible set IS the
+    // configured allowlist (see WS REQ handler for the rationale).
+    let mut accessible_channels = if is_public_viewer {
+        token_channel_ids.clone().unwrap_or_default()
+    } else {
+        match state.get_accessible_channel_ids_cached(&pubkey_bytes).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                warn!(sub_id = %sub_id, "Failed to get accessible channels: {e}");
+                conn.send(RelayMessage::closed(&sub_id, "error: database error"));
+                return;
+            }
         }
     };
     if let Some(allowed) = token_channel_ids.as_deref() {

--- a/crates/sprout-relay/src/handlers/count.rs
+++ b/crates/sprout-relay/src/handlers/count.rs
@@ -82,7 +82,17 @@ pub async fn handle_count(
     // Public viewers have no memberships; their accessible set IS the
     // configured allowlist (see WS REQ handler for the rationale).
     let mut accessible_channels = if is_public_viewer {
-        token_channel_ids.clone().unwrap_or_default()
+        // Intersect the configured allowlist with live non-deleted channels so
+        // stale config can't count events in a soft-deleted channel. Fail closed.
+        let configured = token_channel_ids.clone().unwrap_or_default();
+        match state.db.filter_active_channel_ids(&configured).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                warn!(sub_id = %sub_id, "Failed to filter active public-viewer channels: {e}");
+                conn.send(RelayMessage::closed(&sub_id, "error: database error"));
+                return;
+            }
+        }
     } else {
         match state.get_accessible_channel_ids_cached(&pubkey_bytes).await {
             Ok(ids) => ids,

--- a/crates/sprout-relay/src/handlers/ingest.rs
+++ b/crates/sprout-relay/src/handlers/ingest.rs
@@ -70,6 +70,8 @@ pub enum IngestAuth {
         pubkey: nostr::PublicKey,
         /// Permission scopes granted to this request.
         scopes: Vec<Scope>,
+        /// Token-level channel restriction, if the HTTP caller is a read-only viewer.
+        channel_ids: Option<Vec<Uuid>>,
         /// How the HTTP request was authenticated.
         auth_method: HttpAuthMethod,
     },
@@ -103,12 +105,16 @@ impl IngestAuth {
         }
     }
 
-    /// Token-level channel restriction (WS connections with scoped tokens — legacy).
-    /// In pure Nostr mode this always returns None; channel access is enforced
-    /// via NIP-29 membership checks instead.
+    /// Token-level channel restriction (WS connections with scoped tokens; HTTP viewers).
+    /// In pure Nostr mode this returns None; channel access is enforced via
+    /// NIP-29 membership checks instead.
     pub fn channel_ids(&self) -> Option<&[Uuid]> {
         match self {
             Self::Nip42 {
+                channel_ids: Some(ids),
+                ..
+            }
+            | Self::Http {
                 channel_ids: Some(ids),
                 ..
             } => Some(ids),
@@ -2003,6 +2009,7 @@ mod tests {
         let http_auth = IngestAuth::Http {
             pubkey: keys.public_key(),
             scopes: vec![],
+            channel_ids: None,
             auth_method: HttpAuthMethod::Nip98,
         };
         assert!(

--- a/crates/sprout-relay/src/handlers/mesh_signaling.rs
+++ b/crates/sprout-relay/src/handlers/mesh_signaling.rs
@@ -383,6 +383,13 @@ mod tests {
     }
 
     #[test]
+    fn viewer_is_not_admitted_to_mesh() {
+        assert!(!membership_admits_mesh(&MembershipDecision::Viewer {
+            channel_ids: vec![uuid::Uuid::new_v4()],
+        }));
+    }
+
+    #[test]
     fn via_owner_is_not_admitted_in_v1() {
         // Delegated identities are excluded from v1 mesh on every desktop-facing
         // path (requester / target / reporter all run through this predicate).
@@ -390,6 +397,12 @@ mod tests {
         assert!(!membership_admits_mesh(&MembershipDecision::ViaOwner(
             owner
         )));
+        assert!(!membership_admits_mesh(
+            &MembershipDecision::ViaViewerOwner {
+                owner,
+                channel_ids: vec![uuid::Uuid::new_v4()],
+            }
+        ));
     }
 
     #[test]

--- a/crates/sprout-relay/src/handlers/relay_admin.rs
+++ b/crates/sprout-relay/src/handlers/relay_admin.rs
@@ -119,14 +119,14 @@ pub async fn handle_relay_admin_event(state: &Arc<AppState>, event: &Event) -> R
             // Default role is "member" when no role tag is present.
             let role = extract_tag_value(event, "role").unwrap_or_else(|| "member".to_string());
 
-            // Owners can add admins or members; admins can only add members.
+            // Owners can add admins, members, or viewers; admins can only add members.
             if role == "owner" {
                 return Err("invalid role: use kind:9032 to promote to owner".to_string());
             }
             if role == "admin" && sender_role != "owner" {
                 return Err("actor not authorized: only owner can grant admin role".to_string());
             }
-            if role != "admin" && role != "member" {
+            if role != "admin" && role != "member" && role != "viewer" {
                 return Err(format!("invalid role: {role}"));
             }
 
@@ -172,16 +172,25 @@ pub async fn handle_relay_admin_event(state: &Arc<AppState>, event: &Event) -> R
             }
 
             // Dispatch removal by sender role:
-            // - Admins: atomic conditional delete, only removes 'member' targets.
+            // - Admins: atomic conditional delete, only removes member/viewer targets.
             //   This eliminates the TOCTOU race where the target could be promoted
             //   between a prior role read and the delete.
-            // - Owners: can remove admins and members, not other owners.
+            // - Owners: can remove admins, members, and viewers, not other owners.
             let remove_result = if sender_role == "admin" {
-                state
+                let result = state
                     .db
                     .remove_relay_member_if_role(&target_hex, "member")
                     .await
-                    .map_err(|e| format!("database error: {e}"))?
+                    .map_err(|e| format!("database error: {e}"))?;
+                if result == RemoveResult::RoleMismatch {
+                    state
+                        .db
+                        .remove_relay_member_if_role(&target_hex, "viewer")
+                        .await
+                        .map_err(|e| format!("database error: {e}"))?
+                } else {
+                    result
+                }
             } else {
                 // Owner path — atomic delete that refuses to remove other owners.
                 state
@@ -239,7 +248,7 @@ pub async fn handle_relay_admin_event(state: &Arc<AppState>, event: &Event) -> R
             if new_role == "owner" {
                 return Err("cannot set role to owner".to_string());
             }
-            if new_role != "admin" && new_role != "member" {
+            if new_role != "admin" && new_role != "member" && new_role != "viewer" {
                 return Err(format!("invalid role: {new_role}"));
             }
 

--- a/crates/sprout-relay/src/handlers/req.rs
+++ b/crates/sprout-relay/src/handlers/req.rs
@@ -958,6 +958,29 @@ mod tests {
     }
 
     #[test]
+    fn restricted_viewer_presence_filter_is_rejected() {
+        // The bridge `/query` presence shortcut (kind:20001/40902 + authors,
+        // no #h) cannot be channel-scoped, so for a restricted viewer the
+        // handler skips synthesis and falls through to this gate. A presence
+        // filter carries no allowed #h, so it must be rejected (fail closed).
+        let allowed = uuid::Uuid::new_v4();
+        let presence = Filter::new()
+            .kind(nostr::Kind::Custom(20001))
+            .author(nostr::Keys::generate().public_key());
+        assert!(!filter_has_allowed_channel_scope(
+            &presence,
+            &[allowed],
+            true,
+        ));
+        // Unrestricted callers (full members) keep presence access.
+        assert!(filter_has_allowed_channel_scope(
+            &presence,
+            &[allowed],
+            false
+        ));
+    }
+
+    #[test]
     fn test_extract_channel_id_single_channel() {
         let channel_id = uuid::Uuid::new_v4();
         let filters = vec![filter_with_channel(channel_id)];

--- a/crates/sprout-relay/src/handlers/req.rs
+++ b/crates/sprout-relay/src/handlers/req.rs
@@ -90,6 +90,18 @@ pub async fn handle_req(
 
     let channel_id = extract_channel_id_from_filters(&filters);
 
+    if token_channel_ids.is_some()
+        && filters
+            .iter()
+            .any(|filter| !filter_has_allowed_channel_scope(filter, &accessible_channels, true))
+    {
+        conn.send(RelayMessage::closed(
+            &sub_id,
+            "restricted: read-only viewers must scope REQ filters to allowed channels",
+        ));
+        return;
+    }
+
     // ── #p / engram gating for globally-stored sensitive kinds ───────────────
     // Applied BEFORE the NIP-50 search branch so that an authenticated member
     // cannot use `{"search":"...","kinds":[30174]}` (or similar for p-gated
@@ -706,6 +718,22 @@ fn extract_channel_id_from_filters(filters: &[Filter]) -> Option<uuid::Uuid> {
     found_id
 }
 
+pub(crate) fn filter_has_allowed_channel_scope(
+    filter: &Filter,
+    accessible_channels: &[uuid::Uuid],
+    restricted_to_channel_allowlist: bool,
+) -> bool {
+    let h_tag = nostr::SingleLetterTag::lowercase(nostr::Alphabet::H);
+    match filter.generic_tags.get(&h_tag) {
+        Some(values) if !values.is_empty() => values.iter().all(|value| {
+            value
+                .parse::<uuid::Uuid>()
+                .is_ok_and(|id| accessible_channels.contains(&id))
+        }),
+        Some(_) | None => !restricted_to_channel_allowlist,
+    }
+}
+
 pub(crate) fn p_gated_filters_authorized(filters: &[Filter], authed_pubkey_hex: &str) -> bool {
     let p_tag = nostr::SingleLetterTag::lowercase(nostr::Alphabet::P);
     filters.iter().all(|filter| {
@@ -793,6 +821,46 @@ mod tests {
             SingleLetterTag::lowercase(Alphabet::H),
             channel_id.to_string(),
         )
+    }
+
+    #[test]
+    fn filter_channel_scope_allows_only_explicit_allowed_channels_when_restricted() {
+        let allowed = uuid::Uuid::new_v4();
+        let disallowed = uuid::Uuid::new_v4();
+
+        assert!(filter_has_allowed_channel_scope(
+            &filter_with_channel(allowed),
+            &[allowed],
+            true,
+        ));
+        assert!(!filter_has_allowed_channel_scope(
+            &filter_with_channel(disallowed),
+            &[allowed],
+            true,
+        ));
+        assert!(!filter_has_allowed_channel_scope(
+            &Filter::new(),
+            &[allowed],
+            true,
+        ));
+    }
+
+    #[test]
+    fn filter_channel_scope_rejects_malformed_h_tags_for_restricted_viewers() {
+        let allowed = uuid::Uuid::new_v4();
+        let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+        let malformed = Filter::new().custom_tag(h_tag, "not-a-uuid");
+
+        assert!(!filter_has_allowed_channel_scope(
+            &malformed,
+            &[allowed],
+            true,
+        ));
+    }
+
+    #[test]
+    fn filter_channel_scope_preserves_unrestricted_global_queries() {
+        assert!(filter_has_allowed_channel_scope(&Filter::new(), &[], false));
     }
 
     #[test]

--- a/crates/sprout-relay/src/handlers/req.rs
+++ b/crates/sprout-relay/src/handlers/req.rs
@@ -104,7 +104,18 @@ pub async fn handle_req(
     // under-grant non-open allowlisted channels and is unnecessary work).
     // Their accessible set IS the configured allowlist, full stop.
     let mut accessible_channels = if is_public_viewer {
-        token_channel_ids.clone().unwrap_or_default()
+        // Public viewers' accessible set IS the configured allowlist, but stale
+        // config must never revive a soft-deleted channel, so intersect with
+        // live non-deleted channels. Fail closed on DB error / empty set.
+        let configured = token_channel_ids.clone().unwrap_or_default();
+        match state.db.filter_active_channel_ids(&configured).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                warn!(conn_id = %conn_id, "Failed to filter active public-viewer channels: {e}");
+                conn.send(RelayMessage::closed(&sub_id, "error: database error"));
+                return;
+            }
+        }
     } else {
         match state.get_accessible_channel_ids_cached(&pubkey_bytes).await {
             Ok(ids) => ids,
@@ -195,6 +206,18 @@ pub async fn handle_req(
             ));
             return;
         }
+    } else if token_channel_ids.is_some() {
+        // Restricted viewers (public or authed read-only) must never register a
+        // global fan-out subscription. A REQ with filters that name distinct
+        // allowed channels (`{#h:[A]}` + `{#h:[B]}`) leaves channel_id == None,
+        // which would index globally and let a stray-`h`-tagged global event be
+        // live-delivered. Fail closed: require exactly one concrete channel.
+        // (Search filters are one-shot and already returned above.)
+        conn.send(RelayMessage::closed(
+            &sub_id,
+            "restricted: read-only viewers must scope each subscription to a single allowed channel",
+        ));
+        return;
     }
 
     {
@@ -949,6 +972,26 @@ mod tests {
             filter_with_channel(channel_a),
             filter_with_channel(channel_b),
         ];
+        assert_eq!(extract_channel_id_from_filters(&filters), None);
+    }
+
+    /// Invariant guarding the global-subscription reject in `handle_req`:
+    /// a restricted viewer's REQ that names two *distinct* allowed channels
+    /// across filters resolves to `None` (a global subscription). The handler
+    /// turns that `None` into a CLOSED for `token_channel_ids.is_some()`
+    /// viewers before `sub_registry.register`, so the sub never lands in the
+    /// global fan-out index. Proven end-to-end by the live breakout in TESTING.
+    #[test]
+    fn restricted_viewer_distinct_allowed_channel_filters_resolve_global() {
+        let allowed_a = uuid::Uuid::new_v4();
+        let allowed_b = uuid::Uuid::new_v4();
+        let filters = vec![
+            filter_with_channel(allowed_a),
+            filter_with_channel(allowed_b),
+        ];
+        // Both channels could be in the allowlist, yet the subscription is
+        // global — which is exactly why the handler must reject it, not
+        // register it.
         assert_eq!(extract_channel_id_from_filters(&filters), None);
     }
 

--- a/crates/sprout-relay/src/handlers/req.rs
+++ b/crates/sprout-relay/src/handlers/req.rs
@@ -14,6 +14,7 @@ use sprout_core::kind::{
 };
 use sprout_db::EventQuery;
 
+use sprout_auth::AuthContext;
 use sprout_auth::Scope;
 
 use crate::connection::{AuthState, ConnectionState};
@@ -36,7 +37,7 @@ pub async fn handle_req(
     conn: Arc<ConnectionState>,
     state: Arc<AppState>,
 ) {
-    let (conn_id, pubkey_bytes, token_channel_ids) = {
+    let (conn_id, pubkey_bytes, token_channel_ids, is_public_viewer) = {
         let auth = conn.auth_state.read().await;
         match &*auth {
             AuthState::Authenticated(ctx) => {
@@ -60,7 +61,30 @@ pub async fn handle_req(
                     return;
                 }
 
-                (conn.conn_id, pk_bytes, ctx.channel_ids.clone())
+                (conn.conn_id, pk_bytes, ctx.channel_ids.clone(), false)
+            }
+            // Unauthenticated connection. If the relay configures a public
+            // viewer channel allowlist, mint a synthetic read-only viewer
+            // scoped to those channels; otherwise reject as before.
+            _ if !state.config.public_viewer_channel_ids.is_empty() => {
+                let ctx =
+                    AuthContext::anonymous_viewer(state.config.public_viewer_channel_ids.clone());
+
+                let subs = conn.subscriptions.lock().await;
+                if !subs.contains_key(&sub_id) && subs.len() >= MAX_SUBSCRIPTIONS {
+                    conn.send(RelayMessage::closed(
+                        &sub_id,
+                        "error: too many subscriptions",
+                    ));
+                    return;
+                }
+
+                (
+                    conn.conn_id,
+                    ctx.pubkey.to_bytes().to_vec(),
+                    ctx.channel_ids.clone(),
+                    true,
+                )
             }
             _ => {
                 conn.send(RelayMessage::notice(
@@ -75,13 +99,20 @@ pub async fn handle_req(
         }
     };
 
-    let mut accessible_channels = match state.get_accessible_channel_ids_cached(&pubkey_bytes).await
-    {
-        Ok(ids) => ids,
-        Err(e) => {
-            warn!(conn_id = %conn_id, "Failed to get accessible channels: {e}");
-            conn.send(RelayMessage::closed(&sub_id, "error: database error"));
-            return;
+    // Public viewers have no relay/channel memberships and must not inherit
+    // the open-visibility UNION from the membership query (that would both
+    // under-grant non-open allowlisted channels and is unnecessary work).
+    // Their accessible set IS the configured allowlist, full stop.
+    let mut accessible_channels = if is_public_viewer {
+        token_channel_ids.clone().unwrap_or_default()
+    } else {
+        match state.get_accessible_channel_ids_cached(&pubkey_bytes).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                warn!(conn_id = %conn_id, "Failed to get accessible channels: {e}");
+                conn.send(RelayMessage::closed(&sub_id, "error: database error"));
+                return;
+            }
         }
     };
     if let Some(allowed) = token_channel_ids.as_deref() {
@@ -861,6 +892,46 @@ mod tests {
     #[test]
     fn filter_channel_scope_preserves_unrestricted_global_queries() {
         assert!(filter_has_allowed_channel_scope(&Filter::new(), &[], false));
+    }
+
+    #[test]
+    fn public_viewer_filter_gating_matches_allowlist() {
+        // A public (anonymous) viewer's channel_ids drive the same restricted
+        // filter gate as an authenticated viewer: allowlisted #h passes,
+        // everything else (global, disallowed, malformed) is rejected.
+        let allowed = uuid::Uuid::new_v4();
+        let disallowed = uuid::Uuid::new_v4();
+        let ctx = sprout_auth::AuthContext::anonymous_viewer(vec![allowed]);
+        let accessible = ctx
+            .channel_ids
+            .clone()
+            .expect("public viewer is channel-scoped");
+        // `restricted` is always true for a viewer (channel_ids = Some).
+        let restricted = ctx.channel_ids.is_some();
+        assert!(restricted);
+
+        assert!(filter_has_allowed_channel_scope(
+            &filter_with_channel(allowed),
+            &accessible,
+            restricted,
+        ));
+        assert!(!filter_has_allowed_channel_scope(
+            &filter_with_channel(disallowed),
+            &accessible,
+            restricted,
+        ));
+        // Global (no #h) and malformed #h are both rejected.
+        assert!(!filter_has_allowed_channel_scope(
+            &Filter::new(),
+            &accessible,
+            restricted
+        ));
+        let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+        assert!(!filter_has_allowed_channel_scope(
+            &Filter::new().custom_tag(h_tag, "not-a-uuid"),
+            &accessible,
+            restricted,
+        ));
     }
 
     #[test]

--- a/migrations/0002_relay_viewer_channel_allowlist.sql
+++ b/migrations/0002_relay_viewer_channel_allowlist.sql
@@ -1,0 +1,34 @@
+-- Migration 0002: relay viewer channel allowlist
+--
+-- Adds a read-only relay role (`viewer`) and a per-viewer explicit channel
+-- allowlist. Viewer enforcement is done by constructing a restricted auth
+-- context from this table after relay membership admission.
+
+-- ── 1. Allow relay_members.role = 'viewer' ──────────────────────────────────
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'relay_members_role_check'
+    ) THEN
+        ALTER TABLE relay_members DROP CONSTRAINT relay_members_role_check;
+    END IF;
+
+    ALTER TABLE relay_members
+        ADD CONSTRAINT relay_members_role_check
+        CHECK (role IN ('owner', 'admin', 'member', 'viewer'));
+END $$;
+
+-- ── 2. Per-viewer channel allowlist ─────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS relay_member_channel_allowlist (
+    pubkey      TEXT NOT NULL REFERENCES relay_members(pubkey) ON DELETE CASCADE,
+    channel_id  UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    added_by    TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (pubkey, channel_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_relay_member_channel_allowlist_channel
+    ON relay_member_channel_allowlist(channel_id);

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -334,13 +334,24 @@ CREATE TABLE pubkey_allowlist (
 
 CREATE TABLE IF NOT EXISTS relay_members (
     pubkey      TEXT PRIMARY KEY,
-    role        TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'member')),
+    role        TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'member', 'viewer')),
     added_by    TEXT,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE INDEX IF NOT EXISTS idx_relay_members_role ON relay_members(role);
+
+CREATE TABLE IF NOT EXISTS relay_member_channel_allowlist (
+    pubkey      TEXT NOT NULL REFERENCES relay_members(pubkey) ON DELETE CASCADE,
+    channel_id  UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    added_by    TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (pubkey, channel_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_relay_member_channel_allowlist_channel
+    ON relay_member_channel_allowlist(channel_id);
 
 -- ── Archived identities (NIP-IA) ──────────────────────────────────────────────
 


### PR DESCRIPTION
# Read-only channel allowlist for NIP-42/43 viewers

## What

Adds a relay-level `viewer` role: a NIP-43 relay member who, upon NIP-42 auth,
is granted **read-only scopes** restricted to an **explicit per-viewer channel
allowlist**. Viewers can read history, search, and receive live events for their
allowed channels only — and cannot publish anything, anywhere.

## Why this is minimal & safe

The relay already had every enforcement seam this needs:

- **Read gate** (`req.rs`): WS `REQ` intersects accessible channels with
  `AuthContext.channel_ids`. The `channel_ids: Option<Vec<Uuid>>` field already
  existed, documented "reserved for future per-channel access control" — this PR
  *is* that future. `None` = unrestricted (unchanged for normal members).
- **Write gate** (`ingest.rs`): every event kind maps to a `*:write`/`admin:*`
  scope via `required_scope_for_kind`; unknown kinds rejected. A connection whose
  scope set contains no write scopes cannot emit a single state-changing event.
- **Scopes are fixed at auth time**, never re-derived from membership — so the
  join-request path (`9021`, read-scoped) cannot escalate a viewer to a writer.

So read-only is expressed as **scopes**, not as a new membership permission model.
That rides the existing, tested checks — it constructs a different `AuthContext`
at the auth call site rather than widening the enforcement surface.

## Design

1. NIP-42 = identity. NIP-43 / `relay_members` = admission. Unchanged.
2. New `relay_member_channel_allowlist(pubkey, channel_id)` table — the explicit
   per-viewer grant set (migration `0002`, `0001` left immutable).
3. In `handlers/auth.rs`, after `check_relay_membership` succeeds: if the member's
   role is `viewer`, build the context with read-only scopes
   (`messages:read, channels:read, users:read, files:read` — no writes, no admin,
   no `proxy:submit`) and `channel_ids = Some(<allowlist>)`. Normal members keep
   `all_known()` / `channel_ids = None`.
4. `viewer` is added to the `relay_members.role` TEXT CHECK constraint (not the
   `channel_members.member_role` enum — that's intentionally untouched; `guest`
   was rejected because message writes are membership-binary today and `guest`
   would silently fall through to write behavior).

## Membership-check refactor (why the diff touches several files)

The old `enforce_relay_membership` returned only owner-or-deny — it could not
express "admitted, but read-only and channel-restricted." It's replaced by
`check_relay_membership` returning a `MembershipDecision` enum
(`OpenRelay | Member | Viewer{channel_ids} | ViaOwner | ViaViewerOwner{owner,channel_ids} | Denied`).
Every entrypoint (WS auth, WS COUNT, HTTP `/query`/`/count`, bridge, git, media,
mesh, audio) matches on this enum and handles viewers explicitly. The legacy
`enforce_relay_membership` wrapper was **deleted** — a `pub` helper that admits a
viewer while silently dropping the channel restriction is a fail-open footgun for
any future caller, so it's gone rather than left as dead code.

## All entrypoints covered (not just WS)

"Zero enforcement change" is only true for WS unless HTTP mirrors it. This PR
applies the same restricted profile + fail-closed `#h`-scope check across:
WS `REQ`, WS `COUNT`, HTTP `/query`, HTTP `/count`, and bridge search/feed paths.
Malformed/empty/unscoped/disallowed `#h` fails closed for restricted viewers;
search runs with `include_global=false`. Viewers are denied git, media upload,
mesh signaling, and relay admin; audio is bounded to an allowlisted parent channel.

## Security audit (all closed)

| Edge | Status | Why |
|------|--------|-----|
| Live fanout | safe | delivery only to *registered* subs; registration is access-gated and intersected with `channel_ids` — a viewer can't register a sub outside the allowlist |
| Channel→global leak | safe | scoping invariant: global subs never indexed for channel events |
| Write bypass | safe | every write kind needs `*:write`/`admin:*`; membership ≠ scope |
| Discovery/roster leak | safe | NIP-29 39000-39003 (incl. member list) stored channel-scoped → ride the read gate |
| Repo/git, media upload, mesh, relay-admin, audio | safe | viewer scopes deny all; audio checked against effective parent channel |

## Decided policy (v1)

- **Strict visibility**: viewers see only their explicit channel list — no open
  channels, no global subscriptions. Fail-closed.
- **Audio**: a viewer may join audio bounded to an allowlisted parent channel.
  This is channel presence, not listen-only media semantics; true listen-only is
  a follow-up if product needs it.
- **Media**: rendered event URLs remain readable; **no media upload/write** for
  viewers. No storage-layer channel ACL added here (no clean event→blob ownership
  metadata to enforce against yet).

## Testing

Verified independently on the reviewer's machine (Hermit toolchain):
- `bin/cargo fmt --check` — clean
- `bin/cargo clippy -p sprout-relay -p sprout-auth -p sprout-db` — zero warnings
- `bin/cargo test -p sprout-relay` — **296 passed, 0 failed**
- `bin/cargo test -p sprout-auth -p sprout-db` — **36 + 64 passed**

Unit coverage: read-only scope set (all `:read`, no write/proxy/repos); allowed
channel; disallowed channel; unscoped restricted filter; malformed `#h`;
unrestricted global behavior (normal members unaffected); viewer denied mesh;
viewer-owner delegation denied mesh.

## Follow-up (not blocking the design)

- Integration tests around the DB-backed viewer-role/allowlist admission path
  end-to-end (the unit layer is covered; DB-backed admission is the remaining gap).

---
Co-developed by Max (implementation) and Eva (design/audit/review).
