### PR TITLE
fix(release): update repository name check from block/sprout to block/buzz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   release:
     name: Release
-    if: github.repository == 'block/sprout'
+    if: github.repository == 'block/buzz'
     runs-on: macos-latest
     timeout-minutes: 60
     permissions:
@@ -256,7 +256,7 @@ jobs:
 
   release-macos-x64:
     name: Release macOS (Intel)
-    if: github.repository == 'block/sprout'
+    if: github.repository == 'block/buzz'
     runs-on: macos-latest
     needs: release
     timeout-minutes: 60
@@ -404,7 +404,7 @@ jobs:
 
   release-linux:
     name: Release Linux
-    if: github.repository == 'block/sprout'
+    if: github.repository == 'block/buzz'
     runs-on: ubuntu-latest
     needs: release
     timeout-minutes: 60


### PR DESCRIPTION
The repo was renamed from `block/sprout` to `block/buzz`. The release workflow's `if:` conditions check `github.repository == 'block/sprout'`, which now evaluates to false since GitHub reports the repo as `block/buzz`. This causes all release jobs to skip silently.

Updates the three `if:` conditions (lines 20, 259, 407) to reference `'block/buzz'`.