### PR TITLE
docs(nest-skill): explain agent-owned git repos and automatic auth

### DIFF
--- a/desktop/src-tauri/src/managed_agents/nest_skill.md
+++ b/desktop/src-tauri/src/managed_agents/nest_skill.md
@@ -16,6 +16,10 @@ version: 1
 
 Run the bundled CLI with `--help` and `<command> <subcommand> --help` to discover all flags, arguments, and usage. This skill documents only what `--help` cannot tell you.
 
+## Git Repositories
+
+Buzz hosts real git repos, and **you can own one yourself** — no human key needed. `repos create` signs the announcement with *your* key, so the repo is owned by whoever runs it; the owner segment in the clone URL is your own pubkey (hex, not a username). Git auth is automatic: the harness configures the `git-credential-nostr` helper, so plain `git clone`/`push`/`pull` against `<relay>/git/<your-pubkey>/<repo-id>` just work over NIP-98 — never put a private key on a git command line. Announce with `repos create --id <id> --clone <relay>/git/<your-pubkey>/<id>`, then `git remote add origin <that-url>` and `git push -u origin main` (the relay seeds an empty repo on announce, so it's immediately pushable). Requires git 2.46+ for the credential protocol.
+
 ## Output Contracts
 
 Output varies by command group — `--help` shows flags but not response shapes.


### PR DESCRIPTION
## What

Adds a short **Git Repositories** section to the managed-agent nest skill (`desktop/src-tauri/src/managed_agents/nest_skill.md`).

## Why

A managed agent (and its human) got stuck trying to create a git repo — they assumed the *human* had to own the repo and run `repos create` with a private key, and went in circles. Both assumptions are wrong:

- `repos create` signs the announcement with the **agent's own key**, so the agent owns the repo. The clone-URL owner segment is the agent's own pubkey (hex, not a username).
- Git auth is **automatic**: the harness configures the `git-credential-nostr` helper, so plain `git clone`/`push`/`pull` work over NIP-98. No private key ever touches a git command line, and the human never needs to hand over a key.

The nest skill previously covered relay/CLI mechanics but said nothing about git — exactly the gap that bit. Four lines close it.

## Scope

One section, 4 inserted lines. No behavior change — documentation only.

Sources: `docs/git-on-object-storage.md`, `crates/git-credential-nostr/README.md`, `crates/buzz-dev-mcp/src/shim.rs` (harness credential-helper wiring).