### PR TITLE
feat(release): all-OS desktop builds + universal auto-update manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -559,10 +559,12 @@ jobs:
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
 
       - name: Install desktop dependencies
+        shell: bash
         run: just desktop-install-ci
 
       - name: Add Rust target
-        run: rustup target add "$env:TARGET"
+        shell: bash
+        run: rustup target add "$TARGET"
 
       - name: Patch version
         shell: bash
@@ -665,12 +667,17 @@ jobs:
           persist-credentials: false
 
       - name: Write signature files
+        env:
+          SIG_ARM64: ${{ needs.release.outputs.sig }}
+          SIG_X64: ${{ needs.release-macos-x64.outputs.sig }}
+          SIG_LINUX: ${{ needs.release-linux.outputs.sig }}
+          SIG_WIN: ${{ needs.release-windows.outputs.sig }}
         run: |
           mkdir -p /tmp/sigs
-          echo '${{ needs.release.outputs.sig }}' > /tmp/sigs/darwin-aarch64.sig
-          echo '${{ needs.release-macos-x64.outputs.sig }}' > /tmp/sigs/darwin-x86_64.sig
-          echo '${{ needs.release-linux.outputs.sig }}' > /tmp/sigs/linux-x86_64.sig
-          echo '${{ needs.release-windows.outputs.sig }}' > /tmp/sigs/windows-x86_64.sig
+          echo "$SIG_ARM64" > /tmp/sigs/darwin-aarch64.sig
+          echo "$SIG_X64" > /tmp/sigs/darwin-x86_64.sig
+          echo "$SIG_LINUX" > /tmp/sigs/linux-x86_64.sig
+          echo "$SIG_WIN" > /tmp/sigs/windows-x86_64.sig
 
       - name: Verify archive URLs are accessible
         run: |
@@ -683,10 +690,19 @@ jobs:
             "${{ needs.release-linux.outputs.archive_name }}" \
             "${{ needs.release-windows.outputs.archive_name }}"; do
             echo "Checking $BASE/$name ..."
-            curl -fsI "$BASE/$name" > /dev/null || {
-              echo "::error::Archive not yet accessible: $BASE/$name"
+            success=false
+            for attempt in 1 2 3; do
+              if curl -fsI "$BASE/$name" > /dev/null 2>&1; then
+                success=true
+                break
+              fi
+              echo "Attempt $attempt failed for $name, retrying in 10s..."
+              sleep 10
+            done
+            if [ "$success" != "true" ]; then
+              echo "::error::Archive not accessible after 3 attempts: $BASE/$name"
               exit 1
-            }
+            fi
           done
           echo "All archive URLs verified."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -647,3 +647,66 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCHIVE_PATH: ${{ steps.artifacts.outputs.archive }}
           SIG_PATH: ${{ steps.artifacts.outputs.sig }}
