### PR TITLE
fix(desktop): populate last_message_at in channel browser

### DIFF
--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -156,6 +156,51 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
         }
     }
 
+    // Populate last_message_at by fetching the most recent human message per
+    // channel. Uses per-channel filters (single #h value each) so the relay can
+    // push the query to its indexed channel_id column. Multi-value #h is NOT
+    // SQL-pushed and would silently drop quieter channels under the global limit.
+    let channel_ids: Vec<String> = channels.iter().map(|c| c.id.clone()).collect();
+    if !channel_ids.is_empty() {
+        let filters: Vec<serde_json::Value> = channel_ids
+            .iter()
+            .map(|id| {
+                serde_json::json!({
+                    "kinds": [9, 40002],
+                    "#h": [id],
+                    "limit": 1
+                })
+            })
+            .collect();
+
+        let message_events = query_relay(&state, &filters).await.unwrap_or_default();
+
+        let mut last_message_by_channel: std::collections::HashMap<String, u64> =
+            std::collections::HashMap::new();
+        for ev in &message_events {
+            if let Some(ch_id) = ev.tags.iter().find_map(|t| {
+                let s = t.as_slice();
+                (s.len() >= 2 && s[0] == "h").then(|| s[1].clone())
+            }) {
+                let ts = ev.created_at.as_secs();
+                last_message_by_channel
+                    .entry(ch_id)
+                    .and_modify(|existing| {
+                        if ts > *existing {
+                            *existing = ts;
+                        }
+                    })
+                    .or_insert(ts);
+            }
+        }
+
+        for channel in &mut channels {
+            if let Some(&ts) = last_message_by_channel.get(&channel.id) {
+                channel.last_message_at = Some(nostr_convert::timestamp_to_iso(ts));
+            }
+        }
+    }
+
     // NIP-DV: drop DMs the viewer has hidden. The relay maintains a per-viewer
     // parameterized-replaceable snapshot (kind:30622, d=my pubkey) whose `h`
     // tags list currently-hidden DM channel ids. The snapshot also carries

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -533,7 +533,7 @@ pub fn relay_members_from_event(event: &Event) -> Value {
 // ── Time helpers ────────────────────────────────────────────────────────────
 
 /// Convert a unix-seconds timestamp to a UTC RFC-3339 string.
-fn timestamp_to_iso(secs: u64) -> String {
+pub(crate) fn timestamp_to_iso(secs: u64) -> String {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     let dt = UNIX_EPOCH + Duration::from_secs(secs);
     // Format manually as RFC-3339 — the `time` crate is already a transitive


### PR DESCRIPTION
The "Browse Channels" pane shows "No activity" for every channel because `get_channels` never populated the `last_message_at` field on `ChannelInfo`. The rendering path (`formatRelativeTime`) already handles the field correctly — it just never had data.

## Changes

Add a batched relay query after the existing member-count back-fill in `get_channels` (`desktop/src-tauri/src/commands/channels.rs`). For each browse-pane channel, sends a per-channel filter:

```json
{"kinds": [9, 40002], "#h": ["<channel-id>"], "limit": 1}
```

All filters go in one `/query` POST — the relay loops per-filter, so each returns that channel's newest event with no cross-channel crowding. Per channel, takes `MAX(created_at)` and assigns to `last_message_at`.

**Key decisions:**

- **Per-channel single-`#h` filters** — avoids the multi-value `#h` SQL-pushdown trap where a global limit truncates quieter channels.
- **Kinds `[9, 40002]`** — includes `KIND_STREAM_MESSAGE_V2` so v2-only channels don't show false "No activity". Excludes edits (40003), system messages (40099), and forum kinds (45001/45003).
- **No `since` bound** — channels quiet for weeks show "Active 3w ago" rather than misleading "No activity".
- **No frontend changes** — `formatRelativeTime(channel.lastMessageAt)` already renders correctly on non-null values; the DTO bridge and TypeScript types already wire the field through.

Also bumps `timestamp_to_iso` in `nostr_convert.rs` to `pub(crate)` visibility (was private, already existed).

## Files changed

- `desktop/src-tauri/src/commands/channels.rs` — recency query + assignment
- `desktop/src-tauri/src/nostr_convert.rs` — visibility bump on `timestamp_to_iso`