### PR TITLE
chore(Pulse): gate Follow button behind Pulse feature flag

### DIFF
--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -16,7 +16,6 @@ import { useManagedAgentObserverBridge } from "@/features/agents/observerRelaySt
 import { EditAgentDialog } from "@/features/agents/ui/EditAgentDialog";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
-import { useFeatureEnabled } from "@/shared/features";
 import {
   useContactListQuery,
   useFollowMutation,
@@ -198,12 +197,6 @@ export function UserProfilePanel({
   const isSelf =
     currentPubkey !== undefined && pubkeyLower === currentPubkey.toLowerCase();
   const canViewActivity = isOwner === true && Boolean(onOpenAgentSession);
-  // The people-follow graph (kind:3) is only surfaced for consumption inside
-  // Pulse. When Pulse is off there's nowhere to consume the graph, so we hide
-  // the Follow affordance entirely rather than let users write follows that go
-  // nowhere. (Thread-following in features/messages is unrelated localStorage
-  // state and is not gated here.)
-  const showFollowAction = useFeatureEnabled("pulse");
   const isFollowing =
     !isSelf &&
     (contactListQuery.data?.contacts.some(
@@ -350,7 +343,6 @@ export function UserProfilePanel({
           profile={profile}
           pubkey={pubkey}
           relayAgent={relayAgent}
-          showFollowAction={showFollowAction}
           unfollowMutation={unfollowMutation}
           userStatus={userStatus}
         />

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -16,6 +16,7 @@ import { useManagedAgentObserverBridge } from "@/features/agents/observerRelaySt
 import { EditAgentDialog } from "@/features/agents/ui/EditAgentDialog";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
+import { useFeatureEnabled } from "@/shared/features";
 import {
   useContactListQuery,
   useFollowMutation,
@@ -197,6 +198,12 @@ export function UserProfilePanel({
   const isSelf =
     currentPubkey !== undefined && pubkeyLower === currentPubkey.toLowerCase();
   const canViewActivity = isOwner === true && Boolean(onOpenAgentSession);
+  // The people-follow graph (kind:3) is only surfaced for consumption inside
+  // Pulse. When Pulse is off there's nowhere to consume the graph, so we hide
+  // the Follow affordance entirely rather than let users write follows that go
+  // nowhere. (Thread-following in features/messages is unrelated localStorage
+  // state and is not gated here.)
+  const showFollowAction = useFeatureEnabled("pulse");
   const isFollowing =
     !isSelf &&
     (contactListQuery.data?.contacts.some(
@@ -343,6 +350,7 @@ export function UserProfilePanel({
           profile={profile}
           pubkey={pubkey}
           relayAgent={relayAgent}
+          showFollowAction={showFollowAction}
           unfollowMutation={unfollowMutation}
           userStatus={userStatus}
         />

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -88,6 +88,7 @@ export type ProfileSummaryViewProps = {
   profile: ReturnType<typeof useUserProfileQuery>["data"];
   pubkey: string;
   relayAgent: RelayAgent | undefined;
+  showFollowAction: boolean;
   unfollowMutation: ReturnType<typeof useUnfollowMutation>;
   userStatus: { text: string; emoji: string } | null | undefined;
 };
@@ -120,6 +121,7 @@ export function ProfileSummaryView({
   profile,
   pubkey,
   relayAgent,
+  showFollowAction,
   unfollowMutation,
   userStatus,
 }: ProfileSummaryViewProps) {
@@ -167,6 +169,7 @@ export function ProfileSummaryView({
           isFollowing={isFollowing}
           onMessage={onOpenDm ? handleMessage : undefined}
           pubkey={pubkey}
+          showFollowAction={showFollowAction}
           unfollowMutation={unfollowMutation}
         />
       ) : null}
@@ -420,6 +423,7 @@ function ProfilePrimaryActions({
   onEditAgent,
   onMessage,
   pubkey,
+  showFollowAction,
   unfollowMutation,
 }: {
   canEditAgent: boolean;
@@ -428,40 +432,43 @@ function ProfilePrimaryActions({
   onEditAgent: () => void;
   onMessage?: () => void;
   pubkey: string;
+  showFollowAction: boolean;
   unfollowMutation: ReturnType<typeof useUnfollowMutation>;
 }) {
   return (
     <div className="flex items-start justify-center gap-8">
-      {isFollowing ? (
-        <ProfileQuickAction
-          active
-          disabled={unfollowMutation.isPending}
-          icon={UserMinus}
-          label="Unfollow"
-          onClick={() =>
-            unfollowMutation.mutate(pubkey, {
-              onError: (error) =>
-                toast.error(
-                  `Unfollow failed: ${error instanceof Error ? error.message : String(error)}`,
-                ),
-            })
-          }
-        />
-      ) : (
-        <ProfileQuickAction
-          disabled={followMutation.isPending}
-          icon={UserPlus}
-          label="Follow"
-          onClick={() =>
-            followMutation.mutate(pubkey, {
-              onError: (error) =>
-                toast.error(
-                  `Follow failed: ${error instanceof Error ? error.message : String(error)}`,
-                ),
-            })
-          }
-        />
-      )}
+      {showFollowAction ? (
+        isFollowing ? (
+          <ProfileQuickAction
+            active
+            disabled={unfollowMutation.isPending}
+            icon={UserMinus}
+            label="Unfollow"
+            onClick={() =>
+              unfollowMutation.mutate(pubkey, {
+                onError: (error) =>
+                  toast.error(
+                    `Unfollow failed: ${error instanceof Error ? error.message : String(error)}`,
+                  ),
+              })
+            }
+          />
+        ) : (
+          <ProfileQuickAction
+            disabled={followMutation.isPending}
+            icon={UserPlus}
+            label="Follow"
+            onClick={() =>
+              followMutation.mutate(pubkey, {
+                onError: (error) =>
+                  toast.error(
+                    `Follow failed: ${error instanceof Error ? error.message : String(error)}`,
+                  ),
+              })
+            }
+          />
+        )
+      ) : null}
       {onMessage ? (
         <ProfileQuickAction
           icon={MessageSquare}

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -38,6 +38,7 @@ import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 import { BotIdenticon } from "@/features/messages/ui/BotIdenticon";
 import type { ManagedAgent, RelayAgent } from "@/shared/api/types";
+import { useFeatureEnabled } from "@/shared/features";
 import { cn } from "@/shared/lib/cn";
 import { useNow } from "@/shared/lib/useNow";
 import { Badge } from "@/shared/ui/badge";
@@ -88,7 +89,6 @@ export type ProfileSummaryViewProps = {
   profile: ReturnType<typeof useUserProfileQuery>["data"];
   pubkey: string;
   relayAgent: RelayAgent | undefined;
-  showFollowAction: boolean;
   unfollowMutation: ReturnType<typeof useUnfollowMutation>;
   userStatus: { text: string; emoji: string } | null | undefined;
 };
@@ -121,7 +121,6 @@ export function ProfileSummaryView({
   profile,
   pubkey,
   relayAgent,
-  showFollowAction,
   unfollowMutation,
   userStatus,
 }: ProfileSummaryViewProps) {
@@ -169,7 +168,6 @@ export function ProfileSummaryView({
           isFollowing={isFollowing}
           onMessage={onOpenDm ? handleMessage : undefined}
           pubkey={pubkey}
-          showFollowAction={showFollowAction}
           unfollowMutation={unfollowMutation}
         />
       ) : null}
@@ -423,7 +421,6 @@ function ProfilePrimaryActions({
   onEditAgent,
   onMessage,
   pubkey,
-  showFollowAction,
   unfollowMutation,
 }: {
   canEditAgent: boolean;
@@ -432,9 +429,15 @@ function ProfilePrimaryActions({
   onEditAgent: () => void;
   onMessage?: () => void;
   pubkey: string;
-  showFollowAction: boolean;
   unfollowMutation: ReturnType<typeof useUnfollowMutation>;
 }) {
+  // The people-follow graph (kind:3) is only surfaced for consumption inside
+  // Pulse. When Pulse is off there's nowhere to consume the graph, so we hide
+  // the Follow affordance entirely rather than let users write follows that go
+  // nowhere. (Thread-following in features/messages is unrelated localStorage
+  // state and is not gated here.)
+  const showFollowAction = useFeatureEnabled("pulse");
+
   return (
     <div className="flex items-start justify-center gap-8">
       {showFollowAction ? (

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -431,46 +431,28 @@ function ProfilePrimaryActions({
   pubkey: string;
   unfollowMutation: ReturnType<typeof useUnfollowMutation>;
 }) {
-  // The people-follow graph (kind:3) is only surfaced for consumption inside
-  // Pulse. When Pulse is off there's nowhere to consume the graph, so we hide
-  // the Follow affordance entirely rather than let users write follows that go
-  // nowhere. (Thread-following in features/messages is unrelated localStorage
-  // state and is not gated here.)
   const showFollowAction = useFeatureEnabled("pulse");
+  const followToggleMutation = isFollowing ? unfollowMutation : followMutation;
+
+  const handleFollowClick = () => {
+    followToggleMutation.mutate(pubkey, {
+      onError: (error) =>
+        toast.error(
+          `${isFollowing ? "Unfollow" : "Follow"} failed: ${error.message}`,
+        ),
+    });
+  };
 
   return (
     <div className="flex items-start justify-center gap-8">
       {showFollowAction ? (
-        isFollowing ? (
-          <ProfileQuickAction
-            active
-            disabled={unfollowMutation.isPending}
-            icon={UserMinus}
-            label="Unfollow"
-            onClick={() =>
-              unfollowMutation.mutate(pubkey, {
-                onError: (error) =>
-                  toast.error(
-                    `Unfollow failed: ${error instanceof Error ? error.message : String(error)}`,
-                  ),
-              })
-            }
-          />
-        ) : (
-          <ProfileQuickAction
-            disabled={followMutation.isPending}
-            icon={UserPlus}
-            label="Follow"
-            onClick={() =>
-              followMutation.mutate(pubkey, {
-                onError: (error) =>
-                  toast.error(
-                    `Follow failed: ${error instanceof Error ? error.message : String(error)}`,
-                  ),
-              })
-            }
-          />
-        )
+        <ProfileQuickAction
+          active={isFollowing}
+          disabled={followToggleMutation.isPending}
+          icon={isFollowing ? UserMinus : UserPlus}
+          label={isFollowing ? "Unfollow" : "Follow"}
+          onClick={handleFollowClick}
+        />
       ) : null}
       {onMessage ? (
         <ProfileQuickAction


### PR DESCRIPTION
## Overview

**Category:** `improvement`
**User Impact:** When Pulse is turned off, the Follow/Unfollow button no longer appears on user profile panels.

**Problem:** Following someone writes a Nostr kind:3 contact list, but the only thing that *consumes* that graph in the UI is Pulse (the "Following" feed filter). The Follow button on `UserProfilePanel` was ungated, so even with Pulse off, users could follow people — writing to a graph with nowhere to consume it.

**Solution:** Gate the Follow affordance behind the same `pulse` feature flag that already controls the Pulse sidebar entry and route. When Pulse is disabled, the Follow/Unfollow action is hidden entirely (option A). Message and Edit actions are unaffected.

<details>
<summary>File changes</summary>

**desktop/src/features/profile/ui/UserProfilePanel.tsx**
Computes `showFollowAction = useFeatureEnabled("pulse")` and passes it down to `ProfileSummaryView`.

**desktop/src/features/profile/ui/UserProfilePanelSections.tsx**
Threads `showFollowAction` through `ProfileSummaryView` into `ProfilePrimaryActions`, which now conditionally renders the Follow/Unfollow quick action.

</details>

## Reproduction Steps

1. Run the desktop app with the `pulse` preview feature **disabled** (default).
2. Open any user's profile panel (click a user in a channel).
3. Confirm the **Follow** button is absent; **Message** still shows.
4. Enable the `pulse` preview feature, reopen a profile panel.
5. Confirm **Follow** / **Unfollow** reappears and works as before.

## Notes

- Uses the existing `useFeatureEnabled` hook — same gating mechanism as the Pulse sidebar/route.
- The unrelated **thread-following** feature (`features/messages`, localStorage-backed, follows thread roots not pubkeys) is deliberately left untouched.
- `pnpm typecheck` and `biome lint` pass clean.