### PR TITLE
fix(release): replace hermit with native tool setup on Windows job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -571,6 +571,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.14.0
+          # Disable dependency caching: a writable cache in this release workflow
+          # (contents: write, feeds a signed installer) is a poisoning vector. pnpm
+          # install runs uncached below.
+          package-manager-cache: false
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -564,15 +564,21 @@ jobs:
           ref: ${{ github.event_name == 'push' && github.ref || inputs.ref }}
           persist-credentials: false
 
-      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: ${{ env.TARGET }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.14.0
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: 11.4.0
 
       - name: Install desktop dependencies
         shell: bash
-        run: just desktop-install-ci
-
-      - name: Add Rust target
-        shell: bash
-        run: rustup target add "$TARGET"
+        run: pnpm install --frozen-lockfile
 
       - name: Patch version
         shell: bash


### PR DESCRIPTION
hermit has no Windows support — its bootstrap script only branches on `Darwin` and `Linux`, so `cashapp/activate-hermit` crashes with `HERMIT_STATE_DIR_RAW: unbound variable` on `windows-latest`. The `Release Windows` job has depended on hermit for its entire toolchain since it was added, so it has never succeeded; the codesign OIDC failure earlier in the pipeline masked it until that was fixed.

This replaces `activate-hermit` in the Windows job with pinned native setup actions, matching the exact versions hermit pins:

- `dtolnay/rust-toolchain` at `1.95.0` (from `rust-toolchain.toml`), with `targets: x86_64-pc-windows-msvc` folded in — this replaces the separate `rustup target add` step.
- `actions/setup-node` at `24.14.0`.
- `pnpm/action-setup` at `11.4.0` (matches `packageManager` in `package.json`).

`just desktop-install-ci` is replaced with its one-line body, `pnpm install --frozen-lockfile`, dropping the `just` dependency entirely (`just` is itself a hermit-managed tool and was used for this single recipe).

`cmake` is left to the Windows runner's preinstalled copy; the existing `CMAKE_POLICY_VERSION_MINIMUM` env is unchanged. The macOS and Linux jobs are untouched — they use hermit correctly on supported platforms.
