### PR TITLE
fix(release): publish versioned relay Docker tags via independent release lanes

### DIFF
--- a/.github/workflows/auto-tag-on-release-pr-merge.yml
+++ b/.github/workflows/auto-tag-on-release-pr-merge.yml
@@ -1,5 +1,26 @@
 name: Auto-tag on Release PR Merge
 
+# Three release lanes share this one workflow — adding a lane is one more branch
+# prefix, never a forked copy:
+#
+#   version-bump/<v>   → tag v<v>        → dispatch release.yml (desktop app)
+#   relay-release/<v>  → tag relay-v<v>  → dispatch docker.yml (relay image)
+#   mobile-release/<v> → tag mobile-v<v> → (manual sprout_ref for buzz-releases build — see below)
+#
+# Both the desktop and relay lanes dispatch their build workflow rather than
+# relying on the consumer's `on.push.tags` trigger: auto-tag pushes the tag
+# with the default GITHUB_TOKEN, which GitHub's recursion guard blocks from
+# firing any `on: push` trigger. So release.yml and docker.yml both have a
+# `push.tags` trigger that is dead for auto-pushed tags — the dispatch is the
+# real path. Each dispatch passes the bare version and the tag ref so the
+# consumer builds the tagged commit (github.ref on a dispatch is `main`).
+#
+# The mobile lane is push-only by infosec necessity: OSS `block/buzz` CI must
+# not trigger CI in the private `buzz-releases` repo, so auto-dispatch across
+# that boundary is deliberately disallowed. The mobile-v* tag is consumed
+# manually instead — a human feeds it as the `sprout_ref` input to the
+# `buzz-releases` Buildkite pipeline, which builds and ships mobile.
+
 on:
   pull_request:
     types: [closed]
