### PR TITLE
fix(desktop): restore solid dot for top-level channel unreads

### DIFF
--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -70,6 +70,23 @@ function UnreadCountBadge({
   );
 }
 
+function UnreadDotBadge({
+  channelName,
+  className,
+}: {
+  channelName: string;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn("h-2 w-2 shrink-0 rounded-full bg-primary", className)}
+      data-testid={`channel-unread-dot-${channelName}`}
+    >
+      <span className="sr-only">unread</span>
+    </span>
+  );
+}
+
 export type SidebarDmParticipant = {
   avatarUrl: string | null;
   label: string;
@@ -233,15 +250,16 @@ export function ChannelMenuButton({
           )}
         />
       ) : null}
-      {hasUnread &&
-      unreadCount > 0 &&
-      !isActive &&
-      channel.channelType !== "dm" ? (
-        <UnreadCountBadge
-          channelName={channel.name}
-          className="ml-auto"
-          count={Math.max(unreadCount, 1)}
-        />
+      {hasUnread && !isActive && channel.channelType !== "dm" ? (
+        unreadCount > 0 ? (
+          <UnreadCountBadge
+            channelName={channel.name}
+            className="ml-auto"
+            count={unreadCount}
+          />
+        ) : (
+          <UnreadDotBadge channelName={channel.name} className="ml-auto" />
+        )
       ) : null}
     </SidebarMenuButton>
   );

--- a/desktop/tests/e2e/badge.spec.ts
+++ b/desktop/tests/e2e/badge.spec.ts
@@ -105,6 +105,7 @@ test("regular message bolds inactive channel without numeric badge", async ({
     "600",
   );
   await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
+  await expect(page.getByTestId("channel-unread-dot-random")).toBeVisible();
   await waitForBadgeState(page, withDotOnlyBadge(baselineBadge));
 });
 
@@ -134,6 +135,7 @@ test("numeric badge increments for @mention in inactive channel", async ({
   );
 
   await expect(page.getByTestId("channel-unread-random")).toBeVisible();
+  await expect(page.getByTestId("channel-unread-dot-random")).toHaveCount(0);
   await waitForBadgeState(page, withAdditionalBadgeCount(baselineBadge, 1));
 });
 


### PR DESCRIPTION
The non-DM sidebar badge gate from #1218 (`hasUnread && unreadCount > 0`) erased the unread indicator for channels whose only unread is a plain top-level message. Those messages are deliberately count-0 in `unreadChannelCounts` — only DMs, thread replies, and high-priority (mention/broadcast) events count toward the numeric badge (`countUnreadBadgeObservedEvents`, `unreadChannelCounts.ts:26`). So a top-level-only unread channel showed nothing but a bold name, which is easy to miss.

This restores the two-tier indicator that already exists for the system dock icon:

- **Top-level channel message** → small solid (non-numeric) dot, `bg-primary rounded-full`.
- **DM / @mention / thread reply** → numeric `UnreadCountBadge` (unchanged).

The dot carries a stable `data-testid` (`channel-unread-dot-<name>`) so E2E can assert it. The `font-semibold` bold-name treatment is unchanged and stacks with the dot. DM badges render through their own path and are untouched. The data model (`unreadChannelCounts`) is correct and is not modified.

## Tests

`badge.spec.ts` asserts the solid dot is visible for a top-level-only unread non-DM channel, and that the dot is absent (numeric badge only) for an @mention.
