### PR TITLE
release(helm): buzz chart 0.1.1

### DIFF
--- a/deploy/charts/buzz/Chart.yaml
+++ b/deploy/charts/buzz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   PostgreSQL and Redis. Configurable for single-node evaluation
   (subcharts on) and HA production (external services, existingSecret).
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 home: https://github.com/block/buzz
 sources:


### PR DESCRIPTION
First versioned OCI release of the buzz helm chart.

## What
Bumps `deploy/charts/buzz/Chart.yaml` `version` 0.1.0 → **0.1.1**. `appVersion` stays `0.1.0` — the relay image is unchanged, so this is a chart-packaging release, not an app release.

## Why 0.1.1
Chart.yaml on main is already `0.1.0`, so a no-op PR isn't possible. Tyler OK'd "0.1.0 or 0.1.1 — whatever works"; 0.1.1 gives the meaningful version bump a release PR needs and keeps the published artifact moving forward.

## Release machinery (from #1372)
Merging this `chart-release/0.1.1` branch:
1. `auto-tag-on-release-pr-merge.yml` tags `chart-v0.1.1` and dispatches `helm-chart.yml`.
2. The publish job validates tag-vs-Chart.yaml version (fails closed on drift — here both are 0.1.1), then `helm package` + `helm push oci://ghcr.io/block/buzz/charts/buzz:0.1.1`.

## Validation
- `helm dependency build` + `helm package deploy/charts/buzz` → `buzz-0.1.1.tgz` (matches the publish step's `dist/buzz-${VERSION}.tgz`).
- Branch `<version>` matches `Chart.yaml` `version` per the chart README's Releasing flow.

After publish, tf-stacks #2255 flips from the vendored `file://` chart to `oci://ghcr.io/block/buzz/charts/buzz:0.1.1` and deletes `argocd/charts/buzz/`.