### PR TITLE
fix: tolerate missing private_key_nsec in agent store

### DIFF
--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -88,6 +88,9 @@ pub struct ManagedAgentRecord {
     pub name: String,
     #[serde(default)]
     pub persona_id: Option<String>,
+    /// `#[serde(default)]` so an old build still parses a store whose inline
+    /// key was stripped after a keyring build migrated it into the Keychain.
+    #[serde(default)]
     pub private_key_nsec: String,
     /// NIP-OA auth tag JSON. Computed at agent creation time.
     ///


### PR DESCRIPTION
A keyring build migrates each agent's nsec into the macOS Keychain and strips the inline `private_key_nsec` from the shared dev agent store. On the old (non-keyring) build, `private_key_nsec` is a required field on `ManagedAgentRecord`, so a stripped/missing inline key fails the whole `serde_json::from_str` at the first affected record — taking down `load_managed_agents`, nest-context regeneration, and every agent at once.

Adding `#[serde(default)]` to `private_key_nsec` widens the old build's read tolerance: a missing inline key now deserializes to an empty `String` instead of failing the parse, letting an old build survive a half-migrated store. The empty-key case is already handled downstream by the existing spawn-refusal path, so this is pure read-tolerance widening with no behavior change for valid stores.

Related: keyring foundation #1172 (already forwards-tolerant on its own load path).
