### PR TITLE
Speed up profile wave action

### DIFF
--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -150,8 +150,8 @@ export function useOpenDmMutation() {
         ]),
       );
     },
-    onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
     },
   });
 }

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -596,7 +596,7 @@ export function UserProfilePopover({
                 <div className="flex gap-2">
                   <Button
                     aria-label="Wave"
-                    className="buzz-wave-hover-trigger shrink-0 px-3"
+                    className="buzz-wave-hover-trigger shrink-0 px-3 transition-transform duration-100 ease-out motion-reduce:transition-none motion-safe:active:scale-[0.97]"
                     data-testid={`user-profile-popover-wave-${pubkey}`}
                     disabled={
                       pendingAction !== null || openDmMutation.isPending


### PR DESCRIPTION
## Summary
- Stop waiting on the channel-list refetch after a DM is opened.
- Add reduced-motion-aware press feedback to the profile Wave button.

## Test Plan
- `cd desktop && pnpm typecheck`
- `cd desktop && pnpm check`
- `cd desktop && pnpm build && pnpm exec playwright test tests/e2e/mentions.spec.ts -g "profile popover wave sends a direct message" --project=smoke`