### PR TITLE
fix(desktop): keep channel chrome clear of window controls

### DIFF
--- a/desktop/src/features/chat/ui/ChatHeader.tsx
+++ b/desktop/src/features/chat/ui/ChatHeader.tsx
@@ -14,7 +14,7 @@ import type * as React from "react";
 import type { ChannelType, ChannelVisibility } from "@/shared/api/types";
 import { UpdateIndicator } from "@/features/settings/UpdateIndicator";
 import { cn } from "@/shared/lib/cn";
-import { channelChrome } from "@/shared/layout/chromeLayout";
+import { channelChrome, topChromeInset } from "@/shared/layout/chromeLayout";
 
 type ChatHeaderProps = {
   actions?: React.ReactNode;
@@ -151,6 +151,7 @@ export function ChatHeader({
       ref={chromeWrapperRef}
       className={cn(
         "pointer-events-none relative z-30 bg-background/80 backdrop-blur-md after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-border/35 after:content-[''] supports-backdrop-filter:bg-background/70 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-backdrop-filter:bg-background/55",
+        topChromeInset.padding,
         channelChrome.negativeMargin,
       )}
     >

--- a/desktop/src/features/chat/ui/ChatHeader.tsx
+++ b/desktop/src/features/chat/ui/ChatHeader.tsx
@@ -14,7 +14,8 @@ import type * as React from "react";
 import type { ChannelType, ChannelVisibility } from "@/shared/api/types";
 import { UpdateIndicator } from "@/features/settings/UpdateIndicator";
 import { cn } from "@/shared/lib/cn";
-import { channelChrome, topChromeInset } from "@/shared/layout/chromeLayout";
+import { channelChrome } from "@/shared/layout/chromeLayout";
+import { useOptionalSidebar } from "@/shared/ui/sidebar";
 
 type ChatHeaderProps = {
   actions?: React.ReactNode;
@@ -94,6 +95,9 @@ export function ChatHeader({
   statusBadge,
 }: ChatHeaderProps) {
   const trimmedDescription = description?.trim() ?? "";
+  const sidebar = useOptionalSidebar();
+  const clearCollapsedTopChromeControls =
+    belowSystemChrome && sidebar?.state === "collapsed" && !sidebar.isMobile;
 
   const header = (
     <header
@@ -105,6 +109,7 @@ export function ChatHeader({
             : "min-h-8 py-0"
           : "min-h-11 py-1.5",
         overlaysContent && !belowSystemChrome && "-mb-11",
+        clearCollapsedTopChromeControls && "pl-[176px]",
       )}
       data-testid="chat-header"
       data-tauri-drag-region
@@ -151,7 +156,6 @@ export function ChatHeader({
       ref={chromeWrapperRef}
       className={cn(
         "pointer-events-none relative z-30 bg-background/80 backdrop-blur-md after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-border/35 after:content-[''] supports-backdrop-filter:bg-background/70 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-backdrop-filter:bg-background/55",
-        topChromeInset.padding,
         channelChrome.negativeMargin,
       )}
     >

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -361,7 +361,7 @@ const MessageTimelineBase = React.forwardRef<
         ) : null}
         <div
           className={cn(
-            "absolute inset-0 overflow-y-auto overflow-x-hidden overscroll-contain px-2 pt-1 [overflow-anchor:none]",
+            "absolute inset-0 overflow-y-auto overflow-x-hidden overscroll-none px-2 pt-1 [overflow-anchor:none]",
             hasComposerOverlay ? "pb-24" : "pb-4",
           )}
           data-scroll-restoration-id={scrollRestorationId}


### PR DESCRIPTION
## Summary
- Keep the collapsed-sidebar channel title/header clear of the fixed macOS/window/sidebar/back-forward controls without adding vertical header space.
- Disable the channel timeline's local rubber-band overscroll effect.
- Keep the fix scoped to the channel view shown in Thomas's collapsed-left-nav repro.

## Rationale
Thomas's screenshot: https://sprout-oss.stage.blox.sqprod.co/media/c948709143e10b5ef9d5f8eb028af6f93c7e6c2b7baf63b7888fac8e72d7f5e5.png

When the desktop sidebar is collapsed, the global top-chrome controls are fixed over the left side of the channel header row. The header should not move down; it only needs enough left inset for its title content to start after those controls. `ChatHeader` now applies that extra left padding only for the compact `belowSystemChrome` header while the desktop sidebar is collapsed, leaving expanded/mobile layouts unchanged.

Separately, `overscroll-contain` prevents scroll chaining to ancestors, but it still permits the timeline scroller's own local rubber-band at its boundary. `overscroll-none` suppresses that local overflow effect without blocking normal timeline scrolling.

## Validation
- `cd desktop && PATH="../bin:$PATH" pnpm typecheck`
- `cd desktop && PATH="../bin:$PATH" pnpm check`
- pre-commit hooks on commit
- pre-push hooks on push

Manual macOS visual repro/GIF not captured in this agent session; please verify the collapsed-sidebar channel header/title position and timeline bounce before merge.
