### PR TITLE
fix(relay): include git hook tools in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,9 @@ LABEL org.opencontainers.image.title="Buzz" \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
+        curl \
         git \
+        openssl \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system --gid 1000 buzz \
     && useradd  --system --uid 1000 --gid 1000 --home-dir /var/lib/buzz \

--- a/crates/buzz-relay/src/api/git/hook.rs
+++ b/crates/buzz-relay/src/api/git/hook.rs
@@ -174,3 +174,32 @@ pub async fn install_hook(repo_path: &Path) -> anyhow::Result<()> {
     info!(repo = %repo_path.display(), "pre-receive hook installed");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PRE_RECEIVE_HOOK;
+
+    #[test]
+    fn runtime_image_installs_pre_receive_hook_tools() {
+        let dockerfile = include_str!("../../../../../Dockerfile");
+        let runtime_stage = dockerfile
+            .split("FROM debian:${DEBIAN_VERSION}-slim AS runtime")
+            .nth(1)
+            .expect("Dockerfile should have a runtime stage");
+        let runtime_setup = runtime_stage
+            .split("COPY --from=builder")
+            .next()
+            .expect("runtime stage should copy built artifacts after package setup");
+
+        for tool in ["curl", "openssl"] {
+            assert!(
+                PRE_RECEIVE_HOOK.contains(tool),
+                "test setup expected the pre-receive hook to invoke {tool}"
+            );
+            assert!(
+                runtime_setup.contains(&format!("\n        {tool} \\")),
+                "relay runtime image must install {tool}; the git pre-receive hook uses it and fails closed without it"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- install `curl` and `openssl` in the relay runtime image
- the Buzz git pre-receive hook shells out to both tools before calling `/internal/git/policy`
- without them, git pushes fail closed with `push authorization failed (network error reaching policy service)`

## Testing
- pre-push hooks ran on push: check-push-org, desktop-test, mobile-test, rust-tests, desktop-tauri-test

## Context
This should unblock pushes to Buzz git projects such as `agent-video-recorder` once the staging image is rebuilt/redeployed.