### PR TITLE
feat(desktop): re-snapshot persona config on every agent spawn

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -34,7 +34,9 @@ const overrides = new Map([
   // read-time relay-URL workspace fallback while keeping the create-time env
   // pin (the credential-leak guard). Load-bearing feature growth from the
   // rebase, queued to split with the rest of this list.
-  ["src-tauri/src/commands/agents.rs", 1350],
+  // persona-refresh-on-spawn: re-snapshot + retain_managed_agent_pending call
+  // in start_local_agent_with_preflight adds ~23 lines. Queued to split.
+  ["src-tauri/src/commands/agents.rs", 1380],
   // Residual repos_dir integration in ensure_nest_at: REPOS is provisioned
   // outside NEST_DIRS (it may be a symlink), so it needs its own create +
   // chmod-only-when-real-dir handling plus integration test coverage. The

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -255,8 +255,31 @@ async fn start_local_agent_with_preflight(
     if record.backend != BackendKind::Local {
         return Err(format!("agent {pubkey} is no longer a local agent"));
     }
+    // Re-snapshot the persona onto the record at every spawn so the agent always
+    // starts with the current persona config (system_prompt, model, provider,
+    // env_vars). This clears the "out of date" drift badge without requiring a
+    // delete+recreate. Agent-level env_vars overrides still win (persona_snapshot
+    // layers persona env under agent overrides).
+    if let Some(persona_id) = record.persona_id.clone() {
+        let personas = load_personas(app).unwrap_or_default();
+        if let Some(persona) = personas.iter().find(|p| p.id == persona_id) {
+            let snapshot =
+                crate::managed_agents::persona_events::persona_snapshot(persona, &record.env_vars);
+            if let Some(prompt) = snapshot.system_prompt {
+                record.system_prompt = Some(prompt);
+            }
+            record.model = snapshot.model;
+            record.provider = snapshot.provider;
+            record.env_vars = snapshot.env_vars;
+            record.persona_source_version = Some(snapshot.source_version);
+            record.updated_at = crate::util::now_iso();
+        }
+    }
     start_managed_agent_process(app, record, &mut runtimes, Some(owner_hex))?;
     save_managed_agents(app, &records)?;
+    if let Some(saved_record) = records.iter().find(|r| r.pubkey == pubkey) {
+        retain_managed_agent_pending(app, state, saved_record);
+    }
     let record = records
         .iter()
         .find(|record| record.pubkey == pubkey)

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -91,7 +91,7 @@ pub async fn restore_managed_agents_on_launch(
     let state = app.state::<AppState>();
 
     // ── Phase A (under lock): housekeeping + collect agents to restore ──
-    let agents_to_start: Vec<super::ManagedAgentRecord>;
+    let mut agents_to_start: Vec<super::ManagedAgentRecord>;
     {
         let _store_guard = state
             .managed_agents_store_lock
@@ -150,6 +150,38 @@ pub async fn restore_managed_agents_on_launch(
             }
         }
         agents_to_start = to_start;
+
+        // Re-snapshot persona config for agents about to be restored, matching
+        // the interactive spawn path so auto-start agents also pick up the
+        // current persona on app launch.
+        let personas_for_snapshot = super::load_personas(app).unwrap_or_default();
+        for record in records.iter_mut() {
+            if !agents_to_start.iter().any(|r| r.pubkey == record.pubkey) {
+                continue;
+            }
+            let Some(persona_id) = record.persona_id.clone() else {
+                continue;
+            };
+            let Some(persona) = personas_for_snapshot.iter().find(|p| p.id == persona_id) else {
+                continue;
+            };
+            let snapshot = super::persona_events::persona_snapshot(persona, &record.env_vars);
+            if let Some(prompt) = snapshot.system_prompt {
+                record.system_prompt = Some(prompt);
+            }
+            record.model = snapshot.model;
+            record.provider = snapshot.provider;
+            record.env_vars = snapshot.env_vars;
+            record.persona_source_version = Some(snapshot.source_version);
+            record.updated_at = util::now_iso();
+            changed = true;
+        }
+        // Re-collect to_start from the updated records so Phase B spawns the refreshed config.
+        agents_to_start = records
+            .iter()
+            .filter(|r| agents_to_start.iter().any(|s| s.pubkey == r.pubkey))
+            .cloned()
+            .collect();
 
         if changed {
             save_managed_agents(app, &records)?;

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -276,8 +276,8 @@ function AgentSummary({
           </div>
           {agent.personaOutOfDate ? (
             <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
-              Persona updated since this agent was created. Delete and respawn
-              to apply the new configuration.
+              Persona updated since this agent was created. Respawn to apply
+              the new configuration.
             </p>
           ) : null}
           {channelNames.length > 0 ? (

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -276,8 +276,8 @@ function AgentSummary({
           </div>
           {agent.personaOutOfDate ? (
             <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
-              Persona updated since this agent was created. Respawn to apply
-              the new configuration.
+              Persona updated since this agent was created. Respawn to apply the
+              new configuration.
             </p>
           ) : null}
           {channelNames.length > 0 ? (


### PR DESCRIPTION
## Summary

When an agent linked to a persona is spawned (or auto-restored on launch), the persona's current `system_prompt`, `model`, `provider`, `env_vars`, and `persona_source_version` hash are written back onto the agent record before the process starts. This clears the "OUT OF DATE" drift badge without requiring a delete+recreate cycle.

## Changes

**`commands/agents.rs`** — In `start_local_agent_with_preflight`, before calling `start_managed_agent_process`, re-snapshot the persona onto the mutable record. After `save_managed_agents`, call `retain_managed_agent_pending` to queue a relay publish of the updated record.

**`managed_agents/restore.rs`** — In `restore_managed_agents_on_launch` Phase A, after building `to_start`, re-snapshot all persona-linked agents in that set. Set `changed = true` so the refreshed records are persisted. Re-collect `to_start` from the mutated `records` slice so Phase B spawns the refreshed config.

**`ManagedAgentRow.tsx`** — Update the "OUT OF DATE" badge tooltip to remove the now-stale instruction to delete the agent before respawning.

## Behavior

- Agent-level `env_vars` overrides still win — `persona_snapshot` layers persona env under agent overrides, matching the create-time contract.
- Agents without a `persona_id` are unaffected.
- If the linked persona is deleted, the agent spawns from its existing record fields (same fallback as before).

## Acceptance Criteria

- After editing a persona's system prompt and clicking Spawn on a linked agent, the agent starts with the new system prompt and the "OUT OF DATE" badge is gone
- `persona_source_version` on the agent record matches the current persona hash after spawn
- Auto-start agents pick up the current persona on app launch
- `cargo check` passes clean