### PR TITLE
fix(profile): show archive control while snapshot loads

### DIFF
--- a/desktop/src/features/identity-archive/hooks.ts
+++ b/desktop/src/features/identity-archive/hooks.ts
@@ -101,7 +101,7 @@ export function useUnarchiveIdentityMutation() {
 export type IdentityArchiveActions = {
   /** Render guard only — the relay re-verifies authority on submit. */
   canArchive: boolean;
-  /** `undefined` while the snapshot loads — defer flair + Manage until known. */
+  /** `undefined` while the snapshot loads — defer flair + mutation affordances until known. */
   isArchived: boolean | undefined;
   isPending: boolean;
   archive: () => void;

--- a/desktop/src/features/profile/ui/UserProfileAgentActions.tsx
+++ b/desktop/src/features/profile/ui/UserProfileAgentActions.tsx
@@ -63,9 +63,8 @@ export function UserProfileAgentSettingsMenu({
     onToggleAutoStart !== undefined;
   const autoStartSwitchId = `user-profile-agent-auto-start-${actionKey}`;
   const hasPrimaryActions = Boolean(onDuplicatePersona || onExportPersona);
-  const hasArchiveAction =
-    archiveActions?.canArchive === true &&
-    archiveActions.isArchived !== undefined;
+  const hasArchiveAction = archiveActions?.canArchive === true;
+  const archiveStateKnown = archiveActions?.isArchived !== undefined;
   const shouldConfirmAgentDelete =
     managedAgent !== undefined && onDelete !== undefined;
   const hasManageActions = hasArchiveAction || Boolean(onDelete);
@@ -146,7 +145,7 @@ export function UserProfileAgentSettingsMenu({
             <DropdownMenuSeparator />
           ) : null}
           {hasArchiveAction && archiveActions ? (
-            archiveActions.isArchived ? (
+            archiveActions.isArchived === true ? (
               <DropdownMenuItem
                 data-testid="user-profile-unarchive-identity"
                 disabled={isPending}
@@ -158,11 +157,21 @@ export function UserProfileAgentSettingsMenu({
             ) : (
               <DropdownMenuItem
                 data-testid="user-profile-archive-identity"
-                disabled={isPending}
-                onSelect={() => setArchiveConfirmOpen(true)}
+                disabled={isPending || !archiveStateKnown}
+                onSelect={(event) => {
+                  if (!archiveStateKnown) {
+                    event.preventDefault();
+                    return;
+                  }
+                  setArchiveConfirmOpen(true);
+                }}
               >
                 <Archive className="h-4 w-4" />
-                {archiveActions.isPending ? "Archiving…" : archiveLabel}
+                {archiveActions.isPending
+                  ? "Archiving…"
+                  : archiveStateKnown
+                    ? archiveLabel
+                    : "Checking archive status…"}
               </DropdownMenuItem>
             )
           ) : null}
@@ -186,11 +195,12 @@ export function UserProfileAgentSettingsMenu({
           ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
-      {hasArchiveAction && archiveActions ? (
+      {hasArchiveAction && archiveActions && archiveStateKnown ? (
         <ArchiveConfirmDialog
           isBot={isBot}
           isPending={archiveActions.isPending}
           onConfirm={() => {
+            if (archiveActions.isArchived !== false) return;
             archiveActions.archive();
             setArchiveConfirmOpen(false);
           }}
@@ -245,8 +255,7 @@ export function UserProfileAgentSettingsMenuSlot({
   personaActionKey?: string;
   viewerIsOwner: boolean;
 }) {
-  const canShowArchiveAction =
-    archiveActions.canArchive && archiveActions.isArchived !== undefined;
+  const canShowArchiveAction = archiveActions.canArchive;
   const settingsActionPending =
     isAgentActionPending || archiveActions.isPending;
   const sharedProps = {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -106,12 +106,13 @@ type E2eConfig = {
     stallWebsocketSends?: boolean;
     userSearchDelayMs?: number;
     // NIP-IA gate inputs — see tests/helpers/bridge.ts:MockBridgeOptions for
-    // semantics. These three drive the archive-button gate matrix in
+    // semantics. These options drive the archive-button gate matrix in
     // tests/e2e/identity-archive.spec.ts; they're plumbed into:
-    // - `list_archived_identities` (archivedIdentities)
+    // - `list_archived_identities` (archivedIdentities / archivedIdentitiesDelayMs)
     // - `resolve_oa_owner` (oaOwnerIsMe)
     // - `resetMockRelayMembers` (relayRole)
     archivedIdentities?: string[];
+    archivedIdentitiesDelayMs?: number;
     oaOwnerIsMe?: boolean;
     relayRole?: "owner" | "admin" | "member" | null;
     // Descriptors returned by the mocked `pick_and_upload_media` /
@@ -7649,6 +7650,10 @@ export function maybeInstallE2eTauriMocks() {
         return { owner, is_me: isMe };
       }
       case "list_archived_identities": {
+        const delayMs = activeConfig?.mock?.archivedIdentitiesDelayMs ?? 0;
+        if (delayMs > 0) {
+          await new Promise((resolve) => window.setTimeout(resolve, delayMs));
+        }
         const archived = activeConfig?.mock?.archivedIdentities ?? [];
         return { archived };
       }

--- a/desktop/tests/e2e/identity-archive.spec.ts
+++ b/desktop/tests/e2e/identity-archive.spec.ts
@@ -97,6 +97,26 @@ test.describe("NIP-IA archive button gate", () => {
     ).toBeVisible();
   });
 
+  test("case 3b — verified OA owner viewing Alice while snapshot is pending: Archive visible but disabled", async ({
+    page,
+  }) => {
+    await installMockBridge(page, {
+      relayRole: null,
+      oaOwnerIsMe: true,
+      archivedIdentities: [],
+      archivedIdentitiesDelayMs: 60_000,
+    });
+    await openAliceProfile(page);
+    await openProfileSettingsMenu(page);
+
+    const archiveButton = page.getByTestId("user-profile-archive-identity");
+    await expect(archiveButton).toBeVisible();
+    await expect(archiveButton).toBeDisabled();
+    await expect(archiveButton).toContainText("Checking archive status…");
+    await archiveButton.click({ force: true });
+    await expect(page.getByTestId("archive-confirm-dialog")).toHaveCount(0);
+  });
+
   test("case 4 — no authority viewing Alice: Archive hidden", async ({
     page,
   }) => {

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -134,6 +134,8 @@ type MockBridgeOptions = {
    * "Archived on this relay" flair + Unarchive button.
    */
   archivedIdentities?: string[];
+  /** Delay (ms) for `list_archived_identities`; lets specs assert pending snapshot UI. */
+  archivedIdentitiesDelayMs?: number;
   /**
    * Drives the `is_me` field of `resolve_oa_owner`. When true, the harness
    * reports the active identity as the verified NIP-OA owner of the viewee


### PR DESCRIPTION
## Overview

**Category:** fix
**User Impact:** A verified agent owner now always sees the Archive control on an agent's profile, even while the app is still checking the agent's archive status.

**Problem:** For a verified owner, the Archive/Unarchive control on an agent profile could silently disappear whenever the archived-identities snapshot query was pending, slow, or errored — even though ownership checked out fine. This surfaced as the control appearing in some builds but not others, with no obvious cause.

**Solution:** The control's visibility now tracks *ownership only* (`canArchive`), decoupled from snapshot health. While the snapshot state is unknown, the menu shows a visible-but-disabled "Checking archive status…" item that cannot open the confirm dialog or fire any archive/unarchive mutation. Ownership/permission logic is untouched, and the relay still re-verifies authority on submit.

<details>
<summary>File changes</summary>

**desktop/src/features/profile/ui/UserProfileAgentActions.tsx**
Archive action visibility now keys off `canArchive` alone; introduces `archiveStateKnown` to gate the *interactive* affordances. Unknown state renders a disabled "Checking archive status…" item, the confirm dialog only mounts when the state is known, and `onConfirm` has a belt-and-suspenders guard (`if (archiveActions.isArchived !== false) return`) so an already-archived or unknown identity can never be re-archived.

**desktop/src/features/identity-archive/hooks.ts**
Doc comment clarified: `isArchived === undefined` now defers flair + mutation affordances (not the whole control) until the snapshot is known.

**desktop/src/testing/e2eBridge.ts** / **desktop/tests/helpers/bridge.ts**
Test-bridge wiring to drive a delayed `list_archived_identities` snapshot from E2E.

**desktop/tests/e2e/identity-archive.spec.ts**
New coverage: verified OA owner + delayed archive snapshot shows the disabled "Checking archive status…" item with no dialog/mutation path.

</details>

## Reproduction Steps

1. As a verified owner of a *remote, not-locally-managed* agent, open the agent's profile settings menu while the archived-identities snapshot query is still pending (or simulate a slow/errored snapshot).
2. Before this fix: the Archive control is absent entirely.
3. After this fix: the Archive item is present but disabled, labeled "Checking archive status…"; once the snapshot resolves it becomes the enabled Archive/Unarchive action.

## Screenshots

Pending state (disabled): ![pending](https://sprout-oss.stage.blox.sqprod.co/media/3ca04f62bfc05608db84b23df42377dd34069cc4450b4ac7138fb221a14aec1a.png)

Resolved state (enabled): ![resolved](https://sprout-oss.stage.blox.sqprod.co/media/488e08a59d37b1c8a2058aea02dd4a82739c3b3f0170cc7b4c0b001bfc170e66.png)