### PR TITLE
test: remove dead symbols in onboarding e2e spec

### DIFF
--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -25,10 +25,6 @@ const FIRST_RUN_ALICE = {
   ...TEST_IDENTITIES.alice,
   username: "",
 };
-const FIRST_RUN_KENNY = {
-  ...TEST_IDENTITIES.tyler,
-  username: "Kenny QA",
-};
 
 type TestIdentity = {
   privateKey: string;
@@ -511,27 +507,6 @@ async function expectWelcomeGuideIntro(
     ).toBeVisible();
     await expect(page.getByTestId("system-message-row")).toHaveCount(0);
   }
-}
-
-async function getMockProfile(page: Page) {
-  return page.evaluate(async () => {
-    const invoke = (
-      window as Window & {
-        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
-          command: string,
-          payload?: Record<string, unknown>,
-        ) => Promise<unknown>;
-      }
-    ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
-    if (!invoke) {
-      throw new Error("Mock invoke bridge is unavailable.");
-    }
-
-    return (await invoke("get_profile")) as {
-      avatar_url: string | null;
-      display_name: string | null;
-    };
-  });
 }
 
 async function expectIncompleteOnboarding(page: Page) {


### PR DESCRIPTION
**Category:** fix

**User Impact:** None user-facing — this is CI hygiene that unblocks PRs from merging.

**Problem:** `main` carries two unused symbols in `desktop/tests/e2e/onboarding.spec.ts` — `const FIRST_RUN_KENNY` and `function getMockProfile`. biome's `noUnusedVariables` flags both. Because biome has `vcs.enabled: true`, **push** builds (main) see the file as unchanged and soften the finding to a warning, so main stays green. But **pull_request** builds escalate the same finding to an **error**, failing the `Desktop Core` (`biome check .`) gate. Net result: main is quietly red under PR rules, blocking PR #1044.

**Solution:** Remove the two dead symbols. Nothing else touched. `biome check .` now passes under PR context.

<details>
<summary>File changes</summary>

**desktop/tests/e2e/onboarding.spec.ts**
Removed the unused `FIRST_RUN_KENNY` constant and the unused `getMockProfile` helper function. Both had zero references in the file or repo-wide. 25 deletions, no other changes.

</details>

## Reproduction Steps

1. Check out this branch.
2. Run `pnpm check` from the repo root.
3. Confirm `biome check .` passes clean for both `web` and `desktop` workspaces (666 desktop files checked, no errors).

_PR authored by Bart 🤖_
