### PR TITLE
desktop: make date dividers pill shaped

### DIFF
--- a/desktop/src/features/messages/ui/DayDivider.tsx
+++ b/desktop/src/features/messages/ui/DayDivider.tsx
@@ -6,7 +6,7 @@ export function DayDivider({ label }: { label: string }) {
       data-testid="message-timeline-day-divider"
       data-day-label={label}
     >
-      <p className="relative z-10 shrink-0 rounded-lg border border-border/70 bg-background/95 px-2 py-1 text-2xs font-medium tracking-[0.02em] text-muted-foreground/70 shadow-xs backdrop-blur-sm">
+      <p className="relative z-10 shrink-0 rounded-full border border-border/70 bg-background/95 px-2.5 py-1 text-2xs font-medium tracking-[0.02em] text-muted-foreground/70 shadow-xs backdrop-blur-sm">
         {label}
       </p>
     </section>


### PR DESCRIPTION
## Summary
Date dividers in the conversation timeline now render as full pills, matching the shape language of the new messages pill instead of appearing as small rounded rectangles.

## Test plan
- Pre-commit hooks passed during commit
- Pre-push tests passed during push
