### PR TITLE
Align channel management panel with profile

### DIFF
--- a/desktop/src/features/channels/ui/ChannelCanvas.tsx
+++ b/desktop/src/features/channels/ui/ChannelCanvas.tsx
@@ -117,15 +117,8 @@ export function ChannelCanvas({
   return (
     <div className="space-y-3">
       {canvasContent ? (
-        <div
-          className="rounded-2xl border border-border/70 bg-muted/20 px-4 py-3"
-          data-testid="channel-canvas-content"
-        >
-          <Markdown
-            channelNames={channelNames}
-            compact
-            content={canvasContent}
-          />
+        <div className="px-1 py-1" data-testid="channel-canvas-content">
+          <Markdown channelNames={channelNames} content={canvasContent} />
         </div>
       ) : (
         <p className="text-sm text-muted-foreground">

--- a/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
@@ -1,14 +1,21 @@
 import {
   Archive,
   ArchiveRestore,
+  BookOpenText,
+  ChevronLeft,
   Copy,
   DoorClosed,
   DoorOpen,
   FileText,
-  Hash,
+  Fingerprint,
+  Eye,
   Lock,
   MessageSquare,
+  Pencil,
+  Radio,
+  Type,
   Users,
+  X,
   Zap,
 } from "lucide-react";
 import * as React from "react";
@@ -16,6 +23,7 @@ import { toast } from "sonner";
 
 import {
   useArchiveChannelMutation,
+  useCanvasQuery,
   useChannelDetailsQuery,
   useChannelMembersQuery,
   useDeleteChannelMutation,
@@ -31,7 +39,6 @@ import {
   formatTtlDuration,
   parseTtlDuration,
 } from "@/features/channels/lib/ephemeralChannel";
-import { CreateWorkflowDialog } from "@/features/workflows/ui/CreateWorkflowDialog";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { useTheme } from "@/shared/theme/ThemeProvider";
@@ -47,18 +54,36 @@ import {
   AlertDialogTrigger,
 } from "@/shared/ui/alert-dialog";
 import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetDescription,
-  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/shared/ui/sheet";
-import { Switch } from "@/shared/ui/switch";
 import { Textarea } from "@/shared/ui/textarea";
 import { ChannelCanvas } from "./ChannelCanvas";
+import {
+  ChannelHero,
+  ChannelQuickAction,
+  CopyFieldRow,
+  FieldGroup,
+  getMarkdownPreviewText,
+  InfoFieldRow,
+  IngressRow,
+  NarrativeField,
+  NarrativeGroup,
+  ToggleRow,
+} from "./ChannelManagementSheetRows";
 
 type ChannelManagementSheetProps = {
   channel: Channel | null;
@@ -69,50 +94,6 @@ type ChannelManagementSheetProps = {
 };
 
 const DEFAULT_EPHEMERAL_TTL_SECONDS = 24 * 60 * 60;
-
-function MetadataPill({
-  icon: Icon,
-  label,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-}) {
-  return (
-    <div className="inline-flex items-center gap-2 rounded-full border border-border/80 bg-muted/40 px-3 py-1 text-xs font-medium text-muted-foreground">
-      <Icon className="h-3.5 w-3.5" />
-      <span>{label}</span>
-    </div>
-  );
-}
-
-function ChannelIdRow({ channelId }: { channelId: string }) {
-  async function handleCopyChannelId() {
-    await navigator.clipboard.writeText(channelId);
-    toast.success("Copied channel ID to clipboard");
-  }
-
-  return (
-    <button
-      className="group flex w-full items-center gap-3 rounded-xl border border-border/70 bg-muted/20 px-3 py-2.5 text-left transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-      data-testid="channel-management-channel-id"
-      onClick={() => {
-        void handleCopyChannelId();
-      }}
-      title="Copy channel ID"
-      type="button"
-    >
-      <div className="min-w-0 flex-1 space-y-1">
-        <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground/70">
-          Channel ID
-        </div>
-        <div className="truncate font-mono text-xs text-muted-foreground">
-          {channelId}
-        </div>
-      </div>
-      <Copy className="h-4 w-4 shrink-0 text-muted-foreground/45 transition-colors group-hover:text-muted-foreground" />
-    </button>
-  );
-}
 
 export function ChannelManagementSheet({
   channel,
@@ -125,8 +106,8 @@ export function ChannelManagementSheet({
   const channelId = channel?.id ?? null;
   const detailsQuery = useChannelDetailsQuery(channelId, open);
   const membersQuery = useChannelMembersQuery(channelId, open);
+  const canvasQuery = useCanvasQuery(channelId, channelId !== null && open);
   const updateChannelDetailsMutation = useUpdateChannelMutation(channelId);
-  const updateChannelLifecycleMutation = useUpdateChannelMutation(channelId);
   const setTopicMutation = useSetChannelTopicMutation(channelId);
   const setPurposeMutation = useSetChannelPurposeMutation(channelId);
   const archiveChannelMutation = useArchiveChannelMutation(channelId);
@@ -148,7 +129,8 @@ export function ChannelManagementSheet({
   const isOwner = selfMember?.role === "owner";
   const canManageChannel =
     selfMember?.role === "owner" || selfMember?.role === "admin";
-  const canEditNarrative = selfMember !== null && detail?.channelType !== "dm";
+  const canEditNarrative =
+    canManageChannel && selfMember !== null && detail?.channelType !== "dm";
   const isArchived =
     detail?.archivedAt !== null && detail?.archivedAt !== undefined;
   const canJoin =
@@ -173,7 +155,10 @@ export function ChannelManagementSheet({
   const [isEphemeralDraft, setIsEphemeralDraft] = React.useState(false);
   const [ttlDraft, setTtlDraft] = React.useState("");
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
-  const [isCreateWorkflowOpen, setIsCreateWorkflowOpen] = React.useState(false);
+  const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false);
+  const [activeView, setActiveView] = React.useState<"summary" | "canvas">(
+    "summary",
+  );
 
   // Sync drafts from server only when the sheet opens or the channel changes —
   // not on every background refetch, which would clobber in-flight edits.
@@ -183,7 +168,8 @@ export function ChannelManagementSheet({
       // Reset on close so the next open re-syncs from server.
       syncedForRef.current = null;
       setIsDeleteDialogOpen(false);
-      setIsCreateWorkflowOpen(false);
+      setIsEditDialogOpen(false);
+      setActiveView("summary");
       return;
     }
     if (!detail) {
@@ -205,6 +191,7 @@ export function ChannelManagementSheet({
     setTtlDraft(
       detail.ttlSeconds !== null ? formatTtlDuration(detail.ttlSeconds) : "",
     );
+    setActiveView("summary");
   }, [detail, open]);
 
   if (!channel) {
@@ -253,22 +240,69 @@ export function ChannelManagementSheet({
     nextVisibility !== currentVisibility ||
     nextTtlSeconds !== currentTtlSeconds;
 
-  function handleSaveLifecycle() {
-    void updateChannelLifecycleMutation.mutateAsync({
-      visibility:
-        nextVisibility !== currentVisibility ? nextVisibility : undefined,
-      ttlSeconds:
-        nextTtlSeconds !== currentTtlSeconds ? nextTtlSeconds : undefined,
-    });
-  }
-
   const resolvedChannel = detail ?? channel;
+  const nameDirty = nameDraft.trim() !== resolvedChannel.name.trim();
+  const descriptionDirty =
+    descriptionDraft.trim() !== resolvedChannel.description.trim();
+  const topicDirty = topicDraft.trim() !== (resolvedChannel.topic ?? "").trim();
+  const purposeDirty =
+    purposeDraft.trim() !== (resolvedChannel.purpose ?? "").trim();
+  const isSavingChannelEdits =
+    updateChannelDetailsMutation.isPending ||
+    setTopicMutation.isPending ||
+    setPurposeMutation.isPending;
+  const hasChannelEditChanges =
+    nameDirty ||
+    descriptionDirty ||
+    lifecycleDirty ||
+    topicDirty ||
+    purposeDirty;
+  const canSaveChannelEdits =
+    nameDraft.trim().length > 0 &&
+    !ttlInvalid &&
+    hasChannelEditChanges &&
+    !isSavingChannelEdits;
+  const canvasContent = canvasQuery.data?.content?.trim() ?? "";
+  const hasCanvas = canvasContent.length > 0;
+  const canvasPreview = hasCanvas
+    ? getMarkdownPreviewText(canvasContent)
+    : undefined;
+  const canOpenCanvas = hasCanvas || canEditNarrative;
+
+  async function handleSaveChannelEdits() {
+    try {
+      if (nameDirty || descriptionDirty || lifecycleDirty) {
+        await updateChannelDetailsMutation.mutateAsync({
+          description: descriptionDirty ? descriptionDraft.trim() : undefined,
+          name: nameDirty ? nameDraft.trim() : undefined,
+          ttlSeconds:
+            nextTtlSeconds !== currentTtlSeconds ? nextTtlSeconds : undefined,
+          visibility:
+            lifecycleDirty && nextVisibility !== currentVisibility
+              ? nextVisibility
+              : undefined,
+        });
+      }
+
+      if (topicDirty) {
+        await setTopicMutation.mutateAsync({ topic: topicDraft.trim() });
+      }
+
+      if (purposeDirty) {
+        await setPurposeMutation.mutateAsync({ purpose: purposeDraft.trim() });
+      }
+
+      setIsEditDialogOpen(false);
+    } catch {
+      // React Query stores mutation errors; keep the dialog open and render them.
+    }
+  }
 
   return (
     <Sheet onOpenChange={handleSheetOpenChange} open={open}>
       <SheetContent
         className={cn(
-          "flex w-full flex-col gap-0 overflow-hidden border-l border-border/80 p-0 shadow-none sm:max-w-xl",
+          "flex w-full flex-col gap-0 overflow-hidden border-l border-border/80 p-0 shadow-none sm:!max-w-[380px] [&>button]:hidden",
           isDark
             ? "bg-background/85 backdrop-blur-xl supports-[backdrop-filter]:bg-background/75"
             : "bg-background",
@@ -278,473 +312,537 @@ export function ChannelManagementSheet({
       >
         <SheetHeader
           className={cn(
-            "relative z-10 space-y-4 px-6 py-6 text-left shadow-none",
+            "relative z-10 min-h-11 flex-row items-center gap-3 space-y-0 border-b border-border/35 px-3 py-1.5 text-left shadow-none",
             isDark
-              ? "bg-background/60 backdrop-blur-xl supports-[backdrop-filter]:bg-background/50"
-              : "bg-background",
+              ? "bg-background/70 backdrop-blur-xl supports-[backdrop-filter]:bg-background/55"
+              : "bg-background/80 backdrop-blur-md supports-[backdrop-filter]:bg-background/70",
           )}
         >
-          <SheetTitle className="pr-8">{channel.name}</SheetTitle>
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            {activeView === "canvas" ? (
+              <Button
+                aria-label="Back to channel"
+                data-testid="channel-management-back"
+                onClick={() => setActiveView("summary")}
+                size="icon"
+                type="button"
+                variant="ghost"
+              >
+                <ChevronLeft />
+              </Button>
+            ) : null}
+            <SheetTitle className="min-w-0 flex-1 translate-y-px truncate text-base font-semibold leading-6 tracking-tight">
+              {activeView === "canvas" ? "Canvas" : "Channel"}
+            </SheetTitle>
+          </div>
+          <SheetClose asChild>
+            <Button
+              aria-label="Close channel management"
+              data-testid="channel-management-close"
+              size="icon"
+              type="button"
+              variant="ghost"
+            >
+              <X />
+            </Button>
+          </SheetClose>
           <SheetDescription className="sr-only">
             Channel settings
           </SheetDescription>
-          <div className="flex flex-wrap items-center gap-2">
-            <MetadataPill
-              icon={
-                channel.channelType === "forum"
-                  ? FileText
-                  : channel.channelType === "dm"
-                    ? MessageSquare
-                    : Hash
-              }
-              label={channel.channelType}
-            />
-            <MetadataPill
-              icon={channel.visibility === "private" ? Lock : DoorOpen}
-              label={channel.visibility}
-            />
-            <MetadataPill icon={Users} label={`${memberCount} members`} />
-            {isArchived ? (
-              <MetadataPill icon={Archive} label="archived" />
-            ) : null}
-          </div>
         </SheetHeader>
 
-        <div className="flex-1 space-y-6 overflow-y-auto bg-background px-6 py-6">
-          <ChannelIdRow channelId={resolvedChannel.id} />
-          {detailsQuery.error instanceof Error ? (
-            <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-              {detailsQuery.error.message}
-            </p>
-          ) : null}
+        <div className="flex-1 overflow-y-auto bg-background px-4 pb-8 pt-4">
+          {activeView === "summary" ? (
+            <div className="space-y-6">
+              <ChannelHero channel={resolvedChannel} />
 
-          {membersQuery.error instanceof Error ? (
-            <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-              {membersQuery.error.message}
-            </p>
-          ) : null}
-
-          {canJoin ? (
-            <div className="space-y-3">
-              <Button
-                data-testid="channel-management-join"
-                disabled={joinChannelMutation.isPending}
-                onClick={() => {
-                  void joinChannelMutation.mutateAsync();
-                }}
-                size="sm"
-                type="button"
-              >
-                <DoorOpen className="h-4 w-4" />
-                {joinChannelMutation.isPending ? "Joining..." : "Join channel"}
-              </Button>
-              {joinChannelMutation.error instanceof Error ? (
-                <p className="text-sm text-destructive">
-                  {joinChannelMutation.error.message}
+              {detailsQuery.error instanceof Error ? (
+                <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  {detailsQuery.error.message}
                 </p>
               ) : null}
-            </div>
-          ) : null}
 
-          <div data-testid="channel-canvas-section">
-            <ChannelCanvas
-              canEdit={canEditNarrative}
-              channelId={channelId}
-              isArchived={isArchived}
-            />
-          </div>
-
-          <form
-            className="space-y-3"
-            onSubmit={(event) => {
-              event.preventDefault();
-              void updateChannelDetailsMutation.mutateAsync({
-                description: descriptionDraft.trim() || undefined,
-                name: nameDraft.trim() || undefined,
-              });
-            }}
-          >
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium" htmlFor="channel-name">
-                Name
-              </label>
-              <Input
-                data-testid="channel-management-name"
-                disabled={
-                  !canManageChannel || updateChannelDetailsMutation.isPending
-                }
-                id="channel-name"
-                onChange={(event) => setNameDraft(event.target.value)}
-                value={nameDraft}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <label
-                className="text-sm font-medium"
-                htmlFor="channel-description"
-              >
-                Description
-              </label>
-              <Textarea
-                className="min-h-24"
-                data-testid="channel-management-description"
-                disabled={
-                  !canManageChannel || updateChannelDetailsMutation.isPending
-                }
-                id="channel-description"
-                onChange={(event) => setDescriptionDraft(event.target.value)}
-                value={descriptionDraft}
-              />
-            </div>
-            <Button
-              data-testid="channel-management-save-details"
-              disabled={
-                !canManageChannel || updateChannelDetailsMutation.isPending
-              }
-              size="sm"
-              type="submit"
-            >
-              {updateChannelDetailsMutation.isPending
-                ? "Saving..."
-                : "Save details"}
-            </Button>
-            {updateChannelDetailsMutation.error instanceof Error ? (
-              <p className="text-sm text-destructive">
-                {updateChannelDetailsMutation.error.message}
-              </p>
-            ) : null}
-          </form>
-
-          {resolvedChannel.channelType !== "dm" ? (
-            <div
-              className="space-y-4"
-              data-testid="channel-management-lifecycle"
-            >
-              <div className="flex items-center justify-between gap-4">
-                <div className="space-y-0.5">
-                  <p className="text-sm font-medium">Private</p>
-                  <p className="text-xs text-muted-foreground">
-                    Only members can find and join this channel.
-                  </p>
-                </div>
-                <Switch
-                  checked={isPrivateDraft}
-                  data-testid="channel-management-private-toggle"
-                  disabled={
-                    !canManageChannel ||
-                    updateChannelLifecycleMutation.isPending
-                  }
-                  onCheckedChange={setIsPrivateDraft}
-                />
-              </div>
-
-              <div className="flex items-center justify-between gap-4">
-                <div className="space-y-0.5">
-                  <p className="text-sm font-medium">Ephemeral</p>
-                  <p className="text-xs text-muted-foreground">
-                    Automatically delete this channel after a set time.
-                  </p>
-                </div>
-                <Switch
-                  checked={isEphemeralDraft}
-                  data-testid="channel-management-ephemeral-toggle"
-                  disabled={
-                    !canManageChannel ||
-                    updateChannelLifecycleMutation.isPending
-                  }
-                  onCheckedChange={setIsEphemeralDraft}
-                />
-              </div>
-
-              {isEphemeralDraft ? (
-                <div className="space-y-1.5">
-                  <label className="text-sm font-medium" htmlFor="channel-ttl">
-                    Timeout
-                  </label>
-                  <Input
-                    aria-invalid={ttlInvalid}
-                    data-testid="channel-management-ttl"
-                    disabled={
-                      !canManageChannel ||
-                      updateChannelLifecycleMutation.isPending
-                    }
-                    id="channel-ttl"
-                    onChange={(event) => setTtlDraft(event.target.value)}
-                    placeholder="e.g. 1d, 12h, 30m"
-                    value={ttlDraft}
-                  />
-                  <p
-                    className={cn(
-                      "text-xs",
-                      ttlInvalid ? "text-destructive" : "text-muted-foreground",
-                    )}
-                  >
-                    {ttlInvalid
-                      ? "Enter a duration like 1d, 12h, or 30m."
-                      : "Defaults to 1d when left empty. Resets the deletion countdown from now whenever changed."}
-                  </p>
-                </div>
+              {membersQuery.error instanceof Error ? (
+                <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  {membersQuery.error.message}
+                </p>
               ) : null}
 
-              <Button
-                data-testid="channel-management-save-lifecycle"
-                disabled={
-                  !canManageChannel ||
-                  updateChannelLifecycleMutation.isPending ||
-                  ttlInvalid ||
-                  !lifecycleDirty
-                }
-                onClick={handleSaveLifecycle}
-                size="sm"
-                type="button"
-              >
-                {updateChannelLifecycleMutation.isPending
-                  ? "Saving..."
-                  : "Save visibility"}
-              </Button>
-            </div>
-          ) : null}
-
-          <form
-            className="space-y-3"
-            onSubmit={(event) => {
-              event.preventDefault();
-              void setTopicMutation.mutateAsync({
-                topic: topicDraft.trim(),
-              });
-            }}
-          >
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium" htmlFor="channel-topic">
-                Topic
-              </label>
-              <Input
-                data-testid="channel-management-topic"
-                disabled={!canEditNarrative || setTopicMutation.isPending}
-                id="channel-topic"
-                onChange={(event) => setTopicDraft(event.target.value)}
-                value={topicDraft}
-              />
-            </div>
-            <Button
-              data-testid="channel-management-save-topic"
-              disabled={!canEditNarrative || setTopicMutation.isPending}
-              size="sm"
-              type="submit"
-              variant="outline"
-            >
-              {setTopicMutation.isPending ? "Saving..." : "Save topic"}
-            </Button>
-            {setTopicMutation.error instanceof Error ? (
-              <p className="text-sm text-destructive">
-                {setTopicMutation.error.message}
-              </p>
-            ) : null}
-          </form>
-
-          <form
-            className="space-y-3"
-            onSubmit={(event) => {
-              event.preventDefault();
-              void setPurposeMutation.mutateAsync({
-                purpose: purposeDraft.trim(),
-              });
-            }}
-          >
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium" htmlFor="channel-purpose">
-                Purpose
-              </label>
-              <Input
-                data-testid="channel-management-purpose"
-                disabled={!canEditNarrative || setPurposeMutation.isPending}
-                id="channel-purpose"
-                onChange={(event) => setPurposeDraft(event.target.value)}
-                value={purposeDraft}
-              />
-            </div>
-            <Button
-              data-testid="channel-management-save-purpose"
-              disabled={!canEditNarrative || setPurposeMutation.isPending}
-              size="sm"
-              type="submit"
-              variant="outline"
-            >
-              {setPurposeMutation.isPending ? "Saving..." : "Save purpose"}
-            </Button>
-            {setPurposeMutation.error instanceof Error ? (
-              <p className="text-sm text-destructive">
-                {setPurposeMutation.error.message}
-              </p>
-            ) : null}
-          </form>
-
-          {canEditNarrative ? (
-            <Button
-              data-testid="channel-management-create-workflow"
-              onClick={() => setIsCreateWorkflowOpen(true)}
-              size="sm"
-              type="button"
-              variant="outline"
-            >
-              <Zap className="h-4 w-4" />
-              Create workflow
-            </Button>
-          ) : null}
-        </div>
-
-        {resolvedChannel.channelType !== "dm" ? (
-          <SheetFooter
-            className={cn(
-              "border-t border-border/80 px-6 py-4 sm:flex-row sm:justify-start sm:space-x-0",
-              isDark
-                ? "bg-background/60 backdrop-blur-xl supports-[backdrop-filter]:bg-background/50"
-                : "bg-background",
-            )}
-            data-testid="channel-management-footer"
-          >
-            <div className="w-full space-y-3">
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-start justify-center gap-6">
+                <ChannelQuickAction
+                  icon={Copy}
+                  label="Copy ID"
+                  onClick={() => {
+                    void navigator.clipboard
+                      .writeText(resolvedChannel.id)
+                      .then(() => toast.success("Copied channel ID"));
+                  }}
+                  testId="channel-management-copy-id-action"
+                />
+                {canJoin ? (
+                  <ChannelQuickAction
+                    active
+                    disabled={joinChannelMutation.isPending}
+                    icon={DoorOpen}
+                    label={
+                      joinChannelMutation.isPending ? "Joining..." : "Join"
+                    }
+                    onClick={() => {
+                      void joinChannelMutation.mutateAsync();
+                    }}
+                    testId="channel-management-join"
+                  />
+                ) : null}
                 {canLeave ? (
-                  <Button
-                    data-testid="channel-management-leave"
+                  <ChannelQuickAction
                     disabled={leaveChannelMutation.isPending}
+                    icon={DoorClosed}
+                    label={
+                      leaveChannelMutation.isPending ? "Leaving..." : "Leave"
+                    }
                     onClick={() => {
                       void leaveChannelMutation.mutateAsync().then(() => {
                         onOpenChange(false);
                       });
                     }}
-                    size="sm"
-                    type="button"
-                    variant="outline"
-                  >
-                    <DoorClosed className="h-4 w-4" />
-                    {leaveChannelMutation.isPending ? "Leaving..." : "Leave"}
-                  </Button>
+                    testId="channel-management-leave"
+                  />
                 ) : null}
-                {isArchived ? (
-                  <Button
-                    data-testid="channel-management-unarchive"
-                    disabled={
-                      !canManageChannel || unarchiveChannelMutation.isPending
-                    }
-                    onClick={() => {
-                      void unarchiveChannelMutation.mutateAsync();
-                    }}
-                    size="sm"
-                    type="button"
-                  >
-                    <ArchiveRestore className="h-4 w-4" />
-                    {unarchiveChannelMutation.isPending
-                      ? "Restoring..."
-                      : "Unarchive"}
-                  </Button>
-                ) : (
-                  <Button
-                    data-testid="channel-management-archive"
-                    disabled={
-                      !canManageChannel || archiveChannelMutation.isPending
-                    }
-                    onClick={() => {
-                      void archiveChannelMutation.mutateAsync();
-                    }}
-                    size="sm"
-                    type="button"
-                    variant="outline"
-                  >
-                    <Archive className="h-4 w-4" />
-                    {archiveChannelMutation.isPending
-                      ? "Archiving..."
-                      : "Archive"}
-                  </Button>
-                )}
-                <div className="flex-1" />
-                {isOwner ? (
-                  <AlertDialog
-                    onOpenChange={handleDeleteDialogOpenChange}
-                    open={isDeleteDialogOpen}
-                  >
-                    <AlertDialogTrigger asChild>
-                      <Button
-                        data-testid="channel-management-delete"
-                        disabled={deleteChannelMutation.isPending}
-                        size="sm"
-                        type="button"
-                        variant="destructive"
-                      >
-                        Delete
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent data-testid="channel-delete-confirmation-dialog">
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Delete channel?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Delete {resolvedChannel.name} from the workspace list.
-                          This action cannot be undone.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      {deleteChannelMutation.error instanceof Error ? (
-                        <p className="text-sm text-destructive">
-                          {deleteChannelMutation.error.message}
-                        </p>
-                      ) : null}
-                      <AlertDialogFooter>
-                        <AlertDialogCancel asChild>
-                          <Button
-                            data-testid="channel-delete-cancel"
-                            disabled={deleteChannelMutation.isPending}
-                            type="button"
-                            variant="outline"
-                          >
-                            Cancel
-                          </Button>
-                        </AlertDialogCancel>
-                        <AlertDialogAction asChild>
-                          <Button
-                            data-testid="channel-delete-confirm"
-                            disabled={deleteChannelMutation.isPending}
-                            onClick={(event) => {
-                              event.preventDefault();
-                              void handleDeleteChannel();
-                            }}
-                            type="button"
-                            variant="destructive"
-                          >
-                            {deleteChannelMutation.isPending
-                              ? "Deleting..."
-                              : "Delete channel"}
-                          </Button>
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
+                {canManageChannel ? (
+                  <ChannelQuickAction
+                    icon={Pencil}
+                    label="Edit"
+                    onClick={() => setIsEditDialogOpen(true)}
+                    testId="channel-management-edit"
+                  />
                 ) : null}
               </div>
+
+              {joinChannelMutation.error instanceof Error ? (
+                <p className="text-center text-sm text-destructive">
+                  {joinChannelMutation.error.message}
+                </p>
+              ) : null}
               {leaveChannelMutation.error instanceof Error ? (
-                <p className="text-sm text-destructive">
+                <p className="text-center text-sm text-destructive">
                   {leaveChannelMutation.error.message}
                 </p>
               ) : null}
-              {archiveChannelMutation.error instanceof Error ? (
-                <p className="text-sm text-destructive">
-                  {archiveChannelMutation.error.message}
-                </p>
+
+              {resolvedChannel.description.trim() ||
+              resolvedChannel.topic?.trim() ||
+              resolvedChannel.purpose?.trim() ? (
+                <NarrativeGroup>
+                  {resolvedChannel.description.trim() ? (
+                    <NarrativeField
+                      icon={FileText}
+                      label="Description"
+                      testId="channel-management-description"
+                      value={resolvedChannel.description.trim()}
+                    />
+                  ) : null}
+                  {resolvedChannel.topic?.trim() ? (
+                    <NarrativeField
+                      icon={MessageSquare}
+                      label="Topic"
+                      testId="channel-management-topic"
+                      value={resolvedChannel.topic.trim()}
+                    />
+                  ) : null}
+                  {resolvedChannel.purpose?.trim() ? (
+                    <NarrativeField
+                      icon={Zap}
+                      label="Purpose"
+                      testId="channel-management-purpose"
+                      value={resolvedChannel.purpose.trim()}
+                    />
+                  ) : null}
+                </NarrativeGroup>
               ) : null}
-              {unarchiveChannelMutation.error instanceof Error ? (
-                <p className="text-sm text-destructive">
-                  {unarchiveChannelMutation.error.message}
-                </p>
+
+              {canOpenCanvas ? (
+                <IngressRow
+                  description={canvasPreview}
+                  icon={BookOpenText}
+                  label="Canvas"
+                  onClick={() => setActiveView("canvas")}
+                  testId="channel-canvas-ingress"
+                  trailing={canvasQuery.isLoading ? "Loading..." : undefined}
+                />
+              ) : null}
+
+              <FieldGroup>
+                <CopyFieldRow
+                  icon={Fingerprint}
+                  label="Channel ID"
+                  testId="channel-management-channel-id"
+                  value={resolvedChannel.id}
+                />
+                <InfoFieldRow
+                  icon={Type}
+                  label="Name"
+                  testId="channel-management-name-row"
+                  value={resolvedChannel.name}
+                />
+                <InfoFieldRow
+                  icon={Radio}
+                  label="Type"
+                  testId="channel-management-type"
+                  value={resolvedChannel.channelType}
+                />
+                <InfoFieldRow
+                  icon={resolvedChannel.visibility === "private" ? Lock : Eye}
+                  label="Visibility"
+                  testId="channel-management-visibility"
+                  value={resolvedChannel.visibility}
+                />
+                <InfoFieldRow
+                  icon={Users}
+                  label="Members"
+                  testId="channel-management-member-count"
+                  value={`${memberCount}`}
+                />
+                {isArchived ? (
+                  <InfoFieldRow
+                    icon={Archive}
+                    label="Status"
+                    testId="channel-management-archived"
+                    value="Archived"
+                  />
+                ) : null}
+                {resolvedChannel.ttlSeconds !== null ? (
+                  <InfoFieldRow
+                    icon={Archive}
+                    label="Ephemeral"
+                    testId="channel-management-ephemeral-row"
+                    value={formatTtlDuration(resolvedChannel.ttlSeconds)}
+                  />
+                ) : null}
+              </FieldGroup>
+
+              {canManageChannel && resolvedChannel.channelType !== "dm" ? (
+                <div className="space-y-2">
+                  <div
+                    className="grid grid-cols-2 gap-2"
+                    data-testid="channel-management-footer"
+                  >
+                    {isArchived ? (
+                      <Button
+                        className="w-full justify-center"
+                        data-testid="channel-management-unarchive"
+                        disabled={
+                          !canManageChannel ||
+                          unarchiveChannelMutation.isPending
+                        }
+                        onClick={() => {
+                          void unarchiveChannelMutation.mutateAsync();
+                        }}
+                        size="sm"
+                        type="button"
+                      >
+                        <ArchiveRestore className="h-4 w-4" />
+                        {unarchiveChannelMutation.isPending
+                          ? "Restoring..."
+                          : "Unarchive"}
+                      </Button>
+                    ) : (
+                      <Button
+                        className="w-full justify-center"
+                        data-testid="channel-management-archive"
+                        disabled={
+                          !canManageChannel || archiveChannelMutation.isPending
+                        }
+                        onClick={() => {
+                          void archiveChannelMutation.mutateAsync();
+                        }}
+                        size="sm"
+                        type="button"
+                        variant="outline"
+                      >
+                        <Archive className="h-4 w-4" />
+                        {archiveChannelMutation.isPending
+                          ? "Archiving..."
+                          : "Archive"}
+                      </Button>
+                    )}
+                    {isOwner ? (
+                      <AlertDialog
+                        onOpenChange={handleDeleteDialogOpenChange}
+                        open={isDeleteDialogOpen}
+                      >
+                        <AlertDialogTrigger asChild>
+                          <Button
+                            className="w-full justify-center"
+                            data-testid="channel-management-delete"
+                            disabled={deleteChannelMutation.isPending}
+                            size="sm"
+                            type="button"
+                            variant="destructive"
+                          >
+                            Delete
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent data-testid="channel-delete-confirmation-dialog">
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>Delete channel?</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              Delete {resolvedChannel.name} from the workspace
+                              list. This action cannot be undone.
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          {deleteChannelMutation.error instanceof Error ? (
+                            <p className="text-sm text-destructive">
+                              {deleteChannelMutation.error.message}
+                            </p>
+                          ) : null}
+                          <AlertDialogFooter>
+                            <AlertDialogCancel asChild>
+                              <Button
+                                data-testid="channel-delete-cancel"
+                                disabled={deleteChannelMutation.isPending}
+                                type="button"
+                                variant="outline"
+                              >
+                                Cancel
+                              </Button>
+                            </AlertDialogCancel>
+                            <AlertDialogAction asChild>
+                              <Button
+                                data-testid="channel-delete-confirm"
+                                disabled={deleteChannelMutation.isPending}
+                                onClick={(event) => {
+                                  event.preventDefault();
+                                  void handleDeleteChannel();
+                                }}
+                                type="button"
+                                variant="destructive"
+                              >
+                                {deleteChannelMutation.isPending
+                                  ? "Deleting..."
+                                  : "Delete channel"}
+                              </Button>
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    ) : null}
+                  </div>
+                  {archiveChannelMutation.error instanceof Error ? (
+                    <p className="text-sm text-destructive">
+                      {archiveChannelMutation.error.message}
+                    </p>
+                  ) : null}
+                  {unarchiveChannelMutation.error instanceof Error ? (
+                    <p className="text-sm text-destructive">
+                      {unarchiveChannelMutation.error.message}
+                    </p>
+                  ) : null}
+                </div>
               ) : null}
             </div>
-          </SheetFooter>
-        ) : null}
+          ) : (
+            <div data-testid="channel-canvas-section">
+              <ChannelCanvas
+                canEdit={canEditNarrative}
+                channelId={channelId}
+                isArchived={isArchived}
+              />
+            </div>
+          )}
+        </div>
       </SheetContent>
 
-      <CreateWorkflowDialog
-        channels={[channel]}
-        onOpenChange={setIsCreateWorkflowOpen}
-        open={isCreateWorkflowOpen}
-      />
+      {canManageChannel ? (
+        <Dialog onOpenChange={setIsEditDialogOpen} open={isEditDialogOpen}>
+          <DialogContent className="max-w-lg overflow-hidden p-0">
+            <div className="flex max-h-[85vh] flex-col">
+              <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
+                <DialogTitle>Edit channel</DialogTitle>
+                <DialogDescription>
+                  Update settings for{" "}
+                  <span className="font-medium">{resolvedChannel.name}</span>.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-6 py-5">
+                <div className="space-y-3">
+                  <div className="space-y-1.5">
+                    <label
+                      className="text-sm font-medium"
+                      htmlFor="channel-name"
+                    >
+                      Name
+                    </label>
+                    <Input
+                      data-testid="channel-management-name"
+                      disabled={isSavingChannelEdits}
+                      id="channel-name"
+                      onChange={(event) => setNameDraft(event.target.value)}
+                      value={nameDraft}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <label
+                      className="text-sm font-medium"
+                      htmlFor="channel-description"
+                    >
+                      Description
+                    </label>
+                    <Textarea
+                      className="min-h-24"
+                      data-testid="channel-management-description"
+                      disabled={isSavingChannelEdits}
+                      id="channel-description"
+                      onChange={(event) =>
+                        setDescriptionDraft(event.target.value)
+                      }
+                      value={descriptionDraft}
+                    />
+                  </div>
+                </div>
+
+                {resolvedChannel.channelType !== "dm" ? (
+                  <div
+                    className="space-y-3"
+                    data-testid="channel-management-lifecycle"
+                  >
+                    <FieldGroup>
+                      <ToggleRow
+                        checked={isPrivateDraft}
+                        description="Only members can find and join this channel."
+                        disabled={isSavingChannelEdits}
+                        label="Private"
+                        onCheckedChange={setIsPrivateDraft}
+                        testId="channel-management-private-toggle"
+                      />
+                      <ToggleRow
+                        checked={isEphemeralDraft}
+                        description="Automatically delete this channel after a set time."
+                        disabled={isSavingChannelEdits}
+                        label="Ephemeral"
+                        onCheckedChange={setIsEphemeralDraft}
+                        testId="channel-management-ephemeral-toggle"
+                      />
+                    </FieldGroup>
+
+                    {isEphemeralDraft ? (
+                      <div className="space-y-1.5">
+                        <label
+                          className="text-sm font-medium"
+                          htmlFor="channel-ttl"
+                        >
+                          Timeout
+                        </label>
+                        <Input
+                          aria-invalid={ttlInvalid}
+                          data-testid="channel-management-ttl"
+                          disabled={isSavingChannelEdits}
+                          id="channel-ttl"
+                          onChange={(event) => setTtlDraft(event.target.value)}
+                          placeholder="e.g. 1d, 12h, 30m"
+                          value={ttlDraft}
+                        />
+                        <p
+                          className={cn(
+                            "text-xs",
+                            ttlInvalid
+                              ? "text-destructive"
+                              : "text-muted-foreground",
+                          )}
+                        >
+                          {ttlInvalid
+                            ? "Enter a duration like 1d, 12h, or 30m."
+                            : "Defaults to 1d when left empty. Resets the deletion countdown from now whenever changed."}
+                        </p>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+
+                {canEditNarrative ? (
+                  <div className="space-y-5">
+                    <div className="space-y-3">
+                      <div className="space-y-1.5">
+                        <label
+                          className="text-sm font-medium"
+                          htmlFor="channel-topic"
+                        >
+                          Topic
+                        </label>
+                        <Input
+                          data-testid="channel-management-topic"
+                          disabled={isSavingChannelEdits}
+                          id="channel-topic"
+                          onChange={(event) =>
+                            setTopicDraft(event.target.value)
+                          }
+                          value={topicDraft}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="space-y-3">
+                      <div className="space-y-1.5">
+                        <label
+                          className="text-sm font-medium"
+                          htmlFor="channel-purpose"
+                        >
+                          Purpose
+                        </label>
+                        <Input
+                          data-testid="channel-management-purpose"
+                          disabled={isSavingChannelEdits}
+                          id="channel-purpose"
+                          onChange={(event) =>
+                            setPurposeDraft(event.target.value)
+                          }
+                          value={purposeDraft}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+
+                {updateChannelDetailsMutation.error instanceof Error ? (
+                  <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {updateChannelDetailsMutation.error.message}
+                  </p>
+                ) : null}
+                {setTopicMutation.error instanceof Error ? (
+                  <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {setTopicMutation.error.message}
+                  </p>
+                ) : null}
+                {setPurposeMutation.error instanceof Error ? (
+                  <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {setPurposeMutation.error.message}
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="flex shrink-0 justify-end gap-2 border-t border-border/60 px-6 py-4">
+                <Button
+                  onClick={() => setIsEditDialogOpen(false)}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  data-testid="channel-management-save-changes"
+                  disabled={!canSaveChannelEdits}
+                  onClick={() => void handleSaveChannelEdits()}
+                  size="sm"
+                  type="button"
+                >
+                  {isSavingChannelEdits ? "Saving..." : "Save changes"}
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
     </Sheet>
   );
 }

--- a/desktop/src/features/channels/ui/ChannelManagementSheetRows.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheetRows.tsx
@@ -1,0 +1,304 @@
+import {
+  ChevronRight,
+  Copy,
+  FileText,
+  Hash,
+  MessageSquare,
+  type LucideIcon,
+} from "lucide-react";
+import type * as React from "react";
+import { toast } from "sonner";
+
+import type { Channel } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
+import { Switch } from "@/shared/ui/switch";
+
+function getChannelIcon(channelType: Channel["channelType"]): LucideIcon {
+  if (channelType === "forum") {
+    return FileText;
+  }
+  if (channelType === "dm") {
+    return MessageSquare;
+  }
+  return Hash;
+}
+
+export function ChannelHero({ channel }: { channel: Channel }) {
+  const Icon = getChannelIcon(channel.channelType);
+
+  return (
+    <div className="flex flex-col items-center gap-3 text-center">
+      <div className="flex h-20 w-20 items-center justify-center rounded-full bg-primary text-primary-foreground">
+        <Icon className="h-8 w-8" />
+      </div>
+      <div className="flex max-w-full flex-col items-center">
+        <h3 className="max-w-full truncate text-xl font-semibold tracking-tight">
+          {channel.name}
+        </h3>
+      </div>
+    </div>
+  );
+}
+
+export function ChannelQuickAction({
+  active,
+  disabled,
+  icon: Icon,
+  label,
+  onClick,
+  testId,
+}: {
+  active?: boolean;
+  disabled?: boolean;
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  testId?: string;
+}) {
+  return (
+    <button
+      className="flex w-16 flex-col items-center gap-2 disabled:cursor-not-allowed disabled:opacity-50"
+      data-testid={testId}
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+    >
+      <span
+        className={cn(
+          "flex h-14 w-14 items-center justify-center rounded-full transition-colors",
+          active
+            ? "bg-foreground text-background hover:bg-foreground/90"
+            : "bg-muted/60 text-foreground hover:bg-muted/80",
+        )}
+      >
+        <Icon className="h-5 w-5" />
+      </span>
+      <span
+        className={cn(
+          "max-w-full truncate text-xs",
+          active ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
+        {label}
+      </span>
+    </button>
+  );
+}
+
+export function FieldGroup({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="overflow-hidden rounded-2xl bg-muted/20">{children}</div>
+  );
+}
+
+export function getMarkdownPreviewText(content: string) {
+  return content
+    .split("\n")
+    .map((line) =>
+      line
+        .trim()
+        .replace(/^#{1,6}\s+/, "")
+        .replace(/^>\s?/, "")
+        .replace(/^[-*+]\s+\[[ xX]\]\s+/, "")
+        .replace(/^[-*+]\s+/, "")
+        .replace(/^\d+\.\s+/, "")
+        .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+        .replace(/`([^`]+)`/g, "$1")
+        .replace(/(\*\*|__)(.*?)\1/g, "$2")
+        .replace(/(\*|_)(.*?)\1/g, "$2")
+        .replace(/~~(.*?)~~/g, "$1")
+        .trim(),
+    )
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function CopyFieldRow({
+  icon: Icon,
+  label,
+  value,
+  testId,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  testId?: string;
+}) {
+  async function handleCopy() {
+    await navigator.clipboard.writeText(value);
+    toast.success(`Copied ${label.toLowerCase()}`);
+  }
+
+  return (
+    <button
+      aria-label={`Copy ${label}`}
+      className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
+      data-testid={testId}
+      onClick={() => {
+        void handleCopy();
+      }}
+      title={`Copy ${label}`}
+      type="button"
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-xs font-medium text-foreground">
+          {label}
+        </span>
+        <span className="mt-0.5 block truncate font-mono text-sm text-muted-foreground">
+          {value}
+        </span>
+      </span>
+      <Copy className="h-4 w-4 shrink-0 text-muted-foreground" />
+    </button>
+  );
+}
+
+export function InfoFieldRow({
+  icon: Icon,
+  label,
+  value,
+  testId,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  testId?: string;
+}) {
+  return (
+    <div
+      className="flex w-full items-center gap-3 px-4 py-3"
+      data-testid={testId}
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </span>
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block text-xs font-medium text-foreground">
+          {label}
+        </span>
+        <span className="mt-0.5 block truncate text-sm text-muted-foreground">
+          {value}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export function NarrativeGroup({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="overflow-hidden rounded-2xl bg-muted/20">{children}</div>
+  );
+}
+
+export function NarrativeField({
+  icon: Icon,
+  label,
+  value,
+  testId,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  testId: string;
+}) {
+  return (
+    <div
+      className="flex w-full items-start gap-3 px-4 py-3"
+      data-testid={testId}
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-xs font-medium text-foreground">
+          {label}
+        </span>
+        <span className="mt-1 block whitespace-pre-wrap text-sm leading-6 text-muted-foreground">
+          {value}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export function IngressRow({
+  description,
+  icon: Icon,
+  label,
+  onClick,
+  testId,
+  trailing,
+}: {
+  description?: string;
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  testId: string;
+  trailing?: string;
+}) {
+  return (
+    <button
+      className="flex w-full items-center gap-3 rounded-2xl bg-muted/20 px-4 py-2 text-left transition-colors hover:bg-muted/40"
+      data-testid={testId}
+      onClick={onClick}
+      type="button"
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-medium text-foreground">
+          {label}
+        </span>
+        {description ? (
+          <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+            {description}
+          </span>
+        ) : null}
+      </span>
+      {trailing ? (
+        <span className="text-sm text-muted-foreground">{trailing}</span>
+      ) : null}
+      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+    </button>
+  );
+}
+
+export function ToggleRow({
+  checked,
+  description,
+  disabled,
+  label,
+  onCheckedChange,
+  testId,
+}: {
+  checked: boolean;
+  description: string;
+  disabled?: boolean;
+  label: string;
+  onCheckedChange: (checked: boolean) => void;
+  testId: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-medium text-foreground">
+          {label}
+        </span>
+        <span className="mt-0.5 block text-xs leading-5 text-muted-foreground">
+          {description}
+        </span>
+      </span>
+      <Switch
+        checked={checked}
+        data-testid={testId}
+        disabled={disabled}
+        onCheckedChange={onCheckedChange}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Refactor the channel management sheet into a profile-style panel with a compact header, hero, quick actions, full-width narrative rows, and clearer metadata rows.
- Move channel editing into a single-save dialog and make canvas management a drill-in view with markdown rendering and preview text.
- Split channel management row helpers into a dedicated component file to keep the sheet under desktop file-size limits.

## Test plan
- `pnpm --dir desktop exec biome check src/features/channels/ui/ChannelManagementSheet.tsx src/features/channels/ui/ChannelManagementSheetRows.tsx src/features/channels/ui/ChannelCanvas.tsx`
- `pnpm --dir desktop check:file-sizes`
- `pnpm --dir desktop typecheck`
- Pre-commit hooks passed
- Pre-push hooks passed