### PR TITLE
fix(release): sign version bump commits

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,7 +84,7 @@ Each release produces two GitHub releases:
 1. **`v<version>`** — the user-facing release with the `.dmg` installer
    (macOS).
 
-2. **`sprout-desktop-latest`** — a rolling pre-release for the Tauri
+2. **`buzz-desktop-latest`** — a rolling pre-release for the Tauri
    auto-updater containing `latest.json`, the signed `.tar.gz` archive,
    and its `.sig` signature.
 
@@ -108,7 +108,7 @@ the same `v<version>` release. Intel users download the `_x64.dmg`.
 
   | Secret | Purpose |
   |--------|---------|
-  | `SPROUT_UPDATER_PUBLIC_KEY` | Tauri updater public key (minisign) |
+  | `BUZZ_UPDATER_PUBLIC_KEY` | Tauri updater public key (minisign) |
   | `TAURI_SIGNING_PRIVATE_KEY` | Tauri updater private key |
   | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the private key |
 
@@ -129,7 +129,7 @@ Re-run `just release` from an up-to-date `main`. It resets the branch to current
 The version string must be valid semver: `MAJOR.MINOR.PATCH` with an optional pre-release suffix. Do not include a `v` prefix.
 
 ### Auto-updater reports "no update available"
-Verify that the `sprout-desktop-latest` release exists and contains a
+Verify that the `buzz-desktop-latest` release exists and contains a
 valid `latest.json`. The auto-updater manifest currently lists
 `darwin-aarch64` only, so Intel and Linux users do not yet receive
 auto-updates — they download new versions manually from the release

--- a/justfile
+++ b/justfile
@@ -534,9 +534,9 @@ release *ARGS:
       CHANGELOG.md
     RELEASE_MSG="chore(release): release version ${VERSION}"
     if [[ "$(git log -1 --format='%s' 2>/dev/null)" == "$RELEASE_MSG" ]]; then
-        git commit --amend --no-edit
+        git commit --amend --no-edit -s
     else
-        git commit -m "$RELEASE_MSG"
+        git commit -s -m "$RELEASE_MSG"
     fi
     # Push and open PR
     git push --force-with-lease -u origin "$BRANCH"


### PR DESCRIPTION
## Summary
- sign `just release` generated version-bump commits so release PRs satisfy DCO
- update release docs to reference `buzz-desktop-latest` and `BUZZ_UPDATER_PUBLIC_KEY`

## Verification
- `git diff --check`
- `just --summary`
- `rg -n "SPROUT_UPDATER|sprout-desktop-latest|git commit (--amend --no-edit$|-m \"\$RELEASE_MSG\")" justfile RELEASING.md .github/workflows/release.yml || true`
