### PR TITLE
fix: repair main build after cross-PR merge skew

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3159,6 +3159,7 @@ mod error_outcome_emission_tests {
             max_turn_duration_secs: 3600,
             agents: 1,
             heartbeat_interval_secs: 0,
+            turn_liveness_secs: 10,
             heartbeat_prompt: None,
             system_prompt: None,
             initial_message: None,

--- a/desktop/src-tauri/src/commands/legacy_storage.rs
+++ b/desktop/src-tauri/src/commands/legacy_storage.rs
@@ -80,7 +80,7 @@ fn decode_webkit_local_storage_value(bytes: &[u8]) -> Option<String> {
         return Some(String::new());
     }
 
-    if bytes.len() % 2 == 0 {
+    if bytes.len().is_multiple_of(2) {
         let has_utf16_ascii_shape = bytes.chunks_exact(2).any(|chunk| chunk[1] == 0);
         if has_utf16_ascii_shape {
             let utf16: Vec<u16> = bytes


### PR DESCRIPTION
Two independent clippy/compile errors broke main (87e45c65b) and the local pre-push hook, blocking `just release` for v0.3.19.

Both are cross-PR merge skew: CI for each contributing PR ran before its partner merged, so neither caught the conflict. The `error_outcome_emission_tests::test_config()` initializer was added by #1010 before #1017 introduced `turn_liveness_secs: u64` on `Config`; #1017 updated the two sibling test configs but missed this one. The `manual_is_multiple_of` clippy lint in `legacy_storage.rs` came from #1016 but wasn't exercised by GitHub CI for that PR — only by the local pre-push hook.

- Add missing `turn_liveness_secs: 10` to `error_outcome_emission_tests::test_config()` in `crates/buzz-acp/src/lib.rs` (matches field order and the value used by the two sibling test configs)
- Replace `bytes.len() % 2 == 0` with `bytes.len().is_multiple_of(2)` in `desktop/src-tauri/src/commands/legacy_storage.rs:83`