### PR TITLE
fix: prevent timeline cap from evicting backward-paged roots on live event

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -82,8 +82,9 @@ const overrides = new Map([
   // persona-events rebase: boot-time event-sync wiring (run_boot_migrations
   // syncs team-dir edits before all personas.json readers; run_event_sync
   // signs the persona/team retention events post-identity) layered on top of
-  // main's growth. Load-bearing feature growth, queued to split with the list.
-  ["src-tauri/src/lib.rs", 1034],
+  // main's growth. PR #1246 added show_native_notification to the Tauri
+  // command list. Load-bearing feature growth, queued to split with the list.
+  ["src-tauri/src/lib.rs", 1035],
   // onMarkRead + isUnread prop threading (mirrors the onMarkUnread prop
   // already here) for the single-toggle mark-read/unread menu item — a small
   // overage from load-bearing per-message plumbing, not generic debt growth.

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -5,6 +5,8 @@ import {
   channelMessagesKey,
   dedupeMessagesById,
   mergeTimelineHistoryMessages,
+  MAX_TIMELINE_MESSAGES,
+  isTimelineWindowContentEvent,
   normalizeTimelineMessages,
   sortMessages,
 } from "@/features/messages/lib/messageQueryKeys";
@@ -111,11 +113,40 @@ export function mergeTimelineCacheMessages(
   current: RelayEvent[],
   incoming: RelayEvent,
 ): RelayEvent[] {
-  return mergeMessagesWithNormalizer(
-    current,
-    incoming,
-    normalizeTimelineMessages,
+  const normalizedCurrent = dedupeMessagesById(current);
+  const replacedPending = normalizedCurrent.find((message) =>
+    isMatchingPendingMessage(message, incoming),
   );
+  const incomingWithLocalKey = replacedPending
+    ? {
+        ...incoming,
+        localKey: replacedPending.localKey ?? replacedPending.id,
+      }
+    : incoming;
+  const incomingLocalKey = getLocalRenderKey(incomingWithLocalKey);
+  const deduped = normalizedCurrent.filter(
+    (message) =>
+      message.id !== incoming.id &&
+      getLocalRenderKey(message) !== incomingLocalKey &&
+      !isMatchingPendingMessage(message, incoming),
+  );
+  const merged = [...deduped, incomingWithLocalKey];
+  // Check backward-paged state on the ORIGINAL current (before dedup+incoming)
+  // so a live event arriving while scrolled back doesn't evict the older roots.
+  const contentCount = current.filter(isTimelineWindowContentEvent).length;
+  if (contentCount > MAX_TIMELINE_MESSAGES) {
+    // Backward-paged state: the cache has grown past MAX_TIMELINE_MESSAGES via
+    // prepend (the user has scrolled back far enough to load older history).
+    // Skip the cap here so a live event doesn't evict the backward-paged roots
+    // and stall pagination. Note: this means the cache can grow beyond
+    // MAX_TIMELINE_MESSAGES while the user is scrolled back — the same gap
+    // that already exists on the normalizeTimelineHistoryMessages path. A
+    // bounded ceiling for both paths is a follow-up; the risk is acceptable
+    // because scrollback sessions are finite and the cap re-engages on the
+    // next channel mount.
+    return sortMessages(merged);
+  }
+  return normalizeTimelineMessages(merged);
 }
 
 function createOptimisticMessage(

--- a/desktop/src/features/messages/lib/messageQueryKeys.ts
+++ b/desktop/src/features/messages/lib/messageQueryKeys.ts
@@ -12,7 +12,7 @@ import {
   KIND_SYSTEM_MESSAGE,
 } from "@/shared/constants/kinds";
 
-const MAX_TIMELINE_MESSAGES = 2_000;
+export const MAX_TIMELINE_MESSAGES = 2_000;
 
 export function channelMessagesKey(channelId: string) {
   return ["channel-messages", channelId] as const;
@@ -49,7 +49,7 @@ export function sortMessages(messages: RelayEvent[]) {
   });
 }
 
-function isTimelineWindowContentEvent(event: RelayEvent) {
+export function isTimelineWindowContentEvent(event: RelayEvent) {
   return (
     event.kind === KIND_STREAM_MESSAGE ||
     event.kind === KIND_STREAM_MESSAGE_V2 ||


### PR DESCRIPTION
Two CI failures on `main`:

## Fix 1 — `lib.rs` file-size guard (chore)

PR #1246 added `show_native_notification` to the Tauri command list, growing `lib.rs` by one line. Bumps the approved override in `check-file-sizes.mjs` from `1034` to `1035` and updates the comment to mention #1246.

## Fix 2 — Timeline cap evicts backward-paged roots on live event

**Root cause:** When the user scrolls back past `MAX_TIMELINE_MESSAGES` (2000) events, a live subscription event arriving via `mergeTimelineCacheMessages` called `normalizeTimelineMessages`, which caps to the newest 2000 events. This evicted the backward-paged roots, reset `oldestAfterMerge`, and stalled pagination — `deepest` stalled at ~471 instead of reaching < 50. Test `scroll-history.spec.ts:1363` ("channel intro stays hidden while paginating past the timeline cap") was failing.

**Fix:** `mergeTimelineCacheMessages` now checks the content-event count on the ORIGINAL `current` array (before dedup+incoming). If the cache is already in backward-paged state (`> MAX_TIMELINE_MESSAGES` content events), it skips the cap and returns sort+dedupe only. The cap still applies during normal live sessions (cache at or under the limit).

Also exports `isTimelineWindowContentEvent` and `MAX_TIMELINE_MESSAGES` from `messageQueryKeys.ts` so `hooks.ts` can reference them directly.

**Files changed:**
- `desktop/scripts/check-file-sizes.mjs` — bump `lib.rs` override 1034 → 1035
- `desktop/src/features/messages/lib/messageQueryKeys.ts` — export `isTimelineWindowContentEvent` and `MAX_TIMELINE_MESSAGES`
- `desktop/src/features/messages/hooks.ts` — inline backward-paged state check in `mergeTimelineCacheMessages`