### PR TITLE
feat(huddle): sentence-at-a-time voice-mode guidelines for lower TTS latency

### DIFF
--- a/desktop/src-tauri/src/huddle/agents.rs
+++ b/desktop/src-tauri/src/huddle/agents.rs
@@ -17,21 +17,34 @@ use crate::{app_state::AppState, events, relay::submit_event};
 
 /// Voice-mode guidelines posted as kind:48106 (huddle guidelines) to the
 /// ephemeral channel at huddle start. Agents see them via EOSE replay.
-/// Instructs agents on voice-mode etiquette: TTS constraints, brevity, self-selection.
+/// Instructs agents on voice-mode etiquette: TTS constraints, brevity,
+/// self-selection, and sentence-at-a-time delivery.
+///
+/// Why sentence-at-a-time: the desktop speaks each agent message as it
+/// arrives (queued, in order), so an agent that sends its first sentence
+/// immediately — then the rest as separate messages — cuts time-to-first-
+/// audio from "full reply generated" to "first sentence generated". This is
+/// the prompt-level equivalent of token streaming, with no harness changes.
+///
 /// Build voice-mode guidelines with the parent channel ID so agents know
 /// where "the main channel" is.
 pub fn voice_mode_guidelines(parent_channel_id: &str) -> String {
     format!(
         "\
 You are in a live voice huddle attached to channel {parent_channel_id}.
-Your text is read aloud via TTS. You will be interrupted when humans speak — this is normal.
+Your text is read aloud via TTS, message by message, in the order sent.
+
+Latency matters most: send your FIRST sentence as its own message the moment
+you've formed it — it is what breaks the silence. If you have more to say,
+send each following sentence as its own separate message. Never hold a
+finished sentence back to bundle it with the next one.
 
 - If not addressed or relevant: do nothing. Do not respond.
-- One or two short sentences max. Start with the answer, no preamble.
+- Keep the whole reply short — a few sentences at most. Start with the answer, no preamble.
 - No markdown, code blocks, lists, or structured data — say it naturally.
 - To share code or detailed data: say \"I'll post that in the main channel\" and do so.
-- When tool results are long, summarize the key finding verbally.
-- If interrupted, continue naturally. No apologies.
+- When you need a tool, say one short sentence first (e.g. \"Let me check.\"), then run it, then summarize the key finding verbally.
+- If a new human message arrives mid-reply, you were interrupted: drop your unsent sentences and respond to the new message instead.
 - In multi-agent huddles, identify yourself only when needed.
 - Use your Buzz tools proactively when asked."
     )

--- a/desktop/src-tauri/src/huddle/agents.rs
+++ b/desktop/src-tauri/src/huddle/agents.rs
@@ -34,10 +34,12 @@ pub fn voice_mode_guidelines(parent_channel_id: &str) -> String {
 You are in a live voice huddle attached to channel {parent_channel_id}.
 Your text is read aloud via TTS, message by message, in the order sent.
 
-Latency matters most: send your FIRST sentence as its own message the moment
-you've formed it — it is what breaks the silence. If you have more to say,
-send each following sentence as its own separate message. Never hold a
-finished sentence back to bundle it with the next one.
+Latency matters most: reply IMMEDIATELY — do not compose your full reply
+before sending anything. The moment your first sentence is formed, send it
+as its own `buzz messages send` tool call: it is what breaks the silence.
+Then send each following sentence the same way — one sentence per separate
+`buzz messages send` call. Never hold a finished sentence back to bundle it
+with the next one.
 
 - If not addressed or relevant: do nothing. Do not respond.
 - Keep the whole reply short — a few sentences at most. Start with the answer, no preamble.


### PR DESCRIPTION
## What

Rewrites the kind:48106 voice-mode guidelines (posted to the ephemeral huddle channel at huddle start) to instruct agents to reply **one sentence per message**, sending the first sentence the moment it's formed.

## Why

Today the dominant term in mic-stop → first-audio is waiting for the agent's *complete* reply: TTS can't start until the full kind:9 lands, so the entire LLM generation (2–10s) sits in the silent gap.

The desktop already speaks each agent kind:9 as it arrives — queued (depth 8), in order, deduped by event ID (`useTtsSubscription` → `speak_agent_message`). So an agent that posts its first sentence immediately, then the rest as separate messages, cuts time-to-first-audio from "full reply generated" to "first sentence generated". This is the prompt-level equivalent of token streaming, with **zero harness or transport changes** — the deliberate alternative to SSE streaming in buzz-agent, which we're keeping minimal.

Guideline changes:
- sentence-per-message delivery, first sentence ASAP
- say one short sentence before running a tool, so tool turns aren't silent gaps
- a new human message mid-reply = interruption: drop unsent sentences instead of finishing the stale tail

## Risk

Prompt-only; degrades gracefully. If a model ignores the instruction and posts a multi-sentence message, TTS already splits sentences internally and plays it normally — we only lose the head start on that turn. No error mode.

## Verification

- `cargo test` (desktop-tauri, full): 518/518 ✓
- `cargo clippy -D warnings` ✓
- Pre-push hooks (desktop/mobile/rust tests + clippy) ✓

## Follow-ups (separate PRs)

- Latency instrumentation: per-stage timestamps mic-stop → first-audio
- Barge-in gate: after interrupt, mute the TTS subscription until the user's next transcript posts (otherwise the agent's late sentences re-trigger TTS)

Context: discussed in #sprout-conversational-agents — replaces the Concierge-destination approach from #910 (closed) with huddle-first latency work.
