### PR TITLE
fix(read-state): enforce byte-budget eviction in currentContexts()

### DIFF
--- a/desktop/src/features/channels/readState/readStateFormat.ts
+++ b/desktop/src/features/channels/readState/readStateFormat.ts
@@ -10,6 +10,12 @@ export const READ_STATE_HORIZON_SECONDS = 7 * 24 * 60 * 60;
 
 export const MAX_CONTEXTS = 10_000;
 
+// Maximum plaintext byte length for the JSON blob passed to nip44EncryptToSelf.
+// NIP-44 v2 hard-caps plaintext at 65,535 bytes; the relay enforces a 256 KB
+// content limit. 32 KB gives ample headroom for NIP-44 overhead (~1.4×
+// expansion to ~45 KB ciphertext) while keeping the blob well under both caps.
+export const READ_STATE_MAX_PLAINTEXT_BYTES = 32_768;
+
 // Context-key prefix for a per-MESSAGE read marker (LP4 v3). One grow-only
 // marker per reply id; the badge predicate reads effective("msg:<id>") live so
 // reading an ancestor never covers a descendant (Issue 2 by construction).

--- a/desktop/src/features/channels/readState/readStateManager.test.mjs
+++ b/desktop/src/features/channels/readState/readStateManager.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   applyRemoteContextTimestamp,
   resolveEffectiveTimestamp,
+  trimContextsToBudget,
 } from "./readStateManager.ts";
 
 const threadKey = `thread:${"a".repeat(64)}`;
@@ -144,4 +145,101 @@ test("applyRemoteContextTimestamp keeps read markers monotonic even if sync even
   assert.equal(result, "advanced");
   assert.equal(effectiveState.get("channel-1"), 200);
   assert.equal(contextSourceCreatedAt.get("channel-1"), 11);
+});
+
+// ── trimContextsToBudget ──────────────────────────────────────────────────────
+
+const CLIENT_ID = "test-client-id";
+const MSG_ID = "a".repeat(64);
+const THREAD_ID = "b".repeat(64);
+
+test("trimContextsToBudget_underBudget_returnsZeroAndLeavesContextsUnchanged", () => {
+  const contexts = { [`msg:${MSG_ID}`]: 100 };
+  // A very large budget — nothing should be evicted.
+  const evicted = trimContextsToBudget(contexts, CLIENT_ID, 1_000_000);
+  assert.equal(evicted, 0);
+  assert.ok(`msg:${MSG_ID}` in contexts);
+});
+
+test("trimContextsToBudget_overBudget_evictsMsgEntriesOldestFirst", () => {
+  // Build a contexts map that exceeds a tiny budget.
+  // Three msg entries with timestamps 1 (oldest), 2, 3 (newest).
+  const contexts = {
+    [`msg:${MSG_ID}`]: 1,
+    [`msg:${"c".repeat(64)}`]: 3,
+    [`msg:${"d".repeat(64)}`]: 2,
+  };
+  const encoder = new TextEncoder();
+  const fullSize = encoder.encode(
+    JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
+  ).length;
+  // Budget that requires evicting at least one entry.
+  const budget = fullSize - 10;
+
+  const evicted = trimContextsToBudget(contexts, CLIENT_ID, budget);
+  assert.ok(evicted >= 1, `expected at least 1 eviction, got ${evicted}`);
+  // The oldest entry (ts=1) must be gone.
+  assert.ok(!(`msg:${MSG_ID}` in contexts), "oldest msg entry should be evicted");
+  // Result must fit within budget.
+  const resultSize = encoder.encode(
+    JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
+  ).length;
+  assert.ok(resultSize <= budget, `result ${resultSize} exceeds budget ${budget}`);
+});
+
+test("trimContextsToBudget_channelKeysNeverEvicted", () => {
+  // Fill with msg entries plus one channel key; budget forces eviction.
+  const contexts = {};
+  for (let i = 0; i < 50; i++) {
+    contexts[`msg:${i.toString().padStart(64, "0")}`] = i;
+  }
+  contexts["channel:some-channel-id"] = 999;
+
+  const encoder = new TextEncoder();
+  const fullSize = encoder.encode(
+    JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
+  ).length;
+  const budget = Math.floor(fullSize / 2);
+
+  trimContextsToBudget(contexts, CLIENT_ID, budget);
+
+  // Channel key must survive regardless of how many msg entries were evicted.
+  assert.ok("channel:some-channel-id" in contexts, "channel key must not be evicted");
+  const resultSize = encoder.encode(
+    JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
+  ).length;
+  assert.ok(resultSize <= budget, `result ${resultSize} exceeds budget ${budget}`);
+});
+
+test("trimContextsToBudget_msgEvictedBeforeThread", () => {
+  // One msg entry (older) and one thread entry (newer).
+  // Budget forces exactly one eviction; msg must go first.
+  const contexts = {
+    [`msg:${MSG_ID}`]: 1,
+    [`thread:${THREAD_ID}`]: 2,
+  };
+  const encoder = new TextEncoder();
+  const fullSize = encoder.encode(
+    JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
+  ).length;
+  // Tight budget: remove exactly one entry.
+  const oneEntrySize = encoder.encode(
+    JSON.stringify({
+      v: 1,
+      client_id: CLIENT_ID,
+      contexts: { [`thread:${THREAD_ID}`]: 2 },
+    }),
+  ).length;
+  const budget = oneEntrySize + 5; // fits one entry, not two
+
+  const evicted = trimContextsToBudget(contexts, CLIENT_ID, budget);
+  assert.equal(evicted, 1);
+  assert.ok(!(`msg:${MSG_ID}` in contexts), "msg entry should be evicted before thread");
+  assert.ok(`thread:${THREAD_ID}` in contexts, "thread entry should survive");
+});
+
+test("trimContextsToBudget_emptyContexts_returnsZero", () => {
+  const contexts = {};
+  const evicted = trimContextsToBudget(contexts, CLIENT_ID, 100);
+  assert.equal(evicted, 0);
 });

