### PR TITLE
Harden relay attack surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,8 @@ RELAY_URL=ws://localhost:3000
 # {path}/{owner_hex}/{repo_id}.git/. Default: ./repos (relative to CWD).
 # Set an absolute path to keep repos stable across worktrees.
 # BUZZ_GIT_REPO_PATH=./repos
+# BUZZ_GIT_MAX_PACK_BYTES=524288000
+# BUZZ_GIT_MAX_REPO_BYTES=1048576000
 
 # -----------------------------------------------------------------------------
 # Ephemeral Channels (TTL testing)

--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,14 @@ RELAY_URL=ws://localhost:3000
 # BUZZ_GIT_MAX_REPO_BYTES=1048576000
 
 # -----------------------------------------------------------------------------
+# Media Upload Admission
+# -----------------------------------------------------------------------------
+# Bound image/video parser and storage work admitted by one relay process.
+# BUZZ_MEDIA_MAX_CONCURRENT_UPLOADS=8
+# BUZZ_MEDIA_MAX_CONCURRENT_UPLOADS_PER_PUBKEY=2
+# BUZZ_MEDIA_UPLOADS_PER_MINUTE=30
+
+# -----------------------------------------------------------------------------
 # Ephemeral Channels (TTL testing)
 # -----------------------------------------------------------------------------
 # Override the TTL for all ephemeral channels (in seconds). When set, any

--- a/crates/buzz-db/src/event.rs
+++ b/crates/buzz-db/src/event.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 use buzz_core::kind::{
     event_kind_i32, is_ephemeral, is_parameterized_replaceable, KIND_AUTH, KIND_EVENT_REMINDER,
+    KIND_HUDDLE_STARTED,
 };
 use buzz_core::{CommunityId, StoredEvent};
 
@@ -105,6 +106,16 @@ impl EventQuery {
 /// anything beyond this is either a bug or abuse.
 pub const D_TAG_MAX_LEN: usize = 1024;
 
+/// Maximum huddle-start content bytes considered by the parent-link lookup.
+///
+/// The canonical content is a small JSON object containing one UUID. Rejecting
+/// oversized candidates keeps a malformed lifecycle event from making audio
+/// admission pull large text rows into memory.
+const HUDDLE_LINK_CONTENT_MAX_BYTES: i64 = 512;
+/// Maximum candidate rows inspected after SQL prefiltering by parent, creator,
+/// kind, and UUID substring.
+const HUDDLE_LINK_CANDIDATE_LIMIT: i64 = 32;
+
 /// Extract the `d_tag` value for storage.
 ///
 /// For NIP-33 parameterized replaceable events (kind 30000–39999): returns the first
@@ -148,6 +159,62 @@ pub fn extract_not_before(event: &Event) -> Option<i64> {
             None
         }
     })
+}
+
+fn huddle_started_content_links(content: &str, ephemeral_channel_id: Uuid) -> bool {
+    serde_json::from_str::<serde_json::Value>(content)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("ephemeral_channel_id")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|id| Uuid::parse_str(id).ok())
+        })
+        .is_some_and(|id| id == ephemeral_channel_id)
+}
+
+/// Return whether `parent_channel_id` has a creator-signed huddle-start event
+/// that links to `ephemeral_channel_id`.
+///
+/// The creator constraint matters: a member of some unrelated channel can post
+/// their own kind:48100 event there, but they cannot sign as the creator of the
+/// target ephemeral channel.
+pub async fn huddle_started_link_exists(
+    pool: &PgPool,
+    community_id: CommunityId,
+    parent_channel_id: Uuid,
+    ephemeral_channel_id: Uuid,
+    creator_pubkey: &[u8],
+) -> Result<bool> {
+    let uuid_needle = format!("%{}%", ephemeral_channel_id);
+    let candidates: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT content
+        FROM events
+        WHERE deleted_at IS NULL
+          AND community_id = $1
+          AND channel_id = $2
+          AND kind = $3
+          AND pubkey = $4
+          AND octet_length(content) <= $5
+          AND content ILIKE $6
+        ORDER BY created_at DESC, id ASC
+        LIMIT $7
+        "#,
+    )
+    .bind(community_id.as_uuid())
+    .bind(parent_channel_id)
+    .bind(KIND_HUDDLE_STARTED as i32)
+    .bind(creator_pubkey)
+    .bind(HUDDLE_LINK_CONTENT_MAX_BYTES)
+    .bind(uuid_needle)
+    .bind(HUDDLE_LINK_CANDIDATE_LIMIT)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(candidates
+        .iter()
+        .any(|content| huddle_started_content_links(content, ephemeral_channel_id)))
 }
 
 /// Insert a Nostr event. Rejects AUTH and ephemeral kinds.
@@ -1708,5 +1775,22 @@ mod tests {
                 .expect("re-claim A after release"),
             "A/X must be reclaimable after its own release"
         );
+    }
+
+    #[test]
+    fn huddle_started_content_requires_matching_ephemeral_field() {
+        let channel_id = Uuid::new_v4();
+        let matching = serde_json::json!({
+            "ephemeral_channel_id": channel_id.to_string(),
+        })
+        .to_string();
+        assert!(huddle_started_content_links(&matching, channel_id));
+
+        let wrong_field = serde_json::json!({
+            "other": channel_id.to_string(),
+        })
+        .to_string();
+        assert!(!huddle_started_content_links(&wrong_field, channel_id));
+        assert!(!huddle_started_content_links("not-json", channel_id));
     }
 }

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -413,6 +413,25 @@ impl Db {
         event::count_events(&self.pool, q).await
     }
 
+    /// Return whether a creator-signed huddle-start event links a parent
+    /// channel to an ephemeral huddle channel.
+    pub async fn huddle_started_link_exists(
+        &self,
+        community_id: CommunityId,
+        parent_channel_id: Uuid,
+        ephemeral_channel_id: Uuid,
+        creator_pubkey: &[u8],
+    ) -> Result<bool> {
+        event::huddle_started_link_exists(
+            &self.pool,
+            community_id,
+            parent_channel_id,
+            ephemeral_channel_id,
+            creator_pubkey,
+        )
+        .await
+    }
+
     /// Fetch the latest replaceable event for a (kind, pubkey) pair.
     ///
     /// Uses canonical NIP-16 ordering: `created_at DESC, id ASC`.

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -1542,6 +1542,31 @@ impl Db {
         .await
     }
 
