### PR TITLE
Move agent management into profile sidebar

### DIFF
--- a/desktop/src/app/routes/channels.$channelId.tsx
+++ b/desktop/src/app/routes/channels.$channelId.tsx
@@ -1,13 +1,17 @@
 import * as React from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
+import {
+  parseProfilePanelView,
+  type ProfilePanelView,
+} from "@/features/profile/ui/UserProfilePanelUtils";
 import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
 
 type ChannelRouteSearch = {
   agentSession?: string;
   messageId?: string;
   profile?: string;
-  profileView?: "memories" | "channels";
+  profileView?: ProfilePanelView;
   thread?: string;
   threadRootId?: string;
 };
@@ -16,8 +20,8 @@ function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function profileViewValue(value: unknown): "memories" | "channels" | undefined {
-  return value === "memories" || value === "channels" ? value : undefined;
+function profileViewValue(value: unknown): ProfilePanelView | undefined {
+  return parseProfilePanelView(value) ?? undefined;
 }
 
 function validateChannelSearch(

--- a/desktop/src/app/routes/pulse.tsx
+++ b/desktop/src/app/routes/pulse.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
+import {
+  parseProfilePanelView,
+  type ProfilePanelView,
+} from "@/features/profile/ui/UserProfilePanelUtils";
 import { usePreviewFeatureWarning } from "@/shared/features";
 import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
 
@@ -11,7 +15,7 @@ const PulseScreen = React.lazy(async () => {
 
 type PulseRouteSearch = {
   profile?: string;
-  profileView?: "memories" | "channels";
+  profileView?: ProfilePanelView;
 };
 
 function validatePulseSearch(
@@ -22,10 +26,7 @@ function validatePulseSearch(
       typeof search.profile === "string" && search.profile.length > 0
         ? search.profile
         : undefined,
-    profileView:
-      search.profileView === "memories" || search.profileView === "channels"
-        ? search.profileView
-        : undefined,
+    profileView: parseProfilePanelView(search.profileView) ?? undefined,
   };
 }
 

--- a/desktop/src/features/agents/observerRelayStore.test.mjs
+++ b/desktop/src/features/agents/observerRelayStore.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+
+import {
+  isKnownAgentPubkey,
+  registerKnownAgentPubkeys,
+  resetAgentObserverStore,
+  unregisterKnownAgentPubkeys,
+} from "./observerRelayStore.ts";
+
+const AGENT_A =
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const AGENT_B =
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const AGENT_C =
+  "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+describe("observerRelayStore known agent registrations", () => {
+  beforeEach(() => {
+    resetAgentObserverStore();
+  });
+
+  it("unions known agents from multiple bridge registrations", () => {
+    const agentsPage = Symbol("agents-page");
+    const profilePanel = Symbol("profile-panel");
+
+    registerKnownAgentPubkeys(agentsPage, [AGENT_A, AGENT_B]);
+    registerKnownAgentPubkeys(profilePanel, [AGENT_C]);
+
+    assert.equal(isKnownAgentPubkey(AGENT_A), true);
+    assert.equal(isKnownAgentPubkey(AGENT_B), true);
+    assert.equal(isKnownAgentPubkey(AGENT_C), true);
+
+    registerKnownAgentPubkeys(profilePanel, []);
+
+    assert.equal(isKnownAgentPubkey(AGENT_A), true);
+    assert.equal(isKnownAgentPubkey(AGENT_B), true);
+    assert.equal(isKnownAgentPubkey(AGENT_C), false);
+
+    unregisterKnownAgentPubkeys(agentsPage);
+
+    assert.equal(isKnownAgentPubkey(AGENT_A), false);
+    assert.equal(isKnownAgentPubkey(AGENT_B), false);
+  });
+});

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -47,7 +47,7 @@ const snapshotByAgent = new Map<string, ObserverSnapshot>();
 // We key each subscriber's contribution in `knownAgentsBySubscription` and
 // recompute the union, so co-mounted callers no longer clobber each other.
 const knownAgentPubkeys = new Set<string>();
-const knownAgentsBySubscription = new Map<string, Set<string>>();
+const knownAgentsBySubscription = new Map<string | symbol, Set<string>>();
 
 function recomputeKnownAgentPubkeys() {
   knownAgentPubkeys.clear();
@@ -58,8 +58,8 @@ function recomputeKnownAgentPubkeys() {
   }
 }
 
-function registerKnownAgents(
-  subscriptionId: string,
+export function registerKnownAgentPubkeys(
+  subscriptionId: string | symbol,
   pubkeys: readonly string[],
 ) {
   knownAgentsBySubscription.set(
@@ -69,10 +69,14 @@ function registerKnownAgents(
   recomputeKnownAgentPubkeys();
 }
 
-function unregisterKnownAgents(subscriptionId: string) {
+export function unregisterKnownAgentPubkeys(subscriptionId: string | symbol) {
   if (knownAgentsBySubscription.delete(subscriptionId)) {
     recomputeKnownAgentPubkeys();
   }
+}
+
+export function isKnownAgentPubkey(pubkey: string) {
+  return knownAgentPubkeys.has(normalizePubkey(pubkey));
 }
 
 let connectionState: ConnectionState = "idle";
@@ -176,7 +180,7 @@ async function handleRelayObserverEvent(
 
   // Verify agent is known/trusted before decrypting.
   // Silently drop events from agents we are not managing.
-  if (!knownAgentPubkeys.has(normalizePubkey(agentPubkey))) {
+  if (!isKnownAgentPubkey(agentPubkey)) {
     return;
   }
 
@@ -326,9 +330,9 @@ export function useManagedAgentObserverBridge(
   // own agent list. The store recomputes the union across all subscribers, so
   // a co-mounted caller no longer wipes out this caller's agents.
   React.useEffect(() => {
-    registerKnownAgents(subscriptionId, agentPubkeys);
+    registerKnownAgentPubkeys(subscriptionId, agentPubkeys);
     return () => {
-      unregisterKnownAgents(subscriptionId);
+      unregisterKnownAgentPubkeys(subscriptionId);
     };
   }, [subscriptionId, agentPubkeys]);
 

--- a/desktop/src/features/agents/ui/AgentGroupRows.tsx
+++ b/desktop/src/features/agents/ui/AgentGroupRows.tsx
@@ -6,7 +6,6 @@ export type AgentGroupRowsProps = {
   agents: ManagedAgent[];
   channelIdToName: Record<string, string>;
   channelsByPubkey: Record<string, { id: string; name: string }[]>;
-  isActionPending: boolean;
   logContent: string | null;
   logError: Error | null;
   logLoading: boolean;
@@ -14,19 +13,14 @@ export type AgentGroupRowsProps = {
   presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
   selectedLogAgentPubkey: string | null;
-  onAddToChannel: (agent: ManagedAgent) => void;
-  onDelete: (pubkey: string) => void;
+  onOpenProfile: (pubkey: string) => void;
   onSelectLogAgent: (pubkey: string | null) => void;
-  onStart: (pubkey: string) => void;
-  onStop: (pubkey: string) => void;
-  onToggleStartOnAppLaunch: (pubkey: string, startOnAppLaunch: boolean) => void;
 };
 
 export function AgentGroupRows({
   agents,
   channelIdToName,
   channelsByPubkey,
-  isActionPending,
   logContent,
   logError,
   logLoading,
@@ -34,12 +28,8 @@ export function AgentGroupRows({
   presenceLoaded,
   presenceLookup,
   selectedLogAgentPubkey,
-  onAddToChannel,
-  onDelete,
+  onOpenProfile,
   onSelectLogAgent,
-  onStart,
-  onStop,
-  onToggleStartOnAppLaunch,
 }: AgentGroupRowsProps) {
   return (
     <div className="divide-y divide-border/50 border-t border-border/50">
@@ -48,7 +38,6 @@ export function AgentGroupRows({
           agent={agent}
           channelIdToName={channelIdToName}
           channelNames={channelsByPubkey[normalizePubkey(agent.pubkey)] ?? []}
-          isActionPending={isActionPending}
           isLogSelected={selectedLogAgentPubkey === agent.pubkey}
           key={agent.pubkey}
           logContent={
@@ -59,12 +48,8 @@ export function AgentGroupRows({
           personaLabelsById={personaLabelsById}
           presenceLoaded={presenceLoaded}
           presenceLookup={presenceLookup}
-          onAddToChannel={onAddToChannel}
-          onDelete={onDelete}
+          onOpenProfile={onOpenProfile}
           onSelectLogAgent={onSelectLogAgent}
-          onStart={onStart}
-          onStop={onStop}
-          onToggleStartOnAppLaunch={onToggleStartOnAppLaunch}
         />
       ))}
     </div>

--- a/desktop/src/features/agents/ui/AgentsScreen.tsx
+++ b/desktop/src/features/agents/ui/AgentsScreen.tsx
@@ -1,5 +1,12 @@
 import * as React from "react";
 
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useOpenDmMutation } from "@/features/channels/hooks";
+import { UserProfilePanel } from "@/features/profile/ui/UserProfilePanel";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type { AgentPersona } from "@/shared/api/types";
+import { ProfilePanelProvider } from "@/shared/context/ProfilePanelContext";
+import { useThreadPanelWidth } from "@/shared/hooks/useThreadPanelWidth";
 import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
 
 const AgentsView = React.lazy(async () => {
@@ -7,12 +14,63 @@ const AgentsView = React.lazy(async () => {
   return { default: module.AgentsView };
 });
 
+type ProfilePanelTarget =
+  | { kind: "pubkey"; pubkey: string }
+  | { kind: "persona"; persona: AgentPersona };
+
 export function AgentsScreen() {
+  const identityQuery = useIdentityQuery();
+  const [profilePanelTarget, setProfilePanelTarget] =
+    React.useState<ProfilePanelTarget | null>(null);
+  const threadPanelWidth = useThreadPanelWidth();
+  const openDmMutation = useOpenDmMutation();
+  const { goChannel } = useAppNavigation();
+
+  const handleOpenDm = React.useCallback(
+    async (pubkeys: string[]) => {
+      const dm = await openDmMutation.mutateAsync({ pubkeys });
+      await goChannel(dm.id);
+    },
+    [goChannel, openDmMutation],
+  );
+
   return (
-    <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      <React.Suspense fallback={<ViewLoadingFallback kind="agents" />}>
-        <AgentsView />
-      </React.Suspense>
-    </div>
+    <ProfilePanelProvider
+      onOpenPersonaProfilePanel={(persona) =>
+        setProfilePanelTarget({ kind: "persona", persona })
+      }
+      onOpenProfilePanel={(pubkey) =>
+        setProfilePanelTarget({ kind: "pubkey", pubkey })
+      }
+    >
+      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden">
+          <React.Suspense fallback={<ViewLoadingFallback kind="agents" />}>
+            <AgentsView />
+          </React.Suspense>
+          {profilePanelTarget ? (
+            <UserProfilePanel
+              canResetWidth={threadPanelWidth.canReset}
+              currentPubkey={identityQuery.data?.pubkey}
+              onClose={() => setProfilePanelTarget(null)}
+              onOpenDm={handleOpenDm}
+              onResetWidth={threadPanelWidth.onResetWidth}
+              onResizeStart={threadPanelWidth.onResizeStart}
+              persona={
+                profilePanelTarget.kind === "persona"
+                  ? profilePanelTarget.persona
+                  : undefined
+              }
+              pubkey={
+                profilePanelTarget.kind === "pubkey"
+                  ? profilePanelTarget.pubkey
+                  : undefined
+              }
+              widthPx={threadPanelWidth.widthPx}
+            />
+          ) : null}
+        </div>
+      </div>
+    </ProfilePanelProvider>
   );
 }

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -22,8 +22,10 @@ import { UnifiedAgentsSection } from "./UnifiedAgentsSection";
 import { useManagedAgentActions } from "./useManagedAgentActions";
 import { usePersonaActions } from "./usePersonaActions";
 import { useTeamActions } from "./useTeamActions";
+import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 
 export function AgentsView() {
+  const { openPersonaProfilePanel, openProfilePanel } = useProfilePanel();
   const agents = useManagedAgentActions();
   const personas = usePersonaActions();
   const teamActions = useTeamActions(
@@ -83,11 +85,6 @@ export function AgentsView() {
               personaLabelsById={personas.personaLabelsById}
               presenceLoaded={agents.managedPresenceQuery.isSuccess}
               presenceLookup={agents.managedPresenceQuery.data ?? {}}
-              onAddToChannel={(agent) => {
-                agents.setActionNoticeMessage(null);
-                agents.setActionErrorMessage(null);
-                agents.setAgentToAddToChannel(agent);
-              }}
               onBulkRemoveStopped={() => {
                 void agents.handleBulkRemoveStopped();
               }}
@@ -97,22 +94,13 @@ export function AgentsView() {
               onCreateAgent={() => {
                 agents.setIsCreateOpen(true);
               }}
-              onDeleteAgent={(pubkey) => {
-                void agents.handleDelete(pubkey);
+              onOpenAgentProfile={(pubkey) => {
+                openProfilePanel?.(pubkey);
+              }}
+              onOpenPersonaProfile={(persona) => {
+                openPersonaProfilePanel?.(persona);
               }}
               onSelectLogAgent={agents.setLogAgentPubkey}
-              onStartAgent={(pubkey) => {
-                void agents.handleStart(pubkey);
-              }}
-              onStopAgent={(pubkey) => {
-                void agents.handleStop(pubkey);
-              }}
-              onToggleStartOnAppLaunch={(pubkey, startOnAppLaunch) => {
-                void agents.handleToggleStartOnAppLaunch(
-                  pubkey,
-                  startOnAppLaunch,
-                );
-              }}
               selectedLogAgentPubkey={agents.logAgentPubkey}
               // Persona props
               canChooseCatalog={personas.catalogPersonas.length > 0}
@@ -136,13 +124,6 @@ export function AgentsView() {
               isPersonasPending={personas.isPending}
               onCreatePersona={personas.openCreate}
               onChooseCatalog={personas.openCatalog}
-              onDuplicatePersona={personas.openDuplicate}
-              onEditPersona={personas.openEdit}
-              onExportPersona={personas.handleExport}
-              onDeactivatePersona={(persona) => {
-                void personas.handleSetActive(persona, false, "library");
-              }}
-              onDeletePersona={personas.openDelete}
               onImportPersonaFile={(fileBytes, fileName) => {
                 void personas.handleImportFile(fileBytes, fileName);
               }}

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -1,20 +1,6 @@
 import * as React from "react";
 
-import {
-  AlertTriangle,
-  ChevronDown,
-  ChevronRight,
-  Clipboard,
-  Ellipsis,
-  FileText,
-  Pencil,
-  Play,
-  Power,
-  Square,
-  Trash2,
-  UserPlus,
-} from "lucide-react";
-import { toast } from "sonner";
+import { AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
@@ -29,24 +15,15 @@ import type {
   PresenceStatus,
 } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/shared/ui/dropdown-menu";
-import { EditAgentDialog } from "./EditAgentDialog";
+import { Button } from "@/shared/ui/button";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
 import { ManagedAgentLogPanel } from "./ManagedAgentLogPanel";
-import { ModelPicker } from "./ModelPicker";
 import { truncatePubkey } from "./agentUi";
 
 export function ManagedAgentRow({
   agent,
   channelIdToName,
   channelNames,
-  isActionPending,
   isLogSelected,
   logContent,
   logError,
@@ -54,17 +31,12 @@ export function ManagedAgentRow({
   personaLabelsById,
   presenceLoaded,
   presenceLookup,
-  onAddToChannel,
-  onDelete,
+  onOpenProfile,
   onSelectLogAgent,
-  onStart,
-  onStop,
-  onToggleStartOnAppLaunch,
 }: {
   agent: ManagedAgent;
   channelIdToName: Record<string, string>;
   channelNames: { id: string; name: string }[];
-  isActionPending: boolean;
   isLogSelected: boolean;
   logContent: string | null;
   logError: Error | null;
@@ -72,14 +44,9 @@ export function ManagedAgentRow({
   personaLabelsById: Record<string, string>;
   presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
-  onAddToChannel: (agent: ManagedAgent) => void;
-  onDelete: (pubkey: string) => void;
+  onOpenProfile: (pubkey: string) => void;
   onSelectLogAgent: (pubkey: string | null) => void;
-  onStart: (pubkey: string) => void;
-  onStop: (pubkey: string) => void;
-  onToggleStartOnAppLaunch: (pubkey: string, startOnAppLaunch: boolean) => void;
 }) {
-  const isActive = agent.status === "running" || agent.status === "deployed";
   const isLocal = agent.backend.type === "local";
   const runtimeSource =
     agent.backend.type === "provider" ? `Remote (${agent.backend.id})` : null;
@@ -181,18 +148,14 @@ export function ManagedAgentRow({
         )}
 
         <div className="flex shrink-0 items-start gap-2 lg:pt-0.5">
-          <ModelPicker agent={agent} />
-          <AgentActionsMenu
-            agent={agent}
-            isActionPending={isActionPending}
-            isActive={isActive}
-            onAddToChannel={onAddToChannel}
-            onDelete={onDelete}
-            onOpenLogs={(pubkey) => onSelectLogAgent(pubkey)}
-            onStart={onStart}
-            onStop={onStop}
-            onToggleStartOnAppLaunch={onToggleStartOnAppLaunch}
-          />
+          <Button
+            onClick={() => onOpenProfile(agent.pubkey)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Manage
+          </Button>
         </div>
       </div>
 
@@ -274,12 +237,6 @@ function AgentSummary({
               <span>Remote deployment</span>
             )}
           </div>
-          {agent.personaOutOfDate ? (
-            <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
-              Persona updated since this agent was created. Respawn to apply the
-              new configuration.
-            </p>
-          ) : null}
           {channelNames.length > 0 ? (
             <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
               {channelNames.map((channel) => (
@@ -296,6 +253,12 @@ function AgentSummary({
                 </Badge>
               ))}
             </div>
+          ) : null}
+          {agent.personaOutOfDate ? (
+            <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
+              Persona updated since this agent was created. Respawn to apply the
+              new configuration.
+            </p>
           ) : null}
           {activeWorkingChannels.length > 0 ? (
             <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
@@ -411,151 +374,6 @@ function RuntimeBlock({
         </div>
       ) : null}
     </div>
-  );
-}
-
-function AgentActionsMenu({
-  agent,
-  isActionPending,
-  isActive,
-  onAddToChannel,
-  onDelete,
-  onOpenLogs,
-  onStart,
-  onStop,
-  onToggleStartOnAppLaunch,
-}: {
-  agent: ManagedAgent;
-  isActionPending: boolean;
-  isActive: boolean;
-  onAddToChannel: (agent: ManagedAgent) => void;
-  onDelete: (pubkey: string) => void;
-  onOpenLogs: (pubkey: string) => void;
-  onStart: (pubkey: string) => void;
-  onStop: (pubkey: string) => void;
-  onToggleStartOnAppLaunch: (pubkey: string, startOnAppLaunch: boolean) => void;
-}) {
-  const [editOpen, setEditOpen] = React.useState(false);
-
-  return (
-    <>
-      <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild>
-          <button
-            aria-label={`Agent actions for ${agent.name}`}
-            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            data-testid={`managed-agent-actions-${agent.pubkey}`}
-            type="button"
-          >
-            <Ellipsis className="h-4 w-4" />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="end"
-          onCloseAutoFocus={(event) => event.preventDefault()}
-        >
-          {agent.backend.type === "provider" ? (
-            <>
-              <DropdownMenuItem
-                disabled={isActionPending}
-                onClick={() => onStart(agent.pubkey)}
-              >
-                <Play className="h-4 w-4" />
-                {isActive ? "Redeploy" : "Deploy"}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                disabled={isActionPending}
-                onClick={() => onStop(agent.pubkey)}
-              >
-                <Square className="h-4 w-4" />
-                Shutdown
-              </DropdownMenuItem>
-            </>
-          ) : isActive ? (
-            <DropdownMenuItem
-              disabled={isActionPending}
-              onClick={() => onStop(agent.pubkey)}
-            >
-              <Square className="h-4 w-4" />
-              Stop
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuItem
-              disabled={isActionPending}
-              onClick={() => onStart(agent.pubkey)}
-            >
-              <Play className="h-4 w-4" />
-              Spawn
-            </DropdownMenuItem>
-          )}
-
-          {agent.backend.type !== "provider" ? (
-            <DropdownMenuItem onClick={() => setEditOpen(true)}>
-              <Pencil className="h-4 w-4" />
-              Edit
-            </DropdownMenuItem>
-          ) : null}
-
-          <DropdownMenuItem
-            disabled={isActionPending}
-            onClick={() => onAddToChannel(agent)}
-          >
-            <UserPlus className="h-4 w-4" />
-            Add to channel
-          </DropdownMenuItem>
-
-          <DropdownMenuItem
-            onClick={async () => {
-              await navigator.clipboard.writeText(agent.pubkey);
-              toast.success("Copied pubkey to clipboard");
-            }}
-          >
-            <Clipboard className="h-4 w-4" />
-            Copy pubkey
-          </DropdownMenuItem>
-
-          {agent.backend.type === "local" ? (
-            <DropdownMenuItem onClick={() => onOpenLogs(agent.pubkey)}>
-              <FileText className="h-4 w-4" />
-              View logs
-            </DropdownMenuItem>
-          ) : null}
-
-          {agent.backend.type === "local" ? (
-            <DropdownMenuItem
-              disabled={isActionPending}
-              onClick={() =>
-                onToggleStartOnAppLaunch(agent.pubkey, !agent.startOnAppLaunch)
-              }
-            >
-              <Power className="h-4 w-4" />
-              {agent.startOnAppLaunch
-                ? "Disable auto-start"
-                : "Enable auto-start"}
-            </DropdownMenuItem>
-          ) : null}
-
-          <DropdownMenuSeparator />
-
-          <DropdownMenuItem
-            className="text-destructive focus:text-destructive"
-            disabled={isActionPending}
-            onClick={() => onDelete(agent.pubkey)}
-          >
-            <Trash2 className="h-4 w-4" />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      {editOpen ? (
-        <EditAgentDialog
-          agent={agent}
-          onOpenChange={setEditOpen}
-          open={editOpen}
-        />
-      ) : null}
-    </>
   );
 }
 

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -28,7 +28,6 @@ import {
 } from "@/shared/ui/dropdown-menu";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { AgentGroupRows } from "./AgentGroupRows";
-import { PersonaActionsMenu } from "./PersonaActionsMenu";
 import { PersonaIdentity } from "./PersonaIdentity";
 import { PersonaLibraryEntryPoints } from "./PersonaLibraryEntryPoints";
 
@@ -47,15 +46,12 @@ type UnifiedAgentsSectionProps = {
   personaLabelsById: Record<string, string>;
   presenceLoaded: boolean;
   presenceLookup: PresenceLookup;
-  onAddToChannel: (agent: ManagedAgent) => void;
   onBulkRemoveStopped: () => void;
   onBulkStopRunning: () => void;
   onCreateAgent: () => void;
-  onDeleteAgent: (pubkey: string) => void;
+  onOpenAgentProfile: (pubkey: string) => void;
+  onOpenPersonaProfile: (persona: AgentPersona) => void;
   onSelectLogAgent: (pubkey: string | null) => void;
-  onStartAgent: (pubkey: string) => void;
-  onStopAgent: (pubkey: string) => void;
-  onToggleStartOnAppLaunch: (pubkey: string, startOnAppLaunch: boolean) => void;
   selectedLogAgentPubkey: string | null;
   canChooseCatalog: boolean;
   personas: AgentPersona[];
@@ -66,11 +62,6 @@ type UnifiedAgentsSectionProps = {
   isPersonasPending: boolean;
   onCreatePersona: () => void;
   onChooseCatalog: () => void;
-  onDuplicatePersona: (persona: AgentPersona) => void;
-  onEditPersona: (persona: AgentPersona) => void;
-  onExportPersona: (persona: AgentPersona) => void;
-  onDeactivatePersona: (persona: AgentPersona) => void;
-  onDeletePersona: (persona: AgentPersona) => void;
   onImportPersonaFile: (fileBytes: number[], fileName: string) => void;
 };
 
@@ -120,15 +111,12 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     personaLabelsById,
     presenceLoaded,
     presenceLookup,
-    onAddToChannel,
     onBulkRemoveStopped,
     onBulkStopRunning,
     onCreateAgent,
-    onDeleteAgent,
+    onOpenAgentProfile,
+    onOpenPersonaProfile,
     onSelectLogAgent,
-    onStartAgent,
-    onStopAgent,
-    onToggleStartOnAppLaunch,
     selectedLogAgentPubkey,
     canChooseCatalog,
     personas,
@@ -139,11 +127,6 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     isPersonasPending,
     onCreatePersona,
     onChooseCatalog,
-    onDuplicatePersona,
-    onEditPersona,
-    onExportPersona,
-    onDeactivatePersona,
-    onDeletePersona,
     onImportPersonaFile,
   } = props;
 
@@ -188,12 +171,8 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     presenceLoaded,
     presenceLookup,
     selectedLogAgentPubkey,
-    onAddToChannel,
-    onDelete: onDeleteAgent,
+    onOpenProfile: onOpenAgentProfile,
     onSelectLogAgent,
-    onStart: onStartAgent,
-    onStop: onStopAgent,
-    onToggleStartOnAppLaunch,
   } as const;
 
   return (
@@ -277,16 +256,15 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
                     ) : !hasAgents ? (
                       <Badge variant="outline">Inactive</Badge>
                     ) : null}
-                    <PersonaActionsMenu
-                      isActionPending={isActionPending}
-                      isPending={isPersonasPending}
-                      persona={g.persona}
-                      onDuplicate={onDuplicatePersona}
-                      onEdit={onEditPersona}
-                      onExport={onExportPersona}
-                      onDeactivate={onDeactivatePersona}
-                      onDelete={onDeletePersona}
-                    />
+                    <Button
+                      disabled={isPersonasPending}
+                      onClick={() => onOpenPersonaProfile(g.persona)}
+                      size="sm"
+                      type="button"
+                      variant="ghost"
+                    >
+                      Manage
+                    </Button>
                   </div>
                 </div>
                 {!isCollapsed && hasAgents ? (

--- a/desktop/src/features/channels/ui/useChannelPanelHistoryState.ts
+++ b/desktop/src/features/channels/ui/useChannelPanelHistoryState.ts
@@ -1,6 +1,9 @@
 import * as React from "react";
 
-import type { ProfilePanelView } from "@/features/profile/ui/UserProfilePanel";
+import {
+  profilePanelViewFromSearch,
+  type ProfilePanelView,
+} from "@/features/profile/ui/UserProfilePanelUtils";
 import {
   type HistorySearchSetterOptions,
   useHistorySearchState,
@@ -35,10 +38,6 @@ const CHANNEL_SEARCH_KEYS = [
 ] as const;
 
 const CHANNEL_MANAGEMENT_OPEN_VALUE = "1";
-
-function asProfilePanelView(value: string | null): ProfilePanelView {
-  return value === "memories" || value === "channels" ? value : "summary";
-}
 
 export function useChannelPanelHistoryState() {
   const { applyPatch, values } = useHistorySearchState(CHANNEL_SEARCH_KEYS);
@@ -88,7 +87,7 @@ export function useChannelPanelHistoryState() {
     openAgentSessionPubkey: values.agentSession,
     openThreadHeadId: values.thread,
     profilePanelPubkey: values.profile,
-    profilePanelView: asProfilePanelView(values.profileView),
+    profilePanelView: profilePanelViewFromSearch(values.profileView),
     setChannelManagementOpen,
     setOpenAgentSessionPubkey,
     setOpenThreadHeadId,

--- a/desktop/src/features/profile/ui/UserProfileAgentActions.tsx
+++ b/desktop/src/features/profile/ui/UserProfileAgentActions.tsx
@@ -1,0 +1,105 @@
+import type { LucideIcon } from "lucide-react";
+import { CopyPlus, Download, Trash2 } from "lucide-react";
+
+import type { ManagedAgent } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
+
+export function UserProfileAgentActions({
+  isPending,
+  managedAgent,
+  onDelete,
+  onDuplicatePersona,
+  onExportPersona,
+  personaActionKey,
+}: {
+  isPending: boolean;
+  managedAgent?: ManagedAgent;
+  onDelete?: () => void;
+  onDuplicatePersona?: () => void;
+  onExportPersona?: () => void;
+  personaActionKey?: string;
+}) {
+  const actionKey = managedAgent?.pubkey ?? "persona-draft";
+  const personaKey = personaActionKey ?? actionKey;
+
+  return (
+    <section className="space-y-2">
+      {onDuplicatePersona ? (
+        <AgentActionRow
+          disabled={isPending}
+          icon={CopyPlus}
+          label="Duplicate"
+          onClick={onDuplicatePersona}
+          testId={`user-profile-persona-duplicate-${personaKey}`}
+        />
+      ) : null}
+      {onExportPersona ? (
+        <AgentActionRow
+          disabled={isPending}
+          icon={Download}
+          label="Export"
+          onClick={onExportPersona}
+          testId={`user-profile-persona-export-${personaKey}`}
+        />
+      ) : null}
+      {onDelete ? (
+        <AgentActionRow
+          destructive
+          disabled={isPending}
+          icon={Trash2}
+          label="Delete agent"
+          onClick={onDelete}
+          testId={`user-profile-agent-delete-${actionKey}`}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function AgentActionRow({
+  destructive,
+  disabled,
+  icon: Icon,
+  label,
+  onClick,
+  testId,
+  trailing,
+}: {
+  destructive?: boolean;
+  disabled?: boolean;
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  testId: string;
+  trailing?: string;
+}) {
+  return (
+    <button
+      className={cn(
+        "flex w-full items-center gap-3 rounded-2xl bg-muted/20 px-4 py-2 text-left transition-colors hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-50",
+        destructive && "text-destructive hover:bg-destructive/10",
+      )}
+      data-testid={testId}
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
+        <Icon
+          className={cn(
+            "h-4 w-4",
+            destructive ? "text-destructive" : "text-muted-foreground",
+          )}
+        />
+      </span>
+      <span className="min-w-0 flex-1 text-sm font-medium text-foreground">
+        {label}
+      </span>
+      {trailing ? (
+        <span className="text-sm capitalize text-muted-foreground">
+          {trailing}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/desktop/src/features/profile/ui/UserProfileCreatedAgentSecretDialog.tsx
+++ b/desktop/src/features/profile/ui/UserProfileCreatedAgentSecretDialog.tsx
@@ -1,0 +1,22 @@
+import { SecretRevealDialog } from "@/features/agents/ui/SecretRevealDialog";
+import type { CreateManagedAgentResponse } from "@/shared/api/types";
+import React from "react";
+
+export function useCreatedAgentSecretReveal() {
+  const [createdAgent, setCreatedAgent] =
+    React.useState<CreateManagedAgentResponse | null>(null);
+
+  return {
+    createdAgentSecretDialog: createdAgent ? (
+      <SecretRevealDialog
+        created={createdAgent}
+        onOpenChange={(open) => {
+          if (!open) {
+            setCreatedAgent(null);
+          }
+        }}
+      />
+    ) : null,
+    setCreatedAgent,
+  };
+}

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -88,6 +88,7 @@ import {
 import { cn } from "@/shared/lib/cn";
 import type {
   AgentPersona,
+  AcpRuntime,
   Channel,
   CreateManagedAgentInput,
   CreatePersonaInput,
@@ -189,15 +190,12 @@ export function UserProfilePanel({
   );
   const effectivePubkey = pubkey ?? managedAgent?.pubkey ?? null;
   const pubkeyLower = effectivePubkey?.toLowerCase() ?? "";
-
   const profileQuery = useUserProfileQuery(effectivePubkey ?? undefined);
   const currentProfileQuery = useProfileQuery(currentPubkey !== undefined);
-
   React.useEffect(() => {
     if (!effectivePubkey) return;
     void profileQuery.refetch();
   }, [effectivePubkey, profileQuery.refetch]);
-
   const relayAgentsQuery = useRelayAgentsQuery({ enabled: true });
   const availableRuntimesQuery = useAvailableAcpRuntimes();
   const acpRuntimesQuery = useAcpRuntimesQuery();
@@ -311,7 +309,6 @@ export function UserProfilePanel({
       (contact) => contact.pubkey.toLowerCase() === pubkeyLower,
     ) ??
       false);
-
   const profileChannels = React.useMemo(
     () =>
       deriveProfileChannels(
@@ -322,7 +319,6 @@ export function UserProfilePanel({
       ),
     [pubkeyLower, relayAgent, managedAgent, channelsQuery.data],
   );
-
   const channelIdToName = React.useMemo(() => {
     const map: Record<string, string> = {};
     for (const channel of channelsQuery.data ?? []) {
@@ -330,7 +326,6 @@ export function UserProfilePanel({
     }
     return map;
   }, [channelsQuery.data]);
-
   const targetKey =
     effectivePubkey ?? `persona:${resolvedPersona?.id ?? "unknown"}`;
   const prevTargetKeyRef = React.useRef(targetKey);
@@ -344,7 +339,6 @@ export function UserProfilePanel({
     onOpenDm?.([effectivePubkey]);
     onClose();
   }, [effectivePubkey, onClose, onOpenDm]);
-
   const handleEditAgent = React.useCallback(() => {
     if (managedAgent) {
       setEditAgentOpen(true);
@@ -352,7 +346,6 @@ export function UserProfilePanel({
       setPersonaDialogState(editPersonaDialogState(resolvedPersona));
     }
   }, [managedAgent, resolvedPersona]);
-
   const { deleteManagedAgentRecord, deleteManagedAgentsForPersona } =
     useProfileAgentDeletion({
       channels: channelsQuery.data,
@@ -362,17 +355,21 @@ export function UserProfilePanel({
       presenceLookup: presenceQuery.data,
       relayAgents: relayAgentsQuery.data,
     });
-
   const createManagedAgentForPersona = React.useCallback(
     async (personaToStart: AgentPersona) => {
-      const runtimes = availableRuntimesQuery.data ?? [];
+      const runtimeCatalogData = availableRuntimesQuery.isLoading
+        ? await availableRuntimesQuery.refetch()
+        : { data: availableRuntimesQuery.data };
+      const runtimes = (runtimeCatalogData.data ?? []).filter(
+        (candidate): candidate is AcpRuntime =>
+          candidate.availability === "available",
+      );
       const defaultRuntime = runtimes[0] ?? null;
       const { runtime, warnings } = resolvePersonaRuntime(
         personaToStart.runtime,
         runtimes,
         defaultRuntime,
       );
-
       for (const warning of warnings) {
         toast.warning(warning);
       }
@@ -404,6 +401,8 @@ export function UserProfilePanel({
     },
     [
       availableRuntimesQuery.data,
+      availableRuntimesQuery.isLoading,
+      availableRuntimesQuery.refetch,
       createAgentMutation.mutateAsync,
       managedAgentsQuery.refetch,
       relayAgentsQuery.refetch,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -346,12 +346,12 @@ export function UserProfilePanel({
   }, [effectivePubkey, onClose, onOpenDm]);
 
   const handleEditAgent = React.useCallback(() => {
-    if (resolvedPersona && !resolvedPersona.isBuiltIn) {
+    if (managedAgent) {
+      setEditAgentOpen(true);
+    } else if (resolvedPersona && !resolvedPersona.isBuiltIn) {
       setPersonaDialogState(editPersonaDialogState(resolvedPersona));
-      return;
     }
-    setEditAgentOpen(true);
-  }, [resolvedPersona]);
+  }, [managedAgent, resolvedPersona]);
 
   const { deleteManagedAgentRecord, deleteManagedAgentsForPersona } =
     useProfileAgentDeletion({
@@ -513,6 +513,7 @@ export function UserProfilePanel({
         createPersona: createPersonaMutation.mutateAsync,
         input,
         managedAgent,
+        onCreatedAgent: setCreatedAgent,
         onDone: () => {
           setPersonaDialogState(null);
           void personasQuery.refetch();
@@ -527,6 +528,7 @@ export function UserProfilePanel({
       createPersonaMutation.mutateAsync,
       createManagedAgentForPersona,
       managedAgent,
+      setCreatedAgent,
       personasQuery.refetch,
       resolvedPersona,
       acpRuntimesQuery.data,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -151,16 +151,13 @@ export function UserProfilePanel({
   const personasQuery = usePersonasQuery();
   const managedAgentsQuery = useManagedAgentsQuery({ enabled: true });
   const managedAgent = React.useMemo(() => {
+    if (!pubkey) {
+      return undefined;
+    }
     const agents = managedAgentsQuery.data ?? [];
-    if (pubkey) {
-      const pubkeyLower = pubkey.toLowerCase();
-      return agents.find((agent) => agent.pubkey.toLowerCase() === pubkeyLower);
-    }
-    if (persona) {
-      return agents.find((agent) => agent.personaId === persona.id);
-    }
-    return undefined;
-  }, [managedAgentsQuery.data, persona, pubkey]);
+    const pubkeyLower = pubkey.toLowerCase();
+    return agents.find((agent) => agent.pubkey.toLowerCase() === pubkeyLower);
+  }, [managedAgentsQuery.data, pubkey]);
   const resolvedPersonaFromSource = React.useMemo(() => {
     const personaId = persona?.id ?? managedAgent?.personaId;
     if (personaId) {

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { ArrowLeft, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
@@ -7,7 +6,6 @@ import {
   useAgentMemoryQuery,
   useIsManagedAgent,
 } from "@/features/agent-memory/hooks";
-import { MemoryRefreshButton } from "@/features/agent-memory/ui/MemorySection";
 import {
   type AttachManagedAgentToChannelResult,
   useAcpRuntimesQuery,
@@ -85,8 +83,6 @@ import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
 import { THREAD_PANEL_MIN_WIDTH_PX } from "@/shared/hooks/useThreadPanelWidth";
 import {
   AuxiliaryPanelHeader,
-  AuxiliaryPanelHeaderGroup,
-  AuxiliaryPanelTitle,
   auxiliaryPanelContentPaddingClass,
 } from "@/shared/layout/AuxiliaryPanelHeader";
 import { cn } from "@/shared/lib/cn";
@@ -97,13 +93,16 @@ import type {
   CreatePersonaInput,
   UpdatePersonaInput,
 } from "@/shared/api/types";
-import { Button } from "@/shared/ui/button";
 import {
   OverlayPanelBackdrop,
   PANEL_BASE_CLASS,
   PANEL_OVERLAY_CLASS,
   PANEL_SINGLE_COLUMN_HEADER_LAYER_CLASS,
 } from "@/shared/ui/OverlayPanelBackdrop";
+import {
+  UserProfilePanelHeaderActions,
+  UserProfilePanelHeaderLeft,
+} from "./UserProfilePanelHeaderControls";
 
 export type { ProfilePanelView };
 
@@ -712,46 +711,20 @@ export function UserProfilePanel({
   });
 
   const headerLeftContent = (
-    <AuxiliaryPanelHeaderGroup>
-      {view !== "summary" ? (
-        <Button
-          aria-label="Back to profile"
-          className="shrink-0"
-          data-testid="user-profile-panel-back"
-          onClick={() => setView("summary")}
-          size="icon"
-          type="button"
-          variant="outline"
-        >
-          <ArrowLeft />
-        </Button>
-      ) : null}
-      <AuxiliaryPanelTitle>
-        {PROFILE_PANEL_VIEW_TITLES[view]}
-      </AuxiliaryPanelTitle>
-    </AuxiliaryPanelHeaderGroup>
+    <UserProfilePanelHeaderLeft
+      title={PROFILE_PANEL_VIEW_TITLES[view]}
+      view={view}
+      onBack={() => setView("summary")}
+    />
   );
 
   const headerActions = (
-    <div className="ml-auto flex shrink-0 items-center gap-2">
-      {view === "memories" && viewerIsOwner && effectivePubkey ? (
-        <MemoryRefreshButton
-          agentPubkey={effectivePubkey}
-          variant="outline"
-          viewerIsOwner={viewerIsOwner}
-        />
-      ) : null}
-      <Button
-        aria-label="Close profile"
-        data-testid="user-profile-panel-close"
-        onClick={onClose}
-        size="icon"
-        type="button"
-        variant="ghost"
-      >
-        <X />
-      </Button>
-    </div>
+    <UserProfilePanelHeaderActions
+      effectivePubkey={effectivePubkey}
+      view={view}
+      viewerIsOwner={viewerIsOwner}
+      onClose={onClose}
+    />
   );
 
   const profileBody = (

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { ArrowLeft, X } from "lucide-react";
+import { toast } from "sonner";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import {
@@ -8,12 +9,41 @@ import {
 } from "@/features/agent-memory/hooks";
 import { MemoryRefreshButton } from "@/features/agent-memory/ui/MemorySection";
 import {
+  type AttachManagedAgentToChannelResult,
+  useAcpRuntimesQuery,
+  useAvailableAcpRuntimes,
+  useCreateManagedAgentMutation,
+  useCreatePersonaMutation,
+  useDeleteManagedAgentMutation,
+  useDeletePersonaMutation,
+  useExportPersonaJsonMutation,
+  useManagedAgentLogQuery,
   useRelayAgentsQuery,
   useManagedAgentsQuery,
+  usePersonasQuery,
+  useSetManagedAgentStartOnAppLaunchMutation,
+  useSetPersonaActiveMutation,
+  useStartManagedAgentMutation,
+  useStopManagedAgentMutation,
+  useUpdateManagedAgentMutation,
+  useUpdatePersonaMutation,
 } from "@/features/agents/hooks";
+import { AddAgentToChannelDialog } from "@/features/agents/ui/AddAgentToChannelDialog";
 import { useActiveAgentTurnsBridge } from "@/features/agents/activeAgentTurnsStore";
+import { resolvePersonaRuntime } from "@/features/agents/lib/resolvePersonaRuntime";
+import {
+  isManagedAgentActive,
+  startManagedAgentWithRules,
+  stopManagedAgentWithRules,
+} from "@/features/agents/lib/managedAgentControlActions";
+import { ManagedAgentLogPanel } from "@/features/agents/ui/ManagedAgentLogPanel";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
 import { EditAgentDialog } from "@/features/agents/ui/EditAgentDialog";
+import {
+  duplicatePersonaDialogState,
+  editPersonaDialogState,
+  type PersonaDialogState,
+} from "@/features/agents/ui/personaDialogState";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import {
@@ -24,10 +54,30 @@ import {
   useUserProfileQuery,
 } from "@/features/profile/hooks";
 import {
+  AgentInfoFocusedView,
+  AgentInstructionFocusedView,
+  AgentSettingsFocusedView,
   ChannelsFocusedView,
+  DiagnosticsFocusedView,
   MemoryFocusedView,
+  ModelFocusedView,
   ProfileSummaryView,
 } from "@/features/profile/ui/UserProfilePanelSections";
+import { useProfileAgentDeletion } from "@/features/profile/ui/UserProfilePanelDeletion";
+import { useProfileFieldBuckets } from "@/features/profile/ui/UserProfilePanelFields";
+import { submitProfilePersonaDialog } from "@/features/profile/ui/UserProfilePanelPersonaSubmit";
+import { UserProfilePersonaDialogs } from "@/features/profile/ui/UserProfilePersonaDialogs";
+import {
+  deriveProfileChannels,
+  PROFILE_PANEL_VIEW_TITLES,
+  type ProfilePanelView,
+  resolveAgentInstruction,
+  resolveOwnerHandle,
+  resolvePanelProfile,
+  resolveProfileDisplayName,
+  type UserProfilePanelProps,
+  useRetainedPersona,
+} from "@/features/profile/ui/UserProfilePanelUtils";
 import { useUserStatusQuery } from "@/features/user-status/hooks";
 import { useAgentSession } from "@/shared/context/AgentSessionContext";
 import { useEscapeKey } from "@/shared/hooks/useEscapeKey";
@@ -40,7 +90,13 @@ import {
   auxiliaryPanelContentPaddingClass,
 } from "@/shared/layout/AuxiliaryPanelHeader";
 import { cn } from "@/shared/lib/cn";
-import type { Channel, ManagedAgent, RelayAgent } from "@/shared/api/types";
+import type {
+  AgentPersona,
+  Channel,
+  CreateManagedAgentInput,
+  CreatePersonaInput,
+  UpdatePersonaInput,
+} from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
 import {
   OverlayPanelBackdrop,
@@ -49,86 +105,7 @@ import {
   PANEL_SINGLE_COLUMN_HEADER_LAYER_CLASS,
 } from "@/shared/ui/OverlayPanelBackdrop";
 
-type UserProfilePanelProps = {
-  canResetWidth?: boolean;
-  currentPubkey?: string;
-  isSinglePanelView?: boolean;
-  layout?: "standalone" | "split";
-  onClose: () => void;
-  onOpenDm?: (pubkeys: string[]) => void;
-  onOpenProfile?: (pubkey: string) => void;
-  onResetWidth?: () => void;
-  onResizeStart?: (event: React.PointerEvent<HTMLButtonElement>) => void;
-  onViewChange: (
-    view: ProfilePanelView,
-    options?: { replace?: boolean },
-  ) => void;
-  pubkey: string;
-  /**
-   * When true, the panel sits beside a sibling pane managed by a single-panel
-   * width controller (ChannelScreen). The width is clamped so the sibling keeps
-   * at least THREAD_PANEL_MIN_WIDTH_PX. Standalone/floating mounts (e.g. Pulse)
-   * have no such sibling, so they omit this and use the configured width
-   * directly — otherwise `calc(100% - 300px)` would wrongly shrink the panel.
-   */
-  splitPaneClamp?: boolean;
-  view: ProfilePanelView;
-  widthPx: number;
-};
-
-export type ProfilePanelView = "summary" | "memories" | "channels";
-
-const VIEW_TITLES: Record<ProfilePanelView, string> = {
-  summary: "Profile",
-  memories: "Memories",
-  channels: "Channels",
-};
-
-function truncatePubkey(pubkey: string) {
-  if (pubkey.length <= 16) {
-    return pubkey;
-  }
-
-  return `${pubkey.slice(0, 8)}…${pubkey.slice(-8)}`;
-}
-
-type ProfileChannelLink = {
-  id: string;
-  name: string;
-};
-
-function deriveProfileChannels(
-  pubkeyLower: string,
-  relayAgent: RelayAgent | undefined,
-  managedAgent: ManagedAgent | undefined,
-  channels: Channel[] | undefined,
-): ProfileChannelLink[] {
-  const links = new Map<string, ProfileChannelLink>();
-  const channelsByName = new Map(
-    channels?.map((channel) => [channel.name, channel]) ?? [],
-  );
-
-  relayAgent?.channels.forEach((name, index) => {
-    const channel = channelsByName.get(name);
-    const id = relayAgent.channelIds[index] ?? channel?.id ?? name;
-    links.set(id, { id, name });
-  });
-
-  if (managedAgent && channels) {
-    for (const channel of channels) {
-      const isMember = channel.memberPubkeys.some(
-        (memberPubkey) => memberPubkey.toLowerCase() === pubkeyLower,
-      );
-      if (isMember) {
-        links.set(channel.id, { id: channel.id, name: channel.name });
-      }
-    }
-  }
-
-  return [...links.values()].sort((left, right) =>
-    left.name.localeCompare(right.name),
-  );
-}
+export type { ProfilePanelView };
 
 export function UserProfilePanel({
   canResetWidth,
@@ -141,9 +118,10 @@ export function UserProfilePanel({
   onResetWidth,
   onResizeStart,
   onViewChange,
+  persona,
   pubkey,
   splitPaneClamp = false,
-  view,
+  view: controlledView,
   widthPx,
 }: UserProfilePanelProps) {
   const isOverlay = useIsThreadPanelOverlay();
@@ -151,75 +129,135 @@ export function UserProfilePanel({
   const isSplitLayout = layout === "split";
   useEscapeKey(onClose, isOverlay || isSinglePanelView);
 
+  const [internalView, setInternalView] =
+    React.useState<ProfilePanelView>("summary");
+  const view = controlledView ?? internalView;
+  const setView = React.useCallback(
+    (nextView: ProfilePanelView, options?: { replace?: boolean }) => {
+      if (onViewChange) {
+        onViewChange(nextView, options);
+        return;
+      }
+      setInternalView(nextView);
+    },
+    [onViewChange],
+  );
   const [editAgentOpen, setEditAgentOpen] = React.useState(false);
+  const [addToChannelOpen, setAddToChannelOpen] = React.useState(false);
+  const [personaDialogState, setPersonaDialogState] =
+    React.useState<PersonaDialogState | null>(null);
+  const [personaToDelete, setPersonaToDelete] =
+    React.useState<AgentPersona | null>(null);
 
-  const profileQuery = useUserProfileQuery(pubkey);
+  const personasQuery = usePersonasQuery();
+  const managedAgentsQuery = useManagedAgentsQuery({ enabled: true });
+  const managedAgent = React.useMemo(() => {
+    const agents = managedAgentsQuery.data ?? [];
+    if (pubkey) {
+      const pubkeyLower = pubkey.toLowerCase();
+      return agents.find((agent) => agent.pubkey.toLowerCase() === pubkeyLower);
+    }
+    if (persona) {
+      return agents.find((agent) => agent.personaId === persona.id);
+    }
+    return undefined;
+  }, [managedAgentsQuery.data, persona, pubkey]);
+  const resolvedPersonaFromSource = React.useMemo(() => {
+    const personaId = persona?.id ?? managedAgent?.personaId;
+    if (personaId) {
+      const refreshedPersona = personasQuery.data?.find(
+        (candidate) => candidate.id === personaId,
+      );
+      if (refreshedPersona) {
+        return refreshedPersona;
+      }
+    }
+    if (persona) {
+      return persona;
+    }
+    if (!managedAgent?.personaId) {
+      return undefined;
+    }
+    return personasQuery.data?.find(
+      (candidate) => candidate.id === managedAgent.personaId,
+    );
+  }, [managedAgent?.personaId, persona, personasQuery.data]);
+  const profileIdentityKey =
+    pubkey ?? managedAgent?.pubkey ?? `persona:${persona?.id ?? "unknown"}`;
+  const resolvedPersona = useRetainedPersona(
+    resolvedPersonaFromSource,
+    profileIdentityKey,
+  );
+  const effectivePubkey = pubkey ?? managedAgent?.pubkey ?? null;
+  const pubkeyLower = effectivePubkey?.toLowerCase() ?? "";
+
+  const profileQuery = useUserProfileQuery(effectivePubkey ?? undefined);
   const currentProfileQuery = useProfileQuery(currentPubkey !== undefined);
 
-  // Batch avatar prefetch seeds kind:0 summaries without `about`; refetch on open
-  // so the hero can show the full profile description from relay.
   React.useEffect(() => {
+    if (!effectivePubkey) return;
     void profileQuery.refetch();
-  }, [profileQuery.refetch]);
+  }, [effectivePubkey, profileQuery.refetch]);
 
   const relayAgentsQuery = useRelayAgentsQuery({ enabled: true });
-  const managedAgentsQuery = useManagedAgentsQuery({ enabled: true });
+  const availableRuntimesQuery = useAvailableAcpRuntimes();
+  const acpRuntimesQuery = useAcpRuntimesQuery();
+  const createAgentMutation = useCreateManagedAgentMutation();
+  const updateManagedAgentMutation = useUpdateManagedAgentMutation();
+  const startAgentMutation = useStartManagedAgentMutation();
+  const stopAgentMutation = useStopManagedAgentMutation();
+  const deleteAgentMutation = useDeleteManagedAgentMutation();
+  const startOnLaunchMutation = useSetManagedAgentStartOnAppLaunchMutation();
+  const createPersonaMutation = useCreatePersonaMutation();
+  const updatePersonaMutation = useUpdatePersonaMutation();
+  const deletePersonaMutation = useDeletePersonaMutation();
+  const setPersonaActiveMutation = useSetPersonaActiveMutation();
+  const exportPersonaJsonMutation = useExportPersonaJsonMutation();
   const channelsQuery = useChannelsQuery();
-  const presenceQuery = usePresenceQuery([pubkey]);
-  const userStatusQuery = useUserStatusQuery([pubkey]);
+  const presenceQuery = usePresenceQuery(
+    effectivePubkey ? [effectivePubkey] : [],
+  );
+  const userStatusQuery = useUserStatusQuery(
+    effectivePubkey ? [effectivePubkey] : [],
+  );
   const contactListQuery = useContactListQuery(currentPubkey);
   const followMutation = useFollowMutation(currentPubkey);
   const unfollowMutation = useUnfollowMutation(currentPubkey);
   const { onOpenAgentSession } = useAgentSession();
   const { goChannel } = useAppNavigation();
-
-  const profile = profileQuery.data;
-  const ownerPubkey = profile?.ownerPubkey ?? null;
-  const ownerProfileQuery = useUserProfileQuery(ownerPubkey ?? undefined);
-  const pubkeyLower = pubkey.toLowerCase();
-  const presenceStatus = presenceQuery.data?.[pubkeyLower];
-  const userStatus = userStatusQuery.data?.[pubkeyLower];
+  const profile = resolvePanelProfile({
+    managedAgent,
+    persona: resolvedPersona,
+    profile: profileQuery.data,
+  });
+  const presenceStatus = pubkeyLower
+    ? presenceQuery.data?.[pubkeyLower]
+    : undefined;
+  const userStatus = pubkeyLower
+    ? userStatusQuery.data?.[pubkeyLower]
+    : undefined;
 
   const relayAgent = relayAgentsQuery.data?.find(
     (agent) => agent.pubkey.toLowerCase() === pubkeyLower,
   );
-  const managedAgent = managedAgentsQuery.data?.find(
-    (agent) => agent.pubkey.toLowerCase() === pubkeyLower,
+  const managedAgentLogQuery = useManagedAgentLogQuery(
+    view === "logs" && managedAgent?.backend.type === "local"
+      ? managedAgent.pubkey
+      : null,
   );
-  const isBot = Boolean(relayAgent || managedAgent);
-  // Does THIS desktop hold the agent's seckey? Gates edit (which needs the key)
-  // and grants owner access when the agent is managed locally.
-  const isOwner = useIsManagedAgent(isBot ? pubkey : null);
-  // Is the viewer the agent's declared owner (NIP-OA `ownerPubkey == me`)? This
-  // is the right signal for viewing owner-scoped data (activity feed, memory):
-  // the relay routes and the client decrypts those frames with the owner's OWN
-  // key, so the agent's seckey is never needed. Computed here (before the gates
-  // that consume it) so visibility keys off declared ownership, not key custody.
+  const isBot = Boolean(relayAgent || managedAgent || resolvedPersona);
+  const managedAgentOwner = useIsManagedAgent(isBot ? effectivePubkey : null);
+  const isOwner = resolvedPersona ? true : managedAgentOwner;
+  const ownerPubkey = profile?.ownerPubkey ?? null;
+  const ownerProfileQuery = useUserProfileQuery(ownerPubkey ?? undefined);
   const isCurrentUserOwner =
     currentPubkey !== undefined &&
     ownerPubkey !== null &&
     ownerPubkey.toLowerCase() === currentPubkey.toLowerCase();
-  // The viewer may see owner-scoped data if they declared-own the agent OR they
-  // manage it locally (older agents may not advertise an owner pubkey). Every
-  // real boundary is server-side, so this only controls what UI we paint.
   const viewerIsOwner = isCurrentUserOwner || isOwner === true;
 
-  // Populate the active-turns store for this agent so useActiveAgentTurns works
-  // even if the Agents page hasn't been visited yet.
-  const bridgeAgents = React.useMemo(
-    () =>
-      managedAgent
-        ? [{ pubkey: managedAgent.pubkey, status: managedAgent.status }]
-        : [],
-    [managedAgent],
-  );
-  // The observer bridge subscribes on the OWNER's own pubkey and decrypts the
-  // agent's telemetry with the owner's key — no agent seckey needed. It only
-  // decrypts frames whose agent pubkey is "known", and only subscribes when an
-  // agent is running/deployed. For a remote agent we own but don't manage
-  // locally, `managedAgent` is undefined, so we seed the bridge from the relay
-  // agent (treated as "deployed") when the viewer is the declared owner. This
-  // mirrors what the composer-area ingress already does in ChannelScreen.
+  // Populate the observer and active-turn stores for this agent so profile
+  // activity works even if the Agents page hasn't been visited yet.
   const observerBridgeAgents = React.useMemo(() => {
     if (managedAgent) {
       return [{ pubkey: managedAgent.pubkey, status: managedAgent.status }];
@@ -228,23 +266,48 @@ export function UserProfilePanel({
       return [
         {
           pubkey: relayAgent.pubkey,
-          status: "deployed" as ManagedAgent["status"],
+          status: "deployed" as const,
         },
       ];
     }
     return [];
   }, [managedAgent, relayAgent, viewerIsOwner]);
-  useActiveAgentTurnsBridge(bridgeAgents);
+  useActiveAgentTurnsBridge(observerBridgeAgents);
   useManagedAgentObserverBridge(observerBridgeAgents);
-  const canEditAgent = isOwner === true && managedAgent !== undefined;
-  const memoryQuery = useAgentMemoryQuery(pubkey, {
-    enabled: viewerIsOwner,
+  const canEditAgent =
+    isOwner === true &&
+    (managedAgent !== undefined ||
+      (resolvedPersona !== undefined && !resolvedPersona.isBuiltIn));
+  const memoryQuery = useAgentMemoryQuery(effectivePubkey, {
+    enabled: viewerIsOwner && Boolean(effectivePubkey),
   });
   const isSelf =
-    currentPubkey !== undefined && pubkeyLower === currentPubkey.toLowerCase();
-  const canViewActivity = viewerIsOwner && Boolean(onOpenAgentSession);
+    currentPubkey !== undefined &&
+    pubkeyLower.length > 0 &&
+    pubkeyLower === currentPubkey.toLowerCase();
+  const canViewActivity =
+    viewerIsOwner && Boolean(onOpenAgentSession) && Boolean(effectivePubkey);
+  const canOpenAgentLogs =
+    isOwner === true && managedAgent?.backend.type === "local";
+  const canInstantiateAgent =
+    isOwner === true &&
+    resolvedPersona !== undefined &&
+    managedAgent === undefined;
+  const isAgentActionPending =
+    createAgentMutation.isPending ||
+    updateManagedAgentMutation.isPending ||
+    startAgentMutation.isPending ||
+    stopAgentMutation.isPending ||
+    deleteAgentMutation.isPending ||
+    startOnLaunchMutation.isPending ||
+    createPersonaMutation.isPending ||
+    updatePersonaMutation.isPending ||
+    deletePersonaMutation.isPending ||
+    setPersonaActiveMutation.isPending ||
+    exportPersonaJsonMutation.isPending;
   const isFollowing =
     !isSelf &&
+    pubkeyLower.length > 0 &&
     (contactListQuery.data?.contacts.some(
       (contact) => contact.pubkey.toLowerCase() === pubkeyLower,
     ) ??
@@ -269,19 +332,326 @@ export function UserProfilePanel({
     return map;
   }, [channelsQuery.data]);
 
+  const targetKey =
+    effectivePubkey ?? `persona:${resolvedPersona?.id ?? "unknown"}`;
+  const prevTargetKeyRef = React.useRef(targetKey);
+  React.useEffect(() => {
+    if (prevTargetKeyRef.current === targetKey) return;
+    prevTargetKeyRef.current = targetKey;
+    setView("summary", { replace: true });
+  }, [setView, targetKey]);
   const handleMessage = React.useCallback(() => {
-    onOpenDm?.([pubkey]);
+    if (!effectivePubkey) return;
+    onOpenDm?.([effectivePubkey]);
     onClose();
-  }, [onClose, onOpenDm, pubkey]);
+  }, [effectivePubkey, onClose, onOpenDm]);
 
   const handleEditAgent = React.useCallback(() => {
+    if (resolvedPersona && !resolvedPersona.isBuiltIn) {
+      setPersonaDialogState(editPersonaDialogState(resolvedPersona));
+      return;
+    }
     setEditAgentOpen(true);
-  }, []);
+  }, [resolvedPersona]);
+
+  const { deleteManagedAgentRecord, deleteManagedAgentsForPersona } =
+    useProfileAgentDeletion({
+      channels: channelsQuery.data,
+      deleteManagedAgent: deleteAgentMutation.mutateAsync,
+      managedAgent,
+      managedAgents: managedAgentsQuery.data,
+      presenceLookup: presenceQuery.data,
+      relayAgents: relayAgentsQuery.data,
+    });
+
+  const createManagedAgentForPersona = React.useCallback(
+    async (personaToStart: AgentPersona) => {
+      const runtimes = availableRuntimesQuery.data ?? [];
+      const defaultRuntime = runtimes[0] ?? null;
+      const { runtime, warnings } = resolvePersonaRuntime(
+        personaToStart.runtime,
+        runtimes,
+        defaultRuntime,
+      );
+
+      for (const warning of warnings) {
+        toast.warning(warning);
+      }
+
+      if (!runtime) {
+        throw new Error("No available runtime found for this agent.");
+      }
+
+      const input: CreateManagedAgentInput = {
+        name: personaToStart.displayName,
+        acpCommand: "buzz-acp",
+        agentCommand: runtime.command,
+        agentArgs: runtime.defaultArgs,
+        mcpCommand: runtime.mcpCommand ?? "",
+        personaId: personaToStart.id,
+        systemPrompt: personaToStart.systemPrompt,
+        avatarUrl: personaToStart.avatarUrl ?? undefined,
+        model: personaToStart.model ?? undefined,
+        envVars: personaToStart.envVars,
+        spawnAfterCreate: true,
+        startOnAppLaunch: true,
+        backend: { type: "local" },
+      };
+
+      const created = await createAgentMutation.mutateAsync(input);
+      void managedAgentsQuery.refetch();
+      void relayAgentsQuery.refetch();
+      return created;
+    },
+    [
+      availableRuntimesQuery.data,
+      createAgentMutation.mutateAsync,
+      managedAgentsQuery.refetch,
+      relayAgentsQuery.refetch,
+    ],
+  );
+
+  const handleAgentPrimaryAction = React.useCallback(async () => {
+    if (!managedAgent) return;
+
+    try {
+      if (isManagedAgentActive(managedAgent)) {
+        const result = await stopManagedAgentWithRules({
+          agent: managedAgent,
+          channels: channelsQuery.data ?? [],
+          relayAgents: relayAgentsQuery.data ?? [],
+          stopManagedAgent: stopAgentMutation.mutateAsync,
+        });
+        toast.success(result.noticeMessage ?? `Stopped ${managedAgent.name}.`);
+        return;
+      }
+
+      await startManagedAgentWithRules({
+        agent: managedAgent,
+        startManagedAgent: startAgentMutation.mutateAsync,
+      });
+      toast.success(
+        managedAgent.backend.type === "provider"
+          ? `Deploying ${managedAgent.name}.`
+          : `Started ${managedAgent.name}.`,
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Agent action failed.",
+      );
+    }
+  }, [
+    channelsQuery.data,
+    managedAgent,
+    relayAgentsQuery.data,
+    startAgentMutation.mutateAsync,
+    stopAgentMutation.mutateAsync,
+  ]);
+
+  const handleInstantiateAgent = React.useCallback(async () => {
+    if (!resolvedPersona) return;
+
+    try {
+      const created = await createManagedAgentForPersona(resolvedPersona);
+      if (created.spawnError) {
+        toast.error(created.spawnError);
+      } else {
+        toast.success(`Started ${created.agent.name}.`);
+      }
+      if (created.profileSyncError) {
+        toast.warning(created.profileSyncError);
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to start agent.",
+      );
+    }
+  }, [createManagedAgentForPersona, resolvedPersona]);
+
+  const handleToggleAgentAutoStart = React.useCallback(async () => {
+    if (managedAgent?.backend.type !== "local") return;
+
+    try {
+      const updated = await startOnLaunchMutation.mutateAsync({
+        pubkey: managedAgent.pubkey,
+        startOnAppLaunch: !managedAgent.startOnAppLaunch,
+      });
+      toast.success(
+        updated.startOnAppLaunch
+          ? `Will start ${updated.name} automatically.`
+          : `${updated.name} will stay manual-start only.`,
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update startup preference.",
+      );
+    }
+  }, [managedAgent, startOnLaunchMutation.mutateAsync]);
+
+  const handleDeleteAgent = React.useCallback(async () => {
+    if (!managedAgent) return;
+
+    try {
+      const result = await deleteManagedAgentRecord(managedAgent);
+      if (result.cancelled) return;
+
+      toast.success(`Deleted ${managedAgent.name}.`);
+      onClose();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to delete agent.",
+      );
+    }
+  }, [deleteManagedAgentRecord, managedAgent, onClose]);
+
+  const handleSubmitPersona = React.useCallback(
+    async (input: CreatePersonaInput | UpdatePersonaInput) => {
+      await submitProfilePersonaDialog({
+        createManagedAgentForPersona,
+        createPersona: createPersonaMutation.mutateAsync,
+        input,
+        managedAgent,
+        onDone: () => {
+          setPersonaDialogState(null);
+          void personasQuery.refetch();
+        },
+        previousPersona: resolvedPersona,
+        runtimes: acpRuntimesQuery.data ?? [],
+        updateManagedAgent: updateManagedAgentMutation.mutateAsync,
+        updatePersona: updatePersonaMutation.mutateAsync,
+      });
+    },
+    [
+      createPersonaMutation.mutateAsync,
+      createManagedAgentForPersona,
+      managedAgent,
+      personasQuery.refetch,
+      resolvedPersona,
+      acpRuntimesQuery.data,
+      updateManagedAgentMutation.mutateAsync,
+      updatePersonaMutation.mutateAsync,
+    ],
+  );
+
+  const handleEditPersona = React.useCallback(() => {
+    if (!resolvedPersona || resolvedPersona.isBuiltIn) return;
+    setPersonaDialogState(editPersonaDialogState(resolvedPersona));
+  }, [resolvedPersona]);
+
+  const handleDuplicatePersona = React.useCallback(() => {
+    if (!resolvedPersona) return;
+    setPersonaDialogState(duplicatePersonaDialogState(resolvedPersona));
+  }, [resolvedPersona]);
+
+  const handleExportPersona = React.useCallback(() => {
+    if (!resolvedPersona) return;
+    exportPersonaJsonMutation.mutate(resolvedPersona.id, {
+      onSuccess: (saved) => {
+        if (saved) {
+          toast.success(`Exported ${resolvedPersona.displayName}.`);
+        }
+      },
+      onError: (error) => {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to export agent.",
+        );
+      },
+    });
+  }, [exportPersonaJsonMutation, resolvedPersona]);
+
+  const handleDeletePersona = React.useCallback(async () => {
+    if (!resolvedPersona) return;
+
+    if (resolvedPersona.isBuiltIn) {
+      try {
+        const deletedInstances =
+          await deleteManagedAgentsForPersona(resolvedPersona);
+        if (deletedInstances.cancelled) return;
+
+        await setPersonaActiveMutation.mutateAsync({
+          id: resolvedPersona.id,
+          active: false,
+        });
+        toast.success(`Removed ${resolvedPersona.displayName} from My Agents.`);
+        onClose();
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to delete agent.",
+        );
+      }
+      return;
+    }
+
+    if (resolvedPersona.sourceTeam) {
+      toast.error("This agent is managed by a team.");
+      return;
+    }
+
+    setPersonaToDelete(resolvedPersona);
+  }, [
+    deleteManagedAgentsForPersona,
+    onClose,
+    resolvedPersona,
+    setPersonaActiveMutation.mutateAsync,
+  ]);
+
+  const handleConfirmDeletePersona = React.useCallback(
+    async (personaToConfirm: AgentPersona) => {
+      if (personaToConfirm.sourceTeam) {
+        toast.error("This agent is managed by a team.");
+        setPersonaToDelete(null);
+        return;
+      }
+
+      try {
+        const deletedInstances =
+          await deleteManagedAgentsForPersona(personaToConfirm);
+        if (deletedInstances.cancelled) return;
+
+        await deletePersonaMutation.mutateAsync(personaToConfirm.id);
+        toast.success(`Deleted ${personaToConfirm.displayName}.`);
+        setPersonaToDelete(null);
+        onClose();
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to delete agent.",
+        );
+      }
+    },
+    [deleteManagedAgentsForPersona, deletePersonaMutation.mutateAsync, onClose],
+  );
+
+  const handleAddedToChannel = React.useCallback(
+    (channel: Channel, result: AttachManagedAgentToChannelResult) => {
+      if (result.restarted) {
+        toast.success(
+          `Added ${result.agent.name} to ${channel.name} and restarted it.`,
+        );
+      } else if (result.started) {
+        toast.success(`Added ${result.agent.name} to ${channel.name}.`);
+      } else if (result.membershipAdded) {
+        toast.success(`Added ${result.agent.name} to ${channel.name}.`);
+      } else {
+        toast.success(`${result.agent.name} is already in ${channel.name}.`);
+      }
+      void managedAgentsQuery.refetch();
+      void relayAgentsQuery.refetch();
+      void channelsQuery.refetch();
+    },
+    [
+      channelsQuery.refetch,
+      managedAgentsQuery.refetch,
+      relayAgentsQuery.refetch,
+    ],
+  );
 
   const handleOpenActivity = React.useCallback(() => {
+    if (!effectivePubkey) return;
     onClose();
-    onOpenAgentSession?.(pubkey);
-  }, [onClose, onOpenAgentSession, pubkey]);
+    onOpenAgentSession?.(effectivePubkey);
+  }, [effectivePubkey, onClose, onOpenAgentSession]);
 
   const handleOpenChannel = React.useCallback(
     (channelId: string) => {
@@ -290,43 +660,56 @@ export function UserProfilePanel({
     [goChannel],
   );
 
-  const displayName = profile?.displayName ?? truncatePubkey(pubkey);
-  const ownerHandle = React.useMemo(() => {
-    if (ownerPubkey) {
-      const ownerProfile = ownerProfileQuery.data;
-      return (
-        ownerProfile?.nip05Handle?.trim() ||
-        ownerProfile?.displayName?.trim() ||
-        truncatePubkey(ownerPubkey)
-      );
-    }
-
-    if (currentPubkey === undefined || isOwner !== true) {
-      return null;
-    }
-
-    const currentProfile = currentProfileQuery.data;
-    return (
-      currentProfile?.nip05Handle?.trim() ||
-      currentProfile?.displayName?.trim() ||
-      truncatePubkey(currentPubkey)
-    );
-  }, [
-    currentProfileQuery.data,
-    currentPubkey,
-    isOwner,
-    ownerProfileQuery.data,
-    ownerPubkey,
-  ]);
+  const displayName = resolveProfileDisplayName({
+    persona: resolvedPersona,
+    profile,
+    pubkey: effectivePubkey,
+  });
+  const ownerHandle = resolveOwnerHandle(
+    ownerPubkey ? ownerProfileQuery.data : currentProfileQuery.data,
+    ownerPubkey ?? currentPubkey,
+  );
   const ownerDisplayName = ownerHandle
     ? isCurrentUserOwner || (!ownerPubkey && isOwner === true)
       ? `${ownerHandle} (you)`
       : ownerHandle
     : null;
-  const panelTitle = VIEW_TITLES[view];
-  const memoryCount = memoryQuery.data
-    ? (memoryQuery.data.core ? 1 : 0) + memoryQuery.data.memories.length
-    : undefined;
+  const memoryCount =
+    memoryQuery.data &&
+    (memoryQuery.data.core ? 1 : 0) + memoryQuery.data.memories.length;
+  const agentInstruction = resolveAgentInstruction(
+    managedAgent,
+    resolvedPersona,
+  );
+  const canManagePersona = isOwner === true && resolvedPersona !== undefined;
+  const canEditPersona =
+    canManagePersona && resolvedPersona?.isBuiltIn !== true;
+  const canDeletePersona = canManagePersona && !resolvedPersona?.sourceTeam;
+  const {
+    agentInfoFields,
+    agentSettingsFields,
+    diagnosticsFields,
+    diagnosticsSummary,
+    modelLabel,
+  } = useProfileFieldBuckets({
+    isBot,
+    isOwner,
+    managedAgent,
+    ownerAvatarUrl: ownerProfileQuery.data?.avatarUrl ?? null,
+    ownerDisplayName,
+    ownerHandle,
+    ownerPubkey,
+    onOpenOwner:
+      ownerPubkey && onOpenProfile
+        ? () => onOpenProfile(ownerPubkey)
+        : undefined,
+    persona: resolvedPersona,
+    presenceLoaded: presenceQuery.isSuccess,
+    presenceStatus,
+    profile,
+    pubkey: effectivePubkey,
+    relayAgent,
+  });
 
   const headerLeftContent = (
     <AuxiliaryPanelHeaderGroup>
@@ -335,7 +718,7 @@ export function UserProfilePanel({
           aria-label="Back to profile"
           className="shrink-0"
           data-testid="user-profile-panel-back"
-          onClick={() => onViewChange("summary")}
+          onClick={() => setView("summary")}
           size="icon"
           type="button"
           variant="outline"
@@ -343,18 +726,16 @@ export function UserProfilePanel({
           <ArrowLeft />
         </Button>
       ) : null}
-      <AuxiliaryPanelTitle>{panelTitle}</AuxiliaryPanelTitle>
+      <AuxiliaryPanelTitle>
+        {PROFILE_PANEL_VIEW_TITLES[view]}
+      </AuxiliaryPanelTitle>
     </AuxiliaryPanelHeaderGroup>
   );
 
   const headerActions = (
     <div className="ml-auto flex shrink-0 items-center gap-2">
-      {view === "memories" && viewerIsOwner ? (
-        <MemoryRefreshButton
-          agentPubkey={pubkey}
-          variant="outline"
-          viewerIsOwner={viewerIsOwner}
-        />
+      {view === "memories" && viewerIsOwner && effectivePubkey ? (
+        <MemoryRefreshButton agentPubkey={effectivePubkey} variant="outline" />
       ) : null}
       <Button
         aria-label="Close profile"
@@ -374,59 +755,136 @@ export function UserProfilePanel({
       className={cn(
         "min-h-0 flex-1 overflow-y-auto px-4 pb-6",
         isSplitLayout && auxiliaryPanelContentPaddingClass,
-        !isSplitLayout && !isFloatingOverlay && "pt-[3.25rem]",
+        !isSplitLayout && !isFloatingOverlay && "pt-[4.75rem]",
       )}
     >
       {view === "summary" ? (
         <ProfileSummaryView
           canEditAgent={canEditAgent}
+          canInstantiateAgent={canInstantiateAgent}
+          canOpenAgentLogs={canOpenAgentLogs}
           canViewActivity={canViewActivity}
           channelCount={profileChannels.length}
           channelIdToName={channelIdToName}
           channelsLoading={channelsQuery.isLoading}
           displayName={displayName}
           followMutation={followMutation}
+          agentInstruction={agentInstruction}
+          handleAgentPrimaryAction={handleAgentPrimaryAction}
+          handleDeleteAgent={handleDeleteAgent}
+          handleDeletePersona={
+            canDeletePersona ? handleDeletePersona : undefined
+          }
+          handleDuplicatePersona={
+            canManagePersona ? handleDuplicatePersona : undefined
+          }
           handleEditAgent={handleEditAgent}
+          handleEditPersona={canEditPersona ? handleEditPersona : undefined}
+          handleExportPersona={
+            canManagePersona ? handleExportPersona : undefined
+          }
+          handleInstantiateAgent={handleInstantiateAgent}
           handleMessage={handleMessage}
-          handleOpenActivity={handleOpenActivity}
           isBot={isBot}
+          isAgentActionPending={isAgentActionPending}
           isFollowing={isFollowing}
           isOwner={viewerIsOwner}
           isSelf={isSelf}
           managedAgent={managedAgent}
           memoriesLoading={memoryQuery.isLoading}
           memoryCount={memoryCount}
-          ownerDisplayName={ownerDisplayName}
-          ownerAvatarUrl={ownerProfileQuery.data?.avatarUrl ?? null}
-          ownerHandle={ownerHandle}
-          ownerPubkey={ownerPubkey}
-          onOpenChannels={() => onViewChange("channels")}
-          onOpenOwner={
-            ownerPubkey && onOpenProfile
-              ? () => onOpenProfile(ownerPubkey)
-              : undefined
-          }
-          onOpenMemories={() => onViewChange("memories")}
+          agentInfoFields={agentInfoFields}
+          agentSettingsFields={agentSettingsFields}
+          diagnosticsFields={diagnosticsFields}
+          diagnosticsSummary={diagnosticsSummary}
+          modelLabel={modelLabel}
+          onOpenAgentInfo={() => setView("info")}
+          onOpenAgentSettings={() => setView("settings")}
+          onOpenChannels={() => setView("channels")}
+          onOpenDiagnostics={() => setView("diagnostics")}
+          onOpenInstruction={() => setView("instructions")}
+          onOpenMemories={() => setView("memories")}
+          onOpenModel={() => setView("model")}
           onOpenDm={onOpenDm}
-          presenceLoaded={presenceQuery.isSuccess}
+          persona={resolvedPersona}
           presenceStatus={presenceStatus}
           profile={profile}
-          pubkey={pubkey}
+          pubkey={effectivePubkey}
           relayAgent={relayAgent}
           unfollowMutation={unfollowMutation}
           userStatus={userStatus}
         />
       ) : null}
 
-      {view === "memories" ? (
-        <MemoryFocusedView agentPubkey={pubkey} viewerIsOwner={viewerIsOwner} />
+      {view === "memories" && effectivePubkey ? (
+        <MemoryFocusedView
+          agentPubkey={effectivePubkey}
+          isOwner={viewerIsOwner}
+        />
+      ) : null}
+
+      {view === "instructions" ? (
+        <AgentInstructionFocusedView
+          instruction={agentInstruction}
+          onEdit={canEditPersona ? handleEditPersona : undefined}
+        />
+      ) : null}
+
+      {view === "info" ? (
+        <AgentInfoFocusedView metadataFields={agentInfoFields} />
+      ) : null}
+
+      {view === "model" ? (
+        <ModelFocusedView
+          managedAgent={managedAgent}
+          modelLabel={modelLabel}
+          onModelChanged={() => void managedAgentsQuery.refetch()}
+        />
+      ) : null}
+
+      {view === "settings" ? (
+        <AgentSettingsFocusedView
+          fields={agentSettingsFields}
+          isActionPending={isAgentActionPending}
+          managedAgent={managedAgent}
+          onToggleAutoStart={handleToggleAgentAutoStart}
+        />
+      ) : null}
+
+      {view === "diagnostics" ? (
+        <DiagnosticsFocusedView
+          canOpenAgentLogs={canOpenAgentLogs}
+          canViewActivity={canViewActivity}
+          fields={diagnosticsFields}
+          managedAgent={managedAgent}
+          onOpenActivity={handleOpenActivity}
+          onOpenAgentLogs={() => setView("logs")}
+          pubkey={effectivePubkey}
+        />
       ) : null}
 
       {view === "channels" ? (
         <ChannelsFocusedView
+          canAddToChannel={managedAgent !== undefined && isOwner === true}
           channels={profileChannels}
+          isActionPending={isAgentActionPending}
           isLoading={channelsQuery.isLoading}
+          onAddToChannel={() => setAddToChannelOpen(true)}
           onOpenChannel={handleOpenChannel}
+        />
+      ) : null}
+
+      {view === "logs" ? (
+        <ManagedAgentLogPanel
+          error={
+            managedAgentLogQuery.error instanceof Error
+              ? managedAgentLogQuery.error
+              : null
+          }
+          isLoading={managedAgentLogQuery.isLoading}
+          logContent={managedAgentLogQuery.data?.content ?? null}
+          selectedAgent={managedAgent ?? null}
+          variant="inline"
         />
       ) : null}
     </div>
@@ -440,7 +898,44 @@ export function UserProfilePanel({
         open={editAgentOpen}
       />
     ) : null;
-
+  const addAgentToChannelDialog = managedAgent ? (
+    <AddAgentToChannelDialog
+      agent={managedAgent ?? null}
+      onAdded={handleAddedToChannel}
+      onOpenChange={setAddToChannelOpen}
+      open={addToChannelOpen}
+    />
+  ) : null;
+  const personaDialogs = (
+    <UserProfilePersonaDialogs
+      createError={
+        createPersonaMutation.error instanceof Error
+          ? createPersonaMutation.error
+          : null
+      }
+      isPending={
+        createPersonaMutation.isPending ||
+        updatePersonaMutation.isPending ||
+        updateManagedAgentMutation.isPending ||
+        createAgentMutation.isPending
+      }
+      personaDialogState={personaDialogState}
+      personaToDelete={personaToDelete}
+      runtimes={acpRuntimesQuery.data ?? []}
+      runtimesLoading={acpRuntimesQuery.isLoading}
+      updateError={
+        updatePersonaMutation.error instanceof Error
+          ? updatePersonaMutation.error
+          : null
+      }
+      onCloseDelete={() => setPersonaToDelete(null)}
+      onCloseDialog={() => setPersonaDialogState(null)}
+      onConfirmDelete={(selectedPersona) => {
+        void handleConfirmDeletePersona(selectedPersona);
+      }}
+      onSubmit={handleSubmitPersona}
+    />
+  );
   if (isSplitLayout) {
     return (
       <>
@@ -452,6 +947,8 @@ export function UserProfilePanel({
           {profileBody}
         </div>
         {editAgentDialog}
+        {addAgentToChannelDialog}
+        {personaDialogs}
       </>
     );
   }
@@ -495,7 +992,7 @@ export function UserProfilePanel({
         {!isOverlay ? (
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 top-0 z-40 h-[3.25rem] bg-background/80 backdrop-blur-md supports-[backdrop-filter]:bg-background/70 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-[backdrop-filter]:bg-background/55"
+            className="pointer-events-none absolute inset-x-0 top-0 z-40 h-[4.75rem] bg-background/80 backdrop-blur-md after:absolute after:left-0 after:right-0 after:top-10 after:h-px after:bg-border/35 supports-[backdrop-filter]:bg-background/70 peer-hover/profile-resize:after:bg-border/80 peer-focus-visible/profile-resize:after:bg-border/80 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-[backdrop-filter]:bg-background/55"
           />
         ) : null}
 
@@ -503,10 +1000,10 @@ export function UserProfilePanel({
           className={cn(
             "flex cursor-default select-none items-center",
             isSinglePanelView
-              ? `relative ${PANEL_SINGLE_COLUMN_HEADER_LAYER_CLASS} -mb-[3.25rem] min-h-[3.25rem] shrink-0 gap-2.5 bg-transparent px-4 py-2 sm:pl-6 sm:pr-3`
+              ? `relative ${PANEL_SINGLE_COLUMN_HEADER_LAYER_CLASS} -mb-[4.75rem] min-h-[4.75rem] shrink-0 gap-2.5 bg-transparent pb-1 pl-4 pr-2 pt-[2.625rem] sm:pl-6 sm:pr-3`
               : isOverlay
-                ? "relative z-50 min-h-[3.25rem] shrink-0 gap-3 bg-background/80 px-5 py-2 backdrop-blur-md supports-[backdrop-filter]:bg-background/70 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-[backdrop-filter]:bg-background/55"
-                : "absolute inset-x-0 top-0 z-50 min-h-[3.25rem] gap-3 bg-transparent px-3 py-2 after:absolute after:bottom-0 after:-left-px after:top-0 after:w-px after:bg-border/45 after:transition-colors peer-hover/profile-resize:after:bg-border/80 peer-focus-visible/profile-resize:after:bg-border/80",
+                ? "relative z-50 min-h-11 shrink-0 gap-3 bg-background/80 px-3 py-1.5 backdrop-blur-md supports-[backdrop-filter]:bg-background/70 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-[backdrop-filter]:bg-background/55"
+                : "absolute inset-x-0 top-[2.625rem] z-50 min-h-8 gap-3 bg-transparent px-3 py-1 after:absolute after:bottom-0 after:-left-px after:top-0 after:w-px after:bg-border/45 after:transition-colors peer-hover/profile-resize:after:bg-border/80 peer-focus-visible/profile-resize:after:bg-border/80",
           )}
           data-tauri-drag-region
         >
@@ -517,6 +1014,8 @@ export function UserProfilePanel({
         {profileBody}
       </aside>
       {editAgentDialog}
+      {addAgentToChannelDialog}
+      {personaDialogs}
     </>
   );
 }

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -103,6 +103,7 @@ import {
   UserProfilePanelHeaderActions,
   UserProfilePanelHeaderLeft,
 } from "./UserProfilePanelHeaderControls";
+import { useCreatedAgentSecretReveal } from "./UserProfileCreatedAgentSecretDialog";
 
 export type { ProfilePanelView };
 
@@ -130,6 +131,8 @@ export function UserProfilePanel({
 
   const [internalView, setInternalView] =
     React.useState<ProfilePanelView>("summary");
+  const { createdAgentSecretDialog, setCreatedAgent } =
+    useCreatedAgentSecretReveal();
   const view = controlledView ?? internalView;
   const setView = React.useCallback(
     (nextView: ProfilePanelView, options?: { replace?: boolean }) => {
@@ -449,6 +452,7 @@ export function UserProfilePanel({
 
     try {
       const created = await createManagedAgentForPersona(resolvedPersona);
+      setCreatedAgent(created);
       if (created.spawnError) {
         toast.error(created.spawnError);
       } else {
@@ -462,7 +466,7 @@ export function UserProfilePanel({
         error instanceof Error ? error.message : "Failed to start agent.",
       );
     }
-  }, [createManagedAgentForPersona, resolvedPersona]);
+  }, [createManagedAgentForPersona, resolvedPersona, setCreatedAgent]);
 
   const handleToggleAgentAutoStart = React.useCallback(async () => {
     if (managedAgent?.backend.type !== "local") return;
@@ -918,6 +922,7 @@ export function UserProfilePanel({
         </div>
         {editAgentDialog}
         {addAgentToChannelDialog}
+        {createdAgentSecretDialog}
         {personaDialogs}
       </>
     );
@@ -985,6 +990,7 @@ export function UserProfilePanel({
       </aside>
       {editAgentDialog}
       {addAgentToChannelDialog}
+      {createdAgentSecretDialog}
       {personaDialogs}
     </>
   );

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -649,22 +649,25 @@ export function UserProfilePanel({
     onClose();
     onOpenAgentSession?.(effectivePubkey);
   }, [effectivePubkey, onClose, onOpenAgentSession]);
-
   const handleOpenChannel = React.useCallback(
     (channelId: string) => {
       void goChannel(channelId);
     },
     [goChannel],
   );
-
   const displayName = resolveProfileDisplayName({
     persona: resolvedPersona,
     profile,
     pubkey: effectivePubkey,
   });
+  const ownerProfile = ownerPubkey
+    ? ownerProfileQuery.data
+    : isOwner === true
+      ? currentProfileQuery.data
+      : undefined;
   const ownerHandle = resolveOwnerHandle(
-    ownerPubkey ? ownerProfileQuery.data : currentProfileQuery.data,
-    ownerPubkey ?? currentPubkey,
+    ownerProfile,
+    ownerPubkey ?? (isOwner === true ? currentPubkey : undefined),
   );
   const ownerDisplayName = ownerHandle
     ? isCurrentUserOwner || (!ownerPubkey && isOwner === true)
@@ -715,7 +718,6 @@ export function UserProfilePanel({
       onBack={() => setView("summary")}
     />
   );
-
   const headerActions = (
     <UserProfilePanelHeaderActions
       effectivePubkey={effectivePubkey}
@@ -724,7 +726,6 @@ export function UserProfilePanel({
       onClose={onClose}
     />
   );
-
   const profileBody = (
     <div
       className={cn(

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -735,7 +735,11 @@ export function UserProfilePanel({
   const headerActions = (
     <div className="ml-auto flex shrink-0 items-center gap-2">
       {view === "memories" && viewerIsOwner && effectivePubkey ? (
-        <MemoryRefreshButton agentPubkey={effectivePubkey} variant="outline" />
+        <MemoryRefreshButton
+          agentPubkey={effectivePubkey}
+          variant="outline"
+          viewerIsOwner={viewerIsOwner}
+        />
       ) : null}
       <Button
         aria-label="Close profile"

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -602,21 +602,17 @@ export function UserProfilePanel({
       }
 
       try {
-        const deletedInstances =
-          await deleteManagedAgentsForPersona(personaToConfirm);
-        if (deletedInstances.cancelled) return;
-
         await deletePersonaMutation.mutateAsync(personaToConfirm.id);
         toast.success(`Deleted ${personaToConfirm.displayName}.`);
         setPersonaToDelete(null);
         onClose();
       } catch (error) {
         toast.error(
-          error instanceof Error ? error.message : "Failed to delete agent.",
+          error instanceof Error ? error.message : "Failed to delete persona.",
         );
       }
     },
-    [deleteManagedAgentsForPersona, deletePersonaMutation.mutateAsync, onClose],
+    [deletePersonaMutation.mutateAsync, onClose],
   );
 
   const handleAddedToChannel = React.useCallback(

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -365,7 +365,7 @@ export function UserProfilePanel({
           candidate.availability === "available",
       );
       const defaultRuntime = runtimes[0] ?? null;
-      const { runtime, warnings } = resolvePersonaRuntime(
+      const { runtime, warnings, isOverridden } = resolvePersonaRuntime(
         personaToStart.runtime,
         runtimes,
         defaultRuntime,
@@ -382,6 +382,7 @@ export function UserProfilePanel({
         name: personaToStart.displayName,
         acpCommand: "buzz-acp",
         agentCommand: runtime.command,
+        harnessOverride: isOverridden,
         agentArgs: runtime.defaultArgs,
         mcpCommand: runtime.mcpCommand ?? "",
         personaId: personaToStart.id,
@@ -809,7 +810,6 @@ export function UserProfilePanel({
       {view === "info" ? (
         <AgentInfoFocusedView metadataFields={agentInfoFields} />
       ) : null}
-
       {view === "model" ? (
         <ModelFocusedView
           managedAgent={managedAgent}

--- a/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
@@ -1,0 +1,159 @@
+import * as React from "react";
+
+import {
+  deleteManagedAgentWithRules,
+  type ManagedAgentActionResult,
+} from "@/features/agents/lib/managedAgentControlActions";
+import { removeChannelMember } from "@/shared/api/tauri";
+import type {
+  AgentPersona,
+  Channel,
+  ManagedAgent,
+  PresenceLookup,
+  RelayAgent,
+} from "@/shared/api/types";
+import { getRelayAgentChannelIds } from "@/features/profile/ui/UserProfilePanelUtils";
+
+type DeleteManagedAgentRulesContext = Omit<
+  Parameters<typeof deleteManagedAgentWithRules>[0],
+  "agent"
+>;
+
+type DeleteProfileManagedAgentContext = DeleteManagedAgentRulesContext & {
+  removeAgentFromAllChannels: (pubkey: string) => Promise<void>;
+};
+
+type DeleteProfileManagedAgentsForPersonaContext =
+  DeleteProfileManagedAgentContext & {
+    managedAgents: readonly ManagedAgent[];
+    selectedAgent?: ManagedAgent;
+  };
+
+type UseProfileAgentDeletionInput = {
+  channels?: readonly Channel[];
+  deleteManagedAgent: DeleteManagedAgentRulesContext["deleteManagedAgent"];
+  managedAgent?: ManagedAgent;
+  managedAgents?: readonly ManagedAgent[];
+  presenceLookup?: PresenceLookup | null;
+  relayAgents?: readonly RelayAgent[];
+};
+
+export function useProfileAgentDeletion({
+  channels,
+  deleteManagedAgent,
+  managedAgent,
+  managedAgents,
+  presenceLookup,
+  relayAgents,
+}: UseProfileAgentDeletionInput) {
+  const removeAgentFromAllChannels = React.useCallback(
+    async (agentPubkey: string) => {
+      const normalizedPubkey = agentPubkey.toLowerCase();
+      const channelIds = new Set(
+        getRelayAgentChannelIds(relayAgents, agentPubkey),
+      );
+      for (const channel of channels ?? []) {
+        if (
+          channel.memberPubkeys.some(
+            (memberPubkey) => memberPubkey.toLowerCase() === normalizedPubkey,
+          )
+        ) {
+          channelIds.add(channel.id);
+        }
+      }
+      if (channelIds.size === 0) return;
+      await Promise.allSettled(
+        [...channelIds].map((channelId) =>
+          removeChannelMember(channelId, agentPubkey),
+        ),
+      );
+    },
+    [channels, relayAgents],
+  );
+
+  const deleteManagedAgentRecord = React.useCallback(
+    (agentToDelete: ManagedAgent) =>
+      deleteProfileManagedAgent(agentToDelete, {
+        channels: channels ?? [],
+        deleteManagedAgent,
+        presenceLookup,
+        relayAgents: relayAgents ?? [],
+        removeAgentFromAllChannels,
+      }),
+    [
+      channels,
+      deleteManagedAgent,
+      presenceLookup,
+      relayAgents,
+      removeAgentFromAllChannels,
+    ],
+  );
+
+  const deleteManagedAgentsForPersona = React.useCallback(
+    (persona: AgentPersona) =>
+      deleteProfileManagedAgentsForPersona(persona, {
+        channels: channels ?? [],
+        deleteManagedAgent,
+        managedAgents: managedAgents ?? [],
+        presenceLookup,
+        relayAgents: relayAgents ?? [],
+        removeAgentFromAllChannels,
+        selectedAgent: managedAgent,
+      }),
+    [
+      channels,
+      deleteManagedAgent,
+      managedAgent,
+      managedAgents,
+      presenceLookup,
+      relayAgents,
+      removeAgentFromAllChannels,
+    ],
+  );
+
+  return {
+    deleteManagedAgentRecord,
+    deleteManagedAgentsForPersona,
+    removeAgentFromAllChannels,
+  };
+}
+
+export async function deleteProfileManagedAgent(
+  agent: ManagedAgent,
+  context: DeleteProfileManagedAgentContext,
+): Promise<ManagedAgentActionResult> {
+  const { removeAgentFromAllChannels, ...deleteContext } = context;
+  const result = await deleteManagedAgentWithRules({
+    agent,
+    ...deleteContext,
+  });
+  if (result.cancelled) return result;
+
+  await removeAgentFromAllChannels(agent.pubkey);
+  return result;
+}
+
+export async function deleteProfileManagedAgentsForPersona(
+  persona: AgentPersona,
+  context: DeleteProfileManagedAgentsForPersonaContext,
+): Promise<ManagedAgentActionResult> {
+  const { managedAgents, selectedAgent, ...deleteContext } = context;
+  const agentsByPubkey = new Map<string, ManagedAgent>();
+
+  for (const agent of managedAgents) {
+    if (agent.personaId === persona.id) {
+      agentsByPubkey.set(agent.pubkey, agent);
+    }
+  }
+
+  if (selectedAgent?.personaId === persona.id) {
+    agentsByPubkey.set(selectedAgent.pubkey, selectedAgent);
+  }
+
+  for (const agent of agentsByPubkey.values()) {
+    const result = await deleteProfileManagedAgent(agent, deleteContext);
+    if (result.cancelled) return result;
+  }
+
+  return {};
+}

--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -111,20 +111,19 @@ export function useProfileFieldBuckets({
   return React.useMemo(() => {
     const metadataFields = [
       ...buildPublicFields({ pubkey, profile, relayAgent, isBot, persona }),
-      ...(isOwner === true
-        ? buildOwnerFields({
-            managedAgent,
-            ownerAvatarUrl,
-            ownerDisplayName,
-            ownerHandle,
-            ownerPubkey,
-            onOpenOwner,
-            persona,
-            presenceLoaded,
-            presenceStatus,
-            relayAgent,
-          })
-        : []),
+      ...buildOwnerFields({
+        includeManagementFields: isOwner === true,
+        managedAgent,
+        ownerAvatarUrl,
+        ownerDisplayName,
+        ownerHandle,
+        ownerPubkey,
+        onOpenOwner,
+        persona,
+        presenceLoaded,
+        presenceStatus,
+        relayAgent,
+      }),
     ];
     const diagnosticsFields =
       bucketProfileFields(metadataFields).diagnosticsFields;
@@ -225,6 +224,7 @@ export function buildPublicFields({
 }
 
 export function buildOwnerFields({
+  includeManagementFields,
   managedAgent,
   ownerAvatarUrl,
   ownerDisplayName,
@@ -236,6 +236,7 @@ export function buildOwnerFields({
   presenceStatus,
   relayAgent,
 }: {
+  includeManagementFields: boolean;
   managedAgent: ManagedAgent | undefined;
   ownerAvatarUrl: string | null;
   ownerDisplayName: string | null;
@@ -279,6 +280,10 @@ export function buildOwnerFields({
       label: "Owned by",
       testId: "user-profile-owned-by",
     });
+  }
+
+  if (!includeManagementFields) {
+    return fields;
   }
 
   if (managedAgent?.agentCommand) {

--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -1,0 +1,491 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Activity,
+  Copy,
+  Cpu,
+  Fingerprint,
+  MessageSquare,
+  Server,
+  Terminal,
+  UserRound,
+} from "lucide-react";
+import * as React from "react";
+import { toast } from "sonner";
+
+import { AgentStatusBadge } from "@/features/agents/ui/AgentStatusBadge";
+import { truncatePubkey as truncatePubkeyShort } from "@/features/profile/lib/identity";
+import type {
+  AgentPersona,
+  ManagedAgent,
+  Profile,
+  RelayAgent,
+} from "@/shared/api/types";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+
+const RUNTIME_LABELS: Record<string, string> = {
+  goose: "Goose",
+  "claude-code": "Claude Code",
+  "codex-acp": "Codex",
+  aider: "Aider",
+};
+
+function runtimeLabel(command: string): string {
+  return RUNTIME_LABELS[command] ?? command;
+}
+
+async function copyToClipboard(value: string, label?: string) {
+  await navigator.clipboard.writeText(value);
+  toast.success(label ? `Copied ${label}` : "Copied to clipboard");
+}
+
+export type ProfileField = {
+  copyValue?: string;
+  displayValue: string;
+  displayNode?: React.ReactNode;
+  icon: LucideIcon;
+  label: string;
+  testId?: string;
+};
+
+const AGENT_INFO_LABELS = new Set([
+  "Public key",
+  "Owned by",
+  "NIP-05",
+  "Agent type",
+  "Capabilities",
+  "Backend",
+]);
+const AGENT_SETTINGS_LABELS = new Set([
+  "Runtime",
+  "Respond to",
+  "ACP command",
+  "MCP command",
+]);
+const DIAGNOSTICS_LABELS = new Set(["Status", "Last error"]);
+
+export function bucketProfileFields(fields: ProfileField[]) {
+  return {
+    agentInfoFields: fields.filter((field) =>
+      AGENT_INFO_LABELS.has(field.label),
+    ),
+    agentSettingsFields: fields.filter((field) =>
+      AGENT_SETTINGS_LABELS.has(field.label),
+    ),
+    diagnosticsFields: fields.filter((field) =>
+      DIAGNOSTICS_LABELS.has(field.label),
+    ),
+  };
+}
+
+export function useProfileFieldBuckets({
+  isBot,
+  isOwner,
+  managedAgent,
+  ownerAvatarUrl,
+  ownerDisplayName,
+  ownerHandle,
+  ownerPubkey,
+  onOpenOwner,
+  persona,
+  presenceLoaded,
+  presenceStatus,
+  profile,
+  pubkey,
+  relayAgent,
+}: {
+  isBot: boolean;
+  isOwner: boolean | undefined;
+  managedAgent: ManagedAgent | undefined;
+  ownerAvatarUrl: string | null;
+  ownerDisplayName: string | null;
+  ownerHandle: string | null;
+  ownerPubkey: string | null;
+  onOpenOwner?: () => void;
+  persona: AgentPersona | undefined;
+  presenceLoaded: boolean;
+  presenceStatus: "online" | "away" | "offline" | undefined;
+  profile: Profile | undefined;
+  pubkey: string | null;
+  relayAgent: RelayAgent | undefined;
+}) {
+  return React.useMemo(() => {
+    const metadataFields = [
+      ...buildPublicFields({ pubkey, profile, relayAgent, isBot, persona }),
+      ...(isOwner === true
+        ? buildOwnerFields({
+            managedAgent,
+            ownerAvatarUrl,
+            ownerDisplayName,
+            ownerHandle,
+            ownerPubkey,
+            onOpenOwner,
+            persona,
+            presenceLoaded,
+            presenceStatus,
+            relayAgent,
+          })
+        : []),
+    ];
+    const diagnosticsFields =
+      bucketProfileFields(metadataFields).diagnosticsFields;
+
+    return {
+      ...bucketProfileFields(metadataFields),
+      diagnosticsSummary:
+        diagnosticsFields.find((field) => field.label === "Status")
+          ?.displayValue ??
+        diagnosticsFields.find((field) => field.label === "Last error")
+          ?.displayValue ??
+        null,
+      modelLabel: managedAgent?.model ?? persona?.model ?? "Auto",
+    };
+  }, [
+    isBot,
+    isOwner,
+    managedAgent,
+    ownerAvatarUrl,
+    ownerDisplayName,
+    ownerHandle,
+    ownerPubkey,
+    onOpenOwner,
+    persona,
+    presenceLoaded,
+    presenceStatus,
+    profile,
+    pubkey,
+    relayAgent,
+  ]);
+}
+
+export function buildPublicFields({
+  isBot,
+  persona,
+  profile,
+  pubkey,
+  relayAgent,
+}: {
+  isBot: boolean;
+  persona?: AgentPersona;
+  profile: Profile | undefined;
+  pubkey: string | null;
+  relayAgent: RelayAgent | undefined;
+}): ProfileField[] {
+  const fields: ProfileField[] = [];
+
+  if (pubkey) {
+    fields.push({
+      copyValue: pubkey,
+      displayValue: truncatePubkeyShort(pubkey),
+      icon: Fingerprint,
+      label: "Public key",
+      testId: "user-profile-copy-pubkey",
+    });
+  }
+
+  if (profile?.nip05Handle) {
+    fields.push({
+      copyValue: profile.nip05Handle,
+      displayValue: profile.nip05Handle,
+      icon: UserRound,
+      label: "NIP-05",
+      testId: "user-profile-nip05",
+    });
+  }
+
+  if (isBot && relayAgent?.agentType) {
+    fields.push({
+      copyValue: relayAgent.agentType,
+      displayValue: runtimeLabel(relayAgent.agentType),
+      icon: Cpu,
+      label: "Agent type",
+      testId: "user-profile-agent-type",
+    });
+  }
+
+  if (!pubkey && persona) {
+    fields.push({
+      displayValue: "Not deployed",
+      icon: Activity,
+      label: "Status",
+      testId: "user-profile-agent-status",
+    });
+  }
+
+  if (relayAgent?.capabilities.length) {
+    fields.push({
+      copyValue: relayAgent.capabilities.join(", "),
+      displayValue: relayAgent.capabilities.join(", "),
+      icon: Server,
+      label: "Capabilities",
+      testId: "user-profile-capabilities",
+    });
+  }
+
+  return fields;
+}
+
+export function buildOwnerFields({
+  managedAgent,
+  ownerAvatarUrl,
+  ownerDisplayName,
+  ownerHandle,
+  ownerPubkey,
+  onOpenOwner,
+  persona,
+  presenceLoaded,
+  presenceStatus,
+  relayAgent,
+}: {
+  managedAgent: ManagedAgent | undefined;
+  ownerAvatarUrl: string | null;
+  ownerDisplayName: string | null;
+  ownerHandle: string | null;
+  ownerPubkey: string | null;
+  onOpenOwner?: () => void;
+  persona?: AgentPersona;
+  presenceLoaded: boolean;
+  presenceStatus: "online" | "away" | "offline" | undefined;
+  relayAgent: RelayAgent | undefined;
+}): ProfileField[] {
+  const fields: ProfileField[] = [];
+
+  if (ownerDisplayName) {
+    fields.push({
+      copyValue: onOpenOwner
+        ? undefined
+        : (ownerPubkey ?? ownerHandle ?? undefined),
+      displayValue: ownerDisplayName,
+      displayNode: onOpenOwner ? (
+        <button
+          className="inline-flex max-w-full items-center gap-2 rounded text-left text-sm text-muted-foreground transition-colors hover:text-foreground hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenOwner();
+          }}
+          title={ownerDisplayName}
+          type="button"
+        >
+          <UserAvatar
+            avatarUrl={ownerAvatarUrl}
+            className="shrink-0"
+            displayName={ownerHandle ?? ownerDisplayName}
+            size="xs"
+            testId="user-profile-owner-avatar"
+          />
+          <span className="truncate">{ownerDisplayName}</span>
+        </button>
+      ) : undefined,
+      icon: UserRound,
+      label: "Owned by",
+      testId: "user-profile-owned-by",
+    });
+  }
+
+  if (managedAgent?.agentCommand) {
+    fields.push({
+      copyValue: managedAgent.agentCommand,
+      displayValue: runtimeLabel(managedAgent.agentCommand),
+      icon: Terminal,
+      label: "Runtime",
+      testId: "user-profile-runtime",
+    });
+  } else if (relayAgent?.agentType) {
+    fields.push({
+      copyValue: relayAgent.agentType,
+      displayValue: runtimeLabel(relayAgent.agentType),
+      icon: Terminal,
+      label: "Runtime",
+      testId: "user-profile-runtime",
+    });
+  } else if (persona?.runtime) {
+    fields.push({
+      copyValue: persona.runtime,
+      displayValue: runtimeLabel(persona.runtime),
+      icon: Terminal,
+      label: "Runtime",
+      testId: "user-profile-runtime",
+    });
+  }
+
+  if (managedAgent) {
+    fields.push({
+      displayValue: managedAgent.status
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (char: string) => char.toUpperCase()),
+      displayNode: (
+        <AgentStatusBadge
+          presenceLoaded={presenceLoaded}
+          presenceStatus={presenceStatus}
+          status={managedAgent.status}
+        />
+      ),
+      icon: Activity,
+      label: "Status",
+      testId: "user-profile-agent-status",
+    });
+  }
+
+  if (managedAgent?.model) {
+    fields.push({
+      copyValue: managedAgent.model,
+      displayValue: managedAgent.model,
+      icon: Cpu,
+      label: "Model",
+      testId: "user-profile-model",
+    });
+  } else if (persona?.model) {
+    fields.push({
+      copyValue: persona.model,
+      displayValue: persona.model,
+      icon: Cpu,
+      label: "Model",
+      testId: "user-profile-model",
+    });
+  }
+
+  if (managedAgent?.acpCommand) {
+    fields.push({
+      copyValue: managedAgent.acpCommand,
+      displayValue: managedAgent.acpCommand,
+      icon: Terminal,
+      label: "ACP command",
+      testId: "user-profile-acp",
+    });
+  }
+
+  if (managedAgent?.mcpCommand) {
+    fields.push({
+      copyValue: managedAgent.mcpCommand,
+      displayValue: managedAgent.mcpCommand,
+      icon: Terminal,
+      label: "MCP command",
+      testId: "user-profile-mcp",
+    });
+  }
+
+  if (managedAgent?.backend.type === "provider") {
+    const backendLabel = managedAgent.backend.id;
+    fields.push({
+      copyValue: backendLabel,
+      displayValue: backendLabel,
+      icon: Server,
+      label: "Backend",
+      testId: "user-profile-backend",
+    });
+  }
+
+  if (managedAgent) {
+    fields.push({
+      displayValue: managedAgent.startOnAppLaunch ? "Yes" : "No",
+      icon: Server,
+      label: "Start on launch",
+      testId: "user-profile-start-on-launch",
+    });
+    fields.push({
+      displayValue: managedAgent.respondTo.replace(/-/g, " "),
+      icon: MessageSquare,
+      label: "Respond to",
+      testId: "user-profile-respond-to",
+    });
+  }
+
+  if (managedAgent?.lastError) {
+    fields.push({
+      copyValue: managedAgent.lastError,
+      displayValue: managedAgent.lastError,
+      icon: Activity,
+      label: "Last error",
+      testId: "user-profile-last-error",
+    });
+  }
+
+  return fields;
+}
+
+export function ProfileFieldGroup({ fields }: { fields: ProfileField[] }) {
+  const publicKeyLabel = "Public key";
+  const ownedByLabel = "Owned by";
+  const statusLabel = "Status";
+  const orderedFields = [
+    ...fields.filter((field) => field.label === publicKeyLabel),
+    ...fields.filter((field) => field.label === ownedByLabel),
+    ...fields.filter(
+      (field) =>
+        field.label !== publicKeyLabel &&
+        field.label !== ownedByLabel &&
+        field.copyValue,
+    ),
+    ...fields.filter((field) => field.label === statusLabel),
+    ...fields.filter((field) => {
+      if (
+        field.label === publicKeyLabel ||
+        field.label === ownedByLabel ||
+        field.label === statusLabel
+      ) {
+        return false;
+      }
+      return !field.copyValue;
+    }),
+  ];
+
+  return (
+    <section>
+      <div className="overflow-hidden rounded-2xl bg-muted/20">
+        {orderedFields.map((field) => (
+          <ProfileFieldRow field={field} key={field.testId ?? field.label} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ProfileFieldRow({ field }: { field: ProfileField }) {
+  const Icon = field.icon;
+  const isCopyable = Boolean(field.copyValue);
+
+  const content = (
+    <>
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </span>
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block text-xs font-medium text-foreground">
+          {field.label}
+        </span>
+        <span
+          className="mt-0.5 block truncate text-sm text-muted-foreground"
+          title={field.displayValue}
+        >
+          {field.displayNode ?? field.displayValue}
+        </span>
+      </span>
+      {isCopyable ? (
+        <Copy className="h-4 w-4 shrink-0 text-muted-foreground" />
+      ) : null}
+    </>
+  );
+
+  if (isCopyable && field.copyValue) {
+    return (
+      <button
+        aria-label={`Copy ${field.label}`}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
+        data-testid={field.testId}
+        onClick={() => void copyToClipboard(field.copyValue ?? "", field.label)}
+        title={`Copy ${field.label}`}
+        type="button"
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center gap-3 px-4 py-3"
+      data-testid={field.testId}
+    >
+      {content}
+    </div>
+  );
+}

--- a/desktop/src/features/profile/ui/UserProfilePanelHeaderControls.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelHeaderControls.tsx
@@ -1,0 +1,72 @@
+import { ArrowLeft, X } from "lucide-react";
+
+import { MemoryRefreshButton } from "@/features/agent-memory/ui/MemorySection";
+import type { ProfilePanelView } from "@/features/profile/ui/UserProfilePanelUtils";
+import {
+  AuxiliaryPanelHeaderGroup,
+  AuxiliaryPanelTitle,
+} from "@/shared/layout/AuxiliaryPanelHeader";
+import { Button } from "@/shared/ui/button";
+
+export function UserProfilePanelHeaderLeft({
+  title,
+  view,
+  onBack,
+}: {
+  title: string;
+  view: ProfilePanelView;
+  onBack: () => void;
+}) {
+  return (
+    <AuxiliaryPanelHeaderGroup>
+      {view !== "summary" ? (
+        <Button
+          aria-label="Back to profile"
+          className="shrink-0"
+          data-testid="user-profile-panel-back"
+          onClick={onBack}
+          size="icon"
+          type="button"
+          variant="outline"
+        >
+          <ArrowLeft />
+        </Button>
+      ) : null}
+      <AuxiliaryPanelTitle>{title}</AuxiliaryPanelTitle>
+    </AuxiliaryPanelHeaderGroup>
+  );
+}
+
+export function UserProfilePanelHeaderActions({
+  effectivePubkey,
+  view,
+  viewerIsOwner,
+  onClose,
+}: {
+  effectivePubkey: string | null;
+  view: ProfilePanelView;
+  viewerIsOwner: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <div className="ml-auto flex shrink-0 items-center gap-2">
+      {view === "memories" && viewerIsOwner && effectivePubkey ? (
+        <MemoryRefreshButton
+          agentPubkey={effectivePubkey}
+          variant="outline"
+          viewerIsOwner={viewerIsOwner}
+        />
+      ) : null}
+      <Button
+        aria-label="Close profile"
+        data-testid="user-profile-panel-close"
+        onClick={onClose}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <X />
+      </Button>
+    </div>
+  );
+}

--- a/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { validateLinkedAgentRuntimeEdit } from "./UserProfilePanelPersonaSubmit.ts";
+import {
+  submitProfilePersonaDialog,
+  validateLinkedAgentRuntimeEdit,
+} from "./UserProfilePanelPersonaSubmit.ts";
 
 function agent(overrides = {}) {
   return {
@@ -66,6 +69,19 @@ function updateInput(overrides = {}) {
     avatarUrl: undefined,
     systemPrompt: "Prompt",
     runtime: "claude",
+    model: undefined,
+    provider: undefined,
+    namePool: [],
+    ...overrides,
+  };
+}
+
+function createInput(overrides = {}) {
+  return {
+    displayName: "Fizz",
+    avatarUrl: undefined,
+    systemPrompt: "Prompt",
+    runtime: "goose",
     model: undefined,
     provider: undefined,
     namePool: [],
@@ -147,4 +163,37 @@ test("validateLinkedAgentRuntimeEdit allows clearing linked runtime preference",
     }),
     null,
   );
+});
+
+test("submitProfilePersonaDialog reports created agents for secret reveal", async () => {
+  const createdAgent = {
+    agent: agent({ name: "Fizz Prime" }),
+    privateKeyNsec: "nsec1secret",
+    profileSyncError: null,
+    spawnError: null,
+  };
+  let revealedAgent = null;
+  let done = false;
+
+  await submitProfilePersonaDialog({
+    createManagedAgentForPersona: async () => createdAgent,
+    createPersona: async () => persona({ displayName: "Fizz Prime" }),
+    input: createInput({ displayName: "Fizz Prime" }),
+    managedAgent: undefined,
+    onCreatedAgent: (created) => {
+      revealedAgent = created;
+    },
+    onDone: () => {
+      done = true;
+    },
+    updateManagedAgent: async () => {
+      throw new Error("updateManagedAgent should not be called");
+    },
+    updatePersona: async () => {
+      throw new Error("updatePersona should not be called");
+    },
+  });
+
+  assert.equal(revealedAgent, createdAgent);
+  assert.equal(done, true);
 });

--- a/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.test.mjs
@@ -136,3 +136,15 @@ test("validateLinkedAgentRuntimeEdit allows unchanged or unlinked runtime prefer
     null,
   );
 });
+
+test("validateLinkedAgentRuntimeEdit allows clearing linked runtime preference", () => {
+  assert.equal(
+    validateLinkedAgentRuntimeEdit({
+      input: updateInput({ runtime: undefined }),
+      managedAgent: agent(),
+      previousPersona: persona({ runtime: "goose" }),
+      runtimes: [],
+    }),
+    null,
+  );
+});

--- a/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateLinkedAgentRuntimeEdit } from "./UserProfilePanelPersonaSubmit.ts";
+
+function agent(overrides = {}) {
+  return {
+    pubkey: "deadbeef".repeat(8),
+    name: "Fizz",
+    personaId: "persona-1",
+    relayUrl: "ws://localhost:3000",
+    acpCommand: "buzz-acp",
+    agentCommand: "goose",
+    agentArgs: [],
+    mcpCommand: "",
+    turnTimeoutSeconds: 320,
+    idleTimeoutSeconds: null,
+    maxTurnDurationSeconds: null,
+    parallelism: 1,
+    systemPrompt: "Prompt",
+    avatarUrl: null,
+    model: null,
+    mcpToolsets: null,
+    envVars: {},
+    status: "stopped",
+    pid: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    lastStartedAt: null,
+    lastStoppedAt: null,
+    lastExitCode: null,
+    lastError: null,
+    logPath: null,
+    startOnAppLaunch: true,
+    backend: { type: "local" },
+    backendAgentId: null,
+    respondTo: "owner-only",
+    respondToAllowlist: [],
+    ...overrides,
+  };
+}
+
+function persona(overrides = {}) {
+  return {
+    id: "persona-1",
+    displayName: "Fizz",
+    avatarUrl: null,
+    systemPrompt: "Prompt",
+    runtime: "goose",
+    model: null,
+    provider: null,
+    namePool: [],
+    isBuiltIn: false,
+    isActive: true,
+    envVars: {},
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function updateInput(overrides = {}) {
+  return {
+    id: "persona-1",
+    displayName: "Fizz",
+    avatarUrl: undefined,
+    systemPrompt: "Prompt",
+    runtime: "claude",
+    model: undefined,
+    provider: undefined,
+    namePool: [],
+    ...overrides,
+  };
+}
+
+function runtime(overrides = {}) {
+  return {
+    id: "claude",
+    label: "Claude Code",
+    avatarUrl: "",
+    availability: "available",
+    command: "claude",
+    binaryPath: "/usr/local/bin/claude",
+    defaultArgs: [],
+    mcpCommand: null,
+    installHint: "",
+    installInstructionsUrl: "",
+    canAutoInstall: false,
+    underlyingCliPath: null,
+    ...overrides,
+  };
+}
+
+test("validateLinkedAgentRuntimeEdit allows available runtime changes", () => {
+  assert.equal(
+    validateLinkedAgentRuntimeEdit({
+      input: updateInput({ runtime: "claude" }),
+      managedAgent: agent(),
+      previousPersona: persona({ runtime: "goose" }),
+      runtimes: [runtime()],
+    }),
+    null,
+  );
+});
+
+test("validateLinkedAgentRuntimeEdit rejects unavailable linked-agent runtime changes", () => {
+  assert.equal(
+    validateLinkedAgentRuntimeEdit({
+      input: updateInput({ runtime: "claude" }),
+      managedAgent: agent(),
+      previousPersona: persona({ runtime: "goose" }),
+      runtimes: [runtime({ availability: "cli_missing", command: null })],
+    }),
+    "Claude Code is not available. Install it before saving this linked agent.",
+  );
+});
+
+test("validateLinkedAgentRuntimeEdit allows unchanged or unlinked runtime preferences", () => {
+  assert.equal(
+    validateLinkedAgentRuntimeEdit({
+      input: updateInput({ runtime: "goose" }),
+      managedAgent: agent(),
+      previousPersona: persona({ runtime: "goose" }),
+      runtimes: [],
+    }),
+    null,
+  );
+
+  assert.equal(
+    validateLinkedAgentRuntimeEdit({
+      input: updateInput({ runtime: "claude" }),
+      managedAgent: undefined,
+      previousPersona: persona({ runtime: "goose" }),
+      runtimes: [],
+    }),
+    null,
+  );
+});

--- a/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.ts
@@ -18,6 +18,7 @@ type SubmitProfilePersonaDialogOptions = {
   createPersona: (input: CreatePersonaInput) => Promise<AgentPersona>;
   input: CreatePersonaInput | UpdatePersonaInput;
   managedAgent: ManagedAgent | undefined;
+  onCreatedAgent?: (created: CreateManagedAgentResponse) => void;
   onDone: () => void;
   previousPersona?: AgentPersona;
   runtimes?: readonly AcpRuntimeCatalogEntry[];
@@ -71,6 +72,7 @@ export async function submitProfilePersonaDialog({
   createPersona,
   input,
   managedAgent,
+  onCreatedAgent,
   onDone,
   previousPersona,
   runtimes,
@@ -108,6 +110,7 @@ export async function submitProfilePersonaDialog({
       const persona = await createPersona(input);
       try {
         const created = await createManagedAgentForPersona(persona);
+        onCreatedAgent?.(created);
         if (created.spawnError) {
           toast.error(
             `${persona.displayName} was created, but it did not start: ${created.spawnError}`,

--- a/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.ts
@@ -1,0 +1,135 @@
+import { toast } from "sonner";
+
+import { personaManagedAgentUpdate } from "@/features/profile/ui/UserProfilePanelUtils";
+import type {
+  AcpRuntimeCatalogEntry,
+  AgentPersona,
+  CreateManagedAgentResponse,
+  CreatePersonaInput,
+  ManagedAgent,
+  UpdateManagedAgentInput,
+  UpdatePersonaInput,
+} from "@/shared/api/types";
+
+type SubmitProfilePersonaDialogOptions = {
+  createManagedAgentForPersona: (
+    persona: AgentPersona,
+  ) => Promise<CreateManagedAgentResponse>;
+  createPersona: (input: CreatePersonaInput) => Promise<AgentPersona>;
+  input: CreatePersonaInput | UpdatePersonaInput;
+  managedAgent: ManagedAgent | undefined;
+  onDone: () => void;
+  previousPersona?: AgentPersona;
+  runtimes?: readonly AcpRuntimeCatalogEntry[];
+  updateManagedAgent: (
+    input: UpdateManagedAgentInput,
+  ) => Promise<{ agent: ManagedAgent; profileSyncError: string | null }>;
+  updatePersona: (input: UpdatePersonaInput) => Promise<AgentPersona>;
+};
+
+type ValidateLinkedAgentRuntimeEditOptions = {
+  input: UpdatePersonaInput;
+  managedAgent: ManagedAgent | undefined;
+  previousPersona?: AgentPersona;
+  runtimes?: readonly AcpRuntimeCatalogEntry[];
+};
+
+function normalizeRuntimePreference(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+export function validateLinkedAgentRuntimeEdit({
+  input,
+  managedAgent,
+  previousPersona,
+  runtimes,
+}: ValidateLinkedAgentRuntimeEditOptions): string | null {
+  if (!managedAgent || !previousPersona) {
+    return null;
+  }
+
+  const previousRuntime = normalizeRuntimePreference(previousPersona.runtime);
+  const nextRuntime = normalizeRuntimePreference(input.runtime);
+  if (previousRuntime === nextRuntime) {
+    return null;
+  }
+
+  const runtime = runtimes?.find((candidate) => candidate.id === nextRuntime);
+  if (runtime?.availability === "available" && runtime.command) {
+    return null;
+  }
+
+  const runtimeLabel = runtime?.label ?? "This provider";
+  return `${runtimeLabel} is not available. Install it before saving this linked agent.`;
+}
+
+export async function submitProfilePersonaDialog({
+  createManagedAgentForPersona,
+  createPersona,
+  input,
+  managedAgent,
+  onDone,
+  previousPersona,
+  runtimes,
+  updateManagedAgent,
+  updatePersona,
+}: SubmitProfilePersonaDialogOptions) {
+  try {
+    if ("id" in input) {
+      const runtimeEditError = validateLinkedAgentRuntimeEdit({
+        input,
+        managedAgent,
+        previousPersona,
+        runtimes,
+      });
+      if (runtimeEditError) {
+        toast.error(runtimeEditError);
+        return;
+      }
+
+      const persona = await updatePersona(input);
+      const agentUpdate = managedAgent
+        ? personaManagedAgentUpdate(managedAgent, persona, {
+            previousPersona,
+            runtimes,
+          })
+        : null;
+      const result = agentUpdate ? await updateManagedAgent(agentUpdate) : null;
+      if (result?.profileSyncError) {
+        toast.warning(
+          `${result.agent.name} was updated, but profile sync failed: ${result.profileSyncError}`,
+        );
+      }
+      toast.success(`Updated ${input.displayName}.`);
+    } else {
+      const persona = await createPersona(input);
+      try {
+        const created = await createManagedAgentForPersona(persona);
+        if (created.spawnError) {
+          toast.error(
+            `${persona.displayName} was created, but it did not start: ${created.spawnError}`,
+          );
+        } else {
+          toast.success(`Created and started ${created.agent.name}.`);
+        }
+        if (created.profileSyncError) {
+          toast.warning(
+            `${created.agent.name} was created, but profile sync failed: ${created.profileSyncError}`,
+          );
+        }
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? `${persona.displayName} was created, but the agent instance could not be created: ${error.message}`
+            : `${persona.displayName} was created, but the agent instance could not be created.`,
+        );
+      }
+    }
+
+    onDone();
+  } catch (error) {
+    toast.error(
+      error instanceof Error ? error.message : "Failed to save agent.",
+    );
+  }
+}

--- a/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelPersonaSubmit.ts
@@ -53,6 +53,9 @@ export function validateLinkedAgentRuntimeEdit({
   if (previousRuntime === nextRuntime) {
     return null;
   }
+  if (!nextRuntime) {
+    return null;
+  }
 
   const runtime = runtimes?.find((candidate) => candidate.id === nextRuntime);
   if (runtime?.availability === "available" && runtime.command) {

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -7,24 +7,26 @@ import {
   ChevronDown,
   ChevronRight,
   ChevronUp,
-  Copy,
   Cpu,
-  Fingerprint,
+  FileText,
   Hash,
+  Info,
   MessageSquare,
   Pencil,
-  Server,
-  Terminal,
+  Play,
+  Power,
+  Settings,
+  Square,
   UserMinus,
   UserPlus,
-  UserRound,
 } from "lucide-react";
 import { toast } from "sonner";
 
 import { MemorySection } from "@/features/agent-memory/ui/MemorySection";
-import { AgentStatusBadge } from "@/features/agents/ui/AgentStatusBadge";
 import { useActiveAgentTurns } from "@/features/agents/activeAgentTurnsStore";
+import { getManagedAgentPrimaryActionLabel } from "@/features/agents/lib/managedAgentControlActions";
 import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
+import { ModelPicker } from "@/features/agents/ui/ModelPicker";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { getPresenceLabel } from "@/features/presence/lib/presence";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
@@ -33,65 +35,73 @@ import type {
   useUnfollowMutation,
   useUserProfileQuery,
 } from "@/features/profile/hooks";
-import { truncatePubkey as truncatePubkeyShort } from "@/features/profile/lib/identity";
+import {
+  type ProfileField,
+  ProfileFieldGroup,
+} from "@/features/profile/ui/UserProfilePanelFields";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 import { BotIdenticon } from "@/features/messages/ui/BotIdenticon";
-import type { ManagedAgent, RelayAgent } from "@/shared/api/types";
+import { UserProfileAgentActions } from "@/features/profile/ui/UserProfileAgentActions";
+import type {
+  AgentPersona,
+  ManagedAgent,
+  RelayAgent,
+} from "@/shared/api/types";
 import { useFeatureEnabled } from "@/shared/features";
 import { cn } from "@/shared/lib/cn";
 import { useNow } from "@/shared/lib/useNow";
 import { Badge } from "@/shared/ui/badge";
-import { UserAvatar } from "@/shared/ui/UserAvatar";
-
-const RUNTIME_LABELS: Record<string, string> = {
-  goose: "Goose",
-  "claude-code": "Claude Code",
-  "codex-acp": "Codex",
-  aider: "Aider",
-};
-
-function runtimeLabel(command: string): string {
-  return RUNTIME_LABELS[command] ?? command;
-}
-
-async function copyToClipboard(value: string, label?: string) {
-  await navigator.clipboard.writeText(value);
-  toast.success(label ? `Copied ${label}` : "Copied to clipboard");
-}
+import { Button } from "@/shared/ui/button";
+import { Markdown } from "@/shared/ui/markdown";
 
 // ── Summary view ─────────────────────────────────────────────────────────────
 
 export type ProfileSummaryViewProps = {
   canEditAgent: boolean;
+  canOpenAgentLogs: boolean;
   canViewActivity: boolean;
   channelCount: number;
   channelIdToName: Record<string, string>;
   channelsLoading: boolean;
   displayName: string;
   followMutation: ReturnType<typeof useFollowMutation>;
+  canInstantiateAgent: boolean;
+  agentInstruction: string | null;
+  handleAgentPrimaryAction: () => void;
+  handleDeletePersona?: () => void;
+  handleDuplicatePersona?: () => void;
+  handleDeleteAgent: () => void;
   handleEditAgent: () => void;
+  handleEditPersona?: () => void;
+  handleExportPersona?: () => void;
+  handleInstantiateAgent: () => void;
   handleMessage: () => void;
-  handleOpenActivity: () => void;
   isBot: boolean;
+  isAgentActionPending: boolean;
   isFollowing: boolean;
   isOwner: boolean | undefined;
   isSelf: boolean;
   managedAgent: ManagedAgent | undefined;
   memoriesLoading: boolean;
   memoryCount: number | undefined;
-  ownerDisplayName: string | null;
-  ownerAvatarUrl: string | null;
-  ownerHandle: string | null;
-  ownerPubkey: string | null;
+  agentInfoFields: ProfileField[];
+  agentSettingsFields: ProfileField[];
+  diagnosticsFields: ProfileField[];
+  diagnosticsSummary: string | null;
+  modelLabel: string;
+  onOpenAgentInfo: () => void;
+  onOpenAgentSettings: () => void;
   onOpenChannels: () => void;
-  onOpenOwner?: () => void;
+  onOpenDiagnostics: () => void;
+  onOpenInstruction: () => void;
   onOpenMemories: () => void;
+  onOpenModel: () => void;
   onOpenDm?: (pubkeys: string[]) => void;
-  presenceLoaded: boolean;
+  persona?: AgentPersona;
   presenceStatus: "online" | "away" | "offline" | undefined;
   profile: ReturnType<typeof useUserProfileQuery>["data"];
-  pubkey: string;
+  pubkey: string | null;
   relayAgent: RelayAgent | undefined;
   unfollowMutation: ReturnType<typeof useUnfollowMutation>;
   userStatus: { text: string; emoji: string } | null | undefined;
@@ -99,31 +109,46 @@ export type ProfileSummaryViewProps = {
 
 export function ProfileSummaryView({
   canEditAgent,
+  canOpenAgentLogs,
   canViewActivity,
   channelCount,
   channelIdToName,
   channelsLoading,
   displayName,
   followMutation,
+  canInstantiateAgent,
+  agentInstruction,
+  handleAgentPrimaryAction,
+  handleDeletePersona,
+  handleDuplicatePersona,
+  handleDeleteAgent,
   handleEditAgent,
+  handleEditPersona,
+  handleExportPersona,
+  handleInstantiateAgent,
   handleMessage,
-  handleOpenActivity,
   isBot,
+  isAgentActionPending,
   isFollowing,
   isOwner,
   isSelf,
   managedAgent,
   memoriesLoading,
   memoryCount,
-  ownerDisplayName,
-  ownerAvatarUrl,
-  ownerHandle,
-  ownerPubkey,
+  agentInfoFields,
+  agentSettingsFields,
+  diagnosticsFields,
+  diagnosticsSummary,
+  modelLabel,
+  onOpenAgentInfo,
+  onOpenAgentSettings,
   onOpenChannels,
-  onOpenOwner,
+  onOpenDiagnostics,
+  onOpenInstruction,
   onOpenMemories,
+  onOpenModel,
   onOpenDm,
-  presenceLoaded,
+  persona,
   presenceStatus,
   profile,
   pubkey,
@@ -134,32 +159,20 @@ export function ProfileSummaryView({
   const { goChannel } = useAppNavigation();
   const activeTurns = useActiveAgentTurns(isBot ? pubkey : null);
 
-  const metadataFields = [
-    ...buildPublicFields({
-      pubkey,
-      profile,
-      relayAgent,
-      isBot,
-    }),
-    ...(ownerDisplayName || isOwner === true
-      ? buildOwnerFields({
-          includeOperationalFields: isOwner === true,
-          managedAgent,
-          ownerDisplayName,
-          ownerAvatarUrl,
-          ownerHandle,
-          ownerPubkey,
-          onOpenOwner,
-          presenceLoaded,
-          presenceStatus,
-          relayAgent,
-        })
-      : []),
-  ];
-
-  const showMemoriesIngress = isOwner === true;
+  const showMemoriesIngress = isOwner === true && Boolean(pubkey);
+  const showInstructionIngress =
+    isOwner === true &&
+    (agentInstruction !== null || handleEditPersona !== undefined);
   const showChannelsIngress =
     channelsLoading || channelCount > 0 || isBot || relayAgent !== undefined;
+  const showModelIngress = isOwner === true && isBot;
+  const showAgentSettingsIngress =
+    isOwner === true &&
+    (agentSettingsFields.length > 0 || managedAgent?.backend.type === "local");
+  const showDiagnosticsIngress =
+    diagnosticsFields.length > 0 || canOpenAgentLogs || canViewActivity;
+  const showAgentInfoIngress = agentInfoFields.length > 0;
+  const personaActionKey = persona?.id;
 
   return (
     <div className="flex flex-col gap-6 pt-4">
@@ -171,11 +184,33 @@ export function ProfileSummaryView({
         userStatus={userStatus}
       />
 
-      {!isSelf ? (
+      {canInstantiateAgent ? (
+        <ProfilePersonaPrimaryActions
+          canEditAgent={canEditAgent}
+          disabled={isAgentActionPending}
+          onEditAgent={handleEditAgent}
+          onStartAgent={handleInstantiateAgent}
+        />
+      ) : !isSelf && pubkey ? (
         <ProfilePrimaryActions
           canEditAgent={canEditAgent}
           followMutation={followMutation}
           onEditAgent={handleEditAgent}
+          agentActionDisabled={isAgentActionPending}
+          agentActionLabel={
+            isOwner === true && managedAgent
+              ? getManagedAgentPrimaryActionLabel(managedAgent)
+              : undefined
+          }
+          agentActionLive={
+            managedAgent?.status === "running" ||
+            managedAgent?.status === "deployed"
+          }
+          onAgentPrimaryAction={
+            isOwner === true && managedAgent
+              ? handleAgentPrimaryAction
+              : undefined
+          }
           isFollowing={isFollowing}
           onMessage={onOpenDm ? handleMessage : undefined}
           pubkey={pubkey}
@@ -197,8 +232,32 @@ export function ProfileSummaryView({
         </div>
       ) : null}
 
-      {showMemoriesIngress || showChannelsIngress || canViewActivity ? (
+      {showInstructionIngress ||
+      showModelIngress ||
+      showMemoriesIngress ||
+      showChannelsIngress ||
+      showAgentSettingsIngress ||
+      showDiagnosticsIngress ||
+      showAgentInfoIngress ? (
         <section className="space-y-2">
+          {showInstructionIngress ? (
+            <ProfileIngressRow
+              icon={FileText}
+              label="Agent instruction"
+              onClick={onOpenInstruction}
+              testId="user-profile-agent-instruction-ingress"
+              trailing={handleEditPersona ? "Edit" : "View"}
+            />
+          ) : null}
+          {showModelIngress ? (
+            <ProfileIngressRow
+              icon={Cpu}
+              label="Model"
+              onClick={onOpenModel}
+              testId="user-profile-model-ingress"
+              trailing={modelLabel}
+            />
+          ) : null}
           {showMemoriesIngress ? (
             <ProfileIngressRow
               icon={Brain}
@@ -229,19 +288,54 @@ export function ProfileSummaryView({
               }
             />
           ) : null}
-          {canViewActivity ? (
+          {showAgentSettingsIngress ? (
+            <ProfileIngressRow
+              icon={Settings}
+              label="Agent settings"
+              onClick={onOpenAgentSettings}
+              testId="user-profile-agent-settings-ingress"
+              trailing="View"
+            />
+          ) : null}
+          {showDiagnosticsIngress ? (
             <ProfileIngressRow
               icon={Activity}
-              label="Activity log"
-              onClick={handleOpenActivity}
-              testId={`user-profile-view-activity-${pubkey}`}
+              label="Diagnostics"
+              onClick={onOpenDiagnostics}
+              testId="user-profile-diagnostics-ingress"
+              trailing={diagnosticsSummary ?? "View"}
+            />
+          ) : null}
+          {showAgentInfoIngress ? (
+            <ProfileIngressRow
+              icon={Info}
+              label="Agent info"
+              onClick={onOpenAgentInfo}
+              testId="user-profile-agent-info-ingress"
+              trailing="View"
             />
           ) : null}
         </section>
       ) : null}
 
-      {metadataFields.length > 0 ? (
-        <ProfileFieldGroup fields={metadataFields} />
+      {isOwner === true && managedAgent ? (
+        <UserProfileAgentActions
+          isPending={isAgentActionPending}
+          managedAgent={managedAgent}
+          onDelete={handleDeleteAgent}
+          onDuplicatePersona={handleDuplicatePersona}
+          onExportPersona={handleExportPersona}
+          personaActionKey={personaActionKey}
+        />
+      ) : null}
+      {canInstantiateAgent ? (
+        <UserProfileAgentActions
+          isPending={isAgentActionPending}
+          onDelete={handleDeletePersona}
+          onDuplicatePersona={handleDuplicatePersona}
+          onExportPersona={handleExportPersona}
+          personaActionKey={personaActionKey}
+        />
       ) : null}
     </div>
   );
@@ -426,17 +520,25 @@ function ProfileHeroDescription({ about }: { about: string }) {
 // ── Primary actions ──────────────────────────────────────────────────────────
 
 function ProfilePrimaryActions({
+  agentActionDisabled,
+  agentActionLabel,
+  agentActionLive,
   canEditAgent,
   followMutation,
   isFollowing,
+  onAgentPrimaryAction,
   onEditAgent,
   onMessage,
   pubkey,
   unfollowMutation,
 }: {
+  agentActionDisabled?: boolean;
+  agentActionLabel?: string;
+  agentActionLive?: boolean;
   canEditAgent: boolean;
   followMutation: ReturnType<typeof useFollowMutation>;
   isFollowing: boolean;
+  onAgentPrimaryAction?: () => void;
   onEditAgent: () => void;
   onMessage?: () => void;
   pubkey: string;
@@ -475,6 +577,49 @@ function ProfilePrimaryActions({
       ) : null}
       {canEditAgent ? (
         <ProfileQuickAction
+          icon={Pencil}
+          label="Edit"
+          onClick={onEditAgent}
+          testId="user-profile-edit-agent"
+        />
+      ) : null}
+      {onAgentPrimaryAction && agentActionLabel ? (
+        <ProfileQuickAction
+          active={agentActionLive}
+          disabled={agentActionDisabled}
+          icon={agentActionLive ? Square : Play}
+          label={agentActionLabel}
+          onClick={onAgentPrimaryAction}
+          testId="user-profile-agent-primary-action"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function ProfilePersonaPrimaryActions({
+  canEditAgent,
+  disabled,
+  onEditAgent,
+  onStartAgent,
+}: {
+  canEditAgent: boolean;
+  disabled: boolean;
+  onEditAgent: () => void;
+  onStartAgent: () => void;
+}) {
+  return (
+    <div className="flex items-start justify-center gap-8">
+      <ProfileQuickAction
+        disabled={disabled}
+        icon={Play}
+        label="Start agent"
+        onClick={onStartAgent}
+        testId="user-profile-start-agent"
+      />
+      {canEditAgent ? (
+        <ProfileQuickAction
+          disabled={disabled}
           icon={Pencil}
           label="Edit"
           onClick={onEditAgent}
@@ -530,343 +675,17 @@ function ProfileQuickAction({
   );
 }
 
-// ── Field rows ───────────────────────────────────────────────────────────────
-
-type ProfileField = {
-  copyValue?: string;
-  /**
-   * Plain-text representation. Always required so non-visual surfaces (e.g. tooltips,
-   * copy-to-clipboard) keep working. When `displayNode` is set, the row renders that
-   * instead of the text — but the text still drives the title/tooltip.
-   */
-  displayValue: string;
-  /**
-   * Optional rich rendering for the value cell (e.g. a status badge). When present,
-   * replaces the plain text node in the row.
-   */
-  displayNode?: React.ReactNode;
-  icon: LucideIcon;
-  label: string;
-  testId?: string;
-};
-
-function buildPublicFields({
-  isBot,
-  profile,
-  pubkey,
-  relayAgent,
-}: {
-  isBot: boolean;
-  profile: ProfileSummaryViewProps["profile"];
-  pubkey: string;
-  relayAgent: RelayAgent | undefined;
-}): ProfileField[] {
-  const fields: ProfileField[] = [
-    {
-      copyValue: pubkey,
-      displayValue: truncatePubkeyShort(pubkey),
-      icon: Fingerprint,
-      label: "Public key",
-      testId: "user-profile-copy-pubkey",
-    },
-  ];
-
-  if (profile?.nip05Handle) {
-    fields.push({
-      copyValue: profile.nip05Handle,
-      displayValue: profile.nip05Handle,
-      icon: UserRound,
-      label: "NIP-05",
-      testId: "user-profile-nip05",
-    });
-  }
-
-  if (isBot && relayAgent?.agentType) {
-    fields.push({
-      copyValue: relayAgent.agentType,
-      displayValue: runtimeLabel(relayAgent.agentType),
-      icon: Cpu,
-      label: "Agent type",
-      testId: "user-profile-agent-type",
-    });
-  }
-
-  if (relayAgent?.capabilities.length) {
-    fields.push({
-      copyValue: relayAgent.capabilities.join(", "),
-      displayValue: relayAgent.capabilities.join(", "),
-      icon: Server,
-      label: "Capabilities",
-      testId: "user-profile-capabilities",
-    });
-  }
-
-  return fields;
-}
-
-function buildOwnerFields({
-  includeOperationalFields,
-  managedAgent,
-  ownerDisplayName,
-  ownerAvatarUrl,
-  ownerHandle,
-  ownerPubkey,
-  onOpenOwner,
-  presenceLoaded,
-  presenceStatus,
-  relayAgent,
-}: {
-  includeOperationalFields: boolean;
-  managedAgent: ManagedAgent | undefined;
-  ownerDisplayName: string | null;
-  ownerAvatarUrl: string | null;
-  ownerHandle: string | null;
-  ownerPubkey: string | null;
-  onOpenOwner?: () => void;
-  presenceLoaded: boolean;
-  presenceStatus: "online" | "away" | "offline" | undefined;
-  relayAgent: RelayAgent | undefined;
-}): ProfileField[] {
-  const fields: ProfileField[] = [];
-
-  if (ownerDisplayName) {
-    fields.push({
-      copyValue: onOpenOwner
-        ? undefined
-        : (ownerPubkey ?? ownerHandle ?? undefined),
-      displayValue: ownerDisplayName,
-      displayNode: onOpenOwner ? (
-        <button
-          className="inline-flex max-w-full items-center gap-2 rounded text-left text-sm text-muted-foreground transition-colors hover:text-foreground hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-          onClick={(event) => {
-            event.stopPropagation();
-            onOpenOwner();
-          }}
-          title={ownerDisplayName}
-          type="button"
-        >
-          <UserAvatar
-            avatarUrl={ownerAvatarUrl}
-            className="shrink-0"
-            displayName={ownerHandle ?? ownerDisplayName}
-            size="xs"
-            testId="user-profile-owner-avatar"
-          />
-          <span className="truncate">{ownerDisplayName}</span>
-        </button>
-      ) : undefined,
-      icon: UserRound,
-      label: "Owned by",
-      testId: "user-profile-owned-by",
-    });
-  }
-
-  if (!includeOperationalFields) {
-    return fields;
-  }
-
-  if (managedAgent?.agentCommand) {
-    fields.push({
-      copyValue: managedAgent.agentCommand,
-      displayValue: runtimeLabel(managedAgent.agentCommand),
-      icon: Terminal,
-      label: "Runtime",
-      testId: "user-profile-runtime",
-    });
-  } else if (relayAgent?.agentType) {
-    fields.push({
-      copyValue: relayAgent.agentType,
-      displayValue: runtimeLabel(relayAgent.agentType),
-      icon: Terminal,
-      label: "Runtime",
-      testId: "user-profile-runtime",
-    });
-  }
-
-  if (managedAgent) {
-    fields.push({
-      displayValue: managedAgent.status
-        .replace(/_/g, " ")
-        .replace(/\b\w/g, (char: string) => char.toUpperCase()),
-      displayNode: (
-        <AgentStatusBadge
-          presenceLoaded={presenceLoaded}
-          presenceStatus={presenceStatus}
-          status={managedAgent.status}
-        />
-      ),
-      icon: Activity,
-      label: "Status",
-      testId: "user-profile-agent-status",
-    });
-  }
-
-  if (managedAgent?.model) {
-    fields.push({
-      copyValue: managedAgent.model,
-      displayValue: managedAgent.model,
-      icon: Cpu,
-      label: "Model",
-      testId: "user-profile-model",
-    });
-  }
-
-  if (managedAgent?.acpCommand) {
-    fields.push({
-      copyValue: managedAgent.acpCommand,
-      displayValue: managedAgent.acpCommand,
-      icon: Terminal,
-      label: "ACP command",
-      testId: "user-profile-acp",
-    });
-  }
-
-  if (managedAgent?.mcpCommand) {
-    fields.push({
-      copyValue: managedAgent.mcpCommand,
-      displayValue: managedAgent.mcpCommand,
-      icon: Terminal,
-      label: "MCP command",
-      testId: "user-profile-mcp",
-    });
-  }
-
-  if (managedAgent?.backend.type === "provider") {
-    const backendLabel = managedAgent.backend.id;
-    fields.push({
-      copyValue: backendLabel,
-      displayValue: backendLabel,
-      icon: Server,
-      label: "Backend",
-      testId: "user-profile-backend",
-    });
-  }
-
-  if (managedAgent) {
-    fields.push({
-      displayValue: managedAgent.startOnAppLaunch ? "Yes" : "No",
-      icon: Server,
-      label: "Start on launch",
-      testId: "user-profile-start-on-launch",
-    });
-    fields.push({
-      displayValue: managedAgent.respondTo.replace(/-/g, " "),
-      icon: MessageSquare,
-      label: "Respond to",
-      testId: "user-profile-respond-to",
-    });
-  }
-
-  if (managedAgent?.lastError) {
-    fields.push({
-      copyValue: managedAgent.lastError,
-      displayValue: managedAgent.lastError,
-      icon: Activity,
-      label: "Last error",
-      testId: "user-profile-last-error",
-    });
-  }
-
-  return fields;
-}
-
-function ProfileFieldGroup({ fields }: { fields: ProfileField[] }) {
-  const publicKeyLabel = "Public key";
-  const ownedByLabel = "Owned by";
-  const statusLabel = "Status";
-  const orderedFields = [
-    ...fields.filter((field) => field.label === publicKeyLabel),
-    ...fields.filter((field) => field.label === ownedByLabel),
-    ...fields.filter(
-      (field) =>
-        field.label !== publicKeyLabel &&
-        field.label !== ownedByLabel &&
-        field.copyValue,
-    ),
-    ...fields.filter((field) => field.label === statusLabel),
-    ...fields.filter((field) => {
-      if (
-        field.label === publicKeyLabel ||
-        field.label === ownedByLabel ||
-        field.label === statusLabel
-      ) {
-        return false;
-      }
-      return !field.copyValue;
-    }),
-  ];
-
-  return (
-    <section>
-      <div className="overflow-hidden rounded-2xl bg-muted/20">
-        {orderedFields.map((field) => (
-          <ProfileFieldRow field={field} key={field.testId ?? field.label} />
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function ProfileFieldRow({ field }: { field: ProfileField }) {
-  const Icon = field.icon;
-  const isCopyable = Boolean(field.copyValue);
-
-  const content = (
-    <>
-      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
-        <Icon className="h-4 w-4 text-muted-foreground" />
-      </span>
-      <span className="min-w-0 flex-1 text-left">
-        <span className="block text-xs font-medium text-foreground">
-          {field.label}
-        </span>
-        <span
-          className="mt-0.5 block truncate text-sm text-muted-foreground"
-          title={field.displayValue}
-        >
-          {field.displayNode ?? field.displayValue}
-        </span>
-      </span>
-      {isCopyable ? (
-        <Copy className="h-4 w-4 shrink-0 text-muted-foreground" />
-      ) : null}
-    </>
-  );
-
-  if (isCopyable && field.copyValue) {
-    return (
-      <button
-        aria-label={`Copy ${field.label}`}
-        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
-        data-testid={field.testId}
-        onClick={() => void copyToClipboard(field.copyValue ?? "", field.label)}
-        title={`Copy ${field.label}`}
-        type="button"
-      >
-        {content}
-      </button>
-    );
-  }
-
-  return (
-    <div
-      className="flex items-center gap-3 px-4 py-3"
-      data-testid={field.testId}
-    >
-      {content}
-    </div>
-  );
-}
-
 // ── Ingress rows ─────────────────────────────────────────────────────────────
 
 function ProfileIngressRow({
+  disabled,
   icon: Icon,
   label,
   onClick,
   testId,
   trailing,
 }: {
+  disabled?: boolean;
   icon: LucideIcon;
   label: string;
   onClick: () => void;
@@ -875,8 +694,9 @@ function ProfileIngressRow({
 }) {
   return (
     <button
-      className="flex w-full items-center gap-3 rounded-2xl bg-muted/20 px-4 py-2 text-left transition-colors hover:bg-muted/40"
+      className="flex w-full items-center gap-3 rounded-2xl bg-muted/20 px-4 py-2 text-left transition-colors hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-50"
       data-testid={testId}
+      disabled={disabled}
       onClick={onClick}
       type="button"
     >
@@ -887,7 +707,12 @@ function ProfileIngressRow({
         {label}
       </span>
       {trailing ? (
-        <span className="text-sm text-muted-foreground">{trailing}</span>
+        <span
+          className="max-w-[45%] truncate text-right text-sm text-muted-foreground"
+          title={trailing}
+        >
+          {trailing}
+        </span>
       ) : null}
       <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
     </button>
@@ -898,18 +723,18 @@ function ProfileIngressRow({
 
 export function MemoryFocusedView({
   agentPubkey,
-  viewerIsOwner,
+  isOwner,
 }: {
   agentPubkey: string;
-  viewerIsOwner: boolean | undefined;
+  isOwner: boolean | undefined;
 }) {
-  if (viewerIsOwner !== true) {
+  if (isOwner !== true) {
     return null;
   }
 
   return (
     <div className="pt-4">
-      <MemorySection agentPubkey={agentPubkey} viewerIsOwner={viewerIsOwner} />
+      <MemorySection agentPubkey={agentPubkey} />
     </div>
   );
 }
@@ -920,55 +745,246 @@ type ProfileChannelLink = {
 };
 
 export function ChannelsFocusedView({
+  canAddToChannel,
   channels,
+  isActionPending,
   isLoading,
+  onAddToChannel,
   onOpenChannel,
 }: {
+  canAddToChannel: boolean;
   channels: ProfileChannelLink[];
+  isActionPending: boolean;
   isLoading: boolean;
+  onAddToChannel: () => void;
   onOpenChannel: (channelId: string) => void;
 }) {
-  if (isLoading) {
-    return (
-      <p className="pt-4 text-base leading-7 text-muted-foreground">
-        Loading channels…
-      </p>
-    );
-  }
+  return (
+    <div className="space-y-3 pt-4">
+      {canAddToChannel ? (
+        <ProfileIngressRow
+          disabled={isActionPending}
+          icon={UserPlus}
+          label="Add to channel"
+          onClick={onAddToChannel}
+          testId="user-profile-agent-add-channel"
+          trailing={isActionPending ? "Working…" : undefined}
+        />
+      ) : null}
+      {isLoading ? (
+        <p className="text-base leading-7 text-muted-foreground">
+          Loading channels…
+        </p>
+      ) : channels.length === 0 ? (
+        <p
+          className="text-base leading-7 italic text-muted-foreground"
+          data-testid="user-profile-channels-empty"
+        >
+          No visible channel memberships.
+        </p>
+      ) : (
+        <ul
+          className="overflow-hidden rounded-2xl bg-muted/20"
+          data-testid="user-profile-channels-list"
+        >
+          {channels.map((channel) => (
+            <li key={channel.id}>
+              <button
+                aria-label={`Open #${channel.name}`}
+                className="group flex w-full items-center gap-3 px-4 py-3 text-left text-base leading-7 text-foreground transition-colors hover:bg-muted/40"
+                data-testid={`user-profile-channel-link-${channel.name}`}
+                onClick={() => onOpenChannel(channel.id)}
+                type="button"
+              >
+                <span className="min-w-0 flex-1 truncate">#{channel.name}</span>
+                <ArrowUpRight
+                  aria-hidden="true"
+                  className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground"
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
 
-  if (channels.length === 0) {
-    return (
-      <p
-        className="pt-4 text-base leading-7 italic text-muted-foreground"
-        data-testid="user-profile-channels-empty"
-      >
-        No visible channel memberships.
-      </p>
-    );
+export function AgentInfoFocusedView({
+  metadataFields,
+}: {
+  metadataFields: ProfileField[];
+}) {
+  if (metadataFields.length === 0) {
+    return null;
   }
 
   return (
-    <ul
-      className="overflow-hidden rounded-2xl bg-muted/20"
-      data-testid="user-profile-channels-list"
-    >
-      {channels.map((channel) => (
-        <li key={channel.id}>
-          <button
-            aria-label={`Open #${channel.name}`}
-            className="group flex w-full items-center gap-3 px-4 py-3 text-left text-base leading-7 text-foreground transition-colors hover:bg-muted/40"
-            data-testid={`user-profile-channel-link-${channel.name}`}
-            onClick={() => onOpenChannel(channel.id)}
-            type="button"
-          >
-            <span className="min-w-0 flex-1 truncate">#{channel.name}</span>
-            <ArrowUpRight
-              aria-hidden="true"
-              className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground"
+    <div className="pt-4">
+      <ProfileFieldGroup fields={metadataFields} />
+    </div>
+  );
+}
+
+export function ModelFocusedView({
+  managedAgent,
+  modelLabel,
+  onModelChanged,
+}: {
+  managedAgent: ManagedAgent | undefined;
+  modelLabel: string;
+  onModelChanged: () => void;
+}) {
+  return (
+    <div className="space-y-3 pt-4">
+      <div className="flex items-center gap-3 rounded-2xl bg-muted/20 px-4 py-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
+          <Cpu className="h-4 w-4 text-muted-foreground" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-xs font-medium text-foreground">
+            Model
+          </span>
+          <span className="mt-0.5 block truncate text-sm text-muted-foreground">
+            {modelLabel}
+          </span>
+        </span>
+        {managedAgent ? (
+          <ModelPicker agent={managedAgent} onModelChanged={onModelChanged} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function AgentSettingsFocusedView({
+  fields,
+  isActionPending,
+  managedAgent,
+  onToggleAutoStart,
+}: {
+  fields: ProfileField[];
+  isActionPending: boolean;
+  managedAgent: ManagedAgent | undefined;
+  onToggleAutoStart: () => void;
+}) {
+  const canToggleAutoStart =
+    managedAgent !== undefined && managedAgent.backend.type === "local";
+
+  if (fields.length === 0 && !canToggleAutoStart) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3 pt-4">
+      {canToggleAutoStart && managedAgent ? (
+        <ProfileIngressRow
+          disabled={isActionPending}
+          icon={Power}
+          label={
+            managedAgent.startOnAppLaunch
+              ? "Disable auto-start"
+              : "Enable auto-start"
+          }
+          onClick={onToggleAutoStart}
+          testId={`user-profile-agent-auto-start-${managedAgent.pubkey}`}
+          trailing={managedAgent.startOnAppLaunch ? "On" : "Off"}
+        />
+      ) : null}
+      {fields.length > 0 ? <ProfileFieldGroup fields={fields} /> : null}
+    </div>
+  );
+}
+
+export function DiagnosticsFocusedView({
+  canOpenAgentLogs,
+  canViewActivity,
+  fields,
+  managedAgent,
+  onOpenActivity,
+  onOpenAgentLogs,
+  pubkey,
+}: {
+  canOpenAgentLogs: boolean;
+  canViewActivity: boolean;
+  fields: ProfileField[];
+  managedAgent: ManagedAgent | undefined;
+  onOpenActivity: () => void;
+  onOpenAgentLogs: () => void;
+  pubkey: string | null;
+}) {
+  const hasActions = canOpenAgentLogs || canViewActivity;
+
+  if (fields.length === 0 && !hasActions) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3 pt-4">
+      {fields.length > 0 ? <ProfileFieldGroup fields={fields} /> : null}
+      {canOpenAgentLogs && managedAgent ? (
+        <ProfileIngressRow
+          icon={FileText}
+          label="Harness log"
+          onClick={onOpenAgentLogs}
+          testId={`user-profile-agent-logs-${managedAgent.pubkey}`}
+          trailing="View"
+        />
+      ) : null}
+      {canViewActivity ? (
+        <ProfileIngressRow
+          icon={Activity}
+          label="Activity log"
+          onClick={onOpenActivity}
+          testId={`user-profile-view-activity-${pubkey}`}
+          trailing="View"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function AgentInstructionFocusedView({
+  instruction,
+  onEdit,
+}: {
+  instruction: string | null;
+  onEdit?: () => void;
+}) {
+  const trimmedInstruction = instruction?.trim() ?? "";
+
+  return (
+    <div className="space-y-3 pt-4">
+      <div className="rounded-2xl bg-muted/20 px-4 py-3">
+        {trimmedInstruction ? (
+          <div data-testid="user-profile-agent-instruction">
+            <Markdown
+              className="text-sm leading-6"
+              content={trimmedInstruction}
+              interactive={false}
             />
-          </button>
-        </li>
-      ))}
-    </ul>
+          </div>
+        ) : (
+          <p
+            className="text-sm leading-6 text-muted-foreground"
+            data-testid="user-profile-agent-instruction-empty"
+          >
+            No instruction set.
+          </p>
+        )}
+      </div>
+      {onEdit ? (
+        <Button
+          className="w-full justify-start gap-2"
+          data-testid="user-profile-agent-instruction-edit"
+          onClick={onEdit}
+          type="button"
+          variant="outline"
+        >
+          <Pencil className="h-4 w-4" />
+          Edit agent
+        </Button>
+      ) : null}
+    </div>
   );
 }

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -734,7 +734,7 @@ export function MemoryFocusedView({
 
   return (
     <div className="pt-4">
-      <MemorySection agentPubkey={agentPubkey} />
+      <MemorySection agentPubkey={agentPubkey} viewerIsOwner={isOwner} />
     </div>
   );
 }

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -85,7 +85,6 @@ test("personaManagedAgentUpdate syncs edited persona identity to linked agent", 
   assert.deepEqual(personaManagedAgentUpdate(agent(), persona()), {
     pubkey: "deadbeef".repeat(8),
     name: "Fizz Prime",
-    avatarUrl: null,
     systemPrompt: "New prompt",
     model: "new-model",
     envVars: { NEW_KEY: "2" },
@@ -121,7 +120,6 @@ test("personaManagedAgentUpdate maps changed persona runtime to linked agent com
     {
       pubkey: "deadbeef".repeat(8),
       name: "Fizz Prime",
-      avatarUrl: null,
       systemPrompt: "New prompt",
       model: "new-model",
       envVars: { NEW_KEY: "2" },

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -113,20 +113,48 @@ test("personaManagedAgentUpdate skips unrelated or unchanged agents", () => {
 
 test("personaManagedAgentUpdate maps changed persona runtime to linked agent commands", () => {
   assert.deepEqual(
-    personaManagedAgentUpdate(agent(), persona({ runtime: "claude" }), {
-      previousPersona: persona({ runtime: "goose" }),
-      runtimes: [runtime()],
-    }),
+    personaManagedAgentUpdate(
+      agent({ envVars: { SHARED: "old", AGENT_ONLY: "keep" } }),
+      persona({
+        runtime: "claude",
+        envVars: { SHARED: "new", PERSONA_ONLY: "set" },
+      }),
+      {
+        previousPersona: persona({
+          runtime: "goose",
+          envVars: { SHARED: "old" },
+        }),
+        runtimes: [runtime()],
+      },
+    ),
     {
       pubkey: "deadbeef".repeat(8),
       name: "Fizz Prime",
       systemPrompt: "New prompt",
       model: "new-model",
-      envVars: { NEW_KEY: "2" },
+      envVars: { SHARED: "new", PERSONA_ONLY: "set", AGENT_ONLY: "keep" },
       agentCommand: "claude",
       agentArgs: ["mcp", "serve"],
       mcpCommand: "claude-mcp",
     },
+  );
+});
+
+test("personaManagedAgentUpdate preserves agent env overrides when persona env is unchanged", () => {
+  assert.deepEqual(
+    personaManagedAgentUpdate(
+      agent({
+        name: "Fizz Prime",
+        systemPrompt: "New prompt",
+        model: "new-model",
+        envVars: { API_KEY: "agent-secret" },
+      }),
+      persona({ envVars: { API_KEY: "persona-default" } }),
+      {
+        previousPersona: persona({ envVars: { API_KEY: "persona-default" } }),
+      },
+    ),
+    null,
   );
 });
 

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseProfilePanelView,
+  personaManagedAgentUpdate,
+  profilePanelViewFromSearch,
+} from "./UserProfilePanelUtils.ts";
+
+function agent(overrides = {}) {
+  return {
+    pubkey: "deadbeef".repeat(8),
+    name: "Fizz",
+    personaId: "persona-1",
+    relayUrl: "ws://localhost:3000",
+    acpCommand: "buzz-acp",
+    agentCommand: "goose",
+    agentArgs: [],
+    mcpCommand: "",
+    turnTimeoutSeconds: 320,
+    idleTimeoutSeconds: null,
+    maxTurnDurationSeconds: null,
+    parallelism: 1,
+    systemPrompt: "Old prompt",
+    avatarUrl: "app-avatar://old",
+    model: "old-model",
+    mcpToolsets: null,
+    envVars: { OLD_KEY: "1" },
+    status: "stopped",
+    pid: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    lastStartedAt: null,
+    lastStoppedAt: null,
+    lastExitCode: null,
+    lastError: null,
+    logPath: null,
+    startOnAppLaunch: true,
+    backend: { type: "local" },
+    backendAgentId: null,
+    respondTo: "owner-only",
+    respondToAllowlist: [],
+    ...overrides,
+  };
+}
+
+function persona(overrides = {}) {
+  return {
+    id: "persona-1",
+    displayName: "Fizz Prime",
+    avatarUrl: null,
+    systemPrompt: "New prompt",
+    runtime: "goose",
+    model: "new-model",
+    provider: null,
+    namePool: [],
+    isBuiltIn: false,
+    isActive: true,
+    envVars: { NEW_KEY: "2" },
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function runtime(overrides = {}) {
+  return {
+    id: "claude",
+    label: "Claude Code",
+    avatarUrl: "app-avatar://claude",
+    availability: "available",
+    command: "claude",
+    binaryPath: "/usr/local/bin/claude",
+    defaultArgs: ["mcp", "serve"],
+    mcpCommand: "claude-mcp",
+    installHint: "",
+    installInstructionsUrl: "",
+    canAutoInstall: false,
+    underlyingCliPath: null,
+    ...overrides,
+  };
+}
+
+test("personaManagedAgentUpdate syncs edited persona identity to linked agent", () => {
+  assert.deepEqual(personaManagedAgentUpdate(agent(), persona()), {
+    pubkey: "deadbeef".repeat(8),
+    name: "Fizz Prime",
+    avatarUrl: null,
+    systemPrompt: "New prompt",
+    model: "new-model",
+    envVars: { NEW_KEY: "2" },
+  });
+});
+
+test("personaManagedAgentUpdate skips unrelated or unchanged agents", () => {
+  assert.equal(
+    personaManagedAgentUpdate(agent({ personaId: "persona-2" }), persona()),
+    null,
+  );
+  assert.equal(
+    personaManagedAgentUpdate(
+      agent({
+        name: "Fizz Prime",
+        avatarUrl: null,
+        systemPrompt: "New prompt",
+        model: "new-model",
+        envVars: { NEW_KEY: "2" },
+      }),
+      persona(),
+    ),
+    null,
+  );
+});
+
+test("personaManagedAgentUpdate maps changed persona runtime to linked agent commands", () => {
+  assert.deepEqual(
+    personaManagedAgentUpdate(agent(), persona({ runtime: "claude" }), {
+      previousPersona: persona({ runtime: "goose" }),
+      runtimes: [runtime()],
+    }),
+    {
+      pubkey: "deadbeef".repeat(8),
+      name: "Fizz Prime",
+      avatarUrl: null,
+      systemPrompt: "New prompt",
+      model: "new-model",
+      envVars: { NEW_KEY: "2" },
+      agentCommand: "claude",
+      agentArgs: ["mcp", "serve"],
+      mcpCommand: "claude-mcp",
+    },
+  );
+});
+
+test("personaManagedAgentUpdate leaves runtime fields alone when runtime is unchanged", () => {
+  assert.equal(
+    personaManagedAgentUpdate(
+      agent({
+        name: "Fizz Prime",
+        avatarUrl: null,
+        systemPrompt: "New prompt",
+        model: "new-model",
+        envVars: { NEW_KEY: "2" },
+        agentArgs: ["custom"],
+      }),
+      persona({ runtime: "goose" }),
+      {
+        previousPersona: persona({ runtime: "goose" }),
+        runtimes: [runtime({ id: "goose", command: "goose" })],
+      },
+    ),
+    null,
+  );
+});
+
+test("parseProfilePanelView accepts all profile panel subviews", () => {
+  for (const view of [
+    "summary",
+    "info",
+    "settings",
+    "diagnostics",
+    "model",
+    "instructions",
+    "memories",
+    "channels",
+    "logs",
+  ]) {
+    assert.equal(parseProfilePanelView(view), view);
+  }
+});
+
+test("profilePanelViewFromSearch falls back to summary for invalid values", () => {
+  assert.equal(parseProfilePanelView("missing"), null);
+  assert.equal(profilePanelViewFromSearch("missing"), "summary");
+  assert.equal(profilePanelViewFromSearch(null), "summary");
+});

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -179,7 +179,7 @@ test("personaManagedAgentUpdate leaves runtime fields alone when runtime is unch
   );
 });
 
-test("personaManagedAgentUpdate resets runtime fields when persona runtime is cleared", () => {
+test("personaManagedAgentUpdate leaves runtime inheritance when persona runtime is cleared", () => {
   assert.deepEqual(
     personaManagedAgentUpdate(
       agent({
@@ -206,9 +206,6 @@ test("personaManagedAgentUpdate resets runtime fields when persona runtime is cl
       name: "Fizz Prime",
       systemPrompt: "New prompt",
       model: "new-model",
-      agentCommand: "goose",
-      agentArgs: [],
-      mcpCommand: "",
     },
   );
 });

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -179,6 +179,40 @@ test("personaManagedAgentUpdate leaves runtime fields alone when runtime is unch
   );
 });
 
+test("personaManagedAgentUpdate resets runtime fields when persona runtime is cleared", () => {
+  assert.deepEqual(
+    personaManagedAgentUpdate(
+      agent({
+        agentCommand: "claude",
+        agentArgs: ["mcp", "serve"],
+        mcpCommand: "claude-mcp",
+      }),
+      persona({ runtime: null }),
+      {
+        previousPersona: persona({ runtime: "claude" }),
+        runtimes: [
+          runtime({
+            id: "goose",
+            command: "goose",
+            defaultArgs: [],
+            mcpCommand: "",
+          }),
+          runtime({ id: "claude" }),
+        ],
+      },
+    ),
+    {
+      pubkey: "deadbeef".repeat(8),
+      name: "Fizz Prime",
+      systemPrompt: "New prompt",
+      model: "new-model",
+      agentCommand: "goose",
+      agentArgs: [],
+      mcpCommand: "",
+    },
+  );
+});
+
 test("parseProfilePanelView accepts all profile panel subviews", () => {
   for (const view of [
     "summary",

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -254,8 +254,13 @@ export function personaManagedAgentUpdate(
     hasChanges = true;
   }
 
-  if (!stringRecordEqual(persona.envVars, agent.envVars)) {
-    input.envVars = persona.envVars;
+  const nextEnvVars = mergedPersonaEnvVarsForAgent(
+    agent,
+    persona,
+    options.previousPersona,
+  );
+  if (!stringRecordEqual(nextEnvVars, agent.envVars)) {
+    input.envVars = nextEnvVars;
     hasChanges = true;
   }
 
@@ -284,6 +289,27 @@ export function personaManagedAgentUpdate(
   }
 
   return hasChanges ? input : null;
+}
+
+function mergedPersonaEnvVarsForAgent(
+  agent: ManagedAgent,
+  persona: AgentPersona,
+  previousPersona: AgentPersona | undefined,
+) {
+  if (!previousPersona) {
+    return persona.envVars;
+  }
+  if (stringRecordEqual(persona.envVars, previousPersona.envVars)) {
+    return agent.envVars;
+  }
+
+  const nextEnvVars = { ...persona.envVars };
+  for (const [key, value] of Object.entries(agent.envVars)) {
+    if (previousPersona.envVars[key] !== value) {
+      nextEnvVars[key] = value;
+    }
+  }
+  return nextEnvVars;
 }
 
 function stringArrayEqual(left: readonly string[], right: readonly string[]) {

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -1,0 +1,326 @@
+import * as React from "react";
+import type {
+  AcpRuntimeCatalogEntry,
+  AgentPersona,
+  Channel,
+  ManagedAgent,
+  Profile,
+  RelayAgent,
+  UpdateManagedAgentInput,
+} from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+export type ProfileChannelLink = {
+  id: string;
+  name: string;
+};
+
+export type ProfilePanelView =
+  | "summary"
+  | "info"
+  | "settings"
+  | "diagnostics"
+  | "model"
+  | "instructions"
+  | "memories"
+  | "channels"
+  | "logs";
+
+export const PROFILE_PANEL_VIEW_TITLES: Record<ProfilePanelView, string> = {
+  summary: "Profile",
+  info: "Agent info",
+  settings: "Agent settings",
+  diagnostics: "Diagnostics",
+  model: "Model",
+  instructions: "Agent instruction",
+  memories: "Memories",
+  channels: "Channels",
+  logs: "Harness log",
+};
+
+const PROFILE_PANEL_VIEWS = new Set<ProfilePanelView>(
+  Object.keys(PROFILE_PANEL_VIEW_TITLES) as ProfilePanelView[],
+);
+
+export function parseProfilePanelView(value: unknown): ProfilePanelView | null {
+  return typeof value === "string" &&
+    PROFILE_PANEL_VIEWS.has(value as ProfilePanelView)
+    ? (value as ProfilePanelView)
+    : null;
+}
+
+export function profilePanelViewFromSearch(value: unknown): ProfilePanelView {
+  return parseProfilePanelView(value) ?? "summary";
+}
+
+export type UserProfilePanelProps = {
+  canResetWidth?: boolean;
+  currentPubkey?: string;
+  isSinglePanelView?: boolean;
+  layout?: "standalone" | "split";
+  onClose: () => void;
+  onOpenDm?: (pubkeys: string[]) => void;
+  onOpenProfile?: (pubkey: string) => void;
+  onResetWidth?: () => void;
+  onResizeStart?: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  onViewChange?: (
+    view: ProfilePanelView,
+    options?: { replace?: boolean },
+  ) => void;
+  persona?: AgentPersona;
+  pubkey?: string;
+  splitPaneClamp?: boolean;
+  view?: ProfilePanelView;
+  widthPx: number;
+};
+
+export function truncatePubkey(pubkey: string) {
+  if (pubkey.length <= 16) {
+    return pubkey;
+  }
+
+  return `${pubkey.slice(0, 8)}…${pubkey.slice(-8)}`;
+}
+
+export function deriveProfileChannels(
+  pubkeyLower: string,
+  relayAgent: RelayAgent | undefined,
+  managedAgent: ManagedAgent | undefined,
+  channels: Channel[] | undefined,
+): ProfileChannelLink[] {
+  const links = new Map<string, ProfileChannelLink>();
+  const channelsByName = new Map(
+    channels?.map((channel) => [channel.name, channel]) ?? [],
+  );
+
+  relayAgent?.channels.forEach((name, index) => {
+    const channel = channelsByName.get(name);
+    const id = relayAgent.channelIds[index] ?? channel?.id ?? name;
+    links.set(id, { id, name });
+  });
+
+  if (managedAgent && channels) {
+    for (const channel of channels) {
+      const isMember = channel.memberPubkeys.some(
+        (memberPubkey) => memberPubkey.toLowerCase() === pubkeyLower,
+      );
+      if (isMember) {
+        links.set(channel.id, { id: channel.id, name: channel.name });
+      }
+    }
+  }
+
+  return [...links.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+}
+
+export function getRelayAgentChannelIds(
+  relayAgents: readonly RelayAgent[] | undefined,
+  agentPubkey: string,
+): string[] {
+  const normalized = normalizePubkey(agentPubkey);
+  const agent = (relayAgents ?? []).find(
+    (candidate) => normalizePubkey(candidate.pubkey) === normalized,
+  );
+  return agent?.channelIds ?? [];
+}
+
+export function buildPersonaDraftProfile(persona: AgentPersona): Profile {
+  return {
+    pubkey: "",
+    displayName: persona.displayName,
+    avatarUrl: persona.avatarUrl,
+    about: null,
+    nip05Handle: null,
+    ownerPubkey: null,
+  };
+}
+
+export function resolvePanelProfile({
+  persona,
+  profile,
+}: {
+  managedAgent: ManagedAgent | undefined;
+  persona: AgentPersona | undefined;
+  profile: Profile | undefined;
+}): Profile | undefined {
+  const baseProfile =
+    profile ?? (persona ? buildPersonaDraftProfile(persona) : undefined);
+  return withProfileAvatarFallback(baseProfile, [persona?.avatarUrl]);
+}
+
+export function resolveProfileAvatarUrl(
+  ...candidates: Array<string | null | undefined>
+): string | null {
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+export function withProfileAvatarFallback(
+  profile: Profile | undefined,
+  fallbackAvatarUrls: Array<string | null | undefined>,
+): Profile | undefined {
+  const profileAvatarUrl = normalizeProfileFallbackAvatarUrl(
+    profile?.avatarUrl,
+  );
+  const avatarUrl = resolveProfileAvatarUrl(
+    profileAvatarUrl,
+    ...fallbackAvatarUrls.map((avatarUrl) =>
+      normalizeProfileFallbackAvatarUrl(avatarUrl),
+    ),
+  );
+  return profile && avatarUrl !== profile.avatarUrl
+    ? { ...profile, avatarUrl }
+    : profile;
+}
+
+function normalizeProfileFallbackAvatarUrl(
+  avatarUrl: string | null | undefined,
+): string | null {
+  const trimmed = avatarUrl?.trim();
+  if (!trimmed) return null;
+  return trimmed;
+}
+
+export function resolveProfileDisplayName({
+  persona,
+  profile,
+  pubkey,
+}: {
+  persona: AgentPersona | undefined;
+  profile: Profile | undefined;
+  pubkey: string | null;
+}) {
+  return (
+    profile?.displayName ??
+    persona?.displayName ??
+    (pubkey ? truncatePubkey(pubkey) : "Agent")
+  );
+}
+
+export function resolveOwnerHandle(
+  profile: Profile | undefined,
+  currentPubkey: string | undefined,
+) {
+  if (currentPubkey === undefined) {
+    return null;
+  }
+
+  return (
+    profile?.nip05Handle?.trim() ||
+    profile?.displayName?.trim() ||
+    truncatePubkey(currentPubkey)
+  );
+}
+
+export function resolveAgentInstruction(
+  managedAgent: ManagedAgent | undefined,
+  persona: AgentPersona | undefined,
+) {
+  return (
+    managedAgent?.systemPrompt?.trim() || persona?.systemPrompt.trim() || null
+  );
+}
+
+export function personaManagedAgentUpdate(
+  agent: ManagedAgent,
+  persona: AgentPersona,
+  options: {
+    previousPersona?: AgentPersona;
+    runtimes?: readonly AcpRuntimeCatalogEntry[];
+  } = {},
+): UpdateManagedAgentInput | null {
+  if (agent.personaId !== persona.id) return null;
+
+  const input: UpdateManagedAgentInput = { pubkey: agent.pubkey };
+  let hasChanges = false;
+
+  if (persona.displayName !== agent.name) {
+    input.name = persona.displayName;
+    hasChanges = true;
+  }
+
+  if (persona.systemPrompt !== (agent.systemPrompt ?? "")) {
+    input.systemPrompt = persona.systemPrompt;
+    hasChanges = true;
+  }
+
+  if ((persona.model ?? null) !== (agent.model ?? null)) {
+    input.model = persona.model;
+    hasChanges = true;
+  }
+
+  if (!stringRecordEqual(persona.envVars, agent.envVars)) {
+    input.envVars = persona.envVars;
+    hasChanges = true;
+  }
+
+  const runtimeChanged =
+    options.previousPersona !== undefined &&
+    options.previousPersona.runtime !== persona.runtime;
+  const runtime = runtimeChanged
+    ? options.runtimes?.find((candidate) => candidate.id === persona.runtime)
+    : undefined;
+  if (runtime?.command) {
+    if (runtime.command !== agent.agentCommand) {
+      input.agentCommand = runtime.command;
+      hasChanges = true;
+    }
+
+    if (!stringArrayEqual(runtime.defaultArgs, agent.agentArgs)) {
+      input.agentArgs = [...runtime.defaultArgs];
+      hasChanges = true;
+    }
+
+    const mcpCommand = runtime.mcpCommand ?? "";
+    if (mcpCommand !== agent.mcpCommand) {
+      input.mcpCommand = mcpCommand;
+      hasChanges = true;
+    }
+  }
+
+  return hasChanges ? input : null;
+}
+
+function stringArrayEqual(left: readonly string[], right: readonly string[]) {
+  if (left.length !== right.length) return false;
+
+  return left.every((value, index) => value === right[index]);
+}
+
+function stringRecordEqual(
+  left: Record<string, string>,
+  right: Record<string, string>,
+) {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) return false;
+
+  return leftKeys.every((key) => left[key] === right[key]);
+}
+
+export function useRetainedPersona(
+  sourcePersona: AgentPersona | undefined,
+  profileIdentityKey: string,
+) {
+  const [retainedPersona, setRetainedPersona] = React.useState<{
+    key: string;
+    persona: AgentPersona;
+  } | null>(null);
+
+  React.useEffect(() => {
+    if (!sourcePersona) return;
+    setRetainedPersona({ key: profileIdentityKey, persona: sourcePersona });
+  }, [profileIdentityKey, sourcePersona]);
+
+  return (
+    sourcePersona ??
+    (retainedPersona?.key === profileIdentityKey
+      ? retainedPersona.persona
+      : undefined)
+  );
+}

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -296,7 +296,7 @@ function resolvePersonaManagedAgentRuntime(
   runtimes: readonly AcpRuntimeCatalogEntry[] | undefined,
 ) {
   if (!runtimes?.length) return undefined;
-  if (!runtimeId) return runtimes[0];
+  if (!runtimeId) return undefined;
   return runtimes.find((candidate) => candidate.id === runtimeId);
 }
 

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -268,7 +268,7 @@ export function personaManagedAgentUpdate(
     options.previousPersona !== undefined &&
     options.previousPersona.runtime !== persona.runtime;
   const runtime = runtimeChanged
-    ? options.runtimes?.find((candidate) => candidate.id === persona.runtime)
+    ? resolvePersonaManagedAgentRuntime(persona.runtime, options.runtimes)
     : undefined;
   if (runtime?.command) {
     if (runtime.command !== agent.agentCommand) {
@@ -289,6 +289,15 @@ export function personaManagedAgentUpdate(
   }
 
   return hasChanges ? input : null;
+}
+
+function resolvePersonaManagedAgentRuntime(
+  runtimeId: string | null | undefined,
+  runtimes: readonly AcpRuntimeCatalogEntry[] | undefined,
+) {
+  if (!runtimes?.length) return undefined;
+  if (!runtimeId) return runtimes[0];
+  return runtimes.find((candidate) => candidate.id === runtimeId);
 }
 
 function mergedPersonaEnvVarsForAgent(

--- a/desktop/src/features/profile/ui/UserProfilePersonaDialogs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePersonaDialogs.tsx
@@ -1,0 +1,67 @@
+import type {
+  AcpRuntimeCatalogEntry,
+  AgentPersona,
+  CreatePersonaInput,
+  UpdatePersonaInput,
+} from "@/shared/api/types";
+import { PersonaDeleteDialog } from "@/features/agents/ui/PersonaDeleteDialog";
+import { PersonaDialog } from "@/features/agents/ui/PersonaDialog";
+import type { PersonaDialogState } from "@/features/agents/ui/personaDialogState";
+
+export function UserProfilePersonaDialogs({
+  createError,
+  isPending,
+  personaDialogState,
+  personaToDelete,
+  runtimes,
+  runtimesLoading,
+  updateError,
+  onCloseDelete,
+  onCloseDialog,
+  onConfirmDelete,
+  onSubmit,
+}: {
+  createError: Error | null;
+  isPending: boolean;
+  personaDialogState: PersonaDialogState | null;
+  personaToDelete: AgentPersona | null;
+  runtimes: AcpRuntimeCatalogEntry[];
+  runtimesLoading: boolean;
+  updateError: Error | null;
+  onCloseDelete: () => void;
+  onCloseDialog: () => void;
+  onConfirmDelete: (persona: AgentPersona) => void;
+  onSubmit: (input: CreatePersonaInput | UpdatePersonaInput) => Promise<void>;
+}) {
+  return (
+    <>
+      <PersonaDialog
+        description={personaDialogState?.description ?? ""}
+        error={updateError ?? createError}
+        initialValues={personaDialogState?.initialValues ?? null}
+        isPending={isPending}
+        runtimes={runtimes}
+        runtimesLoading={runtimesLoading}
+        onOpenChange={(open) => {
+          if (!open) {
+            onCloseDialog();
+          }
+        }}
+        onSubmit={onSubmit}
+        open={personaDialogState !== null}
+        submitLabel={personaDialogState?.submitLabel ?? "Save"}
+        title={personaDialogState?.title ?? "Agent"}
+      />
+      <PersonaDeleteDialog
+        onConfirm={onConfirmDelete}
+        onOpenChange={(open) => {
+          if (!open) {
+            onCloseDelete();
+          }
+        }}
+        open={personaToDelete !== null}
+        persona={personaToDelete}
+      />
+    </>
+  );
+}

--- a/desktop/src/features/pulse/ui/PulseScreen.tsx
+++ b/desktop/src/features/pulse/ui/PulseScreen.tsx
@@ -3,9 +3,10 @@ import * as React from "react";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useOpenDmMutation } from "@/features/channels/hooks";
 import {
+  profilePanelViewFromSearch,
   type ProfilePanelView,
-  UserProfilePanel,
-} from "@/features/profile/ui/UserProfilePanel";
+} from "@/features/profile/ui/UserProfilePanelUtils";
+import { UserProfilePanel } from "@/features/profile/ui/UserProfilePanel";
 import { PulseView } from "@/features/pulse/ui/PulseView";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { ProfilePanelProvider } from "@/shared/context/ProfilePanelContext";
@@ -18,10 +19,7 @@ export function PulseScreen() {
   const identityQuery = useIdentityQuery();
   const { applyPatch, values } = useHistorySearchState(PULSE_PANEL_SEARCH_KEYS);
   const profilePanelPubkey = values.profile;
-  const profilePanelView: ProfilePanelView =
-    values.profileView === "memories" || values.profileView === "channels"
-      ? values.profileView
-      : "summary";
+  const profilePanelView = profilePanelViewFromSearch(values.profileView);
   const handleOpenProfilePanel = React.useCallback(
     (pubkey: string) => applyPatch({ profile: pubkey, profileView: null }),
     [applyPatch],

--- a/desktop/src/shared/context/ProfilePanelContext.tsx
+++ b/desktop/src/shared/context/ProfilePanelContext.tsx
@@ -1,23 +1,32 @@
 import * as React from "react";
 
+import type { AgentPersona } from "@/shared/api/types";
+
 type ProfilePanelContextValue = {
   openProfilePanel: ((pubkey: string) => void) | null;
+  openPersonaProfilePanel: ((persona: AgentPersona) => void) | null;
 };
 
 const ProfilePanelContext = React.createContext<ProfilePanelContextValue>({
   openProfilePanel: null,
+  openPersonaProfilePanel: null,
 });
 
 export function ProfilePanelProvider({
   children,
   onOpenProfilePanel,
+  onOpenPersonaProfilePanel,
 }: {
   children: React.ReactNode;
   onOpenProfilePanel: (pubkey: string) => void;
+  onOpenPersonaProfilePanel?: (persona: AgentPersona) => void;
 }) {
   const value = React.useMemo(
-    () => ({ openProfilePanel: onOpenProfilePanel }),
-    [onOpenProfilePanel],
+    () => ({
+      openProfilePanel: onOpenProfilePanel,
+      openPersonaProfilePanel: onOpenPersonaProfilePanel ?? null,
+    }),
+    [onOpenPersonaProfilePanel, onOpenProfilePanel],
   );
 
   return (

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -1034,7 +1034,7 @@ test("clicking author name opens user profile panel", async ({ page }) => {
   // Click now opens the full profile panel instead of the popover
   const panel = page.getByTestId("user-profile-panel");
   await expect(panel).toBeVisible();
-  await expect(panel).toContainText("deadbeef");
+  await expect(panel).toContainText("npub1mock...");
 });
 
 test("hovering avatar opens popover, clicking opens profile panel", async ({

--- a/desktop/tests/e2e/mesh-compute.spec.ts
+++ b/desktop/tests/e2e/mesh-compute.spec.ts
@@ -64,15 +64,22 @@ async function setMesh(
   }, mesh);
 }
 
-async function openManagedAgentActions(
+async function openManagedAgentProfile(
   page: import("@playwright/test").Page,
   pubkey: string,
 ) {
-  const trigger = page.getByTestId(`managed-agent-actions-${pubkey}`);
-  await trigger.scrollIntoViewIfNeeded();
-  await trigger.focus();
-  await trigger.press("Enter");
-  await expect(trigger).toHaveAttribute("data-state", "open");
+  const row = page.getByTestId(`managed-agent-${pubkey}`);
+  await row.getByRole("button", { name: "Manage" }).click();
+  await expect(page.getByTestId("user-profile-panel")).toBeVisible();
+}
+
+async function clickManagedAgentPrimaryAction(
+  page: import("@playwright/test").Page,
+  label: string,
+) {
+  const action = page.getByTestId("user-profile-agent-primary-action");
+  await expect(action).toContainText(label);
+  await action.click();
 }
 
 async function openNewAgentMenu(page: import("@playwright/test").Page) {
@@ -330,8 +337,8 @@ test("saved relay-mesh agents restart via the backend serve-target preflight", a
     0,
   );
 
-  await openManagedAgentActions(page, pubkey);
-  await page.getByRole("menuitem", { name: "Stop" }).click();
+  await openManagedAgentProfile(page, pubkey);
+  await clickManagedAgentPrimaryAction(page, "Stop");
   await expect
     .poll(async () => await commands(page))
     .toContain("stop_managed_agent");
@@ -339,22 +346,19 @@ test("saved relay-mesh agents restart via the backend serve-target preflight", a
 
   // With a live serve target for the model, manual restart goes through:
   // the backend preflight re-resolves the target and the agent starts.
-  await openManagedAgentActions(page, pubkey);
-  await page.getByRole("menuitem", { name: "Spawn" }).click();
+  await clickManagedAgentPrimaryAction(page, "Respawn");
   await expect
     .poll(async () => await commands(page))
     .toContain("start_managed_agent");
   await expect(row).toContainText("running");
 
-  await openManagedAgentActions(page, pubkey);
-  await page.getByRole("menuitem", { name: "Stop" }).click();
+  await clickManagedAgentPrimaryAction(page, "Stop");
   await expect(row).toContainText("stopped");
 
   // Without a live serve target, the backend preflight rejects the start
   // with an actionable error, surfaced as a toast; the agent stays stopped.
   await setMesh(page, { models: [] });
-  await openManagedAgentActions(page, pubkey);
-  await page.getByRole("menuitem", { name: "Spawn" }).click();
+  await clickManagedAgentPrimaryAction(page, "Respawn");
 
   await expect(
     page


### PR DESCRIPTION
## Summary
- Moves agent and persona management into the Agents profile sidebar while keeping this PR standalone on main.
- Replaces the per-agent and per-persona action menus on the existing Agents list with profile-sidebar manage entrypoints.
- Adds profile panel action helpers, edit/delete submission utilities, and focused tests.

## Notes
- This PR intentionally does not depend on the agents/teams card simplification PR.

## Validation
- `cd desktop && pnpm check`
- `cd desktop && pnpm typecheck`