### PR TITLE
Fix ACP activity tool title detection

### DIFF
--- a/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { buildTranscript } from "./agentSessionTranscript.ts";
+import { formatToolTitle } from "./agentSessionToolCatalog.ts";
 
 const baseEvent = {
   seq: 1,
@@ -12,6 +13,29 @@ const baseEvent = {
   sessionId: "sess-1",
   turnId: "turn-1",
 };
+
+function acpToolUpdate(seq, update) {
+  return {
+    ...baseEvent,
+    seq,
+    kind: "acp_read",
+    payload: {
+      method: "session/update",
+      params: {
+        sessionId: baseEvent.sessionId,
+        update,
+      },
+    },
+  };
+}
+
+function toolItems(events) {
+  return buildTranscript(events).filter((item) => item.type === "tool");
+}
+
+function activityTitle(item) {
+  return formatToolTitle(item.buzzToolName ?? item.toolName, item.title);
+}
 
 // --- stub-overflow vanish (pins the pre-existing degraded-frame behavior) ---
 
@@ -70,4 +94,103 @@ test("buildTranscript renders Prompt context + user message for a multi-block se
     ["Agent Memory — core", "Context", "Buzz event: @mention"],
     "every section header is counted",
   );
+});
+
+test("buildTranscript keeps read_file activity categorized by the actual tool when output names Buzz tools", () => {
+  const [item] = toolItems([
+    acpToolUpdate(10, {
+      sessionUpdate: "tool_call",
+      toolCallId: "call-read-file",
+      status: "executing",
+      title: "read_file",
+      kind: "read_file",
+      rawInput: {
+        path: "desktop/src/features/agents/ui/agentSessionToolCatalog.ts",
+      },
+    }),
+    acpToolUpdate(11, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call-read-file",
+      status: "completed",
+      title: "read_file",
+      kind: "read_file",
+      rawInput: {
+        path: "desktop/src/features/agents/ui/agentSessionToolCatalog.ts",
+      },
+      content: {
+        type: "text",
+        text: 'const BUZZ_READ_TOOLS = new Set(["get_feed", "get_event"]);\nconst BUZZ_WRITE_TOOLS = new Set(["delete_message"]);',
+      },
+    }),
+  ]);
+
+  assert.equal(item.toolName, "read_file");
+  assert.equal(item.buzzToolName, null);
+  assert.equal(item.title, "read_file");
+  assert.equal(activityTitle(item), "read_file");
+  assert.equal(item.status, "completed");
+  assert.match(item.result, /get_feed/);
+  assert.match(item.result, /delete_message/);
+});
+
+test("buildTranscript keeps shell activity categorized by the actual tool when grep output names Buzz tools", () => {
+  const [item] = toolItems([
+    acpToolUpdate(20, {
+      sessionUpdate: "tool_call",
+      toolCallId: "call-shell-rg",
+      status: "executing",
+      title: "shell",
+      kind: "shell",
+      rawInput: {
+        command: 'rg -n "get_event|delete_message" desktop/src',
+      },
+    }),
+    acpToolUpdate(21, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call-shell-rg",
+      status: "completed",
+      title: "shell",
+      kind: "shell",
+      rawInput: {
+        command: 'rg -n "get_event|delete_message" desktop/src',
+      },
+      rawOutput:
+        'desktop/src/features/agents/ui/agentSessionToolCatalog.ts:83:  "get_event",\n' +
+        'desktop/src/features/agents/ui/agentSessionToolCatalog.ts:92:  "delete_message",',
+    }),
+  ]);
+
+  assert.equal(item.toolName, "shell");
+  assert.equal(item.buzzToolName, null);
+  assert.equal(activityTitle(item), "shell");
+  assert.equal(item.status, "completed");
+  assert.match(item.result, /get_event/);
+  assert.match(item.result, /delete_message/);
+});
+
+test("buildTranscript categorizes explicit Buzz tool calls for the activity bar", () => {
+  const [item] = toolItems([
+    acpToolUpdate(30, {
+      sessionUpdate: "tool_call",
+      toolCallId: "call-get-feed",
+      status: "executing",
+      title: "Tool call",
+      toolName: "get_feed",
+      rawInput: { limit: 20 },
+    }),
+    acpToolUpdate(31, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call-get-feed",
+      status: "completed",
+      title: "Tool call",
+      toolName: "get_feed",
+      content: { type: "text", text: "[]" },
+    }),
+  ]);
+
+  assert.equal(item.toolName, "get_feed");
+  assert.equal(item.buzzToolName, "get_feed");
+  assert.equal(activityTitle(item), "Get Feed");
+  assert.deepEqual(item.args, { limit: 20 });
+  assert.equal(item.status, "completed");
 });

