### PR TITLE
chore(scripts): update post-screenshots repo name to block/buzz

### DIFF
--- a/scripts/post-screenshots.sh
+++ b/scripts/post-screenshots.sh
@@ -17,7 +17,7 @@ fi
 
 GH_USER=$(gh api user --jq .login)
 BRANCH="agent-screenshots/${GH_USER}"
-REPO="block/sprout"
+REPO="block/buzz"
 
 mapfile -t PNGS < <(find "$PNG_DIR" -maxdepth 1 -name "*.png" -type f | sort)
 if [[ ${#PNGS[@]} -eq 0 ]]; then


### PR DESCRIPTION
The repo was renamed from `block/sprout` to `block/buzz` in #1012, but `scripts/post-screenshots.sh` still hardcoded the old name. The `REPO` constant feeds both the raw image URL and the `gh pr comment --repo` call, so this one-line edit fixes both.

GitHub redirects the old name, so this was cosmetic — but the constant should reflect the current repo.