### PR TITLE
Add Amp as a known ACP provider

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -9,7 +9,7 @@ Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
                                        (send_message, etc.)
 ```
 
-Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
+Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/zed-industries/codex-acp)), **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)), and **amp** (via [amp-acp](https://github.com/tao12345666333/amp-acp)).
 
 ## Prerequisites
 
@@ -90,6 +90,23 @@ buzz-acp
 
 Older installs that still expose `claude-code-acp` are also supported. `buzz-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
+
+## Running with Amp
+
+[amp-acp](https://github.com/tao12345666333/amp-acp) wraps Sourcegraph's Amp coding agent in an ACP interface.
+
+```bash
+# Install the adapter
+npm install -g amp-acp
+
+# Run
+export AMP_API_KEY="..."   # your Amp API key
+export BUZZ_ACP_AGENT_COMMAND="amp-acp"
+
+buzz-acp
+```
+
+The desktop app auto-discovers `amp-acp` if it's on PATH.
 
 ## Configuration
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -524,7 +524,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "buzz-agent" | "amp-acp" => Some(Vec::new()),
         _ => None,
     }
 }

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -68,8 +68,8 @@ const overrides = new Map([
   // refactor followup. discovery.rs is dominated by the new test module
   // (the effective_agent_command / divergent / create-time override matrix);
   // types.rs adds the persona/instance harness fields. Load-bearing, not
-  // generic debt.
-  ["src-tauri/src/managed_agents/discovery.rs", 1043],
+  // generic debt. Amp ACP provider entry (+22 lines) added in follow-up.
+  ["src-tauri/src/managed_agents/discovery.rs", 1065],
   ["src-tauri/src/managed_agents/types.rs", 1037],
   // migration_tests.rs carries the harness-sync migration coverage plus the
   // patch_json_records owner-only writeback regression test (SECURITY.md:90

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -47,6 +47,7 @@ pub(crate) struct KnownAcpRuntime {
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const AMP_AVATAR_URL: &str = "https://ampcode.com/img/amp-logo.png";
 const BUZZ_AGENT_AVATAR_URL: &str =
     "https://raw.githubusercontent.com/block/buzz/refs/heads/main/crates/buzz-agent/buzz-agent.png";
 
@@ -130,6 +131,27 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         cli_install_hint: "Install the Codex CLI via the official install script.",
         adapter_install_hint: "Install the Codex ACP adapter via npm.",
         skill_dir: Some(".codex/skills"),
+        supports_acp_model_switching: false,
+        model_env_var: None,
+        provider_env_var: None,
+        provider_locked: true,
+        default_env: &[],
+    },
+    KnownAcpRuntime {
+        id: "amp",
+        label: "Amp",
+        commands: &["amp-acp"],
+        aliases: &[],
+        avatar_url: AMP_AVATAR_URL,
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: Some("amp"),
+        cli_install_commands: &[],
+        adapter_install_commands: &["npm install -g amp-acp"],
+        install_instructions_url: "https://github.com/tao12345666333/amp-acp",
+        cli_install_hint: "Install Amp via https://ampcode.com.",
+        adapter_install_hint: "Install the Amp ACP adapter via npm.",
+        skill_dir: None,
         supports_acp_model_switching: false,
         model_env_var: None,
         provider_env_var: None,


### PR DESCRIPTION
Register [amp-acp](https://github.com/tao12345666333/amp-acp) as a known ACP provider alongside Goose, Claude Code, and Codex.

Revives #208 (originally by @akuttig-block), updated for the current `KnownAcpRuntime` struct shape.

## Changes

- **`desktop/src-tauri/src/managed_agents/discovery.rs`** — Add `amp` to `KNOWN_ACP_RUNTIMES` with command `amp-acp`, avatar URL, and all required struct fields
- **`crates/buzz-acp/src/config.rs`** — Add `amp-acp` to `default_agent_args()` match arm so it runs with no extra args
- **`crates/buzz-acp/README.md`** — Add "Running with Amp" section; list amp-acp in supported agents

## Install

```bash
npm install -g amp-acp
```

## Usage

```bash
export AMP_API_KEY="..."
export BUZZ_ACP_AGENT_COMMAND="amp-acp"
buzz-acp
```

The desktop app auto-discovers `amp-acp` if it's on PATH.