### PR TITLE
feat(desktop): default temporary channels to 7-day expiry

### DIFF
--- a/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
@@ -68,7 +68,7 @@ type ChannelManagementSheetProps = {
   open: boolean;
 };
 
-const DEFAULT_EPHEMERAL_TTL_SECONDS = 24 * 60 * 60;
+const DEFAULT_EPHEMERAL_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 function MetadataPill({
   icon: Icon,
@@ -481,7 +481,7 @@ export function ChannelManagementSheet({
                   >
                     {ttlInvalid
                       ? "Enter a duration like 1d, 12h, or 30m."
-                      : "Defaults to 1d when left empty. Resets the deletion countdown from now whenever changed."}
+                      : "Defaults to 7d when left empty. Resets the deletion countdown from now whenever changed."}
                   </p>
                 </div>
               ) : null}

--- a/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
+++ b/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
@@ -12,8 +12,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Switch } from "@/shared/ui/switch";
 import { Textarea } from "@/shared/ui/textarea";
 
-/** Default TTL for ephemeral channels: 1 day of inactivity. */
-const EPHEMERAL_TTL_SECONDS = 86400;
+/** Default TTL for ephemeral channels: 7 days of inactivity. */
+const EPHEMERAL_TTL_SECONDS = 604800;
 const CREATE_FIELD_SHELL_CLASS =
   "rounded-xl border border-input bg-muted/40 transition-colors duration-150 ease-out hover:border-muted-foreground/40 focus-within:border-muted-foreground/50";
 const CREATE_FIELD_CONTROL_CLASS =
@@ -199,7 +199,7 @@ export function CreateChannelDialog({
                     }}
                   />
                   <ChannelDurationOption
-                    ariaLabel="Ephemeral - auto-archives after 1 day of inactivity"
+                    ariaLabel="Ephemeral - auto-archives after 7 days of inactivity"
                     checked={ephemeral}
                     description="For quick discussions that archive automatically when inactive."
                     icon={ClockFading}

--- a/desktop/tests/e2e/channel-controls-screenshots.spec.ts
+++ b/desktop/tests/e2e/channel-controls-screenshots.spec.ts
@@ -175,7 +175,7 @@ test.describe("channel controls screenshots", () => {
     await expect(
       page.getByTestId("channel-management-ephemeral-toggle"),
     ).toHaveAttribute("data-state", "checked");
-    await expect(page.getByTestId("channel-management-ttl")).toHaveValue("1d");
+    await expect(page.getByTestId("channel-management-ttl")).toHaveValue("7d");
     await settle(page);
 
     await lifecycle.screenshot({

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -570,7 +570,7 @@ test("create ephemeral stream shows sidebar and header affordances", async ({
     .fill("Auto-cleaned test stream");
   await page.getByRole("button", { name: "Channel duration: Ongoing" }).click();
   await page
-    .getByLabel("Ephemeral - auto-archives after 1 day of inactivity")
+    .getByLabel("Ephemeral - auto-archives after 7 days of inactivity")
     .click();
   await page.getByTestId("create-channel-submit").click();
 
@@ -614,7 +614,7 @@ test("ephemeral countdown refreshes when switching channels after a clock jump",
       .getByRole("button", { name: "Channel duration: Ongoing" })
       .click();
     await page
-      .getByLabel("Ephemeral - auto-archives after 1 day of inactivity")
+      .getByLabel("Ephemeral - auto-archives after 7 days of inactivity")
       .click();
     await page.getByTestId("create-channel-submit").click();
     await expect(page.getByTestId("chat-title")).toContainText(channelName);
@@ -1210,7 +1210,7 @@ test("manage channel updates visibility and ephemeral lifecycle independently", 
       expect.objectContaining({
         command: "update_channel",
         payload: expect.objectContaining({
-          input: expect.objectContaining({ ttlSeconds: 86400 }),
+          input: expect.objectContaining({ ttlSeconds: 604800 }),
         }),
       }),
     );
@@ -1224,7 +1224,7 @@ test("manage channel updates visibility and ephemeral lifecycle independently", 
     channelId: "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50",
   });
   expect(channelAfterEnable).toMatchObject({
-    ttl_seconds: 86400,
+    ttl_seconds: 604800,
     visibility: "private",
   });
 
@@ -1237,7 +1237,7 @@ test("manage channel updates visibility and ephemeral lifecycle independently", 
   await expect(
     page.getByTestId("channel-management-ephemeral-toggle"),
   ).toHaveAttribute("data-state", "checked");
-  await expect(page.getByTestId("channel-management-ttl")).toHaveValue("1d");
+  await expect(page.getByTestId("channel-management-ttl")).toHaveValue("7d");
 
   await page.getByTestId("channel-management-private-toggle").click();
   await page.getByTestId("channel-management-ephemeral-toggle").click();


### PR DESCRIPTION
Bumps the default expiry for temporary (ephemeral) channels from 1 day to 7 days. The default lives entirely in two desktop constants applied when a user enables a temporary channel without entering a TTL — the relay, CLI, and DB impose no default (TTL is always client-supplied), so this is a frontend-only change.

## Changes

- `CreateChannelDialog.tsx`: `EPHEMERAL_TTL_SECONDS` `86400` → `604800`, plus the doc comment and the "auto-archives after 1 day" `ariaLabel` copy.
- `ChannelManagementSheet.tsx`: `DEFAULT_EPHEMERAL_TTL_SECONDS` `24 * 60 * 60` → `7 * 24 * 60 * 60`, plus the "Defaults to 1d when left empty" helper copy.
- E2E specs: assertions pinned to the old default flip with it — `ttlSeconds`/`ttl_seconds` `86400` → `604800`, the `ariaLabel` matchers, and the `toHaveValue("1d")` → `"7d"` reopen-display checks.

`formatTtlDuration(604800)` returns `"7d"`, so the field renders the new default consistently.
