### PR TITLE
fix(desktop): keep history prepend anchored on the visible row

### DIFF
--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -208,7 +208,7 @@ const MessageTimelineBase = React.forwardRef<
     highlightedMessageId,
     isAtBottom,
     newMessageCount,
-    restoreScrollPosition,
+    restoreScrollBy,
     scrollToBottom,
     scrollToBottomOnNextUpdate,
     scrollToMessage,
@@ -292,7 +292,9 @@ const MessageTimelineBase = React.forwardRef<
     fetchOlder,
     hasOlderMessages,
     isLoading: showTimelineSkeleton,
-    restoreScrollPosition,
+    renderedFirstMessageId: deferredMessages[0]?.id ?? null,
+    renderedMessageCount: deferredMessages.length,
+    restoreScrollBy,
     scrollContainerRef,
     sentinelRef: topSentinelRef,
   });
@@ -347,7 +349,10 @@ const MessageTimelineBase = React.forwardRef<
             <div ref={topSentinelRef} aria-hidden className="h-px" />
 
             {isFetchingOlder ? (
-              <div className="flex justify-center py-2">
+              <div
+                className="pointer-events-none absolute inset-x-0 top-1 flex justify-center"
+                data-testid="message-fetching-older"
+              >
                 <Spinner className="h-4 w-4 border-2 text-muted-foreground" />
               </div>
             ) : null}

--- a/desktop/src/features/messages/ui/useLoadOlderOnScroll.ts
+++ b/desktop/src/features/messages/ui/useLoadOlderOnScroll.ts
@@ -1,31 +1,139 @@
 import * as React from "react";
 
+const TOP_ANCHOR_OFFSET = 12;
+
+type VisibleMessageAnchor = {
+  id: string;
+  topOffset: number;
+};
+
+type PendingPrependRestore = {
+  anchor: VisibleMessageAnchor | null;
+  previousFirstMessageId: string | null;
+  previousMessageCount: number;
+  previousScrollHeight: number;
+};
+
 type UseLoadOlderOnScrollOptions = {
   fetchOlder?: () => Promise<void>;
   hasOlderMessages: boolean;
   isLoading: boolean;
-  restoreScrollPosition: (scrollTop: number) => void;
+  renderedFirstMessageId: string | null;
+  renderedMessageCount: number;
+  restoreScrollBy: (delta: number) => void;
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   sentinelRef: React.RefObject<HTMLDivElement | null>;
 };
 
