### PR TITLE
fix(desktop): DM close button replaces unread badge on hover

### DIFF
--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -40,6 +40,8 @@ const SECTION_LABEL_CHEVRON_ICON_CLASS =
   "absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2";
 const SIDEBAR_ROW_ACTION_VISIBILITY_CLASS =
   "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 md:opacity-0";
+const SIDEBAR_ROW_ACTION_REPLACED_BADGE_CLASS =
+  "max-md:opacity-0 md:group-focus-within/menu-item:opacity-0 md:group-hover/menu-item:opacity-0";
 const SIDEBAR_ROW_ICON_ACTION_CLASS =
   "flex size-6 items-center justify-center p-1 text-sidebar-foreground/45 transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring peer-data-[active=true]/menu-button:text-sidebar-active-foreground/75 peer-data-[active=true]/menu-button:hover:text-sidebar-active-foreground [&>svg]:size-4 [&>svg]:shrink-0";
 
@@ -376,7 +378,10 @@ export function SidebarSection({
                     !(isActiveChannel && selectedChannelId === channel.id) ? (
                       <UnreadCountBadge
                         channelName={channel.name}
-                        className="absolute right-1 top-1/2 -translate-y-1/2"
+                        className={cn(
+                          "pointer-events-none absolute right-1 top-1/2 -translate-y-1/2 transition-opacity",
+                          onHideDm && SIDEBAR_ROW_ACTION_REPLACED_BADGE_CLASS,
+                        )}
                         count={Math.max(
                           unreadChannelCounts.get(channel.id) ?? 0,
                           1,


### PR DESCRIPTION
## What

In the left sidebar, the DM close (×) button and the unread badge both render at `absolute right-1 top-1/2 -translate-y-1/2`. The × is hover/focus-gated via `SIDEBAR_ROW_ACTION_VISIBILITY_CLASS`, but the badge had **no** gating — so on hover the × stacked directly on top of the unread badge (the reported overlap).

## Fix

The badge now hides exactly where the × appears, via a new `SIDEBAR_ROW_ACTION_REPLACED_BADGE_CLASS` — the symmetric inverse of the × visibility:

- **Mobile (`<md`):** the × is always visible (no hover on touch), so the badge is hidden whenever a hide action exists — avoids a persistent overlap.
- **Desktop (`md+`):** the badge shows at rest and fades out on row hover / focus-within, so the × cleanly replaces it in the same slot.

Applied only when `onHideDm` is present, so DM rows without a close action keep their always-visible badge (no behavior change).

Three deliberate choices:
1. `onHideDm &&` guard — only swap when there's an × to replace the badge.
2. `pointer-events-none` on the badge — the × (z-10, same slot) reliably takes clicks during the opacity crossfade.
3. `transition-opacity` — symmetric crossfade with the ×, no layout shift. The badge stays in the DOM (opacity-0), so its `sr-only` unread count remains in the a11y tree when a keyboard user tabs to the row.

## Verification

- `biome check` clean, `tsc --noEmit` clean
- `pnpm --dir desktop test` — 1132 passed
- Pre-commit + pre-push hooks green (rust/desktop/mobile fmt + tests)

Reviewed earlier in-channel by Dawn and Sami (9/10 on minimal/elegant/correct) and independently validated by Pinky (who caught the mobile overlap case).

@wesb please review.