### PR TITLE
docs: clean up remaining Buzz references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,9 @@ node_modules/
 .sqlx/
 
 # SQLite database (created by relay in CWD)
-sprout.db
-sprout.db-wal
-sprout.db-shm
+buzz.db
+buzz.db-wal
+buzz.db-shm
 
 # Docker volumes (if mounted locally)
 mysql-data/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -561,7 +561,7 @@ Kind 5 (deletion) is intentionally blocked inbound — the relay's deletion hand
 | KIND_REACTION | 7 | Reaction |
 | KIND_DELETION | 5 | Standard NIP-09 deletion |
 
-`to_sprout(to_standard(k))` is NOT lossless for secondary mappings (e.g., kind:1 → KIND_STREAM_MESSAGE → kind:42). Translation invalidates Schnorr signatures (event ID includes kind) — proxy re-signs events with shadow keys.
+`to_buzz(to_standard(k))` is NOT lossless for secondary mappings (e.g., kind:1 → KIND_STREAM_MESSAGE → kind:42). Translation invalidates Schnorr signatures (event ID includes kind) — proxy re-signs events with shadow keys.
 
 **Dual auth:** Pubkey-based guest registration (persistent, primary) + invite tokens (ad-hoc, time-limited, secondary). Both use NIP-42 for the authentication handshake. The `proxy:submit` scope on the proxy's API token bypasses the relay's pubkey enforcement for shadow-signed events.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**conduct@sprout-relay.org**.
+**conduct@buzz-relay.org**.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -445,4 +445,4 @@ their sign-off. When in doubt, check with your legal team.
 ---
 
 *Thank you for contributing to Buzz. Every bug report, documentation fix,
-and code contribution makes the project better for everyone. 🌱*
+and code contribution makes the project better for everyone. 🐝*

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,7 +84,7 @@ Each release produces two GitHub releases:
 1. **`v<version>`** — the user-facing release with the `.dmg` installer
    (macOS).
 
-2. **`sprout-desktop-latest`** — a rolling pre-release for the Tauri
+2. **`buzz-desktop-latest`** — a rolling pre-release for the Tauri
    auto-updater containing `latest.json`, the signed `.tar.gz` archive,
    and its `.sig` signature.
 
@@ -108,7 +108,7 @@ the same `v<version>` release. Intel users download the `_x64.dmg`.
 
   | Secret | Purpose |
   |--------|---------|
-  | `SPROUT_UPDATER_PUBLIC_KEY` | Tauri updater public key (minisign) |
+  | `BUZZ_UPDATER_PUBLIC_KEY` | Tauri updater public key (minisign) |
   | `TAURI_SIGNING_PRIVATE_KEY` | Tauri updater private key |
   | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the private key |
 
@@ -129,7 +129,7 @@ Re-run `just release` from an up-to-date `main`. It resets the branch to current
 The version string must be valid semver: `MAJOR.MINOR.PATCH` with an optional pre-release suffix. Do not include a `v` prefix.
 
 ### Auto-updater reports "no update available"
-Verify that the `sprout-desktop-latest` release exists and contains a
+Verify that the `buzz-desktop-latest` release exists and contains a
 valid `latest.json`. The auto-updater manifest currently lists
 `darwin-aarch64` only, so Intel and Linux users do not yet receive
 auto-updates — they download new versions manually from the release

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 **Please do not report security vulnerabilities through public GitHub issues.**
 
 If you discover a security vulnerability in Buzz, please report it by emailing
-**security@sprout-relay.org**. Include as much detail as possible:
+**security@buzz-relay.org**. Include as much detail as possible:
 
 - A description of the vulnerability and its potential impact
 - Steps to reproduce or a proof-of-concept (if available)

--- a/TESTING.md
+++ b/TESTING.md
@@ -264,7 +264,7 @@ out of the box with `just setup` or `just relay`. Common overrides:
 | `BUZZ_BIND_ADDR`                | `0.0.0.0:3000`              | Main app port |
 | `BUZZ_HEALTH_PORT`              | `8080`                      | `/_liveness`, `/_readiness` |
 | `BUZZ_METRICS_PORT`             | `9102`                      | Prometheus `/metrics` |
-| `RELAY_URL`                       | `ws://localhost:3000`       | Advertised in NIP-11 / NIP-42 challenges. **Note: no `SPROUT_` prefix.** |
+| `RELAY_URL`                       | `ws://localhost:3000`       | Advertised in NIP-11 / NIP-42 challenges. **Note: no `BUZZ_` prefix.** |
 | `DATABASE_URL`                    | `postgres://buzz:buzz_dev@localhost:5432/buzz` | |
 | `REDIS_URL`                       | `redis://localhost:6379`    | |
 | `TYPESENSE_URL`                   | `http://localhost:8108`     | |

