### PR TITLE
fix(desktop): stop clipping the agent-activity row under the composer

### DIFF
--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -197,8 +197,16 @@ export function BotActivityComposerAction({
               +{typingAgents.length - 2}
             </span>
           ) : null}
-          <span className={cn(isInline ? "max-w-40 truncate" : "sr-only")}>
-            {isInline ? <Shimmer>{visibleStatusLabel}</Shimmer> : "working"}
+          <span
+            className={cn(
+              isInline ? "min-w-0 flex-1 overflow-hidden" : "sr-only",
+            )}
+          >
+            {isInline ? (
+              <Shimmer className="block truncate">{visibleStatusLabel}</Shimmer>
+            ) : (
+              "working"
+            )}
           </span>
           {isInline ? null : (
             <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" />

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -686,10 +686,10 @@ export const ChannelPane = React.memo(function ChannelPane({
                   }
                   showTopBorder={false}
                 />
-                <div className="h-7 overflow-visible bg-background px-5 pb-1 pt-0">
+                <div className="min-h-8 overflow-visible bg-background px-5 pb-1.5 pt-0">
                   <div className="flex h-full w-full items-center gap-2 overflow-visible">
                     {hasComposerBotActivity ? (
-                      <div className="shrink-0 overflow-visible">
+                      <div className="flex min-w-0 flex-1 overflow-visible">
                         <BotActivityComposerAction
                           agents={activityAgents}
                           channelId={activeChannel?.id ?? null}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -832,13 +832,15 @@ export function MessageThreadPanel({
           />
           <div
             className={cn(
-              "h-7 bg-background pb-1 pt-0",
+              "min-h-8 bg-background pb-1.5 pt-0",
               THREAD_PANEL_COMPOSER_GUTTER_CLASS,
             )}
           >
-            <div className="mx-auto flex h-full w-full max-w-4xl items-center gap-2">
+            <div className="mx-auto flex h-full w-full max-w-4xl items-center gap-2 overflow-visible">
               {toolbarExtraActions ? (
-                <div className="shrink-0">{toolbarExtraActions}</div>
+                <div className="flex min-w-0 flex-1 overflow-visible">
+                  {toolbarExtraActions}
+                </div>
               ) : null}
               {threadTypingPubkeys.length > 0 ? (
                 <TypingIndicatorRow


### PR DESCRIPTION
## What

The agent-activity row under the chat composer clipped on the **bottom** (text descenders + the avatar ring) and on the **right** (long status text hard-cut mid-word, no ellipsis). Fixed both, in the main channel composer **and** the thread side panel (same inline component, rendered in two places).

## Why it clipped

Two independent root causes in the inline `BotActivityComposerAction`:

1. **Right-side clip** — the status label used `max-w-40 truncate`, but `truncate` sat on a span wrapping an `inline-block` Shimmer, so `text-overflow: ellipsis` never applied; long text just hard-clipped at the fixed 160px. Now the label flexes (`min-w-0 flex-1`) and `block truncate` lives on the Shimmer itself, so it ellipsizes against real available width.

2. **Bottom clip** — the row was a fixed `h-7` (28px) sitting flush at the pane's bottom edge with only `pb-1`, clipping descenders and the avatar ring's outer pixels. Bumped to `min-h-8` + `pb-1.5`.

## Thread-panel parity

The inline action is rendered in two spots (both in `ChannelPane`): the main composer, and the thread side panel via `toolbarExtraActions`. The thread panel had its **own** composer row that still used the old `h-7`/`pb-1` and wrapped the action in `shrink-0` (no bounded width → no ellipsis). Brought it to parity (`min-h-8` + `pb-1.5`, wrapper `flex min-w-0 flex-1`) so both spots behave identically.

The `toolbar` variant (used elsewhere) keeps its label `sr-only` and is untouched.

## Files

```
 desktop/src/features/channels/ui/BotActivityBar.tsx     |  12 ++--
 desktop/src/features/channels/ui/ChannelPane.tsx        |   4 +-
 desktop/src/features/messages/ui/MessageThreadPanel.tsx |   8 ++-
```

## Validation

`tsc`, `biome check`, file-size guard, and px-text guard all pass (`just desktop-check` green). CSS-layout-only change; no logic touched.

> Note: I couldn't grab a before/after screenshot — the bar only renders while an agent is actively typing in a channel, which I couldn't reproduce in a dev build.
