### PR TITLE
fix(relay): resubscribe agents when an archived channel is restored

### DIFF
--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -1165,6 +1165,39 @@ async fn handle_edit_metadata(event: &Event, state: &Arc<AppState>) -> anyhow::R
                                 }),
                             )
                             .await?;
+
+                            // Resubscribe connected agents after restore: archiving evicts their
+                            // live subscriptions (CLOSED "channel access revoked") and unarchive
+                            // otherwise emits no signal that makes a connected agent resubscribe.
+                            // We reuse the member_added notification (44100) purely as a resubscribe
+                            // trigger — no membership actually changed here — because it flows on the
+                            // agent's always-live global membership subscription, the same path
+                            // remove/re-add uses to recover. Humans self-heal via the re-emitted
+                            // kind:39000 discovery, so this is intentionally agent-scoped.
+                            //
+                            // Known limitation: emit_membership_notification builds a created_at=now
+                            // event with no nonce, and insert_event skips fan-out on a duplicate id.
+                            // Four sub-second toggles (archive->unarchive->archive->unarchive) on the
+                            // same channel by the same actor could collide ids and skip a fan-out.
+                            // Not reachable in practice — unarchive has a single human-driven caller;
+                            // the reaper only auto-archives — so we don't engineer around it.
+                            for member in state.db.get_members(channel_id).await? {
+                                if let Err(e) = emit_membership_notification(
+                                    state,
+                                    channel_id,
+                                    &member.pubkey,
+                                    &actor_bytes,
+                                    KIND_MEMBER_ADDED_NOTIFICATION,
+                                )
+                                .await
+                                {
+                                    warn!(
+                                        channel = %channel_id,
+                                        error = %e,
+                                        "post-unarchive resubscribe notification failed"
+                                    );
+                                }
+                            }
                         }
                         _ => {} // ignore invalid values
                     }

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -846,6 +846,79 @@ async fn test_nip29_put_user_default_policy_allows() {
     ws.disconnect().await.expect("disconnect");
 }
 
+/// Restoring an archived channel must re-signal connected members so their
+/// agents resubscribe. Archive evicts live channel subscriptions; unarchive
+/// emits a kind:44100 member_added notification per member on the always-live
+/// global membership feed, which is the resubscribe trigger remove/re-add uses.
+#[tokio::test]
+#[ignore]
+async fn test_unarchive_emits_member_added_notification() {
+    let url = relay_url();
+
+    let owner_keys = Keys::generate();
+    let owner_pubkey_hex = owner_keys.public_key().to_hex();
+
+    // Creating the channel makes the owner its sole member.
+    let channel_id = create_test_channel(&owner_keys).await;
+
+    let mut ws = BuzzTestClient::connect(&url, &owner_keys)
+        .await
+        .expect("connect as owner");
+
+    // Subscribe to the global membership feed (kind:44100 addressed to the owner).
+    // This is a global, non-channel-scoped subscription, so archive's
+    // channel-scoped eviction leaves it intact across the archive→unarchive cycle.
+    let sid = sub_id("membership-feed");
+    let membership_filter = Filter::new().kind(Kind::Custom(44100)).custom_tags(
+        SingleLetterTag::lowercase(Alphabet::P),
+        [owner_pubkey_hex.as_str()],
+    );
+    ws.subscribe(&sid, vec![membership_filter])
+        .await
+        .expect("subscribe to membership feed");
+    ws.collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("membership feed EOSE");
+
+    // Archive, then unarchive, the channel via kind:9002 edit-metadata.
+    for archived in ["true", "false"] {
+        let event = EventBuilder::new(Kind::Custom(9002), "")
+            .tags([
+                Tag::parse(["h", &channel_id]).unwrap(),
+                Tag::parse(["archived", archived]).unwrap(),
+            ])
+            .sign_with_keys(&owner_keys)
+            .unwrap();
+        let ok = ws.send_event(event).await.expect("send kind 9002");
+        assert!(ok.accepted, "edit-metadata rejected: {}", ok.message);
+    }
+
+    // The unarchive must fan out a 44100 to the owner. Loop past any other
+    // events delivered on the connection until we see it (or time out).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .filter(|d| !d.is_zero())
+            .expect("timed out waiting for member_added notification");
+        if let RelayMessage::Event { event, .. } = ws
+            .recv_event(remaining)
+            .await
+            .expect("recv membership notification")
+        {
+            if event.kind == Kind::Custom(44100) {
+                let content: serde_json::Value =
+                    serde_json::from_str(&event.content).expect("parse notification content");
+                assert_eq!(content["type"], "member_added");
+                assert_eq!(content["channel_id"], channel_id);
+                break;
+            }
+        }
+    }
+
+    ws.disconnect().await.expect("disconnect");
+}
+
 /// NIP-29 kind 9000 (PUT_USER): "nobody" policy blocks a third party from adding the agent.
 #[tokio::test]
 #[ignore]


### PR DESCRIPTION
Restoring an archived channel left connected agents silent in it until they were removed and re-added.

Archiving a channel sends every connected subscriber `CLOSED restricted: channel access revoked`. A connected agent matches that reason, drops the channel from its live subscriptions, and keeps its socket alive (the intended no-reconnect-storm behavior). Unarchive flips `archived_at` back to `NULL`, posts a `channel_unarchived` system message into the channel, and re-emits kind:39000 discovery — but it emitted nothing on the agent's always-live global membership feed, so a connected agent never learned to resubscribe. Remove/re-add worked only as a side effect: re-adding emits a `member_added` notification (kind:44100) on that feed, which is what triggers a fresh subscribe.

Unarchive now emits that same kind:44100 `member_added` notification to each current member, reusing the existing `emit_membership_notification` helper. It is purely a resubscribe trigger — no membership actually changed — so the emit site carries a `WHY` comment to keep the next reader from misreading it. Each per-member emit is guarded with a `warn!` rather than `?` so one malformed member pubkey can't abort the unarchive side-effect mid-loop and skip the discovery re-emission. The fix is agent-scoped: human clients re-derive their channel list from the re-emitted kind:39000 discovery and need no extra signal.