--- a/desktop/src/features/agents/ui/agentSessionTranscriptHelpers.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptHelpers.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   extractPromptText,
+  extractToolIdentity,
   parsePromptText,
   parseSystemPromptSections,
 } from "./agentSessionTranscriptHelpers.ts";
@@ -122,6 +123,43 @@ test("extractPromptText handles plain string blocks", () => {
 test("extractPromptText returns empty string when prompt is missing or not an array", () => {
   assert.equal(extractPromptText({}), "");
   assert.equal(extractPromptText({ params: { prompt: "nope" } }), "");
+});
+
+test("extractToolIdentity ignores Buzz tool names that only appear in file contents", () => {
+  const identity = extractToolIdentity({
+    sessionUpdate: "tool_call_update",
+    toolCallId: "read-file-1",
+    status: "completed",
+    title: "read_file",
+    kind: "read_file",
+    rawInput: {
+      path: "desktop/src/features/agents/ui/agentSessionToolCatalog.ts",
+    },
+    content: {
+      text: 'const BUZZ_READ_TOOLS = new Set(["get_feed", "get_event"]);',
+    },
+  });
+
+  assert.deepEqual(identity, {
+    title: "read_file",
+    toolName: "read_file",
+    buzzToolName: null,
+  });
+});
+
+test("extractToolIdentity still recognizes explicit Buzz tool fields", () => {
+  const identity = extractToolIdentity({
+    sessionUpdate: "tool_call",
+    title: "Tool call",
+    toolName: "get_feed",
+    rawInput: { limit: 50 },
+  });
+
+  assert.deepEqual(identity, {
+    title: "Tool call",
+    toolName: "get_feed",
+    buzzToolName: "get_feed",
+  });
 });
 
 // --- parseSystemPromptSections: deterministic Base/System split ---

--- a/desktop/src/features/agents/ui/agentSessionTranscriptHelpers.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptHelpers.ts
@@ -188,11 +188,9 @@ export function extractToolIdentity(update: Record<string, unknown>): {
   buzzToolName: string | null;
 } {
   const candidates = collectToolNameCandidates(update);
-  const knownName =
-    candidates
-      .map((candidate) => findBuzzToolName(candidate, true))
-      .find((candidate): candidate is string => Boolean(candidate)) ??
-    findBuzzToolName(JSON.stringify(update), false);
+  const knownName = candidates
+    .map((candidate) => findBuzzToolName(candidate, true))
+    .find((candidate): candidate is string => Boolean(candidate));
   const firstSpecific = candidates.find(
     (candidate) => !isGenericToolTitle(candidate),
   );
@@ -201,7 +199,7 @@ export function extractToolIdentity(update: Record<string, unknown>): {
   return {
     title,
     toolName: knownName ?? normalizeToolName(firstSpecific ?? title),
-    buzzToolName: knownName,
+    buzzToolName: knownName ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary
- stop inferring Buzz tool names by scanning entire ACP tool-call payloads
- only trust explicit identity-bearing fields when deriving tool identity
- add regression coverage for real-shaped ACP `session/update` fixtures where tool output mentions Buzz tool names

## Validation
- `pnpm --dir desktop test -- agentSessionTranscript.test.mjs agentSessionTranscriptHelpers.test.mjs` (1021/1021)
- `pnpm --dir desktop typecheck`
- `git diff --check origin/main...HEAD`
