### PR TITLE
Restore channel date divider rule

### DIFF
--- a/desktop/src/features/messages/ui/DayDivider.tsx
+++ b/desktop/src/features/messages/ui/DayDivider.tsx
@@ -2,7 +2,7 @@ export function DayDivider({ label }: { label: string }) {
   return (
     <section
       aria-label={label}
-      className="sticky top-(--buzz-channel-content-top-padding,5.75rem) z-[5] flex justify-center"
+      className="sticky top-(--buzz-channel-content-top-padding,5.75rem) z-[5] flex justify-center before:absolute before:inset-x-0 before:top-1/2 before:h-px before:-translate-y-1/2 before:bg-border/35 before:content-['']"
       data-testid="message-timeline-day-divider"
       data-day-label={label}
     >


### PR DESCRIPTION
## Summary
- Restore the full-width hairline behind channel date divider pills.

## Snapshot
![Restored channel date divider](https://raw.githubusercontent.com/block/buzz/2f2bc772a62bf923f6433688cccd0eb9598553b8/pr-1395--restored-date-divider-tight.png)

## Checks
- `bin/pnpm -C desktop exec biome check src/features/messages/ui/DayDivider.tsx`
- `bin/pnpm -C desktop check:px-text`
- `bin/just desktop-screenshot --name restored-date-divider-tight --active-channel general --clip 300,170,840,170 --wait 2000 --outdir test-results/screenshots`
- pre-push hook: `check-push-org`, `desktop-test`, `mobile-test`, `rust-tests`, `desktop-tauri-test`
