### PR TITLE
desktop: restore channel browse button

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -864,6 +864,7 @@ export function AppShell() {
                           onMarkAllChannelsRead={markAllChannelsRead}
                           onMarkChannelRead={markChannelRead}
                           onMarkChannelUnread={markChannelUnread}
+                          onBrowseChannels={handleOpenBrowseChannels}
                           onOpenDm={async ({ pubkeys }) => {
                             const directMessage =
                               await openDmMutation.mutateAsync({

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -129,6 +129,7 @@ type AppSidebarProps = {
     lastMessageAt: string | null | undefined,
   ) => void;
   onMarkAllChannelsRead: () => void;
+  onBrowseChannels?: () => void;
   onOpenDm: (input: { pubkeys: string[] }) => Promise<void>;
   onUpdateWorkspace: (
     id: string,
@@ -192,6 +193,7 @@ export function AppSidebar({
   onMarkChannelUnread,
   onMarkChannelRead,
   onMarkAllChannelsRead,
+  onBrowseChannels,
   onOpenDm,
   onUpdateWorkspace,
   onRemoveWorkspace,
@@ -662,6 +664,7 @@ export function AppSidebar({
                   />
                 ))}
                 <ChannelGroupSection
+                  browseAriaLabel="Browse channels"
                   createAriaLabel="Create a channel"
                   draggable
                   groupClassName={
@@ -672,6 +675,7 @@ export function AppSidebar({
                   isActiveChannel={selectedView === "channel"}
                   items={sectionBuckets.unassigned}
                   listTestId="stream-list"
+                  onBrowseClick={onBrowseChannels}
                   onCreateClick={() => setCreateDialogKind("stream")}
                   onMarkAllRead={onMarkAllChannelsRead}
                   onMarkChannelRead={onMarkChannelRead}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -11,6 +11,7 @@ import {
   GripVertical,
   Pencil,
   Plus,
+  Search,
   Star,
   StarOff,
   Trash2,
@@ -227,13 +228,17 @@ export function ChannelContextMenuItems({
 // ---------------------------------------------------------------------------
 
 function SectionHeaderActions({
+  browseAriaLabel,
   createAriaLabel,
   hasUnread,
+  onBrowseClick,
   onCreateClick,
   onMarkAllRead,
 }: {
+  browseAriaLabel?: string;
   createAriaLabel: string;
   hasUnread?: boolean;
+  onBrowseClick?: () => void;
   onCreateClick?: () => void;
   onMarkAllRead?: () => void;
 }) {
@@ -251,6 +256,20 @@ function SectionHeaderActions({
           type="button"
         >
           <CheckCheck className="h-4 w-4" />
+        </button>
+      ) : null}
+      {onBrowseClick ? (
+        <button
+          aria-label={browseAriaLabel}
+          className={cn(
+            SECTION_ICON_BUTTON_CLASS,
+            SECTION_ACTION_VISIBILITY_CLASS,
+          )}
+          onClick={onBrowseClick}
+          title={browseAriaLabel}
+          type="button"
+        >
+          <Search className="h-4 w-4" />
         </button>
       ) : null}
       {onCreateClick ? (
@@ -275,6 +294,7 @@ function SectionHeaderActions({
 // ---------------------------------------------------------------------------
 
 export function ChannelGroupSection({
+  browseAriaLabel,
   createAriaLabel,
   draggable,
   groupClassName,
@@ -283,6 +303,7 @@ export function ChannelGroupSection({
   isActiveChannel,
   items,
   listTestId,
+  onBrowseClick,
   onCreateClick,
   onMarkAllRead,
   onMarkChannelRead,
@@ -305,6 +326,7 @@ export function ChannelGroupSection({
   onStarChannel,
   onUnstarChannel,
 }: {
+  browseAriaLabel?: string;
   createAriaLabel: string;
   draggable?: boolean;
   groupClassName?: string;
@@ -312,6 +334,7 @@ export function ChannelGroupSection({
   isActiveChannel: boolean;
   items: Channel[];
   listTestId: string;
+  onBrowseClick?: () => void;
   onCreateClick?: () => void;
   onMarkChannelRead: (
     channelId: string,
@@ -421,8 +444,10 @@ export function ChannelGroupSection({
           </button>
         </SidebarGroupLabel>
         <SectionHeaderActions
+          browseAriaLabel={browseAriaLabel}
           createAriaLabel={createAriaLabel}
           hasUnread={hasUnread}
+          onBrowseClick={onBrowseClick}
           onCreateClick={onCreateClick}
           onMarkAllRead={onMarkAllRead}
         />


### PR DESCRIPTION
## Summary
- Restores the Channels sidebar browse/search icon next to the create-channel button.
- Reuses the existing Browse Channels dialog so channel selection/search is available from the left navigation again.

## Test plan
- `ReadLints` on touched files
- Pre-commit hooks during commit: desktop/web fixes, Rust/Tauri format, mobile format/analyze
- Pre-push checks during push: desktop tests, mobile tests, Rust tests, Tauri tests