+
+  assemble-manifest:
+    name: Assemble multi-platform latest.json
+    runs-on: ubuntu-latest
+    needs: [release, release-macos-x64, release-linux, release-windows]
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event_name == 'push' && github.ref || inputs.ref }}
+          persist-credentials: false
+
+      - name: Write signature files
+        run: |
+          mkdir -p /tmp/sigs
+          echo '${{ needs.release.outputs.sig }}' > /tmp/sigs/darwin-aarch64.sig
+          echo '${{ needs.release-macos-x64.outputs.sig }}' > /tmp/sigs/darwin-x86_64.sig
+          echo '${{ needs.release-linux.outputs.sig }}' > /tmp/sigs/linux-x86_64.sig
+          echo '${{ needs.release-windows.outputs.sig }}' > /tmp/sigs/windows-x86_64.sig
+
+      - name: Verify archive URLs are accessible
+        run: |
+          set -euo pipefail
+          BASE="https://github.com/block/buzz/releases/download/buzz-desktop-latest"
+
+          for name in \
+            "${{ needs.release.outputs.archive_name }}" \
+            "${{ needs.release-macos-x64.outputs.archive_name }}" \
+            "${{ needs.release-linux.outputs.archive_name }}" \
+            "${{ needs.release-windows.outputs.archive_name }}"; do
+            echo "Checking $BASE/$name ..."
+            curl -fsI "$BASE/$name" > /dev/null || {
+              echo "::error::Archive not yet accessible: $BASE/$name"
+              exit 1
+            }
+          done
+          echo "All archive URLs verified."
+
+      - name: Generate unified latest.json
+        run: |
+          BASE="https://github.com/block/buzz/releases/download/buzz-desktop-latest"
+
+          bash desktop/scripts/generate-oss-latest-json.sh "$VERSION" \
+            "darwin-aarch64:/tmp/sigs/darwin-aarch64.sig:${BASE}/${{ needs.release.outputs.archive_name }}" \
+            "darwin-x86_64:/tmp/sigs/darwin-x86_64.sig:${BASE}/${{ needs.release-macos-x64.outputs.archive_name }}" \
+            "linux-x86_64:/tmp/sigs/linux-x86_64.sig:${BASE}/${{ needs.release-linux.outputs.archive_name }}" \
+            "windows-x86_64:/tmp/sigs/windows-x86_64.sig:${BASE}/${{ needs.release-windows.outputs.archive_name }}" \
+            > latest.json
+          cat latest.json
+
+      - name: Upload latest.json to rolling release
+        run: |
+          gh release create buzz-desktop-latest \
+            --prerelease \
+            --title "Buzz Desktop Auto-Update" \
+            --notes "Rolling release for the Tauri auto-updater. Do not download manually — use the versioned release instead." \
+            2>/dev/null || true
+          gh release upload buzz-desktop-latest latest.json --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       id-token: write # required by block/apple-codesign-action for OIDC
     outputs:
       version: ${{ steps.version.outputs.version }}
+      archive_name: ${{ steps.artifacts.outputs.archive_name }}
+      sig: ${{ steps.read-sig.outputs.sig }}
     steps:
       - name: Determine version
         id: version
@@ -68,7 +70,7 @@ jobs:
         run: cd desktop && node scripts/build-release-config.mjs
         env:
           BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
-          BUZZ_UPDATER_ENDPOINT: https://github.com/block/sprout/releases/download/buzz-desktop-latest/latest.json
+          BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
 
       - name: Build sidecars
         run: |
@@ -119,7 +121,7 @@ jobs:
         run: cd desktop && pnpm tauri build --verbose --no-sign --config src-tauri/tauri.release.conf.json
         env:
           BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
-          BUZZ_UPDATER_ENDPOINT: https://github.com/block/sprout/releases/download/buzz-desktop-latest/latest.json
+          BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
@@ -209,18 +211,11 @@ jobs:
           echo "archive_name=$(basename "$ARCHIVE")" >> "$GITHUB_OUTPUT"
           echo "sig=$SIG" >> "$GITHUB_OUTPUT"
 
-      - name: Generate latest.json
-        run: |
-          bash desktop/scripts/generate-oss-latest-json.sh \
-            "$VERSION" \
-            "$SIG_PATH" \
-            "https://github.com/block/sprout/releases/download/buzz-desktop-latest/$ARCHIVE_NAME" \
-            > latest.json
-          cat latest.json
+      - name: Read updater signature
+        id: read-sig
+        run: echo "sig=$(cat "$SIG_PATH")" >> "$GITHUB_OUTPUT"
         env:
-          VERSION: ${{ steps.version.outputs.version }}
           SIG_PATH: ${{ steps.artifacts.outputs.sig }}
-          ARCHIVE_NAME: ${{ steps.artifacts.outputs.archive_name }}
 
       - name: Create versioned GitHub release
         env:
@@ -242,7 +237,7 @@ jobs:
             --notes "$NOTES" \
             "$DMG_PATH"
 
-      - name: Update rolling release for auto-updater
+      - name: Upload updater archive to rolling release
         run: |
           gh release create buzz-desktop-latest \
             --prerelease \
@@ -250,7 +245,6 @@ jobs:
             --notes "Rolling release for the Tauri auto-updater. Do not download manually — use the versioned release instead." \
             2>/dev/null || true
           gh release upload buzz-desktop-latest \
-            latest.json \
             "$ARCHIVE_PATH" \
             "$SIG_PATH" \
             --clobber
