### PR TITLE
feat(composer): wrap selection on buzz:// link paste

### DIFF
--- a/desktop/src/features/messages/lib/messageLink.test.mjs
+++ b/desktop/src/features/messages/lib/messageLink.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildMessageLink,
+  isBuzzUrl,
   isMessageLink,
   parseMessageLink,
 } from "./messageLink.ts";
@@ -117,4 +118,29 @@ test("isMessageLink matches buzz://message and legacy buzz://message", () => {
   assert.equal(isMessageLink("https://example.com"), false);
   assert.equal(isMessageLink(undefined), false);
   assert.equal(isMessageLink(""), false);
+});
+
+test("isBuzzUrl matches any well-formed buzz:// URL", () => {
+  // Message deep-links.
+  assert.equal(
+    isBuzzUrl(`buzz://message?channel=${CHANNEL}&id=${MESSAGE}`),
+    true,
+  );
+  // Non-message buzz:// URLs (tho wants ALL buzz:// links to wrap).
+  assert.equal(isBuzzUrl("buzz://connect?relay=wss://x"), true);
+  assert.equal(isBuzzUrl("buzz://channel?id=abc"), true);
+  // Surrounding whitespace is tolerated.
+  assert.equal(
+    isBuzzUrl(`  buzz://message?channel=${CHANNEL}&id=${MESSAGE}  `),
+    true,
+  );
+  // Standard URLs and non-buzz schemes are rejected.
+  assert.equal(isBuzzUrl("https://example.com"), false);
+  assert.equal(isBuzzUrl("mailto:x@example.com"), false);
+  // Malformed / empty input is rejected.
+  assert.equal(isBuzzUrl("buzz"), false);
+  assert.equal(isBuzzUrl("not a url at all"), false);
+  assert.equal(isBuzzUrl(undefined), false);
+  assert.equal(isBuzzUrl(null), false);
+  assert.equal(isBuzzUrl(""), false);
 });

--- a/desktop/src/features/messages/lib/messageLink.ts
+++ b/desktop/src/features/messages/lib/messageLink.ts
@@ -102,3 +102,22 @@ export function isMessageLink(href: string | undefined | null): boolean {
   if (!href) return false;
   return href.startsWith("buzz://message?") || href === "buzz://message";
 }
+
+/**
+ * Returns true if `text` is any `buzz://` URL (not just the message-link
+ * format). Used by the composer's wrap-on-paste handler: linkifyjs (which
+ * TipTap's built-in paste handler relies on) doesn't recognise the `buzz`
+ * scheme, so we detect it ourselves and wrap the highlighted selection.
+ *
+ * Validated via `URL` so we only treat genuinely well-formed `buzz://` URLs as
+ * links — a bare `buzz:` or malformed string won't match.
+ */
+export function isBuzzUrl(text: string | undefined | null): boolean {
+  if (!text) return false;
+  const trimmed = text.trim();
+  try {
+    return new URL(trimmed).protocol === MESSAGE_LINK_SCHEME;
+  } catch {
+    return false;
+  }
+}

