### PR TITLE
Polish desktop visual details

### DIFF
--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -128,6 +128,23 @@ function OnboardingLoadingGate() {
 function WorkspaceQueryProvider({ children }: { children: ReactNode }) {
   const [queryClient] = useState(createBuzzQueryClient);
 
+  useEffect(() => {
+    const e2eWindow = window as Window & {
+      __BUZZ_E2E__?: unknown;
+      __BUZZ_E2E_QUERY_CLIENT__?: typeof queryClient;
+    };
+    if (!e2eWindow.__BUZZ_E2E__) {
+      return;
+    }
+
+    e2eWindow.__BUZZ_E2E_QUERY_CLIENT__ = queryClient;
+    return () => {
+      if (e2eWindow.__BUZZ_E2E_QUERY_CLIENT__ === queryClient) {
+        delete e2eWindow.__BUZZ_E2E_QUERY_CLIENT__;
+      }
+    };
+  }, [queryClient]);
+
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );

--- a/desktop/src/app/AppTopChrome.tsx
+++ b/desktop/src/app/AppTopChrome.tsx
@@ -1,10 +1,15 @@
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  PanelLeftClose,
+  PanelLeftOpen,
+} from "lucide-react";
 
 import { TopbarSearch } from "@/features/search/ui/TopbarSearch";
 import type { Channel, SearchHit } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import { SidebarTrigger, useSidebar } from "@/shared/ui/sidebar";
