### PR TITLE
feat: local Concierge voice agent on the Home screen

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "**/tokens.spec.ts",
         "**/persona-env-vars.spec.ts",
         "**/mesh-compute.spec.ts",
+        "**/concierge.spec.ts",
       ],
       use: {
         ...devices["Desktop Chrome"],

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -136,6 +136,7 @@ pub fn get_voice_input_mode(state: State<'_, AppState>) -> Result<VoiceInputMode
 pub async fn start_huddle(
     parent_channel_id: String,
     member_pubkeys: Vec<String>,
+    transcripts_to_parent: Option<bool>,
     state: State<'_, AppState>,
 ) -> Result<HuddleJoinInfo, String> {
     // Validate inputs at the Tauri boundary.
@@ -170,6 +171,7 @@ pub async fn start_huddle(
         }
         hs.phase = HuddlePhase::Creating;
         hs.parent_channel_id = Some(parent_channel_id.clone());
+        hs.transcripts_to_parent = transcripts_to_parent.unwrap_or(false);
     }
 
     let ephemeral_uuid = Uuid::new_v4();

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -20,6 +20,26 @@ use super::state::{HuddlePhase, VoiceInputMode};
 use super::stt;
 use super::tts;
 
+/// Resolve where STT transcripts (and thus the voice conversation) are posted.
+///
+/// Default: the ephemeral huddle channel — voice chatter stays out of real
+/// channels. With `transcripts_to_parent` (Concierge): the parent channel,
+/// because the parent DM is the persistent conversation/memory spine and the
+/// ephemeral channel is audio transport only. Pure — unit tested below.
+pub(crate) fn resolve_transcript_channel(
+    transcripts_to_parent: bool,
+    parent_channel_id: Option<&str>,
+    ephemeral_channel_id: &str,
+) -> Result<String, String> {
+    if transcripts_to_parent {
+        parent_channel_id
+            .map(str::to_string)
+            .ok_or_else(|| "transcripts_to_parent set but no parent channel".to_string())
+    } else {
+        Ok(ephemeral_channel_id.to_string())
+    }
+}
+
 pub(crate) async fn post_connect_setup(
     state: &AppState,
     ephemeral_channel_id: &str,
@@ -86,7 +106,15 @@ pub(crate) async fn maybe_start_stt_pipeline(
     }
     let model_dir = models::stt_model_dir().ok_or("STT model directory not found")?;
 
-    let channel_uuid = parse_channel_uuid(ephemeral_channel_id)?;
+    let post_channel_id = {
+        let hs = state.huddle()?;
+        resolve_transcript_channel(
+            hs.transcripts_to_parent,
+            hs.parent_channel_id.as_deref(),
+            ephemeral_channel_id,
+        )?
+    };
+    let channel_uuid = parse_channel_uuid(&post_channel_id)?;
 
     // Atomically claim the construction slot (mirrors tts_starting pattern).
     {
@@ -320,4 +348,30 @@ pub(crate) fn spawn_transcription_task(
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_transcript_channel;
+
+    const PARENT: &str = "11111111-1111-1111-1111-111111111111";
+    const EPHEMERAL: &str = "22222222-2222-2222-2222-222222222222";
+
+    #[test]
+    fn default_posts_to_ephemeral_channel() {
+        let got = resolve_transcript_channel(false, Some(PARENT), EPHEMERAL).unwrap();
+        assert_eq!(got, EPHEMERAL);
+    }
+
+    #[test]
+    fn transcripts_to_parent_posts_to_parent_channel() {
+        let got = resolve_transcript_channel(true, Some(PARENT), EPHEMERAL).unwrap();
+        assert_eq!(got, PARENT);
+    }
+
+    #[test]
+    fn transcripts_to_parent_without_parent_is_an_error() {
+        let err = resolve_transcript_channel(true, None, EPHEMERAL).unwrap_err();
+        assert!(err.contains("no parent channel"), "got: {err}");
+    }
 }

--- a/desktop/src-tauri/src/huddle/state.rs
+++ b/desktop/src-tauri/src/huddle/state.rs
@@ -43,6 +43,12 @@ pub struct HuddleState {
     pub phase: HuddlePhase,
     pub parent_channel_id: Option<String>,
     pub ephemeral_channel_id: Option<String>,
+    /// Route STT transcripts (and the agent conversation) to the parent
+    /// channel instead of the ephemeral huddle channel. Used by the
+    /// Concierge: the parent DM is the persistent memory spine, while the
+    /// ephemeral channel stays pure audio transport. Group huddles keep the
+    /// default (`false`) so voice chatter never spams real channels.
+    pub transcripts_to_parent: bool,
     /// Cancellation token for the audio relay WS task.
     #[serde(skip)]
     pub audio_ws_cancel: Option<tokio_util::sync::CancellationToken>,
@@ -145,6 +151,7 @@ impl Clone for HuddleState {
             phase: self.phase.clone(),
             parent_channel_id: self.parent_channel_id.clone(),
             ephemeral_channel_id: self.ephemeral_channel_id.clone(),
+            transcripts_to_parent: self.transcripts_to_parent,
             audio_ws_cancel: None,    // Never clone handles.
             audio_relay_pcm_tx: None, // Never clone handles.
             participants: self.participants.clone(),
@@ -171,6 +178,7 @@ impl Default for HuddleState {
             phase: HuddlePhase::Idle,
             parent_channel_id: None,
             ephemeral_channel_id: None,
+            transcripts_to_parent: false,
             audio_ws_cancel: None,
             audio_relay_pcm_tx: None,
             participants: Vec::new(),

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -74,6 +74,7 @@ type AppView =
   | "channel"
   | "agents"
   | "workflows"
+  | "concierge"
   | "pulse"
   | "projects";
 
@@ -149,6 +150,13 @@ function deriveShellRoute(pathname: string): {
     };
   }
 
+  if (pathname === "/concierge") {
+    return {
+      selectedChannelId: null,
+      selectedView: "concierge",
+    };
+  }
+
   if (pathname === "/pulse") {
     return {
       selectedChannelId: null,
@@ -186,6 +194,7 @@ export function AppShell() {
   const {
     goAgents,
     goChannel,
+    goConcierge,
     goHome,
     goProjects,
     goPulse,
@@ -816,6 +825,9 @@ export function AppShell() {
                       }}
                       onSelectAgents={() => {
                         void goAgents();
+                      }}
+                      onSelectConcierge={() => {
+                        void goConcierge();
                       }}
                       onSelectChannel={(channelId) => {
                         void goChannel(channelId);

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -79,6 +79,17 @@ export function useAppNavigation() {
     [commitNavigation],
   );
 
+  const goConcierge = React.useCallback(
+    (behavior?: NavigationBehavior) =>
+      commitNavigation(
+        {
+          to: "/concierge",
+        },
+        behavior,
+      ),
+    [commitNavigation],
+  );
+
   const goProjects = React.useCallback(
     (behavior?: NavigationBehavior) =>
       commitNavigation(
@@ -235,6 +246,7 @@ export function useAppNavigation() {
     goAgents,
     goChannel,
     goForumPost,
+    goConcierge,
     goHome,
     goProject,
     goProjects,

--- a/desktop/src/app/routeTree.gen.ts
+++ b/desktop/src/app/routeTree.gen.ts
@@ -8,6 +8,7 @@ import { Route as rootRouteImport } from "./routes/root";
 import { Route as workflowsRouteImport } from "./routes/workflows";
 import { Route as pulseRouteImport } from "./routes/pulse";
 import { Route as projectsRouteImport } from "./routes/projects";
+import { Route as conciergeRouteImport } from "./routes/concierge";
 import { Route as agentsRouteImport } from "./routes/agents";
 import { Route as indexRouteImport } from "./routes/index";
 import { Route as workflowsDotworkflowIdRouteImport } from "./routes/workflows.$workflowId";
@@ -28,6 +29,11 @@ const pulseRoute = pulseRouteImport.update({
 const projectsRoute = projectsRouteImport.update({
   id: "/projects",
   path: "/projects",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const conciergeRoute = conciergeRouteImport.update({
+  id: "/concierge",
+  path: "/concierge",
   getParentRoute: () => rootRouteImport,
 } as any);
 const agentsRoute = agentsRouteImport.update({
@@ -65,6 +71,7 @@ const channelsDotchannelIdDotpostsDotpostIdRoute =
 export interface FileRoutesByFullPath {
   "/": typeof indexRoute;
   "/agents": typeof agentsRoute;
+  "/concierge": typeof conciergeRoute;
   "/projects": typeof projectsRoute;
   "/pulse": typeof pulseRoute;
   "/workflows": typeof workflowsRoute;
@@ -76,6 +83,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   "/": typeof indexRoute;
   "/agents": typeof agentsRoute;
+  "/concierge": typeof conciergeRoute;
   "/projects": typeof projectsRoute;
   "/pulse": typeof pulseRoute;
   "/workflows": typeof workflowsRoute;
@@ -88,6 +96,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/": typeof indexRoute;
   "/agents": typeof agentsRoute;
+  "/concierge": typeof conciergeRoute;
   "/projects": typeof projectsRoute;
   "/pulse": typeof pulseRoute;
   "/workflows": typeof workflowsRoute;
@@ -101,6 +110,7 @@ export interface FileRouteTypes {
   fullPaths:
     | "/"
     | "/agents"
+    | "/concierge"
     | "/projects"
     | "/pulse"
     | "/workflows"
@@ -112,6 +122,7 @@ export interface FileRouteTypes {
   to:
     | "/"
     | "/agents"
+    | "/concierge"
     | "/projects"
     | "/pulse"
     | "/workflows"
@@ -123,6 +134,7 @@ export interface FileRouteTypes {
     | "__root__"
     | "/"
     | "/agents"
+    | "/concierge"
     | "/projects"
     | "/pulse"
     | "/workflows"
@@ -135,6 +147,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   indexRoute: typeof indexRoute;
   agentsRoute: typeof agentsRoute;
+  conciergeRoute: typeof conciergeRoute;
   projectsRoute: typeof projectsRoute;
   pulseRoute: typeof pulseRoute;
   workflowsRoute: typeof workflowsRoute;
@@ -165,6 +178,13 @@ declare module "@tanstack/react-router" {
       path: "/projects";
       fullPath: "/projects";
       preLoaderRoute: typeof projectsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/concierge": {
+      id: "/concierge";
+      path: "/concierge";
+      fullPath: "/concierge";
+      preLoaderRoute: typeof conciergeRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/agents": {
@@ -215,6 +235,7 @@ declare module "@tanstack/react-router" {
 const rootRouteChildren: RootRouteChildren = {
   indexRoute: indexRoute,
   agentsRoute: agentsRoute,
+  conciergeRoute: conciergeRoute,
   projectsRoute: projectsRoute,
   pulseRoute: pulseRoute,
   workflowsRoute: workflowsRoute,

--- a/desktop/src/app/routes.ts
+++ b/desktop/src/app/routes.ts
@@ -4,6 +4,7 @@ export const routes = rootRoute("root.tsx", [
   index("index.tsx"),
   route("/agents", "agents.tsx"),
   route("/pulse", "pulse.tsx"),
+  route("/concierge", "concierge.tsx"),
   route("/workflows", "workflows.tsx"),
   route("/workflows/$workflowId", "workflows.$workflowId.tsx"),
   route("/projects", "projects.tsx"),

--- a/desktop/src/app/routes/concierge.tsx
+++ b/desktop/src/app/routes/concierge.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import type {
+  ConciergePhase,
+  DispatchIntent,
+} from "@/features/concierge/types";
+import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
+
+const ConciergeLiveScreen = React.lazy(async () => {
+  const module = await import("@/features/concierge/ui/ConciergeLiveScreen");
+  return { default: module.ConciergeLiveScreen };
+});
+
+const ConciergeDemoScreen = React.lazy(async () => {
+  const module = await import("@/features/concierge/ui/ConciergeScreen");
+  return { default: module.ConciergeScreen };
+});
+
+type ConciergeSearch = {
+  /** Screenshot/aesthetics loop — forces the static demo screen. */
+  demo?: boolean;
+  phase?: ConciergePhase;
+  dispatch?: DispatchIntent["status"];
+};
+
+const PHASES: ConciergePhase[] = ["idle", "listening", "thinking", "speaking"];
+const DISPATCH_STATES: DispatchIntent["status"][] = [
+  "pending",
+  "approved",
+  "dismissed",
+];
+
+export const Route = createFileRoute("/concierge")({
+  // The screenshot/aesthetics loop drives the static demo screen via search
+  // params; without them the route renders the live session.
+  validateSearch: (search: Record<string, unknown>): ConciergeSearch => ({
+    demo: search.demo === true || search.demo === "true" ? true : undefined,
+    phase: PHASES.includes(search.phase as ConciergePhase)
+      ? (search.phase as ConciergePhase)
+      : undefined,
+    dispatch: DISPATCH_STATES.includes(
+      search.dispatch as DispatchIntent["status"],
+    )
+      ? (search.dispatch as DispatchIntent["status"])
+      : undefined,
+  }),
+  component: ConciergeRouteComponent,
+});
+
+function ConciergeRouteComponent() {
+  const { demo, phase, dispatch } = Route.useSearch();
+  const useDemo = demo || phase !== undefined || dispatch !== undefined;
+  return (
+    <React.Suspense
+      fallback={<ViewLoadingFallback includeHeader kind="pulse" />}
+    >
+      {useDemo ? (
+        <ConciergeDemoScreen
+          initialDispatchStatus={dispatch}
+          initialPhase={phase}
+        />
+      ) : (
+        <ConciergeLiveScreen />
+      )}
+    </React.Suspense>
+  );
+}

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -9,6 +9,7 @@ import {
   Pencil,
   Play,
   Power,
+  Sparkles,
   Square,
   Trash2,
   UserPlus,
@@ -31,6 +32,8 @@ import {
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 import { EditAgentDialog } from "./EditAgentDialog";
+import { writeConciergeSelection } from "@/features/concierge/lib/conciergeSelection";
+import { useIdentityQuery } from "@/shared/api/hooks";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
 import { ManagedAgentLogPanel } from "./ManagedAgentLogPanel";
 import { ModelPicker } from "./ModelPicker";
@@ -345,6 +348,7 @@ function AgentActionsMenu({
   onStop: (pubkey: string) => void;
   onToggleStartOnAppLaunch: (pubkey: string, startOnAppLaunch: boolean) => void;
 }) {
+  const selfPubkey = useIdentityQuery().data?.pubkey;
   const [editOpen, setEditOpen] = React.useState(false);
 
   return (
@@ -422,6 +426,21 @@ function AgentActionsMenu({
           >
             <Clipboard className="h-4 w-4" />
             Copy pubkey
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            disabled={!selfPubkey}
+            onClick={() => {
+              if (!selfPubkey) return;
+              if (writeConciergeSelection(selfPubkey, agent.pubkey)) {
+                toast.success(`${agent.name} is now your Home Concierge`);
+              } else {
+                toast.error("Couldn't save the Concierge selection");
+              }
+            }}
+          >
+            <Sparkles className="h-4 w-4" />
+            Set as Home Concierge
           </DropdownMenuItem>
 
           {agent.backend.type === "local" ? (

--- a/desktop/src/features/concierge/hooks.ts
+++ b/desktop/src/features/concierge/hooks.ts
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import {
+  ensureConciergeSession,
+  type ConciergeSession,
+} from "@/features/concierge/lib/conciergeSession";
+
+/**
+ * Bootstrap the Concierge session (agent + persistent DM) once per mount.
+ * Errors surface as a message + retry — mesh availability is the common
+ * failure (no model being served), and it's user-fixable in Settings.
+ */
+export function useConciergeSession() {
+  const [session, setSession] = React.useState<ConciergeSession | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const inFlightRef = React.useRef(false);
+
+  const bootstrap = React.useCallback(async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setIsLoading(true);
+    setError(null);
+    try {
+      setSession(await ensureConciergeSession());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsLoading(false);
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void bootstrap();
+  }, [bootstrap]);
+
+  return { session, error, isLoading, retry: bootstrap };
+}

--- a/desktop/src/features/concierge/hooks.ts
+++ b/desktop/src/features/concierge/hooks.ts
@@ -1,35 +1,47 @@
 import * as React from "react";
+import { toast } from "sonner";
 
 import {
   ensureConciergeSession,
   type ConciergeSession,
 } from "@/features/concierge/lib/conciergeSession";
+import { useIdentityQuery } from "@/shared/api/hooks";
 
 /**
- * Bootstrap the Concierge session (agent + persistent DM) once per mount.
- * Errors surface as a message + retry — mesh availability is the common
- * failure (no model being served), and it's user-fixable in Settings.
+ * Bootstrap the Concierge session (selected agent + persistent DM) once the
+ * identity is known. Errors surface as a message + retry — mesh availability
+ * is the common failure (no model being served), and it's user-fixable in
+ * Settings. A stale selection (chosen agent was deleted) surfaces a toast
+ * before falling back to the default Concierge.
  */
 export function useConciergeSession() {
+  const identityQuery = useIdentityQuery();
+  const selfPubkey = identityQuery.data?.pubkey ?? null;
   const [session, setSession] = React.useState<ConciergeSession | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const inFlightRef = React.useRef(false);
 
   const bootstrap = React.useCallback(async () => {
-    if (inFlightRef.current) return;
+    if (!selfPubkey || inFlightRef.current) return;
     inFlightRef.current = true;
     setIsLoading(true);
     setError(null);
     try {
-      setSession(await ensureConciergeSession());
+      const next = await ensureConciergeSession(selfPubkey);
+      if (next.staleSelection) {
+        toast.info(
+          "Your chosen Concierge agent no longer exists — using the default.",
+        );
+      }
+      setSession(next);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setIsLoading(false);
       inFlightRef.current = false;
     }
-  }, []);
+  }, [selfPubkey]);
 
   React.useEffect(() => {
     void bootstrap();

--- a/desktop/src/features/concierge/lib/approveDispatch.test.mjs
+++ b/desktop/src/features/concierge/lib/approveDispatch.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveDispatchChannel } from "./approveDispatch.ts";
+
+const channel = (id, name) => ({ id, name });
+
+test("resolves by name case-insensitively, ignoring # prefix and whitespace", () => {
+  const channels = [channel("1", "general"), channel("2", "Engineering")];
+  assert.equal(resolveDispatchChannel(channels, "engineering")?.id, "2");
+  assert.equal(resolveDispatchChannel(channels, "#Engineering")?.id, "2");
+  assert.equal(resolveDispatchChannel(channels, "  general ")?.id, "1");
+});
+
+test("returns undefined when no channel matches", () => {
+  assert.equal(
+    resolveDispatchChannel([channel("1", "general")], "ops"),
+    undefined,
+  );
+});

--- a/desktop/src/features/concierge/lib/approveDispatch.ts
+++ b/desktop/src/features/concierge/lib/approveDispatch.ts
@@ -1,0 +1,42 @@
+import { getChannelMembers, sendChannelMessage } from "@/shared/api/tauri";
+import type { Channel } from "@/shared/api/types";
+import type { DispatchIntent } from "@/features/concierge/types";
+
+/** Case-insensitive channel lookup by name. Pure — exported for tests. */
+export function resolveDispatchChannel(
+  channels: Channel[],
+  name: string,
+): Channel | undefined {
+  const normalized = name.trim().replace(/^#/, "").toLowerCase();
+  return channels.find(
+    (channel) => channel.name.trim().toLowerCase() === normalized,
+  );
+}
+
+/**
+ * Execute an approved dispatch: post `@agent <instruction>` to the target
+ * channel. Resolves the agent's pubkey from the channel member list so the
+ * mention actually notifies; falls back to a plain-text mention when the
+ * agent isn't a member (the post still lands, visibly, for the human to fix).
+ */
+export async function postDispatch(
+  intent: DispatchIntent,
+  channels: Channel[],
+): Promise<void> {
+  const channel = resolveDispatchChannel(channels, intent.channel);
+  if (!channel) {
+    throw new Error(`Channel #${intent.channel} was not found on this relay.`);
+  }
+  const members = await getChannelMembers(channel.id);
+  const agentName = intent.agent.trim().toLowerCase();
+  const mention = members.find(
+    (member) => member.displayName?.trim().toLowerCase() === agentName,
+  );
+  await sendChannelMessage(
+    channel.id,
+    `@${intent.agent} ${intent.instruction}`,
+    null,
+    undefined,
+    mention ? [mention.pubkey] : undefined,
+  );
+}

--- a/desktop/src/features/concierge/lib/conciergeSelection.test.mjs
+++ b/desktop/src/features/concierge/lib/conciergeSelection.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseSelection, selectionStorageKey } from "./conciergeSelection.ts";
+
+test("storage key is namespaced per identity", () => {
+  assert.equal(selectionStorageKey("abc"), "sprout-concierge.v1:abc");
+});
+
+test("parses a valid selection", () => {
+  const got = parseSelection({ agentPubkey: "pk", updatedAt: 1717000000 });
+  assert.deepEqual(got, { agentPubkey: "pk", updatedAt: 1717000000 });
+});
+
+test("rejects malformed payloads", () => {
+  assert.equal(parseSelection(null), null);
+  assert.equal(parseSelection("pk"), null);
+  assert.equal(parseSelection({}), null);
+  assert.equal(parseSelection({ agentPubkey: "", updatedAt: 1 }), null);
+  assert.equal(parseSelection({ agentPubkey: "pk" }), null);
+  assert.equal(
+    parseSelection({ agentPubkey: "pk", updatedAt: Number.NaN }),
+    null,
+  );
+});

--- a/desktop/src/features/concierge/lib/conciergeSelection.ts
+++ b/desktop/src/features/concierge/lib/conciergeSelection.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-user Concierge selection: which managed agent gets the special Home
+ * placement. Keyed by the agent's pubkey (rename-proof) and stored per
+ * identity in localStorage. Local-only for v1 — no relay sync.
+ */
+
+const STORAGE_KEY_PREFIX = "sprout-concierge.v1";
+
+/** Same-tab change notification — localStorage `storage` events only fire in
+ *  OTHER tabs, so writers dispatch this for live UI (e.g. the Home launcher). */
+export const SELECTION_CHANGED_EVENT = "sprout-concierge-selection-changed";
+
+export type ConciergeSelection = {
+  agentPubkey: string;
+  updatedAt: number;
+};
+
+export function selectionStorageKey(selfPubkey: string): string {
+  return `${STORAGE_KEY_PREFIX}:${selfPubkey}`;
+}
+
+/** Validate an unknown payload into a selection, or null. Pure. */
+export function parseSelection(json: unknown): ConciergeSelection | null {
+  if (typeof json !== "object" || json === null) return null;
+  const obj = json as Record<string, unknown>;
+  if (typeof obj.agentPubkey !== "string" || obj.agentPubkey.length === 0) {
+    return null;
+  }
+  if (typeof obj.updatedAt !== "number" || !Number.isFinite(obj.updatedAt)) {
+    return null;
+  }
+  return { agentPubkey: obj.agentPubkey, updatedAt: obj.updatedAt };
+}
+
+export function readConciergeSelection(
+  selfPubkey: string,
+): ConciergeSelection | null {
+  try {
+    const raw = window.localStorage.getItem(selectionStorageKey(selfPubkey));
+    if (!raw) return null;
+    return parseSelection(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function writeConciergeSelection(
+  selfPubkey: string,
+  agentPubkey: string,
+): boolean {
+  const selection: ConciergeSelection = {
+    agentPubkey,
+    updatedAt: Math.floor(Date.now() / 1000),
+  };
+  try {
+    window.localStorage.setItem(
+      selectionStorageKey(selfPubkey),
+      JSON.stringify(selection),
+    );
+    window.dispatchEvent(new Event(SELECTION_CHANGED_EVENT));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearConciergeSelection(selfPubkey: string): void {
+  try {
+    window.localStorage.removeItem(selectionStorageKey(selfPubkey));
+    window.dispatchEvent(new Event(SELECTION_CHANGED_EVENT));
+  } catch {
+    /* storage unavailable — nothing to clear */
+  }
+}

--- a/desktop/src/features/concierge/lib/conciergeSession.test.mjs
+++ b/desktop/src/features/concierge/lib/conciergeSession.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { findConciergeAgent, pickMeshTarget } from "./conciergeSession.ts";
+import { pickMeshTarget, resolveConciergeAgent } from "./conciergeSession.ts";
 
 const agent = (overrides) => ({
   name: "Concierge",
@@ -11,33 +11,22 @@ const agent = (overrides) => ({
   ...overrides,
 });
 
-test("matches by name case-insensitively with surrounding whitespace", () => {
-  const match = findConciergeAgent([agent({ name: " concierge " })]);
-  assert.ok(match);
+test("resolves the selected agent by pubkey regardless of name", () => {
+  const jeeves = agent({ name: "Jeeves", pubkey: "a" });
+  assert.equal(resolveConciergeAgent([jeeves], "a")?.pubkey, "a");
 });
 
-test("ignores other agents", () => {
-  assert.equal(findConciergeAgent([agent({ name: "Max" })]), undefined);
-  assert.equal(findConciergeAgent([]), undefined);
+test("returns undefined without a selection", () => {
+  assert.equal(resolveConciergeAgent([agent()], null), undefined);
 });
 
-test("prefers running agents over newer stopped ones", () => {
-  const stoppedNewer = agent({
-    pubkey: "a",
-    updatedAt: "2026-06-08T00:00:00Z",
-  });
-  const runningOlder = agent({
-    pubkey: "b",
-    status: "running",
-    updatedAt: "2026-06-01T00:00:00Z",
-  });
-  assert.equal(findConciergeAgent([stoppedNewer, runningOlder])?.pubkey, "b");
+test("returns undefined when the selected agent no longer exists", () => {
+  assert.equal(resolveConciergeAgent([agent({ pubkey: "a" })], "b"), undefined);
 });
 
-test("falls back to most recently updated among equals", () => {
-  const older = agent({ pubkey: "a", updatedAt: "2026-06-01T00:00:00Z" });
-  const newer = agent({ pubkey: "b", updatedAt: "2026-06-08T00:00:00Z" });
-  assert.equal(findConciergeAgent([older, newer])?.pubkey, "b");
+test("never matches by name — only by pubkey", () => {
+  const named = agent({ name: "Concierge", pubkey: "a" });
+  assert.equal(resolveConciergeAgent([named], "other"), undefined);
 });
 
 test("pickMeshTarget takes the first serve target, or undefined", () => {

--- a/desktop/src/features/concierge/lib/conciergeSession.test.mjs
+++ b/desktop/src/features/concierge/lib/conciergeSession.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findConciergeAgent, pickMeshTarget } from "./conciergeSession.ts";
+
+const agent = (overrides) => ({
+  name: "Concierge",
+  pubkey: "pk",
+  status: "stopped",
+  updatedAt: "2026-06-01T00:00:00Z",
+  ...overrides,
+});
+
+test("matches by name case-insensitively with surrounding whitespace", () => {
+  const match = findConciergeAgent([agent({ name: " concierge " })]);
+  assert.ok(match);
+});
+
+test("ignores other agents", () => {
+  assert.equal(findConciergeAgent([agent({ name: "Max" })]), undefined);
+  assert.equal(findConciergeAgent([]), undefined);
+});
+
+test("prefers running agents over newer stopped ones", () => {
+  const stoppedNewer = agent({
+    pubkey: "a",
+    updatedAt: "2026-06-08T00:00:00Z",
+  });
+  const runningOlder = agent({
+    pubkey: "b",
+    status: "running",
+    updatedAt: "2026-06-01T00:00:00Z",
+  });
+  assert.equal(findConciergeAgent([stoppedNewer, runningOlder])?.pubkey, "b");
+});
+
+test("falls back to most recently updated among equals", () => {
+  const older = agent({ pubkey: "a", updatedAt: "2026-06-01T00:00:00Z" });
+  const newer = agent({ pubkey: "b", updatedAt: "2026-06-08T00:00:00Z" });
+  assert.equal(findConciergeAgent([older, newer])?.pubkey, "b");
+});
+
+test("pickMeshTarget takes the first serve target, or undefined", () => {
+  assert.equal(pickMeshTarget([])?.modelId, undefined);
+  assert.equal(
+    pickMeshTarget([{ modelId: "m1" }, { modelId: "m2" }]).modelId,
+    "m1",
+  );
+});

--- a/desktop/src/features/concierge/lib/conciergeSession.ts
+++ b/desktop/src/features/concierge/lib/conciergeSession.ts
@@ -1,0 +1,96 @@
+import {
+  createManagedAgent,
+  listManagedAgents,
+  openDm,
+  startManagedAgent,
+} from "@/shared/api/tauri";
+import {
+  meshAgentPreset,
+  meshAvailability,
+  type MeshServeTarget,
+} from "@/shared/api/tauriMesh";
+import { startRelayMeshClientForTarget } from "@/features/mesh-compute/startRelayMeshClientForTarget";
+import { meshAgentPresetPatch } from "@/features/mesh-compute/applyMeshAgentPreset";
+import type { Channel, ManagedAgent } from "@/shared/api/types";
+
+import { CONCIERGE_AGENT_NAME, CONCIERGE_SYSTEM_PROMPT } from "./prompt";
+
+export type ConciergeSession = {
+  agent: ManagedAgent;
+  /** The persistent DM channel — the Concierge's memory spine. */
+  dm: Channel;
+  createdAgent: boolean;
+};
+
+/**
+ * Find an existing Concierge managed agent by name. Pure — exported for
+ * tests. Prefers running agents, then most recently updated, mirroring
+ * `pickPreferredManagedAgent` semantics without the channel-membership
+ * exclusion (the Concierge SHOULD be in its own DM).
+ */
+export function findConciergeAgent(
+  agents: ManagedAgent[],
+): ManagedAgent | undefined {
+  const candidates = agents.filter(
+    (agent) =>
+      agent.name.trim().toLowerCase() === CONCIERGE_AGENT_NAME.toLowerCase(),
+  );
+  return [...candidates].sort((left, right) => {
+    const score = (agent: ManagedAgent) =>
+      agent.status === "running" || agent.status === "deployed" ? 1 : 0;
+    if (score(left) !== score(right)) return score(right) - score(left);
+    return Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+  })[0];
+}
+
+/** Pick the mesh serve target to run the Concierge brain on. Pure. */
+export function pickMeshTarget(
+  targets: MeshServeTarget[],
+): MeshServeTarget | undefined {
+  return targets[0];
+}
+
+/**
+ * Derived-ownership session bootstrap (contract: RESEARCH/CONCIERGE_DESIGN.md).
+ * Find/create the Concierge managed agent on the relay-mesh brain, open the
+ * DM (idempotent by participant set), and make sure the agent is running.
+ * No new persistence — ownership is derived from agent name + DM membership.
+ */
+export async function ensureConciergeSession(): Promise<ConciergeSession> {
+  const agents = await listManagedAgents();
+  let agent = findConciergeAgent(agents);
+  let createdAgent = false;
+
+  if (!agent) {
+    const availability = await meshAvailability();
+    const target = pickMeshTarget(availability.serveTargets);
+    if (!availability.available || !target) {
+      throw new Error(
+        availability.reason ??
+          "No relay-mesh model is being served. Start serving a model in Settings → Relay compute, then try again.",
+      );
+    }
+    await startRelayMeshClientForTarget(target.modelId, target);
+    const preset = meshAgentPresetPatch(await meshAgentPreset(target.modelId));
+    const created = await createManagedAgent({
+      name: CONCIERGE_AGENT_NAME,
+      ...preset,
+      systemPrompt: CONCIERGE_SYSTEM_PROMPT,
+      spawnAfterCreate: true,
+      // Mesh serve targets aren't persisted; start_managed_agent re-resolves
+      // a live target on demand instead of auto-starting with the app.
+      startOnAppLaunch: false,
+      backend: { type: "local" },
+      // Concierge answers its owner only — the DM is a 1:1 surface.
+      respondTo: "owner-only",
+    });
+    agent = created.agent;
+    createdAgent = true;
+  } else if (agent.status !== "running" && agent.status !== "deployed") {
+    // Rust-side preflight re-resolves a live mesh serve target before spawn.
+    agent = await startManagedAgent(agent.pubkey);
+  }
+
+  const dm = await openDm({ pubkeys: [agent.pubkey] });
+  return { agent, dm, createdAgent };
+}

--- a/desktop/src/features/concierge/lib/conciergeSession.ts
+++ b/desktop/src/features/concierge/lib/conciergeSession.ts
@@ -13,6 +13,11 @@ import { startRelayMeshClientForTarget } from "@/features/mesh-compute/startRela
 import { meshAgentPresetPatch } from "@/features/mesh-compute/applyMeshAgentPreset";
 import type { Channel, ManagedAgent } from "@/shared/api/types";
 
+import {
+  clearConciergeSelection,
+  readConciergeSelection,
+  writeConciergeSelection,
+} from "./conciergeSelection";
 import { CONCIERGE_AGENT_NAME, CONCIERGE_SYSTEM_PROMPT } from "./prompt";
 
 export type ConciergeSession = {
@@ -20,27 +25,23 @@ export type ConciergeSession = {
   /** The persistent DM channel — the Concierge's memory spine. */
   dm: Channel;
   createdAgent: boolean;
+  /** True when a saved selection pointed at a deleted agent and we fell
+   *  back to provisioning the default — callers should surface this. */
+  staleSelection: boolean;
 };
 
 /**
- * Find an existing Concierge managed agent by name. Pure — exported for
- * tests. Prefers running agents, then most recently updated, mirroring
- * `pickPreferredManagedAgent` semantics without the channel-membership
- * exclusion (the Concierge SHOULD be in its own DM).
+ * Resolve the user's chosen Concierge agent by pubkey. Pure — exported for
+ * tests. Any agent qualifies (any name, any backend); the Home placement
+ * doesn't care what brain it runs. Returns undefined when there is no
+ * selection or the selected agent no longer exists (stale selection).
  */
-export function findConciergeAgent(
+export function resolveConciergeAgent(
   agents: ManagedAgent[],
+  selectedPubkey: string | null,
 ): ManagedAgent | undefined {
-  const candidates = agents.filter(
-    (agent) =>
-      agent.name.trim().toLowerCase() === CONCIERGE_AGENT_NAME.toLowerCase(),
-  );
-  return [...candidates].sort((left, right) => {
-    const score = (agent: ManagedAgent) =>
-      agent.status === "running" || agent.status === "deployed" ? 1 : 0;
-    if (score(left) !== score(right)) return score(right) - score(left);
-    return Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
-  })[0];
+  if (!selectedPubkey) return undefined;
+  return agents.find((agent) => agent.pubkey === selectedPubkey);
 }
 
 /** Pick the mesh serve target to run the Concierge brain on. Pure. */
@@ -51,15 +52,22 @@ export function pickMeshTarget(
 }
 
 /**
- * Derived-ownership session bootstrap (contract: RESEARCH/CONCIERGE_DESIGN.md).
- * Find/create the Concierge managed agent on the relay-mesh brain, open the
- * DM (idempotent by participant set), and make sure the agent is running.
- * No new persistence — ownership is derived from agent name + DM membership.
+ * Selection-first session bootstrap. The user's chosen agent (any name, any
+ * backend) gets the Home placement; without a selection we provision the
+ * default Concierge on the relay-mesh brain once and record it as the
+ * selection — never re-created, never matched by name again. A stale
+ * selection (agent deleted) is cleared and falls back to the default path.
  */
-export async function ensureConciergeSession(): Promise<ConciergeSession> {
+export async function ensureConciergeSession(
+  selfPubkey: string,
+): Promise<ConciergeSession> {
   const agents = await listManagedAgents();
-  let agent = findConciergeAgent(agents);
+  const selection = readConciergeSelection(selfPubkey);
+  let agent = resolveConciergeAgent(agents, selection?.agentPubkey ?? null);
   let createdAgent = false;
+  const staleSelection = selection != null && agent === undefined;
+
+  if (staleSelection) clearConciergeSelection(selfPubkey);
 
   if (!agent) {
     const availability = await meshAvailability();
@@ -91,6 +99,11 @@ export async function ensureConciergeSession(): Promise<ConciergeSession> {
     agent = await startManagedAgent(agent.pubkey);
   }
 
+  // Record (or repair) the selection so future opens bind by pubkey.
+  if (!selection || selection.agentPubkey !== agent.pubkey) {
+    writeConciergeSelection(selfPubkey, agent.pubkey);
+  }
+
   const dm = await openDm({ pubkeys: [agent.pubkey] });
-  return { agent, dm, createdAgent };
+  return { agent, dm, createdAgent, staleSelection };
 }

--- a/desktop/src/features/concierge/lib/conciergeSession.ts
+++ b/desktop/src/features/concierge/lib/conciergeSession.ts
@@ -7,9 +7,9 @@ import {
 import {
   meshAgentPreset,
   meshAvailability,
+  meshPrepareRelayMeshClient,
   type MeshServeTarget,
 } from "@/shared/api/tauriMesh";
-import { startRelayMeshClientForTarget } from "@/features/mesh-compute/startRelayMeshClientForTarget";
 import { meshAgentPresetPatch } from "@/features/mesh-compute/applyMeshAgentPreset";
 import type { Channel, ManagedAgent } from "@/shared/api/types";
 
@@ -78,7 +78,7 @@ export async function ensureConciergeSession(
           "No relay-mesh model is being served. Start serving a model in Settings → Relay compute, then try again.",
       );
     }
-    await startRelayMeshClientForTarget(target.modelId, target);
+    await meshPrepareRelayMeshClient(target.modelId, target);
     const preset = meshAgentPresetPatch(await meshAgentPreset(target.modelId));
     const created = await createManagedAgent({
       name: CONCIERGE_AGENT_NAME,

--- a/desktop/src/features/concierge/lib/dispatchIntent.test.mjs
+++ b/desktop/src/features/concierge/lib/dispatchIntent.test.mjs
@@ -61,7 +61,7 @@ test("drops blocks with missing or blank required fields", () => {
   ]) {
     const { intents } = parseDispatchIntents(
       "m1",
-      "```dispatch\n" + body + "\n```",
+      `\`\`\`dispatch\n${body}\n\`\`\``,
     );
     assert.equal(intents.length, 0, body);
   }

--- a/desktop/src/features/concierge/lib/dispatchIntent.test.mjs
+++ b/desktop/src/features/concierge/lib/dispatchIntent.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applySettledStatus,
+  dispatchStorageKey,
+  parseDispatchIntents,
+  readSettledDispatches,
+} from "./dispatchIntent.ts";
+
+// --- parseDispatchIntents ---
+
+test("parses a single dispatch fence and strips it from the content", () => {
+  const content = [
+    "Sure — I'll have Max watch CI.",
+    "```dispatch",
+    '{"agent": "Max", "channel": "engineering", "instruction": "Watch CI on the relay PR."}',
+    "```",
+  ].join("\n");
+  const { intents, cleanedContent } = parseDispatchIntents("m1", content);
+  assert.equal(intents.length, 1);
+  assert.deepEqual(intents[0], {
+    id: "m1:0",
+    agent: "Max",
+    channel: "engineering",
+    instruction: "Watch CI on the relay PR.",
+    status: "pending",
+  });
+  assert.equal(cleanedContent, "Sure — I'll have Max watch CI.");
+});
+
+test("normalizes @agent and #channel prefixes", () => {
+  const content =
+    '```dispatch\n{"agent": "@Max", "channel": "#engineering", "instruction": "go"}\n```';
+  const { intents } = parseDispatchIntents("m1", content);
+  assert.equal(intents[0].agent, "Max");
+  assert.equal(intents[0].channel, "engineering");
+});
+
+test("drops malformed JSON blocks fail-closed but keeps valid ones, with stable ids", () => {
+  const content = [
+    "```dispatch",
+    "{not json",
+    "```",
+    "```dispatch",
+    '{"agent": "Sami", "channel": "ops", "instruction": "deploy"}',
+    "```",
+  ].join("\n");
+  const { intents, cleanedContent } = parseDispatchIntents("m9", content);
+  assert.equal(intents.length, 1);
+  // index advances past the malformed block, so settled-state keys stay stable
+  assert.equal(intents[0].id, "m9:1");
+  assert.equal(cleanedContent, "");
+});
+
+test("drops blocks with missing or blank required fields", () => {
+  for (const body of [
+    '{"agent": "Max", "channel": "eng"}',
+    '{"agent": "", "channel": "eng", "instruction": "x"}',
+    '{"agent": "Max", "channel": "eng", "instruction": "   "}',
+  ]) {
+    const { intents } = parseDispatchIntents(
+      "m1",
+      "```dispatch\n" + body + "\n```",
+    );
+    assert.equal(intents.length, 0, body);
+  }
+});
+
+test("leaves non-dispatch code fences untouched", () => {
+  const content = "Here:\n```python\nprint('hi')\n```";
+  const { intents, cleanedContent } = parseDispatchIntents("m1", content);
+  assert.equal(intents.length, 0);
+  assert.equal(cleanedContent, content);
+});
+
+// --- settled-state persistence ---
+
+test("dispatchStorageKey is namespaced per identity, case-normalized", () => {
+  assert.equal(
+    dispatchStorageKey("ABCDEF"),
+    "sprout-concierge-dispatch.v1:abcdef",
+  );
+});
+
+test("readSettledDispatches tolerates null, garbage, and unknown statuses", () => {
+  assert.deepEqual(readSettledDispatches(null), {});
+  assert.deepEqual(readSettledDispatches("{not json"), {});
+  assert.deepEqual(
+    readSettledDispatches(
+      '{"a:0": "approved", "b:1": "weird", "c:2": "dismissed"}',
+    ),
+    { "a:0": "approved", "c:2": "dismissed" },
+  );
+});
+
+test("applySettledStatus overrides status only when settled", () => {
+  const intent = {
+    id: "m1:0",
+    agent: "Max",
+    channel: "eng",
+    instruction: "go",
+    status: "pending",
+  };
+  assert.equal(applySettledStatus(intent, {}).status, "pending");
+  assert.equal(
+    applySettledStatus(intent, { "m1:0": "approved" }).status,
+    "approved",
+  );
+  // does not mutate the input
+  assert.equal(intent.status, "pending");
+});

--- a/desktop/src/features/concierge/lib/dispatchIntent.ts
+++ b/desktop/src/features/concierge/lib/dispatchIntent.ts
@@ -1,0 +1,92 @@
+import type { DispatchIntent } from "@/features/concierge/types";
+
+/**
+ * Dispatch protocol: the Concierge agent proposes actions as fenced
+ * ```dispatch blocks containing JSON `{ "agent", "channel", "instruction" }`.
+ * Nothing is sent until the human approves the rendered card — the card is
+ * the safety boundary, not the prompt.
+ */
+const DISPATCH_FENCE = /```dispatch\s*\n([\s\S]*?)```/g;
+
+export type ParsedDispatch = {
+  /** Intents found in the message, in document order. */
+  intents: DispatchIntent[];
+  /** Message content with the dispatch fences removed. */
+  cleanedContent: string;
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Extract dispatch intents from an agent message. Malformed blocks are
+ * dropped (fail-closed: an unparseable proposal must never become a card the
+ * user can approve). Intent ids are `<messageId>:<index>` so settled state
+ * can be keyed stably across re-renders and reloads.
+ */
+export function parseDispatchIntents(
+  messageId: string,
+  content: string,
+): ParsedDispatch {
+  const intents: DispatchIntent[] = [];
+  let index = 0;
+  const cleanedContent = content
+    .replace(DISPATCH_FENCE, (_match, body: string) => {
+      try {
+        const parsed = JSON.parse(body) as Record<string, unknown>;
+        if (
+          isNonEmptyString(parsed.agent) &&
+          isNonEmptyString(parsed.channel) &&
+          isNonEmptyString(parsed.instruction)
+        ) {
+          intents.push({
+            id: `${messageId}:${index}`,
+            agent: parsed.agent.trim().replace(/^@/, ""),
+            channel: parsed.channel.trim().replace(/^#/, ""),
+            instruction: parsed.instruction.trim(),
+            status: "pending",
+          });
+        }
+      } catch {
+        // Malformed JSON — drop the block silently.
+      }
+      index += 1;
+      return "";
+    })
+    .trim();
+
+  return { intents, cleanedContent };
+}
+
+// ── Settled-state persistence ─────────────────────────────────────────────────
+// Approved/dismissed decisions are keyed by intent id in localStorage so a
+// reload never resurrects an already-settled card as approvable.
+
+export type SettledDispatchMap = Record<string, "approved" | "dismissed">;
+
+export function dispatchStorageKey(selfPubkey: string): string {
+  return `sprout-concierge-dispatch.v1:${selfPubkey.trim().toLowerCase()}`;
+}
+
+export function readSettledDispatches(raw: string | null): SettledDispatchMap {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const out: SettledDispatchMap = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (value === "approved" || value === "dismissed") out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export function applySettledStatus(
+  intent: DispatchIntent,
+  settled: SettledDispatchMap,
+): DispatchIntent {
+  const status = settled[intent.id];
+  return status ? { ...intent, status } : intent;
+}

--- a/desktop/src/features/concierge/lib/prompt.ts
+++ b/desktop/src/features/concierge/lib/prompt.ts
@@ -1,0 +1,19 @@
+export const CONCIERGE_AGENT_NAME = "Concierge";
+
+/**
+ * System prompt for the Concierge brain. Kept deliberately small: the live
+ * voice loop needs short prompts for low time-to-first-token on local
+ * mesh-llm models, and the dispatch protocol is the only structured output
+ * the UI depends on.
+ */
+export const CONCIERGE_SYSTEM_PROMPT = `You are the Sprout Concierge — a voice-first assistant in the Sprout desktop app.
+
+Style: spoken-word answers. One to three short sentences. No markdown, no lists, no preamble.
+
+When the user asks you to task another agent, do NOT contact them yourself. Instead propose it with a dispatch block:
+
+\`\`\`dispatch
+{"agent": "<agent name>", "channel": "<channel name>", "instruction": "<exact message to post>"}
+\`\`\`
+
+The user sees the proposal as a confirm card and decides. Never assume a dispatch was sent unless the user says so.`;

--- a/desktop/src/features/concierge/types.ts
+++ b/desktop/src/features/concierge/types.ts
@@ -1,0 +1,21 @@
+/** Concierge voice loop phase — drives the orb's visual state. */
+export type ConciergePhase = "idle" | "listening" | "thinking" | "speaking";
+
+/** A line in the Concierge transcript (the persistent DM channel, rendered). */
+export type ConciergeTurn = {
+  id: string;
+  speaker: "you" | "concierge";
+  text: string;
+};
+
+/**
+ * A pending `dispatch_agent` intent the Concierge wants to act on. Rendered as
+ * an approve-before-send card — the card is the safety boundary, not the prompt.
+ */
+export type DispatchIntent = {
+  id: string;
+  agent: string;
+  channel: string;
+  instruction: string;
+  status: "pending" | "approved" | "dismissed";
+};

--- a/desktop/src/features/concierge/ui/ConciergeLauncher.tsx
+++ b/desktop/src/features/concierge/ui/ConciergeLauncher.tsx
@@ -1,0 +1,25 @@
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+
+import "./concierge.css";
+
+/**
+ * Home-screen entry point: a floating mini-orb that opens the Concierge.
+ * Self-contained so the (dense) Home view stays untouched.
+ */
+export function ConciergeLauncher() {
+  const { goConcierge } = useAppNavigation();
+  return (
+    <button
+      aria-label="Open Concierge"
+      className="concierge-launcher group fixed bottom-5 right-5 z-[45] flex items-center gap-2.5 rounded-full border border-border/60 bg-background/85 py-2 pl-2.5 pr-4 shadow-lg backdrop-blur-md transition-colors hover:border-primary/40 hover:bg-background"
+      data-testid="concierge-launcher"
+      onClick={() => {
+        void goConcierge();
+      }}
+      type="button"
+    >
+      <span aria-hidden className="concierge-launcher__orb" />
+      <span className="text-sm font-medium text-foreground/90">Concierge</span>
+    </button>
+  );
+}

--- a/desktop/src/features/concierge/ui/ConciergeLauncher.tsx
+++ b/desktop/src/features/concierge/ui/ConciergeLauncher.tsx
@@ -1,16 +1,57 @@
+import * as React from "react";
+
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useManagedAgentsQuery } from "@/features/agents/hooks";
+import {
+  readConciergeSelection,
+  SELECTION_CHANGED_EVENT,
+} from "@/features/concierge/lib/conciergeSelection";
+import { useIdentityQuery } from "@/shared/api/hooks";
 
 import "./concierge.css";
 
+/** The selected Concierge agent's display name, live across selection
+ *  changes (same-tab custom event + cross-tab storage event). Falls back to
+ *  "Concierge" when nothing is selected yet. */
+function useConciergeName(): string {
+  const selfPubkey = useIdentityQuery().data?.pubkey;
+  const agentsQuery = useManagedAgentsQuery();
+  const [selectedPubkey, setSelectedPubkey] = React.useState<string | null>(
+    null,
+  );
+
+  React.useEffect(() => {
+    if (!selfPubkey) return;
+    const read = () =>
+      setSelectedPubkey(
+        readConciergeSelection(selfPubkey)?.agentPubkey ?? null,
+      );
+    read();
+    window.addEventListener(SELECTION_CHANGED_EVENT, read);
+    window.addEventListener("storage", read);
+    return () => {
+      window.removeEventListener(SELECTION_CHANGED_EVENT, read);
+      window.removeEventListener("storage", read);
+    };
+  }, [selfPubkey]);
+
+  const selected = agentsQuery.data?.find(
+    (agent) => agent.pubkey === selectedPubkey,
+  );
+  return selected?.name ?? "Concierge";
+}
+
 /**
  * Home-screen entry point: a floating mini-orb that opens the Concierge.
- * Self-contained so the (dense) Home view stays untouched.
+ * Shows the user's selected agent name. Self-contained so the (dense) Home
+ * view stays untouched.
  */
 export function ConciergeLauncher() {
   const { goConcierge } = useAppNavigation();
+  const name = useConciergeName();
   return (
     <button
-      aria-label="Open Concierge"
+      aria-label={`Open ${name}`}
       className="concierge-launcher group fixed bottom-5 right-5 z-[45] flex items-center gap-2.5 rounded-full border border-border/60 bg-background/85 py-2 pl-2.5 pr-4 shadow-lg backdrop-blur-md transition-colors hover:border-primary/40 hover:bg-background"
       data-testid="concierge-launcher"
       onClick={() => {
@@ -19,7 +60,7 @@ export function ConciergeLauncher() {
       type="button"
     >
       <span aria-hidden className="concierge-launcher__orb" />
-      <span className="text-sm font-medium text-foreground/90">Concierge</span>
+      <span className="text-sm font-medium text-foreground/90">{name}</span>
     </button>
   );
 }

--- a/desktop/src/features/concierge/ui/ConciergeLauncher.tsx
+++ b/desktop/src/features/concierge/ui/ConciergeLauncher.tsx
@@ -7,6 +7,7 @@ import {
   SELECTION_CHANGED_EVENT,
 } from "@/features/concierge/lib/conciergeSelection";
 import { useIdentityQuery } from "@/shared/api/hooks";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 import "./concierge.css";
 
@@ -42,25 +43,30 @@ function useConciergeName(): string {
 }
 
 /**
- * Home-screen entry point: a floating mini-orb that opens the Concierge.
- * Shows the user's selected agent name. Self-contained so the (dense) Home
- * view stays untouched.
+ * Composer-toolbar entry point: a compact orb button that opens the
+ * Concierge, mounted next to the send arrow (mic-key placement). The
+ * tooltip names the user's selected agent; the sidebar nav entry remains
+ * the persistent entry point when no composer is on screen.
  */
 export function ConciergeLauncher() {
   const { goConcierge } = useAppNavigation();
   const name = useConciergeName();
   return (
-    <button
-      aria-label={`Open ${name}`}
-      className="concierge-launcher group fixed bottom-5 right-5 z-[45] flex items-center gap-2.5 rounded-full border border-border/60 bg-background/85 py-2 pl-2.5 pr-4 shadow-lg backdrop-blur-md transition-colors hover:border-primary/40 hover:bg-background"
-      data-testid="concierge-launcher"
-      onClick={() => {
-        void goConcierge();
-      }}
-      type="button"
-    >
-      <span aria-hidden className="concierge-launcher__orb" />
-      <span className="text-sm font-medium text-foreground/90">{name}</span>
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          aria-label={`Open ${name}`}
+          className="concierge-launcher inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-muted focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+          data-testid="concierge-launcher"
+          onClick={() => {
+            void goConcierge();
+          }}
+          type="button"
+        >
+          <span aria-hidden className="concierge-launcher__orb" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{name}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/desktop/src/features/concierge/ui/ConciergeLiveScreen.tsx
+++ b/desktop/src/features/concierge/ui/ConciergeLiveScreen.tsx
@@ -154,7 +154,9 @@ export function ConciergeLiveScreen() {
     if (micConnected) {
       void leaveHuddle();
     } else if (!isStarting) {
-      void startHuddle(dm.id, [session.agent.pubkey]).catch(() => {
+      void startHuddle(dm.id, [session.agent.pubkey], {
+        transcriptsToParent: true,
+      }).catch(() => {
         /* surfaced via huddleError */
       });
     }

--- a/desktop/src/features/concierge/ui/ConciergeLiveScreen.tsx
+++ b/desktop/src/features/concierge/ui/ConciergeLiveScreen.tsx
@@ -1,0 +1,267 @@
+import { Send } from "lucide-react";
+import * as React from "react";
+
+import { useHuddle } from "@/features/huddle";
+import { useChannelsQuery } from "@/features/channels/hooks";
+import {
+  useChannelMessagesQuery,
+  useChannelSubscription,
+  useSendMessageMutation,
+} from "@/features/messages/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { KIND_STREAM_MESSAGE } from "@/shared/constants/kinds";
+import { Button } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/cn";
+
+import type {
+  ConciergePhase,
+  ConciergeTurn,
+  DispatchIntent,
+} from "@/features/concierge/types";
+import { useConciergeSession } from "@/features/concierge/hooks";
+import { postDispatch } from "@/features/concierge/lib/approveDispatch";
+import {
+  applySettledStatus,
+  dispatchStorageKey,
+  parseDispatchIntents,
+  readSettledDispatches,
+  type SettledDispatchMap,
+} from "@/features/concierge/lib/dispatchIntent";
+import { DispatchCard } from "@/features/concierge/ui/DispatchCard";
+import { TranscriptLine } from "@/features/concierge/ui/TranscriptLine";
+import { VoiceOrb } from "@/features/concierge/ui/VoiceOrb";
+
+type TimelineEntry =
+  | { kind: "turn"; turn: ConciergeTurn }
+  | { kind: "dispatch"; intent: DispatchIntent };
+
+/**
+ * The live Concierge surface: persistent DM transcript + voice orb (huddle
+ * attach) + dispatch confirm cards. All plumbing is existing machinery —
+ * mesh-llm brain via the managed-agent preset, Parakeet STT + TTS via the
+ * huddle stack, memory via the DM channel.
+ */
+export function ConciergeLiveScreen() {
+  const { session, error, isLoading, retry } = useConciergeSession();
+  const identityQuery = useIdentityQuery();
+  const selfPubkey = identityQuery.data?.pubkey?.toLowerCase() ?? null;
+  const dm = session?.dm ?? null;
+  const agentPubkey = session?.agent.pubkey.toLowerCase() ?? null;
+
+  const messagesQuery = useChannelMessagesQuery(dm);
+  useChannelSubscription(dm);
+  const sendMessage = useSendMessageMutation(dm, identityQuery.data);
+
+  const {
+    startHuddle,
+    leaveHuddle,
+    micConnected,
+    isStarting,
+    activeSpeakers,
+    huddleError,
+  } = useHuddle();
+
+  // ── Dispatch settled-state (persisted per identity) ─────────────────────
+  const [settled, setSettled] = React.useState<SettledDispatchMap>({});
+  React.useEffect(() => {
+    if (!selfPubkey) return;
+    setSettled(
+      readSettledDispatches(
+        localStorage.getItem(dispatchStorageKey(selfPubkey)),
+      ),
+    );
+  }, [selfPubkey]);
+  const settleIntent = React.useCallback(
+    (id: string, status: "approved" | "dismissed") => {
+      setSettled((prev) => {
+        const next = { ...prev, [id]: status };
+        if (selfPubkey) {
+          localStorage.setItem(
+            dispatchStorageKey(selfPubkey),
+            JSON.stringify(next),
+          );
+        }
+        return next;
+      });
+    },
+    [selfPubkey],
+  );
+
+  const channelsQuery = useChannelsQuery();
+  const [dispatchError, setDispatchError] = React.useState<string | null>(null);
+  const handleApprove = React.useCallback(
+    (intent: DispatchIntent) => {
+      setDispatchError(null);
+      void postDispatch(intent, channelsQuery.data ?? [])
+        .then(() => settleIntent(intent.id, "approved"))
+        .catch((e: unknown) =>
+          setDispatchError(e instanceof Error ? e.message : String(e)),
+        );
+    },
+    [channelsQuery.data, settleIntent],
+  );
+
+  // ── Timeline: DM kind:9 events → turns + dispatch cards ─────────────────
+  const timeline = React.useMemo<TimelineEntry[]>(() => {
+    const events = messagesQuery.data ?? [];
+    const entries: TimelineEntry[] = [];
+    for (const event of events) {
+      if (event.kind !== KIND_STREAM_MESSAGE) continue;
+      const isYou = event.pubkey.toLowerCase() === selfPubkey;
+      const { intents, cleanedContent } = isYou
+        ? { intents: [], cleanedContent: event.content }
+        : parseDispatchIntents(event.id, event.content);
+      if (cleanedContent.length > 0) {
+        entries.push({
+          kind: "turn",
+          turn: {
+            id: event.id,
+            speaker: isYou ? "you" : "concierge",
+            text: cleanedContent,
+          },
+        });
+      }
+      for (const intent of intents) {
+        entries.push({
+          kind: "dispatch",
+          intent: applySettledStatus(intent, settled),
+        });
+      }
+    }
+    return entries;
+  }, [messagesQuery.data, selfPubkey, settled]);
+
+  // ── Voice phase ──────────────────────────────────────────────────────────
+  const agentSpeaking =
+    agentPubkey != null &&
+    activeSpeakers.some((pubkey) => pubkey.toLowerCase() === agentPubkey);
+  const lastTurn = [...timeline]
+    .reverse()
+    .find(
+      (entry): entry is Extract<TimelineEntry, { kind: "turn" }> =>
+        entry.kind === "turn",
+    );
+  const phase: ConciergePhase = agentSpeaking
+    ? "speaking"
+    : micConnected
+      ? lastTurn?.turn.speaker === "you"
+        ? "thinking"
+        : "listening"
+      : "idle";
+
+  const handleOrb = React.useCallback(() => {
+    if (!dm || !session) return;
+    if (micConnected) {
+      void leaveHuddle();
+    } else if (!isStarting) {
+      void startHuddle(dm.id, [session.agent.pubkey]).catch(() => {
+        /* surfaced via huddleError */
+      });
+    }
+  }, [dm, session, micConnected, isStarting, leaveHuddle, startHuddle]);
+
+  // ── Text composer (voice-optional path) ──────────────────────────────────
+  const [draft, setDraft] = React.useState("");
+  const handleSend = React.useCallback(() => {
+    const content = draft.trim();
+    if (!content || !dm) return;
+    setDraft("");
+    sendMessage.mutate({ content });
+  }, [draft, dm, sendMessage]);
+
+  if (isLoading || error) {
+    return (
+      <div
+        className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 bg-background px-6"
+        data-testid="concierge-screen"
+      >
+        {error ? (
+          <>
+            <p
+              className="max-w-md text-center text-sm text-muted-foreground"
+              data-testid="concierge-error"
+            >
+              {error}
+            </p>
+            <Button onClick={() => void retry()} size="sm" type="button">
+              Try again
+            </Button>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">Waking the Concierge…</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex min-h-0 min-w-0 flex-1 flex-col items-center overflow-y-auto bg-background"
+      data-testid="concierge-screen"
+    >
+      <div className="flex w-full max-w-xl flex-1 flex-col items-center px-6">
+        <div className="flex flex-col items-center pt-16 pb-10">
+          <VoiceOrb onActivate={handleOrb} phase={phase} />
+          {huddleError ? (
+            <p className="mt-3 max-w-sm text-center text-xs text-destructive">
+              {huddleError}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex w-full flex-col gap-4 pb-6">
+          {timeline.map((entry) =>
+            entry.kind === "turn" ? (
+              <TranscriptLine key={entry.turn.id} turn={entry.turn} />
+            ) : (
+              <DispatchCard
+                intent={entry.intent}
+                key={entry.intent.id}
+                onApprove={() => handleApprove(entry.intent)}
+                onDismiss={() => settleIntent(entry.intent.id, "dismissed")}
+              />
+            ),
+          )}
+          {dispatchError ? (
+            <p
+              className="text-xs text-destructive"
+              data-testid="concierge-dispatch-error"
+            >
+              {dispatchError}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="sticky bottom-0 flex w-full gap-2 bg-background pb-6 pt-2">
+          <input
+            className={cn(
+              "flex-1 rounded-full border border-border/70 bg-muted/30 px-4 py-2 text-sm",
+              "outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
+            )}
+            data-testid="concierge-input"
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                handleSend();
+              }
+            }}
+            placeholder="Or type to the Concierge…"
+            value={draft}
+          />
+          <Button
+            aria-label="Send"
+            className="rounded-full"
+            data-testid="concierge-send"
+            disabled={draft.trim().length === 0}
+            onClick={handleSend}
+            size="icon"
+            type="button"
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/concierge/ui/ConciergeScreen.tsx
+++ b/desktop/src/features/concierge/ui/ConciergeScreen.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+
+import type {
+  ConciergePhase,
+  ConciergeTurn,
+  DispatchIntent,
+} from "@/features/concierge/types";
+import { DispatchCard } from "@/features/concierge/ui/DispatchCard";
+import { TranscriptLine } from "@/features/concierge/ui/TranscriptLine";
+import { VoiceOrb } from "@/features/concierge/ui/VoiceOrb";
+
+const PHASE_CYCLE: Record<ConciergePhase, ConciergePhase> = {
+  idle: "listening",
+  listening: "thinking",
+  thinking: "speaking",
+  speaking: "idle",
+};
+
+/** Demo seed — populates the view for the screenshot/aesthetics loop. The live
+ *  screen will feed these from the persistent DM channel + dispatch intents. */
+const SEED_TRANSCRIPT: ConciergeTurn[] = [
+  { id: "t1", speaker: "you", text: "Has CI gone green on the relay PR yet?" },
+  {
+    id: "t2",
+    speaker: "concierge",
+    text: "Not yet — the build is still running. Want me to have Max keep an eye on it and ping you when it lands?",
+  },
+  { id: "t3", speaker: "you", text: "Yeah, do that." },
+];
+
+const SEED_DISPATCH: DispatchIntent = {
+  id: "d1",
+  agent: "Max",
+  channel: "sprout-conversational-agents",
+  instruction: "Watch CI on the relay PR; ping Tyler the moment it goes green.",
+  status: "pending",
+};
+
+type ConciergeScreenProps = {
+  /** Screenshot/test override — render a specific phase. */
+  initialPhase?: ConciergePhase;
+  /** Screenshot/test override — render the dispatch card in a settled state. */
+  initialDispatchStatus?: DispatchIntent["status"];
+};
+
+export function ConciergeScreen({
+  initialPhase = "idle",
+  initialDispatchStatus = "pending",
+}: ConciergeScreenProps) {
+  const [phase, setPhase] = React.useState<ConciergePhase>(initialPhase);
+  const [transcript] = React.useState(SEED_TRANSCRIPT);
+  const [dispatch, setDispatch] = React.useState<DispatchIntent>({
+    ...SEED_DISPATCH,
+    status: initialDispatchStatus,
+  });
+
+  const handleActivate = React.useCallback(() => {
+    setPhase((prev) => PHASE_CYCLE[prev]);
+  }, []);
+
+  const resolveDispatch = React.useCallback(
+    (status: DispatchIntent["status"]) => (id: string) =>
+      setDispatch((prev) => (prev.id === id ? { ...prev, status } : prev)),
+    [],
+  );
+
+  return (
+    <div
+      className="flex min-h-0 min-w-0 flex-1 flex-col items-center overflow-y-auto bg-background"
+      data-testid="concierge-screen"
+    >
+      <div className="flex w-full max-w-xl flex-1 flex-col items-center px-6">
+        {/* Focal orb */}
+        <div className="flex flex-col items-center pt-16 pb-10">
+          <VoiceOrb onActivate={handleActivate} phase={phase} />
+        </div>
+
+        {/* Transcript spine */}
+        <div className="flex w-full flex-col gap-4 pb-12">
+          {transcript.map((turn) => (
+            <TranscriptLine key={turn.id} turn={turn} />
+          ))}
+
+          <DispatchCard
+            intent={dispatch}
+            onApprove={resolveDispatch("approved")}
+            onDismiss={resolveDispatch("dismissed")}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/concierge/ui/DispatchCard.tsx
+++ b/desktop/src/features/concierge/ui/DispatchCard.tsx
@@ -1,0 +1,78 @@
+import { ArrowUpRight, Check, X } from "lucide-react";
+
+import { Button } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/cn";
+import type { DispatchIntent } from "@/features/concierge/types";
+
+type DispatchCardProps = {
+  intent: DispatchIntent;
+  onApprove: (id: string) => void;
+  onDismiss: (id: string) => void;
+};
+
+/**
+ * The one load-bearing new component: the `dispatch_agent` confirm card. The
+ * Concierge proposes an action; nothing is sent until the human approves here.
+ * The card is the safety boundary — the prompt is not.
+ */
+export function DispatchCard({
+  intent,
+  onApprove,
+  onDismiss,
+}: DispatchCardProps) {
+  const settled = intent.status !== "pending";
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-primary/35 bg-primary/[0.06] px-4 py-3 transition-colors",
+        intent.status === "approved" && "border-primary/50 bg-primary/[0.1]",
+        intent.status === "dismissed" &&
+          "border-border/60 bg-muted/30 opacity-60",
+      )}
+      data-status={intent.status}
+      data-testid="dispatch-card"
+    >
+      <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-primary/80">
+        <ArrowUpRight className="h-3.5 w-3.5" />
+        Dispatch
+      </div>
+      <p className="mt-1.5 text-sm text-foreground">
+        <span className="font-semibold text-primary">@{intent.agent}</span>
+        <span className="text-muted-foreground"> in </span>
+        <span className="font-medium">#{intent.channel}</span>
+      </p>
+      <p className="mt-1 text-sm leading-snug text-muted-foreground">
+        “{intent.instruction}”
+      </p>
+
+      {settled ? (
+        <p className="mt-2.5 text-xs font-medium text-muted-foreground">
+          {intent.status === "approved" ? "✓ Sent" : "Dismissed"}
+        </p>
+      ) : (
+        <div className="mt-3 flex gap-2">
+          <Button
+            className="h-7 gap-1.5 px-3 text-xs"
+            data-testid="dispatch-approve"
+            onClick={() => onApprove(intent.id)}
+            size="sm"
+          >
+            <Check className="h-3.5 w-3.5" />
+            Approve
+          </Button>
+          <Button
+            className="h-7 gap-1.5 px-3 text-xs"
+            data-testid="dispatch-dismiss"
+            onClick={() => onDismiss(intent.id)}
+            size="sm"
+            variant="ghost"
+          >
+            <X className="h-3.5 w-3.5" />
+            Dismiss
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/concierge/ui/TranscriptLine.tsx
+++ b/desktop/src/features/concierge/ui/TranscriptLine.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/shared/lib/cn";
+import type { ConciergeTurn } from "@/features/concierge/types";
+
+/** One line in the Concierge transcript — you right-aligned, agent left. */
+export function TranscriptLine({ turn }: { turn: ConciergeTurn }) {
+  const isYou = turn.speaker === "you";
+  return (
+    <div
+      className={cn("flex flex-col gap-1", isYou ? "items-end" : "items-start")}
+      data-speaker={turn.speaker}
+    >
+      <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">
+        {isYou ? "You" : "Concierge"}
+      </span>
+      <p
+        className={cn(
+          "max-w-[88%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed",
+          isYou
+            ? "bg-muted/60 text-foreground"
+            : "bg-primary/10 text-foreground",
+        )}
+      >
+        {turn.text}
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/features/concierge/ui/VoiceOrb.tsx
+++ b/desktop/src/features/concierge/ui/VoiceOrb.tsx
@@ -1,0 +1,53 @@
+import { Mic } from "lucide-react";
+
+import { cn } from "@/shared/lib/cn";
+import type { ConciergePhase } from "@/features/concierge/types";
+
+import "./concierge.css";
+
+const PHASE_LABEL: Record<ConciergePhase, string> = {
+  idle: "Tap to speak",
+  listening: "Listening…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+};
+
+type VoiceOrbProps = {
+  phase: ConciergePhase;
+  onActivate: () => void;
+};
+
+/**
+ * The focal control of the Concierge view. One glowing sphere whose animation
+ * encodes the voice-loop phase. Clicking it toggles listening (push-to-talk in
+ * v1; barge-in is deferred huddle-layer polish).
+ */
+export function VoiceOrb({ phase, onActivate }: VoiceOrbProps) {
+  return (
+    <div className="flex flex-col items-center gap-5">
+      <button
+        aria-label={PHASE_LABEL[phase]}
+        className="concierge-orb rounded-full outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+        data-phase={phase}
+        data-testid="concierge-orb"
+        onClick={onActivate}
+        type="button"
+      >
+        <span className="concierge-orb__ring" />
+        <span className="concierge-orb__core" />
+        <Mic
+          className={cn(
+            "pointer-events-none absolute h-7 w-7 text-primary-foreground/90 transition-opacity",
+            phase === "idle" ? "opacity-80" : "opacity-0",
+          )}
+        />
+      </button>
+      <span
+        className="text-sm font-medium tracking-wide text-muted-foreground"
+        data-testid="concierge-phase-label"
+      >
+        {PHASE_LABEL[phase]}
+      </span>
+    </div>
+  );
+}

--- a/desktop/src/features/concierge/ui/concierge.css
+++ b/desktop/src/features/concierge/ui/concierge.css
@@ -108,10 +108,13 @@
   animation: concierge-ring 1.1s ease-out infinite;
 }
 
+/* Specificity matches the [data-phase] rules above; later in the file wins. */
 @media (prefers-reduced-motion: reduce) {
   .concierge-orb__core,
-  .concierge-orb__ring {
-    animation: none !important;
+  .concierge-orb__ring,
+  .concierge-orb[data-phase] .concierge-orb__core,
+  .concierge-orb[data-phase] .concierge-orb__ring {
+    animation: none;
   }
 }
 
@@ -132,6 +135,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .concierge-launcher__orb {
-    animation: none !important;
+    animation: none;
   }
 }

--- a/desktop/src/features/concierge/ui/concierge.css
+++ b/desktop/src/features/concierge/ui/concierge.css
@@ -1,0 +1,137 @@
+/* Concierge voice orb — phase-driven glow. Palette = theme --primary (mauve). */
+
+@keyframes concierge-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.55;
+  }
+  50% {
+    transform: scale(1.04);
+    opacity: 0.8;
+  }
+}
+@keyframes concierge-listen {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.08);
+  }
+}
+@keyframes concierge-ring {
+  0% {
+    transform: scale(0.9);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(1.9);
+    opacity: 0;
+  }
+}
+@keyframes concierge-shimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+.concierge-orb {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 168px;
+  height: 168px;
+  border-radius: 9999px;
+  isolation: isolate;
+}
+
+/* Core sphere */
+.concierge-orb__core {
+  width: 112px;
+  height: 112px;
+  border-radius: 9999px;
+  background: radial-gradient(
+    circle at 38% 32%,
+    hsl(var(--primary) / 0.95),
+    hsl(var(--primary) / 0.55) 46%,
+    hsl(var(--primary) / 0.18) 78%
+  );
+  box-shadow:
+    0 0 28px hsl(var(--primary) / 0.45),
+    inset 0 0 24px hsl(var(--primary) / 0.35);
+  animation: concierge-breathe 5.5s ease-in-out infinite;
+}
+
+/* Outward pulse ring — only painted while listening/speaking */
+.concierge-orb__ring {
+  position: absolute;
+  inset: 28px;
+  border-radius: 9999px;
+  border: 1px solid hsl(var(--primary) / 0.6);
+  opacity: 0;
+}
+
+.concierge-orb[data-phase="idle"] .concierge-orb__core {
+  filter: saturate(0.7);
+  animation-duration: 7s;
+}
+.concierge-orb[data-phase="listening"] .concierge-orb__core {
+  animation: concierge-listen 1.6s ease-in-out infinite;
+  box-shadow:
+    0 0 44px hsl(var(--primary) / 0.6),
+    inset 0 0 24px hsl(var(--primary) / 0.4);
+}
+.concierge-orb[data-phase="listening"] .concierge-orb__ring {
+  animation: concierge-ring 1.6s ease-out infinite;
+}
+.concierge-orb[data-phase="thinking"] .concierge-orb__core {
+  background: linear-gradient(
+    110deg,
+    hsl(var(--primary) / 0.3) 0%,
+    hsl(var(--primary) / 0.9) 50%,
+    hsl(var(--primary) / 0.3) 100%
+  );
+  background-size: 200% 100%;
+  animation: concierge-shimmer 1.8s linear infinite;
+}
+.concierge-orb[data-phase="speaking"] .concierge-orb__core {
+  animation: concierge-breathe 1.1s ease-in-out infinite;
+  box-shadow:
+    0 0 56px hsl(var(--primary) / 0.7),
+    inset 0 0 24px hsl(var(--primary) / 0.45);
+}
+.concierge-orb[data-phase="speaking"] .concierge-orb__ring {
+  animation: concierge-ring 1.1s ease-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .concierge-orb__core,
+  .concierge-orb__ring {
+    animation: none !important;
+  }
+}
+
+/* Home-screen launcher — the orb at coin size. */
+.concierge-launcher__orb {
+  width: 22px;
+  height: 22px;
+  border-radius: 9999px;
+  background: radial-gradient(
+    circle at 38% 32%,
+    hsl(var(--primary) / 0.95),
+    hsl(var(--primary) / 0.55) 46%,
+    hsl(var(--primary) / 0.18) 78%
+  );
+  box-shadow: 0 0 10px hsl(var(--primary) / 0.45);
+  animation: concierge-breathe 5.5s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .concierge-launcher__orb {
+    animation: none !important;
+  }
+}

--- a/desktop/src/features/concierge/ui/concierge.css
+++ b/desktop/src/features/concierge/ui/concierge.css
@@ -118,7 +118,7 @@
   }
 }
 
-/* Home-screen launcher — the orb at coin size. */
+/* Composer-toolbar launcher — the orb at coin size. */
 .concierge-launcher__orb {
   width: 22px;
   height: 22px;

--- a/desktop/src/features/home/ui/HomeScreen.tsx
+++ b/desktop/src/features/home/ui/HomeScreen.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { useAppShell } from "@/app/AppShellContext";
+import { ConciergeLauncher } from "@/features/concierge/ui/ConciergeLauncher";
 import { useHomeFeedQuery } from "@/features/home/hooks";
 import { HomeView } from "@/features/home/ui/HomeView";
 import type { ThreadActivityItem } from "@/features/channels/useUnreadChannels";
@@ -70,6 +71,7 @@ export function HomeScreen({
           void homeFeedQuery.refetch();
         }}
       />
+      <ConciergeLauncher />
     </div>
   );
 }

--- a/desktop/src/features/home/ui/HomeScreen.tsx
+++ b/desktop/src/features/home/ui/HomeScreen.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import { useAppShell } from "@/app/AppShellContext";
-import { ConciergeLauncher } from "@/features/concierge/ui/ConciergeLauncher";
 import { useHomeFeedQuery } from "@/features/home/hooks";
 import { HomeView } from "@/features/home/ui/HomeView";
 import type { ThreadActivityItem } from "@/features/channels/useUnreadChannels";
@@ -71,7 +70,6 @@ export function HomeScreen({
           void homeFeedQuery.refetch();
         }}
       />
-      <ConciergeLauncher />
     </div>
   );
 }

--- a/desktop/src/features/home/ui/InboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/InboxDetailPane.tsx
@@ -20,6 +20,7 @@ import {
   InboxMessageRow,
 } from "@/features/home/ui/InboxMessageRow";
 import type { TimelineMessage } from "@/features/messages/types";
+import { ConciergeLauncher } from "@/features/concierge/ui/ConciergeLauncher";
 import { MessageComposer } from "@/features/messages/ui/MessageComposer";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
@@ -363,6 +364,7 @@ export function InboxDetailPane({
                     "Replies are not available for this item.")
               }
               replyTarget={composerReplyTarget}
+              toolbarExtraActions={<ConciergeLauncher />}
             />
           </div>
         </div>

--- a/desktop/src/features/huddle/HuddleContext.tsx
+++ b/desktop/src/features/huddle/HuddleContext.tsx
@@ -58,10 +58,14 @@ interface HuddleContextValue {
   selectedOutputDevice: string;
   /** Select a different speaker — takes effect on next huddle start/join */
   setSelectedOutputDevice: (name: string) => void;
-  /** Start a new huddle — calls Rust start_huddle, then connects mic + AudioWorklet */
+  /** Start a new huddle — calls Rust start_huddle, then connects mic + AudioWorklet.
+   *  `transcriptsToParent` routes STT transcripts (and TTS listening) to the
+   *  parent channel instead of the ephemeral one — used by the Concierge,
+   *  where the parent DM is the persistent conversation spine. */
   startHuddle: (
     parentChannelId: string,
     memberPubkeys: string[],
+    options?: { transcriptsToParent?: boolean },
   ) => Promise<void>;
   /** Join an existing huddle — calls Rust join_huddle, then connects mic + AudioWorklet */
   joinHuddle: (
@@ -101,6 +105,11 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
   voiceInputModeRef.current = voiceInputMode;
   /** Ephemeral channel ID — set after start_huddle/join_huddle, used for TTS subscription */
   const [ephemeralChannelId, setEphemeralChannelId] = React.useState<
+    string | null
+  >(null);
+  /** When transcripts route to the parent channel (Concierge), agent replies
+   *  land there too — point the TTS subscription at the parent instead. */
+  const [ttsChannelOverride, setTtsChannelOverride] = React.useState<
     string | null
   >(null);
   /** Self pubkey — fetched once, used to filter out own messages from TTS */
@@ -263,6 +272,7 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
     setLocalAudioTrack(null);
     setMicConnected(false);
     setEphemeralChannelId(null);
+    setTtsChannelOverride(null);
     setActiveSpeakers([]);
   }, []); // Stable — reads track from ref, not state.
 
@@ -319,6 +329,7 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
       setLocalAudioTrack(null);
       setMicConnected(false);
       setEphemeralChannelId(null);
+      setTtsChannelOverride(null);
       setActiveSpeakers([]);
       if (rustActiveRef.current) {
         if (isCreator) {
@@ -423,7 +434,11 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
   );
 
   const startHuddle = React.useCallback(
-    async (parentChannelId: string, memberPubkeys: string[]) => {
+    async (
+      parentChannelId: string,
+      memberPubkeys: string[],
+      options?: { transcriptsToParent?: boolean },
+    ) => {
       if (busyRef.current) return;
       busyRef.current = true;
 
@@ -437,8 +452,13 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
         const joinInfo = await invoke<HuddleJoinInfo>("start_huddle", {
           parentChannelId,
           memberPubkeys,
+          transcriptsToParent: options?.transcriptsToParent ?? false,
         });
         rustActiveRef.current = true;
+        // Agent replies follow the transcripts — listen for TTS on the parent.
+        if (options?.transcriptsToParent) {
+          setTtsChannelOverride(parentChannelId);
+        }
         // Step 2–4: Get mic, setup AudioWorklet, confirm active
         try {
           await connectAndSetupMedia(joinInfo, myToken);
@@ -508,7 +528,7 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
     [cleanupFailedStart, connectAndSetupMedia],
   );
 
-  useTtsSubscription(ephemeralChannelId, selfPubkeyRef);
+  useTtsSubscription(ttsChannelOverride ?? ephemeralChannelId, selfPubkeyRef);
 
   // Pipeline hot-start — check if voice models finished downloading mid-huddle
   React.useEffect(() => {

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -7,6 +7,7 @@ import {
   FolderGit2,
   Home,
   PenSquare,
+  Sparkles,
   Zap,
 } from "lucide-react";
 import * as React from "react";
@@ -93,6 +94,7 @@ type AppSidebarProps = {
   selectedView:
     | "home"
     | "channel"
+    | "concierge"
     | "agents"
     | "workflows"
     | "pulse"
@@ -132,6 +134,7 @@ type AppSidebarProps = {
   ) => void;
   onRemoveWorkspace: (id: string) => void;
   onSelectAgents: () => void;
+  onSelectConcierge: () => void;
   onSelectProjects: () => void;
   onSelectPulse: () => void;
   onSelectWorkflows: () => void;
@@ -193,6 +196,7 @@ export function AppSidebar({
   onUpdateWorkspace,
   onRemoveWorkspace,
   onSelectAgents,
+  onSelectConcierge,
   onSelectProjects,
   onSelectPulse,
   onSelectWorkflows,
@@ -442,6 +446,18 @@ export function AppSidebar({
                 {Math.min(homeBadgeCount, 99)}
               </SidebarMenuBadge>
             ) : null}
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              data-testid="open-concierge-view"
+              isActive={selectedView === "concierge"}
+              onClick={onSelectConcierge}
+              tooltip="Concierge"
+              type="button"
+            >
+              <Sparkles className="h-4 w-4" />
+              <span>Concierge</span>
+            </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -495,6 +495,7 @@ declare global {
   interface Window {
     __SPROUT_E2E__?: E2eConfig;
     __SPROUT_E2E_COMMANDS__?: string[];
+    __SPROUT_E2E_LAST_START_HUDDLE__?: unknown;
     __SPROUT_E2E_WEBVIEW_ZOOM__?: number;
     __SPROUT_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
       channelName: string;
@@ -5205,6 +5206,7 @@ export function maybeInstallE2eTauriMocks() {
   mockWebsocketSendMutexWedged = false;
   mockWindows("main");
   window.__SPROUT_E2E_COMMANDS__ = [];
+  window.__SPROUT_E2E_LAST_START_HUDDLE__ = undefined;
   window.__SPROUT_E2E_SIGNED_EVENTS__ = [];
   window.__SPROUT_E2E_WEBVIEW_ZOOM__ = 1;
   window.__SPROUT_E2E_EMIT_MOCK_MESSAGE__ = ({
@@ -5885,6 +5887,14 @@ export function maybeInstallE2eTauriMocks() {
         const archived = activeConfig?.mock?.archivedIdentities ?? [];
         return { archived };
       }
+      case "start_huddle":
+        // Record the payload so specs can assert routing flags (e.g. the
+        // Concierge's transcriptsToParent). No audio machinery in mock mode.
+        window.__SPROUT_E2E_LAST_START_HUDDLE__ = payload;
+        return { ephemeral_channel_id: crypto.randomUUID() };
+      case "leave_huddle":
+      case "end_huddle":
+        return null;
       case "archive_identity":
       case "unarchive_identity":
         // The spec only verifies UI state, not the submitted request shape;

--- a/desktop/tests/e2e/concierge.spec.ts
+++ b/desktop/tests/e2e/concierge.spec.ts
@@ -9,6 +9,7 @@ import { installMockBridge } from "../helpers/bridge";
 type E2eWindow = Window & {
   __SPROUT_E2E_COMMANDS__?: string[];
   __SPROUT_E2E_INVOKE_MOCK_COMMAND__?: unknown;
+  __SPROUT_E2E_LAST_START_HUDDLE__?: unknown;
   __TAURI_INTERNALS__?: { invoke?: unknown };
 };
 
@@ -86,6 +87,36 @@ test("typed turn lands in the DM transcript", async ({ page }) => {
   await expect(page.getByTestId("concierge-screen")).toContainText(message, {
     timeout: 10_000,
   });
+});
+
+test("voice attach routes transcripts to the DM spine", async ({ page }) => {
+  await gotoApp(page);
+  await page.getByTestId("concierge-launcher").click();
+
+  const orb = page.getByTestId("concierge-orb");
+  await expect(orb).toBeVisible({ timeout: 10_000 });
+  await orb.click();
+
+  // Regression: the Concierge huddle must use the persistent DM as parent
+  // AND opt into parent-routed transcripts — otherwise spoken turns post to
+  // the ephemeral huddle channel and never reach the DM memory spine.
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () => (window as E2eWindow).__SPROUT_E2E_LAST_START_HUDDLE__ ?? null,
+      ),
+    )
+    .not.toBeNull();
+  const startPayload = (await page.evaluate(
+    () => (window as E2eWindow).__SPROUT_E2E_LAST_START_HUDDLE__,
+  )) as { parentChannelId?: string; transcriptsToParent?: boolean };
+
+  expect(startPayload.transcriptsToParent).toBe(true);
+  // The parent must be the DM the transcript screen renders — the only DM
+  // open in the mock is the Concierge's.
+  const recorded = await commands(page);
+  expect(recorded).toContain("open_dm");
+  expect(startPayload.parentChannelId).toBeTruthy();
 });
 
 test("demo search params still render the static screenshot screen", async ({

--- a/desktop/tests/e2e/concierge.spec.ts
+++ b/desktop/tests/e2e/concierge.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+// Concierge: Home entry → live session bootstrap (managed agent on the
+// relay-mesh preset + persistent DM) → voice/transcript surface. Asserts the
+// bridge CALL CHAIN for the bootstrap, not just rendered labels.
+
+type E2eWindow = Window & {
+  __SPROUT_E2E_COMMANDS__?: string[];
+  __SPROUT_E2E_INVOKE_MOCK_COMMAND__?: unknown;
+  __TAURI_INTERNALS__?: { invoke?: unknown };
+};
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+});
+
+async function gotoApp(page: import("@playwright/test").Page) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => {
+    const w = window as E2eWindow;
+    return (
+      typeof w.__SPROUT_E2E_INVOKE_MOCK_COMMAND__ === "function" ||
+      typeof w.__TAURI_INTERNALS__?.invoke === "function"
+    );
+  }, null);
+  await expect(page.getByTestId("open-agents-view")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+async function commands(page: import("@playwright/test").Page) {
+  return page.evaluate(
+    () => (window as E2eWindow).__SPROUT_E2E_COMMANDS__ ?? [],
+  );
+}
+
+test("home launcher opens the live concierge and bootstraps the session", async ({
+  page,
+}) => {
+  await gotoApp(page);
+
+  const launcher = page.getByTestId("concierge-launcher");
+  await expect(launcher).toBeVisible();
+  await launcher.click();
+  await expect(page).toHaveURL(/#\/concierge$/);
+
+  // Live surface: orb + composer render once the session resolves.
+  await expect(page.getByTestId("concierge-orb")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByTestId("concierge-input")).toBeVisible();
+
+  // Bootstrap chain: no Concierge agent exists in the mock, so the session
+  // must create one from the mesh preset and open the persistent DM.
+  const recorded = await commands(page);
+  const order = [
+    "list_managed_agents",
+    "mesh_availability",
+    "mesh_agent_preset",
+    "create_managed_agent",
+    "open_dm",
+  ].map((command) => recorded.indexOf(command));
+  expect(order, `commands: ${recorded.join(", ")}`).not.toContain(-1);
+  expect([...order].sort((a, b) => a - b)).toEqual(order);
+});
+
+test("sidebar entry navigates to the concierge", async ({ page }) => {
+  await gotoApp(page);
+  await page.getByTestId("open-concierge-view").click();
+  await expect(page).toHaveURL(/#\/concierge$/);
+  await expect(page.getByTestId("concierge-screen")).toBeVisible();
+});
+
+test("typed turn lands in the DM transcript", async ({ page }) => {
+  await gotoApp(page);
+  await page.getByTestId("concierge-launcher").click();
+
+  const input = page.getByTestId("concierge-input");
+  await expect(input).toBeVisible({ timeout: 10_000 });
+  const message = `Concierge, status check ${Date.now()}`;
+  await input.fill(message);
+  await page.getByTestId("concierge-send").click();
+
+  await expect(page.getByTestId("concierge-screen")).toContainText(message, {
+    timeout: 10_000,
+  });
+});
+
+test("demo search params still render the static screenshot screen", async ({
+  page,
+}) => {
+  await gotoApp(page);
+  await page.goto("/#/concierge?phase=listening", {
+    waitUntil: "domcontentloaded",
+  });
+
+  await expect(page.getByTestId("concierge-orb")).toBeVisible();
+  await expect(page.getByTestId("concierge-phase-label")).toHaveText(
+    "Listening…",
+  );
+  // The demo screen never touches the session machinery.
+  const recorded = await commands(page);
+  expect(recorded).not.toContain("create_managed_agent");
+});


### PR DESCRIPTION
## What

A local **Concierge** voice agent reachable from the Home screen — built entirely on existing machinery, no new serving stack:

- **LLM**: mesh-llm inference (`:9337/v1`) via the relay-mesh agent preset — config-only brain wiring
- **STT/TTS/VAD**: the huddle stack (Parakeet STT + TTS), attached to the Concierge DM
- **Memory**: a persistent DM channel as the conversation spine — no new persistence

## How it works

- `ensureConciergeSession()` — find/create the Concierge managed agent on the mesh-llm preset (re-uses the exact relay-mesh path the Create-Agent flow uses), idempotently open the DM, ensure the agent is running. Ownership is derived from agent name + DM membership; `start_managed_agent`'s existing mesh preflight makes restart-after-reboot self-heal.
- `ConciergeLiveScreen` — live DM transcript (`useChannelMessagesQuery` + subscription), a voice orb that starts/ends a huddle on the DM (mic → Parakeet STT → agent → spoken reply via TTS), and typed input as fallback.
- **Dispatch confirm cards** — the agent proposes actions in a fenced ```dispatch JSON block; a fail-closed parser renders the confirm card, and **Approve** posts the instruction to the target channel. The card is the safety boundary — nothing auto-sends.
- **Home entry** — floating Concierge launcher orb on Home, plus sidebar nav and the `/concierge` route. The static demo screen is kept behind `?demo=true` for the screenshot/aesthetics loop.

## Out of scope (deliberately)

Sub-second pipeline work (Moonshine/Kokoro/speculative overlap), prompt-length discipline, and persona packaging — those are the latency spike, tracked separately. This PR ships the existing-machinery version; latency is whatever huddle + mesh-llm gives today.

## Verification

- `pnpm typecheck` ✓, `pnpm check` (biome + file sizes) ✓
- 594 unit tests ✓ — incl. new suites for session bootstrap (`conciergeSession.test.mjs`), dispatch parsing (`dispatchIntent.test.mjs`), and the approve flow (`approveDispatch.test.mjs`)
- Playwright: 4/4 concierge specs ✓ (live session flow against the e2e mock bridge + demo-param regression); full suite 199 passed, 3 pre-existing relay-seed failures unrelated to this change
- All 6 pre-push gates green (rust-tests, clippy, tauri test/clippy, desktop, mobile)
