### PR TITLE
fix(desktop): keep group DM message actions on-screen

### DIFF
--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -324,7 +324,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
                 showMessageList && !showIntro && "mt-auto",
               )}
               contentClassName={cn(
-                "flex flex-col gap-2",
+                "flex min-w-0 flex-col gap-2",
                 (showIntro || showGenericEmpty) && "min-h-full",
               )}
               loading={isLoading}


### PR DESCRIPTION
## Summary

Fix group-DM timelines whose intro content can force the timeline content wrapper wider than the viewport. When that happens, even short later messages (for example `Hi`) inherit the wide row width and their right-anchored hover action bar is clipped off-screen.

This adds `min-w-0` to the timeline reveal content wrapper so the group-DM intro and message list shrink within the visible timeline.

## Verification

- Reproduced in the desktop E2E app with a group DM containing long participant display names, then sent and hovered a short `Hi` message.
  - Before fix: timeline `scrollWidth` expanded to `2600` while `clientWidth` was `980`; the action bar right edge was off-screen.
  - After fix: timeline `scrollWidth == clientWidth == 980`; row width `956`; action bar right edge `1264` in a `1280` viewport.
- `cd desktop && ../bin/pnpm typecheck`
- `cd desktop && ../bin/pnpm check` exits 0; it still prints existing unrelated lint warnings in `thread-unread-screenshots.spec.ts`.

## Note

This replaces the earlier markdown-overflow framing in #1079 for the group-DM reaction-bar issue.
