### PR TITLE
fix(deps): pin aws-creds to fork with EKS Pod Identity support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,8 +397,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "aws-creds"
 version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3b85155d265df828f84e53886ed9e427aed979dd8a39f5b8b2162c77e142d7"
+source = "git+https://github.com/tlongwell-block/rust-s3?rev=c9fce3620dd434c1f810101d672cf384268dbb0f#c9fce3620dd434c1f810101d672cf384268dbb0f"
 dependencies = [
  "attohttpc",
  "home",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,3 +148,12 @@ lto = "fat"
 codegen-units = 1
 panic = "abort"
 strip = true
+
+# Temporary fork pin: aws-creds 0.39.1 (via rust-s3) cannot read EKS Pod Identity
+# credentials (AWS_CONTAINER_CREDENTIALS_FULL_URI + AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE),
+# which the relay pod on bb-block requires for S3 media + git storage. This pins
+# aws-creds to a fork that adopts the aws-creds portion of durch/rust-s3#449
+# (FULL_URI + token-file + Authorization header, refresh-safe, with a loopback
+# allowlist for the auth token). Revert to crates.io once #449 lands upstream.
+[patch.crates-io]
+aws-creds = { git = "https://github.com/tlongwell-block/rust-s3", rev = "c9fce3620dd434c1f810101d672cf384268dbb0f" }


### PR DESCRIPTION
Follow-up to #1417 (Redis TLS) — the second blocker on the bb-block relay deploy.

## Problem
After the Redis TLS fix, the relay pod on bb-block failed with:
```
failed to initialize media storage: Could not get valid credentials
```
The pod authenticates to S3 via **EKS Pod Identity** (`AWS_CONTAINER_CREDENTIALS_FULL_URI` + `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`). But `aws-creds` 0.39.1 — pulled transitively via `rust-s3` 0.37.2 — only reads the ECS `RELATIVE_URI` form, hardcodes the ECS endpoint, and sends no `Authorization` header. So it never gets creds for either S3 media **or** git CAS storage. Wren independently confirmed buzz is correctly onboarded to Pod Identity (cluster app-service standard), so the fix belongs in the creds layer, not infra.

## Fix
Pin `aws-creds` to [`tlongwell-block/rust-s3@c9fce362`](https://github.com/tlongwell-block/rust-s3/commit/c9fce3620dd434c1f810101d672cf384268dbb0f), which adopts the **aws-creds portion** of upstream [`durch/rust-s3#449`](https://github.com/durch/rust-s3/pull/449):
- Falls through to `AWS_CONTAINER_CREDENTIALS_FULL_URI` when `RELATIVE_URI` is absent.
- Reads the bearer token from `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` (then `AWS_CONTAINER_AUTHORIZATION_TOKEN`) and sends it as `Authorization`.
- **Refresh-safe:** sets `expiration` from the response, so rust-s3's auto-`refresh()` re-fetches on token expiry rather than silently 403ing after ~6h.
- **Security allowlist:** the auth token is only sent to the documented Pod Identity loopback addresses (`169.254.170.23` / `[fd00:ec2::23]`) over http/https; token-file read fails loud (no silent env fallback).

## Scope (minimal)
- `[patch.crates-io]` redirects **only** `aws-creds`. `rust-s3` stays on crates.io 0.37.2; no S3 call sites and no git CAS logic change.
- `Cargo.lock` delta is exactly one line (aws-creds source).
- **Temporary pin** — a personal OSS fork used for test-then-upstream (per Tyler). Revert to crates.io once #449 lands; if it stalls into a long-lived prod dep, move the fork to a Block-managed org.

## Human review
This adopts an upstream PR that had only bot review. Wren + I reviewed the full diff together (refresh safety, the allowlist, error mapping) — see thread. We are the human review it lacked.

## Verification
- `cargo build -p buzz-media -p buzz-relay` — clean against the fork.
- `cargo test -p buzz-media` — 42 passed (MinIO round-trip ignored, needs live MinIO).
- `cargo test -p buzz-relay` — 429 passed, 0 failed, incl. the git-CAS unit tests (2 live-S3 probes env-gated behind `BUZZ_GIT_S3_PROBE=1`).
- Live media + git S3 round-trip and a token-refresh survival check will be verified on-cluster after the image ships.