--- a/VISION.md
+++ b/VISION.md
@@ -1,12 +1,12 @@
-# 🌱 Sprout — The relay is the workspace
+# 🐝 Buzz — The relay is the workspace
 
 > An engineer is debugging a production incident at 2am. They type in the incident channel: "What happened last time we saw this error?"
 >
 > An agent watching the channel searches six months of incident history and posts the threads, root causes, and fixes — then offers to page the engineer who deployed the last one.
 
-The platform made it possible. The agent made it happen. Sprout is the pipe — event store, search index, subscriptions, delivery — not the brain. Humans and agents bring the intelligence. Sprout gives them a shared space to use it.
+The platform made it possible. The agent made it happen. Buzz is the pipe — event store, search index, subscriptions, delivery — not the brain. Humans and agents bring the intelligence. Buzz gives them a shared space to use it.
 
-One relay is your entire workspace. Work, conversation, agents, automation, artifacts, docs — one domain, one identity system, one search index. `myproject.com` in a browser shows your repos. `git clone repoa.myproject.com` works. Open the Sprout app and you're in the channels where the work happens. No GitHub. No Discord. No stitching five services together. The project lives in one place, and that place is yours. See [VISION_SOVEREIGN.md](VISION_SOVEREIGN.md) for the full picture.
+One relay is your entire workspace. Work, conversation, agents, automation, artifacts, docs — one domain, one identity system, one search index. `myproject.com` in a browser shows your repos. `git clone repoa.myproject.com` works. Open the Buzz app and you're in the channels where the work happens. No GitHub. No Discord. No stitching five services together. The project lives in one place, and that place is yours. See [VISION_SOVEREIGN.md](VISION_SOVEREIGN.md) for the full picture.
 
 ---
 
@@ -43,7 +43,7 @@ The relay enforces all access control. Channel membership is the only gate.
 | **DMs** | Participants only | N/A (up to 9) | Any member |
 | **Guests** | Scoped to specific channels | Invited | N/A |
 
-Guests (investors, reporters, partners) get a scoped token with membership in specific channels. Same access model as everyone else. Guests can connect with their own Nostr client (Coracle, nak, Amethyst) through [`sprout-proxy`](NOSTR.md), which translates standard NIP-28 events to Sprout's internal protocol. Two auth paths: pubkey-based guest registration (persistent) or invite tokens (ad-hoc, time-limited).
+Guests (investors, reporters, partners) get a scoped token with membership in specific channels. Same access model as everyone else. Guests can connect with their own Nostr client (Coracle, nak, Amethyst) through [`buzz-proxy`](NOSTR.md), which translates standard NIP-28 events to Buzz's internal protocol. Two auth paths: pubkey-based guest registration (persistent) or invite tokens (ad-hoc, time-limited).
 
 ---
 
