### PR TITLE
fix(desktop): stop search shortcut from hijacking the sidebar

### DIFF
--- a/desktop/src/features/search/ui/TopbarSearch.tsx
+++ b/desktop/src/features/search/ui/TopbarSearch.tsx
@@ -538,13 +538,15 @@ export function TopbarSearch({
     ],
   );
 
+  // Edge-trigger: the counter never resets, so `!== 0` would replay on remount.
+  const lastFocusRequestRef = React.useRef(focusRequest);
   React.useEffect(() => {
-    if (focusRequest === 0) {
+    if (focusRequest === lastFocusRequestRef.current) {
       return;
     }
+    lastFocusRequestRef.current = focusRequest;
 
     openSearchDialog();
-    triggerRef.current?.focus();
   }, [focusRequest, openSearchDialog]);
 
   React.useEffect(() => {

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -62,7 +62,6 @@ import {
   SidebarMenu,
   SidebarMenuItem,
   SidebarRail,
-  useSidebar,
 } from "@/shared/ui/sidebar";
 
 type CollapsibleSidebarGroup =
@@ -239,24 +238,6 @@ export function AppSidebar({
   const setIsNewDmOpen = onNewDmOpenChange ?? setIsNewDmOpenInternal;
   const scrollRef = React.useRef<HTMLDivElement>(null);
   useSidebarScrollLock(scrollRef);
-
-  // Search lives in the sidebar's pinned header, so a ⌘K focus request must
-  // first reveal the sidebar. When collapsed (offcanvas) on desktop the input
-  // is mounted but translated off-screen; on mobile it is unmounted entirely.
-  // Open the sidebar on each focus-request bump so the input the shortcut
-  // focuses is actually visible. Skips the initial mount (request === 0).
-  const { isMobile, setOpen, setOpenMobile } = useSidebar();
-  React.useEffect(() => {
-    if (searchFocusRequest === 0) {
-      return;
-    }
-
-    if (isMobile) {
-      setOpenMobile(true);
-    } else {
-      setOpen(true);
-    }
-  }, [searchFocusRequest, isMobile, setOpen, setOpenMobile]);
 
   React.useEffect(() => {
     const scrollElement = scrollRef.current;

--- a/desktop/tests/e2e/navigation.spec.ts
+++ b/desktop/tests/e2e/navigation.spec.ts
@@ -274,6 +274,26 @@ test("settings shortcut returns without opening search dialog", async ({
   await expect(page.getByTestId("chat-title")).toHaveText("general");
   const channelUrl = page.url();
 
+  // Open search via the ⌘K shortcut so the focus-request counter is non-zero,
+  // then close it. The Settings subtree remounts the sidebar + search on close,
+  // which must not replay the stale counter and resurrect search.
+  await page.evaluate(() => {
+    const isMac = /mac|iphone|ipad|ipod/i.test(navigator.platform);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        code: "KeyK",
+        ctrlKey: !isMac,
+        key: "k",
+        metaKey: isMac,
+      }),
+    );
+  });
+  await expect(page.getByTestId("search-dialog-input")).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("search-results")).not.toBeVisible();
+
   await page.keyboard.press(
     process.platform === "darwin" ? "Meta+Comma" : "Control+Comma",
   );

--- a/desktop/tests/e2e/smoke.spec.ts
+++ b/desktop/tests/e2e/smoke.spec.ts
@@ -318,7 +318,7 @@ test("closes sidebar search with Escape", async ({ page }) => {
   await expect(page.getByTestId("open-search")).toBeFocused();
 });
 
-test("reopens the collapsed sidebar when the search shortcut fires", async ({
+test("search shortcut opens search without disturbing the collapsed sidebar", async ({
   page,
 }) => {
   await page.goto("/");
@@ -334,11 +334,23 @@ test("reopens the collapsed sidebar when the search shortcut fires", async ({
     .click();
   await expect(sidebarRoot).toHaveAttribute("data-state", "collapsed");
 
-  await focusSidebarSearchWithShortcut(page);
+  await page.evaluate(() => {
+    const isMac = /mac|iphone|ipad|ipod/i.test(navigator.platform);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        code: "KeyK",
+        ctrlKey: !isMac,
+        key: "k",
+        metaKey: isMac,
+      }),
+    );
+  });
 
-  // The shortcut reveals the sidebar and focuses the dialog search input.
-  await expect(sidebarRoot).toHaveAttribute("data-state", "expanded");
+  // Search opens in its portal dialog; the sidebar must not react.
   await expect(page.getByTestId("search-dialog-input")).toBeFocused();
+  await expect(sidebarRoot).toHaveAttribute("data-state", "collapsed");
 });
 
 test("search results use your resolved profile label instead of You", async ({


### PR DESCRIPTION
## Problem

Two related bugs reported with global search (⌘K):

1. **⌘K forces a collapsed sidebar open.** The search input actually lives in a centered portal dialog, not the sidebar, so there is no reason for the sidebar to move.
2. **Closing Settings resurrects the search dialog** (and the sidebar toggle appears "broken" because the sidebar keeps getting force-opened).

## Root cause

Search open is signaled by `searchFocusRequest`, a monotonically incrementing counter in `AppShell`. Two effects watched it — one in `TopbarSearch` (opens the dialog) and one in `AppSidebar` (`setOpen(true)` to reveal the pinned-header trigger). Both guarded only on `counter === 0`, and the counter never resets. Any remount while it was non-zero — e.g. closing Settings, which remounts the sidebar subtree — replayed the last "open search + open sidebar."

## Fix

- **`AppSidebar.tsx`** — delete the effect that force-opened the sidebar on every focus request. (The `isMobile`/`setOpenMobile` branch was unreachable in the desktop app: Tauri `minWidth` is 800, mobile breakpoint is 768.)
- **`TopbarSearch.tsx`** — make the open effect edge-triggered via a ref initialized to the current counter, so it fires only on a genuine change, never on remount. Also drop the now-pointless refocus of the (possibly off-screen) sidebar trigger button.

## Tests

- `smoke.spec.ts` — collapsed-sidebar test now asserts the sidebar **stays collapsed** on ⌘K (failed on old code with "expected collapsed, received expanded").
- `navigation.spec.ts` — settings-shortcut test extended: open search via ⌘K → close → open/close Settings → search must stay hidden (failed on old code, reproducing the report exactly).

## Verification

- `just desktop-check`, `just desktop-typecheck`, `just desktop-test` (1475 unit tests) ✅
- Both affected smoke E2E specs: 30 passed ✅
- Full smoke E2E run: two failures in `channels.spec.ts` / `scroll-history.spec.ts` are pre-existing on `main` (reproduced on a clean `main` checkout) and unrelated to this change.
