### PR TITLE
fix(desktop): let channel members bypass mention agent gate

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -209,7 +209,11 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (candidate.isAgent && !mentionableAgentPubkeys.has(pubkey)) {
+      if (
+        candidate.isAgent &&
+        !candidate.isMember &&
+        !mentionableAgentPubkeys.has(pubkey)
+      ) {
         return;
       }
 


### PR DESCRIPTION

<img width="175" height="59" alt="image" src="https://github.com/user-attachments/assets/f73b9667-4437-4139-aa01-daf0580a88b8" />
he's back

**Category:** fix

**User Impact:** Agents that are already members of a channel reappear in `@`-mention autocomplete, even when they live in a different build's `managed-agents.json` or were set to `respondTo: owner-only`.

**Problem:** PR #942 added a global gate that hides any agent from the mention picker unless the running build owns it locally or it advertises `respondTo: "anyone"`. The intent — keeping the relay's long tail of non-responsive bots out of the picker — is right, but the same gate was applied to bots that are already explicit channel members. Across multiple builds (prod, dev, worktrees) each Tauri instance has its own `managed-agents.json` keyed by bundle identifier, so the same persona lives behind different pubkeys per build and only one build "owns" each pubkey. The result was that my canonical Ned/Bart/Marge agents stopped autocompleting in channels they're members of whenever I ran from a different build.

**Solution:** Treat channel membership as its own opt-in signal. Members bypass the directory gate; non-members and global-search hits still go through it, so the zombie zoo stays hidden.

<details>
<summary>File changes</summary>

**desktop/src/features/messages/lib/useMentions.ts**
Adjusted the agent gate in `addCandidate` so it only fires for non-members (`!candidate.isMember`). Membership is only ever set by the channel-members loop — directory and global-search candidates are hard-coded `isMember: false` — so the bypass can't be triggered by relay discovery results. The archived-identity filter runs before this gate, so archived agents stay hidden even when they're members.

</details>

## Reproduction steps

1. Run a dev/worktree build of Sprout — i.e. one whose `managed-agents.json` does NOT contain the canonical Ned pubkey owned by your prod build.
2. Open a channel where Ned is a member (and Ned was created with the default `respondTo: "owner-only"`).
3. In the composer, type `@n`.
4. Before this PR: Ned does not appear in autocomplete. After: Ned appears, labeled as a channel member.
5. Now type `@n` in a channel where Ned is **not** a member: Ned should still NOT appear (directory gate intact).
6. Archive a zombie via the identity-archive flow → confirm it's filtered out of the picker.
