### PR TITLE
fix(desktop): remount timeline scroll node per channel

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -262,7 +262,7 @@ export const ChannelPane = React.memo(function ChannelPane({
   useComposerHeightPadding(
     timelineScrollRef,
     composerWrapperRef,
-    `${isSinglePanelView}:${hasMainComposerOverlay}`,
+    `${activeChannelId}:${isSinglePanelView}:${hasMainComposerOverlay}`,
   );
 
   const clearWelcomeComposerDismissTimer = React.useCallback(() => {

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -205,6 +205,12 @@ const MessageTimelineBase = React.forwardRef<
   const scrollRestorationId = targetMessageId
     ? `message-timeline:${channelId ?? "none"}:target:${targetMessageId}`
     : `message-timeline:${channelId ?? "none"}`;
+  // Keep the scroll node's DOM lifetime scoped to a channel. TanStack Router's
+  // scroll-restoration listener runs outside React and may write a saved
+  // scrollTop into the current scroll element during navigation; reusing the
+  // same node across channel routes can leave the newly-loaded message list
+  // painted at a stale offset until the user's next scroll event forces layout.
+  const scrollContainerDomKey = channelId ?? "none";
 
   const timelineBodySurface = selectTimelineBodySurface({
     deferredCount: deferredMessages.length,
@@ -339,6 +345,7 @@ const MessageTimelineBase = React.forwardRef<
           )}
           data-scroll-restoration-id={scrollRestorationId}
           data-testid="message-timeline"
+          key={scrollContainerDomKey}
           onScroll={onScroll}
           ref={scrollContainerRef}
         >


### PR DESCRIPTION
## Summary
- Remount the main message timeline scroll container when the active channel changes.
- Keep the existing TanStack scroll restoration IDs, including target-message IDs, but scope the actual scroll node DOM lifetime per channel.
- Include `activeChannelId` in the composer padding reset key so overlay padding reattaches to the new timeline scroll element after remount.

## Why
After the channel-switch skeleton fix, the same `message-timeline` scroll DOM node could be reused across channel route transitions. TanStack Router's scroll restoration listener runs outside React and can synchronously write a saved `scrollTop` into the current scroll element during navigation. That stale offset can leave the newly loaded channel painted offscreen/blank until the next user scroll causes layout/scroll correction.

## Validation
- `git diff --check`
- `bin/node --import ./desktop/test-loader.mjs --experimental-strip-types --test desktop/src/features/messages/lib/timelineSnapshot.test.mjs desktop/src/features/messages/lib/timelineLoadingState.test.mjs` — 46 passed
- `bin/pnpm --dir desktop typecheck`
- `bin/pnpm --dir desktop build` — passed with existing Vite warnings about dynamic imports/large chunks
- `bin/pnpm --dir desktop exec playwright test --project=smoke tests/e2e/messaging.spec.ts -g "messages persist across channel switches|different channels have independent messages"` — 2 passed
- Pre-push hook: desktop/mobile/rust test suites passed
