### PR TITLE
feat: elect a single leader instance and surface it in the desktop UI

### DIFF
--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -71,10 +71,11 @@ toml = "1.0"
 # Filter expressions
 evalexpr = { workspace = true }
 
-# Process-group kill (safe wrapper around killpg) — Unix-only; kill_process_group
-# has a #[cfg(not(unix))] fallback in acp.rs.
+# Process-group kill (safe wrapper around killpg) and leader-lock flock — Unix-only.
+# kill_process_group (acp.rs) and the leader-lock writer (leader.rs) both have
+# #[cfg(not(unix))] fallbacks. "fs" pulls in the safe `Flock` RAII wrapper.
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["signal"] }
+nix = { version = "0.31", default-features = false, features = ["signal", "fs"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/buzz-acp/src/leader.rs
+++ b/crates/buzz-acp/src/leader.rs
@@ -1,0 +1,254 @@
+//! Client-side leader election (read side).
+//!
+//! When multiple Buzz instances share the same agent keypair, the relay fans
+//! every matching event out to all of them (NIP-01). Without coordination,
+//! each instance would prompt its agent and respond — duplicate replies for a
+//! single mention. A per-agent-key *leader lock* designates exactly one
+//! instance as the active responder; non-leaders still receive and render
+//! events but suppress the prompt path (and the pre-dispatch `👀` side-effect).
+//!
+//! This module owns only the **read** half: given a lock file written by some
+//! instance, decide whether *this* process is the leader for a given agent
+//! pubkey. Lock acquisition, stealing, and failover live elsewhere (Phase 2).
+//!
+//! # Lock contract
+//!
+//! - Lock dir: `~/.buzz/leader-locks/`, one file per agent pubkey:
+//!   `<pubkey-hex>.lock`, JSON `{"instance_id","pid","claimed_at"}`.
+//! - **Absent** lock file → this process is leader. Single-instance dev is
+//!   thereby unaffected: no lock, no suppression.
+//! - **Present** → leader iff the lock's `instance_id` equals this process's
+//!   own election id ([`ELECTION_ID_ENV`]).
+//! - **No instance id** (env unset, e.g. solo CLI use or pre-Phase-2 where
+//!   nothing writes the election id) → leader. There is no coordinating
+//!   desktop, so there is nothing to defer to.
+//! - **Malformed** lock file → fail safe to leader. A corrupt lock must never
+//!   silence the only responder.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde::Deserialize;
+
+/// Environment variable carrying this window's leader-election identity.
+///
+/// Per-window election identity; Phase 2 supplies a process-unique value —
+/// the Tauri bundle identifier is NOT sufficient (it collides across
+/// same-class windows like DMG + dev, or worktrees whose icon-gen fell back
+/// to the shared dev id). Kept behind this constant so Phase 2 can swap the
+/// source without touching the gate. Distinct from `BUZZ_MANAGED_AGENT`
+/// (reaper identity): reaper identity partitions by app-class, election
+/// identity must be unique per window — opposite uniqueness requirements.
+const ELECTION_ID_ENV: &str = "BUZZ_INSTANCE_ELECTION_ID";
+
+/// Decides whether this process should act on events for a given agent key.
+pub trait LeaderCheck: Send + Sync {
+    /// Whether this process is the leader for `agent_pubkey_hex`.
+    ///
+    /// Reads through the cache on first sight of a key so the very first
+    /// dispatch is correct without waiting for a refresh tick; subsequent
+    /// calls are served from cache and updated by [`LeaderCheck::refresh`].
+    fn is_leader(&self, agent_pubkey_hex: &str) -> bool;
+
+    /// Re-read all known lock files and update cached status. Called on a
+    /// fixed cadence by the event loop so leadership changes take effect
+    /// without a restart.
+    fn refresh(&self);
+}
+
+/// On-disk lock file shape. Only `instance_id` is load-bearing for the read
+/// side; `pid` and `claimed_at` are written by the (Phase 2) acquire path and
+/// ignored here.
+#[derive(Deserialize)]
+struct LockFile {
+    instance_id: String,
+}
+
+/// Filesystem-backed [`LeaderCheck`] over `~/.buzz/leader-locks/`.
+pub struct FileLeaderCheck {
+    /// This process's election id ([`ELECTION_ID_ENV`]). `None` when unset —
+    /// solo CLI use or the pre-Phase-2 regime, where this process is always
+    /// leader.
+    instance_id: Option<String>,
+    lock_dir: PathBuf,
+    /// Cached leader status per agent pubkey hex. Seeded read-through on first
+    /// `is_leader`, refreshed in place by `refresh`.
+    cache: Mutex<HashMap<String, bool>>,
+}
+
+impl FileLeaderCheck {
+    /// Build from the ambient environment: election id from
+    /// [`ELECTION_ID_ENV`], lock dir under `$HOME/.buzz/leader-locks/`.
+    pub fn from_env() -> Self {
+        let lock_dir = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_default()
+            .join(".buzz")
+            .join("leader-locks");
+        Self::new(std::env::var(ELECTION_ID_ENV).ok(), lock_dir)
+    }
+
+    fn new(instance_id: Option<String>, lock_dir: PathBuf) -> Self {
+        Self {
+            instance_id,
+            lock_dir,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Read the lock for `pubkey_hex` and compute leadership per the contract.
+    fn read_status(&self, pubkey_hex: &str) -> bool {
+        // No coordinating instance id → nothing to defer to.
+        let Some(self_id) = self.instance_id.as_deref() else {
+            return true;
+        };
+        let path = self.lock_dir.join(format!("{pubkey_hex}.lock"));
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            // Absent (or unreadable) lock → leader.
+            Err(_) => return true,
+        };
+        match serde_json::from_str::<LockFile>(&contents) {
+            Ok(lock) => lock.instance_id == self_id,
+            // Malformed lock → fail safe to leader.
+            Err(_) => true,
+        }
+    }
+}
+
+impl LeaderCheck for FileLeaderCheck {
+    fn is_leader(&self, agent_pubkey_hex: &str) -> bool {
+        if let Some(&cached) = self.cache.lock().unwrap().get(agent_pubkey_hex) {
+            return cached;
+        }
+        let status = self.read_status(agent_pubkey_hex);
+        self.cache
+            .lock()
+            .unwrap()
+            .insert(agent_pubkey_hex.to_string(), status);
+        status
+    }
+
+    fn refresh(&self) {
+        // Re-read only keys we've already been asked about — those are the
+        // agent pubkeys this process actually dispatches for.
+        let keys: Vec<String> = self.cache.lock().unwrap().keys().cloned().collect();
+        for key in keys {
+            let status = self.read_status(&key);
+            self.cache.lock().unwrap().insert(key, status);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    const PUBKEY: &str = "abc123";
+    // Opaque per-window election ids — deliberately NOT bundle-class strings.
+    // The leader-election identity must be unique per window; baking in
+    // `bundle-id == election-id` would mask the same-class collision Phase 2
+    // must avoid.
+    const SELF_ID: &str = "window-a";
+    const OTHER_ID: &str = "window-b";
+
+    /// Unique scratch dir per test, removed on drop. Avoids a dev-dep on
+    /// `tempfile` for four file reads.
+    struct TmpDir(PathBuf);
+
+    impl TmpDir {
+        fn new() -> Self {
+            static N: AtomicU32 = AtomicU32::new(0);
+            let dir = std::env::temp_dir().join(format!(
+                "buzz-acp-leader-{}-{}",
+                std::process::id(),
+                N.fetch_add(1, Ordering::Relaxed),
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+
+        fn lock_path(&self) -> PathBuf {
+            self.0.join(format!("{PUBKEY}.lock"))
+        }
+
+        fn write_lock(&self, contents: &str) {
+            std::fs::write(self.lock_path(), contents).unwrap();
+        }
+    }
+
+    impl Drop for TmpDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn test_absent_lock_file_is_leader() {
+        let dir = TmpDir::new();
+        let lc = FileLeaderCheck::new(Some(SELF_ID.into()), dir.0.clone());
+        assert!(lc.is_leader(PUBKEY));
+    }
+
+    #[test]
+    fn test_lock_matching_own_instance_is_leader() {
+        let dir = TmpDir::new();
+        dir.write_lock(&format!(
+            r#"{{"instance_id":"{SELF_ID}","pid":123,"claimed_at":"2026-06-15T00:00:00Z"}}"#
+        ));
+        let lc = FileLeaderCheck::new(Some(SELF_ID.into()), dir.0.clone());
+        assert!(lc.is_leader(PUBKEY));
+    }
+
+    #[test]
+    fn test_lock_naming_other_instance_is_observer() {
+        let dir = TmpDir::new();
+        dir.write_lock(&format!(
+            r#"{{"instance_id":"{OTHER_ID}","pid":123,"claimed_at":"2026-06-15T00:00:00Z"}}"#
+        ));
+        let lc = FileLeaderCheck::new(Some(SELF_ID.into()), dir.0.clone());
+        assert!(!lc.is_leader(PUBKEY));
+    }
+
+    #[test]
+    fn test_malformed_lock_fails_safe_to_leader() {
+        let dir = TmpDir::new();
+        dir.write_lock("{ this is not json ");
+        let lc = FileLeaderCheck::new(Some(SELF_ID.into()), dir.0.clone());
+        assert!(lc.is_leader(PUBKEY));
+    }
+
+    #[test]
+    fn test_no_instance_id_is_leader_even_with_foreign_lock() {
+        let dir = TmpDir::new();
+        dir.write_lock(&format!(
+            r#"{{"instance_id":"{OTHER_ID}","pid":123,"claimed_at":"2026-06-15T00:00:00Z"}}"#
+        ));
+        let lc = FileLeaderCheck::new(None, dir.0.clone());
+        assert!(lc.is_leader(PUBKEY));
+    }
+
+    #[test]
+    fn test_refresh_flips_status_when_lock_changes() {
+        let dir = TmpDir::new();
+        let lc = FileLeaderCheck::new(Some(SELF_ID.into()), dir.0.clone());
+
+        // No lock yet → leader, and the key is now cached.
+        assert!(lc.is_leader(PUBKEY));
+
+        // A foreign instance claims the lock.
+        dir.write_lock(&format!(r#"{{"instance_id":"{OTHER_ID}"}}"#));
+        // Cache still says leader until refresh.
+        assert!(lc.is_leader(PUBKEY));
+
+        lc.refresh();
+        assert!(!lc.is_leader(PUBKEY));
+
+        // Lock removed (leader stepped down) → back to leader after refresh.
+        std::fs::remove_file(dir.lock_path()).unwrap();
+        lc.refresh();
+        assert!(lc.is_leader(PUBKEY));
+    }
+}

--- a/crates/buzz-acp/src/leader.rs
+++ b/crates/buzz-acp/src/leader.rs
@@ -1,4 +1,4 @@
-//! Client-side leader election (read side).
+//! Client-side leader election.
 //!
 //! When multiple Buzz instances share the same agent keypair, the relay fans
 //! every matching event out to all of them (NIP-01). Without coordination,
@@ -7,9 +7,10 @@
 //! instance as the active responder; non-leaders still receive and render
 //! events but suppress the prompt path (and the pre-dispatch `👀` side-effect).
 //!
-//! This module owns only the **read** half: given a lock file written by some
-//! instance, decide whether *this* process is the leader for a given agent
-//! pubkey. Lock acquisition, stealing, and failover live elsewhere (Phase 2).
+//! This module owns both halves: the **read** side decides whether *this*
+//! process is the leader for a given agent pubkey; the **write** side
+//! ([`FileLeaderCheck::acquire`] / [`FileLeaderCheck::release`]) claims and
+//! relinquishes the lock.
 //!
 //! # Lock contract
 //!
@@ -20,11 +21,29 @@
 //!   lock (permission, mid-write truncation) fails safe to leader for the same reason.
 //! - **Present** → leader iff the lock's `instance_id` equals this process's
 //!   own election id ([`ELECTION_ID_ENV`]).
-//! - **No instance id** (env unset, e.g. solo CLI use or pre-Phase-2 where
-//!   nothing writes the election id) → leader. There is no coordinating
-//!   desktop, so there is nothing to defer to.
+//! - **No instance id** (`instance_id` unset on the check itself, e.g. tests
+//!   constructing a read-only checker) → leader. There is no coordinating
+//!   instance, so there is nothing to defer to. The harness always carries a
+//!   minted id (see [`FileLeaderCheck::from_env_or_mint`]).
 //! - **Malformed** lock file → fail safe to leader. A corrupt lock must never
 //!   silence the only responder.
+//!
+//! ## Claim
+//!
+//! Claim is **auto-on-launch plus explicit re-claim**. The harness self-elects
+//! at startup: [`FileLeaderCheck::from_env_or_mint`] gives every process a
+//! unique election id, and the lifecycle calls [`acquire`](FileLeaderCheck::acquire)
+//! to take an *unowned* lock. An explicit re-claim / hard-steal gesture (sidebar
+//! UI) layers on top in a later phase; both paths share the same writer.
+//!
+//! Acquisition is guarded by an exclusive `flock` held across the
+//! read-decide-write window, closing the TOCTOU race between two instances
+//! racing to claim the same key. A claim **succeeds** when the lock is free
+//! (absent, empty, or malformed), already ours, held by a **dead** pid, or held
+//! by a **stale** claim whose pid was recycled by an unrelated process
+//! (failover when a leader crashes without releasing); it **fails** — leaving
+//! this process an observer — only when a *live* foreign pid holds a *fresh*
+//! claim.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -34,14 +53,27 @@ use serde::Deserialize;
 
 /// Environment variable carrying this window's leader-election identity.
 ///
-/// Per-window election identity; Phase 2 supplies a process-unique value —
-/// the Tauri bundle identifier is NOT sufficient (it collides across
-/// same-class windows like DMG + dev, or worktrees whose icon-gen fell back
-/// to the shared dev id). Kept behind this constant so Phase 2 can swap the
-/// source without touching the gate. Distinct from `BUZZ_MANAGED_AGENT`
-/// (reaper identity): reaper identity partitions by app-class, election
-/// identity must be unique per window — opposite uniqueness requirements.
+/// Per-window election identity. The desktop may inject a process-unique value
+/// per spawn; when unset, [`FileLeaderCheck::from_env_or_mint`] mints one
+/// in-process so the harness can self-elect headlessly. The Tauri bundle
+/// identifier is NOT sufficient as a source — it collides across same-class
+/// windows (DMG + dev, or worktrees whose icon-gen fell back to the shared dev
+/// id). Distinct from `BUZZ_MANAGED_AGENT` (reaper identity): reaper identity
+/// partitions by app-class, election identity must be unique per window —
+/// opposite uniqueness requirements.
 const ELECTION_ID_ENV: &str = "BUZZ_INSTANCE_ELECTION_ID";
+
+/// A claim older than this is treated as abandoned for takeover purposes, even
+/// if its pid still maps to a live process (which can happen after the OS
+/// recycles a crashed leader's pid).
+///
+/// Must comfortably exceed the 5s `leader_refresh` cadence in `lib.rs`: a live
+/// leader rewrites `claimed_at` on every tick, so this bound only ever elapses
+/// for an abandoned claim. The 2x margin tolerates a single delayed tick
+/// without falsely evicting an active leader (which would split-brain — worse
+/// than the stall this guards against).
+#[cfg(unix)]
+const STALE_CLAIM: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Decides whether this process should act on events for a given agent key.
 pub trait LeaderCheck: Send + Sync {
@@ -58,9 +90,10 @@ pub trait LeaderCheck: Send + Sync {
     fn refresh(&self);
 }
 
-/// On-disk lock file shape. Only `instance_id` is load-bearing for the read
-/// side; `pid` and `claimed_at` are written by the (Phase 2) acquire path and
-/// ignored here.
+/// On-disk lock file shape for the read side. Only `instance_id` is
+/// load-bearing here; `pid` and `claimed_at` are written by the acquire path
+/// and ignored by the reader. The write side parses with [`OwnerInfo`] instead,
+/// which also reads `pid` for dead-pid takeover.
 #[derive(Deserialize)]
 struct LockFile {
     instance_id: String,
@@ -79,15 +112,36 @@ pub struct FileLeaderCheck {
 }
 
 impl FileLeaderCheck {
-    /// Build from the ambient environment: election id from
-    /// [`ELECTION_ID_ENV`], lock dir under `$HOME/.buzz/leader-locks/`.
-    pub fn from_env() -> Self {
-        let lock_dir = std::env::var_os("HOME")
+    /// Build from the ambient environment, minting a process-unique election
+    /// id when [`ELECTION_ID_ENV`] is unset so a process with no externally
+    /// supplied identity can still claim a lock and self-elect headlessly.
+    /// Lock dir is `$HOME/.buzz/leader-locks/`.
+    ///
+    /// The minted id is `{pid}-{nanos}`. The pid feeds dead-pid takeover; the
+    /// launch-time nanos make the id unique across processes that share a pid
+    /// over time, so a recycled pid can't be mistaken for *us* in the
+    /// self-ownership check. Recycled-pid takeover (a crashed leader's pid
+    /// reused by an unrelated live process) is handled separately by the
+    /// `claimed_at` staleness bound in [`lock_is_takeable`](Self::lock_is_takeable),
+    /// not by the nanos. An externally set env value is honored verbatim
+    /// (desktop per-spawn injection).
+    pub fn from_env_or_mint() -> Self {
+        let instance_id = std::env::var(ELECTION_ID_ENV).ok().unwrap_or_else(|| {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            format!("{}-{}", std::process::id(), nanos)
+        });
+        Self::new(Some(instance_id), Self::default_lock_dir())
+    }
+
+    fn default_lock_dir() -> PathBuf {
+        std::env::var_os("HOME")
             .map(PathBuf::from)
             .unwrap_or_default()
             .join(".buzz")
-            .join("leader-locks");
-        Self::new(std::env::var(ELECTION_ID_ENV).ok(), lock_dir)
+            .join("leader-locks")
     }
 
     fn new(instance_id: Option<String>, lock_dir: PathBuf) -> Self {
@@ -115,6 +169,179 @@ impl FileLeaderCheck {
             // Malformed lock → fail safe to leader.
             Err(_) => true,
         }
+    }
+
+    /// Claim the leader lock for `pubkey_hex`, returning whether this process
+    /// now holds it (and may act as leader).
+    ///
+    /// Holds an exclusive `flock` across the read-decide-write window so two
+    /// instances racing to claim the same key cannot both win. Succeeds when
+    /// the lock is free (absent/empty/malformed), already ours, or held by a
+    /// dead pid; fails (observer) only when a live foreign pid holds it.
+    ///
+    /// Best-effort and idempotent: an IO error (e.g. unwritable lock dir)
+    /// returns the read-side fail-safe (leader) rather than propagating, and
+    /// re-claiming a lock we already own simply rewrites it.
+    #[cfg(unix)]
+    pub fn acquire(&self, pubkey_hex: &str) -> bool {
+        use nix::fcntl::{Flock, FlockArg};
+        use std::io::{Read, Seek, SeekFrom, Write};
+
+        // No election id → nothing to claim with; mirror the read-side
+        // always-leader contract.
+        let Some(self_id) = self.instance_id.as_deref() else {
+            return true;
+        };
+
+        if std::fs::create_dir_all(&self.lock_dir).is_err() {
+            return true; // can't write a lock → fail safe to leader
+        }
+        let path = self.lock_dir.join(format!("{pubkey_hex}.lock"));
+        let file = match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+        {
+            Ok(f) => f,
+            Err(_) => return true,
+        };
+        let mut locked = match Flock::lock(file, FlockArg::LockExclusive) {
+            Ok(l) => l,
+            Err(_) => return true,
+        };
+
+        let mut contents = String::new();
+        if locked.read_to_string(&mut contents).is_err() {
+            return true;
+        }
+        if !self.lock_is_takeable(&contents, self_id) {
+            return false; // live foreign owner — observe
+        }
+
+        let body = format!(
+            r#"{{"instance_id":"{self_id}","pid":{},"claimed_at":"{}"}}"#,
+            std::process::id(),
+            chrono::Utc::now().to_rfc3339(),
+        );
+        // Truncate-then-write under the held lock so a shorter claim can't
+        // leave a trailing tail of the previous owner's JSON.
+        let written = locked
+            .seek(SeekFrom::Start(0))
+            .and_then(|_| locked.set_len(0))
+            .and_then(|_| locked.write_all(body.as_bytes()))
+            .and_then(|_| locked.flush());
+        written.is_ok()
+    }
+
+    /// Release the leader lock for `pubkey_hex` if and only if we own it.
+    ///
+    /// Empties the file rather than unlinking it: removing a file another
+    /// process may already hold an `flock` fd on would race a fresh claim onto
+    /// a detached inode. An empty file reads back as malformed → fail-safe to
+    /// leader, so the next acquirer treats it as free.
+    #[cfg(unix)]
+    pub fn release(&self, pubkey_hex: &str) {
+        use nix::fcntl::{Flock, FlockArg};
+        use std::io::Read;
+
+        let Some(self_id) = self.instance_id.as_deref() else {
+            return;
+        };
+        let path = self.lock_dir.join(format!("{pubkey_hex}.lock"));
+        let Ok(file) = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+        else {
+            return; // nothing to release
+        };
+        let Ok(mut locked) = Flock::lock(file, FlockArg::LockExclusive) else {
+            return;
+        };
+        let mut contents = String::new();
+        if locked.read_to_string(&mut contents).is_err() {
+            return;
+        }
+        // Only clear a lock we still own — never stomp a successor's claim.
+        if matches!(serde_json::from_str::<LockFile>(&contents), Ok(l) if l.instance_id == self_id)
+        {
+            let _ = locked.set_len(0);
+        }
+    }
+
+    /// Whether the current lock `contents` may be claimed by `self_id`:
+    /// free (absent text/empty/malformed), already ours, held by a dead pid, or
+    /// held by a *stale* claim whose pid has been recycled by an unrelated
+    /// process.
+    ///
+    /// The stale arm closes a failover stall: a leader SIGKILLed without
+    /// release leaves a lock whose pid the OS may recycle for an unrelated,
+    /// long-lived process. A bare pid-alive probe would then read that recycled
+    /// pid as the original leader and never take over, wedging the agent
+    /// leaderless indefinitely. A *live* leader rewrites `claimed_at` on every
+    /// refresh tick, so its claim is always fresher than [`STALE_CLAIM`]; only
+    /// an abandoned claim ages past the bound. Pairing pid-alive with a stale
+    /// timestamp distinguishes a recycled pid from a genuinely active leader
+    /// without evicting the latter.
+    #[cfg(unix)]
+    fn lock_is_takeable(&self, contents: &str, self_id: &str) -> bool {
+        #[derive(serde::Deserialize)]
+        struct OwnerInfo {
+            instance_id: String,
+            pid: u32,
+            claimed_at: String,
+        }
+        match serde_json::from_str::<OwnerInfo>(contents) {
+            Ok(owner) => {
+                owner.instance_id == self_id
+                    || !pid_is_alive(owner.pid)
+                    || claim_is_stale(&owner.claimed_at)
+            }
+            Err(_) => true, // empty or malformed → free to take
+        }
+    }
+
+    /// Non-Unix has no `flock`; claims always succeed (always-leader), matching
+    /// the read-side absent→leader contract and the `kill_process_group`
+    /// `#[cfg(not(unix))]` pattern. The desktop targets macOS/Linux only.
+    #[cfg(not(unix))]
+    pub fn acquire(&self, _pubkey_hex: &str) -> bool {
+        true
+    }
+
+    /// Non-Unix release is a no-op (nothing was written).
+    #[cfg(not(unix))]
+    pub fn release(&self, _pubkey_hex: &str) {}
+}
+
+/// Whether a process with `pid` is alive, via signal 0 (existence probe).
+/// `ESRCH` means gone; other errors (e.g. `EPERM` for a live process we can't
+/// signal) are treated as alive so we never steal from a running leader.
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+    use nix::errno::Errno;
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+
+    !matches!(kill(Pid::from_raw(pid as i32), None), Err(Errno::ESRCH))
+}
+
+/// Whether an RFC 3339 `claimed_at` is older than [`STALE_CLAIM`].
+///
+/// An unparseable timestamp is treated as stale (takeable): a claim we can't
+/// date can't be proven fresh, so we must not let it wedge a takeover. A claim
+/// timestamped in the future (clock skew) is not stale — `signed_duration_since`
+/// is negative, which never exceeds the positive bound.
+#[cfg(unix)]
+fn claim_is_stale(claimed_at: &str) -> bool {
+    match chrono::DateTime::parse_from_rfc3339(claimed_at) {
+        Ok(claimed) => {
+            chrono::Utc::now().signed_duration_since(claimed)
+                > chrono::Duration::from_std(STALE_CLAIM).unwrap_or(chrono::Duration::MAX)
+        }
+        Err(_) => true,
     }
 }
 
@@ -265,5 +492,197 @@ mod tests {
         std::fs::remove_file(dir.lock_path()).unwrap();
         lc.refresh();
         assert!(lc.is_leader(PUBKEY));
+    }
+
+    // ── Writer (acquire / release) — Unix only ───────────────────────────────
+    #[cfg(unix)]
+    mod writer {
+        use super::*;
+
+        /// A checker rooted at `dir` with election id `id`, as the harness
+        /// builds it (always `Some(id)`).
+        fn checker(dir: &TmpDir, id: &str) -> FileLeaderCheck {
+            FileLeaderCheck::new(Some(id.into()), dir.0.clone())
+        }
+
+        /// PID guaranteed not to be alive: spawn a trivial child, reap it.
+        /// The kernel won't recycle the number while the test runs.
+        fn dead_pid() -> u32 {
+            let mut child = std::process::Command::new("true").spawn().unwrap();
+            let pid = child.id();
+            child.wait().unwrap();
+            pid
+        }
+
+        /// An RFC 3339 timestamp `secs` in the past — `now()` minus an offset,
+        /// so a fixture can model a fresh (active) or aged (abandoned) claim.
+        fn claimed_secs_ago(secs: i64) -> String {
+            (chrono::Utc::now() - chrono::Duration::seconds(secs)).to_rfc3339()
+        }
+
+        #[test]
+        fn test_acquire_unowned_lock_succeeds_and_writes_self() {
+            let dir = TmpDir::new();
+            let lc = checker(&dir, SELF_ID);
+            assert!(lc.acquire(PUBKEY), "free lock must be claimable");
+            // Read side now sees our own id → leader.
+            assert!(lc.is_leader(PUBKEY));
+        }
+
+        #[test]
+        fn test_acquire_creates_lock_dir_when_absent() {
+            let dir = TmpDir::new();
+            let nested = dir.0.join("missing-subdir");
+            let lc = FileLeaderCheck::new(Some(SELF_ID.into()), nested.clone());
+            assert!(lc.acquire(PUBKEY));
+            assert!(nested.join(format!("{PUBKEY}.lock")).exists());
+        }
+
+        #[test]
+        fn test_two_writers_race_exactly_one_wins() {
+            let dir = TmpDir::new();
+            let a = checker(&dir, SELF_ID);
+            let b = checker(&dir, OTHER_ID);
+            // First claim wins; the second sees a live foreign owner (this
+            // very test process is alive) and must observe.
+            assert!(a.acquire(PUBKEY), "first writer claims the free lock");
+            assert!(!b.acquire(PUBKEY), "second writer must not double-claim");
+            assert!(a.is_leader(PUBKEY));
+            assert!(!b.is_leader(PUBKEY));
+        }
+
+        #[test]
+        fn test_dead_pid_lock_is_taken_over() {
+            let dir = TmpDir::new();
+            dir.write_lock(&format!(
+                r#"{{"instance_id":"{OTHER_ID}","pid":{},"claimed_at":"2026-06-15T00:00:00Z"}}"#,
+                dead_pid()
+            ));
+            let lc = checker(&dir, SELF_ID);
+            assert!(lc.acquire(PUBKEY), "dead-pid lock must be reclaimable");
+            assert!(lc.is_leader(PUBKEY), "takeover rewrites the lock to us");
+        }
+
+        #[test]
+        fn test_live_foreign_lock_blocks_acquire() {
+            let dir = TmpDir::new();
+            // Live pid + fresh claim → an active leader; claim must fail.
+            dir.write_lock(&format!(
+                r#"{{"instance_id":"{OTHER_ID}","pid":{},"claimed_at":"{}"}}"#,
+                std::process::id(),
+                claimed_secs_ago(0),
+            ));
+            let lc = checker(&dir, SELF_ID);
+            assert!(
+                !lc.acquire(PUBKEY),
+                "live foreign owner must block the claim"
+            );
+            assert!(!lc.is_leader(PUBKEY));
+        }
+
+        #[test]
+        fn test_recycled_pid_with_stale_claim_is_taken_over() {
+            // A crashed leader's pid recycled to an unrelated live process:
+            // pid probes alive, but the abandoned claim has aged past the
+            // staleness bound. Without the bound this wedges leaderless.
+            let dir = TmpDir::new();
+            dir.write_lock(&format!(
+                r#"{{"instance_id":"{OTHER_ID}","pid":{},"claimed_at":"{}"}}"#,
+                std::process::id(), // a guaranteed-live pid stands in for the recycled one
+                claimed_secs_ago(STALE_CLAIM.as_secs() as i64 + 5),
+            ));
+            let lc = checker(&dir, SELF_ID);
+            assert!(
+                lc.acquire(PUBKEY),
+                "stale claim on a live (recycled) pid must be reclaimable"
+            );
+            assert!(lc.is_leader(PUBKEY), "takeover rewrites the lock to us");
+        }
+
+        #[test]
+        fn test_reacquire_own_lock_is_idempotent() {
+            let dir = TmpDir::new();
+            let lc = checker(&dir, SELF_ID);
+            assert!(lc.acquire(PUBKEY));
+            assert!(lc.acquire(PUBKEY), "re-claiming our own lock stays leader");
+            assert!(lc.is_leader(PUBKEY));
+        }
+
+        #[test]
+        fn test_release_frees_lock_for_another_writer() {
+            let dir = TmpDir::new();
+            let a = checker(&dir, SELF_ID);
+            let b = checker(&dir, OTHER_ID);
+            assert!(a.acquire(PUBKEY));
+            assert!(!b.acquire(PUBKEY), "blocked while A holds it");
+
+            a.release(PUBKEY);
+            // After release the file is empty (malformed) → free to take.
+            assert!(b.acquire(PUBKEY), "released lock must be claimable");
+            assert!(b.is_leader(PUBKEY));
+            assert!(!a.is_leader(PUBKEY), "A no longer owns the lock");
+        }
+
+        #[test]
+        fn test_release_does_not_stomp_a_successor() {
+            let dir = TmpDir::new();
+            let a = checker(&dir, SELF_ID);
+            // B (a different, live owner with a fresh claim) holds the lock.
+            dir.write_lock(&format!(
+                r#"{{"instance_id":"{OTHER_ID}","pid":{},"claimed_at":"{}"}}"#,
+                std::process::id(),
+                claimed_secs_ago(0),
+            ));
+            // A releasing must NOT clear B's claim (A doesn't own it).
+            a.release(PUBKEY);
+            assert!(
+                !FileLeaderCheck::new(Some(SELF_ID.into()), dir.0.clone()).acquire(PUBKEY),
+                "B's live lock must survive A's release"
+            );
+        }
+
+        #[test]
+        fn test_no_instance_id_acquire_is_noop_always_leader() {
+            let dir = TmpDir::new();
+            let lc = FileLeaderCheck::new(None, dir.0.clone());
+            assert!(lc.acquire(PUBKEY), "no id → always leader, no write");
+            assert!(
+                !dir.lock_path().exists(),
+                "no-id acquire must not write a lock file"
+            );
+        }
+
+        #[test]
+        fn test_concurrent_acquire_yields_exactly_one_winner() {
+            // Without the flock guard, two threads could both read the empty
+            // lock and both write — two leaders. The exclusive flock forces a
+            // serial read-decide-write, so exactly one wins and the rest see a
+            // live foreign owner (this same process's pid).
+            let dir = std::sync::Arc::new(TmpDir::new());
+            let winners = std::sync::Arc::new(AtomicU32::new(0));
+            let start = std::sync::Arc::new(std::sync::Barrier::new(8));
+            let handles: Vec<_> = (0..8)
+                .map(|i| {
+                    let dir = dir.clone();
+                    let winners = winners.clone();
+                    let start = start.clone();
+                    std::thread::spawn(move || {
+                        let lc = FileLeaderCheck::new(Some(format!("id-{i}")), dir.0.clone());
+                        start.wait();
+                        if lc.acquire(PUBKEY) {
+                            winners.fetch_add(1, Ordering::Relaxed);
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().unwrap();
+            }
+            assert_eq!(
+                winners.load(Ordering::Relaxed),
+                1,
+                "exactly one concurrent writer may win the lock"
+            );
+        }
     }
 }

--- a/crates/buzz-acp/src/leader.rs
+++ b/crates/buzz-acp/src/leader.rs
@@ -47,9 +47,24 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use serde::Deserialize;
+
+/// Stand-down timeout: how long `acquire()` is suppressed after `stand_down()`.
+///
+/// 2× the 5s refresh tick guarantees the target gets at least one full tick to
+/// acquire before the old leader resumes. If the target is alive, it acquires
+/// within 5s. If the target crashed, the old leader recovers after this timeout
+/// — zero-leader window is bounded and self-healing.
+#[cfg(not(test))]
+const STAND_DOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Shortened for tests so we can exercise the auto-expire path without sleeping.
+#[cfg(test)]
+const STAND_DOWN_TIMEOUT: Duration = Duration::from_millis(5);
 
 /// Environment variable carrying this window's leader-election identity.
 ///
@@ -109,6 +124,13 @@ pub struct FileLeaderCheck {
     /// Cached leader status per agent pubkey hex. Seeded read-through on first
     /// `is_leader`, refreshed in place by `refresh`.
     cache: Mutex<HashMap<String, bool>>,
+    /// When set, `acquire()` becomes a no-op (returns false without touching
+    /// the lock file) until the stand-down is cleared by `resume()` or after
+    /// [`STAND_DOWN_TIMEOUT`] expires.
+    standing_down: AtomicBool,
+    /// When the stand-down was entered. Used by `is_standing_down()` to
+    /// auto-expire the suppression after [`STAND_DOWN_TIMEOUT`].
+    stood_down_at: Mutex<Option<Instant>>,
 }
 
 impl FileLeaderCheck {
@@ -149,6 +171,8 @@ impl FileLeaderCheck {
             instance_id,
             lock_dir,
             cache: Mutex::new(HashMap::new()),
+            standing_down: AtomicBool::new(false),
+            stood_down_at: Mutex::new(None),
         }
     }
 
@@ -171,6 +195,47 @@ impl FileLeaderCheck {
         }
     }
 
+    /// Returns this instance's election id, or `None` for always-leader mode.
+    pub fn instance_id(&self) -> Option<&str> {
+        self.instance_id.as_deref()
+    }
+
+    /// Enter stand-down: suppress all `acquire()` calls until `resume()` or
+    /// [`STAND_DOWN_TIMEOUT`] expires. Called when this instance receives a
+    /// `claim_leadership` targeting a different instance and this instance is
+    /// the current leader.
+    pub fn stand_down(&self) {
+        self.standing_down.store(true, Ordering::Release);
+        *self.stood_down_at.lock().unwrap_or_else(|e| e.into_inner()) = Some(Instant::now());
+    }
+
+    /// Exit stand-down. Called by the target after successful acquire, or
+    /// automatically when [`STAND_DOWN_TIMEOUT`] expires.
+    #[allow(dead_code)]
+    pub fn resume(&self) {
+        self.standing_down.store(false, Ordering::Release);
+        *self.stood_down_at.lock().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+
+    /// Whether this instance is currently standing down (suppressing acquire).
+    /// Auto-expires after [`STAND_DOWN_TIMEOUT`] to prevent permanent
+    /// zero-leader on a lost handoff.
+    fn is_standing_down(&self) -> bool {
+        if !self.standing_down.load(Ordering::Acquire) {
+            return false;
+        }
+        let mut guard = self.stood_down_at.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(at) = *guard {
+            if at.elapsed() > STAND_DOWN_TIMEOUT {
+                // Auto-expire: clear stand-down inline to avoid re-locking.
+                self.standing_down.store(false, Ordering::Release);
+                *guard = None;
+                return false;
+            }
+        }
+        true
+    }
+
     /// Claim the leader lock for `pubkey_hex`, returning whether this process
     /// now holds it (and may act as leader).
     ///
@@ -186,6 +251,11 @@ impl FileLeaderCheck {
     pub fn acquire(&self, pubkey_hex: &str) -> bool {
         use nix::fcntl::{Flock, FlockArg};
         use std::io::{Read, Seek, SeekFrom, Write};
+
+        // Stand-down suppresses re-claim during cooperative handoff.
+        if self.is_standing_down() {
+            return false;
+        }
 
         // No election id → nothing to claim with; mirror the read-side
         // always-leader contract.
@@ -308,6 +378,9 @@ impl FileLeaderCheck {
     /// `#[cfg(not(unix))]` pattern. The desktop targets macOS/Linux only.
     #[cfg(not(unix))]
     pub fn acquire(&self, _pubkey_hex: &str) -> bool {
+        if self.is_standing_down() {
+            return false;
+        }
         true
     }
 
@@ -683,6 +756,72 @@ mod tests {
                 1,
                 "exactly one concurrent writer may win the lock"
             );
+        }
+
+        #[test]
+        fn test_stand_down_suppresses_acquire() {
+            let dir = TmpDir::new();
+            let a = checker(&dir, SELF_ID);
+            let b = checker(&dir, OTHER_ID);
+            assert!(a.acquire(PUBKEY), "A claims the free lock");
+            // A stands down and releases — simulating cooperative handoff.
+            a.stand_down();
+            a.release(PUBKEY);
+            // A's next tick: acquire returns false (standing down).
+            assert!(
+                !a.acquire(PUBKEY),
+                "standing-down instance must not re-claim"
+            );
+            // B can now take the free lock.
+            assert!(b.acquire(PUBKEY), "B must acquire the released lock");
+        }
+
+        #[test]
+        fn test_stand_down_auto_expires() {
+            let dir = TmpDir::new();
+            let a = checker(&dir, SELF_ID);
+            assert!(a.acquire(PUBKEY));
+            a.stand_down();
+            a.release(PUBKEY);
+            // acquire is suppressed while standing down.
+            assert!(!a.acquire(PUBKEY));
+            // Wait for the test-configured timeout (5ms) to expire.
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            // After timeout, stand-down auto-expires and acquire succeeds.
+            assert!(
+                a.acquire(PUBKEY),
+                "acquire must succeed after stand-down timeout expires"
+            );
+        }
+
+        #[test]
+        fn test_cooperative_handoff_transfers_leadership() {
+            let dir = TmpDir::new();
+            let a = checker(&dir, SELF_ID);
+            let b = checker(&dir, OTHER_ID);
+            assert!(a.acquire(PUBKEY), "A is leader");
+            assert!(!b.acquire(PUBKEY), "B blocked while A holds it");
+
+            // Cooperative handoff: A stands down + releases.
+            a.stand_down();
+            a.release(PUBKEY);
+            // B acquires on its next tick.
+            assert!(b.acquire(PUBKEY), "B must win after A stands down");
+            // A's next tick: still standing down, can't re-grab.
+            assert!(
+                !a.acquire(PUBKEY),
+                "A must not re-claim while standing down"
+            );
+        }
+
+        #[test]
+        fn test_instance_id_accessor() {
+            let dir = TmpDir::new();
+            let with_id = FileLeaderCheck::new(Some("test-id-123".into()), dir.0.clone());
+            assert_eq!(with_id.instance_id(), Some("test-id-123"));
+
+            let without_id = FileLeaderCheck::new(None, dir.0.clone());
+            assert_eq!(without_id.instance_id(), None);
         }
     }
 }

--- a/crates/buzz-acp/src/leader.rs
+++ b/crates/buzz-acp/src/leader.rs
@@ -15,8 +15,9 @@
 //!
 //! - Lock dir: `~/.buzz/leader-locks/`, one file per agent pubkey:
 //!   `<pubkey-hex>.lock`, JSON `{"instance_id","pid","claimed_at"}`.
-//! - **Absent** lock file → this process is leader. Single-instance dev is
-//!   thereby unaffected: no lock, no suppression.
+//! - **Absent or unreadable** lock file → this process is leader. Single-instance
+//!   dev is thereby unaffected: no lock, no suppression. Any IO error reading the
+//!   lock (permission, mid-write truncation) fails safe to leader for the same reason.
 //! - **Present** → leader iff the lock's `instance_id` equals this process's
 //!   own election id ([`ELECTION_ID_ENV`]).
 //! - **No instance id** (env unset, e.g. solo CLI use or pre-Phase-2 where
@@ -119,13 +120,18 @@ impl FileLeaderCheck {
 
 impl LeaderCheck for FileLeaderCheck {
     fn is_leader(&self, agent_pubkey_hex: &str) -> bool {
-        if let Some(&cached) = self.cache.lock().unwrap().get(agent_pubkey_hex) {
+        if let Some(&cached) = self
+            .cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(agent_pubkey_hex)
+        {
             return cached;
         }
         let status = self.read_status(agent_pubkey_hex);
         self.cache
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .insert(agent_pubkey_hex.to_string(), status);
         status
     }
@@ -133,10 +139,19 @@ impl LeaderCheck for FileLeaderCheck {
     fn refresh(&self) {
         // Re-read only keys we've already been asked about — those are the
         // agent pubkeys this process actually dispatches for.
-        let keys: Vec<String> = self.cache.lock().unwrap().keys().cloned().collect();
+        let keys: Vec<String> = self
+            .cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .keys()
+            .cloned()
+            .collect();
         for key in keys {
             let status = self.read_status(&key);
-            self.cache.lock().unwrap().insert(key, status);
+            self.cache
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(key, status);
         }
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4,6 +4,7 @@ mod acp;
 mod config;
 mod engram_fetch;
 mod filter;
+mod leader;
 mod observer;
 mod pool;
 mod queue;
@@ -1295,6 +1296,7 @@ async fn tokio_main() -> Result<()> {
             .as_deref()
             .and_then(|hex| nostr::PublicKey::from_hex(hex).ok()),
         memory_enabled: config.memory_enabled,
+        leader: Arc::new(leader::FileLeaderCheck::from_env()),
     });
 
     if !config.memory_enabled {
@@ -1339,6 +1341,13 @@ async fn tokio_main() -> Result<()> {
     };
     let mut typing_channels: HashMap<Uuid, ThreadTags> = HashMap::new();
     let mut presence_task: Option<tokio::task::JoinHandle<()>> = None;
+
+    // ── Step 6c2: Leader-status refresh timer ────────────────────────────────
+    // Re-reads the per-key leader lock every 5s so a leadership change (another
+    // instance claiming/releasing this agent) takes effect without a restart.
+    // Faster cadence than the 30s maintenance tick because failover latency is
+    // user-visible. Cheap: one file read per known agent key.
+    let mut leader_refresh = tokio::time::interval(Duration::from_secs(5));
 
     // ── Step 6d: Maintenance (slot refill + queue compaction) ────────────────
     // Runs at the TOP of every loop iteration via Instant check — cannot be
@@ -1828,11 +1837,15 @@ async fn tokio_main() -> Result<()> {
                                 prompt_tag,
                             });
                             // 👀 — immediate "seen" reaction, only if the event
-                            // was actually queued (not dropped by DedupMode::Drop).
+                            // was actually queued (not dropped by DedupMode::Drop)
+                            // AND this instance is the leader for this agent key.
+                            // The reaction fires at queue-push time, BEFORE
+                            // dispatch, so the dispatch gate alone would let
+                            // every sharing instance emit a redundant 👀.
                             // Fire-and-forget: on rare fast-failure paths the
                             // guard's cleanup may race with this add, leaving a
                             // cosmetic stale 👀. Acceptable — see ReactionGuard docs.
-                            if accepted {
+                            if accepted && ctx.leader.is_leader(&pubkey_hex) {
                                 let rc = ctx.rest_client.clone();
                                 tokio::spawn(async move {
                                     pool::reaction_add(&rc, &event_id_hex, "👀").await;
@@ -1940,6 +1953,14 @@ async fn tokio_main() -> Result<()> {
                             }
                         }
                     }
+                    None
+                }
+                _ = leader_refresh.tick() => {
+                    let _ = result_rx;
+                    // Re-read leader lock(s) so claim/release/failover by
+                    // another instance flips this process between active and
+                    // observer without a restart.
+                    ctx.leader.refresh();
                     None
                 }
                 _ = shutdown_rx.changed() => {
@@ -2177,6 +2198,14 @@ fn dispatch_pending(
     queue: &mut EventQueue,
     ctx: &Arc<PromptContext>,
 ) -> Vec<(Uuid, ThreadTags)> {
+    // Multi-instance leader gate: when this agent's keypair is shared across
+    // several Buzz instances, only the leader promotes queued events to
+    // prompts. Non-leaders keep the queue populated (so the UI still renders
+    // the conversation) but never dispatch. Solo dev has no lock file, so this
+    // is unconditionally `true` and behavior is unchanged.
+    if !ctx.leader.is_leader(&ctx.agent_keys.public_key().to_hex()) {
+        return Vec::new();
+    }
     let mut dispatched_channels = Vec::new();
     loop {
         let batch = match queue.flush_next() {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1266,6 +1266,20 @@ async fn tokio_main() -> Result<()> {
     let mut queue = EventQueue::new(dedup_mode);
 
     let base_prompt_content = config.base_prompt_content.take();
+    // Leader election: self-mint an election id and auto-claim this agent
+    // key's lock so the first instance up leads and a later instance under the
+    // same key observes. Best-effort — acquire fails safe to leader on IO error
+    // and yields observer only when a live foreign instance holds the lock.
+    // The concrete handle is kept (separately from the `Arc<dyn LeaderCheck>`
+    // stored in `ctx`) so the lifecycle can re-acquire on failover and release
+    // on shutdown.
+    let agent_pubkey_hex = config.keys.public_key().to_hex();
+    let leader = Arc::new(leader::FileLeaderCheck::from_env_or_mint());
+    if leader.acquire(&agent_pubkey_hex) {
+        tracing::info!(agent = %agent_pubkey_hex, "leader lock acquired — active responder");
+    } else {
+        tracing::info!(agent = %agent_pubkey_hex, "leader lock held by another instance — observing");
+    }
     let ctx = Arc::new(PromptContext {
         mcp_servers: build_mcp_servers(&config),
         initial_message: config.initial_message.clone(),
@@ -1296,7 +1310,7 @@ async fn tokio_main() -> Result<()> {
             .as_deref()
             .and_then(|hex| nostr::PublicKey::from_hex(hex).ok()),
         memory_enabled: config.memory_enabled,
-        leader: Arc::new(leader::FileLeaderCheck::from_env()),
+        leader: leader.clone(),
     });
 
     if !config.memory_enabled {
@@ -1957,9 +1971,14 @@ async fn tokio_main() -> Result<()> {
                 }
                 _ = leader_refresh.tick() => {
                     let _ = result_rx;
-                    // Re-read leader lock(s) so claim/release/failover by
-                    // another instance flips this process between active and
-                    // observer without a restart.
+                    // Re-attempt the claim first: if the current leader died
+                    // without releasing, its lock now names a dead pid and this
+                    // acquire takes over (failover); otherwise it's a no-op
+                    // rewrite of our own lock or a no-op observe. Then re-read
+                    // so the cached status reflects any claim/release/failover
+                    // and flips this process between active and observer without
+                    // a restart.
+                    leader.acquire(&agent_pubkey_hex);
                     ctx.leader.refresh();
                     None
                 }
@@ -2038,6 +2057,9 @@ async fn tokio_main() -> Result<()> {
     }
 
     // ── Shutdown sequence ─────────────────────────────────────────────────────
+    // Relinquish leadership first so a co-located sibling can take over
+    // immediately rather than waiting out the dead-pid failover window.
+    leader.release(&agent_pubkey_hex);
     tracing::info!("shutdown: waiting for in-flight prompts");
     // 30 s is generous for in-flight prompts to be cancelled; using
     // max_turn_duration here would cause Ctrl+C to hang for up to an hour.

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2618,6 +2618,14 @@ fn dispatch_heartbeat(
     if *heartbeat_in_flight {
         return;
     }
+    // Multi-instance leader gate: the heartbeat prompt acts autonomously on the
+    // wire (sends messages, approves workflows), so non-leaders must not fire it
+    // — otherwise N instances on a shared key would each self-prompt and act,
+    // the same duplicate-actor bug the dispatch gate prevents. Solo dev has no
+    // lock file, so this is unconditionally `true` and behavior is unchanged.
+    if !ctx.leader.is_leader(&ctx.agent_keys.public_key().to_hex()) {
+        return;
+    }
     let agent = match pool.try_claim(None) {
         Some(a) => a,
         None => return,
@@ -3603,6 +3611,78 @@ mod error_outcome_emission_tests {
     async fn application_error_emits_exactly_one_feed_event() {
         let app = AcpError::IdleTimeout(std::time::Duration::from_secs(1));
         assert_eq!(turn_errors_emitted_for(PromptOutcome::Error(app)).await, 1);
+    }
+
+    /// Stub [`LeaderCheck`] that always reports a fixed leadership verdict —
+    /// isolates the heartbeat gate from the filesystem reader (cleared
+    /// separately in `leader::tests`).
+    struct FixedLeader(bool);
+    impl crate::leader::LeaderCheck for FixedLeader {
+        fn is_leader(&self, _agent_pubkey_hex: &str) -> bool {
+            self.0
+        }
+        fn refresh(&self) {}
+    }
+
+    fn prompt_context_with_leader(keys: nostr::Keys, is_leader: bool) -> Arc<PromptContext> {
+        Arc::new(PromptContext {
+            mcp_servers: vec![],
+            initial_message: None,
+            idle_timeout: Duration::from_secs(60),
+            max_turn_duration: Duration::from_secs(60),
+            turn_liveness_interval: Duration::ZERO,
+            dedup_mode: config::DedupMode::Queue,
+            system_prompt: None,
+            heartbeat_prompt: None,
+            base_prompt: None,
+            cwd: "/".into(),
+            rest_client: crate::relay::RestClient {
+                http: reqwest::Client::new(),
+                base_url: "http://localhost:3000".into(),
+                keys: keys.clone(),
+                auth_tag_json: None,
+            },
+            channel_info: std::collections::HashMap::new(),
+            context_message_limit: 0,
+            max_turns_per_session: 0,
+            permission_mode: config::PermissionMode::BypassPermissions,
+            agent_keys: keys,
+            agent_owner_pubkey: None,
+            memory_enabled: false,
+            leader: Arc::new(FixedLeader(is_leader)),
+        })
+    }
+
+    /// Pins the second half of the leader invariant: the autonomous heartbeat
+    /// prompt (which sends messages / approves workflows on the wire) must not
+    /// fire on a non-leader, even with an idle agent ready. Without the gate,
+    /// N instances sharing one key would each self-prompt and act — the exact
+    /// duplicate-actor bug the dispatch gate already prevents on the event path.
+    #[tokio::test]
+    async fn test_non_leader_heartbeat_claims_no_agent() {
+        let ctx = prompt_context_with_leader(nostr::Keys::generate(), false);
+        let mut pool = AgentPool::from_slots(vec![Some(dummy_agent(0).await)]);
+        let mut heartbeat_in_flight = false;
+
+        dispatch_heartbeat(&mut pool, &ctx, &mut heartbeat_in_flight);
+
+        assert!(pool.any_idle(), "non-leader must not claim the idle agent");
+        assert!(!heartbeat_in_flight, "non-leader heartbeat must not fire");
+    }
+
+    /// Companion to the gate test: the same idle agent + fired heartbeat path,
+    /// but as the leader, DOES claim and fire — so the gate test proves the
+    /// gate, not a broken dispatch path.
+    #[tokio::test]
+    async fn test_leader_heartbeat_claims_idle_agent() {
+        let ctx = prompt_context_with_leader(nostr::Keys::generate(), true);
+        let mut pool = AgentPool::from_slots(vec![Some(dummy_agent(0).await)]);
+        let mut heartbeat_in_flight = false;
+
+        dispatch_heartbeat(&mut pool, &ctx, &mut heartbeat_in_flight);
+
+        assert!(!pool.any_idle(), "leader must claim the idle agent");
+        assert!(heartbeat_in_flight, "leader heartbeat must fire");
     }
 }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -10,6 +10,7 @@ mod pool;
 mod queue;
 mod relay;
 
+use leader::LeaderCheck;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -681,6 +682,8 @@ fn handle_relay_observer_control_event(
     pool: &mut AgentPool,
     observer: Option<&observer::ObserverHandle>,
     owner_pubkey_hex: &str,
+    leader: &std::sync::Arc<leader::FileLeaderCheck>,
+    agent_pubkey_hex: &str,
 ) {
     // Defense-in-depth: verify signature even though the relay already checked.
     if let Err(e) = buzz_core::verify_event(&event) {
@@ -719,36 +722,75 @@ fn handle_relay_observer_control_event(
     };
 
     let command_type = payload.get("type").and_then(|value| value.as_str());
-    if command_type != Some("cancel_turn") {
+    if command_type == Some("cancel_turn") {
+        let Some(channel_id) = payload
+            .get("channelId")
+            .and_then(|value| value.as_str())
+            .and_then(|value| value.parse::<Uuid>().ok())
+        else {
+            tracing::warn!("observer cancel_turn control frame missing valid channelId");
+            return;
+        };
+
+        let fired = signal_in_flight_task(pool, channel_id, ControlSignal::Cancel);
+        let status = if fired { "sent" } else { "no_active_turn" };
+        if let Some(observer) = observer {
+            observer.emit(
+                "control_result",
+                None,
+                &observer::ObserverContext {
+                    channel_id: Some(channel_id.to_string()),
+                    session_id: None,
+                    turn_id: None,
+                },
+                serde_json::json!({
+                    "type": "cancel_turn",
+                    "status": status,
+                }),
+            );
+        }
+    } else if command_type == Some("claim_leadership") {
+        let target_id = payload.get("targetInstanceId").and_then(|v| v.as_str());
+        let self_id = leader.instance_id();
+
+        match (target_id, self_id) {
+            (Some(target), Some(self_instance)) if target == self_instance => {
+                // We are the target — attempt to acquire.
+                let acquired = leader.acquire(agent_pubkey_hex);
+                if acquired {
+                    if let Some(obs) = observer {
+                        obs.emit(
+                            "control_result",
+                            None,
+                            &observer::ObserverContext {
+                                channel_id: None,
+                                session_id: None,
+                                turn_id: None,
+                            },
+                            serde_json::json!({
+                                "type": "claim_leadership",
+                                "status": "claimed",
+                            }),
+                        );
+                    }
+                }
+                // If !acquired: do nothing. Next 5s tick will succeed
+                // (old leader standing down). leadership_status stream
+                // is the desktop's source of truth.
+            }
+            (Some(_target), Some(_self_instance)) => {
+                // We are NOT the target — if we're leader, stand down + release.
+                if leader.is_leader(agent_pubkey_hex) {
+                    leader.stand_down();
+                    leader.release(agent_pubkey_hex);
+                }
+            }
+            _ => {
+                tracing::warn!("claim_leadership frame missing targetInstanceId or no self id");
+            }
+        }
+    } else {
         tracing::debug!(payload = %payload, "ignoring unknown observer control frame");
-        return;
-    }
-
-    let Some(channel_id) = payload
-        .get("channelId")
-        .and_then(|value| value.as_str())
-        .and_then(|value| value.parse::<Uuid>().ok())
-    else {
-        tracing::warn!("observer cancel_turn control frame missing valid channelId");
-        return;
-    };
-
-    let fired = signal_in_flight_task(pool, channel_id, ControlSignal::Cancel);
-    let status = if fired { "sent" } else { "no_active_turn" };
-    if let Some(observer) = observer {
-        observer.emit(
-            "control_result",
-            None,
-            &observer::ObserverContext {
-                channel_id: Some(channel_id.to_string()),
-                session_id: None,
-                turn_id: None,
-            },
-            serde_json::json!({
-                "type": "cancel_turn",
-                "status": status,
-            }),
-        );
     }
 }
 
@@ -1556,7 +1598,7 @@ async fn tokio_main() -> Result<()> {
                     match control_event {
                         Some(event) => {
                             if let Some(ref owner_hex) = owner_cache.pubkey {
-                                handle_relay_observer_control_event(&config.keys, event, &mut pool, observer.as_ref(), owner_hex);
+                                handle_relay_observer_control_event(&config.keys, event, &mut pool, observer.as_ref(), owner_hex, &leader, &agent_pubkey_hex);
                             } else {
                                 tracing::warn!("observer control frame received but no owner resolved — dropping");
                             }
@@ -1980,6 +2022,20 @@ async fn tokio_main() -> Result<()> {
                     // a restart.
                     leader.acquire(&agent_pubkey_hex);
                     ctx.leader.refresh();
+                    // Emit leadership_status so the desktop can track which
+                    // instances are alive and who currently leads.
+                    if let (Some(obs), Some(instance_id)) = (observer.as_ref(), leader.instance_id()) {
+                        obs.emit(
+                            "leadership_status",
+                            None,
+                            &observer::ObserverContext { channel_id: None, session_id: None, turn_id: None },
+                            serde_json::json!({
+                                "type": "leadership_status",
+                                "instanceId": instance_id,
+                                "isLeader": ctx.leader.is_leader(&agent_pubkey_hex),
+                            }),
+                        );
+                    }
                     None
                 }
                 _ = shutdown_rx.changed() => {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3684,6 +3684,57 @@ mod error_outcome_emission_tests {
         assert!(!pool.any_idle(), "leader must claim the idle agent");
         assert!(heartbeat_in_flight, "leader heartbeat must fire");
     }
+
+    /// Seed `queue` with one pending event so `dispatch_pending` has work to
+    /// promote when the leader gate allows it.
+    fn queue_one_pending(queue: &mut EventQueue) {
+        use nostr::{EventBuilder, Keys, Kind};
+        let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "@agent hello")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        queue.push(QueuedEvent {
+            channel_id: Uuid::new_v4(),
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "@mention".into(),
+        });
+    }
+
+    /// Pins the primary suppression surface: a non-leader must never promote a
+    /// queued event to a prompt, even with an idle agent and pending work.
+    /// Without this gate, N instances sharing one key would each dispatch the
+    /// same mention — the duplicate-actor bug leader election exists to prevent.
+    #[tokio::test]
+    async fn test_non_leader_dispatch_pending_promotes_nothing() {
+        let ctx = prompt_context_with_leader(nostr::Keys::generate(), false);
+        let mut pool = AgentPool::from_slots(vec![Some(dummy_agent(0).await)]);
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        queue_one_pending(&mut queue);
+
+        let dispatched = dispatch_pending(&mut pool, &mut queue, &ctx);
+
+        assert!(
+            dispatched.is_empty(),
+            "non-leader must not promote queued events"
+        );
+        assert!(pool.any_idle(), "non-leader must not claim the idle agent");
+    }
+
+    /// Companion to the gate test: the same idle agent + pending event, but as
+    /// the leader, DOES promote — proving the gate test catches the gate, not a
+    /// broken dispatch path.
+    #[tokio::test]
+    async fn test_leader_dispatch_pending_promotes_queued_event() {
+        let ctx = prompt_context_with_leader(nostr::Keys::generate(), true);
+        let mut pool = AgentPool::from_slots(vec![Some(dummy_agent(0).await)]);
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        queue_one_pending(&mut queue);
+
+        let dispatched = dispatch_pending(&mut pool, &mut queue, &ctx);
+
+        assert_eq!(dispatched.len(), 1, "leader must promote the queued event");
+        assert!(!pool.any_idle(), "leader must claim the idle agent");
+    }
 }
 
 #[cfg(test)]

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -33,6 +33,7 @@ use crate::acp::{
     AcpError, McpServer, ModelSwitchMethod, StopReason,
 };
 use crate::config::{DedupMode, PermissionMode};
+use crate::leader::LeaderCheck;
 use crate::observer;
 use crate::queue::{
     ContextMessage, ConversationContext, FlushBatch, PromptChannelInfo, PromptProfile,
@@ -253,6 +254,11 @@ pub struct PromptContext {
     /// `[Agent Memory — core]` section. On by default; disabled via
     /// `--no-memory` / `BUZZ_ACP_NO_MEMORY`.
     pub memory_enabled: bool,
+    /// Multi-instance leader gate. When several Buzz instances share this
+    /// agent's keypair, only the leader promotes queued events to prompts and
+    /// emits the pre-dispatch `👀` reaction; non-leaders observe silently.
+    /// Defaults to "always leader" when no lock file exists (solo dev).
+    pub leader: Arc<dyn LeaderCheck>,
 }
 
 // ── AgentPool impl ────────────────────────────────────────────────────────────

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         "**/team-management-screenshots.spec.ts",
         "**/active-turn-screenshots.spec.ts",
         "**/active-turn-resilience-screenshots.spec.ts",
+        "**/leadership-screenshots.spec.ts",
         "**/profile-active-turn-screenshots.spec.ts",
         "**/file-attachment.spec.ts",
         "**/video-attachment.spec.ts",

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -16,6 +16,11 @@ import {
   createEmptyTranscriptState,
   processTranscriptEvent,
 } from "./ui/agentSessionTranscript";
+import {
+  type InstanceLeadership,
+  LEADERSHIP_EVENT_KIND,
+  buildLeadership,
+} from "./ui/leadershipHelpers";
 
 const MAX_OBSERVER_EVENTS = 800;
 
@@ -32,11 +37,13 @@ const IDLE_SNAPSHOT: ObserverSnapshot = {
 };
 
 const EMPTY_TRANSCRIPT: TranscriptItem[] = [];
+const EMPTY_LEADERSHIP: InstanceLeadership[] = [];
 
 const listeners = new Set<() => void>();
 const eventsByAgent = new Map<string, ObserverEvent[]>();
 const transcriptByAgent = new Map<string, TranscriptState>();
 const snapshotByAgent = new Map<string, ObserverSnapshot>();
+const leadershipByAgent = new Map<string, InstanceLeadership[]>();
 
 // Normalized pubkeys of agents we are actively managing. Only events whose
 // "agent" tag matches an entry here will be decrypted (defense-in-depth).
@@ -107,6 +114,14 @@ function appendAgentEvent(agentPubkey: string, event: ObserverEvent) {
   } else {
     // Slow path: full rebuild (out-of-order insertion or trim fired)
     transcriptByAgent.set(key, buildTranscriptState(final));
+  }
+
+  // Rebuild the cached leadership array only when a leadership frame lands, so
+  // `getAgentLeadership` stays a stable map lookup (referential stability is
+  // required by `useSyncExternalStore`). The rebuild walks the trimmed window,
+  // so instances whose latest frame aged out are pruned automatically.
+  if (event.kind === LEADERSHIP_EVENT_KIND) {
+    leadershipByAgent.set(key, buildLeadership(final));
   }
 
   // Invalidate cached snapshot for this agent
@@ -272,6 +287,20 @@ export function getAgentTranscript(
   return state?.items ?? EMPTY_TRANSCRIPT;
 }
 
+export type { InstanceLeadership };
+
+export function getAgentLeadership(
+  agentPubkey?: string | null,
+  enabled?: boolean,
+): InstanceLeadership[] {
+  if (!enabled || !agentPubkey) {
+    return EMPTY_LEADERSHIP;
+  }
+  return (
+    leadershipByAgent.get(normalizePubkey(agentPubkey)) ?? EMPTY_LEADERSHIP
+  );
+}
+
 export function useManagedAgentObserverBridge(
   agents: readonly Pick<ManagedAgent, "pubkey" | "status">[],
 ) {
@@ -308,6 +337,7 @@ export function resetAgentObserverStore() {
   eventsByAgent.clear();
   transcriptByAgent.clear();
   snapshotByAgent.clear();
+  leadershipByAgent.clear();
   knownAgentPubkeys.clear();
   connectionState = "idle";
   errorMessage = null;

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -328,6 +328,31 @@ export function useManagedAgentObserverBridge(
   }, [hasActiveAgent]);
 }
 
+// Test-only: inject synthetic `leadership_status` frames through the real
+// ingest path (`appendAgentEvent`), so the cached-map rebuild the consumer
+// reads is exercised — not a fake. Registers the agent as known so the row
+// renders. Production ingest (`handleRelayObserverEvent`) is untouched.
+export function seedLeadershipForTest(
+  agentPubkey: string,
+  instances: readonly { instanceId: string; isLeader: boolean }[],
+) {
+  knownAgentPubkeys.add(normalizePubkey(agentPubkey));
+  let seq = Date.now();
+  for (const { instanceId, isLeader } of instances) {
+    seq += 1;
+    appendAgentEvent(agentPubkey, {
+      seq,
+      timestamp: new Date().toISOString(),
+      kind: LEADERSHIP_EVENT_KIND,
+      agentIndex: null,
+      channelId: null,
+      sessionId: null,
+      turnId: null,
+      payload: { instanceId, isLeader },
+    });
+  }
+}
+
 export function resetAgentObserverStore() {
   generation += 1;
   const unsubscribe = unsubscribeRelay;

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   ChevronRight,
   Clipboard,
+  Crown,
   Ellipsis,
   FileText,
   Pencil,
@@ -33,13 +34,23 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 import { EditAgentDialog } from "./EditAgentDialog";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
 import { ManagedAgentLogPanel } from "./ManagedAgentLogPanel";
 import { ModelPicker } from "./ModelPicker";
-import { truncatePubkey } from "./agentUi";
+import { truncateInstanceId, truncatePubkey } from "./agentUi";
+import { useAgentLeadership } from "./useObserverEvents";
+import {
+  type InstanceLeadership,
+  filterStaleInstances,
+  selectFreshestLeader,
+} from "./leadershipHelpers";
+import { claimManagedAgentLeadership } from "@/shared/api/agentControl";
 
 export function ManagedAgentRow({
   agent,
@@ -115,6 +126,21 @@ export function ManagedAgentRow({
   // crash. Generic exits stay verbatim so we don't lie about other failures.
   const friendlyError = friendlyAgentLastError(agent.lastError);
 
+  // Leadership frames flow into the owner-wide observer store regardless of
+  // session-panel state, so this is enabled on row visibility (gated only on a
+  // pubkey). The 5s clock drives stale eviction without a new frame arriving —
+  // a crashed leader's last frame ages out and the badge drops within 15s.
+  const leadership = useAgentLeadership(true, agent.pubkey);
+  const leadershipNow = useNow(5000);
+  const liveInstances = React.useMemo(
+    () => filterStaleInstances(leadership, leadershipNow),
+    [leadership, leadershipNow],
+  );
+  const leaderInstanceId = React.useMemo(
+    () => selectFreshestLeader(liveInstances)?.instanceId ?? null,
+    [liveInstances],
+  );
+
   return (
     <div
       className={cn(
@@ -146,6 +172,7 @@ export function ManagedAgentRow({
               <StatusBlock
                 friendlyError={friendlyError}
                 isWorking={isWorking}
+                leaderInstanceId={leaderInstanceId}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -169,6 +196,7 @@ export function ManagedAgentRow({
               <StatusBlock
                 friendlyError={friendlyError}
                 isWorking={isWorking}
+                leaderInstanceId={leaderInstanceId}
                 presenceLoaded={presenceLoaded}
                 presenceStatus={presenceStatus}
                 processDetail={processDetail}
@@ -183,8 +211,10 @@ export function ManagedAgentRow({
           <ModelPicker agent={agent} />
           <AgentActionsMenu
             agent={agent}
+            instances={liveInstances}
             isActionPending={isActionPending}
             isActive={isActive}
+            leaderInstanceId={leaderInstanceId}
             onAddToChannel={onAddToChannel}
             onDelete={onDelete}
             onOpenLogs={(pubkey) => onSelectLogAgent(pubkey)}
@@ -335,6 +365,7 @@ function WorkingBadge({
 function StatusBlock({
   friendlyError,
   isWorking,
+  leaderInstanceId,
   presenceLoaded,
   presenceStatus,
   processDetail,
@@ -342,6 +373,7 @@ function StatusBlock({
 }: {
   friendlyError: ReturnType<typeof friendlyAgentLastError>;
   isWorking: boolean;
+  leaderInstanceId: string | null;
   presenceLoaded: boolean;
   presenceStatus: PresenceStatus | undefined;
   processDetail: string;
@@ -352,12 +384,20 @@ function StatusBlock({
       <p className="text-2xs font-semibold uppercase tracking-[0.16em] text-muted-foreground lg:hidden">
         Status
       </p>
-      <AgentStatusBadge
-        isWorking={isWorking}
-        presenceLoaded={presenceLoaded}
-        presenceStatus={presenceStatus}
-        status={status}
-      />
+      <div className="flex flex-wrap items-center gap-1.5">
+        <AgentStatusBadge
+          isWorking={isWorking}
+          presenceLoaded={presenceLoaded}
+          presenceStatus={presenceStatus}
+          status={status}
+        />
+        {leaderInstanceId ? (
+          <Badge className="gap-1" variant="outline">
+            <Crown className="h-3 w-3" />
+            Leader
+          </Badge>
+        ) : null}
+      </div>
       <p className="text-xs text-muted-foreground">{processDetail}</p>
       {friendlyError ? (
         <p
@@ -403,8 +443,10 @@ function RuntimeBlock({
 
 function AgentActionsMenu({
   agent,
+  instances,
   isActionPending,
   isActive,
+  leaderInstanceId,
   onAddToChannel,
   onDelete,
   onOpenLogs,
@@ -413,8 +455,10 @@ function AgentActionsMenu({
   onToggleStartOnAppLaunch,
 }: {
   agent: ManagedAgent;
+  instances: InstanceLeadership[];
   isActionPending: boolean;
   isActive: boolean;
+  leaderInstanceId: string | null;
   onAddToChannel: (agent: ManagedAgent) => void;
   onDelete: (pubkey: string) => void;
   onOpenLogs: (pubkey: string) => void;
@@ -423,6 +467,8 @@ function AgentActionsMenu({
   onToggleStartOnAppLaunch: (pubkey: string, startOnAppLaunch: boolean) => void;
 }) {
   const [editOpen, setEditOpen] = React.useState(false);
+  // Nothing to steal unless at least two instances are racing.
+  const showLeadershipSubmenu = instances.length > 1;
 
   return (
     <>
@@ -520,6 +566,57 @@ function AgentActionsMenu({
                 ? "Disable auto-start"
                 : "Enable auto-start"}
             </DropdownMenuItem>
+          ) : null}
+
+          {showLeadershipSubmenu ? (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <Crown className="h-4 w-4" />
+                Leadership
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {instances.map((instance) => {
+                  const isLeader = instance.instanceId === leaderInstanceId;
+                  return (
+                    <DropdownMenuItem
+                      disabled={isLeader}
+                      key={instance.instanceId}
+                      onClick={async () => {
+                        try {
+                          await claimManagedAgentLeadership(
+                            agent.pubkey,
+                            instance.instanceId,
+                          );
+                          toast.success(
+                            `Leadership request sent to ${agent.name}.`,
+                          );
+                        } catch (error) {
+                          toast.error(
+                            error instanceof Error
+                              ? error.message
+                              : `Failed to send leadership request to ${agent.name}.`,
+                          );
+                        }
+                      }}
+                    >
+                      {isLeader ? (
+                        <Crown className="h-4 w-4" />
+                      ) : (
+                        <span className="h-4 w-4" />
+                      )}
+                      <span className="font-mono">
+                        {truncateInstanceId(instance.instanceId)}
+                      </span>
+                      <span className="ml-auto text-xs text-muted-foreground">
+                        {isLeader
+                          ? "Leader"
+                          : `${formatElapsed(Date.now() - instance.lastSeen)} ago`}
+                      </span>
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
           ) : null}
 
           <DropdownMenuSeparator />

--- a/desktop/src/features/agents/ui/agentUi.ts
+++ b/desktop/src/features/agents/ui/agentUi.ts
@@ -2,6 +2,18 @@ export function truncatePubkey(pubkey: string) {
   return `${pubkey.slice(0, 8)}…${pubkey.slice(-6)}`;
 }
 
+/**
+ * Election instance ids are `{pid}-{launch-nanos}` (minted per harness window).
+ * The pid prefix identifies the process; the long nanos tail only disambiguates
+ * relaunches, so keep the prefix and a short suffix. Short ids pass through.
+ */
+export function truncateInstanceId(instanceId: string) {
+  if (instanceId.length <= 16) {
+    return instanceId;
+  }
+  return `${instanceId.slice(0, 8)}…${instanceId.slice(-4)}`;
+}
+
 function commandLooksLikePath(command: string) {
   const trimmed = command.trim();
   return (

--- a/desktop/src/features/agents/ui/leadershipHelpers.test.mjs
+++ b/desktop/src/features/agents/ui/leadershipHelpers.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LEADERSHIP_STALE_MS,
+  buildLeadership,
+  filterStaleInstances,
+  parseLeadershipPayload,
+  selectFreshestLeader,
+} from "./leadershipHelpers.ts";
+
+// `Date.parse` consumes RFC3339 strings (what the harness emits via
+// chrono::Utc::now().to_rfc3339()), so tests build timestamps the same way.
+const iso = (epochMs) => new Date(epochMs).toISOString();
+
+function leadershipEvent({ seq, instanceId, isLeader, at, kind, payload }) {
+  return {
+    seq,
+    timestamp: iso(at),
+    kind: kind ?? "leadership_status",
+    agentIndex: null,
+    channelId: null,
+    sessionId: null,
+    turnId: null,
+    payload: payload ?? { type: "leadership_status", instanceId, isLeader },
+  };
+}
+
+// --- parseLeadershipPayload ---
+
+test("parseLeadershipPayload accepts a well-formed payload", () => {
+  const result = parseLeadershipPayload({
+    type: "leadership_status",
+    instanceId: "123-456",
+    isLeader: true,
+  });
+  assert.deepEqual(result, { instanceId: "123-456", isLeader: true });
+});
+
+test("parseLeadershipPayload rejects non-object payloads", () => {
+  for (const bad of [null, undefined, "string", 42, true, []]) {
+    // Arrays are objects but lack the required string/boolean fields, so they
+    // must also be rejected.
+    assert.equal(parseLeadershipPayload(bad), null);
+  }
+});
+
+test("parseLeadershipPayload rejects a missing or non-string instanceId", () => {
+  assert.equal(parseLeadershipPayload({ isLeader: true }), null);
+  assert.equal(parseLeadershipPayload({ instanceId: 5, isLeader: true }), null);
+});
+
+test("parseLeadershipPayload rejects a non-boolean isLeader", () => {
+  assert.equal(
+    parseLeadershipPayload({ instanceId: "a", isLeader: "yes" }),
+    null,
+  );
+  assert.equal(parseLeadershipPayload({ instanceId: "a" }), null);
+});
+
+// --- buildLeadership ---
+
+test("buildLeadership keeps the latest frame per instanceId", () => {
+  const events = [
+    leadershipEvent({ seq: 1, instanceId: "A", isLeader: true, at: 1000 }),
+    leadershipEvent({ seq: 2, instanceId: "B", isLeader: false, at: 1500 }),
+    leadershipEvent({ seq: 3, instanceId: "A", isLeader: false, at: 2000 }),
+  ];
+  const result = buildLeadership(events);
+  assert.equal(result.length, 2);
+  const a = result.find((i) => i.instanceId === "A");
+  assert.deepEqual(a, { instanceId: "A", isLeader: false, lastSeen: 2000 });
+});
+
+test("buildLeadership ignores non-leadership events", () => {
+  const events = [
+    leadershipEvent({ seq: 1, kind: "turn_started", payload: {}, at: 500 }),
+    leadershipEvent({ seq: 2, instanceId: "A", isLeader: true, at: 1000 }),
+  ];
+  const result = buildLeadership(events);
+  assert.deepEqual(result, [
+    { instanceId: "A", isLeader: true, lastSeen: 1000 },
+  ]);
+});
+
+test("buildLeadership drops frames that fail the payload guard", () => {
+  const events = [
+    leadershipEvent({
+      seq: 1,
+      payload: { instanceId: 5, isLeader: true },
+      at: 1000,
+    }),
+    leadershipEvent({ seq: 2, instanceId: "A", isLeader: true, at: 1500 }),
+  ];
+  const result = buildLeadership(events);
+  assert.deepEqual(result, [
+    { instanceId: "A", isLeader: true, lastSeen: 1500 },
+  ]);
+});
+
+test("buildLeadership drops frames with an unparseable timestamp", () => {
+  const bad = leadershipEvent({
+    seq: 1,
+    instanceId: "A",
+    isLeader: true,
+    at: 1000,
+  });
+  bad.timestamp = "not-a-date";
+  const good = leadershipEvent({
+    seq: 2,
+    instanceId: "B",
+    isLeader: false,
+    at: 1500,
+  });
+  const result = buildLeadership([bad, good]);
+  assert.deepEqual(result, [
+    { instanceId: "B", isLeader: false, lastSeen: 1500 },
+  ]);
+});
+
+test("buildLeadership returns an empty array for no leadership frames", () => {
+  assert.deepEqual(buildLeadership([]), []);
+});
+
+test("buildLeadership prunes a zombie instance whose frame aged out of the window", () => {
+  // Simulates the trimmed event window: the dead instance's frame is gone, so
+  // only the survivor's frame remains in the input. The reduction therefore
+  // never re-surfaces the zombie instanceId.
+  const events = [
+    leadershipEvent({
+      seq: 9,
+      instanceId: "survivor",
+      isLeader: true,
+      at: 5000,
+    }),
+  ];
+  const result = buildLeadership(events);
+  assert.deepEqual(
+    result.map((i) => i.instanceId),
+    ["survivor"],
+  );
+});
+
+// --- filterStaleInstances ---
+
+test("filterStaleInstances drops instances past the stale threshold", () => {
+  const now = 100_000;
+  const fresh = { instanceId: "fresh", isLeader: true, lastSeen: now - 1000 };
+  const stale = {
+    instanceId: "stale",
+    isLeader: false,
+    lastSeen: now - LEADERSHIP_STALE_MS - 1,
+  };
+  const result = filterStaleInstances([fresh, stale], now);
+  assert.deepEqual(result, [fresh]);
+});
+
+test("filterStaleInstances keeps an instance exactly at the threshold", () => {
+  const now = 100_000;
+  const boundary = {
+    instanceId: "boundary",
+    isLeader: true,
+    lastSeen: now - LEADERSHIP_STALE_MS,
+  };
+  assert.deepEqual(filterStaleInstances([boundary], now), [boundary]);
+});
+
+test("filterStaleInstances treats a NaN lastSeen as stale", () => {
+  const now = 100_000;
+  const nan = { instanceId: "nan", isLeader: true, lastSeen: Number.NaN };
+  // now - NaN === NaN, and `NaN <= threshold` is false, so it is excluded.
+  assert.deepEqual(filterStaleInstances([nan], now), []);
+});
+
+// --- selectFreshestLeader ---
+
+test("selectFreshestLeader returns null when no instance leads", () => {
+  const instances = [
+    { instanceId: "A", isLeader: false, lastSeen: 1000 },
+    { instanceId: "B", isLeader: false, lastSeen: 2000 },
+  ];
+  assert.equal(selectFreshestLeader(instances), null);
+});
+
+test("selectFreshestLeader picks the freshest among multiple leaders", () => {
+  // The transient two-leader window after a crash: the dead leader's stale
+  // isLeader:true and the survivor's fresh one coexist. Freshest wins.
+  const dead = { instanceId: "dead", isLeader: true, lastSeen: 1000 };
+  const survivor = { instanceId: "survivor", isLeader: true, lastSeen: 9000 };
+  assert.equal(selectFreshestLeader([dead, survivor]), survivor);
+});
+
+test("selectFreshestLeader ignores non-leaders even if fresher", () => {
+  const leader = { instanceId: "leader", isLeader: true, lastSeen: 1000 };
+  const followerFresher = {
+    instanceId: "follower",
+    isLeader: false,
+    lastSeen: 9000,
+  };
+  assert.equal(selectFreshestLeader([leader, followerFresher]), leader);
+});
+
+test("selectFreshestLeader returns null for an empty list", () => {
+  assert.equal(selectFreshestLeader([]), null);
+});

--- a/desktop/src/features/agents/ui/leadershipHelpers.ts
+++ b/desktop/src/features/agents/ui/leadershipHelpers.ts
@@ -1,0 +1,102 @@
+import type { ObserverEvent } from "./agentSessionTypes";
+
+/** Per-window-instance leadership state derived from `leadership_status` frames. */
+export type InstanceLeadership = {
+  instanceId: string;
+  isLeader: boolean;
+  lastSeen: number; // epoch ms — Date.parse(event.timestamp)
+};
+
+export const LEADERSHIP_EVENT_KIND = "leadership_status";
+
+/**
+ * An instance is stale once it has missed 3 consecutive 5s emit ticks. A
+ * surviving instance re-emits within 5s, so 15s tolerates a single dropped
+ * relay frame without the badge flickering.
+ */
+export const LEADERSHIP_STALE_MS = 15_000;
+
+/**
+ * Narrows the untrusted `unknown` payload of a `leadership_status` frame.
+ * Harness emits arbitrary JSON (`observer.rs`), so the contents are validated
+ * here at the boundary; malformed frames are dropped rather than producing
+ * `undefined`/`NaN` entries.
+ */
+export function parseLeadershipPayload(
+  payload: unknown,
+): { instanceId: string; isLeader: boolean } | null {
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  if (
+    typeof record.instanceId !== "string" ||
+    typeof record.isLeader !== "boolean"
+  ) {
+    return null;
+  }
+  return { instanceId: record.instanceId, isLeader: record.isLeader };
+}
+
+/**
+ * Reduces an agent's observer events to the latest `leadership_status` frame
+ * per `instanceId`. `events` must be sorted ascending (the store keeps
+ * `eventsByAgent` sorted by `compareObserverEvents`), so a simple
+ * last-write-wins walk in iteration order is correct — no comparator needed.
+ *
+ * Instances whose latest frame fell out of the trimmed event window are
+ * naturally absent, so this also prunes zombie instanceIds. Frames that fail
+ * the payload guard or carry an unparseable timestamp are dropped.
+ */
+export function buildLeadership(
+  events: readonly ObserverEvent[],
+): InstanceLeadership[] {
+  const latestByInstance = new Map<string, InstanceLeadership>();
+  for (const event of events) {
+    if (event.kind !== LEADERSHIP_EVENT_KIND) {
+      continue;
+    }
+    const parsed = parseLeadershipPayload(event.payload);
+    if (!parsed) {
+      continue;
+    }
+    const lastSeen = Date.parse(event.timestamp);
+    if (Number.isNaN(lastSeen)) {
+      continue;
+    }
+    latestByInstance.set(parsed.instanceId, { ...parsed, lastSeen });
+  }
+  return [...latestByInstance.values()];
+}
+
+/** Drops instances whose last frame is older than the stale threshold. */
+export function filterStaleInstances(
+  instances: readonly InstanceLeadership[],
+  now: number,
+): InstanceLeadership[] {
+  return instances.filter(
+    (instance) => now - instance.lastSeen <= LEADERSHIP_STALE_MS,
+  );
+}
+
+/**
+ * The instance to surface as leader: the freshest (`max(lastSeen)`) among
+ * those reporting `isLeader`. After a leader window crashes, the survivor's
+ * `isLeader: true` and the dead window's stale `isLeader: true` coexist for up
+ * to one stale window; picking the freshest converges to the survivor without
+ * a "contested" UI state. Returns null when no instance currently leads.
+ */
+export function selectFreshestLeader(
+  instances: readonly InstanceLeadership[],
+): InstanceLeadership | null {
+  let leader: InstanceLeadership | null = null;
+  for (const instance of instances) {
+    if (!instance.isLeader) {
+      continue;
+    }
+    if (!leader || instance.lastSeen > leader.lastSeen) {
+      leader = instance;
+    }
+  }
+  return leader;
+}

--- a/desktop/src/features/agents/ui/useObserverEvents.ts
+++ b/desktop/src/features/agents/ui/useObserverEvents.ts
@@ -2,10 +2,12 @@ import * as React from "react";
 
 import {
   ensureRelayObserverSubscription,
+  getAgentLeadership,
   getAgentObserverSnapshot,
   getAgentTranscript,
   subscribeAgentObserverStore,
 } from "@/features/agents/observerRelayStore";
+import type { InstanceLeadership } from "@/features/agents/observerRelayStore";
 import type { TranscriptItem } from "./agentSessionTypes";
 
 // Stable subscribe reference shared by all useSyncExternalStore hooks.
@@ -40,6 +42,18 @@ export function useAgentTranscript(
 ): TranscriptItem[] {
   const getSnapshot = React.useCallback(
     () => getAgentTranscript(agentPubkey, enabled),
+    [agentPubkey, enabled],
+  );
+
+  return React.useSyncExternalStore(subscribeToStore, getSnapshot);
+}
+
+export function useAgentLeadership(
+  enabled: boolean,
+  agentPubkey?: string | null,
+): InstanceLeadership[] {
+  const getSnapshot = React.useCallback(
+    () => getAgentLeadership(agentPubkey, enabled),
     [agentPubkey, enabled],
   );
 

--- a/desktop/src/shared/api/agentControl.ts
+++ b/desktop/src/shared/api/agentControl.ts
@@ -11,3 +11,18 @@ export async function cancelManagedAgentTurn(
   });
   return { status: "sent" };
 }
+
+// Best-effort cooperative-steal request. The harness gates its `control_result`
+// ack on a successful lock acquire, so this ack only means "frame sent" — the
+// `leadership_status` stream remains the source of truth for who actually
+// leads. The UI must not optimistically flip on this return value.
+export async function claimManagedAgentLeadership(
+  pubkey: string,
+  targetInstanceId: string,
+): Promise<{ status: "sent" }> {
+  await sendAgentObserverControl(pubkey, {
+    type: "claim_leadership",
+    targetInstanceId,
+  });
+  return { status: "sent" };
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -8,6 +8,7 @@ import { relayClient } from "@/shared/api/relayClient";
 import type { ConnectionState } from "@/shared/api/relayClientShared";
 import type { RelayEvent } from "@/shared/api/types";
 import { syncAgentTurnsFromEvents } from "@/features/agents/activeAgentTurnsStore";
+import { seedLeadershipForTest } from "@/features/agents/observerRelayStore";
 import {
   CUSTOM_EMOJI_SET_D_TAG,
   KIND_EMOJI_SET,
@@ -652,6 +653,10 @@ declare global {
       agentPubkey: string;
       channelId: string;
       turnId: string;
+    }) => void;
+    __BUZZ_E2E_SEED_LEADERSHIP__?: (input: {
+      agentPubkey: string;
+      instances: { instanceId: string; isLeader: boolean }[];
     }) => void;
     __BUZZ_E2E_EMIT_MOCK_READ_STATE__?: (input: {
       clientId: string;
@@ -6338,6 +6343,9 @@ export function maybeInstallE2eTauriMocks() {
         payload: null,
       },
     ]);
+  };
+  window.__BUZZ_E2E_SEED_LEADERSHIP__ = ({ agentPubkey, instances }) => {
+    seedLeadershipForTest(agentPubkey, instances);
   };
   const meshNodeStatus = (
     state: "off" | "running",

--- a/desktop/tests/e2e/leadership-screenshots.spec.ts
+++ b/desktop/tests/e2e/leadership-screenshots.spec.ts
@@ -1,0 +1,188 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const SHOTS = "test-results/leadership";
+
+// Mock agent pubkeys (distinct from the relay agents seeded by default).
+const AGENT_PAUL = "aa".repeat(32);
+const AGENT_DUNCAN = "bb".repeat(32);
+
+type LeadershipInstance = { instanceId: string; isLeader: boolean };
+
+async function waitForBridge(page: import("@playwright/test").Page) {
+  await page.waitForFunction(
+    () =>
+      typeof (window as Window & { __BUZZ_E2E_SEED_LEADERSHIP__?: unknown })
+        .__BUZZ_E2E_SEED_LEADERSHIP__ === "function",
+    null,
+    { timeout: 10_000 },
+  );
+}
+
+async function openAgentsView(page: import("@playwright/test").Page) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await waitForBridge(page);
+  await page.getByTestId("open-agents-view").click();
+  await expect(page.getByTestId("unified-agents-groups")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+// The freshest-leader rule selects max(lastSeen), tie-broken by seq. The seed
+// hook seeds in array order with a monotonic seq, so list the intended leader
+// LAST to make selection deterministic even when timestamps collide at ms.
+async function seedLeadership(
+  page: import("@playwright/test").Page,
+  agentPubkey: string,
+  instances: LeadershipInstance[],
+) {
+  await page.evaluate(
+    ({ pubkey, frames }) => {
+      const win = window as Window & {
+        __BUZZ_E2E_SEED_LEADERSHIP__?: (input: {
+          agentPubkey: string;
+          instances: { instanceId: string; isLeader: boolean }[];
+        }) => void;
+      };
+      win.__BUZZ_E2E_SEED_LEADERSHIP__?.({
+        agentPubkey: pubkey,
+        instances: frames,
+      });
+    },
+    { pubkey: agentPubkey, frames: instances },
+  );
+}
+
+const MANAGED_AGENTS = [
+  {
+    pubkey: AGENT_PAUL,
+    name: "Paul",
+    status: "running" as const,
+    channelNames: ["general", "engineering"],
+  },
+  {
+    pubkey: AGENT_DUNCAN,
+    name: "Duncan",
+    status: "running" as const,
+    channelNames: ["general", "design"],
+  },
+];
+
+async function openLeadershipSubmenu(
+  page: import("@playwright/test").Page,
+  agentPubkey: string,
+) {
+  await page.getByTestId(`managed-agent-actions-${agentPubkey}`).click();
+  const submenuTrigger = page.getByRole("menuitem", { name: "Leadership" });
+  await expect(submenuTrigger).toBeVisible();
+  await submenuTrigger.hover();
+  // Settle the submenu open animation before capture.
+  await submenuTrigger.evaluate((el) =>
+    Promise.all(
+      el
+        .closest("[data-state]")
+        ?.getAnimations()
+        .map((a) => a.finished) ?? [],
+    ),
+  );
+}
+
+test.describe("leadership UI screenshots", () => {
+  test.use({ viewport: { width: 1280, height: 720 } });
+
+  test("01 — single instance shows Leader badge, no submenu", async ({
+    page,
+  }) => {
+    await installMockBridge(page, { managedAgents: MANAGED_AGENTS });
+    await openAgentsView(page);
+
+    await seedLeadership(page, AGENT_PAUL, [
+      { instanceId: "4821-1718600000000000", isLeader: true },
+    ]);
+
+    const row = page.getByTestId(`managed-agent-${AGENT_PAUL}`);
+    await expect(row).toContainText("Leader", { timeout: 5_000 });
+
+    await page.getByTestId(`managed-agent-actions-${AGENT_PAUL}`).click();
+    await expect(
+      page.getByRole("menuitem", { name: "Leadership" }),
+    ).toHaveCount(0);
+    await page.keyboard.press("Escape");
+
+    await page.getByTestId("unified-agents-groups").screenshot({
+      path: `${SHOTS}/01-single-instance-leader.png`,
+    });
+  });
+
+  test("02 — multi-instance badge reflects the freshest leader", async ({
+    page,
+  }) => {
+    await installMockBridge(page, { managedAgents: MANAGED_AGENTS });
+    await openAgentsView(page);
+
+    // Leader seeded last → highest seq → wins the freshest-leader tie-break.
+    await seedLeadership(page, AGENT_PAUL, [
+      { instanceId: "4821-1718600000000000", isLeader: false },
+      { instanceId: "5190-1718600100000000", isLeader: false },
+      { instanceId: "6033-1718600200000000", isLeader: true },
+    ]);
+
+    const row = page.getByTestId(`managed-agent-${AGENT_PAUL}`);
+    await expect(row).toContainText("Leader", { timeout: 5_000 });
+
+    await page.getByTestId("unified-agents-groups").screenshot({
+      path: `${SHOTS}/02-multi-instance-badge.png`,
+    });
+  });
+
+  test("03 — leadership submenu lists each instance", async ({ page }) => {
+    await installMockBridge(page, { managedAgents: MANAGED_AGENTS });
+    await openAgentsView(page);
+
+    await seedLeadership(page, AGENT_PAUL, [
+      { instanceId: "4821-1718600000000000", isLeader: false },
+      { instanceId: "5190-1718600100000000", isLeader: false },
+      { instanceId: "6033-1718600200000000", isLeader: true },
+    ]);
+
+    const row = page.getByTestId(`managed-agent-${AGENT_PAUL}`);
+    await expect(row).toContainText("Leader", { timeout: 5_000 });
+
+    await openLeadershipSubmenu(page, AGENT_PAUL);
+    await expect(page.getByRole("menuitem", { name: /Leader/ })).toBeVisible();
+
+    await page.screenshot({
+      path: `${SHOTS}/03-leadership-submenu.png`,
+      clip: { x: 0, y: 0, width: 1280, height: 720 },
+    });
+  });
+
+  test("04 — Make leader action on a non-leader instance", async ({ page }) => {
+    await installMockBridge(page, { managedAgents: MANAGED_AGENTS });
+    await openAgentsView(page);
+
+    await seedLeadership(page, AGENT_PAUL, [
+      { instanceId: "4821-1718600000000000", isLeader: false },
+      { instanceId: "5190-1718600100000000", isLeader: false },
+      { instanceId: "6033-1718600200000000", isLeader: true },
+    ]);
+
+    const row = page.getByTestId(`managed-agent-${AGENT_PAUL}`);
+    await expect(row).toContainText("Leader", { timeout: 5_000 });
+
+    await openLeadershipSubmenu(page, AGENT_PAUL);
+
+    // A non-leader instance's item is the enabled cooperative-steal entry point.
+    const makeLeaderItem = page
+      .getByRole("menuitem")
+      .filter({ hasText: "4821" });
+    await expect(makeLeaderItem).toBeVisible();
+    await makeLeaderItem.hover();
+
+    await page.screenshot({
+      path: `${SHOTS}/04-make-leader-action.png`,
+      clip: { x: 0, y: 0, width: 1280, height: 720 },
+    });
+  });
+});

--- a/docs/nips/NIP-LE.md
+++ b/docs/nips/NIP-LE.md
@@ -64,8 +64,7 @@ The lock lives on the LOCAL filesystem at
 defines no wire format. This is why this NIP touches no relay protocol: leader
 election is entirely local to the machine running the instances.
 
-The lock file contains a JSON object with the following shape
-(provisional — finalized against Phase 2 implementation):
+The lock file contains a JSON object with the following shape:
 
 ```json
 {
@@ -82,35 +81,59 @@ The lock file contains a JSON object with the following shape
   generation fell back to the shared identifier), causing two windows to both
   match the lock and both lead. A correct election identity is unique per
   running window (for example a process-unique value derived at launch).
-- `pid`: the operating-system process id of the leading window.
-- `claimed_at`: when the current leader claimed the lock.
+- `pid`: the operating-system process id of the leading window. Read by the
+  acquire path to detect a dead leader (dead-pid takeover); informational to the
+  read side.
+- `claimed_at`: when the current leader claimed the lock. Rewritten by the
+  leader on every refresh tick, and read by the acquire path to detect a stale
+  (abandoned) claim whose pid has been recycled by an unrelated process (see
+  Claim/Steal Semantics); informational to the read side.
 
 Only `instance_id` is significant to the read side; `pid` and `claimed_at` are
-informational, written by the Phase-2 acquire path and ignored when deciding
+informational to it, written by the acquire path and ignored when deciding
 leadership.
 
 An instance is the leader for an agent identity iff a lock file exists and its
 `instance_id` equals that instance's own election identity. A malformed or
 unparseable lock file MUST fail safe to leader, preserving solo-dev behavior.
 An absent or unreadable lock file (permission error, or a partial read while
-another instance is mid-rewrite) likewise fails safe to leader. Because the read
-side is unguarded (acquire/steal `flock` is Phase 2), a concurrent rewrite read as
+another instance is mid-rewrite) likewise fails safe to leader. The read side is
+deliberately unguarded (it takes no `flock`), so a concurrent rewrite read as
 malformed can briefly produce a duplicate responder; this self-heals on the next
 refresh (≤5s, see below) and is the intended trade — a transient duplicate beats
 silencing the only responder.
 
 Leadership changes (claim, release, failover) take effect within a bounded refresh
 interval of 5 seconds: each instance re-reads its leader lock(s) every 5s, so a
-stale-cache window after a leadership change is capped at that interval. Phase 2
-MUST NOT regress this bound.
+stale-cache window after a leadership change is capped at that interval. The
+refresh also re-attempts the claim, so a survivor takes over a dead leader's lock
+within the same bound.
 
 Acquire and steal MUST be `flock`-guarded to close the read-check-write TOCTOU
-window between two instances racing to claim or steal the same lock.
+window between two instances racing to claim or steal the same lock: the writer
+holds an exclusive `flock` across the read-decide-write sequence so at most one
+racer wins.
 
 ## Claim/Steal Semantics
 
-Ownership is explicit and sticky to a window: a window claims an agent (via the
-agent sidebar menu) and remains its leader until the lock is released or stolen.
+Claim is **auto-on-launch plus explicit re-claim**. An instance self-elects at
+startup: it acquires the lock if it is unowned (absent, released, held by a
+dead pid, or held by a stale claim whose pid was recycled — see below), and
+otherwise runs as an observer. The first instance up for an agent key leads; a
+later instance under the same key observes. On graceful shutdown an instance
+releases its lock so a co-located sibling can take over without waiting out the
+dead-pid failover window. An explicit re-claim gesture (the agent sidebar menu)
+layers on top, letting a chosen window take ownership; both paths share one writer.
+
+Failover MUST tolerate pid recycling. A leader that crashes without releasing
+leaves a lock whose `pid` the OS may later reuse for an unrelated, long-lived
+process; a bare pid-liveness probe would then read the recycled pid as the
+original leader and never take over, wedging the agent leaderless. The acquire
+path therefore treats a claim as takeable when its pid is dead **or** its
+`claimed_at` is older than a staleness bound that comfortably exceeds the 5s
+refresh interval (e.g. 10s). A live leader rewrites `claimed_at` on every refresh
+tick, so only an abandoned claim ages past the bound — distinguishing a recycled
+pid from a genuinely active leader without evicting the latter.
 
 Hard-steal: claiming an agent in window B immediately aborts window A's
 in-flight turn. The abort reuses NIP-AO's `cancel_turn` control frame

--- a/docs/nips/NIP-LE.md
+++ b/docs/nips/NIP-LE.md
@@ -135,6 +135,57 @@ refresh interval (e.g. 10s). A live leader rewrites `claimed_at` on every refres
 tick, so only an abandoned claim ages past the bound — distinguishing a recycled
 pid from a genuinely active leader without evicting the latter.
 
+### Cooperative Steal (Manual Leadership Transfer)
+
+A deliberate steal — initiated from the desktop sidebar UI — uses a
+**cooperative** mechanism: the current leader voluntarily stands down rather than
+being forcibly evicted. This preserves the split-brain guard (`lock_is_takeable`)
+that prevents two leaders from coexisting.
+
+**Stand-down primitive.** When the current leader receives a `claim_leadership`
+control frame targeting a different instance, it enters *stand-down*: a state
+that suppresses `acquire()` (returns false without touching the lock file) until
+either `resume()` is called or a timeout expires. The leader then releases its
+lock, making it free for the target.
+
+**Timeout.** Stand-down auto-expires after 10 seconds (2× the 5s refresh tick).
+This bounds the zero-leader window: if the target instance crashes or fails to
+acquire, the old leader resumes and re-claims on its next tick. The worst case
+is a brief gap with no leader (bounded, self-healing) — never a split-brain.
+
+**Handoff sequence:**
+
+1. Desktop sends a `claim_leadership` control frame (NIP-AO kind 24200) with
+   `{ "type": "claim_leadership", "targetInstanceId": "<target>" }`.
+2. All co-located instances receive the broadcast.
+3. The **current leader** (non-target): calls `stand_down()` then `release()`.
+   Its next refresh tick's `acquire()` returns false (standing down), preventing
+   re-grab.
+4. The **target instance** (match): calls `acquire()`. If the lock is now free
+   (old leader released), it succeeds and emits a `control_result` with
+   `status: "claimed"`. If the lock is not yet free (race — old leader hasn't
+   processed the frame yet), it does nothing; its next 5s refresh tick will
+   succeed once the old leader stands down.
+5. **Other observers** (non-target, non-leader): ignore the frame.
+
+**Failure direction.** Cooperative steal never bypasses the live-leader guard.
+The worst case is zero leaders briefly (stand-down entered but target didn't
+acquire), which self-heals via the 10s timeout. This is preferable to force-steal
+which would risk two leaders briefly.
+
+### Scope Boundary
+
+Leader election is **single-host only**. The lock file lives at
+`~/.buzz/leader-locks/<pubkey>.lock` — a local filesystem artifact. Instances on
+different machines have different `~/.buzz/` directories and cannot see each
+other's locks.
+
+The `claim_leadership` control frame (sent via the relay) reaches all subscribed
+instances regardless of host, but the `acquire()` that follows only contends with
+co-located processes sharing the same lock file. Cross-machine coordination
+(relay-mediated lock or consensus) is a separate future change, explicitly out of
+scope.
+
 Hard-steal: claiming an agent in window B immediately aborts window A's
 in-flight turn. The abort reuses NIP-AO's `cancel_turn` control frame
 (kind 24200); this NIP does not define a separate cancel mechanism. See NIP-AO

--- a/docs/nips/NIP-LE.md
+++ b/docs/nips/NIP-LE.md
@@ -1,0 +1,117 @@
+NIP-LE
+======
+
+Leader Election (Shared-Identity Multi-Instance)
+------------------------------------------------
+
+`draft` `optional`
+
+This NIP defines a client-side, local-filesystem convention by which multiple
+instances running under a single shared agent identity elect exactly one
+*prompter* (leader), so that a mention fanned out to every instance produces a
+single agent response.
+
+## Motivation
+
+When several Buzz client instances run with the same agent keypair, the relay
+correctly fans every event addressed to that key out to all connected instances
+(per NIP-01). Without coordination, every instance promotes the event to an
+agent prompt and every instance responds — duplicating work and producing
+duplicate replies under one identity.
+
+This commonly arises in development: a packaged build (DMG) and one or more
+`just staging` builds from in-progress worktrees may run concurrently, all
+sharing the developer's agent identities.
+
+This NIP defines a minimal coordination layer that elects a single prompter per
+agent identity without any relay-side logic and without defining a wire format.
+
+## Non-Goals
+
+This NIP does not define any Nostr event kind or tag.
+This NIP does not define relay-side coordination.
+This NIP does not define a cancel mechanism — hard-steal reuses NIP-AO's
+`cancel_turn` control frame.
+This NIP does not define the durable election identity source; it requires only
+that the identity be per-window-unique (see The Lock Contract).
+
+## The Invariant
+
+A single agent identity MAY have N subscribed instances but MUST have exactly
+one *prompter* (the leader).
+
+Non-leader instances MUST subscribe to and render the full conversation — the
+message queue stays ungated so the UI displays all messages identically to the
+leader. Non-leader instances MUST suppress:
+
+- (a) the prompt/dispatch path — they do not promote queued events to agent
+  prompts; and
+- (b) pre-dispatch side-effects — specifically the `👀` acknowledgement reaction,
+  which fires at queue-acceptance time, before dispatch; and
+- (c) the autonomous heartbeat prompt path — the periodic self-prompt that, when
+  enabled, has the agent act on the wire (send messages, approve workflows);
+  non-leaders MUST NOT fire it, for the same duplicate-actor reason as (a).
+
+Fail-safe: if no lock exists for an agent identity, every instance is a leader.
+This is the single-instance / solo-dev default and is byte-unchanged from
+behavior prior to this NIP — a solo developer has exactly one instance, which
+leads unconditionally.
+
+## The Lock Contract
+
+The lock lives on the LOCAL filesystem at
+`~/.buzz/leader-locks/<agent-pubkey-hex>.lock`. It is NOT a Nostr event and
+defines no wire format. This is why this NIP touches no relay protocol: leader
+election is entirely local to the machine running the instances.
+
+The lock file contains a JSON object with the following shape
+(provisional — finalized against Phase 2 implementation):
+
+```json
+{
+  "instance_id": "<per-window-unique election id>",
+  "pid": 12345,
+  "claimed_at": "<iso8601 or unix timestamp>"
+}
+```
+
+- `instance_id`: the identity of the leading window. It MUST be a
+  per-window-unique election identity. The Tauri bundle identifier is
+  insufficient — it collides across same-class windows (for example a DMG build
+  and a `just staging` dev build, or two worktree builds whose unique-icon
+  generation fell back to the shared identifier), causing two windows to both
+  match the lock and both lead. A correct election identity is unique per
+  running window (for example a process-unique value derived at launch).
+- `pid`: the operating-system process id of the leading window.
+- `claimed_at`: when the current leader claimed the lock.
+
+An instance is the leader for an agent identity iff a lock file exists and its
+`instance_id` equals that instance's own election identity. A malformed or
+unparseable lock file MUST fail safe to leader, preserving solo-dev behavior.
+
+Acquire and steal MUST be `flock`-guarded to close the read-check-write TOCTOU
+window between two instances racing to claim or steal the same lock.
+
+## Claim/Steal Semantics
+
+Ownership is explicit and sticky to a window: a window claims an agent (via the
+agent sidebar menu) and remains its leader until the lock is released or stolen.
+
+Hard-steal: claiming an agent in window B immediately aborts window A's
+in-flight turn. The abort reuses NIP-AO's `cancel_turn` control frame
+(kind 24200); this NIP does not define a separate cancel mechanism. See NIP-AO
+for the control-frame structure and authorization rules.
+
+## Relationship to other NIPs
+
+NIP-LE references the following NIPs; it does not amend any of them.
+
+- **NIP-OA (Owner Attestation)** — owns the owner↔agent identity model (one owner
+  authorizes one agent key) but is silent on what happens when that same agent
+  key runs in N instances at once. NIP-LE fills that gap.
+- **NIP-RS (Cross-Device Read State Sync)** — precedent for same-user,
+  multi-instance coordination. NIP-RS synchronizes *data* (read position) across
+  instances; NIP-LE coordinates *behavior* (which instance prompts).
+- **NIP-AO (Agent Observability)** — provides the `cancel_turn` control frame
+  (kind 24200) that NIP-LE's hard-steal reuses to abort a displaced window's
+  in-flight turn.

--- a/docs/nips/NIP-LE.md
+++ b/docs/nips/NIP-LE.md
@@ -85,9 +85,24 @@ The lock file contains a JSON object with the following shape
 - `pid`: the operating-system process id of the leading window.
 - `claimed_at`: when the current leader claimed the lock.
 
+Only `instance_id` is significant to the read side; `pid` and `claimed_at` are
+informational, written by the Phase-2 acquire path and ignored when deciding
+leadership.
+
 An instance is the leader for an agent identity iff a lock file exists and its
 `instance_id` equals that instance's own election identity. A malformed or
 unparseable lock file MUST fail safe to leader, preserving solo-dev behavior.
+An absent or unreadable lock file (permission error, or a partial read while
+another instance is mid-rewrite) likewise fails safe to leader. Because the read
+side is unguarded (acquire/steal `flock` is Phase 2), a concurrent rewrite read as
+malformed can briefly produce a duplicate responder; this self-heals on the next
+refresh (≤5s, see below) and is the intended trade — a transient duplicate beats
+silencing the only responder.
+
+Leadership changes (claim, release, failover) take effect within a bounded refresh
+interval of 5 seconds: each instance re-reads its leader lock(s) every 5s, so a
+stale-cache window after a leadership change is capped at that interval. Phase 2
+MUST NOT regress this bound.
 
 Acquire and steal MUST be `flock`-guarded to close the read-check-write TOCTOU
 window between two instances racing to claim or steal the same lock.


### PR DESCRIPTION
## Summary

When multiple Buzz dev instances share an agent keypair, the relay fans every matching event out to all of them (NIP-01) and each instance prompts its agent — duplicate replies for a single `@mention`. This adds a per-agent-key *leader lock* so only the leader instance acts autonomously on the wire. Non-leaders still receive and render events (the queue stays ungated for UI) but suppress every path that would emit under the shared identity.

This PR carries the **NIP-LE specification** (`docs/nips/NIP-LE.md`), the **read side** (every instance derives leadership from the lock file), the **writer + auto-claim lifecycle** (the harness self-elects on launch, fails over on leader death, releases on shutdown), and the **desktop leadership UI** (a per-agent leader badge plus a cooperative "Make leader" steal control).

## The invariant

A single agent identity may have N subscribed instances but exactly one *prompter* (the leader). Non-leaders suppress all three surfaces that would otherwise act under the shared key:

- **(a) the prompt/dispatch path** — non-leaders promote nothing queued to a prompt.
- **(b) the pre-dispatch `👀` reaction** — fires at queue-acceptance time, before dispatch, so the dispatch gate alone would let every sharing instance emit a redundant 👀.
- **(c) the autonomous heartbeat prompt path** — the periodic self-prompt that, when enabled, has the agent `buzz messages send` / `buzz workflows approve` on its own; non-leaders must not fire it, or N instances each act for the same key.

Each surface maps 1:1 to a gate in the code. `docs/nips/NIP-LE.md` is the normative spec for this invariant and the lock contract.

## How leadership is decided (read side)

Every instance reads `~/.buzz/leader-locks/<pubkey-hex>.lock` and resolves:

- **absent** lock → leader (solo dev is unaffected — no lock, no suppression)
- **present + `instance_id` matches this process's election id** → leader
- **present + foreign `instance_id`** → observer
- **no election id** → leader (solo CLI with the env unset)
- **unreadable or malformed** → fail safe to leader: any IO error (permission, mid-write truncation) or parse failure resolves to leader, so a corrupt lock never silences the only responder

Status is cached per agent key and refreshed in place by `refresh()`. Leadership is **read-derived, never acquire-derived**: `is_leader` independently reads the file, so an acquire that fails open on an IO error can never force a process to lead next to a live foreign leader.

## How a leader is elected (writer + auto-claim)

The harness self-mints a process-unique election id (`{pid}-{nanos}`) when `BUZZ_INSTANCE_ELECTION_ID` is unset, and honors the env verbatim if set (desktop per-spawn injection). The same id is both written into the lock and used by the read check, so a process's writes match its own reads.

- **Startup** — `acquire(agent_pubkey)`: take an exclusive `flock`, then read-decide-write **under the held lock** so the read→decide→write TOCTOU window is closed. The lock is takeable iff free (absent / empty / malformed), already ours, the owner's pid is dead (`kill(pid, None)` → `ESRCH`), or the owner's `claimed_at` is stale (older than `STALE_CLAIM` = 10s = 2× the refresh). On success it writes `{instance_id, pid, claimed_at}`; a live, fresh foreign owner → observe.
- **Failover** — no new timer. The existing 5s `leader_refresh` tick calls `acquire` before `refresh`, so a leader re-stamps its own `claimed_at` every tick (its claim is always fresher than the bound), and a survivor re-reads a dead-or-stale lock and takes over within 5s.
- **Shutdown** — `release` empties the lock file (never unlinks → no detached-inode race) only if we still own it, so a co-located sibling takes over immediately and a successor's claim is never stomped.

**Dead-pid vs recycled-pid.** The `ESRCH` fast path catches the common crash-without-release case instantly. The `claimed_at` staleness arm is the backstop for the rarer case where the OS recycles the crashed leader's pid onto an unrelated live process before any survivor ticks: the recycled pid reads as alive, but with no live leader re-stamping the claim it ages past the bound and becomes takeable — closing what would otherwise be a permanent leaderless wedge. The only owner the staleness arm can evict is a live-pid process that has missed two consecutive refresh ticks, which requires a full-runtime stall (turns run on a spawned pool, so a normal heavy turn never blocks the refresh) — in which state the leader is non-functional and takeover is correct, self-healing to a transient duplicate at worst.

## Desktop leadership UI

The desktop is the **owner/controller**, not a contending instance. `leadership_status` frames already land in `eventsByAgent` via the owner-wide observer subscription, so the UI is a cached derivation — no new store, no new subscription, no relay change.

- **Leader badge** in `ManagedAgentRow` beside the status — shows when an agent has a live leader instance. Hidden when no live instance reports.
- **Leadership submenu** in the row's `...` dropdown — lists each live instance (truncated `instanceId`, last-seen, leader marker) with a per-instance "Make leader" action. The current leader's item is disabled. Hidden when `<= 1` live instance, so the solo-dev UX is byte-unchanged.
- `leadershipByAgent` is a cached `Map` rebuilt **only** when a `leadership_status` frame appends, mirroring `transcriptByAgent`. `getAgentLeadership` stays a stable map lookup so it satisfies the `useSyncExternalStore` referential-stability contract (a fresh array per `getSnapshot` would render-storm).
- `parseLeadershipPayload` narrows the untrusted `unknown` payload at the boundary; malformed frames are dropped. `lastSeen = Date.parse(event.timestamp)` with `NaN` → drop.
- **Staleness lives in the component, not the store** — the store stays time-independent. The row filters against a `useNow(5000)` clock at a 15s threshold (3 missed 5s ticks), so a crashed leader's badge ages out without a new frame arriving.
- **Freshest-leader rule:** the badge reflects `max(lastSeen)` among instances reporting `isLeader`, dissolving the `<= 15s` transient two-leader window after a crash without a "contested" state.
- **Non-authoritative ack:** `claimManagedAgentLeadership` mirrors `cancelManagedAgentTurn` and returns `{ status: "sent" }`. The UI never optimistically flips — it converges off the `leadership_status` stream.

## Portability

The writer is `#[cfg(unix)]` (`flock` is Unix); `#[cfg(not(unix))]` is an always-leader no-op acquire/release, mirroring the existing `kill_process_group` cfg pattern. Desktop targets macOS/Linux; Windows is not a leader-election target. The `flock` feature is added to the existing `cfg(unix)` `nix` dependency; `claimed_at` parsing reuses the already-present `chrono` workspace dep (Cargo.lock unchanged).

## Election identity

The lock keys on a per-process election identity behind a single named constant (`ELECTION_ID_ENV` = `BUZZ_INSTANCE_ELECTION_ID`). It is **deliberately not** the Tauri bundle identifier (`BUZZ_MANAGED_AGENT`): the bundle id collides across same-class windows (DMG + dev share `xyz.block.buzz.app(.dev)`; a worktree falls back to the shared dev id if `swift generate-dev-icon` fails), which would let two windows both match the lock and both lead. Reaper identity partitions by app-class; election identity must be unique per process.

## What changed

**Harness (`buzz-acp`):**
- **`docs/nips/NIP-LE.md`** (new) — the NIP-LE spec: the exactly-one-prompter invariant (surfaces a/b/c), the local-filesystem lock contract, claim semantics (auto-on-launch acquire-if-unowned **plus** explicit re-claim), the `flock` TOCTOU guard, and dead-pid + stale-claim failover.
- **`crates/buzz-acp/src/leader.rs`** — the `LeaderCheck` trait and `FileLeaderCheck`: the read side (above), plus the writer half — `acquire`/`release`, `lock_is_takeable` (`ours || dead-pid || stale`), `pid_is_alive` (`ESRCH`-only-dead; `EPERM` → alive so a live leader is never stolen from), `claim_is_stale`, and `from_env_or_mint` (honor env if set, else mint `{pid}-{nanos}`).
- **`crates/buzz-acp/src/pool.rs`** — `PromptContext` carries `leader: Arc<dyn LeaderCheck>`.
- **`crates/buzz-acp/src/lib.rs`** — constructs `from_env_or_mint`; auto-`acquire` on startup; re-`acquire` before `refresh` in the 5s `leader_refresh` tick; `release` first in shutdown teardown; gates (a) `dispatch_pending`, (b) the queue-push `👀` `reaction_add`, (c) `dispatch_heartbeat`; emits the `leadership_status` observer frame consumed by the desktop UI.

**Desktop:**
- **`leadershipHelpers.ts`** (new) — pure derivation: `parseLeadershipPayload`, `buildLeadership`, `filterStaleInstances`, `selectFreshestLeader`.
- **`leadershipHelpers.test.mjs`** (new) — 17 behavior tests.
- **`observerRelayStore.ts`** — `leadershipByAgent` cached map, rebuild-on-append, `getAgentLeadership` selector.
- **`agentControl.ts`** — `claimManagedAgentLeadership` sender.
- **`useObserverEvents.ts`** — `useAgentLeadership` hook.
- **`agentUi.ts`** — `truncateInstanceId`.
- **`ManagedAgentRow.tsx`** — leader badge + leadership submenu.
- **`e2eBridge.ts`** + **`observerRelayStore.ts`** — test-only `__BUZZ_E2E_SEED_LEADERSHIP__` hook routing synthetic `leadership_status` frames through the real cached-map rebuild path (production ingest untouched).
- **`leadership-screenshots.spec.ts`** (new) + **`playwright.config.ts`** — E2E screenshot spec, 4 scenarios in the smoke project.

## Tests

**Harness — twenty-one `buzz-acp` unit tests, all behavior-focused.**

- **Reader (6):** absent → leader, self-owned → leader, foreign-owned → observer, malformed → fail-safe leader, no-election-id → leader even with a foreign lock, and `refresh` flips status when the lock changes. Ids are opaque per-window strings (`window-a`/`window-b`) so the suite can't enshrine `bundle-id == election-id`.
- **Writer (11):** unowned-acquire writes self, creates the lock dir when absent, two-writer race yields exactly one winner, dead-pid lock is taken over, live+fresh foreign lock blocks acquire, **recycled-pid-with-stale-claim is taken over** (the failover-stall reproduction — fails without the staleness arm), reacquire-own is idempotent, release frees the lock for another writer, release does not stomp a successor, no-election-id acquire is a no-op (always leader), and an 8-thread barrier-synced concurrent acquire yields exactly one winner (proving `flock` serialization, not just the happy path).
- **Gates (4):** a leader/non-leader pair over the heartbeat gate (c) and a leader/non-leader pair over the dispatch gate (a) — proving each negative test exercises its gate, not a dead path.

`cargo test -p buzz-acp` → 330 passed. `cargo fmt --check` / `cargo clippy --all-targets` clean.

**Desktop:** 17 behavior tests over the pure leadership derivation (guard drops, latest-per-instance, NaN-timestamp drop, zombie prune, stale boundary, NaN-stale, freshest-among-multiple-leaders, the two-leader transient). The store-level referential-stability contract is verified at review (the store imports Tauri bindings that fail under node). `pnpm typecheck` / `pnpm check` clean; `pnpm test` 760/760. The leadership E2E screenshot spec passes 4/4 in the smoke project.