@@ -60,7 +60,7 @@ content   JSON payload
 sig       Schnorr signature
 ```
 
-Sprout extends the standard Nostr event format with custom kind numbers for enterprise features.
+Buzz extends the standard Nostr event format with custom kind numbers for enterprise features.
 
 New message type? New kind integer. Zero breaking changes.
 
@@ -93,7 +93,7 @@ One model. TLS in transit. At-rest encryption delegated to the storage layer (e.
 
 ## Huddles
 
-Real-time voice runs over a WebSocket Opus relay built into `sprout-relay`. Sprout authenticates participants (NIP-42), admits them to a room, and forwards Opus frames between peers — no external SFU.
+Real-time voice runs over a WebSocket Opus relay built into `buzz-relay`. Buzz authenticates participants (NIP-42), admits them to a room, and forwards Opus frames between peers — no external SFU.
 
 - Agents join the same audio relay as humans — they bring their own STT/TTS
 - Huddle lifecycle flows as Nostr events: started, joined, left, ended
@@ -102,7 +102,7 @@ Voice, room lifecycle, and lifecycle events are wired. Recording and per-track p
 
 ---
 
-## Sprout Mesh
+## Buzz Mesh
 
 Relay communities can pool opted-in member hardware into shared AI compute. Existing agents see it as a local OpenAI-compatible provider; the relay gates discovery and trust with the same membership model it already uses for messages, code, and workflows. Models too large for any single machine split across several. See [VISION_MESH.md](VISION_MESH.md) for the full compute-commons vision.
 
@@ -139,7 +139,7 @@ Beyond chat: channels are workspaces.
 
 The relay hosts git repos. Smart HTTP — standard `git clone`, `git push`, nothing special. Your npub signs pushes. Same domain, same auth, same identity as everything else on the relay.
 
-Branches are channels. Create a feature branch, Sprout creates a channel — CI results, review comments, and the merge decision all live there. When the branch merges, the channel archives into a permanent record of why that code exists.
+Branches are channels. Create a feature branch, Buzz creates a channel — CI results, review comments, and the merge decision all live there. When the branch merges, the channel archives into a permanent record of why that code exists.
 
 See [VISION_PROJECTS.md](VISION_PROJECTS.md) for the full forge vision: the project model, the merge flow, branch protections, and how agents participate as contributors.
 
@@ -147,7 +147,7 @@ See [VISION_PROJECTS.md](VISION_PROJECTS.md) for the full forge vision: the proj
 
 ## Agent CLI
 
-`sprout-cli` is an agent-first CLI that mirrors and extends the MCP surface — same primitives, plus repo, upload, and canvas operations where the CLI is the canonical interface. JSON-only stdout, structured errors on stderr, two-tier auth (NIP-98 keypair → dev pubkey). Agents can script the entire platform without a GUI.
+`buzz-cli` is an agent-first CLI that mirrors and extends the MCP surface — same primitives, plus repo, upload, and canvas operations where the CLI is the canonical interface. JSON-only stdout, structured errors on stderr, two-tier auth (NIP-98 keypair → dev pubkey). Agents can script the entire platform without a GUI.
 
 ---
 
@@ -190,7 +190,7 @@ Not afterthoughts — ship blockers:
 
 ## Build Model
 
-Greenfield. Agent swarms build in parallel, integrating at the event store boundary. Sprout is being built with AI-assisted development — agents write code, crossfire reviews across multiple models catch blind spots before merge. A complete platform, not a collection of independent microservices.
+Greenfield. Agent swarms build in parallel, integrating at the event store boundary. Buzz is being built with AI-assisted development — agents write code, crossfire reviews across multiple models catch blind spots before merge. A complete platform, not a collection of independent microservices.
 
 ---
 
@@ -205,12 +205,12 @@ Greenfield. Agent swarms build in parallel, integrating at the event store bound
 | ✅ | Channel features — messaging, threads, reactions, canvases, media uploads, editing, deletion, typing indicators, NIP-29, soft-delete |
 | ✅ | Workflow engine — YAML-as-code, execution traces, message/reaction/schedule/webhook triggers |
 | ✅ | Identity — NIP-05, public profiles, NIP-98 auth, agent protection |
-| ✅ | NIP-28 proxy — third-party Nostr clients (Coracle, nak, Amethyst) via `sprout-proxy` |
-| ✅ | Agent CLI — `sprout-cli`, mirrors and extends the MCP surface |
+| ✅ | NIP-28 proxy — third-party Nostr clients (Coracle, nak, Amethyst) via `buzz-proxy` |
+| ✅ | Agent CLI — `buzz-cli`, mirrors and extends the MCP surface |
 | ✅ | Agent personas and teams — desktop-managed, built-in defaults, operator-defined |
 | 🚧 | Workflow approval gates — infrastructure exists (DB, API, UI); executor doesn't persist/resume (WF-08) |
 | ✅ | Huddles — WebSocket Opus voice relay + lifecycle events (recording/tracks planned) |
-| ✅ | Sprout Mesh — relay-gated shared AI compute (mesh-llm over iroh); members pool GPUs, agents consume via a local OpenAI-compatible endpoint |
+| ✅ | Buzz Mesh — relay-gated shared AI compute (mesh-llm over iroh); members pool GPUs, agents consume via a local OpenAI-compatible endpoint |
 | 🚧 | Mobile client — Flutter app (channels, forum, search, profile, pairing); in active development |
 | 📋 | Developer portal, push notifications, culture features |
 
@@ -222,4 +222,4 @@ See [README.md](README.md) for setup and [AGENTS.md](AGENTS.md) for connecting A
 
 ---
 
-*Sprout 🌱 — where humans and agents are just colleagues.*
+*Buzz 🐝 — where humans and agents are just colleagues.*

--- a/VISION_AGENT.md
+++ b/VISION_AGENT.md
@@ -1,4 +1,4 @@
-# Vision: sprout-agent + sprout-dev-mcp
+# Vision: buzz-agent + buzz-dev-mcp
 
 ## The Problem
 
@@ -10,9 +10,9 @@ We wanted something we could read in an afternoon and audit with confidence.
 
 Two binaries, two protocols, no coupling between them.
 
-**sprout-agent** is an ACP agent. It speaks the Agent Client Protocol over stdio, calls an LLM, and uses MCP tools. Multiple concurrent sessions, each with its own MCP servers, history, and context. When context fills up, a session summarizes its own history and continues. It works with Zed, JetBrains, sprout-acp, or anything else that speaks ACP.
+**buzz-agent** is an ACP agent. It speaks the Agent Client Protocol over stdio, calls an LLM, and uses MCP tools. Multiple concurrent sessions, each with its own MCP servers, history, and context. When context fills up, a session summarizes its own history and continues. It works with Zed, JetBrains, buzz-acp, or anything else that speaks ACP.
 
-**sprout-dev-mcp** is an MCP server. It gives any agent a shell and a file editor. Ephemeral processes with process-group kill on every exit path. Bounded output. File edits resolve against the working directory. It works with any agent or client that speaks MCP.
+**buzz-dev-mcp** is an MCP server. It gives any agent a shell and a file editor. Ephemeral processes with process-group kill on every exit path. Bounded output. File edits resolve against the working directory. It works with any agent or client that speaks MCP.
 
 Together: two crates of Rust purpose-built for headless autonomous coding work.
 
@@ -22,20 +22,20 @@ Together: two crates of Rust purpose-built for headless autonomous coding work.
 
 **Correctness at the boundary.** ACP compliance is not a checkbox. We report a concrete protocol version. We emit every required notification. We handle cancellation on every path. We kill process trees on timeout. Key safety properties have regression tests that lock them down.
 
-**Composability through standards.** The agent does not know what MCP server it talks to. The MCP server does not know what agent is calling it. They compose through protocols, not imports. Run ten agents behind sprout with different MCP configurations. Swap the LLM provider with one environment variable. Point Zed at sprout-agent and you get the same tool-calling behavior in your editor.
+**Composability through standards.** The agent does not know what MCP server it talks to. The MCP server does not know what agent is calling it. They compose through protocols, not imports. Run ten agents behind Buzz with different MCP configurations. Swap the LLM provider with one environment variable. Point Zed at buzz-agent and you get the same tool-calling behavior in your editor.
 
 ## The Architecture
 
 ```