--- a/desktop/src/features/messages/lib/messageLink.ts
+++ b/desktop/src/features/messages/lib/messageLink.ts
@@ -104,13 +104,8 @@ export function isMessageLink(href: string | undefined | null): boolean {
 }
 
 /**
- * Returns true if `text` is any `buzz://` URL (not just the message-link
- * format). Used by the composer's wrap-on-paste handler: linkifyjs (which
- * TipTap's built-in paste handler relies on) doesn't recognise the `buzz`
- * scheme, so we detect it ourselves and wrap the highlighted selection.
- *
- * Validated via `URL` so we only treat genuinely well-formed `buzz://` URLs as
- * links — a bare `buzz:` or malformed string won't match.
+ * Returns true if `text` is any well-formed `buzz://` URL (not just the
+ * message-link format) — used by the composer's wrap-on-paste handler.
  */
 export function isBuzzUrl(text: string | undefined | null): boolean {
   if (!text) return false;

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -6,7 +6,12 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Link from "@tiptap/extension-link";
 import { Extension, type KeyboardShortcutCommand } from "@tiptap/core";
-import { Selection, TextSelection } from "@tiptap/pm/state";
+import {
+  Plugin,
+  PluginKey,
+  Selection,
+  TextSelection,
+} from "@tiptap/pm/state";
 
 import { isMacPlatform } from "@/shared/lib/platform";
 import type { CustomEmoji } from "@/shared/lib/remarkCustomEmoji";
@@ -23,6 +28,7 @@ import {
   handleCodeFenceEnter,
   insertNewlineInCodeBlock,
 } from "./codeBlockExtensions";
+import { isBuzzUrl } from "./messageLink";
 
 /**
  * Plain-text edit descriptor returned by autocomplete hooks
@@ -299,6 +305,44 @@ export function useRichTextEditor({
         Link.extend({
           inclusive() {
             return false;
+          },
+          // The built-in `linkOnPaste` handler detects URLs with linkifyjs,
+          // which only knows standard schemes (http/https/mailto) — so pasting
+          // a `buzz://` URL over a text selection clobbers it with raw text
+          // instead of wrapping it in a link. Prepend our own paste handler
+          // that recognises `buzz://` URLs and wraps the highlighted selection,
+          // matching the standard-URL UX. Runs before the parent plugins so it
+          // claims the paste first; otherwise we defer to TipTap's defaults.
+          addProseMirrorPlugins() {
+            const linkType = this.type;
+            const buzzLinkPaste = new Plugin({
+              key: new PluginKey("buzzLinkOnPaste"),
+              props: {
+                handlePaste: (view, _event, slice) => {
+                  const { selection } = view.state;
+                  // Only wrap when there's a selection to wrap — empty
+                  // selections fall through to TipTap's normal insert path.
+                  if (selection.empty) return false;
+
+                  let textContent = "";
+                  slice.content.forEach((node) => {
+                    textContent += node.textContent;
+                  });
+
+                  const href = textContent.trim();
+                  // The whole clipboard payload must be a single buzz:// URL —
+                  // same contract as the built-in handler (`value === text`).
+                  if (!isBuzzUrl(href)) return false;
+
+                  return this.editor
+                    .chain()
+                    .setMark(linkType, { href })
+                    .run();
+                },
+              },
+            });
+
+            return [buzzLinkPaste, ...(this.parent?.() ?? [])];
           },
         }).configure({
           openOnClick: false,

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -306,13 +306,9 @@ export function useRichTextEditor({
           inclusive() {
             return false;
           },
-          // The built-in `linkOnPaste` handler detects URLs with linkifyjs,
-          // which only knows standard schemes (http/https/mailto) — so pasting
-          // a `buzz://` URL over a text selection clobbers it with raw text
-          // instead of wrapping it in a link. Prepend our own paste handler
-          // that recognises `buzz://` URLs and wraps the highlighted selection,
-          // matching the standard-URL UX. Runs before the parent plugins so it
-          // claims the paste first; otherwise we defer to TipTap's defaults.
+          // linkifyjs (which TipTap's `linkOnPaste` uses) doesn't recognise
+          // `buzz://`, so wrap such links ourselves. Runs before the parent
+          // plugins; defers to TipTap's defaults otherwise.
           addProseMirrorPlugins() {
             const linkType = this.type;
             const buzzLinkPaste = new Plugin({
@@ -320,8 +316,6 @@ export function useRichTextEditor({
               props: {
                 handlePaste: (view, _event, slice) => {
                   const { selection } = view.state;
-                  // Only wrap when there's a selection to wrap — empty
-                  // selections fall through to TipTap's normal insert path.
                   if (selection.empty) return false;
 
                   let textContent = "";
@@ -329,9 +323,8 @@ export function useRichTextEditor({
                     textContent += node.textContent;
                   });
 
+                  // Only wrap when the whole payload is a single buzz:// URL.
                   const href = textContent.trim();
-                  // The whole clipboard payload must be a single buzz:// URL —
-                  // same contract as the built-in handler (`value === text`).
                   if (!isBuzzUrl(href)) return false;
 
                   return this.editor


### PR DESCRIPTION

<img width="900" height="545" alt="Screen Recording 2026-06-14 at 3 42 11 PM" src="https://github.com/user-attachments/assets/5b8c73f3-03b7-490a-bbfe-ad64af101e10" />


## Overview

**Category:** improvement
**User Impact:** Highlighting text in the chat composer and pasting a `buzz://` link now wraps the selection in a hyperlink — exactly like pasting a standard `https://` link.

**Problem:** Pasting a `buzz://` URL over a text selection replaced the highlighted text with the raw URL instead of turning it into a link. Standard `https://` links already wrapped-on-paste, so the inconsistency was confusing.

**Solution:** TipTap's built-in `linkOnPaste` handler detects URLs with linkifyjs, which only knows standard schemes (http/https/mailto) — it has no idea `buzz://` is a URL, so the wrap-on-paste handler bailed. This adds a custom ProseMirror paste plugin (prepended before TipTap's defaults) that recognizes any well-formed `buzz://` URL and wraps the highlighted selection in a link mark. Per tho's direction, **all** `buzz://` URLs wrap, not just the `buzz://message?...` deep-link format.

<details>
<summary>File changes</summary>

**desktop/src/features/messages/lib/messageLink.ts**
Added `isBuzzUrl()` — a broad check (via the `URL` API) for any well-formed `buzz://` URL, distinct from the existing message-link-only `isMessageLink()`.

**desktop/src/features/messages/lib/useRichTextEditor.ts**
Extended the Link extension's `addProseMirrorPlugins` with a `buzzLinkOnPaste` plugin that wraps a non-empty selection in a link mark when the clipboard payload is a single `buzz://` URL. Runs before the parent plugins so it claims the paste; otherwise defers to TipTap's defaults.

**desktop/src/features/messages/lib/messageLink.test.mjs**
Added coverage for `isBuzzUrl()`: message links, non-message `buzz://` URLs, whitespace tolerance, and rejection of standard/malformed/empty input.

</details>

## Reproduction Steps

1. Run the desktop app and open the chat composer.
2. Copy a `buzz://` URL (e.g. `buzz://message?channel=...&id=...`).
3. Type some text, highlight a portion of it, and paste.
4. The highlighted text becomes a hyperlink pointing at the `buzz://` URL (previously it was clobbered with the raw URL text).
5. Repeat with a standard `https://` URL to confirm existing behavior is unchanged.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (only pre-existing warnings in unrelated e2e files)
- `pnpm test` ✅ 720 passing
