### PR TITLE
fix(sidebar): compact working-agent avatar indicator

### DIFF
--- a/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
+++ b/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
@@ -193,11 +193,18 @@ describe("activeAgentTurnsStore", () => {
 
       const summaries = getActiveTurnsByChannel();
       assert.deepEqual(
-        summaries.map(({ channelId, agentCount }) => ({
+        summaries.map(({ agentCount, agentPubkeys, channelId }) => ({
           channelId,
           agentCount,
+          agentPubkeys,
         })),
-        [{ channelId: "shared", agentCount: 2 }],
+        [
+          {
+            channelId: "shared",
+            agentCount: 2,
+            agentPubkeys: [AGENT, AGENT_2].sort(),
+          },
+        ],
       );
       assert.equal(
         summaries[0].anchorAt,

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -49,6 +49,7 @@ export type ActiveChannelTurnSummary = {
   channelId: string;
   anchorAt: number;
   agentCount: number;
+  agentPubkeys: string[];
 };
 
 // Module-level state: agentPubkey → turnId → ActiveTurn
@@ -474,11 +475,15 @@ export function getActiveTurnsByChannel(): ActiveChannelTurnSummary[] {
   }
 
   const result = [...summaries.entries()]
-    .map(([channelId, summary]) => ({
-      channelId,
-      anchorAt: summary.anchorAt,
-      agentCount: summary.agentPubkeys.size,
-    }))
+    .map(([channelId, summary]) => {
+      const agentPubkeys = [...summary.agentPubkeys].sort();
+      return {
+        channelId,
+        anchorAt: summary.anchorAt,
+        agentCount: agentPubkeys.length,
+        agentPubkeys,
+      };
+    })
     .sort((a, b) => a.channelId.localeCompare(b.channelId));
   cachedChannelTurnSummaries = result;
   return result;

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -37,6 +37,11 @@ const listeners = new Set<() => void>();
 const eventsByAgent = new Map<string, ObserverEvent[]>();
 const transcriptByAgent = new Map<string, TranscriptState>();
 const snapshotByAgent = new Map<string, ObserverSnapshot>();
+const observerCandidatePubkeys = new Set<string>();
+let cachedObserverCandidatePubkeys: string[] | null = null;
+const pendingEventsByAgent = new Map<string, RelayEvent[]>();
+const MAX_PENDING_EVENTS_PER_AGENT = 100;
+const EMPTY_PUBKEYS: string[] = [];
 
 // Normalized pubkeys of agents we are actively managing. Only events whose
 // "agent" tag matches an entry here will be decrypted (defense-in-depth).
@@ -49,6 +54,38 @@ const snapshotByAgent = new Map<string, ObserverSnapshot>();
 const knownAgentPubkeys = new Set<string>();
 const knownAgentsBySubscription = new Map<string, Set<string>>();
 
+function registerObserverCandidate(agentPubkey: string) {
+  const key = normalizePubkey(agentPubkey);
+  if (observerCandidatePubkeys.has(key)) return;
+  observerCandidatePubkeys.add(key);
+  cachedObserverCandidatePubkeys = null;
+  notifyListeners();
+}
+
+function flushPendingEventsForAgent(
+  agentPubkey: string,
+  activeGeneration: number,
+) {
+  const key = normalizePubkey(agentPubkey);
+  const pendingEvents = pendingEventsByAgent.get(key);
+  if (!pendingEvents || pendingEvents.length === 0) return;
+  pendingEventsByAgent.delete(key);
+  for (const event of pendingEvents) {
+    eventProcessingQueue = eventProcessingQueue
+      .then(() => handleRelayObserverEvent(event, activeGeneration))
+      .catch((error) => {
+        if (activeGeneration !== generation) {
+          return;
+        }
+        setConnectionState(
+          "error",
+          error instanceof Error
+            ? `Observer event handling failed: ${error.message}`
+            : "Observer event handling failed.",
+        );
+      });
+  }
+}
 function recomputeKnownAgentPubkeys() {
   knownAgentPubkeys.clear();
   for (const subscriptionAgents of knownAgentsBySubscription.values()) {
@@ -172,15 +209,33 @@ async function handleRelayObserverEvent(
     return;
   }
 
-  // Verify agent is known/trusted before decrypting.
-  // Silently drop events from agents we are not managing.
-  if (!knownAgentPubkeys.has(normalizePubkey(agentPubkey))) {
+  // Defense-in-depth: verify the event sender matches the claimed agent pubkey
+  // before surfacing it as an owner-resolution candidate. The relay gates on
+  // is_agent_owner, but a compromised relay could misroute.
+  if (normalizePubkey(event.pubkey) !== normalizePubkey(agentPubkey)) {
     return;
   }
 
-  // Defense-in-depth: verify the event sender matches the claimed agent pubkey.
-  // The relay gates on is_agent_owner, but a compromised relay could misroute.
-  if (normalizePubkey(event.pubkey) !== normalizePubkey(agentPubkey)) {
+  // Surface every routed agent pubkey to owner-gated callers before the trusted
+  // known-agent check. The relay subscription is already scoped to the viewer's
+  // pubkey, so these are candidates for the same declared-owner gate used by
+  // profile surfaces. We still defer decryption until a caller explicitly adds
+  // the agent to `knownAgentPubkeys` below.
+  registerObserverCandidate(agentPubkey);
+
+  // Verify agent is known/trusted before decrypting.
+  // Silently hold events from agents we have not yet resolved as owned.
+  if (!knownAgentPubkeys.has(normalizePubkey(agentPubkey))) {
+    const key = normalizePubkey(agentPubkey);
+    const pendingEvents = pendingEventsByAgent.get(key) ?? [];
+    pendingEvents.push(event);
+    if (pendingEvents.length > MAX_PENDING_EVENTS_PER_AGENT) {
+      pendingEvents.splice(
+        0,
+        pendingEvents.length - MAX_PENDING_EVENTS_PER_AGENT,
+      );
+    }
+    pendingEventsByAgent.set(key, pendingEvents);
     return;
   }
 
@@ -325,6 +380,9 @@ export function useManagedAgentObserverBridge(
   // a co-mounted caller no longer wipes out this caller's agents.
   React.useEffect(() => {
     registerKnownAgents(subscriptionId, agentPubkeys);
+    for (const agentPubkey of agentPubkeys) {
+      flushPendingEventsForAgent(agentPubkey, generation);
+    }
     return () => {
       unregisterKnownAgents(subscriptionId);
     };
@@ -338,6 +396,21 @@ export function useManagedAgentObserverBridge(
   }, [hasActiveAgent]);
 }
 
+export function useObserverCandidatePubkeys(): string[] {
+  React.useEffect(() => {
+    void ensureRelayObserverSubscription();
+  }, []);
+
+  const getSnapshot = React.useCallback(() => {
+    if (observerCandidatePubkeys.size === 0) return EMPTY_PUBKEYS;
+    if (cachedObserverCandidatePubkeys) return cachedObserverCandidatePubkeys;
+    cachedObserverCandidatePubkeys = [...observerCandidatePubkeys].sort();
+    return cachedObserverCandidatePubkeys;
+  }, []);
+
+  return React.useSyncExternalStore(subscribeAgentObserverStore, getSnapshot);
+}
+
 export function resetAgentObserverStore() {
   generation += 1;
   const unsubscribe = unsubscribeRelay;
@@ -349,6 +422,9 @@ export function resetAgentObserverStore() {
   snapshotByAgent.clear();
   knownAgentPubkeys.clear();
   knownAgentsBySubscription.clear();
+  observerCandidatePubkeys.clear();
+  cachedObserverCandidatePubkeys = null;
+  pendingEventsByAgent.clear();
   connectionState = "idle";
   errorMessage = null;
   notifyListeners();

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -5,21 +5,69 @@ import {
   useActiveAgentTurnsBridge,
   useActiveAgentTurnsByChannel,
 } from "@/features/agents/activeAgentTurnsStore";
-import { useManagedAgentsQuery } from "@/features/agents/hooks";
+import {
+  useManagedAgentsQuery,
+  useRelayAgentsQuery,
+} from "@/features/agents/hooks";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type { ManagedAgent } from "@/shared/api/types";
+
+type BridgeAgent = Pick<ManagedAgent, "pubkey" | "status">;
 
 export function useActiveWorkingChannelsById(): ReadonlyMap<
   string,
   ActiveChannelTurnSummary
 > {
+  const identityQuery = useIdentityQuery();
+  const currentPubkey = identityQuery.data?.pubkey;
   const managedAgentsQuery = useManagedAgentsQuery();
+  const relayAgentsQuery = useRelayAgentsQuery({ enabled: true });
   const managedAgents = React.useMemo(
     () => managedAgentsQuery.data ?? [],
     [managedAgentsQuery.data],
   );
+  const relayAgents = React.useMemo(
+    () => relayAgentsQuery.data ?? [],
+    [relayAgentsQuery.data],
+  );
+  const relayAgentPubkeys = React.useMemo(
+    () => relayAgents.map((agent) => agent.pubkey),
+    [relayAgents],
+  );
+  const relayAgentProfilesQuery = useUsersBatchQuery(relayAgentPubkeys, {
+    enabled: Boolean(currentPubkey) && relayAgentPubkeys.length > 0,
+  });
+  const bridgeAgents = React.useMemo<BridgeAgent[]>(() => {
+    const agentsByPubkey = new Map<string, BridgeAgent>();
+    for (const agent of managedAgents) {
+      agentsByPubkey.set(agent.pubkey.toLowerCase(), {
+        pubkey: agent.pubkey,
+        status: agent.status,
+      });
+    }
 
-  useManagedAgentObserverBridge(managedAgents);
-  useActiveAgentTurnsBridge(managedAgents);
+    if (currentPubkey) {
+      const currentPubkeyLower = currentPubkey.toLowerCase();
+      const profiles = relayAgentProfilesQuery.data?.profiles ?? {};
+      for (const agent of relayAgents) {
+        const key = agent.pubkey.toLowerCase();
+        const ownerPubkey = profiles[key]?.ownerPubkey;
+        if (ownerPubkey?.toLowerCase() !== currentPubkeyLower) continue;
+        if (agentsByPubkey.has(key)) continue;
+        agentsByPubkey.set(key, {
+          pubkey: agent.pubkey,
+          status: "deployed",
+        });
+      }
+    }
+
+    return [...agentsByPubkey.values()];
+  }, [currentPubkey, managedAgents, relayAgentProfilesQuery.data, relayAgents]);
+
+  useManagedAgentObserverBridge(bridgeAgents);
+  useActiveAgentTurnsBridge(bridgeAgents);
 
   const activeWorkingChannels = useActiveAgentTurnsByChannel();
   return React.useMemo(

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -9,7 +9,10 @@ import {
   useManagedAgentsQuery,
   useRelayAgentsQuery,
 } from "@/features/agents/hooks";
-import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
+import {
+  useManagedAgentObserverBridge,
+  useObserverCandidatePubkeys,
+} from "@/features/agents/observerRelayStore";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import type { ManagedAgent } from "@/shared/api/types";
@@ -32,13 +35,21 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
     () => relayAgentsQuery.data ?? [],
     [relayAgentsQuery.data],
   );
+  const observerCandidatePubkeys = useObserverCandidatePubkeys();
   const relayAgentPubkeys = React.useMemo(
     () => relayAgents.map((agent) => agent.pubkey),
     [relayAgents],
   );
-  const relayAgentProfilesQuery = useUsersBatchQuery(relayAgentPubkeys, {
-    enabled: Boolean(currentPubkey) && relayAgentPubkeys.length > 0,
-  });
+  const ownerCandidatePubkeys = React.useMemo(
+    () => [...new Set([...relayAgentPubkeys, ...observerCandidatePubkeys])],
+    [observerCandidatePubkeys, relayAgentPubkeys],
+  );
+  const ownerCandidateProfilesQuery = useUsersBatchQuery(
+    ownerCandidatePubkeys,
+    {
+      enabled: Boolean(currentPubkey) && ownerCandidatePubkeys.length > 0,
+    },
+  );
   const bridgeAgents = React.useMemo<BridgeAgent[]>(() => {
     const agentsByPubkey = new Map<string, BridgeAgent>();
     for (const agent of managedAgents) {
@@ -50,21 +61,26 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
 
     if (currentPubkey) {
       const currentPubkeyLower = currentPubkey.toLowerCase();
-      const profiles = relayAgentProfilesQuery.data?.profiles ?? {};
-      for (const agent of relayAgents) {
-        const key = agent.pubkey.toLowerCase();
+      const profiles = ownerCandidateProfilesQuery.data?.profiles ?? {};
+      for (const pubkey of ownerCandidatePubkeys) {
+        const key = pubkey.toLowerCase();
         const ownerPubkey = profiles[key]?.ownerPubkey;
         if (ownerPubkey?.toLowerCase() !== currentPubkeyLower) continue;
         if (agentsByPubkey.has(key)) continue;
         agentsByPubkey.set(key, {
-          pubkey: agent.pubkey,
+          pubkey,
           status: "deployed",
         });
       }
     }
 
     return [...agentsByPubkey.values()];
-  }, [currentPubkey, managedAgents, relayAgentProfilesQuery.data, relayAgents]);
+  }, [
+    currentPubkey,
+    managedAgents,
+    ownerCandidateProfilesQuery.data,
+    ownerCandidatePubkeys,
+  ]);
 
   useManagedAgentObserverBridge(bridgeAgents);
   useActiveAgentTurnsBridge(bridgeAgents);

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -18,6 +18,9 @@ import {
 import { ChannelContextMenuItems } from "@/features/sidebar/ui/CustomChannelSection";
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { getEphemeralChannelDisplay } from "@/features/channels/lib/ephemeralChannel";
 import { EphemeralChannelBadge } from "@/features/channels/ui/EphemeralChannelBadge";
 import {
@@ -28,6 +31,7 @@ import {
 import type { Channel, PresenceStatus } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { useNow } from "@/shared/lib/useNow";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -99,7 +103,7 @@ function UnreadDotBadge({
   );
 }
 
-function ChannelWorkingBadge({
+function ChannelWorkingAgents({
   channelName,
   isActive,
   summary,
@@ -110,24 +114,110 @@ function ChannelWorkingBadge({
 }) {
   const now = useNow(1000);
   const elapsed = formatElapsed(now - summary.anchorAt);
+  const profilesQuery = useUsersBatchQuery(summary.agentPubkeys, {
+    enabled: summary.agentPubkeys.length > 0,
+  });
+  const profiles = profilesQuery.data?.profiles;
+  const agents = summary.agentPubkeys.map((pubkey) => {
+    const profile = profiles?.[pubkey.toLowerCase()];
+    const label = resolveUserLabel({
+      pubkey,
+      profiles,
+    });
+
+    return {
+      avatarUrl: profile?.avatarUrl ?? null,
+      label,
+      pubkey,
+    };
+  });
+  const visibleAgents = agents.slice(0, 3);
+  const overflowCount = Math.max(0, agents.length - visibleAgents.length);
   const label =
-    summary.agentCount > 1
-      ? `${summary.agentCount} working · ${elapsed}`
-      : `Working · ${elapsed}`;
+    agents.length > 1
+      ? `${agents.length} agents working · ${elapsed}`
+      : `${agents[0]?.label ?? "Agent"} is working · ${elapsed}`;
 
   return (
-    <span
-      className={cn(
-        "hidden max-w-32 shrink-0 truncate rounded-full px-1.5 py-0.5 text-2xs font-medium leading-none tabular-nums motion-safe:animate-pulse group-data-[collapsible=icon]:hidden sm:inline-flex",
-        isActive
-          ? "bg-sidebar-active-foreground/20 text-sidebar-active-foreground"
-          : "bg-primary/10 text-primary",
-      )}
-      data-testid={`channel-working-${channelName}`}
-      title={label}
-    >
-      {label}
-    </span>
+    <Popover>
+      <PopoverTrigger asChild>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions lint/a11y/useKeyWithClickEvents: Radix popover trigger sits inside the channel row button; click opens the popover without navigating the row. */}
+        <span
+          className="hidden shrink-0 items-center py-px transition-opacity motion-safe:animate-pulse group-data-[collapsible=icon]:hidden sm:inline-flex"
+          data-testid={`channel-working-${channelName}`}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
+          title={label}
+        >
+          <span className="flex items-center -space-x-1 overflow-visible px-0.5">
+            {visibleAgents.map((agent) => (
+              <ProfileAvatar
+                avatarUrl={agent.avatarUrl}
+                className={cn(
+                  "h-[18px] w-[18px] border text-3xs shadow-xs ring-1",
+                  isActive
+                    ? "border-sidebar-active bg-sidebar-active-foreground/15 text-sidebar-active-foreground ring-sidebar-active-foreground/25"
+                    : "border-sidebar bg-sidebar text-sidebar-foreground ring-primary/25",
+                )}
+                iconClassName="h-3 w-3"
+                key={agent.pubkey}
+                label={agent.label}
+                testId={`channel-working-avatar-${channelName}-${agent.pubkey}`}
+              />
+            ))}
+            {overflowCount > 0 ? (
+              <span
+                className={cn(
+                  "flex h-[18px] min-w-[18px] items-center justify-center rounded-full border px-1 text-3xs font-semibold leading-none shadow-xs ring-1",
+                  isActive
+                    ? "border-sidebar-active bg-sidebar-active-foreground/15 text-sidebar-active-foreground ring-sidebar-active-foreground/25"
+                    : "border-sidebar bg-sidebar text-sidebar-foreground ring-primary/25",
+                )}
+              >
+                +{overflowCount}
+              </span>
+            ) : null}
+          </span>
+        </span>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-60 p-1"
+        onClick={(event) => event.stopPropagation()}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        side="right"
+        sideOffset={8}
+      >
+        <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
+          Working · {elapsed}
+        </div>
+        <div className="mt-1 flex flex-col gap-1">
+          {agents.map((agent) => (
+            <div
+              className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-foreground"
+              data-testid={`channel-working-agent-${channelName}-${agent.pubkey}`}
+              key={agent.pubkey}
+            >
+              <ProfileAvatar
+                avatarUrl={agent.avatarUrl}
+                className="h-6 w-6 shrink-0 text-2xs"
+                iconClassName="h-3.5 w-3.5"
+                label={agent.label}
+              />
+              <span className="min-w-0 flex-1 truncate">{agent.label}</span>
+              <span
+                aria-hidden="true"
+                className="h-2 w-2 shrink-0 rounded-full bg-primary motion-safe:animate-pulse"
+              />
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -283,7 +373,7 @@ export function ChannelMenuButton({
         />
       ) : null}
       {activeWorking ? (
-        <ChannelWorkingBadge
+        <ChannelWorkingAgents
           channelName={channel.name}
           isActive={isActive}
           summary={activeWorking}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -131,8 +131,8 @@ function ChannelWorkingAgents({
       pubkey,
     };
   });
-  const visibleAgents = agents.slice(0, 3);
-  const overflowCount = Math.max(0, agents.length - visibleAgents.length);
+  const visibleAgents = agents.slice(0, agents.length > 3 ? 2 : 3);
+  const overflowCount = agents.length > 3 ? agents.length - 2 : 0;
   const label =
     agents.length > 1
       ? `${agents.length} agents working · ${elapsed}`
@@ -158,10 +158,10 @@ function ChannelWorkingAgents({
               <ProfileAvatar
                 avatarUrl={agent.avatarUrl}
                 className={cn(
-                  "h-[18px] w-[18px] border text-3xs shadow-xs ring-1",
+                  "h-[18px] w-[18px] text-3xs shadow-xs",
                   isActive
-                    ? "border-sidebar-active bg-sidebar-active-foreground/15 text-sidebar-active-foreground ring-sidebar-active-foreground/25"
-                    : "border-sidebar bg-sidebar text-sidebar-foreground ring-primary/25",
+                    ? "bg-sidebar-active-foreground/15 text-sidebar-active-foreground"
+                    : "bg-sidebar text-sidebar-foreground",
                 )}
                 iconClassName="h-3 w-3"
                 key={agent.pubkey}
@@ -172,10 +172,10 @@ function ChannelWorkingAgents({
             {overflowCount > 0 ? (
               <span
                 className={cn(
-                  "flex h-[18px] min-w-[18px] items-center justify-center rounded-full border px-1 text-3xs font-semibold leading-none shadow-xs ring-1",
+                  "flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1 text-3xs font-semibold leading-none shadow-xs",
                   isActive
-                    ? "border-sidebar-active bg-sidebar-active-foreground/15 text-sidebar-active-foreground ring-sidebar-active-foreground/25"
-                    : "border-sidebar bg-sidebar text-sidebar-foreground ring-primary/25",
+                    ? "bg-sidebar-active-foreground/15 text-sidebar-active-foreground"
+                    : "bg-sidebar text-sidebar-foreground",
                 )}
               >
                 +{overflowCount}


### PR DESCRIPTION
## Overview

**Category:** fix
**User Impact:** The sidebar "working" indicator is now a compact pulsing avatar group instead of a wide text badge, so channel names keep their horizontal space — and a declared owner sees their agent light up even when it runs on another machine.

**Problem:** The working indicator shipped in #1274 rendered as a `Working · 1m 20s` text badge that ate into the channel name's horizontal space. It also decided which agents to show purely on local key custody (`managedAgents`), so a declared owner whose agent runs on another machine — owning it but holding no local key — would not see their own agent working.

**Solution:** Replace the text badge with a pulsing avatar group (with a who's-working popover), tighten the overflow rule, drop a stray accent border/ring, and widen the visibility gate from key custody to declared ownership — the same NIP-OA `ownerPubkey == viewer` signal #1229 standardized across the other owner surfaces. Encryption stays the real security boundary, so the wider read gate leaks nothing.

<details>
<summary>File changes</summary>

**desktop/src/features/sidebar/ui/SidebarSection.tsx**
Replaced the `Working · 1m 20s` text badge with a pulsing agent avatar group plus a who's-working popover. Overflow rule: show all avatars when ≤3, collapse to 2 avatars + a "+N" badge past 3. Removed the accent `border`/`ring-1` glow from both the avatars and the +N badge.

**desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts**
Widened the working-agent seed from locally managed agents to also include relay agents whose profile `ownerPubkey` matches the current viewer (mirrors the #1229 declared-ownership gate). Dedupes by pubkey, preserving managed-agent status when an agent appears in both sets. Falls back to managed-only when there is no viewer identity.

**desktop/src/features/agents/activeAgentTurnsStore.ts**
Active channel turn summaries now carry `agentPubkeys` so the sidebar can resolve avatars for each working agent.

**desktop/src/features/agents/activeAgentTurnsStore.test.mjs**
Updated the store test for the new pubkey aggregation.

</details>

## Reproduction Steps

1. Run the desktop app as the declared owner of one or more agents.
2. Have agents take turns in a few channels (single, multiple, and more than three in one channel).
3. In the left sidebar, confirm working channels show a compact pulsing avatar group at the right edge of the row — channel names keep their space (no more wide text badge).
4. Confirm the overflow collapses to 2 avatars + "+N" once a channel has more than three working agents, and that the avatars carry no accent border/ring.
5. Hover the avatars to confirm the who's-working popover lists each agent with avatar + name.
6. With an agent you declare ownership of but that runs on another machine (no local key), confirm its working indicator now lights up.

## Screenshots/Demos

Screenshots of the avatar group, overflow, and popover are being captured against this branch and will be added in review.
