### PR TITLE
fix(desktop): seed up agent JSON files in sync_shared_agent_data

### DIFF
--- a/desktop/src-tauri/src/migration.rs
+++ b/desktop/src-tauri/src/migration.rs
@@ -226,6 +226,48 @@ pub fn sync_shared_agent_data(app: &tauri::AppHandle) {
         return;
     }
 
+    // Seed-up: if canonical is missing a shared file but a sibling instance
+    // holds real (non-symlink) content, migrate it up to canonical before the
+    // symlink loop runs. Mirrors the SHARED_AGENT_DIRS migration below, applied
+    // to individual files. Without this, a fresh write in a worktree is never
+    // promoted to canonical and gets clobbered by the symlink step.
+    for rel in SHARED_AGENT_FILES {
+        let canonical_file = canonical_dir.join(rel);
+        if canonical_file.exists() {
+            continue;
+        }
+        let Some(parent) = canonical_dir.parent() else {
+            continue;
+        };
+        let Ok(entries) = std::fs::read_dir(parent) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let sibling = entry.path();
+            if sibling == canonical_dir {
+                continue;
+            }
+            let sibling_file = sibling.join(rel);
+            if sibling_file.is_file() && !sibling_file.is_symlink() {
+                if let Some(file_parent) = canonical_file.parent() {
+                    if let Err(e) = std::fs::create_dir_all(file_parent) {
+                        eprintln!(
+                            "buzz-desktop: shared-agent-sync: failed to create {}: {e}",
+                            file_parent.display()
+                        );
+                        break;
+                    }
+                }
+                let _ = std::fs::rename(&sibling_file, &canonical_file);
+                eprintln!(
+                    "buzz-desktop: shared-agent-sync: seeded {rel} from {}",
+                    sibling.display()
+                );
+                break;
+            }
+        }
+    }
+
     let mut synced = 0u32;
     for rel in SHARED_AGENT_FILES {
         let src = canonical_dir.join(rel);

--- a/desktop/src-tauri/src/migration_tests.rs
+++ b/desktop/src-tauri/src/migration_tests.rs
@@ -100,6 +100,35 @@ fn setup_sync_layout() -> (tempfile::TempDir, PathBuf, PathBuf) {
 /// cannot be unit-tested directly.
 #[cfg(unix)]
 fn sync_files(canonical: &Path, worktree: &Path) -> u32 {
+    // Seed-up: mirrors the SHARED_AGENT_FILES seed-up in `sync_shared_agent_data`.
+    // Kept logic-identical to production so these tests exercise real behavior.
+    for rel in SHARED_AGENT_FILES {
+        let canonical_file = canonical.join(rel);
+        if canonical_file.exists() {
+            continue;
+        }
+        let Some(parent) = canonical.parent() else {
+            continue;
+        };
+        let Ok(entries) = std::fs::read_dir(parent) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let sibling = entry.path();
+            if sibling == canonical {
+                continue;
+            }
+            let sibling_file = sibling.join(rel);
+            if sibling_file.is_file() && !sibling_file.is_symlink() {
+                if let Some(file_parent) = canonical_file.parent() {
+                    std::fs::create_dir_all(file_parent).unwrap();
+                }
+                let _ = std::fs::rename(&sibling_file, &canonical_file);
+                break;
+            }
+        }
+    }
+
     let mut synced = 0u32;
     for rel in SHARED_AGENT_FILES {
         let src = canonical.join(rel);
@@ -310,6 +339,103 @@ fn writes_through_symlink_reach_canonical() {
         std::fs::read_to_string(&worktree_path).unwrap(),
         new_content
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn seed_up_migrates_sibling_file_to_canonical_then_symlinks() {
+    let (_parent, canonical, worktree) = setup_sync_layout();
+    let rel = "agents/personas.json";
+    // Canonical is missing the file; a sibling (.main) holds real content.
+    std::fs::remove_file(canonical.join(rel)).unwrap();
+    let sibling = canonical
+        .parent()
+        .unwrap()
+        .join("xyz.block.buzz.app.dev.main");
+    std::fs::create_dir_all(sibling.join("agents")).unwrap();
+    std::fs::write(sibling.join(rel), r#"[{"id":"brain"}]"#).unwrap();
+
+    sync_files(&canonical, &worktree);
+
+    // The real file landed at canonical (proves the rename, not a dangling link).
+    let canonical_file = canonical.join(rel);
+    assert!(
+        canonical_file.is_file() && !canonical_file.is_symlink(),
+        "canonical should hold the migrated real file"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&canonical_file).unwrap(),
+        r#"[{"id":"brain"}]"#,
+    );
+    // The worktree is symlinked to canonical.
+    let dst = worktree.join(rel);
+    assert!(dst.is_symlink());
+    assert_eq!(std::fs::read_link(&dst).unwrap(), canonical_file);
+}
+
+#[cfg(unix)]
+#[test]
+fn seed_up_no_sibling_content_is_noop() {
+    let (_parent, canonical, worktree) = setup_sync_layout();
+    let rel = "agents/personas.json";
+    // Canonical missing the file and no sibling holds it.
+    std::fs::remove_file(canonical.join(rel)).unwrap();
+
+    sync_files(&canonical, &worktree);
+
+    // Nothing to seed: canonical stays missing, worktree gets no symlink for it.
+    assert!(!canonical.join(rel).exists());
+    assert!(!worktree.join(rel).exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn seed_up_skipped_when_canonical_has_file() {
+    let (_parent, canonical, worktree) = setup_sync_layout();
+    let rel = "agents/personas.json";
+    // A sibling also holds different content, but canonical already has the file.
+    let sibling = canonical
+        .parent()
+        .unwrap()
+        .join("xyz.block.buzz.app.dev.main");
+    std::fs::create_dir_all(sibling.join("agents")).unwrap();
+    std::fs::write(sibling.join(rel), r#"[{"id":"should-not-win"}]"#).unwrap();
+
+    sync_files(&canonical, &worktree);
+
+    // Canonical's original content is untouched; the sibling did not seed it.
+    assert_eq!(
+        std::fs::read_to_string(canonical.join(rel)).unwrap(),
+        r#"[{"id":"builtin:fizz"}]"#,
+    );
+    // Pull-symlink path is unchanged: worktree links to canonical.
+    let dst = worktree.join(rel);
+    assert!(dst.is_symlink());
+    assert_eq!(std::fs::read_link(&dst).unwrap(), canonical.join(rel));
+}
+
+#[cfg(unix)]
+#[test]
+fn seed_up_ignores_sibling_symlink_as_source() {
+    let (_parent, canonical, worktree) = setup_sync_layout();
+    let rel = "agents/personas.json";
+    std::fs::remove_file(canonical.join(rel)).unwrap();
+    // Sibling holds only a symlink (not real content) — not a valid seed source.
+    let sibling = canonical
+        .parent()
+        .unwrap()
+        .join("xyz.block.buzz.app.dev.main");
+    std::fs::create_dir_all(sibling.join("agents")).unwrap();
+    std::os::unix::fs::symlink(
+        PathBuf::from("/nonexistent/elsewhere.json"),
+        sibling.join(rel),
+    )
+    .unwrap();
+
+    sync_files(&canonical, &worktree);
+
+    // The symlink was not promoted; canonical stays missing.
+    assert!(!canonical.join(rel).exists());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`SHARE_IDENTITY=1` makes all dev instances share one set of agent data. The `agents/teams` directory already supports this end to end (seed-up-then-symlink), but the three agent JSON files — `managed-agents.json`, `personas.json`, `teams.json` — only got the pull half.

In `sync_shared_agent_data`, the `SHARED_AGENT_FILES` symlink loop is pull-only (`if !src.exists() { continue }`). When canonical lacks a file but a worktree sibling holds real content, that content is never promoted to canonical — it's stranded, and the later symlink step silently replaces the worktree's real file with a link. That's the residual leg of the symptom where a freshly written agent "vanishes" on reopen.

## Change

Add a seed-up pass over `SHARED_AGENT_FILES` **before** the symlink loop in `sync_shared_agent_data`. For each file missing in canonical, it scans sibling instance dirs (same parent, skipping canonical itself), takes the first sibling holding a **real** (non-symlink) file, `create_dir_all`s the canonical `agents/` parent, then `rename`s the file up into canonical. The existing symlink loop then links every sibling to it.

This mirrors the existing `SHARED_AGENT_DIRS` migration **logic** (first-sibling-wins), inserted before the file loop so `src` exists when the symlink loop runs. It deliberately is **not** mtime/newest-wins — pulling stale data forward over fresh data is the opposite of the intent. A losing divergent sibling is preserved as a real file in its own dir and self-heals on the next sync's symlink loop. The seed-up is gated on canonical missing the file, so it never overwrites existing canonical content, and an interrupted run (rename done, symlink not) is recoverable on the next sync.

`sync_shared_agent_data` needs a live `tauri::AppHandle` and can't be unit-tested directly, so the test suite exercises a `sync_files` mirror in `migration_tests.rs`. The seed-up pass is added to that mirror kept logic-identical to production, so green tests reflect real behavior. Four `#[cfg(unix)]` tests cover: sibling content migrated up and symlinked (asserting the real file lands at canonical, not just a dangling link), no-sibling-content no-op, canonical-already-present skip, and a sibling holding only a symlink not being treated as a seed source.
