### PR TITLE
ci(release): enable Tauri auto-updater on Windows and Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -513,6 +513,8 @@ jobs:
       - name: Build Linux Tauri app
         run: cd desktop && pnpm tauri build --verbose --ci --bundles deb,appimage --config src-tauri/tauri.release.conf.json
         env:
+          BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
+          BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -647,6 +649,8 @@ jobs:
         shell: bash
         run: cd desktop && pnpm tauri build --verbose --target "$TARGET" --bundles nsis --config src-tauri/tauri.release.conf.json
         env:
+          BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
+          BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"


### PR DESCRIPTION
The desktop auto-updater works on macOS but is dead on Windows and Linux — "Check for updates" reports that automatic updates aren't available and tells the user to download and install manually.

## Root cause

The updater plugin is registered behind the `buzz_updater_enabled` cfg in `lib.rs`. `build.rs` emits that cfg only when both `BUZZ_UPDATER_PUBLIC_KEY` and `BUZZ_UPDATER_ENDPOINT` are present in the compiler's own env at compile time. Those vars reach the compiler only via the build step's `env:` block.

The macOS arm64 and x64 build steps set them; the Windows and Linux build steps did not. So on those two platforms the cfg was never emitted, the plugin was compiled out, and the frontend's `check()` threw "plugin updater not found" — which the UI maps to the `unavailable` state.

The runtime JSON config channel (`build-release-config.mjs` writing `plugins.updater.{pubkey,endpoints}`) was already wired on all four platforms via the Generate-config step. Only the compile-time cfg channel was missing on Windows and Linux.

## The change

Add `BUZZ_UPDATER_PUBLIC_KEY` and `BUZZ_UPDATER_ENDPOINT` to the `env:` block of the Windows NSIS build step and the Linux Tauri build step, copied verbatim from the macOS build steps. The compile-time-embedded pubkey must match the key the artifacts are signed with (`TAURI_SIGNING_PRIVATE_KEY`, the same secret on all platforms), so these are byte-identical to the macOS lines. No new secret or attack surface — the pubkey is public and the endpoint is a public URL, and both already appear on the Generate-config step of these same jobs.

End-to-end verification is a runtime gate: a real install of a build cut after this lands, successfully checking for and applying an update. Green CI proves upload, not the in-binary plugin.
