### PR TITLE
fix(ci): publish versioned Docker tags via auto-tag dispatch

### DIFF
--- a/.github/workflows/auto-tag-on-release-pr-merge.yml
+++ b/.github/workflows/auto-tag-on-release-pr-merge.yml
@@ -61,3 +61,15 @@ jobs:
           gh workflow run release.yml \
             -f version="$VERSION" \
             -f ref="v$VERSION"
+
+      - name: Trigger Docker image build
+        # docker.yml's on:push:tags trigger never fires for this tag because
+        # the tag was pushed with GITHUB_TOKEN (recursion guard). Dispatch it
+        # explicitly with version+ref, same as the release build above.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ env.version }}
+        run: |
+          gh workflow run docker.yml \
+            -f version="$VERSION" \
+            -f ref="v$VERSION"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,18 @@ name: Docker image
 #   - push to main         → :main + :sha-<7>
 #   - push tags v*.*.*     → :latest + :{version} + :{major}.{minor} + :{major}
 #   - pull_request         → build only (no push), cache stays warm
-#   - workflow_dispatch    → manual canary
+#   - workflow_dispatch    → manual canary, or release-tag dispatch with
+#                            version+ref inputs (auto-tag rescues the dead
+#                            push:tags trigger this way — see below)
+#
+# Why workflow_dispatch carries version/ref inputs:
+#   auto-tag-on-release-pr-merge.yml pushes the release tag with the default
+#   GITHUB_TOKEN, which GitHub deliberately does NOT let fire on:push triggers
+#   (recursion guard). So the push:tags trigger above never runs for releases.
+#   auto-tag instead dispatches this workflow with the version + tag ref, the
+#   same rescue release.yml already uses. On dispatch github.ref is `main`, so
+#   the tag ref must be plumbed through explicitly: checkout pins to inputs.ref,
+#   and the semver tags take inputs.version via metadata-action `value=`.
 
 on:
   push:
@@ -33,6 +44,14 @@ on:
       - "pnpm-workspace.yaml"
       - "patches/**"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver version e.g. 0.3.26 (no v prefix) — for tag-release dispatch"
+        required: false
+      ref:
+        description: "Tag/branch/SHA to build, e.g. v0.3.26"
+        required: false
+        default: main
 
 # One image build per ref; cancel superseded PR builds, but never cancel
 # tag/main builds (publishing must not be aborted mid-flight).
@@ -77,6 +96,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
+          # On workflow_dispatch (release-tag rescue) build the tagged commit,
+          # not main. Empty string = default ref for push/PR events.
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || '' }}
           persist-credentials: false
 
       - name: Set up Docker Buildx
@@ -108,9 +130,9 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha,prefix=sha-,format=short
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=semver,pattern={{major}},value=${{ inputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.title=Buzz
@@ -189,9 +211,9 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha,prefix=sha-,format=short
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=semver,pattern={{major}},value=${{ inputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Create and push manifest list


### PR DESCRIPTION
Auto-tagged releases never published versioned container images. `auto-tag-on-release-pr-merge.yml` pushes the release tag with the default `GITHUB_TOKEN`, and GitHub's recursion guard suppresses every `on: push` trigger (including `push: tags`) for refs pushed with `GITHUB_TOKEN`. So `docker.yml`'s `on: push: tags: ["v[0-9]*"]` never fired for a release. The result: `ghcr.io/block/buzz` only ever had `:main` and `:latest`, and every `ghcr.io/block/buzz:vX.Y.Z` returned `manifest unknown` (404).

`release.yml` has the identical dead `on: push: tags` trigger but is rescued by an explicit `gh workflow run release.yml` dispatch at the end of the auto-tag job. `docker.yml` was added later and was never wired into that rescue. This change mirrors the same approach — no PAT or GitHub App token is introduced.

## Changes

`auto-tag-on-release-pr-merge.yml`
- After the existing release-build dispatch, add a sibling `gh workflow run docker.yml -f version=... -f ref=v...` step using the same `GITHUB_TOKEN`. (`gh workflow run` with `GITHUB_TOKEN` can dispatch other workflows — that is how `release.yml` is already kicked.)

`docker.yml`
- Add `workflow_dispatch.inputs.version` and `inputs.ref` (both optional, `ref` defaults to `main`), so inputless manual canary dispatch still works exactly as before.
- Pin the build job's checkout to `inputs.ref` on `workflow_dispatch` (`github.ref` is `main` on a dispatch, not the tag). Empty string preserves default checkout for push/PR events.
- Add `value=${{ inputs.version }}` to each `type=semver` line in both `meta` steps (build and merge jobs). `type=semver` derives the version from the git ref, which is `main` on a dispatch and would render nothing — the explicit `value=` supplies the version instead.

## Why an empty `value=` is safe on the existing paths

metadata-action's `procSemver` treats an absent and an empty `value` identically (default is `''`). When `value` is empty it falls back to `this.context.ref` stripped of `refs/tags/`. So:
- **Human-pushed tag** (`push` event, `inputs.version` empty): `value=""` → falls back to the tag ref → full semver family renders, unchanged.
- **Release dispatch** (`version`+`ref` set): checkout pins the tag commit; semver tags take `inputs.version`.
- **Inputless canary dispatch** (`ref` = `main`): `value=""` and ref is not a tag → semver tags render nothing, exactly as today (`:main` + `:sha-<7>` only).

`actionlint` passes clean on both workflows.

## Post-merge backfill (manual, one-off)

This fix only affects future releases. To publish the already-tagged `v0.3.26` (and any other versions you want) into GHCR, after merge run once against the tag ref:

```
gh workflow run docker.yml -f version=0.3.26 -f ref=v0.3.26 --repo block/buzz
```

Do not attempt the backfill from this branch pre-merge — `docker.yml` must accept the inputs first.

