### PR TITLE
Image attachment gallery lightbox

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         "**/active-turn-resilience.spec.ts",
         "**/profile-active-turn.spec.ts",
         "**/file-attachment.spec.ts",
+        "**/image-attachment-gallery.spec.ts",
         "**/video-attachment.spec.ts",
         "**/spoiler.spec.ts",
         "**/mentions.spec.ts",

--- a/desktop/src/shared/styles/globals.css
+++ b/desktop/src/shared/styles/globals.css
@@ -2159,8 +2159,7 @@
   }
 }
 
-/* ── Image lightbox zoom slider (shared/ui/markdown) ───────────────────
-   Matches the white-on-glass media control track used by the video player. */
+/* ── Image lightbox zoom slider (shared/ui/markdown) ─────────────────── */
 .image-zoom-slider {
   appearance: none;
   background: transparent;
@@ -2169,7 +2168,7 @@
 .image-zoom-slider:focus-visible {
   outline: none;
   border-radius: 9999px;
-  box-shadow: 0 0 0 2px rgb(255 255 255 / 0.7);
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.7);
 }
 
 .image-zoom-slider::-webkit-slider-runnable-track {
@@ -2177,8 +2176,8 @@
   border-radius: 9999px;
   background: linear-gradient(
     to right,
-    white var(--image-zoom-fill, 0%),
-    rgb(255 255 255 / 0.3) var(--image-zoom-fill, 0%)
+    currentColor var(--image-zoom-fill, 0%),
+    color-mix(in srgb, currentColor 30%, transparent) var(--image-zoom-fill, 0%)
   );
 }
 
@@ -2189,26 +2188,26 @@
   height: 12px;
   width: 12px;
   border-radius: 9999px;
