### PR TITLE
[codex] Stabilize desktop E2E flakes

### DIFF
--- a/desktop/src/features/messages/ui/useAnchoredScroll.ts
+++ b/desktop/src/features/messages/ui/useAnchoredScroll.ts
@@ -410,6 +410,11 @@ export function useAnchoredScroll({
     const prevCount = prevMessageCountRef.current;
     const newLatestArrived =
       lastMessage !== undefined && lastMessage.id !== prevLastId;
+    // Count growth, not tail-id change, is the reliable "messages arrived"
+    // signal. The relay can deliver a message that sorts ahead of an existing
+    // same-second row, so the list grows without the *last* id changing —
+    // `newLatestArrived` misses that case and the unread counter never bumps.
+    const messagesArrived = messages.length - prevCount;
 
     // One-shot: an outbound send armed `scrollToBottomOnNextUpdate`. When the
     // resulting append lands, snap to bottom regardless of the current anchor,
@@ -441,9 +446,8 @@ export function useAnchoredScroll({
         setIsAtBottom(true);
       }
 
-      if (newLatestArrived) {
-        const added = Math.max(1, messages.length - prevCount);
-        setNewMessageCount((current) => current + added);
+      if (messagesArrived > 0) {
+        setNewMessageCount((current) => current + messagesArrived);
       }
     }
 

--- a/desktop/src/features/notifications/use-feed-desktop-notifications.ts
+++ b/desktop/src/features/notifications/use-feed-desktop-notifications.ts
@@ -79,10 +79,12 @@ export function useFeedDesktopNotifications(
   const seenItemIdsRef = React.useRef<Set<string>>(
     new Set(readStoredSeenFeedIds(normalizedPubkey)),
   );
+  const hasInitializedFeedRef = React.useRef(false);
   const hasAutoRequestedRef = React.useRef(false);
 
   React.useEffect(() => {
     seenItemIdsRef.current = new Set(readStoredSeenFeedIds(normalizedPubkey));
+    hasInitializedFeedRef.current = false;
     hasAutoRequestedRef.current = false;
   }, [normalizedPubkey]);
 
@@ -133,21 +135,23 @@ export function useFeedDesktopNotifications(
       return;
     }
 
+    const currentFeedItems = collectHomeAlertItems(feed);
+
     // Wait for sender profiles to load so notification titles include names.
-    // The first-load seed below marks all current items as seen, so we must
-    // defer it until profiles are available — otherwise items get marked seen
-    // before we can dispatch notifications with sender names.
-    if (profiles === undefined) {
+    // Empty feeds do not need profiles; marking them initialized here keeps the
+    // first later live alert from being mistaken for initial-load backlog.
+    if (profiles === undefined && currentFeedItems.length > 0) {
       return;
     }
 
-    const currentFeedItems = collectHomeAlertItems(feed);
-
-    // Guard: empty seen set + populated feed means first load or cleared
-    // storage. Seed the seen set without notifying to prevent a flood.
-    if (seenItemIdsRef.current.size === 0 && currentFeedItems.length > 0) {
-      seenItemIdsRef.current = new Set(currentFeedItems.map((item) => item.id));
-      writeStoredSeenFeedIds(normalizedPubkey, [...seenItemIdsRef.current]);
+    if (!hasInitializedFeedRef.current) {
+      hasInitializedFeedRef.current = true;
+      if (currentFeedItems.length > 0) {
+        seenItemIdsRef.current = new Set(
+          currentFeedItems.map((item) => item.id),
+        );
+        writeStoredSeenFeedIds(normalizedPubkey, [...seenItemIdsRef.current]);
+      }
       return;
     }
 

--- a/desktop/tests/e2e/custom-emoji-screenshots.spec.ts
+++ b/desktop/tests/e2e/custom-emoji-screenshots.spec.ts
@@ -97,20 +97,35 @@ test("message list renders inline and emoji-only messages with Slack-style emoji
   const emojiOnlyRow = rows
     .filter({
       has: page.locator(`img[data-custom-emoji][alt=":${SHORTCODE}:"]`),
+      hasText: "😀 ❤️",
     })
-    .last();
+    .first();
 
   await expect(inlineRow).toBeVisible();
   await expect(emojiOnlyRow).toBeVisible();
 
-  const inlineBox = await inlineRow
-    .locator(`img[data-custom-emoji][alt=":${SHORTCODE}:"]`)
-    .boundingBox();
-  const emojiOnlyBox = await emojiOnlyRow
-    .locator(`img[data-custom-emoji][alt=":${SHORTCODE}:"]`)
-    .boundingBox();
-  expect(inlineBox?.height).toBeGreaterThan(10);
-  expect(emojiOnlyBox?.height).toBeGreaterThan((inlineBox?.height ?? 0) * 1.8);
+  const inlineEmoji = inlineRow.locator(
+    `img[data-custom-emoji][alt=":${SHORTCODE}:"]`,
+  );
+  const emojiOnlyEmoji = emojiOnlyRow.locator(
+    `img[data-custom-emoji][alt=":${SHORTCODE}:"]`,
+  );
+
+  await expect
+    .poll(async () => (await inlineEmoji.boundingBox())?.height ?? 0)
+    .toBeGreaterThan(10);
+  await expect
+    .poll(async () => {
+      const inlineBox = await inlineEmoji.boundingBox();
+      const emojiOnlyBox = await emojiOnlyEmoji.boundingBox();
+
+      if (!inlineBox || !emojiOnlyBox || inlineBox.height === 0) {
+        return 0;
+      }
+
+      return emojiOnlyBox.height / inlineBox.height;
+    })
+    .toBeGreaterThan(1.8);
 
   await page.screenshot({
     path: `${SHOTS}/03-message-list-emoji-sizing.png`,

--- a/desktop/tests/e2e/integration.spec.ts
+++ b/desktop/tests/e2e/integration.spec.ts
@@ -158,6 +158,13 @@ async function getLoggedNotificationCount(
   return (await getLoggedNotifications(page)).length;
 }
 
+async function expectLoggedNotifications(
+  page: import("@playwright/test").Page,
+  expected: Array<{ body: string | null; title: string }>,
+) {
+  await expect.poll(() => getLoggedNotifications(page)).toEqual(expected);
+}
+
 test.beforeAll(async () => {
   test.setTimeout(relaySeedHookTimeoutMs);
   await assertRelaySeeded();
@@ -279,11 +286,7 @@ test("live mentions refetch the home feed without waiting for polling", async ({
       message,
     );
 
-    await expect.poll(() => getLoggedNotificationCount(targetPage)).toBe(1);
-
-    const notifications = await getLoggedNotifications(targetPage);
-
-    expect(notifications).toEqual([
+    await expectLoggedNotifications(targetPage, [
       {
         body: message,
         title: "alice mentioned you in #general",
@@ -341,11 +344,7 @@ test("live forum mentions refetch the home feed without waiting for polling", as
 
     await expect(targetPage.getByTestId("sidebar-home-count")).toHaveText("1");
 
-    await expect.poll(() => getLoggedNotificationCount(targetPage)).toBe(1);
-
-    const notifications = await getLoggedNotifications(targetPage);
-
-    expect(notifications).toEqual([
+    await expectLoggedNotifications(targetPage, [
       {
         body: message,
         title: "alice mentioned you in #watercooler",

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -293,11 +293,8 @@ async function expectWelcomeComposerBannerCompletesAfterPersonaMention(
   ).toBeVisible();
   await expect(banner).toContainText("Nice work.");
   await expect(banner).not.toContainText("Try mentioning");
-  await expect(banner).toHaveAttribute("data-state", "dismissing", {
-    timeout: 5_000,
-  });
   await expect(channelIntro).toBeVisible();
-  await expect(banner).toHaveCount(0, { timeout: 7_000 });
+  await expect(banner).toHaveCount(0, { timeout: 12_000 });
 }
 
 async function getMockChannels(page: Page) {

--- a/desktop/tests/e2e/stream.spec.ts
+++ b/desktop/tests/e2e/stream.spec.ts
@@ -89,6 +89,18 @@ async function sendChannelMessage(
     mentionPubkeys?: string[];
   },
 ) {
+  await page.waitForFunction(
+    () => {
+      const tauriWindow = window as Window & {
+        __TAURI_INTERNALS__?: { invoke?: unknown };
+      };
+
+      return typeof tauriWindow.__TAURI_INTERNALS__?.invoke === "function";
+    },
+    null,
+    { timeout: 5_000 },
+  );
+
   await page.evaluate(
     async ({ channelName: targetChannelName, content, mentionPubkeys }) => {
       const tauriWindow = window as Window & {
@@ -135,6 +147,14 @@ async function scrollTimelineAwayFromBottom(page: Page, minDistance = 160) {
     await page.mouse.wheel(0, -800);
     const metrics = await getTimelineMetrics(page);
     if (metrics.distanceFromBottom > minDistance) {
+      // The DOM scroll position is now off the bottom, but the timeline's
+      // `onScroll` handler updates the React "away from bottom" anchor state
+      // asynchronously. If a new message lands before that commit, the stale
+      // at-bottom anchor swallows it and the unread counter never increments.
+      // The scroll-to-latest pill only mounts once that state has committed,
+      // so waiting for it guarantees the anchor is in the away-from-bottom
+      // branch before callers send the message they expect to be counted.
+      await expect(page.getByTestId("message-scroll-to-latest")).toBeVisible();
       return;
     }
   }


### PR DESCRIPTION
## Summary

This hardens the desktop E2E failures seen on release PRs by addressing the flaky timing assumptions directly:

- Fix feed desktop notification initialization so an initially empty feed is marked initialized instead of treating the first later live alert as initial backlog.
- Poll for exact logged notification payloads in the live mention E2E cases instead of polling only the count and immediately reading stale state.
- Remove the onboarding test's dependency on the transient `dismissing` animation state and assert the durable complete/removed outcome.
- Anchor the custom emoji sizing check to the intended emoji-only row and poll layout measurements before comparing sizes.

## Validation

- `cd desktop && pnpm check`
- `cd desktop && pnpm build`
- `cd desktop && pnpm test`
- `cd desktop && pnpm exec playwright test --project=smoke tests/e2e/custom-emoji-screenshots.spec.ts --grep "message list renders inline"`
- `cd desktop && pnpm exec playwright test --project=integration tests/e2e/onboarding.spec.ts --grep "finishing onboarding creates"`
- `cd desktop && pnpm exec playwright test --project=integration tests/e2e/profile.spec.ts --grep "notification settings drive"`
- Pre-push hook: `desktop-test`, `rust-tests`, `mobile-test`, `desktop-tauri-test`