### PR TITLE
feat(desktop): improve inbox triage

### DIFF
--- a/desktop/src/features/home/lib/inbox.test.mjs
+++ b/desktop/src/features/home/lib/inbox.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildInboxItems, INBOX_PREVIEW_MAX_LENGTH } from "./inbox.ts";
+
+function feedItem(overrides = {}) {
+  return {
+    id: overrides.id ?? "event-1",
+    kind: overrides.kind ?? 45003,
+    pubkey: overrides.pubkey ?? "pubkey-1",
+    content: overrides.content ?? "hello",
+    createdAt: overrides.createdAt ?? 1_700_000_000,
+    channelId: overrides.channelId ?? "channel-1",
+    channelName: overrides.channelName ?? "general",
+    channelType: overrides.channelType,
+    tags: overrides.tags ?? [],
+    category: overrides.category ?? "activity",
+  };
+}
+
+function homeFeed({
+  mentions = [],
+  needsAction = [],
+  activity = [],
+  agentActivity = [],
+} = {}) {
+  return {
+    feed: {
+      mentions,
+      needsAction,
+      activity,
+      agentActivity,
+    },
+    meta: {
+      since: 0,
+      total:
+        mentions.length +
+        needsAction.length +
+        activity.length +
+        agentActivity.length,
+      generatedAt: 1_700_000_000,
+    },
+  };
+}
+
+test("buildInboxItems caps regular and agent previews to the same length", () => {
+  const longHumanMessage = `human ${"message ".repeat(50)}`;
+  const longAgentMessage = `agent\n\n${"response ".repeat(50)}`;
+
+  const items = buildInboxItems({
+    feed: homeFeed({
+      activity: [
+        feedItem({
+          id: "human-message",
+          content: longHumanMessage,
+          createdAt: 1_700_000_000,
+          category: "activity",
+        }),
+      ],
+      agentActivity: [
+        feedItem({
+          id: "agent-message",
+          content: longAgentMessage,
+          createdAt: 1_700_000_001,
+          category: "agent_activity",
+        }),
+      ],
+    }),
+  });
+
+  const human = items.find((item) => item.id === "human-message");
+  const agent = items.find((item) => item.id === "agent-message");
+
+  assert.ok(human);
+  assert.ok(agent);
+  assert.equal(human.preview.length, INBOX_PREVIEW_MAX_LENGTH);
+  assert.equal(agent.preview.length, INBOX_PREVIEW_MAX_LENGTH);
+  assert.equal(human.preview.endsWith("..."), true);
+  assert.equal(agent.preview.endsWith("..."), true);
+  assert.equal(agent.preview.includes("\n"), false);
+});

--- a/desktop/src/features/home/lib/inbox.ts
+++ b/desktop/src/features/home/lib/inbox.ts
@@ -88,6 +88,9 @@ const weekdayFormatter = new Intl.DateTimeFormat("en-US", {
   weekday: "long",
 });
 
+/** Shared text cap for inbox list previews, including long agent responses. */
+export const INBOX_PREVIEW_MAX_LENGTH = 160;
+
 function startOfDay(value: Date) {
   return new Date(value.getFullYear(), value.getMonth(), value.getDate());
 }