@@ -267,6 +261,9 @@ jobs:
     permissions:
       contents: write
       id-token: write # required by block/apple-codesign-action for OIDC
+    outputs:
+      archive_name: ${{ steps.artifacts.outputs.archive_name }}
+      sig: ${{ steps.read-sig.outputs.sig }}
     env:
       VERSION: ${{ needs.release.outputs.version }}
       TARGET: x86_64-apple-darwin
@@ -293,7 +290,7 @@ jobs:
         run: cd desktop && node scripts/build-release-config.mjs
         env:
           BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
-          BUZZ_UPDATER_ENDPOINT: https://github.com/block/sprout/releases/download/buzz-desktop-latest/latest.json
+          BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
 
       - name: Build sidecars
         run: |
@@ -304,7 +301,7 @@ jobs:
         run: cd desktop && pnpm tauri build --verbose --no-sign --target "$TARGET" --config src-tauri/tauri.release.conf.json
         env:
           BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
-          BUZZ_UPDATER_ENDPOINT: https://github.com/block/sprout/releases/download/buzz-desktop-latest/latest.json
+          BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
@@ -332,11 +329,13 @@ jobs:
           entitlements-plist-path: desktop/src-tauri/Entitlements.plist
           artifact-name: buzz-${{ github.sha }}-${{ github.run_id }}-x64
 
