### PR TITLE
fix(desktop): normalize loopback host for HTTP writes and stop Reminders nav flicker

### DIFF
--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -53,14 +53,28 @@ pub fn relay_http_base_url(relay_url: &str) -> String {
     let trimmed = relay_url.trim().trim_end_matches('/');
 
     if let Some(suffix) = trimmed.strip_prefix("wss://") {
-        return format!("https://{suffix}");
+        return format!("https://{}", normalize_loopback_host(suffix));
     }
 
     if let Some(suffix) = trimmed.strip_prefix("ws://") {
-        return format!("http://{suffix}");
+        return format!("http://{}", normalize_loopback_host(suffix));
     }
 
     trimmed.to_string()
+}
+
+/// Rewrite an exact `localhost` host to `127.0.0.1`, preserving port and path.
+///
+/// macOS resolves `localhost` to both `::1` and `127.0.0.1`; reqwest's
+/// happy-eyeballs may try `::1` first, which fails when the relay binds IPv4
+/// only (`0.0.0.0`). Forcing the IPv4 literal makes every HTTP write connect on
+/// the first attempt. Exact-match only — `localhost.evil.com` is untouched.
+fn normalize_loopback_host(authority: &str) -> String {
+    let host_len = authority.find([':', '/']).unwrap_or(authority.len());
+    if &authority[..host_len] == "localhost" {
+        return format!("127.0.0.1{}", &authority[host_len..]);
+    }
+    authority.to_string()
 }
 
 pub fn relay_api_base_url() -> String {
@@ -539,8 +553,64 @@ pub async fn submit_event_with_keys(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_profile_event, classify_intercepted_response, parse_command_response};
+    use super::{
+        build_profile_event, classify_intercepted_response, parse_command_response,
+        relay_http_base_url,
+    };
     use serde::Deserialize;
+
+    // ── relay_http_base_url loopback normalization ───────────────────────────
+
+    #[test]
+    fn loopback_ws_localhost_rewritten_to_ipv4() {
+        assert_eq!(
+            relay_http_base_url("ws://localhost:3000"),
+            "http://127.0.0.1:3000"
+        );
+    }
+
+    #[test]
+    fn loopback_trailing_slash_rewritten_to_ipv4() {
+        assert_eq!(
+            relay_http_base_url("ws://localhost:3000/"),
+            "http://127.0.0.1:3000"
+        );
+    }
+
+    #[test]
+    fn remote_wss_host_unchanged() {
+        assert_eq!(
+            relay_http_base_url("wss://relay.example.com"),
+            "https://relay.example.com"
+        );
+    }
+
+    #[test]
+    fn loopback_ipv4_literal_unchanged() {
+        assert_eq!(
+            relay_http_base_url("ws://127.0.0.1:3000"),
+            "http://127.0.0.1:3000"
+        );
+    }
+
+    #[test]
+    fn localhost_substring_host_not_rewritten() {
+        // Exact-match only: a host that merely starts with "localhost" must NOT
+        // be rewritten, or a malicious host could hijack the loopback path.
+        assert_eq!(
+            relay_http_base_url("ws://localhost.evil.com:3000"),
+            "http://localhost.evil.com:3000"
+        );
+    }
+
+    #[test]
+    fn loopback_wss_localhost_rewritten_to_ipv4() {
+        // The wss:// dev arm normalizes identically to ws://.
+        assert_eq!(
+            relay_http_base_url("wss://localhost:3000"),
+            "https://127.0.0.1:3000"
+        );
+    }
 
     // ── classify_intercepted_response ────────────────────────────────────────
 

--- a/desktop/src/features/reminders/ui/RemindersScreen.tsx
+++ b/desktop/src/features/reminders/ui/RemindersScreen.tsx
@@ -1,13 +1,8 @@
-import { useQuery } from "@tanstack/react-query";
-
-import { getIdentity } from "@/shared/api/tauri";
+import { useIdentityQuery } from "@/shared/api/hooks";
 import { RemindersPanel } from "./RemindersPanel";
 
 export function RemindersScreen() {
-  const identityQuery = useQuery({
-    queryKey: ["identity"],
-    queryFn: getIdentity,
-  });
+  const identityQuery = useIdentityQuery();
 
   if (!identityQuery.data?.pubkey) {
     return null;


### PR DESCRIPTION
Two independent desktop fixes, surfaced together while dogfooding the reminder flow against a local relay.

## Fix 1 — loopback host normalization

The desktop talks to the relay over two transports: WebSocket (subscriptions) and HTTP REST (every write). On macOS, `localhost` resolves to both `::1` and `127.0.0.1`. A local relay binds `0.0.0.0:3000` (IPv4 only), so nothing listens on `::1:3000`. The WebSocket client dials `127.0.0.1` directly and connects, but `reqwest`'s happy-eyeballs tries `::1` first for HTTP writes — the connection is refused, `is_connect()` is true, and `classify_request_error` emits `relay unreachable: could not connect to relay`. The result is a desktop that connects over WS but fails every `create_channel`/`submit_event` against a local relay.

`relay_http_base_url` now rewrites an exact `localhost` host to `127.0.0.1` when deriving the HTTP base, so `reqwest` never attempts `::1`. Scoped strictly to the loopback case:

- only the host segment is rewritten, and only when it is exactly `localhost` (port and path preserved);
- remote `ws://`/`wss://` hosts and IP literals are untouched;
- both the `ws://` → `http://` and `wss://` → `https://` arms normalize identically;
- `localhost.evil.com` is **not** rewritten (exact-match, not prefix/substring).

## Fix 2 — Reminders nav flicker / trap

Navigating to `/reminders` flickered "Setting up your workspace..." and trapped the user with no in-UI back. `RemindersScreen` rolled its own `useQuery({ queryKey: ["identity"], queryFn: getIdentity })` with no `staleTime` (defaults to `0`). On mount it saw the cached `["identity"]` entry as stale and fired a background refetch. React Query flips `fetchStatus` to `fetching` for **every** observer of that key — including the onboarding gate's `useIdentityQuery()`. The gate reads that as `identityIsFetching`, `resolveOnboardingGateStage` returns `blocking`, and `AppReady` swaps `RouterProvider` for the loading screen, killing the nav chrome.

`RemindersScreen` now consumes the shared `useIdentityQuery()` (which sets `staleTime: Infinity`), removing the second observer entirely. Navigating to `/reminders` no longer triggers an identity refetch, so the gate never flips to `blocking`. The `!identityQuery.data?.pubkey` guard reads identically against the shared hook's return shape; the now-unused `useQuery`/`getIdentity` imports are dropped.