### PR TITLE
feat(buzz-agent): lazy skill loading via load_skill tool

### DIFF
--- a/crates/buzz-agent/src/agent.rs
+++ b/crates/buzz-agent/src/agent.rs
@@ -258,7 +258,7 @@ impl RunCtx<'_> {
             // Built-in load_skill: execute inline, no MCP round-trip.
             if call.name == builtin::LOAD_SKILL_TOOL {
                 emit_in_progress(self.wire, self.session_id, call).await;
-                let mut result = builtin::call_load_skill(&call.arguments, self.skills);
+                let mut result = builtin::call_load_skill(&call.arguments, self.skills).await;
                 result.provider_id = call.provider_id.clone();
                 emit_completed(self.wire, self.session_id, call, &result).await;
                 results[idx] = Some(result);

--- a/crates/buzz-agent/src/agent.rs
+++ b/crates/buzz-agent/src/agent.rs
@@ -4,8 +4,10 @@ use serde_json::json;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinSet;
 
+use crate::builtin;
 use crate::config::{Config, MAX_PROMPT_BYTES, MAX_TOOL_CALLS_PER_TURN, MAX_TOOL_RESULT_BYTES};
 use crate::handoff::HandoffOutcome;
+use crate::hints::SkillEntry;
 use crate::llm::Llm;
 use crate::mcp::McpRegistry;
 use crate::mcp::ResultBudget;
@@ -25,6 +27,8 @@ pub struct RunCtx<'a> {
     pub system_prompt: &'a str,
     pub llm: &'a Llm,
     pub mcp: &'a Arc<McpRegistry>,
+    /// Skills discovered at session creation; used by the built-in `load_skill` tool.
+    pub skills: &'a [SkillEntry],
     pub wire: &'a WireSender,
     pub cancel: &'a mut watch::Receiver<bool>,
     pub history: &'a mut Vec<HistoryItem>,
@@ -90,7 +94,11 @@ impl RunCtx<'_> {
                 }
             }
 
-            let tools = self.mcp.tools();
+            let mut tools = self.mcp.tools();
+            // Inject the built-in load_skill tool when skills are available.
+            if !self.skills.is_empty() {
+                tools.push(builtin::load_skill_def());
+            }
             round = round.saturating_add(1);
             let response = tokio::select! {
                 biased;
@@ -246,6 +254,17 @@ impl RunCtx<'_> {
                 return Some(StopReason::Cancelled);
             }
             emit_pending(self.wire, self.session_id, call).await;
+
+            // Built-in load_skill: execute inline, no MCP round-trip.
+            if call.name == builtin::LOAD_SKILL_TOOL {
+                emit_in_progress(self.wire, self.session_id, call).await;
+                let mut result = builtin::call_load_skill(&call.arguments, self.skills);
+                result.provider_id = call.provider_id.clone();
+                emit_completed(self.wire, self.session_id, call, &result).await;
+                results[idx] = Some(result);
+                continue;
+            }
+
             // Hook tools (bare name starts with `_`) are invisible to the
             // LLM and only callable via `call_hooks`. Treat any direct
             // invocation as if the tool didn't exist.

--- a/crates/buzz-agent/src/builtin.rs
+++ b/crates/buzz-agent/src/builtin.rs
@@ -18,14 +18,17 @@ pub fn load_skill_def() -> ToolDef {
         name: LOAD_SKILL_TOOL.to_owned(),
         description: "Load the full content of a skill by name. \
             Call this before using a skill — the system prompt lists skill names \
-            and descriptions only; the full instructions are loaded on demand."
+            and descriptions only; the full instructions are loaded on demand. \
+            To load a supporting file within a skill, use the form \
+            \"skill-name/relative/path\" (e.g. \"my-skill/references/foo.md\")."
             .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "The skill name as listed in the Available Skills section."
+                    "description": "The skill name as listed in the Available Skills section, \
+                        or \"skill-name/relative/path\" to load a supporting file."
                 }
             },
             "required": ["name"]
@@ -43,6 +46,14 @@ pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
         }
     };
 
+    // Two forms:
+    //   "skill-name"            → load SKILL.md body + ## Supporting Files section
+    //   "skill-name/rel/path"   → load a specific supporting file
+    if let Some((skill_name, rel_path)) = name.split_once('/') {
+        return load_supporting_file(skill_name, rel_path, skills);
+    }
+
+    // Plain skill-name form: load SKILL.md body.
     let entry = match skills.iter().find(|s| s.name == name) {
         Some(e) => e,
         None => {
@@ -72,10 +83,116 @@ pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
         body
     };
 
+    let mut output = body.to_owned();
+
+    // Append ## Supporting Files section if this skill has any.
+    if !entry.supporting_files.is_empty() {
+        let skill_dir = entry.path.parent().unwrap_or(&entry.path);
+        output.push_str("\n\n## Supporting Files\n\n");
+        for file in &entry.supporting_files {
+            if let Ok(rel) = file.strip_prefix(skill_dir) {
+                let rel_str = rel.to_string_lossy().replace('\\', "/");
+                let abs_str = file.to_string_lossy().replace('\\', "/");
+                output.push_str(&format!(
+                    "- {} → {} (load_skill(name: \"{}/{}\"))\n",
+                    rel_str, abs_str, entry.name, rel_str
+                ));
+            }
+        }
+    }
+
     ToolResult {
         provider_id: String::new(),
-        content: vec![ToolResultContent::Text(body.to_owned())],
+        content: vec![ToolResultContent::Text(output)],
         is_error: false,
+    }
+}
+
+/// Load a supporting file identified by `skill_name/rel_path`.
+/// Matches against the pre-enumerated `supporting_files` list and applies a
+/// canonicalize-based traversal guard before reading.
+fn load_supporting_file(skill_name: &str, rel_path: &str, skills: &[SkillEntry]) -> ToolResult {
+    let rel_path = rel_path.replace('\\', "/");
+
+    let entry = match skills.iter().find(|s| s.name == skill_name) {
+        Some(e) => e,
+        None => {
+            let available: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+            return error_result(&format!(
+                "load_skill: skill {skill_name:?} not found. Available: {available:?}"
+            ));
+        }
+    };
+
+    let skill_dir = match entry.path.parent() {
+        Some(d) => d,
+        None => {
+            return error_result(&format!(
+                "load_skill: could not determine skill directory for {skill_name:?}"
+            ));
+        }
+    };
+
+    // Match rel_path against the pre-enumerated supporting_files list.
+    let matched = entry.supporting_files.iter().find(|f| {
+        f.strip_prefix(skill_dir)
+            .map(|r| r.to_string_lossy().replace('\\', "/") == rel_path)
+            .unwrap_or(false)
+    });
+
+    let file_path = match matched {
+        Some(p) => p,
+        None => {
+            let available: Vec<String> = entry
+                .supporting_files
+                .iter()
+                .filter_map(|f| {
+                    f.strip_prefix(skill_dir)
+                        .ok()
+                        .map(|r| r.to_string_lossy().replace('\\', "/"))
+                })
+                .collect();
+            if available.is_empty() {
+                return error_result(&format!(
+                    "load_skill: skill {skill_name:?} has no supporting files."
+                ));
+            }
+            return error_result(&format!(
+                "load_skill: file {rel_path:?} not found in skill {skill_name:?}. \
+                 Available: {available:?}"
+            ));
+        }
+    };
+
+    // Traversal guard: canonicalize both paths and verify the file stays inside
+    // the skill directory.
+    let canonical_skill_dir = skill_dir
+        .canonicalize()
+        .unwrap_or_else(|_| skill_dir.to_path_buf());
+
+    match file_path.canonicalize() {
+        Ok(canonical_file) if canonical_file.starts_with(&canonical_skill_dir) => {
+            match std::fs::read_to_string(&canonical_file) {
+                Ok(content) => ToolResult {
+                    provider_id: String::new(),
+                    content: vec![ToolResultContent::Text(format!(
+                        "# Loaded: {}/{}\n\n{}\n\n---\nFile loaded into context.",
+                        skill_name, rel_path, content
+                    ))],
+                    is_error: false,
+                },
+                Err(e) => error_result(&format!(
+                    "load_skill: could not read {skill_name:?}/{rel_path}: {e}"
+                )),
+            }
+        }
+        Ok(_) => error_result(&format!(
+            "load_skill: refusing to load {skill_name:?}/{rel_path}: \
+             resolves outside the skill directory"
+        )),
+        Err(e) => error_result(&format!(
+            "load_skill: could not resolve {skill_name:?}/{rel_path}: {e}"
+        )),
     }
 }
 
