### PR TITLE
Adjust unread pill spacing

### DIFF
--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -274,7 +274,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
         {showUnreadPill ? (
           <div
             className={cn(
-              "pointer-events-none absolute inset-x-0 z-20 flex justify-center px-4",
+              "pointer-events-none absolute inset-x-0 z-20 flex translate-y-3 justify-center px-4",
               channelChrome.top,
             )}
           >

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -250,7 +250,7 @@ export function AppSidebar({
       ? "bottom-56"
       : sidebarFooterCardCount >= 1
         ? "bottom-44"
-        : "bottom-28";
+        : "bottom-24";
   const [isNewDmOpenInternal, setIsNewDmOpenInternal] = React.useState(false);
   const isNewDmOpen = isNewDmOpenProp ?? isNewDmOpenInternal;
   const setIsNewDmOpen = onNewDmOpenChange ?? setIsNewDmOpenInternal;


### PR DESCRIPTION
## Summary
- add top spacing for the channel unread pill below the message header chrome
- tighten the sidebar bottom unread pill offset so its footer gap matches the top overlay spacing

## Verification
- `./bin/pnpm --dir desktop exec tsc --noEmit`
- `./bin/pnpm --dir desktop run build`
- `./bin/pnpm --dir desktop exec playwright test unread-pill-screenshots.spec.ts --project=smoke`
- `./bin/just desktop-check` (passes with existing unrelated warnings in `readStateManager.test.mjs` and `thread-unread-screenshots.spec.ts`)
- `git diff --check`