-Any ACP client (Zed, JetBrains, sprout-acp, custom)
+Any ACP client (Zed, JetBrains, buzz-acp, custom)
         |
         | stdio ACP (JSON-RPC 2.0)
         v
-  sprout-agent (up to 8 concurrent sessions)
+  buzz-agent (up to 8 concurrent sessions)
         |
         | stdio MCP (JSON-RPC 2.0) — one per session
         v
-  sprout-dev-mcp (or any MCP server)
+  buzz-dev-mcp (or any MCP server)
         |
         v
   shell, str_replace, todo; rg + tree on PATH
@@ -56,7 +56,7 @@ Two pipes. Two protocols. Each session gets its own MCP server instances — ful
 ## What This Enables
 
 - Multiple concurrent sessions in one process — each with independent MCP servers, history, and context (configurable cap, default 8)
-- Ten agents in parallel behind sprout, each with their own MCP configuration
+- Ten agents in parallel behind Buzz, each with their own MCP configuration
 - Any ACP client gets a coding agent without a custom adapter
 - Any MCP server gets a capable caller without a custom adapter
 - A codebase small enough to fork, modify, and understand in a day — two crates, no coupling between them

--- a/VISION_MESH.md
+++ b/VISION_MESH.md
@@ -1,10 +1,10 @@
-# 🕸️ Sprout Mesh — Your community is your compute
+# 🕸️ Buzz Mesh — Your community is your compute
 
-> A small team runs their project on one Sprout relay. Three of them have GPUs that sit idle most of the day — a gaming PC, a laptop, a workstation under a desk. One flips a toggle: *Share compute.* The others point their agents at it. Now the whole team's coding agents answer from a capable model running on hardware they already own. No API keys. No cloud bill. Every prompt runs inside the relay community they already chose to trust.
+> A small team runs their project on one Buzz relay. Three of them have GPUs that sit idle most of the day — a gaming PC, a laptop, a workstation under a desk. One flips a toggle: *Share compute.* The others point their agents at it. Now the whole team's coding agents answer from a capable model running on hardware they already own. No API keys. No cloud bill. Every prompt runs inside the relay community they already chose to trust.
 
-A Sprout relay is a trust group. The people in it already know each other — that shared membership is a decision they've already made. Sprout Mesh turns that decision into shared AI compute: the idle GPUs scattered across your community become one pool, usable by every agent on the relay, gated by the membership you already have. And because the pool is many machines, not one, the community can run models larger and more capable than any one member could load alone. More intelligence becomes reachable when the group works as a group.
+A Buzz relay is a trust group. The people in it already know each other — that shared membership is a decision they've already made. Buzz Mesh turns that decision into shared AI compute: the idle GPUs scattered across your community become one pool, usable by every agent on the relay, gated by the membership you already have. And because the pool is many machines, not one, the community can run models larger and more capable than any one member could load alone. More intelligence becomes reachable when the group works as a group.
 
-Nothing here is new on its own. Pooling GPUs across machines is solved. Nostr identity is solved. Relay-gated membership is how Sprout already works. The insight is that the tool that pools the GPUs already speaks the same protocol Sprout is built on — so the mesh's admission gate and your relay's membership gate are the same gate.
+Nothing here is new on its own. Pooling GPUs across machines is solved. Nostr identity is solved. Relay-gated membership is how Buzz already works. The insight is that the tool that pools the GPUs already speaks the same protocol Buzz is built on — so the mesh's admission gate and your relay's membership gate are the same gate.
 
 Each piece is boring. The combination is the thing.
 
@@ -12,11 +12,11 @@ Each piece is boring. The combination is the thing.
 
 ## What You See
 
