### PR TITLE
build: make mesh-llm opt-in for dev/staging to speed up iteration

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,11 @@ desktop_dir := "desktop"
 desktop_tauri_manifest := "desktop/src-tauri/Cargo.toml"
 web_dir := "web"
 
+# Opt-in mesh-llm. Off by default so `just dev`/`just staging` skip ~420 extra
+# crates + the llama.cpp native runtime build and stay fast to iterate on.
+# Turn on to test mesh compute features: `just mesh=1 dev` / `just mesh=1 staging`.
+mesh := ""
+
 # List all available tasks
 default:
     @just --list
@@ -306,7 +311,8 @@ dev *ARGS: bootstrap _ensure-sidecar-stubs _ensure-migrations
     source ../scripts/instance-env.sh
     INSTANCE_ID=$(node -e "console.log(JSON.parse(process.env.BUZZ_TAURI_CONFIG).identifier)")
     echo "Starting on Vite port ${BUZZ_VITE_PORT}, relay ${BUZZ_RELAY_URL}"
-    pnpm exec tauri dev --features mesh-llm --config "$BUZZ_TAURI_CONFIG" {{ARGS}}
+    FEATURES=(); [[ -n "{{mesh}}" ]] && FEATURES=(--features mesh-llm)
+    pnpm exec tauri dev ${FEATURES[@]+"${FEATURES[@]}"} --config "$BUZZ_TAURI_CONFIG" {{ARGS}}
 
 # Run the desktop app against the internal staging relay (installs deps + builds agent tools automatically)
 staging *ARGS: bootstrap _ensure-sidecar-stubs
@@ -315,7 +321,11 @@ staging *ARGS: bootstrap _ensure-sidecar-stubs
     export PATH="{{justfile_directory()}}/bin:$PATH"
     pnpm install  # unconditional: staging must always start with a clean dep tree
     cargo build --release -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
-    export MESH_LLM_NATIVE_RUNTIME_CACHE_DIR="$(./scripts/ensure-mesh-native-runtime.sh)"
+    FEATURES=()
+    if [[ -n "{{mesh}}" ]]; then
+        FEATURES=(--features mesh-llm)
+        export MESH_LLM_NATIVE_RUNTIME_CACHE_DIR="$(./scripts/ensure-mesh-native-runtime.sh)"
+    fi
     # Replace the 0-byte sidecar stub with the real CLI binary so tauri dev picks it up.
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
     cp target/release/buzz "desktop/src-tauri/binaries/buzz-${TARGET}"
@@ -328,7 +338,7 @@ staging *ARGS: bootstrap _ensure-sidecar-stubs
     INSTANCE_ID=$(node -e "console.log(JSON.parse(process.env.BUZZ_TAURI_CONFIG).identifier)")
     trap '../scripts/cleanup-instance-agents.sh "$INSTANCE_ID" || true' EXIT
     echo "Starting staging on Vite port ${BUZZ_VITE_PORT}, relay ${BUZZ_RELAY_URL}"
-    pnpm exec tauri dev --features mesh-llm --config "$BUZZ_TAURI_CONFIG" {{ARGS}}
+    pnpm exec tauri dev ${FEATURES[@]+"${FEATURES[@]}"} --config "$BUZZ_TAURI_CONFIG" {{ARGS}}
 
 # Run the desktop frontend dev server (port derived from worktree)
 desktop-dev:

--- a/desktop/src-tauri/src/mesh_llm/mod.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod.rs
@@ -212,12 +212,12 @@ fn initialize_mesh_native_runtime() -> anyhow::Result<()> {
         .any(|runtime| runtime.mesh_version == current)
     {
         anyhow::bail!(
-            "mesh native runtime for MeshLLM {current} is not installed; run `just staging` or `just mesh-e2e-hardware` to prepare it"
+            "mesh native runtime for MeshLLM {current} is not installed; run `just mesh=1 staging` or `just mesh-e2e-hardware` to prepare it"
         );
     }
     mesh_llm_host_runtime::initialize_host_runtime().map_err(|error| {
         anyhow::anyhow!(
-            "mesh native runtime failed to load; run `just staging` or `just mesh-e2e-hardware` to repair it: {error}"
+            "mesh native runtime failed to load; run `just mesh=1 staging` or `just mesh-e2e-hardware` to repair it: {error}"
         )
     })
 }

