### PR TITLE
perf(ci): speed up PR CI wall clock and local dev builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[profile.dev]
+# Full file/line backtraces, no per-variable debug info. ~20-30% faster
+# builds and much faster macOS link. Need lldb locals? Override per-shell:
+# CARGO_PROFILE_DEV_DEBUG=2
+debug = "line-tables-only"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     branches: [main, release]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
@@ -81,6 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.event_name != 'pull_request' }}
@@ -102,6 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: desktop/src-tauri
@@ -264,6 +270,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: |
@@ -479,9 +486,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
-        with:
-          channel: stable
+      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
       - name: Install dependencies
         run: cd mobile && flutter pub get
       - name: Format check
@@ -554,8 +559,10 @@ jobs:
       - name: Build server binaries
         env:
           TARGET: ${{ matrix.target }}
+          # PRs: compile + build-script gate only (no codegen/link). Main: full link gate.
+          CARGO_CMD: ${{ github.event_name == 'pull_request' && 'check' || 'build' }}
         run: |
-          cross build --release --target "$TARGET" \
+          cross "$CARGO_CMD" --release --target "$TARGET" \
             -p buzz-relay \
             -p buzz-acp \
             -p buzz-agent \

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@
 
 # Editor / IDE
 .idea/
-.vscode/
+.vscode/*
+!.vscode/settings.json
 *.swp
 *.swo
 *~

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.targetDir": true
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,13 +119,19 @@ buzz-media = { path = "crates/buzz-media" }
 buzz-sdk = { path = "crates/buzz-sdk" }
 buzz-ws-client = { path = "crates/buzz-ws-client" }
 
-# CI profile — release-grade codegen for the relay so e2e tests hit a
-# realistic binary, not an unoptimised debug build.  Inherits `release`
-# defaults (opt-level 3, no debug-assertions) but keeps incremental
-# compilation enabled and avoids LTO so the build stays fast.
+# CI profile — builds the relay for desktop e2e. Dependencies keep full
+# release optimization (warm from main's cache; they carry the runtime hot
+# path: tokio/sqlx/axum). Workspace crates build at opt-level 1 — enough for
+# stable e2e timing (PR #307 flakiness was opt-0 + debug-assertions) at
+# roughly half the codegen cost. `incremental` is irrelevant in CI:
+# rust-cache exports CARGO_INCREMENTAL=0 and never caches member artifacts.
 [profile.ci]
 inherits = "release"
 lto = false
+opt-level = 1
+
+[profile.ci.package."*"]
+opt-level = 3
 
 # Sprig profile — optimized for deploy-anywhere Sprig release artifacts.
 # Sprig is distributed over the network and installed on fresh hosts, so binary

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,10 +20,6 @@ pre-commit:
 pre-push:
   parallel: true
   commands:
-    rust-clippy:
-      run: just clippy
-    desktop-tauri-clippy:
-      run: just desktop-tauri-clippy
     rust-tests:
       run: just test-unit
     desktop-test:


### PR DESCRIPTION
## Summary

Measured baseline: PR CI ~10 min wall clock.

### CI — critical path & compute

- **`profile.ci` opt-level 1 for workspace crates** (`Cargo.toml`): deps keep `opt-level = 3` via `[profile.ci.package."*"]` so the main-seeded dep cache stays byte-identical. The relay build should drop from ~4m38s to ~2m15–2m45s. opt-level 1 keeps debug-assertions off (release inherit) so the e2e timing stability from [#307](https://github.com/block/buzz/pull/307) is preserved.

- **mold linker** (`rui314/setup-mold@v1`) on three Linux link jobs: `unit-tests`, `desktop-core`, `desktop-e2e-relay`. Not added to clippy (check-mode, no link), cross-compile (links inside the cross container), or macOS (ld64 beats mold on Apple Silicon).

- **Concurrency group** on `ci.yml`: superseded PR pushes cancel in-flight runs. Mirrors the existing group already on `docker.yml`. Never cancels main/release pushes so cache seeding is unaffected.

- **`cross check` on PRs, `cross build` on main** (`server-cross-compile`): catches compile/build-script/proc-macro errors on PRs; link-only musl errors surface on the main push. Saves ~5+ runner-min per Rust PR and removes the future wall-clock cap.

### CI — smaller wins

- **Mobile job: migrate from `flutter-action` to hermit.** The mobile job was the only CI job not using `activate-hermit`. Replaced `subosito/flutter-action` (which was set to `channel: stable`, a floating version) with the same `cashapp/activate-hermit` action every other job uses. Flutter version is now managed in one place (the hermit binstub) for both local dev and CI.

### Local dev

- **`.cargo/config.toml`** (new): `debug = "line-tables-only"` for `[profile.dev]`. Full file/line backtraces, no per-variable debug info — ~20–30% faster local builds and much faster link on macOS. Applies to both the root workspace and `desktop/src-tauri` via cargo config discovery (cargo walks up from cwd; workspace exclusion does not affect config files). Also shrinks CI test binaries since the `test` profile inherits dev, superseding the `CARGO_PROFILE_TEST_DEBUG=0` approach. If you need lldb variable inspection: `CARGO_PROFILE_DEV_DEBUG=2 cargo build …`.

- **`.vscode/settings.json`** (new): `rust-analyzer.cargo.targetDir: true` sends RA's `cargo check` to `target/rust-analyzer/` so it no longer invalidates the `cargo build` artifact cache. Cursor reads `.vscode/` too. Updated `.gitignore` to track this file.

- **Remove clippy from `lefthook` pre-push**: both `rust-clippy` and `desktop-tauri-clippy` duplicated the CI `rust-lint` job and cost 2–4 min per push. CI still gates merges. Fast tests stay in pre-push.

## Verification

For the `profile.ci` change specifically: re-run the integration shards a few times to confirm no e2e flakiness at opt-level 1. If Playwright timeouts reappear, bump `[profile.ci]` to `opt-level = 2` — still ~25–35% faster than 3 and well above the opt-0 threshold that triggered #307.