### PR TITLE
chore(desktop): bump AppShell.tsx file-size override to match main

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -67,9 +67,10 @@ const overrides = new Map([
   // Approved override; still queued to split with the rest of this list.
   ["src/features/messages/ui/MessageThreadPanel.tsx", 1006],
   // useDueReminderBadgeCount hook call + sum to wire due-reminder count into
-  // the Inbox nav badge — a small overage from load-bearing badge plumbing,
-  // not generic debt growth. Approved override; still queued to split.
-  ["src/app/AppShell.tsx", 1007],
+  // the Inbox nav badge, plus a one-line drift to match the file's current
+  // length — a small overage from load-bearing badge plumbing, not generic
+  // debt growth. Approved override; still queued to split.
+  ["src/app/AppShell.tsx", 1008],
 ]);
 
 await runFileSizeCheck({


### PR DESCRIPTION
`src/app/AppShell.tsx` is 1008 lines but its `check-file-sizes.mjs` override sits at 1007, so the desktop file-size gate (`pnpm check:file-sizes` in the Desktop Core job) fails on main's own tip. This is pre-existing drift — the override fell one line behind the file.

This bumps the override to 1008 to match reality. The `AppShell.tsx` source is unchanged; only the override entry moves. Queued to split with the rest of the list, same as the other entries.

Related: [block/buzz#1172](https://github.com/block/buzz/pull/1172) rebases on top of main once this lands and inherits the corrected override cleanly.