### PR TITLE
fix(updater): send no-cache header on update check to avoid stale manifest

### DIFF
--- a/desktop/src/features/settings/hooks/use-updater.ts
+++ b/desktop/src/features/settings/hooks/use-updater.ts
@@ -122,7 +122,9 @@ export function useUpdater() {
           setStatus({ state: "checking" });
         }
 
-        const update = await check();
+        const update = await check({
+          headers: { "Cache-Control": "no-cache" },
+        });
         const shouldShowQuietResult =
           !background || manualResultRequestedRef.current;
 


### PR DESCRIPTION
## Problem

"Check for updates" is flaky: the new version is published but the check often reports "up to date" until you click 3–4 times or restart the app.

Root cause (full writeup in `RESEARCH/UPDATE_CHECK_FLAKINESS.md`): the updater fetches `latest.json` with a plain `GET` and no cache directive. The manifest is overwritten in place at a stable URL and served from a multi-node cache (Fastly for OSS, Artifactory HA replicas for the internal build) with **no `Cache-Control`**. A check can hit a node still serving the *old* manifest → `version` not greater than current → "up to date". A retry/restart eventually lands on a fresh node — the 4-clicks symptom.

## Fix

Pass `Cache-Control: no-cache` request headers on the updater `check()`, so every poll explicitly revalidates instead of trusting a stale cached copy.

```ts
const update = await check({ headers: { "Cache-Control": "no-cache" } });
```

This sits in `runUpdateCheck`, the single code path behind **both** the manual "Check for updates" button and the launch/6h background check, so one edit covers every check.

## Scope / honesty

This is app-side hardening — a backstop, not a standalone fix. A shared/origin cache can ignore *request* headers, so this is most effective paired with the response-side fix landing in `squareup/sprout-releases` (no-cache on the Artifactory manifest PUT). It meaningfully helps the **internal** build.

For the **public/OSS** path to be deterministic, a follow-up is still needed: point the OSS check at a source that isn't asset-CDN-cached (the GitHub **API** release endpoint returns `cache-control: max-age=60` + ETag, bounded staleness, no node roulette). github.com strips the query string before redirecting to the signed asset, so a cache-buster can't beat the OSS asset CDN.

## Testing

No hook-test harness exists in this repo yet, and this is a pure pass-through of an options object verified against `tauri-plugin-updater`'s typed API (`CheckOptions.headers?: HeadersInit`). Full pre-push suite (desktop-test, rust-tests, mobile-test, clippy, tauri-test) passes green. Adding a Tauri-plugin mock + RTL scaffold for a one-liner felt disproportionate — flagging the tradeoff rather than hiding it.
