### PR TITLE
ci: move reminder e2e to a dedicated backend-integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,15 +396,6 @@ jobs:
           exit 1
       - name: Seed desktop e2e data
         run: bash scripts/setup-desktop-test-data.sh
-      - name: Reminder runtime e2e (proves migrations provisioned the schema)
-        # Runs the NIP-ER reminder e2e against the migration-provisioned relay.
-        # If migrations/0003 is missing or wrong, every reminder INSERT/query
-        # 500s and these tests fail — the guard that the snapshot and the sqlx
-        # migration runner can never silently diverge again. One shard suffices.
-        if: matrix.shard == 1
-        run: cargo test --profile ci -p buzz-test-client --test e2e_event_reminder -- --ignored
-        env:
-          RELAY_URL: ws://localhost:3000
       - name: Desktop relay-backed e2e
         run: cd desktop && pnpm exec playwright test --project=integration --shard=${{ matrix.shard }}/2
       - name: Upload desktop integration artifacts
@@ -440,6 +431,94 @@ jobs:
             exit 1
           fi
           echo "Desktop E2E Integration shards passed"
+
+  backend-integration:
+    name: Backend Integration (relay e2e)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [changes, desktop-e2e-relay]
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name != 'pull_request' }}
+      - name: Start integration services
+        run: docker compose up -d postgres redis typesense minio minio-init
+      - name: Wait for integration services
+        run: |
+          wait_healthy() {
+            local service="$1"
+            local container="$2"
+            for attempt in $(seq 1 60); do
+              status=$(docker inspect --format='{{.State.Health.Status}}' "${container}" 2>/dev/null || echo "not_found")
+              if [ "${status}" = "healthy" ]; then
+                echo "${service} is healthy"
+                return 0
+              fi
+              sleep 2
+            done
+            docker logs "${container}" || true
+            return 1
+          }
+          wait_healthy "Postgres" "buzz-postgres"
+          wait_healthy "Redis" "buzz-redis"
+          wait_healthy "Typesense" "buzz-typesense"
+          wait_healthy "MinIO" "buzz-minio"
+      - name: Download relay binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: desktop-e2e-relay
+          path: target/ci
+      - name: Start relay
+        run: |
+          chmod +x ./target/ci/buzz-relay
+          nohup env \
+            DATABASE_URL=postgres://buzz:buzz_dev@localhost:5432/buzz \
+            BUZZ_AUTO_MIGRATE=true \
+            REDIS_URL=redis://localhost:6379 \
+            TYPESENSE_URL=http://localhost:8108 \
+            TYPESENSE_API_KEY=buzz_dev_key \
+            RELAY_URL=ws://localhost:3000 \
+            BUZZ_BIND_ADDR=0.0.0.0:3000 \
+            BUZZ_REQUIRE_AUTH_TOKEN=false \
+            BUZZ_RECONCILE_CHANNELS=true \
+            BUZZ_GIT_PROBE_WRITERS=8 \
+            SPROUT_REMINDER_SCHEDULER_INTERVAL_SECS=1 \
+            ./target/ci/buzz-relay > /tmp/buzz-relay.log 2>&1 &
+          echo $! > /tmp/buzz-relay.pid
+          for attempt in $(seq 1 60); do
+            if ! kill -0 "$(cat /tmp/buzz-relay.pid)" 2>/dev/null; then
+              cat /tmp/buzz-relay.log
+              exit 1
+            fi
+            status_code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/_readiness || true)
+            if [ "${status_code}" = "200" ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat /tmp/buzz-relay.log
+          exit 1
+      - name: NIP-ER reminder e2e
+        # Feature e2e for NIP-ER (Event Reminders, kind:30300): write-path
+        # validation, author-only read filtering, and scheduler delivery against
+        # a live relay. The schema-drift / migration-version guarantee is owned
+        # by the buzz-db migration.rs unit tests, not this suite.
+        run: cargo test --profile ci -p buzz-test-client --test e2e_event_reminder -- --ignored
+        env:
+          RELAY_URL: ws://localhost:3000
+      - name: Upload relay log
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: backend-integration-relay-log
+          path: /tmp/buzz-relay.log
+          if-no-files-found: ignore
 
   web:
     name: Web


### PR DESCRIPTION
## Problem

The NIP-ER reminder e2e ran as a step named `Reminder runtime e2e (proves migrations provisioned the schema)` inside the **Desktop E2E Integration** shard (`.github/workflows/ci.yml`). Two structural defects:

1. **The name lied.** The real schema-drift / migration-version guard lives in the `crates/buzz-db/src/migration.rs` unit tests — they assert the runner applies versions `[1,2,3]` on a fresh DB and that `schema/schema.sql` (the pgschema desired-state snapshot) has not drifted from migration output. That unit test is the sentinel. This suite's "migration proof" was incidental: if `migrations/0003` were missing, reminder `INSERT`s would 500 as a side effect — but that is not the test's reason to exist. It is feature e2e (write-path validation, author-only read filtering, scheduler delivery) in a sentinel costume.
2. **Orphan on the wrong job.** It was the only backend/relay `--ignored` e2e wired into CI, bolted onto a **Desktop** shard because the NIP-ER feature PR had nowhere proper to put it. `just test-integration` (the natural local home) cannot host a relay-backed `--ignored` suite without booting a relay, so the test had no backend CI home.

## Change

- Add a dedicated `backend-integration` job (`Backend Integration (relay e2e)`) that boots `postgres`, `redis`, `typesense`, `minio`, `minio-init` via docker compose, downloads the existing `desktop-e2e-relay` artifact, starts the migration-provisioned relay using the same proven relay-boot block, and runs the reminder suite.
- Remove the reminder step (and its `if: matrix.shard == 1`) from the Desktop E2E Integration shard. That shard keeps booting its relay for `Desktop relay-backed e2e`.
- Rename the step to `NIP-ER reminder e2e`; the step comment now describes it as feature e2e and points the schema-provisioning guarantee at the `migration.rs` unit tests where it correctly lives.
- The `migration.rs` unit tests are untouched.

## Notes

The `cargo test --profile ci -p buzz-test-client --test e2e_event_reminder -- --ignored` invocation and `RELAY_URL: ws://localhost:3000` env are preserved byte-identical, so the suite keeps running against a migration-provisioned relay rather than silently dropping to never-executed. The new job reuses the `desktop-e2e-relay` artifact (no duplicate relay build); its `if:` (`push || rust`) is a subset of the relay job's `if:`, so the artifact always exists when this job runs.

`backend-integration` is a new top-level CI check. If branch protection enumerates required checks explicitly, the new check should be added to the required set in repo settings.
