### PR TITLE
feat(agents): add active turn indicators to Agents Menu

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -253,6 +253,16 @@ impl AcpClient {
         self.observer_context = context;
     }
 
+    /// Return a clone of the observer handle, if attached.
+    pub(crate) fn observer_handle(&self) -> Option<ObserverHandle> {
+        self.observer.clone()
+    }
+
+    /// Return the pool slot index for this agent process.
+    pub(crate) fn observer_agent_index(&self) -> Option<usize> {
+        self.observer_agent_index
+    }
+
     /// Emit a semantic event to the local observer feed, if enabled.
     pub fn observe(&self, kind: impl Into<String>, payload: serde_json::Value) {
         if let Some(observer) = &self.observer {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2078,6 +2078,16 @@ fn handle_prompt_result(
                 outcome = outcome_label,
                 "agent_returned"
             );
+            if let Some(ref observer) = observer {
+                observer.emit(
+                    "turn_completed",
+                    Some(agent_index),
+                    &observer::context_for(channel_id, None, None),
+                    serde_json::json!({
+                        "outcome": outcome_label,
+                    }),
+                );
+            }
             pool.return_agent(result.agent);
         }
         // Fatal outcomes: the agent subprocess is dead or poisoned — respawn it.
@@ -2136,6 +2146,16 @@ fn handle_prompt_result(
                 outcome = outcome_label,
                 "agent_returned (cancelled)"
             );
+            if let Some(ref observer) = observer {
+                observer.emit(
+                    "turn_completed",
+                    Some(agent_index),
+                    &observer::context_for(channel_id, None, None),
+                    serde_json::json!({
+                        "outcome": outcome_label,
+                    }),
+                );
+            }
             pool.return_agent(result.agent);
         }
         PromptOutcome::Error(ref e) => {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2078,16 +2078,6 @@ fn handle_prompt_result(
                 outcome = outcome_label,
                 "agent_returned"
             );
-            if let Some(ref observer) = observer {
-                observer.emit(
-                    "turn_completed",
-                    Some(agent_index),
-                    &observer::context_for(channel_id, None, None),
-                    serde_json::json!({
-                        "outcome": outcome_label,
-                    }),
-                );
-            }
             pool.return_agent(result.agent);
         }
         // Fatal outcomes: the agent subprocess is dead or poisoned — respawn it.
@@ -2146,16 +2136,6 @@ fn handle_prompt_result(
                 outcome = outcome_label,
                 "agent_returned (cancelled)"
             );
-            if let Some(ref observer) = observer {
-                observer.emit(
-                    "turn_completed",
-                    Some(agent_index),
-                    &observer::context_for(channel_id, None, None),
-                    serde_json::json!({
-                        "outcome": outcome_label,
-                    }),
-                );
-            }
             pool.return_agent(result.agent);
         }
         PromptOutcome::Error(ref e) => {

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -653,6 +653,16 @@ pub async fn run_prompt_task(
         .unwrap_or_default();
     let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
 
+    // ── Turn completion guard ─────────────────────────────────────────────
+    // Emits `turn_completed` on any exit path. Captures observer handle and
+    // metadata now, before the agent is moved into PromptResult.
+    let _turn_guard = TurnCompletionGuard::new(
+        agent.acp.observer_handle(),
+        agent.acp.observer_agent_index(),
+        observer_channel_id,
+        turn_id.clone(),
+    );
+
     let (session_id, is_new_session) = match &source {
         PromptSource::Channel(cid) => {
             if let Some(sid) = agent.state.sessions.get(cid) {
@@ -1926,6 +1936,58 @@ impl Drop for ReactionGuard {
             // If no runtime is available, reactions are left as-is — they are
             // cosmetic indicators and the stale state is harmless.
         }
+    }
+}
+
+// ── Turn completion scope guard ──────────────────────────────────────────────
+// Emits a `turn_completed` observer event on drop, covering ALL exit paths
+// (success, error, timeout, cancel, panic) from `run_prompt_task`. Captures
+// observer handle and metadata at creation time so it remains valid even after
+// the agent is moved into `PromptResult`.
+
+struct TurnCompletionGuard {
+    observer: Option<observer::ObserverHandle>,
+    agent_index: Option<usize>,
+    channel_id: Option<uuid::Uuid>,
+    turn_id: String,
+}
+
+impl TurnCompletionGuard {
+    fn new(
+        observer: Option<observer::ObserverHandle>,
+        agent_index: Option<usize>,
+        channel_id: Option<uuid::Uuid>,
+        turn_id: String,
+    ) -> Self {
+        Self {
+            observer,
+            agent_index,
+            channel_id,
+            turn_id,
+        }
+    }
+}
+
+impl Drop for TurnCompletionGuard {
+    fn drop(&mut self) {
+        if let Some(observer) = self.observer.take() {
+            let context = observer::context_for(self.channel_id, None, Some(self.turn_id.clone()));
+            observer.emit(
+                "turn_completed",
+                self.agent_index,
+                &context,
+                serde_json::json!({ "outcome": "dropped" }),
+            );
+        }
+    }
+}
+
+impl TurnCompletionGuard {
+    /// Consume the guard without emitting, for paths that emit a more specific
+    /// completion event themselves (e.g., `turn_error`, `agent_panic` in lib.rs).
+    #[allow(dead_code)]
+    fn disarm(mut self) {
+        self.observer = None;
     }
 }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1976,18 +1976,9 @@ impl Drop for TurnCompletionGuard {
                 "turn_completed",
                 self.agent_index,
                 &context,
-                serde_json::json!({ "outcome": "dropped" }),
+                serde_json::json!({}),
             );
         }
-    }
-}
-
-impl TurnCompletionGuard {
-    /// Consume the guard without emitting, for paths that emit a more specific
-    /// completion event themselves (e.g., `turn_error`, `agent_panic` in lib.rs).
-    #[allow(dead_code)]
-    fn disarm(mut self) {
-        self.observer = None;
     }
 }
 

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         "**/channel-star-screenshots.spec.ts",
         "**/channel-controls-screenshots.spec.ts",
         "**/team-management-screenshots.spec.ts",
+        "**/active-turn-screenshots.spec.ts",
         "**/file-attachment.spec.ts",
         "**/video-attachment.spec.ts",
         "**/mentions.spec.ts",

--- a/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
+++ b/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
@@ -40,7 +40,7 @@ describe("activeAgentTurnsStore", () => {
       assert.ok(channels.has("c1"));
     });
 
