### PR TITLE
desktop: drop redundant post-subscribe history refetch

### DIFF
--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -277,16 +277,15 @@ export function useChannelSubscription(channel: Channel | null) {
         }
 
         cleanup = dispose;
-
-        void syncLatestHistory().catch((error) => {
-          if (!isDisposed) {
-            console.error(
-              "Failed to refresh channel history after subscribing",
-              channelId,
-              error,
-            );
-          }
-        });
+        // No post-subscribe history refetch: useChannelMessagesQuery already
+        // loaded the latest CHANNEL_HISTORY_LIMIT (200) events, and the live
+        // subscription itself backfills up to 50 most-recent events via its
+        // initial REQ (buildChannelFilter(id, 50)). Both write into the same
+        // channelMessagesKey cache, so any window between the two REQs is
+        // covered by the live sub's overlap unless >50 messages land in
+        // <1s — vanishingly rare in practice. The reconnect listener above
+        // still bridges gaps from connection drops, where the gap *is*
+        // unbounded.
       })
       .catch((error) => {
         console.error("Failed to subscribe to channel", channelId, error);


### PR DESCRIPTION
On channel open the GUI fired three relay REQs:

1. `useChannelMessagesQuery` → `fetchChannelHistory(id, 200)`
2. `subscribeToChannel` → `REQ {kinds, #h, limit: 50}` (history + live)
3. `.then(syncLatestHistory)` → `fetchChannelHistory(id, 200)` (again)

REQ #3 was intended to bridge a hypothetical gap between REQ #1's EOSE and REQ #2's subscription being established. In practice that window is sub-second and the live subscription already backfills the 50 most-recent stored events on its initial REQ — those 50 overlap the tail of REQ #1's 200 and write into the same `channelMessagesKey` cache (dedup via `mergeTimelineCacheMessages`). The third fetch was double-coverage, not a correctness fence.

Reconnect — where the gap really is unbounded — keeps its own `syncLatestHistory` call via `subscribeToReconnects` (untouched); `relayReconnectReplay` handles `since=lastSeen` paging from there.

## Impact

- 450 events/open → 250 events/open (~44% transfer cut)
- One full WS round-trip removed from the channel-open critical path
- Per staging measurements (Eva, Perci): warm-socket channel-open critical path drops by ~0.3–0.4s, which is the entire felt slowness on channel switches reported in [buzz-bugs thread](https://github.com/block/buzz)

## Why now / what's not here

This is the minimal-correct change in a multi-lane investigation Eva sequenced. Other lanes (Mari #1129 thread-load dedup, Perci's connect/auth lifecycle audit) land separately.

A follow-up can switch REQ #2 from `limit:50` to `limit:0 + since:now` to make the subscription pure-live — that's separable, has its own subscription-semantics implications across the codebase, and is not bundled here.

## Validation

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` — 1011/1011 passing
- Pre-commit + pre-push hooks (`rust-fmt`, `web-fix`, `desktop-tauri-fmt`, `desktop-fix`, `mobile-fix`, all `*-test` suites) — clean