+    /// Insert or update a workflow using its NIP-33 `d`-tag UUID.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn upsert_workflow(
+        &self,
+        community_id: CommunityId,
+        id: Uuid,
+        channel_id: Option<Uuid>,
+        owner_pubkey: &[u8],
+        name: &str,
+        definition_json: &str,
+        definition_hash: &[u8],
+    ) -> Result<()> {
+        workflow::upsert_workflow(
+            &self.pool,
+            community_id,
+            id,
+            channel_id,
+            owner_pubkey,
+            name,
+            definition_json,
+            definition_hash,
+        )
+        .await
+    }
+
     /// Fetch a single workflow by ID, scoped to its community.
     pub async fn get_workflow(
         &self,

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -1679,6 +1679,16 @@ impl Db {
         workflow::delete_workflow(&self.pool, community_id, id).await
     }
 
+    /// Delete a workflow only when it belongs to the provided owner.
+    pub async fn delete_workflow_for_owner(
+        &self,
+        community_id: CommunityId,
+        id: Uuid,
+        owner_pubkey: &[u8],
+    ) -> Result<()> {
+        workflow::delete_workflow_for_owner(&self.pool, community_id, id, owner_pubkey).await
+    }
+
     /// Find a workflow by owner pubkey and name within a community. Used for
     /// NIP-09 a-tag deletion where the d-tag is the workflow name (not UUID).
     pub async fn find_workflow_by_owner_and_name(

--- a/crates/buzz-db/src/workflow.rs
+++ b/crates/buzz-db/src/workflow.rs
@@ -301,6 +301,56 @@ pub async fn create_workflow(
     Ok(id)
 }
 
+/// Insert or update a workflow at the caller-supplied NIP-33 `d`-tag UUID.
+///
+/// Updates are allowed only when the existing row has the same owner and
+/// channel. That keeps a learned workflow UUID from becoming a cross-user or
+/// cross-channel overwrite primitive while still making retries idempotent.
+#[allow(clippy::too_many_arguments)]
+pub async fn upsert_workflow(
+    pool: &PgPool,
+    community_id: CommunityId,
+    id: Uuid,
+    channel_id: Option<Uuid>,
+    owner_pubkey: &[u8],
+    name: &str,
+    definition_json: &str,
+    definition_hash: &[u8],
+) -> Result<()> {
+    let row = sqlx::query(
+        r#"
+        INSERT INTO workflows
+            (community_id, id, name, owner_pubkey, channel_id, definition, definition_hash, status, enabled)
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, 'active', TRUE)
+        ON CONFLICT (community_id, id) DO UPDATE
+        SET name = EXCLUDED.name,
+            definition = EXCLUDED.definition,
+            definition_hash = EXCLUDED.definition_hash,
+            updated_at = NOW()
+        WHERE workflows.owner_pubkey = EXCLUDED.owner_pubkey
+          AND workflows.channel_id IS NOT DISTINCT FROM EXCLUDED.channel_id
+        RETURNING id
+        "#,
+    )
+    .bind(community_id.as_uuid())
+    .bind(id)
+    .bind(name)
+    .bind(owner_pubkey)
+    .bind(channel_id)
+    .bind(definition_json)
+    .bind(definition_hash)
+    .fetch_optional(pool)
+    .await?;
+
+    if row.is_none() {
+        return Err(DbError::AccessDenied(format!(
+            "workflow {id} belongs to a different owner or channel"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Fetch a single workflow by ID, scoped to its community.
 ///
 /// `workflows` is keyed `(community_id, id)`; the same workflow UUID can exist

--- a/crates/buzz-db/src/workflow.rs
+++ b/crates/buzz-db/src/workflow.rs
@@ -656,6 +656,34 @@ pub async fn delete_workflow(pool: &PgPool, community_id: CommunityId, id: Uuid)
     Ok(())
 }
 
+/// Delete a workflow only when it belongs to `owner_pubkey`.
+///
+/// Used by event-driven deletion paths where the workflow UUID is attacker
+/// controlled. Keeping the owner predicate in the DELETE statement avoids a
+/// check-then-delete race and ensures a caller cannot delete another user's
+/// workflow just by learning its UUID.
+pub async fn delete_workflow_for_owner(
+    pool: &PgPool,
+    community_id: CommunityId,
+    id: Uuid,
+    owner_pubkey: &[u8],
+) -> Result<()> {
+    let affected = sqlx::query(
+        "DELETE FROM workflows WHERE community_id = $1 AND id = $2 AND owner_pubkey = $3",
+    )
+    .bind(community_id.as_uuid())
+    .bind(id)
+    .bind(owner_pubkey)
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    if affected == 0 {
+        return Err(DbError::NotFound(format!("workflow {id}")));
+    }
+    Ok(())
+}
+
 // -- Workflow Run CRUD --------------------------------------------------------
 
 /// Insert a new workflow run. Returns the new run's UUID.

--- a/crates/buzz-media/src/error.rs
+++ b/crates/buzz-media/src/error.rs
@@ -56,6 +56,10 @@ pub enum MediaError {
     TokenRevoked,
     #[error("pubkey mismatch")]
     PubkeyMismatch,
+    #[error("upload rate limit exceeded")]
+    UploadRateLimitExceeded,
+    #[error("upload concurrency limit reached")]
+    UploadConcurrencyLimitReached,
     /// Video codec is not H.264 (avc1).
     #[error("unsupported video codec: only H.264 (avc1) is accepted")]
     WrongCodec,
@@ -133,6 +137,9 @@ impl IntoResponse for MediaError {
             }
             Self::InsufficientScope => (StatusCode::FORBIDDEN, self.to_string()),
             Self::RelayMembershipRequired => (StatusCode::FORBIDDEN, self.to_string()),
+            Self::UploadRateLimitExceeded | Self::UploadConcurrencyLimitReached => {
+                (StatusCode::TOO_MANY_REQUESTS, self.to_string())
+            }
             Self::UnsupportedContainer => (StatusCode::UNSUPPORTED_MEDIA_TYPE, self.to_string()),
             Self::WrongCodec
             | Self::DurationTooLong

--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -740,10 +740,16 @@ pub async fn count_events(
             } else {
                 // Fallback: query + post-filter for non-pushable constraints.
                 let mut q = query;
-                q.limit = Some(100_000);
-                q.max_limit = Some(100_000);
+                crate::handlers::req::apply_count_fallback_limit(&mut q);
                 match state.db.query_events(&q).await {
                     Ok(stored_events) => {
+                        if crate::handlers::req::count_fallback_exceeded(stored_events.len()) {
+                            metrics::counter!("buzz_count_fallback_rejections_total").increment(1);
+                            return Err(api_error(
+                                StatusCode::BAD_REQUEST,
+                                "count filter requires narrower constraints",
+                            ));
+                        }
                         for se in stored_events {
                             if !buzz_core::filter::filters_match(std::slice::from_ref(filter), &se)
                             {
@@ -790,11 +796,17 @@ pub async fn count_events(
                     }
                 }
             } else {
-                // Fallback: query with high limit + post-filter for correctness.
-                query.limit = Some(100_000);
-                query.max_limit = Some(100_000);
+                // Fallback: query a bounded candidate set + post-filter.
+                crate::handlers::req::apply_count_fallback_limit(&mut query);
                 match state.db.query_events(&query).await {
                     Ok(stored_events) => {
+                        if crate::handlers::req::count_fallback_exceeded(stored_events.len()) {
+                            metrics::counter!("buzz_count_fallback_rejections_total").increment(1);
+                            return Err(api_error(
+                                StatusCode::BAD_REQUEST,
+                                "count filter requires narrower constraints",
+                            ));
+                        }
                         for se in stored_events {
                             if !buzz_core::filter::filters_match(std::slice::from_ref(filter), &se)
                             {

--- a/crates/buzz-relay/src/api/git/cas_publish.rs
+++ b/crates/buzz-relay/src/api/git/cas_publish.rs
@@ -68,7 +68,9 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tracing::{debug, warn};
 
-use crate::api::git::manifest::{pointer_key, Manifest, ManifestError, MANIFEST_VERSION};
+use crate::api::git::manifest::{
+    pointer_key, Manifest, ManifestError, MANIFEST_VERSION, MAX_MANIFEST_REFS,
+};
 use crate::api::git::store::{CasOutcome, ETag, GitStore, Precond, StoreError};
 use buzz_core::TenantContext;
 
@@ -124,6 +126,21 @@ pub enum CasError {
     /// workspace. Pre-CAS — the pointer was never written.
     #[error("pack capture: {0}")]
     PackCapture(String),
+
+    /// The push would make the repo exceed the relay's configured byte budget.
+    #[error("resource limit: {0}")]
+    ResourceLimit(String),
+}
+
+/// Resource limits carried from hydration into the publish step.
+#[derive(Debug, Clone, Copy)]
+pub struct PublishLimits {
+    /// Bytes already materialized from the parent manifest.
+    pub parent_hydrated_bytes: u64,
+    /// Maximum bytes allowed in one newly captured pack.
+    pub max_pack_bytes: u64,
+    /// Maximum total hydrated bytes allowed for the resulting repo.
+    pub max_repo_bytes: u64,
 }
 
 /// Outcome of a successful CAS. Carries the composed manifest so the
@@ -209,23 +226,52 @@ impl ParentState {
 async fn snapshot_workspace_state(
     repo_path: &Path,
 ) -> Result<(BTreeMap<String, String>, String), CasError> {
+    const MAX_REF_SNAPSHOT_BYTES: u64 = 4 * 1024 * 1024;
+
+    let refs_stdout_tmp = tempfile::NamedTempFile::new()
+        .map_err(|e| CasError::PackCapture(format!("for-each-ref stdout tempfile: {e}")))?;
+    let refs_stdout_file = refs_stdout_tmp
+        .reopen()
+        .map_err(|e| CasError::PackCapture(format!("for-each-ref stdout reopen: {e}")))?;
+    let refs_stderr_tmp = tempfile::NamedTempFile::new()
+        .map_err(|e| CasError::PackCapture(format!("for-each-ref stderr tempfile: {e}")))?;
+    let refs_stderr_file = refs_stderr_tmp
+        .reopen()
+        .map_err(|e| CasError::PackCapture(format!("for-each-ref stderr reopen: {e}")))?;
+
     let mut refs_cmd = Command::new("git");
     refs_cmd
         .args(["for-each-ref", "--format=%(refname) %(objectname)"])
-        .current_dir(repo_path);
+        .current_dir(repo_path)
+        .stdout(Stdio::from(refs_stdout_file))
+        .stderr(Stdio::from(refs_stderr_file));
     super::transport::harden_git_env(&mut refs_cmd);
-    let refs_out = refs_cmd
-        .output()
+    let refs_status = refs_cmd
+        .status()
         .await
         .map_err(|e| CasError::PackCapture(format!("for-each-ref spawn: {e}")))?;
-    if !refs_out.status.success() {
+    if !refs_status.success() {
         return Err(CasError::PackCapture(format!(
-            "for-each-ref failed: status={:?}",
-            refs_out.status.code()
+            "for-each-ref failed: status={:?} stderr={}",
+            refs_status.code(),
+            read_prefix(refs_stderr_tmp.path(), 64 * 1024).await
         )));
     }
+    let refs_stdout_len = tokio::fs::metadata(refs_stdout_tmp.path())
+        .await
+        .map_err(|e| CasError::PackCapture(format!("for-each-ref stdout metadata: {e}")))?
+        .len();
+    if refs_stdout_len > MAX_REF_SNAPSHOT_BYTES {
+        return Err(CasError::ResourceLimit(format!(
+            "ref snapshot is {refs_stdout_len} bytes (max {MAX_REF_SNAPSHOT_BYTES})"
+        )));
+    }
+    let refs_stdout = tokio::fs::read(refs_stdout_tmp.path())
+        .await
+        .map_err(|e| CasError::PackCapture(format!("for-each-ref stdout read: {e}")))?;
+
     let mut refs = BTreeMap::new();
-    for line in std::str::from_utf8(&refs_out.stdout)
+    for line in std::str::from_utf8(&refs_stdout)
         .unwrap_or_default()
         .lines()
     {
@@ -236,6 +282,11 @@ async fn snapshot_workspace_state(
         if oid.len() != 40 || !oid.chars().all(|c| c.is_ascii_hexdigit()) {
             warn!(ref_name = %name, oid = %oid, "for-each-ref returned malformed oid; skipping");
             continue;
+        }
+        if refs.len() >= MAX_MANIFEST_REFS && !refs.contains_key(name) {
+            return Err(CasError::ResourceLimit(format!(
+                "workspace contains more than {MAX_MANIFEST_REFS} refs"
+            )));
         }
         refs.insert(name.to_string(), oid.to_string());
     }
@@ -328,6 +379,7 @@ async fn capture_pack(
     repo_path: &Path,
     refs_before: &BTreeMap<String, String>,
     refs_after: &BTreeMap<String, String>,
+    max_pack_bytes: u64,
 ) -> Result<Option<Vec<u8>>, CasError> {
     // Build rev-spec stdin: positive new tips, negative old tips.
     // Deduplicate against the same-oid case — no point feeding `X ^X`.
@@ -349,12 +401,23 @@ async fn capture_pack(
         stdin_lines.push('\n');
     }
 
+    let stdout_tmp = tempfile::NamedTempFile::new()
+        .map_err(|e| CasError::PackCapture(format!("pack-objects stdout tempfile: {e}")))?;
+    let stdout_file = stdout_tmp
+        .reopen()
+        .map_err(|e| CasError::PackCapture(format!("pack-objects stdout reopen: {e}")))?;
+    let stderr_tmp = tempfile::NamedTempFile::new()
+        .map_err(|e| CasError::PackCapture(format!("pack-objects stderr tempfile: {e}")))?;
+    let stderr_file = stderr_tmp
+        .reopen()
+        .map_err(|e| CasError::PackCapture(format!("pack-objects stderr reopen: {e}")))?;
+
     let mut cmd = Command::new("git");
     cmd.args(["pack-objects", "--revs", "--stdout", "-q"])
         .current_dir(repo_path)
         .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file));
     super::transport::harden_git_env(&mut cmd);
     let mut child = cmd
         .spawn()
@@ -375,16 +438,43 @@ async fn capture_pack(
         .await
         .map_err(|e| CasError::PackCapture(format!("pack-objects wait: {e}")))?;
     if !out.status.success() {
+        let stderr = read_prefix(stderr_tmp.path(), 64 * 1024).await;
         return Err(CasError::PackCapture(format!(
             "pack-objects failed: status={:?} stderr={}",
             out.status.code(),
-            String::from_utf8_lossy(&out.stderr)
+            stderr
         )));
     }
-    if out.stdout.is_empty() {
+    let pack_len = tokio::fs::metadata(stdout_tmp.path())
+        .await
+        .map_err(|e| CasError::PackCapture(format!("pack-objects stdout metadata: {e}")))?
+        .len();
+    if pack_len > max_pack_bytes {
+        return Err(CasError::ResourceLimit(format!(
+            "pack-objects output is {pack_len} bytes (max {max_pack_bytes})"
+        )));
+    }
+    if pack_len == 0 {
         return Ok(None);
     }
-    Ok(Some(out.stdout))
+    let pack_bytes = tokio::fs::read(stdout_tmp.path())
+        .await
+        .map_err(|e| CasError::PackCapture(format!("pack-objects stdout read: {e}")))?;
+    Ok(Some(pack_bytes))
+}
+
+async fn read_prefix(path: &Path, max_bytes: u64) -> String {
+    use tokio::io::AsyncReadExt;
+
+    let Ok(file) = tokio::fs::File::open(path).await else {
+        return "<stderr unavailable>".to_string();
+    };
+    let mut bytes = Vec::new();
+    let mut limited = file.take(max_bytes);
+    if limited.read_to_end(&mut bytes).await.is_err() {
+        return "<stderr unavailable>".to_string();
+    }
+    String::from_utf8_lossy(&bytes).to_string()
 }
 
 /// Compose `m_after` from the parent manifest and the new ref/pack state.
@@ -464,6 +554,7 @@ pub async fn cas_publish(
     owner: &str,
     repo: &str,
     parent_state: &ParentState,
+    limits: PublishLimits,
 ) -> Result<CasSuccess, CasError> {
     let pkey = pointer_key(ctx.community(), owner, repo);
 
@@ -487,8 +578,25 @@ pub async fn cas_publish(
     // parent manifest's refs — i.e. the set the workspace was hydrated
     // against — so the delta covers exactly the objects this push
     // introduced.
-    let pack_bytes = capture_pack(repo_path, &parent_state.parent.refs, &refs_after).await?;
+    let pack_bytes = capture_pack(
+        repo_path,
+        &parent_state.parent.refs,
+        &refs_after,
+        limits.max_pack_bytes,
+    )
+    .await?;
     let new_pack_key = if let Some(bytes) = pack_bytes {
+        let new_pack_bytes = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+        let total_bytes = limits
+            .parent_hydrated_bytes
+            .checked_add(new_pack_bytes)
+            .ok_or_else(|| CasError::ResourceLimit("repo byte count overflowed u64".into()))?;
+        if total_bytes > limits.max_repo_bytes {
+            return Err(CasError::ResourceLimit(format!(
+                "repo would need {total_bytes} hydrated bytes (max {})",
+                limits.max_repo_bytes
+            )));
+        }
         debug!(bytes = bytes.len(), "captured push pack");
         let pack_key = store.put_pack(&bytes).await?;
         if let Err(e) = write_idx_sidecar(store, &pack_key, &bytes).await {
@@ -618,6 +726,9 @@ mod tests {
 
     // `pointer_key` is owned by `manifest.rs` and unit-tested there
     // (one source of truth — Max/Sami's centralization point).
+    fn pack_key(ch: char) -> String {
+        format!("packs/{}", ch.to_string().repeat(64))
+    }
 
     #[test]
     fn digest_from_pack_key_strips_prefix() {
@@ -655,12 +766,12 @@ mod tests {
             None,
             "refs/heads/main".into(),
             refs.clone(),
-            Some("packs/abc".into()),
+            Some(pack_key('a')),
         );
         assert_eq!(m.version, MANIFEST_VERSION);
         assert_eq!(m.head, "refs/heads/main");
         assert_eq!(m.refs, refs);
-        assert_eq!(m.packs, vec!["packs/abc".to_string()]);
+        assert_eq!(m.packs, vec![pack_key('a')]);
         assert_eq!(m.parent, None);
     }
 
@@ -674,19 +785,19 @@ mod tests {
     #[test]
     fn compose_after_covers_parent_packs() {
         let mut parent = ParentState::fresh().parent;
-        parent.packs = vec!["packs/old1".into(), "packs/old2".into()];
+        parent.packs = vec![pack_key('1'), pack_key('2')];
         let m = compose_after(
             &parent,
             Some(parent_digest()),
             "refs/heads/main".into(),
             BTreeMap::new(),
-            Some("packs/new".into()),
+            Some(pack_key('3')),
         );
         // Inv_Closed: child covers parent.
         for p in &parent.packs {
             assert!(m.packs.contains(p));
         }
-        assert!(m.packs.contains(&"packs/new".to_string()));
+        assert!(m.packs.contains(&pack_key('3')));
         // Sorted.
         let mut sorted = m.packs.clone();
         sorted.sort();
@@ -700,7 +811,7 @@ mod tests {
     #[test]
     fn compose_after_no_new_pack_refs_only_push() {
         let mut parent = ParentState::fresh().parent;
-        parent.packs = vec!["packs/x".into()];
+        parent.packs = vec![pack_key('e')];
         let m = compose_after(
             &parent,
             Some(parent_digest()),
@@ -708,21 +819,21 @@ mod tests {
             BTreeMap::new(),
             None,
         );
-        assert_eq!(m.packs, vec!["packs/x".to_string()]);
+        assert_eq!(m.packs, vec![pack_key('e')]);
     }
 
     #[test]
     fn compose_after_dedupes_pack_already_in_parent() {
         let mut parent = ParentState::fresh().parent;
-        parent.packs = vec!["packs/x".into()];
+        parent.packs = vec![pack_key('e')];
         let m = compose_after(
             &parent,
             Some(parent_digest()),
             "refs/heads/main".into(),
             BTreeMap::new(),
-            Some("packs/x".into()),
+            Some(pack_key('e')),
         );
-        assert_eq!(m.packs, vec!["packs/x".to_string()]);
+        assert_eq!(m.packs, vec![pack_key('e')]);
     }
 
     /// `cas_publish` must invoke `Manifest::validate()` between
@@ -745,7 +856,7 @@ mod tests {
             None,
             "refs/heads/main".into(),
             refs,
-            Some("packs/abc".into()),
+            Some(pack_key('a')),
         );
         let manifest_err = m.validate().expect_err("unsafe refname must reject");
         match &manifest_err {
@@ -776,7 +887,7 @@ mod tests {
             None,
             String::new(), // empty HEAD — the fallback's worst case
             refs,
-            Some("packs/abc".into()),
+            Some(pack_key('a')),
         );
         assert!(matches!(
             m.validate(),

--- a/crates/buzz-relay/src/api/git/hydrate.rs
+++ b/crates/buzz-relay/src/api/git/hydrate.rs
@@ -30,7 +30,6 @@
 
 use std::path::{Path, PathBuf};
 
-use futures_util::future::try_join_all;
 use tempfile::TempDir;
 use tokio::process::Command;
 
@@ -38,6 +37,11 @@ use super::cas_publish::ParentState;
 use super::manifest::{is_hex_oid, is_safe_refname, pointer_key, Manifest, ManifestError};
 use super::store::{ETag, GitStore, StoreError};
 use buzz_core::TenantContext;
+
+/// Manifests should stay small after ref/pack cardinality validation. Bound
+/// the object read itself so malformed historical state cannot allocate an
+/// arbitrary JSON body before validation runs.
+const MAX_MANIFEST_BYTES: u64 = 4 * 1024 * 1024;
 
 /// A bare repo hydrated to a temporary directory.
 ///
@@ -48,6 +52,8 @@ pub struct HydratedRepo {
     _tempdir: TempDir,
     /// Absolute path to the bare repo root.
     path: PathBuf,
+    /// Total bytes of parent packs materialized into this workspace.
+    hydrated_bytes: u64,
 }
 
 impl HydratedRepo {
@@ -55,13 +61,18 @@ impl HydratedRepo {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    /// Total bytes of parent packs materialized into this workspace.
+    pub fn hydrated_bytes(&self) -> u64 {
+        self.hydrated_bytes
+    }
 }
 
 /// Hydration errors.
 ///
 /// "Repo doesn't exist" is signalled by `Ok(None)` from `hydrate_for_read`,
 /// not a variant here — the type system enforces the 404-vs-5xx split.
-/// Every variant of `HydrateError` maps to a backend / data error → HTTP 5xx.
+/// Resource-limit failures map to 413; other variants are backend/data errors.
 #[derive(Debug, thiserror::Error)]
 pub enum HydrateError {
     /// Pointer body was not a valid manifest digest (64 hex chars).
@@ -76,6 +87,9 @@ pub enum HydrateError {
     /// `git init --bare`, `git index-pack`, or filesystem operation failed.
     #[error("hydrate: {0}")]
     Hydrate(String),
+    /// A stored repo exceeds the relay's per-request resource budget.
+    #[error("resource limit: {0}")]
+    ResourceLimit(String),
 }
 
 // `pointer_key` is imported from `super::manifest` — single source of truth
@@ -91,11 +105,15 @@ pub async fn hydrate_for_read(
     ctx: &TenantContext,
     owner: &str,
     repo: &str,
+    max_pack_bytes: u64,
+    max_repo_bytes: u64,
 ) -> Result<Option<HydratedRepo>, HydrateError> {
     let Some((_etag, _digest, manifest)) = load_pointer(store, ctx, owner, repo).await? else {
         return Ok(None);
     };
-    Ok(Some(materialize_manifest(store, &manifest).await?))
+    Ok(Some(
+        materialize_manifest(store, &manifest, max_pack_bytes, max_repo_bytes).await?,
+    ))
 }
 
 /// Load the current manifest for a read path without materializing pack objects.
@@ -140,10 +158,13 @@ pub async fn hydrate_for_write(
     ctx: &TenantContext,
     owner: &str,
     repo: &str,
+    max_pack_bytes: u64,
+    max_repo_bytes: u64,
 ) -> Result<(HydratedRepo, ParentState), HydrateError> {
     match load_pointer(store, ctx, owner, repo).await? {
         Some((etag, digest, manifest)) => {
-            let repo = materialize_manifest(store, &manifest).await?;
+            let repo =
+                materialize_manifest(store, &manifest, max_pack_bytes, max_repo_bytes).await?;
             let parent = ParentState::from_loaded(etag, digest, manifest);
             Ok((repo, parent))
         }
@@ -159,6 +180,7 @@ pub async fn hydrate_for_write(
                 HydratedRepo {
                     _tempdir: tempdir,
                     path,
+                    hydrated_bytes: 0,
                 },
                 ParentState::fresh(),
             ))
@@ -189,9 +211,26 @@ async fn load_pointer(
         return Err(HydrateError::InvalidPointer);
     }
     let manifest_key = format!("manifests/{digest}");
-    let manifest_bytes = store.get_verified(&manifest_key, &digest).await?;
+    let manifest_bytes =
+        get_verified_limited(store, &manifest_key, &digest, MAX_MANIFEST_BYTES).await?;
     let manifest = Manifest::from_bytes(&manifest_bytes)?;
+    manifest.validate()?;
     Ok(Some((etag, digest, manifest)))
+}
+
+async fn get_verified_limited(
+    store: &GitStore,
+    key: &str,
+    digest: &str,
+    max_bytes: u64,
+) -> Result<bytes::Bytes, HydrateError> {
+    match store.get_verified_limited(key, digest, max_bytes).await {
+        Ok(bytes) => Ok(bytes),
+        Err(StoreError::ObjectTooLarge { size, max, .. }) => Err(HydrateError::ResourceLimit(
+            format!("object {key} is {size} bytes (max {max})"),
+        )),
+        Err(err) => Err(err.into()),
+    }
 }
 
 /// Materialize a manifest into a fresh tempdir bare repo.
@@ -203,28 +242,42 @@ async fn load_pointer(
 async fn materialize_manifest(
     store: &GitStore,
     manifest: &Manifest,
+    max_pack_bytes: u64,
+    max_repo_bytes: u64,
 ) -> Result<HydratedRepo, HydrateError> {
-    // Fetch all packs in parallel, each digest-verified by its key.
-    let pack_fetches = manifest.packs.iter().map(|key| async move {
-        let digest = key
-            .strip_prefix("packs/")
-            .ok_or_else(|| HydrateError::Hydrate(format!("malformed pack key {key:?}")))?;
-        let bytes = store.get_verified(key, digest).await?;
-        Ok::<_, HydrateError>((digest.to_string(), bytes))
-    });
-    let packs = try_join_all(pack_fetches).await?;
-
     // Init bare repo.
     let tempdir = TempDir::new().map_err(|e| HydrateError::Hydrate(format!("tempdir: {e}")))?;
     let path = tempdir.path().to_path_buf();
     run_git(&path, &["init", "--bare", "--quiet"]).await?;
 
-    // Phase 1: write + index every pack. Any failure here aborts before any
-    // ref is written — failed hydrate ⇒ no advertised refs.
+    // Phase 1: fetch, write, and index one pack at a time. Keeping only one
+    // verified pack body resident avoids a manifest with many historical packs
+    // multiplying memory by pack_count. Any failure here aborts before any ref
+    // is written — failed hydrate ⇒ no advertised refs.
     let pack_dir = path.join("objects").join("pack");
-    for (digest, bytes) in &packs {
+    let mut hydrated_bytes = 0u64;
+    for key in &manifest.packs {
+        let digest = key
+            .strip_prefix("packs/")
+            .ok_or_else(|| HydrateError::Hydrate(format!("malformed pack key {key:?}")))?;
+        let bytes = get_verified_limited(store, key, digest, max_pack_bytes).await?;
+        let pack_bytes = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+        if pack_bytes > max_pack_bytes {
+            return Err(HydrateError::ResourceLimit(format!(
+                "pack {digest} is {pack_bytes} bytes (max {max_pack_bytes})"
+            )));
+        }
+        hydrated_bytes = hydrated_bytes.checked_add(pack_bytes).ok_or_else(|| {
+            HydrateError::ResourceLimit("repo byte count overflowed u64".to_string())
+        })?;
+        if hydrated_bytes > max_repo_bytes {
+            return Err(HydrateError::ResourceLimit(format!(
+                "repo needs {hydrated_bytes} hydrated bytes (max {max_repo_bytes})"
+            )));
+        }
+
         let pack_path = pack_dir.join(format!("pack-{digest}.pack"));
-        tokio::fs::write(&pack_path, bytes)
+        tokio::fs::write(&pack_path, &bytes)
             .await
             .map_err(|e| HydrateError::Hydrate(format!("write pack {digest}: {e}")))?;
         install_or_generate_idx(store, &path, digest, &pack_path).await?;
@@ -271,6 +324,7 @@ async fn materialize_manifest(
     Ok(HydratedRepo {
         _tempdir: tempdir,
         path,
+        hydrated_bytes,
     })
 }
 
@@ -286,7 +340,10 @@ async fn install_or_generate_idx(
             tokio::fs::write(&idx_path, &idx_bytes)
                 .await
                 .map_err(|e| HydrateError::Hydrate(format!("write idx {pack_digest}: {e}")))?;
-            match run_git(repo_path, &["verify-pack", idx_path.to_str().unwrap()]).await {
+            let idx_path_str = idx_path
+                .to_str()
+                .ok_or_else(|| HydrateError::Hydrate("idx path is not valid utf-8".to_string()))?;
+            match run_git(repo_path, &["verify-pack", idx_path_str]).await {
                 Ok(()) => return Ok(()),
                 Err(e) => {
                     tracing::warn!(
@@ -313,7 +370,10 @@ async fn install_or_generate_idx(
     // checks, which would re-prove what manifest.packs already covers by
     // construction (Inv_Closed, write-path invariant). Latency cost on every
     // clone is not worth re-proving a write-path bug.
-    run_git(repo_path, &["index-pack", pack_path.to_str().unwrap()]).await
+    let pack_path_str = pack_path
+        .to_str()
+        .ok_or_else(|| HydrateError::Hydrate("pack path is not valid utf-8".to_string()))?;
+    run_git(repo_path, &["index-pack", pack_path_str]).await
 }
 
 /// Run `git <args>` in `cwd`, fail on non-zero exit.
@@ -496,7 +556,7 @@ mod tests {
         }
 
         // Hydrate.
-        let hydrated = hydrate_for_read(&st, &ctx, &owner, repo)
+        let hydrated = hydrate_for_read(&st, &ctx, &owner, repo, u64::MAX, u64::MAX)
             .await
             .expect("hydrate")
             .expect("hydrate Some");
@@ -569,7 +629,7 @@ mod tests {
         let st = store();
         let owner = format!("nope-{}", uuid::Uuid::new_v4());
         let ctx = tenant();
-        let result = hydrate_for_read(&st, &ctx, &owner, "ghost")
+        let result = hydrate_for_read(&st, &ctx, &owner, "ghost", u64::MAX, u64::MAX)
             .await
             .expect("ok");
         assert!(result.is_none(), "missing pointer must surface as None");
@@ -616,7 +676,7 @@ mod tests {
             super::super::store::CasOutcome::LostRace => panic!("first INM* must win"),
         }
 
-        let hydrated = hydrate_for_read(&st, &ctx, &owner, "void")
+        let hydrated = hydrate_for_read(&st, &ctx, &owner, "void", u64::MAX, u64::MAX)
             .await
             .expect("hydrate")
             .expect("hydrate Some");

--- a/crates/buzz-relay/src/api/git/manifest.rs
+++ b/crates/buzz-relay/src/api/git/manifest.rs
@@ -32,6 +32,13 @@ use serde::{Deserialize, Serialize};
 
 /// Current manifest schema version. Bump on incompatible change.
 pub const MANIFEST_VERSION: u32 = 1;
+/// Maximum number of pack objects one manifest may reference.
+///
+/// Hydration indexes packs one at a time, but an unbounded pack list still
+/// turns one request into unbounded object-store and git subprocess work.
+pub const MAX_MANIFEST_PACKS: usize = 128;
+/// Maximum number of refs one manifest may advertise.
+pub const MAX_MANIFEST_REFS: usize = 10_000;
 
 /// A repository's published state.
 ///
@@ -95,6 +102,25 @@ pub enum ManifestError {
     /// (`Inv_RefDerivedFromParent`).
     #[error("manifest parent is not a bare 64-char hex digest: {0:?}")]
     MalformedParent(String),
+    /// Manifest names too many packs for one bounded hydration request.
+    #[error("manifest contains too many packs: {got} (max {max})")]
+    TooManyPacks {
+        /// Number of pack keys in the manifest.
+        got: usize,
+        /// Hard cap enforced by the relay.
+        max: usize,
+    },
+    /// Manifest names too many refs for one bounded advertisement request.
+    #[error("manifest contains too many refs: {got} (max {max})")]
+    TooManyRefs {
+        /// Number of refs in the manifest.
+        got: usize,
+        /// Hard cap enforced by the relay.
+        max: usize,
+    },
+    /// A pack key is not exactly `packs/<64 lowercase hex sha256>`.
+    #[error("manifest contains malformed pack key {0:?}")]
+    MalformedPackKey(String),
 }
 
 /// Conservative refname validation, used symmetrically on both the write side
@@ -131,7 +157,12 @@ pub fn is_hex_oid(s: &str) -> bool {
 /// manifest digests are *always* SHA-256, so this is the tighter predicate
 /// for the `Manifest::parent` field.
 fn is_manifest_digest(s: &str) -> bool {
-    s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit())
+    s.len() == 64 && s.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+}
+
+/// Content-addressed pack-key predicate.
+pub fn is_pack_key(s: &str) -> bool {
+    s.strip_prefix("packs/").is_some_and(is_manifest_digest)
 }
 
 /// The canonical pointer key for a repo: `repos/<community>/<owner>/<repo>/pointer`.
@@ -159,10 +190,24 @@ impl Manifest {
     /// - `head` is non-empty and passes `is_safe_refname`.
     /// - Every key in `refs` passes `is_safe_refname`.
     /// - Every value in `refs` is a hex OID per `is_hex_oid`.
+    /// - Pack/ref cardinality stays within bounded hydration limits.
+    /// - Every pack key is a canonical content-addressed key.
     /// - `parent`, if `Some`, is a bare 64-char hex digest (not a store key).
     ///
     /// Read-side `hydrate` runs the same predicates as defense-in-depth.
     pub fn validate(&self) -> Result<(), ManifestError> {
+        if self.packs.len() > MAX_MANIFEST_PACKS {
+            return Err(ManifestError::TooManyPacks {
+                got: self.packs.len(),
+                max: MAX_MANIFEST_PACKS,
+            });
+        }
+        if self.refs.len() > MAX_MANIFEST_REFS {
+            return Err(ManifestError::TooManyRefs {
+                got: self.refs.len(),
+                max: MAX_MANIFEST_REFS,
+            });
+        }
         if self.head.is_empty() {
             return Err(ManifestError::EmptyHead);
         }
@@ -178,6 +223,11 @@ impl Manifest {
                     refname: refname.clone(),
                     oid: oid.clone(),
                 });
+            }
+        }
+        for pack in &self.packs {
+            if !is_pack_key(pack) {
+                return Err(ManifestError::MalformedPackKey(pack.clone()));
             }
         }
         if let Some(p) = &self.parent {
@@ -220,6 +270,10 @@ impl Manifest {
 mod tests {
     use super::*;
 
+    fn pack_key(ch: char) -> String {
+        format!("packs/{}", ch.to_string().repeat(64))
+    }
+
     fn sample() -> Manifest {
         let mut refs = BTreeMap::new();
         refs.insert(
@@ -234,7 +288,7 @@ mod tests {
             version: MANIFEST_VERSION,
             head: "refs/heads/main".into(),
             refs,
-            packs: vec!["packs/cc".into(), "packs/dd".into()],
+            packs: vec![pack_key('c'), pack_key('d')],
             parent: Some("ee".repeat(32)),
         }
     }
@@ -265,10 +319,10 @@ mod tests {
     #[test]
     fn canonical_bytes_sorts_and_dedups_packs() {
         let mut m = sample();
-        m.packs = vec!["packs/dd".into(), "packs/cc".into(), "packs/dd".into()];
+        m.packs = vec![pack_key('d'), pack_key('c'), pack_key('d')];
         let bytes = m.canonical_bytes().unwrap();
         let back = Manifest::from_bytes(&bytes).unwrap();
-        assert_eq!(back.packs, vec!["packs/cc", "packs/dd"]);
+        assert_eq!(back.packs, vec![pack_key('c'), pack_key('d')]);
     }
 
     #[test]
@@ -386,6 +440,28 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_malformed_pack_key() {
+        let mut m = sample();
+        m.packs = vec!["packs/not-a-digest".into()];
+        assert!(matches!(
+            m.validate(),
+            Err(ManifestError::MalformedPackKey(_))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_too_many_packs() {
+        let mut m = sample();
+        m.packs = (0..=MAX_MANIFEST_PACKS)
+            .map(|i| format!("packs/{i:064x}"))
+            .collect();
+        assert!(matches!(
+            m.validate(),
+            Err(ManifestError::TooManyPacks { .. })
+        ));
+    }
+
+    #[test]
     fn validate_accepts_no_parent() {
         let mut m = sample();
         m.parent = None;
@@ -472,14 +548,17 @@ mod tests {
             version: 1,
             head: "refs/heads/main".into(),
             refs,
-            packs: vec!["packs/p1".into()],
+            packs: vec![pack_key('1')],
             parent: None,
         };
         let bytes = m.canonical_bytes().unwrap();
         let s = std::str::from_utf8(&bytes).unwrap();
         assert_eq!(
             s,
-            r#"{"version":1,"head":"refs/heads/main","refs":{"refs/heads/main":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"packs":["packs/p1"],"parent":null}"#
+            format!(
+                r#"{{"version":1,"head":"refs/heads/main","refs":{{"refs/heads/main":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},"packs":["{}"],"parent":null}}"#,
+                pack_key('1')
+            )
         );
     }
 }

--- a/crates/buzz-relay/src/api/git/store.rs
+++ b/crates/buzz-relay/src/api/git/store.rs
@@ -68,6 +68,16 @@ pub enum StoreError {
     /// The requested key does not exist.
     #[error("object not found: {0}")]
     NotFound(String),
+    /// The object is larger than the caller's bounded read budget.
+    #[error("object too large: {key} is {size} bytes (max {max})")]
+    ObjectTooLarge {
+        /// Object key that was read.
+        key: String,
+        /// Object size reported by the backend.
+        size: u64,
+        /// Maximum bytes the caller allows for this read.
+        max: u64,
+    },
     /// A1 detectability fired: the bytes at `key` do not hash to `expected`.
     #[error("digest mismatch on {key}: expected {expected}, got {actual}")]
     DigestMismatch {
@@ -332,6 +342,54 @@ impl GitStore {
                 key: key.into(),
                 expected: expected_digest.into(),
                 actual,
+            });
+        }
+        Ok(bytes)
+    }
+
+    /// GET an immutable object after rejecting objects larger than `max_bytes`.
+    ///
+    /// Pack and manifest objects are content addressed and create-only, so the
+    /// HEAD result cannot race with a different body at the same key. The
+    /// second length check protects against a backend that reports a bad
+    /// Content-Length header.
+    pub async fn get_verified_limited(
+        &self,
+        key: &str,
+        expected_digest: &str,
+        max_bytes: u64,
+    ) -> Result<Bytes, StoreError> {
+        let (head, status) = self.bucket.head_object(key).await.map_err(|e| match e {
+            S3Error::HttpFailWithBody(404, _) => StoreError::NotFound(key.into()),
+            other => StoreError::Backend(other),
+        })?;
+        if status == 404 {
+            return Err(StoreError::NotFound(key.into()));
+        }
+        if !(200..300).contains(&status) {
+            return Err(StoreError::Backend(S3Error::HttpFailWithBody(
+                status,
+                "unexpected status".into(),
+            )));
+        }
+        if let Some(content_length) = head.content_length {
+            let size = u64::try_from(content_length).unwrap_or(u64::MAX);
+            if size > max_bytes {
+                return Err(StoreError::ObjectTooLarge {
+                    key: key.into(),
+                    size,
+                    max: max_bytes,
+                });
+            }
+        }
+
+        let bytes = self.get_verified(key, expected_digest).await?;
+        let size = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+        if size > max_bytes {
+            return Err(StoreError::ObjectTooLarge {
+                key: key.into(),
+                size,
+                max: max_bytes,
             });
         }
         Ok(bytes)

--- a/crates/buzz-relay/src/api/git/transport.rs
+++ b/crates/buzz-relay/src/api/git/transport.rs
@@ -26,7 +26,7 @@ use tokio::process::Command;
 use tower_http::limit::RequestBodyLimitLayer;
 use tracing::{error, info, warn};
 
-use super::cas_publish::{cas_publish, CasError, ParentState};
+use super::cas_publish::{cas_publish, CasError, ParentState, PublishLimits};
 use super::hook::install_hook;
 use super::hydrate::{
     hydrate_for_read, hydrate_for_write, load_manifest_for_read, HydrateError, HydratedRepo,
@@ -39,6 +39,14 @@ use buzz_core::TenantContext;
 const INFO_REFS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 /// Timeout for pack operations (upload-pack, receive-pack) — large repos need time.
 const PACK_OPS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+/// Maximum buffered response bytes for receive-pack status output.
+///
+/// A receive-pack response is protocol status, not repository contents. One
+/// MiB is generous and prevents a malformed subprocess path from turning a
+/// push into an arbitrary in-memory response buffer.
+const RECEIVE_PACK_MAX_OUTPUT_BYTES: u64 = 1024 * 1024;
+/// Maximum ref advertisement output after manifest ref-count validation.
+const INFO_REFS_MAX_OUTPUT_BYTES: u64 = 4 * 1024 * 1024;
 
 /// NIP-98 auth extractor for git routes.
 ///
@@ -307,6 +315,13 @@ fn acquire_git_permit(
 /// via `Ok(None)` from [`hydrate_for_read`] and never reaches this fn.
 fn hydrate_error_to_response(owner: &str, repo: &str, err: HydrateError) -> Response {
     error!(error = %err, owner = %owner, repo = %repo, "hydrate failed");
+    if matches!(err, HydrateError::ResourceLimit(_)) {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "repository exceeds relay resource limits",
+        )
+            .into_response();
+    }
     (
         StatusCode::INTERNAL_SERVER_ERROR,
         "git backend hydration failed",
@@ -561,7 +576,16 @@ async fn info_refs_subprocess(
 ) -> Result<Response, Response> {
     let _permit = acquire_git_permit(state)?;
 
-    let repo = match hydrate_for_read(&state.git_store, tenant, &params.owner, &params.repo).await {
+    let repo = match hydrate_for_read(
+        &state.git_store,
+        tenant,
+        &params.owner,
+        &params.repo,
+        state.config.git_max_pack_bytes,
+        state.config.git_max_repo_bytes,
+    )
+    .await
+    {
         Ok(Some(repo)) => repo,
         Ok(None) => return Err((StatusCode::NOT_FOUND, "repository not found").into_response()),
         Err(e) => return Err(hydrate_error_to_response(&params.owner, &params.repo, e)),
@@ -572,23 +596,39 @@ async fn info_refs_subprocess(
     // "receive-pack" (without the "git-" prefix).
     let git_subcmd = service.strip_prefix("git-").unwrap_or(service);
 
+    let stdout_tmp = tempfile::NamedTempFile::new().map_err(|e| {
+        error!(error = %e, "git info_refs stdout tempfile failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
+    let stderr_tmp = tempfile::NamedTempFile::new().map_err(|e| {
+        error!(error = %e, "git info_refs stderr tempfile failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
+    let stdout_file = stdout_tmp.reopen().map_err(|e| {
+        error!(error = %e, "git info_refs stdout tempfile reopen failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
+    let stderr_file = stderr_tmp.reopen().map_err(|e| {
+        error!(error = %e, "git info_refs stderr tempfile reopen failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
+
     let mut cmd = Command::new("git");
     cmd.arg(git_subcmd)
         .arg("--stateless-rpc")
         .arg("--advertise-refs")
         .arg(repo.path())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::from(stdout_file))
+        .stderr(std::process::Stdio::from(stderr_file))
         .kill_on_drop(true);
     harden_git_env(&mut cmd);
 
-    let child = cmd.spawn().map_err(|e| {
+    let mut child = cmd.spawn().map_err(|e| {
         error!(error = %e, "git subprocess failed to spawn");
         (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
     })?;
 
-    // kill_on_drop requires a Child handle — .output() doesn't expose one.
-    let output = tokio::time::timeout(INFO_REFS_TIMEOUT, child.wait_with_output())
+    let status = tokio::time::timeout(INFO_REFS_TIMEOUT, child.wait())
         .await
         .map_err(|_| {
             warn!(
@@ -602,11 +642,34 @@ async fn info_refs_subprocess(
             (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
         })?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    if !status.success() {
+        let stderr = read_log_prefix(stderr_tmp.path(), 64 * 1024).await;
         error!(stderr = %stderr, "git --advertise-refs failed");
         return Err((StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response());
     }
+    let stdout_len = tokio::fs::metadata(stdout_tmp.path())
+        .await
+        .map_err(|e| {
+            error!(error = %e, "git info_refs stdout metadata failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+        })?
+        .len();
+    if stdout_len > INFO_REFS_MAX_OUTPUT_BYTES {
+        warn!(
+            bytes = stdout_len,
+            max = INFO_REFS_MAX_OUTPUT_BYTES,
+            "git info_refs output exceeded limit"
+        );
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "git ref advertisement exceeds relay limits",
+        )
+            .into_response());
+    }
+    let stdout = tokio::fs::read(stdout_tmp.path()).await.map_err(|e| {
+        error!(error = %e, "git info_refs stdout read failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
     // `repo` (the tempdir) must live until *after* the subprocess has read
     // its objects. Holding it until here is the structural lifetime that
     // guarantees that.
@@ -615,10 +678,10 @@ async fn info_refs_subprocess(
     // Build pkt-line response: service header + flush + git output.
     let svc_line = format!("# service={service}\n");
     let svc_pkt = format!("{:04x}{svc_line}", svc_line.len() + 4);
-    let mut body = Vec::with_capacity(svc_pkt.len() + 4 + output.stdout.len());
+    let mut body = Vec::with_capacity(svc_pkt.len() + 4 + stdout.len());
     body.extend_from_slice(svc_pkt.as_bytes());
     body.extend_from_slice(b"0000"); // flush packet
-    body.extend_from_slice(&output.stdout);
+    body.extend_from_slice(&stdout);
 
     let content_type = format!("application/x-{service}-advertisement");
     Ok(Response::builder()
@@ -644,12 +707,20 @@ pub async fn upload_pack(
     let _ = validate_repo_id(&params.owner, &params.repo)?;
     let _permit = acquire_git_permit(&state)?;
 
-    let repo =
-        match hydrate_for_read(&state.git_store, &auth.tenant, &params.owner, &params.repo).await {
-            Ok(Some(repo)) => repo,
-            Ok(None) => return Err((StatusCode::NOT_FOUND, "repository not found").into_response()),
-            Err(e) => return Err(hydrate_error_to_response(&params.owner, &params.repo, e)),
-        };
+    let repo = match hydrate_for_read(
+        &state.git_store,
+        &auth.tenant,
+        &params.owner,
+        &params.repo,
+        state.config.git_max_pack_bytes,
+        state.config.git_max_repo_bytes,
+    )
+    .await
+    {
+        Ok(Some(repo)) => repo,
+        Ok(None) => return Err((StatusCode::NOT_FOUND, "repository not found").into_response()),
+        Err(e) => return Err(hydrate_error_to_response(&params.owner, &params.repo, e)),
+    };
 
     // Track A: stream the subprocess stdout straight into the response body
     // instead of buffering the whole pack into RAM. `repo` (the hydrated
@@ -723,10 +794,16 @@ pub async fn receive_pack(
     // Hydrate parent state + workspace in one round-trip. ParentState
     // travels with the workspace into finalize_push so the CAS predicates
     // on the same pointer ETag the workspace was hydrated from.
-    let (repo, parent_state) =
-        hydrate_for_write(&state.git_store, &auth.tenant, &params.owner, &params.repo)
-            .await
-            .map_err(|e| hydrate_error_to_response(&params.owner, &params.repo, e))?;
+    let (repo, parent_state) = hydrate_for_write(
+        &state.git_store,
+        &auth.tenant,
+        &params.owner,
+        &params.repo,
+        state.config.git_max_pack_bytes,
+        state.config.git_max_repo_bytes,
+    )
+    .await
+    .map_err(|e| hydrate_error_to_response(&params.owner, &params.repo, e))?;
 
     // Install the pre-receive hook into the ephemeral workspace. The
     // hook script is fixed per-deployment; per-push state (callback URL,
@@ -766,7 +843,14 @@ pub async fn receive_pack(
     // Run receive-pack against the tempdir. Returns the *owned* subprocess
     // output (PackOutput) — crucially NOT a Response, so the post-push
     // fence in finalize_push can sequence the CAS before any 2xx exists.
-    let pack = run_git_at(repo.path(), "receive-pack", body, &hook_env).await?;
+    let pack = run_git_at(
+        repo.path(),
+        "receive-pack",
+        body,
+        &hook_env,
+        RECEIVE_PACK_MAX_OUTPUT_BYTES,
+    )
+    .await?;
 
     let ctx = PushContext {
         pack,
@@ -816,14 +900,32 @@ async fn run_git_at(
     service: &str,
     body: Body,
     extra_env: &[(&str, String)],
+    max_output_bytes: u64,
 ) -> Result<PackOutput, Response> {
+    let stdout_tmp = tempfile::NamedTempFile::new().map_err(|e| {
+        error!(error = %e, service = %service, "git stdout tempfile failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
+    let stderr_tmp = tempfile::NamedTempFile::new().map_err(|e| {
+        error!(error = %e, service = %service, "git stderr tempfile failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
+    let stdout_file = stdout_tmp.reopen().map_err(|e| {
+        error!(error = %e, service = %service, "git stdout tempfile reopen failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
+    let stderr_file = stderr_tmp.reopen().map_err(|e| {
+        error!(error = %e, service = %service, "git stderr tempfile reopen failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
+
     let mut cmd = Command::new("git");
     cmd.arg(service)
         .arg("--stateless-rpc")
         .arg(repo_path)
         .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::from(stdout_file))
+        .stderr(std::process::Stdio::from(stderr_file))
         .kill_on_drop(true);
     harden_git_env(&mut cmd);
     for (key, value) in extra_env {
@@ -858,11 +960,11 @@ async fn run_git_at(
 
     let timeout_result = tokio::time::timeout(PACK_OPS_TIMEOUT, async {
         let _ = body_task.await;
-        child.wait_with_output().await
+        child.wait().await
     })
     .await;
 
-    let output = match timeout_result {
+    let status = match timeout_result {
         Err(_elapsed) => {
             body_abort.abort();
             warn!(service = %service, timeout_secs = PACK_OPS_TIMEOUT.as_secs(), "git subprocess timed out");
@@ -872,11 +974,32 @@ async fn run_git_at(
             error!(error = %e, service = %service, "git subprocess failed");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response());
         }
-        Ok(Ok(out)) => out,
+        Ok(Ok(status)) => status,
     };
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout_len = tokio::fs::metadata(stdout_tmp.path())
+        .await
+        .map_err(|e| {
+            error!(error = %e, service = %service, "git stdout metadata failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+        })?
+        .len();
+    if stdout_len > max_output_bytes {
+        warn!(
+            service = %service,
+            bytes = stdout_len,
+            max = max_output_bytes,
+            "git subprocess output exceeded limit"
+        );
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "git output exceeds relay limits",
+        )
+            .into_response());
+    }
+
+    if !status.success() {
+        let stderr = read_log_prefix(stderr_tmp.path(), 64 * 1024).await;
         warn!(stderr = %stderr, service = %service, "git subprocess exited with error");
         // Still return output — git protocol errors are communicated in-band.
         // A non-zero exit feeds `PackOutput.ok` below, but it is NOT the signal
@@ -891,7 +1014,12 @@ async fn run_git_at(
     // decline, so the exit code alone is insufficient — the rejection lives in
     // the in-band report-status. Fold both signals into `ok` so `finalize_push`
     // skips CAS publish + kind:30618 on any rejected ref.
-    let report_rejected = service == "receive-pack" && receive_pack_report_rejected(&output.stdout);
+    let stdout = tokio::fs::read(stdout_tmp.path()).await.map_err(|e| {
+        error!(error = %e, service = %service, "git stdout read failed");
+        (StatusCode::INTERNAL_SERVER_ERROR, "git error").into_response()
+    })?;
+
+    let report_rejected = service == "receive-pack" && receive_pack_report_rejected(&stdout);
     if report_rejected {
         warn!(
             service = %service,
@@ -900,9 +1028,23 @@ async fn run_git_at(
     }
 
     Ok(PackOutput {
-        stdout: output.stdout,
-        ok: output.status.success() && !report_rejected,
+        stdout,
+        ok: status.success() && !report_rejected,
     })
+}
+
+async fn read_log_prefix(path: &Path, max_bytes: u64) -> String {
+    use tokio::io::AsyncReadExt;
+
+    let Ok(file) = tokio::fs::File::open(path).await else {
+        return "<stderr unavailable>".to_string();
+    };
+    let mut bytes = Vec::new();
+    let mut limited = file.take(max_bytes);
+    if limited.read_to_end(&mut bytes).await.is_err() {
+        return "<stderr unavailable>".to_string();
+    }
+    String::from_utf8_lossy(&bytes).to_string()
 }
 
 /// Returns true when a `git receive-pack` report-status stream contains an
@@ -1214,6 +1356,11 @@ async fn finalize_push(state: &Arc<AppState>, ctx: PushContext) -> Response {
         &ctx.owner,
         &ctx.repo,
         &ctx.parent_state,
+        PublishLimits {
+            parent_hydrated_bytes: ctx.repo_handle.hydrated_bytes(),
+            max_pack_bytes: state.config.git_max_pack_bytes,
+            max_repo_bytes: state.config.git_max_repo_bytes,
+        },
     )
     .await
     {
@@ -1248,6 +1395,19 @@ async fn finalize_push(state: &Arc<AppState>, ctx: PushContext) -> Response {
             return (
                 StatusCode::BAD_REQUEST,
                 "push produced invalid manifest state",
+            )
+                .into_response();
+        }
+        Err(CasError::ResourceLimit(e)) => {
+            warn!(
+                owner = %ctx.owner,
+                repo = %ctx.repo,
+                error = %e,
+                "push rejected: repo exceeds relay resource limits"
+            );
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "repository exceeds relay resource limits",
             )
                 .into_response();
         }

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -6,6 +6,7 @@
 //!   HEAD /media/{sha256_ext}    — BUD-01 existence check
 
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use axum::http::header;
 use axum::{
@@ -37,6 +38,75 @@ pub(crate) struct AuthenticatedUpload {
     /// this HTTP door), identical to the WS door in `router.rs` and the bridge
     /// door in `bridge.rs`. Server-resolved, never client-supplied.
     tenant: TenantContext,
+    _upload_permit: UploadPermit,
+}
+
+const MEDIA_UPLOAD_RATE_WINDOW: Duration = Duration::from_secs(60);
+
+struct UploadPermit {
+    _global: tokio::sync::OwnedSemaphorePermit,
+    in_flight: Arc<dashmap::DashMap<[u8; 32], u32>>,
+    pubkey: [u8; 32],
+}
+
+impl Drop for UploadPermit {
+    fn drop(&mut self) {
+        use dashmap::mapref::entry::Entry;
+
+        if let Entry::Occupied(mut entry) = self.in_flight.entry(self.pubkey) {
+            if *entry.get() <= 1 {
+                entry.remove();
+            } else {
+                *entry.get_mut() -= 1;
+            }
+        }
+    }
+}
+
+fn upload_rate_limited(state: &AppState, pubkey: &nostr::PublicKey) -> bool {
+    let key: [u8; 32] = pubkey.to_bytes();
+    let now = Instant::now();
+    let limit = state.config.media_uploads_per_minute;
+    let mut entry = state
+        .media_upload_rate_limiter
+        .entry(key)
+        .or_insert((0, now));
+    let (count, window_start) = entry.value_mut();
+    if now.duration_since(*window_start) >= MEDIA_UPLOAD_RATE_WINDOW {
+        *count = 1;
+        *window_start = now;
+        return false;
+    }
+    if *count >= limit {
+        return true;
+    }
+    *count += 1;
+    false
+}
+
+fn acquire_upload_permit(
+    state: &AppState,
+    pubkey: &nostr::PublicKey,
+) -> Result<UploadPermit, MediaError> {
+    let global = state
+        .media_upload_semaphore
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| MediaError::UploadConcurrencyLimitReached)?;
+
+    let key: [u8; 32] = pubkey.to_bytes();
+    let mut in_flight = state.media_uploads_in_flight.entry(key).or_insert(0);
+    if *in_flight >= state.config.media_max_concurrent_uploads_per_pubkey {
+        return Err(MediaError::UploadConcurrencyLimitReached);
+    }
+    *in_flight += 1;
+    drop(in_flight);
+
+    Ok(UploadPermit {
+        _global: global,
+        in_flight: Arc::clone(&state.media_uploads_in_flight),
+        pubkey: key,
+    })
 }
 
 impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
@@ -122,10 +192,21 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
         .await
         .map_err(|_| MediaError::RelayMembershipRequired)?;
 
+        if upload_rate_limited(state, &auth_event.pubkey) {
+            metrics::counter!("buzz_media_upload_rejections_total", "reason" => "rate_limit")
+                .increment(1);
+            return Err(MediaError::UploadRateLimitExceeded);
+        }
+        let upload_permit = acquire_upload_permit(state, &auth_event.pubkey).inspect_err(|_| {
+            metrics::counter!("buzz_media_upload_rejections_total", "reason" => "concurrency")
+                .increment(1);
+        })?;
+
         Ok(AuthenticatedUpload {
             auth_event,
             scopes,
             tenant,
+            _upload_permit: upload_permit,
         })
     }
 }
@@ -147,9 +228,8 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedUpload {
 ///   - Raw binary body (the file bytes)
 ///
 /// Returns a [`BlobDescriptor`] JSON on success.
-// TODO(v2): Add per-pubkey upload rate limiting and storage quotas to prevent
-// bandwidth/storage exhaustion from authenticated callers. Currently mitigated by
-// auth requirement (API token + Blossom signature) and body size limit.
+// TODO(v2): Add persistent per-pubkey storage quotas. Admission limits below
+// bound active parser/storage work, but they do not cap durable bytes stored.
 pub async fn upload_blob(
     State(state): State<Arc<AppState>>,
     auth: AuthenticatedUpload,

--- a/crates/buzz-relay/src/audio/handler.rs
+++ b/crates/buzz-relay/src/audio/handler.rs
@@ -200,7 +200,8 @@ async fn handle_audio_connection(
         return;
     }
 
-    if let Err(e) = ensure_membership(
+    // ── Step 3: membership check / auto-add ───────────────────────────────────
+    let parent_id_for_event = match ensure_membership(
         &state,
         &tenant,
         channel_id,
@@ -209,16 +210,19 @@ async fn handle_audio_connection(
     )
     .await
     {
-        warn!(channel_id = %channel_id, pubkey = %pubkey_hex, "audio membership denied: {e}");
-        let _ = ws_send
-            .send(WsMessage::Text(
-                serde_json::json!({"type":"error","message":"not a member"})
-                    .to_string()
-                    .into(),
-            ))
-            .await;
-        return;
-    }
+        Ok(parent_id) => parent_id,
+        Err(e) => {
+            warn!(channel_id = %channel_id, pubkey = %pubkey_hex, "audio membership denied: {e}");
+            let _ = ws_send
+                .send(WsMessage::Text(
+                    serde_json::json!({"type":"error","message":"not a member"})
+                        .to_string()
+                        .into(),
+                ))
+                .await;
+            return;
+        }
+    };
 
     // Huddle audio guardrail (plan §5b). Audio frames are relayed only within
     // a single pod; under horizontal scaling (any-pod-any-connection) two peers
@@ -380,7 +384,7 @@ async fn handle_audio_connection(
 
     room.broadcast_control(joined_msg);
 
-    let parent_id_for_event = parent_channel_id.unwrap_or(channel_id);
+    // ── Step 6: emit kind:48101 (PARTICIPANT_JOINED) ──────────────────────────
     emit_participant_event(
         &state,
         &tenant,
@@ -698,7 +702,7 @@ async fn ensure_membership(
     channel_id: Uuid,
     pubkey_bytes: &[u8],
     parent_channel_id: Option<Uuid>,
-) -> Result<(), String> {
+) -> Result<Uuid, String> {
     // Load channel first — reject archived channels before any membership check.
     // This ensures auto-ended huddles can't be rejoined by existing members.
     let channel = state
@@ -711,6 +715,29 @@ async fn ensure_membership(
         return Err("channel is archived".into());
     }
 
+    // Lifecycle events for an ephemeral huddle belong in its parent channel.
+    // Resolve that parent from a creator-signed kind:48100 event instead of
+    // trusting the UUID supplied by the client during audio auth.
+    let lifecycle_parent_id = if channel.ttl_seconds.is_some() {
+        let parent_id = parent_channel_id.ok_or("ephemeral channel requires parent linkage")?;
+        let linked = state
+            .db
+            .huddle_started_link_exists(
+                tenant.community(),
+                parent_id,
+                channel_id,
+                &channel.created_by,
+            )
+            .await
+            .map_err(|e| format!("db error: {e}"))?;
+        if !linked {
+            return Err("ephemeral channel is not linked to claimed parent".into());
+        }
+        parent_id
+    } else {
+        channel_id
+    };
+
     // Fast path: already a member.
     let is_member = state
         .is_member_cached(tenant.community(), channel_id, pubkey_bytes)
@@ -718,45 +745,35 @@ async fn ensure_membership(
         .map_err(|e| format!("db error: {e}"))?;
 
     if is_member {
-        return Ok(());
+        return Ok(lifecycle_parent_id);
     }
 
     if channel.visibility == "open" {
-        return Ok(());
+        return Ok(lifecycle_parent_id);
     }
 
     // Auto-add path: private ephemeral channel + caller is member of parent.
-    //
-    // TODO(security): parent_channel_id is client-supplied and unverified.
-    // We don't confirm it's the *actual* parent of this ephemeral channel.
-    // Security relies on the ephemeral UUID being unguessable (UUIDv4) and
-    // only discoverable via the kind:48100 event in the real parent channel
-    // — which requires parent membership. A future hardening pass should
-    // verify the parent→ephemeral linkage by checking that a kind:48100
-    // event exists in the claimed parent channel referencing this channel ID.
     if channel.ttl_seconds.is_some() {
-        if let Some(parent_id) = parent_channel_id {
-            let parent_member = state
-                .is_member_cached(tenant.community(), parent_id, pubkey_bytes)
+        let parent_member = state
+            .is_member_cached(tenant.community(), lifecycle_parent_id, pubkey_bytes)
+            .await
+            .map_err(|e| format!("db error: {e}"))?;
+
+        if parent_member {
+            state
+                .db
+                .add_member(
+                    tenant.community(),
+                    channel_id,
+                    pubkey_bytes,
+                    MemberRole::Member,
+                    Some(&channel.created_by),
+                )
                 .await
-                .map_err(|e| format!("db error: {e}"))?;
+                .map_err(|e| format!("auto-add failed: {e}"))?;
+            state.invalidate_membership(tenant, channel_id, pubkey_bytes);
 
-            if parent_member {
-                state
-                    .db
-                    .add_member(
-                        tenant.community(),
-                        channel_id,
-                        pubkey_bytes,
-                        MemberRole::Member,
-                        Some(&channel.created_by),
-                    )
-                    .await
-                    .map_err(|e| format!("auto-add failed: {e}"))?;
-                state.invalidate_membership(tenant, channel_id, pubkey_bytes);
-
-                return Ok(());
-            }
+            return Ok(lifecycle_parent_id);
         }
     }
 

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -128,6 +128,11 @@ pub struct Config {
     pub git_repo_path: std::path::PathBuf,
     /// Maximum pack file size for git push (bytes). Default: 500 MB.
     pub git_max_pack_bytes: u64,
+    /// Maximum total bytes materialized for one git repo request. Default: 1 GB.
+    ///
+    /// This bounds clone/fetch hydration work across a repo's historical pack
+    /// set rather than only bounding one incoming push body.
+    pub git_max_repo_bytes: u64,
     /// Maximum number of repos per pubkey. Default: 100.
     pub git_max_repos_per_pubkey: u32,
     /// Maximum concurrent git subprocess operations. Default: 20.
@@ -325,6 +330,10 @@ impl Config {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(500 * 1024 * 1024); // 500 MB
+        let git_max_repo_bytes: u64 = std::env::var("BUZZ_GIT_MAX_REPO_BYTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| git_max_pack_bytes.saturating_mul(2)); // 1 GB at defaults
         let git_max_repos_per_pubkey: u32 = std::env::var("BUZZ_GIT_MAX_REPOS_PER_PUBKEY")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -392,6 +401,7 @@ impl Config {
             ephemeral_ttl_override,
             git_repo_path,
             git_max_pack_bytes,
+            git_max_repo_bytes,
             git_max_repos_per_pubkey,
             git_max_concurrent_ops,
             git_hook_hmac_secret,

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -114,6 +114,12 @@ pub struct Config {
 
     /// Media storage configuration (S3/MinIO).
     pub media: buzz_media::MediaConfig,
+    /// Maximum concurrent media uploads handled by one relay process.
+    pub media_max_concurrent_uploads: usize,
+    /// Maximum concurrent media uploads accepted from one pubkey.
+    pub media_max_concurrent_uploads_per_pubkey: u32,
+    /// Maximum media upload starts accepted from one pubkey per minute.
+    pub media_uploads_per_minute: u32,
 
     /// Optional override for ephemeral channel TTL (in seconds).
     /// When set, any channel created with a TTL tag will use this value instead
@@ -309,6 +315,24 @@ impl Config {
             public_base_url: std::env::var("BUZZ_MEDIA_BASE_URL")
                 .unwrap_or_else(|_| "http://localhost:3000/media".to_string()),
         };
+        let media_max_concurrent_uploads: usize =
+            std::env::var("BUZZ_MEDIA_MAX_CONCURRENT_UPLOADS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .filter(|&v| v > 0)
+                .unwrap_or(8);
+        let media_max_concurrent_uploads_per_pubkey: u32 =
+            std::env::var("BUZZ_MEDIA_MAX_CONCURRENT_UPLOADS_PER_PUBKEY")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .filter(|&v| v > 0)
+                .unwrap_or(2)
+                .min(u32::try_from(media_max_concurrent_uploads).unwrap_or(u32::MAX));
+        let media_uploads_per_minute: u32 = std::env::var("BUZZ_MEDIA_UPLOADS_PER_MINUTE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(30);
 
         let ephemeral_ttl_override = std::env::var("BUZZ_EPHEMERAL_TTL_OVERRIDE")
             .ok()
@@ -398,6 +422,9 @@ impl Config {
             relay_owner_pubkey,
             allow_nip_oa_auth,
             media,
+            media_max_concurrent_uploads,
+            media_max_concurrent_uploads_per_pubkey,
+            media_uploads_per_minute,
             ephemeral_ttl_override,
             git_repo_path,
             git_max_pack_bytes,

--- a/crates/buzz-relay/src/connection.rs
+++ b/crates/buzz-relay/src/connection.rs
@@ -22,6 +22,9 @@ use crate::protocol::{ClientMessage, RelayMessage};
 use crate::state::AppState;
 use buzz_pubsub::EventTopic;
 
+/// Maximum time a new socket may hold a connection slot without completing NIP-42 auth.
+const AUTH_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Shared mutable subscription map for a single WebSocket connection.
 pub(crate) type ConnectionSubscriptions = Arc<Mutex<HashMap<String, Vec<Filter>>>>;
 
@@ -190,6 +193,29 @@ pub async fn handle_connection(
         heartbeat_cancel,
     ));
 
+    let auth_timeout_conn = Arc::clone(&conn);
+    let auth_timeout_cancel = cancel.clone();
+    let auth_timeout_task = tokio::spawn(async move {
+        tokio::select! {
+            _ = tokio::time::sleep(AUTH_TIMEOUT) => {
+                let authenticated = matches!(
+                    *auth_timeout_conn.auth_state.read().await,
+                    AuthState::Authenticated(_)
+                );
+                if !authenticated {
+                    warn!(
+                        conn_id = %auth_timeout_conn.conn_id,
+                        timeout_secs = AUTH_TIMEOUT.as_secs(),
+                        "NIP-42 auth timeout — closing connection"
+                    );
+                    metrics::counter!("buzz_ws_auth_timeouts_total").increment(1);
+                    auth_timeout_cancel.cancel();
+                }
+            }
+            _ = auth_timeout_cancel.cancelled() => {}
+        }
+    });
+
     recv_loop(
         ws_recv,
         Arc::clone(&conn),
@@ -202,6 +228,7 @@ pub async fn handle_connection(
     cancel.cancel();
     let _ = send_task.await;
     let _ = heartbeat_task.await;
+    let _ = auth_timeout_task.await;
 
     for removed in state.sub_registry.remove_connection(conn.conn_id) {
         state

--- a/crates/buzz-relay/src/handlers/command_executor.rs
+++ b/crates/buzz-relay/src/handlers/command_executor.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 use buzz_core::kind::*;
 use buzz_core::tenant::{CommunityId, TenantContext};
 use buzz_db::workflow::{ApprovalStatus, RunStatus};
+use buzz_db::DbError;
 use buzz_workflow::executor::TriggerContext;
 
 use crate::state::AppState;
@@ -80,15 +81,12 @@ enum PersistResult {
 /// If the event is a duplicate (ON CONFLICT DO NOTHING), the transaction is
 /// rolled back and `PersistResult::Duplicate` is returned — no mutations needed.
 ///
-/// NOTE: Domain mutations (open_dm, create_workflow, etc.) execute on the
+/// NOTE: Domain mutations (open_dm, upsert_workflow, etc.) execute on the
 /// connection pool, NOT inside this transaction. The pattern is idempotent but
 /// not strictly atomic: if a mutation succeeds but commit fails, the mutation
 /// persists without the event record. On retry, the event INSERT succeeds
 /// (no conflict), and the mutation re-executes — which is safe for idempotent
-/// operations (open_dm, hide_dm, update_approval) but may create duplicates
-/// for non-idempotent ones (create_workflow). This is acceptable for the
-/// current command set where create_workflow uses a client-generated d-tag
-/// as the natural dedup key.
+/// operations (open_dm, hide_dm, update_approval, upsert_workflow).
 async fn persist_command_event(
     state: &Arc<AppState>,
     tenant: &TenantContext,
@@ -116,18 +114,82 @@ async fn persist_command_event(
     })?;
     let received_at = chrono::Utc::now();
 
-    // Extract d_tag for parameterized replaceable kinds (NIP-33)
-    let d_tag: Option<String> = if is_parameterized_replaceable(event.kind.as_u16() as u32) {
-        event.tags.iter().find_map(|t| {
-            if t.kind().to_string() == "d" {
-                t.content().map(|s| s.to_string())
-            } else {
-                None
+    // Extract d_tag for parameterized replaceable kinds (NIP-33).
+    let d_tag = buzz_db::event::extract_d_tag(event);
+    if let Some(ref d_tag) = d_tag {
+        if d_tag.len() > buzz_db::event::D_TAG_MAX_LEN {
+            return Err(IngestError::Rejected(format!(
+                "invalid: d tag too long ({} bytes, max {})",
+                d_tag.len(),
+                buzz_db::event::D_TAG_MAX_LEN,
+            )));
+        }
+
+        // Command kinds normally use plain insert semantics, but workflow
+        // definitions are NIP-33 events. Serialize writers for the same
+        // coordinate and reject stale writes before executing the domain
+        // mutation, otherwise old updates can overwrite newer workflow state.
+        let lock_key = {
+            let mut h: u64 = 0xcbf29ce484222325;
+            for b in tenant.community().as_uuid().as_bytes() {
+                h ^= *b as u64;
+                h = h.wrapping_mul(0x100000001b3);
             }
-        })
-    } else {
-        None
-    };
+            for b in kind_i32.to_le_bytes() {
+                h ^= b as u64;
+                h = h.wrapping_mul(0x100000001b3);
+            }
+            for b in pubkey_bytes.as_slice() {
+                h ^= *b as u64;
+                h = h.wrapping_mul(0x100000001b3);
+            }
+            for b in d_tag.as_bytes() {
+                h ^= *b as u64;
+                h = h.wrapping_mul(0x100000001b3);
+            }
+            h as i64
+        };
+
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(lock_key)
+            .execute(tx.as_mut())
+            .await
+            .map_err(|e| IngestError::Internal(format!("error: lock event coordinate: {e}")))?;
+
+        let existing: Option<(chrono::DateTime<chrono::Utc>, Vec<u8>)> = sqlx::query_as(
+            "SELECT created_at, id FROM events \
+             WHERE community_id = $1 AND kind = $2 AND pubkey = $3 AND d_tag = $4 AND deleted_at IS NULL \
+             ORDER BY created_at DESC, id ASC LIMIT 1",
+        )
+        .bind(tenant.community().as_uuid())
+        .bind(kind_i32)
+        .bind(pubkey_bytes.as_slice())
+        .bind(d_tag)
+        .fetch_optional(tx.as_mut())
+        .await
+        .map_err(|e| IngestError::Internal(format!("error: query event coordinate: {e}")))?;
+
+        let incoming_id = event.id.as_bytes().as_slice();
+        if let Some((existing_ts, existing_id)) = existing {
+            let dominated = created_at < existing_ts
+                || (created_at == existing_ts && incoming_id >= existing_id.as_slice());
+            if dominated {
+                return Ok(PersistResult::Duplicate);
+            }
+
+            sqlx::query(
+                "UPDATE events SET deleted_at = NOW() \
+                 WHERE community_id = $1 AND kind = $2 AND pubkey = $3 AND d_tag = $4 AND deleted_at IS NULL",
+            )
+            .bind(tenant.community().as_uuid())
+            .bind(kind_i32)
+            .bind(pubkey_bytes.as_slice())
+            .bind(d_tag)
+            .execute(tx.as_mut())
+            .await
+            .map_err(|e| IngestError::Internal(format!("error: replace old event: {e}")))?;
+        }
+    }
 
     let result = sqlx::query(
         r#"
@@ -572,17 +634,16 @@ async fn handle_workflow_def(
 ) -> Result<IngestResult, IngestError> {
     let self_bytes = auth.pubkey().to_bytes().to_vec();
 
-    // 1. Extract channel from `h` tag, workflow name from `name` tag or d-tag
+    // 1. Extract channel and the canonical workflow UUID from the NIP-33 d-tag.
     let channel_id_str = extract_h_tag(event)
         .ok_or_else(|| IngestError::Rejected("invalid: missing h tag (channel_id)".into()))?;
     let channel_id = Uuid::parse_str(&channel_id_str)
         .map_err(|_| IngestError::Rejected("invalid: bad channel_id format".into()))?;
 
-    let workflow_name = extract_tag(event, "name")
-        .or_else(|| extract_d_tag(event))
-        .ok_or_else(|| {
-            IngestError::Rejected("invalid: missing workflow name (name or d tag)".into())
-        })?;
+    let workflow_id_str = extract_d_tag(event)
+        .ok_or_else(|| IngestError::Rejected("invalid: missing d tag (workflow_id)".into()))?;
+    let workflow_id = Uuid::parse_str(&workflow_id_str)
+        .map_err(|_| IngestError::Rejected("invalid: bad workflow_id format".into()))?;
 
     // 2. Validate caller has channel access (minimum: is a member)
     let is_member = state
@@ -598,15 +659,45 @@ async fn handle_workflow_def(
     // 3. Parse YAML from event.content
     let (def, definition_json_str) = buzz_workflow::WorkflowEngine::parse_yaml(&event.content)
         .map_err(|e| IngestError::Rejected(format!("invalid: workflow YAML parse error: {e}")))?;
+    let workflow_name = extract_tag(event, "name").unwrap_or_else(|| def.name.clone());
 
     let mut definition_json: serde_json::Value = serde_json::from_str(&definition_json_str)
         .map_err(|e| IngestError::Internal(format!("error: json parse of definition: {e}")))?;
 
-    // Generate webhook secret if this workflow uses a Webhook trigger
+    let existing_workflow = match state.db.get_workflow(tenant.community(), workflow_id).await {
+        Ok(workflow) => {
+            if workflow.owner_pubkey != self_bytes || workflow.channel_id != Some(channel_id) {
+                return Err(IngestError::Rejected(
+                    "forbidden: workflow belongs to a different owner or channel".into(),
+                ));
+            }
+            Some(workflow)
+        }
+        Err(DbError::NotFound(_)) => None,
+        Err(e) => {
+            return Err(IngestError::Internal(format!(
+                "error: db get_workflow: {e}"
+            )));
+        }
+    };
+
+    // Preserve the existing webhook secret across updates. A new secret is
+    // returned only when the workflow first gains a webhook trigger.
     let webhook_secret = if matches!(def.trigger, buzz_workflow::TriggerDef::Webhook) {
-        let secret = webhook_secret::generate_webhook_secret();
+        let existing_secret = existing_workflow
+            .as_ref()
+            .and_then(|workflow| webhook_secret::extract_secret(&workflow.definition));
+        let secret = existing_secret.unwrap_or_else(webhook_secret::generate_webhook_secret);
         webhook_secret::inject_secret(&mut definition_json, &secret);
-        Some(secret)
+        if existing_workflow
+            .as_ref()
+            .and_then(|workflow| webhook_secret::extract_secret(&workflow.definition))
+            .is_none()
+        {
+            Some(secret)
+        } else {
+            None
+        }
     } else {
         None
     };
@@ -628,7 +719,9 @@ async fn handle_workflow_def(
         PersistResult::Inserted(tx) => tx,
     };
 
-    // 4. Execute: create_workflow. The workflow's community is the request's
+    // 4. Execute: upsert by the NIP-33 d-tag UUID. A retry updates the same
+    // row instead of creating another enabled workflow that would fan out on
+    // every matching event. The workflow's community is the request's
     // server-bound tenant — never re-derived from the (client-supplied) channel
     // id. `community_of_channel(channel_id)` is ambiguous when the same channel
     // UUID exists in two communities and could mint the workflow under the wrong
@@ -644,10 +737,11 @@ async fn handle_workflow_def(
         .await
         .map_err(|_| IngestError::Rejected("invalid: workflow channel not found".into()))?;
 
-    let workflow_id = state
+    state
         .db
-        .create_workflow(
+        .upsert_workflow(
             community_id,
+            workflow_id,
             Some(channel_id),
             &self_bytes,
             &workflow_name,
@@ -655,9 +749,14 @@ async fn handle_workflow_def(
             &hash,
         )
         .await
-        .map_err(|e| IngestError::Internal(format!("error: db create_workflow: {e}")))?;
+        .map_err(|e| match e {
+            DbError::AccessDenied(_) => IngestError::Rejected(
+                "forbidden: workflow belongs to a different owner or channel".into(),
+            ),
+            other => IngestError::Internal(format!("error: db upsert_workflow: {other}")),
+        })?;
 
-    // Commit: event + workflow creation succeeded atomically.
+    // Commit the event transaction after the idempotent workflow upsert succeeds.
     tx.commit()
         .await
         .map_err(|e| IngestError::Internal(format!("error: commit transaction: {e}")))?;

--- a/crates/buzz-relay/src/handlers/command_executor.rs
+++ b/crates/buzz-relay/src/handlers/command_executor.rs
@@ -93,8 +93,9 @@ async fn persist_command_event(
     state: &Arc<AppState>,
     tenant: &TenantContext,
     event: &Event,
+    channel_id_override: Option<Uuid>,
 ) -> Result<PersistResult, IngestError> {
-    let channel_id = extract_channel_id(event);
+    let channel_id = channel_id_override.or_else(|| extract_channel_id(event));
 
     let mut tx = state
         .db
@@ -273,7 +274,7 @@ async fn handle_dm_open(
     }
 
     // Persist the command event (idempotency) — returns open transaction
-    let tx = match persist_command_event(state, tenant, event).await? {
+    let tx = match persist_command_event(state, tenant, event, None).await? {
         PersistResult::Duplicate => {
             return Ok(IngestResult {
                 event_id: event.id.to_hex(),
@@ -427,7 +428,7 @@ async fn handle_dm_add_member(
     }
 
     // Persist the command event — returns open transaction
-    let tx = match persist_command_event(state, tenant, event).await? {
+    let tx = match persist_command_event(state, tenant, event, None).await? {
         PersistResult::Duplicate => {
             return Ok(IngestResult {
                 event_id: event.id.to_hex(),
@@ -526,7 +527,7 @@ async fn handle_dm_hide(
     }
 
     // Persist the command event — returns open transaction
-    let tx = match persist_command_event(state, tenant, event).await? {
+    let tx = match persist_command_event(state, tenant, event, None).await? {
         PersistResult::Duplicate => {
             return Ok(IngestResult {
                 event_id: event.id.to_hex(),
@@ -616,7 +617,7 @@ async fn handle_workflow_def(
     let hash = compute_definition_hash(&definition_json_final);
 
     // Persist the command event — returns open transaction
-    let tx = match persist_command_event(state, tenant, event).await? {
+    let tx = match persist_command_event(state, tenant, event, None).await? {
         PersistResult::Duplicate => {
             return Ok(IngestResult {
                 event_id: event.id.to_hex(),
@@ -704,25 +705,19 @@ async fn handle_workflow_trigger(
         .await
         .map_err(|_| IngestError::Rejected("invalid: workflow not found".into()))?;
 
-    // 3. Validate caller has channel access (if workflow is channel-scoped)
-    if let Some(channel_id) = workflow.channel_id {
-        let is_member = state
-            .is_member_cached(tenant.community(), channel_id, &self_bytes)
-            .await
-            .map_err(|e| IngestError::Internal(format!("error: membership check: {e}")))?;
-        if !is_member {
-            return Err(IngestError::Rejected(
-                "forbidden: not a member of the workflow's channel".into(),
-            ));
-        }
-    } else if workflow.owner_pubkey != self_bytes {
+    // 3. Manual triggers execute with the workflow owner's authority, so only
+    // the owner may start them. Channel membership alone is insufficient: a
+    // member could otherwise invoke another user's webhook or message actions.
+    if workflow.owner_pubkey != self_bytes {
         return Err(IngestError::Rejected(
             "forbidden: not authorized to trigger this workflow".into(),
         ));
     }
 
-    // Persist the command event — returns open transaction
-    let tx = match persist_command_event(state, tenant, event).await? {
+    // Persist the command event under the workflow channel even though the
+    // trigger event itself only carries the workflow UUID. Storing channel
+    // triggers as global events leaks workflow IDs to unrelated relay members.
+    let tx = match persist_command_event(state, tenant, event, workflow.channel_id).await? {
         PersistResult::Duplicate => {
             return Ok(IngestResult {
                 event_id: event.id.to_hex(),
@@ -903,7 +898,7 @@ async fn handle_approval_grant(
     check_approver_spec(&approval.approver_spec, &self_hex)?;
 
     // Persist the command event — returns open transaction
-    let tx = match persist_command_event(state, tenant, event).await? {
+    let tx = match persist_command_event(state, tenant, event, None).await? {
         PersistResult::Duplicate => {
             return Ok(IngestResult {
                 event_id: event.id.to_hex(),
@@ -1014,7 +1009,7 @@ async fn handle_approval_deny(
     check_approver_spec(&approval.approver_spec, &self_hex)?;
 
     // Persist the command event — returns open transaction
-    let tx = match persist_command_event(state, tenant, event).await? {
+    let tx = match persist_command_event(state, tenant, event, None).await? {
         PersistResult::Duplicate => {
             return Ok(IngestResult {
                 event_id: event.id.to_hex(),

--- a/crates/buzz-relay/src/handlers/count.rs
+++ b/crates/buzz-relay/src/handlers/count.rs
@@ -160,10 +160,17 @@ pub async fn handle_count(
             } else {
                 // Fallback: query + post-filter for non-pushable constraints.
                 let mut q = query;
-                q.limit = Some(100_000);
-                q.max_limit = Some(100_000);
+                super::req::apply_count_fallback_limit(&mut q);
                 match state.db.query_events(&q).await {
                     Ok(stored_events) => {
+                        if super::req::count_fallback_exceeded(stored_events.len()) {
+                            metrics::counter!("buzz_count_fallback_rejections_total").increment(1);
+                            conn.send(RelayMessage::closed(
+                                &sub_id,
+                                "restricted: count filter requires narrower constraints",
+                            ));
+                            return;
+                        }
                         for se in stored_events {
                             if !buzz_core::filter::filters_match(std::slice::from_ref(filter), &se)
                             {
@@ -215,11 +222,18 @@ pub async fn handle_count(
                     }
                 }
             } else {
-                // Fallback: query with high limit + post-filter for correctness.
-                query.limit = Some(100_000);
-                query.max_limit = Some(100_000);
+                // Fallback: query a bounded candidate set + post-filter.
+                super::req::apply_count_fallback_limit(&mut query);
                 match state.db.query_events(&query).await {
                     Ok(stored_events) => {
+                        if super::req::count_fallback_exceeded(stored_events.len()) {
+                            metrics::counter!("buzz_count_fallback_rejections_total").increment(1);
+                            conn.send(RelayMessage::closed(
+                                &sub_id,
+                                "restricted: count filter requires narrower constraints",
+                            ));
+                            return;
+                        }
                         for se in stored_events {
                             if !buzz_core::filter::filters_match(std::slice::from_ref(filter), &se)
                             {

--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -693,6 +693,26 @@ pub async fn build_event_query_from_filter(
     filter_to_query_params(filter, channel_id, community)
 }
 
+/// Maximum SQL candidate rows a non-pushable COUNT filter may inspect before
+/// the client must add narrower constraints.
+///
+/// COUNT needs an exact answer. For filters that require Rust post-filtering,
+/// fetch one extra row so callers can reject over-budget scans rather than
+/// returning a truncated count.
+pub(crate) const COUNT_FALLBACK_CANDIDATE_LIMIT: i64 = 5_000;
+
+/// Apply the bounded candidate budget used by COUNT post-filter fallbacks.
+pub(crate) fn apply_count_fallback_limit(query: &mut EventQuery) {
+    let fetch_limit = COUNT_FALLBACK_CANDIDATE_LIMIT + 1;
+    query.limit = Some(fetch_limit);
+    query.max_limit = Some(fetch_limit);
+}
+
+/// Return whether a COUNT fallback query exceeded its exact-count budget.
+pub(crate) fn count_fallback_exceeded(candidate_count: usize) -> bool {
+    candidate_count > COUNT_FALLBACK_CANDIDATE_LIMIT as usize
+}
+
 /// Returns `true` if all constraints in this filter can be fully represented
 /// in SQL by `filter_to_query_params` — meaning `count_events()` will produce
 /// an exact count without post-filtering.
@@ -1164,6 +1184,21 @@ mod tests {
             SingleLetterTag::lowercase(Alphabet::H),
             channel_id.to_string(),
         )
+    }
+
+    #[test]
+    fn count_fallback_fetches_one_extra_candidate() {
+        let mut query =
+            EventQuery::for_community(buzz_core::tenant::CommunityId::from_uuid(uuid::Uuid::nil()));
+        apply_count_fallback_limit(&mut query);
+        assert_eq!(query.limit, Some(COUNT_FALLBACK_CANDIDATE_LIMIT + 1));
+        assert_eq!(query.max_limit, Some(COUNT_FALLBACK_CANDIDATE_LIMIT + 1));
+        assert!(!count_fallback_exceeded(
+            COUNT_FALLBACK_CANDIDATE_LIMIT as usize
+        ));
+        assert!(count_fallback_exceeded(
+            COUNT_FALLBACK_CANDIDATE_LIMIT as usize + 1
+        ));
     }
 
     #[test]

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -1741,6 +1741,7 @@ async fn handle_a_tag_deletion(
         .map_err(|_| anyhow::anyhow!("invalid kind in a-tag"))?;
     let pubkey_hex = parts[1];
     let d_tag = parts[2];
+    let actor_bytes = effective_message_author(event, &state.relay_keypair.public_key());
 
     match kind_num {
         buzz_core::kind::KIND_WORKFLOW_DEF => {
@@ -1748,22 +1749,21 @@ async fn handle_a_tag_deletion(
             if let Ok(wf_id) = uuid::Uuid::parse_str(d_tag) {
                 state
                     .db
-                    .delete_workflow(tenant.community(), wf_id)
+                    .delete_workflow_for_owner(tenant.community(), wf_id, &actor_bytes)
                     .await
                     .map_err(|e| anyhow::anyhow!("failed to delete workflow {wf_id}: {e}"))?;
                 tracing::info!(workflow_id = %wf_id, "Workflow deleted via NIP-09 a-tag (UUID)");
             } else {
                 // Name-based lookup
-                let owner_bytes = hex::decode(pubkey_hex).unwrap_or_default();
                 match state
                     .db
-                    .find_workflow_by_owner_and_name(tenant.community(), &owner_bytes, d_tag)
+                    .find_workflow_by_owner_and_name(tenant.community(), &actor_bytes, d_tag)
                     .await
                 {
                     Ok(Some(wf)) => {
                         state
                             .db
-                            .delete_workflow(tenant.community(), wf.id)
+                            .delete_workflow_for_owner(tenant.community(), wf.id, &actor_bytes)
                             .await
                             .map_err(|e| {
                                 anyhow::anyhow!("failed to delete workflow {}: {e}", wf.id)

--- a/crates/buzz-relay/src/state.rs
+++ b/crates/buzz-relay/src/state.rs
@@ -220,6 +220,8 @@ pub struct AppState {
     /// serialization — that's the CAS at the manifest pointer (spec
     /// §Push step 7, `Inv_NoFork`).
     pub git_semaphore: Arc<Semaphore>,
+    /// Semaphore limiting concurrent media upload parsing/transcoding work.
+    pub media_upload_semaphore: Arc<Semaphore>,
 
     /// Workflow engine for background processing.
     pub workflow_engine: Arc<WorkflowEngine>,
@@ -283,6 +285,11 @@ pub struct AppState {
     /// trusted, but a buggy desktop loop shouldn't make the relay sign+fan
     /// unboundedly. 20/sec is far above any real interactive use.
     pub mesh_connect_rate_limiter: Arc<DashMap<[u8; 32], (u32, Instant)>>,
+    /// Per-uploader sliding-window rate limiter for media upload starts.
+    /// Key: uploader pubkey bytes (32). Value: (count, window_start).
+    pub media_upload_rate_limiter: Arc<DashMap<[u8; 32], (u32, Instant)>>,
+    /// Current in-flight media uploads per uploader pubkey.
+    pub media_uploads_in_flight: Arc<DashMap<[u8; 32], u32>>,
     /// Cache for observer agent-owner authorization (kind 24200).
     /// Key: (agent_pubkey_bytes, owner_pubkey_bytes). Value: is_owner.
     /// agent_owner_pubkey is immutable so a long TTL (5 min) is safe.
@@ -357,6 +364,7 @@ impl AppState {
         });
 
         let git_max_concurrent_ops = config.git_max_concurrent_ops;
+        let media_max_concurrent_uploads = config.media_max_concurrent_uploads;
         let git_store = crate::api::git::store::GitStore::new(
             &config.media.s3_endpoint,
             &config.media.s3_access_key,
@@ -379,6 +387,7 @@ impl AppState {
             conn_semaphore: Arc::new(Semaphore::new(max_connections)),
             handler_semaphore: Arc::new(Semaphore::new(max_concurrent_handlers)),
             git_semaphore: Arc::new(Semaphore::new(git_max_concurrent_ops)),
+            media_upload_semaphore: Arc::new(Semaphore::new(media_max_concurrent_uploads)),
             workflow_engine,
             relay_keypair,
 
@@ -415,6 +424,8 @@ impl AppState {
             nip98_replay,
             observer_rate_limiter: Arc::new(DashMap::new()),
             mesh_connect_rate_limiter: Arc::new(DashMap::new()),
+            media_upload_rate_limiter: Arc::new(DashMap::new()),
+            media_uploads_in_flight: Arc::new(DashMap::new()),
             observer_owner_cache: Arc::new(
                 moka::sync::Cache::builder()
                     .max_capacity(1_000)


### PR DESCRIPTION
## Summary

This hardens eight relay trust and resource-exhaustion paths. Each commit is scoped to one issue.

## Commits

- `507094c5 Fix workflow deletion ownership`
  Fixes an authorization bug where a user could delete another user's workflow by UUID or name. Workflow deletion now qualifies the DB operation by the effective message author.

- `b96f8627 Scope manual workflow triggers`
  Fixes cross-user workflow execution and global trigger event leakage. Manual triggers now require workflow ownership and persist under the workflow channel instead of the global channel.

- `350d8500 Replace workflow definitions by d-tag UUID`
  Fixes a storage and fan-out amplification path where repeated definition events for one logical workflow could create multiple live rows instead of replacing the existing definition. Workflow definitions now upsert by `d`-tag UUID, reject owner or channel changes, and preserve webhook secrets across updates.

- `b20e1e4d Expire unauthenticated relay sockets`
  Fixes a connection-slot DoS where clients could keep websocket connections open indefinitely before authenticating. Unauthenticated sockets are now closed after 5 seconds.

- `d0f234cc Bound git relay resource usage`
  Fixes memory and CPU exhaustion paths in the git relay from oversized manifests, refs, packs, hydrated repositories, and subprocess output. Git reads and writes now enforce manifest, ref, pack, and repo budgets and keep bounded subprocess output in tempfiles.

- `a10ddc4d Limit media upload admission`
  Fixes upload-based process exhaustion by adding global and per-pubkey concurrency limits plus per-pubkey request-rate limits before the relay reads upload bodies.

- `67b854ae Bound COUNT fallback scans`
  Fixes expensive COUNT filters that could force fallback scans across up to 100,000 candidate rows. Fallback scans now cap at 5,000 candidates and reject broader filters instead of consuming unbounded work.

- `5919081c Verify huddle parent linkage`
  Fixes TTL huddle parent spoofing where a client-supplied parent UUID could make membership checks and relay-signed lifecycle events target an unrelated parent. Parent linkage now has to be proven by a creator-signed huddle-start event.

## Safety And Tradeoffs

Workflow definition updates preserve existing webhook secrets and reject owner or channel changes for an existing UUID. Git and COUNT requests over configured budgets now fail closed instead of consuming unbounded relay memory or CPU. Media upload admission is intentionally in-memory per relay instance, so it protects process resources without attempting cross-replica quota accounting.

## Testing

- `cargo test -p buzz-db --lib`
- `cargo test -p buzz-media --lib`
- `env -u BUZZ_GIT_REPO_PATH cargo test -p buzz-relay --lib -- --test-threads=1`
- `cargo clippy -p buzz-relay --lib -- -D warnings`
- `CMAKE_POLICY_VERSION_MINIMUM=3.5 just ci`
