### PR TITLE
feat(cli): support visibility on channels update

### DIFF
--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -349,6 +349,7 @@ pub async fn cmd_update_channel(
     channel_id: &str,
     name: Option<&str>,
     description: Option<&str>,
+    visibility: Option<&str>,
     ttl: Option<i64>,
     no_ttl: bool,
 ) -> Result<(), CliError> {
@@ -360,15 +361,25 @@ pub async fn cmd_update_channel(
         (None, false) => None,
     };
 
-    if name.is_none() && description.is_none() && ttl_change.is_none() {
+    if let Some(v) = visibility {
+        if v != "open" && v != "private" {
+            return Err(CliError::Usage(format!(
+                "--visibility must be 'open' or 'private' (got: {v})"
+            )));
+        }
+    }
+
+    if name.is_none() && description.is_none() && visibility.is_none() && ttl_change.is_none() {
         return Err(CliError::Usage(
-            "at least one field required (--name, --description, --ttl, --no-ttl)".into(),
+            "at least one field required (--name, --description, --visibility, --ttl, --no-ttl)"
+                .into(),
         ));
     }
     let channel_uuid = parse_uuid(channel_id)?;
 
-    let builder = buzz_sdk::build_update_channel(channel_uuid, name, description, None, ttl_change)
-        .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
+    let builder =
+        buzz_sdk::build_update_channel(channel_uuid, name, description, visibility, ttl_change)
+            .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
 
     let event = client.sign_event(builder)?;
     let resp = client.submit_event(event).await?;
@@ -621,14 +632,17 @@ pub async fn dispatch(
             channel,
             name,
             description,
+            visibility,
             ttl,
             no_ttl,
         } => {
+            let vis = visibility.as_ref().map(|v| v.to_string());
             cmd_update_channel(
                 client,
                 &channel,
                 name.as_deref(),
                 description.as_deref(),
+                vis.as_deref(),
                 ttl,
                 no_ttl,
             )

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -414,7 +414,7 @@ pub enum ChannelsCmd {
         #[arg(long, value_name = "SECONDS")]
         ttl: Option<i64>,
     },
-    /// Update channel name, description, or ephemeral TTL
+    /// Update channel name, description, visibility, or ephemeral TTL
     Update {
         /// Channel UUID
         #[arg(long)]
@@ -425,6 +425,10 @@ pub enum ChannelsCmd {
         /// New channel description
         #[arg(long)]
         description: Option<String>,
+        /// Change channel visibility: "open" (publicly listable/joinable) or
+        /// "private" (invite-only). Requires owner/admin.
+        #[arg(long, value_enum)]
+        visibility: Option<ChannelVisibility>,
         /// Make the channel ephemeral (or change its lifetime): seconds until
         /// the relay archives it after the last message. Conflicts with --no-ttl.
         #[arg(long, value_name = "SECONDS", conflicts_with = "no_ttl")]


### PR DESCRIPTION
## What

Add `--visibility <open|private>` to `buzz channels update`, so a channel's visibility can be flipped after creation from the CLI. Previously visibility was a create-time-only field: `channels create` took `--visibility`, but `channels update` only handled name/description/ttl.

## Why it's small

The plumbing below the CLI already existed:

- **SDK** — `buzz_sdk::build_update_channel` already accepts a `visibility` arg, validates `open|private`, and emits the `["visibility", v]` tag on the kind:9002 edit-metadata event (`crates/buzz-sdk/src/builders.rs:572`). Already covered by SDK tests (`:2069`, `:2086`).
- **Relay** — `side_effects.rs` already validates the tag value, gates it behind owner/admin auth, applies the DB update, invalidates the visibility/accessible-channel caches, and emits a `visibility_changed` event (`:382-397`, `:424-437`, `:1075-1107`).

The CLI just hardcoded `None` for that arg and exposed no flag. This PR wires the flag through — no SDK or relay changes.

## Change

- `lib.rs`: add `visibility: Option<ChannelVisibility>` to the `Update` clap variant (`value_enum`, so invalid values are rejected at parse time with `[possible values: open, private]` — matching `channels create`).
- `channels.rs`: thread it into `cmd_update_channel`, include it in the no-op guard + error message, and pass it to `build_update_channel`.

No `public` alias — held to `open|private` to match `create`, the SDK, and relay validation (one vocabulary).

## Testing

- `cargo test -p buzz-cli -p buzz-sdk` — green (135 + 205).
- `cargo clippy -p buzz-cli` — clean.
- `cargo fmt -p buzz-cli --check` — clean.
- **Live smoke** against a real channel (`f5bf2e54-...`), each flip confirmed via the stored kind:9002 `visibility` tag on the relay:

```bash
buzz channels update --channel <uuid> --visibility private   # -> accepted; relay stores ["visibility","private"]
buzz channels update --channel <uuid> --visibility open      # -> accepted; relay stores ["visibility","open"]
buzz channels update --channel <uuid> --visibility public    # -> rejected at parse: [possible values: open, private]
```

## Review

Planned and diff-reviewed with Wren; independently confirmed not already wired by Max.
