### PR TITLE
perf(desktop): debounce channel-list refetch + profile get_channels

### DIFF
--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -12,6 +12,7 @@ use crate::{
 
 #[tauri::command]
 pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>, String> {
+    let _profile_start = std::time::Instant::now();
     let my_pubkey = {
         let keys = state.keys.lock().map_err(|e| e.to_string())?;
         keys.public_key().to_hex()
@@ -39,6 +40,9 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
         }
         all
     };
+
+    #[cfg(debug_assertions)]
+    let t_members = _profile_start.elapsed();
 
     let mut channel_ids: Vec<String> = member_events
         .iter()
@@ -75,6 +79,9 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
         Vec::new()
     };
 
+    #[cfg(debug_assertions)]
+    let t_member_meta = _profile_start.elapsed();
+
     // Step 3: fetch ALL open channel metadata so the channel browser can show
     // discoverable channels the user hasn't joined yet. The relay's access
     // control allows reading kind:39000 for open channels regardless of membership.
@@ -86,6 +93,9 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
         })],
     )
     .await?;
+
+    #[cfg(debug_assertions)]
+    let t_open_meta = _profile_start.elapsed();
 
     // Merge: member channels (marked as member) + open channels (not yet joined).
     let member_d_tags: std::collections::HashSet<String> = meta_events
@@ -156,6 +166,9 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
         }
     }
 
+    #[cfg(debug_assertions)]
+    let t_member_counts = _profile_start.elapsed();
+
     // Populate last_message_at by fetching the most recent human message per
     // channel. Uses per-channel filters (single #h value each) so the relay can
     // push the query to its indexed channel_id column. Multi-value #h is NOT
@@ -201,6 +214,9 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
         }
     }
 
+    #[cfg(debug_assertions)]
+    let t_last_message = _profile_start.elapsed();
+
     // NIP-DV: drop DMs the viewer has hidden. The relay maintains a per-viewer
     // parameterized-replaceable snapshot (kind:30622, d=my pubkey) whose `h`
     // tags list currently-hidden DM channel ids. The snapshot also carries
@@ -234,6 +250,22 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
     };
     if !hidden_dms.is_empty() {
         channels.retain(|c| c.channel_type != "dm" || !hidden_dms.contains(&c.id));
+    }
+
+    #[cfg(debug_assertions)]
+    {
+        let total = _profile_start.elapsed();
+        eprintln!(
+            "buzz-desktop: get_channels profile channels={} members={:?} member_meta={:?} open_meta={:?} member_counts={:?} last_message={:?} hidden_dm={:?} total={:?}",
+            channels.len(),
+            t_members,
+            t_member_meta - t_members,
+            t_open_meta - t_member_meta,
+            t_member_counts - t_open_meta,
+            t_last_message - t_member_counts,
+            total - t_last_message,
+            total,
+        );
     }
 
     Ok(channels)

--- a/desktop/src/features/channels/refreshChannelsWhenIdle.test.mjs
+++ b/desktop/src/features/channels/refreshChannelsWhenIdle.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { refreshChannelsWhenIdle } from "./refreshChannelsWhenIdle.ts";
+
+function spy() {
+  const fn = () => {
+    fn.calls++;
+  };
+  fn.calls = 0;
+  return fn;
+}
+
+test("invalidates when no fetch is in flight", () => {
+  const invalidate = spy();
+  const reArm = spy();
+  refreshChannelsWhenIdle({ isFetching: () => 0, invalidate, reArm });
+  assert.equal(invalidate.calls, 1);
+  assert.equal(reArm.calls, 0);
+});
+
+test("re-arms instead of invalidating while a fetch is in flight", () => {
+  const invalidate = spy();
+  const reArm = spy();
+  refreshChannelsWhenIdle({ isFetching: () => 1, invalidate, reArm });
+  assert.equal(
+    invalidate.calls,
+    0,
+    "must not invalidate mid-flight (would drop the dirty signal)",
+  );
+  assert.equal(reArm.calls, 1);
+});
+
+test("re-arm then idle eventually invalidates exactly once", () => {
+  const invalidate = spy();
+  const reArm = spy();
+  // First pass: fetch in flight -> re-arm.
+  let fetching = 1;
+  const deps = {
+    isFetching: () => fetching,
+    invalidate,
+    // Simulate the debounce re-firing the same action.
+    reArm: () => {
+      reArm.calls++;
+      refreshChannelsWhenIdle(deps);
+    },
+  };
+  // Once re-armed, the fetch has finished.
+  reArm.calls = 0;
+  const reArmOnce = deps.reArm;
+  deps.reArm = () => {
+    fetching = 0;
+    reArmOnce();
+  };
+
+  refreshChannelsWhenIdle(deps);
+  assert.equal(reArm.calls, 1, "re-armed once while fetching");
+  assert.equal(invalidate.calls, 1, "invalidated once after going idle");
+});

