### PR TITLE
Remove deferred render opacity pulse

### DIFF
--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -428,14 +428,7 @@ export function MessageThreadPanel({
         <div className="px-3 pb-3 pt-1" data-testid="message-thread-replies">
           {repliesRenderState === "list" ? (
             <div
-              className={cn(
-                "space-y-2.5",
-                // While a deferred render is in flight the painted reply list
-                // lags the latest `threadReplies`. Dim it slightly so the
-                // streaming-in reads as intentional instead of frozen — mirrors
-                // the main timeline.
-                isRepliesPending && "opacity-60 transition-opacity",
-              )}
+              className="space-y-2.5"
               data-render-pending={isRepliesPending ? "true" : undefined}
             >
               {deferredThreadReplies.map((entry, index) => {

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { ArrowDown, ArrowUp, Hash } from "lucide-react";
 
+import { selectDeferredListRenderState } from "@/features/messages/lib/timelineSnapshot";
 import { getDmParticipantPreview } from "@/features/channels/lib/dmParticipantDisplay";
 import type { TimelineMessage } from "@/features/messages/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
@@ -252,16 +253,27 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     sentinelRef: topSentinelRef,
   });
 
-  const showDirectMessageIntro = !isLoading && directMessageIntro !== null;
+  const timelineRenderState = selectDeferredListRenderState(
+    deferredMessages.length,
+    messages.length,
+  );
+  const isDeferredListPending = !isLoading && timelineRenderState === "pending";
+  const showDirectMessageIntro =
+    !isLoading &&
+    timelineRenderState !== "pending" &&
+    directMessageIntro !== null;
   const showChannelIntro =
-    !isLoading && channelIntro !== null && directMessageIntro === null;
+    !isLoading &&
+    timelineRenderState !== "pending" &&
+    channelIntro !== null &&
+    directMessageIntro === null;
   const showIntro = showDirectMessageIntro || showChannelIntro;
   const showGenericEmpty =
     !isLoading &&
-    deferredMessages.length === 0 &&
+    timelineRenderState === "empty" &&
     directMessageIntro === null &&
     channelIntro === null;
-  const showMessageList = !isLoading && deferredMessages.length > 0;
+  const showMessageList = !isLoading && timelineRenderState === "list";
   const timelineSkeletonRows = useTimelineSkeletonRows({
     channelId,
     isLoading,
@@ -327,7 +339,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
                 "flex flex-col gap-2",
                 (showIntro || showGenericEmpty) && "min-h-full",
               )}
-              loading={isLoading}
+              loading={isLoading || isDeferredListPending}
               skeleton={<TimelineSkeleton rows={timelineSkeletonRows} />}
             >
               {showDirectMessageIntro ? (

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -460,14 +460,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
 
               {showMessageList ? (
                 <div
-                  className={cn(
-                    "flex flex-col gap-2",
-                    !showIntro && "mt-auto",
-                    // While a deferred render is in flight the painted
-                    // list lags the latest `messages`. Dim it slightly so the
-                    // streaming-in feels intentional instead of frozen.
-                    isRenderPending && "opacity-60 transition-opacity",
-                  )}
+                  className={cn("flex flex-col gap-2", !showIntro && "mt-auto")}
                   data-render-pending={isRenderPending ? "true" : undefined}
                 >
                   <TimelineMessageList


### PR DESCRIPTION
## Summary
- remove the pending deferred-render opacity transition from the main message timeline
- remove the same visual dimming from thread replies
- keep `data-render-pending` intact so E2E wait helpers still synchronize on deferred commits
- keep intro/empty affordances hidden while live messages are waiting for the deferred list commit, so channel entry shows the message skeleton instead of briefly popping the channel intro before rows arrive

## Testing
- `bin/just desktop-typecheck`
- `bin/just desktop-test`
- `bin/just desktop-check`
- `cd desktop && pnpm build`
- `cd desktop && pnpm exec playwright test --project=smoke tests/e2e/mentions.spec.ts`
- `cd desktop && pnpm exec playwright test --project=smoke tests/e2e/smoke.spec.ts -g "replaces the channel pane when switching channels"`
- `cd desktop && pnpm exec playwright test --project=smoke tests/e2e/channels.spec.ts -g "empty channel shows intro actions|channel with messages shows content|sidebar clears unread indicator after opening a DM"`

Co-reviewed with @Brain in Buzz; Brain verified the initial diff and the `data-render-pending` constraint.
