### PR TITLE
Tighten sidebar section actions

### DIFF
--- a/desktop/src/features/sidebar/lib/channelSectionsStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSectionsStorage.test.mjs
@@ -48,6 +48,18 @@ test("parseChannelSectionPayload: valid complete payload returns correct store",
   });
 });
 
+test("parseChannelSectionPayload: preserves optional section icons", () => {
+  const payload = {
+    version: 1,
+    sections: [{ id: "s1", name: "Work", icon: ":sparkles:", order: 0 }],
+    assignments: {},
+  };
+  const result = parseChannelSectionPayload(payload);
+  assert.deepEqual(result?.sections, [
+    { id: "s1", name: "Work", icon: ":sparkles:", order: 0 },
+  ]);
+});
+
 test("parseChannelSectionPayload: null input returns null", () => {
   assert.equal(parseChannelSectionPayload(null), null);
 });

--- a/desktop/src/features/sidebar/lib/channelSectionsStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelSectionsStorage.ts
@@ -3,6 +3,7 @@ const STORAGE_KEY_PREFIX = "buzz-channel-sections.v1";
 export type ChannelSection = {
   id: string;
   name: string;
+  icon?: string;
   order: number;
 };
 
@@ -40,14 +41,29 @@ export function parseChannelSectionPayload(
   if (typeof json !== "object" || json === null) return null;
   const obj = json as Record<string, unknown>;
   const sections: ChannelSection[] = Array.isArray(obj.sections)
-    ? obj.sections.filter(
-        (entry: unknown): entry is ChannelSection =>
-          typeof entry === "object" &&
-          entry !== null &&
-          typeof (entry as Record<string, unknown>).id === "string" &&
-          typeof (entry as Record<string, unknown>).name === "string" &&
-          typeof (entry as Record<string, unknown>).order === "number",
-      )
+    ? obj.sections.flatMap((entry: unknown): ChannelSection[] => {
+        if (typeof entry !== "object" || entry === null) return [];
+        const section = entry as Record<string, unknown>;
+        if (
+          typeof section.id !== "string" ||
+          typeof section.name !== "string" ||
+          typeof section.order !== "number"
+        ) {
+          return [];
+        }
+        const icon =
+          typeof section.icon === "string" && section.icon.trim().length > 0
+            ? section.icon.trim()
+            : undefined;
+        return [
+          {
+            id: section.id,
+            name: section.name,
+            ...(icon ? { icon } : {}),
+            order: section.order,
+          },
+        ];
+      })
     : [];
   const assignments: Record<string, string> =
     typeof obj.assignments === "object" &&

--- a/desktop/src/features/sidebar/lib/channelSectionsSync.ts
+++ b/desktop/src/features/sidebar/lib/channelSectionsSync.ts
@@ -126,6 +126,7 @@ export class ChannelSectionSyncManager {
         !last ||
         last.id !== current.id ||
         last.name !== current.name ||
+        last.icon !== current.icon ||
         last.order !== current.order
       )
         return false;

--- a/desktop/src/features/sidebar/lib/useChannelSections.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSections.ts
@@ -21,8 +21,8 @@ import type {
 export function useChannelSections(pubkey: string | undefined): {
   sections: ChannelSection[];
   assignments: Record<string, string>;
-  createSection: (name: string) => ChannelSection | null;
-  renameSection: (sectionId: string, newName: string) => void;
+  createSection: (name: string, icon?: string) => ChannelSection | null;
+  renameSection: (sectionId: string, newName: string, icon?: string) => void;
   deleteSection: (sectionId: string) => void;
   moveSectionUp: (sectionId: string) => void;
   moveSectionDown: (sectionId: string) => void;
@@ -165,16 +165,18 @@ export function useChannelSections(pubkey: string | undefined): {
   );
 
   const createSection = React.useCallback(
-    (name: string): ChannelSection | null => {
+    (name: string, icon?: string): ChannelSection | null => {
       if (!pubkey) return null;
       const prev = readChannelSectionsStore(pubkey);
       const maxOrder =
         prev.sections.length > 0
           ? Math.max(...prev.sections.map((s) => s.order))
           : -1;
+      const trimmedIcon = icon?.trim();
       const section: ChannelSection = {
         id: crypto.randomUUID(),
         name,
+        ...(trimmedIcon ? { icon: trimmedIcon } : {}),
         order: maxOrder + 1,
       };
       setStore((current) => {
@@ -192,16 +194,24 @@ export function useChannelSections(pubkey: string | undefined): {
   );
 
   const renameSection = React.useCallback(
-    (sectionId: string, newName: string) => {
+    (sectionId: string, newName: string, icon?: string) => {
       if (!pubkey) {
         return;
       }
+      const trimmedIcon = icon?.trim();
       setStore((prev) => {
         const next: ChannelSectionStore = {
           ...prev,
-          sections: prev.sections.map((s) =>
-            s.id === sectionId ? { ...s, name: newName } : s,
-          ),
+          sections: prev.sections.map((s) => {
+            if (s.id !== sectionId) return s;
+            const nextSection: ChannelSection = { ...s, name: newName };
+            if (trimmedIcon) {
+              nextSection.icon = trimmedIcon;
+            } else {
+              delete nextSection.icon;
+            }
+            return nextSection;
+          }),
         };
         if (!writeChannelSectionsStore(pubkey, next)) {
           return prev;

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -421,8 +421,8 @@ export function AppSidebar({
   );
 
   const handleCreateSectionConfirm = React.useCallback(
-    (name: string) => {
-      const section = createSection(name);
+    (value: { name: string; icon?: string }) => {
+      const section = createSection(value.name, value.icon);
       if (!section) {
         return;
       }
@@ -877,9 +877,10 @@ export function AppSidebar({
           if (!open) setRenameSectionTarget(null);
         }}
         sectionName={renameSectionTarget?.name ?? ""}
-        onConfirm={(newName) => {
+        sectionIcon={renameSectionTarget?.icon ?? ""}
+        onConfirm={(value) => {
           if (renameSectionTarget) {
-            renameSection(renameSectionTarget.id, newName);
+            renameSection(renameSectionTarget.id, value.name, value.icon);
           }
           setRenameSectionTarget(null);
         }}

--- a/desktop/src/features/sidebar/ui/ChannelSectionDialogs.tsx
+++ b/desktop/src/features/sidebar/ui/ChannelSectionDialogs.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
 
+import { X } from "lucide-react";
+
+import { EmojiPicker } from "@/features/custom-emoji/ui/EmojiPicker";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,9 +22,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
+import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 import { Input } from "@/shared/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import type { Channel } from "@/shared/api/types";
 import { useLeaveChannelMutation } from "@/features/channels/hooks";
+
+export type SectionDialogValue = {
+  name: string;
+  icon?: string;
+};
 
 type SectionNameDialogProps = {
   open: boolean;
@@ -29,9 +39,10 @@ type SectionNameDialogProps = {
   title: string;
   description: string;
   initialValue: string;
+  initialIcon?: string;
   confirmLabel: string;
-  isConfirmDisabled: (trimmed: string) => boolean;
-  onConfirm: (name: string) => void;
+  isConfirmDisabled: (trimmed: string, icon: string) => boolean;
+  onConfirm: (value: SectionDialogValue) => void;
 };
 
 function SectionNameDialog({
@@ -40,28 +51,44 @@ function SectionNameDialog({
   title,
   description,
   initialValue,
+  initialIcon = "",
   confirmLabel,
   isConfirmDisabled,
   onConfirm,
 }: SectionNameDialogProps) {
   const [name, setName] = React.useState(initialValue);
+  const [icon, setIcon] = React.useState(initialIcon);
+  const [pickerOpen, setPickerOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   React.useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setPickerOpen(false);
+      return;
+    }
     setName(initialValue);
+    setIcon(initialIcon);
     // Small delay to let dialog animation start before focusing
     const timerId = globalThis.setTimeout(() => {
       inputRef.current?.focus();
     }, 50);
     return () => globalThis.clearTimeout(timerId);
-  }, [open, initialValue]);
+  }, [open, initialValue, initialIcon]);
+
+  function handleIconSelect(selectedIcon: string) {
+    setIcon(selectedIcon);
+    setPickerOpen(false);
+  }
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const trimmed = name.trim();
-    if (isConfirmDisabled(trimmed)) return;
-    onConfirm(trimmed);
+    const trimmedIcon = icon.trim();
+    if (isConfirmDisabled(trimmed, trimmedIcon)) return;
+    onConfirm({
+      name: trimmed,
+      ...(trimmedIcon ? { icon: trimmedIcon } : {}),
+    });
   }
 
   return (
@@ -72,23 +99,66 @@ function SectionNameDialog({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
-          <Input
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
-            onChange={(event) => setName(event.target.value)}
-            placeholder="Section name"
-            ref={inputRef}
-            spellCheck={false}
-            value={name}
-          />
+          <div className="flex items-center gap-2">
+            <Popover onOpenChange={setPickerOpen} open={pickerOpen}>
+              <div className="relative shrink-0">
+                <PopoverTrigger asChild>
+                  <button
+                    aria-label="Choose section icon"
+                    className="flex h-9 w-9 items-center justify-center rounded-md border border-input text-lg transition-colors hover:bg-accent"
+                    type="button"
+                  >
+                    {icon ? (
+                      <StatusEmoji className="h-5 w-5" value={icon} />
+                    ) : (
+                      <span className="text-sm font-medium">#</span>
+                    )}
+                  </button>
+                </PopoverTrigger>
+                {icon ? (
+                  <button
+                    aria-label="Clear section icon"
+                    className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border border-background bg-muted text-muted-foreground hover:bg-accent hover:text-foreground"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setIcon("");
+                    }}
+                    type="button"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                ) : null}
+              </div>
+              <PopoverContent
+                align="start"
+                className="w-auto overflow-hidden rounded-2xl p-0"
+                portalled={false}
+                sideOffset={4}
+              >
+                <EmojiPicker autoFocus onSelect={handleIconSelect} />
+              </PopoverContent>
+            </Popover>
+            <Input
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Section name"
+              ref={inputRef}
+              spellCheck={false}
+              value={name}
+            />
+          </div>
           <div className="flex justify-end gap-2 mt-4">
             <DialogClose asChild>
               <Button variant="ghost" type="button">
                 Cancel
               </Button>
             </DialogClose>
-            <Button type="submit" disabled={isConfirmDisabled(name.trim())}>
+            <Button
+              type="submit"
+              disabled={isConfirmDisabled(name.trim(), icon.trim())}
+            >
               {confirmLabel}
             </Button>
           </div>
@@ -101,7 +171,7 @@ function SectionNameDialog({
 export type CreateSectionDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConfirm: (name: string) => void;
+  onConfirm: (value: SectionDialogValue) => void;
 };
 
 export function CreateSectionDialog({
@@ -114,8 +184,9 @@ export function CreateSectionDialog({
       open={open}
       onOpenChange={onOpenChange}
       title="Create section"
-      description="Sections let you group related channels in the sidebar."
+      description="Choose an icon and name for this sidebar section."
       initialValue=""
+      initialIcon=""
       confirmLabel="Create"
       isConfirmDisabled={(trimmed) => trimmed.length === 0}
       onConfirm={onConfirm}
@@ -127,13 +198,15 @@ export type RenameSectionDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   sectionName: string;
-  onConfirm: (newName: string) => void;
+  sectionIcon?: string;
+  onConfirm: (value: SectionDialogValue) => void;
 };
 
 export function RenameSectionDialog({
   open,
   onOpenChange,
   sectionName,
+  sectionIcon = "",
   onConfirm,
 }: RenameSectionDialogProps) {
   return (
@@ -141,11 +214,13 @@ export function RenameSectionDialog({
       open={open}
       onOpenChange={onOpenChange}
       title="Rename section"
-      description="Enter a new name for this section."
+      description="Choose an icon and name for this sidebar section."
       initialValue={sectionName}
-      confirmLabel="Rename"
-      isConfirmDisabled={(trimmed) =>
-        trimmed.length === 0 || trimmed === sectionName
+      initialIcon={sectionIcon}
+      confirmLabel="Save"
+      isConfirmDisabled={(trimmed, icon) =>
+        trimmed.length === 0 ||
+        (trimmed === sectionName.trim() && icon === sectionIcon.trim())
       }
       onConfirm={onConfirm}
     />

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -8,9 +8,8 @@ import {
   CheckCircle2,
   ChevronDown,
   CircleDot,
-  Clipboard,
   Copy,
-  GripVertical,
+  EllipsisVertical,
   LogOut,
   Pencil,
   Plus,
@@ -18,6 +17,7 @@ import {
   StarOff,
   Trash2,
 } from "lucide-react";
+import { useRef, type ReactNode } from "react";
 
 import { toast } from "sonner";
 
@@ -31,6 +31,13 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/shared/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -51,16 +58,39 @@ import {
 } from "@/features/sidebar/ui/sidebarSectionStyles";
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import type { ChannelSection } from "@/features/sidebar/lib/useChannelSections";
+import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { HashSearch } from "@/shared/ui/icons";
 
 const SECTION_LABEL_BUTTON_CLASS =
   "group/section-label flex w-fit max-w-[calc(100%-3rem)] cursor-pointer appearance-none items-center gap-1 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
+const CUSTOM_SECTION_LABEL_BUTTON_CLASS =
+  "group/section-label flex w-fit max-w-[calc(100%-3rem)] cursor-pointer appearance-none items-center gap-2 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
 const SECTION_LABEL_CHEVRON_CLASS =
   "relative size-2.5 shrink-0 text-current opacity-0 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/section-label:opacity-100 group-focus-within/sidebar-section:opacity-100 group-focus-visible/section-label:opacity-100";
 const SECTION_LABEL_CHEVRON_ICON_CLASS =
   "absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2";
+const CUSTOM_SECTION_ACTION_VISIBILITY_CLASS =
+  "opacity-0 transition-opacity group-hover/sidebar-section:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100";
+const SIDEBAR_CONTEXT_ICON_SLOT_CLASS =
+  "flex h-4 w-4 shrink-0 items-center justify-center";
+
+function deferContextMenuAction(action: () => void) {
+  globalThis.setTimeout(action, 0);
+}
+
+function ContextMenuIconSlot({ children }: { children?: ReactNode }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={SIDEBAR_CONTEXT_ICON_SLOT_CLASS}
+      data-sidebar-context-icon-slot
+    >
+      {children}
+    </span>
+  );
+}
 
 function MoveToSectionSubmenu({
   channelId,
@@ -81,29 +111,49 @@ function MoveToSectionSubmenu({
 
   return (
     <ContextMenuSub>
-      <ContextMenuSubTrigger>Move to section</ContextMenuSubTrigger>
+      <ContextMenuSubTrigger>
+        <ContextMenuIconSlot />
+        <span>Move to section</span>
+      </ContextMenuSubTrigger>
       <ContextMenuSubContent>
         {sections.map((section) => (
           <ContextMenuItem
             key={section.id}
-            onClick={() => onAssignChannel(channelId, section.id)}
+            onSelect={() =>
+              deferContextMenuAction(() =>
+                onAssignChannel(channelId, section.id),
+              )
+            }
           >
-            {currentSectionId === section.id ? (
-              <Check className="h-4 w-4" />
-            ) : (
-              <span className="h-4 w-4" />
-            )}
-            {section.name}
+            <ContextMenuIconSlot>
+              {currentSectionId === section.id ? (
+                <Check className="h-4 w-4" />
+              ) : section.icon ? (
+                <StatusEmoji className="h-4 w-4" value={section.icon} />
+              ) : null}
+            </ContextMenuIconSlot>
+            <span>{section.name}</span>
           </ContextMenuItem>
         ))}
         {sections.length > 0 ? <ContextMenuSeparator /> : null}
-        <ContextMenuItem onClick={() => onCreateSectionForChannel(channelId)}>
-          <Plus className="h-4 w-4" />
-          New section...
+        <ContextMenuItem
+          onSelect={() =>
+            deferContextMenuAction(() => onCreateSectionForChannel(channelId))
+          }
+        >
+          <ContextMenuIconSlot>
+            <Plus className="h-4 w-4" />
+          </ContextMenuIconSlot>
+          <span>New section...</span>
         </ContextMenuItem>
         {currentSectionId ? (
-          <ContextMenuItem onClick={() => onUnassignChannel(channelId)}>
-            Remove from section
+          <ContextMenuItem
+            onSelect={() =>
+              deferContextMenuAction(() => onUnassignChannel(channelId))
+            }
+          >
+            <ContextMenuIconSlot />
+            <span>Remove from section</span>
           </ContextMenuItem>
         ) : null}
       </ContextMenuSubContent>
@@ -120,6 +170,35 @@ function copyToClipboard(text: string, successMessage: string) {
     .catch(() => {
       toast.error("Failed to copy to clipboard");
     });
+}
+
+function CopyChannelSubmenu({ channel }: { channel: Channel }) {
+  return (
+    <ContextMenuSub>
+      <ContextMenuSubTrigger>
+        <ContextMenuIconSlot>
+          <Copy className="h-4 w-4" />
+        </ContextMenuIconSlot>
+        <span>Copy</span>
+      </ContextMenuSubTrigger>
+      <ContextMenuSubContent>
+        <ContextMenuItem
+          onSelect={() =>
+            copyToClipboard(channel.name, "Channel name copied to clipboard")
+          }
+        >
+          <span>Copy channel name</span>
+        </ContextMenuItem>
+        <ContextMenuItem
+          onSelect={() =>
+            copyToClipboard(channel.id, "Channel ID copied to clipboard")
+          }
+        >
+          <span>Copy channel ID</span>
+        </ContextMenuItem>
+      </ContextMenuSubContent>
+    </ContextMenuSub>
+  );
 }
 
 export function ChannelContextMenuItems({
@@ -164,94 +243,118 @@ export function ChannelContextMenuItems({
   const showReadToggle = hasUnread
     ? Boolean(onMarkChannelRead)
     : Boolean(onMarkChannelUnread);
-  return (
-    <>
-      {showStar ? (
-        isStarred ? (
-          <ContextMenuItem onClick={() => onUnstarChannel?.(channel.id)}>
-            <StarOff className="h-4 w-4" />
-            Unstar channel
-          </ContextMenuItem>
-        ) : (
-          <ContextMenuItem onClick={() => onStarChannel?.(channel.id)}>
-            <Star className="h-4 w-4" />
-            Star channel
-          </ContextMenuItem>
-        )
-      ) : null}
-      {showStar && showReadToggle ? <ContextMenuSeparator /> : null}
-      {hasUnread && onMarkChannelRead ? (
-        <ContextMenuItem
-          onClick={() => onMarkChannelRead(channel.id, channel.lastMessageAt)}
-        >
-          <CheckCircle2 className="h-4 w-4" />
-          Mark as read
-        </ContextMenuItem>
-      ) : !hasUnread && onMarkChannelUnread ? (
-        <ContextMenuItem onClick={() => onMarkChannelUnread(channel.id)}>
-          <CircleDot className="h-4 w-4" />
-          Mark unread
-        </ContextMenuItem>
-      ) : null}
-      {onMuteChannel && onUnmuteChannel ? (
-        <>
-          <ContextMenuSeparator />
-          {isMuted ? (
-            <ContextMenuItem onClick={() => onUnmuteChannel(channel.id)}>
-              <Bell className="h-4 w-4" />
-              Unmute channel
-            </ContextMenuItem>
-          ) : (
-            <ContextMenuItem onClick={() => onMuteChannel(channel.id)}>
-              <BellOff className="h-4 w-4" />
-              Mute channel
-            </ContextMenuItem>
-          )}
-        </>
-      ) : null}
-      {sections &&
+  const showMuteToggle = Boolean(onMuteChannel && onUnmuteChannel);
+  const showMove = Boolean(
+    sections &&
       assignments &&
       onAssignChannel &&
       onUnassignChannel &&
-      onCreateSectionForChannel ? (
-        <>
-          <ContextMenuSeparator />
-          <MoveToSectionSubmenu
-            channelId={channel.id}
-            sections={sections}
-            assignments={assignments}
-            onAssignChannel={onAssignChannel}
-            onUnassignChannel={onUnassignChannel}
-            onCreateSectionForChannel={onCreateSectionForChannel}
-          />
-        </>
+      onCreateSectionForChannel,
+  );
+
+  return (
+    <>
+      <CopyChannelSubmenu channel={channel} />
+      {showMove ? (
+        <MoveToSectionSubmenu
+          channelId={channel.id}
+          sections={sections ?? []}
+          assignments={assignments ?? {}}
+          onAssignChannel={onAssignChannel ?? (() => {})}
+          onUnassignChannel={onUnassignChannel ?? (() => {})}
+          onCreateSectionForChannel={onCreateSectionForChannel ?? (() => {})}
+        />
       ) : null}
-      <ContextMenuSeparator />
-      <ContextMenuItem
-        onClick={() =>
-          copyToClipboard(channel.name, "Channel name copied to clipboard")
-        }
-      >
-        <Copy className="h-4 w-4" />
-        Copy channel name
-      </ContextMenuItem>
-      <ContextMenuItem
-        onClick={() =>
-          copyToClipboard(channel.id, "Channel ID copied to clipboard")
-        }
-      >
-        <Clipboard className="h-4 w-4" />
-        Copy channel ID
-      </ContextMenuItem>
+      {showReadToggle ? <ContextMenuSeparator /> : null}
+      {hasUnread && onMarkChannelRead ? (
+        <ContextMenuItem
+          onSelect={() =>
+            deferContextMenuAction(() =>
+              onMarkChannelRead(channel.id, channel.lastMessageAt),
+            )
+          }
+        >
+          <ContextMenuIconSlot>
+            <CheckCircle2 className="h-4 w-4" />
+          </ContextMenuIconSlot>
+          <span>Mark as read</span>
+        </ContextMenuItem>
+      ) : !hasUnread && onMarkChannelUnread ? (
+        <ContextMenuItem
+          onSelect={() =>
+            deferContextMenuAction(() => onMarkChannelUnread(channel.id))
+          }
+        >
+          <ContextMenuIconSlot>
+            <CircleDot className="h-4 w-4" />
+          </ContextMenuIconSlot>
+          <span>Mark unread</span>
+        </ContextMenuItem>
+      ) : null}
+      {showMuteToggle || showStar ? <ContextMenuSeparator /> : null}
+      {showMuteToggle ? (
+        isMuted ? (
+          <ContextMenuItem
+            onSelect={() =>
+              deferContextMenuAction(() => onUnmuteChannel?.(channel.id))
+            }
+          >
+            <ContextMenuIconSlot>
+              <Bell className="h-4 w-4" />
+            </ContextMenuIconSlot>
+            <span>Unmute channel</span>
+          </ContextMenuItem>
+        ) : (
+          <ContextMenuItem
+            onSelect={() =>
+              deferContextMenuAction(() => onMuteChannel?.(channel.id))
+            }
+          >
+            <ContextMenuIconSlot>
+              <BellOff className="h-4 w-4" />
+            </ContextMenuIconSlot>
+            <span>Mute channel</span>
+          </ContextMenuItem>
+        )
+      ) : null}
+      {showStar ? (
+        isStarred ? (
+          <ContextMenuItem
+            onSelect={() =>
+              deferContextMenuAction(() => onUnstarChannel?.(channel.id))
+            }
+          >
+            <ContextMenuIconSlot>
+              <StarOff className="h-4 w-4" />
+            </ContextMenuIconSlot>
+            <span>Unstar channel</span>
+          </ContextMenuItem>
+        ) : (
+          <ContextMenuItem
+            onSelect={() =>
+              deferContextMenuAction(() => onStarChannel?.(channel.id))
+            }
+          >
+            <ContextMenuIconSlot>
+              <Star className="h-4 w-4" />
+            </ContextMenuIconSlot>
+            <span>Star channel</span>
+          </ContextMenuItem>
+        )
+      ) : null}
       {onLeaveChannel ? (
         <>
           <ContextMenuSeparator />
           <ContextMenuItem
             className="text-destructive focus:text-destructive"
-            onClick={() => onLeaveChannel(channel)}
+            onSelect={() =>
+              deferContextMenuAction(() => onLeaveChannel(channel))
+            }
           >
-            <LogOut className="h-4 w-4" />
-            Leave channel
+            <ContextMenuIconSlot>
+              <LogOut className="h-4 w-4" />
+            </ContextMenuIconSlot>
+            <span>Leave channel</span>
           </ContextMenuItem>
         </>
       ) : null}
@@ -318,6 +421,97 @@ function SectionHeaderActions({
         </button>
       ) : null}
     </div>
+  );
+}
+
+function CustomSectionActionsMenu({
+  sectionId,
+  sectionName,
+  hasUnread,
+  isFirst,
+  isLast,
+  onMarkSectionRead,
+  onRenameSection,
+  onDeleteSection,
+  onMoveSectionUp,
+  onMoveSectionDown,
+}: {
+  sectionId: string;
+  sectionName: string;
+  hasUnread: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  onMarkSectionRead: () => void;
+  onRenameSection: () => void;
+  onDeleteSection: () => void;
+  onMoveSectionUp: () => void;
+  onMoveSectionDown: () => void;
+}) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label={`Open actions for ${sectionName}`}
+          className={cn(
+            SECTION_ICON_BUTTON_CLASS,
+            CUSTOM_SECTION_ACTION_VISIBILITY_CLASS,
+          )}
+          data-testid={`section-actions-${sectionId}`}
+          onClick={(event) => event.stopPropagation()}
+          onPointerDown={(event) => event.stopPropagation()}
+          ref={triggerRef}
+          type="button"
+        >
+          <EllipsisVertical className="h-4 w-4" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          triggerRef.current?.blur();
+        }}
+      >
+        {hasUnread ? (
+          <DropdownMenuItem
+            onSelect={() => deferContextMenuAction(onMarkSectionRead)}
+          >
+            <CheckCheck className="h-4 w-4" />
+            <span>Mark all as read</span>
+          </DropdownMenuItem>
+        ) : null}
+        <DropdownMenuItem
+          onSelect={() => deferContextMenuAction(onRenameSection)}
+        >
+          <Pencil className="h-4 w-4" />
+          <span>Rename section</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={isFirst}
+          onSelect={() => deferContextMenuAction(onMoveSectionUp)}
+        >
+          <ArrowUp className="h-4 w-4" />
+          <span>Move up</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={isLast}
+          onSelect={() => deferContextMenuAction(onMoveSectionDown)}
+        >
+          <ArrowDown className="h-4 w-4" />
+          <span>Move down</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="text-destructive focus:text-destructive"
+          onSelect={() => deferContextMenuAction(onDeleteSection)}
+        >
+          <Trash2 className="h-4 w-4" />
+          <span>Delete section</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -586,97 +780,111 @@ export function CustomChannelSection({
           >
             <ContextMenu>
               <ContextMenuTrigger asChild>
-                <div className="relative" {...dragHandleProps}>
+                <div
+                  className="group/section-header relative"
+                  {...dragHandleProps}
+                >
                   <SidebarGroupLabel asChild>
                     <button
                       aria-controls={contentId}
                       aria-expanded={!isCollapsed}
-                      className={SECTION_LABEL_BUTTON_CLASS}
+                      className={CUSTOM_SECTION_LABEL_BUTTON_CLASS}
                       onClick={onToggleCollapsed}
                       type="button"
                     >
-                      <GripVertical
-                        className={cn(
-                          "h-4 w-4 shrink-0 text-sidebar-foreground/30",
-                          SECTION_ACTION_VISIBILITY_CLASS,
-                        )}
+                      {section.icon ? (
+                        <span
+                          aria-hidden="true"
+                          className="flex h-4 w-4 shrink-0 items-center justify-center"
+                          data-testid={`section-icon-${section.id}`}
+                        >
+                          <StatusEmoji
+                            className="h-4 w-4"
+                            value={section.icon}
+                          />
+                        </span>
+                      ) : null}
+                      <span
+                        className="truncate"
+                        data-testid={`section-title-${section.id}`}
+                      >
+                        {section.name}
+                      </span>
+                      <span
                         aria-hidden="true"
-                      />
-                      <span>{section.name}</span>
-                      <ChevronDown
-                        aria-hidden="true"
-                        className={cn(
-                          SECTION_LABEL_CHEVRON_CLASS,
-                          isCollapsed ? "-rotate-90" : "rotate-0",
-                        )}
-                      />
+                        className={SECTION_LABEL_CHEVRON_CLASS}
+                      >
+                        <ChevronDown
+                          className={cn(
+                            SECTION_LABEL_CHEVRON_ICON_CLASS,
+                            isCollapsed ? "-rotate-90" : "rotate-0",
+                          )}
+                        />
+                      </span>
                     </button>
                   </SidebarGroupLabel>
-                  <div
-                    className={cn(
-                      "absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5",
-                      SECTION_ACTION_VISIBILITY_CLASS,
-                    )}
-                  >
-                    {hasUnread ? (
-                      <button
-                        aria-label="Mark all as read"
-                        className={SECTION_ICON_BUTTON_CLASS}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onMarkSectionRead();
-                        }}
-                        title="Mark all as read"
-                        type="button"
-                      >
-                        <CheckCheck className="h-4 w-4" />
-                      </button>
-                    ) : null}
-                    <button
-                      aria-label="Rename section"
-                      className={SECTION_ICON_BUTTON_CLASS}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onRenameSection();
-                      }}
-                      type="button"
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </button>
-                    <button
-                      aria-label="Delete section"
-                      className={SECTION_ICON_BUTTON_CLASS}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDeleteSection();
-                      }}
-                      type="button"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
+                  <div className="absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5">
+                    <CustomSectionActionsMenu
+                      sectionId={section.id}
+                      sectionName={section.name}
+                      hasUnread={hasUnread}
+                      isFirst={isFirst}
+                      isLast={isLast}
+                      onMarkSectionRead={onMarkSectionRead}
+                      onRenameSection={onRenameSection}
+                      onDeleteSection={onDeleteSection}
+                      onMoveSectionUp={onMoveSectionUp}
+                      onMoveSectionDown={onMoveSectionDown}
+                    />
                   </div>
                 </div>
               </ContextMenuTrigger>
               <ContextMenuContent>
-                <ContextMenuItem onClick={onRenameSection}>
-                  <Pencil className="h-4 w-4" />
-                  Rename section
+                {hasUnread ? (
+                  <ContextMenuItem
+                    onSelect={() => deferContextMenuAction(onMarkSectionRead)}
+                  >
+                    <ContextMenuIconSlot>
+                      <CheckCheck className="h-4 w-4" />
+                    </ContextMenuIconSlot>
+                    <span>Mark all as read</span>
+                  </ContextMenuItem>
+                ) : null}
+                <ContextMenuItem
+                  onSelect={() => deferContextMenuAction(onRenameSection)}
+                >
+                  <ContextMenuIconSlot>
+                    <Pencil className="h-4 w-4" />
+                  </ContextMenuIconSlot>
+                  <span>Rename section</span>
                 </ContextMenuItem>
-                <ContextMenuItem disabled={isFirst} onClick={onMoveSectionUp}>
-                  <ArrowUp className="h-4 w-4" />
-                  Move up
+                <ContextMenuItem
+                  disabled={isFirst}
+                  onSelect={() => deferContextMenuAction(onMoveSectionUp)}
+                >
+                  <ContextMenuIconSlot>
+                    <ArrowUp className="h-4 w-4" />
+                  </ContextMenuIconSlot>
+                  <span>Move up</span>
                 </ContextMenuItem>
-                <ContextMenuItem disabled={isLast} onClick={onMoveSectionDown}>
-                  <ArrowDown className="h-4 w-4" />
-                  Move down
+                <ContextMenuItem
+                  disabled={isLast}
+                  onSelect={() => deferContextMenuAction(onMoveSectionDown)}
+                >
+                  <ContextMenuIconSlot>
+                    <ArrowDown className="h-4 w-4" />
+                  </ContextMenuIconSlot>
+                  <span>Move down</span>
                 </ContextMenuItem>
                 <ContextMenuSeparator />
                 <ContextMenuItem
                   className="text-destructive focus:text-destructive"
-                  onClick={onDeleteSection}
+                  onSelect={() => deferContextMenuAction(onDeleteSection)}
                 >
-                  <Trash2 className="h-4 w-4" />
-                  Delete section
+                  <ContextMenuIconSlot>
+                    <Trash2 className="h-4 w-4" />
+                  </ContextMenuIconSlot>
+                  <span>Delete section</span>
                 </ContextMenuItem>
               </ContextMenuContent>
             </ContextMenu>

--- a/desktop/src/shared/ui/popover.tsx
+++ b/desktop/src/shared/ui/popover.tsx
@@ -15,27 +15,51 @@ const PopoverTrigger = PopoverPrimitive.Trigger;
 
 const PopoverAnchor = PopoverPrimitive.Anchor;
 
+type PopoverContentProps = React.ComponentPropsWithoutRef<
+  typeof PopoverPrimitive.Content
+> & {
+  portalled?: boolean;
+};
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, style, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-xl p-4 outline-hidden",
-        POPOVER_RADIX_MOTION_CLASS,
-        POPOVER_RADIX_SIDE_MOTION_CLASS,
-        POPOVER_SURFACE_CLASS,
-        className,
-      )}
-      style={{ ...POPOVER_SHADOW_STYLE, ...style }}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
+  PopoverContentProps
+>(
+  (
+    {
+      className,
+      align = "center",
+      portalled = true,
+      sideOffset = 4,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const content = (
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-xl p-4 outline-hidden",
+          POPOVER_RADIX_MOTION_CLASS,
+          POPOVER_RADIX_SIDE_MOTION_CLASS,
+          POPOVER_SURFACE_CLASS,
+          className,
+        )}
+        style={{ ...POPOVER_SHADOW_STYLE, ...style }}
+        {...props}
+      />
+    );
+
+    if (!portalled) {
+      return content;
+    }
+
+    return <PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>;
+  },
+);
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -1,9 +1,17 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 import { installMockBridge } from "../helpers/bridge";
 
 const SIDEBAR_WIDTH_STORAGE_KEY = "buzz-sidebar-width";
 const DEFAULT_SIDEBAR_WIDTH = 300;
+const MOCK_PUBKEY = "deadbeef".repeat(8);
+const RANDOM_CHANNEL_ID = "9dae0116-799b-5071-a0a8-fdd30a91a35d";
+const PRIORITY_SECTION = {
+  id: "sec-priority",
+  name: "Priority",
+  icon: "\u2728",
+  order: 0,
+};
 
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
@@ -40,6 +48,318 @@ async function dragSidebarRail(page: Page, deltaX: number) {
   await page.mouse.move(startX + deltaX, startY, { steps: 8 });
   await page.mouse.up();
 }
+
+async function seedChannelSections(
+  page: Page,
+  assignments: Record<string, string> = {},
+) {
+  await page.addInitScript(
+    ({ pubkey, section, seededAssignments }) => {
+      window.localStorage.setItem(
+        `buzz-channel-sections.v1:${pubkey}`,
+        JSON.stringify({
+          version: 1,
+          sections: [section],
+          assignments: seededAssignments,
+        }),
+      );
+    },
+    {
+      pubkey: MOCK_PUBKEY,
+      section: PRIORITY_SECTION,
+      seededAssignments: assignments,
+    },
+  );
+}
+
+async function visibleContextMenuRows(menu: Locator) {
+  return menu.locator('[role="menuitem"]').evaluateAll((elements) => {
+    return elements
+      .filter((element): element is HTMLElement => {
+        if (!(element instanceof HTMLElement)) return false;
+        const rect = element.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      })
+      .map((element) => {
+        const iconSlot = element.querySelector<HTMLElement>(
+          "[data-sidebar-context-icon-slot]",
+        );
+        const label = Array.from(element.querySelectorAll("span")).find(
+          (span) =>
+            !span.hasAttribute("data-sidebar-context-icon-slot") &&
+            span.textContent?.trim(),
+        );
+
+        return {
+          iconLeft: iconSlot?.getBoundingClientRect().left ?? null,
+          text: element.textContent?.trim() ?? "",
+          textLeft: label?.getBoundingClientRect().left ?? null,
+        };
+      });
+  });
+}
+
+async function expectMenuTextAligned(menu: Locator) {
+  const rows = await visibleContextMenuRows(menu);
+  const textLefts = rows
+    .map((row) => row.textLeft)
+    .filter((left): left is number => typeof left === "number");
+  expect(textLefts.length).toBeGreaterThan(1);
+  const firstTextLeft = textLefts[0];
+  for (const textLeft of textLefts) {
+    expect(Math.abs(textLeft - firstTextLeft)).toBeLessThanOrEqual(1);
+  }
+  for (const row of rows) {
+    expect(row.iconLeft, row.text).not.toBeNull();
+  }
+}
+
+async function expectAppClickable(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => getComputedStyle(document.body).pointerEvents),
+    )
+    .not.toBe("none");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+}
+
+async function emojiPickerScrollTop(emojiPicker: Locator) {
+  return emojiPicker.evaluate((element) => {
+    const scroll = element.shadowRoot?.querySelector<HTMLElement>(".scroll");
+    return scroll?.scrollTop ?? null;
+  });
+}
+
+test("aligns custom section headers with the built-in sidebar sections", async ({
+  page,
+}) => {
+  await seedChannelSections(page, {
+    [RANDOM_CHANNEL_ID]: PRIORITY_SECTION.id,
+  });
+  await page.goto("/");
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+
+  const customSectionButton = page.locator(
+    `[aria-controls="sidebar-section-${PRIORITY_SECTION.id}"]`,
+  );
+  await expect(customSectionButton).toBeVisible();
+  await expect(customSectionButton).toContainText(PRIORITY_SECTION.name);
+  await expect(customSectionButton).toContainText(PRIORITY_SECTION.icon);
+  await expect(
+    customSectionButton.locator(".lucide-grip-vertical"),
+  ).toHaveCount(0);
+  await expect(customSectionButton.locator(".lucide-chevron-down")).toHaveCount(
+    1,
+  );
+
+  const inlineGaps = await page.evaluate(
+    ({ sectionId }) => {
+      const sectionIcon = document.querySelector<HTMLElement>(
+        `[data-testid="section-icon-${sectionId}"]`,
+      );
+      const sectionTitle = document.querySelector<HTMLElement>(
+        `[data-testid="section-title-${sectionId}"]`,
+      );
+      const channelRow = document.querySelector<HTMLElement>(
+        '[data-testid="channel-random"]',
+      );
+      const channelIcon = channelRow?.querySelector<HTMLElement>("svg");
+      const channelTitle = Array.from(
+        channelRow?.querySelectorAll<HTMLElement>("span") ?? [],
+      ).find((span) => span.textContent?.trim() === "random");
+
+      if (!sectionIcon || !sectionTitle || !channelIcon || !channelTitle) {
+        throw new Error("Expected section and channel inline elements");
+      }
+
+      return {
+        channel: Math.round(
+          channelTitle.getBoundingClientRect().left -
+            channelIcon.getBoundingClientRect().right,
+        ),
+        section: Math.round(
+          sectionTitle.getBoundingClientRect().left -
+            sectionIcon.getBoundingClientRect().right,
+        ),
+      };
+    },
+    { sectionId: PRIORITY_SECTION.id },
+  );
+
+  expect(inlineGaps.section).toBe(inlineGaps.channel);
+
+  const sectionActions = page.getByTestId(
+    `section-actions-${PRIORITY_SECTION.id}`,
+  );
+  await expect
+    .poll(() =>
+      sectionActions.evaluate((element) => getComputedStyle(element).opacity),
+    )
+    .toBe("0");
+
+  await page.getByTestId("channel-random").hover();
+  await expect
+    .poll(() =>
+      sectionActions.evaluate((element) => getComputedStyle(element).opacity),
+    )
+    .toBe("1");
+
+  await page.mouse.move(500, 500);
+  await expect
+    .poll(() =>
+      sectionActions.evaluate((element) => getComputedStyle(element).opacity),
+    )
+    .toBe("0");
+
+  await customSectionButton.hover();
+  await expect(sectionActions).toBeVisible();
+  await expect(sectionActions.locator(".lucide-ellipsis-vertical")).toHaveCount(
+    1,
+  );
+  await expect
+    .poll(() =>
+      sectionActions.evaluate((element) => getComputedStyle(element).opacity),
+    )
+    .toBe("1");
+  await sectionActions.click();
+  await expect(
+    page.getByRole("menuitem", { name: "Rename section" }),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      sectionActions.evaluate((element) => getComputedStyle(element).opacity),
+    )
+    .toBe("1");
+  await expect(page.getByRole("menuitem", { name: "Move up" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Move down" })).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: "Delete section" }),
+  ).toBeVisible();
+  await page.mouse.click(500, 500);
+  await expect
+    .poll(() =>
+      sectionActions.evaluate((element) => getComputedStyle(element).opacity),
+    )
+    .toBe("0");
+});
+
+test("custom section emoji picker scrolls", async ({ page }) => {
+  await seedChannelSections(page);
+  await page.goto("/");
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+
+  await page
+    .locator(`[aria-controls="sidebar-section-${PRIORITY_SECTION.id}"]`)
+    .hover();
+  await page.getByTestId(`section-actions-${PRIORITY_SECTION.id}`).hover();
+  await page.getByTestId(`section-actions-${PRIORITY_SECTION.id}`).click();
+  await page.getByRole("menuitem", { name: "Rename section" }).click();
+
+  await expect(
+    page.getByRole("dialog", { name: "Rename section" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Choose section icon" }).click();
+  const emojiPicker = page.locator("em-emoji-picker").first();
+  await expect(emojiPicker).toBeVisible();
+
+  await expect.poll(() => emojiPickerScrollTop(emojiPicker)).not.toBeNull();
+  const beforeScrollTop = await emojiPickerScrollTop(emojiPicker);
+  expect(beforeScrollTop).not.toBeNull();
+
+  await emojiPicker.hover();
+  await page.mouse.wheel(0, 700);
+
+  await expect
+    .poll(() => emojiPickerScrollTop(emojiPicker))
+    .toBeGreaterThan(beforeScrollTop ?? 0);
+});
+
+test("orders and aligns channel and direct-message context menu items", async ({
+  page,
+}) => {
+  await seedChannelSections(page);
+  await page.goto("/");
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+
+  await page.getByTestId("channel-random").click({ button: "right" });
+  await expect(
+    page.getByRole("menuitem", { name: "Mark unread" }),
+  ).toBeVisible();
+  const channelMenu = page.getByRole("menu").first();
+  await expectMenuTextAligned(channelMenu);
+
+  const channelRows = await visibleContextMenuRows(channelMenu);
+  expect(channelRows.map((row) => row.text)).toEqual([
+    "Copy",
+    "Move to section",
+    "Mark unread",
+    "Mute channel",
+    "Star channel",
+    "Leave channel",
+  ]);
+
+  const channelMenuBox = await channelMenu.boundingBox();
+  expect(channelMenuBox?.width ?? 0).toBeGreaterThanOrEqual(238);
+
+  await page.getByRole("menuitem", { name: "Copy" }).hover();
+  await expect(
+    page.getByRole("menuitem", { name: "Copy channel name" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: "Copy channel ID" }),
+  ).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("menu")).toHaveCount(0);
+  await page.getByTestId("channel-alice-tyler").click({ button: "right" });
+  await expect(page.getByRole("menuitem", { name: "Copy" })).toBeVisible();
+  const dmMenu = page.getByRole("menu").first();
+  await expectMenuTextAligned(dmMenu);
+
+  const dmRows = await visibleContextMenuRows(dmMenu);
+  expect(dmRows.map((row) => row.text)).toEqual([
+    "Copy",
+    "Mark unread",
+    "Mute channel",
+  ]);
+});
+
+test("channel context menu move and leave actions do not freeze the app", async ({
+  page,
+}) => {
+  await seedChannelSections(page);
+  await page.goto("/");
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+
+  await page.getByTestId("channel-random").click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Move to section" }).hover();
+  await page.getByRole("menuitem", { name: PRIORITY_SECTION.name }).click();
+  await expect(page.getByRole("menu")).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        ({ pubkey, channelId }) => {
+          const raw = window.localStorage.getItem(
+            `buzz-channel-sections.v1:${pubkey}`,
+          );
+          const parsed = raw ? JSON.parse(raw) : null;
+          return parsed?.assignments?.[channelId] ?? null;
+        },
+        { pubkey: MOCK_PUBKEY, channelId: RANDOM_CHANNEL_ID },
+      ),
+    )
+    .toBe(PRIORITY_SECTION.id);
+  await expectAppClickable(page);
+
+  await page.getByTestId("channel-random").click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Leave channel" }).click();
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByRole("alertdialog")).toHaveCount(0);
+  await expectAppClickable(page);
+});
 
 test("resizes, persists, and snaps to the default sidebar width", async ({
   page,

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -13,10 +13,6 @@ const PRIORITY_SECTION = {
   order: 0,
 };
 
-test.beforeEach(async ({ page }) => {
-  await installMockBridge(page);
-});
-
 async function sidebarWidth(page: Page) {
   return page.getByTestId("app-sidebar").evaluate((element) => {
     return Math.round(element.getBoundingClientRect().width);
@@ -137,6 +133,7 @@ test("aligns custom section headers with the built-in sidebar sections", async (
   await seedChannelSections(page, {
     [RANDOM_CHANNEL_ID]: PRIORITY_SECTION.id,
   });
+  await installMockBridge(page);
   await page.goto("/");
   await expect(page.getByTestId("app-sidebar")).toBeVisible();
 
@@ -246,6 +243,7 @@ test("aligns custom section headers with the built-in sidebar sections", async (
 
 test("custom section emoji picker scrolls", async ({ page }) => {
   await seedChannelSections(page);
+  await installMockBridge(page);
   await page.goto("/");
   await expect(page.getByTestId("app-sidebar")).toBeVisible();
 
@@ -279,6 +277,7 @@ test("orders and aligns channel and direct-message context menu items", async ({
   page,
 }) => {
   await seedChannelSections(page);
+  await installMockBridge(page);
   await page.goto("/");
   await expect(page.getByTestId("app-sidebar")).toBeVisible();
 
@@ -330,6 +329,7 @@ test("channel context menu move and leave actions do not freeze the app", async 
   page,
 }) => {
   await seedChannelSections(page);
+  await installMockBridge(page);
   await page.goto("/");
   await expect(page.getByTestId("app-sidebar")).toBeVisible();
 
@@ -364,6 +364,7 @@ test("channel context menu move and leave actions do not freeze the app", async 
 test("resizes, persists, and snaps to the default sidebar width", async ({
   page,
 }) => {
+  await installMockBridge(page);
   await page.goto("/");
   await expect(page.getByTestId("app-sidebar")).toBeVisible();
 
@@ -390,6 +391,7 @@ test("resizes, persists, and snaps to the default sidebar width", async ({
 test("shows a sidebar update card when an update is ready", async ({
   page,
 }) => {
+  await installMockBridge(page);
   await page.goto("/");
   await expect(page.getByTestId("app-sidebar")).toBeVisible();
 


### PR DESCRIPTION
## Summary
- Align custom section headers with built-in sidebar rows and replace edit/delete inline buttons with a vertical-ellipsis menu.
- Reorder channel/DM context menus with aligned text, a Copy submenu, Move to section under Copy, and non-freezing move/leave actions.
- Keep the section emoji picker behavior intact while restoring scroll support.

## Snapshot
![Sidebar section action menu](https://raw.githubusercontent.com/block/buzz/1877c5fe04c6699216b22b5c2ecffcbed66611e8/channel-styling-prs-20260701-1224/sidebar-section-actions.png)

## Checks
- `git diff --check HEAD`
- `pnpm --dir desktop check`
- `pnpm --dir desktop typecheck`
- Combined validation before splitting: `pnpm --dir desktop test`, `pnpm --dir desktop build`, focused Playwright smoke/integration suites
