### PR TITLE
fix: unconditionally replace CLI symlink on boot

### DIFF
--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -265,9 +265,9 @@ fn ensure_skill_symlinks(_root: &Path) -> Result<(), String> {
 
 /// Ensures `~/.local/bin/buzz` is a symlink to the bundled CLI binary.
 ///
-/// Creates the symlink if it doesn't exist, updates it if it already points
-/// to a Buzz app bundle, and leaves it alone if it points elsewhere (to
-/// avoid clobbering another tool's binary).
+/// On every boot: replaces any existing symlink unconditionally (the `buzz`
+/// name is our namespace), creates a new one if absent, and leaves regular
+/// files alone to avoid clobbering a user-compiled binary.
 ///
 /// Non-fatal: callers should ignore errors — the symlink is a convenience
 /// for human Terminal use; agents find the CLI via PATH augmentation.
@@ -287,23 +287,14 @@ pub fn ensure_cli_symlink(exe_parent: &Path) -> Result<(), String> {
     let link = local_bin.join("buzz");
     match link.symlink_metadata() {
         Ok(meta) if meta.file_type().is_symlink() => {
-            // Symlink exists — only update if it points to a Buzz bundle.
-            if let Ok(target) = fs::read_link(&link) {
-                let target_str = target.display().to_string();
-                if target_str.contains(".app/Contents/MacOS") {
-                    // Buzz-owned symlink — update to current bundle path.
-                    let _ = fs::remove_file(&link);
-                    std::os::unix::fs::symlink(&buzz_bin, &link)
-                        .map_err(|e| format!("symlink {}: {e}", link.display()))?;
-                }
-                // Otherwise: symlink points elsewhere — don't clobber.
-            }
+            let _ = fs::remove_file(&link);
+            std::os::unix::fs::symlink(&buzz_bin, &link)
+                .map_err(|e| format!("symlink {}: {e}", link.display()))?;
         }
         Ok(_) => {
             // Regular file or directory — don't clobber.
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // No file exists — create the symlink.
             std::os::unix::fs::symlink(&buzz_bin, &link)
                 .map_err(|e| format!("symlink {}: {e}", link.display()))?;
         }
@@ -935,15 +926,39 @@ mod tests {
         fs::create_dir(&exe_parent).unwrap();
         fs::write(exe_parent.join("buzz"), "binary").unwrap();
 
-        // Point home_dir to a temp location by using ensure_cli_symlink
-        // directly with a custom link target. We'll test the logic manually.
+        // Simulate the symlink creation path.
         let local_bin = tmp.path().join("local_bin");
         fs::create_dir_all(&local_bin).unwrap();
         let link = local_bin.join("buzz");
 
-        // Create symlink manually to test the creation path.
         std::os::unix::fs::symlink(exe_parent.join("buzz"), &link).unwrap();
         assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read_link(&link).unwrap(), exe_parent.join("buzz"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_cli_symlink_replaces_stale_symlink() {
+        // Simulates the bug: a symlink pointing to a deleted worktree path
+        // should be unconditionally replaced on next boot.
+        let tmp = tempfile::tempdir().unwrap();
+        let exe_parent = tmp.path().join("MacOS");
+        fs::create_dir(&exe_parent).unwrap();
+        fs::write(exe_parent.join("buzz"), "current binary").unwrap();
+
+        let local_bin = tmp.path().join("local_bin");
+        fs::create_dir_all(&local_bin).unwrap();
+        let link = local_bin.join("buzz");
+
+        // Create a stale symlink pointing to a nonexistent worktree path.
+        let stale_target = tmp.path().join("worktrees/old/target/debug/buzz");
+        std::os::unix::fs::symlink(&stale_target, &link).unwrap();
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read_link(&link).unwrap(), stale_target);
+
+        // The new logic replaces any symlink unconditionally.
+        let _ = fs::remove_file(&link);
+        std::os::unix::fs::symlink(exe_parent.join("buzz"), &link).unwrap();
         assert_eq!(fs::read_link(&link).unwrap(), exe_parent.join("buzz"));
     }
 
@@ -956,11 +971,8 @@ mod tests {
         let link = local_bin.join("buzz");
         fs::write(&link, "user-installed binary").unwrap();
 
-        // Verify it's a regular file.
+        // Regular files are preserved — the Ok(_) branch skips them.
         assert!(link.symlink_metadata().unwrap().file_type().is_file());
-        // Content should be preserved (we can't call ensure_cli_symlink
-        // directly without controlling dirs::home_dir(), but the logic
-        // in the Ok(_) branch of ensure_cli_symlink skips regular files).
         assert_eq!(fs::read_to_string(&link).unwrap(), "user-installed binary");
     }
 

--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -938,32 +938,6 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn ensure_cli_symlink_replaces_stale_symlink() {
-        // Simulates the bug: a symlink pointing to a deleted worktree path
-        // should be unconditionally replaced on next boot.
-        let tmp = tempfile::tempdir().unwrap();
-        let exe_parent = tmp.path().join("MacOS");
-        fs::create_dir(&exe_parent).unwrap();
-        fs::write(exe_parent.join("buzz"), "current binary").unwrap();
-
-        let local_bin = tmp.path().join("local_bin");
-        fs::create_dir_all(&local_bin).unwrap();
-        let link = local_bin.join("buzz");
-
-        // Create a stale symlink pointing to a nonexistent worktree path.
-        let stale_target = tmp.path().join("worktrees/old/target/debug/buzz");
-        std::os::unix::fs::symlink(&stale_target, &link).unwrap();
-        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
-        assert_eq!(fs::read_link(&link).unwrap(), stale_target);
-
-        // The new logic replaces any symlink unconditionally.
-        let _ = fs::remove_file(&link);
-        std::os::unix::fs::symlink(exe_parent.join("buzz"), &link).unwrap();
-        assert_eq!(fs::read_link(&link).unwrap(), exe_parent.join("buzz"));
-    }
-
-    #[cfg(unix)]
-    #[test]
     fn ensure_cli_symlink_does_not_clobber_regular_file() {
         let tmp = tempfile::tempdir().unwrap();
         let local_bin = tmp.path().join("local_bin");


### PR DESCRIPTION
## Problem

`ensure_cli_symlink()` used a `.app/Contents/MacOS` heuristic to decide whether an existing symlink at `~/.local/bin/buzz` was "ours" to update. When a dev build (`just dev` from a worktree) created the symlink first, it pointed to a path like `.worktrees/<name>/desktop/src-tauri/target/debug/buzz`. Once that worktree was cleaned up:

1. The symlink broke permanently (dangling target)
2. The production app refused to fix it — the target didn't match `.app/Contents/MacOS`, so it fell into the "don't clobber" branch

## Fix

Replace the ownership heuristic with unconditional logic:

- **Symlink exists** → remove and recreate pointing to current binary
- **Regular file exists** → skip (don't clobber user-compiled binaries)
- **Nothing exists** → create the symlink

The `buzz` name at `~/.local/bin/buzz` is effectively our namespace — no other tool uses it. The only meaningful guard is "don't delete a regular file." Symlinks are always ours to manage.

Removed the `ensure_cli_symlink_replaces_stale_symlink` test that replicated logic inline instead of calling the real function (couldn't catch regressions). This also brings `nest.rs` back under the 1450-line file-size lint limit.

## Workaround for affected users

`rm ~/.local/bin/buzz` — the next Buzz app launch recreates it correctly.