### PR TITLE
chore(ci): remove broken Microsoft apt sources before apt-get update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,13 @@ jobs:
         with:
           workspaces: desktop/src-tauri
           save-if: ${{ github.event_name != 'pull_request' }}
+      - name: Remove broken Microsoft apt sources
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list \
+                     /etc/apt/sources.list.d/packages.microsoft.com.list
+          sudo rm -f /etc/apt/trusted.gpg.d/microsoft.gpg \
+                     /etc/apt/trusted.gpg.d/microsoft-prod.gpg
       - name: Install Tauri dependencies (Linux)
         env:
           DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,6 +463,13 @@ jobs:
           workspaces: desktop/src-tauri
           lookup-only: true
 
+      - name: Remove broken Microsoft apt sources
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list \
+                     /etc/apt/sources.list.d/packages.microsoft.com.list
+          sudo rm -f /etc/apt/trusted.gpg.d/microsoft.gpg \
+                     /etc/apt/trusted.gpg.d/microsoft-prod.gpg
       - name: Install Tauri dependencies (Linux)
         env:
           DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
GitHub-hosted Ubuntu 24.04 runners include Microsoft package repos (`azure-cli`, `packages.microsoft.com/ubuntu/24.04/prod`) in their default apt sources. These repos intermittently return 403 Forbidden, causing `apt-get update` to fail with exit code 100 even though none of our dependencies come from those repos.

This was the root cause of the Desktop Core failure on main after #1256 merged.

Add a step before "Install Tauri dependencies (Linux)" in both `ci.yml` and `release.yml` that removes the Microsoft source list files and their signing keys before running `apt-get update`.