### PR TITLE
polish(agents): activity-feed transcript UI pass

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1356,6 +1356,7 @@ pub fn build_managed_agent_summary(
         max_turn_duration_seconds: record.max_turn_duration_seconds,
         parallelism: record.parallelism,
         system_prompt: effective_prompt,
+        avatar_url: record.avatar_url.clone(),
         model: effective_model,
         mcp_toolsets: record.mcp_toolsets.clone(),
         env_vars: record.env_vars.clone(),

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -224,6 +224,7 @@ pub struct ManagedAgentSummary {
     pub max_turn_duration_seconds: Option<u64>,
     pub parallelism: u32,
     pub system_prompt: Option<String>,
+    pub avatar_url: Option<String>,
     pub model: Option<String>,
     pub mcp_toolsets: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -11,9 +11,11 @@ import { asRecord, formatCodeValue, formatDuration } from "./agentSessionUtils";
 
 export function ToolItem({
   compact = false,
+  grouped = false,
   item,
 }: {
   compact?: boolean;
+  grouped?: boolean;
   item: Extract<TranscriptItem, { type: "tool" }>;
 }) {
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -32,7 +34,11 @@ export function ToolItem({
 
   return (
     <div
-      className={cn("not-prose w-full", compact ? "px-0" : "px-1")}
+      className={cn(
+        "not-prose w-full",
+        compact ? "px-0" : "px-1",
+        grouped ? "py-0" : compact ? "py-0.5" : "py-0.5",
+      )}
       data-testid="transcript-tool-item"
     >
       <details
@@ -42,7 +48,7 @@ export function ToolItem({
       >
         <summary
           className={cn(
-            "inline-flex max-w-full cursor-pointer list-none items-center gap-5 py-px",
+            "inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px",
             compactSummaryTone(),
           )}
         >

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -7,7 +7,11 @@ import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import type { TranscriptItem } from "./agentSessionTypes";
 import { getBuzzToolInfo } from "./agentSessionToolCatalog";
 import { buildCompactToolSummary } from "./agentSessionToolSummary";
-import { asRecord, formatCodeValue, formatDuration } from "./agentSessionUtils";
+import {
+  formatCodeValue,
+  getToolDurationDisplay,
+  isInlineImageData,
+} from "./agentSessionUtils";
 
 export function ToolItem({
   item,
@@ -20,7 +24,7 @@ export function ToolItem({
   const canonicalToolName = item.buzzToolName ?? item.toolName;
   const buzzTool = getBuzzToolInfo(canonicalToolName);
   const compactSummary = buildCompactToolSummary(item);
-  const duration = getToolDuration(item);
+  const duration = getToolDurationDisplay(item);
   const handleToggle = React.useCallback(
     (event: React.SyntheticEvent<HTMLDetailsElement>) => {
       setIsExpanded(event.currentTarget.open);
@@ -86,6 +90,10 @@ export function ToolItem({
 
 function compactSummaryTone() {
   return "text-muted-foreground/60 group-open:text-muted-foreground";
+}
+
+function resolveImageSrc(source: string): string {
+  return isInlineImageData(source) ? source : rewriteRelayUrl(source);
 }
 
 function CompactToolSummaryRow({
@@ -188,13 +196,6 @@ function CompactMessageSummary({
   );
 }
 
-function resolveImageSrc(source: string): string {
-  if (source.startsWith("data:image/")) {
-    return source;
-  }
-  return rewriteRelayUrl(source);
-}
-
 function ViewImageToolPreview({
   src,
   title,
@@ -294,48 +295,6 @@ function ImageLightbox({
   );
 }
 
-function getToolDuration(item: Extract<TranscriptItem, { type: "tool" }>) {
-  if (item.startedAt && item.completedAt) {
-    return formatDuration(item.startedAt, item.completedAt);
-  }
-
-  const resultRecord = asRecord(parseToolResultValue(item.result));
-  const durationMs =
-    getToolNumber(resultRecord, ["duration_ms", "durationMs"]) ??
-    getToolNumber(resultRecord, ["elapsed_ms", "elapsedMs"]);
-  return durationMs == null ? null : formatDurationMs(durationMs);
-}
-
-function getToolNumber(
-  record: Record<string, unknown>,
-  keys: string[],
-): number | null {
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === "number" && Number.isFinite(value)) {
-      return value;
-    }
-  }
-  return null;
-}
-
-function formatDurationMs(ms: number) {
-  if (ms < 0) return null;
-  const totalSeconds = ms / 1000;
-  if (totalSeconds < 60) {
-    return totalSeconds < 10
-      ? `${totalSeconds.toFixed(1)}s`
-      : `${Math.round(totalSeconds)}s`;
-  }
-  let minutes = Math.floor(totalSeconds / 60);
-  let seconds = Math.round(totalSeconds % 60);
-  if (seconds === 60) {
-    minutes += 1;
-    seconds = 0;
-  }
-  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
-}
-
 function ToolDetailBlocks({
   args,
   description,
@@ -415,21 +374,4 @@ function ToolCodeBlock({
       </pre>
     </div>
   );
-}
-
-function parseToolResultValue(result: string): unknown {
-  const trimmed = result.trim();
-  if (!trimmed) return null;
-
-  try {
-    const parsed = JSON.parse(trimmed);
-    if (typeof parsed !== "string") return parsed;
-    try {
-      return JSON.parse(parsed);
-    } catch {
-      return parsed;
-    }
-  } catch {
-    return null;
-  }
 }

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Send } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
@@ -40,16 +40,27 @@ export function ToolItem({
       >
         <summary
           className={cn(
-            "inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px",
+            "max-w-full cursor-pointer list-none py-px",
+            compactSummary.presentation === "inline" &&
+              "inline-flex items-center gap-1.5",
             compactSummaryTone(),
           )}
         >
-          <CompactToolSummaryRow
-            duration={duration}
-            preview={compactSummary.preview}
-            thumbnailSrc={compactSummary.thumbnailSrc}
-            label={compactSummary.label}
-          />
+          {compactSummary.presentation === "message" ? (
+            <CompactMessageSummary
+              duration={duration}
+              isError={item.isError || item.status === "failed"}
+              label={compactSummary.label}
+              preview={compactSummary.preview}
+            />
+          ) : (
+            <CompactToolSummaryRow
+              duration={duration}
+              preview={compactSummary.preview}
+              thumbnailSrc={compactSummary.thumbnailSrc}
+              label={compactSummary.label}
+            />
+          )}
         </summary>
 
         <ToolDetailBlocks
@@ -131,6 +142,52 @@ function CompactToolSummaryRow({
   );
 }
 
+function CompactMessageSummary({
+  duration,
+  isError,
+  label,
+  preview,
+}: {
+  duration: string | null;
+  isError: boolean;
+  label: string;
+  preview: string | null;
+}) {
+  const mutedTone = compactSummaryTone();
+  return (
+    <div className="flex max-w-[85%] flex-col items-start gap-1.5">
+      <div
+        className={cn(
+          "min-w-0 rounded-2xl border px-3 py-2 text-sm leading-relaxed shadow-sm",
+          isError
+            ? "border-destructive/25 bg-destructive/10 text-destructive"
+            : "border-primary/15 bg-primary/6 text-foreground",
+        )}
+        data-testid="transcript-tool-message-preview"
+      >
+        <p className="whitespace-pre-wrap wrap-break-word">
+          {preview || "Message content unavailable."}
+        </p>
+      </div>
+      <div className="inline-flex max-w-full items-center gap-1.5 px-1">
+        <Send className={cn("h-3.5 w-3.5 shrink-0", mutedTone)} />
+        <span className={cn("truncate text-xs font-medium", mutedTone)}>
+          {label}
+        </span>
+        {duration ? (
+          <span className={cn("shrink-0 text-xs", mutedTone)}>{duration}</span>
+        ) : null}
+        <ChevronDown
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180",
+            mutedTone,
+          )}
+        />
+      </div>
+    </div>
+  );
+}
+
 function resolveImageSrc(source: string): string {
   if (source.startsWith("data:image/")) {
     return source;
@@ -159,7 +216,7 @@ function ViewImageToolPreview({
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: opens lightbox on click */}
       <img
         alt={alt}
-        className="block max-h-64 max-w-sm cursor-pointer rounded-md object-contain"
+        className="ml-1.5 block max-h-64 max-w-[min(24rem,calc(100%-0.375rem))] cursor-pointer rounded-lg object-contain"
         decoding="async"
         loading="lazy"
         onClick={() => setLightboxOpen(true)}

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ArrowUpRight, ChevronDown, Wrench } from "lucide-react";
+import { ArrowUpRight, ChevronDown, CircleDot, Wrench } from "lucide-react";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
@@ -7,6 +7,7 @@ import { resolveUserLabel } from "@/features/profile/lib/identity";
 import type { Channel, UserProfileSummary } from "@/shared/api/types";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
 import { cn } from "@/shared/lib/cn";
+import { Badge } from "@/shared/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import type { TranscriptItem } from "./agentSessionTypes";
@@ -27,8 +28,12 @@ import {
 } from "./agentSessionUtils";
 
 export function ToolItem({
+  compact = false,
+  isActive = false,
   item,
 }: {
+  compact?: boolean;
+  isActive?: boolean;
   item: Extract<TranscriptItem, { type: "tool" }>;
 }) {
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -48,7 +53,15 @@ export function ToolItem({
   );
 
   return (
-    <div className="not-prose w-full px-1">
+    <div
+      className={cn(
+        "not-prose w-full",
+        compact ? "px-0" : "px-1",
+        isActive &&
+          "rounded-lg border border-primary/15 bg-primary/[0.03] px-2 py-1",
+      )}
+      data-testid="transcript-tool-item"
+    >
       <details
         className="group w-full"
         onToggle={handleToggle}
@@ -59,13 +72,22 @@ export function ToolItem({
             <ToolIcon
               className={cn(
                 "h-4 w-4 shrink-0",
-                buzzTool ? "text-primary" : "text-muted-foreground",
+                buzzTool || isActive ? "text-primary" : "text-muted-foreground",
               )}
             />
           ) : null}
           <span className="min-w-0 truncate text-sm font-medium">
             {toolTitle}
           </span>
+          {isActive ? (
+            <Badge
+              className="h-4 gap-0.5 px-1 text-[9px] font-normal"
+              variant="default"
+            >
+              <CircleDot className="h-2 w-2" />
+              Live
+            </Badge>
+          ) : null}
           {buzzTool ? (
             <BuzzToolInlineAction args={item.args} result={item.result} />
           ) : null}

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -81,7 +81,7 @@ export function ToolItem({
           </span>
           {isActive ? (
             <Badge
-              className="h-4 gap-0.5 px-1 text-[9px] font-normal"
+              className="h-4 gap-0.5 px-1 text-xs font-normal"
               variant="default"
             >
               <CircleDot className="h-2 w-2" />
@@ -220,7 +220,7 @@ function ToolTimestamp({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="shrink-0 cursor-default text-[11px] text-muted-foreground/60">
+        <span className="shrink-0 cursor-default text-xs text-muted-foreground/60">
           {time}
           {duration ? ` · ${duration}` : null}
         </span>
@@ -282,7 +282,7 @@ function BuzzToolInlineAction({
   if (action.onClick) {
     return (
       <button
-        className="inline-flex max-w-[14rem] shrink min-w-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/[0.05] px-1.5 py-0.5 text-[11px] font-normal leading-none text-primary/90 transition-colors hover:border-primary/35 hover:bg-primary/10 hover:text-primary"
+        className="inline-flex max-w-[14rem] shrink min-w-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/[0.05] px-1.5 py-0.5 text-xs font-normal leading-none text-primary/90 transition-colors hover:border-primary/35 hover:bg-primary/10 hover:text-primary"
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();
@@ -301,7 +301,7 @@ function BuzzToolInlineAction({
 
   return (
     <span
-      className="inline-flex max-w-[14rem] shrink min-w-0 items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-1.5 py-0.5 text-[11px] font-normal leading-none text-muted-foreground"
+      className="inline-flex max-w-[14rem] shrink min-w-0 items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs font-normal leading-none text-muted-foreground"
       title={action.title}
     >
       {action.avatar}

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -15,8 +15,11 @@ import {
   formatToolTitle,
   getBuzzToolInfo,
   getToolStatusDisplay,
-  normalizeToolNameText,
 } from "./agentSessionToolCatalog";
+import {
+  buildCompactToolSummary,
+  isCompactDeveloperTool,
+} from "./agentSessionToolSummary";
 import {
   asRecord,
   formatCodeValue,
@@ -46,7 +49,10 @@ export function ToolItem({
   const ToolIcon = buzzTool?.icon ?? Wrench;
   const showStatus = status.state !== "output-available";
   const toolTitle = formatToolTitle(canonicalToolName, item.title);
-  const isCommandTool = isShellCommandTool(item);
+  const useCompactSummary = isCompactDeveloperTool(item);
+  const compactSummary = useCompactSummary
+    ? buildCompactToolSummary(item)
+    : null;
   const duration = getToolDuration(item);
   const handleToggle = React.useCallback(
     (event: React.SyntheticEvent<HTMLDetailsElement>) => {
@@ -73,11 +79,15 @@ export function ToolItem({
         <summary
           className={cn(
             "inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px",
-            isCommandTool && "text-muted-foreground",
+            useCompactSummary && "text-muted-foreground",
           )}
         >
-          {isCommandTool ? (
-            <CommandToolSummary item={item} duration={duration} />
+          {compactSummary ? (
+            <CompactToolSummaryRow
+              duration={duration}
+              preview={compactSummary.preview}
+              label={compactSummary.label}
+            />
           ) : (
             <>
               {ToolIcon ? (
@@ -135,30 +145,24 @@ export function ToolItem({
   );
 }
 
-function CommandToolSummary({
+function CompactToolSummaryRow({
   duration,
-  item,
+  label,
+  preview,
 }: {
   duration: string | null;
-  item: Extract<TranscriptItem, { type: "tool" }>;
+  label: string;
+  preview: string | null;
 }) {
-  const command = getToolString(item.args, ["command"]);
-  const label =
-    item.status === "failed" || item.isError
-      ? "Command failed"
-      : item.status === "executing" || item.status === "pending"
-        ? "Running command"
-        : "Ran command";
-
   return (
     <>
       <span className="shrink-0 text-sm font-semibold">{label}</span>
-      {command ? (
+      {preview ? (
         <span
           className="min-w-0 max-w-48 truncate text-sm text-muted-foreground/70"
-          title={command}
+          title={preview}
         >
-          {command}
+          {preview}
         </span>
       ) : null}
       {duration ? (
@@ -169,14 +173,6 @@ function CommandToolSummary({
       <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
     </>
   );
-}
-
-function isShellCommandTool(item: Extract<TranscriptItem, { type: "tool" }>) {
-  return [item.buzzToolName, item.toolName, item.title].some((value) => {
-    if (!value) return false;
-    const normalized = normalizeToolNameText(value);
-    return normalized === "shell" || normalized.endsWith("_shell");
-  });
 }
 
 function getToolDuration(item: Extract<TranscriptItem, { type: "tool" }>) {

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -10,12 +10,8 @@ import { buildCompactToolSummary } from "./agentSessionToolSummary";
 import { asRecord, formatCodeValue, formatDuration } from "./agentSessionUtils";
 
 export function ToolItem({
-  compact = false,
-  grouped = false,
   item,
 }: {
-  compact?: boolean;
-  grouped?: boolean;
   item: Extract<TranscriptItem, { type: "tool" }>;
 }) {
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -34,11 +30,7 @@ export function ToolItem({
 
   return (
     <div
-      className={cn(
-        "not-prose w-full",
-        compact ? "px-0" : "px-1",
-        grouped ? "py-0" : compact ? "py-0.5" : "py-0.5",
-      )}
+      className="not-prose w-full px-0 py-0.5"
       data-testid="transcript-tool-item"
     >
       <details

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -1,60 +1,27 @@
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ArrowUpRight, ChevronDown, CircleDot, Wrench } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 
-import { useAppNavigation } from "@/app/navigation/useAppNavigation";
-import { useUsersBatchQuery } from "@/features/profile/hooks";
-import { resolveUserLabel } from "@/features/profile/lib/identity";
-import type { Channel, UserProfileSummary } from "@/shared/api/types";
-import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
 import { cn } from "@/shared/lib/cn";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
-import { Badge } from "@/shared/ui/badge";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
-import { UserAvatar } from "@/shared/ui/UserAvatar";
 import type { TranscriptItem } from "./agentSessionTypes";
-import {
-  formatToolTitle,
-  getBuzzToolInfo,
-  getToolStatusDisplay,
-} from "./agentSessionToolCatalog";
-import {
-  buildCompactToolSummary,
-  isCompactDeveloperTool,
-} from "./agentSessionToolSummary";
-import {
-  asRecord,
-  formatCodeValue,
-  formatDuration,
-  formatTranscriptTime,
-  getResultArray,
-  getToolString,
-  getToolStringList,
-  shortenMiddle,
-} from "./agentSessionUtils";
+import { getBuzzToolInfo } from "./agentSessionToolCatalog";
+import { buildCompactToolSummary } from "./agentSessionToolSummary";
+import { asRecord, formatCodeValue, formatDuration } from "./agentSessionUtils";
 
 export function ToolItem({
   compact = false,
-  isActive = false,
   item,
 }: {
   compact?: boolean;
-  isActive?: boolean;
   item: Extract<TranscriptItem, { type: "tool" }>;
 }) {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const status = getToolStatusDisplay(item.status, item.isError);
   const hasArgs = Object.keys(item.args).length > 0;
   const hasResult = item.result.trim().length > 0;
   const canonicalToolName = item.buzzToolName ?? item.toolName;
   const buzzTool = getBuzzToolInfo(canonicalToolName);
-  const ToolIcon = buzzTool?.icon ?? Wrench;
-  const showStatus = status.state !== "output-available";
-  const toolTitle = formatToolTitle(canonicalToolName, item.title);
-  const useCompactSummary = isCompactDeveloperTool(item);
-  const compactSummary = useCompactSummary
-    ? buildCompactToolSummary(item)
-    : null;
+  const compactSummary = buildCompactToolSummary(item);
   const duration = getToolDuration(item);
   const handleToggle = React.useCallback(
     (event: React.SyntheticEvent<HTMLDetailsElement>) => {
@@ -65,12 +32,7 @@ export function ToolItem({
 
   return (
     <div
-      className={cn(
-        "not-prose w-full",
-        compact ? "px-0" : "px-1",
-        isActive &&
-          "rounded-lg border border-primary/15 bg-primary/3 px-2 py-1",
-      )}
+      className={cn("not-prose w-full", compact ? "px-0" : "px-1")}
       data-testid="transcript-tool-item"
     >
       <details
@@ -80,59 +42,16 @@ export function ToolItem({
       >
         <summary
           className={cn(
-            "inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px",
-            useCompactSummary && "text-muted-foreground",
+            "inline-flex max-w-full cursor-pointer list-none items-center gap-5 py-px",
+            compactSummaryTone(),
           )}
         >
-          {compactSummary ? (
-            <CompactToolSummaryRow
-              duration={duration}
-              preview={compactSummary.preview}
-              thumbnailSrc={compactSummary.thumbnailSrc}
-              label={compactSummary.label}
-            />
-          ) : (
-            <>
-              {ToolIcon ? (
-                <ToolIcon
-                  className={cn(
-                    "h-4 w-4 shrink-0",
-                    buzzTool || isActive
-                      ? "text-primary"
-                      : "text-muted-foreground",
-                  )}
-                />
-              ) : null}
-              <span className="min-w-0 truncate text-sm font-medium">
-                {toolTitle}
-              </span>
-              {isActive ? (
-                <Badge
-                  className="h-4 gap-0.5 px-1 text-xs font-normal"
-                  variant="default"
-                >
-                  <CircleDot className="h-2 w-2" />
-                  Live
-                </Badge>
-              ) : null}
-              {buzzTool ? (
-                <BuzzToolInlineAction args={item.args} result={item.result} />
-              ) : null}
-              {showStatus ? (
-                <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
-                  <status.Icon
-                    className={cn(
-                      "h-4 w-4",
-                      item.status === "executing" && "animate-pulse",
-                    )}
-                  />
-                  {status.label}
-                </span>
-              ) : null}
-              <ToolTimestamp item={item} duration={duration} />
-              <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
-            </>
-          )}
+          <CompactToolSummaryRow
+            duration={duration}
+            preview={compactSummary.preview}
+            thumbnailSrc={compactSummary.thumbnailSrc}
+            label={compactSummary.label}
+          />
         </summary>
 
         <ToolDetailBlocks
@@ -141,7 +60,7 @@ export function ToolItem({
           hasArgs={hasArgs}
           hasResult={hasResult}
           imagePreview={
-            compactSummary?.kind === "view_image" && isExpanded
+            compactSummary.kind === "view_image" && isExpanded
               ? {
                   src: compactSummary.thumbnailSrc,
                   title: compactSummary.preview,
@@ -156,6 +75,10 @@ export function ToolItem({
   );
 }
 
+function compactSummaryTone() {
+  return "text-muted-foreground/60 group-open:text-muted-foreground";
+}
+
 function CompactToolSummaryRow({
   duration,
   label,
@@ -168,6 +91,7 @@ function CompactToolSummaryRow({
   thumbnailSrc: string | null;
 }) {
   const [thumbnailFailed, setThumbnailFailed] = React.useState(false);
+  const mutedTone = compactSummaryTone();
   const resolvedThumbnail = React.useMemo(() => {
     if (!thumbnailSrc || thumbnailFailed) return null;
     return resolveImageSrc(thumbnailSrc);
@@ -175,7 +99,9 @@ function CompactToolSummaryRow({
 
   return (
     <>
-      <span className="shrink-0 text-sm font-semibold">{label}</span>
+      <span className={cn("shrink-0 text-sm font-semibold", mutedTone)}>
+        {label}
+      </span>
       {resolvedThumbnail ? (
         <img
           alt=""
@@ -188,18 +114,21 @@ function CompactToolSummaryRow({
         />
       ) : preview ? (
         <span
-          className="min-w-0 max-w-48 truncate text-sm text-muted-foreground/70"
+          className={cn("min-w-0 max-w-48 truncate text-sm", mutedTone)}
           title={preview}
         >
           {preview}
         </span>
       ) : null}
       {duration ? (
-        <span className="shrink-0 text-xs text-muted-foreground/70">
-          {duration}
-        </span>
+        <span className={cn("shrink-0 text-xs", mutedTone)}>{duration}</span>
       ) : null}
-      <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+      <ChevronDown
+        className={cn(
+          "h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180",
+          mutedTone,
+        )}
+      />
     </>
   );
 }
@@ -433,239 +362,6 @@ function ToolCodeBlock({
   );
 }
 
-const toolFullDateTimeFormat = new Intl.DateTimeFormat(undefined, {
-  weekday: "long",
-  year: "numeric",
-  month: "long",
-  day: "numeric",
-  hour: "numeric",
-  minute: "2-digit",
-  second: "2-digit",
-});
-
-function ToolTimestamp({
-  duration,
-  item,
-}: {
-  duration: string | null;
-  item: Extract<TranscriptItem, { type: "tool" }>;
-}) {
-  const time = formatTranscriptTime(item.timestamp);
-  if (!time) return null;
-  const date = new Date(item.timestamp);
-  const fullDateTime = Number.isNaN(date.getTime())
-    ? item.timestamp
-    : toolFullDateTimeFormat.format(date);
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="shrink-0 cursor-default text-xs text-muted-foreground/60">
-          {time}
-          {duration ? ` · ${duration}` : null}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top">{fullDateTime}</TooltipContent>
-    </Tooltip>
-  );
-}
-
-function BuzzToolInlineAction({
-  args,
-  result,
-}: {
-  args: Record<string, unknown>;
-  result: string;
-}) {
-  const { channels } = useChannelNavigation();
-  const { goChannel } = useAppNavigation();
-  const resultValue = React.useMemo(
-    () => parseToolResultValue(result),
-    [result],
-  );
-  const resultRecord = asRecord(resultValue);
-  const channelId =
-    getToolString(args, ["channel_id", "channelId"]) ??
-    getToolString(resultRecord, ["channel_id", "channelId"]);
-  const pubkeys = React.useMemo(
-    () => getToolStringList(args, ["pubkeys", "pubkey"]),
-    [args],
-  );
-  const profilesQuery = useUsersBatchQuery(pubkeys, {
-    enabled: pubkeys.length > 0,
-  });
-  const profiles = profilesQuery.data?.profiles;
-  const openChannel = React.useCallback(
-    (messageId?: string) => {
-      if (!channelId) return;
-      void goChannel(channelId, messageId ? { messageId } : undefined);
-    },
-    [channelId, goChannel],
-  );
-  const action = React.useMemo(
-    () =>
-      getBuzzToolInlineAction({
-        args,
-        channelId,
-        channels,
-        openChannel,
-        profiles,
-        resultValue,
-      }),
-    [args, channelId, channels, openChannel, profiles, resultValue],
-  );
-
-  if (!action) {
-    return null;
-  }
-
-  if (action.onClick) {
-    return (
-      <button
-        className="inline-flex max-w-56 shrink min-w-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-1.5 py-0.5 text-xs font-normal leading-none text-primary/90 transition-colors hover:border-primary/35 hover:bg-primary/10 hover:text-primary"
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          action.onClick?.();
-        }}
-        title={action.title}
-        type="button"
-      >
-        {action.avatar}
-        <span className="shrink-0">{action.label}</span>
-        <span className="truncate">{action.value}</span>
-        <ArrowUpRight className="h-4 w-4 shrink-0" />
-      </button>
-    );
-  }
-
-  return (
-    <span
-      className="inline-flex max-w-56 shrink min-w-0 items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs font-normal leading-none text-muted-foreground"
-      title={action.title}
-    >
-      {action.avatar}
-      <span className="shrink-0">{action.label}</span>
-      <span className="truncate">{action.value}</span>
-    </span>
-  );
-}
-
-type BuzzToolInlineActionModel = {
-  avatar?: React.ReactNode;
-  label: string;
-  value: string;
-  title: string;
-  onClick?: () => void;
-};
-
-function getBuzzToolInlineAction({
-  args,
-  channelId,
-  channels,
-  openChannel,
-  profiles,
-  resultValue,
-}: {
-  args: Record<string, unknown>;
-  channelId: string | null;
-  channels: Channel[];
-  openChannel: (messageId?: string) => void;
-  profiles: Record<string, UserProfileSummary> | undefined;
-  resultValue: unknown;
-}): BuzzToolInlineActionModel | null {
-  const resultRecord = asRecord(resultValue);
-  const eventId =
-    getToolString(args, ["event_id", "eventId"]) ??
-    getToolString(resultRecord, ["event_id", "eventId", "id"]);
-
-  if (eventId && channelId) {
-    return {
-      label: resultRecord.accepted === true ? "posted" : "event",
-      onClick: () => openChannel(eventId),
-      title: eventId,
-      value: getChannelChipLabel(channels, channelId),
-    };
-  }
-
-  const messages = getResultArray(resultValue, resultRecord, "messages");
-  if (messages) {
-    return {
-      label: "read",
-      onClick: channelId ? () => openChannel() : undefined,
-      title: `${messages.length} messages`,
-      value: `${messages.length} message${messages.length === 1 ? "" : "s"}`,
-    };
-  }
-
-  if (channelId) {
-    return {
-      label: "channel",
-      onClick: () => openChannel(),
-      title: channelId,
-      value: getChannelChipLabel(channels, channelId),
-    };
-  }
-
-  const workflowId =
-    getToolString(args, ["workflow_id", "workflowId"]) ??
-    getToolString(resultRecord, ["workflow_id", "workflowId"]);
-  if (workflowId) {
-    return {
-      label: "workflow",
-      title: workflowId,
-      value: shortenMiddle(workflowId, 26),
-    };
-  }
-
-  const pubkeys = getToolStringList(args, ["pubkeys", "pubkey"]);
-  if (pubkeys.length > 0) {
-    if (pubkeys.length === 1) {
-      const pk = pubkeys[0];
-      const displayName = resolveUserLabel({ pubkey: pk, profiles });
-      const profile = profiles?.[pk.toLowerCase()];
-      return {
-        avatar: (
-          <UserAvatar
-            avatarUrl={profile?.avatarUrl ?? null}
-            className="shrink-0"
-            displayName={displayName}
-            size="xs"
-          />
-        ),
-        label: "user",
-        title: pk,
-        value: displayName,
-      };
-    }
-    return {
-      label: "users",
-      title: pubkeys
-        .map((pk) => resolveUserLabel({ pubkey: pk, profiles }))
-        .join(", "),
-      value: `${pubkeys.length} users`,
-    };
-  }
-
-  const query = getToolString(args, ["query"]);
-  if (query) {
-    return {
-      label: "query",
-      title: query,
-      value: shortenMiddle(query, 30),
-    };
-  }
-
-  if (typeof resultRecord.accepted === "boolean") {
-    return {
-      label: "relay",
-      title: resultRecord.accepted ? "accepted" : "rejected",
-      value: resultRecord.accepted ? "accepted" : "rejected",
-    };
-  }
-
-  return null;
-}
-
 function parseToolResultValue(result: string): unknown {
   const trimmed = result.trim();
   if (!trimmed) return null;
@@ -681,9 +377,4 @@ function parseToolResultValue(result: string): unknown {
   } catch {
     return null;
   }
-}
-
-function getChannelChipLabel(channels: Channel[], channelId: string) {
-  const channel = channels.find((candidate) => candidate.id === channelId);
-  return channel ? `#${channel.name}` : `#${shortenMiddle(channelId, 22)}`;
 }

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { ArrowUpRight, ChevronDown, CircleDot, Wrench } from "lucide-react";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
@@ -7,6 +8,7 @@ import { resolveUserLabel } from "@/features/profile/lib/identity";
 import type { Channel, UserProfileSummary } from "@/shared/api/types";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
 import { cn } from "@/shared/lib/cn";
+import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { Badge } from "@/shared/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
@@ -86,6 +88,7 @@ export function ToolItem({
             <CompactToolSummaryRow
               duration={duration}
               preview={compactSummary.preview}
+              thumbnailSrc={compactSummary.thumbnailSrc}
               label={compactSummary.label}
             />
           ) : (
@@ -137,6 +140,14 @@ export function ToolItem({
           description={buzzTool?.label}
           hasArgs={hasArgs}
           hasResult={hasResult}
+          imagePreview={
+            compactSummary?.kind === "view_image" && isExpanded
+              ? {
+                  src: compactSummary.thumbnailSrc,
+                  title: compactSummary.preview,
+                }
+              : null
+          }
           isError={item.isError}
           result={item.result}
         />
@@ -149,15 +160,33 @@ function CompactToolSummaryRow({
   duration,
   label,
   preview,
+  thumbnailSrc,
 }: {
   duration: string | null;
   label: string;
   preview: string | null;
+  thumbnailSrc: string | null;
 }) {
+  const [thumbnailFailed, setThumbnailFailed] = React.useState(false);
+  const resolvedThumbnail = React.useMemo(() => {
+    if (!thumbnailSrc || thumbnailFailed) return null;
+    return resolveImageSrc(thumbnailSrc);
+  }, [thumbnailFailed, thumbnailSrc]);
+
   return (
     <>
       <span className="shrink-0 text-sm font-semibold">{label}</span>
-      {preview ? (
+      {resolvedThumbnail ? (
+        <img
+          alt=""
+          className="h-5 w-auto max-w-12 shrink-0 rounded-sm object-cover"
+          decoding="async"
+          loading="lazy"
+          onError={() => setThumbnailFailed(true)}
+          src={resolvedThumbnail}
+          title={preview ?? undefined}
+        />
+      ) : preview ? (
         <span
           className="min-w-0 max-w-48 truncate text-sm text-muted-foreground/70"
           title={preview}
@@ -172,6 +201,112 @@ function CompactToolSummaryRow({
       ) : null}
       <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
     </>
+  );
+}
+
+function resolveImageSrc(source: string): string {
+  if (source.startsWith("data:image/")) {
+    return source;
+  }
+  return rewriteRelayUrl(source);
+}
+
+function ViewImageToolPreview({
+  src,
+  title,
+}: {
+  src: string;
+  title: string | null;
+}) {
+  const [lightboxOpen, setLightboxOpen] = React.useState(false);
+  const [imageFailed, setImageFailed] = React.useState(false);
+  const resolvedSrc = React.useMemo(() => resolveImageSrc(src), [src]);
+  const alt = title ?? "Viewed image";
+
+  if (imageFailed) {
+    return null;
+  }
+
+  return (
+    <>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: opens lightbox on click */}
+      <img
+        alt={alt}
+        className="block max-h-64 max-w-sm cursor-pointer rounded-md object-contain"
+        decoding="async"
+        loading="lazy"
+        onClick={() => setLightboxOpen(true)}
+        onError={() => setImageFailed(true)}
+        src={resolvedSrc}
+        title={title ?? undefined}
+      />
+      <ImageLightbox
+        alt={alt}
+        onOpenChange={setLightboxOpen}
+        open={lightboxOpen}
+        src={resolvedSrc}
+      />
+    </>
+  );
+}
+
+function ImageLightbox({
+  alt,
+  onOpenChange,
+  open,
+  src,
+}: {
+  alt: string;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  src: string;
+}) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          className="fixed inset-0 z-50 flex items-center justify-center p-8"
+          onInteractOutside={(event) => event.preventDefault()}
+          onPointerDownOutside={(event) => event.preventDefault()}
+        >
+          <DialogPrimitive.Title className="sr-only">
+            {alt}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Full-size image preview. Press Escape or click outside the image to
+            close.
+          </DialogPrimitive.Description>
+          <DialogPrimitive.Close
+            aria-label="Close lightbox"
+            className="absolute inset-0 cursor-default"
+          />
+          <img
+            alt={alt}
+            className="relative max-h-[90vh] max-w-[90vw] rounded-lg object-contain"
+            src={src}
+          />
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full bg-black/50 p-2 text-white/80 transition-colors hover:bg-black/70 hover:text-white focus:outline-hidden focus:ring-2 focus:ring-white/30">
+            <svg
+              aria-hidden="true"
+              fill="none"
+              height="20"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M18 6L6 18M6 6l12 12"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+              />
+            </svg>
+          </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 }
 
@@ -222,6 +357,7 @@ function ToolDetailBlocks({
   description,
   hasArgs,
   hasResult,
+  imagePreview,
   isError,
   result,
 }: {
@@ -229,6 +365,7 @@ function ToolDetailBlocks({
   description?: string;
   hasArgs: boolean;
   hasResult: boolean;
+  imagePreview: { src: string | null; title: string | null } | null;
   isError: boolean;
   result: string;
 }) {
@@ -238,6 +375,12 @@ function ToolDetailBlocks({
         <p className="max-w-2xl text-xs leading-5 text-muted-foreground">
           {description}
         </p>
+      ) : null}
+      {imagePreview?.src ? (
+        <ViewImageToolPreview
+          src={imagePreview.src}
+          title={imagePreview.title}
+        />
       ) : null}
       {hasArgs ? (
         <ToolCodeBlock

--- a/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionToolItem.tsx
@@ -15,6 +15,7 @@ import {
   formatToolTitle,
   getBuzzToolInfo,
   getToolStatusDisplay,
+  normalizeToolNameText,
 } from "./agentSessionToolCatalog";
 import {
   asRecord,
@@ -45,6 +46,8 @@ export function ToolItem({
   const ToolIcon = buzzTool?.icon ?? Wrench;
   const showStatus = status.state !== "output-available";
   const toolTitle = formatToolTitle(canonicalToolName, item.title);
+  const isCommandTool = isShellCommandTool(item);
+  const duration = getToolDuration(item);
   const handleToggle = React.useCallback(
     (event: React.SyntheticEvent<HTMLDetailsElement>) => {
       setIsExpanded(event.currentTarget.open);
@@ -58,7 +61,7 @@ export function ToolItem({
         "not-prose w-full",
         compact ? "px-0" : "px-1",
         isActive &&
-          "rounded-lg border border-primary/15 bg-primary/[0.03] px-2 py-1",
+          "rounded-lg border border-primary/15 bg-primary/3 px-2 py-1",
       )}
       data-testid="transcript-tool-item"
     >
@@ -67,43 +70,56 @@ export function ToolItem({
         onToggle={handleToggle}
         open={isExpanded}
       >
-        <summary className="inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px">
-          {ToolIcon ? (
-            <ToolIcon
-              className={cn(
-                "h-4 w-4 shrink-0",
-                buzzTool || isActive ? "text-primary" : "text-muted-foreground",
-              )}
-            />
-          ) : null}
-          <span className="min-w-0 truncate text-sm font-medium">
-            {toolTitle}
-          </span>
-          {isActive ? (
-            <Badge
-              className="h-4 gap-0.5 px-1 text-xs font-normal"
-              variant="default"
-            >
-              <CircleDot className="h-2 w-2" />
-              Live
-            </Badge>
-          ) : null}
-          {buzzTool ? (
-            <BuzzToolInlineAction args={item.args} result={item.result} />
-          ) : null}
-          {showStatus ? (
-            <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
-              <status.Icon
-                className={cn(
-                  "h-4 w-4",
-                  item.status === "executing" && "animate-pulse",
-                )}
-              />
-              {status.label}
-            </span>
-          ) : null}
-          <ToolTimestamp item={item} />
-          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+        <summary
+          className={cn(
+            "inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px",
+            isCommandTool && "text-muted-foreground",
+          )}
+        >
+          {isCommandTool ? (
+            <CommandToolSummary item={item} duration={duration} />
+          ) : (
+            <>
+              {ToolIcon ? (
+                <ToolIcon
+                  className={cn(
+                    "h-4 w-4 shrink-0",
+                    buzzTool || isActive
+                      ? "text-primary"
+                      : "text-muted-foreground",
+                  )}
+                />
+              ) : null}
+              <span className="min-w-0 truncate text-sm font-medium">
+                {toolTitle}
+              </span>
+              {isActive ? (
+                <Badge
+                  className="h-4 gap-0.5 px-1 text-xs font-normal"
+                  variant="default"
+                >
+                  <CircleDot className="h-2 w-2" />
+                  Live
+                </Badge>
+              ) : null}
+              {buzzTool ? (
+                <BuzzToolInlineAction args={item.args} result={item.result} />
+              ) : null}
+              {showStatus ? (
+                <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+                  <status.Icon
+                    className={cn(
+                      "h-4 w-4",
+                      item.status === "executing" && "animate-pulse",
+                    )}
+                  />
+                  {status.label}
+                </span>
+              ) : null}
+              <ToolTimestamp item={item} duration={duration} />
+              <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+            </>
+          )}
         </summary>
 
         <ToolDetailBlocks
@@ -117,6 +133,92 @@ export function ToolItem({
       </details>
     </div>
   );
+}
+
+function CommandToolSummary({
+  duration,
+  item,
+}: {
+  duration: string | null;
+  item: Extract<TranscriptItem, { type: "tool" }>;
+}) {
+  const command = getToolString(item.args, ["command"]);
+  const label =
+    item.status === "failed" || item.isError
+      ? "Command failed"
+      : item.status === "executing" || item.status === "pending"
+        ? "Running command"
+        : "Ran command";
+
+  return (
+    <>
+      <span className="shrink-0 text-sm font-semibold">{label}</span>
+      {command ? (
+        <span
+          className="min-w-0 max-w-48 truncate text-sm text-muted-foreground/70"
+          title={command}
+        >
+          {command}
+        </span>
+      ) : null}
+      {duration ? (
+        <span className="shrink-0 text-xs text-muted-foreground/70">
+          {duration}
+        </span>
+      ) : null}
+      <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+    </>
+  );
+}
+
+function isShellCommandTool(item: Extract<TranscriptItem, { type: "tool" }>) {
+  return [item.buzzToolName, item.toolName, item.title].some((value) => {
+    if (!value) return false;
+    const normalized = normalizeToolNameText(value);
+    return normalized === "shell" || normalized.endsWith("_shell");
+  });
+}
+
+function getToolDuration(item: Extract<TranscriptItem, { type: "tool" }>) {
+  if (item.startedAt && item.completedAt) {
+    return formatDuration(item.startedAt, item.completedAt);
+  }
+
+  const resultRecord = asRecord(parseToolResultValue(item.result));
+  const durationMs =
+    getToolNumber(resultRecord, ["duration_ms", "durationMs"]) ??
+    getToolNumber(resultRecord, ["elapsed_ms", "elapsedMs"]);
+  return durationMs == null ? null : formatDurationMs(durationMs);
+}
+
+function getToolNumber(
+  record: Record<string, unknown>,
+  keys: string[],
+): number | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function formatDurationMs(ms: number) {
+  if (ms < 0) return null;
+  const totalSeconds = ms / 1000;
+  if (totalSeconds < 60) {
+    return totalSeconds < 10
+      ? `${totalSeconds.toFixed(1)}s`
+      : `${Math.round(totalSeconds)}s`;
+  }
+  let minutes = Math.floor(totalSeconds / 60);
+  let seconds = Math.round(totalSeconds % 60);
+  if (seconds === 60) {
+    minutes += 1;
+    seconds = 0;
+  }
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
 
 function ToolDetailBlocks({
@@ -180,7 +282,7 @@ function ToolCodeBlock({
       </h4>
       <pre
         className={cn(
-          "max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md px-3 py-2 font-mono text-xs leading-5",
+          "max-h-64 overflow-auto whitespace-pre-wrap wrap-break-word rounded-md px-3 py-2 font-mono text-xs leading-5",
           tone === "error"
             ? "bg-destructive/10 text-destructive"
             : "bg-muted/50 text-foreground",
@@ -203,16 +305,14 @@ const toolFullDateTimeFormat = new Intl.DateTimeFormat(undefined, {
 });
 
 function ToolTimestamp({
+  duration,
   item,
 }: {
+  duration: string | null;
   item: Extract<TranscriptItem, { type: "tool" }>;
 }) {
   const time = formatTranscriptTime(item.timestamp);
   if (!time) return null;
-  const duration =
-    item.startedAt && item.completedAt
-      ? formatDuration(item.startedAt, item.completedAt)
-      : null;
   const date = new Date(item.timestamp);
   const fullDateTime = Number.isNaN(date.getTime())
     ? item.timestamp
@@ -282,7 +382,7 @@ function BuzzToolInlineAction({
   if (action.onClick) {
     return (
       <button
-        className="inline-flex max-w-[14rem] shrink min-w-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/[0.05] px-1.5 py-0.5 text-xs font-normal leading-none text-primary/90 transition-colors hover:border-primary/35 hover:bg-primary/10 hover:text-primary"
+        className="inline-flex max-w-56 shrink min-w-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-1.5 py-0.5 text-xs font-normal leading-none text-primary/90 transition-colors hover:border-primary/35 hover:bg-primary/10 hover:text-primary"
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();
@@ -301,7 +401,7 @@ function BuzzToolInlineAction({
 
   return (
     <span
-      className="inline-flex max-w-[14rem] shrink min-w-0 items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs font-normal leading-none text-muted-foreground"
+      className="inline-flex max-w-56 shrink min-w-0 items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-1.5 py-0.5 text-xs font-normal leading-none text-muted-foreground"
       title={action.title}
     >
       {action.avatar}

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -3,6 +3,7 @@ import {
   AlertCircle,
   Bot,
   Brain,
+  CheckCheck,
   ChevronDown,
   CircleDot,
   Loader2,
@@ -19,9 +20,18 @@ import { cn } from "@/shared/lib/cn";
 import { Badge } from "@/shared/ui/badge";
 import { Markdown } from "@/shared/ui/markdown";
 import { Shimmer } from "@/shared/ui/Shimmer";
+import { Toggle } from "@/shared/ui/toggle";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
-import type { TranscriptItem } from "./agentSessionTypes";
+import type { PromptSection, TranscriptItem } from "./agentSessionTypes";
 import { ToolItem } from "./AgentSessionToolItem";
+import {
+  buildTranscriptDisplayBlocks,
+  formatTurnSetupLabel,
+  turnSetupDetail,
+  turnSetupTimestamp,
+  type TranscriptDisplayBlock,
+  type TranscriptTurnSegment,
+} from "./agentSessionTranscriptGrouping";
 import { buildTranscriptPresentation } from "./agentSessionTranscriptPresentation";
 import { formatTranscriptTime } from "./agentSessionUtils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
@@ -49,6 +59,10 @@ export function AgentSessionTranscriptList({
   const presentation = React.useMemo(
     () => buildTranscriptPresentation(items, isWorking),
     [items, isWorking],
+  );
+  const displayBlocks = React.useMemo(
+    () => buildTranscriptDisplayBlocks(items),
+    [items],
   );
 
   if (items.length === 0) {
@@ -81,26 +95,15 @@ export function AgentSessionTranscriptList({
         className={cn("w-full", compact ? "py-0.5" : "py-1")}
         role="log"
       >
-        {items.map((item) => (
-          <div
-            className={cn(
-              "first:mt-0",
-              compact ? "mt-2.5" : "mt-4",
-              getItemSpacingClass(item),
-            )}
-            key={item.id}
-          >
-            {SHOW_TRANSCRIPT_ACP_SOURCE && item.acpSource ? (
-              <TranscriptAcpSourceBadge source={item.acpSource} />
-            ) : null}
-            <TranscriptItemView
-              agentName={agentName}
-              compact={compact}
-              isActive={presentation.activeItemIds.has(item.id)}
-              item={item}
-              profiles={profiles}
-            />
-          </div>
+        {displayBlocks.map((block) => (
+          <TranscriptDisplayBlockView
+            activeItemIds={presentation.activeItemIds}
+            agentName={agentName}
+            block={block}
+            compact={compact}
+            key={getDisplayBlockKey(block)}
+            profiles={profiles}
+          />
         ))}
       </div>
     </div>
@@ -315,6 +318,351 @@ function getStateLabel(
   }
 }
 
+function getDisplayBlockKey(block: TranscriptDisplayBlock) {
+  if (block.kind === "single") {
+    return block.item.id;
+  }
+  return `turn:${block.turnId}`;
+}
+
+function TranscriptDisplayBlockView({
+  activeItemIds,
+  agentName,
+  block,
+  compact,
+  profiles,
+}: {
+  activeItemIds: ReadonlySet<string>;
+  agentName: string;
+  block: TranscriptDisplayBlock;
+  compact: boolean;
+  profiles?: UserProfileLookup;
+}) {
+  if (block.kind === "single") {
+    return (
+      <TranscriptItemRow
+        activeItemIds={activeItemIds}
+        agentName={agentName}
+        compact={compact}
+        item={block.item}
+        profiles={profiles}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn("first:mt-0", compact ? "mt-2.5" : "mt-4")}
+      data-testid="transcript-turn-group"
+      data-turn-id={block.turnId}
+    >
+      {block.segments.map((segment) => (
+        <TranscriptTurnSegmentView
+          activeItemIds={activeItemIds}
+          agentName={agentName}
+          compact={compact}
+          key={getTurnSegmentKey(block.turnId, segment)}
+          profiles={profiles}
+          segment={segment}
+        />
+      ))}
+    </div>
+  );
+}
+
+function getTurnSegmentKey(turnId: string, segment: TranscriptTurnSegment) {
+  if (segment.kind === "setup") {
+    return `turn:${turnId}:setup`;
+  }
+  if (segment.kind === "prompt") {
+    return `turn:${turnId}:prompt`;
+  }
+  return segment.item.id;
+}
+
+function TranscriptTurnSegmentView({
+  activeItemIds,
+  agentName,
+  compact,
+  profiles,
+  segment,
+}: {
+  activeItemIds: ReadonlySet<string>;
+  agentName: string;
+  compact: boolean;
+  profiles?: UserProfileLookup;
+  segment: TranscriptTurnSegment;
+}) {
+  if (segment.kind === "prompt") {
+    return (
+      <TurnPromptBlock
+        compact={compact}
+        context={segment.context}
+        profiles={profiles}
+        setup={segment.setup}
+        user={segment.user}
+      />
+    );
+  }
+
+  if (segment.kind === "setup") {
+    return <TurnSetupStatus compact={compact} items={segment.items} />;
+  }
+
+  return (
+    <TranscriptItemRow
+      activeItemIds={activeItemIds}
+      agentName={agentName}
+      compact={compact}
+      item={segment.item}
+      profiles={profiles}
+    />
+  );
+}
+
+function TurnPromptBlock({
+  compact,
+  context,
+  profiles,
+  setup,
+  user,
+}: {
+  compact: boolean;
+  context: Extract<TranscriptItem, { type: "metadata" }> | null;
+  profiles?: UserProfileLookup;
+  setup: Extract<TranscriptItem, { type: "lifecycle" }>[];
+  user: Extract<TranscriptItem, { type: "message" }>;
+}) {
+  return (
+    <div
+      className={cn("first:mt-0", compact ? "mt-2.5" : "mt-4")}
+      data-testid="transcript-prompt-bundle"
+    >
+      {SHOW_TRANSCRIPT_ACP_SOURCE ? (
+        <div className="mb-1 flex flex-wrap gap-1">
+          <TranscriptAcpSourceBadge source="session/prompt:user" />
+          {context ? (
+            <TranscriptAcpSourceBadge source="session/prompt:context" />
+          ) : null}
+        </div>
+      ) : null}
+      <PromptUserMessage
+        compact={compact}
+        context={context}
+        item={user}
+        profiles={profiles}
+        setup={setup}
+      />
+    </div>
+  );
+}
+
+function PromptUserMessage({
+  compact,
+  context = null,
+  item,
+  profiles,
+  setup = [],
+}: {
+  compact: boolean;
+  context?: Extract<TranscriptItem, { type: "metadata" }> | null;
+  item: Extract<TranscriptItem, { type: "message" }>;
+  profiles?: UserProfileLookup;
+  setup?: Extract<TranscriptItem, { type: "lifecycle" }>[];
+}) {
+  const [contextOpen, setContextOpen] = React.useState(false);
+  const text = item.text.trim();
+  const authorProfile = item.authorPubkey
+    ? profiles?.[item.authorPubkey.toLowerCase()]
+    : null;
+  const authorLabel = item.authorPubkey
+    ? resolveUserLabel({
+        pubkey: item.authorPubkey,
+        fallbackName: item.title,
+        profiles,
+      })
+    : item.title || "User";
+
+  return (
+    <div
+      className="flex flex-row"
+      data-role="user-message"
+      data-testid="transcript-user-message"
+    >
+      <UserAvatar
+        avatarUrl={authorProfile?.avatarUrl ?? null}
+        className="mr-2 mt-1 h-5 w-5 shrink-0 text-[8px]"
+        displayName={authorLabel}
+        size="xs"
+      />
+      <div className="group relative min-w-0 max-w-[85%] flex flex-col items-start gap-1">
+        <div
+          className={cn(
+            "w-full min-w-0 rounded-2xl bg-muted p-3 text-sm leading-relaxed text-foreground",
+            compact && "p-2.5",
+          )}
+        >
+          <p className="whitespace-pre-wrap break-words">{text}</p>
+          {contextOpen && context ? (
+            <PromptContextSections sections={context.sections} />
+          ) : null}
+        </div>
+        <TurnSetupFooter
+          context={context}
+          contextOpen={contextOpen}
+          items={setup}
+          onContextOpenChange={setContextOpen}
+          timestamp={item.timestamp}
+        />
+      </div>
+    </div>
+  );
+}
+
+function PromptContextSections({ sections }: { sections: PromptSection[] }) {
+  return (
+    <div
+      className="mt-2 space-y-2 border-t border-border/40 pt-2"
+      data-testid="transcript-prompt-context-sections"
+    >
+      {sections.map((section) => (
+        <details
+          className="group/section"
+          key={`${section.title}:${section.body.slice(0, 48)}`}
+        >
+          <summary className="inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 text-xs font-medium text-foreground/80">
+            <span className="truncate">{section.title}</span>
+            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open/section:rotate-180" />
+          </summary>
+          <pre className="mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/40 px-2 py-1.5 font-mono text-[11px] leading-5 text-muted-foreground">
+            {section.body.trim() || "No metadata."}
+          </pre>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+function TurnSetupFooter({
+  context = null,
+  contextOpen = false,
+  items,
+  onContextOpenChange,
+  timestamp,
+}: {
+  context?: Extract<TranscriptItem, { type: "metadata" }> | null;
+  contextOpen?: boolean;
+  items: Extract<TranscriptItem, { type: "lifecycle" }>[];
+  onContextOpenChange?: (open: boolean) => void;
+  timestamp: string;
+}) {
+  const label = formatTurnSetupLabel(items);
+  const detail = turnSetupDetail(items);
+  const tooltipText = [label, detail].filter(Boolean).join(" · ");
+  const showSetup = items.length > 0;
+  const showContext = context != null && context.sections.length > 0;
+
+  if (!showSetup && !showContext) {
+    return <TranscriptTimestamp timestamp={timestamp} />;
+  }
+
+  return (
+    <div
+      className="flex items-center gap-1.5 text-muted-foreground/80"
+      data-testid="transcript-turn-setup"
+    >
+      {showSetup ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className="inline-flex shrink-0 items-center justify-center rounded-sm text-muted-foreground/70 transition-colors hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              type="button"
+            >
+              <CheckCheck className="h-3.5 w-3.5" />
+              <span className="sr-only">{tooltipText}</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            <p>{tooltipText}</p>
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+      {showContext ? (
+        <Toggle
+          aria-label={`${contextOpen ? "Hide" : "Show"} prompt context`}
+          className="h-5 min-h-0 min-w-0 gap-1 rounded-md px-1.5 text-[10px] font-medium data-[state=on]:bg-muted data-[state=on]:text-foreground"
+          data-testid="transcript-prompt-context-toggle"
+          onPressedChange={onContextOpenChange}
+          pressed={contextOpen}
+          size="sm"
+          variant="outline"
+        >
+          Context
+          <span className="text-muted-foreground/70">
+            {context.sections.length}
+          </span>
+        </Toggle>
+      ) : null}
+      <TranscriptTimestamp timestamp={timestamp} />
+    </div>
+  );
+}
+
+function TranscriptItemRow({
+  activeItemIds,
+  agentName,
+  compact,
+  item,
+  profiles,
+}: {
+  activeItemIds: ReadonlySet<string>;
+  agentName: string;
+  compact: boolean;
+  item: TranscriptItem;
+  profiles?: UserProfileLookup;
+}) {
+  return (
+    <div
+      className={cn(
+        "first:mt-0",
+        compact ? "mt-2.5" : "mt-4",
+        getItemSpacingClass(item),
+      )}
+      key={item.id}
+    >
+      {SHOW_TRANSCRIPT_ACP_SOURCE && item.acpSource ? (
+        <TranscriptAcpSourceBadge source={item.acpSource} />
+      ) : null}
+      <TranscriptItemView
+        agentName={agentName}
+        compact={compact}
+        isActive={activeItemIds.has(item.id)}
+        item={item}
+        profiles={profiles}
+      />
+    </div>
+  );
+}
+
+function TurnSetupStatus({
+  compact,
+  items,
+}: {
+  compact: boolean;
+  items: Extract<TranscriptItem, { type: "lifecycle" }>[];
+}) {
+  const timestamp = turnSetupTimestamp(items);
+  if (items.length === 0 || !timestamp) {
+    return null;
+  }
+
+  return (
+    <div className={cn("rounded-md px-2 py-1.5", compact ? "mt-2" : "mt-2.5")}>
+      <TurnSetupFooter items={items} timestamp={timestamp} />
+    </div>
+  );
+}
+
 function getItemSpacingClass(item: TranscriptItem) {
   if (item.type === "lifecycle") {
     return "mt-2 first:mt-0";
@@ -495,16 +843,25 @@ function ThoughtItem({
 
 function MetadataItem({
   compact,
+  embedded = false,
   item,
 }: {
   compact: boolean;
+  embedded?: boolean;
   item: Extract<TranscriptItem, { type: "metadata" }>;
 }) {
   return (
     <details
       className={cn(
-        "group not-prose w-full rounded-md border border-border/50 bg-muted/20",
-        compact ? "px-2 py-1" : "px-2 py-1.5",
+        "group not-prose w-full",
+        embedded
+          ? compact
+            ? "px-2 py-1"
+            : "px-2.5 py-1.5"
+          : cn(
+              "rounded-md border border-border/50 bg-muted/20",
+              compact ? "px-2 py-1" : "px-2 py-1.5",
+            ),
       )}
       data-testid="transcript-metadata-item"
     >

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -1,32 +1,61 @@
 import * as React from "react";
-import { Bot, Brain, ChevronDown, Radio, TerminalSquare } from "lucide-react";
+import {
+  AlertCircle,
+  Bot,
+  Brain,
+  ChevronDown,
+  CircleDot,
+  Loader2,
+  Radio,
+  TerminalSquare,
+  Wrench,
+} from "lucide-react";
 
 import {
   resolveUserLabel,
   type UserProfileLookup,
 } from "@/features/profile/lib/identity";
 import { cn } from "@/shared/lib/cn";
+import { Badge } from "@/shared/ui/badge";
 import { Markdown } from "@/shared/ui/markdown";
+import { Shimmer } from "@/shared/ui/Shimmer";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import type { TranscriptItem } from "./agentSessionTypes";
 import { ToolItem } from "./AgentSessionToolItem";
+import { buildTranscriptPresentation } from "./agentSessionTranscriptPresentation";
 import { formatTranscriptTime } from "./agentSessionUtils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 export function AgentSessionTranscriptList({
   agentName,
+  compact = false,
   emptyDescription,
+  isWorking = false,
   items,
   profiles,
+  showInterventionHint = false,
 }: {
   agentName: string;
+  compact?: boolean;
   emptyDescription: string;
+  isWorking?: boolean;
   items: TranscriptItem[];
   profiles?: UserProfileLookup;
+  showInterventionHint?: boolean;
 }) {
+  const presentation = React.useMemo(
+    () => buildTranscriptPresentation(items, isWorking),
+    [items, isWorking],
+  );
+
   if (items.length === 0) {
     return (
-      <div className="flex min-h-56 flex-col items-center justify-center px-6 py-10 text-center">
+      <div
+        className={cn(
+          "flex flex-col items-center justify-center px-6 py-10 text-center",
+          compact ? "min-h-40" : "min-h-56",
+        )}
+      >
         <Radio className="mx-auto h-4 w-4 text-muted-foreground" />
         <p className="mt-3 text-sm font-medium">No ACP activity yet</p>
         <p className="mt-1 text-sm text-muted-foreground">{emptyDescription}</p>
@@ -35,57 +64,295 @@ export function AgentSessionTranscriptList({
   }
 
   return (
-    <div
-      aria-label="Live ACP transcript"
-      aria-live="polite"
-      className="w-full py-1"
-      role="log"
-    >
-      {items.map((item) => (
-        <div className="mt-4 first:mt-0" key={item.id}>
-          <TranscriptItemView
-            agentName={agentName}
-            item={item}
-            profiles={profiles}
-          />
-        </div>
-      ))}
+    <div className="w-full">
+      <TranscriptNowSummary
+        agentName={agentName}
+        compact={compact}
+        isWorking={isWorking}
+        presentation={presentation}
+        showInterventionHint={showInterventionHint}
+      />
+      <div
+        aria-label="Live ACP transcript"
+        aria-live="polite"
+        className={cn("w-full", compact ? "py-0.5" : "py-1")}
+        role="log"
+      >
+        {items.map((item) => (
+          <div
+            className={cn(
+              "first:mt-0",
+              compact ? "mt-2.5" : "mt-4",
+              getItemSpacingClass(item),
+            )}
+            key={item.id}
+          >
+            <TranscriptItemView
+              agentName={agentName}
+              compact={compact}
+              isActive={presentation.activeItemIds.has(item.id)}
+              item={item}
+              profiles={profiles}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
 
+function TranscriptNowSummary({
+  agentName,
+  compact,
+  isWorking,
+  presentation,
+  showInterventionHint,
+}: {
+  agentName: string;
+  compact: boolean;
+  isWorking: boolean;
+  presentation: ReturnType<typeof buildTranscriptPresentation>;
+  showInterventionHint: boolean;
+}) {
+  const { counts, hasError, headline, lastUpdatedAt, state } = presentation;
+  const showSummary = isWorking || hasError || itemsHaveActivity(counts);
+
+  if (!showSummary) {
+    return null;
+  }
+
+  const StateIcon = getStateIcon(state, isWorking);
+  const statusLabel = getStateLabel(state, isWorking);
+  const lastUpdated = lastUpdatedAt
+    ? formatTranscriptTime(lastUpdatedAt)
+    : null;
+
+  return (
+    <div
+      className={cn(
+        "sticky top-0 z-10 mb-3 rounded-lg border bg-background/95 backdrop-blur-sm",
+        hasError
+          ? "border-destructive/30 bg-destructive/[0.04]"
+          : "border-border/70",
+        compact ? "px-2.5 py-2" : "px-3 py-2.5",
+      )}
+      data-testid="agent-transcript-now-summary"
+    >
+      <div className="flex items-start gap-2">
+        <span
+          className={cn(
+            "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full",
+            hasError
+              ? "bg-destructive/10 text-destructive"
+              : isWorking
+                ? "bg-primary/10 text-primary"
+                : "bg-muted text-muted-foreground",
+          )}
+        >
+          <StateIcon
+            className={cn(
+              "h-3 w-3",
+              isWorking &&
+                state !== "error" &&
+                state !== "idle" &&
+                "animate-pulse",
+            )}
+          />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Now
+            </p>
+            <span className="text-[11px] text-muted-foreground/70">·</span>
+            <p className="text-[11px] text-muted-foreground">{agentName}</p>
+            {lastUpdated ? (
+              <>
+                <span className="text-[11px] text-muted-foreground/70">·</span>
+                <p className="text-[11px] text-muted-foreground/70">
+                  {lastUpdated}
+                </p>
+              </>
+            ) : null}
+          </div>
+          <p
+            className={cn(
+              "mt-0.5 text-sm font-medium leading-snug",
+              hasError ? "text-destructive" : "text-foreground",
+            )}
+          >
+            {isWorking && state !== "idle" && state !== "error" ? (
+              <Shimmer>{headline}</Shimmer>
+            ) : (
+              headline
+            )}
+          </p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            <Badge
+              className="h-5 px-1.5 text-[10px] font-normal"
+              variant={
+                hasError ? "destructive" : isWorking ? "default" : "secondary"
+              }
+            >
+              {statusLabel}
+            </Badge>
+            {counts.tools > 0 ? (
+              <ActivityCountBadge
+                count={counts.tools}
+                label="tool"
+                tone={counts.toolErrors > 0 ? "error" : "default"}
+              />
+            ) : null}
+            {counts.thoughts > 0 ? (
+              <ActivityCountBadge count={counts.thoughts} label="thought" />
+            ) : null}
+            {counts.messages > 0 ? (
+              <ActivityCountBadge count={counts.messages} label="message" />
+            ) : null}
+          </div>
+          {showInterventionHint && isWorking ? (
+            <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+              Use <span className="font-medium text-foreground">Stop</span>{" "}
+              above to interrupt this turn without stopping the agent process.
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ActivityCountBadge({
+  count,
+  label,
+  tone = "default",
+}: {
+  count: number;
+  label: string;
+  tone?: "default" | "error";
+}) {
+  return (
+    <Badge
+      className="h-5 px-1.5 text-[10px] font-normal"
+      variant={tone === "error" ? "destructive" : "outline"}
+    >
+      {count} {label}
+      {count === 1 ? "" : "s"}
+    </Badge>
+  );
+}
+
+function itemsHaveActivity(
+  counts: ReturnType<typeof buildTranscriptPresentation>["counts"],
+) {
+  return (
+    counts.tools > 0 ||
+    counts.thoughts > 0 ||
+    counts.messages > 0 ||
+    counts.lifecycle > 0
+  );
+}
+
+function getStateIcon(
+  state: ReturnType<typeof buildTranscriptPresentation>["state"],
+  isWorking: boolean,
+) {
+  if (state === "error") {
+    return AlertCircle;
+  }
+  if (!isWorking) {
+    return CircleDot;
+  }
+  switch (state) {
+    case "tool_running":
+      return Wrench;
+    case "thinking":
+      return Brain;
+    case "responding":
+      return Bot;
+    default:
+      return Loader2;
+  }
+}
+
+function getStateLabel(
+  state: ReturnType<typeof buildTranscriptPresentation>["state"],
+  isWorking: boolean,
+) {
+  if (state === "error") {
+    return "Error";
+  }
+  if (!isWorking) {
+    return "Idle";
+  }
+  switch (state) {
+    case "tool_running":
+      return "Running tool";
+    case "thinking":
+      return "Thinking";
+    case "responding":
+      return "Responding";
+    default:
+      return "Working";
+  }
+}
+
+function getItemSpacingClass(item: TranscriptItem) {
+  if (item.type === "lifecycle") {
+    return "mt-2 first:mt-0";
+  }
+  if (item.type === "metadata" || item.type === "thought") {
+    return "mt-2 first:mt-0";
+  }
+  return undefined;
+}
+
 const TranscriptItemView = React.memo(function TranscriptItemView({
   agentName,
+  compact,
+  isActive,
   item,
   profiles,
 }: {
   agentName: string;
+  compact: boolean;
+  isActive: boolean;
   item: TranscriptItem;
   profiles?: UserProfileLookup;
 }) {
   if (item.type === "message") {
     return (
-      <MessageItem agentName={agentName} item={item} profiles={profiles} />
+      <MessageItem
+        agentName={agentName}
+        compact={compact}
+        isActive={isActive}
+        item={item}
+        profiles={profiles}
+      />
     );
   }
   if (item.type === "tool") {
-    return <ToolItem item={item} />;
+    return <ToolItem compact={compact} isActive={isActive} item={item} />;
   }
   if (item.type === "thought") {
-    return <ThoughtItem item={item} />;
+    return <ThoughtItem compact={compact} isActive={isActive} item={item} />;
   }
   if (item.type === "metadata") {
-    return <MetadataItem item={item} />;
+    return <MetadataItem compact={compact} item={item} />;
   }
   return <LifecycleItem item={item} />;
 });
 
 function MessageItem({
   agentName,
+  compact,
+  isActive,
   item,
   profiles,
 }: {
   agentName: string;
+  compact: boolean;
+  isActive: boolean;
   item: Extract<TranscriptItem, { type: "message" }>;
   profiles?: UserProfileLookup;
 }) {
@@ -105,9 +372,16 @@ function MessageItem({
   return (
     <div
       className={cn(
-        "flex flex-row px-1 py-1 animate-in fade-in duration-200 motion-reduce:animate-none",
+        "flex flex-row animate-in fade-in duration-200 motion-reduce:animate-none",
+        compact ? "px-0 py-0.5" : "px-1 py-1",
+        isAssistant &&
+          isActive &&
+          "rounded-lg border border-primary/15 bg-primary/[0.03] px-2 py-1.5",
       )}
       data-role={isAssistant ? "assistant-message" : "user-message"}
+      data-testid={
+        isAssistant ? "transcript-assistant-message" : "transcript-user-message"
+      }
     >
       {!isAssistant ? (
         <UserAvatar
@@ -129,6 +403,15 @@ function MessageItem({
               <Bot className="h-4 w-4 text-muted-foreground" />
             </span>
             <span className="font-normal text-foreground">{agentName}</span>
+            {isActive ? (
+              <Badge
+                className="h-4 gap-0.5 px-1 text-[9px] font-normal"
+                variant="default"
+              >
+                <CircleDot className="h-2 w-2" />
+                Live
+              </Badge>
+            ) : null}
             <TranscriptTimestamp timestamp={item.timestamp} />
           </div>
         ) : null}
@@ -153,15 +436,35 @@ function MessageItem({
 }
 
 function ThoughtItem({
+  compact,
+  isActive,
   item,
 }: {
+  compact: boolean;
+  isActive: boolean;
   item: Extract<TranscriptItem, { type: "thought" }>;
 }) {
   return (
-    <details className="group not-prose w-full px-1">
+    <details
+      className={cn(
+        "group not-prose w-full rounded-md border border-transparent",
+        compact ? "px-0" : "px-1",
+        isActive && "border-primary/15 bg-primary/[0.03] px-2 py-1",
+      )}
+      data-testid="transcript-thought-item"
+    >
       <summary className="inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px text-muted-foreground">
-        <Brain className="h-4 w-4" />
+        <Brain className={cn("h-4 w-4", isActive && "text-primary")} />
         <span className="truncate text-sm font-medium">{item.title}</span>
+        {isActive ? (
+          <Badge
+            className="h-4 gap-0.5 px-1 text-[9px] font-normal"
+            variant="default"
+          >
+            <CircleDot className="h-2 w-2" />
+            Live
+          </Badge>
+        ) : null}
         <TranscriptTimestamp timestamp={item.timestamp} />
         <ChevronDown className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180" />
       </summary>
@@ -173,16 +476,24 @@ function ThoughtItem({
 }
 
 function MetadataItem({
+  compact,
   item,
 }: {
+  compact: boolean;
   item: Extract<TranscriptItem, { type: "metadata" }>;
 }) {
   return (
-    <details className="group not-prose w-full px-1">
+    <details
+      className={cn(
+        "group not-prose w-full rounded-md border border-border/50 bg-muted/20",
+        compact ? "px-2 py-1" : "px-2 py-1.5",
+      )}
+      data-testid="transcript-metadata-item"
+    >
       <summary className="inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px text-muted-foreground">
-        <TerminalSquare className="h-4 w-4" />
-        <span className="truncate text-sm font-medium">{item.title}</span>
-        <span className="shrink-0 text-xs">
+        <TerminalSquare className="h-3.5 w-3.5 shrink-0 opacity-70" />
+        <span className="truncate text-xs font-medium">{item.title}</span>
+        <span className="shrink-0 text-[10px] text-muted-foreground/70">
           {item.sections.length} section{item.sections.length === 1 ? "" : "s"}
         </span>
         <TranscriptTimestamp timestamp={item.timestamp} />
@@ -217,12 +528,20 @@ function LifecycleItem({
   return (
     <div
       className={cn(
-        "flex items-center justify-start gap-1.5 px-1 py-2 text-left text-xs",
-        isError ? "text-destructive" : "text-muted-foreground",
+        "flex items-center justify-start gap-1.5 rounded-md px-2 py-1.5 text-left text-xs",
+        isError
+          ? "border border-destructive/20 bg-destructive/5 text-destructive"
+          : "text-muted-foreground/80",
       )}
+      data-testid="transcript-lifecycle-item"
     >
+      {isError ? (
+        <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+      ) : (
+        <CircleDot className="h-3 w-3 shrink-0 opacity-50" />
+      )}
       <span className="font-medium">{item.title}</span>
-      {item.text ? <span> - {item.text}</span> : null}
+      {item.text ? <span className="opacity-80">· {item.text}</span> : null}
       <TranscriptTimestamp timestamp={item.timestamp} />
     </div>
   );

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -26,6 +26,9 @@ import { buildTranscriptPresentation } from "./agentSessionTranscriptPresentatio
 import { formatTranscriptTime } from "./agentSessionUtils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
+/** Dev-only: surface the observer wire label that produced each transcript row. */
+const SHOW_TRANSCRIPT_ACP_SOURCE = import.meta.env.DEV;
+
 export function AgentSessionTranscriptList({
   agentName,
   compact = false,
@@ -87,6 +90,9 @@ export function AgentSessionTranscriptList({
             )}
             key={item.id}
           >
+            {SHOW_TRANSCRIPT_ACP_SOURCE && item.acpSource ? (
+              <TranscriptAcpSourceBadge source={item.acpSource} />
+            ) : null}
             <TranscriptItemView
               agentName={agentName}
               compact={compact}
@@ -98,6 +104,18 @@ export function AgentSessionTranscriptList({
         ))}
       </div>
     </div>
+  );
+}
+
+function TranscriptAcpSourceBadge({ source }: { source: string }) {
+  return (
+    <span
+      className="mb-1 inline-flex max-w-full rounded border border-amber-500/25 bg-amber-500/10 px-1.5 py-0.5 font-mono text-[10px] leading-none text-amber-800 dark:text-amber-200"
+      data-testid="transcript-acp-source"
+      title={`ACP wire source: ${source}`}
+    >
+      {source}
+    </span>
   );
 }
 

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -291,7 +291,7 @@ function PromptUserMessage({
       />
       <div className="group relative flex max-w-[85%] min-w-0 flex-col items-end gap-1">
         <div className="w-full min-w-0 rounded-2xl bg-muted p-2.5 text-sm leading-relaxed text-foreground">
-          <Markdown content={text || " "} tight />
+          <Markdown content={text || " "} mediaInset tight />
           {contextOpen && context ? (
             <PromptContextSections sections={context.sections} setup={setup} />
           ) : null}
@@ -607,7 +607,7 @@ function MessageItem({
             <Markdown compact content={text || " "} />
           ) : (
             <>
-              <Markdown content={text || " "} tight />
+              <Markdown content={text || " "} mediaInset tight />
               <TranscriptTimestamp timestamp={item.timestamp} />
             </>
           )}

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -155,6 +155,14 @@ function TranscriptDisplayBlockView({
   profiles?: UserProfileLookup;
 }) {
   if (block.kind === "single") {
+    if (block.item.type === "tool") {
+      return (
+        <div className={cn("first:mt-0", compact ? "mt-3" : "mt-3.5")}>
+          <ToolCallGroup compact={compact} items={[block.item]} />
+        </div>
+      );
+    }
+
     return (
       <TranscriptItemRow
         agentAvatarUrl={agentAvatarUrl}
@@ -169,23 +177,49 @@ function TranscriptDisplayBlockView({
 
   return (
     <div
-      className={cn("first:mt-0", compact ? "mt-2.5" : "mt-4")}
+      className={cn("first:mt-0", compact ? "mt-2.5" : "mt-3.5")}
       data-testid="transcript-turn-group"
       data-turn-id={block.turnId}
     >
-      {block.segments.map((segment) => (
-        <TranscriptTurnSegmentView
-          agentAvatarUrl={agentAvatarUrl}
-          agentName={agentName}
-          agentPubkey={agentPubkey}
-          compact={compact}
+      {block.segments.map((segment, index) => (
+        <div
+          className={getTurnSegmentSpacing(
+            block.segments[index - 1],
+            segment,
+            compact,
+          )}
           key={getTurnSegmentKey(block.turnId, segment)}
-          profiles={profiles}
-          segment={segment}
-        />
+        >
+          <TranscriptTurnSegmentView
+            agentAvatarUrl={agentAvatarUrl}
+            agentName={agentName}
+            agentPubkey={agentPubkey}
+            compact={compact}
+            profiles={profiles}
+            segment={segment}
+          />
+        </div>
       ))}
     </div>
   );
+}
+
+function getTurnSegmentSpacing(
+  previous: TranscriptTurnSegment | undefined,
+  segment: TranscriptTurnSegment,
+  compact: boolean,
+): string | undefined {
+  if (!previous) {
+    return undefined;
+  }
+
+  const involvesTool =
+    previous.kind === "tool_group" || segment.kind === "tool_group";
+  if (involvesTool) {
+    return compact ? "mt-3" : "mt-3.5";
+  }
+
+  return compact ? "mt-2" : "mt-2.5";
 }
 
 function getTurnSegmentKey(turnId: string, segment: TranscriptTurnSegment) {
@@ -194,6 +228,9 @@ function getTurnSegmentKey(turnId: string, segment: TranscriptTurnSegment) {
   }
   if (segment.kind === "prompt") {
     return `turn:${turnId}:prompt`;
+  }
+  if (segment.kind === "tool_group") {
+    return `turn:${turnId}:tools:${segment.items.map((item) => item.id).join("+")}`;
   }
   return segment.item.id;
 }
@@ -226,12 +263,17 @@ function TranscriptTurnSegmentView({
     return <TurnSetupStatus compact={compact} items={segment.items} />;
   }
 
+  if (segment.kind === "tool_group") {
+    return <ToolCallGroup compact={compact} items={segment.items} />;
+  }
+
   return (
     <TranscriptItemRow
       agentAvatarUrl={agentAvatarUrl}
       agentName={agentName}
       agentPubkey={agentPubkey}
       compact={compact}
+      embedded
       item={segment.item}
       profiles={profiles}
     />
@@ -252,10 +294,7 @@ function TurnPromptBlock({
   user: Extract<TranscriptItem, { type: "message" }>;
 }) {
   return (
-    <div
-      className={cn("first:mt-0", compact ? "mt-2.5" : "mt-4")}
-      data-testid="transcript-prompt-bundle"
-    >
+    <div data-testid="transcript-prompt-bundle">
       {SHOW_TRANSCRIPT_ACP_SOURCE ? (
         <div className="mb-1 flex flex-wrap gap-1">
           <TranscriptAcpSourceBadge source="session/prompt:user" />
@@ -464,24 +503,42 @@ function TurnSetupFooter({
   );
 }
 
+function ToolCallGroup({
+  compact,
+  items,
+}: {
+  compact: boolean;
+  items: Extract<TranscriptItem, { type: "tool" }>[];
+}) {
+  return (
+    <div className="flex flex-col gap-0" data-testid="transcript-tool-group">
+      {items.map((item) => (
+        <ToolItem compact={compact} grouped key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
 function TranscriptItemRow({
   agentAvatarUrl,
   agentName,
   agentPubkey,
   compact,
+  embedded = false,
   item,
   profiles,
 }: AgentTranscriptIdentityProps & {
   compact: boolean;
+  embedded?: boolean;
   item: TranscriptItem;
   profiles?: UserProfileLookup;
 }) {
   return (
     <div
       className={cn(
-        "first:mt-0",
-        compact ? "mt-2.5" : "mt-4",
-        getItemSpacingClass(item),
+        !embedded && "first:mt-0",
+        !embedded && (compact ? "mt-2" : "mt-2.5"),
+        !embedded && getItemSpacingClass(item),
       )}
       key={item.id}
     >
@@ -513,7 +570,7 @@ function TurnSetupStatus({
   }
 
   return (
-    <div className={cn("rounded-md px-2 py-1.5", compact ? "mt-2" : "mt-2.5")}>
+    <div className={cn("rounded-md px-2 py-1.5", compact ? "mt-1.5" : "mt-2")}>
       <TurnSetupFooter items={items} timestamp={timestamp} />
     </div>
   );
@@ -521,10 +578,10 @@ function TurnSetupStatus({
 
 function getItemSpacingClass(item: TranscriptItem) {
   if (item.type === "lifecycle") {
-    return "mt-2 first:mt-0";
+    return "mt-1.5 first:mt-0";
   }
   if (item.type === "metadata" || item.type === "thought") {
-    return "mt-2 first:mt-0";
+    return "mt-1.5 first:mt-0";
   }
   return undefined;
 }
@@ -603,7 +660,13 @@ function MessageItem({
       className={cn(
         "flex animate-in fade-in duration-200 motion-reduce:animate-none",
         isAssistant ? "flex-row" : "flex-row items-start justify-end",
-        compact ? "px-0 py-0.5" : "px-1 py-1",
+        isAssistant
+          ? compact
+            ? "px-0 py-0"
+            : "px-1 py-0"
+          : compact
+            ? "px-0 py-0.5"
+            : "px-1 py-1",
       )}
       data-role={isAssistant ? "assistant-message" : "user-message"}
       data-testid={

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -608,17 +608,13 @@ function TurnSetupFooter({
       {showContext ? (
         <Toggle
           aria-label={`${contextOpen ? "Hide" : "Show"} prompt context`}
-          className="h-5 min-h-0 min-w-0 gap-1 rounded-md px-1.5 text-xs font-medium data-[state=on]:bg-muted data-[state=on]:text-foreground"
           data-testid="transcript-prompt-context-toggle"
           onPressedChange={onContextOpenChange}
           pressed={contextOpen}
-          size="sm"
+          size="xs"
           variant="outline"
         >
           Context
-          <span className="text-muted-foreground/70">
-            {context.sections.length}
-          </span>
         </Toggle>
       ) : null}
       <TranscriptTimestamp timestamp={timestamp} />

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/features/profile/lib/identity";
 import { cn } from "@/shared/lib/cn";
 import { normalizePubkey } from "@/shared/lib/pubkey";
-import { Badge } from "@/shared/ui/badge";
 import { Markdown } from "@/shared/ui/markdown";
 import { Toggle } from "@/shared/ui/toggle";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
@@ -29,12 +28,35 @@ import {
   type TranscriptDisplayBlock,
   type TranscriptTurnSegment,
 } from "./agentSessionTranscriptGrouping";
-import { buildTranscriptPresentation } from "./agentSessionTranscriptPresentation";
 import { formatTranscriptTime } from "./agentSessionUtils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
-/** Dev-only: surface the observer wire label that produced each transcript row. */
-const SHOW_TRANSCRIPT_ACP_SOURCE = import.meta.env.DEV;
+const TRANSCRIPT_ACP_SOURCE_STORAGE_KEY = "buzz:show-transcript-acp-source";
+
+/**
+ * Opt-in only: source pills are useful while iterating on observer parsing, but
+ * they should not appear for every local dev session.
+ */
+const SHOW_TRANSCRIPT_ACP_SOURCE = shouldShowTranscriptAcpSource();
+
+function shouldShowTranscriptAcpSource() {
+  const envValue = import.meta.env.VITE_SHOW_TRANSCRIPT_ACP_SOURCE;
+  if (envValue === "1" || envValue === "true") {
+    return true;
+  }
+
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    return (
+      window.localStorage.getItem(TRANSCRIPT_ACP_SOURCE_STORAGE_KEY) === "1"
+    );
+  } catch {
+    return false;
+  }
+}
 
 type AgentTranscriptIdentityProps = {
   agentAvatarUrl: string | null;
@@ -48,7 +70,6 @@ export function AgentSessionTranscriptList({
   agentPubkey,
   compact = false,
   emptyDescription,
-  isWorking = false,
   items,
   profiles,
 }: AgentTranscriptIdentityProps & {
@@ -58,10 +79,6 @@ export function AgentSessionTranscriptList({
   items: TranscriptItem[];
   profiles?: UserProfileLookup;
 }) {
-  const presentation = React.useMemo(
-    () => buildTranscriptPresentation(items, isWorking),
-    [items, isWorking],
-  );
   const displayBlocks = React.useMemo(
     () => buildTranscriptDisplayBlocks(items),
     [items],
@@ -92,7 +109,6 @@ export function AgentSessionTranscriptList({
       >
         {displayBlocks.map((block) => (
           <TranscriptDisplayBlockView
-            activeItemIds={presentation.activeItemIds}
             agentAvatarUrl={agentAvatarUrl}
             agentName={agentName}
             agentPubkey={agentPubkey}
@@ -127,7 +143,6 @@ function getDisplayBlockKey(block: TranscriptDisplayBlock) {
 }
 
 function TranscriptDisplayBlockView({
-  activeItemIds,
   agentAvatarUrl,
   agentName,
   agentPubkey,
@@ -135,7 +150,6 @@ function TranscriptDisplayBlockView({
   compact,
   profiles,
 }: AgentTranscriptIdentityProps & {
-  activeItemIds: ReadonlySet<string>;
   block: TranscriptDisplayBlock;
   compact: boolean;
   profiles?: UserProfileLookup;
@@ -143,7 +157,6 @@ function TranscriptDisplayBlockView({
   if (block.kind === "single") {
     return (
       <TranscriptItemRow
-        activeItemIds={activeItemIds}
         agentAvatarUrl={agentAvatarUrl}
         agentName={agentName}
         agentPubkey={agentPubkey}
@@ -162,7 +175,6 @@ function TranscriptDisplayBlockView({
     >
       {block.segments.map((segment) => (
         <TranscriptTurnSegmentView
-          activeItemIds={activeItemIds}
           agentAvatarUrl={agentAvatarUrl}
           agentName={agentName}
           agentPubkey={agentPubkey}
@@ -187,7 +199,6 @@ function getTurnSegmentKey(turnId: string, segment: TranscriptTurnSegment) {
 }
 
 function TranscriptTurnSegmentView({
-  activeItemIds,
   agentAvatarUrl,
   agentName,
   agentPubkey,
@@ -195,7 +206,6 @@ function TranscriptTurnSegmentView({
   profiles,
   segment,
 }: AgentTranscriptIdentityProps & {
-  activeItemIds: ReadonlySet<string>;
   compact: boolean;
   profiles?: UserProfileLookup;
   segment: TranscriptTurnSegment;
@@ -218,7 +228,6 @@ function TranscriptTurnSegmentView({
 
   return (
     <TranscriptItemRow
-      activeItemIds={activeItemIds}
       agentAvatarUrl={agentAvatarUrl}
       agentName={agentName}
       agentPubkey={agentPubkey}
@@ -313,7 +322,7 @@ function PromptUserMessage({
         >
           <p className="whitespace-pre-wrap wrap-break-word">{text}</p>
           {contextOpen && context ? (
-            <PromptContextSections sections={context.sections} />
+            <PromptContextSections sections={context.sections} setup={setup} />
           ) : null}
         </div>
         <TurnSetupFooter
@@ -328,12 +337,19 @@ function PromptUserMessage({
   );
 }
 
-function PromptContextSections({ sections }: { sections: PromptSection[] }) {
+function PromptContextSections({
+  sections,
+  setup,
+}: {
+  sections: PromptSection[];
+  setup: Extract<TranscriptItem, { type: "lifecycle" }>[];
+}) {
   return (
     <div
       className="mt-2 space-y-2 border-t border-border/40 pt-2"
       data-testid="transcript-prompt-context-sections"
     >
+      <PromptSetupSummary items={setup} />
       {sections.map((section) => (
         <details
           className="group/section"
@@ -349,6 +365,29 @@ function PromptContextSections({ sections }: { sections: PromptSection[] }) {
         </details>
       ))}
     </div>
+  );
+}
+
+function PromptSetupSummary({
+  items,
+}: {
+  items: Extract<TranscriptItem, { type: "lifecycle" }>[];
+}) {
+  const label = formatTurnSetupLabel(items);
+  const detail = turnSetupDetail(items);
+  const setupText = [label, detail].filter(Boolean).join(" · ");
+
+  if (!setupText) {
+    return null;
+  }
+
+  return (
+    <p
+      className="text-xs leading-5 text-muted-foreground"
+      data-testid="transcript-prompt-setup-summary"
+    >
+      {setupText}
+    </p>
   );
 }
 
@@ -375,12 +414,35 @@ function TurnSetupFooter({
     return <TranscriptTimestamp timestamp={timestamp} />;
   }
 
+  const contextToggle = showContext ? (
+    <Toggle
+      aria-label={`${contextOpen ? "Hide" : "Show"} prompt context`}
+      data-testid="transcript-prompt-context-toggle"
+      className="data-[state=on]:bg-primary/10 data-[state=on]:text-primary dark:data-[state=on]:bg-primary/15"
+      onPressedChange={onContextOpenChange}
+      pressed={contextOpen}
+      size="xs"
+      variant="ghost"
+    >
+      {showSetup ? <CheckCheck aria-hidden="true" /> : null}
+      Context
+    </Toggle>
+  ) : null;
+
   return (
     <div
       className="flex items-center gap-1.5 text-muted-foreground/80"
       data-testid="transcript-turn-setup"
     >
-      {showSetup ? (
+      {showContext && showSetup ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{contextToggle}</TooltipTrigger>
+          <TooltipContent side="top">
+            <p>{tooltipText}</p>
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+      {!showContext && showSetup ? (
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -396,25 +458,13 @@ function TurnSetupFooter({
           </TooltipContent>
         </Tooltip>
       ) : null}
-      {showContext ? (
-        <Toggle
-          aria-label={`${contextOpen ? "Hide" : "Show"} prompt context`}
-          data-testid="transcript-prompt-context-toggle"
-          onPressedChange={onContextOpenChange}
-          pressed={contextOpen}
-          size="xs"
-          variant="outline"
-        >
-          Context
-        </Toggle>
-      ) : null}
+      {showContext && !showSetup ? contextToggle : null}
       <TranscriptTimestamp timestamp={timestamp} />
     </div>
   );
 }
 
 function TranscriptItemRow({
-  activeItemIds,
   agentAvatarUrl,
   agentName,
   agentPubkey,
@@ -422,7 +472,6 @@ function TranscriptItemRow({
   item,
   profiles,
 }: AgentTranscriptIdentityProps & {
-  activeItemIds: ReadonlySet<string>;
   compact: boolean;
   item: TranscriptItem;
   profiles?: UserProfileLookup;
@@ -444,7 +493,6 @@ function TranscriptItemRow({
         agentName={agentName}
         agentPubkey={agentPubkey}
         compact={compact}
-        isActive={activeItemIds.has(item.id)}
         item={item}
         profiles={profiles}
       />
@@ -486,12 +534,10 @@ const TranscriptItemView = React.memo(function TranscriptItemView({
   agentName,
   agentPubkey,
   compact,
-  isActive,
   item,
   profiles,
 }: AgentTranscriptIdentityProps & {
   compact: boolean;
-  isActive: boolean;
   item: TranscriptItem;
   profiles?: UserProfileLookup;
 }) {
@@ -502,17 +548,16 @@ const TranscriptItemView = React.memo(function TranscriptItemView({
         agentName={agentName}
         agentPubkey={agentPubkey}
         compact={compact}
-        isActive={isActive}
         item={item}
         profiles={profiles}
       />
     );
   }
   if (item.type === "tool") {
-    return <ToolItem compact={compact} isActive={isActive} item={item} />;
+    return <ToolItem compact={compact} item={item} />;
   }
   if (item.type === "thought") {
-    return <ThoughtItem compact={compact} isActive={isActive} item={item} />;
+    return <ThoughtItem compact={compact} item={item} />;
   }
   if (item.type === "metadata") {
     return <MetadataItem compact={compact} item={item} />;
@@ -525,12 +570,10 @@ function MessageItem({
   agentName,
   agentPubkey,
   compact,
-  isActive,
   item,
   profiles,
 }: AgentTranscriptIdentityProps & {
   compact: boolean;
-  isActive: boolean;
   item: Extract<TranscriptItem, { type: "message" }>;
   profiles?: UserProfileLookup;
 }) {
@@ -561,9 +604,6 @@ function MessageItem({
         "flex animate-in fade-in duration-200 motion-reduce:animate-none",
         isAssistant ? "flex-row" : "flex-row items-start justify-end",
         compact ? "px-0 py-0.5" : "px-1 py-1",
-        isAssistant &&
-          isActive &&
-          "rounded-lg border border-primary/15 bg-primary/3 px-2 py-1.5",
       )}
       data-role={isAssistant ? "assistant-message" : "user-message"}
       data-testid={
@@ -596,15 +636,6 @@ function MessageItem({
             <span className="text-xs font-semibold text-foreground">
               {assistantLabel}
             </span>
-            {isActive ? (
-              <Badge
-                className="h-4 gap-0.5 px-1 text-xs font-normal"
-                variant="default"
-              >
-                <CircleDot className="h-2 w-2" />
-                Live
-              </Badge>
-            ) : null}
             <TranscriptTimestamp timestamp={item.timestamp} />
           </div>
         ) : null}
@@ -630,11 +661,9 @@ function MessageItem({
 
 function ThoughtItem({
   compact,
-  isActive,
   item,
 }: {
   compact: boolean;
-  isActive: boolean;
   item: Extract<TranscriptItem, { type: "thought" }>;
 }) {
   return (
@@ -642,22 +671,12 @@ function ThoughtItem({
       className={cn(
         "group not-prose w-full rounded-md border border-transparent",
         compact ? "px-0" : "px-1",
-        isActive && "border-primary/15 bg-primary/3 px-2 py-1",
       )}
       data-testid="transcript-thought-item"
     >
       <summary className="inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px text-muted-foreground">
-        <Brain className={cn("h-4 w-4", isActive && "text-primary")} />
+        <Brain className="h-4 w-4" />
         <span className="truncate text-sm font-medium">{item.title}</span>
-        {isActive ? (
-          <Badge
-            className="h-4 gap-0.5 px-1 text-xs font-normal"
-            variant="default"
-          >
-            <CircleDot className="h-2 w-2" />
-            Live
-          </Badge>
-        ) : null}
         <TranscriptTimestamp timestamp={item.timestamp} />
         <ChevronDown className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180" />
       </summary>

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -800,7 +800,7 @@ function MessageItem({
           <div className="mb-0.5 flex items-center gap-1.5 text-xs">
             <UserAvatar
               avatarUrl={assistantAvatarUrl}
-              className="h-5 w-5 shrink-0 text-[8px]"
+              className="shrink-0"
               displayName={assistantLabel}
               size="xs"
               testId="transcript-assistant-avatar"

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -1,15 +1,12 @@
 import * as React from "react";
 import {
   AlertCircle,
-  Bot,
   Brain,
   CheckCheck,
   ChevronDown,
   CircleDot,
-  Loader2,
   Radio,
   TerminalSquare,
-  Wrench,
 } from "lucide-react";
 
 import {
@@ -20,7 +17,6 @@ import { cn } from "@/shared/lib/cn";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { Badge } from "@/shared/ui/badge";
 import { Markdown } from "@/shared/ui/markdown";
-import { Shimmer } from "@/shared/ui/Shimmer";
 import { Toggle } from "@/shared/ui/toggle";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import type { PromptSection, TranscriptItem } from "./agentSessionTypes";
@@ -55,14 +51,12 @@ export function AgentSessionTranscriptList({
   isWorking = false,
   items,
   profiles,
-  showInterventionHint = false,
 }: AgentTranscriptIdentityProps & {
   compact?: boolean;
   emptyDescription: string;
   isWorking?: boolean;
   items: TranscriptItem[];
   profiles?: UserProfileLookup;
-  showInterventionHint?: boolean;
 }) {
   const presentation = React.useMemo(
     () => buildTranscriptPresentation(items, isWorking),
@@ -90,13 +84,6 @@ export function AgentSessionTranscriptList({
 
   return (
     <div className="w-full">
-      <TranscriptNowSummary
-        agentName={agentName}
-        compact={compact}
-        isWorking={isWorking}
-        presentation={presentation}
-        showInterventionHint={showInterventionHint}
-      />
       <div
         aria-label="Live ACP transcript"
         aria-live="polite"
@@ -130,202 +117,6 @@ function TranscriptAcpSourceBadge({ source }: { source: string }) {
       {source}
     </span>
   );
-}
-
-function TranscriptNowSummary({
-  agentName,
-  compact,
-  isWorking,
-  presentation,
-  showInterventionHint,
-}: {
-  agentName: string;
-  compact: boolean;
-  isWorking: boolean;
-  presentation: ReturnType<typeof buildTranscriptPresentation>;
-  showInterventionHint: boolean;
-}) {
-  const { counts, hasError, headline, lastUpdatedAt, state } = presentation;
-  const showSummary = isWorking || hasError || itemsHaveActivity(counts);
-
-  if (!showSummary) {
-    return null;
-  }
-
-  const StateIcon = getStateIcon(state, isWorking);
-  const statusLabel = getStateLabel(state, isWorking);
-  const lastUpdated = lastUpdatedAt
-    ? formatTranscriptTime(lastUpdatedAt)
-    : null;
-
-  return (
-    <div
-      className={cn(
-        "sticky top-0 z-10 mb-3 rounded-lg border bg-background/95 backdrop-blur-sm",
-        hasError
-          ? "border-destructive/30 bg-destructive/[0.04]"
-          : "border-border/70",
-        compact ? "px-2.5 py-2" : "px-3 py-2.5",
-      )}
-      data-testid="agent-transcript-now-summary"
-    >
-      <div className="flex items-start gap-2">
-        <span
-          className={cn(
-            "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full",
-            hasError
-              ? "bg-destructive/10 text-destructive"
-              : isWorking
-                ? "bg-primary/10 text-primary"
-                : "bg-muted text-muted-foreground",
-          )}
-        >
-          <StateIcon
-            className={cn(
-              "h-3 w-3",
-              isWorking &&
-                state !== "error" &&
-                state !== "idle" &&
-                "animate-pulse",
-            )}
-          />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              Now
-            </p>
-            <span className="text-xs text-muted-foreground/70">·</span>
-            <p className="text-xs text-muted-foreground">{agentName}</p>
-            {lastUpdated ? (
-              <>
-                <span className="text-xs text-muted-foreground/70">·</span>
-                <p className="text-xs text-muted-foreground/70">
-                  {lastUpdated}
-                </p>
-              </>
-            ) : null}
-          </div>
-          <p
-            className={cn(
-              "mt-0.5 text-sm font-medium leading-snug",
-              hasError ? "text-destructive" : "text-foreground",
-            )}
-          >
-            {isWorking && state !== "idle" && state !== "error" ? (
-              <Shimmer>{headline}</Shimmer>
-            ) : (
-              headline
-            )}
-          </p>
-          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-            <Badge
-              className="h-5 px-1.5 text-xs font-normal"
-              variant={
-                hasError ? "destructive" : isWorking ? "default" : "secondary"
-              }
-            >
-              {statusLabel}
-            </Badge>
-            {counts.tools > 0 ? (
-              <ActivityCountBadge
-                count={counts.tools}
-                label="tool"
-                tone={counts.toolErrors > 0 ? "error" : "default"}
-              />
-            ) : null}
-            {counts.thoughts > 0 ? (
-              <ActivityCountBadge count={counts.thoughts} label="thought" />
-            ) : null}
-            {counts.messages > 0 ? (
-              <ActivityCountBadge count={counts.messages} label="message" />
-            ) : null}
-          </div>
-          {showInterventionHint && isWorking ? (
-            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-              Use <span className="font-medium text-foreground">Stop</span>{" "}
-              above to interrupt this turn without stopping the agent process.
-            </p>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ActivityCountBadge({
-  count,
-  label,
-  tone = "default",
-}: {
-  count: number;
-  label: string;
-  tone?: "default" | "error";
-}) {
-  return (
-    <Badge
-      className="h-5 px-1.5 text-xs font-normal"
-      variant={tone === "error" ? "destructive" : "outline"}
-    >
-      {count} {label}
-      {count === 1 ? "" : "s"}
-    </Badge>
-  );
-}
-
-function itemsHaveActivity(
-  counts: ReturnType<typeof buildTranscriptPresentation>["counts"],
-) {
-  return (
-    counts.tools > 0 ||
-    counts.thoughts > 0 ||
-    counts.messages > 0 ||
-    counts.lifecycle > 0
-  );
-}
-
-function getStateIcon(
-  state: ReturnType<typeof buildTranscriptPresentation>["state"],
-  isWorking: boolean,
-) {
-  if (state === "error") {
-    return AlertCircle;
-  }
-  if (!isWorking) {
-    return CircleDot;
-  }
-  switch (state) {
-    case "tool_running":
-      return Wrench;
-    case "thinking":
-      return Brain;
-    case "responding":
-      return Bot;
-    default:
-      return Loader2;
-  }
-}
-
-function getStateLabel(
-  state: ReturnType<typeof buildTranscriptPresentation>["state"],
-  isWorking: boolean,
-) {
-  if (state === "error") {
-    return "Error";
-  }
-  if (!isWorking) {
-    return "Idle";
-  }
-  switch (state) {
-    case "tool_running":
-      return "Running tool";
-    case "thinking":
-      return "Thinking";
-    case "responding":
-      return "Responding";
-    default:
-      return "Working";
-  }
 }
 
 function getDisplayBlockKey(block: TranscriptDisplayBlock) {

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -68,12 +68,10 @@ export function AgentSessionTranscriptList({
   agentAvatarUrl,
   agentName,
   agentPubkey,
-  compact = false,
   emptyDescription,
   items,
   profiles,
 }: AgentTranscriptIdentityProps & {
-  compact?: boolean;
   emptyDescription: string;
   isWorking?: boolean;
   items: TranscriptItem[];
@@ -86,12 +84,7 @@ export function AgentSessionTranscriptList({
 
   if (items.length === 0) {
     return (
-      <div
-        className={cn(
-          "flex flex-col items-center justify-center px-6 py-10 text-center",
-          compact ? "min-h-40" : "min-h-56",
-        )}
-      >
+      <div className="flex min-h-40 flex-col items-center justify-center px-6 py-10 text-center">
         <Radio className="mx-auto h-4 w-4 text-muted-foreground" />
         <p className="mt-3 text-sm font-medium">No ACP activity yet</p>
         <p className="mt-1 text-sm text-muted-foreground">{emptyDescription}</p>
@@ -104,7 +97,7 @@ export function AgentSessionTranscriptList({
       <div
         aria-label="Live ACP transcript"
         aria-live="polite"
-        className={cn("w-full", compact ? "py-0.5" : "py-1")}
+        className="w-full py-0.5"
         role="log"
       >
         {displayBlocks.map((block) => (
@@ -113,7 +106,6 @@ export function AgentSessionTranscriptList({
             agentName={agentName}
             agentPubkey={agentPubkey}
             block={block}
-            compact={compact}
             key={getDisplayBlockKey(block)}
             profiles={profiles}
           />
@@ -147,28 +139,17 @@ function TranscriptDisplayBlockView({
   agentName,
   agentPubkey,
   block,
-  compact,
   profiles,
 }: AgentTranscriptIdentityProps & {
   block: TranscriptDisplayBlock;
-  compact: boolean;
   profiles?: UserProfileLookup;
 }) {
   if (block.kind === "single") {
-    if (block.item.type === "tool") {
-      return (
-        <div className={cn("first:mt-0", compact ? "mt-3" : "mt-3.5")}>
-          <ToolCallGroup compact={compact} items={[block.item]} />
-        </div>
-      );
-    }
-
     return (
       <TranscriptItemRow
         agentAvatarUrl={agentAvatarUrl}
         agentName={agentName}
         agentPubkey={agentPubkey}
-        compact={compact}
         item={block.item}
         profiles={profiles}
       />
@@ -177,49 +158,22 @@ function TranscriptDisplayBlockView({
 
   return (
     <div
-      className={cn("first:mt-0", compact ? "mt-2.5" : "mt-3.5")}
+      className="first:mt-0 mt-2.5"
       data-testid="transcript-turn-group"
       data-turn-id={block.turnId}
     >
-      {block.segments.map((segment, index) => (
-        <div
-          className={getTurnSegmentSpacing(
-            block.segments[index - 1],
-            segment,
-            compact,
-          )}
+      {block.segments.map((segment) => (
+        <TranscriptTurnSegmentView
+          agentAvatarUrl={agentAvatarUrl}
+          agentName={agentName}
+          agentPubkey={agentPubkey}
           key={getTurnSegmentKey(block.turnId, segment)}
-        >
-          <TranscriptTurnSegmentView
-            agentAvatarUrl={agentAvatarUrl}
-            agentName={agentName}
-            agentPubkey={agentPubkey}
-            compact={compact}
-            profiles={profiles}
-            segment={segment}
-          />
-        </div>
+          profiles={profiles}
+          segment={segment}
+        />
       ))}
     </div>
   );
-}
-
-function getTurnSegmentSpacing(
-  previous: TranscriptTurnSegment | undefined,
-  segment: TranscriptTurnSegment,
-  compact: boolean,
-): string | undefined {
-  if (!previous) {
-    return undefined;
-  }
-
-  const involvesTool =
-    previous.kind === "tool_group" || segment.kind === "tool_group";
-  if (involvesTool) {
-    return compact ? "mt-3" : "mt-3.5";
-  }
-
-  return compact ? "mt-2" : "mt-2.5";
 }
 
 function getTurnSegmentKey(turnId: string, segment: TranscriptTurnSegment) {
@@ -229,9 +183,6 @@ function getTurnSegmentKey(turnId: string, segment: TranscriptTurnSegment) {
   if (segment.kind === "prompt") {
     return `turn:${turnId}:prompt`;
   }
-  if (segment.kind === "tool_group") {
-    return `turn:${turnId}:tools:${segment.items.map((item) => item.id).join("+")}`;
-  }
   return segment.item.id;
 }
 
@@ -239,18 +190,15 @@ function TranscriptTurnSegmentView({
   agentAvatarUrl,
   agentName,
   agentPubkey,
-  compact,
   profiles,
   segment,
 }: AgentTranscriptIdentityProps & {
-  compact: boolean;
   profiles?: UserProfileLookup;
   segment: TranscriptTurnSegment;
 }) {
   if (segment.kind === "prompt") {
     return (
       <TurnPromptBlock
-        compact={compact}
         context={segment.context}
         profiles={profiles}
         setup={segment.setup}
@@ -260,11 +208,7 @@ function TranscriptTurnSegmentView({
   }
 
   if (segment.kind === "setup") {
-    return <TurnSetupStatus compact={compact} items={segment.items} />;
-  }
-
-  if (segment.kind === "tool_group") {
-    return <ToolCallGroup compact={compact} items={segment.items} />;
+    return <TurnSetupStatus items={segment.items} />;
   }
 
   return (
@@ -272,8 +216,6 @@ function TranscriptTurnSegmentView({
       agentAvatarUrl={agentAvatarUrl}
       agentName={agentName}
       agentPubkey={agentPubkey}
-      compact={compact}
-      embedded
       item={segment.item}
       profiles={profiles}
     />
@@ -281,13 +223,11 @@ function TranscriptTurnSegmentView({
 }
 
 function TurnPromptBlock({
-  compact,
   context,
   profiles,
   setup,
   user,
 }: {
-  compact: boolean;
   context: Extract<TranscriptItem, { type: "metadata" }> | null;
   profiles?: UserProfileLookup;
   setup: Extract<TranscriptItem, { type: "lifecycle" }>[];
@@ -304,7 +244,6 @@ function TurnPromptBlock({
         </div>
       ) : null}
       <PromptUserMessage
-        compact={compact}
         context={context}
         item={user}
         profiles={profiles}
@@ -315,13 +254,11 @@ function TurnPromptBlock({
 }
 
 function PromptUserMessage({
-  compact,
   context = null,
   item,
   profiles,
   setup = [],
 }: {
-  compact: boolean;
   context?: Extract<TranscriptItem, { type: "metadata" }> | null;
   item: Extract<TranscriptItem, { type: "message" }>;
   profiles?: UserProfileLookup;
@@ -353,12 +290,7 @@ function PromptUserMessage({
         size="xs"
       />
       <div className="group relative flex max-w-[85%] min-w-0 flex-col items-end gap-1">
-        <div
-          className={cn(
-            "w-full min-w-0 rounded-2xl bg-muted p-3 text-sm leading-relaxed text-foreground",
-            compact && "p-2.5",
-          )}
-        >
+        <div className="w-full min-w-0 rounded-2xl bg-muted p-2.5 text-sm leading-relaxed text-foreground">
           <p className="whitespace-pre-wrap wrap-break-word">{text}</p>
           {contextOpen && context ? (
             <PromptContextSections sections={context.sections} setup={setup} />
@@ -503,43 +435,19 @@ function TurnSetupFooter({
   );
 }
 
-function ToolCallGroup({
-  compact,
-  items,
-}: {
-  compact: boolean;
-  items: Extract<TranscriptItem, { type: "tool" }>[];
-}) {
-  return (
-    <div className="flex flex-col gap-0" data-testid="transcript-tool-group">
-      {items.map((item) => (
-        <ToolItem compact={compact} grouped key={item.id} item={item} />
-      ))}
-    </div>
-  );
-}
-
 function TranscriptItemRow({
   agentAvatarUrl,
   agentName,
   agentPubkey,
-  compact,
-  embedded = false,
   item,
   profiles,
 }: AgentTranscriptIdentityProps & {
-  compact: boolean;
-  embedded?: boolean;
   item: TranscriptItem;
   profiles?: UserProfileLookup;
 }) {
   return (
     <div
-      className={cn(
-        !embedded && "first:mt-0",
-        !embedded && (compact ? "mt-2" : "mt-2.5"),
-        !embedded && getItemSpacingClass(item),
-      )}
+      className={cn("first:mt-0", getTranscriptItemRowSpacing(item))}
       key={item.id}
     >
       {SHOW_TRANSCRIPT_ACP_SOURCE && item.acpSource ? (
@@ -549,7 +457,6 @@ function TranscriptItemRow({
         agentAvatarUrl={agentAvatarUrl}
         agentName={agentName}
         agentPubkey={agentPubkey}
-        compact={compact}
         item={item}
         profiles={profiles}
       />
@@ -558,10 +465,8 @@ function TranscriptItemRow({
 }
 
 function TurnSetupStatus({
-  compact,
   items,
 }: {
-  compact: boolean;
   items: Extract<TranscriptItem, { type: "lifecycle" }>[];
 }) {
   const timestamp = turnSetupTimestamp(items);
@@ -570,31 +475,29 @@ function TurnSetupStatus({
   }
 
   return (
-    <div className={cn("rounded-md px-2 py-1.5", compact ? "mt-1.5" : "mt-2")}>
+    <div className="mt-1.5 rounded-md px-2 py-1.5">
       <TurnSetupFooter items={items} timestamp={timestamp} />
     </div>
   );
 }
 
-function getItemSpacingClass(item: TranscriptItem) {
-  if (item.type === "lifecycle") {
-    return "mt-1.5 first:mt-0";
+function getTranscriptItemRowSpacing(item: TranscriptItem): string {
+  if (item.type === "message") {
+    return "my-2.5";
   }
-  if (item.type === "metadata" || item.type === "thought") {
-    return "mt-1.5 first:mt-0";
+  if (item.type === "tool") {
+    return "my-1";
   }
-  return undefined;
+  return "my-2";
 }
 
 const TranscriptItemView = React.memo(function TranscriptItemView({
   agentAvatarUrl,
   agentName,
   agentPubkey,
-  compact,
   item,
   profiles,
 }: AgentTranscriptIdentityProps & {
-  compact: boolean;
   item: TranscriptItem;
   profiles?: UserProfileLookup;
 }) {
@@ -604,20 +507,19 @@ const TranscriptItemView = React.memo(function TranscriptItemView({
         agentAvatarUrl={agentAvatarUrl}
         agentName={agentName}
         agentPubkey={agentPubkey}
-        compact={compact}
         item={item}
         profiles={profiles}
       />
     );
   }
   if (item.type === "tool") {
-    return <ToolItem compact={compact} item={item} />;
+    return <ToolItem item={item} />;
   }
   if (item.type === "thought") {
-    return <ThoughtItem compact={compact} item={item} />;
+    return <ThoughtItem item={item} />;
   }
   if (item.type === "metadata") {
-    return <MetadataItem compact={compact} item={item} />;
+    return <MetadataItem item={item} />;
   }
   return <LifecycleItem item={item} />;
 });
@@ -626,11 +528,9 @@ function MessageItem({
   agentAvatarUrl,
   agentName,
   agentPubkey,
-  compact,
   item,
   profiles,
 }: AgentTranscriptIdentityProps & {
-  compact: boolean;
   item: Extract<TranscriptItem, { type: "message" }>;
   profiles?: UserProfileLookup;
 }) {
@@ -659,14 +559,9 @@ function MessageItem({
     <div
       className={cn(
         "flex animate-in fade-in duration-200 motion-reduce:animate-none",
-        isAssistant ? "flex-row" : "flex-row items-start justify-end",
         isAssistant
-          ? compact
-            ? "px-0 py-0"
-            : "px-1 py-0"
-          : compact
-            ? "px-0 py-0.5"
-            : "px-1 py-1",
+          ? "flex-row px-0 py-1.5"
+          : "flex-row items-start justify-end px-0 py-0.5",
       )}
       data-role={isAssistant ? "assistant-message" : "user-message"}
       data-testid={
@@ -723,18 +618,13 @@ function MessageItem({
 }
 
 function ThoughtItem({
-  compact,
   item,
 }: {
-  compact: boolean;
   item: Extract<TranscriptItem, { type: "thought" }>;
 }) {
   return (
     <details
-      className={cn(
-        "group not-prose w-full rounded-md border border-transparent",
-        compact ? "px-0" : "px-1",
-      )}
+      className="group not-prose w-full rounded-md border border-transparent px-0"
       data-testid="transcript-thought-item"
     >
       <summary className="inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px text-muted-foreground">
@@ -751,27 +641,13 @@ function ThoughtItem({
 }
 
 function MetadataItem({
-  compact,
-  embedded = false,
   item,
 }: {
-  compact: boolean;
-  embedded?: boolean;
   item: Extract<TranscriptItem, { type: "metadata" }>;
 }) {
   return (
     <details
-      className={cn(
-        "group not-prose w-full",
-        embedded
-          ? compact
-            ? "px-2 py-1"
-            : "px-2.5 py-1.5"
-          : cn(
-              "rounded-md border border-border/50 bg-muted/20",
-              compact ? "px-2 py-1" : "px-2 py-1.5",
-            ),
-      )}
+      className="group not-prose w-full rounded-md border border-border/50 bg-muted/20 px-2 py-1"
       data-testid="transcript-metadata-item"
     >
       <summary className="inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px text-muted-foreground">

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -17,6 +17,7 @@ import {
   type UserProfileLookup,
 } from "@/features/profile/lib/identity";
 import { cn } from "@/shared/lib/cn";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import { Badge } from "@/shared/ui/badge";
 import { Markdown } from "@/shared/ui/markdown";
 import { Shimmer } from "@/shared/ui/Shimmer";
@@ -39,16 +40,23 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 /** Dev-only: surface the observer wire label that produced each transcript row. */
 const SHOW_TRANSCRIPT_ACP_SOURCE = import.meta.env.DEV;
 
+type AgentTranscriptIdentityProps = {
+  agentAvatarUrl: string | null;
+  agentName: string;
+  agentPubkey: string;
+};
+
 export function AgentSessionTranscriptList({
+  agentAvatarUrl,
   agentName,
+  agentPubkey,
   compact = false,
   emptyDescription,
   isWorking = false,
   items,
   profiles,
   showInterventionHint = false,
-}: {
-  agentName: string;
+}: AgentTranscriptIdentityProps & {
   compact?: boolean;
   emptyDescription: string;
   isWorking?: boolean;
@@ -98,7 +106,9 @@ export function AgentSessionTranscriptList({
         {displayBlocks.map((block) => (
           <TranscriptDisplayBlockView
             activeItemIds={presentation.activeItemIds}
+            agentAvatarUrl={agentAvatarUrl}
             agentName={agentName}
+            agentPubkey={agentPubkey}
             block={block}
             compact={compact}
             key={getDisplayBlockKey(block)}
@@ -113,7 +123,7 @@ export function AgentSessionTranscriptList({
 function TranscriptAcpSourceBadge({ source }: { source: string }) {
   return (
     <span
-      className="mb-1 inline-flex max-w-full rounded border border-amber-500/25 bg-amber-500/10 px-1.5 py-0.5 font-mono text-[10px] leading-none text-amber-800 dark:text-amber-200"
+      className="mb-1 inline-flex max-w-full rounded border border-amber-500/25 bg-amber-500/10 px-1.5 py-0.5 font-mono text-xs leading-none text-amber-800 dark:text-amber-200"
       data-testid="transcript-acp-source"
       title={`ACP wire source: ${source}`}
     >
@@ -182,15 +192,15 @@ function TranscriptNowSummary({
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               Now
             </p>
-            <span className="text-[11px] text-muted-foreground/70">·</span>
-            <p className="text-[11px] text-muted-foreground">{agentName}</p>
+            <span className="text-xs text-muted-foreground/70">·</span>
+            <p className="text-xs text-muted-foreground">{agentName}</p>
             {lastUpdated ? (
               <>
-                <span className="text-[11px] text-muted-foreground/70">·</span>
-                <p className="text-[11px] text-muted-foreground/70">
+                <span className="text-xs text-muted-foreground/70">·</span>
+                <p className="text-xs text-muted-foreground/70">
                   {lastUpdated}
                 </p>
               </>
@@ -210,7 +220,7 @@ function TranscriptNowSummary({
           </p>
           <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
             <Badge
-              className="h-5 px-1.5 text-[10px] font-normal"
+              className="h-5 px-1.5 text-xs font-normal"
               variant={
                 hasError ? "destructive" : isWorking ? "default" : "secondary"
               }
@@ -232,7 +242,7 @@ function TranscriptNowSummary({
             ) : null}
           </div>
           {showInterventionHint && isWorking ? (
-            <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
               Use <span className="font-medium text-foreground">Stop</span>{" "}
               above to interrupt this turn without stopping the agent process.
             </p>
@@ -254,7 +264,7 @@ function ActivityCountBadge({
 }) {
   return (
     <Badge
-      className="h-5 px-1.5 text-[10px] font-normal"
+      className="h-5 px-1.5 text-xs font-normal"
       variant={tone === "error" ? "destructive" : "outline"}
     >
       {count} {label}
@@ -327,13 +337,14 @@ function getDisplayBlockKey(block: TranscriptDisplayBlock) {
 
 function TranscriptDisplayBlockView({
   activeItemIds,
+  agentAvatarUrl,
   agentName,
+  agentPubkey,
   block,
   compact,
   profiles,
-}: {
+}: AgentTranscriptIdentityProps & {
   activeItemIds: ReadonlySet<string>;
-  agentName: string;
   block: TranscriptDisplayBlock;
   compact: boolean;
   profiles?: UserProfileLookup;
@@ -342,7 +353,9 @@ function TranscriptDisplayBlockView({
     return (
       <TranscriptItemRow
         activeItemIds={activeItemIds}
+        agentAvatarUrl={agentAvatarUrl}
         agentName={agentName}
+        agentPubkey={agentPubkey}
         compact={compact}
         item={block.item}
         profiles={profiles}
@@ -359,7 +372,9 @@ function TranscriptDisplayBlockView({
       {block.segments.map((segment) => (
         <TranscriptTurnSegmentView
           activeItemIds={activeItemIds}
+          agentAvatarUrl={agentAvatarUrl}
           agentName={agentName}
+          agentPubkey={agentPubkey}
           compact={compact}
           key={getTurnSegmentKey(block.turnId, segment)}
           profiles={profiles}
@@ -382,13 +397,14 @@ function getTurnSegmentKey(turnId: string, segment: TranscriptTurnSegment) {
 
 function TranscriptTurnSegmentView({
   activeItemIds,
+  agentAvatarUrl,
   agentName,
+  agentPubkey,
   compact,
   profiles,
   segment,
-}: {
+}: AgentTranscriptIdentityProps & {
   activeItemIds: ReadonlySet<string>;
-  agentName: string;
   compact: boolean;
   profiles?: UserProfileLookup;
   segment: TranscriptTurnSegment;
@@ -412,7 +428,9 @@ function TranscriptTurnSegmentView({
   return (
     <TranscriptItemRow
       activeItemIds={activeItemIds}
+      agentAvatarUrl={agentAvatarUrl}
       agentName={agentName}
+      agentPubkey={agentPubkey}
       compact={compact}
       item={segment.item}
       profiles={profiles}
@@ -491,7 +509,7 @@ function PromptUserMessage({
     >
       <UserAvatar
         avatarUrl={authorProfile?.avatarUrl ?? null}
-        className="mr-2 mt-1 h-5 w-5 shrink-0 text-[8px]"
+        className="mr-2 mt-1 shrink-0"
         displayName={authorLabel}
         size="xs"
       />
@@ -534,7 +552,7 @@ function PromptContextSections({ sections }: { sections: PromptSection[] }) {
             <span className="truncate">{section.title}</span>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open/section:rotate-180" />
           </summary>
-          <pre className="mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/40 px-2 py-1.5 font-mono text-[11px] leading-5 text-muted-foreground">
+          <pre className="mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/40 px-2 py-1.5 font-mono text-xs leading-5 text-muted-foreground">
             {section.body.trim() || "No metadata."}
           </pre>
         </details>
@@ -590,7 +608,7 @@ function TurnSetupFooter({
       {showContext ? (
         <Toggle
           aria-label={`${contextOpen ? "Hide" : "Show"} prompt context`}
-          className="h-5 min-h-0 min-w-0 gap-1 rounded-md px-1.5 text-[10px] font-medium data-[state=on]:bg-muted data-[state=on]:text-foreground"
+          className="h-5 min-h-0 min-w-0 gap-1 rounded-md px-1.5 text-xs font-medium data-[state=on]:bg-muted data-[state=on]:text-foreground"
           data-testid="transcript-prompt-context-toggle"
           onPressedChange={onContextOpenChange}
           pressed={contextOpen}
@@ -610,13 +628,14 @@ function TurnSetupFooter({
 
 function TranscriptItemRow({
   activeItemIds,
+  agentAvatarUrl,
   agentName,
+  agentPubkey,
   compact,
   item,
   profiles,
-}: {
+}: AgentTranscriptIdentityProps & {
   activeItemIds: ReadonlySet<string>;
-  agentName: string;
   compact: boolean;
   item: TranscriptItem;
   profiles?: UserProfileLookup;
@@ -634,7 +653,9 @@ function TranscriptItemRow({
         <TranscriptAcpSourceBadge source={item.acpSource} />
       ) : null}
       <TranscriptItemView
+        agentAvatarUrl={agentAvatarUrl}
         agentName={agentName}
+        agentPubkey={agentPubkey}
         compact={compact}
         isActive={activeItemIds.has(item.id)}
         item={item}
@@ -674,13 +695,14 @@ function getItemSpacingClass(item: TranscriptItem) {
 }
 
 const TranscriptItemView = React.memo(function TranscriptItemView({
+  agentAvatarUrl,
   agentName,
+  agentPubkey,
   compact,
   isActive,
   item,
   profiles,
-}: {
-  agentName: string;
+}: AgentTranscriptIdentityProps & {
   compact: boolean;
   isActive: boolean;
   item: TranscriptItem;
@@ -689,7 +711,9 @@ const TranscriptItemView = React.memo(function TranscriptItemView({
   if (item.type === "message") {
     return (
       <MessageItem
+        agentAvatarUrl={agentAvatarUrl}
         agentName={agentName}
+        agentPubkey={agentPubkey}
         compact={compact}
         isActive={isActive}
         item={item}
@@ -710,13 +734,14 @@ const TranscriptItemView = React.memo(function TranscriptItemView({
 });
 
 function MessageItem({
+  agentAvatarUrl,
   agentName,
+  agentPubkey,
   compact,
   isActive,
   item,
   profiles,
-}: {
-  agentName: string;
+}: AgentTranscriptIdentityProps & {
   compact: boolean;
   isActive: boolean;
   item: Extract<TranscriptItem, { type: "message" }>;
@@ -734,6 +759,14 @@ function MessageItem({
         profiles,
       })
     : item.title || "User";
+  const agentProfile = profiles?.[normalizePubkey(agentPubkey)] ?? null;
+  const assistantLabel = resolveUserLabel({
+    pubkey: agentPubkey,
+    fallbackName: agentName,
+    profiles,
+    preferResolvedSelfLabel: true,
+  });
+  const assistantAvatarUrl = agentProfile?.avatarUrl ?? agentAvatarUrl;
 
   return (
     <div
@@ -752,7 +785,7 @@ function MessageItem({
       {!isAssistant ? (
         <UserAvatar
           avatarUrl={authorProfile?.avatarUrl ?? null}
-          className="mr-2 mt-1 h-5 w-5 shrink-0 text-[8px]"
+          className="mr-2 mt-1 shrink-0"
           displayName={authorLabel}
           size="xs"
         />
@@ -764,14 +797,20 @@ function MessageItem({
         )}
       >
         {isAssistant ? (
-          <div className="mb-0.5 flex items-center gap-1 text-xs">
-            <span className="flex h-5 w-5 items-center justify-center">
-              <Bot className="h-4 w-4 text-muted-foreground" />
+          <div className="mb-0.5 flex items-center gap-1.5 text-xs">
+            <UserAvatar
+              avatarUrl={assistantAvatarUrl}
+              className="h-5 w-5 shrink-0 text-[8px]"
+              displayName={assistantLabel}
+              size="xs"
+              testId="transcript-assistant-avatar"
+            />
+            <span className="text-xs font-semibold text-foreground">
+              {assistantLabel}
             </span>
-            <span className="font-normal text-foreground">{agentName}</span>
             {isActive ? (
               <Badge
-                className="h-4 gap-0.5 px-1 text-[9px] font-normal"
+                className="h-4 gap-0.5 px-1 text-xs font-normal"
                 variant="default"
               >
                 <CircleDot className="h-2 w-2" />
@@ -824,7 +863,7 @@ function ThoughtItem({
         <span className="truncate text-sm font-medium">{item.title}</span>
         {isActive ? (
           <Badge
-            className="h-4 gap-0.5 px-1 text-[9px] font-normal"
+            className="h-4 gap-0.5 px-1 text-xs font-normal"
             variant="default"
           >
             <CircleDot className="h-2 w-2" />
@@ -868,7 +907,7 @@ function MetadataItem({
       <summary className="inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 py-px text-muted-foreground">
         <TerminalSquare className="h-3.5 w-3.5 shrink-0 opacity-70" />
         <span className="truncate text-xs font-medium">{item.title}</span>
-        <span className="shrink-0 text-[10px] text-muted-foreground/70">
+        <span className="shrink-0 text-xs text-muted-foreground/70">
           {item.sections.length} section{item.sections.length === 1 ? "" : "s"}
         </span>
         <TranscriptTimestamp timestamp={item.timestamp} />
@@ -884,7 +923,7 @@ function MetadataItem({
               <span className="truncate">{section.title}</span>
               <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open/section:rotate-180" />
             </summary>
-            <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-3 py-2 font-mono text-[11px] leading-5 text-muted-foreground">
+            <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-3 py-2 font-mono text-xs leading-5 text-muted-foreground">
               {section.body.trim() || "No metadata."}
             </pre>
           </details>
@@ -942,7 +981,7 @@ function TranscriptTimestamp({ timestamp }: { timestamp: string }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="shrink-0 cursor-default text-[11px] text-muted-foreground/60">
+        <span className="shrink-0 cursor-default text-xs text-muted-foreground/60">
           {formatted}
         </span>
       </TooltipTrigger>

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -291,7 +291,7 @@ function PromptUserMessage({
       />
       <div className="group relative flex max-w-[85%] min-w-0 flex-col items-end gap-1">
         <div className="w-full min-w-0 rounded-2xl bg-muted p-2.5 text-sm leading-relaxed text-foreground">
-          <p className="whitespace-pre-wrap wrap-break-word">{text}</p>
+          <Markdown content={text || " "} tight />
           {contextOpen && context ? (
             <PromptContextSections sections={context.sections} setup={setup} />
           ) : null}
@@ -607,7 +607,7 @@ function MessageItem({
             <Markdown compact content={text || " "} />
           ) : (
             <>
-              <p className="whitespace-pre-wrap wrap-break-word">{text}</p>
+              <Markdown content={text || " "} tight />
               <TranscriptTimestamp timestamp={item.timestamp} />
             </>
           )}

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -294,24 +294,24 @@ function PromptUserMessage({
 
   return (
     <div
-      className="flex flex-row"
+      className="flex flex-row items-start justify-end"
       data-role="user-message"
       data-testid="transcript-user-message"
     >
       <UserAvatar
         avatarUrl={authorProfile?.avatarUrl ?? null}
-        className="mr-2 mt-1 shrink-0"
+        className="order-last ml-2 mt-1 shrink-0"
         displayName={authorLabel}
         size="xs"
       />
-      <div className="group relative min-w-0 max-w-[85%] flex flex-col items-start gap-1">
+      <div className="group relative flex max-w-[85%] min-w-0 flex-col items-end gap-1">
         <div
           className={cn(
             "w-full min-w-0 rounded-2xl bg-muted p-3 text-sm leading-relaxed text-foreground",
             compact && "p-2.5",
           )}
         >
-          <p className="whitespace-pre-wrap break-words">{text}</p>
+          <p className="whitespace-pre-wrap wrap-break-word">{text}</p>
           {contextOpen && context ? (
             <PromptContextSections sections={context.sections} />
           ) : null}
@@ -343,7 +343,7 @@ function PromptContextSections({ sections }: { sections: PromptSection[] }) {
             <span className="truncate">{section.title}</span>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open/section:rotate-180" />
           </summary>
-          <pre className="mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/40 px-2 py-1.5 font-mono text-xs leading-5 text-muted-foreground">
+          <pre className="mt-1.5 max-h-56 overflow-auto whitespace-pre-wrap wrap-break-word rounded-md bg-background/40 px-2 py-1.5 font-mono text-xs leading-5 text-muted-foreground">
             {section.body.trim() || "No metadata."}
           </pre>
         </details>
@@ -558,11 +558,12 @@ function MessageItem({
   return (
     <div
       className={cn(
-        "flex flex-row animate-in fade-in duration-200 motion-reduce:animate-none",
+        "flex animate-in fade-in duration-200 motion-reduce:animate-none",
+        isAssistant ? "flex-row" : "flex-row items-start justify-end",
         compact ? "px-0 py-0.5" : "px-1 py-1",
         isAssistant &&
           isActive &&
-          "rounded-lg border border-primary/15 bg-primary/[0.03] px-2 py-1.5",
+          "rounded-lg border border-primary/15 bg-primary/3 px-2 py-1.5",
       )}
       data-role={isAssistant ? "assistant-message" : "user-message"}
       data-testid={
@@ -572,15 +573,15 @@ function MessageItem({
       {!isAssistant ? (
         <UserAvatar
           avatarUrl={authorProfile?.avatarUrl ?? null}
-          className="mr-2 mt-1 shrink-0"
+          className="order-last ml-2 mt-1 shrink-0"
           displayName={authorLabel}
           size="xs"
         />
       ) : null}
       <div
         className={cn(
-          "group relative min-w-0 flex flex-col items-start gap-1",
-          isAssistant ? "w-full" : "max-w-[85%]",
+          "group relative flex min-w-0 flex-col gap-1",
+          isAssistant ? "w-full items-start" : "max-w-[85%] items-end",
         )}
       >
         {isAssistant ? (
@@ -617,7 +618,7 @@ function MessageItem({
             <Markdown compact content={text || " "} />
           ) : (
             <>
-              <p className="whitespace-pre-wrap break-words">{text}</p>
+              <p className="whitespace-pre-wrap wrap-break-word">{text}</p>
               <TranscriptTimestamp timestamp={item.timestamp} />
             </>
           )}
@@ -641,7 +642,7 @@ function ThoughtItem({
       className={cn(
         "group not-prose w-full rounded-md border border-transparent",
         compact ? "px-0" : "px-1",
-        isActive && "border-primary/15 bg-primary/[0.03] px-2 py-1",
+        isActive && "border-primary/15 bg-primary/3 px-2 py-1",
       )}
       data-testid="transcript-thought-item"
     >
@@ -710,7 +711,7 @@ function MetadataItem({
               <span className="truncate">{section.title}</span>
               <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open/section:rotate-180" />
             </summary>
-            <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-3 py-2 font-mono text-xs leading-5 text-muted-foreground">
+            <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap wrap-break-word rounded-md bg-muted/50 px-3 py-2 font-mono text-xs leading-5 text-muted-foreground">
               {section.body.trim() || "No metadata."}
             </pre>
           </details>

--- a/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
@@ -21,6 +21,11 @@ import type {
   ObserverEvent,
   TranscriptItem,
 } from "./agentSessionTypes";
+import {
+  deriveLatestSessionId,
+  resolveRawRailLayout,
+  scopeByChannel,
+} from "./agentSessionPanelLayout";
 import { shorten } from "./agentSessionUtils";
 import { useObserverEvents, useAgentTranscript } from "./useObserverEvents";
 
@@ -58,29 +63,21 @@ export function ManagedAgentSessionPanel({
 
   // Filter transcript items by channelId (lightweight — items now carry channelId)
   const scopedTranscript = React.useMemo(
-    () =>
-      channelId
-        ? transcript.filter((item) => item.channelId === channelId)
-        : transcript,
+    () => scopeByChannel(transcript, channelId),
     [channelId, transcript],
   );
 
   // Filter raw events by channelId for the RawEventRail
   const scopedEvents = React.useMemo(
-    () =>
-      channelId
-        ? events.filter((event) => event.channelId === channelId)
-        : events,
+    () => scopeByChannel(events, channelId),
     [channelId, events],
   );
 
   // Derive latestSessionId from channel-scoped events
-  const latestSessionId = React.useMemo(() => {
-    for (let i = scopedEvents.length - 1; i >= 0; i--) {
-      if (scopedEvents[i].sessionId) return scopedEvents[i].sessionId;
-    }
-    return null;
-  }, [scopedEvents]);
+  const latestSessionId = React.useMemo(
+    () => deriveLatestSessionId(scopedEvents),
+    [scopedEvents],
+  );
 
   return (
     <section
@@ -181,7 +178,9 @@ function SessionBody({
   showRaw: boolean;
   transcript: TranscriptItem[];
 }) {
-  if (showRaw && rawLayout === "exclusive") {
+  const rawRail = resolveRawRailLayout(showRaw, rawLayout);
+
+  if (rawRail.mode === "exclusive") {
     return (
       <>
         <RawEventRail events={events} />
@@ -205,7 +204,7 @@ function SessionBody({
       ) : (
         <div
           className={cn(
-            showRaw && rawLayout === "responsive"
+            rawRail.mode === "side"
               ? "mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_20rem]"
               : "mt-0",
           )}
@@ -219,9 +218,7 @@ function SessionBody({
             items={transcript}
             profiles={profiles}
           />
-          {showRaw && rawLayout === "responsive" ? (
-            <RawEventRail events={events} />
-          ) : null}
+          {rawRail.mode === "side" ? <RawEventRail events={events} /> : null}
         </div>
       )}
 

--- a/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
@@ -25,7 +25,9 @@ import { shorten } from "./agentSessionUtils";
 import { useObserverEvents, useAgentTranscript } from "./useObserverEvents";
 
 type ManagedAgentSessionPanelProps = {
-  agent: Pick<ManagedAgent, "pubkey" | "name" | "status">;
+  agent: Pick<ManagedAgent, "pubkey" | "name" | "status"> & {
+    avatarUrl?: string | null;
+  };
   channelId?: string | null;
   className?: string;
   compact?: boolean;
@@ -101,7 +103,9 @@ export function ManagedAgentSessionPanel({
       ) : null}
 
       <SessionBody
+        agentAvatarUrl={agent.avatarUrl ?? null}
         agentName={agent.name}
+        agentPubkey={agent.pubkey}
         compact={compact}
         connectionState={connectionState}
         emptyDescription={emptyDescription}
@@ -155,7 +159,9 @@ function SessionHeader({
 }
 
 function SessionBody({
+  agentAvatarUrl,
   agentName,
+  agentPubkey,
   compact,
   connectionState,
   emptyDescription,
@@ -169,7 +175,9 @@ function SessionBody({
   showRaw,
   transcript,
 }: {
+  agentAvatarUrl: string | null;
   agentName: string;
+  agentPubkey: string;
   compact: boolean;
   connectionState: ConnectionState;
   emptyDescription: string;
@@ -213,7 +221,9 @@ function SessionBody({
           )}
         >
           <AgentSessionTranscriptList
+            agentAvatarUrl={agentAvatarUrl}
             agentName={agentName}
+            agentPubkey={agentPubkey}
             compact={compact}
             emptyDescription={emptyDescription}
             isWorking={isWorking}

--- a/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
@@ -28,8 +28,11 @@ type ManagedAgentSessionPanelProps = {
   agent: Pick<ManagedAgent, "pubkey" | "name" | "status">;
   channelId?: string | null;
   className?: string;
+  compact?: boolean;
   emptyDescription?: string;
+  isWorking?: boolean;
   showHeader?: boolean;
+  showInterventionHint?: boolean;
   showRaw?: boolean;
   profiles?: UserProfileLookup;
 };
@@ -38,8 +41,11 @@ export function ManagedAgentSessionPanel({
   agent,
   channelId = null,
   className,
+  compact = false,
   emptyDescription = "Mention this agent in a channel to watch the next turn.",
+  isWorking = false,
   showHeader = true,
+  showInterventionHint = false,
   showRaw = true,
   profiles,
 }: ManagedAgentSessionPanelProps) {
@@ -94,12 +100,15 @@ export function ManagedAgentSessionPanel({
 
       <SessionBody
         agentName={agent.name}
+        compact={compact}
         connectionState={connectionState}
         emptyDescription={emptyDescription}
         errorMessage={errorMessage}
         events={scopedEvents}
         hasObserver={hasObserver}
+        isWorking={isWorking}
         profiles={profiles}
+        showInterventionHint={showInterventionHint}
         showRaw={showRaw}
         transcript={scopedTranscript}
       />
@@ -144,22 +153,28 @@ function SessionHeader({
 
 function SessionBody({
   agentName,
+  compact,
   connectionState,
   emptyDescription,
   errorMessage,
   events,
   hasObserver,
+  isWorking,
   profiles,
+  showInterventionHint,
   showRaw,
   transcript,
 }: {
   agentName: string;
+  compact: boolean;
   connectionState: ConnectionState;
   emptyDescription: string;
   errorMessage: string | null;
   events: ObserverEvent[];
   hasObserver: boolean;
+  isWorking: boolean;
   profiles?: UserProfileLookup;
+  showInterventionHint: boolean;
   showRaw: boolean;
   transcript: TranscriptItem[];
 }) {
@@ -179,9 +194,12 @@ function SessionBody({
         >
           <AgentSessionTranscriptList
             agentName={agentName}
+            compact={compact}
             emptyDescription={emptyDescription}
+            isWorking={isWorking}
             items={transcript}
             profiles={profiles}
+            showInterventionHint={showInterventionHint}
           />
           {showRaw ? <RawEventRail events={events} /> : null}
         </div>

--- a/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
@@ -31,6 +31,7 @@ type ManagedAgentSessionPanelProps = {
   compact?: boolean;
   emptyDescription?: string;
   isWorking?: boolean;
+  rawLayout?: "responsive" | "exclusive";
   showHeader?: boolean;
   showInterventionHint?: boolean;
   showRaw?: boolean;
@@ -44,6 +45,7 @@ export function ManagedAgentSessionPanel({
   compact = false,
   emptyDescription = "Mention this agent in a channel to watch the next turn.",
   isWorking = false,
+  rawLayout = "responsive",
   showHeader = true,
   showInterventionHint = false,
   showRaw = true,
@@ -108,6 +110,7 @@ export function ManagedAgentSessionPanel({
         hasObserver={hasObserver}
         isWorking={isWorking}
         profiles={profiles}
+        rawLayout={rawLayout}
         showInterventionHint={showInterventionHint}
         showRaw={showRaw}
         transcript={scopedTranscript}
@@ -161,6 +164,7 @@ function SessionBody({
   hasObserver,
   isWorking,
   profiles,
+  rawLayout,
   showInterventionHint,
   showRaw,
   transcript,
@@ -174,10 +178,26 @@ function SessionBody({
   hasObserver: boolean;
   isWorking: boolean;
   profiles?: UserProfileLookup;
+  rawLayout: "responsive" | "exclusive";
   showInterventionHint: boolean;
   showRaw: boolean;
   transcript: TranscriptItem[];
 }) {
+  if (showRaw && rawLayout === "exclusive") {
+    return (
+      <>
+        <RawEventRail events={events} />
+
+        {errorMessage ? (
+          <p className="mt-4 inline-flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            <CircleAlert className="h-4 w-4" />
+            {errorMessage}
+          </p>
+        ) : null}
+      </>
+    );
+  }
+
   return (
     <>
       {!hasObserver ? (
@@ -187,7 +207,7 @@ function SessionBody({
       ) : (
         <div
           className={cn(
-            showRaw
+            showRaw && rawLayout === "responsive"
               ? "mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_20rem]"
               : "mt-0",
           )}
@@ -201,7 +221,9 @@ function SessionBody({
             profiles={profiles}
             showInterventionHint={showInterventionHint}
           />
-          {showRaw ? <RawEventRail events={events} /> : null}
+          {showRaw && rawLayout === "responsive" ? (
+            <RawEventRail events={events} />
+          ) : null}
         </div>
       )}
 

--- a/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
@@ -35,7 +35,6 @@ type ManagedAgentSessionPanelProps = {
   isWorking?: boolean;
   rawLayout?: "responsive" | "exclusive";
   showHeader?: boolean;
-  showInterventionHint?: boolean;
   showRaw?: boolean;
   profiles?: UserProfileLookup;
 };
@@ -49,7 +48,6 @@ export function ManagedAgentSessionPanel({
   isWorking = false,
   rawLayout = "responsive",
   showHeader = true,
-  showInterventionHint = false,
   showRaw = true,
   profiles,
 }: ManagedAgentSessionPanelProps) {
@@ -115,7 +113,6 @@ export function ManagedAgentSessionPanel({
         isWorking={isWorking}
         profiles={profiles}
         rawLayout={rawLayout}
-        showInterventionHint={showInterventionHint}
         showRaw={showRaw}
         transcript={scopedTranscript}
       />
@@ -171,7 +168,6 @@ function SessionBody({
   isWorking,
   profiles,
   rawLayout,
-  showInterventionHint,
   showRaw,
   transcript,
 }: {
@@ -187,7 +183,6 @@ function SessionBody({
   isWorking: boolean;
   profiles?: UserProfileLookup;
   rawLayout: "responsive" | "exclusive";
-  showInterventionHint: boolean;
   showRaw: boolean;
   transcript: TranscriptItem[];
 }) {
@@ -229,7 +224,6 @@ function SessionBody({
             isWorking={isWorking}
             items={transcript}
             profiles={profiles}
-            showInterventionHint={showInterventionHint}
           />
           {showRaw && rawLayout === "responsive" ? (
             <RawEventRail events={events} />

--- a/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
@@ -30,7 +30,6 @@ type ManagedAgentSessionPanelProps = {
   };
   channelId?: string | null;
   className?: string;
-  compact?: boolean;
   emptyDescription?: string;
   isWorking?: boolean;
   rawLayout?: "responsive" | "exclusive";
@@ -43,7 +42,6 @@ export function ManagedAgentSessionPanel({
   agent,
   channelId = null,
   className,
-  compact = false,
   emptyDescription = "Mention this agent in a channel to watch the next turn.",
   isWorking = false,
   rawLayout = "responsive",
@@ -104,7 +102,6 @@ export function ManagedAgentSessionPanel({
         agentAvatarUrl={agent.avatarUrl ?? null}
         agentName={agent.name}
         agentPubkey={agent.pubkey}
-        compact={compact}
         connectionState={connectionState}
         emptyDescription={emptyDescription}
         errorMessage={errorMessage}
@@ -159,7 +156,6 @@ function SessionBody({
   agentAvatarUrl,
   agentName,
   agentPubkey,
-  compact,
   connectionState,
   emptyDescription,
   errorMessage,
@@ -174,7 +170,6 @@ function SessionBody({
   agentAvatarUrl: string | null;
   agentName: string;
   agentPubkey: string;
-  compact: boolean;
   connectionState: ConnectionState;
   emptyDescription: string;
   errorMessage: string | null;
@@ -219,7 +214,6 @@ function SessionBody({
             agentAvatarUrl={agentAvatarUrl}
             agentName={agentName}
             agentPubkey={agentPubkey}
-            compact={compact}
             emptyDescription={emptyDescription}
             isWorking={isWorking}
             items={transcript}

--- a/desktop/src/features/agents/ui/RawEventRail.tsx
+++ b/desktop/src/features/agents/ui/RawEventRail.tsx
@@ -1,46 +1,28 @@
-import * as React from "react";
-
-import { Button } from "@/shared/ui/button";
 import type { ObserverEvent } from "./agentSessionTypes";
 import { describeRawEvent } from "./agentSessionTranscript";
 
 export function RawEventRail({ events }: { events: ObserverEvent[] }) {
-  const [expanded, setExpanded] = React.useState(false);
-  const visible = expanded ? events : events.slice(-18);
-
   return (
-    <aside className="rounded-lg border border-border/70 bg-[#17171d] text-zinc-100">
-      <div className="flex items-center justify-between border-b border-white/10 px-3 py-2">
-        <div>
-          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-400">
-            Raw ACP
+    <section className="flex min-h-0 w-full flex-col text-foreground">
+      <div className="min-h-0 flex-1">
+        {events.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No raw events yet.
           </p>
-          <p className="text-xs text-zinc-500">JSON-RPC payloads</p>
-        </div>
-        <Button
-          className="h-7 text-zinc-300 hover:text-zinc-50"
-          onClick={() => setExpanded((current) => !current)}
-          size="sm"
-          variant="ghost"
-        >
-          {expanded ? "Latest" : "All"}
-        </Button>
-      </div>
-      <div className="max-h-[34rem] overflow-auto px-3 py-3">
-        {visible.length === 0 ? (
-          <p className="text-xs text-zinc-500">No raw events yet.</p>
         ) : (
           <div className="space-y-2">
-            {visible.map((event) => (
+            {events.map((event) => (
               <details
-                className="rounded-md border border-white/10 bg-white/[0.03] px-2 py-1.5"
+                className="group rounded-md border border-border/55 bg-muted/25 px-2.5 py-1.5 transition-colors open:bg-muted/35"
                 key={event.seq}
               >
-                <summary className="cursor-pointer select-none text-xs text-zinc-300">
-                  <span className="font-mono text-zinc-500">#{event.seq}</span>{" "}
+                <summary className="cursor-pointer select-none text-xs text-muted-foreground transition-colors group-open:text-foreground">
+                  <span className="font-mono text-muted-foreground/70">
+                    #{event.seq}
+                  </span>{" "}
                   {describeRawEvent(event)}
                 </summary>
-                <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-5 text-zinc-300">
+                <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap wrap-break-word rounded-md border border-border/40 bg-background/45 p-2 text-[11px] leading-5 text-muted-foreground">
                   {JSON.stringify(event.payload, null, 2)}
                 </pre>
               </details>
@@ -48,6 +30,6 @@ export function RawEventRail({ events }: { events: ObserverEvent[] }) {
           </div>
         )}
       </div>
-    </aside>
+    </section>
   );
 }

--- a/desktop/src/features/agents/ui/RawEventRail.tsx
+++ b/desktop/src/features/agents/ui/RawEventRail.tsx
@@ -22,7 +22,7 @@ export function RawEventRail({ events }: { events: ObserverEvent[] }) {
                   </span>{" "}
                   {describeRawEvent(event)}
                 </summary>
-                <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap wrap-break-word rounded-md border border-border/40 bg-background/45 p-2 text-[11px] leading-5 text-muted-foreground">
+                <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap wrap-break-word rounded-md border border-border/40 bg-background/45 p-2 font-mono text-xs leading-5 text-muted-foreground">
                   {JSON.stringify(event.payload, null, 2)}
                 </pre>
               </details>

--- a/desktop/src/features/agents/ui/agentSessionPanelLayout.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionPanelLayout.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deriveLatestSessionId,
+  resolveRawRailLayout,
+  scopeByChannel,
+} from "./agentSessionPanelLayout.ts";
+
+// ---- scopeByChannel ----
+
+const items = [
+  { id: "a", channelId: "channel-1" },
+  { id: "b", channelId: "channel-2" },
+  { id: "c", channelId: "channel-1" },
+];
+
+test("scopeByChannel returns the input unchanged when channelId is null", () => {
+  assert.equal(scopeByChannel(items, null), items);
+});
+
+test("scopeByChannel returns the input unchanged when channelId is undefined", () => {
+  assert.equal(scopeByChannel(items, undefined), items);
+});
+
+test("scopeByChannel filters items down to the requested channel", () => {
+  const scoped = scopeByChannel(items, "channel-1");
+  assert.deepEqual(
+    scoped.map((item) => item.id),
+    ["a", "c"],
+  );
+});
+
+test("scopeByChannel returns an empty array when no item matches", () => {
+  assert.deepEqual(scopeByChannel(items, "channel-99"), []);
+});
+
+// ---- deriveLatestSessionId ----
+
+test("deriveLatestSessionId returns null for an empty list", () => {
+  assert.equal(deriveLatestSessionId([]), null);
+});
+
+test("deriveLatestSessionId returns the last event's sessionId", () => {
+  const events = [
+    { seq: 1, sessionId: "sess-1" },
+    { seq: 2, sessionId: "sess-2" },
+  ];
+  assert.equal(deriveLatestSessionId(events), "sess-2");
+});
+
+test("deriveLatestSessionId skips trailing events without a sessionId", () => {
+  const events = [
+    { seq: 1, sessionId: "sess-1" },
+    { seq: 2, sessionId: null },
+    { seq: 3, sessionId: undefined },
+  ];
+  assert.equal(deriveLatestSessionId(events), "sess-1");
+});
+
+test("deriveLatestSessionId returns null when no event carries a sessionId", () => {
+  const events = [{ seq: 1, sessionId: null }, { seq: 2 }];
+  assert.equal(deriveLatestSessionId(events), null);
+});
+
+// ---- resolveRawRailLayout (raw-ACP view toggle) ----
+
+test("resolveRawRailLayout hides the rail when showRaw is off", () => {
+  assert.deepEqual(resolveRawRailLayout(false, "responsive"), {
+    mode: "hidden",
+  });
+  assert.deepEqual(resolveRawRailLayout(false, "exclusive"), {
+    mode: "hidden",
+  });
+});
+
+test("resolveRawRailLayout renders the rail exclusively when toggled on in exclusive layout", () => {
+  assert.deepEqual(resolveRawRailLayout(true, "exclusive"), {
+    mode: "exclusive",
+  });
+});
+
+test("resolveRawRailLayout renders the rail beside the transcript in responsive layout", () => {
+  assert.deepEqual(resolveRawRailLayout(true, "responsive"), { mode: "side" });
+});

--- a/desktop/src/features/agents/ui/agentSessionPanelLayout.ts
+++ b/desktop/src/features/agents/ui/agentSessionPanelLayout.ts
@@ -1,0 +1,48 @@
+import type { ObserverEvent } from "./agentSessionTypes";
+
+/**
+ * Filter transcript items or raw observer events down to a single channel.
+ * A null `channelId` means "no scoping" — the input is returned as-is.
+ */
+export function scopeByChannel<T extends { channelId?: string | null }>(
+  items: readonly T[],
+  channelId: string | null | undefined,
+): T[] {
+  if (!channelId) return items as T[];
+  return items.filter((item) => item.channelId === channelId);
+}
+
+/**
+ * Derive the most recent session id from a list of observer events by
+ * scanning from the end. Returns null when no event carries a sessionId.
+ */
+export function deriveLatestSessionId(
+  events: readonly ObserverEvent[],
+): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const sessionId = events[i]?.sessionId;
+    if (sessionId) return sessionId;
+  }
+  return null;
+}
+
+export type RawRailLayout =
+  | { mode: "hidden" }
+  | { mode: "exclusive" }
+  | { mode: "side" };
+
+/**
+ * Decide how the raw-ACP event rail should be rendered relative to the
+ * transcript:
+ * - `hidden`    — raw view is off
+ * - `exclusive` — raw rail replaces the transcript entirely
+ * - `side`      — raw rail renders alongside the transcript (responsive)
+ */
+export function resolveRawRailLayout(
+  showRaw: boolean,
+  rawLayout: "responsive" | "exclusive",
+): RawRailLayout {
+  if (!showRaw) return { mode: "hidden" };
+  if (rawLayout === "exclusive") return { mode: "exclusive" };
+  return { mode: "side" };
+}

--- a/desktop/src/features/agents/ui/agentSessionToolItemHelpers.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionToolItemHelpers.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatDurationMs,
+  getToolDurationDisplay,
+  isInlineImageData,
+  parseToolResultValue,
+} from "./agentSessionUtils.ts";
+
+// ---- isInlineImageData (dual-layer image-scheme security guard) ----
+
+test("isInlineImageData accepts data:image/ URIs", () => {
+  const dataUri =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC";
+  assert.equal(isInlineImageData(dataUri), true);
+});
+
+test("isInlineImageData rejects non-image data: schemes (no passthrough widening)", () => {
+  // A non-image data: URI must NOT be treated as a safe inline image —
+  // it has to fall through to the relay rewrite path.
+  assert.equal(
+    isInlineImageData(
+      "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+    ),
+    false,
+  );
+  assert.equal(isInlineImageData("data:application/json;base64,e30="), false);
+});
+
+test("isInlineImageData rejects relay-relative and absolute media URLs", () => {
+  assert.equal(isInlineImageData("/media/abc123.png"), false);
+  assert.equal(isInlineImageData("https://relay.example/media/abc.png"), false);
+});
+
+// ---- formatDurationMs ----
+
+test("formatDurationMs returns null for negative input", () => {
+  assert.equal(formatDurationMs(-1), null);
+});
+
+test("formatDurationMs renders sub-10s with one decimal", () => {
+  assert.equal(formatDurationMs(400), "0.4s");
+  assert.equal(formatDurationMs(9900), "9.9s");
+});
+
+test("formatDurationMs rounds 10s..60s to whole seconds", () => {
+  assert.equal(formatDurationMs(12300), "12s");
+  assert.equal(formatDurationMs(59400), "59s");
+});
+
+test("formatDurationMs renders minutes and seconds", () => {
+  assert.equal(formatDurationMs(90000), "1m 30s");
+  assert.equal(formatDurationMs(120000), "2m");
+});
+
+test("formatDurationMs carries a rounded 60s into the next minute", () => {
+  // 89.7s rounds the seconds component to 60, which must carry to 1m 30s
+  assert.equal(formatDurationMs(89700), "1m 30s");
+});
+
+// ---- parseToolResultValue (JSON double-parse) ----
+
+test("parseToolResultValue returns null for empty/whitespace", () => {
+  assert.equal(parseToolResultValue(""), null);
+  assert.equal(parseToolResultValue("   "), null);
+});
+
+test("parseToolResultValue parses a JSON object", () => {
+  assert.deepEqual(parseToolResultValue('{"duration_ms":123}'), {
+    duration_ms: 123,
+  });
+});
+
+test("parseToolResultValue unwraps a double-encoded JSON string", () => {
+  // The result is a JSON string that itself contains JSON.
+  const doubleEncoded = JSON.stringify(JSON.stringify({ ok: true }));
+  assert.deepEqual(parseToolResultValue(doubleEncoded), { ok: true });
+});
+
+test("parseToolResultValue returns the inner string when it is not JSON", () => {
+  const wrapped = JSON.stringify("plain text");
+  assert.equal(parseToolResultValue(wrapped), "plain text");
+});
+
+test("parseToolResultValue returns null for invalid JSON", () => {
+  assert.equal(parseToolResultValue("not json {"), null);
+});
+
+// ---- getToolDurationDisplay (fallback chain) ----
+
+const startedAt = "2026-06-14T19:00:00.000Z";
+const completedAt = "2026-06-14T19:00:02.000Z";
+
+test("getToolDurationDisplay prefers start/complete timestamps", () => {
+  assert.equal(
+    getToolDurationDisplay({ startedAt, completedAt, result: "" }),
+    "2.0s",
+  );
+});
+
+test("getToolDurationDisplay falls back to duration_ms in the result payload", () => {
+  assert.equal(
+    getToolDurationDisplay({
+      startedAt: null,
+      completedAt: null,
+      result: JSON.stringify({ duration_ms: 3500 }),
+    }),
+    "3.5s",
+  );
+});
+
+test("getToolDurationDisplay falls back to elapsed_ms when duration_ms absent", () => {
+  assert.equal(
+    getToolDurationDisplay({
+      result: JSON.stringify({ elapsed_ms: 65000 }),
+    }),
+    "1m 5s",
+  );
+});
+
+test("getToolDurationDisplay returns null when no duration is available", () => {
+  assert.equal(getToolDurationDisplay({ result: "" }), null);
+  assert.equal(
+    getToolDurationDisplay({ result: JSON.stringify({ other: 1 }) }),
+    null,
+  );
+});

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.test.mjs
@@ -1,10 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-  buildCompactToolSummary,
-  isCompactDeveloperTool,
-} from "./agentSessionToolSummary.ts";
+import { buildCompactToolSummary } from "./agentSessionToolSummary.ts";
 
 const baseTimestamp = "2026-06-14T19:00:00.000Z";
 
@@ -26,29 +23,19 @@ function makeTool(overrides = {}) {
   };
 }
 
-test("isCompactDeveloperTool returns false for Buzz relay tools", () => {
-  assert.equal(
-    isCompactDeveloperTool(
-      makeTool({
-        toolName: "send_message",
-        buzzToolName: "send_message",
-        title: "Send Message",
-      }),
-    ),
-    false,
+test("buildCompactToolSummary formats Buzz send_message preview", () => {
+  const summary = buildCompactToolSummary(
+    makeTool({
+      toolName: "send_message",
+      buzzToolName: "send_message",
+      title: "Send Message",
+      args: { content: "Hello team" },
+    }),
   );
-});
 
-test("isCompactDeveloperTool detects buzz-dev-mcp shell tools", () => {
-  assert.equal(
-    isCompactDeveloperTool(
-      makeTool({
-        toolName: "buzz-dev-mcp__shell",
-        title: "buzz-dev-mcp__shell",
-      }),
-    ),
-    true,
-  );
+  assert.equal(summary.kind, "buzz");
+  assert.equal(summary.label, "Send Message");
+  assert.equal(summary.preview, "Hello team");
 });
 
 test("buildCompactToolSummary formats shell command preview", () => {

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.test.mjs
@@ -36,6 +36,40 @@ test("buildCompactToolSummary formats Buzz send_message preview", () => {
   assert.equal(summary.kind, "buzz");
   assert.equal(summary.label, "Send Message");
   assert.equal(summary.preview, "Hello team");
+  assert.equal(summary.presentation, "message");
+});
+
+test("buildCompactToolSummary treats buzz messages send commands as messages", () => {
+  const summary = buildCompactToolSummary(
+    makeTool({
+      toolName: "buzz-dev-mcp__shell",
+      args: {
+        command:
+          'buzz --format compact messages send --channel channel-1 --content "@Ned are you working"',
+      },
+    }),
+  );
+
+  assert.equal(summary.kind, "shell");
+  assert.equal(summary.label, "Send Message");
+  assert.equal(summary.preview, "@Ned are you working");
+  assert.equal(summary.presentation, "message");
+});
+
+test("buildCompactToolSummary extracts simple piped buzz message content", () => {
+  const summary = buildCompactToolSummary(
+    makeTool({
+      toolName: "shell",
+      args: {
+        command:
+          'echo "hello from stdin" | ./target/release/buzz messages send --channel channel-1 --content -',
+      },
+    }),
+  );
+
+  assert.equal(summary.label, "Send Message");
+  assert.equal(summary.preview, "hello from stdin");
+  assert.equal(summary.presentation, "message");
 });
 
 test("buildCompactToolSummary formats shell command preview", () => {
@@ -48,6 +82,7 @@ test("buildCompactToolSummary formats shell command preview", () => {
 
   assert.equal(summary.label, "Ran command");
   assert.equal(summary.preview, "git status");
+  assert.equal(summary.presentation, "inline");
 });
 
 test("buildCompactToolSummary formats view_image thumbnail source", () => {

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.test.mjs
@@ -63,19 +63,31 @@ test("buildCompactToolSummary formats shell command preview", () => {
   assert.equal(summary.preview, "git status");
 });
 
-test("buildCompactToolSummary formats view_image source preview", () => {
+test("buildCompactToolSummary formats view_image thumbnail source", () => {
+  const source =
+    "https://sprout-oss.stage.blox.sqprod.co/media/ffd1b2721f2d52e19f0ca2be9aa7842cdec5b4e0215aaab2a67c26a2a76a6a83.png";
   const summary = buildCompactToolSummary(
     makeTool({
       toolName: "buzz-dev-mcp__view_image",
-      args: {
-        source:
-          "https://sprout-oss.stage.blox.sqprod.co/media/ffd1b2721f2d52e19f0ca2be9aa7842cdec5b4e0215aaab2a67c26a2a76a6a83.png",
-      },
+      args: { source },
     }),
   );
 
   assert.equal(summary.label, "Viewed image");
-  assert.ok(summary.preview?.startsWith("https://sprout-oss"));
+  assert.equal(summary.thumbnailSrc, source);
+  assert.equal(summary.preview, source);
+});
+
+test("buildCompactToolSummary uses basename for local view_image paths", () => {
+  const summary = buildCompactToolSummary(
+    makeTool({
+      toolName: "view_image",
+      args: { source: "desktop/assets/screenshot.png" },
+    }),
+  );
+
+  assert.equal(summary.thumbnailSrc, null);
+  assert.equal(summary.preview, "screenshot.png");
 });
 
 test("buildCompactToolSummary formats read_file path preview", () => {

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCompactToolSummary,
+  isCompactDeveloperTool,
+} from "./agentSessionToolSummary.ts";
+
+const baseTimestamp = "2026-06-14T19:00:00.000Z";
+
+function makeTool(overrides = {}) {
+  return {
+    id: "tool:1",
+    type: "tool",
+    title: "Tool call",
+    toolName: "shell",
+    buzzToolName: null,
+    status: "completed",
+    args: {},
+    result: "",
+    isError: false,
+    timestamp: baseTimestamp,
+    startedAt: baseTimestamp,
+    completedAt: "2026-06-14T19:00:01.000Z",
+    ...overrides,
+  };
+}
+
+test("isCompactDeveloperTool returns false for Buzz relay tools", () => {
+  assert.equal(
+    isCompactDeveloperTool(
+      makeTool({
+        toolName: "send_message",
+        buzzToolName: "send_message",
+        title: "Send Message",
+      }),
+    ),
+    false,
+  );
+});
+
+test("isCompactDeveloperTool detects buzz-dev-mcp shell tools", () => {
+  assert.equal(
+    isCompactDeveloperTool(
+      makeTool({
+        toolName: "buzz-dev-mcp__shell",
+        title: "buzz-dev-mcp__shell",
+      }),
+    ),
+    true,
+  );
+});
+
+test("buildCompactToolSummary formats shell command preview", () => {
+  const summary = buildCompactToolSummary(
+    makeTool({
+      toolName: "buzz-dev-mcp__shell",
+      args: { command: "git status" },
+    }),
+  );
+
+  assert.equal(summary.label, "Ran command");
+  assert.equal(summary.preview, "git status");
+});
+
+test("buildCompactToolSummary formats view_image source preview", () => {
+  const summary = buildCompactToolSummary(
+    makeTool({
+      toolName: "buzz-dev-mcp__view_image",
+      args: {
+        source:
+          "https://sprout-oss.stage.blox.sqprod.co/media/ffd1b2721f2d52e19f0ca2be9aa7842cdec5b4e0215aaab2a67c26a2a76a6a83.png",
+      },
+    }),
+  );
+
+  assert.equal(summary.label, "Viewed image");
+  assert.ok(summary.preview?.startsWith("https://sprout-oss"));
+});
+
+test("buildCompactToolSummary formats read_file path preview", () => {
+  const summary = buildCompactToolSummary(
+    makeTool({
+      toolName: "read_file",
+      args: { path: "desktop/src/app/App.tsx" },
+    }),
+  );
+
+  assert.equal(summary.label, "Read file");
+  assert.equal(summary.preview, "desktop/src/app/App.tsx");
+});
+
+test("buildCompactToolSummary formats todo list preview", () => {
+  const summary = buildCompactToolSummary(
+    makeTool({
+      toolName: "todo",
+      args: {
+        todos: [
+          { text: "Ship compact summaries", done: false },
+          { text: "Verify UI", done: false },
+        ],
+      },
+    }),
+  );
+
+  assert.equal(summary.label, "Updated todos");
+  assert.equal(summary.preview, "Ship compact summaries (+1)");
+});
+
+test("buildCompactToolSummary uses running and failed labels", () => {
+  assert.equal(
+    buildCompactToolSummary(
+      makeTool({ toolName: "str_replace", status: "executing" }),
+    ).label,
+    "Editing file",
+  );
+  assert.equal(
+    buildCompactToolSummary(
+      makeTool({ toolName: "str_replace", status: "failed", isError: true }),
+    ).label,
+    "Edit failed",
+  );
+});

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.ts
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.ts
@@ -110,7 +110,7 @@ function classifyDeveloperToolName(
   if (base === "postcompact") return "post_compact_hook";
 
   if (DEVELOPER_TOOL_BASES.has(base)) {
-    return base === "shell" ? "shell" : "dev_mcp";
+    return "dev_mcp";
   }
 
   if (normalized.includes("buzz_dev_mcp")) {

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.ts
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.ts
@@ -131,7 +131,7 @@ function compactToolLabel(
   }
 
   const labels: Record<
-    CompactToolKind,
+    Exclude<CompactToolKind, "buzz">,
     { completed: string; running: string; failed: string }
   > = {
     generic: {
@@ -142,12 +142,7 @@ function compactToolLabel(
     ...developerToolLabels(),
   };
 
-  const labelsMap = labels as Record<
-    CompactToolKind,
-    { completed: string; running: string; failed: string }
-  >;
-
-  const set = labelsMap[kind];
+  const set = labels[kind];
   if (failed) return set.failed;
   if (running) return set.running;
   return set.completed;

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.ts
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.ts
@@ -1,9 +1,15 @@
 import type { ToolStatus, TranscriptItem } from "./agentSessionTypes";
 import {
+  formatToolTitle,
   getBuzzToolInfo,
+  isGenericToolTitle,
   normalizeToolNameText,
 } from "./agentSessionToolCatalog";
-import { asRecord, getToolString } from "./agentSessionUtils";
+import {
+  asRecord,
+  getToolString,
+  getToolStringList,
+} from "./agentSessionUtils";
 
 export type CompactToolKind =
   | "shell"
@@ -13,7 +19,9 @@ export type CompactToolKind =
   | "todo"
   | "stop_hook"
   | "post_compact_hook"
-  | "dev_mcp";
+  | "dev_mcp"
+  | "buzz"
+  | "generic";
 
 export type CompactToolSummary = {
   kind: CompactToolKind;
@@ -35,24 +43,31 @@ const DEVELOPER_TOOL_BASES = new Set([
 
 type ToolItem = Extract<TranscriptItem, { type: "tool" }>;
 
-/** Whether this tool row should use the muted compact developer summary. */
-export function isCompactDeveloperTool(item: ToolItem): boolean {
-  if (item.buzzToolName && getBuzzToolInfo(item.buzzToolName)) {
-    return false;
-  }
-  return resolveDeveloperToolKind(item) !== null;
-}
-
-/** Build the compact summary label and preview for developer MCP tool rows. */
+/** Build the muted compact summary label and preview for any tool row. */
 export function buildCompactToolSummary(item: ToolItem): CompactToolSummary {
-  const kind = resolveDeveloperToolKind(item) ?? "dev_mcp";
+  const kind = resolveCompactToolKind(item);
   const { preview, thumbnailSrc } = extractCompactToolPreview(item, kind);
   return {
     kind,
-    label: compactToolLabel(kind, item.status, item.isError),
+    label: compactToolLabel(kind, item, item.status, item.isError),
     preview,
     thumbnailSrc,
   };
+}
+
+function resolveCompactToolKind(item: ToolItem): CompactToolKind {
+  const developerKind = resolveDeveloperToolKind(item);
+  if (developerKind) {
+    return developerKind;
+  }
+
+  for (const value of [item.buzzToolName, item.toolName, item.title]) {
+    if (value && getBuzzToolInfo(value)) {
+      return "buzz";
+    }
+  }
+
+  return "generic";
 }
 
 function resolveDeveloperToolKind(item: ToolItem): CompactToolKind | null {
@@ -98,16 +113,51 @@ function stripMcpServerPrefix(normalized: string): string {
 
 function compactToolLabel(
   kind: CompactToolKind,
+  item: ToolItem,
   status: ToolStatus,
   isError: boolean,
 ): string {
   const failed = isError || status === "failed";
   const running = status === "executing" || status === "pending";
 
+  if (kind === "buzz") {
+    const title = formatToolTitle(
+      item.buzzToolName ?? item.toolName,
+      item.title,
+    );
+    if (failed) return `${title} failed`;
+    if (running) return title;
+    return title;
+  }
+
   const labels: Record<
     CompactToolKind,
     { completed: string; running: string; failed: string }
   > = {
+    generic: {
+      completed: "Ran tool",
+      running: "Running tool",
+      failed: "Tool failed",
+    },
+    ...developerToolLabels(),
+  };
+
+  const labelsMap = labels as Record<
+    CompactToolKind,
+    { completed: string; running: string; failed: string }
+  >;
+
+  const set = labelsMap[kind];
+  if (failed) return set.failed;
+  if (running) return set.running;
+  return set.completed;
+}
+
+function developerToolLabels(): Record<
+  Exclude<CompactToolKind, "buzz" | "generic">,
+  { completed: string; running: string; failed: string }
+> {
+  return {
     shell: {
       completed: "Ran command",
       running: "Running command",
@@ -149,11 +199,6 @@ function compactToolLabel(
       failed: "Tool failed",
     },
   };
-
-  const set = labels[kind];
-  if (failed) return set.failed;
-  if (running) return set.running;
-  return set.completed;
 }
 
 type CompactToolPreview = {
@@ -181,11 +226,54 @@ function extractCompactToolPreview(
     case "post_compact_hook":
       return emptyPreview();
     case "dev_mcp":
+    case "generic":
       return textPreview(
-        getToolString(args, ["command", "path", "source", "query", "name"]) ??
-          null,
+        getToolString(args, [
+          "command",
+          "path",
+          "source",
+          "query",
+          "name",
+          "content",
+          "message",
+        ]) ??
+          (item.title && !isGenericToolTitle(item.title) ? item.title : null),
       );
+    case "buzz":
+      return textPreview(extractBuzzToolPreview(args));
   }
+}
+
+function extractBuzzToolPreview(args: Record<string, unknown>): string | null {
+  const content = getToolString(args, ["content", "message", "text", "body"]);
+  if (content) {
+    return content;
+  }
+
+  const query = getToolString(args, ["query", "search"]);
+  if (query) {
+    return query;
+  }
+
+  const channelId = getToolString(args, ["channel_id", "channelId"]);
+  if (channelId) {
+    return channelId;
+  }
+
+  const workflowId = getToolString(args, ["workflow_id", "workflowId"]);
+  if (workflowId) {
+    return workflowId;
+  }
+
+  const pubkeys = getToolStringList(args, ["pubkeys", "pubkey"]);
+  if (pubkeys.length === 1) {
+    return pubkeys[0];
+  }
+  if (pubkeys.length > 1) {
+    return `${pubkeys.length} users`;
+  }
+
+  return getToolString(args, ["event_id", "eventId", "name"]);
 }
 
 function textPreview(preview: string | null): CompactToolPreview {

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.ts
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.ts
@@ -29,6 +29,7 @@ export type CompactToolSummary = {
   preview: string | null;
   /** When set, the compact row renders a tiny image instead of text preview. */
   thumbnailSrc: string | null;
+  presentation: "inline" | "message";
 };
 
 const DEVELOPER_TOOL_BASES = new Set([
@@ -46,12 +47,24 @@ type ToolItem = Extract<TranscriptItem, { type: "tool" }>;
 /** Build the muted compact summary label and preview for any tool row. */
 export function buildCompactToolSummary(item: ToolItem): CompactToolSummary {
   const kind = resolveCompactToolKind(item);
+  const messageSendPreview = extractMessageSendPreview(item, kind);
+  if (messageSendPreview !== undefined) {
+    return {
+      kind,
+      label: compactMessageSendLabel(item.status, item.isError),
+      preview: messageSendPreview,
+      thumbnailSrc: null,
+      presentation: "message",
+    };
+  }
+
   const { preview, thumbnailSrc } = extractCompactToolPreview(item, kind);
   return {
     kind,
     label: compactToolLabel(kind, item, item.status, item.isError),
     preview,
     thumbnailSrc,
+    presentation: "inline",
   };
 }
 
@@ -196,6 +209,13 @@ function developerToolLabels(): Record<
   };
 }
 
+function compactMessageSendLabel(status: ToolStatus, isError: boolean) {
+  if (isError || status === "failed") {
+    return "Send Message failed";
+  }
+  return "Send Message";
+}
+
 type CompactToolPreview = {
   preview: string | null;
   thumbnailSrc: string | null;
@@ -269,6 +289,210 @@ function extractBuzzToolPreview(args: Record<string, unknown>): string | null {
   }
 
   return getToolString(args, ["event_id", "eventId", "name"]);
+}
+
+function extractMessageSendPreview(
+  item: ToolItem,
+  kind: CompactToolKind,
+): string | null | undefined {
+  if (isBuzzSendMessageTool(item)) {
+    return extractBuzzToolMessageContent(item.args);
+  }
+
+  if (kind !== "shell") {
+    return undefined;
+  }
+
+  const command = getToolString(item.args, ["command"]);
+  return command ? extractBuzzCliSendMessageContent(command) : undefined;
+}
+
+function isBuzzSendMessageTool(item: ToolItem) {
+  return [item.buzzToolName, item.toolName, item.title].some((value) => {
+    if (!value) return false;
+    return normalizeToolNameText(value) === "send_message";
+  });
+}
+
+function extractBuzzToolMessageContent(
+  args: Record<string, unknown>,
+): string | null {
+  return getToolString(args, ["content", "message", "text", "body"]);
+}
+
+function extractBuzzCliSendMessageContent(
+  command: string,
+): string | null | undefined {
+  const tokens = tokenizeShellCommand(command);
+  const commandRange = findBuzzMessagesSendCommand(tokens);
+  if (!commandRange) {
+    return undefined;
+  }
+
+  const content = getFlagValue(tokens, commandRange.sendIndex + 1, "--content");
+  if (!content) {
+    return null;
+  }
+  if (content !== "-") {
+    return content;
+  }
+
+  const pipedContent = extractSimpleEchoPipeContent(
+    tokens,
+    commandRange.buzzIndex,
+  );
+  return pipedContent ?? null;
+}
+
+function tokenizeShellCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      tokens.push(current);
+      current = "";
+    }
+  };
+
+  for (const char of command) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (char === "\\" && quote !== "'") {
+      escaping = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      pushCurrent();
+      continue;
+    }
+
+    if (char === "|" || char === ";" || char === "&") {
+      pushCurrent();
+      tokens.push(char);
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+  pushCurrent();
+  return tokens;
+}
+
+function findBuzzMessagesSendCommand(
+  tokens: string[],
+): { buzzIndex: number; sendIndex: number } | null {
+  for (let i = 0; i < tokens.length; i++) {
+    if (!isBuzzExecutable(tokens[i])) {
+      continue;
+    }
+
+    const messagesIndex = tokens.indexOf("messages", i + 1);
+    if (messagesIndex === -1) {
+      continue;
+    }
+    if (
+      messagesIndex > i &&
+      hasCommandSeparator(tokens, i + 1, messagesIndex)
+    ) {
+      continue;
+    }
+    if (tokens[messagesIndex + 1] === "send") {
+      return { buzzIndex: i, sendIndex: messagesIndex + 1 };
+    }
+  }
+
+  return null;
+}
+
+function isBuzzExecutable(token: string) {
+  return token === "buzz" || token.split(/[\\/]/).pop() === "buzz";
+}
+
+function hasCommandSeparator(tokens: string[], start: number, end: number) {
+  for (let i = start; i < end; i++) {
+    if (isCommandSeparator(tokens[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isCommandSeparator(token: string) {
+  return token === "|" || token === ";" || token === "&";
+}
+
+function getFlagValue(tokens: string[], start: number, flag: string) {
+  for (let i = start; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (isCommandSeparator(token)) {
+      return null;
+    }
+    if (token === flag) {
+      return tokens[i + 1] && !isCommandSeparator(tokens[i + 1])
+        ? tokens[i + 1]
+        : null;
+    }
+    if (token.startsWith(`${flag}=`)) {
+      return token.slice(flag.length + 1);
+    }
+  }
+  return null;
+}
+
+function extractSimpleEchoPipeContent(
+  tokens: string[],
+  buzzIndex: number,
+): string | null {
+  const pipeIndex = tokens.lastIndexOf("|", buzzIndex);
+  if (pipeIndex <= 0) {
+    return null;
+  }
+
+  const echoStart = findSegmentStart(tokens, pipeIndex - 1);
+  const leftSegment = tokens.slice(echoStart, pipeIndex);
+  if (leftSegment[0] !== "echo") {
+    return null;
+  }
+
+  const contentTokens = leftSegment
+    .slice(1)
+    .filter((token) => !token.startsWith("-"));
+  return contentTokens.length > 0 ? contentTokens.join(" ") : null;
+}
+
+function findSegmentStart(tokens: string[], beforeIndex: number) {
+  for (let i = beforeIndex; i >= 0; i--) {
+    if (isCommandSeparator(tokens[i])) {
+      return i + 1;
+    }
+  }
+  return 0;
 }
 
 function textPreview(preview: string | null): CompactToolPreview {

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.ts
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.ts
@@ -1,0 +1,203 @@
+import type { ToolStatus, TranscriptItem } from "./agentSessionTypes";
+import {
+  getBuzzToolInfo,
+  normalizeToolNameText,
+} from "./agentSessionToolCatalog";
+import { asRecord, getToolString } from "./agentSessionUtils";
+
+export type CompactToolKind =
+  | "shell"
+  | "read_file"
+  | "view_image"
+  | "str_replace"
+  | "todo"
+  | "stop_hook"
+  | "post_compact_hook"
+  | "dev_mcp";
+
+export type CompactToolSummary = {
+  kind: CompactToolKind;
+  label: string;
+  preview: string | null;
+};
+
+const DEVELOPER_TOOL_BASES = new Set([
+  "shell",
+  "read_file",
+  "view_image",
+  "str_replace",
+  "todo",
+  "stop",
+  "postcompact",
+]);
+
+type ToolItem = Extract<TranscriptItem, { type: "tool" }>;
+
+/** Whether this tool row should use the muted compact developer summary. */
+export function isCompactDeveloperTool(item: ToolItem): boolean {
+  if (item.buzzToolName && getBuzzToolInfo(item.buzzToolName)) {
+    return false;
+  }
+  return resolveDeveloperToolKind(item) !== null;
+}
+
+/** Build the compact summary label and preview for developer MCP tool rows. */
+export function buildCompactToolSummary(item: ToolItem): CompactToolSummary {
+  const kind = resolveDeveloperToolKind(item) ?? "dev_mcp";
+  const preview = extractCompactToolPreview(item, kind);
+  return {
+    kind,
+    label: compactToolLabel(kind, item.status, item.isError),
+    preview,
+  };
+}
+
+function resolveDeveloperToolKind(item: ToolItem): CompactToolKind | null {
+  for (const value of [item.toolName, item.title, item.buzzToolName]) {
+    const kind = classifyDeveloperToolName(value);
+    if (kind) return kind;
+  }
+  return null;
+}
+
+function classifyDeveloperToolName(
+  value: string | null | undefined,
+): CompactToolKind | null {
+  if (!value) return null;
+
+  const normalized = normalizeToolNameText(value);
+  const base = stripMcpServerPrefix(normalized);
+
+  if (base === "shell" || normalized.endsWith("_shell")) {
+    return "shell";
+  }
+  if (base === "read_file") return "read_file";
+  if (base === "view_image") return "view_image";
+  if (base === "str_replace") return "str_replace";
+  if (base === "todo") return "todo";
+  if (base === "stop") return "stop_hook";
+  if (base === "postcompact") return "post_compact_hook";
+
+  if (DEVELOPER_TOOL_BASES.has(base)) {
+    return base === "shell" ? "shell" : "dev_mcp";
+  }
+
+  if (normalized.includes("buzz_dev_mcp")) {
+    return "dev_mcp";
+  }
+
+  return null;
+}
+
+function stripMcpServerPrefix(normalized: string): string {
+  return normalized.replace(/^buzz_dev_mcp_/, "");
+}
+
+function compactToolLabel(
+  kind: CompactToolKind,
+  status: ToolStatus,
+  isError: boolean,
+): string {
+  const failed = isError || status === "failed";
+  const running = status === "executing" || status === "pending";
+
+  const labels: Record<
+    CompactToolKind,
+    { completed: string; running: string; failed: string }
+  > = {
+    shell: {
+      completed: "Ran command",
+      running: "Running command",
+      failed: "Command failed",
+    },
+    read_file: {
+      completed: "Read file",
+      running: "Reading file",
+      failed: "Read failed",
+    },
+    view_image: {
+      completed: "Viewed image",
+      running: "Viewing image",
+      failed: "View failed",
+    },
+    str_replace: {
+      completed: "Edited file",
+      running: "Editing file",
+      failed: "Edit failed",
+    },
+    todo: {
+      completed: "Updated todos",
+      running: "Updating todos",
+      failed: "Todo update failed",
+    },
+    stop_hook: {
+      completed: "Checked todos",
+      running: "Checking todos",
+      failed: "Todo check failed",
+    },
+    post_compact_hook: {
+      completed: "Synced todos",
+      running: "Syncing todos",
+      failed: "Todo sync failed",
+    },
+    dev_mcp: {
+      completed: "Ran tool",
+      running: "Running tool",
+      failed: "Tool failed",
+    },
+  };
+
+  const set = labels[kind];
+  if (failed) return set.failed;
+  if (running) return set.running;
+  return set.completed;
+}
+
+function extractCompactToolPreview(
+  item: ToolItem,
+  kind: CompactToolKind,
+): string | null {
+  const args = item.args;
+
+  switch (kind) {
+    case "shell":
+      return getToolString(args, ["command"]);
+    case "read_file":
+    case "str_replace":
+      return getToolString(args, ["path"]);
+    case "view_image":
+      return getToolString(args, ["source"]);
+    case "todo":
+      return getTodoPreview(args);
+    case "stop_hook":
+    case "post_compact_hook":
+      return null;
+    case "dev_mcp":
+      return (
+        getToolString(args, ["command", "path", "source", "query", "name"]) ??
+        null
+      );
+  }
+}
+
+function getTodoPreview(args: Record<string, unknown>): string | null {
+  const todos = args.todos;
+  if (!Array.isArray(todos)) {
+    return "todo list";
+  }
+  if (todos.length === 0) {
+    return "empty list";
+  }
+
+  const first = todos[0];
+  const firstText =
+    first && typeof first === "object"
+      ? getToolString(asRecord(first), ["text"])
+      : null;
+
+  if (firstText) {
+    return todos.length > 1 ? `${firstText} (+${todos.length - 1})` : firstText;
+  }
+
+  return `${todos.length} item${todos.length === 1 ? "" : "s"}`;
+}

--- a/desktop/src/features/agents/ui/agentSessionToolSummary.ts
+++ b/desktop/src/features/agents/ui/agentSessionToolSummary.ts
@@ -19,6 +19,8 @@ export type CompactToolSummary = {
   kind: CompactToolKind;
   label: string;
   preview: string | null;
+  /** When set, the compact row renders a tiny image instead of text preview. */
+  thumbnailSrc: string | null;
 };
 
 const DEVELOPER_TOOL_BASES = new Set([
@@ -44,11 +46,12 @@ export function isCompactDeveloperTool(item: ToolItem): boolean {
 /** Build the compact summary label and preview for developer MCP tool rows. */
 export function buildCompactToolSummary(item: ToolItem): CompactToolSummary {
   const kind = resolveDeveloperToolKind(item) ?? "dev_mcp";
-  const preview = extractCompactToolPreview(item, kind);
+  const { preview, thumbnailSrc } = extractCompactToolPreview(item, kind);
   return {
     kind,
     label: compactToolLabel(kind, item.status, item.isError),
     preview,
+    thumbnailSrc,
   };
 }
 
@@ -153,31 +156,68 @@ function compactToolLabel(
   return set.completed;
 }
 
+type CompactToolPreview = {
+  preview: string | null;
+  thumbnailSrc: string | null;
+};
+
 function extractCompactToolPreview(
   item: ToolItem,
   kind: CompactToolKind,
-): string | null {
+): CompactToolPreview {
   const args = item.args;
 
   switch (kind) {
     case "shell":
-      return getToolString(args, ["command"]);
+      return textPreview(getToolString(args, ["command"]));
     case "read_file":
     case "str_replace":
-      return getToolString(args, ["path"]);
+      return textPreview(getToolString(args, ["path"]));
     case "view_image":
-      return getToolString(args, ["source"]);
+      return getViewImagePreview(getToolString(args, ["source"]));
     case "todo":
-      return getTodoPreview(args);
+      return textPreview(getTodoPreview(args));
     case "stop_hook":
     case "post_compact_hook":
-      return null;
+      return emptyPreview();
     case "dev_mcp":
-      return (
+      return textPreview(
         getToolString(args, ["command", "path", "source", "query", "name"]) ??
-        null
+          null,
       );
   }
+}
+
+function textPreview(preview: string | null): CompactToolPreview {
+  return { preview, thumbnailSrc: null };
+}
+
+function emptyPreview(): CompactToolPreview {
+  return { preview: null, thumbnailSrc: null };
+}
+
+function getViewImagePreview(source: string | null): CompactToolPreview {
+  if (!source) {
+    return emptyPreview();
+  }
+
+  const trimmed = source.trim();
+  if (
+    trimmed.startsWith("data:image/") ||
+    trimmed.startsWith("http://") ||
+    trimmed.startsWith("https://")
+  ) {
+    return {
+      preview: trimmed,
+      thumbnailSrc: trimmed,
+    };
+  }
+
+  const basename = trimmed.split(/[/\\]/).pop() ?? trimmed;
+  return {
+    preview: basename,
+    thumbnailSrc: null,
+  };
 }
 
 function getTodoPreview(args: Record<string, unknown>): string | null {

--- a/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
@@ -3,6 +3,101 @@ import test from "node:test";
 
 import { buildTranscript } from "./agentSessionTranscript.ts";
 
+const turnId = "turn-abc";
+const sessionId = "sess-1";
+const channelId = "channel-1";
+const baseTimestamp = "2026-06-14T22:20:23.000Z";
+
+function makeTurnEvents() {
+  return [
+    {
+      seq: 1,
+      timestamp: baseTimestamp,
+      kind: "turn_started",
+      agentIndex: 0,
+      channelId,
+      sessionId: null,
+      turnId,
+      payload: { triggeringEventIds: ["event-1"] },
+    },
+    {
+      seq: 2,
+      timestamp: baseTimestamp,
+      kind: "session_resolved",
+      agentIndex: 0,
+      channelId,
+      sessionId,
+      turnId,
+      payload: { sessionId, isNewSession: false },
+    },
+    {
+      seq: 3,
+      timestamp: baseTimestamp,
+      kind: "acp_write",
+      agentIndex: 0,
+      channelId,
+      sessionId,
+      turnId,
+      payload: {
+        method: "session/prompt",
+        params: {
+          sessionId,
+          prompt: [
+            {
+              type: "text",
+              text: "[Buzz event: message]\nContent: @Ned deliberate, wider pass\nFrom: Tyler hex: abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+            },
+          ],
+        },
+      },
+    },
+    {
+      seq: 4,
+      timestamp: "2026-06-14T22:20:47.000Z",
+      kind: "acp_read",
+      agentIndex: 0,
+      channelId,
+      sessionId,
+      turnId,
+      payload: {
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            messageId: "msg-1",
+            content: [{ type: "text", text: "On it." }],
+          },
+        },
+      },
+    },
+  ];
+}
+
+test("buildTranscript attaches turnId and sessionId to generated items", () => {
+  const items = buildTranscript(makeTurnEvents());
+
+  assert.ok(items.length >= 4);
+  for (const item of items) {
+    assert.equal(item.turnId, turnId);
+    assert.equal(item.channelId, channelId);
+  }
+
+  const sessionResolved = items.find(
+    (item) =>
+      item.type === "lifecycle" && item.acpSource === "session_resolved",
+  );
+  assert.equal(sessionResolved?.sessionId, sessionId);
+
+  const userPrompt = items.find(
+    (item) =>
+      item.type === "message" &&
+      item.role === "user" &&
+      item.acpSource === "session/prompt:user",
+  );
+  assert.ok(userPrompt);
+  assert.equal(userPrompt.sessionId, sessionId);
+});
+
 test("buildTranscript tags assistant chunks with agent_message_chunk", () => {
   const items = buildTranscript([
     {

--- a/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildTranscript } from "./agentSessionTranscript.ts";
+
+test("buildTranscript tags assistant chunks with agent_message_chunk", () => {
+  const items = buildTranscript([
+    {
+      seq: 1,
+      timestamp: "2026-06-14T20:47:14.000Z",
+      kind: "acp_read",
+      agentIndex: 0,
+      channelId: "channel-1",
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      payload: {
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            messageId: "msg-1",
+            content: [{ type: "text", text: "Marge is summoned." }],
+          },
+        },
+      },
+    },
+  ]);
+
+  assert.equal(items.length, 1);
+  assert.equal(items[0]?.type, "message");
+  assert.equal(items[0]?.acpSource, "agent_message_chunk");
+});
+
+test("buildTranscript tags thought chunks with agent_thought_chunk", () => {
+  const items = buildTranscript([
+    {
+      seq: 2,
+      timestamp: "2026-06-14T20:47:15.000Z",
+      kind: "acp_read",
+      agentIndex: 0,
+      channelId: "channel-1",
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      payload: {
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            messageId: "thought-1",
+            content: [{ type: "text", text: "Considering next step." }],
+          },
+        },
+      },
+    },
+  ]);
+
+  assert.equal(items.length, 1);
+  assert.equal(items[0]?.type, "thought");
+  assert.equal(items[0]?.acpSource, "agent_thought_chunk");
+});

--- a/desktop/src/features/agents/ui/agentSessionTranscript.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.ts
@@ -108,6 +108,12 @@ function sealOpenMessages(d: TranscriptDraft) {
   }
 }
 
+type TranscriptItemContext = {
+  channelId: string | null;
+  turnId: string | null;
+  sessionId: string | null;
+};
+
 function upsertMessage(
   d: TranscriptDraft,
   id: string,
@@ -115,7 +121,7 @@ function upsertMessage(
   title: string,
   text: string,
   timestamp: string,
-  channelId: string | null,
+  ctx: TranscriptItemContext,
   authorPubkey: string | null = null,
   acpSource?: string,
 ) {
@@ -127,7 +133,9 @@ function upsertMessage(
       replaceItem(d, currentKey, {
         ...existing,
         text: existing.text + text,
-        channelId,
+        channelId: ctx.channelId,
+        turnId: ctx.turnId ?? existing.turnId,
+        sessionId: ctx.sessionId ?? existing.sessionId,
         authorPubkey: authorPubkey ?? existing.authorPubkey,
         acpSource: acpSource ?? existing.acpSource,
       });
@@ -144,7 +152,9 @@ function upsertMessage(
     title,
     text,
     timestamp,
-    channelId,
+    channelId: ctx.channelId,
+    turnId: ctx.turnId,
+    sessionId: ctx.sessionId,
     authorPubkey,
     acpSource,
   });
@@ -159,7 +169,7 @@ function upsertTextItem(
   title: string,
   text: string,
   timestamp: string,
-  channelId: string | null,
+  ctx: TranscriptItemContext,
   acpSource?: string,
 ) {
   const existing = d.itemsById.get(id);
@@ -167,13 +177,25 @@ function upsertTextItem(
     replaceItem(d, id, {
       ...existing,
       text: existing.text + text,
-      channelId,
+      channelId: ctx.channelId,
+      turnId: ctx.turnId ?? existing.turnId,
+      sessionId: ctx.sessionId ?? existing.sessionId,
       acpSource: acpSource ?? existing.acpSource,
     });
     return;
   }
   sealOpenMessages(d);
-  pushItem(d, { id, type, title, text, timestamp, channelId, acpSource });
+  pushItem(d, {
+    id,
+    type,
+    title,
+    text,
+    timestamp,
+    channelId: ctx.channelId,
+    turnId: ctx.turnId,
+    sessionId: ctx.sessionId,
+    acpSource,
+  });
 }
 
 function upsertMetadata(
@@ -182,7 +204,7 @@ function upsertMetadata(
   title: string,
   sections: PromptSection[],
   timestamp: string,
-  channelId: string | null,
+  ctx: TranscriptItemContext,
   acpSource?: string,
 ) {
   const existing = d.itemsById.get(id);
@@ -190,7 +212,9 @@ function upsertMetadata(
     replaceItem(d, id, {
       ...existing,
       sections,
-      channelId,
+      channelId: ctx.channelId,
+      turnId: ctx.turnId ?? existing.turnId,
+      sessionId: ctx.sessionId ?? existing.sessionId,
       acpSource: acpSource ?? existing.acpSource,
     });
     return;
@@ -202,7 +226,9 @@ function upsertMetadata(
     title,
     sections,
     timestamp,
-    channelId,
+    channelId: ctx.channelId,
+    turnId: ctx.turnId,
+    sessionId: ctx.sessionId,
     acpSource,
   });
 }
@@ -218,7 +244,7 @@ function upsertTool(
   result: string,
   isError: boolean,
   timestamp: string,
-  channelId: string | null,
+  ctx: TranscriptItemContext,
   acpSource?: string,
 ) {
   const existing = d.itemsById.get(id);
@@ -248,7 +274,9 @@ function upsertTool(
         existing.completedAt == null
           ? timestamp
           : existing.completedAt,
-      channelId,
+      channelId: ctx.channelId,
+      turnId: ctx.turnId ?? existing.turnId,
+      sessionId: ctx.sessionId ?? existing.sessionId,
       acpSource: acpSource ?? existing.acpSource,
     });
     return;
@@ -267,7 +295,9 @@ function upsertTool(
     timestamp,
     startedAt: timestamp,
     completedAt: null,
-    channelId,
+    channelId: ctx.channelId,
+    turnId: ctx.turnId,
+    sessionId: ctx.sessionId,
     acpSource,
   });
 }
@@ -284,6 +314,11 @@ export function processTranscriptEvent(
 
   const channelId = event.channelId ?? null;
   const ch = channelId ?? "global";
+  const ctx: TranscriptItemContext = {
+    channelId,
+    turnId: event.turnId,
+    sessionId: event.sessionId ?? d.latestSessionId,
+  };
 
   if (event.kind === "turn_started") {
     upsertTextItem(
@@ -293,7 +328,7 @@ export function processTranscriptEvent(
       "Turn started",
       describeTurnStarted(event.payload),
       event.timestamp,
-      channelId,
+      ctx,
       event.kind,
     );
   } else if (event.kind === "session_resolved") {
@@ -304,7 +339,7 @@ export function processTranscriptEvent(
       "Session ready",
       describeSessionResolved(event.payload),
       event.timestamp,
-      channelId,
+      ctx,
       event.kind,
     );
   } else if (event.kind === "acp_parse_error") {
@@ -315,7 +350,7 @@ export function processTranscriptEvent(
       "Wire parse error",
       extractBlockText(event.payload),
       event.timestamp,
-      channelId,
+      ctx,
       event.kind,
     );
   } else if (event.kind === "turn_error" || event.kind === "agent_panic") {
@@ -331,7 +366,7 @@ export function processTranscriptEvent(
       title,
       `${outcome}: ${error}`,
       event.timestamp,
-      channelId,
+      ctx,
       event.kind,
     );
   } else if (event.kind === "acp_read" || event.kind === "acp_write") {
@@ -350,7 +385,7 @@ export function processTranscriptEvent(
             parsedPrompt.userTitle,
             parsedPrompt.userText,
             event.timestamp,
-            channelId,
+            ctx,
             parsedPrompt.userPubkey,
             "session/prompt:user",
           );
@@ -362,7 +397,7 @@ export function processTranscriptEvent(
             "Prompt context",
             parsedPrompt.sections,
             event.timestamp,
-            channelId,
+            ctx,
             "session/prompt:context",
           );
         }
@@ -382,7 +417,7 @@ export function processTranscriptEvent(
           "Assistant",
           extractContentText(update.content),
           event.timestamp,
-          channelId,
+          ctx,
           null,
           updateType,
         );
@@ -394,7 +429,7 @@ export function processTranscriptEvent(
           "User",
           extractContentText(update.content),
           event.timestamp,
-          channelId,
+          ctx,
           null,
           updateType,
         );
@@ -406,7 +441,7 @@ export function processTranscriptEvent(
           "Thinking",
           extractContentText(update.content),
           event.timestamp,
-          channelId,
+          ctx,
           updateType,
         );
       } else if (updateType === "tool_call") {
@@ -423,7 +458,7 @@ export function processTranscriptEvent(
           extractToolResult(update),
           false,
           event.timestamp,
-          channelId,
+          ctx,
           updateType,
         );
       } else if (updateType === "tool_call_update") {
@@ -443,7 +478,7 @@ export function processTranscriptEvent(
           extractToolResult(update),
           status === "failed",
           event.timestamp,
-          channelId,
+          ctx,
           updateType,
         );
       } else if (updateType === "plan") {
@@ -454,7 +489,7 @@ export function processTranscriptEvent(
           "Plan",
           extractContentText(update.content) || JSON.stringify(update, null, 2),
           event.timestamp,
-          channelId,
+          ctx,
           updateType,
         );
       }

--- a/desktop/src/features/agents/ui/agentSessionTranscript.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.ts
@@ -117,6 +117,7 @@ function upsertMessage(
   timestamp: string,
   channelId: string | null,
   authorPubkey: string | null = null,
+  acpSource?: string,
 ) {
   const currentKey = d.activeMessageKey.get(id);
 
@@ -128,6 +129,7 @@ function upsertMessage(
         text: existing.text + text,
         channelId,
         authorPubkey: authorPubkey ?? existing.authorPubkey,
+        acpSource: acpSource ?? existing.acpSource,
       });
       return;
     }
@@ -144,6 +146,7 @@ function upsertMessage(
     timestamp,
     channelId,
     authorPubkey,
+    acpSource,
   });
   d.activeMessageKey = new Map(d.activeMessageKey);
   d.activeMessageKey.set(id, newKey);
@@ -157,14 +160,20 @@ function upsertTextItem(
   text: string,
   timestamp: string,
   channelId: string | null,
+  acpSource?: string,
 ) {
   const existing = d.itemsById.get(id);
   if (existing && existing.type === type) {
-    replaceItem(d, id, { ...existing, text: existing.text + text, channelId });
+    replaceItem(d, id, {
+      ...existing,
+      text: existing.text + text,
+      channelId,
+      acpSource: acpSource ?? existing.acpSource,
+    });
     return;
   }
   sealOpenMessages(d);
-  pushItem(d, { id, type, title, text, timestamp, channelId });
+  pushItem(d, { id, type, title, text, timestamp, channelId, acpSource });
 }
 
 function upsertMetadata(
@@ -174,14 +183,28 @@ function upsertMetadata(
   sections: PromptSection[],
   timestamp: string,
   channelId: string | null,
+  acpSource?: string,
 ) {
   const existing = d.itemsById.get(id);
   if (existing?.type === "metadata") {
-    replaceItem(d, id, { ...existing, sections, channelId });
+    replaceItem(d, id, {
+      ...existing,
+      sections,
+      channelId,
+      acpSource: acpSource ?? existing.acpSource,
+    });
     return;
   }
   sealOpenMessages(d);
-  pushItem(d, { id, type: "metadata", title, sections, timestamp, channelId });
+  pushItem(d, {
+    id,
+    type: "metadata",
+    title,
+    sections,
+    timestamp,
+    channelId,
+    acpSource,
+  });
 }
 
 function upsertTool(
@@ -196,6 +219,7 @@ function upsertTool(
   isError: boolean,
   timestamp: string,
   channelId: string | null,
+  acpSource?: string,
 ) {
   const existing = d.itemsById.get(id);
   const canonicalBuzzToolName =
@@ -225,6 +249,7 @@ function upsertTool(
           ? timestamp
           : existing.completedAt,
       channelId,
+      acpSource: acpSource ?? existing.acpSource,
     });
     return;
   }
@@ -243,6 +268,7 @@ function upsertTool(
     startedAt: timestamp,
     completedAt: null,
     channelId,
+    acpSource,
   });
 }
 
@@ -268,6 +294,7 @@ export function processTranscriptEvent(
       describeTurnStarted(event.payload),
       event.timestamp,
       channelId,
+      event.kind,
     );
   } else if (event.kind === "session_resolved") {
     upsertTextItem(
@@ -278,6 +305,7 @@ export function processTranscriptEvent(
       describeSessionResolved(event.payload),
       event.timestamp,
       channelId,
+      event.kind,
     );
   } else if (event.kind === "acp_parse_error") {
     upsertTextItem(
@@ -288,6 +316,7 @@ export function processTranscriptEvent(
       extractBlockText(event.payload),
       event.timestamp,
       channelId,
+      event.kind,
     );
   } else if (event.kind === "turn_error" || event.kind === "agent_panic") {
     const payload = asRecord(event.payload);
@@ -303,6 +332,7 @@ export function processTranscriptEvent(
       `${outcome}: ${error}`,
       event.timestamp,
       channelId,
+      event.kind,
     );
   } else if (event.kind === "acp_read" || event.kind === "acp_write") {
     const payload = asRecord(event.payload);
@@ -322,6 +352,7 @@ export function processTranscriptEvent(
             event.timestamp,
             channelId,
             parsedPrompt.userPubkey,
+            "session/prompt:user",
           );
         }
         if (parsedPrompt.sections.length > 0) {
@@ -332,6 +363,7 @@ export function processTranscriptEvent(
             parsedPrompt.sections,
             event.timestamp,
             channelId,
+            "session/prompt:context",
           );
         }
       }
@@ -351,6 +383,8 @@ export function processTranscriptEvent(
           extractContentText(update.content),
           event.timestamp,
           channelId,
+          null,
+          updateType,
         );
       } else if (updateType === "user_message_chunk") {
         upsertMessage(
@@ -361,6 +395,8 @@ export function processTranscriptEvent(
           extractContentText(update.content),
           event.timestamp,
           channelId,
+          null,
+          updateType,
         );
       } else if (updateType === "agent_thought_chunk") {
         upsertTextItem(
@@ -371,6 +407,7 @@ export function processTranscriptEvent(
           extractContentText(update.content),
           event.timestamp,
           channelId,
+          updateType,
         );
       } else if (updateType === "tool_call") {
         const toolId = asString(update.toolCallId) ?? `tool:${event.seq}`;
@@ -387,6 +424,7 @@ export function processTranscriptEvent(
           false,
           event.timestamp,
           channelId,
+          updateType,
         );
       } else if (updateType === "tool_call_update") {
         const toolId = asString(update.toolCallId) ?? `tool:${event.seq}`;
@@ -406,6 +444,7 @@ export function processTranscriptEvent(
           status === "failed",
           event.timestamp,
           channelId,
+          updateType,
         );
       } else if (updateType === "plan") {
         upsertTextItem(
@@ -416,6 +455,7 @@ export function processTranscriptEvent(
           extractContentText(update.content) || JSON.stringify(update, null, 2),
           event.timestamp,
           channelId,
+          updateType,
         );
       }
     }

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildTranscriptDisplayBlocks,
+  flattenDisplayBlocks,
+  formatTurnSetupLabel,
+} from "./agentSessionTranscriptGrouping.ts";
+
+const baseTimestamp = "2026-06-14T22:20:23.000Z";
+
+function lifecycle(id, title, acpSource, turnId, text = "") {
+  return {
+    id,
+    type: "lifecycle",
+    title,
+    text,
+    timestamp: baseTimestamp,
+    acpSource,
+    turnId,
+    sessionId: "sess-1",
+    channelId: "channel-1",
+  };
+}
+
+function userPrompt(id, text, turnId) {
+  return {
+    id,
+    type: "message",
+    role: "user",
+    title: "Buzz event",
+    text,
+    timestamp: baseTimestamp,
+    acpSource: "session/prompt:user",
+    turnId,
+    sessionId: "sess-1",
+    channelId: "channel-1",
+  };
+}
+
+function promptContext(id, turnId) {
+  return {
+    id,
+    type: "metadata",
+    title: "Prompt context",
+    sections: [{ title: "Channel", body: "general" }],
+    timestamp: baseTimestamp,
+    acpSource: "session/prompt:context",
+    turnId,
+    sessionId: "sess-1",
+    channelId: "channel-1",
+  };
+}
+
+function assistantMessage(id, text, turnId) {
+  return {
+    id,
+    type: "message",
+    role: "assistant",
+    title: "Assistant",
+    text,
+    timestamp: "2026-06-14T22:20:47.000Z",
+    acpSource: "agent_message_chunk",
+    turnId,
+    sessionId: "sess-1",
+    channelId: "channel-1",
+  };
+}
+
+function toolCall(id, turnId) {
+  return {
+    id,
+    type: "tool",
+    title: "Shell",
+    toolName: "buzz-dev-mcp__shell",
+    buzzToolName: null,
+    status: "completed",
+    args: {},
+    result: "ok",
+    isError: false,
+    timestamp: "2026-06-14T22:20:47.000Z",
+    startedAt: "2026-06-14T22:20:47.000Z",
+    completedAt: "2026-06-14T22:20:47.400Z",
+    acpSource: "tool_call_update",
+    turnId,
+    sessionId: "sess-1",
+    channelId: "channel-1",
+  };
+}
+
+test("buildTranscriptDisplayBlocks bundles user prompt, setup, and context together", () => {
+  const rawItems = [
+    lifecycle(
+      "turn",
+      "Turn started",
+      "turn_started",
+      "turn-1",
+      "Triggered by 1 event.",
+    ),
+    lifecycle("session", "Session ready", "session_resolved", "turn-1"),
+    userPrompt("prompt", "@Ned deliberate, wider pass", "turn-1"),
+    promptContext("context", "turn-1"),
+    assistantMessage("assistant", "Thinking out loud.", "turn-1"),
+    toolCall("tool", "turn-1"),
+  ];
+
+  const blocks = buildTranscriptDisplayBlocks(rawItems);
+  const displayOrder = flattenDisplayBlocks(blocks).map((item) => item.id);
+
+  assert.deepEqual(displayOrder, [
+    "prompt",
+    "turn",
+    "session",
+    "context",
+    "assistant",
+    "tool",
+  ]);
+
+  const turnBlock = blocks[0];
+  assert.equal(turnBlock?.kind, "turn");
+  assert.equal(turnBlock.segments[0]?.kind, "prompt");
+  const promptSegment = turnBlock.segments[0];
+  assert.equal(promptSegment.user.id, "prompt");
+  assert.equal(promptSegment.context?.id, "context");
+  assert.equal(promptSegment.setup.length, 2);
+  assert.equal(turnBlock.segments[1]?.kind, "item");
+});
+
+test("buildTranscriptDisplayBlocks collapses setup lifecycle inside prompt bundle", () => {
+  const rawItems = [
+    lifecycle("turn", "Turn started", "turn_started", "turn-1"),
+    lifecycle("session", "Session ready", "session_resolved", "turn-1"),
+    userPrompt("prompt", "hello", "turn-1"),
+  ];
+
+  const blocks = buildTranscriptDisplayBlocks(rawItems);
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0]?.kind, "turn");
+
+  const turnBlock = blocks[0];
+  assert.equal(turnBlock.segments.length, 1);
+  assert.equal(turnBlock.segments[0]?.kind, "prompt");
+  assert.equal(
+    formatTurnSetupLabel(turnBlock.segments[0].setup),
+    "Turn started · Session ready",
+  );
+});
+
+test("buildTranscriptDisplayBlocks keeps lifecycle visible when prompt is missing", () => {
+  const rawItems = [
+    lifecycle("turn", "Turn started", "turn_started", "turn-1"),
+    lifecycle("session", "Session ready", "session_resolved", "turn-1"),
+  ];
+
+  const blocks = buildTranscriptDisplayBlocks(rawItems);
+  const displayOrder = flattenDisplayBlocks(blocks).map((item) => item.id);
+
+  assert.deepEqual(displayOrder, ["turn", "session"]);
+});
+
+test("buildTranscriptDisplayBlocks leaves error lifecycle prominent outside prompt bundle", () => {
+  const rawItems = [
+    lifecycle("turn", "Turn started", "turn_started", "turn-1"),
+    userPrompt("prompt", "hello", "turn-1"),
+    lifecycle(
+      "error",
+      "Turn error",
+      "turn_error",
+      "turn-1",
+      "timeout: agent hung",
+    ),
+  ];
+
+  const blocks = buildTranscriptDisplayBlocks(rawItems);
+  const displayOrder = flattenDisplayBlocks(blocks).map((item) => item.id);
+
+  assert.deepEqual(displayOrder, ["prompt", "turn", "error"]);
+  assert.equal(blocks[0]?.segments[0]?.kind, "prompt");
+  assert.equal(blocks[0]?.segments[1]?.kind, "item");
+  assert.equal(blocks[0]?.segments[1]?.item.id, "error");
+});
+
+test("buildTranscriptDisplayBlocks passes through items without turnId", () => {
+  const orphan = {
+    id: "orphan",
+    type: "lifecycle",
+    title: "Wire parse error",
+    text: "bad json",
+    timestamp: baseTimestamp,
+    acpSource: "acp_parse_error",
+    channelId: "channel-1",
+  };
+
+  const blocks = buildTranscriptDisplayBlocks([orphan]);
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0]?.kind, "single");
+  assert.equal(blocks[0]?.item.id, "orphan");
+});

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -124,6 +124,32 @@ test("buildTranscriptDisplayBlocks bundles user prompt, setup, and context toget
   assert.equal(promptSegment.context?.id, "context");
   assert.equal(promptSegment.setup.length, 2);
   assert.equal(turnBlock.segments[1]?.kind, "item");
+  assert.equal(turnBlock.segments[2]?.kind, "tool_group");
+});
+
+test("buildTranscriptDisplayBlocks groups consecutive tool calls", () => {
+  const rawItems = [
+    userPrompt("prompt", "run these", "turn-1"),
+    toolCall("tool-1", "turn-1"),
+    toolCall("tool-2", "turn-1"),
+    assistantMessage("assistant", "Done.", "turn-1"),
+    toolCall("tool-3", "turn-1"),
+  ];
+
+  const blocks = buildTranscriptDisplayBlocks(rawItems);
+  const turnBlock = blocks[0];
+  assert.equal(turnBlock?.kind, "turn");
+  assert.equal(turnBlock.segments[1]?.kind, "tool_group");
+  assert.deepEqual(
+    turnBlock.segments[1]?.items?.map((item) => item.id),
+    ["tool-1", "tool-2"],
+  );
+  assert.equal(turnBlock.segments[2]?.kind, "item");
+  assert.equal(turnBlock.segments[3]?.kind, "tool_group");
+  assert.deepEqual(
+    turnBlock.segments[3]?.items?.map((item) => item.id),
+    ["tool-3"],
+  );
 });
 
 test("buildTranscriptDisplayBlocks collapses setup lifecycle inside prompt bundle", () => {
@@ -146,23 +172,25 @@ test("buildTranscriptDisplayBlocks collapses setup lifecycle inside prompt bundl
   );
 });
 
-test("buildTranscriptDisplayBlocks hides setup lifecycle when prompt is missing", () => {
+test("buildTranscriptDisplayBlocks hides setup and context when prompt is missing", () => {
   const rawItems = [
     lifecycle("turn", "Turn started", "turn_started", "turn-1"),
     lifecycle("session", "Session ready", "session_resolved", "turn-1"),
     promptContext("context", "turn-1"),
+    toolCall("tool", "turn-1"),
   ];
 
   const blocks = buildTranscriptDisplayBlocks(rawItems);
   const displayOrder = flattenDisplayBlocks(blocks).map((item) => item.id);
 
-  assert.deepEqual(displayOrder, ["context"]);
+  assert.deepEqual(displayOrder, ["tool"]);
 });
 
-test("buildTranscriptDisplayBlocks drops setup-only turns", () => {
+test("buildTranscriptDisplayBlocks drops setup-and-context-only turns", () => {
   const rawItems = [
     lifecycle("turn", "Turn started", "turn_started", "turn-1"),
     lifecycle("session", "Session ready", "session_resolved", "turn-1"),
+    promptContext("context", "turn-1"),
   ];
 
   const blocks = buildTranscriptDisplayBlocks(rawItems);

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -146,16 +146,28 @@ test("buildTranscriptDisplayBlocks collapses setup lifecycle inside prompt bundl
   );
 });
 
-test("buildTranscriptDisplayBlocks keeps lifecycle visible when prompt is missing", () => {
+test("buildTranscriptDisplayBlocks hides setup lifecycle when prompt is missing", () => {
+  const rawItems = [
+    lifecycle("turn", "Turn started", "turn_started", "turn-1"),
+    lifecycle("session", "Session ready", "session_resolved", "turn-1"),
+    promptContext("context", "turn-1"),
+  ];
+
+  const blocks = buildTranscriptDisplayBlocks(rawItems);
+  const displayOrder = flattenDisplayBlocks(blocks).map((item) => item.id);
+
+  assert.deepEqual(displayOrder, ["context"]);
+});
+
+test("buildTranscriptDisplayBlocks drops setup-only turns", () => {
   const rawItems = [
     lifecycle("turn", "Turn started", "turn_started", "turn-1"),
     lifecycle("session", "Session ready", "session_resolved", "turn-1"),
   ];
 
   const blocks = buildTranscriptDisplayBlocks(rawItems);
-  const displayOrder = flattenDisplayBlocks(blocks).map((item) => item.id);
 
-  assert.deepEqual(displayOrder, ["turn", "session"]);
+  assert.deepEqual(blocks, []);
 });
 
 test("buildTranscriptDisplayBlocks leaves error lifecycle prominent outside prompt bundle", () => {

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -124,32 +124,7 @@ test("buildTranscriptDisplayBlocks bundles user prompt, setup, and context toget
   assert.equal(promptSegment.context?.id, "context");
   assert.equal(promptSegment.setup.length, 2);
   assert.equal(turnBlock.segments[1]?.kind, "item");
-  assert.equal(turnBlock.segments[2]?.kind, "tool_group");
-});
-
-test("buildTranscriptDisplayBlocks groups consecutive tool calls", () => {
-  const rawItems = [
-    userPrompt("prompt", "run these", "turn-1"),
-    toolCall("tool-1", "turn-1"),
-    toolCall("tool-2", "turn-1"),
-    assistantMessage("assistant", "Done.", "turn-1"),
-    toolCall("tool-3", "turn-1"),
-  ];
-
-  const blocks = buildTranscriptDisplayBlocks(rawItems);
-  const turnBlock = blocks[0];
-  assert.equal(turnBlock?.kind, "turn");
-  assert.equal(turnBlock.segments[1]?.kind, "tool_group");
-  assert.deepEqual(
-    turnBlock.segments[1]?.items?.map((item) => item.id),
-    ["tool-1", "tool-2"],
-  );
   assert.equal(turnBlock.segments[2]?.kind, "item");
-  assert.equal(turnBlock.segments[3]?.kind, "tool_group");
-  assert.deepEqual(
-    turnBlock.segments[3]?.items?.map((item) => item.id),
-    ["tool-3"],
-  );
 });
 
 test("buildTranscriptDisplayBlocks collapses setup lifecycle inside prompt bundle", () => {

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -1,0 +1,208 @@
+import type { TranscriptItem } from "./agentSessionTypes";
+
+export type TranscriptTurnSegment =
+  | { kind: "item"; item: TranscriptItem }
+  | { kind: "setup"; items: Extract<TranscriptItem, { type: "lifecycle" }>[] }
+  | {
+      kind: "prompt";
+      user: Extract<TranscriptItem, { type: "message" }>;
+      context: Extract<TranscriptItem, { type: "metadata" }> | null;
+      setup: Extract<TranscriptItem, { type: "lifecycle" }>[];
+    };
+
+export type TranscriptDisplayBlock =
+  | { kind: "single"; item: TranscriptItem }
+  | { kind: "turn"; turnId: string; segments: TranscriptTurnSegment[] };
+
+function isUserPrompt(
+  item: TranscriptItem,
+): item is Extract<TranscriptItem, { type: "message" }> {
+  return (
+    item.type === "message" &&
+    item.role === "user" &&
+    item.acpSource === "session/prompt:user"
+  );
+}
+
+function isPromptContext(
+  item: TranscriptItem,
+): item is Extract<TranscriptItem, { type: "metadata" }> {
+  return (
+    item.type === "metadata" && item.acpSource === "session/prompt:context"
+  );
+}
+
+function isSetupLifecycle(
+  item: TranscriptItem,
+): item is Extract<TranscriptItem, { type: "lifecycle" }> {
+  return (
+    item.type === "lifecycle" &&
+    (item.acpSource === "turn_started" || item.acpSource === "session_resolved")
+  );
+}
+
+function isErrorLifecycle(
+  item: TranscriptItem,
+): item is Extract<TranscriptItem, { type: "lifecycle" }> {
+  return (
+    item.type === "lifecycle" && item.title.toLowerCase().includes("error")
+  );
+}
+
+type TurnBucket = {
+  turnId: string;
+  items: TranscriptItem[];
+};
+
+function classifyTurnItems(items: TranscriptItem[]): TranscriptTurnSegment[] {
+  const userPrompt = items.find(isUserPrompt) ?? null;
+  const setupLifecycle = items.filter(isSetupLifecycle);
+  const promptContext = items.find(isPromptContext) ?? null;
+  const consumed = new Set<TranscriptItem>();
+
+  if (userPrompt) consumed.add(userPrompt);
+  for (const item of setupLifecycle) consumed.add(item);
+  if (promptContext) consumed.add(promptContext);
+
+  const activity = items.filter((item) => !consumed.has(item));
+
+  if (!userPrompt) {
+    return items.map((item) => ({ kind: "item", item }));
+  }
+
+  const segments: TranscriptTurnSegment[] = [
+    {
+      kind: "prompt",
+      user: userPrompt,
+      context: promptContext,
+      setup: setupLifecycle,
+    },
+  ];
+
+  for (const item of activity) {
+    if (isErrorLifecycle(item)) {
+      segments.push({ kind: "item", item });
+      continue;
+    }
+    if (isSetupLifecycle(item)) {
+      continue;
+    }
+    segments.push({ kind: "item", item });
+  }
+
+  return segments;
+}
+
+/**
+ * Build presentation-only display blocks from normalized transcript items.
+ * Raw observer order is preserved in the source items; this only reorders
+ * within a turn for user-facing narrative flow.
+ */
+export function buildTranscriptDisplayBlocks(
+  items: TranscriptItem[],
+): TranscriptDisplayBlock[] {
+  const blocks: TranscriptDisplayBlock[] = [];
+  const turnBuckets = new Map<string, TurnBucket>();
+  const displayOrder: Array<
+    { kind: "single"; item: TranscriptItem } | { kind: "turn"; turnId: string }
+  > = [];
+
+  for (const item of items) {
+    const turnId = item.turnId;
+    if (!turnId) {
+      displayOrder.push({ kind: "single", item });
+      continue;
+    }
+
+    let bucket = turnBuckets.get(turnId);
+    if (!bucket) {
+      bucket = { turnId, items: [] };
+      turnBuckets.set(turnId, bucket);
+      displayOrder.push({ kind: "turn", turnId });
+    }
+    bucket.items.push(item);
+  }
+
+  for (const entry of displayOrder) {
+    if (entry.kind === "single") {
+      blocks.push({ kind: "single", item: entry.item });
+      continue;
+    }
+
+    const bucket = turnBuckets.get(entry.turnId);
+    if (!bucket || bucket.items.length === 0) {
+      continue;
+    }
+
+    blocks.push({
+      kind: "turn",
+      turnId: entry.turnId,
+      segments: classifyTurnItems(bucket.items),
+    });
+  }
+
+  return blocks;
+}
+
+/** Flatten display blocks back to items for testing display order. */
+export function flattenDisplayBlocks(
+  blocks: TranscriptDisplayBlock[],
+): TranscriptItem[] {
+  const result: TranscriptItem[] = [];
+
+  for (const block of blocks) {
+    if (block.kind === "single") {
+      result.push(block.item);
+      continue;
+    }
+
+    for (const segment of block.segments) {
+      if (segment.kind === "item") {
+        result.push(segment.item);
+      } else if (segment.kind === "prompt") {
+        result.push(segment.user);
+        result.push(...segment.setup);
+        if (segment.context) {
+          result.push(segment.context);
+        }
+      } else {
+        result.push(...segment.items);
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Human-readable labels for a collapsed turn setup row. */
+export function formatTurnSetupLabel(
+  items: Extract<TranscriptItem, { type: "lifecycle" }>[],
+): string {
+  const labels = items.map((item) => item.title);
+  return labels.join(" · ");
+}
+
+/** Earliest timestamp among setup lifecycle items. */
+export function turnSetupTimestamp(
+  items: Extract<TranscriptItem, { type: "lifecycle" }>[],
+): string | null {
+  if (items.length === 0) return null;
+  return items.reduce(
+    (earliest, item) =>
+      Date.parse(item.timestamp) < Date.parse(earliest)
+        ? item.timestamp
+        : earliest,
+    items[0].timestamp,
+  );
+}
+
+/** Optional detail text from setup lifecycle items (e.g. trigger count). */
+export function turnSetupDetail(
+  items: Extract<TranscriptItem, { type: "lifecycle" }>[],
+): string | null {
+  const details = items
+    .map((item) => item.text.trim())
+    .filter((text) => text.length > 0);
+  if (details.length === 0) return null;
+  return details.join(" ");
+}

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -84,9 +84,6 @@ function classifyTurnItems(items: TranscriptItem[]): TranscriptTurnSegment[] {
       segments.push({ kind: "item", item });
       continue;
     }
-    if (isSetupLifecycle(item)) {
-      continue;
-    }
     segments.push({ kind: "item", item });
   }
 

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -62,12 +62,12 @@ function classifyTurnItems(items: TranscriptItem[]): TranscriptTurnSegment[] {
 
   if (userPrompt) consumed.add(userPrompt);
   for (const item of setupLifecycle) consumed.add(item);
-  if (promptContext) consumed.add(promptContext);
+  if (userPrompt && promptContext) consumed.add(promptContext);
 
   const activity = items.filter((item) => !consumed.has(item));
 
   if (!userPrompt) {
-    return items.map((item) => ({ kind: "item", item }));
+    return activity.map((item) => ({ kind: "item", item }));
   }
 
   const segments: TranscriptTurnSegment[] = [
@@ -134,11 +134,14 @@ export function buildTranscriptDisplayBlocks(
       continue;
     }
 
-    blocks.push({
-      kind: "turn",
-      turnId: entry.turnId,
-      segments: classifyTurnItems(bucket.items),
-    });
+    const segments = classifyTurnItems(bucket.items);
+    if (segments.length > 0) {
+      blocks.push({
+        kind: "turn",
+        turnId: entry.turnId,
+        segments,
+      });
+    }
   }
 
   return blocks;

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -2,6 +2,7 @@ import type { TranscriptItem } from "./agentSessionTypes";
 
 export type TranscriptTurnSegment =
   | { kind: "item"; item: TranscriptItem }
+  | { kind: "tool_group"; items: Extract<TranscriptItem, { type: "tool" }>[] }
   | { kind: "setup"; items: Extract<TranscriptItem, { type: "lifecycle" }>[] }
   | {
       kind: "prompt";
@@ -62,12 +63,14 @@ function classifyTurnItems(items: TranscriptItem[]): TranscriptTurnSegment[] {
 
   if (userPrompt) consumed.add(userPrompt);
   for (const item of setupLifecycle) consumed.add(item);
-  if (userPrompt && promptContext) consumed.add(promptContext);
+  if (promptContext) consumed.add(promptContext);
 
   const activity = items.filter((item) => !consumed.has(item));
 
   if (!userPrompt) {
-    return activity.map((item) => ({ kind: "item", item }));
+    return groupConsecutiveToolSegments(
+      activity.map((item) => ({ kind: "item", item })),
+    );
   }
 
   const segments: TranscriptTurnSegment[] = [
@@ -90,7 +93,34 @@ function classifyTurnItems(items: TranscriptItem[]): TranscriptTurnSegment[] {
     segments.push({ kind: "item", item });
   }
 
-  return segments;
+  return groupConsecutiveToolSegments(segments);
+}
+
+function groupConsecutiveToolSegments(
+  segments: TranscriptTurnSegment[],
+): TranscriptTurnSegment[] {
+  const grouped: TranscriptTurnSegment[] = [];
+  let toolBuffer: Extract<TranscriptItem, { type: "tool" }>[] = [];
+
+  const flushTools = () => {
+    if (toolBuffer.length === 0) {
+      return;
+    }
+    grouped.push({ kind: "tool_group", items: toolBuffer });
+    toolBuffer = [];
+  };
+
+  for (const segment of segments) {
+    if (segment.kind === "item" && segment.item.type === "tool") {
+      toolBuffer.push(segment.item);
+      continue;
+    }
+    flushTools();
+    grouped.push(segment);
+  }
+
+  flushTools();
+  return grouped;
 }
 
 /**
@@ -162,6 +192,8 @@ export function flattenDisplayBlocks(
     for (const segment of block.segments) {
       if (segment.kind === "item") {
         result.push(segment.item);
+      } else if (segment.kind === "tool_group") {
+        result.push(...segment.items);
       } else if (segment.kind === "prompt") {
         result.push(segment.user);
         result.push(...segment.setup);

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -2,7 +2,6 @@ import type { TranscriptItem } from "./agentSessionTypes";
 
 export type TranscriptTurnSegment =
   | { kind: "item"; item: TranscriptItem }
-  | { kind: "tool_group"; items: Extract<TranscriptItem, { type: "tool" }>[] }
   | { kind: "setup"; items: Extract<TranscriptItem, { type: "lifecycle" }>[] }
   | {
       kind: "prompt";
@@ -68,9 +67,7 @@ function classifyTurnItems(items: TranscriptItem[]): TranscriptTurnSegment[] {
   const activity = items.filter((item) => !consumed.has(item));
 
   if (!userPrompt) {
-    return groupConsecutiveToolSegments(
-      activity.map((item) => ({ kind: "item", item })),
-    );
+    return activity.map((item) => ({ kind: "item", item }));
   }
 
   const segments: TranscriptTurnSegment[] = [
@@ -93,34 +90,7 @@ function classifyTurnItems(items: TranscriptItem[]): TranscriptTurnSegment[] {
     segments.push({ kind: "item", item });
   }
 
-  return groupConsecutiveToolSegments(segments);
-}
-
-function groupConsecutiveToolSegments(
-  segments: TranscriptTurnSegment[],
-): TranscriptTurnSegment[] {
-  const grouped: TranscriptTurnSegment[] = [];
-  let toolBuffer: Extract<TranscriptItem, { type: "tool" }>[] = [];
-
-  const flushTools = () => {
-    if (toolBuffer.length === 0) {
-      return;
-    }
-    grouped.push({ kind: "tool_group", items: toolBuffer });
-    toolBuffer = [];
-  };
-
-  for (const segment of segments) {
-    if (segment.kind === "item" && segment.item.type === "tool") {
-      toolBuffer.push(segment.item);
-      continue;
-    }
-    flushTools();
-    grouped.push(segment);
-  }
-
-  flushTools();
-  return grouped;
+  return segments;
 }
 
 /**
@@ -192,8 +162,6 @@ export function flattenDisplayBlocks(
     for (const segment of block.segments) {
       if (segment.kind === "item") {
         result.push(segment.item);
-      } else if (segment.kind === "tool_group") {
-        result.push(...segment.items);
       } else if (segment.kind === "prompt") {
         result.push(segment.user);
         result.push(...segment.setup);

--- a/desktop/src/features/agents/ui/agentSessionTranscriptHelpers.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptHelpers.test.mjs
@@ -65,6 +65,37 @@ test("parsePromptText extracts content, hex pubkey, and a title-cased kind", () 
   );
 });
 
+test("parsePromptText preserves multiline event content in the user bubble text", () => {
+  const text = [
+    "[Buzz event: @mention]",
+    "Event ID: event-1",
+    "Channel: agents",
+    `From: tho (hex: ${HEX})`,
+    "Time: 2026-06-15T17:15:00Z",
+    "Content: @Ned",
+    "",
+    "- remove that stray cherry pick if it's not adding value here",
+    "- help me understand what that e2eBridge change does",
+    "- we'd want the e2e seed path as a separate pull request",
+    'Tags: [["h","agents"]]',
+    "Parsed: mentions=[Ned]",
+  ].join("\n");
+
+  const result = parsePromptText(text);
+
+  assert.equal(
+    result.userText,
+    [
+      "@Ned",
+      "",
+      "- remove that stray cherry pick if it's not adding value here",
+      "- help me understand what that e2eBridge change does",
+      "- we'd want the e2e seed path as a separate pull request",
+    ].join("\n"),
+  );
+  assert.equal(result.userPubkey, HEX);
+});
+
 test("parsePromptText lowercases the extracted hex pubkey", () => {
   const text = [
     "[Buzz event: dm]",

--- a/desktop/src/features/agents/ui/agentSessionTranscriptHelpers.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptHelpers.ts
@@ -85,9 +85,39 @@ function parsePromptSections(text: string): PromptSection[] {
   return sections;
 }
 
+const EVENT_CONTENT_BOUNDARY_RE =
+  /^(?:Event ID|Channel|Kind|From|Time|Tags|Parsed):\s*/;
+const EVENT_BLOCK_BOUNDARY_RE = /^--- Event \d+\b/;
+
 function extractEventContent(body: string): string {
-  const contentMatch = body.match(/^Content:\s*(.*)$/m);
-  return contentMatch?.[1]?.trim() ?? "";
+  const lines = body.split(/\r?\n/);
+  const chunks: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^Content:\s?(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    const contentLines = [match[1] ?? ""];
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      if (
+        EVENT_CONTENT_BOUNDARY_RE.test(line) ||
+        EVENT_BLOCK_BOUNDARY_RE.test(line)
+      ) {
+        break;
+      }
+      contentLines.push(line);
+    }
+
+    const content = contentLines.join("\n").trim();
+    if (content) {
+      chunks.push(content);
+    }
+  }
+
+  return chunks.join("\n\n");
 }
 
 function extractEventAuthorPubkey(body: string): string | null {

--- a/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildTranscriptPresentation,
+  getActivityHeadline,
+  isMeaningfulItem,
+} from "./agentSessionTranscriptPresentation.ts";
+
+const baseTimestamp = "2026-06-14T19:00:00.000Z";
+
+function makeTool(overrides = {}) {
+  return {
+    id: "tool:1",
+    type: "tool",
+    title: "Send Message",
+    toolName: "send_message",
+    buzzToolName: "send_message",
+    status: "executing",
+    args: { channel_id: "abc" },
+    result: "",
+    isError: false,
+    timestamp: baseTimestamp,
+    startedAt: baseTimestamp,
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides = {}) {
+  return {
+    id: "msg:1",
+    type: "message",
+    role: "assistant",
+    title: "Assistant",
+    text: "Looking into that now.",
+    timestamp: baseTimestamp,
+    ...overrides,
+  };
+}
+
+test("getActivityHeadline formats tool titles and assistant text", () => {
+  assert.equal(getActivityHeadline(makeTool()), "Send Message");
+  assert.equal(
+    getActivityHeadline(makeMessage({ text: "First line\nSecond line" })),
+    "First line",
+  );
+  assert.equal(getActivityHeadline(makeMessage({ text: "   " })), "Responding");
+});
+
+test("isMeaningfulItem ignores lifecycle noise and metadata", () => {
+  assert.equal(
+    isMeaningfulItem({
+      id: "life:1",
+      type: "lifecycle",
+      title: "Turn started",
+      text: "",
+      timestamp: baseTimestamp,
+    }),
+    false,
+  );
+  assert.equal(
+    isMeaningfulItem({
+      id: "meta:1",
+      type: "metadata",
+      title: "Prompt context",
+      sections: [],
+      timestamp: baseTimestamp,
+    }),
+    false,
+  );
+  assert.equal(
+    isMeaningfulItem({
+      id: "life:2",
+      type: "lifecycle",
+      title: "Turn error",
+      text: "boom",
+      timestamp: baseTimestamp,
+    }),
+    true,
+  );
+});
+
+test("buildTranscriptPresentation marks running tools as active while working", () => {
+  const items = [
+    makeMessage({ id: "msg:user", role: "user", text: "Please help" }),
+    makeTool({ id: "tool:running", status: "executing" }),
+  ];
+
+  const presentation = buildTranscriptPresentation(items, true);
+
+  assert.equal(presentation.state, "tool_running");
+  assert.equal(presentation.headline, "Send Message");
+  assert.equal(presentation.counts.tools, 1);
+  assert.equal(presentation.counts.messages, 1);
+  assert.ok(presentation.activeItemIds.has("tool:running"));
+});
+
+test("buildTranscriptPresentation highlights assistant streaming while working", () => {
+  const items = [
+    makeMessage({ id: "msg:assistant", role: "assistant", text: "Drafting" }),
+  ];
+
+  const presentation = buildTranscriptPresentation(items, true);
+
+  assert.equal(presentation.state, "responding");
+  assert.equal(presentation.headline, "Drafting");
+  assert.ok(presentation.activeItemIds.has("msg:assistant"));
+});
+
+test("buildTranscriptPresentation surfaces lifecycle errors", () => {
+  const items = [
+    makeTool({
+      id: "tool:done",
+      status: "completed",
+      completedAt: "2026-06-14T19:00:05.000Z",
+    }),
+    {
+      id: "life:error",
+      type: "lifecycle",
+      title: "Turn error",
+      text: "timeout",
+      timestamp: "2026-06-14T19:00:06.000Z",
+    },
+  ];
+
+  const presentation = buildTranscriptPresentation(items, false);
+
+  assert.equal(presentation.state, "error");
+  assert.equal(presentation.hasError, true);
+  assert.equal(presentation.headline, "Turn error");
+});
+
+test("buildTranscriptPresentation returns idle state when not working", () => {
+  const items = [
+    makeTool({
+      id: "tool:done",
+      status: "completed",
+      completedAt: "2026-06-14T19:00:05.000Z",
+    }),
+  ];
+
+  const presentation = buildTranscriptPresentation(items, false);
+
+  assert.equal(presentation.state, "idle");
+  assert.equal(presentation.activeItemIds.size, 0);
+  assert.equal(presentation.headline, "Send Message");
+});

--- a/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.ts
@@ -1,0 +1,280 @@
+import { formatToolTitle } from "./agentSessionToolCatalog";
+import type { TranscriptItem } from "./agentSessionTypes";
+
+export type TranscriptActivityCounts = {
+  tools: number;
+  toolErrors: number;
+  thoughts: number;
+  messages: number;
+  lifecycle: number;
+  metadata: number;
+};
+
+export type TranscriptActivityState =
+  | "idle"
+  | "responding"
+  | "thinking"
+  | "tool_running"
+  | "error";
+
+export type TranscriptPresentation = {
+  headline: string;
+  state: TranscriptActivityState;
+  counts: TranscriptActivityCounts;
+  latestMeaningfulItem: TranscriptItem | null;
+  latestMeaningfulItemId: string | null;
+  activeItemIds: ReadonlySet<string>;
+  lastUpdatedAt: string | null;
+  hasError: boolean;
+};
+
+const LIFECYCLE_NOISE = new Set([
+  "turn started",
+  "session ready",
+  "wire parse error",
+]);
+
+/** Human-readable headline for a single transcript item. */
+export function getActivityHeadline(item: TranscriptItem): string | null {
+  if (item.type === "tool") {
+    return formatToolTitle(item.buzzToolName ?? item.toolName, item.title);
+  }
+
+  if (item.type === "message") {
+    if (item.role === "assistant") {
+      const trimmed = item.text.trim();
+      if (trimmed.length > 0) {
+        const firstLine = trimmed.split("\n")[0]?.trim() ?? "";
+        if (firstLine.length > 0) {
+          return firstLine.length > 72
+            ? `${firstLine.slice(0, 69)}…`
+            : firstLine;
+        }
+      }
+      return "Responding";
+    }
+    return item.title || "User prompt";
+  }
+
+  if (item.type === "thought") {
+    return item.title === "Plan" ? "Planning" : item.title;
+  }
+
+  if (item.type === "metadata") {
+    return item.title;
+  }
+
+  return item.title;
+}
+
+function isLifecycleNoise(
+  item: Extract<TranscriptItem, { type: "lifecycle" }>,
+) {
+  return LIFECYCLE_NOISE.has(item.title.toLowerCase());
+}
+
+/** Whether an item should contribute to the "Now" summary and headline scan. */
+export function isMeaningfulItem(item: TranscriptItem): boolean {
+  if (item.type === "lifecycle") {
+    return !isLifecycleNoise(item);
+  }
+  if (item.type === "metadata") {
+    return false;
+  }
+  return true;
+}
+
+function isToolRunning(item: Extract<TranscriptItem, { type: "tool" }>) {
+  return item.status === "executing" || item.status === "pending";
+}
+
+function isLifecycleError(
+  item: Extract<TranscriptItem, { type: "lifecycle" }>,
+) {
+  return item.title.toLowerCase().includes("error");
+}
+
+function countItems(items: TranscriptItem[]): TranscriptActivityCounts {
+  const counts: TranscriptActivityCounts = {
+    tools: 0,
+    toolErrors: 0,
+    thoughts: 0,
+    messages: 0,
+    lifecycle: 0,
+    metadata: 0,
+  };
+
+  for (const item of items) {
+    switch (item.type) {
+      case "tool":
+        counts.tools += 1;
+        if (item.isError || item.status === "failed") {
+          counts.toolErrors += 1;
+        }
+        break;
+      case "thought":
+        counts.thoughts += 1;
+        break;
+      case "message":
+        counts.messages += 1;
+        break;
+      case "lifecycle":
+        counts.lifecycle += 1;
+        break;
+      case "metadata":
+        counts.metadata += 1;
+        break;
+    }
+  }
+
+  return counts;
+}
+
+function findLatestMeaningfulItem(
+  items: TranscriptItem[],
+): TranscriptItem | null {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i];
+    if (isMeaningfulItem(item)) {
+      return item;
+    }
+  }
+  return null;
+}
+
+function resolveActivityState(
+  latest: TranscriptItem | null,
+  hasError: boolean,
+  isWorking: boolean,
+): TranscriptActivityState {
+  if (!isWorking) {
+    return hasError ? "error" : "idle";
+  }
+
+  if (hasError && latest?.type === "lifecycle" && isLifecycleError(latest)) {
+    return "error";
+  }
+
+  if (latest?.type === "tool" && isToolRunning(latest)) {
+    return "tool_running";
+  }
+
+  if (latest?.type === "thought") {
+    return "thinking";
+  }
+
+  if (latest?.type === "message" && latest.role === "assistant") {
+    return "responding";
+  }
+
+  if (latest?.type === "tool") {
+    return "tool_running";
+  }
+
+  return "idle";
+}
+
+function resolveHeadline(
+  latest: TranscriptItem | null,
+  state: TranscriptActivityState,
+  isWorking: boolean,
+): string {
+  if (latest) {
+    const headline = getActivityHeadline(latest);
+    if (headline) {
+      return headline;
+    }
+  }
+
+  if (isWorking) {
+    switch (state) {
+      case "tool_running":
+        return "Running a tool";
+      case "thinking":
+        return "Thinking";
+      case "responding":
+        return "Responding";
+      case "error":
+        return "Encountered an error";
+      default:
+        return "Working";
+    }
+  }
+
+  if (state === "error") {
+    return "Last turn ended with an error";
+  }
+
+  return "Waiting for activity";
+}
+
+function collectActiveItemIds(
+  items: TranscriptItem[],
+  isWorking: boolean,
+): ReadonlySet<string> {
+  if (!isWorking || items.length === 0) {
+    return new Set();
+  }
+
+  const active = new Set<string>();
+
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i];
+
+    if (item.type === "tool" && isToolRunning(item)) {
+      active.add(item.id);
+      break;
+    }
+
+    if (item.type === "thought") {
+      active.add(item.id);
+      break;
+    }
+
+    if (item.type === "message" && item.role === "assistant") {
+      active.add(item.id);
+      break;
+    }
+  }
+
+  return active;
+}
+
+function detectError(items: TranscriptItem[]): boolean {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i];
+    if (!isMeaningfulItem(item)) {
+      continue;
+    }
+    if (item.type === "lifecycle" && isLifecycleError(item)) {
+      return true;
+    }
+    if (item.type === "tool" && (item.isError || item.status === "failed")) {
+      return true;
+    }
+    break;
+  }
+  return false;
+}
+
+/** Derive presentation metadata for a transcript list. */
+export function buildTranscriptPresentation(
+  items: TranscriptItem[],
+  isWorking = false,
+): TranscriptPresentation {
+  const latestMeaningfulItem = findLatestMeaningfulItem(items);
+  const hasError = detectError(items);
+  const state = resolveActivityState(latestMeaningfulItem, hasError, isWorking);
+
+  return {
+    headline: resolveHeadline(latestMeaningfulItem, state, isWorking),
+    state,
+    counts: countItems(items),
+    latestMeaningfulItem,
+    latestMeaningfulItemId: latestMeaningfulItem?.id ?? null,
+    activeItemIds: collectActiveItemIds(items, isWorking),
+    lastUpdatedAt:
+      items.length > 0 ? (items[items.length - 1]?.timestamp ?? null) : null,
+    hasError,
+  };
+}

--- a/desktop/src/features/agents/ui/agentSessionTypes.ts
+++ b/desktop/src/features/agents/ui/agentSessionTypes.ts
@@ -23,8 +23,15 @@ export type ToolStatus = "executing" | "completed" | "failed" | "pending";
 /** Observer/ACP wire label for dev-only transcript debugging. */
 export type TranscriptAcpSource = string;
 
+/** Shared optional identity fields attached during transcript construction. */
+export type TranscriptItemIdentity = {
+  turnId?: string | null;
+  sessionId?: string | null;
+  channelId?: string | null;
+};
+
 export type TranscriptItem =
-  | {
+  | ({
       id: string;
       type: "message";
       role: "assistant" | "user";
@@ -33,36 +40,32 @@ export type TranscriptItem =
       timestamp: string;
       acpSource?: TranscriptAcpSource;
       authorPubkey?: string | null;
-      channelId?: string | null;
-    }
-  | {
+    } & TranscriptItemIdentity)
+  | ({
       id: string;
       type: "thought";
       title: string;
       text: string;
       timestamp: string;
       acpSource?: TranscriptAcpSource;
-      channelId?: string | null;
-    }
-  | {
+    } & TranscriptItemIdentity)
+  | ({
       id: string;
       type: "lifecycle";
       title: string;
       text: string;
       timestamp: string;
       acpSource?: TranscriptAcpSource;
-      channelId?: string | null;
-    }
-  | {
+    } & TranscriptItemIdentity)
+  | ({
       id: string;
       type: "metadata";
       title: string;
       sections: PromptSection[];
       timestamp: string;
       acpSource?: TranscriptAcpSource;
-      channelId?: string | null;
-    }
-  | {
+    } & TranscriptItemIdentity)
+  | ({
       id: string;
       type: "tool";
       title: string;
@@ -76,8 +79,7 @@ export type TranscriptItem =
       startedAt: string;
       completedAt: string | null;
       acpSource?: TranscriptAcpSource;
-      channelId?: string | null;
-    };
+    } & TranscriptItemIdentity);
 
 export type PromptSection = {
   title: string;

--- a/desktop/src/features/agents/ui/agentSessionTypes.ts
+++ b/desktop/src/features/agents/ui/agentSessionTypes.ts
@@ -20,6 +20,9 @@ export type ConnectionState =
 
 export type ToolStatus = "executing" | "completed" | "failed" | "pending";
 
+/** Observer/ACP wire label for dev-only transcript debugging. */
+export type TranscriptAcpSource = string;
+
 export type TranscriptItem =
   | {
       id: string;
@@ -28,6 +31,7 @@ export type TranscriptItem =
       title: string;
       text: string;
       timestamp: string;
+      acpSource?: TranscriptAcpSource;
       authorPubkey?: string | null;
       channelId?: string | null;
     }
@@ -37,6 +41,7 @@ export type TranscriptItem =
       title: string;
       text: string;
       timestamp: string;
+      acpSource?: TranscriptAcpSource;
       channelId?: string | null;
     }
   | {
@@ -45,6 +50,7 @@ export type TranscriptItem =
       title: string;
       text: string;
       timestamp: string;
+      acpSource?: TranscriptAcpSource;
       channelId?: string | null;
     }
   | {
@@ -53,6 +59,7 @@ export type TranscriptItem =
       title: string;
       sections: PromptSection[];
       timestamp: string;
+      acpSource?: TranscriptAcpSource;
       channelId?: string | null;
     }
   | {
@@ -68,6 +75,7 @@ export type TranscriptItem =
       timestamp: string;
       startedAt: string;
       completedAt: string | null;
+      acpSource?: TranscriptAcpSource;
       channelId?: string | null;
     };
 

--- a/desktop/src/features/agents/ui/agentSessionUtils.ts
+++ b/desktop/src/features/agents/ui/agentSessionUtils.ts
@@ -64,6 +64,91 @@ export function asRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
+/**
+ * True when a tool image source is an inline `data:image/` URI that should be
+ * rendered as-is. This is the dual-layer image-scheme guard: only the
+ * `data:image/` prefix is treated as a safe passthrough — every other scheme
+ * (including other `data:` subtypes) must be routed through the relay rewriter.
+ * Never widen this beyond `data:image/`.
+ */
+export function isInlineImageData(source: string): boolean {
+  return source.startsWith("data:image/");
+}
+
+function getToolNumber(
+  record: Record<string, unknown>,
+  keys: string[],
+): number | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/** Format a millisecond duration; negative input yields null. */
+export function formatDurationMs(ms: number): string | null {
+  if (ms < 0) return null;
+  const totalSeconds = ms / 1000;
+  if (totalSeconds < 60) {
+    return totalSeconds < 10
+      ? `${totalSeconds.toFixed(1)}s`
+      : `${Math.round(totalSeconds)}s`;
+  }
+  let minutes = Math.floor(totalSeconds / 60);
+  let seconds = Math.round(totalSeconds % 60);
+  if (seconds === 60) {
+    minutes += 1;
+    seconds = 0;
+  }
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+/**
+ * Parse a tool result string into a value. Handles the double-encoding case
+ * where a JSON string itself contains JSON. Returns null on empty or invalid
+ * input.
+ */
+export function parseToolResultValue(result: string): unknown {
+  const trimmed = result.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== "string") return parsed;
+    try {
+      return JSON.parse(parsed);
+    } catch {
+      return parsed;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a tool's display duration. Prefers the start/complete timestamps,
+ * then falls back to `duration_ms`/`elapsed_ms` fields inside the parsed
+ * result payload.
+ */
+export function getToolDurationDisplay(item: {
+  startedAt?: string | null;
+  completedAt?: string | null;
+  result: string;
+}): string | null {
+  if (item.startedAt && item.completedAt) {
+    return formatDuration(item.startedAt, item.completedAt);
+  }
+
+  const resultRecord = asRecord(parseToolResultValue(item.result));
+  const durationMs =
+    getToolNumber(resultRecord, ["duration_ms", "durationMs"]) ??
+    getToolNumber(resultRecord, ["elapsed_ms", "elapsedMs"]);
+  return durationMs == null ? null : formatDurationMs(durationMs);
+}
+
 export function asString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }

--- a/desktop/src/features/agents/ui/rawEventRail.test.mjs
+++ b/desktop/src/features/agents/ui/rawEventRail.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeRawEvent } from "./agentSessionTranscriptHelpers.ts";
+
+function rawEvent(overrides = {}) {
+  return {
+    seq: 1,
+    kind: "acp",
+    sessionId: "sess-1",
+    channelId: "channel-1",
+    payload: {},
+    ...overrides,
+  };
+}
+
+test("describeRawEvent surfaces the session/update sessionUpdate label", () => {
+  const event = rawEvent({
+    payload: {
+      method: "session/update",
+      params: { update: { sessionUpdate: "agent_message_chunk" } },
+    },
+  });
+  assert.equal(describeRawEvent(event), "agent_message_chunk");
+});
+
+test("describeRawEvent falls back to the method when session/update lacks an update label", () => {
+  const event = rawEvent({
+    payload: { method: "session/update", params: {} },
+  });
+  assert.equal(describeRawEvent(event), "session/update");
+});
+
+test("describeRawEvent uses the method for non-session/update payloads", () => {
+  const event = rawEvent({ payload: { method: "session/prompt" } });
+  assert.equal(describeRawEvent(event), "session/prompt");
+});
+
+test("describeRawEvent falls back to the event kind when no method is present", () => {
+  const event = rawEvent({ kind: "acp_parse_error", payload: {} });
+  assert.equal(describeRawEvent(event), "acp_parse_error");
+});

--- a/desktop/src/features/channels/lib/agentSessionCandidates.ts
+++ b/desktop/src/features/channels/lib/agentSessionCandidates.ts
@@ -11,6 +11,7 @@ export type ChannelAgentSessionAgent = Pick<
   "pubkey" | "name" | "status"
 > & {
   agentSource: "managed" | "member-bot" | "relay";
+  avatarUrl?: string | null;
   canInterruptTurn: boolean;
   channelIds?: string[];
   channels?: string[];
@@ -57,6 +58,7 @@ export function buildChannelAgentSessionCandidates({
       name: agent.name,
       status: agent.status,
       agentSource: "managed",
+      avatarUrl: agent.avatarUrl,
       canInterruptTurn: true,
       channelIds: existing?.channelIds,
       channels: existing?.channels,

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -160,9 +160,12 @@ export function AgentSessionThreadPanel({
         agent={agent}
         channelId={channel.id}
         className="border-0 bg-transparent p-0 shadow-none"
+        compact
         emptyDescription={`Mention ${agent.name} in the channel to see its work here.`}
+        isWorking={isWorking}
         profiles={profiles}
         showHeader={false}
+        showInterventionHint={canInterruptTurn}
         showRaw={false}
       />
     </div>

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -1,4 +1,5 @@
-import { ArrowLeft, CircleDot, Octagon, X } from "lucide-react";
+import * as React from "react";
+import { ArrowLeft, CircleDot, Octagon, TerminalSquare, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
@@ -25,6 +26,7 @@ import {
   PANEL_SINGLE_COLUMN_HEADER_LAYER_CLASS,
 } from "@/shared/ui/OverlayPanelBackdrop";
 import { THREAD_PANEL_MIN_WIDTH_PX } from "@/shared/hooks/useThreadPanelWidth";
+import { Switch } from "@/shared/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import type { ChannelAgentSessionAgent } from "./useChannelAgentSessions";
 
@@ -60,6 +62,19 @@ export function AgentSessionThreadPanel({
   useEscapeKey(onClose, isOverlay || isSinglePanelView);
 
   const { ref: scrollRef, onScroll } = useStickToBottom<HTMLDivElement>();
+  const rawFeedScopeKey = `${agent.pubkey}:${channel.id}`;
+  const [rawFeedState, setRawFeedState] = React.useState(() => ({
+    scopeKey: rawFeedScopeKey,
+    show: false,
+  }));
+  const showRawFeed =
+    rawFeedState.scopeKey === rawFeedScopeKey && rawFeedState.show;
+  const handleRawFeedChange = React.useCallback(
+    (checked: boolean) => {
+      setRawFeedState({ scopeKey: rawFeedScopeKey, show: checked });
+    },
+    [rawFeedScopeKey],
+  );
 
   async function handleInterruptTurn() {
     try {
@@ -86,6 +101,32 @@ export function AgentSessionThreadPanel({
           <CircleDot className="h-2.5 w-2.5" />
           Live
         </Badge>
+      ) : null}
+      {isLive ? (
+        <div
+          className="flex min-w-19 shrink-0 items-center justify-end gap-2"
+          title={
+            showRawFeed
+              ? "Hide raw JSON-RPC payloads."
+              : "Show raw JSON-RPC payloads for this channel."
+          }
+        >
+          <label
+            className="flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-muted-foreground"
+            htmlFor="agent-session-raw-feed-switch"
+          >
+            <TerminalSquare className="h-3 w-3" />
+            Raw
+          </label>
+          <Switch
+            aria-label={showRawFeed ? "Hide raw feed" : "Show raw feed"}
+            checked={showRawFeed}
+            className="shrink-0 data-[state=unchecked]:bg-muted-foreground/45 [&>span]:bg-white"
+            data-testid="agent-session-toggle-raw-feed"
+            id="agent-session-raw-feed-switch"
+            onCheckedChange={handleRawFeedChange}
+          />
+        </div>
       ) : null}
       {isLive && isWorking ? (
         <Tooltip>
@@ -140,7 +181,9 @@ export function AgentSessionThreadPanel({
         >
           <ArrowLeft />
         </Button>
-        <AuxiliaryPanelTitle>Activity</AuxiliaryPanelTitle>
+        <AuxiliaryPanelTitle>
+          {showRawFeed ? "Raw ACP Activity" : "Activity"}
+        </AuxiliaryPanelTitle>
       </AuxiliaryPanelHeaderGroup>
       {agentHeaderActions}
     </>
@@ -164,9 +207,10 @@ export function AgentSessionThreadPanel({
         emptyDescription={`Mention ${agent.name} in the channel to see its work here.`}
         isWorking={isWorking}
         profiles={profiles}
+        rawLayout="exclusive"
         showHeader={false}
         showInterventionHint={canInterruptTurn}
-        showRaw={false}
+        showRaw={showRawFeed}
       />
     </div>
   );

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -200,7 +200,6 @@ export function AgentSessionThreadPanel({
         agent={agent}
         channelId={channel.id}
         className="border-0 bg-transparent p-0 shadow-none"
-        compact
         emptyDescription={`Mention ${agent.name} in the channel to see its work here.`}
         isWorking={isWorking}
         profiles={profiles}

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -94,10 +94,7 @@ export function AgentSessionThreadPanel({
   const agentHeaderActions = (
     <div className="ml-auto flex shrink-0 items-center gap-2">
       {isLive && isWorking ? (
-        <Badge
-          className="shrink-0 gap-1 px-2 py-0 text-[10px]"
-          variant="default"
-        >
+        <Badge className="shrink-0 gap-1 px-2 py-0 text-xs" variant="default">
           <CircleDot className="h-2.5 w-2.5" />
           Live
         </Badge>
@@ -112,7 +109,7 @@ export function AgentSessionThreadPanel({
           }
         >
           <label
-            className="flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-muted-foreground"
+            className="flex shrink-0 items-center gap-1.5 text-xs font-medium text-muted-foreground"
             htmlFor="agent-session-raw-feed-switch"
           >
             <TerminalSquare className="h-3 w-3" />
@@ -133,7 +130,7 @@ export function AgentSessionThreadPanel({
           <TooltipTrigger asChild>
             <Button
               aria-label="Stop current agent turn"
-              className="h-6 px-2 text-[11px]"
+              className="h-6 px-2 text-xs"
               data-testid="agent-session-stop-turn"
               disabled={!canInterruptTurn}
               onClick={() => {

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -206,7 +206,6 @@ export function AgentSessionThreadPanel({
         profiles={profiles}
         rawLayout="exclusive"
         showHeader={false}
-        showInterventionHint={canInterruptTurn}
         showRaw={showRawFeed}
       />
     </div>

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 import { Loader2 } from "lucide-react";
 
 import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
-import type { TranscriptItem } from "@/features/agents/ui/agentSessionTypes";
-import { formatToolTitle } from "@/features/agents/ui/agentSessionToolCatalog";
+import { getActivityHeadline } from "@/features/agents/ui/agentSessionTranscriptPresentation";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ManagedAgent } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
@@ -26,18 +25,6 @@ type BotActivityBarProps = {
 const HOVER_OPEN_DELAY_MS = 150;
 const HOVER_CLOSE_DELAY_MS = 180;
 const HEADLINE_ROTATION_MS = 2200;
-
-function getActivityHeadline(item: TranscriptItem): string | null {
-  if (item.type === "tool") {
-    return formatToolTitle(item.buzzToolName ?? item.toolName, item.title);
-  }
-
-  if (item.type === "message") {
-    return item.role === "assistant" ? "Responding" : item.title;
-  }
-
-  return item.title;
-}
 
 export function BotActivityComposerAction({
   agents,

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -171,16 +171,17 @@ export function BotActivityComposerAction({
                 className={cn(
                   "border border-background",
                   isInline
-                    ? "!h-[18px] !w-[18px] shadow-xs ring-1 ring-primary/25 text-[7px]"
-                    : "!h-5 !w-5 text-[8px]",
+                    ? "!h-[18px] !w-[18px] shadow-xs ring-1 ring-primary/25 text-xs leading-none"
+                    : "shrink-0",
                 )}
                 displayName={agent.name}
                 key={agent.pubkey}
+                size="xs"
               />
             ))}
           </span>
           {typingAgents.length > 2 ? (
-            <span className="text-[11px] leading-none">
+            <span className="text-xs leading-none">
               +{typingAgents.length - 2}
             </span>
           ) : null}
@@ -227,8 +228,9 @@ export function BotActivityComposerAction({
               >
                 <UserAvatar
                   avatarUrl={agentAvatarUrl(agent)}
-                  className="!h-6 !w-6 shrink-0 text-[9px]"
+                  className="shrink-0"
                   displayName={agent.name}
+                  size="sm"
                 />
                 <span className="min-w-0 flex-1 truncate">{agent.name}</span>
                 <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -185,25 +185,6 @@ export function ChannelScreen({
         : [],
     [activeChannel],
   );
-  const messageProfilePubkeys = React.useMemo(
-    () => [
-      ...new Set([
-        ...messageAuthorPubkeys,
-        ...messageMentionPubkeys,
-        ...activeDmParticipantPubkeys,
-        ...typingEntries.map((entry) => entry.pubkey),
-      ]),
-    ],
-    [
-      activeDmParticipantPubkeys,
-      messageAuthorPubkeys,
-      messageMentionPubkeys,
-      typingEntries,
-    ],
-  );
-  const messageProfilesQuery = useUsersBatchQuery(messageProfilePubkeys, {
-    enabled: messageProfilePubkeys.length > 0,
-  });
   const channelMembersQuery = useChannelMembersQuery(activeChannel?.id ?? null);
   const channelMembers = channelMembersQuery.data;
   const managedAgentsQuery = useManagedAgentsQuery();
@@ -225,6 +206,27 @@ export function ChannelScreen({
     }
     return pubkeys;
   }, [channelMembers, managedAgents, relayAgents]);
+  const messageProfilePubkeys = React.useMemo(
+    () => [
+      ...new Set([
+        ...messageAuthorPubkeys,
+        ...messageMentionPubkeys,
+        ...activeDmParticipantPubkeys,
+        ...agentPubkeys,
+        ...typingEntries.map((entry) => entry.pubkey),
+      ]),
+    ],
+    [
+      activeDmParticipantPubkeys,
+      agentPubkeys,
+      messageAuthorPubkeys,
+      messageMentionPubkeys,
+      typingEntries,
+    ],
+  );
+  const messageProfilesQuery = useUsersBatchQuery(messageProfilePubkeys, {
+    enabled: messageProfilePubkeys.length > 0,
+  });
   const allAgentSessionCandidates = React.useMemo(
     () =>
       buildChannelAgentSessionCandidates({

--- a/desktop/src/features/channels/ui/useChannelActivityTyping.ts
+++ b/desktop/src/features/channels/ui/useChannelActivityTyping.ts
@@ -98,12 +98,22 @@ export function mergeAgentNamesIntoProfiles(
   relayAgents: RelayAgent[],
 ): UserProfileLookup {
   const merged = { ...profiles };
-  for (const agent of [...relayAgents, ...managedAgents]) {
+  for (const agent of relayAgents) {
     const key = normalizePubkey(agent.pubkey);
     merged[key] = {
       ...merged[key],
       displayName: merged[key]?.displayName || agent.name,
       avatarUrl: merged[key]?.avatarUrl ?? null,
+      nip05Handle: merged[key]?.nip05Handle ?? null,
+      isAgent: true,
+    };
+  }
+  for (const agent of managedAgents) {
+    const key = normalizePubkey(agent.pubkey);
+    merged[key] = {
+      ...merged[key],
+      displayName: merged[key]?.displayName || agent.name,
+      avatarUrl: merged[key]?.avatarUrl ?? agent.avatarUrl,
       nip05Handle: merged[key]?.nip05Handle ?? null,
       isAgent: true,
     };

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -45,10 +45,7 @@ import type {
   OpenDmInput,
 } from "@/shared/api/types";
 
-type RawIdentity = {
-  pubkey: string;
-  display_name: string;
-};
+type RawIdentity = { pubkey: string; display_name: string };
 
 type RawProfile = {
   pubkey: string;
@@ -213,6 +210,7 @@ export type RawManagedAgent = {
   max_turn_duration_seconds: number | null;
   parallelism: number;
   system_prompt: string | null;
+  avatar_url?: string | null;
   model: string | null;
   mcp_toolsets: string | null;
   env_vars?: Record<string, string>;
@@ -868,6 +866,7 @@ export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {
     maxTurnDurationSeconds: agent.max_turn_duration_seconds,
     parallelism: agent.parallelism,
     systemPrompt: agent.system_prompt,
+    avatarUrl: agent.avatar_url ?? null,
     model: agent.model,
     mcpToolsets: agent.mcp_toolsets,
     envVars: agent.env_vars ?? {},

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -282,6 +282,7 @@ export type ManagedAgent = {
   maxTurnDurationSeconds: number | null;
   parallelism: number;
   systemPrompt: string | null;
+  avatarUrl: string | null;
   model: string | null;
   mcpToolsets: string | null;
   /** Per-agent env vars. Layered on top of persona envVars. */

--- a/desktop/src/shared/ui/UserAvatar.tsx
+++ b/desktop/src/shared/ui/UserAvatar.tsx
@@ -6,8 +6,8 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/shared/ui/avatar";
 type UserAvatarSize = "xs" | "sm" | "md";
 
 const sizeClasses: Record<UserAvatarSize, string> = {
-  xs: "h-5 w-5 text-[8px]",
-  sm: "h-6 w-6 text-[9px]",
+  xs: "h-5 w-5 text-xs",
+  sm: "h-6 w-6 text-xs",
   md: "h-10 w-10 text-xs",
 };
 

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -224,6 +224,7 @@ type MarkdownProps = {
   agentMentionPubkeysByName?: Record<string, string>;
   mentionNames?: string[];
   mentionPubkeysByName?: Record<string, string>;
+  mediaInset?: boolean;
   searchQuery?: string;
   tight?: boolean;
   videoReviewContext?: VideoReviewContext;
@@ -748,6 +749,7 @@ function createMarkdownComponents(
   variant: MarkdownVariant,
   runtimeRef: React.RefObject<MarkdownRuntime>,
   interactive = true,
+  mediaInset = false,
 ): Components {
   const paragraphClassName =
     variant === "tight"
@@ -898,7 +900,12 @@ function createMarkdownComponents(
       if (resolvedSrc?.endsWith(".mp4")) {
         const entry = src ? imetaByUrl?.get(src) : undefined;
         return (
-          <span data-block-media="">
+          <span
+            className={cn(
+              mediaInset && "mx-1.5 block max-w-[calc(100%-0.75rem)]",
+            )}
+            data-block-media=""
+          >
             <MarkdownVideoPlayer
               key={src ?? resolvedSrc}
               alt={alt}
@@ -910,7 +917,13 @@ function createMarkdownComponents(
         );
       }
       return (
-        <span data-block-media="" className="block">
+        <span
+          data-block-media=""
+          className={cn(
+            "block",
+            mediaInset && "mx-1.5 max-w-[calc(100%-0.75rem)]",
+          )}
+        >
           <ImageBlock alt={alt} resolvedSrc={resolvedSrc} src={src} />
         </span>
       );
@@ -1115,6 +1128,7 @@ function MarkdownInner({
   imetaByUrl,
   interactive = true,
   agentMentionPubkeysByName,
+  mediaInset = false,
   mentionNames,
   mentionPubkeysByName,
   searchQuery,
@@ -1161,8 +1175,9 @@ function MarkdownInner({
   });
 
   const components = React.useMemo(
-    () => createMarkdownComponents(variant, runtimeRef, interactive),
-    [variant, runtimeRef, interactive],
+    () =>
+      createMarkdownComponents(variant, runtimeRef, interactive, mediaInset),
+    [variant, runtimeRef, interactive, mediaInset],
   );
 
   // biome-ignore lint/suspicious/noExplicitAny: PluggableList type not directly importable
@@ -1276,6 +1291,7 @@ export const Markdown = React.memo(
     prev.compact === next.compact &&
     prev.customEmoji === next.customEmoji &&
     prev.interactive === next.interactive &&
+    prev.mediaInset === next.mediaInset &&
     prev.tight === next.tight &&
     prev.agentMentionPubkeysByName === next.agentMentionPubkeysByName &&
     prev.mentionPubkeysByName === next.mentionPubkeysByName &&

--- a/desktop/src/shared/ui/toggle.tsx
+++ b/desktop/src/shared/ui/toggle.tsx
@@ -10,12 +10,14 @@ const toggleVariants = cva(
     variants: {
       variant: {
         default: "bg-transparent",
+        ghost:
+          "bg-transparent hover:bg-muted/70 hover:text-foreground data-[state=on]:bg-muted data-[state=on]:text-foreground",
         outline:
           "border border-input/40 bg-background hover:bg-muted/70 data-[state=on]:bg-muted data-[state=on]:text-foreground",
       },
       size: {
         default: "h-9 px-3 min-w-9",
-        xs: "h-5 min-h-0 min-w-0 gap-1 rounded-md px-1.5 text-xs font-medium",
+        xs: "h-5 min-h-0 min-w-0 gap-1 rounded-md px-1.5 text-xs font-medium [&_svg]:size-3.5",
         sm: "h-8 px-2 min-w-8",
         lg: "h-10 px-3 min-w-10",
       },

--- a/desktop/src/shared/ui/toggle.tsx
+++ b/desktop/src/shared/ui/toggle.tsx
@@ -10,10 +10,12 @@ const toggleVariants = cva(
     variants: {
       variant: {
         default: "bg-transparent",
-        outline: "border border-input/40 bg-background hover:bg-muted/70",
+        outline:
+          "border border-input/40 bg-background hover:bg-muted/70 data-[state=on]:bg-muted data-[state=on]:text-foreground",
       },
       size: {
         default: "h-9 px-3 min-w-9",
+        xs: "h-5 min-h-0 min-w-0 gap-1 rounded-md px-1.5 text-xs font-medium",
         sm: "h-8 px-2 min-w-8",
         lg: "h-10 px-3 min-w-10",
       },

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -38,6 +38,7 @@ type MockCommandAvailability = {
 type MockManagedAgentSeed = {
   pubkey: string;
   name: string;
+  avatarUrl?: string | null;
   personaId?: string | null;
   status?: RawManagedAgent["status"];
   channelNames?: string[];
@@ -358,6 +359,7 @@ type RawManagedAgent = {
   max_turn_duration_seconds: number | null;
   parallelism: number;
   system_prompt: string | null;
+  avatar_url: string | null;
   model: string | null;
   env_vars?: Record<string, string>;
   status: "running" | "stopped" | "deployed" | "not_deployed";
@@ -873,6 +875,7 @@ function cloneManagedAgent(agent: MockManagedAgent): RawManagedAgent {
     max_turn_duration_seconds: agent.max_turn_duration_seconds ?? null,
     parallelism: agent.parallelism,
     system_prompt: agent.system_prompt,
+    avatar_url: agent.avatar_url ?? null,
     model: agent.model,
     env_vars: { ...(agent.env_vars ?? {}) },
     status: agent.status,
@@ -962,6 +965,7 @@ function buildSeededManagedAgent(seed: MockManagedAgentSeed): MockManagedAgent {
     max_turn_duration_seconds: null,
     parallelism: 1,
     system_prompt: null,
+    avatar_url: seed.avatarUrl ?? null,
     model: null,
     env_vars: {},
     status,
@@ -4747,6 +4751,7 @@ async function handleCreateManagedAgent(
     max_turn_duration_seconds: args.input.maxTurnDurationSeconds ?? null,
     parallelism: args.input.parallelism ?? 1,
     system_prompt: args.input.systemPrompt?.trim() || null,
+    avatar_url: avatarUrl,
     model: args.input.model?.trim() || null,
     env_vars: { ...(args.input.envVars ?? {}) },
     status: args.input.spawnAfterCreate ? "running" : "stopped",

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -773,6 +773,15 @@ test("shows and clears activity indicators for active channel agents", async ({
   await expect(page.getByTestId("agent-session-thread-panel")).toContainText(
     "alice",
   );
+  await expect(page.getByTestId("agent-transcript-now-summary")).toBeVisible();
+  await expect(page.getByTestId("agent-transcript-now-summary")).toContainText(
+    "Working",
+  );
+  await expect(page.getByTestId("agent-session-stop-turn")).toBeVisible();
+  await expect(page.getByTestId("agent-session-stop-turn")).toBeDisabled();
+  await expect(page.getByTestId("agent-session-thread-panel")).toContainText(
+    "No ACP activity yet",
+  );
   await expect(page.getByTestId("message-typing-indicator")).toHaveCount(0);
 
   await page.evaluate((pubkey) => {

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -773,10 +773,7 @@ test("shows and clears activity indicators for active channel agents", async ({
   await expect(page.getByTestId("agent-session-thread-panel")).toContainText(
     "alice",
   );
-  await expect(page.getByTestId("agent-transcript-now-summary")).toBeVisible();
-  await expect(page.getByTestId("agent-transcript-now-summary")).toContainText(
-    "Working",
-  );
+  await expect(page.getByTestId("agent-transcript-now-summary")).toHaveCount(0);
   await expect(page.getByTestId("agent-session-stop-turn")).toBeVisible();
   await expect(page.getByTestId("agent-session-stop-turn")).toBeDisabled();
   await expect(page.getByTestId("agent-session-thread-panel")).toContainText(


### PR DESCRIPTION
**Category:** improvement

**User Impact:** The desktop Activity panel that streams an agent live runtime is cleaner and easier to scan — grouped turns, agent avatars, compact tool/shell rows, inline image previews, and a raw-ACP view toggle.

**Problem:** The Activity transcript was visually flat and dense — repeated agent headers, noisy tool rows, inconsistent typography, and no grouping made it hard to follow an agent turns at a glance.

**Solution:** A polish pass across the activity-feed runtime UI: grouped ACP turns into a user-first bundle, collapsed/simplified tool and shell rows with compact summaries, standardized transcript typography (text-xs), added agent avatars, inline thumbnails + lightbox for image tools, right-aligned user messages, a raw ACP view toggle, and formatted prompt bubbles. Backed by unit tests for grouping, presentation, and tool summaries.

> **Stack — PR 2 of 2.** Base is **#1060** (`tho/activity-ingress-ownership`), not main. Review/merge #1060 first. Carved out of #1053 (conflicting vs main); the UI commits sit on top of the ingress foundation. Glossy live-populated screenshots follow in the e2e observer-seed PR (PR 3, not yet open).

<details>
<summary>Highlights from the commit history</summary>

- Group ACP turn prompts into a user-first transcript bundle
- Add raw ACP activity view toggle + dev-only source labels
- Show agent avatars in activity transcripts; standardize typography to text-xs
- Simplify shell command rows; compact summaries for developer MCP tool rows
- Preview view_image tools with inline thumbnails and lightbox
- Right-align user transcript messages; hide setup-only / orphan-context rows
- Keep live activity styling in the header; drop transcript compact mode
- Render formatted prompt bubbles
- Type-honesty fix: make the compact tool label map honest about the keys it indexes

</details>

**Reproduction steps**
1. Check out this branch (or review stacked on #1060).
2. Run the desktop app, open a channel with a managed agent, and mention it.
3. Open the **Activity** panel — observe grouped turns, avatars, compact rows, image previews, and the raw-view toggle.

🤖 Branch split + PR by Ned (sequencer) / Bart (builder).
