### PR TITLE
Maximize desktop window on launch

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -371,7 +371,17 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(
             tauri_plugin_window_state::Builder::default()
-                .with_state_flags(StateFlags::all() & !StateFlags::VISIBLE)
+                // The main window should always launch edge-to-edge in the
+                // available desktop area. Do not let stale saved geometry or
+                // fullscreen state override the maximized launch config.
+                .with_state_flags(
+                    StateFlags::all()
+                        & !(StateFlags::VISIBLE
+                            | StateFlags::POSITION
+                            | StateFlags::SIZE
+                            | StateFlags::MAXIMIZED
+                            | StateFlags::FULLSCREEN),
+                )
                 .build(),
         )
         .plugin(tauri_plugin_websocket::init())

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -19,6 +19,7 @@
         "title": "",
         "width": 800,
         "height": 600,
+        "maximized": true,
         "visible": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,


### PR DESCRIPTION
## Summary
- launches the desktop main window maximized by default
- stops saved window-state geometry/fullscreen flags from overriding the maximized launch config

## Checks
- code-checks review pass completed for the native launch slice
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml --features mesh-llm`
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`