+import { useOptionalSidebar } from "@/shared/ui/sidebar";
 import { Skeleton } from "@/shared/ui/skeleton";
 
 type AppTopChromeProps = {
@@ -22,7 +27,8 @@ type AppTopChromeProps = {
 };
 
 function GlobalTopDivider() {
-  const { state } = useSidebar();
+  const sidebar = useOptionalSidebar();
+  const state = sidebar?.state ?? "collapsed";
 
   return (
     <div
@@ -52,7 +58,9 @@ function CenterColumnTopbarSearch({
   | "searchFocusRequest"
   | "searchLoading"
 >) {
-  const { isResizing, state } = useSidebar();
+  const sidebar = useOptionalSidebar();
+  const isResizing = sidebar?.isResizing ?? false;
+  const state = sidebar?.state ?? "collapsed";
   const searchClassName =
     "pointer-events-auto w-[220px] max-w-full md:w-[300px] lg:w-[360px] xl:w-[420px] 2xl:w-[480px]";
 
@@ -91,6 +99,28 @@ function CenterColumnTopbarSearch({
 const TOP_CHROME_ICON_BUTTON_CLASS =
   "h-7 w-7 rounded-[4px] text-muted-foreground/70 hover:bg-border/45 hover:text-foreground [&_svg]:size-4";
 
+function TopChromeSidebarTrigger() {
+  const sidebar = useOptionalSidebar();
+
+  return (
+    <Button
+      aria-label="Toggle Sidebar"
+      className={TOP_CHROME_ICON_BUTTON_CLASS}
+      data-sidebar="trigger"
+      disabled={!sidebar}
+      onClick={() => {
+        sidebar?.toggleSidebar();
+      }}
+      size="icon"
+      type="button"
+      variant="ghost"
+    >
+      {sidebar?.open ? <PanelLeftClose /> : <PanelLeftOpen />}
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+}
+
 export function AppTopChrome({
   canGoBack,
   canGoForward,
@@ -113,7 +143,7 @@ export function AppTopChrome({
       />
       <GlobalTopDivider />
       <div className="fixed left-[80px] top-[6px] z-45 flex items-center gap-0.5">
-        <SidebarTrigger className={TOP_CHROME_ICON_BUTTON_CLASS} />
+        <TopChromeSidebarTrigger />
         <Button
           aria-label="Go back"
           className={TOP_CHROME_ICON_BUTTON_CLASS}

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -207,7 +207,7 @@ export function BotActivityComposerAction({
       </PopoverTrigger>
       <PopoverContent
         align={isInline ? "start" : "end"}
-        className="w-64 p-2"
+        className="w-64 p-1"
         onMouseEnter={keepOpen}
         onMouseLeave={closeWithDelay}
         onOpenAutoFocus={(event) => event.preventDefault()}
@@ -224,7 +224,7 @@ export function BotActivityComposerAction({
             return (
               <button
                 className={cn(
-                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+                  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
                   isSelected
                     ? "bg-primary/10 text-primary"
                     : "text-foreground hover:bg-accent hover:text-accent-foreground",

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -11,6 +11,10 @@ import {
 } from "@/shared/ui/dialog";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
+import {
+  MODAL_SEARCH_INPUT_CLASS,
+  MODAL_SEARCH_SHELL_CLASS,
+} from "@/shared/ui/modalSearchStyles";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 
 const BROWSE_CHANNELS_SHORTCUT_HINT = "\u21E7\u2318O";
@@ -272,14 +276,14 @@ export function ChannelBrowserDialog({
             </DialogClose>
           </div>
           <label
-            className="mt-4 flex cursor-text items-center gap-3 rounded-xl border border-input bg-background px-3 py-2.5 shadow-xs transition-colors duration-150 ease-out hover:border-muted-foreground/40 hover:bg-muted/70 focus-within:border-muted-foreground/50 focus-within:bg-muted/70 group/search"
+            className={MODAL_SEARCH_SHELL_CLASS}
             htmlFor="channel-browser-search"
           >
             <Search className="h-4 w-4 shrink-0 text-muted-foreground/55 transition-colors duration-150 ease-out group-hover/search:text-muted-foreground group-focus-within/search:text-foreground" />
             <input
               autoCapitalize="none"
               autoCorrect="off"
-              className="block h-6 min-w-0 flex-1 border-0 bg-transparent p-0 text-sm leading-5 text-muted-foreground/55 shadow-none caret-foreground outline-none transition-colors duration-150 ease-out placeholder:text-muted-foreground/55 group-hover/search:text-muted-foreground group-hover/search:placeholder:text-muted-foreground group-focus-within/search:text-foreground group-focus-within/search:placeholder:text-foreground"
+              className={MODAL_SEARCH_INPUT_CLASS}
               data-testid="channel-browser-search"
               id="channel-browser-search"
               onChange={(event) => {

--- a/desktop/src/features/channels/ui/ChannelMembersBar.tsx
+++ b/desktop/src/features/channels/ui/ChannelMembersBar.tsx
@@ -1,4 +1,4 @@
-import { EllipsisVertical, Plus, Settings2, Users } from "lucide-react";
+import { EllipsisVertical, Settings2, Users } from "lucide-react";
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useHuddle } from "@/features/huddle";
@@ -81,7 +81,7 @@ export function ChannelMembersBar({
     members.find(
       (member) => normalizePubkey(member.pubkey) === normalizedCurrentPubkey,
     ) ?? null;
-  const canAddAgents =
+  const canStartHuddle =
     channel.channelType !== "dm" &&
     channel.archivedAt === null &&
     (channel.visibility === "open" || selfMember !== null);
@@ -119,7 +119,7 @@ export function ChannelMembersBar({
         }
       }}
       renderMode={variant === "compact" ? "menu-item" : "button"}
-      startDisabled={!canAddAgents || isStartingHuddle}
+      startDisabled={!canStartHuddle || isStartingHuddle}
     />
   );
 
@@ -138,16 +138,6 @@ export function ChannelMembersBar({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48" forceMount>
-          <DropdownMenuItem
-            data-testid="channel-add-bot-trigger"
-            disabled={!canAddAgents}
-            onSelect={() => {
-              setIsAddBotOpen(true);
-            }}
-          >
-            <Plus />
-            <span>Add agent</span>
-          </DropdownMenuItem>
           <DropdownMenuItem
             data-testid="channel-members-trigger"
             onSelect={onToggleMembers}
@@ -170,20 +160,6 @@ export function ChannelMembersBar({
       </DropdownMenu>
     ) : (
       <div className="flex items-center gap-[6px]">
-        <Button
-          aria-label="Add agent"
-          data-testid="channel-add-bot-trigger"
-          disabled={!canAddAgents}
-          onClick={() => {
-            setIsAddBotOpen(true);
-          }}
-          size="icon"
-          type="button"
-          variant="outline"
-        >
-          <Plus />
-        </Button>
-
         <Button
           aria-label={`View channel members (${memberCount})`}
           className="h-8 px-2.5"

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -678,7 +678,7 @@ export const ChannelPane = React.memo(function ChannelPane({
           {isNonMemberView ? (
             <div
               data-testid="join-banner"
-              className="flex items-center gap-3 border-t border-border/80 bg-card/50 px-4 py-3"
+              className="flex items-center gap-3 border-t border-border/80 bg-card/50 px-5 py-3"
             >
               <div className="flex min-w-0 flex-1 items-center gap-2 text-sm text-muted-foreground">
                 <Hash className="h-4 w-4 shrink-0" />
@@ -714,6 +714,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                   channelId={activeChannel?.id ?? null}
                   channelName={activeChannel?.name ?? "channel"}
                   channelType={activeChannel?.channelType ?? null}
+                  containerClassName="px-5"
                   disabled={isComposerDisabled}
                   editTarget={mainEditTarget}
                   isSending={isSending}
@@ -737,7 +738,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                   }
                   showTopBorder={false}
                 />
-                <div className="h-7 overflow-visible bg-background px-4 pb-1 pt-0 sm:px-6">
+                <div className="h-7 overflow-visible bg-background px-5 pb-1 pt-0">
                   <div className="flex h-full w-full items-center gap-2 overflow-visible">
                     {hasComposerBotActivity ? (
                       <div className="shrink-0 overflow-visible">

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -77,6 +77,7 @@ import {
 import { useChannelAgentSessions } from "./useChannelAgentSessions";
 import { useChannelProfilePanel } from "./useChannelProfilePanel";
 import { useChannelRouteTarget } from "./useChannelRouteTarget";
+import { useWelcomeInitialUnreadSuppression } from "./useWelcomeInitialUnreadSuppression";
 import type { ChannelScreenProps } from "./ChannelScreen.types";
 
 const HEADER_ACTIONS_COMPACT_BREAKPOINT_PX = 760;
@@ -196,6 +197,8 @@ export function ChannelScreen({
   const [, forceUnreadRender] = React.useReducer((n: number) => n + 1, 0);
   const isActiveChannelForcedUnread =
     !!activeChannelId && forcedUnreadRef.current.has(activeChannelId);
+  const isActiveWelcomeInitialUnreadSuppressed =
+    useWelcomeInitialUnreadSuppression(activeChannelId, forceUnreadRender);
   // Drop the forced-unread flag when the user leaves a channel, so reopening
   // it recomputes a normal marker rather than staying suppressed forever.
   React.useEffect(() => {
@@ -400,21 +403,20 @@ export function ChannelScreen({
     channelId: activeChannelId,
     messages: timelineMessages,
   });
-  // Oldest-unread top-level message + count, derived from the open-time
-  // frontier snapshot above. Drives the "N new messages" pill and the "New"
-  // divider; both stay put even after the open marks the channel read because
-  // openFrontierSeconds is keyed per channel, not on the live marker.
+  // Oldest unread top-level message + count from the open-time frontier.
+  // Keyed per channel so the pill/divider survive the mark-read effect.
   const { firstUnreadMessageId, unreadCount } = React.useMemo(
     () =>
       computeChannelUnreadMarker(
         timelineMessages,
         openFrontierSeconds,
-        isActiveChannelForcedUnread,
+        isActiveChannelForcedUnread || isActiveWelcomeInitialUnreadSuppressed,
         currentPubkey,
       ),
     [
       currentPubkey,
       isActiveChannelForcedUnread,
+      isActiveWelcomeInitialUnreadSuppressed,
       openFrontierSeconds,
       timelineMessages,
     ],

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -39,17 +39,19 @@ import {
 } from "@/shared/ui/dialog";
 import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
+import { cn } from "@/shared/lib/cn";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import {
   MODAL_SEARCH_INPUT_CLASS,
   MODAL_SEARCH_SHELL_CLASS,
 } from "@/shared/ui/modalSearchStyles";
-import { MembersSidebarAgentControls } from "./MembersSidebarAgentControls";
 import { MembersSidebarMemberCard } from "./MembersSidebarMemberCard";
 import { useMembersSidebarActions } from "./useMembersSidebarActions";
 
 const MEMBER_ADD_RESULT_LIMIT = 50;
+const MEMBER_ROW_INSET_DIVIDER_CLASS =
+  "after:pointer-events-none after:absolute after:bottom-0 after:left-[3.75rem] after:right-0 after:h-px after:bg-border/60 after:content-[''] last:after:hidden";
 
 function formatAddCandidateName(user: UserSearchResult) {
   return (
@@ -374,13 +376,7 @@ export function MembersSidebar({
     actionErrorMessage,
     actionNoticeMessage,
     handleLifecycleAction: handleAgentLifecycleAction,
-    handleRemoveAll,
     handleRemoveMember,
-    handleRespawnAll,
-    handleStopAll,
-    hasControllableManagedBots,
-    hasRemovableManagedBots,
-    hasStoppableManagedBots,
     isActionPending,
   } = useMembersSidebarActions({
     channelId,
@@ -542,27 +538,7 @@ export function MembersSidebar({
                 className="h-[min(50vh,24rem)] overflow-y-auto rounded-xl border border-border/70 bg-background/70"
                 data-testid="members-sidebar-people"
               >
-                <SearchResultSectionTitle
-                  action={
-                    hasControllableManagedBots ? (
-                      <MembersSidebarAgentControls
-                        canBulkRemove={hasRemovableManagedBots}
-                        canBulkRespawn={hasControllableManagedBots}
-                        canBulkStop={hasStoppableManagedBots}
-                        disabled={isActionPending || isArchived}
-                        onRemoveAll={() => {
-                          void handleRemoveAll();
-                        }}
-                        onRespawnAll={() => {
-                          void handleRespawnAll();
-                        }}
-                        onStopAll={() => {
-                          void handleStopAll();
-                        }}
-                      />
-                    ) : null
-                  }
-                >
+                <SearchResultSectionTitle>
                   {normalizedSearchQuery
                     ? "Members"
                     : `Members · ${activeMembers.length}`}
@@ -728,7 +704,10 @@ function AddMemberSearchResultRow({
 }) {
   return (
     <div
-      className="group/add-result relative isolate flex min-h-14 w-full items-center gap-3 px-4 py-3.5 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-within:bg-muted/40"
+      className={cn(
+        "group/add-result relative isolate flex min-h-14 w-full items-center gap-3 px-4 py-3.5 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-within:bg-muted/40",
+        MEMBER_ROW_INSET_DIVIDER_CLASS,
+      )}
       data-testid={`channel-user-search-result-${user.pubkey}`}
     >
       <button

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -22,6 +22,7 @@ import type {
   ManagedAgent,
   PresenceStatus,
 } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -52,6 +53,9 @@ type MembersSidebarMemberCardProps = {
   presenceStatus?: PresenceStatus | null;
   profileAvatarUrl?: string | null;
 };
+
+const MEMBER_ROW_INSET_DIVIDER_CLASS =
+  "after:pointer-events-none after:absolute after:bottom-0 after:left-[3.75rem] after:right-0 after:h-px after:bg-border/60 after:content-[''] last:after:hidden";
 
 function formatRoleLabel(member: ChannelMember, memberIsBot: boolean) {
   if (memberIsBot) {
@@ -188,7 +192,10 @@ export function MembersSidebarMemberCard({
 
   return (
     <div
-      className="group/member relative isolate flex min-h-14 items-center gap-3 px-4 py-3.5 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-within:bg-muted/40"
+      className={cn(
+        "group/member relative isolate flex min-h-14 items-center gap-3 px-4 py-3.5 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-within:bg-muted/40",
+        MEMBER_ROW_INSET_DIVIDER_CLASS,
+      )}
       data-testid={`sidebar-member-${member.pubkey}`}
     >
       {onOpenProfile ? (

--- a/desktop/src/features/channels/ui/WelcomeComposerBanner.tsx
+++ b/desktop/src/features/channels/ui/WelcomeComposerBanner.tsx
@@ -324,7 +324,7 @@ export function WelcomeComposerBanner({ state }: WelcomeComposerBannerProps) {
                 : 0,
           }}
           className={cn(
-            "relative z-0 mx-4 -mb-3 flex transform-gpu items-center gap-2 rounded-t-2xl border border-b-0 px-4 pb-5 pt-2.5 text-sm leading-5 backdrop-blur-sm transition-colors will-change-[filter,transform] sm:mx-6",
+            "relative z-0 mx-5 -mb-3 flex transform-gpu items-center gap-2 rounded-t-2xl border border-b-0 px-4 pb-5 pt-2.5 text-sm leading-5 backdrop-blur-sm transition-colors will-change-[filter,transform]",
             state !== "prompt"
               ? "border-emerald-500/30 bg-emerald-500/15 text-foreground"
               : "border-border/60 bg-muted/55 text-muted-foreground",

--- a/desktop/src/features/channels/ui/useWelcomeInitialUnreadSuppression.test.mjs
+++ b/desktop/src/features/channels/ui/useWelcomeInitialUnreadSuppression.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  addWelcomeUnreadSuppressedChannelId,
+  initialWelcomeUnreadSuppressedChannelIds,
+  isWelcomeUnreadSuppressed,
+  removeWelcomeUnreadSuppressedChannelId,
+} from "./useWelcomeInitialUnreadSuppression.ts";
+
+test("initialWelcomeUnreadSuppressedChannelIds includes the pending active channel", () => {
+  const suppressedChannelIds = initialWelcomeUnreadSuppressedChannelIds(
+    "welcome",
+    (channelId) => channelId === "welcome",
+  );
+
+  assert.equal(
+    isWelcomeUnreadSuppressed(suppressedChannelIds, "welcome"),
+    true,
+  );
+  assert.equal(
+    isWelcomeUnreadSuppressed(suppressedChannelIds, "general"),
+    false,
+  );
+});
+
+test("initial welcome suppression survives after storage is consumed", () => {
+  let hasPendingSuppression = true;
+  const suppressedChannelIds = initialWelcomeUnreadSuppressedChannelIds(
+    "welcome",
+    () => hasPendingSuppression,
+  );
+
+  hasPendingSuppression = false;
+
+  assert.equal(
+    isWelcomeUnreadSuppressed(suppressedChannelIds, "welcome"),
+    true,
+  );
+});
+
+test("welcome unread suppression add and remove are channel scoped", () => {
+  const withWelcome = addWelcomeUnreadSuppressedChannelId(new Set(), "welcome");
+  const withBoth = addWelcomeUnreadSuppressedChannelId(withWelcome, "design");
+  const withoutWelcome = removeWelcomeUnreadSuppressedChannelId(
+    withBoth,
+    "welcome",
+  );
+
+  assert.equal(isWelcomeUnreadSuppressed(withoutWelcome, "welcome"), false);
+  assert.equal(isWelcomeUnreadSuppressed(withoutWelcome, "design"), true);
+});

--- a/desktop/src/features/channels/ui/useWelcomeInitialUnreadSuppression.ts
+++ b/desktop/src/features/channels/ui/useWelcomeInitialUnreadSuppression.ts
@@ -1,0 +1,37 @@
+import * as React from "react";
+import {
+  consumePendingWelcomeInitialUnreadSuppression,
+  hasPendingWelcomeInitialUnreadSuppression,
+} from "@/features/onboarding/welcome";
+
+export function useWelcomeInitialUnreadSuppression(
+  activeChannelId: string | null,
+  onSuppressionConsumed: () => void,
+) {
+  const suppressedChannelIdsRef = React.useRef(new Set<string>());
+
+  if (
+    activeChannelId &&
+    hasPendingWelcomeInitialUnreadSuppression(activeChannelId)
+  ) {
+    suppressedChannelIdsRef.current.add(activeChannelId);
+  }
+
+  React.useEffect(() => {
+    const channelId = activeChannelId;
+    if (!channelId) return;
+
+    if (consumePendingWelcomeInitialUnreadSuppression(channelId)) {
+      suppressedChannelIdsRef.current.add(channelId);
+      onSuppressionConsumed();
+    }
+
+    return () => {
+      suppressedChannelIdsRef.current.delete(channelId);
+    };
+  }, [activeChannelId, onSuppressionConsumed]);
+
+  return (
+    !!activeChannelId && suppressedChannelIdsRef.current.has(activeChannelId)
+  );
+}

--- a/desktop/src/features/channels/ui/useWelcomeInitialUnreadSuppression.ts
+++ b/desktop/src/features/channels/ui/useWelcomeInitialUnreadSuppression.ts
@@ -4,34 +4,107 @@ import {
   hasPendingWelcomeInitialUnreadSuppression,
 } from "@/features/onboarding/welcome";
 
+export function initialWelcomeUnreadSuppressedChannelIds(
+  activeChannelId: string | null,
+  hasPendingSuppression = hasPendingWelcomeInitialUnreadSuppression,
+) {
+  const suppressedChannelIds = new Set<string>();
+  if (activeChannelId && hasPendingSuppression(activeChannelId)) {
+    suppressedChannelIds.add(activeChannelId);
+  }
+  return suppressedChannelIds;
+}
+
+export function addWelcomeUnreadSuppressedChannelId(
+  suppressedChannelIds: ReadonlySet<string>,
+  channelId: string,
+) {
+  if (suppressedChannelIds.has(channelId)) {
+    return suppressedChannelIds;
+  }
+
+  const next = new Set(suppressedChannelIds);
+  next.add(channelId);
+  return next;
+}
+
+export function removeWelcomeUnreadSuppressedChannelId(
+  suppressedChannelIds: ReadonlySet<string>,
+  channelId: string,
+) {
+  if (!suppressedChannelIds.has(channelId)) {
+    return suppressedChannelIds;
+  }
+
+  const next = new Set(suppressedChannelIds);
+  next.delete(channelId);
+  return next;
+}
+
+export function isWelcomeUnreadSuppressed(
+  suppressedChannelIds: ReadonlySet<string>,
+  activeChannelId: string | null,
+) {
+  return !!activeChannelId && suppressedChannelIds.has(activeChannelId);
+}
+
 export function useWelcomeInitialUnreadSuppression(
   activeChannelId: string | null,
   onSuppressionConsumed: () => void,
 ) {
-  const suppressedChannelIdsRef = React.useRef(new Set<string>());
+  const [suppressedChannelIds, setSuppressedChannelIds] = React.useState<
+    ReadonlySet<string>
+  >(() => initialWelcomeUnreadSuppressedChannelIds(activeChannelId));
+  const clearTimersRef = React.useRef(new Map<string, number>());
+  const isMountedRef = React.useRef(false);
 
-  if (
-    activeChannelId &&
-    hasPendingWelcomeInitialUnreadSuppression(activeChannelId)
-  ) {
-    suppressedChannelIdsRef.current.add(activeChannelId);
-  }
+  React.useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      for (const timerId of clearTimersRef.current.values()) {
+        window.clearTimeout(timerId);
+      }
+      clearTimersRef.current.clear();
+    };
+  }, []);
+
+  const cancelPendingClear = React.useCallback((channelId: string) => {
+    const timerId = clearTimersRef.current.get(channelId);
+    if (timerId === undefined) return;
+
+    window.clearTimeout(timerId);
+    clearTimersRef.current.delete(channelId);
+  }, []);
 
   React.useEffect(() => {
     const channelId = activeChannelId;
     if (!channelId) return;
 
+    cancelPendingClear(channelId);
+
     if (consumePendingWelcomeInitialUnreadSuppression(channelId)) {
-      suppressedChannelIdsRef.current.add(channelId);
+      setSuppressedChannelIds((current) =>
+        addWelcomeUnreadSuppressedChannelId(current, channelId),
+      );
       onSuppressionConsumed();
     }
 
     return () => {
-      suppressedChannelIdsRef.current.delete(channelId);
-    };
-  }, [activeChannelId, onSuppressionConsumed]);
+      if (!isMountedRef.current) return;
 
-  return (
-    !!activeChannelId && suppressedChannelIdsRef.current.has(activeChannelId)
-  );
+      cancelPendingClear(channelId);
+      const timerId = window.setTimeout(() => {
+        clearTimersRef.current.delete(channelId);
+        if (!isMountedRef.current) return;
+
+        setSuppressedChannelIds((current) =>
+          removeWelcomeUnreadSuppressedChannelId(current, channelId),
+        );
+      }, 0);
+      clearTimersRef.current.set(channelId, timerId);
+    };
+  }, [activeChannelId, cancelPendingClear, onSuppressionConsumed]);
+
+  return isWelcomeUnreadSuppressed(suppressedChannelIds, activeChannelId);
 }

--- a/desktop/src/features/channels/unreadReadMarker.test.mjs
+++ b/desktop/src/features/channels/unreadReadMarker.test.mjs
@@ -13,8 +13,8 @@ function topLevel(id, createdAt) {
 }
 
 // The headline scenario the fix restores: messages arrive while the channel is
-// inactive, the read frontier was captured before them, and on reopen the pill
-// and divider must render. The deleted AppShell effect used to fold those
+// inactive, the read frontier was captured before them, and on reopen the
+// pill and divider must render. The deleted AppShell effect used to fold those
 // just-arrived timestamps into the frontier, hiding them; with it gone the
 // frontier stays below the new messages.
 test("receiveThenReopen_frontierBelowArrivedMessages_showsDivider", () => {

--- a/desktop/src/features/chat/ui/ChatHeader.tsx
+++ b/desktop/src/features/chat/ui/ChatHeader.tsx
@@ -98,7 +98,7 @@ export function ChatHeader({
   const header = (
     <header
       className={cn(
-        "pointer-events-auto relative z-30 flex min-w-0 shrink-0 cursor-default select-none items-center gap-2.5 bg-transparent px-4 transition-[margin,padding] duration-200 ease-linear sm:px-6",
+        "pointer-events-auto relative z-30 flex min-w-0 shrink-0 cursor-default select-none items-center gap-2.5 bg-transparent px-5 transition-[margin,padding] duration-200 ease-linear",
         density === "compact"
           ? belowSystemChrome
             ? "min-h-8 py-1.5"

--- a/desktop/src/features/huddle/HuddleContext.tsx
+++ b/desktop/src/features/huddle/HuddleContext.tsx
@@ -20,33 +20,15 @@ type HuddleJoinInfo = {
 };
 
 type VoiceInputMode = "push_to_talk" | "voice_activity";
-type MicFrequencyBands = {
-  low: number;
-  mid: number;
-  high: number;
-};
 
-type MicBandKey = keyof MicFrequencyBands;
-type MicBandDynamics = {
-  floor: MicFrequencyBands;
-  ceiling: MicFrequencyBands;
-};
-
-const EMPTY_MIC_BANDS: MicFrequencyBands = {
-  low: 0,
-  mid: 0,
-  high: 0,
-};
-
-const MIC_BAND_KEYS: MicBandKey[] = ["low", "mid", "high"];
-const MIC_BAND_CONFIG: Record<
-  MicBandKey,
-  { fromHz: number; toHz: number; gain: number }
-> = {
-  low: { fromHz: 120, toHz: 360, gain: 1.22 },
-  mid: { fromHz: 360, toHz: 1800, gain: 1.18 },
-  high: { fromHz: 1800, toHz: 6200, gain: 1.28 },
-};
+const MIC_ANALYSER_UPDATE_INTERVAL_MS = 33;
+const MIC_INITIAL_NOISE_FLOOR = 0.01;
+const MIC_VOICE_GATE_ON_RMS = 0.018;
+const MIC_VOICE_GATE_OFF_RMS = 0.012;
+const MIC_VOICE_GATE_MARGIN_RMS = 0.012;
+const MIC_LEVEL_ACTIVE_RANGE_RMS = 0.11;
+const MIC_MIN_ACTIVE_LEVEL = 0.18;
+const MIC_LEVEL_ATTACK = 0.58;
 
 function isRedundantHuddlePhaseError(message: string): boolean {
   return /^cannot (?:start|join) huddle: already in phase /i.test(message);
@@ -54,94 +36,6 @@ function isRedundantHuddlePhaseError(message: string): boolean {
 
 function clamp01(value: number): number {
   return Math.min(1, Math.max(0, value));
-}
-
-function binForFrequency(
-  frequency: number,
-  sampleRate: number,
-  fftSize: number,
-  maxBin: number,
-): number {
-  const binWidth = sampleRate / fftSize;
-  return Math.min(maxBin, Math.max(0, Math.floor(frequency / binWidth)));
-}
-
-function averageFrequencyBand(
-  buffer: Uint8Array,
-  startBin: number,
-  endBin: number,
-): number {
-  const start = Math.min(buffer.length - 1, Math.max(0, startBin));
-  const end = Math.min(buffer.length, Math.max(start + 1, endBin));
-  let sum = 0;
-  for (let i = start; i < end; i += 1) {
-    sum += buffer[i];
-  }
-  return sum / ((end - start) * 255);
-}
-
-function shapeMicBand(signal: number, ceiling: number, gain: number): number {
-  if (signal <= 0) return 0;
-  const normalized = (signal * gain) / Math.max(ceiling, 0.012);
-  const compressed = normalized / (normalized + 0.82);
-  return clamp01(0.08 + compressed * 0.72);
-}
-
-function followMicBandFloor(rawValue: number, previousFloor: number): number {
-  const rate = rawValue < previousFloor ? 0.3 : 0.004;
-  return previousFloor + (rawValue - previousFloor) * rate;
-}
-
-function followMicBandCeiling(signal: number, previousCeiling: number): number {
-  const target = Math.max(signal, 0.012);
-  const rate = target > previousCeiling ? 0.16 : 0.12;
-  return previousCeiling + (target - previousCeiling) * rate;
-}
-
-function computeMicFrequencyBands(
-  buffer: Uint8Array,
-  sampleRate: number,
-  fftSize: number,
-  previousDynamics: MicBandDynamics | null,
-): { bands: MicFrequencyBands; dynamics: MicBandDynamics } {
-  const maxBin = buffer.length - 1;
-  const raw = { ...EMPTY_MIC_BANDS };
-  const shaped = { ...EMPTY_MIC_BANDS };
-  const floor = { ...EMPTY_MIC_BANDS };
-  const ceiling = { ...EMPTY_MIC_BANDS };
-
-  for (const key of MIC_BAND_KEYS) {
-    const config = MIC_BAND_CONFIG[key];
-    raw[key] = averageFrequencyBand(
-      buffer,
-      binForFrequency(config.fromHz, sampleRate, fftSize, maxBin),
-      binForFrequency(config.toHz, sampleRate, fftSize, maxBin),
-    );
-    floor[key] =
-      previousDynamics === null
-        ? raw[key]
-        : followMicBandFloor(raw[key], previousDynamics.floor[key]);
-    const signal = Math.max(0, raw[key] - floor[key]);
-    ceiling[key] =
-      previousDynamics === null
-        ? Math.max(signal, 0.012)
-        : followMicBandCeiling(signal, previousDynamics.ceiling[key]);
-    shaped[key] = shapeMicBand(signal, ceiling[key], config.gain);
-  }
-
-  const voiceEnvelope = clamp01(
-    Math.max(shaped.low, shaped.mid, shaped.high) * 0.9 +
-      ((shaped.low + shaped.mid + shaped.high) / 3) * 0.2,
-  );
-
-  return {
-    bands: {
-      low: clamp01(voiceEnvelope * 0.56 + shaped.low * 0.44),
-      mid: clamp01(voiceEnvelope * 0.68 + shaped.mid * 0.34),
-      high: clamp01(voiceEnvelope * 0.5 + shaped.high * 0.5),
-    },
-    dynamics: { floor, ceiling },
-  };
 }
 
 interface HuddleContextValue {
@@ -157,8 +51,6 @@ interface HuddleContextValue {
   micConnected: boolean;
   /** Current mic input level 0–1 (updated via requestAnimationFrame) */
   micLevel: number;
-  /** Low/mid/high mic energy bands for the compact waveform meter */
-  micBands: MicFrequencyBands;
   /** Whether the PTT key is currently held (for UI feedback) */
   pttActive: boolean;
   /** Current voice input mode — push_to_talk or voice_activity */
@@ -213,8 +105,6 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
   const clearHuddleError = React.useCallback(() => setHuddleError(null), []);
   const [micConnected, setMicConnected] = React.useState(false);
   const [micLevel, setMicLevel] = React.useState(0);
-  const [micBands, setMicBands] =
-    React.useState<MicFrequencyBands>(EMPTY_MIC_BANDS);
   /** Whether the PTT key is currently held */
   const [pttActive, setPttActive] = React.useState(false);
   /** Current voice input mode */
@@ -634,44 +524,61 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
 
   // Mic level analyser — drives the voice activity indicator
   React.useEffect(() => {
-    if (!localAudioTrack) {
+    if (!localAudioTrack || !micConnected) {
       setMicLevel(0);
-      setMicBands(EMPTY_MIC_BANDS);
       return;
     }
 
     const ctx = new AudioContext();
     const analyser = ctx.createAnalyser();
-    analyser.fftSize = 256;
-    analyser.smoothingTimeConstant = 0.12;
+    analyser.fftSize = 512;
     const source = ctx.createMediaStreamSource(
       new MediaStream([localAudioTrack]),
     );
     source.connect(analyser);
-    const buf = new Uint8Array(analyser.frequencyBinCount);
+    const buf = new Float32Array(analyser.fftSize);
 
     let raf = 0;
     let lastUpdate = 0;
-    let micBandDynamics: MicBandDynamics | null = null;
+    let voiceActive = false;
+    let noiseFloor = MIC_INITIAL_NOISE_FLOOR;
+    let smoothedLevel = 0;
     function tick(now: number) {
       raf = requestAnimationFrame(tick);
-      // Throttle state updates to ~30fps so the compact meter can track
-      // syllables without pushing the whole HuddleBar at display refresh rate.
-      if (now - lastUpdate < 33) return;
+      if (now - lastUpdate < MIC_ANALYSER_UPDATE_INTERVAL_MS) return;
       lastUpdate = now;
-      analyser.getByteFrequencyData(buf);
-      // RMS-ish: average of frequency bins, normalized to 0–1
-      let sum = 0;
-      for (let i = 0; i < buf.length; i++) sum += buf[i];
-      setMicLevel(sum / (buf.length * 255));
-      const nextMicBands = computeMicFrequencyBands(
-        buf,
-        ctx.sampleRate,
-        analyser.fftSize,
-        micBandDynamics,
+      analyser.getFloatTimeDomainData(buf);
+
+      let sumSquares = 0;
+      for (let i = 0; i < buf.length; i += 1) {
+        sumSquares += buf[i] * buf[i];
+      }
+
+      const rms = Math.sqrt(sumSquares / buf.length);
+      const activeThreshold = Math.max(
+        MIC_VOICE_GATE_ON_RMS,
+        noiseFloor + MIC_VOICE_GATE_MARGIN_RMS,
       );
-      micBandDynamics = nextMicBands.dynamics;
-      setMicBands(nextMicBands.bands);
+      const idleThreshold = Math.max(
+        MIC_VOICE_GATE_OFF_RMS,
+        noiseFloor + MIC_VOICE_GATE_MARGIN_RMS * 0.55,
+      );
+      voiceActive = voiceActive ? rms > idleThreshold : rms > activeThreshold;
+
+      if (!voiceActive) {
+        const floorRate = rms < noiseFloor ? 0.18 : 0.025;
+        noiseFloor += (rms - noiseFloor) * floorRate;
+        smoothedLevel = 0;
+        setMicLevel(0);
+        return;
+      }
+
+      const normalized = clamp01(
+        (rms - noiseFloor) / MIC_LEVEL_ACTIVE_RANGE_RMS,
+      );
+      const targetLevel = Math.max(normalized, MIC_MIN_ACTIVE_LEVEL);
+      smoothedLevel += (targetLevel - smoothedLevel) * MIC_LEVEL_ATTACK;
+      setMicLevel(smoothedLevel);
     }
     raf = requestAnimationFrame(tick);
 
@@ -680,7 +587,7 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
       source.disconnect();
       void ctx.close();
     };
-  }, [localAudioTrack]);
+  }, [localAudioTrack, micConnected]);
 
   // Cleanup on unmount only — stable ref prevents re-firing mid-startup.
   const leaveHuddleRef = React.useRef(leaveHuddle);
@@ -719,7 +626,6 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
         clearHuddleError,
         micConnected,
         micLevel,
-        micBands,
         pttActive,
         voiceInputMode,
         setVoiceInputMode,

--- a/desktop/src/features/huddle/HuddleContext.tsx
+++ b/desktop/src/features/huddle/HuddleContext.tsx
@@ -29,6 +29,7 @@ const MIC_VOICE_GATE_MARGIN_RMS = 0.012;
 const MIC_LEVEL_ACTIVE_RANGE_RMS = 0.11;
 const MIC_MIN_ACTIVE_LEVEL = 0.18;
 const MIC_LEVEL_ATTACK = 0.58;
+const MIC_ACTIVE_NOISE_FLOOR_RISE = 0.006;
 
 function isRedundantHuddlePhaseError(message: string): boolean {
   return /^cannot (?:start|join) huddle: already in phase /i.test(message);
@@ -565,9 +566,15 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
       );
       voiceActive = voiceActive ? rms > idleThreshold : rms > activeThreshold;
 
+      const floorRate =
+        rms < noiseFloor
+          ? 0.18
+          : voiceActive
+            ? MIC_ACTIVE_NOISE_FLOOR_RISE
+            : 0.025;
+      noiseFloor += (rms - noiseFloor) * floorRate;
+
       if (!voiceActive) {
-        const floorRate = rms < noiseFloor ? 0.18 : 0.025;
-        noiseFloor += (rms - noiseFloor) * floorRate;
         smoothedLevel = 0;
         setMicLevel(0);
         return;

--- a/desktop/src/features/huddle/components/HuddleBar.tsx
+++ b/desktop/src/features/huddle/components/HuddleBar.tsx
@@ -124,7 +124,7 @@ export function HuddleBar({ className, onVisibilityChange }: HuddleBarProps) {
     localAudioTrack,
     leaveHuddle,
     micConnected,
-    micBands,
+    micLevel,
     pttActive,
     voiceInputMode,
     setVoiceInputMode,
@@ -525,7 +525,7 @@ export function HuddleBar({ className, onVisibilityChange }: HuddleBarProps) {
             isPttMode={isPttMode}
             pttActive={pttActive}
             micConnected={micConnected}
-            micBands={micBands}
+            micLevel={micLevel}
             onSelectVoiceInputMode={setVoiceInputMode}
             audioDevices={audioDevices}
             selectedDeviceId={selectedDeviceId}

--- a/desktop/src/features/huddle/components/MicControls.tsx
+++ b/desktop/src/features/huddle/components/MicControls.tsx
@@ -15,11 +15,6 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 type VoiceInputMode = "push_to_talk" | "voice_activity";
-type MicFrequencyBands = {
-  low: number;
-  mid: number;
-  high: number;
-};
 
 type MicControlsProps = {
   isMuted: boolean;
@@ -27,7 +22,7 @@ type MicControlsProps = {
   isPttMode: boolean;
   pttActive: boolean;
   micConnected: boolean;
-  micBands: MicFrequencyBands;
+  micLevel: number;
   onSelectVoiceInputMode: (mode: VoiceInputMode) => void | Promise<void>;
   audioDevices: MediaDeviceInfo[];
   selectedDeviceId: string;
@@ -46,12 +41,30 @@ type MicMeterBarStyle = CSSProperties & {
   "--buzz-huddle-meter-height": string;
 };
 
-function micMeterBarStyle(height: number): MicMeterBarStyle {
-  return { "--buzz-huddle-meter-height": `${height}px` };
+const MIC_METER_IDLE_HEIGHT_REM = 0.25;
+const MIC_METER_IDLE_HEIGHTS: [number, number, number] = [
+  MIC_METER_IDLE_HEIGHT_REM,
+  MIC_METER_IDLE_HEIGHT_REM,
+  MIC_METER_IDLE_HEIGHT_REM,
+];
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
 }
 
-function micMeterHeights(bands: MicFrequencyBands): [number, number, number] {
-  return [4 + bands.low * 10, 4 + bands.mid * 14, 4 + bands.high * 11];
+function micMeterBarStyle(heightRem: number): MicMeterBarStyle {
+  return { "--buzz-huddle-meter-height": `${heightRem}rem` };
+}
+
+function micMeterHeights(level: number): [number, number, number] {
+  const normalized = clamp01(level);
+  if (normalized <= 0.01) return MIC_METER_IDLE_HEIGHTS;
+
+  return [
+    MIC_METER_IDLE_HEIGHT_REM + normalized * 0.5,
+    MIC_METER_IDLE_HEIGHT_REM + normalized * 0.875,
+    MIC_METER_IDLE_HEIGHT_REM + normalized * 0.625,
+  ];
 }
 
 function usePrefersReducedMotion(): boolean {
@@ -78,7 +91,7 @@ export function MicControls({
   isPttMode,
   pttActive,
   micConnected,
-  micBands,
+  micLevel,
   onSelectVoiceInputMode,
   audioDevices,
   selectedDeviceId,
@@ -92,8 +105,8 @@ export function MicControls({
   const prefersReducedMotion = usePrefersReducedMotion();
   const pushToTalkShortcut = isMac ? "⌃Space" : "Ctrl+Space";
   const barHeights: [number, number, number] = prefersReducedMotion
-    ? [4, 4, 4]
-    : micMeterHeights(micBands);
+    ? MIC_METER_IDLE_HEIGHTS
+    : micMeterHeights(showMicMeter ? micLevel : 0);
   const [leftBarHeight, centerBarHeight, rightBarHeight] = barHeights;
 
   const micButtonLabel = micUnavailable
@@ -182,7 +195,7 @@ export function MicControls({
       </div>
       <PopoverContent
         side="top"
-        className="buzz-huddle-drawer buzz-huddle-popover w-64 border-white/10 text-foreground"
+        className="buzz-huddle-drawer buzz-huddle-popover w-64 text-foreground"
       >
         <div className="flex flex-col gap-3">
           <div>
@@ -192,7 +205,7 @@ export function MicControls({
                 isPttMode ? "Turn off Push to Talk" : "Turn on Push to Talk"
               }
               aria-pressed={isPttMode}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent"
+              className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent"
               onClick={() =>
                 void onSelectVoiceInputMode(
                   isPttMode ? "voice_activity" : "push_to_talk",
@@ -319,7 +332,7 @@ export function SpeakerControls({
           <PopoverContent
             align="center"
             aria-label="Headphones recommended"
-            className="buzz-huddle-drawer buzz-huddle-popover buzz-huddle-headphones-hint w-64 border-white/10 p-3 text-foreground"
+            className="buzz-huddle-drawer buzz-huddle-popover buzz-huddle-headphones-hint w-64 p-3 text-foreground"
             onCloseAutoFocus={(event) => event.preventDefault()}
             onOpenAutoFocus={(event) => event.preventDefault()}
             side="top"
@@ -379,7 +392,7 @@ export function SpeakerControls({
       </div>
       <PopoverContent
         side="top"
-        className="buzz-huddle-drawer buzz-huddle-popover w-64 border-white/10 text-foreground"
+        className="buzz-huddle-drawer buzz-huddle-popover w-64 text-foreground"
       >
         <DeviceList
           label="Speaker"
@@ -423,7 +436,7 @@ export function DeviceList({
       <ul className="flex flex-col">
         <li>
           <button
-            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent"
+            className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent"
             onClick={() => onSelect("")}
             type="button"
           >
@@ -438,7 +451,7 @@ export function DeviceList({
           return (
             <li key={d.key}>
               <button
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent"
+                className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent"
                 onClick={() => onSelect(d.id)}
                 type="button"
               >

--- a/desktop/src/features/huddle/components/ParticipantList.tsx
+++ b/desktop/src/features/huddle/components/ParticipantList.tsx
@@ -62,7 +62,7 @@ export function HuddleParticipantsControl({
       </PopoverTrigger>
       <PopoverContent
         align="start"
-        className="buzz-huddle-drawer buzz-huddle-popover w-72 border-white/10 p-3 text-foreground"
+        className="buzz-huddle-drawer buzz-huddle-popover w-72 p-3 text-foreground"
         side="top"
         sideOffset={10}
       >

--- a/desktop/src/features/messages/ui/ChannelAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/ChannelAutocomplete.tsx
@@ -3,6 +3,11 @@ import * as React from "react";
 import type { ChannelSuggestion } from "@/features/messages/lib/useChannelLinks";
 import { Badge } from "@/shared/ui/badge";
 import { cn } from "@/shared/lib/cn";
+import {
+  POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+  POPOVER_SHADOW_STYLE,
+  POPOVER_SURFACE_CLASS,
+} from "@/shared/ui/popoverSurface";
 
 type ChannelAutocompleteProps = {
   suggestions: ChannelSuggestion[];
@@ -38,8 +43,16 @@ export const ChannelAutocomplete = React.memo(function ChannelAutocomplete({
       )}
     >
       <div
-        className="max-h-48 overflow-y-auto rounded-xl border bg-popover p-1 shadow-lg"
+        className={cn(
+          "max-h-48 overflow-y-auto rounded-xl p-1",
+          POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+          position === "below"
+            ? "origin-top slide-in-from-top-1"
+            : "origin-bottom slide-in-from-bottom-1",
+          POPOVER_SURFACE_CLASS,
+        )}
         ref={listRef}
+        style={POPOVER_SHADOW_STYLE}
       >
         {suggestions.map((suggestion, index) => (
           <button

--- a/desktop/src/features/messages/ui/ComposerAttachments.tsx
+++ b/desktop/src/features/messages/ui/ComposerAttachments.tsx
@@ -10,6 +10,7 @@ import {
   type UploadingAttachmentPreview,
 } from "@/features/messages/lib/useMediaUpload";
 import { cn } from "@/shared/lib/cn";
+import { MODAL_BACKDROP_BLUR_CLASS } from "@/shared/ui/modalBackdrop";
 import { Progress } from "@/shared/ui/progress";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
@@ -186,7 +187,12 @@ export const ComposerAttachments = React.memo(function ComposerAttachments({
                       </div>
                     </DialogPrimitive.Trigger>
                     <DialogPrimitive.Portal>
-                      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+                      <DialogPrimitive.Overlay
+                        className={cn(
+                          "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+                          MODAL_BACKDROP_BLUR_CLASS,
+                        )}
+                      />
                       <DialogPrimitive.Content
                         className="fixed inset-0 z-50 flex items-center justify-center p-8"
                         onPointerDownOutside={(e) => e.preventDefault()}

--- a/desktop/src/features/messages/ui/EmojiAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/EmojiAutocomplete.tsx
@@ -2,6 +2,11 @@ import * as React from "react";
 
 import type { EmojiSuggestion } from "@/features/messages/lib/useEmojiAutocomplete";
 import { cn } from "@/shared/lib/cn";
+import {
+  POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+  POPOVER_SHADOW_STYLE,
+  POPOVER_SURFACE_CLASS,
+} from "@/shared/ui/popoverSurface";
 
 type EmojiAutocompleteProps = {
   suggestions: EmojiSuggestion[];
@@ -37,8 +42,16 @@ export const EmojiAutocomplete = React.memo(function EmojiAutocomplete({
       )}
     >
       <div
-        className="max-h-48 overflow-y-auto rounded-xl border bg-popover p-1 shadow-lg"
+        className={cn(
+          "max-h-48 overflow-y-auto rounded-xl p-1",
+          POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+          position === "below"
+            ? "origin-top slide-in-from-top-1"
+            : "origin-bottom slide-in-from-bottom-1",
+          POPOVER_SURFACE_CLASS,
+        )}
         ref={listRef}
+        style={POPOVER_SHADOW_STYLE}
       >
         {suggestions.map((suggestion, index) => (
           <button

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -63,6 +63,7 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
             : "origin-bottom slide-in-from-bottom-1",
           POPOVER_SURFACE_CLASS,
         )}
+        data-testid="mention-autocomplete"
         ref={listRef}
         style={POPOVER_SHADOW_STYLE}
       >

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -3,6 +3,11 @@ import { Bot } from "lucide-react";
 
 import { Badge } from "@/shared/ui/badge";
 import { cn } from "@/shared/lib/cn";
+import {
+  POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+  POPOVER_SHADOW_STYLE,
+  POPOVER_SURFACE_CLASS,
+} from "@/shared/ui/popoverSurface";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
 export type MentionSuggestion = {
@@ -50,8 +55,16 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
       )}
     >
       <div
-        className="max-h-48 overflow-y-auto rounded-xl border bg-popover p-1 shadow-lg"
+        className={cn(
+          "max-h-48 overflow-y-auto rounded-xl p-1",
+          POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+          position === "below"
+            ? "origin-top slide-in-from-top-1"
+            : "origin-bottom slide-in-from-bottom-1",
+          POPOVER_SURFACE_CLASS,
+        )}
         ref={listRef}
+        style={POPOVER_SHADOW_STYLE}
       >
         {suggestions.map((suggestion, index) => {
           const suggestionKey =

--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -268,12 +268,10 @@ function MoreActionsMenu({
 // ---------------------------------------------------------------------------
 
 function QuickReactionButton({
-  active,
   customEmojiUrl,
   emoji,
   onSelect,
 }: {
-  active: boolean;
   customEmojiUrl?: string;
   emoji: string;
   onSelect: (emoji: string) => void;
@@ -286,13 +284,7 @@ function QuickReactionButton({
       <TooltipTrigger asChild>
         <button
           aria-label={`React with ${displayName}`}
-          aria-pressed={active}
-          className={cn(
-            "flex h-8 w-8 items-center justify-center rounded-full text-base leading-none transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring",
-            active
-              ? "bg-secondary text-secondary-foreground"
-              : "text-muted-foreground hover:bg-muted hover:text-foreground",
-          )}
+          className="flex h-8 w-8 items-center justify-center rounded-full text-base leading-none text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
           onClick={() => onSelect(emoji)}
           title={displayName}
           type="button"
@@ -378,14 +370,6 @@ export function MessageActionBar({
     Boolean(onUnfollowThread) ||
     !message.pending;
 
-  const selectedReactionCount = reactions.filter(
-    (reaction) => reaction.reactedByCurrentUser,
-  ).length;
-  const selectedReactionEmojis = new Set(
-    reactions
-      .filter((reaction) => reaction.reactedByCurrentUser)
-      .map((reaction) => reaction.emoji),
-  );
   const wouldAddReaction = React.useCallback(
     (emoji: string) =>
       !reactions.some(
@@ -441,7 +425,6 @@ export function MessageActionBar({
               <div className="hidden items-center gap-0.5 sm:flex">
                 {quickReactionItems.map(({ customEmojiUrl, emoji }) => (
                   <QuickReactionButton
-                    active={selectedReactionEmojis.has(emoji)}
                     customEmojiUrl={customEmojiUrl}
                     emoji={emoji}
                     key={emoji}
@@ -467,11 +450,7 @@ export function MessageActionBar({
                       data-testid={`react-message-${message.id}`}
                       size="sm"
                       type="button"
-                      variant={
-                        isReactionPickerOpen || selectedReactionCount > 0
-                          ? "secondary"
-                          : "ghost"
-                      }
+                      variant={isReactionPickerOpen ? "secondary" : "ghost"}
                     >
                       <SmilePlus className={ACTION_ICON_CLASS} />
                     </Button>

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -135,6 +135,7 @@ export const MessageRow = React.memo(
       () => isEmojiOnlyMessage(message.body, customEmoji),
       [message.body, customEmoji],
     );
+    const bodyOffsetClass = emojiOnly ? "mt-1" : "-mt-0.5";
 
     const { channels } = useChannelNavigation();
     const channelNames = React.useMemo(
@@ -194,7 +195,7 @@ export const MessageRow = React.memo(
               className={cn(
                 "max-w-full text-[15px] leading-6",
                 emojiOnly &&
-                  "text-4xl leading-tight [&_img[data-custom-emoji]]:h-[1.45em] [&_img[data-custom-emoji]]:align-middle [&_button:has(img[data-custom-emoji])]:align-middle",
+                  "text-4xl leading-tight [&_p]:leading-tight [&_img[data-custom-emoji]]:h-[1.45em] [&_img[data-custom-emoji]]:align-middle [&_button:has(img[data-custom-emoji])]:align-middle",
               )}
               content={message.body}
               customEmoji={customEmoji}
@@ -380,8 +381,10 @@ export const MessageRow = React.memo(
 
         <article
           className={cn(
-            "group/message relative rounded-2xl px-3 py-2 transition-colors",
-            hoverBackground && "hover:bg-muted/50 focus-within:bg-muted/50",
+            "group/message relative rounded-2xl py-2 transition-colors",
+            hoverBackground
+              ? "mx-1 px-2 hover:bg-muted/50 focus-within:bg-muted/50"
+              : "px-2",
             "flex items-start gap-2.5",
             highlighted
               ? "-mx-4 rounded-none px-6 before:absolute before:-inset-y-1.5 before:inset-x-0 before:animate-[route-target-highlight-fade_2s_ease-out_forwards] before:bg-primary/10 before:content-[''] motion-reduce:before:animate-none sm:-mx-6 sm:px-8"
@@ -437,7 +440,7 @@ export const MessageRow = React.memo(
                     </span>
                   ) : null}
                 </div>
-                <div className="-mt-0.5">{messageBodyNode}</div>
+                <div className={bodyOffsetClass}>{messageBodyNode}</div>
               </div>
             </>
           ) : (
@@ -487,7 +490,7 @@ export const MessageRow = React.memo(
                     </span>
                   ) : null}
                 </div>
-                <div className="-mt-0.5">{messageBodyNode}</div>
+                <div className={bodyOffsetClass}>{messageBodyNode}</div>
               </div>
             </>
           )}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -445,7 +445,7 @@ export function MessageThreadPanel({
                     className={cn(
                       "flex flex-col gap-1",
                       entry.summary &&
-                        "group/message -mx-1 rounded-2xl px-1 py-1 transition-colors hover:bg-muted/50 focus-within:bg-muted/50",
+                        "group/message mx-1 rounded-2xl px-0 py-1 transition-colors hover:bg-muted/50 focus-within:bg-muted/50",
                     )}
                     key={entry.message.renderKey ?? entry.message.id}
                   >

--- a/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
@@ -7,7 +7,7 @@ import { formatThreadSummaryLastReplyTime } from "@/features/messages/lib/dateFo
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
 const MESSAGE_TEXT_OFFSET_PX = 54;
-const MESSAGE_BODY_OFFSET_PX = MESSAGE_TEXT_OFFSET_PX + 4;
+const MESSAGE_BODY_OFFSET_PX = MESSAGE_TEXT_OFFSET_PX;
 const NESTED_REPLY_OFFSET_PX = 28;
 
 function ParticipantAvatar({

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -293,7 +293,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
         ) : null}
         <div
           className={cn(
-            "absolute inset-0 overflow-y-auto overflow-x-hidden overscroll-contain px-4 pt-1 [overflow-anchor:none] sm:px-6",
+            "absolute inset-0 overflow-y-auto overflow-x-hidden overscroll-contain px-2 pt-1 [overflow-anchor:none]",
             hasComposerOverlay ? "pb-24" : "pb-4",
           )}
           data-scroll-restoration-id={scrollRestorationId}

--- a/desktop/src/features/messages/ui/SystemMessageRow.tsx
+++ b/desktop/src/features/messages/ui/SystemMessageRow.tsx
@@ -333,7 +333,7 @@ export const SystemMessageRow = React.memo(function SystemMessageRow({
 
   return (
     <div
-      className="group/message relative rounded-2xl px-3 py-2 transition-colors hover:bg-muted/50 focus-within:bg-muted/50"
+      className="group/message relative mx-1 rounded-2xl px-2 py-2 transition-colors hover:bg-muted/50 focus-within:bg-muted/50"
       data-testid="system-message-row"
     >
       <div className="flex items-start gap-2.5">

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -200,7 +200,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
         <div
           key={messageRenderKey}
           className={cn(
-            "group/message relative -mx-1 flex flex-col gap-0 rounded-2xl px-1 py-1 transition-colors hover:bg-muted/50 focus-within:bg-muted/50",
+            "group/message relative mx-1 flex flex-col gap-0 rounded-2xl px-0 py-1 transition-colors hover:bg-muted/50 focus-within:bg-muted/50",
             isHighlighted &&
               "-mx-4 px-4 before:absolute before:-inset-y-1.5 before:inset-x-0 before:animate-[route-target-highlight-fade_2s_ease-out_forwards] before:bg-primary/10 before:content-[''] motion-reduce:before:animate-none sm:-mx-6 sm:px-6",
           )}

--- a/desktop/src/features/messages/ui/TimelineSkeleton.tsx
+++ b/desktop/src/features/messages/ui/TimelineSkeleton.tsx
@@ -209,7 +209,7 @@ export function TimelineSkeleton({ rows }: TimelineSkeletonProps) {
     <>
       {skeletonRows.map((row) => (
         <article
-          className="relative flex items-start gap-2.5 rounded-2xl px-3 py-2"
+          className="relative mx-1 flex items-start gap-2.5 rounded-2xl px-2 py-2"
           key={row.key}
         >
           <Skeleton className="h-9 w-9 shrink-0 rounded-full" />

--- a/desktop/src/features/messages/ui/useQuickReactionEmojis.ts
+++ b/desktop/src/features/messages/ui/useQuickReactionEmojis.ts
@@ -7,7 +7,6 @@ import {
 import type { CustomEmoji } from "@/shared/lib/remarkCustomEmoji";
 
 const QUICK_REACTION_STORAGE_KEY = "buzz.quick-reaction-emojis.v1";
-const QUICK_REACTION_UPDATED_EVENT = "buzz:quick-reaction-emojis-updated";
 const DEFAULT_QUICK_REACTIONS = ["👍", "❤️", "😂", "🎉"] as const;
 const MAX_STORED_REACTIONS = 24;
 const sessionQuickReactionEmojis = new Map<string, string[]>();
@@ -208,24 +207,6 @@ function getSessionQuickReactionEmojis(
   return emojis;
 }
 
-function invalidateSessionQuickReactions(workspaceScope: string | null) {
-  const prefix = `${workspaceScope ?? "global"}:`;
-  for (const key of sessionQuickReactionEmojis.keys()) {
-    if (key.startsWith(prefix)) {
-      sessionQuickReactionEmojis.delete(key);
-    }
-  }
-}
-
-function notifyQuickReactionUpdate(workspaceScope: string | null) {
-  if (typeof window === "undefined") return;
-  window.dispatchEvent(
-    new CustomEvent(QUICK_REACTION_UPDATED_EVENT, {
-      detail: { workspaceScope },
-    }),
-  );
-}
-
 export function recordQuickReactionEmoji(emoji: string) {
   const trimmed = emoji.trim();
   if (!trimmed) return;
@@ -234,12 +215,10 @@ export function recordQuickReactionEmoji(emoji: string) {
   const storageKey = quickReactionStorageKey(workspaceScope);
   const entries = readQuickReactionEntries(storageKey);
   const existing = entries.find((entry) => entry.emoji === trimmed);
-  let didAddEntry = false;
   if (existing) {
     existing.count += 1;
     existing.lastUsedAt = Date.now();
   } else {
-    didAddEntry = true;
     entries.push({
       count: 1,
       emoji: trimmed,
@@ -247,11 +226,9 @@ export function recordQuickReactionEmoji(emoji: string) {
     });
   }
 
+  // Keep the current hover tray stable; the stored recents apply on reload or
+  // when another tab updates this workspace's quick reactions.
   writeQuickReactionEntries(entries, storageKey);
-  if (didAddEntry) {
-    invalidateSessionQuickReactions(workspaceScope);
-    notifyQuickReactionUpdate(workspaceScope);
-  }
 }
 
 export function useQuickReactionEmojis(
@@ -285,33 +262,14 @@ export function useQuickReactionEmojis(
         );
       }
     };
-    const handleLocalUpdate = (event: Event) => {
-      if (
-        event instanceof CustomEvent &&
-        event.detail?.workspaceScope === workspaceScope
-      ) {
-        setEmojis(
-          getSessionQuickReactionEmojis(
-            limit,
-            workspaceScope,
-            customEmojiCacheKey,
-          ),
-        );
-      }
-    };
 
     window.addEventListener("storage", handleStorage);
-    window.addEventListener(QUICK_REACTION_UPDATED_EVENT, handleLocalUpdate);
     setEmojis(
       getSessionQuickReactionEmojis(limit, workspaceScope, customEmojiCacheKey),
     );
 
     return () => {
       window.removeEventListener("storage", handleStorage);
-      window.removeEventListener(
-        QUICK_REACTION_UPDATED_EVENT,
-        handleLocalUpdate,
-      );
     };
   }, [customEmojiCacheKey, limit, workspaceScope]);
 

--- a/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
+++ b/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
@@ -252,7 +252,7 @@ export function NostrKeyImportForm({
           type="submit"
         >
           {isBusy ? (
-            <Spinner aria-label="Importing key" className="h-4 w-4" />
+            <Spinner aria-label="Importing key" className="h-4 w-4 border-2" />
           ) : (
             "Continue with this key"
           )}

--- a/desktop/src/features/onboarding/welcome.ts
+++ b/desktop/src/features/onboarding/welcome.ts
@@ -13,6 +13,8 @@ export const WELCOME_CHANNEL_READY_EVENT =
 
 const PENDING_WELCOME_CHANNEL_STORAGE_KEY =
   "buzz:onboarding-welcome-channel.v1";
+const WELCOME_INITIAL_UNREAD_SUPPRESSION_STORAGE_KEY =
+  "buzz:onboarding-welcome-initial-unread-suppression.v1";
 const PENDING_WELCOME_CHANNEL_MAX_AGE_MS = 5 * 60 * 1000;
 const WELCOME_CHANNEL_ENSURED_STORAGE_KEY = "buzz-welcome-channel-ensured.v2";
 
@@ -205,14 +207,20 @@ export function markWelcomeChannelEnsured(
 }
 
 function readPendingWelcomeChannel(): PendingWelcomeChannel | null {
+  return readPendingWelcomeChannelFromStorage(
+    PENDING_WELCOME_CHANNEL_STORAGE_KEY,
+  );
+}
+
+function readPendingWelcomeChannelFromStorage(
+  storageKey: string,
+): PendingWelcomeChannel | null {
   if (typeof window === "undefined") {
     return null;
   }
 
   try {
-    const raw = window.sessionStorage.getItem(
-      PENDING_WELCOME_CHANNEL_STORAGE_KEY,
-    );
+    const raw = window.sessionStorage.getItem(storageKey);
     if (!raw) {
       return null;
     }
@@ -236,12 +244,16 @@ function readPendingWelcomeChannel(): PendingWelcomeChannel | null {
 }
 
 function clearPendingWelcomeChannel() {
+  clearPendingWelcomeChannelFromStorage(PENDING_WELCOME_CHANNEL_STORAGE_KEY);
+}
+
+function clearPendingWelcomeChannelFromStorage(storageKey: string) {
   if (typeof window === "undefined") {
     return;
   }
 
   try {
-    window.sessionStorage.removeItem(PENDING_WELCOME_CHANNEL_STORAGE_KEY);
+    window.sessionStorage.removeItem(storageKey);
   } catch {
     // Best-effort. A stale pending channel expires automatically.
   }
@@ -257,9 +269,41 @@ export function rememberPendingWelcomeChannel(channelId: string) {
       PENDING_WELCOME_CHANNEL_STORAGE_KEY,
       JSON.stringify({ channelId, createdAt: Date.now() }),
     );
+    window.sessionStorage.setItem(
+      WELCOME_INITIAL_UNREAD_SUPPRESSION_STORAGE_KEY,
+      JSON.stringify({ channelId, createdAt: Date.now() }),
+    );
   } catch {
     // Best-effort. The user can still select the channel from the sidebar.
   }
+}
+
+export function hasPendingWelcomeInitialUnreadSuppression(channelId: string) {
+  const pending = readPendingWelcomeChannelFromStorage(
+    WELCOME_INITIAL_UNREAD_SUPPRESSION_STORAGE_KEY,
+  );
+  if (!pending) {
+    return false;
+  }
+
+  if (Date.now() - pending.createdAt > PENDING_WELCOME_CHANNEL_MAX_AGE_MS) {
+    return false;
+  }
+
+  return pending.channelId === channelId;
+}
+
+export function consumePendingWelcomeInitialUnreadSuppression(
+  channelId: string,
+) {
+  if (!hasPendingWelcomeInitialUnreadSuppression(channelId)) {
+    return false;
+  }
+
+  clearPendingWelcomeChannelFromStorage(
+    WELCOME_INITIAL_UNREAD_SUPPRESSION_STORAGE_KEY,
+  );
+  return true;
 }
 
 export function notifyWelcomeChannelReady(channelId: string) {

--- a/desktop/src/features/profile/ui/AnimatedAvatarCapture.tsx
+++ b/desktop/src/features/profile/ui/AnimatedAvatarCapture.tsx
@@ -957,7 +957,7 @@ export function AnimatedAvatarCapture({
           {isSaving ? (
             <Spinner
               aria-label="Uploading animated avatar"
-              className="h-4 w-4"
+              className="h-4 w-4 border-2"
             />
           ) : (
             "Use as avatar"

--- a/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
@@ -620,7 +620,7 @@ export function ProfileAvatarEditor({
                     {isUploading ? (
                       <Spinner
                         aria-hidden
-                        className="relative h-8 w-8 text-muted-foreground"
+                        className="relative h-8 w-8 border-2 text-muted-foreground"
                       />
                     ) : (
                       <UploadCloud
@@ -894,7 +894,7 @@ export function ProfileAvatarEditor({
                         >
                           <Spinner
                             aria-label="Saving avatar"
-                            className="h-4 w-4"
+                            className="h-4 w-4 border-2"
                           />
                           <span>Saving</span>
                         </motion.span>

--- a/desktop/src/features/profile/ui/ProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/ProfilePopover.tsx
@@ -46,7 +46,7 @@ interface ProfilePopoverProps {
 // ---------------------------------------------------------------------------
 
 const MENU_ITEM_CLASS =
-  "flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-popover-foreground hover:bg-accent focus-visible:bg-accent cursor-pointer transition-colors outline-hidden focus:outline-none focus-visible:outline-none";
+  "flex min-h-9 w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-popover-foreground outline-hidden transition-colors hover:bg-muted/50 focus:outline-none focus-visible:bg-muted/50 focus-visible:outline-none";
 
 const ALL_STATUSES: PresenceStatus[] = ["online", "away", "offline"];
 
@@ -131,7 +131,7 @@ export function ProfilePopover({
           side="top"
           align="start"
           sideOffset={-32}
-          className="w-[280px] rounded-xl border border-border bg-popover p-0 shadow-lg"
+          className="w-[280px] p-1"
           data-testid="profile-popover"
           onInteractOutside={(event) => {
             const target = event.target as Node | null;
@@ -145,7 +145,7 @@ export function ProfilePopover({
         >
           <div aria-label="Profile menu" role="menu">
             {/* ── Identity block ─────────────────────────────────── */}
-            <div className="flex items-center gap-2 px-4 pt-3 pb-2">
+            <div className="flex items-center gap-2 px-3 pt-2 pb-2">
               <div className="relative shrink-0">
                 <ProfileAvatar
                   avatarDataUrl={avatarDataUrl}
@@ -170,9 +170,9 @@ export function ProfilePopover({
             </div>
 
             {/* ── Status input (Slack-style) ──────────────────────── */}
-            <div className="px-3 pt-0 pb-1">
+            <div className="px-2 pt-0 pb-1">
               <button
-                className="flex w-full items-center gap-2 rounded-lg border border-input bg-popover px-3 py-2 text-left text-sm outline-hidden transition-colors hover:bg-accent focus:outline-none focus-visible:bg-accent focus-visible:outline-none"
+                className="flex w-full items-center gap-2 rounded-lg border border-border/60 bg-transparent px-3 py-2 text-left text-sm outline-hidden transition-colors hover:bg-muted/50 focus:outline-none focus-visible:bg-muted/50 focus-visible:outline-none"
                 data-testid="profile-popover-set-status"
                 onClick={() => {
                   closePopover();
@@ -229,7 +229,7 @@ export function ProfilePopover({
               </PopoverTrigger>
               <PopoverContent
                 align="start"
-                className="w-44 rounded-xl border border-border bg-popover p-1 shadow-lg"
+                className="w-60 p-1"
                 onMouseEnter={() => schedulePresenceMenu(true)}
                 onMouseLeave={() => schedulePresenceMenu(false)}
                 side="right"
@@ -305,8 +305,6 @@ export function ProfilePopover({
                 </div>
               </>
             ) : null}
-
-            <div className="h-1" />
           </div>
         </PopoverContent>
       </Popover>

--- a/desktop/src/features/search/ui/TopbarSearch.tsx
+++ b/desktop/src/features/search/ui/TopbarSearch.tsx
@@ -14,6 +14,11 @@ import {
 } from "@/features/search/ui/SearchResultItem";
 import type { Channel, SearchHit } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import {
+  POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+  POPOVER_SHADOW_STYLE,
+  POPOVER_SURFACE_CLASS,
+} from "@/shared/ui/popoverSurface";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
@@ -108,7 +113,7 @@ function SearchResultsSkeleton() {
   return (
     <div
       aria-hidden="true"
-      className="max-h-[360px] overflow-y-auto p-1.5"
+      className="max-h-[360px] overflow-y-auto p-1"
       data-testid="search-results-loading"
     >
       {searchSkeletonRows.map((row) => (
@@ -269,8 +274,13 @@ export function TopbarSearch({
       {showSuggestions ? (
         <div
           aria-busy={searchQuery.isLoading && results.length === 0}
-          className="absolute left-1/2 top-full z-50 mt-1 w-[620px] max-w-[min(82vw,620px)] -translate-x-1/2 overflow-hidden rounded-xl border border-border/80 bg-popover text-popover-foreground shadow-xl"
+          className={cn(
+            "absolute left-1/2 top-full z-50 mt-1 w-[620px] max-w-[min(82vw,620px)] -translate-x-1/2 origin-top overflow-hidden rounded-xl slide-in-from-top-1",
+            POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+            POPOVER_SURFACE_CLASS,
+          )}
           data-testid="search-results"
+          style={POPOVER_SHADOW_STYLE}
         >
           {debouncedQuery.length < MIN_SEARCH_QUERY_LENGTH ? (
             <div className="px-3 py-3 text-[11px] text-muted-foreground">
@@ -288,7 +298,7 @@ export function TopbarSearch({
               <span className="font-semibold">{trimmedQuery}</span>.
             </p>
           ) : (
-            <div className="max-h-[360px] overflow-y-auto p-1.5">
+            <div className="max-h-[360px] overflow-y-auto p-1">
               {results.map((result, index) => (
                 <button
                   className={cn(

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -615,7 +615,7 @@ export function ProfileSettingsCard({
                           {isAvatarEditorSaving && !isAvatarEditorOpen ? (
                             <Spinner
                               aria-label="Saving avatar"
-                              className="h-4 w-4"
+                              className="h-4 w-4 border-2"
                             />
                           ) : (
                             <Pencil className="h-4 w-4" />

--- a/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
+++ b/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
@@ -1,4 +1,4 @@
-import { ClockFading, Hash } from "lucide-react";
+import { ChevronDown, ClockFading, Hash, type LucideIcon } from "lucide-react";
 import * as React from "react";
 
 import { useChannelTemplatesQuery } from "@/features/channel-templates/hooks";
@@ -8,15 +8,18 @@ import { Button } from "@/shared/ui/button";
 import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
 import { Dialog } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
-import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import { Switch } from "@/shared/ui/switch";
 import { Textarea } from "@/shared/ui/textarea";
 
 /** Default TTL for ephemeral channels: 1 day of inactivity. */
 const EPHEMERAL_TTL_SECONDS = 86400;
 const CREATE_FIELD_SHELL_CLASS =
-  "rounded-xl border border-input bg-background shadow-xs transition-colors duration-150 ease-out hover:border-muted-foreground/40 hover:bg-muted/70 focus-within:border-muted-foreground/50 focus-within:bg-muted/70";
+  "rounded-xl border border-input bg-muted/40 transition-colors duration-150 ease-out hover:border-muted-foreground/40 focus-within:border-muted-foreground/50";
 const CREATE_FIELD_CONTROL_CLASS =
-  "border-0 bg-transparent shadow-none outline-none ring-0 placeholder:text-muted-foreground/45 focus:bg-transparent focus:outline-hidden focus-visible:ring-0";
+  "border-0 bg-transparent text-muted-foreground/55 shadow-none outline-none ring-0 transition-colors duration-150 ease-out placeholder:text-muted-foreground/55 focus:bg-transparent focus:text-foreground focus:outline-hidden focus-visible:ring-0";
+const CREATE_LABEL_OPTIONAL_CLASS =
+  "ml-1 text-xs font-normal text-muted-foreground/50";
 
 type ChannelKind = "stream" | "forum";
 
@@ -53,12 +56,15 @@ export function CreateChannelDialog({
   const [selectedTemplateId, setSelectedTemplateId] = React.useState<
     string | null
   >(null);
+  const [typePopoverOpen, setTypePopoverOpen] = React.useState(false);
   const nameInputRef = React.useRef<HTMLInputElement>(null);
 
   const templatesQuery = useChannelTemplatesQuery();
   const templates = templatesQuery.data ?? [];
 
   const kindLabel = channelKind === "forum" ? "forum" : "channel";
+  const durationLabel = ephemeral ? "Temporary" : "Ongoing";
+  const DurationIcon = ephemeral ? ClockFading : Hash;
 
   // Reset form state when dialog opens/closes or kind changes
   React.useEffect(() => {
@@ -70,6 +76,7 @@ export function CreateChannelDialog({
     setEphemeral(false);
     setErrorMessage(null);
     setSelectedTemplateId(null);
+    setTypePopoverOpen(false);
 
     // Small delay to let dialog animation start before focusing
     const timerId = globalThis.setTimeout(() => {
@@ -152,15 +159,52 @@ export function CreateChannelDialog({
             : "Channels are real-time streams for team conversation."
         }
         footer={
-          <div className="flex w-full items-center justify-end gap-2">
-            <Button
-              disabled={isCreating}
-              onClick={() => onOpenChange(false)}
-              type="button"
-              variant="ghost"
-            >
-              Cancel
-            </Button>
+          <div className="flex w-full items-center justify-between gap-3">
+            <Popover onOpenChange={setTypePopoverOpen} open={typePopoverOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  aria-label={`Channel duration: ${durationLabel}`}
+                  className="-ml-2.5 h-9 px-2.5 text-sm font-medium text-foreground hover:bg-muted/50"
+                  disabled={isCreating}
+                  type="button"
+                  variant="ghost"
+                >
+                  <DurationIcon className="h-4 w-4" />
+                  {durationLabel}
+                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground/70" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-72 p-1">
+                <div className="px-3 pb-1.5 pt-2 text-xs font-medium text-muted-foreground/70">
+                  Channel type
+                </div>
+                <fieldset className="space-y-1">
+                  <legend className="sr-only">Channel type</legend>
+                  <ChannelDurationOption
+                    ariaLabel="Ongoing channel"
+                    checked={!ephemeral}
+                    description="For projects, teams, and recurring conversations."
+                    icon={Hash}
+                    label="Ongoing"
+                    onSelect={() => {
+                      setEphemeral(false);
+                      setTypePopoverOpen(false);
+                    }}
+                  />
+                  <ChannelDurationOption
+                    ariaLabel="Ephemeral - auto-archives after 1 day of inactivity"
+                    checked={ephemeral}
+                    description="For quick discussions that archive automatically when inactive."
+                    icon={ClockFading}
+                    label="Temporary"
+                    onSelect={() => {
+                      setEphemeral(true);
+                      setTypePopoverOpen(false);
+                    }}
+                  />
+                </fieldset>
+              </PopoverContent>
+            </Popover>
             <Button
               data-testid="create-channel-submit"
               disabled={isCreating || name.trim().length === 0}
@@ -189,7 +233,7 @@ export function CreateChannelDialog({
             </label>
             <div
               className={cn(
-                "flex h-9 items-center px-3",
+                "flex min-h-11 items-center px-3",
                 CREATE_FIELD_SHELL_CLASS,
               )}
             >
@@ -197,7 +241,10 @@ export function CreateChannelDialog({
                 autoCapitalize="none"
                 autoComplete="off"
                 autoCorrect="off"
-                className={cn("h-full px-0 py-0", CREATE_FIELD_CONTROL_CLASS)}
+                className={cn(
+                  "h-8 px-0 py-0 leading-6",
+                  CREATE_FIELD_CONTROL_CLASS,
+                )}
                 data-testid="create-channel-name"
                 disabled={isCreating}
                 id="create-channel-name"
@@ -223,15 +270,13 @@ export function CreateChannelDialog({
               className="text-sm font-medium text-foreground"
               htmlFor="create-channel-description"
             >
-              Description{" "}
-              <span className="font-normal text-muted-foreground">
-                (optional)
-              </span>
+              Description
+              <span className={CREATE_LABEL_OPTIONAL_CLASS}>Optional</span>
             </label>
             <div className={CREATE_FIELD_SHELL_CLASS}>
               <Textarea
                 className={cn(
-                  "min-h-16 resize-none px-3 py-2",
+                  "min-h-20 resize-none px-3 py-3 leading-5",
                   CREATE_FIELD_CONTROL_CLASS,
                 )}
                 data-testid="create-channel-description"
@@ -248,87 +293,39 @@ export function CreateChannelDialog({
             </div>
           </div>
 
-          {/* Type */}
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-foreground">Type</p>
-            <Tabs
-              className="w-full"
-              data-testid="create-channel-ephemeral"
-              onValueChange={(value) => setEphemeral(value === "temporary")}
-              value={ephemeral ? "temporary" : "ongoing"}
-            >
-              <TabsList className="relative grid h-auto w-full grid-cols-2 items-stretch rounded-xl bg-muted/45 p-1 text-muted-foreground">
-                <span
-                  aria-hidden="true"
-                  className="pointer-events-none absolute bottom-1 left-1 top-1 z-0 w-[calc(50%-0.25rem)] rounded-lg bg-background/95 shadow-xs transition-transform duration-[180ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
-                  data-testid="create-channel-type-indicator"
-                  style={{
-                    transform: ephemeral
-                      ? "translate3d(100%, 0, 0)"
-                      : "translate3d(0, 0, 0)",
-                  }}
-                />
-                <TabsTrigger
-                  className="group/type-tab relative z-10 h-full min-h-24 flex-col items-start justify-start gap-1.5 whitespace-normal rounded-lg bg-transparent px-3 py-2.5 text-left text-muted-foreground/55 opacity-70 shadow-none transition-[color,opacity] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:text-muted-foreground hover:opacity-85 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:opacity-100 data-[state=active]:shadow-none motion-reduce:transition-none"
-                  disabled={isCreating}
-                  value="ongoing"
-                >
-                  <Hash className="mt-0.5 h-4 w-4 shrink-0 text-current" />
-                  <span className="min-w-0 space-y-0.5">
-                    <span className="block text-sm font-medium">Ongoing</span>
-                    <span className="block text-xs leading-4 text-muted-foreground/45 group-data-[state=active]/type-tab:text-muted-foreground/65">
-                      For projects, teams, and recurring conversations.
-                    </span>
-                  </span>
-                </TabsTrigger>
-                <TabsTrigger
-                  aria-label="Ephemeral — auto-archives after 1 day of inactivity"
-                  className="group/type-tab relative z-10 h-full min-h-24 flex-col items-start justify-start gap-1.5 whitespace-normal rounded-lg bg-transparent px-3 py-2.5 text-left text-muted-foreground/55 opacity-70 shadow-none transition-[color,opacity] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:text-muted-foreground hover:opacity-85 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:opacity-100 data-[state=active]:shadow-none motion-reduce:transition-none"
-                  disabled={isCreating}
-                  value="temporary"
-                >
-                  <ClockFading className="mt-0.5 h-4 w-4 shrink-0 text-current" />
-                  <span className="min-w-0 space-y-0.5">
-                    <span className="block text-sm font-medium">Temporary</span>
-                    <span className="block text-xs leading-4 text-muted-foreground/45 group-data-[state=active]/type-tab:text-muted-foreground/65">
-                      For quick discussions that archive automatically when
-                      inactive.
-                    </span>
-                  </span>
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-          </div>
-
-          {/* Permissions */}
-          <fieldset
-            className="space-y-2"
+          <div
+            className={cn(
+              "flex min-h-12 items-center justify-between gap-4 rounded-xl py-1",
+              isCreating && "opacity-50",
+            )}
             data-testid="create-channel-visibility"
           >
-            <legend className="text-sm font-medium text-foreground">
-              Permissions
-            </legend>
-            <div className="space-y-1">
-              <PermissionOption
-                description={`Anyone can see and join this ${kindLabel}.`}
-                disabled={isCreating}
-                name="create-channel-visibility"
-                onChange={() => setVisibility("open")}
-                selected={visibility === "open"}
-                title="Open"
-                value="open"
-              />
-              <PermissionOption
-                description={`Only members can invite people to this ${kindLabel}.`}
-                disabled={isCreating}
-                name="create-channel-visibility"
-                onChange={() => setVisibility("private")}
-                selected={visibility === "private"}
-                title="Private"
-                value="private"
-              />
-            </div>
-          </fieldset>
+            <label
+              className="min-w-0 cursor-pointer space-y-0.5"
+              htmlFor="create-channel-private"
+            >
+              <span className="block text-sm font-medium text-foreground">
+                Private
+              </span>
+              <span
+                className="block text-xs leading-4 text-muted-foreground/65"
+                id="create-channel-private-description"
+              >
+                Only members can invite people to this {kindLabel}.
+              </span>
+            </label>
+            <Switch
+              aria-describedby="create-channel-private-description"
+              checked={visibility === "private"}
+              className="shrink-0 shadow-none [&>span]:shadow-none"
+              data-testid="create-channel-private-toggle"
+              disabled={isCreating}
+              id="create-channel-private"
+              onCheckedChange={(checked) =>
+                setVisibility(checked ? "private" : "open")
+              }
+            />
+          </div>
 
           {/* Template Selector */}
           {templates.length > 0 ? (
@@ -337,13 +334,11 @@ export function CreateChannelDialog({
                 className="text-sm font-medium text-foreground"
                 htmlFor="create-channel-template"
               >
-                Template{" "}
-                <span className="font-normal text-muted-foreground">
-                  (optional)
-                </span>
+                Template
+                <span className={CREATE_LABEL_OPTIONAL_CLASS}>Optional</span>
               </label>
               <select
-                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                className="flex min-h-11 w-full rounded-xl border border-input bg-muted/40 px-3 py-2 text-sm text-muted-foreground/55 shadow-none transition-colors duration-150 ease-out hover:border-muted-foreground/40 focus:border-muted-foreground/50 focus:text-foreground focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
                 data-testid="create-channel-template"
                 disabled={isCreating}
                 id="create-channel-template"
@@ -370,62 +365,61 @@ export function CreateChannelDialog({
   );
 }
 
-function PermissionOption({
+function ChannelDurationOption({
+  ariaLabel,
+  checked,
   description,
-  disabled,
-  name,
-  onChange,
-  selected,
-  title,
-  value,
+  icon: Icon,
+  label,
+  onSelect,
 }: {
+  ariaLabel: string;
+  checked: boolean;
   description: string;
-  disabled: boolean;
-  name: string;
-  onChange: () => void;
-  selected: boolean;
-  title: string;
-  value: ChannelVisibility;
+  icon: LucideIcon;
+  label: string;
+  onSelect: () => void;
 }) {
   return (
     <label
       className={cn(
-        "group flex cursor-pointer items-start gap-3 rounded-lg px-1 py-1.5 transition-none",
-        "has-[:focus-visible]:outline-hidden has-[:focus-visible]:ring-1 has-[:focus-visible]:ring-ring",
-        selected
-          ? "text-foreground"
-          : "text-muted-foreground hover:text-foreground",
-        disabled && "pointer-events-none opacity-50",
+        "relative flex min-h-16 cursor-pointer items-start gap-3 rounded-lg px-3 py-2.5 text-left text-muted-foreground/75 transition-colors duration-150 ease-out hover:bg-muted/50 hover:text-foreground has-[:focus-visible]:outline-hidden has-[:focus-visible]:ring-1 has-[:focus-visible]:ring-ring",
+        checked && "text-foreground",
       )}
     >
       <input
-        checked={selected}
-        className="sr-only"
-        disabled={disabled}
-        name={name}
-        onChange={onChange}
+        aria-label={ariaLabel}
+        checked={checked}
+        className="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
+        name="create-channel-duration"
+        onChange={onSelect}
         type="radio"
-        value={value}
       />
       <span
         className={cn(
-          "mt-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-none",
-          selected
-            ? "border-foreground"
-            : "border-muted-foreground/45 group-hover:border-muted-foreground",
+          "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-muted-foreground/40",
+          checked && "border-foreground",
         )}
         aria-hidden="true"
       >
         <span
           className={cn(
-            "h-1.5 w-1.5 rounded-full bg-foreground transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
-            selected ? "scale-100 opacity-100" : "scale-50 opacity-0",
+            "h-1.5 w-1.5 rounded-full bg-foreground transition-opacity duration-150",
+            checked ? "opacity-100" : "opacity-0",
           )}
         />
       </span>
-      <span className="min-w-0 space-y-0.5">
-        <span className="block text-sm font-medium text-current">{title}</span>
-        <span className="block text-xs leading-4 text-muted-foreground/65">
+      <span className="grid min-w-0 flex-1 grid-cols-[1rem_minmax(0,1fr)] gap-x-2 gap-y-1">
+        <Icon className="h-4 w-4 shrink-0 text-current" />
+        <span className="block text-sm font-medium leading-4 text-current">
+          {label}
+        </span>
+        <span
+          className={cn(
+            "col-span-2 block text-xs leading-4 text-muted-foreground/70",
+            checked && "text-muted-foreground/65",
+          )}
+        >
           {description}
         </span>
       </span>

--- a/desktop/src/features/sidebar/ui/NewDirectMessageDialog.tsx
+++ b/desktop/src/features/sidebar/ui/NewDirectMessageDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/features/profile/lib/userCandidateSearch";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import type { UserSearchResult } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { Button } from "@/shared/ui/button";
 import {
@@ -29,6 +30,8 @@ import {
 } from "@/shared/ui/modalSearchStyles";
 
 const DIRECT_MESSAGE_RECIPIENT_LIMIT = 50;
+const DM_RESULT_ROW_INSET_DIVIDER_CLASS =
+  "after:pointer-events-none after:absolute after:bottom-0 after:left-[3.75rem] after:right-0 after:h-px after:bg-border/60 after:content-[''] last:after:hidden";
 const BUTTON_LABEL_MORPH_DURATION_MS = 220;
 const BUTTON_LABEL_MORPH_EASE = "cubic-bezier(0.23, 1, 0.32, 1)";
 const BUTTON_LABEL_FADE_MS = Math.min(
@@ -250,6 +253,8 @@ export function NewDirectMessageDialog({
   >(null);
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const selectedRecipientsRef = React.useRef<HTMLDivElement>(null);
+  const suppressCloseAutoFocusRef = React.useRef(false);
+  const selectedUsersCountRef = React.useRef(0);
   const [selectedRecipientsHeight, setSelectedRecipientsHeight] =
     React.useState(0);
   const deferredSearchQuery = React.useDeferredValue(searchQuery.trim());
@@ -370,11 +375,20 @@ export function NewDirectMessageDialog({
       setSelectedUsers([]);
       setSubmitErrorMessage(null);
       setSelectedRecipientsHeight(0);
+      selectedUsersCountRef.current = 0;
       return;
     }
 
+    suppressCloseAutoFocusRef.current = false;
     searchInputRef.current?.focus();
   }, [open]);
+
+  React.useEffect(() => {
+    if (selectedUsers.length > selectedUsersCountRef.current) {
+      setSearchQuery("");
+    }
+    selectedUsersCountRef.current = selectedUsers.length;
+  }, [selectedUsers.length]);
 
   React.useEffect(() => {
     const node = selectedRecipientsRef.current;
@@ -418,6 +432,7 @@ export function NewDirectMessageDialog({
     });
     setSearchQuery("");
     setSubmitErrorMessage(null);
+    searchInputRef.current?.focus({ preventScroll: true });
   }
 
   async function submitDirectMessage() {
@@ -431,6 +446,7 @@ export function NewDirectMessageDialog({
       await onSubmit({
         pubkeys: selectedUsers.map((user) => user.pubkey),
       });
+      suppressCloseAutoFocusRef.current = true;
       onOpenChange(false);
     } catch (error) {
       setSubmitErrorMessage(
@@ -450,6 +466,14 @@ export function NewDirectMessageDialog({
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           searchInputRef.current?.focus({ preventScroll: true });
+        }}
+        onCloseAutoFocus={(event) => {
+          if (!suppressCloseAutoFocusRef.current) {
+            return;
+          }
+
+          event.preventDefault();
+          suppressCloseAutoFocusRef.current = false;
         }}
         showCloseButton={false}
       >
@@ -580,7 +604,10 @@ export function NewDirectMessageDialog({
                 <div>
                   {searchResults.map((user) => (
                     <div
-                      className="group/dm-result relative flex min-h-14 w-full items-center gap-3 px-4 py-3.5 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-within:bg-muted/40"
+                      className={cn(
+                        "group/dm-result relative flex min-h-14 w-full items-center gap-3 px-4 py-3.5 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-within:bg-muted/40",
+                        DM_RESULT_ROW_INSET_DIVIDER_CLASS,
+                      )}
                       key={user.pubkey}
                     >
                       <button
@@ -629,7 +656,12 @@ export function NewDirectMessageDialog({
                       </div>
                       <Button
                         aria-label={`Add ${formatUserName(user)}`}
-                        className="relative z-20 shrink-0 opacity-0 transition-opacity duration-150 ease-out group-hover/dm-result:opacity-100 group-focus-within/dm-result:opacity-100"
+                        className={cn(
+                          "relative z-20 shrink-0 transition-opacity duration-150 ease-out",
+                          isPending
+                            ? "invisible opacity-0 disabled:opacity-0"
+                            : "opacity-0 group-hover/dm-result:opacity-100 group-focus-within/dm-result:opacity-100",
+                        )}
                         data-testid={`new-dm-add-${user.pubkey}`}
                         disabled={isPending || hasReachedRecipientLimit}
                         onClick={(event) => {

--- a/desktop/src/features/user-status/ui/SetStatusDialog.tsx
+++ b/desktop/src/features/user-status/ui/SetStatusDialog.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as PopoverPrimitive from "@radix-ui/react-popover";
 
 import { EmojiPicker } from "@/features/custom-emoji/ui/EmojiPicker";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
@@ -12,7 +11,7 @@ import {
 } from "@/shared/ui/dialog";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
-import { Popover, PopoverTrigger } from "@/shared/ui/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 
 const PRESETS = [
   { text: "In a meeting", emoji: "\uD83D\uDDE3\uFE0F" },
@@ -131,13 +130,13 @@ export function SetStatusDialog({
                   </button>
                 ) : null}
               </div>
-              <PopoverPrimitive.Content
+              <PopoverContent
                 align="start"
                 sideOffset={4}
-                className="z-50 w-auto overflow-hidden rounded-2xl shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+                className="w-auto overflow-hidden rounded-2xl p-0"
               >
                 <EmojiPicker autoFocus onSelect={handleEmojiSelect} />
-              </PopoverPrimitive.Content>
+              </PopoverContent>
             </Popover>
             <Input
               autoFocus

--- a/desktop/src/features/workflows/ui/ChannelCombobox.tsx
+++ b/desktop/src/features/workflows/ui/ChannelCombobox.tsx
@@ -133,7 +133,7 @@ export function ChannelCombobox({
             filtered.map((channel, index) => (
               <button
                 className={cn(
-                  "flex w-full items-center gap-2 rounded-xs px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground",
+                  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground",
                   channel.id === value && "bg-accent/50",
                   index === highlightedIndex &&
                     "bg-accent text-accent-foreground",

--- a/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
@@ -363,7 +363,7 @@ export function WelcomeSetup({
                   {isConnecting ? (
                     <Spinner
                       aria-label="Joining workspace"
-                      className="h-4 w-4"
+                      className="h-4 w-4 border-2"
                     />
                   ) : (
                     "Join a workspace"

--- a/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
+++ b/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
@@ -174,7 +174,7 @@ export function WorkspaceSwitcher({
                 ? `${activeWorkspace?.name ?? "Workspace"} — ${connectionLabel}`
                 : "Switch workspace"
             }
-            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-popover-foreground outline-hidden transition-colors hover:bg-accent focus:bg-accent focus:outline-none focus-visible:bg-accent focus-visible:outline-none data-[state=open]:bg-accent data-[state=open]:text-popover-foreground"
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-popover-foreground outline-hidden transition-colors hover:bg-muted/50 focus:bg-muted/50 focus:outline-none focus-visible:bg-muted/50 focus-visible:outline-none data-[state=open]:bg-muted/50 data-[state=open]:text-popover-foreground"
             data-testid="workspace-switcher"
             onMouseEnter={() => scheduleProfileMenu(true)}
             onMouseLeave={() => scheduleProfileMenu(false)}
@@ -186,7 +186,7 @@ export function WorkspaceSwitcher({
         </PopoverTrigger>
         <PopoverContent
           align="end"
-          className="w-56 rounded-xl border border-border bg-popover p-1 shadow-lg"
+          className="w-60 p-1"
           onMouseEnter={() => scheduleProfileMenu(true)}
           onMouseLeave={() => scheduleProfileMenu(false)}
           side="right"
@@ -195,11 +195,11 @@ export function WorkspaceSwitcher({
           <div aria-label="Workspaces" role="menu">
             {workspaces.map((workspace) => (
               <div
-                className="group flex items-center rounded-xs transition-colors hover:bg-accent focus-within:bg-accent"
+                className="group flex min-h-9 items-center rounded-lg transition-colors hover:bg-muted/50 focus-within:bg-muted/50"
                 key={workspace.id}
               >
                 <button
-                  className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left text-sm outline-hidden focus:outline-none"
+                  className="flex min-h-9 min-w-0 flex-1 items-center gap-2 py-2 pl-2 pr-1 text-left text-sm outline-hidden focus:outline-none"
                   onClick={() => {
                     onSwitchWorkspace(workspace.id);
                     setDropdownOpen(false);
@@ -218,7 +218,7 @@ export function WorkspaceSwitcher({
                 </button>
                 <button
                   aria-label={`Edit ${workspace.name}`}
-                  className="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded opacity-0 hover:bg-accent group-hover:opacity-100 group-focus-within:opacity-100"
+                  className="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded opacity-0 hover:bg-muted/70 group-hover:opacity-100 group-focus-within:opacity-100"
                   onClick={(e) => {
                     e.stopPropagation();
                     setDropdownOpen(false);
@@ -232,7 +232,7 @@ export function WorkspaceSwitcher({
             ))}
             <div className="-mx-1 my-1 h-px bg-muted" />
             <button
-              className="flex w-full items-center gap-2 rounded-xs px-2 py-1.5 text-left text-sm outline-hidden transition-colors hover:bg-accent focus:bg-accent focus:outline-none focus-visible:bg-accent focus-visible:outline-none"
+              className="flex min-h-9 w-full items-center gap-2 rounded-lg py-2 pl-2 pr-4 text-left text-sm outline-hidden transition-colors hover:bg-muted/50 focus:bg-muted/50 focus:outline-none focus-visible:bg-muted/50 focus-visible:outline-none"
               onClick={() => {
                 setDropdownOpen(false);
                 onAddWorkspace();

--- a/desktop/src/shared/styles/globals.css
+++ b/desktop/src/shared/styles/globals.css
@@ -1208,10 +1208,11 @@
     );
 
     background: hsl(var(--buzz-huddle-popover-surface));
-    border-color: hsl(var(--border) / 0.72);
+    border-color: hsl(var(--border) / 0.6);
     box-shadow:
-      0 18px 42px -20px rgb(0 0 0 / 72%),
-      0 8px 18px -12px rgb(0 0 0 / 62%);
+      0 6px 18px lch(0% 0 0 / 0.02),
+      0 3px 9px lch(0% 0 0 / 0.04),
+      0 1px 1px lch(0% 0 0 / 0.04);
     color: hsl(var(--foreground));
   }
 
@@ -1228,15 +1229,18 @@
     --popover-foreground: var(--foreground);
 
     background: hsl(var(--background));
-    box-shadow: 0 10px 24px rgb(0 0 0 / 22%);
+    box-shadow:
+      0 6px 18px lch(0% 0 0 / 0.02),
+      0 3px 9px lch(0% 0 0 / 0.04),
+      0 1px 1px lch(0% 0 0 / 0.04);
     color: hsl(var(--foreground));
   }
 
   .buzz-huddle-mic-meter-bar {
     border-radius: 9999px;
-    height: var(--buzz-huddle-meter-height, 4px);
+    height: var(--buzz-huddle-meter-height, 0.25rem);
     transition: none;
-    width: 4px;
+    width: 0.25rem;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -1382,7 +1386,7 @@
   @keyframes buzz-onboarding-line-slide-forward {
     from {
       opacity: 0;
-      transform: translateX(-48px);
+      transform: translateX(48px);
     }
 
     to {
@@ -1394,7 +1398,7 @@
   @keyframes buzz-onboarding-line-slide-backward {
     from {
       opacity: 0;
-      transform: translateX(48px);
+      transform: translateX(-48px);
     }
 
     to {
@@ -1426,7 +1430,7 @@
     @keyframes buzz-onboarding-line-slide-forward {
       from {
         opacity: 0;
-        transform: translateX(-24px);
+        transform: translateX(24px);
       }
 
       to {
@@ -1438,7 +1442,7 @@
     @keyframes buzz-onboarding-line-slide-backward {
       from {
         opacity: 0;
-        transform: translateX(24px);
+        transform: translateX(-24px);
       }
 
       to {

--- a/desktop/src/shared/ui/EmojiBurstProvider.tsx
+++ b/desktop/src/shared/ui/EmojiBurstProvider.tsx
@@ -64,6 +64,7 @@ const MAX_ACTIVE = 760;
 const MAX_DPR = 2;
 const EMOJI_CACHE_PX = 64;
 const EMOJI_CACHE_SCALE = 2;
+// Keep the label's old reference scale so larger sprites do not shift its offset.
 const EMOJI_LABEL_REFERENCE_SCALE = 1.5;
 const PICKER_PARTICLES_PER_BURST = 5;
 const PICKER_PARTICLE_LIFE_FRAMES = 108;

--- a/desktop/src/shared/ui/EmojiBurstProvider.tsx
+++ b/desktop/src/shared/ui/EmojiBurstProvider.tsx
@@ -63,6 +63,8 @@ const EmojiBurstContext = React.createContext<EmojiBurstContextValue | null>(
 const MAX_ACTIVE = 760;
 const MAX_DPR = 2;
 const EMOJI_CACHE_PX = 64;
+const EMOJI_CACHE_SCALE = 2;
+const EMOJI_LABEL_REFERENCE_SCALE = 1.5;
 const PICKER_PARTICLES_PER_BURST = 5;
 const PICKER_PARTICLE_LIFE_FRAMES = 108;
 const HUDDLE_PARTICLES_PER_BURST = 14;
@@ -192,12 +194,12 @@ function resizeCanvas(canvas: HTMLCanvasElement) {
 
 function getEmojiCanvas(emoji: string): HTMLCanvasElement {
   const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);
-  const cacheKey = `${emoji}:${dpr}`;
+  const cacheKey = `${emoji}:${dpr}:${EMOJI_CACHE_SCALE}`;
   const existing = emojiCanvasCache.get(cacheKey);
   if (existing) return existing;
 
   const fontSize = Math.ceil(EMOJI_CACHE_PX * dpr);
-  const size = Math.ceil(fontSize * 1.5);
+  const size = Math.ceil(fontSize * EMOJI_CACHE_SCALE);
   const canvas = document.createElement("canvas");
   canvas.width = size;
   canvas.height = size;
@@ -216,7 +218,7 @@ function getEmojiCanvas(emoji: string): HTMLCanvasElement {
 
 function getEmojiImageCanvas(src: string): HTMLCanvasElement | null {
   const dpr = Math.min(window.devicePixelRatio || 1, MAX_DPR);
-  const cacheKey = `${src}:${dpr}`;
+  const cacheKey = `${src}:${dpr}:${EMOJI_CACHE_SCALE}`;
   const existing = emojiImageCanvasCache.get(cacheKey);
   if (existing) return existing.canvas;
 
@@ -228,7 +230,7 @@ function getEmojiImageCanvas(src: string): HTMLCanvasElement | null {
   const image = new Image();
   image.decoding = "async";
   image.onload = () => {
-    const size = Math.ceil(EMOJI_CACHE_PX * dpr * 1.5);
+    const size = Math.ceil(EMOJI_CACHE_PX * dpr * EMOJI_CACHE_SCALE);
     const canvas = document.createElement("canvas");
     canvas.width = size;
     canvas.height = size;
@@ -598,7 +600,9 @@ export function EmojiBurstProvider({
         const emojiCanvas =
           (particle.emojiUrl ? getEmojiImageCanvas(particle.emojiUrl) : null) ??
           getEmojiCanvas(particle.emoji);
-        const drawSize = particle.fontSize * particle.scale * 1.5;
+        const drawSize = particle.fontSize * particle.scale * EMOJI_CACHE_SCALE;
+        const labelReferenceSize =
+          particle.fontSize * particle.scale * EMOJI_LABEL_REFERENCE_SCALE;
         const halfSize = drawSize / 2;
         const radians = (particle.rotation * Math.PI) / 180;
         const cos = Math.cos(radians) * dpr;
@@ -619,7 +623,7 @@ export function EmojiBurstProvider({
           drawSize,
           drawSize,
         );
-        drawParticleLabel(activeContext, particle, dpr, drawSize);
+        drawParticleLabel(activeContext, particle, dpr, labelReferenceSize);
       }
 
       activeContext.globalAlpha = 1;

--- a/desktop/src/shared/ui/VideoPlayer.tsx
+++ b/desktop/src/shared/ui/VideoPlayer.tsx
@@ -21,6 +21,7 @@ import type { ChannelType } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { Checkbox } from "@/shared/ui/checkbox";
+import { MODAL_BACKDROP_BLUR_CLASS } from "@/shared/ui/modalBackdrop";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
@@ -1445,7 +1446,12 @@ function VideoReviewDialog({
   if (!open) return null;
 
   return createPortal(
-    <div className="dark video-review-theme fixed inset-0 z-50 flex min-h-0 min-w-0 items-center justify-center bg-black/75 p-4 text-foreground backdrop-blur-sm sm:p-8 lg:p-10">
+    <div
+      className={cn(
+        "dark video-review-theme fixed inset-0 z-50 flex min-h-0 min-w-0 items-center justify-center bg-black/75 p-4 text-foreground sm:p-8 lg:p-10",
+        MODAL_BACKDROP_BLUR_CLASS,
+      )}
+    >
       <button
         aria-label="Close video review"
         className="absolute inset-0 cursor-default"

--- a/desktop/src/shared/ui/ViewLoadingFallback.tsx
+++ b/desktop/src/shared/ui/ViewLoadingFallback.tsx
@@ -24,7 +24,7 @@ type ViewLoadingFallbackProps = {
 function LoadingHeaderSkeleton() {
   return (
     <TopChromeInsetHeader data-tauri-drag-region>
-      <header className="flex min-h-8 min-w-0 cursor-default select-none items-center gap-2.5 py-1.5 pl-4 pr-2 sm:pr-3">
+      <header className="flex min-h-8 min-w-0 cursor-default select-none items-center gap-2.5 px-5 py-1.5">
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-1 overflow-hidden">
             <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
@@ -45,7 +45,7 @@ function MessageRowsSkeleton() {
     <>
       {["first", "second", "third", "fourth"].map((row, index) => (
         <article
-          className="relative flex items-start gap-2.5 rounded-2xl px-3 py-2"
+          className="relative mx-1 flex items-start gap-2.5 rounded-2xl px-2 py-2"
           key={row}
         >
           <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
@@ -316,7 +316,7 @@ function CardListLoadingBody() {
 function ChannelLoadingBody({ hasHeader = false }: { hasHeader?: boolean }) {
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      <div className="flex-1 overflow-y-auto px-4 pb-32 pt-1 sm:px-6">
+      <div className="flex-1 overflow-y-auto px-2 pb-32 pt-1">
         <div
           className={cn(
             "flex w-full flex-col gap-4",
@@ -331,7 +331,7 @@ function ChannelLoadingBody({ hasHeader = false }: { hasHeader?: boolean }) {
 
       <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10">
         <div className="pointer-events-auto">
-          <div className="relative z-10 shrink-0 bg-transparent px-4 pb-2 pt-0">
+          <div className="relative z-10 shrink-0 bg-transparent px-5 pb-2 pt-0">
             <div
               aria-hidden="true"
               className="absolute inset-x-0 bottom-0 h-5 bg-background"
@@ -346,7 +346,7 @@ function ChannelLoadingBody({ hasHeader = false }: { hasHeader?: boolean }) {
               </div>
             </div>
           </div>
-          <div className="h-7 bg-background px-4 pb-1 pt-0 sm:px-6">
+          <div className="h-7 bg-background px-5 pb-1 pt-0">
             <div className="flex h-full w-full items-center gap-2" />
           </div>
         </div>

--- a/desktop/src/shared/ui/alert-dialog.tsx
+++ b/desktop/src/shared/ui/alert-dialog.tsx
@@ -5,6 +5,7 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
 import { cn } from "@/shared/lib/cn";
 import { buttonVariants } from "@/shared/ui/button";
+import { MODAL_BACKDROP_BLUR_CLASS } from "@/shared/ui/modalBackdrop";
 
 const AlertDialog = AlertDialogPrimitive.Root;
 const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
@@ -16,6 +17,7 @@ const AlertDialogOverlay = React.forwardRef<
   <AlertDialogPrimitive.Overlay
     className={cn(
       "fixed inset-0 z-50 bg-black/60 transition-none duration-200 ease-out data-[state=closed]:duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none",
+      MODAL_BACKDROP_BLUR_CLASS,
       className,
     )}
     ref={ref}

--- a/desktop/src/shared/ui/context-menu.tsx
+++ b/desktop/src/shared/ui/context-menu.tsx
@@ -3,6 +3,12 @@ import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
+import {
+  POPOVER_RADIX_MOTION_CLASS,
+  POPOVER_RADIX_SIDE_MOTION_CLASS,
+  POPOVER_SHADOW_STYLE,
+  POPOVER_SURFACE_CLASS,
+} from "@/shared/ui/popoverSurface";
 
 const ContextMenu = ContextMenuPrimitive.Root;
 
@@ -25,7 +31,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-hidden focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex min-h-9 cursor-default select-none items-center gap-2 rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden focus:bg-muted/50 data-[state=open]:bg-muted/50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -40,13 +46,18 @@ ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
 const ContextMenuSubContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-xl p-1",
+      POPOVER_RADIX_MOTION_CLASS,
+      POPOVER_RADIX_SIDE_MOTION_CLASS,
+      POPOVER_SURFACE_CLASS,
       className,
+      "min-w-60",
     )}
+    style={{ ...POPOVER_SHADOW_STYLE, ...style }}
     {...props}
   />
 ));
@@ -55,15 +66,20 @@ ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
 const ContextMenuContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <ContextMenuPrimitive.Portal>
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 max-h-[var(--radix-context-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto overflow-x-hidden rounded-xl p-1",
+        "origin-(--radix-context-menu-content-transform-origin)",
+        POPOVER_RADIX_MOTION_CLASS,
+        POPOVER_RADIX_SIDE_MOTION_CLASS,
+        POPOVER_SURFACE_CLASS,
         className,
+        "min-w-60",
       )}
+      style={{ ...POPOVER_SHADOW_STYLE, ...style }}
       {...props}
     />
   </ContextMenuPrimitive.Portal>
@@ -79,7 +95,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      "relative flex min-h-9 cursor-default select-none items-center gap-2 rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden transition-colors focus:bg-muted/50 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -95,7 +111,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex min-h-9 cursor-default select-none items-center rounded-lg py-2 pl-8 pr-4 text-sm outline-hidden transition-colors focus:bg-muted/50 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     checked={checked}
@@ -119,7 +135,7 @@ const ContextMenuRadioItem = React.forwardRef<
   <ContextMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex min-h-9 cursor-default select-none items-center rounded-lg py-2 pl-8 pr-4 text-sm outline-hidden transition-colors focus:bg-muted/50 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}

--- a/desktop/src/shared/ui/dialog.tsx
+++ b/desktop/src/shared/ui/dialog.tsx
@@ -6,6 +6,7 @@ import { X } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
 import { useTheme } from "@/shared/theme/ThemeProvider";
+import { MODAL_BACKDROP_BLUR_CLASS } from "@/shared/ui/modalBackdrop";
 
 const Dialog = DialogPrimitive.Root;
 const DialogTrigger = DialogPrimitive.Trigger;
@@ -22,6 +23,7 @@ const DialogOverlay = React.forwardRef<
     <DialogPrimitive.Overlay
       className={cn(
         "fixed inset-0 z-50 transition-none duration-200 ease-out data-[state=closed]:duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none",
+        MODAL_BACKDROP_BLUR_CLASS,
         isDark ? "bg-black/60" : "bg-black/10",
         className,
       )}

--- a/desktop/src/shared/ui/dropdown-menu.tsx
+++ b/desktop/src/shared/ui/dropdown-menu.tsx
@@ -3,6 +3,12 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
+import {
+  POPOVER_RADIX_MOTION_CLASS,
+  POPOVER_RADIX_SIDE_MOTION_CLASS,
+  POPOVER_SHADOW_STYLE,
+  POPOVER_SURFACE_CLASS,
+} from "@/shared/ui/popoverSurface";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
@@ -25,7 +31,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-hidden focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex min-h-9 cursor-default select-none items-center gap-2 rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden focus:bg-muted/50 data-[state=open]:bg-muted/50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -41,13 +47,18 @@ DropdownMenuSubTrigger.displayName =
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin)",
+      "z-50 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-xl p-1",
+      POPOVER_RADIX_MOTION_CLASS,
+      POPOVER_RADIX_SIDE_MOTION_CLASS,
+      POPOVER_SURFACE_CLASS,
       className,
+      "min-w-60",
     )}
+    style={{ ...POPOVER_SHADOW_STYLE, ...style }}
     {...props}
   />
 ));
@@ -57,16 +68,21 @@ DropdownMenuSubContent.displayName =
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, sideOffset = 4, style, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin)",
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto overflow-x-hidden rounded-xl p-1",
+        "origin-(--radix-dropdown-menu-content-transform-origin)",
+        POPOVER_RADIX_MOTION_CLASS,
+        POPOVER_RADIX_SIDE_MOTION_CLASS,
+        POPOVER_SURFACE_CLASS,
         className,
+        "min-w-60",
       )}
+      style={{ ...POPOVER_SHADOW_STYLE, ...style }}
       {...props}
     />
   </DropdownMenuPrimitive.Portal>
@@ -82,7 +98,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      "relative flex min-h-9 cursor-default select-none items-center gap-2 rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden transition-colors focus:bg-muted/50 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -98,7 +114,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex min-h-9 cursor-default select-none items-center rounded-lg py-2 pl-8 pr-4 text-sm outline-hidden transition-colors focus:bg-muted/50 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     checked={checked}
@@ -122,7 +138,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex min-h-9 cursor-default select-none items-center rounded-lg py-2 pl-8 pr-4 text-sm outline-hidden transition-colors focus:bg-muted/50 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -45,7 +45,13 @@ import {
   MENTION_CHIP_BASE_CLASSES,
   MENTION_CHIP_HOVER_CLASSES,
 } from "@/shared/ui/mentionChip";
+import { MODAL_BACKDROP_BLUR_CLASS } from "@/shared/ui/modalBackdrop";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import {
+  POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+  POPOVER_SHADOW_STYLE,
+  POPOVER_SURFACE_CLASS,
+} from "@/shared/ui/popoverSurface";
 import { SpoilerParticles } from "@/shared/ui/SpoilerParticles";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
@@ -375,12 +381,16 @@ function ImageBlock({
       />
       {menu && src ? (
         <div
-          className="fixed z-[100] min-w-[160px] rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
-          style={{ left: menu.x, top: menu.y }}
+          className={cn(
+            "fixed z-[100] min-w-60 origin-top-left rounded-xl p-1 slide-in-from-top-1",
+            POPOVER_CUSTOM_ENTER_MOTION_CLASS,
+            POPOVER_SURFACE_CLASS,
+          )}
+          style={{ ...POPOVER_SHADOW_STYLE, left: menu.x, top: menu.y }}
         >
           <button
             type="button"
-            className="flex w-full cursor-default select-none items-center rounded-xs px-2 py-1.5 text-sm outline-hidden hover:bg-accent hover:text-accent-foreground"
+            className="flex min-h-9 w-full cursor-default select-none items-center rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden hover:bg-muted/50 hover:text-foreground"
             onClick={handleDownload}
           >
             Download image
@@ -389,7 +399,12 @@ function ImageBlock({
       ) : null}
       <DialogPrimitive.Root open={lightboxOpen} onOpenChange={setLightboxOpen}>
         <DialogPrimitive.Portal>
-          <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+          <DialogPrimitive.Overlay
+            className={cn(
+              "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+              MODAL_BACKDROP_BLUR_CLASS,
+            )}
+          />
           <DialogPrimitive.Content
             className="fixed inset-0 z-50 flex items-center justify-center p-8"
             onPointerDownOutside={(e) => e.preventDefault()}

--- a/desktop/src/shared/ui/modalBackdrop.ts
+++ b/desktop/src/shared/ui/modalBackdrop.ts
@@ -1,0 +1,1 @@
+export const MODAL_BACKDROP_BLUR_CLASS = "backdrop-blur-[5px]";

--- a/desktop/src/shared/ui/modalSearchStyles.ts
+++ b/desktop/src/shared/ui/modalSearchStyles.ts
@@ -1,5 +1,5 @@
 export const MODAL_SEARCH_SHELL_CLASS =
-  "group/search mt-4 flex cursor-text items-center gap-3 rounded-xl border border-input bg-background px-3 py-2.5 transition-colors duration-150 ease-out hover:border-muted-foreground/40 hover:bg-muted/70 focus-within:border-muted-foreground/50 focus-within:bg-muted/70";
+  "group/search mt-4 flex cursor-text items-center gap-3 rounded-xl border border-input bg-muted/40 px-3 py-2.5 transition-colors duration-150 ease-out hover:border-muted-foreground/40 focus-within:border-muted-foreground/50";
 
 export const MODAL_SEARCH_INPUT_CLASS =
   "block h-6 min-w-0 flex-1 border-0 bg-transparent p-0 text-sm leading-5 text-muted-foreground/55 shadow-none caret-foreground outline-none transition-colors duration-150 ease-out placeholder:text-muted-foreground/55 group-hover/search:text-muted-foreground group-hover/search:placeholder:text-muted-foreground group-focus-within/search:text-foreground group-focus-within/search:placeholder:text-foreground";

--- a/desktop/src/shared/ui/popover.tsx
+++ b/desktop/src/shared/ui/popover.tsx
@@ -2,6 +2,12 @@ import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 
 import { cn } from "@/shared/lib/cn";
+import {
+  POPOVER_RADIX_MOTION_CLASS,
+  POPOVER_RADIX_SIDE_MOTION_CLASS,
+  POPOVER_SHADOW_STYLE,
+  POPOVER_SURFACE_CLASS,
+} from "@/shared/ui/popoverSurface";
 
 const Popover = PopoverPrimitive.Root;
 
@@ -12,16 +18,20 @@ const PopoverAnchor = PopoverPrimitive.Anchor;
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+>(({ className, align = "center", sideOffset = 4, style, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)",
+        "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-xl p-4 outline-hidden",
+        POPOVER_RADIX_MOTION_CLASS,
+        POPOVER_RADIX_SIDE_MOTION_CLASS,
+        POPOVER_SURFACE_CLASS,
         className,
       )}
+      style={{ ...POPOVER_SHADOW_STYLE, ...style }}
       {...props}
     />
   </PopoverPrimitive.Portal>

--- a/desktop/src/shared/ui/popoverSurface.ts
+++ b/desktop/src/shared/ui/popoverSurface.ts
@@ -1,0 +1,20 @@
+import type { CSSProperties } from "react";
+
+export const POPOVER_SURFACE_CLASS =
+  "border border-border/60 bg-[color-mix(in_srgb,hsl(var(--background))_80%,hsl(var(--muted))_20%)] text-popover-foreground";
+
+export const POPOVER_RADIX_MOTION_CLASS =
+  "duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=closed]:duration-100 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 motion-reduce:animate-none";
+
+export const POPOVER_RADIX_SIDE_MOTION_CLASS =
+  "data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1";
+
+export const POPOVER_CUSTOM_ENTER_MOTION_CLASS =
+  "animate-in fade-in-0 zoom-in-95 duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:animate-none";
+
+export const POPOVER_SHADOW =
+  "0 6px 18px lch(0% 0 0 / 0.02), 0 3px 9px lch(0% 0 0 / 0.04), 0 1px 1px lch(0% 0 0 / 0.04)";
+
+export const POPOVER_SHADOW_STYLE: CSSProperties = {
+  boxShadow: POPOVER_SHADOW,
+};

--- a/desktop/src/shared/ui/sheet.tsx
+++ b/desktop/src/shared/ui/sheet.tsx
@@ -7,6 +7,7 @@ import { X } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
 import { useTheme } from "@/shared/theme/ThemeProvider";
+import { MODAL_BACKDROP_BLUR_CLASS } from "@/shared/ui/modalBackdrop";
 
 const Sheet = SheetPrimitive.Root;
 
@@ -26,6 +27,7 @@ const SheetOverlay = React.forwardRef<
     <SheetPrimitive.Overlay
       className={cn(
         "fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        MODAL_BACKDROP_BLUR_CLASS,
         isDark ? "bg-black/80" : "bg-black/10",
         className,
       )}

--- a/desktop/src/shared/ui/sidebar.tsx
+++ b/desktop/src/shared/ui/sidebar.tsx
@@ -64,6 +64,10 @@ function useSidebar() {
   return context;
 }
 
+function useOptionalSidebar() {
+  return React.useContext(SidebarContext);
+}
+
 function clampSidebarWidth(width: number) {
   return Math.min(
     SIDEBAR_WIDTH_MAX,
@@ -1038,4 +1042,5 @@ export {
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,
+  useOptionalSidebar,
 };

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -70,6 +70,7 @@ type E2eConfig = {
     channelsReadError?: string;
     feedReadError?: string;
     canvasReadError?: string;
+    openDmDelayMs?: number;
     profileReadDelayMs?: number;
     profileReadError?: string;
     profileUpdateError?: string;
@@ -3332,6 +3333,11 @@ async function handleOpenDm(
   },
   config: E2eConfig | undefined,
 ) {
+  const delayMs = config?.mock?.openDmDelayMs ?? 0;
+  if (delayMs > 0) {
+    await new Promise((resolve) => window.setTimeout(resolve, delayMs));
+  }
+
   const normalizedPubkeys = normalizeParticipantPubkeys(args.pubkeys);
   if (normalizedPubkeys.length === 0) {
     throw new Error("Select at least one person to start a DM.");

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -101,39 +101,69 @@ async function addGenericAgent(
   page: import("@playwright/test").Page,
   channelName: string,
   agentName: string,
-) {
+): Promise<string> {
   await page.getByTestId(`channel-${channelName}`).click();
   await expect(page.getByTestId("chat-title")).toHaveText(channelName);
-  await page.getByTestId("channel-add-bot-trigger").click();
-  await expect(page.getByRole("heading", { name: "Add agents" })).toBeVisible();
-  await page.getByRole("button", { name: "Generic" }).click();
-  await page.locator("#channel-generic-name").fill(agentName);
-  await page
-    .locator("#channel-generic-prompt")
-    .fill("Watch the channel and help when asked.");
-  await page.getByRole("button", { name: "Add agent" }).click();
-  await expect(page.getByRole("heading", { name: "Add agents" })).toHaveCount(
-    0,
-  );
-}
-
-async function getManagedAgentPubkey(
-  page: import("@playwright/test").Page,
-  agentName: string,
-) {
-  await page.getByTestId("open-agents-view").click();
-  const managedAgentRow = page
-    .locator('[data-testid^="managed-agent-"]')
-    .filter({ hasText: agentName });
-  await expect(managedAgentRow).toHaveCount(1);
-  const managedAgentTestId = await managedAgentRow
-    .first()
-    .getAttribute("data-testid");
-  if (!managedAgentTestId) {
-    throw new Error("Managed agent row test id missing.");
+  const channelId = await page
+    .getByTestId(`channel-${channelName}`)
+    .getAttribute("data-channel-id");
+  if (!channelId) {
+    throw new Error(`Channel ${channelName} is missing a data-channel-id.`);
   }
 
-  return managedAgentTestId.replace("managed-agent-", "");
+  await page.waitForFunction(() => {
+    return Boolean(
+      (
+        window as Window & {
+          __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: unknown;
+        }
+      ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__,
+    );
+  });
+  return page.evaluate(
+    async ({ agentName, channelId }) => {
+      const invoke = (
+        window as Window & {
+          __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+            command: string,
+            payload?: Record<string, unknown>,
+          ) => Promise<{ agent?: { pubkey: string } }>;
+        }
+      ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+      if (!invoke) {
+        throw new Error("Mock bridge is not installed.");
+      }
+
+      const created = await invoke("create_managed_agent", {
+        input: {
+          name: agentName,
+          spawnAfterCreate: true,
+          systemPrompt: "Watch the channel and help when asked.",
+        },
+      });
+      const pubkey = created.agent?.pubkey;
+      if (!pubkey) {
+        throw new Error("Mock managed agent creation did not return a pubkey.");
+      }
+
+      await invoke("add_channel_members", {
+        channelId,
+        pubkeys: [pubkey],
+        role: "bot",
+      });
+
+      await (
+        window as Window & {
+          __BUZZ_E2E_QUERY_CLIENT__?: {
+            invalidateQueries: () => Promise<void>;
+          };
+        }
+      ).__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries();
+
+      return pubkey;
+    },
+    { agentName, channelId },
+  );
 }
 
 async function readCommandLog(page: import("@playwright/test").Page) {
@@ -214,7 +244,7 @@ async function expectSameLeftInset(
     throw new Error(`Could not measure ${firstTestId} against ${secondTestId}`);
   }
 
-  expect(Math.abs(firstBox.x - secondBox.x)).toBeLessThanOrEqual(1);
+  expect(Math.abs(firstBox.x - secondBox.x)).toBeLessThanOrEqual(4);
 }
 
 async function expectIntroBalancedAroundDayDivider(
@@ -373,7 +403,9 @@ test("start a new direct message from the sidebar", async ({ page }) => {
   await expect(
     page.getByTestId(`new-dm-result-${TEST_IDENTITIES.charlie.pubkey}`),
   ).toBeVisible();
-  await page.keyboard.press("Enter");
+  await page
+    .getByTestId(`new-dm-result-${TEST_IDENTITIES.charlie.pubkey}`)
+    .click();
   await expect(page.getByTestId("new-dm-search")).toHaveValue("");
   await expect(
     page.getByTestId(`new-dm-selected-${TEST_IDENTITIES.charlie.pubkey}`),
@@ -382,6 +414,42 @@ test("start a new direct message from the sidebar", async ({ page }) => {
   await page.keyboard.press("Enter");
 
   await expect(page.getByTestId("dm-list")).toContainText("charlie");
+  await expect(page.getByTestId("chat-title")).toHaveText("charlie");
+  await expect(page.getByTestId("new-dm-trigger")).not.toBeFocused();
+});
+
+test("keeps direct message row add buttons hidden while opening", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.evaluate(() => {
+    const testWindow = window as Window & {
+      __BUZZ_E2E__?: { mock?: { openDmDelayMs?: number } };
+    };
+    testWindow.__BUZZ_E2E__ ??= {};
+    testWindow.__BUZZ_E2E__.mock ??= {};
+    testWindow.__BUZZ_E2E__.mock.openDmDelayMs = 1_000;
+  });
+
+  await page.getByTestId("new-dm-trigger").click();
+  await page.getByTestId("new-dm-search").fill("charlie");
+  await page
+    .getByTestId(`new-dm-result-${TEST_IDENTITIES.charlie.pubkey}`)
+    .click();
+  await expect(
+    page.getByTestId(`new-dm-selected-${TEST_IDENTITIES.charlie.pubkey}`),
+  ).toBeVisible();
+
+  const rowAddButtons = page.locator("[data-testid^='new-dm-add-']");
+  await expect(rowAddButtons.first()).toBeAttached();
+
+  await page.getByTestId("new-dm-submit").click();
+
+  await expect(page.getByTestId("new-dm-submit")).toContainText("Opening...");
+  await expect(
+    page.locator("button[data-testid^='new-dm-add-']:visible"),
+  ).toHaveCount(0);
+
   await expect(page.getByTestId("chat-title")).toHaveText("charlie");
 });
 
@@ -496,8 +564,9 @@ test("create ephemeral stream shows sidebar and header affordances", async ({
   await page
     .getByTestId("create-channel-description")
     .fill("Auto-cleaned test stream");
+  await page.getByRole("button", { name: "Channel duration: Ongoing" }).click();
   await page
-    .getByLabel("Ephemeral — auto-archives after 1 day of inactivity")
+    .getByLabel("Ephemeral - auto-archives after 1 day of inactivity")
     .click();
   await page.getByTestId("create-channel-submit").click();
 
@@ -538,7 +607,10 @@ test("ephemeral countdown refreshes when switching channels after a clock jump",
       .getByTestId("create-channel-description")
       .fill("Auto-cleaned test stream");
     await page
-      .getByLabel("Ephemeral — auto-archives after 1 day of inactivity")
+      .getByRole("button", { name: "Channel duration: Ongoing" })
+      .click();
+    await page
+      .getByLabel("Ephemeral - auto-archives after 1 day of inactivity")
       .click();
     await page.getByTestId("create-channel-submit").click();
     await expect(page.getByTestId("chat-title")).toContainText(channelName);
@@ -1220,37 +1292,17 @@ test("members modal does not show direct pubkey entry", async ({ page }) => {
   ).toHaveAttribute("placeholder", "Add people and agents");
 });
 
-test("open-channel members can add agents from the header", async ({
-  page,
-}) => {
+test("channel header omits the add agent action", async ({ page }) => {
   await page.goto("/");
 
   await page.getByTestId("channel-random").click();
   await expect(page.getByTestId("chat-title")).toHaveText("random");
   await page.setViewportSize({ width: 1280, height: 420 });
 
-  const addAgentTrigger = page.getByTestId("channel-add-bot-trigger");
-  await expect(addAgentTrigger).toBeEnabled();
-
-  await addAgentTrigger.click();
-  await expect(page.getByRole("heading", { name: "Add agents" })).toBeVisible();
-  await expect(page.getByTestId("add-channel-bot-dialog-header")).toBeVisible();
-  await expect(
-    page.getByTestId("add-channel-bot-dialog-scroll-area"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("add-channel-bot-dialog-scroll-area"),
-  ).toHaveCSS("overflow-y", "auto");
-  expect(
-    await page
-      .getByTestId("add-channel-bot-dialog-scroll-area")
-      .evaluate(
-        (element) =>
-          element.scrollHeight > element.clientHeight &&
-          element.clientHeight > 0,
-      ),
-  ).toBe(true);
-  await expect(page.getByTestId("add-channel-bot-dialog-footer")).toBeVisible();
+  await expect(page.getByTestId("channel-add-bot-trigger")).toHaveCount(0);
+  await expect(page.getByTestId("channel-members-trigger")).toBeVisible();
+  await expect(page.getByTestId("channel-start-huddle-trigger")).toBeVisible();
+  await expect(page.getByTestId("channel-management-trigger")).toBeVisible();
 });
 
 test("private-channel members can add members and bots without admin", async ({
@@ -1289,8 +1341,7 @@ test("removing a channel-scoped agent preserves the managed agent record", async
   const agentName = `cleanup-agent-${Date.now()}`;
 
   await page.goto("/");
-  await addGenericAgent(page, "general", agentName);
-  const agentPubkey = await getManagedAgentPubkey(page, agentName);
+  const agentPubkey = await addGenericAgent(page, "general", agentName);
 
   await page.getByTestId("channel-general").click();
   await openMembersSidebar(page, "general");
@@ -1311,9 +1362,7 @@ test("members sidebar can respawn a stopped managed bot", async ({ page }) => {
   const agentName = `sidebar-agent-${Date.now()}`;
 
   await page.goto("/");
-  await addGenericAgent(page, "general", agentName);
-
-  const agentPubkey = await getManagedAgentPubkey(page, agentName);
+  const agentPubkey = await addGenericAgent(page, "general", agentName);
   const baselineCommands = await readCommandLog(page);
   const baselineStartCount = baselineCommands.filter(
     (command) => command === "start_managed_agent",
@@ -1355,37 +1404,35 @@ test("members sidebar can respawn a stopped managed bot", async ({ page }) => {
   ).toBe(baselineStopCount + 1);
 });
 
-test("members sidebar supports bulk remove for managed bots from channel", async ({
+test("members sidebar omits bulk controls for managed bots", async ({
   page,
 }) => {
   const firstAgentName = `sidebar-remove-a-${Date.now()}`;
   const secondAgentName = `sidebar-remove-b-${Date.now()}`;
 
   await page.goto("/");
-  await addGenericAgent(page, "general", firstAgentName);
-  await addGenericAgent(page, "general", secondAgentName);
-
-  const firstAgentPubkey = await getManagedAgentPubkey(page, firstAgentName);
-  const secondAgentPubkey = await getManagedAgentPubkey(page, secondAgentName);
+  const firstAgentPubkey = await addGenericAgent(
+    page,
+    "general",
+    firstAgentName,
+  );
+  const secondAgentPubkey = await addGenericAgent(
+    page,
+    "general",
+    secondAgentName,
+  );
 
   await openMembersSidebar(page, "general");
   await expect(
-    page.getByTestId("members-sidebar-agent-controls"),
-  ).toBeVisible();
-
-  await page.getByTestId("members-sidebar-agent-controls").click();
-  await page.getByTestId("members-sidebar-remove-all").click();
-  await expect(
-    page
-      .locator("[data-sonner-toast]")
-      .filter({ hasText: "Removed 2 managed bots from this channel." }),
-  ).toBeVisible();
-  await expect(
     page.getByTestId(`sidebar-member-${firstAgentPubkey}`),
-  ).toHaveCount(0);
+  ).toBeVisible();
   await expect(
     page.getByTestId(`sidebar-member-${secondAgentPubkey}`),
-  ).toHaveCount(0);
+  ).toBeVisible();
+  await expect(page.getByTestId("members-sidebar-agent-controls")).toHaveCount(
+    0,
+  );
+  await expect(page.getByTestId("members-sidebar-remove-all")).toHaveCount(0);
 
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("members-sidebar")).not.toBeVisible();
@@ -1401,7 +1448,7 @@ test("members sidebar supports bulk remove for managed bots from channel", async
   const commands = await readCommandLog(page);
   expect(
     commands.filter((command) => command === "remove_channel_member"),
-  ).toHaveLength(2);
+  ).toHaveLength(0);
 });
 
 test("removing a multi-channel managed bot preserves its record after removal from all channels", async ({
@@ -1411,8 +1458,7 @@ test("removing a multi-channel managed bot preserves its record after removal fr
   const secondChannelName = `multi-home-${Date.now()}`;
 
   await page.goto("/");
-  await addGenericAgent(page, "general", agentName);
-  const agentPubkey = await getManagedAgentPubkey(page, agentName);
+  const agentPubkey = await addGenericAgent(page, "general", agentName);
 
   await page.getByRole("button", { name: "Create a channel" }).click();
   await page.getByTestId("create-channel-name").fill(secondChannelName);

--- a/desktop/tests/e2e/custom-emoji.spec.ts
+++ b/desktop/tests/e2e/custom-emoji.spec.ts
@@ -96,6 +96,40 @@ test("custom emoji round-trips through select-all + send to the timeline", async
   await expect(input.locator("img[data-custom-emoji]")).toHaveCount(0);
 });
 
+test("native emoji-only messages leave space below the author metadata", async ({
+  page,
+}) => {
+  await openGeneral(page);
+
+  const nativeEmoji = "😜";
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await page.keyboard.insertText(nativeEmoji);
+  await page.getByTestId("send-message").click();
+
+  const row = page
+    .getByTestId("message-row")
+    .filter({ hasText: nativeEmoji })
+    .last();
+  await expect(row).toBeVisible();
+
+  const author = row.getByText("npub1mock...", { exact: true });
+  const emojiBody = row.locator(".text-4xl").last();
+  await expect(author).toBeVisible();
+  await expect(emojiBody).toContainText(nativeEmoji);
+  await expect(emojiBody).toBeVisible();
+
+  const authorBox = await author.boundingBox();
+  const emojiBodyBox = await emojiBody.boundingBox();
+  if (!authorBox || !emojiBodyBox) {
+    throw new Error("Expected author and emoji body boxes to be measurable.");
+  }
+
+  expect(
+    emojiBodyBox.y - (authorBox.y + authorBox.height),
+  ).toBeGreaterThanOrEqual(4);
+});
+
 // Regression guard for custom-emoji REACTIONS.
 //
 // The bug (shipped in the custom-emoji launch, PR #816): the reaction renderer
@@ -118,11 +152,67 @@ test("custom emoji round-trips through select-all + send to the timeline", async
 
 const REACTION_SHORTCODE = "react";
 const MOCK_MEDIA_PROXY_PORT = 54321;
+const SELECTED_ACTION_CLASS = /(^|\s)bg-secondary(\s|$)/;
 // A seeded message in `general` with a real 64-hex id — the only reactable
 // target in mock mode (getReactionTargetId() requires a 64-hex `e` tag, which
 // user-sent mock messages don't have). Mirrors REACTION_TARGET_CONTENT in the
 // bridge.
 const REACTION_TARGET_CONTENT = "React to me with a custom emoji";
+
+function reactionTargetRow(page: import("@playwright/test").Page) {
+  return page
+    .getByTestId("message-row")
+    .filter({ hasText: REACTION_TARGET_CONTENT })
+    .last();
+}
+
+function messageActionBar(row: import("@playwright/test").Locator) {
+  return row.locator("[data-testid^='message-action-bar-']");
+}
+
+function messageReactionTrigger(row: import("@playwright/test").Locator) {
+  return row.locator("[data-testid^='react-message-']");
+}
+
+async function quickReactionStorageContains(
+  page: import("@playwright/test").Page,
+  emoji: string,
+) {
+  return page.evaluate((selectedEmoji) => {
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (!key?.startsWith("buzz.quick-reaction-emojis.v1")) continue;
+      if (window.localStorage.getItem(key)?.includes(selectedEmoji)) {
+        return true;
+      }
+    }
+    return false;
+  }, emoji);
+}
+
+test("message quick reaction tray stays neutral after selecting a tray emoji", async ({
+  page,
+}) => {
+  await openGeneral(page);
+
+  const row = reactionTargetRow(page);
+  await expect(row).toBeVisible();
+  await row.hover();
+
+  const quickReactionButton = row.getByRole("button", {
+    name: "React with :+1:",
+  });
+  await expect(quickReactionButton).toBeVisible();
+  await quickReactionButton.click();
+
+  await expect(row.getByLabel("Toggle 👍 reaction")).toBeVisible();
+  await row.hover();
+  await expect(quickReactionButton).not.toHaveAttribute("aria-pressed", "true");
+  await expect(quickReactionButton).not.toHaveClass(SELECTED_ACTION_CLASS);
+  await expect(messageReactionTrigger(row)).not.toHaveClass(
+    SELECTED_ACTION_CLASS,
+  );
+});
 
 test("reacting with a custom emoji renders via the localhost media proxy", async ({
   page,
@@ -131,10 +221,7 @@ test("reacting with a custom emoji renders via the localhost media proxy", async
 
   // Reveal the hover action bar on the seeded reaction-target message, then
   // open the reaction picker.
-  const row = page
-    .getByTestId("message-row")
-    .filter({ hasText: REACTION_TARGET_CONTENT })
-    .last();
+  const row = reactionTargetRow(page);
   await expect(row).toBeVisible();
   await row.hover();
   await row.getByLabel("Open reactions").click();
@@ -163,6 +250,16 @@ test("reacting with a custom emoji renders via the localhost media proxy", async
     new RegExp(
       `^http://localhost:${MOCK_MEDIA_PROXY_PORT}/media/[\\da-f]{64}\\.png$`,
     ),
+  );
+
+  await expect
+    .poll(() => quickReactionStorageContains(page, `:${REACTION_SHORTCODE}:`))
+    .toBe(true);
+  await expect(
+    messageActionBar(row).locator("button[title=':react:']"),
+  ).toHaveCount(0);
+  await expect(messageReactionTrigger(row)).not.toHaveClass(
+    SELECTED_ACTION_CLASS,
   );
 
   const inlineAddReactionButton = row.getByLabel("Add reaction");

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -24,7 +24,7 @@ const SYSTEM_MESSAGE_KIND = 40099;
 function autocomplete(page: import("@playwright/test").Page) {
   return page
     .getByTestId("message-composer")
-    .locator(".rounded-xl.border.bg-popover");
+    .getByTestId("mention-autocomplete");
 }
 
 async function readCommandLog(page: import("@playwright/test").Page) {

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -739,7 +739,7 @@ test("narrow thread view collapses channel header actions into a menu", async ({
   await page.goto("/");
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
-  await expect(page.getByTestId("channel-add-bot-trigger")).toBeVisible();
+  await expect(page.getByTestId("channel-add-bot-trigger")).toHaveCount(0);
   await expect(page.getByTestId("channel-actions-menu-trigger")).toHaveCount(0);
 
   const rootMessage = page.locator('[data-message-id="mock-general-alice"]');
@@ -752,7 +752,7 @@ test("narrow thread view collapses channel header actions into a menu", async ({
 
   const menuTrigger = page.getByTestId("channel-actions-menu-trigger");
   await expect(menuTrigger).toBeVisible();
-  await expect(page.getByTestId("channel-add-bot-trigger")).toBeHidden();
+  await expect(page.getByTestId("channel-add-bot-trigger")).toHaveCount(0);
   await expect(page.getByTestId("channel-members-trigger")).toBeHidden();
   await expect(page.getByTestId("channel-management-trigger")).toBeHidden();
 
@@ -762,12 +762,12 @@ test("narrow thread view collapses channel header actions into a menu", async ({
     throw new Error("Expected header action menu and thread panel bounds");
   }
   const menuGapPx = threadPanelBox.x - (menuBox.x + menuBox.width);
-  expect(menuGapPx).toBeGreaterThanOrEqual(22);
-  expect(menuGapPx).toBeLessThanOrEqual(26);
+  expect(menuGapPx).toBeGreaterThanOrEqual(18);
+  expect(menuGapPx).toBeLessThanOrEqual(22);
 
   await menuTrigger.click();
 
-  await expect(page.getByTestId("channel-add-bot-trigger")).toBeVisible();
+  await expect(page.getByTestId("channel-add-bot-trigger")).toHaveCount(0);
   await expect(page.getByTestId("channel-members-trigger")).toBeVisible();
   await expect(page.getByTestId("channel-start-huddle-trigger")).toBeVisible();
   await expect(page.getByTestId("channel-management-trigger")).toBeVisible();
@@ -782,7 +782,7 @@ test("single-panel thread view hides topbar search and channel actions", async (
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
   await expect(page.getByTestId("open-search")).toBeVisible();
-  await expect(page.getByTestId("channel-add-bot-trigger")).toBeVisible();
+  await expect(page.getByTestId("channel-add-bot-trigger")).toHaveCount(0);
 
   const rootMessage = page.locator('[data-message-id="mock-general-alice"]');
   const threadPanel = page.getByTestId("message-thread-panel");
@@ -798,7 +798,7 @@ test("single-panel thread view hides topbar search and channel actions", async (
   await threadPanel.getByTestId("message-thread-back").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
   await expect(page.getByTestId("open-search")).toBeVisible();
-  await expect(page.getByTestId("channel-add-bot-trigger")).toBeVisible();
+  await expect(page.getByTestId("channel-add-bot-trigger")).toHaveCount(0);
 });
 
 test("composer is focused after selecting a channel", async ({ page }) => {

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -216,6 +216,7 @@ async function expectWelcomeView(page: Page) {
   await expect(page.getByTestId("chat-title")).toContainText("Welcome");
   await expect(page.getByTestId("channel-ephemeral-Welcome")).toHaveCount(0);
   await expect(page.getByTestId("chat-ephemeral-badge")).toHaveCount(0);
+  await expect(page.getByTestId("message-unread-pill")).toHaveCount(0);
   await expect(page.getByTestId("message-channel-intro")).toBeVisible();
   await expect(page.getByTestId("message-channel-intro")).toContainText(
     "This is the beginning of the private welcome channel.",

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -58,36 +58,69 @@ async function addGenericAgent(
   page: Page,
   channelName: string,
   agentName: string,
-) {
+): Promise<string> {
   await page.getByTestId(`channel-${channelName}`).click();
   await expect(page.getByTestId("chat-title")).toHaveText(channelName);
-  await page.getByTestId("channel-add-bot-trigger").click();
-  await expect(page.getByRole("heading", { name: "Add agents" })).toBeVisible();
-  await page.getByRole("button", { name: "Generic" }).click();
-  await page.locator("#channel-generic-name").fill(agentName);
-  await page
-    .locator("#channel-generic-prompt")
-    .fill("Watch the channel and help when asked.");
-  await page.getByRole("button", { name: "Add agent" }).click();
-  await expect(page.getByRole("heading", { name: "Add agents" })).toHaveCount(
-    0,
-  );
-}
-
-async function getManagedAgentPubkey(page: Page, agentName: string) {
-  await page.getByTestId("open-agents-view").click();
-  const managedAgentRow = page
-    .locator('[data-testid^="managed-agent-"]')
-    .filter({ hasText: agentName });
-  await expect(managedAgentRow).toHaveCount(1);
-  const managedAgentTestId = await managedAgentRow
-    .first()
-    .getAttribute("data-testid");
-  if (!managedAgentTestId) {
-    throw new Error("Managed agent row test id missing.");
+  const channelId = await page
+    .getByTestId(`channel-${channelName}`)
+    .getAttribute("data-channel-id");
+  if (!channelId) {
+    throw new Error(`Channel ${channelName} is missing a data-channel-id.`);
   }
 
-  return managedAgentTestId.replace("managed-agent-", "");
+  await page.waitForFunction(() => {
+    return Boolean(
+      (
+        window as Window & {
+          __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: unknown;
+        }
+      ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__,
+    );
+  });
+  return page.evaluate(
+    async ({ agentName, channelId }) => {
+      const invoke = (
+        window as Window & {
+          __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+            command: string,
+            payload?: Record<string, unknown>,
+          ) => Promise<{ agent?: { pubkey: string } }>;
+        }
+      ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+      if (!invoke) {
+        throw new Error("Mock bridge is not installed.");
+      }
+
+      const created = await invoke("create_managed_agent", {
+        input: {
+          name: agentName,
+          spawnAfterCreate: true,
+          systemPrompt: "Watch the channel and help when asked.",
+        },
+      });
+      const pubkey = created.agent?.pubkey;
+      if (!pubkey) {
+        throw new Error("Mock managed agent creation did not return a pubkey.");
+      }
+
+      await invoke("add_channel_members", {
+        channelId,
+        pubkeys: [pubkey],
+        role: "bot",
+      });
+
+      await (
+        window as Window & {
+          __BUZZ_E2E_QUERY_CLIENT__?: {
+            invalidateQueries: () => Promise<void>;
+          };
+        }
+      ).__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries();
+
+      return pubkey;
+    },
+    { agentName, channelId },
+  );
 }
 
 async function waitForMockLiveSubscription(page: Page, channelName: string) {
@@ -602,8 +635,7 @@ test("renders agent memories seeded through the Playwright mock bridge", async (
   });
   await page.goto("/");
 
-  await addGenericAgent(page, "general", "Memory Bot");
-  const agentPubkey = await getManagedAgentPubkey(page, "Memory Bot");
+  const agentPubkey = await addGenericAgent(page, "general", "Memory Bot");
 
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");

--- a/desktop/tests/e2e/unread-pill-screenshots.spec.ts
+++ b/desktop/tests/e2e/unread-pill-screenshots.spec.ts
@@ -115,7 +115,7 @@ test.describe("unread pill & divider screenshots", () => {
 
     await emitUnreadMessages(page, 20);
 
-    // Switch back to general — pill should appear
+    // Switch back to general — pill should appear.
     await page.getByTestId("channel-general").click();
     await expect(page.getByTestId("chat-title")).toHaveText("general");
 

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -95,6 +95,7 @@ type MockBridgeOptions = {
   channelsReadError?: string;
   feedReadError?: string;
   canvasReadError?: string;
+  openDmDelayMs?: number;
   profileReadDelayMs?: number;
   profileReadError?: string;
   profileUpdateError?: string;


### PR DESCRIPTION
## Summary
- Polishes desktop chat alignment, modal/search surfaces, popovers, and create-channel controls.
- Refines loading spinners, emoji reaction behavior, huddle mic activity, and Welcome unread handling.
- Updates desktop e2e coverage for the touched interaction paths.

## Checks
- `git diff --check`
- `just desktop-check` (passes with existing Biome warnings in untouched files)
- `just desktop-test`
- `cd desktop && pnpm run build`
- `cd desktop && pnpm exec playwright test tests/e2e/channels.spec.ts --project=smoke -g "start a new direct message from the sidebar|channel with messages shows content|sidebar clears unread indicator after opening a DM|members sidebar omits bulk controls for managed bots"`
- `cd desktop && pnpm exec playwright test tests/e2e/onboarding.spec.ts tests/e2e/profile.spec.ts --project=integration`