### PR TITLE
fix(desktop): preserve login-shell PATH for managed agents

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -11,6 +11,9 @@ use crate::{
     util::now_iso,
 };
 
+mod path;
+use path::build_augmented_path;
+
 type RespondToEnv = (Vec<(&'static str, String)>, Vec<&'static str>);
 
 /// Binary name fragments for all known agent/harness processes that Buzz
@@ -1535,28 +1538,13 @@ pub fn spawn_agent_child(
     //   - bundled CLI via ~/.local/bin symlink
     //   - bundled sidecars (buzz, buzz-acp, etc.) via exe parent (Contents/MacOS/)
     //   - runtimes (node, python, etc.) via login shell PATH
-    let augmented_path = {
-        let mut parts: Vec<std::path::PathBuf> = Vec::new();
-        if let Some(home) = dirs::home_dir() {
-            parts.push(home.join(".local").join("bin"));
-        }
-        if let Ok(exe) = std::env::current_exe() {
-            if let Some(parent) = exe.parent() {
-                parts.push(parent.to_path_buf());
-            }
-        }
-        if let Some(shell_path) = login_shell_path() {
-            parts.push(std::path::PathBuf::from(shell_path));
-        }
-        if parts.is_empty() {
-            None
-        } else {
-            // join_paths uses the platform separator (':' on Unix, ';' on Windows).
-            std::env::join_paths(parts)
-                .ok()
-                .map(|s| s.to_string_lossy().into_owned())
-        }
-    };
+    let augmented_path = build_augmented_path(
+        dirs::home_dir(),
+        std::env::current_exe()
+            .ok()
+            .and_then(|exe| exe.parent().map(std::path::Path::to_path_buf)),
+        login_shell_path(),
+    );
 
     let mut command = std::process::Command::new(&resolved_acp_command);
     if let Some(home) = super::default_agent_workdir() {

--- a/desktop/src-tauri/src/managed_agents/runtime/path.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/path.rs
@@ -1,0 +1,79 @@
+//! PATH augmentation for launched managed-agent child processes.
+
+use std::path::PathBuf;
+
+/// Assemble the augmented `PATH` for a launched managed-agent child process.
+///
+/// Concatenates, in priority order: `<home>/.local/bin` (the bundled CLI
+/// symlink), the running executable's parent dir (DMG sidecars under
+/// `Contents/MacOS/`), and the user's login-shell `PATH` (runtimes like
+/// node/python).
+///
+/// `shell_path` is the raw colon-delimited string from a login shell, so it is
+/// split into individual entries before joining. Pushing it as a single segment
+/// would make `join_paths` reject it (a segment containing the separator is an
+/// error), collapsing the entire augmented `PATH` to `None` — the bug this
+/// guards against, which left managed agents unable to find `buzz`. Returns
+/// `None` only when no entries exist.
+pub(super) fn build_augmented_path(
+    home: Option<PathBuf>,
+    exe_parent: Option<PathBuf>,
+    shell_path: Option<String>,
+) -> Option<String> {
+    let mut parts: Vec<PathBuf> = Vec::new();
+    if let Some(home) = home {
+        parts.push(home.join(".local").join("bin"));
+    }
+    if let Some(parent) = exe_parent {
+        parts.push(parent);
+    }
+    if let Some(shell_path) = shell_path {
+        parts.extend(std::env::split_paths(&shell_path));
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    // join_paths uses the platform separator (':' on Unix, ';' on Windows).
+    std::env::join_paths(parts)
+        .ok()
+        .map(|s| s.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_augmented_path;
+    use std::path::PathBuf;
+
+    #[cfg(unix)]
+    #[test]
+    fn splits_colon_delimited_shell_path() {
+        // Regression: the shell PATH arrives as one colon-delimited string. It
+        // must be split into segments before join_paths, or join_paths rejects
+        // it and the whole augmented PATH collapses to None (managed agents then
+        // lose `buzz`).
+        let result = build_augmented_path(
+            Some(PathBuf::from("/home/agent")),
+            Some(PathBuf::from("/Applications/Buzz.app/Contents/MacOS")),
+            Some("/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin".to_string()),
+        );
+        assert_eq!(
+            result.as_deref(),
+            Some(
+                "/home/agent/.local/bin:/Applications/Buzz.app/Contents/MacOS:\
+/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+            ),
+        );
+    }
+
+    #[test]
+    fn none_when_no_inputs() {
+        assert_eq!(build_augmented_path(None, None, None), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_path_only() {
+        let result = build_augmented_path(None, None, Some("/usr/bin:/bin".to_string()));
+        assert_eq!(result.as_deref(), Some("/usr/bin:/bin"));
+    }
+}


### PR DESCRIPTION
## Summary
- split the login-shell `PATH` with `std::env::split_paths` before passing entries to `std::env::join_paths`
- extract managed-agent PATH assembly into a small pure helper so the regression is unit-testable while keeping `runtime.rs` under the existing file-size cap
- add regression coverage for colon-delimited shell PATHs no longer collapsing the augmented PATH to `None`

## Review notes
- Root cause: `login_shell_path()` returns one colon-delimited string; treating it as one `PathBuf` makes `join_paths` fail on Unix (`path segment contains separator ':'`). The prior `.ok()` then dropped the entire augmented PATH, so launched agents inherited the bare GUI-launch PATH and could not find `buzz`, `gh`, Homebrew tools, etc.
- User-provided persona/agent env vars still run after this setup, so explicit `PATH` overrides continue to win.

## Validation
- `./bin/cargo test --manifest-path desktop/src-tauri/Cargo.toml managed_agents::runtime::path -- --nocapture`
- `./bin/cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- `cd desktop && ../bin/pnpm check:file-sizes`
- `cd desktop && ../bin/cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cd desktop && ../bin/cargo test --manifest-path src-tauri/Cargo.toml`
- pre-push hooks on `git push -u origin fix/managed-agent-path-join` (desktop/mobile/rust fast tests) passed
