### PR TITLE
fix: give agent-observer sub a replay-capable limit

### DIFF
--- a/desktop/src/shared/api/observerRelay.test.mjs
+++ b/desktop/src/shared/api/observerRelay.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+
+import { relayClient } from "./relayClient.ts";
+import { subscribeToAgentObserverFrames } from "./observerRelay.ts";
+
+// Regression guard: the observer subscription MUST request a replay-capable
+// limit. With `limit: 0` the relay truncates reconnect replay to zero rows
+// (NIP-01: limit 0 = no historical rows), so a turn_started missed during a
+// network drop never re-delivers and the active-agents badge never appears.
+test("subscribeToAgentObserverFrames requests a replay-capable limit", () => {
+  const calls = [];
+  mock.method(relayClient, "subscribeLive", (filter) => {
+    calls.push(filter);
+    return () => {};
+  });
+
+  subscribeToAgentObserverFrames("owner-pubkey", () => {});
+
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0].limit,
+    1000,
+    "observer sub must use limit:1000 so reconnect replay can recover missed frames — limit:0 drops the gap",
+  );
+
+  mock.reset();
+});

--- a/desktop/src/shared/api/observerRelay.test.mjs
+++ b/desktop/src/shared/api/observerRelay.test.mjs
@@ -8,7 +8,7 @@ import { subscribeToAgentObserverFrames } from "./observerRelay.ts";
 // limit. With `limit: 0` the relay truncates reconnect replay to zero rows
 // (NIP-01: limit 0 = no historical rows), so a turn_started missed during a
 // network drop never re-delivers and the active-agents badge never appears.
-test("subscribeToAgentObserverFrames requests a replay-capable limit", () => {
+test("subscribeToAgentObserverFrames requests a replay-capable limit with a since window", () => {
   const calls = [];
   mock.method(relayClient, "subscribeLive", (filter) => {
     calls.push(filter);
@@ -22,6 +22,10 @@ test("subscribeToAgentObserverFrames requests a replay-capable limit", () => {
     calls[0].limit,
     1000,
     "observer sub must use limit:1000 so reconnect replay can recover missed frames — limit:0 drops the gap",
+  );
+  assert.ok(
+    calls[0].since && calls[0].since > 0,
+    "observer sub must carry `since` so launch history stays suppressed — only the reconnect replay window is backfilled",
   );
 
   mock.reset();

--- a/desktop/src/shared/api/observerRelay.ts
+++ b/desktop/src/shared/api/observerRelay.ts
@@ -11,7 +11,11 @@ export function subscribeToAgentObserverFrames(
     {
       kinds: [KIND_AGENT_OBSERVER_FRAME],
       "#p": [ownerPubkey],
-      limit: 0,
+      // The high `limit` lets reconnect replay recover observer frames missed
+      // during a drop. `since` still suppresses launch-time history; only the
+      // reconnect replay window is backfilled. A `limit: 0` here would truncate
+      // that replay to zero rows, dropping the gap (NIP-01: limit 0 = no rows).
+      limit: 1000,
       since: Math.floor(Date.now() / 1_000),
     },
     onEvent,


### PR DESCRIPTION
Under WARP VPN churn, an agent's active-timer badge sometimes never appeared for a turn that was genuinely in progress: the agent kept working and the turn eventually finished, but the badge was missing the whole time.

The active-agents badge is purely event-driven — `activeAgentTurnsStore` derives every turn from `turn_started` / `turn_completed` / `turn_liveness` observer frames. The relay client already does gap-recovery on reconnect: it replays each live `REQ` with a `since` window to backfill events missed during a drop. The agent-observer subscription opted out of that recovery by passing `limit: 0`, which the relay's historical path correctly truncates to zero rows (NIP-01: `limit 0` means "no historical results"). So on reconnect the observer `REQ` matched the gap window and was then truncated to nothing — a `turn_started` that fired mid-drop never re-delivered, and the badge never showed.

The cause is one-sided: the observer sub is the only reconnect-dependent subscription that opted out of replay. The fix mirrors the proven `subscribeToChannelLive` pattern — a replay-capable `limit: 1000` (which clamps cleanly at the DB's `max_limit.unwrap_or(1000)` cap), with `since: now` unchanged so launch-time history stays suppressed and only the reconnect replay window changes. Re-delivered frames are idempotent against the store's `(timestamp, seq)` watermark, so there is no double-count.

A regression-guard test asserts `subscribeToAgentObserverFrames` requests `limit: 1000`; store idempotency under replay is already covered by `activeAgentTurnsStore.test.mjs`.
