### PR TITLE
fix(release): use signed NSIS installer for updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -664,23 +664,26 @@ jobs:
             exit 1
           fi
 
-          # Rename with _alpha-unsigned marker
+          # Tauri 2.x with createUpdaterArtifacts: true signs the NSIS
+          # installer in place (<name>-setup.exe + <name>-setup.exe.sig).
+          SIG="${EXE}.sig"
+          if [[ ! -f "$SIG" ]]; then
+            echo "::error::NSIS installer signature not found: $SIG"
+            exit 1
+          fi
+
+          # Rename with _alpha-unsigned marker, keeping the detached signature
+          # in lockstep so latest.json matches the uploaded updater artifact.
           EXE_DIR=$(dirname "$EXE")
           EXE_BASE=$(basename "$EXE" .exe)
           MARKED_EXE="${EXE_DIR}/${EXE_BASE}_alpha-unsigned.exe"
+          MARKED_SIG="${MARKED_EXE}.sig"
           mv "$EXE" "$MARKED_EXE"
+          mv "$SIG" "$MARKED_SIG"
           echo "exe=$MARKED_EXE" >> "$GITHUB_OUTPUT"
-
-          # Find the updater .nsis.zip and .sig
-          ARCHIVE=$(find "$BUNDLE_DIR/nsis" -name '*.nsis.zip' ! -name '*.sig' -type f | head -1)
-          SIG="${ARCHIVE}.sig"
-          if [[ -z "$ARCHIVE" || ! -f "$SIG" ]]; then
-            echo "::error::NSIS updater archive or signature not found in $BUNDLE_DIR/nsis"
-            exit 1
-          fi
-          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
-          echo "archive_name=$(basename "$ARCHIVE")" >> "$GITHUB_OUTPUT"
-          echo "sig=$SIG" >> "$GITHUB_OUTPUT"
+          echo "archive=$MARKED_EXE" >> "$GITHUB_OUTPUT"
+          echo "archive_name=$(basename "$MARKED_EXE")" >> "$GITHUB_OUTPUT"
+          echo "sig=$MARKED_SIG" >> "$GITHUB_OUTPUT"
 
       - name: Read updater signature
         id: read-sig


### PR DESCRIPTION
## Summary
- use the signed NSIS `.exe`/`.exe.sig` pair as the Windows updater artifact
- stop looking for the deprecated `*.nsis.zip` artifact that Tauri no longer produces

## Why
The release workflow's `release-windows` job currently fails while locating the Windows updater artifact because Tauri emits the signed NSIS installer in place (`.exe` + `.exe.sig`), not a separate `.nsis.zip` archive.

Because `assemble-manifest` depends on all four platform jobs, a failing Windows job prevents `latest.json` from regenerating. That is why the live `buzz-desktop-latest/latest.json` is still stuck at `0.3.18`.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`
- `actionlint .github/workflows/release.yml`

## Release follow-up
After this merges, cut one clean full-version tag (for example `v0.3.21`, not an rc) so all four platform jobs pass and `assemble-manifest` regenerates `buzz-desktop-latest/latest.json`.

## Deferred follow-up
The larger atomic rolling-release hardening work has been split out of this urgent fix and can be proposed separately.