@@ -95,5 +212,258 @@ fn error_result(msg: &str) -> ToolResult {
         provider_id: String::new(),
         content: vec![ToolResultContent::Text(msg.to_owned())],
         is_error: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn text_content(result: &ToolResult) -> String {
+        match &result.content[0] {
+            ToolResultContent::Text(t) => t.clone(),
+            ToolResultContent::Image { .. } => panic!("unexpected Image content in test"),
+        }
+    }
+
+    fn make_skill(name: &str, description: &str, path: PathBuf) -> SkillEntry {
+        SkillEntry {
+            name: name.to_owned(),
+            description: description.to_owned(),
+            path,
+            supporting_files: Vec::new(),
+        }
+    }
+
+    fn make_skill_with_files(
+        name: &str,
+        description: &str,
+        path: PathBuf,
+        supporting_files: Vec<PathBuf>,
+    ) -> SkillEntry {
+        SkillEntry {
+            name: name.to_owned(),
+            description: description.to_owned(),
+            path,
+            supporting_files,
+        }
+    }
+
+    #[test]
+    fn call_load_skill_missing_name_arg() {
+        let result = call_load_skill(&serde_json::json!({}), &[]);
+        assert!(result.is_error);
+        let text = text_content(&result);
+        assert!(text.contains("missing required argument"), "got: {text}");
+    }
+
+    #[test]
+    fn call_load_skill_skill_not_found() {
+        let result = call_load_skill(&serde_json::json!({"name": "no-such"}), &[]);
+        assert!(result.is_error);
+        let text = text_content(&result);
+        assert!(text.contains("not found"), "got: {text}");
+    }
+
+    #[test]
+    fn call_load_skill_returns_body_strips_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        let skill_md = tmp.path().join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: test\ndescription: A test\n---\nSkill body here.\n",
+        )
+        .unwrap();
+        let skills = vec![make_skill("test", "A test", skill_md)];
+        let result = call_load_skill(&serde_json::json!({"name": "test"}), &skills);
+        assert!(!result.is_error);
+        let text = text_content(&result);
+        assert!(text.contains("Skill body here."), "got: {text}");
+        assert!(!text.contains("---"), "frontmatter should be stripped: {text}");
+    }
+
+    #[test]
+    fn call_load_skill_appends_supporting_files_section() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path();
+        let skill_md = skill_dir.join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: my-skill\ndescription: desc\n---\nBody.\n",
+        )
+        .unwrap();
+        let refs_dir = skill_dir.join("references");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        let ref_file = refs_dir.join("foo.md");
+        std::fs::write(&ref_file, "Reference content.").unwrap();
+
+        let skills = vec![make_skill_with_files(
+            "my-skill",
+            "desc",
+            skill_md,
+            vec![ref_file],
+        )];
+        let result = call_load_skill(&serde_json::json!({"name": "my-skill"}), &skills);
+        assert!(!result.is_error);
+        let text = text_content(&result);
+        assert!(text.contains("Body."), "body missing: {text}");
+        assert!(
+            text.contains("## Supporting Files"),
+            "missing Supporting Files section: {text}"
+        );
+        assert!(
+            text.contains("references/foo.md"),
+            "missing file listing: {text}"
+        );
+        assert!(
+            text.contains("load_skill(name: \"my-skill/references/foo.md\")"),
+            "missing load_skill hint: {text}"
+        );
+    }
+
+    #[test]
+    fn call_load_skill_no_supporting_files_section_when_empty() {
+        let tmp = TempDir::new().unwrap();
+        let skill_md = tmp.path().join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: bare\ndescription: desc\n---\nBody.\n",
+        )
+        .unwrap();
+        let skills = vec![make_skill("bare", "desc", skill_md)];
+        let result = call_load_skill(&serde_json::json!({"name": "bare"}), &skills);
+        assert!(!result.is_error);
+        let text = text_content(&result);
+        assert!(
+            !text.contains("## Supporting Files"),
+            "should not have Supporting Files section when none: {text}"
+        );
+    }
+
+    #[test]
+    fn call_load_skill_supporting_file_returns_content() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path();
+        let skill_md = skill_dir.join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: my-skill\ndescription: desc\n---\nBody.\n",
+        )
+        .unwrap();
+        let refs_dir = skill_dir.join("references");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        let ref_file = refs_dir.join("foo.md");
+        std::fs::write(&ref_file, "Reference content here.").unwrap();
+
+        let skills = vec![make_skill_with_files(
+            "my-skill",
+            "desc",
+            skill_md,
+            vec![ref_file],
+        )];
+        let result =
+            call_load_skill(&serde_json::json!({"name": "my-skill/references/foo.md"}), &skills);
+        assert!(!result.is_error, "expected success, got error");
+        let text = text_content(&result);
+        assert!(
+            text.contains("Reference content here."),
+            "file content missing: {text}"
+        );
+        assert!(
+            text.contains("# Loaded: my-skill/references/foo.md"),
+            "missing header: {text}"
+        );
+    }
+
+    #[test]
+    fn call_load_skill_supporting_file_not_found_lists_available() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path();
+        let skill_md = skill_dir.join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: my-skill\ndescription: desc\n---\nBody.\n",
+        )
+        .unwrap();
+        let refs_dir = skill_dir.join("references");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        let ref_file = refs_dir.join("foo.md");
+        std::fs::write(&ref_file, "content").unwrap();
+
+        let skills = vec![make_skill_with_files(
+            "my-skill",
+            "desc",
+            skill_md,
+            vec![ref_file],
+        )];
+        let result = call_load_skill(
+            &serde_json::json!({"name": "my-skill/references/missing.md"}),
+            &skills,
+        );
+        assert!(result.is_error);
+        let text = text_content(&result);
+        assert!(text.contains("not found"), "got: {text}");
+        assert!(text.contains("references/foo.md"), "should list available: {text}");
+    }
+
+    #[test]
+    fn call_load_skill_no_supporting_files_error_message() {
+        let tmp = TempDir::new().unwrap();
+        let skill_md = tmp.path().join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: bare\ndescription: desc\n---\nBody.\n",
+        )
+        .unwrap();
+        let skills = vec![make_skill("bare", "desc", skill_md)];
+        let result =
+            call_load_skill(&serde_json::json!({"name": "bare/anything.md"}), &skills);
+        assert!(result.is_error);
+        let text = text_content(&result);
+        assert!(text.contains("no supporting files"), "got: {text}");
+    }
+
+    #[test]
+    fn call_load_skill_traversal_guard_rejects_escape() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let skill_md = skill_dir.join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: my-skill\ndescription: desc\n---\nBody.\n",
+        )
+        .unwrap();
+
+        // Create a file outside the skill dir that we'll try to reference.
+        let outside_file = tmp.path().join("secret.txt");
+        std::fs::write(&outside_file, "secret content").unwrap();
+
+        // Manually construct a SkillEntry with a supporting_files entry that
+        // points outside the skill dir — simulating a crafted/malicious entry.
+        // The traversal guard should catch this.
+        let skills = vec![make_skill_with_files(
+            "my-skill",
+            "desc",
+            skill_md.clone(),
+            vec![outside_file.clone()],
+        )];
+
+        // The slash form splits "my-skill/../secret.txt" into skill_name="my-skill"
+        // and rel_path="../secret.txt". strip_prefix(skill_dir) on outside_file
+        // fails, so it won't match any supporting_files entry — the pre-enumeration
+        // guard rejects it before the canonicalize guard even fires.
+        let result = call_load_skill(
+            &serde_json::json!({"name": "my-skill/../secret.txt"}),
+            &skills,
+        );
+        assert!(result.is_error, "traversal attempt should be rejected");
+        let text = text_content(&result);
+        assert!(
+            !text.contains("secret content"),
+            "secret content must not be returned: {text}"
+        );
     }
 }

--- a/crates/buzz-agent/src/builtin.rs
+++ b/crates/buzz-agent/src/builtin.rs
@@ -6,7 +6,7 @@
 
 use serde_json::{json, Value};
 
-use crate::hints::{SkillEntry, MAX_SKILL_BODY_BYTES};
+use crate::hints::{strip_frontmatter, SkillEntry, MAX_SKILL_BODY_BYTES};
 use crate::mcp::truncate_at_boundary;
 use crate::types::{ToolDef, ToolResult, ToolResultContent};
 
@@ -36,9 +36,9 @@ pub fn load_skill_def() -> ToolDef {
     }
 }
 
-/// Execute a `load_skill` call. Returns `Ok(ToolResult)` on success or a
+/// Execute a `load_skill` call. Returns a `ToolResult` on success or a
 /// user-visible error result if the skill is not found or cannot be read.
-pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
+pub async fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
     let name = match arguments.get("name").and_then(Value::as_str) {
         Some(n) => n,
         None => {
@@ -50,7 +50,7 @@ pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
     //   "skill-name"            → load SKILL.md body + ## Supporting Files section
     //   "skill-name/rel/path"   → load a specific supporting file
     if let Some((skill_name, rel_path)) = name.split_once('/') {
-        return load_supporting_file(skill_name, rel_path, skills);
+        return load_supporting_file(skill_name, rel_path, skills).await;
     }
 
     // Plain skill-name form: load SKILL.md body.
@@ -64,7 +64,12 @@ pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
         }
     };
 
