### PR TITLE
fix(desktop): quiet boot reconcile noise for unreachable relays

### DIFF
--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -867,9 +867,13 @@ pub async fn start_managed_agent(
                 reconcile_agent_profile(&state, &reconcile_app, &reconcile_pubkey, &reconcile_data)
                     .await
             {
-                eprintln!(
-                    "buzz-desktop: profile reconciliation failed for agent {reconcile_pubkey}: {e}"
-                );
+                // Suppress the expected relay-unreachable case; see the same
+                // guard in restore.rs's boot reconcile path for the rationale.
+                if !e.starts_with("relay unreachable:") {
+                    eprintln!(
+                        "buzz-desktop: profile reconciliation failed for agent {reconcile_pubkey}: {e}"
+                    );
+                }
             }
         });
     }

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -232,7 +232,17 @@ pub async fn restore_managed_agents_on_launch(
                 crate::commands::reconcile_agent_profile(&state, &reconcile_app, &pubkey, &data)
                     .await
             {
-                eprintln!("buzz-desktop: profile reconciliation failed for agent {pubkey}: {e}");
+                // A local agent may deliberately target a relay that isn't
+                // running (e.g. ws://localhost:3000 between boots); the relay
+                // helper marks every such case with the "relay unreachable:"
+                // prefix (see relay.rs). That's expected, not a failure worth
+                // a per-agent line every boot — only genuine reconcile errors
+                // surface loudly.
+                if !e.starts_with("relay unreachable:") {
+                    eprintln!(
+                        "buzz-desktop: profile reconciliation failed for agent {pubkey}: {e}"
+                    );
+                }
             }
         });
     }

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -211,11 +211,16 @@ pub(crate) async fn parse_json_response<T: DeserializeOwned>(
         return Err(msg);
     }
 
-    // Drop the reqwest error detail — it contains the raw URL.
+    // A successful HTTP response whose body fails to deserialize means the relay
+    // was reached but returned something unexpected (protocol mismatch, relay bug,
+    // corrupted body) — NOT a connectivity failure. Keep it off the
+    // "relay unreachable:" bucket so it surfaces loudly instead of being treated
+    // as a transient unreachable-relay condition. The reqwest error detail is
+    // dropped because it contains the raw URL.
     response
         .json::<T>()
         .await
-        .map_err(|_| "relay unreachable: response was not valid JSON".to_string())
+        .map_err(|_| "relay returned malformed response: not valid JSON".to_string())
 }
 
 pub async fn relay_error_message(response: reqwest::Response) -> String {

--- a/desktop/src/features/agents/ui/CreateAgentDialog.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialog.tsx
@@ -57,7 +57,7 @@ export function CreateAgentDialog({
   const backendProvidersQuery = useBackendProvidersQuery();
   const { lastRuntimeId, setLastRuntime } = useLastRuntime();
   const [acpCommand, setAcpCommand] = React.useState("buzz-acp");
-  const [agentCommand, setAgentCommand] = React.useState("goose");
+  const [agentCommand, setAgentCommand] = React.useState("buzz-agent");
   const [agentArgs, setAgentArgs] = React.useState("acp");
   const [mcpCommand, setMcpCommand] = React.useState("");
   const [mcpToolsets, setMcpToolsets] = React.useState("");
@@ -236,7 +236,7 @@ export function CreateAgentDialog({
     setSpawnAfterCreate(true);
     setStartOnAppLaunch(true);
     setAcpCommand("buzz-acp");
-    setAgentCommand("goose");
+    setAgentCommand("buzz-agent");
     setAgentArgs("acp");
     setMcpCommand("");
     setMcpToolsets("");


### PR DESCRIPTION
Local agents reconcile their `kind:0` profile against their own per-record relay. When that relay is unreachable — which is normal for a local agent deliberately pointed at an offline `ws://localhost:3000` — both reconcile paths logged one failure line per agent. On boot this produced a wall of identical `relay unreachable` lines on every `just staging` run; on a manual start it logged a spurious line per agent.

This keeps the per-record relay authoritative (a local agent can still target whatever relay it wants) and only changes how an unreachable relay is logged.

## Changes

- `restore.rs` — boot reconciliation suppresses the per-agent failure line when the error is the expected relay-unreachable case, detected via the documented `"relay unreachable:"` prefix the relay helper guarantees (`relay.rs`). Genuine reconcile failures still log loudly.
- `agents.rs` — the UI-start reconcile path (which `restore.rs` mirrors) gets the same guard, so both paths are consistent.
- `relay.rs` — `parse_json_response` previously labeled a successful 2xx response with an undeserializable body as `"relay unreachable:"`, the same prefix as a genuine transport failure. That meant the reconcile guard above would silently swallow a reached-but-malformed response (protocol mismatch, relay bug, corrupted body). Re-prefixed to `"relay returned malformed response:"` so it falls outside the unreachable bucket and surfaces loudly. The frontend connectivity classifier (`relayError.ts`) also correctly stops treating it as a connectivity failure — a parse error is not a connectivity problem.
- `CreateAgentDialog.tsx` — the create-agent picker defaults to `buzz-agent` instead of `goose`, matching `default_agent_command()`, so new local agents stop being created on the dead `goose` command.

No relay override, no data migration, nothing written to `managed-agents.json`. The only behavior changes are the picker default and which error conditions log; where agents connect is untouched.