-      - name: Replace DMG and signed .app
+      - name: Replace DMG and rebuild updater archive
         env:
           SIGNED_DMG: ${{ steps.codesign.outputs.signed-dmg-path }}
           SIGNED_APP_ZIP: ${{ steps.codesign.outputs.signed-artifact-path }}
           UNSIGNED_DMG: ${{ steps.unsigned.outputs.dmg }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           APP_DIR="desktop/src-tauri/target/${TARGET}/release/bundle/macos"
@@ -344,13 +343,18 @@ jobs:
           # Replace the unsigned DMG with the signed/notarized one.
           cp "$SIGNED_DMG" "$UNSIGNED_DMG"
 
-          # Swap the unsigned .app for the signed .app from the action's zip,
-          # so the verify step below checks the signed bundle (matches arm64).
+          # Swap the unsigned .app for the signed .app from the action's zip.
           EXTRACT_DIR="${RUNNER_TEMP}/signed-app-extract-x64"
           rm -rf "$EXTRACT_DIR" && mkdir -p "$EXTRACT_DIR"
           ditto -x -k "$SIGNED_APP_ZIP" "$EXTRACT_DIR"
           rm -rf "${APP_DIR}/Buzz.app"
           cp -R "${EXTRACT_DIR}/Buzz.app" "${APP_DIR}/Buzz.app"
+
+          # Rebuild the updater archive from the signed .app and re-sign with the Tauri updater key.
+          rm -f "${APP_DIR}/Buzz.app.tar.gz" "${APP_DIR}/Buzz.app.tar.gz.sig"
+          (cd "$APP_DIR" && tar -czf Buzz.app.tar.gz Buzz.app)
+          TARBALL_ABS="$(pwd)/${APP_DIR}/Buzz.app.tar.gz"
+          (cd desktop && pnpm tauri signer sign "$TARBALL_ABS")
 
       - name: Verify code signature
         run: |
@@ -358,11 +362,43 @@ jobs:
           codesign --verify --deep --strict --verbose=2 "$APP_DIR"
           spctl --assess --type execute --verbose=4 "$APP_DIR"
 
+      - name: Locate updater archive
+        id: artifacts
+        run: |
+          BUNDLE_DIR="desktop/src-tauri/target/${TARGET}/release/bundle"
+
+          ARCHIVE=$(find "$BUNDLE_DIR/macos" -name '*.tar.gz' ! -name '*.sig' -type f | head -1)
+          SIG="${ARCHIVE}.sig"
+          if [[ -z "$ARCHIVE" || ! -f "$SIG" ]]; then
+            echo "::error::Updater archive or signature not found in $BUNDLE_DIR/macos"
+            exit 1
+          fi
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+          echo "archive_name=$(basename "$ARCHIVE")" >> "$GITHUB_OUTPUT"
+          echo "sig=$SIG" >> "$GITHUB_OUTPUT"
+
+      - name: Read updater signature
+        id: read-sig
+        run: echo "sig=$(cat "$SIG_PATH")" >> "$GITHUB_OUTPUT"
+        env:
+          SIG_PATH: ${{ steps.artifacts.outputs.sig }}
+
       - name: Upload Intel DMG to versioned GitHub release
         run: gh release upload "v${VERSION}" "$DMG_PATH" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DMG_PATH: ${{ steps.unsigned.outputs.dmg }}
+
+      - name: Upload updater archive to rolling release
+        run: |
+          gh release upload buzz-desktop-latest \
+            "$ARCHIVE_PATH" \
+            "$SIG_PATH" \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCHIVE_PATH: ${{ steps.artifacts.outputs.archive }}
+          SIG_PATH: ${{ steps.artifacts.outputs.sig }}
 
   release-linux:
     name: Release Linux
@@ -371,6 +407,9 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write
+    outputs:
+      archive_name: ${{ steps.linux-artifacts.outputs.archive_name }}
+      sig: ${{ steps.read-sig.outputs.sig }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -425,10 +464,18 @@ jobs:
           cargo build --release -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
           ./scripts/bundle-sidecars.sh
 
+      - name: Generate release config
+        run: cd desktop && node scripts/build-release-config.mjs
+        env:
+          BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
+          BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
+
       - name: Build Linux Tauri app
-        run: cd desktop && pnpm tauri build --verbose --ci --bundles deb,appimage
+        run: cd desktop && pnpm tauri build --verbose --ci --bundles deb,appimage --config src-tauri/tauri.release.conf.json
         env:
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       - name: Locate Linux build artifacts
         id: linux-artifacts
@@ -449,6 +496,24 @@ jobs:
           fi
           echo "appimage=$APPIMAGE" >> "$GITHUB_OUTPUT"
 
+          # Updater archive: Tauri emits <name>.AppImage.tar.gz + .sig when signing is enabled
+          ARCHIVE=$(find "$BUNDLE_DIR/appimage" -name '*.AppImage.tar.gz' ! -name '*.sig' -type f | head -1)
+          SIG="${ARCHIVE}.sig"
+          if [[ -z "$ARCHIVE" || ! -f "$SIG" ]]; then
+            echo "::error::AppImage updater archive or signature not found in $BUNDLE_DIR/appimage"
+            exit 1
+          fi
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+          echo "archive_name=$(basename "$ARCHIVE")" >> "$GITHUB_OUTPUT"
+          echo "sig=$SIG" >> "$GITHUB_OUTPUT"
+
+      - name: Read updater signature
+        id: read-sig
+        run: echo "sig=$(cat "$SIG_PATH")" >> "$GITHUB_OUTPUT"
+        env:
+          SIG_PATH: ${{ steps.linux-artifacts.outputs.sig }}
+
+      # NOTE: .deb is NOT auto-updatable (Tauri updater constraint — only AppImage supports it on Linux)
       - name: Upload Linux artifacts to versioned GitHub release
         env:
           VERSION: ${{ needs.release.outputs.version }}
@@ -460,3 +525,125 @@ jobs:
             "$DEB_PATH" \
             "$APPIMAGE_PATH" \
             --clobber
+
+      - name: Upload updater archive to rolling release
+        run: |
+          gh release upload buzz-desktop-latest \
+            "$ARCHIVE_PATH" \
+            "$SIG_PATH" \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCHIVE_PATH: ${{ steps.linux-artifacts.outputs.archive }}
+          SIG_PATH: ${{ steps.linux-artifacts.outputs.sig }}
+
+  release-windows:
+    name: Release Windows
+    runs-on: windows-latest
+    needs: release
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    outputs:
+      archive_name: ${{ steps.artifacts.outputs.archive_name }}
+      sig: ${{ steps.read-sig.outputs.sig }}
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+      TARGET: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event_name == 'push' && github.ref || inputs.ref }}
+          persist-credentials: false
+
+      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+
+      - name: Install desktop dependencies
+        run: just desktop-install-ci
+
+      - name: Add Rust target
+        run: rustup target add "$env:TARGET"
+
+      - name: Patch version
+        shell: bash
+        run: |
+          cd desktop && node scripts/set-version-from-tag.mjs "$VERSION"
+          cd src-tauri && cargo update --workspace
+
+      - name: Generate release config
+        shell: bash
+        run: cd desktop && node scripts/build-release-config.mjs
+        env:
+          BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
+          BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
+
+      - name: Build sidecars
+        shell: bash
+        run: |
+          cargo build --release --target "$TARGET" -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          ./scripts/bundle-sidecars.sh "$TARGET"
+
+      - name: Build Windows NSIS installer (unsigned)
+        shell: bash
+        run: cd desktop && pnpm tauri build --verbose --target "$TARGET" --bundles nsis --config src-tauri/tauri.release.conf.json
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+
+      - name: Locate Windows build artifacts
+        id: artifacts
+        shell: bash
+        run: |
+          BUNDLE_DIR="desktop/src-tauri/target/${TARGET}/release/bundle"
+
+          # Find the NSIS installer .exe
+          EXE=$(find "$BUNDLE_DIR/nsis" -name '*.exe' -type f | head -1)
+          if [[ -z "$EXE" ]]; then
+            echo "::error::No NSIS installer found in $BUNDLE_DIR/nsis"
+            exit 1
+          fi
+
+          # Rename with _alpha-unsigned marker
+          EXE_DIR=$(dirname "$EXE")
+          EXE_BASE=$(basename "$EXE" .exe)
+          MARKED_EXE="${EXE_DIR}/${EXE_BASE}_alpha-unsigned.exe"
+          mv "$EXE" "$MARKED_EXE"
+          echo "exe=$MARKED_EXE" >> "$GITHUB_OUTPUT"
+
+          # Find the updater .nsis.zip and .sig
+          ARCHIVE=$(find "$BUNDLE_DIR/nsis" -name '*.nsis.zip' ! -name '*.sig' -type f | head -1)
+          SIG="${ARCHIVE}.sig"
+          if [[ -z "$ARCHIVE" || ! -f "$SIG" ]]; then
+            echo "::error::NSIS updater archive or signature not found in $BUNDLE_DIR/nsis"
+            exit 1
+          fi
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+          echo "archive_name=$(basename "$ARCHIVE")" >> "$GITHUB_OUTPUT"
+          echo "sig=$SIG" >> "$GITHUB_OUTPUT"
+
+      - name: Read updater signature
+        id: read-sig
+        shell: bash
+        run: echo "sig=$(cat "$SIG_PATH")" >> "$GITHUB_OUTPUT"
+        env:
+          SIG_PATH: ${{ steps.artifacts.outputs.sig }}
+
+      - name: Upload Windows installer to versioned GitHub release
+        shell: bash
+        run: gh release upload "v${VERSION}" "$EXE_PATH" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXE_PATH: ${{ steps.artifacts.outputs.exe }}
+
+      - name: Upload updater archive to rolling release
+        shell: bash
+        run: |
+          gh release upload buzz-desktop-latest \
+            "$ARCHIVE_PATH" \
+            "$SIG_PATH" \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCHIVE_PATH: ${{ steps.artifacts.outputs.archive }}
+          SIG_PATH: ${{ steps.artifacts.outputs.sig }}

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -58,9 +58,6 @@ hex = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-# Process-group kill (safe wrapper around killpg)
-nix = { version = "0.31", default-features = false, features = ["signal"] }
-
 # Error handling
 thiserror = { workspace = true }
 anyhow = { workspace = true }
