### PR TITLE
fix(release): mark prerelease versions so they do not become latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,10 +232,15 @@ jobs:
           if [[ -z "$NOTES" ]]; then
             NOTES="Buzz Desktop v${VERSION}"
           fi
+          PRERELEASE_FLAGS=()
+          if [[ "$VERSION" =~ -(test|alpha|beta|rc)([.-]|$) ]]; then
+            PRERELEASE_FLAGS=(--prerelease --latest=false)
+          fi
           gh release create "v${VERSION}" \
             --target "$RELEASE_SHA" \
             --title "Buzz Desktop v${VERSION}" \
             --notes "$NOTES" \
+            "${PRERELEASE_FLAGS[@]}" \
             "$DMG_PATH"
 
       - name: Upload updater archive to rolling release


### PR DESCRIPTION
The versioned `gh release create` call in `.github/workflows/release.yml` relied on `gh` defaults (`make_latest=legacy`), so GitHub decided "Latest" by created-date and semver comparison. A `-test`/`-beta`/`-rc` tag (e.g. `0.0.0-test.1`) could be promoted to the public Latest release pointer because the tag was never flagged as a prerelease.

This guards the versioned release: any version whose semver contains a hyphen is treated as a prerelease and gets `--prerelease --latest=false`, so GitHub never promotes it. Stable versions (no hyphen) keep the current behavior with no extra flags.

A bash array is used instead of inline `$(...)` so the stable-release path expands to nothing — an empty `$()` would leave a stray empty argument that `gh` may reject.

The two `buzz-desktop-latest` rolling-release calls are unchanged; they were already `--prerelease`.