### PR TITLE
fix(desktop): enable mesh llm for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
           key: mesh-llama-${{ runner.os }}-metal-${{ steps.mesh_rev.outputs.rev }}
 
       - name: Build unsigned Tauri app
-        run: cd desktop && pnpm tauri build --verbose --no-sign --config src-tauri/tauri.release.conf.json
+        run: cd desktop && pnpm tauri build --verbose --no-sign --features mesh-llm --config src-tauri/tauri.release.conf.json
         env:
           BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
           BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json


### PR DESCRIPTION
## Summary
- enable the `mesh-llm` Cargo feature when building the unsigned macOS Tauri release artifact
- keep the existing mesh llama native library prep/cache steps wired to the actual app build

## Validation
- `git diff --check`
- pre-commit hook passed during commit (`rust-fmt`, `desktop-tauri-fmt`, `web-fix`, `desktop-fix`, `mobile-fix`)
- pre-push hook passed during push (`desktop-test`, `rust-tests`, `mobile-test`, `desktop-tauri-test`)
- verified separately that `pnpm tauri build --features mesh-llm ...` forwards to Cargo as `cargo build --bins --features mesh-llm,tauri/custom-protocol --release`