@@ -73,6 +70,11 @@ toml = "1.0"
 
 # Filter expressions
 evalexpr = { workspace = true }
+
+# Process-group kill (safe wrapper around killpg) — Unix-only; kill_process_group
+# has a #[cfg(not(unix))] fallback in acp.rs.
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", default-features = false, features = ["signal"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/git-sign-nostr/src/lib.rs
+++ b/crates/git-sign-nostr/src/lib.rs
@@ -74,6 +74,7 @@
 use std::fs;
 use std::io::{self, Read, Write};
 use std::mem::ManuallyDrop;
+#[cfg(unix)]
 use std::os::unix::io::FromRawFd;
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -338,12 +339,20 @@ impl StatusWriter {
                         eprintln!("warning: --status-fd={fd} is not a valid open fd, using stderr");
                         return Ok(Self { file: None });
                     }
+                    // SAFETY EXCEPTION: Required for Unix fd operations; no safe Rust API
+                    // exists for from_raw_fd. The fd is >= 1 (validated by parse_status_fd),
+                    // confirmed open by fcntl above, and git owns its lifetime. We use
+                    // ManuallyDrop to prevent Rust from closing the inherited fd on drop.
+                    Some(ManuallyDrop::new(unsafe { fs::File::from_raw_fd(fd) }))
                 }
