### PR TITLE
fix(onboarding): skip onboarding when relay already has a profile

### DIFF
--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -110,7 +110,7 @@ function OnboardingLoadingGate() {
               type="button"
               variant="ghost"
             >
-              Continue using Nostr
+              I already have a key
             </Button>
           </div>
         </OnboardingSlideTransition>

--- a/desktop/src/features/onboarding/hooks.ts
+++ b/desktop/src/features/onboarding/hooks.ts
@@ -36,6 +36,7 @@ type UseFirstRunOnboardingGateOptions = {
   identityIsFetching: boolean;
   identityStatus: QueryStatus;
   isSharedIdentity: boolean;
+  profileDisplayName: string | null | undefined;
   profileIsFetching: boolean;
   profileStatus: QueryStatus;
 };
@@ -130,6 +131,7 @@ export function useFirstRunOnboardingGate({
   identityIsFetching,
   identityStatus,
   isSharedIdentity,
+  profileDisplayName,
   profileIsFetching,
   profileStatus,
 }: UseFirstRunOnboardingGateOptions) {
@@ -198,9 +200,25 @@ export function useFirstRunOnboardingGate({
       return;
     }
 
+    // If the relay already has a profile with a display name for this pubkey,
+    // the user has previously completed onboarding (possibly on another
+    // machine or app data directory). Skip the onboarding flow and mark as
+    // complete so they go straight to the app.
+    const hasExistingProfile =
+      profileStatus === "success" &&
+      typeof profileDisplayName === "string" &&
+      profileDisplayName.trim().length > 0;
+
     setGateState((current) =>
       updateActiveGateState(current, currentPubkey, (activeGateState) => {
-        const alreadyOnboarded = activeGateState.hasCompletedCurrentPubkey;
+        const alreadyOnboarded =
+          activeGateState.hasCompletedCurrentPubkey || hasExistingProfile;
+        if (alreadyOnboarded && typeof window !== "undefined") {
+          window.localStorage.setItem(
+            onboardingCompletionStorageKey(currentPubkey),
+            "true",
+          );
+        }
         return {
           ...activeGateState,
           hasCompletedCurrentPubkey: alreadyOnboarded,
@@ -215,6 +233,7 @@ export function useFirstRunOnboardingGate({
     hasSettledCurrentPubkey,
     identityStatus,
     isSharedIdentity,
+    profileDisplayName,
     profileIsFetching,
     profileStatus,
   ]);
@@ -268,6 +287,7 @@ export function useAppOnboardingState(isSharedIdentity: boolean) {
     identityIsFetching: identityQuery.fetchStatus === "fetching",
     identityStatus: identityQuery.status,
     isSharedIdentity,
+    profileDisplayName: profileQuery.data?.displayName,
     profileIsFetching: profileQuery.fetchStatus === "fetching",
     profileStatus: profileQuery.status,
   });

--- a/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
+++ b/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
@@ -1,0 +1,273 @@
+import * as React from "react";
+import { Check, KeyRound } from "lucide-react";
+
+import { cn } from "@/shared/lib/cn";
+import { nsecToNpub, shortenNpub } from "@/shared/lib/nostrUtils";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Spinner } from "@/shared/ui/spinner";
+
+const NOSTR_KEY_FILE_MAX_BYTES = 1024;
+
+type NostrKeyImportFormProps = {
+  disabled?: boolean;
+  errorMessage?: string | null;
+  onBack: () => void;
+  onImport: (nsec: string) => Promise<void>;
+};
+
+/**
+ * Paste-or-drop nsec import form with a live npub preview.
+ *
+ * Shared between the first-run welcome flow (no workspace yet) and the
+ * onboarding profile flow (workspace exists, user wants to reuse an
+ * existing key). The caller owns what happens after `onImport` resolves.
+ */
+export function NostrKeyImportForm({
+  disabled = false,
+  errorMessage: externalErrorMessage = null,
+  onBack,
+  onImport,
+}: NostrKeyImportFormProps) {
+  const [nsecInput, setNsecInput] = React.useState("");
+  const [isImporting, setIsImporting] = React.useState(false);
+  const [importError, setImportError] = React.useState<string | null>(null);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+  const previewNpub = React.useMemo(() => nsecToNpub(nsecInput), [nsecInput]);
+  const trimmedInput = nsecInput.trim();
+  const hasInput = trimmedInput.length > 0;
+  const isValid = previewNpub !== null;
+  const isBusy = disabled || isImporting;
+  const showInvalidHint = hasInput && !isValid && trimmedInput.length >= 5;
+  const errorMessage = importError ?? externalErrorMessage;
+
+  React.useLayoutEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const openFilePicker = React.useCallback(() => {
+    if (isBusy) {
+      return;
+    }
+
+    fileInputRef.current?.click();
+  }, [isBusy]);
+
+  const handleFiles = React.useCallback(async (files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (file.size > NOSTR_KEY_FILE_MAX_BYTES) {
+      setImportError(
+        "That file is too large to be a key. Drop a .key file or paste your nsec.",
+      );
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      const firstLine =
+        text.split(/\r?\n/).find((line) => line.trim().length > 0) ?? "";
+      setNsecInput(firstLine.trim());
+      setImportError(null);
+    } catch (error) {
+      setImportError(
+        error instanceof Error ? error.message : "Couldn't read that file.",
+      );
+    }
+  }, []);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (!previewNpub) {
+      setImportError(
+        "That doesn't look like a valid nsec. Paste an nsec1 key.",
+      );
+      return;
+    }
+
+    setIsImporting(true);
+    setImportError(null);
+
+    try {
+      await onImport(trimmedInput);
+    } catch (error) {
+      setImportError(
+        error instanceof Error ? error.message : "Failed to import key.",
+      );
+    } finally {
+      setIsImporting(false);
+    }
+  }, [onImport, previewNpub, trimmedInput]);
+
+  return (
+    <form
+      className="mt-8 flex w-full flex-col gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleSubmit();
+      }}
+    >
+      <div className="space-y-1.5 text-left">
+        <label
+          className="text-sm font-medium text-foreground"
+          htmlFor="nostr-private-key"
+        >
+          Private key
+        </label>
+        <Input
+          autoComplete="off"
+          autoCorrect="off"
+          className="h-10 bg-background"
+          data-testid="nostr-import-nsec-input"
+          id="nostr-private-key"
+          onChange={(event) => {
+            setNsecInput(event.target.value);
+            setImportError(null);
+          }}
+          placeholder="nsec1..."
+          ref={inputRef}
+          spellCheck={false}
+          type="password"
+          value={nsecInput}
+        />
+      </div>
+
+      <input
+        accept=".key,text/plain"
+        className="sr-only"
+        disabled={isBusy}
+        onChange={(event) => {
+          void handleFiles(event.currentTarget.files);
+          event.currentTarget.value = "";
+        }}
+        ref={fileInputRef}
+        tabIndex={-1}
+        type="file"
+      />
+
+      <button
+        className={cn(
+          "relative flex h-[120px] flex-col items-center justify-center gap-3 overflow-hidden rounded-xl border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-[250ms] ease-out hover:bg-muted/80 disabled:opacity-60",
+          isDragging &&
+            "border-primary bg-primary/10 text-primary ring-1 ring-primary/35 hover:bg-primary/10",
+        )}
+        data-dragging={isDragging ? "true" : undefined}
+        data-testid="nostr-import-drop"
+        disabled={isBusy}
+        onClick={openFilePicker}
+        onDragEnter={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!isBusy) {
+            setIsDragging(true);
+          }
+        }}
+        onDragLeave={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (
+            event.currentTarget.contains(event.relatedTarget as Node | null)
+          ) {
+            return;
+          }
+          setIsDragging(false);
+        }}
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!isBusy) {
+            event.dataTransfer.dropEffect = "copy";
+          }
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setIsDragging(false);
+          if (isBusy) {
+            return;
+          }
+          void handleFiles(event.dataTransfer.files);
+        }}
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute inset-0 rounded-[inherit] bg-primary/10 opacity-0 transition-opacity duration-[250ms] ease-out",
+            isDragging && "opacity-100",
+          )}
+        />
+        <KeyRound
+          className={cn(
+            "relative h-8 w-8 text-muted-foreground transition-colors duration-[250ms] ease-out",
+            isDragging && "text-primary",
+          )}
+        />
+        <span
+          className={cn(
+            "relative text-sm font-medium text-muted-foreground transition-colors duration-[250ms] ease-out",
+            isDragging && "text-primary",
+          )}
+        >
+          Drop a key here
+        </span>
+      </button>
+
+      {previewNpub ? (
+        <div
+          className="flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs"
+          data-testid="nostr-import-npub-preview"
+        >
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+          <div className="min-w-0 space-y-0.5">
+            <p className="font-medium text-foreground">
+              This will use this Nostr identity:
+            </p>
+            <p className="break-all font-mono text-[11px] text-muted-foreground">
+              {shortenNpub(previewNpub)}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {showInvalidHint && !errorMessage ? (
+        <p className="text-xs text-muted-foreground">
+          Waiting for a valid nsec1 key.
+        </p>
+      ) : null}
+
+      {errorMessage ? (
+        <p className="text-center text-sm text-destructive">{errorMessage}</p>
+      ) : null}
+
+      <div className="flex w-full flex-col gap-3 pt-1">
+        <Button
+          className="h-10 w-full"
+          data-testid="nostr-import-submit"
+          disabled={!isValid || isBusy}
+          type="submit"
+        >
+          {isBusy ? (
+            <Spinner aria-label="Importing key" className="h-4 w-4" />
+          ) : (
+            "Continue with this key"
+          )}
+        </Button>
+
+        <Button
+          className="h-10 w-full text-muted-foreground hover:text-accent-foreground"
+          disabled={isBusy}
+          onClick={onBack}
+          type="button"
+          variant="ghost"
+        >
+          Back
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -19,7 +19,11 @@ import { ONBOARDING_DEFAULT_THEME_NAME } from "@/shared/theme/theme-loader";
 import { StepProgress } from "@/shared/ui/step-progress";
 import { AvatarStep } from "./AvatarStep";
 import { MembershipDenied } from "./MembershipDenied";
-import type { OnboardingTransitionDirection } from "./OnboardingSlideTransition";
+import { NostrKeyImportForm } from "./NostrKeyImportForm";
+import {
+  type OnboardingTransitionDirection,
+  OnboardingSlideTransition,
+} from "./OnboardingSlideTransition";
 import { ProfileStep } from "./ProfileStep";
 import { SetupStep } from "./SetupStep";
 import { ThemeStep, preloadThemePreviewVars } from "./ThemeStep";
@@ -228,6 +232,11 @@ export function OnboardingFlow({
     setCurrentPage("profile");
   }, []);
 
+  const showKeyImportPage = React.useCallback(() => {
+    setTransitionDirection("forward");
+    setCurrentPage("key-import");
+  }, []);
+
   const saveProfileAndContinue = React.useCallback(
     async (nextPage: OnboardingPage) => {
       if (isProfileAdvancePending) {
@@ -365,7 +374,11 @@ export function OnboardingFlow({
       : profileStepState.saveRecovery,
   };
 
-  const importDeniedKey = React.useCallback(
+  // Swapping the identity changes the pubkey, which remounts this flow
+  // (keyed on pubkey in App.tsx) and re-runs the onboarding gate: the new
+  // key's relay profile reseeds the steps, and a key that already finished
+  // onboarding on this machine skips straight into the app.
+  const importExistingKey = React.useCallback(
     async (nsec: string) => {
       const identity = await importIdentity(nsec);
       relayClient.disconnect();
@@ -390,7 +403,7 @@ export function OnboardingFlow({
               }
             : undefined
         }
-        onImportKey={canBackToWorkspaceSetup ? undefined : importDeniedKey}
+        onImportKey={canBackToWorkspaceSetup ? undefined : importExistingKey}
         onRetry={() => {
           void saveProfileAndContinue(membershipRetryPage);
         }}
@@ -402,7 +415,9 @@ export function OnboardingFlow({
   return (
     <div
       className={`buzz-startup-shell flex items-center justify-center bg-background px-4 py-8 text-foreground ${
-        currentPage === "profile" || currentPage === "avatar"
+        currentPage === "profile" ||
+        currentPage === "avatar" ||
+        currentPage === "key-import"
           ? "buzz-onboarding-neutral-theme"
           : ""
       }`}
@@ -429,7 +444,7 @@ export function OnboardingFlow({
           }`}
           completeSegmentClassName="bg-primary/35"
           currentStep={
-            currentPage === "profile"
+            currentPage === "profile" || currentPage === "key-import"
               ? 2
               : currentPage === "avatar"
                 ? 3
@@ -451,6 +466,7 @@ export function OnboardingFlow({
                   }
                 : undefined,
               clearAvatarDraft: resetAvatarDraft,
+              importExistingKey: showKeyImportPage,
               onUploadingChange: setIsUploadingAvatar,
               skipForNow,
               submit: () => {
@@ -462,6 +478,28 @@ export function OnboardingFlow({
             direction={transitionDirection}
             state={profileStepState}
           />
+        ) : currentPage === "key-import" ? (
+          <OnboardingSlideTransition
+            className="flex w-full flex-col items-center text-center"
+            direction={transitionDirection}
+            transitionKey={`key-import-${transitionDirection}`}
+          >
+            <div className="w-full max-w-[440px]">
+              <h1 className="text-3xl font-semibold tracking-tight">
+                Use your existing key
+              </h1>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                Import your Nostr private key to use that identity with Buzz. If
+                this key already has a profile on the relay, your name and
+                avatar are restored automatically.
+              </p>
+            </div>
+
+            <NostrKeyImportForm
+              onBack={showProfilePage}
+              onImport={importExistingKey}
+            />
+          </OnboardingSlideTransition>
         ) : currentPage === "avatar" ? (
           <AvatarStep
             actions={{

--- a/desktop/src/features/onboarding/ui/ProfileStep.tsx
+++ b/desktop/src/features/onboarding/ui/ProfileStep.tsx
@@ -35,8 +35,14 @@ export function ProfileStep({
   transitionEffect = "line-slide",
   state,
 }: ProfileStepProps) {
-  const { advanceWithoutSaving, back, skipForNow, submit, updateDisplayName } =
-    actions;
+  const {
+    advanceWithoutSaving,
+    back,
+    importExistingKey,
+    skipForNow,
+    submit,
+    updateDisplayName,
+  } = actions;
   const { isSaving, name, saveRecovery } = state;
   const displayNameDraft = name.draftValue;
   const hasDisplayNameDraft = displayNameDraft.length > 0;
@@ -140,6 +146,17 @@ export function ProfileStep({
             Back
           </Button>
         ) : null}
+
+        <Button
+          className="text-muted-foreground hover:text-accent-foreground"
+          data-testid="onboarding-import-key"
+          disabled={isSaving}
+          onClick={importExistingKey}
+          type="button"
+          variant="ghost"
+        >
+          I already have a key
+        </Button>
 
         <div className="flex min-h-8 items-center gap-2">
           <div className="flex-1" />

--- a/desktop/src/features/onboarding/ui/types.ts
+++ b/desktop/src/features/onboarding/ui/types.ts
@@ -2,6 +2,7 @@ import type { AcpRuntimeCatalogEntry, Profile } from "@/shared/api/types";
 
 export type OnboardingPage =
   | "profile"
+  | "key-import"
   | "avatar"
   | "theme"
   | "setup"
@@ -48,6 +49,7 @@ export type ProfileStepState = {
 export type ProfileStepActions = {
   advanceWithoutSaving: () => void;
   back?: () => void;
+  importExistingKey: () => void;
   clearAvatarDraft: () => void;
   onUploadingChange: (isUploading: boolean) => void;
   skipForNow: () => void;

--- a/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
@@ -1,17 +1,16 @@
 import * as React from "react";
-import { Check, Hexagon, KeyRound } from "lucide-react";
+import { Hexagon } from "lucide-react";
 import { flushSync } from "react-dom";
 
 import {
   getIdentity,
   importIdentity as tauriImportIdentity,
 } from "@/shared/api/tauri";
+import { NostrKeyImportForm } from "@/features/onboarding/ui/NostrKeyImportForm";
 import {
   type OnboardingTransitionDirection,
   OnboardingSlideTransition,
 } from "@/features/onboarding/ui/OnboardingSlideTransition";
-import { cn } from "@/shared/lib/cn";
-import { nsecToNpub, shortenNpub } from "@/shared/lib/nostrUtils";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Spinner } from "@/shared/ui/spinner";
@@ -31,7 +30,6 @@ type WelcomeSetupProps = {
 };
 
 const DEFAULT_WORKSPACE_HANDOFF_MIN_MS = 200;
-const NOSTR_KEY_FILE_MAX_BYTES = 1024;
 
 function wait(ms: number) {
   return new Promise<void>((resolve) => {
@@ -50,80 +48,6 @@ function NostrKeyImportPage({
   onBack: () => void;
   onImport: (nsec: string) => Promise<void>;
 }) {
-  const [nsecInput, setNsecInput] = React.useState("");
-  const [isImporting, setIsImporting] = React.useState(false);
-  const [importError, setImportError] = React.useState<string | null>(null);
-  const [isDragging, setIsDragging] = React.useState(false);
-  const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
-  const previewNpub = React.useMemo(() => nsecToNpub(nsecInput), [nsecInput]);
-  const trimmedInput = nsecInput.trim();
-  const hasInput = trimmedInput.length > 0;
-  const isValid = previewNpub !== null;
-  const isBusy = disabled || isImporting;
-  const showInvalidHint = hasInput && !isValid && trimmedInput.length >= 5;
-  const errorMessage = importError ?? connectionError;
-
-  React.useLayoutEffect(() => {
-    inputRef.current?.focus();
-  }, []);
-
-  const openFilePicker = React.useCallback(() => {
-    if (isBusy) {
-      return;
-    }
-
-    fileInputRef.current?.click();
-  }, [isBusy]);
-
-  const handleFiles = React.useCallback(async (files: FileList | null) => {
-    const file = files?.[0];
-    if (!file) {
-      return;
-    }
-
-    if (file.size > NOSTR_KEY_FILE_MAX_BYTES) {
-      setImportError(
-        "That file is too large to be a key. Drop a .key file or paste your nsec.",
-      );
-      return;
-    }
-
-    try {
-      const text = await file.text();
-      const firstLine =
-        text.split(/\r?\n/).find((line) => line.trim().length > 0) ?? "";
-      setNsecInput(firstLine.trim());
-      setImportError(null);
-    } catch (error) {
-      setImportError(
-        error instanceof Error ? error.message : "Couldn't read that file.",
-      );
-    }
-  }, []);
-
-  const handleSubmit = React.useCallback(async () => {
-    if (!previewNpub) {
-      setImportError(
-        "That doesn't look like a valid nsec. Paste an nsec1 key.",
-      );
-      return;
-    }
-
-    setIsImporting(true);
-    setImportError(null);
-
-    try {
-      await onImport(trimmedInput);
-    } catch (error) {
-      setImportError(
-        error instanceof Error ? error.message : "Failed to import key.",
-      );
-    } finally {
-      setIsImporting(false);
-    }
-  }, [onImport, previewNpub, trimmedInput]);
-
   return (
     <OnboardingSlideTransition
       className="flex w-full flex-col items-center text-center"
@@ -135,177 +59,18 @@ function NostrKeyImportPage({
           Use your existing key
         </h1>
         <p className="mt-3 text-sm leading-6 text-muted-foreground">
-          Import your Nostr private key to use that identity with Buzz. If
-          this key already has a profile on the relay, your name and avatar are
+          Import your Nostr private key to use that identity with Buzz. If this
+          key already has a profile on the relay, your name and avatar are
           restored automatically.
         </p>
       </div>
 
-      <form
-        className="mt-8 flex w-full flex-col gap-4"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void handleSubmit();
-        }}
-      >
-        <div className="space-y-1.5 text-left">
-          <label
-            className="text-sm font-medium text-foreground"
-            htmlFor="nostr-private-key"
-          >
-            Private key
-          </label>
-          <Input
-            autoComplete="off"
-            autoCorrect="off"
-            className="h-10 bg-background"
-            data-testid="welcome-nostr-nsec-input"
-            id="nostr-private-key"
-            onChange={(event) => {
-              setNsecInput(event.target.value);
-              setImportError(null);
-            }}
-            placeholder="nsec1..."
-            ref={inputRef}
-            spellCheck={false}
-            type="password"
-            value={nsecInput}
-          />
-        </div>
-
-        <input
-          accept=".key,text/plain"
-          className="sr-only"
-          disabled={isBusy}
-          onChange={(event) => {
-            void handleFiles(event.currentTarget.files);
-            event.currentTarget.value = "";
-          }}
-          ref={fileInputRef}
-          tabIndex={-1}
-          type="file"
-        />
-
-        <button
-          className={cn(
-            "relative flex h-[120px] flex-col items-center justify-center gap-3 overflow-hidden rounded-xl border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-[250ms] ease-out hover:bg-muted/80 disabled:opacity-60",
-            isDragging &&
-              "border-primary bg-primary/10 text-primary ring-1 ring-primary/35 hover:bg-primary/10",
-          )}
-          data-dragging={isDragging ? "true" : undefined}
-          data-testid="welcome-nostr-drop"
-          disabled={isBusy}
-          onClick={openFilePicker}
-          onDragEnter={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            if (!isBusy) {
-              setIsDragging(true);
-            }
-          }}
-          onDragLeave={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            if (
-              event.currentTarget.contains(event.relatedTarget as Node | null)
-            ) {
-              return;
-            }
-            setIsDragging(false);
-          }}
-          onDragOver={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            if (!isBusy) {
-              event.dataTransfer.dropEffect = "copy";
-            }
-          }}
-          onDrop={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            setIsDragging(false);
-            if (isBusy) {
-              return;
-            }
-            void handleFiles(event.dataTransfer.files);
-          }}
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            className={cn(
-              "pointer-events-none absolute inset-0 rounded-[inherit] bg-primary/10 opacity-0 transition-opacity duration-[250ms] ease-out",
-              isDragging && "opacity-100",
-            )}
-          />
-          <KeyRound
-            className={cn(
-              "relative h-8 w-8 text-muted-foreground transition-colors duration-[250ms] ease-out",
-              isDragging && "text-primary",
-            )}
-          />
-          <span
-            className={cn(
-              "relative text-sm font-medium text-muted-foreground transition-colors duration-[250ms] ease-out",
-              isDragging && "text-primary",
-            )}
-          >
-            Drop a key here
-          </span>
-        </button>
-
-        {previewNpub ? (
-          <div
-            className="flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs"
-            data-testid="welcome-nostr-npub-preview"
-          >
-            <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
-            <div className="min-w-0 space-y-0.5">
-              <p className="font-medium text-foreground">
-                This will use this Nostr identity:
-              </p>
-              <p className="break-all font-mono text-[11px] text-muted-foreground">
-                {shortenNpub(previewNpub)}
-              </p>
-            </div>
-          </div>
-        ) : null}
-
-        {showInvalidHint && !errorMessage ? (
-          <p className="text-xs text-muted-foreground">
-            Waiting for a valid nsec1 key.
-          </p>
-        ) : null}
-
-        {errorMessage ? (
-          <p className="text-center text-sm text-destructive">{errorMessage}</p>
-        ) : null}
-
-        <div className="flex w-full flex-col gap-3 pt-1">
-          <Button
-            className="h-10 w-full"
-            data-testid="welcome-nostr-submit"
-            disabled={!isValid || isBusy}
-            type="submit"
-          >
-            {isBusy ? (
-              <Spinner aria-label="Importing key" className="h-4 w-4" />
-            ) : (
-              "Continue with this key"
-            )}
-          </Button>
-
-          <Button
-            className="h-10 w-full text-muted-foreground hover:text-accent-foreground"
-            disabled={isBusy}
-            onClick={onBack}
-            type="button"
-            variant="ghost"
-          >
-            Back
-          </Button>
-        </div>
-      </form>
+      <NostrKeyImportForm
+        disabled={disabled}
+        errorMessage={connectionError}
+        onBack={onBack}
+        onImport={onImport}
+      />
     </OnboardingSlideTransition>
   );
 }

--- a/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
@@ -132,10 +132,12 @@ function NostrKeyImportPage({
     >
       <div className="w-full max-w-[440px]">
         <h1 className="text-3xl font-semibold tracking-tight">
-          Import your Nostr key
+          Use your existing key
         </h1>
         <p className="mt-3 text-sm leading-6 text-muted-foreground">
-          Import an existing Nostr private key to use that identity with Buzz.
+          Import your Nostr private key to use that identity with Buzz. If
+          this key already has a profile on the relay, your name and avatar are
+          restored automatically.
         </p>
       </div>
 
@@ -289,7 +291,7 @@ function NostrKeyImportPage({
             {isBusy ? (
               <Spinner aria-label="Importing key" className="h-4 w-4" />
             ) : (
-              "Import key"
+              "Continue with this key"
             )}
           </Button>
 
@@ -494,7 +496,7 @@ export function WelcomeSetup({
                 type="button"
                 variant="ghost"
               >
-                I have my own Nostr key
+                I already have a key
               </Button>
             </div>
 

--- a/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
@@ -132,7 +132,7 @@ function NostrKeyImportPage({
     >
       <div className="w-full max-w-[440px]">
         <h1 className="text-3xl font-semibold tracking-tight">
-          Continue using Nostr
+          Import your Nostr key
         </h1>
         <p className="mt-3 text-sm leading-6 text-muted-foreground">
           Import an existing Nostr private key to use that identity with Buzz.
@@ -289,7 +289,7 @@ function NostrKeyImportPage({
             {isBusy ? (
               <Spinner aria-label="Importing key" className="h-4 w-4" />
             ) : (
-              "Continue using Nostr"
+              "Import key"
             )}
           </Button>
 
@@ -494,7 +494,7 @@ export function WelcomeSetup({
                 type="button"
                 variant="ghost"
               >
-                Continue using Nostr
+                I have my own Nostr key
               </Button>
             </div>
 

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -238,9 +238,8 @@ test("welcome can continue using an existing Nostr key", async ({ page }) => {
   await expect(page.getByTestId("nostr-import-npub-preview")).toBeVisible();
   await page.getByTestId("nostr-import-submit").click();
 
-  await expect(page.getByTestId("onboarding-display-name")).toHaveValue(
-    "alice",
-  );
+  // Alice already has a relay profile with a display name, so onboarding
+  // auto-completes after the identity swap.
   await expect
     .poll(() =>
       page.evaluate(() => {
@@ -252,17 +251,8 @@ test("welcome can continue using an existing Nostr key", async ({ page }) => {
       }),
     )
     .toBe(TEST_IDENTITIES.alice.pubkey);
-  await expect
-    .poll(() =>
-      page.evaluate((storageKey) => {
-        const rawIdentity = window.localStorage.getItem(storageKey);
-        const identity = rawIdentity
-          ? (JSON.parse(rawIdentity) as { pubkey?: string })
-          : null;
-        return identity?.pubkey ?? null;
-      }, E2E_IDENTITY_OVERRIDE_STORAGE_KEY),
-    )
-    .toBe(TEST_IDENTITIES.alice.pubkey);
+  await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await expectHomeView(page);
 });
 
 test("welcome presents custom workspace setup as joining a workspace", async ({
@@ -287,6 +277,7 @@ test("welcome presents custom workspace setup as joining a workspace", async ({
 test("identity fallback text does not count as a real onboarding name", async ({
   page,
 }) => {
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
   await installMockBridge(page, undefined, { skipOnboardingSeed: true });
   await page.goto("/");
 
@@ -562,20 +553,17 @@ test("first-run onboarding keeps the shell hidden through setup and only marks H
   await expectHomeSeenCount(page, 2);
 });
 
-test("existing relay profile prefills the name step without localStorage completion", async ({
+test("existing relay profile with display name auto-skips onboarding without localStorage", async ({
   page,
 }) => {
+  // A user whose relay profile already has a display name should skip
+  // onboarding even without the localStorage completion flag.
   await seedActiveIdentity(page, TEST_IDENTITIES.alice);
   await installMockBridge(page, undefined, { skipOnboardingSeed: true });
   await page.goto("/");
 
-  await expect(page.getByTestId("onboarding-gate")).toBeVisible();
-  await expectShellHidden(page);
-  await expect(page.getByTestId("onboarding-display-name")).toHaveValue(
-    "alice",
-  );
-  await expect(page.getByTestId("onboarding-next")).toBeEnabled();
-  await expect(page.getByTestId("onboarding-back")).toHaveCount(0);
+  await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await expectHomeView(page);
 });
 
 test("onboarding can import an existing key when the workspace is already set up", async ({

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -230,7 +230,7 @@ test("welcome can continue using an existing Nostr key", async ({ page }) => {
 
   await page.getByTestId("welcome-continue-nostr").click();
   await expect(
-    page.getByRole("heading", { name: "Continue using Nostr" }),
+    page.getByRole("heading", { name: "Use your existing key" }),
   ).toBeVisible();
 
   const importedNsec = nsecEncode(hexToBytes(TEST_IDENTITIES.alice.privateKey));

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -683,38 +683,18 @@ test("failed first profile saves can be skipped for the current session", async 
   await expectHomeView(page);
 });
 
-test("failed saved profile saves can continue without retrying the display name", async ({
+test("existing relay profile with display name auto-completes onboarding", async ({
   page,
 }) => {
+  // A user whose relay profile already has a display name should skip
+  // onboarding entirely — they've already set up their identity previously
+  // (possibly on another machine or app data directory).
   await seedActiveIdentity(page, TEST_IDENTITIES.alice);
-  await installMockBridge(
-    page,
-    {
-      profileUpdateError: "Temporary profile sync failure.",
-    },
-    { skipOnboardingSeed: true },
-  );
+  await installMockBridge(page, undefined, { skipOnboardingSeed: true });
   await page.goto("/");
 
-  await expect(page.getByTestId("onboarding-display-name")).toHaveValue(
-    "alice",
-  );
-  await page.getByTestId("onboarding-display-name").fill("Alice Draft");
-  await page.getByTestId("onboarding-next").click();
-
-  await expect(page.getByText("Temporary profile sync failure.")).toBeVisible();
-  await page.getByTestId("onboarding-next-without-saving").click();
-
-  await expect(page.getByTestId("onboarding-page-avatar")).toBeVisible();
-  const avatarUrl = "https://example.com/alice-onboarding-avatar.png";
-  await page.getByTestId("onboarding-avatar-url").fill(avatarUrl);
-  await page.getByTestId("onboarding-next").click();
-
-  await expect(page.getByTestId("onboarding-page-theme")).toBeVisible();
-  await expect(await getMockProfile(page)).toMatchObject({
-    avatar_url: avatarUrl,
-    display_name: "alice",
-  });
+  await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await expectHomeView(page);
 });
 
 test("membership denial can import a different invited key", async ({

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -234,9 +234,9 @@ test("welcome can continue using an existing Nostr key", async ({ page }) => {
   ).toBeVisible();
 
   const importedNsec = nsecEncode(hexToBytes(TEST_IDENTITIES.alice.privateKey));
-  await page.getByTestId("welcome-nostr-nsec-input").fill(importedNsec);
-  await expect(page.getByTestId("welcome-nostr-npub-preview")).toBeVisible();
-  await page.getByTestId("welcome-nostr-submit").click();
+  await page.getByTestId("nostr-import-nsec-input").fill(importedNsec);
+  await expect(page.getByTestId("nostr-import-npub-preview")).toBeVisible();
+  await page.getByTestId("nostr-import-submit").click();
 
   await expect(page.getByTestId("onboarding-display-name")).toHaveValue(
     "alice",
@@ -576,6 +576,33 @@ test("existing relay profile prefills the name step without localStorage complet
   );
   await expect(page.getByTestId("onboarding-next")).toBeEnabled();
   await expect(page.getByTestId("onboarding-back")).toHaveCount(0);
+});
+
+test("onboarding can import an existing key when the workspace is already set up", async ({
+  page,
+}) => {
+  // Workspace exists (default seed), but this identity has no profile yet,
+  // so the app lands on the onboarding name step — Tyler's moved-laptop /
+  // fresh-dev-instance case.
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
+  await installMockBridge(page, undefined, { skipOnboardingSeed: true });
+  await page.goto("/");
+
+  await expect(page.getByTestId("onboarding-display-name")).toHaveValue("");
+  await page.getByTestId("onboarding-import-key").click();
+  await expect(
+    page.getByRole("heading", { name: "Use your existing key" }),
+  ).toBeVisible();
+
+  const importedNsec = nsecEncode(hexToBytes(TEST_IDENTITIES.alice.privateKey));
+  await page.getByTestId("nostr-import-nsec-input").fill(importedNsec);
+  await expect(page.getByTestId("nostr-import-npub-preview")).toBeVisible();
+  await page.getByTestId("nostr-import-submit").click();
+
+  // Identity swap remounts the flow; alice's relay profile prefills the name.
+  await expect(page.getByTestId("onboarding-display-name")).toHaveValue(
+    "alice",
+  );
 });
 
 test("finishing onboarding auto-joins the #general channel for a new member", async ({

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -599,10 +599,10 @@ test("onboarding can import an existing key when the workspace is already set up
   await expect(page.getByTestId("nostr-import-npub-preview")).toBeVisible();
   await page.getByTestId("nostr-import-submit").click();
 
-  // Identity swap remounts the flow; alice's relay profile prefills the name.
-  await expect(page.getByTestId("onboarding-display-name")).toHaveValue(
-    "alice",
-  );
+  // Identity swap remounts the flow; alice already has a relay profile with
+  // a display name, so onboarding auto-completes and lands in the app.
+  await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await expectHomeView(page);
 });
 
 test("finishing onboarding auto-joins the #general channel for a new member", async ({
@@ -723,6 +723,8 @@ test("membership denial can import a different invited key", async ({
   ).toBeVisible();
   await page.getByTestId("membership-denied-import-key").click();
 
+  // Alice already has a relay profile with a display name, so after the
+  // identity swap the onboarding gate auto-completes.
   await expect
     .poll(() =>
       page.evaluate(
@@ -732,7 +734,6 @@ test("membership denial can import a different invited key", async ({
       ),
     )
     .toEqual(expect.arrayContaining(["plugin:websocket|disconnect"]));
-  await expect(page.getByTestId("onboarding-page-1")).toBeVisible();
   await expect
     .poll(() =>
       page.evaluate((storageKey) => {
@@ -744,7 +745,6 @@ test("membership denial can import a different invited key", async ({
       }, E2E_IDENTITY_OVERRIDE_STORAGE_KEY),
     )
     .toBe(TEST_IDENTITIES.alice.pubkey);
-  await page.getByTestId("onboarding-next").click();
-
-  await expect(page.getByTestId("onboarding-page-avatar")).toBeVisible();
+  await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await expectHomeView(page);
 });

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -178,7 +178,10 @@ test("completed users skip the loading gate while profile is still settling", as
 test("first-run default workspace handoff gives immediate stepper feedback", async ({
   page,
 }) => {
-  await seedActiveIdentity(page, FIRST_RUN_KENNY);
+  // Use a blank-username identity so the profile has no display name and
+  // the auto-skip logic does not fire — we need to stay in onboarding to
+  // verify the stepper UX.
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
   await installMockBridge(
     page,
     {
@@ -212,7 +215,7 @@ test("first-run default workspace handoff gives immediate stepper feedback", asy
   );
 
   const nameInput = page.getByTestId("onboarding-display-name");
-  await expect(nameInput).toHaveValue("Kenny QA");
+  await expect(nameInput).toHaveValue("");
   await expect(page.getByRole("progressbar")).toHaveAttribute(
     "aria-valuenow",
     "2",


### PR DESCRIPTION
## Problem

When a user reclones the repo or gets a new app data directory (e.g. the Tauri bundle identifier changes during the Sprout → Buzz rename), the WebView's `localStorage` is empty. The onboarding gate checks `localStorage` for a completion flag — if it's missing, onboarding is shown even though:

1. The user's `identity.key` is already on disk (valid nsec)
2. The relay already has a kind:0 profile with their display name

This forces existing users through the full onboarding flow unnecessarily.

## Fix

In `useFirstRunOnboardingGate`, after the profile query settles, check if the relay returned a profile with a non-empty `displayName`. If so, the user has already completed onboarding previously — auto-mark it complete (persist to localStorage) and skip straight to the app.

This means:
- **New users** (no kind:0 on relay): still see full onboarding ✓
- **Existing users** (kind:0 exists with display name): skip onboarding ✓
- **Shared identity worktrees**: still fast-pathed as before ✓

## Also

- Renamed "Continue using Nostr" → "I have my own Nostr key" (clearer intent)
- Updated copy to reference Buzz instead of Sprout in the key import page