### PR TITLE
feat: publish persona, team, and managed-agent records as relay events

### DIFF
--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -128,6 +128,15 @@ pub const KIND_PERSONA: u32 = 30175;
 /// authoritative across clients and reboots, mirroring `KIND_PERSONA`.
 pub const KIND_TEAM: u32 = 30176;
 
+/// NIP-AP: Managed Agent (parameterized replaceable, owner-authored).
+///
+/// Managed-agent definition event published by the workspace owner. Addressed
+/// by `(pubkey, kind, d_tag)` where `d_tag` is the agent's pubkey. Content is
+/// an explicit opt-IN allowlist projection of the agent record — it MUST never
+/// carry the agent's secret key, NIP-OA auth tag, env vars, or runtime fields,
+/// since these events are world-readable on the relay.
+pub const KIND_MANAGED_AGENT: u32 = 30177;
+
 // NIP-29 group admin events
 /// NIP-29: Add a user to a group.
 pub const KIND_NIP29_PUT_USER: u32 = 9000;
@@ -411,6 +420,7 @@ pub const ALL_KINDS: &[u32] = &[
     KIND_EVENT_REMINDER,
     KIND_PERSONA,
     KIND_TEAM,
+    KIND_MANAGED_AGENT,
     KIND_NIP29_PUT_USER,
     KIND_NIP29_REMOVE_USER,
     KIND_NIP29_EDIT_METADATA,
@@ -595,6 +605,7 @@ pub fn event_kind_i32(event: &nostr::Event) -> i32 {
 const _: () = assert!(is_replaceable(KIND_AGENT_PROFILE)); // 10100 ∈ 10000–19999
 const _: () = assert!(is_parameterized_replaceable(KIND_PERSONA)); // 30175 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_TEAM)); // 30176 ∈ 30000–39999
+const _: () = assert!(is_parameterized_replaceable(KIND_MANAGED_AGENT)); // 30177 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_WORKFLOW_DEF)); // 30620 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_EVENT_REMINDER)); // 30300 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_MESH_LLM_RELAY_STATUS)); // 30621 ∈ 30000–39999

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -119,6 +119,15 @@ pub const AUTHOR_ONLY_KINDS: &[u32] = &[KIND_EVENT_REMINDER];
 /// Designed for discoverability and sharing — d-tag is not blinded.
 pub const KIND_PERSONA: u32 = 30175;
 
+/// NIP-AP: Agent Team (parameterized replaceable, owner-authored).
+///
+/// Team definition event published by the workspace owner. Addressed by
+/// `(pubkey, kind, d_tag)` where `d_tag` is the team's stable id. Content is a
+/// JSON body projecting public team fields (name, description, persona_ids).
+/// A team is a user-facing grouping of personas; publishing keeps it
+/// authoritative across clients and reboots, mirroring `KIND_PERSONA`.
+pub const KIND_TEAM: u32 = 30176;
+
 // NIP-29 group admin events
 /// NIP-29: Add a user to a group.
 pub const KIND_NIP29_PUT_USER: u32 = 9000;
@@ -401,6 +410,7 @@ pub const ALL_KINDS: &[u32] = &[
     KIND_AGENT_ENGRAM,
     KIND_EVENT_REMINDER,
     KIND_PERSONA,
+    KIND_TEAM,
     KIND_NIP29_PUT_USER,
     KIND_NIP29_REMOVE_USER,
     KIND_NIP29_EDIT_METADATA,
@@ -584,6 +594,7 @@ pub fn event_kind_i32(event: &nostr::Event) -> i32 {
 // Compile-time: new kinds are in the expected ranges.
 const _: () = assert!(is_replaceable(KIND_AGENT_PROFILE)); // 10100 ∈ 10000–19999
 const _: () = assert!(is_parameterized_replaceable(KIND_PERSONA)); // 30175 ∈ 30000–39999
+const _: () = assert!(is_parameterized_replaceable(KIND_TEAM)); // 30176 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_WORKFLOW_DEF)); // 30620 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_EVENT_REMINDER)); // 30300 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_MESH_LLM_RELAY_STATUS)); // 30621 ∈ 30000–39999

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -21,7 +21,7 @@ use buzz_core::kind::{
     KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED, KIND_GIT_STATUS_OPEN,
     KIND_HUDDLE_ENDED, KIND_HUDDLE_GUIDELINES, KIND_HUDDLE_PARTICIPANT_JOINED,
     KIND_HUDDLE_PARTICIPANT_LEFT, KIND_HUDDLE_STARTED, KIND_IA_ARCHIVE_REQUEST,
-    KIND_IA_UNARCHIVE_REQUEST, KIND_LONG_FORM, KIND_MEMBER_ADDED_NOTIFICATION,
+    KIND_IA_UNARCHIVE_REQUEST, KIND_LONG_FORM, KIND_MANAGED_AGENT, KIND_MEMBER_ADDED_NOTIFICATION,
     KIND_MEMBER_REMOVED_NOTIFICATION, KIND_MESH_LLM_RELAY_STATUS, KIND_MUTE_LIST,
     KIND_NIP29_CREATE_GROUP, KIND_NIP29_DELETE_EVENT, KIND_NIP29_DELETE_GROUP,
     KIND_NIP29_EDIT_METADATA, KIND_NIP29_JOIN_REQUEST, KIND_NIP29_LEAVE_REQUEST,
@@ -30,7 +30,7 @@ use buzz_core::kind::{
     KIND_PROFILE, KIND_REACTION, KIND_READ_STATE, KIND_STREAM_MESSAGE,
     KIND_STREAM_MESSAGE_BOOKMARKED, KIND_STREAM_MESSAGE_DIFF, KIND_STREAM_MESSAGE_EDIT,
     KIND_STREAM_MESSAGE_PINNED, KIND_STREAM_MESSAGE_SCHEDULED, KIND_STREAM_MESSAGE_V2,
-    KIND_STREAM_REMINDER, KIND_TEXT_NOTE, KIND_USER_STATUS, KIND_WORKFLOW_DEF,
+    KIND_STREAM_REMINDER, KIND_TEAM, KIND_TEXT_NOTE, KIND_USER_STATUS, KIND_WORKFLOW_DEF,
     KIND_WORKFLOW_TRIGGER, RELAY_ADMIN_ADD_MEMBER, RELAY_ADMIN_CHANGE_ROLE,
     RELAY_ADMIN_REMOVE_MEMBER,
 };
@@ -155,7 +155,9 @@ fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static s
         KIND_PROFILE => Ok(Scope::UsersWrite),
         KIND_TEXT_NOTE | KIND_LONG_FORM => Ok(Scope::MessagesWrite),
         KIND_CONTACT_LIST | KIND_READ_STATE | KIND_USER_STATUS | KIND_AGENT_ENGRAM
-        | KIND_EVENT_REMINDER | KIND_PERSONA => Ok(Scope::UsersWrite),
+        | KIND_EVENT_REMINDER | KIND_PERSONA | KIND_TEAM | KIND_MANAGED_AGENT => {
+            Ok(Scope::UsersWrite)
+        }
         // NIP-51 standard lists and NIP-65 relay list — user-owned global state,
         // same ownership shape as kind:3 (contacts) and kind:0 (profile).
         KIND_MUTE_LIST
@@ -347,6 +349,10 @@ pub(crate) fn is_global_only_kind(kind: u32) -> bool {
             | KIND_AGENT_PROFILE
             // NIP-AP: persona definitions (30175): owner-authored, keyed by (pubkey, kind, d_tag).
             | KIND_PERSONA
+            // NIP-AP: team (30176) + managed-agent (30177) definitions: owner-authored,
+            // keyed by (pubkey, kind, d_tag). A stray `h` tag must not channel-scope them.
+            | KIND_TEAM
+            | KIND_MANAGED_AGENT
             // NIP-34: git events use `a` tags (repo reference), not `h` tags (channel scope).
             // Parameterized replaceable kinds are keyed by (pubkey, kind, d_tag).
             | KIND_GIT_REPO_ANNOUNCEMENT
@@ -1926,8 +1932,8 @@ mod tests {
     use super::*;
     use buzz_core::kind::{
         KIND_CANVAS, KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_FORUM_VOTE, KIND_LONG_FORM,
-        KIND_PERSONA, KIND_PRESENCE_UPDATE, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_DIFF,
-        KIND_USER_STATUS,
+        KIND_MANAGED_AGENT, KIND_PERSONA, KIND_PRESENCE_UPDATE, KIND_STREAM_MESSAGE,
+        KIND_STREAM_MESSAGE_DIFF, KIND_TEAM, KIND_USER_STATUS,
     };
 
     #[test]
@@ -2097,6 +2103,8 @@ mod tests {
             KIND_AGENT_ENGRAM,
             KIND_AGENT_PROFILE,
             KIND_PERSONA,
+            KIND_TEAM,
+            KIND_MANAGED_AGENT,
         ];
         for kind in migrated {
             assert!(
@@ -2168,6 +2176,32 @@ mod tests {
     fn persona_is_global_only() {
         assert!(is_global_only_kind(KIND_PERSONA));
         assert!(!requires_h_channel_scope(KIND_PERSONA));
+    }
+
+    #[test]
+    fn team_and_managed_agent_are_in_scope_allowlist() {
+        let dummy = make_dummy_event();
+        for kind in [KIND_TEAM, KIND_MANAGED_AGENT] {
+            assert_eq!(
+                required_scope_for_kind(kind, &dummy).unwrap(),
+                Scope::UsersWrite,
+                "kind {kind} should require UsersWrite scope"
+            );
+        }
+    }
+
+    #[test]
+    fn team_and_managed_agent_are_global_only() {
+        for kind in [KIND_TEAM, KIND_MANAGED_AGENT] {
+            assert!(
+                is_global_only_kind(kind),
+                "kind {kind} should be global-only (never channel-scoped)"
+            );
+            assert!(
+                !requires_h_channel_scope(kind),
+                "kind {kind} must not require an h-tag channel scope"
+            );
+        }
     }
 
     #[test]

--- a/crates/buzz-test-client/tests/e2e_managed_agent.rs
+++ b/crates/buzz-test-client/tests/e2e_managed_agent.rs
@@ -1,14 +1,16 @@
 //! End-to-end tests for kind:30177 managed-agent events (NIP-AP).
 //!
 //! These tests verify the relay accepts and addresses managed-agent events the
-//! same way it does personas, and — the security-critical case — that the
-//! content round-tripped through the relay carries only the opt-IN allowlisted
-//! identity/config fields and never a secret.
+//! same way it does personas, and that content published as a projection-shaped
+//! body round-trips through the relay unchanged.
 //!
 //! - Accepts a valid managed-agent event and queries it back by NIP-33
 //!   coordinate (the `d`-tag is the agent's 64-hex pubkey).
-//! - The published content carries NO `private_key_nsec`, `auth_tag`,
-//!   `env_vars`, provider backend blob, or runtime fields.
+//! - Round-trips the published content through the relay, confirming it returns
+//!   exactly the projected fields and nothing more. The body is a hand-built
+//!   secret-free literal; the secret-exclusion regression guard lives in the
+//!   `agent_events.rs` unit test, not here (the e2e crate can't reach the
+//!   desktop projection function).
 //! - Enforces NIP-33 replacement semantics (same d-tag, newer timestamp wins).
 //! - Honors a NIP-09 a-tag tombstone, removing the agent coordinate.
 //!
@@ -134,15 +136,19 @@ async fn test_managed_agent_publish_and_query() {
     client.disconnect().await.expect("disconnect");
 }
 
-// ── Secret exclusion (the security-critical case) ────────────────────────────
+// ── Round-trip fidelity (relay returns only what was published) ──────────────
 
-/// The content round-tripped through the relay must carry only the opt-IN
-/// allowlisted identity/config fields — never a secret, the provider backend
-/// blob, env vars, or runtime fields. This proves the full publish→relay→query
-/// pipe, not just the projection function (which is unit-tested separately).
+/// The relay round-trips published content byte-for-byte: a projection-shaped
+/// body goes out, and the relay returns exactly those fields and nothing more.
+/// The body here is a hand-built secret-free literal (`agent_projection_content`),
+/// so this test does NOT exercise the desktop projection function — the e2e crate
+/// can't reach it. The secret-exclusion regression guard lives in the
+/// `agent_events.rs` unit test (`content_excludes_secrets_and_runtime_fields`),
+/// which feeds a fully-populated secret-bearing record through the real
+/// projection. This test confirms the relay neither adds nor drops fields.
 #[tokio::test]
 #[ignore]
-async fn test_managed_agent_published_content_excludes_secrets() {
+async fn test_managed_agent_round_trips_only_projected_fields() {
     let url = relay_url();
     let keys = Keys::generate();
     let d_tag = agent_d_tag();
@@ -177,7 +183,10 @@ async fn test_managed_agent_published_content_excludes_secrets() {
     assert_eq!(events.len(), 1, "expected exactly one managed-agent event");
     let published = &events[0].content;
 
-    // Secret-bearing fields — must never appear in relay-stored content.
+    // The relay must not inject fields. These assertions confirm round-trip
+    // fidelity for a projection-shaped body — they are NOT the secret guard
+    // (the input literal is secret-free by construction; the real guard is the
+    // `agent_events.rs` unit test over the projection function).
     for forbidden in [
         "private_key_nsec",
         "private_key",

--- a/crates/buzz-test-client/tests/e2e_managed_agent.rs
+++ b/crates/buzz-test-client/tests/e2e_managed_agent.rs
@@ -1,0 +1,328 @@
+//! End-to-end tests for kind:30177 managed-agent events (NIP-AP).
+//!
+//! These tests verify the relay accepts and addresses managed-agent events the
+//! same way it does personas, and — the security-critical case — that the
+//! content round-tripped through the relay carries only the opt-IN allowlisted
+//! identity/config fields and never a secret.
+//!
+//! - Accepts a valid managed-agent event and queries it back by NIP-33
+//!   coordinate (the `d`-tag is the agent's 64-hex pubkey).
+//! - The published content carries NO `private_key_nsec`, `auth_tag`,
+//!   `env_vars`, provider backend blob, or runtime fields.
+//! - Enforces NIP-33 replacement semantics (same d-tag, newer timestamp wins).
+//! - Honors a NIP-09 a-tag tombstone, removing the agent coordinate.
+//!
+//! # Running
+//!
+//! Start the relay, then run:
+//!
+//! ```text
+//! RELAY_URL=ws://localhost:3000 cargo test --test e2e_managed_agent -- --ignored
+//! ```
+
+use std::time::Duration;
+
+use buzz_test_client::BuzzTestClient;
+use nostr::{Alphabet, EventBuilder, Filter, Keys, Kind, SingleLetterTag, Tag, Timestamp};
+
+const AGENT_KIND: u16 = 30177;
+
+fn relay_url() -> String {
+    std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string())
+}
+
+fn sub_id(name: &str) -> String {
+    format!("e2e-managed-agent-{name}-{}", uuid::Uuid::new_v4())
+}
+
+/// The opt-IN allowlist projection a real `ManagedAgentRecord` produces (see
+/// `desktop/src-tauri/src/managed_agents/agent_events.rs`). Built inline here
+/// because the e2e crate does not depend on the desktop crate; the
+/// projection-function exclusion contract is unit-tested in that module. This
+/// is exactly the field set the desktop publishes — secrets, the backend blob,
+/// env vars, and runtime fields are absent by construction.
+fn agent_projection_content(name: &str) -> String {
+    serde_json::json!({
+        "name": name,
+        "persona_id": "persona-1",
+        "system_prompt": "You are a test agent.",
+        "model": "claude-opus-4",
+        "provider": "anthropic",
+        "mcp_toolsets": "default",
+        "persona_source_version": "abc123",
+        "parallelism": 24,
+        "respond_to": "allowlist",
+        "respond_to_allowlist": ["79be667e"]
+    })
+    .to_string()
+}
+
+/// Build a managed-agent event whose `d`-tag is the agent's 64-hex pubkey,
+/// mirroring the desktop `build_agent_event` shape.
+fn agent_event(keys: &Keys, d_tag: &str, content: &str) -> nostr::Event {
+    EventBuilder::new(Kind::Custom(AGENT_KIND), content)
+        .tags(vec![Tag::parse(["d", d_tag]).unwrap()])
+        .sign_with_keys(keys)
+        .unwrap()
+}
+
+fn agent_event_at(keys: &Keys, d_tag: &str, content: &str, created_at: u64) -> nostr::Event {
+    EventBuilder::new(Kind::Custom(AGENT_KIND), content)
+        .tags(vec![Tag::parse(["d", d_tag]).unwrap()])
+        .custom_created_at(Timestamp::from(created_at))
+        .sign_with_keys(keys)
+        .unwrap()
+}
+
+/// Build a NIP-09 a-tag-only deletion at the agent's NIP-33 coordinate,
+/// mirroring the desktop `build_agent_delete` shape (no `e`-tag).
+fn agent_delete_event(keys: &Keys, d_tag: &str) -> nostr::Event {
+    let coord = format!("{AGENT_KIND}:{}:{d_tag}", keys.public_key().to_hex());
+    EventBuilder::new(Kind::Custom(5), "")
+        .tags(vec![Tag::parse(["a", coord.as_str()]).unwrap()])
+        .sign_with_keys(keys)
+        .unwrap()
+}
+
+/// A synthetic agent `d`-tag: 64 lowercase hex chars, the agent-pubkey grammar.
+fn agent_d_tag() -> String {
+    uuid::Uuid::new_v4().simple().to_string().repeat(2)
+}
+
+// ── Publish and query back ───────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_managed_agent_publish_and_query() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let d_tag = agent_d_tag();
+    let content = agent_projection_content("Test Agent");
+
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let event = agent_event(&keys, &d_tag, &content);
+    let ok = client.send_event(event).await.expect("send agent");
+    assert!(
+        ok.accepted,
+        "relay rejected managed-agent event: {}",
+        ok.message
+    );
+
+    let sid = sub_id("query");
+    let filter = Filter::new()
+        .kind(Kind::Custom(AGENT_KIND))
+        .author(keys.public_key())
+        .custom_tags(SingleLetterTag::lowercase(Alphabet::D), [d_tag.as_str()]);
+
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe");
+
+    let events = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect events");
+
+    assert_eq!(events.len(), 1, "expected exactly one managed-agent event");
+    let ev = &events[0];
+    assert_eq!(ev.content, content);
+    assert_eq!(ev.pubkey, keys.public_key());
+    assert_eq!(ev.kind, Kind::Custom(AGENT_KIND));
+
+    client.disconnect().await.expect("disconnect");
+}
+
+// ── Secret exclusion (the security-critical case) ────────────────────────────
+
+/// The content round-tripped through the relay must carry only the opt-IN
+/// allowlisted identity/config fields — never a secret, the provider backend
+/// blob, env vars, or runtime fields. This proves the full publish→relay→query
+/// pipe, not just the projection function (which is unit-tested separately).
+#[tokio::test]
+#[ignore]
+async fn test_managed_agent_published_content_excludes_secrets() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let d_tag = agent_d_tag();
+    let content = agent_projection_content("Secret-Free Agent");
+
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let event = agent_event(&keys, &d_tag, &content);
+    let ok = client.send_event(event).await.expect("send agent");
+    assert!(
+        ok.accepted,
+        "relay rejected managed-agent event: {}",
+        ok.message
+    );
+
+    let sid = sub_id("secrets");
+    let filter = Filter::new()
+        .kind(Kind::Custom(AGENT_KIND))
+        .author(keys.public_key())
+        .custom_tags(SingleLetterTag::lowercase(Alphabet::D), [d_tag.as_str()]);
+
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe");
+
+    let events = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect events");
+
+    assert_eq!(events.len(), 1, "expected exactly one managed-agent event");
+    let published = &events[0].content;
+
+    // Secret-bearing fields — must never appear in relay-stored content.
+    for forbidden in [
+        "private_key_nsec",
+        "private_key",
+        "nsec1",
+        "auth_tag",
+        "env_vars",
+        "backend",
+        "backend_agent_id",
+        "provider_binary_path",
+    ] {
+        assert!(
+            !published.contains(forbidden),
+            "published managed-agent content leaked `{forbidden}`: {published}"
+        );
+    }
+
+    // Runtime fields — must never appear.
+    for forbidden in [
+        "runtime_pid",
+        "last_started_at",
+        "last_stopped_at",
+        "last_exit_code",
+        "last_error",
+        "relay_url",
+    ] {
+        assert!(
+            !published.contains(forbidden),
+            "published managed-agent content leaked runtime field `{forbidden}`: {published}"
+        );
+    }
+
+    // Identity/config fields — must be present (proves we published real content).
+    assert!(published.contains("Secret-Free Agent"), "missing name");
+    assert!(published.contains("system_prompt"), "missing system_prompt");
+
+    client.disconnect().await.expect("disconnect");
+}
+
+// ── NIP-33 replacement semantics ─────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_managed_agent_nip33_replacement_newer_wins() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let d_tag = agent_d_tag();
+
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let now = Timestamp::now().as_secs();
+    let old_content = agent_projection_content("Old Agent");
+    let old_event = agent_event_at(&keys, &d_tag, &old_content, now - 100);
+    let ok = client.send_event(old_event).await.expect("send old");
+    assert!(ok.accepted, "relay rejected old event: {}", ok.message);
+
+    let new_content = agent_projection_content("New Agent");
+    let new_event = agent_event_at(&keys, &d_tag, &new_content, now);
+    let ok = client.send_event(new_event).await.expect("send new");
+    assert!(ok.accepted, "relay rejected new event: {}", ok.message);
+
+    let sid = sub_id("replace");
+    let filter = Filter::new()
+        .kind(Kind::Custom(AGENT_KIND))
+        .author(keys.public_key())
+        .custom_tags(SingleLetterTag::lowercase(Alphabet::D), [d_tag.as_str()]);
+
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe");
+
+    let events = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect");
+
+    assert_eq!(events.len(), 1, "NIP-33: only newest event should remain");
+    assert_eq!(
+        events[0].content, new_content,
+        "should be the newer version"
+    );
+
+    client.disconnect().await.expect("disconnect");
+}
+
+// ── NIP-09 coordinate deletion (tombstone) ───────────────────────────────────
+
+/// The a-tag tombstone is the only state-destroying op in the managed-agent
+/// flow. Publish an agent, confirm it is live, publish the a-tag-only tombstone
+/// at its coordinate, then assert the query returns it gone.
+#[tokio::test]
+#[ignore]
+async fn test_managed_agent_tombstone_deletes_coordinate() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let d_tag = agent_d_tag();
+    let content = agent_projection_content("Doomed Agent");
+
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let event = agent_event(&keys, &d_tag, &content);
+    let ok = client.send_event(event).await.expect("send agent");
+    assert!(
+        ok.accepted,
+        "relay rejected managed-agent event: {}",
+        ok.message
+    );
+
+    let filter = || {
+        Filter::new()
+            .kind(Kind::Custom(AGENT_KIND))
+            .author(keys.public_key())
+            .custom_tags(SingleLetterTag::lowercase(Alphabet::D), [d_tag.as_str()])
+    };
+
+    let sid = sub_id("tombstone-pre");
+    client
+        .subscribe(&sid, vec![filter()])
+        .await
+        .expect("subscribe pre");
+    let before = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect pre");
+    assert_eq!(before.len(), 1, "agent should be live before deletion");
+
+    let tombstone = agent_delete_event(&keys, &d_tag);
+    let ok = client.send_event(tombstone).await.expect("send tombstone");
+    assert!(ok.accepted, "relay rejected tombstone: {}", ok.message);
+
+    let sid = sub_id("tombstone-post");
+    client
+        .subscribe(&sid, vec![filter()])
+        .await
+        .expect("subscribe post");
+    let after = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect post");
+    assert_eq!(
+        after.len(),
+        0,
+        "tombstone should remove the agent coordinate, got {} event(s)",
+        after.len()
+    );
+
+    client.disconnect().await.expect("disconnect");
+}

--- a/crates/buzz-test-client/tests/e2e_team.rs
+++ b/crates/buzz-test-client/tests/e2e_team.rs
@@ -1,0 +1,218 @@
+//! End-to-end tests for kind:30176 team events (NIP-AP).
+//!
+//! These tests verify the relay accepts and addresses team events the same way
+//! it does personas:
+//! - Accepts a valid team event and queries it back by NIP-33 coordinate.
+//! - Enforces NIP-33 replacement semantics (same d-tag, newer timestamp wins).
+//! - Honors a NIP-09 a-tag tombstone, removing the team coordinate.
+//!
+//! The team `d`-tag is the team's stable id (a slug-like string), not a 64-hex
+//! pubkey — it exercises the generic parameterized-replaceable path that
+//! enforces only `D_TAG_MAX_LEN`, distinct from the persona slug envelope.
+//!
+//! # Running
+//!
+//! Start the relay, then run:
+//!
+//! ```text
+//! RELAY_URL=ws://localhost:3000 cargo test --test e2e_team -- --ignored
+//! ```
+
+use std::time::Duration;
+
+use buzz_test_client::BuzzTestClient;
+use nostr::{Alphabet, EventBuilder, Filter, Keys, Kind, SingleLetterTag, Tag, Timestamp};
+
+const TEAM_KIND: u16 = 30176;
+
+fn relay_url() -> String {
+    std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string())
+}
+
+fn sub_id(name: &str) -> String {
+    format!("e2e-team-{name}-{}", uuid::Uuid::new_v4())
+}
+
+/// Build a team event whose `d`-tag is the team id, mirroring the desktop
+/// `build_team_event` shape.
+fn team_event(keys: &Keys, d_tag: &str, content: &str) -> nostr::Event {
+    EventBuilder::new(Kind::Custom(TEAM_KIND), content)
+        .tags(vec![Tag::parse(["d", d_tag]).unwrap()])
+        .sign_with_keys(keys)
+        .unwrap()
+}
+
+fn team_event_at(keys: &Keys, d_tag: &str, content: &str, created_at: u64) -> nostr::Event {
+    EventBuilder::new(Kind::Custom(TEAM_KIND), content)
+        .tags(vec![Tag::parse(["d", d_tag]).unwrap()])
+        .custom_created_at(Timestamp::from(created_at))
+        .sign_with_keys(keys)
+        .unwrap()
+}
+
+/// Build a NIP-09 a-tag-only deletion at the team's NIP-33 coordinate,
+/// mirroring the desktop `build_team_delete` shape (no `e`-tag, so the relay
+/// takes the coordinate-delete path rather than the event-id path).
+fn team_delete_event(keys: &Keys, d_tag: &str) -> nostr::Event {
+    let coord = format!("{TEAM_KIND}:{}:{d_tag}", keys.public_key().to_hex());
+    EventBuilder::new(Kind::Custom(5), "")
+        .tags(vec![Tag::parse(["a", coord.as_str()]).unwrap()])
+        .sign_with_keys(keys)
+        .unwrap()
+}
+
+// ── Publish and query back ───────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_team_publish_and_query() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let d_tag = format!("team-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    let content = serde_json::json!({
+        "name": "Test Team",
+        "description": "A test team for E2E validation",
+        "persona_ids": ["p1", "p2"]
+    })
+    .to_string();
+
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let event = team_event(&keys, &d_tag, &content);
+    let ok = client.send_event(event).await.expect("send team");
+    assert!(ok.accepted, "relay rejected team event: {}", ok.message);
+
+    let sid = sub_id("query");
+    let filter = Filter::new()
+        .kind(Kind::Custom(TEAM_KIND))
+        .author(keys.public_key())
+        .custom_tags(SingleLetterTag::lowercase(Alphabet::D), [d_tag.as_str()]);
+
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe");
+
+    let events = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect events");
+
+    assert_eq!(events.len(), 1, "expected exactly one team event");
+    let ev = &events[0];
+    assert_eq!(ev.content, content);
+    assert_eq!(ev.pubkey, keys.public_key());
+    assert_eq!(ev.kind, Kind::Custom(TEAM_KIND));
+
+    client.disconnect().await.expect("disconnect");
+}
+
+// ── NIP-33 replacement semantics ─────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_team_nip33_replacement_newer_wins() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let d_tag = format!("team-replace-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let now = Timestamp::now().as_secs();
+    let old_content = r#"{"name":"Old Team","persona_ids":["p1"]}"#;
+    let old_event = team_event_at(&keys, &d_tag, old_content, now - 100);
+    let ok = client.send_event(old_event).await.expect("send old");
+    assert!(ok.accepted, "relay rejected old event: {}", ok.message);
+
+    let new_content = r#"{"name":"New Team","persona_ids":["p1","p2"]}"#;
+    let new_event = team_event_at(&keys, &d_tag, new_content, now);
+    let ok = client.send_event(new_event).await.expect("send new");
+    assert!(ok.accepted, "relay rejected new event: {}", ok.message);
+
+    let sid = sub_id("replace");
+    let filter = Filter::new()
+        .kind(Kind::Custom(TEAM_KIND))
+        .author(keys.public_key())
+        .custom_tags(SingleLetterTag::lowercase(Alphabet::D), [d_tag.as_str()]);
+
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe");
+
+    let events = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect");
+
+    assert_eq!(events.len(), 1, "NIP-33: only newest event should remain");
+    assert_eq!(
+        events[0].content, new_content,
+        "should be the newer version"
+    );
+
+    client.disconnect().await.expect("disconnect");
+}
+
+// ── NIP-09 coordinate deletion (tombstone) ───────────────────────────────────
+
+/// The a-tag tombstone is the only state-destroying op in the team flow: it
+/// removes the team for every client and across reboots. This proves the relay
+/// acts on it — publish a team, confirm it is live, publish the a-tag-only
+/// tombstone at its coordinate, then assert the query returns it gone.
+#[tokio::test]
+#[ignore]
+async fn test_team_tombstone_deletes_coordinate() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let d_tag = format!("team-tombstone-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    let content = r#"{"name":"Doomed Team","persona_ids":["p1"]}"#;
+
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let event = team_event(&keys, &d_tag, content);
+    let ok = client.send_event(event).await.expect("send team");
+    assert!(ok.accepted, "relay rejected team event: {}", ok.message);
+
+    let filter = || {
+        Filter::new()
+            .kind(Kind::Custom(TEAM_KIND))
+            .author(keys.public_key())
+            .custom_tags(SingleLetterTag::lowercase(Alphabet::D), [d_tag.as_str()])
+    };
+
+    let sid = sub_id("tombstone-pre");
+    client
+        .subscribe(&sid, vec![filter()])
+        .await
+        .expect("subscribe pre");
+    let before = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect pre");
+    assert_eq!(before.len(), 1, "team should be live before deletion");
+
+    let tombstone = team_delete_event(&keys, &d_tag);
+    let ok = client.send_event(tombstone).await.expect("send tombstone");
+    assert!(ok.accepted, "relay rejected tombstone: {}", ok.message);
+
+    let sid = sub_id("tombstone-post");
+    client
+        .subscribe(&sid, vec![filter()])
+        .await
+        .expect("subscribe post");
+    let after = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect post");
+    assert_eq!(
+        after.len(),
+        0,
+        "tombstone should remove the team coordinate, got {} event(s)",
+        after.len()
+    );
+
+    client.disconnect().await.expect("disconnect");
+}

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -245,6 +245,11 @@ pub async fn update_managed_agent(
             .find(|r| r.pubkey == input.pubkey)
             .ok_or_else(|| format!("agent {} not found", input.pubkey))?;
 
+        // Publish the edit to the relay. After-save, inside the lock, before
+        // any .await. The retention upsert hashes the opt-IN projection, so an
+        // update that touched only runtime/local fields is a no-op publish.
+        super::agents::retain_managed_agent_pending(&app, &state, record);
+
         let sync_params = if name_changed {
             let agent_keys = Keys::parse(&record.private_key_nsec)
                 .map_err(|e| format!("failed to parse agent keys: {e}"))?;

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -26,6 +26,121 @@ fn workspace_owner_hex(state: &AppState) -> Result<String, String> {
     Ok(keys.public_key().to_hex())
 }
 
+/// Retain a freshly authored managed-agent event in the local store, flagged
+/// for relay sync. MUST be called inside the `managed_agents_store_lock`-held
+/// body after `save_managed_agents`, NEVER across an `.await`: it acquires
+/// `state.keys` and a retention-db connection, both `std::sync` guards, and
+/// drops them before returning.
+///
+/// Owner-authored, mirroring `commands::personas::retain_persona_pending`: the
+/// owner keys sign, the d_tag is the agent's pubkey, so the coordinate is
+/// `30177:<owner>:<agent_pubkey>`. The event content is the opt-IN
+/// [`agent_event_content`] projection — the retention upsert's content-equality
+/// guard compares this projection, so an operational start/stop that mutates
+/// only runtime fields produces an identical row and never re-enqueues a
+/// publish. Best-effort: a failure here is logged and swallowed so a retention
+/// hiccup never blocks the disk-authoritative write.
+pub(super) fn retain_managed_agent_pending(
+    app: &AppHandle,
+    state: &AppState,
+    record: &ManagedAgentRecord,
+) {
+    use crate::managed_agents::{
+        agent_events::build_agent_event,
+        retention::{get_retained_event, open_retention_db, retain_event, RetainedEvent},
+    };
+    use buzz_core_pkg::kind::KIND_MANAGED_AGENT;
+    use nostr::JsonUtil;
+
+    let result = (|| -> Result<(), String> {
+        let (owner_pubkey, event) = {
+            let keys = state.keys.lock().map_err(|e| e.to_string())?;
+            let event = build_agent_event(record)?
+                .sign_with_keys(&keys)
+                .map_err(|e| format!("failed to sign managed-agent event: {e}"))?;
+            (keys.public_key().to_hex(), event)
+        };
+        let conn = open_retention_db(&managed_agents_base_dir(app)?.join("retention.db"))?;
+        // Skip re-publishing when the projection is unchanged: compare the new
+        // event's content (the opt-IN projection JSON) against the retained
+        // row's. A start/stop or any edit that touched only excluded
+        // runtime/local fields produces an identical projection, so it is a
+        // no-op here — operational churn never re-enqueues a publish.
+        if let Some(existing) =
+            get_retained_event(&conn, KIND_MANAGED_AGENT, &owner_pubkey, &record.pubkey)?
+        {
+            if existing.content == event.content.as_str() {
+                return Ok(());
+            }
+        }
+        retain_event(
+            &conn,
+            &RetainedEvent {
+                kind: KIND_MANAGED_AGENT,
+                pubkey: owner_pubkey,
+                d_tag: record.pubkey.clone(),
+                content: event.content.to_string(),
+                created_at: event.created_at.as_secs() as i64,
+                raw_event: event.as_json(),
+                pending_sync: true,
+            },
+        )
+    })();
+    if let Err(e) = result {
+        eprintln!("buzz-desktop: agent-retain: {e}");
+    }
+}
+
+/// Purge a deleted agent's pending row and enqueue a NIP-09 tombstone, both
+/// inside the `managed_agents_store_lock`-held delete body and NEVER across an
+/// `.await`.
+///
+/// Mirrors `commands::personas::tombstone_persona_pending`: the agent row at
+/// `(30177, owner, agent_pubkey)` is purged first so an unpublished edit can
+/// never resurrect it after the tombstone publishes, then the kind:5 tombstone
+/// is retained at its own `(5, owner, agent_pubkey)` coordinate with
+/// `pending_sync = 1`. The `d_tag` is the agent's pubkey. Best-effort: a
+/// failure is logged and swallowed so a retention hiccup never blocks the
+/// disk-authoritative delete.
+fn tombstone_managed_agent_pending(app: &AppHandle, state: &AppState, agent_pubkey: &str) {
+    use crate::managed_agents::{
+        agent_events::build_agent_delete,
+        retention::{delete_retained_event, open_retention_db, retain_event, RetainedEvent},
+    };
+    use buzz_core_pkg::kind::KIND_MANAGED_AGENT;
+    use nostr::JsonUtil;
+
+    const KIND_DELETE: u32 = 5;
+
+    let result = (|| -> Result<(), String> {
+        let (owner_pubkey, event) = {
+            let keys = state.keys.lock().map_err(|e| e.to_string())?;
+            let owner_pubkey = keys.public_key().to_hex();
+            let event = build_agent_delete(agent_pubkey, &owner_pubkey)?
+                .sign_with_keys(&keys)
+                .map_err(|e| format!("failed to sign managed-agent tombstone: {e}"))?;
+            (owner_pubkey, event)
+        };
+        let conn = open_retention_db(&managed_agents_base_dir(app)?.join("retention.db"))?;
+        delete_retained_event(&conn, KIND_MANAGED_AGENT, &owner_pubkey, agent_pubkey)?;
+        retain_event(
+            &conn,
+            &RetainedEvent {
+                kind: KIND_DELETE,
+                pubkey: owner_pubkey,
+                d_tag: agent_pubkey.to_string(),
+                content: event.content.to_string(),
+                created_at: event.created_at.as_secs() as i64,
+                raw_event: event.as_json(),
+                pending_sync: true,
+            },
+        )
+    })();
+    if let Err(e) = result {
+        eprintln!("buzz-desktop: agent-tombstone: {e}");
+    }
+}
+
 fn normalize_relay_mesh(
     config: Option<&RelayMeshConfig>,
     backend: &BackendKind,
@@ -586,6 +701,10 @@ pub async fn create_managed_agent(
             .iter()
             .find(|record| record.pubkey == pubkey)
             .ok_or_else(|| "created agent disappeared unexpectedly".to_string())?;
+        // Publish the agent to the relay. Inside the Phase-3 lock, after save,
+        // before any .await — owner-authored, every agent (Will's ruling: no
+        // is_builtin/persona-membership gate).
+        retain_managed_agent_pending(&app, &state, record);
         let personas = load_personas(&app).unwrap_or_default();
         (
             build_managed_agent_summary(&app, record, &runtimes, &personas)?,
@@ -1062,6 +1181,11 @@ pub fn delete_managed_agent(
             return Err(format!("agent {pubkey} not found"));
         }
         save_managed_agents(&app, &records)?;
+        // Tombstone-after-validation: only reached past the deployed-remote
+        // guard above and a confirmed removal — never orphan a live remote
+        // deployment's relay record. Inside the lock, before the block closes
+        // (no .await here). Every agent published, so every delete tombstones.
+        tombstone_managed_agent_pending(&app, &state, &pubkey);
     }
     try_regenerate_nest(&app);
     Ok(())

--- a/desktop/src-tauri/src/commands/personas.rs
+++ b/desktop/src-tauri/src/commands/personas.rs
@@ -29,6 +29,112 @@ fn trim_optional(value: Option<String>) -> Option<String> {
     })
 }
 
+/// Retain a freshly authored persona event in the local store, flagged for
+/// relay sync. Called inside a command's `managed_agents_store_lock`-held body
+/// after `save_personas`; the background flush loop publishes it out-of-band.
+///
+/// The event is signed with the owner keys at call time, so its `created_at`
+/// is `now` — newer than any prior retained row, clearing the upsert's
+/// newer-or-equal guard. `pending_sync = 1` enqueues it for the flush loop,
+/// which is the sole publisher. Best-effort: a failure here is logged and
+/// swallowed so a retention hiccup never blocks the disk-authoritative write.
+///
+/// Unlike `retain_managed_agent_pending`, this has no projection-equality
+/// short-circuit: personas have no start/stop runtime churn, so a republish
+/// only happens on a genuine create/update/delete user edit (`set_persona_active`
+/// does not retain, so the local-only `is_active` toggle never republishes, and
+/// a byte-identical user-save republish is harmlessly NIP-33-replaced). The
+/// guard is intentionally omitted.
+fn retain_persona_pending(app: &AppHandle, state: &AppState, persona: &PersonaRecord) {
+    use crate::managed_agents::{
+        managed_agents_base_dir,
+        persona_events::{build_persona_event, persona_d_tag},
+        retention::{open_retention_db, retain_event, RetainedEvent},
+    };
+    use buzz_core_pkg::kind::KIND_PERSONA;
+    use nostr::JsonUtil;
+
+    let result = (|| -> Result<(), String> {
+        let (pubkey, event) = {
+            let keys = state.keys.lock().map_err(|e| e.to_string())?;
+            let event = build_persona_event(persona)?
+                .sign_with_keys(&keys)
+                .map_err(|e| format!("failed to sign persona event: {e}"))?;
+            (keys.public_key().to_hex(), event)
+        };
+        let conn = open_retention_db(&managed_agents_base_dir(app)?.join("retention.db"))?;
+        retain_event(
+            &conn,
+            &RetainedEvent {
+                kind: KIND_PERSONA,
+                pubkey,
+                d_tag: persona_d_tag(persona),
+                content: event.content.to_string(),
+                created_at: event.created_at.as_secs() as i64,
+                raw_event: event.as_json(),
+                pending_sync: true,
+            },
+        )
+    })();
+    if let Err(e) = result {
+        eprintln!("buzz-desktop: persona-retain: {e}");
+    }
+}
+
+/// Purge a deleted persona's pending row and enqueue a NIP-09 tombstone, both
+/// inside the `managed_agents_store_lock`-held delete body.
+///
+/// PURGE IN: `delete_retained_event` removes the persona's `(30175, pubkey,
+/// d_tag)` row. Running it under the same lock that serializes `retain_event`
+/// closes the same-second resurrect race — a concurrent edit can't re-insert a
+/// pending persona row after the tombstone is queued.
+///
+/// PUBLISH OUT: the kind:5 tombstone is retained at its own coordinate `(5,
+/// pubkey, d_tag)` (distinct from the purged persona row) with `pending_sync =
+/// 1`; the flush loop publishes it. Best-effort: a failure is logged and
+/// swallowed so a retention hiccup never blocks the disk-authoritative delete.
+fn tombstone_persona_pending(app: &AppHandle, state: &AppState, d_tag: &str) {
+    use crate::managed_agents::{
+        managed_agents_base_dir,
+        persona_events::build_persona_delete,
+        retention::{delete_retained_event, open_retention_db, retain_event, RetainedEvent},
+    };
+    use buzz_core_pkg::kind::KIND_PERSONA;
+    use nostr::JsonUtil;
+
+    const KIND_DELETE: u32 = 5;
+
+    let result = (|| -> Result<(), String> {
+        let (pubkey, event) = {
+            let keys = state.keys.lock().map_err(|e| e.to_string())?;
+            let pubkey = keys.public_key().to_hex();
+            let event = build_persona_delete(d_tag, &pubkey)?
+                .sign_with_keys(&keys)
+                .map_err(|e| format!("failed to sign persona tombstone: {e}"))?;
+            (pubkey, event)
+        };
+        let conn = open_retention_db(&managed_agents_base_dir(app)?.join("retention.db"))?;
+        // Purge the persona row first so an unpublished edit can never resurrect
+        // it after the tombstone publishes.
+        delete_retained_event(&conn, KIND_PERSONA, &pubkey, d_tag)?;
+        retain_event(
+            &conn,
+            &RetainedEvent {
+                kind: KIND_DELETE,
+                pubkey,
+                d_tag: d_tag.to_string(),
+                content: event.content.to_string(),
+                created_at: event.created_at.as_secs() as i64,
+                raw_event: event.as_json(),
+                pending_sync: true,
+            },
+        )
+    })();
+    if let Err(e) = result {
+        eprintln!("buzz-desktop: persona-tombstone: {e}");
+    }
+}
+
 #[tauri::command]
 pub fn list_personas(
     app: AppHandle,
@@ -86,6 +192,7 @@ pub fn create_persona(
     };
     personas.push(persona.clone());
     save_personas(&app, &personas)?;
+    retain_persona_pending(&app, &state, &persona);
     try_regenerate_nest(&app);
     Ok(persona)
 }
@@ -139,6 +246,7 @@ pub fn update_persona(
         .into_iter()
         .find(|record| record.id == input.id)
         .ok_or_else(|| format!("persona {} disappeared unexpectedly", input.id))?;
+    retain_persona_pending(&app, &state, &result);
     try_regenerate_nest(&app);
     Ok(result)
 }
@@ -164,6 +272,10 @@ pub fn delete_persona(
             .any(|persona_id| persona_id == id.as_str())
     });
     validate_persona_deletion(persona, referenced_by_team)?;
+    // Capture the coordinate before the record leaves the list. Only reached
+    // for non-builtin, non-team personas (validate_persona_deletion rejects
+    // both), so every deleted persona here is one this owner published.
+    let d_tag = crate::managed_agents::persona_events::persona_d_tag(persona);
 
     let original_len = personas.len();
     personas.retain(|record| record.id != id);
@@ -171,6 +283,7 @@ pub fn delete_persona(
         return Err(format!("persona {id} not found"));
     }
     save_personas(&app, &personas)?;
+    tombstone_persona_pending(&app, &state, &d_tag);
 
     let mut agents = load_managed_agents(&app)?;
     let mut changed_agents = false;

--- a/desktop/src-tauri/src/commands/teams.rs
+++ b/desktop/src-tauri/src/commands/teams.rs
@@ -28,6 +28,99 @@ fn trim_optional(value: Option<String>) -> Option<String> {
     })
 }
 
+/// Retain a freshly authored team event in the local store, flagged for relay
+/// sync. Called inside a command's `managed_agents_store_lock`-held body after
+/// `save_teams`; the background flush loop publishes it out-of-band.
+///
+/// Mirrors `commands::personas::retain_persona_pending`. Built-in teams are not
+/// owner-authored, so the caller skips them — this helper assumes the team is
+/// publishable. Best-effort: a failure here is logged and swallowed so a
+/// retention hiccup never blocks the disk-authoritative write.
+fn retain_team_pending(app: &AppHandle, state: &AppState, team: &TeamRecord) {
+    use crate::managed_agents::{
+        managed_agents_base_dir,
+        retention::{open_retention_db, retain_event, RetainedEvent},
+        team_events::build_team_event,
+    };
+    use buzz_core_pkg::kind::KIND_TEAM;
+    use nostr::JsonUtil;
+
+    let result = (|| -> Result<(), String> {
+        let (pubkey, event) = {
+            let keys = state.keys.lock().map_err(|e| e.to_string())?;
+            let event = build_team_event(team)?
+                .sign_with_keys(&keys)
+                .map_err(|e| format!("failed to sign team event: {e}"))?;
+            (keys.public_key().to_hex(), event)
+        };
+        let conn = open_retention_db(&managed_agents_base_dir(app)?.join("retention.db"))?;
+        retain_event(
+            &conn,
+            &RetainedEvent {
+                kind: KIND_TEAM,
+                pubkey,
+                d_tag: team.id.clone(),
+                content: event.content.to_string(),
+                created_at: event.created_at.as_secs() as i64,
+                raw_event: event.as_json(),
+                pending_sync: true,
+            },
+        )
+    })();
+    if let Err(e) = result {
+        eprintln!("buzz-desktop: team-retain: {e}");
+    }
+}
+
+/// Purge a deleted team's pending row and enqueue a NIP-09 tombstone, both
+/// inside the `managed_agents_store_lock`-held delete body.
+///
+/// Mirrors `commands::personas::tombstone_persona_pending`: the team row is
+/// purged first so an unpublished edit can never resurrect it after the
+/// tombstone publishes, then the kind:5 tombstone is retained at its own
+/// `(5, pubkey, d_tag)` coordinate with `pending_sync = 1`. Best-effort: a
+/// failure is logged and swallowed so a retention hiccup never blocks the
+/// disk-authoritative delete.
+fn tombstone_team_pending(app: &AppHandle, state: &AppState, d_tag: &str) {
+    use crate::managed_agents::{
+        managed_agents_base_dir,
+        retention::{delete_retained_event, open_retention_db, retain_event, RetainedEvent},
+        team_events::build_team_delete,
+    };
+    use buzz_core_pkg::kind::KIND_TEAM;
+    use nostr::JsonUtil;
+
+    const KIND_DELETE: u32 = 5;
+
+    let result = (|| -> Result<(), String> {
+        let (pubkey, event) = {
+            let keys = state.keys.lock().map_err(|e| e.to_string())?;
+            let pubkey = keys.public_key().to_hex();
+            let event = build_team_delete(d_tag, &pubkey)?
+                .sign_with_keys(&keys)
+                .map_err(|e| format!("failed to sign team tombstone: {e}"))?;
+            (pubkey, event)
+        };
+        let conn = open_retention_db(&managed_agents_base_dir(app)?.join("retention.db"))?;
+        delete_retained_event(&conn, KIND_TEAM, &pubkey, d_tag)?;
+        retain_event(
+            &conn,
+            &RetainedEvent {
+                kind: KIND_DELETE,
+                pubkey,
+                d_tag: d_tag.to_string(),
+                content: event.content.to_string(),
+                created_at: event.created_at.as_secs() as i64,
+                raw_event: event.as_json(),
+                pending_sync: true,
+            },
+        )
+    })();
+    if let Err(e) = result {
+        eprintln!("buzz-desktop: team-tombstone: {e}");
+    }
+}
+
 #[tauri::command]
 pub fn list_teams(app: AppHandle, state: State<'_, AppState>) -> Result<Vec<TeamRecord>, String> {
     let _store_guard = state
@@ -69,6 +162,8 @@ pub fn create_team(
     };
     teams.push(team.clone());
     save_teams(&app, &teams)?;
+    // Created teams are always non-builtin; publish to the relay.
+    retain_team_pending(&app, &state, &team);
     Ok(team)
 }
 
@@ -100,6 +195,10 @@ pub fn update_team(
 
     let updated = team.clone();
     save_teams(&app, &teams)?;
+    // Built-in teams are not owner-authored — never publish them.
+    if !updated.is_builtin {
+        retain_team_pending(&app, &state, &updated);
+    }
     Ok(updated)
 }
 
@@ -110,6 +209,10 @@ pub fn delete_team(id: String, app: AppHandle, state: State<'_, AppState>) -> Re
         .lock()
         .map_err(|error| error.to_string())?;
     delete_team_with_cascade(&app, &id)?;
+    // delete_team_with_cascade rejects built-in teams via validate_team_deletion,
+    // so reaching here means this team was owner-published — tombstone it. The
+    // d_tag is the team id, captured before the record left the store.
+    tombstone_team_pending(&app, &state, &id);
     try_regenerate_nest(&app);
     Ok(())
 }

--- a/desktop/src-tauri/src/commands/teams.rs
+++ b/desktop/src-tauri/src/commands/teams.rs
@@ -36,6 +36,10 @@ fn trim_optional(value: Option<String>) -> Option<String> {
 /// owner-authored, so the caller skips them — this helper assumes the team is
 /// publishable. Best-effort: a failure here is logged and swallowed so a
 /// retention hiccup never blocks the disk-authoritative write.
+///
+/// Unlike `retain_managed_agent_pending`, this has no projection-equality
+/// short-circuit: teams have no start/stop runtime churn, so a republish only
+/// happens on an actual user edit. The guard is intentionally omitted.
 fn retain_team_pending(app: &AppHandle, state: &AppState, team: &TeamRecord) {
     use crate::managed_agents::{
         managed_agents_base_dir,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -695,6 +695,32 @@ pub fn run() {
                 }
             });
 
+            // Drain events the retention store flagged `pending_sync` (UI
+            // create/edit, delete tombstones, launch reconcile) to the relay.
+            // One loop is the sole publisher for persona, team, and managed-
+            // agent writers; a relay-unreachable tick leaves rows pending for
+            // the next sweep.
+            let flush_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                use std::time::Duration;
+                use tauri::Manager;
+                let Ok(db_path) = managed_agents::managed_agents_base_dir(&flush_handle)
+                    .map(|d| d.join("retention.db"))
+                else {
+                    eprintln!("buzz-desktop: event-flush: cannot resolve retention db path");
+                    return;
+                };
+                loop {
+                    let state = flush_handle.state::<AppState>();
+                    if let Err(e) =
+                        managed_agents::persona_events::flush_pending_events(&db_path, &state).await
+                    {
+                        eprintln!("buzz-desktop: event-flush: {e}");
+                    }
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                }
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/desktop/src-tauri/src/managed_agents/agent_events.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_events.rs
@@ -1,0 +1,290 @@
+//! Serialize `ManagedAgentRecord` ↔ kind:30177 managed-agent events and
+//! publish via relay.
+//!
+//! Managed-agent events are NIP-33 parameterized replaceable events keyed by
+//! `(pubkey, kind, d_tag)` where `d_tag` is the agent's pubkey. They mirror the
+//! persona event flow (see `persona_events`): the same retention store and
+//! flush loop publish them — this module only owns the kind-specific
+//! projection, build, content-hash, and tombstone.
+//!
+//! # Security: opt-IN allowlist, never record-minus-denylist
+//!
+//! These events are world-readable on the relay. [`ManagedAgentEventContent`]
+//! is an explicit opt-IN projection: it lists exactly the fields that are safe
+//! to publish. A field added to [`super::ManagedAgentRecord`] later defaults to
+//! NOT published unless it is deliberately added here. The flush loop is a
+//! blind pre-signed pipe — this projection is the ONLY guard. It MUST NEVER
+//! carry:
+//! - `private_key_nsec` — the agent's secret key.
+//! - `auth_tag` — the NIP-OA owner attestation.
+//! - `env_vars` — may hold API keys / credentials.
+//! - `backend` — `Provider { config }` is an opaque blob that may hold secrets.
+//! - any runtime field (`runtime_pid`, `last_*`, `backend_agent_id`, …) — these
+//!   mutate on every start/stop and describe transient process state.
+
+use buzz_core_pkg::kind::KIND_MANAGED_AGENT;
+use nostr::{EventBuilder, Kind, Tag};
+use serde::{Deserialize, Serialize};
+
+use super::{ManagedAgentRecord, RespondTo};
+
+/// The JSON body stored in a managed-agent event's content field.
+///
+/// Explicit opt-IN allowlist of the agent's public identity + behavioral
+/// config. See the module docs for the exclusion contract — secrets, the
+/// provider backend blob, and all runtime/install fields are deliberately
+/// absent and must stay that way.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManagedAgentEventContent {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_toolsets: Option<String>,
+    /// `persona_content_hash` of the persona snapshot pinned at create time.
+    /// Public drift indicator (not a secret) — lets other clients flag a stale
+    /// snapshot without re-reading the source persona.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_source_version: Option<String>,
+    pub parallelism: u32,
+    /// Inbound author gate mode (wire string).
+    pub respond_to: RespondTo,
+    /// Allowlisted author pubkeys when `respond_to == Allowlist`. These are
+    /// public keys, not secrets.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub respond_to_allowlist: Vec<String>,
+}
+
+/// Project a `ManagedAgentRecord` onto the content fields published in
+/// managed-agent events.
+///
+/// This is the single source of truth for what leaves the device. The
+/// retention upsert compares the serialized projection to suppress a
+/// re-publish when only excluded runtime/local fields changed, so an
+/// operational start/stop produces an identical projection and never
+/// republishes.
+pub fn agent_event_content(record: &ManagedAgentRecord) -> ManagedAgentEventContent {
+    ManagedAgentEventContent {
+        name: record.name.clone(),
+        persona_id: record.persona_id.clone(),
+        system_prompt: record.system_prompt.clone(),
+        model: record.model.clone(),
+        provider: record.provider.clone(),
+        mcp_toolsets: record.mcp_toolsets.clone(),
+        persona_source_version: record.persona_source_version.clone(),
+        parallelism: record.parallelism,
+        respond_to: record.respond_to,
+        respond_to_allowlist: record.respond_to_allowlist.clone(),
+    }
+}
+
+/// Build a kind:30177 event from a `ManagedAgentRecord`.
+///
+/// Returns an unsigned `EventBuilder` — the caller signs and submits. The
+/// `d_tag` is the agent's pubkey.
+pub fn build_agent_event(record: &ManagedAgentRecord) -> Result<EventBuilder, String> {
+    let content = serde_json::to_string(&agent_event_content(record))
+        .map_err(|e| format!("failed to serialize managed-agent content: {e}"))?;
+    let tags =
+        vec![Tag::parse(["d", record.pubkey.as_str()]).map_err(|e| format!("invalid d-tag: {e}"))?];
+    Ok(EventBuilder::new(Kind::Custom(KIND_MANAGED_AGENT as u16), content).tags(tags))
+}
+
+/// Build a NIP-09 deletion (kind:5) targeting an agent's kind:30177 event.
+///
+/// Carries a single `a`-tag with the NIP-33 coordinate
+/// `30177:<owner>:<d_tag>` and no `e`-tag: an `e`-tag routes the relay to the
+/// event-id deletion path, leaving the parameterized-replaceable coordinate
+/// live. The coordinate delete removes the agent for every client and across
+/// reboots.
+pub fn build_agent_delete(d_tag: &str, owner_pubkey_hex: &str) -> Result<EventBuilder, String> {
+    let coord = format!("{KIND_MANAGED_AGENT}:{owner_pubkey_hex}:{d_tag}");
+    let tag = Tag::parse(["a", coord.as_str()]).map_err(|e| format!("invalid a-tag: {e}"))?;
+    Ok(EventBuilder::new(Kind::Custom(5), "").tags(vec![tag]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn sample_agent() -> ManagedAgentRecord {
+        ManagedAgentRecord {
+            pubkey: "agentpubkeyhex".to_string(),
+            name: "Test Agent".to_string(),
+            persona_id: Some("persona-1".to_string()),
+            private_key_nsec: "nsec1secretdonotpublish".to_string(),
+            auth_tag: Some("authtagsecret".to_string()),
+            relay_url: "wss://relay.example".to_string(),
+            avatar_url: Some("https://example.com/a.png".to_string()),
+            acp_command: "buzz-acp".to_string(),
+            agent_command: "goose".to_string(),
+            agent_args: vec!["--flag".to_string()],
+            mcp_command: "buzz-dev-mcp".to_string(),
+            turn_timeout_seconds: 320,
+            idle_timeout_seconds: None,
+            max_turn_duration_seconds: None,
+            parallelism: 24,
+            system_prompt: Some("You are a test agent.".to_string()),
+            model: Some("claude-opus-4".to_string()),
+            provider: Some("anthropic".to_string()),
+            persona_source_version: Some("abc123".to_string()),
+            mcp_toolsets: Some("default".to_string()),
+            env_vars: BTreeMap::from([("OPENAI_API_KEY".to_string(), "sk-secret".to_string())]),
+            start_on_app_launch: true,
+            runtime_pid: Some(4242),
+            backend: super::super::BackendKind::Provider {
+                id: "buzz-backend-x".to_string(),
+                config: serde_json::json!({ "api_key": "sk-provider-secret" }),
+            },
+            backend_agent_id: Some("remote-id".to_string()),
+            provider_binary_path: Some("/path/to/binary".to_string()),
+            persona_team_dir: None,
+            persona_name_in_team: None,
+            created_at: "2025-01-01T00:00:00Z".to_string(),
+            updated_at: "2025-01-01T00:00:00Z".to_string(),
+            last_started_at: Some("2025-01-02T00:00:00Z".to_string()),
+            last_stopped_at: Some("2025-01-03T00:00:00Z".to_string()),
+            last_exit_code: Some(0),
+            last_error: Some("some runtime error".to_string()),
+            respond_to: RespondTo::Allowlist,
+            respond_to_allowlist: vec!["79be667e".to_string()],
+            relay_mesh: None,
+        }
+    }
+
+    #[test]
+    fn build_agent_event_produces_correct_kind() {
+        let builder = build_agent_event(&sample_agent()).unwrap();
+        let keys = nostr::Keys::generate();
+        let event = builder.sign_with_keys(&keys).unwrap();
+        assert_eq!(event.kind.as_u16() as u32, KIND_MANAGED_AGENT);
+    }
+
+    #[test]
+    fn d_tag_is_agent_pubkey() {
+        let builder = build_agent_event(&sample_agent()).unwrap();
+        let keys = nostr::Keys::generate();
+        let event = builder.sign_with_keys(&keys).unwrap();
+        let d = event
+            .tags
+            .iter()
+            .find_map(|t| {
+                let v: Vec<&str> = t.as_slice().iter().map(|s| s.as_str()).collect();
+                (v.first() == Some(&"d"))
+                    .then(|| v.get(1).map(|s| s.to_string()))
+                    .flatten()
+            })
+            .unwrap();
+        assert_eq!(d, "agentpubkeyhex");
+    }
+
+    /// The security-critical assertion: the published projection must NEVER
+    /// carry secrets, the provider backend blob, env vars, or runtime fields.
+    #[test]
+    fn content_excludes_secrets_and_runtime_fields() {
+        let json = serde_json::to_string(&agent_event_content(&sample_agent())).unwrap();
+
+        // Secrets — must never appear.
+        assert!(
+            !json.contains("nsec1secretdonotpublish"),
+            "leaked private key"
+        );
+        assert!(!json.contains("private_key"), "leaked private key field");
+        assert!(!json.contains("authtagsecret"), "leaked auth tag value");
+        assert!(!json.contains("auth_tag"), "leaked auth tag field");
+        assert!(!json.contains("OPENAI_API_KEY"), "leaked env var key");
+        assert!(!json.contains("sk-secret"), "leaked env var value");
+        assert!(!json.contains("env_vars"), "leaked env var field");
+        assert!(
+            !json.contains("sk-provider-secret"),
+            "leaked provider config secret"
+        );
+        assert!(!json.contains("backend"), "leaked backend blob");
+
+        // Runtime / install fields — must never appear.
+        assert!(!json.contains("runtime_pid"), "leaked runtime pid");
+        assert!(!json.contains("4242"), "leaked runtime pid value");
+        assert!(!json.contains("last_started_at"));
+        assert!(!json.contains("last_stopped_at"));
+        assert!(!json.contains("last_exit_code"));
+        assert!(!json.contains("last_error"));
+        assert!(!json.contains("some runtime error"));
+        assert!(!json.contains("backend_agent_id"));
+        assert!(!json.contains("provider_binary_path"));
+        assert!(!json.contains("relay_url"));
+
+        // Identity fields — must appear.
+        assert!(json.contains("\"name\""));
+        assert!(json.contains("Test Agent"));
+        assert!(json.contains("persona_id"));
+        assert!(json.contains("system_prompt"));
+    }
+
+    #[test]
+    fn projection_is_deterministic() {
+        let agent = sample_agent();
+        let a = serde_json::to_string(&agent_event_content(&agent)).unwrap();
+        let b = serde_json::to_string(&agent_event_content(&agent)).unwrap();
+        assert_eq!(a, b);
+    }
+
+    /// Mutating only runtime fields must NOT change the projection — the
+    /// guarantee that operational start/stop never republishes.
+    #[test]
+    fn projection_ignores_runtime_field_churn() {
+        let agent = sample_agent();
+        let mut churned = agent.clone();
+        churned.runtime_pid = Some(9999);
+        churned.last_started_at = Some("2099-01-01T00:00:00Z".to_string());
+        churned.last_exit_code = Some(1);
+        churned.last_error = Some("different error".to_string());
+        churned.updated_at = "2099-12-31T00:00:00Z".to_string();
+        assert_eq!(
+            agent_event_content(&agent),
+            agent_event_content(&churned),
+            "runtime field churn must not alter the published projection"
+        );
+    }
+
+    #[test]
+    fn projection_changes_on_meaningful_edit() {
+        let agent = sample_agent();
+        let mut edited = agent.clone();
+        edited.system_prompt = Some("A different prompt.".to_string());
+        assert_ne!(agent_event_content(&agent), agent_event_content(&edited));
+    }
+
+    #[test]
+    fn build_agent_delete_has_single_a_tag_no_e_tag() {
+        const OWNER: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let builder = build_agent_delete("agentpubkeyhex", OWNER).unwrap();
+        let keys = nostr::Keys::generate();
+        let event = builder.sign_with_keys(&keys).unwrap();
+
+        assert_eq!(event.kind, Kind::Custom(5));
+
+        let a_tags: Vec<&[String]> = event
+            .tags
+            .iter()
+            .map(|t| t.as_slice())
+            .filter(|v| v.first().map(String::as_str) == Some("a"))
+            .collect();
+        assert_eq!(a_tags.len(), 1);
+        assert_eq!(
+            a_tags[0][1],
+            format!("{KIND_MANAGED_AGENT}:{OWNER}:agentpubkeyhex")
+        );
+
+        assert!(event
+            .tags
+            .iter()
+            .all(|t| t.as_slice().first().map(String::as_str) != Some("e")));
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -4,9 +4,6 @@ mod env_vars;
 mod nest;
 mod persona_avatars;
 mod persona_card;
-// `publish_persona_event` / `fetch_persona_events` are #939 publishing
-// primitives not yet wired to a call site; keep them without a dead-code warn.
-#[allow(dead_code)]
 pub(crate) mod persona_events;
 mod personas;
 #[cfg(windows)]
@@ -14,7 +11,6 @@ mod process_lifecycle;
 #[cfg(feature = "mesh-llm")]
 mod relay_mesh;
 mod restore;
-#[allow(dead_code)]
 pub mod retention;
 mod runtime;
 mod storage;

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -14,6 +14,7 @@ mod restore;
 pub mod retention;
 mod runtime;
 mod storage;
+pub(crate) mod team_events;
 mod team_repair;
 mod teams;
 mod types;

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod agent_events;
 mod backend;
 mod discovery;
 mod env_vars;

--- a/desktop/src-tauri/src/managed_agents/persona_events.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_events.rs
@@ -63,6 +63,18 @@ pub fn build_persona_event(record: &PersonaRecord) -> Result<EventBuilder, Strin
     Ok(EventBuilder::new(Kind::Custom(KIND_PERSONA as u16), content_json).tags(tags))
 }
 
+/// Build a NIP-09 deletion (kind:5) targeting a persona's kind:30175 event.
+///
+/// Carries a single `a`-tag with the NIP-33 coordinate `30175:<owner>:<d_tag>`
+/// and no `e`-tag: an `e`-tag routes the relay to the event-id deletion path,
+/// which leaves the parameterized-replaceable coordinate live. The coordinate
+/// delete removes the persona for every client and across reboots.
+pub fn build_persona_delete(d_tag: &str, owner_pubkey_hex: &str) -> Result<EventBuilder, String> {
+    let coord = format!("{KIND_PERSONA}:{owner_pubkey_hex}:{d_tag}");
+    let tag = Tag::parse(["a", coord.as_str()]).map_err(|e| format!("invalid a-tag: {e}"))?;
+    Ok(EventBuilder::new(Kind::Custom(5), "").tags(vec![tag]))
+}
+
 /// Parse a kind:30175 event back into a `PersonaRecord`.
 ///
 /// The event's d-tag becomes the persona ID and slug.
@@ -104,29 +116,77 @@ pub fn persona_from_event(event: &nostr::Event) -> Result<PersonaRecord, String>
     })
 }
 
-/// Publish a persona event to the relay.
-pub async fn publish_persona_event(
-    record: &PersonaRecord,
+/// Drain every `pending_sync` event from the retention store to the relay.
+///
+/// Each writer (UI create/edit, delete tombstone, launch reconcile) retains a
+/// signed event with `pending_sync = 1`; this loop is the sole publisher.
+///
+/// Per row, the last synchronous read before the network `.await` is a fresh
+/// `get_retained_event` re-check — the connection holds no `Mutex` across the
+/// await, so a concurrent edit or delete is observed here:
+/// - gone (deleted): skip, nothing to publish.
+/// - newer `created_at` or different `content`: skip; the newer row is itself
+///   `pending_sync` and publishes on its own pass.
+///
+/// Only a row that still matches what we read is published, then cleared via
+/// `mark_synced` on the exact `created_at`+`content` the relay accepted — so an
+/// edit landing between publish and clear is never falsely marked synced.
+///
+/// Returns the number of events the relay accepted. Best-effort: a relay
+/// failure on one row leaves it pending for the next sweep and does not abort
+/// the remaining rows.
+pub async fn flush_pending_events(
+    db_path: &std::path::Path,
     state: &AppState,
-) -> Result<String, String> {
-    let builder = build_persona_event(record)?;
-    let response = crate::relay::submit_event(builder, state).await?;
-    Ok(response.event_id)
-}
-
-/// Fetch all persona events authored by the current user from the relay.
-pub async fn fetch_persona_events(state: &AppState) -> Result<Vec<nostr::Event>, String> {
-    let pubkey = {
-        let keys = state.keys.lock().map_err(|e| e.to_string())?;
-        keys.public_key().to_hex()
+) -> Result<u32, String> {
+    use crate::managed_agents::retention::{
+        get_pending_sync, get_retained_event, mark_synced, open_retention_db,
     };
+    use nostr::JsonUtil;
 
-    let filter = serde_json::json!({
-        "kinds": [KIND_PERSONA],
-        "authors": [pubkey]
-    });
+    let pending = {
+        let conn = open_retention_db(db_path)?;
+        get_pending_sync(&conn)?
+    }; // connection dropped before any .await
 
-    crate::relay::query_relay(state, &[filter]).await
+    let mut flushed = 0u32;
+    for row in pending {
+        // Re-read immediately before publishing; the row may have been edited
+        // or deleted since the pending snapshot above.
+        let current = {
+            let conn = open_retention_db(db_path)?;
+            get_retained_event(&conn, row.kind, &row.pubkey, &row.d_tag)?
+        };
+        let Some(current) = current else {
+            continue; // deleted out from under us
+        };
+        if current.created_at != row.created_at || current.content != row.content {
+            continue; // superseded by a newer edit; that row publishes itself
+        }
+
+        let event = nostr::Event::from_json(&current.raw_event)
+            .map_err(|e| format!("failed to parse retained event '{}': {e}", current.d_tag))?;
+
+        if crate::relay::submit_signed_event(&event, state)
+            .await
+            .is_err()
+        {
+            continue; // relay unreachable — stays pending for the next sweep
+        }
+
+        let conn = open_retention_db(db_path)?;
+        mark_synced(
+            &conn,
+            current.kind,
+            &current.pubkey,
+            &current.d_tag,
+            current.created_at,
+            &current.content,
+        )?;
+        flushed += 1;
+    }
+
+    Ok(flushed)
 }
 
 /// SHA-256 (lowercase hex) of a persona's canonical content JSON.
@@ -309,6 +369,32 @@ mod tests {
         // Deserialized persona is always non-builtin and active
         assert!(!restored.is_builtin);
         assert!(restored.is_active);
+    }
+
+    #[test]
+    fn build_persona_delete_has_single_a_tag_no_e_tag() {
+        const OWNER: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let builder = build_persona_delete("test-slug", OWNER).unwrap();
+        let keys = nostr::Keys::generate();
+        let event = builder.sign_with_keys(&keys).unwrap();
+
+        assert_eq!(event.kind, Kind::Custom(5));
+
+        let a_tags: Vec<&[String]> = event
+            .tags
+            .iter()
+            .map(|t| t.as_slice())
+            .filter(|v| v.first().map(String::as_str) == Some("a"))
+            .collect();
+        assert_eq!(a_tags.len(), 1);
+        assert_eq!(a_tags[0][1], format!("{KIND_PERSONA}:{OWNER}:test-slug"));
+
+        // An e-tag would route to the event-id deletion path and leave the
+        // replaceable coordinate live — the tombstone must carry none.
+        assert!(event
+            .tags
+            .iter()
+            .all(|t| t.as_slice().first().map(String::as_str) != Some("e")));
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/retention.rs
+++ b/desktop/src-tauri/src/managed_agents/retention.rs
@@ -1,8 +1,9 @@
 //! Local SQLite retention store for persona events.
 //!
 //! Provides durable client-side storage for persona events, enabling offline
-//! boot when the relay is unreachable. Uses `INSERT OR REPLACE` keyed on
-//! `(kind, pubkey, d_tag)` for NIP-33 latest-wins semantics.
+//! boot when the relay is unreachable. Upserts via `ON CONFLICT DO UPDATE`
+//! keyed on `(kind, pubkey, d_tag)`, replacing only on a newer-or-equal
+//! `created_at` for NIP-33 latest-wins semantics.
 
 use std::path::Path;
 
@@ -21,8 +22,17 @@ pub struct RetainedEvent {
 }
 
 /// Open (or create) the retention database at the given path.
+///
+/// Sets WAL journaling and a `busy_timeout` on every connection so the
+/// flush-loop connection and command-path connections can write concurrently
+/// without spurious `SQLITE_BUSY` errors.
 pub fn open_retention_db(path: &Path) -> Result<Connection, String> {
     let conn = Connection::open(path).map_err(|e| format!("failed to open retention db: {e}"))?;
+
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .map_err(|e| format!("failed to set WAL mode: {e}"))?;
+    conn.pragma_update(None, "busy_timeout", 5000)
+        .map_err(|e| format!("failed to set busy_timeout: {e}"))?;
 
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS persona_events (
@@ -129,14 +139,50 @@ pub fn get_pending_sync(conn: &Connection) -> Result<Vec<RetainedEvent>, String>
         .map_err(|e| format!("failed to read pending sync row: {e}"))
 }
 
-/// Clear the pending_sync flag for a specific event (after relay confirms).
-pub fn mark_synced(conn: &Connection, kind: u32, pubkey: &str, d_tag: &str) -> Result<(), String> {
+/// Clear the `pending_sync` flag for an event the relay just confirmed.
+///
+/// Compare-and-clear: only clears the row if its `created_at` and `content`
+/// still match what was published. A concurrent edit that upserted a newer
+/// version at the same coordinate between the flush loop's read and this call
+/// leaves `pending_sync` set, so the newer edit publishes on the next pass
+/// instead of being silently dropped.
+pub fn mark_synced(
+    conn: &Connection,
+    kind: u32,
+    pubkey: &str,
+    d_tag: &str,
+    created_at: i64,
+    content: &str,
+) -> Result<(), String> {
     conn.execute(
         "UPDATE persona_events SET pending_sync = 0
+         WHERE kind = ?1 AND pubkey = ?2 AND d_tag = ?3
+           AND created_at = ?4 AND content = ?5",
+        params![kind, pubkey, d_tag, created_at, content],
+    )
+    .map_err(|e| format!("failed to mark event synced: {e}"))?;
+
+    Ok(())
+}
+
+/// Delete a retained event by its coordinate.
+///
+/// Called from the synchronous, lock-held delete-persona command body so the
+/// purge serializes against `retain_event` upserts at the same coordinate —
+/// closing the same-second resurrect race where a pending edit would otherwise
+/// publish after the deletion tombstone.
+pub fn delete_retained_event(
+    conn: &Connection,
+    kind: u32,
+    pubkey: &str,
+    d_tag: &str,
+) -> Result<(), String> {
+    conn.execute(
+        "DELETE FROM persona_events
          WHERE kind = ?1 AND pubkey = ?2 AND d_tag = ?3",
         params![kind, pubkey, d_tag],
     )
-    .map_err(|e| format!("failed to mark event synced: {e}"))?;
+    .map_err(|e| format!("failed to delete retained event: {e}"))?;
 
     Ok(())
 }
@@ -263,12 +309,12 @@ mod tests {
     }
 
     #[test]
-    fn mark_synced_clears_flag() {
+    fn test_mark_synced_matching_row_clears_flag() {
         let conn = test_db();
         let event = sample_event();
         retain_event(&conn, &event).unwrap();
 
-        mark_synced(&conn, 30175, "abc123", "test-persona").unwrap();
+        mark_synced(&conn, 30175, "abc123", "test-persona", 1000, &event.content).unwrap();
 
         let pending = get_pending_sync(&conn).unwrap();
         assert!(pending.is_empty());
@@ -276,6 +322,53 @@ mod tests {
         let results = get_retained_personas(&conn, "abc123").unwrap();
         assert_eq!(results.len(), 1);
         assert!(!results[0].pending_sync);
+    }
+
+    #[test]
+    fn test_mark_synced_stale_version_leaves_flag_set() {
+        let conn = test_db();
+        let published = sample_event();
+        retain_event(&conn, &published).unwrap();
+
+        // A newer edit lands at the same coordinate before the flush loop
+        // clears the version it published.
+        let mut newer = sample_event();
+        newer.content = r#"{"display_name":"Edited"}"#.to_string();
+        newer.created_at = 2000;
+        retain_event(&conn, &newer).unwrap();
+
+        // Clearing against the OLD version must not touch the newer pending row.
+        mark_synced(
+            &conn,
+            30175,
+            "abc123",
+            "test-persona",
+            1000,
+            &published.content,
+        )
+        .unwrap();
+
+        let pending = get_pending_sync(&conn).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].created_at, 2000);
+    }
+
+    #[test]
+    fn test_delete_retained_event_removes_row() {
+        let conn = test_db();
+        retain_event(&conn, &sample_event()).unwrap();
+
+        delete_retained_event(&conn, 30175, "abc123", "test-persona").unwrap();
+
+        assert!(get_retained_event(&conn, 30175, "abc123", "test-persona")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_delete_retained_event_missing_row_is_noop() {
+        let conn = test_db();
+        delete_retained_event(&conn, 30175, "abc123", "nonexistent").unwrap();
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/team_events.rs
+++ b/desktop/src-tauri/src/managed_agents/team_events.rs
@@ -1,0 +1,161 @@
+//! Serialize `TeamRecord` ↔ kind:30176 team events and publish via relay.
+//!
+//! Team events are NIP-33 parameterized replaceable events keyed by
+//! `(pubkey, kind, d_tag)` where `d_tag` is the team's stable id. They mirror
+//! the persona event flow (see `persona_events`): the same retention store and
+//! flush loop publish them — this module only owns the kind-specific
+//! projection, build, and tombstone.
+
+use buzz_core_pkg::kind::KIND_TEAM;
+use nostr::{EventBuilder, Kind, Tag};
+use serde::{Deserialize, Serialize};
+
+use super::TeamRecord;
+
+/// The JSON body stored in a team event's content field.
+///
+/// Explicit opt-IN projection of the public team fields. A team carries no
+/// secrets, but the projection is still explicit so a future `TeamRecord`
+/// field is published only when deliberately added here. Local-only fields
+/// (`source_dir`, `is_symlink`, `is_builtin`, timestamps) are intentionally
+/// omitted — they describe this client's install, not the shared team.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamEventContent {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub persona_ids: Vec<String>,
+}
+
+/// Project a `TeamRecord` onto the content fields published in team events.
+/// Centralizes the field mapping so a new published field is added in exactly
+/// one place.
+pub fn team_event_content(record: &TeamRecord) -> TeamEventContent {
+    TeamEventContent {
+        name: record.name.clone(),
+        description: record.description.clone(),
+        persona_ids: record.persona_ids.clone(),
+    }
+}
+
+/// Build a kind:30176 event from a `TeamRecord`.
+///
+/// Returns an unsigned `EventBuilder` — the caller signs and submits.
+pub fn build_team_event(record: &TeamRecord) -> Result<EventBuilder, String> {
+    let content = serde_json::to_string(&team_event_content(record))
+        .map_err(|e| format!("failed to serialize team content: {e}"))?;
+    let tags =
+        vec![Tag::parse(["d", record.id.as_str()]).map_err(|e| format!("invalid d-tag: {e}"))?];
+    Ok(EventBuilder::new(Kind::Custom(KIND_TEAM as u16), content).tags(tags))
+}
+
+/// Build a NIP-09 deletion (kind:5) targeting a team's kind:30176 event.
+///
+/// Carries a single `a`-tag with the NIP-33 coordinate `30176:<owner>:<d_tag>`
+/// and no `e`-tag: an `e`-tag routes the relay to the event-id deletion path,
+/// leaving the parameterized-replaceable coordinate live. The coordinate
+/// delete removes the team for every client and across reboots.
+pub fn build_team_delete(d_tag: &str, owner_pubkey_hex: &str) -> Result<EventBuilder, String> {
+    let coord = format!("{KIND_TEAM}:{owner_pubkey_hex}:{d_tag}");
+    let tag = Tag::parse(["a", coord.as_str()]).map_err(|e| format!("invalid a-tag: {e}"))?;
+    Ok(EventBuilder::new(Kind::Custom(5), "").tags(vec![tag]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn sample_team() -> TeamRecord {
+        TeamRecord {
+            id: "team-123".to_string(),
+            name: "Test Team".to_string(),
+            description: Some("A test team".to_string()),
+            persona_ids: vec!["p1".to_string(), "p2".to_string()],
+            is_builtin: false,
+            source_dir: Some(PathBuf::from("/local/only/path")),
+            is_symlink: true,
+            symlink_target: Some("/somewhere".to_string()),
+            version: Some("1.0".to_string()),
+            created_at: "2025-01-01T00:00:00Z".to_string(),
+            updated_at: "2025-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn build_team_event_produces_correct_kind() {
+        let builder = build_team_event(&sample_team()).unwrap();
+        let keys = nostr::Keys::generate();
+        let event = builder.sign_with_keys(&keys).unwrap();
+        assert_eq!(event.kind.as_u16() as u32, KIND_TEAM);
+    }
+
+    #[test]
+    fn d_tag_is_team_id() {
+        let builder = build_team_event(&sample_team()).unwrap();
+        let keys = nostr::Keys::generate();
+        let event = builder.sign_with_keys(&keys).unwrap();
+        let d = event
+            .tags
+            .iter()
+            .find_map(|t| {
+                let v: Vec<&str> = t.as_slice().iter().map(|s| s.as_str()).collect();
+                (v.first() == Some(&"d"))
+                    .then(|| v.get(1).map(|s| s.to_string()))
+                    .flatten()
+            })
+            .unwrap();
+        assert_eq!(d, "team-123");
+    }
+
+    #[test]
+    fn content_omits_local_only_fields() {
+        let event_content = team_event_content(&sample_team());
+        let json = serde_json::to_string(&event_content).unwrap();
+        // Published fields present.
+        assert!(json.contains("\"name\""));
+        assert!(json.contains("\"persona_ids\""));
+        // Local-only / install-specific fields never published.
+        assert!(!json.contains("source_dir"));
+        assert!(!json.contains("is_symlink"));
+        assert!(!json.contains("symlink_target"));
+        assert!(!json.contains("is_builtin"));
+        assert!(!json.contains("created_at"));
+        assert!(!json.contains("version"));
+    }
+
+    #[test]
+    fn content_round_trips() {
+        let event_content = team_event_content(&sample_team());
+        let json = serde_json::to_string(&event_content).unwrap();
+        let restored: TeamEventContent = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, event_content);
+    }
+
+    #[test]
+    fn build_team_delete_has_single_a_tag_no_e_tag() {
+        const OWNER: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let builder = build_team_delete("team-123", OWNER).unwrap();
+        let keys = nostr::Keys::generate();
+        let event = builder.sign_with_keys(&keys).unwrap();
+
+        assert_eq!(event.kind, Kind::Custom(5));
+
+        let a_tags: Vec<&[String]> = event
+            .tags
+            .iter()
+            .map(|t| t.as_slice())
+            .filter(|v| v.first().map(String::as_str) == Some("a"))
+            .collect();
+        assert_eq!(a_tags.len(), 1);
+        assert_eq!(a_tags[0][1], format!("{KIND_TEAM}:{OWNER}:team-123"));
+
+        // An e-tag would route to the event-id deletion path and leave the
+        // replaceable coordinate live — the tombstone must carry none.
+        assert!(event
+            .tags
+            .iter()
+            .all(|t| t.as_slice().first().map(String::as_str) != Some("e")));
+    }
+}

--- a/desktop/src-tauri/src/migration.rs
+++ b/desktop/src-tauri/src/migration.rs
@@ -917,17 +917,20 @@ pub fn migrate_persona_provider_to_runtime(app: &tauri::AppHandle) {
     rename_provider_to_runtime_in_personas(&path);
 }
 
-/// Migrate existing `personas.json` entries to persona events in the local
-/// retention store.
+/// Reconcile `personas.json` into the persona-event retention store.
 ///
 /// Must run AFTER `migrate_packs_to_teams` (depends on field renames being
 /// complete) and AFTER the persisted identity is resolved (it signs every
 /// retained event with the owner's keys).
 ///
-/// Idempotent: skips when the retention store already holds events for the
-/// owner pubkey — the data is the sentinel, so no separate sentinel file is
-/// needed. This avoids re-running (and resetting `pending_sync`) on every
-/// launch when a sentinel write silently fails.
+/// Per-record reconcile: for each non-builtin persona it compares the freshly
+/// serialized event content against the retained row at the same coordinate
+/// and re-retains (marking `pending_sync = 1`) only when the row is absent or
+/// its content differs. An unchanged persona is left untouched, so a launch
+/// after a no-op edit does not churn `pending_sync`; a persona added or edited
+/// on disk between launches is picked up and republished. There is no
+/// whole-store sentinel — comparing per coordinate is what lets newly added
+/// personas reach the relay.
 ///
 /// Strategy: write to local SQLite retention first (durable copy), mark as
 /// `pending_sync = 1` for later relay publish. Migration succeeds on local
@@ -953,15 +956,15 @@ pub fn migrate_personas_to_events(app: &tauri::AppHandle, keys: &nostr::Keys) {
     }
 }
 
-/// Core migration logic, decoupled from the Tauri `AppHandle` for testing.
+/// Core reconcile logic, decoupled from the Tauri `AppHandle` for testing.
 ///
-/// Returns the number of personas written to the retention store. Returns
-/// `Ok(0)` when migration has already run (retention store has rows for the
-/// owner pubkey) or when there are no non-builtin personas to migrate.
+/// Returns the number of personas (re)written to the retention store. Returns
+/// `Ok(0)` when every non-builtin persona already has a matching retained row
+/// (or there are none to reconcile).
 fn migrate_personas_in_dir(base_dir: &Path, keys: &nostr::Keys) -> Result<u32, String> {
     use crate::managed_agents::{
         persona_events::{build_persona_event, persona_d_tag},
-        retention::{has_retained_personas, open_retention_db, retain_event, RetainedEvent},
+        retention::{get_retained_event, open_retention_db, retain_event, RetainedEvent},
         PersonaRecord,
     };
     use buzz_core_pkg::kind::KIND_PERSONA;
@@ -969,8 +972,7 @@ fn migrate_personas_in_dir(base_dir: &Path, keys: &nostr::Keys) -> Result<u32, S
 
     let pubkey = keys.public_key().to_hex();
 
-    // Read personas.json fresh at migration time. Nothing to migrate if the
-    // file is absent.
+    // Read personas.json fresh at reconcile time. Nothing to do if absent.
     let personas_path = base_dir.join("personas.json");
     if !personas_path.exists() {
         return Ok(0);
@@ -991,12 +993,6 @@ fn migrate_personas_in_dir(base_dir: &Path, keys: &nostr::Keys) -> Result<u32, S
     let conn =
         open_retention_db(&db_path).map_err(|e| format!("failed to open retention db: {e}"))?;
 
-    // Idempotency: the retention rows themselves are the sentinel. If the
-    // owner already has retained personas, migration ran on a prior launch.
-    if has_retained_personas(&conn, &pubkey)? {
-        return Ok(0);
-    }
-
     let mut migrated = 0u32;
 
     for record in &records {
@@ -1014,11 +1010,20 @@ fn migrate_personas_in_dir(base_dir: &Path, keys: &nostr::Keys) -> Result<u32, S
             .sign_with_keys(keys)
             .map_err(|e| format!("failed to sign event for '{}': {e}", record.display_name))?;
 
+        // Per-coordinate reconcile: skip when an identical body is already
+        // retained, so an unchanged persona doesn't reset `pending_sync`.
+        let event_content = event.content.to_string();
+        if let Some(existing) = get_retained_event(&conn, KIND_PERSONA, &pubkey, &d_tag)? {
+            if existing.content == event_content {
+                continue;
+            }
+        }
+
         let retained = RetainedEvent {
             kind: KIND_PERSONA,
             pubkey: pubkey.clone(),
             d_tag,
-            content: event.content.to_string(),
+            content: event_content,
             // Safety: nostr timestamps are seconds and stay below i64::MAX
             // until year 2262.
             created_at: event.created_at.as_secs() as i64,

--- a/desktop/src-tauri/src/migration_tests.rs
+++ b/desktop/src-tauri/src/migration_tests.rs
@@ -793,16 +793,97 @@ fn migrate_personas_skips_builtins() {
 }
 
 #[test]
-fn migrate_personas_skips_when_retention_already_populated() {
+fn migrate_personas_unchanged_second_run_is_noop() {
     let base = tempfile::tempdir().unwrap();
     write_base_personas(base.path(), &one_persona());
     let keys = nostr::Keys::generate();
 
-    // First run migrates; second run is a no-op (retention rows are the
-    // sentinel — no separate sentinel file).
+    // First run retains; second run with identical personas re-retains
+    // nothing — the per-coordinate content matches, so `pending_sync` is
+    // not churned.
     assert_eq!(migrate_personas_in_dir(base.path(), &keys).unwrap(), 1);
     assert_eq!(migrate_personas_in_dir(base.path(), &keys).unwrap(), 0);
     assert!(!base.path().join("migration_state.json").exists());
+}
+
+#[test]
+fn migrate_personas_new_persona_after_first_run_gets_retained() {
+    use crate::managed_agents::retention::{get_retained_personas, open_retention_db};
+
+    let base = tempfile::tempdir().unwrap();
+    write_base_personas(base.path(), &one_persona());
+    let keys = nostr::Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+
+    assert_eq!(migrate_personas_in_dir(base.path(), &keys).unwrap(), 1);
+
+    // A persona added to personas.json after the first reconcile must be
+    // picked up — the whole-store sentinel that previously short-circuited
+    // this is gone.
+    let mut two = one_persona();
+    two.as_array_mut().unwrap().push(serde_json::json!({
+        "id": "test-writer",
+        "display_name": "Test Writer",
+        "system_prompt": "You write tests.",
+        "is_builtin": false,
+        "is_active": true,
+        "name_pool": [],
+        "env_vars": {},
+        "created_at": "2025-01-02T00:00:00Z",
+        "updated_at": "2025-01-02T00:00:00Z"
+    }));
+    write_base_personas(base.path(), &two);
+
+    assert_eq!(migrate_personas_in_dir(base.path(), &keys).unwrap(), 1);
+
+    let conn = open_retention_db(&base.path().join("retention.db")).unwrap();
+    let rows = get_retained_personas(&conn, &pubkey).unwrap();
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn migrate_personas_edited_persona_re_retains_pending() {
+    use crate::managed_agents::retention::{get_retained_event, mark_synced, open_retention_db};
+    use buzz_core_pkg::kind::KIND_PERSONA;
+
+    let base = tempfile::tempdir().unwrap();
+    write_base_personas(base.path(), &one_persona());
+    let keys = nostr::Keys::generate();
+    let pubkey = keys.public_key().to_hex();
+
+    assert_eq!(migrate_personas_in_dir(base.path(), &keys).unwrap(), 1);
+
+    // Simulate the flush loop confirming the first publish.
+    let conn = open_retention_db(&base.path().join("retention.db")).unwrap();
+    let row = get_retained_event(&conn, KIND_PERSONA, &pubkey, "code-reviewer")
+        .unwrap()
+        .unwrap();
+    mark_synced(
+        &conn,
+        KIND_PERSONA,
+        &pubkey,
+        "code-reviewer",
+        row.created_at,
+        &row.content,
+    )
+    .unwrap();
+    drop(conn);
+
+    // Editing the persona on disk must re-retain it as pending so the edit
+    // reaches the relay on the next flush.
+    let mut edited = one_persona();
+    edited.as_array_mut().unwrap()[0]["system_prompt"] =
+        serde_json::json!("You review code carefully.");
+    write_base_personas(base.path(), &edited);
+
+    assert_eq!(migrate_personas_in_dir(base.path(), &keys).unwrap(), 1);
+
+    let conn = open_retention_db(&base.path().join("retention.db")).unwrap();
+    let row = get_retained_event(&conn, KIND_PERSONA, &pubkey, "code-reviewer")
+        .unwrap()
+        .unwrap();
+    assert!(row.pending_sync);
+    assert!(row.content.contains("carefully"));
 }
 
 #[test]

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -503,6 +503,47 @@ pub async fn submit_event(
     Ok(result)
 }
 
+/// POST an already-signed event to `/events` with NIP-98 auth.
+///
+/// The persona flush loop drains pre-signed events from the retention store,
+/// so it must publish them verbatim — re-signing through `submit_event` would
+/// mint a new `created_at`/signature and break the compare-and-clear that
+/// `mark_synced` relies on. Only the NIP-98 request auth is signed here (with
+/// the owner keys), and that lock is dropped before the `.await`.
+pub async fn submit_signed_event(
+    event: &nostr::Event,
+    state: &AppState,
+) -> Result<SubmitEventResponse, String> {
+    let url = format!("{}/events", relay_api_base_url_with_override(state));
+    let body_bytes = event.as_json().into_bytes();
+    let auth_header = {
+        let keys = state.keys.lock().map_err(|e| e.to_string())?;
+        build_nip98_auth_header_for_keys(&keys, &Method::POST, &url, &body_bytes)?
+    }; // keys lock dropped here
+
+    let response = state
+        .http_client
+        .post(&url)
+        .header("Authorization", auth_header)
+        .header("Content-Type", "application/json")
+        .body(body_bytes)
+        .send()
+        .await
+        .map_err(|e| classify_request_error(&e))?;
+
+    if !response.status().is_success() {
+        return Err(relay_error_message(response).await);
+    }
+
+    let result: SubmitEventResponse = parse_json_response(response).await?;
+
+    if !result.accepted {
+        return Err(format!("relay rejected event: {}", result.message));
+    }
+
+    Ok(result)
+}
+
 /// Sign an event with explicit keys and POST it to `/events` with NIP-98 auth.
 ///
 /// Managed-agent flows use this to publish as the agent itself while still


### PR DESCRIPTION
Wires the [#939](https://github.com/block/buzz/pull/939) retention/publish primitives to their call sites so persona (`30175`), team (`30176`), and managed-agent (`30177`) records publish as NIP-33 parameterized-replaceable events. #939 landed the primitives — the kind-generic retention store, `submit_signed_event`, and the projection/build helpers — but deferred all the call-site wiring; this PR adds it for all three kinds in one pass and teaches the relay to accept the two new kinds.

## Model: retention-first

Every writer (UI create/edit, delete tombstone) signs an event and writes it to the local SQLite retention store with `pending_sync = 1` — the disk copy is authoritative and the write never blocks on the network. A single background loop is the sole publisher: it drains pending rows to the relay every 30s and clears `pending_sync` only on the exact `created_at`+`content` the relay accepted. A relay-unreachable tick leaves rows pending for the next sweep.

The retention table is keyed by `(kind, pubkey, d_tag)` and is fully kind-generic, so team and managed-agent rows share it with persona rows at zero schema cost.

## Desktop wiring

- `flush_pending_events` (the kind-agnostic drain loop, spawned at startup in `lib.rs`) — re-reads each row immediately before publishing, so a concurrent edit or delete is observed: a superseded or deleted row is skipped and the newer row publishes on its own pass.
- `retain_event` on create/edit for all three kinds; `delete_retained_event` + a NIP-09 kind:5 tombstone on delete. The pending row is purged **before** the tombstone is retained, so an unpublished edit can never resurrect a deleted record after the tombstone publishes.
- Republish suppression keys on the **projected content**, not the raw record: an edit (or operational start/stop for agents) that touched only excluded fields produces an identical projection and is a no-op, so churn never re-enqueues a publish.

## Managed-agent secret exclusion

`ManagedAgentEventContent` is an explicit opt-**IN** allowlist — it lists exactly the public-identity and behavioral-config fields safe to broadcast, never a record-minus-denylist. The signed event is world-readable on the relay, so this projection is the only guard: `private_key_nsec`, `env_vars`, the opaque `backend` provider blob, and all runtime/install fields are deliberately excluded.

## Relay accept-path

`required_scope_for_kind` registers `KIND_TEAM` and `KIND_MANAGED_AGENT` in the same `UsersWrite` arm as `KIND_PERSONA` (owner-authored, user-scoped state keyed by the signing key), and both are marked global-only so a stray `h` tag never channel-scopes them. Team ids and 64-hex agent pubkeys satisfy the generic parameterized-replaceable `d_tag` path (`D_TAG_MAX_LEN` only) — the persona slug envelope is not extended.

## Concurrency

No `MutexGuard` is held across an `.await`: the signing-key lock is scoped to a synchronous block that returns the signed event, and the drain loop re-opens the retention connection per row, dropping it before each network send.

## Stack

Based on [#939](https://github.com/block/buzz/pull/939) (`wpfleger/persona-events`). Merge-gated on #939 landing first.