@@ -134,9 +137,13 @@ function feedHeadline(item: FeedItem) {
 }
 
 function feedPreview(item: FeedItem) {
-  const content = item.content.trim();
+  const content = item.content.trim().replace(/\s+/g, " ");
   if (content.length > 0) {
-    return content;
+    if (content.length <= INBOX_PREVIEW_MAX_LENGTH) {
+      return content;
+    }
+
+    return `${content.slice(0, INBOX_PREVIEW_MAX_LENGTH - 3).trimEnd()}...`;
   }
 
   if (item.kind === 46010) {

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -414,7 +414,6 @@ export function HomeView({
             onFilterChange={setFilter}
             onSelect={(itemId) => {
               handleUserSelectItem(itemId);
-              markItemRead(itemId);
             }}
             reminderPubkey={currentPubkey}
             selectedId={selectedItemId}

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -41,6 +41,7 @@ import {
   countDueReminders,
   useRemindersQuery,
 } from "@/features/reminders/hooks";
+import { useRemindLater } from "@/features/reminders/ui/RemindMeLaterProvider";
 import { deleteMessage, sendChannelMessage } from "@/shared/api/tauri";
 import type { HomeFeedResponse } from "@/shared/api/types";
 import { KIND_REACTION } from "@/shared/constants/kinds";
@@ -108,6 +109,7 @@ export function HomeView({
   );
   const [isDeletingMessage, setIsDeletingMessage] = React.useState(false);
   const [isSendingReply, setIsSendingReply] = React.useState(false);
+  const { openReminder, activeReminderEventIds } = useRemindLater();
   const [localRepliesByItemId, setLocalRepliesByItemId] = React.useState<
     Record<string, InboxReply[]>
   >({});
@@ -407,11 +409,29 @@ export function HomeView({
       >
         {showListPane ? (
           <InboxListPane
+            activeReminderEventIds={activeReminderEventIds}
             doneSet={effectiveDoneSet}
             dueReminderCount={dueReminderCount}
             filter={filter}
             items={filteredItems}
             onFilterChange={setFilter}
+            onMarkUnread={markItemUnread}
+            onOpenDirect={(item) => {
+              const channelId = item.item.channelId;
+              if (!channelId) {
+                return;
+              }
+
+              onOpenContext(channelId, item.id);
+            }}
+            onRemindLater={(item) => {
+              openReminder({
+                eventId: item.id,
+                channelId: item.item.channelId ?? "",
+                preview: item.preview.slice(0, 100),
+                authorPubkey: item.item.pubkey,
+              });
+            }}
             onSelect={(itemId) => {
               handleUserSelectItem(itemId);
               markItemRead(itemId);

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -414,6 +414,7 @@ export function HomeView({
             onFilterChange={setFilter}
             onSelect={(itemId) => {
               handleUserSelectItem(itemId);
+              markItemRead(itemId);
             }}
             reminderPubkey={currentPubkey}
             selectedId={selectedItemId}

--- a/desktop/src/features/home/ui/InboxListPane.tsx
+++ b/desktop/src/features/home/ui/InboxListPane.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Mail } from "lucide-react";
 import * as React from "react";
 
 import {
@@ -88,22 +88,32 @@ export function InboxListPane({
         </div>
 
         <div className="min-w-0 flex-1">
-          <div className="flex items-start gap-2">
+          <div className="flex items-baseline gap-2">
             <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <p className="truncate text-sm font-semibold text-foreground">
-                  {item.senderLabel}
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <p className="truncate text-sm font-semibold text-foreground">
+                    {item.senderLabel}
+                  </p>
+                  {item.isActionRequired ? (
+                    <span className="inline-flex shrink-0 items-center text-2xs font-semibold uppercase tracking-[0.14em] text-amber-600 dark:text-amber-300">
+                      Needs action
+                    </span>
+                  ) : null}
+                </div>
+                <p
+                  className={cn(
+                    "mt-0.5 truncate text-2xs text-muted-foreground",
+                    isDone ? "font-normal" : "font-semibold",
+                  )}
+                >
+                  {typeLabel}
                 </p>
-                {item.isActionRequired ? (
-                  <span className="inline-flex shrink-0 items-center text-2xs font-semibold uppercase tracking-[0.14em] text-amber-600 dark:text-amber-300">
-                    Needs action
-                  </span>
-                ) : null}
               </div>
             </div>
             <span
               className={cn(
-                "shrink-0 text-xs text-muted-foreground",
+                "shrink-0 text-xs leading-5 text-muted-foreground",
                 isDone ? "font-normal" : "font-semibold",
               )}
             >
@@ -126,17 +136,6 @@ export function InboxListPane({
               mentionNames={item.mentionNames}
             />
           </div>
-
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            <span
-              className={cn(
-                "text-2xs text-muted-foreground",
-                isDone ? "font-normal" : "font-semibold",
-              )}
-            >
-              {typeLabel}
-            </span>
-          </div>
         </div>
       </button>
     );
@@ -153,7 +152,11 @@ export function InboxListPane({
         <div className="px-5 py-1">
           {/* Cap to the list-column width so the right-aligned dropdown stays
               put when the pane goes full-width in reminders mode. */}
-          <div className="flex min-w-0 max-w-[var(--home-inbox-list-width)] items-center justify-end gap-3">
+          <div className="flex min-w-0 max-w-[var(--home-inbox-list-width)] items-center justify-between gap-3">
+            <h1 className="flex min-w-0 items-center gap-1.5 text-sm font-semibold leading-5 tracking-tight text-foreground">
+              <Mail className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">Inbox</span>
+            </h1>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button

--- a/desktop/src/features/home/ui/InboxListPane.tsx
+++ b/desktop/src/features/home/ui/InboxListPane.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Mail } from "lucide-react";
+import { Clock, ExternalLink, Mail, MailOpen, ChevronDown } from "lucide-react";
 import * as React from "react";
 
 import {
@@ -12,6 +12,7 @@ import { TopChromeInsetHeader } from "@/shared/layout/TopChromeInsetHeader";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { Markdown } from "@/shared/ui/markdown";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,11 +37,15 @@ type InboxListPaneProps = {
   filter: InboxFilter;
   items: InboxItem[];
   onFilterChange: (filter: InboxFilter) => void;
+  onMarkUnread: (itemId: string) => void;
+  onOpenDirect: (item: InboxItem) => void;
+  onRemindLater: (item: InboxItem) => void;
   onSelect: (itemId: string) => void;
   selectedId: string | null;
   showRightDivider?: boolean;
   dueReminderCount: number;
   reminderPubkey?: string;
+  activeReminderEventIds?: ReadonlySet<string>;
 };
 
 export function InboxListPane({
@@ -48,11 +53,15 @@ export function InboxListPane({
   filter,
   items,
   onFilterChange,
+  onMarkUnread,
+  onOpenDirect,
+  onRemindLater,
   onSelect,
   selectedId,
   showRightDivider = false,
   dueReminderCount,
   reminderPubkey,
+  activeReminderEventIds,
 }: InboxListPaneProps) {
   const activeFilter = FILTER_OPTIONS.find((option) => option.value === filter);
   const isReminders = filter === "reminders";
@@ -61,80 +70,116 @@ export function InboxListPane({
   const renderItem = (item: InboxItem) => {
     const isSelected = item.id === selectedId;
     const isDone = doneSet.has(item.id);
+    const hasActiveReminder = activeReminderEventIds?.has(item.id) ?? false;
+    const hasChannelTarget = Boolean(item.item.channelId);
     const typeLabel = formatInboxTypeLabel(item);
 
     return (
-      <button
-        className={cn(
-          "flex w-full items-start gap-2.5 border-l px-5 py-2 text-left transition-colors",
-          isSelected
-            ? "border-l-transparent bg-muted/30"
-            : "border-l-transparent hover:bg-muted/25 active:bg-muted/40",
-        )}
+      <div
+        className="group/inbox-item relative"
         data-testid={`home-inbox-item-${item.id}`}
-        onClick={() => onSelect(item.id)}
-        type="button"
       >
-        <div className="relative">
-          <UserAvatar
-            avatarUrl={item.avatarUrl}
-            className="h-8 w-8"
-            displayName={item.senderLabel}
-            size="md"
-          />
-          {!isDone ? (
-            <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-background bg-primary" />
-          ) : null}
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex items-baseline gap-2">
-            <div className="min-w-0 flex-1">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <p className="truncate text-sm font-semibold text-foreground">
-                    {item.senderLabel}
-                  </p>
-                  {item.isActionRequired ? (
-                    <span className="inline-flex shrink-0 items-center text-2xs font-semibold uppercase tracking-[0.14em] text-amber-600 dark:text-amber-300">
-                      Needs action
-                    </span>
-                  ) : null}
-                </div>
-                <p
-                  className={cn(
-                    "mt-0.5 truncate text-2xs text-muted-foreground",
-                    isDone ? "font-normal" : "font-semibold",
-                  )}
-                >
-                  {typeLabel}
-                </p>
-              </div>
-            </div>
-            <span
-              className={cn(
-                "shrink-0 text-xs leading-5 text-muted-foreground",
-                isDone ? "font-normal" : "font-semibold",
-              )}
-            >
-              {item.timestampLabel}
-            </span>
+        <button
+          className={cn(
+            "flex w-full items-start gap-2.5 border-l px-5 py-2 text-left transition-colors",
+            isSelected
+              ? "border-l-transparent bg-muted/30"
+              : "border-l-transparent hover:bg-muted/25 active:bg-muted/40",
+          )}
+          onClick={() => onSelect(item.id)}
+          type="button"
+        >
+          <div className="relative">
+            <UserAvatar
+              avatarUrl={item.avatarUrl}
+              className="h-8 w-8"
+              displayName={item.senderLabel}
+              size="md"
+            />
+            {!isDone ? (
+              <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2 border-background bg-primary" />
+            ) : null}
           </div>
 
-          <Markdown
-            className={cn(
-              "mt-0.5 line-clamp-2 max-w-full text-sm! leading-5! **:inline [&_*]:text-inherit [&_a]:font-medium [&_a]:text-current [&_br]:hidden [&_p]:inline",
-              isDone
-                ? "font-normal text-muted-foreground"
-                : "font-semibold text-foreground",
-            )}
-            content={item.preview}
-            interactive={false}
-            mentionNames={item.mentionNames}
-            plainInlineReferences
-          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2">
+              <div className="min-w-0 flex-1">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="truncate text-sm font-semibold text-foreground">
+                      {item.senderLabel}
+                    </p>
+                    {item.isActionRequired ? (
+                      <span className="inline-flex shrink-0 items-center text-2xs font-semibold uppercase tracking-[0.14em] text-amber-600 dark:text-amber-300">
+                        Needs action
+                      </span>
+                    ) : null}
+                  </div>
+                  <p
+                    className={cn(
+                      "mt-0.5 truncate text-2xs text-muted-foreground",
+                      isDone ? "font-normal" : "font-semibold",
+                    )}
+                  >
+                    {typeLabel}
+                  </p>
+                </div>
+              </div>
+              <span
+                className={cn(
+                  "shrink-0 text-xs leading-5 text-muted-foreground transition-opacity group-hover/inbox-item:opacity-0 group-focus-within/inbox-item:opacity-0",
+                  isDone ? "font-normal" : "font-semibold",
+                )}
+              >
+                {item.timestampLabel}
+              </span>
+            </div>
+
+            <Markdown
+              className={cn(
+                "mt-0.5 line-clamp-2 max-w-full text-sm! leading-5! **:inline [&_*]:text-inherit [&_a]:font-medium [&_a]:text-current [&_br]:hidden [&_p]:inline",
+                isDone
+                  ? "font-normal text-muted-foreground"
+                  : "font-semibold text-foreground",
+              )}
+              content={item.preview}
+              interactive={false}
+              mentionNames={item.mentionNames}
+              plainInlineReferences
+            />
+          </div>
+        </button>
+
+        <div className="absolute right-4 top-1.5 z-10 flex items-center gap-1 rounded-full border border-border/70 bg-background/95 p-0.5 opacity-0 shadow-xs backdrop-blur-sm transition-opacity group-hover/inbox-item:opacity-100 group-focus-within/inbox-item:opacity-100 supports-[backdrop-filter]:bg-background/85">
+          <InboxRowActionButton
+            label="Mark unread"
+            onClick={() => onMarkUnread(item.id)}
+          >
+            <MailOpen className="h-3.5 w-3.5" />
+          </InboxRowActionButton>
+          <InboxRowActionButton
+            disabled={!hasChannelTarget}
+            label={hasChannelTarget ? "Open in channel" : "No channel link"}
+            onClick={() => onOpenDirect(item)}
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+          </InboxRowActionButton>
+          <InboxRowActionButton
+            active={hasActiveReminder}
+            disabled={!hasChannelTarget}
+            label={
+              hasChannelTarget
+                ? hasActiveReminder
+                  ? "Reminder set"
+                  : "Remind me later"
+                : "Cannot remind without a channel"
+            }
+            onClick={() => onRemindLater(item)}
+          >
+            <Clock className="h-3.5 w-3.5" />
+          </InboxRowActionButton>
         </div>
-      </button>
+      </div>
     );
   };
 
@@ -246,5 +291,46 @@ export function InboxListPane({
         </div>
       )}
     </section>
+  );
+}
+
+function InboxRowActionButton({
+  active = false,
+  children,
+  disabled = false,
+  label,
+  onClick,
+}: {
+  active?: boolean;
+  children: React.ReactNode;
+  disabled?: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          aria-label={label}
+          disabled={disabled}
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-40",
+            active && "bg-blue-500/10 text-blue-500 hover:text-blue-500",
+          )}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (disabled) {
+              return;
+            }
+            onClick();
+          }}
+          type="button"
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/desktop/src/features/home/ui/InboxListPane.tsx
+++ b/desktop/src/features/home/ui/InboxListPane.tsx
@@ -121,21 +121,18 @@ export function InboxListPane({
             </span>
           </div>
 
-          <div
+          <Markdown
             className={cn(
-              "mt-0.5 line-clamp-2 text-sm leading-5 **:inline [&_a]:font-medium [&_a]:text-current [&_br]:hidden [&_p]:inline",
+              "mt-0.5 line-clamp-2 max-w-full text-sm! leading-5! **:inline [&_*]:text-inherit [&_a]:font-medium [&_a]:text-current [&_br]:hidden [&_p]:inline",
               isDone
                 ? "font-normal text-muted-foreground"
                 : "font-semibold text-foreground",
             )}
-          >
-            <Markdown
-              className="inline max-w-full text-inherit"
-              content={item.preview}
-              interactive={false}
-              mentionNames={item.mentionNames}
-            />
-          </div>
+            content={item.preview}
+            interactive={false}
+            mentionNames={item.mentionNames}
+            plainInlineReferences
+          />
         </div>
       </button>
     );

--- a/desktop/src/features/home/useHomeInboxReadState.ts
+++ b/desktop/src/features/home/useHomeInboxReadState.ts
@@ -45,15 +45,39 @@ export function useHomeInboxReadState({
   markDoneLocal,
   undoDoneLocal,
 }: UseHomeInboxReadStateOptions) {
+  const [forcedUnreadItemIds, setForcedUnreadItemIds] = React.useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const itemById = React.useMemo(
     () => new Map(items.map((item) => [item.id, item])),
     [items],
   );
 
+  React.useEffect(() => {
+    setForcedUnreadItemIds((current) => {
+      if (current.size === 0) {
+        return current;
+      }
+
+      const next = new Set<string>();
+      for (const item of items) {
+        if (current.has(item.id)) {
+          next.add(item.id);
+        }
+      }
+
+      return next.size === current.size ? current : next;
+    });
+  }, [items]);
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: readStateVersion invalidates getChannelReadAt
   const effectiveDoneSet = React.useMemo<ReadonlySet<string>>(() => {
     const result = new Set<string>();
     for (const item of items) {
+      if (forcedUnreadItemIds.has(item.id)) {
+        continue;
+      }
+
       const channelId = item.item.channelId;
       if (channelId) {
         const readAt = getChannelReadAt(channelId);
@@ -67,10 +91,26 @@ export function useHomeInboxReadState({
       }
     }
     return result;
-  }, [getChannelReadAt, items, localDoneSet, readStateVersion]);
+  }, [
+    forcedUnreadItemIds,
+    getChannelReadAt,
+    items,
+    localDoneSet,
+    readStateVersion,
+  ]);
 
   const markItemRead = React.useCallback(
     (itemId: string) => {
+      setForcedUnreadItemIds((current) => {
+        if (!current.has(itemId)) {
+          return current;
+        }
+
+        const next = new Set(current);
+        next.delete(itemId);
+        return next;
+      });
+
       const item = itemById.get(itemId);
       const channelId = item?.item.channelId ?? null;
       if (item && channelId) {
@@ -87,6 +127,14 @@ export function useHomeInboxReadState({
 
   const markItemUnread = React.useCallback(
     (itemId: string) => {
+      setForcedUnreadItemIds((current) => {
+        if (current.has(itemId)) {
+          return current;
+        }
+
+        return new Set(current).add(itemId);
+      });
+
       const item = itemById.get(itemId);
       const channelId = item?.item.channelId ?? null;
       if (item && channelId) {

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -238,6 +238,7 @@ type MarkdownProps = {
   customEmoji?: CustomEmoji[];
   imetaByUrl?: ImetaLookup;
   interactive?: boolean;
+  plainInlineReferences?: boolean;
   agentMentionPubkeysByName?: Record<string, string>;
   mentionNames?: string[];
   mentionPubkeysByName?: Record<string, string>;
@@ -1678,6 +1679,7 @@ function SpoilerInline({
 function createMarkdownComponents(
   runtimeRef: React.RefObject<MarkdownRuntime>,
   interactive = true,
+  plainInlineReferences = false,
 ): Components {
   const paragraphClassName = "leading-[inherit]";
   const listItemClassName = "my-1 [&_p]:inline";
@@ -1795,6 +1797,14 @@ function createMarkdownComponents(
                 {line}
               </span>
             ))}
+          </code>
+        );
+      }
+
+      if (plainInlineReferences) {
+        return (
+          <code {...props} className="font-mono text-inherit">
+            {children}
           </code>
         );
       }
@@ -1937,6 +1947,10 @@ function createMarkdownComponents(
       const { agentMentionPubkeysByName, mentionPubkeysByName } =
         runtimeRef.current;
       const mentionText = String(children ?? "");
+      if (plainInlineReferences) {
+        return <span>{mentionText}</span>;
+      }
+
       const mentionName = mentionText.replace(/^@/, "").trim().toLowerCase();
       const pubkey = mentionPubkeysByName?.[mentionName];
       const isAgentMention =
@@ -1988,6 +2002,10 @@ function createMarkdownComponents(
       return <InlineEmojiPopover alt={alt} resolvedSrc={resolvedSrc} />;
     },
     "channel-link": ({ children }: { children?: React.ReactNode }) => {
+      if (plainInlineReferences) {
+        return <span>{children}</span>;
+      }
+
       const { channels, onOpenChannel } = runtimeRef.current;
       const text = String(children ?? "");
       const channelName = text.startsWith("#") ? text.slice(1) : text;
@@ -2075,6 +2093,7 @@ function MarkdownInner({
   customEmoji,
   imetaByUrl,
   interactive = true,
+  plainInlineReferences = false,
   agentMentionPubkeysByName,
   mentionNames,
   mentionPubkeysByName,
@@ -2116,8 +2135,9 @@ function MarkdownInner({
   });
 
   const components = React.useMemo(
-    () => createMarkdownComponents(runtimeRef, interactive),
-    [runtimeRef, interactive],
+    () =>
+      createMarkdownComponents(runtimeRef, interactive, plainInlineReferences),
+    [runtimeRef, interactive, plainInlineReferences],
   );
 
   // biome-ignore lint/suspicious/noExplicitAny: PluggableList type not directly importable
@@ -2200,6 +2220,7 @@ export const Markdown = React.memo(
     prev.className === next.className &&
     prev.customEmoji === next.customEmoji &&
     prev.interactive === next.interactive &&
+    prev.plainInlineReferences === next.plainInlineReferences &&
     prev.agentMentionPubkeysByName === next.agentMentionPubkeysByName &&
     prev.mentionPubkeysByName === next.mentionPubkeysByName &&
     shallowArrayEqual(prev.mentionNames, next.mentionNames) &&


### PR DESCRIPTION
## Summary
Inbox now behaves more like a message triage surface: long previews stay readable, unread state is explicit, and each row exposes quick actions without opening the full message first.

This fixes agent responses overpowering the inbox list by normalizing and bounding preview text, while preserving Markdown emphasis in the compact preview. It also restores the inbox header, moves message context under the sender, and keeps unread rows bold until they are opened or explicitly marked read.

Row hover actions now let users mark an item unread, jump directly to the source message in its channel, or set a reminder using the existing Remind me later flow.

## Test Plan
- `cd desktop && node --import ./test-loader.mjs --experimental-strip-types --test ./src/features/home/lib/inbox.test.mjs`
- Pre-push hooks passed: desktop tests, mobile tests, Rust tests, and desktop Tauri tests.
