### PR TITLE
Move search entry into sidebar nav

### DIFF
--- a/desktop/src/features/search/ui/TopbarSearch.tsx
+++ b/desktop/src/features/search/ui/TopbarSearch.tsx
@@ -20,6 +20,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/shared/ui/dialog";
+import { SidebarMenuButton } from "@/shared/ui/sidebar";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
@@ -30,6 +31,7 @@ type TopbarSearchProps = {
   focusRequest?: number;
   onOpenChannel: (channelId: string) => void;
   onOpenResult: (hit: SearchHit) => void;
+  variant?: "bar" | "sidebar-item";
 };
 
 function describeSearchHit(hit: SearchHit) {
@@ -146,11 +148,13 @@ export function TopbarSearch({
   focusRequest = 0,
   onOpenChannel,
   onOpenResult,
+  variant = "bar",
 }: TopbarSearchProps) {
   const [isOpen, setIsOpen] = React.useState(false);
   const [selectedMenuIndex, setSelectedMenuIndex] = React.useState(0);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const dialogInputRef = React.useRef<HTMLInputElement>(null);
+  const isSidebarItemVariant = variant === "sidebar-item";
   const {
     channelLookup,
     debouncedQuery,
@@ -330,26 +334,45 @@ export function TopbarSearch({
     <div className={cn("relative", className)}>
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogTrigger asChild>
-          <button
-            aria-label="Search everything"
-            className="group/search flex h-7 w-full items-center gap-2 rounded-lg border border-border/70 bg-background px-2.5 text-left text-xs text-muted-foreground shadow-xs transition-colors duration-150 ease-out hover:bg-muted/70 hover:text-foreground focus-visible:border-border focus-visible:bg-muted/70 focus-visible:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-            data-testid="open-search"
-            ref={triggerRef}
-            type="button"
-          >
-            <Search className="h-4 w-4 shrink-0 text-muted-foreground/55 transition-colors duration-150 ease-out group-hover/search:text-muted-foreground group-focus-visible/search:text-foreground" />
-            <span
-              className={cn(
-                "min-w-0 flex-1 translate-y-px truncate transition-colors duration-150 ease-out",
-                query ? "text-foreground" : "text-muted-foreground/55",
-              )}
+          {isSidebarItemVariant ? (
+            <SidebarMenuButton
+              className="group/search"
+              data-testid="open-search"
+              ref={triggerRef}
+              title="Search"
+              type="button"
             >
-              {query || "Search everything"}
-            </span>
-            <kbd className="shrink-0 text-2xs text-muted-foreground/70">
-              &#x2318;K
-            </kbd>
-          </button>
+              <Search className="h-4 w-4" />
+              <span className="min-w-0 flex-1 truncate">Search</span>
+              <kbd
+                aria-hidden="true"
+                className="ml-auto shrink-0 text-2xs text-sidebar-foreground/45 opacity-0 transition-opacity duration-150 group-hover/search:opacity-100 group-focus-visible/search:opacity-100 group-data-[collapsible=icon]:hidden"
+              >
+                &#x2318;K
+              </kbd>
+            </SidebarMenuButton>
+          ) : (
+            <button
+              aria-label="Search everything"
+              className="group/search flex h-7 w-full items-center gap-2 rounded-lg border border-border/70 bg-background px-2.5 text-left text-xs text-muted-foreground shadow-xs transition-colors duration-150 ease-out hover:bg-muted/70 hover:text-foreground focus-visible:border-border focus-visible:bg-muted/70 focus-visible:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+              data-testid="open-search"
+              ref={triggerRef}
+              type="button"
+            >
+              <Search className="h-4 w-4 shrink-0 text-muted-foreground/55 transition-colors duration-150 ease-out group-hover/search:text-muted-foreground group-focus-visible/search:text-foreground" />
+              <span
+                className={cn(
+                  "min-w-0 flex-1 translate-y-px truncate transition-colors duration-150 ease-out",
+                  query ? "text-foreground" : "text-muted-foreground/55",
+                )}
+              >
+                {query || "Search everything"}
+              </span>
+              <kbd className="shrink-0 text-2xs text-muted-foreground/70">
+                &#x2318;K
+              </kbd>
+            </button>
+          )}
         </DialogTrigger>
         <DialogContent
           aria-busy={searchQuery.isLoading && results.length === 0}

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -529,18 +529,21 @@ export function AppSidebar({
           className="mt-(--buzz-top-chrome-height,2.5rem) shrink-0 px-2 pt-2"
           data-testid="sidebar-pinned-header"
         >
-          <TopbarSearch
-            channels={searchChannels}
-            currentPubkey={currentPubkey}
-            focusRequest={searchFocusRequest}
-            onOpenChannel={onSelectChannel}
-            onOpenResult={onOpenSearchResult}
-          />
           <SidebarHeader
             className="cursor-default select-none px-0 pb-0 pt-2"
             data-tauri-drag-region
           >
             <SidebarMenu>
+              <SidebarMenuItem>
+                <TopbarSearch
+                  channels={searchChannels}
+                  currentPubkey={currentPubkey}
+                  focusRequest={searchFocusRequest}
+                  onOpenChannel={onSelectChannel}
+                  onOpenResult={onOpenSearchResult}
+                  variant="sidebar-item"
+                />
+              </SidebarMenuItem>
               <SidebarMenuItem>
                 <SidebarMenuButton
                   isActive={selectedView === "home"}


### PR DESCRIPTION
## Summary
- Move the search trigger from the standalone sidebar search bar into the primary sidebar nav above Inbox.
- Add a sidebar-menu search trigger variant that shows the Command-K hint on hover/focus.

## Validation
- `just desktop-typecheck`
- `git diff --check`
- px-value diff sweep

## Screenshots

![Sidebar search entry row with keyboard shortcut affordance](https://raw.githubusercontent.com/block/buzz/5cc5154714b1c7bdf5c85ced01992d96c904f846/pr-1211--pr1211-sidebar-search-entry.png)