--- a/desktop/src/features/channels/readState/readStateManager.test.mjs
+++ b/desktop/src/features/channels/readState/readStateManager.test.mjs
@@ -156,8 +156,9 @@ const THREAD_ID = "b".repeat(64);
 test("trimContextsToBudget_underBudget_returnsZeroAndLeavesContextsUnchanged", () => {
   const contexts = { [`msg:${MSG_ID}`]: 100 };
   // A very large budget — nothing should be evicted.
-  const evicted = trimContextsToBudget(contexts, CLIENT_ID, 1_000_000);
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, 1_000_000);
   assert.equal(evicted, 0);
+  assert.equal(fitsAfterTrim, true);
   assert.ok(`msg:${MSG_ID}` in contexts);
 });
 
@@ -176,8 +177,9 @@ test("trimContextsToBudget_overBudget_evictsMsgEntriesOldestFirst", () => {
   // Budget that requires evicting at least one entry.
   const budget = fullSize - 10;
 
-  const evicted = trimContextsToBudget(contexts, CLIENT_ID, budget);
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, budget);
   assert.ok(evicted >= 1, `expected at least 1 eviction, got ${evicted}`);
+  assert.equal(fitsAfterTrim, true);
   // The oldest entry (ts=1) must be gone.
   assert.ok(!(`msg:${MSG_ID}` in contexts), "oldest msg entry should be evicted");
   // Result must fit within budget.
@@ -201,10 +203,11 @@ test("trimContextsToBudget_channelKeysNeverEvicted", () => {
   ).length;
   const budget = Math.floor(fullSize / 2);
 
-  trimContextsToBudget(contexts, CLIENT_ID, budget);
+  const { fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, budget);
 
   // Channel key must survive regardless of how many msg entries were evicted.
   assert.ok("channel:some-channel-id" in contexts, "channel key must not be evicted");
+  assert.equal(fitsAfterTrim, true);
   const resultSize = encoder.encode(
     JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
   ).length;
@@ -232,14 +235,37 @@ test("trimContextsToBudget_msgEvictedBeforeThread", () => {
   ).length;
   const budget = oneEntrySize + 5; // fits one entry, not two
 
-  const evicted = trimContextsToBudget(contexts, CLIENT_ID, budget);
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, budget);
   assert.equal(evicted, 1);
+  assert.equal(fitsAfterTrim, true);
   assert.ok(!(`msg:${MSG_ID}` in contexts), "msg entry should be evicted before thread");
   assert.ok(`thread:${THREAD_ID}` in contexts, "thread entry should survive");
 });
 