+function findVisibleMessageAnchor(
+  container: HTMLDivElement,
+): VisibleMessageAnchor | null {
+  const containerRect = container.getBoundingClientRect();
+  const preferredTop = Math.min(TOP_ANCHOR_OFFSET, containerRect.height / 2);
+  let bestAnchor: (VisibleMessageAnchor & { distance: number }) | null = null;
+
+  for (const row of Array.from(
+    container.querySelectorAll<HTMLElement>("[data-message-id]"),
+  )) {
+    const rect = row.getBoundingClientRect();
+    if (rect.bottom <= containerRect.top || rect.top >= containerRect.bottom) {
+      continue;
+    }
+
+    const id = row.dataset.messageId;
+    if (!id) {
+      continue;
+    }
+
+    const topOffset = rect.top - containerRect.top;
+    const distance = Math.abs(topOffset - preferredTop);
+    if (!bestAnchor || distance < bestAnchor.distance) {
+      bestAnchor = { distance, id, topOffset };
+    }
+  }
+
+  return bestAnchor
+    ? { id: bestAnchor.id, topOffset: bestAnchor.topOffset }
+    : null;
+}
+
 /**
  * Triggers `fetchOlder` when a sentinel element near the top of the scroll
  * container enters the viewport, then restores the scroll position so the
- * visible content doesn't jump.
+ * visible message row doesn't jump when older rows are prepended.
  */
 export function useLoadOlderOnScroll({
   fetchOlder,
   hasOlderMessages,
   isLoading,
-  restoreScrollPosition,
+  renderedFirstMessageId,
+  renderedMessageCount,
+  restoreScrollBy,
   scrollContainerRef,
   sentinelRef,
 }: UseLoadOlderOnScrollOptions) {
-  const restoreScrollPositionRef = React.useRef(restoreScrollPosition);
+  const fetchOlderRef = React.useRef(fetchOlder);
+  const pendingRestoreRef = React.useRef<PendingPrependRestore | null>(null);
+  const renderedFirstMessageIdRef = React.useRef(renderedFirstMessageId);
+  const renderedMessageCountRef = React.useRef(renderedMessageCount);
+  const restoreScrollByRef = React.useRef(restoreScrollBy);
+  const resumeObservingRef = React.useRef<(() => void) | null>(null);
+
   React.useEffect(() => {
-    restoreScrollPositionRef.current = restoreScrollPosition;
+    fetchOlderRef.current = fetchOlder;
   });
+
+  React.useEffect(() => {
+    renderedFirstMessageIdRef.current = renderedFirstMessageId;
+    renderedMessageCountRef.current = renderedMessageCount;
+  });
+
+  React.useEffect(() => {
+    restoreScrollByRef.current = restoreScrollBy;
+  });
+
+  React.useLayoutEffect(() => {
+    const pending = pendingRestoreRef.current;
+    if (!pending) {
+      return;
+    }
+
+    const hasCommittedPrepend =
+      renderedFirstMessageId !== pending.previousFirstMessageId ||
+      renderedMessageCount > pending.previousMessageCount;
+    if (!hasCommittedPrepend) {
+      return;
+    }
+
+    pendingRestoreRef.current = null;
+
+    const container = scrollContainerRef.current;
+    if (!container) {
+      resumeObservingRef.current?.();
+      return;
+    }
+
+    if (pending.anchor) {
+      const anchor = container.querySelector<HTMLElement>(
+        `[data-message-id="${CSS.escape(pending.anchor.id)}"]`,
+      );
+      if (anchor) {
+        const nextAnchorOffset =
+          anchor.getBoundingClientRect().top -
+          container.getBoundingClientRect().top;
+        restoreScrollByRef.current(nextAnchorOffset - pending.anchor.topOffset);
+        resumeObservingRef.current?.();
+        return;
+      }
+    }
+
+    const scrollHeightDelta =
+      container.scrollHeight - pending.previousScrollHeight;
+    if (scrollHeightDelta > 0) {
+      restoreScrollByRef.current(scrollHeightDelta);
+    }
+    resumeObservingRef.current?.();
+  }, [renderedFirstMessageId, renderedMessageCount, scrollContainerRef]);
 
   React.useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -44,31 +152,27 @@ export function useLoadOlderOnScroll({
     let currentObserver: IntersectionObserver | null = null;
 
     const observe = () => {
-      if (disposed) {
+      if (disposed || pendingRestoreRef.current) {
         return;
       }
 
       currentObserver = new IntersectionObserver(
         ([entry]) => {
-          if (!entry.isIntersecting || disposed) {
+          if (!entry.isIntersecting || disposed || pendingRestoreRef.current) {
             return;
           }
 
           currentObserver?.disconnect();
+          pendingRestoreRef.current = {
+            anchor: findVisibleMessageAnchor(container),
+            previousFirstMessageId: renderedFirstMessageIdRef.current,
+            previousMessageCount: renderedMessageCountRef.current,
+            previousScrollHeight: container.scrollHeight,
+          };
 
-          const previousHeight = container.scrollHeight;
-          const previousScrollTop = container.scrollTop;
-          void fetchOlder().then(() => {
-            requestAnimationFrame(() => {
-              requestAnimationFrame(() => {
-                const newHeight = container.scrollHeight;
-                const delta = newHeight - previousHeight;
-                if (delta > 0) {
-                  restoreScrollPositionRef.current(previousScrollTop + delta);
-                }
-                observe();
-              });
-            });
+          void fetchOlderRef.current?.().catch(() => {
+            pendingRestoreRef.current = null;
+            observe();
           });
         },
         { root: container, rootMargin: "200px 0px 0px 0px" },
@@ -77,9 +181,11 @@ export function useLoadOlderOnScroll({
       currentObserver.observe(sentinel);
     };
 
+    resumeObservingRef.current = observe;
     observe();
     return () => {
       disposed = true;
+      resumeObservingRef.current = null;
       currentObserver?.disconnect();
     };
   }, [

--- a/desktop/src/features/messages/ui/useLoadOlderOnScroll.ts
+++ b/desktop/src/features/messages/ui/useLoadOlderOnScroll.ts
@@ -170,10 +170,29 @@ export function useLoadOlderOnScroll({
             previousScrollHeight: container.scrollHeight,
           };
 
-          void fetchOlderRef.current?.().catch(() => {
-            pendingRestoreRef.current = null;
-            observe();
-          });
+          const restorePending = pendingRestoreRef.current;
+          void fetchOlderRef.current?.().then(
+            () => {
+              // Empty-older-page guard: if the fetch resolved without a
+              // committed prepend (zero new rows or duplicate of head),
+              // the layout effect never fires and `pendingRestoreRef`
+              // would stay set, wedging the observer. Wait one paint to
+              // let any real commit run the layout effect (which clears
+              // `pendingRestoreRef`); if our pending is still the live
+              // one, treat it as a no-commit fetch and re-arm.
+              requestAnimationFrame(() => {
+                if (disposed || pendingRestoreRef.current !== restorePending) {
+                  return;
+                }
+                pendingRestoreRef.current = null;
+                resumeObservingRef.current?.();
+              });
+            },
+            () => {
+              pendingRestoreRef.current = null;
+              observe();
+            },
+          );
         },
         { root: container, rootMargin: "200px 0px 0px 0px" },
       );

--- a/desktop/src/features/messages/ui/useTimelineScrollManager.ts
+++ b/desktop/src/features/messages/ui/useTimelineScrollManager.ts
@@ -183,6 +183,29 @@ export function useTimelineScrollManager({
     [syncScrollState],
   );
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: timelineRef is a stable React ref passed from the parent — its identity never changes
+  const restoreScrollBy = React.useCallback(
+    (delta: number) => {
+      const timeline = timelineRef.current;
+
+      if (!timeline || delta === 0) {
+        return;
+      }
+
+      isProgrammaticBottomScrollRef.current = false;
+      timeline.scrollBy({ top: delta, behavior: "auto" });
+      previousScrollTopRef.current += delta;
+      lockedScrollTopRef.current = previousScrollTopRef.current;
+
+      requestAnimationFrame(() => {
+        lockedScrollTopRef.current = null;
+        previousScrollTopRef.current = timeline.scrollTop;
+        syncScrollState();
+      });
+    },
+    [syncScrollState],
+  );
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: timelineRef is a stable React ref — its identity never changes
   const scrollToBottom = React.useCallback(
     (behavior: ScrollBehavior) => {
@@ -455,6 +478,7 @@ export function useTimelineScrollManager({
     highlightedMessageId,
     isAtBottom,
     newMessageCount,
+    restoreScrollBy,
     restoreScrollPosition,
     scrollToBottom,
     scrollToBottomOnNextUpdate,

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -80,6 +80,12 @@ type E2eConfig = {
     updateAvailable?: boolean;
     updateChannelDelayMs?: number;
     updateDownloadDelayMs?: number;
+    // Delay applied to older-history fetches (`REQ` with `until`) so the
+    // anchor-invariant test in `messaging.spec.ts` has a deterministic
+    // window to snapshot the visible row before the prepend commits.
+    // Only affects history-paging requests; the initial channel load is
+    // not delayed.
+    historyDelayMs?: number;
     restartDelayMs?: number;
     updateVersion?: string;
     stallWebsocketSends?: boolean;
@@ -1495,6 +1501,35 @@ const mockChannels: MockChannel[] = [
       createMockMember(MOCK_IDENTITY_PUBKEY, "member", 700),
     ],
   }),
+  // Long-history fixture for the scroll-anchor invariant test in
+  // `messaging.spec.ts`. Seeded in `getMockMessageStore` with enough
+  // messages to force at least one older-fetch round-trip past the
+  // initial 200-msg load.
+  createMockChannel({
+    id: "1f0d9f7a-c2ad-5b23-b35f-17ed1bb10930",
+    name: "history-jump",
+    channel_type: "stream",
+    visibility: "open",
+    description: "Long history fixture for scroll anchoring tests",
+    topic: null,
+    purpose: null,
+    last_message_at: isoMinutesAgo(1),
+    archived_at: null,
+    created_by: MOCK_IDENTITY_PUBKEY,
+    topic_set_by: null,
+    topic_set_at: null,
+    purpose_set_by: null,
+    purpose_set_at: null,
+    topic_required: false,
+    max_members: null,
+    nip29_group_id: null,
+    created_minutes_ago: 1440,
+    updated_minutes_ago: 1,
+    members: [
+      createMockMember(MOCK_IDENTITY_PUBKEY, "owner", 1440),
+      createMockMember(ALICE_PUBKEY, "member", 1200),
+    ],
+  }),
 ];
 
 const mockMessages = new Map<string, RelayEvent[]>();
@@ -2261,7 +2296,22 @@ function getMockMessageStore(channelId: string): RelayEvent[] {
                 sig: "mocksig".repeat(20).slice(0, 128),
               },
             ]
-          : [];
+          : channelId === "1f0d9f7a-c2ad-5b23-b35f-17ed1bb10930"
+            ? // History-jump fixture: 240 sequential messages spaced 1 minute
+              // apart so the initial 200-msg load doesn't cover the full
+              // history and `useLoadOlderOnScroll` has to page back. Numbered
+              // bottom-up (001 = oldest, 240 = newest) so the test can assert
+              // anchor stability against a known message number.
+              Array.from({ length: 240 }, (_, index) => ({
+                id: `mock-history-jump-${String(index + 1).padStart(3, "0")}`,
+                pubkey: ALICE_PUBKEY,
+                created_at: Math.floor(Date.now() / 1000) - (240 - index) * 60,
+                kind: 9,
+                tags: [["h", channelId]],
+                content: `History jump fixture message ${String(index + 1).padStart(3, "0")}`,
+                sig: "mocksig".repeat(20).slice(0, 128),
+              }))
+            : [];
 
   mockMessages.set(channelId, seeded);
   return seeded;
@@ -5869,6 +5919,21 @@ function sendToMockSocket(args: {
     const channelId = filter["#h"]?.[0];
     if (!channelId) {
       sendWsText(socket.handler, ["EOSE", subId]);
+      return;
+    }
+
+    // Older-history paging uses `until` to bound the fetch above the oldest
+    // currently-rendered message. Delay only that path when the test asks for
+    // it — initial loads stay snappy.
+    const historyDelayMs = getConfig()?.mock?.historyDelayMs;
+    if (
+      filter.until !== undefined &&
+      historyDelayMs !== undefined &&
+      historyDelayMs > 0
+    ) {
+      setTimeout(() => {
+        emitMockHistory(socket, subId, channelId, filter);
+      }, historyDelayMs);
       return;
     }
 

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -1,7 +1,112 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
 import { openSettings } from "../helpers/settings";
+
+const SCROLL_PREPEND_ANCHOR_DRIFT_TOLERANCE_PX = 4;
+
+type TimelineAnchorSnapshot = {
+  anchors: Array<{ id: string; top: number; visible: boolean }>;
+  firstMessageId: string | null;
+  messageCount: number;
+  metrics: {
+    clientHeight: number;
+    scrollHeight: number;
+    scrollTop: number;
+  };
+};
+
+async function snapshotRenderedAnchors(
+  page: Page,
+): Promise<TimelineAnchorSnapshot | null> {
+  return page.evaluate(() => {
+    const timeline = document.querySelector(
+      '[data-testid="message-timeline"]',
+    ) as HTMLElement | null;
+    if (!timeline) return null;
+
+    const containerRect = timeline.getBoundingClientRect();
+    const rows = Array.from(
+      timeline.querySelectorAll<HTMLElement>("[data-message-id]"),
+    );
+
+    return {
+      messageCount: rows.length,
+      firstMessageId: rows[0]?.dataset.messageId ?? null,
+      metrics: {
+        clientHeight: timeline.clientHeight,
+        scrollHeight: timeline.scrollHeight,
+        scrollTop: timeline.scrollTop,
+      },
+      anchors: rows.map((row) => {
+        const rect = row.getBoundingClientRect();
+        return {
+          id: row.dataset.messageId ?? "",
+          top: rect.top - containerRect.top,
+          visible:
+            rect.bottom > containerRect.top && rect.top < containerRect.bottom,
+        };
+      }),
+    };
+  });
+}
+
+async function findVisibleTimelineAnchor(page: Page) {
+  return page.evaluate(() => {
+    const timeline = document.querySelector(
+      '[data-testid="message-timeline"]',
+    ) as HTMLElement | null;
+    if (!timeline) return null;
+
+    const rect = timeline.getBoundingClientRect();
+    const preferredTop = rect.height / 3;
+    let best: { distance: number; id: string; top: number } | null = null;
+
+    for (const row of Array.from(
+      timeline.querySelectorAll<HTMLElement>("[data-message-id]"),
+    )) {
+      const rowRect = row.getBoundingClientRect();
+      if (rowRect.bottom <= rect.top || rowRect.top >= rect.bottom) {
+        continue;
+      }
+
+      const top = rowRect.top - rect.top;
+      const distance = Math.abs(top - preferredTop);
+      if (!best || distance < best.distance) {
+        best = { distance, id: row.dataset.messageId ?? "", top };
+      }
+    }
+
+    return best ? { id: best.id, top: best.top } : null;
+  });
+}
+
+async function waitForPrependCommit(
+  page: Page,
+  previousFirstMessageId: string | null,
+  previousCount: number,
+  timeoutMs = 5_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const snap = await snapshotRenderedAnchors(page);
+    if (
+      snap &&
+      snap.firstMessageId !== previousFirstMessageId &&
+      snap.messageCount > previousCount
+    ) {
+      return snap;
+    }
+    await page.waitForTimeout(50);
+  }
+
+  const finalSnap = await snapshotRenderedAnchors(page);
+  throw new Error(
+    `Prepend did not commit within ${timeoutMs}ms. Final snapshot: ${JSON.stringify(
+      finalSnap,
+    )}`,
+  );
+}
 
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
@@ -61,6 +166,115 @@ test("long autolink wraps without widening the timeline", async ({ page }) => {
       return barBox.x + barBox.width - (timelineBox.x + timelineBox.width);
     })
     .toBeLessThanOrEqual(0);
+});
+
+test("older-history prepend keeps the visible row pinned", async ({ page }) => {
+  // Override only this spec's mock config with a delayed older-history response.
+  // The delay gives the test a deterministic window to snapshot the anchor after
+  // the sentinel fires but before the prepended rows commit.
+  await installMockBridge(page, { historyDelayMs: 250 });
+
+  await page.goto("/");
+  await page.getByTestId("channel-history-jump").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("history-jump");
+  await expect(page.getByTestId("message-timeline")).toContainText(
+    "History jump fixture message 240",
+  );
+
+  await expect
+    .poll(async () => {
+      const snap = await snapshotRenderedAnchors(page);
+      return snap?.messageCount ?? 0;
+    })
+    .toBeGreaterThan(150);
+
+  const timeline = page.getByTestId("message-timeline");
+  await timeline.hover();
+
+  // Move close enough that one more wheel tick enters the 200px top rootMargin,
+  // but stop before the sentinel can fire. Capturing the anchor before the
+  // loading spinner appears keeps the assertion tied to the row the user was
+  // actually reading when the older fetch started.
+  let before: TimelineAnchorSnapshot | null = null;
+  for (let attempts = 0; attempts < 80; attempts += 1) {
+    before = await snapshotRenderedAnchors(page);
+    if (!before) throw new Error("Timeline disappeared while scrolling.");
+    if (before.metrics.scrollTop < 700) break;
+    await page.mouse.wheel(0, -600);
+    await page.waitForTimeout(20);
+  }
+  for (let attempts = 0; attempts < 20; attempts += 1) {
+    before = await snapshotRenderedAnchors(page);
+    if (!before) throw new Error("Timeline disappeared while positioning.");
+    if (before.metrics.scrollTop <= 300) break;
+    await page.mouse.wheel(0, -80);
+    await page.waitForTimeout(20);
+  }
+
+  before = await snapshotRenderedAnchors(page);
+  if (!before) throw new Error("Timeline disappeared before prepend.");
+  expect(
+    before.metrics.scrollTop,
+    `test must snapshot before the top sentinel fires; got ${JSON.stringify(
+      before.metrics,
+    )}`,
+  ).toBeGreaterThan(200);
+
+  const anchorBefore = await findVisibleTimelineAnchor(page);
+  if (!anchorBefore) {
+    throw new Error(
+      `Could not find visible anchor before prepend. Snapshot: ${JSON.stringify(
+        await snapshotRenderedAnchors(page),
+      )}`,
+    );
+  }
+
+  before = await snapshotRenderedAnchors(page);
+  if (!before) throw new Error("Timeline disappeared before prepend.");
+
+  await page.mouse.wheel(0, -160);
+  await expect(page.getByTestId("message-fetching-older")).toHaveCount(1);
+
+  const triggerSnapshot = await snapshotRenderedAnchors(page);
+  if (!triggerSnapshot) throw new Error("Timeline disappeared after trigger.");
+  const expectedAnchorTop =
+    anchorBefore.top +
+    (before.metrics.scrollTop - triggerSnapshot.metrics.scrollTop);
+
+  const after = await waitForPrependCommit(
+    page,
+    before.firstMessageId,
+    before.messageCount,
+  );
+  expect(after.firstMessageId).toBe("mock-history-jump-001");
+
+  // Let the layout-effect restore and scroll manager settle.
+  await page.waitForTimeout(80);
+
+  const livePosition = await page.evaluate((id) => {
+    const timeline = document.querySelector(
+      '[data-testid="message-timeline"]',
+    ) as HTMLElement | null;
+    if (!timeline) return null;
+
+    const row = timeline.querySelector<HTMLElement>(
+      `[data-message-id="${CSS.escape(id)}"]`,
+    );
+    if (!row) return null;
+
+    return (
+      row.getBoundingClientRect().top - timeline.getBoundingClientRect().top
+    );
+  }, anchorBefore.id);
+
+  expect(livePosition, "anchor row missing after prepend").not.toBeNull();
+  const drift = Math.abs((livePosition ?? 0) - expectedAnchorTop);
+  expect(
+    drift,
+    `anchor row "${anchorBefore.id}" drifted ${drift.toFixed(2)}px ` +
+      `(was ${expectedAnchorTop.toFixed(2)}px at prepend start, now ${(livePosition ?? 0).toFixed(2)}px). ` +
+      `Tolerance is ${SCROLL_PREPEND_ANCHOR_DRIFT_TOLERANCE_PX}px.`,
+  ).toBeLessThanOrEqual(SCROLL_PREPEND_ANCHOR_DRIFT_TOLERANCE_PX);
 });
 
 test("send multiple messages in sequence", async ({ page }) => {

--- a/desktop/tests/e2e/scroll-prepend-stability.spec.ts
+++ b/desktop/tests/e2e/scroll-prepend-stability.spec.ts
@@ -1,0 +1,365 @@
+/**
+ * Scroll prepend stability invariant — real-relay smoke for the channel
+ * scroll-jump regression.
+ *
+ * Status: **nightly / manual-gated**, NOT part of the integration project's
+ * default `testMatch`. The default gate for the math/timing class of this
+ * bug is the mock-bridge case in `messaging.spec.ts` (deterministic, no
+ * seed dependency). This spec exists as a real-relay artifact for hand
+ * verification of a fix candidate against the actual relay path. Run with:
+ *
+ *     pnpm -C desktop exec playwright test scroll-prepend-stability.spec.ts
+ *
+ * **Precondition — local relay must reconcile DB-seeded channels.** The
+ * relay only emits the `kind:39000` discovery events for channels inserted
+ * via `scripts/setup-desktop-test-data.sh` if it was started with
+ * `BUZZ_RECONCILE_CHANNELS=1` (see `crates/buzz-relay/src/main.rs:307`).
+ * If your local relay was started without that env var, the DB will have
+ * the seed channels but the relay won't emit them — `assertRelaySeeded()`
+ * below will hang until the timeout. Restart the relay with the env var
+ * before running this spec. (CI runners always restart fresh and don't
+ * hit this trap.)
+ *
+ * Invariant: when older history is prepended, the visible anchor row stays
+ * pinned to the same viewport offset. If this test ever fails, we have
+ * re-introduced a `scrollTop`-during-input write somewhere in the
+ * load-older path.
+ *
+ * IMPORTANT — this is a half-test. It runs on headless Chromium, NOT on
+ * WKWebView (the actual Tauri target on macOS). That means it catches the
+ * math/timing class of bugs (stale `previousScrollTop` captured before
+ * commit, wrong `delta` math, ResizeObserver stomp on the restore, etc.)
+ * but it does NOT reproduce the macOS-specific stale-`scrollTop`-read
+ * hazard documented in Element/Matrix `docs/scrolling.md`. A green run
+ * here is necessary, not sufficient — manual macOS wheel-scroll repro is
+ * still required before any fix in this area is called shipped. See
+ * `RESEARCH/BUZZ_SCROLL_PREPEND_2026-06-14.md` for the full background.
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+
+import { installRelayBridge } from "../helpers/bridge";
+
+// Initial channel history limit is 200; older batch size is 100. To force at
+// least one older-fetch round-trip, we need strictly more than 200 messages
+// in the channel. 240 gives us enough headroom that the test still triggers
+// load-older even if a couple of messages get dropped or merged.
+const SEED_MESSAGE_COUNT = 240;
+// Tolerance for the anchor's vertical position before vs. after prepend.
+// Sub-pixel rounding and zoom can shift things a hair; anything past this
+// is a real jump.
+const ANCHOR_DRIFT_TOLERANCE_PX = 4;
+
+async function createChannel(page: Page, channelName: string): Promise<string> {
+  await page.getByRole("button", { name: "Create a channel" }).click();
+  await page.getByTestId("create-channel-name").fill(channelName);
+  await page.getByTestId("create-channel-submit").click();
+  await expect(page.getByTestId("chat-title")).toHaveText(channelName);
+  return await page.evaluate(async (name) => {
+    const tauriWindow = window as Window & {
+      __TAURI_INTERNALS__?: {
+        invoke: (
+          command: string,
+          payload?: Record<string, unknown>,
+        ) => Promise<unknown>;
+      };
+    };
+    const invoke = tauriWindow.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) throw new Error("Tauri invoke unavailable");
+    const channels = (await invoke("get_channels")) as Array<{
+      id: string;
+      name: string;
+    }>;
+    const channel = channels.find((c) => c.name === name);
+    if (!channel) throw new Error(`Channel not found: ${name}`);
+    return channel.id;
+  }, channelName);
+}
+
+async function seedChannelMessages(
+  page: Page,
+  channelId: string,
+  count: number,
+  prefix: string,
+) {
+  // Sends `count` messages in small batches via the Tauri bridge. This is
+  // slow (each call hits the relay and waits for ack) but it's the only
+  // path that produces real signed events the load-older fetch can return.
+  // Batches keep the JS event loop from starving the renderer.
+  const BATCH_SIZE = 20;
+  for (let start = 0; start < count; start += BATCH_SIZE) {
+    const end = Math.min(start + BATCH_SIZE, count);
+    await page.evaluate(
+      async ({ channelId, prefix, start, end }) => {
+        const tauriWindow = window as Window & {
+          __TAURI_INTERNALS__?: {
+            invoke: (
+              command: string,
+              payload?: Record<string, unknown>,
+            ) => Promise<unknown>;
+          };
+        };
+        const invoke = tauriWindow.__TAURI_INTERNALS__?.invoke;
+        if (!invoke) throw new Error("Tauri invoke unavailable");
+        for (let i = start; i < end; i += 1) {
+          await invoke("send_channel_message", {
+            channelId,
+            content: `${prefix} seed ${i.toString().padStart(4, "0")}`,
+            kind: null,
+            mediaTags: null,
+            mentionPubkeys: null,
+            parentEventId: null,
+          });
+        }
+      },
+      { channelId, prefix, start, end },
+    );
+  }
+}
+
+/**
+ * Reads, for each currently rendered message row, its `data-message-id`
+ * plus the vertical offset of its top edge relative to the timeline
+ * container's top edge.
+ */
+async function snapshotRenderedAnchors(page: Page) {
+  return page.evaluate(() => {
+    const timeline = document.querySelector(
+      '[data-testid="message-timeline"]',
+    ) as HTMLElement | null;
+    if (!timeline) return null;
+    const containerRect = timeline.getBoundingClientRect();
+    const rows = Array.from(
+      timeline.querySelectorAll<HTMLElement>("[data-message-id]"),
+    );
+    return {
+      messageCount: rows.length,
+      firstMessageId: rows[0]?.dataset.messageId ?? null,
+      metrics: {
+        clientHeight: timeline.clientHeight,
+        scrollHeight: timeline.scrollHeight,
+        scrollTop: timeline.scrollTop,
+      },
+      anchors: rows.map((row) => {
+        const rect = row.getBoundingClientRect();
+        return {
+          bottom: rect.bottom - containerRect.top,
+          id: row.dataset.messageId ?? "",
+          top: rect.top - containerRect.top,
+          visible:
+            rect.bottom > containerRect.top && rect.top < containerRect.bottom,
+        };
+      }),
+    };
+  });
+}
+
+async function getTimelineMetrics(page: Page) {
+  return page.getByTestId("message-timeline").evaluate((el) => {
+    const t = el as HTMLDivElement;
+    return {
+      clientHeight: t.clientHeight,
+      scrollHeight: t.scrollHeight,
+      scrollTop: t.scrollTop,
+    };
+  });
+}
+
+/**
+ * Scrolls the timeline up using wheel events (not `scrollTop=` writes —
+ * we don't want the harness to bypass the same code path the user uses).
+ * Stops once `messageCount` rendered rows are above the viewport — i.e.
+ * we've scrolled far enough that we're near the top sentinel and the
+ * older-fetch rootMargin (200px) will fire.
+ *
+ * Returns the anchor we want to track: a message id that is currently
+ * visible roughly one-third down the viewport. We pick mid-viewport
+ * (not the top) so that even if the prepend goes wrong by a little, the
+ * anchor doesn't accidentally scroll off-screen and become unfindable.
+ */
+async function scrollUpAndPickAnchor(page: Page) {
+  const timeline = page.getByTestId("message-timeline");
+  await timeline.hover();
+  // Wheel up in large but realistic chunks (~1 screenful per tick).
+  for (let attempts = 0; attempts < 60; attempts += 1) {
+    const metrics = await getTimelineMetrics(page);
+    if (metrics.scrollTop < 400) break;
+    await page.mouse.wheel(0, -600);
+    await page.waitForTimeout(40);
+  }
+
+  const anchor = await page.evaluate(() => {
+    const timeline = document.querySelector(
+      '[data-testid="message-timeline"]',
+    ) as HTMLElement | null;
+    if (!timeline) return null;
+    const rect = timeline.getBoundingClientRect();
+    const preferredTop = rect.height / 3;
+    let best: { distance: number; id: string; top: number } | null = null;
+
+    for (const row of Array.from(
+      timeline.querySelectorAll<HTMLElement>("[data-message-id]"),
+    )) {
+      const rowRect = row.getBoundingClientRect();
+      if (rowRect.bottom <= rect.top || rowRect.top >= rect.bottom) {
+        continue;
+      }
+      const top = rowRect.top - rect.top;
+      const distance = Math.abs(top - preferredTop);
+      if (!best || distance < best.distance) {
+        best = { distance, id: row.dataset.messageId ?? "", top };
+      }
+    }
+
+    return best ? { id: best.id, top: best.top } : null;
+  });
+  if (!anchor) {
+    const snap = await snapshotRenderedAnchors(page);
+    throw new Error(
+      `Could not find an anchor message row after scrolling up. Snapshot: ${JSON.stringify(
+        snap,
+      )}`,
+    );
+  }
+  return anchor;
+}
+
+async function waitForPrependCommit(
+  page: Page,
+  previousFirstMessageId: string,
+  previousCount: number,
+  timeoutMs = 5_000,
+) {
+  // Polls until the rendered message snapshot shows BOTH a new first-message
+  // id AND a larger row count. Either alone is not enough: a count bump with
+  // the same first id can happen on bottom appends; a first-id change with no
+  // count bump can happen if a message gets re-keyed.
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const snap = await snapshotRenderedAnchors(page);
+    if (
+      snap &&
+      snap.firstMessageId !== previousFirstMessageId &&
+      snap.messageCount > previousCount
+    ) {
+      return snap;
+    }
+    await page.waitForTimeout(50);
+  }
+  throw new Error("Prepend did not commit within the expected window.");
+}
+
+test("anchor row stays pinned across older-history prepend", async ({
+  browser,
+}) => {
+  // This is slow on purpose — seeding 240 messages over the real relay takes
+  // ~10–15 seconds locally and longer on CI.
+  test.slow();
+
+  const channelName = `prepend-stability-${Date.now()}`;
+  const ownerContext = await browser.newContext();
+  const readerContext = await browser.newContext();
+  const ownerPage = await ownerContext.newPage();
+  const readerPage = await readerContext.newPage();
+
+  try {
+    // Alice creates the channel and seeds it; Tyler reads it. Splitting the
+    // roles keeps the seed path off the same JS context that will run the
+    // assertion, which keeps the seed-loop's render churn from polluting the
+    // measurement.
+    await installRelayBridge(ownerPage, "alice");
+    await installRelayBridge(readerPage, "tyler");
+    await ownerPage.goto("/");
+    await readerPage.goto("/");
+
+    const channelId = await createChannel(ownerPage, channelName);
+    await seedChannelMessages(ownerPage, channelId, SEED_MESSAGE_COUNT, "msg");
+
+    // Reader joins the channel.
+    await readerPage.getByTestId("browse-channels").click();
+    await expect(
+      readerPage.getByTestId("channel-browser-dialog"),
+    ).toBeVisible();
+    await readerPage
+      .getByTestId(`browse-channel-${channelName}`)
+      .getByRole("button", { name: "Join" })
+      .click();
+    await expect(readerPage.getByTestId("chat-title")).toHaveText(channelName);
+
+    // Wait for the initial history load (200 messages) to land. We need at
+    // least 100 rendered rows before we even try scrolling up; in practice
+    // the initial load brings 200.
+    await expect
+      .poll(
+        async () => {
+          const snap = await snapshotRenderedAnchors(readerPage);
+          return snap?.messageCount ?? 0;
+        },
+        { timeout: 15_000 },
+      )
+      .toBeGreaterThan(150);
+
+    // Give the timeline a beat to settle (initial scroll-to-bottom, layout).
+    await readerPage.waitForTimeout(300);
+
+    // Scroll up and pick an anchor message that's currently visible.
+    const anchorBefore = await scrollUpAndPickAnchor(readerPage);
+
+    // Snapshot the rendered state right before the fetch fires so we can
+    // detect commit later.
+    const before = await snapshotRenderedAnchors(readerPage);
+    if (!before) throw new Error("Timeline disappeared before prepend.");
+
+    // Trigger one more wheel tick to push the top sentinel into the
+    // load-older rootMargin (200px above the viewport).
+    await readerPage.getByTestId("message-timeline").hover();
+    await readerPage.mouse.wheel(0, -800);
+
+    // Wait for the prepend to commit.
+    const after = await waitForPrependCommit(
+      readerPage,
+      before.firstMessageId ?? "",
+      before.messageCount,
+    );
+
+    // Give the post-commit layout-effect one frame to run its restore.
+    await readerPage.waitForTimeout(80);
+
+    // Find the same anchor id in the new render and measure where it is now.
+    const anchorAfter = after.anchors.find((a) => a.id === anchorBefore.id);
+    expect(anchorAfter, "anchor row missing after prepend").toBeDefined();
+
+    // Re-measure live (not from the cached `after` snapshot) — the
+    // layout-effect restore may run AFTER `waitForPrependCommit` returned.
+    const livePosition = await readerPage.evaluate((id) => {
+      const timeline = document.querySelector(
+        '[data-testid="message-timeline"]',
+      ) as HTMLElement | null;
+      if (!timeline) return null;
+      const row = timeline.querySelector<HTMLElement>(
+        `[data-message-id="${CSS.escape(id)}"]`,
+      );
+      if (!row) return null;
+      return (
+        row.getBoundingClientRect().top - timeline.getBoundingClientRect().top
+      );
+    }, anchorBefore.id);
+
+    expect(
+      livePosition,
+      "anchor row missing after layout settle",
+    ).not.toBeNull();
+    const drift = Math.abs((livePosition ?? 0) - anchorBefore.top);
+    expect(
+      drift,
+      `anchor row "${anchorBefore.id}" drifted ${drift.toFixed(2)}px ` +
+        `(was ${anchorBefore.top.toFixed(2)}px, now ${(livePosition ?? 0).toFixed(2)}px). ` +
+        `Tolerance is ${ANCHOR_DRIFT_TOLERANCE_PX}px. ` +
+        `This means the older-history prepend moved the viewport — the ` +
+        `scroll-jump bug has regressed.`,
+    ).toBeLessThanOrEqual(ANCHOR_DRIFT_TOLERANCE_PX);
+  } finally {
+    await readerContext.close();
+    await ownerContext.close();
+  }
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -104,6 +104,13 @@ type MockBridgeOptions = {
   updateAvailable?: boolean;
   updateChannelDelayMs?: number;
   updateDownloadDelayMs?: number;
+  /**
+   * Delay (ms) applied to older-history fetches in the mock relay so the
+   * scroll-anchor invariant test can snapshot the visible row before the
+   * prepend commits. Only affects older-paging requests (those with `until`
+   * set); the initial channel load is unaffected.
+   */
+  historyDelayMs?: number;
   updateVersion?: string;
   stallWebsocketSends?: boolean;
   userSearchDelayMs?: number;


### PR DESCRIPTION
## The bug

Scrolling up in a channel to load older history yanks the viewport to the
oldest just-loaded message instead of keeping the row the user was reading
pinned to the same screen position. Recurring regression; previous "fixes"
relied on math against `container.scrollTop`, which is stale on macOS
WKWebView mid-wheel (root cause documented in
`RESEARCH/BUZZ_SCROLL_PREPEND_2026-06-14.md` and Element/Matrix
`docs/scrolling.md`).

## The fix (two parts, in `useLoadOlderOnScroll.ts` + `MessageTimeline.tsx`)

1. **Anchor on a real visible DOM node**, not on a `scrollTop` value.
   When the top sentinel intersects, `findVisibleMessageAnchor` walks
   `[data-message-id]` rows and picks the one whose top-offset is closest
   to `min(12px, containerHeight / 2)` — the row the user is most likely
   reading. We snapshot `{ id, topOffset, fallbackScrollHeight }` in a
   ref while we wait for the prepended rows to commit.

2. **Restore via relative `scrollBy(delta)`, no `scrollTop` read.**
   In a layout-effect keyed on the actual rendered first-id + count
   changing (i.e., the prepend has committed), we read the anchor row's
   new top-offset and call `restoreScrollBy(nextTopOffset - savedTopOffset)`.
   This is the difference between "passes headless Chromium" and
   "actually fixed on macOS" — no stale read, no read-then-write.

`MessageTimeline.tsx` switches the consumer from `restoreScrollPosition`
(absolute write) to `restoreScrollBy` (relative), and changes the
fetch-older spinner from an in-flow block to an absolute overlay so the
spinner's own mount doesn't shove the topmost message down and confuse
the anchor math.

`useTimelineScrollManager.ts` adds the `restoreScrollBy` primitive
(`container.scrollBy(0, delta)`) alongside the existing scroll API.

## The regression gate

Mock-bridge invariant test in `messaging.spec.ts` ("older-history
prepend keeps the visible row pinned"):

- Seeds a `history-jump` mock channel with 240 messages — enough to
  force at least one older-fetch round-trip past the 200-msg initial
  load.
- New `historyDelayMs` config knob delays only the older-history `REQ`
  with `until` (not initial loads), giving a deterministic snapshot
  window after the sentinel fires but before the prepend commits.
- Uses real `mouse.wheel` events, snapshots the anchor row by
  `[data-message-id]` rect against the timeline container, awaits
  prepend commit via first-id-changed + count-grew, then asserts
  ≤ 4px drift after layout-effect restore.
- Accounts for `scrollTop` drift between snapshots so it doesn't
  false-pass when `scrollBy` is wired correctly but the user kept
  wheeling.

A nightly-gated `scroll-prepend-stability.spec.ts` is included for
manual real-relay smoke (excluded from both `smoke` and `integration`
`testMatch` in `playwright.config.ts`). Run manually with
`pnpm -C desktop exec playwright test scroll-prepend-stability.spec.ts`
against a relay started with `BUZZ_RECONCILE_CHANNELS=1`.

## Verified

- Positive test green against the fixed build (~3s, single worker).
- Negative test (restore neutered to `void delta`) fails as expected —
  confirms the gate catches the regression.
- `pnpm typecheck` + `pnpm check` (biome) clean.
- Build clean.

## What's NOT done in this PR

- **Manual macOS wheel-scroll repro.** Headless Chromium ≠ WKWebView.
  A green CI run here is necessary, not sufficient. @tlongwell-block —
  pulling this branch on macOS and confirming the jump is gone is the
  load-bearing pass before this is "shipped."
- **Empty-older-page guard.** If `fetchOlder` resolves with zero new rows,
  `hasCommittedPrepend` never goes true, the layout effect early-returns
  leaving `pendingRestoreRef` set, and the observer never re-arms — older
  loading silently wedges. Happy path is covered; this is a follow-up
  commit on the same PR (resume observing if the fetch resolves with no
  commit). _Landed as `da1606c2` — converts the fetch handler to
  `.then(onFulfilled, onRejected)` and uses a single-rAF settle fence with
  an identity check on the captured pending to re-arm only on a true
  no-commit, never racing a real commit's restore._



