### PR TITLE
fix(ci): restore E2E flakiness fixes for pgschema, docker-pull, and spec timing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,18 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: cashapp/activate-hermit@e49f5cb4dd64ff0b0b659d1d8df499595451155a # v1
       - name: Start integration services
-        run: docker compose up -d postgres redis minio minio-init
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose up -d postgres redis minio minio-init; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "docker compose up failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "docker compose up failed (attempt $attempt), retrying in $((attempt * 5))s..." >&2
+            sleep $((attempt * 5))
+          done
       - name: Get pnpm store directory
         id: pnpm-cache
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
@@ -380,6 +391,13 @@ jobs:
           PGUSER: buzz
           PGPASSWORD: buzz_dev
           PGDATABASE: buzz
+          # Use the already-running docker postgres for desired-state planning instead of
+          # downloading an embedded Postgres from Maven Central (transient-fetch flake source).
+          PGSCHEMA_PLAN_HOST: localhost
+          PGSCHEMA_PLAN_PORT: "5432"
+          PGSCHEMA_PLAN_DB: buzz
+          PGSCHEMA_PLAN_USER: buzz
+          PGSCHEMA_PLAN_PASSWORD: buzz_dev
         run: |
           ./bin/pgschema apply --file schema/schema.sql --auto-approve
           docker exec -i -e PGPASSWORD=buzz_dev buzz-postgres \
@@ -471,7 +489,18 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' }}
       - name: Start integration services
-        run: docker compose up -d postgres redis minio minio-init
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose up -d postgres redis minio minio-init; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "docker compose up failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "docker compose up failed (attempt $attempt), retrying in $((attempt * 5))s..." >&2
+            sleep $((attempt * 5))
+          done
       - name: Wait for integration services
         run: |
           wait_healthy() {
@@ -513,6 +542,13 @@ jobs:
           PGUSER: buzz
           PGPASSWORD: buzz_dev
           PGDATABASE: buzz
+          # Use the already-running docker postgres for desired-state planning instead of
+          # downloading an embedded Postgres from Maven Central (transient-fetch flake source).
+          PGSCHEMA_PLAN_HOST: localhost
+          PGSCHEMA_PLAN_PORT: "5432"
+          PGSCHEMA_PLAN_DB: buzz
+          PGSCHEMA_PLAN_USER: buzz
+          PGSCHEMA_PLAN_PASSWORD: buzz_dev
         run: |
           ./bin/pgschema apply --file schema/schema.sql --auto-approve
           docker exec -i -e PGPASSWORD=buzz_dev buzz-postgres \

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -331,14 +331,16 @@ test("persona model options follow the selected LLM provider", async ({
 
   // Switch to Default (no explicit provider) — model resets to "Default model".
   await llmProvider.click();
-  const llmProviderMenu = page.getByRole("menu").filter({
-    has: page.getByRole("menuitemradio", { name: "OpenAI", exact: true }),
-  });
-  const defaultOption = llmProviderMenu
-    .last()
-    .getByRole("menuitemradio", { name: "Default", exact: true });
-  await expect(defaultOption).toBeVisible();
-  await defaultOption.click();
+  // Wait for Radix menu animations to settle before locating the menu item.
+  // The prior approach held a filtered locator across the open→animate boundary
+  // and clicked a node that Radix was still re-mounting, producing
+  // "element is not stable" / "element was detached from the DOM" failures.
+  // Matching the OpenAI/Anthropic steps above: wait for animations, then
+  // locate fresh at click-time so no stale reference crosses the re-render.
+  await waitForAnimations(page);
+  await page
+    .getByRole("menuitemradio", { name: "Default", exact: true })
+    .click();
   await expect(model).toBeVisible();
   await expect(model).toContainText("Default model");
 });

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -334,10 +334,11 @@ test("persona model options follow the selected LLM provider", async ({
   const llmProviderMenu = page.getByRole("menu").filter({
     has: page.getByRole("menuitemradio", { name: "OpenAI", exact: true }),
   });
-  await llmProviderMenu
+  const defaultOption = llmProviderMenu
     .last()
-    .getByRole("menuitemradio", { name: "Default", exact: true })
-    .click();
+    .getByRole("menuitemradio", { name: "Default", exact: true });
+  await expect(defaultOption).toBeVisible();
+  await defaultOption.click();
   await expect(model).toBeVisible();
   await expect(model).toContainText("Default model");
 });


### PR DESCRIPTION
Fixes three distinct root causes behind the recurring "Desktop E2E Integration" CI failures. All three buckets in one commit on `duncan/e2e-flakiness-fix` off `2f496debc`.

## Bucket A — restore `PGSCHEMA_PLAN_*` env block (`.github/workflows/ci.yml`)

PR #1070 (`e3736f08b`) added a 5-var block pointing `pgschema apply` at the already-running docker Postgres instead of downloading an embedded one from Maven Central. PR #963 (`ff824a365`) silently deleted those lines via a stale-base rebase. Restored at **both** pgschema-apply sites (`ci.yml:396-400` and `547-551`). Eliminates the `failed to start embedded PostgreSQL: no version found matching 17.5.0` flake deterministically.

## Bucket B — retry loop for `docker compose up` (`.github/workflows/ci.yml`)

Both "Start integration services" steps ran `docker compose up -d postgres redis minio minio-init` with no retry. A single Docker Hub 500 killed the job pre-test. Wrapped both sites in a 3-attempt retry with 5s/10s backoff. Persistent failure still exits 1 after 3 attempts.

## Bucket C — stabilize radix detach race (`desktop/tests/e2e/persona-env-vars.spec.ts`)

The `persona model options follow the selected LLM provider` test failed on the "Switch to Default" step with `element is not stable` / `element was detached from the DOM`. The prior approach built a filtered `defaultOption` locator before opening the menu and held it across the open→re-render boundary — Radix was still re-mounting the collection when the click landed.

Fix mirrors the OpenAI and Anthropic steps in the same test: after `llmProvider.click()`, call `waitForAnimations(page)` to let Radix finish animating/re-mounting, then locate `menuitemradio` for "Default" fresh at click-time via the bare `page.getByRole` pattern. No stale handle crosses the open/re-render boundary.

## Gate

Buckets A/B/C are not exercised by `just desktop-tauri-test` (828/828 passing locally). Real proof is the live E2E Integration CI shard.