### PR TITLE
Revamp new agent dialog

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -67,9 +67,11 @@ const overrides = new Map([
   // harness-persona-sync feature growth, queued to split in the resolver-unify
   // refactor followup. discovery.rs is dominated by the new test module
   // (the effective_agent_command / divergent / create-time override matrix);
+  // alias-preservation coverage extends that matrix so create-time persona
+  // agents keep an installed runtime alias when the primary command is absent.
   // types.rs adds the persona/instance harness fields. Load-bearing, not
   // generic debt.
-  ["src-tauri/src/managed_agents/discovery.rs", 1043],
+  ["src-tauri/src/managed_agents/discovery.rs", 1085],
   ["src-tauri/src/managed_agents/types.rs", 1037],
   // migration_tests.rs carries the harness-sync migration coverage plus the
   // patch_json_records owner-only writeback regression test (SECURITY.md:90

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -355,9 +355,19 @@ fn title_case_model_suffix(value: &str, preserve_first_separator: bool) -> Strin
         .collect::<String>()
 }
 
-fn normalize_openai_compatible_models(response: OpenAiModelListResponse) -> Vec<AgentModelInfo> {
+fn normalize_openai_compatible_models(
+    response: OpenAiModelListResponse,
+    provider: Option<&str>,
+) -> Vec<AgentModelInfo> {
     let mut seen = HashSet::new();
     let mut items = response.data;
+    let filter_to_openai_text_models = matches!(
+        provider
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("openai")
+    );
     let all_ids = items
         .iter()
         .map(|item| item.id.clone())
@@ -371,10 +381,10 @@ fn normalize_openai_compatible_models(response: OpenAiModelListResponse) -> Vec<
 
     items
         .into_iter()
-        .filter(|item| is_agent_text_model_id(&item.id))
+        .filter(|item| !filter_to_openai_text_models || is_agent_text_model_id(&item.id))
         .filter(|item| match openai_dated_snapshot_alias(&item.id) {
-            Some(alias) => !all_ids.contains(&alias),
-            None => true,
+            Some(alias) if filter_to_openai_text_models => !all_ids.contains(&alias),
+            Some(_) | None => true,
         })
         .filter(|item| seen.insert(item.id.clone()))
         .map(|item| AgentModelInfo {
@@ -416,7 +426,7 @@ async fn discover_openai_compatible_models(
         .json::<OpenAiModelListResponse>()
         .await
         .map_err(|error| format!("OpenAI model discovery response parse failed: {error}"))?;
-    let models = normalize_openai_compatible_models(response);
+    let models = normalize_openai_compatible_models(response, provider);
     if models.is_empty() {
         return Err("OpenAI model discovery returned no compatible text models".to_string());
     }

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -235,14 +235,46 @@ fn is_openai_compatible_provider(provider: Option<&str>) -> bool {
     )
 }
 
+#[cfg(test)]
 fn openai_compatible_models_url(env: &BTreeMap<String, String>) -> String {
-    let base_url = env
-        .get("OPENAI_COMPAT_BASE_URL")
+    let base_url = env_value(env, "OPENAI_COMPAT_BASE_URL")
+        .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+    format!("{}/models", base_url.trim_end_matches('/'))
+}
+
+fn openai_compatible_models_url_for_discovery(env: &BTreeMap<String, String>) -> String {
+    let base_url = env_or_process_value(env, "OPENAI_COMPAT_BASE_URL")
+        .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+    format!("{}/models", base_url.trim_end_matches('/'))
+}
+
+fn env_value(env: &BTreeMap<String, String>, key: &str) -> Option<String> {
+    env.get(key)
         .map(String::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or("https://api.openai.com/v1");
-    format!("{}/models", base_url.trim_end_matches('/'))
+        .map(str::to_string)
+}
+
+fn env_or_process_value(env: &BTreeMap<String, String>, key: &str) -> Option<String> {
+    env_value(env, key).or_else(|| {
+        std::env::var(key)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn redaction_env_with_value(
+    env: &BTreeMap<String, String>,
+    key: &str,
+    value: &str,
+) -> BTreeMap<String, String> {
+    let mut redaction_env = env.clone();
+    redaction_env
+        .entry(key.to_string())
+        .or_insert_with(|| value.to_string());
+    redaction_env
 }
 
 fn is_agent_text_model_id(id: &str) -> bool {
@@ -363,23 +395,20 @@ async fn discover_openai_compatible_models(
         return Ok(None);
     }
 
-    let api_key = env
-        .get("OPENAI_COMPAT_API_KEY")
-        .map(String::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
+    let api_key = env_or_process_value(env, "OPENAI_COMPAT_API_KEY")
         .ok_or_else(|| "config: OPENAI_COMPAT_API_KEY required".to_string())?;
-    let url = openai_compatible_models_url(env);
+    let redaction_env = redaction_env_with_value(env, "OPENAI_COMPAT_API_KEY", &api_key);
+    let url = openai_compatible_models_url_for_discovery(env);
     let response = client
         .get(&url)
-        .bearer_auth(api_key)
+        .bearer_auth(&api_key)
         .send()
         .await
         .map_err(|error| format!("OpenAI model discovery request failed: {error}"))?;
     let status = response.status();
     if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
-        let body = crate::managed_agents::redact_env_values_in(&body, env);
+        let body = crate::managed_agents::redact_env_values_in(&body, &redaction_env);
         return Err(format!("OpenAI model discovery HTTP {status}: {body}"));
     }
 
@@ -428,13 +457,20 @@ fn is_anthropic_provider(provider: Option<&str>) -> bool {
     )
 }
 
+#[cfg(test)]
 fn anthropic_models_url(env: &BTreeMap<String, String>) -> String {
-    let base_url = env
-        .get("ANTHROPIC_BASE_URL")
-        .map(String::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("https://api.anthropic.com");
+    let base_url = env_value(env, "ANTHROPIC_BASE_URL")
+        .unwrap_or_else(|| "https://api.anthropic.com".to_string());
+    anthropic_models_url_from_base(&base_url)
+}
+
+fn anthropic_models_url_for_discovery(env: &BTreeMap<String, String>) -> String {
+    let base_url = env_or_process_value(env, "ANTHROPIC_BASE_URL")
+        .unwrap_or_else(|| "https://api.anthropic.com".to_string());
+    anthropic_models_url_from_base(&base_url)
+}
+
+fn anthropic_models_url_from_base(base_url: &str) -> String {
     let base_url = base_url.trim_end_matches('/');
     if base_url.ends_with("/v1") {
         format!("{base_url}/models")
@@ -499,18 +535,16 @@ async fn discover_anthropic_models(
         return Ok(None);
     }
 
-    let api_key = env
-        .get("ANTHROPIC_API_KEY")
-        .map(String::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
+    let api_key = env_or_process_value(env, "ANTHROPIC_API_KEY")
         .ok_or_else(|| "config: ANTHROPIC_API_KEY required".to_string())?;
-    let url = anthropic_models_url(env);
+    let redaction_env = redaction_env_with_value(env, "ANTHROPIC_API_KEY", &api_key);
+    let url = anthropic_models_url_for_discovery(env);
     let mut models = Vec::new();
     let mut after_id: Option<String> = None;
     for _ in 0..20 {
         let response =
-            fetch_anthropic_model_page(client, &url, api_key, after_id.as_deref(), env).await?;
+            fetch_anthropic_model_page(client, &url, &api_key, after_id.as_deref(), &redaction_env)
+                .await?;
         let has_more = response.has_more;
         after_id = response.last_id.clone();
         models.extend(normalize_anthropic_models(response));
@@ -881,109 +915,5 @@ fn normalize_agent_models(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn openai_model_normalization_keeps_agent_text_models() {
-        let models = normalize_openai_compatible_models(OpenAiModelListResponse {
-            data: vec![
-                OpenAiModelListItem {
-                    id: "text-embedding-3-large".to_string(),
-                    created: Some(4),
-                },
-                OpenAiModelListItem {
-                    id: "gpt-image-2".to_string(),
-                    created: Some(5),
-                },
-                OpenAiModelListItem {
-                    id: "chatgpt-5.5-pro-2026-04-23".to_string(),
-                    created: Some(7),
-                },
-                OpenAiModelListItem {
-                    id: "chatgpt-5.5-pro".to_string(),
-                    created: Some(6),
-                },
-                OpenAiModelListItem {
-                    id: "gpt-5.4-mini".to_string(),
-                    created: Some(2),
-                },
-                OpenAiModelListItem {
-                    id: "o4-mini".to_string(),
-                    created: Some(3),
-                },
-                OpenAiModelListItem {
-                    id: "gpt-5.4-mini".to_string(),
-                    created: Some(1),
-                },
-            ],
-        });
-
-        let ids_and_names = models
-            .into_iter()
-            .map(|model| (model.id, model.name))
-            .collect::<Vec<_>>();
-        assert_eq!(
-            ids_and_names,
-            vec![
-                (
-                    "chatgpt-5.5-pro".to_string(),
-                    Some("ChatGPT 5.5 Pro".to_string()),
-                ),
-                ("o4-mini".to_string(), Some("o4-mini".to_string())),
-                ("gpt-5.4-mini".to_string(), Some("GPT-5.4 mini".to_string()),),
-            ]
-        );
-    }
-
-    #[test]
-    fn openai_models_url_uses_openai_default_base_url() {
-        assert_eq!(
-            openai_compatible_models_url(&BTreeMap::new()),
-            "https://api.openai.com/v1/models"
-        );
-    }
-
-    #[test]
-    fn anthropic_models_url_uses_anthropic_default_base_url() {
-        assert_eq!(
-            anthropic_models_url(&BTreeMap::new()),
-            "https://api.anthropic.com/v1/models"
-        );
-    }
-
-    #[test]
-    fn anthropic_models_url_accepts_versioned_base_url() {
-        let env = BTreeMap::from([(
-            "ANTHROPIC_BASE_URL".to_string(),
-            "https://proxy.example/v1/".to_string(),
-        )]);
-
-        assert_eq!(
-            anthropic_models_url(&env),
-            "https://proxy.example/v1/models"
-        );
-    }
-
-    #[test]
-    fn anthropic_model_normalization_uses_display_names() {
-        let models = normalize_anthropic_models(AnthropicModelListResponse {
-            data: vec![
-                AnthropicModelListItem {
-                    id: "claude-opus-4-6".to_string(),
-                    display_name: Some("Claude Opus 4.6".to_string()),
-                },
-                AnthropicModelListItem {
-                    id: "claude-opus-4-6".to_string(),
-                    display_name: Some("Duplicate".to_string()),
-                },
-            ],
-            has_more: false,
-            last_id: None,
-        });
-
-        assert_eq!(models.len(), 1);
-        assert_eq!(models[0].id, "claude-opus-4-6");
-        assert_eq!(models[0].name.as_deref(), Some("Claude Opus 4.6"));
-    }
-}
+#[path = "agent_models_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -246,9 +246,68 @@ fn is_agent_text_model_id(id: &str) -> bool {
     lower.starts_with("gpt-") || lower.starts_with('o') || lower.starts_with("chatgpt-")
 }
 
+fn openai_dated_snapshot_alias(id: &str) -> Option<String> {
+    let (base, date) = id.rsplit_once('-')?;
+    if date.len() != 2 || !date.chars().all(|character| character.is_ascii_digit()) {
+        return None;
+    }
+    let (base, month) = base.rsplit_once('-')?;
+    if month.len() != 2 || !month.chars().all(|character| character.is_ascii_digit()) {
+        return None;
+    }
+    let (base, year) = base.rsplit_once('-')?;
+    if year.len() != 4 || !year.chars().all(|character| character.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(base.to_string())
+}
+
+fn openai_model_display_name(id: &str) -> String {
+    let canonical = openai_dated_snapshot_alias(id).unwrap_or_else(|| id.to_string());
+    if let Some(rest) = canonical.strip_prefix("chatgpt-") {
+        return format!("ChatGPT {}", title_case_model_suffix(rest, false));
+    }
+    if let Some(rest) = canonical.strip_prefix("gpt-") {
+        return format!("GPT-{}", title_case_model_suffix(rest, true));
+    }
+
+    canonical
+}
+
+fn title_case_model_suffix(value: &str, preserve_first_separator: bool) -> String {
+    value
+        .split('-')
+        .enumerate()
+        .map(|(index, part)| {
+            let part = if part.eq_ignore_ascii_case("pro") {
+                "Pro".to_string()
+            } else if part.eq_ignore_ascii_case("mini") {
+                "mini".to_string()
+            } else if part.eq_ignore_ascii_case("nano") {
+                "nano".to_string()
+            } else {
+                part.to_string()
+            };
+
+            if preserve_first_separator && index == 0 {
+                part
+            } else if index == 0 {
+                part
+            } else {
+                format!(" {part}")
+            }
+        })
+        .collect::<String>()
+}
+
 fn normalize_openai_compatible_models(response: OpenAiModelListResponse) -> Vec<AgentModelInfo> {
     let mut seen = HashSet::new();
     let mut items = response.data;
+    let all_ids = items
+        .iter()
+        .map(|item| item.id.clone())
+        .collect::<HashSet<String>>();
     items.sort_by(|left, right| {
         right
             .created
@@ -259,10 +318,14 @@ fn normalize_openai_compatible_models(response: OpenAiModelListResponse) -> Vec<
     items
         .into_iter()
         .filter(|item| is_agent_text_model_id(&item.id))
+        .filter(|item| match openai_dated_snapshot_alias(&item.id) {
+            Some(alias) => !all_ids.contains(&alias),
+            None => true,
+        })
         .filter(|item| seen.insert(item.id.clone()))
         .map(|item| AgentModelInfo {
+            name: Some(openai_model_display_name(&item.id)),
             id: item.id,
-            name: None,
             description: None,
         })
         .collect()
@@ -677,6 +740,14 @@ mod tests {
                     created: Some(5),
                 },
                 OpenAiModelListItem {
+                    id: "chatgpt-5.5-pro-2026-04-23".to_string(),
+                    created: Some(7),
+                },
+                OpenAiModelListItem {
+                    id: "chatgpt-5.5-pro".to_string(),
+                    created: Some(6),
+                },
+                OpenAiModelListItem {
                     id: "gpt-5.4-mini".to_string(),
                     created: Some(2),
                 },
@@ -691,8 +762,21 @@ mod tests {
             ],
         });
 
-        let ids = models.into_iter().map(|model| model.id).collect::<Vec<_>>();
-        assert_eq!(ids, vec!["o4-mini", "gpt-5.4-mini"]);
+        let ids_and_names = models
+            .into_iter()
+            .map(|model| (model.id, model.name))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ids_and_names,
+            vec![
+                (
+                    "chatgpt-5.5-pro".to_string(),
+                    Some("ChatGPT 5.5 Pro".to_string()),
+                ),
+                ("o4-mini".to_string(), Some("o4-mini".to_string())),
+                ("gpt-5.4-mini".to_string(), Some("GPT-5.4 mini".to_string()),),
+            ]
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -194,6 +194,11 @@ async fn run_agent_models_command(
                 }
             }
         }
+        // Mirror runtime spawn: internal builds may bake Databricks host/model
+        // defaults. User-provided env below still wins.
+        for (key, value) in crate::managed_agents::build_databricks_defaults() {
+            cmd.env(key, value);
+        }
         // User env layering — written LAST so it overrides any Buzz-set env above.
         for (k, v) in &merged_env {
             cmd.env(k, v);

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -1,6 +1,10 @@
-use std::collections::HashSet;
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::PathBuf,
+};
 
 use nostr::Keys;
+use serde::Deserialize;
 use tauri::{AppHandle, State};
 
 use crate::{
@@ -11,7 +15,7 @@ use crate::{
         managed_agent_avatar_url, missing_command_message, normalize_agent_args, resolve_command,
         resolve_effective_prompt_model_provider, save_managed_agents, sync_managed_agent_processes,
         try_regenerate_nest, AgentModelInfo, AgentModelsResponse, UpdateManagedAgentRequest,
-        UpdateManagedAgentResponse,
+        UpdateManagedAgentResponse, DEFAULT_ACP_COMMAND,
     },
     relay::{relay_ws_url_with_override, sync_managed_agent_profile},
     util::now_iso,
@@ -85,6 +89,84 @@ pub async fn get_agent_models(
         (resolved, resolved_agent, args, effective_model, env)
     }; // store lock released — subprocess runs without holding the lock
 
+    run_agent_models_command(
+        resolved_acp,
+        agent_command,
+        agent_args,
+        persisted_model,
+        merged_env,
+    )
+    .await
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverAgentModelsInput {
+    #[serde(default)]
+    pub acp_command: Option<String>,
+    pub agent_command: String,
+    #[serde(default)]
+    pub agent_args: Vec<String>,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub env_vars: BTreeMap<String, String>,
+}
+
+/// Query available models from an unsaved agent configuration.
+///
+/// This powers the new-agent dialog before a persona/agent record exists. It
+/// mirrors the saved-agent discovery command, but derives runtime/provider/env
+/// from the current form state instead of loading a persisted record.
+#[tauri::command]
+pub async fn discover_agent_models(
+    input: DiscoverAgentModelsInput,
+) -> Result<AgentModelsResponse, String> {
+    crate::managed_agents::validate_user_env_keys(&input.env_vars)?;
+
+    let acp_command = input
+        .acp_command
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_ACP_COMMAND);
+    let resolved_acp = resolve_command(acp_command)
+        .ok_or_else(|| missing_command_message(acp_command, "ACP harness command"))?;
+
+    let agent_command = input.agent_command.trim();
+    if agent_command.is_empty() {
+        return Err("agent command is required for model discovery".to_string());
+    }
+    let agent_args = normalize_agent_args(agent_command, input.agent_args);
+    let resolved_agent = resolve_command(agent_command)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| agent_command.to_string());
+
+    let mut derived_env = BTreeMap::new();
+    if let Some(meta) = known_acp_runtime(agent_command) {
+        let provider = input
+            .provider
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        if !meta.provider_locked {
+            if let (Some(env_key), Some(provider)) = (meta.provider_env_var, provider) {
+                derived_env.insert(env_key.to_string(), provider.to_string());
+            }
+        }
+    }
+    let merged_env = crate::managed_agents::merged_user_env(&derived_env, &input.env_vars);
+
+    run_agent_models_command(resolved_acp, resolved_agent, agent_args, None, merged_env).await
+}
+
+async fn run_agent_models_command(
+    resolved_acp: PathBuf,
+    agent_command: String,
+    agent_args: Vec<String>,
+    persisted_model: Option<String>,
+    merged_env: BTreeMap<String, String>,
+) -> Result<AgentModelsResponse, String> {
     // Clone the env map for redaction below — `merged_env` is moved
     // into the spawn_blocking closure and we still need the values to
     // scrub any user-supplied secrets that the child surfaces in stderr.

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -73,7 +73,7 @@ pub async fn get_agent_models(
         // provider/env snapshot, and runtime spawn reads that same snapshot.
         // Discover models against the record snapshot so an out-of-date persona
         // cannot offer models for a provider this agent will not launch with.
-        let discovery = saved_agent_model_discovery_config(record);
+        let discovery = saved_agent_model_discovery_config(record, &effective_command);
 
         (
             resolved,
@@ -126,11 +126,25 @@ struct SavedAgentModelDiscoveryConfig {
 
 fn saved_agent_model_discovery_config(
     record: &crate::managed_agents::ManagedAgentRecord,
+    agent_command: &str,
 ) -> SavedAgentModelDiscoveryConfig {
+    let mut derived_env = BTreeMap::new();
+    if let Some(meta) = known_acp_runtime(agent_command) {
+        for (key, value) in crate::managed_agents::runtime_metadata_env_vars(
+            meta.model_env_var,
+            meta.provider_env_var,
+            meta.provider_locked,
+            record.model.as_deref(),
+            record.provider.as_deref(),
+        ) {
+            derived_env.insert(key.to_string(), value.to_string());
+        }
+    }
+
     SavedAgentModelDiscoveryConfig {
         model: record.model.clone(),
         provider: record.provider.clone(),
-        env: crate::managed_agents::merged_user_env(&BTreeMap::new(), &record.env_vars),
+        env: crate::managed_agents::merged_user_env(&derived_env, &record.env_vars),
     }
 }
 

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -276,9 +276,7 @@ fn redaction_env_with_value(
     value: &str,
 ) -> BTreeMap<String, String> {
     let mut redaction_env = env.clone();
-    redaction_env
-        .entry(key.to_string())
-        .or_insert_with(|| value.to_string());
+    redaction_env.insert(key.to_string(), value.to_string());
     redaction_env
 }
 

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -108,6 +108,17 @@ pub async fn get_agent_models(
         return Ok(models);
     }
 
+    if let Some(models) = discover_anthropic_models(
+        &state.http_client,
+        effective_provider.as_deref(),
+        &merged_env,
+        persisted_model.clone(),
+    )
+    .await?
+    {
+        return Ok(models);
+    }
+
     run_agent_models_command(
         resolved_acp,
         agent_command,
@@ -178,6 +189,17 @@ pub async fn discover_agent_models(
     let merged_env = crate::managed_agents::merged_user_env(&derived_env, &input.env_vars);
 
     if let Some(models) = discover_openai_compatible_models(
+        &state.http_client,
+        input.provider.as_deref(),
+        &merged_env,
+        None,
+    )
+    .await?
+    {
+        return Ok(models);
+    }
+
+    if let Some(models) = discover_anthropic_models(
         &state.http_client,
         input.provider.as_deref(),
         &merged_env,
@@ -372,6 +394,141 @@ async fn discover_openai_compatible_models(
 
     Ok(Some(AgentModelsResponse {
         agent_name: provider.unwrap_or("openai").trim().to_string(),
+        agent_version: "models-api".to_string(),
+        models,
+        agent_default_model: None,
+        selected_model,
+        supports_switching: true,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicModelListResponse {
+    data: Vec<AnthropicModelListItem>,
+    #[serde(default)]
+    has_more: bool,
+    #[serde(default)]
+    last_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicModelListItem {
+    id: String,
+    #[serde(default)]
+    display_name: Option<String>,
+}
+
+fn is_anthropic_provider(provider: Option<&str>) -> bool {
+    matches!(
+        provider
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("anthropic")
+    )
+}
+
+fn anthropic_models_url(env: &BTreeMap<String, String>) -> String {
+    let base_url = env
+        .get("ANTHROPIC_BASE_URL")
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("https://api.anthropic.com");
+    let base_url = base_url.trim_end_matches('/');
+    if base_url.ends_with("/v1") {
+        format!("{base_url}/models")
+    } else {
+        format!("{base_url}/v1/models")
+    }
+}
+
+fn normalize_anthropic_models(response: AnthropicModelListResponse) -> Vec<AgentModelInfo> {
+    let mut seen = HashSet::new();
+    response
+        .data
+        .into_iter()
+        .filter(|item| seen.insert(item.id.clone()))
+        .map(|item| AgentModelInfo {
+            id: item.id,
+            name: item.display_name,
+            description: None,
+        })
+        .collect()
+}
+
+async fn fetch_anthropic_model_page(
+    client: &reqwest::Client,
+    url: &str,
+    api_key: &str,
+    after_id: Option<&str>,
+    env: &BTreeMap<String, String>,
+) -> Result<AnthropicModelListResponse, String> {
+    let mut request = client
+        .get(url)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01");
+    if let Some(after_id) = after_id {
+        request = request.query(&[("after_id", after_id)]);
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|error| format!("Anthropic model discovery request failed: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let body = crate::managed_agents::redact_env_values_in(&body, env);
+        return Err(format!("Anthropic model discovery HTTP {status}: {body}"));
+    }
+
+    response
+        .json::<AnthropicModelListResponse>()
+        .await
+        .map_err(|error| format!("Anthropic model discovery response parse failed: {error}"))
+}
+
+async fn discover_anthropic_models(
+    client: &reqwest::Client,
+    provider: Option<&str>,
+    env: &BTreeMap<String, String>,
+    selected_model: Option<String>,
+) -> Result<Option<AgentModelsResponse>, String> {
+    if !is_anthropic_provider(provider) {
+        return Ok(None);
+    }
+
+    let api_key = env
+        .get("ANTHROPIC_API_KEY")
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "config: ANTHROPIC_API_KEY required".to_string())?;
+    let url = anthropic_models_url(env);
+    let mut models = Vec::new();
+    let mut after_id: Option<String> = None;
+    for _ in 0..20 {
+        let response =
+            fetch_anthropic_model_page(client, &url, api_key, after_id.as_deref(), env).await?;
+        let has_more = response.has_more;
+        after_id = response.last_id.clone();
+        models.extend(normalize_anthropic_models(response));
+        if !has_more {
+            break;
+        }
+        if after_id.as_deref().unwrap_or_default().is_empty() {
+            return Err("Anthropic model discovery pagination did not return last_id".to_string());
+        }
+    }
+    let mut seen = HashSet::new();
+    models.retain(|model| seen.insert(model.id.clone()));
+    if models.is_empty() {
+        return Err("Anthropic model discovery returned no models".to_string());
+    }
+
+    Ok(Some(AgentModelsResponse {
+        agent_name: provider.unwrap_or("anthropic").trim().to_string(),
         agent_version: "models-api".to_string(),
         models,
         agent_default_model: None,
@@ -785,5 +942,48 @@ mod tests {
             openai_compatible_models_url(&BTreeMap::new()),
             "https://api.openai.com/v1/models"
         );
+    }
+
+    #[test]
+    fn anthropic_models_url_uses_anthropic_default_base_url() {
+        assert_eq!(
+            anthropic_models_url(&BTreeMap::new()),
+            "https://api.anthropic.com/v1/models"
+        );
+    }
+
+    #[test]
+    fn anthropic_models_url_accepts_versioned_base_url() {
+        let env = BTreeMap::from([(
+            "ANTHROPIC_BASE_URL".to_string(),
+            "https://proxy.example/v1/".to_string(),
+        )]);
+
+        assert_eq!(
+            anthropic_models_url(&env),
+            "https://proxy.example/v1/models"
+        );
+    }
+
+    #[test]
+    fn anthropic_model_normalization_uses_display_names() {
+        let models = normalize_anthropic_models(AnthropicModelListResponse {
+            data: vec![
+                AnthropicModelListItem {
+                    id: "claude-opus-4-6".to_string(),
+                    display_name: Some("Claude Opus 4.6".to_string()),
+                },
+                AnthropicModelListItem {
+                    id: "claude-opus-4-6".to_string(),
+                    display_name: Some("Duplicate".to_string()),
+                },
+            ],
+            has_more: false,
+            last_id: None,
+        });
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "claude-opus-4-6");
+        assert_eq!(models[0].name.as_deref(), Some("Claude Opus 4.6"));
     }
 }

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -13,9 +13,9 @@ use crate::{
         build_managed_agent_summary, current_instance_id, default_agent_workdir,
         find_managed_agent_mut, known_acp_runtime, load_managed_agents, load_personas,
         managed_agent_avatar_url, missing_command_message, normalize_agent_args, resolve_command,
-        resolve_effective_prompt_model_provider, save_managed_agents, sync_managed_agent_processes,
-        try_regenerate_nest, AgentModelInfo, AgentModelsResponse, UpdateManagedAgentRequest,
-        UpdateManagedAgentResponse, DEFAULT_ACP_COMMAND,
+        save_managed_agents, sync_managed_agent_processes, try_regenerate_nest, AgentModelInfo,
+        AgentModelsResponse, UpdateManagedAgentRequest, UpdateManagedAgentResponse,
+        DEFAULT_ACP_COMMAND,
     },
     relay::{relay_ws_url_with_override, sync_managed_agent_profile},
     util::now_iso,
@@ -69,31 +69,19 @@ pub async fn get_agent_models(
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| effective_command.clone());
 
-        // Same env layering as runtime spawn: persona env < agent env.
-        // Model discovery needs the user's credentials. Fail closed on
-        // persona-resolution errors so a corrupt personas.json doesn't
-        // produce a model list as if the persona had no credentials.
-        let persona_env =
-            crate::managed_agents::resolve_persona_env(&app, record.persona_id.as_deref())?;
-        let env = crate::managed_agents::merged_user_env(&persona_env, &record.env_vars);
-
-        // Resolve the effective model from the linked persona so the ModelPicker
-        // dropdown shows the current persona model as selected.
-        let (_prompt, effective_model, effective_provider) =
-            resolve_effective_prompt_model_provider(
-                record.persona_id.as_deref(),
-                &personas,
-                record.system_prompt.clone(),
-                record.model.clone(),
-            );
+        // ModelPicker can persist a selected model but not rewrite the saved
+        // provider/env snapshot, and runtime spawn reads that same snapshot.
+        // Discover models against the record snapshot so an out-of-date persona
+        // cannot offer models for a provider this agent will not launch with.
+        let discovery = saved_agent_model_discovery_config(record);
 
         (
             resolved,
             resolved_agent,
             args,
-            effective_model,
-            effective_provider,
-            env,
+            discovery.model,
+            discovery.provider,
+            discovery.env,
         )
     }; // store lock released — subprocess runs without holding the lock
 
@@ -127,6 +115,23 @@ pub async fn get_agent_models(
         merged_env,
     )
     .await
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SavedAgentModelDiscoveryConfig {
+    model: Option<String>,
+    provider: Option<String>,
+    env: BTreeMap<String, String>,
+}
+
+fn saved_agent_model_discovery_config(
+    record: &crate::managed_agents::ManagedAgentRecord,
+) -> SavedAgentModelDiscoveryConfig {
+    SavedAgentModelDiscoveryConfig {
+        model: record.model.clone(),
+        provider: record.provider.clone(),
+        env: crate::managed_agents::merged_user_env(&BTreeMap::new(), &record.env_vars),
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -31,7 +31,7 @@ pub async fn get_agent_models(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<AgentModelsResponse, String> {
-    let (resolved_acp, agent_command, agent_args, persisted_model, merged_env) = {
+    let (resolved_acp, agent_command, agent_args, persisted_model, effective_provider, merged_env) = {
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -79,15 +79,34 @@ pub async fn get_agent_models(
 
         // Resolve the effective model from the linked persona so the ModelPicker
         // dropdown shows the current persona model as selected.
-        let (_prompt, effective_model, _provider) = resolve_effective_prompt_model_provider(
-            record.persona_id.as_deref(),
-            &personas,
-            record.system_prompt.clone(),
-            record.model.clone(),
-        );
+        let (_prompt, effective_model, effective_provider) =
+            resolve_effective_prompt_model_provider(
+                record.persona_id.as_deref(),
+                &personas,
+                record.system_prompt.clone(),
+                record.model.clone(),
+            );
 
-        (resolved, resolved_agent, args, effective_model, env)
+        (
+            resolved,
+            resolved_agent,
+            args,
+            effective_model,
+            effective_provider,
+            env,
+        )
     }; // store lock released — subprocess runs without holding the lock
+
+    if let Some(models) = discover_openai_compatible_models(
+        &state.http_client,
+        effective_provider.as_deref(),
+        &merged_env,
+        persisted_model.clone(),
+    )
+    .await?
+    {
+        return Ok(models);
+    }
 
     run_agent_models_command(
         resolved_acp,
@@ -121,6 +140,7 @@ pub struct DiscoverAgentModelsInput {
 #[tauri::command]
 pub async fn discover_agent_models(
     input: DiscoverAgentModelsInput,
+    state: State<'_, AppState>,
 ) -> Result<AgentModelsResponse, String> {
     crate::managed_agents::validate_user_env_keys(&input.env_vars)?;
 
@@ -157,7 +177,144 @@ pub async fn discover_agent_models(
     }
     let merged_env = crate::managed_agents::merged_user_env(&derived_env, &input.env_vars);
 
+    if let Some(models) = discover_openai_compatible_models(
+        &state.http_client,
+        input.provider.as_deref(),
+        &merged_env,
+        None,
+    )
+    .await?
+    {
+        return Ok(models);
+    }
+
     run_agent_models_command(resolved_acp, resolved_agent, agent_args, None, merged_env).await
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiModelListResponse {
+    data: Vec<OpenAiModelListItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiModelListItem {
+    id: String,
+    #[serde(default)]
+    created: Option<i64>,
+}
+
+fn is_openai_compatible_provider(provider: Option<&str>) -> bool {
+    matches!(
+        provider
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("openai" | "openai-compat")
+    )
+}
+
+fn openai_compatible_models_url(env: &BTreeMap<String, String>) -> String {
+    let base_url = env
+        .get("OPENAI_COMPAT_BASE_URL")
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("https://api.openai.com/v1");
+    format!("{}/models", base_url.trim_end_matches('/'))
+}
+
+fn is_agent_text_model_id(id: &str) -> bool {
+    let lower = id.to_ascii_lowercase();
+    if [
+        "audio",
+        "dall-e",
+        "embedding",
+        "image",
+        "moderation",
+        "realtime",
+        "speech",
+        "transcribe",
+        "tts",
+        "whisper",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+    {
+        return false;
+    }
+
+    lower.starts_with("gpt-") || lower.starts_with('o') || lower.starts_with("chatgpt-")
+}
+
+fn normalize_openai_compatible_models(response: OpenAiModelListResponse) -> Vec<AgentModelInfo> {
+    let mut seen = HashSet::new();
+    let mut items = response.data;
+    items.sort_by(|left, right| {
+        right
+            .created
+            .cmp(&left.created)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    items
+        .into_iter()
+        .filter(|item| is_agent_text_model_id(&item.id))
+        .filter(|item| seen.insert(item.id.clone()))
+        .map(|item| AgentModelInfo {
+            id: item.id,
+            name: None,
+            description: None,
+        })
+        .collect()
+}
+
+async fn discover_openai_compatible_models(
+    client: &reqwest::Client,
+    provider: Option<&str>,
+    env: &BTreeMap<String, String>,
+    selected_model: Option<String>,
+) -> Result<Option<AgentModelsResponse>, String> {
+    if !is_openai_compatible_provider(provider) {
+        return Ok(None);
+    }
+
+    let api_key = env
+        .get("OPENAI_COMPAT_API_KEY")
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "config: OPENAI_COMPAT_API_KEY required".to_string())?;
+    let url = openai_compatible_models_url(env);
+    let response = client
+        .get(&url)
+        .bearer_auth(api_key)
+        .send()
+        .await
+        .map_err(|error| format!("OpenAI model discovery request failed: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let body = crate::managed_agents::redact_env_values_in(&body, env);
+        return Err(format!("OpenAI model discovery HTTP {status}: {body}"));
+    }
+
+    let response = response
+        .json::<OpenAiModelListResponse>()
+        .await
+        .map_err(|error| format!("OpenAI model discovery response parse failed: {error}"))?;
+    let models = normalize_openai_compatible_models(response);
+    if models.is_empty() {
+        return Err("OpenAI model discovery returned no compatible text models".to_string());
+    }
+
+    Ok(Some(AgentModelsResponse {
+        agent_name: provider.unwrap_or("openai").trim().to_string(),
+        agent_version: "models-api".to_string(),
+        models,
+        agent_default_model: None,
+        selected_model,
+        supports_switching: true,
+    }))
 }
 
 async fn run_agent_models_command(
@@ -500,5 +657,49 @@ fn normalize_agent_models(
         agent_default_model,
         selected_model: persisted_model,
         supports_switching,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openai_model_normalization_keeps_agent_text_models() {
+        let models = normalize_openai_compatible_models(OpenAiModelListResponse {
+            data: vec![
+                OpenAiModelListItem {
+                    id: "text-embedding-3-large".to_string(),
+                    created: Some(4),
+                },
+                OpenAiModelListItem {
+                    id: "gpt-image-2".to_string(),
+                    created: Some(5),
+                },
+                OpenAiModelListItem {
+                    id: "gpt-5.4-mini".to_string(),
+                    created: Some(2),
+                },
+                OpenAiModelListItem {
+                    id: "o4-mini".to_string(),
+                    created: Some(3),
+                },
+                OpenAiModelListItem {
+                    id: "gpt-5.4-mini".to_string(),
+                    created: Some(1),
+                },
+            ],
+        });
+
+        let ids = models.into_iter().map(|model| model.id).collect::<Vec<_>>();
+        assert_eq!(ids, vec!["o4-mini", "gpt-5.4-mini"]);
+    }
+
+    #[test]
+    fn openai_models_url_uses_openai_default_base_url() {
+        assert_eq!(
+            openai_compatible_models_url(&BTreeMap::new()),
+            "https://api.openai.com/v1/models"
+        );
     }
 }

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -149,6 +149,21 @@ fn anthropic_model_normalization_uses_display_names() {
 }
 
 #[test]
+fn redaction_env_records_value_used_for_request() {
+    let env = BTreeMap::from([("OPENAI_COMPAT_API_KEY".to_string(), "   ".to_string())]);
+
+    let redaction_env =
+        redaction_env_with_value(&env, "OPENAI_COMPAT_API_KEY", "inherited-process-key");
+
+    assert_eq!(
+        redaction_env
+            .get("OPENAI_COMPAT_API_KEY")
+            .map(String::as_str),
+        Some("inherited-process-key")
+    );
+}
+
+#[test]
 fn saved_agent_model_discovery_uses_record_snapshot() {
     let record: crate::managed_agents::ManagedAgentRecord = serde_json::from_str(
         r#"{

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+#[test]
+fn openai_model_normalization_keeps_agent_text_models() {
+    let models = normalize_openai_compatible_models(OpenAiModelListResponse {
+        data: vec![
+            OpenAiModelListItem {
+                id: "text-embedding-3-large".to_string(),
+                created: Some(4),
+            },
+            OpenAiModelListItem {
+                id: "gpt-image-2".to_string(),
+                created: Some(5),
+            },
+            OpenAiModelListItem {
+                id: "chatgpt-5.5-pro-2026-04-23".to_string(),
+                created: Some(7),
+            },
+            OpenAiModelListItem {
+                id: "chatgpt-5.5-pro".to_string(),
+                created: Some(6),
+            },
+            OpenAiModelListItem {
+                id: "gpt-5.4-mini".to_string(),
+                created: Some(2),
+            },
+            OpenAiModelListItem {
+                id: "o4-mini".to_string(),
+                created: Some(3),
+            },
+            OpenAiModelListItem {
+                id: "gpt-5.4-mini".to_string(),
+                created: Some(1),
+            },
+        ],
+    });
+
+    let ids_and_names = models
+        .into_iter()
+        .map(|model| (model.id, model.name))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ids_and_names,
+        vec![
+            (
+                "chatgpt-5.5-pro".to_string(),
+                Some("ChatGPT 5.5 Pro".to_string()),
+            ),
+            ("o4-mini".to_string(), Some("o4-mini".to_string())),
+            ("gpt-5.4-mini".to_string(), Some("GPT-5.4 mini".to_string()),),
+        ]
+    );
+}
+
+#[test]
+fn openai_models_url_uses_openai_default_base_url() {
+    assert_eq!(
+        openai_compatible_models_url(&BTreeMap::new()),
+        "https://api.openai.com/v1/models"
+    );
+}
+
+#[test]
+fn anthropic_models_url_uses_anthropic_default_base_url() {
+    assert_eq!(
+        anthropic_models_url(&BTreeMap::new()),
+        "https://api.anthropic.com/v1/models"
+    );
+}
+
+#[test]
+fn anthropic_models_url_accepts_versioned_base_url() {
+    let env = BTreeMap::from([(
+        "ANTHROPIC_BASE_URL".to_string(),
+        "https://proxy.example/v1/".to_string(),
+    )]);
+
+    assert_eq!(
+        anthropic_models_url(&env),
+        "https://proxy.example/v1/models"
+    );
+}
+
+#[test]
+fn anthropic_model_normalization_uses_display_names() {
+    let models = normalize_anthropic_models(AnthropicModelListResponse {
+        data: vec![
+            AnthropicModelListItem {
+                id: "claude-opus-4-6".to_string(),
+                display_name: Some("Claude Opus 4.6".to_string()),
+            },
+            AnthropicModelListItem {
+                id: "claude-opus-4-6".to_string(),
+                display_name: Some("Duplicate".to_string()),
+            },
+        ],
+        has_more: false,
+        last_id: None,
+    });
+
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].id, "claude-opus-4-6");
+    assert_eq!(models[0].name.as_deref(), Some("Claude Opus 4.6"));
+}

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -147,3 +147,44 @@ fn anthropic_model_normalization_uses_display_names() {
     assert_eq!(models[0].id, "claude-opus-4-6");
     assert_eq!(models[0].name.as_deref(), Some("Claude Opus 4.6"));
 }
+
+#[test]
+fn saved_agent_model_discovery_uses_record_snapshot() {
+    let record: crate::managed_agents::ManagedAgentRecord = serde_json::from_str(
+        r#"{
+            "pubkey": "abcd1234",
+            "name": "test-agent",
+            "private_key_nsec": "nsec1fake",
+            "relay_url": "wss://localhost:3000",
+            "acp_command": "buzz-acp",
+            "agent_command": "goose",
+            "agent_args": [],
+            "mcp_command": "",
+            "turn_timeout_seconds": 320,
+            "system_prompt": null,
+            "model": "record-model",
+            "provider": "databricks",
+            "env_vars": {
+                "OPENAI_API_KEY": "record-key",
+                "BUZZ_PRIVATE_KEY": "must-not-leak"
+            },
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "last_started_at": null,
+            "last_stopped_at": null,
+            "last_exit_code": null,
+            "last_error": null
+        }"#,
+    )
+    .expect("sample managed agent record");
+
+    let config = saved_agent_model_discovery_config(&record);
+
+    assert_eq!(config.model.as_deref(), Some("record-model"));
+    assert_eq!(config.provider.as_deref(), Some("databricks"));
+    assert_eq!(
+        config.env.get("OPENAI_API_KEY").map(String::as_str),
+        Some("record-key")
+    );
+    assert!(!config.env.contains_key("BUZZ_PRIVATE_KEY"));
+}

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -193,10 +193,18 @@ fn saved_agent_model_discovery_uses_record_snapshot() {
     )
     .expect("sample managed agent record");
 
-    let config = saved_agent_model_discovery_config(&record);
+    let config = saved_agent_model_discovery_config(&record, "goose");
 
     assert_eq!(config.model.as_deref(), Some("record-model"));
     assert_eq!(config.provider.as_deref(), Some("databricks"));
+    assert_eq!(
+        config.env.get("GOOSE_MODEL").map(String::as_str),
+        Some("record-model")
+    );
+    assert_eq!(
+        config.env.get("GOOSE_PROVIDER").map(String::as_str),
+        Some("databricks")
+    );
     assert_eq!(
         config.env.get("OPENAI_API_KEY").map(String::as_str),
         Some("record-key")

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -2,38 +2,41 @@ use super::*;
 
 #[test]
 fn openai_model_normalization_keeps_agent_text_models() {
-    let models = normalize_openai_compatible_models(OpenAiModelListResponse {
-        data: vec![
-            OpenAiModelListItem {
-                id: "text-embedding-3-large".to_string(),
-                created: Some(4),
-            },
-            OpenAiModelListItem {
-                id: "gpt-image-2".to_string(),
-                created: Some(5),
-            },
-            OpenAiModelListItem {
-                id: "chatgpt-5.5-pro-2026-04-23".to_string(),
-                created: Some(7),
-            },
-            OpenAiModelListItem {
-                id: "chatgpt-5.5-pro".to_string(),
-                created: Some(6),
-            },
-            OpenAiModelListItem {
-                id: "gpt-5.4-mini".to_string(),
-                created: Some(2),
-            },
-            OpenAiModelListItem {
-                id: "o4-mini".to_string(),
-                created: Some(3),
-            },
-            OpenAiModelListItem {
-                id: "gpt-5.4-mini".to_string(),
-                created: Some(1),
-            },
-        ],
-    });
+    let models = normalize_openai_compatible_models(
+        OpenAiModelListResponse {
+            data: vec![
+                OpenAiModelListItem {
+                    id: "text-embedding-3-large".to_string(),
+                    created: Some(4),
+                },
+                OpenAiModelListItem {
+                    id: "gpt-image-2".to_string(),
+                    created: Some(5),
+                },
+                OpenAiModelListItem {
+                    id: "chatgpt-5.5-pro-2026-04-23".to_string(),
+                    created: Some(7),
+                },
+                OpenAiModelListItem {
+                    id: "chatgpt-5.5-pro".to_string(),
+                    created: Some(6),
+                },
+                OpenAiModelListItem {
+                    id: "gpt-5.4-mini".to_string(),
+                    created: Some(2),
+                },
+                OpenAiModelListItem {
+                    id: "o4-mini".to_string(),
+                    created: Some(3),
+                },
+                OpenAiModelListItem {
+                    id: "gpt-5.4-mini".to_string(),
+                    created: Some(1),
+                },
+            ],
+        },
+        Some("openai"),
+    );
 
     let ids_and_names = models
         .into_iter()
@@ -48,6 +51,48 @@ fn openai_model_normalization_keeps_agent_text_models() {
             ),
             ("o4-mini".to_string(), Some("o4-mini".to_string())),
             ("gpt-5.4-mini".to_string(), Some("GPT-5.4 mini".to_string()),),
+        ]
+    );
+}
+
+#[test]
+fn openai_compat_model_normalization_preserves_provider_specific_ids() {
+    let models = normalize_openai_compatible_models(
+        OpenAiModelListResponse {
+            data: vec![
+                OpenAiModelListItem {
+                    id: "meta-llama/Llama-3.3-70B-Instruct".to_string(),
+                    created: Some(5),
+                },
+                OpenAiModelListItem {
+                    id: "mistral-large-latest".to_string(),
+                    created: Some(4),
+                },
+                OpenAiModelListItem {
+                    id: "anthropic/claude-sonnet-4-6".to_string(),
+                    created: Some(3),
+                },
+                OpenAiModelListItem {
+                    id: "text-embedding-compatible".to_string(),
+                    created: Some(2),
+                },
+                OpenAiModelListItem {
+                    id: "meta-llama/Llama-3.3-70B-Instruct".to_string(),
+                    created: Some(1),
+                },
+            ],
+        },
+        Some("openai-compat"),
+    );
+
+    let ids = models.into_iter().map(|model| model.id).collect::<Vec<_>>();
+    assert_eq!(
+        ids,
+        vec![
+            "meta-llama/Llama-3.3-70B-Instruct".to_string(),
+            "mistral-large-latest".to_string(),
+            "anthropic/claude-sonnet-4-6".to_string(),
+            "text-embedding-compatible".to_string(),
         ]
     );
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -508,6 +508,7 @@ pub fn run() {
             delete_managed_agent,
             get_managed_agent_log,
             get_agent_models,
+            discover_agent_models,
             mesh_availability,
             mesh_start_node,
             mesh_ensure_client_node,

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -315,9 +315,9 @@ pub fn divergent_agent_command_override(
 /// distinct cases that the backend MUST tell apart:
 ///
 /// - DELIBERATE OVERRIDE (`harness_override` true): the user explicitly picked a
-///   non-persona runtime in a deploy dialog that exposes a runtime selector (e.g.
-///   `AddChannelBotDialog`, "overriding persona preferences"). This is a real pin
-///   and is preserved via `divergent_agent_command_override`.
+///   runtime command in UI that exposes a runtime selector. This is a real pin
+///   and is preserved when it differs from the command inheritance would spawn,
+///   including installed aliases such as `claude-code-acp`.
 /// - MISSING-RUNTIME FALLBACK (`harness_override` false): the persona's runtime
 ///   isn't installed locally, so `resolvePersonaRuntime` substitutes a fallback
 ///   default. This is NOT a pin — baking it would freeze the agent on the fallback
@@ -341,6 +341,15 @@ pub fn create_time_agent_command_override(
     if persona_id.is_some() && !harness_override {
         return None;
     }
+
+    if persona_id.is_some() && harness_override {
+        let picked = picked_command
+            .map(str::trim)
+            .filter(|value| !value.is_empty())?;
+        let inherited_command = effective_agent_command(persona_id, personas, None);
+        return (picked != inherited_command).then(|| picked.to_string());
+    }
+
     divergent_agent_command_override(persona_id, personas, picked_command)
 }
 
@@ -1023,6 +1032,38 @@ mod tests {
         let personas = vec![persona_with_runtime("p1", Some("goose"))];
         assert_eq!(
             create_time_agent_command_override(Some("p1"), &personas, Some("goose"), false),
+            None
+        );
+    }
+
+    #[test]
+    fn create_time_override_preserves_selected_runtime_alias() {
+        // A `claude` persona inherits the primary command `claude-agent-acp`,
+        // but discovery may select an installed alias such as `claude-code-acp`.
+        // When UI marks that create-time selection as explicit, preserve the
+        // alias so the first spawn uses a command known to be installed.
+        let personas = vec![persona_with_runtime("p1", Some("claude"))];
+        assert_eq!(
+            create_time_agent_command_override(
+                Some("p1"),
+                &personas,
+                Some("claude-code-acp"),
+                true
+            ),
+            Some("claude-code-acp".to_string())
+        );
+    }
+
+    #[test]
+    fn create_time_override_inherits_exact_persona_command() {
+        let personas = vec![persona_with_runtime("p1", Some("claude"))];
+        assert_eq!(
+            create_time_agent_command_override(
+                Some("p1"),
+                &personas,
+                Some("claude-agent-acp"),
+                true
+            ),
             None
         );
     }

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -243,11 +243,9 @@ pub fn default_agent_command() -> String {
         .to_string()
 }
 
-/// Resolve the agent command (harness) for a spawn/deploy/summary. Mirrors the
-/// model resolution in `resolve_effective_prompt_model_provider`: the linked
+/// Resolve the agent command (harness) for a spawn/deploy/summary. The linked
 /// persona wins so persona harness edits propagate on the next spawn. An
-/// explicit per-instance override (`agent_command_override`) takes precedence,
-/// matching the opt-in `record.model` override pattern.
+/// explicit per-instance override (`agent_command_override`) takes precedence.
 ///
 /// Resolution order:
 ///   1. explicit override (non-empty) — a deliberate per-instance pin;

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -296,36 +296,5 @@ pub(crate) fn merged_user_env(
     merged
 }
 
-/// Resolve a managed-agent record's persona env_vars, failing closed.
-///
-/// Three outcomes:
-/// - `persona_id` is `None` → returns `Ok({})` (agent has no persona, no env to inherit).
-/// - `persona_id = Some(id)` and the persona exists → returns `Ok(persona.env_vars)`.
-/// - `persona_id = Some(id)` and either personas.json fails to load OR no persona
-///   with that id exists → returns `Err(...)`.
-///
-/// Why fail closed: persona env_vars frequently carry API credentials
-/// (ANTHROPIC_API_KEY, OPENAI_API_KEY, …). If we swallow load errors and
-/// quietly spawn with an empty env, the agent comes up unauthenticated and
-/// the user sees a downstream "401 from provider" with no obvious cause.
-/// Better to surface the persona load failure at spawn/deploy/discovery
-/// time.
-pub(crate) fn resolve_persona_env(
-    app: &tauri::AppHandle,
-    persona_id: Option<&str>,
-) -> Result<BTreeMap<String, String>, String> {
-    let Some(pid) = persona_id else {
-        return Ok(BTreeMap::new());
-    };
-    let personas = super::load_personas(app).map_err(|e| {
-        format!("failed to load personas while resolving env for persona `{pid}`: {e}")
-    })?;
-    let persona = personas
-        .into_iter()
-        .find(|p| p.id == pid)
-        .ok_or_else(|| format!("persona `{pid}` not found while resolving env"))?;
-    Ok(persona.env_vars)
-}
-
 #[cfg(test)]
 mod tests;

--- a/desktop/src-tauri/src/managed_agents/persona_card.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_card.rs
@@ -9,6 +9,7 @@ pub struct ParsedPersonaPreview {
     pub display_name: String,
     pub system_prompt: String,
     pub avatar_data_url: Option<String>,
+    pub avatar_ref: Option<String>,
     pub runtime: Option<String>,
     pub model: Option<String>,
     pub provider: Option<String>,
@@ -69,6 +70,7 @@ pub fn parse_png_persona(png_bytes: &[u8]) -> Result<ParsedPersonaPreview, Strin
         display_name: fields.display_name,
         system_prompt: fields.system_prompt,
         avatar_data_url,
+        avatar_ref: None,
         runtime: fields.runtime,
         model: fields.model,
         provider: fields.provider,
@@ -224,6 +226,7 @@ pub fn parse_json_persona(json_bytes: &[u8]) -> Result<ParsedPersonaPreview, Str
         display_name: fields.display_name,
         system_prompt: fields.system_prompt,
         avatar_data_url: fields.avatar_url,
+        avatar_ref: None,
         runtime: fields.runtime,
         model: fields.model,
         provider: fields.provider,
@@ -284,6 +287,7 @@ pub fn parse_md_persona(md_bytes: &[u8]) -> Result<ParsedPersonaPreview, String>
         display_name: config.display_name,
         system_prompt: config.prompt,
         avatar_data_url: None, // .persona.md avatars are paths, not data URIs
+        avatar_ref: config.avatar,
         runtime: config.runtime,
         model,
         provider: None, // .persona.md format does not carry llmProvider
@@ -385,6 +389,7 @@ pub fn parse_zip_pack(zip_bytes: &[u8]) -> Result<ParsePersonaFilesResult, Strin
             display_name: p.display_name.clone(),
             system_prompt: p.system_prompt.clone(),
             avatar_data_url: None,
+            avatar_ref: p.avatar.clone(),
             runtime: p.runtime.clone(),
             model: p.model.clone(),
             provider: None, // persona packs do not carry llmProvider
@@ -804,6 +809,16 @@ mod tests {
             Some("https://example.com/ada.png")
         );
         assert!(result.source_file.is_empty());
+    }
+
+    #[test]
+    fn parse_md_carries_avatar_ref() {
+        let md = b"---\nname: goosey\ndisplay_name: Goosey\navatar: app-avatar:gloopies-19\ndescription: A goose persona.\n---\nYou are Goosey.\n";
+        let result = parse_md_persona(md).unwrap();
+
+        assert_eq!(result.display_name, "Goosey");
+        assert!(result.avatar_data_url.is_none());
+        assert_eq!(result.avatar_ref.as_deref(), Some("app-avatar:gloopies-19"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1522,28 +1522,6 @@ pub(crate) fn build_respond_to_env(
     Ok((set, remove))
 }
 
-/// Resolve the effective system prompt, model, and provider from the *live*
-/// persona for **display and model-discovery only** — the ModelPicker shows the
-/// current persona model as selected. The spawn and deploy paths deliberately
-/// do NOT use this; they read the pinned record snapshot so a running agent
-/// stays on the config it was created with. The linked persona wins here; the
-/// record values are the fallback when no persona is linked or it was deleted.
-pub(crate) fn resolve_effective_prompt_model_provider(
-    persona_id: Option<&str>,
-    personas: &[crate::managed_agents::types::PersonaRecord],
-    record_prompt: Option<String>,
-    record_model: Option<String>,
-) -> (Option<String>, Option<String>, Option<String>) {
-    match persona_id.and_then(|pid| personas.iter().find(|p| p.id == pid)) {
-        Some(p) => (
-            Some(p.system_prompt.clone()),
-            p.model.clone(),
-            p.provider.clone(),
-        ),
-        None => (record_prompt, record_model, None),
-    }
-}
-
 /// Spawn an agent process without holding any locks on records or runtimes.
 /// Returns the child process and log path on success. The caller is responsible
 /// for updating `ManagedAgentRecord` fields and inserting into the runtimes map.

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1985,7 +1985,7 @@ pub fn stop_managed_agent_process(
 /// switching need the initial bootstrap value. Provider injection is skipped
 /// when `provider_locked` is true (e.g. Claude runtimes that only work with
 /// Anthropic).
-fn runtime_metadata_env_vars<'a>(
+pub(crate) fn runtime_metadata_env_vars<'a>(
     model_env_var: Option<&'a str>,
     provider_env_var: Option<&'a str>,
     provider_locked: bool,

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1872,7 +1872,7 @@ fn child_rust_log_filter() -> String {
 
 /// Databricks host/model baked in at compile time for internal builds. Empty
 /// in OSS builds, where the `BUZZ_BUILD_DATABRICKS_*` env is unset.
-fn build_databricks_defaults() -> Vec<(&'static str, &'static str)> {
+pub(crate) fn build_databricks_defaults() -> Vec<(&'static str, &'static str)> {
     let mut defaults = Vec::new();
     if let Some(host) = option_env!("BUZZ_DESKTOP_BUILD_DATABRICKS_HOST") {
         if !host.is_empty() {

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -253,11 +253,7 @@ fn build_env_rejects_empty_allowlist_in_allowlist_mode() {
     assert!(err.contains("at least one pubkey"));
 }
 
-// ── resolve_effective_prompt_model_provider tests ───────────────────
-
-fn persona(id: &str, prompt: &str, model: Option<&str>) -> crate::managed_agents::PersonaRecord {
-    persona_with_provider(id, prompt, model, None)
-}
+// ── persona fixture helpers ─────────────────────────────────────────
 
 fn persona_with_provider(
     id: &str,
@@ -282,66 +278,6 @@ fn persona_with_provider(
         created_at: "2026-06-09T00:00:00Z".to_string(),
         updated_at: "2026-06-09T00:00:00Z".to_string(),
     }
-}
-
-#[test]
-fn linked_persona_wins_over_record_snapshot() {
-    let personas = vec![persona_with_provider(
-        "p1",
-        "fresh",
-        Some("m-fresh"),
-        Some("anthropic"),
-    )];
-    let (prompt, model, provider) = super::resolve_effective_prompt_model_provider(
-        Some("p1"),
-        &personas,
-        Some("stale".into()),
-        Some("m-stale".into()),
-    );
-    assert_eq!(prompt.as_deref(), Some("fresh"));
-    assert_eq!(model.as_deref(), Some("m-fresh"));
-    assert_eq!(provider.as_deref(), Some("anthropic"));
-}
-
-#[test]
-fn no_persona_id_falls_back_to_record() {
-    let personas = vec![persona("p1", "fresh", Some("m-fresh"))];
-    let (prompt, model, provider) = super::resolve_effective_prompt_model_provider(
-        None,
-        &personas,
-        Some("record".into()),
-        Some("m-record".into()),
-    );
-    assert_eq!(prompt.as_deref(), Some("record"));
-    assert_eq!(model.as_deref(), Some("m-record"));
-    assert_eq!(provider, None);
-}
-
-#[test]
-fn deleted_persona_falls_back_to_record() {
-    let personas = vec![persona("p1", "fresh", None)];
-    let (prompt, model, provider) = super::resolve_effective_prompt_model_provider(
-        Some("gone"),
-        &personas,
-        Some("record".into()),
-        Some("m-record".into()),
-    );
-    assert_eq!(prompt.as_deref(), Some("record"));
-    assert_eq!(model.as_deref(), Some("m-record"));
-    assert_eq!(provider, None);
-}
-
-#[test]
-fn persona_with_no_model_clears_stale_record_model() {
-    let personas = vec![persona("p1", "fresh", None)];
-    let (prompt, model, _provider) = super::resolve_effective_prompt_model_provider(
-        Some("p1"),
-        &personas,
-        Some("stale".into()),
-        Some("m-stale".into()),
-    );
-    assert_eq!(prompt.as_deref(), Some("fresh"));
-    assert_eq!(model, None);
 }
 
 // ── persona pin/refresh acceptance (Phase 4) ────────────────────────────

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -310,11 +310,10 @@ pub struct CreateManagedAgentRequest {
     pub relay_url: Option<String>,
     pub acp_command: Option<String>,
     pub agent_command: Option<String>,
-    /// True when `agent_command` is a runtime the user deliberately picked to
-    /// override the linked persona (a deploy-dialog runtime selector). Distinguishes
-    /// a real pin from a missing-runtime fallback so a persona-backed create only
-    /// stores an `agent_command_override` for the former. Defaults `false`: callers
-    /// that don't set it (persona-less creates, fallback divergence) inherit.
+    /// True when `agent_command` is a runtime command the user deliberately
+    /// picked for a linked persona. Distinguishes a real selection, including an
+    /// installed alias, from a missing-runtime fallback so a persona-backed
+    /// create only stores an `agent_command_override` for the former.
     #[serde(default)]
     pub harness_override: bool,
     #[serde(default)]

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -172,6 +172,7 @@ export function AgentCreationPreview({
         className="flex min-h-9 items-center gap-2 rounded-lg px-2.5 py-1.5 transition-colors duration-150 ease-out focus-within:bg-muted/50"
         onSubmit={(event) => {
           event.preventDefault();
+          event.stopPropagation();
           applyAvatarUrl();
         }}
       >

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -1,0 +1,167 @@
+import * as React from "react";
+import { Upload } from "lucide-react";
+
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
+import { cn } from "@/shared/lib/cn";
+import { Spinner } from "@/shared/ui/spinner";
+
+function isAvatarFileDrag(event: React.DragEvent<HTMLElement>) {
+  return Array.from(event.dataTransfer.types).includes("Files");
+}
+
+export function AgentCreationPreview({
+  avatarUrl,
+  disabled = false,
+  label,
+  onUploadPendingChange,
+  onSelectAvatar,
+}: {
+  avatarUrl: string | null;
+  disabled?: boolean;
+  label: string;
+  onUploadPendingChange?: (isPending: boolean) => void;
+  onSelectAvatar: (avatarUrl: string) => void;
+}) {
+  const [isDragOverAvatar, setIsDragOverAvatar] = React.useState(false);
+  const avatarDragDepthRef = React.useRef(0);
+  const {
+    inputRef: avatarUploadInputRef,
+    isUploading,
+    errorMessage: uploadErrorMessage,
+    clearError: clearUploadError,
+    openPicker: openUploadPicker,
+    uploadFile: uploadAvatarFile,
+    handleFileChange: handleAvatarUploadFileChange,
+  } = useAvatarUpload({
+    onUploadSuccess: onSelectAvatar,
+  });
+
+  React.useEffect(() => {
+    onUploadPendingChange?.(isUploading);
+    return () => {
+      onUploadPendingChange?.(false);
+    };
+  }, [isUploading, onUploadPendingChange]);
+
+  const handleAvatarDragEnter = React.useCallback(
+    (event: React.DragEvent<HTMLFieldSetElement>) => {
+      if (disabled || !isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      avatarDragDepthRef.current += 1;
+      event.dataTransfer.dropEffect = "copy";
+      setIsDragOverAvatar(true);
+    },
+    [disabled],
+  );
+
+  const handleAvatarDragOver = React.useCallback(
+    (event: React.DragEvent<HTMLFieldSetElement>) => {
+      if (disabled || !isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = "copy";
+      setIsDragOverAvatar(true);
+    },
+    [disabled],
+  );
+
+  const handleAvatarDragLeave = React.useCallback(
+    (event: React.DragEvent<HTMLFieldSetElement>) => {
+      if (!isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      avatarDragDepthRef.current = Math.max(0, avatarDragDepthRef.current - 1);
+      if (avatarDragDepthRef.current === 0) {
+        setIsDragOverAvatar(false);
+      }
+    },
+    [],
+  );
+
+  const handleAvatarDrop = React.useCallback(
+    (event: React.DragEvent<HTMLFieldSetElement>) => {
+      if (!isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      avatarDragDepthRef.current = 0;
+      setIsDragOverAvatar(false);
+
+      const file = event.dataTransfer.files[0];
+      if (!file || disabled || isUploading) {
+        return;
+      }
+
+      clearUploadError();
+      void uploadAvatarFile(file);
+    },
+    [clearUploadError, disabled, isUploading, uploadAvatarFile],
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-[220px] lg:sticky lg:top-0">
+      <fieldset
+        aria-label="Agent avatar preview"
+        className={cn(
+          "group/avatar-preview relative m-0 aspect-[4/5] min-h-[240px] min-w-0 overflow-hidden rounded-xl border border-border/70 bg-muted/50 p-0 shadow-xs transition-[background-color,border-color,box-shadow] duration-150",
+          isDragOverAvatar &&
+            "border-dashed border-primary/70 bg-primary/5 ring-2 ring-primary/15",
+        )}
+        onDragEnter={handleAvatarDragEnter}
+        onDragLeave={handleAvatarDragLeave}
+        onDragOver={handleAvatarDragOver}
+        onDrop={handleAvatarDrop}
+      >
+        <input
+          accept="image/gif,image/jpeg,image/png,image/webp"
+          className="hidden"
+          onChange={handleAvatarUploadFileChange}
+          ref={avatarUploadInputRef}
+          type="file"
+        />
+
+        <div className="absolute inset-0 flex items-center justify-center">
+          <ProfileAvatar
+            avatarUrl={avatarUrl}
+            className="h-36 w-36 text-4xl"
+            label={label}
+          />
+        </div>
+
+        {uploadErrorMessage ? (
+          <p className="absolute inset-x-3 bottom-12 rounded-md bg-background/95 px-2 py-1 text-center text-xs text-destructive shadow-xs">
+            {uploadErrorMessage}
+          </p>
+        ) : null}
+
+        <div className="absolute inset-x-3 bottom-3 flex justify-center">
+          <button
+            className="inline-flex h-8 translate-y-1 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-background/90 px-3 text-xs font-medium text-foreground opacity-0 shadow-xs transition-[background-color,opacity,transform] duration-150 hover:bg-muted focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring group-hover/avatar-preview:translate-y-0 group-hover/avatar-preview:opacity-100 group-focus-within/avatar-preview:translate-y-0 group-focus-within/avatar-preview:opacity-100"
+            disabled={disabled || isUploading}
+            onClick={() => {
+              clearUploadError();
+              openUploadPicker();
+            }}
+            type="button"
+          >
+            {isUploading ? (
+              <Spinner className="h-3.5 w-3.5 border-2" />
+            ) : (
+              <Upload className="h-3.5 w-3.5" />
+            )}
+            {isUploading ? "Uploading..." : "Edit avatar"}
+          </button>
+        </div>
+      </fieldset>
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -1,14 +1,23 @@
 import * as React from "react";
-import { Upload, X } from "lucide-react";
+import { Pencil, Plus } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
 import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
 
 function isAvatarFileDrag(event: React.DragEvent<HTMLElement>) {
   return Array.from(event.dataTransfer.types).includes("Files");
 }
+
+const AVATAR_APPLY_MOTION_TRANSITION = {
+  duration: 0.14,
+  ease: [0.23, 1, 0.32, 1],
+} as const;
 
 export function AgentCreationPreview({
   avatarUrl,
@@ -25,8 +34,14 @@ export function AgentCreationPreview({
   onUploadPendingChange?: (isPending: boolean) => void;
   onSelectAvatar: (avatarUrl: string) => void;
 }) {
+  const avatarEditClipId = React.useId().replace(/:/g, "");
   const [isDragOverAvatar, setIsDragOverAvatar] = React.useState(false);
+  const [isAvatarMenuOpen, setIsAvatarMenuOpen] = React.useState(false);
+  const [avatarUrlDraft, setAvatarUrlDraft] = React.useState("");
+  const [isAvatarUrlInputFocused, setIsAvatarUrlInputFocused] =
+    React.useState(false);
   const avatarDragDepthRef = React.useRef(0);
+  const shouldReduceMotion = useReducedMotion();
   const {
     inputRef: avatarUploadInputRef,
     isUploading,
@@ -45,6 +60,36 @@ export function AgentCreationPreview({
       onUploadPendingChange?.(false);
     };
   }, [isUploading, onUploadPendingChange]);
+
+  React.useEffect(() => {
+    if (isAvatarMenuOpen) {
+      setAvatarUrlDraft("");
+      setIsAvatarUrlInputFocused(false);
+    }
+  }, [isAvatarMenuOpen]);
+
+  function applyAvatarUrl() {
+    const nextUrl = avatarUrlDraft.trim();
+    if (nextUrl.length === 0) {
+      return;
+    }
+    clearUploadError();
+    onSelectAvatar(nextUrl);
+    setIsAvatarMenuOpen(false);
+  }
+
+  const avatarClipStyle = React.useMemo<React.CSSProperties>(
+    () => ({
+      clipPath: `url(#${avatarEditClipId})`,
+      transform: "translateZ(0)",
+    }),
+    [avatarEditClipId],
+  );
+  const hasAvatarUrlDraft = avatarUrlDraft.trim().length > 0;
+  const hasAvatar = (avatarUrl?.trim().length ?? 0) > 0;
+  const applyButtonTransition = shouldReduceMotion
+    ? { duration: 0 }
+    : AVATAR_APPLY_MOTION_TRANSITION;
 
   const handleAvatarDragEnter = React.useCallback(
     (event: React.DragEvent<HTMLFieldSetElement>) => {
@@ -109,12 +154,93 @@ export function AgentCreationPreview({
     [clearUploadError, disabled, isUploading, uploadAvatarFile],
   );
 
+  const avatarMenuContent = (
+    <PopoverContent align="center" className="w-72 space-y-1 p-1">
+      <button
+        className="flex min-h-9 w-full items-center rounded-lg px-2.5 text-left text-sm outline-hidden transition-colors duration-150 ease-out hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+        disabled={disabled || isUploading}
+        onClick={() => {
+          clearUploadError();
+          openUploadPicker();
+          setIsAvatarMenuOpen(false);
+        }}
+        type="button"
+      >
+        Upload an image
+      </button>
+      <form
+        className="flex min-h-9 items-center gap-2 rounded-lg px-2.5 py-1.5 transition-colors duration-150 ease-out focus-within:bg-muted/50"
+        onSubmit={(event) => {
+          event.preventDefault();
+          applyAvatarUrl();
+        }}
+      >
+        <label className="sr-only" htmlFor="agent-avatar-url">
+          Use a URL
+        </label>
+        <Input
+          autoCapitalize="none"
+          autoComplete="off"
+          autoCorrect="off"
+          className={cn(
+            "h-7 min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-sm shadow-none outline-none focus-visible:ring-0",
+            isAvatarUrlInputFocused
+              ? "placeholder:text-muted-foreground/55"
+              : "placeholder:text-popover-foreground",
+          )}
+          disabled={disabled || isUploading}
+          id="agent-avatar-url"
+          onBlur={() => setIsAvatarUrlInputFocused(false)}
+          onChange={(event) => setAvatarUrlDraft(event.target.value)}
+          onFocus={() => setIsAvatarUrlInputFocused(true)}
+          placeholder={isAvatarUrlInputFocused ? "https://..." : "Use a URL"}
+          spellCheck={false}
+          value={avatarUrlDraft}
+        />
+        <AnimatePresence initial={false}>
+          {hasAvatarUrlDraft ? (
+            <motion.div
+              animate={{ opacity: 1, scale: 1, width: "auto" }}
+              className="overflow-hidden"
+              exit={{ opacity: 0, scale: 0.96, width: 0 }}
+              initial={{ opacity: 0, scale: 0.96, width: 0 }}
+              key="apply-avatar-url"
+              transition={applyButtonTransition}
+            >
+              <Button
+                className="h-7 px-2 text-xs"
+                disabled={disabled || isUploading}
+                size="xs"
+                type="submit"
+              >
+                Apply
+              </Button>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </form>
+      {hasAvatar && onClearAvatar ? (
+        <button
+          className="flex min-h-9 w-full items-center rounded-lg px-2.5 text-left text-sm text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+          disabled={disabled || isUploading}
+          onClick={() => {
+            onClearAvatar();
+            setIsAvatarMenuOpen(false);
+          }}
+          type="button"
+        >
+          Remove avatar
+        </button>
+      ) : null}
+    </PopoverContent>
+  );
+
   return (
     <div className="mx-auto w-full max-w-[220px] lg:sticky lg:top-0">
       <fieldset
         aria-label="Agent avatar preview"
         className={cn(
-          "group/avatar-preview relative m-0 aspect-[4/5] min-h-[240px] min-w-0 overflow-hidden rounded-xl border border-border/70 bg-muted/50 p-0 shadow-xs transition-[background-color,border-color,box-shadow] duration-150",
+          "group/avatar-preview relative m-0 flex min-h-[190px] min-w-0 flex-col items-center justify-center gap-3 rounded-xl border border-transparent p-0 transition-[background-color,border-color,box-shadow] duration-150",
           isDragOverAvatar &&
             "border-dashed border-primary/70 bg-primary/5 ring-2 ring-primary/15",
         )}
@@ -131,50 +257,100 @@ export function AgentCreationPreview({
           type="file"
         />
 
-        <div className="absolute inset-0 flex items-center justify-center">
-          <ProfileAvatar
-            avatarUrl={avatarUrl}
-            className="h-36 w-36 text-4xl"
-            label={label}
-          />
+        <div className="relative h-36 w-36">
+          {hasAvatar ? (
+            <>
+              <svg
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 h-full w-full"
+                fill="none"
+                height="144"
+                viewBox="0 0 144 144"
+                width="144"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <clipPath clipPathUnits="userSpaceOnUse" id={avatarEditClipId}>
+                  <path
+                    clipRule="evenodd"
+                    d="M100.734 83.3298C102.415 84.1574 104.616 83.8757 105.495 82.2207C109.647 74.3981 112 65.4738 112 56C112 25.0721 86.9279 0 56 0C25.0721 0 0 25.0721 0 56C0 86.9279 25.0721 112 56 112C65.4738 112 74.3981 109.647 82.2207 105.495C83.8757 104.616 84.1574 102.415 83.3298 100.734C82.4783 99.0047 82 97.0582 82 95C82 87.8203 87.8203 82 95 82C97.0582 82 99.0047 82.4783 100.734 83.3298Z"
+                    fillRule="evenodd"
+                    transform="translate(-25.875 -25.875) scale(1.575)"
+                  />
+                </clipPath>
+              </svg>
+
+              <div className="relative h-full w-full" style={avatarClipStyle}>
+                <ProfileAvatar
+                  avatarUrl={avatarUrl}
+                  className={cn(
+                    "h-full w-full text-4xl transition-shadow duration-150",
+                    isDragOverAvatar && "ring-2 ring-primary/30",
+                  )}
+                  label={label}
+                />
+              </div>
+
+              <div className="absolute bottom-0 right-0 z-10 flex h-[42px] w-[42px] items-center justify-center rounded-full bg-background">
+                <Popover
+                  open={isAvatarMenuOpen}
+                  onOpenChange={setIsAvatarMenuOpen}
+                >
+                  <PopoverTrigger asChild>
+                    <button
+                      aria-label="Edit avatar"
+                      className="flex h-9 w-9 items-center justify-center rounded-full bg-sidebar-active text-sidebar-active-foreground shadow-lg transition-[background-color,scale] duration-150 ease-out hover:scale-[1.04] hover:bg-sidebar-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:opacity-90 disabled:hover:scale-100"
+                      disabled={disabled || isUploading}
+                      title="Edit avatar"
+                      type="button"
+                    >
+                      {isUploading ? (
+                        <Spinner
+                          aria-label="Uploading avatar"
+                          className="h-4 w-4 border-2"
+                        />
+                      ) : (
+                        <Pencil className="h-4 w-4" />
+                      )}
+                    </button>
+                  </PopoverTrigger>
+                  {avatarMenuContent}
+                </Popover>
+              </div>
+            </>
+          ) : (
+            <Popover open={isAvatarMenuOpen} onOpenChange={setIsAvatarMenuOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  aria-label="Add avatar"
+                  className={cn(
+                    "flex h-full w-full items-center justify-center rounded-full border-2 border-dashed border-border bg-background text-primary shadow-xs transition-[background-color,border-color,color,box-shadow] duration-150 ease-out hover:border-primary/50 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-70",
+                    isDragOverAvatar &&
+                      "border-primary/70 bg-primary/5 ring-2 ring-primary/15",
+                  )}
+                  disabled={disabled || isUploading}
+                  title="Add avatar"
+                  type="button"
+                >
+                  {isUploading ? (
+                    <Spinner
+                      aria-label="Uploading avatar"
+                      className="h-4 w-4 border-2"
+                    />
+                  ) : (
+                    <Plus aria-hidden="true" className="h-14 w-14" />
+                  )}
+                </button>
+              </PopoverTrigger>
+              {avatarMenuContent}
+            </Popover>
+          )}
         </div>
 
         {uploadErrorMessage ? (
-          <p className="absolute inset-x-3 bottom-12 rounded-md bg-background/95 px-2 py-1 text-center text-xs text-destructive shadow-xs">
+          <p className="max-w-full rounded-md bg-background/95 px-2 py-1 text-center text-xs text-destructive shadow-xs">
             {uploadErrorMessage}
           </p>
         ) : null}
-
-        <div className="absolute inset-x-3 bottom-3 flex justify-center gap-2">
-          <button
-            className="inline-flex h-8 translate-y-1 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-background/90 px-3 text-xs font-medium text-foreground opacity-0 shadow-xs transition-[background-color,opacity,transform] duration-150 hover:bg-muted focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring group-hover/avatar-preview:translate-y-0 group-hover/avatar-preview:opacity-100 group-focus-within/avatar-preview:translate-y-0 group-focus-within/avatar-preview:opacity-100"
-            disabled={disabled || isUploading}
-            onClick={() => {
-              clearUploadError();
-              openUploadPicker();
-            }}
-            type="button"
-          >
-            {isUploading ? (
-              <Spinner className="h-3.5 w-3.5 border-2" />
-            ) : (
-              <Upload className="h-3.5 w-3.5" />
-            )}
-            {isUploading ? "Uploading..." : "Edit avatar"}
-          </button>
-          {avatarUrl && onClearAvatar ? (
-            <button
-              className="inline-flex h-8 translate-y-1 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-background/90 px-3 text-xs font-medium text-foreground opacity-0 shadow-xs transition-[background-color,opacity,transform] duration-150 hover:bg-muted focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring group-hover/avatar-preview:translate-y-0 group-hover/avatar-preview:opacity-100 group-focus-within/avatar-preview:translate-y-0 group-focus-within/avatar-preview:opacity-100"
-              disabled={disabled || isUploading}
-              onClick={onClearAvatar}
-              title="Remove avatar"
-              type="button"
-            >
-              <X className="h-3.5 w-3.5" />
-              Remove
-            </button>
-          ) : null}
-        </div>
       </fieldset>
     </div>
   );

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Upload } from "lucide-react";
+import { Upload, X } from "lucide-react";
 
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
@@ -14,12 +14,14 @@ export function AgentCreationPreview({
   avatarUrl,
   disabled = false,
   label,
+  onClearAvatar,
   onUploadPendingChange,
   onSelectAvatar,
 }: {
   avatarUrl: string | null;
   disabled?: boolean;
   label: string;
+  onClearAvatar?: () => void;
   onUploadPendingChange?: (isPending: boolean) => void;
   onSelectAvatar: (avatarUrl: string) => void;
 }) {
@@ -143,7 +145,7 @@ export function AgentCreationPreview({
           </p>
         ) : null}
 
-        <div className="absolute inset-x-3 bottom-3 flex justify-center">
+        <div className="absolute inset-x-3 bottom-3 flex justify-center gap-2">
           <button
             className="inline-flex h-8 translate-y-1 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-background/90 px-3 text-xs font-medium text-foreground opacity-0 shadow-xs transition-[background-color,opacity,transform] duration-150 hover:bg-muted focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring group-hover/avatar-preview:translate-y-0 group-hover/avatar-preview:opacity-100 group-focus-within/avatar-preview:translate-y-0 group-focus-within/avatar-preview:opacity-100"
             disabled={disabled || isUploading}
@@ -160,6 +162,18 @@ export function AgentCreationPreview({
             )}
             {isUploading ? "Uploading..." : "Edit avatar"}
           </button>
+          {avatarUrl && onClearAvatar ? (
+            <button
+              className="inline-flex h-8 translate-y-1 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-background/90 px-3 text-xs font-medium text-foreground opacity-0 shadow-xs transition-[background-color,opacity,transform] duration-150 hover:bg-muted focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring group-hover/avatar-preview:translate-y-0 group-hover/avatar-preview:opacity-100 group-focus-within/avatar-preview:translate-y-0 group-focus-within/avatar-preview:opacity-100"
+              disabled={disabled || isUploading}
+              onClick={onClearAvatar}
+              title="Remove avatar"
+              type="button"
+            >
+              <X className="h-3.5 w-3.5" />
+              Remove
+            </button>
+          ) : null}
         </div>
       </fieldset>
     </div>

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -206,10 +206,7 @@ export function AgentsView() {
           isImportPending={
             personas.personaImportActions.isApplyingPersonaImportUpdate
           }
-          isPending={
-            personas.createPersonaMutation.isPending ||
-            personas.updatePersonaMutation.isPending
-          }
+          isPending={personas.isPending}
           runtimes={personas.acpRuntimesQuery.data ?? []}
           runtimesLoading={personas.acpRuntimesQuery.isLoading}
           onImportUpdateFile={

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -192,6 +192,16 @@ export function AgentsView() {
           }}
         />
       ) : null}
+      {personas.createdAgent ? (
+        <SecretRevealDialog
+          created={personas.createdAgent}
+          onOpenChange={(open) => {
+            if (!open) {
+              personas.setCreatedAgent(null);
+            }
+          }}
+        />
+      ) : null}
       {personas.personaDialogState ? (
         <PersonaDialog
           description={personas.personaDialogState.description}

--- a/desktop/src/features/agents/ui/BatchImportDialog.tsx
+++ b/desktop/src/features/agents/ui/BatchImportDialog.tsx
@@ -19,6 +19,7 @@ import {
   DialogTitle,
 } from "@/shared/ui/dialog";
 import { buildBatchImportPersonaInput } from "./batchImportPersonaInput";
+import { resolveManagedAgentAvatarUrl } from "./managedAgentAvatar";
 import { importedAvatarUrl } from "./personaDialogState";
 
 type BatchImportDialogProps = {
@@ -93,7 +94,9 @@ export function BatchImportDialog({
       });
 
       try {
-        await createPersona(buildBatchImportPersonaInput(persona));
+        const input = buildBatchImportPersonaInput(persona);
+        const avatarUrl = await resolveManagedAgentAvatarUrl(input.avatarUrl);
+        await createPersona({ ...input, avatarUrl });
         completed += 1;
         setImportedCount(completed);
         setItemStatuses((prev) => {

--- a/desktop/src/features/agents/ui/BatchImportDialog.tsx
+++ b/desktop/src/features/agents/ui/BatchImportDialog.tsx
@@ -173,7 +173,7 @@ export function BatchImportDialog({
                         onClick={(e: React.MouseEvent) => e.stopPropagation()}
                       />
                       <ProfileAvatar
-                        avatarUrl={persona.avatarDataUrl}
+                        avatarUrl={persona.avatarDataUrl ?? persona.avatarRef}
                         className="h-8 w-8 rounded-lg text-xs"
                         label={persona.displayName}
                       />

--- a/desktop/src/features/agents/ui/BatchImportDialog.tsx
+++ b/desktop/src/features/agents/ui/BatchImportDialog.tsx
@@ -19,6 +19,7 @@ import {
   DialogTitle,
 } from "@/shared/ui/dialog";
 import { buildBatchImportPersonaInput } from "./batchImportPersonaInput";
+import { importedAvatarUrl } from "./personaDialogState";
 
 type BatchImportDialogProps = {
   fileName: string;
@@ -143,6 +144,7 @@ export function BatchImportDialog({
                   .trim()
                   .split("\n")
                   .find((line) => line.trim().length > 0);
+                const avatarUrl = importedAvatarUrl(persona);
 
                 return (
                   <div
@@ -173,7 +175,7 @@ export function BatchImportDialog({
                         onClick={(e: React.MouseEvent) => e.stopPropagation()}
                       />
                       <ProfileAvatar
-                        avatarUrl={persona.avatarDataUrl ?? persona.avatarRef}
+                        avatarUrl={avatarUrl}
                         className="h-8 w-8 rounded-lg text-xs"
                         label={persona.displayName}
                       />

--- a/desktop/src/features/agents/ui/EnvVarsEditor.tsx
+++ b/desktop/src/features/agents/ui/EnvVarsEditor.tsx
@@ -3,6 +3,11 @@ import * as React from "react";
 
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
+import { cn } from "@/shared/lib/cn";
+import {
+  PERSONA_FIELD_CONTROL_CLASS,
+  PERSONA_FIELD_SHELL_CLASS,
+} from "./personaDialogPickers";
 
 export type EnvVarsValue = Record<string, string>;
 
@@ -98,28 +103,48 @@ export function EnvVarsEditor({
           return (
             <div key={row.id} className="space-y-1">
               <div className="flex items-center gap-2">
-                <Input
-                  aria-label="Variable name"
-                  className="flex-1 font-mono text-xs"
-                  data-testid="env-vars-key"
-                  disabled={disabled}
-                  onChange={(event) =>
-                    updateRow(row.id, { key: event.target.value })
-                  }
-                  placeholder="ANTHROPIC_API_KEY"
-                  value={row.key}
-                />
-                <Input
-                  aria-label="Variable value"
-                  className="flex-[2] font-mono text-xs"
-                  data-testid="env-vars-value"
-                  disabled={disabled}
-                  onChange={(event) =>
-                    updateRow(row.id, { value: event.target.value })
-                  }
-                  placeholder="sk-ant-..."
-                  value={row.value}
-                />
+                <div
+                  className={cn(
+                    "flex min-h-11 flex-1 items-center px-3",
+                    PERSONA_FIELD_SHELL_CLASS,
+                  )}
+                >
+                  <Input
+                    aria-label="Variable name"
+                    className={cn(
+                      "h-8 px-0 py-0 font-mono leading-6",
+                      PERSONA_FIELD_CONTROL_CLASS,
+                    )}
+                    data-testid="env-vars-key"
+                    disabled={disabled}
+                    onChange={(event) =>
+                      updateRow(row.id, { key: event.target.value })
+                    }
+                    placeholder="VARIABLE_NAME"
+                    value={row.key}
+                  />
+                </div>
+                <div
+                  className={cn(
+                    "flex min-h-11 flex-[2] items-center px-3",
+                    PERSONA_FIELD_SHELL_CLASS,
+                  )}
+                >
+                  <Input
+                    aria-label="Variable value"
+                    className={cn(
+                      "h-8 px-0 py-0 font-mono leading-6",
+                      PERSONA_FIELD_CONTROL_CLASS,
+                    )}
+                    data-testid="env-vars-value"
+                    disabled={disabled}
+                    onChange={(event) =>
+                      updateRow(row.id, { value: event.target.value })
+                    }
+                    placeholder="value"
+                    value={row.value}
+                  />
+                </div>
                 <Button
                   aria-label="Remove variable"
                   data-testid="env-vars-remove"

--- a/desktop/src/features/agents/ui/PersonaAdvancedFields.tsx
+++ b/desktop/src/features/agents/ui/PersonaAdvancedFields.tsx
@@ -1,0 +1,65 @@
+import { Input } from "@/shared/ui/input";
+import { cn } from "@/shared/lib/cn";
+import { EnvVarsEditor, type EnvVarsValue } from "./EnvVarsEditor";
+import {
+  PERSONA_FIELD_CONTROL_CLASS,
+  PERSONA_FIELD_SHELL_CLASS,
+} from "./personaDialogPickers";
+
+const PERSONA_LABEL_OPTIONAL_CLASS =
+  "ml-1 text-xs font-normal text-muted-foreground/50";
+
+export function PersonaAdvancedFields({
+  disabled,
+  envVars,
+  namePoolText,
+  onEnvVarsChange,
+  onNamePoolTextChange,
+}: {
+  disabled: boolean;
+  envVars: EnvVarsValue;
+  namePoolText: string;
+  onEnvVarsChange: (value: EnvVarsValue) => void;
+  onNamePoolTextChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-5 pt-2">
+      <div className="space-y-1.5">
+        <label
+          className="text-sm font-medium text-foreground"
+          htmlFor="persona-name-pool"
+        >
+          Instance name pool
+          <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
+        </label>
+        <div
+          className={cn(
+            "flex min-h-11 items-center px-3",
+            PERSONA_FIELD_SHELL_CLASS,
+          )}
+        >
+          <Input
+            autoCapitalize="words"
+            autoCorrect="off"
+            className={cn(
+              "h-8 px-0 py-0 leading-6",
+              PERSONA_FIELD_CONTROL_CLASS,
+            )}
+            disabled={disabled}
+            id="persona-name-pool"
+            onChange={(event) => onNamePoolTextChange(event.target.value)}
+            placeholder="Birch, Compass, Ridge, Thistle"
+            spellCheck={false}
+            value={namePoolText}
+          />
+        </div>
+      </div>
+
+      <EnvVarsEditor
+        disabled={disabled}
+        onChange={onEnvVarsChange}
+        value={envVars}
+      />
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -53,6 +53,7 @@ import {
   PERSONA_FIELD_SHELL_CLASS,
   PERSONA_LABEL_OPTIONAL_CLASS,
   shouldClearKnownModelForSelectionScope,
+  sortPersonaRuntimes,
 } from "./personaDialogPickers";
 import { shouldClearModelForRuntimeChange } from "./personaRuntimeModel";
 import {
@@ -480,6 +481,10 @@ export function PersonaDialog({
     providerApiKeyConfig?.envVar ?? null,
   );
   const runtimeDropdownValue = runtime.trim() || NO_RUNTIME_DROPDOWN_VALUE;
+  const sortedRuntimes = React.useMemo(
+    () => sortPersonaRuntimes(runtimes),
+    [runtimes],
+  );
   const blankRuntimeOptionLabel = runtimesLoading
     ? "Loading providers..."
     : isCreateMode
@@ -494,7 +499,7 @@ export function PersonaDialog({
           },
         ]
       : []),
-    ...runtimes.map((candidate) => ({
+    ...sortedRuntimes.map((candidate) => ({
       disabled: isCreateMode && candidate.availability !== "available",
       label: `${formatRuntimeOptionLabel(candidate)}${
         isCreateMode && candidate.id === defaultRuntime?.id ? " (default)" : ""

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -556,6 +556,7 @@ export function PersonaDialog({
             avatarUrl={previewAvatarUrl}
             disabled={isPending || isAvatarUploadPending}
             label={previewLabel}
+            onClearAvatar={() => setAvatarUrl("")}
             onUploadPendingChange={setIsAvatarUploadPending}
             onSelectAvatar={setAvatarUrl}
           />

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -398,15 +398,18 @@ export function PersonaDialog({
     (!isCreateMode || runtime.trim().length > 0) &&
     (!isCreateMode || selectedRuntimeIsAvailable) &&
     !isAvatarUploadPending;
-  const { discoveredModelOptions, modelDiscoveryLoading } =
-    usePersonaModelDiscovery({
-      envVars,
-      isCustomProviderEditing,
-      modelFieldVisible,
-      open,
-      provider,
-      selectedRuntime,
-    });
+  const {
+    discoveredModelOptions,
+    modelDiscoveryLoading,
+    modelDiscoveryStatus,
+  } = usePersonaModelDiscovery({
+    envVars,
+    isCustomProviderEditing,
+    modelFieldVisible,
+    open,
+    provider,
+    selectedRuntime,
+  });
   const staticModelOptions = getPersonaModelOptions(runtime, provider);
   const runtimeModelOptions = getRuntimePersonaModelOptions(runtime);
   const modelOptions = discoveredModelOptions ?? staticModelOptions;
@@ -832,6 +835,20 @@ export function PersonaDialog({
                           value={model}
                         />
                       </div>
+                    ) : null}
+                    {modelDiscoveryStatus ? (
+                      <p
+                        aria-live="polite"
+                        className={cn(
+                          "text-xs",
+                          modelDiscoveryStatus.tone === "warning"
+                            ? "text-warning"
+                            : "text-muted-foreground",
+                        )}
+                        data-testid="persona-model-discovery-status"
+                      >
+                        {modelDiscoveryStatus.message}
+                      </p>
                     ) : null}
                   </div>
                 </motion.div>

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -16,7 +16,9 @@ import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
 import { AgentCreationPreview } from "./AgentCreationPreview";
 import { PersonaDropdownField } from "./PersonaDropdownField";
-import { EnvVarsEditor, type EnvVarsValue } from "./EnvVarsEditor";
+import type { EnvVarsValue } from "./EnvVarsEditor";
+import { PersonaAdvancedFields } from "./PersonaAdvancedFields";
+import { PersonaProviderApiKeyField } from "./PersonaProviderApiKeyField";
 import {
   getImportButtonLabel,
   getImportButtonTone,
@@ -38,6 +40,7 @@ import {
   getModelSelectValue,
   getPersonaModelOptions,
   getPersonaProviderOptions,
+  getProviderApiKeyConfig,
   getProviderApiKeyEnvVar,
   getRuntimePersonaModelOptions,
   hasPersonaModelOption,
@@ -82,6 +85,26 @@ const ADVANCED_FIELDS_MOTION_TRANSITION = {
 
 function hasText(value: string | null | undefined): boolean {
   return (value?.trim().length ?? 0) > 0;
+}
+
+function hasAdvancedEnvVars(
+  value: EnvVarsValue,
+  managedKey: string | null,
+): boolean {
+  return Object.keys(value).some((key) => key !== managedKey);
+}
+
+function getAdvancedEnvVars(
+  value: EnvVarsValue,
+  managedKey: string | null,
+): EnvVarsValue {
+  if (!managedKey || !(managedKey in value)) {
+    return value;
+  }
+
+  const next = { ...value };
+  delete next[managedKey];
+  return next;
 }
 
 export function PersonaDialog({
@@ -155,10 +178,14 @@ export function PersonaDialog({
         : "";
     const nextEnvVars =
       "envVars" in initialValues ? (initialValues.envVars ?? {}) : {};
+    const managedApiKeyEnvVar = getProviderApiKeyEnvVar(
+      initialValues.provider ?? "",
+    );
     setNamePoolText(nextNamePoolText);
     setEnvVars(nextEnvVars);
     setShowAdvancedFields(
-      nextNamePoolText.trim().length > 0 || Object.keys(nextEnvVars).length > 0,
+      nextNamePoolText.trim().length > 0 ||
+        hasAdvancedEnvVars(nextEnvVars, managedApiKeyEnvVar),
     );
     setIsAvatarUploadPending(false);
     setImportErrorMessage(null);
@@ -389,7 +416,18 @@ export function PersonaDialog({
     initialModelProviderEditableWithoutRuntime && runtime.trim().length === 0;
   const llmProviderFieldVisible =
     runtime.trim().length > 0 || blankRuntimeModelProviderEditable;
-  const modelFieldVisible = llmProviderFieldVisible;
+  const trimmedProvider = provider.trim();
+  const providerApiKeyConfig = isCustomProviderEditing
+    ? null
+    : getProviderApiKeyConfig(trimmedProvider);
+  const providerApiKeyValue = providerApiKeyConfig
+    ? (envVars[providerApiKeyConfig.envVar] ?? "")
+    : "";
+  const providerApiKeyFieldVisible =
+    llmProviderFieldVisible && providerApiKeyConfig !== null;
+  const modelFieldVisible =
+    llmProviderFieldVisible &&
+    (!providerApiKeyFieldVisible || providerApiKeyValue.trim().length > 0);
   const isCreateMode = Boolean(initialValues && !("id" in initialValues));
   const selectedRuntimeIsAvailable =
     runtime.trim().length === 0 ||
@@ -426,12 +464,15 @@ export function PersonaDialog({
   const showCustomModelInput =
     modelFieldVisible && (isCustomModelEditing || isModelCustom);
   const providerOptions = getPersonaProviderOptions(provider);
-  const trimmedProvider = provider.trim();
   const providerSelectValue = isCustomProviderEditing
     ? CUSTOM_PROVIDER_DROPDOWN_VALUE
     : trimmedProvider || AUTO_PROVIDER_DROPDOWN_VALUE;
   const showCustomProviderInput =
     llmProviderFieldVisible && isCustomProviderEditing;
+  const advancedEnvVars = getAdvancedEnvVars(
+    envVars,
+    providerApiKeyConfig?.envVar ?? null,
+  );
   const runtimeDropdownValue = runtime.trim() || NO_RUNTIME_DROPDOWN_VALUE;
   const blankRuntimeOptionLabel = runtimesLoading
     ? "Loading providers..."
@@ -518,15 +559,40 @@ export function PersonaDialog({
     setIsCustomModelEditing(false);
   }, [isCustomModelEditing, model, modelFieldVisible, open, provider, runtime]);
 
-  function showProviderEnvVar(envKey: string) {
-    setShowAdvancedFields(true);
+  function updateProviderApiKey(envKey: string, value: string) {
     setEnvVars((current) => {
-      if (Object.keys(current).includes(envKey)) {
+      if ((current[envKey] ?? "") === value) {
         return current;
       }
+
+      const next = { ...current };
+      if (value.length > 0) {
+        next[envKey] = value;
+      } else {
+        delete next[envKey];
+      }
+      return next;
+    });
+  }
+
+  function handleProviderApiKeyChange(value: string) {
+    if (!providerApiKeyConfig) {
+      return;
+    }
+
+    updateProviderApiKey(providerApiKeyConfig.envVar, value);
+  }
+
+  function handleAdvancedEnvVarsChange(nextAdvancedEnvVars: EnvVarsValue) {
+    setEnvVars((current) => {
+      const managedEnvVar = providerApiKeyConfig?.envVar ?? null;
+      if (!managedEnvVar || !(managedEnvVar in current)) {
+        return nextAdvancedEnvVars;
+      }
+
       return {
-        ...current,
-        [envKey]: "",
+        ...nextAdvancedEnvVars,
+        [managedEnvVar]: current[managedEnvVar],
       };
     });
   }
@@ -566,8 +632,9 @@ export function PersonaDialog({
     setIsCustomProviderEditing(false);
     setProvider(nextProvider);
     const requiredEnvVar = getProviderApiKeyEnvVar(nextProvider);
-    if (requiredEnvVar) {
-      showProviderEnvVar(requiredEnvVar);
+    if (requiredEnvVar && !envVars[requiredEnvVar]?.trim()) {
+      setModel("");
+      setIsCustomModelEditing(false);
     }
     if (
       !isCustomModelEditing &&
@@ -801,6 +868,14 @@ export function PersonaDialog({
                     />
                   </div>
                 ) : null}
+                {providerApiKeyFieldVisible && providerApiKeyConfig ? (
+                  <PersonaProviderApiKeyField
+                    config={providerApiKeyConfig}
+                    disabled={isPending}
+                    onChange={handleProviderApiKeyChange}
+                    value={providerApiKeyValue}
+                  />
+                ) : null}
               </div>
             ) : null}
 
@@ -899,48 +974,13 @@ export function PersonaDialog({
                     key="persona-advanced-fields"
                     transition={advancedFieldsTransition}
                   >
-                    <div className="space-y-5 pt-2">
-                      <div className="space-y-1.5">
-                        <label
-                          className="text-sm font-medium text-foreground"
-                          htmlFor="persona-name-pool"
-                        >
-                          Instance name pool
-                          <span className={PERSONA_LABEL_OPTIONAL_CLASS}>
-                            Optional
-                          </span>
-                        </label>
-                        <div
-                          className={cn(
-                            "flex min-h-11 items-center px-3",
-                            PERSONA_FIELD_SHELL_CLASS,
-                          )}
-                        >
-                          <Input
-                            autoCapitalize="words"
-                            autoCorrect="off"
-                            className={cn(
-                              "h-8 px-0 py-0 leading-6",
-                              PERSONA_FIELD_CONTROL_CLASS,
-                            )}
-                            disabled={isPending}
-                            id="persona-name-pool"
-                            onChange={(event) =>
-                              setNamePoolText(event.target.value)
-                            }
-                            placeholder="Birch, Compass, Ridge, Thistle"
-                            spellCheck={false}
-                            value={namePoolText}
-                          />
-                        </div>
-                      </div>
-
-                      <EnvVarsEditor
-                        disabled={isPending}
-                        onChange={setEnvVars}
-                        value={envVars}
-                      />
-                    </div>
+                    <PersonaAdvancedFields
+                      disabled={isPending}
+                      envVars={advancedEnvVars}
+                      namePoolText={namePoolText}
+                      onEnvVarsChange={handleAdvancedEnvVarsChange}
+                      onNamePoolTextChange={setNamePoolText}
+                    />
                   </motion.div>
                 ) : null}
               </AnimatePresence>

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -503,11 +503,6 @@ export function PersonaDialog({
       nextValue === AUTO_PROVIDER_DROPDOWN_VALUE ? "" : nextValue;
     setIsCustomProviderEditing(false);
     setProvider(nextProvider);
-    if (nextProvider.trim().length === 0) {
-      setModel("");
-      setIsCustomModelEditing(false);
-      return;
-    }
     if (
       !isCustomModelEditing &&
       shouldClearKnownModelForSelectionScope({

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -75,6 +75,10 @@ const ADVANCED_FIELDS_MOTION_TRANSITION = {
   ease: [0.23, 1, 0.32, 1],
 } as const;
 
+function hasText(value: string | null | undefined): boolean {
+  return (value?.trim().length ?? 0) > 0;
+}
+
 export function PersonaDialog({
   open,
   title,
@@ -120,6 +124,12 @@ export function PersonaDialog({
     [runtimes],
   );
   const shouldReduceMotion = useReducedMotion();
+  const initialModelProviderEditableWithoutRuntime = Boolean(
+    initialValues &&
+      "id" in initialValues &&
+      !hasText(initialValues.runtime) &&
+      (hasText(initialValues.model) || hasText(initialValues.provider)),
+  );
 
   React.useEffect(() => {
     if (!open || !initialValues) {
@@ -307,10 +317,13 @@ export function PersonaDialog({
 
     const trimmedRuntime = runtime.trim();
     const previousRuntime = initialValues.runtime?.trim() ?? "";
+    const modelProviderEditableWithoutRuntime =
+      initialModelProviderEditableWithoutRuntime && trimmedRuntime.length === 0;
     const shouldPreserveHiddenModelProvider =
       "id" in initialValues &&
       previousRuntime.length === 0 &&
-      trimmedRuntime.length === 0;
+      trimmedRuntime.length === 0 &&
+      !modelProviderEditableWithoutRuntime;
     const namePool = parsePersonaNamePoolText(namePoolText);
     const namePoolInput =
       namePool.length > 0
@@ -323,16 +336,18 @@ export function PersonaDialog({
       avatarUrl: avatarUrl.trim() || undefined,
       systemPrompt: systemPrompt.trim(),
       runtime: trimmedRuntime || undefined,
-      model: trimmedRuntime
-        ? model.trim() || undefined
-        : shouldPreserveHiddenModelProvider
-          ? initialValues.model
-          : undefined,
-      provider: trimmedRuntime
-        ? provider.trim() || undefined
-        : shouldPreserveHiddenModelProvider
-          ? initialValues.provider
-          : undefined,
+      model:
+        trimmedRuntime || modelProviderEditableWithoutRuntime
+          ? model.trim() || undefined
+          : shouldPreserveHiddenModelProvider
+            ? initialValues.model
+            : undefined,
+      provider:
+        trimmedRuntime || modelProviderEditableWithoutRuntime
+          ? provider.trim() || undefined
+          : shouldPreserveHiddenModelProvider
+            ? initialValues.provider
+            : undefined,
       namePool: namePoolInput,
       envVars,
     };
@@ -365,7 +380,10 @@ export function PersonaDialog({
   });
 
   const selectedRuntime = runtimes.find((p) => p.id === runtime);
-  const llmProviderFieldVisible = runtime.trim().length > 0;
+  const blankRuntimeModelProviderEditable =
+    initialModelProviderEditableWithoutRuntime && runtime.trim().length === 0;
+  const llmProviderFieldVisible =
+    runtime.trim().length > 0 || blankRuntimeModelProviderEditable;
   const modelFieldVisible = llmProviderFieldVisible;
   const isCreateMode = Boolean(initialValues && !("id" in initialValues));
   const selectedRuntimeIsAvailable =

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -470,7 +470,7 @@ export function PersonaDialog({
   const showCustomModelInput =
     modelFieldVisible && (isCustomModelEditing || isModelCustom);
   const providerOptions = getPersonaProviderOptions(provider, runtime);
-  const defaultLlmProviderLabel = getDefaultLlmProviderLabel(runtime);
+  const defaultLlmProviderLabel = getDefaultLlmProviderLabel();
   const providerSelectValue = isCustomProviderEditing
     ? CUSTOM_PROVIDER_DROPDOWN_VALUE
     : trimmedProvider || AUTO_PROVIDER_DROPDOWN_VALUE;

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { RefreshCw, Upload } from "lucide-react";
 
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
 import type {
   AcpRuntimeCatalogEntry,
   CreatePersonaInput,
@@ -9,14 +11,10 @@ import type {
 import { useFileImportZone } from "@/shared/hooks/useFileImportZone";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/shared/ui/dialog";
+import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
+import { Dialog } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
+import { Spinner } from "@/shared/ui/spinner";
 import { Textarea } from "@/shared/ui/textarea";
 import { EnvVarsEditor, type EnvVarsValue } from "./EnvVarsEditor";
 import {
@@ -26,6 +24,7 @@ import {
   IMPORT_ERROR_VISIBILITY_MS,
 } from "./personaDialogImportState";
 import { canSubmitPersonaDialog } from "./personaDialogState";
+import { shouldClearModelForRuntimeChange } from "./personaRuntimeModel";
 
 type PersonaDialogProps = {
   open: boolean;
@@ -46,6 +45,106 @@ type PersonaDialogProps = {
     fileName: string,
   ) => Promise<void>;
 };
+
+const PERSONA_FIELD_SHELL_CLASS =
+  "rounded-xl border border-input bg-muted/40 transition-colors duration-150 ease-out hover:border-muted-foreground/40 focus-within:border-muted-foreground/50";
+const PERSONA_FIELD_CONTROL_CLASS =
+  "border-0 bg-transparent text-muted-foreground shadow-none outline-none ring-0 transition-colors duration-150 ease-out placeholder:text-muted-foreground/55 focus:bg-transparent focus:text-muted-foreground focus:outline-hidden focus-visible:ring-0";
+const PERSONA_LABEL_OPTIONAL_CLASS =
+  "ml-1 text-xs font-normal text-muted-foreground/50";
+const AUTO_MODEL_DROPDOWN_VALUE = "__auto_model__";
+const AUTO_PROVIDER_DROPDOWN_VALUE = "__auto_provider__";
+
+type PersonaModelOption = {
+  id: string;
+  label: string;
+};
+
+const AUTO_MODEL_OPTION: PersonaModelOption = {
+  id: "",
+  label: "Auto (provider default)",
+};
+
+const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
+  { id: "", label: "Auto (runtime default)" },
+  { id: "anthropic", label: "Anthropic" },
+  { id: "openai", label: "OpenAI" },
+  { id: "openai-compat", label: "OpenAI-compatible" },
+  { id: "databricks", label: "Databricks" },
+];
+
+const PERSONA_MODEL_OPTIONS_BY_RUNTIME: Record<
+  string,
+  readonly PersonaModelOption[]
+> = {
+  goose: [
+    AUTO_MODEL_OPTION,
+    { id: "goose-claude-4-6-opus", label: "Claude Opus 4.6" },
+    { id: "goose-claude-4-6-sonnet", label: "Claude Sonnet 4.6" },
+    { id: "gpt-5", label: "GPT-5" },
+    { id: "gpt-5-mini", label: "GPT-5 mini" },
+    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+  ],
+  "buzz-agent": [
+    AUTO_MODEL_OPTION,
+    { id: "goose-claude-4-6-opus", label: "Claude Opus 4.6" },
+    { id: "goose-claude-4-6-sonnet", label: "Claude Sonnet 4.6" },
+    { id: "gpt-5", label: "GPT-5" },
+    { id: "gpt-5-mini", label: "GPT-5 mini" },
+    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+  ],
+  claude: [AUTO_MODEL_OPTION],
+  codex: [AUTO_MODEL_OPTION],
+};
+
+function getPersonaModelOptions(
+  runtimeId: string,
+  currentModel: string,
+): readonly PersonaModelOption[] {
+  const options = PERSONA_MODEL_OPTIONS_BY_RUNTIME[runtimeId] ?? [
+    AUTO_MODEL_OPTION,
+  ];
+  const trimmedModel = currentModel.trim();
+  if (
+    trimmedModel.length === 0 ||
+    options.some((option) => option.id === trimmedModel)
+  ) {
+    return options;
+  }
+
+  return [...options, { id: trimmedModel, label: `${trimmedModel} (current)` }];
+}
+
+function getPersonaProviderOptions(
+  currentProvider: string,
+): readonly PersonaModelOption[] {
+  const trimmedProvider = currentProvider.trim();
+  if (
+    trimmedProvider.length === 0 ||
+    PERSONA_LLM_PROVIDER_OPTIONS.some((option) => option.id === trimmedProvider)
+  ) {
+    return PERSONA_LLM_PROVIDER_OPTIONS;
+  }
+
+  return [
+    ...PERSONA_LLM_PROVIDER_OPTIONS,
+    { id: trimmedProvider, label: `${trimmedProvider} (current)` },
+  ];
+}
+
+function formatRuntimeOptionLabel(runtime: AcpRuntimeCatalogEntry) {
+  const suffix =
+    runtime.availability === "adapter_missing"
+      ? " (adapter missing)"
+      : runtime.availability === "cli_missing"
+        ? " (CLI missing)"
+        : runtime.availability === "not_installed"
+          ? " (not installed)"
+          : "";
+  return `${runtime.label}${suffix}`;
+}
 
 export function PersonaDialog({
   open,
@@ -68,7 +167,6 @@ export function PersonaDialog({
   const [runtime, setRuntime] = React.useState("");
   const [model, setModel] = React.useState("");
   const [provider, setProvider] = React.useState("");
-  const [namePoolText, setNamePoolText] = React.useState("");
   const [envVars, setEnvVars] = React.useState<EnvVarsValue>({});
   const [isImportingUpdate, setIsImportingUpdate] = React.useState(false);
   const [importErrorMessage, setImportErrorMessage] = React.useState<
@@ -93,13 +191,7 @@ export function PersonaDialog({
     setRuntime(initialValues.runtime ?? "");
     setModel(initialValues.model ?? "");
     setProvider(initialValues.provider ?? "");
-    setNamePoolText(
-      ("namePool" in initialValues
-        ? (initialValues as { namePool?: string[] }).namePool
-        : undefined
-      )?.join(", ") ?? "",
-    );
-    setEnvVars(initialValues.envVars ?? {});
+    setEnvVars("envVars" in initialValues ? (initialValues.envVars ?? {}) : {});
     setImportErrorMessage(null);
     setIsImportingUpdate(false);
   }, [initialValues, open]);
@@ -220,7 +312,7 @@ export function PersonaDialog({
       setRuntime("");
       setModel("");
       setProvider("");
-      setNamePoolText("");
+      setEnvVars({});
       setImportErrorMessage(null);
       setIsImportingUpdate(false);
       setIsWindowFileDragOver(false);
@@ -230,22 +322,24 @@ export function PersonaDialog({
   }
 
   async function handleSubmit() {
-    if (!initialValues) {
+    if (
+      !initialValues ||
+      !canSubmitPersonaDialog({ displayName, isPending })
+    ) {
       return;
     }
 
-    const namePool = namePoolText
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
+    const trimmedRuntime = runtime.trim();
+    const preservedNamePool =
+      "namePool" in initialValues ? initialValues.namePool : undefined;
     const baseInput = {
-      displayName,
+      displayName: displayName.trim(),
       avatarUrl: avatarUrl.trim() || undefined,
-      systemPrompt,
-      runtime: runtime.trim() || undefined,
+      systemPrompt: systemPrompt.trim(),
+      runtime: trimmedRuntime || undefined,
       model: model.trim() || undefined,
       provider: provider.trim() || undefined,
-      namePool: namePool.length > 0 ? namePool : undefined,
+      namePool: preservedNamePool,
       envVars,
     };
 
@@ -260,6 +354,11 @@ export function PersonaDialog({
     await onSubmit(baseInput);
   }
 
+  function handleSubmitForm(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void handleSubmit();
+  }
+
   const importButtonTone = getImportButtonTone({
     isWindowFileDragOver,
     isImportDragOver,
@@ -272,6 +371,30 @@ export function PersonaDialog({
   });
 
   const selectedRuntime = runtimes.find((p) => p.id === runtime);
+  const modelFieldVisible = runtime.trim().length > 0;
+  const isCreateMode = Boolean(initialValues && !("id" in initialValues));
+  const selectedRuntimeIsAvailable =
+    runtime.trim().length === 0 ||
+    selectedRuntime?.availability === "available";
+  const canSubmit =
+    canSubmitPersonaDialog({ displayName, isPending }) &&
+    (!isCreateMode || runtime.trim().length > 0) &&
+    (!isCreateMode || selectedRuntimeIsAvailable);
+  const modelOptions = getPersonaModelOptions(runtime, model);
+  const providerOptions = getPersonaProviderOptions(provider);
+  const selectedRuntimeLabel = runtimesLoading
+    ? "Loading providers..."
+    : (selectedRuntime?.label ?? "Choose a provider");
+  const selectedModelLabel =
+    modelOptions.find((option) => option.id === model)?.label ??
+    AUTO_MODEL_OPTION.label;
+  const selectedProviderLabel =
+    providerOptions.find((option) => option.id === provider)?.label ??
+    (provider.trim()
+      ? `${provider.trim()} (current)`
+      : "Auto (runtime default)");
+  const previewLabel = displayName.trim() || "Agent name";
+  const previewAvatarUrl = avatarUrl.trim() || null;
   const runtimeWarning =
     selectedRuntime && selectedRuntime.availability !== "available" ? (
       <p className="text-xs text-warning">
@@ -285,191 +408,24 @@ export function PersonaDialog({
     ) : null;
 
   return (
-    <Dialog onOpenChange={handleOpenChange} open={open}>
-      <DialogContent className="max-w-2xl overflow-hidden p-0">
-        <div className="flex max-h-[85vh] flex-col">
-          <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
-            <DialogTitle>{title}</DialogTitle>
-            {description.trim().length > 0 ? (
-              <DialogDescription>{description}</DialogDescription>
-            ) : null}
-          </DialogHeader>
-
-          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-5">
-            <div className="space-y-1.5">
-              <label
-                className="text-sm font-medium"
-                htmlFor="persona-display-name"
-              >
-                Display name
-              </label>
-              <Input
-                autoCorrect="off"
-                disabled={isPending}
-                id="persona-display-name"
-                onChange={(event) => setDisplayName(event.target.value)}
-                placeholder="Researcher"
-                value={displayName}
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <label
-                className="text-sm font-medium"
-                htmlFor="persona-avatar-url"
-              >
-                Avatar URL
-              </label>
-              <Input
-                autoCapitalize="none"
-                autoCorrect="off"
-                disabled={isPending}
-                id="persona-avatar-url"
-                onChange={(event) => setAvatarUrl(event.target.value)}
-                placeholder="https://example.com/avatar.png"
-                spellCheck={false}
-                value={avatarUrl}
-              />
-              <p className="text-xs text-muted-foreground">
-                Optional. Deployed agents fall back to the runtime avatar if
-                this is blank.
-              </p>
-            </div>
-
-            <div className="space-y-1.5">
-              <label
-                className="text-sm font-medium"
-                htmlFor="persona-system-prompt"
-              >
-                System prompt
-              </label>
-              <Textarea
-                className="min-h-40"
-                disabled={isPending}
-                id="persona-system-prompt"
-                onChange={(event) => setSystemPrompt(event.target.value)}
-                placeholder="Describe what this persona should do."
-                value={systemPrompt}
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium" htmlFor="persona-runtime">
-                Preferred runtime
-              </label>
-              <select
-                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs"
-                disabled={isPending || runtimesLoading}
-                id="persona-runtime"
-                onChange={(event) => setRuntime(event.target.value)}
-                value={runtime}
-              >
-                <option value="">
-                  {runtimesLoading
-                    ? "Loading runtimes..."
-                    : "No preference (use default)"}
-                </option>
-                {runtimes.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.label}
-                    {p.availability === "adapter_missing"
-                      ? " (adapter missing)"
-                      : p.availability === "cli_missing"
-                        ? " (CLI missing)"
-                        : p.availability === "not_installed"
-                          ? " (not installed)"
-                          : ""}
-                  </option>
-                ))}
-              </select>
-              <p className="text-xs text-muted-foreground">
-                Optional. When deploying this persona, the selected runtime will
-                be pre-selected. Unavailable runtimes can be installed from
-                Settings &gt; Doctor.
-              </p>
-              {runtimeWarning}
-            </div>
-
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium" htmlFor="persona-model">
-                Preferred model
-              </label>
-              <Input
-                autoCapitalize="none"
-                autoCorrect="off"
-                disabled={isPending}
-                id="persona-model"
-                onChange={(event) => setModel(event.target.value)}
-                placeholder="e.g. gpt-4o, claude-sonnet-4-20250514"
-                spellCheck={false}
-                value={model}
-              />
-              <p className="text-xs text-muted-foreground">
-                Optional. Passed to the agent at creation time. Leave blank to
-                use the runtime default.
-              </p>
-            </div>
-
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium" htmlFor="persona-provider">
-                LLM Provider
-              </label>
-              <Input
-                autoCapitalize="none"
-                autoCorrect="off"
-                disabled={isPending}
-                id="persona-provider"
-                onChange={(event) => setProvider(event.target.value)}
-                placeholder="e.g. databricks, anthropic, openai"
-                spellCheck={false}
-                value={provider}
-              />
-              <p className="text-xs text-muted-foreground">
-                Optional. Injected as the runtime's provider env var at agent
-                creation time. Leave blank for auto-detection or provider-locked
-                runtimes.
-              </p>
-            </div>
-
-            <div className="space-y-1.5">
-              <label
-                className="text-sm font-medium"
-                htmlFor="persona-name-pool"
-              >
-                Instance name pool
-              </label>
-              <Input
-                autoCapitalize="none"
-                autoCorrect="off"
-                disabled={isPending}
-                id="persona-name-pool"
-                onChange={(event) => setNamePoolText(event.target.value)}
-                placeholder="Birch, Compass, Ridge, Thistle, ..."
-                spellCheck={false}
-                value={namePoolText}
-              />
-              <p className="text-xs text-muted-foreground">
-                Comma-separated names for bot copies. Each instance gets a
-                random name from this pool. Leave empty to use generic defaults.
-              </p>
-            </div>
-
-            <EnvVarsEditor
-              disabled={isPending}
-              helperText="Injected when agents created from this persona spawn. Per-agent overrides can replace these."
-              onChange={setEnvVars}
-              value={envVars}
-            />
-
-            {error ? (
-              <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                {error.message}
-              </p>
-            ) : null}
-          </div>
-
-          <div className="flex shrink-0 items-center justify-between gap-3 border-t border-border/60 px-6 py-4">
-            <div className="flex min-h-8 items-center">
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && isPending) return;
+        handleOpenChange(nextOpen);
+      }}
+      open={open}
+    >
+      <ChooserDialogContent
+        className="max-w-3xl border-0"
+        contentClassName="pt-3"
+        data-testid="persona-dialog"
+        description={description}
+        footerClassName="border-t-0 pt-0"
+        headerClassName="pb-2"
+        title={title}
+        footer={
+          <div className="flex w-full items-center justify-between gap-3">
+            <div className="flex min-h-9 items-center">
               {canImportPersonaUpdate ? (
                 <>
                   <input
@@ -481,7 +437,7 @@ export function PersonaDialog({
                   />
                   <button
                     className={cn(
-                      "inline-flex h-8 items-center gap-2 rounded-md border px-3 text-xs font-medium transition-colors",
+                      "inline-flex h-9 items-center gap-2 rounded-md border px-3 text-xs font-medium transition-colors",
                       importButtonTone === "drag"
                         ? "border-dashed border-primary/70 bg-primary/10 text-primary"
                         : importButtonTone === "error"
@@ -512,25 +468,424 @@ export function PersonaDialog({
 
             <div className="flex items-center gap-2">
               <Button
+                disabled={isPending}
                 onClick={() => handleOpenChange(false)}
-                size="sm"
                 type="button"
                 variant="outline"
               >
                 Cancel
               </Button>
               <Button
-                disabled={!canSubmitPersonaDialog({ displayName, isPending })}
-                onClick={() => void handleSubmit()}
-                size="sm"
-                type="button"
+                data-testid="persona-dialog-submit"
+                disabled={!canSubmit}
+                form="persona-dialog-form"
+                type="submit"
               >
                 {isPending ? "Saving..." : submitLabel}
               </Button>
             </div>
           </div>
-        </div>
-      </DialogContent>
+        }
+      >
+        <form
+          className="grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]"
+          id="persona-dialog-form"
+          onSubmit={handleSubmitForm}
+        >
+          <AgentCreationPreview
+            avatarUrl={previewAvatarUrl}
+            disabled={isPending}
+            label={previewLabel}
+            onSelectAvatar={setAvatarUrl}
+          />
+
+          <div className="space-y-5">
+            <div className="space-y-1.5">
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="persona-display-name"
+              >
+                Agent name
+              </label>
+              <div
+                className={cn(
+                  "flex min-h-11 items-center px-3",
+                  PERSONA_FIELD_SHELL_CLASS,
+                )}
+              >
+                <Input
+                  autoCorrect="off"
+                  className={cn(
+                    "h-8 px-0 py-0 leading-6",
+                    PERSONA_FIELD_CONTROL_CLASS,
+                  )}
+                  disabled={isPending}
+                  id="persona-display-name"
+                  onChange={(event) => setDisplayName(event.target.value)}
+                  placeholder="Fizz"
+                  value={displayName}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="persona-system-prompt"
+              >
+                Agent instruction
+              </label>
+              <div className={PERSONA_FIELD_SHELL_CLASS}>
+                <Textarea
+                  className={cn(
+                    "min-h-40 resize-y px-3 py-3 leading-5",
+                    PERSONA_FIELD_CONTROL_CLASS,
+                  )}
+                  disabled={isPending}
+                  id="persona-system-prompt"
+                  onChange={(event) => setSystemPrompt(event.target.value)}
+                  placeholder="Describe what this agent should do."
+                  value={systemPrompt}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="persona-runtime"
+              >
+                Provider
+              </label>
+              <div className={PERSONA_FIELD_SHELL_CLASS}>
+                <select
+                  className={cn(
+                    "h-11 w-full appearance-none px-3 py-2",
+                    PERSONA_FIELD_CONTROL_CLASS,
+                  )}
+                  disabled={isPending || runtimesLoading}
+                  id="persona-runtime"
+                  onChange={(event) => {
+                    const nextRuntime = event.target.value;
+                    const previousRuntime = runtime;
+                    setRuntime(nextRuntime);
+                    if (
+                      shouldClearModelForRuntimeChange(
+                        previousRuntime,
+                        nextRuntime,
+                      )
+                    ) {
+                      setModel("");
+                    }
+                  }}
+                  value={runtime}
+                >
+                  <option value="" disabled>
+                    {selectedRuntimeLabel}
+                  </option>
+                  {runtimes.map((candidate) => (
+                    <option
+                      disabled={
+                        isCreateMode && candidate.availability !== "available"
+                      }
+                      key={candidate.id}
+                      value={candidate.id}
+                    >
+                      {formatRuntimeOptionLabel(candidate)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {runtimeWarning}
+            </div>
+
+            <div
+              aria-hidden={!modelFieldVisible}
+              className={cn(
+                "grid overflow-hidden transition-[grid-template-rows,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+                modelFieldVisible
+                  ? "grid-rows-[1fr] opacity-100"
+                  : "grid-rows-[0fr] opacity-0",
+              )}
+            >
+              <div className="min-h-0 overflow-hidden">
+                <div
+                  className={cn(
+                    "space-y-1.5 transition-[transform,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+                    modelFieldVisible
+                      ? "translate-y-0 opacity-100"
+                      : "-translate-y-1 opacity-0",
+                  )}
+                >
+                  <label
+                    className="text-sm font-medium text-foreground"
+                    htmlFor="persona-model"
+                  >
+                    Model
+                    <span className={PERSONA_LABEL_OPTIONAL_CLASS}>
+                      Optional
+                    </span>
+                  </label>
+                  <div className={PERSONA_FIELD_SHELL_CLASS}>
+                    <select
+                      className={cn(
+                        "h-11 w-full appearance-none px-3 py-2",
+                        PERSONA_FIELD_CONTROL_CLASS,
+                      )}
+                      disabled={isPending || !modelFieldVisible}
+                      id="persona-model"
+                      onChange={(event) => {
+                        const nextModel = event.target.value;
+                        setModel(
+                          nextModel === AUTO_MODEL_DROPDOWN_VALUE
+                            ? ""
+                            : nextModel,
+                        );
+                      }}
+                      value={model.trim() || AUTO_MODEL_DROPDOWN_VALUE}
+                    >
+                      <option value="" disabled>
+                        {selectedModelLabel}
+                      </option>
+                      {modelOptions.map((option) => (
+                        <option
+                          key={option.id || AUTO_MODEL_DROPDOWN_VALUE}
+                          value={option.id || AUTO_MODEL_DROPDOWN_VALUE}
+                        >
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div
+              aria-hidden={!modelFieldVisible}
+              className={cn(
+                "grid overflow-hidden transition-[grid-template-rows,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+                modelFieldVisible
+                  ? "grid-rows-[1fr] opacity-100"
+                  : "grid-rows-[0fr] opacity-0",
+              )}
+            >
+              <div className="min-h-0 overflow-hidden">
+                <div
+                  className={cn(
+                    "space-y-1.5 transition-[transform,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+                    modelFieldVisible
+                      ? "translate-y-0 opacity-100"
+                      : "-translate-y-1 opacity-0",
+                  )}
+                >
+                  <label
+                    className="text-sm font-medium text-foreground"
+                    htmlFor="persona-llm-provider"
+                  >
+                    LLM provider
+                    <span className={PERSONA_LABEL_OPTIONAL_CLASS}>
+                      Optional
+                    </span>
+                  </label>
+                  <div className={PERSONA_FIELD_SHELL_CLASS}>
+                    <select
+                      className={cn(
+                        "h-11 w-full appearance-none px-3 py-2",
+                        PERSONA_FIELD_CONTROL_CLASS,
+                      )}
+                      disabled={isPending || !modelFieldVisible}
+                      id="persona-llm-provider"
+                      onChange={(event) => {
+                        const nextProvider = event.target.value;
+                        setProvider(
+                          nextProvider === AUTO_PROVIDER_DROPDOWN_VALUE
+                            ? ""
+                            : nextProvider,
+                        );
+                      }}
+                      value={provider.trim() || AUTO_PROVIDER_DROPDOWN_VALUE}
+                    >
+                      <option value="" disabled>
+                        {selectedProviderLabel}
+                      </option>
+                      {providerOptions.map((option) => (
+                        <option
+                          key={option.id || AUTO_PROVIDER_DROPDOWN_VALUE}
+                          value={option.id || AUTO_PROVIDER_DROPDOWN_VALUE}
+                        >
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <EnvVarsEditor
+              disabled={isPending}
+              onChange={setEnvVars}
+              value={envVars}
+            />
+
+            {error ? (
+              <p className="text-sm text-destructive">{error.message}</p>
+            ) : null}
+          </div>
+        </form>
+      </ChooserDialogContent>
     </Dialog>
+  );
+}
+
+function isAvatarFileDrag(event: React.DragEvent<HTMLElement>) {
+  return Array.from(event.dataTransfer.types).includes("Files");
+}
+
+function AgentCreationPreview({
+  avatarUrl,
+  disabled = false,
+  label,
+  onSelectAvatar,
+}: {
+  avatarUrl: string | null;
+  disabled?: boolean;
+  label: string;
+  onSelectAvatar: (avatarUrl: string) => void;
+}) {
+  const [isDragOverAvatar, setIsDragOverAvatar] = React.useState(false);
+  const avatarDragDepthRef = React.useRef(0);
+  const {
+    inputRef: avatarUploadInputRef,
+    isUploading,
+    errorMessage: uploadErrorMessage,
+    clearError: clearUploadError,
+    openPicker: openUploadPicker,
+    uploadFile: uploadAvatarFile,
+    handleFileChange: handleAvatarUploadFileChange,
+  } = useAvatarUpload({
+    onUploadSuccess: onSelectAvatar,
+  });
+
+  const handleAvatarDragEnter = React.useCallback(
+    (event: React.DragEvent<HTMLFieldSetElement>) => {
+      if (disabled || !isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      avatarDragDepthRef.current += 1;
+      event.dataTransfer.dropEffect = "copy";
+      setIsDragOverAvatar(true);
+    },
+    [disabled],
+  );
+
+  const handleAvatarDragOver = React.useCallback(
+    (event: React.DragEvent<HTMLFieldSetElement>) => {
+      if (disabled || !isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = "copy";
+      setIsDragOverAvatar(true);
+    },
+    [disabled],
+  );
+
+  const handleAvatarDragLeave = React.useCallback(
+    (event: React.DragEvent<HTMLFieldSetElement>) => {
+      if (!isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      avatarDragDepthRef.current = Math.max(0, avatarDragDepthRef.current - 1);
+      if (avatarDragDepthRef.current === 0) {
+        setIsDragOverAvatar(false);
+      }
+    },
+    [],
+  );
+
+  const handleAvatarDrop = React.useCallback(
+    (event: React.DragEvent<HTMLFieldSetElement>) => {
+      if (!isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      avatarDragDepthRef.current = 0;
+      setIsDragOverAvatar(false);
+
+      const file = event.dataTransfer.files[0];
+      if (!file || disabled || isUploading) {
+        return;
+      }
+
+      clearUploadError();
+      void uploadAvatarFile(file);
+    },
+    [clearUploadError, disabled, isUploading, uploadAvatarFile],
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-[220px] lg:sticky lg:top-0">
+      <fieldset
+        aria-label="Agent avatar preview"
+        className={cn(
+          "group/avatar-preview relative m-0 aspect-[4/5] min-h-[240px] min-w-0 overflow-hidden rounded-xl border border-border/70 bg-muted/50 p-0 shadow-xs transition-[background-color,border-color,box-shadow] duration-150",
+          isDragOverAvatar &&
+            "border-dashed border-primary/70 bg-primary/5 ring-2 ring-primary/15",
+        )}
+        onDragEnter={handleAvatarDragEnter}
+        onDragLeave={handleAvatarDragLeave}
+        onDragOver={handleAvatarDragOver}
+        onDrop={handleAvatarDrop}
+      >
+        <input
+          accept="image/gif,image/jpeg,image/png,image/webp"
+          className="hidden"
+          onChange={handleAvatarUploadFileChange}
+          ref={avatarUploadInputRef}
+          type="file"
+        />
+
+        <div className="absolute inset-0 flex items-center justify-center">
+          <ProfileAvatar
+            avatarUrl={avatarUrl}
+            className="h-36 w-36 text-4xl"
+            label={label}
+          />
+        </div>
+
+        {uploadErrorMessage ? (
+          <p className="absolute inset-x-3 bottom-12 rounded-md bg-background/95 px-2 py-1 text-center text-xs text-destructive shadow-xs">
+            {uploadErrorMessage}
+          </p>
+        ) : null}
+
+        <div className="absolute inset-x-3 bottom-3 flex justify-center">
+          <button
+            className="inline-flex h-8 translate-y-1 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-background/90 px-3 text-xs font-medium text-foreground opacity-0 shadow-xs transition-[background-color,opacity,transform] duration-150 hover:bg-muted focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring group-hover/avatar-preview:translate-y-0 group-hover/avatar-preview:opacity-100 group-focus-within/avatar-preview:translate-y-0 group-focus-within/avatar-preview:opacity-100"
+            disabled={disabled || isUploading}
+            onClick={() => {
+              clearUploadError();
+              openUploadPicker();
+            }}
+            type="button"
+          >
+            {isUploading ? (
+              <Spinner className="h-3.5 w-3.5 border-2" />
+            ) : (
+              <Upload className="h-3.5 w-3.5" />
+            )}
+            {isUploading ? "Uploading..." : "Edit avatar"}
+          </button>
+        </div>
+      </fieldset>
+    </div>
   );
 }

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -420,8 +420,7 @@ export function PersonaDialog({
   const providerApiKeyFieldVisible =
     llmProviderFieldVisible && providerApiKeyConfig !== null;
   const modelFieldVisible =
-    (runtime.trim().length > 0 || blankRuntimeModelProviderEditable) &&
-    (!providerApiKeyFieldVisible || providerApiKeyValue.trim().length > 0);
+    runtime.trim().length > 0 || blankRuntimeModelProviderEditable;
   const isExplicitModelRequired =
     modelFieldVisible && providerRequiresExplicitModel(providerForModelScope);
   const isCreateMode = Boolean(initialValues && !("id" in initialValues));

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -32,6 +32,11 @@ import {
   parsePersonaNamePoolText,
 } from "./personaDialogState";
 import {
+  getAdvancedEnvVars,
+  hasAdvancedEnvVars,
+  hasText,
+} from "./personaDialogEnvVars";
+import {
   AUTO_MODEL_DROPDOWN_VALUE,
   AUTO_PROVIDER_DROPDOWN_VALUE,
   CUSTOM_MODEL_DROPDOWN_VALUE,
@@ -48,6 +53,7 @@ import {
   hasPersonaModelOption,
   NO_RUNTIME_DROPDOWN_VALUE,
   providerRequiresExplicitModel,
+  runtimeSupportsLlmProviderSelection,
   type PersonaDropdownOption,
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
@@ -85,30 +91,6 @@ const ADVANCED_FIELDS_MOTION_TRANSITION = {
   duration: 0.18,
   ease: [0.23, 1, 0.32, 1],
 } as const;
-
-function hasText(value: string | null | undefined): boolean {
-  return (value?.trim().length ?? 0) > 0;
-}
-
-function hasAdvancedEnvVars(
-  value: EnvVarsValue,
-  managedKey: string | null,
-): boolean {
-  return Object.keys(value).some((key) => key !== managedKey);
-}
-
-function getAdvancedEnvVars(
-  value: EnvVarsValue,
-  managedKey: string | null,
-): EnvVarsValue {
-  if (!managedKey || !(managedKey in value)) {
-    return value;
-  }
-
-  const next = { ...value };
-  delete next[managedKey];
-  return next;
-}
 
 export function PersonaDialog({
   open,
@@ -354,6 +336,10 @@ export function PersonaDialog({
     const previousRuntime = initialValues.runtime?.trim() ?? "";
     const modelProviderEditableWithoutRuntime =
       initialModelProviderEditableWithoutRuntime && trimmedRuntime.length === 0;
+    const llmProviderVisibleForSubmit =
+      (trimmedRuntime.length > 0 &&
+        runtimeSupportsLlmProviderSelection(trimmedRuntime)) ||
+      modelProviderEditableWithoutRuntime;
     const shouldPreserveHiddenModelProvider =
       "id" in initialValues &&
       previousRuntime.length === 0 &&
@@ -377,12 +363,11 @@ export function PersonaDialog({
           : shouldPreserveHiddenModelProvider
             ? initialValues.model
             : undefined,
-      provider:
-        trimmedRuntime || modelProviderEditableWithoutRuntime
-          ? provider.trim() || undefined
-          : shouldPreserveHiddenModelProvider
-            ? initialValues.provider
-            : undefined,
+      provider: llmProviderVisibleForSubmit
+        ? provider.trim() || undefined
+        : shouldPreserveHiddenModelProvider
+          ? initialValues.provider
+          : undefined,
       namePool: namePoolInput,
       envVars,
     };
@@ -417,22 +402,28 @@ export function PersonaDialog({
   const selectedRuntime = runtimes.find((p) => p.id === runtime);
   const blankRuntimeModelProviderEditable =
     initialModelProviderEditableWithoutRuntime && runtime.trim().length === 0;
+  const runtimeCanChooseLlmProvider =
+    runtimeSupportsLlmProviderSelection(runtime) ||
+    blankRuntimeModelProviderEditable;
   const llmProviderFieldVisible =
-    runtime.trim().length > 0 || blankRuntimeModelProviderEditable;
+    (runtime.trim().length > 0 && runtimeCanChooseLlmProvider) ||
+    blankRuntimeModelProviderEditable;
+  const providerForModelScope = llmProviderFieldVisible ? provider : "";
   const trimmedProvider = provider.trim();
-  const providerApiKeyConfig = isCustomProviderEditing
-    ? null
-    : getProviderApiKeyConfig(trimmedProvider);
+  const providerApiKeyConfig =
+    llmProviderFieldVisible && !isCustomProviderEditing
+      ? getProviderApiKeyConfig(trimmedProvider)
+      : null;
   const providerApiKeyValue = providerApiKeyConfig
     ? (envVars[providerApiKeyConfig.envVar] ?? "")
     : "";
   const providerApiKeyFieldVisible =
     llmProviderFieldVisible && providerApiKeyConfig !== null;
   const modelFieldVisible =
-    llmProviderFieldVisible &&
+    (runtime.trim().length > 0 || blankRuntimeModelProviderEditable) &&
     (!providerApiKeyFieldVisible || providerApiKeyValue.trim().length > 0);
   const isExplicitModelRequired =
-    modelFieldVisible && providerRequiresExplicitModel(trimmedProvider);
+    modelFieldVisible && providerRequiresExplicitModel(providerForModelScope);
   const isCreateMode = Boolean(initialValues && !("id" in initialValues));
   const selectedRuntimeIsAvailable =
     runtime.trim().length === 0 ||
@@ -452,10 +443,13 @@ export function PersonaDialog({
     isCustomProviderEditing,
     modelFieldVisible,
     open,
-    provider,
+    provider: providerForModelScope,
     selectedRuntime,
   });
-  const staticModelOptions = getPersonaModelOptions(runtime, provider);
+  const staticModelOptions = getPersonaModelOptions(
+    runtime,
+    providerForModelScope,
+  );
   const runtimeModelOptions = getRuntimePersonaModelOptions(runtime);
   const modelOptions = discoveredModelOptions ?? staticModelOptions;
   const isModelCustom = !hasPersonaModelOption(
@@ -469,7 +463,10 @@ export function PersonaDialog({
   });
   const showCustomModelInput =
     modelFieldVisible && (isCustomModelEditing || isModelCustom);
-  const providerOptions = getPersonaProviderOptions(provider, runtime);
+  const providerOptions = getPersonaProviderOptions(
+    providerForModelScope,
+    runtime,
+  );
   const defaultLlmProviderLabel = getDefaultLlmProviderLabel(runtime);
   const providerSelectValue = isCustomProviderEditing
     ? CUSTOM_PROVIDER_DROPDOWN_VALUE
@@ -561,14 +558,25 @@ export function PersonaDialog({
       !open ||
       !modelFieldVisible ||
       isCustomModelEditing ||
-      !shouldClearKnownModelForSelectionScope({ model, provider, runtime })
+      !shouldClearKnownModelForSelectionScope({
+        model,
+        provider: providerForModelScope,
+        runtime,
+      })
     ) {
       return;
     }
 
     setModel("");
     setIsCustomModelEditing(false);
-  }, [isCustomModelEditing, model, modelFieldVisible, open, provider, runtime]);
+  }, [
+    isCustomModelEditing,
+    model,
+    modelFieldVisible,
+    open,
+    providerForModelScope,
+    runtime,
+  ]);
 
   function updateProviderApiKey(envKey: string, value: string) {
     setEnvVars((current) => {
@@ -584,6 +592,29 @@ export function PersonaDialog({
       }
       return next;
     });
+  }
+
+  function removeEnvVar(envKey: string) {
+    setEnvVars((current) => {
+      if (!(envKey in current)) {
+        return current;
+      }
+
+      const next = { ...current };
+      delete next[envKey];
+      return next;
+    });
+  }
+
+  function clearManagedProviderApiKeyWhenLeaving(
+    previousProvider: string,
+    nextProvider: string,
+  ) {
+    const previousEnvVar = getProviderApiKeyEnvVar(previousProvider);
+    const nextEnvVar = getProviderApiKeyEnvVar(nextProvider);
+    if (previousEnvVar && previousEnvVar !== nextEnvVar) {
+      removeEnvVar(previousEnvVar);
+    }
   }
 
   function handleProviderApiKeyChange(value: string) {
@@ -612,6 +643,9 @@ export function PersonaDialog({
     const nextRuntime =
       nextValue === NO_RUNTIME_DROPDOWN_VALUE ? "" : nextValue;
     const previousRuntime = runtime;
+    const nextRuntimeCanChooseLlmProvider =
+      nextRuntime.trim().length > 0 &&
+      runtimeSupportsLlmProviderSelection(nextRuntime);
     setRuntime(nextRuntime);
     if (
       shouldClearModelForRuntimeChange(previousRuntime, nextRuntime) ||
@@ -624,7 +658,8 @@ export function PersonaDialog({
       setModel("");
       setIsCustomModelEditing(false);
     }
-    if (nextRuntime.trim().length === 0) {
+    if (!nextRuntimeCanChooseLlmProvider) {
+      clearManagedProviderApiKeyWhenLeaving(provider, "");
       setIsCustomModelEditing(false);
       setIsCustomProviderEditing(false);
       setProvider("");
@@ -633,6 +668,7 @@ export function PersonaDialog({
 
   function handleProviderDropdownChange(nextValue: string) {
     if (nextValue === CUSTOM_PROVIDER_DROPDOWN_VALUE) {
+      clearManagedProviderApiKeyWhenLeaving(provider, "");
       setIsCustomProviderEditing(true);
       setProvider("");
       return;
@@ -640,6 +676,7 @@ export function PersonaDialog({
 
     const nextProvider =
       nextValue === AUTO_PROVIDER_DROPDOWN_VALUE ? "" : nextValue;
+    clearManagedProviderApiKeyWhenLeaving(provider, nextProvider);
     setIsCustomProviderEditing(false);
     setProvider(nextProvider);
     const requiredEnvVar = getProviderApiKeyEnvVar(nextProvider);

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -53,6 +53,7 @@ const PERSONA_FIELD_CONTROL_CLASS =
 const PERSONA_LABEL_OPTIONAL_CLASS =
   "ml-1 text-xs font-normal text-muted-foreground/50";
 const AUTO_MODEL_DROPDOWN_VALUE = "__auto_model__";
+const CUSTOM_MODEL_DROPDOWN_VALUE = "__custom_model__";
 const AUTO_PROVIDER_DROPDOWN_VALUE = "__auto_provider__";
 
 type PersonaModelOption = {
@@ -101,20 +102,35 @@ const PERSONA_MODEL_OPTIONS_BY_RUNTIME: Record<
 
 function getPersonaModelOptions(
   runtimeId: string,
-  currentModel: string,
 ): readonly PersonaModelOption[] {
-  const options = PERSONA_MODEL_OPTIONS_BY_RUNTIME[runtimeId] ?? [
-    AUTO_MODEL_OPTION,
-  ];
-  const trimmedModel = currentModel.trim();
-  if (
+  return PERSONA_MODEL_OPTIONS_BY_RUNTIME[runtimeId] ?? [AUTO_MODEL_OPTION];
+}
+
+function hasPersonaModelOption(
+  options: readonly PersonaModelOption[],
+  modelId: string,
+) {
+  const trimmedModel = modelId.trim();
+  return (
     trimmedModel.length === 0 ||
     options.some((option) => option.id === trimmedModel)
-  ) {
-    return options;
+  );
+}
+
+function getModelSelectValue({
+  isCustomModelEditing,
+  isModelCustom,
+  model,
+}: {
+  isCustomModelEditing: boolean;
+  isModelCustom: boolean;
+  model: string;
+}) {
+  if (isCustomModelEditing || isModelCustom) {
+    return CUSTOM_MODEL_DROPDOWN_VALUE;
   }
 
-  return [...options, { id: trimmedModel, label: `${trimmedModel} (current)` }];
+  return model.trim() || AUTO_MODEL_DROPDOWN_VALUE;
 }
 
 function getPersonaProviderOptions(
@@ -166,6 +182,7 @@ export function PersonaDialog({
   const [systemPrompt, setSystemPrompt] = React.useState("");
   const [runtime, setRuntime] = React.useState("");
   const [model, setModel] = React.useState("");
+  const [isCustomModelEditing, setIsCustomModelEditing] = React.useState(false);
   const [provider, setProvider] = React.useState("");
   const [envVars, setEnvVars] = React.useState<EnvVarsValue>({});
   const [isAvatarUploadPending, setIsAvatarUploadPending] =
@@ -192,6 +209,7 @@ export function PersonaDialog({
     setSystemPrompt(initialValues.systemPrompt);
     setRuntime(initialValues.runtime ?? "");
     setModel(initialValues.model ?? "");
+    setIsCustomModelEditing(false);
     setProvider(initialValues.provider ?? "");
     setEnvVars("envVars" in initialValues ? (initialValues.envVars ?? {}) : {});
     setIsAvatarUploadPending(false);
@@ -314,6 +332,7 @@ export function PersonaDialog({
       setSystemPrompt("");
       setRuntime("");
       setModel("");
+      setIsCustomModelEditing(false);
       setProvider("");
       setEnvVars({});
       setIsAvatarUploadPending(false);
@@ -386,7 +405,15 @@ export function PersonaDialog({
     (!isCreateMode || runtime.trim().length > 0) &&
     (!isCreateMode || selectedRuntimeIsAvailable) &&
     !isAvatarUploadPending;
-  const modelOptions = getPersonaModelOptions(runtime, model);
+  const modelOptions = getPersonaModelOptions(runtime);
+  const isModelCustom = !hasPersonaModelOption(modelOptions, model);
+  const modelSelectValue = getModelSelectValue({
+    isCustomModelEditing,
+    isModelCustom,
+    model,
+  });
+  const showCustomModelInput =
+    modelFieldVisible && (isCustomModelEditing || isModelCustom);
   const providerOptions = getPersonaProviderOptions(provider);
   const blankRuntimeOptionLabel =
     isCreateMode && runtimesLoading
@@ -395,7 +422,7 @@ export function PersonaDialog({
         ? "Choose a provider"
         : "No preference (use app default)";
   const selectedModelLabel =
-    modelOptions.find((option) => option.id === model)?.label ??
+    modelOptions.find((option) => option.id === model.trim())?.label ??
     AUTO_MODEL_OPTION.label;
   const selectedProviderLabel =
     providerOptions.find((option) => option.id === provider)?.label ??
@@ -590,8 +617,10 @@ export function PersonaDialog({
                       )
                     ) {
                       setModel("");
+                      setIsCustomModelEditing(false);
                     }
                     if (nextRuntime.trim().length === 0) {
+                      setIsCustomModelEditing(false);
                       setProvider("");
                     }
                   }}
@@ -653,13 +682,22 @@ export function PersonaDialog({
                       id="persona-model"
                       onChange={(event) => {
                         const nextModel = event.target.value;
+                        if (nextModel === CUSTOM_MODEL_DROPDOWN_VALUE) {
+                          setIsCustomModelEditing(true);
+                          if (!isModelCustom) {
+                            setModel("");
+                          }
+                          return;
+                        }
+
+                        setIsCustomModelEditing(false);
                         setModel(
                           nextModel === AUTO_MODEL_DROPDOWN_VALUE
                             ? ""
                             : nextModel,
                         );
                       }}
-                      value={model.trim() || AUTO_MODEL_DROPDOWN_VALUE}
+                      value={modelSelectValue}
                     >
                       <option value="" disabled>
                         {selectedModelLabel}
@@ -672,8 +710,33 @@ export function PersonaDialog({
                           {option.label}
                         </option>
                       ))}
+                      <option value={CUSTOM_MODEL_DROPDOWN_VALUE}>
+                        Custom model...
+                      </option>
                     </select>
                   </div>
+                  {showCustomModelInput ? (
+                    <div
+                      className={cn(
+                        "mt-2 flex min-h-11 items-center px-3",
+                        PERSONA_FIELD_SHELL_CLASS,
+                      )}
+                    >
+                      <Input
+                        aria-label="Custom model ID"
+                        autoCorrect="off"
+                        className={cn(
+                          "h-8 px-0 py-0 leading-6",
+                          PERSONA_FIELD_CONTROL_CLASS,
+                        )}
+                        disabled={isPending || !modelFieldVisible}
+                        id="persona-custom-model"
+                        onChange={(event) => setModel(event.target.value)}
+                        placeholder="Custom model ID"
+                        value={model}
+                      />
+                    </div>
+                  ) : null}
                 </div>
               </div>
             </div>

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -18,6 +18,7 @@ import { AgentCreationPreview } from "./AgentCreationPreview";
 import { PersonaDropdownField } from "./PersonaDropdownField";
 import type { EnvVarsValue } from "./EnvVarsEditor";
 import { PersonaAdvancedFields } from "./PersonaAdvancedFields";
+import { PersonaModelField } from "./PersonaModelField";
 import { PersonaProviderApiKeyField } from "./PersonaProviderApiKeyField";
 import {
   getImportButtonLabel,
@@ -36,6 +37,7 @@ import {
   CUSTOM_MODEL_DROPDOWN_VALUE,
   CUSTOM_PROVIDER_DROPDOWN_VALUE,
   formatRuntimeOptionLabel,
+  getDefaultLlmProviderLabel,
   getDefaultPersonaRuntime,
   getModelSelectValue,
   getPersonaModelOptions,
@@ -45,9 +47,11 @@ import {
   getRuntimePersonaModelOptions,
   hasPersonaModelOption,
   NO_RUNTIME_DROPDOWN_VALUE,
+  providerRequiresExplicitModel,
   type PersonaDropdownOption,
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
+  PERSONA_LABEL_OPTIONAL_CLASS,
   shouldClearKnownModelForSelectionScope,
 } from "./personaDialogPickers";
 import { shouldClearModelForRuntimeChange } from "./personaRuntimeModel";
@@ -76,8 +80,6 @@ type PersonaDialogProps = {
   ) => Promise<void>;
 };
 
-const PERSONA_LABEL_OPTIONAL_CLASS =
-  "ml-1 text-xs font-normal text-muted-foreground/50";
 const ADVANCED_FIELDS_MOTION_TRANSITION = {
   duration: 0.18,
   ease: [0.23, 1, 0.32, 1],
@@ -428,6 +430,8 @@ export function PersonaDialog({
   const modelFieldVisible =
     llmProviderFieldVisible &&
     (!providerApiKeyFieldVisible || providerApiKeyValue.trim().length > 0);
+  const isExplicitModelRequired =
+    modelFieldVisible && providerRequiresExplicitModel(trimmedProvider);
   const isCreateMode = Boolean(initialValues && !("id" in initialValues));
   const selectedRuntimeIsAvailable =
     runtime.trim().length === 0 ||
@@ -436,6 +440,7 @@ export function PersonaDialog({
     canSubmitPersonaDialog({ displayName, isPending }) &&
     (!isCreateMode || runtime.trim().length > 0) &&
     (!isCreateMode || selectedRuntimeIsAvailable) &&
+    (!isExplicitModelRequired || model.trim().length > 0) &&
     !isAvatarUploadPending;
   const {
     discoveredModelOptions,
@@ -463,7 +468,8 @@ export function PersonaDialog({
   });
   const showCustomModelInput =
     modelFieldVisible && (isCustomModelEditing || isModelCustom);
-  const providerOptions = getPersonaProviderOptions(provider);
+  const providerOptions = getPersonaProviderOptions(provider, runtime);
+  const defaultLlmProviderLabel = getDefaultLlmProviderLabel(runtime);
   const providerSelectValue = isCustomProviderEditing
     ? CUSTOM_PROVIDER_DROPDOWN_VALUE
     : trimmedProvider || AUTO_PROVIDER_DROPDOWN_VALUE;
@@ -843,7 +849,7 @@ export function PersonaDialog({
                   id="persona-llm-provider"
                   onValueChange={handleProviderDropdownChange}
                   options={providerDropdownOptions}
-                  placeholder="Auto (default)"
+                  placeholder={defaultLlmProviderLabel}
                   value={providerSelectValue}
                 />
                 {showCustomProviderInput ? (
@@ -881,70 +887,18 @@ export function PersonaDialog({
 
             <AnimatePresence initial={false}>
               {modelFieldVisible ? (
-                <motion.div
-                  animate={{ height: "auto", opacity: 1, scale: 1 }}
-                  className="origin-top overflow-hidden"
-                  exit={{ height: 0, opacity: 0, scale: 0.98 }}
-                  initial={{ height: 0, opacity: 0, scale: 0.98 }}
-                  key="persona-model-field"
+                <PersonaModelField
+                  disabled={isPending}
+                  isExplicitModelRequired={isExplicitModelRequired}
+                  model={model}
+                  modelDiscoveryStatus={modelDiscoveryStatus}
+                  modelDropdownOptions={modelDropdownOptions}
+                  modelSelectValue={modelSelectValue}
+                  onCustomModelChange={setModel}
+                  onModelValueChange={handleModelDropdownChange}
+                  showCustomModelInput={showCustomModelInput}
                   transition={advancedFieldsTransition}
-                >
-                  <div className="space-y-1.5">
-                    <label
-                      className="text-sm font-medium text-foreground"
-                      htmlFor="persona-model"
-                    >
-                      Model
-                      <span className={PERSONA_LABEL_OPTIONAL_CLASS}>
-                        Optional
-                      </span>
-                    </label>
-                    <PersonaDropdownField
-                      disabled={isPending}
-                      id="persona-model"
-                      onValueChange={handleModelDropdownChange}
-                      options={modelDropdownOptions}
-                      placeholder="Auto (default)"
-                      value={modelSelectValue}
-                    />
-                    {showCustomModelInput ? (
-                      <div
-                        className={cn(
-                          "mt-2 flex min-h-11 items-center px-3",
-                          PERSONA_FIELD_SHELL_CLASS,
-                        )}
-                      >
-                        <Input
-                          aria-label="Custom model ID"
-                          autoCorrect="off"
-                          className={cn(
-                            "h-8 px-0 py-0 leading-6",
-                            PERSONA_FIELD_CONTROL_CLASS,
-                          )}
-                          disabled={isPending}
-                          id="persona-custom-model"
-                          onChange={(event) => setModel(event.target.value)}
-                          placeholder="Custom model ID"
-                          value={model}
-                        />
-                      </div>
-                    ) : null}
-                    {modelDiscoveryStatus ? (
-                      <p
-                        aria-live="polite"
-                        className={cn(
-                          "text-xs",
-                          modelDiscoveryStatus.tone === "warning"
-                            ? "text-warning"
-                            : "text-muted-foreground",
-                        )}
-                        data-testid="persona-model-discovery-status"
-                      >
-                        {modelDiscoveryStatus.message}
-                      </p>
-                    ) : null}
-                  </div>
-                </motion.div>
+                />
               ) : null}
             </AnimatePresence>
 

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -47,6 +47,10 @@ import {
   shouldClearKnownModelForSelectionScope,
 } from "./personaDialogPickers";
 import { shouldClearModelForRuntimeChange } from "./personaRuntimeModel";
+import {
+  MODEL_DISCOVERY_LOADING_VALUE,
+  usePersonaModelDiscovery,
+} from "./usePersonaModelDiscovery";
 
 type PersonaDialogProps = {
   open: boolean;
@@ -394,9 +398,22 @@ export function PersonaDialog({
     (!isCreateMode || runtime.trim().length > 0) &&
     (!isCreateMode || selectedRuntimeIsAvailable) &&
     !isAvatarUploadPending;
-  const modelOptions = getPersonaModelOptions(runtime, provider);
+  const { discoveredModelOptions, modelDiscoveryLoading } =
+    usePersonaModelDiscovery({
+      envVars,
+      isCustomProviderEditing,
+      modelFieldVisible,
+      open,
+      provider,
+      selectedRuntime,
+    });
+  const staticModelOptions = getPersonaModelOptions(runtime, provider);
   const runtimeModelOptions = getRuntimePersonaModelOptions(runtime);
-  const isModelCustom = !hasPersonaModelOption(runtimeModelOptions, model);
+  const modelOptions = discoveredModelOptions ?? staticModelOptions;
+  const isModelCustom = !hasPersonaModelOption(
+    discoveredModelOptions ?? runtimeModelOptions,
+    model,
+  );
   const modelSelectValue = getModelSelectValue({
     isCustomModelEditing,
     isModelCustom,
@@ -405,9 +422,10 @@ export function PersonaDialog({
   const showCustomModelInput =
     modelFieldVisible && (isCustomModelEditing || isModelCustom);
   const providerOptions = getPersonaProviderOptions(provider);
+  const trimmedProvider = provider.trim();
   const providerSelectValue = isCustomProviderEditing
     ? CUSTOM_PROVIDER_DROPDOWN_VALUE
-    : provider.trim() || AUTO_PROVIDER_DROPDOWN_VALUE;
+    : trimmedProvider || AUTO_PROVIDER_DROPDOWN_VALUE;
   const showCustomProviderInput =
     llmProviderFieldVisible && isCustomProviderEditing;
   const runtimeDropdownValue = runtime.trim() || NO_RUNTIME_DROPDOWN_VALUE;
@@ -454,6 +472,15 @@ export function PersonaDialog({
       label: option.label,
       value: option.id || AUTO_MODEL_DROPDOWN_VALUE,
     })),
+    ...(modelDiscoveryLoading && discoveredModelOptions === null
+      ? [
+          {
+            disabled: true,
+            label: "Loading models...",
+            value: MODEL_DISCOVERY_LOADING_VALUE,
+          },
+        ]
+      : []),
     { label: "Custom model...", value: CUSTOM_MODEL_DROPDOWN_VALUE },
   ];
   const previewLabel = displayName.trim() || "Agent name";

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -366,12 +366,7 @@ export function PersonaDialog({
 
   const selectedRuntime = runtimes.find((p) => p.id === runtime);
   const llmProviderFieldVisible = runtime.trim().length > 0;
-  const modelFieldVisible =
-    llmProviderFieldVisible &&
-    (isCustomProviderEditing ||
-      provider.trim().length > 0 ||
-      model.trim().length > 0 ||
-      isCustomModelEditing);
+  const modelFieldVisible = llmProviderFieldVisible;
   const isCreateMode = Boolean(initialValues && !("id" in initialValues));
   const selectedRuntimeIsAvailable =
     runtime.trim().length === 0 ||

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { RefreshCw, Upload } from "lucide-react";
+import { ChevronDown, RefreshCw, Upload } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import type {
   AcpRuntimeCatalogEntry,
@@ -14,6 +15,7 @@ import { Dialog } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
 import { AgentCreationPreview } from "./AgentCreationPreview";
+import { PersonaDropdownField } from "./PersonaDropdownField";
 import { EnvVarsEditor, type EnvVarsValue } from "./EnvVarsEditor";
 import {
   getImportButtonLabel,
@@ -26,6 +28,24 @@ import {
   formatPersonaNamePoolText,
   parsePersonaNamePoolText,
 } from "./personaDialogState";
+import {
+  AUTO_MODEL_DROPDOWN_VALUE,
+  AUTO_PROVIDER_DROPDOWN_VALUE,
+  CUSTOM_MODEL_DROPDOWN_VALUE,
+  CUSTOM_PROVIDER_DROPDOWN_VALUE,
+  formatRuntimeOptionLabel,
+  getDefaultPersonaRuntime,
+  getModelSelectValue,
+  getPersonaModelOptions,
+  getPersonaProviderOptions,
+  getRuntimePersonaModelOptions,
+  hasPersonaModelOption,
+  NO_RUNTIME_DROPDOWN_VALUE,
+  type PersonaDropdownOption,
+  PERSONA_FIELD_CONTROL_CLASS,
+  PERSONA_FIELD_SHELL_CLASS,
+  shouldClearKnownModelForSelectionScope,
+} from "./personaDialogPickers";
 import { shouldClearModelForRuntimeChange } from "./personaRuntimeModel";
 
 type PersonaDialogProps = {
@@ -48,122 +68,12 @@ type PersonaDialogProps = {
   ) => Promise<void>;
 };
 
-const PERSONA_FIELD_SHELL_CLASS =
-  "rounded-xl border border-input bg-muted/40 transition-colors duration-150 ease-out hover:border-muted-foreground/40 focus-within:border-muted-foreground/50";
-const PERSONA_FIELD_CONTROL_CLASS =
-  "border-0 bg-transparent text-muted-foreground shadow-none outline-none ring-0 transition-colors duration-150 ease-out placeholder:text-muted-foreground/55 focus:bg-transparent focus:text-muted-foreground focus:outline-hidden focus-visible:ring-0";
 const PERSONA_LABEL_OPTIONAL_CLASS =
   "ml-1 text-xs font-normal text-muted-foreground/50";
-const AUTO_MODEL_DROPDOWN_VALUE = "__auto_model__";
-const CUSTOM_MODEL_DROPDOWN_VALUE = "__custom_model__";
-const AUTO_PROVIDER_DROPDOWN_VALUE = "__auto_provider__";
-const CUSTOM_PROVIDER_DROPDOWN_VALUE = "__custom_provider__";
-
-type PersonaModelOption = {
-  id: string;
-  label: string;
-};
-
-const AUTO_MODEL_OPTION: PersonaModelOption = {
-  id: "",
-  label: "Auto (provider default)",
-};
-
-const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
-  { id: "", label: "Auto (runtime default)" },
-  { id: "anthropic", label: "Anthropic" },
-  { id: "openai", label: "OpenAI" },
-  { id: "openai-compat", label: "OpenAI-compatible" },
-  { id: "databricks", label: "Databricks" },
-];
-
-const PERSONA_MODEL_OPTIONS_BY_RUNTIME: Record<
-  string,
-  readonly PersonaModelOption[]
-> = {
-  goose: [
-    AUTO_MODEL_OPTION,
-    { id: "goose-claude-4-6-opus", label: "Claude Opus 4.6" },
-    { id: "goose-claude-4-6-sonnet", label: "Claude Sonnet 4.6" },
-    { id: "gpt-5", label: "GPT-5" },
-    { id: "gpt-5-mini", label: "GPT-5 mini" },
-    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
-    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
-  ],
-  "buzz-agent": [
-    AUTO_MODEL_OPTION,
-    { id: "goose-claude-4-6-opus", label: "Claude Opus 4.6" },
-    { id: "goose-claude-4-6-sonnet", label: "Claude Sonnet 4.6" },
-    { id: "gpt-5", label: "GPT-5" },
-    { id: "gpt-5-mini", label: "GPT-5 mini" },
-    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
-    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
-  ],
-  claude: [AUTO_MODEL_OPTION],
-  codex: [AUTO_MODEL_OPTION],
-};
-
-function getPersonaModelOptions(
-  runtimeId: string,
-): readonly PersonaModelOption[] {
-  return PERSONA_MODEL_OPTIONS_BY_RUNTIME[runtimeId] ?? [AUTO_MODEL_OPTION];
-}
-
-function hasPersonaModelOption(
-  options: readonly PersonaModelOption[],
-  modelId: string,
-) {
-  const trimmedModel = modelId.trim();
-  return (
-    trimmedModel.length === 0 ||
-    options.some((option) => option.id === trimmedModel)
-  );
-}
-
-function getModelSelectValue({
-  isCustomModelEditing,
-  isModelCustom,
-  model,
-}: {
-  isCustomModelEditing: boolean;
-  isModelCustom: boolean;
-  model: string;
-}) {
-  if (isCustomModelEditing || isModelCustom) {
-    return CUSTOM_MODEL_DROPDOWN_VALUE;
-  }
-
-  return model.trim() || AUTO_MODEL_DROPDOWN_VALUE;
-}
-
-function getPersonaProviderOptions(
-  currentProvider: string,
-): readonly PersonaModelOption[] {
-  const trimmedProvider = currentProvider.trim();
-  if (
-    trimmedProvider.length === 0 ||
-    PERSONA_LLM_PROVIDER_OPTIONS.some((option) => option.id === trimmedProvider)
-  ) {
-    return PERSONA_LLM_PROVIDER_OPTIONS;
-  }
-
-  return [
-    ...PERSONA_LLM_PROVIDER_OPTIONS,
-    { id: trimmedProvider, label: `${trimmedProvider} (current)` },
-  ];
-}
-
-function formatRuntimeOptionLabel(runtime: AcpRuntimeCatalogEntry) {
-  const suffix =
-    runtime.availability === "adapter_missing"
-      ? " (adapter missing)"
-      : runtime.availability === "cli_missing"
-        ? " (CLI missing)"
-        : runtime.availability === "not_installed"
-          ? " (not installed)"
-          : "";
-  return `${runtime.label}${suffix}`;
-}
+const ADVANCED_FIELDS_MOTION_TRANSITION = {
+  duration: 0.18,
+  ease: [0.23, 1, 0.32, 1],
+} as const;
 
 export function PersonaDialog({
   open,
@@ -191,6 +101,7 @@ export function PersonaDialog({
     React.useState(false);
   const [namePoolText, setNamePoolText] = React.useState("");
   const [envVars, setEnvVars] = React.useState<EnvVarsValue>({});
+  const [showAdvancedFields, setShowAdvancedFields] = React.useState(false);
   const [isAvatarUploadPending, setIsAvatarUploadPending] =
     React.useState(false);
   const [isImportingUpdate, setIsImportingUpdate] = React.useState(false);
@@ -204,6 +115,11 @@ export function PersonaDialog({
       ? initialValues.id
       : null;
   const canImportPersonaUpdate = isEditMode && Boolean(onImportUpdateFile);
+  const defaultRuntime = React.useMemo(
+    () => getDefaultPersonaRuntime(runtimes),
+    [runtimes],
+  );
+  const shouldReduceMotion = useReducedMotion();
 
   React.useEffect(() => {
     if (!open || !initialValues) {
@@ -218,16 +134,37 @@ export function PersonaDialog({
     setIsCustomModelEditing(false);
     setProvider(initialValues.provider ?? "");
     setIsCustomProviderEditing(false);
-    setNamePoolText(
+    const nextNamePoolText =
       "namePool" in initialValues
         ? formatPersonaNamePoolText(initialValues.namePool)
-        : "",
+        : "";
+    const nextEnvVars =
+      "envVars" in initialValues ? (initialValues.envVars ?? {}) : {};
+    setNamePoolText(nextNamePoolText);
+    setEnvVars(nextEnvVars);
+    setShowAdvancedFields(
+      nextNamePoolText.trim().length > 0 || Object.keys(nextEnvVars).length > 0,
     );
-    setEnvVars("envVars" in initialValues ? (initialValues.envVars ?? {}) : {});
     setIsAvatarUploadPending(false);
     setImportErrorMessage(null);
     setIsImportingUpdate(false);
   }, [initialValues, open]);
+
+  React.useEffect(() => {
+    if (
+      !open ||
+      !initialValues ||
+      "id" in initialValues ||
+      initialValues.runtime?.trim() ||
+      runtimesLoading ||
+      runtime.trim().length > 0 ||
+      defaultRuntime === null
+    ) {
+      return;
+    }
+
+    setRuntime(defaultRuntime.id);
+  }, [defaultRuntime, initialValues, open, runtime, runtimesLoading]);
 
   React.useEffect(() => {
     if (!open || !canImportPersonaUpdate) {
@@ -349,6 +286,7 @@ export function PersonaDialog({
       setIsCustomProviderEditing(false);
       setNamePoolText("");
       setEnvVars({});
+      setShowAdvancedFields(false);
       setIsAvatarUploadPending(false);
       setImportErrorMessage(null);
       setIsImportingUpdate(false);
@@ -427,7 +365,13 @@ export function PersonaDialog({
   });
 
   const selectedRuntime = runtimes.find((p) => p.id === runtime);
-  const modelFieldVisible = runtime.trim().length > 0;
+  const llmProviderFieldVisible = runtime.trim().length > 0;
+  const modelFieldVisible =
+    llmProviderFieldVisible &&
+    (isCustomProviderEditing ||
+      provider.trim().length > 0 ||
+      model.trim().length > 0 ||
+      isCustomModelEditing);
   const isCreateMode = Boolean(initialValues && !("id" in initialValues));
   const selectedRuntimeIsAvailable =
     runtime.trim().length === 0 ||
@@ -437,8 +381,9 @@ export function PersonaDialog({
     (!isCreateMode || runtime.trim().length > 0) &&
     (!isCreateMode || selectedRuntimeIsAvailable) &&
     !isAvatarUploadPending;
-  const modelOptions = getPersonaModelOptions(runtime);
-  const isModelCustom = !hasPersonaModelOption(modelOptions, model);
+  const modelOptions = getPersonaModelOptions(runtime, provider);
+  const runtimeModelOptions = getRuntimePersonaModelOptions(runtime);
+  const isModelCustom = !hasPersonaModelOption(runtimeModelOptions, model);
   const modelSelectValue = getModelSelectValue({
     isCustomModelEditing,
     isModelCustom,
@@ -450,21 +395,54 @@ export function PersonaDialog({
   const providerSelectValue = isCustomProviderEditing
     ? CUSTOM_PROVIDER_DROPDOWN_VALUE
     : provider.trim() || AUTO_PROVIDER_DROPDOWN_VALUE;
-  const showCustomProviderInput = modelFieldVisible && isCustomProviderEditing;
-  const blankRuntimeOptionLabel =
-    isCreateMode && runtimesLoading
-      ? "Loading providers..."
-      : isCreateMode
-        ? "Choose a provider"
-        : "No preference (use app default)";
-  const selectedModelLabel =
-    modelOptions.find((option) => option.id === model.trim())?.label ??
-    AUTO_MODEL_OPTION.label;
-  const selectedProviderLabel =
-    providerOptions.find((option) => option.id === provider)?.label ??
-    (provider.trim()
-      ? `${provider.trim()} (current)`
-      : "Auto (runtime default)");
+  const showCustomProviderInput =
+    llmProviderFieldVisible && isCustomProviderEditing;
+  const runtimeDropdownValue = runtime.trim() || NO_RUNTIME_DROPDOWN_VALUE;
+  const blankRuntimeOptionLabel = runtimesLoading
+    ? "Loading providers..."
+    : isCreateMode
+      ? "Choose a provider"
+      : "No preference (use app default)";
+  const runtimeDropdownOptions: PersonaDropdownOption[] = [
+    ...(!isCreateMode
+      ? [
+          {
+            label: blankRuntimeOptionLabel,
+            value: NO_RUNTIME_DROPDOWN_VALUE,
+          },
+        ]
+      : []),
+    ...runtimes.map((candidate) => ({
+      disabled: isCreateMode && candidate.availability !== "available",
+      label: `${formatRuntimeOptionLabel(candidate)}${
+        isCreateMode && candidate.id === defaultRuntime?.id ? " (default)" : ""
+      }`,
+      value: candidate.id,
+    })),
+  ];
+  if (
+    runtime.trim().length > 0 &&
+    !runtimeDropdownOptions.some((option) => option.value === runtime)
+  ) {
+    runtimeDropdownOptions.push({
+      label: `${runtime.trim()} (current)`,
+      value: runtime.trim(),
+    });
+  }
+  const providerDropdownOptions: PersonaDropdownOption[] = [
+    ...providerOptions.map((option) => ({
+      label: option.label,
+      value: option.id || AUTO_PROVIDER_DROPDOWN_VALUE,
+    })),
+    { label: "Custom provider...", value: CUSTOM_PROVIDER_DROPDOWN_VALUE },
+  ];
+  const modelDropdownOptions: PersonaDropdownOption[] = [
+    ...modelOptions.map((option) => ({
+      label: option.label,
+      value: option.id || AUTO_MODEL_DROPDOWN_VALUE,
+    })),
+    { label: "Custom model...", value: CUSTOM_MODEL_DROPDOWN_VALUE },
+  ];
   const previewLabel = displayName.trim() || "Agent name";
   const previewAvatarUrl = avatarUrl.trim() || null;
   const runtimeWarning =
@@ -478,6 +456,88 @@ export function PersonaDialog({
         Visit Settings &gt; Doctor to set it up.
       </p>
     ) : null;
+  const advancedFieldsTransition = shouldReduceMotion
+    ? { duration: 0 }
+    : ADVANCED_FIELDS_MOTION_TRANSITION;
+
+  React.useEffect(() => {
+    if (
+      !open ||
+      !modelFieldVisible ||
+      isCustomModelEditing ||
+      !shouldClearKnownModelForSelectionScope({ model, provider, runtime })
+    ) {
+      return;
+    }
+
+    setModel("");
+    setIsCustomModelEditing(false);
+  }, [isCustomModelEditing, model, modelFieldVisible, open, provider, runtime]);
+
+  function handleRuntimeDropdownChange(nextValue: string) {
+    const nextRuntime =
+      nextValue === NO_RUNTIME_DROPDOWN_VALUE ? "" : nextValue;
+    const previousRuntime = runtime;
+    setRuntime(nextRuntime);
+    if (
+      shouldClearModelForRuntimeChange(previousRuntime, nextRuntime) ||
+      shouldClearKnownModelForSelectionScope({
+        model,
+        provider,
+        runtime: nextRuntime,
+      })
+    ) {
+      setModel("");
+      setIsCustomModelEditing(false);
+    }
+    if (nextRuntime.trim().length === 0) {
+      setIsCustomModelEditing(false);
+      setIsCustomProviderEditing(false);
+      setProvider("");
+    }
+  }
+
+  function handleProviderDropdownChange(nextValue: string) {
+    if (nextValue === CUSTOM_PROVIDER_DROPDOWN_VALUE) {
+      setIsCustomProviderEditing(true);
+      setProvider("");
+      return;
+    }
+
+    const nextProvider =
+      nextValue === AUTO_PROVIDER_DROPDOWN_VALUE ? "" : nextValue;
+    setIsCustomProviderEditing(false);
+    setProvider(nextProvider);
+    if (nextProvider.trim().length === 0) {
+      setModel("");
+      setIsCustomModelEditing(false);
+      return;
+    }
+    if (
+      !isCustomModelEditing &&
+      shouldClearKnownModelForSelectionScope({
+        model,
+        provider: nextProvider,
+        runtime,
+      })
+    ) {
+      setModel("");
+      setIsCustomModelEditing(false);
+    }
+  }
+
+  function handleModelDropdownChange(nextValue: string) {
+    if (nextValue === CUSTOM_MODEL_DROPDOWN_VALUE) {
+      setIsCustomModelEditing(true);
+      if (!isModelCustom) {
+        setModel("");
+      }
+      return;
+    }
+
+    setIsCustomModelEditing(false);
+    setModel(nextValue === AUTO_MODEL_DROPDOWN_VALUE ? "" : nextValue);
+  }
 
   return (
     <Dialog
@@ -635,280 +695,186 @@ export function PersonaDialog({
               >
                 Provider
               </label>
-              <div className={PERSONA_FIELD_SHELL_CLASS}>
-                <select
-                  className={cn(
-                    "h-11 w-full appearance-none px-3 py-2",
-                    PERSONA_FIELD_CONTROL_CLASS,
-                  )}
-                  disabled={isPending || runtimesLoading}
-                  id="persona-runtime"
-                  onChange={(event) => {
-                    const nextRuntime = event.target.value;
-                    const previousRuntime = runtime;
-                    setRuntime(nextRuntime);
-                    if (
-                      shouldClearModelForRuntimeChange(
-                        previousRuntime,
-                        nextRuntime,
-                      )
-                    ) {
-                      setModel("");
-                      setIsCustomModelEditing(false);
-                    }
-                    if (nextRuntime.trim().length === 0) {
-                      setIsCustomModelEditing(false);
-                      setIsCustomProviderEditing(false);
-                      setProvider("");
-                    }
-                  }}
-                  value={runtime}
-                >
-                  <option disabled={isCreateMode} value="">
-                    {blankRuntimeOptionLabel}
-                  </option>
-                  {runtimes.map((candidate) => (
-                    <option
-                      disabled={
-                        isCreateMode && candidate.availability !== "available"
-                      }
-                      key={candidate.id}
-                      value={candidate.id}
-                    >
-                      {formatRuntimeOptionLabel(candidate)}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <PersonaDropdownField
+                disabled={isPending || runtimesLoading}
+                id="persona-runtime"
+                onValueChange={handleRuntimeDropdownChange}
+                options={runtimeDropdownOptions}
+                placeholder={blankRuntimeOptionLabel}
+                value={runtimeDropdownValue}
+              />
               {runtimeWarning}
             </div>
 
-            <div
-              aria-hidden={!modelFieldVisible}
-              className={cn(
-                "grid overflow-hidden transition-[grid-template-rows,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
-                modelFieldVisible
-                  ? "grid-rows-[1fr] opacity-100"
-                  : "grid-rows-[0fr] opacity-0",
-              )}
-            >
-              <div className="min-h-0 overflow-hidden">
-                <div
-                  className={cn(
-                    "space-y-1.5 transition-[transform,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
-                    modelFieldVisible
-                      ? "translate-y-0 opacity-100"
-                      : "-translate-y-1 opacity-0",
-                  )}
+            {llmProviderFieldVisible ? (
+              <div className="space-y-1.5">
+                <label
+                  className="text-sm font-medium text-foreground"
+                  htmlFor="persona-llm-provider"
                 >
-                  <label
-                    className="text-sm font-medium text-foreground"
-                    htmlFor="persona-model"
-                  >
-                    Model
-                    <span className={PERSONA_LABEL_OPTIONAL_CLASS}>
-                      Optional
-                    </span>
-                  </label>
-                  <div className={PERSONA_FIELD_SHELL_CLASS}>
-                    <select
-                      className={cn(
-                        "h-11 w-full appearance-none px-3 py-2",
-                        PERSONA_FIELD_CONTROL_CLASS,
-                      )}
-                      disabled={isPending || !modelFieldVisible}
-                      id="persona-model"
-                      onChange={(event) => {
-                        const nextModel = event.target.value;
-                        if (nextModel === CUSTOM_MODEL_DROPDOWN_VALUE) {
-                          setIsCustomModelEditing(true);
-                          if (!isModelCustom) {
-                            setModel("");
-                          }
-                          return;
-                        }
-
-                        setIsCustomModelEditing(false);
-                        setModel(
-                          nextModel === AUTO_MODEL_DROPDOWN_VALUE
-                            ? ""
-                            : nextModel,
-                        );
-                      }}
-                      value={modelSelectValue}
-                    >
-                      <option value="" disabled>
-                        {selectedModelLabel}
-                      </option>
-                      {modelOptions.map((option) => (
-                        <option
-                          key={option.id || AUTO_MODEL_DROPDOWN_VALUE}
-                          value={option.id || AUTO_MODEL_DROPDOWN_VALUE}
-                        >
-                          {option.label}
-                        </option>
-                      ))}
-                      <option value={CUSTOM_MODEL_DROPDOWN_VALUE}>
-                        Custom model...
-                      </option>
-                    </select>
-                  </div>
-                  {showCustomModelInput ? (
-                    <div
-                      className={cn(
-                        "mt-2 flex min-h-11 items-center px-3",
-                        PERSONA_FIELD_SHELL_CLASS,
-                      )}
-                    >
-                      <Input
-                        aria-label="Custom model ID"
-                        autoCorrect="off"
-                        className={cn(
-                          "h-8 px-0 py-0 leading-6",
-                          PERSONA_FIELD_CONTROL_CLASS,
-                        )}
-                        disabled={isPending || !modelFieldVisible}
-                        id="persona-custom-model"
-                        onChange={(event) => setModel(event.target.value)}
-                        placeholder="Custom model ID"
-                        value={model}
-                      />
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            </div>
-
-            <div
-              aria-hidden={!modelFieldVisible}
-              className={cn(
-                "grid overflow-hidden transition-[grid-template-rows,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
-                modelFieldVisible
-                  ? "grid-rows-[1fr] opacity-100"
-                  : "grid-rows-[0fr] opacity-0",
-              )}
-            >
-              <div className="min-h-0 overflow-hidden">
-                <div
-                  className={cn(
-                    "space-y-1.5 transition-[transform,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
-                    modelFieldVisible
-                      ? "translate-y-0 opacity-100"
-                      : "-translate-y-1 opacity-0",
-                  )}
-                >
-                  <label
-                    className="text-sm font-medium text-foreground"
-                    htmlFor="persona-llm-provider"
-                  >
-                    LLM provider
-                    <span className={PERSONA_LABEL_OPTIONAL_CLASS}>
-                      Optional
-                    </span>
-                  </label>
-                  <div className={PERSONA_FIELD_SHELL_CLASS}>
-                    <select
-                      className={cn(
-                        "h-11 w-full appearance-none px-3 py-2",
-                        PERSONA_FIELD_CONTROL_CLASS,
-                      )}
-                      disabled={isPending || !modelFieldVisible}
-                      id="persona-llm-provider"
-                      onChange={(event) => {
-                        const nextProvider = event.target.value;
-                        if (nextProvider === CUSTOM_PROVIDER_DROPDOWN_VALUE) {
-                          setIsCustomProviderEditing(true);
-                          setProvider("");
-                          return;
-                        }
-
-                        setIsCustomProviderEditing(false);
-                        setProvider(
-                          nextProvider === AUTO_PROVIDER_DROPDOWN_VALUE
-                            ? ""
-                            : nextProvider,
-                        );
-                      }}
-                      value={providerSelectValue}
-                    >
-                      <option value="" disabled>
-                        {selectedProviderLabel}
-                      </option>
-                      {providerOptions.map((option) => (
-                        <option
-                          key={option.id || AUTO_PROVIDER_DROPDOWN_VALUE}
-                          value={option.id || AUTO_PROVIDER_DROPDOWN_VALUE}
-                        >
-                          {option.label}
-                        </option>
-                      ))}
-                      <option value={CUSTOM_PROVIDER_DROPDOWN_VALUE}>
-                        Custom provider...
-                      </option>
-                    </select>
-                  </div>
-                  {showCustomProviderInput ? (
-                    <div
-                      className={cn(
-                        "mt-2 flex min-h-11 items-center px-3",
-                        PERSONA_FIELD_SHELL_CLASS,
-                      )}
-                    >
-                      <Input
-                        aria-label="Custom provider ID"
-                        autoCorrect="off"
-                        className={cn(
-                          "h-8 px-0 py-0 leading-6",
-                          PERSONA_FIELD_CONTROL_CLASS,
-                        )}
-                        disabled={isPending || !modelFieldVisible}
-                        id="persona-custom-provider"
-                        onChange={(event) => setProvider(event.target.value)}
-                        placeholder="Custom provider ID"
-                        value={provider}
-                      />
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              <label
-                className="text-sm font-medium text-foreground"
-                htmlFor="persona-name-pool"
-              >
-                Instance name pool
-                <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
-              </label>
-              <div
-                className={cn(
-                  "flex min-h-11 items-center px-3",
-                  PERSONA_FIELD_SHELL_CLASS,
-                )}
-              >
-                <Input
-                  autoCapitalize="words"
-                  autoCorrect="off"
-                  className={cn(
-                    "h-8 px-0 py-0 leading-6",
-                    PERSONA_FIELD_CONTROL_CLASS,
-                  )}
+                  LLM provider
+                  <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
+                </label>
+                <PersonaDropdownField
                   disabled={isPending}
-                  id="persona-name-pool"
-                  onChange={(event) => setNamePoolText(event.target.value)}
-                  placeholder="Birch, Compass, Ridge, Thistle"
-                  spellCheck={false}
-                  value={namePoolText}
+                  id="persona-llm-provider"
+                  onValueChange={handleProviderDropdownChange}
+                  options={providerDropdownOptions}
+                  placeholder="Auto (default)"
+                  value={providerSelectValue}
                 />
+                {showCustomProviderInput ? (
+                  <div
+                    className={cn(
+                      "mt-2 flex min-h-11 items-center px-3",
+                      PERSONA_FIELD_SHELL_CLASS,
+                    )}
+                  >
+                    <Input
+                      aria-label="Custom provider ID"
+                      autoCorrect="off"
+                      className={cn(
+                        "h-8 px-0 py-0 leading-6",
+                        PERSONA_FIELD_CONTROL_CLASS,
+                      )}
+                      disabled={isPending}
+                      id="persona-custom-provider"
+                      onChange={(event) => setProvider(event.target.value)}
+                      placeholder="Custom provider ID"
+                      value={provider}
+                    />
+                  </div>
+                ) : null}
               </div>
-            </div>
+            ) : null}
 
-            <EnvVarsEditor
-              disabled={isPending}
-              onChange={setEnvVars}
-              value={envVars}
-            />
+            <AnimatePresence initial={false}>
+              {modelFieldVisible ? (
+                <motion.div
+                  animate={{ height: "auto", opacity: 1, scale: 1 }}
+                  className="origin-top overflow-hidden"
+                  exit={{ height: 0, opacity: 0, scale: 0.98 }}
+                  initial={{ height: 0, opacity: 0, scale: 0.98 }}
+                  key="persona-model-field"
+                  transition={advancedFieldsTransition}
+                >
+                  <div className="space-y-1.5">
+                    <label
+                      className="text-sm font-medium text-foreground"
+                      htmlFor="persona-model"
+                    >
+                      Model
+                      <span className={PERSONA_LABEL_OPTIONAL_CLASS}>
+                        Optional
+                      </span>
+                    </label>
+                    <PersonaDropdownField
+                      disabled={isPending}
+                      id="persona-model"
+                      onValueChange={handleModelDropdownChange}
+                      options={modelDropdownOptions}
+                      placeholder="Auto (default)"
+                      value={modelSelectValue}
+                    />
+                    {showCustomModelInput ? (
+                      <div
+                        className={cn(
+                          "mt-2 flex min-h-11 items-center px-3",
+                          PERSONA_FIELD_SHELL_CLASS,
+                        )}
+                      >
+                        <Input
+                          aria-label="Custom model ID"
+                          autoCorrect="off"
+                          className={cn(
+                            "h-8 px-0 py-0 leading-6",
+                            PERSONA_FIELD_CONTROL_CLASS,
+                          )}
+                          disabled={isPending}
+                          id="persona-custom-model"
+                          onChange={(event) => setModel(event.target.value)}
+                          placeholder="Custom model ID"
+                          value={model}
+                        />
+                      </div>
+                    ) : null}
+                  </div>
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
+
+            <div className="space-y-3">
+              <button
+                aria-expanded={showAdvancedFields}
+                className="inline-flex h-9 items-center gap-1.5 text-sm font-medium text-foreground transition-colors hover:text-foreground/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                onClick={() => setShowAdvancedFields((current) => !current)}
+                type="button"
+              >
+                <span>Advanced</span>
+                <ChevronDown
+                  className={cn(
+                    "h-4 w-4 text-muted-foreground transition-transform duration-150 ease-out",
+                    showAdvancedFields && "rotate-180",
+                  )}
+                />
+              </button>
+
+              <AnimatePresence initial={false}>
+                {showAdvancedFields ? (
+                  <motion.div
+                    animate={{ height: "auto", opacity: 1, scale: 1 }}
+                    className="origin-top overflow-hidden"
+                    exit={{ height: 0, opacity: 0, scale: 0.98 }}
+                    initial={{ height: 0, opacity: 0, scale: 0.98 }}
+                    key="persona-advanced-fields"
+                    transition={advancedFieldsTransition}
+                  >
+                    <div className="space-y-5 pt-2">
+                      <div className="space-y-1.5">
+                        <label
+                          className="text-sm font-medium text-foreground"
+                          htmlFor="persona-name-pool"
+                        >
+                          Instance name pool
+                          <span className={PERSONA_LABEL_OPTIONAL_CLASS}>
+                            Optional
+                          </span>
+                        </label>
+                        <div
+                          className={cn(
+                            "flex min-h-11 items-center px-3",
+                            PERSONA_FIELD_SHELL_CLASS,
+                          )}
+                        >
+                          <Input
+                            autoCapitalize="words"
+                            autoCorrect="off"
+                            className={cn(
+                              "h-8 px-0 py-0 leading-6",
+                              PERSONA_FIELD_CONTROL_CLASS,
+                            )}
+                            disabled={isPending}
+                            id="persona-name-pool"
+                            onChange={(event) =>
+                              setNamePoolText(event.target.value)
+                            }
+                            placeholder="Birch, Compass, Ridge, Thistle"
+                            spellCheck={false}
+                            value={namePoolText}
+                          />
+                        </div>
+                      </div>
+
+                      <EnvVarsEditor
+                        disabled={isPending}
+                        onChange={setEnvVars}
+                        value={envVars}
+                      />
+                    </div>
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+            </div>
 
             {error ? (
               <p className="text-sm text-destructive">{error.message}</p>

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -470,7 +470,7 @@ export function PersonaDialog({
   const showCustomModelInput =
     modelFieldVisible && (isCustomModelEditing || isModelCustom);
   const providerOptions = getPersonaProviderOptions(provider, runtime);
-  const defaultLlmProviderLabel = getDefaultLlmProviderLabel();
+  const defaultLlmProviderLabel = getDefaultLlmProviderLabel(runtime);
   const providerSelectValue = isCustomProviderEditing
     ? CUSTOM_PROVIDER_DROPDOWN_VALUE
     : trimmedProvider || AUTO_PROVIDER_DROPDOWN_VALUE;

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
 import { RefreshCw, Upload } from "lucide-react";
 
-import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
-import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
 import type {
   AcpRuntimeCatalogEntry,
   CreatePersonaInput,
@@ -14,8 +12,8 @@ import { Button } from "@/shared/ui/button";
 import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
 import { Dialog } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
-import { Spinner } from "@/shared/ui/spinner";
 import { Textarea } from "@/shared/ui/textarea";
+import { AgentCreationPreview } from "./AgentCreationPreview";
 import { EnvVarsEditor, type EnvVarsValue } from "./EnvVarsEditor";
 import {
   getImportButtonLabel,
@@ -55,6 +53,7 @@ const PERSONA_LABEL_OPTIONAL_CLASS =
 const AUTO_MODEL_DROPDOWN_VALUE = "__auto_model__";
 const CUSTOM_MODEL_DROPDOWN_VALUE = "__custom_model__";
 const AUTO_PROVIDER_DROPDOWN_VALUE = "__auto_provider__";
+const CUSTOM_PROVIDER_DROPDOWN_VALUE = "__custom_provider__";
 
 type PersonaModelOption = {
   id: string;
@@ -184,6 +183,8 @@ export function PersonaDialog({
   const [model, setModel] = React.useState("");
   const [isCustomModelEditing, setIsCustomModelEditing] = React.useState(false);
   const [provider, setProvider] = React.useState("");
+  const [isCustomProviderEditing, setIsCustomProviderEditing] =
+    React.useState(false);
   const [envVars, setEnvVars] = React.useState<EnvVarsValue>({});
   const [isAvatarUploadPending, setIsAvatarUploadPending] =
     React.useState(false);
@@ -211,6 +212,7 @@ export function PersonaDialog({
     setModel(initialValues.model ?? "");
     setIsCustomModelEditing(false);
     setProvider(initialValues.provider ?? "");
+    setIsCustomProviderEditing(false);
     setEnvVars("envVars" in initialValues ? (initialValues.envVars ?? {}) : {});
     setIsAvatarUploadPending(false);
     setImportErrorMessage(null);
@@ -334,6 +336,7 @@ export function PersonaDialog({
       setModel("");
       setIsCustomModelEditing(false);
       setProvider("");
+      setIsCustomProviderEditing(false);
       setEnvVars({});
       setIsAvatarUploadPending(false);
       setImportErrorMessage(null);
@@ -354,6 +357,11 @@ export function PersonaDialog({
     }
 
     const trimmedRuntime = runtime.trim();
+    const previousRuntime = initialValues.runtime?.trim() ?? "";
+    const shouldPreserveHiddenModelProvider =
+      "id" in initialValues &&
+      previousRuntime.length === 0 &&
+      trimmedRuntime.length === 0;
     const preservedNamePool =
       "namePool" in initialValues ? initialValues.namePool : undefined;
     const baseInput = {
@@ -361,8 +369,16 @@ export function PersonaDialog({
       avatarUrl: avatarUrl.trim() || undefined,
       systemPrompt: systemPrompt.trim(),
       runtime: trimmedRuntime || undefined,
-      model: trimmedRuntime ? model.trim() || undefined : undefined,
-      provider: trimmedRuntime ? provider.trim() || undefined : undefined,
+      model: trimmedRuntime
+        ? model.trim() || undefined
+        : shouldPreserveHiddenModelProvider
+          ? initialValues.model
+          : undefined,
+      provider: trimmedRuntime
+        ? provider.trim() || undefined
+        : shouldPreserveHiddenModelProvider
+          ? initialValues.provider
+          : undefined,
       namePool: preservedNamePool,
       envVars,
     };
@@ -415,6 +431,10 @@ export function PersonaDialog({
   const showCustomModelInput =
     modelFieldVisible && (isCustomModelEditing || isModelCustom);
   const providerOptions = getPersonaProviderOptions(provider);
+  const providerSelectValue = isCustomProviderEditing
+    ? CUSTOM_PROVIDER_DROPDOWN_VALUE
+    : provider.trim() || AUTO_PROVIDER_DROPDOWN_VALUE;
+  const showCustomProviderInput = modelFieldVisible && isCustomProviderEditing;
   const blankRuntimeOptionLabel =
     isCreateMode && runtimesLoading
       ? "Loading providers..."
@@ -621,6 +641,7 @@ export function PersonaDialog({
                     }
                     if (nextRuntime.trim().length === 0) {
                       setIsCustomModelEditing(false);
+                      setIsCustomProviderEditing(false);
                       setProvider("");
                     }
                   }}
@@ -778,13 +799,20 @@ export function PersonaDialog({
                       id="persona-llm-provider"
                       onChange={(event) => {
                         const nextProvider = event.target.value;
+                        if (nextProvider === CUSTOM_PROVIDER_DROPDOWN_VALUE) {
+                          setIsCustomProviderEditing(true);
+                          setProvider("");
+                          return;
+                        }
+
+                        setIsCustomProviderEditing(false);
                         setProvider(
                           nextProvider === AUTO_PROVIDER_DROPDOWN_VALUE
                             ? ""
                             : nextProvider,
                         );
                       }}
-                      value={provider.trim() || AUTO_PROVIDER_DROPDOWN_VALUE}
+                      value={providerSelectValue}
                     >
                       <option value="" disabled>
                         {selectedProviderLabel}
@@ -797,8 +825,33 @@ export function PersonaDialog({
                           {option.label}
                         </option>
                       ))}
+                      <option value={CUSTOM_PROVIDER_DROPDOWN_VALUE}>
+                        Custom provider...
+                      </option>
                     </select>
                   </div>
+                  {showCustomProviderInput ? (
+                    <div
+                      className={cn(
+                        "mt-2 flex min-h-11 items-center px-3",
+                        PERSONA_FIELD_SHELL_CLASS,
+                      )}
+                    >
+                      <Input
+                        aria-label="Custom provider ID"
+                        autoCorrect="off"
+                        className={cn(
+                          "h-8 px-0 py-0 leading-6",
+                          PERSONA_FIELD_CONTROL_CLASS,
+                        )}
+                        disabled={isPending || !modelFieldVisible}
+                        id="persona-custom-provider"
+                        onChange={(event) => setProvider(event.target.value)}
+                        placeholder="Custom provider ID"
+                        value={provider}
+                      />
+                    </div>
+                  ) : null}
                 </div>
               </div>
             </div>
@@ -816,165 +869,5 @@ export function PersonaDialog({
         </form>
       </ChooserDialogContent>
     </Dialog>
-  );
-}
-
-function isAvatarFileDrag(event: React.DragEvent<HTMLElement>) {
-  return Array.from(event.dataTransfer.types).includes("Files");
-}
-
-function AgentCreationPreview({
-  avatarUrl,
-  disabled = false,
-  label,
-  onUploadPendingChange,
-  onSelectAvatar,
-}: {
-  avatarUrl: string | null;
-  disabled?: boolean;
-  label: string;
-  onUploadPendingChange?: (isPending: boolean) => void;
-  onSelectAvatar: (avatarUrl: string) => void;
-}) {
-  const [isDragOverAvatar, setIsDragOverAvatar] = React.useState(false);
-  const avatarDragDepthRef = React.useRef(0);
-  const {
-    inputRef: avatarUploadInputRef,
-    isUploading,
-    errorMessage: uploadErrorMessage,
-    clearError: clearUploadError,
-    openPicker: openUploadPicker,
-    uploadFile: uploadAvatarFile,
-    handleFileChange: handleAvatarUploadFileChange,
-  } = useAvatarUpload({
-    onUploadSuccess: onSelectAvatar,
-  });
-
-  React.useEffect(() => {
-    onUploadPendingChange?.(isUploading);
-    return () => {
-      onUploadPendingChange?.(false);
-    };
-  }, [isUploading, onUploadPendingChange]);
-
-  const handleAvatarDragEnter = React.useCallback(
-    (event: React.DragEvent<HTMLFieldSetElement>) => {
-      if (disabled || !isAvatarFileDrag(event)) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      avatarDragDepthRef.current += 1;
-      event.dataTransfer.dropEffect = "copy";
-      setIsDragOverAvatar(true);
-    },
-    [disabled],
-  );
-
-  const handleAvatarDragOver = React.useCallback(
-    (event: React.DragEvent<HTMLFieldSetElement>) => {
-      if (disabled || !isAvatarFileDrag(event)) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      event.dataTransfer.dropEffect = "copy";
-      setIsDragOverAvatar(true);
-    },
-    [disabled],
-  );
-
-  const handleAvatarDragLeave = React.useCallback(
-    (event: React.DragEvent<HTMLFieldSetElement>) => {
-      if (!isAvatarFileDrag(event)) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      avatarDragDepthRef.current = Math.max(0, avatarDragDepthRef.current - 1);
-      if (avatarDragDepthRef.current === 0) {
-        setIsDragOverAvatar(false);
-      }
-    },
-    [],
-  );
-
-  const handleAvatarDrop = React.useCallback(
-    (event: React.DragEvent<HTMLFieldSetElement>) => {
-      if (!isAvatarFileDrag(event)) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      avatarDragDepthRef.current = 0;
-      setIsDragOverAvatar(false);
-
-      const file = event.dataTransfer.files[0];
-      if (!file || disabled || isUploading) {
-        return;
-      }
-
-      clearUploadError();
-      void uploadAvatarFile(file);
-    },
-    [clearUploadError, disabled, isUploading, uploadAvatarFile],
-  );
-
-  return (
-    <div className="mx-auto w-full max-w-[220px] lg:sticky lg:top-0">
-      <fieldset
-        aria-label="Agent avatar preview"
-        className={cn(
-          "group/avatar-preview relative m-0 aspect-[4/5] min-h-[240px] min-w-0 overflow-hidden rounded-xl border border-border/70 bg-muted/50 p-0 shadow-xs transition-[background-color,border-color,box-shadow] duration-150",
-          isDragOverAvatar &&
-            "border-dashed border-primary/70 bg-primary/5 ring-2 ring-primary/15",
-        )}
-        onDragEnter={handleAvatarDragEnter}
-        onDragLeave={handleAvatarDragLeave}
-        onDragOver={handleAvatarDragOver}
-        onDrop={handleAvatarDrop}
-      >
-        <input
-          accept="image/gif,image/jpeg,image/png,image/webp"
-          className="hidden"
-          onChange={handleAvatarUploadFileChange}
-          ref={avatarUploadInputRef}
-          type="file"
-        />
-
-        <div className="absolute inset-0 flex items-center justify-center">
-          <ProfileAvatar
-            avatarUrl={avatarUrl}
-            className="h-36 w-36 text-4xl"
-            label={label}
-          />
-        </div>
-
-        {uploadErrorMessage ? (
-          <p className="absolute inset-x-3 bottom-12 rounded-md bg-background/95 px-2 py-1 text-center text-xs text-destructive shadow-xs">
-            {uploadErrorMessage}
-          </p>
-        ) : null}
-
-        <div className="absolute inset-x-3 bottom-3 flex justify-center">
-          <button
-            className="inline-flex h-8 translate-y-1 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-background/90 px-3 text-xs font-medium text-foreground opacity-0 shadow-xs transition-[background-color,opacity,transform] duration-150 hover:bg-muted focus-visible:translate-y-0 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring group-hover/avatar-preview:translate-y-0 group-hover/avatar-preview:opacity-100 group-focus-within/avatar-preview:translate-y-0 group-focus-within/avatar-preview:opacity-100"
-            disabled={disabled || isUploading}
-            onClick={() => {
-              clearUploadError();
-              openUploadPicker();
-            }}
-            type="button"
-          >
-            {isUploading ? (
-              <Spinner className="h-3.5 w-3.5 border-2" />
-            ) : (
-              <Upload className="h-3.5 w-3.5" />
-            )}
-            {isUploading ? "Uploading..." : "Edit avatar"}
-          </button>
-        </div>
-      </fieldset>
-    </div>
   );
 }

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -38,6 +38,7 @@ import {
   getModelSelectValue,
   getPersonaModelOptions,
   getPersonaProviderOptions,
+  getProviderApiKeyEnvVar,
   getRuntimePersonaModelOptions,
   hasPersonaModelOption,
   NO_RUNTIME_DROPDOWN_VALUE,
@@ -517,6 +518,19 @@ export function PersonaDialog({
     setIsCustomModelEditing(false);
   }, [isCustomModelEditing, model, modelFieldVisible, open, provider, runtime]);
 
+  function showProviderEnvVar(envKey: string) {
+    setShowAdvancedFields(true);
+    setEnvVars((current) => {
+      if (Object.keys(current).includes(envKey)) {
+        return current;
+      }
+      return {
+        ...current,
+        [envKey]: "",
+      };
+    });
+  }
+
   function handleRuntimeDropdownChange(nextValue: string) {
     const nextRuntime =
       nextValue === NO_RUNTIME_DROPDOWN_VALUE ? "" : nextValue;
@@ -551,6 +565,10 @@ export function PersonaDialog({
       nextValue === AUTO_PROVIDER_DROPDOWN_VALUE ? "" : nextValue;
     setIsCustomProviderEditing(false);
     setProvider(nextProvider);
+    const requiredEnvVar = getProviderApiKeyEnvVar(nextProvider);
+    if (requiredEnvVar) {
+      showProviderEnvVar(requiredEnvVar);
+    }
     if (
       !isCustomModelEditing &&
       shouldClearKnownModelForSelectionScope({

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -168,6 +168,8 @@ export function PersonaDialog({
   const [model, setModel] = React.useState("");
   const [provider, setProvider] = React.useState("");
   const [envVars, setEnvVars] = React.useState<EnvVarsValue>({});
+  const [isAvatarUploadPending, setIsAvatarUploadPending] =
+    React.useState(false);
   const [isImportingUpdate, setIsImportingUpdate] = React.useState(false);
   const [importErrorMessage, setImportErrorMessage] = React.useState<
     string | null
@@ -192,6 +194,7 @@ export function PersonaDialog({
     setModel(initialValues.model ?? "");
     setProvider(initialValues.provider ?? "");
     setEnvVars("envVars" in initialValues ? (initialValues.envVars ?? {}) : {});
+    setIsAvatarUploadPending(false);
     setImportErrorMessage(null);
     setIsImportingUpdate(false);
   }, [initialValues, open]);
@@ -313,6 +316,7 @@ export function PersonaDialog({
       setModel("");
       setProvider("");
       setEnvVars({});
+      setIsAvatarUploadPending(false);
       setImportErrorMessage(null);
       setIsImportingUpdate(false);
       setIsWindowFileDragOver(false);
@@ -324,7 +328,8 @@ export function PersonaDialog({
   async function handleSubmit() {
     if (
       !initialValues ||
-      !canSubmitPersonaDialog({ displayName, isPending })
+      !canSubmitPersonaDialog({ displayName, isPending }) ||
+      isAvatarUploadPending
     ) {
       return;
     }
@@ -337,8 +342,8 @@ export function PersonaDialog({
       avatarUrl: avatarUrl.trim() || undefined,
       systemPrompt: systemPrompt.trim(),
       runtime: trimmedRuntime || undefined,
-      model: model.trim() || undefined,
-      provider: provider.trim() || undefined,
+      model: trimmedRuntime ? model.trim() || undefined : undefined,
+      provider: trimmedRuntime ? provider.trim() || undefined : undefined,
       namePool: preservedNamePool,
       envVars,
     };
@@ -379,12 +384,16 @@ export function PersonaDialog({
   const canSubmit =
     canSubmitPersonaDialog({ displayName, isPending }) &&
     (!isCreateMode || runtime.trim().length > 0) &&
-    (!isCreateMode || selectedRuntimeIsAvailable);
+    (!isCreateMode || selectedRuntimeIsAvailable) &&
+    !isAvatarUploadPending;
   const modelOptions = getPersonaModelOptions(runtime, model);
   const providerOptions = getPersonaProviderOptions(provider);
-  const selectedRuntimeLabel = runtimesLoading
-    ? "Loading providers..."
-    : (selectedRuntime?.label ?? "Choose a provider");
+  const blankRuntimeOptionLabel =
+    isCreateMode && runtimesLoading
+      ? "Loading providers..."
+      : isCreateMode
+        ? "Choose a provider"
+        : "No preference (use app default)";
   const selectedModelLabel =
     modelOptions.find((option) => option.id === model)?.label ??
     AUTO_MODEL_OPTION.label;
@@ -410,7 +419,7 @@ export function PersonaDialog({
   return (
     <Dialog
       onOpenChange={(nextOpen) => {
-        if (!nextOpen && isPending) return;
+        if (!nextOpen && (isPending || isAvatarUploadPending)) return;
         handleOpenChange(nextOpen);
       }}
       open={open}
@@ -468,7 +477,7 @@ export function PersonaDialog({
 
             <div className="flex items-center gap-2">
               <Button
-                disabled={isPending}
+                disabled={isPending || isAvatarUploadPending}
                 onClick={() => handleOpenChange(false)}
                 type="button"
                 variant="outline"
@@ -481,7 +490,11 @@ export function PersonaDialog({
                 form="persona-dialog-form"
                 type="submit"
               >
-                {isPending ? "Saving..." : submitLabel}
+                {isPending
+                  ? "Saving..."
+                  : isAvatarUploadPending
+                    ? "Uploading..."
+                    : submitLabel}
               </Button>
             </div>
           </div>
@@ -494,8 +507,9 @@ export function PersonaDialog({
         >
           <AgentCreationPreview
             avatarUrl={previewAvatarUrl}
-            disabled={isPending}
+            disabled={isPending || isAvatarUploadPending}
             label={previewLabel}
+            onUploadPendingChange={setIsAvatarUploadPending}
             onSelectAvatar={setAvatarUrl}
           />
 
@@ -577,11 +591,14 @@ export function PersonaDialog({
                     ) {
                       setModel("");
                     }
+                    if (nextRuntime.trim().length === 0) {
+                      setProvider("");
+                    }
                   }}
                   value={runtime}
                 >
-                  <option value="" disabled>
-                    {selectedRuntimeLabel}
+                  <option disabled={isCreateMode} value="">
+                    {blankRuntimeOptionLabel}
                   </option>
                   {runtimes.map((candidate) => (
                     <option
@@ -747,11 +764,13 @@ function AgentCreationPreview({
   avatarUrl,
   disabled = false,
   label,
+  onUploadPendingChange,
   onSelectAvatar,
 }: {
   avatarUrl: string | null;
   disabled?: boolean;
   label: string;
+  onUploadPendingChange?: (isPending: boolean) => void;
   onSelectAvatar: (avatarUrl: string) => void;
 }) {
   const [isDragOverAvatar, setIsDragOverAvatar] = React.useState(false);
@@ -767,6 +786,13 @@ function AgentCreationPreview({
   } = useAvatarUpload({
     onUploadSuccess: onSelectAvatar,
   });
+
+  React.useEffect(() => {
+    onUploadPendingChange?.(isUploading);
+    return () => {
+      onUploadPendingChange?.(false);
+    };
+  }, [isUploading, onUploadPendingChange]);
 
   const handleAvatarDragEnter = React.useCallback(
     (event: React.DragEvent<HTMLFieldSetElement>) => {

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -21,7 +21,11 @@ import {
   getImportErrorLabel,
   IMPORT_ERROR_VISIBILITY_MS,
 } from "./personaDialogImportState";
-import { canSubmitPersonaDialog } from "./personaDialogState";
+import {
+  canSubmitPersonaDialog,
+  formatPersonaNamePoolText,
+  parsePersonaNamePoolText,
+} from "./personaDialogState";
 import { shouldClearModelForRuntimeChange } from "./personaRuntimeModel";
 
 type PersonaDialogProps = {
@@ -185,6 +189,7 @@ export function PersonaDialog({
   const [provider, setProvider] = React.useState("");
   const [isCustomProviderEditing, setIsCustomProviderEditing] =
     React.useState(false);
+  const [namePoolText, setNamePoolText] = React.useState("");
   const [envVars, setEnvVars] = React.useState<EnvVarsValue>({});
   const [isAvatarUploadPending, setIsAvatarUploadPending] =
     React.useState(false);
@@ -213,6 +218,11 @@ export function PersonaDialog({
     setIsCustomModelEditing(false);
     setProvider(initialValues.provider ?? "");
     setIsCustomProviderEditing(false);
+    setNamePoolText(
+      "namePool" in initialValues
+        ? formatPersonaNamePoolText(initialValues.namePool)
+        : "",
+    );
     setEnvVars("envVars" in initialValues ? (initialValues.envVars ?? {}) : {});
     setIsAvatarUploadPending(false);
     setImportErrorMessage(null);
@@ -337,6 +347,7 @@ export function PersonaDialog({
       setIsCustomModelEditing(false);
       setProvider("");
       setIsCustomProviderEditing(false);
+      setNamePoolText("");
       setEnvVars({});
       setIsAvatarUploadPending(false);
       setImportErrorMessage(null);
@@ -362,8 +373,13 @@ export function PersonaDialog({
       "id" in initialValues &&
       previousRuntime.length === 0 &&
       trimmedRuntime.length === 0;
-    const preservedNamePool =
-      "namePool" in initialValues ? initialValues.namePool : undefined;
+    const namePool = parsePersonaNamePoolText(namePoolText);
+    const namePoolInput =
+      namePool.length > 0
+        ? namePool
+        : "namePool" in initialValues
+          ? []
+          : undefined;
     const baseInput = {
       displayName: displayName.trim(),
       avatarUrl: avatarUrl.trim() || undefined,
@@ -379,7 +395,7 @@ export function PersonaDialog({
         : shouldPreserveHiddenModelProvider
           ? initialValues.provider
           : undefined,
-      namePool: preservedNamePool,
+      namePool: namePoolInput,
       envVars,
     };
 
@@ -854,6 +870,37 @@ export function PersonaDialog({
                     </div>
                   ) : null}
                 </div>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="persona-name-pool"
+              >
+                Instance name pool
+                <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
+              </label>
+              <div
+                className={cn(
+                  "flex min-h-11 items-center px-3",
+                  PERSONA_FIELD_SHELL_CLASS,
+                )}
+              >
+                <Input
+                  autoCapitalize="words"
+                  autoCorrect="off"
+                  className={cn(
+                    "h-8 px-0 py-0 leading-6",
+                    PERSONA_FIELD_CONTROL_CLASS,
+                  )}
+                  disabled={isPending}
+                  id="persona-name-pool"
+                  onChange={(event) => setNamePoolText(event.target.value)}
+                  placeholder="Birch, Compass, Ridge, Thistle"
+                  spellCheck={false}
+                  value={namePoolText}
+                />
               </div>
             </div>
 

--- a/desktop/src/features/agents/ui/PersonaDropdownField.tsx
+++ b/desktop/src/features/agents/ui/PersonaDropdownField.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/shared/lib/cn";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+import {
+  type PersonaDropdownOption,
+  PERSONA_FIELD_CONTROL_CLASS,
+  PERSONA_FIELD_SHELL_CLASS,
+} from "./personaDialogPickers";
+
+export function PersonaDropdownField({
+  disabled,
+  id,
+  onValueChange,
+  options,
+  placeholder,
+  value,
+}: {
+  disabled?: boolean;
+  id: string;
+  onValueChange: (value: string) => void;
+  options: readonly PersonaDropdownOption[];
+  placeholder: string;
+  value: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const selectedOption = options.find((option) => option.value === value);
+
+  return (
+    <div className={PERSONA_FIELD_SHELL_CLASS}>
+      <DropdownMenu modal={false} onOpenChange={setOpen} open={open}>
+        <DropdownMenuTrigger asChild>
+          <button
+            className={cn(
+              "flex h-11 w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm leading-6",
+              PERSONA_FIELD_CONTROL_CLASS,
+              disabled && "cursor-default opacity-60",
+            )}
+            disabled={disabled}
+            id={id}
+            type="button"
+          >
+            <span
+              className={cn(
+                "min-w-0 flex-1 truncate",
+                !selectedOption && "text-muted-foreground/55",
+              )}
+            >
+              {selectedOption?.label ?? placeholder}
+            </span>
+            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground/60" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          sideOffset={5}
+          style={{
+            minWidth: "var(--radix-dropdown-menu-trigger-width)",
+            width: "var(--radix-dropdown-menu-trigger-width)",
+          }}
+        >
+          <DropdownMenuRadioGroup
+            onValueChange={(nextValue) => {
+              onValueChange(nextValue);
+              setOpen(false);
+            }}
+            value={value}
+          >
+            {options.map((option) => (
+              <DropdownMenuRadioItem
+                disabled={option.disabled}
+                key={option.value}
+                value={option.value}
+              >
+                <span className="truncate">{option.label}</span>
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/PersonaDropdownField.tsx
+++ b/desktop/src/features/agents/ui/PersonaDropdownField.tsx
@@ -16,6 +16,7 @@ import {
 } from "./personaDialogPickers";
 
 export function PersonaDropdownField({
+  contentClassName,
   disabled,
   id,
   onValueChange,
@@ -23,6 +24,7 @@ export function PersonaDropdownField({
   placeholder,
   value,
 }: {
+  contentClassName?: string;
   disabled?: boolean;
   id: string;
   onValueChange: (value: string) => void;
@@ -60,6 +62,7 @@ export function PersonaDropdownField({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="start"
+          className={contentClassName}
           onCloseAutoFocus={(event) => event.preventDefault()}
           sideOffset={5}
           style={{

--- a/desktop/src/features/agents/ui/PersonaDropdownField.tsx
+++ b/desktop/src/features/agents/ui/PersonaDropdownField.tsx
@@ -62,7 +62,7 @@ export function PersonaDropdownField({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="start"
-          className={contentClassName}
+          className={cn("overflow-hidden", contentClassName)}
           onCloseAutoFocus={(event) => event.preventDefault()}
           sideOffset={5}
           style={{
@@ -70,23 +70,29 @@ export function PersonaDropdownField({
             width: "var(--radix-dropdown-menu-trigger-width)",
           }}
         >
-          <DropdownMenuRadioGroup
-            onValueChange={(nextValue) => {
-              onValueChange(nextValue);
-              setOpen(false);
-            }}
-            value={value}
+          <div
+            className="max-h-[min(16rem,var(--radix-dropdown-menu-content-available-height))] overflow-y-auto overscroll-contain"
+            onTouchMoveCapture={(event) => event.stopPropagation()}
+            onWheelCapture={(event) => event.stopPropagation()}
           >
-            {options.map((option) => (
-              <DropdownMenuRadioItem
-                disabled={option.disabled}
-                key={option.value}
-                value={option.value}
-              >
-                <span className="truncate">{option.label}</span>
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
+            <DropdownMenuRadioGroup
+              onValueChange={(nextValue) => {
+                onValueChange(nextValue);
+                setOpen(false);
+              }}
+              value={value}
+            >
+              {options.map((option) => (
+                <DropdownMenuRadioItem
+                  disabled={option.disabled}
+                  key={option.value}
+                  value={option.value}
+                >
+                  <span className="truncate">{option.label}</span>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </div>
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/desktop/src/features/agents/ui/PersonaModelField.tsx
+++ b/desktop/src/features/agents/ui/PersonaModelField.tsx
@@ -1,0 +1,108 @@
+import type * as React from "react";
+import { motion } from "motion/react";
+
+import { cn } from "@/shared/lib/cn";
+import { Input } from "@/shared/ui/input";
+import { PersonaDropdownField } from "./PersonaDropdownField";
+import type { PersonaModelDiscoveryStatus } from "./personaModelDiscoveryStatus";
+import {
+  type PersonaDropdownOption,
+  PERSONA_FIELD_CONTROL_CLASS,
+  PERSONA_FIELD_SHELL_CLASS,
+  PERSONA_LABEL_OPTIONAL_CLASS,
+} from "./personaDialogPickers";
+
+type PersonaModelFieldProps = {
+  disabled: boolean;
+  isExplicitModelRequired: boolean;
+  model: string;
+  modelDiscoveryStatus: PersonaModelDiscoveryStatus | null;
+  modelDropdownOptions: readonly PersonaDropdownOption[];
+  modelSelectValue: string;
+  onCustomModelChange: (value: string) => void;
+  onModelValueChange: (value: string) => void;
+  showCustomModelInput: boolean;
+  transition: React.ComponentProps<typeof motion.div>["transition"];
+};
+
+export function PersonaModelField({
+  disabled,
+  isExplicitModelRequired,
+  model,
+  modelDiscoveryStatus,
+  modelDropdownOptions,
+  modelSelectValue,
+  onCustomModelChange,
+  onModelValueChange,
+  showCustomModelInput,
+  transition,
+}: PersonaModelFieldProps) {
+  return (
+    <motion.div
+      animate={{ height: "auto", opacity: 1, scale: 1 }}
+      className="origin-top overflow-hidden"
+      exit={{ height: 0, opacity: 0, scale: 0.98 }}
+      initial={{ height: 0, opacity: 0, scale: 0.98 }}
+      key="persona-model-field"
+      transition={transition}
+    >
+      <div className="space-y-1.5">
+        <label
+          className="text-sm font-medium text-foreground"
+          htmlFor="persona-model"
+        >
+          Model
+          {!isExplicitModelRequired ? (
+            <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
+          ) : null}
+        </label>
+        <PersonaDropdownField
+          disabled={disabled}
+          id="persona-model"
+          onValueChange={onModelValueChange}
+          options={modelDropdownOptions}
+          placeholder={
+            isExplicitModelRequired ? "Choose a model" : "Default model"
+          }
+          value={modelSelectValue}
+        />
+        {showCustomModelInput ? (
+          <div
+            className={cn(
+              "mt-2 flex min-h-11 items-center px-3",
+              PERSONA_FIELD_SHELL_CLASS,
+            )}
+          >
+            <Input
+              aria-label="Custom model ID"
+              autoCorrect="off"
+              className={cn(
+                "h-8 px-0 py-0 leading-6",
+                PERSONA_FIELD_CONTROL_CLASS,
+              )}
+              disabled={disabled}
+              id="persona-custom-model"
+              onChange={(event) => onCustomModelChange(event.target.value)}
+              placeholder="Custom model ID"
+              value={model}
+            />
+          </div>
+        ) : null}
+        {modelDiscoveryStatus ? (
+          <p
+            aria-live="polite"
+            className={cn(
+              "text-xs",
+              modelDiscoveryStatus.tone === "warning"
+                ? "text-warning"
+                : "text-muted-foreground",
+            )}
+            data-testid="persona-model-discovery-status"
+          >
+            {modelDiscoveryStatus.message}
+          </p>
+        ) : null}
+      </div>
+    </motion.div>
+  );
+}

--- a/desktop/src/features/agents/ui/PersonaModelField.tsx
+++ b/desktop/src/features/agents/ui/PersonaModelField.tsx
@@ -57,6 +57,7 @@ export function PersonaModelField({
           ) : null}
         </label>
         <PersonaDropdownField
+          contentClassName="max-h-64 overflow-y-auto"
           disabled={disabled}
           id="persona-model"
           onValueChange={onModelValueChange}

--- a/desktop/src/features/agents/ui/PersonaModelField.tsx
+++ b/desktop/src/features/agents/ui/PersonaModelField.tsx
@@ -57,7 +57,6 @@ export function PersonaModelField({
           ) : null}
         </label>
         <PersonaDropdownField
-          contentClassName="max-h-64 overflow-y-auto"
           disabled={disabled}
           id="persona-model"
           onValueChange={onModelValueChange}

--- a/desktop/src/features/agents/ui/PersonaProviderApiKeyField.tsx
+++ b/desktop/src/features/agents/ui/PersonaProviderApiKeyField.tsx
@@ -1,0 +1,47 @@
+import { Input } from "@/shared/ui/input";
+import { cn } from "@/shared/lib/cn";
+import {
+  type ProviderApiKeyConfig,
+  PERSONA_FIELD_CONTROL_CLASS,
+  PERSONA_FIELD_SHELL_CLASS,
+} from "./personaDialogPickers";
+
+export function PersonaProviderApiKeyField({
+  config,
+  disabled,
+  onChange,
+  value,
+}: {
+  config: ProviderApiKeyConfig;
+  disabled: boolean;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  return (
+    <div className="mt-2 space-y-1.5">
+      <label
+        className="text-sm font-medium text-foreground"
+        htmlFor="persona-provider-api-key"
+      >
+        {config.label}
+      </label>
+      <div
+        className={cn(
+          "flex min-h-11 items-center px-3",
+          PERSONA_FIELD_SHELL_CLASS,
+        )}
+      >
+        <Input
+          autoCorrect="off"
+          className={cn("h-8 px-0 py-0 leading-6", PERSONA_FIELD_CONTROL_CLASS)}
+          data-testid="persona-provider-api-key"
+          disabled={disabled}
+          id="persona-provider-api-key"
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={config.placeholder}
+          value={value}
+        />
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -221,7 +221,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               agents={ungrouped}
               collapsed={collapsed}
               groupKey="__ungrouped__"
-              label="Custom Agents"
+              label="Custom agents"
               presenceLoaded={presenceLoaded}
               presenceLookup={presenceLookup}
               onToggle={toggle}
@@ -499,19 +499,19 @@ function NewAgentCard({
           disabled={isPersonasPending}
           onClick={onCreatePersona}
         >
-          Persona
+          New agent
         </DropdownMenuItem>
         {canChooseCatalog ? (
           <DropdownMenuItem
             disabled={isPersonasPending}
             onClick={onChooseCatalog}
           >
-            Choose from Catalog...
+            Choose from catalog
           </DropdownMenuItem>
         ) : null}
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={onCreateAgent}>
-          Custom Agent
+          Custom agent
         </DropdownMenuItem>
         <DropdownMenuItem onClick={openFilePicker}>
           Import persona file

--- a/desktop/src/features/agents/ui/batchImportPersonaInput.ts
+++ b/desktop/src/features/agents/ui/batchImportPersonaInput.ts
@@ -6,7 +6,7 @@ export function buildBatchImportPersonaInput(
 ): CreatePersonaInput {
   return {
     displayName: persona.displayName,
-    avatarUrl: persona.avatarDataUrl ?? undefined,
+    avatarUrl: persona.avatarDataUrl ?? persona.avatarRef ?? undefined,
     systemPrompt: persona.systemPrompt,
     runtime: persona.runtime ?? undefined,
     model: persona.model ?? undefined,

--- a/desktop/src/features/agents/ui/batchImportPersonaInput.ts
+++ b/desktop/src/features/agents/ui/batchImportPersonaInput.ts
@@ -1,12 +1,13 @@
 import type { ParsedPersonaPreview } from "@/shared/api/tauriPersonas";
 import type { CreatePersonaInput } from "@/shared/api/types";
+import { importedAvatarUrl } from "./personaDialogState";
 
 export function buildBatchImportPersonaInput(
   persona: ParsedPersonaPreview,
 ): CreatePersonaInput {
   return {
     displayName: persona.displayName,
-    avatarUrl: persona.avatarDataUrl ?? persona.avatarRef ?? undefined,
+    avatarUrl: importedAvatarUrl(persona) || undefined,
     systemPrompt: persona.systemPrompt,
     runtime: persona.runtime ?? undefined,
     model: persona.model ?? undefined,

--- a/desktop/src/features/agents/ui/managedAgentAvatar.test.mjs
+++ b/desktop/src/features/agents/ui/managedAgentAvatar.test.mjs
@@ -42,3 +42,27 @@ test("resolveManagedAgentAvatarUrl omits invalid data image URIs", async () => {
 
   assert.equal(uploaded, undefined);
 });
+
+test("resolveManagedAgentAvatarUrl uses safe fallback when data image upload fails", async () => {
+  const uploaded = await resolveManagedAgentAvatarUrl(
+    "data:image/png;base64,YQ==",
+    async () => {
+      throw new Error("upload failed");
+    },
+    "app-avatar://goose",
+  );
+
+  assert.equal(uploaded, "app-avatar://goose");
+});
+
+test("resolveManagedAgentAvatarUrl ignores data URI fallbacks", async () => {
+  const uploaded = await resolveManagedAgentAvatarUrl(
+    "data:image/png;base64,YQ==",
+    async () => {
+      throw new Error("upload failed");
+    },
+    "data:image/png;base64,Yg==",
+  );
+
+  assert.equal(uploaded, undefined);
+});

--- a/desktop/src/features/agents/ui/managedAgentAvatar.test.mjs
+++ b/desktop/src/features/agents/ui/managedAgentAvatar.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveManagedAgentAvatarUrl } from "./managedAgentAvatar.ts";
+
+test("resolveManagedAgentAvatarUrl uploads data image URIs", async () => {
+  const uploaded = await resolveManagedAgentAvatarUrl(
+    "data:image/png;base64,aGVsbG8=",
+    async (bytes) => {
+      assert.deepEqual(bytes, [104, 101, 108, 108, 111]);
+      return {
+        url: "https://relay.example/avatar.png",
+        sha256: "hash",
+        size: bytes.length,
+        type: "image/png",
+        uploaded: 1,
+      };
+    },
+  );
+
+  assert.equal(uploaded, "https://relay.example/avatar.png");
+});
+
+test("resolveManagedAgentAvatarUrl passes non-data URLs through", async () => {
+  const uploaded = await resolveManagedAgentAvatarUrl(
+    " https://relay.example/already-hosted.png ",
+    async () => {
+      throw new Error("should not upload hosted avatars");
+    },
+  );
+
+  assert.equal(uploaded, "https://relay.example/already-hosted.png");
+});
+
+test("resolveManagedAgentAvatarUrl omits invalid data image URIs", async () => {
+  const uploaded = await resolveManagedAgentAvatarUrl(
+    "data:image/png;base64,",
+    async () => {
+      throw new Error("should not upload invalid data URIs");
+    },
+  );
+
+  assert.equal(uploaded, undefined);
+});

--- a/desktop/src/features/agents/ui/managedAgentAvatar.ts
+++ b/desktop/src/features/agents/ui/managedAgentAvatar.ts
@@ -1,0 +1,29 @@
+import { type BlobDescriptor, uploadMediaBytes } from "@/shared/api/tauri";
+
+type UploadMediaBytes = (
+  data: number[],
+  filename?: string,
+) => Promise<BlobDescriptor>;
+
+export async function resolveManagedAgentAvatarUrl(
+  avatarUrl: string | null | undefined,
+  upload: UploadMediaBytes = uploadMediaBytes,
+): Promise<string | undefined> {
+  const resolvedAvatarUrl = avatarUrl?.trim() || undefined;
+  if (!resolvedAvatarUrl?.startsWith("data:image/")) {
+    return resolvedAvatarUrl;
+  }
+
+  try {
+    const [, b64] = resolvedAvatarUrl.split(",", 2);
+    if (!b64) {
+      throw new Error("empty data URI payload");
+    }
+    const bytes = Array.from(atob(b64), (char) => char.charCodeAt(0));
+    const blob = await upload(bytes);
+    return blob.url;
+  } catch (err) {
+    console.warn("Avatar upload failed, proceeding without avatar:", err);
+    return undefined;
+  }
+}

--- a/desktop/src/features/agents/ui/managedAgentAvatar.ts
+++ b/desktop/src/features/agents/ui/managedAgentAvatar.ts
@@ -1,4 +1,10 @@
-import { type BlobDescriptor, uploadMediaBytes } from "@/shared/api/tauri";
+type BlobDescriptor = {
+  url: string;
+  sha256: string;
+  size: number;
+  type: string;
+  uploaded: number;
+};
 
 type UploadMediaBytes = (
   data: number[],
@@ -7,7 +13,7 @@ type UploadMediaBytes = (
 
 export async function resolveManagedAgentAvatarUrl(
   avatarUrl: string | null | undefined,
-  upload: UploadMediaBytes = uploadMediaBytes,
+  upload: UploadMediaBytes = defaultUploadMediaBytes,
   fallbackAvatarUrl?: string | null,
 ): Promise<string | undefined> {
   const resolvedAvatarUrl = avatarUrl?.trim() || undefined;
@@ -27,6 +33,11 @@ export async function resolveManagedAgentAvatarUrl(
     console.warn("Avatar upload failed, proceeding without avatar:", err);
     return safeFallbackAvatarUrl(fallbackAvatarUrl);
   }
+}
+
+async function defaultUploadMediaBytes(data: number[], filename?: string) {
+  const { uploadMediaBytes } = await import("@/shared/api/tauri");
+  return uploadMediaBytes(data, filename);
 }
 
 function safeFallbackAvatarUrl(avatarUrl: string | null | undefined) {

--- a/desktop/src/features/agents/ui/managedAgentAvatar.ts
+++ b/desktop/src/features/agents/ui/managedAgentAvatar.ts
@@ -8,6 +8,7 @@ type UploadMediaBytes = (
 export async function resolveManagedAgentAvatarUrl(
   avatarUrl: string | null | undefined,
   upload: UploadMediaBytes = uploadMediaBytes,
+  fallbackAvatarUrl?: string | null,
 ): Promise<string | undefined> {
   const resolvedAvatarUrl = avatarUrl?.trim() || undefined;
   if (!resolvedAvatarUrl?.startsWith("data:image/")) {
@@ -24,6 +25,11 @@ export async function resolveManagedAgentAvatarUrl(
     return blob.url;
   } catch (err) {
     console.warn("Avatar upload failed, proceeding without avatar:", err);
-    return undefined;
+    return safeFallbackAvatarUrl(fallbackAvatarUrl);
   }
+}
+
+function safeFallbackAvatarUrl(avatarUrl: string | null | undefined) {
+  const trimmed = avatarUrl?.trim() || undefined;
+  return trimmed?.startsWith("data:image/") ? undefined : trimmed;
 }

--- a/desktop/src/features/agents/ui/managedAgentAvatar.ts
+++ b/desktop/src/features/agents/ui/managedAgentAvatar.ts
@@ -29,8 +29,7 @@ export async function resolveManagedAgentAvatarUrl(
     const bytes = Array.from(atob(b64), (char) => char.charCodeAt(0));
     const blob = await upload(bytes);
     return blob.url;
-  } catch (err) {
-    console.warn("Avatar upload failed, proceeding without avatar:", err);
+  } catch {
     return safeFallbackAvatarUrl(fallbackAvatarUrl);
   }
 }

--- a/desktop/src/features/agents/ui/personaDialogEnvVars.ts
+++ b/desktop/src/features/agents/ui/personaDialogEnvVars.ts
@@ -1,0 +1,25 @@
+import type { EnvVarsValue } from "./EnvVarsEditor";
+
+export function hasText(value: string | null | undefined): boolean {
+  return (value?.trim().length ?? 0) > 0;
+}
+
+export function hasAdvancedEnvVars(
+  value: EnvVarsValue,
+  managedKey: string | null,
+): boolean {
+  return Object.keys(value).some((key) => key !== managedKey);
+}
+
+export function getAdvancedEnvVars(
+  value: EnvVarsValue,
+  managedKey: string | null,
+): EnvVarsValue {
+  if (!managedKey || !(managedKey in value)) {
+    return value;
+  }
+
+  const next = { ...value };
+  delete next[managedKey];
+  return next;
+}

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -203,10 +203,21 @@ function runtimeDefaultsToDatabricks(runtimeId: string) {
   return runtimeId === "buzz-agent" || runtimeId === "goose";
 }
 
+export function runtimeSupportsLlmProviderSelection(runtimeId: string) {
+  return runtimeDefaultsToDatabricks(runtimeId);
+}
+
 function effectiveModelProviderForOptions(
   runtimeId: string,
   providerId: string | null | undefined,
 ) {
+  if (
+    runtimeId.trim().length > 0 &&
+    !runtimeSupportsLlmProviderSelection(runtimeId)
+  ) {
+    return "";
+  }
+
   const trimmedProvider = providerId?.trim() ?? "";
   if (trimmedProvider.length === 0 && runtimeDefaultsToDatabricks(runtimeId)) {
     return "databricks";

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -32,6 +32,12 @@ export type PersonaDropdownOption = {
   value: string;
 };
 
+export type ProviderApiKeyConfig = {
+  envVar: string;
+  label: string;
+  placeholder: string;
+};
+
 const AUTO_MODEL_OPTION: PersonaModelOption = {
   id: "",
   label: "Auto (default)",
@@ -235,16 +241,35 @@ export function getPersonaProviderOptions(
   ];
 }
 
-export function getProviderApiKeyEnvVar(providerId: string): string | null {
+export function getProviderApiKeyConfig(
+  providerId: string,
+): ProviderApiKeyConfig | null {
   switch (providerId.trim()) {
     case "anthropic":
-      return "ANTHROPIC_API_KEY";
+      return {
+        envVar: "ANTHROPIC_API_KEY",
+        label: "Anthropic API key",
+        placeholder: "sk-ant-...",
+      };
     case "openai":
+      return {
+        envVar: "OPENAI_COMPAT_API_KEY",
+        label: "OpenAI API key",
+        placeholder: "sk-...",
+      };
     case "openai-compat":
-      return "OPENAI_COMPAT_API_KEY";
+      return {
+        envVar: "OPENAI_COMPAT_API_KEY",
+        label: "OpenAI-compatible API key",
+        placeholder: "sk-...",
+      };
     default:
       return null;
   }
+}
+
+export function getProviderApiKeyEnvVar(providerId: string): string | null {
+  return getProviderApiKeyConfig(providerId)?.envVar ?? null;
 }
 
 export function shouldClearKnownModelForSelectionScope({

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -45,9 +45,12 @@ const DEFAULT_MODEL_OPTION: PersonaModelOption = {
   label: "Default model",
 };
 
+const DATABRICKS_DEFAULT_MODEL_ID = "goose-claude-4-8-opus";
+const DATABRICKS_DEFAULT_MODEL_LABEL = "Claude Opus 4.8";
+
 const DATABRICKS_DEFAULT_MODEL_OPTION: PersonaModelOption = {
   id: "",
-  label: "Databricks default model",
+  label: `${DATABRICKS_DEFAULT_MODEL_LABEL} (default)`,
 };
 
 // Databricks IDs are sourced from squareup/goose-releases goose_models.json.
@@ -171,7 +174,7 @@ const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
   { id: "anthropic", label: "Anthropic" },
   { id: "openai", label: "OpenAI" },
   { id: "openai-compat", label: "OpenAI-compatible" },
-  { id: "databricks", label: "Databricks" },
+  { id: "databricks", label: "Databricks (Pro)" },
 ];
 
 const PERSONA_MODEL_OPTIONS_BY_RUNTIME: Record<
@@ -196,12 +199,30 @@ function isKnownLlmProvider(
   return (KNOWN_LLM_PROVIDER_IDS as readonly string[]).includes(providerId);
 }
 
+function runtimeDefaultsToDatabricks(runtimeId: string) {
+  return runtimeId === "buzz-agent" || runtimeId === "goose";
+}
+
+function effectiveModelProviderForOptions(
+  runtimeId: string,
+  providerId: string | null | undefined,
+) {
+  const trimmedProvider = providerId?.trim() ?? "";
+  if (trimmedProvider.length === 0 && runtimeDefaultsToDatabricks(runtimeId)) {
+    return "databricks";
+  }
+  return trimmedProvider;
+}
+
 export function getPersonaModelOptions(
   runtimeId: string,
   providerId: string | null | undefined,
 ): readonly PersonaModelOption[] {
   const options = getRuntimePersonaModelOptions(runtimeId);
-  const trimmedProvider = providerId?.trim() ?? "";
+  const trimmedProvider = effectiveModelProviderForOptions(
+    runtimeId,
+    providerId,
+  );
   if (trimmedProvider.length === 0) {
     return options.filter((option) => option.id.length === 0);
   }
@@ -213,7 +234,8 @@ export function getPersonaModelOptions(
     (option) =>
       (option.id.length === 0 &&
         !providerRequiresExplicitModel(trimmedProvider)) ||
-      option.providers?.includes(trimmedProvider),
+      (option.id !== DATABRICKS_DEFAULT_MODEL_ID &&
+        option.providers?.includes(trimmedProvider)),
   );
 }
 
@@ -267,8 +289,8 @@ export function providerRequiresExplicitModel(
 }
 
 export function getDefaultLlmProviderLabel(runtimeId: string) {
-  return runtimeId === "buzz-agent" || runtimeId === "goose"
-    ? "Databricks default"
+  return runtimeDefaultsToDatabricks(runtimeId)
+    ? "Databricks (Pro)"
     : "Default";
 }
 
@@ -277,10 +299,16 @@ export function getPersonaProviderOptions(
   runtimeId: string,
 ): readonly PersonaModelOption[] {
   const trimmedProvider = currentProvider.trim();
-  const options = [
-    { id: "", label: getDefaultLlmProviderLabel(runtimeId) },
-    ...PERSONA_LLM_PROVIDER_OPTIONS,
-  ];
+  const providerOptions = runtimeDefaultsToDatabricks(runtimeId)
+    ? PERSONA_LLM_PROVIDER_OPTIONS.filter((option) =>
+        trimmedProvider === "databricks" ? true : option.id !== "databricks",
+      )
+    : PERSONA_LLM_PROVIDER_OPTIONS;
+  const defaultProviderOptions =
+    runtimeDefaultsToDatabricks(runtimeId) && trimmedProvider === "databricks"
+      ? []
+      : [{ id: "", label: getDefaultLlmProviderLabel(runtimeId) }];
+  const options = [...defaultProviderOptions, ...providerOptions];
   if (
     trimmedProvider.length === 0 ||
     options.some((option) => option.id === trimmedProvider)
@@ -352,6 +380,53 @@ export function formatRuntimeOptionLabel(runtime: AcpRuntimeCatalogEntry) {
           ? " (not installed)"
           : "";
   return `${runtime.label}${suffix}`;
+}
+
+function runtimeAvailabilitySortRank(
+  availability: AcpRuntimeCatalogEntry["availability"],
+) {
+  switch (availability) {
+    case "available":
+      return 0;
+    case "cli_missing":
+      return 1;
+    case "not_installed":
+      return 2;
+    case "adapter_missing":
+      return 3;
+  }
+}
+
+function runtimePreferenceSortRank(runtimeId: string) {
+  switch (runtimeId) {
+    case "buzz-agent":
+      return 0;
+    case "goose":
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+export function sortPersonaRuntimes(
+  runtimes: readonly AcpRuntimeCatalogEntry[],
+) {
+  return [...runtimes].sort((left, right) => {
+    const availabilityDelta =
+      runtimeAvailabilitySortRank(left.availability) -
+      runtimeAvailabilitySortRank(right.availability);
+    if (availabilityDelta !== 0) {
+      return availabilityDelta;
+    }
+
+    const preferenceDelta =
+      runtimePreferenceSortRank(left.id) - runtimePreferenceSortRank(right.id);
+    if (preferenceDelta !== 0) {
+      return preferenceDelta;
+    }
+
+    return left.label.localeCompare(right.label);
+  });
 }
 
 export function getDefaultPersonaRuntime(runtimes: AcpRuntimeCatalogEntry[]) {

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -20,7 +20,7 @@ const KNOWN_LLM_PROVIDER_IDS = [
 
 type PersonaLlmProviderId = (typeof KNOWN_LLM_PROVIDER_IDS)[number];
 
-type PersonaModelOption = {
+export type PersonaModelOption = {
   id: string;
   label: string;
   providers?: readonly PersonaLlmProviderId[];
@@ -236,8 +236,8 @@ export function getDefaultPersonaRuntime(runtimes: AcpRuntimeCatalogEntry[]) {
     (runtime) => runtime.availability === "available",
   );
   return (
-    available.find((runtime) => runtime.id === "goose") ??
     available.find((runtime) => runtime.id === "buzz-agent") ??
+    available.find((runtime) => runtime.id === "goose") ??
     available[0] ??
     null
   );

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -174,7 +174,7 @@ const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
   { id: "anthropic", label: "Anthropic" },
   { id: "openai", label: "OpenAI" },
   { id: "openai-compat", label: "OpenAI-compatible" },
-  { id: "databricks", label: "Databricks (Pro)" },
+  { id: "databricks", label: "Databricks" },
 ];
 
 const PERSONA_MODEL_OPTIONS_BY_RUNTIME: Record<
@@ -288,10 +288,8 @@ export function providerRequiresExplicitModel(
   );
 }
 
-export function getDefaultLlmProviderLabel(runtimeId: string) {
-  return runtimeDefaultsToDatabricks(runtimeId)
-    ? "Databricks (Pro)"
-    : "Default";
+export function getDefaultLlmProviderLabel() {
+  return "Default";
 }
 
 export function getPersonaProviderOptions(
@@ -307,7 +305,7 @@ export function getPersonaProviderOptions(
   const defaultProviderOptions =
     runtimeDefaultsToDatabricks(runtimeId) && trimmedProvider === "databricks"
       ? []
-      : [{ id: "", label: getDefaultLlmProviderLabel(runtimeId) }];
+      : [{ id: "", label: getDefaultLlmProviderLabel() }];
   const options = [...defaultProviderOptions, ...providerOptions];
   if (
     trimmedProvider.length === 0 ||

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -1,0 +1,244 @@
+import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
+
+export const PERSONA_FIELD_SHELL_CLASS =
+  "rounded-xl border border-input bg-muted/40 transition-colors duration-150 ease-out hover:border-muted-foreground/40 focus-within:border-muted-foreground/50";
+export const PERSONA_FIELD_CONTROL_CLASS =
+  "border-0 bg-transparent text-muted-foreground shadow-none outline-none ring-0 transition-colors duration-150 ease-out placeholder:text-muted-foreground/55 focus:bg-transparent focus:text-muted-foreground focus:outline-hidden focus-visible:ring-0";
+
+export const AUTO_MODEL_DROPDOWN_VALUE = "__auto_model__";
+export const CUSTOM_MODEL_DROPDOWN_VALUE = "__custom_model__";
+export const AUTO_PROVIDER_DROPDOWN_VALUE = "__auto_provider__";
+export const CUSTOM_PROVIDER_DROPDOWN_VALUE = "__custom_provider__";
+export const NO_RUNTIME_DROPDOWN_VALUE = "__no_runtime__";
+
+const KNOWN_LLM_PROVIDER_IDS = [
+  "anthropic",
+  "databricks",
+  "openai",
+  "openai-compat",
+] as const;
+
+type PersonaLlmProviderId = (typeof KNOWN_LLM_PROVIDER_IDS)[number];
+
+type PersonaModelOption = {
+  id: string;
+  label: string;
+  providers?: readonly PersonaLlmProviderId[];
+};
+
+export type PersonaDropdownOption = {
+  disabled?: boolean;
+  label: string;
+  value: string;
+};
+
+const AUTO_MODEL_OPTION: PersonaModelOption = {
+  id: "",
+  label: "Auto (default)",
+};
+
+const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
+  { id: "", label: "Auto (default)" },
+  { id: "anthropic", label: "Anthropic" },
+  { id: "openai", label: "OpenAI" },
+  { id: "openai-compat", label: "OpenAI-compatible" },
+  { id: "databricks", label: "Databricks" },
+];
+
+const PERSONA_MODEL_OPTIONS_BY_RUNTIME: Record<
+  string,
+  readonly PersonaModelOption[]
+> = {
+  goose: [
+    AUTO_MODEL_OPTION,
+    {
+      id: "goose-claude-4-6-opus",
+      label: "Claude Opus 4.6",
+      providers: ["anthropic", "databricks"],
+    },
+    {
+      id: "goose-claude-4-6-sonnet",
+      label: "Claude Sonnet 4.6",
+      providers: ["anthropic", "databricks"],
+    },
+    {
+      id: "gpt-5",
+      label: "GPT-5",
+      providers: ["databricks", "openai", "openai-compat"],
+    },
+    {
+      id: "gpt-5-mini",
+      label: "GPT-5 mini",
+      providers: ["databricks", "openai", "openai-compat"],
+    },
+    {
+      id: "gemini-2.5-pro",
+      label: "Gemini 2.5 Pro",
+      providers: ["databricks", "openai-compat"],
+    },
+    {
+      id: "gemini-2.5-flash",
+      label: "Gemini 2.5 Flash",
+      providers: ["databricks", "openai-compat"],
+    },
+  ],
+  "buzz-agent": [
+    AUTO_MODEL_OPTION,
+    {
+      id: "goose-claude-4-6-opus",
+      label: "Claude Opus 4.6",
+      providers: ["anthropic", "databricks"],
+    },
+    {
+      id: "goose-claude-4-6-sonnet",
+      label: "Claude Sonnet 4.6",
+      providers: ["anthropic", "databricks"],
+    },
+    {
+      id: "gpt-5",
+      label: "GPT-5",
+      providers: ["databricks", "openai", "openai-compat"],
+    },
+    {
+      id: "gpt-5-mini",
+      label: "GPT-5 mini",
+      providers: ["databricks", "openai", "openai-compat"],
+    },
+    {
+      id: "gemini-2.5-pro",
+      label: "Gemini 2.5 Pro",
+      providers: ["databricks", "openai-compat"],
+    },
+    {
+      id: "gemini-2.5-flash",
+      label: "Gemini 2.5 Flash",
+      providers: ["databricks", "openai-compat"],
+    },
+  ],
+  claude: [AUTO_MODEL_OPTION],
+  codex: [AUTO_MODEL_OPTION],
+};
+
+export function getRuntimePersonaModelOptions(
+  runtimeId: string,
+): readonly PersonaModelOption[] {
+  return PERSONA_MODEL_OPTIONS_BY_RUNTIME[runtimeId] ?? [AUTO_MODEL_OPTION];
+}
+
+function isKnownLlmProvider(
+  providerId: string,
+): providerId is PersonaLlmProviderId {
+  return (KNOWN_LLM_PROVIDER_IDS as readonly string[]).includes(providerId);
+}
+
+export function getPersonaModelOptions(
+  runtimeId: string,
+  providerId: string | null | undefined,
+): readonly PersonaModelOption[] {
+  const options = getRuntimePersonaModelOptions(runtimeId);
+  const trimmedProvider = providerId?.trim() ?? "";
+  if (!isKnownLlmProvider(trimmedProvider)) {
+    return options;
+  }
+
+  return options.filter(
+    (option) =>
+      option.id.length === 0 || option.providers?.includes(trimmedProvider),
+  );
+}
+
+function hasExactPersonaModelOption(
+  options: readonly PersonaModelOption[],
+  modelId: string,
+) {
+  const trimmedModel = modelId.trim();
+  return (
+    trimmedModel.length > 0 &&
+    options.some((option) => option.id === trimmedModel)
+  );
+}
+
+export function hasPersonaModelOption(
+  options: readonly PersonaModelOption[],
+  modelId: string,
+) {
+  const trimmedModel = modelId.trim();
+  return (
+    trimmedModel.length === 0 ||
+    options.some((option) => option.id === trimmedModel)
+  );
+}
+
+export function getModelSelectValue({
+  isCustomModelEditing,
+  isModelCustom,
+  model,
+}: {
+  isCustomModelEditing: boolean;
+  isModelCustom: boolean;
+  model: string;
+}) {
+  if (isCustomModelEditing || isModelCustom) {
+    return CUSTOM_MODEL_DROPDOWN_VALUE;
+  }
+
+  return model.trim() || AUTO_MODEL_DROPDOWN_VALUE;
+}
+
+export function getPersonaProviderOptions(
+  currentProvider: string,
+): readonly PersonaModelOption[] {
+  const trimmedProvider = currentProvider.trim();
+  if (
+    trimmedProvider.length === 0 ||
+    PERSONA_LLM_PROVIDER_OPTIONS.some((option) => option.id === trimmedProvider)
+  ) {
+    return PERSONA_LLM_PROVIDER_OPTIONS;
+  }
+
+  return [
+    ...PERSONA_LLM_PROVIDER_OPTIONS,
+    { id: trimmedProvider, label: `${trimmedProvider} (current)` },
+  ];
+}
+
+export function shouldClearKnownModelForSelectionScope({
+  model,
+  provider,
+  runtime,
+}: {
+  model: string;
+  provider: string | null | undefined;
+  runtime: string;
+}) {
+  const runtimeOptions = getRuntimePersonaModelOptions(runtime);
+  const scopedOptions = getPersonaModelOptions(runtime, provider);
+  return (
+    hasExactPersonaModelOption(runtimeOptions, model) &&
+    !hasExactPersonaModelOption(scopedOptions, model)
+  );
+}
+
+export function formatRuntimeOptionLabel(runtime: AcpRuntimeCatalogEntry) {
+  const suffix =
+    runtime.availability === "adapter_missing"
+      ? " (adapter missing)"
+      : runtime.availability === "cli_missing"
+        ? " (CLI missing)"
+        : runtime.availability === "not_installed"
+          ? " (not installed)"
+          : "";
+  return `${runtime.label}${suffix}`;
+}
+
+export function getDefaultPersonaRuntime(runtimes: AcpRuntimeCatalogEntry[]) {
+  const available = runtimes.filter(
+    (runtime) => runtime.availability === "available",
+  );
+  return (
+    available.find((runtime) => runtime.id === "goose") ??
+    available.find((runtime) => runtime.id === "buzz-agent") ??
+    available[0] ??
+    null
+  );
+}

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -4,6 +4,8 @@ export const PERSONA_FIELD_SHELL_CLASS =
   "rounded-xl border border-input bg-muted/40 transition-colors duration-150 ease-out hover:border-muted-foreground/40 focus-within:border-muted-foreground/50";
 export const PERSONA_FIELD_CONTROL_CLASS =
   "border-0 bg-transparent text-muted-foreground shadow-none outline-none ring-0 transition-colors duration-150 ease-out placeholder:text-muted-foreground/55 focus:bg-transparent focus:text-muted-foreground focus:outline-hidden focus-visible:ring-0";
+export const PERSONA_LABEL_OPTIONAL_CLASS =
+  "ml-1 text-xs font-normal text-muted-foreground/50";
 
 export const AUTO_MODEL_DROPDOWN_VALUE = "__auto_model__";
 export const CUSTOM_MODEL_DROPDOWN_VALUE = "__custom_model__";
@@ -38,16 +40,21 @@ export type ProviderApiKeyConfig = {
   placeholder: string;
 };
 
-const AUTO_MODEL_OPTION: PersonaModelOption = {
+const DEFAULT_MODEL_OPTION: PersonaModelOption = {
   id: "",
-  label: "Auto (default)",
+  label: "Default model",
+};
+
+const DATABRICKS_DEFAULT_MODEL_OPTION: PersonaModelOption = {
+  id: "",
+  label: "Databricks default model",
 };
 
 // Databricks IDs are sourced from squareup/goose-releases goose_models.json.
 // `goose-claude-4-8-opus` is also the current Buzz internal build default in
 // squareup/buzz-releases, though it is ahead of that registry today.
 const BUZZ_AGENT_MODEL_OPTIONS: readonly PersonaModelOption[] = [
-  AUTO_MODEL_OPTION,
+  DATABRICKS_DEFAULT_MODEL_OPTION,
   {
     id: "goose-claude-4-8-opus",
     label: "Claude Opus 4.8",
@@ -99,6 +106,26 @@ const BUZZ_AGENT_MODEL_OPTIONS: readonly PersonaModelOption[] = [
     providers: ["databricks"],
   },
   {
+    id: "gpt-5.5",
+    label: "GPT-5.5",
+    providers: ["openai", "openai-compat"],
+  },
+  {
+    id: "gpt-5.4",
+    label: "GPT-5.4",
+    providers: ["openai", "openai-compat"],
+  },
+  {
+    id: "gpt-5.4-mini",
+    label: "GPT-5.4 mini",
+    providers: ["openai", "openai-compat"],
+  },
+  {
+    id: "gpt-5.4-nano",
+    label: "GPT-5.4 nano",
+    providers: ["openai", "openai-compat"],
+  },
+  {
     id: "gpt-5",
     label: "GPT-5",
     providers: ["openai", "openai-compat"],
@@ -141,7 +168,6 @@ const BUZZ_AGENT_MODEL_OPTIONS: readonly PersonaModelOption[] = [
 ];
 
 const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
-  { id: "", label: "Auto (default)" },
   { id: "anthropic", label: "Anthropic" },
   { id: "openai", label: "OpenAI" },
   { id: "openai-compat", label: "OpenAI-compatible" },
@@ -154,14 +180,14 @@ const PERSONA_MODEL_OPTIONS_BY_RUNTIME: Record<
 > = {
   goose: BUZZ_AGENT_MODEL_OPTIONS,
   "buzz-agent": BUZZ_AGENT_MODEL_OPTIONS,
-  claude: [AUTO_MODEL_OPTION],
-  codex: [AUTO_MODEL_OPTION],
+  claude: [DEFAULT_MODEL_OPTION],
+  codex: [DEFAULT_MODEL_OPTION],
 };
 
 export function getRuntimePersonaModelOptions(
   runtimeId: string,
 ): readonly PersonaModelOption[] {
-  return PERSONA_MODEL_OPTIONS_BY_RUNTIME[runtimeId] ?? [AUTO_MODEL_OPTION];
+  return PERSONA_MODEL_OPTIONS_BY_RUNTIME[runtimeId] ?? [DEFAULT_MODEL_OPTION];
 }
 
 function isKnownLlmProvider(
@@ -176,13 +202,18 @@ export function getPersonaModelOptions(
 ): readonly PersonaModelOption[] {
   const options = getRuntimePersonaModelOptions(runtimeId);
   const trimmedProvider = providerId?.trim() ?? "";
+  if (trimmedProvider.length === 0) {
+    return options.filter((option) => option.id.length === 0);
+  }
   if (!isKnownLlmProvider(trimmedProvider)) {
     return options;
   }
 
   return options.filter(
     (option) =>
-      option.id.length === 0 || option.providers?.includes(trimmedProvider),
+      (option.id.length === 0 &&
+        !providerRequiresExplicitModel(trimmedProvider)) ||
+      option.providers?.includes(trimmedProvider),
   );
 }
 
@@ -224,19 +255,41 @@ export function getModelSelectValue({
   return model.trim() || AUTO_MODEL_DROPDOWN_VALUE;
 }
 
+export function providerRequiresExplicitModel(
+  providerId: string | null | undefined,
+) {
+  const trimmedProvider = providerId?.trim() ?? "";
+  return (
+    trimmedProvider === "anthropic" ||
+    trimmedProvider === "openai" ||
+    trimmedProvider === "openai-compat"
+  );
+}
+
+export function getDefaultLlmProviderLabel(runtimeId: string) {
+  return runtimeId === "buzz-agent" || runtimeId === "goose"
+    ? "Databricks default"
+    : "Default";
+}
+
 export function getPersonaProviderOptions(
   currentProvider: string,
+  runtimeId: string,
 ): readonly PersonaModelOption[] {
   const trimmedProvider = currentProvider.trim();
+  const options = [
+    { id: "", label: getDefaultLlmProviderLabel(runtimeId) },
+    ...PERSONA_LLM_PROVIDER_OPTIONS,
+  ];
   if (
     trimmedProvider.length === 0 ||
-    PERSONA_LLM_PROVIDER_OPTIONS.some((option) => option.id === trimmedProvider)
+    options.some((option) => option.id === trimmedProvider)
   ) {
-    return PERSONA_LLM_PROVIDER_OPTIONS;
+    return options;
   }
 
   return [
-    ...PERSONA_LLM_PROVIDER_OPTIONS,
+    ...options,
     { id: trimmedProvider, label: `${trimmedProvider} (current)` },
   ];
 }

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -288,8 +288,10 @@ export function providerRequiresExplicitModel(
   );
 }
 
-export function getDefaultLlmProviderLabel() {
-  return "Default";
+export function getDefaultLlmProviderLabel(runtimeId: string) {
+  return runtimeDefaultsToDatabricks(runtimeId)
+    ? "Databricks (default)"
+    : "Default";
 }
 
 export function getPersonaProviderOptions(
@@ -305,7 +307,7 @@ export function getPersonaProviderOptions(
   const defaultProviderOptions =
     runtimeDefaultsToDatabricks(runtimeId) && trimmedProvider === "databricks"
       ? []
-      : [{ id: "", label: getDefaultLlmProviderLabel() }];
+      : [{ id: "", label: getDefaultLlmProviderLabel(runtimeId) }];
   const options = [...defaultProviderOptions, ...providerOptions];
   if (
     trimmedProvider.length === 0 ||

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -37,6 +37,103 @@ const AUTO_MODEL_OPTION: PersonaModelOption = {
   label: "Auto (default)",
 };
 
+// Databricks IDs are sourced from squareup/goose-releases goose_models.json.
+// `goose-claude-4-8-opus` is also the current Buzz internal build default in
+// squareup/buzz-releases, though it is ahead of that registry today.
+const BUZZ_AGENT_MODEL_OPTIONS: readonly PersonaModelOption[] = [
+  AUTO_MODEL_OPTION,
+  {
+    id: "goose-claude-4-8-opus",
+    label: "Claude Opus 4.8",
+    providers: ["databricks"],
+  },
+  {
+    id: "goose-claude-4-7-opus",
+    label: "Claude Opus 4.7",
+    providers: ["databricks"],
+  },
+  {
+    id: "goose-claude-4-6-opus",
+    label: "Claude Opus 4.6",
+    providers: ["anthropic", "databricks"],
+  },
+  {
+    id: "goose-claude-4-6-sonnet",
+    label: "Claude Sonnet 4.6",
+    providers: ["anthropic", "databricks"],
+  },
+  {
+    id: "goose-claude-4-5-opus",
+    label: "Claude Opus 4.5",
+    providers: ["databricks"],
+  },
+  {
+    id: "goose-claude-4-5-sonnet",
+    label: "Claude Sonnet 4.5",
+    providers: ["databricks"],
+  },
+  {
+    id: "goose-claude-4-5-haiku",
+    label: "Claude Haiku 4.5",
+    providers: ["databricks"],
+  },
+  {
+    id: "goose-gpt-5-2",
+    label: "GPT-5.2",
+    providers: ["databricks"],
+  },
+  {
+    id: "databricks-gpt-5-5-pro",
+    label: "GPT-5.5 Pro",
+    providers: ["databricks"],
+  },
+  {
+    id: "databricks-gpt-5-5",
+    label: "GPT-5.5",
+    providers: ["databricks"],
+  },
+  {
+    id: "gpt-5",
+    label: "GPT-5",
+    providers: ["openai", "openai-compat"],
+  },
+  {
+    id: "gpt-5-mini",
+    label: "GPT-5 mini",
+    providers: ["openai", "openai-compat"],
+  },
+  {
+    id: "goose-gemini-3-5-flash",
+    label: "Gemini 3.5 Flash",
+    providers: ["databricks"],
+  },
+  {
+    id: "goose-gemini-3-1-pro",
+    label: "Gemini 3.1 Pro",
+    providers: ["databricks"],
+  },
+  {
+    id: "goose-gemini-3-1-flash-lite",
+    label: "Gemini 3.1 Flash Lite",
+    providers: ["databricks"],
+  },
+  {
+    id: "goose-gemini-2-5-pro",
+    label: "Gemini 2.5 Pro",
+    providers: ["databricks"],
+  },
+  {
+    id: "gemini-2.5-pro",
+    label: "Gemini 2.5 Pro",
+    providers: ["openai-compat"],
+  },
+  {
+    id: "gemini-2.5-flash",
+    label: "Gemini 2.5 Flash",
+    providers: ["openai-compat"],
+  },
+];
+
 const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
   { id: "", label: "Auto (default)" },
   { id: "anthropic", label: "Anthropic" },
@@ -49,72 +146,8 @@ const PERSONA_MODEL_OPTIONS_BY_RUNTIME: Record<
   string,
   readonly PersonaModelOption[]
 > = {
-  goose: [
-    AUTO_MODEL_OPTION,
-    {
-      id: "goose-claude-4-6-opus",
-      label: "Claude Opus 4.6",
-      providers: ["anthropic", "databricks"],
-    },
-    {
-      id: "goose-claude-4-6-sonnet",
-      label: "Claude Sonnet 4.6",
-      providers: ["anthropic", "databricks"],
-    },
-    {
-      id: "gpt-5",
-      label: "GPT-5",
-      providers: ["databricks", "openai", "openai-compat"],
-    },
-    {
-      id: "gpt-5-mini",
-      label: "GPT-5 mini",
-      providers: ["databricks", "openai", "openai-compat"],
-    },
-    {
-      id: "gemini-2.5-pro",
-      label: "Gemini 2.5 Pro",
-      providers: ["databricks", "openai-compat"],
-    },
-    {
-      id: "gemini-2.5-flash",
-      label: "Gemini 2.5 Flash",
-      providers: ["databricks", "openai-compat"],
-    },
-  ],
-  "buzz-agent": [
-    AUTO_MODEL_OPTION,
-    {
-      id: "goose-claude-4-6-opus",
-      label: "Claude Opus 4.6",
-      providers: ["anthropic", "databricks"],
-    },
-    {
-      id: "goose-claude-4-6-sonnet",
-      label: "Claude Sonnet 4.6",
-      providers: ["anthropic", "databricks"],
-    },
-    {
-      id: "gpt-5",
-      label: "GPT-5",
-      providers: ["databricks", "openai", "openai-compat"],
-    },
-    {
-      id: "gpt-5-mini",
-      label: "GPT-5 mini",
-      providers: ["databricks", "openai", "openai-compat"],
-    },
-    {
-      id: "gemini-2.5-pro",
-      label: "Gemini 2.5 Pro",
-      providers: ["databricks", "openai-compat"],
-    },
-    {
-      id: "gemini-2.5-flash",
-      label: "Gemini 2.5 Flash",
-      providers: ["databricks", "openai-compat"],
-    },
-  ],
+  goose: BUZZ_AGENT_MODEL_OPTIONS,
+  "buzz-agent": BUZZ_AGENT_MODEL_OPTIONS,
   claude: [AUTO_MODEL_OPTION],
   codex: [AUTO_MODEL_OPTION],
 };

--- a/desktop/src/features/agents/ui/personaDialogPickers.tsx
+++ b/desktop/src/features/agents/ui/personaDialogPickers.tsx
@@ -235,6 +235,18 @@ export function getPersonaProviderOptions(
   ];
 }
 
+export function getProviderApiKeyEnvVar(providerId: string): string | null {
+  switch (providerId.trim()) {
+    case "anthropic":
+      return "ANTHROPIC_API_KEY";
+    case "openai":
+    case "openai-compat":
+      return "OPENAI_COMPAT_API_KEY";
+    default:
+      return null;
+  }
+}
+
 export function shouldClearKnownModelForSelectionScope({
   model,
   provider,

--- a/desktop/src/features/agents/ui/personaDialogState.test.mjs
+++ b/desktop/src/features/agents/ui/personaDialogState.test.mjs
@@ -44,7 +44,7 @@ test("createPersonaDialogState returns a fresh empty draft", () => {
   const first = createPersonaDialogState();
   const second = createPersonaDialogState();
 
-  assert.equal(first.title, "Create persona");
+  assert.equal(first.title, "Create agent");
   assert.deepEqual(first.initialValues, {
     displayName: "",
     avatarUrl: "",
@@ -123,7 +123,7 @@ test("editPersonaDialogState preserves the persona id for updates", () => {
     updatedAt: "2025-01-02T00:00:00Z",
   });
 
-  assert.equal(state.title, "Edit persona");
+  assert.equal(state.title, "Edit agent");
   assert.equal(state.description, "");
   assert.equal(state.submitLabel, "Save changes");
   assert.deepEqual(state.initialValues, {
@@ -165,6 +165,7 @@ test("importPersonaDialogState maps parsed persona previews into create drafts",
   const state = importPersonaDialogState({
     displayName: "Imported",
     avatarDataUrl: null,
+    avatarRef: null,
     systemPrompt: "Imported prompt",
     runtime: null,
     model: "model-b",
@@ -182,6 +183,22 @@ test("importPersonaDialogState maps parsed persona previews into create drafts",
     model: "model-b",
     provider: undefined,
   });
+});
+
+test("importPersonaDialogState preserves Goose app-avatar refs from persona markdown", () => {
+  const state = importPersonaDialogState({
+    displayName: "Goosey",
+    avatarDataUrl: null,
+    avatarRef: "app-avatar:gloopies-19",
+    systemPrompt: "Imported prompt",
+    runtime: null,
+    model: null,
+    provider: null,
+    namePool: [],
+    sourceFile: "goosey.persona.md",
+  });
+
+  assert.equal(state.initialValues.avatarUrl, "app-avatar:gloopies-19");
 });
 
 test("editPersonaDialogState preserves provider=databricks", () => {
@@ -248,6 +265,7 @@ test("importPersonaDialogState preserves provider=anthropic", () => {
   const state = importPersonaDialogState({
     displayName: "Imported With Provider",
     avatarDataUrl: null,
+    avatarRef: null,
     systemPrompt: "Anthropic agent.",
     runtime: "goose",
     model: "claude-sonnet",

--- a/desktop/src/features/agents/ui/personaDialogState.test.mjs
+++ b/desktop/src/features/agents/ui/personaDialogState.test.mjs
@@ -233,6 +233,27 @@ test("importPersonaDialogState filters unresolved Goose app-avatar refs", () => 
   assert.equal(state.initialValues.avatarUrl, "");
 });
 
+test("importPersonaDialogState filters nonpersistent imported avatar refs", () => {
+  for (const avatarRef of [
+    "blob:https://buzz.example/temporary-avatar",
+    "ipfs://bafybeigdyrzt",
+  ]) {
+    const state = importPersonaDialogState({
+      displayName: "Packed avatar",
+      avatarDataUrl: null,
+      avatarRef,
+      systemPrompt: "Imported prompt",
+      runtime: null,
+      model: null,
+      provider: null,
+      namePool: [],
+      sourceFile: "pack.persona.zip",
+    });
+
+    assert.equal(state.initialValues.avatarUrl, "");
+  }
+});
+
 test("importPersonaDialogState preserves URL-like avatar refs", () => {
   const state = importPersonaDialogState({
     displayName: "Hosted avatar",
@@ -267,6 +288,7 @@ test("importPersonaDialogState filters relative avatar refs from packs", () => {
 
   assert.equal(state.initialValues.avatarUrl, "");
 });
+
 test("editPersonaDialogState preserves provider=databricks", () => {
   const state = editPersonaDialogState({
     id: "persona-provider",

--- a/desktop/src/features/agents/ui/personaDialogState.test.mjs
+++ b/desktop/src/features/agents/ui/personaDialogState.test.mjs
@@ -201,6 +201,40 @@ test("importPersonaDialogState preserves Goose app-avatar refs from persona mark
   assert.equal(state.initialValues.avatarUrl, "app-avatar:gloopies-19");
 });
 
+test("importPersonaDialogState preserves URL-like avatar refs", () => {
+  const state = importPersonaDialogState({
+    displayName: "Hosted avatar",
+    avatarDataUrl: null,
+    avatarRef: "https://relay.example/avatar.png",
+    systemPrompt: "Imported prompt",
+    runtime: null,
+    model: null,
+    provider: null,
+    namePool: [],
+    sourceFile: "hosted.persona.md",
+  });
+
+  assert.equal(
+    state.initialValues.avatarUrl,
+    "https://relay.example/avatar.png",
+  );
+});
+
+test("importPersonaDialogState filters relative avatar refs from packs", () => {
+  const state = importPersonaDialogState({
+    displayName: "Packed avatar",
+    avatarDataUrl: null,
+    avatarRef: "./avatars/lep.png",
+    systemPrompt: "Imported prompt",
+    runtime: null,
+    model: null,
+    provider: null,
+    namePool: [],
+    sourceFile: "pack.persona.zip",
+  });
+
+  assert.equal(state.initialValues.avatarUrl, "");
+});
 test("editPersonaDialogState preserves provider=databricks", () => {
   const state = editPersonaDialogState({
     id: "persona-provider",

--- a/desktop/src/features/agents/ui/personaDialogState.test.mjs
+++ b/desktop/src/features/agents/ui/personaDialogState.test.mjs
@@ -217,7 +217,7 @@ test("importPersonaDialogState preserves imported name pools", () => {
   assert.deepEqual(state.initialValues.namePool, ["Birch", "Compass"]);
 });
 
-test("importPersonaDialogState preserves Goose app-avatar refs from persona markdown", () => {
+test("importPersonaDialogState filters unresolved Goose app-avatar refs", () => {
   const state = importPersonaDialogState({
     displayName: "Goosey",
     avatarDataUrl: null,
@@ -230,7 +230,7 @@ test("importPersonaDialogState preserves Goose app-avatar refs from persona mark
     sourceFile: "goosey.persona.md",
   });
 
-  assert.equal(state.initialValues.avatarUrl, "app-avatar:gloopies-19");
+  assert.equal(state.initialValues.avatarUrl, "");
 });
 
 test("importPersonaDialogState preserves URL-like avatar refs", () => {

--- a/desktop/src/features/agents/ui/personaDialogState.test.mjs
+++ b/desktop/src/features/agents/ui/personaDialogState.test.mjs
@@ -6,7 +6,9 @@ import {
   createPersonaDialogState,
   duplicatePersonaDialogState,
   editPersonaDialogState,
+  formatPersonaNamePoolText,
   importPersonaDialogState,
+  parsePersonaNamePoolText,
 } from "./personaDialogState.ts";
 
 test("canSubmitPersonaDialog requires a display name but not a system prompt", () => {
@@ -38,6 +40,20 @@ test("canSubmitPersonaDialog blocks while a save is pending", () => {
     canSubmitPersonaDialog({ displayName: "Coder", isPending: true }),
     false,
   );
+});
+
+test("persona name pool helpers parse, format, and clear values", () => {
+  assert.deepEqual(parsePersonaNamePoolText("Birch, Compass, , Ridge "), [
+    "Birch",
+    "Compass",
+    "Ridge",
+  ]);
+  assert.deepEqual(parsePersonaNamePoolText("   "), []);
+  assert.equal(
+    formatPersonaNamePoolText(["Birch", "Compass", "Ridge"]),
+    "Birch, Compass, Ridge",
+  );
+  assert.equal(formatPersonaNamePoolText(undefined), "");
 });
 
 test("createPersonaDialogState returns a fresh empty draft", () => {
@@ -183,6 +199,22 @@ test("importPersonaDialogState maps parsed persona previews into create drafts",
     model: "model-b",
     provider: undefined,
   });
+});
+
+test("importPersonaDialogState preserves imported name pools", () => {
+  const state = importPersonaDialogState({
+    displayName: "Named imports",
+    avatarDataUrl: null,
+    avatarRef: null,
+    systemPrompt: "Imported prompt",
+    runtime: null,
+    model: null,
+    provider: null,
+    namePool: ["Birch", "Compass"],
+    sourceFile: "named.persona.json",
+  });
+
+  assert.deepEqual(state.initialValues.namePool, ["Birch", "Compass"]);
 });
 
 test("importPersonaDialogState preserves Goose app-avatar refs from persona markdown", () => {

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -104,7 +104,7 @@ export function importPersonaDialogState(
     submitLabel: "Create agent",
     initialValues: {
       displayName: persona.displayName,
-      avatarUrl: persona.avatarDataUrl ?? "",
+      avatarUrl: persona.avatarDataUrl ?? persona.avatarRef ?? "",
       systemPrompt: persona.systemPrompt,
       runtime: persona.runtime ?? undefined,
       model: persona.model ?? undefined,

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -1,4 +1,4 @@
-import type { ParsePersonaFilesResult } from "@/shared/api/tauriPersonas";
+import type { ParsedPersonaPreview } from "@/shared/api/tauriPersonas";
 import type {
   AgentPersona,
   CreatePersonaInput,
@@ -12,7 +12,10 @@ export type PersonaDialogState = {
   title: string;
 };
 
-type ParsedPersonaDraft = ParsePersonaFilesResult["personas"][number];
+type ImportedPersonaAvatarPreview = Pick<
+  ParsedPersonaPreview,
+  "avatarDataUrl" | "avatarRef"
+>;
 
 /**
  * Whether the persona dialog's save action should be enabled.
@@ -49,7 +52,7 @@ function isSafeImportedAvatarRef(
   }
 }
 
-function importedAvatarUrl(persona: ParsedPersonaDraft) {
+export function importedAvatarUrl(persona: ImportedPersonaAvatarPreview) {
   if (persona.avatarDataUrl) return persona.avatarDataUrl;
   return isSafeImportedAvatarRef(persona.avatarRef) ? persona.avatarRef : "";
 }
@@ -122,7 +125,7 @@ export function editPersonaDialogState(
 }
 
 export function importPersonaDialogState(
-  persona: ParsedPersonaDraft,
+  persona: ParsedPersonaPreview,
 ): PersonaDialogState {
   return {
     title: `Import ${persona.displayName}`,

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -42,8 +42,6 @@ function isSafeImportedAvatarRef(
     return (
       parsed.protocol === "http:" ||
       parsed.protocol === "https:" ||
-      parsed.protocol === "blob:" ||
-      parsed.protocol === "ipfs:" ||
       (parsed.protocol === "data:" && trimmed.startsWith("data:image/"))
     );
   } catch {

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -30,10 +30,10 @@ export function canSubmitPersonaDialog(args: {
 
 export function createPersonaDialogState(): PersonaDialogState {
   return {
-    title: "Create persona",
+    title: "Create agent",
     description:
-      "Save a reusable role, prompt, and optional avatar for future agent deployments.",
-    submitLabel: "Create persona",
+      "Create an agent profile and start its managed agent instance.",
+    submitLabel: "Create agent",
     initialValues: {
       displayName: "",
       avatarUrl: "",
@@ -50,8 +50,8 @@ export function duplicatePersonaDialogState(
   return {
     title: `Duplicate ${persona.displayName}`,
     description:
-      "Create a new persona by copying this template and adjusting it as needed.",
-    submitLabel: "Create persona",
+      "Create a new agent by copying this profile and adjusting it as needed.",
+    submitLabel: "Create agent",
     initialValues: {
       displayName: `${persona.displayName} copy`,
       avatarUrl: persona.avatarUrl ?? "",
@@ -74,7 +74,7 @@ export function editPersonaDialogState(
   persona: AgentPersona,
 ): PersonaDialogState {
   return {
-    title: "Edit persona",
+    title: "Edit agent",
     description: "",
     submitLabel: "Save changes",
     initialValues: {
@@ -100,8 +100,8 @@ export function importPersonaDialogState(
 ): PersonaDialogState {
   return {
     title: `Import ${persona.displayName}`,
-    description: "Review and save this imported persona.",
-    submitLabel: "Create persona",
+    description: "Review and create this imported agent.",
+    submitLabel: "Create agent",
     initialValues: {
       displayName: persona.displayName,
       avatarUrl: persona.avatarDataUrl ?? "",

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -36,7 +36,6 @@ function isSafeImportedAvatarRef(
 ): ref is string {
   const trimmed = ref?.trim();
   if (!trimmed) return false;
-  if (trimmed.startsWith("app-avatar:")) return true;
 
   try {
     const parsed = new URL(trimmed);

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -28,6 +28,32 @@ export function canSubmitPersonaDialog(args: {
   return args.displayName.trim().length > 0 && !args.isPending;
 }
 
+function isSafeImportedAvatarRef(
+  ref: string | null | undefined,
+): ref is string {
+  const trimmed = ref?.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith("app-avatar:")) return true;
+
+  try {
+    const parsed = new URL(trimmed);
+    return (
+      parsed.protocol === "http:" ||
+      parsed.protocol === "https:" ||
+      parsed.protocol === "blob:" ||
+      parsed.protocol === "ipfs:" ||
+      (parsed.protocol === "data:" && trimmed.startsWith("data:image/"))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function importedAvatarUrl(persona: ParsedPersonaDraft) {
+  if (persona.avatarDataUrl) return persona.avatarDataUrl;
+  return isSafeImportedAvatarRef(persona.avatarRef) ? persona.avatarRef : "";
+}
+
 export function createPersonaDialogState(): PersonaDialogState {
   return {
     title: "Create agent",
@@ -104,7 +130,7 @@ export function importPersonaDialogState(
     submitLabel: "Create agent",
     initialValues: {
       displayName: persona.displayName,
-      avatarUrl: persona.avatarDataUrl ?? persona.avatarRef ?? "",
+      avatarUrl: importedAvatarUrl(persona),
       systemPrompt: persona.systemPrompt,
       runtime: persona.runtime ?? undefined,
       model: persona.model ?? undefined,

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -57,6 +57,17 @@ export function importedAvatarUrl(persona: ImportedPersonaAvatarPreview) {
   return isSafeImportedAvatarRef(persona.avatarRef) ? persona.avatarRef : "";
 }
 
+export function formatPersonaNamePoolText(namePool: string[] | undefined) {
+  return namePool?.join(", ") ?? "";
+}
+
+export function parsePersonaNamePoolText(text: string): string[] {
+  return text
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
 export function createPersonaDialogState(): PersonaDialogState {
   return {
     title: "Create agent",
@@ -138,6 +149,7 @@ export function importPersonaDialogState(
       runtime: persona.runtime ?? undefined,
       model: persona.model ?? undefined,
       provider: persona.provider ?? undefined,
+      ...(persona.namePool.length > 0 ? { namePool: persona.namePool } : {}),
     },
   };
 }

--- a/desktop/src/features/agents/ui/personaImportPlan.test.mjs
+++ b/desktop/src/features/agents/ui/personaImportPlan.test.mjs
@@ -87,6 +87,17 @@ test("buildPersonaImportPlan detects avatar change", () => {
   assert.equal(plan.fields[0]?.field, "avatarUrl");
 });
 
+test("buildPersonaImportPlan detects avatar ref changes", () => {
+  const plan = buildPersonaImportPlan({
+    persona: createPersona({ avatarUrl: null }),
+    preview: createPreview({ avatarRef: "app-avatar:gloopies-19" }),
+  });
+
+  assert.equal(plan.fields.length, 1);
+  assert.equal(plan.fields[0]?.field, "avatarUrl");
+  assert.equal(plan.fields[0]?.importedValue, "app-avatar:gloopies-19");
+});
+
 test("buildPersonaImportPlan detects runtime change", () => {
   const plan = buildPersonaImportPlan({
     persona: createPersona({ runtime: "goose" }),

--- a/desktop/src/features/agents/ui/personaImportPlan.test.mjs
+++ b/desktop/src/features/agents/ui/personaImportPlan.test.mjs
@@ -87,15 +87,27 @@ test("buildPersonaImportPlan detects avatar change", () => {
   assert.equal(plan.fields[0]?.field, "avatarUrl");
 });
 
-test("buildPersonaImportPlan detects avatar ref changes", () => {
+test("buildPersonaImportPlan detects hosted avatar ref changes", () => {
   const plan = buildPersonaImportPlan({
     persona: createPersona({ avatarUrl: null }),
-    preview: createPreview({ avatarRef: "app-avatar:gloopies-19" }),
+    preview: createPreview({ avatarRef: "https://new.example/avatar.png" }),
   });
 
   assert.equal(plan.fields.length, 1);
   assert.equal(plan.fields[0]?.field, "avatarUrl");
-  assert.equal(plan.fields[0]?.importedValue, "app-avatar:gloopies-19");
+  assert.equal(plan.fields[0]?.importedValue, "https://new.example/avatar.png");
+});
+
+test("buildPersonaImportPlan ignores unresolved app-avatar refs", () => {
+  const plan = buildPersonaImportPlan({
+    persona: createPersona({ avatarUrl: "https://old.example/avatar.png" }),
+    preview: createPreview({ avatarRef: "app-avatar:gloopies-19" }),
+  });
+
+  assert.equal(
+    plan.fields.some((field) => field.field === "avatarUrl"),
+    false,
+  );
 });
 
 test("buildPersonaImportPlan ignores raw relative avatar refs", () => {

--- a/desktop/src/features/agents/ui/personaImportPlan.test.mjs
+++ b/desktop/src/features/agents/ui/personaImportPlan.test.mjs
@@ -98,6 +98,18 @@ test("buildPersonaImportPlan detects avatar ref changes", () => {
   assert.equal(plan.fields[0]?.importedValue, "app-avatar:gloopies-19");
 });
 
+test("buildPersonaImportPlan ignores raw relative avatar refs", () => {
+  const plan = buildPersonaImportPlan({
+    persona: createPersona({ avatarUrl: null }),
+    preview: createPreview({ avatarRef: "./avatars/lep.png" }),
+  });
+
+  assert.equal(
+    plan.fields.some((field) => field.field === "avatarUrl"),
+    false,
+  );
+});
+
 test("buildPersonaImportPlan detects runtime change", () => {
   const plan = buildPersonaImportPlan({
     persona: createPersona({ runtime: "goose" }),

--- a/desktop/src/features/agents/ui/personaImportPlan.test.mjs
+++ b/desktop/src/features/agents/ui/personaImportPlan.test.mjs
@@ -100,7 +100,7 @@ test("buildPersonaImportPlan detects avatar ref changes", () => {
 
 test("buildPersonaImportPlan ignores raw relative avatar refs", () => {
   const plan = buildPersonaImportPlan({
-    persona: createPersona({ avatarUrl: null }),
+    persona: createPersona({ avatarUrl: "https://old.example/avatar.png" }),
     preview: createPreview({ avatarRef: "./avatars/lep.png" }),
   });
 

--- a/desktop/src/features/agents/ui/personaImportPlan.test.mjs
+++ b/desktop/src/features/agents/ui/personaImportPlan.test.mjs
@@ -122,6 +122,23 @@ test("buildPersonaImportPlan ignores raw relative avatar refs", () => {
   );
 });
 
+test("buildPersonaImportPlan ignores nonpersistent imported avatar refs", () => {
+  for (const avatarRef of [
+    "blob:https://buzz.example/temporary-avatar",
+    "ipfs://bafybeigdyrzt",
+  ]) {
+    const plan = buildPersonaImportPlan({
+      persona: createPersona({ avatarUrl: "https://old.example/avatar.png" }),
+      preview: createPreview({ avatarRef }),
+    });
+
+    assert.equal(
+      plan.fields.some((field) => field.field === "avatarUrl"),
+      false,
+    );
+  }
+});
+
 test("buildPersonaImportPlan detects runtime change", () => {
   const plan = buildPersonaImportPlan({
     persona: createPersona({ runtime: "goose" }),

--- a/desktop/src/features/agents/ui/personaImportPlan.ts
+++ b/desktop/src/features/agents/ui/personaImportPlan.ts
@@ -126,7 +126,11 @@ export function buildPersonaImportPlan({
 
   const existingAvatar = normalizeOptionalText(persona.avatarUrl);
   const importedAvatar = normalizeOptionalText(importedAvatarUrl(preview));
-  if (existingAvatar !== importedAvatar) {
+  const hasUnusableAvatarRef =
+    !preview.avatarDataUrl &&
+    Boolean(preview.avatarRef?.trim()) &&
+    !importedAvatar;
+  if (!hasUnusableAvatarRef && existingAvatar !== importedAvatar) {
     fields.push({
       field: "avatarUrl",
       label: "Avatar",

--- a/desktop/src/features/agents/ui/personaImportPlan.ts
+++ b/desktop/src/features/agents/ui/personaImportPlan.ts
@@ -124,7 +124,9 @@ export function buildPersonaImportPlan({
   }
 
   const existingAvatar = normalizeOptionalText(persona.avatarUrl);
-  const importedAvatar = normalizeOptionalText(preview.avatarDataUrl);
+  const importedAvatar = normalizeOptionalText(
+    preview.avatarDataUrl ?? preview.avatarRef,
+  );
   if (existingAvatar !== importedAvatar) {
     fields.push({
       field: "avatarUrl",

--- a/desktop/src/features/agents/ui/personaImportPlan.ts
+++ b/desktop/src/features/agents/ui/personaImportPlan.ts
@@ -1,5 +1,6 @@
 import type { ParsedPersonaPreview } from "@/shared/api/tauriPersonas";
 import type { AgentPersona } from "@/shared/api/types";
+import { importedAvatarUrl } from "./personaDialogState";
 
 type LineChangeCounts = {
   addedLines: number;
@@ -124,9 +125,7 @@ export function buildPersonaImportPlan({
   }
 
   const existingAvatar = normalizeOptionalText(persona.avatarUrl);
-  const importedAvatar = normalizeOptionalText(
-    preview.avatarDataUrl ?? preview.avatarRef,
-  );
+  const importedAvatar = normalizeOptionalText(importedAvatarUrl(preview));
   if (existingAvatar !== importedAvatar) {
     fields.push({
       field: "avatarUrl",

--- a/desktop/src/features/agents/ui/personaImportUpdateInput.ts
+++ b/desktop/src/features/agents/ui/personaImportUpdateInput.ts
@@ -23,7 +23,7 @@ export function buildPersonaImportUpdateInput({
       ? preview.systemPrompt
       : existing.systemPrompt,
     avatarUrl: selectedFieldSet.has("avatarUrl")
-      ? (preview.avatarDataUrl ?? undefined)
+      ? (preview.avatarDataUrl ?? preview.avatarRef ?? undefined)
       : (existing.avatarUrl ?? undefined),
     runtime: selectedFieldSet.has("runtime")
       ? (preview.runtime ?? undefined)

--- a/desktop/src/features/agents/ui/personaImportUpdateInput.ts
+++ b/desktop/src/features/agents/ui/personaImportUpdateInput.ts
@@ -1,5 +1,6 @@
 import type { ParsedPersonaPreview } from "@/shared/api/tauriPersonas";
 import type { AgentPersona, UpdatePersonaInput } from "@/shared/api/types";
+import { importedAvatarUrl } from "./personaDialogState";
 
 type BuildPersonaImportUpdateInputArgs = {
   existing: AgentPersona;
@@ -23,7 +24,7 @@ export function buildPersonaImportUpdateInput({
       ? preview.systemPrompt
       : existing.systemPrompt,
     avatarUrl: selectedFieldSet.has("avatarUrl")
-      ? (preview.avatarDataUrl ?? preview.avatarRef ?? undefined)
+      ? importedAvatarUrl(preview) || undefined
       : (existing.avatarUrl ?? undefined),
     runtime: selectedFieldSet.has("runtime")
       ? (preview.runtime ?? undefined)

--- a/desktop/src/features/agents/ui/personaLibraryCopy.ts
+++ b/desktop/src/features/agents/ui/personaLibraryCopy.ts
@@ -2,12 +2,13 @@ export const personaLibraryCopy = {
   title: "My agents",
   description:
     "The personas you have chosen for this app. Use them to create teams and launch agents.",
-  chooseFromCatalog: "Choose...",
-  createNew: "Persona",
+  chooseFromCatalog: "Choose from catalog",
+  createNew: "New agent",
+  customAgent: "Custom agent",
   import: "Import",
   emptyTitle: "No agents yet",
   emptyDescription:
-    "Choose one from Persona Catalog, add your own persona, or import one to get started.",
+    "Create a new agent, choose one from the catalog, or import one to get started.",
   emptyImportHint:
     "Or drop a .persona.md, .persona.json, .persona.png, or .zip file here to import.",
 } as const;

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatModelDiscoveryErrorStatus,
+  formatModelDiscoveryFallbackStatus,
+} from "./personaModelDiscoveryStatus.ts";
+
+test("model discovery status names missing Anthropic credentials", () => {
+  const status = formatModelDiscoveryErrorStatus(
+    new Error("config: ANTHROPIC_API_KEY required"),
+    "anthropic",
+  );
+
+  assert.equal(status.tone, "warning");
+  assert.match(status.message, /ANTHROPIC_API_KEY/);
+  assert.match(status.message, /Anthropic models/);
+});
+
+test("model discovery status names missing OpenAI-compatible credentials", () => {
+  const status = formatModelDiscoveryErrorStatus(
+    new Error("config: OPENAI_COMPAT_API_KEY required"),
+    "openai-compat",
+  );
+
+  assert.equal(status.tone, "warning");
+  assert.match(status.message, /OPENAI_COMPAT_API_KEY/);
+  assert.match(status.message, /OpenAI models/);
+});
+
+test("model discovery status names missing Databricks defaults", () => {
+  const status = formatModelDiscoveryErrorStatus(
+    new Error("config: DATABRICKS_HOST required"),
+    "databricks",
+  );
+
+  assert.equal(status.tone, "warning");
+  assert.match(status.message, /DATABRICKS_HOST/);
+  assert.match(status.message, /DATABRICKS_MODEL/);
+});
+
+test("model discovery status explains a runtime without live model listing", () => {
+  const status = formatModelDiscoveryFallbackStatus({
+    provider: "databricks",
+    response: {
+      agentName: "buzz-agent",
+      agentVersion: "0.0.0",
+      models: [],
+      agentDefaultModel: null,
+      selectedModel: null,
+      supportsSwitching: false,
+    },
+  });
+
+  assert.equal(status?.tone, "muted");
+  assert.match(status?.message ?? "", /Databricks/);
+  assert.match(status?.message ?? "", /does not expose a live model list/);
+});
+
+test("model discovery status stays quiet when live models are available", () => {
+  const status = formatModelDiscoveryFallbackStatus({
+    provider: "databricks",
+    response: {
+      agentName: "buzz-agent",
+      agentVersion: "0.0.0",
+      models: [{ id: "goose-gpt-5-5", name: "GPT 5.5", description: null }],
+      agentDefaultModel: null,
+      selectedModel: null,
+      supportsSwitching: true,
+    },
+  });
+
+  assert.equal(status, null);
+});

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
@@ -1,10 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-  formatModelDiscoveryErrorStatus,
-  formatModelDiscoveryFallbackStatus,
-} from "./personaModelDiscoveryStatus.ts";
+import { formatModelDiscoveryErrorStatus } from "./personaModelDiscoveryStatus.ts";
 
 test("model discovery status names missing Anthropic credentials", () => {
   const status = formatModelDiscoveryErrorStatus(
@@ -12,9 +9,9 @@ test("model discovery status names missing Anthropic credentials", () => {
     "anthropic",
   );
 
-  assert.equal(status.tone, "warning");
-  assert.match(status.message, /ANTHROPIC_API_KEY/);
-  assert.match(status.message, /Anthropic models/);
+  assert.equal(status?.tone, "warning");
+  assert.match(status?.message ?? "", /ANTHROPIC_API_KEY/);
+  assert.match(status?.message ?? "", /Anthropic models/);
 });
 
 test("model discovery status names missing OpenAI-compatible credentials", () => {
@@ -23,52 +20,16 @@ test("model discovery status names missing OpenAI-compatible credentials", () =>
     "openai-compat",
   );
 
-  assert.equal(status.tone, "warning");
-  assert.match(status.message, /OPENAI_COMPAT_API_KEY/);
-  assert.match(status.message, /OpenAI models/);
+  assert.equal(status?.tone, "warning");
+  assert.match(status?.message ?? "", /OPENAI_COMPAT_API_KEY/);
+  assert.match(status?.message ?? "", /OpenAI models/);
 });
 
-test("model discovery status names missing Databricks defaults", () => {
+test("model discovery status stays quiet for missing Databricks defaults", () => {
   const status = formatModelDiscoveryErrorStatus(
     new Error("config: DATABRICKS_HOST required"),
     "databricks",
   );
-
-  assert.equal(status.tone, "warning");
-  assert.match(status.message, /DATABRICKS_HOST/);
-  assert.match(status.message, /DATABRICKS_MODEL/);
-});
-
-test("model discovery status explains a runtime without live model listing", () => {
-  const status = formatModelDiscoveryFallbackStatus({
-    provider: "databricks",
-    response: {
-      agentName: "buzz-agent",
-      agentVersion: "0.0.0",
-      models: [],
-      agentDefaultModel: null,
-      selectedModel: null,
-      supportsSwitching: false,
-    },
-  });
-
-  assert.equal(status?.tone, "muted");
-  assert.match(status?.message ?? "", /Databricks/);
-  assert.match(status?.message ?? "", /does not expose a live model list/);
-});
-
-test("model discovery status stays quiet when live models are available", () => {
-  const status = formatModelDiscoveryFallbackStatus({
-    provider: "databricks",
-    response: {
-      agentName: "buzz-agent",
-      agentVersion: "0.0.0",
-      models: [{ id: "goose-gpt-5-5", name: "GPT 5.5", description: null }],
-      agentDefaultModel: null,
-      selectedModel: null,
-      supportsSwitching: true,
-    },
-  });
 
   assert.equal(status, null);
 });

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
@@ -10,7 +10,7 @@ test("model discovery status names missing Anthropic credentials", () => {
   );
 
   assert.equal(status?.tone, "warning");
-  assert.match(status?.message ?? "", /ANTHROPIC_API_KEY/);
+  assert.match(status?.message ?? "", /Anthropic API key/);
   assert.match(status?.message ?? "", /Anthropic models/);
 });
 
@@ -21,7 +21,7 @@ test("model discovery status names missing OpenAI-compatible credentials", () =>
   );
 
   assert.equal(status?.tone, "warning");
-  assert.match(status?.message ?? "", /OPENAI_COMPAT_API_KEY/);
+  assert.match(status?.message ?? "", /OpenAI API key/);
   assert.match(status?.message ?? "", /OpenAI models/);
 });
 

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -1,0 +1,118 @@
+import type { AgentModelsResponse } from "@/shared/api/types";
+
+export type PersonaModelDiscoveryStatus = {
+  message: string;
+  tone: "muted" | "warning";
+};
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return "Unknown model discovery error";
+  }
+}
+
+function knownProviderLabel(provider: string): string | null {
+  switch (provider.trim()) {
+    case "anthropic":
+      return "Anthropic";
+    case "databricks":
+      return "Databricks";
+    case "openai":
+      return "OpenAI";
+    case "openai-compat":
+      return "OpenAI-compatible";
+    default:
+      return null;
+  }
+}
+
+function providerObjectLabel(provider: string): string {
+  return knownProviderLabel(provider) ?? "the selected provider";
+}
+
+function providerSubjectLabel(provider: string): string {
+  return knownProviderLabel(provider) ?? "The selected provider";
+}
+
+export function formatModelDiscoveryErrorStatus(
+  error: unknown,
+  provider: string,
+): PersonaModelDiscoveryStatus {
+  const message = errorMessage(error);
+
+  if (message.includes("ANTHROPIC_API_KEY required")) {
+    return {
+      message:
+        "Using built-in model options. Add ANTHROPIC_API_KEY in Advanced env vars to load Anthropic models.",
+      tone: "warning",
+    };
+  }
+
+  if (message.includes("OPENAI_COMPAT_API_KEY required")) {
+    return {
+      message:
+        "Using built-in model options. Add OPENAI_COMPAT_API_KEY in Advanced env vars to load OpenAI models.",
+      tone: "warning",
+    };
+  }
+
+  if (
+    message.includes("DATABRICKS_HOST required") ||
+    message.includes("DATABRICKS_MODEL required")
+  ) {
+    return {
+      message:
+        "Using built-in Databricks model options. DATABRICKS_HOST and DATABRICKS_MODEL are required for live Databricks models.",
+      tone: "warning",
+    };
+  }
+
+  if (message.includes("BUZZ_AGENT_PROVIDER required")) {
+    return {
+      message:
+        "Using built-in model options. Select an LLM provider or set DATABRICKS_HOST and DATABRICKS_MODEL to load live models.",
+      tone: "warning",
+    };
+  }
+
+  return {
+    message: `Using built-in model options. Could not load live models for ${providerObjectLabel(
+      provider,
+    )}.`,
+    tone: "warning",
+  };
+}
+
+export function formatModelDiscoveryFallbackStatus({
+  provider,
+  response,
+}: {
+  provider: string;
+  response: AgentModelsResponse | null;
+}): PersonaModelDiscoveryStatus | null {
+  if (!response || response.models.length > 0) {
+    return null;
+  }
+
+  if (!response.supportsSwitching) {
+    return {
+      message: `Using built-in model options. ${providerSubjectLabel(
+        provider,
+      )} does not expose a live model list yet.`,
+      tone: "muted",
+    };
+  }
+
+  return {
+    message: "Using built-in model options. No live models were reported.",
+    tone: "muted",
+  };
+}

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -38,16 +38,14 @@ export function formatModelDiscoveryErrorStatus(
 
   if (message.includes("ANTHROPIC_API_KEY required")) {
     return {
-      message:
-        "Enter ANTHROPIC_API_KEY in Advanced env vars to load Anthropic models.",
+      message: "Enter an Anthropic API key to load Anthropic models.",
       tone: "warning",
     };
   }
 
   if (message.includes("OPENAI_COMPAT_API_KEY required")) {
     return {
-      message:
-        "Enter OPENAI_COMPAT_API_KEY in Advanced env vars to load OpenAI models.",
+      message: "Enter an OpenAI API key to load OpenAI models.",
       tone: "warning",
     };
   }

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -1,5 +1,3 @@
-import type { AgentModelsResponse } from "@/shared/api/types";
-
 export type PersonaModelDiscoveryStatus = {
   message: string;
   tone: "muted" | "warning";
@@ -19,39 +17,29 @@ function errorMessage(error: unknown): string {
   }
 }
 
-function knownProviderLabel(provider: string): string | null {
+function providerObjectLabel(provider: string): string {
   switch (provider.trim()) {
     case "anthropic":
       return "Anthropic";
-    case "databricks":
-      return "Databricks";
     case "openai":
       return "OpenAI";
     case "openai-compat":
       return "OpenAI-compatible";
     default:
-      return null;
+      return "the selected provider";
   }
-}
-
-function providerObjectLabel(provider: string): string {
-  return knownProviderLabel(provider) ?? "the selected provider";
-}
-
-function providerSubjectLabel(provider: string): string {
-  return knownProviderLabel(provider) ?? "The selected provider";
 }
 
 export function formatModelDiscoveryErrorStatus(
   error: unknown,
   provider: string,
-): PersonaModelDiscoveryStatus {
+): PersonaModelDiscoveryStatus | null {
   const message = errorMessage(error);
 
   if (message.includes("ANTHROPIC_API_KEY required")) {
     return {
       message:
-        "Using built-in model options. Add ANTHROPIC_API_KEY in Advanced env vars to load Anthropic models.",
+        "Enter ANTHROPIC_API_KEY in Advanced env vars to load Anthropic models.",
       tone: "warning",
     };
   }
@@ -59,28 +47,17 @@ export function formatModelDiscoveryErrorStatus(
   if (message.includes("OPENAI_COMPAT_API_KEY required")) {
     return {
       message:
-        "Using built-in model options. Add OPENAI_COMPAT_API_KEY in Advanced env vars to load OpenAI models.",
+        "Enter OPENAI_COMPAT_API_KEY in Advanced env vars to load OpenAI models.",
       tone: "warning",
     };
   }
 
   if (
     message.includes("DATABRICKS_HOST required") ||
-    message.includes("DATABRICKS_MODEL required")
+    message.includes("DATABRICKS_MODEL required") ||
+    message.includes("BUZZ_AGENT_PROVIDER required")
   ) {
-    return {
-      message:
-        "Using built-in Databricks model options. DATABRICKS_HOST and DATABRICKS_MODEL are required for live Databricks models.",
-      tone: "warning",
-    };
-  }
-
-  if (message.includes("BUZZ_AGENT_PROVIDER required")) {
-    return {
-      message:
-        "Using built-in model options. Select an LLM provider or set DATABRICKS_HOST and DATABRICKS_MODEL to load live models.",
-      tone: "warning",
-    };
+    return null;
   }
 
   return {
@@ -88,31 +65,5 @@ export function formatModelDiscoveryErrorStatus(
       provider,
     )}.`,
     tone: "warning",
-  };
-}
-
-export function formatModelDiscoveryFallbackStatus({
-  provider,
-  response,
-}: {
-  provider: string;
-  response: AgentModelsResponse | null;
-}): PersonaModelDiscoveryStatus | null {
-  if (!response || response.models.length > 0) {
-    return null;
-  }
-
-  if (!response.supportsSwitching) {
-    return {
-      message: `Using built-in model options. ${providerSubjectLabel(
-        provider,
-      )} does not expose a live model list yet.`,
-      tone: "muted",
-    };
-  }
-
-  return {
-    message: "Using built-in model options. No live models were reported.",
-    tone: "muted",
   };
 }

--- a/desktop/src/features/agents/ui/personaRuntimeModel.test.mjs
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldClearModelForRuntimeChange } from "./personaRuntimeModel.ts";
+
+test("shouldClearModelForRuntimeChange preserves model for first runtime selection", () => {
+  assert.equal(shouldClearModelForRuntimeChange("", "goose"), false);
+});
+
+test("shouldClearModelForRuntimeChange clears model when switching runtimes", () => {
+  assert.equal(shouldClearModelForRuntimeChange("goose", "claude"), true);
+});
+
+test("shouldClearModelForRuntimeChange keeps model for unchanged runtime", () => {
+  assert.equal(shouldClearModelForRuntimeChange("goose", "goose"), false);
+});

--- a/desktop/src/features/agents/ui/personaRuntimeModel.test.mjs
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.test.mjs
@@ -11,6 +11,10 @@ test("shouldClearModelForRuntimeChange clears model when switching runtimes", ()
   assert.equal(shouldClearModelForRuntimeChange("goose", "claude"), true);
 });
 
+test("shouldClearModelForRuntimeChange clears model when runtime is removed", () => {
+  assert.equal(shouldClearModelForRuntimeChange("goose", ""), true);
+});
+
 test("shouldClearModelForRuntimeChange keeps model for unchanged runtime", () => {
   assert.equal(shouldClearModelForRuntimeChange("goose", "goose"), false);
 });

--- a/desktop/src/features/agents/ui/personaRuntimeModel.ts
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.ts
@@ -1,0 +1,9 @@
+export function shouldClearModelForRuntimeChange(
+  previousRuntime: string,
+  nextRuntime: string,
+): boolean {
+  const previous = previousRuntime.trim();
+  const next = nextRuntime.trim();
+
+  return previous.length > 0 && next.length > 0 && previous !== next;
+}

--- a/desktop/src/features/agents/ui/personaRuntimeModel.ts
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.ts
@@ -5,5 +5,5 @@ export function shouldClearModelForRuntimeChange(
   const previous = previousRuntime.trim();
   const next = nextRuntime.trim();
 
-  return previous.length > 0 && next.length > 0 && previous !== next;
+  return previous.length > 0 && previous !== next;
 }

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -32,6 +32,7 @@ import {
   importPersonaDialogState,
   type PersonaDialogState,
 } from "./personaDialogState";
+import { resolveManagedAgentAvatarUrl } from "./managedAgentAvatar";
 import { usePersonaImportActions } from "./usePersonaImportActions";
 
 type PersonaFeedbackSurface = "catalog" | "library";
@@ -115,6 +116,7 @@ export function usePersonaActions() {
         }
 
         const persona = await createPersonaMutation.mutateAsync(input);
+        const avatarUrl = await resolveManagedAgentAvatarUrl(persona.avatarUrl);
         const agentInput: CreateManagedAgentInput = {
           name: persona.displayName,
           acpCommand: "buzz-acp",
@@ -123,9 +125,8 @@ export function usePersonaActions() {
           mcpCommand: runtime.mcpCommand ?? "",
           personaId: persona.id,
           systemPrompt: persona.systemPrompt,
-          avatarUrl: persona.avatarUrl ?? undefined,
+          avatarUrl,
           model: persona.model ?? undefined,
-          envVars: persona.envVars,
           spawnAfterCreate: true,
           startOnAppLaunch: true,
           backend: { type: "local" },

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -125,12 +125,15 @@ export function usePersonaActions() {
           return;
         }
 
-        const persona = await createPersonaMutation.mutateAsync(input);
         const avatarUrl = await resolveManagedAgentAvatarUrl(
-          persona.avatarUrl,
+          input.avatarUrl,
           undefined,
           runtime.avatarUrl,
         );
+        const persona = await createPersonaMutation.mutateAsync({
+          ...input,
+          avatarUrl,
+        });
         const agentInput: CreateManagedAgentInput = {
           name: persona.displayName,
           acpCommand: "buzz-acp",
@@ -140,7 +143,7 @@ export function usePersonaActions() {
           personaId: persona.id,
           harnessOverride: true,
           systemPrompt: persona.systemPrompt,
-          avatarUrl,
+          avatarUrl: persona.avatarUrl ?? avatarUrl,
           model: persona.model ?? undefined,
           spawnAfterCreate: true,
           startOnAppLaunch: true,

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   personasQueryKey,
   useAcpRuntimesQuery,
+  useCreateManagedAgentMutation,
   useCreatePersonaMutation,
   useDeletePersonaMutation,
   useExportPersonaJsonMutation,
@@ -18,7 +19,9 @@ import {
 } from "@/shared/api/tauriPersonas";
 import { isSingleItemFile } from "@/shared/lib/fileMagic";
 import type {
+  AcpRuntime,
   AgentPersona,
+  CreateManagedAgentInput,
   CreatePersonaInput,
   UpdatePersonaInput,
 } from "@/shared/api/types";
@@ -41,6 +44,7 @@ export function usePersonaActions() {
   const acpRuntimesQuery = useAcpRuntimesQuery({
     enabled: shouldLoadAcpRuntimes,
   });
+  const createAgentMutation = useCreateManagedAgentMutation();
   const createPersonaMutation = useCreatePersonaMutation();
   const updatePersonaMutation = useUpdatePersonaMutation();
   const deletePersonaMutation = useDeletePersonaMutation();
@@ -65,6 +69,14 @@ export function usePersonaActions() {
     React.useState<PersonaFeedbackSurface>("library");
 
   const personas = personasQuery.data ?? [];
+  const availableRuntimes = React.useMemo(
+    () =>
+      (acpRuntimesQuery.data ?? []).filter(
+        (runtime): runtime is AcpRuntime =>
+          runtime.availability === "available",
+      ),
+    [acpRuntimesQuery.data],
+  );
   const { catalogPersonas, libraryPersonas, personaLabelsById } = React.useMemo(
     () => getPersonaLibraryState(personas),
     [personas],
@@ -92,8 +104,56 @@ export function usePersonaActions() {
         await updatePersonaMutation.mutateAsync(input);
         setPersonaNoticeMessage(`Updated ${input.displayName}.`);
       } else {
-        await createPersonaMutation.mutateAsync(input);
-        setPersonaNoticeMessage(`Created ${input.displayName}.`);
+        const runtime = availableRuntimes.find(
+          (candidate) => candidate.id === input.runtime,
+        );
+        if (!runtime) {
+          setPersonaErrorMessage(
+            "Choose an available provider for this agent.",
+          );
+          return;
+        }
+
+        const persona = await createPersonaMutation.mutateAsync(input);
+        const agentInput: CreateManagedAgentInput = {
+          name: persona.displayName,
+          acpCommand: "buzz-acp",
+          agentCommand: runtime.command,
+          agentArgs: runtime.defaultArgs,
+          mcpCommand: runtime.mcpCommand ?? "",
+          personaId: persona.id,
+          systemPrompt: persona.systemPrompt,
+          avatarUrl: persona.avatarUrl ?? undefined,
+          model: persona.model ?? undefined,
+          envVars: persona.envVars,
+          spawnAfterCreate: true,
+          startOnAppLaunch: true,
+          backend: { type: "local" },
+        };
+
+        try {
+          const created = await createAgentMutation.mutateAsync(agentInput);
+          if (created.spawnError) {
+            setPersonaErrorMessage(
+              `${persona.displayName} was created, but it did not start: ${created.spawnError}`,
+            );
+          } else {
+            setPersonaNoticeMessage(
+              `Created and started ${created.agent.name}.`,
+            );
+          }
+          if (created.profileSyncError) {
+            setPersonaErrorMessage(
+              `${created.agent.name} was created, but profile sync failed: ${created.profileSyncError}`,
+            );
+          }
+        } catch (error) {
+          setPersonaErrorMessage(
+            error instanceof Error
+              ? `${persona.displayName} was created, but the agent instance could not be created: ${error.message}`
+              : `${persona.displayName} was created, but the agent instance could not be created.`,
+          );
+        }
       }
       setPersonaDialogState(null);
     } catch (error) {
@@ -218,6 +278,7 @@ export function usePersonaActions() {
 
   const isPending =
     createPersonaMutation.isPending ||
+    createAgentMutation.isPending ||
     updatePersonaMutation.isPending ||
     deletePersonaMutation.isPending ||
     setPersonaActiveMutation.isPending ||

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -116,7 +116,11 @@ export function usePersonaActions() {
         }
 
         const persona = await createPersonaMutation.mutateAsync(input);
-        const avatarUrl = await resolveManagedAgentAvatarUrl(persona.avatarUrl);
+        const avatarUrl = await resolveManagedAgentAvatarUrl(
+          persona.avatarUrl,
+          undefined,
+          runtime.avatarUrl,
+        );
         const agentInput: CreateManagedAgentInput = {
           name: persona.displayName,
           acpCommand: "buzz-acp",

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -71,6 +71,8 @@ export function usePersonaActions() {
     React.useState<PersonaFeedbackSurface>("library");
   const [createdAgent, setCreatedAgent] =
     React.useState<CreateManagedAgentResponse | null>(null);
+  const [isPersonaSubmitPending, setIsPersonaSubmitPending] =
+    React.useState(false);
 
   const personas = personasQuery.data ?? [];
   const availableRuntimes = React.useMemo(
@@ -102,7 +104,12 @@ export function usePersonaActions() {
   }
 
   async function handleSubmit(input: CreatePersonaInput | UpdatePersonaInput) {
+    if (isPersonaSubmitPending) {
+      return;
+    }
+
     clearFeedback("library");
+    setIsPersonaSubmitPending(true);
     try {
       if ("id" in input) {
         await updatePersonaMutation.mutateAsync(input);
@@ -170,6 +177,8 @@ export function usePersonaActions() {
       setPersonaErrorMessage(
         error instanceof Error ? error.message : "Failed to save persona.",
       );
+    } finally {
+      setIsPersonaSubmitPending(false);
     }
   }
 
@@ -287,6 +296,7 @@ export function usePersonaActions() {
   }
 
   const isPending =
+    isPersonaSubmitPending ||
     createPersonaMutation.isPending ||
     createAgentMutation.isPending ||
     updatePersonaMutation.isPending ||

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -22,6 +22,7 @@ import type {
   AcpRuntime,
   AgentPersona,
   CreateManagedAgentInput,
+  CreateManagedAgentResponse,
   CreatePersonaInput,
   UpdatePersonaInput,
 } from "@/shared/api/types";
@@ -68,6 +69,8 @@ export function usePersonaActions() {
   >(null);
   const [personaFeedbackSurface, setPersonaFeedbackSurface] =
     React.useState<PersonaFeedbackSurface>("library");
+  const [createdAgent, setCreatedAgent] =
+    React.useState<CreateManagedAgentResponse | null>(null);
 
   const personas = personasQuery.data ?? [];
   const availableRuntimes = React.useMemo(
@@ -138,6 +141,7 @@ export function usePersonaActions() {
 
         try {
           const created = await createAgentMutation.mutateAsync(agentInput);
+          setCreatedAgent(created);
           if (created.spawnError) {
             setPersonaErrorMessage(
               `${persona.displayName} was created, but it did not start: ${created.spawnError}`,
@@ -311,6 +315,8 @@ export function usePersonaActions() {
     personaNoticeMessage,
     personaErrorMessage,
     personaFeedbackSurface,
+    createdAgent,
+    setCreatedAgent,
     personaImportActions,
     handleSubmit,
     handleDelete,

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -131,6 +131,7 @@ export function usePersonaActions() {
           agentArgs: runtime.defaultArgs,
           mcpCommand: runtime.mcpCommand ?? "",
           personaId: persona.id,
+          harnessOverride: true,
           systemPrompt: persona.systemPrompt,
           avatarUrl,
           model: persona.model ?? undefined,

--- a/desktop/src/features/agents/ui/usePersonaImportActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaImportActions.ts
@@ -8,6 +8,7 @@ import {
   type ParsedPersonaPreview,
 } from "@/shared/api/tauriPersonas";
 import type { AgentPersona } from "@/shared/api/types";
+import { resolveManagedAgentAvatarUrl } from "./managedAgentAvatar";
 import { buildPersonaImportPlan } from "./personaImportPlan";
 import { buildPersonaImportUpdateInput } from "./personaImportUpdateInput";
 import {
@@ -115,6 +116,13 @@ export function usePersonaImportActions(
         preview,
         selectedFields,
       });
+      if (selectedFields.includes("avatarUrl")) {
+        updateInput.avatarUrl = await resolveManagedAgentAvatarUrl(
+          updateInput.avatarUrl,
+          undefined,
+          existing.avatarUrl,
+        );
+      }
 
       await updatePersonaApi(updateInput);
 

--- a/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
+++ b/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
@@ -6,6 +6,11 @@ import type {
   AgentModelsResponse,
 } from "@/shared/api/types";
 import type { EnvVarsValue } from "./EnvVarsEditor";
+import {
+  formatModelDiscoveryErrorStatus,
+  formatModelDiscoveryFallbackStatus,
+  type PersonaModelDiscoveryStatus,
+} from "./personaModelDiscoveryStatus";
 import type { PersonaModelOption } from "./personaDialogPickers";
 
 export const MODEL_DISCOVERY_LOADING_VALUE = "__model_discovery_loading__";
@@ -51,6 +56,8 @@ export function usePersonaModelDiscovery({
 }) {
   const [modelDiscoveryData, setModelDiscoveryData] =
     React.useState<AgentModelsResponse | null>(null);
+  const [modelDiscoveryStatus, setModelDiscoveryStatus] =
+    React.useState<PersonaModelDiscoveryStatus | null>(null);
   const [modelDiscoveryLoading, setModelDiscoveryLoading] =
     React.useState(false);
   const modelDiscoveryCacheRef = React.useRef(
@@ -98,6 +105,7 @@ export function usePersonaModelDiscovery({
     if (modelDiscoveryKey === null || discoveryAgentCommand === null) {
       modelDiscoveryRequestRef.current += 1;
       setModelDiscoveryData(null);
+      setModelDiscoveryStatus(null);
       setModelDiscoveryLoading(false);
       return;
     }
@@ -107,11 +115,13 @@ export function usePersonaModelDiscovery({
     const cached = modelDiscoveryCacheRef.current.get(modelDiscoveryKey);
     if (cached) {
       setModelDiscoveryData(cached);
+      setModelDiscoveryStatus(null);
       setModelDiscoveryLoading(false);
       return;
     }
 
     setModelDiscoveryData(null);
+    setModelDiscoveryStatus(null);
     setModelDiscoveryLoading(true);
     void discoverAgentModels({
       agentCommand: discoveryAgentCommand,
@@ -125,12 +135,16 @@ export function usePersonaModelDiscovery({
         }
         modelDiscoveryCacheRef.current.set(modelDiscoveryKey, response);
         setModelDiscoveryData(response);
+        setModelDiscoveryStatus(null);
       })
-      .catch(() => {
+      .catch((error) => {
         if (modelDiscoveryRequestRef.current !== requestId) {
           return;
         }
         setModelDiscoveryData(null);
+        setModelDiscoveryStatus(
+          formatModelDiscoveryErrorStatus(error, trimmedProvider),
+        );
       })
       .finally(() => {
         if (modelDiscoveryRequestRef.current === requestId) {
@@ -149,9 +163,23 @@ export function usePersonaModelDiscovery({
     () => getDiscoveredPersonaModelOptions(modelDiscoveryData),
     [modelDiscoveryData],
   );
+  const modelDiscoveryFallbackStatus = React.useMemo(
+    () =>
+      discoveredModelOptions === null
+        ? formatModelDiscoveryFallbackStatus({
+            provider: trimmedProvider,
+            response: modelDiscoveryData,
+          })
+        : null,
+    [discoveredModelOptions, modelDiscoveryData, trimmedProvider],
+  );
 
   return {
     discoveredModelOptions,
     modelDiscoveryLoading,
+    modelDiscoveryStatus:
+      modelDiscoveryLoading || discoveredModelOptions !== null
+        ? null
+        : (modelDiscoveryStatus ?? modelDiscoveryFallbackStatus),
   };
 }

--- a/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
+++ b/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
@@ -11,6 +11,7 @@ import {
   type PersonaModelDiscoveryStatus,
 } from "./personaModelDiscoveryStatus";
 import type { PersonaModelOption } from "./personaDialogPickers";
+import { providerRequiresExplicitModel } from "./personaDialogPickers";
 
 export const MODEL_DISCOVERY_LOADING_VALUE = "__model_discovery_loading__";
 
@@ -24,13 +25,25 @@ function stableModelDiscoveryEnvKey(envVars: EnvVarsValue): string {
 
 function getDiscoveredPersonaModelOptions(
   response: AgentModelsResponse | null,
+  provider: string,
 ): readonly PersonaModelOption[] | null {
   if (!response?.supportsSwitching || response.models.length === 0) {
     return null;
   }
 
+  const defaultModelOption = providerRequiresExplicitModel(provider)
+    ? []
+    : [
+        {
+          id: "",
+          label: response.agentDefaultModel?.trim()
+            ? `Default model (${response.agentDefaultModel})`
+            : "Default model",
+        },
+      ];
+
   return [
-    { id: "", label: "Auto (default)" },
+    ...defaultModelOption,
     ...response.models.map((model) => ({
       id: model.id,
       label: model.name?.trim() || model.id,
@@ -159,8 +172,8 @@ export function usePersonaModelDiscovery({
   ]);
 
   const discoveredModelOptions = React.useMemo(
-    () => getDiscoveredPersonaModelOptions(modelDiscoveryData),
-    [modelDiscoveryData],
+    () => getDiscoveredPersonaModelOptions(modelDiscoveryData, trimmedProvider),
+    [modelDiscoveryData, trimmedProvider],
   );
 
   return {

--- a/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
+++ b/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
@@ -1,0 +1,157 @@
+import * as React from "react";
+
+import { discoverAgentModels } from "@/shared/api/agentModels";
+import type {
+  AcpRuntimeCatalogEntry,
+  AgentModelsResponse,
+} from "@/shared/api/types";
+import type { EnvVarsValue } from "./EnvVarsEditor";
+import type { PersonaModelOption } from "./personaDialogPickers";
+
+export const MODEL_DISCOVERY_LOADING_VALUE = "__model_discovery_loading__";
+
+function stableModelDiscoveryEnvKey(envVars: EnvVarsValue): string {
+  return JSON.stringify(
+    Object.entries(envVars).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+}
+
+function getDiscoveredPersonaModelOptions(
+  response: AgentModelsResponse | null,
+): readonly PersonaModelOption[] | null {
+  if (!response?.supportsSwitching || response.models.length === 0) {
+    return null;
+  }
+
+  return [
+    { id: "", label: "Auto (default)" },
+    ...response.models.map((model) => ({
+      id: model.id,
+      label: model.name?.trim() || model.id,
+    })),
+  ];
+}
+
+export function usePersonaModelDiscovery({
+  envVars,
+  isCustomProviderEditing,
+  modelFieldVisible,
+  open,
+  provider,
+  selectedRuntime,
+}: {
+  envVars: EnvVarsValue;
+  isCustomProviderEditing: boolean;
+  modelFieldVisible: boolean;
+  open: boolean;
+  provider: string;
+  selectedRuntime: AcpRuntimeCatalogEntry | undefined;
+}) {
+  const [modelDiscoveryData, setModelDiscoveryData] =
+    React.useState<AgentModelsResponse | null>(null);
+  const [modelDiscoveryLoading, setModelDiscoveryLoading] =
+    React.useState(false);
+  const modelDiscoveryCacheRef = React.useRef(
+    new Map<string, AgentModelsResponse>(),
+  );
+  const modelDiscoveryRequestRef = React.useRef(0);
+
+  const trimmedProvider = provider.trim();
+  const discoveryAgentCommand = selectedRuntime?.command?.trim()
+    ? selectedRuntime.command
+    : null;
+  const canDiscoverModelOptions =
+    open &&
+    modelFieldVisible &&
+    selectedRuntime?.availability === "available" &&
+    discoveryAgentCommand !== null &&
+    (!isCustomProviderEditing || trimmedProvider.length > 0);
+  const modelDiscoveryEnvKey = React.useMemo(
+    () => stableModelDiscoveryEnvKey(envVars),
+    [envVars],
+  );
+  const modelDiscoveryArgsKey = JSON.stringify(
+    selectedRuntime?.defaultArgs ?? [],
+  );
+  const modelDiscoveryKey = React.useMemo(() => {
+    if (!canDiscoverModelOptions || discoveryAgentCommand === null) {
+      return null;
+    }
+
+    return JSON.stringify({
+      agentCommand: discoveryAgentCommand,
+      agentArgs: modelDiscoveryArgsKey,
+      provider: trimmedProvider,
+      envVars: modelDiscoveryEnvKey,
+    });
+  }, [
+    canDiscoverModelOptions,
+    discoveryAgentCommand,
+    modelDiscoveryArgsKey,
+    modelDiscoveryEnvKey,
+    trimmedProvider,
+  ]);
+
+  React.useEffect(() => {
+    if (modelDiscoveryKey === null || discoveryAgentCommand === null) {
+      modelDiscoveryRequestRef.current += 1;
+      setModelDiscoveryData(null);
+      setModelDiscoveryLoading(false);
+      return;
+    }
+
+    const requestId = modelDiscoveryRequestRef.current + 1;
+    modelDiscoveryRequestRef.current = requestId;
+    const cached = modelDiscoveryCacheRef.current.get(modelDiscoveryKey);
+    if (cached) {
+      setModelDiscoveryData(cached);
+      setModelDiscoveryLoading(false);
+      return;
+    }
+
+    setModelDiscoveryData(null);
+    setModelDiscoveryLoading(true);
+    void discoverAgentModels({
+      agentCommand: discoveryAgentCommand,
+      agentArgs: selectedRuntime?.defaultArgs ?? [],
+      provider: trimmedProvider || undefined,
+      envVars,
+    })
+      .then((response) => {
+        if (modelDiscoveryRequestRef.current !== requestId) {
+          return;
+        }
+        modelDiscoveryCacheRef.current.set(modelDiscoveryKey, response);
+        setModelDiscoveryData(response);
+      })
+      .catch(() => {
+        if (modelDiscoveryRequestRef.current !== requestId) {
+          return;
+        }
+        setModelDiscoveryData(null);
+      })
+      .finally(() => {
+        if (modelDiscoveryRequestRef.current === requestId) {
+          setModelDiscoveryLoading(false);
+        }
+      });
+  }, [
+    discoveryAgentCommand,
+    envVars,
+    modelDiscoveryKey,
+    selectedRuntime?.defaultArgs,
+    trimmedProvider,
+  ]);
+
+  const discoveredModelOptions = React.useMemo(
+    () => getDiscoveredPersonaModelOptions(modelDiscoveryData),
+    [modelDiscoveryData],
+  );
+
+  return {
+    discoveredModelOptions,
+    modelDiscoveryLoading,
+  };
+}

--- a/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
+++ b/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
@@ -15,6 +15,8 @@ import { providerRequiresExplicitModel } from "./personaDialogPickers";
 
 export const MODEL_DISCOVERY_LOADING_VALUE = "__model_discovery_loading__";
 
+const MODEL_DISCOVERY_CREDENTIAL_DEBOUNCE_MS = 250;
+
 function stableModelDiscoveryEnvKey(envVars: EnvVarsValue): string {
   return JSON.stringify(
     Object.entries(envVars).sort(([left], [right]) =>
@@ -78,6 +80,8 @@ export function usePersonaModelDiscovery({
   const modelDiscoveryRequestRef = React.useRef(0);
 
   const trimmedProvider = provider.trim();
+  const shouldDebounceModelDiscovery =
+    providerRequiresExplicitModel(trimmedProvider);
   const discoveryAgentCommand = selectedRuntime?.command?.trim()
     ? selectedRuntime.command
     : null;
@@ -124,7 +128,9 @@ export function usePersonaModelDiscovery({
 
     const requestId = modelDiscoveryRequestRef.current + 1;
     modelDiscoveryRequestRef.current = requestId;
-    const cached = modelDiscoveryCacheRef.current.get(modelDiscoveryKey);
+    const activeAgentCommand = discoveryAgentCommand;
+    const activeModelDiscoveryKey = modelDiscoveryKey;
+    const cached = modelDiscoveryCacheRef.current.get(activeModelDiscoveryKey);
     if (cached) {
       setModelDiscoveryData(cached);
       setModelDiscoveryStatus(null);
@@ -135,39 +141,60 @@ export function usePersonaModelDiscovery({
     setModelDiscoveryData(null);
     setModelDiscoveryStatus(null);
     setModelDiscoveryLoading(true);
-    void discoverAgentModels({
-      agentCommand: discoveryAgentCommand,
-      agentArgs: selectedRuntime?.defaultArgs ?? [],
-      provider: trimmedProvider || undefined,
-      envVars,
-    })
-      .then((response) => {
-        if (modelDiscoveryRequestRef.current !== requestId) {
-          return;
-        }
-        modelDiscoveryCacheRef.current.set(modelDiscoveryKey, response);
-        setModelDiscoveryData(response);
-        setModelDiscoveryStatus(null);
+    function runModelDiscovery() {
+      void discoverAgentModels({
+        agentCommand: activeAgentCommand,
+        agentArgs: selectedRuntime?.defaultArgs ?? [],
+        provider: trimmedProvider || undefined,
+        envVars,
       })
-      .catch((error) => {
-        if (modelDiscoveryRequestRef.current !== requestId) {
-          return;
-        }
-        setModelDiscoveryData(null);
-        setModelDiscoveryStatus(
-          formatModelDiscoveryErrorStatus(error, trimmedProvider),
-        );
-      })
-      .finally(() => {
-        if (modelDiscoveryRequestRef.current === requestId) {
-          setModelDiscoveryLoading(false);
-        }
-      });
+        .then((response) => {
+          if (modelDiscoveryRequestRef.current !== requestId) {
+            return;
+          }
+          modelDiscoveryCacheRef.current.set(activeModelDiscoveryKey, response);
+          setModelDiscoveryData(response);
+          setModelDiscoveryStatus(null);
+        })
+        .catch((error) => {
+          if (modelDiscoveryRequestRef.current !== requestId) {
+            return;
+          }
+          setModelDiscoveryData(null);
+          setModelDiscoveryStatus(
+            formatModelDiscoveryErrorStatus(error, trimmedProvider),
+          );
+        })
+        .finally(() => {
+          if (modelDiscoveryRequestRef.current === requestId) {
+            setModelDiscoveryLoading(false);
+          }
+        });
+    }
+
+    if (!shouldDebounceModelDiscovery) {
+      runModelDiscovery();
+      return;
+    }
+
+    const timeout = window.setTimeout(
+      runModelDiscovery,
+      MODEL_DISCOVERY_CREDENTIAL_DEBOUNCE_MS,
+    );
+
+    return () => {
+      window.clearTimeout(timeout);
+      if (modelDiscoveryRequestRef.current === requestId) {
+        modelDiscoveryRequestRef.current += 1;
+        setModelDiscoveryLoading(false);
+      }
+    };
   }, [
     discoveryAgentCommand,
     envVars,
     modelDiscoveryKey,
     selectedRuntime?.defaultArgs,
+    shouldDebounceModelDiscovery,
     trimmedProvider,
   ]);
 

--- a/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
+++ b/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
@@ -8,7 +8,6 @@ import type {
 import type { EnvVarsValue } from "./EnvVarsEditor";
 import {
   formatModelDiscoveryErrorStatus,
-  formatModelDiscoveryFallbackStatus,
   type PersonaModelDiscoveryStatus,
 } from "./personaModelDiscoveryStatus";
 import type { PersonaModelOption } from "./personaDialogPickers";
@@ -163,16 +162,6 @@ export function usePersonaModelDiscovery({
     () => getDiscoveredPersonaModelOptions(modelDiscoveryData),
     [modelDiscoveryData],
   );
-  const modelDiscoveryFallbackStatus = React.useMemo(
-    () =>
-      discoveredModelOptions === null
-        ? formatModelDiscoveryFallbackStatus({
-            provider: trimmedProvider,
-            response: modelDiscoveryData,
-          })
-        : null,
-    [discoveredModelOptions, modelDiscoveryData, trimmedProvider],
-  );
 
   return {
     discoveredModelOptions,
@@ -180,6 +169,6 @@ export function usePersonaModelDiscovery({
     modelDiscoveryStatus:
       modelDiscoveryLoading || discoveredModelOptions !== null
         ? null
-        : (modelDiscoveryStatus ?? modelDiscoveryFallbackStatus),
+        : modelDiscoveryStatus,
   };
 }

--- a/desktop/src/shared/api/agentModels.ts
+++ b/desktop/src/shared/api/agentModels.ts
@@ -1,0 +1,14 @@
+import type { AgentModelsResponse } from "@/shared/api/types";
+import { invokeTauri } from "@/shared/api/tauri";
+
+export type DiscoverAgentModelsInput = {
+  acpCommand?: string;
+  agentCommand: string;
+  agentArgs?: string[];
+  provider?: string;
+  envVars?: Record<string, string>;
+};
+
+export async function discoverAgentModels(input: DiscoverAgentModelsInput) {
+  return invokeTauri<AgentModelsResponse>("discover_agent_models", { input });
+}

--- a/desktop/src/shared/api/tauriPersonas.ts
+++ b/desktop/src/shared/api/tauriPersonas.ts
@@ -10,6 +10,7 @@ type RawParsedPersonaPreview = {
   display_name: string;
   system_prompt: string;
   avatar_data_url: string | null;
+  avatar_ref: string | null;
   runtime: string | null;
   model: string | null;
   provider: string | null;
@@ -32,6 +33,7 @@ export type ParsedPersonaPreview = {
   displayName: string;
   systemPrompt: string;
   avatarDataUrl: string | null;
+  avatarRef: string | null;
   runtime: string | null;
   model: string | null;
   provider: string | null;
@@ -154,7 +156,8 @@ export async function parsePersonaFiles(
     personas: raw.personas.map((p) => ({
       displayName: p.display_name,
       systemPrompt: p.system_prompt,
-      avatarDataUrl: p.avatar_data_url,
+      avatarDataUrl: p.avatar_data_url ?? null,
+      avatarRef: p.avatar_ref ?? null,
       runtime: p.runtime,
       model: p.model,
       provider: p.provider,

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -364,10 +364,9 @@ export type CreateManagedAgentInput = {
   acpCommand?: string;
   agentCommand?: string;
   /**
-   * True when `agentCommand` is a runtime the user deliberately picked to
-   * override the linked persona (a deploy-dialog runtime selector). Lets the
-   * backend distinguish a real pin from a missing-runtime fallback. Omit/false
-   * for persona-less creates and fallback divergence — both inherit.
+   * True when `agentCommand` is a runtime command the user deliberately picked
+   * for a linked persona. Lets the backend preserve real selections, including
+   * installed aliases, while still ignoring missing-runtime fallbacks.
    */
   harnessOverride?: boolean;
   agentArgs?: string[];

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -6832,6 +6832,41 @@ export function maybeInstallE2eTauriMocks() {
           selectedModel: null,
           supportsSwitching: false,
         };
+      case "discover_agent_models": {
+        const input = (payload as { input?: { provider?: string } } | null)
+          ?.input;
+        const provider = input?.provider?.trim() ?? "";
+        const openAiModels = [
+          { id: "gpt-5", name: "GPT-5", description: null },
+          { id: "gpt-5-mini", name: "GPT-5 mini", description: null },
+        ];
+        const anthropicModels = [
+          {
+            id: "goose-claude-4-6-opus",
+            name: "Claude Opus 4.6",
+            description: null,
+          },
+          {
+            id: "goose-claude-4-6-sonnet",
+            name: "Claude Sonnet 4.6",
+            description: null,
+          },
+        ];
+        const models =
+          provider === "openai"
+            ? openAiModels
+            : provider === "anthropic"
+              ? anthropicModels
+              : [...anthropicModels, ...openAiModels];
+        return {
+          agentName: "mock-agent",
+          agentVersion: "0.0.0",
+          models,
+          agentDefaultModel: null,
+          selectedModel: null,
+          supportsSwitching: true,
+        };
+      }
       case "update_managed_agent":
         return handleUpdateManagedAgent(
           payload as Parameters<typeof handleUpdateManagedAgent>[0],

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -6837,8 +6837,10 @@ export function maybeInstallE2eTauriMocks() {
           ?.input;
         const provider = input?.provider?.trim() ?? "";
         const openAiModels = [
-          { id: "gpt-5", name: "GPT-5", description: null },
-          { id: "gpt-5-mini", name: "GPT-5 mini", description: null },
+          { id: "gpt-5.5", name: "GPT-5.5", description: null },
+          { id: "gpt-5.4", name: "GPT-5.4", description: null },
+          { id: "gpt-5.4-mini", name: "GPT-5.4 mini", description: null },
+          { id: "gpt-5.4-nano", name: "GPT-5.4 nano", description: null },
         ];
         const anthropicModels = [
           {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -5084,6 +5084,7 @@ async function handleParsePersonaFiles(args: {
     display_name: string;
     system_prompt: string;
     avatar_data_url: string | null;
+    avatar_ref: string | null;
     source_file: string;
   }[];
   skipped: { source_file: string; reason: string }[];
@@ -5095,6 +5096,7 @@ async function handleParsePersonaFiles(args: {
         display_name: "Imported Persona",
         system_prompt: "You are an imported test persona.",
         avatar_data_url: null,
+        avatar_ref: null,
         source_file: args.fileName,
       },
     ],

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -31,7 +31,7 @@ async function gotoApp(page: import("@playwright/test").Page) {
 
 async function openPersonaCatalog(page: import("@playwright/test").Page) {
   await page.getByTestId("new-agent-card").click();
-  await page.getByText("Choose from Catalog...").click();
+  await page.getByText("Choose from catalog").click();
 }
 
 async function getCatalogOrder(page: import("@playwright/test").Page) {

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -31,7 +31,7 @@ async function gotoApp(page: import("@playwright/test").Page) {
 
 async function openPersonaCatalog(page: import("@playwright/test").Page) {
   await page.getByTestId("new-agent-card").click();
-  await page.getByText("Choose from catalog").click();
+  await page.getByRole("menuitem", { name: "Choose from catalog" }).click();
 }
 
 async function getCatalogOrder(page: import("@playwright/test").Page) {

--- a/desktop/tests/e2e/mesh-compute.spec.ts
+++ b/desktop/tests/e2e/mesh-compute.spec.ts
@@ -157,7 +157,7 @@ test("Run-on-relay-mesh ensures the client node BEFORE spawning the agent", asyn
   await gotoApp(page);
   await page.getByTestId("open-agents-view").click();
   await openNewAgentMenu(page);
-  await page.getByText("Custom Agent").click();
+  await page.getByText("Custom agent").click();
 
   // Member is admitted -> the relay-mesh toggle becomes enabled (availability
   // resolves to available). Wait for that before driving the flow.
@@ -201,7 +201,7 @@ test("Run-on-relay-mesh skips connect signaling for own serve target", async ({
   await gotoApp(page);
   await page.getByTestId("open-agents-view").click();
   await openNewAgentMenu(page);
-  await page.getByText("Custom Agent").click();
+  await page.getByText("Custom agent").click();
   await page.getByTestId("agent-name-input").fill("Own Mesh Agent");
 
   const toggle = page.getByTestId("agent-relay-mesh-toggle");
@@ -241,7 +241,7 @@ test("Run-on-relay-mesh canonicalizes the mesh connect #p target", async ({
   await gotoApp(page);
   await page.getByTestId("open-agents-view").click();
   await openNewAgentMenu(page);
-  await page.getByText("Custom Agent").click();
+  await page.getByText("Custom agent").click();
   await page.getByTestId("agent-name-input").fill("Mesh Agent");
 
   const toggle = page.getByTestId("agent-relay-mesh-toggle");
@@ -279,7 +279,7 @@ test("a non-member cannot enable relay-mesh — membership is the gate", async (
 
   await page.getByTestId("open-agents-view").click();
   await openNewAgentMenu(page);
-  await page.getByText("Custom Agent").click();
+  await page.getByText("Custom agent").click();
 
   // The relay-mesh toggle stays disabled — a non-member cannot even opt into
   // running on the mesh, let alone spawn an agent against it.
@@ -298,7 +298,7 @@ test("saved relay-mesh agents restart via the backend serve-target preflight", a
   await gotoApp(page);
   await page.getByTestId("open-agents-view").click();
   await openNewAgentMenu(page);
-  await page.getByText("Custom Agent").click();
+  await page.getByText("Custom agent").click();
   await page.getByTestId("agent-name-input").fill("Saved relay mesh agent");
 
   const toggle = page.getByTestId("agent-relay-mesh-toggle");

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { waitForAnimations } from "../helpers/animations";
 import { installMockBridge } from "../helpers/bridge";
 
 test.beforeEach(async ({ page }) => {
@@ -249,6 +250,13 @@ test("env vars editor renders in PersonaDialog new-persona form", async ({
   await page.getByTestId("env-vars-add").click();
   await keys.nth(2).fill("OPENAI_BASE_URL");
   await values.nth(2).fill("https://api.openai.com/v1");
+
+  // Capture a screenshot of the dialog with three env vars filled. Helps
+  // reviewers see the UI at a glance.
+  await waitForAnimations(page);
+  await page
+    .getByRole("dialog")
+    .screenshot({ path: "test-results/persona-env-dialog.png" });
 
   // Remove the first row to verify per-row removal still works.
   await page.getByTestId("env-vars-remove").first().click();

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -269,10 +269,7 @@ test("persona model options follow the selected LLM provider", async ({
   await gotoApp(page);
 
   await page.getByTestId("open-agents-view").click();
-  await page
-    .getByTestId("agents-library-personas")
-    .getByRole("button", { name: "New", exact: true })
-    .click();
+  await page.getByTestId("new-agent-card").click();
   await page.getByRole("menuitem", { name: /^New agent$/ }).click();
 
   const provider = page.locator("#persona-runtime");

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -280,7 +280,8 @@ test("persona model options follow the selected LLM provider", async ({
   const model = page.locator("#persona-model");
   await expect(provider).toContainText("Goose (default)");
   await expect(llmProvider).toBeVisible();
-  await expect(model).toHaveCount(0);
+  await expect(model).toBeVisible();
+  await expect(model).toContainText("Auto (default)");
 
   await llmProvider.click();
   await page
@@ -321,5 +322,14 @@ test("persona model options follow the selected LLM provider", async ({
     .last()
     .getByRole("menuitemradio", { name: "Auto (default)", exact: true })
     .click();
-  await expect(model).toHaveCount(0);
+  await expect(model).toBeVisible();
+  await expect(model).toContainText("Claude Sonnet 4.6");
+
+  await model.click();
+  await expect(
+    page.getByRole("menuitemradio", { name: "Claude Sonnet 4.6" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("menuitemradio", { name: "GPT-5", exact: true }),
+  ).toBeVisible();
 });

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -221,12 +221,15 @@ test("env vars editor renders in PersonaDialog new-persona form", async ({
 }) => {
   await gotoApp(page);
 
-  // Open the Agents view, click New > Persona to open the persona dialog.
+  // Open the Agents view, click New > New agent to open the persona dialog.
   await page.getByTestId("open-agents-view").click();
   await page.getByTestId("new-agent-card").click();
-  await page.getByRole("menuitem", { name: /^Persona$/ }).click();
+  await page.getByRole("menuitem", { name: /^New agent$/ }).click();
 
-  // The env vars editor should be present.
+  await expect(page.getByTestId("env-vars-editor")).toHaveCount(0);
+  await page.getByRole("button", { name: "Advanced", exact: true }).click();
+
+  // The env vars editor should be present after opening Advanced.
   await expect(page.getByTestId("env-vars-editor")).toBeVisible();
   // Initially empty (no rows).
   await expect(page.getByTestId("env-vars-key")).toHaveCount(0);
@@ -250,4 +253,65 @@ test("env vars editor renders in PersonaDialog new-persona form", async ({
   // Remove the first row to verify per-row removal still works.
   await page.getByTestId("env-vars-remove").first().click();
   await expect(keys).toHaveCount(2);
+});
+
+test("persona model options follow the selected LLM provider", async ({
+  page,
+}) => {
+  await gotoApp(page);
+
+  await page.getByTestId("open-agents-view").click();
+  await page
+    .getByTestId("agents-library-personas")
+    .getByRole("button", { name: "New", exact: true })
+    .click();
+  await page.getByRole("menuitem", { name: /^New agent$/ }).click();
+
+  const provider = page.locator("#persona-runtime");
+  const llmProvider = page.locator("#persona-llm-provider");
+  const model = page.locator("#persona-model");
+  await expect(provider).toContainText("Goose (default)");
+  await expect(llmProvider).toBeVisible();
+  await expect(model).toHaveCount(0);
+
+  await llmProvider.click();
+  await page
+    .getByRole("menuitemradio", { name: "OpenAI", exact: true })
+    .click();
+  await expect(model).toBeVisible();
+  await model.click();
+  await expect(
+    page.getByRole("menuitemradio", { name: "GPT-5", exact: true }),
+  ).toBeVisible();
+  await expect(page.getByRole("menuitemradio", { name: /Claude/ })).toHaveCount(
+    0,
+  );
+  await page.getByRole("menuitemradio", { name: "GPT-5", exact: true }).click();
+  await expect(model).toContainText("GPT-5");
+
+  await llmProvider.click();
+  await page
+    .getByRole("menuitemradio", { name: "Anthropic", exact: true })
+    .click();
+  await expect(model).toContainText("Auto (default)");
+
+  await model.click();
+  await expect(
+    page.getByRole("menuitemradio", { name: "Claude Sonnet 4.6" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("menuitemradio", { name: "GPT-5", exact: true }),
+  ).toHaveCount(0);
+  await page.getByRole("menuitemradio", { name: "Claude Sonnet 4.6" }).click();
+  await expect(model).toContainText("Claude Sonnet 4.6");
+
+  await llmProvider.click();
+  const llmProviderMenu = page.getByRole("menu").filter({
+    has: page.getByRole("menuitemradio", { name: "OpenAI", exact: true }),
+  });
+  await llmProviderMenu
+    .last()
+    .getByRole("menuitemradio", { name: "Auto (default)", exact: true })
+    .click();
+  await expect(model).toHaveCount(0);
 });

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -284,10 +284,13 @@ test("persona model options follow the selected LLM provider", async ({
   await page
     .getByRole("menuitemradio", { name: "OpenAI", exact: true })
     .click();
-  await expect(page.getByTestId("env-vars-editor")).toBeVisible();
-  const envKeys = page.getByTestId("env-vars-key");
-  await expect(envKeys).toHaveCount(1);
-  await expect(envKeys.first()).toHaveValue("OPENAI_COMPAT_API_KEY");
+  const providerApiKey = page.getByTestId("persona-provider-api-key");
+  await expect(page.getByText("OpenAI API key")).toBeVisible();
+  await expect(providerApiKey).toBeVisible();
+  await expect(page.getByTestId("env-vars-editor")).toHaveCount(0);
+  await expect(model).toHaveCount(0);
+
+  await providerApiKey.fill("sk-openai-test");
   await expect(model).toBeVisible();
   await model.click();
   await expect(
@@ -303,8 +306,12 @@ test("persona model options follow the selected LLM provider", async ({
   await page
     .getByRole("menuitemradio", { name: "Anthropic", exact: true })
     .click();
-  await expect(envKeys).toHaveCount(2);
-  await expect(envKeys.nth(1)).toHaveValue("ANTHROPIC_API_KEY");
+  await expect(page.getByText("Anthropic API key")).toBeVisible();
+  await expect(providerApiKey).toHaveValue("");
+  await expect(model).toHaveCount(0);
+
+  await providerApiKey.fill("sk-ant-test");
+  await expect(model).toBeVisible();
   await expect(model).toContainText("Auto (default)");
 
   await model.click();

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -58,6 +58,24 @@ async function invokeTauri<T>(
   );
 }
 
+async function openModelMenu(
+  page: import("@playwright/test").Page,
+  model: import("@playwright/test").Locator,
+) {
+  await model.click();
+  const menu = page
+    .getByRole("menu")
+    .filter({
+      has: page.getByRole("menuitemradio", {
+        name: "Custom model...",
+        exact: true,
+      }),
+    })
+    .last();
+  await expect(menu).toBeVisible();
+  return menu;
+}
+
 test("persona env_vars round-trip through create_persona + update_persona", async ({
   page,
 }) => {
@@ -278,7 +296,7 @@ test("persona model options follow the selected LLM provider", async ({
   await expect(provider).toContainText("Buzz Agent (default)");
   await expect(llmProvider).toBeVisible();
   await expect(model).toBeVisible();
-  await expect(model).toContainText("Auto (default)");
+  await expect(model).toContainText("Default model");
 
   await llmProvider.click();
   await page
@@ -288,19 +306,26 @@ test("persona model options follow the selected LLM provider", async ({
   await expect(page.getByText("OpenAI API key")).toBeVisible();
   await expect(providerApiKey).toBeVisible();
   await expect(page.getByTestId("env-vars-editor")).toHaveCount(0);
-  await expect(model).toHaveCount(0);
+  await expect(model).toBeVisible();
 
   await providerApiKey.fill("sk-openai-test");
-  await expect(model).toBeVisible();
-  await model.click();
+  const openAiModelMenu = await openModelMenu(page, model);
   await expect(
-    page.getByRole("menuitemradio", { name: "GPT-5", exact: true }),
+    openAiModelMenu.getByRole("menuitemradio", {
+      name: "GPT-5.5",
+      exact: true,
+    }),
   ).toBeVisible();
-  await expect(page.getByRole("menuitemradio", { name: /Claude/ })).toHaveCount(
-    0,
-  );
-  await page.getByRole("menuitemradio", { name: "GPT-5", exact: true }).click();
-  await expect(model).toContainText("GPT-5");
+  await expect(
+    openAiModelMenu.getByRole("menuitemradio", { name: "GPT-5", exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    openAiModelMenu.getByRole("menuitemradio", { name: /Claude/ }),
+  ).toHaveCount(0);
+  await openAiModelMenu
+    .getByRole("menuitemradio", { name: "GPT-5.5", exact: true })
+    .click();
+  await expect(model).toContainText("GPT-5.5");
 
   await llmProvider.click();
   await page
@@ -308,20 +333,25 @@ test("persona model options follow the selected LLM provider", async ({
     .click();
   await expect(page.getByText("Anthropic API key")).toBeVisible();
   await expect(providerApiKey).toHaveValue("");
-  await expect(model).toHaveCount(0);
+  await expect(model).toBeVisible();
 
   await providerApiKey.fill("sk-ant-test");
-  await expect(model).toBeVisible();
-  await expect(model).toContainText("Auto (default)");
 
-  await model.click();
+  const anthropicModelMenu = await openModelMenu(page, model);
   await expect(
-    page.getByRole("menuitemradio", { name: "Claude Sonnet 4.6" }),
+    anthropicModelMenu.getByRole("menuitemradio", {
+      name: "Claude Sonnet 4.6",
+    }),
   ).toBeVisible();
   await expect(
-    page.getByRole("menuitemradio", { name: "GPT-5", exact: true }),
+    anthropicModelMenu.getByRole("menuitemradio", {
+      name: "GPT-5.5",
+      exact: true,
+    }),
   ).toHaveCount(0);
-  await page.getByRole("menuitemradio", { name: "Claude Sonnet 4.6" }).click();
+  await anthropicModelMenu
+    .getByRole("menuitemradio", { name: "Claude Sonnet 4.6" })
+    .click();
   await expect(model).toContainText("Claude Sonnet 4.6");
 
   await llmProvider.click();
@@ -330,16 +360,19 @@ test("persona model options follow the selected LLM provider", async ({
   });
   await llmProviderMenu
     .last()
-    .getByRole("menuitemradio", { name: "Auto (default)", exact: true })
+    .getByRole("menuitemradio", { name: "Databricks (default)", exact: true })
     .click();
   await expect(model).toBeVisible();
   await expect(model).toContainText("Claude Sonnet 4.6");
 
-  await model.click();
+  const defaultModelMenu = await openModelMenu(page, model);
   await expect(
-    page.getByRole("menuitemradio", { name: "Claude Sonnet 4.6" }),
+    defaultModelMenu.getByRole("menuitemradio", { name: "Claude Sonnet 4.6" }),
   ).toBeVisible();
   await expect(
-    page.getByRole("menuitemradio", { name: "GPT-5", exact: true }),
+    defaultModelMenu.getByRole("menuitemradio", {
+      name: "GPT-5.5",
+      exact: true,
+    }),
   ).toBeVisible();
 });

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -284,6 +284,10 @@ test("persona model options follow the selected LLM provider", async ({
   await page
     .getByRole("menuitemradio", { name: "OpenAI", exact: true })
     .click();
+  await expect(page.getByTestId("env-vars-editor")).toBeVisible();
+  const envKeys = page.getByTestId("env-vars-key");
+  await expect(envKeys).toHaveCount(1);
+  await expect(envKeys.first()).toHaveValue("OPENAI_COMPAT_API_KEY");
   await expect(model).toBeVisible();
   await model.click();
   await expect(
@@ -299,6 +303,8 @@ test("persona model options follow the selected LLM provider", async ({
   await page
     .getByRole("menuitemradio", { name: "Anthropic", exact: true })
     .click();
+  await expect(envKeys).toHaveCount(2);
+  await expect(envKeys.nth(1)).toHaveValue("ANTHROPIC_API_KEY");
   await expect(model).toContainText("Auto (default)");
 
   await model.click();

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -275,7 +275,7 @@ test("persona model options follow the selected LLM provider", async ({
   const provider = page.locator("#persona-runtime");
   const llmProvider = page.locator("#persona-llm-provider");
   const model = page.locator("#persona-model");
-  await expect(provider).toContainText("Goose (default)");
+  await expect(provider).toContainText("Buzz Agent (default)");
   await expect(llmProvider).toBeVisible();
   await expect(model).toBeVisible();
   await expect(model).toContainText("Auto (default)");

--- a/desktop/tests/e2e/smoke.spec.ts
+++ b/desktop/tests/e2e/smoke.spec.ts
@@ -116,7 +116,7 @@ test("create agent supports parallelism and system prompt overrides", async ({
   await page.goto("/");
   await page.getByTestId("open-agents-view").click();
   await page.getByTestId("new-agent-card").click();
-  await page.getByText("Custom Agent").click();
+  await page.getByText("Custom agent").click();
 
   await page.getByTestId("agent-name-input").fill(agentName);
   await page.getByRole("button", { name: "Advanced setup" }).click();


### PR DESCRIPTION
## Summary
- Revamps the new/edit agent dialog into the new agent flow with the profile-style avatar affordance, compact controls, and animated advanced fields.
- Makes Buzz Agent the default available runtime, labels Databricks as the default LLM provider, and keeps adapter-missing runtimes last.
- Adds model selection before save with Databricks fallbacks plus live discovery for OpenAI, OpenAI-compatible, and Anthropic when provider credentials are entered or inherited from the app environment.
- Keeps provider API keys in dedicated fields while preserving advanced environment variables, imported avatars/name pools, and runtime/provider/model state.
- Addresses review feedback by debouncing credential-driven discovery, keeping the model picker visible for inherited provider credentials, hiding provider credential controls for provider-locked runtimes, reading direct model API credentials from inherited env when needed, and filtering nonpersistent imported avatar refs.

## Screenshots

### Default new agent dialog
![Default new agent dialog](https://raw.githubusercontent.com/block/buzz/005de9f169eb4c3012fa6a66cccf7c3a14c361b8/pr-1201--01-new-agent-default.png)

### Avatar menu
![Avatar menu](https://raw.githubusercontent.com/block/buzz/005de9f169eb4c3012fa6a66cccf7c3a14c361b8/pr-1201--02-avatar-menu.png)

### LLM provider and model
![LLM provider and model](https://raw.githubusercontent.com/block/buzz/005de9f169eb4c3012fa6a66cccf7c3a14c361b8/pr-1201--03-llm-model.png)

## Validation
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `just desktop-check`
- `just desktop-test` (1216 tests)
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml model` (15 tests)
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml agent_models` (6 tests)
- `just desktop-build`
- `cd desktop && pnpm exec playwright test --project=integration tests/e2e/persona-env-vars.spec.ts` (5 tests)
- Pre-push hooks: `desktop-test`, `rust-tests`, `mobile-test`, `desktop-tauri-test`
- `shasum -a 256 desktop/test-results/pr-1201-screenshots/*.png`