-    let raw = match std::fs::read_to_string(&entry.path) {
+    // Read the file off the async executor to avoid blocking a Tokio worker.
+    let skill_path = entry.path.clone();
+    let raw = match tokio::task::spawn_blocking(move || std::fs::read_to_string(&skill_path))
+        .await
+        .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+    {
         Ok(s) => s,
         Err(e) => {
             return error_result(&format!("load_skill: could not read {:?}: {e}", entry.path));
@@ -84,10 +89,9 @@ pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
         for file in &entry.supporting_files {
             if let Ok(rel) = file.strip_prefix(skill_dir) {
                 let rel_str = rel.to_string_lossy().replace('\\', "/");
-                let abs_str = file.to_string_lossy().replace('\\', "/");
                 output.push_str(&format!(
-                    "- {} → {} (load_skill(name: \"{}/{}\"))\n",
-                    rel_str, abs_str, entry.name, rel_str
+                    "- {} (load_skill(name: \"{}/{}\"))\n",
+                    rel_str, entry.name, rel_str
                 ));
             }
         }
@@ -111,7 +115,11 @@ pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
 /// Load a supporting file identified by `skill_name/rel_path`.
 /// Matches against the pre-enumerated `supporting_files` list and applies a
 /// canonicalize-based traversal guard before reading.
-fn load_supporting_file(skill_name: &str, rel_path: &str, skills: &[SkillEntry]) -> ToolResult {
+async fn load_supporting_file(
+    skill_name: &str,
+    rel_path: &str,
+    skills: &[SkillEntry],
+) -> ToolResult {
     let rel_path = rel_path.replace('\\', "/");
 
     let entry = match skills.iter().find(|s| s.name == skill_name) {
@@ -176,41 +184,41 @@ fn load_supporting_file(skill_name: &str, rel_path: &str, skills: &[SkillEntry])
         }
     };
 
-    match file_path.canonicalize() {
-        Ok(canonical_file) if canonical_file.starts_with(&canonical_skill_dir) => {
-            match std::fs::read_to_string(&canonical_file) {
+    // Clone the path so we can move it into spawn_blocking.
+    let file_path = file_path.clone();
+    let skill_name = skill_name.to_owned();
+    let rel_path_owned = rel_path.clone();
+
+    match tokio::task::spawn_blocking(move || file_path.canonicalize().map(|c| (c, file_path)))
+        .await
+        .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+    {
+        Ok((canonical_file, resolved_path)) if canonical_file.starts_with(&canonical_skill_dir) => {
+            match tokio::task::spawn_blocking(move || std::fs::read_to_string(&resolved_path))
+                .await
+                .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+            {
                 Ok(content) => ToolResult {
                     provider_id: String::new(),
                     content: vec![ToolResultContent::Text(format!(
                         "# Loaded: {}/{}\n\n{}\n\n---\nFile loaded into context.",
-                        skill_name, rel_path, content
+                        skill_name, rel_path_owned, content
                     ))],
                     is_error: false,
                 },
                 Err(e) => error_result(&format!(
-                    "load_skill: could not read {skill_name:?}/{rel_path}: {e}"
+                    "load_skill: could not read {skill_name:?}/{rel_path_owned}: {e}"
                 )),
             }
         }
         Ok(_) => error_result(&format!(
-            "load_skill: refusing to load {skill_name:?}/{rel_path}: \
+            "load_skill: refusing to load {skill_name:?}/{rel_path_owned}: \
              resolves outside the skill directory"
         )),
         Err(e) => error_result(&format!(
-            "load_skill: could not resolve {skill_name:?}/{rel_path}: {e}"
+            "load_skill: could not resolve {skill_name:?}/{rel_path_owned}: {e}"
         )),
     }
-}
-
-fn strip_frontmatter(content: &str) -> &str {
-    let Some(rest) = content.strip_prefix("---\n") else {
-        return content;
-    };
-    let Some(close_pos) = rest.find("\n---") else {
-        return content;
-    };
-    let after = &rest[close_pos + 4..]; // skip "\n---"
-    after.strip_prefix('\n').unwrap_or(after)
 }
 
 fn error_result(msg: &str) -> ToolResult {
@@ -257,24 +265,24 @@ mod tests {
         }
     }
 
-    #[test]
-    fn call_load_skill_missing_name_arg() {
-        let result = call_load_skill(&serde_json::json!({}), &[]);
+    #[tokio::test]
+    async fn call_load_skill_missing_name_arg() {
+        let result = call_load_skill(&serde_json::json!({}), &[]).await;
         assert!(result.is_error);
         let text = text_content(&result);
         assert!(text.contains("missing required argument"), "got: {text}");
     }
 
-    #[test]
-    fn call_load_skill_skill_not_found() {
-        let result = call_load_skill(&serde_json::json!({"name": "no-such"}), &[]);
+    #[tokio::test]
+    async fn call_load_skill_skill_not_found() {
+        let result = call_load_skill(&serde_json::json!({"name": "no-such"}), &[]).await;
         assert!(result.is_error);
         let text = text_content(&result);
         assert!(text.contains("not found"), "got: {text}");
     }
 
-    #[test]
-    fn call_load_skill_returns_body_strips_frontmatter() {
+    #[tokio::test]
+    async fn call_load_skill_returns_body_strips_frontmatter() {
         let tmp = TempDir::new().unwrap();
         let skill_md = tmp.path().join("SKILL.md");
         std::fs::write(
@@ -283,7 +291,7 @@ mod tests {
         )
         .unwrap();
         let skills = vec![make_skill("test", "A test", skill_md)];
-        let result = call_load_skill(&serde_json::json!({"name": "test"}), &skills);
+        let result = call_load_skill(&serde_json::json!({"name": "test"}), &skills).await;
         assert!(!result.is_error);
         let text = text_content(&result);
         assert!(text.contains("Skill body here."), "got: {text}");
@@ -293,8 +301,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn call_load_skill_appends_supporting_files_section() {
+    #[tokio::test]
+    async fn call_load_skill_appends_supporting_files_section() {
         let tmp = TempDir::new().unwrap();
         let skill_dir = tmp.path();
         let skill_md = skill_dir.join("SKILL.md");
@@ -314,7 +322,7 @@ mod tests {
             skill_md,
             vec![ref_file],
         )];
-        let result = call_load_skill(&serde_json::json!({"name": "my-skill"}), &skills);
+        let result = call_load_skill(&serde_json::json!({"name": "my-skill"}), &skills).await;
         assert!(!result.is_error);
         let text = text_content(&result);
         assert!(text.contains("Body."), "body missing: {text}");
@@ -332,8 +340,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn call_load_skill_no_supporting_files_section_when_empty() {
+    #[tokio::test]
+    async fn call_load_skill_no_supporting_files_section_when_empty() {
         let tmp = TempDir::new().unwrap();
         let skill_md = tmp.path().join("SKILL.md");
         std::fs::write(
@@ -342,7 +350,7 @@ mod tests {
         )
         .unwrap();
         let skills = vec![make_skill("bare", "desc", skill_md)];
-        let result = call_load_skill(&serde_json::json!({"name": "bare"}), &skills);
+        let result = call_load_skill(&serde_json::json!({"name": "bare"}), &skills).await;
         assert!(!result.is_error);
         let text = text_content(&result);
         assert!(
@@ -351,8 +359,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn call_load_skill_supporting_file_returns_content() {
+    #[tokio::test]
+    async fn call_load_skill_supporting_file_returns_content() {
         let tmp = TempDir::new().unwrap();
         let skill_dir = tmp.path();
         let skill_md = skill_dir.join("SKILL.md");
@@ -375,7 +383,8 @@ mod tests {
         let result = call_load_skill(
             &serde_json::json!({"name": "my-skill/references/foo.md"}),
             &skills,
-        );
+        )
+        .await;
         assert!(!result.is_error, "expected success, got error");
         let text = text_content(&result);
         assert!(
@@ -388,8 +397,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn call_load_skill_supporting_file_not_found_lists_available() {
+    #[tokio::test]
+    async fn call_load_skill_supporting_file_not_found_lists_available() {
         let tmp = TempDir::new().unwrap();
         let skill_dir = tmp.path();
         let skill_md = skill_dir.join("SKILL.md");
@@ -412,7 +421,8 @@ mod tests {
         let result = call_load_skill(
             &serde_json::json!({"name": "my-skill/references/missing.md"}),
             &skills,
-        );
+        )
+        .await;
         assert!(result.is_error);
         let text = text_content(&result);
         assert!(text.contains("not found"), "got: {text}");
@@ -422,8 +432,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn call_load_skill_no_supporting_files_error_message() {
+    #[tokio::test]
+    async fn call_load_skill_no_supporting_files_error_message() {
         let tmp = TempDir::new().unwrap();
         let skill_md = tmp.path().join("SKILL.md");
         std::fs::write(
@@ -432,14 +442,15 @@ mod tests {
         )
         .unwrap();
         let skills = vec![make_skill("bare", "desc", skill_md)];
-        let result = call_load_skill(&serde_json::json!({"name": "bare/anything.md"}), &skills);
+        let result =
+            call_load_skill(&serde_json::json!({"name": "bare/anything.md"}), &skills).await;
         assert!(result.is_error);
         let text = text_content(&result);
         assert!(text.contains("no supporting files"), "got: {text}");
     }
 
-    #[test]
-    fn call_load_skill_traversal_guard_rejects_escape() {
+    #[tokio::test]
+    async fn call_load_skill_traversal_guard_rejects_escape() {
         let tmp = TempDir::new().unwrap();
         let skill_dir = tmp.path().join("my-skill");
         std::fs::create_dir_all(&skill_dir).unwrap();
@@ -471,12 +482,49 @@ mod tests {
         let result = call_load_skill(
             &serde_json::json!({"name": "my-skill/../secret.txt"}),
             &skills,
-        );
+        )
+        .await;
         assert!(result.is_error, "traversal attempt should be rejected");
         let text = text_content(&result);
         assert!(
             !text.contains("secret content"),
             "secret content must not be returned: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_load_skill_truncates_large_body() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path();
+        let skill_md = skill_dir.join("SKILL.md");
+        // Build a body that exceeds MAX_SKILL_BODY_BYTES (32 KiB).
+        let large_body = "x".repeat(40 * 1024);
+        std::fs::write(
+            &skill_md,
+            format!("---\nname: big\ndescription: desc\n---\n{large_body}\n"),
+        )
+        .unwrap();
+        // Add a supporting file so the Supporting Files section is also appended
+        // before the cap is applied.
+        let refs_dir = skill_dir.join("references");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        let ref_file = refs_dir.join("extra.md");
+        std::fs::write(&ref_file, "extra content").unwrap();
+
+        let skills = vec![make_skill_with_files(
+            "big",
+            "desc",
+            skill_md,
+            vec![ref_file],
+        )];
+        let result = call_load_skill(&serde_json::json!({"name": "big"}), &skills).await;
+        assert!(!result.is_error);
+        let text = text_content(&result);
+        assert!(
+            text.len() <= MAX_SKILL_BODY_BYTES,
+            "output length {} exceeds MAX_SKILL_BODY_BYTES {}",
+            text.len(),
+            MAX_SKILL_BODY_BYTES
         );
     }
 }

--- a/crates/buzz-agent/src/builtin.rs
+++ b/crates/buzz-agent/src/builtin.rs
@@ -67,21 +67,13 @@ pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
     let raw = match std::fs::read_to_string(&entry.path) {
         Ok(s) => s,
         Err(e) => {
-            return error_result(&format!(
-                "load_skill: could not read {:?}: {e}",
-                entry.path
-            ));
+            return error_result(&format!("load_skill: could not read {:?}: {e}", entry.path));
         }
     };
 
     // Strip the YAML frontmatter — the agent already knows name/description
     // from the system prompt; return only the body.
     let body = strip_frontmatter(&raw);
-    let body = if body.len() > MAX_SKILL_BODY_BYTES {
-        truncate_at_boundary(body, MAX_SKILL_BODY_BYTES)
-    } else {
-        body
-    };
 
     let mut output = body.to_owned();
 
@@ -100,6 +92,14 @@ pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
             }
         }
     }
+
+    // Apply the size cap to the full output (body + Supporting Files section)
+    // so the total tool result stays within MAX_SKILL_BODY_BYTES.
+    let output = if output.len() > MAX_SKILL_BODY_BYTES {
+        truncate_at_boundary(&output, MAX_SKILL_BODY_BYTES).to_owned()
+    } else {
+        output
+    };
 
     ToolResult {
         provider_id: String::new(),
@@ -165,10 +165,16 @@ fn load_supporting_file(skill_name: &str, rel_path: &str, skills: &[SkillEntry])
     };
 
     // Traversal guard: canonicalize both paths and verify the file stays inside
-    // the skill directory.
-    let canonical_skill_dir = skill_dir
-        .canonicalize()
-        .unwrap_or_else(|_| skill_dir.to_path_buf());
+    // the skill directory. Fail hard if the skill directory itself can't be
+    // canonicalized — a degraded guard is worse than no guard.
+    let canonical_skill_dir = match skill_dir.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            return error_result(&format!(
+                "load_skill: could not canonicalize skill directory for {skill_name:?}: {e}"
+            ));
+        }
+    };
 
     match file_path.canonicalize() {
         Ok(canonical_file) if canonical_file.starts_with(&canonical_skill_dir) => {
@@ -281,7 +287,10 @@ mod tests {
         assert!(!result.is_error);
         let text = text_content(&result);
         assert!(text.contains("Skill body here."), "got: {text}");
-        assert!(!text.contains("---"), "frontmatter should be stripped: {text}");
+        assert!(
+            !text.contains("---"),
+            "frontmatter should be stripped: {text}"
+        );
     }
 
     #[test]
@@ -363,8 +372,10 @@ mod tests {
             skill_md,
             vec![ref_file],
         )];
-        let result =
-            call_load_skill(&serde_json::json!({"name": "my-skill/references/foo.md"}), &skills);
+        let result = call_load_skill(
+            &serde_json::json!({"name": "my-skill/references/foo.md"}),
+            &skills,
+        );
         assert!(!result.is_error, "expected success, got error");
         let text = text_content(&result);
         assert!(
@@ -405,7 +416,10 @@ mod tests {
         assert!(result.is_error);
         let text = text_content(&result);
         assert!(text.contains("not found"), "got: {text}");
-        assert!(text.contains("references/foo.md"), "should list available: {text}");
+        assert!(
+            text.contains("references/foo.md"),
+            "should list available: {text}"
+        );
     }
 
     #[test]
@@ -418,8 +432,7 @@ mod tests {
         )
         .unwrap();
         let skills = vec![make_skill("bare", "desc", skill_md)];
-        let result =
-            call_load_skill(&serde_json::json!({"name": "bare/anything.md"}), &skills);
+        let result = call_load_skill(&serde_json::json!({"name": "bare/anything.md"}), &skills);
         assert!(result.is_error);
         let text = text_content(&result);
         assert!(text.contains("no supporting files"), "got: {text}");

--- a/crates/buzz-agent/src/builtin.rs
+++ b/crates/buzz-agent/src/builtin.rs
@@ -1,0 +1,99 @@
+//! Built-in tools that run in-process, bypassing MCP.
+//!
+//! Currently: `load_skill` — reads a skill's full SKILL.md body from disk
+//! and returns it so the agent can load skill content on demand rather than
+//! having every skill inlined into the system prompt at session start.
+
+use serde_json::{json, Value};
+
+use crate::hints::{SkillEntry, MAX_SKILL_BODY_BYTES};
+use crate::mcp::truncate_at_boundary;
+use crate::types::{ToolDef, ToolResult, ToolResultContent};
+
+pub const LOAD_SKILL_TOOL: &str = "load_skill";
+
+/// Return the `ToolDef` for `load_skill` to include in the LLM tool list.
+pub fn load_skill_def() -> ToolDef {
+    ToolDef {
+        name: LOAD_SKILL_TOOL.to_owned(),
+        description: "Load the full content of a skill by name. \
+            Call this before using a skill — the system prompt lists skill names \
+            and descriptions only; the full instructions are loaded on demand."
+            .to_owned(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The skill name as listed in the Available Skills section."
+                }
+            },
+            "required": ["name"]
+        }),
+    }
+}
+
+/// Execute a `load_skill` call. Returns `Ok(ToolResult)` on success or a
+/// user-visible error result if the skill is not found or cannot be read.
+pub fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolResult {
+    let name = match arguments.get("name").and_then(Value::as_str) {
+        Some(n) => n,
+        None => {
+            return error_result("load_skill: missing required argument \"name\"");
+        }
+    };
+
+    let entry = match skills.iter().find(|s| s.name == name) {
+        Some(e) => e,
+        None => {
+            let available: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+            return error_result(&format!(
+                "load_skill: skill {name:?} not found. Available: {available:?}"
+            ));
+        }
+    };
+
+    let raw = match std::fs::read_to_string(&entry.path) {
+        Ok(s) => s,
+        Err(e) => {
+            return error_result(&format!(
+                "load_skill: could not read {:?}: {e}",
+                entry.path
+            ));
+        }
+    };
+
+    // Strip the YAML frontmatter — the agent already knows name/description
+    // from the system prompt; return only the body.
+    let body = strip_frontmatter(&raw);
+    let body = if body.len() > MAX_SKILL_BODY_BYTES {
+        truncate_at_boundary(body, MAX_SKILL_BODY_BYTES)
+    } else {
+        body
+    };
+
+    ToolResult {
+        provider_id: String::new(),
+        content: vec![ToolResultContent::Text(body.to_owned())],
+        is_error: false,
+    }
+}
+
+fn strip_frontmatter(content: &str) -> &str {
+    let Some(rest) = content.strip_prefix("---\n") else {
+        return content;
+    };
+    let Some(close_pos) = rest.find("\n---") else {
+        return content;
+    };
+    let after = &rest[close_pos + 4..]; // skip "\n---"
+    after.strip_prefix('\n').unwrap_or(after)
+}
+
+fn error_result(msg: &str) -> ToolResult {
+    ToolResult {
+        provider_id: String::new(),
+        content: vec![ToolResultContent::Text(msg.to_owned())],
+        is_error: true,
+    }
+}

--- a/crates/buzz-agent/src/hints.rs
+++ b/crates/buzz-agent/src/hints.rs
@@ -4,17 +4,19 @@ use std::path::{Path, PathBuf};
 use crate::mcp::truncate_at_boundary;
 
 const MAX_HINTS_BYTES: usize = 128 * 1024;
-const MAX_SKILL_BODY_BYTES: usize = 32 * 1024;
+pub const MAX_SKILL_BODY_BYTES: usize = 32 * 1024;
 const SKILL_DIRS: &[&str] = &[".agents/skills", ".goose/skills", ".claude/skills"];
 
 fn home_dir() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
 }
 
+#[derive(Clone)]
 pub struct SkillEntry {
     pub name: String,
     pub description: String,
-    pub body: String,
+    /// Absolute path to the SKILL.md file; used by `load_skill` to read on demand.
+    pub path: PathBuf,
 }
 
 /// Handles both normal repos (`.git/` dir) and worktrees (`.git` file).
@@ -77,15 +79,12 @@ fn load_hint_files_impl(cwd: &Path, home: Option<&Path>) -> String {
     result
 }
 
-fn parse_skill_frontmatter(content: &str) -> Option<(String, String, String)> {
+fn parse_skill_frontmatter(content: &str) -> Option<(String, String)> {
     // Must start with `---`
     let rest = content.strip_prefix("---\n")?;
     // Find the closing `---`
     let close_pos = rest.find("\n---")?;
     let yaml_block = &rest[..close_pos];
-    // Everything after the closing `---\n` (or `---` at end) is the body.
-    let after_close = &rest[close_pos + 4..]; // skip "\n---"
-    let body = after_close.strip_prefix('\n').unwrap_or(after_close);
 
     let map: HashMap<String, serde_yaml::Value> = serde_yaml::from_str(yaml_block).ok()?;
     let name = map
@@ -101,13 +100,7 @@ fn parse_skill_frontmatter(content: &str) -> Option<(String, String, String)> {
         .unwrap_or("")
         .to_string();
 
-    let body = if body.len() > MAX_SKILL_BODY_BYTES {
-        truncate_at_boundary(body, MAX_SKILL_BODY_BYTES).to_string()
-    } else {
-        body.to_string()
-    };
-
-    Some((name, description, body))
+    Some((name, description))
 }
 
 fn scan_skill_dir(dir: &Path, seen: &mut HashSet<String>, skills: &mut Vec<SkillEntry>) {
@@ -126,7 +119,7 @@ fn scan_skill_dir(dir: &Path, seen: &mut HashSet<String>, skills: &mut Vec<Skill
         let Ok(content) = std::fs::read_to_string(&skill_md) else {
             continue;
         };
-        let Some((name, description, body)) = parse_skill_frontmatter(&content) else {
+        let Some((name, description)) = parse_skill_frontmatter(&content) else {
             continue;
         };
         if seen.contains(&name) {
@@ -136,7 +129,7 @@ fn scan_skill_dir(dir: &Path, seen: &mut HashSet<String>, skills: &mut Vec<Skill
         skills.push(SkillEntry {
             name,
             description,
-            body,
+            path: skill_md,
         });
     }
 }
@@ -160,6 +153,10 @@ pub fn build_hints_section(cwd: &Path) -> String {
     build_hints_section_impl(cwd, home_dir().as_deref())
 }
 
+pub fn discover_skills(cwd: &Path) -> Vec<SkillEntry> {
+    discover_skills_impl(cwd, home_dir().as_deref())
+}
+
 fn build_hints_section_impl(cwd: &Path, home: Option<&Path>) -> String {
     let hints_text = load_hint_files_impl(cwd, home);
     let skills = discover_skills_impl(cwd, home);
@@ -181,13 +178,9 @@ fn build_hints_section_impl(cwd: &Path, home: Option<&Path>) -> String {
         for skill in &skills {
             out.push_str(&format!("- {}: {}\n", skill.name, skill.description));
         }
-        for skill in &skills {
-            out.push_str(&format!("\n### {}\n", skill.name));
-            out.push_str(&skill.body);
-            if !skill.body.ends_with('\n') {
-                out.push('\n');
-            }
-        }
+        out.push_str(
+            "\nUse the `load_skill` tool to read the full content of a skill before using it.\n",
+        );
     }
 
     out
@@ -304,6 +297,11 @@ mod tests {
         let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
         assert!(names.contains(&"my-skill"), "missing my-skill");
         assert!(names.contains(&"other-skill"), "missing other-skill");
+        // Paths should point to the SKILL.md files.
+        for skill in &skills {
+            assert!(skill.path.exists(), "path does not exist: {:?}", skill.path);
+            assert!(skill.path.ends_with("SKILL.md"));
+        }
     }
 
     #[test]
@@ -334,7 +332,8 @@ mod tests {
             skills[0].description, "from agents",
             "first wins (.agents/)"
         );
-        assert_eq!(skills[0].body.trim(), "Agents body.");
+        // Path should point to the .agents/ version (first wins).
+        assert!(skills[0].path.to_str().unwrap().contains(".agents/skills/shared"));
     }
 
     #[test]
@@ -395,10 +394,20 @@ mod tests {
             result.contains("buzz-cli: CLI reference for Buzz managed agents"),
             "missing skill bullet"
         );
-        assert!(result.contains("### buzz-cli"), "missing skill header");
+        // Body must NOT be inlined — lazy loading only.
         assert!(
-            result.contains("Use `buzz` to manage agents."),
-            "missing skill body"
+            !result.contains("Use `buzz` to manage agents."),
+            "skill body must not be inlined in system prompt"
+        );
+        // The load_skill instruction must be present.
+        assert!(
+            result.contains("load_skill"),
+            "missing load_skill instruction"
+        );
+        // The old ### heading format must not appear.
+        assert!(
+            !result.contains("### buzz-cli"),
+            "skill body heading must not be inlined"
         );
     }
 

--- a/crates/buzz-agent/src/hints.rs
+++ b/crates/buzz-agent/src/hints.rs
@@ -150,12 +150,12 @@ fn scan_skill_dir(dir: &Path, seen: &mut HashSet<String>, skills: &mut Vec<Skill
 /// are treated as separate skills and are not descended into.
 fn collect_supporting_files(skill_dir: &Path) -> Vec<PathBuf> {
     let mut result = Vec::new();
-    collect_supporting_files_impl(skill_dir, skill_dir, &mut result);
+    collect_supporting_files_impl(skill_dir, &mut result);
     result.sort();
     result
 }
 
-fn collect_supporting_files_impl(skill_dir: &Path, current: &Path, out: &mut Vec<PathBuf>) {
+fn collect_supporting_files_impl(current: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(current) else {
         return;
     };
@@ -173,11 +173,9 @@ fn collect_supporting_files_impl(skill_dir: &Path, current: &Path, out: &mut Vec
             if path.join("SKILL.md").is_file() {
                 continue;
             }
-            collect_supporting_files_impl(skill_dir, &path, out);
-        } else if ft.is_file() {
-            if path.file_name().and_then(|n| n.to_str()) != Some("SKILL.md") {
-                out.push(path);
-            }
+            collect_supporting_files_impl(&path, out);
+        } else if ft.is_file() && path.file_name().and_then(|n| n.to_str()) != Some("SKILL.md") {
+            out.push(path);
         }
     }
 }

--- a/crates/buzz-agent/src/hints.rs
+++ b/crates/buzz-agent/src/hints.rs
@@ -17,6 +17,10 @@ pub struct SkillEntry {
     pub description: String,
     /// Absolute path to the SKILL.md file; used by `load_skill` to read on demand.
     pub path: PathBuf,
+    /// Absolute paths to every non-SKILL.md file in the skill directory tree.
+    /// Pre-enumerated at discovery time so `load_skill` can match by relative path
+    /// without doing arbitrary filesystem lookups at call time.
+    pub supporting_files: Vec<PathBuf>,
 }
 
 /// Handles both normal repos (`.git/` dir) and worktrees (`.git` file).
@@ -126,11 +130,55 @@ fn scan_skill_dir(dir: &Path, seen: &mut HashSet<String>, skills: &mut Vec<Skill
             continue;
         }
         seen.insert(name.clone());
+
+        // Collect supporting files: every non-SKILL.md file in the skill dir tree.
+        // Don't descend into subdirs that themselves have a SKILL.md — those are
+        // separate skills with their own entries.
+        let supporting_files = collect_supporting_files(&subdir);
+
         skills.push(SkillEntry {
             name,
             description,
             path: skill_md,
+            supporting_files,
         });
+    }
+}
+
+/// Walk `skill_dir` recursively and return the absolute path of every file
+/// that is not `SKILL.md`. Subdirectories that contain their own `SKILL.md`
+/// are treated as separate skills and are not descended into.
+fn collect_supporting_files(skill_dir: &Path) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    collect_supporting_files_impl(skill_dir, skill_dir, &mut result);
+    result.sort();
+    result
+}
+
+fn collect_supporting_files_impl(skill_dir: &Path, current: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(current) else {
+        return;
+    };
+    let mut items: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+    items.sort_by_key(|e| e.path());
+
+    for entry in items {
+        let path = entry.path();
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if ft.is_dir() {
+            // Don't descend into subdirs that are themselves skills.
+            if path.join("SKILL.md").is_file() {
+                continue;
+            }
+            collect_supporting_files_impl(skill_dir, &path, out);
+        } else if ft.is_file() {
+            if path.file_name().and_then(|n| n.to_str()) != Some("SKILL.md") {
+                out.push(path);
+            }
+        }
     }
 }
 
@@ -530,5 +578,81 @@ mod tests {
         let skills = discover_skills_impl(cwd.path(), None);
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "local");
+    }
+
+    #[test]
+    fn collect_supporting_files_finds_non_skill_md_files() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path();
+        // SKILL.md should be excluded.
+        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: x\n---\n").unwrap();
+        // A references subdir with files.
+        let refs = skill_dir.join("references");
+        std::fs::create_dir_all(&refs).unwrap();
+        std::fs::write(refs.join("foo.md"), "foo").unwrap();
+        std::fs::write(refs.join("bar.md"), "bar").unwrap();
+        // A script at the top level.
+        std::fs::write(skill_dir.join("setup.sh"), "#!/bin/sh").unwrap();
+
+        let files = collect_supporting_files(skill_dir);
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"foo.md".to_owned()), "missing foo.md: {names:?}");
+        assert!(names.contains(&"bar.md".to_owned()), "missing bar.md: {names:?}");
+        assert!(names.contains(&"setup.sh".to_owned()), "missing setup.sh: {names:?}");
+        assert!(!names.contains(&"SKILL.md".to_owned()), "SKILL.md should be excluded: {names:?}");
+    }
+
+    #[test]
+    fn collect_supporting_files_does_not_descend_into_nested_skills() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path();
+        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: x\n---\n").unwrap();
+        std::fs::write(skill_dir.join("helper.sh"), "#!/bin/sh").unwrap();
+
+        // A nested subdir that is itself a skill — should not be descended into.
+        let nested = skill_dir.join("nested-skill");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("SKILL.md"), "---\nname: nested\n---\n").unwrap();
+        std::fs::write(nested.join("secret.md"), "should not appear").unwrap();
+
+        let files = collect_supporting_files(skill_dir);
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"helper.sh".to_owned()), "missing helper.sh: {names:?}");
+        assert!(
+            !names.contains(&"secret.md".to_owned()),
+            "nested skill's files should not appear: {names:?}"
+        );
+    }
+
+    #[test]
+    fn discover_skills_populates_supporting_files() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path();
+        let skill_dir = cwd.join(".agents/skills/with-refs");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: with-refs\ndescription: Has refs\n---\nBody.\n",
+        )
+        .unwrap();
+        let refs = skill_dir.join("references");
+        std::fs::create_dir_all(&refs).unwrap();
+        std::fs::write(refs.join("guide.md"), "guide content").unwrap();
+
+        let skills = discover_skills_impl(cwd, None);
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "with-refs");
+        assert_eq!(skills[0].supporting_files.len(), 1);
+        assert!(
+            skills[0].supporting_files[0].ends_with("references/guide.md"),
+            "unexpected path: {:?}",
+            skills[0].supporting_files[0]
+        );
     }
 }

--- a/crates/buzz-agent/src/hints.rs
+++ b/crates/buzz-agent/src/hints.rs
@@ -197,20 +197,16 @@ fn discover_skills_impl(cwd: &Path, home: Option<&Path>) -> Vec<SkillEntry> {
     skills
 }
 
-pub fn build_hints_section(cwd: &Path) -> String {
+pub fn build_hints_section(cwd: &Path) -> (String, Vec<SkillEntry>) {
     build_hints_section_impl(cwd, home_dir().as_deref())
 }
 
-pub fn discover_skills(cwd: &Path) -> Vec<SkillEntry> {
-    discover_skills_impl(cwd, home_dir().as_deref())
-}
-
-fn build_hints_section_impl(cwd: &Path, home: Option<&Path>) -> String {
+fn build_hints_section_impl(cwd: &Path, home: Option<&Path>) -> (String, Vec<SkillEntry>) {
     let hints_text = load_hint_files_impl(cwd, home);
     let skills = discover_skills_impl(cwd, home);
 
     if hints_text.is_empty() && skills.is_empty() {
-        return String::new();
+        return (String::new(), skills);
     }
 
     let mut out = String::from("# Additional Instructions\n");
@@ -231,7 +227,20 @@ fn build_hints_section_impl(cwd: &Path, home: Option<&Path>) -> String {
         );
     }
 
-    out
+    (out, skills)
+}
+
+/// Strip the YAML frontmatter block from a skill file's content and return
+/// the body. If no valid frontmatter is found, returns the content unchanged.
+pub(crate) fn strip_frontmatter(content: &str) -> &str {
+    let Some(rest) = content.strip_prefix("---\n") else {
+        return content;
+    };
+    let Some(close_pos) = rest.find("\n---") else {
+        return content;
+    };
+    let after = &rest[close_pos + 4..]; // skip "\n---"
+    after.strip_prefix('\n').unwrap_or(after)
 }
 
 #[cfg(test)]
@@ -408,8 +417,9 @@ mod tests {
     #[test]
     fn build_hints_section_empty() {
         let tmp = TempDir::new().unwrap();
-        let result = build_hints_section_impl(tmp.path(), None);
+        let (result, skills) = build_hints_section_impl(tmp.path(), None);
         assert_eq!(result, "");
+        assert!(skills.is_empty());
     }
 
     #[test]
@@ -427,7 +437,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = build_hints_section_impl(cwd, None);
+        let (result, skills) = build_hints_section_impl(cwd, None);
 
         assert!(
             result.contains("# Additional Instructions"),
@@ -461,6 +471,9 @@ mod tests {
             !result.contains("### buzz-cli"),
             "skill body heading must not be inlined"
         );
+        // The returned skills list should contain the discovered skill.
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "buzz-cli");
     }
 
     #[test]

--- a/crates/buzz-agent/src/hints.rs
+++ b/crates/buzz-agent/src/hints.rs
@@ -381,7 +381,11 @@ mod tests {
             "first wins (.agents/)"
         );
         // Path should point to the .agents/ version (first wins).
-        assert!(skills[0].path.to_str().unwrap().contains(".agents/skills/shared"));
+        assert!(skills[0]
+            .path
+            .to_str()
+            .unwrap()
+            .contains(".agents/skills/shared"));
     }
 
     #[test]
@@ -599,10 +603,22 @@ mod tests {
             .iter()
             .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
             .collect();
-        assert!(names.contains(&"foo.md".to_owned()), "missing foo.md: {names:?}");
-        assert!(names.contains(&"bar.md".to_owned()), "missing bar.md: {names:?}");
-        assert!(names.contains(&"setup.sh".to_owned()), "missing setup.sh: {names:?}");
-        assert!(!names.contains(&"SKILL.md".to_owned()), "SKILL.md should be excluded: {names:?}");
+        assert!(
+            names.contains(&"foo.md".to_owned()),
+            "missing foo.md: {names:?}"
+        );
+        assert!(
+            names.contains(&"bar.md".to_owned()),
+            "missing bar.md: {names:?}"
+        );
+        assert!(
+            names.contains(&"setup.sh".to_owned()),
+            "missing setup.sh: {names:?}"
+        );
+        assert!(
+            !names.contains(&"SKILL.md".to_owned()),
+            "SKILL.md should be excluded: {names:?}"
+        );
     }
 
     #[test]
@@ -623,7 +639,10 @@ mod tests {
             .iter()
             .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
             .collect();
-        assert!(names.contains(&"helper.sh".to_owned()), "missing helper.sh: {names:?}");
+        assert!(
+            names.contains(&"helper.sh".to_owned()),
+            "missing helper.sh: {names:?}"
+        );
         assert!(
             !names.contains(&"secret.md".to_owned()),
             "nested skill's files should not appear: {names:?}"

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -271,12 +271,12 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
             .await;
         }
     }
+    let (hints_text, skills) = if app.cfg.hints_enabled {
+        hints::build_hints_section(std::path::Path::new(&p.cwd))
+    } else {
+        (String::new(), Vec::new())
+    };
     let effective_system_prompt: Arc<str> = {
-        let hints = if app.cfg.hints_enabled {
-            hints::build_hints_section(std::path::Path::new(&p.cwd))
-        } else {
-            String::new()
-        };
         // When the harness provides a systemPrompt (base_prompt + persona), use
         // it as the primary content and suppress the default. The default is only
         // a fallback for legacy harnesses that don't send systemPrompt.
@@ -284,10 +284,10 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
             Some(client_prompt) if !client_prompt.trim().is_empty() => client_prompt.to_owned(),
             _ => app.cfg.system_prompt.clone(),
         };
-        let prompt = if hints.is_empty() {
+        let prompt = if hints_text.is_empty() {
             base
         } else {
-            format!("{base}\n\n{hints}")
+            format!("{base}\n\n{hints_text}")
         };
         // Reject combined prompts exceeding 512KB.
         if prompt.len() > MAX_SYSTEM_PROMPT_BYTES {
@@ -304,11 +304,6 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
             .await;
         }
         Arc::from(prompt)
-    };
-    let skills = if app.cfg.hints_enabled {
-        hints::discover_skills(std::path::Path::new(&p.cwd))
-    } else {
-        Vec::new()
     };
     let mcp = match McpRegistry::spawn_all(&app.cfg, &p.mcp_servers, &p.cwd).await {
         Ok(m) => Arc::new(m),

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 mod agent;
 pub mod auth;
+mod builtin;
 mod config;
 mod handoff;
 mod hints;
@@ -19,6 +20,7 @@ use tokio::sync::{mpsc, watch, Mutex};
 
 use crate::agent::RunCtx;
 use crate::config::{Config, MAX_SYSTEM_PROMPT_BYTES, PROTOCOL_VERSION};
+use crate::hints::SkillEntry;
 use crate::llm::Llm;
 use crate::mcp::McpRegistry;
 use crate::types::HistoryItem;
@@ -36,6 +38,8 @@ struct App {
 struct Session {
     id: String,
     mcp: Arc<McpRegistry>,
+    /// Skills discovered at session creation; used by the built-in `load_skill` tool.
+    skills: Vec<SkillEntry>,
     history: Vec<HistoryItem>,
     cancel_tx: watch::Sender<bool>,
     busy: bool,
@@ -301,6 +305,11 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
         }
         Arc::from(prompt)
     };
+    let skills = if app.cfg.hints_enabled {
+        hints::discover_skills(std::path::Path::new(&p.cwd))
+    } else {
+        Vec::new()
+    };
     let mcp = match McpRegistry::spawn_all(&app.cfg, &p.mcp_servers, &p.cwd).await {
         Ok(m) => Arc::new(m),
         Err(e) => return reject(wire_tx, id, e.json_rpc_code(), &e.to_string()).await,
@@ -326,6 +335,7 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
         Session {
             id: session_id.clone(),
             mcp,
+            skills,
             history: Vec::new(),
             cancel_tx,
             busy: false,
@@ -369,6 +379,7 @@ async fn run_prompt(app: Arc<App>, id: Value, params: Value, wire_tx: WireSender
     let (
         sid,
         mcp,
+        skills,
         mut history,
         mut original_task,
         mut handoff_count,
@@ -395,6 +406,7 @@ async fn run_prompt(app: Arc<App>, id: Value, params: Value, wire_tx: WireSender
         system_prompt: &effective_system_prompt,
         llm: &app.llm,
         mcp: &mcp,
+        skills: &skills,
         wire: &wire_tx,
         cancel: &mut cancel_rx,
         history: &mut history,
@@ -433,6 +445,7 @@ async fn acquire_session(
     (
         String,
         Arc<McpRegistry>,
+        Vec<SkillEntry>,
         Vec<HistoryItem>,
         Option<String>,
         usize,
@@ -452,9 +465,13 @@ async fn acquire_session(
     s.busy = true;
     let (tx, rx) = watch::channel(false);
     s.cancel_tx = tx;
+    // Skills are read-only after session creation; clone the Vec so RunCtx
+    // can hold a reference without holding the sessions lock.
+    let skills = s.skills.clone();
     Ok((
         s.id.clone(),
         s.mcp.clone(),
+        skills,
         std::mem::take(&mut s.history),
         s.original_task.take(),
         s.handoff_count,

--- a/crates/buzz-agent/tests/hints_integration.rs
+++ b/crates/buzz-agent/tests/hints_integration.rs
@@ -494,67 +494,8 @@ async fn load_skill_tool_returns_body() {
     });
     let end_turn = openai_text("done");
 
-    let (url, captures) = {
-        use std::collections::VecDeque;
-        use tokio::net::TcpListener;
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let url = format!("http://{}", listener.local_addr().unwrap());
-        let queue = Arc::new(Mutex::new(VecDeque::from(vec![load_skill_call, end_turn])));
-        let captures: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
-        let cap2 = captures.clone();
-        tokio::spawn(async move {
-            loop {
-                let (mut sock, _) = match listener.accept().await {
-                    Ok(p) => p,
-                    Err(_) => return,
-                };
-                let queue = queue.clone();
-                let captured = cap2.clone();
-                tokio::spawn(async move {
-                    let mut buf = Vec::new();
-                    let mut tmp = [0u8; 8192];
-                    while !buf.windows(4).any(|w| w == b"\r\n\r\n") {
-                        match sock.read(&mut tmp).await {
-                            Ok(0) | Err(_) => return,
-                            Ok(n) => buf.extend_from_slice(&tmp[..n]),
-                        }
-                    }
-                    let header_end = buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
-                    let headers = &buf[..header_end];
-                    let mut body_len = 0usize;
-                    for line in headers.split(|b| *b == b'\n') {
-                        let line = std::str::from_utf8(line).unwrap_or("");
-                        if let Some(rest) = line.to_ascii_lowercase().strip_prefix("content-length:") {
-                            body_len = rest.trim().trim_end_matches('\r').parse().unwrap_or(0);
-                        }
-                    }
-                    while buf.len() < header_end + body_len {
-                        match sock.read(&mut tmp).await {
-                            Ok(0) | Err(_) => return,
-                            Ok(n) => buf.extend_from_slice(&tmp[..n]),
-                        }
-                    }
-                    if let Ok(req) = serde_json::from_slice::<Value>(&buf[header_end..]) {
-                        captured.lock().await.push(req);
-                    }
-                    let body = queue.lock().await.pop_front()
-                        .unwrap_or_else(|| json!({"error": "no response"}));
-                    let body_s = serde_json::to_string(&body).unwrap();
-                    let resp = format!(
-                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
-                         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
-                        body_s.len(), body_s,
-                    );
-                    let _ = sock.write_all(resp.as_bytes()).await;
-                    let _ = sock.shutdown().await;
-                });
-            }
-        });
-        (url, captures)
-    };
-
-    let mut h = Harness::spawn_with_env(&url, &[]).await;
+    let llm = spawn_capturing_llm(vec![load_skill_call, end_turn]).await;
+    let mut h = Harness::spawn_with_env(&llm.url, &[]).await;
     let sid = init_session(&mut h, cwd.to_str().unwrap()).await;
 
     let p = h
@@ -566,23 +507,16 @@ async fn load_skill_tool_returns_body() {
     let _ = h.recv_until(|v| v["id"] == json!(p)).await;
 
     // The second LLM request (round 2) should contain the skill body in tool results.
-    let reqs = captures.lock().await;
-    assert!(reqs.len() >= 2, "expected at least 2 LLM requests, got {}", reqs.len());
-    let round2 = &reqs[1];
-    let messages = round2["messages"].as_array().expect("messages array");
-    let tool_result_msg = messages.iter().find(|m| {
-        m["role"] == "tool"
-            || (m["role"] == "user"
-                && m["content"].as_array().map_or(false, |arr| {
-                    arr.iter().any(|c| c["type"] == "tool_result")
-                }))
-    });
-    // The body must appear somewhere in the second request's messages.
-    let round2_str = serde_json::to_string(round2).unwrap();
+    let reqs = llm.captured.lock().await;
+    assert!(
+        reqs.len() >= 2,
+        "expected at least 2 LLM requests, got {}",
+        reqs.len()
+    );
+    let round2_str = serde_json::to_string(&reqs[1]).unwrap();
     assert!(
         round2_str.contains("SKILL_BODY_CONTENT_99"),
         "load_skill result must contain skill body in round 2 request.\nGot: {round2_str}"
     );
-    drop(tool_result_msg); // suppress unused warning
     h.shutdown().await;
 }

--- a/crates/buzz-agent/tests/hints_integration.rs
+++ b/crates/buzz-agent/tests/hints_integration.rs
@@ -248,7 +248,8 @@ async fn hints_suppressed_with_env_var() {
     h.shutdown().await;
 }
 
-/// SKILL.md files in .agents/skills/ are loaded into the system prompt.
+/// SKILL.md files in .agents/skills/ are loaded into the system prompt as metadata only.
+/// The body is NOT inlined; the agent uses `load_skill` to fetch it on demand.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn skills_loaded_from_agents_skills_dir() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -276,13 +277,20 @@ async fn skills_loaded_from_agents_skills_dir() {
     let captured = llm.captured.lock().await;
     assert!(!captured.is_empty(), "no LLM request captured");
     let system = captured[0]["messages"][0]["content"].as_str().unwrap_or("");
+    // Skill name must appear in the metadata listing.
     assert!(
         system.contains("test-skill"),
         "system prompt missing skill name: {system}"
     );
+    // Body must NOT be inlined — lazy loading only.
     assert!(
-        system.contains("SKILL_BODY_MARKER_77"),
-        "system prompt missing skill body: {system}"
+        !system.contains("SKILL_BODY_MARKER_77"),
+        "skill body must not be inlined in system prompt: {system}"
+    );
+    // The load_skill instruction must be present.
+    assert!(
+        system.contains("load_skill"),
+        "system prompt missing load_skill instruction: {system}"
     );
     h.shutdown().await;
 }
@@ -372,6 +380,7 @@ async fn global_agents_md_loaded() {
 }
 
 /// Global skills from ~/.agents/skills/ are loaded; project-level wins on name conflict.
+/// Bodies are NOT inlined — only metadata (name + description) appears in the system prompt.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn global_skills_loaded_and_project_wins() {
     let home_tmp = tempfile::TempDir::new().unwrap();
@@ -417,21 +426,163 @@ async fn global_skills_loaded_and_project_wins() {
     let captured = llm.captured.lock().await;
     assert!(!captured.is_empty(), "no LLM request captured");
     let system = captured[0]["messages"][0]["content"].as_str().unwrap_or("");
+    // Both skill names must appear in the metadata listing.
     assert!(
         system.contains("global-only"),
         "system prompt missing global-only skill name: {system}"
     );
     assert!(
-        system.contains("GLOBAL_SKILL_BODY_88"),
-        "system prompt missing global-only skill body: {system}"
+        system.contains("shared-name"),
+        "system prompt missing shared-name skill: {system}"
+    );
+    // Project description wins over global for the shared name.
+    assert!(
+        system.contains("Project version"),
+        "system prompt should show project description for shared-name: {system}"
     );
     assert!(
-        system.contains("PROJECT_SHARED_BODY_WIN"),
-        "system prompt missing project skill body: {system}"
+        !system.contains("Global version"),
+        "system prompt should NOT show global description for shared-name: {system}"
+    );
+    // Bodies must NOT be inlined.
+    assert!(
+        !system.contains("GLOBAL_SKILL_BODY_88"),
+        "skill body must not be inlined: {system}"
+    );
+    assert!(
+        !system.contains("PROJECT_SHARED_BODY_WIN"),
+        "skill body must not be inlined: {system}"
     );
     assert!(
         !system.contains("GLOBAL_SHARED_BODY_LOSE"),
-        "system prompt should NOT contain shadowed global skill body: {system}"
+        "shadowed skill body must not be inlined: {system}"
     );
+    h.shutdown().await;
+}
+
+/// `load_skill` tool is advertised when skills exist, and returns the skill body.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_skill_tool_returns_body() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let cwd = tmp.path();
+    let skill_dir = cwd.join(".agents/skills/my-skill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: my-skill\ndescription: A skill\n---\nSKILL_BODY_CONTENT_99\n",
+    )
+    .unwrap();
+
+    // Round 1: LLM calls load_skill("my-skill").
+    // Round 2: LLM returns end_turn after seeing the body.
+    let load_skill_call = json!({
+        "id": "cc-ls", "object": "chat.completion", "model": "fake-model",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant", "content": null,
+                "tool_calls": [{
+                    "id": "tc-1", "type": "function",
+                    "function": {
+                        "name": "load_skill",
+                        "arguments": "{\"name\":\"my-skill\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    });
+    let end_turn = openai_text("done");
+
+    let (url, captures) = {
+        use std::collections::VecDeque;
+        use tokio::net::TcpListener;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let queue = Arc::new(Mutex::new(VecDeque::from(vec![load_skill_call, end_turn])));
+        let captures: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let cap2 = captures.clone();
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = match listener.accept().await {
+                    Ok(p) => p,
+                    Err(_) => return,
+                };
+                let queue = queue.clone();
+                let captured = cap2.clone();
+                tokio::spawn(async move {
+                    let mut buf = Vec::new();
+                    let mut tmp = [0u8; 8192];
+                    while !buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                        match sock.read(&mut tmp).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                        }
+                    }
+                    let header_end = buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+                    let headers = &buf[..header_end];
+                    let mut body_len = 0usize;
+                    for line in headers.split(|b| *b == b'\n') {
+                        let line = std::str::from_utf8(line).unwrap_or("");
+                        if let Some(rest) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                            body_len = rest.trim().trim_end_matches('\r').parse().unwrap_or(0);
+                        }
+                    }
+                    while buf.len() < header_end + body_len {
+                        match sock.read(&mut tmp).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                        }
+                    }
+                    if let Ok(req) = serde_json::from_slice::<Value>(&buf[header_end..]) {
+                        captured.lock().await.push(req);
+                    }
+                    let body = queue.lock().await.pop_front()
+                        .unwrap_or_else(|| json!({"error": "no response"}));
+                    let body_s = serde_json::to_string(&body).unwrap();
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body_s.len(), body_s,
+                    );
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                    let _ = sock.shutdown().await;
+                });
+            }
+        });
+        (url, captures)
+    };
+
+    let mut h = Harness::spawn_with_env(&url, &[]).await;
+    let sid = init_session(&mut h, cwd.to_str().unwrap()).await;
+
+    let p = h
+        .send(
+            "session/prompt",
+            json!({"sessionId": sid, "prompt": [{"type":"text","text":"use my-skill"}]}),
+        )
+        .await;
+    let _ = h.recv_until(|v| v["id"] == json!(p)).await;
+
+    // The second LLM request (round 2) should contain the skill body in tool results.
+    let reqs = captures.lock().await;
+    assert!(reqs.len() >= 2, "expected at least 2 LLM requests, got {}", reqs.len());
+    let round2 = &reqs[1];
+    let messages = round2["messages"].as_array().expect("messages array");
+    let tool_result_msg = messages.iter().find(|m| {
+        m["role"] == "tool"
+            || (m["role"] == "user"
+                && m["content"].as_array().map_or(false, |arr| {
+                    arr.iter().any(|c| c["type"] == "tool_result")
+                }))
+    });
+    // The body must appear somewhere in the second request's messages.
+    let round2_str = serde_json::to_string(round2).unwrap();
+    assert!(
+        round2_str.contains("SKILL_BODY_CONTENT_99"),
+        "load_skill result must contain skill body in round 2 request.\nGot: {round2_str}"
+    );
+    drop(tool_result_msg); // suppress unused warning
     h.shutdown().await;
 }

--- a/crates/buzz-agent/tests/regressions.rs
+++ b/crates/buzz-agent/tests/regressions.rs
@@ -689,8 +689,13 @@ async fn description_clamping_enforced() {
 
     let captured = llm.captured.lock().await;
     let tools = captured[0]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 1);
-    let desc = tools[0]["function"]["description"].as_str().unwrap_or("");
+    // The MCP tool is "big__tool_0"; load_skill may also be present when
+    // global skills are discovered from HOME. Find the MCP tool by name.
+    let mcp_tool = tools
+        .iter()
+        .find(|t| t["function"]["name"].as_str() == Some("big__tool_0"))
+        .expect("big__tool_0 not found in tool list");
+    let desc = mcp_tool["function"]["description"].as_str().unwrap_or("");
     assert!(
         desc.len() <= 1024,
         "description not clamped: {} bytes (expected ≤ 1024)",


### PR DESCRIPTION
## What

buzz-agent was inlining full SKILL.md bodies (up to 32 KiB each) into the system prompt at session start. With 76 skills that's up to 2.4 MiB. This PR adopts Goose's model: metadata-only injection at session start, then a `load_skill` built-in tool for on-demand body loading.

## Changes

**`hints.rs`**: `build_hints_section` now emits metadata-only (`- name: description` bullets + `load_skill` instruction) and returns `(String, Vec<SkillEntry>)` so callers get both the hints string and the discovered skills from a single filesystem scan. `SkillEntry` drops `body`, gains `path` (absolute path to SKILL.md) and `supporting_files` (pre-enumerated non-SKILL.md files in the skill directory). Body is never read at session start. Shared `strip_frontmatter` helper extracted here and imported by `builtin.rs`.

**`builtin.rs`**: `load_skill` built-in tool with two forms matching Goose:
- `load_skill(name: "skill-name")` — reads SKILL.md from disk via `tokio::task::spawn_blocking`, strips frontmatter, appends `## Supporting Files` section listing available files with `load_skill` hints, then applies 32 KiB cap to the full output
- `load_skill(name: "skill-name/references/foo.md")` — loads a specific supporting file (also via `spawn_blocking`), matched against the pre-enumerated list (not raw filesystem), with `canonicalize` + `starts_with` traversal guard that returns a hard error on failure

**`agent.rs`/`lib.rs`**: `load_skill` injected into LLM tool list when skills present; dispatched inline in `execute_calls` (async `.await`). `lib.rs` destructures the single `build_hints_section` call — no separate `discover_skills` call. Skills stored on `Session` (`Vec<SkillEntry>`), cloned into `RunCtx` per prompt.

## Alignment with Goose

Verified against `~/Development/goose/crates/goose/src/skills/`:
- `get_instructions()` → our `build_hints_section`: metadata-only bullets
- `load_skill` tool name, `name` parameter, required-field schema
- Frontmatter stripping, 32 KiB cap applied to full output (body + Supporting Files section)
- Supporting-file discovery (walk skill dir, skip nested skills), pre-enumeration, slash-form dispatch, traversal guard
- `## Supporting Files` section format with relative paths only (no absolute path leakage)

Intentional scope reductions: no `args` template substitution (buzz-agent doesn't need it).

## Files changed

- `crates/buzz-agent/src/hints.rs` — `SkillEntry` gains `supporting_files`; `build_hints_section` returns `(String, Vec<SkillEntry>)`; shared `strip_frontmatter` extracted as `pub(crate)`; `collect_supporting_files` helper
- `crates/buzz-agent/src/builtin.rs` — async `load_skill` tool with both forms, `spawn_blocking` for all filesystem I/O, traversal guard (hard error on canonicalize failure), Supporting Files section with relative paths
- `crates/buzz-agent/src/agent.rs` — injects `load_skill` into tool list, dispatches inline with `.await`
- `crates/buzz-agent/src/lib.rs` — destructures single `build_hints_section` call, stores skills on `Session`, passes to `RunCtx`
- `crates/buzz-agent/tests/hints_integration.rs` — updated + `load_skill_tool_returns_body` test using `spawn_capturing_llm`
- `crates/buzz-agent/tests/regressions.rs` — `description_clamping_enforced` updated

## Tests

162 tests passing. Coverage includes: supporting file discovery, `load_skill` both forms, not-found errors, traversal guard rejection, `## Supporting Files` section presence/absence, and truncation of bodies exceeding 32 KiB.