### PR TITLE
Smooth channel loading: single-surface timeline state machine

### DIFF
--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -35,7 +35,10 @@ import {
 } from "@/features/messages/lib/formatTimelineMessages";
 import { getThreadReference } from "@/features/messages/lib/threading";
 import { imetaMediaFromTags } from "@/features/messages/lib/imetaMediaMarkdown";
-import { selectTimelineLoadingState } from "@/features/messages/lib/timelineLoadingState";
+import {
+  resolveTimelineLoadingLatch,
+  selectTimelineLoadingState,
+} from "@/features/messages/lib/timelineLoadingState";
 import { useFetchOlderMessages } from "@/features/messages/useFetchOlderMessages";
 import { useLoadMissingAncestors } from "@/features/messages/useLoadMissingAncestors";
 import { useChannelTyping } from "@/features/messages/useChannelTyping";
@@ -477,7 +480,7 @@ export function ChannelScreen({
     });
   // `data !== undefined` is not "loaded": the cache is seeded early by stale
   // placeholders and the live subscription. Wait for the history fetch to settle.
-  const isTimelineLoading =
+  const timelineLoadingNow =
     activeChannel !== null &&
     activeChannel.channelType !== "forum" &&
     selectTimelineLoadingState({
@@ -486,6 +489,16 @@ export function ChannelScreen({
       isPlaceholderData: messagesQuery.isPlaceholderData,
       dataLength: messagesQuery.data?.length ?? null,
     });
+  // Latch loaded per channel so a later background refetch can't flip back to
+  // the skeleton — that re-flip is the "skeleton bouncing up and down" on entry.
+  const settledChannelIdRef = React.useRef<string | null>(null);
+  const { settledChannelId, isLoading: isTimelineLoading } =
+    resolveTimelineLoadingLatch(
+      settledChannelIdRef.current,
+      activeChannelId,
+      timelineLoadingNow,
+    );
+  settledChannelIdRef.current = settledChannelId;
   const shouldShowInitialChannelLoading = isTimelineLoading;
   // Panel identity (thread/profile/agent session) lives in the URL search
   // params, so channel changes and back/forward traversals carry it per

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -499,7 +499,6 @@ export function ChannelScreen({
       timelineLoadingNow,
     );
   settledChannelIdRef.current = settledChannelId;
-  const shouldShowInitialChannelLoading = isTimelineLoading;
   // Panel identity (thread/profile/agent session) lives in the URL search
   // params, so channel changes and back/forward traversals carry it per
   // history entry — only the local ephemeral targets need resetting here.
@@ -626,9 +625,7 @@ export function ChannelScreen({
           ref={channelContentRef}
         >
           {activeChannel ? (
-            shouldShowInitialChannelLoading ? (
-              <ViewLoadingFallback includeHeader kind="channel" />
-            ) : activeChannel.channelType === "forum" ? (
+            activeChannel.channelType === "forum" ? (
               <>
                 {channelHeader}
                 <React.Suspense fallback={<ViewLoadingFallback kind="forum" />}>

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/features/messages/lib/formatTimelineMessages";
 import { getThreadReference } from "@/features/messages/lib/threading";
 import { imetaMediaFromTags } from "@/features/messages/lib/imetaMediaMarkdown";
+import { selectTimelineLoadingState } from "@/features/messages/lib/timelineLoadingState";
 import { useFetchOlderMessages } from "@/features/messages/useFetchOlderMessages";
 import { useLoadMissingAncestors } from "@/features/messages/useLoadMissingAncestors";
 import { useChannelTyping } from "@/features/messages/useChannelTyping";
@@ -474,12 +475,17 @@ export function ChannelScreen({
       setThreadReplyTargetId,
       setThreadScrollTargetId,
     });
-  const hasTimelineData = messagesQuery.data !== undefined;
+  // `data !== undefined` is not "loaded": the cache is seeded early by stale
+  // placeholders and the live subscription. Wait for the history fetch to settle.
   const isTimelineLoading =
     activeChannel !== null &&
     activeChannel.channelType !== "forum" &&
-    !hasTimelineData &&
-    messagesQuery.isPending;
+    selectTimelineLoadingState({
+      isPending: messagesQuery.isPending,
+      isFetching: messagesQuery.isFetching,
+      isPlaceholderData: messagesQuery.isPlaceholderData,
+      dataLength: messagesQuery.data?.length ?? null,
+    });
   const shouldShowInitialChannelLoading = isTimelineLoading;
   // Panel identity (thread/profile/agent session) lives in the URL search
   // params, so channel changes and back/forward traversals carry it per

--- a/desktop/src/features/messages/lib/timelineLoadingState.test.mjs
+++ b/desktop/src/features/messages/lib/timelineLoadingState.test.mjs
@@ -71,3 +71,36 @@ test("background refetch of a populated channel is not loading", () => {
     false,
   );
 });
+
+import { resolveTimelineLoadingLatch } from "./timelineLoadingState.ts";
+
+test("latch: loading on first entry to a channel", () => {
+  const r = resolveTimelineLoadingLatch(null, "chan-a", true);
+  assert.equal(r.isLoading, true);
+  assert.equal(r.settledChannelId, null);
+});
+
+test("latch: settles when loadingNow turns false, recording the channel", () => {
+  const r = resolveTimelineLoadingLatch(null, "chan-a", false);
+  assert.equal(r.isLoading, false);
+  assert.equal(r.settledChannelId, "chan-a");
+});
+
+test("latch: background refetch blip stays loaded once settled", () => {
+  // settled for chan-a, then loadingNow blips true (isFetching) — must NOT
+  // re-show the skeleton (the bounce Wes reported).
+  const r = resolveTimelineLoadingLatch("chan-a", "chan-a", true);
+  assert.equal(r.isLoading, false);
+  assert.equal(r.settledChannelId, "chan-a");
+});
+
+test("latch: switching channels resets and loads the new one", () => {
+  const r = resolveTimelineLoadingLatch("chan-a", "chan-b", true);
+  assert.equal(r.isLoading, true);
+  assert.equal(r.settledChannelId, "chan-a"); // not yet settled for b
+});
+
+test("latch: no active channel passes loadingNow through untouched", () => {
+  assert.equal(resolveTimelineLoadingLatch("chan-a", null, true).isLoading, true);
+  assert.equal(resolveTimelineLoadingLatch("chan-a", null, false).isLoading, false);
+});

--- a/desktop/src/features/messages/lib/timelineLoadingState.test.mjs
+++ b/desktop/src/features/messages/lib/timelineLoadingState.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { selectTimelineLoadingState } from "./timelineLoadingState.ts";
+
+const settled = {
+  isPending: false,
+  isFetching: false,
+  isPlaceholderData: false,
+  dataLength: null,
+};
+
+test("pending first fetch with no cache is loading", () => {
+  assert.equal(
+    selectTimelineLoadingState({ ...settled, isPending: true }),
+    true,
+  );
+});
+
+test("stale placeholder while refetching is loading", () => {
+  // Revisited within gcTime: placeholderData hands back a cached array while the
+  // authoritative fetch runs. Must keep the skeleton up, not flash the intro.
+  assert.equal(
+    selectTimelineLoadingState({
+      ...settled,
+      isFetching: true,
+      isPlaceholderData: true,
+      dataLength: 0,
+    }),
+    true,
+  );
+});
+
+test("subscription-seeded empty cache while fetching is loading", () => {
+  // The live subscription's setQueryData seeds [] before history settles, so
+  // data is defined but empty and a fetch is still in flight.
+  assert.equal(
+    selectTimelineLoadingState({
+      ...settled,
+      isFetching: true,
+      isPlaceholderData: false,
+      dataLength: 0,
+    }),
+    true,
+  );
+});
+
+test("settled with rows is not loading", () => {
+  assert.equal(
+    selectTimelineLoadingState({ ...settled, dataLength: 5 }),
+    false,
+  );
+});
+
+test("settled and genuinely empty is not loading (real empty channel)", () => {
+  assert.equal(
+    selectTimelineLoadingState({ ...settled, dataLength: 0 }),
+    false,
+  );
+});
+
+test("background refetch of a populated channel is not loading", () => {
+  // staleTime expiry can trigger a background refetch; with rows already present
+  // we are loaded and must not re-show the skeleton.
+  assert.equal(
+    selectTimelineLoadingState({
+      ...settled,
+      isFetching: true,
+      dataLength: 12,
+    }),
+    false,
+  );
+});

--- a/desktop/src/features/messages/lib/timelineLoadingState.test.mjs
+++ b/desktop/src/features/messages/lib/timelineLoadingState.test.mjs
@@ -101,6 +101,12 @@ test("latch: switching channels resets and loads the new one", () => {
 });
 
 test("latch: no active channel passes loadingNow through untouched", () => {
-  assert.equal(resolveTimelineLoadingLatch("chan-a", null, true).isLoading, true);
-  assert.equal(resolveTimelineLoadingLatch("chan-a", null, false).isLoading, false);
+  assert.equal(
+    resolveTimelineLoadingLatch("chan-a", null, true).isLoading,
+    true,
+  );
+  assert.equal(
+    resolveTimelineLoadingLatch("chan-a", null, false).isLoading,
+    false,
+  );
 });

--- a/desktop/src/features/messages/lib/timelineLoadingState.ts
+++ b/desktop/src/features/messages/lib/timelineLoadingState.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure decision for "is the channel timeline still doing its initial load."
+ *
+ * Extracted so the windows below are covered by the lib `*.test.mjs` suite.
+ * The trap: `data !== undefined` looks like "loaded" but the per-channel query
+ * cache is seeded early — by a stale `placeholderData` on revisit, and by the
+ * live subscription's `setQueryData` — before the authoritative history fetch
+ * settles. Treating that as loaded flashes the channel intro/empty state over a
+ * list that is about to stream in.
+ */
+export type TimelineQueryStatus = {
+  isPending: boolean;
+  isFetching: boolean;
+  isPlaceholderData: boolean;
+  dataLength: number | null;
+};
+
+export function selectTimelineLoadingState(
+  status: TimelineQueryStatus,
+): boolean {
+  if (status.isPending) {
+    return true;
+  }
+  // A fetch is in flight; keep loading while what we'd show is a placeholder or
+  // still empty. Once real rows are present we are loaded, even mid-refetch.
+  return (
+    status.isFetching &&
+    (status.isPlaceholderData || (status.dataLength ?? 0) === 0)
+  );
+}

--- a/desktop/src/features/messages/lib/timelineLoadingState.ts
+++ b/desktop/src/features/messages/lib/timelineLoadingState.ts
@@ -28,3 +28,28 @@ export function selectTimelineLoadingState(
     (status.isPlaceholderData || (status.dataLength ?? 0) === 0)
   );
 }
+
+/**
+ * Monotonic loading latch keyed by channel. Once a channel has settled (loaded),
+ * `loadingNow` blipping true again (a background refetch) must not re-show the
+ * skeleton — that re-flip is the visible skeleton bounce on entry. A different
+ * channel id resets the latch so the new channel loads fresh.
+ */
+export function resolveTimelineLoadingLatch(
+  settledChannelId: string | null,
+  activeChannelId: string | null,
+  loadingNow: boolean,
+): { settledChannelId: string | null; isLoading: boolean } {
+  if (activeChannelId === null) {
+    return { settledChannelId, isLoading: loadingNow };
+  }
+  if (settledChannelId === activeChannelId) {
+    // Already settled for this channel — stay loaded through refetch blips.
+    return { settledChannelId, isLoading: false };
+  }
+  if (!loadingNow) {
+    // First settle for this channel; latch it.
+    return { settledChannelId: activeChannelId, isLoading: false };
+  }
+  return { settledChannelId, isLoading: true };
+}

--- a/desktop/src/features/messages/lib/timelineSnapshot.test.mjs
+++ b/desktop/src/features/messages/lib/timelineSnapshot.test.mjs
@@ -8,6 +8,7 @@ import {
   resolveDeepLinkTarget,
   selectDeferredListRenderState,
   selectLatestMessageKey,
+  selectTimelineSurface,
 } from "./timelineSnapshot.ts";
 
 // Local-midnight unix-second timestamps so isSameDay (local time) is stable
@@ -286,4 +287,73 @@ test("deferred-render: keys the empty decision off the live count, not deferred"
   // the empty state is a function of the LIVE list, never the lagging one.
   assert.equal(selectDeferredListRenderState(0, 0), "empty");
   assert.equal(selectDeferredListRenderState(0, 1), "pending");
+});
+
+test("timeline-surface: loading and deferred-pending both paint the single static skeleton", () => {
+  assert.equal(
+    selectTimelineSurface({
+      deferredCount: 0,
+      hasChannelIntro: false,
+      hasDirectMessageIntro: false,
+      isLoading: true,
+      liveCount: 0,
+    }),
+    "skeleton",
+  );
+  assert.equal(
+    selectTimelineSurface({
+      deferredCount: 0,
+      hasChannelIntro: true,
+      hasDirectMessageIntro: false,
+      isLoading: false,
+      liveCount: 3,
+    }),
+    "skeleton",
+  );
+});
+
+test("timeline-surface: live rows win over intro/empty surfaces", () => {
+  assert.equal(
+    selectTimelineSurface({
+      deferredCount: 2,
+      hasChannelIntro: true,
+      hasDirectMessageIntro: true,
+      isLoading: false,
+      liveCount: 2,
+    }),
+    "list",
+  );
+});
+
+test("timeline-surface: empty channels choose exactly one intro or empty surface", () => {
+  assert.equal(
+    selectTimelineSurface({
+      deferredCount: 0,
+      hasChannelIntro: false,
+      hasDirectMessageIntro: true,
+      isLoading: false,
+      liveCount: 0,
+    }),
+    "direct-message-intro",
+  );
+  assert.equal(
+    selectTimelineSurface({
+      deferredCount: 0,
+      hasChannelIntro: true,
+      hasDirectMessageIntro: false,
+      isLoading: false,
+      liveCount: 0,
+    }),
+    "channel-intro",
+  );
+  assert.equal(
+    selectTimelineSurface({
+      deferredCount: 0,
+      hasChannelIntro: false,
+      hasDirectMessageIntro: false,
+      isLoading: false,
+      liveCount: 0,
+    }),
+    "empty",
+  );
 });

--- a/desktop/src/features/messages/lib/timelineSnapshot.test.mjs
+++ b/desktop/src/features/messages/lib/timelineSnapshot.test.mjs
@@ -8,7 +8,8 @@ import {
   resolveDeepLinkTarget,
   selectDeferredListRenderState,
   selectLatestMessageKey,
-  selectTimelineSurface,
+  selectTimelineBodySurface,
+  selectTimelineIntroSurface,
 } from "./timelineSnapshot.ts";
 
 // Local-midnight unix-second timestamps so isSameDay (local time) is stable
@@ -289,22 +290,18 @@ test("deferred-render: keys the empty decision off the live count, not deferred"
   assert.equal(selectDeferredListRenderState(0, 1), "pending");
 });
 
-test("timeline-surface: loading and deferred-pending both paint the single static skeleton", () => {
+test("timeline-body-surface: loading and deferred-pending both paint the single static skeleton", () => {
   assert.equal(
-    selectTimelineSurface({
+    selectTimelineBodySurface({
       deferredCount: 0,
-      hasChannelIntro: false,
-      hasDirectMessageIntro: false,
       isLoading: true,
       liveCount: 0,
     }),
     "skeleton",
   );
   assert.equal(
-    selectTimelineSurface({
+    selectTimelineBodySurface({
       deferredCount: 0,
-      hasChannelIntro: true,
-      hasDirectMessageIntro: false,
       isLoading: false,
       liveCount: 3,
     }),
@@ -312,12 +309,10 @@ test("timeline-surface: loading and deferred-pending both paint the single stati
   );
 });
 
-test("timeline-surface: live rows win over intro/empty surfaces", () => {
+test("timeline-body-surface: deferred rows paint the message list", () => {
   assert.equal(
-    selectTimelineSurface({
+    selectTimelineBodySurface({
       deferredCount: 2,
-      hasChannelIntro: true,
-      hasDirectMessageIntro: true,
       isLoading: false,
       liveCount: 2,
     }),
@@ -325,35 +320,65 @@ test("timeline-surface: live rows win over intro/empty surfaces", () => {
   );
 });
 
-test("timeline-surface: empty channels choose exactly one intro or empty surface", () => {
+test("timeline-body-surface: empty only when live and deferred rows are empty", () => {
   assert.equal(
-    selectTimelineSurface({
+    selectTimelineBodySurface({
       deferredCount: 0,
-      hasChannelIntro: false,
-      hasDirectMessageIntro: true,
-      isLoading: false,
-      liveCount: 0,
-    }),
-    "direct-message-intro",
-  );
-  assert.equal(
-    selectTimelineSurface({
-      deferredCount: 0,
-      hasChannelIntro: true,
-      hasDirectMessageIntro: false,
-      isLoading: false,
-      liveCount: 0,
-    }),
-    "channel-intro",
-  );
-  assert.equal(
-    selectTimelineSurface({
-      deferredCount: 0,
-      hasChannelIntro: false,
-      hasDirectMessageIntro: false,
       isLoading: false,
       liveCount: 0,
     }),
     "empty",
+  );
+});
+
+test("timeline-intro-surface: skeleton suppresses intro while loading", () => {
+  assert.equal(
+    selectTimelineIntroSurface({
+      hasChannelIntro: true,
+      hasDirectMessageIntro: false,
+      isSkeletonVisible: true,
+    }),
+    null,
+  );
+});
+
+test("timeline-intro-surface: intro may coexist with the message list", () => {
+  assert.equal(
+    selectTimelineBodySurface({
+      deferredCount: 2,
+      isLoading: false,
+      liveCount: 2,
+    }),
+    "list",
+  );
+  assert.equal(
+    selectTimelineIntroSurface({
+      hasChannelIntro: true,
+      hasDirectMessageIntro: false,
+      isSkeletonVisible: false,
+    }),
+    "channel-intro",
+  );
+});
+
+test("timeline-intro-surface: direct-message intro wins over channel intro", () => {
+  assert.equal(
+    selectTimelineIntroSurface({
+      hasChannelIntro: true,
+      hasDirectMessageIntro: true,
+      isSkeletonVisible: false,
+    }),
+    "direct-message-intro",
+  );
+});
+
+test("timeline-intro-surface: no intro without an intro model", () => {
+  assert.equal(
+    selectTimelineIntroSurface({
+      hasChannelIntro: false,
+      hasDirectMessageIntro: false,
+      isSkeletonVisible: false,
+    }),
+    null,
   );
 });

--- a/desktop/src/features/messages/lib/timelineSnapshot.ts
+++ b/desktop/src/features/messages/lib/timelineSnapshot.ts
@@ -149,26 +149,17 @@ export function selectDeferredListRenderState(
   return "pending";
 }
 
-export type TimelineSurface =
-  | "skeleton"
-  | "direct-message-intro"
-  | "channel-intro"
-  | "empty"
-  | "list";
+export type TimelineBodySurface = "skeleton" | "empty" | "list";
 
-export function selectTimelineSurface({
+export function selectTimelineBodySurface({
   deferredCount,
-  hasChannelIntro,
-  hasDirectMessageIntro,
   isLoading,
   liveCount,
 }: {
   deferredCount: number;
-  hasChannelIntro: boolean;
-  hasDirectMessageIntro: boolean;
   isLoading: boolean;
   liveCount: number;
-}): TimelineSurface {
+}): TimelineBodySurface {
   if (isLoading) {
     return "skeleton";
   }
@@ -177,8 +168,25 @@ export function selectTimelineSurface({
   if (renderState === "pending") {
     return "skeleton";
   }
-  if (renderState === "list") {
-    return "list";
+  return renderState;
+}
+
+export type TimelineIntroSurface =
+  | "direct-message-intro"
+  | "channel-intro"
+  | null;
+
+export function selectTimelineIntroSurface({
+  hasChannelIntro,
+  hasDirectMessageIntro,
+  isSkeletonVisible,
+}: {
+  hasChannelIntro: boolean;
+  hasDirectMessageIntro: boolean;
+  isSkeletonVisible: boolean;
+}): TimelineIntroSurface {
+  if (isSkeletonVisible) {
+    return null;
   }
   if (hasDirectMessageIntro) {
     return "direct-message-intro";
@@ -186,5 +194,5 @@ export function selectTimelineSurface({
   if (hasChannelIntro) {
     return "channel-intro";
   }
-  return "empty";
+  return null;
 }

--- a/desktop/src/features/messages/lib/timelineSnapshot.ts
+++ b/desktop/src/features/messages/lib/timelineSnapshot.ts
@@ -148,3 +148,43 @@ export function selectDeferredListRenderState(
   }
   return "pending";
 }
+
+export type TimelineSurface =
+  | "skeleton"
+  | "direct-message-intro"
+  | "channel-intro"
+  | "empty"
+  | "list";
+
+export function selectTimelineSurface({
+  deferredCount,
+  hasChannelIntro,
+  hasDirectMessageIntro,
+  isLoading,
+  liveCount,
+}: {
+  deferredCount: number;
+  hasChannelIntro: boolean;
+  hasDirectMessageIntro: boolean;
+  isLoading: boolean;
+  liveCount: number;
+}): TimelineSurface {
+  if (isLoading) {
+    return "skeleton";
+  }
+
+  const renderState = selectDeferredListRenderState(deferredCount, liveCount);
+  if (renderState === "pending") {
+    return "skeleton";
+  }
+  if (renderState === "list") {
+    return "list";
+  }
+  if (hasDirectMessageIntro) {
+    return "direct-message-intro";
+  }
+  if (hasChannelIntro) {
+    return "channel-intro";
+  }
+  return "empty";
+}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -428,14 +428,7 @@ export function MessageThreadPanel({
         <div className="px-3 pb-3 pt-1" data-testid="message-thread-replies">
           {repliesRenderState === "list" ? (
             <div
-              className={cn(
-                "space-y-2.5",
-                // While a deferred render is in flight the painted reply list
-                // lags the latest `threadReplies`. Dim it slightly so the
-                // streaming-in reads as intentional instead of frozen — mirrors
-                // the main timeline.
-                isRepliesPending && "opacity-60 transition-opacity",
-              )}
+              className="space-y-2.5"
               data-render-pending={isRepliesPending ? "true" : undefined}
             >
               {deferredThreadReplies.map((entry, index) => {

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -460,14 +460,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
 
               {showMessageList ? (
                 <div
-                  className={cn(
-                    "flex flex-col gap-2",
-                    !showIntro && "mt-auto",
-                    // While a deferred render is in flight the painted
-                    // list lags the latest `messages`. Dim it slightly so the
-                    // streaming-in feels intentional instead of frozen.
-                    isRenderPending && "opacity-60 transition-opacity",
-                  )}
+                  className={cn("flex flex-col gap-2", !showIntro && "mt-auto")}
                   data-render-pending={isRenderPending ? "true" : undefined}
                 >
                   <TimelineMessageList

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { ArrowDown, ArrowUp, Hash } from "lucide-react";
 
-import { selectTimelineSurface } from "@/features/messages/lib/timelineSnapshot";
+import {
+  selectTimelineBodySurface,
+  selectTimelineIntroSurface,
+} from "@/features/messages/lib/timelineSnapshot";
 import { getDmParticipantPreview } from "@/features/channels/lib/dmParticipantDisplay";
 import type { TimelineMessage } from "@/features/messages/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
@@ -167,23 +170,27 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     ? `message-timeline:${channelId ?? "none"}:target:${targetMessageId}`
     : `message-timeline:${channelId ?? "none"}`;
 
-  const timelineSurface = selectTimelineSurface({
+  const timelineBodySurface = selectTimelineBodySurface({
     deferredCount: deferredMessages.length,
-    hasChannelIntro: channelIntro !== null && directMessageIntro === null,
-    hasDirectMessageIntro: directMessageIntro !== null,
     isLoading,
     liveCount: messages.length,
   });
-  const showDirectMessageIntro = timelineSurface === "direct-message-intro";
-  const showChannelIntro = timelineSurface === "channel-intro";
+  const showTimelineSkeleton = timelineBodySurface === "skeleton";
+  const timelineIntroSurface = selectTimelineIntroSurface({
+    hasChannelIntro: channelIntro !== null && directMessageIntro === null,
+    hasDirectMessageIntro: directMessageIntro !== null,
+    isSkeletonVisible: showTimelineSkeleton,
+  });
+  const showDirectMessageIntro =
+    timelineIntroSurface === "direct-message-intro";
+  const showChannelIntro = timelineIntroSurface === "channel-intro";
   const activeDirectMessageIntro = showDirectMessageIntro
     ? directMessageIntro
     : null;
   const activeChannelIntro = showChannelIntro ? channelIntro : null;
   const showIntro = showDirectMessageIntro || showChannelIntro;
-  const showGenericEmpty = timelineSurface === "empty";
-  const showMessageList = timelineSurface === "list";
-  const showTimelineSkeleton = timelineSurface === "skeleton";
+  const showGenericEmpty = timelineBodySurface === "empty" && !showIntro;
+  const showMessageList = timelineBodySurface === "list";
 
   const {
     bottomAnchorRef,

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ArrowDown, ArrowUp, Hash } from "lucide-react";
 
-import { selectDeferredListRenderState } from "@/features/messages/lib/timelineSnapshot";
+import { selectTimelineSurface } from "@/features/messages/lib/timelineSnapshot";
 import { getDmParticipantPreview } from "@/features/channels/lib/dmParticipantDisplay";
 import type { TimelineMessage } from "@/features/messages/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
@@ -10,7 +10,6 @@ import { cn } from "@/shared/lib/cn";
 import { channelChrome } from "@/shared/layout/chromeLayout";
 import { Button } from "@/shared/ui/button";
 import { Spinner } from "@/shared/ui/spinner";
-import { SkeletonReveal } from "@/shared/ui/skeleton";
 import { TooltipProvider } from "@/shared/ui/tooltip";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { TimelineSkeleton, useTimelineSkeletonRows } from "./TimelineSkeleton";
@@ -168,6 +167,24 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     ? `message-timeline:${channelId ?? "none"}:target:${targetMessageId}`
     : `message-timeline:${channelId ?? "none"}`;
 
+  const timelineSurface = selectTimelineSurface({
+    deferredCount: deferredMessages.length,
+    hasChannelIntro: channelIntro !== null && directMessageIntro === null,
+    hasDirectMessageIntro: directMessageIntro !== null,
+    isLoading,
+    liveCount: messages.length,
+  });
+  const showDirectMessageIntro = timelineSurface === "direct-message-intro";
+  const showChannelIntro = timelineSurface === "channel-intro";
+  const activeDirectMessageIntro = showDirectMessageIntro
+    ? directMessageIntro
+    : null;
+  const activeChannelIntro = showChannelIntro ? channelIntro : null;
+  const showIntro = showDirectMessageIntro || showChannelIntro;
+  const showGenericEmpty = timelineSurface === "empty";
+  const showMessageList = timelineSurface === "list";
+  const showTimelineSkeleton = timelineSurface === "skeleton";
+
   const {
     bottomAnchorRef,
     contentRef,
@@ -180,7 +197,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     syncScrollState,
   } = useTimelineScrollManager({
     channelId,
-    isLoading,
+    isLoading: showTimelineSkeleton,
     messages: deferredMessages,
     onTargetReached,
     scrollContainerRef,
@@ -211,7 +228,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     !isUnreadPillDismissed &&
     unreadCount > 0 &&
     firstUnreadMessageId !== null &&
-    !isLoading;
+    !showTimelineSkeleton;
   if (showUnreadPill) hasShownPillRef.current = true;
   const handleJumpToOldestUnread = React.useCallback(() => {
     setIsUnreadPillDismissed(true);
@@ -224,6 +241,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
   const prevSearchActiveRef = React.useRef<string | null>(null);
   // biome-ignore lint/correctness/useExhaustiveDependencies: scrollContainerRef is a stable React ref
   React.useEffect(() => {
+    if (showTimelineSkeleton) return;
     if (
       !searchActiveMessageId ||
       searchActiveMessageId === prevSearchActiveRef.current
@@ -242,42 +260,21 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     if (el) {
       el.scrollIntoView({ block: "center", behavior: "smooth" });
     }
-  }, [searchActiveMessageId]);
+  }, [searchActiveMessageId, showTimelineSkeleton]);
 
   useLoadOlderOnScroll({
     fetchOlder,
     hasOlderMessages,
-    isLoading,
+    isLoading: showTimelineSkeleton,
     restoreScrollPosition,
     scrollContainerRef,
     sentinelRef: topSentinelRef,
   });
 
-  const timelineRenderState = selectDeferredListRenderState(
-    deferredMessages.length,
-    messages.length,
-  );
-  const isDeferredListPending = !isLoading && timelineRenderState === "pending";
-  const showDirectMessageIntro =
-    !isLoading &&
-    timelineRenderState !== "pending" &&
-    directMessageIntro !== null;
-  const showChannelIntro =
-    !isLoading &&
-    timelineRenderState !== "pending" &&
-    channelIntro !== null &&
-    directMessageIntro === null;
-  const showIntro = showDirectMessageIntro || showChannelIntro;
-  const showGenericEmpty =
-    !isLoading &&
-    timelineRenderState === "empty" &&
-    directMessageIntro === null &&
-    channelIntro === null;
-  const showMessageList = !isLoading && timelineRenderState === "list";
   const timelineSkeletonRows = useTimelineSkeletonRows({
     channelId,
-    isLoading,
-    messages,
+    isLoading: showTimelineSkeleton,
+    messages: showTimelineSkeleton ? EMPTY_MESSAGES : deferredMessages,
   });
 
   return (
@@ -329,41 +326,38 @@ export const MessageTimeline = React.memo(function MessageTimeline({
               </div>
             ) : null}
 
-            <SkeletonReveal
+            <div
               className={cn(
-                "min-h-[18rem]",
+                "flex min-h-[18rem] min-w-0 flex-col gap-2",
                 (showIntro || showGenericEmpty) && "min-h-full",
                 showMessageList && !showIntro && "mt-auto",
               )}
-              contentClassName={cn(
-                "flex min-w-0 flex-col gap-2",
-                (showIntro || showGenericEmpty) && "min-h-full",
-              )}
-              loading={isLoading || isDeferredListPending}
-              skeleton={<TimelineSkeleton rows={timelineSkeletonRows} />}
             >
-              {showDirectMessageIntro ? (
+              {showTimelineSkeleton ? (
+                <TimelineSkeleton rows={timelineSkeletonRows} />
+              ) : null}
+              {activeDirectMessageIntro ? (
                 <div
                   className="mb-0.5 mt-auto flex w-full flex-col items-start px-3 py-2 text-left"
                   data-testid="message-dm-intro"
                 >
                   <DirectMessageIntroAvatarStack
-                    participants={directMessageIntro.participants}
+                    participants={activeDirectMessageIntro.participants}
                   />
                   <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
-                    {directMessageIntro.displayName}
+                    {activeDirectMessageIntro.displayName}
                   </p>
                   <p className="mt-1 max-w-full truncate whitespace-nowrap text-sm leading-5 text-muted-foreground">
                     This is the beginning of your direct message with{" "}
                     <span className="font-medium text-foreground">
-                      {directMessageIntro.displayName}
+                      {activeDirectMessageIntro.displayName}
                     </span>
                     .
                   </p>
                 </div>
               ) : null}
 
-              {showChannelIntro ? (
+              {activeChannelIntro ? (
                 <div
                   className="mb-0.5 mt-auto flex w-full max-w-2xl flex-col items-start px-3 py-2 text-left"
                   data-testid="message-channel-intro"
@@ -372,28 +366,28 @@ export const MessageTimeline = React.memo(function MessageTimeline({
                     className="flex h-[60px] w-[60px] items-center justify-center rounded-2xl border border-border/70 bg-muted/40 text-muted-foreground"
                     data-testid="message-channel-intro-icon"
                   >
-                    {channelIntro.icon ?? (
+                    {activeChannelIntro.icon ?? (
                       <Hash aria-hidden className="h-7 w-7" />
                     )}
                   </div>
                   <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
-                    #{channelIntro.channelName}
+                    #{activeChannelIntro.channelName}
                   </p>
                   <p className="mt-1 max-w-full text-sm leading-5 text-muted-foreground">
                     This is the beginning of the{" "}
                     <span className="font-medium text-foreground">
-                      {channelIntro.channelKindLabel}
+                      {activeChannelIntro.channelKindLabel}
                     </span>
                     .
                   </p>
-                  {channelIntro.description ? (
+                  {activeChannelIntro.description ? (
                     <p className="mt-2 max-w-xl text-sm leading-5 text-muted-foreground">
-                      {channelIntro.description}
+                      {activeChannelIntro.description}
                     </p>
                   ) : null}
-                  {channelIntro.actions?.length ? (
+                  {activeChannelIntro.actions?.length ? (
                     <div className="mt-4 flex max-w-full flex-nowrap gap-3 overflow-x-auto pb-1">
-                      {channelIntro.actions.map((action) => {
+                      {activeChannelIntro.actions.map((action) => {
                         const hasDescription = Boolean(action.description);
 
                         return (
@@ -504,7 +498,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
                   />
                 </div>
               ) : null}
-            </SkeletonReveal>
+            </div>
 
             <div aria-hidden className="h-px" ref={bottomAnchorRef} />
           </div>

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { ArrowDown, ArrowUp, Hash } from "lucide-react";
 
+import { selectDeferredListRenderState } from "@/features/messages/lib/timelineSnapshot";
 import { getDmParticipantPreview } from "@/features/channels/lib/dmParticipantDisplay";
 import type { TimelineMessage } from "@/features/messages/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
@@ -252,16 +253,27 @@ export const MessageTimeline = React.memo(function MessageTimeline({
     sentinelRef: topSentinelRef,
   });
 
-  const showDirectMessageIntro = !isLoading && directMessageIntro !== null;
+  const timelineRenderState = selectDeferredListRenderState(
+    deferredMessages.length,
+    messages.length,
+  );
+  const isDeferredListPending = !isLoading && timelineRenderState === "pending";
+  const showDirectMessageIntro =
+    !isLoading &&
+    timelineRenderState !== "pending" &&
+    directMessageIntro !== null;
   const showChannelIntro =
-    !isLoading && channelIntro !== null && directMessageIntro === null;
+    !isLoading &&
+    timelineRenderState !== "pending" &&
+    channelIntro !== null &&
+    directMessageIntro === null;
   const showIntro = showDirectMessageIntro || showChannelIntro;
   const showGenericEmpty =
     !isLoading &&
-    deferredMessages.length === 0 &&
+    timelineRenderState === "empty" &&
     directMessageIntro === null &&
     channelIntro === null;
-  const showMessageList = !isLoading && deferredMessages.length > 0;
+  const showMessageList = !isLoading && timelineRenderState === "list";
   const timelineSkeletonRows = useTimelineSkeletonRows({
     channelId,
     isLoading,
@@ -327,7 +339,7 @@ export const MessageTimeline = React.memo(function MessageTimeline({
                 "flex min-w-0 flex-col gap-2",
                 (showIntro || showGenericEmpty) && "min-h-full",
               )}
-              loading={isLoading}
+              loading={isLoading || isDeferredListPending}
               skeleton={<TimelineSkeleton rows={timelineSkeletonRows} />}
             >
               {showDirectMessageIntro ? (

--- a/desktop/src/features/messages/ui/useTimelineScrollManager.ts
+++ b/desktop/src/features/messages/ui/useTimelineScrollManager.ts
@@ -41,6 +41,11 @@ export function useTimelineScrollManager({
   const previousLastMessageKeyRef = React.useRef<string | undefined>(undefined);
   const previousMessageCountRef = React.useRef(0);
   const handledTargetMessageIdRef = React.useRef<string | null>(null);
+  // Mirror isLoading into a ref so the ResizeObservers (which subscribe once)
+  // can skip reacting while the skeleton is up — reacting to height churn under
+  // a streaming-in list is what makes the timeline thrash on entry.
+  const isLoadingRef = React.useRef(isLoading);
+  isLoadingRef.current = isLoading;
   const [isAtBottom, setIsAtBottom] = React.useState(true);
   const [highlightedMessageId, setHighlightedMessageId] = React.useState<
     string | null
@@ -241,6 +246,12 @@ export function useTimelineScrollManager({
       const nextTimelineHeight = entry.contentRect.height;
       previousTimelineHeightRef.current = nextTimelineHeight;
 
+      // Track height while loading, but don't scroll — the init layout-effect
+      // owns the first scroll once content settles.
+      if (isLoadingRef.current) {
+        return;
+      }
+
       if (
         previousTimelineHeight === null ||
         Math.abs(nextTimelineHeight - previousTimelineHeight) < 1
@@ -271,6 +282,9 @@ export function useTimelineScrollManager({
     }
 
     const observer = new ResizeObserver(() => {
+      if (isLoadingRef.current) {
+        return;
+      }
       if (shouldStickToBottomRef.current) {
         scrollToBottom("auto");
         return;


### PR DESCRIPTION
## Problem
Switching channels showed the loading skeleton "multiple times" with a vertical shake, then the messages shook/faded when the skeleton cleared. Goal (from #weird-ui-flicker-and-loading): show loading, then show messages — one surface at a time, buttery smooth.

## Root cause
Two thrash engines, both around the skeleton:

1. **Multiple skeleton surfaces.** The historical full-pane `ViewLoadingFallback` data branch in `ChannelScreen` could swap a differently-laid-out skeleton in front of `MessageTimeline`'s own skeleton — overlapping skeleton regions on screen at once.
2. **The reveal animation restarted on every commit.** `MessageTimeline` used `SkeletonReveal` with `loading={isLoading || isDeferredListPending}`. `useDeferredValue` re-defers on every new `messages` identity while events stream in, so `isDeferredListPending` blipped pending→list→pending across commits. Each blip re-fired `SkeletonReveal`'s `useLayoutEffect` reset + rAF crossfade + relative↔absolute layout swap → the skeleton re-appeared/re-pulsed (vertical shake) and content faded in on reveal.

## Fix — one timeline state machine, one visible surface
A strict, derived single-surface model. Exactly one of `skeleton | direct-message-intro | channel-intro | empty | list` renders at any time. No overlap, no crossfade, no animation on the skeleton.

- **`ChannelScreen`**: remove the dead full-pane channel-loading branch; always mount `ChannelPane` (real header/composer/timeline) and pass `isTimelineLoading` down. Keep the per-channel monotonic loading latch and the scroll-freeze.
- **`MessageTimeline`**: drop `SkeletonReveal` entirely; render plain conditional surfaces driven by a new pure `selectTimelineSurface(...)`. Both hard-loading and the deferred catch-up window map to `skeleton`, so the same `TimelineSkeleton` node stays mounted across the hold — no remount flash, no reveal restart, zero gap before rows. Scroll/search/load-older are gated on the same skeleton state so rows don't shake during catch-up; skeleton row estimate ignores uncommitted messages so its height doesn't jump.

### Invariants (enforced by unit tests)
1. Exactly one surface renders — no overlap.
2. Loading is monotonic per channel (latch).
3. The loading surface is a plain conditional, not `SkeletonReveal` — no layout-effect reset, no rAF, no absolute↔relative swap.
4. Deferred-pending never restarts the skeleton — it holds the same static frame, then swaps to list once.
5. Stable container geometry across loading→list (`min-h-[18rem]`).

## Tests
- New `selectTimelineSurface` table in `timelineSnapshot.test.mjs` (loading + pending both → skeleton; live rows win; empty picks exactly one intro/empty surface).
- Existing `timelineLoadingState.test.mjs` latch cases retained.
- Full desktop unit suite: **902/902**.
- `pnpm typecheck`, `pnpm check`, `pnpm build` all clean (pre-existing chunk warnings only).

Note: the "buttery smooth" feel is best confirmed in a running build (fast A→B→A switching, empty channel, throttled relay) — the suite proves the logic/invariants.

Co-authored by Pinky (MessageTimeline state machine + `selectTimelineSurface`) and Brain (ChannelScreen full-pane removal, loading latch, scroll-freeze, integration). Closes the channel-load flicker reported in #weird-ui-flicker-and-loading.
