### PR TITLE
fix(buzz-acp): inject Codex network allowlist for relay hostname at spawn time

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -524,9 +524,13 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
 /// a domain allowlist. Without this, `buzz-cli` requests to the relay are blocked before
 /// they reach WARP or any other outbound network path.
 ///
-/// Returns `["-c", "network.enabled=true", "-c", "network.allowed_domains=[\"<host>\"]"]`
+/// Returns `["-c", "network_proxy.mode=\"full\"", "-c", "network_proxy.domains.\"<host>\"=\"allow\""]`
 /// for Codex agents, or an empty vec for non-Codex agents or when the hostname cannot
 /// be parsed from the relay URL.
+///
+/// The `network_proxy` keys map to `NetworkProxyConfigToml` in codex-acp's config schema:
+/// - `network_proxy.mode="full"` enables the managed proxy for all outbound traffic
+/// - `network_proxy.domains."<host>"="allow"` adds the relay hostname to the allowlist
 ///
 /// Handles `ws://`, `wss://`, `http://`, and `https://` schemes. Port is stripped —
 /// Codex's domain allowlist matches on hostname only.
@@ -556,9 +560,9 @@ pub fn codex_network_args(agent_command: &str, relay_url: &str) -> Vec<String> {
 
     vec![
         "-c".into(),
-        "network.enabled=true".into(),
+        "network_proxy.mode=\"full\"".into(),
         "-c".into(),
-        format!("network.allowed_domains=[\"{host}\"]"),
+        format!("network_proxy.domains.\"{host}\"=\"allow\""),
     ]
 }
 
@@ -1424,9 +1428,9 @@ mod tests {
             args,
             vec![
                 "-c",
-                "network.enabled=true",
+                "network_proxy.mode=\"full\"",
                 "-c",
-                "network.allowed_domains=[\"sprout-oss.stage.blox.sqprod.co\"]",
+                "network_proxy.domains.\"sprout-oss.stage.blox.sqprod.co\"=\"allow\"",
             ]
         );
     }
@@ -1438,9 +1442,9 @@ mod tests {
             args,
             vec![
                 "-c",
-                "network.enabled=true",
+                "network_proxy.mode=\"full\"",
                 "-c",
-                "network.allowed_domains=[\"localhost\"]",
+                "network_proxy.domains.\"localhost\"=\"allow\"",
             ]
         );
     }
@@ -1452,9 +1456,9 @@ mod tests {
             args,
             vec![
                 "-c",
-                "network.enabled=true",
+                "network_proxy.mode=\"full\"",
                 "-c",
-                "network.allowed_domains=[\"relay.example.com\"]",
+                "network_proxy.domains.\"relay.example.com\"=\"allow\"",
             ]
         );
     }
@@ -1466,9 +1470,9 @@ mod tests {
             args,
             vec![
                 "-c",
-                "network.enabled=true",
+                "network_proxy.mode=\"full\"",
                 "-c",
-                "network.allowed_domains=[\"relay.example.com\"]",
+                "network_proxy.domains.\"relay.example.com\"=\"allow\"",
             ]
         );
     }
@@ -1481,9 +1485,9 @@ mod tests {
             args,
             vec![
                 "-c",
-                "network.enabled=true",
+                "network_proxy.mode=\"full\"",
                 "-c",
-                "network.allowed_domains=[\"relay.example.com\"]",
+                "network_proxy.domains.\"relay.example.com\"=\"allow\"",
             ]
         );
     }