-You open Sprout and flip on **Share compute.** Your machine loads a model your GPU can hold and starts answering requests from other members of your relay. A consent panel is honest about the deal: prompts from other members run on your hardware, and what you're serving is visible to the people you share the relay with.
+You open Buzz and flip on **Share compute.** Your machine loads a model your GPU can hold and starts answering requests from other members of your relay. A consent panel is honest about the deal: prompts from other members run on your hardware, and what you're serving is visible to the people you share the relay with.
 
 On another machine, you point an agent at the mesh and pick from whatever models your community is serving. The agent talks to a normal local AI endpoint; the work routes to whoever's hosting that model — the workstation down the hall, or a teammate three timezones away. The agent neither knows nor cares which.
 
-When an agent needs a model, Sprout helps it find a member machine already serving one: the relay coordinates the trust, the machines do the work, and the request runs directly between them — the relay never sees a token of it.
+When an agent needs a model, Buzz helps it find a member machine already serving one: the relay coordinates the trust, the machines do the work, and the request runs directly between them — the relay never sees a token of it.
 
 And when a model is too large for any single machine, the mesh can split it across several, each holding a slice. A model no one's laptop could run alone runs because the community ran it together.
 
@@ -44,10 +44,10 @@ These are honest costs. They're worth it if you want capable AI for your communi
 
 ## The Point
 
-The relay is the workspace. Sprout Mesh makes it the compute commons too.
+The relay is the workspace. Buzz Mesh makes it the compute commons too.
 
 Your community is not just where agents talk, plan, and leave records. It is where they can run.
 
 ---
 
-*Sprout 🕸️ — your community is your compute.*
+*Buzz 🐝 — your community is your compute.*

--- a/VISION_PROJECTS.md
+++ b/VISION_PROJECTS.md
@@ -1,10 +1,10 @@
-# 🌿 Sprout Projects — A Nostr-Native Forge
+# 🐝 Buzz Projects — A Nostr-Native Forge
 
-> Someone pushes a fix. Sprout creates a channel for the branch. The CI agent picks up the push, runs the tests, posts results back to the channel. A co-maintainer reviews the diff inline, approves it — a signed event, cryptographic proof. Merge. The workflow runs the integration. The channel archives into a permanent record of why that code exists.
+> Someone pushes a fix. Buzz creates a channel for the branch. The CI agent picks up the push, runs the tests, posts results back to the channel. A co-maintainer reviews the diff inline, approves it — a signed event, cryptographic proof. Merge. The workflow runs the integration. The channel archives into a permanent record of why that code exists.
 >
 > Bug report to merged patch. One place. One search index. One identity system. The branch channel was the pull request, the CI dashboard, and the discussion thread.
 
-This document is the software-forge slice of the broader Sprout platform. [VISION.md](VISION.md) covers the platform. [VISION_SOVEREIGN.md](VISION_SOVEREIGN.md) covers the sovereign relay story — one domain, one relay, one project. This doc zooms in on what it looks like when that relay hosts code.
+This document is the software-forge slice of the broader Buzz platform. [VISION.md](VISION.md) covers the platform. [VISION_SOVEREIGN.md](VISION_SOVEREIGN.md) covers the sovereign relay story — one domain, one relay, one project. This doc zooms in on what it looks like when that relay hosts code.
 
 ---
 
@@ -14,31 +14,31 @@ A project lives on the relay. `myproject.com` in a browser shows the project hom
 
 Git transport is standard Smart HTTP — `git clone`, `git push`, nothing special. Your npub signs pushes. Same domain, same auth, same identity as everything else on the relay.
 
-The portable representation is a NIP-34 repo announcement (kind:30617) — standard metadata that any NIP-34 client can discover and render. Sprout extends it with `sprout-` prefixed tags for channel binding and visibility:
+The portable representation is a NIP-34 repo announcement (kind:30617) — standard metadata that any NIP-34 client can discover and render. Buzz extends it with `buzz-` prefixed tags for channel binding and visibility:
 
 ```json
 {
   "kind": 30617,
   "tags": [
-    ["d", "sprout"],
-    ["name", "sprout"],
+    ["d", "buzz"],
+    ["name", "buzz"],
     ["clone", "https://repoa.myproject.com"],
     ["relays", "wss://myproject.com"],
     ["maintainers", "<co-maintainer-npub>"],
-    ["sprout-channel", "<channel-uuid>"],
-    ["sprout-visibility", "listed"],
-    ["sprout-protect", "main", "push-allowed", "<alice-npub>", "<bob-npub>"],
-    ["sprout-protect", "main", "require-approval", "2"],
-    ["sprout-protect", "main", "no-force-push"]
+    ["buzz-channel", "<channel-uuid>"],
+    ["buzz-visibility", "listed"],
+    ["buzz-protect", "main", "push-allowed", "<alice-npub>", "<bob-npub>"],
+    ["buzz-protect", "main", "require-approval", "2"],
+    ["buzz-protect", "main", "no-force-push"]
   ]
 }
 ```
 
