### PR TITLE
feat(desktop): wire directory-backed team UI — install, sync, reveal

### DIFF
--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -150,6 +150,9 @@ export function AgentsView() {
               onEdit={teamActions.openEditDialog}
               onExport={teamActions.handleExportTeam}
               onImportFile={teamActions.handleImportFile}
+              onInstallFromDirectory={teamActions.handleInstallFromDirectory}
+              onSync={teamActions.handleSyncTeam}
+              onRevealInFinder={teamActions.handleRevealInFinder}
               onAddToChannel={teamActions.setTeamToAddToChannel}
               personas={personas.libraryPersonas}
               teams={teamActions.teams}

--- a/desktop/src/features/agents/ui/TeamsSection.tsx
+++ b/desktop/src/features/agents/ui/TeamsSection.tsx
@@ -2,7 +2,10 @@ import {
   CopyPlus,
   Download,
   Ellipsis,
+  FolderOpen,
+  FolderSync,
   Info,
+  Link,
   Pencil,
   Rocket,
   Trash2,
@@ -41,6 +44,9 @@ type TeamsSectionProps = {
   onDelete: (team: AgentTeam) => void;
   onAddToChannel: (team: AgentTeam) => void;
   onImportFile: (fileBytes: number[], fileName: string) => void;
+  onInstallFromDirectory: () => void;
+  onSync: (team: AgentTeam) => void;
+  onRevealInFinder: (team: AgentTeam) => void;
 };
 
 export function TeamsSection({
@@ -56,6 +62,9 @@ export function TeamsSection({
   onDelete,
   onAddToChannel,
   onImportFile,
+  onInstallFromDirectory,
+  onSync,
+  onRevealInFinder,
 }: TeamsSectionProps) {
   const {
     fileInputRef,
@@ -93,11 +102,21 @@ export function TeamsSection({
           ref={fileInputRef}
           type="file"
         />
-        <CreateNewButton
-          ariaLabel="Create team"
-          label="Team"
-          onClick={onCreate}
-        />
+        <div className="flex items-center gap-2">
+          <button
+            className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={onInstallFromDirectory}
+            type="button"
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+            Install from directory
+          </button>
+          <CreateNewButton
+            ariaLabel="Create team"
+            label="Team"
+            onClick={onCreate}
+          />
+        </div>
       </div>
 
       {isLoading ? (
@@ -138,6 +157,25 @@ export function TeamsSection({
                       <p className="truncate text-sm font-semibold tracking-tight">
                         {team.name}
                       </p>
+                      {team.isSymlink ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
+                              <Link className="h-3.5 w-3.5" />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="max-w-xs">
+                            <p>
+                              Linked from {team.symlinkTarget ?? team.sourceDir}
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      ) : null}
+                      {team.version ? (
+                        <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          v{team.version}
+                        </span>
+                      ) : null}
                       {team.description ? (
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -221,6 +259,24 @@ export function TeamsSection({
                         <Download className="h-4 w-4" />
                         Export
                       </DropdownMenuItem>
+                      {team.sourceDir ? (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            disabled={isPending}
+                            onClick={() => onSync(team)}
+                          >
+                            <FolderSync className="h-4 w-4" />
+                            Sync from directory
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => onRevealInFinder(team)}
+                          >
+                            <FolderOpen className="h-4 w-4" />
+                            Reveal in Finder
+                          </DropdownMenuItem>
+                        </>
+                      ) : null}
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         className="text-destructive focus:text-destructive"

--- a/desktop/src/features/agents/ui/useTeamActions.ts
+++ b/desktop/src/features/agents/ui/useTeamActions.ts
@@ -15,13 +15,17 @@ import {
   type ParsedTeamPreview,
   createTeam as createTeamApi,
   exportTeamToJson,
+  installTeamFromDirectory,
   parseTeamFile,
+  pickTeamDirectory,
+  syncTeamDirectory,
 } from "@/shared/api/tauriTeams";
 import {
   createPersona,
   deletePersona,
   updatePersona,
 } from "@/shared/api/tauriPersonas";
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import type {
   AgentPersona,
   AgentTeam,
@@ -205,6 +209,63 @@ export function useTeamActions(
         err instanceof Error ? err.message : "Failed to parse team file.",
       );
     }
+  }
+
+  async function handleInstallFromDirectory() {
+    actions.setActionNoticeMessage(null);
+    actions.setActionErrorMessage(null);
+    try {
+      const path = await pickTeamDirectory();
+      if (!path) return;
+      const team = await installTeamFromDirectory(path, true);
+      actions.setActionNoticeMessage(
+        `Installed team "${team.name}" from directory.`,
+      );
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: teamsQueryKey }),
+        queryClient.invalidateQueries({ queryKey: personasQueryKey }),
+        queryClient.invalidateQueries({ queryKey: managedAgentsQueryKey }),
+      ]);
+    } catch (err) {
+      actions.setActionErrorMessage(
+        err instanceof Error
+          ? err.message
+          : "Failed to install team from directory.",
+      );
+    }
+  }
+
+  async function handleSyncTeam(team: AgentTeam) {
+    actions.setActionNoticeMessage(null);
+    actions.setActionErrorMessage(null);
+    try {
+      const result = await syncTeamDirectory(team.id);
+      const changes = [
+        result.personas_added.length > 0 &&
+          `${result.personas_added.length} added`,
+        result.personas_updated.length > 0 &&
+          `${result.personas_updated.length} updated`,
+        result.personas_removed.length > 0 &&
+          `${result.personas_removed.length} removed`,
+      ].filter(Boolean);
+      const summary =
+        changes.length > 0 ? changes.join(", ") : "already up to date";
+      actions.setActionNoticeMessage(`Synced "${team.name}": ${summary}.`);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: teamsQueryKey }),
+        queryClient.invalidateQueries({ queryKey: personasQueryKey }),
+        queryClient.invalidateQueries({ queryKey: managedAgentsQueryKey }),
+      ]);
+    } catch (err) {
+      actions.setActionErrorMessage(
+        err instanceof Error ? err.message : "Failed to sync team directory.",
+      );
+    }
+  }
+
+  function handleRevealInFinder(team: AgentTeam) {
+    if (!team.sourceDir) return;
+    void revealItemInDir(team.sourceDir);
   }
 
   async function handleEditDialogImportUpdateFile(
@@ -492,6 +553,9 @@ export function useTeamActions(
     handleTeamDeployed,
     handleExportTeam,
     handleImportFile,
+    handleInstallFromDirectory,
+    handleSyncTeam,
+    handleRevealInFinder,
     handleEditDialogImportUpdateFile,
     handleTeamImportComplete,
     handleTeamImportUpdateApply,

--- a/desktop/src/shared/api/tauriTeams.ts
+++ b/desktop/src/shared/api/tauriTeams.ts
@@ -11,6 +11,10 @@ type RawTeam = {
   description: string | null;
   persona_ids: string[];
   is_builtin?: boolean;
+  source_dir?: string | null;
+  is_symlink?: boolean;
+  symlink_target?: string | null;
+  version?: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -22,6 +26,10 @@ function fromRawTeam(team: RawTeam): AgentTeam {
     description: team.description,
     personaIds: team.persona_ids,
     isBuiltin: team.is_builtin ?? false,
+    sourceDir: team.source_dir ?? null,
+    isSymlink: team.is_symlink ?? false,
+    symlinkTarget: team.symlink_target ?? null,
+    version: team.version ?? null,
     createdAt: team.created_at,
     updatedAt: team.updated_at,
   };
@@ -82,4 +90,31 @@ export async function parseTeamFile(
     fileBytes,
     fileName,
   });
+}
+
+export type SyncResult = {
+  personas_added: string[];
+  personas_removed: string[];
+  personas_updated: string[];
+  metadata_changed: boolean;
+};
+
+export async function pickTeamDirectory(): Promise<string | null> {
+  return invokeTauri<string | null>("pick_team_directory");
+}
+
+export async function installTeamFromDirectory(
+  path: string,
+  symlink?: boolean,
+): Promise<AgentTeam> {
+  return fromRawTeam(
+    await invokeTauri<RawTeam>("install_team_from_directory", {
+      path,
+      symlink: symlink ?? false,
+    }),
+  );
+}
+
+export async function syncTeamDirectory(teamId: string): Promise<SyncResult> {
+  return invokeTauri<SyncResult>("sync_team_directory", { teamId });
 }

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -501,6 +501,14 @@ export type AgentTeam = {
   description: string | null;
   personaIds: string[];
   isBuiltin: boolean;
+  /** Absolute path to the team's backing directory (if directory-backed). */
+  sourceDir: string | null;
+  /** Whether sourceDir is a symlink to an external directory. */
+  isSymlink: boolean;
+  /** Resolved symlink target path (for display). Only set when isSymlink is true. */
+  symlinkTarget: string | null;
+  /** Version from the team's plugin.json manifest. */
+  version: string | null;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
Adds the frontend UI for directory-backed team management, building on the backend plumbing from PR #852.

## Changes

**`tauriTeams.ts`** — New Tauri command bindings:
- `installTeamFromDirectory(path)` — install a team from a local directory
- `syncTeamDirectory(teamId)` — re-sync a directory-backed team with its source
- `pickTeamDirectory()` — open native directory picker

**`types.ts`** — Extended `AgentTeam` with directory-backed fields:
- `sourceDir`, `isSymlink`, `symlinkTarget`, `version`

**`TeamsSection.tsx`** — Enhanced team cards for directory-backed teams:
- Symlink badge indicator when `isSymlink` is true
- Version badge when `version` is set
- "Reveal in Finder" menu item (via `@tauri-apps/plugin-opener`)
- "Sync" menu item to reconcile directory changes
- "Install from directory" button in the section header

**`useTeamActions.ts`** — New hook composing install/sync mutations with the directory picker flow.

**`AgentsView.tsx`** — Wires the install-from-directory action into the teams section.

Stack: #852 → this PR