### PR TITLE
fix(desktop): prune real-channel observed refs on thread/message read

### DIFF
--- a/desktop/src/features/channels/unreadChannelCounts.ts
+++ b/desktop/src/features/channels/unreadChannelCounts.ts
@@ -65,6 +65,32 @@ export function recordObservedUnreadEvent(
   return true;
 }
 
+// Drop observed refs for channels whose unread events the read markers now
+// fully cover. `markThreadRead`/`markMessageRead` advance a `thread:<root>`/
+// `msg:<id>` marker, but `markChannelRead`'s clearObserved prune keys these maps
+// by that synthetic key — never the real channel — so the real channel's refs
+// linger after a thread/message read covers its last badge event. A channel
+// absent from `unreadChannelIds` (and not forced or active) has no unread
+// observed events left, so its refs are dead weight. Pruning them is invisible
+// to the count (a covered channel and an absent one both contribute 0).
+export function pruneCoveredObservedRefs(
+  latestByChannel: Map<string, number>,
+  observedByChannel: Map<string, Map<string, ObservedUnreadEvent>>,
+  channelIds: Iterable<string>,
+  unreadChannelIds: ReadonlySet<string>,
+  forcedChannelIds: ReadonlySet<string>,
+  activeChannelId: string | null,
+): void {
+  for (const channelId of channelIds) {
+    if (channelId === activeChannelId) continue;
+    if (unreadChannelIds.has(channelId)) continue;
+    if (forcedChannelIds.has(channelId)) continue;
+    if (latestByChannel.get(channelId) === undefined) continue;
+    latestByChannel.delete(channelId);
+    observedByChannel.delete(channelId);
+  }
+}
+
 export function countUnreadObservedEvents(
   eventsById: ReadonlyMap<string, ObservedUnreadEvent> | undefined,
   getReadAt: (event: ObservedUnreadEvent) => number | null,

--- a/desktop/src/features/channels/unreadReadMarker.test.mjs
+++ b/desktop/src/features/channels/unreadReadMarker.test.mjs
@@ -8,6 +8,7 @@ import {
   countUnreadHighPriorityObservedEvents,
   countUnreadObservedEvents,
   observedUnreadEventReadAt,
+  pruneCoveredObservedRefs,
   recordObservedUnreadEvent,
 } from "./unreadChannelCounts.ts";
 import {
@@ -386,6 +387,114 @@ test("highPriorityObservedEvents_countOnlyUnreadHighPriorityItems", () => {
 
   assert.equal(countUnreadObservedEvents(events, getReadAt), 2);
   assert.equal(countUnreadHighPriorityObservedEvents(events, getReadAt), 1);
+});
+
+// --- Clearing asymmetry: prune covered observed refs ---
+
+// The headline regression. A channel was read top-level-only (channel-open) and
+// later a thread reply arrived; reading THAT thread advances thread:<root> so
+// the badge counts 0, but markChannelRead("thread:<root>") can't prune the real
+// channel's refs (wrong key). pruneCoveredObservedRefs drops the dead refs once
+// the memo no longer reports the channel unread, and the badge must STAY 0 even
+// if a catch-up REQ re-records the same already-covered event.
+test("pruneCoveredObservedRefs_threadReadCovers_prunesRefsAndBadgeStaysZero", () => {
+  const channelId = "chan";
+  const rootId = "root-1";
+  const reply = observed("reply", 500, rootId);
+  const latestByChannel = new Map([[channelId, 500]]);
+  const observedByChannel = new Map();
+  recordObservedUnreadEvent(observedByChannel, channelId, reply, 20);
+
+  // Before reading the thread: channel marker 300 < reply 500, badge counts 1.
+  const beforeRead = readAtFor(300, new Map());
+  assert.equal(
+    countUnreadBadgeObservedEvents(
+      observedByChannel.get(channelId),
+      beforeRead,
+    ),
+    1,
+  );
+
+  // Reading the thread advances thread:root-1=500. The badge now counts 0, so
+  // the memo drops the channel from unreadChannelIds — the prune signal.
+  const afterRead = readAtFor(300, new Map([[rootId, 500]]));
+  assert.equal(
+    countUnreadBadgeObservedEvents(observedByChannel.get(channelId), afterRead),
+    0,
+  );
+
+  pruneCoveredObservedRefs(
+    latestByChannel,
+    observedByChannel,
+    [channelId],
+    new Set(),
+    new Set(),
+    null,
+  );
+
+  assert.equal(latestByChannel.has(channelId), false);
+  assert.equal(observedByChannel.has(channelId), false);
+
+  // A catch-up REQ re-records the same covered event. The badge must stay 0.
+  recordObservedUnreadEvent(observedByChannel, channelId, reply, 20);
+  assert.equal(
+    countUnreadBadgeObservedEvents(observedByChannel.get(channelId), afterRead),
+    0,
+  );
+});
+
+test("pruneCoveredObservedRefs_channelStillUnread_keepsRefs", () => {
+  const channelId = "chan";
+  const latestByChannel = new Map([[channelId, 500]]);
+  const observedByChannel = new Map([[channelId, new Map()]]);
+
+  pruneCoveredObservedRefs(
+    latestByChannel,
+    observedByChannel,
+    [channelId],
+    new Set([channelId]),
+    new Set(),
+    null,
+  );
+
+  assert.equal(latestByChannel.has(channelId), true);
+  assert.equal(observedByChannel.has(channelId), true);
+});
+
+test("pruneCoveredObservedRefs_activeChannel_keepsRefs", () => {
+  const channelId = "chan";
+  const latestByChannel = new Map([[channelId, 500]]);
+  const observedByChannel = new Map([[channelId, new Map()]]);
+
+  pruneCoveredObservedRefs(
+    latestByChannel,
+    observedByChannel,
+    [channelId],
+    new Set(),
+    new Set(),
+    channelId,
+  );
+
+  assert.equal(latestByChannel.has(channelId), true);
+  assert.equal(observedByChannel.has(channelId), true);
+});
+
+test("pruneCoveredObservedRefs_forcedUnread_keepsRefs", () => {
+  const channelId = "chan";
+  const latestByChannel = new Map([[channelId, 500]]);
+  const observedByChannel = new Map([[channelId, new Map()]]);
+
+  pruneCoveredObservedRefs(
+    latestByChannel,
+    observedByChannel,
+    [channelId],
+    new Set(),
+    new Set([channelId]),
+    null,
+  );
+
+  assert.equal(latestByChannel.has(channelId), true);
+  assert.equal(observedByChannel.has(channelId), true);
 });
 
 test("addThreadActivityItems keeps newest items when input is newest-first", () => {

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -12,6 +12,7 @@ import {
   makeObservedUnreadEvent,
   mapsEqual,
   observedUnreadEventReadAt,
+  pruneCoveredObservedRefs,
   recordObservedUnreadEvent,
   type ObservedUnreadEvent,
 } from "@/features/channels/unreadChannelCounts";
@@ -917,6 +918,21 @@ export function useUnreadChannels(
 
   const unreadChannelIdsRef = React.useRef(unreadChannelIds);
   unreadChannelIdsRef.current = unreadChannelIds;
+
+  // Drop observed refs the read markers now fully cover (the thread/message
+  // read clearing asymmetry — see pruneCoveredObservedRefs). Driven off the
+  // memo's own output; no version bump and no loop because pruning is invisible
+  // to the count.
+  React.useEffect(() => {
+    pruneCoveredObservedRefs(
+      latestByChannelRef.current,
+      observedUnreadEventsByChannelRef.current,
+      channels.map((channel) => channel.id),
+      unreadChannelIds,
+      forcedUnreadRef.current,
+      activeChannelId,
+    );
+  }, [unreadChannelIds, channels, activeChannelId]);
 
   const markAllChannelsRead = React.useCallback(() => {
     for (const channelId of unreadChannelIdsRef.current) {


### PR DESCRIPTION
## What this is

A latent-liability cleanup in the channel unread bookkeeping. **It is not the phantom-badge fix** — the phantom Will reported is working-as-designed (NIP-RS Option 1: a new reply to an unopened thread correctly lights the numeric badge), and whether passive channel-open should also clear thread-tier badges is a separate UX decision currently with Will. This PR changes none of that behavior.

## The asymmetry

`markThreadRead`/`markMessageRead` (`AppShell.tsx`) route through `markChannelRead` with a synthetic `thread:<root>`/`msg:<id>` key. Inside `markChannelRead`, the `clearObserved` prune looks up `latestByChannelRef` under that key — which is keyed by *real channel id*, so the lookup is always `undefined`, `clearObserved` resolves to `false`, and the prune never runs. Even if it did, it would delete the entry under the synthetic key, not the real channel's.

Net: after a thread/message read covers a channel's last badge event, the real channel's `latestByChannelRef` and `observedUnreadEventsByChannelRef` entries are never dropped. The badge count stays correct (the unread memo re-evaluates each observed event against the current markers), but the channel remains permanently eligible for recount with dead refs — a latent liability, not a visible bug.

## The fix

A lazy prune effect in `useUnreadChannels`, driven off the unread memo's own output. A channel that is absent from `unreadChannelIds`, not forced-unread, and not active has no unread observed events left, so its observed refs are dead weight and get dropped. Pruning is invisible to the count (a covered channel and an absent one both contribute 0), so there is no `readStateVersion` bump and no re-render loop. The decision logic lives in a pure `pruneCoveredObservedRefs` in `unreadChannelCounts.ts` (the existing home for observed-ref mutation), making it unit-testable alongside the other observed-event helpers.

Regression coverage: a thread read that covers a channel's last badge event prunes both refs, and the badge stays `0` even when a catch-up REQ re-records the same already-covered event; plus the three retention paths (channel still unread, active channel, forced-unread) that must keep their refs.

## Note for reviewers

`useUnreadChannels.ts` sits close to the repo's 1000-line file-size ceiling; the prune *decision* is therefore extracted to `unreadChannelCounts.ts` rather than inlined, which keeps the hook file under the limit and the logic testable as a pure function.

Related: #1253 (the Phase 1 dot-tier restore, already merged) — this is the Phase 2 cleanup track from the same investigation.
