### PR TITLE
fix(desktop): render lightbox image sharply at full resolution

### DIFF
--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -814,8 +814,21 @@ function ImageZoomOverlay({
   const isOpen = phase === "open";
   const isFading = phase === "fading";
   const displayBox = imageLightboxZoomBox(targetBox, zoom);
-  const transform =
-    prefersReducedMotion || isOpen
+  // Once fully settled at 1x, drop the transform to `none` so the wrapper
+  // leaves the GPU-composited path and the <img> repaints through WebKit's
+  // high-quality paint rasterizer — matching inline-image sharpness. An
+  // identity `translate3d` would keep it composited, so it must be `none`.
+  const atRest =
+    isOpen &&
+    hasEntered &&
+    zoom === IMAGE_LIGHTBOX_MIN_ZOOM &&
+    // Holds composited through the trackpad gesture-end idle window: after a
+    // pinch settles back to exactly 1x, `isAdjustingZoom` stays true for
+    // IMAGE_LIGHTBOX_TRACKPAD_ZOOM_IDLE_MS, avoiding a demote/re-promote thrash.
+    !isAdjustingZoom;
+  const transform = atRest
+    ? "none"
+    : prefersReducedMotion || isOpen
       ? imageLightboxTransform(targetBox, displayBox)
       : imageLightboxTransform(targetBox, sourceBox);
   const imageTransitionDuration = prefersReducedMotion
@@ -919,15 +932,22 @@ function ImageZoomOverlay({
         }}
       />
       <div
-        className="absolute z-10 origin-top-left overflow-visible transition-[opacity,transform] will-change-transform"
+        className={cn(
+          "absolute z-10 origin-top-left overflow-visible transition-[opacity,transform]",
+          // Only promote to a composited layer while animating; demoting at
+          // rest is what restores high-quality rasterization.
+          !atRest && "will-change-transform",
+        )}
         style={{
           ...imageLightboxStyle(targetBox),
           opacity: prefersReducedMotion && isClosing ? 0 : 1,
           transform,
           transitionDuration: `${imageTransitionDuration}ms`,
-          transitionProperty: prefersReducedMotion
-            ? "opacity"
-            : "opacity, transform",
+          // At rest, exclude `transform` from the transition so the swap to
+          // `none` is instantaneous — a transitioned transform-to-`none` is
+          // browser-inconsistent and can flash at the settle.
+          transitionProperty:
+            prefersReducedMotion || atRest ? "opacity" : "opacity, transform",
           transitionTimingFunction: isClosing
             ? IMAGE_LIGHTBOX_EASE_IN_OUT
             : IMAGE_LIGHTBOX_EASE_OUT,

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -816,8 +816,8 @@ function ImageZoomOverlay({
   const displayBox = imageLightboxZoomBox(targetBox, zoom);
   const transform =
     prefersReducedMotion || isOpen
-      ? imageLightboxTransform(sourceBox, displayBox)
-      : "translate3d(0, 0, 0) scale(1)";
+      ? imageLightboxTransform(targetBox, displayBox)
+      : imageLightboxTransform(targetBox, sourceBox);
   const imageTransitionDuration = prefersReducedMotion
     ? IMAGE_LIGHTBOX_REDUCED_MOTION_MS
     : isClosing
@@ -921,7 +921,7 @@ function ImageZoomOverlay({
       <div
         className="absolute z-10 origin-top-left overflow-visible transition-[opacity,transform] will-change-transform"
         style={{
-          ...imageLightboxStyle(sourceBox),
+          ...imageLightboxStyle(targetBox),
           opacity: prefersReducedMotion && isClosing ? 0 : 1,
           transform,
           transitionDuration: `${imageTransitionDuration}ms`,


### PR DESCRIPTION
Expanding a posted screenshot in the lightbox rendered it blurry — almost unreadable — even though the stored bytes are full resolution and the inline thumbnail is sharp. After the first fix the lightbox was much sharper but still slightly softer than the inline image on identical bytes.

## Problem

Two compositing-related defects degraded the lightbox `<img>`:

1. **Upscaled raster.** The `ImageZoomOverlay` wrapper was laid out at the inline `sourceBox` (~384px, the `max-w-sm` thumbnail footprint) and reached full-screen size only via a held composited `transform: scale(~5.3)`. WebKit rasterizes a composited `will-change-transform` layer at its layout size, so the overlay displayed the 384px raster GPU-upscaled — blurry the instant it opened, regardless of the full-res `src`.
2. **Composited-path softness at rest.** Even laid out at full size, the wrapper stays on a GPU-composited layer (it carries `will-change-transform` and `imageLightboxTransform` always emits a `translate3d` — both compositing triggers). WebKit's compositing rasterizer downsamples a large image at lower quality than its main paint path, so the settled lightbox stayed slightly softer than the inline `<img>`, which is never composited.

## Fix

**Full-resolution raster.** Lay the overlay wrapper out at the full `targetBox` so the `h-full w-full` `<img>` is laid out at full size and WebKit rasterizes the layer at full resolution. The open animation becomes a FLIP inverse transform: frame 0 is `imageLightboxTransform(targetBox, sourceBox)` (the full-size element scaled down to visually occupy the inline footprint), animating to identity at rest. Close reverses the same transform; the resize handler derives both layout and transform from `targetBox` so they recompute together.

**Demote at rest.** Once fully opened and at 1x zoom, set the wrapper `transform` to `none` (an identity `translate3d` would keep it composited) and drop `will-change-transform`, so the layer leaves the composited path and the `<img>` repaints through the high-quality rasterizer — matching inline-image sharpness. Compositing stays on through the open, close, and zoom animations. At the settle, `transform` is excluded from the transition so the swap to `none` is instantaneous and cannot animate into a flash.

Motion stays compositor-only throughout — no layout-property animation, no jank — and the open/close animation reads identically to before.
