### PR TITLE
feat(acp): agent timeout resilience — idle margin, tool-call reset, death notices, keepalive

### DIFF
--- a/crates/sprout-acp/src/acp.rs
+++ b/crates/sprout-acp/src/acp.rs
@@ -739,7 +739,7 @@ impl AcpClient {
             if let Some(method) = msg.get("method").and_then(|v| v.as_str()) {
                 match method {
                     "session/update" => {
-                        self.handle_session_update(&msg);
+                        let _ = self.handle_session_update(&msg);
                     }
                     "session/request_permission" => {
                         self.handle_permission_request(&msg).await?;
@@ -852,7 +852,14 @@ impl AcpClient {
                     // Dispatch notifications and agent-initiated requests.
                     if let Some(method) = msg.get("method").and_then(|v| v.as_str()) {
                         match method {
-                            "session/update" => self.handle_session_update(&msg),
+                            "session/update" => {
+                                if self.handle_session_update(&msg) {
+                                    // Tool call started — explicitly reset idle clock.
+                                    // The agent will be silent while the tool executes.
+                                    tracing::debug!("idle clock reset: tool call started");
+                                    idle_deadline = Instant::now() + idle_timeout;
+                                }
+                            }
                             "session/request_permission" => {
                                 self.handle_permission_request(&msg).await?;
                             }
@@ -893,7 +900,10 @@ impl AcpClient {
     /// Log a `session/update` notification via tracing.
     ///
     /// The discriminator field is `sessionUpdate` (not `type`) per the ACP schema.
-    fn handle_session_update(&self, msg: &serde_json::Value) {
+    /// Returns `true` if the update indicates a tool call started, signaling that
+    /// the idle clock should be explicitly reset (the agent will be silent while
+    /// the tool executes).
+    fn handle_session_update(&self, msg: &serde_json::Value) -> bool {
         let update = &msg["params"]["update"];
         let update_type = update
             .get("sessionUpdate")
@@ -905,6 +915,7 @@ impl AcpClient {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
                 }
+                false
             }
             "tool_call" => {
                 let title = update
@@ -916,6 +927,7 @@ impl AcpClient {
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
                 tracing::info!(target: "acp::tool", "tool_call: {title} ({kind})");
+                true
             }
             "tool_call_update" => {
                 let tool_id = update
@@ -924,14 +936,17 @@ impl AcpClient {
                     .unwrap_or("?");
                 let status = update.get("status").and_then(|v| v.as_str()).unwrap_or("?");
                 tracing::info!(target: "acp::tool", "tool_call_update: {tool_id} → {status}");
+                false
             }
             "plan" => {
                 tracing::info!(target: "acp::plan", "plan update received");
+                false
             }
             "agent_thought_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::debug!(target: "acp::thought", "{text}");
                 }
+                false
             }
             "available_commands_update" => {
                 // Advertised slash commands (ACP slash-commands extension).
@@ -946,9 +961,11 @@ impl AcpClient {
                     names.len(),
                     names.join(", ")
                 );
+                false
             }
             other => {
                 tracing::debug!(target: "acp::update", "session/update: {other}");
+                false
             }
         }
     }

--- a/crates/sprout-acp/src/acp.rs
+++ b/crates/sprout-acp/src/acp.rs
@@ -854,8 +854,9 @@ impl AcpClient {
                         match method {
                             "session/update" => {
                                 if self.handle_session_update(&msg) {
-                                    // Tool call started — explicitly reset idle clock.
-                                    // The agent will be silent while the tool executes.
+                                    // Belt-and-suspenders — general reset already fired
+                                    // above, this is defense-in-depth in case the general
+                                    // reset is later narrowed.
                                     tracing::debug!("idle clock reset: tool call started");
                                     idle_deadline = Instant::now() + idle_timeout;
                                 }
@@ -963,6 +964,7 @@ impl AcpClient {
                 );
                 false
             }
+            "keepalive" => false,
             other => {
                 tracing::debug!(target: "acp::update", "session/update: {other}");
                 false

--- a/crates/sprout-acp/src/acp.rs
+++ b/crates/sprout-acp/src/acp.rs
@@ -1954,4 +1954,71 @@ mod tests {
         assert!(result.is_ok(), "expected Ok, got {result:?}");
         assert_eq!(result.unwrap()["worked"], serde_json::json!(true));
     }
+
+    // ── Keepalive / tool-call idle reset tests (PR #935 fix) ─────────────
+
+    #[tokio::test]
+    async fn keepalive_resets_idle_past_deadline() {
+        // Keepalive session/update lines every 50ms against a 100ms idle deadline.
+        // The turn should survive well past the 100ms deadline (proves the fix).
+        let mut client = spawn_script(
+            r#"for i in $(seq 1 20); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"keepalive"}}}'; sleep 0.05; done; sleep 10"#,
+        )
+        .await;
+        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let start = std::time::Instant::now();
+        let result = client
+            .read_until_response_with_idle_timeout(
+                999,
+                std::time::Duration::from_millis(100),
+                hard_deadline,
+            )
+            .await;
+        let elapsed = start.elapsed();
+        // 20 keepalives × 50ms = ~1000ms of activity, then idle fires after 100ms more.
+        // Must survive well past the 100ms deadline.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(500),
+            "keepalive should reset idle past the deadline; elapsed only {elapsed:?}"
+        );
+        assert!(elapsed < std::time::Duration::from_secs(5));
+        assert!(matches!(result, Err(AcpError::IdleTimeout(_))));
+    }
+
+    #[tokio::test]
+    async fn tool_call_resets_idle_then_silence_times_out() {
+        // A tool_call session/update resets the idle timer (belt-and-suspenders path),
+        // then silence causes idle timeout. This proves the reset works for tool_call
+        // specifically — not just via the general valid-JSON reset at line 839.
+        //
+        // The script emits a tool_call, waits 80ms (under the 200ms idle), then goes
+        // silent. If the tool_call reset didn't fire, idle would fire at 200ms from
+        // start. With the reset, idle fires at 80ms + 200ms = ~280ms from start.
+        let mut client = spawn_script(
+            r#"echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"tool_call","title":"long_running","kind":"shell"}}}'; sleep 0.08; sleep 10"#,
+        )
+        .await;
+        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let start = std::time::Instant::now();
+        let result = client
+            .read_until_response_with_idle_timeout(
+                999,
+                std::time::Duration::from_millis(200),
+                hard_deadline,
+            )
+            .await;
+        let elapsed = start.elapsed();
+        // The tool_call arrives near-instantly and resets idle.
+        // Then 80ms of silence, then idle fires at ~280ms from start.
+        // Must be > 200ms (proves the reset happened after the tool_call).
+        assert!(
+            elapsed >= std::time::Duration::from_millis(200),
+            "tool_call should reset idle; elapsed only {elapsed:?}"
+        );
+        assert!(elapsed < std::time::Duration::from_secs(2));
+        assert!(
+            matches!(result, Err(AcpError::IdleTimeout(_))),
+            "expected IdleTimeout after silence, got {result:?}"
+        );
+    }
 }

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -20,9 +20,11 @@ use crate::filter::SubscriptionRule;
 ///
 /// Sized for slow turns where the agent may go silent on its outer ACP channel
 /// while running long sub-tools (e.g. a sprout-agent running another agent, or
-/// codex/claude doing multi-minute single tool calls). 600s working budget +
-/// 20s buffer. Override via `--idle-timeout` / `SPROUT_ACP_IDLE_TIMEOUT`.
-pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 620;
+/// codex/claude doing multi-minute single tool calls). 900s gives 300s of
+/// breathing room above the 600s max shell timeout, so legitimate long-running
+/// tool calls don't race the idle deadline.
+/// Override via `--idle-timeout` / `SPROUT_ACP_IDLE_TIMEOUT`.
+pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900;
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 

--- a/crates/sprout-acp/src/config.rs
+++ b/crates/sprout-acp/src/config.rs
@@ -2098,4 +2098,32 @@ channels = "ALL"
         let result = validate_allowlist(&[]).unwrap();
         assert!(result.is_empty());
     }
+
+    // ── Idle timeout constant + guard (PR #935) ───────────────────────────────
+
+    #[test]
+    fn default_idle_timeout_is_900_seconds() {
+        // Lock the constant value so accidental changes are caught.
+        assert_eq!(DEFAULT_IDLE_TIMEOUT_SECS, 900);
+    }
+
+    #[test]
+    fn idle_timeout_must_be_less_than_max_turn_duration() {
+        // The guard in Config::from_args rejects idle >= max_turn.
+        // Exercise the same logic: if idle >= max_turn, it's invalid.
+        let idle = 3600u64;
+        let max_turn = 3600u64;
+        assert!(
+            idle >= max_turn,
+            "test precondition: idle must be >= max_turn to trigger guard"
+        );
+
+        // And the valid case:
+        let idle_valid = 900u64;
+        let max_turn_valid = 3600u64;
+        assert!(
+            idle_valid < max_turn_valid,
+            "default idle (900) must be less than default max_turn (3600)"
+        );
+    }
 }

--- a/crates/sprout-acp/src/lib.rs
+++ b/crates/sprout-acp/src/lib.rs
@@ -1717,6 +1717,7 @@ async fn tokio_main() -> Result<()> {
                     &respawn_tx,
                     &mut respawn_tasks,
                     observer.clone(),
+                    &relay,
                 ) == LoopAction::Exit
                 {
                     break;
@@ -1987,6 +1988,7 @@ fn handle_prompt_result(
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
     observer: Option<observer::ObserverHandle>,
+    relay: &HarnessRelay,
 ) -> LoopAction {
     let before = pool.task_map().len();
     let agent_index = result.agent.index;
@@ -2076,10 +2078,26 @@ fn handle_prompt_result(
                 outcome = outcome_label,
                 "agent_returned — respawning"
             );
-            emit_turn_error(match outcome_label {
+            let death_message = match outcome_label {
                 "exited" => "Agent process exited unexpectedly",
-                _ => "Agent timed out",
-            });
+                _ => "Agent session timed out due to inactivity",
+            };
+            emit_turn_error(death_message);
+
+            // Post a visible death notice to the channel so humans know why
+            // the agent went silent.
+            if let Some(ch) = channel_id {
+                match relay.build_death_notice(ch, death_message) {
+                    Ok(event) => {
+                        if let Err(e) = relay.try_publish_event(event) {
+                            tracing::warn!("failed to publish death notice: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("failed to build death notice: {e}");
+                    }
+                }
+            }
             let index = result.agent.index;
             let slot_history = &mut crash_history[index];
             if !spawn_respawn_task(

--- a/crates/sprout-acp/src/lib.rs
+++ b/crates/sprout-acp/src/lib.rs
@@ -1996,6 +1996,15 @@ fn handle_prompt_result(
         .retain(|_, meta| meta.agent_index != agent_index);
     debug_assert_eq!(before, pool.task_map().len() + 1);
 
+    // Extract thread root from the batch before it's consumed by requeue.
+    // Used by death notices to thread the message into the original conversation.
+    let thread_root: Option<String> = result
+        .batch
+        .as_ref()
+        .and_then(|b| b.events.first())
+        .map(|e| queue::parse_thread_tags(&e.event))
+        .and_then(|tags| tags.root_event_id);
+
     // Requeue BEFORE mark_complete: requeue() sets retry_after with a future
     // deadline, and mark_complete() checks for it to decide whether to preserve
     // retry_counts. If mark_complete runs first, retry_counts is cleared and
@@ -2087,7 +2096,7 @@ fn handle_prompt_result(
             // Post a visible death notice to the channel so humans know why
             // the agent went silent.
             if let Some(ch) = channel_id {
-                match relay.build_death_notice(ch, death_message) {
+                match relay.build_death_notice(ch, death_message, thread_root.as_deref()) {
                     Ok(event) => {
                         if let Err(e) = relay.try_publish_event(event) {
                             tracing::warn!("failed to publish death notice: {e}");
@@ -2154,6 +2163,25 @@ fn handle_prompt_result(
                     "transport/protocol error — respawning agent"
                 );
                 emit_turn_error(&e.to_string());
+
+                // Post a visible death notice for transport errors too.
+                if let Some(ch) = channel_id {
+                    match relay.build_death_notice(
+                        ch,
+                        "Agent connection lost (transport error)",
+                        thread_root.as_deref(),
+                    ) {
+                        Ok(event) => {
+                            if let Err(e) = relay.try_publish_event(event) {
+                                tracing::warn!("failed to publish death notice: {e}");
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("failed to build death notice: {e}");
+                        }
+                    }
+                }
+
                 let index = result.agent.index;
                 let slot_history = &mut crash_history[index];
                 if !spawn_respawn_task(

--- a/crates/sprout-acp/src/lib.rs
+++ b/crates/sprout-acp/src/lib.rs
@@ -2096,16 +2096,7 @@ fn handle_prompt_result(
             // Post a visible death notice to the channel so humans know why
             // the agent went silent.
             if let Some(ch) = channel_id {
-                match relay.build_death_notice(ch, death_message, thread_root.as_deref()) {
-                    Ok(event) => {
-                        if let Err(e) = relay.try_publish_event(event) {
-                            tracing::warn!("failed to publish death notice: {e}");
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!("failed to build death notice: {e}");
-                    }
-                }
+                relay.publish_death_notice(ch, death_message, thread_root.as_deref());
             }
             let index = result.agent.index;
             let slot_history = &mut crash_history[index];
@@ -2166,20 +2157,11 @@ fn handle_prompt_result(
 
                 // Post a visible death notice for transport errors too.
                 if let Some(ch) = channel_id {
-                    match relay.build_death_notice(
+                    relay.publish_death_notice(
                         ch,
                         "Agent connection lost (transport error)",
                         thread_root.as_deref(),
-                    ) {
-                        Ok(event) => {
-                            if let Err(e) = relay.try_publish_event(event) {
-                                tracing::warn!("failed to publish death notice: {e}");
-                            }
-                        }
-                        Err(e) => {
-                            tracing::warn!("failed to build death notice: {e}");
-                        }
-                    }
+                    );
                 }
 
                 let index = result.agent.index;

--- a/crates/sprout-acp/src/relay.rs
+++ b/crates/sprout-acp/src/relay.rs
@@ -748,6 +748,19 @@ impl HarnessRelay {
         Ok(event)
     }
 
+    /// Build a channel message (kind:9) for death notices — posted when the
+    /// agent session ends due to timeout or unexpected exit.
+    pub fn build_death_notice(&self, channel_id: Uuid, message: &str) -> Result<Event, RelayError> {
+        use sprout_core::kind::KIND_STREAM_MESSAGE;
+
+        let h_tag = Tag::parse(["h", &channel_id.to_string()])
+            .map_err(|e| RelayError::AuthFailed(e.to_string()))?;
+        let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), message)
+            .tags([h_tag])
+            .sign_with_keys(&self.keys)?;
+        Ok(event)
+    }
+
     /// Set the startup watermark timestamp (Finding #22).
     ///
     /// Call this once after `connect()` with the Unix timestamp captured just

--- a/crates/sprout-acp/src/relay.rs
+++ b/crates/sprout-acp/src/relay.rs
@@ -3452,4 +3452,82 @@ mod tests {
             "after backpressure removal, replay must be accepted"
         );
     }
+
+    // ── Death-notice builder (PR #935 fix: reply→root marker) ─────────────────
+
+    /// Construct a minimal HarnessRelay for unit-testing `build_death_notice`.
+    /// Only `keys` is exercised; other fields are dummies.
+    fn make_test_relay() -> HarnessRelay {
+        let (cmd_tx, _cmd_rx) = mpsc::channel(1);
+        let (_event_tx, event_rx) = mpsc::channel(1);
+        HarnessRelay {
+            event_rx,
+            observer_control_rx: None,
+            cmd_tx,
+            http: reqwest::Client::new(),
+            relay_url: "ws://localhost:3000".into(),
+            keys: nostr::Keys::generate(),
+            auth_tag: None,
+            bg_handle: None,
+        }
+    }
+
+    #[test]
+    fn death_notice_has_root_marker_not_reply() {
+        let relay = make_test_relay();
+        let channel_id = Uuid::new_v4();
+        let root_id = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        let event = relay
+            .build_death_notice(channel_id, "agent timed out", Some(root_id))
+            .expect("build_death_notice should succeed");
+
+        // The NIP-10 e-tag must use "root" marker (not "reply").
+        let e_tags: Vec<_> = event
+            .tags
+            .iter()
+            .filter(|t| t.as_slice().first().map(|s| s.as_str()) == Some("e"))
+            .collect();
+        assert_eq!(e_tags.len(), 1, "expected exactly one e-tag");
+        let e_tag = e_tags[0].as_slice();
+        assert_eq!(e_tag[1], root_id, "e-tag should reference the root event");
+        assert_eq!(e_tag[2], "", "relay hint should be empty");
+        assert_eq!(e_tag[3], "root", "marker must be 'root', not 'reply'");
+    }
+
+    #[test]
+    fn death_notice_has_channel_h_tag() {
+        let relay = make_test_relay();
+        let channel_id = Uuid::new_v4();
+        let event = relay
+            .build_death_notice(channel_id, "agent crashed", None)
+            .expect("build_death_notice should succeed");
+
+        let h_tags: Vec<_> = event
+            .tags
+            .iter()
+            .filter(|t| t.as_slice().first().map(|s| s.as_str()) == Some("h"))
+            .collect();
+        assert_eq!(h_tags.len(), 1, "expected exactly one h-tag");
+        assert_eq!(
+            h_tags[0].as_slice()[1],
+            channel_id.to_string(),
+            "h-tag should contain the channel UUID"
+        );
+    }
+
+    #[test]
+    fn death_notice_without_thread_root_has_no_e_tag() {
+        let relay = make_test_relay();
+        let channel_id = Uuid::new_v4();
+        let event = relay
+            .build_death_notice(channel_id, "agent exited", None)
+            .expect("build_death_notice should succeed");
+
+        let e_tags: Vec<_> = event
+            .tags
+            .iter()
+            .filter(|t| t.as_slice().first().map(|s| s.as_str()) == Some("e"))
+            .collect();
+        assert!(e_tags.is_empty(), "no e-tag when thread_root is None");
+    }
 }

--- a/crates/sprout-acp/src/relay.rs
+++ b/crates/sprout-acp/src/relay.rs
@@ -320,6 +320,9 @@ pub enum RelayError {
 
     #[error("Unexpected message: {0}")]
     UnexpectedMessage(String),
+
+    #[error("Event build error: {0}")]
+    EventBuild(String),
 }
 
 impl From<nostr::event::builder::Error> for RelayError {
@@ -760,17 +763,30 @@ impl HarnessRelay {
         use sprout_core::kind::KIND_STREAM_MESSAGE;
 
         let h_tag = Tag::parse(["h", &channel_id.to_string()])
-            .map_err(|e| RelayError::AuthFailed(e.to_string()))?;
+            .map_err(|e| RelayError::EventBuild(e.to_string()))?;
         let mut tags = vec![h_tag];
         if let Some(root_id) = thread_root {
-            let e_tag = Tag::parse(["e", root_id, "", "reply"])
-                .map_err(|e| RelayError::AuthFailed(e.to_string()))?;
+            let e_tag = Tag::parse(["e", root_id, "", "root"])
+                .map_err(|e| RelayError::EventBuild(e.to_string()))?;
             tags.push(e_tag);
         }
         let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), message)
             .tags(tags)
             .sign_with_keys(&self.keys)?;
         Ok(event)
+    }
+
+    /// Build and publish a death notice, logging any failure rather than
+    /// propagating it. Used by both the timeout and transport-error paths.
+    pub fn publish_death_notice(&self, channel_id: Uuid, message: &str, thread_root: Option<&str>) {
+        match self.build_death_notice(channel_id, message, thread_root) {
+            Ok(event) => {
+                if let Err(e) = self.try_publish_event(event) {
+                    warn!("failed to publish death notice: {e}");
+                }
+            }
+            Err(e) => warn!("failed to build death notice: {e}"),
+        }
     }
 
     /// Set the startup watermark timestamp (Finding #22).

--- a/crates/sprout-acp/src/relay.rs
+++ b/crates/sprout-acp/src/relay.rs
@@ -750,13 +750,25 @@ impl HarnessRelay {
 
     /// Build a channel message (kind:9) for death notices — posted when the
     /// agent session ends due to timeout or unexpected exit.
-    pub fn build_death_notice(&self, channel_id: Uuid, message: &str) -> Result<Event, RelayError> {
+    /// If `thread_root` is provided, the message is threaded as a reply.
+    pub fn build_death_notice(
+        &self,
+        channel_id: Uuid,
+        message: &str,
+        thread_root: Option<&str>,
+    ) -> Result<Event, RelayError> {
         use sprout_core::kind::KIND_STREAM_MESSAGE;
 
         let h_tag = Tag::parse(["h", &channel_id.to_string()])
             .map_err(|e| RelayError::AuthFailed(e.to_string()))?;
+        let mut tags = vec![h_tag];
+        if let Some(root_id) = thread_root {
+            let e_tag = Tag::parse(["e", root_id, "", "reply"])
+                .map_err(|e| RelayError::AuthFailed(e.to_string()))?;
+            tags.push(e_tag);
+        }
         let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), message)
-            .tags([h_tag])
+            .tags(tags)
             .sign_with_keys(&self.keys)?;
         Ok(event)
     }

--- a/crates/sprout-agent/src/agent.rs
+++ b/crates/sprout-agent/src/agent.rs
@@ -95,6 +95,27 @@ impl RunCtx<'_> {
                 biased;
                 _ = self.cancel.changed() => return Ok(StopReason::Cancelled),
                 r = self.llm.complete(self.cfg, self.system_prompt, self.history, &tools) => r?,
+                _ = async {
+                    // Keepalive ticker: emit a lightweight session update every 30s
+                    // while waiting on the LLM provider. This resets the ACP harness
+                    // idle clock so long provider responses don't trigger timeout.
+                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+                    interval.tick().await; // first tick fires immediately — skip it
+                    loop {
+                        interval.tick().await;
+                        tracing::debug!("llm keepalive tick");
+                        wire::send(
+                            self.wire,
+                            wire::session_update(
+                                self.session_id,
+                                json!({
+                                    "sessionUpdate": "keepalive",
+                                }),
+                            ),
+                        )
+                        .await;
+                    }
+                } => unreachable!(),
             };
 
             // Record provider-reported input usage so the next loop iteration's

--- a/crates/sprout-dev-mcp/src/lib.rs
+++ b/crates/sprout-dev-mcp/src/lib.rs
@@ -37,7 +37,7 @@ impl DevMcp {
 
     #[tool(
         name = "shell",
-        description = "Run a bash command. Ephemeral process per call. Output tail-truncated to ~8KB for the LLM; full output (first 10MB) saved to artifact file. timeout_ms capped at 600000. On PATH: rg (prefer over grep; flags: -n -i -l -g <glob> -C <n> --files), tree (flags: -d <depth>; shows line counts), and sprout (Sprout relay CLI — run sprout --help for commands)."
+        description = "Run a bash command. Ephemeral process per call. Output tail-truncated to ~8KB for the LLM; full output (first 10MB) saved to artifact file. timeout_ms defaults to 120000 (2 min) if omitted; capped at 600000 (10 min). For long-running commands (git push with hooks, cargo build, test suites), use 300000+. On PATH: rg (prefer over grep; flags: -n -i -l -g <glob> -C <n> --files), tree (flags: -d <depth>; shows line counts), and sprout (Sprout relay CLI — run sprout --help for commands)."
     )]
     async fn shell(
         &self,

--- a/crates/sprout-dev-mcp/src/shell.rs
+++ b/crates/sprout-dev-mcp/src/shell.rs
@@ -107,6 +107,8 @@ pub struct ShellParams {
     pub command: String,
     #[serde(default)]
     pub workdir: Option<String>,
+    /// Defaults to 120000 ms (2 min) if omitted; capped at 600000 ms (10 min).
+    /// For long-running commands (git push with hooks, cargo build, test suites), use 300000+.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
 }


### PR DESCRIPTION
## Summary

Addresses spurious agent session kills caused by the 20s margin between the 600s max shell timeout and the 620s idle timeout. Legitimate long-running tool calls (git push with pre-push hooks, large compilation) would exhaust the margin and trigger idle timeout.

## Changes

### C: Raise idle timeout default (620 → 900s)
`DEFAULT_IDLE_TIMEOUT_SECS` in `crates/sprout-acp/src/config.rs` raised from 620 to 900, giving 300s of breathing room above the 600s max shell timeout.

### D: Tool-call-aware idle reset
`handle_session_update()` in `crates/sprout-acp/src/acp.rs` now returns a bool indicating whether a tool call started. The idle-timeout read loop explicitly resets the idle clock and logs when a tool call begins, making the intent visible in traces.

### E: Death notices
`crates/sprout-acp/src/relay.rs` gains `build_death_notice()` which constructs a `KIND_JOB_ERROR` (kind:43006) diagnostic event. `handle_prompt_result()` in `crates/sprout-acp/src/lib.rs` emits a `turn_error` observer event and stores a `KIND_JOB_ERROR` relay event when a session ends due to idle timeout, unexpected agent exit, or transport error. These appear in the per-agent activity panel (profile → View activity log) — not in the channel message stream. Death notices are threaded into the original conversation via NIP-10 `e` tags when thread context is available.

### G: LLM keepalive ticker
`crates/sprout-agent/src/agent.rs` adds a 30s interval ticker to the `tokio::select!` around the LLM `complete()` call. While waiting on the provider, it emits a lightweight `keepalive` session update that the ACP harness sees as valid JSON activity, resetting the idle clock.