### PR TITLE
chore(justfile): build git-credential-nostr in dev and staging recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -274,7 +274,7 @@ proxy-release:
 dev *ARGS: _ensure-sidecar-stubs
     #!/usr/bin/env bash
     set -euo pipefail
-    cargo build -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p buzz-cli
+    cargo build -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
     cd {{desktop_dir}}
     [[ -d node_modules ]] || pnpm install
     source ../scripts/instance-env.sh
@@ -290,7 +290,7 @@ staging *ARGS: _ensure-sidecar-stubs
     #!/usr/bin/env bash
     set -euo pipefail
     pnpm install
-    cargo build --release -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p buzz-cli
+    cargo build --release -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
     export MESH_LLM_NATIVE_RUNTIME_CACHE_DIR="$(./scripts/ensure-mesh-native-runtime.sh)"
     # Replace the 0-byte sidecar stub with the real CLI binary so tauri dev picks it up.
     TARGET=$(rustc -vV | sed -n 's|host: ||p')


### PR DESCRIPTION
The desktop runtime resolves `git-credential-nostr` at agent spawn time to configure git credential helpers. The `dev` and `staging` justfile recipes never included it in their `cargo build` commands, relying on a stale binary from previous full-workspace builds. The sprout→buzz rename invalidated cargo fingerprints, exposing the gap.

Adds `-p git-credential-nostr` to both the `just dev` (debug) and `just staging` (release) cargo build commands so the binary is always available when agents spawn.