### PR TITLE
fix(desktop): un-clip hover action bar's upward bleed under content-visibility

### DIFF
--- a/desktop/src/shared/styles/globals.css
+++ b/desktop/src/shared/styles/globals.css
@@ -2054,6 +2054,11 @@
     contain-intrinsic-size: auto 60px;
   }
 
+  /* paint containment clips the action bar's upward bleed; un-pause the active row */
+  .timeline-row-cv:is(:hover, :focus-within) {
+    content-visibility: visible;
+  }
+
   .content-visibility-auto-interactive {
     content-visibility: auto;
     contain-intrinsic-size: auto 200px;

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -88,6 +88,15 @@ test("long autolink wraps without widening the timeline", async ({ page }) => {
       return barBox.x + barBox.width - (timelineBox.x + timelineBox.width);
     })
     .toBeLessThanOrEqual(0);
+  // #1338 guard: hovering must un-pause the row so the upward-bleeding bar renders
+  await expect
+    .poll(async () =>
+      actionBar.evaluate((bar) => {
+        const cvRow = bar.closest(".timeline-row-cv");
+        return cvRow ? getComputedStyle(cvRow).contentVisibility : "missing";
+      }),
+    )
+    .toBe("visible");
 });
 
 test("send multiple messages in sequence", async ({ page }) => {


### PR DESCRIPTION
## What

The message-row action bar (react / reply) intentionally bleeds slightly **above** its row's top edge. After #1338 added `content-visibility: auto` paint containment to timeline rows, that containment clipped the overhang — leaving the reaction bar sheared off at the top (both the normal message hover bar and the system "joined the channel" row's react button).

## Fix

One CSS rule: drop paint containment on a row **only while it's hovered / focused** — the only time the action bar is visible.

```css
.timeline-row-cv:is(:hover, :focus-within) {
  content-visibility: visible;
}
```

Idle and offscreen rows keep `content-visibility: auto`, so the **#1338 scroll/perf win is fully preserved**. This mirrors the existing `.content-visibility-auto-interactive` pattern already in the same file, so it's idiomatic here.

The original "floating bleed above the message" positioning is untouched — earlier component-level experiments were reverted; `MessageRow` / `MessageThreadPanel` are back to `origin/main`.

## Test

Adds an e2e regression guard in `messaging.spec.ts` asserting a hovered row resolves to `content-visibility: visible`. **Proven to bite**: removing the CSS rule fails the guard.

- `tsc` clean, biome clean, build green
- 22 timeline / scroll / virtualization e2e tests pass → no scroll regression

## Diff

2 files / ~14 lines (CSS rule + e2e guard).

## Screenshots

Normal message — bleed-above look restored, bar fully rendered:

![normal message action bar](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/1354/msg.png)

System "joined the channel" row — react button is now a full circle, no longer sheared:

![system row react button](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/1354/sys.png)