@@ -13,7 +34,9 @@ jobs:
   auto-tag:
     if: >
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'version-bump/') &&
+      (startsWith(github.event.pull_request.head.ref, 'version-bump/') ||
+       startsWith(github.event.pull_request.head.ref, 'relay-release/') ||
+       startsWith(github.event.pull_request.head.ref, 'mobile-release/')) &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -22,42 +45,78 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
-      - name: Extract version from branch name
+      - name: Resolve lane and version from branch name
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          VERSION="${BRANCH#version-bump/}"
+          # Lane is decided by branch prefix: the tag prefix and whether a
+          # downstream workflow_dispatch is needed both follow from it.
+          case "$BRANCH" in
+            version-bump/*)
+              VERSION="${BRANCH#version-bump/}"
+              TAG_PREFIX="v"
+              DISPATCH="release" ;;
+            relay-release/*)
+              VERSION="${BRANCH#relay-release/}"
+              TAG_PREFIX="relay-v"
+              DISPATCH="docker" ;;
+            mobile-release/*)
+              VERSION="${BRANCH#mobile-release/}"
+              TAG_PREFIX="mobile-v"
+              DISPATCH="" ;;
+            *)
+              echo "::error::Unhandled branch prefix: '$BRANCH'"
+              exit 1 ;;
+          esac
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
             echo "::error::Invalid version in branch name: '$VERSION'"
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_ENV"
-          echo "Tagging v${VERSION}"
+          echo "tag=${TAG_PREFIX}${VERSION}" >> "$GITHUB_ENV"
+          echo "dispatch=$DISPATCH" >> "$GITHUB_ENV"
+          echo "Tagging ${TAG_PREFIX}${VERSION}"
 
       - name: Create and push tag
         env:
-          VERSION: ${{ env.version }}
+          TAG: ${{ env.tag }}
         run: |
-          EXISTING_SHA="$(git ls-remote --tags origin "refs/tags/v$VERSION" | awk '{print $1}')"
+          EXISTING_SHA="$(git ls-remote --tags origin "refs/tags/$TAG" | awk '{print $1}')"
           if [ -n "$EXISTING_SHA" ]; then
             if [ "$EXISTING_SHA" = "$GITHUB_SHA" ]; then
-              echo "Tag v$VERSION already exists at $GITHUB_SHA — skipping tag creation"
+              echo "Tag $TAG already exists at $GITHUB_SHA — skipping tag creation"
               exit 0
             else
-              echo "::error::Tag v$VERSION already exists at $EXISTING_SHA (expected $GITHUB_SHA)"
+              echo "::error::Tag $TAG already exists at $EXISTING_SHA (expected $GITHUB_SHA)"
               exit 1
             fi
           fi
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
+          git tag "$TAG"
+          git push origin "$TAG"
 
       - name: Trigger release build
+        # The desktop and relay lanes dispatch their build workflow because the
+        # consumer's on:push:tags trigger is dead for auto-pushed tags (default
+        # GITHUB_TOKEN, recursion guard — see header comment). Mobile has no
+        # consumer yet, so dispatch="" skips this step entirely.
+        if: ${{ env.dispatch != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISPATCH: ${{ env.dispatch }}
           VERSION: ${{ env.version }}
+          TAG: ${{ env.tag }}
         run: |
-          gh workflow run release.yml \
+          # Both workflows take the bare version (for the build) and the tag ref
+          # (so the dispatch builds the tagged commit, not main).
+          case "$DISPATCH" in
+            release) WORKFLOW="release.yml" ;;
+            docker)  WORKFLOW="docker.yml" ;;
+            *)
+              echo "::error::Unhandled dispatch target: '$DISPATCH'"
+              exit 1 ;;
+          esac
+          gh workflow run "$WORKFLOW" \
             -f version="$VERSION" \
-            -f ref="v$VERSION"
+            -f ref="$TAG"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,9 +9,9 @@ name: Docker image
 # GitHub-hosted runners.
 #
 # Versioning: the relay is versioned independently of the desktop app via
-# its own `relay-v*` tags (see `just release-relay`). Desktop `v*` tags and
-# agent `sprig-v*` tags do NOT publish this image — only `relay-v*` does, so
-# the relay image version tracks crates/buzz-relay/Cargo.toml, never desktop.
+# its own `relay-v*` tags (see `just release-relay`). Desktop `v*` tags do
+# NOT publish this image — only `relay-v*` does, so the relay image version
+# tracks crates/buzz-relay/Cargo.toml, never desktop.
 #
 # Triggers:
 #   - push to main           → :main + :sha-<7>

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,16 +8,42 @@ name: Docker image
 # This avoids QEMU emulation (~10× slower for Rust) at zero cost on free
 # GitHub-hosted runners.
 #
+# Versioning: the relay is versioned independently of the desktop app via
+# its own `relay-v*` tags (see `just release-relay`). Desktop `v*` tags and
+# agent `sprig-v*` tags do NOT publish this image — only `relay-v*` does, so
+# the relay image version tracks crates/buzz-relay/Cargo.toml, never desktop.
+#
 # Triggers:
-#   - push to main         → :main + :sha-<7>
-#   - push tags v*.*.*     → :latest + :{version} + :{major}.{minor} + :{major}
-#   - pull_request         → build only (no push), cache stays warm
-#   - workflow_dispatch    → manual canary
+#   - push to main           → :main + :sha-<7>
+#   - push tags relay-v*.*.* → :{version} + :{major}.{minor} + :{major}
+#                              (+ :latest for stable, NOT for prereleases)
+#   - pull_request           → build only (no push), cache stays warm
+#   - workflow_dispatch      → manual canary (no inputs), or relay-tag rescue
+#                              dispatch with version+ref inputs (see below)
+#
+# Why workflow_dispatch carries version/ref inputs:
+#   auto-tag-on-release-pr-merge.yml pushes relay-v* with the default
+#   GITHUB_TOKEN, which GitHub deliberately does NOT let fire on:push triggers
+#   (recursion guard). So the push:tags trigger above never runs for releases.
+#   auto-tag instead dispatches this workflow with the bare version + tag ref,
+#   the same rescue release.yml already uses for the desktop lane. On dispatch
+#   github.ref is `main`, so the tag ref is plumbed through explicitly: checkout
+#   pins to inputs.ref, and the semver tags take inputs.version via `value=`.
+#   On the rescue path inputs.version is already bare (e.g. 0.3.0), so the
+#   match=^relay-v(.*)$ regex simply no-ops (it warns, leaving the value
+#   intact) and the bare version flows straight to the semver parser. On a
+#   real push event value= is empty and the match strips relay-v from the ref.
+#   Inputless canary dispatch (version="", ref=main) renders no semver tag.
+#
+# The :latest tag tracks the latest STABLE relay release: metadata-action's
+# `flavor.latest=auto` (its default) emits :latest only for non-prerelease
+# semver, so relay-v0.3.0-rc.1 publishes :0.3.0-rc.1 without moving :latest,
+# and main pushes (no semver tag) never produce :latest.
 
 on:
   push:
     branches: [main]
-    tags: ["v[0-9]*"]
+    tags: ["relay-v[0-9]*"]
   pull_request:
     paths:
       - "Dockerfile"
@@ -33,6 +59,14 @@ on:
       - "pnpm-workspace.yaml"
       - "patches/**"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver version e.g. 0.3.0 (no relay-v prefix) — for relay-tag rescue dispatch"
+        required: false
+      ref:
+        description: "Tag/branch/SHA to build, e.g. relay-v0.3.0"
+        required: false
+        default: main
 
 # One image build per ref; cancel superseded PR builds, but never cancel
 # tag/main builds (publishing must not be aborted mid-flight).
@@ -77,6 +111,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
+          # On workflow_dispatch (relay-tag rescue) build the tagged commit,
+          # not main. Empty string = default ref for push/PR events.
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || '' }}
           persist-credentials: false
 
       - name: Set up Docker Buildx
@@ -103,15 +140,26 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ${{ env.IMAGE_NAME }}
-          # Tag matrix — every main commit gets sha-<7>, releases get full
-          # semver family. Pull requests get nothing (push: false below).
+          # Tag matrix — every main commit gets sha-<7>, relay releases get the
+          # full semver family. The semver entries carry match=^relay-v(.*)$
+          # because metadata-action does NOT strip a `relay-v` prefix on its
+          # own — it only strips refs/tags/, then runs the raw ref through
+          # semver.valid(), which rejects "relay-v0.3.0". The match capture
+          # group feeds the bare version to the semver parser. value= supplies
+          # the version on the auto-tag rescue dispatch (github.ref is `main`
+          # there, not the tag): it is already bare, so match no-ops (warns,
+          # value intact) and the bare version validates as-is. On push value=
+          # is empty, so the ref drives it and match strips relay-v — push
+          # behavior is unchanged. Pull requests get nothing (push: false
+          # below). :latest is intentionally absent — flavor.latest defaults to
+          # `auto`, which adds :latest for stable semver tags only (not
+          # prereleases, not main pushes).
           tags: |
             type=ref,event=branch
             type=sha,prefix=sha-,format=short
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},match=^relay-v(.*)$,value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},match=^relay-v(.*)$,value=${{ inputs.version }}
+            type=semver,pattern={{major}},match=^relay-v(.*)$,value=${{ inputs.version }}
           labels: |
             org.opencontainers.image.title=Buzz
             org.opencontainers.image.description=WebSocket relay server for the Buzz communications platform
@@ -186,13 +234,17 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ${{ env.IMAGE_NAME }}
+          # Must mirror the build job's tag matrix exactly — the merge job
+          # re-derives tags to stamp them onto the multi-arch manifest. See
+          # the build job's `meta` step for why match=^relay-v(.*)$, why
+          # value=${{ inputs.version }} carries the rescue-dispatch version,
+          # and why :latest is left to flavor.latest=auto.
           tags: |
             type=ref,event=branch
             type=sha,prefix=sha-,format=short
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},match=^relay-v(.*)$,value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},match=^relay-v(.*)$,value=${{ inputs.version }}
+            type=semver,pattern={{major}},match=^relay-v(.*)$,value=${{ inputs.version }}
 
       - name: Create and push manifest list
         id: manifest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -155,8 +155,8 @@ jobs:
           # `auto`, which adds :latest for stable semver tags only (not
           # prereleases, not main pushes).
           tags: |
-            type=ref,event=branch
-            type=sha,prefix=sha-,format=short
+            type=ref,event=branch,enable=${{ github.event_name != 'workflow_dispatch' || inputs.version == '' }}
+            type=sha,prefix=sha-,format=short,enable=${{ github.event_name != 'workflow_dispatch' || inputs.version == '' }}
             type=semver,pattern={{version}},match=^relay-v(.*)$,value=${{ inputs.version }}
             type=semver,pattern={{major}}.{{minor}},match=^relay-v(.*)$,value=${{ inputs.version }}
             type=semver,pattern={{major}},match=^relay-v(.*)$,value=${{ inputs.version }}
@@ -240,8 +240,8 @@ jobs:
           # value=${{ inputs.version }} carries the rescue-dispatch version,
           # and why :latest is left to flavor.latest=auto.
           tags: |
-            type=ref,event=branch
-            type=sha,prefix=sha-,format=short
+            type=ref,event=branch,enable=${{ github.event_name != 'workflow_dispatch' || inputs.version == '' }}
+            type=sha,prefix=sha-,format=short,enable=${{ github.event_name != 'workflow_dispatch' || inputs.version == '' }}
             type=semver,pattern={{version}},match=^relay-v(.*)$,value=${{ inputs.version }}
             type=semver,pattern={{major}}.{{minor}},match=^relay-v(.*)$,value=${{ inputs.version }}
             type=semver,pattern={{major}},match=^relay-v(.*)$,value=${{ inputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,9 +9,9 @@ name: Docker image
 # GitHub-hosted runners.
 #
 # Versioning: the relay is versioned independently of the desktop app via
-# its own `relay-v*` tags (see `just release-relay`). Desktop `v*` tags do
-# NOT publish this image — only `relay-v*` does, so the relay image version
-# tracks crates/buzz-relay/Cargo.toml, never desktop.
+# its own `relay-v*` tags (see `just release-relay`). Desktop `v*` tags and
+# agent `sprig-v*` tags do NOT publish this image — only `relay-v*` does, so
+# the relay image version tracks crates/buzz-relay/Cargo.toml, never desktop.
 #
 # Triggers:
 #   - push to main           → :main + :sha-<7>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -552,5 +552,5 @@ just mobile-dev
 - [CONTRIBUTING.md](CONTRIBUTING.md) — setup, code style, PR process, how to add event kinds / CLI subcommands / API endpoints
 - [TESTING.md](TESTING.md) — multi-agent E2E test guide
 - [ARCHITECTURE.md](ARCHITECTURE.md) — system design and component relationships
-- [RELEASING.md](RELEASING.md) — release process: `just release`, auto-tag, internal builds
+- [RELEASING.md](RELEASING.md) — release process: `release-desktop`, `release-relay`, `release-mobile`, auto-tag, internal builds
 - [README.md](README.md) — project overview and quick start

--- a/Justfile
+++ b/Justfile
@@ -439,6 +439,10 @@ check-compile:
 get-current-version:
     @node -p "require('./desktop/package.json').version"
 
+# Read the current relay version from its crate manifest
+get-current-relay-version:
+    @grep -m1 '^version = ' crates/buzz-relay/Cargo.toml | sed -E 's/version = "(.*)"/\1/'
+
 # Compute next minor version (e.g., 0.3.0 → 0.4.0)
 get-next-minor-version:
     @python3 -c "v='$(just get-current-version)'.split('.'); print(f'{v[0]}.{int(v[1])+1}.0')"
@@ -446,6 +450,18 @@ get-next-minor-version:
 # Compute next patch version (e.g., 0.3.0 → 0.3.1)
 get-next-patch-version:
     @python3 -c "v='$(just get-current-version)'.split('.'); print(f'{v[0]}.{v[1]}.{int(v[2])+1}')"
+
+# Compute next relay patch version (e.g., 0.3.0 → 0.3.1)
+get-next-relay-patch-version:
+    @python3 -c "v='$(just get-current-relay-version)'.split('.'); print(f'{v[0]}.{v[1]}.{int(v[2])+1}')"
+
+# Read the current mobile version from pubspec.yaml (strips the +build suffix)
+get-current-mobile-version:
+    @grep -m1 '^version: ' mobile/pubspec.yaml | sed -E 's/version: ([^+]*).*/\1/'
+
+# Compute next mobile patch version (e.g., 0.3.0 → 0.3.1)
+get-next-mobile-patch-version:
+    @python3 -c "v='$(just get-current-mobile-version)'.split('.'); print(f'{v[0]}.{v[1]}.{int(v[2])+1}')"
 
 # Update version in all package manifests and regenerate lockfiles
 bump-version version:
@@ -476,50 +492,131 @@ bump-version version:
         t = t.replace(/^version = \".*\"/m, 'version = \"{{ version }}\"');
         fs.writeFileSync(p, t);
     "
-    # mobile/pubspec.yaml — bump version but preserve build number
-    sed -i '' "s/^version: .*/version: {{ version }}+1/" mobile/pubspec.yaml
     # Regenerate lockfiles
     pnpm install --lockfile-only
     cargo update -p buzz-desktop --manifest-path desktop/src-tauri/Cargo.toml
-    (unset GIT_DIR GIT_WORK_TREE; cd mobile && flutter pub get)
-    echo "Bumped all manifests to {{ version }} and regenerated lockfiles"
+    echo "Bumped desktop manifests to {{ version }} and regenerated lockfiles"
 
-# Create or update a release PR that bumps version and generates changelog
-release *ARGS:
+# Bump the relay crate version and regenerate the lockfile
+bump-relay-version version:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Determine target version
+    if ! echo "{{ version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+        echo "Error: '{{ version }}' is not valid semver (expected X.Y.Z)"
+        exit 1
+    fi
+    # buzz-relay carries its own `version =` (not version.workspace), so the
+    # replace targets the package version line only.
+    sed -i '' -E "s/^version = \".*\"/version = \"{{ version }}\"/" crates/buzz-relay/Cargo.toml
+    cargo update -p buzz-relay
+    echo "Bumped buzz-relay to {{ version }} and regenerated Cargo.lock"
+
+# Bump the mobile pubspec version and regenerate the lockfile
+bump-mobile-version version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! echo "{{ version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+        echo "Error: '{{ version }}' is not valid semver (expected X.Y.Z)"
+        exit 1
+    fi
+    # pubspec carries a `version: X.Y.Z+build`; preserve the `+build` convention
+    # (a literal `+1`, matching the desktop lane's prior behavior).
+    sed -i '' "s/^version: .*/version: {{ version }}+1/" mobile/pubspec.yaml
+    (unset GIT_DIR GIT_WORK_TREE; cd mobile && flutter pub get)
+    echo "Bumped mobile to {{ version }} and regenerated pubspec.lock"
+
+# Open or update the desktop release PR (signed desktop app)
+release-desktop *ARGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
     ARG="{{ ARGS }}"
-    if [[ -z "$ARG" ]]; then
-        VERSION=$(just get-next-patch-version)
-    elif [[ "$ARG" == "patch" ]]; then
+    if [[ -z "$ARG" || "$ARG" == "patch" ]]; then
         VERSION=$(just get-next-patch-version)
     else
         VERSION="$ARG"
     fi
-    echo "Preparing release v${VERSION}..."
-    # Ensure on main branch
+    just _release-pr desktop "$VERSION"
+
+# Open or update the relay release PR (ghcr.io/block/buzz image)
+release-relay *ARGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ARG="{{ ARGS }}"
+    if [[ -z "$ARG" || "$ARG" == "patch" ]]; then
+        VERSION=$(just get-next-relay-patch-version)
+    else
+        VERSION="$ARG"
+    fi
+    just _release-pr relay "$VERSION"
+
+# Open or update the mobile release PR (Buzz mobile app)
+release-mobile *ARGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ARG="{{ ARGS }}"
+    if [[ -z "$ARG" || "$ARG" == "patch" ]]; then
+        VERSION=$(just get-next-mobile-patch-version)
+    else
+        VERSION="$ARG"
+    fi
+    just _release-pr mobile "$VERSION"
+
+# Shared release-PR engine. One body, three lanes — the only lane-specific steps
+# are the version-bump command and the file/tag/changelog identifiers selected
+# in the `case` below. Everything else (git preflight, branch reset, changelog
+# generation, commit, push, PR open/edit) is identical across lanes.
+_release-pr lane version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    VERSION="{{ version }}"
+    # Lane-specific identifiers. The bump command runs after the branch switch.
+    case "{{ lane }}" in
+        desktop)
+            BRANCH_PREFIX="version-bump"
+            TAG_MATCH='v[0-9]*'
+            TAG_PREFIX="v"
+            CHANGELOG="CHANGELOG.md"
+            ADD_FILES=(desktop/package.json desktop/src-tauri/tauri.conf.json desktop/src-tauri/Cargo.toml desktop/src-tauri/Cargo.lock pnpm-lock.yaml CHANGELOG.md)
+            ARTIFACT="Buzz Desktop" ;;
+        relay)
+            BRANCH_PREFIX="relay-release"
+            TAG_MATCH='relay-v[0-9]*'
+            TAG_PREFIX="relay-v"
+            CHANGELOG="crates/buzz-relay/CHANGELOG.md"
+            ADD_FILES=(crates/buzz-relay/Cargo.toml Cargo.lock crates/buzz-relay/CHANGELOG.md)
+            ARTIFACT="Buzz Relay" ;;
+        mobile)
+            BRANCH_PREFIX="mobile-release"
+            TAG_MATCH='mobile-v[0-9]*'
+            TAG_PREFIX="mobile-v"
+            CHANGELOG="mobile/CHANGELOG.md"
+            ADD_FILES=(mobile/pubspec.yaml mobile/pubspec.lock mobile/CHANGELOG.md)
+            ARTIFACT="Buzz Mobile" ;;
+        *)
+            echo "Error: unknown release lane '{{ lane }}'"
+            exit 1 ;;
+    esac
+    echo "Preparing ${ARTIFACT} release v${VERSION}..."
+    # Must run on main with a clean, up-to-date tree.
     CURRENT_BRANCH=$(git symbolic-ref --short HEAD)
     if [[ "$CURRENT_BRANCH" != "main" ]]; then
         echo "Error: must be on main branch (currently on '$CURRENT_BRANCH')"
         exit 1
     fi
