### PR TITLE
fix(desktop): gate push-to-talk global shortcut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,7 +843,7 @@ jobs:
         env:
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
       - name: Test (Tauri crate)
-        run: cargo test --manifest-path desktop/src-tauri/Cargo.toml --target $env:TARGET
+        run: cargo test --manifest-path desktop/src-tauri/Cargo.toml --target $env:TARGET --no-default-features --features system-keyring
         env:
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -17,8 +17,9 @@ name = "buzz_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [features]
-default = ["system-keyring"]
+default = ["system-keyring", "global-shortcut"]
 mesh-llm = ["dep:mesh-llm-sdk", "dep:mesh-llm-host-runtime"]
+global-shortcut = ["dep:tauri-plugin-global-shortcut"]
 # OS keyring backing for desktop secret storage (nsec private keys). When
 # disabled, secrets fall back to 0o600 files. On by default for real builds.
 system-keyring = ["dep:keyring"]
@@ -88,7 +89,7 @@ sha2 = "0.11"
 tar = "0.4"
 bzip2 = "0.6"
 chrono = { version = "0.4", features = ["serde"] }
-tauri-plugin-global-shortcut = "2"
+tauri-plugin-global-shortcut = { version = "2", optional = true }
 tauri-plugin-notification = "2.3.3"
 uuid = { version = "1", features = ["v4"] }
 png = "0.18"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -22,9 +22,6 @@
     "dialog:default",
     "updater:allow-check",
     "updater:allow-download-and-install",
-    "process:allow-restart",
-    "global-shortcut:allow-register",
-    "global-shortcut:allow-unregister",
-    "global-shortcut:allow-is-registered"
+    "process:allow-restart"
   ]
 }

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -11,6 +11,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::huddle::HuddleState;
 use crate::managed_agents::ManagedAgentProcess;