-Branch protections live in the same event — `sprout-protect` tags. The relay enforces them at the git transport layer. Only npubs listed in `push-allowed` can push to protected branches. Force pushes are blocked. Merges require the specified number of signed approval events (kind:46011) before the relay accepts the push.
+Branch protections live in the same event — `buzz-protect` tags. The relay enforces them at the git transport layer. Only npubs listed in `push-allowed` can push to protected branches. Force pushes are blocked. Merges require the specified number of signed approval events (kind:46011) before the relay accepts the push.
 
 Agents inherit access from their owner via [NIP-OA](docs/nips/NIP-OA.md). The relay checks: does the push carry a valid NIP-OA auth tag, and is the owner pubkey in that tag listed in `push-allowed`? If yes, the push is accepted — the agent's own pubkey doesn't need to be in the list. Add a maintainer, and all their authorized agents can push. Remove the maintainer, and all their agents lose access instantly. Agents without NIP-OA attestation are treated as their own identity and must be listed explicitly.
 
-Standard NIP-34 clients see a normal repo. gitworkshop.dev renders it. ngit-cli works with it. Sprout clients read the `sprout-` tags and wire up the channel and project UI. One event, two audiences, zero custom kinds.
+Standard NIP-34 clients see a normal repo. gitworkshop.dev renders it. ngit-cli works with it. Buzz clients read the `buzz-` tags and wire up the channel and project UI. One event, two audiences, zero custom kinds.
 
 NIP-34 is the metadata and discovery layer. Git remains the transport. The transport is boring. The metadata is portable.
 
@@ -48,7 +48,7 @@ NIP-34 is the metadata and discovery layer. Git remains the transport. The trans
 
 A feature branch is a conversation.
 
-When you create a branch, Sprout creates a channel. The branch's patches, review comments, CI results, and merge decision all live in that channel. When the branch merges, the channel archives. The conversation becomes the permanent record of why that code exists.
+When you create a branch, Buzz creates a channel. The branch's patches, review comments, CI results, and merge decision all live in that channel. When the branch merges, the channel archives. The conversation becomes the permanent record of why that code exists.
 
 ```
 #feat-auth-fix
@@ -125,7 +125,7 @@ Workflows orchestrate. Agents perform the compute. The relay is the message bus,
 
 A push to a branch channel triggers the CI workflow. The workflow engine coordinates the steps — build, test, lint. Agents run the actual jobs on their own infrastructure: your server, a cloud function, a laptop. Results post back to the branch channel alongside the conversation.
 
-Workflows live in the repo (`.sprout/workflows/`) or are defined at the project level and inherited by every branch channel automatically — no per-branch configuration, no copy-pasting YAML.
+Workflows live in the repo (`.buzz/workflows/`) or are defined at the project level and inherited by every branch channel automatically — no per-branch configuration, no copy-pasting YAML.
 
 ```yaml
 name: CI
@@ -154,9 +154,9 @@ Every step traced. Every trace a signed event. Change the project CI once and ev
 
 ### Issues → Forum + NIP-34
 
-Bug reports are NIP-34 kind:1621 events, rendered through Sprout's forum surface. Threaded comments use NIP-22 kind:1111. Labels, assignees, milestones are nostr tags. Design discussions and RFCs use the forum's long-form async surface.
+Bug reports are NIP-34 kind:1621 events, rendered through Buzz's forum surface. Threaded comments use NIP-22 kind:1111. Labels, assignees, milestones are nostr tags. Design discussions and RFCs use the forum's long-form async surface.
 
-NIP-34 clients can discover and interact with issues. Sprout's forum gives them a home with threading, search, and agent triage.
+NIP-34 clients can discover and interact with issues. Buzz's forum gives them a home with threading, search, and agent triage.
 
 ### Docs → Canvases
 
@@ -175,7 +175,7 @@ Agents are project members with npubs, contribution histories, and reputations. 
 | | Human | Agent |
 |---|---|---|
 | Identity | secp256k1 keypair | secp256k1 keypair |
-| Handle | `alice@sprout.dev` | `triage-bot@sprout.dev` |
+| Handle | `alice@buzz.dev` | `triage-bot@buzz.dev` |
 | Events | Signed with npub | Signed with npub |
 | History | On the relay | On the relay |
 | Reputation | Earned by contributions | Earned by contributions |
@@ -194,7 +194,7 @@ Agents are project members with npubs, contribution histories, and reputations. 
 
 Standard kinds as substrate. Custom kinds only where genuinely novel.
 
-| Layer | Standard NIP Kinds | Sprout Custom | Rationale |
+| Layer | Standard NIP Kinds | Buzz Custom | Rationale |
 |-------|-------------------|---------------|-----------|
 | **Git state** | 30617, 30618, 1617, 1618, 1621, 1630-1633 (NIP-34) | — | Interop with ngit, gitworkshop.dev |
 | **Comments** | 1111 (NIP-22) | — | Threaded replies everywhere |
@@ -204,10 +204,10 @@ Standard kinds as substrate. Custom kinds only where genuinely novel.
 | **Artifacts** | 1063 (NIP-94) | — | Build outputs on Blossom/S3 |
 | **Workflows** | — | 46001-46012 | No NIP equivalent |
 | **Job dispatch** | — | 43001-43006 | Delegation trees |
