### PR TITLE
refactor(desktop): drop dead goose-set avatar refs

### DIFF
--- a/desktop/src-tauri/src/commands/personas.rs
+++ b/desktop/src-tauri/src/commands/personas.rs
@@ -375,7 +375,7 @@ mod tests {
         let md = br#"---
 name: fizz
 display_name: Fizz
-avatar: app-avatar:pollies-12
+avatar: app-avatar:persona-12
 runtime: goose
 ---
 You are Fizz.
@@ -388,7 +388,7 @@ You are Fizz.
         assert_eq!(result.personas[0].display_name, "Fizz");
         assert_eq!(
             result.personas[0].avatar_ref.as_deref(),
-            Some("app-avatar:pollies-12")
+            Some("app-avatar:persona-12")
         );
         assert_eq!(result.personas[0].source_file, "fizz.md");
     }

--- a/desktop/src-tauri/src/managed_agents/persona_card_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_card_tests.rs
@@ -409,7 +409,7 @@ fn parse_md_persona_preserves_app_avatar_ref() {
 name: goosey
 display_name: Goosey
 description: Goose internal agent.
-avatar: app-avatar:gloopies-19
+avatar: app-avatar:persona-19
 model: anthropic:claude-sonnet-4
 runtime: goose
 ---
@@ -418,7 +418,7 @@ You are Goosey.
     let result = parse_md_persona(md).unwrap();
     assert_eq!(result.display_name, "Goosey");
     assert_eq!(result.avatar_data_url, None);
-    assert_eq!(result.avatar_ref.as_deref(), Some("app-avatar:gloopies-19"));
+    assert_eq!(result.avatar_ref.as_deref(), Some("app-avatar:persona-19"));
     assert_eq!(result.model.as_deref(), Some("claude-sonnet-4"));
     assert_eq!(result.provider.as_deref(), Some("anthropic"));
     assert_eq!(result.runtime.as_deref(), Some("goose"));
@@ -446,7 +446,7 @@ fn parse_md_persona_accepts_goose_internal_frontmatter() {
     let md = br#"---
 name: block.md
 description: Opinionated guide to Block's intelligence operating model.
-avatar: app-avatar:gloopies-19
+avatar: app-avatar:persona-19
 metadata:
   gooseInternalBundled: true
 ---
@@ -454,7 +454,7 @@ You are block.md.
 "#;
     let result = parse_md_persona(md).unwrap();
     assert_eq!(result.display_name, "block.md");
-    assert_eq!(result.avatar_ref.as_deref(), Some("app-avatar:gloopies-19"));
+    assert_eq!(result.avatar_ref.as_deref(), Some("app-avatar:persona-19"));
     assert_eq!(result.system_prompt, "You are block.md.\n");
 }
 
@@ -495,7 +495,7 @@ fn parse_zip_with_plain_md_persona_preserves_avatar_ref() {
 name: fizz
 display_name: Fizz
 description: Engineering agent.
-avatar: app-avatar:pollies-12
+avatar: app-avatar:persona-12
 runtime: goose
 model: anthropic:claude-sonnet-4
 ---
@@ -508,7 +508,7 @@ You are Fizz.
     assert_eq!(result.personas[0].display_name, "Fizz");
     assert_eq!(
         result.personas[0].avatar_ref.as_deref(),
-        Some("app-avatar:pollies-12")
+        Some("app-avatar:persona-12")
     );
     assert_eq!(result.personas[0].source_file, "fizz.md");
 }

--- a/desktop/src/shared/avatars/gooseAppAvatarRefs.test.mjs
+++ b/desktop/src/shared/avatars/gooseAppAvatarRefs.test.mjs
@@ -8,31 +8,22 @@ import {
 
 test("toGooseAppAvatarRef canonicalizes app-avatar refs", () => {
   assert.equal(
-    toGooseAppAvatarRef("app-avatar:gloopies-19"),
-    "app-avatar:gloopies-19",
+    toGooseAppAvatarRef("app-avatar:persona-19"),
+    "app-avatar:persona-19",
   );
 });
 
-test("toGooseAppAvatarRef ignores Goose-looking paths by default", () => {
-  assert.equal(toGooseAppAvatarRef("./avatars/pollies_2.png"), null);
-});
-
-test("toGooseAppAvatarRef detects Goose avatar ids in paths during import", () => {
-  assert.equal(
-    toGooseAppAvatarRef("./avatars/pollies_2.png", {
-      allowFilenameFallback: true,
-    }),
-    "app-avatar:pollies-2",
-  );
+test("toGooseAppAvatarRef ignores filesystem-looking paths", () => {
+  assert.equal(toGooseAppAvatarRef("./avatars/persona_2.png"), null);
 });
 
 test("resolveImportedPersonaAvatarUrl prefers app-avatar refs over data URLs", () => {
   assert.equal(
     resolveImportedPersonaAvatarUrl({
       avatarDataUrl: "https://example.com/avatar.png",
-      avatarRef: "app-avatar:fuzzies-1",
+      avatarRef: "app-avatar:persona-1",
     }),
-    "app-avatar:fuzzies-1",
+    "app-avatar:persona-1",
   );
 });
 
@@ -46,13 +37,13 @@ test("resolveImportedPersonaAvatarUrl preserves ordinary image URLs", () => {
   );
 });
 
-test("resolveImportedPersonaAvatarUrl does not rewrite Goose-looking remote URLs", () => {
+test("resolveImportedPersonaAvatarUrl does not rewrite remote image URLs", () => {
   assert.equal(
     resolveImportedPersonaAvatarUrl({
-      avatarDataUrl: "https://cdn.example.com/avatars/pollies_2.png",
+      avatarDataUrl: "https://cdn.example.com/avatars/persona_2.png",
       avatarRef: null,
     }),
-    "https://cdn.example.com/avatars/pollies_2.png",
+    "https://cdn.example.com/avatars/persona_2.png",
   );
 });
 
@@ -63,15 +54,5 @@ test("resolveImportedPersonaAvatarUrl preserves URL avatar refs", () => {
       avatarRef: " https://example.com/persona-avatar.png ",
     }),
     "https://example.com/persona-avatar.png",
-  );
-});
-
-test("resolveImportedPersonaAvatarUrl preserves Goose-looking URL avatar refs", () => {
-  assert.equal(
-    resolveImportedPersonaAvatarUrl({
-      avatarDataUrl: null,
-      avatarRef: " https://cdn.example.com/avatars/pollies_2.png ",
-    }),
-    "https://cdn.example.com/avatars/pollies_2.png",
   );
 });

--- a/desktop/src/shared/avatars/gooseAppAvatarRefs.ts
+++ b/desktop/src/shared/avatars/gooseAppAvatarRefs.ts
@@ -1,11 +1,6 @@
 export const GOOSE_APP_AVATAR_REF_PREFIX = "app-avatar:" as const;
 
 const APP_AVATAR_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
-const GOOSE_COLLECTION_ID_PATTERN = /^(fuzzies|gloopies|pollies)[-_](\d+)$/;
-
-type ParseGooseAppAvatarOptions = {
-  allowFilenameFallback?: boolean;
-};
 
 function cleanAvatarCandidate(value: string): string {
   const basename = value
@@ -19,7 +14,6 @@ function cleanAvatarCandidate(value: string): string {
 
 export function parseGooseAppAvatarId(
   value: string | null | undefined,
-  options: ParseGooseAppAvatarOptions = {},
 ): string | null {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -33,22 +27,13 @@ export function parseGooseAppAvatarId(
     return APP_AVATAR_ID_PATTERN.test(id) ? id : null;
   }
 
-  if (options.allowFilenameFallback) {
-    const candidate = cleanAvatarCandidate(trimmed);
-    const collectionMatch = GOOSE_COLLECTION_ID_PATTERN.exec(candidate);
-    if (collectionMatch) {
-      return `${collectionMatch[1]}-${collectionMatch[2]}`;
-    }
-  }
-
   return null;
 }
 
 export function toGooseAppAvatarRef(
   value: string | null | undefined,
-  options: ParseGooseAppAvatarOptions = {},
 ): string | null {
-  const id = parseGooseAppAvatarId(value, options);
+  const id = parseGooseAppAvatarId(value);
   return id ? `${GOOSE_APP_AVATAR_REF_PREFIX}${id}` : null;
 }
 
@@ -67,15 +52,8 @@ export function resolveImportedPersonaAvatarUrl({
   avatarDataUrl?: string | null;
   avatarRef?: string | null;
 }): string | null {
-  const trimmedAvatarRef = avatarRef?.trim();
-  const avatarRefFileFallback =
-    trimmedAvatarRef && !isPersistableAvatarUrl(trimmedAvatarRef)
-      ? toGooseAppAvatarRef(trimmedAvatarRef, { allowFilenameFallback: true })
-      : null;
   const gooseRef =
-    toGooseAppAvatarRef(avatarRef) ??
-    avatarRefFileFallback ??
-    toGooseAppAvatarRef(avatarDataUrl);
+    toGooseAppAvatarRef(avatarRef) ?? toGooseAppAvatarRef(avatarDataUrl);
   if (gooseRef) {
     return gooseRef;
   }


### PR DESCRIPTION
## Summary

Removes the dead **goose-set** avatar references from `gooseAppAvatarRefs`, stacked on top of #1202 (agent avatar plumbing).

The goose avatar sets (fuzzies / gloopies / pollies) were already pulled from the project as a separate effort around #1132, so #1202's support for them is dead intent. This strips the goose-set vocabulary and the now-orphaned code that only existed to serve it.

## What changed

- **`desktop/src/shared/avatars/gooseAppAvatarRefs.ts`** — removed `GOOSE_COLLECTION_ID_PATTERN`, the `allowFilenameFallback` option/type, the filename-fallback branch in `parseGooseAppAvatarId`, and the now-orphaned `avatarRefFileFallback` in `resolveImportedPersonaAvatarUrl`. Collapsing the pattern made the whole fallback path dead, so it's removed rather than left as a vestigial option.
- **`gooseAppAvatarRefs.test.mjs`** — trimmed the fallback-only test; swapped goose-set sample ids for neutral `persona-*` ones.
- **Rust test fixtures** (`commands/personas.rs`, `managed_agents/persona_card_tests.rs`) — swapped goose-set sample ids for neutral `persona-*` ids (used only as opaque ref strings).

**Untouched / confirmed independent:** the `app-avatar:` prefix parsing, `isGooseAppAvatarRef` (used by `profile/hooks.ts`), and the runtime-avatar whitelist. `resolveImportedPersonaAvatarUrl` still serves `personaDialogState.ts`.

Net: 4 files, +19/−60.

## Stacking

- **Base:** `kennylopez-agent-avatar-plumbing` (#1202's branch) — **not** `main`.
- Single commit on top of #1202's head `67eb982b`.

## Verification

- `gooseAppAvatarRefs` JS tests 6/6, `pnpm typecheck`, `pnpm lint` all clean.
- Pre-push hooks ran full suites: `desktop-test`, `rust-tests`, `desktop-tauri-test` all passed (validates the Rust fixture edits).