-test("trimContextsToBudget_emptyContexts_returnsZero", () => {
+test("trimContextsToBudget_emptyContexts_returnsZeroAndFits", () => {
+  // Empty contexts: blob is just the skeleton — fits any reasonable budget.
   const contexts = {};
-  const evicted = trimContextsToBudget(contexts, CLIENT_ID, 100);
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, 1_000_000);
   assert.equal(evicted, 0);
+  assert.equal(fitsAfterTrim, true);
+});
+
+test("trimContextsToBudget_channelOnlyBlobExceedsBudget_fitsAfterTrimFalse", () => {
+  // Channel keys cannot be evicted. If the channel-only skeleton exceeds the
+  // budget, fitsAfterTrim must be false so the caller can suppress the publish.
+  const contexts = {
+    "channel:some-channel-id": 100,
+  };
+  const encoder = new TextEncoder();
+  const skeletonSize = encoder.encode(
+    JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
+  ).length;
+  // Budget smaller than the channel-only skeleton — cannot be satisfied.
+  const budget = skeletonSize - 1;
+
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, budget);
+  assert.equal(evicted, 0, "no evictable entries exist");
+  assert.equal(fitsAfterTrim, false, "channel-only blob still exceeds budget");
+  // Channel key must still be present.
+  assert.ok("channel:some-channel-id" in contexts);
 });

--- a/desktop/src/features/channels/readState/readStateManager.test.mjs
+++ b/desktop/src/features/channels/readState/readStateManager.test.mjs
@@ -156,7 +156,11 @@ const THREAD_ID = "b".repeat(64);
 test("trimContextsToBudget_underBudget_returnsZeroAndLeavesContextsUnchanged", () => {
   const contexts = { [`msg:${MSG_ID}`]: 100 };
   // A very large budget — nothing should be evicted.
-  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, 1_000_000);
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(
+    contexts,
+    CLIENT_ID,
+    1_000_000,
+  );
   assert.equal(evicted, 0);
   assert.equal(fitsAfterTrim, true);
   assert.ok(`msg:${MSG_ID}` in contexts);
@@ -171,22 +175,31 @@ test("trimContextsToBudget_overBudget_evictsMsgEntriesOldestFirst", () => {
     [`msg:${"d".repeat(64)}`]: 2,
   };
   const encoder = new TextEncoder();
-  const fullSize = encoder.encode(
-    JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
-  ).length;
   // Budget that requires evicting at least one entry.
-  const budget = fullSize - 10;
+  const budget =
+    encoder.encode(JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }))
+      .length - 10;
 
-  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, budget);
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(
+    contexts,
+    CLIENT_ID,
+    budget,
+  );
   assert.ok(evicted >= 1, `expected at least 1 eviction, got ${evicted}`);
   assert.equal(fitsAfterTrim, true);
   // The oldest entry (ts=1) must be gone.
-  assert.ok(!(`msg:${MSG_ID}` in contexts), "oldest msg entry should be evicted");
+  assert.ok(
+    !(`msg:${MSG_ID}` in contexts),
+    "oldest msg entry should be evicted",
+  );
   // Result must fit within budget.
   const resultSize = encoder.encode(
     JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
   ).length;
