### PR TITLE
Add relay disconnect UX: friendly errors, reconnect, cached identity

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
         "**/workflows.spec.ts",
         "**/identity-archive.spec.ts",
         "**/identity-archive-hide.spec.ts",
+        "**/relay-connectivity-screenshots.spec.ts",
       ],
       use: {
         ...devices["Desktop Chrome"],

--- a/desktop/src-tauri/src/commands/media.rs
+++ b/desktop/src-tauri/src/commands/media.rs
@@ -5,7 +5,10 @@ use sha2::{Digest, Sha256};
 use tauri::State;
 
 use crate::app_state::AppState;
-use crate::relay::relay_api_base_url_with_override;
+use crate::relay::{
+    classify_request_error, parse_json_response, relay_api_base_url_with_override,
+    relay_error_message,
+};
 
 use super::media_transcode::{is_video_file, transcode_and_extract_poster};
 
@@ -246,17 +249,13 @@ async fn do_upload(
     } else {
         req.body(body).send().await
     }
-    .map_err(|e| format!("upload failed: {e}"))?;
+    .map_err(|e| classify_request_error(&e))?;
 
     if !resp.status().is_success() {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        return Err(format!("upload failed ({status}): {text}"));
+        return Err(relay_error_message(resp).await);
     }
 
-    resp.json::<BlobDescriptor>()
-        .await
-        .map_err(|e| format!("parse failed: {e}"))
+    parse_json_response::<BlobDescriptor>(resp).await
 }
 
 // ── Commands ─────────────────────────────────────────────────────────────────

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -3,7 +3,7 @@ use tauri::State;
 
 use crate::app_state::AppState;
 use crate::commands::export_util::save_bytes_with_dialog;
-use crate::relay::relay_api_base_url_with_override;
+use crate::relay::{classify_request_error, relay_api_base_url_with_override, relay_error_message};
 
 use super::media::{detect_and_validate_mime, sanitize_filename};
 
