### PR TITLE
fix(desktop): switch macOS keychain to Data Protection Keychain

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ ctrlc = { version = "3", features = ["termination"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSHapticFeedback"] }
 keyring = { version = "3.6.3", default-features = false, features = ["apple-native", "vendored"], optional = true }
+security-framework = { version = "3.7.0", features = ["OSX_10_15"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_Foundation"] }

--- a/desktop/src-tauri/src/secret_store.rs
+++ b/desktop/src-tauri/src/secret_store.rs
@@ -63,10 +63,47 @@ fn keyring_entry(service: &str, key: &str) -> Result<keyring::Entry, keyring::Er
     keyring::Entry::new(service, key)
 }
 
+// macOS-specific imports for the Data Protection Keychain backend.
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
+use security_framework::base::Error as SFError;
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
+use security_framework::passwords::{
+    delete_generic_password_options, generic_password, set_generic_password_options,
+    PasswordOptions,
+};
+
+/// Returns true when the security-framework error is "item not found" (-25300).
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
+fn is_not_found(e: &SFError) -> bool {
+    e.code() == -25300
+}
+
+/// Build a `PasswordOptions` for the Data Protection Keychain.
+#[cfg(all(feature = "system-keyring", target_os = "macos"))]
+fn dpk_opts(service: &str, key: &str) -> PasswordOptions {
+    let mut opts = PasswordOptions::new_generic_password(service, key);
+    opts.use_protected_keychain();
+    opts
+}
+
 impl SecretStore {
     /// Probe whether `key` exists and whether the backend is reachable.
     pub fn probe(&self, key: &str) -> KeyringProbe {
-        #[cfg(feature = "system-keyring")]
+        // macOS: probe the Data Protection Keychain only. Items still in the
+        // old keychain will be migrated on the first `load` call.
+        #[cfg(all(feature = "system-keyring", target_os = "macos"))]
+        {
+            match generic_password(dpk_opts(&self.service, key)) {
+                Ok(_) => KeyringProbe::Present,
+                Err(ref e) if is_not_found(e) => KeyringProbe::ReachableButEmpty,
+                Err(ref e) if is_keyring_availability_error(&e.to_string()) => {
+                    KeyringProbe::Unreachable
+                }
+                Err(_) => KeyringProbe::ReachableButEmpty,
+            }
+        }
+        // Non-macOS system-keyring path (Windows, Linux).
+        #[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
         {
             match keyring_entry(&self.service, key) {
                 Ok(entry) => match entry.get_password() {
@@ -75,8 +112,6 @@ impl SecretStore {
                     Err(e) if is_keyring_availability_error(&e.to_string()) => {
                         KeyringProbe::Unreachable
                     }
-                    // A non-availability per-entry error (e.g. bad attributes)
-                    // means the backend is reachable but the entry is unusable.
                     Err(_) => KeyringProbe::ReachableButEmpty,
                 },
                 Err(e) if is_keyring_availability_error(&e.to_string()) => {
@@ -95,7 +130,35 @@ impl SecretStore {
     /// Load the secret for `key`. `Ok(None)` when there is no entry; `Err` only
     /// when the backend errored in a way that is not "missing".
     pub fn load(&self, key: &str) -> Result<Option<String>, String> {
-        #[cfg(feature = "system-keyring")]
+        // macOS: try Data Protection Keychain first; fall back to old keychain
+        // and migrate on a miss (one-time per item).
+        #[cfg(all(feature = "system-keyring", target_os = "macos"))]
+        {
+            match generic_password(dpk_opts(&self.service, key)) {
+                Ok(bytes) => String::from_utf8(bytes)
+                    .map(Some)
+                    .map_err(|e| format!("keyring utf8: {e}")),
+                Err(ref e) if is_not_found(e) => {
+                    // Not in DPK — check old keychain and migrate if found.
+                    let entry = keyring_entry(&self.service, key)
+                        .map_err(|e| format!("keyring entry: {e}"))?;
+                    match entry.get_password() {
+                        Ok(old_val) => {
+                            // Migrate to DPK.
+                            self.store(key, &old_val)?;
+                            // Best-effort cleanup from old keychain.
+                            let _ = entry.delete_credential();
+                            Ok(Some(old_val))
+                        }
+                        Err(keyring::Error::NoEntry) => Ok(None),
+                        Err(e) => Err(format!("keyring get: {e}")),
+                    }
+                }
+                Err(e) => Err(format!("keyring get: {e}")),
+            }
+        }
+        // Non-macOS system-keyring path (Windows, Linux).
+        #[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
         {
             let entry =
                 keyring_entry(&self.service, key).map_err(|e| format!("keyring entry: {e}"))?;
@@ -115,7 +178,14 @@ impl SecretStore {
     /// Store `value` for `key`. Reports `Err` on availability failures — callers
     /// decide whether to fall back to file storage.
     pub fn store(&self, key: &str, value: &str) -> Result<(), String> {
-        #[cfg(feature = "system-keyring")]
+        // macOS: write directly to the Data Protection Keychain.
+        #[cfg(all(feature = "system-keyring", target_os = "macos"))]
+        {
+            set_generic_password_options(value.as_bytes(), dpk_opts(&self.service, key))
+                .map_err(|e| format!("keyring set: {e}"))
+        }
+        // Non-macOS system-keyring path (Windows, Linux).
+        #[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
         {
             let entry =
                 keyring_entry(&self.service, key).map_err(|e| format!("keyring entry: {e}"))?;
@@ -132,7 +202,28 @@ impl SecretStore {
 
     /// Delete the secret for `key`. A missing entry is not an error.
     pub fn delete(&self, key: &str) -> Result<(), String> {
-        #[cfg(feature = "system-keyring")]
+        // macOS: delete from both DPK and old keychain (best-effort on old).
+        #[cfg(all(feature = "system-keyring", target_os = "macos"))]
+        {
+            // Delete from Data Protection Keychain; missing is fine.
+            match delete_generic_password_options(dpk_opts(&self.service, key)) {
+                Ok(()) => {}
+                Err(ref e) if is_not_found(e) => {}
+                Err(e) => return Err(format!("keyring delete: {e}")),
+            }
+            // Best-effort cleanup from old keychain.
+            if let Ok(entry) = keyring_entry(&self.service, key) {
+                match entry.delete_credential() {
+                    Ok(()) | Err(keyring::Error::NoEntry) => {}
+                    Err(e) => {
+                        eprintln!("buzz-desktop: old-keychain delete for {key}: {e}");
+                    }
+                }
+            }
+            Ok(())
+        }
+        // Non-macOS system-keyring path (Windows, Linux).
+        #[cfg(all(feature = "system-keyring", not(target_os = "macos")))]
         {
             let entry =
                 keyring_entry(&self.service, key).map_err(|e| format!("keyring entry: {e}"))?;


### PR DESCRIPTION
## Problem

The `keyring` crate uses `SecKeychainAddGenericPassword` with a null ACL, which creates items requiring user confirmation on every access — even by the same app. This causes ~20 prompts on migration launch and 7 on every subsequent launch.

Unsigned dev builds (`tauri dev` / `cargo run`) lack the hardened-runtime entitlement required by the Data Protection Keychain and were panicking with `errSecMissingEntitlement` (-34018) on startup.

## Solution

Switch the macOS backend to the modern `SecItem` API with `kSecUseDataProtectionKeychain=true` via `security_framework::passwords::PasswordOptions::use_protected_keychain()`. Items stored this way use `kSecAttrAccessible` instead of ACLs and never prompt after the first device unlock.

Unsigned dev builds detect `errSecMissingEntitlement` (-34018) and fall back to the legacy `keyring` crate path automatically — no panic, no entitlement required. Windows and Linux paths are unchanged.

## Changes

- `desktop/src-tauri/Cargo.toml` — adds `security-framework = { version = "3.7.0", features = ["OSX_10_15"] }` to the macOS target section
- `desktop/src-tauri/src/secret_store.rs` — replaces macOS `probe`/`load`/`store`/`delete` with DPK backend; adds `is_dpk_unavailable` fallback for unsigned builds

## Behavior

| Build type | First launch | Every subsequent launch |
|---|---|---|
| Signed release | 7 prompts (one per key, once only) | 0 prompts |
| Unsigned dev (`tauri dev`) | Legacy keychain prompts (same as pre-v0.3.32) | Legacy keychain prompts |

## Migration

`load()` tries DPK first; on a miss it checks the old keychain, migrates the value to DPK, and best-effort deletes the old entry. If DPK is unavailable (`errSecMissingEntitlement`), the legacy `keyring` path is used directly — no migration attempted.