### PR TITLE
Refine app loading skeletons

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -184,6 +184,7 @@ export function AppShell() {
     React.useState(false);
   const [searchFocusRequest, setSearchFocusRequest] = React.useState(0);
   const [topbarSearchHidden, setTopbarSearchHidden] = React.useState(false);
+  const [topbarSearchLoading, setTopbarSearchLoading] = React.useState(false);
   const [browseDialogType, setBrowseDialogType] =
     React.useState<BrowseDialogType>(null);
   const [isNewDmOpen, setIsNewDmOpen] = React.useState(false);
@@ -743,6 +744,7 @@ export function AppShell() {
             isFollowingThread,
             isNotifiedForThread,
             setTopbarSearchHidden,
+            setTopbarSearchLoading,
             threadActivityItems,
           }}
         >
@@ -762,6 +764,7 @@ export function AppShell() {
                     }}
                     onOpenResult={handleOpenSearchResult}
                     searchHidden={topbarSearchHidden}
+                    searchLoading={topbarSearchLoading}
                     searchFocusRequest={searchFocusRequest}
                   />
                 ) : null}

--- a/desktop/src/app/AppShellContext.tsx
+++ b/desktop/src/app/AppShellContext.tsx
@@ -22,6 +22,7 @@ type AppShellContextValue = {
   isFollowingThread: (rootId: string) => boolean;
   isNotifiedForThread: (rootId: string) => boolean;
   setTopbarSearchHidden: (hidden: boolean) => void;
+  setTopbarSearchLoading: (loading: boolean) => void;
   threadActivityItems: ThreadActivityItem[];
 };
 
@@ -38,6 +39,7 @@ const AppShellContext = React.createContext<AppShellContextValue>({
   isFollowingThread: () => false,
   isNotifiedForThread: () => false,
   setTopbarSearchHidden: () => {},
+  setTopbarSearchLoading: () => {},
   threadActivityItems: [],
 });
 

--- a/desktop/src/app/AppTopChrome.tsx
+++ b/desktop/src/app/AppTopChrome.tsx
@@ -2,8 +2,10 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { TopbarSearch } from "@/features/search/ui/TopbarSearch";
 import type { Channel, SearchHit } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { SidebarTrigger, useSidebar } from "@/shared/ui/sidebar";
