### PR TITLE
fix(desktop): keep channel header search/add icons always visible

### DIFF
--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -261,10 +261,7 @@ function SectionHeaderActions({
       {onBrowseClick ? (
         <button
           aria-label={browseAriaLabel}
-          className={cn(
-            SECTION_ICON_BUTTON_CLASS,
-            SECTION_ACTION_VISIBILITY_CLASS,
-          )}
+          className={SECTION_ICON_BUTTON_CLASS}
           onClick={onBrowseClick}
           title={browseAriaLabel}
           type="button"
@@ -275,10 +272,7 @@ function SectionHeaderActions({
       {onCreateClick ? (
         <button
           aria-label={createAriaLabel}
-          className={cn(
-            SECTION_ICON_BUTTON_CLASS,
-            SECTION_ACTION_VISIBILITY_CLASS,
-          )}
+          className={SECTION_ICON_BUTTON_CLASS}
           onClick={onCreateClick}
           type="button"
         >


### PR DESCRIPTION
## Problem
The "Channels" header **search** (🔍) and **add** (+) icons in the left channel bar fade to `opacity-0` unless the section is hovered or focused. At rest they're invisible, so users can't discover how to browse or create channels. Reported by Tyler in #buzz-bugs.

## Cause
`SectionHeaderActions` (`desktop/src/features/sidebar/ui/CustomChannelSection.tsx`) applies `SECTION_ACTION_VISIBILITY_CLASS` (`opacity-0 … group-hover/focus-within:opacity-100`) to the browse and create buttons. #856 originally made these always visible; a later sidebar-polish pass reintroduced the fade — so this is a regression.

## Fix
Drop `SECTION_ACTION_VISIBILITY_CLASS` from those two buttons. They now render at the shared `SECTION_ICON_BUTTON_CLASS` resting opacity (50%) and still brighten on hover/focus, matching every other always-present sidebar icon. The contextual **mark-all-read** (✓✓) button keeps its hover-reveal behavior — it only appears on unread and wasn't part of the report.

2 insertions, 8 deletions, one file.

## Verification
- `biome check` ✓ · `tsc --noEmit` ✓
- pre-commit + pre-push hooks green (rust-tests, desktop-test, mobile-test, tauri-test)