### PR TITLE
feat(desktop): open profile panel from MembersSidebar rows

### DIFF
--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -163,15 +163,18 @@ export function MembersSidebar({
   useFeedbackToasts(actionNoticeMessage, actionErrorMessage);
 
   const { openProfilePanel } = useProfilePanel();
+  // UserProfilePanel only renders inside ChannelPane, which forums replace
+  // with ForumView — opening there would close the sheet and show nothing.
+  const isForumChannel = channel?.channelType === "forum";
   const handleOpenProfile = React.useMemo(
     () =>
-      openProfilePanel
+      openProfilePanel && !isForumChannel
         ? (pubkey: string) => {
             onOpenChange(false);
             openProfilePanel(pubkey);
           }
         : undefined,
-    [onOpenChange, openProfilePanel],
+    [isForumChannel, onOpenChange, openProfilePanel],
   );
 
   const [editRespondToAgent, setEditRespondToAgent] =

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -28,6 +28,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
+import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
@@ -161,6 +162,18 @@ export function MembersSidebar({
 
   useFeedbackToasts(actionNoticeMessage, actionErrorMessage);
 
+  const { openProfilePanel } = useProfilePanel();
+  const handleOpenProfile = React.useMemo(
+    () =>
+      openProfilePanel
+        ? (pubkey: string) => {
+            onOpenChange(false);
+            openProfilePanel(pubkey);
+          }
+        : undefined,
+    [onOpenChange, openProfilePanel],
+  );
+
   const [editRespondToAgent, setEditRespondToAgent] =
     React.useState<ManagedAgent | null>(null);
 
@@ -192,6 +205,7 @@ export function MembersSidebar({
         onManagedAgentAction={(agent) => {
           void handleAgentLifecycleAction(agent);
         }}
+        onOpenProfile={handleOpenProfile}
         onRemoveMember={handleRemoveMember}
         onViewActivity={
           onViewActivity

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -46,6 +46,7 @@ type MembersSidebarMemberCardProps = {
   onChangeRole: (member: ChannelMember, role: string) => void;
   onEditRespondTo?: (agent: ManagedAgent) => void;
   onManagedAgentAction: (agent: ManagedAgent) => void;
+  onOpenProfile?: (pubkey: string) => void;
   onRemoveMember: (member: ChannelMember) => void;
   onViewActivity?: (pubkey: string) => void;
   presenceStatus?: PresenceStatus | null;
@@ -97,6 +98,7 @@ export function MembersSidebarMemberCard({
   onChangeRole,
   onEditRespondTo,
   onManagedAgentAction,
+  onOpenProfile,
   onRemoveMember,
   onViewActivity,
   presenceStatus,
@@ -112,60 +114,76 @@ export function MembersSidebarMemberCard({
     ? Boolean(managedAgent) || canRemoveMember || canViewActivity
     : canRemoveMember || canChangeRole;
 
+  const memberIdentity = (
+    <>
+      <div className="relative shrink-0">
+        <ProfileAvatar
+          avatarUrl={profileAvatarUrl ?? null}
+          className="h-9 w-9 text-[11px] shadow-none"
+          iconClassName="h-4 w-4"
+          label={memberAvatarLabel}
+        />
+        {presenceStatus ? (
+          <span
+            className="absolute -bottom-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background"
+            data-testid={`sidebar-member-presence-${member.pubkey}`}
+          >
+            <PresenceDot className="h-2 w-2" status={presenceStatus} />
+          </span>
+        ) : null}
+      </div>
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5">
+          <p className="truncate text-sm font-medium leading-5">
+            {memberLabel}
+          </p>
+          <Badge className="shrink-0" variant="secondary">
+            {roleLabel}
+          </Badge>
+          {managedAgent ? (
+            <>
+              <Badge
+                className="shrink-0"
+                data-testid={`sidebar-managed-agent-status-${member.pubkey}`}
+                variant="secondary"
+              >
+                {formatManagedAgentStatus(managedAgent)}
+              </Badge>
+              <Badge
+                className="shrink-0"
+                data-testid={`sidebar-managed-agent-respond-to-${member.pubkey}`}
+                variant="outline"
+              >
+                {formatRespondToLabel(managedAgent)}
+              </Badge>
+            </>
+          ) : null}
+        </div>
+        <p className="truncate font-mono text-[10px] text-muted-foreground/50">
+          {truncatePubkey(member.pubkey)}
+        </p>
+      </div>
+    </>
+  );
+
   return (
     <div
       className="group flex items-center justify-between gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-muted/40"
       data-testid={`sidebar-member-${member.pubkey}`}
     >
-      <div className="flex min-w-0 items-center gap-3">
-        <div className="relative shrink-0">
-          <ProfileAvatar
-            avatarUrl={profileAvatarUrl ?? null}
-            className="h-9 w-9 text-[11px] shadow-none"
-            iconClassName="h-4 w-4"
-            label={memberAvatarLabel}
-          />
-          {presenceStatus ? (
-            <span
-              className="absolute -bottom-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background"
-              data-testid={`sidebar-member-presence-${member.pubkey}`}
-            >
-              <PresenceDot className="h-2 w-2" status={presenceStatus} />
-            </span>
-          ) : null}
-        </div>
-        <div className="min-w-0">
-          <div className="flex items-center gap-1.5">
-            <p className="truncate text-sm font-medium leading-5">
-              {memberLabel}
-            </p>
-            <Badge className="shrink-0" variant="secondary">
-              {roleLabel}
-            </Badge>
-            {managedAgent ? (
-              <>
-                <Badge
-                  className="shrink-0"
-                  data-testid={`sidebar-managed-agent-status-${member.pubkey}`}
-                  variant="secondary"
-                >
-                  {formatManagedAgentStatus(managedAgent)}
-                </Badge>
-                <Badge
-                  className="shrink-0"
-                  data-testid={`sidebar-managed-agent-respond-to-${member.pubkey}`}
-                  variant="outline"
-                >
-                  {formatRespondToLabel(managedAgent)}
-                </Badge>
-              </>
-            ) : null}
-          </div>
-          <p className="truncate font-mono text-[10px] text-muted-foreground/50">
-            {truncatePubkey(member.pubkey)}
-          </p>
-        </div>
-      </div>
+      {onOpenProfile ? (
+        <button
+          aria-label={`Open profile for ${memberLabel}`}
+          className="flex min-w-0 flex-1 items-center gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-md"
+          data-testid={`sidebar-member-open-profile-${member.pubkey}`}
+          onClick={() => onOpenProfile(member.pubkey)}
+          type="button"
+        >
+          {memberIdentity}
+        </button>
+      ) : (
+        <div className="flex min-w-0 items-center gap-3">{memberIdentity}</div>
+      )}
       {hasActions ? (
         <MemberActionsMenu
           canChangeRole={canChangeRole}


### PR DESCRIPTION
<img width="900" height="483" alt="Screen Recording 2026-06-10 at 5 48 32 PM" src="https://github.com/user-attachments/assets/bc4a43e5-ea99-40b6-bd80-ffb44a8dc3d5" />

## Summary

Click the avatar / name region of a member row in the People & Bots sidebar to open that user's profile panel. Reuses the existing `ProfilePanelContext` opener that already powers profile opens from `@mentions` and `UserProfilePopover` — same code path, same target panel.

### Behavior

- Clicking the left region (avatar + display name + role badges + pubkey) opens the profile panel for that pubkey.
- The kebab menu remains a separate sibling button, so role changes, view-activity, remove-from-channel, etc. still work without intercepting the row click.
- Closes the members sheet first, then opens the profile — matches the existing `onViewActivity` flow.
- Falls back to the original non-clickable layout when `ProfilePanelContext` isn't available (defensive — every current caller provides it, but the hook returns `{openProfilePanel: null}` if no provider).

### Why

The People list is the most natural place to discover an identity you don't already have a message thread with — especially useful for finding agents you don't talk to often. The profile panel already exists; this just adds the obvious click ingress that was missing.

New testid: `sidebar-member-open-profile-<pubkey>` on the clickable region.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `biome check` clean on touched files
- [x] 627/627 unit tests pass
- [ ] Manual: open the Members sidebar, click a row → profile panel opens for that pubkey, sheet closes
- [ ] Manual: kebab menu actions (change role, remove, view activity) still work without opening the profile
- [ ] Manual: keyboard nav reaches the row button (focus ring visible)


