### PR TITLE
Copy channel name from header

### DIFF
--- a/desktop/src/features/chat/ui/ChatHeader.tsx
+++ b/desktop/src/features/chat/ui/ChatHeader.tsx
@@ -130,7 +130,7 @@ export function ChatHeader({
       data-tauri-drag-region
     >
       <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-[4px] overflow-hidden">
+        <div className="group/title flex min-w-0 items-center gap-[4px] overflow-hidden">
           <div className="shrink-0">
             {leadingContent ?? (
               <ChannelIcon
@@ -149,7 +149,7 @@ export function ChatHeader({
           </h1>
           <Button
             aria-label={`Copy channel name: ${title}`}
-            className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+            className="h-6 w-6 shrink-0 opacity-0 text-muted-foreground transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/title:opacity-100"
             onClick={() => void handleCopyTitle()}
             size="icon-xs"
             title="Copy channel name"

--- a/desktop/src/features/chat/ui/ChatHeader.tsx
+++ b/desktop/src/features/chat/ui/ChatHeader.tsx
@@ -10,6 +10,7 @@ import {
   Zap,
 } from "lucide-react";
 import type * as React from "react";
+import { toast } from "sonner";
 
 import type { ChannelType, ChannelVisibility } from "@/shared/api/types";
 import { UpdateIndicator } from "@/features/settings/UpdateIndicator";
@@ -99,6 +100,16 @@ export function ChatHeader({
   const clearCollapsedTopChromeControls =
     belowSystemChrome && sidebar?.state === "collapsed" && !sidebar.isMobile;
 
+  function handleTitleClick() {
+    const value = title.trim();
+    if (!value) return;
+
+    void navigator.clipboard
+      .writeText(value)
+      .then(() => toast.success("Channel name copied"))
+      .catch(() => toast.error("Failed to copy channel name"));
+  }
+
   const header = (
     <header
       className={cn(
@@ -130,7 +141,15 @@ export function ChatHeader({
             data-testid="chat-title"
             title={trimmedDescription || undefined}
           >
-            {title}
+            <button
+              aria-label="Copy channel name"
+              className="max-w-full cursor-copy truncate text-left"
+              onClick={handleTitleClick}
+              title="Click to copy channel name"
+              type="button"
+            >
+              {title}
+            </button>
           </h1>
           {statusBadge ? (
             <div className="flex shrink-0 flex-wrap items-center gap-1">

--- a/desktop/src/features/chat/ui/ChatHeader.tsx
+++ b/desktop/src/features/chat/ui/ChatHeader.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   Bot,
   CircleDot,
+  Copy,
   FileText,
   FolderGit2,
   Hash,
@@ -16,6 +17,7 @@ import type { ChannelType, ChannelVisibility } from "@/shared/api/types";
 import { UpdateIndicator } from "@/features/settings/UpdateIndicator";
 import { cn } from "@/shared/lib/cn";
 import { channelChrome } from "@/shared/layout/chromeLayout";
+import { Button } from "@/shared/ui/button";
 import { useOptionalSidebar } from "@/shared/ui/sidebar";
 
 type ChatHeaderProps = {
@@ -100,14 +102,16 @@ export function ChatHeader({
   const clearCollapsedTopChromeControls =
     belowSystemChrome && sidebar?.state === "collapsed" && !sidebar.isMobile;
 
-  function handleTitleClick() {
+  async function handleCopyTitle() {
     const value = title.trim();
     if (!value) return;
 
-    void navigator.clipboard
-      .writeText(value)
-      .then(() => toast.success("Channel name copied"))
-      .catch(() => toast.error("Failed to copy channel name"));
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success("Channel name copied");
+    } catch {
+      toast.error("Failed to copy channel name");
+    }
   }
 
   const header = (
@@ -137,20 +141,23 @@ export function ChatHeader({
             )}
           </div>
           <h1
-            className="min-w-0 flex-1 translate-y-px truncate text-base font-semibold leading-6 tracking-tight"
+            className="min-w-0 translate-y-px truncate text-base font-semibold leading-6 tracking-tight"
             data-testid="chat-title"
             title={trimmedDescription || undefined}
           >
-            <button
-              aria-label="Copy channel name"
-              className="max-w-full cursor-copy truncate text-left"
-              onClick={handleTitleClick}
-              title="Click to copy channel name"
-              type="button"
-            >
-              {title}
-            </button>
+            {title}
           </h1>
+          <Button
+            aria-label={`Copy channel name: ${title}`}
+            className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+            onClick={() => void handleCopyTitle()}
+            size="icon-xs"
+            title="Copy channel name"
+            type="button"
+            variant="ghost"
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </Button>
           {statusBadge ? (
             <div className="flex shrink-0 flex-wrap items-center gap-1">
               {statusBadge}


### PR DESCRIPTION
## Summary
- make the channel header title copy the channel name to the clipboard
- expose the title as a keyboard-accessible copy button while preserving the existing header layout/description tooltip
- show success/error toasts for clipboard result

## Test plan
- pnpm --dir desktop lint
- pnpm --dir desktop typecheck
- pnpm --dir desktop check
- pre-commit hooks during commit
- pre-push hooks during push