-| **Project binding** | 30617 (NIP-34) | `sprout-` tags | Channel, visibility |
+| **Project binding** | 30617 (NIP-34) | `buzz-` tags | Channel, visibility |
 | **Audit** | — | 48001 | Hash-chain tamper-evident log |
 
-If Sprout disappears tomorrow, your repos still work on gitworkshop.dev, your patches still work with ngit-cli, your identities still work on any nostr client. Centralized deployment, decentralized protocol.
+If Buzz disappears tomorrow, your repos still work on gitworkshop.dev, your patches still work with ngit-cli, your identities still work on any nostr client. Centralized deployment, decentralized protocol.
 
 ---
 
@@ -220,7 +220,7 @@ If Sprout disappears tomorrow, your repos still work on gitworkshop.dev, your pa
 | MCP server + ACP agent harness | ✅ Ships today |
 | Blossom media storage (SHA-256, S3) | ✅ Ships today |
 | Approval gates | 🚧 Infrastructure exists; executor wiring in progress |
-| Project binding (kind:30617 + `sprout-` tags) | 📋 Designed |
+| Project binding (kind:30617 + `buzz-` tags) | 📋 Designed |
 | Git hosting (smart HTTP + NIP-34) | ✅ Ships today |
 | Merge coordinator | 📋 Designed |
 | NIP-34 issues (kind:1621) | 📋 Designed |
@@ -230,4 +230,4 @@ The collaboration platform is built, and git hosting ships today — `git clone`
 
 ---
 
-*Sprout 🌿 — the forge where identity is the foundation.*
+*Buzz 🐝 — the forge where identity is the foundation.*

--- a/VISION_SOVEREIGN.md
+++ b/VISION_SOVEREIGN.md
@@ -1,4 +1,4 @@
-# Sprout — Your Project, Your Domain
+# Buzz — Your Project, Your Domain
 
 `myproject.com` is your workspace. Not a GitHub org page that happens to have your
 name on it. Not a Discord server that Discord could delete tomorrow. Your domain.
@@ -31,7 +31,7 @@ and the code is syntax-highlighted. The clone URL sits at the top:
 git clone repoa.myproject.com
 ```
 
-Next to it, a "Connect on Sprout" button.
+Next to it, a "Connect on Buzz" button.
 
 No separate website. No static site generator, no deploy step, no "pages" concept.
 The relay serves rendered HTML to browsers and responds to `git clone` at the same
@@ -41,7 +41,7 @@ A browser gets a rendered page. A git client gets a git server. Same URL.
 You clone it. It works. No special tooling. No new protocol. Git is git. You push
 the same way. Agents clone and push the same way. The repos are repos.
 
-You hit "Connect on Sprout" and the app opens. You're in `#general`. The team is
+You hit "Connect on Buzz" and the app opens. You're in `#general`. The team is
 talking. There's a forum with open issues and design discussions. There's a canvas
 with the architecture doc — updated last week by the docs agent after a refactor
 landed. Three feature branches are active, each one a channel. You're in.
@@ -50,15 +50,15 @@ Everything is here.
 A new contributor finds the project the same way. They browse the code, read the
 README, click into the forum and see the open issues. They read a design doc in the
 canvas. They understand the project before they write a line of code. Then they hit
-"Connect on Sprout" and they're in the community. No separate onboarding flow. No
+"Connect on Buzz" and they're in the community. No separate onboarding flow. No
 "read our wiki at wiki.myproject.com and our forum at forum.myproject.com and our
 chat at discord.gg/..." Everything is at `myproject.com`. That's where everything
 is.
 
 Not every project needs to run its own relay. Most people will just join one that
 someone else runs — the way most people use GitHub instead of running Gitea. And
-you can use Sprout as a collaboration layer on top of GitHub if that's what makes
-sense — work in Sprout channels, push releases to your public repo. The sovereign
+you can use Buzz as a collaboration layer on top of GitHub if that's what makes
+sense — work in Buzz channels, push releases to your public repo. The sovereign
 setup is the full version. But the tools work at every level of commitment.
 
 ---
@@ -72,7 +72,7 @@ a response in seconds. The maintainer sees a pre-processed report, not a raw inb
 They read the triage summary, confirm it's real, assign it. Thirty seconds of their
 time instead of five minutes.
 
-Someone picks up the bug. They create a branch. Sprout creates a channel:
+Someone picks up the bug. They create a branch. Buzz creates a channel:
 `#feat-auth-fix`. They work there. They push commits. The CI agent picks up the
 work — it's watching for pushes, it's just a member with compute — runs the tests,
 posts results back to the channel. Green. The patch lands in the channel as a
@@ -121,7 +121,7 @@ inherits it automatically — no per-branch configuration, no copy-pasting YAML.
 ## The Social Layer
 
 Not everything belongs in the repo. Not everything belongs in a channel. Some
