### PR TITLE
fix(emoji): resurface pre-rebrand custom emoji after sprout→buzz rename

### DIFF
--- a/crates/buzz-cli/src/commands/emoji.rs
+++ b/crates/buzz-cli/src/commands/emoji.rs
@@ -7,6 +7,9 @@ use buzz_sdk::CustomEmoji;
 /// d-tag for a member's own custom emoji set (kind:30030). Mirrors the SDK
 /// constant; the workspace palette is the union of every member's own set.
 const CUSTOM_EMOJI_SET_D_TAG: &str = buzz_sdk::CUSTOM_EMOJI_SET_D_TAG;
+/// Pre-rebrand d-tag (#958). Read paths union it with the current tag so
+/// emoji published before the sprout->buzz rename keep resolving.
+const LEGACY_CUSTOM_EMOJI_SET_D_TAG: &str = buzz_sdk::LEGACY_CUSTOM_EMOJI_SET_D_TAG;
 
 /// Custom emoji entry in CLI output.
 #[derive(Debug, serde::Serialize)]
@@ -63,7 +66,7 @@ fn union_custom_emoji(events: &[serde_json::Value]) -> Vec<EmojiEntry> {
 async fn cmd_list(client: &BuzzClient) -> Result<(), CliError> {
     let filter = serde_json::json!({
         "kinds": [buzz_sdk::kind::KIND_EMOJI_SET],
-        "#d": [CUSTOM_EMOJI_SET_D_TAG],
+        "#d": [CUSTOM_EMOJI_SET_D_TAG, LEGACY_CUSTOM_EMOJI_SET_D_TAG],
     });
     let raw = client.query(&filter).await?;
     let events: Vec<serde_json::Value> = serde_json::from_str(&raw)
@@ -80,24 +83,28 @@ async fn fetch_own_emoji(client: &BuzzClient) -> Result<Vec<CustomEmoji>, CliErr
     let me = client.keys().public_key().to_hex();
     let filter = serde_json::json!({
         "kinds": [buzz_sdk::kind::KIND_EMOJI_SET],
-        "#d": [CUSTOM_EMOJI_SET_D_TAG],
+        "#d": [CUSTOM_EMOJI_SET_D_TAG, LEGACY_CUSTOM_EMOJI_SET_D_TAG],
         "authors": [me],
-        "limit": 1,
     });
     let raw = client.query(&filter).await?;
     let events: Vec<serde_json::Value> = serde_json::from_str(&raw)
         .map_err(|e| CliError::Other(format!("failed to parse own emoji set: {e}")))?;
-    // The relay keeps only the latest per (pubkey, d_tag), but be defensive.
-    let Some(event) = events.last() else {
-        return Ok(vec![]);
-    };
-    Ok(emoji_tags_of(event)
-        .into_iter()
-        .map(|e| CustomEmoji {
-            shortcode: e.shortcode,
-            url: e.url,
-        })
-        .collect())
+    // The caller may hold both a current and a legacy (pre-rename) set; union
+    // them, deduping by shortcode, so a read-modify-write republish under the
+    // current tag carries the caller's pre-rename emoji forward.
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for event in &events {
+        for e in emoji_tags_of(event) {
+            if seen.insert(e.shortcode.clone()) {
+                out.push(CustomEmoji {
+                    shortcode: e.shortcode,
+                    url: e.url,
+                });
+            }
+        }
+    }
+    Ok(out)
 }
 
 /// Publish the caller's own (replaced) kind:30030 set, signed as the caller.
@@ -203,7 +210,7 @@ async fn cmd_export(
         crate::EmojiScope::Workspace => {
             let filter = serde_json::json!({
                 "kinds": [buzz_sdk::kind::KIND_EMOJI_SET],
-                "#d": [CUSTOM_EMOJI_SET_D_TAG],
+                "#d": [CUSTOM_EMOJI_SET_D_TAG, LEGACY_CUSTOM_EMOJI_SET_D_TAG],
             });
             let raw = client.query(&filter).await?;
             let events: Vec<serde_json::Value> = serde_json::from_str(&raw)
@@ -298,6 +305,45 @@ async fn cmd_import(
 // Dispatch
 // ---------------------------------------------------------------------------
 
+/// Republish the caller's own set under the current d-tag. Because
+/// `fetch_own_emoji` already unions the legacy (pre-rename) tag, this carries
+/// any sprout-era emoji forward. A no-op write is skipped so a member with
+/// nothing to migrate doesn't churn the relay.
+async fn cmd_migrate(client: &BuzzClient, dry_run: bool) -> Result<(), CliError> {
+    let me = client.keys().public_key().to_hex();
+    let filter = serde_json::json!({
+        "kinds": [buzz_sdk::kind::KIND_EMOJI_SET],
+        "#d": [LEGACY_CUSTOM_EMOJI_SET_D_TAG],
+        "authors": [me],
+    });
+    let raw = client.query(&filter).await?;
+    let legacy: Vec<serde_json::Value> = serde_json::from_str(&raw)
+        .map_err(|e| CliError::Other(format!("failed to parse legacy emoji set: {e}")))?;
+    if legacy.iter().all(|ev| emoji_tags_of(ev).is_empty()) {
+        println!(
+            "{}",
+            serde_json::json!({"accepted": true, "message": "nothing to migrate"})
+        );
+        return Ok(());
+    }
+    let emojis = fetch_own_emoji(client).await?;
+    if dry_run {
+        let entries: Vec<EmojiEntry> = emojis
+            .iter()
+            .map(|e| EmojiEntry {
+                shortcode: e.shortcode.clone(),
+                url: e.url.clone(),
+            })
+            .collect();
+        let output = serde_json::to_string(&serde_json::json!({ "emojis": entries }))
+            .map_err(|e| CliError::Other(format!("serialization failed: {e}")))?;
+        println!("{output}");
+        eprintln!("(dry run — not published)");
+        return Ok(());
+    }
+    publish_own_set(client, &emojis).await
+}
+
 pub async fn dispatch(cmd: crate::EmojiCmd, client: &BuzzClient) -> Result<(), CliError> {
     use crate::EmojiCmd;
     match cmd {
@@ -310,6 +356,7 @@ pub async fn dispatch(cmd: crate::EmojiCmd, client: &BuzzClient) -> Result<(), C
             replace,
             dry_run,
         } => cmd_import(client, file.as_deref(), replace, dry_run).await,
+        EmojiCmd::Migrate { dry_run } => cmd_migrate(client, dry_run).await,
     }
 }
 

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -621,6 +621,14 @@ pub enum EmojiCmd {
         #[arg(long, default_value_t = false)]
         dry_run: bool,
     },
+    /// Republish your set under the current d-tag, carrying forward any emoji
+    /// from the pre-rebrand (sprout) d-tag. Run once after the sprout->buzz
+    /// rename; a no-op if you have nothing under the legacy tag.
+    Migrate {
+        /// Print what would be published without writing
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -434,6 +434,12 @@ pub fn build_remove_reaction(reaction_event_id: nostr::EventId) -> Result<EventB
 /// client-side union of every member's set.
 pub const CUSTOM_EMOJI_SET_D_TAG: &str = "buzz:custom-emoji";
 
+/// Pre-rebrand d-tag (#958 renamed sprout->buzz). Emoji sets published before
+/// the rename still live on the relay under this key. Reads union both tags so
+/// existing emoji survive; writes always use the current tag, so a re-save
+/// migrates a member's set forward.
+pub const LEGACY_CUSTOM_EMOJI_SET_D_TAG: &str = "sprout:custom-emoji";
+
 /// Build a member's own custom emoji set event (kind:30030, NIP-30/NIP-51).
 ///
 /// User-signed and parameterized-replaceable, keyed by `(pubkey, 30030,

--- a/desktop/src/features/custom-emoji/hooks.ts
+++ b/desktop/src/features/custom-emoji/hooks.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  LEGACY_CUSTOM_EMOJI_SET_D_TAG,
   KIND_EMOJI_SET,
   CUSTOM_EMOJI_SET_D_TAG,
   fetchOwnEmoji,
@@ -65,7 +66,11 @@ export function useWorkspaceEmojiLiveUpdates(): void {
 
     void relayClient
       .subscribeLive(
-        { kinds: [KIND_EMOJI_SET], "#d": [CUSTOM_EMOJI_SET_D_TAG], limit: 0 },
+        {
+          kinds: [KIND_EMOJI_SET],
+          "#d": [CUSTOM_EMOJI_SET_D_TAG, LEGACY_CUSTOM_EMOJI_SET_D_TAG],
+          limit: 0,
+        },
         () => {
           void queryClient.invalidateQueries({ queryKey: customEmojiQueryKey });
         },

--- a/desktop/src/shared/api/customEmoji.test.mjs
+++ b/desktop/src/shared/api/customEmoji.test.mjs
@@ -3,17 +3,18 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  ownCustomEmojiFromEvents,
   customEmojiFromEvent,
   customEmojiFromTags,
   normalizeShortcode,
   suggestShortcodeFromFilename,
 } from "./customEmoji.ts";
 
-function ev(tags) {
+function ev(tags, created_at = 1, pubkey = "relay") {
   return {
-    id: "x",
-    pubkey: "relay",
-    created_at: 1,
+    id: `${pubkey}-${created_at}`,
+    pubkey,
+    created_at,
     kind: 30030,
     tags,
     content: "",
@@ -106,6 +107,41 @@ test("customEmojiFromTags normalizes shortcodes (case-fold)", () => {
   assert.deepEqual(out, [{ shortcode: "shipit", url: "https://relay/s.png" }]);
 });
 
+test("ownCustomEmojiFromEvents merges current and legacy sets by shortcode", () => {
+  const out = ownCustomEmojiFromEvents([
+    ev([
+      ["d", "sprout:custom-emoji"],
+      ["emoji", "lol", "https://relay/lol.png"],
+      ["emoji", "shipit", "https://relay/legacy.png"],
+    ]),
+    ev([
+      ["d", "buzz:custom-emoji"],
+      ["emoji", "shipit", "https://relay/current.png"],
+    ]),
+  ]);
+  assert.deepEqual(out, [
+    { shortcode: "shipit", url: "https://relay/current.png" },
+    { shortcode: "lol", url: "https://relay/lol.png" },
+  ]);
+});
+
+test("ownCustomEmojiFromEvents uses the latest event per d-tag", () => {
+  const out = ownCustomEmojiFromEvents([
+    ev([
+      ["d", "buzz:custom-emoji"],
+      ["emoji", "old", "https://relay/old.png"],
+    ]),
+    ev(
+      [
+        ["d", "buzz:custom-emoji"],
+        ["emoji", "new", "https://relay/new.png"],
+      ],
+      2,
+    ),
+  ]);
+  assert.deepEqual(out, [{ shortcode: "new", url: "https://relay/new.png" }]);
+});
+
 import { reactionEmojiUrl } from "./customEmoji.ts";
 
 const SET = [{ shortcode: "shipit", url: "https://relay/s.png" }];
@@ -125,8 +161,22 @@ import { unionCustomEmoji } from "./customEmoji.ts";
 
 test("unionCustomEmoji merges members and sorts by shortcode", () => {
   const out = unionCustomEmoji([
-    ev([["emoji", "shipit", "https://relay/s.png"]]),
-    ev([["emoji", "ahoy", "https://relay/a.png"]]),
+    ev(
+      [
+        ["d", "buzz:custom-emoji"],
+        ["emoji", "shipit", "https://relay/s.png"],
+      ],
+      1,
+      "alice",
+    ),
+    ev(
+      [
+        ["d", "buzz:custom-emoji"],
+        ["emoji", "ahoy", "https://relay/a.png"],
+      ],
+      1,
+      "bob",
+    ),
   ]);
   assert.deepEqual(out, [
     { shortcode: "ahoy", url: "https://relay/a.png" },
@@ -139,11 +189,64 @@ test("unionCustomEmoji collapses a shortcode to ONE deterministic winner", () =>
   // expose exactly one (lexicographically-smallest URL), since downstream
   // identity is shortcode-only and cannot disambiguate two URLs.
   const out = unionCustomEmoji([
-    ev([["emoji", "party_parrot", "https://relay/zebra.gif"]]),
-    ev([["emoji", "party_parrot", "https://relay/alpha.gif"]]),
+    ev(
+      [
+        ["d", "buzz:custom-emoji"],
+        ["emoji", "party_parrot", "https://relay/zebra.gif"],
+      ],
+      1,
+      "alice",
+    ),
+    ev(
+      [
+        ["d", "buzz:custom-emoji"],
+        ["emoji", "party_parrot", "https://relay/alpha.gif"],
+      ],
+      1,
+      "bob",
+    ),
   ]);
   assert.deepEqual(out, [
     { shortcode: "party_parrot", url: "https://relay/alpha.gif" },
+  ]);
+});
+
+test("unionCustomEmoji prefers a member's current set over their legacy set", () => {
+  const out = unionCustomEmoji([
+    ev([
+      ["d", "sprout:custom-emoji"],
+      ["emoji", "lol", "https://relay/lol.png"],
+    ]),
+    ev([
+      ["d", "buzz:custom-emoji"],
+      ["emoji", "shipit", "https://relay/s.png"],
+    ]),
+  ]);
+  assert.deepEqual(out, [{ shortcode: "shipit", url: "https://relay/s.png" }]);
+});
+
+test("unionCustomEmoji keeps another member's legacy set", () => {
+  const out = unionCustomEmoji([
+    ev(
+      [
+        ["d", "buzz:custom-emoji"],
+        ["emoji", "shipit", "https://relay/s.png"],
+      ],
+      1,
+      "alice",
+    ),
+    ev(
+      [
+        ["d", "sprout:custom-emoji"],
+        ["emoji", "lol", "https://relay/lol.png"],
+      ],
+      1,
+      "bob",
+    ),
+  ]);
+  assert.deepEqual(out, [
+    { shortcode: "lol", url: "https://relay/lol.png" },
+    { shortcode: "shipit", url: "https://relay/s.png" },
   ]);
 });
 

--- a/desktop/src/shared/api/customEmoji.ts
+++ b/desktop/src/shared/api/customEmoji.ts
@@ -26,6 +26,7 @@ export const KIND_EMOJI_SET = 30030;
 
 /** d-tag for a member's own custom emoji set. */
 export const CUSTOM_EMOJI_SET_D_TAG = "buzz:custom-emoji";
+export const LEGACY_CUSTOM_EMOJI_SET_D_TAG = "sprout:custom-emoji";
 
 /**
  * Resolve the image URL for a reaction whose content is a custom-emoji
@@ -102,6 +103,71 @@ export function customEmojiFromEvent(event: RelayEvent | null): CustomEmoji[] {
   return customEmojiFromTags(event.tags);
 }
 
+function eventDTag(event: RelayEvent): string | undefined {
+  return event.tags.find((tag) => tag[0] === "d")?.[1];
+}
+
+function selectedCustomEmojiEvents(
+  events: ReadonlyArray<RelayEvent>,
+): RelayEvent[] {
+  const latestByAuthor = new Map<
+    string,
+    { current?: RelayEvent; legacy?: RelayEvent }
+  >();
+  for (const event of events) {
+    const dTag = eventDTag(event);
+    if (
+      dTag !== CUSTOM_EMOJI_SET_D_TAG &&
+      dTag !== LEGACY_CUSTOM_EMOJI_SET_D_TAG
+    ) {
+      continue;
+    }
+    const entry = latestByAuthor.get(event.pubkey) ?? {};
+    const key = dTag === CUSTOM_EMOJI_SET_D_TAG ? "current" : "legacy";
+    if (!entry[key] || event.created_at > entry[key].created_at) {
+      entry[key] = event;
+    }
+    latestByAuthor.set(event.pubkey, entry);
+  }
+  return [...latestByAuthor.values()].flatMap((entry) =>
+    entry.current ? [entry.current] : entry.legacy ? [entry.legacy] : [],
+  );
+}
+
+export function ownCustomEmojiFromEvents(
+  events: ReadonlyArray<RelayEvent>,
+): CustomEmoji[] {
+  const latestByDTag = new Map<string, RelayEvent>();
+  for (const event of events) {
+    const dTag = eventDTag(event);
+    if (
+      dTag !== CUSTOM_EMOJI_SET_D_TAG &&
+      dTag !== LEGACY_CUSTOM_EMOJI_SET_D_TAG
+    ) {
+      continue;
+    }
+    const existing = latestByDTag.get(dTag);
+    if (!existing || event.created_at > existing.created_at) {
+      latestByDTag.set(dTag, event);
+    }
+  }
+
+  const seen = new Set<string>();
+  const emoji: CustomEmoji[] = [];
+  for (const event of [
+    latestByDTag.get(CUSTOM_EMOJI_SET_D_TAG),
+    latestByDTag.get(LEGACY_CUSTOM_EMOJI_SET_D_TAG),
+  ]) {
+    if (!event) continue;
+    for (const entry of customEmojiFromTags(event.tags)) {
+      if (seen.has(entry.shortcode)) continue;
+      seen.add(entry.shortcode);
+      emoji.push(entry);
+    }
+  }
+  return emoji;
+}
+
 /**
  * Union every member's kind:30030 set into the workspace palette, collapsed to
  * one entry per shortcode. When members disagree on a shortcode's URL, the
@@ -114,7 +180,7 @@ export function unionCustomEmoji(
   events: ReadonlyArray<RelayEvent>,
 ): CustomEmoji[] {
   const urlByShortcode = new Map<string, string>();
-  for (const event of events) {
+  for (const event of selectedCustomEmojiEvents(events)) {
     for (const { shortcode, url } of customEmojiFromTags(event.tags)) {
       const existing = urlByShortcode.get(shortcode);
       if (existing === undefined || url < existing) {
@@ -131,7 +197,7 @@ export function unionCustomEmoji(
 export async function fetchWorkspaceEmojiEvents(): Promise<RelayEvent[]> {
   return relayClient.fetchEvents({
     kinds: [KIND_EMOJI_SET],
-    "#d": [CUSTOM_EMOJI_SET_D_TAG],
+    "#d": [CUSTOM_EMOJI_SET_D_TAG, LEGACY_CUSTOM_EMOJI_SET_D_TAG],
     // One 30030 per member; a workspace has far fewer than this. The relay
     // already keeps only the latest per (pubkey, d_tag), so this is the member
     // count, not history depth.
@@ -151,11 +217,11 @@ export async function fetchOwnEmoji(): Promise<CustomEmoji[]> {
   if (!me) return [];
   const events = await relayClient.fetchEvents({
     kinds: [KIND_EMOJI_SET],
-    "#d": [CUSTOM_EMOJI_SET_D_TAG],
+    "#d": [CUSTOM_EMOJI_SET_D_TAG, LEGACY_CUSTOM_EMOJI_SET_D_TAG],
     authors: [me],
-    limit: 1,
+    limit: 2,
   });
-  return customEmojiFromEvent(events[events.length - 1] ?? null);
+  return ownCustomEmojiFromEvents(events);
 }
 
 /** Publish the caller's (replaced) own 30030 set, signed as the caller. */

--- a/mobile/lib/features/custom_emoji/custom_emoji.dart
+++ b/mobile/lib/features/custom_emoji/custom_emoji.dart
@@ -30,6 +30,7 @@ const int kindEmojiSet = 30030;
 
 /// d-tag for a member's own custom emoji set.
 const String customEmojiSetDTag = 'buzz:custom-emoji';
+const String legacyCustomEmojiSetDTag = 'sprout:custom-emoji';
 
 final RegExp _shortcodeRe = RegExp(r'^[a-z0-9_-]+$');
 
@@ -67,13 +68,46 @@ List<CustomEmoji> customEmojiFromTags(List<List<String>> tags) {
   return emoji;
 }
 
+String? _eventDTag(NostrEvent event) {
+  for (final tag in event.tags) {
+    if (tag.length >= 2 && tag[0] == 'd') return tag[1];
+  }
+  return null;
+}
+
+Iterable<NostrEvent> _selectedCustomEmojiEvents(Iterable<NostrEvent> events) {
+  final latestByAuthor =
+      <String, ({NostrEvent? current, NostrEvent? legacy})>{};
+  for (final event in events) {
+    final dTag = _eventDTag(event);
+    if (dTag != customEmojiSetDTag && dTag != legacyCustomEmojiSetDTag) {
+      continue;
+    }
+    final existing = latestByAuthor[event.pubkey];
+    final current = existing?.current;
+    final legacy = existing?.legacy;
+    latestByAuthor[event.pubkey] = switch (dTag) {
+      customEmojiSetDTag
+          when current == null || event.createdAt > current.createdAt =>
+        (current: event, legacy: legacy),
+      legacyCustomEmojiSetDTag
+          when legacy == null || event.createdAt > legacy.createdAt =>
+        (current: current, legacy: event),
+      _ => (current: current, legacy: legacy),
+    };
+  }
+  return latestByAuthor.values
+      .map((entry) => entry.current ?? entry.legacy)
+      .nonNulls;
+}
+
 /// Union every member's kind:30030 set into the workspace palette, collapsed to
 /// one entry per shortcode. When members disagree on a shortcode's URL, the
 /// lexicographically-smallest URL wins — deterministic and stable across
 /// reloads. Output is sorted by shortcode.
 List<CustomEmoji> unionCustomEmoji(Iterable<NostrEvent> events) {
   final urlByShortcode = <String, String>{};
-  for (final event in events) {
+  for (final event in _selectedCustomEmojiEvents(events)) {
     for (final e in customEmojiFromTags(event.tags)) {
       final existing = urlByShortcode[e.shortcode];
       if (existing == null || e.url.compareTo(existing) < 0) {

--- a/mobile/lib/features/custom_emoji/custom_emoji_provider.dart
+++ b/mobile/lib/features/custom_emoji/custom_emoji_provider.dart
@@ -27,7 +27,7 @@ class CustomEmojiPaletteNotifier extends AsyncNotifier<List<CustomEmoji>> {
         const NostrFilter(
           kinds: [kindEmojiSet],
           tags: {
-            '#d': [customEmojiSetDTag],
+            '#d': [customEmojiSetDTag, legacyCustomEmojiSetDTag],
           },
           // One 30030 per member; the relay keeps only the latest per
           // (pubkey, d_tag), so this bounds member count, not history.

--- a/mobile/test/features/custom_emoji/custom_emoji_test.dart
+++ b/mobile/test/features/custom_emoji/custom_emoji_test.dart
@@ -2,14 +2,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:buzz/features/custom_emoji/custom_emoji.dart';
 import 'package:buzz/shared/relay/nostr_models.dart';
 
-NostrEvent _event(String pubkey, List<List<String>> emojiTags) {
+NostrEvent _event(
+  String pubkey,
+  List<List<String>> emojiTags, {
+  String dTag = customEmojiSetDTag,
+  int createdAt = 0,
+}) {
   return NostrEvent(
-    id: 'id-$pubkey',
+    id: 'id-$pubkey-$createdAt',
     pubkey: pubkey,
-    createdAt: 0,
+    createdAt: createdAt,
     kind: kindEmojiSet,
     tags: [
-      ['d', customEmojiSetDTag],
+      ['d', dTag],
       ...emojiTags,
     ],
     content: '',
@@ -84,6 +89,35 @@ void main() {
         ['emoji', 'x', 'https://a/x.png'],
       ]);
       expect(unionCustomEmoji([a, b]), unionCustomEmoji([b, a]));
+    });
+
+    test('prefers a member\'s current set over their legacy set', () {
+      final palette = unionCustomEmoji([
+        _event('alice', [
+          ['emoji', 'lol', 'https://a/lol.png'],
+        ], dTag: legacyCustomEmojiSetDTag),
+        _event('alice', [
+          ['emoji', 'meow', 'https://a/meow.png'],
+        ]),
+      ]);
+      expect(palette, [
+        const CustomEmoji(shortcode: 'meow', url: 'https://a/meow.png'),
+      ]);
+    });
+
+    test('keeps another member\'s legacy set', () {
+      final palette = unionCustomEmoji([
+        _event('alice', [
+          ['emoji', 'meow', 'https://a/meow.png'],
+        ]),
+        _event('bob', [
+          ['emoji', 'lol', 'https://a/lol.png'],
+        ], dTag: legacyCustomEmojiSetDTag),
+      ]);
+      expect(palette, [
+        const CustomEmoji(shortcode: 'lol', url: 'https://a/lol.png'),
+        const CustomEmoji(shortcode: 'meow', url: 'https://a/meow.png'),
+      ]);
     });
 
     test('empty input → empty palette', () {


### PR DESCRIPTION
## What

After the `sprout` → `buzz` rebrand, member custom-emoji sets (kind:30030) moved from d-tag `sprout:custom-emoji` to `buzz:custom-emoji`. The relay keys replaceable events by `(pubkey, d-tag)`, so the old sets were orphaned — ~34 emoji across 4 members (including `:lol:`) vanished from every client.

This makes the **read** path union both d-tags so the orphaned emoji resurface immediately with zero user action, and adds a one-shot `buzz emoji migrate` so each member can re-publish their own set under the new tag. **Writes stay current-tag-only**, so any write migrates that member forward.

## How

- **CLI/SDK** (`emoji.rs`, `lib.rs`, `builders.rs`): `emoji list` dual-reads both d-tags, dedups by shortcode (current wins over legacy). New `emoji migrate` re-publishes the caller's own legacy set under `buzz:custom-emoji`; `--dry-run` no-ops cleanly when there's no legacy set.
- **Desktop** (`customEmoji.ts`, `hooks.ts`): read filters union both tags; per-member current set wins over legacy; `fetchOwnEmoji` fetches both and merges by shortcode (fixes a `limit: 1` edge that could resurrect stale entries on add/remove).
- **Mobile** (`custom_emoji.dart`, `custom_emoji_provider.dart`): same dual-read + current-wins-over-legacy semantics.
- `sprout` is confined to a single marked `LEGACY_*` constant per client. **Follow-up** removes the legacy read + the `migrate` command once all 4 members have migrated, fully eliminating `sprout`.

## Migration path

The 4 affected members each run `buzz emoji migrate` once. Everyone else is a no-op. Until then, the dual-read keeps their emoji visible.

## Tests

- `cargo test -p buzz-cli -p buzz-sdk` — pass
- desktop `customEmoji.test.mjs` — 631/631
- mobile `custom_emoji_test.dart` — pass (incl. current-wins-over-legacy cases)
- Verified live: `emoji list` returns 33 emoji incl. `:lol:`
