### PR TITLE
Polish desktop sidebar navigation

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -298,6 +298,7 @@ export function AppShell() {
     markChannelRead,
     markChannelUnread,
     unreadChannelIds,
+    unreadChannelCounts,
     highPriorityUnreadChannelIds,
     getEffectiveTimestamp: getChannelReadAt,
     readStateVersion,
@@ -897,6 +898,7 @@ export function AppShell() {
                           selectedChannelId={selectedChannelId}
                           selectedView={selectedView}
                           unreadChannelIds={unreadChannelIds}
+                          unreadChannelCounts={unreadChannelCounts}
                           mutedChannelIds={mutedChannelIds}
                           onMuteChannel={muteChannel}
                           onUnmuteChannel={unmuteChannel}

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -391,10 +391,6 @@ export function AppShell() {
     setBrowseDialogType("stream");
     void refetchChannels();
   }, [refetchChannels]);
-  const handleOpenBrowseForums = React.useCallback(() => {
-    setBrowseDialogType("forum");
-    void refetchChannels();
-  }, [refetchChannels]);
   const handleOpenSearch = React.useCallback(() => {
     setSearchFocusRequest((request) => request + 1);
     void refetchChannels();
@@ -856,8 +852,6 @@ export function AppShell() {
                           onMarkAllChannelsRead={markAllChannelsRead}
                           onMarkChannelRead={markChannelRead}
                           onMarkChannelUnread={markChannelUnread}
-                          onOpenBrowseChannels={handleOpenBrowseChannels}
-                          onOpenBrowseForums={handleOpenBrowseForums}
                           onOpenDm={async ({ pubkeys }) => {
                             const directMessage =
                               await openDmMutation.mutateAsync({

--- a/desktop/src/app/AppTopChrome.tsx
+++ b/desktop/src/app/AppTopChrome.tsx
@@ -4,6 +4,7 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
 } from "lucide-react";
+import * as React from "react";
 
 import { TopbarSearch } from "@/features/search/ui/TopbarSearch";
 import type { Channel, SearchHit } from "@/shared/api/types";
@@ -98,6 +99,7 @@ function CenterColumnTopbarSearch({
 
 const TOP_CHROME_ICON_BUTTON_CLASS =
   "h-7 w-7 rounded-[4px] text-muted-foreground/70 hover:bg-border/45 hover:text-foreground [&_svg]:size-4";
+const TOP_CHROME_WHEEL_GUARD_HEIGHT = 40;
 
 function TopChromeSidebarTrigger() {
   const sidebar = useOptionalSidebar();
@@ -134,6 +136,22 @@ export function AppTopChrome({
   searchFocusRequest,
   searchLoading = false,
 }: AppTopChromeProps) {
+  React.useEffect(() => {
+    const handleWheel = (event: WheelEvent) => {
+      if (event.clientY <= TOP_CHROME_WHEEL_GUARD_HEIGHT) {
+        event.preventDefault();
+      }
+    };
+
+    document.addEventListener("wheel", handleWheel, {
+      capture: true,
+      passive: false,
+    });
+    return () => {
+      document.removeEventListener("wheel", handleWheel, { capture: true });
+    };
+  }, []);
+
   return (
     <>
       <div

--- a/desktop/src/features/channels/unreadChannelCounts.ts
+++ b/desktop/src/features/channels/unreadChannelCounts.ts
@@ -1,0 +1,86 @@
+export type ObservedUnreadEvent = {
+  id: string;
+  createdAt: number;
+};
+
+export function mapsEqual(
+  a: ReadonlyMap<string, number>,
+  b: ReadonlyMap<string, number>,
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const [key, value] of a) {
+    if (b.get(key) !== value) return false;
+  }
+  return true;
+}
+
+export function recordObservedUnreadEvent(
+  eventsByChannel: Map<string, Map<string, number>>,
+  channelId: string,
+  event: ObservedUnreadEvent,
+  limit: number,
+): void {
+  let eventsById = eventsByChannel.get(channelId);
+  if (!eventsById) {
+    eventsById = new Map<string, number>();
+    eventsByChannel.set(channelId, eventsById);
+  }
+  if (eventsById.has(event.id)) return;
+
+  eventsById.set(event.id, event.createdAt);
+  if (eventsById.size <= limit) return;
+
+  const oldest = [...eventsById.entries()].sort((a, b) => a[1] - b[1])[0]?.[0];
+  if (oldest) {
+    eventsById.delete(oldest);
+  }
+}
+
+export function countUnreadObservedEvents(
+  eventsById: ReadonlyMap<string, number> | undefined,
+  readAt: number | null,
+): number {
+  if (!eventsById) return 0;
+  let count = 0;
+  for (const createdAt of eventsById.values()) {
+    if (readAt === null || createdAt > readAt) count += 1;
+  }
+  return count;
+}
+
+export function buildChannelThreadRoots<
+  T extends { channelId: string; tags: string[][] },
+>(
+  items: readonly T[],
+  getRootId: (tags: string[][]) => string | null,
+): Map<string, Set<string>> {
+  const byChannel = new Map<string, Set<string>>();
+  for (const item of items) {
+    const rootId = getRootId(item.tags);
+    if (rootId === null) continue;
+    let roots = byChannel.get(item.channelId);
+    if (!roots) {
+      roots = new Set<string>();
+      byChannel.set(item.channelId, roots);
+    }
+    roots.add(rootId);
+  }
+  return byChannel;
+}
+
+export function channelUnreadFrontier(
+  channelMarker: number | null,
+  threadRoots: ReadonlySet<string> | undefined,
+  getThreadOwnMarker: (rootId: string) => number | null,
+): number | null {
+  let frontier = channelMarker;
+  if (threadRoots) {
+    for (const rootId of threadRoots) {
+      const own = getThreadOwnMarker(rootId);
+      if (own !== null && (frontier === null || own > frontier)) {
+        frontier = own;
+      }
+    }
+  }
+  return frontier;
+}

--- a/desktop/src/features/channels/unreadReadMarker.test.mjs
+++ b/desktop/src/features/channels/unreadReadMarker.test.mjs
@@ -5,8 +5,8 @@ import { computeChannelUnreadMarker } from "../messages/lib/unreadMarker.ts";
 import {
   buildChannelThreadRoots,
   channelUnreadFrontier,
-  resolveChannelReadMarker,
-} from "./useUnreadChannels.ts";
+} from "./unreadChannelCounts.ts";
+import { resolveChannelReadMarker } from "./useUnreadChannels.ts";
 
 function topLevel(id, createdAt) {
   return { id, createdAt, author: "a", time: "", body: "", depth: 0 };

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -4,6 +4,14 @@ import {
   useLiveChannelUpdates,
   type UseLiveChannelUpdatesOptions,
 } from "@/features/channels/useLiveChannelUpdates";
+import {
+  buildChannelThreadRoots,
+  channelUnreadFrontier,
+  countUnreadObservedEvents,
+  mapsEqual,
+  recordObservedUnreadEvent,
+  type ObservedUnreadEvent,
+} from "@/features/channels/unreadChannelCounts";
 import { useReadState } from "@/features/channels/readState/useReadState";
 import {
   getThreadReference,
@@ -245,53 +253,6 @@ function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
   return true;
 }
 
-// Build channelId -> set of thread rootIds observed in that channel, derived
-// from the thread-activity log (the same items that feed latestByChannelRef).
-// Used by the sidebar unread scan to fold per-thread read markers into a
-// channel's effective frontier so opening a thread clears the channel dot.
-export function buildChannelThreadRoots(
-  items: readonly ThreadActivityItem[],
-  getRootId: (tags: string[][]) => string | null,
-): Map<string, Set<string>> {
-  const byChannel = new Map<string, Set<string>>();
-  for (const item of items) {
-    const rootId = getRootId(item.tags);
-    if (rootId === null) continue;
-    let roots = byChannel.get(item.channelId);
-    if (!roots) {
-      roots = new Set<string>();
-      byChannel.set(item.channelId, roots);
-    }
-    roots.add(rootId);
-  }
-  return byChannel;
-}
-
-// The channel's effective read frontier for sidebar-unread purposes: its own
-// channel marker folded with the highest OWN thread marker among its observed
-// thread roots. Using the thread OWN marker (not the hierarchical effective
-// value) is deliberate — the hierarchical resolver maps every thread to the
-// ACTIVE channel, so it would borrow the wrong marker for a background channel.
-// An unread reply in a thread keeps the dot until that thread is opened
-// (advancing the thread marker past the reply); a never-read thread (no own
-// marker) contributes nothing and the channel marker governs.
-export function channelUnreadFrontier(
-  channelMarker: number | null,
-  threadRoots: ReadonlySet<string> | undefined,
-  getThreadOwnMarker: (rootId: string) => number | null,
-): number | null {
-  let frontier = channelMarker;
-  if (threadRoots) {
-    for (const rootId of threadRoots) {
-      const own = getThreadOwnMarker(rootId);
-      if (own !== null && (frontier === null || own > frontier)) {
-        frontier = own;
-      }
-    }
-  }
-  return frontier;
-}
-
 export function useUnreadChannels(
   channels: Channel[],
   activeChannel: Channel | null,
@@ -324,6 +285,9 @@ export function useUnreadChannels(
   // change. Stale entries for channels the user has left are silently
   // ignored by the memo (it iterates the current channels list, not the map).
   const latestByChannelRef = React.useRef(new Map<string, number>());
+  const observedUnreadEventsByChannelRef = React.useRef(
+    new Map<string, Map<string, number>>(),
+  );
   const latestHighPriorityByChannelRef = React.useRef(
     new Map<string, number>(),
   );
@@ -388,6 +352,7 @@ export function useUnreadChannels(
   // biome-ignore lint/correctness/useExhaustiveDependencies: pubkey/relayClient are intentional reset signals
   React.useEffect(() => {
     latestByChannelRef.current = new Map();
+    observedUnreadEventsByChannelRef.current = new Map();
     latestHighPriorityByChannelRef.current = new Map();
     forcedUnreadRef.current = new Set();
     caughtUpChannelsRef.current = new Set();
@@ -437,6 +402,7 @@ export function useUnreadChannels(
       // guard suppresses the readStateVersion bump.
       if (clearObserved) {
         latestByChannelRef.current.delete(channelId);
+        observedUnreadEventsByChannelRef.current.delete(channelId);
         latestHighPriorityByChannelRef.current.delete(channelId);
         bumpLatestVersion();
       }
@@ -460,8 +426,23 @@ export function useUnreadChannels(
   // and external authors, so the map is always a strict subset of "newest
   // external trigger message this client has observed."
   const callerOnChannelMessage = liveUpdateOptions.onChannelMessage;
+  const recordUnreadEvent = React.useCallback(
+    (channelId: string, event: ObservedUnreadEvent) => {
+      recordObservedUnreadEvent(
+        observedUnreadEventsByChannelRef.current,
+        channelId,
+        event,
+        CATCH_UP_LIMIT,
+      );
+    },
+    [],
+  );
   const handleChannelMessage = React.useCallback(
     (channelId: string, event: RelayEvent) => {
+      recordUnreadEvent(channelId, {
+        id: event.id,
+        createdAt: event.created_at,
+      });
       const current = latestByChannelRef.current.get(channelId) ?? 0;
       if (event.created_at > current) {
         latestByChannelRef.current.set(channelId, event.created_at);
@@ -488,7 +469,7 @@ export function useUnreadChannels(
 
       callerOnChannelMessage?.(channelId, event);
     },
-    [callerOnChannelMessage, normalizedPubkey],
+    [callerOnChannelMessage, normalizedPubkey, recordUnreadEvent],
   );
 
   const handleSelfChannelMessage = React.useCallback(
@@ -618,6 +599,7 @@ export function useUnreadChannels(
           ok: true;
           maxExternal: number;
           maxHighPriority: number;
+          unreadEvents: ObservedUnreadEvent[];
           threadReplies: ThreadActivityItem[];
         }
       | { channelId: string; ok: false };
@@ -669,6 +651,7 @@ export function useUnreadChannels(
           // applying the notification filter to both.
           let maxExternal = 0;
           let maxHighPriority = 0;
+          const unreadEvents: ObservedUnreadEvent[] = [];
           const threadReplies: ThreadActivityItem[] = [];
           const ch = channels.find((c) => c.id === channelId);
           const chType = ch?.channelType;
@@ -698,6 +681,7 @@ export function useUnreadChannels(
             if (event.created_at > maxExternal) {
               maxExternal = event.created_at;
             }
+            unreadEvents.push({ id: event.id, createdAt: event.created_at });
             if (
               chType === "dm" ||
               (normalizedPubkey !== null &&
@@ -727,6 +711,7 @@ export function useUnreadChannels(
             ok: true,
             maxExternal,
             maxHighPriority,
+            unreadEvents,
             threadReplies,
           };
         } catch {
@@ -745,9 +730,20 @@ export function useUnreadChannels(
           caughtUpChannelsRef.current.delete(result.channelId);
           continue;
         }
-        const { channelId, maxExternal, maxHighPriority, threadReplies } =
-          result;
+        const {
+          channelId,
+          maxExternal,
+          maxHighPriority,
+          unreadEvents,
+          threadReplies,
+        } = result;
         allThreadReplies.push(...threadReplies);
+        if (unreadEvents.length > 0) {
+          for (const event of unreadEvents) {
+            recordUnreadEvent(channelId, event);
+          }
+          didAdvance = true;
+        }
         if (maxExternal > 0) {
           const readAtNow = getEffectiveTimestamp(channelId) ?? 0;
           if (maxExternal > readAtNow) {
@@ -808,6 +804,7 @@ export function useUnreadChannels(
     getEffectiveTimestamp,
     isReadStateReady,
     normalizedPubkey,
+    recordUnreadEvent,
     relayClient,
   ]);
 
@@ -825,11 +822,13 @@ export function useUnreadChannels(
         return {
           unreadChannelIds: new Set<string>(),
           highPriorityUnreadChannelIds: new Set<string>(),
+          unreadChannelCounts: new Map<string, number>(),
         };
       }
 
       const unread = new Set<string>();
       const highPriority = new Set<string>();
+      const counts = new Map<string, number>();
 
       // Map each channel to the thread roots observed in it, so a channel's
       // frontier can fold in per-thread read markers (Option A): opening a
@@ -847,6 +846,7 @@ export function useUnreadChannels(
         if (forcedUnreadRef.current.has(channel.id)) {
           // Forced-unread is dot tier only — not high-priority.
           unread.add(channel.id);
+          counts.set(channel.id, 1);
           continue;
         }
 
@@ -861,6 +861,11 @@ export function useUnreadChannels(
         if (readAt !== null && latest <= readAt) continue;
 
         unread.add(channel.id);
+        const observedEvents = observedUnreadEventsByChannelRef.current.get(
+          channel.id,
+        );
+        const unreadCount = countUnreadObservedEvents(observedEvents, readAt);
+        counts.set(channel.id, Math.max(unreadCount, 1));
 
         // DM channels: any unread DM is high-priority.
         if (channel.channelType === "dm") {
@@ -882,6 +887,7 @@ export function useUnreadChannels(
       return {
         unreadChannelIds: unread,
         highPriorityUnreadChannelIds: highPriority,
+        unreadChannelCounts: counts,
       };
     }, [
       activeChannelId,
@@ -897,6 +903,9 @@ export function useUnreadChannels(
   // so downstream memos don't re-run on every render when sets are equal.
   const prevUnreadRef = React.useRef<ReadonlySet<string>>(new Set());
   const prevHighPriorityRef = React.useRef<ReadonlySet<string>>(new Set());
+  const prevUnreadCountsRef = React.useRef<ReadonlyMap<string, number>>(
+    new Map(),
+  );
 
   const unreadChannelIds = setsEqual(
     rawUnread.unreadChannelIds,
@@ -913,6 +922,14 @@ export function useUnreadChannels(
     ? prevHighPriorityRef.current
     : rawUnread.highPriorityUnreadChannelIds;
   prevHighPriorityRef.current = highPriorityUnreadChannelIds;
+
+  const unreadChannelCounts = mapsEqual(
+    rawUnread.unreadChannelCounts,
+    prevUnreadCountsRef.current,
+  )
+    ? prevUnreadCountsRef.current
+    : rawUnread.unreadChannelCounts;
+  prevUnreadCountsRef.current = unreadChannelCounts;
 
   const unreadChannelIdsRef = React.useRef(unreadChannelIds);
   unreadChannelIdsRef.current = unreadChannelIds;
@@ -935,6 +952,7 @@ export function useUnreadChannels(
 
   return {
     unreadChannelIds,
+    unreadChannelCounts,
     highPriorityUnreadChannelIds,
     markAllChannelsRead,
     markChannelRead,

--- a/desktop/src/features/profile/ui/ProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/ProfilePopover.tsx
@@ -188,7 +188,7 @@ export function ProfilePopover({
                   <span className="flex min-w-0 flex-1 items-center gap-1 truncate text-popover-foreground">
                     {userStatusEmoji ? (
                       <StatusEmoji
-                        className="h-3.5 w-3.5 shrink-0"
+                        className="w-5 shrink-0 text-base"
                         value={userStatusEmoji}
                       />
                     ) : null}

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -7,7 +7,7 @@ import {
   Bot,
   FolderGit2,
   Home,
-  MessageCirclePlus,
+  Plus,
   Zap,
 } from "lucide-react";
 import {
@@ -51,7 +51,10 @@ import {
   SidebarLoadingContent,
   useSidebarLoadingShape,
 } from "@/features/sidebar/ui/sidebarLoadingSkeleton";
-import { SECTION_ICON_BUTTON_CLASS } from "@/features/sidebar/ui/sidebarSectionStyles";
+import {
+  SECTION_ACTION_VISIBILITY_CLASS,
+  SECTION_ICON_BUTTON_CLASS,
+} from "@/features/sidebar/ui/sidebarSectionStyles";
 import type {
   Channel,
   ChannelVisibility,
@@ -126,8 +129,6 @@ type AppSidebarProps = {
     templateId?: string;
   }) => Promise<void>;
   onOpenAddWorkspace: () => void;
-  onOpenBrowseChannels: () => void;
-  onOpenBrowseForums: () => void;
   onHideDm: (channelId: string) => void;
   onMarkChannelUnread: (channelId: string) => void;
   onMarkChannelRead: (
@@ -195,8 +196,6 @@ export function AppSidebar({
   onCreateChannel,
   onCreateForum,
   onOpenAddWorkspace,
-  onOpenBrowseChannels,
-  onOpenBrowseForums,
   onHideDm,
   onMarkChannelUnread,
   onMarkChannelRead,
@@ -597,7 +596,6 @@ export function AppSidebar({
             <>
               {starredChannels.length > 0 ? (
                 <ChannelGroupSection
-                  browseAriaLabel="Starred channels"
                   createAriaLabel="Starred channels"
                   hasUnread={starredChannels.some((c) =>
                     unreadChannelIds.has(c.id),
@@ -681,8 +679,6 @@ export function AppSidebar({
                   />
                 ))}
                 <ChannelGroupSection
-                  browseAriaLabel="Browse channels"
-                  browseTestId="browse-channels"
                   createAriaLabel="Create a channel"
                   draggable
                   groupClassName={
@@ -693,7 +689,6 @@ export function AppSidebar({
                   isActiveChannel={selectedView === "channel"}
                   items={sectionBuckets.unassigned}
                   listTestId="stream-list"
-                  onBrowse={onOpenBrowseChannels}
                   onCreateClick={() => setCreateDialogKind("stream")}
                   onMarkAllRead={onMarkAllChannelsRead}
                   onMarkChannelRead={onMarkChannelRead}
@@ -719,15 +714,12 @@ export function AppSidebar({
               </SidebarDndContext>
               <FeatureGate feature="forum">
                 <ChannelGroupSection
-                  browseAriaLabel="Browse forums"
-                  browseTestId="browse-forums"
                   createAriaLabel="Create a forum"
                   hasUnread={unreadChannelIds.size > 0}
                   isCollapsed={collapsedGroups.forums}
                   isActiveChannel={selectedView === "channel"}
                   items={forumChannels}
                   listTestId="forum-list"
-                  onBrowse={onOpenBrowseForums}
                   onCreateClick={() => setCreateDialogKind("forum")}
                   onMarkAllRead={onMarkAllChannelsRead}
                   onMarkChannelRead={onMarkChannelRead}
@@ -749,7 +741,7 @@ export function AppSidebar({
                     <button
                       aria-expanded={isNewDmOpen}
                       aria-label="Compose new message"
-                      className={SECTION_ICON_BUTTON_CLASS}
+                      className={`${SECTION_ICON_BUTTON_CLASS} ${SECTION_ACTION_VISIBILITY_CLASS}`}
                       data-testid="new-dm-trigger"
                       onClick={() => {
                         setIsNewDmOpen(true);
@@ -757,7 +749,7 @@ export function AppSidebar({
                       title="Compose new message"
                       type="button"
                     >
-                      <MessageCirclePlus className="h-4 w-4" />
+                      <Plus className="h-4 w-4" />
                     </button>
                   </div>
                 }

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -23,7 +23,6 @@ import * as React from "react";
 import { FeatureGate } from "@/shared/features";
 import { SidebarDndContext } from "@/features/sidebar/ui/SidebarDnd";
 
-import { useManagedAgentsQuery } from "@/features/agents/hooks";
 import type { Workspace } from "@/features/workspaces/types";
 import { AddWorkspaceDialog } from "@/features/workspaces/ui/AddWorkspaceDialog";
 import { useDeferredLoad } from "@/shared/hooks/useDeferredStartup";
@@ -107,6 +106,7 @@ type AppSidebarProps = {
     | "workflows"
     | "pulse"
     | "projects";
+  unreadChannelCounts: ReadonlyMap<string, number>;
   unreadChannelIds: ReadonlySet<string>;
   workspaces: Workspace[];
   onAddWorkspace: (workspace: Workspace) => void;
@@ -187,6 +187,7 @@ export function AppSidebar({
   errorMessage,
   selectedChannelId,
   selectedView,
+  unreadChannelCounts,
   unreadChannelIds,
   workspaces,
   onAddWorkspace,
@@ -400,16 +401,6 @@ export function AppSidebar({
     isLoading,
     streamChannels,
   });
-  const shouldLoadAgentCount = useDeferredLoad({
-    immediate: selectedView === "agents",
-    timeoutMs: 250,
-  });
-  const managedAgentsQuery = useManagedAgentsQuery({
-    enabled: shouldLoadAgentCount,
-  });
-  const totalAgentCount = managedAgentsQuery.data?.length ?? 0;
-  const shouldShowAgentCount =
-    totalAgentCount > 0 || managedAgentsQuery.isFetched;
   const resolvedDisplayName =
     profile?.displayName?.trim() ||
     fallbackDisplayName?.trim() ||
@@ -515,14 +506,6 @@ export function AppSidebar({
               <Bot className="h-4 w-4" />
               <span>Agents</span>
             </SidebarMenuButton>
-            {shouldShowAgentCount ? (
-              <SidebarMenuBadge
-                className="right-2 rounded-full bg-sidebar-accent/70 px-1.5 text-2xs leading-none text-sidebar-foreground/75 peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
-                data-testid="sidebar-agents-count"
-              >
-                <span className="leading-none">{totalAgentCount}</span>
-              </SidebarMenuBadge>
-            ) : null}
           </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton
@@ -563,7 +546,7 @@ export function AppSidebar({
             testId="sidebar-more-unread-above"
           />
         ) : null}
-        <SidebarContent className="pb-32" ref={scrollRef}>
+        <SidebarContent ref={scrollRef}>
           {isLoading ? (
             <SidebarLoadingContent shape={sidebarLoadingShape} />
           ) : null}
@@ -592,6 +575,7 @@ export function AppSidebar({
                   onToggleCollapsed={() => toggleCollapsedGroup("starred")}
                   selectedChannelId={selectedChannelId}
                   title="Starred"
+                  unreadChannelCounts={unreadChannelCounts}
                   unreadChannelIds={unreadChannelIds}
                   mutedChannelIds={mutedChannelIds}
                   onMuteChannel={onMuteChannel}
@@ -622,6 +606,7 @@ export function AppSidebar({
                     isCollapsed={collapsedSections[section.id] ?? false}
                     isActiveChannel={selectedView === "channel"}
                     selectedChannelId={selectedChannelId}
+                    unreadChannelCounts={unreadChannelCounts}
                     unreadChannelIds={unreadChannelIds}
                     sections={channelSections}
                     assignments={channelAssignments}
@@ -675,6 +660,7 @@ export function AppSidebar({
                   onToggleCollapsed={() => toggleCollapsedGroup("channels")}
                   selectedChannelId={selectedChannelId}
                   title="Channels"
+                  unreadChannelCounts={unreadChannelCounts}
                   unreadChannelIds={unreadChannelIds}
                   sections={channelSections}
                   assignments={channelAssignments}
@@ -708,6 +694,7 @@ export function AppSidebar({
                   onToggleCollapsed={() => toggleCollapsedGroup("forums")}
                   selectedChannelId={selectedChannelId}
                   title="Forums"
+                  unreadChannelCounts={unreadChannelCounts}
                   unreadChannelIds={unreadChannelIds}
                   mutedChannelIds={mutedChannelIds}
                   onMuteChannel={onMuteChannel}
@@ -746,6 +733,7 @@ export function AppSidebar({
                 selectedChannelId={selectedChannelId}
                 testId="dm-list"
                 title="Direct Messages"
+                unreadChannelCounts={unreadChannelCounts}
                 unreadChannelIds={unreadChannelIds}
                 mutedChannelIds={mutedChannelIds}
                 onMuteChannel={onMuteChannel}
@@ -790,7 +778,7 @@ export function AppSidebar({
           />
         ) : null}
 
-        <SidebarFooter className="absolute inset-x-0 bottom-0 z-30 bg-sidebar/55 backdrop-blur-xl supports-[backdrop-filter]:bg-sidebar/45 dark:bg-sidebar/45 dark:supports-[backdrop-filter]:bg-sidebar/35">
+        <SidebarFooter className="z-30 shrink-0 bg-sidebar/55 backdrop-blur-xl supports-[backdrop-filter]:bg-sidebar/45 dark:bg-sidebar/45 dark:supports-[backdrop-filter]:bg-sidebar/35">
           <SidebarMenu>
             <SidebarMenuItem>
               <SidebarProfileCard

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -234,6 +234,45 @@ export function AppSidebar({
   const setIsNewDmOpen = onNewDmOpenChange ?? setIsNewDmOpenInternal;
   const scrollRef = React.useRef<HTMLDivElement>(null);
   useSidebarScrollLock(scrollRef);
+
+  React.useEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY === 0) return;
+
+      const maxScrollTop =
+        scrollElement.scrollHeight - scrollElement.clientHeight;
+      if (maxScrollTop <= 0) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      const atTop = scrollElement.scrollTop <= 0;
+      const atBottom = scrollElement.scrollTop >= maxScrollTop - 1;
+      const scrollingPastTop = event.deltaY < 0 && atTop;
+      const scrollingPastBottom = event.deltaY > 0 && atBottom;
+
+      if (scrollingPastTop || scrollingPastBottom) {
+        event.preventDefault();
+        event.stopPropagation();
+        scrollElement.scrollTop = scrollingPastTop ? 0 : maxScrollTop;
+      }
+    };
+
+    scrollElement.addEventListener("wheel", handleWheel, {
+      capture: true,
+      passive: false,
+    });
+    return () => {
+      scrollElement.removeEventListener("wheel", handleWheel, {
+        capture: true,
+      });
+    };
+  }, []);
+
   const [createDialogKind, setCreateDialogKind] =
     React.useState<CreateChannelKind | null>(null);
 
@@ -443,99 +482,6 @@ export function AppSidebar({
       data-testid="app-sidebar"
       variant="sidebar"
     >
-      <SidebarHeader
-        className="cursor-default select-none pt-11"
-        data-tauri-drag-region
-      >
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              isActive={selectedView === "home"}
-              onClick={onSelectHome}
-              tooltip="Home"
-              type="button"
-            >
-              <Home className="h-4 w-4" />
-              <span>Home</span>
-            </SidebarMenuButton>
-            {homeBadgeCount > 0 ? (
-              <SidebarMenuBadge
-                className="right-2 rounded-full bg-primary/15 px-1.5 text-2xs text-primary peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
-                data-testid="sidebar-home-count"
-              >
-                {Math.min(homeBadgeCount, 99)}
-              </SidebarMenuBadge>
-            ) : null}
-          </SidebarMenuItem>
-          <FeatureGate feature="pulse">
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                data-testid="open-pulse-view"
-                isActive={selectedView === "pulse"}
-                onClick={onSelectPulse}
-                tooltip="Pulse"
-                type="button"
-              >
-                <Activity className="h-4 w-4" />
-                <span>Pulse</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </FeatureGate>
-          <FeatureGate feature="projects">
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                data-testid="open-projects-view"
-                isActive={selectedView === "projects"}
-                onClick={onSelectProjects}
-                tooltip="Projects"
-                type="button"
-              >
-                <FolderGit2 className="h-4 w-4" />
-                <span>Projects</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </FeatureGate>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              data-testid="open-agents-view"
-              isActive={selectedView === "agents"}
-              onClick={onSelectAgents}
-              tooltip="Agents"
-              type="button"
-            >
-              <Bot className="h-4 w-4" />
-              <span>Agents</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              data-testid="open-reminders-view"
-              isActive={selectedView === "reminders"}
-              onClick={onSelectReminders}
-              tooltip="Reminders"
-              type="button"
-            >
-              <Bell className="h-4 w-4" />
-              <span>Reminders</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <FeatureGate feature="workflows">
-            <SidebarMenuItem>
-              <SidebarMenuButton
-                data-testid="open-workflows-view"
-                isActive={selectedView === "workflows"}
-                onClick={onSelectWorkflows}
-                tooltip="Workflows"
-                type="button"
-              >
-                <Zap className="h-4 w-4" />
-                <span>Workflows</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </FeatureGate>
-        </SidebarMenu>
-      </SidebarHeader>
-
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
         {unreadAboveCount > 0 ? (
           <MoreUnreadButton
@@ -546,7 +492,103 @@ export function AppSidebar({
             testId="sidebar-more-unread-above"
           />
         ) : null}
-        <SidebarContent ref={scrollRef}>
+        <SidebarContent
+          className="buzz-sidebar-scrollbar mt-(--buzz-top-chrome-height,2.5rem) overscroll-none"
+          ref={scrollRef}
+        >
+          <SidebarHeader
+            className="cursor-default select-none"
+            data-tauri-drag-region
+          >
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  isActive={selectedView === "home"}
+                  onClick={onSelectHome}
+                  tooltip="Home"
+                  type="button"
+                >
+                  <Home className="h-4 w-4" />
+                  <span>Home</span>
+                </SidebarMenuButton>
+                {homeBadgeCount > 0 ? (
+                  <SidebarMenuBadge
+                    className="right-2 rounded-full bg-primary/15 px-1.5 text-2xs text-primary peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
+                    data-testid="sidebar-home-count"
+                  >
+                    {Math.min(homeBadgeCount, 99)}
+                  </SidebarMenuBadge>
+                ) : null}
+              </SidebarMenuItem>
+              <FeatureGate feature="pulse">
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    data-testid="open-pulse-view"
+                    isActive={selectedView === "pulse"}
+                    onClick={onSelectPulse}
+                    tooltip="Pulse"
+                    type="button"
+                  >
+                    <Activity className="h-4 w-4" />
+                    <span>Pulse</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </FeatureGate>
+              <FeatureGate feature="projects">
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    data-testid="open-projects-view"
+                    isActive={selectedView === "projects"}
+                    onClick={onSelectProjects}
+                    tooltip="Projects"
+                    type="button"
+                  >
+                    <FolderGit2 className="h-4 w-4" />
+                    <span>Projects</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </FeatureGate>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  data-testid="open-agents-view"
+                  isActive={selectedView === "agents"}
+                  onClick={onSelectAgents}
+                  tooltip="Agents"
+                  type="button"
+                >
+                  <Bot className="h-4 w-4" />
+                  <span>Agents</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  data-testid="open-reminders-view"
+                  isActive={selectedView === "reminders"}
+                  onClick={onSelectReminders}
+                  tooltip="Reminders"
+                  type="button"
+                >
+                  <Bell className="h-4 w-4" />
+                  <span>Reminders</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <FeatureGate feature="workflows">
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    data-testid="open-workflows-view"
+                    isActive={selectedView === "workflows"}
+                    onClick={onSelectWorkflows}
+                    tooltip="Workflows"
+                    type="button"
+                  >
+                    <Zap className="h-4 w-4" />
+                    <span>Workflows</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </FeatureGate>
+            </SidebarMenu>
+          </SidebarHeader>
+
           {isLoading ? (
             <SidebarLoadingContent shape={sidebarLoadingShape} />
           ) : null}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -11,7 +11,6 @@ import {
   GripVertical,
   Pencil,
   Plus,
-  Search,
   Star,
   StarOff,
   Trash2,
@@ -56,7 +55,9 @@ import { cn } from "@/shared/lib/cn";
 const SECTION_LABEL_BUTTON_CLASS =
   "group/section-label flex w-fit max-w-[calc(100%-3rem)] cursor-pointer appearance-none items-center gap-1 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
 const SECTION_LABEL_CHEVRON_CLASS =
-  "h-2.5 w-2.5 shrink-0 opacity-0 text-sidebar-foreground/45 transition-[color,opacity,transform] group-hover/section-label:opacity-100 group-hover/section-label:text-sidebar-foreground group-focus-visible/section-label:opacity-100 group-focus-visible/section-label:text-sidebar-foreground";
+  "relative size-2.5 shrink-0 opacity-0 text-sidebar-foreground/45 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/sidebar-section:text-sidebar-foreground group-hover/section-label:opacity-100 group-hover/section-label:text-sidebar-foreground group-focus-within/sidebar-section:opacity-100 group-focus-within/sidebar-section:text-sidebar-foreground group-focus-visible/section-label:opacity-100 group-focus-visible/section-label:text-sidebar-foreground";
+const SECTION_LABEL_CHEVRON_ICON_CLASS =
+  "absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2";
 
 // ---------------------------------------------------------------------------
 // MoveToSectionSubmenu — internal helper
@@ -222,23 +223,17 @@ export function ChannelContextMenuItems({
 }
 
 // ---------------------------------------------------------------------------
-// SectionHeaderActions — browse + create icon buttons for section headers
+// SectionHeaderActions — create and read-state icon buttons for section headers
 // ---------------------------------------------------------------------------
 
 function SectionHeaderActions({
-  browseAriaLabel,
-  browseTestId,
   createAriaLabel,
   hasUnread,
-  onBrowse,
   onCreateClick,
   onMarkAllRead,
 }: {
-  browseAriaLabel: string;
-  browseTestId?: string;
   createAriaLabel: string;
   hasUnread?: boolean;
-  onBrowse?: () => void;
   onCreateClick?: () => void;
   onMarkAllRead?: () => void;
 }) {
@@ -258,21 +253,13 @@ function SectionHeaderActions({
           <CheckCheck className="h-4 w-4" />
         </button>
       ) : null}
-      {onBrowse ? (
-        <button
-          aria-label={browseAriaLabel}
-          className={SECTION_ICON_BUTTON_CLASS}
-          data-testid={browseTestId}
-          onClick={onBrowse}
-          type="button"
-        >
-          <Search className="h-4 w-4" />
-        </button>
-      ) : null}
       {onCreateClick ? (
         <button
           aria-label={createAriaLabel}
-          className={SECTION_ICON_BUTTON_CLASS}
+          className={cn(
+            SECTION_ICON_BUTTON_CLASS,
+            SECTION_ACTION_VISIBILITY_CLASS,
+          )}
           onClick={onCreateClick}
           type="button"
         >
@@ -288,8 +275,6 @@ function SectionHeaderActions({
 // ---------------------------------------------------------------------------
 
 export function ChannelGroupSection({
-  browseAriaLabel,
-  browseTestId,
   createAriaLabel,
   draggable,
   groupClassName,
@@ -298,7 +283,6 @@ export function ChannelGroupSection({
   isActiveChannel,
   items,
   listTestId,
-  onBrowse,
   onCreateClick,
   onMarkAllRead,
   onMarkChannelRead,
@@ -321,8 +305,6 @@ export function ChannelGroupSection({
   onStarChannel,
   onUnstarChannel,
 }: {
-  browseAriaLabel: string;
-  browseTestId?: string;
   createAriaLabel: string;
   draggable?: boolean;
   groupClassName?: string;
@@ -330,7 +312,6 @@ export function ChannelGroupSection({
   isActiveChannel: boolean;
   items: Channel[];
   listTestId: string;
-  onBrowse?: () => void;
   onCreateClick?: () => void;
   onMarkChannelRead: (
     channelId: string,
@@ -429,21 +410,19 @@ export function ChannelGroupSection({
             type="button"
           >
             <span>{title}</span>
-            <ChevronDown
-              aria-hidden="true"
-              className={cn(
-                SECTION_LABEL_CHEVRON_CLASS,
-                isCollapsed ? "-rotate-90" : "rotate-0",
-              )}
-            />
+            <span aria-hidden="true" className={SECTION_LABEL_CHEVRON_CLASS}>
+              <ChevronDown
+                className={cn(
+                  SECTION_LABEL_CHEVRON_ICON_CLASS,
+                  isCollapsed ? "-rotate-90" : "rotate-0",
+                )}
+              />
+            </span>
           </button>
         </SidebarGroupLabel>
         <SectionHeaderActions
-          browseAriaLabel={browseAriaLabel}
-          browseTestId={browseTestId}
           createAriaLabel={createAriaLabel}
           hasUnread={hasUnread}
-          onBrowse={onBrowse}
           onCreateClick={onCreateClick}
           onMarkAllRead={onMarkAllRead}
         />

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -307,6 +307,7 @@ export function ChannelGroupSection({
   onToggleCollapsed,
   selectedChannelId,
   title,
+  unreadChannelCounts,
   unreadChannelIds,
   sections,
   assignments,
@@ -340,6 +341,7 @@ export function ChannelGroupSection({
   onToggleCollapsed: () => void;
   selectedChannelId: string | null;
   title: string;
+  unreadChannelCounts: ReadonlyMap<string, number>;
   unreadChannelIds: ReadonlySet<string>;
   hasUnread?: boolean;
   onMarkAllRead?: () => void;
@@ -369,6 +371,7 @@ export function ChannelGroupSection({
                     <ChannelMenuButton
                       channel={channel}
                       hasUnread={unreadChannelIds.has(channel.id)}
+                      unreadCount={unreadChannelCounts.get(channel.id) ?? 0}
                       isMuted={mutedChannelIds?.has(channel.id)}
                       isActive={
                         isActiveChannel && selectedChannelId === channel.id
@@ -380,6 +383,7 @@ export function ChannelGroupSection({
                   <ChannelMenuButton
                     channel={channel}
                     hasUnread={unreadChannelIds.has(channel.id)}
+                    unreadCount={unreadChannelCounts.get(channel.id) ?? 0}
                     isMuted={mutedChannelIds?.has(channel.id)}
                     isActive={
                       isActiveChannel && selectedChannelId === channel.id
@@ -468,6 +472,7 @@ export function CustomChannelSection({
   isCollapsed,
   isActiveChannel,
   selectedChannelId,
+  unreadChannelCounts,
   unreadChannelIds,
   sections,
   assignments,
@@ -498,6 +503,7 @@ export function CustomChannelSection({
   isCollapsed: boolean;
   isActiveChannel: boolean;
   selectedChannelId: string | null;
+  unreadChannelCounts: ReadonlyMap<string, number>;
   unreadChannelIds: ReadonlySet<string>;
   sections: ChannelSection[];
   assignments: Record<string, string>;
@@ -643,6 +649,9 @@ export function CustomChannelSection({
                               <ChannelMenuButton
                                 channel={channel}
                                 hasUnread={unreadChannelIds.has(channel.id)}
+                                unreadCount={
+                                  unreadChannelCounts.get(channel.id) ?? 0
+                                }
                                 isMuted={mutedChannelIds?.has(channel.id)}
                                 isActive={
                                   isActiveChannel &&

--- a/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
@@ -88,8 +88,11 @@ export function SidebarProfileCard({
   const workspaceLabel = activeWorkspace?.name ?? "No workspace";
   const readonlyWorkspaceLabel = (
     <span className="flex min-w-0 cursor-pointer items-center gap-1 text-xs leading-snug text-sidebar-foreground/70">
-      <span aria-hidden="true" className="shrink-0 text-2xs leading-none">
-        🐝
+      <span
+        aria-hidden="true"
+        className="flex w-3.5 shrink-0 items-center justify-center text-2xs"
+      >
+        <span className="-translate-y-px leading-normal">🐝</span>
       </span>
       <span className="truncate">{workspaceLabel}</span>
     </span>
@@ -201,7 +204,7 @@ export function SidebarProfileCard({
               >
                 {selfUserStatus?.emoji ? (
                   <StatusEmoji
-                    className="mr-1 h-3.5 w-3.5"
+                    className="mr-1 w-4 shrink-0 text-xs"
                     value={selfUserStatus.emoji}
                   />
                 ) : null}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -35,7 +35,9 @@ import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
 const SECTION_LABEL_BUTTON_CLASS =
   "group/section-label flex w-fit max-w-[calc(100%-3rem)] cursor-pointer appearance-none items-center gap-1 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
 const SECTION_LABEL_CHEVRON_CLASS =
-  "h-2.5 w-2.5 shrink-0 opacity-0 text-sidebar-foreground/45 transition-[color,opacity,transform] group-hover/section-label:opacity-100 group-hover/section-label:text-sidebar-foreground group-focus-visible/section-label:opacity-100 group-focus-visible/section-label:text-sidebar-foreground";
+  "relative size-2.5 shrink-0 opacity-0 text-sidebar-foreground/45 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/sidebar-section:text-sidebar-foreground group-hover/section-label:opacity-100 group-hover/section-label:text-sidebar-foreground group-focus-within/sidebar-section:opacity-100 group-focus-within/sidebar-section:text-sidebar-foreground group-focus-visible/section-label:opacity-100 group-focus-visible/section-label:text-sidebar-foreground";
+const SECTION_LABEL_CHEVRON_ICON_CLASS =
+  "absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2";
 const SIDEBAR_ROW_ACTION_VISIBILITY_CLASS =
   "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 md:opacity-0";
 const SIDEBAR_ROW_ICON_ACTION_CLASS =
@@ -310,13 +312,14 @@ export function SidebarSection({
               type="button"
             >
               <span>{title}</span>
-              <ChevronDown
-                aria-hidden="true"
-                className={cn(
-                  SECTION_LABEL_CHEVRON_CLASS,
-                  isCollapsed ? "-rotate-90" : "rotate-0",
-                )}
-              />
+              <span aria-hidden="true" className={SECTION_LABEL_CHEVRON_CLASS}>
+                <ChevronDown
+                  className={cn(
+                    SECTION_LABEL_CHEVRON_ICON_CLASS,
+                    isCollapsed ? "-rotate-90" : "rotate-0",
+                  )}
+                />
+              </span>
             </button>
           ) : (
             title

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -41,6 +41,33 @@ const SIDEBAR_ROW_ACTION_VISIBILITY_CLASS =
 const SIDEBAR_ROW_ICON_ACTION_CLASS =
   "flex size-6 items-center justify-center p-1 text-sidebar-foreground/45 transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring peer-data-[active=true]/menu-button:text-sidebar-active-foreground/75 peer-data-[active=true]/menu-button:hover:text-sidebar-active-foreground [&>svg]:size-4 [&>svg]:shrink-0";
 
+function formatUnreadCount(count: number): string {
+  return count > 99 ? "99+" : String(count);
+}
+
+function UnreadCountBadge({
+  channelName,
+  className,
+  count,
+}: {
+  channelName: string;
+  className?: string;
+  count: number;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-primary px-1 text-2xs font-semibold leading-none text-primary-foreground tabular-nums",
+        className,
+      )}
+      data-testid={`channel-unread-${channelName}`}
+    >
+      {formatUnreadCount(count)}
+      <span className="sr-only"> new comment{count === 1 ? "" : "s"}</span>
+    </span>
+  );
+}
+
 export type SidebarDmParticipant = {
   avatarUrl: string | null;
   label: string;
@@ -144,6 +171,7 @@ export function ChannelMenuButton({
   label,
   isActive,
   hasUnread,
+  unreadCount = 0,
   isMuted,
   dmParticipants,
   presenceStatus,
@@ -153,6 +181,7 @@ export function ChannelMenuButton({
   label?: string;
   isActive: boolean;
   hasUnread: boolean;
+  unreadCount?: number;
   isMuted?: boolean;
   dmParticipants?: SidebarDmParticipant[];
   presenceStatus?: PresenceStatus;
@@ -203,10 +232,10 @@ export function ChannelMenuButton({
         />
       ) : null}
       {hasUnread && !isActive && channel.channelType !== "dm" ? (
-        <span
-          aria-hidden="true"
-          className="ml-auto h-2.5 w-2.5 shrink-0 rounded-full bg-primary"
-          data-testid={`channel-unread-${channel.name}`}
+        <UnreadCountBadge
+          channelName={channel.name}
+          className="ml-auto"
+          count={Math.max(unreadCount, 1)}
         />
       ) : null}
     </SidebarMenuButton>
@@ -225,6 +254,7 @@ export function SidebarSection({
   selectedChannelId,
   title,
   testId,
+  unreadChannelCounts,
   unreadChannelIds,
   onHideDm,
   onMarkChannelRead,
@@ -246,6 +276,7 @@ export function SidebarSection({
   selectedChannelId: string | null;
   title: string;
   testId: string;
+  unreadChannelCounts: ReadonlyMap<string, number>;
   unreadChannelIds: ReadonlySet<string>;
   onHideDm?: (channelId: string) => void;
   onMarkChannelRead?: (
@@ -307,6 +338,7 @@ export function SidebarSection({
                       channel={channel}
                       dmParticipants={dmParticipantsByChannelId?.[channel.id]}
                       hasUnread={unreadChannelIds.has(channel.id)}
+                      unreadCount={unreadChannelCounts.get(channel.id) ?? 0}
                       isMuted={mutedChannelIds?.has(channel.id)}
                       isActive={
                         isActiveChannel && selectedChannelId === channel.id
@@ -318,10 +350,13 @@ export function SidebarSection({
                     {channel.channelType === "dm" &&
                     unreadChannelIds.has(channel.id) &&
                     !(isActiveChannel && selectedChannelId === channel.id) ? (
-                      <span
-                        aria-hidden="true"
-                        className="absolute right-[9px] top-1/2 h-2.5 w-2.5 -translate-y-1/2 rounded-full bg-primary"
-                        data-testid={`channel-unread-${channel.name}`}
+                      <UnreadCountBadge
+                        channelName={channel.name}
+                        className="absolute right-1 top-1/2 -translate-y-1/2"
+                        count={Math.max(
+                          unreadChannelCounts.get(channel.id) ?? 0,
+                          1,
+                        )}
                       />
                     ) : null}
                     {channel.channelType === "dm" && onHideDm ? (

--- a/desktop/src/features/user-status/ui/StatusEmoji.tsx
+++ b/desktop/src/features/user-status/ui/StatusEmoji.tsx
@@ -43,10 +43,7 @@ export function StatusEmoji({ value, className }: StatusEmojiProps) {
           alt={value}
           title={displayName}
           src={rewriteRelayUrl(found.url)}
-          className={cn(
-            "inline-block object-contain align-text-bottom",
-            className,
-          )}
+          className={cn("inline-block object-contain align-middle", className)}
           draggable={false}
         />
       );
@@ -57,7 +54,13 @@ export function StatusEmoji({ value, className }: StatusEmojiProps) {
   // Thread the caller's className through so native statuses keep the spacing
   // (e.g. `mr-1`) every display site applies to the image branch above.
   return (
-    <span className={className} title={displayName}>
+    <span
+      className={cn(
+        "inline-flex items-center justify-center leading-normal align-middle",
+        className,
+      )}
+      title={displayName}
+    >
       {value}
     </span>
   );

--- a/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
+++ b/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
@@ -52,6 +52,14 @@ type WorkspaceSwitcherProps = {
   onRemoveWorkspace: (id: string) => void;
 };
 
+function WorkspaceEmojiIcon({ className }: { className: string }) {
+  return (
+    <span aria-hidden="true" className={className}>
+      <span className="-translate-y-px leading-normal">🐝</span>
+    </span>
+  );
+}
+
 export function WorkspaceSwitcher({
   activeWorkspace,
   workspaces,
@@ -129,15 +137,13 @@ export function WorkspaceSwitcher({
           </TooltipContent>
         </Tooltip>
       ) : (
-        <span
+        <WorkspaceEmojiIcon
           className={
             isProfileVariant
-              ? "flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-sidebar-border/70 bg-sidebar-accent/40 text-2xs leading-none"
-              : "flex h-5 w-5 shrink-0 items-center justify-center text-xs leading-none"
+              ? "flex w-5 shrink-0 items-center justify-center rounded-md border border-sidebar-border/70 bg-sidebar-accent/40 text-2xs"
+              : "flex w-5 shrink-0 items-center justify-center text-xs"
           }
-        >
-          🐝
-        </span>
+        />
       )}
       <span
         className={

--- a/desktop/src/shared/styles/globals.css
+++ b/desktop/src/shared/styles/globals.css
@@ -2,6 +2,34 @@
 @import "tw-animate-css";
 @config "../../../tailwind.config.js";
 
+.buzz-sidebar-scrollbar {
+  scrollbar-color: transparent transparent;
+}
+
+.buzz-sidebar-scrollbar:hover {
+  scrollbar-color: hsl(var(--sidebar-border) / 0.8) transparent;
+}
+
+.buzz-sidebar-scrollbar::-webkit-scrollbar {
+  height: 10px;
+  width: 10px;
+}
+
+.buzz-sidebar-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.buzz-sidebar-scrollbar::-webkit-scrollbar-thumb {
+  background-clip: content-box;
+  background-color: transparent;
+  border: 3px solid transparent;
+  border-radius: 999px;
+}
+
+.buzz-sidebar-scrollbar:hover::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--sidebar-border) / 0.8);
+}
+
 .sprout-arc-spinner {
   animation: sprout-arc-spinner-spin 500ms linear infinite;
 }


### PR DESCRIPTION
## Summary
- Replace sidebar unread dots with numeric unread badges and remove the Agents counter so navigation state is easier to scan.
- Rework the left sidebar scroll area so navigation scrolls cleanly above the fixed footer, prevents macOS rubber-band movement in the sidebar/top chrome, and shows the scrollbar only while interacting with the sidebar.
- Simplify sidebar section header actions by removing channel/forum search icons, using the same plain `+` affordance for channels and direct messages, and revealing `+`/collapse controls together on hover without visual shifting.
- Polish the profile menu by vertically centering status/workspace emoji and preventing native emoji glyphs from being clipped.

## Test plan
- `cd desktop && pnpm exec biome check src/app/AppShell.tsx src/app/AppTopChrome.tsx src/features/profile/ui/ProfilePopover.tsx src/features/sidebar/ui/AppSidebar.tsx src/features/sidebar/ui/CustomChannelSection.tsx src/features/sidebar/ui/SidebarProfileCard.tsx src/features/sidebar/ui/SidebarSection.tsx src/features/user-status/ui/StatusEmoji.tsx src/features/workspaces/ui/WorkspaceSwitcher.tsx src/shared/styles/globals.css`
- `cd desktop && pnpm exec tsc --noEmit`
- `git diff --check`
- Pre-commit hooks passed during commits.
- Pre-push hooks passed when pushing `left-side-nav`.