### PR TITLE
Fix: user messages animate like agent messages

### DIFF
--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -255,7 +255,7 @@ export const MessageRow = React.memo(
 
         <article
           className={cn(
-            "group/message rounded-2xl px-2 py-1.5 transition-colors",
+            "group/message animate-in fade-in-0 slide-in-from-bottom-1 rounded-2xl px-2 py-1.5 transition-colors",
             isThreadReplyLayout ? "space-y-1.5" : "flex items-start gap-2.5",
             highlighted ? "bg-primary/10 ring-1 ring-primary/30" : "",
           )}


### PR DESCRIPTION
### What
User-authored message rows now use the same enter animation as agent messages (fade + slight slide), matching size/feel.

### Why
User messages looked visually different (no text/bubble animation) vs agent messages.

### Changes
- desktop/src/features/messages/ui/MessageRow.tsx: add animate-in + fade-in + slide-in classes on the message <article>.

### Testing
- Not run here (pnpm/corepack wants Artifactory auth in this env). Please rely on CI / run locally.
