### PR TITLE
fix(agent): raise combined system prompt cap to 1 MiB

### DIFF
--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -3,7 +3,10 @@ use std::time::Duration;
 pub const PROTOCOL_VERSION: u32 = 2;
 
 pub const MAX_PROMPT_BYTES: usize = 1024 * 1024;
-pub const MAX_SYSTEM_PROMPT_BYTES: usize = 512 * 1024;
+/// Ceiling on the combined system prompt (harness prompt + persona + hints).
+/// Raised from 512 KiB to 1 MiB to fit large discovered skill/AGENTS.md hint
+/// sections; matches `MAX_PROMPT_BYTES`.
+pub const MAX_SYSTEM_PROMPT_BYTES: usize = 1024 * 1024;
 /// Total per-result byte ceiling (text + images). Sized for image-bearing
 /// results — view_image can legitimately return multi-MiB base64 payloads.
 /// Text is governed by the much smaller `BUZZ_AGENT_MAX_TOOL_RESULT_TEXT_BYTES`.

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -285,7 +285,7 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
         } else {
             format!("{base}\n\n{hints}")
         };
-        // Reject combined prompts exceeding 512KB.
+        // Reject combined prompts exceeding MAX_SYSTEM_PROMPT_BYTES.
         if prompt.len() > MAX_SYSTEM_PROMPT_BYTES {
             return reject(
                 wire_tx,

--- a/crates/buzz-agent/tests/fake_llm.rs
+++ b/crates/buzz-agent/tests/fake_llm.rs
@@ -423,7 +423,7 @@ async fn rejects_oversized_line() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn session_new_rejects_oversized_system_prompt() {
-    // A systemPrompt exceeding 512KB must produce a JSON-RPC error, not a panic.
+    // A systemPrompt exceeding 1 MiB must produce a JSON-RPC error, not a panic.
     let url = spawn_fake_llm(vec![]).await;
     let mut h = Harness::spawn(&url).await;
     h.send(
@@ -434,8 +434,8 @@ async fn session_new_rejects_oversized_system_prompt() {
     let r = h.recv().await;
     assert_eq!(r["result"]["protocolVersion"], 2);
 
-    // 600KB payload — exceeds the 512KB limit.
-    let big_prompt = "x".repeat(600 * 1024);
+    // 1100KB payload — exceeds the 1 MiB limit.
+    let big_prompt = "x".repeat(1100 * 1024);
     let id = h
         .send(
             "session/new",
@@ -449,8 +449,8 @@ async fn session_new_rejects_oversized_system_prompt() {
     );
     let err_msg = r["error"]["message"].as_str().unwrap_or("");
     assert!(
-        err_msg.contains("512KB limit"),
-        "error message should mention 512KB limit, got: {err_msg}"
+        err_msg.contains("1024KB limit"),
+        "error message should mention 1024KB limit, got: {err_msg}"
     );
     h.shutdown().await;
 }


### PR DESCRIPTION
## Problem

`buzz-agent`'s `session/new` handler rejects any combined system prompt (harness prompt + persona + discovered `AGENTS.md`/skill hints) larger than `MAX_SYSTEM_PROMPT_BYTES` (512 KiB). The hints builder in `crates/buzz-agent/src/hints.rs` inlines the **full body** of every `SKILL.md` it discovers under `~/.agents/skills` (plus `.goose/skills`, `.claude/skills`, and `AGENTS.md` layers).

On a machine with a large personal skill library this overflows the cap. A user with ~76 skills (~517 KiB of `SKILL.md` bodies) hits:

```
session/new: combined system prompt exceeds 512KB limit (533647 bytes)
```

and the agent (e.g. Fizz on the Block staging relay) can't start a session at all.

## Change

Raise `MAX_SYSTEM_PROMPT_BYTES` from 512 KiB to **1 MiB**, matching the sibling `MAX_PROMPT_BYTES` constant in the same file.

This cap guards the `buzz-acp` ↔ `buzz-agent` stdio (ACP) boundary; it is **not** the relay frame size (`BUZZ_MAX_FRAME_BYTES` / `DEFAULT_MAX_FRAME_BYTES`), so wire limits are unaffected.

## Tests

Updated `session_new_rejects_oversized_system_prompt` in `crates/buzz-agent/tests/fake_llm.rs` to use a 1100 KiB payload and assert the new `1024KB limit` message. `cargo test -p buzz-agent` passes (21 unit + integration tests).

## Notes

- This raises the guardrail; it does not address the underlying behavior that the full skill bodies are inlined into every `session/new`. A follow-up could summarize/elide skill bodies or make the cap env-tunable (like `BUZZ_AGENT_MAX_TOOL_RESULT_TEXT_BYTES`), but that's out of scope here.