### PR TITLE
fix(sidebar): trim working badge label and name working agents in tooltip

### DIFF
--- a/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
+++ b/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
@@ -193,11 +193,18 @@ describe("activeAgentTurnsStore", () => {
 
       const summaries = getActiveTurnsByChannel();
       assert.deepEqual(
-        summaries.map(({ channelId, agentCount }) => ({
+        summaries.map(({ channelId, agentCount, agentPubkeys }) => ({
           channelId,
           agentCount,
+          agentPubkeys,
         })),
-        [{ channelId: "shared", agentCount: 2 }],
+        [
+          {
+            channelId: "shared",
+            agentCount: 2,
+            agentPubkeys: [AGENT, AGENT_2],
+          },
+        ],
       );
       assert.equal(
         summaries[0].anchorAt,

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -49,6 +49,8 @@ export type ActiveChannelTurnSummary = {
   channelId: string;
   anchorAt: number;
   agentCount: number;
+  agentPubkeys: string[];
+  agentNames?: string[];
 };
 
 // Module-level state: agentPubkey → turnId → ActiveTurn
@@ -478,6 +480,7 @@ export function getActiveTurnsByChannel(): ActiveChannelTurnSummary[] {
       channelId,
       anchorAt: summary.anchorAt,
       agentCount: summary.agentPubkeys.size,
+      agentPubkeys: [...summary.agentPubkeys].sort(),
     }))
     .sort((a, b) => a.channelId.localeCompare(b.channelId));
   cachedChannelTurnSummaries = result;

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
@@ -20,4 +20,18 @@ describe("resolveActiveWorkingChannelNames", () => {
 
     assert.deepEqual(resolved.agentNames, ["Ned", "Bart"]);
   });
+
+  it("uses a generic label when an active agent name is unresolved", () => {
+    const resolved = resolveActiveWorkingChannelNames(
+      {
+        channelId: "chan-1",
+        anchorAt: 0,
+        agentCount: 2,
+        agentPubkeys: ["AAAA", "cccc"],
+      },
+      [{ pubkey: "aaaa", name: "Ned" }],
+    );
+
+    assert.deepEqual(resolved.agentNames, ["Ned", "another agent"]);
+  });
 });

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
@@ -21,7 +21,7 @@ describe("resolveActiveWorkingChannelNames", () => {
     assert.deepEqual(resolved.agentNames, ["Ned", "Bart"]);
   });
 
-  it("uses a generic label when an active agent name is unresolved", () => {
+  it("omits unresolved active agents from the resolved names", () => {
     const resolved = resolveActiveWorkingChannelNames(
       {
         channelId: "chan-1",
@@ -32,6 +32,6 @@ describe("resolveActiveWorkingChannelNames", () => {
       [{ pubkey: "aaaa", name: "Ned" }],
     );
 
-    assert.deepEqual(resolved.agentNames, ["Ned", "another agent"]);
+    assert.deepEqual(resolved.agentNames, ["Ned"]);
   });
 });

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { resolveActiveWorkingChannelNames } from "./useActiveWorkingChannelsById.ts";
+
+describe("resolveActiveWorkingChannelNames", () => {
+  it("resolves active agent pubkeys to managed agent names", () => {
+    const resolved = resolveActiveWorkingChannelNames(
+      {
+        channelId: "chan-1",
+        anchorAt: 0,
+        agentCount: 2,
+        agentPubkeys: ["AAAA", "bbbb"],
+      },
+      [
+        { pubkey: "aaaa", name: "Ned" },
+        { pubkey: "BBBB", name: "Bart" },
+      ],
+    );
+
+    assert.deepEqual(resolved.agentNames, ["Ned", "Bart"]);
+  });
+});

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -9,8 +9,6 @@ import { useManagedAgentsQuery } from "@/features/agents/hooks";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
-const UNKNOWN_WORKING_AGENT_LABEL = "another agent";
-
 export function resolveActiveWorkingChannelNames(
   summary: ActiveChannelTurnSummary,
   managedAgents: readonly { pubkey: string; name: string }[],
@@ -21,11 +19,10 @@ export function resolveActiveWorkingChannelNames(
 
   return {
     ...summary,
-    agentNames: summary.agentPubkeys.map(
-      (pubkey) =>
-        namesByPubkey.get(normalizePubkey(pubkey)) ??
-        UNKNOWN_WORKING_AGENT_LABEL,
-    ),
+    agentNames: summary.agentPubkeys.flatMap((pubkey) => {
+      const name = namesByPubkey.get(normalizePubkey(pubkey));
+      return name ? [name] : [];
+    }),
   };
 }
 

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -9,6 +9,8 @@ import { useManagedAgentsQuery } from "@/features/agents/hooks";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
+const UNKNOWN_WORKING_AGENT_LABEL = "another agent";
+
 export function resolveActiveWorkingChannelNames(
   summary: ActiveChannelTurnSummary,
   managedAgents: readonly { pubkey: string; name: string }[],
@@ -20,7 +22,9 @@ export function resolveActiveWorkingChannelNames(
   return {
     ...summary,
     agentNames: summary.agentPubkeys.map(
-      (pubkey) => namesByPubkey.get(normalizePubkey(pubkey)) ?? pubkey,
+      (pubkey) =>
+        namesByPubkey.get(normalizePubkey(pubkey)) ??
+        UNKNOWN_WORKING_AGENT_LABEL,
     ),
   };
 }

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -7,6 +7,23 @@ import {
 } from "@/features/agents/activeAgentTurnsStore";
 import { useManagedAgentsQuery } from "@/features/agents/hooks";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+export function resolveActiveWorkingChannelNames(
+  summary: ActiveChannelTurnSummary,
+  managedAgents: readonly { pubkey: string; name: string }[],
+): ActiveChannelTurnSummary {
+  const namesByPubkey = new Map(
+    managedAgents.map((agent) => [normalizePubkey(agent.pubkey), agent.name]),
+  );
+
+  return {
+    ...summary,
+    agentNames: summary.agentPubkeys.map(
+      (pubkey) => namesByPubkey.get(normalizePubkey(pubkey)) ?? pubkey,
+    ),
+  };
+}
 
 export function useActiveWorkingChannelsById(): ReadonlyMap<
   string,
@@ -25,8 +42,14 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
   return React.useMemo(
     () =>
       new Map(
-        activeWorkingChannels.map((summary) => [summary.channelId, summary]),
+        activeWorkingChannels.map((summary) => {
+          const resolvedSummary = resolveActiveWorkingChannelNames(
+            summary,
+            managedAgents,
+          );
+          return [resolvedSummary.channelId, resolvedSummary];
+        }),
       ),
-    [activeWorkingChannels],
+    [activeWorkingChannels, managedAgents],
   );
 }

--- a/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
+++ b/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { formatWorkingTooltip } from "./SidebarSection.tsx";
+
+function summary(agentNames, agentCount = agentNames.length) {
+  return {
+    channelId: "chan-1",
+    anchorAt: 0,
+    agentCount,
+    agentPubkeys: agentNames.map((name) => `${name.toLowerCase()}-pubkey`),
+    agentNames,
+  };
+}
+
+describe("formatWorkingTooltip", () => {
+  it("lists one agent name", () => {
+    assert.equal(formatWorkingTooltip(summary(["Ned"])), "Ned working");
+  });
+
+  it("joins two agent names with an ampersand", () => {
+    assert.equal(
+      formatWorkingTooltip(summary(["Ned", "Bart"])),
+      "Ned & Bart working",
+    );
+  });
+
+  it("lists up to three agent names", () => {
+    assert.equal(
+      formatWorkingTooltip(summary(["Ned", "Bart", "Carl"])),
+      "Ned, Bart, & Carl working",
+    );
+  });
+
+  it("uses the others count after three agent names", () => {
+    assert.equal(
+      formatWorkingTooltip(summary(["Ned", "Bart", "Carl", "Marge", "Lisa"])),
+      "Ned, Bart, Carl, & 2 others working",
+    );
+  });
+});

--- a/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
+++ b/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
@@ -8,57 +8,45 @@ function summary(agentNames, agentCount = agentNames.length) {
     channelId: "chan-1",
     anchorAt: 0,
     agentCount,
-    agentPubkeys: agentNames.map(
-      (name, index) => `${name.toLowerCase()}-${index}-pubkey`,
+    agentPubkeys: Array.from(
+      { length: agentCount },
+      (_, index) => `agent-${index}-pubkey`,
     ),
     agentNames,
   };
 }
 
 describe("formatWorkingTooltip", () => {
-  it("lists one agent name", () => {
+  it("names one known agent", () => {
     assert.equal(formatWorkingTooltip(summary(["Ned"])), "Ned working");
   });
 
-  it("joins two agent names with and", () => {
+  it("names one known agent and counts one additional agent", () => {
     assert.equal(
       formatWorkingTooltip(summary(["Ned", "Bart"])),
-      "Ned and Bart working",
+      "Ned and 1 agent working",
     );
   });
 
-  it("lists up to three agent names", () => {
+  it("names one known agent and counts multiple additional agents", () => {
     assert.equal(
       formatWorkingTooltip(summary(["Ned", "Bart", "Carl"])),
-      "Ned, Bart, and Carl working",
+      "Ned and 2 agents working",
     );
   });
 
-  it("uses the more count after three agent names", () => {
-    assert.equal(
-      formatWorkingTooltip(summary(["Ned", "Bart", "Carl", "Marge", "Lisa"])),
-      "Ned, Bart, Carl, and 2 more working",
-    );
+  it("uses a singular count when all agents are unknown", () => {
+    assert.equal(formatWorkingTooltip(summary([], 1)), "1 agent working");
   });
 
-  it("uses and 1 more for the four-agent boundary", () => {
-    assert.equal(
-      formatWorkingTooltip(summary(["Ned", "Bart", "Carl", "Marge"])),
-      "Ned, Bart, Carl, and 1 more working",
-    );
+  it("uses a plural count when all agents are unknown", () => {
+    assert.equal(formatWorkingTooltip(summary([], 3)), "3 agents working");
   });
 
-  it("uses a generic label for one unresolved agent", () => {
+  it("counts unknown agents with the named lead", () => {
     assert.equal(
-      formatWorkingTooltip(summary(["Ned", "another agent"])),
-      "Ned and another agent working",
-    );
-  });
-
-  it("collapses multiple unresolved agents into the more count", () => {
-    assert.equal(
-      formatWorkingTooltip(summary(["Ned", "another agent", "another agent"])),
-      "Ned and 2 more working",
+      formatWorkingTooltip(summary(["Ned"], 3)),
+      "Ned and 2 agents working",
     );
   });
 });

--- a/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
+++ b/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
@@ -8,7 +8,9 @@ function summary(agentNames, agentCount = agentNames.length) {
     channelId: "chan-1",
     anchorAt: 0,
     agentCount,
-    agentPubkeys: agentNames.map((name) => `${name.toLowerCase()}-pubkey`),
+    agentPubkeys: agentNames.map(
+      (name, index) => `${name.toLowerCase()}-${index}-pubkey`,
+    ),
     agentNames,
   };
 }
@@ -18,24 +20,45 @@ describe("formatWorkingTooltip", () => {
     assert.equal(formatWorkingTooltip(summary(["Ned"])), "Ned working");
   });
 
-  it("joins two agent names with an ampersand", () => {
+  it("joins two agent names with and", () => {
     assert.equal(
       formatWorkingTooltip(summary(["Ned", "Bart"])),
-      "Ned & Bart working",
+      "Ned and Bart working",
     );
   });
 
   it("lists up to three agent names", () => {
     assert.equal(
       formatWorkingTooltip(summary(["Ned", "Bart", "Carl"])),
-      "Ned, Bart, & Carl working",
+      "Ned, Bart, and Carl working",
     );
   });
 
-  it("uses the others count after three agent names", () => {
+  it("uses the more count after three agent names", () => {
     assert.equal(
       formatWorkingTooltip(summary(["Ned", "Bart", "Carl", "Marge", "Lisa"])),
-      "Ned, Bart, Carl, & 2 others working",
+      "Ned, Bart, Carl, and 2 more working",
+    );
+  });
+
+  it("uses and 1 more for the four-agent boundary", () => {
+    assert.equal(
+      formatWorkingTooltip(summary(["Ned", "Bart", "Carl", "Marge"])),
+      "Ned, Bart, Carl, and 1 more working",
+    );
+  });
+
+  it("uses a generic label for one unresolved agent", () => {
+    assert.equal(
+      formatWorkingTooltip(summary(["Ned", "another agent"])),
+      "Ned and another agent working",
+    );
+  });
+
+  it("collapses multiple unresolved agents into the more count", () => {
+    assert.equal(
+      formatWorkingTooltip(summary(["Ned", "another agent", "another agent"])),
+      "Ned and 2 more working",
     );
   });
 });

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -111,9 +111,7 @@ function ChannelWorkingBadge({
   const now = useNow(1000);
   const elapsed = formatElapsed(now - summary.anchorAt);
   const label =
-    summary.agentCount > 1
-      ? `${summary.agentCount} working · ${elapsed}`
-      : `Working · ${elapsed}`;
+    summary.agentCount > 1 ? `${summary.agentCount} · ${elapsed}` : elapsed;
 
   return (
     <span

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -111,7 +111,7 @@ function ChannelWorkingBadge({
   const now = useNow(1000);
   const elapsed = formatElapsed(now - summary.anchorAt);
   const label =
-    summary.agentCount > 1 ? `${summary.agentCount} · ${elapsed}` : elapsed;
+    summary.agentCount > 1 ? `${elapsed} (${summary.agentCount})` : elapsed;
 
   return (
     <span

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -99,10 +99,12 @@ function UnreadDotBadge({
   );
 }
 
+const UNKNOWN_WORKING_AGENT_LABEL = "another agent";
+
 function formatAgentList(names: readonly string[]) {
-  if (names.length <= 1) return names[0] ?? "Agent";
-  if (names.length === 2) return `${names[0]} & ${names[1]}`;
-  return `${names.slice(0, -1).join(", ")}, & ${names[names.length - 1]}`;
+  if (names.length <= 1) return names[0] ?? UNKNOWN_WORKING_AGENT_LABEL;
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
 }
 
 export function formatWorkingTooltip(
@@ -111,15 +113,31 @@ export function formatWorkingTooltip(
   const names =
     summary.agentNames && summary.agentNames.length > 0
       ? summary.agentNames
-      : summary.agentPubkeys;
-  const visibleNames = names.slice(0, 3);
-  const othersCount = summary.agentCount - visibleNames.length;
-  const subject =
-    othersCount > 0
-      ? `${visibleNames.join(", ")}, & ${othersCount} ${othersCount === 1 ? "other" : "others"}`
-      : formatAgentList(visibleNames);
+      : summary.agentPubkeys.map(() => UNKNOWN_WORKING_AGENT_LABEL);
+  const resolvedNames = names.filter(
+    (name) => name !== UNKNOWN_WORKING_AGENT_LABEL,
+  );
+  const visibleNames = resolvedNames.slice(0, 3);
+  const hiddenCount = summary.agentCount - visibleNames.length;
 
-  return `${subject} working`;
+  if (hiddenCount <= 0) {
+    return `${formatAgentList(visibleNames)} working`;
+  }
+
+  if (visibleNames.length === 0) {
+    const subject =
+      hiddenCount === 1
+        ? UNKNOWN_WORKING_AGENT_LABEL
+        : `${UNKNOWN_WORKING_AGENT_LABEL} and ${hiddenCount - 1} more`;
+    return `${subject} working`;
+  }
+
+  const tail =
+    hiddenCount === 1 && visibleNames.length < 3
+      ? UNKNOWN_WORKING_AGENT_LABEL
+      : `${hiddenCount} more`;
+
+  return `${formatAgentList([...visibleNames, tail])} working`;
 }
 
 function ChannelWorkingBadge({

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -99,45 +99,25 @@ function UnreadDotBadge({
   );
 }
 
-const UNKNOWN_WORKING_AGENT_LABEL = "another agent";
-
-function formatAgentList(names: readonly string[]) {
-  if (names.length <= 1) return names[0] ?? UNKNOWN_WORKING_AGENT_LABEL;
-  if (names.length === 2) return `${names[0]} and ${names[1]}`;
-  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+function formatAgentCount(count: number) {
+  return `${count} ${count === 1 ? "agent" : "agents"}`;
 }
 
 export function formatWorkingTooltip(
   summary: ActiveChannelTurnSummary,
 ): string {
-  const names =
-    summary.agentNames && summary.agentNames.length > 0
-      ? summary.agentNames
-      : summary.agentPubkeys.map(() => UNKNOWN_WORKING_AGENT_LABEL);
-  const resolvedNames = names.filter(
-    (name) => name !== UNKNOWN_WORKING_AGENT_LABEL,
-  );
-  const visibleNames = resolvedNames.slice(0, 3);
-  const hiddenCount = summary.agentCount - visibleNames.length;
+  const leadName = summary.agentNames?.[0];
 
-  if (hiddenCount <= 0) {
-    return `${formatAgentList(visibleNames)} working`;
+  if (!leadName) {
+    return `${formatAgentCount(summary.agentCount)} working`;
   }
 
-  if (visibleNames.length === 0) {
-    const subject =
-      hiddenCount === 1
-        ? UNKNOWN_WORKING_AGENT_LABEL
-        : `${UNKNOWN_WORKING_AGENT_LABEL} and ${hiddenCount - 1} more`;
-    return `${subject} working`;
+  const remainingAgentCount = summary.agentCount - 1;
+  if (remainingAgentCount <= 0) {
+    return `${leadName} working`;
   }
 
-  const tail =
-    hiddenCount === 1 && visibleNames.length < 3
-      ? UNKNOWN_WORKING_AGENT_LABEL
-      : `${hiddenCount} more`;
-
-  return `${formatAgentList([...visibleNames, tail])} working`;
+  return `${leadName} and ${formatAgentCount(remainingAgentCount)} working`;
 }
 
 function ChannelWorkingBadge({

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -99,6 +99,29 @@ function UnreadDotBadge({
   );
 }
 
+function formatAgentList(names: readonly string[]) {
+  if (names.length <= 1) return names[0] ?? "Agent";
+  if (names.length === 2) return `${names[0]} & ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")}, & ${names[names.length - 1]}`;
+}
+
+export function formatWorkingTooltip(
+  summary: ActiveChannelTurnSummary,
+): string {
+  const names =
+    summary.agentNames && summary.agentNames.length > 0
+      ? summary.agentNames
+      : summary.agentPubkeys;
+  const visibleNames = names.slice(0, 3);
+  const othersCount = summary.agentCount - visibleNames.length;
+  const subject =
+    othersCount > 0
+      ? `${visibleNames.join(", ")}, & ${othersCount} ${othersCount === 1 ? "other" : "others"}`
+      : formatAgentList(visibleNames);
+
+  return `${subject} working`;
+}
+
 function ChannelWorkingBadge({
   channelName,
   isActive,
@@ -112,6 +135,7 @@ function ChannelWorkingBadge({
   const elapsed = formatElapsed(now - summary.anchorAt);
   const label =
     summary.agentCount > 1 ? `${elapsed} (${summary.agentCount})` : elapsed;
+  const title = formatWorkingTooltip(summary);
 
   return (
     <span
@@ -122,7 +146,7 @@ function ChannelWorkingBadge({
           : "bg-primary/10 text-primary",
       )}
       data-testid={`channel-working-${channelName}`}
-      title={label}
+      title={title}
     >
       {label}
     </span>


### PR DESCRIPTION
## Overview

**Category:** `improvement`
**User Impact:** The sidebar "working" pill no longer crowds out the channel name, and hovering it now says in plain prose who's working — e.g. `Ned and 2 agents working`.

**Problem:** The sidebar channel-row working pill rendered a `Working · 3s` label that ate horizontal room, forcing the channel name to ellipsize too early (`buzz-channel-indicat…`). There was also no way to tell *who* was working without opening the channel.

**Solution:** Trim the pill to a bare elapsed time (`3s` single-agent, `4m 3s (2)` multi-agent) so the channel name keeps its room, and move the "who" into the native hover tooltip. The tooltip uses one cohesive prose rule — name at most one agent and count everyone else as `agents` — so it stays narrow no matter how many agents work or how long their names are, and reads naturally rather than as a list.

<details>
<summary>File changes</summary>

**desktop/src/features/sidebar/ui/SidebarSection.tsx**
Trims the visible pill label to bare elapsed time and adds `formatWorkingTooltip`, which drives the row's `title`. Implements the cohesive labeling rule: one resolved name max, then `N agent`/`N agents` for everyone else (known overflow and unknowns alike).

**desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts**
Resolves working agent pubkeys to managed-agent names for the tooltip; unresolved pubkeys are dropped from the name list so they fold into the count rather than ever surfacing raw hex.

**desktop/src/features/agents/activeAgentTurnsStore.ts**
Surfaces the set of working-agent pubkeys per channel (`agentPubkeys`) so the sidebar can resolve names — additive, no consumer impact.

**desktop/src/features/sidebar/ui/SidebarSection.test.mjs**
Covers the six tooltip spec cases: one known, named+1 (singular), named+2+ (plural), all-unknown singular, all-unknown plural, and mixed known/unknown.

**desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs**
Covers the pubkey→name resolution path, including case-insensitive matching and the unresolved-drop behavior.

**desktop/src/features/agents/activeAgentTurnsStore.test.mjs**
Asserts `agentPubkeys` is aggregated correctly per channel.

</details>

## Reproduction Steps

1. Run the desktop app with at least one channel that has an actively working agent.
2. Look at the sidebar channel row: the working pill now shows just the elapsed time (e.g. `3s`, or `4m 3s (2)` when multiple agents are working), and the channel name no longer ellipsizes early.
3. Hover the pill: the native tooltip reads as prose — `Ned working`, `Ned and 1 agent working`, `Ned and 2 agents working`, or `3 agents working` when no name resolves.

## Notes

- The tooltip is a native OS `title` attribute, so it isn't DOM-renderable and can't be captured in a screenshot.
- "agent"/"agents" is the only count noun, chosen so the label never reads as if humans could appear there (humans don't show in this surface).

---
Coordination: buzz://message?channel=e325a47e-d11d-4f16-8e2d-0c55a2d924bb&thread=a9d0d732b58d87849405cb38fc18efc9e75a03af273abf3bf4d94ae583a7b174
