### PR TITLE
test(desktop): gate keychain-write test behind --ignored

### DIFF
--- a/desktop/src-tauri/src/secret_store.rs
+++ b/desktop/src-tauri/src/secret_store.rs
@@ -568,6 +568,7 @@ mod tests {
         // tests; here we only verify the skip path.
     }
 
+    #[ignore = "requires real OS keychain (run locally)"]
     #[test]
     fn mutate_blob_does_not_advance_cache_on_write_failure() {
         // Copy-on-write safety: if `write_blob_raw` fails (denied prompt,
@@ -576,40 +577,46 @@ mod tests {
         // must NOT be skipped as a no-op — the equality check must compare
         // against the durable cache, not an unpersisted candidate.
         //
-        // On unsigned CI builds the keychain is unreachable, so any `store()`
-        // for a key not already in the warm cache will call `write_blob_raw`
-        // and receive an error. We verify that after the error:
+        // This is a real-keychain integration test. Run locally with:
+        //   cargo test -p buzz-desktop -- --ignored mutate_blob_does_not_advance
+        //
+        // On a machine with a reachable keychain the `store()` call succeeds
+        // (result.is_ok()) and the write-failure branch is skipped — the test
+        // still passes. On a machine where the write is denied (e.g., user
+        // clicks Deny in the macOS prompt) result.is_err() and the assertions
+        // below verify the cache invariant. We verify that after an error:
         //   1. The cache is not advanced (the previously cached key is intact).
         //   2. The failed key is not present (the dirty candidate was discarded).
         let mut map = HashMap::new();
         map.insert("existing".to_string(), "durable_val".to_string());
         let store = SecretStore::with_cache("buzz-test-cow-write-fail", Some(map));
 
-        // Attempt to add a new key — on unsigned CI this will try write_blob_raw
-        // and fail; with copy-on-write the cache must remain at {existing}.
+        // Attempt to add a new key — this calls write_blob_raw against the
+        // real keychain; with copy-on-write the cache must remain at {existing}
+        // if the write fails.
         let result = store.store("new_key", "new_val");
 
         if result.is_err() {
-            // Write failed (expected on unsigned CI): confirm cache was not
-            // advanced — the existing key is still intact and the new key
-            // was never committed to the in-memory state.
+            // Write failed (e.g., user denied the keychain prompt): confirm
+            // cache was not advanced — the existing key is still intact and
+            // the new key was never committed to the in-memory state.
             assert_eq!(
                 store.load("existing").unwrap(),
                 Some("durable_val".to_string()),
                 "cache must remain at last durable state after write failure"
             );
             // load("new_key") goes through the unchanged cache (no entry),
-            // then attempts migrate_legacy_key which also fails on unsigned CI,
-            // returning either Ok(None) or Err — either is correct since the
-            // key was never durably stored.
+            // then attempts migrate_legacy_key which also fails on a denied
+            // keychain, returning either Ok(None) or Err — either is correct
+            // since the key was never durably stored.
             let after = store.load("new_key");
             assert!(
                 matches!(after, Ok(None) | Err(_)),
                 "a key whose write failed must not be visible via load: {after:?}"
             );
         }
-        // If result.is_ok() the test ran on a machine with a real keychain and
-        // the write succeeded — no assertion needed for the failure path.
+        // If result.is_ok() the write succeeded — the cache-integrity invariant
+        // does not apply to the success path; no assertion needed here.
     }
 
     #[test]


### PR DESCRIPTION
## What

Gates `mutate_blob_does_not_advance_cache_on_write_failure` behind `#[ignore = "requires real OS keychain (run locally)"]`, matching the convention already used by the sibling integration tests directly below it in `secret_store.rs`.

Also refreshes the test's doc comment to drop stale references to "unsigned CI" and accurately describe both execution paths.

## Why

This test stores a new key via `store()`, which drives `mutate_blob` down the `next != current` branch and calls `write_blob_raw()` — a real macOS keychain write. On a signed developer machine (or any machine with a reachable keychain) this pops the system authorization dialog for service `buzz-test-cow-write-fail` every time the default `cargo test` or `just desktop-tauri-test` pass runs.

The four integration tests immediately below it in the file (`blob_stores_and_retrieves_multiple_keys`, `blob_probe_present_absent_unreachable`, `blob_delete_removes_key_not_others`, `blob_migration_from_per_key_entry`) are already gated with `#[ignore = "requires real OS keychain (run locally)"]` for exactly this reason. This test belongs in that same bucket: its whole purpose is to exercise what happens when `write_blob_raw` is called against the real keychain backend, so it cannot run safely without one.

## Running the test



On a machine with a reachable keychain the write succeeds (`result.is_ok()`) and the write-failure branch is skipped — the test still passes. On a machine where the write is denied (user clicks Deny in the macOS prompt) `result.is_err()` and the cache-integrity assertions fire.