### PR TITLE
fix(desktop): refresh channel state after unarchive

### DIFF
--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -319,6 +319,9 @@ export function useUnarchiveChannelMutation(channelId: string | null) {
 
       setChannelArchivedState(queryClient, channelId, null);
     },
+    onSettled: async () => {
+      await invalidateChannelState(queryClient, channelId);
+    },
   });
 }
 


### PR DESCRIPTION
## Problem

Unarchiving a channel succeeds on the relay, but the desktop UI keeps showing the channel as archived in the channel browser/search and leaves the message composer disabled. Verified the relay side is correct: the unarchived channel reports `archived_at: null`, and both the send-gate and channel-list/search read `archived_at` fresh from the DB.

## Root cause

In `desktop/src/features/channels/hooks.ts` there's an asymmetry between the archive and unarchive mutations:

- `useArchiveChannelMutation` patches the cache optimistically (`onSuccess`) **and** invalidates/refetches via `onSettled → invalidateChannelState`.
- `useUnarchiveChannelMutation` only did the optimistic patch — no `onSettled`.

The optimistic patch updates `channelsQueryKey` and the detail query in place, but doesn't reconcile against the relay. The channel browser reads the list query and the composer gate reads the detail query; with `useChannelsQuery` on a 60s `staleTime`/`refetchInterval`, the stale archived state sticks until an unrelated refetch fires.

## Fix

Give the unarchive mutation the same `onSettled: invalidateChannelState` the archive mutation already has, so the channel list, detail, and members queries refetch from the relay after a successful unarchive.

```diff
       setChannelArchivedState(queryClient, channelId, null);
     },
+    onSettled: async () => {
+      await invalidateChannelState(queryClient, channelId);
+    },
   });
 }
```

## Verification

- `tsc --noEmit` — clean
- `biome lint` (changed file) — clean
- `pnpm test` — 585/585 pass
- pre-push hook suite (rust-tests, clippy, desktop/mobile/tauri tests) — all green

## Note on tests

No regression test added. The desktop suite runs node's built-in test runner over `*.test.mjs` for pure-logic modules — there's no React/`renderHook`/QueryClient harness, so testing this React Query lifecycle wiring would require standing up a new harness, disproportionate to a one-line symmetry fix. Happy to add the harness + a mutation-lifecycle test as a follow-up if desired.
