### PR TITLE
fix(desktop): resolve effective model and prompt from persona in display path

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -30,7 +30,7 @@ const rules = [
 // Do not add to this list; split the file instead. Remove each entry as its
 // file is broken up. Tracked as a follow-up.
 const overrides = new Map([
-  ["src-tauri/src/commands/agents.rs", 1287],
+  ["src-tauri/src/commands/agents.rs", 1294],
   ["src-tauri/src/managed_agents/nest.rs", 1420],
   ["src-tauri/src/managed_agents/runtime.rs", 1940],
   ["src-tauri/src/managed_agents/personas.rs", 1080],

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -7,8 +7,9 @@ use crate::{
     app_state::AppState,
     managed_agents::{
         build_managed_agent_summary, default_agent_workdir, find_managed_agent_mut,
-        known_acp_runtime, load_managed_agents, managed_agent_avatar_url, missing_command_message,
-        normalize_agent_args, resolve_command, save_managed_agents, sync_managed_agent_processes,
+        known_acp_runtime, load_managed_agents, load_personas, managed_agent_avatar_url,
+        missing_command_message, normalize_agent_args, resolve_command,
+        resolve_effective_prompt_model_provider, save_managed_agents, sync_managed_agent_processes,
         try_regenerate_nest, AgentModelInfo, AgentModelsResponse, UpdateManagedAgentRequest,
         UpdateManagedAgentResponse,
     },
@@ -62,7 +63,17 @@ pub async fn get_agent_models(
             crate::managed_agents::resolve_persona_env(&app, record.persona_id.as_deref())?;
         let env = crate::managed_agents::merged_user_env(&persona_env, &record.env_vars);
 
-        (resolved, resolved_agent, args, record.model.clone(), env)
+        // Resolve the effective model from the linked persona so the ModelPicker
+        // dropdown shows the current persona model as selected.
+        let personas = load_personas(&app).unwrap_or_default();
+        let (_prompt, effective_model, _provider) = resolve_effective_prompt_model_provider(
+            record.persona_id.as_deref(),
+            &personas,
+            record.system_prompt.clone(),
+            record.model.clone(),
+        );
+
+        (resolved, resolved_agent, args, effective_model, env)
     }; // store lock released — subprocess runs without holding the lock
 
     // Clone the env map for redaction below — `merged_env` is moved
@@ -249,7 +260,10 @@ pub async fn update_managed_agent(
             None
         };
 
-        let summary = build_managed_agent_summary(&app, record, &runtimes)?;
+        let summary = {
+            let personas = load_personas(&app).unwrap_or_default();
+            build_managed_agent_summary(&app, record, &runtimes, &personas)?
+        };
         (summary, sync_params)
     }; // lock dropped here
 

--- a/desktop/src-tauri/src/commands/agent_settings.rs
+++ b/desktop/src-tauri/src/commands/agent_settings.rs
@@ -3,7 +3,7 @@ use tauri::{AppHandle, State};
 use crate::{
     app_state::AppState,
     managed_agents::{
-        build_managed_agent_summary, find_managed_agent_mut, load_managed_agents,
+        build_managed_agent_summary, find_managed_agent_mut, load_managed_agents, load_personas,
         save_managed_agents, sync_managed_agent_processes, ManagedAgentSummary,
     },
     util::now_iso,
@@ -41,5 +41,6 @@ pub fn set_managed_agent_start_on_app_launch(
         .iter()
         .find(|record| record.pubkey == pubkey)
         .ok_or_else(|| format!("agent {pubkey} not found"))?;
-    build_managed_agent_summary(&app, record, &runtimes)
+    let personas = load_personas(&app).unwrap_or_default();
+    build_managed_agent_summary(&app, record, &runtimes, &personas)
 }

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -111,7 +111,8 @@ async fn start_local_agent_with_preflight(
         .iter()
         .find(|record| record.pubkey == pubkey)
         .ok_or_else(|| format!("agent {pubkey} not found"))?;
-    build_managed_agent_summary(app, record, &runtimes)
+    let personas = load_personas(app).unwrap_or_default();
+    build_managed_agent_summary(app, record, &runtimes, &personas)
 }
 
 /// Build the standard agent JSON payload for provider deploy calls.
@@ -283,9 +284,10 @@ pub fn list_managed_agents(
         save_managed_agents(&app, &records)?;
     }
 
+    let personas = load_personas(&app).unwrap_or_default();
     records
         .iter()
-        .map(|record| build_managed_agent_summary(&app, record, &runtimes))
+        .map(|record| build_managed_agent_summary(&app, record, &runtimes, &personas))
         .collect()
 }
 
@@ -565,8 +567,9 @@ pub async fn create_managed_agent(
             .iter()
             .find(|record| record.pubkey == pubkey)
             .ok_or_else(|| "created agent disappeared unexpectedly".to_string())?;
+        let personas = load_personas(&app).unwrap_or_default();
         (
-            build_managed_agent_summary(&app, record, &runtimes)?,
+            build_managed_agent_summary(&app, record, &runtimes, &personas)?,
             resolved_avatar_url,
         )
     };
@@ -595,7 +598,8 @@ pub async fn create_managed_agent(
                     .iter()
                     .find(|record| record.pubkey == pubkey)
                     .ok_or_else(|| "created agent disappeared unexpectedly".to_string())?;
-                build_managed_agent_summary(&app, record, &runtimes)?
+                let personas = load_personas(&app).unwrap_or_default();
+                build_managed_agent_summary(&app, record, &runtimes, &personas)?
             }
         }
     } else {
@@ -681,7 +685,8 @@ pub async fn create_managed_agent(
             .iter()
             .find(|r| r.pubkey == pubkey)
             .ok_or_else(|| "agent disappeared".to_string())?;
-        build_managed_agent_summary(&app, record, &runtimes)?
+        let personas = load_personas(&app).unwrap_or_default();
+        build_managed_agent_summary(&app, record, &runtimes, &personas)?
     } else {
         agent
     };
@@ -811,7 +816,8 @@ pub async fn start_managed_agent(
                 .iter()
                 .find(|r| r.pubkey == pubkey)
                 .ok_or_else(|| format!("agent {pubkey} not found"))?;
-            build_managed_agent_summary(&app, record, &runtimes)
+            let personas = load_personas(&app).unwrap_or_default();
+            build_managed_agent_summary(&app, record, &runtimes, &personas)
         }
         StartTarget::Provider { backend, .. } => Err(format!(
             "agent {pubkey} has unsupported backend kind: {backend:?}"
@@ -1003,7 +1009,8 @@ pub fn stop_managed_agent(
         .iter()
         .find(|record| record.pubkey == pubkey)
         .ok_or_else(|| format!("agent {pubkey} not found"))?;
-    build_managed_agent_summary(&app, record, &runtimes)
+    let personas = load_personas(&app).unwrap_or_default();
+    build_managed_agent_summary(&app, record, &runtimes, &personas)
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1278,6 +1278,7 @@ pub fn build_managed_agent_summary(
     app: &AppHandle,
     record: &ManagedAgentRecord,
     runtimes: &HashMap<String, ManagedAgentProcess>,
+    personas: &[crate::managed_agents::types::PersonaRecord],
 ) -> Result<ManagedAgentSummary, String> {
     use crate::managed_agents::BackendKind;
 
@@ -1330,6 +1331,17 @@ pub fn build_managed_agent_summary(
         }
     };
 
+    // Resolve the effective model and system_prompt from the linked persona
+    // (mirrors spawn-time logic) so the UI displays the current persona values,
+    // not the stale record snapshot.
+    let (effective_prompt, effective_model, _effective_provider) =
+        resolve_effective_prompt_model_provider(
+            record.persona_id.as_deref(),
+            personas,
+            record.system_prompt.clone(),
+            record.model.clone(),
+        );
+
     Ok(ManagedAgentSummary {
         pubkey: record.pubkey.clone(),
         name: record.name.clone(),
@@ -1343,8 +1355,8 @@ pub fn build_managed_agent_summary(
         idle_timeout_seconds: record.idle_timeout_seconds,
         max_turn_duration_seconds: record.max_turn_duration_seconds,
         parallelism: record.parallelism,
-        system_prompt: record.system_prompt.clone(),
-        model: record.model.clone(),
+        system_prompt: effective_prompt,
+        model: effective_model,
         mcp_toolsets: record.mcp_toolsets.clone(),
         env_vars: record.env_vars.clone(),
         backend: record.backend.clone(),
@@ -1435,7 +1447,7 @@ pub(crate) fn build_respond_to_env(
 /// linked persona always wins so persona edits propagate on the next spawn; the
 /// record snapshot is the fallback only when no persona is linked or it was
 /// deleted. Provider comes from the persona (the record has no provider field).
-fn resolve_effective_prompt_model_provider(
+pub(crate) fn resolve_effective_prompt_model_provider(
     persona_id: Option<&str>,
     personas: &[crate::managed_agents::types::PersonaRecord],
     record_prompt: Option<String>,


### PR DESCRIPTION
The Agents panel and ModelPicker displayed stale `model`/`system_prompt` values from `ManagedAgentRecord` — a creation-time snapshot that never updated when the linked persona changed. The spawn path already resolved the effective values from the persona; this aligns the display path to do the same.

## Changes

- `build_managed_agent_summary()` now accepts a `&[PersonaRecord]` slice and resolves the effective model and system_prompt from the linked persona (mirroring the spawn-time logic in `resolve_effective_prompt_model_provider()`)
- All callers in `agents.rs`, `agent_models.rs`, and `agent_settings.rs` load personas once per handler and pass the slice
- `get_agent_models` now resolves the effective model for `selected_model` so the ModelPicker dropdown shows the correct selection
- Made `resolve_effective_prompt_model_provider` `pub(crate)` for reuse in the display path

## Behavior

- When a persona is linked: summary shows the persona's current model and system_prompt
- When no persona is linked: falls back to `record.model` / `record.system_prompt` (unchanged)
- No changes to spawn-time behavior (`spawn_agent_child` untouched)