@@ -1497,9 +1501,9 @@ mod tests {
             args,
             vec![
                 "-c",
-                "network.enabled=true",
+                "network_proxy.mode=\"full\"",
                 "-c",
-                "network.allowed_domains=[\"relay.example.com\"]",
+                "network_proxy.domains.\"relay.example.com\"=\"allow\"",
             ]
         );
     }

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -546,7 +546,10 @@ pub fn codex_network_args(agent_command: &str, relay_url: &str) -> Vec<String> {
         Ok(u) => match u.host_str() {
             Some(h) => h.to_owned(),
             None => {
-                tracing::warn!(relay_url, "codex network allowlist: no host in relay URL — skipping injection");
+                tracing::warn!(
+                    relay_url,
+                    "codex network allowlist: no host in relay URL — skipping injection"
+                );
                 return vec![];
             }
         },
@@ -1495,8 +1498,7 @@ mod tests {
     #[test]
     fn codex_network_args_full_path_codex_command() {
         // Full path like /usr/local/bin/codex-acp should be normalized.
-        let args =
-            codex_network_args("/usr/local/bin/codex-acp", "wss://relay.example.com");
+        let args = codex_network_args("/usr/local/bin/codex-acp", "wss://relay.example.com");
         assert_eq!(
             args,
             vec![

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -517,6 +517,48 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     }
 }
 
+/// Build `-c` flag pairs that allowlist the relay hostname in Codex's network sandbox.
+///
+/// Codex sandboxes MCP subprocesses (including `buzz-cli`) behind a local proxy with
+/// a domain allowlist. Without this, `buzz-cli` requests to the relay are blocked before
+/// they reach WARP or any other outbound network path.
+///
+/// Returns `["-c", "network.enabled=true", "-c", "network.allowed_domains=[\"<host>\"]"]`
+/// for Codex agents, or an empty vec for non-Codex agents or when the hostname cannot
+/// be parsed from the relay URL.
+///
+/// Handles `ws://`, `wss://`, `http://`, and `https://` schemes. Port is stripped —
+/// Codex's domain allowlist matches on hostname only.
+pub fn codex_network_args(agent_command: &str, relay_url: &str) -> Vec<String> {
+    match normalize_agent_command_identity(agent_command).as_str() {
+        "codex" | "codex-acp" => {}
+        _ => return vec![],
+    }
+
+    // Strip scheme prefix, then take only the authority (before the first '/'),
+    // then strip the port suffix. Handles ws://, wss://, http://, https://.
+    let without_scheme = relay_url
+        .trim_start_matches("wss://")
+        .trim_start_matches("ws://")
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+
+    let authority = without_scheme.split('/').next().unwrap_or("");
+    // Strip port (e.g. "example.com:3000" → "example.com").
+    let host = authority.split(':').next().unwrap_or("").trim();
+
+    if host.is_empty() {
+        return vec![];
+    }
+
+    vec![
+        "-c".into(),
+        "network.enabled=true".into(),
+        "-c".into(),
+        format!("network.allowed_domains=[\"{host}\"]"),
+    ]
+}
+
 pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
     let normalized = agent_args
         .into_iter()
@@ -645,7 +687,16 @@ impl Config {
             ));
         }
 
-        let agent_args = normalize_agent_args(&agent_command, args.agent_args);
+        let mut agent_args = normalize_agent_args(&agent_command, args.agent_args);
+
+        // Prepend Codex network allowlist flags so buzz-cli (an MCP subprocess)
+        // can reach the relay through Codex's sandbox proxy. No-op for non-Codex agents.
+        let network_args = codex_network_args(&agent_command, &args.relay_url);
+        if !network_args.is_empty() {
+            let mut merged = network_args;
+            merged.extend(agent_args);
+            agent_args = merged;
+        }
 
         // Finding #49b — warn on invalid UUIDs in --channels.
         if let Some(ref channels) = args.channels {
@@ -1359,6 +1410,116 @@ mod tests {
             normalize_agent_args("codex-acp", vec!["ACP".into()]),
             Vec::<String>::new()
         );
+    }
+
+    // --- codex_network_args tests ---
+
+    #[test]
+    fn codex_network_args_wss_url() {
+        let args = codex_network_args("codex-acp", "wss://sprout-oss.stage.blox.sqprod.co");
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "network.enabled=true",
+                "-c",
+                "network.allowed_domains=[\"sprout-oss.stage.blox.sqprod.co\"]",
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_network_args_ws_url() {
+        let args = codex_network_args("codex-acp", "ws://localhost:3000");
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "network.enabled=true",
+                "-c",
+                "network.allowed_domains=[\"localhost\"]",
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_network_args_https_url() {
+        let args = codex_network_args("codex-acp", "https://relay.example.com/path");
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "network.enabled=true",
+                "-c",
+                "network.allowed_domains=[\"relay.example.com\"]",
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_network_args_http_url_with_port() {
+        let args = codex_network_args("codex-acp", "http://relay.example.com:8080/query");
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "network.enabled=true",
+                "-c",
+                "network.allowed_domains=[\"relay.example.com\"]",
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_network_args_bare_codex_command() {
+        // "codex" (not "codex-acp") should also get the args.
+        let args = codex_network_args("codex", "wss://relay.example.com");
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "network.enabled=true",
+                "-c",
+                "network.allowed_domains=[\"relay.example.com\"]",
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_network_args_full_path_codex_command() {
+        // Full path like /usr/local/bin/codex-acp should be normalized.
+        let args =
+            codex_network_args("/usr/local/bin/codex-acp", "wss://relay.example.com");
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "network.enabled=true",
+                "-c",
+                "network.allowed_domains=[\"relay.example.com\"]",
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_network_args_non_codex_agent_returns_empty() {
+        assert!(codex_network_args("goose", "wss://relay.example.com").is_empty());
+        assert!(codex_network_args("claude-agent-acp", "wss://relay.example.com").is_empty());
+        assert!(codex_network_args("buzz-agent", "wss://relay.example.com").is_empty());
+    }
+
+    #[test]
+    fn codex_network_args_empty_relay_url_returns_empty() {
+        assert!(codex_network_args("codex-acp", "").is_empty());
+    }
+
+    #[test]
+    fn codex_network_args_schemeless_string_extracts_as_host() {
+        // A bare string with no scheme is treated as the host — no panic, no empty result.
+        // This is an edge case; real relay URLs always have a scheme.
+        let args = codex_network_args("codex-acp", "not-a-url");
+        assert_eq!(args.len(), 4);
+        assert!(args[3].contains("not-a-url"));
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use nostr::Keys;
 use thiserror::Error;
+use url::Url;
 use uuid::Uuid;
 
 use crate::filter::SubscriptionRule;
@@ -535,21 +536,23 @@ pub fn codex_network_args(agent_command: &str, relay_url: &str) -> Vec<String> {
         _ => return vec![],
     }
 
-    // Strip scheme prefix, then take only the authority (before the first '/'),
-    // then strip the port suffix. Handles ws://, wss://, http://, https://.
-    let without_scheme = relay_url
-        .trim_start_matches("wss://")
-        .trim_start_matches("ws://")
-        .trim_start_matches("https://")
-        .trim_start_matches("http://");
+    // Use the `url` crate so ws://, wss://, http://, https:// are all handled
+    // correctly. On parse failure, skip injection rather than panicking.
+    let host = match Url::parse(relay_url) {
+        Ok(u) => match u.host_str() {
+            Some(h) => h.to_owned(),
+            None => {
+                tracing::warn!(relay_url, "codex network allowlist: no host in relay URL — skipping injection");
+                return vec![];
+            }
+        },
+        Err(e) => {
+            tracing::warn!(relay_url, error = %e, "codex network allowlist: failed to parse relay URL — skipping injection");
+            return vec![];
+        }
+    };
 
-    let authority = without_scheme.split('/').next().unwrap_or("");
-    // Strip port (e.g. "example.com:3000" → "example.com").
-    let host = authority.split(':').next().unwrap_or("").trim();
-
-    if host.is_empty() {
-        return vec![];
-    }
+    tracing::debug!(host, "injecting codex network allowlist for host");
 
     vec![
         "-c".into(),
@@ -1510,16 +1513,14 @@ mod tests {
 
     #[test]
     fn codex_network_args_empty_relay_url_returns_empty() {
+        // Empty string fails Url::parse — graceful empty return.
         assert!(codex_network_args("codex-acp", "").is_empty());
     }
 
     #[test]
-    fn codex_network_args_schemeless_string_extracts_as_host() {
-        // A bare string with no scheme is treated as the host — no panic, no empty result.
-        // This is an edge case; real relay URLs always have a scheme.
-        let args = codex_network_args("codex-acp", "not-a-url");
-        assert_eq!(args.len(), 4);
-        assert!(args[3].contains("not-a-url"));
+    fn codex_network_args_schemeless_string_returns_empty() {
+        // A bare string with no scheme fails Url::parse — graceful empty return.
+        assert!(codex_network_args("codex-acp", "not-a-url").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Codex sandboxes MCP subprocesses (including `buzz-cli`) behind a local proxy (`127.0.0.1:3128`) with a domain allowlist. When `buzz-acp` spawns `codex-acp`, `buzz-cli` requests to the relay are blocked before they reach WARP or any other outbound path — because the relay hostname isn't in Codex's allowlist.

```
{"error":"network_error","message":"network error: error sending request for url (https://sprout-oss.stage.blox.sqprod.co/query)"}
```

## Fix

When `buzz-acp` spawns a Codex agent, parse the relay hostname from `BUZZ_RELAY_URL` and prepend `-c` flag pairs to the agent args that configure Codex's network proxy to allow that hostname:

```
-c network_proxy.mode="full"
-c network_proxy.domains."<host>"="allow"
```

These keys map to `NetworkProxyConfigToml` in codex-acp's config schema — `mode="full"` enables the managed proxy for all outbound traffic, and `domains` is the per-hostname allowlist map.

## Implementation

**`crates/buzz-acp/src/config.rs`**

- Add `codex_network_args(agent_command, relay_url) -> Vec<String>` — uses `url::Url::parse()` to extract the hostname (handles `ws://`, `wss://`, `http://`, `https://`; port stripped automatically). On parse failure, logs a warning and returns empty rather than panicking. Logs `tracing::debug!` at injection time for version-coupling diagnosability.
- In `Config::from_cli()`, prepend the result to `agent_args` after `normalize_agent_args()`. Single injection point — all spawn paths (initial, respawn, refill) pick up the flags automatically with no changes to `lib.rs`.
- No new dependencies — `url` crate was already a workspace dep in `buzz-acp/Cargo.toml`.

## Tests

9 unit tests covering:
- `wss://` relay URL (production case — the failing scenario)
- `ws://` with port (local dev default)
- `https://` with path
- `http://` with port and path
- Bare `codex` command (not just `codex-acp`)
- Full path command (`/usr/local/bin/codex-acp`)
- Non-Codex agents return empty (goose, claude-agent-acp, buzz-agent)
- Empty relay URL returns empty (parse failure → graceful skip)
- Schemeless string returns empty (parse failure → graceful skip)

## Note on spike confirmation

The `network_proxy` key format was confirmed via binary analysis of `codex-acp` v0.15.0 by Thufir — `NetworkProxyConfigToml` struct fields are visible in the binary. A live end-to-end session confirmation (relay request succeeds through the sandbox) has not been run. If that is a hard gate before merge, flag it.