### PR TITLE
style(desktop): unify corner radii to rounded-2xl (16px)

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -801,7 +801,7 @@ export function AppShell() {
                             className="isolate min-h-0 min-w-0 overflow-hidden bg-sidebar"
                             style={chromeCssVarDefaults}
                           >
-                            <div className="relative z-10 mb-2 ml-px mr-2 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-background shadow-[-1px_-1px_0_0_hsl(var(--sidebar-border)/0.45)]">
+                            <div className="relative z-10 mb-2 ml-px mr-2 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-background shadow-[-1px_-1px_0_0_hsl(var(--sidebar-border)/0.45)]">
                               <ConnectionBanner
                                 errorMessage={channelsErrorMessage}
                               />

--- a/desktop/src/features/agents/ui/AgentIdentityCard.tsx
+++ b/desktop/src/features/agents/ui/AgentIdentityCard.tsx
@@ -30,13 +30,13 @@ export function AgentIdentityCard({
   return (
     <div
       className={cn(
-        "group relative aspect-[4/5] w-full min-w-0 overflow-hidden rounded-xl border border-border/70 bg-muted/50 text-left shadow-xs transition-colors hover:border-border hover:bg-muted/65",
+        "group relative aspect-[4/5] w-full min-w-0 overflow-hidden rounded-2xl border border-border/70 bg-muted/50 text-left shadow-xs transition-colors hover:border-border hover:bg-muted/65",
       )}
       data-testid={dataTestId}
     >
       <button
         aria-label={ariaLabel}
-        className="absolute inset-0 z-10 rounded-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+        className="absolute inset-0 z-10 rounded-2xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
         onClick={onClick}
         type="button"
       />

--- a/desktop/src/features/agents/ui/CreateIdentityCard.tsx
+++ b/desktop/src/features/agents/ui/CreateIdentityCard.tsx
@@ -20,7 +20,7 @@ export const CreateIdentityCard = React.forwardRef<
     <button
       aria-label={ariaLabel}
       className={cn(
-        "group relative flex aspect-[4/5] w-full min-w-0 items-center justify-center overflow-hidden rounded-xl border border-dashed border-border/80 bg-transparent text-muted-foreground shadow-xs transition-colors hover:border-border hover:bg-muted/70 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+        "group relative flex aspect-[4/5] w-full min-w-0 items-center justify-center overflow-hidden rounded-2xl border border-dashed border-border/80 bg-transparent text-muted-foreground shadow-xs transition-colors hover:border-border hover:bg-muted/70 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
         className,
       )}
       data-testid={dataTestId}

--- a/desktop/src/features/agents/ui/TeamIdentityCard.tsx
+++ b/desktop/src/features/agents/ui/TeamIdentityCard.tsx
@@ -42,7 +42,7 @@ export function TeamIdentityCard({
 
   return (
     <Card
-      className="min-w-0 overflow-hidden p-0 transition-colors hover:border-border hover:bg-muted/65"
+      className="min-w-0 overflow-hidden rounded-2xl p-0 transition-colors hover:border-border hover:bg-muted/65"
       data-testid={dataTestId}
     >
       <div className="relative aspect-[4/5] min-w-0 overflow-hidden bg-muted/50">

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -500,7 +500,7 @@ const MessageTimelineBase = React.forwardRef<
                               "flex shrink-0 border border-border/70 bg-background/70 text-left transition-colors hover:bg-muted/60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
                               hasDescription
                                 ? "h-56 w-[13.75rem] flex-col rounded-2xl p-4"
-                                : "h-28 w-64 flex-col rounded-xl p-4",
+                                : "h-28 w-64 flex-col rounded-2xl p-4",
                             )}
                             data-testid={action.testId}
                             key={action.label}
@@ -556,7 +556,7 @@ const MessageTimelineBase = React.forwardRef<
 
               {showGenericEmpty ? (
                 <div
-                  className="mt-auto rounded-3xl border border-dashed border-border/80 bg-card/70 px-6 py-10 text-center shadow-xs"
+                  className="mt-auto rounded-2xl border border-dashed border-border/80 bg-card/70 px-6 py-10 text-center shadow-xs"
                   data-testid="message-empty"
                 >
                   <p className="text-base font-semibold tracking-tight">

--- a/desktop/src/shared/ui/dialog.tsx
+++ b/desktop/src/shared/ui/dialog.tsx
@@ -54,7 +54,7 @@ const DialogContent = React.forwardRef<
     <div className="fixed inset-0 z-50 grid place-items-center overflow-y-auto p-4 pointer-events-none">
       <DialogPrimitive.Content
         className={cn(
-          "pointer-events-auto relative grid w-[calc(100vw-2rem)] max-w-2xl gap-4 rounded-3xl bg-background p-6 shadow-2xl outline-hidden",
+          "pointer-events-auto relative grid w-[calc(100vw-2rem)] max-w-2xl gap-4 rounded-2xl bg-background p-6 shadow-2xl outline-hidden",
           MODAL_CONTENT_MOTION_CLASS,
           className,
         )}

--- a/desktop/src/shared/ui/identity-card-skeleton.tsx
+++ b/desktop/src/shared/ui/identity-card-skeleton.tsx
@@ -17,7 +17,7 @@ export function IdentityCardSkeleton({
   return (
     <div
       className={cn(
-        "relative aspect-[4/5] w-full min-w-0 overflow-hidden rounded-xl border border-border/70 bg-muted/50 shadow-xs",
+        "relative aspect-[4/5] w-full min-w-0 overflow-hidden rounded-2xl border border-border/70 bg-muted/50 shadow-xs",
         className,
       )}
     >


### PR DESCRIPTION
## Summary

Unifies corner radii across core surfaces and identity/intro cards onto the native Tailwind `rounded-2xl` (16px) step, eliminating the previous 12/24px mismatch. Every value is a stock Tailwind utility — **no arbitrary radius values**.

## Surfaces changed (all → `rounded-2xl`)

**Core 3:**
- **Main container** — `AppShell.tsx`: `rounded-xl` (12) → `rounded-2xl` (16)
- **Modal/dialog** — shared `DialogContent` in `dialog.tsx`: `rounded-3xl` (24) → `rounded-2xl` (16)
- **Composer** — `MessageComposer.tsx`: already `rounded-2xl`, unchanged

**Cards (this round):**
- **Agent cards** — `AgentIdentityCard.tsx` (card + focus-ring), `CreateIdentityCard.tsx` ("New agent"), `identity-card-skeleton.tsx` (loading state matches)
- **Team cards** — `TeamIdentityCard.tsx`: per-instance `rounded-2xl` override on the shared `<Card>`, scoped to team cards only (the other `Card` consumers — projects/workflows/etc. — are intentionally left untouched to keep the blast radius minimal)
- **Welcome + top-of-channel cards** — `MessageTimeline.tsx`: no-description CTA card `rounded-xl`→`rounded-2xl`; generic empty-state `rounded-3xl`→`rounded-2xl`. The with-description top cards ("Create agent"/"Add people") were already 16px.

## Scope

Deliberately narrow — only the surfaces explicitly requested, **not** all ~228 `rounded-*` call sites app-wide.

## After screenshots

Captured from the genuine built app via the repo's own E2E harness (`desktop/tests/helpers/screenshot.mjs` + mock relay bridge). What to look for: every card, modal, container, and intro card sits on the same 16px curve.

**Agents view** — "New agent" + "Fizz" agent cards at 16px:

![agents view at 16px](https://sprout-oss.stage.blox.sqprod.co/media/19c19bd4e129372b81cbaa37501c8158c841e1c1496ed12f4e47c859aaf7ff4a.png)

**Teams view** — Engineering / Research Agents / Platform Tools + "New team", all 16px:

![teams view at 16px](https://sprout-oss.stage.blox.sqprod.co/media/9ae57b819783d907a1baa84f09ef1a04fa588b2e7616a00639383545309147d1.png)

**Welcome channel** — "Create a channel" / "Create a custom agent" CTAs at 16px, matching the composer:

![welcome channel at 16px](https://sprout-oss.stage.blox.sqprod.co/media/ae6d31937a4cac1922762ad31c5b858d0f924d4525a9f97648a6f194a3508d2d.png)

## Diff

7 files, 9 insertions / 9 deletions.

## Verification

- `biome check` clean on all touched files
- Pre-push suite green (desktop, mobile, rust, tauri tests)
- Real booted-app screenshots above confirm 16px on agents view, teams view, welcome channel, and general channel intro cards

🤖 Generated with assistance from an agent. Co-authored / signed off by the human operator.
