### PR TITLE
Sort direct messages alphabetically

### DIFF
--- a/desktop/src/features/sidebar/lib/dmSidebarSort.test.mjs
+++ b/desktop/src/features/sidebar/lib/dmSidebarSort.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sortDmChannelsByLabel } from "./dmSidebarSort.ts";
+
+function makeDm(id, name) {
+  return {
+    archivedAt: null,
+    channelType: "dm",
+    description: "",
+    id,
+    isMember: true,
+    lastMessageAt: null,
+    memberCount: 2,
+    memberPubkeys: [],
+    name,
+    participantPubkeys: [],
+    participants: [],
+    purpose: null,
+    topic: null,
+    ttlDeadline: null,
+    ttlSeconds: null,
+    visibility: "private",
+  };
+}
+
+test("sorts direct messages by resolved display label", () => {
+  const sorted = sortDmChannelsByLabel(
+    [
+      makeDm("c", "Group DM (3)"),
+      makeDm("a", "Group DM (3)"),
+      makeDm("b", "Group DM (3)"),
+    ],
+    {
+      a: "Fizz",
+      b: "Brain",
+      c: "Wes",
+    },
+  );
+
+  assert.deepEqual(
+    sorted.map((channel) => channel.id),
+    ["b", "a", "c"],
+  );
+});
+
+test("falls back to channel name until labels resolve", () => {
+  const sorted = sortDmChannelsByLabel(
+    [makeDm("b", "Zed"), makeDm("a", "Amy")],
+    {},
+  );
+
+  assert.deepEqual(
+    sorted.map((channel) => channel.id),
+    ["a", "b"],
+  );
+});
+
+test("uses channel id as a deterministic tie breaker", () => {
+  const sorted = sortDmChannelsByLabel(
+    [makeDm("b", "Group DM (3)"), makeDm("a", "Group DM (3)")],
+    {
+      a: "Wes",
+      b: "Wes",
+    },
+  );
+
+  assert.deepEqual(
+    sorted.map((channel) => channel.id),
+    ["a", "b"],
+  );
+});

--- a/desktop/src/features/sidebar/lib/dmSidebarSort.ts
+++ b/desktop/src/features/sidebar/lib/dmSidebarSort.ts
@@ -1,0 +1,14 @@
+import type { Channel } from "@/shared/api/types";
+
+export function sortDmChannelsByLabel(
+  channels: Channel[],
+  channelLabels: Record<string, string>,
+) {
+  return [...channels].sort((left, right) => {
+    const leftLabel = channelLabels[left.id] ?? left.name;
+    const rightLabel = channelLabels[right.id] ?? right.name;
+    return (
+      leftLabel.localeCompare(rightLabel) || left.id.localeCompare(right.id)
+    );
+  });
+}

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -21,6 +21,7 @@ import {
   type ChannelSection,
 } from "@/features/sidebar/lib/useChannelSections";
 import { useDmSidebarMetadata } from "@/features/sidebar/useDmSidebarMetadata";
+import { sortDmChannelsByLabel } from "@/features/sidebar/lib/dmSidebarSort";
 import { useSidebarScrollLock } from "@/features/sidebar/lib/useSidebarScrollLock";
 import { useUnreadOverflow } from "@/features/sidebar/lib/useUnreadOverflow";
 import {
@@ -458,6 +459,10 @@ export function AppSidebar({
       fallbackDisplayName,
       profileDisplayName: profile?.displayName,
     });
+  const sortedDirectMessages = React.useMemo(
+    () => sortDmChannelsByLabel(directMessages, dmChannelLabels),
+    [directMessages, dmChannelLabels],
+  );
   const sidebarLoadingShape = useSidebarLoadingShape({
     activeWorkspaceId: activeWorkspace?.id,
     currentPubkey,
@@ -787,7 +792,7 @@ export function AppSidebar({
                 dmParticipantsByChannelId={dmParticipantsByChannelId}
                 isCollapsed={collapsedGroups.directMessages}
                 isActiveChannel={selectedView === "channel"}
-                items={directMessages}
+                items={sortedDirectMessages}
                 channelLabels={dmChannelLabels}
                 onHideDm={onHideDm}
                 onMarkChannelRead={onMarkChannelRead}


### PR DESCRIPTION
## Summary
- Sort direct-message sidebar rows by the resolved display label shown to the user
- Fall back to channel name while profile labels are still loading
- Add deterministic channel-id tie-breaking plus unit coverage

## Tests
- `bin/pnpm --dir desktop test`
- `bin/pnpm --dir desktop typecheck`
- `bin/pnpm --dir desktop check`
- pre-push hook with `CMAKE_POLICY_VERSION_MINIMUM=3.5` (desktop-test, rust-tests, mobile-test, desktop-tauri-test all passed)

## Screenshots
Not attached: this is an ordering-only sidebar change, and I wasn’t able to capture a clean before/after quickly without spending time on a local app-state setup.