+import { Skeleton } from "@/shared/ui/skeleton";
 
 type AppTopChromeProps = {
   canGoBack: boolean;
@@ -16,6 +18,7 @@ type AppTopChromeProps = {
   onOpenResult: (hit: SearchHit) => void;
   searchHidden?: boolean;
   searchFocusRequest: number;
+  searchLoading?: boolean;
 };
 
 function GlobalTopDivider() {
@@ -39,6 +42,7 @@ function CenterColumnTopbarSearch({
   onOpenChannel,
   onOpenResult,
   searchFocusRequest,
+  searchLoading = false,
 }: Pick<
   AppTopChromeProps,
   | "channels"
@@ -46,8 +50,11 @@ function CenterColumnTopbarSearch({
   | "onOpenChannel"
   | "onOpenResult"
   | "searchFocusRequest"
+  | "searchLoading"
 >) {
   const { isResizing, state } = useSidebar();
+  const searchClassName =
+    "pointer-events-auto w-[220px] max-w-full md:w-[300px] lg:w-[360px] xl:w-[420px] 2xl:w-[480px]";
 
   return (
     <div
@@ -59,20 +66,30 @@ function CenterColumnTopbarSearch({
         right: 0,
       }}
     >
-      <TopbarSearch
-        channels={channels}
-        className="pointer-events-auto w-[220px] max-w-full md:w-[300px] lg:w-[360px] xl:w-[420px] 2xl:w-[480px]"
-        currentPubkey={currentPubkey}
-        focusRequest={searchFocusRequest}
-        onOpenChannel={onOpenChannel}
-        onOpenResult={onOpenResult}
-      />
+      {searchLoading ? (
+        <div
+          aria-hidden="true"
+          className={cn("h-7", searchClassName)}
+          data-testid="topbar-search-loading"
+        >
+          <Skeleton className="h-full w-full rounded-lg" />
+        </div>
+      ) : (
+        <TopbarSearch
+          channels={channels}
+          className={searchClassName}
+          currentPubkey={currentPubkey}
+          focusRequest={searchFocusRequest}
+          onOpenChannel={onOpenChannel}
+          onOpenResult={onOpenResult}
+        />
+      )}
     </div>
   );
 }
 
 const TOP_CHROME_ICON_BUTTON_CLASS =
-  "rounded-[4px] text-muted-foreground/70 hover:bg-border/45 hover:text-foreground";
+  "h-7 w-7 rounded-[4px] text-muted-foreground/70 hover:bg-border/45 hover:text-foreground [&_svg]:size-4";
 
 export function AppTopChrome({
   canGoBack,
@@ -85,6 +102,7 @@ export function AppTopChrome({
   onOpenResult,
   searchHidden = false,
   searchFocusRequest,
+  searchLoading = false,
 }: AppTopChromeProps) {
   return (
     <>
@@ -94,7 +112,7 @@ export function AppTopChrome({
         data-tauri-drag-region
       />
       <GlobalTopDivider />
-      <div className="fixed left-[80px] top-[9px] z-45 flex items-center gap-0.5">
+      <div className="fixed left-[80px] top-[6px] z-45 flex items-center gap-0.5">
         <SidebarTrigger className={TOP_CHROME_ICON_BUTTON_CLASS} />
         <Button
           aria-label="Go back"
@@ -126,6 +144,7 @@ export function AppTopChrome({
           onOpenChannel={onOpenChannel}
           onOpenResult={onOpenResult}
           searchFocusRequest={searchFocusRequest}
+          searchLoading={searchLoading}
         />
       )}
     </>

--- a/desktop/src/features/agent-memory/ui/MemorySection.tsx
+++ b/desktop/src/features/agent-memory/ui/MemorySection.tsx
@@ -85,7 +85,7 @@ export function MemoryRefreshButton({
     >
       <RefreshCw
         className={cn(
-          iconClassName ?? "h-3.5 w-3.5",
+          iconClassName ?? "h-4 w-4",
           query.isFetching && "animate-spin",
         )}
       />
@@ -169,7 +169,7 @@ function MemoryErrorState({
       role="alert"
     >
       <div className="flex items-start gap-2">
-        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-destructive" />
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
         <div className="space-y-1">
           <div className="font-medium text-destructive">
             Couldn't load memory
@@ -196,7 +196,7 @@ function MemoryStaleErrorBanner({ onRetry }: { onRetry: () => void }) {
       className="mb-2 flex items-center gap-2 rounded-md border border-warning/30 bg-warning/5 px-2 py-1.5 text-xs"
       data-testid="agent-memory-stale-error"
     >
-      <AlertTriangle className="h-3 w-3 shrink-0 text-warning" />
+      <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
       <span className="flex-1 text-muted-foreground">Refresh failed.</span>
       <button
         className="font-medium text-warning hover:underline"
@@ -511,7 +511,7 @@ function MemoryEntryAccordion({
           ref={titleRef}
         >
           {hasDanglingRefs ? (
-            <AlertTriangle className="mr-1 inline-block h-3.5 w-3.5 align-[-2px] text-warning" />
+            <AlertTriangle className="mr-1 inline-block h-4 w-4 align-[-2px] text-warning" />
           ) : null}
           <MemorySlugTitle slug={entry.slug} />
         </div>

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -81,7 +81,7 @@ export function ToolItem({
             </span>
           ) : null}
           <ToolTimestamp item={item} />
-          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
         </summary>
 
         <ToolDetailBlocks
@@ -272,7 +272,7 @@ function BuzzToolInlineAction({
         {action.avatar}
         <span className="shrink-0">{action.label}</span>
         <span className="truncate">{action.value}</span>
-        <ArrowUpRight className="h-3 w-3 shrink-0" />
+        <ArrowUpRight className="h-4 w-4 shrink-0" />
       </button>
     );
   }

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -27,7 +27,7 @@ export function AgentSessionTranscriptList({
   if (items.length === 0) {
     return (
       <div className="flex min-h-56 flex-col items-center justify-center px-6 py-10 text-center">
-        <Radio className="mx-auto h-5 w-5 text-muted-foreground" />
+        <Radio className="mx-auto h-4 w-4 text-muted-foreground" />
         <p className="mt-3 text-sm font-medium">No ACP activity yet</p>
         <p className="mt-1 text-sm text-muted-foreground">{emptyDescription}</p>
       </div>
@@ -126,7 +126,7 @@ function MessageItem({
         {isAssistant ? (
           <div className="mb-0.5 flex items-center gap-1 text-xs">
             <span className="flex h-5 w-5 items-center justify-center">
-              <Bot className="h-3.5 w-3.5 text-muted-foreground" />
+              <Bot className="h-4 w-4 text-muted-foreground" />
             </span>
             <span className="font-normal text-foreground">{agentName}</span>
             <TranscriptTimestamp timestamp={item.timestamp} />
@@ -163,7 +163,7 @@ function ThoughtItem({
         <Brain className="h-4 w-4" />
         <span className="truncate text-sm font-medium">{item.title}</span>
         <TranscriptTimestamp timestamp={item.timestamp} />
-        <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180" />
+        <ChevronDown className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180" />
       </summary>
       <div className="py-2 pl-5 text-sm leading-6 text-muted-foreground">
         <Markdown compact content={item.text.trim() || " "} />
@@ -186,7 +186,7 @@ function MetadataItem({
           {item.sections.length} section{item.sections.length === 1 ? "" : "s"}
         </span>
         <TranscriptTimestamp timestamp={item.timestamp} />
-        <ChevronDown className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180" />
+        <ChevronDown className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180" />
       </summary>
       <div className="space-y-3 py-2 pl-5">
         {item.sections.map((section) => (
@@ -196,7 +196,7 @@ function MetadataItem({
           >
             <summary className="inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 text-xs font-medium text-foreground/80">
               <span className="truncate">{section.title}</span>
-              <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open/section:rotate-180" />
+              <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open/section:rotate-180" />
             </summary>
             <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-3 py-2 font-mono text-[11px] leading-5 text-muted-foreground">
               {section.body.trim() || "No metadata."}

--- a/desktop/src/features/agents/ui/BatchImportDialog.tsx
+++ b/desktop/src/features/agents/ui/BatchImportDialog.tsx
@@ -213,12 +213,12 @@ export function BatchImportDialog({
                   onClick={() => setSkippedExpanded((prev) => !prev)}
                   type="button"
                 >
-                  <AlertTriangle className="h-3.5 w-3.5" />
+                  <AlertTriangle className="h-4 w-4" />
                   {skipped.length} file{skipped.length !== 1 ? "s" : ""} skipped
                   {skippedExpanded ? (
-                    <ChevronDown className="h-3.5 w-3.5" />
+                    <ChevronDown className="h-4 w-4" />
                   ) : (
-                    <ChevronRight className="h-3.5 w-3.5" />
+                    <ChevronRight className="h-4 w-4" />
                   )}
                 </button>
                 {skippedExpanded ? (

--- a/desktop/src/features/agents/ui/CopyButton.tsx
+++ b/desktop/src/features/agents/ui/CopyButton.tsx
@@ -20,7 +20,7 @@ export function CopyButton({
       type="button"
       variant="outline"
     >
-      <Copy className="h-3.5 w-3.5" />
+      <Copy className="h-4 w-4" />
       <span>{label ?? "Copy"}</span>
     </Button>
   );

--- a/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
@@ -3,7 +3,6 @@ import {
   CircleAlert,
   CircleDot,
   Clock3,
-  Loader2,
   TerminalSquare,
   XCircle,
 } from "lucide-react";
@@ -14,6 +13,7 @@ import type { ManagedAgent } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { Badge } from "@/shared/ui/badge";
 import { Skeleton } from "@/shared/ui/skeleton";
+import { Spinner } from "@/shared/ui/spinner";
 import { AgentSessionTranscriptList } from "./AgentSessionTranscriptList";
 import { RawEventRail } from "./RawEventRail";
 import type {
@@ -229,7 +229,7 @@ function ObserverStatusBadge({ state }: { state: ConnectionState }) {
     state === "open"
       ? { label: "Live", Icon: CircleDot, variant: "default" as const }
       : state === "connecting"
-        ? { label: "Connecting", Icon: Loader2, variant: "secondary" as const }
+        ? { label: "Connecting", variant: "secondary" as const }
         : state === "error"
           ? {
               label: "Unavailable",
@@ -239,12 +239,15 @@ function ObserverStatusBadge({ state }: { state: ConnectionState }) {
           : state === "closed"
             ? { label: "Closed", Icon: Clock3, variant: "secondary" as const }
             : { label: "Idle", Icon: Clock3, variant: "secondary" as const };
+  const StatusIcon = display.Icon;
 
   return (
     <Badge className="gap-1.5" variant={display.variant}>
-      <display.Icon
-        className={cn("h-3.5 w-3.5", state === "connecting" && "animate-spin")}
-      />
+      {StatusIcon ? (
+        <StatusIcon aria-hidden className="h-4 w-4" />
+      ) : (
+        <Spinner aria-hidden className="h-4 w-4 border-2" />
+      )}
       {display.label}
     </Badge>
   );
@@ -253,7 +256,7 @@ function ObserverStatusBadge({ state }: { state: ConnectionState }) {
 function EmptyObserverState() {
   return (
     <div className="mt-4 flex min-h-48 flex-col items-center justify-center px-6 py-8 text-center">
-      <TerminalSquare className="mx-auto h-5 w-5 text-muted-foreground" />
+      <TerminalSquare className="mx-auto h-4 w-4 text-muted-foreground" />
       <p className="mt-3 text-sm font-medium">Observer not attached</p>
       <p className="mt-1 text-sm text-muted-foreground">
         The live feed is available for local agents started after this update.

--- a/desktop/src/features/agents/ui/ModelPicker.tsx
+++ b/desktop/src/features/agents/ui/ModelPicker.tsx
@@ -93,7 +93,7 @@ export function ModelPicker({
             variant="ghost"
           >
             <span className="truncate">{displayLabel}</span>
-            <ChevronDown className="h-3 w-3 text-muted-foreground" />
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -103,7 +103,7 @@ export function ModelPicker({
         >
           {loading ? (
             <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
-              <Spinner className="h-3.5 w-3.5" />
+              <Spinner className="h-4 w-4 border-2" />
               Loading models...
             </div>
           ) : error ? (

--- a/desktop/src/features/agents/ui/PersonaCatalogSelectionBadge.tsx
+++ b/desktop/src/features/agents/ui/PersonaCatalogSelectionBadge.tsx
@@ -20,7 +20,7 @@ export function PersonaCatalogSelectionBadge({
           : "border border-border/70 bg-background/85 text-muted-foreground",
       )}
     >
-      {isActive ? <Check className="h-3 w-3" /> : null}
+      {isActive ? <Check className="h-4 w-4" /> : null}
       {isActive
         ? personaCatalogCopy.selectedState
         : personaCatalogCopy.availableState}

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -497,12 +497,12 @@ export function PersonaDialog({
                         : undefined
                     }
                   >
-                    <Upload className="h-3.5 w-3.5" />
+                    <Upload className="h-4 w-4" />
                     <span className="max-w-[16rem] truncate">
                       {importButtonLabel}
                     </span>
                     {isImportingUpdate ? (
-                      <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                      <RefreshCw className="h-4 w-4 animate-spin" />
                     ) : null}
                   </button>
                 </>

--- a/desktop/src/features/agents/ui/PersonaIdentity.tsx
+++ b/desktop/src/features/agents/ui/PersonaIdentity.tsx
@@ -46,7 +46,7 @@ export function PersonaIdentity({
                     className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
                     type="button"
                   >
-                    <Info className="h-3.5 w-3.5" />
+                    <Info className="h-4 w-4" />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom" className="max-w-xs">

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -258,7 +258,7 @@ function AllowlistPicker({
                   onClick={() => onRemove(pubkey)}
                   type="button"
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-4 w-4" />
                 </button>
               </div>
             ))}

--- a/desktop/src/features/agents/ui/TeamDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamDialog.tsx
@@ -475,12 +475,12 @@ export function TeamDialog({
                           : undefined
                       }
                     >
-                      <Upload className="h-3.5 w-3.5" />
+                      <Upload className="h-4 w-4" />
                       <span className="max-w-[16rem] truncate">
                         {importButtonLabel}
                       </span>
                       {isImportingUpdate ? (
-                        <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                        <RefreshCw className="h-4 w-4 animate-spin" />
                       ) : null}
                     </button>
                   </>

--- a/desktop/src/features/agents/ui/TeamImportDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamImportDialog.tsx
@@ -130,7 +130,7 @@ export function TeamImportDialog({
           {preview ? (
             <div className="space-y-4">
               <div className="flex items-center gap-3 rounded-lg border border-border/60 bg-card/80 px-4 py-3">
-                <Users className="h-5 w-5 shrink-0 text-muted-foreground" />
+                <Users className="h-4 w-4 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
                   <p className="text-sm font-semibold tracking-tight">
                     {preview.name}

--- a/desktop/src/features/agents/ui/TeamsSection.tsx
+++ b/desktop/src/features/agents/ui/TeamsSection.tsx
@@ -108,7 +108,7 @@ export function TeamsSection({
             onClick={onInstallFromDirectory}
             type="button"
           >
-            <FolderOpen className="h-3.5 w-3.5" />
+            <FolderOpen className="h-4 w-4" />
             Install from directory
           </button>
           <CreateNewButton
@@ -161,7 +161,7 @@ export function TeamsSection({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-                              <Link className="h-3.5 w-3.5" />
+                              <Link className="h-4 w-4" />
                             </span>
                           </TooltipTrigger>
                           <TooltipContent side="bottom" className="max-w-xs">
@@ -184,7 +184,7 @@ export function TeamsSection({
                               className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
                               type="button"
                             >
-                              <Info className="h-3.5 w-3.5" />
+                              <Info className="h-4 w-4" />
                             </button>
                           </TooltipTrigger>
                           <TooltipContent side="bottom" className="max-w-xs">

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -19,7 +19,6 @@ import type {
 } from "@/shared/api/types";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
-import { Card } from "@/shared/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -329,7 +328,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
             size="sm"
             variant="ghost"
           >
-            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+            <Trash2 className="mr-1.5 h-4 w-4" />
             Remove stopped
           </Button>
         </div>
@@ -471,18 +470,72 @@ function SectionHeader({
 
 function LoadingSkeleton() {
   return (
-    <Card className="overflow-hidden">
-      {["a", "b", "c"].map((k) => (
+    <div className="space-y-3">
+      {["a", "b", "c"].map((k, index) => (
         <div
-          className="flex items-center gap-4 border-b border-border/60 px-4 py-3 last:border-b-0"
+          className="overflow-hidden rounded-xl border border-border/70 bg-card/40"
           key={k}
         >
-          <Skeleton className="h-8 w-8 rounded-lg" />
-          <Skeleton className="h-4 w-28" />
-          <Skeleton className="h-5 w-16 rounded-full" />
+          <div className="flex items-center gap-2 px-3 py-2">
+            <div className="flex min-w-0 flex-1 items-center gap-2 py-1">
+              <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+              <Skeleton className="h-8 w-8 shrink-0 rounded-lg" />
+              <div className="flex min-w-0 items-center gap-2">
+                <Skeleton className={index === 2 ? "h-4 w-36" : "h-4 w-32"} />
+                <Skeleton className="h-5 w-14 rounded-full" />
+              </div>
+              <Skeleton className="ml-1 h-3 w-20 shrink-0" />
+            </div>
+            {index === 1 ? (
+              <Skeleton className="h-5 w-16 rounded-full" />
+            ) : null}
+            <Skeleton className="h-8 w-8 shrink-0 rounded-lg" />
+          </div>
+          <div className="divide-y divide-border/50 border-t border-border/50">
+            <div className="flex items-start gap-3 px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="grid gap-3 lg:grid-cols-[minmax(0,1.8fr)_minmax(120px,0.8fr)_minmax(0,1.1fr)] lg:gap-4">
+                  <div className="min-w-0">
+                    <div className="flex items-start gap-3">
+                      <Skeleton className="mt-0.5 h-4 w-4 shrink-0 rounded-sm" />
+                      <Skeleton className="mt-1 h-2 w-2 shrink-0 rounded-full" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Skeleton className="h-4 w-36" />
+                          <Skeleton className="h-5 w-16 rounded-full" />
+                        </div>
+                        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+                          <Skeleton className="h-3 w-20" />
+                          <Skeleton className="h-3 w-24" />
+                        </div>
+                        {index === 0 ? (
+                          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                            <Skeleton className="h-5 w-20 rounded-full" />
+                            <Skeleton className="h-5 w-24 rounded-full" />
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Skeleton className="h-5 w-20 rounded-full" />
+                    <Skeleton className="h-3 w-24" />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Skeleton className="h-4 w-28" />
+                    <Skeleton className="h-3 w-20" />
+                  </div>
+                </div>
+              </div>
+              <div className="flex shrink-0 items-start gap-2 lg:pt-0.5">
+                <Skeleton className="h-7 w-24 rounded-md" />
+                <Skeleton className="h-7 w-7 rounded-md" />
+              </div>
+            </div>
+          </div>
         </div>
       ))}
-    </Card>
+    </div>
   );
 }
 

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -530,7 +530,7 @@ export function AddChannelBotDialog({
                 variant="ghost"
               >
                 <span className="truncate">{runtimeTriggerLabel}</span>
-                <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent

--- a/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
@@ -54,7 +54,7 @@ function SelectionChipButton({
               ? "bg-primary/20 text-primary ring-1 ring-primary/20"
               : "bg-background/80 text-muted-foreground ring-1 ring-border/70",
           )}
-          iconClassName="h-3.5 w-3.5"
+          iconClassName="h-4 w-4"
           label={label}
         />
       ) : null}
@@ -193,7 +193,7 @@ export function AddChannelBotPersonasSection({
                         <ProfileAvatar
                           avatarUrl={persona.avatarUrl}
                           className="h-7 w-7 text-[10px] bg-primary-foreground/20 text-primary-foreground"
-                          iconClassName="h-3.5 w-3.5"
+                          iconClassName="h-4 w-4"
                           label={persona.displayName}
                         />
                         <p className="font-medium">{persona.displayName}</p>

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -102,7 +102,7 @@ export function AgentSessionThreadPanel({
               type="button"
               variant="outline"
             >
-              <Octagon className="h-3 w-3" />
+              <Octagon className="h-4 w-4" />
               Stop
             </Button>
           </TooltipTrigger>

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -201,7 +201,7 @@ export function BotActivityComposerAction({
             {isInline ? <Shimmer>{visibleStatusLabel}</Shimmer> : "working"}
           </span>
           {isInline ? null : (
-            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin opacity-70" />
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" />
           )}
         </button>
       </PopoverTrigger>
@@ -244,7 +244,7 @@ export function BotActivityComposerAction({
                   displayName={agent.name}
                 />
                 <span className="min-w-0 flex-1 truncate">{agent.name}</span>
-                <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground/70" />
+                <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />
               </button>
             );
           })}

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -125,7 +125,7 @@ export function ChannelBrowserDialog({
       ? archivedChannels
       : activeTab === "joined"
         ? joinedChannels
-        : currentChannels;
+        : matchingChannels;
 
   const orderedVisibleChannels = React.useMemo(
     () => [
@@ -321,10 +321,10 @@ export function ChannelBrowserDialog({
                 if (
                   event.key === "Enter" &&
                   !event.nativeEvent.isComposing &&
-                  selectedItem
+                  orderedVisibleChannels.length > 0
                 ) {
                   event.preventDefault();
-                  handleSelect(selectedItem);
+                  handleSelect(selectedItem ?? orderedVisibleChannels[0]);
                 }
               }}
               placeholder={searchPlaceholder}
@@ -455,11 +455,14 @@ function ChannelCard({
           ? "group/channel-row flex min-h-16 items-center gap-4 bg-muted/40 px-4 py-3 transition-colors duration-150 ease-out"
           : "group/channel-row flex min-h-16 items-center gap-4 px-4 py-3 transition-colors duration-150 ease-out hover:bg-muted/40"
       }
+      data-testid={`browse-channel-${channel.name}`}
     >
       <button
         className="min-w-0 flex-1 border-0 bg-transparent p-0 text-left text-foreground outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-        data-testid={`browse-channel-${channel.name}`}
-        onClick={onSelect}
+        onClick={(event) => {
+          event.stopPropagation();
+          onSelect();
+        }}
         type="button"
       >
         <div className="min-w-0">

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -1,52 +1,20 @@
 import * as React from "react";
-import {
-  Compass,
-  FileText,
-  Hash,
-  LogIn,
-  Search,
-  Users,
-  type LucideIcon,
-} from "lucide-react";
+import { Compass, Search, X, type LucideIcon } from "lucide-react";
 
 import type { Channel } from "@/shared/api/types";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
 import { Badge } from "@/shared/ui/badge";
-import { Input } from "@/shared/ui/input";
 import { Button } from "@/shared/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 
 const BROWSE_CHANNELS_SHORTCUT_HINT = "\u21E7\u2318O";
-
-function formatRelativeTime(isoString: string | null) {
-  if (!isoString) {
-    return "No activity";
-  }
-
-  const diff = Math.floor((Date.now() - new Date(isoString).getTime()) / 1_000);
-
-  if (diff < 60) {
-    return "just now";
-  }
-
-  if (diff < 60 * 60) {
-    return `${Math.floor(diff / 60)}m ago`;
-  }
-
-  if (diff < 60 * 60 * 24) {
-    return `${Math.floor(diff / (60 * 60))}h ago`;
-  }
-
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-  }).format(new Date(isoString));
-}
+type BrowserTab = "all" | "joined" | "archived";
 
 function BrowseState({
   icon: Icon,
@@ -60,7 +28,7 @@ function BrowseState({
   return (
     <div className="flex flex-col items-center justify-center px-6 py-16 text-center">
       <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-        <Icon className="h-5 w-5" />
+        <Icon className="h-4 w-4" />
       </div>
       <p className="mt-4 text-base font-semibold tracking-tight">{title}</p>
       <p className="mt-2 max-w-md text-sm text-muted-foreground">
@@ -88,24 +56,35 @@ export function ChannelBrowserDialog({
   onSelectChannel,
 }: ChannelBrowserDialogProps) {
   const [query, setQuery] = React.useState("");
-  const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const [activeTab, setActiveTab] = React.useState<BrowserTab>("all");
+  const [selectedIndex, setSelectedIndex] = React.useState<number | null>(null);
   const [joiningChannelId, setJoiningChannelId] = React.useState<string | null>(
     null,
   );
+  const contentRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const tabListRef = React.useRef<HTMLDivElement>(null);
+  const tabTriggerRefs = React.useRef<
+    Record<BrowserTab, HTMLButtonElement | null>
+  >({
+    all: null,
+    joined: null,
+    archived: null,
+  });
+  const [tabIndicator, setTabIndicator] = React.useState({
+    left: 0,
+    width: 0,
+  });
   const deferredQuery = React.useDeferredValue(query.trim().toLowerCase());
 
   const isForumMode = channelTypeFilter === "forum";
   const browseTitle = isForumMode ? "Browse Forums" : "Browse Channels";
-  const browseDescription = isForumMode
-    ? "Discover and join open forums."
-    : "Discover and join open channels.";
   const searchPlaceholder = isForumMode
     ? "Search forums by name or description"
     : "Search channels by name or description";
   const entityLabel = isForumMode ? "forum" : "channel";
 
-  const browsableChannels = React.useMemo(() => {
+  const matchingChannels = React.useMemo(() => {
     const filtered = channels.filter(
       (channel) =>
         channel.channelType !== "dm" &&
@@ -126,53 +105,114 @@ export function ChannelBrowserDialog({
     );
   }, [channels, channelTypeFilter, deferredQuery]);
 
-  const notJoined = React.useMemo(
-    () => browsableChannels.filter((channel) => !channel.isMember),
-    [browsableChannels],
+  const currentChannels = React.useMemo(
+    () => matchingChannels.filter((channel) => channel.archivedAt === null),
+    [matchingChannels],
   );
 
-  const joined = React.useMemo(
-    () => browsableChannels.filter((channel) => channel.isMember),
-    [browsableChannels],
-  );
-  const hasArchivedJoinedChannels = React.useMemo(
-    () => joined.some((channel) => channel.archivedAt !== null),
-    [joined],
+  const joinedChannels = React.useMemo(
+    () => currentChannels.filter((channel) => channel.isMember),
+    [currentChannels],
   );
 
-  // Flat list for keyboard navigation: not-joined first, then joined
-  const allItems = React.useMemo(
-    () => [...notJoined, ...joined],
-    [notJoined, joined],
+  const archivedChannels = React.useMemo(
+    () => matchingChannels.filter((channel) => channel.archivedAt !== null),
+    [matchingChannels],
   );
+
+  const visibleChannels =
+    activeTab === "archived"
+      ? archivedChannels
+      : activeTab === "joined"
+        ? joinedChannels
+        : currentChannels;
+
+  const orderedVisibleChannels = React.useMemo(
+    () => [
+      ...visibleChannels.filter((channel) => !channel.isMember),
+      ...visibleChannels.filter((channel) => channel.isMember),
+    ],
+    [visibleChannels],
+  );
+
+  const allTabLabel = isForumMode ? "All forums" : "All channels";
+
+  const updateTabIndicator = React.useCallback(() => {
+    const list = tabListRef.current;
+    const trigger = tabTriggerRefs.current[activeTab];
+
+    if (!open || !list || !trigger) {
+      return;
+    }
+
+    const nextIndicator = {
+      left: trigger.offsetLeft,
+      width: trigger.offsetWidth,
+    };
+
+    setTabIndicator((current) =>
+      Math.abs(current.left - nextIndicator.left) < 0.5 &&
+      Math.abs(current.width - nextIndicator.width) < 0.5
+        ? current
+        : nextIndicator,
+    );
+  }, [activeTab, open]);
+
+  React.useLayoutEffect(() => {
+    updateTabIndicator();
+
+    if (!open) {
+      return;
+    }
+
+    let isCancelled = false;
+    const updateIfActive = () => {
+      if (!isCancelled) {
+        updateTabIndicator();
+      }
+    };
+    const frameId = window.requestAnimationFrame(updateIfActive);
+    const observer = new ResizeObserver(updateTabIndicator);
+    const list = tabListRef.current;
+
+    void document.fonts.ready.then(updateIfActive);
+
+    if (list) {
+      observer.observe(list);
+    }
+
+    for (const trigger of Object.values(tabTriggerRefs.current)) {
+      if (trigger) {
+        observer.observe(trigger);
+      }
+    }
+
+    return () => {
+      isCancelled = true;
+      window.cancelAnimationFrame(frameId);
+      observer.disconnect();
+    };
+  }, [open, updateTabIndicator]);
 
   React.useEffect(() => {
     if (!open) {
       setQuery("");
-      setSelectedIndex(0);
+      setActiveTab("all");
+      setSelectedIndex(null);
       setJoiningChannelId(null);
       return;
     }
-
-    const timeout = window.setTimeout(() => {
-      inputRef.current?.focus();
-      inputRef.current?.select();
-    }, 0);
-
-    return () => {
-      window.clearTimeout(timeout);
-    };
   }, [open]);
 
   React.useEffect(() => {
     setSelectedIndex((current) => {
-      if (allItems.length === 0) {
-        return 0;
+      if (current === null || orderedVisibleChannels.length === 0) {
+        return null;
       }
 
-      return Math.min(current, allItems.length - 1);
+      return Math.min(current, orderedVisibleChannels.length - 1);
     });
-  }, [allItems]);
+  }, [orderedVisibleChannels]);
 
   async function handleJoin(channelId: string) {
     setJoiningChannelId(channelId);
@@ -191,45 +231,90 @@ export function ChannelBrowserDialog({
     onSelectChannel(channel.id);
   }
 
-  const selectedItem = allItems[selectedIndex];
+  const selectedItem =
+    selectedIndex !== null ? orderedVisibleChannels[selectedIndex] : undefined;
+  const emptyTitle =
+    deferredQuery.length > 0
+      ? `No ${entityLabel}s match your search`
+      : activeTab === "archived"
+        ? `No archived ${entityLabel}s`
+        : activeTab === "joined"
+          ? `No joined ${entityLabel}s`
+          : `No ${entityLabel}s to browse`;
+  const emptyDescription =
+    deferredQuery.length > 0
+      ? "Try a different name or keyword."
+      : activeTab === "archived"
+        ? `Archived ${entityLabel}s you have joined will appear here.`
+        : activeTab === "joined"
+          ? `${entityLabel[0].toUpperCase()}${entityLabel.slice(1)}s you join will appear here.`
+          : `All open ${entityLabel}s are available in the sidebar. Create a new ${entityLabel} to get started.`;
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent
-        className="gap-0 overflow-hidden p-0"
+        aria-describedby={undefined}
+        className="gap-0 overflow-hidden border-0 px-6 pb-0 pt-6"
         data-testid={
           isForumMode ? "forum-browser-dialog" : "channel-browser-dialog"
         }
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          contentRef.current?.focus();
+        }}
+        ref={contentRef}
+        showCloseButton={false}
       >
-        <DialogHeader className="border-b border-border/80 px-6 py-5">
-          <DialogTitle className="flex items-center gap-3">
-            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-xs">
-              <Compass className="h-4 w-4" />
-            </span>
-            {browseTitle}
-          </DialogTitle>
-          <DialogDescription>{browseDescription}</DialogDescription>
-          <div className="mt-4 flex items-center gap-3 rounded-2xl border border-input bg-card px-3 py-3 shadow-xs">
-            <Search className="h-4 w-4 text-muted-foreground" />
-            <Input
-              className="h-auto border-0 bg-transparent px-0 py-0 text-base shadow-none focus-visible:ring-0"
+        <DialogHeader className="space-y-0 pb-5">
+          <div className="flex items-center justify-between gap-4">
+            <DialogTitle>{browseTitle}</DialogTitle>
+            <DialogClose className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 ease-out hover:bg-accent hover:text-accent-foreground focus:outline-hidden focus:ring-1 focus:ring-ring">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </DialogClose>
+          </div>
+          <label
+            className="mt-4 flex cursor-text items-center gap-3 rounded-xl border border-input bg-background px-3 py-2.5 shadow-xs transition-colors duration-150 ease-out hover:border-muted-foreground/40 hover:bg-muted/70 focus-within:border-muted-foreground/50 focus-within:bg-muted/70 group/search"
+            htmlFor="channel-browser-search"
+          >
+            <Search className="h-4 w-4 shrink-0 text-muted-foreground/55 transition-colors duration-150 ease-out group-hover/search:text-muted-foreground group-focus-within/search:text-foreground" />
+            <input
+              autoCapitalize="none"
+              autoCorrect="off"
+              className="block h-6 min-w-0 flex-1 border-0 bg-transparent p-0 text-sm leading-5 text-muted-foreground/55 shadow-none caret-foreground outline-none transition-colors duration-150 ease-out placeholder:text-muted-foreground/55 group-hover/search:text-muted-foreground group-hover/search:placeholder:text-muted-foreground group-focus-within/search:text-foreground group-focus-within/search:placeholder:text-foreground"
               data-testid="channel-browser-search"
+              id="channel-browser-search"
               onChange={(event) => {
                 setQuery(event.target.value);
-                setSelectedIndex(0);
+                setSelectedIndex(null);
               }}
               onKeyDown={(event) => {
-                if (event.key === "ArrowDown" && allItems.length > 0) {
+                if (
+                  event.key === "ArrowDown" &&
+                  orderedVisibleChannels.length > 0
+                ) {
                   event.preventDefault();
                   setSelectedIndex((current) =>
-                    Math.min(current + 1, allItems.length - 1),
+                    current === null
+                      ? 0
+                      : Math.min(
+                          current + 1,
+                          orderedVisibleChannels.length - 1,
+                        ),
                   );
                   return;
                 }
 
-                if (event.key === "ArrowUp" && allItems.length > 0) {
+                if (
+                  event.key === "ArrowUp" &&
+                  orderedVisibleChannels.length > 0
+                ) {
                   event.preventDefault();
-                  setSelectedIndex((current) => Math.max(current - 1, 0));
+                  setSelectedIndex((current) =>
+                    current === null
+                      ? orderedVisibleChannels.length - 1
+                      : Math.max(current - 1, 0),
+                  );
                   return;
                 }
 
@@ -244,91 +329,102 @@ export function ChannelBrowserDialog({
               }}
               placeholder={searchPlaceholder}
               ref={inputRef}
+              spellCheck={false}
+              type="text"
               value={query}
             />
-            <span className="hidden shrink-0 text-xs text-muted-foreground/50 sm:block">
+            <span
+              className={`hidden shrink-0 text-xs text-muted-foreground/50 transition-opacity duration-150 ease-out group-focus-within/search:opacity-0 sm:block ${
+                query.length > 0 ? "opacity-0" : "opacity-100"
+              }`}
+            >
               {BROWSE_CHANNELS_SHORTCUT_HINT}
             </span>
-          </div>
+          </label>
         </DialogHeader>
 
-        <div className="max-h-[60vh] overflow-y-auto">
-          {browsableChannels.length === 0 ? (
-            deferredQuery.length > 0 ? (
-              <BrowseState
-                description="Try a different name or keyword."
-                icon={Search}
-                title={`No ${entityLabel}s match your search`}
-              />
-            ) : (
-              <BrowseState
-                description={`All open ${entityLabel}s are available in the sidebar. Create a new ${entityLabel} to get started.`}
-                icon={Compass}
-                title={`No ${entityLabel}s to browse`}
-              />
-            )
-          ) : (
-            <div className="p-3">
-              {notJoined.length > 0 ? (
-                <>
-                  <div className="mb-3 flex items-center justify-between px-2 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                    <span>
-                      {notJoined.length} {entityLabel}
-                      {notJoined.length !== 1 ? "s" : ""} to join
-                    </span>
-                    <span>Enter to view</span>
-                  </div>
-                  <div className="space-y-2">
-                    {notJoined.map((channel) => {
-                      const flatIndex = allItems.indexOf(channel);
-                      return (
-                        <ChannelCard
-                          channel={channel}
-                          isJoining={joiningChannelId === channel.id}
-                          isSelected={flatIndex === selectedIndex}
-                          key={channel.id}
-                          onJoin={() => {
-                            void handleJoin(channel.id);
-                          }}
-                          onMouseEnter={() => setSelectedIndex(flatIndex)}
-                          onSelect={() => handleSelect(channel)}
-                        />
-                      );
-                    })}
-                  </div>
-                </>
-              ) : null}
+        <div className="h-[min(60vh,30rem)] overflow-hidden">
+          <div className="flex h-full flex-col">
+            <Tabs
+              className="shrink-0"
+              onValueChange={(value) => {
+                setActiveTab(value as BrowserTab);
+                setSelectedIndex(null);
+              }}
+              value={activeTab}
+            >
+              <TabsList
+                className="relative h-auto w-full justify-start gap-6 rounded-none border-b border-border/70 bg-transparent p-0 text-muted-foreground"
+                ref={tabListRef}
+              >
+                <span
+                  aria-hidden="true"
+                  className="pointer-events-none absolute bottom-[-1px] left-0 h-0.5 w-px origin-left rounded-full bg-foreground opacity-0 transition-[transform,opacity] duration-[180ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none data-[ready=true]:opacity-100"
+                  data-ready={tabIndicator.width > 0}
+                  data-testid="channel-browser-tab-indicator"
+                  style={{
+                    transform: `translate3d(${tabIndicator.left}px, 0, 0) scaleX(${tabIndicator.width})`,
+                  }}
+                />
+                <TabsTrigger
+                  className="rounded-none border-b-2 border-transparent bg-transparent px-0 py-2 text-sm font-medium shadow-none transition-colors duration-150 ease-out data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                  ref={(element) => {
+                    tabTriggerRefs.current.all = element;
+                  }}
+                  value="all"
+                >
+                  {allTabLabel}
+                </TabsTrigger>
+                <TabsTrigger
+                  className="rounded-none border-b-2 border-transparent bg-transparent px-0 py-2 text-sm font-medium shadow-none transition-colors duration-150 ease-out data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                  ref={(element) => {
+                    tabTriggerRefs.current.joined = element;
+                  }}
+                  value="joined"
+                >
+                  Joined
+                </TabsTrigger>
+                <TabsTrigger
+                  className="rounded-none border-b-2 border-transparent bg-transparent px-0 py-2 text-sm font-medium shadow-none transition-colors duration-150 ease-out data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                  ref={(element) => {
+                    tabTriggerRefs.current.archived = element;
+                  }}
+                  value="archived"
+                >
+                  Archived
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
 
-              {joined.length > 0 ? (
-                <>
-                  <div className="mb-3 mt-4 flex items-center px-2 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                    <span>Joined</span>
-                  </div>
-                  <div className="space-y-2">
-                    {joined.map((channel) => {
-                      const flatIndex = allItems.indexOf(channel);
-                      return (
-                        <ChannelCard
-                          channel={channel}
-                          isJoining={false}
-                          isSelected={flatIndex === selectedIndex}
-                          key={channel.id}
-                          onMouseEnter={() => setSelectedIndex(flatIndex)}
-                          onSelect={() => handleSelect(channel)}
-                        />
-                      );
-                    })}
-                  </div>
-                </>
-              ) : null}
+            <div className="min-h-0 flex-1 overflow-y-auto pb-6 pt-4">
+              {orderedVisibleChannels.length === 0 ? (
+                <BrowseState
+                  description={emptyDescription}
+                  icon={deferredQuery.length > 0 ? Search : Compass}
+                  title={emptyTitle}
+                />
+              ) : (
+                <div className="overflow-hidden rounded-xl border border-border/70 bg-background/70 shadow-xs divide-y divide-border/55">
+                  {orderedVisibleChannels.map((channel, index) => (
+                    <ChannelCard
+                      channel={channel}
+                      isJoining={joiningChannelId === channel.id}
+                      isSelected={index === selectedIndex}
+                      key={channel.id}
+                      onJoin={
+                        !channel.isMember
+                          ? () => {
+                              void handleJoin(channel.id);
+                            }
+                          : undefined
+                      }
+                      onSelect={() => handleSelect(channel)}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
-          )}
-        </div>
-
-        <div className="border-t border-border/80 bg-card/50 px-6 py-3 text-xs text-muted-foreground">
-          {hasArchivedJoinedChannels
-            ? `Showing open ${entityLabel}s and your archived ${entityLabel}s. Private ${entityLabel}s require an invite.`
-            : `Showing open ${entityLabel}s. Private ${entityLabel}s require an invite.`}
+          </div>
         </div>
       </DialogContent>
     </Dialog>
@@ -340,80 +436,77 @@ function ChannelCard({
   isJoining,
   isSelected,
   onJoin,
-  onMouseEnter,
   onSelect,
 }: {
   channel: Channel;
   isJoining: boolean;
   isSelected: boolean;
   onJoin?: () => void;
-  onMouseEnter: () => void;
   onSelect: () => void;
 }) {
+  const memberLabel = `${channel.memberCount} ${
+    channel.memberCount === 1 ? "member" : "members"
+  }`;
+
   return (
-    <button
+    <div
       className={
         isSelected
-          ? "w-full rounded-2xl border border-primary/30 bg-primary/10 px-4 py-4 text-left shadow-xs outline-hidden transition-colors"
-          : "w-full rounded-2xl border border-border/80 bg-card/60 px-4 py-4 text-left shadow-xs outline-hidden transition-colors hover:border-primary/20 hover:bg-accent"
+          ? "group/channel-row flex min-h-16 items-center gap-4 bg-muted/40 px-4 py-3 transition-colors duration-150 ease-out"
+          : "group/channel-row flex min-h-16 items-center gap-4 px-4 py-3 transition-colors duration-150 ease-out hover:bg-muted/40"
       }
-      data-testid={`browse-channel-${channel.name}`}
-      onClick={onSelect}
-      onMouseEnter={onMouseEnter}
-      type="button"
     >
-      <div className="flex items-start gap-3">
-        <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl bg-secondary text-secondary-foreground">
-          {channel.channelType === "forum" ? (
-            <FileText className="h-4 w-4" />
-          ) : (
-            <Hash className="h-4 w-4" />
-          )}
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <p className="text-sm font-semibold tracking-tight">
+      <button
+        className="min-w-0 flex-1 border-0 bg-transparent p-0 text-left text-foreground outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+        data-testid={`browse-channel-${channel.name}`}
+        onClick={onSelect}
+        type="button"
+      >
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="shrink-0 text-sm font-normal text-muted-foreground">
+              #
+            </span>
+            <p className="min-w-0 truncate text-base font-medium tracking-tight">
               {channel.name}
             </p>
-            <Badge variant="secondary">{channel.channelType}</Badge>
             {channel.archivedAt ? (
-              <Badge variant="warning">archived</Badge>
+              <Badge className="ml-1 shrink-0" variant="warning">
+                archived
+              </Badge>
             ) : null}
-            <div className="ml-auto flex items-center gap-3">
-              <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                <Users className="h-3 w-3" />
-                {channel.memberCount}
-              </span>
-              <span className="text-xs text-muted-foreground">
-                {formatRelativeTime(channel.lastMessageAt)}
-              </span>
-            </div>
           </div>
-          {channel.description ? (
-            <p className="mt-1 text-sm leading-6 text-muted-foreground line-clamp-2">
-              {channel.description}
-            </p>
-          ) : null}
+          <p className="mt-1 truncate text-sm text-muted-foreground">
+            <span>{memberLabel}</span>
+            {channel.description ? (
+              <>
+                <span className="px-1.5">·</span>
+                <span title={channel.description}>{channel.description}</span>
+              </>
+            ) : null}
+          </p>
         </div>
+      </button>
 
-        {!channel.isMember && onJoin ? (
-          <Button
-            className="shrink-0"
-            disabled={isJoining}
-            onClick={(event) => {
-              event.stopPropagation();
-              onJoin();
-            }}
-            size="sm"
-            type="button"
-            variant="default"
-          >
-            <LogIn className="mr-1.5 h-3.5 w-3.5" />
-            {isJoining ? "Joining..." : "Join"}
-          </Button>
-        ) : null}
-      </div>
-    </button>
+      {!channel.isMember && onJoin ? (
+        <Button
+          className={
+            isJoining
+              ? "shrink-0"
+              : "shrink-0 opacity-0 transition-opacity duration-150 ease-out group-hover/channel-row:opacity-100 group-focus-within/channel-row:opacity-100"
+          }
+          disabled={isJoining}
+          onClick={(event) => {
+            event.stopPropagation();
+            onJoin();
+          }}
+          size="sm"
+          type="button"
+          variant="default"
+        >
+          {isJoining ? "Joining..." : "Join"}
+        </Button>
+      ) : null}
+    </div>
   );
 }

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -61,7 +61,6 @@ export function ChannelBrowserDialog({
   const [joiningChannelId, setJoiningChannelId] = React.useState<string | null>(
     null,
   );
-  const contentRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
   const tabListRef = React.useRef<HTMLDivElement>(null);
   const tabTriggerRefs = React.useRef<
@@ -260,9 +259,8 @@ export function ChannelBrowserDialog({
         }
         onOpenAutoFocus={(event) => {
           event.preventDefault();
-          contentRef.current?.focus();
+          inputRef.current?.focus({ preventScroll: true });
         }}
-        ref={contentRef}
         showCloseButton={false}
       >
         <DialogHeader className="space-y-0 pb-5">

--- a/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
@@ -79,7 +79,7 @@ function MetadataPill({
 }) {
   return (
     <div className="inline-flex items-center gap-2 rounded-full border border-border/80 bg-muted/40 px-3 py-1 text-xs font-medium text-muted-foreground">
-      <Icon className="h-3.5 w-3.5" />
+      <Icon className="h-4 w-4" />
       <span>{label}</span>
     </div>
   );

--- a/desktop/src/features/channels/ui/ChannelMemberInviteCard.tsx
+++ b/desktop/src/features/channels/ui/ChannelMemberInviteCard.tsx
@@ -234,7 +234,7 @@ export function ChannelMemberInviteCard({
                     }}
                     type="button"
                   >
-                    <X className="h-3 w-3" />
+                    <X className="h-4 w-4" />
                   </button>
                 </div>
               ))}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -4,7 +4,10 @@ import { Bot, Hash, LogIn, Plus, Sparkles, UserPlus } from "lucide-react";
 import { useMediaUpload } from "@/features/messages/lib/useMediaUpload";
 import { MessageComposer } from "@/features/messages/ui/MessageComposer";
 import { DropZoneOverlay } from "@/features/messages/ui/ComposerAttachments";
-import { MessageThreadPanel } from "@/features/messages/ui/MessageThreadPanel";
+import {
+  MessageThreadPanel,
+  MessageThreadPanelSkeleton,
+} from "@/features/messages/ui/MessageThreadPanel";
 import { MessageTimeline } from "@/features/messages/ui/MessageTimeline";
 import type { ImetaMedia } from "@/features/messages/lib/imetaMediaMarkdown";
 import { useComposerHeightPadding } from "@/features/messages/ui/useComposerHeightPadding";
@@ -714,7 +717,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                 size="sm"
                 variant="default"
               >
-                <LogIn className="mr-1.5 h-3.5 w-3.5" />
+                <LogIn className="mr-1.5 h-4 w-4" />
                 {isJoining ? "Joining..." : "Join to participate"}
               </Button>
             </div>
@@ -854,27 +857,15 @@ export const ChannelPane = React.memo(function ChannelPane({
               panel
             );
           })()
-        : activeChannel && selectedAgent
+        : openThreadHeadId && activeChannel
           ? (() => {
               const panel = (
-                <AgentSessionThreadPanel
-                  agent={selectedAgent}
-                  canInterruptTurn={selectedAgent.canInterruptTurn}
-                  channel={activeChannel}
-                  isWorking={botTypingEntries.some(
-                    (entry) =>
-                      entry.pubkey.toLowerCase() ===
-                      selectedAgent.pubkey.toLowerCase(),
-                  )}
+                <MessageThreadPanelSkeleton
                   isSinglePanelView={
                     useSplitAuxiliaryPane ? false : isSinglePanelView
                   }
                   layout={useSplitAuxiliaryPane ? "split" : "standalone"}
-                  profiles={profiles}
-                  onBackToProfile={() =>
-                    onOpenProfilePanel(selectedAgent.pubkey)
-                  }
-                  onClose={onCloseAgentSession}
+                  onClose={onCloseThread}
                   widthPx={threadPanelWidthPx}
                 />
               );
@@ -883,7 +874,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                   canResetWidth={canResetThreadPanelWidth}
                   onResetWidth={onResetThreadPanelWidth}
                   onResizeStart={onThreadPanelResizeStart}
-                  testId="agent-session-thread-panel"
+                  testId="message-thread-panel"
                   widthPx={threadPanelWidthPx}
                 >
                   {panel}
@@ -892,19 +883,27 @@ export const ChannelPane = React.memo(function ChannelPane({
                 panel
               );
             })()
-          : profilePanelPubkey
+          : activeChannel && selectedAgent
             ? (() => {
                 const panel = (
-                  <UserProfilePanel
-                    currentPubkey={currentPubkey}
+                  <AgentSessionThreadPanel
+                    agent={selectedAgent}
+                    canInterruptTurn={selectedAgent.canInterruptTurn}
+                    channel={activeChannel}
+                    isWorking={botTypingEntries.some(
+                      (entry) =>
+                        entry.pubkey.toLowerCase() ===
+                        selectedAgent.pubkey.toLowerCase(),
+                    )}
                     isSinglePanelView={
                       useSplitAuxiliaryPane ? false : isSinglePanelView
                     }
                     layout={useSplitAuxiliaryPane ? "split" : "standalone"}
-                    onClose={onCloseProfilePanel}
-                    onOpenDm={onOpenDm}
-                    pubkey={profilePanelPubkey}
-                    splitPaneClamp
+                    profiles={profiles}
+                    onBackToProfile={() =>
+                      onOpenProfilePanel(selectedAgent.pubkey)
+                    }
+                    onClose={onCloseAgentSession}
                     widthPx={threadPanelWidthPx}
                   />
                 );
@@ -913,7 +912,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                     canResetWidth={canResetThreadPanelWidth}
                     onResetWidth={onResetThreadPanelWidth}
                     onResizeStart={onThreadPanelResizeStart}
-                    testId="user-profile-panel"
+                    testId="agent-session-thread-panel"
                     widthPx={threadPanelWidthPx}
                   >
                     {panel}
@@ -922,7 +921,37 @@ export const ChannelPane = React.memo(function ChannelPane({
                   panel
                 );
               })()
-            : null}
+            : profilePanelPubkey
+              ? (() => {
+                  const panel = (
+                    <UserProfilePanel
+                      currentPubkey={currentPubkey}
+                      isSinglePanelView={
+                        useSplitAuxiliaryPane ? false : isSinglePanelView
+                      }
+                      layout={useSplitAuxiliaryPane ? "split" : "standalone"}
+                      onClose={onCloseProfilePanel}
+                      onOpenDm={onOpenDm}
+                      pubkey={profilePanelPubkey}
+                      splitPaneClamp
+                      widthPx={threadPanelWidthPx}
+                    />
+                  );
+                  return useSplitAuxiliaryPane ? (
+                    <RightAuxiliaryPane
+                      canResetWidth={canResetThreadPanelWidth}
+                      onResetWidth={onResetThreadPanelWidth}
+                      onResizeStart={onThreadPanelResizeStart}
+                      testId="user-profile-panel"
+                      widthPx={threadPanelWidthPx}
+                    >
+                      {panel}
+                    </RightAuxiliaryPane>
+                  ) : (
+                    panel
+                  );
+                })()
+              : null}
     </div>
   );
 });

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -434,6 +434,7 @@ export function ChannelScreen({
     activeChannel.channelType !== "forum" &&
     (messagesQuery.isPending ||
       (messagesQuery.isFetching && resolvedMessages.length === 0));
+  const shouldShowInitialChannelLoading = isTimelineLoading;
   const resetComposerTargets = React.useCallback(
     (_channelId: string | null) => {
       setOpenThreadHeadId(null);
@@ -549,7 +550,9 @@ export function ChannelScreen({
           ref={channelContentRef}
         >
           {activeChannel ? (
-            activeChannel.channelType === "forum" ? (
+            shouldShowInitialChannelLoading ? (
+              <ViewLoadingFallback includeHeader kind="channel" />
+            ) : activeChannel.channelType === "forum" ? (
               <>
                 {channelHeader}
                 <React.Suspense fallback={<ViewLoadingFallback kind="forum" />}>
@@ -564,7 +567,9 @@ export function ChannelScreen({
                 </React.Suspense>
               </>
             ) : (
-              <React.Suspense fallback={<ViewLoadingFallback kind="channel" />}>
+              <React.Suspense
+                fallback={<ViewLoadingFallback includeHeader kind="channel" />}
+              >
                 <ChannelPane
                   activeChannel={activeChannel}
                   agentPubkeys={agentPubkeys}

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -429,11 +429,12 @@ export function ChannelScreen({
       setThreadReplyTargetId,
       setThreadScrollTargetId,
     });
+  const hasTimelineData = messagesQuery.data !== undefined;
   const isTimelineLoading =
     activeChannel !== null &&
     activeChannel.channelType !== "forum" &&
-    (messagesQuery.isPending ||
-      (messagesQuery.isFetching && resolvedMessages.length === 0));
+    !hasTimelineData &&
+    messagesQuery.isPending;
   const shouldShowInitialChannelLoading = isTimelineLoading;
   const resetComposerTargets = React.useCallback(
     (_channelId: string | null) => {

--- a/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreenHeader.tsx
@@ -60,7 +60,7 @@ export function ChannelScreenHeader({
         size="sm"
         variant="default"
       >
-        <LogIn className="mr-1.5 h-3.5 w-3.5" />
+        <LogIn className="mr-1.5 h-4 w-4" />
         {isJoining ? "Joining…" : "Join"}
       </Button>
     ) : (

--- a/desktop/src/features/channels/ui/QuickBotBar.tsx
+++ b/desktop/src/features/channels/ui/QuickBotBar.tsx
@@ -81,7 +81,7 @@ export function QuickBotBar({ personas, pending, onAdd }: QuickBotBarProps) {
                   )}
                   {isThisPending ? (
                     <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-background/70">
-                      <Spinner className="h-3.5 w-3.5 text-primary" />
+                      <Spinner className="h-4 w-4 border-2 text-primary" />
                     </div>
                   ) : null}
                 </button>

--- a/desktop/src/features/chat/ui/ChatHeader.tsx
+++ b/desktop/src/features/chat/ui/ChatHeader.tsx
@@ -32,8 +32,8 @@ type ChatHeaderProps = {
   statusBadge?: React.ReactNode;
 };
 
-const HEADER_ICON_CLASS = "h-[14px] w-[14px] text-muted-foreground";
-const CHANNEL_HASH_ICON_CLASS = "h-[14px] w-[14px] translate-y-px";
+const HEADER_ICON_CLASS = "h-4 w-4 text-muted-foreground";
+const CHANNEL_HASH_ICON_CLASS = "h-4 w-4 translate-y-px";
 
 function ChannelIcon({
   channelType,
@@ -98,12 +98,12 @@ export function ChatHeader({
   const header = (
     <header
       className={cn(
-        "pointer-events-auto relative z-30 flex min-w-0 shrink-0 cursor-default select-none items-center gap-2.5 bg-transparent pl-4 pr-2 transition-[margin,padding] duration-200 ease-linear sm:pr-3",
+        "pointer-events-auto relative z-30 flex min-w-0 shrink-0 cursor-default select-none items-center gap-2.5 bg-transparent px-4 transition-[margin,padding] duration-200 ease-linear sm:px-6",
         density === "compact"
           ? belowSystemChrome
             ? "min-h-8 py-1.5"
             : "min-h-8 py-0"
-          : "min-h-11 py-1.5 sm:pl-6",
+          : "min-h-11 py-1.5",
         overlaysContent && !belowSystemChrome && "-mb-11",
       )}
       data-testid="chat-header"

--- a/desktop/src/features/forum/ui/DeleteActionMenu.tsx
+++ b/desktop/src/features/forum/ui/DeleteActionMenu.tsx
@@ -16,13 +16,9 @@ type DeleteActionMenuProps = {
   iconSize?: "sm" | "md";
 };
 
-export function DeleteActionMenu({
-  label,
-  onConfirm,
-  iconSize = "md",
-}: DeleteActionMenuProps) {
+export function DeleteActionMenu({ label, onConfirm }: DeleteActionMenuProps) {
   const [isOpen, setIsOpen] = React.useState(false);
-  const iconClass = iconSize === "sm" ? "h-3.5 w-3.5" : "h-4 w-4";
+  const iconClass = "h-4 w-4";
 
   return (
     <div className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">

--- a/desktop/src/features/forum/ui/ForumComposerCompactLayout.tsx
+++ b/desktop/src/features/forum/ui/ForumComposerCompactLayout.tsx
@@ -5,6 +5,7 @@ import { Plus } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
+import { Spinner } from "@/shared/ui/spinner";
 
 type ForumComposerCompactLayoutProps = {
   editor: Editor | null;
@@ -45,12 +46,12 @@ export function ForumComposerCompactLayout({
         variant="ghost"
       >
         {isSending ? (
-          <span
+          <Spinner
             aria-hidden
-            className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent"
+            className="h-4 w-4 border-2 text-primary-foreground"
           />
         ) : (
-          <Plus aria-hidden className="h-3.5 w-3.5" />
+          <Plus aria-hidden className="h-4 w-4" />
         )}
       </Button>
     </div>

--- a/desktop/src/features/forum/ui/ForumPostCard.tsx
+++ b/desktop/src/features/forum/ui/ForumPostCard.tsx
@@ -125,7 +125,7 @@ export function ForumPostCard({
 
       {summary && summary.replyCount > 0 ? (
         <div className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
-          <MessageSquare className="h-3.5 w-3.5" />
+          <MessageSquare className="h-4 w-4" />
           <span>
             {summary.replyCount}{" "}
             {summary.replyCount === 1 ? "reply" : "replies"}

--- a/desktop/src/features/home/ui/HomeLoadingState.tsx
+++ b/desktop/src/features/home/ui/HomeLoadingState.tsx
@@ -2,28 +2,112 @@ import { Skeleton } from "@/shared/ui/skeleton";
 
 export function HomeLoadingState() {
   return (
-    <div className="flex-1 overflow-hidden">
+    <div className="min-h-0 flex-1 overflow-hidden">
       <div className="grid h-full min-h-0 w-full lg:grid-cols-[320px_minmax(0,1fr)]">
         <div className="relative overflow-hidden bg-background/60 after:absolute after:bottom-0 after:right-0 after:top-10 after:w-px after:bg-border/70 after:content-['']">
-          <div className="border-b border-border/70 px-4 pb-4 pt-14">
-            <Skeleton className="h-4 w-20" />
-            <Skeleton className="mt-2 h-4 w-28" />
-            <Skeleton className="mt-4 h-10 rounded-md" />
+          <div className="px-5 py-1 pt-14">
+            <div className="flex min-w-0 items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-[6px]">
+                <Skeleton className="h-4 w-4 shrink-0 rounded-md" />
+                <Skeleton className="h-4 w-14" />
+              </div>
+              <Skeleton className="h-7 w-14 rounded-full" />
+            </div>
           </div>
-          <div className="space-y-3 px-4 py-4">
-            {["a", "b", "c", "d"].map((row) => (
-              <Skeleton className="h-20 rounded-md" key={row} />
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {["first", "second", "third", "fourth", "fifth"].map((row) => (
+              <div
+                className="flex w-full items-start gap-2.5 px-5 py-2"
+                key={row}
+              >
+                <div className="relative shrink-0">
+                  <Skeleton className="h-8 w-8 rounded-full" />
+                  {row === "first" || row === "third" ? (
+                    <Skeleton className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full" />
+                  ) : null}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <Skeleton className="h-4 w-24" />
+                        {row === "second" ? (
+                          <Skeleton className="h-3 w-20" />
+                        ) : null}
+                      </div>
+                    </div>
+                    <Skeleton className="h-3 w-10" />
+                  </div>
+                  <div className="mt-1 space-y-1.5">
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-4/5" />
+                  </div>
+                  <Skeleton className="mt-2 h-3 w-16" />
+                </div>
+              </div>
             ))}
           </div>
         </div>
 
-        <div className="overflow-hidden bg-background/60">
-          <div className="border-b border-border/70 px-5 pb-4 pt-14">
-            <Skeleton className="h-5 w-48" />
-            <Skeleton className="mt-3 h-8 w-72" />
+        <div className="relative flex min-h-0 flex-col overflow-hidden bg-background/60">
+          <div className="px-5 py-1 pr-3 pt-14">
+            <div className="flex min-w-0 items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-[4px]">
+                <Skeleton className="h-4 w-4 shrink-0 rounded-md" />
+                <Skeleton className="h-4 w-40" />
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <Skeleton className="h-8 w-20 rounded-full" />
+                <Skeleton className="h-8 w-8 rounded-full" />
+              </div>
+            </div>
           </div>
-          <div className="px-5 py-5">
-            <Skeleton className="h-64 rounded-md" />
+
+          <div className="min-h-0 flex-1 overflow-y-auto pb-32">
+            {["selected", "context-a", "context-b"].map((row, index) => (
+              <div className="relative px-5 py-2" key={row}>
+                {index === 1 ? (
+                  <div className="mx-1 mb-3 border-t border-border/60" />
+                ) : null}
+                <article className="relative flex items-start gap-2.5">
+                  <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0">
+                      <Skeleton className="h-4 w-24" />
+                      <Skeleton className="h-3 w-24" />
+                    </div>
+                    <div className="mt-1 space-y-1.5">
+                      <Skeleton className="h-4 w-full max-w-2xl" />
+                      <Skeleton
+                        className={
+                          index === 0
+                            ? "h-4 w-5/6 max-w-xl"
+                            : "h-4 w-2/3 max-w-lg"
+                        }
+                      />
+                    </div>
+                    <div className="mt-2 flex items-center gap-4">
+                      <Skeleton className="h-4 w-8 rounded-full" />
+                      <Skeleton className="h-4 w-8 rounded-full" />
+                    </div>
+                  </div>
+                </article>
+              </div>
+            ))}
+          </div>
+
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10">
+            <div className="pointer-events-auto px-4 pb-4 sm:px-4">
+              <div className="relative isolate rounded-2xl border border-border/50 bg-background/80 px-3 pb-2 pt-3 shadow-none backdrop-blur-md sm:px-4">
+                <Skeleton className="h-5 w-48" />
+                <div className="mt-4 flex items-center gap-2">
+                  <Skeleton className="h-8 w-8 rounded-lg" />
+                  <Skeleton className="h-8 w-8 rounded-lg" />
+                  <Skeleton className="ml-auto h-8 w-20 rounded-full" />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/desktop/src/features/home/ui/InboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/InboxDetailPane.tsx
@@ -264,10 +264,7 @@ export function InboxDetailPane({
                       type="button"
                     >
                       {hasChannelContext ? (
-                        <Hash
-                          className="h-[14px] w-[14px] shrink-0"
-                          color="gray"
-                        />
+                        <Hash className="h-4 w-4 shrink-0" color="gray" />
                       ) : null}
                       <span className="min-w-0 translate-y-px truncate">
                         {contextLabel}
@@ -279,10 +276,7 @@ export function InboxDetailPane({
                       title={item.fullTimestampLabel}
                     >
                       {hasChannelContext ? (
-                        <Hash
-                          className="h-[14px] w-[14px] shrink-0"
-                          color="gray"
-                        />
+                        <Hash className="h-4 w-4 shrink-0" color="gray" />
                       ) : null}
                       <span className="min-w-0 translate-y-px truncate">
                         {contextLabel}

--- a/desktop/src/features/home/ui/InboxListPane.tsx
+++ b/desktop/src/features/home/ui/InboxListPane.tsx
@@ -59,7 +59,7 @@ export function InboxListPane({
         <div className="px-5 py-1">
           <div className="flex min-w-0 items-center justify-between gap-3">
             <div className="flex min-w-0 items-center gap-[6px]">
-              <Inbox className="h-[14px] w-[14px] shrink-0 text-muted-foreground" />
+              <Inbox className="h-4 w-4 shrink-0 text-muted-foreground" />
               <h2 className="translate-y-px truncate text-sm font-semibold leading-5 tracking-tight">
                 Inbox
               </h2>
@@ -73,7 +73,7 @@ export function InboxListPane({
                   variant="outline"
                 >
                   <span>{activeFilter?.label ?? "All"}</span>
-                  <ChevronDown className="h-3 w-3" />
+                  <ChevronDown className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-40">

--- a/desktop/src/features/home/ui/RecentNotesSection.tsx
+++ b/desktop/src/features/home/ui/RecentNotesSection.tsx
@@ -67,7 +67,7 @@ export function RecentNotesSection({
                   size="sm"
                 />
                 {isAgent ? (
-                  <Bot className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full bg-background p-0.5 text-muted-foreground" />
+                  <Bot className="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full bg-background p-0.5 text-muted-foreground" />
                 ) : null}
               </div>
               <div className="min-w-0 flex-1">

--- a/desktop/src/features/huddle/components/HeadphonesNotice.tsx
+++ b/desktop/src/features/huddle/components/HeadphonesNotice.tsx
@@ -24,7 +24,7 @@ export function HeadphonesNotice({ onDismiss }: { onDismiss: () => void }) {
       data-testid="huddle-headphones-notice"
       className="flex items-center gap-1.5 rounded bg-amber-500/10 px-2 py-1 text-xs text-amber-700 dark:text-amber-300"
     >
-      <Headphones className="h-3 w-3" />
+      <Headphones className="h-4 w-4" />
       <span className="max-w-[260px] truncate">
         Headphones recommended — echo cancellation lands in the next release.
       </span>

--- a/desktop/src/features/huddle/components/HuddleBar.tsx
+++ b/desktop/src/features/huddle/components/HuddleBar.tsx
@@ -304,7 +304,7 @@ export function HuddleBar({ className }: HuddleBarProps) {
           size="icon"
           variant="ghost"
         >
-          <Plus className="h-3.5 w-3.5" />
+          <Plus className="h-4 w-4" />
         </Button>
       </div>
 

--- a/desktop/src/features/huddle/components/MicControls.tsx
+++ b/desktop/src/features/huddle/components/MicControls.tsx
@@ -67,7 +67,7 @@ export function MicControls({
             size="icon"
             variant="secondary"
           >
-            <ChevronUp className="h-3 w-3" />
+            <ChevronUp className="h-4 w-4" />
           </Button>
         </PopoverTrigger>
       </div>
@@ -151,7 +151,7 @@ export function SpeakerControls({
             size="icon"
             variant="secondary"
           >
-            <ChevronUp className="h-3 w-3" />
+            <ChevronUp className="h-4 w-4" />
           </Button>
         </PopoverTrigger>
       </div>
@@ -192,7 +192,7 @@ export function DeviceList({
             type="button"
           >
             <Check
-              className={cn("h-3 w-3 shrink-0", selectedId && "invisible")}
+              className={cn("h-4 w-4 shrink-0", selectedId && "invisible")}
             />
             System default
           </button>
@@ -207,7 +207,7 @@ export function DeviceList({
                 type="button"
               >
                 <Check
-                  className={cn("h-3 w-3 shrink-0", !isSelected && "invisible")}
+                  className={cn("h-4 w-4 shrink-0", !isSelected && "invisible")}
                 />
                 <span className="truncate">{d.label}</span>
               </button>

--- a/desktop/src/features/mesh-compute/ui/MeshComputeSettingsCard.tsx
+++ b/desktop/src/features/mesh-compute/ui/MeshComputeSettingsCard.tsx
@@ -244,7 +244,7 @@ export function MeshComputeSettingsCard() {
           <summary className="flex cursor-pointer items-center gap-1.5 text-sm font-medium text-foreground">
             <ChevronDown
               className={cn(
-                "h-3.5 w-3.5 text-muted-foreground transition-transform",
+                "h-4 w-4 text-muted-foreground transition-transform",
                 advancedOpen ? "rotate-0" : "-rotate-90",
               )}
             />

--- a/desktop/src/features/mesh-compute/ui/RelayMeshAgentSection.tsx
+++ b/desktop/src/features/mesh-compute/ui/RelayMeshAgentSection.tsx
@@ -166,7 +166,7 @@ export function RelayMeshAgentSection({
           ) : null}
           {overrides.length > 0 ? (
             <p className="flex items-start gap-1.5 rounded bg-warning-bg/60 px-2 py-1.5 text-xs text-warning">
-              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
               <span>
                 Using Relay mesh overrides this agent's {overrides.join(", ")}.
               </span>

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -321,9 +321,12 @@ export function useRichTextEditor({
       ],
       editorProps: {
         attributes: {
+          autocapitalize: "none",
+          autocorrect: "off",
           class:
             "min-h-0 resize-none overflow-y-hidden border-0 bg-transparent px-0 py-0 text-sm leading-6 md:leading-6 shadow-none focus-visible:ring-0 caret-foreground outline-hidden prose-sm max-w-none",
           "data-testid": "message-input",
+          spellcheck: "false",
         },
         // ArrowUp in an empty composer → edit your last message (Slack
         // parity). Handled here in ProseMirror's own DOM `keydown` hook —

--- a/desktop/src/features/messages/ui/ComposerAttachments.tsx
+++ b/desktop/src/features/messages/ui/ComposerAttachments.tsx
@@ -135,7 +135,7 @@ export const ComposerAttachments = React.memo(function ComposerAttachments({
                   className="group relative"
                 >
                   <div className="flex h-5 max-w-[10rem] items-center gap-1 rounded border border-border/70 bg-muted px-1.5">
-                    <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />
+                    <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
                     <span className="truncate text-[10px] text-muted-foreground">
                       {label}
                     </span>
@@ -186,7 +186,7 @@ export const ComposerAttachments = React.memo(function ComposerAttachments({
                             )}
                             <div className="absolute inset-0 bg-black/15" />
                             <div className="absolute flex h-5 w-5 items-center justify-center rounded-full bg-black/55 backdrop-blur-sm">
-                              <Play className="h-3 w-3 fill-white text-white" />
+                              <Play className="h-4 w-4 fill-white text-white" />
                             </div>
                           </div>
                         ) : (
@@ -231,7 +231,7 @@ export const ComposerAttachments = React.memo(function ComposerAttachments({
                           />
                         )}
                         <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full bg-black/50 p-2 text-white/80 transition-colors hover:bg-black/70 hover:text-white focus:outline-hidden focus:ring-2 focus:ring-white/30">
-                          <X className="h-5 w-5" />
+                          <X className="h-4 w-4" />
                           <span className="sr-only">Close</span>
                         </DialogPrimitive.Close>
                       </DialogPrimitive.Content>

--- a/desktop/src/features/messages/ui/DiffMessage.tsx
+++ b/desktop/src/features/messages/ui/DiffMessage.tsx
@@ -86,7 +86,7 @@ export default function DiffMessage({
                 type="button"
                 variant="ghost"
               >
-                <Maximize2 className="h-3.5 w-3.5" />
+                <Maximize2 className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>Expand diff</TooltipContent>

--- a/desktop/src/features/messages/ui/DiffMessageExpanded.tsx
+++ b/desktop/src/features/messages/ui/DiffMessageExpanded.tsx
@@ -46,7 +46,7 @@ export default function DiffMessageExpanded({
                 type="button"
                 variant={viewType === "unified" ? "secondary" : "ghost"}
               >
-                <Rows3 className="h-3.5 w-3.5" />
+                <Rows3 className="h-4 w-4" />
                 Unified
               </Button>
               <Button
@@ -58,7 +58,7 @@ export default function DiffMessageExpanded({
                 type="button"
                 variant={viewType === "split" ? "secondary" : "ghost"}
               >
-                <SplitSquareVertical className="h-3.5 w-3.5" />
+                <SplitSquareVertical className="h-4 w-4" />
                 Split
               </Button>
             </div>

--- a/desktop/src/features/messages/ui/FormattingToolbar.tsx
+++ b/desktop/src/features/messages/ui/FormattingToolbar.tsx
@@ -212,13 +212,13 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
                 "hover:bg-muted hover:text-foreground",
                 "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring",
                 "disabled:pointer-events-none disabled:opacity-50",
-                "[&_svg]:pointer-events-none [&_svg]:size-3.5 [&_svg]:shrink-0",
+                "[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
                 item.active
                   ? "bg-primary text-primary-foreground"
                   : "bg-transparent text-muted-foreground",
               )}
             >
-              <item.icon className="h-3.5 w-3.5" />
+              <item.icon className="h-4 w-4" />
             </button>
           </TooltipTrigger>
           <TooltipContent>

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -98,7 +98,7 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
                     >
                       <Bot
                         aria-hidden="true"
-                        className="h-3 w-3"
+                        className="h-4 w-4"
                         data-testid="mention-agent-icon"
                       />
                       {agentLabel}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -34,6 +34,7 @@ export const MessageRow = React.memo(
     channelId = null,
     highlighted = false,
     hoverBackground = true,
+    actionBarPlacement = "floating",
     isFollowingThread,
     layoutVariant = "default",
     message,
@@ -53,6 +54,7 @@ export const MessageRow = React.memo(
     channelId?: string | null;
     highlighted?: boolean;
     hoverBackground?: boolean;
+    actionBarPlacement?: "floating" | "inside";
     isFollowingThread?: boolean;
     layoutVariant?: "default" | "thread-reply";
     message: TimelineMessage;
@@ -255,7 +257,14 @@ export const MessageRow = React.memo(
     );
 
     const actionBarNode = (
-      <div className="absolute right-2 top-1 z-10">
+      <div
+        className={cn(
+          "absolute right-2 top-1 z-10",
+          actionBarPlacement === "floating"
+            ? "sm:top-0 sm:-translate-y-1/2"
+            : "sm:top-1 sm:translate-y-0",
+        )}
+      >
         <MessageActionBar
           channelId={channelId}
           isFollowingThread={isFollowingThread}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -23,6 +23,7 @@ import {
   PANEL_OVERLAY_CLASS,
   PANEL_SINGLE_COLUMN_HEADER_LAYER_CLASS,
 } from "@/shared/ui/OverlayPanelBackdrop";
+import { Skeleton } from "@/shared/ui/skeleton";
 import { MessageComposer } from "./MessageComposer";
 import { MessageRow } from "./MessageRow";
 import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
@@ -80,6 +81,13 @@ type MessageThreadPanelProps = {
   onUnfollowThread?: () => void;
 };
 
+type MessageThreadPanelSkeletonProps = {
+  isSinglePanelView?: boolean;
+  layout?: "standalone" | "split";
+  onClose: () => void;
+  widthPx: number;
+};
+
 function canManageMessage(
   message: TimelineMessage,
   currentPubkey: string | undefined,
@@ -88,6 +96,159 @@ function canManageMessage(
     currentPubkey &&
       message.pubkey &&
       currentPubkey.toLowerCase() === message.pubkey.toLowerCase(),
+  );
+}
+
+function ThreadMessageSkeleton({ isHead = false }: { isHead?: boolean }) {
+  return (
+    <article className="relative flex items-start gap-2.5 rounded-2xl px-3 py-2">
+      <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
+      <div className="-mt-1 min-w-0 flex-1">
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0">
+          <Skeleton className="h-[15px] w-28" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+        <div className="mt-1 space-y-1.5 pb-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className={isHead ? "h-4 w-4/5" : "h-4 w-2/3"} />
+        </div>
+        <div className="flex items-center gap-4">
+          <Skeleton className="h-4 w-8 rounded-full" />
+          <Skeleton className="h-4 w-8 rounded-full" />
+          <Skeleton className="h-4 w-8 rounded-full" />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function ThreadComposerSkeleton() {
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10">
+      <div className="pointer-events-auto">
+        <div className="relative z-10 shrink-0 bg-transparent px-4 pb-2 pt-0">
+          <div className="relative isolate rounded-2xl border border-border/50 bg-background/80 px-3 pb-2 pt-3 shadow-none backdrop-blur-md sm:px-4">
+            <Skeleton className="h-5 w-48 max-w-full" />
+            <div className="mt-4 flex items-center gap-2">
+              <Skeleton className="h-8 w-8 rounded-lg" />
+              <Skeleton className="h-8 w-8 rounded-lg" />
+              <Skeleton className="ml-auto h-8 w-20 rounded-full" />
+            </div>
+          </div>
+        </div>
+        <div className="-mt-1 h-7 bg-background px-4 pb-1 pt-0 sm:px-6" />
+      </div>
+    </div>
+  );
+}
+
+export function MessageThreadPanelSkeleton({
+  isSinglePanelView = false,
+  layout = "standalone",
+  onClose,
+  widthPx,
+}: MessageThreadPanelSkeletonProps) {
+  const isOverlay = useIsThreadPanelOverlay();
+  const isFloatingOverlay = isOverlay && !isSinglePanelView;
+  const isSplitLayout = layout === "split";
+  useEscapeKey(onClose, isOverlay || isSinglePanelView);
+
+  const threadHeaderContent = (
+    <>
+      <AuxiliaryPanelHeaderGroup>
+        {isSinglePanelView ? (
+          <Button
+            aria-label="Back to conversation"
+            className="shrink-0"
+            onClick={onClose}
+            size="icon"
+            type="button"
+            variant="outline"
+          >
+            <ArrowLeft />
+          </Button>
+        ) : null}
+        <AuxiliaryPanelTitle>Thread</AuxiliaryPanelTitle>
+      </AuxiliaryPanelHeaderGroup>
+      <Button
+        aria-label="Close thread"
+        className="ml-auto"
+        onClick={onClose}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <X />
+      </Button>
+    </>
+  );
+
+  const threadBody = (
+    <div
+      className={cn(
+        "min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain pb-24 [overflow-anchor:none]",
+        isSplitLayout && auxiliaryPanelContentPaddingClass,
+        !isSplitLayout && !isFloatingOverlay && "pt-[4.75rem]",
+      )}
+      data-testid="message-thread-loading"
+    >
+      <div className="px-3 pb-1 pt-0" data-testid="message-thread-head-loading">
+        <ThreadMessageSkeleton isHead />
+      </div>
+      <div className="space-y-2.5 px-3 pb-3 pt-1">
+        <ThreadMessageSkeleton />
+        <ThreadMessageSkeleton />
+        <div className="ml-[58px] flex items-center gap-1.5 pt-0.5">
+          <Skeleton className="h-7 w-7 rounded-full" />
+          <Skeleton className="h-7 w-7 rounded-full" />
+          <Skeleton className="h-4 w-28 rounded-full" />
+        </div>
+      </div>
+    </div>
+  );
+
+  if (isSplitLayout) {
+    return (
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        <AuxiliaryPanelHeader>{threadHeaderContent}</AuxiliaryPanelHeader>
+        {threadBody}
+        <ThreadComposerSkeleton />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {isFloatingOverlay && <OverlayPanelBackdrop onClose={onClose} />}
+      <aside
+        className={cn(
+          PANEL_BASE_CLASS,
+          isSinglePanelView && "border-l-0",
+          isFloatingOverlay && PANEL_OVERLAY_CLASS,
+        )}
+        data-testid="message-thread-panel"
+        style={{
+          width: isSinglePanelView
+            ? "100%"
+            : `min(${widthPx}px, calc(100% - ${THREAD_PANEL_MIN_WIDTH_PX}px))`,
+        }}
+      >
+        <div
+          className={cn(
+            "flex cursor-default select-none items-center",
+            isSinglePanelView
+              ? `relative ${PANEL_SINGLE_COLUMN_HEADER_LAYER_CLASS} -mb-[4.75rem] min-h-[4.75rem] shrink-0 gap-2.5 bg-background/80 pb-[0.1875rem] pl-4 pr-2 pt-[2.6875rem] backdrop-blur-md supports-[backdrop-filter]:bg-background/70 sm:pr-3 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-[backdrop-filter]:bg-background/55`
+              : "relative z-50 min-h-11 shrink-0 gap-3 bg-background/80 px-3 py-1.5 backdrop-blur-md supports-[backdrop-filter]:bg-background/70 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-[backdrop-filter]:bg-background/55",
+          )}
+          data-tauri-drag-region
+        >
+          {threadHeaderContent}
+        </div>
+
+        {threadBody}
+        <ThreadComposerSkeleton />
+      </aside>
+    </>
   );
 }
 
@@ -190,6 +351,7 @@ export function MessageThreadPanel({
         <div className="px-3 pb-1 pt-0" data-testid="message-thread-head">
           <div className="rounded-2xl">
             <MessageRow
+              actionBarPlacement="inside"
               agentPubkeys={agentPubkeys}
               channelId={channelId}
               isFollowingThread={isFollowingThread}

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -9,8 +9,9 @@ import { cn } from "@/shared/lib/cn";
 import { channelChrome } from "@/shared/layout/chromeLayout";
 import { Button } from "@/shared/ui/button";
 import { Spinner } from "@/shared/ui/spinner";
+import { SkeletonReveal } from "@/shared/ui/skeleton";
 import { TooltipProvider } from "@/shared/ui/tooltip";
-import { TimelineSkeleton } from "./TimelineSkeleton";
+import { TimelineSkeleton, useTimelineSkeletonRows } from "./TimelineSkeleton";
 import { TimelineMessageList } from "./TimelineMessageList";
 import { useLoadOlderOnScroll } from "./useLoadOlderOnScroll";
 import { useTimelineScrollManager } from "./useTimelineScrollManager";
@@ -192,6 +193,11 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     directMessageIntro === null &&
     channelIntro === null;
   const showMessageList = !isLoading && messages.length > 0;
+  const timelineSkeletonRows = useTimelineSkeletonRows({
+    channelId,
+    isLoading,
+    messages,
+  });
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -218,175 +224,187 @@ export const MessageTimeline = React.memo(function MessageTimeline({
 
             {isFetchingOlder ? (
               <div className="flex justify-center py-2">
-                <Spinner className="h-4 w-4 text-muted-foreground" />
+                <Spinner className="h-4 w-4 border-2 text-muted-foreground" />
               </div>
             ) : null}
 
-            {isLoading ? <TimelineSkeleton /> : null}
-
-            {showDirectMessageIntro ? (
-              <div
-                className="mb-0.5 mt-auto flex w-full flex-col items-start px-3 py-2 text-left"
-                data-testid="message-dm-intro"
-              >
-                <ProfileAvatar
-                  avatarUrl={directMessageIntro.avatarUrl}
-                  className="h-[60px] w-[60px] text-base"
-                  iconClassName="h-6 w-6"
-                  label={directMessageIntro.displayName}
-                  testId="message-dm-intro-avatar"
-                />
-                <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
-                  {directMessageIntro.displayName}
-                </p>
-                <p className="mt-1 max-w-full truncate whitespace-nowrap text-sm leading-5 text-muted-foreground">
-                  This is the beginning of your direct message with{" "}
-                  <span className="font-medium text-foreground">
-                    {directMessageIntro.displayName}
-                  </span>
-                  .
-                </p>
-              </div>
-            ) : null}
-
-            {showChannelIntro ? (
-              <div
-                className="mb-0.5 mt-auto flex w-full max-w-2xl flex-col items-start px-3 py-2 text-left"
-                data-testid="message-channel-intro"
-              >
+            <SkeletonReveal
+              className={cn(
+                "min-h-[18rem]",
+                (showIntro || showGenericEmpty) && "min-h-full",
+                showMessageList && !showIntro && "mt-auto",
+              )}
+              contentClassName={cn(
+                "flex flex-col gap-2",
+                (showIntro || showGenericEmpty) && "min-h-full",
+              )}
+              loading={isLoading}
+              skeleton={<TimelineSkeleton rows={timelineSkeletonRows} />}
+            >
+              {showDirectMessageIntro ? (
                 <div
-                  className="flex h-[60px] w-[60px] items-center justify-center rounded-2xl border border-border/70 bg-muted/40 text-muted-foreground"
-                  data-testid="message-channel-intro-icon"
+                  className="mb-0.5 mt-auto flex w-full flex-col items-start px-3 py-2 text-left"
+                  data-testid="message-dm-intro"
                 >
-                  {channelIntro.icon ?? (
-                    <Hash aria-hidden className="h-7 w-7" />
-                  )}
-                </div>
-                <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
-                  #{channelIntro.channelName}
-                </p>
-                <p className="mt-1 max-w-full text-sm leading-5 text-muted-foreground">
-                  This is the beginning of the{" "}
-                  <span className="font-medium text-foreground">
-                    {channelIntro.channelKindLabel}
-                  </span>
-                  .
-                </p>
-                {channelIntro.description ? (
-                  <p className="mt-2 max-w-xl text-sm leading-5 text-muted-foreground">
-                    {channelIntro.description}
+                  <ProfileAvatar
+                    avatarUrl={directMessageIntro.avatarUrl}
+                    className="h-[60px] w-[60px] text-base"
+                    iconClassName="h-6 w-6"
+                    label={directMessageIntro.displayName}
+                    testId="message-dm-intro-avatar"
+                  />
+                  <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
+                    {directMessageIntro.displayName}
                   </p>
-                ) : null}
-                {channelIntro.actions?.length ? (
-                  <div className="mt-4 flex max-w-full flex-nowrap gap-3 overflow-x-auto pb-1">
-                    {channelIntro.actions.map((action) => {
-                      const hasDescription = Boolean(action.description);
+                  <p className="mt-1 max-w-full truncate whitespace-nowrap text-sm leading-5 text-muted-foreground">
+                    This is the beginning of your direct message with{" "}
+                    <span className="font-medium text-foreground">
+                      {directMessageIntro.displayName}
+                    </span>
+                    .
+                  </p>
+                </div>
+              ) : null}
 
-                      return (
-                        <button
-                          className={cn(
-                            "flex shrink-0 border border-border/70 bg-background/70 text-left transition-colors hover:bg-muted/60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
-                            hasDescription
-                              ? "h-56 w-[13.75rem] flex-col rounded-2xl p-4"
-                              : "h-28 w-64 flex-col rounded-xl p-4",
-                          )}
-                          data-testid={action.testId}
-                          key={action.label}
-                          onClick={action.onClick}
-                          type="button"
-                        >
-                          <span
+              {showChannelIntro ? (
+                <div
+                  className="mb-0.5 mt-auto flex w-full max-w-2xl flex-col items-start px-3 py-2 text-left"
+                  data-testid="message-channel-intro"
+                >
+                  <div
+                    className="flex h-[60px] w-[60px] items-center justify-center rounded-2xl border border-border/70 bg-muted/40 text-muted-foreground"
+                    data-testid="message-channel-intro-icon"
+                  >
+                    {channelIntro.icon ?? (
+                      <Hash aria-hidden className="h-7 w-7" />
+                    )}
+                  </div>
+                  <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
+                    #{channelIntro.channelName}
+                  </p>
+                  <p className="mt-1 max-w-full text-sm leading-5 text-muted-foreground">
+                    This is the beginning of the{" "}
+                    <span className="font-medium text-foreground">
+                      {channelIntro.channelKindLabel}
+                    </span>
+                    .
+                  </p>
+                  {channelIntro.description ? (
+                    <p className="mt-2 max-w-xl text-sm leading-5 text-muted-foreground">
+                      {channelIntro.description}
+                    </p>
+                  ) : null}
+                  {channelIntro.actions?.length ? (
+                    <div className="mt-4 flex max-w-full flex-nowrap gap-3 overflow-x-auto pb-1">
+                      {channelIntro.actions.map((action) => {
+                        const hasDescription = Boolean(action.description);
+
+                        return (
+                          <button
                             className={cn(
-                              "flex shrink-0 items-center justify-center rounded-full bg-muted/70 text-muted-foreground",
+                              "flex shrink-0 border border-border/70 bg-background/70 text-left transition-colors hover:bg-muted/60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
                               hasDescription
-                                ? "h-12 w-12 [&_svg]:h-6 [&_svg]:w-6"
-                                : "h-10 w-10 [&_svg]:h-5 [&_svg]:w-5",
+                                ? "h-56 w-[13.75rem] flex-col rounded-2xl p-4"
+                                : "h-28 w-64 flex-col rounded-xl p-4",
                             )}
-                            data-testid={
-                              action.testId
-                                ? `${action.testId}-icon`
-                                : undefined
-                            }
+                            data-testid={action.testId}
+                            key={action.label}
+                            onClick={action.onClick}
+                            type="button"
                           >
-                            {action.icon}
-                          </span>
-                          <span className="mt-auto min-w-0">
                             <span
-                              className="block whitespace-normal break-words text-base font-medium leading-6 text-foreground"
+                              className={cn(
+                                "flex shrink-0 items-center justify-center rounded-full bg-muted/70 text-muted-foreground",
+                                hasDescription
+                                  ? "h-12 w-12 [&_svg]:h-6 [&_svg]:w-6"
+                                  : "h-10 w-10 [&_svg]:h-5 [&_svg]:w-5",
+                              )}
                               data-testid={
                                 action.testId
-                                  ? `${action.testId}-title`
+                                  ? `${action.testId}-icon`
                                   : undefined
                               }
                             >
-                              {action.label}
+                              {action.icon}
                             </span>
-                            {action.description ? (
+                            <span className="mt-auto min-w-0">
                               <span
-                                className="mt-1 block whitespace-normal break-words text-sm leading-5 text-muted-foreground"
+                                className="block whitespace-normal break-words text-base font-medium leading-6 text-foreground"
                                 data-testid={
                                   action.testId
-                                    ? `${action.testId}-description`
+                                    ? `${action.testId}-title`
                                     : undefined
                                 }
                               >
-                                {action.description}
+                                {action.label}
                               </span>
-                            ) : null}
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
+                              {action.description ? (
+                                <span
+                                  className="mt-1 block whitespace-normal break-words text-sm leading-5 text-muted-foreground"
+                                  data-testid={
+                                    action.testId
+                                      ? `${action.testId}-description`
+                                      : undefined
+                                  }
+                                >
+                                  {action.description}
+                                </span>
+                              ) : null}
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
 
-            {showGenericEmpty ? (
-              <div
-                className="mt-auto rounded-3xl border border-dashed border-border/80 bg-card/70 px-6 py-10 text-center shadow-xs"
-                data-testid="message-empty"
-              >
-                <p className="text-base font-semibold tracking-tight">
-                  {emptyTitle}
-                </p>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {emptyDescription}
-                </p>
-              </div>
-            ) : null}
+              {showGenericEmpty ? (
+                <div
+                  className="mt-auto rounded-3xl border border-dashed border-border/80 bg-card/70 px-6 py-10 text-center shadow-xs"
+                  data-testid="message-empty"
+                >
+                  <p className="text-base font-semibold tracking-tight">
+                    {emptyTitle}
+                  </p>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {emptyDescription}
+                  </p>
+                </div>
+              ) : null}
 
-            {showMessageList ? (
-              <div
-                className={cn("flex flex-col gap-2", !showIntro && "mt-auto")}
-              >
-                <TimelineMessageList
-                  agentPubkeys={agentPubkeys}
-                  channelId={channelId}
-                  channelName={channelName}
-                  channelType={channelType}
-                  currentPubkey={currentPubkey}
-                  followThreadById={followThreadById}
-                  highlightedMessageId={highlightedMessageId}
-                  isFollowingThreadById={isFollowingThreadById}
-                  messageFooters={messageFooters}
-                  messages={messages}
-                  onDelete={onDelete}
-                  onEdit={onEdit}
-                  onMarkUnread={onMarkUnread}
-                  onReply={onReply}
-                  isSendingVideoReviewComment={isSendingVideoReviewComment}
-                  onSendVideoReviewComment={onSendVideoReviewComment}
-                  onToggleReaction={onToggleReaction}
-                  personaLookup={personaLookup}
-                  profiles={profiles}
-                  searchActiveMessageId={searchActiveMessageId}
-                  searchMatchingMessageIds={searchMatchingMessageIds}
-                  searchQuery={searchQuery}
-                  unfollowThreadById={unfollowThreadById}
-                />
-              </div>
-            ) : null}
+              {showMessageList ? (
+                <div
+                  className={cn("flex flex-col gap-2", !showIntro && "mt-auto")}
+                >
+                  <TimelineMessageList
+                    agentPubkeys={agentPubkeys}
+                    channelId={channelId}
+                    channelName={channelName}
+                    channelType={channelType}
+                    currentPubkey={currentPubkey}
+                    followThreadById={followThreadById}
+                    highlightedMessageId={highlightedMessageId}
+                    isFollowingThreadById={isFollowingThreadById}
+                    messageFooters={messageFooters}
+                    messages={messages}
+                    onDelete={onDelete}
+                    onEdit={onEdit}
+                    onMarkUnread={onMarkUnread}
+                    onReply={onReply}
+                    isSendingVideoReviewComment={isSendingVideoReviewComment}
+                    onSendVideoReviewComment={onSendVideoReviewComment}
+                    onToggleReaction={onToggleReaction}
+                    personaLookup={personaLookup}
+                    profiles={profiles}
+                    searchActiveMessageId={searchActiveMessageId}
+                    searchMatchingMessageIds={searchMatchingMessageIds}
+                    searchQuery={searchQuery}
+                    unfollowThreadById={unfollowThreadById}
+                  />
+                </div>
+              ) : null}
+            </SkeletonReveal>
 
             <div aria-hidden className="h-px" ref={bottomAnchorRef} />
           </div>
@@ -400,7 +418,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
             )}
           >
             <Button
-              className="pointer-events-auto h-7 min-h-7 gap-1.5 rounded-full border-border/50 bg-background/85 px-2.5 text-[11px] font-medium text-muted-foreground shadow-xs backdrop-blur-sm hover:bg-muted/70 hover:text-foreground [&_svg]:size-3.5"
+              className="pointer-events-auto h-7 min-h-7 gap-1.5 rounded-full border-border/50 bg-background/85 px-2.5 text-[11px] font-medium text-muted-foreground shadow-xs backdrop-blur-sm hover:bg-muted/70 hover:text-foreground [&_svg]:size-4"
               data-testid="message-scroll-to-latest"
               onClick={() => {
                 scrollToBottom("smooth");

--- a/desktop/src/features/messages/ui/TimelineSkeleton.tsx
+++ b/desktop/src/features/messages/ui/TimelineSkeleton.tsx
@@ -1,22 +1,242 @@
+import * as React from "react";
+
+import type { TimelineMessage } from "@/features/messages/types";
+import { cn } from "@/shared/lib/cn";
 import { Skeleton } from "@/shared/ui/skeleton";
 
-export function TimelineSkeleton() {
-  const skeletonRows = ["first", "second", "third", "fourth"];
+const TIMELINE_SKELETON_CACHE_PREFIX = "buzz-timeline-skeleton-shape.v1";
+const timelineSkeletonWidthClasses = [
+  "w-10",
+  "w-12",
+  "w-16",
+  "w-20",
+  "w-24",
+  "w-28",
+  "w-32",
+  "w-1/2",
+  "w-2/3",
+  "w-3/4",
+  "w-4/5",
+  "w-5/6",
+  "w-11/12",
+  "w-full",
+] as const;
+const timelineSkeletonActionKeys = ["reply", "react", "more"] as const;
+const timelineSkeletonBodyLineKeys = ["primary", "secondary", "tertiary"];
+
+type TimelineSkeletonWidthClass = (typeof timelineSkeletonWidthClasses)[number];
+
+export type TimelineSkeletonRowShape = {
+  actionCount: number;
+  authorWidthClass: TimelineSkeletonWidthClass;
+  bodyLineWidthClasses: TimelineSkeletonWidthClass[];
+  key: string;
+};
+
+type TimelineSkeletonCachePayload = {
+  rows: TimelineSkeletonRowShape[];
+  version: 1;
+};
+
+const fallbackTimelineSkeletonRows: TimelineSkeletonRowShape[] = [
+  {
+    actionCount: 3,
+    authorWidthClass: "w-28",
+    bodyLineWidthClasses: ["w-full", "w-4/5"],
+    key: "first",
+  },
+  {
+    actionCount: 3,
+    authorWidthClass: "w-24",
+    bodyLineWidthClasses: ["w-full", "w-2/3"],
+    key: "second",
+  },
+  {
+    actionCount: 3,
+    authorWidthClass: "w-32",
+    bodyLineWidthClasses: ["w-5/6"],
+    key: "third",
+  },
+  {
+    actionCount: 3,
+    authorWidthClass: "w-20",
+    bodyLineWidthClasses: ["w-full", "w-4/5"],
+    key: "fourth",
+  },
+];
+
+function isTimelineWidthClass(
+  value: unknown,
+): value is TimelineSkeletonWidthClass {
+  return timelineSkeletonWidthClasses.includes(
+    value as TimelineSkeletonWidthClass,
+  );
+}
+
+function parseTimelineSkeletonRows(
+  rows: unknown,
+): TimelineSkeletonRowShape[] | null {
+  if (!Array.isArray(rows)) return null;
+
+  const parsed = rows
+    .slice(0, 4)
+    .filter((row: unknown): row is TimelineSkeletonRowShape => {
+      if (typeof row !== "object" || row === null) return false;
+      const record = row as Record<string, unknown>;
+      return (
+        typeof record.key === "string" &&
+        Number.isInteger(record.actionCount) &&
+        Number(record.actionCount) >= 0 &&
+        Number(record.actionCount) <= timelineSkeletonActionKeys.length &&
+        isTimelineWidthClass(record.authorWidthClass) &&
+        Array.isArray(record.bodyLineWidthClasses) &&
+        record.bodyLineWidthClasses.length > 0 &&
+        record.bodyLineWidthClasses.length <= 3 &&
+        record.bodyLineWidthClasses.every(isTimelineWidthClass)
+      );
+    });
+
+  return parsed.length > 0 ? parsed : null;
+}
+
+function timelineSkeletonCacheKey(channelId?: string | null) {
+  return channelId ? `${TIMELINE_SKELETON_CACHE_PREFIX}:${channelId}` : null;
+}
+
+function readTimelineSkeletonRows(
+  channelId?: string | null,
+): TimelineSkeletonRowShape[] | null {
+  const cacheKey = timelineSkeletonCacheKey(channelId);
+  if (!cacheKey || typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem(cacheKey);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const payload = parsed as Record<string, unknown>;
+    if (payload.version !== 1) return null;
+
+    return parseTimelineSkeletonRows(payload.rows);
+  } catch {
+    return null;
+  }
+}
+
+function writeTimelineSkeletonRows(
+  channelId: string | null | undefined,
+  rows: TimelineSkeletonRowShape[],
+) {
+  const cacheKey = timelineSkeletonCacheKey(channelId);
+  if (!cacheKey || rows.length === 0 || typeof window === "undefined") return;
+
+  const payload: TimelineSkeletonCachePayload = {
+    rows: rows.slice(0, 4),
+    version: 1,
+  };
+
+  try {
+    window.localStorage.setItem(cacheKey, JSON.stringify(payload));
+  } catch {
+    // localStorage can be unavailable or full in embedded webviews.
+  }
+}
+
+function widthClassForText(text: string): TimelineSkeletonWidthClass {
+  const length = text.trim().length;
+  if (length >= 18) return "w-32";
+  if (length >= 14) return "w-28";
+  if (length >= 10) return "w-24";
+  if (length >= 7) return "w-20";
+  return "w-16";
+}
+
+function bodyLineWidthsForText(text: string): TimelineSkeletonWidthClass[] {
+  const length = text.replace(/\s+/g, " ").trim().length;
+  if (length >= 140) return ["w-full", "w-11/12", "w-2/3"];
+  if (length >= 90) return ["w-full", "w-4/5"];
+  if (length >= 48) return ["w-5/6", "w-2/3"];
+  if (length >= 24) return ["w-2/3"];
+  return ["w-1/2"];
+}
+
+function rowsFromMessages(
+  messages: TimelineMessage[],
+): TimelineSkeletonRowShape[] {
+  return messages.slice(-4).map((message, index) => ({
+    actionCount: Math.min(
+      timelineSkeletonActionKeys.length,
+      Math.max(2, (message.reactions?.length ?? 0) + 2),
+    ),
+    authorWidthClass: widthClassForText(message.author),
+    bodyLineWidthClasses: bodyLineWidthsForText(message.body),
+    key: message.renderKey ?? message.id ?? `message-${index}`,
+  }));
+}
+
+export function useTimelineSkeletonRows({
+  channelId,
+  isLoading,
+  messages,
+}: {
+  channelId?: string | null;
+  isLoading: boolean;
+  messages: TimelineMessage[];
+}) {
+  const liveRows = React.useMemo(() => rowsFromMessages(messages), [messages]);
+  const cachedRows = React.useMemo(
+    () => readTimelineSkeletonRows(channelId),
+    [channelId],
+  );
+
+  React.useEffect(() => {
+    if (isLoading || liveRows.length === 0) return;
+    writeTimelineSkeletonRows(channelId, liveRows);
+  }, [channelId, isLoading, liveRows]);
+
+  return liveRows.length > 0 ? liveRows : (cachedRows ?? undefined);
+}
+
+type TimelineSkeletonProps = {
+  rows?: TimelineSkeletonRowShape[];
+};
+
+export function TimelineSkeleton({ rows }: TimelineSkeletonProps) {
+  const skeletonRows = rows?.length ? rows : fallbackTimelineSkeletonRows;
 
   return (
     <>
-      {skeletonRows.map((row, index) => (
-        <div className="flex gap-2.5" key={row}>
-          <Skeleton className="h-9 w-9 shrink-0 rounded-xl" />
-          <div className="min-w-0 flex-1 space-y-1">
-            <div className="flex items-baseline gap-2">
-              <Skeleton className="h-3.5 w-28" />
-              <Skeleton className="h-3 w-12" />
+      {skeletonRows.map((row) => (
+        <article
+          className="relative flex items-start gap-2.5 rounded-2xl px-3 py-2"
+          key={row.key}
+        >
+          <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
+          <div className="-mt-1 min-w-0 flex-1">
+            <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0">
+              <Skeleton className={cn("h-[15px]", row.authorWidthClass)} />
+              <Skeleton className="h-3 w-10" />
             </div>
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className={index % 2 === 0 ? "h-4 w-4/5" : "h-4 w-2/3"} />
+            <div className="mt-1 space-y-1.5 pb-2">
+              {timelineSkeletonBodyLineKeys
+                .slice(0, row.bodyLineWidthClasses.length)
+                .map((lineKey, index) => (
+                  <Skeleton
+                    className={cn("h-4", row.bodyLineWidthClasses[index])}
+                    key={`${row.key}-body-${lineKey}`}
+                  />
+                ))}
+            </div>
+            <div className="flex items-center gap-4">
+              {timelineSkeletonActionKeys
+                .slice(0, row.actionCount)
+                .map((key) => (
+                  <Skeleton className="h-4 w-8 rounded-full" key={key} />
+                ))}
+            </div>
           </div>
-        </div>
+        </article>
       ))}
     </>
   );

--- a/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
+++ b/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
@@ -117,7 +117,7 @@ export function TypingIndicatorRow({
                         : "h-5 w-5 text-[8px]",
                     )}
                     iconClassName={
-                      isActivityVariant ? "h-2.5 w-2.5" : "h-3 w-3"
+                      isActivityVariant ? "h-2.5 w-2.5" : "h-4 w-4"
                     }
                   />
                 </div>

--- a/desktop/src/features/onboarding/ui/AvatarStep.tsx
+++ b/desktop/src/features/onboarding/ui/AvatarStep.tsx
@@ -167,7 +167,7 @@ function AvatarStepActions({
             {isSaving || isUploadingAvatar ? (
               <Spinner
                 aria-label={isSaving ? "Saving profile" : "Uploading avatar"}
-                className="h-4 w-4"
+                className="h-4 w-4 border-2"
               />
             ) : (
               "Next"

--- a/desktop/src/features/onboarding/ui/MembershipDenied.tsx
+++ b/desktop/src/features/onboarding/ui/MembershipDenied.tsx
@@ -89,7 +89,7 @@ export function MembershipDenied({
           <Badge variant="warning">Membership required</Badge>
           <div className="flex items-center gap-3">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive/10">
-              <ShieldX className="h-5 w-5 text-destructive" />
+              <ShieldX className="h-4 w-4 text-destructive" />
             </div>
             <h1 className="text-2xl font-semibold tracking-tight text-foreground">
               Not a member yet
@@ -172,7 +172,7 @@ export function MembershipDenied({
                   className="flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs"
                   data-testid="membership-denied-npub-preview"
                 >
-                  <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+                  <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
                   <div className="min-w-0 space-y-0.5">
                     <p className="font-medium text-foreground">
                       This will use this Nostr identity:
@@ -197,7 +197,10 @@ export function MembershipDenied({
                 type="submit"
               >
                 {isImportingKey ? (
-                  <Spinner aria-label="Importing key" className="h-4 w-4" />
+                  <Spinner
+                    aria-label="Importing key"
+                    className="h-4 w-4 border-2"
+                  />
                 ) : (
                   "Import key"
                 )}
@@ -236,7 +239,7 @@ export function MembershipDenied({
                   }}
                   type="button"
                 >
-                  <KeyRound className="h-3 w-3" />
+                  <KeyRound className="h-4 w-4" />
                   Use a different key
                 </button>
               ) : null}

--- a/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
+++ b/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
@@ -222,7 +222,7 @@ export function NostrKeyImportForm({
           className="flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs"
           data-testid="nostr-import-npub-preview"
         >
-          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+          <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
           <div className="min-w-0 space-y-0.5">
             <p className="font-medium text-foreground">
               This will use this Nostr identity:

--- a/desktop/src/features/onboarding/ui/ProfileStep.tsx
+++ b/desktop/src/features/onboarding/ui/ProfileStep.tsx
@@ -92,6 +92,7 @@ export function ProfileStep({
           ) : null}
           <input
             aria-label="Name"
+            autoCapitalize="none"
             autoComplete="off"
             autoCorrect="off"
             className={cn(
@@ -128,7 +129,7 @@ export function ProfileStep({
           type="button"
         >
           {isSaving ? (
-            <Spinner aria-label="Saving profile" className="h-4 w-4" />
+            <Spinner aria-label="Saving profile" className="h-4 w-4 border-2" />
           ) : (
             "Next"
           )}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -106,7 +106,7 @@ function RuntimeStatus({
         className="flex h-8 shrink-0 items-center justify-center"
         role="status"
       >
-        <Spinner className="h-4 w-4 text-foreground" />
+        <Spinner className="h-4 w-4 border-2 text-foreground" />
       </div>
     );
   }

--- a/desktop/src/features/profile/ui/AvatarUpload.tsx
+++ b/desktop/src/features/profile/ui/AvatarUpload.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
-import { Camera, Link2, Loader2, Upload, X } from "lucide-react";
+import { Camera, Link2, Upload, X } from "lucide-react";
 
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
 import { Input } from "@/shared/ui/input";
+import { Spinner } from "@/shared/ui/spinner";
 
 type AvatarUploadProps = {
   avatarUrl: string;
@@ -90,7 +91,7 @@ export function AvatarUpload({
               title="Remove photo"
               type="button"
             >
-              <X className="h-3 w-3" />
+              <X className="h-4 w-4" />
             </button>
           ) : (
             <div className="absolute -bottom-1 -right-1 flex h-8 w-8 items-center justify-center rounded-full border border-background bg-primary text-primary-foreground shadow-xs">
@@ -127,9 +128,12 @@ export function AvatarUpload({
           type="button"
         >
           {isUploading ? (
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            <Spinner
+              aria-hidden
+              className="h-4 w-4 border-2 text-muted-foreground"
+            />
           ) : (
-            <Upload className="h-5 w-5 text-muted-foreground" />
+            <Upload className="h-4 w-4 text-muted-foreground" />
           )}
           <span className="text-xs text-muted-foreground">
             {isUploading ? (

--- a/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
@@ -1,6 +1,6 @@
 import emojiData from "@emoji-mart/data";
 import Picker from "@emoji-mart/react";
-import { Link2, Loader2, UploadCloud } from "lucide-react";
+import { Link2, UploadCloud } from "lucide-react";
 import { motion } from "motion/react";
 import * as React from "react";
 
@@ -579,7 +579,10 @@ export function ProfileAvatarEditor({
                       data-testid={`${testIdPrefix}-drop-mask`}
                     />
                     {isUploading ? (
-                      <Loader2 className="relative h-8 w-8 animate-spin text-muted-foreground" />
+                      <Spinner
+                        aria-hidden
+                        className="relative h-8 w-8 text-muted-foreground"
+                      />
                     ) : (
                       <UploadCloud
                         className={cn(
@@ -612,6 +615,8 @@ export function ProfileAvatarEditor({
                   <div className="flex h-16 items-center gap-3 rounded-xl bg-muted px-5 transition-colors duration-[250ms] ease-out focus-within:bg-muted/80">
                     <Link2 className="h-4 w-4 text-muted-foreground" />
                     <input
+                      autoCapitalize="none"
+                      autoCorrect="off"
                       className="min-w-0 flex-1 bg-transparent text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground"
                       data-testid={`${testIdPrefix}-url`}
                       disabled={isInputDisabled}
@@ -636,6 +641,7 @@ export function ProfileAvatarEditor({
                         }
                       }}
                       placeholder="Paste a URL (Slack profile, etc.)"
+                      spellCheck={false}
                       type="url"
                       value={urlDraft}
                     />
@@ -960,7 +966,10 @@ export function ProfileAvatarEditor({
               type="button"
             >
               {donePending ? (
-                <Spinner aria-label="Saving avatar" className="h-4 w-4" />
+                <Spinner
+                  aria-label="Saving avatar"
+                  className="h-4 w-4 border-2"
+                />
               ) : (
                 "Done"
               )}

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -345,7 +345,7 @@ function ProfileHeroDescription({ about }: { about: string }) {
           type="button"
         >
           more
-          <ChevronDown className="h-3 w-3" />
+          <ChevronDown className="h-4 w-4" />
         </button>
       ) : null}
       {expanded ? (
@@ -356,7 +356,7 @@ function ProfileHeroDescription({ about }: { about: string }) {
           type="button"
         >
           less
-          <ChevronUp className="h-3 w-3" />
+          <ChevronUp className="h-4 w-4" />
         </button>
       ) : null}
     </div>

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -259,7 +259,7 @@ export function UserProfilePopover({
               }}
               type="button"
             >
-              <Activity className="h-3.5 w-3.5 text-muted-foreground" />
+              <Activity className="h-4 w-4 text-muted-foreground" />
               View activity log
             </button>
           ) : null}

--- a/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
@@ -30,7 +30,7 @@ function CloneUrlRow({ url }: { url: string }) {
 
   return (
     <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-3 py-2">
-      <GitFork className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <GitFork className="h-4 w-4 shrink-0 text-muted-foreground" />
       <code className="min-w-0 flex-1 truncate text-xs">{url}</code>
       <Button
         className="h-6 w-6 shrink-0"
@@ -39,9 +39,9 @@ function CloneUrlRow({ url }: { url: string }) {
         variant="ghost"
       >
         {copied ? (
-          <Check className="h-3 w-3 text-green-500" />
+          <Check className="h-4 w-4 text-green-500" />
         ) : (
-          <Copy className="h-3 w-3" />
+          <Copy className="h-4 w-4" />
         )}
       </Button>
     </div>
@@ -89,7 +89,7 @@ export function ProjectDetailScreen({ projectId }: ProjectDetailScreenProps) {
             size="sm"
             variant="ghost"
           >
-            <ArrowLeft className="mr-1.5 h-3.5 w-3.5" />
+            <ArrowLeft className="mr-1.5 h-4 w-4" />
             Back to Projects
           </Button>
         </div>
@@ -111,7 +111,7 @@ export function ProjectDetailScreen({ projectId }: ProjectDetailScreenProps) {
           size="sm"
           variant="outline"
         >
-          <ArrowLeft className="mr-1.5 h-3.5 w-3.5" />
+          <ArrowLeft className="mr-1.5 h-4 w-4" />
           Back to Projects
         </Button>
       </div>
@@ -136,7 +136,7 @@ export function ProjectDetailScreen({ projectId }: ProjectDetailScreenProps) {
             size="sm"
             variant="ghost"
           >
-            <ArrowLeft className="h-3.5 w-3.5" />
+            <ArrowLeft className="h-4 w-4" />
             Back to Projects
           </Button>
         </div>
@@ -144,7 +144,7 @@ export function ProjectDetailScreen({ projectId }: ProjectDetailScreenProps) {
         <div className="mx-auto w-full max-w-2xl space-y-6">
           <section className="space-y-2">
             <div className="flex items-center gap-2">
-              <FolderGit2 className="h-5 w-5 text-muted-foreground" />
+              <FolderGit2 className="h-4 w-4 text-muted-foreground" />
               <h2 className="text-lg font-semibold">{project.name}</h2>
             </div>
             {project.description ? (
@@ -178,7 +178,7 @@ export function ProjectDetailScreen({ projectId }: ProjectDetailScreenProps) {
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                <ExternalLink className="h-3.5 w-3.5" />
+                <ExternalLink className="h-4 w-4" />
                 {project.webUrl}
               </a>
             </section>
@@ -188,7 +188,7 @@ export function ProjectDetailScreen({ projectId }: ProjectDetailScreenProps) {
             <section className="space-y-2">
               <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                 <span className="flex items-center gap-1.5">
-                  <Users className="h-3.5 w-3.5" />
+                  <Users className="h-4 w-4" />
                   Contributors ({project.contributors.length})
                 </span>
               </h3>

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -86,19 +86,19 @@ export function ProjectsView() {
                 <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground/70">
                   {project.cloneUrls.length > 0 ? (
                     <span className="flex items-center gap-1">
-                      <GitFork className="h-3 w-3" />
+                      <GitFork className="h-4 w-4" />
                       {project.cloneUrls[0]}
                     </span>
                   ) : null}
                   {project.contributors.length > 0 ? (
                     <span className="flex items-center gap-1">
-                      <Users className="h-3 w-3" />
+                      <Users className="h-4 w-4" />
                       {project.contributors.length}
                     </span>
                   ) : null}
                   {project.webUrl ? (
                     <span className="flex items-center gap-1">
-                      <ExternalLink className="h-3 w-3" />
+                      <ExternalLink className="h-4 w-4" />
                       Web
                     </span>
                   ) : null}

--- a/desktop/src/features/pulse/ui/AgentActivityCard.tsx
+++ b/desktop/src/features/pulse/ui/AgentActivityCard.tsx
@@ -66,7 +66,7 @@ export function AgentActivityCard({
             type="button"
           >
             <UserAvatar avatarUrl={avatarUrl} displayName={displayName} />
-            <Bot className="absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full bg-background p-0.5 text-muted-foreground" />
+            <Bot className="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full bg-background p-0.5 text-muted-foreground" />
           </button>
         </UserProfilePopover>
         <div className="min-w-0 flex-1">
@@ -87,9 +87,9 @@ export function AgentActivityCard({
             type="button"
           >
             {expanded ? (
-              <ChevronDown className="h-3.5 w-3.5" />
+              <ChevronDown className="h-4 w-4" />
             ) : (
-              <ChevronRight className="h-3.5 w-3.5" />
+              <ChevronRight className="h-4 w-4" />
             )}
             {group.notes.length} updates
           </button>

--- a/desktop/src/features/pulse/ui/NoteCard.tsx
+++ b/desktop/src/features/pulse/ui/NoteCard.tsx
@@ -171,7 +171,7 @@ export function NoteCard({
             displayName={displayName}
           />
           {isAgent ? (
-            <Bot className="absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full bg-background p-0.5 text-muted-foreground" />
+            <Bot className="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full bg-background p-0.5 text-muted-foreground" />
           ) : null}
         </button>
       </UserProfilePopover>

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -349,7 +349,7 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
                       className="absolute right-1.5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full bg-foreground/10 text-foreground transition-colors hover:bg-foreground/15 dark:bg-white/85 dark:text-black dark:hover:bg-white"
                       type="button"
                     >
-                      <Search className="h-3.5 w-3.5" />
+                      <Search className="h-4 w-4" />
                     </button>
                   </div>
                 </div>

--- a/desktop/src/features/relay-members/ui/RelayMembersCard.tsx
+++ b/desktop/src/features/relay-members/ui/RelayMembersCard.tsx
@@ -121,7 +121,7 @@ function MemberRow({
               size="sm"
               variant="ghost"
             >
-              <MoreHorizontal className="h-3.5 w-3.5" />
+              <MoreHorizontal className="h-4 w-4" />
               <span className="sr-only">Actions</span>
             </Button>
           </DropdownMenuTrigger>
@@ -231,7 +231,7 @@ export function RelayMembersCard({
             onClick={() => setAddDialogOpen(true)}
             size="sm"
           >
-            <Plus className="h-3.5 w-3.5" />
+            <Plus className="h-4 w-4" />
             Add Member
           </Button>
         ) : null}

--- a/desktop/src/features/relay-members/ui/RelayMembersSettingsCard.tsx
+++ b/desktop/src/features/relay-members/ui/RelayMembersSettingsCard.tsx
@@ -165,10 +165,10 @@ function RelayMemberRow({
       <div className="min-w-0 flex-1 space-y-0.5">
         <div className="flex flex-wrap items-center gap-1.5">
           {member.role === "owner" ? (
-            <Crown className="h-3.5 w-3.5 text-amber-500" />
+            <Crown className="h-4 w-4 text-amber-500" />
           ) : null}
           {member.role === "admin" ? (
-            <Shield className="h-3.5 w-3.5 text-blue-500" />
+            <Shield className="h-4 w-4 text-blue-500" />
           ) : null}
           <span className="truncate text-sm font-medium">{displayName}</span>
           {isSelf ? (
@@ -461,10 +461,13 @@ export function RelayMembersSettingsCard({
           <div className="relative">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <input
+              autoCapitalize="none"
+              autoCorrect="off"
               className="w-full rounded-lg border border-border/70 bg-background/70 py-2 pl-9 pr-3 text-sm placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
               data-testid="relay-members-search"
               onChange={(event) => setSearch(event.target.value)}
               placeholder="Search members by name, npub, or role…"
+              spellCheck={false}
               type="text"
               value={search}
             />

--- a/desktop/src/features/search/ui/ChannelFindBar.tsx
+++ b/desktop/src/features/search/ui/ChannelFindBar.tsx
@@ -62,6 +62,8 @@ export function ChannelFindBar({
       <div className="relative flex min-w-0 flex-1 items-center">
         <input
           ref={inputRef}
+          autoCapitalize="none"
+          autoCorrect="off"
           className={cn(
             "h-7 w-full rounded-md border border-input bg-transparent px-2 pr-20 text-sm",
             "placeholder:text-muted-foreground",
@@ -70,6 +72,7 @@ export function ChannelFindBar({
           onChange={(event) => onQueryChange(event.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Find in channel"
+          spellCheck={false}
           type="text"
           value={query}
         />

--- a/desktop/src/features/search/ui/TopbarSearch.tsx
+++ b/desktop/src/features/search/ui/TopbarSearch.tsx
@@ -1,4 +1,4 @@
-import { LoaderCircle, Search } from "lucide-react";
+import { Search } from "lucide-react";
 import * as React from "react";
 
 import { resolveUserLabel } from "@/features/profile/lib/identity";
@@ -14,6 +14,7 @@ import {
 } from "@/features/search/ui/SearchResultItem";
 import type { Channel, SearchHit } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { Skeleton } from "@/shared/ui/skeleton";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
 type TopbarSearchProps = {
@@ -74,6 +75,62 @@ function formatRelativeTime(unixSeconds: number) {
     month: "short",
     day: "numeric",
   }).format(new Date(unixSeconds * 1_000));
+}
+
+const searchSkeletonRows = [
+  {
+    iconShape: "rounded-md",
+    key: "channel",
+    metaWidth: "w-16",
+    previewWidth: "w-48",
+    titleWidth: "w-28",
+    trailingWidth: "w-14",
+  },
+  {
+    iconShape: "rounded-full",
+    key: "message",
+    metaWidth: "w-24",
+    previewWidth: "w-72",
+    titleWidth: "w-24",
+    trailingWidth: "w-20",
+  },
+  {
+    iconShape: "rounded-full",
+    key: "note",
+    metaWidth: "w-20",
+    previewWidth: "w-60",
+    titleWidth: "w-32",
+    trailingWidth: "w-16",
+  },
+] as const;
+
+function SearchResultsSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      className="max-h-[360px] overflow-y-auto p-1.5"
+      data-testid="search-results-loading"
+    >
+      {searchSkeletonRows.map((row) => (
+        <div
+          className="flex w-full items-center gap-3 rounded-lg px-3 py-2"
+          key={row.key}
+        >
+          <Skeleton className={cn("h-7 w-7 shrink-0", row.iconShape)} />
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <Skeleton className={cn("h-4", row.titleWidth)} />
+              <Skeleton className={cn("h-3", row.metaWidth)} />
+            </div>
+            <Skeleton
+              className={cn("mt-1.5 h-3 max-w-full", row.previewWidth)}
+            />
+          </div>
+          <Skeleton className={cn("h-3 shrink-0", row.trailingWidth)} />
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export function TopbarSearch({
@@ -156,11 +213,13 @@ export function TopbarSearch({
 
   return (
     <div className={cn("relative", className)} ref={rootRef}>
-      <div className="flex h-7 items-center gap-2 rounded-lg border border-border/70 bg-muted/45 px-2.5 text-xs text-muted-foreground shadow-xs backdrop-blur transition-colors focus-within:border-border focus-within:bg-muted/70 focus-within:text-foreground hover:bg-muted/70 supports-[backdrop-filter]:bg-muted/35">
-        <Search className="h-3.5 w-3.5 shrink-0" />
+      <div className="group/search flex h-7 items-center gap-2 rounded-lg border border-border/70 bg-background px-2.5 text-xs text-muted-foreground shadow-xs transition-colors duration-150 ease-out focus-within:border-border focus-within:bg-muted/70 focus-within:text-foreground hover:bg-muted/70">
+        <Search className="h-4 w-4 shrink-0 text-muted-foreground/55 transition-colors duration-150 ease-out group-focus-within/search:text-foreground group-hover/search:text-muted-foreground" />
         <input
           aria-label="Search everything"
-          className="min-w-0 flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground outline-none"
+          autoCapitalize="none"
+          autoCorrect="off"
+          className="min-w-0 translate-y-px flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground/55 outline-none transition-colors duration-150 ease-out group-focus-within/search:placeholder:text-foreground group-hover/search:placeholder:text-muted-foreground"
           data-testid="open-search"
           ref={inputRef}
           onChange={(event) => {
@@ -199,6 +258,7 @@ export function TopbarSearch({
             }
           }}
           placeholder="Search everything"
+          spellCheck={false}
           value={query}
         />
         <kbd className="shrink-0 text-[10px] text-muted-foreground/70">
@@ -208,6 +268,7 @@ export function TopbarSearch({
 
       {showSuggestions ? (
         <div
+          aria-busy={searchQuery.isLoading && results.length === 0}
           className="absolute left-1/2 top-full z-50 mt-1 w-[620px] max-w-[min(82vw,620px)] -translate-x-1/2 overflow-hidden rounded-xl border border-border/80 bg-popover text-popover-foreground shadow-xl"
           data-testid="search-results"
         >
@@ -216,10 +277,7 @@ export function TopbarSearch({
               <p>Type at least two characters for live suggestions.</p>
             </div>
           ) : searchQuery.isLoading && results.length === 0 ? (
-            <div className="flex items-center gap-2 px-3 py-3 text-xs text-muted-foreground">
-              <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-              Searching...
-            </div>
+            <SearchResultsSkeleton />
           ) : searchQuery.error instanceof Error && results.length === 0 ? (
             <p className="px-3 py-3 text-xs text-destructive">
               {searchQuery.error.message}

--- a/desktop/src/features/settings/UpdateIndicator.tsx
+++ b/desktop/src/features/settings/UpdateIndicator.tsx
@@ -1,6 +1,8 @@
-import { Loader2, RefreshCcw, RotateCw } from "lucide-react";
+import type { ComponentType } from "react";
+import { RefreshCcw, RotateCw } from "lucide-react";
 
 import { Button } from "@/shared/ui/button";
+import { Spinner } from "@/shared/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 import { useUpdaterContext } from "./hooks/UpdaterProvider";
@@ -9,13 +11,18 @@ import type { UpdateStatus } from "./hooks/use-updater";
 const indicatorButtonClass =
   "relative text-muted-foreground/80 hover:bg-muted/60 hover:text-foreground";
 
+type IndicatorIcon = ComponentType<{
+  "aria-hidden"?: boolean;
+  className?: string;
+}>;
+
 const variants: Record<
   "available" | "downloading" | "installing" | "ready",
   {
-    Icon: typeof RefreshCcw;
+    Icon: IndicatorIcon;
+    iconClassName?: string;
     label: string;
     badgeColor: string;
-    spin?: boolean;
   }
 > = {
   available: {
@@ -24,16 +31,16 @@ const variants: Record<
     badgeColor: "bg-primary",
   },
   downloading: {
-    Icon: Loader2,
+    Icon: Spinner,
+    iconClassName: "h-4 w-4 border-2",
     label: "Downloading update\u2026",
     badgeColor: "bg-primary",
-    spin: true,
   },
   installing: {
-    Icon: Loader2,
+    Icon: Spinner,
+    iconClassName: "h-4 w-4 border-2",
     label: "Installing update\u2026",
     badgeColor: "bg-primary",
-    spin: true,
   },
   ready: {
     Icon: RotateCw,
@@ -62,7 +69,7 @@ export function UpdateIndicator({ className }: { className?: string }) {
     return null;
   }
 
-  const { Icon, label, badgeColor, spin } = variant;
+  const { Icon, iconClassName = "h-4 w-4", label, badgeColor } = variant;
   const isActionable = status.state === "available" || status.state === "ready";
   const handleClick =
     status.state === "ready"
@@ -87,7 +94,7 @@ export function UpdateIndicator({ className }: { className?: string }) {
           type="button"
           variant="ghost"
         >
-          <Icon className={spin ? "animate-spin" : undefined} />
+          <Icon aria-hidden className={iconClassName} />
           <span
             className={`absolute right-1 top-1 h-1.5 w-1.5 rounded-full ${badgeColor} animate-pulse`}
           />

--- a/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
@@ -120,7 +120,7 @@ export function ChannelTemplatesSettingsCard() {
           type="button"
           variant="outline"
         >
-          <Plus className="mr-1.5 h-3.5 w-3.5" />
+          <Plus className="mr-1.5 h-4 w-4" />
           Create
         </Button>
       </div>
@@ -229,13 +229,13 @@ function TemplateRow({
         <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
           {agentCount > 0 ? (
             <span className="flex items-center gap-1">
-              <Users className="h-3 w-3" />
+              <Users className="h-4 w-4" />
               {agentCount} {agentCount === 1 ? "agent" : "agents"}
             </span>
           ) : null}
           {template.canvasTemplate ? (
             <span className="flex items-center gap-1">
-              <MessageSquare className="h-3 w-3" />
+              <MessageSquare className="h-4 w-4" />
               canvas
             </span>
           ) : null}
@@ -255,11 +255,11 @@ function TemplateRow({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem onClick={onEdit}>
-            <Pencil className="mr-2 h-3.5 w-3.5" />
+            <Pencil className="mr-2 h-4 w-4" />
             Edit
           </DropdownMenuItem>
           <DropdownMenuItem onClick={onDuplicate}>
-            <Copy className="mr-2 h-3.5 w-3.5" />
+            <Copy className="mr-2 h-4 w-4" />
             Duplicate
           </DropdownMenuItem>
           {!template.isBuiltin ? (
@@ -267,7 +267,7 @@ function TemplateRow({
               className="text-destructive focus:text-destructive"
               onClick={onDelete}
             >
-              <Trash2 className="mr-2 h-3.5 w-3.5" />
+              <Trash2 className="mr-2 h-4 w-4" />
               Delete
             </DropdownMenuItem>
           ) : null}

--- a/desktop/src/features/settings/ui/DoctorSettingsPanel.tsx
+++ b/desktop/src/features/settings/ui/DoctorSettingsPanel.tsx
@@ -56,9 +56,9 @@ function InstallActions({
           variant="outline"
         >
           {isInstalling ? (
-            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+            <RefreshCw className="h-4 w-4 animate-spin" />
           ) : (
-            <Download className="h-3.5 w-3.5" />
+            <Download className="h-4 w-4" />
           )}
           {isInstalling ? "Installing..." : "Install"}
         </Button>
@@ -68,7 +68,7 @@ function InstallActions({
         onClick={() => void openUrl(runtime.installInstructionsUrl)}
         type="button"
       >
-        <ExternalLink className="h-3 w-3" />
+        <ExternalLink className="h-4 w-4" />
         View instructions
       </button>
     </div>

--- a/desktop/src/features/settings/ui/MobilePairingCard.tsx
+++ b/desktop/src/features/settings/ui/MobilePairingCard.tsx
@@ -225,7 +225,7 @@ function PairingDialog({
                     type="button"
                   >
                     <code className="min-w-0 flex-1 break-all">{qrUri}</code>
-                    <Copy className="h-3.5 w-3.5 shrink-0" />
+                    <Copy className="h-4 w-4 shrink-0" />
                   </button>
                 </div>
 
@@ -332,7 +332,7 @@ export function MobilePairingCard({
 
       <SettingsOptionGroup>
         <SettingsOptionRow className="gap-3">
-          <Smartphone className="h-5 w-5 shrink-0 text-muted-foreground" />
+          <Smartphone className="h-4 w-4 shrink-0 text-muted-foreground" />
           <div className="min-w-0 flex-1">
             <p className="text-sm font-medium">Pair Mobile Device</p>
             <p className="text-sm font-normal text-muted-foreground">

--- a/desktop/src/features/settings/ui/NotificationSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/NotificationSettingsCard.tsx
@@ -227,7 +227,7 @@ export function NotificationSettingsCard({
                   >
                     {showComingSoon ? (
                       <>
-                        <ChevronUp className="h-3.5 w-3.5" />
+                        <ChevronUp className="h-4 w-4" />
                         Show less
                       </>
                     ) : (

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -57,7 +57,7 @@ function IdentityRow({
           title={`Copy ${label}`}
           type="button"
         >
-          <Copy className="h-3.5 w-3.5 shrink-0" />
+          <Copy className="h-4 w-4 shrink-0" />
           Copy
         </button>
       ) : null}
@@ -97,7 +97,7 @@ function EditProfileMetadataButton({
       title={accessibleLabel}
       type="button"
     >
-      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <Icon className="h-4 w-4 shrink-0" />
       {actionLabel}
     </button>
   );
@@ -577,7 +577,7 @@ export function ProfileSettingsCard({
                                 this device.
                               </p>
                             </div>
-                            <ChevronDown className="h-5 w-5 shrink-0 text-muted-foreground transition-[color,transform] duration-150 ease-out group-open:rotate-180 group-hover/identity:text-foreground group-focus-visible/identity:text-foreground" />
+                            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-[color,transform] duration-150 ease-out group-open:rotate-180 group-hover/identity:text-foreground group-focus-visible/identity:text-foreground" />
                           </summary>
                           <div
                             className="border-t border-border/55 divide-y divide-border/55"

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -193,9 +193,12 @@ function ThemeSettingsCard() {
       <div className="relative mb-3">
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <input
+          autoCapitalize="none"
+          autoCorrect="off"
           className="w-full rounded-lg border border-border/70 bg-background/70 py-2 pl-9 pr-3 text-sm placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search themes..."
+          spellCheck={false}
           type="text"
           value={search}
         />
@@ -269,7 +272,7 @@ function ThemeSettingsCard() {
                 type="button"
               >
                 {accentColor === color.value && (
-                  <Check className={cn("h-3.5 w-3.5", checkClassName)} />
+                  <Check className={cn("h-4 w-4", checkClassName)} />
                 )}
               </button>
             );

--- a/desktop/src/features/settings/ui/SoundPicker.tsx
+++ b/desktop/src/features/settings/ui/SoundPicker.tsx
@@ -135,9 +135,9 @@ export function SoundPicker({
         variant="ghost"
       >
         {isPlaying ? (
-          <Pause className="h-3 w-3" />
+          <Pause className="h-4 w-4" />
         ) : (
-          <Play className="h-3 w-3" />
+          <Play className="h-4 w-4" />
         )}
       </Button>
     </span>

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -60,9 +60,9 @@ import {
   SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSkeleton,
   SidebarRail,
 } from "@/shared/ui/sidebar";
+import { Skeleton } from "@/shared/ui/skeleton";
 
 type CollapsibleSidebarGroup =
   | "starred"
@@ -157,6 +157,304 @@ type AppSidebarProps = {
   onUnstarChannel?: (channelId: string) => void;
 };
 
+const SIDEBAR_SKELETON_CACHE_PREFIX = "buzz-sidebar-skeleton-shape.v1";
+const sidebarLoadingWidthClasses = [
+  "w-14",
+  "w-16",
+  "w-20",
+  "w-24",
+  "w-28",
+  "w-32",
+] as const;
+
+type SidebarLoadingWidthClass = (typeof sidebarLoadingWidthClasses)[number];
+
+type SidebarLoadingRowShape = {
+  avatar?: boolean;
+  key: string;
+  unread?: boolean;
+  widthClass: SidebarLoadingWidthClass;
+};
+
+type SidebarLoadingShape = {
+  channels: SidebarLoadingRowShape[];
+  directMessages: SidebarLoadingRowShape[];
+};
+
+type SidebarLoadingCachePayload = SidebarLoadingShape & {
+  version: 1;
+};
+
+const fallbackSidebarLoadingShape: SidebarLoadingShape = {
+  channels: [
+    { key: "agents", widthClass: "w-20" },
+    { key: "engineering", widthClass: "w-28" },
+    { key: "general", widthClass: "w-20" },
+  ],
+  directMessages: [
+    { key: "alice", widthClass: "w-24" },
+    { key: "bob", widthClass: "w-20" },
+  ],
+};
+
+function isSidebarLoadingWidthClass(
+  value: unknown,
+): value is SidebarLoadingWidthClass {
+  return sidebarLoadingWidthClasses.includes(value as SidebarLoadingWidthClass);
+}
+
+function parseSidebarLoadingRows(
+  rows: unknown,
+  maxRows: number,
+): SidebarLoadingRowShape[] {
+  if (!Array.isArray(rows)) return [];
+
+  return rows
+    .slice(0, maxRows)
+    .filter((row: unknown): row is SidebarLoadingRowShape => {
+      if (typeof row !== "object" || row === null) return false;
+      const record = row as Record<string, unknown>;
+      return (
+        typeof record.key === "string" &&
+        isSidebarLoadingWidthClass(record.widthClass) &&
+        (record.unread === undefined || typeof record.unread === "boolean") &&
+        (record.avatar === undefined || typeof record.avatar === "boolean")
+      );
+    });
+}
+
+function parseSidebarLoadingShape(value: unknown): SidebarLoadingShape | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (record.version !== 1) return null;
+
+  const shape = {
+    channels: parseSidebarLoadingRows(record.channels, 3),
+    directMessages: parseSidebarLoadingRows(record.directMessages, 2),
+  };
+
+  return hasSidebarLoadingRows(shape) ? shape : null;
+}
+
+function hasSidebarLoadingRows(shape: SidebarLoadingShape) {
+  return shape.channels.length > 0 || shape.directMessages.length > 0;
+}
+
+function sidebarSkeletonCacheKey(
+  workspaceId: string | null | undefined,
+  pubkey: string | undefined,
+) {
+  if (!workspaceId) return null;
+  return `${SIDEBAR_SKELETON_CACHE_PREFIX}:${workspaceId}:${pubkey ?? "anonymous"}`;
+}
+
+function readSidebarLoadingShape(
+  cacheKey: string | null,
+): SidebarLoadingShape | null {
+  if (!cacheKey || typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem(cacheKey);
+    return raw ? parseSidebarLoadingShape(JSON.parse(raw)) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSidebarLoadingShape(
+  cacheKey: string | null,
+  shape: SidebarLoadingShape,
+) {
+  if (
+    !cacheKey ||
+    !hasSidebarLoadingRows(shape) ||
+    typeof window === "undefined"
+  ) {
+    return;
+  }
+
+  const payload: SidebarLoadingCachePayload = {
+    channels: shape.channels.slice(0, 3),
+    directMessages: shape.directMessages.slice(0, 2),
+    version: 1,
+  };
+
+  try {
+    window.localStorage.setItem(cacheKey, JSON.stringify(payload));
+  } catch {
+    // localStorage can be unavailable or full in embedded webviews.
+  }
+}
+
+function sidebarWidthClassForText(text: string): SidebarLoadingWidthClass {
+  const length = text.trim().length;
+  if (length >= 20) return "w-32";
+  if (length >= 14) return "w-28";
+  if (length >= 10) return "w-24";
+  if (length >= 6) return "w-20";
+  return "w-16";
+}
+
+function createSidebarLoadingShape({
+  directMessages,
+  dmChannelLabels,
+  streamChannels,
+}: {
+  directMessages: Channel[];
+  dmChannelLabels: Record<string, string>;
+  streamChannels: Channel[];
+}): SidebarLoadingShape {
+  return {
+    channels: streamChannels.slice(0, 3).map((channel) => ({
+      key: channel.id,
+      widthClass: sidebarWidthClassForText(channel.name),
+    })),
+    directMessages: directMessages.slice(0, 2).map((channel) => ({
+      avatar: true,
+      key: channel.id,
+      widthClass: sidebarWidthClassForText(
+        dmChannelLabels[channel.id] ?? channel.name,
+      ),
+    })),
+  };
+}
+
+function useSidebarLoadingShape({
+  activeWorkspaceId,
+  directMessages,
+  dmChannelLabels,
+  isLoading,
+  currentPubkey,
+  streamChannels,
+}: {
+  activeWorkspaceId: string | null | undefined;
+  directMessages: Channel[];
+  dmChannelLabels: Record<string, string>;
+  isLoading: boolean;
+  currentPubkey?: string;
+  streamChannels: Channel[];
+}) {
+  const cacheKey = React.useMemo(
+    () => sidebarSkeletonCacheKey(activeWorkspaceId, currentPubkey),
+    [activeWorkspaceId, currentPubkey],
+  );
+  const liveShape = React.useMemo(
+    () =>
+      createSidebarLoadingShape({
+        directMessages,
+        dmChannelLabels,
+        streamChannels,
+      }),
+    [directMessages, dmChannelLabels, streamChannels],
+  );
+  const cachedShape = React.useMemo(
+    () => readSidebarLoadingShape(cacheKey),
+    [cacheKey],
+  );
+
+  React.useEffect(() => {
+    if (isLoading || !hasSidebarLoadingRows(liveShape)) return;
+    writeSidebarLoadingShape(cacheKey, liveShape);
+  }, [cacheKey, isLoading, liveShape]);
+
+  if (hasSidebarLoadingRows(liveShape)) return liveShape;
+  return cachedShape ?? fallbackSidebarLoadingShape;
+}
+
+function SidebarLoadingRow({
+  avatar = false,
+  widthClass,
+}: {
+  avatar?: boolean;
+  widthClass: string;
+}) {
+  return (
+    <SidebarMenuItem>
+      <div className="flex h-8 items-center gap-2 rounded-md px-2">
+        <Skeleton
+          className={cn(
+            "shrink-0",
+            avatar ? "h-5 w-5 rounded-full" : "h-4 w-4 rounded-sm",
+          )}
+        />
+        <Skeleton className={cn("h-4 min-w-0", widthClass)} />
+      </div>
+    </SidebarMenuItem>
+  );
+}
+
+function SidebarLoadingSection({
+  children,
+  titleWidthClass,
+}: {
+  children: React.ReactNode;
+  titleWidthClass: string;
+}) {
+  return (
+    <SidebarGroup>
+      <div className="group/sidebar-section relative">
+        <SidebarGroupLabel asChild>
+          <div className="flex h-7 w-fit max-w-[calc(100%-3rem)] items-center gap-1">
+            <Skeleton className={cn("h-3.5", titleWidthClass)} />
+          </div>
+        </SidebarGroupLabel>
+      </div>
+      <SidebarGroupContent>
+        <SidebarMenu>{children}</SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+function SidebarLoadingContent({ shape }: { shape: SidebarLoadingShape }) {
+  return (
+    <div data-testid="sidebar-loading">
+      <SidebarLoadingSection titleWidthClass="w-16">
+        {shape.channels.map((row) => (
+          <SidebarLoadingRow key={row.key} widthClass={row.widthClass} />
+        ))}
+      </SidebarLoadingSection>
+      <SidebarLoadingSection titleWidthClass="w-24">
+        {shape.directMessages.map((row) => (
+          <SidebarLoadingRow avatar key={row.key} widthClass={row.widthClass} />
+        ))}
+      </SidebarLoadingSection>
+    </div>
+  );
+}
+
+function SidebarPrimaryNavLoading() {
+  return (
+    <SidebarMenu data-testid="sidebar-primary-nav-loading">
+      {[
+        { key: "home", widthClass: "w-16" },
+        { key: "agents", widthClass: "w-20" },
+      ].map((row) => (
+        <SidebarMenuItem key={row.key}>
+          <div className="flex h-8 items-center gap-2 rounded-md px-2">
+            <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+            <Skeleton className={cn("h-4", row.widthClass)} />
+          </div>
+        </SidebarMenuItem>
+      ))}
+    </SidebarMenu>
+  );
+}
+
+function SidebarProfileLoadingCard() {
+  return (
+    <div className="rounded-xl px-2 py-2" data-testid="sidebar-profile-loading">
+      <div className="flex min-w-0 items-center gap-3">
+        <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+        <div className="min-w-0 flex-1">
+          <Skeleton className="h-4 w-28 max-w-full" />
+          <Skeleton className="mt-1.5 h-3 w-24 max-w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // AppSidebar
 // ---------------------------------------------------------------------------
@@ -217,7 +515,6 @@ export function AppSidebar({
   onStarChannel,
   onUnstarChannel,
 }: AppSidebarProps) {
-  const skeletonRows = ["first", "second", "third", "fourth", "fifth", "sixth"];
   const [isNewDmOpenInternal, setIsNewDmOpenInternal] = React.useState(false);
   const isNewDmOpen = isNewDmOpenProp ?? isNewDmOpenInternal;
   const setIsNewDmOpen = onNewDmOpenChange ?? setIsNewDmOpenInternal;
@@ -368,6 +665,14 @@ export function AppSidebar({
       fallbackDisplayName,
       profileDisplayName: profile?.displayName,
     });
+  const sidebarLoadingShape = useSidebarLoadingShape({
+    activeWorkspaceId: activeWorkspace?.id,
+    currentPubkey,
+    directMessages,
+    dmChannelLabels,
+    isLoading,
+    streamChannels,
+  });
   const shouldLoadAgentCount = useDeferredLoad({
     immediate: selectedView === "agents",
     timeoutMs: 250,
@@ -424,89 +729,93 @@ export function AppSidebar({
         className="cursor-default select-none pt-11"
         data-tauri-drag-region
       >
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              isActive={selectedView === "home"}
-              onClick={onSelectHome}
-              tooltip="Home"
-              type="button"
-            >
-              <Home className="h-4 w-4" />
-              <span>Home</span>
-            </SidebarMenuButton>
-            {homeBadgeCount > 0 ? (
-              <SidebarMenuBadge
-                className="right-2 rounded-full bg-primary/15 px-1.5 text-[11px] text-primary peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
-                data-testid="sidebar-home-count"
-              >
-                {Math.min(homeBadgeCount, 99)}
-              </SidebarMenuBadge>
-            ) : null}
-          </SidebarMenuItem>
-          <FeatureGate feature="pulse">
+        {isLoading ? (
+          <SidebarPrimaryNavLoading />
+        ) : (
+          <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton
-                data-testid="open-pulse-view"
-                isActive={selectedView === "pulse"}
-                onClick={onSelectPulse}
-                tooltip="Pulse"
+                isActive={selectedView === "home"}
+                onClick={onSelectHome}
+                tooltip="Home"
                 type="button"
               >
-                <Activity className="h-4 w-4" />
-                <span>Pulse</span>
+                <Home className="h-4 w-4" />
+                <span>Home</span>
               </SidebarMenuButton>
+              {homeBadgeCount > 0 ? (
+                <SidebarMenuBadge
+                  className="right-2 rounded-full bg-primary/15 px-1.5 text-[11px] text-primary peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
+                  data-testid="sidebar-home-count"
+                >
+                  {Math.min(homeBadgeCount, 99)}
+                </SidebarMenuBadge>
+              ) : null}
             </SidebarMenuItem>
-          </FeatureGate>
-          <FeatureGate feature="projects">
+            <FeatureGate feature="pulse">
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  data-testid="open-pulse-view"
+                  isActive={selectedView === "pulse"}
+                  onClick={onSelectPulse}
+                  tooltip="Pulse"
+                  type="button"
+                >
+                  <Activity className="h-4 w-4" />
+                  <span>Pulse</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </FeatureGate>
+            <FeatureGate feature="projects">
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  data-testid="open-projects-view"
+                  isActive={selectedView === "projects"}
+                  onClick={onSelectProjects}
+                  tooltip="Projects"
+                  type="button"
+                >
+                  <FolderGit2 className="h-4 w-4" />
+                  <span>Projects</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </FeatureGate>
             <SidebarMenuItem>
               <SidebarMenuButton
-                data-testid="open-projects-view"
-                isActive={selectedView === "projects"}
-                onClick={onSelectProjects}
-                tooltip="Projects"
+                data-testid="open-agents-view"
+                isActive={selectedView === "agents"}
+                onClick={onSelectAgents}
+                tooltip="Agents"
                 type="button"
               >
-                <FolderGit2 className="h-4 w-4" />
-                <span>Projects</span>
+                <Bot className="h-4 w-4" />
+                <span>Agents</span>
               </SidebarMenuButton>
+              {shouldShowAgentCount ? (
+                <SidebarMenuBadge
+                  className="right-2 rounded-full bg-sidebar-accent/70 px-1.5 text-[11px] text-sidebar-foreground/75 peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
+                  data-testid="sidebar-agents-count"
+                >
+                  {totalAgentCount}
+                </SidebarMenuBadge>
+              ) : null}
             </SidebarMenuItem>
-          </FeatureGate>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              data-testid="open-agents-view"
-              isActive={selectedView === "agents"}
-              onClick={onSelectAgents}
-              tooltip="Agents"
-              type="button"
-            >
-              <Bot className="h-4 w-4" />
-              <span>Agents</span>
-            </SidebarMenuButton>
-            {shouldShowAgentCount ? (
-              <SidebarMenuBadge
-                className="right-2 rounded-full bg-sidebar-accent/70 px-1.5 text-[11px] text-sidebar-foreground/75 peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
-                data-testid="sidebar-agents-count"
-              >
-                {totalAgentCount}
-              </SidebarMenuBadge>
-            ) : null}
-          </SidebarMenuItem>
-          <FeatureGate feature="workflows">
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                data-testid="open-workflows-view"
-                isActive={selectedView === "workflows"}
-                onClick={onSelectWorkflows}
-                tooltip="Workflows"
-                type="button"
-              >
-                <Zap className="h-4 w-4" />
-                <span>Workflows</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </FeatureGate>
-        </SidebarMenu>
+            <FeatureGate feature="workflows">
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  data-testid="open-workflows-view"
+                  isActive={selectedView === "workflows"}
+                  onClick={onSelectWorkflows}
+                  tooltip="Workflows"
+                  type="button"
+                >
+                  <Zap className="h-4 w-4" />
+                  <span>Workflows</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </FeatureGate>
+          </SidebarMenu>
+        )}
       </SidebarHeader>
 
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -521,16 +830,7 @@ export function AppSidebar({
         ) : null}
         <SidebarContent className="pb-32" ref={scrollRef}>
           {isLoading ? (
-            <SidebarGroup>
-              <SidebarGroupLabel>Channels</SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu data-testid="sidebar-loading">
-                  {skeletonRows.map((row) => (
-                    <SidebarMenuSkeleton key={row} showIcon />
-                  ))}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
+            <SidebarLoadingContent shape={sidebarLoadingShape} />
           ) : null}
 
           {!isLoading ? (
@@ -740,23 +1040,27 @@ export function AppSidebar({
         <SidebarFooter className="absolute inset-x-0 bottom-0 z-30 bg-sidebar/55 backdrop-blur-xl supports-[backdrop-filter]:bg-sidebar/45 dark:bg-sidebar/45 dark:supports-[backdrop-filter]:bg-sidebar/35">
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarProfileCard
-                activeWorkspace={activeWorkspace}
-                isPresencePending={isPresencePending}
-                onOpenAddWorkspace={onOpenAddWorkspace}
-                onOpenSettings={onSelectSettings}
-                onRemoveWorkspace={onRemoveWorkspace}
-                onSetPresenceStatus={onSetPresenceStatus}
-                onSetUserStatus={onSetUserStatus}
-                onClearUserStatus={onClearUserStatus}
-                onSwitchWorkspace={onSwitchWorkspace}
-                onUpdateWorkspace={onUpdateWorkspace}
-                profile={profile}
-                resolvedDisplayName={resolvedDisplayName}
-                selfPresenceStatus={selfPresenceStatus}
-                selfUserStatus={selfUserStatus}
-                workspaces={workspaces}
-              />
+              {isLoading ? (
+                <SidebarProfileLoadingCard />
+              ) : (
+                <SidebarProfileCard
+                  activeWorkspace={activeWorkspace}
+                  isPresencePending={isPresencePending}
+                  onOpenAddWorkspace={onOpenAddWorkspace}
+                  onOpenSettings={onSelectSettings}
+                  onRemoveWorkspace={onRemoveWorkspace}
+                  onSetPresenceStatus={onSetPresenceStatus}
+                  onSetUserStatus={onSetUserStatus}
+                  onClearUserStatus={onClearUserStatus}
+                  onSwitchWorkspace={onSwitchWorkspace}
+                  onUpdateWorkspace={onUpdateWorkspace}
+                  profile={profile}
+                  resolvedDisplayName={resolvedDisplayName}
+                  selfPresenceStatus={selfPresenceStatus}
+                  selfUserStatus={selfUserStatus}
+                  workspaces={workspaces}
+                />
+              )}
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarFooter>

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -40,7 +40,6 @@ import { NewDirectMessageDialog } from "@/features/sidebar/ui/NewDirectMessageDi
 import { SidebarProfileCard } from "@/features/sidebar/ui/SidebarProfileCard";
 import {
   SidebarLoadingContent,
-  SidebarPrimaryNavLoading,
   SidebarProfileLoadingCard,
   useSidebarLoadingShape,
 } from "@/features/sidebar/ui/sidebarLoadingSkeleton";
@@ -433,93 +432,89 @@ export function AppSidebar({
         className="cursor-default select-none pt-11"
         data-tauri-drag-region
       >
-        {isLoading ? (
-          <SidebarPrimaryNavLoading />
-        ) : (
-          <SidebarMenu>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              isActive={selectedView === "home"}
+              onClick={onSelectHome}
+              tooltip="Home"
+              type="button"
+            >
+              <Home className="h-4 w-4" />
+              <span>Home</span>
+            </SidebarMenuButton>
+            {homeBadgeCount > 0 ? (
+              <SidebarMenuBadge
+                className="right-2 rounded-full bg-primary/15 px-1.5 text-[11px] text-primary peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
+                data-testid="sidebar-home-count"
+              >
+                {Math.min(homeBadgeCount, 99)}
+              </SidebarMenuBadge>
+            ) : null}
+          </SidebarMenuItem>
+          <FeatureGate feature="pulse">
             <SidebarMenuItem>
               <SidebarMenuButton
-                isActive={selectedView === "home"}
-                onClick={onSelectHome}
-                tooltip="Home"
+                data-testid="open-pulse-view"
+                isActive={selectedView === "pulse"}
+                onClick={onSelectPulse}
+                tooltip="Pulse"
                 type="button"
               >
-                <Home className="h-4 w-4" />
-                <span>Home</span>
+                <Activity className="h-4 w-4" />
+                <span>Pulse</span>
               </SidebarMenuButton>
-              {homeBadgeCount > 0 ? (
-                <SidebarMenuBadge
-                  className="right-2 rounded-full bg-primary/15 px-1.5 text-[11px] text-primary peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
-                  data-testid="sidebar-home-count"
-                >
-                  {Math.min(homeBadgeCount, 99)}
-                </SidebarMenuBadge>
-              ) : null}
             </SidebarMenuItem>
-            <FeatureGate feature="pulse">
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  data-testid="open-pulse-view"
-                  isActive={selectedView === "pulse"}
-                  onClick={onSelectPulse}
-                  tooltip="Pulse"
-                  type="button"
-                >
-                  <Activity className="h-4 w-4" />
-                  <span>Pulse</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </FeatureGate>
-            <FeatureGate feature="projects">
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  data-testid="open-projects-view"
-                  isActive={selectedView === "projects"}
-                  onClick={onSelectProjects}
-                  tooltip="Projects"
-                  type="button"
-                >
-                  <FolderGit2 className="h-4 w-4" />
-                  <span>Projects</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </FeatureGate>
+          </FeatureGate>
+          <FeatureGate feature="projects">
             <SidebarMenuItem>
               <SidebarMenuButton
-                data-testid="open-agents-view"
-                isActive={selectedView === "agents"}
-                onClick={onSelectAgents}
-                tooltip="Agents"
+                data-testid="open-projects-view"
+                isActive={selectedView === "projects"}
+                onClick={onSelectProjects}
+                tooltip="Projects"
                 type="button"
               >
-                <Bot className="h-4 w-4" />
-                <span>Agents</span>
+                <FolderGit2 className="h-4 w-4" />
+                <span>Projects</span>
               </SidebarMenuButton>
-              {shouldShowAgentCount ? (
-                <SidebarMenuBadge
-                  className="right-2 rounded-full bg-sidebar-accent/70 px-1.5 text-[11px] text-sidebar-foreground/75 peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
-                  data-testid="sidebar-agents-count"
-                >
-                  {totalAgentCount}
-                </SidebarMenuBadge>
-              ) : null}
             </SidebarMenuItem>
-            <FeatureGate feature="workflows">
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  data-testid="open-workflows-view"
-                  isActive={selectedView === "workflows"}
-                  onClick={onSelectWorkflows}
-                  tooltip="Workflows"
-                  type="button"
-                >
-                  <Zap className="h-4 w-4" />
-                  <span>Workflows</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </FeatureGate>
-          </SidebarMenu>
-        )}
+          </FeatureGate>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              data-testid="open-agents-view"
+              isActive={selectedView === "agents"}
+              onClick={onSelectAgents}
+              tooltip="Agents"
+              type="button"
+            >
+              <Bot className="h-4 w-4" />
+              <span>Agents</span>
+            </SidebarMenuButton>
+            {shouldShowAgentCount ? (
+              <SidebarMenuBadge
+                className="right-2 rounded-full bg-sidebar-accent/70 px-1.5 text-[11px] text-sidebar-foreground/75 peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
+                data-testid="sidebar-agents-count"
+              >
+                {totalAgentCount}
+              </SidebarMenuBadge>
+            ) : null}
+          </SidebarMenuItem>
+          <FeatureGate feature="workflows">
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                data-testid="open-workflows-view"
+                isActive={selectedView === "workflows"}
+                onClick={onSelectWorkflows}
+                tooltip="Workflows"
+                type="button"
+              >
+                <Zap className="h-4 w-4" />
+                <span>Workflows</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </FeatureGate>
+        </SidebarMenu>
       </SidebarHeader>
 
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -38,6 +38,12 @@ import {
 import { CreateChannelDialog } from "@/features/sidebar/ui/CreateChannelDialog";
 import { NewDirectMessageDialog } from "@/features/sidebar/ui/NewDirectMessageDialog";
 import { SidebarProfileCard } from "@/features/sidebar/ui/SidebarProfileCard";
+import {
+  SidebarLoadingContent,
+  SidebarPrimaryNavLoading,
+  SidebarProfileLoadingCard,
+  useSidebarLoadingShape,
+} from "@/features/sidebar/ui/sidebarLoadingSkeleton";
 import { SECTION_ACTION_VISIBILITY_CLASS } from "@/features/sidebar/ui/sidebarSectionStyles";
 import type {
   Channel,
@@ -51,10 +57,7 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
-  SidebarGroup,
   SidebarGroupAction,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuBadge,
@@ -62,7 +65,6 @@ import {
   SidebarMenuItem,
   SidebarRail,
 } from "@/shared/ui/sidebar";
-import { Skeleton } from "@/shared/ui/skeleton";
 
 type CollapsibleSidebarGroup =
   | "starred"
@@ -156,304 +158,6 @@ type AppSidebarProps = {
   onStarChannel?: (channelId: string) => void;
   onUnstarChannel?: (channelId: string) => void;
 };
-
-const SIDEBAR_SKELETON_CACHE_PREFIX = "buzz-sidebar-skeleton-shape.v1";
-const sidebarLoadingWidthClasses = [
-  "w-14",
-  "w-16",
-  "w-20",
-  "w-24",
-  "w-28",
-  "w-32",
-] as const;
-
-type SidebarLoadingWidthClass = (typeof sidebarLoadingWidthClasses)[number];
-
-type SidebarLoadingRowShape = {
-  avatar?: boolean;
-  key: string;
-  unread?: boolean;
-  widthClass: SidebarLoadingWidthClass;
-};
-
-type SidebarLoadingShape = {
-  channels: SidebarLoadingRowShape[];
-  directMessages: SidebarLoadingRowShape[];
-};
-
-type SidebarLoadingCachePayload = SidebarLoadingShape & {
-  version: 1;
-};
-
-const fallbackSidebarLoadingShape: SidebarLoadingShape = {
-  channels: [
-    { key: "agents", widthClass: "w-20" },
-    { key: "engineering", widthClass: "w-28" },
-    { key: "general", widthClass: "w-20" },
-  ],
-  directMessages: [
-    { key: "alice", widthClass: "w-24" },
-    { key: "bob", widthClass: "w-20" },
-  ],
-};
-
-function isSidebarLoadingWidthClass(
-  value: unknown,
-): value is SidebarLoadingWidthClass {
-  return sidebarLoadingWidthClasses.includes(value as SidebarLoadingWidthClass);
-}
-
-function parseSidebarLoadingRows(
-  rows: unknown,
-  maxRows: number,
-): SidebarLoadingRowShape[] {
-  if (!Array.isArray(rows)) return [];
-
-  return rows
-    .slice(0, maxRows)
-    .filter((row: unknown): row is SidebarLoadingRowShape => {
-      if (typeof row !== "object" || row === null) return false;
-      const record = row as Record<string, unknown>;
-      return (
-        typeof record.key === "string" &&
-        isSidebarLoadingWidthClass(record.widthClass) &&
-        (record.unread === undefined || typeof record.unread === "boolean") &&
-        (record.avatar === undefined || typeof record.avatar === "boolean")
-      );
-    });
-}
-
-function parseSidebarLoadingShape(value: unknown): SidebarLoadingShape | null {
-  if (typeof value !== "object" || value === null) return null;
-  const record = value as Record<string, unknown>;
-  if (record.version !== 1) return null;
-
-  const shape = {
-    channels: parseSidebarLoadingRows(record.channels, 3),
-    directMessages: parseSidebarLoadingRows(record.directMessages, 2),
-  };
-
-  return hasSidebarLoadingRows(shape) ? shape : null;
-}
-
-function hasSidebarLoadingRows(shape: SidebarLoadingShape) {
-  return shape.channels.length > 0 || shape.directMessages.length > 0;
-}
-
-function sidebarSkeletonCacheKey(
-  workspaceId: string | null | undefined,
-  pubkey: string | undefined,
-) {
-  if (!workspaceId) return null;
-  return `${SIDEBAR_SKELETON_CACHE_PREFIX}:${workspaceId}:${pubkey ?? "anonymous"}`;
-}
-
-function readSidebarLoadingShape(
-  cacheKey: string | null,
-): SidebarLoadingShape | null {
-  if (!cacheKey || typeof window === "undefined") return null;
-
-  try {
-    const raw = window.localStorage.getItem(cacheKey);
-    return raw ? parseSidebarLoadingShape(JSON.parse(raw)) : null;
-  } catch {
-    return null;
-  }
-}
-
-function writeSidebarLoadingShape(
-  cacheKey: string | null,
-  shape: SidebarLoadingShape,
-) {
-  if (
-    !cacheKey ||
-    !hasSidebarLoadingRows(shape) ||
-    typeof window === "undefined"
-  ) {
-    return;
-  }
-
-  const payload: SidebarLoadingCachePayload = {
-    channels: shape.channels.slice(0, 3),
-    directMessages: shape.directMessages.slice(0, 2),
-    version: 1,
-  };
-
-  try {
-    window.localStorage.setItem(cacheKey, JSON.stringify(payload));
-  } catch {
-    // localStorage can be unavailable or full in embedded webviews.
-  }
-}
-
-function sidebarWidthClassForText(text: string): SidebarLoadingWidthClass {
-  const length = text.trim().length;
-  if (length >= 20) return "w-32";
-  if (length >= 14) return "w-28";
-  if (length >= 10) return "w-24";
-  if (length >= 6) return "w-20";
-  return "w-16";
-}
-
-function createSidebarLoadingShape({
-  directMessages,
-  dmChannelLabels,
-  streamChannels,
-}: {
-  directMessages: Channel[];
-  dmChannelLabels: Record<string, string>;
-  streamChannels: Channel[];
-}): SidebarLoadingShape {
-  return {
-    channels: streamChannels.slice(0, 3).map((channel) => ({
-      key: channel.id,
-      widthClass: sidebarWidthClassForText(channel.name),
-    })),
-    directMessages: directMessages.slice(0, 2).map((channel) => ({
-      avatar: true,
-      key: channel.id,
-      widthClass: sidebarWidthClassForText(
-        dmChannelLabels[channel.id] ?? channel.name,
-      ),
-    })),
-  };
-}
-
-function useSidebarLoadingShape({
-  activeWorkspaceId,
-  directMessages,
-  dmChannelLabels,
-  isLoading,
-  currentPubkey,
-  streamChannels,
-}: {
-  activeWorkspaceId: string | null | undefined;
-  directMessages: Channel[];
-  dmChannelLabels: Record<string, string>;
-  isLoading: boolean;
-  currentPubkey?: string;
-  streamChannels: Channel[];
-}) {
-  const cacheKey = React.useMemo(
-    () => sidebarSkeletonCacheKey(activeWorkspaceId, currentPubkey),
-    [activeWorkspaceId, currentPubkey],
-  );
-  const liveShape = React.useMemo(
-    () =>
-      createSidebarLoadingShape({
-        directMessages,
-        dmChannelLabels,
-        streamChannels,
-      }),
-    [directMessages, dmChannelLabels, streamChannels],
-  );
-  const cachedShape = React.useMemo(
-    () => readSidebarLoadingShape(cacheKey),
-    [cacheKey],
-  );
-
-  React.useEffect(() => {
-    if (isLoading || !hasSidebarLoadingRows(liveShape)) return;
-    writeSidebarLoadingShape(cacheKey, liveShape);
-  }, [cacheKey, isLoading, liveShape]);
-
-  if (hasSidebarLoadingRows(liveShape)) return liveShape;
-  return cachedShape ?? fallbackSidebarLoadingShape;
-}
-
-function SidebarLoadingRow({
-  avatar = false,
-  widthClass,
-}: {
-  avatar?: boolean;
-  widthClass: string;
-}) {
-  return (
-    <SidebarMenuItem>
-      <div className="flex h-8 items-center gap-2 rounded-md px-2">
-        <Skeleton
-          className={cn(
-            "shrink-0",
-            avatar ? "h-5 w-5 rounded-full" : "h-4 w-4 rounded-sm",
-          )}
-        />
-        <Skeleton className={cn("h-4 min-w-0", widthClass)} />
-      </div>
-    </SidebarMenuItem>
-  );
-}
-
-function SidebarLoadingSection({
-  children,
-  titleWidthClass,
-}: {
-  children: React.ReactNode;
-  titleWidthClass: string;
-}) {
-  return (
-    <SidebarGroup>
-      <div className="group/sidebar-section relative">
-        <SidebarGroupLabel asChild>
-          <div className="flex h-7 w-fit max-w-[calc(100%-3rem)] items-center gap-1">
-            <Skeleton className={cn("h-3.5", titleWidthClass)} />
-          </div>
-        </SidebarGroupLabel>
-      </div>
-      <SidebarGroupContent>
-        <SidebarMenu>{children}</SidebarMenu>
-      </SidebarGroupContent>
-    </SidebarGroup>
-  );
-}
-
-function SidebarLoadingContent({ shape }: { shape: SidebarLoadingShape }) {
-  return (
-    <div data-testid="sidebar-loading">
-      <SidebarLoadingSection titleWidthClass="w-16">
-        {shape.channels.map((row) => (
-          <SidebarLoadingRow key={row.key} widthClass={row.widthClass} />
-        ))}
-      </SidebarLoadingSection>
-      <SidebarLoadingSection titleWidthClass="w-24">
-        {shape.directMessages.map((row) => (
-          <SidebarLoadingRow avatar key={row.key} widthClass={row.widthClass} />
-        ))}
-      </SidebarLoadingSection>
-    </div>
-  );
-}
-
-function SidebarPrimaryNavLoading() {
-  return (
-    <SidebarMenu data-testid="sidebar-primary-nav-loading">
-      {[
-        { key: "home", widthClass: "w-16" },
-        { key: "agents", widthClass: "w-20" },
-      ].map((row) => (
-        <SidebarMenuItem key={row.key}>
-          <div className="flex h-8 items-center gap-2 rounded-md px-2">
-            <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
-            <Skeleton className={cn("h-4", row.widthClass)} />
-          </div>
-        </SidebarMenuItem>
-      ))}
-    </SidebarMenu>
-  );
-}
-
-function SidebarProfileLoadingCard() {
-  return (
-    <div className="rounded-xl px-2 py-2" data-testid="sidebar-profile-loading">
-      <div className="flex min-w-0 items-center gap-3">
-        <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
-        <div className="min-w-0 flex-1">
-          <Skeleton className="h-4 w-28 max-w-full" />
-          <Skeleton className="mt-1.5 h-3 w-24 max-w-full" />
-        </div>
-      </div>
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // AppSidebar

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -40,7 +40,6 @@ import { NewDirectMessageDialog } from "@/features/sidebar/ui/NewDirectMessageDi
 import { SidebarProfileCard } from "@/features/sidebar/ui/SidebarProfileCard";
 import {
   SidebarLoadingContent,
-  SidebarProfileLoadingCard,
   useSidebarLoadingShape,
 } from "@/features/sidebar/ui/sidebarLoadingSkeleton";
 import { SECTION_ACTION_VISIBILITY_CLASS } from "@/features/sidebar/ui/sidebarSectionStyles";
@@ -739,27 +738,23 @@ export function AppSidebar({
         <SidebarFooter className="absolute inset-x-0 bottom-0 z-30 bg-sidebar/55 backdrop-blur-xl supports-[backdrop-filter]:bg-sidebar/45 dark:bg-sidebar/45 dark:supports-[backdrop-filter]:bg-sidebar/35">
           <SidebarMenu>
             <SidebarMenuItem>
-              {isLoading ? (
-                <SidebarProfileLoadingCard />
-              ) : (
-                <SidebarProfileCard
-                  activeWorkspace={activeWorkspace}
-                  isPresencePending={isPresencePending}
-                  onOpenAddWorkspace={onOpenAddWorkspace}
-                  onOpenSettings={onSelectSettings}
-                  onRemoveWorkspace={onRemoveWorkspace}
-                  onSetPresenceStatus={onSetPresenceStatus}
-                  onSetUserStatus={onSetUserStatus}
-                  onClearUserStatus={onClearUserStatus}
-                  onSwitchWorkspace={onSwitchWorkspace}
-                  onUpdateWorkspace={onUpdateWorkspace}
-                  profile={profile}
-                  resolvedDisplayName={resolvedDisplayName}
-                  selfPresenceStatus={selfPresenceStatus}
-                  selfUserStatus={selfUserStatus}
-                  workspaces={workspaces}
-                />
-              )}
+              <SidebarProfileCard
+                activeWorkspace={activeWorkspace}
+                isPresencePending={isPresencePending}
+                onOpenAddWorkspace={onOpenAddWorkspace}
+                onOpenSettings={onSelectSettings}
+                onRemoveWorkspace={onRemoveWorkspace}
+                onSetPresenceStatus={onSetPresenceStatus}
+                onSetUserStatus={onSetUserStatus}
+                onClearUserStatus={onClearUserStatus}
+                onSwitchWorkspace={onSwitchWorkspace}
+                onUpdateWorkspace={onUpdateWorkspace}
+                profile={profile}
+                resolvedDisplayName={resolvedDisplayName}
+                selfPresenceStatus={selfPresenceStatus}
+                selfUserStatus={selfUserStatus}
+                workspaces={workspaces}
+              />
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarFooter>

--- a/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
+++ b/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
@@ -1,17 +1,22 @@
-import { Lock, Zap } from "lucide-react";
+import { ClockFading, Hash } from "lucide-react";
 import * as React from "react";
 
 import { useChannelTemplatesQuery } from "@/features/channel-templates/hooks";
 import type { ChannelTemplate, ChannelVisibility } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
 import { Dialog } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
-import { Switch } from "@/shared/ui/switch";
+import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 import { Textarea } from "@/shared/ui/textarea";
 
 /** Default TTL for ephemeral channels: 1 day of inactivity. */
 const EPHEMERAL_TTL_SECONDS = 86400;
+const CREATE_FIELD_SHELL_CLASS =
+  "rounded-xl border border-input bg-background shadow-xs transition-colors duration-150 ease-out hover:border-muted-foreground/40 hover:bg-muted/70 focus-within:border-muted-foreground/50 focus-within:bg-muted/70";
+const CREATE_FIELD_CONTROL_CLASS =
+  "border-0 bg-transparent shadow-none outline-none ring-0 placeholder:text-muted-foreground/45 focus:bg-transparent focus:outline-hidden focus-visible:ring-0";
 
 type ChannelKind = "stream" | "forum";
 
@@ -136,7 +141,10 @@ export function CreateChannelDialog({
     >
       <ChooserDialogContent
         className="max-w-lg"
+        contentClassName="pt-3"
         data-testid="create-channel-dialog"
+        footerClassName="border-t-0 pt-0"
+        headerClassName="pb-2"
         title={`Create a new ${kindLabel}`}
         description={
           channelKind === "forum"
@@ -165,7 +173,7 @@ export function CreateChannelDialog({
         }
       >
         <form
-          className="space-y-4"
+          className="space-y-5"
           id="create-channel-form"
           onSubmit={(event) => {
             void handleSubmit(event);
@@ -179,24 +187,34 @@ export function CreateChannelDialog({
             >
               Name
             </label>
-            <Input
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              data-testid="create-channel-name"
-              disabled={isCreating}
-              id="create-channel-name"
-              onChange={(event) => {
-                setName(event.target.value);
-                setErrorMessage(null);
-              }}
-              placeholder={
-                channelKind === "forum" ? "design-discussions" : "release-notes"
-              }
-              ref={nameInputRef}
-              spellCheck={false}
-              value={name}
-            />
+            <div
+              className={cn(
+                "flex h-9 items-center px-3",
+                CREATE_FIELD_SHELL_CLASS,
+              )}
+            >
+              <Input
+                autoCapitalize="none"
+                autoComplete="off"
+                autoCorrect="off"
+                className={cn("h-full px-0 py-0", CREATE_FIELD_CONTROL_CLASS)}
+                data-testid="create-channel-name"
+                disabled={isCreating}
+                id="create-channel-name"
+                onChange={(event) => {
+                  setName(event.target.value);
+                  setErrorMessage(null);
+                }}
+                placeholder={
+                  channelKind === "forum"
+                    ? "design-discussions"
+                    : "release-notes"
+                }
+                ref={nameInputRef}
+                spellCheck={false}
+                value={name}
+              />
+            </div>
           </div>
 
           {/* Description */}
@@ -210,91 +228,136 @@ export function CreateChannelDialog({
                 (optional)
               </span>
             </label>
-            <Textarea
-              className="min-h-16 resize-none"
-              data-testid="create-channel-description"
-              disabled={isCreating}
-              id="create-channel-description"
-              onChange={(event) => {
-                setDescription(event.target.value);
-                setErrorMessage(null);
-              }}
-              placeholder={`What this ${kindLabel} is for`}
-              rows={2}
-              value={description}
-            />
+            <div className={CREATE_FIELD_SHELL_CLASS}>
+              <Textarea
+                className={cn(
+                  "min-h-16 resize-none px-3 py-2",
+                  CREATE_FIELD_CONTROL_CLASS,
+                )}
+                data-testid="create-channel-description"
+                disabled={isCreating}
+                id="create-channel-description"
+                onChange={(event) => {
+                  setDescription(event.target.value);
+                  setErrorMessage(null);
+                }}
+                placeholder={`What this ${kindLabel} is for`}
+                rows={2}
+                value={description}
+              />
+            </div>
           </div>
 
-          {/* Options */}
-          <div className="space-y-3">
-            <div className="flex items-center justify-between gap-3">
-              <label
-                className="flex items-center gap-1.5 text-sm text-muted-foreground"
-                htmlFor="create-channel-private"
-              >
-                <Lock className="h-3.5 w-3.5" />
-                Private — only visible to invited members
-              </label>
-              <Switch
-                checked={visibility === "private"}
-                data-testid="create-channel-visibility"
-                disabled={isCreating}
-                id="create-channel-private"
-                onCheckedChange={(checked) =>
-                  setVisibility(checked ? "private" : "open")
-                }
-              />
-            </div>
-            <div className="flex items-center justify-between gap-3">
-              <label
-                className="flex items-center gap-1.5 text-sm text-muted-foreground"
-                htmlFor="create-channel-ephemeral"
-              >
-                <Zap className="h-3.5 w-3.5" />
-                Ephemeral — auto-archives after 1 day of inactivity
-              </label>
-              <Switch
-                checked={ephemeral}
-                disabled={isCreating}
-                id="create-channel-ephemeral"
-                onCheckedChange={setEphemeral}
-              />
-            </div>
+          {/* Type */}
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-foreground">Type</p>
+            <Tabs
+              className="w-full"
+              data-testid="create-channel-ephemeral"
+              onValueChange={(value) => setEphemeral(value === "temporary")}
+              value={ephemeral ? "temporary" : "ongoing"}
+            >
+              <TabsList className="relative grid h-auto w-full grid-cols-2 items-stretch rounded-xl bg-muted/45 p-1 text-muted-foreground">
+                <span
+                  aria-hidden="true"
+                  className="pointer-events-none absolute bottom-1 left-1 top-1 z-0 w-[calc(50%-0.25rem)] rounded-lg bg-background/95 shadow-xs transition-transform duration-[180ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
+                  data-testid="create-channel-type-indicator"
+                  style={{
+                    transform: ephemeral
+                      ? "translate3d(100%, 0, 0)"
+                      : "translate3d(0, 0, 0)",
+                  }}
+                />
+                <TabsTrigger
+                  className="group/type-tab relative z-10 h-full min-h-24 flex-col items-start justify-start gap-1.5 whitespace-normal rounded-lg bg-transparent px-3 py-2.5 text-left text-muted-foreground/55 opacity-70 shadow-none transition-[color,opacity] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:text-muted-foreground hover:opacity-85 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:opacity-100 data-[state=active]:shadow-none motion-reduce:transition-none"
+                  disabled={isCreating}
+                  value="ongoing"
+                >
+                  <Hash className="mt-0.5 h-4 w-4 shrink-0 text-current" />
+                  <span className="min-w-0 space-y-0.5">
+                    <span className="block text-sm font-medium">Ongoing</span>
+                    <span className="block text-xs leading-4 text-muted-foreground/45 group-data-[state=active]/type-tab:text-muted-foreground/65">
+                      For projects, teams, and recurring conversations.
+                    </span>
+                  </span>
+                </TabsTrigger>
+                <TabsTrigger
+                  className="group/type-tab relative z-10 h-full min-h-24 flex-col items-start justify-start gap-1.5 whitespace-normal rounded-lg bg-transparent px-3 py-2.5 text-left text-muted-foreground/55 opacity-70 shadow-none transition-[color,opacity] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:text-muted-foreground hover:opacity-85 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:opacity-100 data-[state=active]:shadow-none motion-reduce:transition-none"
+                  disabled={isCreating}
+                  value="temporary"
+                >
+                  <ClockFading className="mt-0.5 h-4 w-4 shrink-0 text-current" />
+                  <span className="min-w-0 space-y-0.5">
+                    <span className="block text-sm font-medium">Temporary</span>
+                    <span className="block text-xs leading-4 text-muted-foreground/45 group-data-[state=active]/type-tab:text-muted-foreground/65">
+                      For quick discussions that archive automatically when
+                      inactive.
+                    </span>
+                  </span>
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
           </div>
+
+          {/* Permissions */}
+          <fieldset
+            className="space-y-2"
+            data-testid="create-channel-visibility"
+          >
+            <legend className="text-sm font-medium text-foreground">
+              Permissions
+            </legend>
+            <div className="space-y-1">
+              <PermissionOption
+                description={`Anyone can see and join this ${kindLabel}.`}
+                disabled={isCreating}
+                name="create-channel-visibility"
+                onChange={() => setVisibility("open")}
+                selected={visibility === "open"}
+                title="Open"
+                value="open"
+              />
+              <PermissionOption
+                description={`Only members can invite people to this ${kindLabel}.`}
+                disabled={isCreating}
+                name="create-channel-visibility"
+                onChange={() => setVisibility("private")}
+                selected={visibility === "private"}
+                title="Private"
+                value="private"
+              />
+            </div>
+          </fieldset>
 
           {/* Template Selector */}
-          <div className="space-y-1.5">
-            <label
-              className="text-sm font-medium text-foreground"
-              htmlFor="create-channel-template"
-            >
-              Template{" "}
-              <span className="font-normal text-muted-foreground">
-                (optional)
-              </span>
-            </label>
-            <select
-              className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-              data-testid="create-channel-template"
-              disabled={isCreating || templates.length === 0}
-              id="create-channel-template"
-              onChange={(event) => handleTemplateChange(event.target.value)}
-              value={selectedTemplateId ?? ""}
-            >
-              <option value="">
-                {templatesQuery.isLoading
-                  ? "Loading..."
-                  : templates.length === 0
-                    ? "No templates created yet"
-                    : "No template"}
-              </option>
-              {templates.map((template: ChannelTemplate) => (
-                <option key={template.id} value={template.id}>
-                  {template.name}
-                </option>
-              ))}
-            </select>
-          </div>
+          {templates.length > 0 ? (
+            <div className="space-y-1.5">
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="create-channel-template"
+              >
+                Template{" "}
+                <span className="font-normal text-muted-foreground">
+                  (optional)
+                </span>
+              </label>
+              <select
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                data-testid="create-channel-template"
+                disabled={isCreating}
+                id="create-channel-template"
+                onChange={(event) => handleTemplateChange(event.target.value)}
+                value={selectedTemplateId ?? ""}
+              >
+                <option value="">No template</option>
+                {templates.map((template: ChannelTemplate) => (
+                  <option key={template.id} value={template.id}>
+                    {template.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
 
           {/* Error */}
           {errorMessage ? (
@@ -303,5 +366,68 @@ export function CreateChannelDialog({
         </form>
       </ChooserDialogContent>
     </Dialog>
+  );
+}
+
+function PermissionOption({
+  description,
+  disabled,
+  name,
+  onChange,
+  selected,
+  title,
+  value,
+}: {
+  description: string;
+  disabled: boolean;
+  name: string;
+  onChange: () => void;
+  selected: boolean;
+  title: string;
+  value: ChannelVisibility;
+}) {
+  return (
+    <label
+      className={cn(
+        "group flex cursor-pointer items-start gap-3 rounded-lg px-1 py-1.5 transition-none",
+        "has-[:focus-visible]:outline-hidden has-[:focus-visible]:ring-1 has-[:focus-visible]:ring-ring",
+        selected
+          ? "text-foreground"
+          : "text-muted-foreground hover:text-foreground",
+        disabled && "pointer-events-none opacity-50",
+      )}
+    >
+      <input
+        checked={selected}
+        className="sr-only"
+        disabled={disabled}
+        name={name}
+        onChange={onChange}
+        type="radio"
+        value={value}
+      />
+      <span
+        className={cn(
+          "mt-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-none",
+          selected
+            ? "border-foreground"
+            : "border-muted-foreground/45 group-hover:border-muted-foreground",
+        )}
+        aria-hidden="true"
+      >
+        <span
+          className={cn(
+            "h-1.5 w-1.5 rounded-full bg-foreground transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+            selected ? "scale-100 opacity-100" : "scale-50 opacity-0",
+          )}
+        />
+      </span>
+      <span className="min-w-0 space-y-0.5">
+        <span className="block text-sm font-medium text-current">{title}</span>
+        <span className="block text-xs leading-4 text-muted-foreground/65">
+          {description}
+        </span>
+      </span>
+    </label>
   );
 }

--- a/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
+++ b/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
@@ -282,6 +282,7 @@ export function CreateChannelDialog({
                   </span>
                 </TabsTrigger>
                 <TabsTrigger
+                  aria-label="Ephemeral — auto-archives after 1 day of inactivity"
                   className="group/type-tab relative z-10 h-full min-h-24 flex-col items-start justify-start gap-1.5 whitespace-normal rounded-lg bg-transparent px-3 py-2.5 text-left text-muted-foreground/55 opacity-70 shadow-none transition-[color,opacity] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:text-muted-foreground hover:opacity-85 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:opacity-100 data-[state=active]:shadow-none motion-reduce:transition-none"
                   disabled={isCreating}
                   value="temporary"

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -255,7 +255,7 @@ function SectionHeaderActions({
           title="Mark all as read"
           type="button"
         >
-          <CheckCheck className="h-3.5 w-3.5" />
+          <CheckCheck className="h-4 w-4" />
         </button>
       ) : null}
       {onBrowse ? (
@@ -548,7 +548,7 @@ export function CustomChannelSection({
                     >
                       <GripVertical
                         className={cn(
-                          "h-3 w-3 shrink-0 text-sidebar-foreground/30",
+                          "h-4 w-4 shrink-0 text-sidebar-foreground/30",
                           SECTION_ACTION_VISIBILITY_CLASS,
                         )}
                         aria-hidden="true"
@@ -580,7 +580,7 @@ export function CustomChannelSection({
                         title="Mark all as read"
                         type="button"
                       >
-                        <CheckCheck className="h-3.5 w-3.5" />
+                        <CheckCheck className="h-4 w-4" />
                       </button>
                     ) : null}
                     <button
@@ -592,7 +592,7 @@ export function CustomChannelSection({
                       }}
                       type="button"
                     >
-                      <Pencil className="h-3.5 w-3.5" />
+                      <Pencil className="h-4 w-4" />
                     </button>
                     <button
                       aria-label="Delete section"
@@ -603,7 +603,7 @@ export function CustomChannelSection({
                       }}
                       type="button"
                     >
-                      <Trash2 className="h-3.5 w-3.5" />
+                      <Trash2 className="h-4 w-4" />
                     </button>
                   </div>
                 </div>

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
@@ -3,7 +3,7 @@ import type * as React from "react";
 import { Button } from "@/shared/ui/button";
 
 const MORE_UNREAD_BUTTON_CLASS =
-  "h-7 min-h-7 gap-1.5 rounded-full border-0 bg-primary px-2.5 text-[11px] font-medium text-primary-foreground shadow-md hover:bg-primary/90 [&_svg]:size-3.5";
+  "h-7 min-h-7 gap-1.5 rounded-full border-0 bg-primary px-2.5 text-[11px] font-medium text-primary-foreground shadow-md hover:bg-primary/90 [&_svg]:size-4";
 
 export function MoreUnreadButton({
   bottomClassName = "bottom-0",

--- a/desktop/src/features/sidebar/ui/NewDirectMessageDialog.tsx
+++ b/desktop/src/features/sidebar/ui/NewDirectMessageDialog.tsx
@@ -181,7 +181,7 @@ export function NewDirectMessageDialog({
                     <ProfileAvatar
                       avatarUrl={user.avatarUrl}
                       className="h-5 w-5 text-[10px] shadow-none"
-                      iconClassName="h-3 w-3"
+                      iconClassName="h-4 w-4"
                       label={formatUserName(user)}
                     />
                     <span className="font-medium">{formatUserName(user)}</span>
@@ -198,7 +198,7 @@ export function NewDirectMessageDialog({
                       }}
                       type="button"
                     >
-                      <X className="h-3.5 w-3.5" />
+                      <X className="h-4 w-4" />
                     </button>
                   </div>
                 ))}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -202,7 +202,7 @@ export function ChannelMenuButton({
       {isMuted ? (
         <BellOff
           className={cn(
-            "ml-auto h-3 w-3 shrink-0",
+            "ml-auto h-4 w-4 shrink-0",
             isActive
               ? "text-sidebar-active-foreground/60"
               : "text-sidebar-foreground/40",

--- a/desktop/src/features/sidebar/ui/sidebarLoadingSkeleton.tsx
+++ b/desktop/src/features/sidebar/ui/sidebarLoadingSkeleton.tsx
@@ -281,24 +281,6 @@ export function SidebarLoadingContent({
   );
 }
 
-export function SidebarPrimaryNavLoading() {
-  return (
-    <SidebarMenu data-testid="sidebar-primary-nav-loading">
-      {[
-        { key: "home", widthClass: "w-16" },
-        { key: "agents", widthClass: "w-20" },
-      ].map((row) => (
-        <SidebarMenuItem key={row.key}>
-          <div className="flex h-8 items-center gap-2 rounded-md px-2">
-            <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
-            <Skeleton className={cn("h-4", row.widthClass)} />
-          </div>
-        </SidebarMenuItem>
-      ))}
-    </SidebarMenu>
-  );
-}
-
 export function SidebarProfileLoadingCard() {
   return (
     <div className="rounded-xl px-2 py-2" data-testid="sidebar-profile-loading">

--- a/desktop/src/features/sidebar/ui/sidebarLoadingSkeleton.tsx
+++ b/desktop/src/features/sidebar/ui/sidebarLoadingSkeleton.tsx
@@ -280,17 +280,3 @@ export function SidebarLoadingContent({
     </div>
   );
 }
-
-export function SidebarProfileLoadingCard() {
-  return (
-    <div className="rounded-xl px-2 py-2" data-testid="sidebar-profile-loading">
-      <div className="flex min-w-0 items-center gap-3">
-        <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
-        <div className="min-w-0 flex-1">
-          <Skeleton className="h-4 w-28 max-w-full" />
-          <Skeleton className="mt-1.5 h-3 w-24 max-w-full" />
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/desktop/src/features/sidebar/ui/sidebarLoadingSkeleton.tsx
+++ b/desktop/src/features/sidebar/ui/sidebarLoadingSkeleton.tsx
@@ -1,0 +1,314 @@
+import * as React from "react";
+
+import type { Channel } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
+} from "@/shared/ui/sidebar";
+import { Skeleton } from "@/shared/ui/skeleton";
+
+const SIDEBAR_SKELETON_CACHE_PREFIX = "buzz-sidebar-skeleton-shape.v1";
+const sidebarLoadingWidthClasses = [
+  "w-14",
+  "w-16",
+  "w-20",
+  "w-24",
+  "w-28",
+  "w-32",
+] as const;
+
+type SidebarLoadingWidthClass = (typeof sidebarLoadingWidthClasses)[number];
+
+type SidebarLoadingRowShape = {
+  avatar?: boolean;
+  key: string;
+  unread?: boolean;
+  widthClass: SidebarLoadingWidthClass;
+};
+
+type SidebarLoadingShape = {
+  channels: SidebarLoadingRowShape[];
+  directMessages: SidebarLoadingRowShape[];
+};
+
+type SidebarLoadingCachePayload = SidebarLoadingShape & {
+  version: 1;
+};
+
+const fallbackSidebarLoadingShape: SidebarLoadingShape = {
+  channels: [
+    { key: "agents", widthClass: "w-20" },
+    { key: "engineering", widthClass: "w-28" },
+    { key: "general", widthClass: "w-20" },
+  ],
+  directMessages: [
+    { key: "alice", widthClass: "w-24" },
+    { key: "bob", widthClass: "w-20" },
+  ],
+};
+
+function isSidebarLoadingWidthClass(
+  value: unknown,
+): value is SidebarLoadingWidthClass {
+  return sidebarLoadingWidthClasses.includes(value as SidebarLoadingWidthClass);
+}
+
+function parseSidebarLoadingRows(
+  rows: unknown,
+  maxRows: number,
+): SidebarLoadingRowShape[] {
+  if (!Array.isArray(rows)) return [];
+
+  return rows
+    .slice(0, maxRows)
+    .filter((row: unknown): row is SidebarLoadingRowShape => {
+      if (typeof row !== "object" || row === null) return false;
+      const record = row as Record<string, unknown>;
+      return (
+        typeof record.key === "string" &&
+        isSidebarLoadingWidthClass(record.widthClass) &&
+        (record.unread === undefined || typeof record.unread === "boolean") &&
+        (record.avatar === undefined || typeof record.avatar === "boolean")
+      );
+    });
+}
+
+function parseSidebarLoadingShape(value: unknown): SidebarLoadingShape | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (record.version !== 1) return null;
+
+  const shape = {
+    channels: parseSidebarLoadingRows(record.channels, 3),
+    directMessages: parseSidebarLoadingRows(record.directMessages, 2),
+  };
+
+  return hasSidebarLoadingRows(shape) ? shape : null;
+}
+
+function hasSidebarLoadingRows(shape: SidebarLoadingShape) {
+  return shape.channels.length > 0 || shape.directMessages.length > 0;
+}
+
+function sidebarSkeletonCacheKey(
+  workspaceId: string | null | undefined,
+  pubkey: string | undefined,
+) {
+  if (!workspaceId) return null;
+  return `${SIDEBAR_SKELETON_CACHE_PREFIX}:${workspaceId}:${pubkey ?? "anonymous"}`;
+}
+
+function readSidebarLoadingShape(
+  cacheKey: string | null,
+): SidebarLoadingShape | null {
+  if (!cacheKey || typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem(cacheKey);
+    return raw ? parseSidebarLoadingShape(JSON.parse(raw)) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSidebarLoadingShape(
+  cacheKey: string | null,
+  shape: SidebarLoadingShape,
+) {
+  if (
+    !cacheKey ||
+    !hasSidebarLoadingRows(shape) ||
+    typeof window === "undefined"
+  ) {
+    return;
+  }
+
+  const payload: SidebarLoadingCachePayload = {
+    channels: shape.channels.slice(0, 3),
+    directMessages: shape.directMessages.slice(0, 2),
+    version: 1,
+  };
+
+  try {
+    window.localStorage.setItem(cacheKey, JSON.stringify(payload));
+  } catch {
+    // localStorage can be unavailable or full in embedded webviews.
+  }
+}
+
+function sidebarWidthClassForText(text: string): SidebarLoadingWidthClass {
+  const length = text.trim().length;
+  if (length >= 20) return "w-32";
+  if (length >= 14) return "w-28";
+  if (length >= 10) return "w-24";
+  if (length >= 6) return "w-20";
+  return "w-16";
+}
+
+function createSidebarLoadingShape({
+  directMessages,
+  dmChannelLabels,
+  streamChannels,
+}: {
+  directMessages: Channel[];
+  dmChannelLabels: Record<string, string>;
+  streamChannels: Channel[];
+}): SidebarLoadingShape {
+  return {
+    channels: streamChannels.slice(0, 3).map((channel) => ({
+      key: channel.id,
+      widthClass: sidebarWidthClassForText(channel.name),
+    })),
+    directMessages: directMessages.slice(0, 2).map((channel) => ({
+      avatar: true,
+      key: channel.id,
+      widthClass: sidebarWidthClassForText(
+        dmChannelLabels[channel.id] ?? channel.name,
+      ),
+    })),
+  };
+}
+
+export function useSidebarLoadingShape({
+  activeWorkspaceId,
+  directMessages,
+  dmChannelLabels,
+  isLoading,
+  currentPubkey,
+  streamChannels,
+}: {
+  activeWorkspaceId: string | null | undefined;
+  directMessages: Channel[];
+  dmChannelLabels: Record<string, string>;
+  isLoading: boolean;
+  currentPubkey?: string;
+  streamChannels: Channel[];
+}) {
+  const cacheKey = React.useMemo(
+    () => sidebarSkeletonCacheKey(activeWorkspaceId, currentPubkey),
+    [activeWorkspaceId, currentPubkey],
+  );
+  const liveShape = React.useMemo(
+    () =>
+      createSidebarLoadingShape({
+        directMessages,
+        dmChannelLabels,
+        streamChannels,
+      }),
+    [directMessages, dmChannelLabels, streamChannels],
+  );
+  const cachedShape = React.useMemo(
+    () => readSidebarLoadingShape(cacheKey),
+    [cacheKey],
+  );
+
+  React.useEffect(() => {
+    if (isLoading || !hasSidebarLoadingRows(liveShape)) return;
+    writeSidebarLoadingShape(cacheKey, liveShape);
+  }, [cacheKey, isLoading, liveShape]);
+
+  if (hasSidebarLoadingRows(liveShape)) return liveShape;
+  return cachedShape ?? fallbackSidebarLoadingShape;
+}
+
+function SidebarLoadingRow({
+  avatar = false,
+  widthClass,
+}: {
+  avatar?: boolean;
+  widthClass: string;
+}) {
+  return (
+    <SidebarMenuItem>
+      <div className="flex h-8 items-center gap-2 rounded-md px-2">
+        <Skeleton
+          className={cn(
+            "shrink-0",
+            avatar ? "h-5 w-5 rounded-full" : "h-4 w-4 rounded-sm",
+          )}
+        />
+        <Skeleton className={cn("h-4 min-w-0", widthClass)} />
+      </div>
+    </SidebarMenuItem>
+  );
+}
+
+function SidebarLoadingSection({
+  children,
+  titleWidthClass,
+}: {
+  children: React.ReactNode;
+  titleWidthClass: string;
+}) {
+  return (
+    <SidebarGroup>
+      <div className="group/sidebar-section relative">
+        <SidebarGroupLabel asChild>
+          <div className="flex h-7 w-fit max-w-[calc(100%-3rem)] items-center gap-1">
+            <Skeleton className={cn("h-3.5", titleWidthClass)} />
+          </div>
+        </SidebarGroupLabel>
+      </div>
+      <SidebarGroupContent>
+        <SidebarMenu>{children}</SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+export function SidebarLoadingContent({
+  shape,
+}: {
+  shape: SidebarLoadingShape;
+}) {
+  return (
+    <div data-testid="sidebar-loading">
+      <SidebarLoadingSection titleWidthClass="w-16">
+        {shape.channels.map((row) => (
+          <SidebarLoadingRow key={row.key} widthClass={row.widthClass} />
+        ))}
+      </SidebarLoadingSection>
+      <SidebarLoadingSection titleWidthClass="w-24">
+        {shape.directMessages.map((row) => (
+          <SidebarLoadingRow avatar key={row.key} widthClass={row.widthClass} />
+        ))}
+      </SidebarLoadingSection>
+    </div>
+  );
+}
+
+export function SidebarPrimaryNavLoading() {
+  return (
+    <SidebarMenu data-testid="sidebar-primary-nav-loading">
+      {[
+        { key: "home", widthClass: "w-16" },
+        { key: "agents", widthClass: "w-20" },
+      ].map((row) => (
+        <SidebarMenuItem key={row.key}>
+          <div className="flex h-8 items-center gap-2 rounded-md px-2">
+            <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+            <Skeleton className={cn("h-4", row.widthClass)} />
+          </div>
+        </SidebarMenuItem>
+      ))}
+    </SidebarMenu>
+  );
+}
+
+export function SidebarProfileLoadingCard() {
+  return (
+    <div className="rounded-xl px-2 py-2" data-testid="sidebar-profile-loading">
+      <div className="flex min-w-0 items-center gap-3">
+        <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+        <div className="min-w-0 flex-1">
+          <Skeleton className="h-4 w-28 max-w-full" />
+          <Skeleton className="mt-1.5 h-3 w-24 max-w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/workflows/ui/ChannelCombobox.tsx
+++ b/desktop/src/features/workflows/ui/ChannelCombobox.tsx
@@ -99,7 +99,7 @@ export function ChannelCombobox({
           <span className="truncate">
             {selected ? formatChannelLabel(selected) : "Select a channel..."}
           </span>
-          <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" />
         </button>
       </PopoverTrigger>
       <PopoverContent
@@ -107,10 +107,11 @@ export function ChannelCombobox({
         className="w-(--radix-popover-trigger-width) p-0"
       >
         <div className="flex items-center gap-2 border-b border-border px-3 py-2">
-          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
           <input
-            autoCapitalize="off"
+            autoCapitalize="none"
             autoComplete="off"
+            autoCorrect="off"
             ref={(el) => el?.focus()}
             className="flex-1 bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
             onChange={(e) => {
@@ -119,6 +120,7 @@ export function ChannelCombobox({
             }}
             onKeyDown={handleKeyDown}
             placeholder="Search channels..."
+            spellCheck={false}
             value={query}
           />
         </div>
@@ -142,7 +144,7 @@ export function ChannelCombobox({
               >
                 <Check
                   className={cn(
-                    "h-3.5 w-3.5 shrink-0",
+                    "h-4 w-4 shrink-0",
                     channel.id === value ? "opacity-100" : "opacity-0",
                   )}
                 />

--- a/desktop/src/features/workflows/ui/WorkflowApprovalCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowApprovalCard.tsx
@@ -54,7 +54,7 @@ export function WorkflowApprovalCard({ approval }: WorkflowApprovalCardProps) {
           }
           size="sm"
         >
-          <Check className="mr-1 h-3 w-3" />
+          <Check className="mr-1 h-4 w-4" />
           Approve
         </Button>
         <Button
@@ -70,7 +70,7 @@ export function WorkflowApprovalCard({ approval }: WorkflowApprovalCardProps) {
           size="sm"
           variant="destructive"
         >
-          <X className="mr-1 h-3 w-3" />
+          <X className="mr-1 h-4 w-4" />
           Deny
         </Button>
       </div>

--- a/desktop/src/features/workflows/ui/WorkflowCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowCard.tsx
@@ -89,7 +89,7 @@ export function WorkflowCard({
             {channelName ? <span>{channelName}</span> : null}
             {triggerSummary ? <span>{triggerSummary}</span> : null}
             <span className="flex items-center gap-1">
-              <Clock className="h-3 w-3" />
+              <Clock className="h-4 w-4" />
               {new Date(workflow.updatedAt * 1000).toLocaleDateString()}
             </span>
           </div>

--- a/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDetailPanel.tsx
@@ -93,7 +93,7 @@ export function WorkflowDetailPanel({
               size="sm"
               variant="outline"
             >
-              <Pencil className="mr-1 h-3 w-3" />
+              <Pencil className="mr-1 h-4 w-4" />
               Edit
             </Button>
           ) : null}
@@ -103,7 +103,7 @@ export function WorkflowDetailPanel({
             size="sm"
             variant="outline"
           >
-            <Play className="mr-1 h-3 w-3" />
+            <Play className="mr-1 h-4 w-4" />
             {triggerMutation.isPending ? "Triggering..." : "Trigger"}
           </Button>
           <Button

--- a/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowFormBuilder.tsx
@@ -219,7 +219,7 @@ export function WorkflowFormBuilder({
           type="button"
           variant="ghost"
         >
-          <Code className="h-3.5 w-3.5" />
+          <Code className="h-4 w-4" />
           {mode === "form" ? "Edit as YAML" : "Back to form"}
         </Button>
       </div>
@@ -335,7 +335,7 @@ export function WorkflowFormBuilder({
                 type="button"
                 variant="outline"
               >
-                <Plus className="h-3.5 w-3.5" />
+                <Plus className="h-4 w-4" />
                 Add step
               </Button>
             </div>

--- a/desktop/src/features/workflows/ui/WorkflowStepCard.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowStepCard.tsx
@@ -326,7 +326,7 @@ export function WorkflowStepCard({
           type="button"
           variant="ghost"
         >
-          <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
+          <Trash2 className="h-4 w-4 text-muted-foreground" />
         </Button>
       </div>
 

--- a/desktop/src/features/workflows/ui/WorkflowWebhookHeadersEditor.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowWebhookHeadersEditor.tsx
@@ -48,7 +48,7 @@ export function WorkflowWebhookHeadersEditor({
           type="button"
           variant="outline"
         >
-          <Plus className="h-3.5 w-3.5" />
+          <Plus className="h-4 w-4" />
           Add header
         </Button>
       </div>
@@ -109,7 +109,7 @@ export function WorkflowWebhookHeadersEditor({
                 type="button"
                 variant="ghost"
               >
-                <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
+                <Trash2 className="h-4 w-4 text-muted-foreground" />
               </Button>
             </div>
           ))}

--- a/desktop/src/features/workflows/ui/workflowFormPrimitives.tsx
+++ b/desktop/src/features/workflows/ui/workflowFormPrimitives.tsx
@@ -25,7 +25,7 @@ export function FormSelect({
       >
         {children}
       </select>
-      <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+      <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
     </div>
   );
 }

--- a/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
+++ b/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
@@ -121,7 +121,7 @@ export function WorkspaceSwitcher({
               data-testid="relay-connection-warning"
               role="img"
             >
-              <WifiOff className={isProfileVariant ? "h-3 w-3" : "h-4 w-4"} />
+              <WifiOff className={isProfileVariant ? "h-4 w-4" : "h-4 w-4"} />
             </span>
           </TooltipTrigger>
           <TooltipContent side={isProfileVariant ? "top" : "bottom"}>
@@ -154,8 +154,8 @@ export function WorkspaceSwitcher({
         <ChevronDown
           className={
             isProfileVariant
-              ? "h-3 w-3 shrink-0 text-sidebar-foreground/45"
-              : "h-3.5 w-3.5 shrink-0 text-sidebar-foreground/50"
+              ? "h-4 w-4 shrink-0 text-sidebar-foreground/45"
+              : "h-4 w-4 shrink-0 text-sidebar-foreground/50"
           }
         />
       )}
@@ -209,7 +209,7 @@ export function WorkspaceSwitcher({
                 >
                   <span className="flex h-4 w-4 shrink-0 items-center justify-center">
                     {activeWorkspace?.id === workspace.id ? (
-                      <Check className="h-3.5 w-3.5 text-primary" />
+                      <Check className="h-4 w-4 text-primary" />
                     ) : null}
                   </span>
                   <span className="min-w-0 flex-1 truncate">
@@ -226,7 +226,7 @@ export function WorkspaceSwitcher({
                   }}
                   type="button"
                 >
-                  <MoreHorizontal className="h-3.5 w-3.5" />
+                  <MoreHorizontal className="h-4 w-4" />
                 </button>
               </div>
             ))}
@@ -296,7 +296,7 @@ export function WorkspaceSwitcher({
           >
             <span className="flex h-4 w-4 shrink-0 items-center justify-center">
               {activeWorkspace?.id === workspace.id ? (
-                <Check className="h-3.5 w-3.5 text-primary" />
+                <Check className="h-4 w-4 text-primary" />
               ) : null}
             </span>
             <span className="min-w-0 flex-1 truncate">{workspace.name}</span>
@@ -311,7 +311,7 @@ export function WorkspaceSwitcher({
               }}
               type="button"
             >
-              <MoreHorizontal className="h-3.5 w-3.5" />
+              <MoreHorizontal className="h-4 w-4" />
             </button>
           </DropdownMenuItem>
         ))}

--- a/desktop/src/shared/styles/globals.css
+++ b/desktop/src/shared/styles/globals.css
@@ -2,6 +2,16 @@
 @import "tw-animate-css";
 @config "../../../tailwind.config.js";
 
+.sprout-arc-spinner {
+  animation: sprout-arc-spinner-spin 500ms linear infinite;
+}
+
+@keyframes sprout-arc-spinner-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .buzz-emoji-mart {
   align-items: stretch;
   display: flex;
@@ -834,6 +844,121 @@
   button:disabled,
   [aria-disabled="true"] {
     cursor: default;
+  }
+}
+
+:root {
+  --skel-pulse-dur: 1000ms;
+  --skel-pulse-count: infinite;
+  --skel-pulse-min: 0.5;
+  --skel-reveal-dur: 400ms;
+  --skel-reveal-blur: 2px;
+  --skel-reveal-ease: ease-in-out;
+}
+
+.t-skel {
+  position: relative;
+}
+
+.t-skel[data-layout="flow"] {
+  display: grid;
+}
+
+.t-skel-skeleton,
+.t-skel-content {
+  inset: 0;
+  position: absolute;
+}
+
+.t-skel[data-layout="flow"] > .t-skel-skeleton,
+.t-skel[data-layout="flow"] > .t-skel-content {
+  grid-area: 1 / 1;
+  width: 100%;
+}
+
+.t-skel[data-layout="flow"] > .t-skel-skeleton {
+  inset: auto;
+  position: relative;
+}
+
+.t-skel[data-layout="flow"] > .t-skel-content,
+.t-skel[data-layout="flow"].is-revealed > .t-skel-skeleton {
+  inset: 0;
+  position: absolute;
+}
+
+.t-skel[data-layout="flow"].is-revealed > .t-skel-content {
+  inset: auto;
+  position: relative;
+}
+
+.t-skel-skeleton {
+  filter: blur(0);
+  opacity: 1;
+  transition:
+    opacity var(--skel-reveal-dur) var(--skel-reveal-ease),
+    filter var(--skel-reveal-dur) var(--skel-reveal-ease);
+  z-index: 1;
+}
+
+.t-skel-content {
+  filter: blur(var(--skel-reveal-blur));
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity var(--skel-reveal-dur) var(--skel-reveal-ease),
+    filter var(--skel-reveal-dur) var(--skel-reveal-ease);
+  z-index: 2;
+}
+
+.t-skel.is-revealed .t-skel-skeleton {
+  filter: blur(var(--skel-reveal-blur));
+  opacity: 0;
+  pointer-events: none;
+}
+
+.t-skel.is-revealed .t-skel-content {
+  filter: blur(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.t-skel.is-resetting .t-skel-skeleton,
+.t-skel.is-resetting .t-skel-content {
+  transition: none;
+}
+
+.t-skel-bar.is-pulsing,
+.t-skel-skeleton.is-pulsing > :not(:has(.t-skel-bar)) {
+  animation: t-skel-pulse var(--skel-pulse-dur) ease-in-out
+    var(--skel-pulse-count);
+}
+
+.t-skel.is-revealed .t-skel-bar.is-pulsing,
+.t-skel.is-revealed .t-skel-skeleton.is-pulsing > :not(:has(.t-skel-bar)) {
+  animation: none;
+}
+
+@keyframes t-skel-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: var(--skel-pulse-min);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-skel-skeleton,
+  .t-skel-content {
+    transition: none;
+  }
+
+  .t-skel-bar.is-pulsing,
+  .t-skel-skeleton.is-pulsing > :not(:has(.t-skel-bar)) {
+    animation: none;
   }
 }
 

--- a/desktop/src/shared/ui/VideoPlayer.tsx
+++ b/desktop/src/shared/ui/VideoPlayer.tsx
@@ -1627,7 +1627,7 @@ function VideoReviewDialog({
                           type="button"
                           onClick={() => setIsEmojiPickerOpen((open) => !open)}
                         >
-                          <SmilePlus className="pointer-events-none h-5 w-5" />
+                          <SmilePlus className="pointer-events-none h-4 w-4" />
                         </button>
                       </TooltipTrigger>
                       <TooltipContent>More reactions</TooltipContent>
@@ -1900,7 +1900,7 @@ function VideoReviewCommentBody({
         </p>
         {reactions.some((reaction) => reaction.reactedByCurrentUser) ? (
           <Check
-            className="ml-auto h-3.5 w-3.5 shrink-0 text-primary"
+            className="ml-auto h-4 w-4 shrink-0 text-primary"
             aria-hidden
           />
         ) : null}

--- a/desktop/src/shared/ui/ViewLoadingFallback.tsx
+++ b/desktop/src/shared/ui/ViewLoadingFallback.tsx
@@ -1,9 +1,12 @@
+import * as React from "react";
+
+import { useAppShell } from "@/app/AppShellContext";
 import { Card } from "@/shared/ui/card";
-import { useSidebar } from "@/shared/ui/sidebar";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { cn } from "@/shared/lib/cn";
 import { channelChrome } from "@/shared/layout/chromeLayout";
 import { TopChromeInsetHeader } from "@/shared/layout/TopChromeInsetHeader";
+import { TopChromeBackdrop } from "@/shared/ui/TopChromeBackdrop";
 
 type ViewLoadingFallbackKind =
   | "agents"
@@ -19,26 +22,18 @@ type ViewLoadingFallbackProps = {
 };
 
 function LoadingHeaderSkeleton() {
-  const { state: sidebarState } = useSidebar();
-
   return (
     <TopChromeInsetHeader data-tauri-drag-region>
-      <header
-        className={cn(
-          "flex min-h-[44px] min-w-0 cursor-default select-none items-center gap-[10px] py-[6px] pl-[16px] pr-[8px] transition-[padding] duration-200 ease-linear sm:pl-[24px] sm:pr-[12px]",
-          sidebarState === "collapsed" && "md:pl-[160px]",
-        )}
-      >
+      <header className="flex min-h-8 min-w-0 cursor-default select-none items-center gap-2.5 py-1.5 pl-4 pr-2 sm:pr-3">
         <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-[6px]">
-            <Skeleton className="h-3.5 w-3.5 rounded-xs" />
+          <div className="flex min-w-0 items-center gap-1 overflow-hidden">
+            <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
             <Skeleton className="h-4 w-28 max-w-[50vw]" />
           </div>
-          <Skeleton className="mt-2 h-4 w-full max-w-2xl" />
         </div>
-        <div className="hidden shrink-0 items-center gap-2 sm:flex">
-          <Skeleton className="h-6 w-6 rounded-lg" />
-          <Skeleton className="h-6 w-6 rounded-lg" />
+        <div className="hidden shrink-0 items-center gap-1 sm:flex">
+          <Skeleton className="h-8 w-16 rounded-lg" />
+          <Skeleton className="h-8 w-8 rounded-lg" />
         </div>
       </header>
     </TopChromeInsetHeader>
@@ -48,93 +43,232 @@ function LoadingHeaderSkeleton() {
 function MessageRowsSkeleton() {
   return (
     <>
-      {["first", "second", "third", "fourth", "fifth"].map((row, index) => (
-        <div className="flex gap-3" key={row}>
+      {["first", "second", "third", "fourth"].map((row, index) => (
+        <article
+          className="relative flex items-start gap-2.5 rounded-2xl px-3 py-2"
+          key={row}
+        >
           <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
-          <div className="min-w-0 flex-1 space-y-1 pt-0.5">
-            <div className="flex items-baseline gap-2">
-              <Skeleton className="h-3.5 w-28" />
-              <Skeleton className="h-3 w-12" />
+          <div className="-mt-1 min-w-0 flex-1">
+            <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0">
+              <Skeleton className="h-[15px] w-28" />
+              <Skeleton className="h-3 w-10" />
             </div>
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className={index % 2 === 0 ? "h-4 w-4/5" : "h-4 w-2/3"} />
+            <div className="mt-1 space-y-1.5 pb-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton
+                className={index % 2 === 0 ? "h-4 w-4/5" : "h-4 w-2/3"}
+              />
+            </div>
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-4 w-8 rounded-full" />
+              <Skeleton className="h-4 w-8 rounded-full" />
+              <Skeleton className="h-4 w-8 rounded-full" />
+            </div>
           </div>
-        </div>
+        </article>
       ))}
     </>
   );
 }
 
+const agentLoadingGroups = [
+  {
+    badgeWidth: "w-14",
+    instanceWidth: "w-20",
+    key: "persona-one",
+    rows: ["one-a", "one-b"],
+    titleWidth: "w-32",
+  },
+  {
+    badgeWidth: "w-16",
+    instanceWidth: "w-24",
+    key: "persona-two",
+    rows: ["two-a"],
+    titleWidth: "w-28",
+  },
+  {
+    badgeWidth: "w-12",
+    instanceWidth: "w-20",
+    key: "custom-agents",
+    rows: ["custom-a"],
+    titleWidth: "w-36",
+  },
+] as const;
+
+function AgentRowSkeleton({ variant = 0 }: { variant?: number }) {
+  return (
+    <div className="flex items-start gap-3 px-4 py-3">
+      <div className="min-w-0 flex-1">
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,1.8fr)_minmax(120px,0.8fr)_minmax(0,1.1fr)] lg:gap-4">
+          <div className="min-w-0">
+            <div className="flex items-start gap-3">
+              <Skeleton className="mt-0.5 h-4 w-4 shrink-0 rounded-sm" />
+              <Skeleton className="mt-1 h-2 w-2 shrink-0 rounded-full" />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Skeleton
+                    className={cn("h-4", variant % 2 === 0 ? "w-36" : "w-28")}
+                  />
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                </div>
+                <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+                {variant === 0 ? (
+                  <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                    <Skeleton className="h-5 w-20 rounded-full" />
+                    <Skeleton className="h-5 w-24 rounded-full" />
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1 lg:pt-0.5">
+            <Skeleton className="h-5 w-20 rounded-full" />
+            <Skeleton
+              className={cn("h-3", variant % 2 === 0 ? "w-24" : "w-28")}
+            />
+          </div>
+
+          <div className="space-y-1 lg:pt-0.5">
+            <Skeleton className="h-3 w-28" />
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <Skeleton className="h-3 w-20" />
+              {variant === 0 ? <Skeleton className="h-3 w-24" /> : null}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-start gap-2 lg:pt-0.5">
+        <Skeleton className="h-7 w-24 rounded-md" />
+        <Skeleton className="h-7 w-7 rounded-md" />
+      </div>
+    </div>
+  );
+}
+
+function AgentGroupSkeleton({
+  badgeWidth,
+  instanceWidth,
+  rows,
+  titleWidth,
+}: {
+  badgeWidth: string;
+  instanceWidth: string;
+  rows: readonly string[];
+  titleWidth: string;
+}) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border/70 bg-card/40">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2 py-1">
+          <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+          <Skeleton className="h-8 w-8 shrink-0 rounded-lg" />
+          <div className="flex min-w-0 items-center gap-2">
+            <Skeleton className={cn("h-4", titleWidth)} />
+            <Skeleton className={cn("h-5 rounded-full", badgeWidth)} />
+          </div>
+          <Skeleton className={cn("ml-1 h-3 shrink-0", instanceWidth)} />
+        </div>
+        <Skeleton className="h-7 w-7 shrink-0 rounded-md" />
+      </div>
+
+      <div className="divide-y divide-border/50 border-t border-border/50">
+        {rows.map((row, index) => (
+          <AgentRowSkeleton key={row} variant={index} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AgentsLibrarySkeleton() {
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="mt-2 h-4 w-80 max-w-full" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-7 w-7 rounded-md" />
+          <Skeleton className="h-8 w-16 rounded-lg" />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {agentLoadingGroups.map((group) => (
+          <AgentGroupSkeleton
+            badgeWidth={group.badgeWidth}
+            instanceWidth={group.instanceWidth}
+            key={group.key}
+            rows={group.rows}
+            titleWidth={group.titleWidth}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AgentTeamsSkeleton() {
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="mt-2 h-4 w-96 max-w-full" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="hidden h-8 w-40 rounded-md sm:block" />
+          <Skeleton className="h-8 w-20 rounded-lg" />
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {["team-one", "team-two", "team-three"].map((key, index) => (
+          <Card className="p-3" key={key}>
+            <div className="flex items-start justify-between gap-2.5">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+                  <Skeleton
+                    className={cn("h-4", index === 0 ? "w-28" : "w-36")}
+                  />
+                  {index === 1 ? (
+                    <Skeleton className="h-4 w-8 rounded-full" />
+                  ) : null}
+                </div>
+                <div className="mt-2 flex items-center gap-2">
+                  <div className="flex -space-x-1.5">
+                    <Skeleton className="h-6 w-6 rounded-full border-2 border-card" />
+                    <Skeleton className="h-6 w-6 rounded-full border-2 border-card" />
+                    <Skeleton className="h-6 w-6 rounded-full border-2 border-card" />
+                  </div>
+                  <Skeleton className="h-3 w-20" />
+                </div>
+              </div>
+              <Skeleton className="h-6 w-6 rounded-md" />
+            </div>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function AgentsLoadingBody() {
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-4 pb-4 pt-14 sm:px-6">
-      <div className="space-y-6">
-        <section className="space-y-4">
-          <div className="flex items-center justify-between gap-3">
-            <div className="space-y-2">
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-4 w-72 max-w-full" />
-            </div>
-            <Skeleton className="h-8 w-8 rounded-lg" />
-          </div>
-          <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-4">
-            {["first", "second", "third", "fourth"].map((card) => (
-              <Card className="p-3" key={card}>
-                <div className="flex items-center gap-2.5">
-                  <Skeleton className="h-8 w-8 rounded-lg" />
-                  <div className="min-w-0 flex-1 space-y-2">
-                    <Skeleton className="h-4 w-24" />
-                    <Skeleton className="h-3 w-16 rounded-full" />
-                  </div>
-                </div>
-              </Card>
-            ))}
-          </div>
-        </section>
-
-        <section className="space-y-4">
-          <div className="space-y-2">
-            <Skeleton className="h-5 w-24" />
-            <Skeleton className="h-4 w-80 max-w-full" />
-          </div>
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {["alpha", "beta", "gamma"].map((card) => (
-              <Card className="p-4" key={card}>
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="space-y-2">
-                      <Skeleton className="h-4 w-28" />
-                      <Skeleton className="h-3 w-20 rounded-full" />
-                    </div>
-                    <Skeleton className="h-7 w-16 rounded-full" />
-                  </div>
-                  <Skeleton className="h-4 w-full" />
-                  <Skeleton className="h-4 w-4/5" />
-                </div>
-              </Card>
-            ))}
-          </div>
-        </section>
-
-        <section className="space-y-4">
-          <div className="space-y-2">
-            <Skeleton className="h-5 w-36" />
-            <Skeleton className="h-4 w-72 max-w-full" />
-          </div>
-          <Card className="overflow-hidden">
-            {["one", "two", "three"].map((row) => (
-              <div
-                className="flex items-center gap-4 border-b border-border/60 px-4 py-3 last:border-b-0"
-                key={row}
-              >
-                <Skeleton className="h-4 w-28" />
-                <Skeleton className="h-5 w-16 rounded-full" />
-                <Skeleton className="h-4 w-24" />
-                <Skeleton className="ml-auto h-8 w-24 rounded-lg" />
-              </div>
-            ))}
-          </Card>
-        </section>
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden overscroll-contain px-4 pb-4 pt-14 sm:px-6">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <div className="flex flex-col gap-6">
+          <AgentsLibrarySkeleton />
+          <AgentTeamsSkeleton />
+        </div>
       </div>
     </div>
   );
@@ -181,8 +315,8 @@ function CardListLoadingBody() {
 
 function ChannelLoadingBody({ hasHeader = false }: { hasHeader?: boolean }) {
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      <div className="flex-1 overflow-y-auto px-4 pt-1 sm:px-6">
+    <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="flex-1 overflow-y-auto px-4 pb-32 pt-1 sm:px-6">
         <div
           className={cn(
             "flex w-full flex-col gap-4",
@@ -195,13 +329,25 @@ function ChannelLoadingBody({ hasHeader = false }: { hasHeader?: boolean }) {
         </div>
       </div>
 
-      <div className="border-t border-border/60 bg-background px-4 py-4 sm:px-6">
-        <div className="w-full space-y-3">
-          <Skeleton className="h-10 w-full rounded-2xl" />
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-8 w-20 rounded-lg" />
-            <Skeleton className="h-8 w-16 rounded-lg" />
-            <Skeleton className="ml-auto h-8 w-24 rounded-lg" />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10">
+        <div className="pointer-events-auto">
+          <div className="relative z-10 shrink-0 bg-transparent px-4 pb-2 pt-0">
+            <div
+              aria-hidden="true"
+              className="absolute inset-x-0 bottom-0 h-5 bg-background"
+            />
+            <div className="relative isolate rounded-2xl border border-border/50 bg-background/80 px-3 pb-2 pt-3 shadow-none backdrop-blur-md supports-[backdrop-filter]:bg-background/70 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-[backdrop-filter]:bg-background/55 sm:px-4">
+              <Skeleton className="h-5 w-56 max-w-full" />
+              <div className="mt-4 flex items-center gap-2">
+                <Skeleton className="h-8 w-8 rounded-lg" />
+                <Skeleton className="h-8 w-8 rounded-lg" />
+                <Skeleton className="h-8 w-8 rounded-lg" />
+                <Skeleton className="ml-auto h-8 w-8 rounded-full" />
+              </div>
+            </div>
+          </div>
+          <div className="h-7 bg-background px-4 pb-1 pt-0 sm:px-6">
+            <div className="flex h-full w-full items-center gap-2" />
           </div>
         </div>
       </div>
@@ -250,18 +396,37 @@ export function ViewLoadingFallback({
   includeHeader = false,
   kind,
 }: ViewLoadingFallbackProps) {
+  const { setTopbarSearchLoading } = useAppShell();
+  const shouldShowChannelHeader =
+    includeHeader && (kind === "channel" || kind === "forum");
+
+  React.useLayoutEffect(() => {
+    if (!includeHeader) return;
+
+    setTopbarSearchLoading(true);
+    return () => {
+      setTopbarSearchLoading(false);
+    };
+  }, [includeHeader, setTopbarSearchLoading]);
+
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      {includeHeader ? <LoadingHeaderSkeleton /> : null}
+    <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      {shouldShowChannelHeader ? (
+        <LoadingHeaderSkeleton />
+      ) : includeHeader ? (
+        <TopChromeBackdrop />
+      ) : null}
       {kind === "agents" ? <AgentsLoadingBody /> : null}
       {kind === "workflows" ? <CardListLoadingBody /> : null}
       {kind === "projects" ? <CardListLoadingBody /> : null}
       {kind === "channel" ? (
-        <ChannelLoadingBody hasHeader={includeHeader} />
+        <ChannelLoadingBody hasHeader={shouldShowChannelHeader} />
       ) : null}
-      {kind === "forum" ? <ForumLoadingBody hasHeader={includeHeader} /> : null}
+      {kind === "forum" ? (
+        <ForumLoadingBody hasHeader={shouldShowChannelHeader} />
+      ) : null}
       {kind === "pulse" ? (
-        <ChannelLoadingBody hasHeader={includeHeader} />
+        <ChannelLoadingBody hasHeader={shouldShowChannelHeader} />
       ) : null}
     </div>
   );

--- a/desktop/src/shared/ui/alert-dialog.tsx
+++ b/desktop/src/shared/ui/alert-dialog.tsx
@@ -15,7 +15,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/60 transition-none duration-200 ease-out data-[state=closed]:duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none",
       className,
     )}
     ref={ref}
@@ -33,7 +33,7 @@ const AlertDialogContent = React.forwardRef<
     <div className="fixed inset-0 z-50 grid place-items-center overflow-y-auto p-4 pointer-events-none">
       <AlertDialogPrimitive.Content
         className={cn(
-          "pointer-events-auto grid w-[calc(100vw-2rem)] max-w-md gap-4 rounded-3xl border border-border bg-background p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          "pointer-events-auto grid w-[calc(100vw-2rem)] max-w-md gap-4 rounded-3xl border border-border bg-background p-6 shadow-2xl transition-none duration-200 ease-out data-[state=closed]:duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 motion-reduce:animate-none",
           className,
         )}
         ref={ref}
@@ -74,7 +74,7 @@ const AlertDialogTitle = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
-    className={cn("text-lg font-semibold tracking-tight", className)}
+    className={cn("text-xl font-semibold tracking-tight", className)}
     ref={ref}
     {...props}
   />

--- a/desktop/src/shared/ui/checkbox.tsx
+++ b/desktop/src/shared/ui/checkbox.tsx
@@ -19,7 +19,7 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <Check className="h-3.5 w-3.5" />
+      <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));

--- a/desktop/src/shared/ui/chooser-dialog-content.tsx
+++ b/desktop/src/shared/ui/chooser-dialog-content.tsx
@@ -2,12 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/shared/lib/cn";
 
-import {
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "./dialog";
+import { DialogContent, DialogHeader, DialogTitle } from "./dialog";
 
 type ChooserDialogContentProps = React.ComponentPropsWithoutRef<
   typeof DialogContent
@@ -16,6 +11,7 @@ type ChooserDialogContentProps = React.ComponentPropsWithoutRef<
   footer?: React.ReactNode;
   footerClassName?: string;
   footerTestId?: string;
+  contentClassName?: string;
   headerClassName?: string;
   headerTestId?: string;
   scrollAreaClassName?: string;
@@ -31,7 +27,8 @@ export const ChooserDialogContent = React.forwardRef<
     {
       children,
       className,
-      description,
+      contentClassName,
+      description: _description,
       footer,
       footerClassName,
       footerTestId,
@@ -40,11 +37,13 @@ export const ChooserDialogContent = React.forwardRef<
       scrollAreaClassName,
       scrollAreaTestId,
       title,
+      "aria-describedby": ariaDescribedBy,
       ...props
     },
     ref,
   ) => (
     <DialogContent
+      aria-describedby={ariaDescribedBy}
       className={cn(
         "flex max-h-[85vh] flex-col gap-0 overflow-hidden p-0",
         className,
@@ -53,16 +52,10 @@ export const ChooserDialogContent = React.forwardRef<
       {...props}
     >
       <DialogHeader
-        className={cn(
-          "shrink-0 border-b border-border/60 px-6 py-5 pr-14",
-          headerClassName,
-        )}
+        className={cn("shrink-0 px-6 py-5 pr-14", headerClassName)}
         data-testid={headerTestId}
       >
         <DialogTitle>{title}</DialogTitle>
-        {description ? (
-          <DialogDescription>{description}</DialogDescription>
-        ) : null}
       </DialogHeader>
 
       <div
@@ -72,7 +65,7 @@ export const ChooserDialogContent = React.forwardRef<
         )}
         data-testid={scrollAreaTestId}
       >
-        <div className="py-5">{children}</div>
+        <div className={cn("py-5", contentClassName)}>{children}</div>
       </div>
 
       {footer ? (

--- a/desktop/src/shared/ui/dialog.tsx
+++ b/desktop/src/shared/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   return (
     <DialogPrimitive.Overlay
       className={cn(
-        "fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 transition-none duration-200 ease-out data-[state=closed]:duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none",
         isDark ? "bg-black/60" : "bg-black/10",
         className,
       )}
@@ -32,26 +32,34 @@ const DialogOverlay = React.forwardRef<
 });
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+type DialogContentProps = React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Content
+> & {
+  showCloseButton?: boolean;
+};
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, showCloseButton = true, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <div className="fixed inset-0 z-50 grid place-items-center overflow-y-auto p-4 pointer-events-none">
       <DialogPrimitive.Content
         className={cn(
-          "pointer-events-auto relative grid w-[calc(100vw-2rem)] max-w-2xl gap-4 rounded-3xl border border-border bg-background p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          "pointer-events-auto relative grid w-[calc(100vw-2rem)] max-w-2xl gap-4 rounded-3xl border border-border bg-background p-6 shadow-2xl transition-none duration-200 ease-out data-[state=closed]:duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 motion-reduce:animate-none",
           className,
         )}
         ref={ref}
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-hidden focus:ring-1 focus:ring-ring">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {showCloseButton ? (
+          <DialogPrimitive.Close className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 ease-out hover:bg-accent hover:text-accent-foreground focus:outline-hidden focus:ring-1 focus:ring-ring">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        ) : null}
       </DialogPrimitive.Content>
     </div>
   </DialogPortal>
@@ -74,7 +82,7 @@ const DialogTitle = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
-    className={cn("text-lg font-semibold tracking-tight", className)}
+    className={cn("text-xl font-semibold tracking-tight", className)}
     ref={ref}
     {...props}
   />

--- a/desktop/src/shared/ui/import-status-icon.tsx
+++ b/desktop/src/shared/ui/import-status-icon.tsx
@@ -16,7 +16,9 @@ export function ImportStatusIcon({
 }) {
   switch (status) {
     case "importing":
-      return <Spinner className="h-4 w-4 shrink-0 text-muted-foreground" />;
+      return (
+        <Spinner className="h-4 w-4 shrink-0 border-2 text-muted-foreground" />
+      );
     case "done":
       return <Check className="h-4 w-4 shrink-0 text-green-500" />;
     case "error":

--- a/desktop/src/shared/ui/input.tsx
+++ b/desktop/src/shared/ui/input.tsx
@@ -6,6 +6,9 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
     return (
       <input
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
         type={type}
         className={cn(
           "flex h-9 w-full rounded-lg border border-input/40 bg-background px-3 py-1 text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -520,7 +520,7 @@ function MarkdownCodeBlock({
             type="button"
             variant="ghost"
           >
-            <Copy className="h-3.5 w-3.5" />
+            <Copy className="h-4 w-4" />
             <span className="sr-only">Copy code block</span>
           </Button>
         </TooltipTrigger>
@@ -579,7 +579,7 @@ function FileCard({
       className="my-1 inline-flex max-w-sm items-center gap-3 rounded-xl border border-border/70 bg-muted/40 px-3 py-2 text-left no-underline transition-colors hover:bg-muted/70"
     >
       <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-background text-muted-foreground">
-        <FileText className="h-5 w-5" />
+        <FileText className="h-4 w-4" />
       </span>
       <span className="min-w-0 flex-1">
         <span className="block truncate text-sm font-medium text-foreground">

--- a/desktop/src/shared/ui/skeleton.tsx
+++ b/desktop/src/shared/ui/skeleton.tsx
@@ -1,15 +1,99 @@
+import * as React from "react";
+
 import { cn } from "@/shared/lib/cn";
 
-function Skeleton({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
+type SkeletonProps = React.HTMLAttributes<HTMLDivElement> & {
+  pulsing?: boolean;
+};
+
+function Skeleton({ className, pulsing = true, ...props }: SkeletonProps) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      aria-hidden="true"
+      className={cn(
+        "t-skel-bar rounded-md bg-primary/10",
+        pulsing && "is-pulsing",
+        className,
+      )}
       {...props}
     />
   );
 }
 
-export { Skeleton };
+type SkeletonRevealProps = React.HTMLAttributes<HTMLDivElement> & {
+  contentClassName?: string;
+  layout?: "absolute" | "flow";
+  loading: boolean;
+  skeleton: React.ReactNode;
+  skeletonClassName?: string;
+};
+
+function SkeletonReveal({
+  children,
+  className,
+  contentClassName,
+  layout = "flow",
+  loading,
+  skeleton,
+  skeletonClassName,
+  ...props
+}: SkeletonRevealProps) {
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const previousLoadingRef = React.useRef(loading);
+  const [isResetting, setIsResetting] = React.useState(false);
+
+  React.useLayoutEffect(() => {
+    const wasLoading = previousLoadingRef.current;
+    previousLoadingRef.current = loading;
+
+    if (!loading || wasLoading) return;
+
+    setIsResetting(true);
+    rootRef.current?.getBoundingClientRect();
+
+    const reset = () => setIsResetting(false);
+    const frameId = globalThis.requestAnimationFrame
+      ? globalThis.requestAnimationFrame(reset)
+      : globalThis.setTimeout(reset, 0);
+
+    return () => {
+      if (typeof frameId === "number") {
+        if (globalThis.cancelAnimationFrame) {
+          globalThis.cancelAnimationFrame(frameId);
+        } else {
+          globalThis.clearTimeout(frameId);
+        }
+      }
+    };
+  }, [loading]);
+
+  return (
+    <div
+      className={cn(
+        "t-skel",
+        !loading && "is-revealed",
+        isResetting && "is-resetting",
+        className,
+      )}
+      data-layout={layout}
+      data-state={loading ? "loading" : "loaded"}
+      ref={rootRef}
+      {...props}
+    >
+      <div
+        aria-hidden="true"
+        className={cn("t-skel-skeleton is-pulsing", skeletonClassName)}
+      >
+        {skeleton}
+      </div>
+      <div
+        aria-hidden={loading}
+        className={cn("t-skel-content", contentClassName)}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export { Skeleton, SkeletonReveal };

--- a/desktop/src/shared/ui/spinner.tsx
+++ b/desktop/src/shared/ui/spinner.tsx
@@ -1,26 +1,40 @@
-import { Loader2 } from "lucide-react";
+import type * as React from "react";
 
 import { cn } from "@/shared/lib/cn";
 
-type SpinnerProps = React.ComponentPropsWithoutRef<"svg"> & {
+type SpinnerProps = React.ComponentPropsWithoutRef<"span"> & {
   className?: string;
-  size?: number;
+  size?: number | string;
 };
 
 export function Spinner({
+  children,
   className,
   size,
   role = "status",
   "aria-label": ariaLabel = "Loading",
+  "aria-hidden": ariaHidden,
+  style,
   ...rest
 }: SpinnerProps) {
+  const isDecorative = ariaHidden === true || ariaHidden === "true";
+
   return (
-    <Loader2
-      className={cn("animate-spin", className)}
-      size={size}
-      role={role}
-      aria-label={ariaLabel}
+    <span
+      aria-hidden={ariaHidden}
+      className={cn(
+        "sprout-arc-spinner inline-block h-6 w-6 shrink-0 rounded-full border-4 border-current/10 border-t-current",
+        className,
+      )}
+      role={isDecorative ? undefined : role}
+      style={{
+        ...(size === undefined ? null : { height: size, width: size }),
+        ...style,
+      }}
       {...rest}
-    />
+    >
+      {children}
+      {isDecorative ? null : <span className="sr-only">{ariaLabel}</span>}
+    </span>
   );
 }

--- a/desktop/src/shared/ui/textarea.tsx
+++ b/desktop/src/shared/ui/textarea.tsx
@@ -8,6 +8,9 @@ const Textarea = React.forwardRef<
 >(({ className, ...props }, ref) => {
   return (
     <textarea
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
       className={cn(
         "flex min-h-20 w-full rounded-lg border border-input/40 bg-background px-3 py-2 text-base transition-colors placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -751,8 +751,8 @@ test("narrow thread view collapses channel header actions into a menu", async ({
     throw new Error("Expected header action menu and thread panel bounds");
   }
   const menuGapPx = threadPanelBox.x - (menuBox.x + menuBox.width);
-  expect(menuGapPx).toBeGreaterThanOrEqual(10);
-  expect(menuGapPx).toBeLessThanOrEqual(14);
+  expect(menuGapPx).toBeGreaterThanOrEqual(22);
+  expect(menuGapPx).toBeLessThanOrEqual(26);
 
   await menuTrigger.click();
 

--- a/web/src/features/repos/ui/RepoBlobViewer.tsx
+++ b/web/src/features/repos/ui/RepoBlobViewer.tsx
@@ -258,7 +258,7 @@ export function RepoBlobPage() {
       <BackLink repoId={repoId} />
 
       <div className="mt-4 flex flex-wrap items-center gap-3">
-        <FileText className="h-5 w-5 text-muted-foreground" />
+        <FileText className="h-4 w-4 text-muted-foreground" />
         <h1 className="min-w-0 truncate font-mono text-sm">{filepath}</h1>
         <div className="ml-auto flex items-center gap-2">
           {view &&

--- a/web/src/features/repos/ui/RepoRefsSection.tsx
+++ b/web/src/features/repos/ui/RepoRefsSection.tsx
@@ -22,12 +22,12 @@ export function RepoRefsSection({
             <>
               <div className="flex items-center gap-1.5">
                 <Badge variant="secondary">
-                  <GitBranch className="mr-1 h-3 w-3" />
+                  <GitBranch className="mr-1 h-4 w-4" />
                   {refs.head.ref}
                 </Badge>
                 {refs.head.sha && (
                   <Badge variant="outline" className="font-mono text-xs">
-                    <Hash className="mr-0.5 h-3 w-3" />
+                    <Hash className="mr-0.5 h-4 w-4" />
                     {refs.head.sha.slice(0, 7)}
                   </Badge>
                 )}
@@ -36,13 +36,13 @@ export function RepoRefsSection({
             </>
           )}
           <span className="flex items-center gap-1">
-            <GitBranch className="h-3.5 w-3.5" />
+            <GitBranch className="h-4 w-4" />
             {refs.branches.length}{" "}
             {refs.branches.length === 1 ? "branch" : "branches"}
           </span>
           <span className="text-muted-foreground/60">&middot;</span>
           <span className="flex items-center gap-1">
-            <Tag className="h-3.5 w-3.5" />
+            <Tag className="h-4 w-4" />
             {refs.tags.length} {refs.tags.length === 1 ? "tag" : "tags"}
           </span>
         </div>

--- a/web/src/features/repos/ui/ReposPage.tsx
+++ b/web/src/features/repos/ui/ReposPage.tsx
@@ -104,7 +104,7 @@ export function ReposPage() {
       <div className="flex w-full gap-8 px-4 py-8">
         <div className="min-w-0 flex-1">
           <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold">
-            <BookMarked className="h-5 w-5" /> Repositories
+            <BookMarked className="h-4 w-4" /> Repositories
           </h2>
           <div className="divide-y">
             {["a", "b", "c", "d", "e"].map((key) => (
@@ -131,7 +131,7 @@ export function ReposPage() {
         </div>
 
         <h2 className="mb-4 flex items-center gap-2 text-lg font-semibold">
-          <BookMarked className="h-5 w-5" /> Repositories
+          <BookMarked className="h-4 w-4" /> Repositories
         </h2>
 
         {/* Search + Sort bar */}


### PR DESCRIPTION
Stack 4/5. Depends on #1000.

Summary:
- Replace broad app loading states with closer skeleton layouts for sidebar, home, agents, channel timeline, composer, global search, and thread panels.
- Cache recent sidebar/timeline shapes so skeletons better match the loaded content.
- Wire topbar search into full-page loading states.

Checks:
- `pnpm --dir desktop exec biome check <changed skeleton files>`
- `pnpm --dir desktop typecheck`
- `git diff --check origin/main..HEAD`