-  assert.ok(resultSize <= budget, `result ${resultSize} exceeds budget ${budget}`);
+  assert.ok(
+    resultSize <= budget,
+    `result ${resultSize} exceeds budget ${budget}`,
+  );
 });
 
 test("trimContextsToBudget_channelKeysNeverEvicted", () => {
@@ -206,12 +219,18 @@ test("trimContextsToBudget_channelKeysNeverEvicted", () => {
   const { fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, budget);
 
   // Channel key must survive regardless of how many msg entries were evicted.
-  assert.ok("channel:some-channel-id" in contexts, "channel key must not be evicted");
+  assert.ok(
+    "channel:some-channel-id" in contexts,
+    "channel key must not be evicted",
+  );
   assert.equal(fitsAfterTrim, true);
   const resultSize = encoder.encode(
     JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
   ).length;
-  assert.ok(resultSize <= budget, `result ${resultSize} exceeds budget ${budget}`);
+  assert.ok(
+    resultSize <= budget,
+    `result ${resultSize} exceeds budget ${budget}`,
+  );
 });
 
 test("trimContextsToBudget_msgEvictedBeforeThread", () => {
@@ -222,9 +241,6 @@ test("trimContextsToBudget_msgEvictedBeforeThread", () => {
     [`thread:${THREAD_ID}`]: 2,
   };
   const encoder = new TextEncoder();
-  const fullSize = encoder.encode(
-    JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }),
-  ).length;
   // Tight budget: remove exactly one entry.
   const oneEntrySize = encoder.encode(
     JSON.stringify({
@@ -235,17 +251,28 @@ test("trimContextsToBudget_msgEvictedBeforeThread", () => {
   ).length;
   const budget = oneEntrySize + 5; // fits one entry, not two
 
-  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, budget);
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(
+    contexts,
+    CLIENT_ID,
+    budget,
+  );
   assert.equal(evicted, 1);
   assert.equal(fitsAfterTrim, true);
-  assert.ok(!(`msg:${MSG_ID}` in contexts), "msg entry should be evicted before thread");
+  assert.ok(
+    !(`msg:${MSG_ID}` in contexts),
+    "msg entry should be evicted before thread",
+  );
   assert.ok(`thread:${THREAD_ID}` in contexts, "thread entry should survive");
 });
 
 test("trimContextsToBudget_emptyContexts_returnsZeroAndFits", () => {
   // Empty contexts: blob is just the skeleton — fits any reasonable budget.
   const contexts = {};
-  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, 1_000_000);
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(
+    contexts,
+    CLIENT_ID,
+    1_000_000,
+  );
   assert.equal(evicted, 0);
   assert.equal(fitsAfterTrim, true);
 });
@@ -263,7 +290,11 @@ test("trimContextsToBudget_channelOnlyBlobExceedsBudget_fitsAfterTrimFalse", () 
   // Budget smaller than the channel-only skeleton — cannot be satisfied.
   const budget = skeletonSize - 1;
 
-  const { evicted, fitsAfterTrim } = trimContextsToBudget(contexts, CLIENT_ID, budget);
+  const { evicted, fitsAfterTrim } = trimContextsToBudget(
+    contexts,
+    CLIENT_ID,
+    budget,
+  );
   assert.equal(evicted, 0, "no evictable entries exist");
   assert.equal(fitsAfterTrim, false, "channel-only blob still exceeds budget");
   // Channel key must still be present.

--- a/desktop/src/features/channels/readState/readStateManager.ts
+++ b/desktop/src/features/channels/readState/readStateManager.ts
@@ -236,7 +236,10 @@ export class ReadStateManager {
     await this.startLiveSubscription();
     if (this.destroyed) return;
     const initContexts = this.currentContexts();
-    if (initContexts !== null && !this.isIdenticalToLastPublished(initContexts)) {
+    if (
+      initContexts !== null &&
+      !this.isIdenticalToLastPublished(initContexts)
+    ) {
       this.schedulePublish();
     }
 

--- a/desktop/src/features/channels/readState/readStateManager.ts
+++ b/desktop/src/features/channels/readState/readStateManager.ts
@@ -124,10 +124,24 @@ export function applyRemoteContextTimestamp(args: {
 }
 
 /**
+ * Result of a `trimContextsToBudget` call.
+ */
+export interface TrimResult {
+  /** Number of entries removed from `contexts`. */
+  evicted: number;
+  /** True when the serialized blob fits within `maxBytes` after trimming. */
+  fitsAfterTrim: boolean;
+}
+
+/**
  * Trim a contexts map to fit within `maxBytes` when serialized as the JSON
  * blob `{v:1, client_id, contexts}`. Evicts oldest `msg:` entries first
  * (lowest timestamp), then oldest `thread:` entries. Channel keys are never
- * evicted. Returns the number of entries removed.
+ * evicted. Mutates `contexts` in place.
+ *
+ * Returns `{ evicted, fitsAfterTrim }`. `fitsAfterTrim` is false when the
+ * remaining blob (channel keys only) still exceeds `maxBytes` — the caller
+ * must not publish in that case.
  *
  * Exported for unit testing; callers should prefer `currentContexts()`.
  */
@@ -135,13 +149,14 @@ export function trimContextsToBudget(
   contexts: Record<string, number>,
   clientId: string,
   maxBytes: number,
-): number {
+): TrimResult {
   const encoder = new TextEncoder();
   const blobFor = (c: Record<string, number>) =>
     JSON.stringify({ v: 1, client_id: clientId, contexts: c });
 
-  if (encoder.encode(blobFor(contexts)).length <= maxBytes) {
-    return 0;
+  let currentBytes = encoder.encode(blobFor(contexts)).length;
+  if (currentBytes <= maxBytes) {
+    return { evicted: 0, fitsAfterTrim: true };
   }
 
   const msgEntries: [string, number][] = [];
@@ -157,13 +172,26 @@ export function trimContextsToBudget(
   msgEntries.sort((a, b) => a[1] - b[1]);
   threadEntries.sort((a, b) => a[1] - b[1]);
 
-  let evicted = 0;
-  for (const [key] of [...msgEntries, ...threadEntries]) {
-    if (encoder.encode(blobFor(contexts)).length <= maxBytes) break;
-    delete contexts[key];
-    evicted++;
+  // O(n) pass: subtract each entry's byte contribution from currentBytes and
+  // collect entries to evict. The per-entry estimate is `,"key":timestamp`
+  // (key.length + 3 bytes for `"`, `"`, `:` plus 1 comma) + timestamp digits.
+  // This is an approximation — the final encode below is the authoritative check.
+  const toEvict: string[] = [];
+  for (const [key, ts] of [...msgEntries, ...threadEntries]) {
+    if (currentBytes <= maxBytes) break;
+    // Contribution: `,"key":timestamp` — comma + quoted key + colon + value
+    currentBytes -= key.length + 3 + String(ts).length + 1;
+    toEvict.push(key);
   }
-  return evicted;
+
+  for (const key of toEvict) {
+    delete contexts[key];
+  }
+
+  // Final authoritative check — handles JSON comma-accounting edge cases
+  // (e.g. last-entry comma disappears) that the per-entry estimate ignores.
+  const fitsAfterTrim = encoder.encode(blobFor(contexts)).length <= maxBytes;
+  return { evicted: toEvict.length, fitsAfterTrim };
 }
 
 export class ReadStateManager {
@@ -207,7 +235,8 @@ export class ReadStateManager {
     if (this.destroyed) return;
     await this.startLiveSubscription();
     if (this.destroyed) return;
-    if (!this.isIdenticalToLastPublished(this.currentContexts())) {
+    const initContexts = this.currentContexts();
+    if (initContexts !== null && !this.isIdenticalToLastPublished(initContexts)) {
       this.schedulePublish();
     }
 
@@ -543,8 +572,8 @@ export class ReadStateManager {
     // Build blob from contexts this client is allowed to publish.
     const contexts = this.currentContexts();
 
-    // Suppress no-op publishes
-    if (this.isIdenticalToLastPublished(contexts)) return;
+    // Suppress no-op publishes; also skip if the blob cannot fit within budget.
+    if (contexts === null || this.isIdenticalToLastPublished(contexts)) return;
 
     const blob: ReadStateBlob = {
       v: 1,
@@ -630,7 +659,7 @@ export class ReadStateManager {
     return true;
   }
 
-  private currentContexts(): Record<string, number> {
+  private currentContexts(): Record<string, number> | null {
     const contexts: Record<string, number> = {};
     for (const [ctx, ts] of this.effectiveState) {
       if (!this.publishableContextIds.has(ctx)) {
@@ -643,7 +672,7 @@ export class ReadStateManager {
     // the wrong metric — the relay rejects on byte size, not entry count. Evict
     // oldest msg: entries first (lowest timestamp), then thread: entries, until
     // the JSON fits. Channel keys are never evicted.
-    const evicted = trimContextsToBudget(
+    const { evicted, fitsAfterTrim } = trimContextsToBudget(
       contexts,
       this.clientId,
       READ_STATE_MAX_PLAINTEXT_BYTES,
@@ -652,6 +681,12 @@ export class ReadStateManager {
       console.warn(
         `[ReadStateManager] currentContexts trimmed ${evicted} entries to fit byte budget`,
       );
+    }
+    if (!fitsAfterTrim) {
+      console.error(
+        "[ReadStateManager] currentContexts: blob exceeds byte budget even after full eviction — skipping publish",
+      );
+      return null;
     }
 
     return contexts;

--- a/desktop/src/features/channels/readState/readStateManager.ts
+++ b/desktop/src/features/channels/readState/readStateManager.ts
@@ -10,6 +10,7 @@ import {
   READ_STATE_D_TAG_PREFIX,
   READ_STATE_FETCH_LIMIT,
   READ_STATE_HORIZON_SECONDS,
+  READ_STATE_MAX_PLAINTEXT_BYTES,
   MSG_PREFIX,
   THREAD_PREFIX,
   isValidBlob,
@@ -120,6 +121,49 @@ export function applyRemoteContextTimestamp(args: {
     contextSourceCreatedAt.set(contextId, eventCreatedAt);
   }
   return result;
+}
+
+/**
+ * Trim a contexts map to fit within `maxBytes` when serialized as the JSON
+ * blob `{v:1, client_id, contexts}`. Evicts oldest `msg:` entries first
+ * (lowest timestamp), then oldest `thread:` entries. Channel keys are never
+ * evicted. Returns the number of entries removed.
+ *
+ * Exported for unit testing; callers should prefer `currentContexts()`.
+ */
+export function trimContextsToBudget(
+  contexts: Record<string, number>,
+  clientId: string,
+  maxBytes: number,
+): number {
+  const encoder = new TextEncoder();
+  const blobFor = (c: Record<string, number>) =>
+    JSON.stringify({ v: 1, client_id: clientId, contexts: c });
+
+  if (encoder.encode(blobFor(contexts)).length <= maxBytes) {
+    return 0;
+  }
+
+  const msgEntries: [string, number][] = [];
+  const threadEntries: [string, number][] = [];
+  for (const [key, ts] of Object.entries(contexts)) {
+    if (key.startsWith(MSG_PREFIX)) {
+      msgEntries.push([key, ts]);
+    } else if (key.startsWith(THREAD_PREFIX)) {
+      threadEntries.push([key, ts]);
+    }
+  }
+  // Oldest-first within each tier.
+  msgEntries.sort((a, b) => a[1] - b[1]);
+  threadEntries.sort((a, b) => a[1] - b[1]);
+
+  let evicted = 0;
+  for (const [key] of [...msgEntries, ...threadEntries]) {
+    if (encoder.encode(blobFor(contexts)).length <= maxBytes) break;
+    delete contexts[key];
+    evicted++;
+  }
+  return evicted;
 }
 
 export class ReadStateManager {
@@ -595,24 +639,19 @@ export class ReadStateManager {
       contexts[ctx] = ts;
     }
 
-    // Evict oldest per-thread/per-message entries when approaching the
-    // MAX_CONTEXTS cap (10,000). Channel keys are never evicted. This prevents
-    // silent blob rejection by isValidBlob().
-    const EVICTION_THRESHOLD = 8_000;
-    const contextCount = Object.keys(contexts).length;
-    if (contextCount > EVICTION_THRESHOLD) {
-      const detailEntries: [string, number][] = [];
-      for (const [key, ts] of Object.entries(contexts)) {
-        if (key.startsWith(THREAD_PREFIX) || key.startsWith(MSG_PREFIX)) {
-          detailEntries.push([key, ts]);
-        }
-      }
-      // Sort oldest-first (lowest timestamp = oldest)
-      detailEntries.sort((a, b) => a[1] - b[1]);
-      const toEvict = contextCount - EVICTION_THRESHOLD;
-      for (let i = 0; i < Math.min(toEvict, detailEntries.length); i++) {
-        delete contexts[detailEntries[i][0]];
-      }
+    // Enforce a serialized byte-size budget before encryption. Entry count is
+    // the wrong metric — the relay rejects on byte size, not entry count. Evict
+    // oldest msg: entries first (lowest timestamp), then thread: entries, until
+    // the JSON fits. Channel keys are never evicted.
+    const evicted = trimContextsToBudget(
+      contexts,
+      this.clientId,
+      READ_STATE_MAX_PLAINTEXT_BYTES,
+    );
+    if (evicted > 0) {
+      console.warn(
+        `[ReadStateManager] currentContexts trimmed ${evicted} entries to fit byte budget`,
+      );
     }
 
     return contexts;


### PR DESCRIPTION
Fixes the `[ReadStateManager] publish failed` relay rejection that breaks cross-device read state sync.

## Problem

`currentContexts()` guarded blob size with an entry-count threshold (8k/10k). Entry count is the wrong metric — the relay enforces a byte-size limit on event content, not an entry count. At 8k `msg:` entries the JSON blob is already ~544KB of keys alone, well past the relay's limit. The relay responds with `OK false events too long`, which `relayClientSession.ts` surfaces as the `[ReadStateManager] publish failed` warning. Because `lastPublishedContexts` is never updated on failure, the manager retries on every debounce cycle (~5s).

## Fix

Replace the entry-count eviction block in `currentContexts()` with a serialized byte-budget loop via a new exported pure function `trimContextsToBudget()`:

1. Serialize the full `{v:1, client_id, contexts}` blob and check its UTF-8 byte length.
2. If over budget, collect `msg:` entries and `thread:` entries separately, sort each oldest-first (lowest timestamp).
3. Evict from `msg:` first, then `thread:`, one entry at a time, re-checking the serialized size after each deletion.
4. Channel keys (`channel:`) are never evicted.
5. A `console.warn` fires when trim occurs so the fix is visible in staging.

`READ_STATE_MAX_PLAINTEXT_BYTES = 32_768` (32KB) is added to `readStateFormat.ts`. This produces ~45KB NIP-44 ciphertext (~1.4× overhead), well under the relay's 256KB content cap and NIP-44's 65,535-byte plaintext hard limit.

## Files changed

- `desktop/src/features/channels/readState/readStateFormat.ts` — add `READ_STATE_MAX_PLAINTEXT_BYTES`
- `desktop/src/features/channels/readState/readStateManager.ts` — add `trimContextsToBudget()`, replace eviction block in `currentContexts()`
- `desktop/src/features/channels/readState/readStateManager.test.mjs` — 5 new tests covering the trim path

## Stack

Stack: this PR → #1309