### PR TITLE
docs: link VISION_ACTIVITY from the VISION index

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -132,6 +132,8 @@ Zero is the default. You opt in to noise, not out.
 
 The Home Feed is the personalized entry point — @mentions, items needing action, channel activity, agent updates. Fan-out-on-read, assembled at query time. Agents read the same feed via MCP.
 
+See [VISION_ACTIVITY.md](VISION_ACTIVITY.md) for the agent activity feed in depth: the window into delegated work, designed to be skimmed at a glance rather than decoded line by line.
+
 ---
 
 ## Channel Features


### PR DESCRIPTION
## What

Adds a one-line pointer to `VISION_ACTIVITY.md` from the `VISION.md` index, in the **Home Feed & Notifications** section.

## Why

Follow-up to [Wes's review comment on #1381](https://github.com/block/buzz/pull/1381#discussion_r3501282483) asking whether `VISION_ACTIVITY.md` belongs at the project root.

**The location is correct.** All six VISION docs live at the project root — `VISION.md`, `VISION_AGENT.md`, `VISION_MESH.md`, `VISION_PROJECTS.md`, `VISION_SOVEREIGN.md`, and now `VISION_ACTIVITY.md`. Root is the established convention.

The real gap was **discoverability**: `VISION.md` is the hub and links out to SOVEREIGN / MESH / PROJECTS with a `See [VISION_X.md]...` line each — but never linked ACTIVITY. This PR wires it in where the activity/agent feed is discussed, matching the existing pattern.

## Change

```diff
 The Home Feed is the personalized entry point — @mentions, items needing action, channel activity, agent updates. Fan-out-on-read, assembled at query time. Agents read the same feed via MCP.
+
+See [VISION_ACTIVITY.md](VISION_ACTIVITY.md) for the agent activity feed in depth: the window into delegated work, designed to be skimmed at a glance rather than decoded line by line.
```

Docs-only, one file, no code.