### PR TITLE
ci: key main-push concurrency group on SHA to stop run eviction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:


### PR DESCRIPTION
Pushes to `main` all shared one concurrency group keyed on `github.ref` — the literal string `refs/heads/main` for every push. Under a tightly-clustered merge cadence, each new push entered the shared group and evicted the previously-queued CI run, surfacing as red `cancelled` runs (the "27/29 succeeded" pattern), not real test failures.

Keys the push path on `github.sha` so each main push gets its own group and no run ever evicts another. PRs are unchanged: the `pull_request` branch of the ternary keeps `github.ref` (`refs/pull/<n>/merge`), preserving per-PR grouping plus `cancel-in-progress: true` cancel-on-new-push.

`cancel-in-progress` is untouched. Sprig/Docker have no concurrency block and are unaffected.