-    # Ensure local main and release tags are up-to-date.
     git fetch origin refs/heads/main:refs/remotes/origin/main --no-tags
-    # Release tags are remote-owned state; sync only v* tags so stale local
-    # tags from older histories do not make release preflight fail.
-    git fetch origin '+refs/tags/v*:refs/tags/v*'
+    # Release tags are remote-owned state; sync only this lane's tags so stale
+    # local tags from older histories do not make release preflight fail.
+    git fetch origin "+refs/tags/${TAG_MATCH}:refs/tags/${TAG_MATCH}"
     if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
         echo "Error: local main is not up-to-date with origin/main. Run 'git pull' first."
         exit 1
     fi
-    # Ensure clean working tree
     if ! git diff --quiet || ! git diff --cached --quiet; then
         echo "Error: working tree is dirty. Commit or stash changes first."
         exit 1
     fi
-    # Switch to version-bump branch (create if needed, reset to main if it exists)
-    BRANCH="version-bump/${VERSION}"
+    # Switch to the release branch (create, or reset to main if it exists).
+    BRANCH="${BRANCH_PREFIX}/${VERSION}"
     if git rev-parse --verify "refs/heads/$BRANCH" >/dev/null 2>&1; then
         echo "Branch '$BRANCH' already exists — resetting to origin/main..."
         git switch "$BRANCH"
@@ -531,10 +628,14 @@ release *ARGS:
     else
         git switch -c "$BRANCH"
     fi
