### PR TITLE
fix(ci): set PGSCHEMA_PLAN_* in start-relay-for-tests.sh to avoid embedded-PG fetch

### DIFF
--- a/scripts/start-relay-for-tests.sh
+++ b/scripts/start-relay-for-tests.sh
@@ -89,6 +89,14 @@ export PGUSER=buzz
 export PGPASSWORD=buzz_dev
 export PGDATABASE=buzz
 
+# Use the already-running docker postgres for desired-state planning instead of
+# downloading an embedded Postgres from Maven Central (transient-fetch flake source).
+export PGSCHEMA_PLAN_HOST=localhost
+export PGSCHEMA_PLAN_PORT=5432
+export PGSCHEMA_PLAN_DB=buzz
+export PGSCHEMA_PLAN_USER=buzz
+export PGSCHEMA_PLAN_PASSWORD=buzz_dev
+
 ./bin/pgschema apply --file schema/schema.sql --auto-approve
 docker exec -i -e PGPASSWORD="${PGPASSWORD}" buzz-postgres \
   psql -U "${PGUSER}" -d "${PGDATABASE}" -v ON_ERROR_STOP=1 < scripts/attach-schema-partitions.sql


### PR DESCRIPTION
## Summary

- Extends #1396's Bucket A fix to the Relay E2E script site (`scripts/start-relay-for-tests.sh`), which was the only remaining caller of `pgschema apply` missing the `PGSCHEMA_PLAN_*` env vars
- Without these vars, `pgschema` downloads an embedded Postgres from Maven Central for desired-state planning, causing transient `no version found matching 17.5.0` failures (e.g. run [28545465382](https://github.com/block/buzz/actions/runs/28545465382))
- Adds the same 5 exports (`PGSCHEMA_PLAN_HOST`, `PGSCHEMA_PLAN_PORT`, `PGSCHEMA_PLAN_DB`, `PGSCHEMA_PLAN_USER`, `PGSCHEMA_PLAN_PASSWORD`) pointing at the already-running docker Postgres, matching #1396's approach in `ci.yml`