### PR TITLE
Keep wave huddles pending for placeholder profiles

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -11,7 +11,6 @@ import {
   MessageTimeline,
   type MessageTimelineHandle,
 } from "@/features/messages/ui/MessageTimeline";
-import type { ImetaMedia } from "@/features/messages/lib/imetaMediaMarkdown";
 import { buildDirectMessageIntro } from "@/features/channels/lib/dmParticipantDisplay";
 import {
   getDmHuddleMemberPubkeys,
@@ -23,20 +22,12 @@ import {
 } from "@/features/messages/lib/videoReviewContext";
 import { useComposerHeightPadding } from "@/features/messages/ui/useComposerHeightPadding";
 import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
-import type { TypingIndicatorEntry } from "@/features/messages/useChannelTyping";
-import {
-  type ProfilePanelTab,
-  type ProfilePanelView,
-  UserProfilePanel,
-} from "@/features/profile/ui/UserProfilePanel";
+import { UserProfilePanel } from "@/features/profile/ui/UserProfilePanel";
 import { ChannelFindBar } from "@/features/search/ui/ChannelFindBar";
 import { AgentSessionThreadPanel } from "@/features/channels/ui/AgentSessionThreadPanel";
 import { ChannelManagementAuxiliaryPanel } from "@/features/channels/ui/ChannelManagementAuxiliaryPanel";
 import { RightAuxiliaryPane } from "@/features/channels/ui/RightAuxiliaryPane";
-import {
-  BotActivityComposerAction,
-  type BotActivityAgent,
-} from "@/features/channels/ui/BotActivityBar";
+import { BotActivityComposerAction } from "@/features/channels/ui/BotActivityBar";
 import {
   containsWelcomePersonaMention,
   WelcomeComposerBanner,
@@ -52,136 +43,17 @@ import {
   isWelcomeSetupSystemMessage,
   mentionsKnownAgent,
 } from "@/features/channels/ui/ChannelPane.helpers";
+import type { ChannelPaneProps } from "@/features/channels/ui/ChannelPane.types";
 import * as agentSessionSelection from "@/features/channels/ui/agentSessionSelection";
-import type { ChannelAgentSessionAgent } from "@/features/channels/ui/useChannelAgentSessions";
 import { Button } from "@/shared/ui/button";
-import type { useChannelFind } from "@/features/search/useChannelFind";
-import {
-  buildMainTimelineEntries,
-  type MainTimelineEntry,
-} from "@/features/messages/lib/threadPanel";
+import { buildMainTimelineEntries } from "@/features/messages/lib/threadPanel";
 import { useRenderScopedReactionHydration } from "@/features/messages/lib/useRenderScopedReactionHydration";
 import type { TimelineMessage } from "@/features/messages/types";
-import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { isWelcomeChannel } from "@/features/onboarding/welcome";
 import { KIND_SYSTEM_MESSAGE } from "@/shared/constants/kinds";
-import type { Channel } from "@/shared/api/types";
 import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
 import { channelChrome } from "@/shared/layout/chromeLayout";
 import { cn } from "@/shared/lib/cn";
-type ChannelPaneProps = {
-  activeChannel: Channel | null;
-  activityAgents?: BotActivityAgent[];
-  agentPubkeys?: ReadonlySet<string>;
-  agentPubkeysPending?: boolean;
-  agentSessionAgents: ChannelAgentSessionAgent[];
-  botTypingEntries: TypingIndicatorEntry[];
-  channelFind: ReturnType<typeof useChannelFind>;
-  channelManagementOpen?: boolean;
-  currentPubkey?: string;
-  editTarget?: {
-    author: string;
-    body: string;
-    id: string;
-    imetaMedia?: ImetaMedia[];
-  } | null;
-  fetchOlder?: () => Promise<void>;
-  header?: React.ReactNode;
-  hasOlderMessages?: boolean;
-  isFetchingOlder?: boolean;
-  isJoining?: boolean;
-  isSinglePanelView?: boolean;
-  isSending: boolean;
-  isTimelineLoading: boolean;
-  messages: TimelineMessage[];
-  firstUnreadMessageId?: string | null;
-  unreadCount?: number;
-  canResetThreadPanelWidth: boolean;
-  onCancelEdit?: () => void;
-  onCancelThreadReply: () => void;
-  onCloseAgentSession: () => void;
-  onCloseChannelManagement?: () => void;
-  onChannelManagementDeleted?: () => void;
-  onCloseProfilePanel: () => void;
-  onAddAgent?: () => void;
-  onCreateChannel?: () => void;
-  onCloseThread: () => void;
-  onDelete?: (message: TimelineMessage) => void;
-  onEdit?: (message: TimelineMessage) => void;
-  onEditSave?: (content: string, mediaTags?: string[][]) => Promise<void>;
-  onMarkUnread?: (message: TimelineMessage) => void;
-  onMarkRead?: (message: TimelineMessage) => void;
-  onExpandThreadReplies: (message: TimelineMessage) => void;
-  onJoinChannel?: () => Promise<void>;
-  onOpenAgentSession: (pubkey: string) => void;
-  onOpenDm?: (pubkeys: string[]) => Promise<void> | void;
-  onOpenMembers?: () => void;
-  onOpenProfilePanel: (pubkey: string) => void;
-  onOpenThread: (message: TimelineMessage) => void;
-  onResetThreadPanelWidth: () => void;
-  onSelectThreadReplyTarget: (message: TimelineMessage) => void;
-  onSendMessage: (
-    content: string,
-    mentionPubkeys: string[],
-    mediaTags?: string[][],
-  ) => Promise<void>;
-  onSendVideoReviewComment?: (
-    message: TimelineMessage,
-    content: string,
-    mentionPubkeys: string[],
-    mediaTags?: string[][],
-    parentEventId?: string,
-  ) => Promise<void>;
-  onSendThreadReply: (
-    content: string,
-    mentionPubkeys: string[],
-    mediaTags?: string[][],
-  ) => Promise<void>;
-  onTargetReached?: (messageId: string) => void;
-  onToggleReaction?: (
-    message: TimelineMessage,
-    emoji: string,
-    remove: boolean,
-  ) => Promise<void>;
-  onThreadScrollTargetResolved: () => void;
-  onThreadPanelResizeStart: (
-    event: React.PointerEvent<HTMLButtonElement>,
-  ) => void;
-  personaLookup?: Map<string, string>;
-  profiles?: UserProfileLookup;
-  openThreadHeadId: string | null;
-  shouldShowThreadSkeleton: boolean;
-  openAgentSessionPubkey: string | null;
-  onProfilePanelViewChange: (
-    view: ProfilePanelView,
-    options?: { replace?: boolean },
-  ) => void;
-  onProfilePanelTabChange: (
-    tab: ProfilePanelTab,
-    options?: { replace?: boolean },
-  ) => void;
-  profilePanelPubkey?: string | null;
-  profilePanelTab: ProfilePanelTab;
-  profilePanelView: ProfilePanelView;
-  threadHeadMessage: TimelineMessage | null;
-  threadMessages: MainTimelineEntry[];
-  threadPanelWidthPx: number;
-  threadTypingPubkeys: string[];
-  threadReplyTargetMessage: TimelineMessage | null;
-  threadScrollTargetId: string | null;
-  threadUnreadCounts?: ReadonlyMap<string, number>;
-  threadReplyUnreadCounts?: ReadonlyMap<string, number>;
-  threadFirstUnreadReplyId?: string | null;
-  targetMessageId: string | null;
-  typingPubkeys: string[];
-  isFollowingThread?: boolean;
-  onFollowThread?: () => void;
-  onUnfollowThread?: () => void;
-  followThreadById?: (rootId: string) => void;
-  unfollowThreadById?: (rootId: string) => void;
-  isFollowingThreadById?: (rootId: string) => boolean;
-  isMessageUnreadById?: (messageId: string) => boolean;
-};
 export const ChannelPane = React.memo(function ChannelPane({
   activeChannel,
   agentPubkeys,

--- a/desktop/src/features/channels/ui/ChannelPane.types.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.types.ts
@@ -1,0 +1,128 @@
+import type * as React from "react";
+import type { useChannelFind } from "@/features/search/useChannelFind";
+import type {
+  ProfilePanelTab,
+  ProfilePanelView,
+} from "@/features/profile/ui/UserProfilePanel";
+import type { BotActivityAgent } from "@/features/channels/ui/BotActivityBar";
+import type { ChannelAgentSessionAgent } from "@/features/channels/ui/useChannelAgentSessions";
+import type { ImetaMedia } from "@/features/messages/lib/imetaMediaMarkdown";
+import type { MainTimelineEntry } from "@/features/messages/lib/threadPanel";
+import type { TimelineMessage } from "@/features/messages/types";
+import type { TypingIndicatorEntry } from "@/features/messages/useChannelTyping";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import type { Channel } from "@/shared/api/types";
+
+export type ChannelPaneProps = {
+  activeChannel: Channel | null;
+  activityAgents?: BotActivityAgent[];
+  agentPubkeys?: ReadonlySet<string>;
+  agentPubkeysPending?: boolean;
+  agentSessionAgents: ChannelAgentSessionAgent[];
+  botTypingEntries: TypingIndicatorEntry[];
+  channelFind: ReturnType<typeof useChannelFind>;
+  channelManagementOpen?: boolean;
+  currentPubkey?: string;
+  editTarget?: {
+    author: string;
+    body: string;
+    id: string;
+    imetaMedia?: ImetaMedia[];
+  } | null;
+  fetchOlder?: () => Promise<void>;
+  header?: React.ReactNode;
+  hasOlderMessages?: boolean;
+  isFetchingOlder?: boolean;
+  isJoining?: boolean;
+  isSinglePanelView?: boolean;
+  isSending: boolean;
+  isTimelineLoading: boolean;
+  messages: TimelineMessage[];
+  firstUnreadMessageId?: string | null;
+  unreadCount?: number;
+  canResetThreadPanelWidth: boolean;
+  onCancelEdit?: () => void;
+  onCancelThreadReply: () => void;
+  onCloseAgentSession: () => void;
+  onCloseChannelManagement?: () => void;
+  onChannelManagementDeleted?: () => void;
+  onCloseProfilePanel: () => void;
+  onAddAgent?: () => void;
+  onCreateChannel?: () => void;
+  onCloseThread: () => void;
+  onDelete?: (message: TimelineMessage) => void;
+  onEdit?: (message: TimelineMessage) => void;
+  onEditSave?: (content: string, mediaTags?: string[][]) => Promise<void>;
+  onMarkUnread?: (message: TimelineMessage) => void;
+  onMarkRead?: (message: TimelineMessage) => void;
+  onExpandThreadReplies: (message: TimelineMessage) => void;
+  onJoinChannel?: () => Promise<void>;
+  onOpenAgentSession: (pubkey: string) => void;
+  onOpenDm?: (pubkeys: string[]) => Promise<void> | void;
+  onOpenMembers?: () => void;
+  onOpenProfilePanel: (pubkey: string) => void;
+  onOpenThread: (message: TimelineMessage) => void;
+  onResetThreadPanelWidth: () => void;
+  onSelectThreadReplyTarget: (message: TimelineMessage) => void;
+  onSendMessage: (
+    content: string,
+    mentionPubkeys: string[],
+    mediaTags?: string[][],
+  ) => Promise<void>;
+  onSendVideoReviewComment?: (
+    message: TimelineMessage,
+    content: string,
+    mentionPubkeys: string[],
+    mediaTags?: string[][],
+    parentEventId?: string,
+  ) => Promise<void>;
+  onSendThreadReply: (
+    content: string,
+    mentionPubkeys: string[],
+    mediaTags?: string[][],
+  ) => Promise<void>;
+  onTargetReached?: (messageId: string) => void;
+  onToggleReaction?: (
+    message: TimelineMessage,
+    emoji: string,
+    remove: boolean,
+  ) => Promise<void>;
+  onThreadScrollTargetResolved: () => void;
+  onThreadPanelResizeStart: (
+    event: React.PointerEvent<HTMLButtonElement>,
+  ) => void;
+  personaLookup?: Map<string, string>;
+  profiles?: UserProfileLookup;
+  openThreadHeadId: string | null;
+  shouldShowThreadSkeleton: boolean;
+  openAgentSessionPubkey: string | null;
+  onProfilePanelViewChange: (
+    view: ProfilePanelView,
+    options?: { replace?: boolean },
+  ) => void;
+  onProfilePanelTabChange: (
+    tab: ProfilePanelTab,
+    options?: { replace?: boolean },
+  ) => void;
+  profilePanelPubkey?: string | null;
+  profilePanelTab: ProfilePanelTab;
+  profilePanelView: ProfilePanelView;
+  threadHeadMessage: TimelineMessage | null;
+  threadMessages: MainTimelineEntry[];
+  threadPanelWidthPx: number;
+  threadTypingPubkeys: string[];
+  threadReplyTargetMessage: TimelineMessage | null;
+  threadScrollTargetId: string | null;
+  threadUnreadCounts?: ReadonlyMap<string, number>;
+  threadReplyUnreadCounts?: ReadonlyMap<string, number>;
+  threadFirstUnreadReplyId?: string | null;
+  targetMessageId: string | null;
+  typingPubkeys: string[];
+  isFollowingThread?: boolean;
+  onFollowThread?: () => void;
+  onUnfollowThread?: () => void;
+  followThreadById?: (rootId: string) => void;
+  unfollowThreadById?: (rootId: string) => void;
+  isFollowingThreadById?: (rootId: string) => boolean;
+  isMessageUnreadById?: (messageId: string) => boolean;
+};

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -325,7 +325,9 @@ export function ChannelScreen({
     (channelMembersQuery.isPending ||
       managedAgentsQuery.isPending ||
       relayAgentsQuery.isPending ||
-      (messageProfilePubkeys.length > 0 && messageProfilesQuery.isPending));
+      (messageProfilePubkeys.length > 0 &&
+        (messageProfilesQuery.isPending ||
+          messageProfilesQuery.isPlaceholderData)));
   const {
     agentSessionCandidates,
     botTypingEntries,

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -88,6 +88,7 @@ type E2eConfig = {
     canvasReadError?: string;
     openDmDelayMs?: number;
     sendMessageDelayMs?: number;
+    usersBatchDelayMs?: number;
     /** Delay (ms) applied to older-history (`history-` subId) fetches so e2e
      *  tests can observe the in-flight prepend window. 0/undefined = instant. */
     historyDelayMs?: number;
@@ -3373,6 +3374,13 @@ async function handleGetUsersBatch(
   },
   config: E2eConfig | undefined,
 ) {
+  const usersBatchDelayMs = config?.mock?.usersBatchDelayMs ?? 0;
+  if (usersBatchDelayMs > 0) {
+    await new Promise<void>((resolve) => {
+      window.setTimeout(resolve, usersBatchDelayMs);
+    });
+  }
+
   const identity = getIdentity(config);
   if (!identity) {
     const profiles: RawUsersBatchResponse["profiles"] = {};

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -1460,6 +1460,67 @@ test("wave attachment huddle passes the bot DM pubkey", async ({ page }) => {
     .toEqual(expect.arrayContaining([TEST_IDENTITIES.charlie.pubkey]));
 });
 
+test("wave attachment huddle waits for placeholder profile-only bot data", async ({
+  page,
+}) => {
+  await installMockBridge(page, { usersBatchDelayMs: 2_000 });
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general", SYSTEM_MESSAGE_KIND);
+
+  await page.evaluate(
+    ({ kind, targetPubkey }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content: JSON.stringify({
+          type: "member_joined",
+          actor: targetPubkey,
+          target: targetPubkey,
+        }),
+        kind,
+      });
+    },
+    {
+      kind: SYSTEM_MESSAGE_KIND,
+      targetPubkey: PROFILE_ONLY_AGENT_PUBKEY,
+    },
+  );
+  await waitForTimelineSettled(page);
+
+  const joinedRow = page
+    .getByTestId("system-message-row")
+    .filter({ hasText: "joined the channel" });
+  const agentChip = joinedRow.locator(
+    "[data-mention].agent-mention-highlight",
+    {
+      hasText: "mira",
+    },
+  );
+  await expect(agentChip).toBeVisible({ timeout: 5_000 });
+  await agentChip.hover();
+
+  const profilePopover = page.locator(
+    '[data-testid="user-profile-popover"][data-state="open"]',
+  );
+  await expect(profilePopover).toBeVisible();
+  await profilePopover
+    .getByTestId(`user-profile-popover-wave-${PROFILE_ONLY_AGENT_PUBKEY}`)
+    .click();
+
+  const startHuddleButton = page
+    .getByTestId("message-wave-attachment")
+    .getByRole("button", { name: "Start huddle" });
+  await expect(startHuddleButton).toBeDisabled();
+  await expect(startHuddleButton).toBeEnabled({ timeout: 5_000 });
+  await startHuddleButton.click();
+
+  await expect
+    .poll(() => readStartHuddleMemberPubkeys(page))
+    .toEqual(expect.arrayContaining([PROFILE_ONLY_AGENT_PUBKEY]));
+});
+
 test("wave attachment huddle waits for delayed bot DM pubkey", async ({
   page,
 }) => {

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -112,6 +112,7 @@ type MockBridgeOptions = {
   canvasReadError?: string;
   openDmDelayMs?: number;
   sendMessageDelayMs?: number;
+  usersBatchDelayMs?: number;
   /** Delay (ms) for older-history fetches; see e2eBridge mock config. */
   historyDelayMs?: number;
   profileReadDelayMs?: number;


### PR DESCRIPTION
## Summary
- Keep wave huddle actions disabled while DM participant profile data is placeholder data from a previous users-batch query
- Add a users-batch delay knob to the e2e bridge
- Add smoke coverage for profile-only bot wave huddles waiting through the placeholder window
- Split `ChannelPaneProps` into a type-only sibling file so `ChannelPane.tsx` stays under the desktop file-size guard

## Tests
- ./bin/pnpm --dir desktop exec biome check --write src/features/channels/ui/ChannelPane.tsx src/features/channels/ui/ChannelPane.types.ts src/features/channels/ui/ChannelScreen.tsx src/testing/e2eBridge.ts tests/helpers/bridge.ts tests/e2e/mentions.spec.ts
- ./bin/pnpm --dir desktop typecheck
- ./bin/pnpm --dir desktop check:file-sizes
- git diff --check
- ./bin/pnpm --dir desktop build
- ./bin/pnpm --dir desktop exec playwright test tests/e2e/mentions.spec.ts -g "wave attachment huddle waits for placeholder profile-only bot data|wave attachment huddle waits for delayed bot DM pubkey|system agent avatar huddle passes profile-only bot pubkey|system agent profile huddle passes profile-only bot pubkey" --project=smoke