@@ -140,12 +140,10 @@ async fn fetch_blob_bytes(url: &str, state: &State<'_, AppState>) -> Result<Vec<
         .timeout(DOWNLOAD_TIMEOUT)
         .send()
         .await
-        .map_err(|e| format!("download failed: {e}"))?;
+        .map_err(|e| classify_request_error(&e))?;
 
     if !resp.status().is_success() {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        return Err(format!("download failed ({status}): {text}"));
+        return Err(relay_error_message(resp).await);
     }
 
     // Check Content-Length header upfront if present.
@@ -164,7 +162,7 @@ async fn fetch_blob_bytes(url: &str, state: &State<'_, AppState>) -> Result<Vec<
     let mut bytes = Vec::new();
     let mut stream = resp.bytes_stream();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| format!("download stream error: {e}"))?;
+        let chunk = chunk.map_err(|e| classify_request_error(&e))?;
         if bytes.len() as u64 + chunk.len() as u64 > MAX_DOWNLOAD_BYTES {
             return Err(format!(
                 "file too large (max {} MiB)",

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -127,7 +127,7 @@ pub fn build_nip98_auth_header_for_keys(
 ///
 /// The returned string always starts with `"relay unreachable:"` so the
 /// frontend connectivity classifier can detect it with a simple prefix check.
-fn classify_request_error(e: &reqwest::Error) -> String {
+pub(crate) fn classify_request_error(e: &reqwest::Error) -> String {
     let display = e.to_string().to_lowercase();
     if e.is_timeout() {
         "relay unreachable: request timed out".to_string()
@@ -182,7 +182,7 @@ fn classify_intercepted_response(final_host: &str, content_type: &str) -> Option
 /// appropriate `"relay unreachable:"` message instead of attempting JSON parsing.
 /// URL details are deliberately omitted from error strings so raw URLs are never
 /// surfaced in the UI.
-async fn parse_json_response<T: DeserializeOwned>(
+pub(crate) async fn parse_json_response<T: DeserializeOwned>(
     response: reqwest::Response,
 ) -> Result<T, String> {
     let final_host = response.url().host_str().unwrap_or("").to_string();

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -123,8 +123,104 @@ pub fn build_nip98_auth_header_for_keys(
 
 // ── Error handling ──────────────────────────────────────────────────────────
 
+/// Classify a `send()` failure into a stable, URL-free error string.
+///
+/// The returned string always starts with `"relay unreachable:"` so the
+/// frontend connectivity classifier can detect it with a simple prefix check.
+fn classify_request_error(e: &reqwest::Error) -> String {
+    let display = e.to_string().to_lowercase();
+    if e.is_timeout() {
+        "relay unreachable: request timed out".to_string()
+    } else if e.is_connect() {
+        "relay unreachable: could not connect to relay".to_string()
+    } else if display.contains("dns") || display.contains("failed to lookup") {
+        "relay unreachable: relay host not found".to_string()
+    } else {
+        "relay unreachable: network error".to_string()
+    }
+}
+
+/// Detect responses that were intercepted by a captive portal or auth proxy.
+///
+/// Returns `Some(msg)` when the response clearly did not come from the relay:
+/// - Cloudflare Access redirect (final URL on `*.cloudflareaccess.com`)
+/// - Any other HTML response (proxy login page, captive portal, etc.)
+///
+/// Pure function: takes the already-extracted host and content-type strings so
+/// it can be unit-tested without constructing a real `reqwest::Response`.
+fn classify_intercepted_response(final_host: &str, content_type: &str) -> Option<String> {
+    let host = final_host.to_lowercase();
+    let ct = content_type.to_lowercase();
+
+    // Cloudflare Access intercepts requests and redirects to its own domain.
+    // Label-boundary check prevents `notcloudflareaccess.com.evil.example` from
+    // matching.
+    if host == "cloudflareaccess.com" || host.ends_with(".cloudflareaccess.com") {
+        return Some(
+            "relay unreachable: network sign-in required (Cloudflare Access / VPN) \
+             — re-authenticate and reconnect"
+                .to_string(),
+        );
+    }
+
+    // Generic HTML body from any other proxy or captive portal.
+    if ct.contains("text/html") {
+        return Some(
+            "relay unreachable: relay returned an unexpected HTML page \
+             (VPN or proxy sign-in?)"
+                .to_string(),
+        );
+    }
+
+    None
+}
+
+/// Deserialize a successful response as JSON, guarding against intercepted pages.
+///
+/// Extracts the final URL host and `Content-Type` header before consuming the
+/// response body. If the response looks like a captive-portal page, returns the
+/// appropriate `"relay unreachable:"` message instead of attempting JSON parsing.
+/// URL details are deliberately omitted from error strings so raw URLs are never
+/// surfaced in the UI.
+async fn parse_json_response<T: DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, String> {
+    let final_host = response.url().host_str().unwrap_or("").to_string();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    if let Some(msg) = classify_intercepted_response(&final_host, &content_type) {
+        return Err(msg);
+    }
+
+    // Drop the reqwest error detail — it contains the raw URL.
+    response
+        .json::<T>()
+        .await
+        .map_err(|_| "relay unreachable: response was not valid JSON".to_string())
+}
+
 pub async fn relay_error_message(response: reqwest::Response) -> String {
     let status = response.status();
+
+    // Check for intercepted/proxy responses before reading the body.
+    let final_host = response.url().host_str().unwrap_or("").to_string();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    if let Some(msg) = classify_intercepted_response(&final_host, &content_type) {
+        return msg;
+    }
+
+    // Real relay error: extract the structured message field if available.
     let body = response.text().await.unwrap_or_default();
 
     if let Ok(value) = serde_json::from_str::<serde_json::Value>(&body) {
@@ -137,7 +233,8 @@ pub async fn relay_error_message(response: reqwest::Response) -> String {
         }
     }
 
-    format!("relay returned {status}: {body}")
+    // Non-JSON, non-HTML body: emit status only — no raw body in the UI.
+    format!("relay returned {status}")
 }
 
 // ── HTTP bridge: POST /query ────────────────────────────────────────────────
@@ -175,16 +272,13 @@ pub async fn query_relay_at(
         .body(body_bytes)
         .send()
         .await
-        .map_err(|e| format!("request failed: {e}"))?;
+        .map_err(|e| classify_request_error(&e))?;
 
     if !response.status().is_success() {
         return Err(relay_error_message(response).await);
     }
 
-    response
-        .json::<Vec<nostr::Event>>()
-        .await
-        .map_err(|e| format!("failed to parse query response: {e}"))
+    parse_json_response(response).await
 }
 
 // ── Command response parsing ────────────────────────────────────────────────
@@ -281,7 +375,7 @@ pub async fn sync_managed_agent_profile(
         .body(body_bytes)
         .send()
         .await
-        .map_err(|e| format!("request failed: {e}"))?;
+        .map_err(|e| classify_request_error(&e))?;
 
     if !response.status().is_success() {
         let msg = relay_error_message(response).await;
@@ -380,16 +474,13 @@ pub async fn submit_event(
         .body(body_bytes)
         .send()
         .await
-        .map_err(|e| format!("request failed: {e}"))?;
+        .map_err(|e| classify_request_error(&e))?;
 
     if !response.status().is_success() {
         return Err(relay_error_message(response).await);
     }
 
-    let result: SubmitEventResponse = response
-        .json()
-        .await
-        .map_err(|e| format!("failed to parse response: {e}"))?;
+    let result: SubmitEventResponse = parse_json_response(response).await?;
 
     if !result.accepted {
         return Err(format!("relay rejected event: {}", result.message));
@@ -429,16 +520,13 @@ pub async fn submit_event_with_keys(
         .body(body_bytes)
         .send()
         .await
-        .map_err(|e| format!("request failed: {e}"))?;
+        .map_err(|e| classify_request_error(&e))?;
 
     if !response.status().is_success() {
         return Err(relay_error_message(response).await);
     }
 
-    let result: SubmitEventResponse = response
-        .json()
-        .await
-        .map_err(|e| format!("failed to parse response: {e}"))?;
+    let result: SubmitEventResponse = parse_json_response(response).await?;
 
     if !result.accepted {
         return Err(format!("relay rejected event: {}", result.message));
@@ -451,8 +539,72 @@ pub async fn submit_event_with_keys(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_profile_event, parse_command_response};
+    use super::{build_profile_event, classify_intercepted_response, parse_command_response};
     use serde::Deserialize;
+
+    // ── classify_intercepted_response ────────────────────────────────────────
+
+    #[test]
+    fn intercepted_cloudflare_host_returns_some() {
+        let result = classify_intercepted_response("sqprod.cloudflareaccess.com", "text/html");
+        assert!(result.is_some());
+        let msg = result.unwrap();
+        assert!(
+            msg.starts_with("relay unreachable:"),
+            "should have unreachable prefix"
+        );
+        assert!(msg.contains("Cloudflare"), "should mention Cloudflare");
+    }
+
+    #[test]
+    fn intercepted_cloudflare_apex_host_returns_some() {
+        // The apex domain itself should also match.
+        let result = classify_intercepted_response("cloudflareaccess.com", "application/json");
+        assert!(result.is_some());
+        let msg = result.unwrap();
+        assert!(msg.starts_with("relay unreachable:"));
+        assert!(msg.contains("Cloudflare"));
+    }
+
+    #[test]
+    fn intercepted_non_cloudflare_html_returns_some() {
+        let result =
+            classify_intercepted_response("proxy.corporate.example", "text/html; charset=utf-8");
+        assert!(result.is_some());
+        let msg = result.unwrap();
+        assert!(msg.starts_with("relay unreachable:"));
+    }
+
+    #[test]
+    fn normal_relay_json_returns_none() {
+        let result = classify_intercepted_response("relay.myapp.example.com", "application/json");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn content_type_case_insensitive() {
+        // Uppercase content-type must still be detected.
+        let result = classify_intercepted_response("proxy.example.com", "TEXT/HTML");
+        assert!(result.is_some());
+        assert!(result.unwrap().starts_with("relay unreachable:"));
+    }
+
+    #[test]
+    fn evil_suffix_does_not_match_cloudflare() {
+        // A host whose suffix happens to contain the Cloudflare string but is
+        // not actually a subdomain must NOT match.
+        let result = classify_intercepted_response(
+            "notcloudflareaccess.com.evil.example",
+            "application/json",
+        );
+        assert!(
+            result.is_none(),
+            "false suffix match should not trigger Cloudflare branch"
+        );
+    }
+
+    // classify_request_error requires a real reqwest::Error (not publicly
+    // constructable) — tested indirectly through integration; skipped here.
 
     // ── parse_command_response ───────────────────────────────────────────────
 

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -66,10 +66,7 @@ import { useWorkspaces } from "@/features/workspaces/useWorkspaces";
 import { useApplyTemplate } from "@/features/channel-templates/useApplyTemplate";
 import { relayClient } from "@/shared/api/relayClient";
 import { useIdentityQuery } from "@/shared/api/hooks";
-import {
-  isRelayConnectionDegraded,
-  useRelayConnection,
-} from "@/shared/api/useRelayConnection";
+import { useRelayAutoHeal } from "@/shared/api/useRelayAutoHeal";
 import { useDeferredStartup } from "@/shared/hooks/useDeferredStartup";
 import { joinChannel } from "@/shared/api/tauri";
 import type { Channel, RelayEvent, SearchHit } from "@/shared/api/types";
@@ -222,9 +219,8 @@ export function AppShell() {
     identityQuery.data?.pubkey,
   );
   const profileQuery = useProfileQuery();
-  const connectionState = useRelayConnection();
-  const prevConnectionStateRef = React.useRef(connectionState);
   const deferredPubkey = startupReady ? identityQuery.data?.pubkey : undefined;
+  useRelayAutoHeal();
   usePresenceSubscription();
   useUserStatusSubscription();
   useWorkspaceEmojiLiveUpdates();
@@ -288,17 +284,6 @@ export function AppShell() {
       });
     },
   );
-
-  // Auto-heal: when the connection recovers from a degraded state, invalidate
-  // all queries so errored queries (e.g. messages, which don't poll) refetch
-  // automatically without requiring a manual reconnect action.
-  React.useEffect(() => {
-    const prev = prevConnectionStateRef.current;
-    prevConnectionStateRef.current = connectionState;
-    if (isRelayConnectionDegraded(prev) && connectionState === "connected") {
-      void queryClient.invalidateQueries();
-    }
-  }, [connectionState, queryClient]);
 
   const channelsQuery = useChannelsQuery();
   const { refetch: refetchChannels } = channelsQuery;

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -66,6 +66,10 @@ import { useWorkspaces } from "@/features/workspaces/useWorkspaces";
 import { useApplyTemplate } from "@/features/channel-templates/useApplyTemplate";
 import { relayClient } from "@/shared/api/relayClient";
 import { useIdentityQuery } from "@/shared/api/hooks";
+import {
+  isRelayConnectionDegraded,
+  useRelayConnection,
+} from "@/shared/api/useRelayConnection";
 import { useDeferredStartup } from "@/shared/hooks/useDeferredStartup";
 import { joinChannel } from "@/shared/api/tauri";
 import type { Channel, RelayEvent, SearchHit } from "@/shared/api/types";
@@ -74,6 +78,7 @@ import { MainInsetProvider } from "@/shared/layout/MainInsetContext";
 import { chromeCssVarDefaults } from "@/shared/layout/chromeLayout";
 import { hasPrimaryShortcutModifier } from "@/shared/lib/platform";
 import { useMessageDeepLinks } from "@/shared/useMessageDeepLinks";
+import { ConnectionBanner } from "@/shared/ui/ConnectionBanner";
 import { SidebarInset, SidebarProvider } from "@/shared/ui/sidebar";
 
 type AppView =
@@ -217,6 +222,8 @@ export function AppShell() {
     identityQuery.data?.pubkey,
   );
   const profileQuery = useProfileQuery();
+  const connectionState = useRelayConnection();
+  const prevConnectionStateRef = React.useRef(connectionState);
   const deferredPubkey = startupReady ? identityQuery.data?.pubkey : undefined;
   usePresenceSubscription();
   useUserStatusSubscription();
@@ -281,6 +288,17 @@ export function AppShell() {
       });
     },
   );
+
+  // Auto-heal: when the connection recovers from a degraded state, invalidate
+  // all queries so errored queries (e.g. messages, which don't poll) refetch
+  // automatically without requiring a manual reconnect action.
+  React.useEffect(() => {
+    const prev = prevConnectionStateRef.current;
+    prevConnectionStateRef.current = connectionState;
+    if (isRelayConnectionDegraded(prev) && connectionState === "connected") {
+      void queryClient.invalidateQueries();
+    }
+  }, [connectionState, queryClient]);
 
   const channelsQuery = useChannelsQuery();
   const { refetch: refetchChannels } = channelsQuery;
@@ -938,6 +956,7 @@ export function AppShell() {
                         className="min-h-0 min-w-0 overflow-hidden"
                         style={chromeCssVarDefaults}
                       >
+                        <ConnectionBanner />
                         <Outlet />
                       </SidebarInset>
                     </MainInsetProvider>

--- a/desktop/src/features/channels/ui/ChannelCanvas.tsx
+++ b/desktop/src/features/channels/ui/ChannelCanvas.tsx
@@ -9,7 +9,10 @@ import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext"
 import { Button } from "@/shared/ui/button";
 import { Markdown } from "@/shared/ui/markdown";
 import { Textarea } from "@/shared/ui/textarea";
-import { isRelayUnreachableError } from "@/shared/lib/relayError";
+import {
+  isRelayUnreachableError,
+  RELAY_UNREACHABLE_SHORT,
+} from "@/shared/lib/relayError";
 
 type ChannelCanvasProps = {
   channelId: string | null;
@@ -57,7 +60,7 @@ export function ChannelCanvas({
     return (
       <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
         {isRelayUnreachableError(canvasQuery.error)
-          ? "Canvas unavailable — can't reach the relay."
+          ? RELAY_UNREACHABLE_SHORT
           : canvasQuery.error.message}
       </p>
     );

--- a/desktop/src/features/channels/ui/ChannelCanvas.tsx
+++ b/desktop/src/features/channels/ui/ChannelCanvas.tsx
@@ -9,6 +9,7 @@ import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext"
 import { Button } from "@/shared/ui/button";
 import { Markdown } from "@/shared/ui/markdown";
 import { Textarea } from "@/shared/ui/textarea";
+import { isRelayUnreachableError } from "@/shared/lib/relayError";
 
 type ChannelCanvasProps = {
   channelId: string | null;
@@ -55,7 +56,9 @@ export function ChannelCanvas({
   if (canvasQuery.error instanceof Error) {
     return (
       <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-        {canvasQuery.error.message}
+        {isRelayUnreachableError(canvasQuery.error)
+          ? "Canvas unavailable — can't reach the relay."
+          : canvasQuery.error.message}
       </p>
     );
   }

--- a/desktop/src/features/home/ui/HomeScreen.tsx
+++ b/desktop/src/features/home/ui/HomeScreen.tsx
@@ -5,7 +5,10 @@ import { useHomeFeedQuery } from "@/features/home/hooks";
 import { HomeView } from "@/features/home/ui/HomeView";
 import type { ThreadActivityItem } from "@/features/channels/useUnreadChannels";
 import type { FeedItem, HomeFeedResponse } from "@/shared/api/types";
-import { isRelayUnreachableError } from "@/shared/lib/relayError";
+import {
+  isRelayUnreachableError,
+  RELAY_UNREACHABLE_MESSAGE,
+} from "@/shared/lib/relayError";
 
 type HomeScreenProps = {
   availableChannelIds: ReadonlySet<string>;
@@ -61,7 +64,7 @@ export function HomeScreen({
         errorMessage={
           homeFeedQuery.error !== null && homeFeedQuery.error !== undefined
             ? isRelayUnreachableError(homeFeedQuery.error)
-              ? "Can't reach the relay — check your VPN or network connection."
+              ? RELAY_UNREACHABLE_MESSAGE
               : homeFeedQuery.error instanceof Error
                 ? homeFeedQuery.error.message
                 : undefined

--- a/desktop/src/features/home/ui/HomeScreen.tsx
+++ b/desktop/src/features/home/ui/HomeScreen.tsx
@@ -5,6 +5,7 @@ import { useHomeFeedQuery } from "@/features/home/hooks";
 import { HomeView } from "@/features/home/ui/HomeView";
 import type { ThreadActivityItem } from "@/features/channels/useUnreadChannels";
 import type { FeedItem, HomeFeedResponse } from "@/shared/api/types";
+import { isRelayUnreachableError } from "@/shared/lib/relayError";
 
 type HomeScreenProps = {
   availableChannelIds: ReadonlySet<string>;
@@ -58,8 +59,12 @@ export function HomeScreen({
         availableChannelIds={availableChannelIds}
         currentPubkey={currentPubkey}
         errorMessage={
-          homeFeedQuery.error instanceof Error
-            ? homeFeedQuery.error.message
+          homeFeedQuery.error !== null && homeFeedQuery.error !== undefined
+            ? isRelayUnreachableError(homeFeedQuery.error)
+              ? "Can't reach the relay — check your VPN or network connection."
+              : homeFeedQuery.error instanceof Error
+                ? homeFeedQuery.error.message
+                : undefined
             : undefined
         }
         feed={augmentedFeed}

--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -24,6 +24,8 @@ import {
   fetchAvatarDataUrl,
   readSelfProfileCache,
   writeSelfProfileCache,
+  shouldFetchAvatar,
+  resolveAvatarDataUrl,
 } from "@/features/profile/lib/selfProfileStorage";
 import { useWorkspaces } from "@/features/workspaces/useWorkspaces";
 
@@ -47,33 +49,15 @@ async function persistSelfProfile(
   profile: Profile,
 ): Promise<void> {
   const existing = readSelfProfileCache(relayUrl, pubkey);
-  let avatarDataUrl: string | null = null;
-
-  if (profile.avatarUrl !== null) {
-    if (
-      profile.avatarUrl !== existing.avatarUrl ||
-      existing.avatarDataUrl === null
-    ) {
-      // Avatar URL changed or we never captured a data URL — fetch a fresh one.
-      const fetched = await fetchAvatarDataUrl(
-        rewriteRelayUrl(profile.avatarUrl),
-      );
-      // If the fetch failed but the URL is unchanged, keep the existing data URL
-      // so the offline fallback stays intact.
-      avatarDataUrl =
-        fetched !== null
-          ? fetched
-          : profile.avatarUrl === existing.avatarUrl
-            ? existing.avatarDataUrl
-            : null;
-    } else {
-      // Avatar URL unchanged and a data URL already exists — reuse it without
-      // refetching. Profile refetches every ~30s; don't re-download each time.
-      avatarDataUrl = existing.avatarDataUrl;
-    }
-  }
-  // avatarUrl === null → avatarDataUrl stays null (cleared)
-
+  const fetched =
+    shouldFetchAvatar(profile.avatarUrl, existing) && profile.avatarUrl !== null
+      ? await fetchAvatarDataUrl(rewriteRelayUrl(profile.avatarUrl))
+      : null;
+  const avatarDataUrl = resolveAvatarDataUrl(
+    profile.avatarUrl,
+    fetched,
+    existing,
+  );
   writeSelfProfileCache(relayUrl, pubkey, {
     version: 1,
     displayName: profile.displayName,
@@ -130,6 +114,11 @@ export function useProfileQuery(enabled = true) {
     }
   }, [queryClient, initialData, cached]);
 
+  const seedOptions =
+    initialData !== undefined
+      ? { initialData, initialDataUpdatedAt: cached?.updatedAt }
+      : {};
+
   return useQuery({
     enabled,
     queryKey: profileQueryKey,
@@ -141,12 +130,7 @@ export function useProfileQuery(enabled = true) {
       return profile;
     },
     staleTime: 30_000,
-    ...(initialData !== undefined
-      ? {
-          initialData,
-          initialDataUpdatedAt: cached?.updatedAt,
-        }
-      : {}),
+    ...seedOptions,
   });
 }
 
@@ -166,13 +150,29 @@ export function useSelfProfileCache(): SelfProfileCache | null {
     relayUrl && pubkey ? readSelfProfileCache(relayUrl, pubkey) : null,
   );
 
+  // Track whether this is the initial mount so we can skip re-reading the same
+  // localStorage value the useState initializer already parsed.
+  const isFirstRun = React.useRef(true);
+
   React.useEffect(() => {
+    // Skip the redundant read only on the very first run — it sees the same
+    // relayUrl/pubkey the useState initializer already parsed. Consume the
+    // flag before the guard below: if the first run bails out (e.g. identity
+    // still resolving), the run that later receives the values must read.
+    // Accepted: a sub-millisecond unsubscribed window on mount. It is
+    // self-healing — the next SELF_PROFILE_CACHE_EVENT or dep change re-syncs;
+    // with the no-op write skip the event only fires on real changes.
+    const firstRun = isFirstRun.current;
+    isFirstRun.current = false;
+
     if (!relayUrl || !pubkey) {
       setCache(null);
       return;
     }
 
-    setCache(readSelfProfileCache(relayUrl, pubkey));
+    if (!firstRun) {
+      setCache(readSelfProfileCache(relayUrl, pubkey));
+    }
 
     function handleCacheEvent() {
       setCache(readSelfProfileCache(relayUrl, pubkey));

--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import * as React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -16,19 +16,175 @@ import type {
   UserSearchResult,
   UsersBatchResponse,
 } from "@/shared/api/types";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import {
+  SELF_PROFILE_CACHE_EVENT,
+  type SelfProfileCache,
+  fetchAvatarDataUrl,
+  readSelfProfileCache,
+  writeSelfProfileCache,
+} from "@/features/profile/lib/selfProfileStorage";
+import { useWorkspaces } from "@/features/workspaces/useWorkspaces";
 
 export const profileQueryKey = ["profile"] as const;
 export const contactListQueryKey = (pubkey: string) =>
   ["contact-list", pubkey] as const;
 export const allPulseTimelinesQueryKey = ["pulse-timeline"] as const;
 
+// ---------------------------------------------------------------------------
+// Module-private helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Persists a freshly-fetched profile to localStorage as the offline fallback.
+ * Reuses an existing avatar data URL when the avatar URL is unchanged to avoid
+ * re-downloading the image on every ~30s background refetch.
+ */
+async function persistSelfProfile(
+  relayUrl: string,
+  pubkey: string,
+  profile: Profile,
+): Promise<void> {
+  const existing = readSelfProfileCache(relayUrl, pubkey);
+  let avatarDataUrl: string | null = null;
+
+  if (profile.avatarUrl !== null) {
+    if (
+      profile.avatarUrl !== existing.avatarUrl ||
+      existing.avatarDataUrl === null
+    ) {
+      // Avatar URL changed or we never captured a data URL — fetch a fresh one.
+      const fetched = await fetchAvatarDataUrl(
+        rewriteRelayUrl(profile.avatarUrl),
+      );
+      // If the fetch failed but the URL is unchanged, keep the existing data URL
+      // so the offline fallback stays intact.
+      avatarDataUrl =
+        fetched !== null
+          ? fetched
+          : profile.avatarUrl === existing.avatarUrl
+            ? existing.avatarDataUrl
+            : null;
+    } else {
+      // Avatar URL unchanged and a data URL already exists — reuse it without
+      // refetching. Profile refetches every ~30s; don't re-download each time.
+      avatarDataUrl = existing.avatarDataUrl;
+    }
+  }
+  // avatarUrl === null → avatarDataUrl stays null (cleared)
+
+  writeSelfProfileCache(relayUrl, pubkey, {
+    version: 1,
+    displayName: profile.displayName,
+    avatarUrl: profile.avatarUrl,
+    avatarDataUrl,
+    updatedAt: Date.now(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
 export function useProfileQuery(enabled = true) {
+  const { activeWorkspace } = useWorkspaces();
+  const identityQuery = useIdentityQuery();
+  const queryClient = useQueryClient();
+  const relayUrl = activeWorkspace?.relayUrl ?? "";
+  const pubkey = identityQuery.data?.pubkey ?? "";
+
+  // Parse localStorage once per relayUrl/pubkey pair — not on every render.
+  // Cached identity renders instantly and persists through fetch errors (relay
+  // unreachable); initialDataUpdatedAt keeps the normal background refetch.
+  const cached = React.useMemo(
+    () => (relayUrl && pubkey ? readSelfProfileCache(relayUrl, pubkey) : null),
+    [relayUrl, pubkey],
+  );
+
+  // Stable memo so the seeding effect below has stable deps and doesn't
+  // retrigger on unrelated re-renders.
+  const initialData = React.useMemo(
+    () =>
+      cached && cached.updatedAt > 0
+        ? ({
+            pubkey,
+            displayName: cached.displayName,
+            avatarUrl: cached.avatarUrl,
+            about: null,
+            nip05Handle: null,
+          } satisfies Profile)
+        : undefined,
+    [cached, pubkey],
+  );
+
+  // `initialData` is only honored at query construction, which happens before
+  // identity/workspace resolve on a fresh QueryClient — seed the cache
+  // imperatively once they arrive, without ever stomping a real fetch result.
+  React.useEffect(() => {
+    if (!initialData || !cached) return;
+    if (queryClient.getQueryData(profileQueryKey) === undefined) {
+      queryClient.setQueryData(profileQueryKey, initialData, {
+        updatedAt: cached.updatedAt,
+      });
+    }
+  }, [queryClient, initialData, cached]);
+
   return useQuery({
     enabled,
     queryKey: profileQueryKey,
-    queryFn: getProfile,
+    queryFn: async () => {
+      const profile = await getProfile();
+      if (relayUrl && pubkey) {
+        void persistSelfProfile(relayUrl, pubkey, profile);
+      }
+      return profile;
+    },
     staleTime: 30_000,
+    ...(initialData !== undefined
+      ? {
+          initialData,
+          initialDataUpdatedAt: cached?.updatedAt,
+        }
+      : {}),
   });
+}
+
+/**
+ * Reactive hook for the locally-cached self-profile.
+ *
+ * localStorage isn't reactive — the storage module dispatches
+ * SELF_PROFILE_CACHE_EVENT after writes so this hook re-reads without polling.
+ */
+export function useSelfProfileCache(): SelfProfileCache | null {
+  const { activeWorkspace } = useWorkspaces();
+  const identityQuery = useIdentityQuery();
+  const relayUrl = activeWorkspace?.relayUrl ?? "";
+  const pubkey = identityQuery.data?.pubkey ?? "";
+
+  const [cache, setCache] = React.useState<SelfProfileCache | null>(() =>
+    relayUrl && pubkey ? readSelfProfileCache(relayUrl, pubkey) : null,
+  );
+
+  React.useEffect(() => {
+    if (!relayUrl || !pubkey) {
+      setCache(null);
+      return;
+    }
+
+    setCache(readSelfProfileCache(relayUrl, pubkey));
+
+    function handleCacheEvent() {
+      setCache(readSelfProfileCache(relayUrl, pubkey));
+    }
+
+    window.addEventListener(SELF_PROFILE_CACHE_EVENT, handleCacheEvent);
+    return () => {
+      window.removeEventListener(SELF_PROFILE_CACHE_EVENT, handleCacheEvent);
+    };
+  }, [relayUrl, pubkey]);
+
+  return cache;
 }
 
 export function useContactListQuery(pubkey?: string) {
@@ -129,7 +285,7 @@ export function useUsersBatchQuery(
 
   // Seed individual "user-profile" cache entries so avatar clicks are instant
   // cache hits instead of fresh network requests.
-  useEffect(() => {
+  React.useEffect(() => {
     const profiles = query.data?.profiles;
     if (!profiles) return;
     for (const [pubkey, summary] of Object.entries(profiles)) {
@@ -167,11 +323,18 @@ export function useUserSearchQuery(
 
 export function useUpdateProfileMutation() {
   const queryClient = useQueryClient();
+  const { activeWorkspace } = useWorkspaces();
+  const identityQuery = useIdentityQuery();
 
   return useMutation({
     mutationFn: (input: UpdateProfileInput) => updateProfile(input),
     onSuccess: (profile: Profile) => {
       queryClient.setQueryData(profileQueryKey, profile);
+      const relayUrl = activeWorkspace?.relayUrl ?? "";
+      const pubkey = identityQuery.data?.pubkey ?? profile.pubkey;
+      if (relayUrl && pubkey) {
+        void persistSelfProfile(relayUrl, pubkey, profile);
+      }
     },
     onSettled: async () => {
       await queryClient.invalidateQueries({ queryKey: profileQueryKey });

--- a/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
+++ b/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parseSelfProfileCache, storageKey } from "./selfProfileStorage.ts";
+import {
+  parseSelfProfileCache,
+  resolveAvatarDataUrl,
+  shouldFetchAvatar,
+  storageKey,
+} from "./selfProfileStorage.ts";
 
 // ── storageKey ────────────────────────────────────────────────────────────────
 
@@ -153,4 +158,149 @@ test("parseSelfProfileCache: non-number updatedAt is coerced to 0", () => {
     updatedAt: "yesterday",
   });
   assert.equal(result?.updatedAt, 0);
+});
+
+// ── parseSelfProfileCache: avatarDataUrl data:image/ guard ────────────────────
+
+test("parseSelfProfileCache: valid data:image/ avatarDataUrl is preserved", () => {
+  const result = parseSelfProfileCache({
+    version: 1,
+    displayName: null,
+    avatarUrl: null,
+    avatarDataUrl: "data:image/png;base64,iVBORw0KGgo=",
+    updatedAt: 0,
+  });
+  assert.equal(result?.avatarDataUrl, "data:image/png;base64,iVBORw0KGgo=");
+});
+
+test("parseSelfProfileCache: javascript: avatarDataUrl is coerced to null", () => {
+  const result = parseSelfProfileCache({
+    version: 1,
+    displayName: null,
+    avatarUrl: null,
+    avatarDataUrl: "javascript:alert(1)",
+    updatedAt: 0,
+  });
+  assert.equal(result?.avatarDataUrl, null);
+});
+
+test("parseSelfProfileCache: bare base64 avatarDataUrl is coerced to null", () => {
+  const result = parseSelfProfileCache({
+    version: 1,
+    displayName: null,
+    avatarUrl: null,
+    avatarDataUrl: "iVBORw0KGgoAAAANSUhEUgAAAAUA",
+    updatedAt: 0,
+  });
+  assert.equal(result?.avatarDataUrl, null);
+});
+
+test("parseSelfProfileCache: data:text/html avatarDataUrl is coerced to null", () => {
+  const result = parseSelfProfileCache({
+    version: 1,
+    displayName: null,
+    avatarUrl: null,
+    avatarDataUrl: "data:text/html,<h1>xss</h1>",
+    updatedAt: 0,
+  });
+  assert.equal(result?.avatarDataUrl, null);
+});
+
+// ── shouldFetchAvatar ─────────────────────────────────────────────────────────
+
+/** Minimal SelfProfileCache fixture for policy helper tests. */
+function makeCache(overrides = {}) {
+  return {
+    version: 1,
+    displayName: null,
+    avatarUrl: null,
+    avatarDataUrl: null,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+test("shouldFetchAvatar: URL changed → fetch", () => {
+  const existing = makeCache({
+    avatarUrl: "https://relay.example.com/old.jpg",
+    avatarDataUrl: "data:image/jpeg;base64,/old",
+  });
+  assert.equal(
+    shouldFetchAvatar("https://relay.example.com/new.jpg", existing),
+    true,
+  );
+});
+
+test("shouldFetchAvatar: URL unchanged but avatarDataUrl null → fetch", () => {
+  const existing = makeCache({
+    avatarUrl: "https://relay.example.com/same.jpg",
+    avatarDataUrl: null,
+  });
+  assert.equal(
+    shouldFetchAvatar("https://relay.example.com/same.jpg", existing),
+    true,
+  );
+});
+
+test("shouldFetchAvatar: URL unchanged and avatarDataUrl present → no fetch", () => {
+  const existing = makeCache({
+    avatarUrl: "https://relay.example.com/same.jpg",
+    avatarDataUrl: "data:image/jpeg;base64,/existing",
+  });
+  assert.equal(
+    shouldFetchAvatar("https://relay.example.com/same.jpg", existing),
+    false,
+  );
+});
+
+test("shouldFetchAvatar: nextAvatarUrl null → no fetch", () => {
+  const existing = makeCache({
+    avatarUrl: "https://relay.example.com/old.jpg",
+    avatarDataUrl: "data:image/jpeg;base64,/old",
+  });
+  assert.equal(shouldFetchAvatar(null, existing), false);
+});
+
+// ── resolveAvatarDataUrl ──────────────────────────────────────────────────────
+
+test("resolveAvatarDataUrl: nextAvatarUrl null → null", () => {
+  const existing = makeCache({ avatarDataUrl: "data:image/jpeg;base64,/old" });
+  assert.equal(resolveAvatarDataUrl(null, null, existing), null);
+});
+
+test("resolveAvatarDataUrl: fetch succeeded → use fetched value", () => {
+  const existing = makeCache({
+    avatarUrl: "https://relay.example.com/old.jpg",
+    avatarDataUrl: "data:image/jpeg;base64,/old",
+  });
+  assert.equal(
+    resolveAvatarDataUrl(
+      "https://relay.example.com/new.jpg",
+      "data:image/jpeg;base64,/new",
+      existing,
+    ),
+    "data:image/jpeg;base64,/new",
+  );
+});
+
+test("resolveAvatarDataUrl: fetch failed, URL unchanged → preserve existing", () => {
+  const existing = makeCache({
+    avatarUrl: "https://relay.example.com/same.jpg",
+    avatarDataUrl: "data:image/jpeg;base64,/existing",
+  });
+  assert.equal(
+    resolveAvatarDataUrl("https://relay.example.com/same.jpg", null, existing),
+    "data:image/jpeg;base64,/existing",
+  );
+});
+
+test("resolveAvatarDataUrl: fetch failed, URL changed → null", () => {
+  const existing = makeCache({
+    avatarUrl: "https://relay.example.com/old.jpg",
+    avatarDataUrl: "data:image/jpeg;base64,/old",
+  });
+  assert.equal(
+    resolveAvatarDataUrl("https://relay.example.com/new.jpg", null, existing),
+    null,
+  );
 });

--- a/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
+++ b/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseSelfProfileCache, storageKey } from "./selfProfileStorage.ts";
+
+// ── storageKey ────────────────────────────────────────────────────────────────
+
+test("storageKey: includes pubkey in result", () => {
+  const key = storageKey("https://relay.example.com", "deadbeef");
+  assert.ok(
+    key.includes("deadbeef"),
+    `expected key to contain pubkey, got: ${key}`,
+  );
+});
+
+test("storageKey: strips trailing slash from relay URL", () => {
+  const withSlash = storageKey("https://relay.example.com/", "abc");
+  const withoutSlash = storageKey("https://relay.example.com", "abc");
+  assert.equal(withSlash, withoutSlash);
+});
+
+test("storageKey: strips multiple trailing slashes", () => {
+  const key = storageKey("https://relay.example.com///", "abc");
+  assert.ok(
+    !key.includes("///"),
+    `expected trailing slashes stripped, got: ${key}`,
+  );
+});
+
+test("storageKey: lowercases relay URL", () => {
+  const upper = storageKey("HTTPS://Relay.Example.COM", "abc");
+  const lower = storageKey("https://relay.example.com", "abc");
+  assert.equal(upper, lower);
+});
+
+test("storageKey: trims whitespace from relay URL", () => {
+  const padded = storageKey("  https://relay.example.com  ", "abc");
+  const clean = storageKey("https://relay.example.com", "abc");
+  assert.equal(padded, clean);
+});
+
+test("storageKey: different pubkeys produce different keys", () => {
+  const a = storageKey("https://relay.example.com", "pubkey-a");
+  const b = storageKey("https://relay.example.com", "pubkey-b");
+  assert.notEqual(a, b);
+});
+
+// ── parseSelfProfileCache ─────────────────────────────────────────────────────
+
+test("parseSelfProfileCache: valid v1 payload round-trips", () => {
+  const payload = {
+    version: 1,
+    displayName: "Alice",
+    avatarUrl: "https://relay.example.com/media/abc.jpg",
+    avatarDataUrl: "data:image/jpeg;base64,/9j/4A==",
+    updatedAt: 1700000000000,
+  };
+  const result = parseSelfProfileCache(payload);
+  assert.deepEqual(result, payload);
+});
+
+test("parseSelfProfileCache: null fields are preserved", () => {
+  const payload = {
+    version: 1,
+    displayName: null,
+    avatarUrl: null,
+    avatarDataUrl: null,
+    updatedAt: 0,
+  };
+  const result = parseSelfProfileCache(payload);
+  assert.deepEqual(result, payload);
+});
+
+test("parseSelfProfileCache: wrong version returns null", () => {
+  assert.equal(
+    parseSelfProfileCache({
+      version: 2,
+      displayName: "Bob",
+      avatarUrl: null,
+      avatarDataUrl: null,
+      updatedAt: 0,
+    }),
+    null,
+  );
+});
+
+test("parseSelfProfileCache: missing version returns null", () => {
+  assert.equal(
+    parseSelfProfileCache({
+      displayName: "Bob",
+      avatarUrl: null,
+      avatarDataUrl: null,
+      updatedAt: 0,
+    }),
+    null,
+  );
+});
+
+test("parseSelfProfileCache: null input returns null", () => {
+  assert.equal(parseSelfProfileCache(null), null);
+});
+
+test("parseSelfProfileCache: string input returns null", () => {
+  assert.equal(parseSelfProfileCache("garbage"), null);
+});
+
+test("parseSelfProfileCache: array input returns null", () => {
+  assert.equal(parseSelfProfileCache([1, 2, 3]), null);
+});
+
+test("parseSelfProfileCache: number input returns null", () => {
+  assert.equal(parseSelfProfileCache(42), null);
+});
+
+test("parseSelfProfileCache: non-string displayName is coerced to null", () => {
+  const result = parseSelfProfileCache({
+    version: 1,
+    displayName: 123,
+    avatarUrl: null,
+    avatarDataUrl: null,
+    updatedAt: 0,
+  });
+  assert.notEqual(result, null);
+  assert.equal(result?.displayName, null);
+});
+
+test("parseSelfProfileCache: non-finite updatedAt is coerced to 0", () => {
+  const resultNaN = parseSelfProfileCache({
+    version: 1,
+    displayName: null,
+    avatarUrl: null,
+    avatarDataUrl: null,
+    updatedAt: NaN,
+  });
+  assert.equal(resultNaN?.updatedAt, 0);
+
+  const resultInf = parseSelfProfileCache({
+    version: 1,
+    displayName: null,
+    avatarUrl: null,
+    avatarDataUrl: null,
+    updatedAt: Infinity,
+  });
+  assert.equal(resultInf?.updatedAt, 0);
+});
+
+test("parseSelfProfileCache: non-number updatedAt is coerced to 0", () => {
+  const result = parseSelfProfileCache({
+    version: 1,
+    displayName: null,
+    avatarUrl: null,
+    avatarDataUrl: null,
+    updatedAt: "yesterday",
+  });
+  assert.equal(result?.updatedAt, 0);
+});

--- a/desktop/src/features/profile/lib/selfProfileStorage.ts
+++ b/desktop/src/features/profile/lib/selfProfileStorage.ts
@@ -14,6 +14,15 @@
 const STORAGE_KEY_PREFIX = "buzz-self-profile.v1";
 
 /**
+ * Normalizes a relay URL for use in storage keys.
+ * Trim, strip trailing slashes, lowercase — ensures equivalent URLs map to
+ * the same key regardless of formatting differences.
+ */
+export function normalizeRelayUrl(relayUrl: string): string {
+  return relayUrl.trim().replace(/\/+$/, "").toLowerCase();
+}
+
+/**
  * Dispatched on window after a successful writeSelfProfileCache so that any
  * mounted UI listening for identity changes can re-read without polling.
  *
@@ -52,8 +61,7 @@ const DEFAULT_CACHE: SelfProfileCache = Object.freeze({
  * to the same slot.
  */
 export function storageKey(relayUrl: string, pubkey: string): string {
-  const normalized = relayUrl.trim().replace(/\/+$/, "").toLowerCase();
-  return `${STORAGE_KEY_PREFIX}:${normalized}:${pubkey}`;
+  return `${STORAGE_KEY_PREFIX}:${normalizeRelayUrl(relayUrl)}:${pubkey}`;
 }
 
 /**
@@ -68,8 +76,13 @@ export function parseSelfProfileCache(json: unknown): SelfProfileCache | null {
   const displayName =
     typeof obj.displayName === "string" ? obj.displayName : null;
   const avatarUrl = typeof obj.avatarUrl === "string" ? obj.avatarUrl : null;
+  // Defense-in-depth: avatarDataUrl flows into an <img src> sink; only accept
+  // values that are provably safe image data URLs.
   const avatarDataUrl =
-    typeof obj.avatarDataUrl === "string" ? obj.avatarDataUrl : null;
+    typeof obj.avatarDataUrl === "string" &&
+    obj.avatarDataUrl.startsWith("data:image/")
+      ? obj.avatarDataUrl
+      : null;
   const updatedAt =
     typeof obj.updatedAt === "number" && Number.isFinite(obj.updatedAt)
       ? obj.updatedAt
@@ -108,10 +121,13 @@ export function writeSelfProfileCache(
   cache: SelfProfileCache,
 ): boolean {
   try {
-    window.localStorage.setItem(
-      storageKey(relayUrl, pubkey),
-      JSON.stringify(cache),
-    );
+    const key = storageKey(relayUrl, pubkey);
+    const serialized = JSON.stringify(cache);
+    // The 30s profile refetch otherwise re-stringifies ~341KB, rewrites it,
+    // dispatches the cache event, and re-parses on the listener side even
+    // when nothing changed. Skip the write and event entirely when identical.
+    if (window.localStorage.getItem(key) === serialized) return true;
+    window.localStorage.setItem(key, serialized);
     // localStorage is not reactive — dispatch a custom event so any mounted
     // listeners (e.g. useEffect with addEventListener) can re-read the cache
     // without a polling interval.
@@ -120,6 +136,63 @@ export function writeSelfProfileCache(
   } catch {
     return false;
   }
+}
+
+/**
+ * Removes all self-profile cache entries for every pubkey on the given relay.
+ * Called when a workspace is removed to GC storage for that relay.
+ */
+export function removeSelfProfileCachesForRelay(relayUrl: string): void {
+  try {
+    const prefix = `${STORAGE_KEY_PREFIX}:${normalizeRelayUrl(relayUrl)}:`;
+    // Collect keys first; don't mutate localStorage while iterating by index.
+    const toRemove: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key?.startsWith(prefix)) {
+        toRemove.push(key);
+      }
+    }
+    for (const key of toRemove) {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // Storage access failures are non-fatal.
+  }
+}
+
+/**
+ * Returns true when a fresh avatar data URL should be fetched.
+ *
+ * Fetch when the avatar URL changed or we have no cached data URL — but not on
+ * every ~30s refetch when nothing has changed.
+ */
+export function shouldFetchAvatar(
+  nextAvatarUrl: string | null,
+  existing: SelfProfileCache,
+): boolean {
+  return (
+    nextAvatarUrl !== null &&
+    (nextAvatarUrl !== existing.avatarUrl || existing.avatarDataUrl === null)
+  );
+}
+
+/**
+ * Resolves the avatar data URL to persist given the outcome of the fetch.
+ *
+ * - nextAvatarUrl null → null (avatar cleared)
+ * - fetch succeeded → use fetched value
+ * - fetch failed, URL unchanged → preserve existing data URL (keep offline fallback)
+ * - fetch failed, URL changed → null (stale data URL would show wrong avatar)
+ */
+export function resolveAvatarDataUrl(
+  nextAvatarUrl: string | null,
+  fetched: string | null,
+  existing: SelfProfileCache,
+): string | null {
+  if (nextAvatarUrl === null) return null;
+  if (fetched !== null) return fetched;
+  return nextAvatarUrl === existing.avatarUrl ? existing.avatarDataUrl : null;
 }
 
 /**

--- a/desktop/src/features/profile/lib/selfProfileStorage.ts
+++ b/desktop/src/features/profile/lib/selfProfileStorage.ts
@@ -1,0 +1,161 @@
+/**
+ * Cached self-profile store for relay-unreachable scenarios.
+ *
+ * When the relay is unreachable (e.g. WARP VPN needs reauth), the app cannot
+ * fetch the user's kind-0 profile. This module persists the last successfully
+ * fetched profile — including a base64 avatar snapshot — so the UI can render
+ * the user's identity even when offline.
+ *
+ * Profiles are keyed per relay + pubkey rather than pubkey alone because the
+ * same key can have a different kind-0 on different relays. Scoping by relay
+ * prevents one workspace's cached identity from bleeding into another.
+ */
+
+const STORAGE_KEY_PREFIX = "buzz-self-profile.v1";
+
+/**
+ * Dispatched on window after a successful writeSelfProfileCache so that any
+ * mounted UI listening for identity changes can re-read without polling.
+ *
+ * localStorage writes are not reactive — React state won't update on its own.
+ * Components that need to react to profile updates should listen to this event.
+ */
+export const SELF_PROFILE_CACHE_EVENT = "buzz:self-profile-cache";
+
+export type SelfProfileCache = {
+  version: 1;
+  displayName: string | null;
+  /** Original relay URL from the kind-0 profile event. */
+  avatarUrl: string | null;
+  /**
+   * Base64 data URL captured while the relay was reachable. Capped at 256 KB
+   * to keep localStorage usage bounded. Null if never captured or too large.
+   */
+  avatarDataUrl: string | null;
+  /** ms timestamp of last successful profile fetch. 0 = never fetched. */
+  updatedAt: number;
+};
+
+const DEFAULT_CACHE: SelfProfileCache = Object.freeze({
+  version: 1,
+  displayName: null,
+  avatarUrl: null,
+  avatarDataUrl: null,
+  updatedAt: 0,
+});
+
+/**
+ * Returns the localStorage key for a given relay + pubkey pair.
+ *
+ * Relay URL normalization (trim, strip trailing slashes, lowercase) ensures
+ * that "https://relay.example.com/" and "HTTPS://relay.example.com" resolve
+ * to the same slot.
+ */
+export function storageKey(relayUrl: string, pubkey: string): string {
+  const normalized = relayUrl.trim().replace(/\/+$/, "").toLowerCase();
+  return `${STORAGE_KEY_PREFIX}:${normalized}:${pubkey}`;
+}
+
+/**
+ * Validates and coerces a raw parsed-JSON value into SelfProfileCache.
+ * Returns null if the payload is not a recognizable v1 cache object.
+ */
+export function parseSelfProfileCache(json: unknown): SelfProfileCache | null {
+  if (typeof json !== "object" || json === null) return null;
+  const obj = json as Record<string, unknown>;
+  if (obj.version !== 1) return null;
+
+  const displayName =
+    typeof obj.displayName === "string" ? obj.displayName : null;
+  const avatarUrl = typeof obj.avatarUrl === "string" ? obj.avatarUrl : null;
+  const avatarDataUrl =
+    typeof obj.avatarDataUrl === "string" ? obj.avatarDataUrl : null;
+  const updatedAt =
+    typeof obj.updatedAt === "number" && Number.isFinite(obj.updatedAt)
+      ? obj.updatedAt
+      : 0;
+
+  return { version: 1, displayName, avatarUrl, avatarDataUrl, updatedAt };
+}
+
+/**
+ * Reads the cached self-profile from localStorage.
+ * Returns the default (all-null) cache on any parse or storage failure.
+ */
+export function readSelfProfileCache(
+  relayUrl: string,
+  pubkey: string,
+): SelfProfileCache {
+  try {
+    const raw = window.localStorage.getItem(storageKey(relayUrl, pubkey));
+    if (!raw) return DEFAULT_CACHE;
+    const parsed = JSON.parse(raw);
+    return parseSelfProfileCache(parsed) ?? DEFAULT_CACHE;
+  } catch {
+    return DEFAULT_CACHE;
+  }
+}
+
+/**
+ * Writes the cache to localStorage and fires SELF_PROFILE_CACHE_EVENT so
+ * mounted components can re-read without polling.
+ *
+ * Returns false if the write fails (e.g. storage quota exceeded).
+ */
+export function writeSelfProfileCache(
+  relayUrl: string,
+  pubkey: string,
+  cache: SelfProfileCache,
+): boolean {
+  try {
+    window.localStorage.setItem(
+      storageKey(relayUrl, pubkey),
+      JSON.stringify(cache),
+    );
+    // localStorage is not reactive — dispatch a custom event so any mounted
+    // listeners (e.g. useEffect with addEventListener) can re-read the cache
+    // without a polling interval.
+    window.dispatchEvent(new CustomEvent(SELF_PROFILE_CACHE_EVENT));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetches an avatar from `avatarProxyUrl` and converts it to a base64 data URL.
+ *
+ * The caller should pass the `rewriteRelayUrl()`-proxied URL and invoke this
+ * only immediately after a successful profile fetch — at that moment the relay
+ * is known to be reachable, so the fetch has the best chance of succeeding.
+ *
+ * The data URL is capped at 256 KB to keep localStorage usage bounded across
+ * workspaces and accounts. Returns null on ANY failure: network error, non-OK
+ * response, wrong content-type, blob too large, or FileReader error.
+ */
+export async function fetchAvatarDataUrl(
+  avatarProxyUrl: string,
+): Promise<string | null> {
+  try {
+    const response = await fetch(avatarProxyUrl);
+    if (!response.ok) return null;
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.startsWith("image/")) return null;
+
+    const blob = await response.blob();
+    if (blob.size > 256 * 1024) return null;
+
+    return await new Promise<string | null>((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        resolve(typeof result === "string" ? result : null);
+      };
+      reader.onerror = () => resolve(null);
+      reader.readAsDataURL(blob);
+    });
+  } catch {
+    return null;
+  }
+}

--- a/desktop/src/features/profile/ui/ProfileAvatar.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatar.tsx
@@ -66,7 +66,7 @@ export function ProfileAvatar({
           "font-semibold text-primary",
           plain ? "bg-transparent" : "bg-primary/20",
         )}
-        delayMs={200}
+        delayMs={src === undefined ? undefined : 200}
       >
         {initials.length > 0 ? (
           initials

--- a/desktop/src/features/profile/ui/ProfileAvatar.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatar.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { UserRound } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
@@ -7,6 +8,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/shared/ui/avatar";
 
 type ProfileAvatarProps = {
   avatarUrl: string | null;
+  avatarDataUrl?: string | null;
   label: string;
   className?: string;
   iconClassName?: string;
@@ -16,6 +18,7 @@ type ProfileAvatarProps = {
 
 export function ProfileAvatar({
   avatarUrl,
+  avatarDataUrl,
   label,
   className,
   iconClassName,
@@ -23,6 +26,20 @@ export function ProfileAvatar({
   testId,
 }: ProfileAvatarProps) {
   const initials = getInitials(label);
+
+  // Compute the live (proxied) source and reset failure state when the URL changes.
+  const liveSrc = avatarUrl ? rewriteRelayUrl(avatarUrl) : null;
+  const [liveFailed, setLiveFailed] = React.useState(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: avatarUrl is the trigger — reset liveFailed when the URL changes even though the effect body doesn't reference it directly.
+  React.useEffect(() => {
+    setLiveFailed(false);
+  }, [avatarUrl]);
+
+  // When the relay is unreachable the proxied avatar URL 404s/times out; fall
+  // back to the locally cached data URL instead of dropping to initials.
+  const src = liveFailed
+    ? (avatarDataUrl ?? undefined)
+    : (liveSrc ?? avatarDataUrl ?? undefined);
 
   return (
     <Avatar
@@ -33,12 +50,15 @@ export function ProfileAvatar({
       )}
       data-testid={testId}
     >
-      {avatarUrl ? (
+      {src !== undefined ? (
         <AvatarImage
           alt={`${label} avatar`}
           className="object-cover"
+          onLoadingStatusChange={(status) => {
+            if (status === "error") setLiveFailed(true);
+          }}
           referrerPolicy="no-referrer"
-          src={rewriteRelayUrl(avatarUrl)}
+          src={src}
         />
       ) : null}
       <AvatarFallback

--- a/desktop/src/features/profile/ui/ProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/ProfilePopover.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ChevronRight, Smile } from "lucide-react";
+import { ChevronRight, RefreshCw, Smile } from "lucide-react";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
@@ -19,6 +19,7 @@ interface ProfilePopoverProps {
   onOpenChange: (open: boolean) => void;
   displayName: string;
   avatarUrl: string | null;
+  avatarDataUrl?: string | null;
   currentStatus: PresenceStatus;
   isStatusPending?: boolean;
   userStatusText?: string;
@@ -27,6 +28,8 @@ interface ProfilePopoverProps {
   onSetUserStatus: (text: string, emoji: string) => void;
   onClearUserStatus: () => void;
   onOpenSettings: (section?: "profile" | "appearance") => void;
+  onReconnect?: () => void;
+  isReconnectPending?: boolean;
   children: React.ReactNode;
   // Optional outer container whose clicks should NOT close the popover.
   // Used when auxiliary triggers (avatar, status text) live alongside the
@@ -56,6 +59,7 @@ export function ProfilePopover({
   onOpenChange,
   displayName,
   avatarUrl,
+  avatarDataUrl,
   currentStatus,
   isStatusPending,
   userStatusText,
@@ -64,6 +68,8 @@ export function ProfilePopover({
   onSetUserStatus,
   onClearUserStatus,
   onOpenSettings,
+  onReconnect,
+  isReconnectPending,
   children,
   triggerContainerRef,
   workspaceSwitcherSlot,
@@ -142,6 +148,7 @@ export function ProfilePopover({
             <div className="flex items-center gap-2 px-4 pt-3 pb-2">
               <div className="relative shrink-0">
                 <ProfileAvatar
+                  avatarDataUrl={avatarDataUrl}
                   avatarUrl={avatarUrl}
                   className="h-8 w-8 text-xs"
                   iconClassName="h-4 w-4"
@@ -267,6 +274,27 @@ export function ProfilePopover({
                 {settingsShortcutLabel}
               </kbd>
             </button>
+
+            {onReconnect ? (
+              <button
+                className={MENU_ITEM_CLASS}
+                data-testid="profile-popover-reconnect"
+                disabled={isReconnectPending}
+                onClick={() => {
+                  closePopover();
+                  onReconnect();
+                }}
+                role="menuitem"
+                type="button"
+              >
+                <RefreshCw
+                  className={`h-4 w-4 shrink-0 text-muted-foreground${isReconnectPending ? " animate-spin" : ""}`}
+                />
+                <span className="flex-1">
+                  {isReconnectPending ? "Reconnecting…" : "Reconnect to relay"}
+                </span>
+              </button>
+            ) : null}
 
             {workspaceSwitcherSlot ? (
               <>

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -10,7 +10,10 @@ import {
   Zap,
 } from "lucide-react";
 import { useReconnectRelay } from "@/shared/api/useReconnectRelay";
-import { isRelayUnreachableError } from "@/shared/lib/relayError";
+import {
+  isRelayUnreachableError,
+  RELAY_UNREACHABLE_SHORT,
+} from "@/shared/lib/relayError";
 import * as React from "react";
 import { FeatureGate } from "@/shared/features";
 import { SidebarDndContext } from "@/features/sidebar/ui/SidebarDnd";
@@ -730,7 +733,7 @@ export function AppSidebar({
                 data-testid="sidebar-relay-unreachable"
               >
                 <span className="text-muted-foreground">
-                  Can't reach the relay.{" "}
+                  {RELAY_UNREACHABLE_SHORT}{" "}
                 </span>
                 <button
                   className="text-primary hover:underline disabled:opacity-50"

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -9,6 +9,8 @@ import {
   PenSquare,
   Zap,
 } from "lucide-react";
+import { useReconnectRelay } from "@/shared/api/useReconnectRelay";
+import { isRelayUnreachableError } from "@/shared/lib/relayError";
 import * as React from "react";
 import { FeatureGate } from "@/shared/features";
 import { SidebarDndContext } from "@/features/sidebar/ui/SidebarDnd";
@@ -277,6 +279,8 @@ export function AppSidebar({
     assignChannel,
     unassignChannel,
   } = useChannelSections(currentPubkey);
+
+  const { isPending: isReconnectPending, reconnect } = useReconnectRelay();
 
   const [createSectionState, setCreateSectionState] = React.useState<{
     open: boolean;
@@ -720,9 +724,29 @@ export function AppSidebar({
           ) : null}
 
           {errorMessage ? (
-            <div className="px-3 py-2 text-sm text-destructive">
-              {errorMessage}
-            </div>
+            isRelayUnreachableError(errorMessage) ? (
+              <div
+                className="px-3 py-2 text-sm"
+                data-testid="sidebar-relay-unreachable"
+              >
+                <span className="text-muted-foreground">
+                  Can't reach the relay.{" "}
+                </span>
+                <button
+                  className="text-primary hover:underline disabled:opacity-50"
+                  data-testid="sidebar-reconnect"
+                  disabled={isReconnectPending}
+                  onClick={() => void reconnect()}
+                  type="button"
+                >
+                  {isReconnectPending ? "Reconnecting…" : "Reconnect"}
+                </button>
+              </div>
+            ) : (
+              <div className="px-3 py-2 text-sm text-destructive">
+                {errorMessage}
+              </div>
+            )
           ) : null}
         </SidebarContent>
 

--- a/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
@@ -2,12 +2,14 @@ import * as React from "react";
 
 import { getPresenceLabel } from "@/features/presence/lib/presence";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
+import { useSelfProfileCache } from "@/features/profile/hooks";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { ProfilePopover } from "@/features/profile/ui/ProfilePopover";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 import type { Workspace } from "@/features/workspaces/types";
 import { WorkspaceSwitcher } from "@/features/workspaces/ui/WorkspaceSwitcher";
 import type { PresenceStatus, Profile, UserStatus } from "@/shared/api/types";
+import { useReconnectRelay } from "@/shared/api/useReconnectRelay";
 import { cn } from "@/shared/lib/cn";
 
 type SidebarProfileCardProps = {
@@ -48,6 +50,11 @@ export function SidebarProfileCard({
   selfUserStatus,
   workspaces,
 }: SidebarProfileCardProps) {
+  // Called locally rather than threading props from AppShell — both hooks are
+  // workspace-provider and QueryClient safe at this level.
+  const selfProfileCache = useSelfProfileCache();
+  const { isPending, reconnect } = useReconnectRelay();
+
   const [profilePopoverOpen, setProfilePopoverOpen] = React.useState(false);
   const profileCardRef = React.useRef<HTMLDivElement | null>(null);
   const toggleProfilePopover = React.useCallback(
@@ -98,6 +105,7 @@ export function SidebarProfileCard({
           type="button"
         >
           <ProfileAvatar
+            avatarDataUrl={selfProfileCache?.avatarDataUrl ?? null}
             avatarUrl={profile?.avatarUrl ?? null}
             className="h-8 w-8 text-xs"
             iconClassName="h-4 w-4"
@@ -118,17 +126,20 @@ export function SidebarProfileCard({
           <ProfilePopover
             open={profilePopoverOpen}
             onOpenChange={setProfilePopoverOpen}
-            displayName={resolvedDisplayName}
+            avatarDataUrl={selfProfileCache?.avatarDataUrl ?? null}
             avatarUrl={profile?.avatarUrl ?? null}
             currentStatus={selfPresenceStatus}
+            displayName={resolvedDisplayName}
+            isReconnectPending={isPending}
             isStatusPending={isPresencePending}
-            userStatusText={selfUserStatus?.text}
-            userStatusEmoji={selfUserStatus?.emoji}
-            onSetStatus={onSetPresenceStatus ?? (() => {})}
-            onSetUserStatus={onSetUserStatus}
             onClearUserStatus={onClearUserStatus}
             onOpenSettings={onOpenSettings}
+            onReconnect={() => void reconnect()}
+            onSetStatus={onSetPresenceStatus ?? (() => {})}
+            onSetUserStatus={onSetUserStatus}
             triggerContainerRef={profileCardRef}
+            userStatusEmoji={selfUserStatus?.emoji}
+            userStatusText={selfUserStatus?.text}
             workspaceSwitcherSlot={
               <WorkspaceSwitcher
                 activeWorkspace={activeWorkspace}

--- a/desktop/src/features/workspaces/useWorkspaces.tsx
+++ b/desktop/src/features/workspaces/useWorkspaces.tsx
@@ -16,6 +16,7 @@ import {
   saveActiveWorkspaceId,
   saveWorkspaces,
 } from "./workspaceStorage";
+import { removeSelfProfileCachesForRelay } from "@/features/profile/lib/selfProfileStorage";
 
 export type UseWorkspacesReturn = {
   workspaces: Workspace[];
@@ -105,6 +106,17 @@ function useWorkspacesInternal(): UseWorkspacesReturn {
 
   const removeWorkspace = useCallback(
     (id: string) => {
+      // GC self-profile caches for the removed workspace's relay. Mirror the
+      // updater guard (length > 1) so we only GC when removal will actually
+      // proceed. Runs outside the updater — updaters can execute twice under
+      // React StrictMode.
+      if (workspaces.length > 1) {
+        const removed = workspaces.find((w) => w.id === id);
+        if (removed) {
+          removeSelfProfileCachesForRelay(removed.relayUrl);
+        }
+      }
+
       setWorkspacesState((prev) => {
         // Never allow removing the last workspace
         if (prev.length <= 1) {
@@ -122,7 +134,7 @@ function useWorkspacesInternal(): UseWorkspacesReturn {
         return next;
       });
     },
-    [activeId],
+    [activeId, workspaces],
   );
 
   const switchWorkspace = useCallback(

--- a/desktop/src/shared/api/useReconnectRelay.ts
+++ b/desktop/src/shared/api/useReconnectRelay.ts
@@ -1,0 +1,48 @@
+/**
+ * Light reconnect hook — clears the relay client's terminal flag and refetches
+ * all queries without tearing down the workspace.
+ *
+ * Deliberately uses `relayClient.preconnect()` + `queryClient.invalidateQueries()`
+ * rather than the full `reconnectWorkspace()` path, which unmounts the entire
+ * React tree and clears drafts. The goal here is a transparent re-handshake
+ * when WARP VPN comes back online; the user should not lose their in-progress
+ * compose state.
+ */
+
+import * as React from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { relayClient } from "@/shared/api/relayClient";
+
+export function useReconnectRelay(): {
+  reconnect: () => Promise<void>;
+  isPending: boolean;
+} {
+  const queryClient = useQueryClient();
+  const [isPending, setIsPending] = React.useState(false);
+  // Ref-based guard prevents a second fire if the user clicks while the first
+  // preconnect is still in flight — stale closure over `isPending` state would
+  // allow a double-trigger between the click and the next render.
+  const inFlightRef = React.useRef(false);
+
+  const reconnect = React.useCallback(async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setIsPending(true);
+    try {
+      await relayClient.preconnect();
+      await queryClient.invalidateQueries();
+      // No success toast — the banner auto-hides once the connection state
+      // transitions back to "connected", which is the user-visible confirmation.
+    } catch (err) {
+      toast.error("Reconnect failed — check your VPN or network.");
+      console.error("[useReconnectRelay] reconnect failed:", err);
+    } finally {
+      inFlightRef.current = false;
+      setIsPending(false);
+    }
+  }, [queryClient]);
+
+  return { reconnect, isPending };
+}

--- a/desktop/src/shared/api/useRelayAutoHeal.ts
+++ b/desktop/src/shared/api/useRelayAutoHeal.ts
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  isRelayConnectionDegraded,
+  useRelayConnection,
+} from "@/shared/api/useRelayConnection";
+
+const AUTO_HEAL_MIN_INTERVAL_MS = 15_000;
+
+/**
+ * Auto-heal: when the connection recovers from a degraded state, invalidate
+ * all queries so errored queries (e.g. messages, which don't poll) refetch
+ * automatically without requiring a manual reconnect action.
+ *
+ * Rate-limited to prevent a flappy connection (e.g. VPN toggling) from
+ * firing an unfiltered invalidation — ~20-40 requests across active queries
+ * with retry:1 — every time the relay briefly recovers.
+ */
+export function useRelayAutoHeal(): void {
+  const queryClient = useQueryClient();
+  const connectionState = useRelayConnection();
+  const prevConnectionStateRef = React.useRef(connectionState);
+  const lastAutoHealAtRef = React.useRef(0);
+
+  React.useEffect(() => {
+    const prev = prevConnectionStateRef.current;
+    prevConnectionStateRef.current = connectionState;
+    if (isRelayConnectionDegraded(prev) && connectionState === "connected") {
+      const now = Date.now();
+      if (now - lastAutoHealAtRef.current < AUTO_HEAL_MIN_INTERVAL_MS) {
+        return;
+      }
+      lastAutoHealAtRef.current = now;
+      void queryClient.invalidateQueries();
+    }
+  }, [connectionState, queryClient]);
+}

--- a/desktop/src/shared/lib/relayError.test.mjs
+++ b/desktop/src/shared/lib/relayError.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isRelayUnreachableError, relayErrorDetail } from "./relayError.ts";
+import {
+  isRelayUnreachableError,
+  relayErrorDetail,
+  RELAY_UNREACHABLE_MESSAGE,
+} from "./relayError.ts";
 
 // ── isRelayUnreachableError ───────────────────────────────────────────────────
 
@@ -60,22 +64,19 @@ test("relayErrorDetail: strips prefix and trims for string", () => {
   );
 });
 
-test("relayErrorDetail: prefix with no detail trims to empty string", () => {
-  assert.equal(relayErrorDetail("relay unreachable:"), "");
+test("relayErrorDetail: prefix with no detail returns RELAY_UNREACHABLE_MESSAGE", () => {
+  assert.equal(
+    relayErrorDetail("relay unreachable:"),
+    RELAY_UNREACHABLE_MESSAGE,
+  );
 });
 
 test("relayErrorDetail: unrelated Error returns generic message", () => {
   const detail = relayErrorDetail(new Error("something else"));
-  assert.equal(
-    detail,
-    "The relay is unreachable. Check your VPN or network connection.",
-  );
+  assert.equal(detail, RELAY_UNREACHABLE_MESSAGE);
 });
 
 test("relayErrorDetail: null returns generic message", () => {
   const detail = relayErrorDetail(null);
-  assert.equal(
-    detail,
-    "The relay is unreachable. Check your VPN or network connection.",
-  );
+  assert.equal(detail, RELAY_UNREACHABLE_MESSAGE);
 });

--- a/desktop/src/shared/lib/relayError.test.mjs
+++ b/desktop/src/shared/lib/relayError.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isRelayUnreachableError, relayErrorDetail } from "./relayError.ts";
+
+// ── isRelayUnreachableError ───────────────────────────────────────────────────
+
+test("isRelayUnreachableError: Error with prefix returns true", () => {
+  assert.equal(
+    isRelayUnreachableError(new Error("relay unreachable: connection refused")),
+    true,
+  );
+});
+
+test("isRelayUnreachableError: string with prefix returns true", () => {
+  assert.equal(
+    isRelayUnreachableError("relay unreachable: 403 Forbidden"),
+    true,
+  );
+});
+
+test("isRelayUnreachableError: prefix alone (no detail) returns true", () => {
+  assert.equal(isRelayUnreachableError("relay unreachable:"), true);
+});
+
+test("isRelayUnreachableError: unrelated Error returns false", () => {
+  assert.equal(isRelayUnreachableError(new Error("network timeout")), false);
+});
+
+test("isRelayUnreachableError: unrelated string returns false", () => {
+  assert.equal(isRelayUnreachableError("something went wrong"), false);
+});
+
+test("isRelayUnreachableError: null returns false", () => {
+  assert.equal(isRelayUnreachableError(null), false);
+});
+
+test("isRelayUnreachableError: number returns false", () => {
+  assert.equal(isRelayUnreachableError(42), false);
+});
+
+test("isRelayUnreachableError: plain object returns false", () => {
+  assert.equal(
+    isRelayUnreachableError({ message: "relay unreachable: oops" }),
+    false,
+  );
+});
+
+// ── relayErrorDetail ──────────────────────────────────────────────────────────
+
+test("relayErrorDetail: strips prefix and trims for Error", () => {
+  const err = new Error("relay unreachable:   connection refused  ");
+  assert.equal(relayErrorDetail(err), "connection refused");
+});
+
+test("relayErrorDetail: strips prefix and trims for string", () => {
+  assert.equal(
+    relayErrorDetail("relay unreachable: 403 Forbidden from Cloudflare Access"),
+    "403 Forbidden from Cloudflare Access",
+  );
+});
+
+test("relayErrorDetail: prefix with no detail trims to empty string", () => {
+  assert.equal(relayErrorDetail("relay unreachable:"), "");
+});
+
+test("relayErrorDetail: unrelated Error returns generic message", () => {
+  const detail = relayErrorDetail(new Error("something else"));
+  assert.equal(
+    detail,
+    "The relay is unreachable. Check your VPN or network connection.",
+  );
+});
+
+test("relayErrorDetail: null returns generic message", () => {
+  const detail = relayErrorDetail(null);
+  assert.equal(
+    detail,
+    "The relay is unreachable. Check your VPN or network connection.",
+  );
+});

--- a/desktop/src/shared/lib/relayError.ts
+++ b/desktop/src/shared/lib/relayError.ts
@@ -12,6 +12,10 @@
  */
 const RELAY_UNREACHABLE_PREFIX = "relay unreachable:";
 
+export const RELAY_UNREACHABLE_SHORT = "Can't reach the relay.";
+export const RELAY_UNREACHABLE_MESSAGE =
+  "Can't reach the relay — check your VPN or network connection.";
+
 /**
  * Returns true when `error` carries the stable Rust-layer prefix indicating
  * the relay is unreachable (network failure, WARP VPN reauth needed, etc.).
@@ -41,7 +45,8 @@ export function isRelayUnreachableError(error: unknown): boolean {
 export function relayErrorDetail(error: unknown): string {
   if (isRelayUnreachableError(error)) {
     const message = error instanceof Error ? error.message : (error as string);
-    return message.slice(RELAY_UNREACHABLE_PREFIX.length).trim();
+    const detail = message.slice(RELAY_UNREACHABLE_PREFIX.length).trim();
+    return detail || RELAY_UNREACHABLE_MESSAGE;
   }
-  return "The relay is unreachable. Check your VPN or network connection.";
+  return RELAY_UNREACHABLE_MESSAGE;
 }

--- a/desktop/src/shared/lib/relayError.ts
+++ b/desktop/src/shared/lib/relayError.ts
@@ -1,0 +1,47 @@
+/**
+ * Utilities for classifying relay connectivity errors.
+ *
+ * The Rust backend (`desktop/src-tauri/src/relay.rs`) prefixes every
+ * "relay unreachable" error message with this literal string so that the
+ * frontend can distinguish a transient connectivity failure (e.g. WARP VPN
+ * needs reauth, Cloudflare Access 403) from an application-level error.
+ *
+ * Contract: the Rust layer MUST emit errors starting with exactly this prefix
+ * for any condition where the relay host is unreachable at the network or
+ * auth layer. Do not change this string without updating relay.rs in lockstep.
+ */
+const RELAY_UNREACHABLE_PREFIX = "relay unreachable:";
+
+/**
+ * Returns true when `error` carries the stable Rust-layer prefix indicating
+ * the relay is unreachable (network failure, WARP VPN reauth needed, etc.).
+ *
+ * Accepts both `Error` instances and raw strings so callers can pass whatever
+ * the Tauri IPC or WebSocket layer hands them without pre-normalizing.
+ */
+export function isRelayUnreachableError(error: unknown): boolean {
+  if (error instanceof Error) {
+    return error.message.startsWith(RELAY_UNREACHABLE_PREFIX);
+  }
+  if (typeof error === "string") {
+    return error.startsWith(RELAY_UNREACHABLE_PREFIX);
+  }
+  return false;
+}
+
+/**
+ * Returns a human-readable detail string for an error.
+ *
+ * When the error is classified as a relay-unreachable error, strips the
+ * prefix and trims whitespace so the UI sees only the Rust-authored detail
+ * (e.g. "connection refused" or "403 Forbidden from Cloudflare Access").
+ *
+ * Falls back to a generic connectivity message for anything unclassified.
+ */
+export function relayErrorDetail(error: unknown): string {
+  if (isRelayUnreachableError(error)) {
+    const message = error instanceof Error ? error.message : (error as string);
+    return message.slice(RELAY_UNREACHABLE_PREFIX.length).trim();
+  }
+  return "The relay is unreachable. Check your VPN or network connection.";
+}

--- a/desktop/src/shared/ui/ConnectionBanner.tsx
+++ b/desktop/src/shared/ui/ConnectionBanner.tsx
@@ -1,0 +1,50 @@
+import { WifiOff } from "lucide-react";
+
+import {
+  isRelayConnectionDegraded,
+  useRelayConnection,
+} from "@/shared/api/useRelayConnection";
+import { useReconnectRelay } from "@/shared/api/useReconnectRelay";
+import type { ConnectionState } from "@/shared/api/relayClientShared";
+
+const COPY: Partial<Record<ConnectionState, string>> = {
+  reconnecting: "Reconnecting to relay…",
+  stalled: "Connection lost — relay is not responding.",
+  disconnected: "Disconnected from relay.",
+};
+
+/**
+ * Thin warning strip surfaced when the relay connection is degraded.
+ *
+ * Renders null while the connection is healthy so it takes up no layout space.
+ * The strip auto-disappears once the state transitions back to "connected" —
+ * no success toast needed.
+ */
+export function ConnectionBanner() {
+  const state = useRelayConnection();
+  const { isPending, reconnect } = useReconnectRelay();
+
+  if (!isRelayConnectionDegraded(state)) return null;
+
+  const message = COPY[state] ?? "Connection issue detected.";
+
+  return (
+    <div
+      className="flex shrink-0 items-center gap-2 border-b border-warning/30 bg-warning/5 px-3 py-2 text-xs"
+      data-testid="connection-banner"
+      role="alert"
+    >
+      <WifiOff className="h-3 w-3 shrink-0 text-warning" />
+      <span className="flex-1 text-muted-foreground">{message}</span>
+      <button
+        className="font-medium text-warning hover:underline disabled:opacity-50"
+        data-testid="connection-banner-reconnect"
+        disabled={isPending}
+        onClick={reconnect}
+        type="button"
+      >
+        {isPending ? "Reconnecting…" : "Reconnect"}
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -4,6 +4,8 @@ import { decode } from "nostr-tools/nip19";
 import { finalizeEvent, getPublicKey } from "nostr-tools/pure";
 import { parse as yamlParse } from "yaml";
 
+import { relayClient } from "@/shared/api/relayClient";
+import type { ConnectionState } from "@/shared/api/relayClientShared";
 import type { RelayEvent } from "@/shared/api/types";
 import { syncAgentTurnsFromEvents } from "@/features/agents/activeAgentTurnsStore";
 import {
@@ -65,6 +67,9 @@ type E2eConfig = {
     managedAgents?: MockManagedAgentSeed[];
     agentMemory?: RawAgentMemoryListing | Record<string, RawAgentMemoryListing>;
     createManagedAgentDelayMs?: number;
+    channelsReadError?: string;
+    feedReadError?: string;
+    canvasReadError?: string;
     profileReadDelayMs?: number;
     profileReadError?: string;
     profileUpdateError?: string;
@@ -590,6 +595,7 @@ declare global {
       kind: number;
       tags: string[][];
     }>;
+    __BUZZ_E2E_SET_RELAY_CONNECTION_STATE__?: (state: ConnectionState) => void;
     __BUZZ_E2E_SET_STALL_WEBSOCKET_SENDS__?: (stall: boolean) => void;
     __BUZZ_E2E_SET_MESH__?: (mesh: {
       admitted?: boolean;
@@ -2719,6 +2725,11 @@ async function submitSignedEvent(
 }
 
 async function handleGetChannels(config: E2eConfig | undefined) {
+  const channelsReadError = config?.mock?.channelsReadError;
+  if (channelsReadError) {
+    throw new Error(channelsReadError);
+  }
+
   const identity = getIdentity(config);
   if (!identity) {
     return listMockChannels(config);
@@ -3824,6 +3835,11 @@ async function handleGetFeed(
   },
   config: E2eConfig | undefined,
 ): Promise<RawHomeFeedResponse> {
+  const feedReadError = config?.mock?.feedReadError;
+  if (feedReadError) {
+    throw new Error(feedReadError);
+  }
+
   const identity = getIdentity(config);
   if (!identity) {
     const now = Math.floor(Date.now() / 1000);
@@ -5859,6 +5875,19 @@ export function maybeInstallE2eTauriMocks() {
     emitMockLiveEvent(GLOBAL_MOCK_SUBSCRIPTION, event);
     return event;
   };
+  window.__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__ = (state) => {
+    // Directly emit a connection state change on the relay client singleton,
+    // for tests that need to drive ConnectionBanner without waiting for the
+    // real auth-timeout + reconnect-debounce cycle (~10 s). Reaches the
+    // TS-private emitter via a cast so the production class carries no
+    // test-only seam.
+    (
+      relayClient as unknown as {
+        connectionStateEmitter: { set: (s: ConnectionState) => void };
+      }
+    ).connectionStateEmitter.set(state);
+  };
+
   window.__BUZZ_E2E_SET_STALL_WEBSOCKET_SENDS__ = (stall) => {
     const config = getConfig();
     if (!config?.mock) return;
@@ -6519,6 +6548,14 @@ export function maybeInstallE2eTauriMocks() {
         // The spec only verifies UI state, not the submitted request shape;
         // returning null mirrors the Rust submit_event success path.
         return null;
+      case "get_canvas": {
+        const canvasReadError = activeConfig?.mock?.canvasReadError;
+        if (canvasReadError) {
+          throw new Error(canvasReadError);
+        }
+        // Return the no-canvas success shape — content null means no canvas set.
+        return { content: null, updated_at: null, author: null };
+      }
       default:
         throw new Error(`Unsupported mocked Tauri command: ${command}`);
     }

--- a/desktop/tests/e2e/relay-connectivity-screenshots.spec.ts
+++ b/desktop/tests/e2e/relay-connectivity-screenshots.spec.ts
@@ -1,0 +1,222 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const SHOTS = "test-results/relay-connectivity-screenshots";
+const RELAY_UNREACHABLE = "relay unreachable: connection refused";
+
+// Minimal teal 8×8 PNG as a data URL — satisfies avatarDataUrl's data:image/ guard.
+const MOCK_AVATAR_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAE0lEQVR4nGOQ2rrsPz7MMDIUAACluJ0BkoZ9dQAAAABJRU5ErkJggg==";
+
+// Self-profile cache key: buzz-self-profile.v1:<relay>:<pubkey>
+const MOCK_PUBKEY = "deadbeef".repeat(8);
+const MOCK_RELAY_URL = "ws://localhost:3000";
+const SELF_PROFILE_CACHE_KEY = `buzz-self-profile.v1:${MOCK_RELAY_URL}:${MOCK_PUBKEY}`;
+
+async function settle(page: import("@playwright/test").Page) {
+  await page.evaluate(() =>
+    Promise.all(document.getAnimations().map((a) => a.finished)),
+  );
+}
+
+type ConnectionState =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "stalled"
+  | "disconnected";
+
+/** Directly emit "reconnecting" on the relay client singleton via the E2E test seam. */
+async function driveConnectionDegraded(
+  page: import("@playwright/test").Page,
+  state: ConnectionState = "reconnecting",
+) {
+  await page.evaluate((s) => {
+    const setter = (
+      window as Window & {
+        __BUZZ_E2E_SET_RELAY_CONNECTION_STATE__?: (state: string) => void;
+      }
+    ).__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__;
+    if (!setter) throw new Error("E2E relay state setter not installed.");
+    setter(s);
+  }, state);
+}
+
+test.describe("relay connectivity screenshots", () => {
+  test("01 — sidebar unreachable banner", async ({ page }) => {
+    await installMockBridge(page, { channelsReadError: RELAY_UNREACHABLE });
+    await page.goto("/");
+
+    await expect(page.getByTestId("sidebar-relay-unreachable")).toBeVisible();
+    await expect(page.getByTestId("sidebar-reconnect")).toBeVisible();
+    await settle(page);
+
+    // Clip to sidebar width (256px) so the banner and channel list are both visible.
+    await page.screenshot({
+      path: `${SHOTS}/01-sidebar-unreachable.png`,
+      clip: { x: 0, y: 0, width: 256, height: 720 },
+    });
+  });
+
+  test("02 — connection banner while reconnecting", async ({ page }) => {
+    await installMockBridge(page);
+    await page.goto("/");
+
+    // Wait for a healthy boot, then force the relay into "reconnecting" state.
+    await expect(page.getByTestId("channel-general")).toBeVisible();
+    await driveConnectionDegraded(page);
+
+    // ConnectionBanner debounces non-healthy states by 2 s before rendering.
+    await expect(page.getByTestId("connection-banner")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("connection-banner-reconnect")).toBeVisible();
+    await settle(page);
+
+    // Capture a horizontal strip spanning the full width that shows the banner
+    // above the content pane.
+    await page.screenshot({
+      path: `${SHOTS}/02-connection-banner.png`,
+      clip: { x: 0, y: 0, width: 1280, height: 180 },
+    });
+  });
+
+  test("03 — home feed unreachable", async ({ page }) => {
+    await installMockBridge(page, { feedReadError: RELAY_UNREACHABLE });
+    await page.goto("/");
+
+    // HomeView renders the error card when the feed query fails.
+    await expect(
+      page.getByText(
+        "Can't reach the relay — check your VPN or network connection.",
+      ),
+    ).toBeVisible();
+    await settle(page);
+
+    await page.screenshot({
+      path: `${SHOTS}/03-home-unreachable.png`,
+      clip: { x: 0, y: 0, width: 1280, height: 500 },
+    });
+  });
+
+  test("04 — canvas unreachable in management sheet", async ({ page }) => {
+    await installMockBridge(page, { canvasReadError: RELAY_UNREACHABLE });
+    await page.goto("/");
+
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await page.getByTestId("channel-management-trigger").click();
+    await expect(page.getByTestId("channel-management-sheet")).toBeVisible();
+
+    // ChannelCanvas shows the destructive error paragraph when the query fails.
+    const canvasSection = page.getByTestId("channel-canvas-section");
+    await canvasSection.scrollIntoViewIfNeeded();
+    await expect(
+      canvasSection.getByText("Can't reach the relay."),
+    ).toBeVisible();
+
+    // Await Radix sheet animations before screenshotting.
+    const sheet = page.getByTestId("channel-management-sheet");
+    await sheet.evaluate((el) =>
+      Promise.all(
+        el
+          .closest("[data-state]")
+          ?.getAnimations()
+          .map((a) => a.finished) ?? [],
+      ),
+    );
+    await settle(page);
+
+    // Capture the whole sheet so the error renders in its Canvas-section context.
+    await sheet.screenshot({
+      path: `${SHOTS}/04-canvas-unreachable.png`,
+    });
+  });
+
+  test("05 — cached identity shown offline (avatar + display name)", async ({
+    page,
+  }) => {
+    // Seed the self-profile cache BEFORE installMockBridge so addInitScript
+    // runs in order and the cache is present when React mounts.
+    await page.addInitScript(
+      ({ key, cache }) => {
+        window.localStorage.setItem(key, JSON.stringify(cache));
+      },
+      {
+        key: SELF_PROFILE_CACHE_KEY,
+        cache: {
+          version: 1,
+          displayName: "Tyler Durden",
+          avatarUrl: "http://localhost:3999/avatar.png",
+          avatarDataUrl: MOCK_AVATAR_DATA_URL,
+          updatedAt: 1_700_000_000_000,
+        },
+      },
+    );
+    await installMockBridge(page, { profileReadError: RELAY_UNREACHABLE });
+    await page.goto("/");
+
+    // The profile card should show the cached display name.
+    const profileCard = page.getByTestId("sidebar-profile-card");
+    await expect(profileCard).toContainText("Tyler Durden");
+    await settle(page);
+
+    await profileCard.screenshot({
+      path: `${SHOTS}/05-cached-identity-offline.png`,
+    });
+  });
+
+  test("06 — no-cache npub fallback when offline", async ({ page }) => {
+    // No cache seeded — profile card falls back to the mock identity npub name.
+    await installMockBridge(page, { profileReadError: RELAY_UNREACHABLE });
+    await page.goto("/");
+
+    const profileCard = page.getByTestId("sidebar-profile-card");
+    // Default mock identity display name is "npub1mock...".
+    await expect(profileCard).toContainText("npub1mock");
+    await settle(page);
+
+    await profileCard.screenshot({
+      path: `${SHOTS}/06-no-cache-npub-fallback.png`,
+    });
+  });
+
+  test("07 — profile popover reconnect button while degraded", async ({
+    page,
+  }) => {
+    await installMockBridge(page);
+    await page.goto("/");
+
+    await expect(page.getByTestId("channel-general")).toBeVisible();
+    await driveConnectionDegraded(page);
+
+    // 2 s debounce on the "reconnecting" state before ConnectionBanner shows.
+    await expect(page.getByTestId("connection-banner")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByTestId("sidebar-profile-avatar-button").click();
+    const reconnectBtn = page.getByTestId("profile-popover-reconnect");
+    await expect(reconnectBtn).toBeVisible();
+
+    // Wait for the Radix popover open animation on the [data-state] ancestor —
+    // the popper wrapper itself carries no animations, so querying it returns
+    // an empty list and screenshots capture a half-faded popover.
+    await reconnectBtn.evaluate((el) =>
+      Promise.all(
+        el
+          .closest("[data-state]")
+          ?.getAnimations()
+          .map((a) => a.finished) ?? [],
+      ),
+    );
+
+    // Clip to the sidebar-bottom region that includes the open popover.
+    await page.screenshot({
+      path: `${SHOTS}/07-profile-popover-reconnect.png`,
+      clip: { x: 0, y: 300, width: 480, height: 420 },
+    });
+  });
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -92,6 +92,9 @@ type MockBridgeOptions = {
   };
   managedAgents?: MockManagedAgentSeed[];
   createManagedAgentDelayMs?: number;
+  channelsReadError?: string;
+  feedReadError?: string;
+  canvasReadError?: string;
   profileReadDelayMs?: number;
   profileReadError?: string;
   profileUpdateError?: string;


### PR DESCRIPTION
This PR improves the desktop app's behavior when the relay is unreachable — replacing raw network errors with friendly disconnected states, adding reconnect affordances, and caching the user's identity locally so the sidebar doesn't revert to their npub key.

When WARP VPN needs its daily reauth, Cloudflare Access intercepts relay HTTPS requests and returns an HTML login page with HTTP 200. Previously the Rust backend passed this through as `failed to parse query response: error decoding response body for url (https://sqprod.cloudflareaccess.com/...)`, rendering verbatim in the sidebar — confusing and non-actionable.

- Classify relay HTTP errors with a stable `relay unreachable:` prefix — detect Cloudflare Access intercepts (by final-response host), HTML bodies, and connection/timeout/DNS failures. This covers `query_relay_at()` and `submit_event()` as well as the media commands (`upload_blob`, `fetch_blob_bytes`), which previously surfaced raw reqwest errors (embedding full request URLs) and raw response bodies in upload/download toasts. Raw URLs and HTML bodies are never included in error strings.
- Add `ConnectionBanner` — a thin warning strip above the content pane that auto-appears after 2s when degraded, with a Reconnect button; also add a "Reconnect to relay" item to the profile popover (always visible); reconnect calls `relayClient.preconnect()` + `queryClient.invalidateQueries()` without unmounting the workspace or clearing drafts
- Auto-heal via `useRelayAutoHeal`: when the WebSocket recovers from a degraded state, invalidate all queries so errored queries (messages don't poll) refetch automatically without any user action — rate-limited to once per 15s so a flappy connection (e.g. VPN toggling) can't repeatedly fire an unfiltered invalidation at a relay that just recovered
- Single-source the disconnected-state copy as `RELAY_UNREACHABLE_SHORT` / `RELAY_UNREACHABLE_MESSAGE` in `relayError.ts`, shared by the sidebar banner, home screen, and channel canvas; `relayErrorDetail()` falls back to the full message instead of an empty string when a classified error carries no detail
- Cache the last-fetched self-profile (display name + avatar as a ≤256 KB data URL) in `localStorage` keyed by relay+pubkey via `selfProfileStorage`; `ProfileAvatar` falls back to the cached data URL when the live proxied URL fails to load, and renders initials immediately (instead of after the 200ms fallback delay) when there is no image source at all
- Harden the self-profile cache: writes are skipped entirely when the serialized payload is unchanged (the 30s profile poll otherwise rewrote ~341KB and re-notified listeners every cycle); `avatarDataUrl` is only accepted from storage when it starts with `data:image/` since it flows into an `<img src>` sink; removing a workspace garbage-collects all cached profiles for that relay; the avatar fetch/reuse policy is extracted into pure `shouldFetchAvatar` / `resolveAvatarDataUrl` helpers with unit tests
- Add a `relay-connectivity-screenshots` Playwright spec (smoke project) covering the disconnected-state surfaces, backed by new mock-bridge error knobs (`channelsReadError`, `feedReadError`, `canvasReadError`), a `get_canvas` mock (previously an unsupported-command throw), and a `__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__` seam for driving the `ConnectionBanner` deterministically
