### PR TITLE
fix(sidebar): gate working pill on NIP-OA ownership

### DIFF
--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -128,6 +128,16 @@ function observerTag(event: RelayEvent, tagName: string) {
   return event.tags.find((tag) => tag[0] === tagName)?.[1] ?? null;
 }
 
+function pillDiagBridgeAgents(
+  agents: readonly Pick<ManagedAgent, "pubkey" | "status">[],
+) {
+  return agents.map((agent) => ({
+    pubkey: normalizePubkey(agent.pubkey),
+    status: agent.status,
+    startsObserver: agent.status === "running" || agent.status === "deployed",
+  }));
+}
+
 function appendAgentEvent(agentPubkey: string, event: ObserverEvent) {
   const key = normalizePubkey(agentPubkey);
   const current = eventsByAgent.get(key) ?? [];
@@ -389,6 +399,13 @@ export function useManagedAgentObserverBridge(
       ),
     [agents],
   );
+
+  console.log("[pill-diag] observer bridge render", {
+    subscriptionId,
+    hasActiveAgent,
+    agents: pillDiagBridgeAgents(agents),
+    at: new Date().toISOString(),
+  });
 
   const agentPubkeys = React.useMemo(
     () => agents.map((agent) => agent.pubkey),

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -84,17 +84,26 @@ function registerKnownAgents(
   subscriptionId: string,
   pubkeys: readonly string[],
 ) {
-  knownAgentsBySubscription.set(
-    subscriptionId,
-    new Set(pubkeys.map((pubkey) => normalizePubkey(pubkey))),
-  );
+  const normalizedPubkeys = pubkeys.map((pubkey) => normalizePubkey(pubkey));
+  knownAgentsBySubscription.set(subscriptionId, new Set(normalizedPubkeys));
   recomputeKnownAgentPubkeys();
+  pillDiagLog("registerKnownAgents", {
+    subscriptionId,
+    subscriptionPubkeys: pillDiagPubkeys(normalizedPubkeys),
+  });
 }
 
 function unregisterKnownAgents(subscriptionId: string) {
-  if (knownAgentsBySubscription.delete(subscriptionId)) {
+  const removedPubkeys = knownAgentsBySubscription.get(subscriptionId);
+  const removed = knownAgentsBySubscription.delete(subscriptionId);
+  if (removed) {
     recomputeKnownAgentPubkeys();
   }
+  pillDiagLog("unregisterKnownAgents", {
+    subscriptionId,
+    removed,
+    removedPubkeys: removedPubkeys ? pillDiagPubkeys(removedPubkeys) : [],
+  });
 }
 
 let connectionState: ConnectionState = "idle";
@@ -103,6 +112,44 @@ let unsubscribeRelay: (() => Promise<void>) | null = null;
 let startPromise: Promise<void> | null = null;
 let eventProcessingQueue: Promise<void> = Promise.resolve();
 let generation = 0;
+
+function pillDiagPubkeys(pubkeys: Iterable<string>) {
+  return [...pubkeys].map((pubkey) => normalizePubkey(pubkey)).sort();
+}
+
+function pillDiagState(extra: Record<string, unknown> = {}) {
+  return {
+    generation,
+    connectionState,
+    hasRelaySubscription: Boolean(unsubscribeRelay),
+    hasStartPromise: Boolean(startPromise),
+    knownAgentCount: knownAgentPubkeys.size,
+    knownAgents: pillDiagPubkeys(knownAgentPubkeys),
+    subscriptionCount: knownAgentsBySubscription.size,
+    subscriptionSizes: Object.fromEntries(
+      [...knownAgentsBySubscription.entries()].map(
+        ([subscriptionId, pubkeys]) => [subscriptionId, pubkeys.size],
+      ),
+    ),
+    at: new Date().toISOString(),
+    ...extra,
+  };
+}
+
+function pillDiagLog(label: string, extra: Record<string, unknown> = {}) {
+  console.log(`[pill-diag] observer ${label}`, pillDiagState(extra));
+}
+
+function pillDiagEvent(event: RelayEvent) {
+  const agentPubkey = observerTag(event, "agent");
+  return {
+    eventId: event.id,
+    eventPubkey: normalizePubkey(event.pubkey),
+    agentPubkey: agentPubkey ? normalizePubkey(agentPubkey) : null,
+    frame: observerTag(event, "frame"),
+    createdAt: event.created_at,
+  };
+}
 
 function notifyListeners() {
   for (const listener of listeners) {
@@ -191,26 +238,52 @@ async function handleRelayObserverEvent(
   const agentPubkey = observerTag(event, "agent");
   const frame = observerTag(event, "frame");
   if (!agentPubkey || frame !== "telemetry") {
+    pillDiagLog("drop nonTelemetryFrame", {
+      activeGeneration,
+      event: pillDiagEvent(event),
+    });
     return;
   }
 
   // Verify agent is known/trusted before decrypting.
   // Silently drop events from agents we are not managing.
   if (!knownAgentPubkeys.has(normalizePubkey(agentPubkey))) {
+    pillDiagLog("drop unknownAgent", {
+      activeGeneration,
+      event: pillDiagEvent(event),
+    });
     return;
   }
 
   // Defense-in-depth: verify the event sender matches the claimed agent pubkey.
   // The relay gates on is_agent_owner, but a compromised relay could misroute.
   if (normalizePubkey(event.pubkey) !== normalizePubkey(agentPubkey)) {
+    pillDiagLog("drop senderMismatch", {
+      activeGeneration,
+      event: pillDiagEvent(event),
+    });
     return;
   }
 
   try {
     const parsed = (await decryptObserverEvent(event)) as ObserverEvent;
     if (activeGeneration !== generation) {
+      pillDiagLog("drop staleGenerationAfterDecrypt", {
+        activeGeneration,
+        event: pillDiagEvent(event),
+        parsedKind: parsed.kind,
+        parsedSeq: parsed.seq,
+        parsedTimestamp: parsed.timestamp,
+      });
       return;
     }
+    pillDiagLog("appendFrame", {
+      activeGeneration,
+      event: pillDiagEvent(event),
+      parsedKind: parsed.kind,
+      parsedSeq: parsed.seq,
+      parsedTimestamp: parsed.timestamp,
+    });
     appendAgentEvent(agentPubkey, parsed);
     if (parsed.kind === "session_config_captured") {
       void putAgentSessionConfig(agentPubkey, parsed.payload);
@@ -220,8 +293,18 @@ async function handleRelayObserverEvent(
     }
   } catch (error) {
     if (activeGeneration !== generation) {
+      pillDiagLog("drop staleGenerationAfterError", {
+        activeGeneration,
+        event: pillDiagEvent(event),
+        error: error instanceof Error ? error.message : String(error),
+      });
       return;
     }
+    pillDiagLog("decryptError", {
+      activeGeneration,
+      event: pillDiagEvent(event),
+      error: error instanceof Error ? error.message : String(error),
+    });
     setConnectionState(
       "error",
       error instanceof Error
@@ -233,25 +316,44 @@ async function handleRelayObserverEvent(
 
 export function ensureRelayObserverSubscription() {
   if (unsubscribeRelay) {
+    pillDiagLog("ensure reuseOpenSubscription");
     return Promise.resolve();
   }
   if (startPromise) {
+    pillDiagLog("ensure reuseStartPromise");
     return startPromise;
   }
 
   const activeGeneration = generation;
+  pillDiagLog("ensure start", { activeGeneration });
   setConnectionState("connecting", null);
   startPromise = (async () => {
     const identity = await getIdentity();
+    pillDiagLog("subscribeToAgentObserverFrames start", {
+      activeGeneration,
+      identityPubkey: normalizePubkey(identity.pubkey),
+    });
     const unsubscribe = await subscribeToAgentObserverFrames(
       identity.pubkey,
       (event) => {
+        pillDiagLog("frame received", {
+          activeGeneration,
+          event: pillDiagEvent(event),
+        });
         eventProcessingQueue = eventProcessingQueue
           .then(() => handleRelayObserverEvent(event, activeGeneration))
           .catch((error) => {
             if (activeGeneration !== generation) {
+              pillDiagLog("drop staleGenerationInQueueCatch", {
+                activeGeneration,
+                error: error instanceof Error ? error.message : String(error),
+              });
               return;
             }
+            pillDiagLog("eventHandlingError", {
+              activeGeneration,
+              error: error instanceof Error ? error.message : String(error),
+            });
             setConnectionState(
               "error",
               error instanceof Error
@@ -262,13 +364,19 @@ export function ensureRelayObserverSubscription() {
       },
     );
     if (activeGeneration !== generation) {
+      pillDiagLog("subscribe resolved staleGeneration", { activeGeneration });
       await unsubscribe();
       return;
     }
     unsubscribeRelay = unsubscribe;
+    pillDiagLog("subscribe open", { activeGeneration });
     setConnectionState("open", null);
   })()
     .catch((error) => {
+      pillDiagLog("subscribe error", {
+        activeGeneration,
+        error: error instanceof Error ? error.message : String(error),
+      });
       if (activeGeneration === generation) {
         setConnectionState(
           "error",
@@ -279,6 +387,7 @@ export function ensureRelayObserverSubscription() {
       }
     })
     .finally(() => {
+      pillDiagLog("ensure finally", { activeGeneration });
       if (activeGeneration === generation) {
         startPromise = null;
       }
@@ -406,6 +515,7 @@ export function useManagedAgentObserverBridge(
   }, [subscriptionId, agentPubkeys]);
 
   React.useEffect(() => {
+    pillDiagLog("bridge activeEffect", { hasActiveAgent });
     if (!hasActiveAgent) {
       return;
     }
@@ -425,6 +535,7 @@ export function useManagedAgentObserverBridge(
 }
 
 export function resetAgentObserverStore() {
+  pillDiagLog("reset start", { nextGeneration: generation + 1 });
   generation += 1;
   const unsubscribe = unsubscribeRelay;
   unsubscribeRelay = null;
@@ -439,5 +550,6 @@ export function resetAgentObserverStore() {
   connectionState = "idle";
   errorMessage = null;
   notifyListeners();
+  pillDiagLog("reset afterClear", { hadUnsubscribe: Boolean(unsubscribe) });
   void unsubscribe?.();
 }

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -151,6 +151,16 @@ function pillDiagEvent(event: RelayEvent) {
   };
 }
 
+function pillDiagBridgeAgents(
+  agents: readonly Pick<ManagedAgent, "pubkey" | "status">[],
+) {
+  return agents.map((agent) => ({
+    pubkey: normalizePubkey(agent.pubkey),
+    status: agent.status,
+    startsObserver: agent.status === "running" || agent.status === "deployed",
+  }));
+}
+
 function notifyListeners() {
   for (const listener of listeners) {
     listener();
@@ -498,6 +508,12 @@ export function useManagedAgentObserverBridge(
       ),
     [agents],
   );
+
+  pillDiagLog("bridge render", {
+    subscriptionId,
+    hasActiveAgent,
+    agents: pillDiagBridgeAgents(agents),
+  });
 
   const agentPubkeys = React.useMemo(
     () => agents.map((agent) => agent.pubkey),

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -84,26 +84,17 @@ function registerKnownAgents(
   subscriptionId: string,
   pubkeys: readonly string[],
 ) {
-  const normalizedPubkeys = pubkeys.map((pubkey) => normalizePubkey(pubkey));
-  knownAgentsBySubscription.set(subscriptionId, new Set(normalizedPubkeys));
-  recomputeKnownAgentPubkeys();
-  pillDiagLog("registerKnownAgents", {
+  knownAgentsBySubscription.set(
     subscriptionId,
-    subscriptionPubkeys: pillDiagPubkeys(normalizedPubkeys),
-  });
+    new Set(pubkeys.map((pubkey) => normalizePubkey(pubkey))),
+  );
+  recomputeKnownAgentPubkeys();
 }
 
 function unregisterKnownAgents(subscriptionId: string) {
-  const removedPubkeys = knownAgentsBySubscription.get(subscriptionId);
-  const removed = knownAgentsBySubscription.delete(subscriptionId);
-  if (removed) {
+  if (knownAgentsBySubscription.delete(subscriptionId)) {
     recomputeKnownAgentPubkeys();
   }
-  pillDiagLog("unregisterKnownAgents", {
-    subscriptionId,
-    removed,
-    removedPubkeys: removedPubkeys ? pillDiagPubkeys(removedPubkeys) : [],
-  });
 }
 
 let connectionState: ConnectionState = "idle";
@@ -112,54 +103,6 @@ let unsubscribeRelay: (() => Promise<void>) | null = null;
 let startPromise: Promise<void> | null = null;
 let eventProcessingQueue: Promise<void> = Promise.resolve();
 let generation = 0;
-
-function pillDiagPubkeys(pubkeys: Iterable<string>) {
-  return [...pubkeys].map((pubkey) => normalizePubkey(pubkey)).sort();
-}
-
-function pillDiagState(extra: Record<string, unknown> = {}) {
-  return {
-    generation,
-    connectionState,
-    hasRelaySubscription: Boolean(unsubscribeRelay),
-    hasStartPromise: Boolean(startPromise),
-    knownAgentCount: knownAgentPubkeys.size,
-    knownAgents: pillDiagPubkeys(knownAgentPubkeys),
-    subscriptionCount: knownAgentsBySubscription.size,
-    subscriptionSizes: Object.fromEntries(
-      [...knownAgentsBySubscription.entries()].map(
-        ([subscriptionId, pubkeys]) => [subscriptionId, pubkeys.size],
-      ),
-    ),
-    at: new Date().toISOString(),
-    ...extra,
-  };
-}
-
-function pillDiagLog(label: string, extra: Record<string, unknown> = {}) {
-  console.log(`[pill-diag] observer ${label}`, pillDiagState(extra));
-}
-
-function pillDiagEvent(event: RelayEvent) {
-  const agentPubkey = observerTag(event, "agent");
-  return {
-    eventId: event.id,
-    eventPubkey: normalizePubkey(event.pubkey),
-    agentPubkey: agentPubkey ? normalizePubkey(agentPubkey) : null,
-    frame: observerTag(event, "frame"),
-    createdAt: event.created_at,
-  };
-}
-
-function pillDiagBridgeAgents(
-  agents: readonly Pick<ManagedAgent, "pubkey" | "status">[],
-) {
-  return agents.map((agent) => ({
-    pubkey: normalizePubkey(agent.pubkey),
-    status: agent.status,
-    startsObserver: agent.status === "running" || agent.status === "deployed",
-  }));
-}
 
 function notifyListeners() {
   for (const listener of listeners) {
@@ -248,52 +191,26 @@ async function handleRelayObserverEvent(
   const agentPubkey = observerTag(event, "agent");
   const frame = observerTag(event, "frame");
   if (!agentPubkey || frame !== "telemetry") {
-    pillDiagLog("drop nonTelemetryFrame", {
-      activeGeneration,
-      event: pillDiagEvent(event),
-    });
     return;
   }
 
   // Verify agent is known/trusted before decrypting.
   // Silently drop events from agents we are not managing.
   if (!knownAgentPubkeys.has(normalizePubkey(agentPubkey))) {
-    pillDiagLog("drop unknownAgent", {
-      activeGeneration,
-      event: pillDiagEvent(event),
-    });
     return;
   }
 
   // Defense-in-depth: verify the event sender matches the claimed agent pubkey.
   // The relay gates on is_agent_owner, but a compromised relay could misroute.
   if (normalizePubkey(event.pubkey) !== normalizePubkey(agentPubkey)) {
-    pillDiagLog("drop senderMismatch", {
-      activeGeneration,
-      event: pillDiagEvent(event),
-    });
     return;
   }
 
   try {
     const parsed = (await decryptObserverEvent(event)) as ObserverEvent;
     if (activeGeneration !== generation) {
-      pillDiagLog("drop staleGenerationAfterDecrypt", {
-        activeGeneration,
-        event: pillDiagEvent(event),
-        parsedKind: parsed.kind,
-        parsedSeq: parsed.seq,
-        parsedTimestamp: parsed.timestamp,
-      });
       return;
     }
-    pillDiagLog("appendFrame", {
-      activeGeneration,
-      event: pillDiagEvent(event),
-      parsedKind: parsed.kind,
-      parsedSeq: parsed.seq,
-      parsedTimestamp: parsed.timestamp,
-    });
     appendAgentEvent(agentPubkey, parsed);
     if (parsed.kind === "session_config_captured") {
       void putAgentSessionConfig(agentPubkey, parsed.payload);
@@ -303,18 +220,8 @@ async function handleRelayObserverEvent(
     }
   } catch (error) {
     if (activeGeneration !== generation) {
-      pillDiagLog("drop staleGenerationAfterError", {
-        activeGeneration,
-        event: pillDiagEvent(event),
-        error: error instanceof Error ? error.message : String(error),
-      });
       return;
     }
-    pillDiagLog("decryptError", {
-      activeGeneration,
-      event: pillDiagEvent(event),
-      error: error instanceof Error ? error.message : String(error),
-    });
     setConnectionState(
       "error",
       error instanceof Error
@@ -326,44 +233,25 @@ async function handleRelayObserverEvent(
 
 export function ensureRelayObserverSubscription() {
   if (unsubscribeRelay) {
-    pillDiagLog("ensure reuseOpenSubscription");
     return Promise.resolve();
   }
   if (startPromise) {
-    pillDiagLog("ensure reuseStartPromise");
     return startPromise;
   }
 
   const activeGeneration = generation;
-  pillDiagLog("ensure start", { activeGeneration });
   setConnectionState("connecting", null);
   startPromise = (async () => {
     const identity = await getIdentity();
-    pillDiagLog("subscribeToAgentObserverFrames start", {
-      activeGeneration,
-      identityPubkey: normalizePubkey(identity.pubkey),
-    });
     const unsubscribe = await subscribeToAgentObserverFrames(
       identity.pubkey,
       (event) => {
-        pillDiagLog("frame received", {
-          activeGeneration,
-          event: pillDiagEvent(event),
-        });
         eventProcessingQueue = eventProcessingQueue
           .then(() => handleRelayObserverEvent(event, activeGeneration))
           .catch((error) => {
             if (activeGeneration !== generation) {
-              pillDiagLog("drop staleGenerationInQueueCatch", {
-                activeGeneration,
-                error: error instanceof Error ? error.message : String(error),
-              });
               return;
             }
-            pillDiagLog("eventHandlingError", {
-              activeGeneration,
-              error: error instanceof Error ? error.message : String(error),
-            });
             setConnectionState(
               "error",
               error instanceof Error
@@ -374,19 +262,13 @@ export function ensureRelayObserverSubscription() {
       },
     );
     if (activeGeneration !== generation) {
-      pillDiagLog("subscribe resolved staleGeneration", { activeGeneration });
       await unsubscribe();
       return;
     }
     unsubscribeRelay = unsubscribe;
-    pillDiagLog("subscribe open", { activeGeneration });
     setConnectionState("open", null);
   })()
     .catch((error) => {
-      pillDiagLog("subscribe error", {
-        activeGeneration,
-        error: error instanceof Error ? error.message : String(error),
-      });
       if (activeGeneration === generation) {
         setConnectionState(
           "error",
@@ -397,7 +279,6 @@ export function ensureRelayObserverSubscription() {
       }
     })
     .finally(() => {
-      pillDiagLog("ensure finally", { activeGeneration });
       if (activeGeneration === generation) {
         startPromise = null;
       }
@@ -509,12 +390,6 @@ export function useManagedAgentObserverBridge(
     [agents],
   );
 
-  pillDiagLog("bridge render", {
-    subscriptionId,
-    hasActiveAgent,
-    agents: pillDiagBridgeAgents(agents),
-  });
-
   const agentPubkeys = React.useMemo(
     () => agents.map((agent) => agent.pubkey),
     [agents],
@@ -531,7 +406,6 @@ export function useManagedAgentObserverBridge(
   }, [subscriptionId, agentPubkeys]);
 
   React.useEffect(() => {
-    pillDiagLog("bridge activeEffect", { hasActiveAgent });
     if (!hasActiveAgent) {
       return;
     }
@@ -551,7 +425,6 @@ export function useManagedAgentObserverBridge(
 }
 
 export function resetAgentObserverStore() {
-  pillDiagLog("reset start", { nextGeneration: generation + 1 });
   generation += 1;
   const unsubscribe = unsubscribeRelay;
   unsubscribeRelay = null;
@@ -566,6 +439,5 @@ export function resetAgentObserverStore() {
   connectionState = "idle";
   errorMessage = null;
   notifyListeners();
-  pillDiagLog("reset afterClear", { hadUnsubscribe: Boolean(unsubscribe) });
   void unsubscribe?.();
 }

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
@@ -99,6 +99,28 @@ describe("getOwnedRelayWorkingAgents", () => {
       [],
     );
   });
+
+  it("drops relay agents with missing profiles or null owners", () => {
+    assert.deepEqual(
+      getOwnedRelayWorkingAgents(
+        [
+          { pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia" },
+          { pubkey: "ownerless-agent", name: "ralph" },
+        ],
+        {
+          "ownerless-agent": {
+            displayName: "ralph",
+            avatarUrl: null,
+            nip05Handle: null,
+            ownerPubkey: null,
+            isAgent: true,
+          },
+        },
+        VIEWER_PUBKEY,
+      ),
+      [],
+    );
+  });
 });
 
 describe("mergeWorkingAgents", () => {

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
@@ -1,10 +1,19 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { resolveActiveWorkingChannelNames } from "./useActiveWorkingChannelsById.ts";
+import {
+  getOwnedRelayWorkingAgents,
+  mergeWorkingAgents,
+  resolveActiveWorkingChannelNames,
+} from "./useActiveWorkingChannelsById.ts";
+
+const VIEWER_PUBKEY =
+  "80c5f18be5aafa62cf6198c6335963ba3306b595288117c8ea2f805fc9bdc94a";
+const OWNED_RELAY_AGENT_PUBKEY =
+  "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00";
 
 describe("resolveActiveWorkingChannelNames", () => {
-  it("resolves active agent pubkeys to managed agent names", () => {
+  it("resolves active agent pubkeys to working agent names", () => {
     const resolved = resolveActiveWorkingChannelNames(
       {
         channelId: "chan-1",
@@ -33,5 +42,83 @@ describe("resolveActiveWorkingChannelNames", () => {
     );
 
     assert.deepEqual(resolved.agentNames, ["Ned"]);
+  });
+
+  it("resolves owned relay agent names", () => {
+    const resolved = resolveActiveWorkingChannelNames(
+      {
+        channelId: "chan-1",
+        anchorAt: 0,
+        agentCount: 1,
+        agentPubkeys: [OWNED_RELAY_AGENT_PUBKEY.toUpperCase()],
+      },
+      [{ pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia" }],
+    );
+
+    assert.deepEqual(resolved.agentNames, ["nadia"]);
+  });
+});
+
+describe("getOwnedRelayWorkingAgents", () => {
+  it("keeps relay agents whose NIP-OA owner is the current viewer", () => {
+    assert.deepEqual(
+      getOwnedRelayWorkingAgents(
+        [
+          { pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia" },
+          { pubkey: "other-agent", name: "nelson" },
+        ],
+        {
+          [OWNED_RELAY_AGENT_PUBKEY]: {
+            displayName: "nadia",
+            avatarUrl: null,
+            nip05Handle: null,
+            ownerPubkey: VIEWER_PUBKEY.toUpperCase(),
+            isAgent: true,
+          },
+          "other-agent": {
+            displayName: "nelson",
+            avatarUrl: null,
+            nip05Handle: null,
+            ownerPubkey: "someone-else",
+            isAgent: true,
+          },
+        },
+        VIEWER_PUBKEY,
+      ),
+      [{ pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia", status: "deployed" }],
+    );
+  });
+
+  it("returns no relay agents without a current viewer", () => {
+    assert.deepEqual(
+      getOwnedRelayWorkingAgents(
+        [{ pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia" }],
+        {},
+        undefined,
+      ),
+      [],
+    );
+  });
+});
+
+describe("mergeWorkingAgents", () => {
+  it("dedupes owned relay agents behind locally managed agents", () => {
+    assert.deepEqual(
+      mergeWorkingAgents(
+        [{ pubkey: "AAAA", name: "Ned", status: "running" }],
+        [
+          { pubkey: "aaaa", name: "Relay Ned", status: "deployed" },
+          {
+            pubkey: OWNED_RELAY_AGENT_PUBKEY,
+            name: "nadia",
+            status: "deployed",
+          },
+        ],
+      ),
+      [
+        { pubkey: "AAAA", name: "Ned", status: "running" },
+        { pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia", status: "deployed" },
+      ],
+    );
   });
 });

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
@@ -124,7 +124,7 @@ describe("getOwnedRelayWorkingAgents", () => {
 });
 
 describe("mergeWorkingAgents", () => {
-  it("dedupes owned relay agents behind locally managed agents", () => {
+  it("keeps active managed agents ahead of owned relay duplicates", () => {
     assert.deepEqual(
       mergeWorkingAgents(
         [{ pubkey: "AAAA", name: "Ned", status: "running" }],
@@ -141,6 +141,28 @@ describe("mergeWorkingAgents", () => {
         { pubkey: "AAAA", name: "Ned", status: "running" },
         { pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia", status: "deployed" },
       ],
+    );
+  });
+
+  it("uses owned relay status when a duplicate managed agent is stopped", () => {
+    assert.deepEqual(
+      mergeWorkingAgents(
+        [
+          {
+            pubkey: OWNED_RELAY_AGENT_PUBKEY.toUpperCase(),
+            name: "Local Nadia",
+            status: "stopped",
+          },
+        ],
+        [
+          {
+            pubkey: OWNED_RELAY_AGENT_PUBKEY,
+            name: "nadia",
+            status: "deployed",
+          },
+        ],
+      ),
+      [{ pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia", status: "deployed" }],
     );
   });
 });

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -5,16 +5,32 @@ import {
   useActiveAgentTurnsBridge,
   useActiveAgentTurnsByChannel,
 } from "@/features/agents/activeAgentTurnsStore";
-import { useManagedAgentsQuery } from "@/features/agents/hooks";
+import {
+  useManagedAgentsQuery,
+  useRelayAgentsQuery,
+} from "@/features/agents/hooks";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type {
+  ManagedAgent,
+  RelayAgent,
+  UserProfileSummary,
+} from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+
+type WorkingAgentName = Pick<ManagedAgent, "pubkey" | "name">;
+type WorkingAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
+type OwnedRelayWorkingAgent = Pick<RelayAgent, "pubkey" | "name"> & {
+  status: "deployed";
+};
 
 export function resolveActiveWorkingChannelNames(
   summary: ActiveChannelTurnSummary,
-  managedAgents: readonly { pubkey: string; name: string }[],
+  workingAgents: readonly WorkingAgentName[],
 ): ActiveChannelTurnSummary {
   const namesByPubkey = new Map(
-    managedAgents.map((agent) => [normalizePubkey(agent.pubkey), agent.name]),
+    workingAgents.map((agent) => [normalizePubkey(agent.pubkey), agent.name]),
   );
 
   return {
@@ -26,18 +42,81 @@ export function resolveActiveWorkingChannelNames(
   };
 }
 
+export function getOwnedRelayWorkingAgents(
+  relayAgents: readonly Pick<RelayAgent, "pubkey" | "name">[],
+  profiles: Record<string, UserProfileSummary> | undefined,
+  currentPubkey: string | undefined,
+): OwnedRelayWorkingAgent[] {
+  if (!currentPubkey) return [];
+
+  const normalizedCurrentPubkey = normalizePubkey(currentPubkey);
+  return relayAgents.flatMap((agent) => {
+    const profile = profiles?.[normalizePubkey(agent.pubkey)];
+    if (!profile?.ownerPubkey) return [];
+    if (normalizePubkey(profile.ownerPubkey) !== normalizedCurrentPubkey) {
+      return [];
+    }
+
+    return [{ pubkey: agent.pubkey, name: agent.name, status: "deployed" }];
+  });
+}
+
+export function mergeWorkingAgents(
+  managedAgents: readonly WorkingAgent[],
+  ownedRelayAgents: readonly WorkingAgent[],
+): WorkingAgent[] {
+  const seenPubkeys = new Set<string>();
+  const merged: WorkingAgent[] = [];
+
+  for (const agent of [...managedAgents, ...ownedRelayAgents]) {
+    const pubkey = normalizePubkey(agent.pubkey);
+    if (seenPubkeys.has(pubkey)) continue;
+    seenPubkeys.add(pubkey);
+    merged.push(agent);
+  }
+
+  return merged;
+}
+
 export function useActiveWorkingChannelsById(): ReadonlyMap<
   string,
   ActiveChannelTurnSummary
 > {
+  const identityQuery = useIdentityQuery();
+  const currentPubkey = identityQuery.data?.pubkey;
   const managedAgentsQuery = useManagedAgentsQuery();
   const managedAgents = React.useMemo(
     () => managedAgentsQuery.data ?? [],
     [managedAgentsQuery.data],
   );
+  const relayAgentsQuery = useRelayAgentsQuery();
+  const relayAgents = React.useMemo(
+    () => relayAgentsQuery.data ?? [],
+    [relayAgentsQuery.data],
+  );
+  const relayAgentPubkeys = React.useMemo(
+    () => relayAgents.map((agent) => agent.pubkey),
+    [relayAgents],
+  );
+  const relayAgentProfilesQuery = useUsersBatchQuery(relayAgentPubkeys, {
+    enabled: relayAgentPubkeys.length > 0,
+  });
+  const ownedRelayAgents = React.useMemo(
+    () =>
+      getOwnedRelayWorkingAgents(
+        relayAgents,
+        relayAgentProfilesQuery.data?.profiles,
+        currentPubkey,
+      ),
+    [currentPubkey, relayAgentProfilesQuery.data?.profiles, relayAgents],
+  );
+  const workingAgents = React.useMemo(
+    () => mergeWorkingAgents(managedAgents, ownedRelayAgents),
+    [managedAgents, ownedRelayAgents],
+  );
 
-  useManagedAgentObserverBridge(managedAgents);
-  useActiveAgentTurnsBridge(managedAgents);
+  useManagedAgentObserverBridge(workingAgents);
+  useActiveAgentTurnsBridge(workingAgents);
 
   const activeWorkingChannels = useActiveAgentTurnsByChannel();
   return React.useMemo(
@@ -46,11 +125,11 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
         activeWorkingChannels.map((summary) => {
           const resolvedSummary = resolveActiveWorkingChannelNames(
             summary,
-            managedAgents,
+            workingAgents,
           );
           return [resolvedSummary.channelId, resolvedSummary];
         }),
       ),
-    [activeWorkingChannels, managedAgents],
+    [activeWorkingChannels, workingAgents],
   );
 }

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -22,6 +22,9 @@ import { normalizePubkey } from "@/shared/lib/pubkey";
 
 type WorkingAgentName = Pick<ManagedAgent, "pubkey" | "name">;
 type WorkingAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
+type PillDiagProfile = UserProfileSummary & {
+  pubkey?: string;
+};
 type OwnedRelayWorkingAgent = Pick<RelayAgent, "pubkey" | "name"> & {
   status: "deployed";
 };
@@ -85,6 +88,86 @@ export function mergeWorkingAgents(
   return [...mergedByPubkey.values()];
 }
 
+function summarizeAgent(agent: WorkingAgentName & { status?: string }) {
+  return {
+    pubkey: normalizePubkey(agent.pubkey),
+    name: agent.name,
+    status: agent.status ?? null,
+  };
+}
+
+function summarizeRelayProfile(
+  pubkey: string,
+  profile: PillDiagProfile | undefined,
+  currentPubkey: string | undefined,
+) {
+  return {
+    pubkey: normalizePubkey(pubkey),
+    profileKeyPubkey: profile?.pubkey ? normalizePubkey(profile.pubkey) : null,
+    displayName: profile?.displayName ?? null,
+    isAgent: profile?.isAgent ?? null,
+    ownerPubkey: profile?.ownerPubkey
+      ? normalizePubkey(profile.ownerPubkey)
+      : null,
+    ownsAuthorAgent: ownsAuthorAgent(profile, currentPubkey),
+  };
+}
+
+function logPillDiagnostics({
+  currentPubkey,
+  managedAgents,
+  relayAgents,
+  profiles,
+  ownedRelayAgents,
+  workingAgents,
+  activeWorkingChannels,
+}: {
+  currentPubkey: string | undefined;
+  managedAgents: readonly WorkingAgent[];
+  relayAgents: readonly Pick<RelayAgent, "pubkey" | "name">[];
+  profiles: Record<string, UserProfileSummary> | undefined;
+  ownedRelayAgents: readonly WorkingAgent[];
+  workingAgents: readonly WorkingAgent[];
+  activeWorkingChannels: readonly ActiveChannelTurnSummary[];
+}) {
+  const normalizedProfiles = Object.fromEntries(
+    relayAgents.map((agent) => {
+      const pubkey = normalizePubkey(agent.pubkey);
+      const profile = profiles?.[pubkey] as PillDiagProfile | undefined;
+      return [
+        pubkey,
+        summarizeRelayProfile(agent.pubkey, profile, currentPubkey),
+      ];
+    }),
+  );
+
+  console.groupCollapsed("[pill-diag] active working channels inputs", {
+    currentPubkey: currentPubkey ? normalizePubkey(currentPubkey) : null,
+    managedAgentCount: managedAgents.length,
+    relayAgentCount: relayAgents.length,
+    ownedRelayAgentCount: ownedRelayAgents.length,
+    workingAgentCount: workingAgents.length,
+    activeChannelCount: activeWorkingChannels.length,
+  });
+  console.log("[pill-diag] currentPubkey", {
+    currentPubkey: currentPubkey ? normalizePubkey(currentPubkey) : null,
+  });
+  console.table(managedAgents.map(summarizeAgent));
+  console.log("[pill-diag] managedAgents", managedAgents.map(summarizeAgent));
+  console.table(relayAgents.map(summarizeAgent));
+  console.log("[pill-diag] relayAgents", relayAgents.map(summarizeAgent));
+  console.log("[pill-diag] profilesByRelayAgent", normalizedProfiles);
+  console.table(ownedRelayAgents.map(summarizeAgent));
+  console.log(
+    "[pill-diag] ownedRelayAgents",
+    ownedRelayAgents.map(summarizeAgent),
+  );
+  console.table(workingAgents.map(summarizeAgent));
+  console.log("[pill-diag] workingAgents", workingAgents.map(summarizeAgent));
+  console.log("[pill-diag] activeWorkingChannels", activeWorkingChannels);
+  console.groupEnd();
+}
+
 export function useActiveWorkingChannelsById(): ReadonlyMap<
   string,
   ActiveChannelTurnSummary
@@ -126,6 +209,26 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
   useActiveAgentTurnsBridge(workingAgents);
 
   const activeWorkingChannels = useActiveAgentTurnsByChannel();
+
+  React.useEffect(() => {
+    logPillDiagnostics({
+      currentPubkey,
+      managedAgents,
+      relayAgents,
+      profiles: relayAgentProfilesQuery.data?.profiles,
+      ownedRelayAgents,
+      workingAgents,
+      activeWorkingChannels,
+    });
+  }, [
+    activeWorkingChannels,
+    currentPubkey,
+    managedAgents,
+    ownedRelayAgents,
+    relayAgentProfilesQuery.data?.profiles,
+    relayAgents,
+    workingAgents,
+  ]);
 
   return React.useMemo(
     () =>

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -11,6 +11,7 @@ import {
 } from "@/features/agents/hooks";
 import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { ownsAuthorAgent } from "@/features/profile/lib/identity";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import type {
   ManagedAgent,
@@ -49,11 +50,9 @@ export function getOwnedRelayWorkingAgents(
 ): OwnedRelayWorkingAgent[] {
   if (!currentPubkey) return [];
 
-  const normalizedCurrentPubkey = normalizePubkey(currentPubkey);
   return relayAgents.flatMap((agent) => {
     const profile = profiles?.[normalizePubkey(agent.pubkey)];
-    if (!profile?.ownerPubkey) return [];
-    if (normalizePubkey(profile.ownerPubkey) !== normalizedCurrentPubkey) {
+    if (!ownsAuthorAgent(profile, currentPubkey)) {
       return [];
     }
 

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -22,6 +22,9 @@ import { normalizePubkey } from "@/shared/lib/pubkey";
 
 type WorkingAgentName = Pick<ManagedAgent, "pubkey" | "name">;
 type WorkingAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
+type PillDiagProfile = UserProfileSummary & {
+  pubkey?: string;
+};
 type OwnedRelayWorkingAgent = Pick<RelayAgent, "pubkey" | "name"> & {
   status: "deployed";
 };
@@ -77,6 +80,86 @@ export function mergeWorkingAgents(
   return merged;
 }
 
+function summarizeAgent(agent: WorkingAgentName & { status?: string }) {
+  return {
+    pubkey: normalizePubkey(agent.pubkey),
+    name: agent.name,
+    status: agent.status ?? null,
+  };
+}
+
+function summarizeRelayProfile(
+  pubkey: string,
+  profile: PillDiagProfile | undefined,
+  currentPubkey: string | undefined,
+) {
+  return {
+    pubkey: normalizePubkey(pubkey),
+    profileKeyPubkey: profile?.pubkey ? normalizePubkey(profile.pubkey) : null,
+    displayName: profile?.displayName ?? null,
+    isAgent: profile?.isAgent ?? null,
+    ownerPubkey: profile?.ownerPubkey
+      ? normalizePubkey(profile.ownerPubkey)
+      : null,
+    ownsAuthorAgent: ownsAuthorAgent(profile, currentPubkey),
+  };
+}
+
+function logPillDiagnostics({
+  currentPubkey,
+  managedAgents,
+  relayAgents,
+  profiles,
+  ownedRelayAgents,
+  workingAgents,
+  activeWorkingChannels,
+}: {
+  currentPubkey: string | undefined;
+  managedAgents: readonly WorkingAgent[];
+  relayAgents: readonly Pick<RelayAgent, "pubkey" | "name">[];
+  profiles: Record<string, UserProfileSummary> | undefined;
+  ownedRelayAgents: readonly WorkingAgent[];
+  workingAgents: readonly WorkingAgent[];
+  activeWorkingChannels: readonly ActiveChannelTurnSummary[];
+}) {
+  const normalizedProfiles = Object.fromEntries(
+    relayAgents.map((agent) => {
+      const pubkey = normalizePubkey(agent.pubkey);
+      const profile = profiles?.[pubkey] as PillDiagProfile | undefined;
+      return [
+        pubkey,
+        summarizeRelayProfile(agent.pubkey, profile, currentPubkey),
+      ];
+    }),
+  );
+
+  console.groupCollapsed("[pill-diag] active working channels inputs", {
+    currentPubkey: currentPubkey ? normalizePubkey(currentPubkey) : null,
+    managedAgentCount: managedAgents.length,
+    relayAgentCount: relayAgents.length,
+    ownedRelayAgentCount: ownedRelayAgents.length,
+    workingAgentCount: workingAgents.length,
+    activeChannelCount: activeWorkingChannels.length,
+  });
+  console.log("[pill-diag] currentPubkey", {
+    currentPubkey: currentPubkey ? normalizePubkey(currentPubkey) : null,
+  });
+  console.table(managedAgents.map(summarizeAgent));
+  console.log("[pill-diag] managedAgents", managedAgents.map(summarizeAgent));
+  console.table(relayAgents.map(summarizeAgent));
+  console.log("[pill-diag] relayAgents", relayAgents.map(summarizeAgent));
+  console.log("[pill-diag] profilesByRelayAgent", normalizedProfiles);
+  console.table(ownedRelayAgents.map(summarizeAgent));
+  console.log(
+    "[pill-diag] ownedRelayAgents",
+    ownedRelayAgents.map(summarizeAgent),
+  );
+  console.table(workingAgents.map(summarizeAgent));
+  console.log("[pill-diag] workingAgents", workingAgents.map(summarizeAgent));
+  console.log("[pill-diag] activeWorkingChannels", activeWorkingChannels);
+  console.groupEnd();
+}
+
 export function useActiveWorkingChannelsById(): ReadonlyMap<
   string,
   ActiveChannelTurnSummary
@@ -118,6 +201,27 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
   useActiveAgentTurnsBridge(workingAgents);
 
   const activeWorkingChannels = useActiveAgentTurnsByChannel();
+
+  React.useEffect(() => {
+    logPillDiagnostics({
+      currentPubkey,
+      managedAgents,
+      relayAgents,
+      profiles: relayAgentProfilesQuery.data?.profiles,
+      ownedRelayAgents,
+      workingAgents,
+      activeWorkingChannels,
+    });
+  }, [
+    activeWorkingChannels,
+    currentPubkey,
+    managedAgents,
+    ownedRelayAgents,
+    relayAgentProfilesQuery.data?.profiles,
+    relayAgents,
+    workingAgents,
+  ]);
+
   return React.useMemo(
     () =>
       new Map(

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -20,6 +20,12 @@ import type {
 } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
+console.log("[pill-diag] module loaded", {
+  loadedAt: new Date().toISOString(),
+});
+
+let pillDiagRenderCount = 0;
+
 type WorkingAgentName = Pick<ManagedAgent, "pubkey" | "name">;
 type WorkingAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
 type PillDiagProfile = UserProfileSummary & {
@@ -164,6 +170,12 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
   string,
   ActiveChannelTurnSummary
 > {
+  pillDiagRenderCount += 1;
+  console.log("[pill-diag] hook render", {
+    renderCount: pillDiagRenderCount,
+    renderedAt: new Date().toISOString(),
+  });
+
   const identityQuery = useIdentityQuery();
   const currentPubkey = identityQuery.data?.pubkey;
   const managedAgentsQuery = useManagedAgentsQuery();

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -20,17 +20,8 @@ import type {
 } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
-console.log("[pill-diag] module loaded", {
-  loadedAt: new Date().toISOString(),
-});
-
-let pillDiagRenderCount = 0;
-
 type WorkingAgentName = Pick<ManagedAgent, "pubkey" | "name">;
 type WorkingAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
-type PillDiagProfile = UserProfileSummary & {
-  pubkey?: string;
-};
 type OwnedRelayWorkingAgent = Pick<RelayAgent, "pubkey" | "name"> & {
   status: "deployed";
 };
@@ -69,113 +60,35 @@ export function getOwnedRelayWorkingAgents(
   });
 }
 
+function agentCanStartObserver(agent: WorkingAgent) {
+  return agent.status === "running" || agent.status === "deployed";
+}
+
 export function mergeWorkingAgents(
   managedAgents: readonly WorkingAgent[],
   ownedRelayAgents: readonly WorkingAgent[],
 ): WorkingAgent[] {
-  const seenPubkeys = new Set<string>();
-  const merged: WorkingAgent[] = [];
+  const mergedByPubkey = new Map<string, WorkingAgent>();
 
-  for (const agent of [...managedAgents, ...ownedRelayAgents]) {
-    const pubkey = normalizePubkey(agent.pubkey);
-    if (seenPubkeys.has(pubkey)) continue;
-    seenPubkeys.add(pubkey);
-    merged.push(agent);
+  for (const agent of managedAgents) {
+    mergedByPubkey.set(normalizePubkey(agent.pubkey), agent);
   }
 
-  return merged;
-}
+  for (const agent of ownedRelayAgents) {
+    const pubkey = normalizePubkey(agent.pubkey);
+    const managedAgent = mergedByPubkey.get(pubkey);
+    if (!managedAgent || !agentCanStartObserver(managedAgent)) {
+      mergedByPubkey.set(pubkey, agent);
+    }
+  }
 
-function summarizeAgent(agent: WorkingAgentName & { status?: string }) {
-  return {
-    pubkey: normalizePubkey(agent.pubkey),
-    name: agent.name,
-    status: agent.status ?? null,
-  };
-}
-
-function summarizeRelayProfile(
-  pubkey: string,
-  profile: PillDiagProfile | undefined,
-  currentPubkey: string | undefined,
-) {
-  return {
-    pubkey: normalizePubkey(pubkey),
-    profileKeyPubkey: profile?.pubkey ? normalizePubkey(profile.pubkey) : null,
-    displayName: profile?.displayName ?? null,
-    isAgent: profile?.isAgent ?? null,
-    ownerPubkey: profile?.ownerPubkey
-      ? normalizePubkey(profile.ownerPubkey)
-      : null,
-    ownsAuthorAgent: ownsAuthorAgent(profile, currentPubkey),
-  };
-}
-
-function logPillDiagnostics({
-  currentPubkey,
-  managedAgents,
-  relayAgents,
-  profiles,
-  ownedRelayAgents,
-  workingAgents,
-  activeWorkingChannels,
-}: {
-  currentPubkey: string | undefined;
-  managedAgents: readonly WorkingAgent[];
-  relayAgents: readonly Pick<RelayAgent, "pubkey" | "name">[];
-  profiles: Record<string, UserProfileSummary> | undefined;
-  ownedRelayAgents: readonly WorkingAgent[];
-  workingAgents: readonly WorkingAgent[];
-  activeWorkingChannels: readonly ActiveChannelTurnSummary[];
-}) {
-  const normalizedProfiles = Object.fromEntries(
-    relayAgents.map((agent) => {
-      const pubkey = normalizePubkey(agent.pubkey);
-      const profile = profiles?.[pubkey] as PillDiagProfile | undefined;
-      return [
-        pubkey,
-        summarizeRelayProfile(agent.pubkey, profile, currentPubkey),
-      ];
-    }),
-  );
-
-  console.groupCollapsed("[pill-diag] active working channels inputs", {
-    currentPubkey: currentPubkey ? normalizePubkey(currentPubkey) : null,
-    managedAgentCount: managedAgents.length,
-    relayAgentCount: relayAgents.length,
-    ownedRelayAgentCount: ownedRelayAgents.length,
-    workingAgentCount: workingAgents.length,
-    activeChannelCount: activeWorkingChannels.length,
-  });
-  console.log("[pill-diag] currentPubkey", {
-    currentPubkey: currentPubkey ? normalizePubkey(currentPubkey) : null,
-  });
-  console.table(managedAgents.map(summarizeAgent));
-  console.log("[pill-diag] managedAgents", managedAgents.map(summarizeAgent));
-  console.table(relayAgents.map(summarizeAgent));
-  console.log("[pill-diag] relayAgents", relayAgents.map(summarizeAgent));
-  console.log("[pill-diag] profilesByRelayAgent", normalizedProfiles);
-  console.table(ownedRelayAgents.map(summarizeAgent));
-  console.log(
-    "[pill-diag] ownedRelayAgents",
-    ownedRelayAgents.map(summarizeAgent),
-  );
-  console.table(workingAgents.map(summarizeAgent));
-  console.log("[pill-diag] workingAgents", workingAgents.map(summarizeAgent));
-  console.log("[pill-diag] activeWorkingChannels", activeWorkingChannels);
-  console.groupEnd();
+  return [...mergedByPubkey.values()];
 }
 
 export function useActiveWorkingChannelsById(): ReadonlyMap<
   string,
   ActiveChannelTurnSummary
 > {
-  pillDiagRenderCount += 1;
-  console.log("[pill-diag] hook render", {
-    renderCount: pillDiagRenderCount,
-    renderedAt: new Date().toISOString(),
-  });
-
   const identityQuery = useIdentityQuery();
   const currentPubkey = identityQuery.data?.pubkey;
   const managedAgentsQuery = useManagedAgentsQuery();
@@ -213,26 +126,6 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
   useActiveAgentTurnsBridge(workingAgents);
 
   const activeWorkingChannels = useActiveAgentTurnsByChannel();
-
-  React.useEffect(() => {
-    logPillDiagnostics({
-      currentPubkey,
-      managedAgents,
-      relayAgents,
-      profiles: relayAgentProfilesQuery.data?.profiles,
-      ownedRelayAgents,
-      workingAgents,
-      activeWorkingChannels,
-    });
-  }, [
-    activeWorkingChannels,
-    currentPubkey,
-    managedAgents,
-    ownedRelayAgents,
-    relayAgentProfilesQuery.data?.profiles,
-    relayAgents,
-    workingAgents,
-  ]);
 
   return React.useMemo(
     () =>


### PR DESCRIPTION
## What

The sidebar "working" pill currently only lights for agents the **local build manages**. This makes it light for **any agent the viewer OWNS** (declared NIP-OA owner), regardless of which machine hosts it — matching the `viewerIsOwner` signal used everywhere else in the UI. Before this change, an owned-but-remote agent showed no pill.

## How

A single-site change in the sidebar working-pill bridge (`desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts`):

- `getOwnedRelayWorkingAgents` collects relay agents whose profile `ownerPubkey` matches the current viewer (normalized, case-insensitive — same rule as `viewerIsOwner` at `MembersSidebar.tsx:581`).
- `mergeWorkingAgents` merges those owned-remote agents with locally-managed agents as `status: "deployed"` and feeds the merged set into the existing observer + active-turn bridges. Managed agents win duplicate pubkeys (managed-first, case-insensitive `seenPubkeys`).
- The tooltip name resolver is extended so owned-remote agents resolve to names, not just counts.

### Why the relay posture is preserved (not loosened where it matters)

- The relay subscription is already ownership-keyed: `#p:[identity.pubkey]` with server-side `is_agent_owner`. A viewer only ever *receives* observer frames for agents the relay has already confirmed they own.
- The two client gates that suppressed the pill (`hasActiveAgent` start-gate, `knownAgentPubkeys` frame-trust set) were a strictly-narrower local-custody filter layered on top. This re-keys them to declared ownership so the client matches the relay's existing ownership scope — it grants no access to anything the relay wouldn't already stream.
- A forged profile claiming `ownerPubkey === you` adds a pubkey to the trust set, but no frames arrive unless the relay actually streams them (real ownership required), and the `sender == agent` defense-in-depth check (observerRelayStore) is **untouched**. A client-side profile claim cannot manufacture telemetry access.
- Blast radius: **exactly 2 files**, both in `sidebar/lib`. `observerRelayStore.ts`, `ChannelScreen.tsx`, and the profile panel are untouched.

## Tests

- `getOwnedRelayWorkingAgents` / `mergeWorkingAgents` unit coverage: owner-match, non-owned drop, no-viewer empty, case-insensitive dedupe (managed wins), owned-relay name resolution, and the ownerless-relay-agent guard (missing profile in batch + `ownerPubkey: null` both drop to `[]`).
- `biome check .` green, `pnpm --dir desktop typecheck` green, full desktop suite **1393 / 0 failures** (sidebar + agents slice green incl. the new helper tests).

## Follow-up (not in this PR)

- No end-to-end proof the pill actually lights. The mechanism is verified by trace + unit tests, and the `OWNED_RELAY_AGENT_PUBKEY` fixture exists, but seeding an observer *working frame* for an owned-remote agent and asserting the pill appears would require building an observer-frame seed harness that doesn't exist yet. Disproportionate here; worth a follow-up e2e someday.

## Rollback

Revert the implementation commit — both bridges fall back to `managedAgents`.

Co-authored-by: Taylor Ho <taylorkmho@gmail.com>
Signed-off-by: Taylor Ho <taylorkmho@gmail.com>