-    # Bump versions and lockfiles
-    just bump-version "$VERSION"
-    # Generate changelog
-    LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' 2>/dev/null || echo "")
+    # Lane-specific bump (the one diverging step).
+    case "{{ lane }}" in
+        desktop) just bump-version "$VERSION" ;;
+        relay)   just bump-relay-version "$VERSION" ;;
+        mobile)  just bump-mobile-version "$VERSION" ;;
+    esac
+    # Generate the changelog from commits since this lane's last release tag.
+    LAST_TAG=$(git describe --tags --abbrev=0 --match "$TAG_MATCH" --exclude '*-*' 2>/dev/null || echo "")
     REPO=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
     format_log() {
         local range="$1"
@@ -555,7 +656,7 @@ release *ARGS:
     {
         echo "# Changelog"
         echo ""
-        echo "## v${VERSION}"
+        echo "## ${TAG_PREFIX}${VERSION}"
         echo ""
         if [[ -n "$LAST_TAG" ]]; then
             format_log "${LAST_TAG}..HEAD"
@@ -563,31 +664,23 @@ release *ARGS:
             echo "- Initial release"
         fi
         echo ""
-        if [[ -f CHANGELOG.md ]]; then
-            tail -n +2 CHANGELOG.md
+        if [[ -f "$CHANGELOG" ]]; then
+            tail -n +2 "$CHANGELOG"
         fi
     } > "$TMPFILE"
-    mv "$TMPFILE" CHANGELOG.md
-    # Commit
-    git add \
-      desktop/package.json \
-      desktop/src-tauri/tauri.conf.json \
-      desktop/src-tauri/Cargo.toml \
-      desktop/src-tauri/Cargo.lock \
-      mobile/pubspec.yaml \
-      mobile/pubspec.lock \
-      pnpm-lock.yaml \
-      CHANGELOG.md
-    RELEASE_MSG="chore(release): release version ${VERSION}"
+    mkdir -p "$(dirname "$CHANGELOG")"
+    mv "$TMPFILE" "$CHANGELOG"
+    # Commit.
+    git add "${ADD_FILES[@]}"
+    RELEASE_MSG="chore(release): release ${ARTIFACT} version ${VERSION}"
     if [[ "$(git log -1 --format='%s' 2>/dev/null)" == "$RELEASE_MSG" ]]; then
         git commit --amend --no-edit
     else
         git commit -m "$RELEASE_MSG"
     fi
-    # Push and open PR
+    # Push and open/update the PR.
     git push --force-with-lease -u origin "$BRANCH"
-    # Build PR body
-    PR_BODY="## Release v${VERSION}"$'\n\n'
+    PR_BODY="## ${ARTIFACT} release v${VERSION}"$'\n\n'
     if [[ -n "$LAST_TAG" ]]; then
         PR_BODY+="### Changes since ${LAST_TAG}:"$'\n\n'
         PR_BODY+="$(format_log "${LAST_TAG}..HEAD~1")"$'\n\n'
@@ -595,18 +688,15 @@ release *ARGS:
         PR_BODY+="Initial release."$'\n\n'
     fi
     PR_BODY+="**To release:** merge this PR. The tag and build will happen automatically."
+    PR_TITLE="chore(release): release ${ARTIFACT} version ${VERSION}"
     EXISTING_PR=$(gh pr list --head "$BRANCH" --json url --jq '.[0].url' 2>/dev/null || true)
     if [[ -n "$EXISTING_PR" ]]; then
-        gh pr edit "$BRANCH" \
-            --title "chore(release): release version ${VERSION}" \
-            --body "$PR_BODY"
+        gh pr edit "$BRANCH" --title "$PR_TITLE" --body "$PR_BODY"
         PR_URL="$EXISTING_PR"
         echo ""
         echo "Updated existing release PR: ${PR_URL}"
     else
-        PR_URL=$(gh pr create \
-            --title "chore(release): release version ${VERSION}" \
-            --body "$PR_BODY")
+        PR_URL=$(gh pr create --title "$PR_TITLE" --body "$PR_BODY")
         echo ""
         echo "Release PR opened: ${PR_URL}"
     fi

--- a/Justfile
+++ b/Justfile
@@ -498,7 +498,7 @@ bump-relay-version version:
     set -euo pipefail
     # buzz-relay carries its own `version =` (not version.workspace), so the
     # replace targets the package version line only.
-    sed -i '' -E "s/^version = \".*\"/version = \"{{ version }}\"/" crates/buzz-relay/Cargo.toml
+    perl -i -pe 's/^version = ".*"/version = "{{ version }}"/' crates/buzz-relay/Cargo.toml
     cargo update -p buzz-relay
     echo "Bumped buzz-relay to {{ version }} and regenerated Cargo.lock"
 
@@ -508,7 +508,7 @@ bump-mobile-version version:
     set -euo pipefail
     # pubspec carries a `version: X.Y.Z+build`; preserve the `+build` convention
     # (a literal `+1`, matching the desktop lane's prior behavior).
-    sed -i '' "s/^version: .*/version: {{ version }}+1/" mobile/pubspec.yaml
+    perl -i -pe 's/^version: .*/version: {{ version }}+1/' mobile/pubspec.yaml
     (unset GIT_DIR GIT_WORK_TREE; cd mobile && flutter pub get)
     echo "Bumped mobile to {{ version }} and regenerated pubspec.lock"
 
@@ -566,6 +566,7 @@ _release-pr lane version:
             BRANCH_PREFIX="version-bump"
             TAG_FETCH='v*'
             TAG_MATCH='v[0-9]*'
+            TAG_EXCLUDE='*-*'
             TAG_PREFIX="v"
             CHANGELOG="CHANGELOG.md"
             ADD_FILES=(desktop/package.json desktop/src-tauri/tauri.conf.json desktop/src-tauri/Cargo.toml desktop/src-tauri/Cargo.lock pnpm-lock.yaml CHANGELOG.md)
@@ -574,6 +575,7 @@ _release-pr lane version:
             BRANCH_PREFIX="relay-release"
             TAG_FETCH='relay-v*'
             TAG_MATCH='relay-v[0-9]*'
+            TAG_EXCLUDE='relay-v*-*'
             TAG_PREFIX="relay-v"
             CHANGELOG="crates/buzz-relay/CHANGELOG.md"
             ADD_FILES=(crates/buzz-relay/Cargo.toml Cargo.lock crates/buzz-relay/CHANGELOG.md)
@@ -582,6 +584,7 @@ _release-pr lane version:
             BRANCH_PREFIX="mobile-release"
             TAG_FETCH='mobile-v*'
             TAG_MATCH='mobile-v[0-9]*'
+            TAG_EXCLUDE='mobile-v*-*'
             TAG_PREFIX="mobile-v"
             CHANGELOG="mobile/CHANGELOG.md"
             ADD_FILES=(mobile/pubspec.yaml mobile/pubspec.lock mobile/CHANGELOG.md)
@@ -629,7 +632,7 @@ _release-pr lane version:
         mobile)  just bump-mobile-version "$VERSION" ;;
     esac
     # Generate the changelog from commits since this lane's last release tag.
