### PR TITLE
feat(desktop): surface buried agent replies to the viewer in the channel timeline

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
         "**/identity-archive.spec.ts",
         "**/identity-archive-hide.spec.ts",
         "**/relay-connectivity-screenshots.spec.ts",
+        "**/reply-surfacing-screenshots.spec.ts",
         "**/unread-pill-screenshots.spec.ts",
         "**/sidebar-more-unread-overlap.spec.ts",
         "**/home-collapsed-top-chrome-screenshots.spec.ts",

--- a/desktop/src/features/messages/lib/collapseSurfacedReplies.d.mts
+++ b/desktop/src/features/messages/lib/collapseSurfacedReplies.d.mts
@@ -1,0 +1,21 @@
+/**
+ * Type declarations for the pure collapse in `collapseSurfacedReplies.mjs`.
+ * Runtime lives in `.mjs` so the (TS-loader-less) `node:test` runner imports it
+ * directly; this file gives TypeScript callers a typed view.
+ */
+import type { TimelineMessage } from "@/features/messages/types";
+
+/** One collapsed pointer per thread: the most-recent reply plus its group size. */
+export type CollapsedSurfacedReply = {
+  message: TimelineMessage;
+  count: number;
+};
+
+/**
+ * Collapses surfaced replies sharing a thread (`rootId ?? id`) into one entry
+ * per thread, keeping the most-recent reply (max `createdAt`, `id` tiebreak) as
+ * the representative and counting the group.
+ */
+export function collapseSurfacedReplies(
+  surfaced: TimelineMessage[],
+): CollapsedSurfacedReply[];

--- a/desktop/src/features/messages/lib/collapseSurfacedReplies.mjs
+++ b/desktop/src/features/messages/lib/collapseSurfacedReplies.mjs
@@ -1,0 +1,47 @@
+/**
+ * Pure collapse of surfaced replies into one pointer per thread. `surfaceReplies`
+ * yields every buried agent->viewer reply individually; in this team's threading
+ * model a single thread can hold dozens, which floods the timeline with pointer
+ * rows and destroys its structure. This collapses all surfaced replies sharing a
+ * thread (`rootId ?? id`) into ONE representative carrying the group's count.
+ *
+ * The representative is the MOST RECENT surfaced reply in the thread (max
+ * `createdAt`, `id` as a deterministic tiebreak). The downstream merge sorts the
+ * pointer by that representative's `createdAt`, so the collapsed pill lands where
+ * the newest buried activity is; clicking it navigates to that same most-recent
+ * reply (the freshest thing addressed to the viewer).
+ *
+ * Lives in `.mjs` (not `.ts`) so the TS-loader-less test runner imports the same
+ * source production uses; the sibling `.d.mts` types the result for TS callers.
+ */
+
+/**
+ * @param {{ id: string, createdAt: number, rootId?: string | null }[]} surfaced
+ * @returns {{ message: object, count: number }[]} one entry per thread; `message`
+ *   is the most-recent surfaced reply, `count` the number collapsed into it.
+ */
+export function collapseSurfacedReplies(surfaced) {
+  /** @type {Map<string, { message: object, count: number }>} */
+  const byThread = new Map();
+
+  for (const message of surfaced) {
+    const threadId = message.rootId ?? message.id;
+    const group = byThread.get(threadId);
+    if (!group) {
+      byThread.set(threadId, { message, count: 1 });
+      continue;
+    }
+    group.count += 1;
+    if (isMoreRecent(message, group.message)) group.message = message;
+  }
+
+  return [...byThread.values()];
+}
+
+/** Most recent = greater `createdAt`, breaking ties on greater `id`. */
+function isMoreRecent(candidate, current) {
+  if (candidate.createdAt !== current.createdAt) {
+    return candidate.createdAt > current.createdAt;
+  }
+  return candidate.id > current.id;
+}

--- a/desktop/src/features/messages/lib/collapseSurfacedReplies.test.mjs
+++ b/desktop/src/features/messages/lib/collapseSurfacedReplies.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// Imports the exact source the renderer wires. No inlined copy -> no drift
+// between test expectations and production behaviour.
+import { collapseSurfacedReplies } from "./collapseSurfacedReplies.mjs";
+
+// Minimal shape: collapse reads id, createdAt, rootId. A nested reply carries
+// its thread root's id; a reply with no rootId is its own thread.
+const reply = (id, createdAt, rootId) => ({ id, createdAt, rootId });
+
+// Reduce to a comparable trace of (representative id, count).
+const trace = (groups) =>
+  groups.map((g) => `${g.message.id}:${g.count}`).sort();
+
+test("replies in one thread collapse to a single representative carrying the count", () => {
+  const out = collapseSurfacedReplies([
+    reply("a", 10, "root"),
+    reply("b", 30, "root"),
+    reply("c", 20, "root"),
+  ]);
+  // Most recent (createdAt 30) represents; count is the group size.
+  assert.deepEqual(trace(out), ["b:3"]);
+});
+
+test("two threads collapse independently with no cross-thread merge", () => {
+  const out = collapseSurfacedReplies([
+    reply("a1", 10, "rootA"),
+    reply("a2", 40, "rootA"),
+    reply("b1", 20, "rootB"),
+    reply("b2", 30, "rootB"),
+  ]);
+  // rootA -> a2 (max 40, count 2); rootB -> b2 (max 30, count 2).
+  assert.deepEqual(trace(out), ["a2:2", "b2:2"]);
+});
+
+test("representative is the max createdAt, tiebroken on greater id", () => {
+  // Two replies share createdAt 30; the greater id ("y" > "x") wins.
+  const out = collapseSurfacedReplies([
+    reply("x", 30, "root"),
+    reply("y", 30, "root"),
+    reply("w", 10, "root"),
+  ]);
+  assert.deepEqual(trace(out), ["y:3"]);
+});
+
+test("a reply with no rootId is its own thread keyed by its id", () => {
+  const out = collapseSurfacedReplies([reply("solo", 10, null)]);
+  assert.deepEqual(trace(out), ["solo:1"]);
+});
+
+test("a root-level reply and a nested reply under it share one thread", () => {
+  // The thread root's own thread id is its id; a nested reply carries rootId
+  // equal to that id -> same thread key -> one collapsed pointer.
+  const out = collapseSurfacedReplies([
+    reply("root", 10, null),
+    reply("nested", 20, "root"),
+  ]);
+  assert.deepEqual(trace(out), ["nested:2"]);
+});
+
+test("empty input returns empty", () => {
+  assert.deepEqual(collapseSurfacedReplies([]), []);
+});