--- a/docs/mesh-llm-local-build.md
+++ b/docs/mesh-llm-local-build.md
@@ -24,6 +24,14 @@ cargo build -p buzz-relay --bin buzz-relay
 cargo check --manifest-path desktop/src-tauri/Cargo.toml
 ```
 
+To run the desktop app with mesh enabled, use the opt-in recipes — plain
+`just dev` / `just staging` are mesh-off for fast iteration:
+
+```bash
+just mesh=1 dev       # local relay, mesh-llm on
+just mesh=1 staging   # staging relay, mesh-llm on + native runtime prep
+```
+
 Expect the first build to take several minutes while mesh-llm prepares and builds
 patched llama.cpp. This is intentional for the local demo: there is no external
 binary artifact to fetch and no separate dylib path to configure.


### PR DESCRIPTION
## Problem

`just dev` and `just staging` hardcoded `tauri dev --features mesh-llm`, and `staging` also ran `ensure-mesh-native-runtime.sh` (builds llama.cpp via cmake on cache miss). That forced the heavy mesh path on every iteration build — the two commands humans and agents run most.

Measured cost: desktop tauri deps **without** mesh-llm = **594 crates**; **with** = **1014**. That's **+420 crates (~71%)** plus a C/C++ native runtime build on every `dev`/`staging` run. (Pinky's run on a slightly different graph measured 720 → 1051, +331 — exact number varies by environment, the savings are real either way.)

## Change

Add a `mesh := ""` toggle, off by default:

- `just dev` / `just staging` — fast, no mesh-llm, no native-runtime prep.
- `just mesh=1 dev` / `just mesh=1 staging` — full mesh build for testing compute-sharing features.

mesh-llm is fully optional in code (`default = []` in `desktop/src-tauri/Cargo.toml`; every mesh Tauri command has a `#[cfg(not(feature = "mesh-llm"))]` stub returning `"mesh-llm feature not enabled"`), so the default build is a complete, working app minus the mesh compute UI.

## How this lines up with CI / release

This brings `dev`/`staging` in line with what CI and release **already do**:

- **CI** (`ci.yml`) runs bare `pnpm tauri build` (no `--features mesh-llm`); it only prebuilds/caches the llama native libs separately, keyed by mesh rev.
- **Release** (`release.yml:175-187`) also builds `pnpm tauri build` with **no** `--features mesh-llm` — it sets the LLAMA_STAGE env + caches native libs but does not pass the cargo feature. So the **shipped desktop DMG today compiles mesh-llm OFF** (mesh commands are stubs in production).

⚠️ **Correction to my earlier claim:** I previously said release keeps `--features mesh-llm` — that's wrong. It doesn't. Credit to Pinky for catching it. This doesn't change the iteration-speed fix (default dev/staging matching CI/release is the right call), but it surfaces a **separate product question for @Wes**: if shipped Buzz desktop is *supposed* to include Mesh by default, the release build is missing the feature flag — that's its own bug/decision, out of scope here.

## Full mesh build still available via
- `just mesh=1 dev` / `just mesh=1 staging`
- `just mesh-e2e-hardware` (unchanged)

## Follow-ups (not in this PR, intentionally scoped out)
- Update mesh local-build docs + the runtime error text so they point at the explicit `mesh=1` path, not plain `just staging` (per Pinky).
- The product question above (does shipped desktop want mesh on?).
- `CMAKE_POLICY_VERSION_MINIMUM=3.5` in dev/staging recipes to unbreak local desktop builds on newer CMake.
- Pre-push hook returns non-zero on a relay-dependent e2e step when no relay is running locally.

## Validation
- `just --list` parses; recipes intact.
- Empty-array + `set -u` footgun handled with `${FEATURES[@]+"${FEATURES[@]}"}`; verified under macOS `bash 3.2.57` for both mesh on and off.
- `cargo check` of the desktop tauri crate **without** mesh-llm compiles green — stubs are complete.
- Pre-commit (fmt/lint) and the test suite (rust + desktop + tauri + mobile) pass locally.
