### PR TITLE
fix(desktop): align sidebar unread pills

### DIFF
--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -490,6 +490,7 @@ export function AppSidebar({
             onClick={scrollToNextAbove}
             position="top"
             testId="sidebar-more-unread-above"
+            topClassName="top-(--buzz-top-chrome-height,2.5rem)"
           />
         ) : null}
         <SidebarContent

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -233,29 +233,7 @@ export function AppSidebar({
   const isNewDmOpen = isNewDmOpenProp ?? isNewDmOpenInternal;
   const setIsNewDmOpen = onNewDmOpenChange ?? setIsNewDmOpenInternal;
   const scrollRef = React.useRef<HTMLDivElement>(null);
-  const sidebarFooterRef = React.useRef<HTMLDivElement>(null);
-  const [sidebarFooterHeight, setSidebarFooterHeight] = React.useState<
-    number | null
-  >(null);
   useSidebarScrollLock(scrollRef);
-
-  React.useLayoutEffect(() => {
-    const sidebarFooter = sidebarFooterRef.current;
-    if (!sidebarFooter) {
-      return;
-    }
-
-    const updateFooterHeight = () => {
-      setSidebarFooterHeight(sidebarFooter.getBoundingClientRect().height);
-    };
-
-    updateFooterHeight();
-
-    const resizeObserver = new ResizeObserver(updateFooterHeight);
-    resizeObserver.observe(sidebarFooter);
-
-    return () => resizeObserver.disconnect();
-  }, []);
 
   React.useEffect(() => {
     const scrollElement = scrollRef.current;
@@ -496,16 +474,7 @@ export function AppSidebar({
       data-testid="app-sidebar"
       variant="sidebar"
     >
-      <div
-        className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
-        style={
-          sidebarFooterHeight === null
-            ? undefined
-            : ({
-                "--buzz-sidebar-footer-height": `${sidebarFooterHeight}px`,
-              } as React.CSSProperties)
-        }
-      >
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
         {unreadAboveCount > 0 ? (
           <MoreUnreadButton
             count={unreadAboveCount}
@@ -796,67 +765,66 @@ export function AppSidebar({
           ) : null}
         </SidebarContent>
 
-        {unreadBelowCount > 0 ? (
-          <MoreUnreadButton
-            bottomClassName="bottom-(--buzz-sidebar-footer-height,6rem)"
-            count={unreadBelowCount}
-            onClick={scrollToNextBelow}
-            position="bottom"
-            testId="sidebar-more-unread-below"
-          />
-        ) : null}
-
-        <SidebarFooter
-          className="z-30 shrink-0 bg-sidebar/55 backdrop-blur-xl supports-[backdrop-filter]:bg-sidebar/45 dark:bg-sidebar/45 dark:supports-[backdrop-filter]:bg-sidebar/35"
-          ref={sidebarFooterRef}
-        >
-          <AnimatePresence>
-            {sidebarRelayConnectionCard.showSidebarRelayConnectionCard ? (
-              <SidebarRelayConnectionCard
-                className="mb-2 group-data-[collapsible=icon]:hidden"
-                isConnected={
-                  sidebarRelayConnectionCard.isRelayConnectionSuccess
-                }
-                isReconnectPending={
-                  sidebarRelayConnectionCard.isRelayReconnectPending
-                }
-                onDismiss={
-                  sidebarRelayConnectionCard.onDismissRelayConnectionCard
-                }
-                onReconnect={sidebarRelayConnectionCard.onReconnectRelay}
-                key="sidebar-relay-connection-card"
-              />
-            ) : null}
-          </AnimatePresence>
-          {showSidebarUpdateCard ? (
-            <div className="mb-2 group-data-[collapsible=icon]:hidden">
-              <SidebarUpdateCard
-                onDismiss={() => setIsSidebarUpdateCardDismissed(true)}
-              />
-            </div>
+        <div className="relative z-30 shrink-0">
+          {unreadBelowCount > 0 ? (
+            <MoreUnreadButton
+              bottomClassName="bottom-full"
+              count={unreadBelowCount}
+              onClick={scrollToNextBelow}
+              position="bottom"
+              testId="sidebar-more-unread-below"
+            />
           ) : null}
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarProfileCard
-                activeWorkspace={activeWorkspace}
-                isPresencePending={isPresencePending}
-                onOpenAddWorkspace={onOpenAddWorkspace}
-                onOpenSettings={onSelectSettings}
-                onRemoveWorkspace={onRemoveWorkspace}
-                onSetPresenceStatus={onSetPresenceStatus}
-                onSetUserStatus={onSetUserStatus}
-                onClearUserStatus={onClearUserStatus}
-                onSwitchWorkspace={onSwitchWorkspace}
-                onUpdateWorkspace={onUpdateWorkspace}
-                profile={profile}
-                resolvedDisplayName={resolvedDisplayName}
-                selfPresenceStatus={selfPresenceStatus}
-                selfUserStatus={selfUserStatus}
-                workspaces={workspaces}
-              />
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarFooter>
+
+          <SidebarFooter className="bg-sidebar/55 backdrop-blur-xl supports-[backdrop-filter]:bg-sidebar/45 dark:bg-sidebar/45 dark:supports-[backdrop-filter]:bg-sidebar/35">
+            <AnimatePresence>
+              {sidebarRelayConnectionCard.showSidebarRelayConnectionCard ? (
+                <SidebarRelayConnectionCard
+                  className="mb-2 group-data-[collapsible=icon]:hidden"
+                  isConnected={
+                    sidebarRelayConnectionCard.isRelayConnectionSuccess
+                  }
+                  isReconnectPending={
+                    sidebarRelayConnectionCard.isRelayReconnectPending
+                  }
+                  onDismiss={
+                    sidebarRelayConnectionCard.onDismissRelayConnectionCard
+                  }
+                  onReconnect={sidebarRelayConnectionCard.onReconnectRelay}
+                  key="sidebar-relay-connection-card"
+                />
+              ) : null}
+            </AnimatePresence>
+            {showSidebarUpdateCard ? (
+              <div className="mb-2 group-data-[collapsible=icon]:hidden">
+                <SidebarUpdateCard
+                  onDismiss={() => setIsSidebarUpdateCardDismissed(true)}
+                />
+              </div>
+            ) : null}
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarProfileCard
+                  activeWorkspace={activeWorkspace}
+                  isPresencePending={isPresencePending}
+                  onOpenAddWorkspace={onOpenAddWorkspace}
+                  onOpenSettings={onSelectSettings}
+                  onRemoveWorkspace={onRemoveWorkspace}
+                  onSetPresenceStatus={onSetPresenceStatus}
+                  onSetUserStatus={onSetUserStatus}
+                  onClearUserStatus={onClearUserStatus}
+                  onSwitchWorkspace={onSwitchWorkspace}
+                  onUpdateWorkspace={onUpdateWorkspace}
+                  profile={profile}
+                  resolvedDisplayName={resolvedDisplayName}
+                  selfPresenceStatus={selfPresenceStatus}
+                  selfUserStatus={selfUserStatus}
+                  workspaces={workspaces}
+                />
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarFooter>
+        </div>
       </div>
 
       <CreateChannelDialog

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -229,20 +229,33 @@ export function AppSidebar({
     React.useState(false);
   const showSidebarUpdateCard =
     canShowSidebarUpdateCard && !isSidebarUpdateCardDismissed;
-  const sidebarFooterCardCount =
-    (sidebarRelayConnectionCard.showSidebarRelayConnectionCard ? 1 : 0) +
-    (showSidebarUpdateCard ? 1 : 0);
-  const unreadBelowBottomClass =
-    sidebarFooterCardCount >= 2
-      ? "bottom-56"
-      : sidebarFooterCardCount >= 1
-        ? "bottom-44"
-        : "bottom-24";
   const [isNewDmOpenInternal, setIsNewDmOpenInternal] = React.useState(false);
   const isNewDmOpen = isNewDmOpenProp ?? isNewDmOpenInternal;
   const setIsNewDmOpen = onNewDmOpenChange ?? setIsNewDmOpenInternal;
   const scrollRef = React.useRef<HTMLDivElement>(null);
+  const sidebarFooterRef = React.useRef<HTMLDivElement>(null);
+  const [sidebarFooterHeight, setSidebarFooterHeight] = React.useState<
+    number | null
+  >(null);
   useSidebarScrollLock(scrollRef);
+
+  React.useLayoutEffect(() => {
+    const sidebarFooter = sidebarFooterRef.current;
+    if (!sidebarFooter) {
+      return;
+    }
+
+    const updateFooterHeight = () => {
+      setSidebarFooterHeight(sidebarFooter.getBoundingClientRect().height);
+    };
+
+    updateFooterHeight();
+
+    const resizeObserver = new ResizeObserver(updateFooterHeight);
+    resizeObserver.observe(sidebarFooter);
+
+    return () => resizeObserver.disconnect();
+  }, []);
 
   React.useEffect(() => {
     const scrollElement = scrollRef.current;
@@ -483,7 +496,16 @@ export function AppSidebar({
       data-testid="app-sidebar"
       variant="sidebar"
     >
-      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div
+        className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
+        style={
+          sidebarFooterHeight === null
+            ? undefined
+            : ({
+                "--buzz-sidebar-footer-height": `${sidebarFooterHeight}px`,
+              } as React.CSSProperties)
+        }
+      >
         {unreadAboveCount > 0 ? (
           <MoreUnreadButton
             count={unreadAboveCount}
@@ -776,7 +798,7 @@ export function AppSidebar({
 
         {unreadBelowCount > 0 ? (
           <MoreUnreadButton
-            bottomClassName={unreadBelowBottomClass}
+            bottomClassName="bottom-(--buzz-sidebar-footer-height,6rem)"
             count={unreadBelowCount}
             onClick={scrollToNextBelow}
             position="bottom"
@@ -784,7 +806,10 @@ export function AppSidebar({
           />
         ) : null}
 
-        <SidebarFooter className="z-30 shrink-0 bg-sidebar/55 backdrop-blur-xl supports-[backdrop-filter]:bg-sidebar/45 dark:bg-sidebar/45 dark:supports-[backdrop-filter]:bg-sidebar/35">
+        <SidebarFooter
+          className="z-30 shrink-0 bg-sidebar/55 backdrop-blur-xl supports-[backdrop-filter]:bg-sidebar/45 dark:bg-sidebar/45 dark:supports-[backdrop-filter]:bg-sidebar/35"
+          ref={sidebarFooterRef}
+        >
           <AnimatePresence>
             {sidebarRelayConnectionCard.showSidebarRelayConnectionCard ? (
               <SidebarRelayConnectionCard

--- a/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
+++ b/desktop/src/features/sidebar/ui/MoreUnreadButton.tsx
@@ -6,16 +6,20 @@ export function MoreUnreadButton({
   onClick,
   position,
   testId,
+  topClassName = "top-0",
 }: {
   bottomClassName?: string;
   count: number;
   onClick: () => void;
   position: "top" | "bottom";
   testId: string;
+  topClassName?: string;
 }) {
+  const positionClassName = position === "top" ? topClassName : bottomClassName;
+
   return (
     <div
-      className={`pointer-events-none absolute inset-x-0 z-10 flex justify-center py-1 ${position === "top" ? "top-0" : bottomClassName}`}
+      className={`pointer-events-none absolute inset-x-0 z-10 flex justify-center py-1 ${positionClassName}`}
     >
       <UnreadPill
         direction={position === "top" ? "up" : "down"}

--- a/desktop/src/shared/ui/UnreadPill.tsx
+++ b/desktop/src/shared/ui/UnreadPill.tsx
@@ -3,7 +3,7 @@ import { ArrowDown, ArrowUp } from "lucide-react";
 import { Button } from "@/shared/ui/button";
 
 const UNREAD_PILL_CLASS =
-  "pointer-events-auto h-7 min-h-7 gap-1.5 rounded-full border-primary/40 bg-primary/10 px-2.5 text-2xs font-medium text-primary shadow-xs backdrop-blur-sm hover:bg-primary/20 [&_svg]:size-4";
+  "pointer-events-auto h-7 min-h-7 gap-1.5 rounded-full border-border/70 bg-background/95 px-2 py-1 text-2xs font-medium tracking-[0.02em] text-muted-foreground/70 shadow-xs backdrop-blur-sm hover:bg-muted/70 hover:text-foreground [&_svg]:size-4";
 
 export function unreadCountLabel(count: number) {
   return `${count} new message${count === 1 ? "" : "s"}`;


### PR DESCRIPTION
## Summary
- Move the top sidebar unread overflow pill below the global chrome so it no longer overlaps the window controls.
- Anchor the bottom unread overflow pill directly above the sidebar footer instead of relying on hardcoded footer-height guesses.
- Restyle unread message pills to use the neutral date-divider treatment while preserving pill-shaped corners.

## Test plan
- `cd desktop && npx @biomejs/biome check src/features/sidebar/ui/AppSidebar.tsx src/features/sidebar/ui/MoreUnreadButton.tsx src/shared/ui/UnreadPill.tsx`
- `cd desktop && npx tsc --noEmit -p tsconfig.json`
- `just desktop-screenshot --name sidebar-unread-overflow-short --active-channel engineering --messages ../test-results/sidebar-smoke/unread-messages.json --clip 0,0,300,360 --viewport 1280x360 --outdir ../test-results/sidebar-smoke --wait 2000`
- Pre-commit hooks ran during commits, including desktop Biome, web fix, Rust fmt, Tauri fmt, and mobile analyze.