### PR TITLE
Restore visible links for rich previews

### DIFF
--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -25,7 +25,6 @@ import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext"
 import { cn } from "@/shared/lib/cn";
 import {
   extractSupportedLinkPreviews,
-  isSupportedLinkAutolinkLabel,
   parseSupportedLinkPreview,
 } from "@/shared/lib/linkPreview";
 import { useResolvedLinkPreviews } from "@/shared/lib/useResolvedLinkPreviews";
@@ -1525,8 +1524,7 @@ function createMarkdownComponents(
       </SpoilerInline>
     ),
     a: ({ children, href, ...props }) => {
-      const { imetaByUrl, linkPreviewHrefs, onOpenMessageLink } =
-        runtimeRef.current;
+      const { imetaByUrl, onOpenMessageLink } = runtimeRef.current;
       if (!interactive) {
         return <span className="font-medium text-current">{children}</span>;
       }
@@ -1601,13 +1599,6 @@ function createMarkdownComponents(
         ? parseSupportedLinkPreview(href)
         : null;
       const isLinearLink = supportedLinkPreview?.kind === "linear-issue";
-      if (
-        supportedLinkPreview &&
-        linkPreviewHrefs.has(supportedLinkPreview.href) &&
-        isSupportedLinkAutolinkLabel(label, supportedLinkPreview)
-      ) {
-        return null;
-      }
 
       return (
         <a
@@ -1958,15 +1949,10 @@ function MarkdownInner({
     () => (interactive ? extractSupportedLinkPreviews(content) : []),
     [content, interactive],
   );
-  const linkPreviewHrefs = React.useMemo(
-    () => new Set(linkPreviews.map((preview) => preview.href)),
-    [linkPreviews],
-  );
   const runtimeRef = useLatestRef<MarkdownRuntime>({
     agentMentionPubkeysByName,
     channels,
     imetaByUrl,
-    linkPreviewHrefs,
     mentionPubkeysByName,
     onOpenChannel,
     onOpenMessageLink,

--- a/desktop/src/shared/ui/markdown/types.ts
+++ b/desktop/src/shared/ui/markdown/types.ts
@@ -27,7 +27,6 @@ export type MarkdownRuntime = {
   agentMentionPubkeysByName?: Record<string, string>;
   channels: Channel[];
   imetaByUrl?: ImetaLookup;
-  linkPreviewHrefs: ReadonlySet<string>;
   mentionPubkeysByName?: Record<string, string>;
   onOpenChannel: (channelId: string) => void;
   onOpenMessageLink: (link: ParsedMessageLink) => void;

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -99,6 +99,27 @@ test("long autolink wraps without widening the timeline", async ({ page }) => {
     .toBe("visible");
 });
 
+test("supported link previews keep the message link visible", async ({
+  page,
+}) => {
+  const previewUrl = "https://github.com/block/sprout/pull/1334";
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  await page.getByTestId("message-input").fill(previewUrl);
+  await page.getByTestId("send-message").click();
+
+  const row = page.getByTestId("message-row").last();
+  await expect(
+    row.getByRole("link", { exact: true, name: previewUrl }),
+  ).toBeVisible();
+  await expect(
+    row.locator('[data-link-preview="github-pull-request"]'),
+  ).toBeVisible();
+});
+
 test("send multiple messages in sequence", async ({ page }) => {
   const ts = Date.now();
   const messages = [


### PR DESCRIPTION
## Summary
- Restore visible URL text for supported rich link previews while keeping the preview cards.
- Remove the renderer-only preview href cache that suppressed autolink output.
- Add a Playwright regression test for sent messages with a GitHub preview link.

## Checks
- Code checks: no findings.
- `cd desktop && ../bin/pnpm check`
- `cd desktop && ../bin/pnpm typecheck`
- `cd desktop && node --import ./test-loader.mjs --experimental-strip-types --test src/shared/lib/linkPreview.test.mjs`
- `cd desktop && ../bin/pnpm build`
- `cd desktop && ../bin/pnpm exec playwright test --project=smoke tests/e2e/messaging.spec.ts -g "supported link previews keep the message link visible"`
- Pre-push hook: `check-push-org`, `desktop-test`, `mobile-test`, `rust-tests`, `desktop-tauri-test`

## Screenshots
### Link text and preview cards
Supported links remain visible in the message body while their rich preview cards render below.

![link-preview-visible-link](https://raw.githubusercontent.com/block/buzz/49db9ca2e44879e94a261aa02f3485822d812855/pr-1378--link-preview-visible-link.png)

### Preview hover affordance
The preview card still shows the open affordance on hover.

![link-preview-visible-hover](https://raw.githubusercontent.com/block/buzz/49db9ca2e44879e94a261aa02f3485822d812855/pr-1378--link-preview-visible-hover.png)
