### PR TITLE
Polish sidebar channel navigation

### DIFF
--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -704,11 +704,9 @@ function SearchResultSectionTitle({
   children: React.ReactNode;
 }) {
   return (
-    <div className="sticky top-0 z-10 mr-3 flex min-h-9 items-center gap-2 bg-background/95 px-4 pb-1.5 pt-3 text-xs font-medium uppercase tracking-wide text-muted-foreground/75 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+    <div className="sticky top-0 z-10 mr-3 flex min-h-9 items-center gap-2 bg-background/95 px-4 pb-1.5 pt-3 text-xs font-medium text-muted-foreground/75 backdrop-blur supports-[backdrop-filter]:bg-background/80">
       <span>{children}</span>
-      {action ? (
-        <span className="normal-case tracking-normal">{action}</span>
-      ) : null}
+      {action ? <span>{action}</span> : null}
     </div>
   );
 }

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -619,7 +619,7 @@ export function AppSidebar({
         </div>
 
         <SidebarContent
-          className="buzz-sidebar-scrollbar overscroll-none"
+          className="buzz-sidebar-scrollbar overscroll-none pt-4"
           ref={scrollRef}
         >
           {isLoading ? (
@@ -716,9 +716,6 @@ export function AppSidebar({
                   browseAriaLabel="Browse channels"
                   createAriaLabel="Create a channel"
                   draggable
-                  groupClassName={
-                    channelSections.length > 0 ? undefined : "pt-1"
-                  }
                   hasUnread={unreadChannelIds.size > 0}
                   isCollapsed={collapsedGroups.channels}
                   isActiveChannel={selectedView === "channel"}
@@ -802,7 +799,7 @@ export function AppSidebar({
                 presenceByChannelId={dmPresenceByChannelId}
                 selectedChannelId={selectedChannelId}
                 testId="dm-list"
-                title="Direct Messages"
+                title="Direct messages"
                 unreadChannelCounts={unreadChannelCounts}
                 unreadChannelIds={unreadChannelIds}
                 mutedChannelIds={mutedChannelIds}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -11,7 +11,6 @@ import {
   GripVertical,
   Pencil,
   Plus,
-  Search,
   Star,
   StarOff,
   Trash2,
@@ -48,6 +47,7 @@ import {
 import type { ChannelSection } from "@/features/sidebar/lib/useChannelSections";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { HashSearch } from "@/shared/ui/icons";
 
 // ---------------------------------------------------------------------------
 // Shared styles
@@ -56,7 +56,7 @@ import { cn } from "@/shared/lib/cn";
 const SECTION_LABEL_BUTTON_CLASS =
   "group/section-label flex w-fit max-w-[calc(100%-3rem)] cursor-pointer appearance-none items-center gap-1 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
 const SECTION_LABEL_CHEVRON_CLASS =
-  "relative size-2.5 shrink-0 opacity-0 text-sidebar-foreground/45 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/sidebar-section:text-sidebar-foreground group-hover/section-label:opacity-100 group-hover/section-label:text-sidebar-foreground group-focus-within/sidebar-section:opacity-100 group-focus-within/sidebar-section:text-sidebar-foreground group-focus-visible/section-label:opacity-100 group-focus-visible/section-label:text-sidebar-foreground";
+  "relative size-2.5 shrink-0 text-current opacity-0 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/section-label:opacity-100 group-focus-within/sidebar-section:opacity-100 group-focus-visible/section-label:opacity-100";
 const SECTION_LABEL_CHEVRON_ICON_CLASS =
   "absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2";
 
@@ -261,18 +261,24 @@ function SectionHeaderActions({
       {onBrowseClick ? (
         <button
           aria-label={browseAriaLabel}
-          className={SECTION_ICON_BUTTON_CLASS}
+          className={cn(
+            SECTION_ICON_BUTTON_CLASS,
+            SECTION_ACTION_VISIBILITY_CLASS,
+          )}
           onClick={onBrowseClick}
           title={browseAriaLabel}
           type="button"
         >
-          <Search className="h-4 w-4" />
+          <HashSearch className="h-4 w-4" />
         </button>
       ) : null}
       {onCreateClick ? (
         <button
           aria-label={createAriaLabel}
-          className={SECTION_ICON_BUTTON_CLASS}
+          className={cn(
+            SECTION_ICON_BUTTON_CLASS,
+            SECTION_ACTION_VISIBILITY_CLASS,
+          )}
           onClick={onCreateClick}
           type="button"
         >
@@ -416,8 +422,8 @@ export function ChannelGroupSection({
     ) : null;
 
   const sectionContent = (
-    <SidebarGroup className={groupClassName}>
-      <div className="group/sidebar-section relative">
+    <SidebarGroup className={cn("group/sidebar-section", groupClassName)}>
+      <div className="relative">
         <SidebarGroupLabel asChild>
           <button
             aria-controls={contentId}
@@ -535,13 +541,12 @@ export function CustomChannelSection({
     <SortableSectionShell sectionId={section.id}>
       {({ dragHandleProps, isDragging }) => (
         <DroppableSectionBody sectionId={section.id}>
-          <SidebarGroup className={cn(isDragging && "opacity-30")}>
+          <SidebarGroup
+            className={cn("group/sidebar-section", isDragging && "opacity-30")}
+          >
             <ContextMenu>
               <ContextMenuTrigger asChild>
-                <div
-                  className="group/sidebar-section relative"
-                  {...dragHandleProps}
-                >
+                <div className="relative" {...dragHandleProps}>
                   <SidebarGroupLabel asChild>
                     <button
                       aria-controls={contentId}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -35,7 +35,7 @@ import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
 const SECTION_LABEL_BUTTON_CLASS =
   "group/section-label flex w-fit max-w-[calc(100%-3rem)] cursor-pointer appearance-none items-center gap-1 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
 const SECTION_LABEL_CHEVRON_CLASS =
-  "relative size-2.5 shrink-0 opacity-0 text-sidebar-foreground/45 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/sidebar-section:text-sidebar-foreground group-hover/section-label:opacity-100 group-hover/section-label:text-sidebar-foreground group-focus-within/sidebar-section:opacity-100 group-focus-within/sidebar-section:text-sidebar-foreground group-focus-visible/section-label:opacity-100 group-focus-visible/section-label:text-sidebar-foreground";
+  "relative size-2.5 shrink-0 text-current opacity-0 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/section-label:opacity-100 group-focus-within/sidebar-section:opacity-100 group-focus-visible/section-label:opacity-100";
 const SECTION_LABEL_CHEVRON_ICON_CLASS =
   "absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2";
 const SIDEBAR_ROW_ACTION_VISIBILITY_CLASS =
@@ -300,8 +300,8 @@ export function SidebarSection({
   const canToggle = Boolean(onToggleCollapsed);
 
   return (
-    <SidebarGroup>
-      <div className="group/sidebar-section relative">
+    <SidebarGroup className="group/sidebar-section">
+      <div className="relative">
         <SidebarGroupLabel asChild={canToggle}>
           {canToggle ? (
             <button

--- a/desktop/src/shared/ui/icons.ts
+++ b/desktop/src/shared/ui/icons.ts
@@ -1,0 +1,10 @@
+import { createLucideIcon } from "lucide-react";
+
+export const HashSearch = createLucideIcon("hash-search", [
+  ["line", { x1: "4", x2: "20", y1: "9", y2: "9", key: "pulu6f" }],
+  ["line", { x1: "4", x2: "11", y1: "15", y2: "15", key: "th0qa4" }],
+  ["line", { x1: "10", x2: "8", y1: "3", y2: "21", key: "1ggp8o" }],
+  ["line", { x1: "16", x2: "15", y1: "3", y2: "12", key: "noe5so" }],
+  ["path", { d: "m21 21-1.9-1.9", key: "1g2n9r" }],
+  ["circle", { cx: "17", cy: "17", r: "3", key: "18b49y" }],
+]);


### PR DESCRIPTION
## Summary
- Show channel section actions on section hover/focus and use the new hash-search icon for Browse channels.
- Normalize sidebar section spacing and section title casing.
- Keep section chevrons aligned with section header color behavior.

## Validation
- `just desktop-typecheck`
- `git diff --check`
- px-value diff sweep

## Screenshots

![Sidebar channel navigation hover polish](https://raw.githubusercontent.com/block/buzz/5cc5154714b1c7bdf5c85ced01992d96c904f846/pr-1213--pr1213-sidebar-channel-hover.png)