-    LAST_TAG=$(git describe --tags --abbrev=0 --match "$TAG_MATCH" --exclude '*-*' 2>/dev/null || echo "")
+    LAST_TAG=$(git describe --tags --abbrev=0 --match "$TAG_MATCH" --exclude "$TAG_EXCLUDE" 2>/dev/null || echo "")
     REPO=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')
     format_log() {
         local range="$1"

--- a/Justfile
+++ b/Justfile
@@ -463,15 +463,10 @@ get-current-mobile-version:
 get-next-mobile-patch-version:
     @python3 -c "v='$(just get-current-mobile-version)'.split('.'); print(f'{v[0]}.{v[1]}.{int(v[2])+1}')"
 
-# Update version in all package manifests and regenerate lockfiles
-bump-version version:
+# Update version in desktop package manifests and regenerate lockfiles
+bump-desktop-version version:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Validate semver format
-    if ! echo "{{ version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
-        echo "Error: '{{ version }}' is not valid semver (expected X.Y.Z)"
-        exit 1
-    fi
     # desktop/package.json
     cd desktop && npm pkg set "version={{ version }}" && cd ..
     # desktop/src-tauri/tauri.conf.json
@@ -501,10 +496,6 @@ bump-version version:
 bump-relay-version version:
     #!/usr/bin/env bash
     set -euo pipefail
-    if ! echo "{{ version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
-        echo "Error: '{{ version }}' is not valid semver (expected X.Y.Z)"
-        exit 1
-    fi
     # buzz-relay carries its own `version =` (not version.workspace), so the
     # replace targets the package version line only.
     sed -i '' -E "s/^version = \".*\"/version = \"{{ version }}\"/" crates/buzz-relay/Cargo.toml
@@ -515,10 +506,6 @@ bump-relay-version version:
 bump-mobile-version version:
     #!/usr/bin/env bash
     set -euo pipefail
-    if ! echo "{{ version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
-        echo "Error: '{{ version }}' is not valid semver (expected X.Y.Z)"
-        exit 1
-    fi
     # pubspec carries a `version: X.Y.Z+build`; preserve the `+build` convention
     # (a literal `+1`, matching the desktop lane's prior behavior).
     sed -i '' "s/^version: .*/version: {{ version }}+1/" mobile/pubspec.yaml
@@ -569,10 +556,15 @@ _release-pr lane version:
     #!/usr/bin/env bash
     set -euo pipefail
     VERSION="{{ version }}"
+    if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+        echo "Error: '$VERSION' is not valid semver (expected X.Y.Z)"
+        exit 1
+    fi
     # Lane-specific identifiers. The bump command runs after the branch switch.
     case "{{ lane }}" in
         desktop)
             BRANCH_PREFIX="version-bump"
+            TAG_FETCH='v*'
             TAG_MATCH='v[0-9]*'
             TAG_PREFIX="v"
             CHANGELOG="CHANGELOG.md"
@@ -580,6 +572,7 @@ _release-pr lane version:
             ARTIFACT="Buzz Desktop" ;;
         relay)
             BRANCH_PREFIX="relay-release"
+            TAG_FETCH='relay-v*'
             TAG_MATCH='relay-v[0-9]*'
             TAG_PREFIX="relay-v"
             CHANGELOG="crates/buzz-relay/CHANGELOG.md"
@@ -587,6 +580,7 @@ _release-pr lane version:
             ARTIFACT="Buzz Relay" ;;
         mobile)
             BRANCH_PREFIX="mobile-release"
+            TAG_FETCH='mobile-v*'
             TAG_MATCH='mobile-v[0-9]*'
             TAG_PREFIX="mobile-v"
             CHANGELOG="mobile/CHANGELOG.md"
@@ -606,7 +600,7 @@ _release-pr lane version:
     git fetch origin refs/heads/main:refs/remotes/origin/main --no-tags
     # Release tags are remote-owned state; sync only this lane's tags so stale
     # local tags from older histories do not make release preflight fail.
-    git fetch origin "+refs/tags/${TAG_MATCH}:refs/tags/${TAG_MATCH}"
+    git fetch origin "+refs/tags/${TAG_FETCH}:refs/tags/${TAG_FETCH}"
     if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
         echo "Error: local main is not up-to-date with origin/main. Run 'git pull' first."
         exit 1
@@ -630,7 +624,7 @@ _release-pr lane version:
     fi
     # Lane-specific bump (the one diverging step).
     case "{{ lane }}" in
