### PR TITLE
Fix false "relay unreachable" error on agent creation

### DIFF
--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -886,14 +886,7 @@ pub async fn create_managed_agent(
     // ── Phase 4: sync agent profile on relay (async, outside lock) ───────────
     // Use the avatar persisted on the record so the published profile and any
     // later reconciliation agree on the same value.
-    //
-    // Resolve the sync target via `effective_agent_relay_url`: an explicit
-    // per-agent relay wins, and a blank one (the common case — the UI create
-    // flow never pins a relay) falls back to the active workspace relay. Without
-    // this, a blank `resolved_relay_url` would produce a hostless `/events` POST
-    // that fails to connect and surfaces as a false "relay unreachable" error,
-    // even though the workspace relay is reachable. This mirrors the reconcile
-    // (`reconcile_agent_profile`) and rename (`update_managed_agent`) paths.
+    // Blank per-agent relay falls back to the workspace relay (matches reconcile/rename).
     let sync_relay_url = crate::relay::effective_agent_relay_url(
         &resolved_relay_url,
         &relay_ws_url_with_override(&state),

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -886,9 +886,21 @@ pub async fn create_managed_agent(
     // ── Phase 4: sync agent profile on relay (async, outside lock) ───────────
     // Use the avatar persisted on the record so the published profile and any
     // later reconciliation agree on the same value.
+    //
+    // Resolve the sync target via `effective_agent_relay_url`: an explicit
+    // per-agent relay wins, and a blank one (the common case — the UI create
+    // flow never pins a relay) falls back to the active workspace relay. Without
+    // this, a blank `resolved_relay_url` would produce a hostless `/events` POST
+    // that fails to connect and surfaces as a false "relay unreachable" error,
+    // even though the workspace relay is reachable. This mirrors the reconcile
+    // (`reconcile_agent_profile`) and rename (`update_managed_agent`) paths.
+    let sync_relay_url = crate::relay::effective_agent_relay_url(
+        &resolved_relay_url,
+        &relay_ws_url_with_override(&state),
+    );
     let profile_sync_error = (sync_managed_agent_profile(
         &state,
-        &resolved_relay_url,
+        &sync_relay_url,
         &agent_keys,
         &name,
         resolved_avatar_url.as_deref(),

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -382,12 +382,7 @@ pub async fn sync_managed_agent_profile(
     avatar_url: Option<&str>,
     auth_tag: Option<&str>, // NIP-OA auth tag JSON
 ) -> Result<(), String> {
-    // Guard against a blank/hostless relay URL. An empty `relay_url` collapses to
-    // an empty base, producing a schemeless `/events` POST that fails to connect
-    // and gets misclassified as "relay unreachable" — a false connectivity error
-    // even though the workspace relay is fine. Callers must resolve the effective
-    // relay (see `effective_agent_relay_url`) before syncing; fail loudly here so
-    // any future caller that forgets gets a clear, actionable error instead.
+    // Fail loudly on a blank relay URL — callers must resolve via `effective_agent_relay_url` first.
     let base = relay_http_base_url(relay_url);
     if base.is_empty() {
         return Err(
@@ -724,23 +719,15 @@ mod tests {
 
     #[test]
     fn blank_relay_http_base_is_empty() {
-        // A blank relay URL has no scheme to rewrite, so the HTTP base collapses
-        // to empty. This is the trap behind the false "relay unreachable" toast:
-        // an empty base makes the profile-sync POST target a hostless "/events".
-        // `sync_managed_agent_profile` now guards against this base explicitly.
+        // A blank relay URL has no scheme to rewrite, so the HTTP base is empty.
         assert_eq!(relay_http_base_url(""), "");
         assert_eq!(relay_http_base_url("   "), "");
     }
 
     #[test]
     fn ui_created_agent_blank_relay_resolves_to_reachable_host() {
-        // Regression: the New Agent dialog never pins a per-agent relay, so the
-        // create flow's `resolved_relay_url` is empty. `create_managed_agent`
-        // Phase 4 must resolve the sync target through `effective_agent_relay_url`
-        // (falling back to the active workspace relay) — exactly as reconcile and
-        // rename do — before calling `sync_managed_agent_profile`. Before the fix,
-        // create passed the raw empty string straight through, yielding a hostless
-        // base and a false "relay unreachable" profile-sync error.
+        // A blank per-agent relay (the UI create case) resolves through
+        // `effective_agent_relay_url` to a real workspace host, not a hostless base.
         let resolved_relay_url = ""; // UI create flow: no per-agent relay pinned
         let workspace_relay = "wss://staging.example.com";
 

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -382,12 +382,26 @@ pub async fn sync_managed_agent_profile(
     avatar_url: Option<&str>,
     auth_tag: Option<&str>, // NIP-OA auth tag JSON
 ) -> Result<(), String> {
+    // Guard against a blank/hostless relay URL. An empty `relay_url` collapses to
+    // an empty base, producing a schemeless `/events` POST that fails to connect
+    // and gets misclassified as "relay unreachable" — a false connectivity error
+    // even though the workspace relay is fine. Callers must resolve the effective
+    // relay (see `effective_agent_relay_url`) before syncing; fail loudly here so
+    // any future caller that forgets gets a clear, actionable error instead.
+    let base = relay_http_base_url(relay_url);
+    if base.is_empty() {
+        return Err(
+            "no relay configured for profile sync (resolve the agent's relay URL first)"
+                .to_string(),
+        );
+    }
+
     // Build a signed kind:0 profile event (with optional NIP-OA auth tag).
     let event = build_profile_event(agent_keys, display_name, avatar_url, auth_tag)?;
     let event_json = event.as_json();
     let body_bytes = event_json.into_bytes();
 
-    let url = format!("{}/events", relay_http_base_url(relay_url));
+    let url = format!("{}/events", base);
     let auth = build_nip98_auth_header_for_keys(agent_keys, &Method::POST, &url, &body_bytes)?;
 
     let mut request = state
@@ -706,6 +720,38 @@ mod tests {
             relay_http_base_url("wss://localhost:3000"),
             "https://localhost:3000"
         );
+    }
+
+    #[test]
+    fn blank_relay_http_base_is_empty() {
+        // A blank relay URL has no scheme to rewrite, so the HTTP base collapses
+        // to empty. This is the trap behind the false "relay unreachable" toast:
+        // an empty base makes the profile-sync POST target a hostless "/events".
+        // `sync_managed_agent_profile` now guards against this base explicitly.
+        assert_eq!(relay_http_base_url(""), "");
+        assert_eq!(relay_http_base_url("   "), "");
+    }
+
+    #[test]
+    fn ui_created_agent_blank_relay_resolves_to_reachable_host() {
+        // Regression: the New Agent dialog never pins a per-agent relay, so the
+        // create flow's `resolved_relay_url` is empty. `create_managed_agent`
+        // Phase 4 must resolve the sync target through `effective_agent_relay_url`
+        // (falling back to the active workspace relay) — exactly as reconcile and
+        // rename do — before calling `sync_managed_agent_profile`. Before the fix,
+        // create passed the raw empty string straight through, yielding a hostless
+        // base and a false "relay unreachable" profile-sync error.
+        let resolved_relay_url = ""; // UI create flow: no per-agent relay pinned
+        let workspace_relay = "wss://staging.example.com";
+
+        let sync_relay_url = effective_agent_relay_url(resolved_relay_url, workspace_relay);
+        let base = relay_http_base_url(&sync_relay_url);
+
+        assert!(
+            !base.is_empty(),
+            "blank per-agent relay must resolve to a real workspace host, not a hostless base"
+        );
+        assert_eq!(base, "https://staging.example.com");
     }
 
     // ── classify_intercepted_response ────────────────────────────────────────


### PR DESCRIPTION
# Fix false "relay unreachable" error on agent creation

## Problem
Creating an agent via **Agents → New agent → Create agent** always shows an
error toast:

> `<name>` was created, but profile sync failed: relay unreachable: could not connect to relay

The relay is fully reachable — chat, message send, and the WebSocket connection
all work. The agent is created and (on next start) its profile is published
correctly. The toast is a false alarm, but it reads as data loss to the user.

## Root cause
The New Agent dialog never pins a per-agent relay, so in `create_managed_agent`
(`desktop/src-tauri/src/commands/agents.rs`) `resolved_relay_url` is an empty
string. Phase 4 (profile sync) passed that empty string straight to
`sync_managed_agent_profile`, where `relay_http_base_url("")` returns `""` and
the profile `POST` targets a schemeless, hostless `/events`. `reqwest` can't
connect, and `classify_request_error` buckets the failure as
`"relay unreachable: could not connect to relay"`.

Every other managed-agent relay path resolves the target via
`effective_agent_relay_url`, which falls back to the active workspace relay when
the per-agent value is blank. The create-time sync was the **only** caller that
skipped it:

| Caller | Location | Resolves relay? |
|---|---|---|
| create | `agents.rs:889` | ❌ raw override (bug) |
| reconcile | `agents.rs:1226` | ✅ `effective_agent_relay_url` |
| update/rename | `agent_models.rs:960` | ✅ `effective_agent_relay_url` |

This is why the profile "self-heals" on next agent start — the background
`reconcile_agent_profile` resolves the relay correctly. Only the create-time
toast was broken.

## Fix
1. **Create path** — resolve the sync target through `effective_agent_relay_url`
   in Phase 4, mirroring the reconcile and rename paths.
2. **Hardening** — `sync_managed_agent_profile` now rejects a blank/hostless
   relay URL with a distinct, actionable error instead of the misleading
   "relay unreachable", so any future caller that forgets to resolve the relay
   fails loudly rather than emitting a false connectivity error.

## Tests
The create-time bug lived in the caller (`create_managed_agent` Phase 4 not
invoking the resolver) — a Tauri command that isn't unit-testable. The real
regression protection is the new blank-relay **guard** in
`sync_managed_agent_profile`: any future caller that skips relay resolution now
fails loudly instead of emitting a false "relay unreachable" error.

Supporting unit tests added to `desktop/src-tauri/src/relay.rs`:
- `ui_created_agent_blank_relay_resolves_to_reachable_host` — pins the
  resolution contract the create path now relies on: a blank per-agent relay
  resolves through `effective_agent_relay_url` to the reachable workspace host,
  not a hostless base. (Composes two pure helpers unchanged by this PR, so it
  documents the contract rather than failing against the pre-fix logic.)
- `blank_relay_http_base_is_empty` — pins the empty-base trap the new guard catches.

`cargo test relay::` → 26 passed. `cargo fmt --check` clean. Clippy clean on the
changed files.

## Scope
Two files, +60/−2. No behavior change for agents that pin an explicit relay.

