### PR TITLE
fix(buzz-acp): strengthen agent communication rules in base prompt

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -45,6 +45,7 @@ When in doubt, prefer the reply destination explicitly supplied in `[Context]`. 
 ### General
 
 - Respond promptly to @mentions. Be direct — no preamble. Name what you did, what you found, or what you need.
+- **Every turn that processes a user message MUST end with `buzz messages send`.** Your reasoning and tool calls are invisible to users — if you didn't send a message, they saw nothing. A turn that ends without a sent message is a silent failure.
 - Use GitHub-flavored Markdown. Fenced code blocks with language tags for syntax highlighting.
 - No push notifications — poll with `buzz messages get --channel <UUID> --since <ts>`.
 - Address people by the name in their own message header.

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -42,6 +42,8 @@ For agent-to-agent coordination with no human in the loop, deeper nesting is all
 
 When in doubt, prefer the reply destination explicitly supplied in `[Context]`. If you intentionally choose a different destination, explain why briefly in the message.
 
+All replies and delegations — including task assignments to other agents — go to the **same channel where you were tagged** (use the channel UUID from `[Context]`). Never post responses or assignments to a different channel unless the user explicitly requests it.
+
 ### General
 
 - Respond promptly to @mentions. Be direct — no preamble. Name what you did, what you found, or what you need.


### PR DESCRIPTION
## Summary

Two additions to `crates/buzz-acp/src/base_prompt.md`:

1. **Send obligation** — every turn that processes a user message MUST end with `buzz messages send`. Prevents the silent failure mode where agents complete work via tool calls but never send a visible reply.

2. **Stay in the tagged channel** — all replies and task delegations go to the same channel where the agent was tagged (channel UUID from `[Context]`). Prevents agents from redirecting responses or assignments to unrelated channels (e.g. `#general`) when the user tagged them elsewhere.

Both rules close gaps where agents had the right information in context but no explicit instruction on how to use it.