-things are announcements. Some things are essays. Sprout has surfaces for both,
+things are announcements. Some things are essays. Buzz has surfaces for both,
 and they live on the same relay as the code.
 
 Short notes — project announcements, "we just shipped X," the kind of thing you'd
@@ -217,7 +217,7 @@ decade of polish. Some things will feel rough. Some integrations won't exist yet
 You're early, and early means occasionally hitting edges that haven't been smoothed.
 
 Your contributors are early too. Most developers don't have a nostr keypair.
-Onboarding friction is real — not insurmountable, but real. The "Connect on Sprout"
+Onboarding friction is real — not insurmountable, but real. The "Connect on Buzz"
 button is easy. Explaining what a keypair is takes a sentence. But it's a sentence
 you'll have to write, and some contributors won't bother. You'll lose some people
 at the door who would have clicked "sign in with GitHub" without thinking. That's

--- a/crates/buzz-persona/tests/integration.rs
+++ b/crates/buzz-persona/tests/integration.rs
@@ -60,7 +60,7 @@ fn create_test_pack(dir: &Path) {
         agents_dir.join("pip.persona.md"),
         r##"---
 name: "pip"
-display_name: "Pip 🌱"
+display_name: "Pip 🐝"
 description: "Orchestration agent"
 model: "anthropic:claude-4-opus-20250514"
 subscribe:
@@ -154,7 +154,7 @@ fn full_pipeline_load_and_validate() {
         .expect("lep persona should be loaded");
 
     // 5. Check pip's overrides.
-    assert_eq!(pip.display_name, "Pip 🌱");
+    assert_eq!(pip.display_name, "Pip 🐝");
     assert_eq!(
         pip.model.as_deref(),
         Some("anthropic:claude-4-opus-20250514"),
@@ -422,7 +422,7 @@ fn resolve_full_pipeline() {
         .expect("lep should be resolved");
 
     // Identity
-    assert_eq!(pip.display_name, "Pip 🌱");
+    assert_eq!(pip.display_name, "Pip 🐝");
     assert_eq!(pip.description, "Orchestration agent");
     assert_eq!(pip.version, "1.0.0"); // defaults to pack version
 
@@ -573,7 +573,7 @@ fn resolve_persona_by_name_found() {
 
     let pip = resolve::resolve_persona_by_name(dir.path(), "pip").unwrap();
     assert_eq!(pip.name, "pip");
-    assert_eq!(pip.display_name, "Pip 🌱");
+    assert_eq!(pip.display_name, "Pip 🐝");
 }
 
 /// resolve_persona_by_name returns error for nonexistent name.

--- a/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
@@ -72,7 +72,7 @@ export function SidebarProfileCard({
   const readonlyWorkspaceLabel = (
     <span className="flex min-w-0 cursor-pointer items-center gap-1 text-xs leading-snug text-sidebar-foreground/70">
       <span aria-hidden="true" className="shrink-0 text-[10px] leading-none">
-        🌱
+        🐝
       </span>
       <span className="truncate">{workspaceLabel}</span>
     </span>

--- a/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
+++ b/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
@@ -136,7 +136,7 @@ export function WorkspaceSwitcher({
               : "flex h-5 w-5 shrink-0 items-center justify-center text-xs leading-none"
           }
         >
-          🌱
+          🐝
         </span>
       )}
       <span

--- a/scripts/e2e-git-perms.sh
+++ b/scripts/e2e-git-perms.sh
@@ -456,7 +456,7 @@ cat > "$BOT1_DIR/index.html" << 'HTML'
     </style>
 </head>
 <body>
-    <h1>🌱 Buzz Collaborative Page</h1>
+    <h1>🐝 Buzz Collaborative Page</h1>
     <p>This page was created by two bots collaborating via Buzz's git server.</p>
     <div class="contributor">
         <strong>Bot 1</strong> — Created the initial page structure

--- a/web/src/features/repos/use-repos.ts
+++ b/web/src/features/repos/use-repos.ts
@@ -30,7 +30,7 @@ function eventToRepo(event: NostrEvent): Repo {
   const description = getTag(event, "description") || event.content || "";
   const cloneUrls = getAllTags(event, "clone");
   const webUrl = getTag(event, "web") ?? null;
-  const channelId = getTag(event, "sprout-channel") ?? null;
+  const channelId = getTag(event, "buzz-channel") ?? null;
   const contributors = getAllTags(event, "p");
   const owner = event.pubkey;
 


### PR DESCRIPTION
## Summary
- rename remaining user-facing Sprout references in vision docs to Buzz
- update release/contact docs and local SQLite ignore names to Buzz
- align web repo channel binding lookup with the `buzz-channel` tag name

## Verification
- `git diff --check`
- `just --summary`
- `just web-check`
- `rg -n --hidden -S "Sprout|sprout|SPROUT" -g '!node_modules' -g '!target' -g '!dist' -g '!build' -g '!pnpm-lock.yaml' -g '!Cargo.lock' .` (131 → 58 remaining intentional hits)
