### PR TITLE
ci: cache Flutter pub packages in the Mobile job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,12 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
+      - name: Restore pub cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('mobile/pubspec.lock') }}
+          restore-keys: pub-${{ runner.os }}-
       - name: Install dependencies
         run: cd mobile && flutter pub get
       - name: Format check
@@ -572,6 +578,12 @@ jobs:
         run: cd mobile && flutter analyze
       - name: Test
         run: cd mobile && flutter test
+      - name: Save pub cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('mobile/pubspec.lock') }}
 
   security:
     name: Security


### PR DESCRIPTION
The Mobile CI job ran `flutter pub get` from scratch on every run with no package caching. Under degraded network conditions on GitHub Actions runners, this caused the "Install dependencies" step to block for 13+ minutes against the 15-minute job timeout.

Every other dependency store in the workflow is already cached — pnpm via `actions/cache`, Playwright browsers via `actions/cache`, and Rust via `Swatinem/rust-cache`. The Mobile job was the only gap.

Adds a `Restore pub cache` step before `flutter pub get` and a `Save pub cache` step after `flutter test`, following the exact same split restore/save pattern as the pnpm cache:

- Path: `~/.pub-cache` (default Dart/Flutter pub cache on Linux)
- Key: `pub-{os}-{hash(mobile/pubspec.lock)}` with `pub-{os}-` as the fallback restore key
- Save only on push events (same gate as pnpm), so PR runs restore from the cache seeded by the last main merge
- Uses the same pinned `actions/cache` SHA already in the file