### PR TITLE
fix(desktop): move crypto commands off the main thread

### DIFF
--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -64,30 +64,38 @@ pub fn get_media_proxy_port(state: State<'_, AppState>) -> u16 {
 }
 
 #[tauri::command]
-pub fn sign_event(
+pub async fn sign_event(
     kind: u16,
     content: String,
     created_at: Option<u64>,
     tags: Vec<Vec<String>>,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let keys = state.keys.lock().map_err(|error| error.to_string())?;
+    let keys = state
+        .keys
+        .lock()
+        .map_err(|error| error.to_string())?
+        .clone();
 
-    let nostr_tags = tags
-        .into_iter()
-        .map(|tag| Tag::parse(tag).map_err(|error| format!("invalid tag: {error}")))
-        .collect::<Result<Vec<_>, _>>()?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let nostr_tags = tags
+            .into_iter()
+            .map(|tag| Tag::parse(tag).map_err(|error| format!("invalid tag: {error}")))
+            .collect::<Result<Vec<_>, _>>()?;
 
-    let mut builder = EventBuilder::new(Kind::Custom(kind), content).tags(nostr_tags);
-    if let Some(created_at) = created_at {
-        builder = builder.custom_created_at(Timestamp::from(created_at));
-    }
+        let mut builder = EventBuilder::new(Kind::Custom(kind), content).tags(nostr_tags);
+        if let Some(created_at) = created_at {
+            builder = builder.custom_created_at(Timestamp::from(created_at));
+        }
 
-    let event = builder
-        .sign_with_keys(&keys)
-        .map_err(|error| format!("sign failed: {error}"))?;
+        let event = builder
+            .sign_with_keys(&keys)
+            .map_err(|error| format!("sign failed: {error}"))?;
 
-    Ok(event.as_json())
+        Ok(event.as_json())
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }
 
 #[tauri::command]
@@ -197,49 +205,67 @@ pub fn import_identity(
 }
 
 #[tauri::command]
-pub fn create_auth_event(
+pub async fn create_auth_event(
     challenge: String,
     relay_url: String,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let keys = state.keys.lock().map_err(|error| error.to_string())?;
+    let keys = state
+        .keys
+        .lock()
+        .map_err(|error| error.to_string())?
+        .clone();
 
-    let tags = vec![
-        Tag::parse(vec!["relay", &relay_url])
-            .map_err(|error| format!("relay tag failed: {error}"))?,
-        Tag::parse(vec!["challenge", &challenge])
-            .map_err(|error| format!("challenge tag failed: {error}"))?,
-    ];
+    tauri::async_runtime::spawn_blocking(move || {
+        let tags = vec![
+            Tag::parse(vec!["relay", &relay_url])
+                .map_err(|error| format!("relay tag failed: {error}"))?,
+            Tag::parse(vec!["challenge", &challenge])
+                .map_err(|error| format!("challenge tag failed: {error}"))?,
+        ];
 
-    let event = EventBuilder::new(Kind::Custom(22242), "")
-        .tags(tags)
-        .sign_with_keys(&keys)
-        .map_err(|error| format!("sign failed: {error}"))?;
+        let event = EventBuilder::new(Kind::Custom(22242), "")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .map_err(|error| format!("sign failed: {error}"))?;
 
-    Ok(event.as_json())
+        Ok(event.as_json())
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }
 
 #[tauri::command]
-pub fn nip44_encrypt_to_self(
+pub async fn nip44_encrypt_to_self(
     plaintext: String,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let keys = state.keys.lock().map_err(|e| e.to_string())?;
-    nip44::encrypt(
-        keys.secret_key(),
-        &keys.public_key(),
-        &plaintext,
-        nip44::Version::V2,
-    )
-    .map_err(|e| format!("nip44 encrypt failed: {e}"))
+    let keys = state.keys.lock().map_err(|e| e.to_string())?.clone();
+
+    tauri::async_runtime::spawn_blocking(move || {
+        nip44::encrypt(
+            keys.secret_key(),
+            &keys.public_key(),
+            &plaintext,
+            nip44::Version::V2,
+        )
+        .map_err(|e| format!("nip44 encrypt failed: {e}"))
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }
 
 #[tauri::command]
-pub fn nip44_decrypt_from_self(
+pub async fn nip44_decrypt_from_self(
     ciphertext: String,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let keys = state.keys.lock().map_err(|e| e.to_string())?;
-    nip44::decrypt(keys.secret_key(), &keys.public_key(), &ciphertext)
-        .map_err(|e| format!("nip44 decrypt failed: {e}"))
+    let keys = state.keys.lock().map_err(|e| e.to_string())?.clone();
+
+    tauri::async_runtime::spawn_blocking(move || {
+        nip44::decrypt(keys.secret_key(), &keys.public_key(), &ciphertext)
+            .map_err(|e| format!("nip44 decrypt failed: {e}"))
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }


### PR DESCRIPTION
Four Tauri commands in `identity.rs` — `sign_event`, `create_auth_event`, `nip44_encrypt_to_self`, and `nip44_decrypt_from_self` — were synchronous, running Schnorr signing and NIP-44 encryption directly on the webview main thread. Under burst traffic (reconnect replay resubscribing to 21+ channels, presence updates, read-state sync) this blocked the event loop long enough to trigger the macOS beachball and prevent WebSocket pong responses from being processed, contributing to relay disconnect cycles.

Investigation of local agent subprocess logs revealed ~14,000 disconnect/reconnect events in a single day against the staging relay, confirming a server-side component as well (tracked separately in [block-coder-tf-stacks#2181](https://github.com/squareup/block-coder-tf-stacks/pull/2181)). But the beachball correlation with disconnects pointed to these synchronous crypto commands as an independent client-side contributor — a blocked main thread can't process inbound pong frames, so the relay's 3-missed-pongs (90s) timeout fires even when the network is healthy.

- Convert all four commands from `pub fn` to `pub async fn` with `tauri::async_runtime::spawn_blocking` so crypto work runs on the tokio blocking thread pool instead of the webview main thread
- Clone `Keys` from the `std::sync::Mutex` before entering `spawn_blocking` since `State<'_>` cannot cross the boundary
- No changes to `lib.rs` — `tauri::generate_handler!` handles both sync and async commands identically

Related: [block-coder-tf-stacks#2181](https://github.com/squareup/block-coder-tf-stacks/pull/2181) (staging relay observability, PDB, replica scaling)