### PR TITLE
ci: use running postgres for pgschema desired-state planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,13 @@ jobs:
           PGUSER: buzz
           PGPASSWORD: buzz_dev
           PGDATABASE: buzz
+          # Use the already-running docker postgres for desired-state planning instead of
+          # downloading an embedded Postgres from Maven Central (transient-fetch flake source).
+          PGSCHEMA_PLAN_HOST: localhost
+          PGSCHEMA_PLAN_PORT: "5432"
+          PGSCHEMA_PLAN_DB: buzz
+          PGSCHEMA_PLAN_USER: buzz
+          PGSCHEMA_PLAN_PASSWORD: buzz_dev
       - name: Download relay binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## Problem

The `Desktop E2E Integration` job flakes with:

```
Error: failed to start embedded PostgreSQL: no version found matching 18.0.0
```

This is a misleading error. `./bin/pgschema apply` spins up a throwaway *embedded* Postgres (a Zonky binary downloaded from Maven Central) to build its desired-state catalog for the diff. The vendored `fergusstrange/embedded-postgres` library returns the literal string `no version found matching %s` on **any** non-200 response from Maven (timeout, 5xx, connection reset) — not just a true 404. The `18.0.0` artifact exists and resolves with HTTP 200, so this is a transient Maven Central fetch hiccup wearing a version-mismatch costume, uncorrelated with any code change. Blind reruns pass because the jar is genuinely there.

## Fix

Point pgschema at the already-running docker `buzz-postgres` (`postgres:18`) container as its external plan database via `PGSCHEMA_PLAN_*` env vars on the existing `Apply database schema` step.

In File Mode (`--file`), `apply` binds `PGSCHEMA_PLAN_*` to the `--plan-*` flags, and `CreateDesiredStateProvider` returns the external-database provider **before** the embedded path that calls `StartEmbeddedPostgres`. The Zonky/Maven download is never entered, so Maven Central is removed from the job's critical path permanently — this deletes the flaky dependency rather than dampening it.

Desired-state is built in a timestamp + crypto-random-suffixed temp schema (`pgschema_tmp_<ts>_<8hex>`) that is dropped on exit; `public` is never written during the plan phase. Plan and target are the same `postgres:18` container, satisfying pgschema's exact-major-version requirement.