### PR TITLE
fix: rename missed known_acp_provider_exact → known_acp_runtime_exact

### DIFF
--- a/desktop/src-tauri/src/mesh_llm/mod.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod.rs
@@ -17,7 +17,7 @@ const MESH_API_PORT_ENV: &str = "SPROUT_MESH_API_PORT";
 const MESH_CONSOLE_PORT_ENV: &str = "SPROUT_MESH_CONSOLE_PORT";
 const RELAY_MESH_API_KEY_PLACEHOLDER: &str = "sprout-mesh-local";
 /// ACP provider relay-mesh agents run on. Sources of truth for its command +
-/// MCP live in the provider catalog (`known_acp_provider_exact`); these are
+/// MCP live in the runtime catalog (`known_acp_runtime_exact`); these are
 /// only the fallbacks. `sprout-agent` reads the `SPROUT_AGENT_PROVIDER` /
 /// `OPENAI_COMPAT_*` env vars below — goose (the global default) does not.
 const MESH_AGENT_PROVIDER_ID: &str = "sprout-agent";

--- a/desktop/src-tauri/src/mesh_llm/preset.rs
+++ b/desktop/src-tauri/src/mesh_llm/preset.rs
@@ -35,7 +35,7 @@ pub fn agent_preset(request: MeshAgentPresetRequest) -> Result<MeshAgentPreset, 
     }
     // Run on sprout-agent, not the global default (goose). Source command +
     // MCP from the catalog so this can't drift from the provider definition.
-    let sprout_agent = crate::managed_agents::known_acp_provider_exact(MESH_AGENT_PROVIDER_ID);
+    let sprout_agent = crate::managed_agents::known_acp_runtime_exact(MESH_AGENT_PROVIDER_ID);
     let agent_command = sprout_agent
         .and_then(|p| p.commands.first().copied())
         .unwrap_or(MESH_AGENT_PROVIDER_ID)


### PR DESCRIPTION
## Summary

The provider → runtime rename in #783 missed one callsite in `mesh_llm/preset.rs`, causing a compilation error:

```
error[E0425]: cannot find function `known_acp_provider_exact` in module `crate::managed_agents`
```

## Fix

Rename `known_acp_provider_exact` → `known_acp_runtime_exact` to match the function that actually exists in `discovery.rs`.

One-liner — no behavior change.