### PR TITLE
feat(chart): per-pod emptyDir git scratch when persistence disabled (multi-replica HA)

### DIFF
--- a/deploy/charts/buzz/Chart.yaml
+++ b/deploy/charts/buzz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   PostgreSQL and Redis. Configurable for single-node evaluation
   (subcharts on) and HA production (external services, existingSecret).
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"
 home: https://github.com/block/buzz
 sources:

--- a/deploy/charts/buzz/templates/deployment.yaml
+++ b/deploy/charts/buzz/templates/deployment.yaml
@@ -164,13 +164,13 @@ spec:
             {{- toYaml .Values.relay.resources | nindent 12 }}
 
           volumeMounts:
-            {{- if .Values.persistence.git.enabled }}
             - { name: git-repos, mountPath: {{ .Values.persistence.git.mountPath | quote }} }
-            {{- end }}
 
       volumes:
-        {{- if .Values.persistence.git.enabled }}
         - name: git-repos
+        {{- if .Values.persistence.git.enabled }}
           persistentVolumeClaim:
             claimName: {{ default (printf "%s-git" (include "buzz.fullname" .)) .Values.persistence.git.existingClaim }}
+        {{- else }}
+          emptyDir: {}
         {{- end }}

--- a/deploy/charts/buzz/tests/render_test.yaml
+++ b/deploy/charts/buzz/tests/render_test.yaml
@@ -101,3 +101,38 @@ tests:
             name: BUZZ_HUDDLE_AUDIO_AVAILABLE
             value: "false"
         template: templates/deployment.yaml
+
+  - it: mounts a per-pod emptyDir git scratch volume when persistence is disabled
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+      replicaCount: 5
+      persistence.git.enabled: false
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 5
+        template: templates/deployment.yaml
+      # git-repos is still mounted (BUZZ_GIT_REPO_PATH must be a real dir)…
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: git-repos
+            mountPath: /var/lib/buzz/git
+        template: templates/deployment.yaml
+      # …but as a per-pod emptyDir, not a shared PVC (no multi-attach).
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: git-repos
+            emptyDir: {}
+        template: templates/deployment.yaml
+      # No PVC is rendered at all when persistence is disabled.
+      - hasDocuments:
+          count: 0
+        template: templates/pvc-git.yaml

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -176,14 +176,21 @@ httproute:
 # ── Git scratch volume ───────────────────────────────────────────────────────
 # Ephemeral working space only. No persistent git state lives here — reads/writes
 # hydrate ephemeral repos from object storage per request, and repo-name
-# uniqueness lives in Postgres. ReadWriteOnce is correct at any replicaCount; a
-# ReadWriteMany volume is NOT required for multi-pod.
+# uniqueness lives in Postgres.
+#
+# enabled: true  → mount a PVC at mountPath (durable across pod restarts, but a
+#   single ReadWriteOnce PVC binds to one node, so it does NOT support multi-pod
+#   scheduling across nodes on a Deployment).
+# enabled: false → mount a per-pod emptyDir at mountPath (pure scratch). This is
+#   the correct choice for multi-replica HA: each pod gets its own local working
+#   space, nothing is shared, and there is no volume to multi-attach. Safe
+#   because the object store + Postgres are the sources of truth, not this disk.
 persistence:
   git:
     enabled: true
     mountPath: /var/lib/buzz/git
     storageClass: ""
-    accessMode: ReadWriteOnce    # RWO is fine at any replicaCount (object-store-backed git)
+    accessMode: ReadWriteOnce
     size: 10Gi
     annotations: {}
     existingClaim: ""


### PR DESCRIPTION
## What
Make the relay's git working directory a **per-pod `emptyDir` scratch volume** when `persistence.git.enabled: false`, so the relay scales to N replicas cleanly.

## Why
The git working dir (`BUZZ_GIT_REPO_PATH`) is ephemeral scratch — reads/writes hydrate repos from object storage per request, and repo-name uniqueness lives in Postgres (as of #1432). Nothing durable lives on this disk.

Two problems with the old shape:
1. `persistence.git.enabled: false` mounted **nothing** — the git path pointed at an unmounted directory (git data landed on the container rootfs).
2. `enabled: true` mounts a single **`ReadWriteOnce` PVC**, which binds to one node. On a `Deployment` with `replicaCount > 1`, pods scheduled onto other nodes stay `Pending` with a multi-attach error — even though the git data is fully disposable and could live on independent per-pod disks.

## Change
- `templates/deployment.yaml`: the `git-repos` volume is **always mounted** at `mountPath`; it's a PVC when `persistence.git.enabled`, a per-pod `emptyDir` when not.
- `values.yaml`: document both modes; drop the misleading "RWO is fine at any replicaCount" note (true for disposability, not for multi-node scheduling).
- `tests/render_test.yaml`: assert the emptyDir + zero-PVC path at `replicaCount=5`.
- Chart `0.1.1 → 0.1.2`.

`enabled: true` renders the PVC exactly as before — backward compatible.

## Validation
- `helm unittest deploy/charts/buzz` → **31/31**.
- `helm template` with `persistence.git.enabled=false`: `replicas: 5`, `git-repos` → `emptyDir: {}`, **0 PVC docs**.
- `helm template` with `persistence.git.enabled=true`: `git-repos` → `persistentVolumeClaim: claimName: <fullname>-git`, 1 PVC doc.

## Deploy note
bb-block prod (buzz relay, scaling to 5) will consume this by bumping its chart dep to `0.1.2` and setting `buzz.persistence.git.enabled: false` — the storage half of squareup/bb-block#138.