--- a/desktop/src/features/messages/lib/surfaceReplies.d.mts
+++ b/desktop/src/features/messages/lib/surfaceReplies.d.mts
@@ -1,0 +1,23 @@
+/**
+ * Type declarations for the pure projection in `surfaceReplies.mjs`. Runtime
+ * lives in `.mjs` so the (TS-loader-less) `node:test` runner imports it
+ * directly; this file gives TypeScript callers a typed view.
+ */
+import type { TimelineMessage } from "@/features/messages/types";
+
+/**
+ * Returns the nested messages to surface as root-level pointers: agent-authored
+ * messages that carry a p-tag for the viewer and are not already duplicated at
+ * root.
+ *
+ * @param messages - the built timeline messages (mixed root + nested).
+ * @param isHuman - classifier for a pubkey; the caller resolves unknown
+ *   pubkeys to `true` (human) so unrecognized authors under-surface.
+ * @param viewerPubkey - the reader's pubkey. Only replies p-tagging the viewer
+ *   surface; a null/undefined viewer surfaces nothing (fail closed).
+ */
+export function surfaceReplies(
+  messages: TimelineMessage[],
+  isHuman: (pubkey: string | undefined) => boolean,
+  viewerPubkey: string | undefined,
+): TimelineMessage[];

--- a/desktop/src/features/messages/lib/surfaceReplies.mjs
+++ b/desktop/src/features/messages/lib/surfaceReplies.mjs
@@ -1,0 +1,83 @@
+/**
+ * Pure projection that pulls agent-authored replies addressed to a human up to
+ * the thread root. The channel timeline only renders root-level entries
+ * (`buildMainTimelineEntries` keeps `parentId == null || broadcast`), so an
+ * agent's reply to a human posted *nested* is invisible where the human reads.
+ * This function returns the nested messages that should be surfaced as
+ * lightweight root-level pointers; the real message is never moved or copied —
+ * the caller (Phase 2) renders a pointer row that links down to it.
+ *
+ * Lives in `.mjs` (not `.ts`) so the test runner (`node --test`, no TS loader)
+ * imports the same source production uses; TypeScript callers get types from
+ * the sibling `.d.mts`.
+ */
+
+/**
+ * A message is root-level — and therefore needs no surfacing — under the exact
+ * condition the timeline uses to render it at root: no parent, or a broadcast
+ * reply. Inlined (not imported from `threading.ts`) because that module is
+ * `.ts` and cannot be loaded by the TS-loader-less test runner; the rule is one
+ * line and must stay identical to `buildMainTimelineEntries`'s filter.
+ */
+function isRootLevel(message) {
+  return (
+    message.parentId == null ||
+    (message.tags ?? []).some((t) => t[0] === "broadcast" && t[1] === "1")
+  );
+}
+
+/**
+ * Returns the subset of `messages` to surface as root-level pointers.
+ *
+ * A nested message surfaces iff ALL hold:
+ *   1. it is not already root-level (root needs no surfacing);
+ *   2. its author is an agent — `isHuman(authorPubkey) === false`;
+ *   3. it carries a p-tag for the VIEWER — a `["p", viewerPubkey]`. Surfacing
+ *      exists to pull replies addressed to the reader up where their eye is, so
+ *      only the reader's own buried replies qualify; an agent CC'ing another
+ *      human is that other human's signal, not noise in the reader's timeline.
+ *
+ * `viewerPubkey` FAILS CLOSED: when it is null/undefined (no resolvable reader)
+ * NOTHING surfaces. Over-surfacing is the defect this guards against, so an
+ * unknown viewer must surface nothing rather than fall back to "any human".
+ *
+ * De-dupe is STRICT and THREAD-SCOPED: a candidate is skipped only when a
+ * root-level message *in the same thread* has the EXACT SAME body. Author
+ * identity is irrelevant — an agent's earlier, unrelated root-level post must
+ * not suppress a genuinely new nested reply. Scoping by thread prevents a root
+ * "done" in thread A from suppressing a nested "done" in thread B; short common
+ * bodies collide constantly across a busy channel. The key is
+ * `${threadId}\u0000${body}` where a message's thread id is `rootId ?? id` (a
+ * root's own thread id is its `id`, since its `rootId` is null) and `\u0000`
+ * (NUL) cannot appear in an event id or normal body, so keys never collide.
+ *
+ * Empty/whitespace-only bodies carry no content that can "already exist" at
+ * root, so they are never seeded and never suppress — every such candidate that
+ * passes the trigger conditions surfaces.
+ *
+ * `isHuman` is authoritative as given. The caller resolves unknown
+ * classification to `true` (human), so an unrecognized author is treated human
+ * and fails condition (2): the message under-surfaces rather than mis-surfaces.
+ */
+export function surfaceReplies(messages, isHuman, viewerPubkey) {
+  if (viewerPubkey == null) return [];
+
+  const threadKey = (message) =>
+    `${message.rootId ?? message.id}\u0000${message.body}`;
+  const rootBodies = new Set(
+    messages
+      .filter((message) => isRootLevel(message) && message.body.trim() !== "")
+      .map(threadKey),
+  );
+
+  return messages.filter((message) => {
+    if (isRootLevel(message)) return false;
+    if (isHuman(message.pubkey)) return false;
+    const tagsViewer = (message.tags ?? []).some(
+      (t) => t[0] === "p" && t[1] === viewerPubkey,
+    );
+    if (!tagsViewer) return false;
+    if (message.body.trim() === "") return true;
+    return !rootBodies.has(threadKey(message));
+  });
+}