-    it("skips events with seq <= lastProcessedSeq", () => {
+    it("skips events at or below the watermark", () => {
       syncAgentTurnsFromEvents(AGENT, [
         makeEvent({ seq: 5, turnId: "t1", channelId: "c1" }),
       ]);
@@ -68,39 +68,66 @@ describe("activeAgentTurnsStore", () => {
   });
 
   describe("seq restart detection", () => {
-    it("resets lastProcessedSeq when seq regresses (agent restart)", () => {
-      // Process events up to seq 50
+    it("processes post-restart events whose timestamp climbs past the watermark", () => {
+      // Process events up to seq 50.
       syncAgentTurnsFromEvents(AGENT, [
-        makeEvent({ seq: 50, turnId: "t1", channelId: "c1" }),
+        makeEvent({
+          seq: 50,
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
       ]);
       assert.equal(getActiveChannelsForAgent(AGENT).size, 1);
 
-      // Agent restarts — seq goes back to 1. This should be accepted.
+      // Agent restarts — seq resets to 1, but wall-clock timestamp keeps
+      // climbing. The composite watermark accepts it on timestamp alone.
       syncAgentTurnsFromEvents(AGENT, [
-        makeEvent({ seq: 1, turnId: "t2", channelId: "c2" }),
+        makeEvent({
+          seq: 1,
+          turnId: "t2",
+          channelId: "c2",
+          timestamp: "2024-01-01T00:01:00Z",
+        }),
       ]);
       const channels = getActiveChannelsForAgent(AGENT);
       assert.ok(channels.has("c2"), "post-restart event should be processed");
     });
 
-    it("processes subsequent events after restart detection", () => {
+    it("processes subsequent events after restart", () => {
       syncAgentTurnsFromEvents(AGENT, [
-        makeEvent({ seq: 100, turnId: "t1", channelId: "c1" }),
+        makeEvent({
+          seq: 100,
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
       ]);
 
-      // Restart: seq goes to 1, then 2, then 3
+      // Restart: seq goes 1, 2, 3 with climbing timestamps.
       syncAgentTurnsFromEvents(AGENT, [
-        makeEvent({ seq: 1, turnId: "t2", channelId: "c2" }),
-        makeEvent({ seq: 2, turnId: "t3", channelId: "c3" }),
+        makeEvent({
+          seq: 1,
+          turnId: "t2",
+          channelId: "c2",
+          timestamp: "2024-01-01T00:01:00Z",
+        }),
+        makeEvent({
+          seq: 2,
+          turnId: "t3",
+          channelId: "c3",
+          timestamp: "2024-01-01T00:01:01Z",
+        }),
         makeEvent({
           seq: 3,
           kind: "turn_completed",
           turnId: "t2",
           channelId: "c2",
+          timestamp: "2024-01-01T00:01:02Z",
         }),
       ]);
       const channels = getActiveChannelsForAgent(AGENT);
-      // t1 still active (not ended), t2 ended, t3 still active
+      // t1 still active (not ended), t2 ended, t3 still active.
       assert.ok(channels.has("c1"));
       assert.ok(!channels.has("c2"));
       assert.ok(channels.has("c3"));
@@ -215,6 +242,90 @@ describe("activeAgentTurnsStore", () => {
       ]);
       assert.ok(called > 0);
       unsub();
+    });
+  });
+
+  describe("replay idempotency", () => {
+    it("replaying the same buffer produces no additional state change or notifications", () => {
+      const buffer = [
+        makeEvent({
+          seq: 1,
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+        makeEvent({
+          seq: 2,
+          turnId: "t2",
+          channelId: "c2",
+          timestamp: "2024-01-01T00:00:01Z",
+        }),
+      ];
+
+      // Initial pass.
+      syncAgentTurnsFromEvents(AGENT, buffer);
+      const afterFirst = getActiveChannelsForAgent(AGENT);
+      assert.equal(afterFirst.size, 2);
+
+      // Subscribe, then replay the identical buffer.
+      let notified = 0;
+      const unsub = subscribeActiveAgentTurns(() => {
+        notified++;
+      });
+      syncAgentTurnsFromEvents(AGENT, buffer);
+      unsub();
+
+      assert.equal(notified, 0, "replay must not notify listeners");
+      const afterReplay = getActiveChannelsForAgent(AGENT);
+      assert.equal(
+        afterReplay,
+        afterFirst,
+        "replay must not change turn state (stable reference)",
+      );
+    });
+
+    it("post-restart replay does not reprocess seen events or resurrect evicted turns", () => {
+      // Start a turn, then complete it (turn evicted).
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({
+          seq: 1,
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+        makeEvent({
+          seq: 2,
+          kind: "turn_completed",
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:01Z",
+        }),
+      ]);
+      assert.equal(getActiveChannelsForAgent(AGENT).size, 0);
+
+      // Agent restarts. The harness replays its buffer with seq reset to 1,
+      // but the original event timestamps (older than the watermark) are
+      // unchanged. The start event must NOT resurrect the evicted turn.
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({
+          seq: 1,
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+        makeEvent({
+          seq: 2,
+          kind: "turn_completed",
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:01Z",
+        }),
+      ]);
+      assert.equal(
+        getActiveChannelsForAgent(AGENT).size,
+        0,
+        "stale replayed start must not resurrect an evicted turn",
+      );
     });
   });
 

--- a/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
+++ b/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
@@ -329,6 +329,106 @@ describe("activeAgentTurnsStore", () => {
     });
   });
 
+  describe("replayed eviction safety", () => {
+    it("replayed stale turn_error with null turnId does not kill the live turn", () => {
+      // A turn errors out (harness emits turn_error with a null turnId), then a
+      // fresh turn starts in the same channel.
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({
+          seq: 1,
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+        makeEvent({
+          seq: 2,
+          kind: "turn_error",
+          turnId: null,
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:01Z",
+        }),
+        makeEvent({
+          seq: 3,
+          turnId: "t2",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:02Z",
+        }),
+      ]);
+      assert.equal(getActiveChannelsForAgent(AGENT).size, 1);
+
+      // The full buffer is replayed on the next observer event. The stale
+      // turn_error (below the watermark) must NOT re-run its channel-match
+      // fallback and delete the live turn t2.
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({
+          seq: 1,
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+        makeEvent({
+          seq: 2,
+          kind: "turn_error",
+          turnId: null,
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:01Z",
+        }),
+        makeEvent({
+          seq: 3,
+          turnId: "t2",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:02Z",
+        }),
+      ]);
+      const channels = getActiveChannelsForAgent(AGENT);
+      assert.equal(
+        channels.size,
+        1,
+        "replayed stale turn_error must not delete the live turn",
+      );
+      assert.ok(channels.has("c1"));
+    });
+
+    it("replaying evictions fires no spurious listener notifications", () => {
+      const buffer = [
+        makeEvent({
+          seq: 1,
+          turnId: "t1",
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+        makeEvent({
+          seq: 2,
+          kind: "turn_error",
+          turnId: null,
+          channelId: "c1",
+          timestamp: "2024-01-01T00:00:01Z",
+        }),
+        makeEvent({
+          seq: 3,
+          kind: "agent_panic",
+          turnId: null,
+          channelId: "c2",
+          timestamp: "2024-01-01T00:00:02Z",
+        }),
+      ];
+
+      // Initial pass processes the buffer.
+      syncAgentTurnsFromEvents(AGENT, buffer);
+
+      // Subscribe, then replay the identical buffer. Every event is below the
+      // watermark, so the replay must be a complete no-op.
+      let notified = 0;
+      const unsub = subscribeActiveAgentTurns(() => {
+        notified++;
+      });
+      syncAgentTurnsFromEvents(AGENT, buffer);
+      unsub();
+
+      assert.equal(notified, 0, "replayed evictions must not notify listeners");
+    });
+  });
+
   describe("getActiveChannelsForAgent", () => {
     it("returns EMPTY_SET for null/undefined pubkey", () => {
       assert.equal(getActiveChannelsForAgent(null).size, 0);

--- a/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
+++ b/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+
+import {
+  syncAgentTurnsFromEvents,
+  getActiveChannelsForAgent,
+  resetActiveAgentTurnsStore,
+  subscribeActiveAgentTurns,
+} from "./activeAgentTurnsStore.ts";
+
+const AGENT =
+  "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234";
+
+function makeEvent(overrides) {
+  return {
+    seq: 1,
+    timestamp: "2024-01-01T00:00:00Z",
+    kind: "turn_started",
+    agentIndex: 0,
+    channelId: "chan-1",
+    sessionId: "sess-1",
+    turnId: "turn-1",
+    payload: null,
+    ...overrides,
+  };
+}
+
+describe("activeAgentTurnsStore", () => {
+  beforeEach(() => {
+    resetActiveAgentTurnsStore();
+  });
+
+  describe("seq filtering", () => {
+    it("processes events with increasing seq", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t1", channelId: "c1" }),
+      ]);
+      const channels = getActiveChannelsForAgent(AGENT);
+      assert.equal(channels.size, 1);
+      assert.ok(channels.has("c1"));
+    });
+
+    it("skips events with seq <= lastProcessedSeq", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 5, turnId: "t1", channelId: "c1" }),
+      ]);
+      // Try to process an older event — should be ignored
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 3, turnId: "t2", channelId: "c2" }),
+      ]);
+      const channels = getActiveChannelsForAgent(AGENT);
+      assert.equal(channels.size, 1);
+      assert.ok(channels.has("c1"));
+      assert.ok(!channels.has("c2"));
+    });
+
+    it("skips duplicate seq", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t1", channelId: "c1" }),
+      ]);
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t2", channelId: "c2" }),
+      ]);
+      const channels = getActiveChannelsForAgent(AGENT);
+      assert.equal(channels.size, 1);
+      assert.ok(channels.has("c1"));
+    });
+  });
+
+  describe("seq restart detection", () => {
+    it("resets lastProcessedSeq when seq regresses (agent restart)", () => {
+      // Process events up to seq 50
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 50, turnId: "t1", channelId: "c1" }),
+      ]);
+      assert.equal(getActiveChannelsForAgent(AGENT).size, 1);
+
+      // Agent restarts — seq goes back to 1. This should be accepted.
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t2", channelId: "c2" }),
+      ]);
+      const channels = getActiveChannelsForAgent(AGENT);
+      assert.ok(channels.has("c2"), "post-restart event should be processed");
+    });
+
+    it("processes subsequent events after restart detection", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 100, turnId: "t1", channelId: "c1" }),
+      ]);
+
+      // Restart: seq goes to 1, then 2, then 3
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t2", channelId: "c2" }),
+        makeEvent({ seq: 2, turnId: "t3", channelId: "c3" }),
+        makeEvent({
+          seq: 3,
+          kind: "turn_completed",
+          turnId: "t2",
+          channelId: "c2",
+        }),
+      ]);
+      const channels = getActiveChannelsForAgent(AGENT);
+      // t1 still active (not ended), t2 ended, t3 still active
+      assert.ok(channels.has("c1"));
+      assert.ok(!channels.has("c2"));
+      assert.ok(channels.has("c3"));
+    });
+  });
+
+  describe("eviction at MAX_TURNS_PER_AGENT", () => {
+    it("evicts oldest turn when exceeding 4 concurrent turns", () => {
+      const events = [];
+      for (let i = 1; i <= 5; i++) {
+        events.push(
+          makeEvent({
+            seq: i,
+            turnId: `t${i}`,
+            channelId: `c${i}`,
+            timestamp: `2024-01-01T00:0${i}:00Z`,
+          }),
+        );
+      }
+      syncAgentTurnsFromEvents(AGENT, events);
+      const channels = getActiveChannelsForAgent(AGENT);
+      // Should have evicted c1 (oldest) to make room for c5
+      assert.equal(channels.size, 4);
+      assert.ok(!channels.has("c1"), "oldest turn should be evicted");
+      assert.ok(channels.has("c2"));
+      assert.ok(channels.has("c5"));
+    });
+  });
+
+  describe("endTurn turnId-vs-channelId fallback", () => {
+    it("ends turn by turnId when provided", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t1", channelId: "c1" }),
+        makeEvent({
+          seq: 2,
+          kind: "turn_completed",
+          turnId: "t1",
+          channelId: null,
+        }),
+      ]);
+      assert.equal(getActiveChannelsForAgent(AGENT).size, 0);
+    });
+
+    it("falls back to channelId when turnId is null", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t1", channelId: "c1" }),
+        makeEvent({
+          seq: 2,
+          kind: "turn_completed",
+          turnId: null,
+          channelId: "c1",
+        }),
+      ]);
+      assert.equal(getActiveChannelsForAgent(AGENT).size, 0);
+    });
+
+    it("does nothing when both turnId and channelId are null", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t1", channelId: "c1" }),
+        makeEvent({
+          seq: 2,
+          kind: "turn_completed",
+          turnId: null,
+          channelId: null,
+        }),
+      ]);
+      // Turn should still be active — no way to identify which to end
+      assert.equal(getActiveChannelsForAgent(AGENT).size, 1);
+    });
+
+    it("channelId fallback removes only one matching turn", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t1", channelId: "c1" }),
+        makeEvent({ seq: 2, turnId: "t2", channelId: "c1" }),
+        makeEvent({
+          seq: 3,
+          kind: "turn_completed",
+          turnId: null,
+          channelId: "c1",
+        }),
+      ]);
+      // Only one of the two turns in c1 should be removed
+      const channels = getActiveChannelsForAgent(AGENT);
+      assert.equal(channels.size, 1);
+      assert.ok(channels.has("c1"));
+    });
+  });
+
+  describe("listener notifications", () => {
+    it("notifies on turn_started", () => {
+      let called = 0;
+      const unsub = subscribeActiveAgentTurns(() => {
+        called++;
+      });
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t1", channelId: "c1" }),
+      ]);
+      assert.ok(called > 0);
+      unsub();
+    });
+
+    it("notifies on turn_completed", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t1", channelId: "c1" }),
+      ]);
+      let called = 0;
+      const unsub = subscribeActiveAgentTurns(() => {
+        called++;
+      });
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 2, kind: "turn_completed", turnId: "t1" }),
+      ]);
+      assert.ok(called > 0);
+      unsub();
+    });
+  });
+
+  describe("getActiveChannelsForAgent", () => {
+    it("returns EMPTY_SET for null/undefined pubkey", () => {
+      assert.equal(getActiveChannelsForAgent(null).size, 0);
+      assert.equal(getActiveChannelsForAgent(undefined).size, 0);
+    });
+
+    it("returns stable reference when unchanged", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "t1", channelId: "c1" }),
+      ]);
+      const ref1 = getActiveChannelsForAgent(AGENT);
+      const ref2 = getActiveChannelsForAgent(AGENT);
+      assert.equal(ref1, ref2, "should return cached reference");
+    });
+  });
+});

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -1,0 +1,203 @@
+import * as React from "react";
+
+import {
+  subscribeAgentObserverStore,
+  getAgentObserverSnapshot,
+} from "@/features/agents/observerRelayStore";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import type { ObserverEvent } from "./ui/agentSessionTypes";
+
+/** How long before a turn is considered stale if no completion event arrives. */
+const STALENESS_TIMEOUT_MS = 5 * 60 * 1000;
+
+type ActiveTurn = {
+  turnId: string;
+  channelId: string;
+  startedAt: number;
+};
+
+// Module-level state: agentPubkey → channelId → ActiveTurn
+const activeTurnsByAgent = new Map<string, Map<string, ActiveTurn>>();
+const listeners = new Set<() => void>();
+
+// Track which observer events we've already processed (by seq per agent)
+const lastProcessedSeq = new Map<string, number>();
+
+let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+function notifyListeners() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function startTurn(
+  agentPubkey: string,
+  channelId: string,
+  turnId: string,
+  timestamp: string,
+) {
+  const key = normalizePubkey(agentPubkey);
+  let agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns) {
+    agentTurns = new Map();
+    activeTurnsByAgent.set(key, agentTurns);
+  }
+  agentTurns.set(channelId, {
+    turnId,
+    channelId,
+    startedAt: Date.parse(timestamp) || Date.now(),
+  });
+}
+
+function endTurn(agentPubkey: string, channelId: string | null) {
+  const key = normalizePubkey(agentPubkey);
+  const agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns) return;
+
+  if (channelId) {
+    agentTurns.delete(channelId);
+  }
+  if (agentTurns.size === 0) {
+    activeTurnsByAgent.delete(key);
+  }
+}
+
+function pruneStale() {
+  const now = Date.now();
+  let changed = false;
+  for (const [agentKey, agentTurns] of activeTurnsByAgent) {
+    for (const [channelId, turn] of agentTurns) {
+      if (now - turn.startedAt > STALENESS_TIMEOUT_MS) {
+        agentTurns.delete(channelId);
+        changed = true;
+      }
+    }
+    if (agentTurns.size === 0) {
+      activeTurnsByAgent.delete(agentKey);
+    }
+  }
+  if (changed) {
+    notifyListeners();
+  }
+}
+
+function processEvent(agentPubkey: string, event: ObserverEvent) {
+  const key = normalizePubkey(agentPubkey);
+  const lastSeq = lastProcessedSeq.get(key) ?? 0;
+  if (event.seq <= lastSeq) return;
+  lastProcessedSeq.set(key, event.seq);
+
+  if (event.kind === "turn_started" && event.channelId) {
+    startTurn(
+      agentPubkey,
+      event.channelId,
+      event.turnId ?? `seq-${event.seq}`,
+      event.timestamp,
+    );
+    notifyListeners();
+  } else if (
+    event.kind === "turn_completed" ||
+    event.kind === "turn_error" ||
+    event.kind === "agent_panic"
+  ) {
+    endTurn(agentPubkey, event.channelId);
+    notifyListeners();
+  }
+}
+
+function ensureCleanupInterval() {
+  if (cleanupInterval) return;
+  cleanupInterval = setInterval(pruneStale, 30_000);
+}
+
+function stopCleanupInterval() {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+  }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export function subscribeActiveAgentTurns(listener: () => void) {
+  listeners.add(listener);
+  if (listeners.size === 1) {
+    ensureCleanupInterval();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      stopCleanupInterval();
+    }
+  };
+}
+
+export function getActiveChannelsForAgent(
+  agentPubkey: string | null | undefined,
+): Set<string> {
+  if (!agentPubkey) return EMPTY_SET;
+  const key = normalizePubkey(agentPubkey);
+  const agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns || agentTurns.size === 0) return EMPTY_SET;
+  return new Set(agentTurns.keys());
+}
+
+const EMPTY_SET: Set<string> = new Set();
+
+/**
+ * Synchronize the active-turns store with the latest observer events for a
+ * given agent. Call this from within a React component that has access to the
+ * observer snapshot.
+ */
+export function syncAgentTurnsFromEvents(
+  agentPubkey: string,
+  events: ObserverEvent[],
+) {
+  for (const event of events) {
+    processEvent(agentPubkey, event);
+  }
+}
+
+/**
+ * Hook: returns the set of channel IDs where the given agent is currently working.
+ * Re-renders when the set changes.
+ */
+export function useActiveAgentTurns(
+  agentPubkey: string | null | undefined,
+): Set<string> {
+  const getSnapshot = React.useCallback(
+    () => getActiveChannelsForAgent(agentPubkey),
+    [agentPubkey],
+  );
+
+  return React.useSyncExternalStore(subscribeActiveAgentTurns, getSnapshot);
+}
+
+/**
+ * Bridge hook: processes observer events into the active-turns store.
+ * Should be called by a parent component that has access to the observer events.
+ */
+export function useActiveAgentTurnsBridge(
+  agents: readonly { pubkey: string; status: string }[],
+) {
+  // Subscribe to observer store changes and sync active turns
+  React.useEffect(() => {
+    function syncAll() {
+      for (const agent of agents) {
+        if (agent.status !== "running" && agent.status !== "deployed") continue;
+        const snapshot = getAgentObserverSnapshot(agent.pubkey, true);
+        syncAgentTurnsFromEvents(agent.pubkey, snapshot.events);
+      }
+    }
+
+    syncAll();
+    return subscribeAgentObserverStore(syncAll);
+  }, [agents]);
+}
+
+export function resetActiveAgentTurnsStore() {
+  activeTurnsByAgent.clear();
+  lastProcessedSeq.clear();
+  notifyListeners();
+}

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -3,6 +3,7 @@ import * as React from "react";
 import {
   subscribeAgentObserverStore,
   getAgentObserverSnapshot,
+  compareObserverEvents,
 } from "@/features/agents/observerRelayStore";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import type { ObserverEvent } from "./ui/agentSessionTypes";
