### PR TITLE
Fix display names flashing to pubkeys when loading older messages

### DIFF
--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import {
   getProfile,
@@ -281,6 +286,10 @@ export function useUsersBatchQuery(
     enabled,
     queryKey: ["users-batch", ...normalizedPubkeys],
     queryFn: () => getUsersBatch(normalizedPubkeys),
+    // Loading older messages grows the pubkey set, which changes this query's
+    // key entirely. Without this, already-resolved authors would flash back
+    // to their raw pubkey while the larger batch refetches.
+    placeholderData: keepPreviousData,
     staleTime: 60_000,
     gcTime: 5 * 60 * 1_000,
   });


### PR DESCRIPTION
## Bug

Scrolling up to load older channel history briefly flashes raw pubkeys over display names for messages that were already showing names correctly.

## Root cause

`useUsersBatchQuery` (desktop/src/features/profile/hooks.ts) keys its query on the full sorted set of author pubkeys: `["users-batch", ...normalizedPubkeys]`. Loading older history adds new authors to that set, which changes the query key entirely — TanStack Query treats it as a brand-new query with no data, even though the previous batch's profiles are still valid and cached.

While that new (larger) batch is in flight, `messageProfilesQuery.data` is `undefined`, so every author lookup in `resolveUserLabel` (desktop/src/features/profile/lib/identity.ts) falls through to `truncatePubkey()` — not just the new authors, but everyone, until the refetch resolves.

## Fix

Add `placeholderData: keepPreviousData` to the batch query, the same pattern already used by `useChannelMessagesQuery` for an analogous problem. This keeps the previous batch's resolved names rendering while the larger batch refetches in the background, so already-known authors no longer flash.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Traced the data flow end to end: `ChannelScreen` → `collectMessageAuthorPubkeys` (grows with history) → `useUsersBatchQuery` query key → `resolveUserLabel` fallback path.

Note: I didn't add an e2e repro test — the Playwright mock bridge resolves `get_users_batch` synchronously with no delay-injection hook (unlike channel history, which has `historyDelayMs`), so a faithful repro would require adding that test seam first. Flagging this gap rather than building new test infra for a one-line fix; happy to add it if wanted.