### PR TITLE
fix(desktop): allow saving personas with an empty system prompt

### DIFF
--- a/desktop/src-tauri/src/commands/personas.rs
+++ b/desktop/src-tauri/src/commands/personas.rs
@@ -167,13 +167,13 @@ pub fn create_persona(
     state: State<'_, AppState>,
 ) -> Result<PersonaRecord, String> {
     let display_name = trim_required(&input.display_name, "Display name")?;
-    let system_prompt = trim_required(&input.system_prompt, "System prompt")?;
+    // System prompt optional: core memory is auto-injected. Empty is valid.
+    let system_prompt = input.system_prompt.trim().to_string();
     let avatar_url = trim_optional(input.avatar_url);
     let runtime = trim_optional(input.runtime);
     let model = trim_optional(input.model);
     let provider = trim_optional(input.provider);
     let now = now_iso();
-
     let _store_guard = state
         .managed_agents_store_lock
         .lock()
@@ -217,7 +217,7 @@ pub fn update_persona(
     state: State<'_, AppState>,
 ) -> Result<PersonaRecord, String> {
     let display_name = trim_required(&input.display_name, "Display name")?;
-    let system_prompt = trim_required(&input.system_prompt, "System prompt")?;
+    let system_prompt = input.system_prompt.trim().to_string();
     let avatar_url = trim_optional(input.avatar_url);
     let runtime = trim_optional(input.runtime);
     let model = trim_optional(input.model);

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -25,6 +25,7 @@ import {
   getImportErrorLabel,
   IMPORT_ERROR_VISIBILITY_MS,
 } from "./personaDialogImportState";
+import { canSubmitPersonaDialog } from "./personaDialogState";
 
 type PersonaDialogProps = {
   open: boolean;
@@ -519,11 +520,7 @@ export function PersonaDialog({
                 Cancel
               </Button>
               <Button
-                disabled={
-                  displayName.trim().length === 0 ||
-                  systemPrompt.trim().length === 0 ||
-                  isPending
-                }
+                disabled={!canSubmitPersonaDialog({ displayName, isPending })}
                 onClick={() => void handleSubmit()}
                 size="sm"
                 type="button"

--- a/desktop/src/features/agents/ui/personaDialogState.test.mjs
+++ b/desktop/src/features/agents/ui/personaDialogState.test.mjs
@@ -2,11 +2,43 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  canSubmitPersonaDialog,
   createPersonaDialogState,
   duplicatePersonaDialogState,
   editPersonaDialogState,
   importPersonaDialogState,
 } from "./personaDialogState.ts";
+
+test("canSubmitPersonaDialog requires a display name but not a system prompt", () => {
+  // Empty system prompt is allowed: core memory is auto-injected, so the
+  // persona prompt is optional. Only the display name gates submission.
+  assert.equal(
+    canSubmitPersonaDialog({ displayName: "Coder", isPending: false }),
+    true,
+  );
+  assert.equal(
+    canSubmitPersonaDialog({ displayName: "  Coder  ", isPending: false }),
+    true,
+  );
+});
+
+test("canSubmitPersonaDialog blocks an empty or whitespace display name", () => {
+  assert.equal(
+    canSubmitPersonaDialog({ displayName: "", isPending: false }),
+    false,
+  );
+  assert.equal(
+    canSubmitPersonaDialog({ displayName: "   ", isPending: false }),
+    false,
+  );
+});
+
+test("canSubmitPersonaDialog blocks while a save is pending", () => {
+  assert.equal(
+    canSubmitPersonaDialog({ displayName: "Coder", isPending: true }),
+    false,
+  );
+});
 
 test("createPersonaDialogState returns a fresh empty draft", () => {
   const first = createPersonaDialogState();

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -14,6 +14,20 @@ export type PersonaDialogState = {
 
 type ParsedPersonaDraft = ParsePersonaFilesResult["personas"][number];
 
+/**
+ * Whether the persona dialog's save action should be enabled.
+ *
+ * A display name is the only required field. The system prompt is optional:
+ * core memory is auto-injected at runtime, so a persona need not carry its
+ * own prompt. `isPending` blocks double-submits while a save is in flight.
+ */
+export function canSubmitPersonaDialog(args: {
+  displayName: string;
+  isPending: boolean;
+}): boolean {
+  return args.displayName.trim().length > 0 && !args.isPending;
+}
+
 export function createPersonaDialogState(): PersonaDialogState {
   return {
     title: "Create persona",


### PR DESCRIPTION
## What

Enable saving in the **Persona** panel even when the System Prompt field is empty. Core memory is auto-injected at runtime now, so a persona no longer needs to carry its own prompt.

The **Agent** panel (System Prompt Override) already permitted empty — its `canSubmit` never gated on the prompt and the field reads *"Leave blank to send no ACP system prompt"* — so no change was needed there.

## Changes

- **`commands/personas.rs`** — `create_persona`/`update_persona` validated the prompt via `trim_required`, rejecting empty with *"System prompt is required"*. Now stores the trimmed value; empty is valid. `display_name` stays required.
- **`personaDialogState.ts`** — new pure `canSubmitPersonaDialog({displayName, isPending})` (display name required, prompt optional).
- **`PersonaDialog.tsx`** — save button uses the helper instead of an inline `systemPrompt.trim().length === 0` guard.
- **`personaDialogState.test.mjs`** — 3 unit tests: empty prompt OK, blank display name blocked, pending blocked.

## Behavior

An empty persona prompt persists as `""` and frames as a present, empty `[System]` section; core/base memory still appends via `with_core`. That's exactly the intended distinction: no persona text, but still a system-prompt payload when core/base exists.

## Out of scope

Team-directory and persona-card *import* parsers still filter empty prompts (`teams.rs`, `persona_card.rs`). This PR is the desktop panel **save** behavior only.

## Testing

- `pnpm test` → 1132 pass (incl. 3 new)
- `pnpm typecheck` + `biome check` clean
- `just desktop-tauri-test` → 712 pass, 0 fail
- pre-push hooks (desktop-test, desktop-tauri-test, rust-tests, mobile-test) green

Reviewed with @Max (downstream-assumption + test-surface pass).

Signed-off-by: Tyler Longwell <tlongwell@block.xyz>