--- a/desktop/src/features/channels/refreshChannelsWhenIdle.ts
+++ b/desktop/src/features/channels/refreshChannelsWhenIdle.ts
@@ -1,0 +1,23 @@
+type RefreshDeps = {
+  /** >0 when the channels query is currently fetching. */
+  isFetching: () => number;
+  /** Mark the channels query dirty so it refetches. */
+  invalidate: () => void;
+  /** Re-arm the trailing debounce to retry after the next quiet window. */
+  reArm: () => void;
+};
+
+/**
+ * Refresh the channel list without overlapping or dropping a dirty signal.
+ *
+ * If get_channels is mid-flight, invalidating now would be silently undone: the
+ * in-flight fetch resolves with pre-event data and clears the dirty flag. So we
+ * re-arm instead and let a clean refetch land once the query is idle.
+ */
+export function refreshChannelsWhenIdle(deps: RefreshDeps): void {
+  if (deps.isFetching() > 0) {
+    deps.reArm();
+    return;
+  }
+  deps.invalidate();
+}

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -21,6 +21,7 @@ import {
 } from "@/shared/lib/trailingDebounce";
 
 import { isDmNotifiableKind } from "./isDmNotifiableKind";
+import { refreshChannelsWhenIdle } from "./refreshChannelsWhenIdle";
 
 export type UseLiveChannelUpdatesOptions = {
   currentPubkey?: string;
@@ -115,12 +116,14 @@ export function useLiveChannelUpdates(
   const channelsInvalidateRef = React.useRef<TrailingDebounce | null>(null);
   if (channelsInvalidateRef.current === null) {
     channelsInvalidateRef.current = createTrailingDebounce(() => {
-      // cancelRefetch:false: let an in-flight (multi-second) get_channels finish
-      // rather than restarting it.
-      void queryClient.invalidateQueries(
-        { queryKey: channelsQueryKey },
-        { cancelRefetch: false },
-      );
+      refreshChannelsWhenIdle({
+        isFetching: () =>
+          queryClient.isFetching({ queryKey: channelsQueryKey }),
+        invalidate: () => {
+          void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+        },
+        reArm: () => channelsInvalidateRef.current?.trigger(),
+      });
     }, CHANNELS_INVALIDATE_DEBOUNCE_MS);
   }
   const invalidateChannelsDebounced = React.useCallback(() => {

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -15,6 +15,10 @@ import {
   CHANNEL_MESSAGE_EVENT_KINDS,
 } from "@/shared/constants/kinds";
 import type { Channel, RelayEvent } from "@/shared/api/types";
+import {
+  createTrailingDebounce,
+  type TrailingDebounce,
+} from "@/shared/lib/trailingDebounce";
 
 import { isDmNotifiableKind } from "./isDmNotifiableKind";
 
@@ -108,18 +112,20 @@ export function useLiveChannelUpdates(
   const normalizedCurrentPubkey =
     options.currentPubkey?.trim().toLowerCase() ?? "";
   const seenMentionEventIdsRef = React.useRef(new Set<string>());
-  const channelsInvalidateTimeoutRef = React.useRef<number | undefined>(
-    undefined,
-  );
-  const invalidateChannelsDebounced = React.useCallback(() => {
-    if (channelsInvalidateTimeoutRef.current !== undefined) {
-      return;
-    }
-    channelsInvalidateTimeoutRef.current = window.setTimeout(() => {
-      channelsInvalidateTimeoutRef.current = undefined;
-      void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+  const channelsInvalidateRef = React.useRef<TrailingDebounce | null>(null);
+  if (channelsInvalidateRef.current === null) {
+    channelsInvalidateRef.current = createTrailingDebounce(() => {
+      // cancelRefetch:false: let an in-flight (multi-second) get_channels finish
+      // rather than restarting it.
+      void queryClient.invalidateQueries(
+        { queryKey: channelsQueryKey },
+        { cancelRefetch: false },
+      );
     }, CHANNELS_INVALIDATE_DEBOUNCE_MS);
-  }, [queryClient]);
+  }
+  const invalidateChannelsDebounced = React.useCallback(() => {
+    channelsInvalidateRef.current?.trigger();
+  }, []);
   const liveChannelIds = React.useMemo(
     () => new Set(channels.map((channel) => channel.id)),
     [channels],
@@ -487,10 +493,7 @@ export function useLiveChannelUpdates(
 
   React.useEffect(() => {
     return () => {
-      if (channelsInvalidateTimeoutRef.current !== undefined) {
-        window.clearTimeout(channelsInvalidateTimeoutRef.current);
-        channelsInvalidateTimeoutRef.current = undefined;
-      }
+      channelsInvalidateRef.current?.cancel();
 
       for (const dispose of liveSubsRef.current.values()) {
         void dispose().catch(() => {});

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -66,6 +66,11 @@ export type UseLiveChannelUpdatesOptions = {
 const LIVE_SUBSCRIPTION_RETRY_BASE_MS = 1_000;
 const LIVE_SUBSCRIPTION_RETRY_MAX_MS = 30_000;
 
+// get_channels is an expensive O(channels) relay fan-out. Incoming traffic for
+// non-active channels arrives in bursts, so coalesce the refetch into a single
+// trailing invalidation instead of one per event.
+const CHANNELS_INVALIDATE_DEBOUNCE_MS = 500;
+
 // Only "new content" kinds should bump unread state. Shared with the
 // catch-up query in useUnreadChannels so the two paths stay in lockstep.
 const UNREAD_TRIGGER_KINDS = new Set<number>(CHANNEL_MESSAGE_EVENT_KINDS);
@@ -103,6 +108,18 @@ export function useLiveChannelUpdates(
   const normalizedCurrentPubkey =
     options.currentPubkey?.trim().toLowerCase() ?? "";
   const seenMentionEventIdsRef = React.useRef(new Set<string>());
+  const channelsInvalidateTimeoutRef = React.useRef<number | undefined>(
+    undefined,
+  );
+  const invalidateChannelsDebounced = React.useCallback(() => {
+    if (channelsInvalidateTimeoutRef.current !== undefined) {
+      return;
+    }
+    channelsInvalidateTimeoutRef.current = window.setTimeout(() => {
+      channelsInvalidateTimeoutRef.current = undefined;
+      void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+    }, CHANNELS_INVALIDATE_DEBOUNCE_MS);
+  }, [queryClient]);
   const liveChannelIds = React.useMemo(
     () => new Set(channels.map((channel) => channel.id)),
     [channels],
@@ -186,7 +203,7 @@ export function useLiveChannelUpdates(
 
     if (!liveChannelIds.has(channelId)) {
       if (channelId !== activeChannelId) {
-        void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+        invalidateChannelsDebounced();
       }
       return;
     }
@@ -470,6 +487,11 @@ export function useLiveChannelUpdates(
 
   React.useEffect(() => {
     return () => {
+      if (channelsInvalidateTimeoutRef.current !== undefined) {
+        window.clearTimeout(channelsInvalidateTimeoutRef.current);
+        channelsInvalidateTimeoutRef.current = undefined;
+      }
+
       for (const dispose of liveSubsRef.current.values()) {
         void dispose().catch(() => {});
       }

--- a/desktop/src/shared/lib/trailingDebounce.test.mjs
+++ b/desktop/src/shared/lib/trailingDebounce.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createTrailingDebounce } from "./trailingDebounce.ts";
+
+// Deterministic timer host: timers fire only when we call advance(), so no real
+// time elapses. Mirrors the injectable-timer style of relayStallWatchdog.
+function makeHost() {
+  let nextId = 1;
+  const pending = new Map();
+  return {
+    host: {
+      setTimeout: (handler, ms) => {
+        const id = nextId++;
+        pending.set(id, { handler, remaining: ms });
+        return id;
+      },
+      clearTimeout: (id) => {
+        pending.delete(id);
+      },
+    },
+    advance: (ms) => {
+      for (const [id, t] of [...pending]) {
+        t.remaining -= ms;
+        if (t.remaining <= 0) {
+          pending.delete(id);
+          t.handler();
+        }
+      }
+    },
+    pendingCount: () => pending.size,
+  };
+}
+
+test("coalesces a burst into a single trailing call", () => {
+  const { host, advance } = makeHost();
+  let calls = 0;
+  const d = createTrailingDebounce(() => calls++, 500, host);
+
+  d.trigger();
+  advance(100);
+  d.trigger(); // restarts the window
+  advance(100);
+  d.trigger(); // restarts again
+  assert.equal(calls, 0, "must not fire during the burst");
+
+  advance(500); // quiet period elapses after the last trigger
+  assert.equal(calls, 1, "fires exactly once after quiet");
+});
+
+test("restarts the quiet window on every trigger", () => {
+  const { host, advance } = makeHost();
+  let calls = 0;
+  const d = createTrailingDebounce(() => calls++, 500, host);
+
+  d.trigger();
+  advance(499);
+  d.trigger(); // reset just before firing
+  advance(499);
+  assert.equal(calls, 0, "reset prevents the earlier timer from firing");
+  advance(1);
+  assert.equal(calls, 1);
+});
+
+test("cancel() drops the pending call", () => {
+  const { host, advance, pendingCount } = makeHost();
+  let calls = 0;
+  const d = createTrailingDebounce(() => calls++, 500, host);
+
+  d.trigger();
+  d.cancel();
+  assert.equal(pendingCount(), 0, "no timer left pending");
+  advance(500);
+  assert.equal(calls, 0, "cancelled action never runs");
+});
+
+test("a later trigger after firing schedules a fresh call", () => {
+  const { host, advance } = makeHost();
+  let calls = 0;
+  const d = createTrailingDebounce(() => calls++, 500, host);
+
+  d.trigger();
+  advance(500);
+  assert.equal(calls, 1);
+
+  d.trigger();
+  advance(500);
+  assert.equal(calls, 2);
+});

--- a/desktop/src/shared/lib/trailingDebounce.ts
+++ b/desktop/src/shared/lib/trailingDebounce.ts
@@ -1,0 +1,40 @@
+export type TrailingDebounce = {
+  /** Schedule the action, restarting the quiet window on every call. */
+  trigger: () => void;
+  /** Cancel any pending action (e.g. on unmount). */
+  cancel: () => void;
+};
+
+type TimerHost = {
+  setTimeout: (handler: () => void, ms: number) => number;
+  clearTimeout: (id: number) => void;
+};
+
+/**
+ * Trailing debounce: a burst of `trigger()` calls collapses into a single
+ * `action()` that runs once, `delayMs` after the last call. The timer is
+ * restarted on every trigger, so a sustained burst keeps deferring until quiet.
+ */
+export function createTrailingDebounce(
+  action: () => void,
+  delayMs: number,
+  host: TimerHost = window,
+): TrailingDebounce {
+  let timeoutId: number | undefined;
+  const cancel = () => {
+    if (timeoutId !== undefined) {
+      host.clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+  };
+  return {
+    trigger: () => {
+      cancel();
+      timeoutId = host.setTimeout(() => {
+        timeoutId = undefined;
+        action();
+      }, delayMs);
+    },
+    cancel,
+  };
+}


### PR DESCRIPTION
## What & why

`get_channels` (the channel list) felt slow and fired duplicate stacked requests on a busy workspace (472 channels). This PR ships the **desktop-only** fixes for that — the relay/backend optimization has been split out per a request to hold off on backend changes for now.

## Changes (all desktop, zero relay/DB changes)

1. **Debounce the channel-list invalidation.** Every incoming message on a non-active channel fired a full `get_channels` refetch with no coalescing, stacking 3+ overlapping calls during bursts. Now a 500ms trailing debounce collapses a burst into a single refetch. Timer is cleaned up on unmount.
2. **Per-phase profiling for `get_channels`** (`#[cfg(debug_assertions)]` only — never ships in release). Prints each leg's wall-clock contribution so we can measure where the time goes.

## Measured context (472-channel workspace)

The duplicate storm was the felt slowness — multiple overlapping `get_channels` calls per burst of activity. This eliminates it. The raw single-call latency (~2.5–4s, dominated by per-channel relay round-trips) is **not** addressed here — that needs the relay/bulk-query work, deferred to a follow-up.

## Scope note

The relay fast-path (collapse 472 per-channel last-message queries → 1 indexed query) was removed from this PR and will be a separate change when backend changes are back on the table.

## Testing

- Debounce: timer coalescing + unmount cleanup.
- Profiling is debug-only, no release behavior change.
