### PR TITLE
fix(desktop): enable buzz-dev-mcp MCP server for Codex agents

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -140,7 +140,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         commands: &["codex-acp"],
         aliases: &[],
         avatar_url: CODEX_AVATAR_URL,
-        mcp_command: None,
+        mcp_command: Some("buzz-dev-mcp"),
         mcp_hooks: false,
         underlying_cli: Some("codex"),
         cli_install_commands: &["curl -fsSL https://chatgpt.com/codex/install.sh | sh"],

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -92,6 +92,13 @@ fn buzz_agent_resolved_via_path() {
 }
 
 #[test]
+fn codex_has_mcp_command() {
+    let p = known_acp_runtime("codex-acp").expect("should resolve");
+    assert!(!p.mcp_hooks, "codex-acp does not handle MCP_HOOK_SERVERS");
+    assert_eq!(p.mcp_command, Some("buzz-dev-mcp"));
+}
+
+#[test]
 fn goose_has_no_mcp_hooks() {
     let p = known_acp_runtime("goose").expect("should resolve");
     assert!(!p.mcp_hooks);


### PR DESCRIPTION
This PR fixes Codex agents never connecting to \`buzz-dev-mcp\` by enabling the MCP server for the codex runtime.

The codex runtime entry in \`discovery.rs\` had \`mcp_command: None\`. This propagated to \`BUZZ_ACP_MCP_COMMAND=\"\"\` when spawning buzz-acp for a Codex agent, causing \`build_mcp_servers\` to return an empty list — no MCP server was ever configured, so \`buzz-dev-mcp\` was never started and Codex agents had no access to buzz tools. The Codex-native exec tool is seatbelt-sandboxed with network disabled, so the only way to run \`buzz messages send\` is through the MCP \`shell\` tool; without this fix, Codex agents could receive mentions but could never reply.

- Set \`mcp_command: Some("buzz-dev-mcp")\` on the codex runtime (was \`None\`) to match the buzz-agent entry; \`BUZZ_ACP_MCP_COMMAND\` resolves to the binary path and \`build_mcp_servers\` produces a configured server with \`BUZZ_RELAY_URL\`, \`BUZZ_PRIVATE_KEY\`, and \`BUZZ_AUTH_TAG\` forwarded via the ACP \`McpServer.env\` field, bypassing Codex's parent-env scrub via the protocol
- Leave \`mcp_hooks: false\` since codex-acp does not handle \`MCP_HOOK_SERVERS\` today; lifecycle hooks can be added in a follow-up once the adapter supports them
- Add \`codex_has_mcp_command\` test that pins both \`mcp_command\` and \`mcp_hooks\` fields against regression

E2E verified: Thufir replied via \`buzz messages send\` through the MCP \`shell\` tool after applying this change in a \`just staging\` dev build.