### PR TITLE
test(desktop): pin AGENTS.md migration guard against template drift

### DIFF
--- a/desktop/src-tauri/src/migration_tests.rs
+++ b/desktop/src-tauri/src/migration_tests.rs
@@ -981,3 +981,19 @@ fn migrate_legacy_nest_preserves_user_edited_agents_md() {
         "a user-edited live AGENTS.md must never be clobbered"
     );
 }
+
+#[test]
+fn ensure_nest_writes_agents_md_byte_equal_to_template() {
+    // Guard for the legacy-AGENTS.md migration: copy_file_over_generated_default
+    // detects an untouched default by byte-equality against AGENTS_MD; that holds only
+    // while ensure_nest_at stays an identity on a fresh file. Drift would silently
+    // re-strand the legacy file, so pin the invariant here.
+    let dir = tempfile::tempdir().unwrap();
+    let current = dir.path().join(".buzz");
+    crate::managed_agents::ensure_nest_at(&current).unwrap();
+    assert_eq!(
+        std::fs::read_to_string(current.join("AGENTS.md")).unwrap(),
+        crate::managed_agents::AGENTS_MD,
+        "ensure_nest_at must write AGENTS.md byte-equal to the embedded template"
+    );
+}


### PR DESCRIPTION
Pins the byte-equality invariant that the legacy-nest AGENTS.md migration depends on.

`copy_file_over_generated_default` (added in #1194) decides whether to overwrite `~/.buzz/AGENTS.md` with a legacy `~/.sprout/AGENTS.md` by comparing the destination byte-for-byte against the embedded `AGENTS_MD` template. That comparison only matches an untouched default because `ensure_nest_at` writes the template verbatim and `refresh_agents_md_if_stale` is an exact identity on a fresh file. If a future template or refresh change ever breaks that identity (marker or whitespace normalization, a trailing-newline tweak), the guard would silently fail closed and re-strand the user's legacy instructions — the original bug, reintroduced invisibly.

This adds `ensure_nest_writes_agents_md_byte_equal_to_template`, which runs `ensure_nest_at` on a fresh nest and asserts the written `AGENTS.md` is byte-equal to `AGENTS_MD`. Any drift between what `ensure_nest_at` writes and the raw template now trips a loud test failure instead of silently regressing the migration.

Test-only; no production code changes.

Related: #1194
