### PR TITLE
ci: add fork guards to docker, release, and auto-tag workflows

### DIFF
--- a/.github/workflows/auto-tag-on-release-pr-merge.yml
+++ b/.github/workflows/auto-tag-on-release-pr-merge.yml
@@ -13,7 +13,8 @@ jobs:
   auto-tag:
     if: >
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'version-bump/')
+      startsWith(github.event.pull_request.head.ref, 'version-bump/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -132,7 +132,7 @@ jobs:
           cache-from: |
             type=registry,ref=${{ env.IMAGE_NAME }}-buildcache:${{ matrix.arch }}
           cache-to: |
-            type=registry,ref=${{ env.IMAGE_NAME }}-buildcache:${{ matrix.arch }},mode=max,compression=zstd
+            ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref={0}-buildcache:{1},mode=max,compression=zstd', env.IMAGE_NAME, matrix.arch) || '' }}
 
       - name: Export digest
         if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   release:
     name: Release
+    if: github.repository == 'block/sprout'
     runs-on: macos-latest
     timeout-minutes: 60
     permissions:
@@ -261,6 +262,7 @@ jobs:
 
   release-macos-x64:
     name: Release macOS (Intel)
+    if: github.repository == 'block/sprout'
     runs-on: macos-latest
     needs: release
     timeout-minutes: 60
@@ -366,6 +368,7 @@ jobs:
 
   release-linux:
     name: Release Linux
+    if: github.repository == 'block/sprout'
     runs-on: ubuntu-latest
     needs: release
     timeout-minutes: 60


### PR DESCRIPTION
Hardens three GitHub Actions workflows against fork PRs that could consume secrets or trigger privileged operations.

This is a public OSS repo — fork PRs run on the upstream repo's infrastructure and can access secrets that aren't explicitly gated. Two of the affected workflows have `contents: write` and signing credentials; one has GHCR push access.

- `docker.yml`: the `build` job's `cache-to` was unconditional, so fork PRs would attempt a registry push to `ghcr.io/block/buzz-buildcache` after skipping login, producing an auth error. Now `cache-to` evaluates to an empty string for fork PRs (build still runs, no cache write).
- `release.yml`: adds `if: github.repository == 'block/sprout'` to all three jobs as defense-in-depth. The workflow is tag/dispatch-only so forks can't normally trigger it, but the guard makes intent explicit.
- `auto-tag-on-release-pr-merge.yml`: the `if` condition checked the branch name but not the PR origin. A fork PR named `version-bump/X.Y.Z` merged by a maintainer would have created a version tag and triggered a full release build. Added `github.event.pull_request.head.repo.full_name == github.repository` to the condition.