-                // SAFETY EXCEPTION: Required for Unix fd operations; no safe Rust API
-                // exists for from_raw_fd. The fd is >= 1 (validated by parse_status_fd),
-                // confirmed open by fcntl above, and git owns its lifetime. We use
-                // ManuallyDrop to prevent Rust from closing the inherited fd on drop.
-                Some(ManuallyDrop::new(unsafe { fs::File::from_raw_fd(fd) }))
+                // git's --status-fd passes an inherited numeric fd, which has no
+                // equivalent on Windows. Fall back to stderr; write_line already
+                // handles the None case.
+                #[cfg(not(unix))]
+                {
+                    let _ = (fd, strict);
+                    None
+                }
             }
         };
         Ok(Self { file })

--- a/desktop/scripts/generate-oss-latest-json.sh
+++ b/desktop/scripts/generate-oss-latest-json.sh
@@ -1,21 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 3 ]]; then
-  echo "Usage: generate-oss-latest-json.sh <version> <sig-file> <archive-url>" >&2
+if [[ $# -lt 2 ]]; then
+  echo "Usage: generate-oss-latest-json.sh <version> <platform-key:sig-file:archive-url>..." >&2
+  echo "  e.g. generate-oss-latest-json.sh 1.2.3 \\" >&2
+  echo "         darwin-aarch64:/path/to/app.sig:https://example.com/app.tar.gz \\" >&2
+  echo "         windows-x86_64:/path/to/setup.sig:https://example.com/setup.exe" >&2
   exit 1
 fi
 
 VERSION="$1"
-SIG_FILE="$2"
-ARCHIVE_URL="$3"
+shift
 
-# Only darwin-aarch64 is included because the workflow builds on ARM64 runners
-# only. Supporting Intel Macs (darwin-x86_64) would require a matrix build.
+# Build the jq `platforms` object from N triples. Each triple is
+# `platform-key:sig-file:archive-url`; archive URLs contain colons, so split
+# only on the first two so the URL stays intact.
+platform_args=()
+platforms_obj="{}"
+i=0
+for triple in "$@"; do
+  key="${triple%%:*}"
+  rest="${triple#*:}"
+  sig_file="${rest%%:*}"
+  url="${rest#*:}"
+  if [[ "$key" == "$triple" || "$sig_file" == "$rest" || -z "$key" || -z "$sig_file" || -z "$url" ]]; then
+    echo "Error: malformed triple '$triple' (expected platform-key:sig-file:archive-url)" >&2
+    exit 1
+  fi
+
+  sig_arg="sig$i"
+  url_arg="url$i"
+  platform_args+=(--arg "$sig_arg" "$(cat "$sig_file")" --arg "$url_arg" "$url")
+  # Splice each platform into the accumulating object so no platform is hardcoded.
+  platforms_obj="$platforms_obj + { \"$key\": { signature: \$$sig_arg, url: \$$url_arg } }"
+  i=$((i + 1))
+done
+
 jq -n \
   --arg version "$VERSION" \
   --arg notes "Buzz v$VERSION" \
   --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --arg signature "$(cat "$SIG_FILE")" \
-  --arg url "$ARCHIVE_URL" \
-  '{ version: $version, notes: $notes, pub_date: $pub_date, platforms: { "darwin-aarch64": { signature: $signature, url: $url } } }'
+  "${platform_args[@]}" \
+  "{ version: \$version, notes: \$notes, pub_date: \$pub_date, platforms: ($platforms_obj) }"

--- a/scripts/bundle-sidecars.sh
+++ b/scripts/bundle-sidecars.sh
@@ -14,9 +14,16 @@ else
     SRC_DIR="target/${TARGET}/release"
 fi
 
+# MSVC emits <name>.exe; Tauri's externalBin then expects binaries/<name>-<triple>.exe.
+if [[ "$TARGET" == *windows* ]]; then
+    EXE=".exe"
+else
+    EXE=""
+fi
+
 missing=()
 for bin in "${SIDECARS[@]}"; do
-    [[ -f "$SRC_DIR/$bin" ]] || missing+=("$bin")
+    [[ -f "$SRC_DIR/${bin}${EXE}" ]] || missing+=("${bin}${EXE}")
 done
 if [[ ${#missing[@]} -gt 0 ]]; then
     echo "Error: missing release binaries in $SRC_DIR: ${missing[*]}" >&2
@@ -26,6 +33,6 @@ fi
 
 mkdir -p "$BINARIES_DIR"
 for bin in "${SIDECARS[@]}"; do
-    cp "$SRC_DIR/$bin" "$BINARIES_DIR/${bin}-${TARGET}"
+    cp "$SRC_DIR/${bin}${EXE}" "$BINARIES_DIR/${bin}-${TARGET}${EXE}"
 done
 echo "Sidecars bundled for $TARGET"


### PR DESCRIPTION
## What

Adds Windows, Linux AppImage, and macOS Intel updater support to the desktop release workflow, with a unified multi-platform auto-update manifest.

## Why

The release workflow previously only produced auto-update artifacts for macOS arm64. Other platforms (macOS Intel, Linux, Windows) either lacked updater archives entirely or built them without exposing/uploading them. The `latest.json` manifest was produced solely by the arm64 job, publishing before other platform jobs completed — meaning it could advertise URLs for assets that didn't exist yet.

## How

**Phase 0 — Windows cross-compile source fixes** (`crates/git-sign-nostr/src/lib.rs`, `crates/buzz-acp/Cargo.toml`): Gates Unix-only imports behind `#[cfg(unix)]` and moves the `nix` dependency to `[target.'cfg(unix)'.dependencies]` so all five sidecars pass `cargo check --target x86_64-pc-windows-msvc`.

**Phase 1 — Sidecar bundling** (`scripts/bundle-sidecars.sh`): Handles `.exe` suffix for Windows targets in both the existence check and the copy destination.

**Phase 2 — Manifest generator** (`desktop/scripts/generate-oss-latest-json.sh`): Generalized to accept N `platform-key:sig-file:archive-url` triples instead of hardcoding a single platform.

**Phase 3 — Per-platform updater artifacts + Windows build** (`.github/workflows/release.yml`):
- macOS Intel: locates and uploads the updater archive + signature (already built but never exposed)
- Linux: adds `TAURI_SIGNING_PRIVATE_KEY` so Tauri emits a signed AppImage updater archive
- Windows: new `release-windows` job — unsigned NSIS installer (`_alpha-unsigned` marker) with minisign-signed updater archive
- All platform jobs expose `archive_name` + `sig` as job outputs

**Phase 4 — Atomic manifest assembly** (`.github/workflows/release.yml`): New terminal `assemble-manifest` job (`needs:` all four platform jobs). Sole producer of `latest.json` — the arm64 job no longer owns the manifest. Verifies each archive URL returns HTTP 200 (with 3-attempt retry/10s backoff) before publishing. Signatures passed as job output strings to avoid artifact race conditions.

Also updates all hardcoded `block/sprout` GitHub URLs to `block/buzz` (repo rename).

## Design decisions

- **Signatures via job outputs, not artifacts** — eliminates upload/download timing windows between jobs
- **All-or-none manifest** — `needs:` DAG means if any platform fails, `latest.json` is never updated
- **Retry with backoff on URL verification** — handles GitHub CDN propagation lag without false failures
- **Env-var sig interpolation** — avoids `${{ }}` expression injection anti-pattern in shell scripts
- **Windows unsigned for alpha** — SmartScreen prompt is acceptable; minisign updater signature still verifies independently of Authenticode

## Coverage

- YAML validates (`pyyaml`)
- Pre-push hooks pass (640 desktop tests, rust tests, clippy)
- `cargo check --target x86_64-pc-windows-msvc` passes for all six sidecar crates
