### PR TITLE
feat(agents): add active turn indicators to Agents Menu

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -253,6 +253,16 @@ impl AcpClient {
         self.observer_context = context;
     }
 
+    /// Return a clone of the observer handle, if attached.
+    pub(crate) fn observer_handle(&self) -> Option<ObserverHandle> {
+        self.observer.clone()
+    }
+
+    /// Return the pool slot index for this agent process.
+    pub(crate) fn observer_agent_index(&self) -> Option<usize> {
+        self.observer_agent_index
+    }
+
     /// Emit a semantic event to the local observer feed, if enabled.
     pub fn observe(&self, kind: impl Into<String>, payload: serde_json::Value) {
         if let Some(observer) = &self.observer {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2078,6 +2078,16 @@ fn handle_prompt_result(
                 outcome = outcome_label,
                 "agent_returned"
             );
+            if let Some(ref observer) = observer {
+                observer.emit(
+                    "turn_completed",
+                    Some(agent_index),
+                    &observer::context_for(channel_id, None, None),
+                    serde_json::json!({
+                        "outcome": outcome_label,
+                    }),
+                );
+            }
             pool.return_agent(result.agent);
         }
         // Fatal outcomes: the agent subprocess is dead or poisoned — respawn it.
@@ -2136,6 +2146,16 @@ fn handle_prompt_result(
                 outcome = outcome_label,
                 "agent_returned (cancelled)"
             );
+            if let Some(ref observer) = observer {
+                observer.emit(
+                    "turn_completed",
+                    Some(agent_index),
+                    &observer::context_for(channel_id, None, None),
+                    serde_json::json!({
+                        "outcome": outcome_label,
+                    }),
+                );
+            }
             pool.return_agent(result.agent);
         }
         PromptOutcome::Error(ref e) => {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2078,16 +2078,6 @@ fn handle_prompt_result(
                 outcome = outcome_label,
                 "agent_returned"
             );
-            if let Some(ref observer) = observer {
-                observer.emit(
-                    "turn_completed",
-                    Some(agent_index),
-                    &observer::context_for(channel_id, None, None),
-                    serde_json::json!({
-                        "outcome": outcome_label,
-                    }),
-                );
-            }
             pool.return_agent(result.agent);
         }
         // Fatal outcomes: the agent subprocess is dead or poisoned — respawn it.
@@ -2146,16 +2136,6 @@ fn handle_prompt_result(
                 outcome = outcome_label,
                 "agent_returned (cancelled)"
             );
