### PR TITLE
fix(release): locate signed NSIS installer as the Windows updater artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -664,23 +664,30 @@ jobs:
             exit 1
           fi
 
-          # Rename with _alpha-unsigned marker
+          # Tauri 2.x with createUpdaterArtifacts: true (v2 updater) signs the
+          # NSIS installer in place: it emits <name>-setup.exe + <name>-setup.exe.sig
+          # and NO separate .nsis.zip (that was the deprecated v1Compatible format).
+          # The signed installer IS the updater artifact. Capture its .sig before
+          # the rename below so the manifest signature matches the uploaded exe.
+          SIG="${EXE}.sig"
+          if [[ ! -f "$SIG" ]]; then
+            echo "::error::NSIS installer signature not found: $SIG"
+            exit 1
+          fi
+
+          # Rename with _alpha-unsigned marker, keeping the .sig in lockstep so the
+          # rolling-release archive name and its detached signature stay consistent.
           EXE_DIR=$(dirname "$EXE")
           EXE_BASE=$(basename "$EXE" .exe)
           MARKED_EXE="${EXE_DIR}/${EXE_BASE}_alpha-unsigned.exe"
+          MARKED_SIG="${MARKED_EXE}.sig"
           mv "$EXE" "$MARKED_EXE"
+          mv "$SIG" "$MARKED_SIG"
           echo "exe=$MARKED_EXE" >> "$GITHUB_OUTPUT"
 
-          # Find the updater .nsis.zip and .sig
-          ARCHIVE=$(find "$BUNDLE_DIR/nsis" -name '*.nsis.zip' ! -name '*.sig' -type f | head -1)
-          SIG="${ARCHIVE}.sig"
-          if [[ -z "$ARCHIVE" || ! -f "$SIG" ]]; then
-            echo "::error::NSIS updater archive or signature not found in $BUNDLE_DIR/nsis"
-            exit 1
-          fi
-          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
-          echo "archive_name=$(basename "$ARCHIVE")" >> "$GITHUB_OUTPUT"
-          echo "sig=$SIG" >> "$GITHUB_OUTPUT"
+          echo "archive=$MARKED_EXE" >> "$GITHUB_OUTPUT"
+          echo "archive_name=$(basename "$MARKED_EXE")" >> "$GITHUB_OUTPUT"
+          echo "sig=$MARKED_SIG" >> "$GITHUB_OUTPUT"
 
       - name: Read updater signature
         id: read-sig


### PR DESCRIPTION
## Problem

The `Locate Windows build artifacts` step in `release.yml` globbed for a `*.nsis.zip` updater archive that Tauri 2.x no longer produces. With `createUpdaterArtifacts: true` (the v2 updater format), the NSIS installer is signed in place — `<name>-setup.exe` plus a detached `<name>-setup.exe.sig` — and that signed installer *is* the updater artifact. The `.nsis.zip` was the deprecated v1Compatible format.

The dead glob returned empty and tripped the not-found guard, failing every Windows release run *after* a clean installer build (the `*.exe` find succeeds, then the `*.nsis.zip` find fails). This was the sole remaining blocker on Windows releases once the sqlite link fix (#1029) landed.

## Fix

Capture the installer's own `.sig` (`SIG="${EXE}.sig"`) instead of globbing for the nonexistent `.nsis.zip`, and rename it in lockstep with the `.exe` so the rolling-release archive name and its detached signature stay consistent. The `archive` / `archive_name` / `sig` outputs now point at the marked installer and its sig.

The Windows `latest.json` updater URL consequently points at the full `*_alpha-unsigned.exe` rather than a `.nsis.zip` — correct v2 updater behavior, symmetric with Linux serving the renamed `.AppImage` directly. The name chain is single-sourced: uploaded-object-name, `archive_name`, manifest URL, and verify URL all derive from the one `outputs.archive` pair and cannot diverge.

Related: #1029 (Windows sqlite link fix, already merged — this is the next layer down).