-        desktop) just bump-version "$VERSION" ;;
+        desktop) just bump-desktop-version "$VERSION" ;;
         relay)   just bump-relay-version "$VERSION" ;;
         mobile)  just bump-mobile-version "$VERSION" ;;
     esac

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,60 +1,145 @@
-# Releasing Buzz Desktop
+# Releasing Buzz
+
+Buzz has three independent release lanes, each driven by a release PR — no human
+ever pushes a git tag:
+
+| Lane | Recipe | Artifact |
+|------|--------|----------|
+| Desktop | `just release-desktop` | Signed desktop app (macOS/Linux) |
+| Relay | `just release-relay` | `ghcr.io/block/buzz` container image |
+| Mobile | `just release-mobile` | Buzz mobile app (tag is the `sprout_ref` for the internal build) |
+
+The three lanes version independently: the desktop version lives in
+`desktop/package.json`, the relay version in `crates/buzz-relay/Cargo.toml`, and
+the mobile version in `mobile/pubspec.yaml`.
+
+The mobile lane publishes a `mobile-v<version>` tag that is consumed
+**manually**, cross-repo, as the `sprout_ref` input to the internal
+`buzz-releases` Buildkite pipeline (iOS dogfood → Block Comp Portal, App Store →
+TestFlight — see [Internal Releases](#internal-releases)). The OSS lane is
+tag-only **by design**: OSS `block/buzz` CI cannot trigger CI in the private
+`buzz-releases` repo (infosec), so a human cuts the internal build from the tag
+rather than auto-dispatching across that boundary.
 
 ## Quick Start
 
 ```sh
-# Regular release (next patch version)
-just release
+# Desktop release (next patch version)
+just release-desktop
 
-# Patch release
-just release patch
+# Desktop patch / minor / explicit
+just release-desktop patch
+just release-desktop 0.4.0
+just release-desktop 1.0.0
 
-# Minor release
-just release 0.4.0
+# Relay release (same argument forms)
+just release-relay
+just release-relay 0.4.0
 
-# Any explicit version
-just release 1.0.0
+# Mobile release (same argument forms)
+just release-mobile
+just release-mobile 0.4.0
 ```
 
-This creates a `version-bump/<version>` PR that bumps all version manifests, regenerates lockfiles, and appends a changelog entry. Merge the PR to trigger the build automatically.
+`just release-desktop` creates a `version-bump/<version>` PR; `just
+release-relay` creates a `relay-release/<version>` PR; `just release-mobile`
+creates a `mobile-release/<version>` PR. Each bumps its own version manifest,
+regenerates lockfiles, and appends a changelog entry. Merge the PR to trigger
+the build automatically (the mobile tag is instead the `sprout_ref` a human
+feeds the internal build — see above).
 
-Re-running `just release` with the same version is safe — it detects the existing branch and PR, resets to current `main`, regenerates the changelog with any new commits, and updates the PR in place.
+Re-running any of these recipes with the same version is safe — it detects the
+existing branch and PR, resets to current `main`, regenerates the changelog
+with any new commits, and updates the PR in place.
 
 ---
 
 ## How It Works
 
-1. **`just release`** runs locally on `main` — computes the next version, creates (or reuses) a `version-bump/<version>` branch, bumps versions in all manifests, regenerates lockfiles, generates a changelog entry, commits, pushes, and opens (or updates) a PR.
+All three lanes share one engine; they differ only in which version manifest
+they bump, which branch prefix they use, and what the merge triggers.
 
-2. **Merge the PR** — the `auto-tag-on-release-pr-merge` workflow detects the `version-bump/*` branch merge and pushes a `v<version>` tag.
+### Desktop
 
-3. **Tag triggers `release.yml`** — the existing release workflow builds, signs, notarizes, and publishes the desktop app for macOS and Linux.
+1. **`just release-desktop`** runs locally on `main` — computes the next
+   version, creates (or reuses) a `version-bump/<version>` branch, bumps the
+   desktop manifests, regenerates lockfiles, generates a changelog
+   entry in `CHANGELOG.md`, commits, pushes, and opens (or updates) a PR.
+2. **Merge the PR** — the `auto-tag-on-release-pr-merge` workflow detects the
+   `version-bump/*` branch merge and pushes a `v<version>` tag.
+3. **Tag triggers `release.yml`** — builds, signs, notarizes, and publishes the
+   desktop app for macOS and Linux.
+
+### Relay
+
+1. **`just release-relay`** runs locally on `main` — computes the next relay
+   version, creates (or reuses) a `relay-release/<version>` branch, bumps
+   `crates/buzz-relay/Cargo.toml`, regenerates `Cargo.lock`, generates a
+   changelog entry in `crates/buzz-relay/CHANGELOG.md`, commits, pushes, and
+   opens (or updates) a PR.
+2. **Merge the PR** — the `auto-tag-on-release-pr-merge` workflow detects the
+   `relay-release/*` branch merge and pushes a `relay-v<version>` tag.
+3. **Auto-tag dispatches `docker.yml`** — the same workflow then triggers
+   `docker.yml` with the version and tag ref, which builds the multi-arch relay
+   image and publishes `ghcr.io/block/buzz:<version>` (plus `:<major>.<minor>`,
+   `:<major>`, and `:latest` for stable releases). Prereleases
+   (`relay-v<version>-rc.1`) publish only the prerelease tag and do **not**
+   move `:latest`. (The dispatch — rather than relying on `docker.yml`'s
+   `push: tags` trigger — is required because GitHub suppresses `on: push` for
+   tags pushed by the workflow's own `GITHUB_TOKEN`; the desktop lane dispatches
+   `release.yml` for the same reason.)
+
+### Mobile
+
+1. **`just release-mobile`** runs locally on `main` — computes the next mobile
+   version, creates (or reuses) a `mobile-release/<version>` branch, bumps
+   `mobile/pubspec.yaml` (preserving the `+build` number), regenerates
+   `mobile/pubspec.lock`, generates a changelog entry in `mobile/CHANGELOG.md`,
+   commits, pushes, and opens (or updates) a PR.
+2. **Merge the PR** — the `auto-tag-on-release-pr-merge` workflow detects the
+   `mobile-release/*` branch merge and pushes a `mobile-v<version>` tag.
+3. **The tag is consumed manually, cross-repo** — nothing in OSS `block/buzz`
+   builds on the tag (OSS CI must not trigger CI in the private `buzz-releases`
+   repo — infosec). A human feeds the `mobile-v<version>` tag as the
+   `sprout_ref` input to the internal `buzz-releases` Buildkite pipeline, which
+   builds and ships iOS to Block Comp Portal (dogfood) and TestFlight (App
+   Store, opt-in). See [Internal Releases](#internal-releases).
 
 ---
 
 ## Release Types
 
+The argument forms below apply to `release-desktop`, `release-relay`, and
+`release-mobile`:
+
 | Command | Version | Example |
 |---------|---------|---------|
-| `just release` | Next patch | `0.3.0` → `0.3.1` |
-| `just release patch` | Next patch | `0.3.0` → `0.3.1` |
-| `just release 0.4.0` | Explicit minor | `0.3.1` → `0.4.0` |
-| `just release 1.0.0` | Explicit | `1.0.0` |
+| `just release-desktop` | Next patch | `0.3.0` → `0.3.1` |
+| `just release-desktop patch` | Next patch | `0.3.0` → `0.3.1` |
+| `just release-desktop 0.4.0` | Explicit minor | `0.3.1` → `0.4.0` |
+| `just release-desktop 1.0.0` | Explicit | `1.0.0` |
 
 ---
 
 ## Version Files
 
-`just bump-version <version>` updates these files:
+`just bump-version <version>` (desktop lane) updates these files:
 
 | File | Field |
 |------|-------|
 | `desktop/package.json` | `"version"` |
 | `desktop/src-tauri/tauri.conf.json` | `"version"` |
 | `desktop/src-tauri/Cargo.toml` | `version` (under `[package]`) |
-| `mobile/pubspec.yaml` | `version:` (preserves build number) |
 
-It also regenerates `pnpm-lock.yaml`, `desktop/src-tauri/Cargo.lock`, and `mobile/pubspec.lock`.
+It also regenerates `pnpm-lock.yaml` and `desktop/src-tauri/Cargo.lock`.
+
+`just bump-relay-version <version>` (relay lane) updates
+`crates/buzz-relay/Cargo.toml` (`version` under `[package]`) and regenerates the
+workspace `Cargo.lock`.
+
+`just bump-mobile-version <version>` (mobile lane) updates
+`mobile/pubspec.yaml` (`version:`, preserving the `+build` number) and
+regenerates `mobile/pubspec.lock`.
 
 ---
 
@@ -116,14 +201,14 @@ the same `v<version>` release. Intel users download the `_x64.dmg`.
 
 ## Troubleshooting
 
-### `just release` fails with "must be on main branch"
-Switch to `main` and pull latest before running `just release`.
+### `just release-desktop` fails with "must be on main branch"
+Switch to `main` and pull latest before running the release recipe.
 
-### `just release` fails with "working tree is dirty"
-Commit or stash your changes before running `just release`.
+### `just release-desktop` fails with "working tree is dirty"
+Commit or stash your changes before running the release recipe.
 
 ### New commits merged after creating the release PR
-Re-run `just release` from an up-to-date `main`. It resets the branch to current `main`, regenerates the changelog and PR body to include the new commits, and force-pushes the updated branch.
+Re-run the release recipe (`just release-desktop`, `just release-relay`, or `just release-mobile`) from an up-to-date `main`. It resets the branch to current `main`, regenerates the changelog and PR body to include the new commits, and force-pushes the updated branch.
 
 ### Build fails at "Validate version"
 The version string must be valid semver: `MAJOR.MINOR.PATCH` with an optional pre-release suffix. Do not include a `v` prefix.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,6 +89,10 @@ they bump, which branch prefix they use, and what the merge triggers.
    tags pushed by the workflow's own `GITHUB_TOKEN`; the desktop lane dispatches
    `release.yml` for the same reason.)
 
+Every push to `main` continues to build and publish `:main` + `:sha-<7>` tags
+(the rolling development image). The `:latest` tag tracks the latest **stable**
+relay release only — it does not move on main pushes or prereleases.
+
 ### Mobile
 
 1. **`just release-mobile`** runs locally on `main` — computes the next mobile
@@ -123,7 +127,7 @@ The argument forms below apply to `release-desktop`, `release-relay`, and
 
 ## Version Files
 
-`just bump-version <version>` (desktop lane) updates these files:
+`just bump-desktop-version <version>` (desktop lane) updates these files:
 
 | File | Field |
 |------|-------|

--- a/crates/buzz-relay/Cargo.toml
+++ b/crates/buzz-relay/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "buzz-relay"
 default-run = "buzz-relay"
-version.workspace = true
+# Independent version: buzz-relay ships as a pinnable artifact
+# (ghcr.io/block/buzz), released on its own cadence via `just release-relay`.
+# It does NOT inherit the workspace version.
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/sprig/Cargo.toml
+++ b/crates/sprig/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "sprig"
-version.workspace = true
+# Independent version: sprig ships as a pinnable artifact (sprig-v* tags),
+# released on its own cadence. It does NOT inherit the workspace version.
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/sprig/Cargo.toml
+++ b/crates/sprig/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "sprig"
-# Independent version: sprig ships as a pinnable artifact (sprig-v* tags),
-# released on its own cadence. It does NOT inherit the workspace version.
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Problem

`ghcr.io/block/buzz` had no pinnable versioned tags — only `:main` and `:latest`. The relay image had no versioning scheme of its own: `docker.yml` triggered on the desktop app's `v*` tags, so a desktop release republished the relay image stamped with the desktop semver. Anyone pinning a relay version got a number that tracked desktop, not the relay, and `:latest` could be moved by a non-release main push.

Mobile was welded to desktop the same way: `mobile/pubspec.yaml` bumped in lockstep inside the desktop release lane, so mobile could not version or ship on its own cadence.

## Design

Give the relay and mobile their own independent semver on PR-driven release lanes, decoupled from the desktop cadence. No human ever pushes a tag. The three lanes share one private `_release-pr` engine and differ only in a per-lane `case` (branch prefix, tag glob, changelog path, add-files, artifact label) plus the bump step — a new lane is one more `case` arm, never a fork.

- **Version split** — `crates/buzz-relay` and `crates/sprig` declare their own `version = "0.1.0"` (split off `version.workspace`), so each pinnable artifact carries an independent semver. The ~20 internal libs keep inheriting the workspace version; the root `[workspace.package].version` is unchanged. Mobile versions in `mobile/pubspec.yaml`.
- **Release lanes** — `just release` is renamed to `just release-desktop` (now desktop-only); `just release-relay` opens a `relay-release/<v>` PR; `just release-mobile` opens a `mobile-release/<v>` PR. The desktop lane no longer bumps the mobile manifests. `bump-version` is renamed to `bump-desktop-version` for consistency with `bump-relay-version` / `bump-mobile-version`. `RELEASING.md` documents all three lanes.
- **Tagging** — merging a release PR makes `auto-tag` push the lane's tag (`v<v>` / `relay-v<v>` / `mobile-v<v>`). The three tag namespaces are mutually disjoint by anchored globs.
- **Build dispatch** — `auto-tag` pushes tags with the default `GITHUB_TOKEN`, and GitHub's recursion guard suppresses `on: push` for any ref pushed with that token. So `docker.yml`'s and `release.yml`'s `push: tags` triggers are dead for release tags. Both the desktop and relay lanes therefore *dispatch* their build workflow (`auto-tag` runs `release.yml` / `docker.yml` with the bare version + tag ref); without the dispatch a relay release would push `relay-v*` and publish no image. `docker.yml` gains optional `workflow_dispatch` `version`/`ref` inputs: the build job pins its checkout to `inputs.ref` on dispatch, and the `type=semver` lines carry `value=${{ inputs.version }}` alongside `match=^relay-v(.*)$`. On a real push `value=` is empty and the ref drives it (match strips `relay-v`); on dispatch `value=` supplies the already-bare version (match no-ops). The `push: tags: relay-v*` trigger stays so a human-pushed relay tag still builds — the two paths never overlap (auto-pushed tags only dispatch; human-pushed tags only fire push), so a tag never double-builds.
- **Rolling main images preserved** — every push to `main` continues to build and publish `:main` + `:sha-<7>` tags exactly as before.
- **`:latest` behavior change** — previously `:latest` moved on every push to `main` (via `type=raw,value=latest,enable={{is_default_branch}}`). Now it is governed solely by `flavor.latest=auto`: only the latest *stable* `relay-v*` moves `:latest`. Prereleases (`relay-v*-rc.1`) and main pushes never do. This is intentional — `:latest` should track the latest release, not the latest commit.
- **Mobile tag is consumed manually, cross-repo** — the `mobile-v*` tag is the `sprout_ref` a human feeds the existing manual `buzz-releases` Buildkite pipeline, which builds and ships iOS to Block Comp Portal (dogfood) and TestFlight (App Store, opt-in). The `auto-tag` mobile arm is push-only (no dispatch) **by infosec necessity**: OSS `block/buzz` CI must not trigger CI in the private `buzz-releases` repo, so auto-dispatch across that boundary is deliberately disallowed. This is the deliberate design, not an unbuilt follow-up.

The relay also now reports its own version over NIP-11 (`env!("CARGO_PKG_VERSION")`) instead of the workspace default.

Supersedes and folds in #1154 (which patched the desktop-tag `docker.yml` trigger via the same dispatch rescue, retargeted here to `relay-v*`). #1154 can be closed once this merges.