### PR TITLE
fix(desktop): keep settings shortcut from opening search

### DIFF
--- a/desktop/src/app/useSettingsShortcuts.ts
+++ b/desktop/src/app/useSettingsShortcuts.ts
@@ -26,6 +26,7 @@ export function useSettingsShortcuts({
       }
 
       event.preventDefault();
+      event.stopImmediatePropagation();
       if (open) {
         onClose();
         return;
@@ -34,9 +35,9 @@ export function useSettingsShortcuts({
       onOpenSettings();
     }
 
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, true);
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, true);
     };
   }, [onClose, onOpenSettings, open]);
 }

--- a/desktop/tests/e2e/navigation.spec.ts
+++ b/desktop/tests/e2e/navigation.spec.ts
@@ -266,6 +266,26 @@ test("settings is a route: section survives reload, closing returns to the previ
   await expect(threadPanel).toBeVisible();
 });
 
+test("settings shortcut returns without opening search dialog", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  const channelUrl = page.url();
+
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+Comma" : "Control+Comma",
+  );
+
+  await expect(page).toHaveURL(/#\/settings/);
+  await page.getByTestId("settings-back-to-app").click();
+
+  await expect.poll(() => page.url()).toBe(channelUrl);
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await expect(page.getByTestId("search-results")).not.toBeVisible();
+});
+
 test("message links to visible root messages open the thread panel", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- consume the Cmd+, settings shortcut during the capture phase so the global search shortcut cannot also handle the same keydown
- add e2e coverage for opening settings with Cmd+, using Back to app, and confirming the search dialog remains closed

## Why
Opening settings navigates away from the normal app shell. Without stopping propagation, other global shortcut listeners can still observe the same keydown during the route transition, which leaves the app with the search dialog open after returning from settings.

## Validation
- `bin/pnpm --dir desktop exec biome check src/app/useSettingsShortcuts.ts tests/e2e/navigation.spec.ts`
- `bin/pnpm --dir desktop typecheck`
- `bin/pnpm --dir desktop build`
- `bin/pnpm --dir desktop exec playwright test tests/e2e/navigation.spec.ts --project=smoke --grep "settings shortcut returns without opening search dialog"`
- pre-commit hook via Hermit (`desktop-fix`, `desktop-tauri-fmt`, `rust-fmt`, `mobile-fix`, `web-fix`)
- pre-push hook via Hermit (`desktop-test`, `desktop-tauri-test`, `mobile-test`, `rust-tests`)
