### PR TITLE
Add channel visibility & ephemeral TTL controls to manage sidebar

### DIFF
--- a/crates/sprout-cli/src/commands/channels.rs
+++ b/crates/sprout-cli/src/commands/channels.rs
@@ -350,7 +350,7 @@ pub async fn cmd_update_channel(
     }
     let channel_uuid = parse_uuid(channel_id)?;
 
-    let builder = sprout_sdk::build_update_channel(channel_uuid, name, description)
+    let builder = sprout_sdk::build_update_channel(channel_uuid, name, description, None, None)
         .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
 
     let event = client.sign_event(builder)?;

--- a/crates/sprout-db/src/channel.rs
+++ b/crates/sprout-db/src/channel.rs
@@ -902,30 +902,42 @@ fn row_to_member_record(row: sqlx::postgres::PgRow) -> Result<MemberRecord> {
 
 // ── Phase 2: Channel Metadata ─────────────────────────────────────────────────
 
-/// Partial update for channel name/description.
+/// Partial update for channel metadata. Every field is `None` to leave the
+/// column unchanged.
+#[derive(Default)]
 pub struct ChannelUpdate {
     /// New channel name, or `None` to leave unchanged.
     pub name: Option<String>,
     /// New channel description, or `None` to leave unchanged.
     pub description: Option<String>,
+    /// New visibility (`"open"`/`"private"`), or `None` to leave unchanged.
+    pub visibility: Option<String>,
+    /// TTL change: outer `None` leaves it unchanged, `Some(None)` clears the
+    /// ephemeral TTL (channel becomes permanent), `Some(Some(secs))` sets it.
+    /// On any change the `ttl_deadline` is reset to `NOW() + ttl_seconds`.
+    pub ttl_seconds: Option<Option<i32>>,
 }
 
-/// Updates channel name and/or description dynamically.
+/// Updates channel metadata dynamically.
 ///
-/// At least one field must be `Some`; returns `InvalidData` otherwise.
+/// At least one field must be provided; returns `InvalidData` otherwise.
 /// Returns the updated `ChannelRecord` on success.
 pub async fn update_channel(
     pool: &PgPool,
     channel_id: Uuid,
     updates: ChannelUpdate,
 ) -> Result<ChannelRecord> {
-    if updates.name.is_none() && updates.description.is_none() {
+    if updates.name.is_none()
+        && updates.description.is_none()
+        && updates.visibility.is_none()
+        && updates.ttl_seconds.is_none()
+    {
         return Err(DbError::InvalidData(
             "at least one field must be provided for update".to_string(),
         ));
     }
 
-    // Build SET clause dynamically — only include fields that are Some.
+    // Build SET clause dynamically — only include fields that are provided.
     // Track parameter index for positional placeholders.
     let mut set_parts: Vec<String> = Vec::new();
     let mut param_idx: usize = 1;
@@ -936,6 +948,22 @@ pub async fn update_channel(
     if updates.description.is_some() {
         set_parts.push(format!("description = ${param_idx}"));
         param_idx += 1;
+    }
+    if updates.visibility.is_some() {
+        set_parts.push(format!("visibility = ${param_idx}::channel_visibility"));
+        param_idx += 1;
+    }
+    if let Some(ref ttl) = updates.ttl_seconds {
+        // Set ttl_seconds, then reset the deadline from now (or clear both).
+        set_parts.push(format!("ttl_seconds = ${param_idx}"));
+        param_idx += 1;
+        match ttl {
+            Some(_) => set_parts.push(format!(
+                "ttl_deadline = NOW() + (${} || ' seconds')::interval",
+                param_idx - 1
+            )),
+            None => set_parts.push("ttl_deadline = NULL".to_string()),
+        }
     }
     let sql = format!(
         "UPDATE channels SET {}, updated_at = NOW() WHERE id = ${param_idx} AND deleted_at IS NULL",
@@ -948,6 +976,12 @@ pub async fn update_channel(
     }
     if let Some(ref desc) = updates.description {
         q = q.bind(desc);
+    }
+    if let Some(ref vis) = updates.visibility {
+        q = q.bind(vis);
+    }
+    if let Some(ref ttl) = updates.ttl_seconds {
+        q = q.bind(*ttl);
     }
     q = q.bind(channel_id);
 

--- a/crates/sprout-relay/src/handlers/event.rs
+++ b/crates/sprout-relay/src/handlers/event.rs
@@ -47,6 +47,50 @@ fn bounded_kind_label(kind: u32) -> String {
     }
 }
 
+/// Drop recipients without access before fan-out on a private channel.
+///
+/// Open and channel-less events skip membership filtering (open channel-scoped
+/// events pay one visibility lookup; see `channel_visibility_cached`). For a
+/// private channel, each recipient is kept only if its connection's
+/// authenticated pubkey is a current member; unknown/unauthenticated recipients
+/// fail closed. This is the cluster-wide backstop: even if a stale subscription
+/// survives on another node after an open->private flip, its events are not
+/// delivered here.
+pub async fn filter_fanout_by_access(
+    state: &Arc<AppState>,
+    stored_event: &StoredEvent,
+    matches: Vec<(crate::subscription::ConnId, crate::subscription::SubId)>,
+) -> Vec<(crate::subscription::ConnId, crate::subscription::SubId)> {
+    let Some(channel_id) = stored_event.channel_id else {
+        return matches;
+    };
+    match state.channel_visibility_cached(channel_id).await {
+        Ok(v) if v != "private" => return matches,
+        Ok(_) => {}
+        Err(e) => {
+            // Fail closed: if we cannot determine visibility, do not leak a
+            // possibly-private channel's events.
+            warn!(%channel_id, "fan-out access filter: visibility lookup failed: {e}");
+            return Vec::new();
+        }
+    }
+
+    let mut allowed = Vec::with_capacity(matches.len());
+    for (conn_id, sub_id) in matches {
+        let Some(pubkey) = state.conn_manager.pubkey_for_conn(conn_id) else {
+            continue;
+        };
+        match state.is_member_cached(channel_id, &pubkey).await {
+            Ok(true) => allowed.push((conn_id, sub_id)),
+            Ok(false) => {}
+            Err(e) => {
+                warn!(%channel_id, "fan-out access filter: membership lookup failed: {e}");
+            }
+        }
+    }
+    allowed
+}
+
 /// Publish a stored event to subscribers and kick off async side effects.
 pub(crate) async fn dispatch_persistent_event(
     state: &Arc<AppState>,
@@ -70,6 +114,7 @@ pub(crate) async fn dispatch_persistent_event(
     }
 
     let matches = state.sub_registry.fan_out(stored_event);
+    let matches = filter_fanout_by_access(state, stored_event, matches).await;
     metrics::histogram!("sprout_fanout_recipients").record(matches.len() as f64);
     debug!(
         event_id = %event_id_hex,
@@ -922,5 +967,147 @@ mod tests {
 
         let err = super::agent_observer_route(&event).expect_err("route should reject plaintext");
         assert!(err.contains("NIP-44"));
+    }
+
+    mod fanout_access {
+        use std::collections::HashMap;
+        use std::sync::atomic::AtomicU8;
+        use std::sync::Arc;
+
+        use nostr::{EventBuilder, Keys, Kind};
+        use sprout_core::StoredEvent;
+        use tokio::sync::{mpsc, Mutex};
+        use tokio_util::sync::CancellationToken;
+        use uuid::Uuid;
+
+        use crate::handlers::event::filter_fanout_by_access;
+        use crate::state::AppState;
+
+        fn test_config() -> crate::config::Config {
+            let mut config = crate::config::Config::from_env().expect("default config loads");
+            config.require_relay_membership = false;
+            config.redis_url = "redis://127.0.0.1:1".to_string();
+            config
+        }
+
+        async fn test_state() -> Arc<AppState> {
+            let config = test_config();
+            let pool = sqlx::PgPool::connect_lazy(&config.database_url).expect("lazy pg pool");
+            let db = sprout_db::Db::from_pool(pool.clone());
+            let redis_pool = deadpool_redis::Config::from_url(&config.redis_url)
+                .create_pool(Some(deadpool_redis::Runtime::Tokio1))
+                .expect("redis pool");
+            let pubsub = Arc::new(
+                sprout_pubsub::PubSubManager::new(&config.redis_url, redis_pool.clone())
+                    .await
+                    .expect("pubsub manager"),
+            );
+            let audit = sprout_audit::AuditService::new(pool);
+            let auth = sprout_auth::AuthService::new(config.auth.clone());
+            let search = sprout_search::SearchService::new(sprout_search::SearchConfig {
+                url: config.typesense_url.clone(),
+                api_key: config.typesense_key.clone(),
+                collection: "events".to_string(),
+            });
+            let workflow_engine = Arc::new(sprout_workflow::WorkflowEngine::new(
+                db.clone(),
+                sprout_workflow::WorkflowConfig::default(),
+            ));
+            let media_storage =
+                sprout_media::MediaStorage::new(&config.media).expect("media storage");
+            let (state, _audit_shutdown) = AppState::new(
+                config,
+                db,
+                redis_pool,
+                audit,
+                pubsub,
+                auth,
+                search,
+                workflow_engine,
+                Keys::generate(),
+                media_storage,
+            );
+            Arc::new(state)
+        }
+
+        fn register_conn(state: &AppState, pubkey: Option<Vec<u8>>) -> Uuid {
+            let conn_id = Uuid::new_v4();
+            let (tx, _rx) = mpsc::channel(1);
+            state.conn_manager.register(
+                conn_id,
+                tx,
+                CancellationToken::new(),
+                Arc::new(AtomicU8::new(0)),
+                Arc::new(Mutex::new(HashMap::new())),
+            );
+            if let Some(pk) = pubkey {
+                state.conn_manager.set_authenticated_pubkey(conn_id, pk);
+            }
+            conn_id
+        }
+
+        fn channel_event(channel_id: Option<Uuid>) -> StoredEvent {
+            let event = EventBuilder::new(Kind::Custom(9), "{}")
+                .sign_with_keys(&Keys::generate())
+                .expect("sign event");
+            StoredEvent::new(event, channel_id)
+        }
+
+        #[tokio::test]
+        async fn channel_less_event_passes_through() {
+            let state = test_state().await;
+            let conn = register_conn(&state, Some(vec![1u8; 32]));
+            let matches = vec![(conn, "s".to_string())];
+            let out = filter_fanout_by_access(&state, &channel_event(None), matches.clone()).await;
+            assert_eq!(out, matches);
+        }
+
+        #[tokio::test]
+        async fn open_channel_event_passes_through_unfiltered() {
+            let state = test_state().await;
+            let channel_id = Uuid::new_v4();
+            state
+                .channel_visibility_cache
+                .insert(channel_id, "open".to_string());
+            // A connection with no authenticated pubkey would be dropped on a
+            // private channel; on open it must pass untouched.
+            let conn = register_conn(&state, None);
+            let matches = vec![(conn, "s".to_string())];
+            let out =
+                filter_fanout_by_access(&state, &channel_event(Some(channel_id)), matches.clone())
+                    .await;
+            assert_eq!(out, matches);
+        }
+
+        #[tokio::test]
+        async fn private_channel_keeps_member_drops_non_member_and_unknown() {
+            let state = test_state().await;
+            let channel_id = Uuid::new_v4();
+            state
+                .channel_visibility_cache
+                .insert(channel_id, "private".to_string());
+
+            let member_pk = vec![1u8; 32];
+            let non_member_pk = vec![2u8; 32];
+            state
+                .membership_cache
+                .insert((channel_id, member_pk.clone()), true);
+            state
+                .membership_cache
+                .insert((channel_id, non_member_pk.clone()), false);
+
+            let member = register_conn(&state, Some(member_pk));
+            let non_member = register_conn(&state, Some(non_member_pk));
+            let unauthed = register_conn(&state, None);
+
+            let matches = vec![
+                (member, "m".to_string()),
+                (non_member, "n".to_string()),
+                (unauthed, "u".to_string()),
+            ];
+            let out =
+                filter_fanout_by_access(&state, &channel_event(Some(channel_id)), matches).await;
+            assert_eq!(out, vec![(member, "m".to_string())]);
+        }
     }
 }

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -293,14 +293,22 @@ pub async fn validate_admin_event(
         }
         9002 => {
             // EDIT_METADATA: require at least one recognized metadata tag.
-            const RECOGNIZED_TAGS: &[&str] = &["name", "about", "archived", "topic", "purpose"];
+            const RECOGNIZED_TAGS: &[&str] = &[
+                "name",
+                "about",
+                "archived",
+                "topic",
+                "purpose",
+                "visibility",
+                "ttl",
+            ];
             let has_recognized = event
                 .tags
                 .iter()
                 .any(|t| RECOGNIZED_TAGS.contains(&t.kind().to_string().as_str()));
             if !has_recognized {
                 return Err(anyhow::anyhow!(
-                    "kind:9002 must include at least one metadata tag (name, about, archived, topic, purpose)"
+                    "kind:9002 must include at least one metadata tag (name, about, archived, topic, purpose, visibility, ttl)"
                 ));
             }
 
@@ -321,10 +329,53 @@ pub async fn validate_admin_event(
                 }
             }
 
-            // name/about/archived require owner/admin; topic/purpose allow any member
+            // Validate visibility values before storage.
+            for t in event.tags.iter() {
+                if t.kind().to_string() == "visibility" {
+                    match t.content() {
+                        Some("open") | Some("private") => {}
+                        Some(v) => {
+                            return Err(anyhow::anyhow!(
+                                "invalid visibility value: {v} (must be \"open\" or \"private\")"
+                            ));
+                        }
+                        None => {
+                            return Err(anyhow::anyhow!("visibility tag must have a value"));
+                        }
+                    }
+                }
+            }
+
+            // Validate ttl values before storage. Empty string clears the TTL
+            // (channel becomes permanent); any other value must parse as a
+            // positive integer number of seconds. A bare tag with no value is
+            // rejected so clearing is always explicit (`["ttl", ""]`).
+            for t in event.tags.iter() {
+                if t.kind().to_string() == "ttl" {
+                    match t.content() {
+                        Some("") => {}
+                        Some(v) => match v.parse::<i32>() {
+                            Ok(n) if n > 0 => {}
+                            _ => {
+                                return Err(anyhow::anyhow!(
+                                    "invalid ttl value: {v} (must be a positive integer of seconds, or empty to clear)"
+                                ));
+                            }
+                        },
+                        None => {
+                            return Err(anyhow::anyhow!(
+                                "ttl tag must have a value (seconds, or empty string to clear)"
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // name/about/archived/visibility/ttl require owner/admin;
+            // topic/purpose allow any member.
             let has_privileged_tag = event.tags.iter().any(|t| {
                 let k = t.kind().to_string();
-                k == "name" || k == "about" || k == "archived"
+                k == "name" || k == "about" || k == "archived" || k == "visibility" || k == "ttl"
             });
             if has_privileged_tag {
                 let members = state.db.get_members(channel_id).await?;
@@ -332,7 +383,7 @@ pub async fn validate_admin_event(
                 match actor_member {
                     Some(m) if m.role == "owner" || m.role == "admin" => Ok(()),
                     _ => Err(anyhow::anyhow!(
-                        "actor not authorized for name/about/archived changes"
+                        "actor not authorized for name/about/archived/visibility/ttl changes"
                     )),
                 }
             } else {
@@ -935,7 +986,7 @@ async fn handle_edit_metadata(event: &Event, state: &Arc<AppState>) -> anyhow::R
                             channel_id,
                             sprout_db::channel::ChannelUpdate {
                                 name: Some(val.to_string()),
-                                description: None,
+                                ..Default::default()
                             },
                         )
                         .await?;
@@ -946,8 +997,8 @@ async fn handle_edit_metadata(event: &Event, state: &Arc<AppState>) -> anyhow::R
                         .update_channel(
                             channel_id,
                             sprout_db::channel::ChannelUpdate {
-                                name: None,
                                 description: Some(val.to_string()),
+                                ..Default::default()
                             },
                         )
                         .await?;
@@ -970,6 +1021,56 @@ async fn handle_edit_metadata(event: &Event, state: &Arc<AppState>) -> anyhow::R
                         channel_id,
                         serde_json::json!({
                             "type": "purpose_changed", "actor": actor_hex, "purpose": val
+                        }),
+                    )
+                    .await?;
+                }
+                "visibility" => {
+                    state
+                        .db
+                        .update_channel(
+                            channel_id,
+                            sprout_db::channel::ChannelUpdate {
+                                visibility: Some(val.to_string()),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    // A visibility flip changes who can see the channel, so the
+                    // accessible-channels cache must be cleared.
+                    state.invalidate_all_accessible_channels();
+                    emit_system_message(
+                        state,
+                        channel_id,
+                        serde_json::json!({
+                            "type": "visibility_changed", "actor": actor_hex, "visibility": val
+                        }),
+                    )
+                    .await?;
+                }
+                "ttl" => {
+                    // Empty string clears the TTL (permanent); otherwise it is a
+                    // positive integer of seconds, validated during authorization.
+                    let ttl_change: Option<i32> = if val.is_empty() {
+                        None
+                    } else {
+                        val.parse::<i32>().ok()
+                    };
+                    state
+                        .db
+                        .update_channel(
+                            channel_id,
+                            sprout_db::channel::ChannelUpdate {
+                                ttl_seconds: Some(ttl_change),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    emit_system_message(
+                        state,
+                        channel_id,
+                        serde_json::json!({
+                            "type": "ttl_changed", "actor": actor_hex, "ttl_seconds": ttl_change
                         }),
                     )
                     .await?;

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -40,27 +40,61 @@ async fn evict_live_channel_subscriptions(
     let conn_ids = state.conn_manager.connection_ids_for_pubkey(target_pubkey);
 
     for conn_id in conn_ids {
-        let removed = state
-            .sub_registry
-            .remove_channel_subscriptions(conn_id, channel_id);
-        if removed.is_empty() {
-            continue;
-        }
+        evict_conn_channel_subscriptions(state, channel_id, conn_id).await;
+    }
+}
 
-        if let Some(subscriptions) = state.conn_manager.subscriptions_for(conn_id) {
-            let mut conn_subscriptions = subscriptions.lock().await;
-            for sub_id in &removed {
-                conn_subscriptions.remove(sub_id);
-            }
-        }
+/// Close every live channel-scoped subscription on `conn_id`, removing them from
+/// the connection's local map and sending `CLOSED restricted` for each.
+async fn evict_conn_channel_subscriptions(
+    state: &Arc<AppState>,
+    channel_id: Uuid,
+    conn_id: uuid::Uuid,
+) {
+    let removed = state
+        .sub_registry
+        .remove_channel_subscriptions(conn_id, channel_id);
+    if removed.is_empty() {
+        return;
+    }
 
-        for sub_id in removed {
-            let _ = state.conn_manager.send_to(
-                conn_id,
-                RelayMessage::closed(&sub_id, "restricted: channel access revoked"),
-            );
+    if let Some(subscriptions) = state.conn_manager.subscriptions_for(conn_id) {
+        let mut conn_subscriptions = subscriptions.lock().await;
+        for sub_id in &removed {
+            conn_subscriptions.remove(sub_id);
         }
     }
+
+    for sub_id in removed {
+        let _ = state.conn_manager.send_to(
+            conn_id,
+            RelayMessage::closed(&sub_id, "restricted: channel access revoked"),
+        );
+    }
+}
+
+/// Revoke live channel subscriptions held by connections whose authenticated
+/// pubkey is not a current member. Used when an open channel flips to private:
+/// non-members could have subscribed while it was open, and fan-out does not
+/// re-check membership per event, so their subscriptions must be closed.
+async fn evict_non_member_channel_subscriptions(
+    state: &Arc<AppState>,
+    channel_id: Uuid,
+) -> anyhow::Result<()> {
+    let members = state.db.get_members(channel_id).await?;
+    let member_pubkeys: std::collections::HashSet<Vec<u8>> =
+        members.into_iter().map(|m| m.pubkey).collect();
+
+    for conn_id in state.sub_registry.channel_subscriber_conns(channel_id) {
+        let is_member = match state.conn_manager.pubkey_for_conn(conn_id) {
+            Some(pubkey) => member_pubkeys.contains(&pubkey),
+            None => false,
+        };
+        if !is_member {
+            evict_conn_channel_subscriptions(state, channel_id, conn_id).await;
+        }
+    }
+    Ok(())
 }
 
 /// Dispatch side effects for a stored event.
@@ -1026,6 +1060,12 @@ async fn handle_edit_metadata(event: &Event, state: &Arc<AppState>) -> anyhow::R
                     .await?;
                 }
                 "visibility" => {
+                    let was_open = state
+                        .db
+                        .get_channel(channel_id)
+                        .await
+                        .map(|c| c.visibility == "open")
+                        .unwrap_or(false);
                     state
                         .db
                         .update_channel(
@@ -1039,6 +1079,12 @@ async fn handle_edit_metadata(event: &Event, state: &Arc<AppState>) -> anyhow::R
                     // A visibility flip changes who can see the channel, so the
                     // accessible-channels cache must be cleared.
                     state.invalidate_all_accessible_channels();
+                    // On open -> private, revoke live subscriptions held by
+                    // non-members; fan-out does not re-check access per event,
+                    // so a non-member's existing sub would keep receiving events.
+                    if was_open && val == "private" {
+                        evict_non_member_channel_subscriptions(state, channel_id).await?;
+                    }
                     emit_system_message(
                         state,
                         channel_id,
@@ -1051,10 +1097,14 @@ async fn handle_edit_metadata(event: &Event, state: &Arc<AppState>) -> anyhow::R
                 "ttl" => {
                     // Empty string clears the TTL (permanent); otherwise it is a
                     // positive integer of seconds, validated during authorization.
+                    // Fail closed: a parse failure must reject, never silently
+                    // clear the TTL to permanent.
                     let ttl_change: Option<i32> = if val.is_empty() {
                         None
                     } else {
-                        val.parse::<i32>().ok()
+                        Some(val.parse::<i32>().map_err(|_| {
+                            anyhow::anyhow!("invalid ttl value: {val} (must be a positive integer)")
+                        })?)
                     };
                     state
                         .db

--- a/crates/sprout-relay/src/handlers/side_effects.rs
+++ b/crates/sprout-relay/src/handlers/side_effects.rs
@@ -1077,11 +1077,13 @@ async fn handle_edit_metadata(event: &Event, state: &Arc<AppState>) -> anyhow::R
                         )
                         .await?;
                     // A visibility flip changes who can see the channel, so the
-                    // accessible-channels cache must be cleared.
+                    // accessible-channels and visibility caches must be cleared
+                    // before any later event for this channel fans out.
                     state.invalidate_all_accessible_channels();
-                    // On open -> private, revoke live subscriptions held by
-                    // non-members; fan-out does not re-check access per event,
-                    // so a non-member's existing sub would keep receiving events.
+                    state.invalidate_channel_visibility(channel_id);
+                    // On open -> private, eagerly close non-members' live subs
+                    // for an immediate CLOSED on this node. The fan-out access
+                    // filter is the cluster-wide correctness backstop.
                     if was_open && val == "private" {
                         evict_non_member_channel_subscriptions(state, channel_id).await?;
                     }

--- a/crates/sprout-relay/src/main.rs
+++ b/crates/sprout-relay/src/main.rs
@@ -408,6 +408,12 @@ async fn main() -> anyhow::Result<()> {
                         }
 
                         let matches = state_for_sub.sub_registry.fan_out(&stored);
+                        let matches = sprout_relay::handlers::event::filter_fanout_by_access(
+                            &state_for_sub,
+                            &stored,
+                            matches,
+                        )
+                        .await;
                         metrics::counter!("sprout_multinode_fanout_total").increment(1);
                         if matches.is_empty() {
                             continue;

--- a/crates/sprout-relay/src/state.rs
+++ b/crates/sprout-relay/src/state.rs
@@ -107,6 +107,13 @@ impl ConnectionManager {
             .collect()
     }
 
+    /// Return the authenticated pubkey recorded for a connection, if any.
+    pub fn pubkey_for_conn(&self, conn_id: Uuid) -> Option<Vec<u8>> {
+        self.connections
+            .get(&conn_id)
+            .and_then(|entry| entry.authenticated_pubkey.read().ok()?.clone())
+    }
+
     /// Return the subscription map for a connection, if it is still live.
     pub fn subscriptions_for(&self, conn_id: Uuid) -> Option<ConnectionSubscriptions> {
         self.connections
@@ -660,5 +667,22 @@ mod tests {
 
         assert_eq!(mgr.connection_ids_for_pubkey(&pubkey), vec![conn_id]);
         assert!(mgr.subscriptions_for(conn_id).is_some());
+    }
+
+    #[tokio::test]
+    async fn pubkey_for_conn_returns_authenticated_pubkey() {
+        let mgr = ConnectionManager::new();
+        let conn_id = Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel(1);
+        let cancel = CancellationToken::new();
+        let bp = Arc::new(AtomicU8::new(0));
+        let subscriptions = Arc::new(Mutex::new(HashMap::new()));
+        mgr.register(conn_id, tx, cancel, bp, subscriptions);
+
+        assert_eq!(mgr.pubkey_for_conn(conn_id), None);
+        let pubkey = vec![9u8; 32];
+        mgr.set_authenticated_pubkey(conn_id, pubkey.clone());
+        assert_eq!(mgr.pubkey_for_conn(conn_id), Some(pubkey));
+        assert_eq!(mgr.pubkey_for_conn(Uuid::new_v4()), None);
     }
 }

--- a/crates/sprout-relay/src/state.rs
+++ b/crates/sprout-relay/src/state.rs
@@ -211,6 +211,9 @@ pub struct AppState {
     /// Short TTL (10s) — invalidated on membership or channel visibility changes.
     /// Multi-pod: other pods rely on TTL expiry; only local caches are invalidated.
     pub accessible_channels_cache: Arc<moka::sync::Cache<Vec<u8>, Vec<Uuid>>>,
+    /// Per-channel visibility string, used to gate the private-channel fan-out
+    /// access check so open channels stay zero-cost. Invalidated on a flip.
+    pub channel_visibility_cache: Arc<moka::sync::Cache<Uuid, String>>,
 
     /// Bounded channel for search indexing — prevents OOM if Typesense is slow/down.
     /// Capacity 1000: at ~1KB/event that's ~1MB of backlog before we start dropping.
@@ -374,7 +377,12 @@ impl AppState {
                     .time_to_live(std::time::Duration::from_secs(10))
                     .build(),
             ),
-
+            channel_visibility_cache: Arc::new(
+                moka::sync::Cache::builder()
+                    .max_capacity(10_000)
+                    .time_to_live(std::time::Duration::from_secs(10))
+                    .build(),
+            ),
             search_index_tx,
             audit_tx,
             media_storage: Arc::new(media_storage),
@@ -441,6 +449,11 @@ impl AppState {
         self.accessible_channels_cache.invalidate_all();
     }
 
+    /// Invalidate the cached visibility for a single channel (e.g. after a flip).
+    pub fn invalidate_channel_visibility(&self, channel_id: Uuid) {
+        self.channel_visibility_cache.invalidate(&channel_id);
+    }
+
     /// Invalidate all caches after a channel is deleted.
     ///
     /// Channel deletion is a rare admin operation. We clear the entire membership
@@ -450,6 +463,7 @@ impl AppState {
     pub fn invalidate_channel_deleted(&self) {
         self.membership_cache.invalidate_all();
         self.accessible_channels_cache.invalidate_all();
+        self.channel_visibility_cache.invalidate_all();
     }
 
     /// Get accessible channel IDs with a 10-second cache. Falls back to DB on miss.
@@ -466,6 +480,30 @@ impl AppState {
         let result = self.db.get_accessible_channel_ids(pubkey).await?;
         self.accessible_channels_cache.insert(key, result.clone());
         Ok(result)
+    }
+
+    /// Channel visibility string. Caches only `private` (10s); never caches a
+    /// non-private value.
+    ///
+    /// The fan-out access gate fails open on a non-private result, so a stale
+    /// cached `open` on another node would mask the filter for the whole TTL
+    /// after an open->private flip (no cross-node cache invalidation). Caching
+    /// only `private` keeps the cache fail-safe: the worst stale entry is an
+    /// over-restrictive `private` (drops non-members on a now-open channel for
+    /// <=10s), never a leak.
+    pub async fn channel_visibility_cached(
+        &self,
+        channel_id: Uuid,
+    ) -> Result<String, sprout_db::DbError> {
+        if let Some(cached) = self.channel_visibility_cache.get(&channel_id) {
+            return Ok(cached);
+        }
+        let visibility = self.db.get_channel(channel_id).await?.visibility;
+        if visibility == "private" {
+            self.channel_visibility_cache
+                .insert(channel_id, visibility.clone());
+        }
+        Ok(visibility)
     }
 }
 

--- a/crates/sprout-relay/src/subscription.rs
+++ b/crates/sprout-relay/src/subscription.rs
@@ -174,6 +174,21 @@ impl SubscriptionRegistry {
         sub_ids
     }
 
+    /// Return the distinct connection IDs holding any subscription scoped to
+    /// `channel_id` (both kind-filtered and wildcard channel subscriptions).
+    pub fn channel_subscriber_conns(&self, channel_id: Uuid) -> Vec<ConnId> {
+        let mut conns: HashSet<ConnId> = HashSet::new();
+        for entry in self.channel_kind_index.iter() {
+            if entry.key().channel_id == channel_id {
+                conns.extend(entry.value().iter().map(|(conn_id, _)| *conn_id));
+            }
+        }
+        if let Some(entry) = self.channel_wildcard_index.get(&channel_id) {
+            conns.extend(entry.value().iter().map(|(conn_id, _)| *conn_id));
+        }
+        conns.into_iter().collect()
+    }
+
     /// Return all (conn_id, sub_id) pairs whose filters match the given event.
     pub fn fan_out(&self, event: &StoredEvent) -> Vec<(ConnId, SubId)> {
         let mut results = Vec::new();
@@ -926,6 +941,50 @@ mod tests {
         let matches_b = registry.fan_out(&event_b);
         assert_eq!(matches_b.len(), 1);
         assert_eq!(matches_b[0].1, "sub-b");
+    }
+
+    #[test]
+    fn test_channel_subscriber_conns_dedupes_and_scopes_to_channel() {
+        let registry = SubscriptionRegistry::new();
+        let conn_a = Uuid::new_v4();
+        let conn_b = Uuid::new_v4();
+        let conn_other = Uuid::new_v4();
+        let channel = Uuid::new_v4();
+        let channel_other = Uuid::new_v4();
+
+        // conn_a: a kinded + a wildcard sub on the channel — must dedupe to one entry.
+        registry.register(
+            conn_a,
+            "kinded".to_string(),
+            vec![Filter::new().kind(Kind::TextNote)],
+            Some(channel),
+        );
+        registry.register(
+            conn_a,
+            "wildcard".to_string(),
+            vec![Filter::new()],
+            Some(channel),
+        );
+        // conn_b: kinded sub on the channel.
+        registry.register(
+            conn_b,
+            "b".to_string(),
+            vec![Filter::new().kind(Kind::Metadata)],
+            Some(channel),
+        );
+        // conn_other: subscribed to a different channel — must be excluded.
+        registry.register(
+            conn_other,
+            "other".to_string(),
+            vec![Filter::new().kind(Kind::TextNote)],
+            Some(channel_other),
+        );
+
+        let mut conns = registry.channel_subscriber_conns(channel);
+        conns.sort();
+        let mut expected = vec![conn_a, conn_b];
+        expected.sort();
+        assert_eq!(conns, expected);
     }
 
     #[test]

--- a/crates/sprout-sdk/src/builders.rs
+++ b/crates/sprout-sdk/src/builders.rs
@@ -534,16 +534,28 @@ pub fn build_leave(channel_id: Uuid) -> Result<EventBuilder, SdkError> {
 
 // ── Builder 16: build_update_channel ─────────────────────────────────────────
 
-/// Build a NIP-29 edit-metadata event for name/about (kind 9002).
+/// Build a NIP-29 edit-metadata event for name/about/visibility/ttl (kind 9002).
+///
+/// `ttl`: outer `None` leaves it unchanged; `Some(Some(secs))` sets the
+/// ephemeral timeout; `Some(None)` clears it (emits `["ttl", ""]`).
 pub fn build_update_channel(
     channel_id: Uuid,
     name: Option<&str>,
     about: Option<&str>,
+    visibility: Option<&str>,
+    ttl: Option<Option<i32>>,
 ) -> Result<EventBuilder, SdkError> {
-    if name.is_none() && about.is_none() {
+    if name.is_none() && about.is_none() && visibility.is_none() && ttl.is_none() {
         return Err(SdkError::InvalidTag(
-            "at least one of name or about must be provided".into(),
+            "at least one of name, about, visibility, or ttl must be provided".into(),
         ));
+    }
+    if let Some(v) = visibility {
+        if v != "open" && v != "private" {
+            return Err(SdkError::InvalidTag(
+                "visibility must be \"open\" or \"private\"".into(),
+            ));
+        }
     }
     let mut tags = vec![tag(&["h", &channel_id.to_string()])?];
     if let Some(n) = name {
@@ -551,6 +563,15 @@ pub fn build_update_channel(
     }
     if let Some(a) = about {
         tags.push(tag(&["about", a])?);
+    }
+    if let Some(v) = visibility {
+        tags.push(tag(&["visibility", v])?);
+    }
+    if let Some(ttl) = ttl {
+        match ttl {
+            Some(secs) => tags.push(tag(&["ttl", &secs.to_string()])?),
+            None => tags.push(tag(&["ttl", ""])?),
+        }
     }
     Ok(EventBuilder::new(Kind::Custom(9002), "").tags(tags))
 }
@@ -1606,17 +1627,45 @@ mod tests {
     #[test]
     fn update_channel_name_and_about() {
         let cid = uuid();
-        let ev = sign(build_update_channel(cid, Some("new-name"), Some("new about")).unwrap());
+        let ev = sign(
+            build_update_channel(cid, Some("new-name"), Some("new about"), None, None).unwrap(),
+        );
         assert_eq!(ev.kind.as_u16(), 9002);
         assert!(has_tag(&ev, "name", "new-name"));
         assert!(has_tag(&ev, "about", "new about"));
     }
 
     #[test]
+    fn update_channel_visibility_and_ttl() {
+        let cid = uuid();
+        let ev =
+            sign(build_update_channel(cid, None, None, Some("private"), Some(Some(3600))).unwrap());
+        assert_eq!(ev.kind.as_u16(), 9002);
+        assert!(has_tag(&ev, "visibility", "private"));
+        assert!(has_tag(&ev, "ttl", "3600"));
+    }
+
+    #[test]
+    fn update_channel_clears_ttl() {
+        let cid = uuid();
+        let ev = sign(build_update_channel(cid, None, None, None, Some(None)).unwrap());
+        assert!(has_tag(&ev, "ttl", ""));
+    }
+
+    #[test]
+    fn update_channel_invalid_visibility_rejected() {
+        let cid = uuid();
+        assert!(matches!(
+            build_update_channel(cid, None, None, Some("secret"), None),
+            Err(SdkError::InvalidTag(_))
+        ));
+    }
+
+    #[test]
     fn update_channel_no_fields_rejected() {
         let cid = uuid();
         assert!(matches!(
-            build_update_channel(cid, None, None),
+            build_update_channel(cid, None, None, None, None),
             Err(SdkError::InvalidTag(_))
         ));
     }

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
         "**/custom-emoji-screenshots.spec.ts",
         "**/channel-mute-screenshots.spec.ts",
         "**/channel-star-screenshots.spec.ts",
+        "**/channel-controls-screenshots.spec.ts",
         "**/file-attachment.spec.ts",
         "**/mentions.spec.ts",
         "**/relay-reconnect.spec.ts",

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -329,22 +329,41 @@ pub async fn create_channel(
         .ok_or_else(|| "channel created but metadata not yet available".to_string())
 }
 
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateChannelInput {
+    pub channel_id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub visibility: Option<String>,
+    /// Absent = leave unchanged, `null` = clear (permanent), seconds = set.
+    #[serde(default, deserialize_with = "crate::util::double_option")]
+    pub ttl_seconds: Option<Option<i32>>,
+}
+
 #[tauri::command]
 pub async fn update_channel(
-    channel_id: String,
-    name: Option<String>,
-    description: Option<String>,
+    input: UpdateChannelInput,
     state: State<'_, AppState>,
 ) -> Result<ChannelDetailInfo, String> {
-    let uuid = parse_channel_uuid(&channel_id)?;
-    let builder = events::build_update_channel(uuid, name.as_deref(), description.as_deref())?;
+    let uuid = parse_channel_uuid(&input.channel_id)?;
+    let builder = events::build_update_channel(
+        uuid,
+        input.name.as_deref(),
+        input.description.as_deref(),
+        input.visibility.as_deref(),
+        input.ttl_seconds,
+    )?;
     submit_event(builder, &state).await?;
 
     let events = query_relay(
         &state,
         &[serde_json::json!({
             "kinds": [39000],
-            "#d": [channel_id],
+            "#d": [input.channel_id],
             "limit": 1
         })],
     )

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -158,14 +158,24 @@ pub fn build_leave(channel_id: Uuid) -> Result<EventBuilder, String> {
     Ok(EventBuilder::new(Kind::Custom(9022), "").tags(tags))
 }
 
-/// Kind 9002 — update channel name/description.
+/// Kind 9002 — update channel name/description/visibility/ttl.
+///
+/// `ttl`: outer `None` leaves it unchanged; `Some(Some(secs))` sets the
+/// ephemeral timeout; `Some(None)` clears it (emits `["ttl", ""]`).
 pub fn build_update_channel(
     channel_id: Uuid,
     name: Option<&str>,
     about: Option<&str>,
+    visibility: Option<&str>,
+    ttl: Option<Option<i32>>,
 ) -> Result<EventBuilder, String> {
-    if name.is_none() && about.is_none() {
-        return Err("at least one of name or about must be provided".into());
+    if name.is_none() && about.is_none() && visibility.is_none() && ttl.is_none() {
+        return Err("at least one of name, about, visibility, or ttl must be provided".into());
+    }
+    if let Some(v) = visibility {
+        if v != "open" && v != "private" {
+            return Err("visibility must be \"open\" or \"private\"".into());
+        }
     }
     let mut tags = vec![tag(vec!["h", &channel_id.to_string()])?];
     if let Some(n) = name {
@@ -173,6 +183,15 @@ pub fn build_update_channel(
     }
     if let Some(a) = about {
         tags.push(tag(vec!["about", a])?);
+    }
+    if let Some(v) = visibility {
+        tags.push(tag(vec!["visibility", v])?);
+    }
+    if let Some(ttl) = ttl {
+        match ttl {
+            Some(secs) => tags.push(tag(vec!["ttl", &secs.to_string()])?),
+            None => tags.push(tag(vec!["ttl", ""])?),
+        }
     }
     Ok(EventBuilder::new(Kind::Custom(9002), "").tags(tags))
 }

--- a/desktop/src-tauri/src/util.rs
+++ b/desktop/src-tauri/src/util.rs
@@ -4,6 +4,21 @@ pub fn now_iso() -> String {
     Utc::now().to_rfc3339()
 }
 
+/// Deserialize an `Option<Option<T>>` field that distinguishes an absent key
+/// from an explicit JSON `null`.
+///
+/// Plain serde collapses a present `null` into the outer `None`, making
+/// "clear this field" indistinguishable from "leave it unchanged". Paired with
+/// `#[serde(default)]`, this yields the tri-state needed for nullable patches:
+/// absent → `None`, `null` → `Some(None)`, value → `Some(Some(value))`.
+pub fn double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: serde::Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(Some)
+}
+
 /// Turn a human-readable name into a filesystem-safe slug.
 ///
 /// Non-alphanumeric characters become hyphens, leading/trailing hyphens are
@@ -30,6 +45,21 @@ pub fn slugify(name: &str, fallback: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::slugify;
+
+    #[test]
+    fn double_option_tristate() {
+        #[derive(serde::Deserialize)]
+        struct P {
+            #[serde(default, deserialize_with = "super::double_option")]
+            ttl: Option<Option<i32>>,
+        }
+        let absent: P = serde_json::from_str("{}").unwrap();
+        let null: P = serde_json::from_str(r#"{"ttl": null}"#).unwrap();
+        let set: P = serde_json::from_str(r#"{"ttl": 3600}"#).unwrap();
+        assert_eq!(absent.ttl, None);
+        assert_eq!(null.ttl, Some(None));
+        assert_eq!(set.ttl, Some(Some(3600)));
+    }
 
     #[test]
     fn slugify_basic() {

--- a/desktop/src/features/channels/lib/ephemeralChannel.test.mjs
+++ b/desktop/src/features/channels/lib/ephemeralChannel.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatTtlDuration, parseTtlDuration } from "./ephemeralChannel.ts";
+
+test("parseTtlDuration parses single units", () => {
+  assert.equal(parseTtlDuration("45s"), 45);
+  assert.equal(parseTtlDuration("30m"), 30 * 60);
+  assert.equal(parseTtlDuration("12h"), 12 * 60 * 60);
+  assert.equal(parseTtlDuration("1d"), 24 * 60 * 60);
+});
+
+test("parseTtlDuration parses combined units and tolerates whitespace/case", () => {
+  assert.equal(parseTtlDuration("1d12h"), 36 * 60 * 60);
+  assert.equal(parseTtlDuration(" 1D 12H "), 36 * 60 * 60);
+  assert.equal(parseTtlDuration("1h30m"), 90 * 60);
+});
+
+test("parseTtlDuration rejects malformed input", () => {
+  assert.equal(parseTtlDuration(""), null);
+  assert.equal(parseTtlDuration("   "), null);
+  assert.equal(parseTtlDuration("100"), null); // no unit
+  assert.equal(parseTtlDuration("1x"), null); // bad unit
+  assert.equal(parseTtlDuration("1d!"), null); // trailing junk
+  assert.equal(parseTtlDuration("abc"), null);
+  assert.equal(parseTtlDuration("0m"), null); // zero total
+  assert.equal(parseTtlDuration("1d1d"), null); // duplicate unit
+});
+
+test("formatTtlDuration is the inverse for common values", () => {
+  assert.equal(formatTtlDuration(45), "45s");
+  assert.equal(formatTtlDuration(30 * 60), "30m");
+  assert.equal(formatTtlDuration(12 * 60 * 60), "12h");
+  assert.equal(formatTtlDuration(24 * 60 * 60), "1d");
+  assert.equal(formatTtlDuration(36 * 60 * 60), "1d12h");
+  assert.equal(formatTtlDuration(90 * 60), "1h30m");
+});
+
+test("formatTtlDuration handles non-positive input", () => {
+  assert.equal(formatTtlDuration(0), "");
+  assert.equal(formatTtlDuration(-5), "");
+});
+
+test("parse/format round-trip", () => {
+  for (const s of ["30m", "12h", "1d", "1d12h", "1h30m", "45s"]) {
+    assert.equal(formatTtlDuration(parseTtlDuration(s)), s);
+  }
+});

--- a/desktop/src/features/channels/lib/ephemeralChannel.ts
+++ b/desktop/src/features/channels/lib/ephemeralChannel.ts
@@ -165,3 +165,73 @@ export function getEphemeralChannelDisplay(
           : `Ephemeral channel. Cleans up ${verboseRemaining}.`,
   };
 }
+
+const TTL_UNIT_SECONDS: Record<string, number> = {
+  s: 1,
+  m: 60,
+  h: 60 * 60,
+  d: 60 * 60 * 24,
+};
+
+const TTL_TOKEN_RE = /(\d+)([smhd])/giy;
+
+/**
+ * Parse a friendly duration string (`30m`, `12h`, `1d`, or combinations like
+ * `1d12h`) into a positive number of seconds.
+ *
+ * Whitespace is tolerated, units are case-insensitive, and a bare number is
+ * rejected (a unit is always required). Returns `null` for empty or malformed
+ * input, or for a total of zero. The same unit may not appear twice.
+ */
+export function parseTtlDuration(input: string): number | null {
+  const cleaned = input.trim().toLowerCase().replace(/\s+/g, "");
+  if (cleaned === "") {
+    return null;
+  }
+
+  TTL_TOKEN_RE.lastIndex = 0;
+  const seen = new Set<string>();
+  let total = 0;
+  let consumed = 0;
+  for (
+    let match = TTL_TOKEN_RE.exec(cleaned);
+    match !== null;
+    match = TTL_TOKEN_RE.exec(cleaned)
+  ) {
+    const [token, amount, unit] = match;
+    if (seen.has(unit)) {
+      return null;
+    }
+    seen.add(unit);
+    total += Number(amount) * TTL_UNIT_SECONDS[unit];
+    consumed += token.length;
+  }
+
+  // Reject leftover characters (e.g. "1x", "1d!", "abc") and zero totals.
+  if (consumed !== cleaned.length || total <= 0) {
+    return null;
+  }
+  return total;
+}
+
+/**
+ * Format a number of seconds back into a compact friendly string (`30m`,
+ * `12h`, `1d`, `1d12h`) — the inverse of `parseTtlDuration` for the common
+ * cases. Components that are zero are omitted; a non-positive input yields `""`.
+ */
+export function formatTtlDuration(ttlSeconds: number): string {
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+    return "";
+  }
+  let remaining = Math.floor(ttlSeconds);
+  const parts: string[] = [];
+  for (const unit of ["d", "h", "m", "s"] as const) {
+    const size = TTL_UNIT_SECONDS[unit];
+    const count = Math.floor(remaining / size);
+    if (count > 0) {
+      parts.push(`${count}${unit}`);
+      remaining -= count * size;
+    }
+  }
+  return parts.join("");
+}

--- a/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
@@ -27,6 +27,10 @@ import {
   useUpdateChannelMutation,
 } from "@/features/channels/hooks";
 import { compareMembersByRole } from "@/features/channels/lib/memberUtils";
+import {
+  formatTtlDuration,
+  parseTtlDuration,
+} from "@/features/channels/lib/ephemeralChannel";
 import { CreateWorkflowDialog } from "@/features/workflows/ui/CreateWorkflowDialog";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
@@ -48,9 +52,11 @@ import {
   Sheet,
   SheetContent,
   SheetDescription,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/shared/ui/sheet";
+import { Switch } from "@/shared/ui/switch";
 import { Textarea } from "@/shared/ui/textarea";
 import { ChannelCanvas } from "./ChannelCanvas";
 
@@ -160,6 +166,9 @@ export function ChannelManagementSheet({
   const [descriptionDraft, setDescriptionDraft] = React.useState("");
   const [topicDraft, setTopicDraft] = React.useState("");
   const [purposeDraft, setPurposeDraft] = React.useState("");
+  const [isPrivateDraft, setIsPrivateDraft] = React.useState(false);
+  const [isEphemeralDraft, setIsEphemeralDraft] = React.useState(false);
+  const [ttlDraft, setTtlDraft] = React.useState("");
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
   const [isCreateWorkflowOpen, setIsCreateWorkflowOpen] = React.useState(false);
 
@@ -188,6 +197,11 @@ export function ChannelManagementSheet({
     setDescriptionDraft(detail.description);
     setTopicDraft(detail.topic ?? "");
     setPurposeDraft(detail.purpose ?? "");
+    setIsPrivateDraft(detail.visibility === "private");
+    setIsEphemeralDraft(detail.ttlSeconds !== null);
+    setTtlDraft(
+      detail.ttlSeconds !== null ? formatTtlDuration(detail.ttlSeconds) : "",
+    );
   }, [detail, open]);
 
   if (!channel) {
@@ -216,6 +230,38 @@ export function ChannelManagementSheet({
     }
 
     onOpenChange(next);
+  }
+
+  // Parsed seconds for the ephemeral TTL field. `null` when the field is empty
+  // or malformed; the form blocks saving on a non-empty malformed value.
+  const parsedTtlSeconds = parseTtlDuration(ttlDraft);
+  const ttlInvalid =
+    isEphemeralDraft && ttlDraft.trim() !== "" && parsedTtlSeconds === null;
+
+  const currentVisibility = detail?.visibility ?? channel.visibility;
+  const currentTtlSeconds = detail?.ttlSeconds ?? null;
+  const nextVisibility: "open" | "private" = isPrivateDraft
+    ? "private"
+    : "open";
+  // Ephemeral on with a parsed duration → set those seconds; ephemeral off →
+  // clear (null). An ephemeral toggle with an empty/invalid field leaves the
+  // existing TTL untouched (undefined) so an accidental clear can't happen.
+  const nextTtlSeconds: number | null | undefined = isEphemeralDraft
+    ? (parsedTtlSeconds ?? undefined)
+    : null;
+  const lifecycleDirty =
+    nextVisibility !== currentVisibility ||
+    (nextTtlSeconds !== undefined && nextTtlSeconds !== currentTtlSeconds);
+
+  function handleSaveLifecycle() {
+    void updateChannelMutation.mutateAsync({
+      visibility:
+        nextVisibility !== currentVisibility ? nextVisibility : undefined,
+      ttlSeconds:
+        nextTtlSeconds !== undefined && nextTtlSeconds !== currentTtlSeconds
+          ? nextTtlSeconds
+          : undefined,
+    });
   }
 
   const resolvedChannel = detail ?? channel;
@@ -363,6 +409,93 @@ export function ChannelManagementSheet({
             ) : null}
           </form>
 
+          {resolvedChannel.channelType !== "dm" ? (
+            <div
+              className="space-y-4"
+              data-testid="channel-management-lifecycle"
+            >
+              <div className="flex items-center justify-between gap-4">
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">Private</p>
+                  <p className="text-xs text-muted-foreground">
+                    Only members can find and join this channel.
+                  </p>
+                </div>
+                <Switch
+                  checked={isPrivateDraft}
+                  data-testid="channel-management-private-toggle"
+                  disabled={
+                    !canManageChannel || updateChannelMutation.isPending
+                  }
+                  onCheckedChange={setIsPrivateDraft}
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-4">
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">Ephemeral</p>
+                  <p className="text-xs text-muted-foreground">
+                    Automatically delete this channel after a set time.
+                  </p>
+                </div>
+                <Switch
+                  checked={isEphemeralDraft}
+                  data-testid="channel-management-ephemeral-toggle"
+                  disabled={
+                    !canManageChannel || updateChannelMutation.isPending
+                  }
+                  onCheckedChange={setIsEphemeralDraft}
+                />
+              </div>
+
+              {isEphemeralDraft ? (
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium" htmlFor="channel-ttl">
+                    Timeout
+                  </label>
+                  <Input
+                    aria-invalid={ttlInvalid}
+                    data-testid="channel-management-ttl"
+                    disabled={
+                      !canManageChannel || updateChannelMutation.isPending
+                    }
+                    id="channel-ttl"
+                    onChange={(event) => setTtlDraft(event.target.value)}
+                    placeholder="e.g. 1d, 12h, 30m"
+                    value={ttlDraft}
+                  />
+                  <p
+                    className={cn(
+                      "text-xs",
+                      ttlInvalid ? "text-destructive" : "text-muted-foreground",
+                    )}
+                  >
+                    {ttlInvalid
+                      ? "Enter a duration like 1d, 12h, or 30m."
+                      : "Resets the deletion countdown from now whenever changed."}
+                  </p>
+                </div>
+              ) : null}
+
+              <Button
+                data-testid="channel-management-save-lifecycle"
+                disabled={
+                  !canManageChannel ||
+                  updateChannelMutation.isPending ||
+                  ttlInvalid ||
+                  !lifecycleDirty
+                }
+                onClick={handleSaveLifecycle}
+                size="sm"
+                type="button"
+              >
+                {updateChannelMutation.isPending
+                  ? "Saving..."
+                  : "Save visibility"}
+              </Button>
+            </div>
+          ) : null}
+
           <form
             className="space-y-3"
             onSubmit={(event) => {
@@ -449,9 +582,19 @@ export function ChannelManagementSheet({
               Create workflow
             </Button>
           ) : null}
+        </div>
 
-          {resolvedChannel.channelType !== "dm" ? (
-            <div className="space-y-3">
+        {resolvedChannel.channelType !== "dm" ? (
+          <SheetFooter
+            className={cn(
+              "border-t border-border/80 px-6 py-4 sm:flex-row sm:justify-start sm:space-x-0",
+              isDark
+                ? "bg-background/60 backdrop-blur-xl supports-[backdrop-filter]:bg-background/50"
+                : "bg-background",
+            )}
+            data-testid="channel-management-footer"
+          >
+            <div className="w-full space-y-3">
               <div className="flex items-center gap-2">
                 {canLeave ? (
                   <Button
@@ -584,8 +727,8 @@ export function ChannelManagementSheet({
                 </p>
               ) : null}
             </div>
-          ) : null}
-        </div>
+          </SheetFooter>
+        ) : null}
       </SheetContent>
 
       <CreateWorkflowDialog

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -579,7 +579,9 @@ export async function getChannelMembers(
 export async function updateChannel(
   input: UpdateChannelInput,
 ): Promise<ChannelDetail> {
-  const channel = await invokeTauri<RawChannelDetail>("update_channel", input);
+  const channel = await invokeTauri<RawChannelDetail>("update_channel", {
+    input,
+  });
   return fromRawChannelDetail(channel);
 }
 

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -57,6 +57,9 @@ export type UpdateChannelInput = {
   channelId: string;
   name?: string;
   description?: string;
+  visibility?: ChannelVisibility;
+  /** Omit to leave unchanged, `null` to clear (permanent), or a positive number of seconds to set. */
+  ttlSeconds?: number | null;
 };
 
 export type SetChannelTopicInput = {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -3128,6 +3128,8 @@ async function handleUpdateChannel(
     channelId: string;
     name?: string;
     description?: string;
+    visibility?: "open" | "private";
+    ttlSeconds?: number | null;
   },
   config: E2eConfig | undefined,
 ) {
@@ -3140,6 +3142,16 @@ async function handleUpdateChannel(
     if (args.description !== undefined) {
       channel.description = args.description;
     }
+    if (args.visibility !== undefined) {
+      channel.visibility = args.visibility;
+    }
+    if (args.ttlSeconds !== undefined) {
+      channel.ttl_seconds = args.ttlSeconds;
+      channel.ttl_deadline =
+        args.ttlSeconds === null
+          ? null
+          : new Date(Date.now() + args.ttlSeconds * 1000).toISOString();
+    }
     touchMockChannel(channel);
     return toRawChannelDetail(channel, config);
   }
@@ -3151,6 +3163,12 @@ async function handleUpdateChannel(
   if (args.description !== undefined) {
     tags.push(["about", args.description]);
   }
+  if (args.visibility !== undefined) {
+    tags.push(["visibility", args.visibility]);
+  }
+  if (args.ttlSeconds !== undefined) {
+    tags.push(["ttl", args.ttlSeconds === null ? "" : String(args.ttlSeconds)]);
+  }
   await submitSignedEvent(config, { kind: 9002, content: "", tags });
 
   // Re-fetch updated metadata
@@ -3161,19 +3179,24 @@ async function handleUpdateChannel(
   const evTags = (ev?.tags ?? []) as string[][];
   const getTag = (name: string) =>
     evTags.find((t) => t[0] === name)?.[1] ?? null;
+  const ttlTag = getTag("ttl");
+  const ttlSeconds = ttlTag === null || ttlTag === "" ? null : Number(ttlTag);
   return {
     id: args.channelId,
     name: getTag("name") ?? "",
     description: getTag("about") ?? null,
     channel_type: getTag("t") ?? "stream",
-    visibility: evTags.some((t) => t[0] === "private") ? "private" : "open",
+    visibility: getTag("visibility") ?? "open",
     topic: getTag("topic") ?? null,
     purpose: getTag("purpose") ?? null,
     member_count: 0,
     role: "owner",
     archived_at: null,
-    ttl_seconds: null,
-    ttl_deadline: null,
+    ttl_seconds: ttlSeconds,
+    ttl_deadline:
+      ttlSeconds === null
+        ? null
+        : new Date(Date.now() + ttlSeconds * 1000).toISOString(),
     created_at: ev?.created_at
       ? new Date(ev.created_at * 1000).toISOString()
       : new Date().toISOString(),
@@ -5608,7 +5631,8 @@ export function maybeInstallE2eTauriMocks() {
         );
       case "update_channel":
         return handleUpdateChannel(
-          payload as Parameters<typeof handleUpdateChannel>[0],
+          (payload as { input: Parameters<typeof handleUpdateChannel>[0] })
+            .input,
           activeConfig,
         );
       case "set_channel_topic":

--- a/desktop/tests/e2e/channel-controls-screenshots.spec.ts
+++ b/desktop/tests/e2e/channel-controls-screenshots.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const SHOTS = "test-results/channel-controls";
+
+// `general` seeds the mock identity as owner, so the owner/admin-gated
+// visibility + ephemeral controls are live and interactive.
+async function openManagementSheet(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await page.getByTestId("channel-management-trigger").click();
+  await expect(page.getByTestId("channel-management-sheet")).toBeVisible();
+}
+
+async function settle(page: import("@playwright/test").Page) {
+  await page.evaluate(() =>
+    Promise.all(document.getAnimations().map((a) => a.finished)),
+  );
+}
+
+test.describe("channel controls screenshots", () => {
+  test("01 — lifecycle section: Private + Ephemeral switches", async ({
+    page,
+  }) => {
+    await installMockBridge(page);
+    await openManagementSheet(page);
+
+    const lifecycle = page.getByTestId("channel-management-lifecycle");
+    await lifecycle.scrollIntoViewIfNeeded();
+    await expect(
+      page.getByTestId("channel-management-private-toggle"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("channel-management-ephemeral-toggle"),
+    ).toBeVisible();
+    await settle(page);
+
+    await lifecycle.screenshot({ path: `${SHOTS}/01-lifecycle-default.png` });
+  });
+
+  test("02 — Private toggled on", async ({ page }) => {
+    await installMockBridge(page);
+    await openManagementSheet(page);
+
+    const lifecycle = page.getByTestId("channel-management-lifecycle");
+    await lifecycle.scrollIntoViewIfNeeded();
+    await page.getByTestId("channel-management-private-toggle").click();
+    await expect(
+      page.getByTestId("channel-management-private-toggle"),
+    ).toBeChecked();
+    // Save button enables once the visibility actually changed.
+    await expect(
+      page.getByTestId("channel-management-save-lifecycle"),
+    ).toBeEnabled();
+    await settle(page);
+
+    await lifecycle.screenshot({ path: `${SHOTS}/02-private-on.png` });
+  });
+
+  test("03 — Ephemeral on with friendly timeout field", async ({ page }) => {
+    await installMockBridge(page);
+    await openManagementSheet(page);
+
+    const lifecycle = page.getByTestId("channel-management-lifecycle");
+    await lifecycle.scrollIntoViewIfNeeded();
+    await page.getByTestId("channel-management-ephemeral-toggle").click();
+
+    const ttl = page.getByTestId("channel-management-ttl");
+    await expect(ttl).toBeVisible();
+    await ttl.fill("1d12h");
+    await expect(
+      page.getByTestId("channel-management-save-lifecycle"),
+    ).toBeEnabled();
+    await settle(page);
+
+    await lifecycle.screenshot({ path: `${SHOTS}/03-ephemeral-ttl.png` });
+  });
+
+  test("04 — invalid timeout blocks save with inline error", async ({
+    page,
+  }) => {
+    await installMockBridge(page);
+    await openManagementSheet(page);
+
+    const lifecycle = page.getByTestId("channel-management-lifecycle");
+    await lifecycle.scrollIntoViewIfNeeded();
+    await page.getByTestId("channel-management-ephemeral-toggle").click();
+
+    const ttl = page.getByTestId("channel-management-ttl");
+    await ttl.fill("soon");
+    await expect(ttl).toHaveAttribute("aria-invalid", "true");
+    await expect(
+      page.getByTestId("channel-management-save-lifecycle"),
+    ).toBeDisabled();
+    await settle(page);
+
+    await lifecycle.screenshot({ path: `${SHOTS}/04-ttl-invalid.png` });
+  });
+
+  test("05 — sticky footer pins lifecycle buttons", async ({ page }) => {
+    await installMockBridge(page);
+    await openManagementSheet(page);
+
+    const footer = page.getByTestId("channel-management-footer");
+    await expect(footer).toBeVisible();
+    await expect(page.getByTestId("channel-management-archive")).toBeVisible();
+    await settle(page);
+
+    await footer.screenshot({ path: `${SHOTS}/05-sticky-footer.png` });
+  });
+
+  test("06 — full sheet with new controls", async ({ page }) => {
+    await installMockBridge(page);
+    await openManagementSheet(page);
+
+    const sheet = page.getByTestId("channel-management-sheet");
+    await expect(sheet).toBeVisible();
+    await settle(page);
+
+    await sheet.screenshot({ path: `${SHOTS}/06-management-sheet.png` });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the ability to edit a channel's **visibility** (open/private) and its **ephemeral TTL** after creation, plus a **sticky footer** so the lifecycle buttons (Archive/Unarchive/Leave/Delete) stay visible in the channel manage sidebar. Requested by @Wes.

Previously these fields could only be set at channel-creation time; the kind:9002 edit-metadata path didn't know about them.

## What changed

### Relay (minimal slice)
- **kind:9002 handler** now recognizes new `visibility` and `ttl` tags, validates them (visibility ∈ `open`/`private`; ttl = positive seconds, or `""` to clear → permanent), gates them **owner/admin-only** (same tier as name/about/archived), persists, resets `ttl_deadline = NOW() + ttl` on ttl change, and emits `visibility_changed` / `ttl_changed` system messages.
- A visibility flip **invalidates the accessible-channels cache** — without this, a freshly-private channel would stay visible to non-members until the cache expired.
- **sprout-db** `ChannelUpdate` gains `visibility` and a tri-state `ttl_seconds` (`Some(Some(n))`=set, `Some(None)`=clear, `None`=untouched). Clearing nulls both ttl columns.

### Desktop
- Sidebar lifecycle section: a **Private** switch, an **Ephemeral** switch, and a friendly duration field (`1d`/`12h`/`30m`, combos like `1d12h`) shown when ephemeral is on, with inline validation and a dirty-aware "Save visibility" button (only enables when something actually changed and the duration is valid; an empty/invalid field can't accidentally clear an existing TTL).
- **Sticky `border-t` footer** for Archive/Unarchive/Leave/Delete, pulled out of the scroll area.
- Friendly `1d`/`12h`/`30m` parse/format lives entirely in the web layer; the wire protocol stays numeric seconds, matching channel creation.
- The tauri command uses a `double_option` deserializer so a present `null` survives serde as `Some(None)` (clear) rather than collapsing to `None` (no-change).

## Verification
- Pre-commit: rustfmt, tauri-fmt, biome, file-sizes, mobile analyze — all ✓
- Pre-push full suite: `rust-tests`, `rust-clippy`, `desktop-test`, `desktop-tauri-test`, `desktop-tauri-clippy`, `mobile-test` — all ✓
- New unit tests: ephemeralChannel parse/format + round-trip; SDK builder set/clear/invalid-visibility/no-fields.

The relay validation and the sprout-db update SQL are exercised by the Rust test suite + CI (live Postgres paths) rather than additional inline unit tests.

🤖 Adversarial review requested from @Pinky in parallel.
