### PR TITLE
fix(release): resolve Windows sidecar path and Linux AppImage updater format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -504,9 +504,16 @@ jobs:
           fi
           echo "appimage=$APPIMAGE" >> "$GITHUB_OUTPUT"
 
-          # Updater archive: Tauri emits <name>.AppImage.tar.gz + .sig when signing is enabled
+          # Updater archive: Tauri 2.11+ with createUpdaterArtifacts signs the
+          # AppImage directly (*.AppImage + *.AppImage.sig). Earlier versions
+          # wrapped it in a tar.gz. Try the new format first, fall back to legacy.
           ARCHIVE=$(find "$BUNDLE_DIR/appimage" -name '*.AppImage.tar.gz' ! -name '*.sig' -type f | head -1)
-          SIG="${ARCHIVE}.sig"
+          if [[ -n "$ARCHIVE" ]]; then
+            SIG="${ARCHIVE}.sig"
+          else
+            ARCHIVE="$APPIMAGE"
+            SIG="${APPIMAGE}.sig"
+          fi
           if [[ -z "$ARCHIVE" || ! -f "$SIG" ]]; then
             echo "::error::AppImage updater archive or signature not found in $BUNDLE_DIR/appimage"
             exit 1

--- a/scripts/bundle-sidecars.sh
+++ b/scripts/bundle-sidecars.sh
@@ -6,12 +6,14 @@ HOST=$(rustc -vV | sed -n 's|host: ||p')
 TARGET=${1:-$HOST}
 BINARIES_DIR="desktop/src-tauri/binaries"
 
-# A cross-target build (`cargo build --target <triple>`) emits to
-# target/<triple>/release; a host build emits to target/release.
-if [[ "$TARGET" == "$HOST" ]]; then
-    SRC_DIR="target/release"
-else
+# When --target is passed explicitly to cargo (even if it matches the host),
+# binaries land in target/<triple>/release/. Without --target, they land in
+# target/release/. The script receives the target as $1 only when cargo was
+# invoked with --target, so use the qualified path whenever $1 is set.
+if [[ -n "${1:-}" ]]; then
     SRC_DIR="target/${TARGET}/release"
+else
+    SRC_DIR="target/release"
 fi
 
 # MSVC emits <name>.exe; Tauri's externalBin then expects binaries/<name>-<triple>.exe.


### PR DESCRIPTION
## Problem

The v0.3.19 release failed on Windows and Linux due to two independent bugs in artifact path resolution.

### Windows — "Build sidecars" step

`cargo build --release --target x86_64-pc-windows-msvc` puts binaries in `target/x86_64-pc-windows-msvc/release/`. `bundle-sidecars.sh` checked `TARGET == HOST` and used `target/release/` — which was empty because cargo used the explicit target path.

### Linux — "Locate Linux build artifacts" step

Tauri 2.11 with `createUpdaterArtifacts: true` signs the AppImage directly, producing `*.AppImage` + `*.AppImage.sig`. The workflow expected the legacy format: `*.AppImage.tar.gz` + `*.AppImage.tar.gz.sig`.

## Fix

### `scripts/bundle-sidecars.sh`

Use the target-qualified path (`target/<triple>/release/`) whenever `$1` is provided (indicating `--target` was passed to cargo). Only fall back to `target/release/` when no argument is given (native host build without `--target`).

### `.github/workflows/release.yml`

Try `*.AppImage.tar.gz` first for backwards compatibility, then fall back to using the bare `*.AppImage` as the updater archive with `*.AppImage.sig` as the signature.