--- a/desktop/src/features/messages/lib/surfaceReplies.test.mjs
+++ b/desktop/src/features/messages/lib/surfaceReplies.test.mjs
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// Imports the exact source the renderer wires in Phase 2. No inlined copy → no
+// drift between test expectations and production behaviour.
+import { surfaceReplies } from "./surfaceReplies.mjs";
+
+const HUMAN = "human-pubkey";
+const HUMAN_2 = "human-pubkey-2";
+const AGENT = "agent-pubkey";
+const AGENT_2 = "agent-pubkey-2";
+
+// Caller contract: unknown pubkeys resolve to human (true). Only the known
+// agent pubkeys are non-human; everything else (including undefined) is human.
+const isHuman = (pubkey) => pubkey !== AGENT && pubkey !== AGENT_2;
+
+// The viewer reading the timeline. Only replies p-tagging this pubkey surface.
+const VIEWER = HUMAN;
+
+// `rootId` mirrors production: a root-level message has `rootId == null`
+// (its own thread id is its `id`); a nested reply carries the thread root's id.
+const message = ({
+  id,
+  pubkey,
+  parentId = null,
+  rootId = null,
+  body = "",
+  tags = [],
+}) => ({
+  id,
+  pubkey,
+  author: pubkey,
+  parentId,
+  rootId,
+  body,
+  createdAt: 0,
+  time: "",
+  depth: parentId == null ? 0 : 1,
+  tags,
+});
+
+const p = (pubkey) => ["p", pubkey];
+const ids = (msgs) => msgs.map((m) => m.id);
+
+test("agent-authored nested message tagging a human surfaces", () => {
+  const nested = message({
+    id: "n1",
+    pubkey: AGENT,
+    parentId: "root1",
+    body: "here is your answer",
+    tags: [p(HUMAN)],
+  });
+  const out = surfaceReplies(
+    [message({ id: "root1", pubkey: HUMAN }), nested],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(ids(out), ["n1"]);
+});
+
+test("agent-to-agent nested message (no human p-tag) does not surface", () => {
+  const nested = message({
+    id: "n1",
+    pubkey: AGENT,
+    parentId: "root1",
+    body: "investigating together",
+    tags: [p(AGENT_2)],
+  });
+  const out = surfaceReplies(
+    [message({ id: "root1", pubkey: HUMAN }), nested],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(out, []);
+});
+
+test("human-authored nested message tagging a human does not surface", () => {
+  const nested = message({
+    id: "n1",
+    pubkey: HUMAN,
+    parentId: "root1",
+    body: "what do you think",
+    tags: [p(HUMAN_2)],
+  });
+  const out = surfaceReplies(
+    [message({ id: "root1", pubkey: AGENT }), nested],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(out, []);
+});
+
+test("nested agent reply whose exact body already exists at root in the same thread is de-duped", () => {
+  const body = "the deploy is green";
+  const out = surfaceReplies(
+    [
+      message({ id: "root1", pubkey: AGENT, body }),
+      message({
+        id: "n1",
+        pubkey: AGENT,
+        parentId: "root1",
+        rootId: "root1",
+        body,
+        tags: [p(HUMAN)],
+      }),
+    ],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(out, []);
+});
+
+test("near-but-not-identical body still surfaces (STRICT, not loose, de-dupe)", () => {
+  // Under LOOSE de-dupe (same author already at root) this would be wrongly
+  // skipped: the agent has an unrelated root post in this thread. STRICT
+  // compares body, so a genuinely new nested reply to the human still surfaces.
+  const out = surfaceReplies(
+    [
+      message({ id: "root1", pubkey: AGENT, body: "the deploy is green" }),
+      message({
+        id: "n1",
+        pubkey: AGENT,
+        parentId: "root1",
+        rootId: "root1",
+        body: "the deploy is green now",
+        tags: [p(HUMAN)],
+      }),
+    ],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(ids(out), ["n1"]);
+});
+
+test("unknown author treated as human under-surfaces (fail-safe)", () => {
+  // isHuman returns true for the unknown pubkey → fails the agent-author gate.
+  const nested = message({
+    id: "n1",
+    pubkey: "unknown-pubkey",
+    parentId: "root1",
+    body: "ambiguous author",
+    tags: [p(HUMAN)],
+  });
+  const out = surfaceReplies(
+    [message({ id: "root1", pubkey: HUMAN }), nested],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(out, []);
+});
+
+test("identical body in a different thread surfaces; same-thread root collision de-dupes", () => {
+  // Thread A has a root "done"; thread B has a nested agent→human "done".
+  // Thread-scoped de-dupe must NOT let thread A's root suppress thread B's
+  // reply — but a matching root in the SAME thread still de-dupes.
+  const out = surfaceReplies(
+    [
+      message({ id: "A", pubkey: HUMAN, body: "done" }),
+      message({
+        id: "nB",
+        pubkey: AGENT,
+        parentId: "B",
+        rootId: "B",
+        body: "done",
+        tags: [p(HUMAN)],
+      }),
+      message({ id: "C", pubkey: AGENT, body: "done" }),
+      message({
+        id: "nC",
+        pubkey: AGENT,
+        parentId: "C",
+        rootId: "C",
+        body: "done",
+        tags: [p(HUMAN)],
+      }),
+    ],
+    isHuman,
+    VIEWER,
+  );
+  // nB surfaces (no same-thread root "done"); nC de-dupes (root C is "done").
+  assert.deepEqual(ids(out), ["nB"]);
+});
+
+test("broadcast-tagged nested message is treated as root and does not surface", () => {
+  // Pins the broadcast branch of the inlined isRootLevel: a nested message
+  // (parentId != null) carrying ["broadcast","1"] is root-level, so it is
+  // excluded from surfacing. Guards against silent drift from
+  // buildMainTimelineEntries's canonical filter.
+  const out = surfaceReplies(
+    [
+      message({ id: "root1", pubkey: HUMAN }),
+      message({
+        id: "n1",
+        pubkey: AGENT,
+        parentId: "root1",
+        rootId: "root1",
+        body: "broadcast reply to a human",
+        tags: [["broadcast", "1"], p(HUMAN)],
+      }),
+    ],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(out, []);
+});
+
+test("empty-bodied nested agent reply surfaces despite an empty-bodied root", () => {
+  // An empty body carries no content to "already exist" at root, so it neither
+  // seeds the de-dupe set nor is suppressed by it.
+  const out = surfaceReplies(
+    [
+      message({ id: "root1", pubkey: HUMAN, body: "" }),
+      message({
+        id: "n1",
+        pubkey: AGENT,
+        parentId: "root1",
+        rootId: "root1",
+        body: "",
+        tags: [p(HUMAN)],
+      }),
+    ],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(ids(out), ["n1"]);
+});
+
+test("nested agent reply p-tagging only a non-viewer human does not surface", () => {
+  // HUMAN_2 is a human but NOT the viewer. Viewer-only surfacing means an agent
+  // CC'ing another human is that human's signal, not noise in the viewer's feed.
+  const nested = message({
+    id: "n1",
+    pubkey: AGENT,
+    parentId: "root1",
+    body: "answer for the other human",
+    tags: [p(HUMAN_2)],
+  });
+  const out = surfaceReplies(
+    [message({ id: "root1", pubkey: HUMAN }), nested],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(out, []);
+});
+
+test("nested agent reply p-tagging the viewer alongside another human surfaces", () => {
+  // The viewer p-tag is present (with a non-viewer human also CC'd) -> surfaces.
+  const nested = message({
+    id: "n1",
+    pubkey: AGENT,
+    parentId: "root1",
+    body: "answer for both of you",
+    tags: [p(HUMAN_2), p(VIEWER)],
+  });
+  const out = surfaceReplies(
+    [message({ id: "root1", pubkey: HUMAN }), nested],
+    isHuman,
+    VIEWER,
+  );
+  assert.deepEqual(ids(out), ["n1"]);
+});
+
+test("undefined viewer fails closed: nothing surfaces", () => {
+  // No resolvable reader -> surface nothing, never fall back to "any human".
+  // Over-surfacing is the exact defect this guards against.
+  const nested = message({
+    id: "n1",
+    pubkey: AGENT,
+    parentId: "root1",
+    body: "answer addressed to a human",
+    tags: [p(HUMAN)],
+  });
+  const out = surfaceReplies(
+    [message({ id: "root1", pubkey: HUMAN }), nested],
+    isHuman,
+    undefined,
+  );
+  assert.deepEqual(out, []);
+});

--- a/desktop/src/features/messages/lib/surfacedByRoot.d.mts
+++ b/desktop/src/features/messages/lib/surfacedByRoot.d.mts
@@ -1,0 +1,14 @@
+/**
+ * Type declarations for the pure attach-map construction in `surfacedByRoot.mjs`.
+ * Runtime lives in `.mjs` so the (TS-loader-less) `node:test` runner imports it
+ * directly; this file gives TypeScript callers a typed view.
+ */
+import type { CollapsedSurfacedReply } from "@/features/messages/lib/collapseSurfacedReplies";
+
+/**
+ * Builds the thread-root-id -> collapsed-reply attach map. The renderer looks up
+ * `get(rootEntry.message.id)`; a key matching no entry renders no pill (no orphan).
+ */
+export function buildSurfacedByRoot(
+  collapsed: CollapsedSurfacedReply[],
+): Map<string, CollapsedSurfacedReply>;

--- a/desktop/src/features/messages/lib/surfacedByRoot.mjs
+++ b/desktop/src/features/messages/lib/surfacedByRoot.mjs
@@ -1,0 +1,24 @@
+/**
+ * Pure construction of the surfaced-pill attach map: thread root id -> the
+ * collapsed representative reply + count. The timeline renders only root
+ * entries and looks up `surfacedByRoot.get(entry.message.id)` to attach a pill
+ * below each root. Keying by the thread root id (`rootId ?? id`) and driving the
+ * lookup from the ENTRY side is the no-orphan contract: a surfaced thread whose
+ * root is not a rendered entry (off-window, or a broadcast-rooted subthread
+ * whose NIP-10 root marker points at a different id than the on-screen broadcast
+ * entry) simply never gets looked up, so it renders no pill rather than a
+ * detached orphan.
+ *
+ * Lives in `.mjs` (not `.ts`) so the TS-loader-less test runner imports the same
+ * source production uses; the sibling `.d.mts` types it for TypeScript callers.
+ */
+
+/**
+ * @param {{ message: { id: string, rootId?: string | null }, count: number }[]} collapsed
+ * @returns {Map<string, { message: object, count: number }>} keyed by thread root id
+ */
+export function buildSurfacedByRoot(collapsed) {
+  return new Map(
+    collapsed.map((group) => [group.message.rootId ?? group.message.id, group]),
+  );
+}

--- a/desktop/src/features/messages/lib/surfacedByRoot.test.mjs
+++ b/desktop/src/features/messages/lib/surfacedByRoot.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildSurfacedByRoot } from "./surfacedByRoot.mjs";
+
+const group = (id, rootId, count) => ({
+  message: { id, rootId, body: "x", author: "a" },
+  count,
+});
+
+test("keys each collapsed reply by its thread root id", () => {
+  const map = buildSurfacedByRoot([
+    group("nested1", "rootA", 3),
+    group("nested2", "rootB", 1),
+  ]);
+  assert.equal(map.size, 2);
+  assert.equal(map.get("rootA").count, 3);
+  assert.equal(map.get("rootB").count, 1);
+});
+
+test("a reply with no rootId keys by its own id (it is its own thread root)", () => {
+  const map = buildSurfacedByRoot([group("solo", null, 1)]);
+  assert.equal(map.get("solo").count, 1);
+});
+
+test("a root entry id that is NOT a surfaced thread key yields no pill (undefined)", () => {
+  // The renderer attaches via map.get(entry.message.id). An entry whose id is
+  // not a surfaced thread key gets nothing — the common "this root has no
+  // buried replies to me" case.
+  const map = buildSurfacedByRoot([group("nested", "rootA", 2)]);
+  assert.equal(map.get("some-other-root"), undefined);
+});
+
+test("broadcast-root / off-window edge: a key matching no entry yields no pill, no throw", () => {
+  // A surfaced thread whose root id is absent from the rendered entries (the
+  // root scrolled out, or a broadcast-rooted subthread whose marker points at a
+  // non-entry). The renderer looks up by ENTRY id, so this key is simply never
+  // queried -> no pill, no orphan, no throw. Modeled here: the key exists in the
+  // map but no entry id will ever equal it.
+  const map = buildSurfacedByRoot([group("nested", "absent-root", 5)]);
+  const entryIds = new Set(["visibleRootA", "visibleRootB"]);
+  const pills = [...entryIds].map((id) => map.get(id)).filter(Boolean);
+  assert.deepEqual(pills, []);
+  // The orphan key is present in the map but never resolves to a rendered pill.
+  assert.equal(entryIds.has("absent-root"), false);
+});

--- a/desktop/src/features/messages/ui/SurfacedReplyRow.tsx
+++ b/desktop/src/features/messages/ui/SurfacedReplyRow.tsx
@@ -1,0 +1,72 @@
+import type { TimelineMessage } from "@/features/messages/types";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+import { surfacedReplyLabel } from "./surfacedReplyLabel.mjs";
+
+/**
+ * A read-time pointer that surfaces buried agent replies to the viewer up to
+ * the root timeline, at the most-recent reply's `createdAt`. The real messages
+ * are never moved or copied; clicking navigates DOWN to the most-recent reply in
+ * its thread (open the thread at its `rootId`, scroll to and highlight it).
+ *
+ * One pointer represents a whole thread's buried replies, framed as
+ * "{author} replied to you" with a single-line snippet of the most-recent reply
+ * so the pill is self-explanatory at a glance. For `count > 1` a quiet
+ * "· N replies" suffix follows the snippet; the count is never the headline. An
+ * empty/whitespace-only reply body drops the snippet (no empty quotes).
+ *
+ * Reuses the visual idiom of `MessageThreadSummaryRow` (rounded pill, avatar,
+ * muted label) but is a distinct component: a thread summary means
+ * reply-count/participants and opens a panel rooted at itself, whereas this
+ * points at the most-recent buried reply and navigates down to it.
+ */
+export function SurfacedReplyRow({
+  count,
+  message,
+  onNavigate,
+}: {
+  count: number;
+  message: TimelineMessage;
+  onNavigate: (message: TimelineMessage) => void;
+}) {
+  const { snippet, countSuffix } = surfacedReplyLabel({
+    body: message.body,
+    count,
+  });
+  return (
+    <div className="relative pb-1 pt-0.5">
+      <button
+        aria-label={`Go to ${message.author}'s reply to you`}
+        className="group relative isolate inline-flex h-8 w-fit max-w-full cursor-pointer items-center gap-1.5 rounded-full text-left text-xs font-medium text-muted-foreground transition-[color,opacity] before:pointer-events-none before:absolute before:-bottom-0.5 before:-left-0.5 before:-right-2 before:-top-0.5 before:-z-10 before:rounded-full before:content-[''] before:transition-[background-color,box-shadow] hover:text-foreground hover:opacity-90 hover:before:bg-background/95 hover:before:ring-1 hover:before:ring-border/70 focus-visible:outline-hidden focus-visible:before:bg-background/95 focus-visible:before:ring-1 focus-visible:before:ring-ring"
+        data-surfaced-reply-id={message.id}
+        data-testid="surfaced-reply-row"
+        onClick={() => onNavigate(message)}
+        type="button"
+      >
+        <UserAvatar
+          avatarUrl={message.avatarUrl ?? null}
+          className="ml-0.5 h-7 w-7"
+          displayName={message.author}
+          size="sm"
+        />
+        <div className="flex min-w-0 items-baseline gap-1">
+          <span className="shrink-0 font-medium transition-colors group-hover:text-foreground">
+            {message.author}
+          </span>
+          <span className="shrink-0 font-normal text-muted-foreground/70">
+            replied to you
+          </span>
+          {snippet ? (
+            <span className="truncate font-normal text-muted-foreground/50">
+              — “{snippet}”
+            </span>
+          ) : null}
+          {countSuffix ? (
+            <span className="shrink-0 font-normal text-muted-foreground/50">
+              · {countSuffix}
+            </span>
+          ) : null}
+        </div>
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -1,10 +1,19 @@
 import * as React from "react";
 
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import {
   formatDayHeading,
   isSameDay,
   startOfLocalDaySeconds,
 } from "@/features/messages/lib/dateFormatters";
+import { collapseSurfacedReplies } from "@/features/messages/lib/collapseSurfacedReplies.mjs";
+import { surfaceReplies } from "@/features/messages/lib/surfaceReplies.mjs";
+import { buildSurfacedByRoot } from "@/features/messages/lib/surfacedByRoot.mjs";
+import {
+  getThreadReplyIndentRem,
+  THREAD_REPLY_BODY_OFFSET_REM,
+  threadReplyLength,
+} from "@/features/messages/lib/threadTreeLayout";
 import {
   buildMainTimelineEntries,
   shouldRenderUnreadDivider,
@@ -22,6 +31,7 @@ import { cn } from "@/shared/lib/cn";
 import { DayDivider } from "./DayDivider";
 import { MessageRow } from "./MessageRow";
 import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
+import { SurfacedReplyRow } from "./SurfacedReplyRow";
 import { SystemMessageRow } from "./SystemMessageRow";
 import { UnreadDivider } from "./UnreadDivider";
 
@@ -87,6 +97,8 @@ type TimelineMessageRowModel = {
   key: string;
   message: TimelineMessage;
   summary: ReturnType<typeof buildMainTimelineEntries>[number]["summary"];
+  /** Buried replies-to-viewer in this root's thread, surfaced as an attached pill. */
+  surfaced?: { message: TimelineMessage; count: number };
   type: "message";
 };
 
@@ -104,20 +116,40 @@ type TimelineDayGroup = {
 };
 
 function buildTimelineRenderRows({
+  agentPubkeys,
+  currentPubkey,
   entries,
   firstUnreadMessageId,
   messages,
 }: {
+  agentPubkeys?: ReadonlySet<string>;
+  currentPubkey?: string;
   entries?: ReturnType<typeof buildMainTimelineEntries>;
   firstUnreadMessageId: string | null;
   messages: TimelineMessage[];
 }): TimelineRenderRow[] {
+  // The timeline renders only root entries. `isHuman` resolves unknown/undefined
+  // pubkeys to human so unrecognized authors under-surface (the fail-safe
+  // matching the pure-core contract); `surfaceReplies` keeps only replies
+  // p-tagging the viewer, then `collapseSurfacedReplies` folds each thread's
+  // buried replies into one representative carrying the group count. Each
+  // collapsed entry is ATTACHED to its thread-root entry (keyed by the root's
+  // own id) and renders as a pill below that root — never as a standalone row.
+  // Driving the attach from the entry side means a surfaced thread whose root
+  // is not a rendered entry (off-window, or a broadcast-rooted subthread whose
+  // root marker points elsewhere) simply contributes no pill: no orphan.
   entries ??= buildMainTimelineEntries(messages);
+  const isHuman = (pubkey?: string) =>
+    pubkey == null || !agentPubkeys?.has(pubkey);
+  const surfacedByRoot = buildSurfacedByRoot(
+    collapseSurfacedReplies(surfaceReplies(messages, isHuman, currentPubkey)),
+  );
   const rows: TimelineRenderRow[] = [];
   let previousMessage: TimelineMessage | null = null;
 
   for (let i = 0; i < entries.length; i++) {
-    const { message, summary } = entries[i];
+    const entry = entries[i];
+    const message = entry.message;
     const messageRenderKey = message.renderKey ?? message.id;
 
     if (
@@ -130,6 +162,7 @@ function buildTimelineRenderRows({
         type: "day",
       });
     }
+    previousMessage = message;
 
     // The unread "New" divider only marks a read/unread boundary when there is
     // a message above the first unread. When the first unread is the first
@@ -142,11 +175,10 @@ function buildTimelineRenderRows({
     rows.push({
       key: `msg:${messageRenderKey}`,
       message,
-      summary,
+      summary: entry.summary,
+      surfaced: surfacedByRoot.get(message.id),
       type: "message",
     });
-
-    previousMessage = message;
   }
 
   return rows;
@@ -211,14 +243,17 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
   threadUnreadCounts,
   unfollowThreadById,
 }: TimelineMessageListProps) {
+  const { goChannel } = useAppNavigation();
   const rows = React.useMemo(
     () =>
       buildTimelineRenderRows({
+        agentPubkeys,
+        currentPubkey,
         entries: mainEntries,
         firstUnreadMessageId,
         messages,
       }),
-    [firstUnreadMessageId, mainEntries, messages],
+    [agentPubkeys, currentPubkey, firstUnreadMessageId, mainEntries, messages],
   );
   const dayGroups = React.useMemo(() => buildTimelineDayGroups(rows), [rows]);
 
@@ -245,6 +280,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
               channelType={channelType}
               currentPubkey={currentPubkey}
               followThreadById={followThreadById}
+              goChannel={goChannel}
               highlightedMessageId={highlightedMessageId}
               isFollowingThreadById={isFollowingThreadById}
               isMessageUnreadById={isMessageUnreadById}
@@ -278,6 +314,7 @@ type TimelineRenderRowViewProps = Omit<
   "firstUnreadMessageId" | "messages" | "personaLookup"
 > & {
   allMessages?: TimelineMessage[];
+  goChannel: ReturnType<typeof useAppNavigation>["goChannel"];
   row: TimelineRenderRow;
 };
 
@@ -289,6 +326,7 @@ const TimelineRenderRowView = React.memo(function TimelineRenderRowView({
   channelType,
   currentPubkey,
   followThreadById,
+  goChannel,
   highlightedMessageId = null,
   isFollowingThreadById,
   isMessageUnreadById,
@@ -351,6 +389,37 @@ const TimelineRenderRowView = React.memo(function TimelineRenderRowView({
 
   const { message, summary } = row;
 
+  // The buried-replies-to-viewer pill, attached below this root message. It is
+  // indented to the root's body gutter with the SAME source the thread-summary
+  // row uses (`getThreadReplyIndentRem(depth) + THREAD_REPLY_BODY_OFFSET_REM`),
+  // so the two pills share one indent definition and stay aligned under the
+  // message body — never drifting to the channel margin. Extracted once so all
+  // three root-render branches share it. Click navigates DOWN to the most-recent
+  // surfaced reply; `threadRootId` prefetches the thread root in
+  // ChannelRouteScreen so the open finds the head even when the root is outside
+  // the loaded window — the same mechanism search hits use.
+  const surfacedPill = row.surfaced ? (
+    <div
+      style={{
+        marginLeft: threadReplyLength(
+          getThreadReplyIndentRem(message.depth) + THREAD_REPLY_BODY_OFFSET_REM,
+        ),
+      }}
+    >
+      <SurfacedReplyRow
+        count={row.surfaced.count}
+        message={row.surfaced.message}
+        onNavigate={(target) => {
+          if (!channelId) return;
+          void goChannel(channelId, {
+            messageId: target.id,
+            threadRootId: target.rootId,
+          });
+        }}
+      />
+    </div>
+  ) : null;
+
   if (message.kind === KIND_SYSTEM_MESSAGE) {
     const footer = messageFooters?.[message.id] ?? null;
     return (
@@ -361,6 +430,7 @@ const TimelineRenderRowView = React.memo(function TimelineRenderRowView({
           onToggleReaction={onToggleReaction}
           profiles={profiles}
         />
+        {surfacedPill}
         {footer}
       </div>
     );
@@ -423,6 +493,7 @@ const TimelineRenderRowView = React.memo(function TimelineRenderRowView({
           summary={summary}
           unreadCount={threadUnreadCounts?.get(message.id)}
         />
+        {surfacedPill}
         {footer}
       </div>
     );
@@ -459,6 +530,7 @@ const TimelineRenderRowView = React.memo(function TimelineRenderRowView({
         showDepthGuides={false}
         videoReviewContext={videoReviewContext}
       />
+      {surfacedPill}
       {footer}
     </div>
   );

--- a/desktop/src/features/messages/ui/surfacedReplyLabel.d.mts
+++ b/desktop/src/features/messages/ui/surfacedReplyLabel.d.mts
@@ -1,0 +1,21 @@
+/**
+ * Type declarations for the pure label derivation in `surfacedReplyLabel.mjs`.
+ * Runtime lives in `.mjs` so the (TS-loader-less) `node:test` runner imports it
+ * directly; this file gives TypeScript callers a typed view.
+ */
+
+/** Single-line, truncated preview of a reply body; null when empty/whitespace-only. */
+export function deriveSnippet(body: string | null | undefined): string | null;
+
+/** Presentational parts of a surfaced-reply pill. */
+export type SurfacedReplyLabel = {
+  /** Single-line truncated body preview, or null to render the no-snippet idiom. */
+  snippet: string | null;
+  /** "N replies" suffix for N>1, or null for a single reply. */
+  countSuffix: string | null;
+};
+
+export function surfacedReplyLabel(args: {
+  body: string | null | undefined;
+  count: number;
+}): SurfacedReplyLabel;

--- a/desktop/src/features/messages/ui/surfacedReplyLabel.mjs
+++ b/desktop/src/features/messages/ui/surfacedReplyLabel.mjs
@@ -1,0 +1,49 @@
+/**
+ * Pure derivation of the presentational parts of a surfaced-reply pill, so the
+ * label logic is unit-testable without a DOM (the runner is `node --test` over
+ * `.mjs`, no React renderer). `SurfacedReplyRow` renders these parts as:
+ *
+ *   {author} replied to you — "{snippet}" · {countSuffix}
+ *
+ * with the em-dash + quotes shown only when `snippet` is non-null and the
+ * `· {countSuffix}` shown only when `countSuffix` is non-null.
+ *
+ * Lives in `.mjs` (not `.ts`) so the TS-loader-less test runner imports the same
+ * source production uses; the sibling `.d.mts` types it for TypeScript callers.
+ */
+
+/** Max snippet length before truncation; chosen to fit one pill line. */
+const SNIPPET_MAX = 72;
+const ELLIPSIS = "…";
+
+/**
+ * Collapse a reply body to a single-line preview: newlines/runs of whitespace
+ * become one space, trimmed, truncated to SNIPPET_MAX with an ellipsis. Returns
+ * null for an empty/whitespace-only body so the caller renders the no-snippet
+ * idiom rather than empty quotes.
+ *
+ * @param {string | null | undefined} body
+ * @returns {string | null}
+ */
+export function deriveSnippet(body) {
+  const oneLine = (body ?? "").replace(/\s+/g, " ").trim();
+  if (oneLine === "") return null;
+  if (oneLine.length <= SNIPPET_MAX) return oneLine;
+  return oneLine.slice(0, SNIPPET_MAX).trimEnd() + ELLIPSIS;
+}
+
+/**
+ * The two presentational parts of the pill. `countSuffix` is null for a single
+ * reply (the headline already reads "replied to you") and `"N replies"` for N>1
+ * so the count rides as a quiet suffix, never the headline. Count 1 never reads
+ * "1 replies".
+ *
+ * @param {{ body: string | null | undefined, count: number }} args
+ * @returns {{ snippet: string | null, countSuffix: string | null }}
+ */
+export function surfacedReplyLabel({ body, count }) {
+  return {
+    snippet: deriveSnippet(body),
+    countSuffix: count > 1 ? `${count} replies` : null,
+  };
+}

--- a/desktop/src/features/messages/ui/surfacedReplyLabel.test.mjs
+++ b/desktop/src/features/messages/ui/surfacedReplyLabel.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { deriveSnippet, surfacedReplyLabel } from "./surfacedReplyLabel.mjs";
+
+test("snippet collapses whitespace and newlines to single spaces, trimmed", () => {
+  assert.equal(
+    deriveSnippet("  the   rebase\nis\t\tclean  "),
+    "the rebase is clean",
+  );
+});
+
+test("a short body is returned verbatim (after whitespace collapse)", () => {
+  assert.equal(deriveSnippet("ready for your merge"), "ready for your merge");
+});
+
+test("empty body returns null (caller renders the no-snippet idiom)", () => {
+  assert.equal(deriveSnippet(""), null);
+});
+
+test("whitespace-only body returns null", () => {
+  assert.equal(deriveSnippet("   \n\t  "), null);
+});
+
+test("null/undefined body returns null", () => {
+  assert.equal(deriveSnippet(null), null);
+  assert.equal(deriveSnippet(undefined), null);
+});
+
+test("a long single-line body truncates to the budget with an ellipsis", () => {
+  const body = "x".repeat(200);
+  const out = deriveSnippet(body);
+  // 72 chars + the single-char ellipsis.
+  assert.equal(out.length, 73);
+  assert.ok(out.endsWith("…"));
+  assert.equal(out.slice(0, 72), "x".repeat(72));
+});
+
+test("truncation trims trailing space before the ellipsis (no '… ' gap)", () => {
+  // 71 non-space chars then spaces then more text: cut at 72 lands mid-space.
+  const body = `${"a".repeat(71)}   tail words here that overflow the budget`;
+  const out = deriveSnippet(body);
+  assert.ok(out.endsWith("…"));
+  assert.ok(!out.includes(" …"), `no space before ellipsis: ${out}`);
+});
+
+test("body exactly at the budget is not truncated", () => {
+  const body = "y".repeat(72);
+  assert.equal(deriveSnippet(body), body);
+});
+
+test("label: count 1 yields a snippet and no count suffix", () => {
+  const { snippet, countSuffix } = surfacedReplyLabel({
+    body: "the deploy is green",
+    count: 1,
+  });
+  assert.equal(snippet, "the deploy is green");
+  assert.equal(countSuffix, null);
+});
+
+test("label: count > 1 demotes the count to an 'N replies' suffix after the snippet", () => {
+  const { snippet, countSuffix } = surfacedReplyLabel({
+    body: "first of several",
+    count: 3,
+  });
+  assert.equal(snippet, "first of several");
+  assert.equal(countSuffix, "3 replies");
+});
+
+test("label: count 1 never reads '1 replies'", () => {
+  assert.equal(surfacedReplyLabel({ body: "hi", count: 1 }).countSuffix, null);
+});
+
+test("label: empty body with count > 1 keeps the suffix but drops the snippet", () => {
+  const { snippet, countSuffix } = surfacedReplyLabel({ body: "", count: 4 });
+  assert.equal(snippet, null);
+  assert.equal(countSuffix, "4 replies");
+});

--- a/desktop/tests/e2e/relay-connectivity-screenshots.spec.ts
+++ b/desktop/tests/e2e/relay-connectivity-screenshots.spec.ts
@@ -14,14 +14,19 @@ const MOCK_PUBKEY = "deadbeef".repeat(8);
 const MOCK_RELAY_URL = "ws://localhost:3000";
 const SELF_PROFILE_CACHE_KEY = `buzz-self-profile.v1:${MOCK_RELAY_URL}:${MOCK_PUBKEY}`;
 
+// Wait for mount animations to settle before screenshotting. A cancelled or
+// replaced animation's `finished` promise can hang or reject, tearing down the
+// evaluate context mid-await (AbortError). Cap each wait and swallow rejections
+// so settle() always resolves quickly without a flaky race.
 async function settle(page: import("@playwright/test").Page) {
-  await page.evaluate(() =>
-    // Tolerate cancelled animations: a SkeletonReveal animation cancelled
-    // mid-flight (skeleton → live content swap) rejects `.finished` with an
-    // AbortError. allSettled lets the animations that DO finish settle instead
-    // of aborting the whole wait on the first cancel.
-    Promise.allSettled(document.getAnimations().map((a) => a.finished)),
-  );
+  await page.evaluate(async () => {
+    const guard = (p: Promise<unknown>) =>
+      Promise.race([
+        p.catch(() => {}),
+        new Promise((resolve) => setTimeout(resolve, 1000)),
+      ]);
+    await Promise.all(document.getAnimations().map((a) => guard(a.finished)));
+  });
 }
 
 type ConnectionState =

--- a/desktop/tests/e2e/reply-surfacing-screenshots.spec.ts
+++ b/desktop/tests/e2e/reply-surfacing-screenshots.spec.ts
@@ -1,0 +1,219 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const SHOTS = "test-results/reply-surfacing";
+
+// The mock identity (self) — a human, not in mockAgentPubkeys.
+const SELF_PUBKEY = "deadbeef".repeat(8);
+
+async function waitForMockLiveSubscription(page: Page, channelName: string) {
+  await expect
+    .poll(async () => {
+      return page.evaluate((channelName) => {
+        return (
+          (
+            window as Window & {
+              __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                channelName: string;
+              }) => boolean;
+            }
+          ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({ channelName }) ?? false
+        );
+      }, channelName);
+    })
+    .toBe(true);
+}
+
+type EmitInput = {
+  channelName: string;
+  content: string;
+  parentEventId?: string | null;
+  pubkey?: string;
+  mentionPubkeys?: string[];
+};
+
+function emitMockMessage(page: Page, input: EmitInput) {
+  return page.evaluate((input) => {
+    const emit = (
+      window as Window & {
+        __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+          channelName: string;
+          content: string;
+          parentEventId?: string | null;
+          pubkey?: string;
+          mentionPubkeys?: string[];
+        }) => { id: string; created_at: number };
+      }
+    ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+    if (!emit) {
+      throw new Error("Mock message emitter is unavailable.");
+    }
+    return emit(input);
+  }, input);
+}
+
+test.describe("reply-surfacing screenshots", () => {
+  test.use({ viewport: { width: 1280, height: 720 } });
+
+  test("01 — surfaced reply appears in timeline", async ({ page }) => {
+    await installMockBridge(page);
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await waitForMockLiveSubscription(page, "general");
+
+    // Emit a root message from a human (bob).
+    const root = await emitMockMessage(page, {
+      channelName: "general",
+      content: "Can someone review the latest deploy?",
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+    });
+
+    // Emit a nested reply from an agent (alice) mentioning the self (human).
+    await emitMockMessage(page, {
+      channelName: "general",
+      content: "I reviewed the deploy — looks good, shipping now.",
+      parentEventId: root.id,
+      pubkey: TEST_IDENTITIES.alice.pubkey,
+      mentionPubkeys: [SELF_PUBKEY],
+    });
+
+    // Assert the surfaced-reply-row appears.
+    const surfacedRow = page.getByTestId("surfaced-reply-row");
+    await expect(surfacedRow).toBeVisible({ timeout: 5_000 });
+
+    // Screenshot the timeline area.
+    const timeline = page.getByTestId("message-timeline");
+    await timeline.screenshot({
+      path: `${SHOTS}/01-surfaced-reply-in-timeline.png`,
+    });
+  });
+
+  test("02 — multiple surfaced replies interleave chronologically", async ({
+    page,
+  }) => {
+    await installMockBridge(page);
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await waitForMockLiveSubscription(page, "general");
+
+    // Emit two root messages from a human.
+    const root1 = await emitMockMessage(page, {
+      channelName: "general",
+      content: "Thread one: design feedback needed",
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+    });
+
+    const root2 = await emitMockMessage(page, {
+      channelName: "general",
+      content: "Thread two: backend migration plan",
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+    });
+
+    // Agent replies to both threads, mentioning the human.
+    await emitMockMessage(page, {
+      channelName: "general",
+      content: "Design feedback: the spacing looks off on mobile.",
+      parentEventId: root1.id,
+      pubkey: TEST_IDENTITIES.alice.pubkey,
+      mentionPubkeys: [SELF_PUBKEY],
+    });
+
+    await emitMockMessage(page, {
+      channelName: "general",
+      content: "Migration plan reviewed — ready to proceed.",
+      parentEventId: root2.id,
+      pubkey: TEST_IDENTITIES.alice.pubkey,
+      mentionPubkeys: [SELF_PUBKEY],
+    });
+
+    // Assert multiple surfaced-reply-row elements appear.
+    const surfacedRows = page.getByTestId("surfaced-reply-row");
+    await expect(surfacedRows).toHaveCount(2, { timeout: 5_000 });
+
+    // Screenshot the timeline.
+    const timeline = page.getByTestId("message-timeline");
+    await timeline.screenshot({
+      path: `${SHOTS}/02-multiple-surfaced-replies.png`,
+    });
+  });
+
+  test("03 — agent-to-agent reply does NOT surface", async ({ page }) => {
+    await installMockBridge(page);
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await waitForMockLiveSubscription(page, "general");
+
+    // Emit a root message from a human.
+    const root = await emitMockMessage(page, {
+      channelName: "general",
+      content: "Kick off the pipeline when ready",
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+    });
+
+    // Agent replies mentioning ANOTHER agent (charlie) — no human p-tag.
+    await emitMockMessage(page, {
+      channelName: "general",
+      content: "Delegating pipeline kick-off to charlie.",
+      parentEventId: root.id,
+      pubkey: TEST_IDENTITIES.alice.pubkey,
+      mentionPubkeys: [TEST_IDENTITIES.charlie.pubkey],
+    });
+
+    // Wait a beat to ensure no surfaced row appears.
+    await page.waitForTimeout(1_000);
+
+    // Assert NO surfaced-reply-row appears.
+    const surfacedRows = page.getByTestId("surfaced-reply-row");
+    await expect(surfacedRows).toHaveCount(0);
+
+    // Screenshot the timeline showing no pointer row.
+    const timeline = page.getByTestId("message-timeline");
+    await timeline.screenshot({
+      path: `${SHOTS}/03-agent-to-agent-no-surface.png`,
+    });
+  });
+
+  test("04 — click navigates to nested message", async ({ page }) => {
+    await installMockBridge(page);
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await waitForMockLiveSubscription(page, "general");
+
+    // Emit a root message from a human.
+    const root = await emitMockMessage(page, {
+      channelName: "general",
+      content: "Status update on the release?",
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+    });
+
+    // Agent replies nested, mentioning self.
+    await emitMockMessage(page, {
+      channelName: "general",
+      content: "Release is on track — all checks green.",
+      parentEventId: root.id,
+      pubkey: TEST_IDENTITIES.alice.pubkey,
+      mentionPubkeys: [SELF_PUBKEY],
+    });
+
+    // Wait for the surfaced row.
+    const surfacedRow = page.getByTestId("surfaced-reply-row");
+    await expect(surfacedRow).toBeVisible({ timeout: 5_000 });
+
+    // Click the surfaced reply row.
+    await surfacedRow.click();
+
+    // Assert the thread panel opens.
+    const threadPanel = page.getByTestId("message-thread-panel");
+    await expect(threadPanel).toBeVisible({ timeout: 5_000 });
+
+    // Screenshot the opened thread panel.
+    await threadPanel.screenshot({
+      path: `${SHOTS}/04-click-navigates-to-thread.png`,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Agent replies addressed to you inside threads are invisible on the channel timeline, which renders only root-level entries. This surfaces those buried replies as read-time pointer rows at the reply's own `createdAt` — where your eye is. The real messages are never moved or copied; clicking a pointer navigates down to the most-recent buried reply in its thread and highlights it.

## Design

- **Attached to the root, not interleaved.** `surfaceReplies` is a pure projection that identifies the nested agent replies to surface; `collapseSurfacedReplies` folds each thread's into one representative, and `buildSurfacedByRoot` keys them by thread root id. Each pill renders ATTACHED directly below its thread-root message (same visual grammar as the thread-summary row), driven from the entry side. The originals stay nested; the pill augments its root rather than floating as a standalone row.
- **Viewer-only.** A reply surfaces only when it p-tags the **viewer** (the reader). An agent CC'ing another human is that human's signal, not noise in your feed. An unresolved viewer **fails closed** — surfaces nothing — rather than falling back to "any human", since over-surfacing is the failure mode this guards against.
- **Per-thread collapse.** `collapseSurfacedReplies` folds all surfaced replies sharing a thread (`rootId ?? id`) into **one** pointer carrying the group count, represented by the most-recent reply. In this team's threading model — where nearly every message is a nested reply — this is what keeps the timeline readable: a busy thread contributes one pill, not dozens.
- **Self-explanatory pill.** `SurfacedReplyRow` renders `{author} replied to you` followed by a single-line snippet of the most-recent reply (`surfacedReplyLabel` collapses whitespace and truncates), so the reader sees who and what at a glance. A collapsed group appends a quiet `· N replies` suffix after the snippet — the count is never the headline; an empty body drops the snippet rather than rendering empty quotes. Clicking routes via `goChannel(channelId, { messageId, threadRootId })` to the **most-recent** surfaced reply; `threadRootId` gates the root-event prefetch in `ChannelRouteScreen` so the open never dead-clicks when the thread root sits outside the loaded window. A surfaced thread whose root is not a rendered entry (off-window, or a broadcast-rooted subthread) contributes no pill — no detached orphan.

## Classification fail-safe

The human/agent classifier resolves unknown pubkeys to human (`pubkey == null || !agentPubkeys?.has(pubkey)`), so an unrecognized author under-surfaces rather than mis-surfaces.


