### PR TITLE
fix(release): ignore prerelease tags in changelog generation

### DIFF
--- a/justfile
+++ b/justfile
@@ -504,7 +504,7 @@ release *ARGS:
     # Bump versions and lockfiles
     just bump-version "$VERSION"
     # Generate changelog
-    LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || echo "")
+    LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' 2>/dev/null || echo "")
     TMPFILE=$(mktemp)
     {
         echo "# Changelog"


### PR DESCRIPTION
`git describe --match 'v[0-9]*'` matched the throwaway `v0.0.0-test.1` tag as `LAST_TAG` since it sat between `v0.3.18` and HEAD. The v0.3.19 changelog then started from that commit, silently dropping all commits merged between `v0.3.18` and the test tag.

Add `--exclude '*-*'` to the `git describe` call in the `release` recipe so only stable `vX.Y.Z` tags anchor the changelog range. Stable tags never contain a hyphen; prerelease tags always do. The `v0.0.0-test.1` tag stays on origin as a live fixture confirming the fix holds.

- `justfile`: `--match 'v[0-9]*'` → `--match 'v[0-9]*' --exclude '*-*'`

Follows up on #1013.