### PR TITLE
fix(justfile): complete buzz rename in dev and staging recipes

### DIFF
--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,18 +1,18 @@
 fn main() {
-    println!("cargo:rerun-if-env-changed=SPROUT_RELAY_URL");
-    println!("cargo:rerun-if-env-changed=SPROUT_RELAY_HTTP");
+    println!("cargo:rerun-if-env-changed=BUZZ_RELAY_URL");
+    println!("cargo:rerun-if-env-changed=BUZZ_RELAY_HTTP");
     println!("cargo:rerun-if-env-changed=SPROUT_UPDATER_PUBLIC_KEY");
     println!("cargo:rerun-if-env-changed=SPROUT_UPDATER_ENDPOINT");
     println!("cargo:rerun-if-env-changed=SPROUT_BUILD_DATABRICKS_HOST");
     println!("cargo:rerun-if-env-changed=SPROUT_BUILD_DATABRICKS_MODEL");
     println!("cargo:rustc-check-cfg=cfg(sprout_updater_enabled)");
 
-    if let Ok(relay_url) = std::env::var("SPROUT_RELAY_URL") {
-        println!("cargo:rustc-env=SPROUT_DESKTOP_BUILD_RELAY_URL={relay_url}");
+    if let Ok(relay_url) = std::env::var("BUZZ_RELAY_URL") {
+        println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_RELAY_URL={relay_url}");
     }
 
-    if let Ok(relay_http) = std::env::var("SPROUT_RELAY_HTTP") {
-        println!("cargo:rustc-env=SPROUT_DESKTOP_BUILD_RELAY_HTTP={relay_http}");
+    if let Ok(relay_http) = std::env::var("BUZZ_RELAY_HTTP") {
+        println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_RELAY_HTTP={relay_http}");
     }
 
     if let Ok(host) = std::env::var("SPROUT_BUILD_DATABRICKS_HOST") {

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -19,8 +19,8 @@ fn configured_env_var(name: &str) -> Option<String> {
 }
 
 pub fn relay_ws_url() -> String {
-    configured_env_var("SPROUT_RELAY_URL")
-        .or_else(|| option_env!("SPROUT_DESKTOP_BUILD_RELAY_URL").map(str::to_string))
+    configured_env_var("BUZZ_RELAY_URL")
+        .or_else(|| option_env!("BUZZ_DESKTOP_BUILD_RELAY_URL").map(str::to_string))
         .unwrap_or_else(|| DEFAULT_RELAY_WS_URL.to_string())
 }
 
@@ -64,11 +64,11 @@ pub fn relay_http_base_url(relay_url: &str) -> String {
 }
 
 pub fn relay_api_base_url() -> String {
-    if let Some(base) = configured_env_var("SPROUT_RELAY_HTTP") {
+    if let Some(base) = configured_env_var("BUZZ_RELAY_HTTP") {
         return base.trim_end_matches('/').to_string();
     }
 
-    if let Some(base) = option_env!("SPROUT_DESKTOP_BUILD_RELAY_HTTP") {
+    if let Some(base) = option_env!("BUZZ_DESKTOP_BUILD_RELAY_HTTP") {
         return base.trim().trim_end_matches('/').to_string();
     }
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -51,11 +51,11 @@
     "active": true,
     "targets": "all",
     "externalBin": [
-      "binaries/sprout-acp",
-      "binaries/sprout-agent",
-      "binaries/sprout-dev-mcp",
+      "binaries/buzz-acp",
+      "binaries/buzz-agent",
+      "binaries/buzz-dev-mcp",
       "binaries/git-credential-nostr",
-      "binaries/sprout"
+      "binaries/buzz"
     ],
     "icon": [
       "icons/32x32.png",

--- a/justfile
+++ b/justfile
@@ -174,11 +174,11 @@ desktop-release-build target="aarch64-apple-darwin":
     set -euo pipefail
     TARGET={{target}}
     mkdir -p desktop/src-tauri/binaries
-    touch "desktop/src-tauri/binaries/sprout-acp-$TARGET"
-    touch "desktop/src-tauri/binaries/sprout-agent-$TARGET"
-    touch "desktop/src-tauri/binaries/sprout-dev-mcp-$TARGET"
+    touch "desktop/src-tauri/binaries/buzz-acp-$TARGET"
+    touch "desktop/src-tauri/binaries/buzz-agent-$TARGET"
+    touch "desktop/src-tauri/binaries/buzz-dev-mcp-$TARGET"
     touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET"
-    touch "desktop/src-tauri/binaries/sprout-$TARGET"
+    touch "desktop/src-tauri/binaries/buzz-$TARGET"
     pnpm install
     cd {{desktop_dir}} && pnpm tauri build --features mesh-llm --target {{target}}
 
@@ -293,8 +293,8 @@ staging *ARGS: _ensure-sidecar-stubs
     export MESH_LLM_NATIVE_RUNTIME_CACHE_DIR="$(./scripts/ensure-mesh-native-runtime.sh)"
     # Replace the 0-byte sidecar stub with the real CLI binary so tauri dev picks it up.
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
-    cp target/release/buzz "desktop/src-tauri/binaries/sprout-${TARGET}"
-    chmod +x "desktop/src-tauri/binaries/sprout-${TARGET}"
+    cp target/release/buzz "desktop/src-tauri/binaries/buzz-${TARGET}"
+    chmod +x "desktop/src-tauri/binaries/buzz-${TARGET}"
     cd {{desktop_dir}}
     source ../scripts/instance-env.sh
     export BUZZ_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co"

--- a/justfile
+++ b/justfile
@@ -279,10 +279,10 @@ dev *ARGS: _ensure-sidecar-stubs
     source ../scripts/instance-env.sh
     # Ctrl+C kills the Tauri app before its in-process sweep finishes, leaking
     # agent workers. Reap this instance's agents on exit as a backstop.
-    INSTANCE_ID=$(node -e "console.log(JSON.parse(process.env.SPROUT_TAURI_CONFIG).identifier)")
+    INSTANCE_ID=$(node -e "console.log(JSON.parse(process.env.BUZZ_TAURI_CONFIG).identifier)")
     trap '../scripts/cleanup-instance-agents.sh "$INSTANCE_ID"' EXIT
-    echo "Starting on Vite port ${SPROUT_VITE_PORT}, relay ${SPROUT_RELAY_URL}"
-    pnpm exec tauri dev --features mesh-llm --config "$SPROUT_TAURI_CONFIG" {{ARGS}}
+    echo "Starting on Vite port ${BUZZ_VITE_PORT}, relay ${BUZZ_RELAY_URL}"
+    pnpm exec tauri dev --features mesh-llm --config "$BUZZ_TAURI_CONFIG" {{ARGS}}
 
 # Run the desktop app against the internal staging relay (installs deps + builds agent tools automatically)
 staging *ARGS: _ensure-sidecar-stubs
@@ -297,13 +297,13 @@ staging *ARGS: _ensure-sidecar-stubs
     chmod +x "desktop/src-tauri/binaries/sprout-${TARGET}"
     cd {{desktop_dir}}
     source ../scripts/instance-env.sh
-    export SPROUT_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co"
+    export BUZZ_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co"
     # Ctrl+C kills the Tauri app before its in-process sweep finishes, leaking
     # agent workers. Reap this instance's agents on exit as a backstop.
-    INSTANCE_ID=$(node -e "console.log(JSON.parse(process.env.SPROUT_TAURI_CONFIG).identifier)")
+    INSTANCE_ID=$(node -e "console.log(JSON.parse(process.env.BUZZ_TAURI_CONFIG).identifier)")
     trap '../scripts/cleanup-instance-agents.sh "$INSTANCE_ID"' EXIT
-    echo "Starting staging on Vite port ${SPROUT_VITE_PORT}, relay ${SPROUT_RELAY_URL}"
-    pnpm exec tauri dev --features mesh-llm --config "$SPROUT_TAURI_CONFIG" {{ARGS}}
+    echo "Starting staging on Vite port ${BUZZ_VITE_PORT}, relay ${BUZZ_RELAY_URL}"
+    pnpm exec tauri dev --features mesh-llm --config "$BUZZ_TAURI_CONFIG" {{ARGS}}
 
 # Run the desktop frontend dev server (port derived from worktree)
 desktop-dev:


### PR DESCRIPTION
## Overview

**Category:** fix
**User Impact:** `just dev` and `just staging` work again on a fresh checkout — they currently crash before reaching `tauri dev`, and `staging` would otherwise silently connect to the wrong relay.
**Problem:** #958 (the buzz backend rename) renamed the cargo crates and `_ensure-sidecar-stubs` to `buzz-*`, but three other parts of the build chain were left referencing the old `sprout-*` names, plus a separate env-var rename in `scripts/instance-env.sh` was not propagated:
  1. The `dev` and `staging` recipes still reference `SPROUT_TAURI_CONFIG` / `SPROUT_VITE_PORT` / `SPROUT_RELAY_URL`, but `scripts/instance-env.sh` exports those as `BUZZ_*`. The recipes call `JSON.parse(process.env.SPROUT_TAURI_CONFIG)` on `undefined` and abort with `SyntaxError: "undefined" is not valid JSON`.
  2. `desktop/src-tauri/tauri.conf.json` declares `externalBin` entries as `binaries/sprout-{acp,agent,dev-mcp,...}` and the `staging` + `desktop-release-build` recipes touch/cp `sprout-*` paths, but the stubs created by `_ensure-sidecar-stubs` are now `buzz-*`. tauri-cli aborts with `resource path 'binaries/sprout-acp-aarch64-apple-darwin' doesn't exist`.
  3. The desktop shell itself still read `SPROUT_RELAY_URL` / `SPROUT_RELAY_HTTP` (`relay.rs`, `build.rs`). With the recipes exporting `BUZZ_RELAY_URL`, `just staging` would launch but the app would silently fall back to `ws://localhost:3000` while the sidecar crates (which already read `BUZZ_RELAY_URL`) pointed at staging — a split-brain.
**Solution:** Three narrow sweeps that finish #958's direction:
  1. `SPROUT_TAURI_CONFIG` / `SPROUT_VITE_PORT` / `SPROUT_RELAY_URL` → `BUZZ_*` in the `dev` and `staging` recipes so they read what `instance-env.sh` actually exports.
  2. `binaries/sprout-*` → `binaries/buzz-*` in `tauri.conf.json` externalBin, the `staging` recipe's `cp` target, and the `desktop-release-build` stub `touch` calls — so all four sites agree on the `buzz-*` names that `_ensure-sidecar-stubs` already produces.
  3. `SPROUT_RELAY_URL` / `SPROUT_RELAY_HTTP` → `BUZZ_*` in the desktop shell's read path (`relay.rs:22,67` and the compile-time `BUZZ_DESKTOP_BUILD_RELAY_{URL,HTTP}` bake in `build.rs`) so the shell honors the same relay env vars as everything else.

**Out of scope (pre-existing #958 gaps, follow-up):** the managed-agent spawn handoff still uses `SPROUT_*` names (`runtime.rs` sets `SPROUT_RELAY_URL`/`SPROUT_PRIVATE_KEY`/`SPROUT_ACP_*`, but `buzz-acp` reads `BUZZ_*`; `DEFAULT_ACP_COMMAND` is still `sprout-acp`; `KNOWN_AGENT_BINARIES` only lists `sprout-*`). That handoff needs its own coordinated rename.

<details>
<summary>File changes</summary>

**justfile**
Renamed env-var references inside the `dev` and `staging` recipes from `SPROUT_*` to `BUZZ_*` to match `scripts/instance-env.sh`. Renamed the `cp` target in `staging` and the `touch` paths in `desktop-release-build` from `binaries/sprout-*` to `binaries/buzz-*` to match `_ensure-sidecar-stubs`.

**desktop/src-tauri/tauri.conf.json**
Renamed `externalBin` entries from `binaries/sprout-{acp,agent,dev-mcp}` and `binaries/sprout` to their `binaries/buzz-*` equivalents so they match the stubs produced by `_ensure-sidecar-stubs` and the binaries cargo emits.

**desktop/src-tauri/src/relay.rs, desktop/src-tauri/build.rs**
The desktop shell now reads `BUZZ_RELAY_URL` / `BUZZ_RELAY_HTTP` (and bakes `BUZZ_DESKTOP_BUILD_RELAY_{URL,HTTP}` at compile time) instead of the `SPROUT_*` names, matching the recipes and the renamed crates.

</details>

## Reproduction Steps

1. Fresh checkout of `main` (or fresh worktree from main).
2. Run `just staging` (or `just dev`). Without this fix: `SyntaxError: "undefined" is not valid JSON` right after the cargo build, then later `resource path 'binaries/sprout-acp-...' doesn't exist`; even with those patched, the app would connect to `ws://localhost:3000` instead of the staging relay. With this fix, the recipe proceeds into `tauri dev` and the shell honors `BUZZ_RELAY_URL`.