-  background: white;
+  background: currentColor;
   box-shadow: 0 1px 3px rgb(0 0 0 / 0.3);
 }
 
 .image-zoom-slider:focus-visible::-webkit-slider-thumb {
   box-shadow:
-    0 0 0 3px rgb(255 255 255 / 0.25),
+    0 0 0 3px hsl(var(--ring) / 0.25),
     0 1px 3px rgb(0 0 0 / 0.3);
 }
 
 .image-zoom-slider::-moz-range-track {
   height: 4px;
   border-radius: 9999px;
-  background: rgb(255 255 255 / 0.3);
+  background: color-mix(in srgb, currentColor 30%, transparent);
 }
 
 .image-zoom-slider::-moz-range-progress {
   height: 4px;
   border-radius: 9999px;
-  background: white;
+  background: currentColor;
 }
 
 .image-zoom-slider::-moz-range-thumb {
@@ -2216,13 +2215,13 @@
   height: 12px;
   width: 12px;
   border-radius: 9999px;
-  background: white;
+  background: currentColor;
   box-shadow: 0 1px 3px rgb(0 0 0 / 0.3);
 }
 
 .image-zoom-slider:focus-visible::-moz-range-thumb {
   box-shadow:
-    0 0 0 3px rgb(255 255 255 / 0.25),
+    0 0 0 3px hsl(var(--ring) / 0.25),
     0 1px 3px rgb(0 0 0 / 0.3);
 }
 

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -302,6 +302,7 @@ type ImageGalleryItem = {
   dim?: string;
   resolvedSrc: string;
   src: string | undefined;
+  thumbnailBox?: ImageLightboxBox;
 };
 
 type ImageBlockProps = {
@@ -438,7 +439,7 @@ function imageLightboxBasisBoxForItem(
 ): ImageLightboxBox {
   const dimensions = dimensionsFromDim(item.dim);
   if (!dimensions) {
-    return fallbackBox;
+    return item.thumbnailBox ?? fallbackBox;
   }
 
   return {
@@ -448,11 +449,10 @@ function imageLightboxBasisBoxForItem(
   };
 }
 
-function imageLightboxReturnBoxForItem(
+function imageLightboxThumbnailBoxForItem(
   item: ImageGalleryItem,
-  fallbackBox: ImageLightboxBox,
   sourceScope: Element | null | undefined,
-): ImageLightboxBox {
+): ImageLightboxBox | null {
   const root = sourceScope?.isConnected ? sourceScope : document.body;
   const triggers = Array.from(
     root.querySelectorAll<HTMLElement>("[data-image-lightbox-trigger]"),
@@ -473,11 +473,24 @@ function imageLightboxReturnBoxForItem(
     }
   }
 
-  return fallbackBox;
+  return null;
+}
+
+function imageLightboxReturnBoxForItem(
+  item: ImageGalleryItem,
+  fallbackBox: ImageLightboxBox,
+  sourceScope: Element | null | undefined,
+): ImageLightboxBox {
+  return (
+    imageLightboxThumbnailBoxForItem(item, sourceScope) ??
+    item.thumbnailBox ??
+    fallbackBox
+  );
 }
 
 function imageGalleryItemFromTrigger(
   trigger: HTMLElement,
+  thumbnailBox?: ImageLightboxBox,
 ): ImageGalleryItem | null {
   const resolvedSrc = trigger.dataset.imageLightboxResolvedSrc;
   if (!resolvedSrc) {
@@ -489,6 +502,7 @@ function imageGalleryItemFromTrigger(
     dim: trigger.dataset.imageLightboxDim || undefined,
     resolvedSrc,
     src: trigger.dataset.imageLightboxSrc || undefined,
+    thumbnailBox,
   };
 }
 
@@ -542,7 +556,8 @@ function visibleImageGalleryForTrigger(
       continue;
     }
 
-    const item = imageGalleryItemFromTrigger(candidate);
+    const thumbnailBox = imageLightboxBoxFromRect(rect);
+    const item = imageGalleryItemFromTrigger(candidate, thumbnailBox);
     if (!item) {
       continue;
     }
@@ -676,8 +691,8 @@ function ImageZoomOverlay({
   const shouldReduceMotion = useReducedMotion();
   const prefersReducedMotion = shouldReduceMotion === true;
   const fallbackGalleryItems = React.useMemo<ImageGalleryItem[]>(
-    () => [{ alt, resolvedSrc, src }],
-    [alt, resolvedSrc, src],
+    () => [{ alt, resolvedSrc, src, thumbnailBox: sourceBox }],
+    [alt, resolvedSrc, sourceBox, src],
   );
   const items =
     galleryItems && galleryItems.length > 0
@@ -1525,19 +1540,20 @@ function ImageBlock({ alt, dim, resolvedSrc, src }: ImageBlockProps) {
       }
 
       setMenu(null);
+      const sourceBox = imageLightboxBoxFromRect(rect);
       const sourceScope =
         triggerRef.current?.closest("[data-testid='message-row']") ?? null;
       const gallery = triggerRef.current
         ? visibleImageGalleryForTrigger(
             triggerRef.current,
-            { alt, dim, resolvedSrc, src },
+            { alt, dim, resolvedSrc, src, thumbnailBox: sourceBox },
             sourceScope,
           )
         : { galleryIndex: 0, galleryItems: undefined };
       setLightboxState({
         galleryIndex: gallery.galleryIndex,
         galleryItems: gallery.galleryItems,
-        sourceBox: imageLightboxBoxFromRect(rect),
+        sourceBox,
         sourceScope,
       });
     },

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -4,8 +4,16 @@ import ReactMarkdown, {
   type Components,
   defaultUrlTransform,
 } from "react-markdown";
-import { Copy, Download, FileText, ZoomIn, ZoomOut } from "lucide-react";
-import { useReducedMotion } from "motion/react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  Download,
+  FileText,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
@@ -287,10 +295,31 @@ type ImageLightboxBox = {
   width: number;
 };
 
+type ImageGalleryDirection = "forward" | "backward";
+
+type ImageGalleryItem = {
+  alt: string | undefined;
+  dim?: string;
+  resolvedSrc: string;
+  src: string | undefined;
+};
+
+type ImageBlockProps = {
+  alt: string | undefined;
+  dim?: string;
+  galleryIndex?: number;
+  galleryItems?: ImageGalleryItem[];
+  resolvedSrc: string | undefined;
+  src: string | undefined;
+};
+
 const IMAGE_LIGHTBOX_ENTER_MS = 260;
 const IMAGE_LIGHTBOX_EXIT_MS = 170;
 const IMAGE_LIGHTBOX_FADE_ENTER_MS = 180;
 const IMAGE_LIGHTBOX_FADE_EXIT_MS = 90;
+const IMAGE_LIGHTBOX_GALLERY_SLIDE_MS = 280;
+const IMAGE_LIGHTBOX_GALLERY_SLIDE_DISTANCE_PX = 48;
+const IMAGE_LIGHTBOX_GALLERY_BLUR_PX = 4;
 const IMAGE_LIGHTBOX_REDUCED_MOTION_MS = 100;
 const IMAGE_LIGHTBOX_ZOOM_TRANSITION_MS = 80;
 const IMAGE_LIGHTBOX_BASE_VIEWPORT_RATIO = 0.8;
@@ -303,6 +332,9 @@ const IMAGE_LIGHTBOX_MAX_ZOOM = 3;
 const IMAGE_LIGHTBOX_ZOOM_STEP = 0.05;
 const IMAGE_LIGHTBOX_EASE_OUT = "cubic-bezier(0.23, 1, 0.32, 1)";
 const IMAGE_LIGHTBOX_EASE_IN_OUT = "cubic-bezier(0.77, 0, 0.175, 1)";
+const IMAGE_LIGHTBOX_GALLERY_EASE: [number, number, number, number] = [
+  0.22, 1, 0.36, 1,
+];
 
 function imageLightboxBoxFromRect(rect: DOMRect): ImageLightboxBox {
   return {
@@ -402,6 +434,74 @@ function imageLightboxZoomBox(
   };
 }
 
+function imageLightboxBasisBoxForItem(
+  item: ImageGalleryItem,
+  fallbackBox: ImageLightboxBox,
+): ImageLightboxBox {
+  const dimensions = dimensionsFromDim(item.dim);
+  if (!dimensions) {
+    return fallbackBox;
+  }
+
+  return {
+    ...fallbackBox,
+    height: dimensions.height,
+    width: dimensions.width,
+  };
+}
+
+function imageLightboxReturnBoxForItem(
+  item: ImageGalleryItem,
+  fallbackBox: ImageLightboxBox,
+  sourceScope: Element | null | undefined,
+): ImageLightboxBox {
+  const root = sourceScope?.isConnected ? sourceScope : document.body;
+  const triggers = Array.from(
+    root.querySelectorAll<HTMLElement>("[data-image-lightbox-trigger]"),
+  );
+
+  for (const trigger of triggers) {
+    const isCurrentItem =
+      trigger.dataset.imageLightboxResolvedSrc === item.resolvedSrc ||
+      (item.src != null && trigger.dataset.imageLightboxSrc === item.src);
+    if (!isCurrentItem) {
+      continue;
+    }
+
+    const image = trigger.querySelector("img");
+    const rect = (image ?? trigger).getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      return imageLightboxBoxFromRect(rect);
+    }
+  }
+
+  return fallbackBox;
+}
+
+function imageGalleryItemsFromImeta(
+  imetaByUrl?: ImetaLookup,
+): ImageGalleryItem[] | undefined {
+  if (!imetaByUrl) {
+    return undefined;
+  }
+
+  const items: ImageGalleryItem[] = [];
+  for (const [url, entry] of imetaByUrl) {
+    if (!entry.m?.startsWith("image/")) {
+      continue;
+    }
+
+    items.push({
+      alt: entry.filename ?? "image",
+      dim: entry.dim,
+      resolvedSrc: rewriteRelayUrl(url),
+      src: url,
+    });
+  }
+
+  return items.length > 0 ? items : undefined;
+}
+
 type WebKitGestureLikeEvent = Event & {
   scale?: number;
 };
@@ -491,33 +591,60 @@ function ImageDownloadContextMenu({
 
 function ImageZoomOverlay({
   alt,
-  canDownload,
+  galleryIndex = 0,
+  galleryItems,
   onDownload,
   onClose,
   resolvedSrc,
   sourceBox,
+  sourceScope,
+  src,
 }: {
   alt: string | undefined;
-  canDownload: boolean;
-  onDownload: () => void;
+  galleryIndex?: number;
+  galleryItems?: ImageGalleryItem[];
+  onDownload: (src: string | undefined) => void;
   onClose: () => void;
   resolvedSrc: string;
   sourceBox: ImageLightboxBox;
+  sourceScope?: Element | null;
+  src: string | undefined;
 }) {
   const shouldReduceMotion = useReducedMotion();
   const prefersReducedMotion = shouldReduceMotion === true;
+  const fallbackGalleryItems = React.useMemo<ImageGalleryItem[]>(
+    () => [{ alt, resolvedSrc, src }],
+    [alt, resolvedSrc, src],
+  );
+  const items =
+    galleryItems && galleryItems.length > 0
+      ? galleryItems
+      : fallbackGalleryItems;
+  const safeInitialIndex =
+    galleryIndex >= 0 && galleryIndex < items.length ? galleryIndex : 0;
+  const [currentIndex, setCurrentIndex] = React.useState(safeInitialIndex);
+  const [galleryDirection, setGalleryDirection] =
+    React.useState<ImageGalleryDirection>("forward");
   const [phase, setPhase] = React.useState<
     "opening" | "open" | "closing" | "fading"
   >(() => (prefersReducedMotion ? "open" : "opening"));
   const [hasEntered, setHasEntered] = React.useState(prefersReducedMotion);
   const [isAdjustingZoom, setIsAdjustingZoom] = React.useState(false);
+  const [isGalleryNavigating, setIsGalleryNavigating] = React.useState(false);
   const [menu, setMenu] = React.useState<ImageContextMenuPosition | null>(null);
-  const [targetBox, setTargetBox] = React.useState(() =>
-    imageLightboxTargetBox(sourceBox),
+  const currentItem = items[currentIndex] ?? items[0];
+  const basisBox = React.useMemo(
+    () => imageLightboxBasisBoxForItem(currentItem, sourceBox),
+    [currentItem, sourceBox],
   );
+  const [targetBox, setTargetBox] = React.useState(() =>
+    imageLightboxTargetBox(basisBox),
+  );
+  const [returnBox, setReturnBox] = React.useState(sourceBox);
   const [zoom, setZoom] = React.useState(IMAGE_LIGHTBOX_MIN_ZOOM);
   const controlPointerDownRef = React.useRef(false);
   const fadeTimerRef = React.useRef<number | null>(null);
+  const galleryTransitionTimerRef = React.useRef<number | null>(null);
   const closeTimerRef = React.useRef<number | null>(null);
   const dialogRef = React.useRef<HTMLDivElement | null>(null);
   const descriptionId = React.useId();
@@ -525,6 +652,37 @@ function ImageZoomOverlay({
   const previouslyFocusedElementRef = React.useRef<HTMLElement | null>(null);
   const suppressCloseUntilRef = React.useRef(0);
   const zoomIdleTimerRef = React.useRef<number | null>(null);
+  const hasPreviousImage = currentIndex > 0;
+  const hasNextImage = currentIndex < items.length - 1;
+  const canDownloadCurrentImage = Boolean(currentItem.src);
+  const galleryTransitionFilter =
+    !prefersReducedMotion && isGalleryNavigating
+      ? `blur(${IMAGE_LIGHTBOX_GALLERY_BLUR_PX}px)`
+      : "blur(0px)";
+  const galleryImageVariants = React.useMemo(
+    () => ({
+      center: { filter: "blur(0px)", opacity: 1, x: 0 },
+      enter: (direction: ImageGalleryDirection) => ({
+        filter: galleryTransitionFilter,
+        opacity: 0,
+        x: prefersReducedMotion
+          ? 0
+          : direction === "forward"
+            ? IMAGE_LIGHTBOX_GALLERY_SLIDE_DISTANCE_PX
+            : -IMAGE_LIGHTBOX_GALLERY_SLIDE_DISTANCE_PX,
+      }),
+      exit: (direction: ImageGalleryDirection) => ({
+        filter: galleryTransitionFilter,
+        opacity: 0,
+        x: prefersReducedMotion
+          ? 0
+          : direction === "forward"
+            ? -IMAGE_LIGHTBOX_GALLERY_SLIDE_DISTANCE_PX
+            : IMAGE_LIGHTBOX_GALLERY_SLIDE_DISTANCE_PX,
+      }),
+    }),
+    [galleryTransitionFilter, prefersReducedMotion],
+  );
 
   const markControlGesture = React.useCallback(() => {
     suppressCloseUntilRef.current =
@@ -553,6 +711,15 @@ function ImageZoomOverlay({
   const close = React.useCallback(() => {
     if (closeTimerRef.current != null) return;
 
+    if (galleryTransitionTimerRef.current != null) {
+      window.clearTimeout(galleryTransitionTimerRef.current);
+      galleryTransitionTimerRef.current = null;
+    }
+    setIsGalleryNavigating(false);
+    setReturnBox(
+      imageLightboxReturnBoxForItem(currentItem, sourceBox, sourceScope),
+    );
+
     if (prefersReducedMotion) {
       setPhase("fading");
       closeTimerRef.current = window.setTimeout(() => {
@@ -568,7 +735,43 @@ function ImageZoomOverlay({
     closeTimerRef.current = window.setTimeout(() => {
       onClose();
     }, IMAGE_LIGHTBOX_EXIT_MS + IMAGE_LIGHTBOX_FADE_EXIT_MS);
-  }, [onClose, prefersReducedMotion]);
+  }, [currentItem, onClose, prefersReducedMotion, sourceBox, sourceScope]);
+
+  const navigateGallery = React.useCallback(
+    (nextIndex: number) => {
+      if (
+        nextIndex < 0 ||
+        nextIndex >= items.length ||
+        nextIndex === currentIndex
+      ) {
+        return;
+      }
+
+      markControlGesture();
+      setMenu(null);
+      setGalleryDirection(nextIndex > currentIndex ? "forward" : "backward");
+      if (galleryTransitionTimerRef.current != null) {
+        window.clearTimeout(galleryTransitionTimerRef.current);
+      }
+      setIsGalleryNavigating(!prefersReducedMotion);
+      galleryTransitionTimerRef.current = window.setTimeout(() => {
+        setIsGalleryNavigating(false);
+        galleryTransitionTimerRef.current = null;
+      }, IMAGE_LIGHTBOX_GALLERY_SLIDE_MS);
+      setIsAdjustingZoom(false);
+      setZoom(IMAGE_LIGHTBOX_MIN_ZOOM);
+      setCurrentIndex(nextIndex);
+    },
+    [currentIndex, items.length, markControlGesture, prefersReducedMotion],
+  );
+
+  const goToPreviousImage = React.useCallback(() => {
+    navigateGallery(currentIndex - 1);
+  }, [currentIndex, navigateGallery]);
+
+  const goToNextImage = React.useCallback(() => {
+    navigateGallery(currentIndex + 1);
+  }, [currentIndex, navigateGallery]);
 
   useDismissImageContextMenu(Boolean(menu), closeMenu);
 
@@ -665,16 +868,34 @@ function ImageZoomOverlay({
   }, []);
 
   React.useEffect(() => {
-    const handleResize = () => setTargetBox(imageLightboxTargetBox(sourceBox));
+    const handleResize = () => setTargetBox(imageLightboxTargetBox(basisBox));
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, [sourceBox]);
+  }, [basisBox]);
+
+  React.useEffect(() => {
+    setTargetBox(imageLightboxTargetBox(basisBox));
+  }, [basisBox]);
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
         close();
+        return;
+      }
+
+      const target = event.target;
+      const isRangeInput =
+        target instanceof HTMLInputElement && target.type === "range";
+      if (!isRangeInput && event.key === "ArrowLeft" && hasPreviousImage) {
+        event.preventDefault();
+        goToPreviousImage();
+        return;
+      }
+      if (!isRangeInput && event.key === "ArrowRight" && hasNextImage) {
+        event.preventDefault();
+        goToNextImage();
         return;
       }
 
@@ -727,7 +948,7 @@ function ImageZoomOverlay({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [close]);
+  }, [close, goToNextImage, goToPreviousImage, hasNextImage, hasPreviousImage]);
 
   React.useEffect(() => {
     const dialog = dialogRef.current;
@@ -810,6 +1031,9 @@ function ImageZoomOverlay({
       if (fadeTimerRef.current != null) {
         window.clearTimeout(fadeTimerRef.current);
       }
+      if (galleryTransitionTimerRef.current != null) {
+        window.clearTimeout(galleryTransitionTimerRef.current);
+      }
       if (closeTimerRef.current != null) {
         window.clearTimeout(closeTimerRef.current);
       }
@@ -822,7 +1046,9 @@ function ImageZoomOverlay({
   const isClosing = phase === "closing";
   const isOpen = phase === "open";
   const isFading = phase === "fading";
+  const isReturning = isClosing || isFading;
   const displayBox = imageLightboxZoomBox(targetBox, zoom);
+  const frameBox = isReturning ? returnBox : targetBox;
   // Once fully settled at 1x, drop the transform to `none` so the wrapper
   // leaves the GPU-composited path and the <img> repaints through WebKit's
   // high-quality paint rasterizer — matching inline-image sharpness. An
@@ -837,9 +1063,18 @@ function ImageZoomOverlay({
     !isAdjustingZoom;
   const transform = atRest
     ? "none"
-    : prefersReducedMotion || isOpen
-      ? imageLightboxTransform(targetBox, displayBox)
-      : imageLightboxTransform(targetBox, sourceBox);
+    : isReturning
+      ? "none"
+      : prefersReducedMotion || isOpen
+        ? imageLightboxTransform(targetBox, displayBox)
+        : imageLightboxTransform(targetBox, sourceBox);
+  const imageTransitionProperty = prefersReducedMotion
+    ? "opacity"
+    : isReturning
+      ? "height, left, opacity, top, transform, width"
+      : atRest
+        ? "opacity"
+        : "opacity, transform";
   const imageTransitionDuration = prefersReducedMotion
     ? IMAGE_LIGHTBOX_REDUCED_MOTION_MS
     : isClosing
@@ -858,31 +1093,31 @@ function ImageZoomOverlay({
     ((zoom - IMAGE_LIGHTBOX_MIN_ZOOM) /
       (IMAGE_LIGHTBOX_MAX_ZOOM - IMAGE_LIGHTBOX_MIN_ZOOM)) *
     100;
-  const label = alt?.trim() || "Image preview";
+  const label = currentItem.alt?.trim() || "Image preview";
   const handleImageContextMenu = React.useCallback(
     (event: React.MouseEvent<HTMLImageElement>) => {
       event.preventDefault();
       event.stopPropagation();
       event.nativeEvent.stopImmediatePropagation();
       markControlGesture();
-      if (canDownload) {
+      if (canDownloadCurrentImage) {
         setMenu({ x: event.clientX, y: event.clientY });
       }
     },
-    [canDownload, markControlGesture],
+    [canDownloadCurrentImage, markControlGesture],
   );
   const handleMenuDownload = React.useCallback(() => {
     setMenu(null);
     markControlGesture();
-    onDownload();
-  }, [markControlGesture, onDownload]);
+    onDownload(currentItem.src);
+  }, [currentItem.src, markControlGesture, onDownload]);
 
   return createPortal(
     <div
       aria-describedby={descriptionId}
       aria-label={label}
       aria-modal="true"
-      className="fixed inset-0 z-50 cursor-zoom-out outline-hidden"
+      className="dark video-review-theme fixed inset-0 z-50 cursor-zoom-out outline-hidden"
       onClick={(event) => {
         if (Date.now() < suppressCloseUntilRef.current) {
           return;
@@ -941,6 +1176,7 @@ function ImageZoomOverlay({
         }}
       />
       <div
+        data-image-lightbox-frame=""
         className={cn(
           "absolute z-10 origin-top-left overflow-visible transition-[opacity,transform]",
           // Only promote to a composited layer while animating; demoting at
@@ -948,27 +1184,80 @@ function ImageZoomOverlay({
           !atRest && "will-change-transform",
         )}
         style={{
-          ...imageLightboxStyle(targetBox),
-          opacity: prefersReducedMotion && isClosing ? 0 : 1,
+          ...imageLightboxStyle(frameBox),
+          opacity: prefersReducedMotion && isReturning ? 0 : 1,
           transform,
           transitionDuration: `${imageTransitionDuration}ms`,
           // At rest, exclude `transform` from the transition so the swap to
-          // `none` is instantaneous — a transitioned transform-to-`none` is
-          // browser-inconsistent and can flash at the settle.
-          transitionProperty:
-            prefersReducedMotion || atRest ? "opacity" : "opacity, transform",
+          // `none` is instantaneous. On close, animate the frame box instead
+          // of non-uniformly scaling the image back into the thumbnail.
+          transitionProperty: imageTransitionProperty,
           transitionTimingFunction: isClosing
             ? IMAGE_LIGHTBOX_EASE_IN_OUT
             : IMAGE_LIGHTBOX_EASE_OUT,
         }}
       >
-        <img
-          alt={alt}
-          className="h-full w-full rounded-lg object-contain shadow-2xl"
-          src={resolvedSrc}
-          onContextMenuCapture={handleImageContextMenu}
-        />
+        <div className="relative h-full w-full overflow-hidden rounded-lg shadow-2xl">
+          <AnimatePresence
+            custom={galleryDirection}
+            initial={false}
+            mode="popLayout"
+          >
+            <motion.img
+              alt={currentItem.alt}
+              animate="center"
+              className="absolute inset-0 h-full w-full object-contain"
+              custom={galleryDirection}
+              exit="exit"
+              initial="enter"
+              key={currentItem.resolvedSrc}
+              src={currentItem.resolvedSrc}
+              transition={{
+                duration: prefersReducedMotion
+                  ? IMAGE_LIGHTBOX_REDUCED_MOTION_MS / 1000
+                  : IMAGE_LIGHTBOX_GALLERY_SLIDE_MS / 1000,
+                ease: IMAGE_LIGHTBOX_GALLERY_EASE,
+              }}
+              variants={galleryImageVariants}
+              onContextMenuCapture={handleImageContextMenu}
+            />
+          </AnimatePresence>
+        </div>
       </div>
+      {hasPreviousImage ? (
+        <button
+          aria-label="Previous image"
+          className={cn(
+            "absolute left-3 top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-muted text-muted-foreground shadow-sm backdrop-blur-xl backdrop-saturate-150 transition-[background-color,color,opacity] duration-150 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/70 sm:left-6",
+            isOpen ? "opacity-100" : "pointer-events-none opacity-0",
+          )}
+          data-image-lightbox-controls=""
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            goToPreviousImage();
+          }}
+        >
+          <ChevronLeft className="h-6 w-6 -translate-x-[0.5px]" />
+        </button>
+      ) : null}
+      {hasNextImage ? (
+        <button
+          aria-label="Next image"
+          className={cn(
+            "absolute right-3 top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-muted text-muted-foreground shadow-sm backdrop-blur-xl backdrop-saturate-150 transition-[background-color,color,opacity] duration-150 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/70 sm:right-6",
+            isOpen ? "opacity-100" : "pointer-events-none opacity-0",
+          )}
+          data-image-lightbox-controls=""
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            goToNextImage();
+          }}
+        >
+          <ChevronRight className="h-6 w-6 translate-x-[0.5px]" />
+        </button>
+      ) : null}
       <div
         className={cn(
           "absolute inset-x-0 bottom-4 z-20 flex justify-center px-4 transition-[opacity,transform]",
@@ -981,27 +1270,30 @@ function ImageZoomOverlay({
       >
         <div
           aria-label="Image controls"
-          className="relative isolate flex min-h-11 max-w-[calc(100vw-2rem)] items-center gap-2 rounded-xl px-2 py-1.5 text-white"
+          className="relative isolate flex min-h-11 max-w-[calc(100vw-2rem)] items-center gap-2 rounded-xl px-2 py-1.5 text-muted-foreground"
           data-image-lightbox-controls=""
           role="toolbar"
         >
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] border border-white/10 bg-black/35 backdrop-blur-xl backdrop-saturate-150"
+            className="pointer-events-none absolute inset-0 -z-10 rounded-[inherit] bg-muted shadow-sm backdrop-blur-xl backdrop-saturate-150"
           />
           <button
             aria-label="Download image"
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-white transition-colors hover:bg-white/15 outline-hidden focus-visible:ring-2 focus-visible:ring-white/60 disabled:pointer-events-none disabled:opacity-45"
-            disabled={!canDownload}
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors hover:bg-muted-foreground/10 hover:text-foreground outline-hidden focus-visible:ring-2 focus-visible:ring-ring/70 disabled:pointer-events-none disabled:opacity-45"
+            disabled={!canDownloadCurrentImage}
             type="button"
             onClick={(event) => {
               event.stopPropagation();
-              onDownload();
+              onDownload(currentItem.src);
             }}
           >
             <Download className="h-4 w-4" />
           </button>
-          <div aria-hidden="true" className="h-5 w-px shrink-0 bg-white/15" />
+          <div
+            aria-hidden="true"
+            className="h-5 w-px shrink-0 bg-muted-foreground/15"
+          />
           <ZoomOut aria-hidden="true" className="h-4 w-4 shrink-0 opacity-80" />
           <input
             aria-label="Image zoom"
@@ -1032,12 +1324,12 @@ function ImageZoomOverlay({
             }}
           />
           <ZoomIn aria-hidden="true" className="h-4 w-4 shrink-0 opacity-80" />
-          <span className="min-w-10 text-right text-xs font-medium tabular-nums text-white/90">
+          <span className="min-w-10 text-right text-xs font-medium tabular-nums text-muted-foreground">
             {Math.round(zoom * 100)}%
           </span>
         </div>
       </div>
-      {menu && canDownload ? (
+      {menu && canDownloadCurrentImage ? (
         <ImageDownloadContextMenu
           onDownload={handleMenuDownload}
           position={menu}
@@ -1060,17 +1352,16 @@ function ImageZoomOverlay({
 function ImageBlock({
   alt,
   dim,
+  galleryIndex,
+  galleryItems,
   resolvedSrc,
   src,
-}: {
-  alt: string | undefined;
-  dim?: string;
-  resolvedSrc: string | undefined;
-  src: string | undefined;
-}) {
-  const [lightboxBox, setLightboxBox] = React.useState<ImageLightboxBox | null>(
-    null,
-  );
+}: ImageBlockProps) {
+  const [lightboxState, setLightboxState] = React.useState<{
+    galleryIndex: number;
+    sourceBox: ImageLightboxBox;
+    sourceScope: Element | null;
+  } | null>(null);
   const [isHiddenInSpoiler, setIsHiddenInSpoiler] = React.useState(false);
   const [menu, setMenu] = React.useState<ImageContextMenuPosition | null>(null);
   const inlineImageRef = React.useRef<HTMLImageElement | null>(null);
@@ -1177,9 +1468,14 @@ function ImageBlock({
       }
 
       setMenu(null);
-      setLightboxBox(imageLightboxBoxFromRect(rect));
+      setLightboxState({
+        galleryIndex: galleryIndex ?? 0,
+        sourceBox: imageLightboxBoxFromRect(rect),
+        sourceScope:
+          triggerRef.current?.closest("[data-testid='message-row']") ?? null,
+      });
     },
-    [resolvedSrc],
+    [galleryIndex, resolvedSrc],
   );
 
   const handleImageTriggerClick = () => {
@@ -1188,14 +1484,19 @@ function ImageBlock({
     }
   };
 
-  const handleDownload = () => {
-    setMenu(null);
-    if (!src) return;
-    invokeTauri("download_image", { url: src }).catch((err: unknown) => {
-      const msg = err instanceof Error ? err.message : "Download failed";
-      toast.error(msg);
-    });
-  };
+  const handleDownload = React.useCallback(
+    (downloadSrc: string | undefined) => {
+      setMenu(null);
+      if (!downloadSrc) return;
+      invokeTauri("download_image", { url: downloadSrc }).catch(
+        (err: unknown) => {
+          const msg = err instanceof Error ? err.message : "Download failed";
+          toast.error(msg);
+        },
+      );
+    },
+    [],
+  );
 
   return (
     <>
@@ -1204,8 +1505,11 @@ function ImageBlock({
         aria-label={alt?.trim() ? `Zoom image: ${alt}` : "Zoom image"}
         className={cn(
           "mt-1 inline-block min-w-0 max-w-full cursor-zoom-in rounded-xl border-0 bg-transparent p-0 text-left align-top focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/50",
-          lightboxBox && "opacity-0",
+          lightboxState && "opacity-0",
         )}
+        data-image-lightbox-resolved-src={resolvedSrc}
+        data-image-lightbox-src={src}
+        data-image-lightbox-trigger=""
         data-testid="message-image-lightbox-trigger"
         ref={triggerRef}
         tabIndex={isHiddenInSpoiler ? -1 : undefined}
@@ -1226,20 +1530,98 @@ function ImageBlock({
         />
       </button>
       {menu && src ? (
-        <ImageDownloadContextMenu onDownload={handleDownload} position={menu} />
+        <ImageDownloadContextMenu
+          onDownload={() => handleDownload(src)}
+          position={menu}
+        />
       ) : null}
-      {lightboxBox && resolvedSrc ? (
+      {lightboxState && resolvedSrc ? (
         <ImageZoomOverlay
           alt={alt}
-          canDownload={Boolean(src)}
+          galleryIndex={lightboxState.galleryIndex}
+          galleryItems={galleryItems}
           onDownload={handleDownload}
-          onClose={() => setLightboxBox(null)}
+          onClose={() => setLightboxState(null)}
           resolvedSrc={resolvedSrc}
-          sourceBox={lightboxBox}
+          sourceBox={lightboxState.sourceBox}
+          sourceScope={lightboxState.sourceScope}
+          src={src}
         />
       ) : null}
     </>
   );
+}
+
+function isImageBlockElement(
+  node: React.ReactNode,
+): node is React.ReactElement<ImageBlockProps> {
+  return (
+    React.isValidElement<ImageBlockProps>(node) && node.type === ImageBlock
+  );
+}
+
+function collectImageGalleryItems(
+  children: React.ReactNode[],
+): ImageGalleryItem[] {
+  const items: ImageGalleryItem[] = [];
+
+  const visit = (node: React.ReactNode) => {
+    if (!React.isValidElement<{ children?: React.ReactNode }>(node)) {
+      return;
+    }
+
+    if (isImageBlockElement(node)) {
+      const { alt, dim, resolvedSrc, src } = node.props;
+      if (resolvedSrc) {
+        items.push({ alt, dim, resolvedSrc, src });
+      }
+      return;
+    }
+
+    React.Children.forEach(node.props.children, visit);
+  };
+
+  children.forEach(visit);
+  return items;
+}
+
+function attachImageGalleryProps(
+  children: React.ReactNode[],
+  galleryItems: ImageGalleryItem[],
+): React.ReactNode[] {
+  if (galleryItems.length <= 1) {
+    return children;
+  }
+
+  let nextGalleryIndex = 0;
+
+  const visit = (node: React.ReactNode): React.ReactNode => {
+    if (!React.isValidElement<{ children?: React.ReactNode }>(node)) {
+      return node;
+    }
+
+    if (isImageBlockElement(node)) {
+      if (!node.props.resolvedSrc) {
+        return node;
+      }
+
+      const galleryIndex = nextGalleryIndex;
+      nextGalleryIndex += 1;
+      return React.cloneElement(node, { galleryIndex, galleryItems });
+    }
+
+    if (node.props.children == null) {
+      return node;
+    }
+
+    return React.cloneElement(
+      node,
+      undefined,
+      React.Children.map(node.props.children, visit),
+    );
+  };
+
+  return children.map(visit);
 }
 
 function getReactNodeText(node: React.ReactNode): string {
@@ -1981,11 +2363,25 @@ function createMarkdownComponents(
         );
       }
       const entry = src ? imetaByUrl?.get(src) : undefined;
+      const imetaGalleryItems = imageGalleryItemsFromImeta(imetaByUrl);
+      const imetaGalleryIndex = src
+        ? imetaGalleryItems?.findIndex((item) => item.src === src)
+        : -1;
       return (
         <span data-block-media="" className="block min-w-0 max-w-full">
           <ImageBlock
             alt={alt}
             dim={entry?.dim}
+            galleryIndex={
+              imetaGalleryIndex != null && imetaGalleryIndex >= 0
+                ? imetaGalleryIndex
+                : undefined
+            }
+            galleryItems={
+              imetaGalleryIndex != null && imetaGalleryIndex >= 0
+                ? imetaGalleryItems
+                : undefined
+            }
             resolvedSrc={resolvedSrc}
             src={src}
           />
@@ -2005,9 +2401,15 @@ function createMarkdownComponents(
       const { imageChildren } = classifyChildren(childArray);
 
       if (isImageOnlyParagraph(childArray)) {
+        const galleryItems = collectImageGalleryItems(imageChildren);
+        const galleryChildren = attachImageGalleryProps(
+          imageChildren,
+          galleryItems,
+        );
+
         return (
           <div className="mt-1 grid w-full min-w-0 max-w-lg grid-cols-2 gap-1.5 [&_br]:hidden [&_[data-block-media]]:mt-0 [&_[data-block-media]]:max-w-none [&_img]:mt-0 [&_img]:w-full [&_img]:max-w-full">
-            {imageChildren}
+            {galleryChildren}
           </div>
         );
       }

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -307,8 +307,6 @@ type ImageGalleryItem = {
 type ImageBlockProps = {
   alt: string | undefined;
   dim?: string;
-  galleryIndex?: number;
-  galleryItems?: ImageGalleryItem[];
   resolvedSrc: string | undefined;
   src: string | undefined;
 };
@@ -478,28 +476,93 @@ function imageLightboxReturnBoxForItem(
   return fallbackBox;
 }
 
-function imageGalleryItemsFromImeta(
-  imetaByUrl?: ImetaLookup,
-): ImageGalleryItem[] | undefined {
-  if (!imetaByUrl) {
-    return undefined;
+function imageGalleryItemFromTrigger(
+  trigger: HTMLElement,
+): ImageGalleryItem | null {
+  const resolvedSrc = trigger.dataset.imageLightboxResolvedSrc;
+  if (!resolvedSrc) {
+    return null;
   }
 
-  const items: ImageGalleryItem[] = [];
-  for (const [url, entry] of imetaByUrl) {
-    if (!entry.m?.startsWith("image/")) {
+  return {
+    alt: trigger.dataset.imageLightboxAlt || undefined,
+    dim: trigger.dataset.imageLightboxDim || undefined,
+    resolvedSrc,
+    src: trigger.dataset.imageLightboxSrc || undefined,
+  };
+}
+
+function isVisibleImageLightboxTrigger(trigger: HTMLElement): boolean {
+  if (isInsideHiddenSpoiler(trigger)) {
+    return false;
+  }
+
+  const image = trigger.querySelector("img");
+  for (const element of [trigger, image]) {
+    if (!element) {
       continue;
     }
 
-    items.push({
-      alt: entry.filename ?? "image",
-      dim: entry.dim,
-      resolvedSrc: rewriteRelayUrl(url),
-      src: url,
-    });
+    const style = window.getComputedStyle(element);
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      Number(style.opacity) === 0
+    ) {
+      return false;
+    }
   }
 
-  return items.length > 0 ? items : undefined;
+  return true;
+}
+
+function visibleImageGalleryForTrigger(
+  trigger: HTMLElement,
+  fallbackItem: ImageGalleryItem,
+  sourceScope: Element | null | undefined,
+): { galleryIndex: number; galleryItems?: ImageGalleryItem[] } {
+  const root = sourceScope?.isConnected ? sourceScope : null;
+  const triggers = root
+    ? Array.from(
+        root.querySelectorAll<HTMLElement>("[data-image-lightbox-trigger]"),
+      )
+    : [trigger];
+  const galleryItems: ImageGalleryItem[] = [];
+  let galleryIndex = 0;
+  let foundCurrentTrigger = false;
+
+  for (const candidate of triggers) {
+    if (!isVisibleImageLightboxTrigger(candidate)) {
+      continue;
+    }
+
+    const image = candidate.querySelector("img");
+    const rect = (image ?? candidate).getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      continue;
+    }
+
+    const item = imageGalleryItemFromTrigger(candidate);
+    if (!item) {
+      continue;
+    }
+
+    if (candidate === trigger) {
+      galleryIndex = galleryItems.length;
+      foundCurrentTrigger = true;
+    }
+    galleryItems.push(item);
+  }
+
+  if (!foundCurrentTrigger) {
+    galleryItems.unshift(fallbackItem);
+    galleryIndex = 0;
+  }
+
+  return {
+    galleryIndex,
+    galleryItems: galleryItems.length > 1 ? galleryItems : undefined,
+  };
 }
 
 type WebKitGestureLikeEvent = Event & {
@@ -1349,16 +1412,10 @@ function ImageZoomOverlay({
  * body on hover. Keeping the trigger stable and managing the lightbox via
  * React state avoids that repaint.
  */
-function ImageBlock({
-  alt,
-  dim,
-  galleryIndex,
-  galleryItems,
-  resolvedSrc,
-  src,
-}: ImageBlockProps) {
+function ImageBlock({ alt, dim, resolvedSrc, src }: ImageBlockProps) {
   const [lightboxState, setLightboxState] = React.useState<{
     galleryIndex: number;
+    galleryItems?: ImageGalleryItem[];
     sourceBox: ImageLightboxBox;
     sourceScope: Element | null;
   } | null>(null);
@@ -1468,14 +1525,23 @@ function ImageBlock({
       }
 
       setMenu(null);
+      const sourceScope =
+        triggerRef.current?.closest("[data-testid='message-row']") ?? null;
+      const gallery = triggerRef.current
+        ? visibleImageGalleryForTrigger(
+            triggerRef.current,
+            { alt, dim, resolvedSrc, src },
+            sourceScope,
+          )
+        : { galleryIndex: 0, galleryItems: undefined };
       setLightboxState({
-        galleryIndex: galleryIndex ?? 0,
+        galleryIndex: gallery.galleryIndex,
+        galleryItems: gallery.galleryItems,
         sourceBox: imageLightboxBoxFromRect(rect),
-        sourceScope:
-          triggerRef.current?.closest("[data-testid='message-row']") ?? null,
+        sourceScope,
       });
     },
-    [galleryIndex, resolvedSrc],
+    [alt, dim, resolvedSrc, src],
   );
 
   const handleImageTriggerClick = () => {
@@ -1508,6 +1574,8 @@ function ImageBlock({
           lightboxState && "opacity-0",
         )}
         data-image-lightbox-resolved-src={resolvedSrc}
+        data-image-lightbox-alt={alt}
+        data-image-lightbox-dim={dim}
         data-image-lightbox-src={src}
         data-image-lightbox-trigger=""
         data-testid="message-image-lightbox-trigger"
@@ -1539,7 +1607,7 @@ function ImageBlock({
         <ImageZoomOverlay
           alt={alt}
           galleryIndex={lightboxState.galleryIndex}
-          galleryItems={galleryItems}
+          galleryItems={lightboxState.galleryItems}
           onDownload={handleDownload}
           onClose={() => setLightboxState(null)}
           resolvedSrc={resolvedSrc}
@@ -1550,78 +1618,6 @@ function ImageBlock({
       ) : null}
     </>
   );
-}
-
-function isImageBlockElement(
-  node: React.ReactNode,
-): node is React.ReactElement<ImageBlockProps> {
-  return (
-    React.isValidElement<ImageBlockProps>(node) && node.type === ImageBlock
-  );
-}
-
-function collectImageGalleryItems(
-  children: React.ReactNode[],
-): ImageGalleryItem[] {
-  const items: ImageGalleryItem[] = [];
-
-  const visit = (node: React.ReactNode) => {
-    if (!React.isValidElement<{ children?: React.ReactNode }>(node)) {
-      return;
-    }
-
-    if (isImageBlockElement(node)) {
-      const { alt, dim, resolvedSrc, src } = node.props;
-      if (resolvedSrc) {
-        items.push({ alt, dim, resolvedSrc, src });
-      }
-      return;
-    }
-
-    React.Children.forEach(node.props.children, visit);
-  };
-
-  children.forEach(visit);
-  return items;
-}
-
-function attachImageGalleryProps(
-  children: React.ReactNode[],
-  galleryItems: ImageGalleryItem[],
-): React.ReactNode[] {
-  if (galleryItems.length <= 1) {
-    return children;
-  }
-
-  let nextGalleryIndex = 0;
-
-  const visit = (node: React.ReactNode): React.ReactNode => {
-    if (!React.isValidElement<{ children?: React.ReactNode }>(node)) {
-      return node;
-    }
-
-    if (isImageBlockElement(node)) {
-      if (!node.props.resolvedSrc) {
-        return node;
-      }
-
-      const galleryIndex = nextGalleryIndex;
-      nextGalleryIndex += 1;
-      return React.cloneElement(node, { galleryIndex, galleryItems });
-    }
-
-    if (node.props.children == null) {
-      return node;
-    }
-
-    return React.cloneElement(
-      node,
-      undefined,
-      React.Children.map(node.props.children, visit),
-    );
-  };
-
-  return children.map(visit);
 }
 
 function getReactNodeText(node: React.ReactNode): string {
@@ -2363,25 +2359,11 @@ function createMarkdownComponents(
         );
       }
       const entry = src ? imetaByUrl?.get(src) : undefined;
-      const imetaGalleryItems = imageGalleryItemsFromImeta(imetaByUrl);
-      const imetaGalleryIndex = src
-        ? imetaGalleryItems?.findIndex((item) => item.src === src)
-        : -1;
       return (
         <span data-block-media="" className="block min-w-0 max-w-full">
           <ImageBlock
             alt={alt}
             dim={entry?.dim}
-            galleryIndex={
-              imetaGalleryIndex != null && imetaGalleryIndex >= 0
-                ? imetaGalleryIndex
-                : undefined
-            }
-            galleryItems={
-              imetaGalleryIndex != null && imetaGalleryIndex >= 0
-                ? imetaGalleryItems
-                : undefined
-            }
             resolvedSrc={resolvedSrc}
             src={src}
           />
@@ -2401,15 +2383,9 @@ function createMarkdownComponents(
       const { imageChildren } = classifyChildren(childArray);
 
       if (isImageOnlyParagraph(childArray)) {
-        const galleryItems = collectImageGalleryItems(imageChildren);
-        const galleryChildren = attachImageGalleryProps(
-          imageChildren,
-          galleryItems,
-        );
-
         return (
           <div className="mt-1 grid w-full min-w-0 max-w-lg grid-cols-2 gap-1.5 [&_br]:hidden [&_[data-block-media]]:mt-0 [&_[data-block-media]]:max-w-none [&_img]:mt-0 [&_img]:w-full [&_img]:max-w-full">
-            {galleryChildren}
+            {imageChildren}
           </div>
         );
       }

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -334,6 +334,7 @@ const IMAGE_LIGHTBOX_EASE_IN_OUT = "cubic-bezier(0.77, 0, 0.175, 1)";
 const IMAGE_LIGHTBOX_GALLERY_EASE: [number, number, number, number] = [
   0.22, 1, 0.36, 1,
 ];
+const IMAGE_LIGHTBOX_MARKDOWN_SCOPE_SELECTOR = `.${MESSAGE_MARKDOWN_CLASS}`;
 
 function imageLightboxBoxFromRect(rect: DOMRect): ImageLightboxBox {
   return {
@@ -485,6 +486,15 @@ function imageLightboxReturnBoxForItem(
     imageLightboxThumbnailBoxForItem(item, sourceScope) ??
     item.thumbnailBox ??
     fallbackBox
+  );
+}
+
+function imageLightboxSourceScopeForTrigger(
+  trigger: HTMLElement,
+): Element | null {
+  return (
+    trigger.closest(IMAGE_LIGHTBOX_MARKDOWN_SCOPE_SELECTOR) ??
+    trigger.closest("[data-testid='message-row']")
   );
 }
 
@@ -1541,8 +1551,9 @@ function ImageBlock({ alt, dim, resolvedSrc, src }: ImageBlockProps) {
 
       setMenu(null);
       const sourceBox = imageLightboxBoxFromRect(rect);
-      const sourceScope =
-        triggerRef.current?.closest("[data-testid='message-row']") ?? null;
+      const sourceScope = triggerRef.current
+        ? imageLightboxSourceScopeForTrigger(triggerRef.current)
+        : null;
       const gallery = triggerRef.current
         ? visibleImageGalleryForTrigger(
             triggerRef.current,

--- a/desktop/tests/e2e/image-attachment-gallery.spec.ts
+++ b/desktop/tests/e2e/image-attachment-gallery.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const IMAGE_SHAS = ["a".repeat(64), "b".repeat(64), "c".repeat(64)];
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page, {
+    uploadDescriptors: [
+      {
+        url: `http://localhost:3000/media/${IMAGE_SHAS[0]}.png`,
+        sha256: IMAGE_SHAS[0],
+        size: 1234,
+        type: "image/png",
+        uploaded: Math.floor(Date.now() / 1000),
+        dim: "160x100",
+        filename: "first.png",
+      },
+      {
+        url: `http://localhost:3000/media/${IMAGE_SHAS[1]}.png`,
+        sha256: IMAGE_SHAS[1],
+        size: 2345,
+        type: "image/png",
+        uploaded: Math.floor(Date.now() / 1000),
+        dim: "100x160",
+        filename: "second.png",
+      },
+      {
+        url: `http://localhost:3000/media/${IMAGE_SHAS[2]}.png`,
+        sha256: IMAGE_SHAS[2],
+        size: 3456,
+        type: "image/png",
+        uploaded: Math.floor(Date.now() / 1000),
+        dim: "140x140",
+        filename: "third.png",
+      },
+    ],
+  });
+});
+
+test("image bundle lightbox navigates as a gallery", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  await page.getByTestId("message-input").fill("gallery bundle");
+  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByTestId("send-message").click();
+  await expect(page.getByText("Sending")).toHaveCount(0);
+
+  const row = page
+    .getByTestId("message-row")
+    .filter({ hasText: "gallery bundle" })
+    .last();
+  await expect(row).toBeVisible();
+
+  const triggers = row.getByTestId("message-image-lightbox-trigger");
+  await expect(triggers).toHaveCount(3);
+  await triggers.first().click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator(`img[src*="${IMAGE_SHAS[0]}"]`)).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Previous image" }),
+  ).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Next image" }).click();
+  await expect(dialog.locator(`img[src*="${IMAGE_SHAS[1]}"]`)).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Previous image" }),
+  ).toBeVisible();
+
+  await page.keyboard.press("ArrowRight");
+  await expect(dialog.locator(`img[src*="${IMAGE_SHAS[2]}"]`)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Next image" })).toHaveCount(0);
+
+  const currentThumbnailBox = await triggers
+    .nth(2)
+    .locator("img")
+    .boundingBox();
+  if (!currentThumbnailBox) {
+    throw new Error("Expected current gallery thumbnail to have a layout box");
+  }
+
+  await page.waitForTimeout(500);
+  await page.mouse.click(20, 20);
+  await page.waitForTimeout(200);
+
+  const closingFrameBox = await page
+    .locator("[data-image-lightbox-frame]")
+    .boundingBox();
+  if (!closingFrameBox) {
+    throw new Error("Expected lightbox frame to remain mounted while closing");
+  }
+
+  expect(Math.abs(closingFrameBox.x - currentThumbnailBox.x)).toBeLessThan(2);
+  expect(Math.abs(closingFrameBox.y - currentThumbnailBox.y)).toBeLessThan(2);
+  expect(
+    Math.abs(closingFrameBox.width - currentThumbnailBox.width),
+  ).toBeLessThan(2);
+  expect(
+    Math.abs(closingFrameBox.height - currentThumbnailBox.height),
+  ).toBeLessThan(2);
+});

--- a/desktop/tests/e2e/image-attachment-gallery.spec.ts
+++ b/desktop/tests/e2e/image-attachment-gallery.spec.ts
@@ -1,8 +1,54 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 import { installMockBridge } from "../helpers/bridge";
 
 const IMAGE_SHAS = ["a".repeat(64), "b".repeat(64), "c".repeat(64)];
+const SPOILER_VISIBLE_SHA = "d".repeat(64);
+const SPOILER_HIDDEN_SHA = "e".repeat(64);
+const SPOILER_VISIBLE_URL = `http://localhost:3000/media/${SPOILER_VISIBLE_SHA}.png`;
+const SPOILER_HIDDEN_URL = `http://localhost:3000/media/${SPOILER_HIDDEN_SHA}.png`;
+
+async function waitForMockLiveSubscription(page: Page, channelName: string) {
+  await expect
+    .poll(async () => {
+      return page.evaluate((name) => {
+        return (
+          (
+            window as Window & {
+              __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                channelName: string;
+              }) => boolean;
+            }
+          ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+            channelName: name,
+          }) ?? false
+        );
+      }, channelName);
+    })
+    .toBe(true);
+}
+
+function imageImetaTag({
+  dim,
+  filename,
+  sha,
+  url,
+}: {
+  dim: string;
+  filename: string;
+  sha: string;
+  url: string;
+}) {
+  return [
+    "imeta",
+    `url ${url}`,
+    "m image/png",
+    `x ${sha}`,
+    "size 1234",
+    `dim ${dim}`,
+    `filename ${filename}`,
+  ];
+}
 
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page, {
@@ -102,4 +148,75 @@ test("image bundle lightbox navigates as a gallery", async ({ page }) => {
   expect(
     Math.abs(closingFrameBox.height - currentThumbnailBox.height),
   ).toBeLessThan(2);
+});
+
+test("hidden spoiler images are excluded from gallery navigation until revealed", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  await page.evaluate(
+    ({ content, extraTags }) => {
+      (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            extraTags?: string[][];
+          }) => unknown;
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content,
+        extraTags,
+      });
+    },
+    {
+      content: [
+        "spoiler gallery",
+        `![visible](${SPOILER_VISIBLE_URL})`,
+        `||![hidden](${SPOILER_HIDDEN_URL})||`,
+      ].join("\n"),
+      extraTags: [
+        imageImetaTag({
+          dim: "160x100",
+          filename: "visible.png",
+          sha: SPOILER_VISIBLE_SHA,
+          url: SPOILER_VISIBLE_URL,
+        }),
+        imageImetaTag({
+          dim: "100x160",
+          filename: "hidden.png",
+          sha: SPOILER_HIDDEN_SHA,
+          url: SPOILER_HIDDEN_URL,
+        }),
+      ],
+    },
+  );
+
+  const row = page
+    .getByTestId("message-row")
+    .filter({ hasText: "spoiler gallery" })
+    .last();
+  await expect(row).toBeVisible();
+
+  await row.locator(`img[src*="${SPOILER_VISIBLE_SHA}"]`).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(page.getByRole("button", { name: "Next image" })).toHaveCount(0);
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+
+  const spoiler = row.locator(".buzz-spoiler[data-spoiler]").first();
+  await expect(spoiler).toHaveAttribute("data-revealed", "false");
+  await spoiler.click();
+  await expect(spoiler).toHaveAttribute("data-revealed", "true");
+
+  await row.locator(`img[src*="${SPOILER_VISIBLE_SHA}"]`).click();
+  await expect(dialog).toBeVisible();
+  await expect(page.getByRole("button", { name: "Next image" })).toBeVisible();
 });

--- a/desktop/tests/e2e/image-attachment-gallery.spec.ts
+++ b/desktop/tests/e2e/image-attachment-gallery.spec.ts
@@ -7,6 +7,8 @@ const SPOILER_VISIBLE_SHA = "d".repeat(64);
 const SPOILER_HIDDEN_SHA = "e".repeat(64);
 const SPOILER_VISIBLE_URL = `http://localhost:3000/media/${SPOILER_VISIBLE_SHA}.png`;
 const SPOILER_HIDDEN_URL = `http://localhost:3000/media/${SPOILER_HIDDEN_SHA}.png`;
+const NO_DIM_WIDE_URL = "https://example.com/e2e/gallery-wide.png";
+const NO_DIM_PORTRAIT_URL = "https://example.com/e2e/gallery-portrait.png";
 
 async function waitForMockLiveSubscription(page: Page, channelName: string) {
   await expect
@@ -48,6 +50,27 @@ function imageImetaTag({
     `dim ${dim}`,
     `filename ${filename}`,
   ];
+}
+
+async function installNoDimImageRoutes(page: Page) {
+  await page.route("https://example.com/e2e/gallery-*.png", (route) => {
+    const isPortrait = route.request().url().includes("portrait");
+    const width = isPortrait ? 120 : 320;
+    const height = isPortrait ? 320 : 120;
+    const fill = isPortrait ? "#f4b860" : "#4aa3df";
+    route.fulfill({
+      body: `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><rect width="100%" height="100%" fill="${fill}"/></svg>`,
+      contentType: "image/svg+xml",
+    });
+  });
+}
+
+async function getLightboxFrameBox(page: Page) {
+  const box = await page.locator("[data-image-lightbox-frame]").boundingBox();
+  if (!box) {
+    throw new Error("Expected lightbox frame to have a layout box");
+  }
+  return box;
 }
 
 test.beforeEach(async ({ page }) => {
@@ -219,4 +242,61 @@ test("hidden spoiler images are excluded from gallery navigation until revealed"
   await row.locator(`img[src*="${SPOILER_VISIBLE_SHA}"]`).click();
   await expect(dialog).toBeVisible();
   await expect(page.getByRole("button", { name: "Next image" })).toBeVisible();
+});
+
+test("gallery items without imeta dimensions keep their thumbnail aspect ratio", async ({
+  page,
+}) => {
+  await installNoDimImageRoutes(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  await page.evaluate(
+    ({ content }) => {
+      (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+          }) => unknown;
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content,
+      });
+    },
+    {
+      content: [
+        "no dim gallery",
+        `![wide](${NO_DIM_WIDE_URL})`,
+        `![portrait](${NO_DIM_PORTRAIT_URL})`,
+      ].join("\n"),
+    },
+  );
+
+  const row = page
+    .getByTestId("message-row")
+    .filter({ hasText: "no dim gallery" })
+    .last();
+  await expect(row).toBeVisible();
+  await expect(row.locator(`img[src="${NO_DIM_WIDE_URL}"]`)).toBeVisible();
+  await expect(row.locator(`img[src="${NO_DIM_PORTRAIT_URL}"]`)).toBeVisible();
+
+  await row.locator(`img[src="${NO_DIM_WIDE_URL}"]`).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator(`img[src="${NO_DIM_WIDE_URL}"]`)).toBeVisible();
+  await page.waitForTimeout(350);
+  const wideFrameBox = await getLightboxFrameBox(page);
+  expect(wideFrameBox.width / wideFrameBox.height).toBeGreaterThan(2);
+
+  await page.getByRole("button", { name: "Next image" }).click();
+  await expect(
+    dialog.locator(`img[src="${NO_DIM_PORTRAIT_URL}"]`),
+  ).toBeVisible();
+  await page.waitForTimeout(350);
+  const portraitFrameBox = await getLightboxFrameBox(page);
+  expect(portraitFrameBox.width / portraitFrameBox.height).toBeLessThan(0.6);
 });

--- a/desktop/tests/e2e/image-attachment-gallery.spec.ts
+++ b/desktop/tests/e2e/image-attachment-gallery.spec.ts
@@ -300,3 +300,89 @@ test("gallery items without imeta dimensions keep their thumbnail aspect ratio",
   const portraitFrameBox = await getLightboxFrameBox(page);
   expect(portraitFrameBox.width / portraitFrameBox.height).toBeLessThan(0.6);
 });
+
+test("forum markdown images use the markdown root as their gallery scope", async ({
+  page,
+}) => {
+  await installNoDimImageRoutes(page);
+  await page.goto("/");
+  await expect
+    .poll(() => {
+      return page.evaluate(() => {
+        return (
+          typeof (
+            window as Window & {
+              __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: unknown;
+            }
+          ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function"
+        );
+      });
+    })
+    .toBe(true);
+
+  const postId = await page.evaluate(
+    ({ content }) => {
+      const event = (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            kind: number;
+          }) => { id: string };
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "watercooler",
+        content,
+        kind: 45001,
+      });
+      return event?.id ?? null;
+    },
+    {
+      content: [
+        "forum gallery scope",
+        `![wide](${NO_DIM_WIDE_URL})`,
+        `![portrait](${NO_DIM_PORTRAIT_URL})`,
+      ].join("\n"),
+    },
+  );
+  expect(postId).not.toBeNull();
+
+  await page.getByTestId("channel-watercooler").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("watercooler");
+
+  await page
+    .getByRole("button")
+    .filter({ hasText: "forum gallery scope" })
+    .first()
+    .getByText("forum gallery scope")
+    .click();
+
+  const threadPost = page.locator(`[data-forum-event-id="${postId}"]`);
+  await expect(threadPost).toBeVisible();
+  const triggers = threadPost.getByTestId("message-image-lightbox-trigger");
+  await expect(triggers).toHaveCount(2);
+  await expect
+    .poll(() =>
+      triggers.first().evaluate((trigger) => {
+        return trigger.closest("[data-testid='message-row']") !== null;
+      }),
+    )
+    .toBe(false);
+
+  await triggers.first().click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator(`img[src="${NO_DIM_WIDE_URL}"]`)).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Previous image" }),
+  ).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Next image" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Next image" }).click();
+  await expect(
+    dialog.locator(`img[src="${NO_DIM_PORTRAIT_URL}"]`),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Previous image" }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Add previous/next gallery navigation to image attachment lightboxes for bundled image uploads.
- Keep the overlay in a dark muted theme with navigation-only slide/blur motion.
- Return the close animation to the currently viewed thumbnail.

## Screenshots
### Bundle thumbnails
![Bundle thumbnails](https://raw.githubusercontent.com/block/buzz/3fdb9a27862bd55cb92fc1d686fcfe9762b672ca/pr-1345--01-gallery-bundle.png)

### First image
![First image lightbox](https://raw.githubusercontent.com/block/buzz/3fdb9a27862bd55cb92fc1d686fcfe9762b672ca/pr-1345--02-gallery-start.png)

### Gallery navigation
![Gallery navigation](https://raw.githubusercontent.com/block/buzz/3fdb9a27862bd55cb92fc1d686fcfe9762b672ca/pr-1345--03-gallery-middle.png)

## Tests
- `pnpm -C desktop check`
- `pnpm -C desktop build`
- `pnpm -C desktop exec playwright test --project=smoke tests/e2e/image-attachment-gallery.spec.ts`
- Pre-push hook: `desktop-test`, `rust-tests`, `mobile-test`, `desktop-tauri-test`