+use crate::ptt_shortcut::PttShortcutRuntimeState;
 
 pub struct AppState {
     pub keys: Mutex<Keys>,
@@ -22,11 +23,8 @@ pub struct AppState {
     pub channel_templates_store_lock: Mutex<()>,
     pub managed_agent_processes: Mutex<HashMap<String, ManagedAgentProcess>>,
     pub huddle_state: Mutex<HuddleState>,
-    /// Tauri app handle — stored after setup so huddle commands can emit
-    /// `huddle-state-changed` events without needing the handle threaded
-    /// through every call site.
-    ///
-    /// Set once during `setup()` in `lib.rs`; never cleared.
+    pub ptt_shortcut: PttShortcutRuntimeState,
+    /// Tauri app handle, set once during setup.
     pub app_handle: Mutex<Option<AppHandle>>,
     /// Selected audio output device name. `None` = system default.
     /// Used by `connect_audio_relay` and TTS pipeline when opening sinks.
@@ -93,6 +91,7 @@ pub fn build_app_state() -> AppState {
         channel_templates_store_lock: Mutex::new(()),
         managed_agent_processes: Mutex::new(HashMap::new()),
         huddle_state: Mutex::new(HuddleState::default()),
+        ptt_shortcut: PttShortcutRuntimeState::default(),
         app_handle: Mutex::new(None),
         audio_output_device: Mutex::new(None),
         media_proxy_port: AtomicU16::new(0),
@@ -127,6 +126,7 @@ impl AppState {
             Err(_) => return,
         };
         let Some(app) = app else { return };
+        crate::ptt_shortcut::refresh_registration(&app, self);
         let snapshot = match self.huddle_state.lock() {
             Ok(hs) => hs.clone(),
             Err(_) => return,

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -97,6 +97,8 @@ pub async fn set_voice_input_mode(
             && hs.stt_pipeline.is_some()
     };
 
+    crate::ptt_shortcut::refresh_registration_from_state(&state);
+
     if needs_restart {
         let eph_id = {
             let hs = state.huddle()?;

--- a/desktop/src-tauri/src/huddle/state.rs
+++ b/desktop/src-tauri/src/huddle/state.rs
@@ -13,7 +13,7 @@ use super::{stt, tts};
 
 /// Voice input mode: push-to-talk (PTT) or voice-activity detection (VAD).
 ///
-/// PTT: mic is gated by a global shortcut (Ctrl+Space). Pressing the key sets
+/// PTT: mic is gated by the configured global shortcut (Ctrl+Space by default). Pressing the key sets
 /// `ptt_active` and immediately cancels any playing TTS. Releasing the key
 /// (after a 200 ms delay) stops mic capture and flushes the utterance.
 ///

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -431,19 +431,9 @@ pub fn run() {
                         None => return,
                     };
 
-                    // Only act if a huddle is active and mode is PTT.
-                    let (is_ptt_mode, is_active) = match state.huddle_state.lock() {
-                        Ok(hs) => (
-                            hs.voice_input_mode == huddle::VoiceInputMode::PushToTalk,
-                            matches!(
-                                hs.phase,
-                                huddle::HuddlePhase::Connected | huddle::HuddlePhase::Active
-                            ),
-                        ),
-                        Err(_) => return,
-                    };
-
-                    if !is_ptt_mode || !is_active {
+                    // This is a defensive runtime gate: if unregistering fails after the user
+                    // disables the shortcut, the OS may still deliver events to this handler.
+                    if !ptt_shortcut::should_handle_shortcut_event(&state) {
                         return;
                     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod migration;
 mod models;
 pub mod nostr_convert;
 mod prevent_sleep;
+mod ptt_shortcut;
 mod relay;
 mod secret_store;
 mod templates;
@@ -114,6 +115,7 @@ use managed_agents::{
     restore_managed_agents_on_launch, save_managed_agents, sync_managed_agent_processes,
     try_regenerate_nest, BackendKind, ManagedAgentProcess,
 };
+use ptt_shortcut::{get_ptt_shortcut_settings, set_ptt_shortcut_enabled};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -566,6 +568,8 @@ pub fn run() {
                 *guard = Some(app_handle.clone());
             }
 
+            ptt_shortcut::initialize(&app_handle, &state);
+
             // Bring up the runtime-owned relay-mesh call-me-now listener now,
             // before any saved agent restore can request a connection. Its
             // lifetime is tied to the runtime, not a UI mount — this is what
@@ -637,16 +641,6 @@ pub fn run() {
             if let Some(mgr) = huddle::models::global_model_manager() {
                 mgr.start_stt_download(state.http_client.clone());
                 mgr.start_tts_download(state.http_client.clone());
-            }
-
-            // Non-fatal: huddle works without the shortcut (user can switch to VAD mode).
-            #[cfg(desktop)]
-            {
-                use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
-                let shortcut = Shortcut::new(Some(Modifiers::CONTROL), Code::Space);
-                if let Err(e) = app.handle().global_shortcut().register(shortcut) {
-                    eprintln!("buzz-desktop: failed to register PTT shortcut: {e}");
-                }
             }
 
             // Handle deep link URLs received while the app is running (macOS)
@@ -898,6 +892,8 @@ pub fn run() {
             get_huddle_agent_pubkeys,
             set_voice_input_mode,
             get_voice_input_mode,
+            get_ptt_shortcut_settings,
+            set_ptt_shortcut_enabled,
             list_audio_output_devices,
             set_audio_output_device,
             get_audio_output_device,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -413,84 +413,85 @@ pub fn run() {
         )
         .plugin(tauri_plugin_websocket::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_process::init())
-        .plugin({
-            use tauri_plugin_global_shortcut::ShortcutState;
+        .plugin(tauri_plugin_process::init());
 
-            // Generation counter for the release delay task. Incremented on
-            // every press — a delayed release only fires if the generation
-            // hasn't changed (i.e. no new press happened during the delay).
-            // This prevents press→release→press within 200 ms from having
-            // the first release clobber the second press.
-            let ptt_press_gen = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    #[cfg(feature = "global-shortcut")]
+    let builder = builder.plugin({
+        use tauri_plugin_global_shortcut::ShortcutState;
 
-            tauri_plugin_global_shortcut::Builder::new()
-                .with_handler(move |app, _shortcut, event| {
-                    let state = match app.try_state::<AppState>() {
-                        Some(s) => s,
-                        None => return,
-                    };
+        // Generation counter for the release delay task. Incremented on
+        // every press — a delayed release only fires if the generation
+        // hasn't changed (i.e. no new press happened during the delay).
+        // This prevents press→release→press within 200 ms from having
+        // the first release clobber the second press.
+        let ptt_press_gen = Arc::new(std::sync::atomic::AtomicU64::new(0));
 
-                    // This is a defensive runtime gate: if unregistering fails after the user
-                    // disables the shortcut, the OS may still deliver events to this handler.
-                    if !ptt_shortcut::should_handle_shortcut_event(&state) {
-                        return;
-                    }
+        tauri_plugin_global_shortcut::Builder::new()
+            .with_handler(move |app, _shortcut, event| {
+                let state = match app.try_state::<AppState>() {
+                    Some(s) => s,
+                    None => return,
+                };
 
-                    match event.state {
-                        ShortcutState::Pressed => {
-                            // Bump generation — invalidates any pending release delay.
-                            ptt_press_gen.fetch_add(1, std::sync::atomic::Ordering::Release);
+                // This is a defensive runtime gate: if unregistering fails after the user
+                // disables the shortcut, the OS may still deliver events to this handler.
+                if !ptt_shortcut::should_handle_shortcut_event(&state) {
+                    return;
+                }
 
-                            if let Ok(hs) = state.huddle_state.lock() {
-                                hs.ptt_active
+                match event.state {
+                    ShortcutState::Pressed => {
+                        // Bump generation — invalidates any pending release delay.
+                        ptt_press_gen.fetch_add(1, std::sync::atomic::Ordering::Release);
+
+                        if let Ok(hs) = state.huddle_state.lock() {
+                            hs.ptt_active
+                                .store(true, std::sync::atomic::Ordering::Release);
+                            // Only cancel TTS if it's actually playing — avoids
+                            // a stale cancel flag that drops the next queued message.
+                            if hs.tts_active.load(std::sync::atomic::Ordering::Acquire) {
+                                hs.tts_cancel
                                     .store(true, std::sync::atomic::Ordering::Release);
-                                // Only cancel TTS if it's actually playing — avoids
-                                // a stale cancel flag that drops the next queued message.
-                                if hs.tts_active.load(std::sync::atomic::Ordering::Acquire) {
-                                    hs.tts_cancel
-                                        .store(true, std::sync::atomic::Ordering::Release);
+                            }
+                        }
+                        // Emit ptt-state=true to the frontend.
+                        // The React side plays the press audio cue on this event
+                        // (Web Audio API via HuddleContext). Rust-side rodio audio
+                        // was considered but rejected: the rodio OutputStream must
+                        // outlive the handler and sharing it across the shortcut
+                        // closure adds lifecycle complexity for marginal gain.
+                        // The React implementation is sufficient and simpler.
+                        let _ = app.emit("ptt-state", true);
+                    }
+                    ShortcutState::Released => {
+                        // Capture generation at release time.
+                        let gen_at_release =
+                            ptt_press_gen.load(std::sync::atomic::Ordering::Acquire);
+                        let gen_arc = Arc::clone(&ptt_press_gen);
+                        let app_handle = app.clone();
+                        // 200 ms release delay — captures the tail of the utterance.
+                        // Only applies if no new press happened during the delay.
+                        tauri::async_runtime::spawn(async move {
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                            // Check generation — if it changed, a new press arrived.
+                            if gen_arc.load(std::sync::atomic::Ordering::Acquire) != gen_at_release
+                            {
+                                return; // Superseded by a new press.
+                            }
+                            if let Some(state) = app_handle.try_state::<AppState>() {
+                                if let Ok(hs) = state.huddle_state.lock() {
+                                    hs.ptt_active
+                                        .store(false, std::sync::atomic::Ordering::Release);
                                 }
                             }
-                            // Emit ptt-state=true to the frontend.
-                            // The React side plays the press audio cue on this event
-                            // (Web Audio API via HuddleContext). Rust-side rodio audio
-                            // was considered but rejected: the rodio OutputStream must
-                            // outlive the handler and sharing it across the shortcut
-                            // closure adds lifecycle complexity for marginal gain.
-                            // The React implementation is sufficient and simpler.
-                            let _ = app.emit("ptt-state", true);
-                        }
-                        ShortcutState::Released => {
-                            // Capture generation at release time.
-                            let gen_at_release =
-                                ptt_press_gen.load(std::sync::atomic::Ordering::Acquire);
-                            let gen_arc = Arc::clone(&ptt_press_gen);
-                            let app_handle = app.clone();
-                            // 200 ms release delay — captures the tail of the utterance.
-                            // Only applies if no new press happened during the delay.
-                            tauri::async_runtime::spawn(async move {
-                                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-                                // Check generation — if it changed, a new press arrived.
-                                if gen_arc.load(std::sync::atomic::Ordering::Acquire)
-                                    != gen_at_release
-                                {
-                                    return; // Superseded by a new press.
-                                }
-                                if let Some(state) = app_handle.try_state::<AppState>() {
-                                    if let Ok(hs) = state.huddle_state.lock() {
-                                        hs.ptt_active
-                                            .store(false, std::sync::atomic::Ordering::Release);
-                                    }
-                                }
-                                // Emit ptt-state=false — React plays the release audio cue.
-                                let _ = app_handle.emit("ptt-state", false);
-                            });
-                        }
+                            // Emit ptt-state=false — React plays the release audio cue.
+                            let _ = app_handle.emit("ptt-state", false);
+                        });
                     }
-                })
-                .build()
-        });
+                }
+            })
+            .build()
+    });
 
     // Only register the updater in release builds that were compiled with a
     // real updater configuration. Local unsigned builds omit that config and

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -64,9 +64,7 @@ fn name_matches_known_binary(name: &str) -> bool {
 /// a managed agent wrapper (e.g. `node` running an npm shim for `codex-acp`).
 /// Callers must additionally verify `BUZZ_MANAGED_AGENT` ownership.
 fn name_matches_interpreter(name: &str) -> bool {
-    KNOWN_SCRIPT_INTERPRETERS
-        .iter()
-        .any(|&interp| name == interp)
+    KNOWN_SCRIPT_INTERPRETERS.contains(&name)
 }
 
 #[cfg(unix)]

--- a/desktop/src-tauri/src/ptt_shortcut.rs
+++ b/desktop/src-tauri/src/ptt_shortcut.rs
@@ -136,7 +136,7 @@ fn set_ptt_inactive(app: &AppHandle, state: &AppState) {
     let _ = app.emit("ptt-state", false);
 }
 
-fn should_register(state: &AppState) -> bool {
+pub(crate) fn should_handle_shortcut_event(state: &AppState) -> bool {
     if !state.ptt_shortcut.enabled.load(Ordering::Acquire) {
         return false;
     }
@@ -145,6 +145,10 @@ fn should_register(state: &AppState) -> bool {
     };
     hs.voice_input_mode == VoiceInputMode::PushToTalk
         && matches!(hs.phase, HuddlePhase::Connected | HuddlePhase::Active)
+}
+
+fn should_register(state: &AppState) -> bool {
+    should_handle_shortcut_event(state)
 }
 
 pub fn refresh_registration(app: &AppHandle, state: &AppState) {

--- a/desktop/src-tauri/src/ptt_shortcut.rs
+++ b/desktop/src-tauri/src/ptt_shortcut.rs
@@ -1,0 +1,295 @@
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
+
+use crate::app_state::AppState;
+use crate::huddle::{HuddlePhase, VoiceInputMode};
+
+const SETTINGS_FILE_NAME: &str = "ptt-shortcut.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PttShortcutSettings {
+    pub enabled: bool,
+    pub shortcut: String,
+    pub display: String,
+    pub registered: bool,
+    pub error: Option<String>,
+}
+
+impl Default for PttShortcutSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            shortcut: "Ctrl+Space".to_string(),
+            display: "Ctrl+Space".to_string(),
+            registered: false,
+            error: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PttShortcutRuntimeState {
+    pub enabled: AtomicBool,
+    pub registered: AtomicBool,
+    pub error: Mutex<Option<String>>,
+}
+
+impl Default for PttShortcutRuntimeState {
+    fn default() -> Self {
+        Self {
+            enabled: AtomicBool::new(PttShortcutSettings::default().enabled),
+            registered: AtomicBool::new(false),
+            error: Mutex::new(None),
+        }
+    }
+}
+
+fn ptt_shortcut() -> Shortcut {
+    Shortcut::new(Some(Modifiers::CONTROL), Code::Space)
+}
+
+fn settings_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| format!("app config dir: {e}"))?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create app config dir: {e}"))?;
+    Ok(dir.join(SETTINGS_FILE_NAME))
+}
+
+fn read_enabled(app: &AppHandle) -> Result<bool, String> {
+    let path = settings_path(app)?;
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return Ok(PttShortcutSettings::default().enabled);
+    };
+    if raw.trim().is_empty() {
+        return Ok(PttShortcutSettings::default().enabled);
+    }
+    let parsed: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("read push-to-talk shortcut settings: {e}"))?;
+    Ok(parsed
+        .get("enabled")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(PttShortcutSettings::default().enabled))
+}
+
+fn write_enabled(app: &AppHandle, enabled: bool) -> Result<(), String> {
+    use atomic_write_file::AtomicWriteFile;
+
+    let path = settings_path(app)?;
+    let settings = serde_json::json!({ "enabled": enabled });
+    let payload = serde_json::to_vec_pretty(&settings)
+        .map_err(|e| format!("encode push-to-talk shortcut settings: {e}"))?;
+    let mut file = AtomicWriteFile::open(&path)
+        .map_err(|e| format!("open push-to-talk shortcut settings: {e}"))?;
+    file.write_all(&payload)
+        .map_err(|e| format!("write push-to-talk shortcut settings: {e}"))?;
+    file.commit()
+        .map_err(|e| format!("commit push-to-talk shortcut settings: {e}"))
+}
+
+pub fn initialize(app: &AppHandle, state: &AppState) {
+    match read_enabled(app) {
+        Ok(enabled) => state.ptt_shortcut.enabled.store(enabled, Ordering::Release),
+        Err(e) => {
+            state
+                .ptt_shortcut
+                .error
+                .lock()
+                .map(|mut guard| *guard = Some(e.clone()))
+                .ok();
+            eprintln!("buzz-desktop: failed to load PTT shortcut settings: {e}");
+        }
+    }
+}
+
+pub fn settings_snapshot(state: &AppState) -> PttShortcutSettings {
+    PttShortcutSettings {
+        enabled: state.ptt_shortcut.enabled.load(Ordering::Acquire),
+        registered: state.ptt_shortcut.registered.load(Ordering::Acquire),
+        error: state
+            .ptt_shortcut
+            .error
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_else(|_| Some("Push-to-talk shortcut state is unavailable".to_string())),
+        ..PttShortcutSettings::default()
+    }
+}
+
+fn emit_settings_changed(app: &AppHandle, state: &AppState) {
+    use tauri::Emitter;
+    let _ = app.emit("ptt-shortcut-settings-changed", settings_snapshot(state));
+}
+
+fn set_ptt_inactive(app: &AppHandle, state: &AppState) {
+    if let Ok(hs) = state.huddle_state.lock() {
+        hs.ptt_active.store(false, Ordering::Release);
+    }
+    use tauri::Emitter;
+    let _ = app.emit("ptt-state", false);
+}
+
+fn should_register(state: &AppState) -> bool {
+    if !state.ptt_shortcut.enabled.load(Ordering::Acquire) {
+        return false;
+    }
+    let Ok(hs) = state.huddle_state.lock() else {
+        return false;
+    };
+    hs.voice_input_mode == VoiceInputMode::PushToTalk
+        && matches!(hs.phase, HuddlePhase::Connected | HuddlePhase::Active)
+}
+
+pub fn refresh_registration(app: &AppHandle, state: &AppState) {
+    let should_be_registered = should_register(state);
+    let is_registered = state.ptt_shortcut.registered.load(Ordering::Acquire);
+
+    if should_be_registered == is_registered {
+        if !should_be_registered {
+            let cleared_error = state
+                .ptt_shortcut
+                .error
+                .lock()
+                .map(|mut error| {
+                    let had_error = error.is_some();
+                    *error = None;
+                    had_error
+                })
+                .unwrap_or(false);
+            if cleared_error {
+                emit_settings_changed(app, state);
+            }
+        }
+        return;
+    }
+
+    let shortcut = ptt_shortcut();
+    if should_be_registered {
+        match app.global_shortcut().register(shortcut) {
+            Ok(()) => {
+                state.ptt_shortcut.registered.store(true, Ordering::Release);
+                if let Ok(mut error) = state.ptt_shortcut.error.lock() {
+                    *error = None;
+                }
+                emit_settings_changed(app, state);
+            }
+            Err(e) => {
+                let message = format!("Could not register Ctrl+Space: {e}");
+                state
+                    .ptt_shortcut
+                    .registered
+                    .store(false, Ordering::Release);
+                if let Ok(mut error) = state.ptt_shortcut.error.lock() {
+                    *error = Some(message.clone());
+                }
+                emit_settings_changed(app, state);
+                eprintln!("buzz-desktop: {message}");
+            }
+        }
+    } else {
+        match app.global_shortcut().unregister(shortcut) {
+            Ok(()) => {
+                state
+                    .ptt_shortcut
+                    .registered
+                    .store(false, Ordering::Release);
+                set_ptt_inactive(app, state);
+                if let Ok(mut error) = state.ptt_shortcut.error.lock() {
+                    *error = None;
+                }
+                emit_settings_changed(app, state);
+            }
+            Err(e) => {
+                let message = format!("Could not unregister Ctrl+Space: {e}");
+                if let Ok(mut error) = state.ptt_shortcut.error.lock() {
+                    *error = Some(message.clone());
+                }
+                emit_settings_changed(app, state);
+                eprintln!("buzz-desktop: {message}");
+            }
+        }
+    }
+}
+
+pub fn refresh_registration_from_state(state: &AppState) {
+    let app = match state.app_handle.lock() {
+        Ok(guard) => guard.clone(),
+        Err(_) => None,
+    };
+    if let Some(app) = app {
+        refresh_registration(&app, state);
+    }
+}
+
+#[tauri::command]
+pub fn get_ptt_shortcut_settings(
+    state: State<'_, AppState>,
+) -> Result<PttShortcutSettings, String> {
+    Ok(settings_snapshot(&state))
+}
+
+#[tauri::command]
+pub fn set_ptt_shortcut_enabled(
+    enabled: bool,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<PttShortcutSettings, String> {
+    write_enabled(&app, enabled)?;
+    state.ptt_shortcut.enabled.store(enabled, Ordering::Release);
+    refresh_registration(&app, &state);
+    emit_settings_changed(&app, &state);
+    Ok(settings_snapshot(&state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state_with(enabled: bool, mode: VoiceInputMode, phase: HuddlePhase) -> AppState {
+        let state = crate::app_state::build_app_state();
+        state.ptt_shortcut.enabled.store(enabled, Ordering::Release);
+        {
+            let mut hs = state.huddle_state.lock().unwrap();
+            hs.voice_input_mode = mode;
+            hs.phase = phase;
+        }
+        state
+    }
+
+    #[test]
+    fn registers_only_when_enabled_active_and_ptt() {
+        assert!(should_register(&state_with(
+            true,
+            VoiceInputMode::PushToTalk,
+            HuddlePhase::Connected,
+        )));
+        assert!(should_register(&state_with(
+            true,
+            VoiceInputMode::PushToTalk,
+            HuddlePhase::Active,
+        )));
+
+        assert!(!should_register(&state_with(
+            false,
+            VoiceInputMode::PushToTalk,
+            HuddlePhase::Active,
+        )));
+        assert!(!should_register(&state_with(
+            true,
+            VoiceInputMode::VoiceActivity,
+            HuddlePhase::Active,
+        )));
+        assert!(!should_register(&state_with(
+            true,
+            VoiceInputMode::PushToTalk,
+            HuddlePhase::Idle,
+        )));
+    }
+}

--- a/desktop/src-tauri/src/ptt_shortcut.rs
+++ b/desktop/src-tauri/src/ptt_shortcut.rs
@@ -4,9 +4,11 @@ use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
+#[cfg(feature = "global-shortcut")]
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
 
 use crate::app_state::AppState;
+#[cfg(any(feature = "global-shortcut", test))]
 use crate::huddle::{HuddlePhase, VoiceInputMode};
 
 const SETTINGS_FILE_NAME: &str = "ptt-shortcut.json";
@@ -50,6 +52,7 @@ impl Default for PttShortcutRuntimeState {
     }
 }
 
+#[cfg(feature = "global-shortcut")]
 fn ptt_shortcut() -> Shortcut {
     Shortcut::new(Some(Modifiers::CONTROL), Code::Space)
 }
@@ -136,6 +139,7 @@ fn set_ptt_inactive(app: &AppHandle, state: &AppState) {
     let _ = app.emit("ptt-state", false);
 }
 
+#[cfg(any(feature = "global-shortcut", test))]
 pub(crate) fn should_handle_shortcut_event(state: &AppState) -> bool {
     if !state.ptt_shortcut.enabled.load(Ordering::Acquire) {
         return false;
@@ -147,10 +151,12 @@ pub(crate) fn should_handle_shortcut_event(state: &AppState) -> bool {
         && matches!(hs.phase, HuddlePhase::Connected | HuddlePhase::Active)
 }
 
+#[cfg(any(feature = "global-shortcut", test))]
 fn should_register(state: &AppState) -> bool {
     should_handle_shortcut_event(state)
 }
 
+#[cfg(feature = "global-shortcut")]
 pub fn refresh_registration(app: &AppHandle, state: &AppState) {
     let should_be_registered = should_register(state);
     let is_registered = state.ptt_shortcut.registered.load(Ordering::Acquire);
@@ -219,6 +225,16 @@ pub fn refresh_registration(app: &AppHandle, state: &AppState) {
                 eprintln!("buzz-desktop: {message}");
             }
         }
+    }
+}
+
+#[cfg(not(feature = "global-shortcut"))]
+pub fn refresh_registration(app: &AppHandle, state: &AppState) {
+    if state.ptt_shortcut.registered.swap(false, Ordering::AcqRel) {
+        set_ptt_inactive(app, state);
+    }
+    if let Ok(mut error) = state.ptt_shortcut.error.lock() {
+        *error = None;
     }
 }
 

--- a/desktop/src/features/huddle/HuddleContext.tsx
+++ b/desktop/src/features/huddle/HuddleContext.tsx
@@ -21,6 +21,87 @@ type HuddleJoinInfo = {
 
 type VoiceInputMode = "push_to_talk" | "voice_activity";
 
+export type PttShortcutSettings = {
+  enabled: boolean;
+  shortcut: string;
+  display: string;
+  registered: boolean;
+  error: string | null;
+};
+
+export const DEFAULT_PTT_SHORTCUT_SETTINGS: PttShortcutSettings = {
+  enabled: true,
+  shortcut: "Ctrl+Space",
+  display: "Ctrl+Space",
+  registered: false,
+  error: null,
+};
+
+const PTT_SHORTCUT_SETTINGS_EVENT = "ptt-shortcut-settings-changed";
+
+export function usePttShortcutSettings() {
+  const [settings, setSettings] = React.useState<PttShortcutSettings>(
+    DEFAULT_PTT_SHORTCUT_SETTINGS,
+  );
+  const [isUpdating, setIsUpdating] = React.useState(false);
+
+  const refresh = React.useCallback(() => {
+    invoke<PttShortcutSettings>("get_ptt_shortcut_settings")
+      .then(setSettings)
+      .catch((error) => {
+        setSettings({
+          ...DEFAULT_PTT_SHORTCUT_SETTINGS,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Could not load push-to-talk shortcut settings.",
+        });
+      });
+  }, []);
+
+  React.useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    listen<PttShortcutSettings>(PTT_SHORTCUT_SETTINGS_EVENT, (event) => {
+      if (!cancelled) setSettings(event.payload);
+    }).then((fn) => {
+      if (cancelled) fn();
+      else unlisten = fn;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  const setEnabled = React.useCallback(async (enabled: boolean) => {
+    setIsUpdating(true);
+    try {
+      const next = await invoke<PttShortcutSettings>(
+        "set_ptt_shortcut_enabled",
+        { enabled },
+      );
+      setSettings(next);
+    } catch (error) {
+      setSettings((current) => ({
+        ...current,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Could not update push-to-talk shortcut settings.",
+      }));
+    } finally {
+      setIsUpdating(false);
+    }
+  }, []);
+
+  return { settings, setEnabled, isUpdating, refresh };
+}
+
 const MIC_ANALYSER_UPDATE_INTERVAL_MS = 33;
 const MIC_INITIAL_NOISE_FLOOR = 0.01;
 const MIC_VOICE_GATE_ON_RMS = 0.018;
@@ -207,7 +288,7 @@ export function HuddleProvider({ children }: { children: React.ReactNode }) {
   // to avoid exhausting the browser's ~6 concurrent AudioContext limit.
   const pttAudioCtxRef = React.useRef<AudioContext | null>(null);
 
-  // PTT state from Rust (Ctrl+Space). UI feedback + 50ms audio cue when mic active.
+  // PTT state from Rust (the PTT shortcut). UI feedback + 50ms audio cue when mic active.
   // Actual audio gating is in audioWorklet.ts → worklet.js.
   React.useEffect(() => {
     let cancelled = false;

--- a/desktop/src/features/huddle/components/HuddleBar.tsx
+++ b/desktop/src/features/huddle/components/HuddleBar.tsx
@@ -18,7 +18,7 @@ import { Button } from "@/shared/ui/button";
 import { useEmojiBurst } from "@/shared/ui/EmojiBurstProvider";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
-import { useHuddle } from "../HuddleContext";
+import { useHuddle, usePttShortcutSettings } from "../HuddleContext";
 import { AddAgentDialog, type AgentAddResult } from "./AddAgentDialog";
 import { MicControls, SpeakerControls } from "./MicControls";
 import { HuddleParticipantsControl } from "./ParticipantList";
@@ -144,6 +144,7 @@ export function HuddleBar({ className, onVisibilityChange }: HuddleBarProps) {
   const identityQuery = useIdentityQuery();
   const profileQuery = useProfileQuery();
   const { burstHuddleReaction } = useEmojiBurst();
+  const { settings: pttShortcutSettings } = usePttShortcutSettings();
 
   const isPttMode = voiceInputMode === "push_to_talk";
   const [state, setState] = React.useState<HuddleState | null>(null);
@@ -411,6 +412,11 @@ export function HuddleBar({ className, onVisibilityChange }: HuddleBarProps) {
   // far-end reference. The AEC follow-up PR flips this constant in the
   // same diff that moves playout into WebAudio.
   const aecMissing = true;
+  const pttInstruction = isPttMode
+    ? pttShortcutSettings.enabled
+      ? `push to talk, hold ${pttShortcutSettings.display} to transmit`
+      : "push to talk, background shortcut disabled"
+    : "voice activity detection";
 
   async function handleLeave() {
     if (isLeaving) return;
@@ -525,6 +531,7 @@ export function HuddleBar({ className, onVisibilityChange }: HuddleBarProps) {
             pttActive={pttActive}
             micConnected={micConnected}
             micLevel={micLevel}
+            pttShortcut={pttShortcutSettings}
             onSelectVoiceInputMode={setVoiceInputMode}
             audioDevices={audioDevices}
             selectedDeviceId={selectedDeviceId}
@@ -671,7 +678,7 @@ export function HuddleBar({ className, onVisibilityChange }: HuddleBarProps) {
         {micConnected
           ? "In huddle, microphone connected"
           : "In huddle, no microphone"}
-        {`, voice input: ${isPttMode ? "push to talk, press Ctrl+Space to transmit" : "voice activity detection"}`}
+        {`, voice input: ${pttInstruction}`}
         {modelStatus &&
           modelStatus.stt !== "ready" &&
           `, STT model ${modelStatus.stt}`}

--- a/desktop/src/features/huddle/components/MicControls.tsx
+++ b/desktop/src/features/huddle/components/MicControls.tsx
@@ -6,6 +6,7 @@ import type { CSSProperties } from "react";
 import { cn } from "@/shared/lib/cn";
 import { isMacPlatform } from "@/shared/lib/platform";
 import { Button } from "@/shared/ui/button";
+import type { PttShortcutSettings } from "../HuddleContext";
 import {
   Popover,
   PopoverAnchor,
@@ -23,6 +24,7 @@ type MicControlsProps = {
   pttActive: boolean;
   micConnected: boolean;
   micLevel: number;
+  pttShortcut: PttShortcutSettings;
   onSelectVoiceInputMode: (mode: VoiceInputMode) => void | Promise<void>;
   audioDevices: MediaDeviceInfo[];
   selectedDeviceId: string;
@@ -92,6 +94,7 @@ export function MicControls({
   pttActive,
   micConnected,
   micLevel,
+  pttShortcut,
   onSelectVoiceInputMode,
   audioDevices,
   selectedDeviceId,
@@ -102,8 +105,8 @@ export function MicControls({
   const micUnavailable = !micConnected;
   const showMicMeter = micConnected && !isMuted;
   const isMac = isMacPlatform();
+  const pttShortcutLabel = pttShortcut.display;
   const prefersReducedMotion = usePrefersReducedMotion();
-  const pushToTalkShortcut = isMac ? "⌃Space" : "Ctrl+Space";
   const barHeights: [number, number, number] = prefersReducedMotion
     ? MIC_METER_IDLE_HEIGHTS
     : micMeterHeights(showMicMeter ? micLevel : 0);
@@ -217,10 +220,27 @@ export function MicControls({
                 className={cn("h-3 w-3 shrink-0", !isPttMode && "invisible")}
               />
               <span className="font-medium">Push to Talk</span>
-              <kbd className="ml-auto rounded border border-foreground/10 px-1.5 py-0.5 text-2xs font-medium text-foreground/60">
-                {pushToTalkShortcut}
-              </kbd>
+              {pttShortcut.enabled ? (
+                <kbd className="ml-auto rounded border border-foreground/10 px-1.5 py-0.5 text-2xs font-medium text-foreground/60">
+                  {pttShortcutLabel}
+                </kbd>
+              ) : (
+                <span className="ml-auto text-2xs text-muted-foreground">
+                  Shortcut off
+                </span>
+              )}
             </button>
+            {isPttMode && !pttShortcut.enabled ? (
+              <p className="mt-1 pl-5 text-xs leading-snug text-muted-foreground">
+                Background shortcut disabled. Enable it in Settings → Keyboard
+                Shortcuts.
+              </p>
+            ) : null}
+            {isPttMode && pttShortcut.error ? (
+              <p className="mt-1 pl-5 text-xs leading-snug text-destructive">
+                {pttShortcut.error}
+              </p>
+            ) : null}
             <span className="sr-only" aria-live="polite">
               {isPttMode
                 ? "Push to Talk is enabled."

--- a/desktop/src/features/huddle/lib/audioWorklet.ts
+++ b/desktop/src/features/huddle/lib/audioWorklet.ts
@@ -22,7 +22,7 @@ export type AudioWorkletHandle = {
   /** Send PTT state to the worklet processor. */
   setTransmitting: (active: boolean) => void;
   /** Switch voice input mode. In VAD mode, always transmitting (PTT events ignored).
-   *  In PTT mode, gated by Ctrl+Space. */
+   *  In PTT mode, gated by the PTT shortcut. */
   setMode: (mode: "push_to_talk" | "voice_activity") => void;
   /** Set mic input gain (0–1). Adjusts the GainNode between source and worklet. */
   setGain: (value: number) => void;
@@ -98,18 +98,18 @@ export async function setupAudioWorklet(
 
   // Track the current mode so PTT events are only forwarded in PTT mode.
   // In VAD mode, the worklet stays in transmitting=true regardless of
-  // Ctrl+Space presses — prevents accidental muting. (Crossfire fix I1.)
+  // the PTT shortcut presses — prevents accidental muting. (Crossfire fix I1.)
   let currentMode: "push_to_talk" | "voice_activity" = initialTransmitting
     ? "voice_activity"
     : "push_to_talk";
 
-  // Listen for PTT state from Rust global shortcut (Ctrl+Space press/release).
+  // Listen for PTT state from Rust global shortcut (the PTT shortcut press/release).
   // Direction: Rust→main→worklet. The Tauri event carries a boolean payload.
   let pttUnlisten: UnlistenFn | null = null;
   try {
     pttUnlisten = await listen<boolean>("ptt-state", (event) => {
       // Only forward PTT events to the worklet when in PTT mode.
-      // In VAD mode, Ctrl+Space is ignored — the worklet stays open.
+      // In VAD mode, the PTT shortcut is ignored — the worklet stays open.
       if (currentMode === "push_to_talk") {
         workletNode.port.postMessage({ type: "ptt", active: event.payload });
       }

--- a/desktop/src/features/settings/ui/KeyboardShortcutsCard.tsx
+++ b/desktop/src/features/settings/ui/KeyboardShortcutsCard.tsx
@@ -3,11 +3,12 @@ import {
   getPlatformKeys,
   type KeyboardShortcut,
 } from "@/shared/lib/keyboard-shortcuts";
+import { Switch } from "@/shared/ui/switch";
+import { usePttShortcutSettings } from "@/features/huddle/HuddleContext";
 import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
 
-function KeyCombo({ shortcut }: { shortcut: KeyboardShortcut }) {
-  const keys = getPlatformKeys(shortcut);
+function KeyCombo({ keys }: { keys: string }) {
   // Split on "+" but keep "+" as a standalone key (e.g. for zoom-in "⌘+")
   const parts = keys
     .split(/(?<!\+)\+(?!\s*$)/)
@@ -28,6 +29,60 @@ function KeyCombo({ shortcut }: { shortcut: KeyboardShortcut }) {
   );
 }
 
+function ShortcutKeyCombo({ shortcut }: { shortcut: KeyboardShortcut }) {
+  return <KeyCombo keys={getPlatformKeys(shortcut)} />;
+}
+
+function PushToTalkGlobalShortcutRow() {
+  const { settings, setEnabled, isUpdating } = usePttShortcutSettings();
+  const status = settings.enabled
+    ? settings.registered
+      ? "Active while this PTT huddle is open."
+      : "Registered only while you are in a huddle with Push to Talk selected."
+    : "Disabled. Push to Talk remains available, but no app-wide shortcut is reserved.";
+
+  return (
+    <SettingsOptionGroup>
+      <SettingsOptionRow className="items-start px-3 py-3">
+        <div className="min-w-0 flex-1">
+          <label
+            className="text-sm font-medium text-foreground"
+            htmlFor="ptt-global-shortcut-switch"
+          >
+            Push to Talk
+          </label>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Hold the shortcut to transmit in huddles when Push to Talk is
+            selected.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Global shortcuts work while Buzz is in the background and may
+            override shortcuts in other apps.
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">{status}</p>
+          {settings.error ? (
+            <p className="mt-2 text-xs text-destructive" role="alert">
+              {settings.error}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-3 pt-0.5">
+          <KeyCombo keys={settings.display} />
+          <Switch
+            checked={settings.enabled}
+            data-testid="ptt-global-shortcut-toggle"
+            disabled={isUpdating}
+            id="ptt-global-shortcut-switch"
+            onCheckedChange={(checked) => {
+              void setEnabled(checked);
+            }}
+          />
+        </div>
+      </SettingsOptionRow>
+    </SettingsOptionGroup>
+  );
+}
+
 export function KeyboardShortcutsCard() {
   const categories = getShortcutsByCategory();
 
@@ -35,10 +90,17 @@ export function KeyboardShortcutsCard() {
     <section className="min-w-0" data-testid="settings-shortcuts">
       <SettingsSectionHeader
         title="Keyboard Shortcuts"
-        description="All available keyboard shortcuts. Shortcuts are read-only."
+        description="View Buzz shortcuts and control the global shortcuts that can work outside the app."
       />
 
       <div className="space-y-4">
+        <div>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+            Global shortcuts
+          </h3>
+          <PushToTalkGlobalShortcutRow />
+        </div>
+
         {[...categories.entries()].map(([category, shortcuts]) => (
           <div key={category}>
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
@@ -58,7 +120,7 @@ export function KeyboardShortcutsCard() {
                       {shortcut.description}
                     </span>
                   </div>
-                  <KeyCombo shortcut={shortcut} />
+                  <ShortcutKeyCombo shortcut={shortcut} />
                 </SettingsOptionRow>
               ))}
             </SettingsOptionGroup>

--- a/desktop/src/shared/lib/keyboard-shortcuts.ts
+++ b/desktop/src/shared/lib/keyboard-shortcuts.ts
@@ -175,8 +175,8 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
   },
   {
     id: "push-to-talk",
-    label: "Push to talk",
-    description: "Hold to unmute in a huddle",
+    label: "Push to Talk",
+    description: "Hold the global huddle shortcut to transmit when enabled",
     keys: "Ctrl+Space",
     keysWindows: "Ctrl+Space",
     category: "Messages",

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -6577,6 +6577,22 @@ export function maybeInstallE2eTauriMocks() {
           },
         };
       }
+      case "get_ptt_shortcut_settings":
+        return {
+          enabled: true,
+          shortcut: "Ctrl+Space",
+          display: "Ctrl+Space",
+          registered: false,
+          error: null,
+        };
+      case "set_ptt_shortcut_enabled":
+        return {
+          enabled: (payload as { enabled?: boolean } | null)?.enabled ?? true,
+          shortcut: "Ctrl+Space",
+          display: "Ctrl+Space",
+          registered: false,
+          error: null,
+        };
       case "get_identity":
         if (identity) {
           return {


### PR DESCRIPTION
## Summary
- stop registering the Push to Talk global shortcut at desktop startup
- register `Ctrl+Space` only while a huddle is connected/active, Push to Talk mode is selected, and the user has the global shortcut enabled
- add persistent Push to Talk shortcut enablement settings plus visible Settings and huddle UI states/errors
- update shortcut copy, accessibility status text, and E2E Tauri mocks

## Validation
- `pnpm --dir desktop check`
- `pnpm --dir desktop typecheck`
- `cargo fmt --check`
- `cargo test ptt_shortcut::tests --lib --no-default-features` from `desktop/src-tauri` with temporary empty Tauri sidecar placeholders, removed afterward

## Notes
- The shortcut binding itself remains `Ctrl+Space` for now, but it is no longer reserved globally unless it can actually transmit audio.
- The Settings UI makes the global behavior explicit and lets users disable the shortcut when it conflicts with IDEs or other apps.
