### PR TITLE
fix(desktop): wrap long markdown autolinks

### DIFF
--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -1432,7 +1432,7 @@ function MarkdownInner({
       className={cn(
         MESSAGE_MARKDOWN_CLASS,
         [
-          "max-w-none break-words text-sm leading-relaxed text-foreground",
+          "max-w-none [overflow-wrap:anywhere] text-sm leading-relaxed text-foreground",
           "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
           "[&>*+*]:mt-3",
           "[&>p+p]:mt-1.5",

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -23,6 +23,46 @@ test("send a message and see it in timeline", async ({ page }) => {
   );
 });
 
+test("long autolink wraps without widening the timeline", async ({ page }) => {
+  await page.setViewportSize({ width: 800, height: 600 });
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const longUrl = `https://blocked.teams.cloudflare.com/?${"dependencyconfusionnpm".repeat(18)}`;
+  const message = `Step "adapter" failed: npm error invalid json response body at <${longUrl}> reason: Unexpected token '<'`;
+
+  await page.getByTestId("message-input").fill(message);
+  await page.getByTestId("send-message").click();
+
+  const timeline = page.getByTestId("message-timeline");
+  await expect(timeline).toContainText('Step "adapter" failed');
+  await expect
+    .poll(() =>
+      timeline.evaluate((element) => element.scrollWidth - element.clientWidth),
+    )
+    .toBeLessThanOrEqual(1);
+
+  const row = page.getByTestId("message-row").last();
+  await row.hover();
+
+  const actionBar = page.locator('[data-testid^="message-action-bar-"]').last();
+  await expect(actionBar).toHaveCSS("opacity", "1");
+  await expect
+    .poll(async () => {
+      const [barBox, timelineBox] = await Promise.all([
+        actionBar.boundingBox(),
+        timeline.boundingBox(),
+      ]);
+      if (!barBox || !timelineBox) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return barBox.x + barBox.width - (timelineBox.x + timelineBox.width);
+    })
+    .toBeLessThanOrEqual(0);
+});
+
 test("send multiple messages in sequence", async ({ page }) => {
   const ts = Date.now();
   const messages = [


### PR DESCRIPTION
## Summary
- Use `overflow-wrap:anywhere` for desktop Markdown message content so long autolinks participate in flex min-content sizing
- Add an e2e regression that sends a long Markdown autolink, verifies the timeline does not horizontally overflow, and checks the hover action bar stays inside the timeline

## Verification
- `../bin/biome check tests/e2e/messaging.spec.ts src/shared/ui/markdown.tsx`
- `bin/pnpm --dir desktop build`
- `bin/pnpm --dir desktop exec playwright test tests/e2e/messaging.spec.ts -g "long autolink wraps without widening the timeline" --project=smoke`
- `bin/pnpm --dir desktop test`
- `bin/pnpm --dir desktop check` (exit 0; existing warnings/info only)
- pre-push hooks passed
