### PR TITLE
Make existing-key import discoverable — and available mid-onboarding

### DIFF
--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -110,7 +110,7 @@ function OnboardingLoadingGate() {
               type="button"
               variant="ghost"
             >
-              Continue using Nostr
+              I already have a key
             </Button>
           </div>
         </OnboardingSlideTransition>

--- a/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
+++ b/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
@@ -1,0 +1,273 @@
+import * as React from "react";
+import { Check, KeyRound } from "lucide-react";
+
+import { cn } from "@/shared/lib/cn";
+import { nsecToNpub, shortenNpub } from "@/shared/lib/nostrUtils";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Spinner } from "@/shared/ui/spinner";
+
+const NOSTR_KEY_FILE_MAX_BYTES = 1024;
+
+type NostrKeyImportFormProps = {
+  disabled?: boolean;
+  errorMessage?: string | null;
+  onBack: () => void;
+  onImport: (nsec: string) => Promise<void>;
+};
+
+/**
+ * Paste-or-drop nsec import form with a live npub preview.
+ *
+ * Shared between the first-run welcome flow (no workspace yet) and the
+ * onboarding profile flow (workspace exists, user wants to reuse an
+ * existing key). The caller owns what happens after `onImport` resolves.
+ */
+export function NostrKeyImportForm({
+  disabled = false,
+  errorMessage: externalErrorMessage = null,
+  onBack,
+  onImport,
+}: NostrKeyImportFormProps) {
+  const [nsecInput, setNsecInput] = React.useState("");
+  const [isImporting, setIsImporting] = React.useState(false);
+  const [importError, setImportError] = React.useState<string | null>(null);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+  const previewNpub = React.useMemo(() => nsecToNpub(nsecInput), [nsecInput]);
+  const trimmedInput = nsecInput.trim();
+  const hasInput = trimmedInput.length > 0;
+  const isValid = previewNpub !== null;
+  const isBusy = disabled || isImporting;
+  const showInvalidHint = hasInput && !isValid && trimmedInput.length >= 5;
+  const errorMessage = importError ?? externalErrorMessage;
+
+  React.useLayoutEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const openFilePicker = React.useCallback(() => {
+    if (isBusy) {
+      return;
+    }
+
+    fileInputRef.current?.click();
+  }, [isBusy]);
+
+  const handleFiles = React.useCallback(async (files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (file.size > NOSTR_KEY_FILE_MAX_BYTES) {
+      setImportError(
+        "That file is too large to be a key. Drop a .key file or paste your nsec.",
+      );
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      const firstLine =
+        text.split(/\r?\n/).find((line) => line.trim().length > 0) ?? "";
+      setNsecInput(firstLine.trim());
+      setImportError(null);
+    } catch (error) {
+      setImportError(
+        error instanceof Error ? error.message : "Couldn't read that file.",
+      );
+    }
+  }, []);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (!previewNpub) {
+      setImportError(
+        "That doesn't look like a valid nsec. Paste an nsec1 key.",
+      );
+      return;
+    }
+
+    setIsImporting(true);
+    setImportError(null);
+
+    try {
+      await onImport(trimmedInput);
+    } catch (error) {
+      setImportError(
+        error instanceof Error ? error.message : "Failed to import key.",
+      );
+    } finally {
+      setIsImporting(false);
+    }
+  }, [onImport, previewNpub, trimmedInput]);
+
+  return (
+    <form
+      className="mt-8 flex w-full flex-col gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleSubmit();
+      }}
+    >
+      <div className="space-y-1.5 text-left">
+        <label
+          className="text-sm font-medium text-foreground"
+          htmlFor="nostr-private-key"
+        >
+          Private key
+        </label>
+        <Input
+          autoComplete="off"
+          autoCorrect="off"
+          className="h-10 bg-background"
+          data-testid="nostr-import-nsec-input"
+          id="nostr-private-key"
+          onChange={(event) => {
+            setNsecInput(event.target.value);
+            setImportError(null);
+          }}
+          placeholder="nsec1..."
+          ref={inputRef}
+          spellCheck={false}
+          type="password"
+          value={nsecInput}
+        />
+      </div>
+
+      <input
+        accept=".key,text/plain"
+        className="sr-only"
+        disabled={isBusy}
+        onChange={(event) => {
+          void handleFiles(event.currentTarget.files);
+          event.currentTarget.value = "";
+        }}
+        ref={fileInputRef}
+        tabIndex={-1}
+        type="file"
+      />
+
+      <button
+        className={cn(
+          "relative flex h-[120px] flex-col items-center justify-center gap-3 overflow-hidden rounded-xl border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-[250ms] ease-out hover:bg-muted/80 disabled:opacity-60",
+          isDragging &&
+            "border-primary bg-primary/10 text-primary ring-1 ring-primary/35 hover:bg-primary/10",
+        )}
+        data-dragging={isDragging ? "true" : undefined}
+        data-testid="nostr-import-drop"
+        disabled={isBusy}
+        onClick={openFilePicker}
+        onDragEnter={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!isBusy) {
+            setIsDragging(true);
+          }
+        }}
+        onDragLeave={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (
+            event.currentTarget.contains(event.relatedTarget as Node | null)
+          ) {
+            return;
+          }
+          setIsDragging(false);
+        }}
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!isBusy) {
+            event.dataTransfer.dropEffect = "copy";
+          }
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setIsDragging(false);
+          if (isBusy) {
+            return;
+          }
+          void handleFiles(event.dataTransfer.files);
+        }}
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute inset-0 rounded-[inherit] bg-primary/10 opacity-0 transition-opacity duration-[250ms] ease-out",
+            isDragging && "opacity-100",
+          )}
+        />
+        <KeyRound
+          className={cn(
+            "relative h-8 w-8 text-muted-foreground transition-colors duration-[250ms] ease-out",
+            isDragging && "text-primary",
+          )}
+        />
+        <span
+          className={cn(
+            "relative text-sm font-medium text-muted-foreground transition-colors duration-[250ms] ease-out",
+            isDragging && "text-primary",
+          )}
+        >
+          Drop a key here
+        </span>
+      </button>
+
+      {previewNpub ? (
+        <div
+          className="flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs"
+          data-testid="nostr-import-npub-preview"
+        >
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+          <div className="min-w-0 space-y-0.5">
+            <p className="font-medium text-foreground">
+              This will use this Nostr identity:
+            </p>
+            <p className="break-all font-mono text-[11px] text-muted-foreground">
+              {shortenNpub(previewNpub)}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {showInvalidHint && !errorMessage ? (
+        <p className="text-xs text-muted-foreground">
+          Waiting for a valid nsec1 key.
+        </p>
+      ) : null}
+
+      {errorMessage ? (
+        <p className="text-center text-sm text-destructive">{errorMessage}</p>
+      ) : null}
+
+      <div className="flex w-full flex-col gap-3 pt-1">
+        <Button
+          className="h-10 w-full"
+          data-testid="nostr-import-submit"
+          disabled={!isValid || isBusy}
+          type="submit"
+        >
+          {isBusy ? (
+            <Spinner aria-label="Importing key" className="h-4 w-4" />
+          ) : (
+            "Continue with this key"
+          )}
+        </Button>
+
+        <Button
+          className="h-10 w-full text-muted-foreground hover:text-accent-foreground"
+          disabled={isBusy}
+          onClick={onBack}
+          type="button"
+          variant="ghost"
+        >
+          Back
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -19,7 +19,11 @@ import { ONBOARDING_DEFAULT_THEME_NAME } from "@/shared/theme/theme-loader";
 import { StepProgress } from "@/shared/ui/step-progress";
 import { AvatarStep } from "./AvatarStep";
 import { MembershipDenied } from "./MembershipDenied";
-import type { OnboardingTransitionDirection } from "./OnboardingSlideTransition";
+import { NostrKeyImportForm } from "./NostrKeyImportForm";
+import {
+  type OnboardingTransitionDirection,
+  OnboardingSlideTransition,
+} from "./OnboardingSlideTransition";
 import { ProfileStep } from "./ProfileStep";
 import { SetupStep } from "./SetupStep";
 import { ThemeStep, preloadThemePreviewVars } from "./ThemeStep";
@@ -228,6 +232,11 @@ export function OnboardingFlow({
     setCurrentPage("profile");
   }, []);
 
+  const showKeyImportPage = React.useCallback(() => {
+    setTransitionDirection("forward");
+    setCurrentPage("key-import");
+  }, []);
+
   const saveProfileAndContinue = React.useCallback(
     async (nextPage: OnboardingPage) => {
       if (isProfileAdvancePending) {
@@ -365,7 +374,11 @@ export function OnboardingFlow({
       : profileStepState.saveRecovery,
   };
 
-  const importDeniedKey = React.useCallback(
+  // Swapping the identity changes the pubkey, which remounts this flow
+  // (keyed on pubkey in App.tsx) and re-runs the onboarding gate: the new
+  // key's relay profile reseeds the steps, and a key that already finished
+  // onboarding on this machine skips straight into the app.
+  const importExistingKey = React.useCallback(
     async (nsec: string) => {
       const identity = await importIdentity(nsec);
       relayClient.disconnect();
@@ -390,7 +403,7 @@ export function OnboardingFlow({
               }
             : undefined
         }
-        onImportKey={canBackToWorkspaceSetup ? undefined : importDeniedKey}
+        onImportKey={canBackToWorkspaceSetup ? undefined : importExistingKey}
         onRetry={() => {
           void saveProfileAndContinue(membershipRetryPage);
         }}
@@ -402,7 +415,9 @@ export function OnboardingFlow({
   return (
     <div
       className={`sprout-startup-shell flex items-center justify-center bg-background px-4 py-8 text-foreground ${
-        currentPage === "profile" || currentPage === "avatar"
+        currentPage === "profile" ||
+        currentPage === "avatar" ||
+        currentPage === "key-import"
           ? "sprout-onboarding-neutral-theme"
           : ""
       }`}
@@ -429,7 +444,7 @@ export function OnboardingFlow({
           }`}
           completeSegmentClassName="bg-primary/35"
           currentStep={
-            currentPage === "profile"
+            currentPage === "profile" || currentPage === "key-import"
               ? 2
               : currentPage === "avatar"
                 ? 3
@@ -451,6 +466,7 @@ export function OnboardingFlow({
                   }
                 : undefined,
               clearAvatarDraft: resetAvatarDraft,
+              importExistingKey: showKeyImportPage,
               onUploadingChange: setIsUploadingAvatar,
               skipForNow,
               submit: () => {
@@ -462,6 +478,28 @@ export function OnboardingFlow({
             direction={transitionDirection}
             state={profileStepState}
           />
+        ) : currentPage === "key-import" ? (
+          <OnboardingSlideTransition
+            className="flex w-full flex-col items-center text-center"
+            direction={transitionDirection}
+            transitionKey={`key-import-${transitionDirection}`}
+          >
+            <div className="w-full max-w-[440px]">
+              <h1 className="text-3xl font-semibold tracking-tight">
+                Use your existing key
+              </h1>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                Import your Nostr private key to use that identity with Sprout.
+                If this key already has a profile on the relay, your name and
+                avatar are restored automatically.
+              </p>
+            </div>
+
+            <NostrKeyImportForm
+              onBack={showProfilePage}
+              onImport={importExistingKey}
+            />
+          </OnboardingSlideTransition>
         ) : currentPage === "avatar" ? (
           <AvatarStep
             actions={{

--- a/desktop/src/features/onboarding/ui/ProfileStep.tsx
+++ b/desktop/src/features/onboarding/ui/ProfileStep.tsx
@@ -35,8 +35,14 @@ export function ProfileStep({
   transitionEffect = "line-slide",
   state,
 }: ProfileStepProps) {
-  const { advanceWithoutSaving, back, skipForNow, submit, updateDisplayName } =
-    actions;
+  const {
+    advanceWithoutSaving,
+    back,
+    importExistingKey,
+    skipForNow,
+    submit,
+    updateDisplayName,
+  } = actions;
   const { isSaving, name, saveRecovery } = state;
   const displayNameDraft = name.draftValue;
   const hasDisplayNameDraft = displayNameDraft.length > 0;
@@ -140,6 +146,17 @@ export function ProfileStep({
             Back
           </Button>
         ) : null}
+
+        <Button
+          className="text-muted-foreground hover:text-accent-foreground"
+          data-testid="onboarding-import-key"
+          disabled={isSaving}
+          onClick={importExistingKey}
+          type="button"
+          variant="ghost"
+        >
+          I already have a key
+        </Button>
 
         <div className="flex min-h-8 items-center gap-2">
           <div className="flex-1" />

--- a/desktop/src/features/onboarding/ui/types.ts
+++ b/desktop/src/features/onboarding/ui/types.ts
@@ -2,6 +2,7 @@ import type { AcpRuntimeCatalogEntry, Profile } from "@/shared/api/types";
 
 export type OnboardingPage =
   | "profile"
+  | "key-import"
   | "avatar"
   | "theme"
   | "setup"
@@ -48,6 +49,7 @@ export type ProfileStepState = {
 export type ProfileStepActions = {
   advanceWithoutSaving: () => void;
   back?: () => void;
+  importExistingKey: () => void;
   clearAvatarDraft: () => void;
   onUploadingChange: (isUploading: boolean) => void;
   skipForNow: () => void;

--- a/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
@@ -1,17 +1,16 @@
 import * as React from "react";
-import { Check, KeyRound, Sprout } from "lucide-react";
+import { Sprout } from "lucide-react";
 import { flushSync } from "react-dom";
 
 import {
   getIdentity,
   importIdentity as tauriImportIdentity,
 } from "@/shared/api/tauri";
+import { NostrKeyImportForm } from "@/features/onboarding/ui/NostrKeyImportForm";
 import {
   type OnboardingTransitionDirection,
   OnboardingSlideTransition,
 } from "@/features/onboarding/ui/OnboardingSlideTransition";
-import { cn } from "@/shared/lib/cn";
-import { nsecToNpub, shortenNpub } from "@/shared/lib/nostrUtils";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Spinner } from "@/shared/ui/spinner";
@@ -31,7 +30,6 @@ type WelcomeSetupProps = {
 };
 
 const DEFAULT_WORKSPACE_HANDOFF_MIN_MS = 200;
-const NOSTR_KEY_FILE_MAX_BYTES = 1024;
 
 function wait(ms: number) {
   return new Promise<void>((resolve) => {
@@ -50,80 +48,6 @@ function NostrKeyImportPage({
   onBack: () => void;
   onImport: (nsec: string) => Promise<void>;
 }) {
-  const [nsecInput, setNsecInput] = React.useState("");
-  const [isImporting, setIsImporting] = React.useState(false);
-  const [importError, setImportError] = React.useState<string | null>(null);
-  const [isDragging, setIsDragging] = React.useState(false);
-  const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
-  const previewNpub = React.useMemo(() => nsecToNpub(nsecInput), [nsecInput]);
-  const trimmedInput = nsecInput.trim();
-  const hasInput = trimmedInput.length > 0;
-  const isValid = previewNpub !== null;
-  const isBusy = disabled || isImporting;
-  const showInvalidHint = hasInput && !isValid && trimmedInput.length >= 5;
-  const errorMessage = importError ?? connectionError;
-
-  React.useLayoutEffect(() => {
-    inputRef.current?.focus();
-  }, []);
-
-  const openFilePicker = React.useCallback(() => {
-    if (isBusy) {
-      return;
-    }
-
-    fileInputRef.current?.click();
-  }, [isBusy]);
-
-  const handleFiles = React.useCallback(async (files: FileList | null) => {
-    const file = files?.[0];
-    if (!file) {
-      return;
-    }
-
-    if (file.size > NOSTR_KEY_FILE_MAX_BYTES) {
-      setImportError(
-        "That file is too large to be a key. Drop a .key file or paste your nsec.",
-      );
-      return;
-    }
-
-    try {
-      const text = await file.text();
-      const firstLine =
-        text.split(/\r?\n/).find((line) => line.trim().length > 0) ?? "";
-      setNsecInput(firstLine.trim());
-      setImportError(null);
-    } catch (error) {
-      setImportError(
-        error instanceof Error ? error.message : "Couldn't read that file.",
-      );
-    }
-  }, []);
-
-  const handleSubmit = React.useCallback(async () => {
-    if (!previewNpub) {
-      setImportError(
-        "That doesn't look like a valid nsec. Paste an nsec1 key.",
-      );
-      return;
-    }
-
-    setIsImporting(true);
-    setImportError(null);
-
-    try {
-      await onImport(trimmedInput);
-    } catch (error) {
-      setImportError(
-        error instanceof Error ? error.message : "Failed to import key.",
-      );
-    } finally {
-      setIsImporting(false);
-    }
-  }, [onImport, previewNpub, trimmedInput]);
-
   return (
     <OnboardingSlideTransition
       className="flex w-full flex-col items-center text-center"
@@ -141,171 +65,12 @@ function NostrKeyImportPage({
         </p>
       </div>
 
-      <form
-        className="mt-8 flex w-full flex-col gap-4"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void handleSubmit();
-        }}
-      >
-        <div className="space-y-1.5 text-left">
-          <label
-            className="text-sm font-medium text-foreground"
-            htmlFor="nostr-private-key"
-          >
-            Private key
-          </label>
-          <Input
-            autoComplete="off"
-            autoCorrect="off"
-            className="h-10 bg-background"
-            data-testid="welcome-nostr-nsec-input"
-            id="nostr-private-key"
-            onChange={(event) => {
-              setNsecInput(event.target.value);
-              setImportError(null);
-            }}
-            placeholder="nsec1..."
-            ref={inputRef}
-            spellCheck={false}
-            type="password"
-            value={nsecInput}
-          />
-        </div>
-
-        <input
-          accept=".key,text/plain"
-          className="sr-only"
-          disabled={isBusy}
-          onChange={(event) => {
-            void handleFiles(event.currentTarget.files);
-            event.currentTarget.value = "";
-          }}
-          ref={fileInputRef}
-          tabIndex={-1}
-          type="file"
-        />
-
-        <button
-          className={cn(
-            "relative flex h-[120px] flex-col items-center justify-center gap-3 overflow-hidden rounded-xl border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-[250ms] ease-out hover:bg-muted/80 disabled:opacity-60",
-            isDragging &&
-              "border-primary bg-primary/10 text-primary ring-1 ring-primary/35 hover:bg-primary/10",
-          )}
-          data-dragging={isDragging ? "true" : undefined}
-          data-testid="welcome-nostr-drop"
-          disabled={isBusy}
-          onClick={openFilePicker}
-          onDragEnter={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            if (!isBusy) {
-              setIsDragging(true);
-            }
-          }}
-          onDragLeave={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            if (
-              event.currentTarget.contains(event.relatedTarget as Node | null)
-            ) {
-              return;
-            }
-            setIsDragging(false);
-          }}
-          onDragOver={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            if (!isBusy) {
-              event.dataTransfer.dropEffect = "copy";
-            }
-          }}
-          onDrop={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            setIsDragging(false);
-            if (isBusy) {
-              return;
-            }
-            void handleFiles(event.dataTransfer.files);
-          }}
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            className={cn(
-              "pointer-events-none absolute inset-0 rounded-[inherit] bg-primary/10 opacity-0 transition-opacity duration-[250ms] ease-out",
-              isDragging && "opacity-100",
-            )}
-          />
-          <KeyRound
-            className={cn(
-              "relative h-8 w-8 text-muted-foreground transition-colors duration-[250ms] ease-out",
-              isDragging && "text-primary",
-            )}
-          />
-          <span
-            className={cn(
-              "relative text-sm font-medium text-muted-foreground transition-colors duration-[250ms] ease-out",
-              isDragging && "text-primary",
-            )}
-          >
-            Drop a key here
-          </span>
-        </button>
-
-        {previewNpub ? (
-          <div
-            className="flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs"
-            data-testid="welcome-nostr-npub-preview"
-          >
-            <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
-            <div className="min-w-0 space-y-0.5">
-              <p className="font-medium text-foreground">
-                This will use this Nostr identity:
-              </p>
-              <p className="break-all font-mono text-[11px] text-muted-foreground">
-                {shortenNpub(previewNpub)}
-              </p>
-            </div>
-          </div>
-        ) : null}
-
-        {showInvalidHint && !errorMessage ? (
-          <p className="text-xs text-muted-foreground">
-            Waiting for a valid nsec1 key.
-          </p>
-        ) : null}
-
-        {errorMessage ? (
-          <p className="text-center text-sm text-destructive">{errorMessage}</p>
-        ) : null}
-
-        <div className="flex w-full flex-col gap-3 pt-1">
-          <Button
-            className="h-10 w-full"
-            data-testid="welcome-nostr-submit"
-            disabled={!isValid || isBusy}
-            type="submit"
-          >
-            {isBusy ? (
-              <Spinner aria-label="Importing key" className="h-4 w-4" />
-            ) : (
-              "Continue with this key"
-            )}
-          </Button>
-
-          <Button
-            className="h-10 w-full text-muted-foreground hover:text-accent-foreground"
-            disabled={isBusy}
-            onClick={onBack}
-            type="button"
-            variant="ghost"
-          >
-            Back
-          </Button>
-        </div>
-      </form>
+      <NostrKeyImportForm
+        disabled={disabled}
+        errorMessage={connectionError}
+        onBack={onBack}
+        onImport={onImport}
+      />
     </OnboardingSlideTransition>
   );
 }

--- a/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
@@ -132,10 +132,12 @@ function NostrKeyImportPage({
     >
       <div className="w-full max-w-[440px]">
         <h1 className="text-3xl font-semibold tracking-tight">
-          Continue using Nostr
+          Use your existing key
         </h1>
         <p className="mt-3 text-sm leading-6 text-muted-foreground">
-          Import an existing Nostr private key to use that identity with Sprout.
+          Import your Nostr private key to use that identity with Sprout. If
+          this key already has a profile on the relay, your name and avatar are
+          restored automatically.
         </p>
       </div>
 
@@ -289,7 +291,7 @@ function NostrKeyImportPage({
             {isBusy ? (
               <Spinner aria-label="Importing key" className="h-4 w-4" />
             ) : (
-              "Continue using Nostr"
+              "Continue with this key"
             )}
           </Button>
 
@@ -494,7 +496,7 @@ export function WelcomeSetup({
                 type="button"
                 variant="ghost"
               >
-                Continue using Nostr
+                I already have a key
               </Button>
             </div>
 

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -232,7 +232,7 @@ test("welcome can continue using an existing Nostr key", async ({ page }) => {
 
   await page.getByTestId("welcome-continue-nostr").click();
   await expect(
-    page.getByRole("heading", { name: "Continue using Nostr" }),
+    page.getByRole("heading", { name: "Use your existing key" }),
   ).toBeVisible();
 
   const importedNsec = nsecEncode(hexToBytes(TEST_IDENTITIES.alice.privateKey));

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -236,9 +236,9 @@ test("welcome can continue using an existing Nostr key", async ({ page }) => {
   ).toBeVisible();
 
   const importedNsec = nsecEncode(hexToBytes(TEST_IDENTITIES.alice.privateKey));
-  await page.getByTestId("welcome-nostr-nsec-input").fill(importedNsec);
-  await expect(page.getByTestId("welcome-nostr-npub-preview")).toBeVisible();
-  await page.getByTestId("welcome-nostr-submit").click();
+  await page.getByTestId("nostr-import-nsec-input").fill(importedNsec);
+  await expect(page.getByTestId("nostr-import-npub-preview")).toBeVisible();
+  await page.getByTestId("nostr-import-submit").click();
 
   await expect(page.getByTestId("onboarding-display-name")).toHaveValue(
     "alice",
@@ -584,6 +584,33 @@ test("existing relay profile prefills the name step without localStorage complet
   );
   await expect(page.getByTestId("onboarding-next")).toBeEnabled();
   await expect(page.getByTestId("onboarding-back")).toHaveCount(0);
+});
+
+test("onboarding can import an existing key when the workspace is already set up", async ({
+  page,
+}) => {
+  // Workspace exists (default seed), but this identity has no profile yet,
+  // so the app lands on the onboarding name step — Tyler's moved-laptop /
+  // fresh-dev-instance case.
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
+  await installMockBridge(page, undefined, { skipOnboardingSeed: true });
+  await page.goto("/");
+
+  await expect(page.getByTestId("onboarding-display-name")).toHaveValue("");
+  await page.getByTestId("onboarding-import-key").click();
+  await expect(
+    page.getByRole("heading", { name: "Use your existing key" }),
+  ).toBeVisible();
+
+  const importedNsec = nsecEncode(hexToBytes(TEST_IDENTITIES.alice.privateKey));
+  await page.getByTestId("nostr-import-nsec-input").fill(importedNsec);
+  await expect(page.getByTestId("nostr-import-npub-preview")).toBeVisible();
+  await page.getByTestId("nostr-import-submit").click();
+
+  // Identity swap remounts the flow; alice's relay profile prefills the name.
+  await expect(page.getByTestId("onboarding-display-name")).toHaveValue(
+    "alice",
+  );
 });
 
 test("finishing onboarding auto-joins the #general channel for a new member", async ({


### PR DESCRIPTION
## Summary
Two commits, same goal: a returning relay member (new laptop, fresh dev instance) can find and reuse their existing key.

**Copy (commit 1):**
- Welcome screen ghost button: "Continue using Nostr" → **"I already have a key"**
- Import page heading "Use your existing key" + blurb saying the relay profile (name + avatar) is restored automatically — #924 already does this, we just never said so
- Submit: "Continue with this key"

**Mid-onboarding import (commit 2):**
- Previously the import option only existed on WelcomeSetup, which renders only when no workspace is configured. With a workspace already set up you land straight on the profile step with no way to reuse a key (exactly how Tyler hit it).
- Extracted the paste-or-drop nsec form into a shared `NostrKeyImportForm`; profile step gets an **"I already have a key"** ghost link that opens it.
- Import reuses the existing membership-denied identity-swap path: flow remounts keyed on pubkey, relay profile reseeds the steps; a key that already completed onboarding here skips straight into the app.
- Shared-form testids renamed `welcome-nostr-*` → `nostr-import-*`.

Context: requested by Tyler in #sprout-frontend (thread `bf411361`).

Note: conflicts trivially with #866 (arcade onboarding) which rewrites these files — happy to rebase either direction.

## Checks
- `pnpm typecheck`
- `pnpm exec biome check` (touched files)
- `playwright test tests/e2e/onboarding.spec.ts` — 21/21 passed, incl. new test `onboarding can import an existing key when the workspace is already set up`