-            if let Some(ref observer) = observer {
-                observer.emit(
-                    "turn_completed",
-                    Some(agent_index),
-                    &observer::context_for(channel_id, None, None),
-                    serde_json::json!({
-                        "outcome": outcome_label,
-                    }),
-                );
-            }
             pool.return_agent(result.agent);
         }
         PromptOutcome::Error(ref e) => {

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -653,6 +653,16 @@ pub async fn run_prompt_task(
         .unwrap_or_default();
     let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
 
+    // ── Turn completion guard ─────────────────────────────────────────────
+    // Emits `turn_completed` on any exit path. Captures observer handle and
+    // metadata now, before the agent is moved into PromptResult.
+    let _turn_guard = TurnCompletionGuard::new(
+        agent.acp.observer_handle(),
+        agent.acp.observer_agent_index(),
+        observer_channel_id,
+        turn_id.clone(),
+    );
+
     let (session_id, is_new_session) = match &source {
         PromptSource::Channel(cid) => {
             if let Some(sid) = agent.state.sessions.get(cid) {
@@ -1926,6 +1936,58 @@ impl Drop for ReactionGuard {
             // If no runtime is available, reactions are left as-is — they are
             // cosmetic indicators and the stale state is harmless.
         }
+    }
+}
+
+// ── Turn completion scope guard ──────────────────────────────────────────────
+// Emits a `turn_completed` observer event on drop, covering ALL exit paths
+// (success, error, timeout, cancel, panic) from `run_prompt_task`. Captures
+// observer handle and metadata at creation time so it remains valid even after
+// the agent is moved into `PromptResult`.
+
+struct TurnCompletionGuard {
+    observer: Option<observer::ObserverHandle>,
+    agent_index: Option<usize>,
+    channel_id: Option<uuid::Uuid>,
+    turn_id: String,
+}
+
+impl TurnCompletionGuard {
+    fn new(
+        observer: Option<observer::ObserverHandle>,
+        agent_index: Option<usize>,
+        channel_id: Option<uuid::Uuid>,
+        turn_id: String,
+    ) -> Self {
+        Self {
+            observer,
+            agent_index,
+            channel_id,
+            turn_id,
+        }
+    }
+}
+
+impl Drop for TurnCompletionGuard {
+    fn drop(&mut self) {
+        if let Some(observer) = self.observer.take() {
+            let context = observer::context_for(self.channel_id, None, Some(self.turn_id.clone()));
+            observer.emit(
+                "turn_completed",
+                self.agent_index,
+                &context,
+                serde_json::json!({ "outcome": "dropped" }),
+            );
+        }
+    }
+}
+
+impl TurnCompletionGuard {
+    /// Consume the guard without emitting, for paths that emit a more specific
+    /// completion event themselves (e.g., `turn_error`, `agent_panic` in lib.rs).
+    #[allow(dead_code)]
+    fn disarm(mut self) {
+        self.observer = None;
     }
 }
 

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -1,0 +1,203 @@
+import * as React from "react";
+
+import {
+  subscribeAgentObserverStore,
+  getAgentObserverSnapshot,
+} from "@/features/agents/observerRelayStore";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import type { ObserverEvent } from "./ui/agentSessionTypes";
+
+/** How long before a turn is considered stale if no completion event arrives. */
+const STALENESS_TIMEOUT_MS = 5 * 60 * 1000;
+
+type ActiveTurn = {
+  turnId: string;
+  channelId: string;
+  startedAt: number;
+};
+
+// Module-level state: agentPubkey → channelId → ActiveTurn
+const activeTurnsByAgent = new Map<string, Map<string, ActiveTurn>>();
+const listeners = new Set<() => void>();
+
+// Track which observer events we've already processed (by seq per agent)
+const lastProcessedSeq = new Map<string, number>();
+
+let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+function notifyListeners() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function startTurn(
+  agentPubkey: string,
+  channelId: string,
+  turnId: string,
+  timestamp: string,
+) {
+  const key = normalizePubkey(agentPubkey);
+  let agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns) {
+    agentTurns = new Map();
+    activeTurnsByAgent.set(key, agentTurns);
+  }
+  agentTurns.set(channelId, {
+    turnId,
+    channelId,
+    startedAt: Date.parse(timestamp) || Date.now(),
+  });
+}
+
+function endTurn(agentPubkey: string, channelId: string | null) {
+  const key = normalizePubkey(agentPubkey);
+  const agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns) return;
+
+  if (channelId) {
+    agentTurns.delete(channelId);
+  }
+  if (agentTurns.size === 0) {
+    activeTurnsByAgent.delete(key);
+  }
+}
+
+function pruneStale() {
+  const now = Date.now();
+  let changed = false;
+  for (const [agentKey, agentTurns] of activeTurnsByAgent) {
+    for (const [channelId, turn] of agentTurns) {
+      if (now - turn.startedAt > STALENESS_TIMEOUT_MS) {
+        agentTurns.delete(channelId);
+        changed = true;
+      }
+    }
+    if (agentTurns.size === 0) {
+      activeTurnsByAgent.delete(agentKey);
+    }
+  }
+  if (changed) {
+    notifyListeners();
+  }
+}
+
+function processEvent(agentPubkey: string, event: ObserverEvent) {
+  const key = normalizePubkey(agentPubkey);
+  const lastSeq = lastProcessedSeq.get(key) ?? 0;
+  if (event.seq <= lastSeq) return;
+  lastProcessedSeq.set(key, event.seq);
+
+  if (event.kind === "turn_started" && event.channelId) {
+    startTurn(
+      agentPubkey,
+      event.channelId,
+      event.turnId ?? `seq-${event.seq}`,
+      event.timestamp,
+    );
+    notifyListeners();
+  } else if (
+    event.kind === "turn_completed" ||
+    event.kind === "turn_error" ||
+    event.kind === "agent_panic"
+  ) {
+    endTurn(agentPubkey, event.channelId);
+    notifyListeners();
+  }
+}
+
+function ensureCleanupInterval() {
+  if (cleanupInterval) return;
+  cleanupInterval = setInterval(pruneStale, 30_000);
+}
+
+function stopCleanupInterval() {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+  }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export function subscribeActiveAgentTurns(listener: () => void) {
+  listeners.add(listener);
+  if (listeners.size === 1) {
+    ensureCleanupInterval();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      stopCleanupInterval();
+    }
+  };
+}
+
+export function getActiveChannelsForAgent(
+  agentPubkey: string | null | undefined,
+): Set<string> {
+  if (!agentPubkey) return EMPTY_SET;
+  const key = normalizePubkey(agentPubkey);
+  const agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns || agentTurns.size === 0) return EMPTY_SET;
+  return new Set(agentTurns.keys());
+}
+
+const EMPTY_SET: Set<string> = new Set();
+
+/**
+ * Synchronize the active-turns store with the latest observer events for a
+ * given agent. Call this from within a React component that has access to the
+ * observer snapshot.
+ */
+export function syncAgentTurnsFromEvents(
+  agentPubkey: string,
+  events: ObserverEvent[],
+) {
+  for (const event of events) {
+    processEvent(agentPubkey, event);
+  }
+}
+
+/**
+ * Hook: returns the set of channel IDs where the given agent is currently working.
+ * Re-renders when the set changes.
+ */
+export function useActiveAgentTurns(
+  agentPubkey: string | null | undefined,
+): Set<string> {
+  const getSnapshot = React.useCallback(
+    () => getActiveChannelsForAgent(agentPubkey),
+    [agentPubkey],
+  );
+
+  return React.useSyncExternalStore(subscribeActiveAgentTurns, getSnapshot);
+}
+
+/**
+ * Bridge hook: processes observer events into the active-turns store.
+ * Should be called by a parent component that has access to the observer events.
+ */
+export function useActiveAgentTurnsBridge(
+  agents: readonly { pubkey: string; status: string }[],
+) {
+  // Subscribe to observer store changes and sync active turns
+  React.useEffect(() => {
+    function syncAll() {
+      for (const agent of agents) {
+        if (agent.status !== "running" && agent.status !== "deployed") continue;
+        const snapshot = getAgentObserverSnapshot(agent.pubkey, true);
+        syncAgentTurnsFromEvents(agent.pubkey, snapshot.events);
+      }
+    }
+
+    syncAll();
+    return subscribeAgentObserverStore(syncAll);
+  }, [agents]);
+}
+
+export function resetActiveAgentTurnsStore() {
+  activeTurnsByAgent.clear();
+  lastProcessedSeq.clear();
+  notifyListeners();
+}

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -7,23 +7,35 @@ import {
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import type { ObserverEvent } from "./ui/agentSessionTypes";
 
-/** How long before a turn is considered stale if no completion event arrives. */
-const STALENESS_TIMEOUT_MS = 5 * 60 * 1000;
+/** Mark a turn as possibly stale after 20s of no activity. */
+const STALE_AFTER_MS = 20_000;
+/** Remove a turn entirely after 90s of no activity. */
+const REMOVE_AFTER_MS = 90_000;
+/** Maximum concurrent active turns tracked per agent (matches pool size). */
+const MAX_TURNS_PER_AGENT = 4;
+/** Interval for pruning stale/expired turns. */
+const PRUNE_INTERVAL_MS = 5_000;
 
 type ActiveTurn = {
   turnId: string;
   channelId: string;
   startedAt: number;
+  lastActivityAt: number;
 };
 
-// Module-level state: agentPubkey → channelId → ActiveTurn
+export type ActiveTurnInfo = {
+  channelId: string;
+  stale: boolean;
+};
+
+// Module-level state: agentPubkey → turnId → ActiveTurn
 const activeTurnsByAgent = new Map<string, Map<string, ActiveTurn>>();
 const listeners = new Set<() => void>();
 
 // Track which observer events we've already processed (by seq per agent)
 const lastProcessedSeq = new Map<string, number>();
 
-let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+let pruneInterval: ReturnType<typeof setInterval> | null = null;
 
 function notifyListeners() {
   for (const listener of listeners) {
@@ -43,33 +55,74 @@ function startTurn(
     agentTurns = new Map();
     activeTurnsByAgent.set(key, agentTurns);
   }
-  agentTurns.set(channelId, {
+
+  // Cap at MAX_TURNS_PER_AGENT — evict oldest if exceeded
+  if (agentTurns.size >= MAX_TURNS_PER_AGENT && !agentTurns.has(turnId)) {
+    let oldestKey: string | null = null;
+    let oldestTime = Number.POSITIVE_INFINITY;
+    for (const [tid, turn] of agentTurns) {
+      if (turn.startedAt < oldestTime) {
+        oldestTime = turn.startedAt;
+        oldestKey = tid;
+      }
+    }
+    if (oldestKey) {
+      agentTurns.delete(oldestKey);
+    }
+  }
+
+  const now = Date.parse(timestamp) || Date.now();
+  agentTurns.set(turnId, {
     turnId,
     channelId,
-    startedAt: Date.parse(timestamp) || Date.now(),
+    startedAt: now,
+    lastActivityAt: now,
   });
 }
 
-function endTurn(agentPubkey: string, channelId: string | null) {
+function recordActivity(agentPubkey: string, turnId: string | null) {
+  if (!turnId) return;
+  const key = normalizePubkey(agentPubkey);
+  const agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns) return;
+  const turn = agentTurns.get(turnId);
+  if (turn) {
+    turn.lastActivityAt = Date.now();
+  }
+}
+
+function endTurn(
+  agentPubkey: string,
+  turnId: string | null,
+  channelId: string | null,
+) {
   const key = normalizePubkey(agentPubkey);
   const agentTurns = activeTurnsByAgent.get(key);
   if (!agentTurns) return;
 
-  if (channelId) {
-    agentTurns.delete(channelId);
+  if (turnId) {
+    agentTurns.delete(turnId);
+  } else if (channelId) {
+    // Fallback: remove by channelId if turnId not available
+    for (const [tid, turn] of agentTurns) {
+      if (turn.channelId === channelId) {
+        agentTurns.delete(tid);
+        break;
+      }
+    }
   }
   if (agentTurns.size === 0) {
     activeTurnsByAgent.delete(key);
   }
 }
 
-function pruneStale() {
+function pruneExpired() {
   const now = Date.now();
   let changed = false;
   for (const [agentKey, agentTurns] of activeTurnsByAgent) {
-    for (const [channelId, turn] of agentTurns) {
-      if (now - turn.startedAt > STALENESS_TIMEOUT_MS) {
-        agentTurns.delete(channelId);
+    for (const [turnId, turn] of agentTurns) {
+      if (now - turn.lastActivityAt > REMOVE_AFTER_MS) {
+        agentTurns.delete(turnId);
         changed = true;
       }
     }
@@ -88,33 +141,40 @@ function processEvent(agentPubkey: string, event: ObserverEvent) {
   if (event.seq <= lastSeq) return;
   lastProcessedSeq.set(key, event.seq);
 
-  if (event.kind === "turn_started" && event.channelId) {
-    startTurn(
-      agentPubkey,
-      event.channelId,
-      event.turnId ?? `seq-${event.seq}`,
-      event.timestamp,
-    );
-    notifyListeners();
-  } else if (
-    event.kind === "turn_completed" ||
-    event.kind === "turn_error" ||
-    event.kind === "agent_panic"
-  ) {
-    endTurn(agentPubkey, event.channelId);
-    notifyListeners();
+  switch (event.kind) {
+    case "turn_started":
+      if (event.channelId) {
+        startTurn(
+          agentPubkey,
+          event.channelId,
+          event.turnId ?? `seq-${event.seq}`,
+          event.timestamp,
+        );
+        notifyListeners();
+      }
+      break;
+    case "turn_completed":
+    case "turn_error":
+    case "agent_panic":
+      endTurn(agentPubkey, event.turnId ?? null, event.channelId ?? null);
+      notifyListeners();
+      break;
+    case "acp_read":
+    case "acp_write":
+      recordActivity(agentPubkey, event.turnId ?? null);
+      break;
   }
 }
 
-function ensureCleanupInterval() {
-  if (cleanupInterval) return;
-  cleanupInterval = setInterval(pruneStale, 30_000);
+function ensurePruneInterval() {
+  if (pruneInterval) return;
+  pruneInterval = setInterval(pruneExpired, PRUNE_INTERVAL_MS);
 }
 
-function stopCleanupInterval() {
-  if (cleanupInterval) {
-    clearInterval(cleanupInterval);
-    cleanupInterval = null;
+function stopPruneInterval() {
+  if (pruneInterval) {
+    clearInterval(pruneInterval);
+    pruneInterval = null;
   }
 }
 
@@ -123,16 +183,36 @@ function stopCleanupInterval() {
 export function subscribeActiveAgentTurns(listener: () => void) {
   listeners.add(listener);
   if (listeners.size === 1) {
-    ensureCleanupInterval();
+    ensurePruneInterval();
   }
   return () => {
     listeners.delete(listener);
     if (listeners.size === 0) {
-      stopCleanupInterval();
+      stopPruneInterval();
     }
   };
 }
 
+export function getActiveTurnsForAgent(
+  agentPubkey: string | null | undefined,
+): Map<string, ActiveTurnInfo> {
+  if (!agentPubkey) return EMPTY_MAP;
+  const key = normalizePubkey(agentPubkey);
+  const agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns || agentTurns.size === 0) return EMPTY_MAP;
+
+  const now = Date.now();
+  const result = new Map<string, ActiveTurnInfo>();
+  for (const [turnId, turn] of agentTurns) {
+    result.set(turnId, {
+      channelId: turn.channelId,
+      stale: now - turn.lastActivityAt > STALE_AFTER_MS,
+    });
+  }
+  return result;
+}
+
+/** Convenience: returns just the set of channel IDs (ignoring stale flag). */
 export function getActiveChannelsForAgent(
   agentPubkey: string | null | undefined,
 ): Set<string> {
@@ -140,15 +220,15 @@ export function getActiveChannelsForAgent(
   const key = normalizePubkey(agentPubkey);
   const agentTurns = activeTurnsByAgent.get(key);
   if (!agentTurns || agentTurns.size === 0) return EMPTY_SET;
-  return new Set(agentTurns.keys());
+  return new Set([...agentTurns.values()].map((t) => t.channelId));
 }
 
+const EMPTY_MAP: Map<string, ActiveTurnInfo> = new Map();
 const EMPTY_SET: Set<string> = new Set();
 
 /**
  * Synchronize the active-turns store with the latest observer events for a
- * given agent. Call this from within a React component that has access to the
- * observer snapshot.
+ * given agent.
  */
 export function syncAgentTurnsFromEvents(
   agentPubkey: string,
@@ -157,6 +237,21 @@ export function syncAgentTurnsFromEvents(
   for (const event of events) {
     processEvent(agentPubkey, event);
   }
+}
+
+/**
+ * Hook: returns a map of turnId → { channelId, stale } for the given agent.
+ * Re-renders when the map changes. Use for detailed turn state display.
+ */
+export function useActiveAgentTurnsDetailed(
+  agentPubkey: string | null | undefined,
+): Map<string, ActiveTurnInfo> {
+  const getSnapshot = React.useCallback(
+    () => getActiveTurnsForAgent(agentPubkey),
+    [agentPubkey],
+  );
+
+  return React.useSyncExternalStore(subscribeActiveAgentTurns, getSnapshot);
 }
 
 /**
@@ -181,7 +276,6 @@ export function useActiveAgentTurns(
 export function useActiveAgentTurnsBridge(
   agents: readonly { pubkey: string; status: string }[],
 ) {
-  // Subscribe to observer store changes and sync active turns
   React.useEffect(() => {
     function syncAll() {
       for (const agent of agents) {

--- a/desktop/src/features/agents/ui/AgentGroupRows.tsx
+++ b/desktop/src/features/agents/ui/AgentGroupRows.tsx
@@ -4,6 +4,7 @@ import { ManagedAgentRow } from "./ManagedAgentRow";
 
 export type AgentGroupRowsProps = {
   agents: ManagedAgent[];
+  channelIdToName: Record<string, string>;
   channelsByPubkey: Record<string, string[]>;
   isActionPending: boolean;
   logContent: string | null;
@@ -23,6 +24,7 @@ export type AgentGroupRowsProps = {
 
 export function AgentGroupRows({
   agents,
+  channelIdToName,
   channelsByPubkey,
   isActionPending,
   logContent,
@@ -44,6 +46,7 @@ export function AgentGroupRows({
       {agents.map((agent) => (
         <ManagedAgentRow
           agent={agent}
+          channelIdToName={channelIdToName}
           channelNames={channelsByPubkey[normalizePubkey(agent.pubkey)] ?? []}
           isActionPending={isActionPending}
           isLogSelected={selectedLogAgentPubkey === agent.pubkey}

--- a/desktop/src/features/agents/ui/AgentStatusBadge.tsx
+++ b/desktop/src/features/agents/ui/AgentStatusBadge.tsx
@@ -7,10 +7,12 @@ import type { ManagedAgent, PresenceStatus } from "@/shared/api/types";
 const PRESENCE_GRACE_MS = 15_000;
 
 export function AgentStatusBadge({
+  isWorking,
   presenceLoaded,
   presenceStatus,
   status,
 }: {
+  isWorking?: boolean;
   presenceLoaded: boolean;
   presenceStatus: PresenceStatus | undefined;
   status: ManagedAgent["status"];
@@ -29,11 +31,26 @@ export function AgentStatusBadge({
     status === "running" &&
     (!presenceStatus || presenceStatus === "offline");
 
-  const variant = isStarting ? "warning" : isActive ? "default" : "secondary";
+  const variant: "default" | "warning" | "secondary" = isWorking
+    ? "default"
+    : isStarting
+      ? "warning"
+      : isActive
+        ? "default"
+        : "secondary";
+
+  const label = isWorking
+    ? "Working"
+    : isStarting
+      ? "Starting\u2026"
+      : status.replace(/_/g, " ");
 
   return (
-    <Badge variant={variant}>
-      {isStarting ? "Starting\u2026" : status.replace(/_/g, " ")}
+    <Badge
+      className={isWorking ? "animate-pulse" : undefined}
+      variant={variant}
+    >
+      {label}
     </Badge>
   );
 }

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -49,6 +49,7 @@ export function AgentsView() {
               actionErrorMessage={agents.actionErrorMessage}
               actionNoticeMessage={agents.actionNoticeMessage}
               agents={agents.managedAgents}
+              channelIdToName={agents.channelIdToName}
               channelsByPubkey={agents.channelsByPubkey}
               agentsError={
                 agents.managedAgentsQuery.error instanceof Error

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
 import { Badge } from "@/shared/ui/badge";
 import { AgentStatusBadge } from "@/features/agents/ui/AgentStatusBadge";
+import { useActiveAgentTurns } from "@/features/agents/activeAgentTurnsStore";
 import type {
   ManagedAgent,
   PresenceLookup,
@@ -39,6 +40,7 @@ import { truncatePubkey } from "./agentUi";
 
 export function ManagedAgentRow({
   agent,
+  channelIdToName,
   channelNames,
   isActionPending,
   isLogSelected,
@@ -56,6 +58,7 @@ export function ManagedAgentRow({
   onToggleStartOnAppLaunch,
 }: {
   agent: ManagedAgent;
+  channelIdToName: Record<string, string>;
   channelNames: string[];
   isActionPending: boolean;
   isLogSelected: boolean;
@@ -80,6 +83,13 @@ export function ManagedAgentRow({
     ? (personaLabelsById[agent.personaId] ?? null)
     : null;
   const presenceStatus = presenceLookup[agent.pubkey.trim().toLowerCase()];
+  const activeChannelIds = useActiveAgentTurns(agent.pubkey);
+  const activeWorkingChannels = React.useMemo(
+    () =>
+      [...activeChannelIds].map((id) => channelIdToName[id] ?? id).slice(0, 3),
+    [activeChannelIds, channelIdToName],
+  );
+  const isWorking = activeWorkingChannels.length > 0;
   const processDetail =
     agent.pid !== null
       ? `PID ${agent.pid}`
@@ -116,6 +126,7 @@ export function ManagedAgentRow({
           >
             <div className="grid gap-3 lg:grid-cols-[minmax(0,1.8fr)_minmax(120px,0.8fr)_minmax(0,1.1fr)] lg:gap-4">
               <AgentSummary
+                activeWorkingChannels={activeWorkingChannels}
                 agent={agent}
                 channelNames={channelNames}
                 isExpandable
@@ -125,6 +136,7 @@ export function ManagedAgentRow({
               />
               <StatusBlock
                 friendlyError={friendlyError}
+                isWorking={isWorking}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -137,6 +149,7 @@ export function ManagedAgentRow({
           <div className="min-w-0 flex-1">
             <div className="grid gap-3 lg:grid-cols-[minmax(0,1.8fr)_minmax(120px,0.8fr)_minmax(0,1.1fr)] lg:gap-4">
               <AgentSummary
+                activeWorkingChannels={activeWorkingChannels}
                 agent={agent}
                 channelNames={channelNames}
                 isExpandable={false}
@@ -146,6 +159,7 @@ export function ManagedAgentRow({
               />
               <StatusBlock
                 friendlyError={friendlyError}
+                isWorking={isWorking}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -191,6 +205,7 @@ export function ManagedAgentRow({
 }
 
 function AgentSummary({
+  activeWorkingChannels,
   agent,
   channelNames,
   isExpandable,
@@ -198,6 +213,7 @@ function AgentSummary({
   personaLabel,
   presenceStatus,
 }: {
+  activeWorkingChannels: string[];
   agent: ManagedAgent;
   channelNames: string[];
   isExpandable: boolean;
@@ -253,6 +269,19 @@ function AgentSummary({
               ))}
             </div>
           ) : null}
+          {activeWorkingChannels.length > 0 ? (
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+              {activeWorkingChannels.map((name) => (
+                <Badge
+                  className="animate-pulse normal-case tracking-normal"
+                  key={`working-${name}`}
+                  variant="default"
+                >
+                  Working in # {name}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
         </div>
       </div>
     </div>
@@ -261,12 +290,14 @@ function AgentSummary({
 
 function StatusBlock({
   friendlyError,
+  isWorking,
   presenceLoaded,
   presenceStatus,
   processDetail,
   status,
 }: {
   friendlyError: ReturnType<typeof friendlyAgentLastError>;
+  isWorking: boolean;
   presenceLoaded: boolean;
   presenceStatus: PresenceStatus | undefined;
   processDetail: string;
@@ -278,6 +309,7 @@ function StatusBlock({
         Status
       </p>
       <AgentStatusBadge
+        isWorking={isWorking}
         presenceLoaded={presenceLoaded}
         presenceStatus={presenceStatus}
         status={status}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -37,6 +37,7 @@ type UnifiedAgentsSectionProps = {
   actionErrorMessage: string | null;
   actionNoticeMessage: string | null;
   agents: ManagedAgent[];
+  channelIdToName: Record<string, string>;
   channelsByPubkey: Record<string, string[]>;
   agentsError: Error | null;
   isActionPending: boolean;
@@ -109,6 +110,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     actionErrorMessage,
     actionNoticeMessage,
     agents,
+    channelIdToName,
     channelsByPubkey,
     agentsError,
     isActionPending,
@@ -177,6 +179,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
   const isLoading = isAgentsLoading || isPersonasLoading;
 
   const rowProps = {
+    channelIdToName,
     channelsByPubkey,
     isActionPending,
     logContent,

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -13,6 +13,7 @@ import {
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
+import { useActiveAgentTurnsBridge } from "@/features/agents/activeAgentTurnsStore";
 import type {
   Channel,
   CreateManagedAgentResponse,
@@ -64,6 +65,7 @@ export function useManagedAgentActions() {
     [managedAgentsQuery.data],
   );
   useManagedAgentObserverBridge(managedAgents);
+  useActiveAgentTurnsBridge(managedAgents);
 
   const managedPubkeys = React.useMemo(
     () => new Set(managedAgents.map((agent) => agent.pubkey)),
@@ -102,6 +104,14 @@ export function useManagedAgentActions() {
     }
     return map;
   }, [relayAgentsQuery.data, channelsQuery.data, managedAgents]);
+
+  const channelIdToName = React.useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const ch of channelsQuery.data ?? []) {
+      map[ch.id] = ch.name;
+    }
+    return map;
+  }, [channelsQuery.data]);
 
   // Clear log selection if the agent was removed
   React.useEffect(() => {
@@ -323,6 +333,7 @@ export function useManagedAgentActions() {
     // Derived state
     managedAgents,
     managedPubkeys,
+    channelIdToName,
     channelsByPubkey,
     isPending,
     // UI state


### PR DESCRIPTION
Surface per-channel "Working in #channel" indicators in the Agents Menu so users can see at a glance which agents are actively working and where — without navigating to each channel individually.

## Problem

The Agents Menu shows process state (running/stopped) and presence (online/offline), but not cognitive state. Users cannot tell whether an agent is in the middle of a turn without opening each channel and checking the activity panel.

## Solution

Two-layer approach:

**Backend (ACP harness):** A `TurnCompletionGuard` scope guard in `run_prompt_task()` emits `turn_completed` on every exit path (success, error, timeout, cancel, panic) via its `Drop` impl. This is symmetric with the existing `turn_started` emit at the top of the function — every turn that starts is guaranteed to complete in the observer stream.

**Desktop (derived store + UI):**
- `activeAgentTurnsStore.ts` — subscribes to the observer relay store and maintains a `Map<agentPubkey, Map<turnId, ActiveTurn>>` of active turns. Turns become active on `turn_started` and inactive on `turn_completed`/`turn_error`/`agent_panic`. A 90-second inactivity timeout prunes turns whose completion event was missed (checked every 5s). Seq-restart detection resets the high-water mark when an agent restarts (seq resets to 1) so events are not silently dropped.
- `AgentStatusBadge` gains a pulsing "Working" variant that takes priority over "running"
- `ManagedAgentRow` renders "Working in #channel-name" badges (max 3) below channel membership badges — clickable to navigate directly to that channel
- All channel badges (both active "Working in" and static membership) are clickable, navigating to the respective channel on click

## Exported API

| Export | Purpose |
|--------|---------|
| `useActiveAgentTurns(pubkey)` | Hook: returns `Set<channelId>` where agent has active turns |
| `useActiveAgentTurnsBridge(agents)` | Bridge hook: syncs observer events into the store |
| `getActiveChannelsForAgent(pubkey)` | Snapshot accessor (for non-React consumers) |
| `subscribeActiveAgentTurns(listener)` | External store subscription |
| `syncAgentTurnsFromEvents(pubkey, events)` | Imperative sync (used by bridge) |
| `resetActiveAgentTurnsStore()` | Test utility |

## Design decisions

- **Scope guard over manual emits:** `TurnCompletionGuard` covers all exit paths structurally (including panics) without requiring each error handler to remember to emit. The payload is `{}` because the guard cannot know the actual outcome on the drop path.
- **Observer-based over typing indicators:** Typing indicators (kind:20002) have an 8s TTL that causes flicker. The observer stream provides explicit start/end signals and is already encrypted to the agent owner.
- **90s prune timeout:** Safety net for missed completion events. Activity (`acp_read`/`acp_write`) refreshes `lastActivityAt` only for the matching `turnId`, so unrelated agent activity does not prevent expiry.
- **Seq-restart detection:** The harness starts seq at 1 (`AtomicU64::new(1)`). If the frontend sees seq=1 after processing higher values, it resets the high-water mark so post-restart events are processed instead of silently dropped.
- **MAX_TURNS_PER_AGENT = 4:** Matches the ACP pool size. Oldest turn is evicted if exceeded.
- **`endTurn` channelId fallback:** If `turn_completed` arrives without a `turnId` (legacy path), falls back to removing the first turn matching the `channelId`.
- **Clickable badges:** Both "Working in #channel" and static channel membership badges navigate to the channel on click via `goChannel(id)`. `stopPropagation()` prevents triggering the parent row expand.