### PR TITLE
Add video playback speed control

### DIFF
--- a/desktop/src/shared/ui/VideoPlayer.tsx
+++ b/desktop/src/shared/ui/VideoPlayer.tsx
@@ -701,6 +701,7 @@ export function VideoPlayer({
 }: VideoPlayerProps) {
   const persistedReviewKey = reviewKey ?? src;
   const videoRef = React.useRef<HTMLVideoElement>(null);
+  const inlineSurfaceRef = React.useRef<HTMLDivElement | null>(null);
   const reviewVideoRef = React.useRef<HTMLVideoElement>(null);
   const [started, setStarted] = React.useState(false);
   const [isPlaying, setIsPlaying] = React.useState(false);
@@ -726,6 +727,9 @@ export function VideoPlayer({
     () => getReviewPlaybackPosition(persistedReviewKey) ?? 0,
   );
   const [pendingSeekSeconds, setPendingSeekSeconds] = React.useState<
+    number | null
+  >(null);
+  const [inlineRenderedWidth, setInlineRenderedWidth] = React.useState<
     number | null
   >(null);
 
@@ -809,6 +813,34 @@ export function VideoPlayer({
     applyPlaybackSpeed(videoRef.current);
     applyPlaybackSpeed(reviewVideoRef.current);
   }, [applyPlaybackSpeed]);
+
+  React.useLayoutEffect(() => {
+    const element = inlineSurfaceRef.current;
+    if (!element) {
+      setInlineRenderedWidth(null);
+      return;
+    }
+
+    const updateWidth = () => {
+      const width = element.getBoundingClientRect().width;
+      setInlineRenderedWidth((currentWidth) =>
+        currentWidth !== null && Math.abs(currentWidth - width) < 0.5
+          ? currentWidth
+          : width,
+      );
+    };
+
+    updateWidth();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateWidth);
+      return () => window.removeEventListener("resize", updateWidth);
+    }
+
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
 
   const handlePlaybackSpeedChange = React.useCallback((speed: number) => {
     if (isPlaybackSpeedOption(speed)) {
@@ -931,7 +963,8 @@ export function VideoPlayer({
   const inlineAspectRatio = aspectRatio ?? naturalAspectRatio ?? 16 / 9;
   const inlineSurfaceWidth = getInlineSurfaceWidth(inlineAspectRatio);
   const showInlineSpeedControl =
-    inlineSurfaceWidth >= INLINE_SPEED_CONTROL_MIN_WIDTH;
+    inlineRenderedWidth !== null &&
+    inlineRenderedWidth >= INLINE_SPEED_CONTROL_MIN_WIDTH;
   const inlineSurfaceStyle: React.CSSProperties = {
     aspectRatio: String(inlineAspectRatio),
     maxHeight: 256,
@@ -946,6 +979,7 @@ export function VideoPlayer({
         data-testid="video-player"
       >
         <div
+          ref={inlineSurfaceRef}
           className="group/video relative isolate max-w-full overflow-hidden rounded-2xl border border-border/70 bg-black"
           style={inlineSurfaceStyle}
         >

--- a/desktop/src/shared/ui/VideoPlayer.tsx
+++ b/desktop/src/shared/ui/VideoPlayer.tsx
@@ -22,6 +22,7 @@ import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { Checkbox } from "@/shared/ui/checkbox";
 import { MODAL_BACKDROP_BLUR_CLASS } from "@/shared/ui/modalBackdrop";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
@@ -102,6 +103,8 @@ type TimecodedComment = {
 const TIMECODE_RE =
   /^\s*\[((?:(?:\d{1,2}:)?\d{1,2}:)?\d{2}(?:\.\d{1,3})?)\]\s*/;
 const QUICK_REACTIONS = ["😂", "😍", "😮", "🙌", "👍", "👎"];
+const DEFAULT_PLAYBACK_SPEED = 1;
+const PLAYBACK_SPEEDS = [2, 1.75, 1.5, 1.25, 1, 0.75, 0.5, 0.25];
 
 /**
  * Frosted-glass backing layer for floating media controls. The parent must
@@ -161,6 +164,14 @@ function formatCommentTimecode(seconds: number): string {
     fractionalDigits: 1,
     trimZeroFraction: true,
   });
+}
+
+function formatPlaybackSpeed(speed: number): string {
+  return `${speed}x`;
+}
+
+function isPlaybackSpeedOption(speed: number): boolean {
+  return PLAYBACK_SPEEDS.some((option) => option === speed);
 }
 
 function parseTimecode(value: string): number | null {
@@ -603,6 +614,82 @@ function VolumeControl({
   );
 }
 
+function PlaybackSpeedControl({
+  playbackSpeed,
+  onPlaybackSpeedChange,
+  size = "inline",
+  testId,
+}: {
+  playbackSpeed: number;
+  onPlaybackSpeedChange: (speed: number) => void;
+  size?: "inline" | "review";
+  testId: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const label = formatPlaybackSpeed(playbackSpeed);
+  const triggerSizeClass =
+    size === "review"
+      ? "h-8 min-w-11 rounded-lg px-2 text-xs"
+      : "h-7 min-w-10 rounded-md px-1.5 text-2xs";
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          aria-label={`Playback speed: ${label}`}
+          className={cn(
+            "flex shrink-0 items-center justify-center font-semibold tabular-nums text-white transition-colors hover:bg-white/15 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-white/60",
+            triggerSizeClass,
+            open && "bg-white/15",
+          )}
+          data-testid={testId}
+          type="button"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {label}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-28 border-white/10 bg-black/85 p-1 text-white backdrop-blur-xl"
+        data-testid={`${testId}-menu`}
+        side="top"
+        sideOffset={8}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="px-2 pb-1 pt-1 text-2xs font-medium text-white/55">
+          Speed
+        </div>
+        <div className="grid gap-0.5">
+          {PLAYBACK_SPEEDS.map((speed) => {
+            const speedLabel = formatPlaybackSpeed(speed);
+            const selected = speed === playbackSpeed;
+            return (
+              <button
+                aria-pressed={selected}
+                className={cn(
+                  "flex h-8 w-full items-center justify-between rounded-lg px-2 text-left text-xs font-medium tabular-nums text-white transition-colors hover:bg-white/15 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-white/60",
+                  selected && "bg-white/15",
+                )}
+                key={speed}
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onPlaybackSpeedChange(speed);
+                  setOpen(false);
+                }}
+              >
+                <span>{speedLabel}</span>
+                {selected ? <Check className="h-3.5 w-3.5" /> : null}
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 export function VideoPlayer({
   src,
   poster,
@@ -625,6 +712,9 @@ export function VideoPlayer({
   const [duration, setDuration] = React.useState(durationSeconds ?? 0);
   const [volume, setVolume] = React.useState(1);
   const [muted, setMuted] = React.useState(false);
+  const [playbackSpeed, setPlaybackSpeed] = React.useState(
+    DEFAULT_PLAYBACK_SPEED,
+  );
   const [naturalAspectRatio, setNaturalAspectRatio] = React.useState<
     number | null
   >(null);
@@ -656,6 +746,7 @@ export function VideoPlayer({
     setIsPlaying(false);
     setIsBuffering(false);
     setHasError(false);
+    setPlaybackSpeed(DEFAULT_PLAYBACK_SPEED);
     setReviewOpenState(isVideoReviewOpen(persistedReviewKey));
     setReviewCurrentTimeState(
       getReviewPlaybackPosition(persistedReviewKey) ?? 0,
@@ -704,6 +795,25 @@ export function VideoPlayer({
     },
     [persistedReviewKey],
   );
+
+  const applyPlaybackSpeed = React.useCallback(
+    (video: HTMLVideoElement | null) => {
+      if (!video) return;
+      video.playbackRate = playbackSpeed;
+    },
+    [playbackSpeed],
+  );
+
+  React.useEffect(() => {
+    applyPlaybackSpeed(videoRef.current);
+    applyPlaybackSpeed(reviewVideoRef.current);
+  }, [applyPlaybackSpeed]);
+
+  const handlePlaybackSpeedChange = React.useCallback((speed: number) => {
+    if (isPlaybackSpeedOption(speed)) {
+      setPlaybackSpeed(speed);
+    }
+  }, []);
 
   useSmoothPlaybackTime(videoRef, isPlaying && !reviewOpen, setCurrentTime);
   const inlineSeek = useThrottledVideoSeek(videoRef);
@@ -865,6 +975,7 @@ export function VideoPlayer({
                 videoHeight,
                 videoWidth,
               } = event.currentTarget;
+              applyPlaybackSpeed(event.currentTarget);
               handleMediaDuration(mediaDuration);
               const savedSeconds =
                 getInlinePlaybackPosition(persistedReviewKey);
@@ -989,6 +1100,11 @@ export function VideoPlayer({
                 >
                   {formatTimecode(duration)}
                 </span>
+                <PlaybackSpeedControl
+                  playbackSpeed={playbackSpeed}
+                  testId="video-inline-speed"
+                  onPlaybackSpeedChange={handlePlaybackSpeedChange}
+                />
                 <VolumeControl
                   muted={muted}
                   volume={volume}
@@ -1023,8 +1139,10 @@ export function VideoPlayer({
         onDurationChange={handleMediaDuration}
         onOpenChange={handleReviewOpenChange}
         onPendingSeekConsumed={handlePendingSeekConsumed}
+        onPlaybackSpeedChange={handlePlaybackSpeedChange}
         open={reviewOpen}
         pendingSeekSeconds={pendingSeekSeconds}
+        playbackSpeed={playbackSpeed}
         poster={poster}
         reviewContext={reviewContext}
         src={src}
@@ -1043,8 +1161,10 @@ function VideoReviewDialog({
   onDurationChange,
   onOpenChange,
   onPendingSeekConsumed,
+  onPlaybackSpeedChange,
   open,
   pendingSeekSeconds,
+  playbackSpeed,
   poster,
   reviewContext,
   src,
@@ -1058,8 +1178,10 @@ function VideoReviewDialog({
   onDurationChange: (seconds: number) => void;
   onOpenChange: (open: boolean) => void;
   onPendingSeekConsumed: () => void;
+  onPlaybackSpeedChange: (speed: number) => void;
   open: boolean;
   pendingSeekSeconds: number | null;
+  playbackSpeed: number;
   poster?: string;
   reviewContext?: VideoReviewContext;
   src: string;
@@ -1300,6 +1422,13 @@ function VideoReviewDialog({
     [videoRef],
   );
 
+  React.useEffect(() => {
+    if (!open) return;
+    const video = videoRef.current;
+    if (!video) return;
+    video.playbackRate = playbackSpeed;
+  }, [open, playbackSpeed, videoRef]);
+
   const postContent = React.useCallback(
     async (
       content: string,
@@ -1538,6 +1667,7 @@ function VideoReviewDialog({
                       setIsPlaying(false);
                     }}
                     onLoadedMetadata={(event) => {
+                      event.currentTarget.playbackRate = playbackSpeed;
                       onDurationChange(event.currentTarget.duration);
                       const { videoHeight, videoWidth } = event.currentTarget;
                       if (videoWidth > 0 && videoHeight > 0) {
@@ -1635,6 +1765,12 @@ function VideoReviewDialog({
                     >
                       {formatTimecode(visibleDuration)}
                     </span>
+                    <PlaybackSpeedControl
+                      playbackSpeed={playbackSpeed}
+                      size="review"
+                      testId="video-review-speed"
+                      onPlaybackSpeedChange={onPlaybackSpeedChange}
+                    />
                     <VolumeControl
                       expanded
                       muted={muted}

--- a/desktop/src/shared/ui/VideoPlayer.tsx
+++ b/desktop/src/shared/ui/VideoPlayer.tsx
@@ -104,6 +104,7 @@ const TIMECODE_RE =
   /^\s*\[((?:(?:\d{1,2}:)?\d{1,2}:)?\d{2}(?:\.\d{1,3})?)\]\s*/;
 const QUICK_REACTIONS = ["😂", "😍", "😮", "🙌", "👍", "👎"];
 const DEFAULT_PLAYBACK_SPEED = 1;
+const INLINE_SPEED_CONTROL_MIN_WIDTH = 220;
 const PLAYBACK_SPEEDS = [2, 1.75, 1.5, 1.25, 1, 0.75, 0.5, 0.25];
 
 /**
@@ -928,10 +929,13 @@ export function VideoPlayer({
     [reviewContext?.comments],
   );
   const inlineAspectRatio = aspectRatio ?? naturalAspectRatio ?? 16 / 9;
+  const inlineSurfaceWidth = getInlineSurfaceWidth(inlineAspectRatio);
+  const showInlineSpeedControl =
+    inlineSurfaceWidth >= INLINE_SPEED_CONTROL_MIN_WIDTH;
   const inlineSurfaceStyle: React.CSSProperties = {
     aspectRatio: String(inlineAspectRatio),
     maxHeight: 256,
-    width: getInlineSurfaceWidth(inlineAspectRatio),
+    width: inlineSurfaceWidth,
   };
   const showControls = started && !hasError;
 
@@ -1100,11 +1104,13 @@ export function VideoPlayer({
                 >
                   {formatTimecode(duration)}
                 </span>
-                <PlaybackSpeedControl
-                  playbackSpeed={playbackSpeed}
-                  testId="video-inline-speed"
-                  onPlaybackSpeedChange={handlePlaybackSpeedChange}
-                />
+                {showInlineSpeedControl ? (
+                  <PlaybackSpeedControl
+                    playbackSpeed={playbackSpeed}
+                    testId="video-inline-speed"
+                    onPlaybackSpeedChange={handlePlaybackSpeedChange}
+                  />
+                ) : null}
                 <VolumeControl
                   muted={muted}
                   volume={volume}

--- a/desktop/tests/e2e/video-attachment.spec.ts
+++ b/desktop/tests/e2e/video-attachment.spec.ts
@@ -232,6 +232,33 @@ test("video upload previews use poster frames and inline videos open review mode
     restoredInlinePlayer.getByRole("button", { name: "Pause video" }),
   ).toBeVisible();
 
+  const inlineSpeedButton =
+    restoredInlinePlayer.getByTestId("video-inline-speed");
+  await expect(inlineSpeedButton).toHaveText("1x");
+  await inlineSpeedButton.click();
+  const inlineSpeedMenu = page.getByTestId("video-inline-speed-menu");
+  await expect(inlineSpeedMenu.getByRole("button")).toHaveText([
+    "2x",
+    "1.75x",
+    "1.5x",
+    "1.25x",
+    "1x",
+    "0.75x",
+    "0.5x",
+    "0.25x",
+  ]);
+  await inlineSpeedMenu
+    .getByRole("button", { name: "1.5x", exact: true })
+    .click();
+  await expect(inlineSpeedButton).toHaveText("1.5x");
+  await expect
+    .poll(() =>
+      restoredInlineVideo.evaluate(
+        (video) => (video as HTMLVideoElement).playbackRate,
+      ),
+    )
+    .toBe(1.5);
+
   // Inline volume controls.
   await inlinePlayer.getByRole("button", { name: "Mute" }).click();
   await expect
@@ -272,6 +299,24 @@ test("video upload previews use poster frames and inline videos open review mode
 
   const reviewVideo = reviewDialog.locator("video");
   await expect(reviewVideo).not.toHaveAttribute("controls", "");
+  const reviewSpeedButton = reviewDialog.getByTestId("video-review-speed");
+  await expect(reviewSpeedButton).toHaveText("1.5x");
+  await expect
+    .poll(() =>
+      reviewVideo.evaluate((video) => (video as HTMLVideoElement).playbackRate),
+    )
+    .toBe(1.5);
+  await reviewSpeedButton.click();
+  await page
+    .getByTestId("video-review-speed-menu")
+    .getByRole("button", { name: "0.25x", exact: true })
+    .click();
+  await expect(reviewSpeedButton).toHaveText("0.25x");
+  await expect
+    .poll(() =>
+      reviewVideo.evaluate((video) => (video as HTMLVideoElement).playbackRate),
+    )
+    .toBe(0.25);
   await reviewDialog.getByRole("button", { name: "Play review video" }).click();
   await expect(
     reviewDialog.getByRole("button", { name: "Pause review video" }),
@@ -569,6 +614,16 @@ test("video upload previews use poster frames and inline videos open review mode
     .getByRole("button", { name: "Close video review" })
     .click();
   await expect(page.getByTestId("video-review-dialog")).toHaveCount(0);
+  await expect(
+    restoredInlinePlayer.getByTestId("video-inline-speed"),
+  ).toHaveText("0.25x");
+  await expect
+    .poll(() =>
+      restoredInlineVideo.evaluate(
+        (video) => (video as HTMLVideoElement).playbackRate,
+      ),
+    )
+    .toBe(0.25);
 
   await reviewButton.evaluate((button) =>
     (button as HTMLButtonElement).click(),

--- a/desktop/tests/e2e/video-attachment.spec.ts
+++ b/desktop/tests/e2e/video-attachment.spec.ts
@@ -4,6 +4,8 @@ import { installMockBridge } from "../helpers/bridge";
 
 const VIDEO_SHA = "b".repeat(64);
 const VIDEO_URL = `http://localhost:3000/media/${VIDEO_SHA}.mp4`;
+const PORTRAIT_VIDEO_SHA = "c".repeat(64);
+const PORTRAIT_VIDEO_URL = `http://localhost:3000/media/${PORTRAIT_VIDEO_SHA}.mp4`;
 const POSTER_DATA_URL =
   "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgODAiPjxyZWN0IHdpZHRoPSIxNjAiIGhlaWdodD0iODAiIGZpbGw9IiMyNjQ2NTMiLz48Y2lyY2xlIGN4PSI1NCIgY3k9IjQwIiByPSIyMiIgZmlsbD0iI2YyYzE0ZSIvPjxwYXRoIGQ9Ik05MiAyNGg0NHYzMkg5MnoiIGZpbGw9IiNmNzgxNTQiLz48L3N2Zz4=";
 
@@ -25,23 +27,29 @@ async function waitForMockLiveSubscription(page: Page, channelName: string) {
     .toBe(true);
 }
 
-function emitMockMessage(page: Page, channelName: string, content: string) {
+function emitMockMessage(
+  page: Page,
+  channelName: string,
+  content: string,
+  options: { extraTags?: string[][] } = {},
+) {
   return page.evaluate(
-    ({ channelName, content }) => {
+    ({ channelName, content, extraTags }) => {
       const emit = (
         window as Window & {
           __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
             channelName: string;
             content: string;
+            extraTags?: string[][];
           }) => unknown;
         }
       ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
       if (!emit) {
         throw new Error("Mock message emitter is unavailable.");
       }
-      emit({ channelName, content });
+      emit({ channelName, content, extraTags });
     },
-    { channelName, content },
+    { channelName, content, extraTags: options.extraTags },
   );
 }
 
@@ -657,4 +665,45 @@ test("video upload previews use poster frames and inline videos open review mode
   await expect(
     threadReviewDialog.getByTestId("video-review-comments"),
   ).toContainText("Color pass looks right");
+});
+
+test("narrow inline videos hide playback speed control", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  await emitMockMessage(page, "general", `![video](${PORTRAIT_VIDEO_URL})`, {
+    extraTags: [
+      [
+        "imeta",
+        `url ${PORTRAIT_VIDEO_URL}`,
+        "m video/mp4",
+        `x ${PORTRAIT_VIDEO_SHA}`,
+        "size 987654",
+        "dim 80x160",
+        "duration 12.5",
+        `image ${POSTER_DATA_URL}`,
+        "filename portrait-demo.mp4",
+      ],
+    ],
+  });
+
+  const portraitPlayer = page.getByTestId("video-player").last();
+  await expect(portraitPlayer).toBeVisible();
+  const portraitBox = await portraitPlayer.boundingBox();
+  expect(portraitBox?.width).toBeLessThan(220);
+
+  await portraitPlayer.getByRole("button", { name: "Play video" }).click();
+  await expect(
+    portraitPlayer.getByTestId("video-inline-controls"),
+  ).toBeVisible();
+  await expect(portraitPlayer.getByTestId("video-inline-speed")).toHaveCount(0);
+
+  await portraitPlayer
+    .getByRole("button", { name: "Open video review" })
+    .click();
+  const reviewDialog = page.getByTestId("video-review-dialog");
+  await expect(reviewDialog).toBeVisible();
+  await expect(reviewDialog.getByTestId("video-review-speed")).toHaveText("1x");
 });

--- a/desktop/tests/e2e/video-attachment.spec.ts
+++ b/desktop/tests/e2e/video-attachment.spec.ts
@@ -6,6 +6,8 @@ const VIDEO_SHA = "b".repeat(64);
 const VIDEO_URL = `http://localhost:3000/media/${VIDEO_SHA}.mp4`;
 const PORTRAIT_VIDEO_SHA = "c".repeat(64);
 const PORTRAIT_VIDEO_URL = `http://localhost:3000/media/${PORTRAIT_VIDEO_SHA}.mp4`;
+const CONSTRAINED_LANDSCAPE_VIDEO_SHA = "d".repeat(64);
+const CONSTRAINED_LANDSCAPE_VIDEO_URL = `http://localhost:3000/media/${CONSTRAINED_LANDSCAPE_VIDEO_SHA}.mp4`;
 const POSTER_DATA_URL =
   "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgODAiPjxyZWN0IHdpZHRoPSIxNjAiIGhlaWdodD0iODAiIGZpbGw9IiMyNjQ2NTMiLz48Y2lyY2xlIGN4PSI1NCIgY3k9IjQwIiByPSIyMiIgZmlsbD0iI2YyYzE0ZSIvPjxwYXRoIGQ9Ik05MiAyNGg0NHYzMkg5MnoiIGZpbGw9IiNmNzgxNTQiLz48L3N2Zz4=";
 
@@ -706,4 +708,58 @@ test("narrow inline videos hide playback speed control", async ({ page }) => {
   const reviewDialog = page.getByTestId("video-review-dialog");
   await expect(reviewDialog).toBeVisible();
   await expect(reviewDialog.getByTestId("video-review-speed")).toHaveText("1x");
+});
+
+test("constrained landscape inline videos measure rendered width before showing speed", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  await emitMockMessage(
+    page,
+    "general",
+    `![video](${CONSTRAINED_LANDSCAPE_VIDEO_URL})`,
+    {
+      extraTags: [
+        [
+          "imeta",
+          `url ${CONSTRAINED_LANDSCAPE_VIDEO_URL}`,
+          "m video/mp4",
+          `x ${CONSTRAINED_LANDSCAPE_VIDEO_SHA}`,
+          "size 987654",
+          "dim 160x80",
+          "duration 12.5",
+          `image ${POSTER_DATA_URL}`,
+          "filename constrained-landscape-demo.mp4",
+        ],
+      ],
+    },
+  );
+
+  const landscapePlayer = page.getByTestId("video-player").last();
+  await expect(landscapePlayer).toBeVisible();
+  const fullWidthBox = await landscapePlayer.boundingBox();
+  expect(fullWidthBox?.width).toBeGreaterThan(220);
+
+  await landscapePlayer.getByRole("button", { name: "Play video" }).click();
+  await expect(
+    landscapePlayer.getByTestId("video-inline-controls"),
+  ).toBeVisible();
+  await expect(landscapePlayer.getByTestId("video-inline-speed")).toBeVisible();
+
+  await landscapePlayer.evaluate((element) => {
+    (element as HTMLElement).style.width = "180px";
+  });
+  await expect
+    .poll(async () => {
+      const box = await landscapePlayer.boundingBox();
+      return box?.width ?? 0;
+    })
+    .toBeLessThan(220);
+  await expect(landscapePlayer.getByTestId("video-inline-speed")).toHaveCount(
+    0,
+  );
 });


### PR DESCRIPTION
## Summary
- Add a playback speed control to inline and review video controls.
- Support 0.25x through 2x, shown fastest-to-slowest in the popover.
- Keep the selected speed in sync between inline playback and review mode.

![Playback speed menu](https://raw.githubusercontent.com/block/buzz/394fdf797e772d0b8281245a018ec36b186c216f/pr-1164--01-playback-speed-menu.png)

## Checks
- `pnpm check`
- `pnpm run build`
- `pnpm exec playwright test tests/e2e/video-attachment.spec.ts --project=smoke`