@@ -29,8 +30,11 @@ const listeners = new Set<() => void>();
 // Only regenerated when the underlying turn map for an agent actually changes.
 const cachedChannelSets = new Map<string, Set<string>>();
 
-// Track which observer events we've already processed (by seq per agent)
-const lastProcessedSeq = new Map<string, number>();
+// Composite watermark per agent: the newest observer event processed, by
+// (timestamp, seq) ordering. An event is processed only if it is strictly
+// newer than this — making full-buffer replays idempotent and post-restart
+// streams (seq resets to 1, timestamp keeps climbing) handled for free.
+const lastProcessed = new Map<string, ObserverEvent>();
 
 let pruneInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -139,22 +143,33 @@ function pruneExpired() {
   }
 }
 
-// INVARIANT: events must be sorted by seq (ascending). syncAgentTurnsFromEvents
-// receives sorted arrays from observerRelayStore. Calling with unsorted events
-// will cause silent data loss.
+// INVARIANT: events must be sorted by (timestamp, seq) ascending.
+// syncAgentTurnsFromEvents receives sorted arrays from observerRelayStore.
+// Calling with unsorted events will cause silent data loss.
 function processEvent(agentPubkey: string, event: ObserverEvent) {
   const key = normalizePubkey(agentPubkey);
-  const lastSeq = lastProcessedSeq.get(key) ?? 0;
 
-  // Detect agent restart: harness always starts seq at 1, so seeing seq=1
-  // after processing higher values means the agent restarted.
-  if (event.seq === 1 && lastSeq > 1) {
-    lastProcessedSeq.set(key, 0);
-  } else if (event.seq <= lastSeq) {
+  // turn_completed / turn_error / agent_panic must evict unconditionally —
+  // gating eviction on the watermark would let a replay resurrect a dead turn.
+  // Eviction is idempotent (deleting an absent turn is a no-op), so replays
+  // stay safe.
+  const isEviction =
+    event.kind === "turn_completed" ||
+    event.kind === "turn_error" ||
+    event.kind === "agent_panic";
+
+  // New-turn creation and activity refresh are gated on the watermark: only
+  // process events strictly newer than the last one seen for this agent.
+  const last = lastProcessed.get(key);
+  if (!isEviction && last && compareObserverEvents(event, last) <= 0) {
     return;
   }
 
-  lastProcessedSeq.set(key, event.seq);
+  // Advance the watermark only for strictly-newer events so out-of-order
+  // evictions don't move it backwards.
+  if (!last || compareObserverEvents(event, last) > 0) {
+    lastProcessed.set(key, event);
+  }
 
   switch (event.kind) {
     case "turn_started":
@@ -278,7 +293,7 @@ export function useActiveAgentTurnsBridge(
 
 export function resetActiveAgentTurnsStore() {
   activeTurnsByAgent.clear();
-  lastProcessedSeq.clear();
+  lastProcessed.clear();
   cachedChannelSets.clear();
   notifyListeners();
 }

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -7,23 +7,35 @@ import {
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import type { ObserverEvent } from "./ui/agentSessionTypes";
 
-/** How long before a turn is considered stale if no completion event arrives. */
-const STALENESS_TIMEOUT_MS = 5 * 60 * 1000;
+/** Mark a turn as possibly stale after 20s of no activity. */
+const STALE_AFTER_MS = 20_000;
+/** Remove a turn entirely after 90s of no activity. */
+const REMOVE_AFTER_MS = 90_000;
+/** Maximum concurrent active turns tracked per agent (matches pool size). */
+const MAX_TURNS_PER_AGENT = 4;
+/** Interval for pruning stale/expired turns. */
+const PRUNE_INTERVAL_MS = 5_000;
 
 type ActiveTurn = {
   turnId: string;
   channelId: string;
   startedAt: number;
+  lastActivityAt: number;
 };
 
-// Module-level state: agentPubkey → channelId → ActiveTurn
+export type ActiveTurnInfo = {
+  channelId: string;
+  stale: boolean;
+};
+
+// Module-level state: agentPubkey → turnId → ActiveTurn
 const activeTurnsByAgent = new Map<string, Map<string, ActiveTurn>>();
 const listeners = new Set<() => void>();
 
 // Track which observer events we've already processed (by seq per agent)
 const lastProcessedSeq = new Map<string, number>();
 
-let cleanupInterval: ReturnType<typeof setInterval> | null = null;
+let pruneInterval: ReturnType<typeof setInterval> | null = null;
 
 function notifyListeners() {
   for (const listener of listeners) {
@@ -43,33 +55,74 @@ function startTurn(
     agentTurns = new Map();
     activeTurnsByAgent.set(key, agentTurns);
   }
-  agentTurns.set(channelId, {
+
+  // Cap at MAX_TURNS_PER_AGENT — evict oldest if exceeded
+  if (agentTurns.size >= MAX_TURNS_PER_AGENT && !agentTurns.has(turnId)) {
+    let oldestKey: string | null = null;
+    let oldestTime = Number.POSITIVE_INFINITY;
+    for (const [tid, turn] of agentTurns) {
+      if (turn.startedAt < oldestTime) {
+        oldestTime = turn.startedAt;
+        oldestKey = tid;
+      }
+    }
+    if (oldestKey) {
+      agentTurns.delete(oldestKey);
+    }
+  }
+
+  const now = Date.parse(timestamp) || Date.now();
+  agentTurns.set(turnId, {
     turnId,
     channelId,
-    startedAt: Date.parse(timestamp) || Date.now(),
+    startedAt: now,
+    lastActivityAt: now,
   });
 }
 
-function endTurn(agentPubkey: string, channelId: string | null) {
+function recordActivity(agentPubkey: string, turnId: string | null) {
+  if (!turnId) return;
+  const key = normalizePubkey(agentPubkey);
+  const agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns) return;
+  const turn = agentTurns.get(turnId);
+  if (turn) {
+    turn.lastActivityAt = Date.now();
+  }
+}
+
+function endTurn(
+  agentPubkey: string,
+  turnId: string | null,
+  channelId: string | null,
+) {
   const key = normalizePubkey(agentPubkey);
   const agentTurns = activeTurnsByAgent.get(key);
   if (!agentTurns) return;
 
-  if (channelId) {
-    agentTurns.delete(channelId);
+  if (turnId) {
+    agentTurns.delete(turnId);
+  } else if (channelId) {
+    // Fallback: remove by channelId if turnId not available
+    for (const [tid, turn] of agentTurns) {
+      if (turn.channelId === channelId) {
+        agentTurns.delete(tid);
+        break;
+      }
+    }
   }
   if (agentTurns.size === 0) {
     activeTurnsByAgent.delete(key);
   }
 }
 
-function pruneStale() {
+function pruneExpired() {
   const now = Date.now();
   let changed = false;
   for (const [agentKey, agentTurns] of activeTurnsByAgent) {
-    for (const [channelId, turn] of agentTurns) {
-      if (now - turn.startedAt > STALENESS_TIMEOUT_MS) {
-        agentTurns.delete(channelId);
+    for (const [turnId, turn] of agentTurns) {
+      if (now - turn.lastActivityAt > REMOVE_AFTER_MS) {
+        agentTurns.delete(turnId);
         changed = true;
       }
     }
@@ -88,33 +141,40 @@ function processEvent(agentPubkey: string, event: ObserverEvent) {
   if (event.seq <= lastSeq) return;
   lastProcessedSeq.set(key, event.seq);
 
-  if (event.kind === "turn_started" && event.channelId) {
-    startTurn(
-      agentPubkey,
-      event.channelId,
-      event.turnId ?? `seq-${event.seq}`,
-      event.timestamp,
-    );
-    notifyListeners();
-  } else if (
-    event.kind === "turn_completed" ||
-    event.kind === "turn_error" ||
-    event.kind === "agent_panic"
-  ) {
-    endTurn(agentPubkey, event.channelId);
-    notifyListeners();
+  switch (event.kind) {
+    case "turn_started":
+      if (event.channelId) {
+        startTurn(
+          agentPubkey,
+          event.channelId,
+          event.turnId ?? `seq-${event.seq}`,
+          event.timestamp,
+        );
+        notifyListeners();
+      }
+      break;
+    case "turn_completed":
+    case "turn_error":
+    case "agent_panic":
+      endTurn(agentPubkey, event.turnId ?? null, event.channelId ?? null);
+      notifyListeners();
+      break;
+    case "acp_read":
+    case "acp_write":
+      recordActivity(agentPubkey, event.turnId ?? null);
+      break;
   }
 }
 
-function ensureCleanupInterval() {
-  if (cleanupInterval) return;
-  cleanupInterval = setInterval(pruneStale, 30_000);
+function ensurePruneInterval() {
+  if (pruneInterval) return;
+  pruneInterval = setInterval(pruneExpired, PRUNE_INTERVAL_MS);
 }
 
-function stopCleanupInterval() {
-  if (cleanupInterval) {
-    clearInterval(cleanupInterval);
-    cleanupInterval = null;
+function stopPruneInterval() {
+  if (pruneInterval) {
+    clearInterval(pruneInterval);
+    pruneInterval = null;
   }
 }
 
@@ -123,16 +183,36 @@ function stopCleanupInterval() {
 export function subscribeActiveAgentTurns(listener: () => void) {
   listeners.add(listener);
   if (listeners.size === 1) {
-    ensureCleanupInterval();
+    ensurePruneInterval();
   }
   return () => {
     listeners.delete(listener);
     if (listeners.size === 0) {
-      stopCleanupInterval();
+      stopPruneInterval();
     }
   };
 }
 
+export function getActiveTurnsForAgent(
+  agentPubkey: string | null | undefined,
+): Map<string, ActiveTurnInfo> {
+  if (!agentPubkey) return EMPTY_MAP;
+  const key = normalizePubkey(agentPubkey);
+  const agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns || agentTurns.size === 0) return EMPTY_MAP;
+
+  const now = Date.now();
+  const result = new Map<string, ActiveTurnInfo>();
+  for (const [turnId, turn] of agentTurns) {
+    result.set(turnId, {
+      channelId: turn.channelId,
+      stale: now - turn.lastActivityAt > STALE_AFTER_MS,
+    });
+  }
+  return result;
+}
+
+/** Convenience: returns just the set of channel IDs (ignoring stale flag). */
 export function getActiveChannelsForAgent(
   agentPubkey: string | null | undefined,
 ): Set<string> {
@@ -140,15 +220,15 @@ export function getActiveChannelsForAgent(
   const key = normalizePubkey(agentPubkey);
   const agentTurns = activeTurnsByAgent.get(key);
   if (!agentTurns || agentTurns.size === 0) return EMPTY_SET;
-  return new Set(agentTurns.keys());
+  return new Set([...agentTurns.values()].map((t) => t.channelId));
 }
 
+const EMPTY_MAP: Map<string, ActiveTurnInfo> = new Map();
 const EMPTY_SET: Set<string> = new Set();
 
 /**
  * Synchronize the active-turns store with the latest observer events for a
- * given agent. Call this from within a React component that has access to the
- * observer snapshot.
+ * given agent.
  */
 export function syncAgentTurnsFromEvents(
   agentPubkey: string,
@@ -157,6 +237,21 @@ export function syncAgentTurnsFromEvents(
   for (const event of events) {
     processEvent(agentPubkey, event);
   }
+}
+
+/**
+ * Hook: returns a map of turnId → { channelId, stale } for the given agent.
+ * Re-renders when the map changes. Use for detailed turn state display.
+ */
+export function useActiveAgentTurnsDetailed(
+  agentPubkey: string | null | undefined,
+): Map<string, ActiveTurnInfo> {
+  const getSnapshot = React.useCallback(
+    () => getActiveTurnsForAgent(agentPubkey),
+    [agentPubkey],
+  );
+
+  return React.useSyncExternalStore(subscribeActiveAgentTurns, getSnapshot);
 }
 
 /**
@@ -181,7 +276,6 @@ export function useActiveAgentTurns(
 export function useActiveAgentTurnsBridge(
   agents: readonly { pubkey: string; status: string }[],
 ) {
-  // Subscribe to observer store changes and sync active turns
   React.useEffect(() => {
     function syncAll() {
       for (const agent of agents) {

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -32,10 +32,20 @@ export type ActiveTurnInfo = {
 const activeTurnsByAgent = new Map<string, Map<string, ActiveTurn>>();
 const listeners = new Set<() => void>();
 
+// Cached snapshots for useSyncExternalStore reference stability.
+// Only regenerated when the underlying turn map for an agent actually changes.
+const cachedChannelSets = new Map<string, Set<string>>();
+const cachedDetailedMaps = new Map<string, Map<string, ActiveTurnInfo>>();
+
 // Track which observer events we've already processed (by seq per agent)
 const lastProcessedSeq = new Map<string, number>();
 
 let pruneInterval: ReturnType<typeof setInterval> | null = null;
+
+function invalidateCache(agentKey: string) {
+  cachedChannelSets.delete(agentKey);
+  cachedDetailedMaps.delete(agentKey);
+}
 
 function notifyListeners() {
   for (const listener of listeners) {
@@ -78,6 +88,7 @@ function startTurn(
     startedAt: now,
     lastActivityAt: now,
   });
+  invalidateCache(key);
 }
 
 function recordActivity(agentPubkey: string, turnId: string | null) {
@@ -114,6 +125,7 @@ function endTurn(
   if (agentTurns.size === 0) {
     activeTurnsByAgent.delete(key);
   }
+  invalidateCache(key);
 }
 
 function pruneExpired() {
@@ -123,6 +135,7 @@ function pruneExpired() {
     for (const [turnId, turn] of agentTurns) {
       if (now - turn.lastActivityAt > REMOVE_AFTER_MS) {
         agentTurns.delete(turnId);
+        invalidateCache(agentKey);
         changed = true;
       }
     }
@@ -130,11 +143,18 @@ function pruneExpired() {
       activeTurnsByAgent.delete(agentKey);
     }
   }
-  if (changed) {
+  // Staleness flag is time-derived — invalidate detailed caches so consumers
+  // see updated stale values on next read.
+  const hadDetailedCaches = cachedDetailedMaps.size > 0;
+  cachedDetailedMaps.clear();
+  if (changed || hadDetailedCaches) {
     notifyListeners();
   }
 }
 
+// INVARIANT: events must be sorted by seq (ascending). syncAgentTurnsFromEvents
+// receives sorted arrays from observerRelayStore. Calling with unsorted events
+// will cause silent data loss.
 function processEvent(agentPubkey: string, event: ObserverEvent) {
   const key = normalizePubkey(agentPubkey);
   const lastSeq = lastProcessedSeq.get(key) ?? 0;
@@ -201,6 +221,9 @@ export function getActiveTurnsForAgent(
   const agentTurns = activeTurnsByAgent.get(key);
   if (!agentTurns || agentTurns.size === 0) return EMPTY_MAP;
 
+  const cached = cachedDetailedMaps.get(key);
+  if (cached) return cached;
+
   const now = Date.now();
   const result = new Map<string, ActiveTurnInfo>();
   for (const [turnId, turn] of agentTurns) {
@@ -209,6 +232,7 @@ export function getActiveTurnsForAgent(
       stale: now - turn.lastActivityAt > STALE_AFTER_MS,
     });
   }
+  cachedDetailedMaps.set(key, result);
   return result;
 }
 
@@ -220,7 +244,13 @@ export function getActiveChannelsForAgent(
   const key = normalizePubkey(agentPubkey);
   const agentTurns = activeTurnsByAgent.get(key);
   if (!agentTurns || agentTurns.size === 0) return EMPTY_SET;
-  return new Set([...agentTurns.values()].map((t) => t.channelId));
+
+  const cached = cachedChannelSets.get(key);
+  if (cached) return cached;
+
+  const result = new Set([...agentTurns.values()].map((t) => t.channelId));
+  cachedChannelSets.set(key, result);
+  return result;
 }
 
 const EMPTY_MAP: Map<string, ActiveTurnInfo> = new Map();
@@ -293,5 +323,7 @@ export function useActiveAgentTurnsBridge(
 export function resetActiveAgentTurnsStore() {
   activeTurnsByAgent.clear();
   lastProcessedSeq.clear();
+  cachedChannelSets.clear();
+  cachedDetailedMaps.clear();
   notifyListeners();
 }

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -7,8 +7,6 @@ import {
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import type { ObserverEvent } from "./ui/agentSessionTypes";
 
-/** Mark a turn as possibly stale after 20s of no activity. */
-const STALE_AFTER_MS = 20_000;
 /** Remove a turn entirely after 90s of no activity. */
 const REMOVE_AFTER_MS = 90_000;
 /** Maximum concurrent active turns tracked per agent (matches pool size). */
@@ -23,11 +21,6 @@ type ActiveTurn = {
   lastActivityAt: number;
 };
 
-export type ActiveTurnInfo = {
-  channelId: string;
-  stale: boolean;
-};
-
 // Module-level state: agentPubkey → turnId → ActiveTurn
 const activeTurnsByAgent = new Map<string, Map<string, ActiveTurn>>();
 const listeners = new Set<() => void>();
@@ -35,7 +28,6 @@ const listeners = new Set<() => void>();
 // Cached snapshots for useSyncExternalStore reference stability.
 // Only regenerated when the underlying turn map for an agent actually changes.
 const cachedChannelSets = new Map<string, Set<string>>();
-const cachedDetailedMaps = new Map<string, Map<string, ActiveTurnInfo>>();
 
 // Track which observer events we've already processed (by seq per agent)
 const lastProcessedSeq = new Map<string, number>();
@@ -44,7 +36,6 @@ let pruneInterval: ReturnType<typeof setInterval> | null = null;
 
 function invalidateCache(agentKey: string) {
   cachedChannelSets.delete(agentKey);
-  cachedDetailedMaps.delete(agentKey);
 }
 
 function notifyListeners() {
@@ -143,11 +134,7 @@ function pruneExpired() {
       activeTurnsByAgent.delete(agentKey);
     }
   }
-  // Staleness flag is time-derived — invalidate detailed caches so consumers
-  // see updated stale values on next read.
-  const hadDetailedCaches = cachedDetailedMaps.size > 0;
-  cachedDetailedMaps.clear();
-  if (changed || hadDetailedCaches) {
+  if (changed) {
     notifyListeners();
   }
 }
@@ -158,7 +145,15 @@ function pruneExpired() {
 function processEvent(agentPubkey: string, event: ObserverEvent) {
   const key = normalizePubkey(agentPubkey);
   const lastSeq = lastProcessedSeq.get(key) ?? 0;
-  if (event.seq <= lastSeq) return;
+
+  // Detect agent restart: harness always starts seq at 1, so seeing seq=1
+  // after processing higher values means the agent restarted.
+  if (event.seq === 1 && lastSeq > 1) {
+    lastProcessedSeq.set(key, 0);
+  } else if (event.seq <= lastSeq) {
+    return;
+  }
+
   lastProcessedSeq.set(key, event.seq);
 
   switch (event.kind) {
@@ -213,30 +208,7 @@ export function subscribeActiveAgentTurns(listener: () => void) {
   };
 }
 
-export function getActiveTurnsForAgent(
-  agentPubkey: string | null | undefined,
-): Map<string, ActiveTurnInfo> {
-  if (!agentPubkey) return EMPTY_MAP;
-  const key = normalizePubkey(agentPubkey);
-  const agentTurns = activeTurnsByAgent.get(key);
-  if (!agentTurns || agentTurns.size === 0) return EMPTY_MAP;
-
-  const cached = cachedDetailedMaps.get(key);
-  if (cached) return cached;
-
-  const now = Date.now();
-  const result = new Map<string, ActiveTurnInfo>();
-  for (const [turnId, turn] of agentTurns) {
-    result.set(turnId, {
-      channelId: turn.channelId,
-      stale: now - turn.lastActivityAt > STALE_AFTER_MS,
-    });
-  }
-  cachedDetailedMaps.set(key, result);
-  return result;
-}
-
-/** Convenience: returns just the set of channel IDs (ignoring stale flag). */
+/** Returns the set of channel IDs where the given agent has active turns. */
 export function getActiveChannelsForAgent(
   agentPubkey: string | null | undefined,
 ): Set<string> {
@@ -253,7 +225,6 @@ export function getActiveChannelsForAgent(
   return result;
 }
 
-const EMPTY_MAP: Map<string, ActiveTurnInfo> = new Map();
 const EMPTY_SET: Set<string> = new Set();
 
 /**
@@ -267,21 +238,6 @@ export function syncAgentTurnsFromEvents(
   for (const event of events) {
     processEvent(agentPubkey, event);
   }
-}
-
-/**
- * Hook: returns a map of turnId → { channelId, stale } for the given agent.
- * Re-renders when the map changes. Use for detailed turn state display.
- */
-export function useActiveAgentTurnsDetailed(
-  agentPubkey: string | null | undefined,
-): Map<string, ActiveTurnInfo> {
-  const getSnapshot = React.useCallback(
-    () => getActiveTurnsForAgent(agentPubkey),
-    [agentPubkey],
-  );
-
-  return React.useSyncExternalStore(subscribeActiveAgentTurns, getSnapshot);
 }
 
 /**
@@ -324,6 +280,5 @@ export function resetActiveAgentTurnsStore() {
   activeTurnsByAgent.clear();
   lastProcessedSeq.clear();
   cachedChannelSets.clear();
-  cachedDetailedMaps.clear();
   notifyListeners();
 }

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -149,27 +149,19 @@ function pruneExpired() {
 function processEvent(agentPubkey: string, event: ObserverEvent) {
   const key = normalizePubkey(agentPubkey);
 
-  // turn_completed / turn_error / agent_panic must evict unconditionally —
-  // gating eviction on the watermark would let a replay resurrect a dead turn.
-  // Eviction is idempotent (deleting an absent turn is a no-op), so replays
-  // stay safe.
-  const isEviction =
-    event.kind === "turn_completed" ||
-    event.kind === "turn_error" ||
-    event.kind === "agent_panic";
-
-  // New-turn creation and activity refresh are gated on the watermark: only
-  // process events strictly newer than the last one seen for this agent.
+  // Gate every event kind on the watermark uniformly: process only events
+  // strictly newer than the last one seen for this agent. With sorted buffers
+  // (the documented invariant), this makes full-buffer replays a complete
+  // no-op. Evictions must be gated too — replaying a stale turn_error/
+  // agent_panic (emitted with a null turnId) would otherwise fall back to
+  // deleting the first turn in the channel, killing the live turn. Resurrection
+  // is not a concern: it would require reprocessing a stale start, which the
+  // watermark already blocks.
   const last = lastProcessed.get(key);
-  if (!isEviction && last && compareObserverEvents(event, last) <= 0) {
+  if (last && compareObserverEvents(event, last) <= 0) {
     return;
   }
-
-  // Advance the watermark only for strictly-newer events so out-of-order
-  // evictions don't move it backwards.
-  if (!last || compareObserverEvents(event, last) > 0) {
-    lastProcessed.set(key, event);
-  }
+  lastProcessed.set(key, event);
 
   switch (event.kind) {
     case "turn_started":

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -115,7 +115,10 @@ function appendAgentEvent(agentPubkey: string, event: ObserverEvent) {
   notifyListeners();
 }
 
-function compareObserverEvents(left: ObserverEvent, right: ObserverEvent) {
+export function compareObserverEvents(
+  left: ObserverEvent,
+  right: ObserverEvent,
+) {
   const leftTime = Date.parse(left.timestamp);
   const rightTime = Date.parse(right.timestamp);
   if (Number.isFinite(leftTime) && Number.isFinite(rightTime)) {

--- a/desktop/src/features/agents/ui/AgentGroupRows.tsx
+++ b/desktop/src/features/agents/ui/AgentGroupRows.tsx
@@ -4,6 +4,7 @@ import { ManagedAgentRow } from "./ManagedAgentRow";
 
 export type AgentGroupRowsProps = {
   agents: ManagedAgent[];
+  channelIdToName: Record<string, string>;
   channelsByPubkey: Record<string, string[]>;
   isActionPending: boolean;
   logContent: string | null;
@@ -23,6 +24,7 @@ export type AgentGroupRowsProps = {
 
 export function AgentGroupRows({
   agents,
+  channelIdToName,
   channelsByPubkey,
   isActionPending,
   logContent,
@@ -44,6 +46,7 @@ export function AgentGroupRows({
       {agents.map((agent) => (
         <ManagedAgentRow
           agent={agent}
+          channelIdToName={channelIdToName}
           channelNames={channelsByPubkey[normalizePubkey(agent.pubkey)] ?? []}
           isActionPending={isActionPending}
           isLogSelected={selectedLogAgentPubkey === agent.pubkey}

--- a/desktop/src/features/agents/ui/AgentGroupRows.tsx
+++ b/desktop/src/features/agents/ui/AgentGroupRows.tsx
@@ -5,7 +5,7 @@ import { ManagedAgentRow } from "./ManagedAgentRow";
 export type AgentGroupRowsProps = {
   agents: ManagedAgent[];
   channelIdToName: Record<string, string>;
-  channelsByPubkey: Record<string, string[]>;
+  channelsByPubkey: Record<string, { id: string; name: string }[]>;
   isActionPending: boolean;
   logContent: string | null;
   logError: Error | null;

--- a/desktop/src/features/agents/ui/AgentStatusBadge.tsx
+++ b/desktop/src/features/agents/ui/AgentStatusBadge.tsx
@@ -7,10 +7,12 @@ import type { ManagedAgent, PresenceStatus } from "@/shared/api/types";
 const PRESENCE_GRACE_MS = 15_000;
 
 export function AgentStatusBadge({
+  isWorking,
   presenceLoaded,
   presenceStatus,
   status,
 }: {
+  isWorking?: boolean;
   presenceLoaded: boolean;
   presenceStatus: PresenceStatus | undefined;
   status: ManagedAgent["status"];
@@ -29,11 +31,26 @@ export function AgentStatusBadge({
     status === "running" &&
     (!presenceStatus || presenceStatus === "offline");
 
-  const variant = isStarting ? "warning" : isActive ? "default" : "secondary";
+  const variant: "default" | "warning" | "secondary" = isWorking
+    ? "default"
+    : isStarting
+      ? "warning"
+      : isActive
+        ? "default"
+        : "secondary";
+
+  const label = isWorking
+    ? "Working"
+    : isStarting
+      ? "Starting\u2026"
+      : status.replace(/_/g, " ");
 
   return (
-    <Badge variant={variant}>
-      {isStarting ? "Starting\u2026" : status.replace(/_/g, " ")}
+    <Badge
+      className={isWorking ? "animate-pulse" : undefined}
+      variant={variant}
+    >
+      {label}
     </Badge>
   );
 }

--- a/desktop/src/features/agents/ui/AgentStatusBadge.tsx
+++ b/desktop/src/features/agents/ui/AgentStatusBadge.tsx
@@ -47,7 +47,7 @@ export function AgentStatusBadge({
 
   return (
     <Badge
-      className={isWorking ? "animate-pulse" : undefined}
+      className={isWorking ? "motion-safe:animate-pulse" : undefined}
       variant={variant}
     >
       {label}

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -49,6 +49,7 @@ export function AgentsView() {
               actionErrorMessage={agents.actionErrorMessage}
               actionNoticeMessage={agents.actionNoticeMessage}
               agents={agents.managedAgents}
+              channelIdToName={agents.channelIdToName}
               channelsByPubkey={agents.channelsByPubkey}
               agentsError={
                 agents.managedAgentsQuery.error instanceof Error

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
 import { Badge } from "@/shared/ui/badge";
 import { AgentStatusBadge } from "@/features/agents/ui/AgentStatusBadge";
+import { useActiveAgentTurns } from "@/features/agents/activeAgentTurnsStore";
 import type {
   ManagedAgent,
   PresenceLookup,
@@ -39,6 +40,7 @@ import { truncatePubkey } from "./agentUi";
 
 export function ManagedAgentRow({
   agent,
+  channelIdToName,
   channelNames,
   isActionPending,
   isLogSelected,
@@ -56,6 +58,7 @@ export function ManagedAgentRow({
   onToggleStartOnAppLaunch,
 }: {
   agent: ManagedAgent;
+  channelIdToName: Record<string, string>;
   channelNames: string[];
   isActionPending: boolean;
   isLogSelected: boolean;
@@ -80,6 +83,13 @@ export function ManagedAgentRow({
     ? (personaLabelsById[agent.personaId] ?? null)
     : null;
   const presenceStatus = presenceLookup[agent.pubkey.trim().toLowerCase()];
+  const activeChannelIds = useActiveAgentTurns(agent.pubkey);
+  const activeWorkingChannels = React.useMemo(
+    () =>
+      [...activeChannelIds].map((id) => channelIdToName[id] ?? id).slice(0, 3),
+    [activeChannelIds, channelIdToName],
+  );
+  const isWorking = activeWorkingChannels.length > 0;
   const processDetail =
     agent.pid !== null
       ? `PID ${agent.pid}`
@@ -116,6 +126,7 @@ export function ManagedAgentRow({
           >
             <div className="grid gap-3 lg:grid-cols-[minmax(0,1.8fr)_minmax(120px,0.8fr)_minmax(0,1.1fr)] lg:gap-4">
               <AgentSummary
+                activeWorkingChannels={activeWorkingChannels}
                 agent={agent}
                 channelNames={channelNames}
                 isExpandable
@@ -125,6 +136,7 @@ export function ManagedAgentRow({
               />
               <StatusBlock
                 friendlyError={friendlyError}
+                isWorking={isWorking}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -137,6 +149,7 @@ export function ManagedAgentRow({
           <div className="min-w-0 flex-1">
             <div className="grid gap-3 lg:grid-cols-[minmax(0,1.8fr)_minmax(120px,0.8fr)_minmax(0,1.1fr)] lg:gap-4">
               <AgentSummary
+                activeWorkingChannels={activeWorkingChannels}
                 agent={agent}
                 channelNames={channelNames}
                 isExpandable={false}
@@ -146,6 +159,7 @@ export function ManagedAgentRow({
               />
               <StatusBlock
                 friendlyError={friendlyError}
+                isWorking={isWorking}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -191,6 +205,7 @@ export function ManagedAgentRow({
 }
 
 function AgentSummary({
+  activeWorkingChannels,
   agent,
   channelNames,
   isExpandable,
@@ -198,6 +213,7 @@ function AgentSummary({
   personaLabel,
   presenceStatus,
 }: {
+  activeWorkingChannels: string[];
   agent: ManagedAgent;
   channelNames: string[];
   isExpandable: boolean;
@@ -253,6 +269,19 @@ function AgentSummary({
               ))}
             </div>
           ) : null}
+          {activeWorkingChannels.length > 0 ? (
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+              {activeWorkingChannels.map((name) => (
+                <Badge
+                  className="animate-pulse normal-case tracking-normal"
+                  key={`working-${name}`}
+                  variant="default"
+                >
+                  Working in # {name}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
         </div>
       </div>
     </div>
@@ -261,12 +290,14 @@ function AgentSummary({
 
 function StatusBlock({
   friendlyError,
+  isWorking,
   presenceLoaded,
   presenceStatus,
   processDetail,
   status,
 }: {
   friendlyError: ReturnType<typeof friendlyAgentLastError>;
+  isWorking: boolean;
   presenceLoaded: boolean;
   presenceStatus: PresenceStatus | undefined;
   processDetail: string;
@@ -278,6 +309,7 @@ function StatusBlock({
         Status
       </p>
       <AgentStatusBadge
+        isWorking={isWorking}
         presenceLoaded={presenceLoaded}
         presenceStatus={presenceStatus}
         status={status}

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
 import { Badge } from "@/shared/ui/badge";
 import { AgentStatusBadge } from "@/features/agents/ui/AgentStatusBadge";
@@ -59,7 +60,7 @@ export function ManagedAgentRow({
 }: {
   agent: ManagedAgent;
   channelIdToName: Record<string, string>;
-  channelNames: string[];
+  channelNames: { id: string; name: string }[];
   isActionPending: boolean;
   isLogSelected: boolean;
   logContent: string | null;
@@ -86,7 +87,9 @@ export function ManagedAgentRow({
   const activeChannelIds = useActiveAgentTurns(agent.pubkey);
   const activeWorkingChannels = React.useMemo(
     () =>
-      [...activeChannelIds].map((id) => channelIdToName[id] ?? id).slice(0, 3),
+      [...activeChannelIds]
+        .map((id) => ({ id, name: channelIdToName[id] ?? id }))
+        .slice(0, 3),
     [activeChannelIds, channelIdToName],
   );
   const isWorking = activeWorkingChannels.length > 0;
@@ -213,14 +216,16 @@ function AgentSummary({
   personaLabel,
   presenceStatus,
 }: {
-  activeWorkingChannels: string[];
+  activeWorkingChannels: { id: string; name: string }[];
   agent: ManagedAgent;
-  channelNames: string[];
+  channelNames: { id: string; name: string }[];
   isExpandable: boolean;
   isLogSelected: boolean;
   personaLabel: string | null;
   presenceStatus: PresenceStatus | undefined;
 }) {
+  const { goChannel } = useAppNavigation();
+
   return (
     <div className="min-w-0">
       <div className="flex items-start gap-3">
@@ -258,26 +263,34 @@ function AgentSummary({
           </div>
           {channelNames.length > 0 ? (
             <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-              {channelNames.map((name) => (
+              {channelNames.map((channel) => (
                 <Badge
-                  className="normal-case tracking-normal"
-                  key={name}
+                  className="cursor-pointer normal-case tracking-normal hover:opacity-80"
+                  key={channel.id}
                   variant="outline"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void goChannel(channel.id);
+                  }}
                 >
-                  # {name}
+                  # {channel.name}
                 </Badge>
               ))}
             </div>
           ) : null}
           {activeWorkingChannels.length > 0 ? (
             <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-              {activeWorkingChannels.map((name) => (
+              {activeWorkingChannels.map((channel) => (
                 <Badge
-                  className="motion-safe:animate-pulse normal-case tracking-normal"
-                  key={`working-${name}`}
+                  className="cursor-pointer motion-safe:animate-pulse normal-case tracking-normal hover:opacity-80"
+                  key={`working-${channel.id}`}
                   variant="default"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void goChannel(channel.id);
+                  }}
                 >
-                  Working in #{name}
+                  Working in #{channel.name}
                 </Badge>
               ))}
             </div>

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -273,7 +273,7 @@ function AgentSummary({
             <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
               {activeWorkingChannels.map((name) => (
                 <Badge
-                  className="animate-pulse normal-case tracking-normal"
+                  className="motion-safe:animate-pulse normal-case tracking-normal"
                   key={`working-${name}`}
                   variant="default"
                 >

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -277,7 +277,7 @@ function AgentSummary({
                   key={`working-${name}`}
                   variant="default"
                 >
-                  Working in # {name}
+                  Working in #{name}
                 </Badge>
               ))}
             </div>

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -37,6 +37,7 @@ type UnifiedAgentsSectionProps = {
   actionErrorMessage: string | null;
   actionNoticeMessage: string | null;
   agents: ManagedAgent[];
+  channelIdToName: Record<string, string>;
   channelsByPubkey: Record<string, string[]>;
   agentsError: Error | null;
   isActionPending: boolean;
@@ -109,6 +110,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     actionErrorMessage,
     actionNoticeMessage,
     agents,
+    channelIdToName,
     channelsByPubkey,
     agentsError,
     isActionPending,
@@ -177,6 +179,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
   const isLoading = isAgentsLoading || isPersonasLoading;
 
   const rowProps = {
+    channelIdToName,
     channelsByPubkey,
     isActionPending,
     logContent,

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -38,7 +38,7 @@ type UnifiedAgentsSectionProps = {
   actionNoticeMessage: string | null;
   agents: ManagedAgent[];
   channelIdToName: Record<string, string>;
-  channelsByPubkey: Record<string, string[]>;
+  channelsByPubkey: Record<string, { id: string; name: string }[]>;
   agentsError: Error | null;
   isActionPending: boolean;
   isAgentsLoading: boolean;

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -13,6 +13,7 @@ import {
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
+import { useActiveAgentTurnsBridge } from "@/features/agents/activeAgentTurnsStore";
 import type {
   Channel,
   CreateManagedAgentResponse,
@@ -64,6 +65,7 @@ export function useManagedAgentActions() {
     [managedAgentsQuery.data],
   );
   useManagedAgentObserverBridge(managedAgents);
+  useActiveAgentTurnsBridge(managedAgents);
 
   const managedPubkeys = React.useMemo(
     () => new Set(managedAgents.map((agent) => agent.pubkey)),
@@ -102,6 +104,14 @@ export function useManagedAgentActions() {
     }
     return map;
   }, [relayAgentsQuery.data, channelsQuery.data, managedAgents]);
+
+  const channelIdToName = React.useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const ch of channelsQuery.data ?? []) {
+      map[ch.id] = ch.name;
+    }
+    return map;
+  }, [channelsQuery.data]);
 
   // Clear log selection if the agent was removed
   React.useEffect(() => {
@@ -323,6 +333,7 @@ export function useManagedAgentActions() {
     // Derived state
     managedAgents,
     managedPubkeys,
+    channelIdToName,
     channelsByPubkey,
     isPending,
     // UI state

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -80,11 +80,14 @@ export function useManagedAgentActions() {
   const managedPresenceQuery = usePresenceQuery(managedPubkeyList);
 
   const channelsByPubkey = React.useMemo(() => {
-    const map: Record<string, string[]> = {};
+    const map: Record<string, { id: string; name: string }[]> = {};
     // Seed from relay agent profiles (kind:10100 events).
     for (const ra of relayAgentsQuery.data ?? []) {
       if (ra.channels.length > 0) {
-        map[normalizePubkey(ra.pubkey)] = ra.channels;
+        map[normalizePubkey(ra.pubkey)] = ra.channels.map((name, i) => ({
+          id: ra.channelIds[i] ?? name,
+          name,
+        }));
       }
     }
     // Fill in from channel member lists (kind:39002) for any managed agents
@@ -97,8 +100,8 @@ export function useManagedAgentActions() {
         const key = normalizePubkey(pk);
         if (!normalizedManaged.has(key)) continue;
         if (!map[key]) map[key] = [];
-        if (!map[key].includes(ch.name)) {
-          map[key].push(ch.name);
+        if (!map[key].some((entry) => entry.id === ch.id)) {
+          map[key].push({ id: ch.id, name: ch.name });
         }
       }
     }

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -84,10 +84,14 @@ export function useManagedAgentActions() {
     // Seed from relay agent profiles (kind:10100 events).
     for (const ra of relayAgentsQuery.data ?? []) {
       if (ra.channels.length > 0) {
-        map[normalizePubkey(ra.pubkey)] = ra.channels.map((name, i) => ({
-          id: ra.channelIds[i] ?? name,
-          name,
-        }));
+        // Skip entries missing a channel id rather than falling back to the
+        // name as id — a misaligned channels/channelIds pairing would otherwise
+        // produce a pill that silently navigates to a channel name as if it
+        // were an id.
+        map[normalizePubkey(ra.pubkey)] = ra.channels.flatMap((name, i) => {
+          const id = ra.channelIds[i];
+          return id ? [{ id, name }] : [];
+        });
       }
     }
     // Fill in from channel member lists (kind:39002) for any managed agents

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -5,6 +5,7 @@ import { finalizeEvent, getPublicKey } from "nostr-tools/pure";
 import { parse as yamlParse } from "yaml";
 
 import type { RelayEvent } from "@/shared/api/types";
+import { syncAgentTurnsFromEvents } from "@/features/agents/activeAgentTurnsStore";
 import {
   CUSTOM_EMOJI_SET_D_TAG,
   KIND_EMOJI_SET,
@@ -594,6 +595,11 @@ declare global {
       admitted?: boolean;
       models?: Array<{ id: string; name: string | null }>;
       denyReason?: string;
+    }) => void;
+    __BUZZ_E2E_SEED_ACTIVE_TURNS__?: (input: {
+      agentPubkey: string;
+      channelId: string;
+      turnId: string;
     }) => void;
     __BUZZ_E2E_EMIT_MOCK_READ_STATE__?: (input: {
       clientId: string;
@@ -5867,6 +5873,26 @@ export function maybeInstallE2eTauriMocks() {
     if (mesh.models !== undefined) mockMeshState.models = mesh.models;
     if (mesh.denyReason !== undefined)
       mockMeshState.denyReason = mesh.denyReason;
+  };
+  let seedTurnSeq = Date.now();
+  window.__BUZZ_E2E_SEED_ACTIVE_TURNS__ = ({
+    agentPubkey,
+    channelId,
+    turnId,
+  }) => {
+    seedTurnSeq += 1;
+    syncAgentTurnsFromEvents(agentPubkey, [
+      {
+        seq: seedTurnSeq,
+        timestamp: new Date().toISOString(),
+        kind: "turn_started",
+        agentIndex: 0,
+        channelId,
+        sessionId: null,
+        turnId,
+        payload: null,
+      },
+    ]);
   };
   const meshNodeStatus = (
     state: "off" | "running",

--- a/desktop/tests/e2e/active-turn-screenshots.spec.ts
+++ b/desktop/tests/e2e/active-turn-screenshots.spec.ts
@@ -1,0 +1,199 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const SHOTS = "test-results/active-turns";
+
+// Mock agent pubkeys (distinct from the relay agents seeded by default)
+const AGENT_PAUL = "aa".repeat(32);
+const AGENT_DUNCAN = "bb".repeat(32);
+const AGENT_THUFIR = "cc".repeat(32);
+
+// Mock channel IDs from the e2e bridge
+const CHANNEL_GENERAL = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const CHANNEL_ENGINEERING = "1c7e1c02-87bb-5e88-b2da-5a7a9432d0c9";
+
+async function waitForBridge(page: import("@playwright/test").Page) {
+  await page.waitForFunction(
+    () =>
+      typeof (window as Window & { __BUZZ_E2E_SEED_ACTIVE_TURNS__?: unknown })
+        .__BUZZ_E2E_SEED_ACTIVE_TURNS__ === "function",
+    null,
+    { timeout: 10_000 },
+  );
+}
+
+async function openAgentsView(page: import("@playwright/test").Page) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await waitForBridge(page);
+  await page.getByTestId("open-agents-view").click();
+  await expect(page.getByTestId("unified-agents-groups")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe("active turn indicator screenshots", () => {
+  test.use({ viewport: { width: 1280, height: 720 } });
+
+  test("01 — baseline: agents running but idle", async ({ page }) => {
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: AGENT_PAUL,
+          name: "Paul",
+          status: "running",
+          channelNames: ["general", "engineering"],
+        },
+        {
+          pubkey: AGENT_DUNCAN,
+          name: "Duncan",
+          status: "running",
+          channelNames: ["general", "design"],
+        },
+        {
+          pubkey: AGENT_THUFIR,
+          name: "Thufir",
+          status: "stopped",
+          channelNames: [],
+        },
+      ],
+    });
+
+    await openAgentsView(page);
+
+    const agentsSection = page.getByTestId("unified-agents-groups");
+    await expect(agentsSection).toContainText("Paul");
+    await expect(agentsSection).toContainText("Duncan");
+    await expect(agentsSection).toContainText("Thufir");
+
+    await agentsSection.screenshot({
+      path: `${SHOTS}/01-baseline-idle.png`,
+    });
+  });
+
+  test("02 — single agent working in one channel", async ({ page }) => {
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: AGENT_PAUL,
+          name: "Paul",
+          status: "running",
+          channelNames: ["general", "engineering"],
+        },
+        {
+          pubkey: AGENT_DUNCAN,
+          name: "Duncan",
+          status: "running",
+          channelNames: ["general", "design"],
+        },
+        {
+          pubkey: AGENT_THUFIR,
+          name: "Thufir",
+          status: "stopped",
+          channelNames: [],
+        },
+      ],
+    });
+
+    await openAgentsView(page);
+    await waitForBridge(page);
+
+    // Seed Paul as actively working in #general
+    await page.evaluate(
+      ({ pubkey, channelId }) => {
+        const win = window as Window & {
+          __BUZZ_E2E_SEED_ACTIVE_TURNS__?: (input: {
+            agentPubkey: string;
+            channelId: string;
+            turnId: string;
+          }) => void;
+        };
+        win.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+          agentPubkey: pubkey,
+          channelId,
+          turnId: "turn-001",
+        });
+      },
+      { pubkey: AGENT_PAUL, channelId: CHANNEL_GENERAL },
+    );
+
+    // Wait for the "Working" badge to appear
+    await expect(page.getByTestId(`managed-agent-${AGENT_PAUL}`)).toContainText(
+      "Working",
+      { timeout: 5_000 },
+    );
+
+    const agentsSection = page.getByTestId("unified-agents-groups");
+    await agentsSection.screenshot({
+      path: `${SHOTS}/02-single-agent-working.png`,
+    });
+  });
+
+  test("03 — mixed states: one working in 2 channels, one idle, one stopped", async ({
+    page,
+  }) => {
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: AGENT_PAUL,
+          name: "Paul",
+          status: "running",
+          channelNames: ["general", "engineering"],
+        },
+        {
+          pubkey: AGENT_DUNCAN,
+          name: "Duncan",
+          status: "running",
+          channelNames: ["general", "design"],
+        },
+        {
+          pubkey: AGENT_THUFIR,
+          name: "Thufir",
+          status: "stopped",
+          channelNames: [],
+        },
+      ],
+    });
+
+    await openAgentsView(page);
+    await waitForBridge(page);
+
+    // Seed Paul as working in both #general and #engineering
+    await page.evaluate(
+      ({ pubkey, channels }) => {
+        const win = window as Window & {
+          __BUZZ_E2E_SEED_ACTIVE_TURNS__?: (input: {
+            agentPubkey: string;
+            channelId: string;
+            turnId: string;
+          }) => void;
+        };
+        for (const { channelId, turnId } of channels) {
+          win.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+            agentPubkey: pubkey,
+            channelId,
+            turnId,
+          });
+        }
+      },
+      {
+        pubkey: AGENT_PAUL,
+        channels: [
+          { channelId: CHANNEL_GENERAL, turnId: "turn-002" },
+          { channelId: CHANNEL_ENGINEERING, turnId: "turn-003" },
+        ],
+      },
+    );
+
+    // Wait for the "Working" indicators to appear
+    await expect(page.getByTestId(`managed-agent-${AGENT_PAUL}`)).toContainText(
+      "Working",
+      { timeout: 5_000 },
+    );
+
+    const agentsSection = page.getByTestId("unified-agents-groups");
+    await agentsSection.screenshot({
+      path: `${SHOTS}/03-mixed-states.png`,
+    });
+  });
+});


### PR DESCRIPTION
Surface per-channel "Working in #channel" indicators in the Agents Menu so users can see at a glance which agents are actively working and where — without navigating to each channel individually.

## Problem

The Agents Menu shows process state (running/stopped) and presence (online/offline), but not cognitive state. Users cannot tell whether an agent is in the middle of a turn without opening each channel and checking the activity panel.

## Solution

Two-layer approach:

**Backend (ACP harness):** A `TurnCompletionGuard` scope guard in `run_prompt_task()` emits `turn_completed` on every exit path (success, error, timeout, cancel, panic) via its `Drop` impl. This is symmetric with the existing `turn_started` emit at the top of the function — every turn that starts is guaranteed to complete in the observer stream. The `Drop` payload is `{}` because the guard cannot know the actual outcome on the drop path.

**Desktop (derived store + UI):**
- `activeAgentTurnsStore.ts` — subscribes to the observer relay store and maintains a `Map<agentPubkey, Map<turnId, ActiveTurn>>` of active turns. Turns become active on `turn_started` and inactive on `turn_completed` / `turn_error` / `agent_panic`. A 90-second inactivity timeout prunes turns whose completion event was missed (checked every 5s).
- `AgentStatusBadge` gains a pulsing "Working" variant that takes priority over "running".
- `ManagedAgentRow` renders "Working in #channel-name" badges (max 3) below channel membership badges.
- All channel badges (both active "Working in" and static membership) are clickable, navigating to the respective channel on click.

## Event ordering: composite watermark

The store dedups observer events with a composite `(timestamp, seq)` watermark per agent, reusing the `compareObserverEvents` comparator from `observerRelayStore`. Every event kind is gated on the watermark uniformly — an event is processed only if it is strictly newer than the last one seen.

- **All event kinds are gated identically.** Starts, activity, and evictions (`turn_completed` / `turn_error` / `agent_panic`) all skip equal-or-older events, so full-buffer replays are a complete no-op given the sorted-buffer invariant.
- **Post-restart streams are handled for free**: the harness resets `seq` to 1 on restart, but wall-clock `timestamp` keeps climbing, so the comparator accepts post-restart events without any `seq === 1` special case.
- **Why evictions are gated too.** The harness emits `turn_error` / `agent_panic` with a null `turnId`, so the store falls back to deleting the first turn matching the channel. Processing such an eviction unconditionally on replay would re-run that channel-match fallback and delete the live turn whose start event is below the watermark. Gating evictions on the watermark closes that hole. Resurrection is not a risk: it would require reprocessing a stale start, which the watermark already blocks.

## Exported API

| Export | Purpose |
|--------|---------|
| `useActiveAgentTurns(pubkey)` | Hook: returns `Set<channelId>` where agent has active turns |
| `useActiveAgentTurnsBridge(agents)` | Bridge hook: syncs observer events into the store |
| `getActiveChannelsForAgent(pubkey)` | Snapshot accessor (for non-React consumers) |
| `subscribeActiveAgentTurns(listener)` | External store subscription |
| `syncAgentTurnsFromEvents(pubkey, events)` | Imperative sync (used by bridge) |
| `resetActiveAgentTurnsStore()` | Test utility |

## Design decisions

- **Scope guard over manual emits:** `TurnCompletionGuard` covers all exit paths structurally (including panics) without requiring each error handler to remember to emit.
- **Observer-based over typing indicators:** Typing indicators (kind:20002) have an 8s TTL that causes flicker. The observer stream provides explicit start/end signals and is already encrypted to the agent owner.
- **90s prune timeout:** Safety net for missed completion events. Activity (`acp_read` / `acp_write`) refreshes `lastActivityAt` only for the matching `turnId`, so unrelated agent activity does not prevent expiry.
- **MAX_TURNS_PER_AGENT = 4:** Matches the ACP pool size. Oldest turn is evicted if exceeded.
- **`endTurn` channelId fallback:** If `turn_completed` arrives without a `turnId` (legacy path), falls back to removing the first turn matching the `channelId`.
- **Clickable badges:** Both "Working in #channel" and static channel membership badges navigate to the channel on click via `goChannel(id)`. `stopPropagation()` prevents triggering the parent row expand.

Replaces #994 (which was opened from a fork); identical change set, head on `block/buzz`.


