### PR TITLE
fix(sidebar): non-selectable channel names + copy/leave context menu actions

### DIFF
--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -28,6 +28,7 @@ import {
   CreateSectionDialog,
   DeleteSectionAlertDialog,
   RenameSectionDialog,
+  useLeaveChannelDialog,
 } from "@/features/sidebar/ui/ChannelSectionDialogs";
 import { MoreUnreadButton } from "@/features/sidebar/ui/MoreUnreadButton";
 import { SidebarSection } from "@/features/sidebar/ui/SidebarSection";
@@ -380,6 +381,8 @@ export function AppSidebar({
     React.useState<ChannelSection | null>(null);
   const [deleteSectionTarget, setDeleteSectionTarget] =
     React.useState<ChannelSection | null>(null);
+  const { requestLeaveChannel, dialog: leaveChannelDialog } =
+    useLeaveChannelDialog();
 
   const sectionIds = React.useMemo(
     () => channelSections.map((s) => s.id),
@@ -674,6 +677,7 @@ export function AppSidebar({
                   starredChannelIds={starredChannelIds}
                   onStarChannel={onStarChannel}
                   onUnstarChannel={onUnstarChannel}
+                  onLeaveChannel={requestLeaveChannel}
                 />
               ) : null}
               <SidebarDndContext
@@ -727,6 +731,7 @@ export function AppSidebar({
                     starredChannelIds={starredChannelIds}
                     onStarChannel={onStarChannel}
                     onUnstarChannel={onUnstarChannel}
+                    onLeaveChannel={requestLeaveChannel}
                   />
                 ))}
                 <ChannelGroupSection
@@ -760,6 +765,7 @@ export function AppSidebar({
                   starredChannelIds={starredChannelIds}
                   onStarChannel={onStarChannel}
                   onUnstarChannel={onUnstarChannel}
+                  onLeaveChannel={requestLeaveChannel}
                 />
               </SidebarDndContext>
               <FeatureGate feature="forum">
@@ -973,6 +979,7 @@ export function AppSidebar({
           setDeleteSectionTarget(null);
         }}
       />
+      {leaveChannelDialog}
       <SidebarRail />
     </Sidebar>
   );

--- a/desktop/src/features/sidebar/ui/ChannelSectionDialogs.tsx
+++ b/desktop/src/features/sidebar/ui/ChannelSectionDialogs.tsx
@@ -20,6 +20,8 @@ import {
   DialogTitle,
 } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
+import type { Channel } from "@/shared/api/types";
+import { useLeaveChannelMutation } from "@/features/channels/hooks";
 
 type SectionNameDialogProps = {
   open: boolean;
@@ -191,4 +193,71 @@ export function DeleteSectionAlertDialog({
       </AlertDialogContent>
     </AlertDialog>
   );
+}
+
+// ---------------------------------------------------------------------------
+// LeaveChannelAlertDialog
+// ---------------------------------------------------------------------------
+
+export type LeaveChannelAlertDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  channelName: string;
+  onConfirm: () => void;
+};
+
+export function LeaveChannelAlertDialog({
+  open,
+  onOpenChange,
+  channelName,
+  onConfirm,
+}: LeaveChannelAlertDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Leave channel</AlertDialogTitle>
+          <AlertDialogDescription>
+            {`Leave "${channelName}"? You'll stop receiving its messages and can rejoin later.`}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={onConfirm}
+          >
+            Leave
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// useLeaveChannelDialog — owns leave-channel state, mutation, and dialog
+// ---------------------------------------------------------------------------
+
+export function useLeaveChannelDialog() {
+  const [target, setTarget] = React.useState<Channel | null>(null);
+  const leaveChannel = useLeaveChannelMutation(target?.id ?? null);
+
+  const dialog = (
+    <LeaveChannelAlertDialog
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open) setTarget(null);
+      }}
+      channelName={target?.name ?? ""}
+      onConfirm={() => {
+        if (target) {
+          leaveChannel.mutate();
+        }
+        setTarget(null);
+      }}
+    />
+  );
+
+  return { requestLeaveChannel: setTarget, dialog };
 }

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -8,13 +8,18 @@ import {
   CheckCircle2,
   ChevronDown,
   CircleDot,
+  Clipboard,
+  Copy,
   GripVertical,
+  LogOut,
   Pencil,
   Plus,
   Star,
   StarOff,
   Trash2,
 } from "lucide-react";
+
+import { toast } from "sonner";
 
 import {
   ContextMenu,
@@ -105,6 +110,17 @@ function MoveToSectionSubmenu({
   );
 }
 
+function copyToClipboard(text: string, successMessage: string) {
+  void navigator.clipboard
+    .writeText(text)
+    .then(() => {
+      toast.success(successMessage);
+    })
+    .catch(() => {
+      toast.error("Failed to copy to clipboard");
+    });
+}
+
 export function ChannelContextMenuItems({
   channel,
   hasUnread,
@@ -121,6 +137,7 @@ export function ChannelContextMenuItems({
   onAssignChannel,
   onUnassignChannel,
   onCreateSectionForChannel,
+  onLeaveChannel,
 }: {
   channel: Channel;
   hasUnread: boolean;
@@ -140,6 +157,7 @@ export function ChannelContextMenuItems({
   onAssignChannel?: (channelId: string, sectionId: string) => void;
   onUnassignChannel?: (channelId: string) => void;
   onCreateSectionForChannel?: (channelId: string) => void;
+  onLeaveChannel?: (channel: Channel) => void;
 }) {
   const showStar = Boolean(onStarChannel && onUnstarChannel);
   const showReadToggle = hasUnread
@@ -205,6 +223,35 @@ export function ChannelContextMenuItems({
             onUnassignChannel={onUnassignChannel}
             onCreateSectionForChannel={onCreateSectionForChannel}
           />
+        </>
+      ) : null}
+      <ContextMenuSeparator />
+      <ContextMenuItem
+        onClick={() =>
+          copyToClipboard(channel.name, "Channel name copied to clipboard")
+        }
+      >
+        <Copy className="h-4 w-4" />
+        Copy channel name
+      </ContextMenuItem>
+      <ContextMenuItem
+        onClick={() =>
+          copyToClipboard(channel.id, "Channel ID copied to clipboard")
+        }
+      >
+        <Clipboard className="h-4 w-4" />
+        Copy channel ID
+      </ContextMenuItem>
+      {onLeaveChannel ? (
+        <>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => onLeaveChannel(channel)}
+          >
+            <LogOut className="h-4 w-4" />
+            Leave channel
+          </ContextMenuItem>
         </>
       ) : null}
     </>
@@ -305,6 +352,7 @@ export function ChannelGroupSection({
   starredChannelIds,
   onStarChannel,
   onUnstarChannel,
+  onLeaveChannel,
 }: {
   browseAriaLabel?: string;
   createAriaLabel: string;
@@ -340,6 +388,7 @@ export function ChannelGroupSection({
   starredChannelIds?: ReadonlySet<string>;
   onStarChannel?: (channelId: string) => void;
   onUnstarChannel?: (channelId: string) => void;
+  onLeaveChannel?: (channel: Channel) => void;
 }) {
   const contentId = `sidebar-${listTestId}`;
 
@@ -394,6 +443,7 @@ export function ChannelGroupSection({
                 onAssignChannel={onAssignChannel}
                 onUnassignChannel={onUnassignChannel}
                 onCreateSectionForChannel={onCreateSectionForChannel}
+                onLeaveChannel={onLeaveChannel}
               />
             </ContextMenuContent>
           </ContextMenu>
@@ -476,6 +526,7 @@ export function CustomChannelSection({
   starredChannelIds,
   onStarChannel,
   onUnstarChannel,
+  onLeaveChannel,
 }: {
   section: ChannelSection;
   channels: Channel[];
@@ -510,6 +561,7 @@ export function CustomChannelSection({
   starredChannelIds?: ReadonlySet<string>;
   onStarChannel?: (channelId: string) => void;
   onUnstarChannel?: (channelId: string) => void;
+  onLeaveChannel?: (channel: Channel) => void;
 }) {
   const contentId = `sidebar-section-${section.id}`;
 
@@ -660,6 +712,7 @@ export function CustomChannelSection({
                             onCreateSectionForChannel={
                               onCreateSectionForChannel
                             }
+                            onLeaveChannel={onLeaveChannel}
                           />
                         </ContextMenuContent>
                       </ContextMenu>

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -452,7 +452,9 @@ export function ChannelGroupSection({
     ) : null;
 
   const sectionContent = (
-    <SidebarGroup className={cn("group/sidebar-section", groupClassName)}>
+    <SidebarGroup
+      className={cn("group/sidebar-section select-none", groupClassName)}
+    >
       <div className="relative">
         <SidebarGroupLabel asChild>
           <button
@@ -570,7 +572,10 @@ export function CustomChannelSection({
       {({ dragHandleProps, isDragging }) => (
         <DroppableSectionBody sectionId={section.id}>
           <SidebarGroup
-            className={cn("group/sidebar-section", isDragging && "opacity-30")}
+            className={cn(
+              "group/sidebar-section select-none",
+              isDragging && "opacity-30",
+            )}
           >
             <ContextMenu>
               <ContextMenuTrigger asChild>

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -234,7 +234,9 @@ export function ChannelMenuButton({
         dmParticipants={dmParticipants}
         presenceStatus={presenceStatus}
       />
-      <span className="min-w-0 flex-1 truncate">{resolvedLabel}</span>
+      <span className="min-w-0 flex-1 select-none truncate">
+        {resolvedLabel}
+      </span>
       {ephemeralDisplay ? (
         <EphemeralChannelBadge
           display={ephemeralDisplay}
@@ -410,12 +412,9 @@ export function SidebarSection({
                   </SidebarMenuItem>
                 );
 
-                const hasContextAction =
-                  (unreadChannelIds.has(channel.id) && onMarkChannelRead) ||
-                  (!unreadChannelIds.has(channel.id) && onMarkChannelUnread) ||
-                  (onMuteChannel && onUnmuteChannel);
-
-                return hasContextAction ? (
+                // The shared menu always renders copy actions, so every row
+                // gets a context menu regardless of read/mute availability.
+                return (
                   <ContextMenu key={channel.id}>
                     <ContextMenuTrigger asChild>{menuItem}</ContextMenuTrigger>
                     <ContextMenuContent>
@@ -430,8 +429,6 @@ export function SidebarSection({
                       />
                     </ContextMenuContent>
                   </ContextMenu>
-                ) : (
-                  menuItem
                 );
               })}
             </SidebarMenu>

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -234,9 +234,7 @@ export function ChannelMenuButton({
         dmParticipants={dmParticipants}
         presenceStatus={presenceStatus}
       />
-      <span className="min-w-0 flex-1 select-none truncate">
-        {resolvedLabel}
-      </span>
+      <span className="min-w-0 flex-1 truncate">{resolvedLabel}</span>
       {ephemeralDisplay ? (
         <EphemeralChannelBadge
           display={ephemeralDisplay}
@@ -325,7 +323,7 @@ export function SidebarSection({
   const canToggle = Boolean(onToggleCollapsed);
 
   return (
-    <SidebarGroup className="group/sidebar-section">
+    <SidebarGroup className="group/sidebar-section select-none">
       <div className="relative">
         <SidebarGroupLabel asChild={canToggle}>
           {canToggle ? (


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Sidebar channel names no longer highlight when you drag across them, and right-clicking a channel now offers Copy channel name, Copy channel ID, and Leave channel (with a confirmation step).

**Problem:** Channel names in the sidebar were text-selectable, so dragging the cursor across them highlighted the text — a small but persistent annoyance. There was also no quick path to copy a channel name or ID, or to leave a channel, from the sidebar.

**Solution:** Added `select-none` to the channel-name span to stop the highlight-on-drag. Extended the shared channel context menu with three new actions — Copy channel name, Copy channel ID, and a destructive Leave channel that confirms via the standard shadcn `AlertDialog` before acting. Copy actions render unconditionally; Leave is gated on an `onLeaveChannel` prop and wired only to stream sections (DMs get copy-only, forums get neither). Leave state/mutation/dialog were extracted into a `useLeaveChannelDialog()` hook to keep `AppSidebar` under the 1000-line file-size limit.

<details>
<summary>File changes</summary>

**desktop/src/features/sidebar/ui/SidebarSection.tsx**
Added `select-none` to the channel-name truncate span so dragging no longer selects the text.

**desktop/src/features/sidebar/ui/CustomChannelSection.tsx**
Added Copy channel name, Copy channel ID, and Leave channel items to the shared `ChannelContextMenuItems`. Copy actions are always present; Leave is gated on `onLeaveChannel`.

**desktop/src/features/sidebar/ui/ChannelSectionDialogs.tsx**
New `useLeaveChannelDialog()` hook owning the leave target state, `useLeaveChannelMutation`, and the shadcn confirm dialog. Returns `{ requestLeaveChannel, dialog }`.

**desktop/src/features/sidebar/ui/AppSidebar.tsx**
Wired the leave dialog hook in and passed `onLeaveChannel` to stream sections. Stays under the file-size cap (994 lines).

</details>

## Reproduction Steps

1. Run the desktop app.
2. In the sidebar, drag your cursor across a channel name — the text should no longer highlight.
3. Right-click a stream channel — you should see Copy channel name, Copy channel ID, and Leave channel.
4. Click Leave channel — a shadcn confirmation dialog with destructive styling appears before anything happens.
5. Right-click a DM (copy actions only, no Leave) and a forum entry (neither) to confirm gating.

## Screenshots/Demos

https://github.com/user-attachments/assets/20165f20-5d76-4392-9d46-382f08b5d8aa

Context menu with the three new actions:
<img width="480" height="720" alt="9f59317a06285f6ffc909589f5ff85e3a6c54172fc50a09a1a96114101d88306" src="https://github.com/user-attachments/assets/e33ee883-e83f-43e2-a80e-39eb48d30ef3" />

Leave-channel shadcn AlertDialog confirm (destructive styling):
<img width="1280" height="720" alt="462d24325f080f3c6d0bc3ff1efbcf0933d6a59e110743bc168ad9584449ee6b" src="https://github.com/user-attachments/assets/41cdc927-7e60-4c16-ad6e-08fe05051895" />
