### PR TITLE
fix(relay): raise grace limit, add replay backpressure, and NOTICE on oversized frames

### DIFF
--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -45,6 +45,8 @@ pub struct Config {
     pub send_buffer_size: usize,
     /// Maximum inbound WebSocket frame size in bytes.
     pub max_frame_bytes: usize,
+    /// Number of consecutive buffer-full events tolerated before cancelling a slow client.
+    pub slow_client_grace_limit: u8,
     /// Authentication provider configuration.
     pub auth: buzz_auth::AuthConfig,
     /// Whether REST API requests must present a valid token. Independent of
@@ -172,6 +174,11 @@ impl Config {
             .and_then(|v| v.parse::<usize>().ok())
             .filter(|&v| v > 0)
             .unwrap_or(DEFAULT_MAX_FRAME_BYTES);
+
+        let slow_client_grace_limit = std::env::var("BUZZ_SLOW_CLIENT_GRACE_LIMIT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(15);
 
         let require_auth_token = std::env::var("BUZZ_REQUIRE_AUTH_TOKEN")
             .map(|v| v == "true" || v == "1")
@@ -375,6 +382,7 @@ impl Config {
             max_concurrent_handlers,
             send_buffer_size,
             max_frame_bytes,
+            slow_client_grace_limit,
             auth,
             require_auth_token,
             cors_origins,
@@ -417,6 +425,7 @@ mod tests {
         assert!(config.max_connections > 0);
         assert!(config.send_buffer_size > 0);
         assert_eq!(config.max_frame_bytes, DEFAULT_MAX_FRAME_BYTES);
+        assert!(config.slow_client_grace_limit > 0);
         assert!(
             !config.pubkey_allowlist_enabled,
             "pubkey_allowlist_enabled should default to false"

--- a/crates/buzz-relay/src/connection.rs
+++ b/crates/buzz-relay/src/connection.rs
@@ -20,10 +20,6 @@ use crate::handlers;
 use crate::protocol::{ClientMessage, RelayMessage};
 use crate::state::AppState;
 
-/// Number of buffer-full events tolerated before cancelling a slow client.
-/// Prevents transient read stalls from hard-disconnecting agents mid-inference.
-pub(crate) const SLOW_CLIENT_GRACE_LIMIT: u8 = 3;
-
 /// Shared mutable subscription map for a single WebSocket connection.
 pub(crate) type ConnectionSubscriptions = Arc<Mutex<HashMap<String, Vec<Filter>>>>;
 
@@ -62,18 +58,20 @@ pub struct ConnectionState {
     pub ctrl_tx: mpsc::Sender<WsMessage>,
     /// Token used to signal graceful shutdown of this connection's tasks.
     pub cancel: CancellationToken,
-    /// Consecutive buffer-full events. Cancel only after [`SLOW_CLIENT_GRACE_LIMIT`].
+    /// Consecutive buffer-full events. Cancel only after `grace_limit`.
     /// Shared with `ConnectionManager::ConnEntry` so both direct sends and
     /// fan-out broadcasts track the same counter.
     pub backpressure_count: Arc<AtomicU8>,
+    /// Configurable slow-client grace limit (from `Config::slow_client_grace_limit`).
+    pub grace_limit: u8,
 }
 
 impl ConnectionState {
     /// Sends a data message to this connection's outbound channel.
     ///
     /// On a full buffer, increments the backpressure counter. The first
-    /// [`SLOW_CLIENT_GRACE_LIMIT`] occurrences log a warning; sustained
-    /// backpressure cancels the connection to prevent unbounded memory growth.
+    /// `grace_limit` occurrences log a warning; sustained backpressure
+    /// cancels the connection to prevent unbounded memory growth.
     pub fn send(&self, msg: String) -> bool {
         match self.send_tx.try_send(WsMessage::Text(msg.into())) {
             Ok(_) => {
@@ -83,12 +81,12 @@ impl ConnectionState {
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                 let count = self.backpressure_count.fetch_add(1, Ordering::Relaxed) + 1;
-                if count >= SLOW_CLIENT_GRACE_LIMIT {
+                if count >= self.grace_limit {
                     warn!(conn_id = %self.conn_id, count, "sustained backpressure — closing slow client");
                     metrics::counter!("buzz_ws_backpressure_disconnects_total").increment(1);
                     self.cancel.cancel();
                 } else {
-                    warn!(conn_id = %self.conn_id, count, grace = SLOW_CLIENT_GRACE_LIMIT, "send buffer full — grace {count}/{SLOW_CLIENT_GRACE_LIMIT}");
+                    warn!(conn_id = %self.conn_id, count, grace = self.grace_limit, "send buffer full — grace {count}/{}", self.grace_limit);
                 }
                 false
             }
@@ -136,6 +134,7 @@ pub async fn handle_connection(socket: WebSocket, state: Arc<AppState>, addr: So
         ctrl_tx: ctrl_tx.clone(),
         cancel: cancel.clone(),
         backpressure_count: Arc::clone(&backpressure_count),
+        grace_limit: state.config.slow_client_grace_limit,
     });
 
     info!(conn_id = %conn_id, addr = %addr, "WebSocket connection established");
@@ -162,6 +161,7 @@ pub async fn handle_connection(socket: WebSocket, state: Arc<AppState>, addr: So
         cancel.clone(),
         Arc::clone(&backpressure_count),
         subscriptions,
+        state.config.slow_client_grace_limit,
     );
 
     let (ws_send, ws_recv) = socket.split();
@@ -303,6 +303,11 @@ async fn recv_loop(
                                 max_frame_bytes,
                                 "frame too large — disconnecting"
                             );
+                            conn.send(format!(
+                                r#"["NOTICE","error: frame too large ({} bytes, limit {})"]"#,
+                                text.len(),
+                                max_frame_bytes
+                            ));
                             break;
                         }
                         trace!(len = text.len(), "frame received");
@@ -317,6 +322,11 @@ async fn recv_loop(
                                 max_frame_bytes,
                                 "binary frame too large — disconnecting"
                             );
+                            conn.send(format!(
+                                r#"["NOTICE","error: binary frame too large ({} bytes, limit {})"]"#,
+                                bytes.len(),
+                                max_frame_bytes
+                            ));
                             break;
                         }
                         // Binary frames: attempt UTF-8 decode and treat as text. Some clients

--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -1071,6 +1071,7 @@ mod tests {
                 CancellationToken::new(),
                 Arc::new(AtomicU8::new(0)),
                 Arc::new(Mutex::new(HashMap::new())),
+                3,
             );
             if let Some(pk) = pubkey {
                 state.conn_manager.set_authenticated_pubkey(conn_id, pk);

--- a/crates/buzz-relay/src/handlers/mesh_signaling.rs
+++ b/crates/buzz-relay/src/handlers/mesh_signaling.rs
@@ -550,6 +550,7 @@ mod tests {
             tokio_util::sync::CancellationToken::new(),
             std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0)),
             std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            3,
         );
         state.sub_registry.register(
             conn_id,

--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -20,7 +20,7 @@ use crate::connection::{AuthState, ConnectionState};
 use crate::protocol::RelayMessage;
 use crate::state::AppState;
 
-const MAX_HISTORICAL_LIMIT: i64 = 10_000;
+const MAX_HISTORICAL_LIMIT: i64 = 2_000;
 const MAX_SUBSCRIPTIONS: usize = 1024;
 const P_GATED_KINDS: [u32; 5] = [
     KIND_AGENT_OBSERVER_FRAME,
@@ -253,6 +253,9 @@ pub async fn handle_req(
                 return;
             }
             total_sent += 1;
+            if total_sent.is_multiple_of(100) {
+                tokio::task::yield_now().await;
+            }
         }
     }
 

--- a/crates/buzz-relay/src/state.rs
+++ b/crates/buzz-relay/src/state.rs
@@ -24,7 +24,7 @@ use deadpool_redis;
 
 use crate::audio::AudioRoomManager;
 use crate::config::Config;
-use crate::connection::{ConnectionSubscriptions, SLOW_CLIENT_GRACE_LIMIT};
+use crate::connection::ConnectionSubscriptions;
 use crate::subscription::SubscriptionRegistry;
 
 /// Per-connection entry in the connection manager.
@@ -36,6 +36,7 @@ struct ConnEntry {
     backpressure_count: Arc<AtomicU8>,
     subscriptions: ConnectionSubscriptions,
     authenticated_pubkey: Arc<std::sync::RwLock<Option<Vec<u8>>>>,
+    grace_limit: u8,
 }
 
 /// Tracks active WebSocket connections and provides message routing by connection ID.
@@ -52,7 +53,7 @@ impl ConnectionManager {
     }
 
     /// Registers a connection with its outbound sender, cancellation token,
-    /// shared backpressure counter, and mutable subscription map.
+    /// shared backpressure counter, mutable subscription map, and grace limit.
     pub fn register(
         &self,
         conn_id: Uuid,
@@ -60,6 +61,7 @@ impl ConnectionManager {
         cancel: CancellationToken,
         backpressure_count: Arc<AtomicU8>,
         subscriptions: ConnectionSubscriptions,
+        grace_limit: u8,
     ) {
         self.connections.insert(
             conn_id,
@@ -69,6 +71,7 @@ impl ConnectionManager {
                 backpressure_count,
                 subscriptions,
                 authenticated_pubkey: Arc::new(std::sync::RwLock::new(None)),
+                grace_limit,
             },
         );
     }
@@ -131,8 +134,8 @@ impl ConnectionManager {
     /// Sends a text message to the given connection.
     ///
     /// Returns `false` if the connection is gone or the buffer is full.
-    /// On sustained backpressure (>[`SLOW_CLIENT_GRACE_LIMIT`] consecutive full
-    /// buffers), cancels the connection. Transient stalls get a warning only.
+    /// On sustained backpressure (>grace_limit consecutive full buffers),
+    /// cancels the connection. Transient stalls get a warning only.
     pub fn send_to(&self, conn_id: Uuid, msg: String) -> bool {
         if let Some(entry) = self.connections.get(&conn_id) {
             let conn = entry.value();
@@ -143,12 +146,12 @@ impl ConnectionManager {
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                     let count = conn.backpressure_count.fetch_add(1, Ordering::Relaxed) + 1;
-                    if count >= SLOW_CLIENT_GRACE_LIMIT {
+                    if count >= conn.grace_limit {
                         tracing::warn!(conn_id = %conn_id, count, "fan-out: sustained backpressure — cancelling slow client");
                         metrics::counter!("buzz_ws_backpressure_disconnects_total").increment(1);
                         conn.cancel.cancel();
                     } else {
-                        tracing::warn!(conn_id = %conn_id, count, grace = SLOW_CLIENT_GRACE_LIMIT, "fan-out: send buffer full — grace {count}/{SLOW_CLIENT_GRACE_LIMIT}");
+                        tracing::warn!(conn_id = %conn_id, count, grace = conn.grace_limit, "fan-out: send buffer full — grace {count}/{}", conn.grace_limit);
                     }
                     false
                 }
@@ -591,6 +594,7 @@ mod tests {
             cancel.clone(),
             Arc::clone(&bp),
             Arc::new(Mutex::new(HashMap::new())),
+            3,
         );
         (mgr, conn_id, rx, cancel, bp)
     }
@@ -633,13 +637,13 @@ mod tests {
     fn send_to_cancels_after_grace_limit() {
         let (mgr, id, _rx, cancel, _bp) = setup_conn(1);
         assert!(mgr.send_to(id, "fill".into()));
-        // Exhaust grace: 3 consecutive Full events.
-        for _ in 0..SLOW_CLIENT_GRACE_LIMIT {
+        // Exhaust grace: 3 consecutive Full events (matches grace_limit=3 from setup_conn).
+        for _ in 0..3u8 {
             mgr.send_to(id, "overflow".into());
         }
         assert!(
             cancel.is_cancelled(),
-            "should cancel after SLOW_CLIENT_GRACE_LIMIT overflows"
+            "should cancel after grace_limit overflows"
         );
     }
 
@@ -662,6 +666,7 @@ mod tests {
             ctrl_tx,
             cancel: cancel.clone(),
             backpressure_count: Arc::clone(&bp),
+            grace_limit: 3,
         };
 
         let mgr = ConnectionManager::new();
@@ -671,6 +676,7 @@ mod tests {
             cancel.clone(),
             Arc::clone(&bp),
             Arc::clone(&conn.subscriptions),
+            3,
         );
 
         // Fill the buffer via direct send.
@@ -705,7 +711,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let bp = Arc::new(AtomicU8::new(0));
         let subscriptions = Arc::new(Mutex::new(HashMap::new()));
-        mgr.register(conn_id, tx, cancel, bp, Arc::clone(&subscriptions));
+        mgr.register(conn_id, tx, cancel, bp, Arc::clone(&subscriptions), 3);
 
         let pubkey = vec![7u8; 32];
         mgr.set_authenticated_pubkey(conn_id, pubkey.clone());
@@ -722,7 +728,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let bp = Arc::new(AtomicU8::new(0));
         let subscriptions = Arc::new(Mutex::new(HashMap::new()));
-        mgr.register(conn_id, tx, cancel, bp, subscriptions);
+        mgr.register(conn_id, tx, cancel, bp, subscriptions, 3);
 
         assert_eq!(mgr.pubkey_for_conn(conn_id), None);
         let pubkey = vec![9u8; 32];


### PR DESCRIPTION
## Summary

Follows #1225 (configurable frame limit, now merged). Addresses the remaining relay disconnect causes that #1225 did not cover.

### Changes

- **Raise slow-client grace limit** — `SLOW_CLIENT_GRACE_LIMIT` from 3 to **15**, configurable via `BUZZ_SLOW_CLIENT_GRACE_LIMIT`. The previous value of 3 consecutive buffer-full `try_send` calls was too aggressive with Istio multi-hop buffering and increased fan-out from more subscribers per channel.
- **Add replay backpressure** — yield to the tokio runtime every 100 events during REQ historical replay so the `send_loop` can drain between batches, preventing buffer overflow mid-replay.
- **Lower historical replay limit** — `MAX_HISTORICAL_LIMIT` from 10,000 to **2,000**. Reconnecting clients rarely need 10k events of backfill. This reduces the worst-case replay burst that can overflow the send buffer.
- **Send NOTICE before oversized-frame disconnect** — on top of #1225's frame-limit fix, the client now receives `["NOTICE","error: frame too large (N bytes, limit M)"]` before the connection closes, giving a diagnostic instead of a silent disconnect.

### Infra follow-up

Separately, `BUZZ_SEND_BUFFER` should be raised from 1,000 to 8,000 in `block-coder-tf-stacks` staging `values.yaml` to further absorb replay and fan-out bursts.