### PR TITLE
fix(profile): consolidate agent profile runtime metadata

### DIFF
--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
@@ -114,25 +114,13 @@ pub(crate) fn read_config_surface(
             overridden_origin: None,
             is_required: false,
         }),
-        system_prompt: {
-            let record_system_prompt = record
+        system_prompt: build_system_prompt_field(
+            &record
                 .system_prompt
                 .clone()
-                .or_else(|| record.env_vars.get("BUZZ_ACP_SYSTEM_PROMPT").cloned());
-            record_system_prompt.as_ref().map(|v| NormalizedField {
-                value: Some(v.clone()),
-                origin: ConfigOrigin::BuzzExplicit,
-                write_via: ConfigWriteMechanism::RespawnWithEnvVar {
-                    env_key: "BUZZ_ACP_SYSTEM_PROMPT".to_string(),
-                },
-                overridden_value: file_config.system_prompt.clone(),
-                overridden_origin: file_config
-                    .system_prompt
-                    .as_ref()
-                    .map(|_| ConfigOrigin::ConfigFile),
-                is_required: false,
-            })
-        },
+                .or_else(|| record.env_vars.get("BUZZ_ACP_SYSTEM_PROMPT").cloned()),
+            &file_config.system_prompt,
+        ),
     };
 
     // Advanced fields from config file extras.
@@ -464,6 +452,38 @@ fn build_thinking_field(
     })
 }
 
+/// Record/env prompt wins (BuzzExplicit, respawnable); a config-file prompt it
+/// shadows is reported as the overridden secondary. A config-file-only prompt
+/// — no record/env value to shadow it — is surfaced directly (read-only)
+/// instead of being dropped: a prompt that drives the agent should always be
+/// visible somewhere in the panel.
+fn build_system_prompt_field(
+    record_prompt: &Option<String>,
+    file_prompt: &Option<String>,
+) -> Option<NormalizedField> {
+    if let Some(v) = record_prompt {
+        return Some(NormalizedField {
+            value: Some(v.clone()),
+            origin: ConfigOrigin::BuzzExplicit,
+            write_via: ConfigWriteMechanism::RespawnWithEnvVar {
+                env_key: "BUZZ_ACP_SYSTEM_PROMPT".to_string(),
+            },
+            overridden_value: file_prompt.clone(),
+            overridden_origin: file_prompt.as_ref().map(|_| ConfigOrigin::ConfigFile),
+            is_required: false,
+        });
+    }
+
+    file_prompt.as_ref().map(|v| NormalizedField {
+        value: Some(v.clone()),
+        origin: ConfigOrigin::ConfigFile,
+        write_via: ConfigWriteMechanism::ReadOnly,
+        overridden_value: None,
+        overridden_origin: None,
+        is_required: false,
+    })
+}
+
 /// Picks the first `Some` value from `tiers` (highest-precedence first) and
 /// returns `(value, origin, overridden_value, overridden_origin)` where the
 /// overridden pair is the next `Some` tier after the winner. Returns `None`
@@ -528,469 +548,5 @@ fn resolve_tilde(path: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-
-    use super::*;
-    use crate::managed_agents::discovery::KnownAcpRuntime;
-    use crate::managed_agents::types::ManagedAgentRecord;
-
-    fn test_runtime() -> &'static KnownAcpRuntime {
-        &KnownAcpRuntime {
-            id: "goose",
-            label: "Goose",
-            commands: &["goose"],
-            aliases: &[],
-            avatar_url: "",
-            mcp_command: None,
-            mcp_hooks: false,
-            underlying_cli: None,
-            cli_install_commands: &[],
-            adapter_install_commands: &[],
-            install_instructions_url: "",
-            cli_install_hint: "",
-            adapter_install_hint: "",
-            skill_dir: None,
-            supports_acp_model_switching: false,
-            model_env_var: Some("GOOSE_MODEL"),
-            provider_env_var: Some("GOOSE_PROVIDER"),
-            provider_locked: false,
-            default_env: &[],
-            config_file_path: Some("~/.config/goose/config.yaml"),
-            config_file_format: Some("yaml"),
-            supports_acp_native_config: true,
-            thinking_env_var: Some("GOOSE_THINKING_EFFORT"),
-            required_normalized_fields: &["model", "provider"],
-        }
-    }
-
-    fn test_record() -> ManagedAgentRecord {
-        ManagedAgentRecord {
-            pubkey: "test".to_string(),
-            name: "Test Agent".to_string(),
-            persona_id: None,
-            private_key_nsec: "".to_string(),
-            auth_tag: None,
-            relay_url: "ws://localhost:3000".to_string(),
-            avatar_url: None,
-            acp_command: "buzz-acp".to_string(),
-            agent_command: "goose".to_string(),
-            agent_args: vec![],
-            mcp_command: "".to_string(),
-            turn_timeout_seconds: 300,
-            idle_timeout_seconds: None,
-            max_turn_duration_seconds: None,
-            parallelism: 1,
-            system_prompt: None,
-            model: None,
-            mcp_toolsets: None,
-            env_vars: BTreeMap::new(),
-            start_on_app_launch: false,
-            runtime_pid: None,
-            backend: crate::managed_agents::types::BackendKind::Local,
-            backend_agent_id: None,
-            provider_binary_path: None,
-            persona_team_dir: None,
-            persona_name_in_team: None,
-            created_at: "".to_string(),
-            updated_at: "".to_string(),
-            last_started_at: None,
-            last_stopped_at: None,
-            last_exit_code: None,
-            last_error: None,
-            respond_to: crate::managed_agents::types::RespondTo::OwnerOnly,
-            respond_to_allowlist: vec![],
-            relay_mesh: None,
-            agent_command_override: None,
-            persona_source_version: None,
-            provider: None,
-        }
-    }
-
-    #[test]
-    fn pre_spawn_surface_reports_pending_acp_tiers() {
-        let record = test_record();
-        let runtime = test_runtime();
-        let surface = read_config_surface(&record, Some(runtime), None, None);
-
-        assert!(surface.is_pre_spawn);
-        assert_eq!(surface.sources.acp_native, ConfigTierStatus::Pending);
-        assert_eq!(
-            surface.sources.acp_config_options,
-            ConfigTierStatus::Pending
-        );
-        assert_eq!(surface.sources.env_vars, ConfigTierStatus::Available);
-    }
-
-    #[test]
-    fn record_model_overrides_file_model() {
-        let mut record = test_record();
-        record.model = Some("explicit-model".to_string());
-        let runtime = test_runtime();
-
-        let surface = read_config_surface(&record, Some(runtime), None, None);
-        let model = surface.normalized.model.unwrap();
-        assert_eq!(model.value.as_deref(), Some("explicit-model"));
-        assert_eq!(model.origin, ConfigOrigin::BuzzExplicit);
-    }
-
-    #[test]
-    fn provider_locked_shows_locked() {
-        let record = test_record();
-        let runtime = &KnownAcpRuntime {
-            provider_locked: true,
-            ..*test_runtime()
-        };
-        let surface = read_config_surface(&record, Some(runtime), None, None);
-        let provider = surface.normalized.provider.unwrap();
-        assert_eq!(provider.value.as_deref(), Some("Anthropic (locked)"));
-        assert_eq!(provider.origin, ConfigOrigin::HarnessConstraint);
-    }
-
-    #[test]
-    fn post_spawn_with_model_config_option_uses_acp() {
-        let record = test_record();
-        let runtime = test_runtime();
-        let cache = SessionConfigCache {
-            config_options: vec![AcpConfigOptionEntry {
-                config_id: "model".to_string(),
-                category: Some("model".to_string()),
-                display_name: Some("Model".to_string()),
-                current_value: Some("claude-opus-4".to_string()),
-                options: vec![],
-            }],
-            available_modes: vec![],
-            available_models: vec![],
-            current_model: Some("claude-opus-4".to_string()),
-            model_overridden: false,
-            goose_native_config: None,
-            captured_at: "".to_string(),
-        };
-
-        let surface = read_config_surface(&record, Some(runtime), Some(&cache), None);
-        assert!(!surface.is_pre_spawn);
-        let model = surface.normalized.model.unwrap();
-        assert_eq!(model.value.as_deref(), Some("claude-opus-4"));
-        assert!(matches!(
-            model.write_via,
-            ConfigWriteMechanism::AcpSetConfigOption { .. }
-        ));
-    }
-
-    #[test]
-    fn acp_model_overrides_file_model_with_override_tracking() {
-        let record = test_record();
-        let runtime = test_runtime();
-        let cache = SessionConfigCache {
-            config_options: vec![],
-            available_modes: vec![],
-            available_models: vec![],
-            current_model: Some("acp-model".to_string()),
-            model_overridden: false,
-            goose_native_config: None,
-            captured_at: "".to_string(),
-        };
-
-        let surface = read_config_surface(&record, Some(runtime), Some(&cache), None);
-        let model = surface.normalized.model.unwrap();
-        assert_eq!(model.value.as_deref(), Some("acp-model"));
-        assert_eq!(model.origin, ConfigOrigin::AcpConfigOption);
-        // The goose config file might have a model too — since we can't control
-        // the actual file in a unit test, just verify the override fields are populated
-        // when we manually construct the scenario via build_model_field.
-    }
-
-    // ── Persona resolution integration tests ────────────────────────────
-    //
-    // These simulate the call-site pattern in agent_config.rs:
-    // 1. Inject persona-resolved values into the record (as if absent)
-    // 2. Call read_config_surface (reader tags them BuzzExplicit)
-    // 3. Re-tag injected fields to PersonaDefault
-    //
-    // This exercises the same logic path as get_agent_config_surface without
-    // requiring Tauri AppHandle/State infrastructure.
-
-    #[test]
-    fn persona_model_injection_produces_persona_default_origin() {
-        let mut record = test_record();
-        // Simulate: record has no model, persona provides one.
-        // The call-site injects it before calling the reader.
-        record.model = Some("persona-model".to_string());
-        let runtime = test_runtime();
-
-        let mut surface = read_config_surface(&record, Some(runtime), None, None);
-
-        // Reader sees injected model as BuzzExplicit.
-        let model = surface.normalized.model.as_ref().unwrap();
-        assert_eq!(model.value.as_deref(), Some("persona-model"));
-        assert_eq!(model.origin, ConfigOrigin::BuzzExplicit);
-
-        // Call-site re-tags (simulating had_model == false).
-        if let Some(ref mut field) = surface.normalized.model {
-            if field.origin == ConfigOrigin::BuzzExplicit {
-                field.origin = ConfigOrigin::PersonaDefault;
-            }
-        }
-
-        let model = surface.normalized.model.unwrap();
-        assert_eq!(model.value.as_deref(), Some("persona-model"));
-        assert_eq!(model.origin, ConfigOrigin::PersonaDefault);
-    }
-
-    // ── Runtime override (Phase 3c) ──────────────────────────────────────
-    //
-    // A live ModelPicker switch is signalled by `model_overridden: true` in the
-    // `session_config_captured` payload. The reader keys the override-active
-    // decision off that flag — NOT off `acp_model != persona_model`, which would
-    // false-positive when a persona model is edited mid-life.
-
-    #[test]
-    fn runtime_override_wins_display_when_model_overridden_is_true() {
-        // Persona-linked agent (record.model == None); persona == "persona-model".
-        // A live switch pushed "live-model" to the session and set model_overridden.
-        let record = test_record();
-        let runtime = test_runtime();
-        let cache = SessionConfigCache {
-            config_options: vec![],
-            available_modes: vec![],
-            available_models: vec![],
-            current_model: Some("live-model".to_string()),
-            model_overridden: true,
-            goose_native_config: None,
-            captured_at: "".to_string(),
-        };
-
-        let surface = read_config_surface(
-            &record,
-            Some(runtime),
-            Some(&cache),
-            Some(("persona-model", ConfigOrigin::PersonaDefault)),
-        );
-        let model = surface.normalized.model.unwrap();
-
-        // Override wins the display value with a runtime-override origin.
-        assert_eq!(model.value.as_deref(), Some("live-model"));
-        assert_eq!(model.origin, ConfigOrigin::RuntimeOverride);
-        // Persona is the secondary value (not struck through — the UI keys off
-        // the RuntimeOverride origin to suppress strikethrough).
-        assert_eq!(model.overridden_value.as_deref(), Some("persona-model"));
-        assert_eq!(model.overridden_origin, Some(ConfigOrigin::PersonaDefault));
-    }
-
-    #[test]
-    fn no_runtime_override_when_model_overridden_is_false() {
-        // At spawn the session's current_model == persona model (BUZZ_ACP_MODEL
-        // is set to the persona model) and model_overridden is false. No override;
-        // the field falls through to normal precedence.
-        let record = test_record();
-        let runtime = test_runtime();
-        let cache = SessionConfigCache {
-            config_options: vec![],
-            available_modes: vec![],
-            available_models: vec![],
-            current_model: Some("persona-model".to_string()),
-            model_overridden: false,
-            goose_native_config: None,
-            captured_at: "".to_string(),
-        };
-
-        let surface = read_config_surface(
-            &record,
-            Some(runtime),
-            Some(&cache),
-            Some(("persona-model", ConfigOrigin::PersonaDefault)),
-        );
-        let model = surface.normalized.model.unwrap();
-
-        // model_overridden is false => the override branch is not taken: origin
-        // is the normal precedence result, never RuntimeOverride.
-        assert_ne!(model.origin, ConfigOrigin::RuntimeOverride);
-        assert_eq!(model.value.as_deref(), Some("persona-model"));
-        assert_ne!(model.overridden_origin, Some(ConfigOrigin::PersonaDefault));
-    }
-
-    #[test]
-    fn no_false_positive_override_when_persona_edited_mid_life() {
-        // Persona-linked agent whose persona model was edited A→B while the
-        // session is stale on the old model A. `model_overridden` is false
-        // because no SwitchModel control signal was sent — the session is merely
-        // stale. Despite acp_model("A") != persona_model("B"), no RuntimeOverride
-        // should be displayed.
-        let record = test_record();
-        let runtime = test_runtime();
-        let cache = SessionConfigCache {
-            config_options: vec![],
-            available_modes: vec![],
-            available_models: vec![],
-            current_model: Some("old-persona-model".to_string()),
-            model_overridden: false,
-            goose_native_config: None,
-            captured_at: "".to_string(),
-        };
-
-        let surface = read_config_surface(
-            &record,
-            Some(runtime),
-            Some(&cache),
-            Some(("new-persona-model", ConfigOrigin::PersonaDefault)),
-        );
-        let model = surface.normalized.model.unwrap();
-
-        // model_overridden is false => no RuntimeOverride, even though
-        // acp_model != persona_model. The old divergence-based signal would
-        // have false-positived here. The persona is never surfaced as the
-        // overridden secondary (that marker is exclusive to a real override).
-        assert_ne!(model.origin, ConfigOrigin::RuntimeOverride);
-        assert_ne!(model.overridden_origin, Some(ConfigOrigin::PersonaDefault));
-    }
-
-    #[test]
-    fn persona_provider_injection_produces_persona_default_origin() {
-        let mut record = test_record();
-        // Simulate: record has no provider env var, persona provides one.
-        // The call-site injects it as GOOSE_PROVIDER before calling the reader.
-        record
-            .env_vars
-            .insert("GOOSE_PROVIDER".to_string(), "anthropic".to_string());
-        let runtime = test_runtime();
-
-        let mut surface = read_config_surface(&record, Some(runtime), None, None);
-
-        // Reader sees injected provider as BuzzExplicit.
-        let provider = surface.normalized.provider.as_ref().unwrap();
-        assert_eq!(provider.value.as_deref(), Some("anthropic"));
-        assert_eq!(provider.origin, ConfigOrigin::BuzzExplicit);
-
-        // Call-site re-tags (simulating had_provider == false).
-        if let Some(ref mut field) = surface.normalized.provider {
-            if field.origin == ConfigOrigin::BuzzExplicit {
-                field.origin = ConfigOrigin::PersonaDefault;
-            }
-        }
-
-        let provider = surface.normalized.provider.unwrap();
-        assert_eq!(provider.value.as_deref(), Some("anthropic"));
-        assert_eq!(provider.origin, ConfigOrigin::PersonaDefault);
-    }
-
-    #[test]
-    fn persona_system_prompt_injection_produces_persona_default_origin() {
-        let mut record = test_record();
-        // Simulate: record has no system_prompt, persona provides one via env var.
-        // The call-site injects it as BUZZ_ACP_SYSTEM_PROMPT before calling the reader.
-        record.env_vars.insert(
-            "BUZZ_ACP_SYSTEM_PROMPT".to_string(),
-            "You are a helpful assistant.".to_string(),
-        );
-        let runtime = test_runtime();
-
-        let mut surface = read_config_surface(&record, Some(runtime), None, None);
-
-        // Reader sees injected prompt as BuzzExplicit.
-        let prompt = surface.normalized.system_prompt.as_ref().unwrap();
-        assert_eq!(
-            prompt.value.as_deref(),
-            Some("You are a helpful assistant.")
-        );
-        assert_eq!(prompt.origin, ConfigOrigin::BuzzExplicit);
-
-        // Call-site re-tags (simulating had_prompt == false).
-        if let Some(ref mut field) = surface.normalized.system_prompt {
-            if field.origin == ConfigOrigin::BuzzExplicit {
-                field.origin = ConfigOrigin::PersonaDefault;
-            }
-        }
-
-        let prompt = surface.normalized.system_prompt.unwrap();
-        assert_eq!(
-            prompt.value.as_deref(),
-            Some("You are a helpful assistant.")
-        );
-        assert_eq!(prompt.origin, ConfigOrigin::PersonaDefault);
-    }
-
-    #[test]
-    fn explicit_record_model_not_retagged_when_already_present() {
-        let mut record = test_record();
-        // Record already has its own model — persona resolution should NOT re-tag.
-        record.model = Some("explicit-model".to_string());
-        let runtime = test_runtime();
-
-        let surface = read_config_surface(&record, Some(runtime), None, None);
-
-        // had_model == true, so no re-tagging occurs. Origin stays BuzzExplicit.
-        let model = surface.normalized.model.unwrap();
-        assert_eq!(model.value.as_deref(), Some("explicit-model"));
-        assert_eq!(model.origin, ConfigOrigin::BuzzExplicit);
-    }
-
-    #[test]
-    fn extra_env_vars_appear_in_advanced_as_buzz_explicit() {
-        let mut record = test_record();
-        // Normalized keys — must NOT appear in advanced.
-        record
-            .env_vars
-            .insert("GOOSE_MODEL".to_string(), "some-model".to_string());
-        record
-            .env_vars
-            .insert("BUZZ_ACP_SYSTEM_PROMPT".to_string(), "hello".to_string());
-        // Non-normalized key — MUST appear in advanced.
-        record
-            .env_vars
-            .insert("SPROUT_ACP_MEMORY".to_string(), "mem-value".to_string());
-        let runtime = test_runtime();
-
-        let surface = read_config_surface(&record, Some(runtime), None, None);
-
-        let advanced_keys: Vec<&str> = surface.advanced.iter().map(|f| f.key.as_str()).collect();
-        assert!(
-            advanced_keys.contains(&"SPROUT_ACP_MEMORY"),
-            "extra env var must appear in advanced"
-        );
-        assert!(
-            !advanced_keys.contains(&"GOOSE_MODEL"),
-            "normalized model key must not appear in advanced"
-        );
-        assert!(
-            !advanced_keys.contains(&"BUZZ_ACP_SYSTEM_PROMPT"),
-            "normalized system prompt key must not appear in advanced"
-        );
-
-        let field = surface
-            .advanced
-            .iter()
-            .find(|f| f.key == "SPROUT_ACP_MEMORY")
-            .unwrap();
-        assert_eq!(field.value.as_deref(), Some("mem-value"));
-        assert_eq!(field.origin, ConfigOrigin::BuzzExplicit);
-        assert!(matches!(
-            field.write_via,
-            ConfigWriteMechanism::RespawnWithEnvVar { ref env_key } if env_key == "SPROUT_ACP_MEMORY"
-        ));
-    }
-
-    #[test]
-    fn extra_env_var_skipped_when_already_in_file_config_extra() {
-        // If a key is in both record.env_vars and file_config.extra, the config
-        // file entry wins (it was already added to advanced). The env var must
-        // not produce a second entry.
-        //
-        // We can't inject into file_config.extra directly in a unit test (it
-        // comes from disk), so we verify the dedup logic via the normalized-key
-        // path: GOOSE_THINKING_EFFORT is a normalized key and must not appear
-        // in advanced even if set in env_vars.
-        let mut record = test_record();
-        record
-            .env_vars
-            .insert("GOOSE_THINKING_EFFORT".to_string(), "high".to_string());
-        let runtime = test_runtime();
-
-        let surface = read_config_surface(&record, Some(runtime), None, None);
-
-        let advanced_keys: Vec<&str> = surface.advanced.iter().map(|f| f.key.as_str()).collect();
-        assert!(
-            !advanced_keys.contains(&"GOOSE_THINKING_EFFORT"),
-            "normalized thinking key must not appear in advanced"
-        );
-    }
-}
+#[path = "reader_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -1,0 +1,497 @@
+//! Unit tests for `config_bridge/reader.rs` (kept in a sibling file so
+//! `reader.rs` stays under the 1000-line budget; `#[path]`-included from
+//! there).
+
+use std::collections::BTreeMap;
+
+use super::*;
+use crate::managed_agents::discovery::KnownAcpRuntime;
+use crate::managed_agents::types::ManagedAgentRecord;
+
+fn test_runtime() -> &'static KnownAcpRuntime {
+    &KnownAcpRuntime {
+        id: "goose",
+        label: "Goose",
+        commands: &["goose"],
+        aliases: &[],
+        avatar_url: "",
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: None,
+        cli_install_commands: &[],
+        adapter_install_commands: &[],
+        install_instructions_url: "",
+        cli_install_hint: "",
+        adapter_install_hint: "",
+        skill_dir: None,
+        supports_acp_model_switching: false,
+        model_env_var: Some("GOOSE_MODEL"),
+        provider_env_var: Some("GOOSE_PROVIDER"),
+        provider_locked: false,
+        default_env: &[],
+        config_file_path: Some("~/.config/goose/config.yaml"),
+        config_file_format: Some("yaml"),
+        supports_acp_native_config: true,
+        thinking_env_var: Some("GOOSE_THINKING_EFFORT"),
+        required_normalized_fields: &["model", "provider"],
+    }
+}
+
+fn test_record() -> ManagedAgentRecord {
+    ManagedAgentRecord {
+        pubkey: "test".to_string(),
+        name: "Test Agent".to_string(),
+        persona_id: None,
+        private_key_nsec: "".to_string(),
+        auth_tag: None,
+        relay_url: "ws://localhost:3000".to_string(),
+        avatar_url: None,
+        acp_command: "buzz-acp".to_string(),
+        agent_command: "goose".to_string(),
+        agent_args: vec![],
+        mcp_command: "".to_string(),
+        turn_timeout_seconds: 300,
+        idle_timeout_seconds: None,
+        max_turn_duration_seconds: None,
+        parallelism: 1,
+        system_prompt: None,
+        model: None,
+        mcp_toolsets: None,
+        env_vars: BTreeMap::new(),
+        start_on_app_launch: false,
+        runtime_pid: None,
+        backend: crate::managed_agents::types::BackendKind::Local,
+        backend_agent_id: None,
+        provider_binary_path: None,
+        persona_team_dir: None,
+        persona_name_in_team: None,
+        created_at: "".to_string(),
+        updated_at: "".to_string(),
+        last_started_at: None,
+        last_stopped_at: None,
+        last_exit_code: None,
+        last_error: None,
+        respond_to: crate::managed_agents::types::RespondTo::OwnerOnly,
+        respond_to_allowlist: vec![],
+        relay_mesh: None,
+        agent_command_override: None,
+        persona_source_version: None,
+        provider: None,
+    }
+}
+
+#[test]
+fn pre_spawn_surface_reports_pending_acp_tiers() {
+    let record = test_record();
+    let runtime = test_runtime();
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    assert!(surface.is_pre_spawn);
+    assert_eq!(surface.sources.acp_native, ConfigTierStatus::Pending);
+    assert_eq!(
+        surface.sources.acp_config_options,
+        ConfigTierStatus::Pending
+    );
+    assert_eq!(surface.sources.env_vars, ConfigTierStatus::Available);
+}
+
+#[test]
+fn record_model_overrides_file_model() {
+    let mut record = test_record();
+    record.model = Some("explicit-model".to_string());
+    let runtime = test_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+    let model = surface.normalized.model.unwrap();
+    assert_eq!(model.value.as_deref(), Some("explicit-model"));
+    assert_eq!(model.origin, ConfigOrigin::BuzzExplicit);
+}
+
+#[test]
+fn provider_locked_shows_locked() {
+    let record = test_record();
+    let runtime = &KnownAcpRuntime {
+        provider_locked: true,
+        ..*test_runtime()
+    };
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+    let provider = surface.normalized.provider.unwrap();
+    assert_eq!(provider.value.as_deref(), Some("Anthropic (locked)"));
+    assert_eq!(provider.origin, ConfigOrigin::HarnessConstraint);
+}
+
+#[test]
+fn post_spawn_with_model_config_option_uses_acp() {
+    let record = test_record();
+    let runtime = test_runtime();
+    let cache = SessionConfigCache {
+        config_options: vec![AcpConfigOptionEntry {
+            config_id: "model".to_string(),
+            category: Some("model".to_string()),
+            display_name: Some("Model".to_string()),
+            current_value: Some("claude-opus-4".to_string()),
+            options: vec![],
+        }],
+        available_modes: vec![],
+        available_models: vec![],
+        current_model: Some("claude-opus-4".to_string()),
+        model_overridden: false,
+        goose_native_config: None,
+        captured_at: "".to_string(),
+    };
+
+    let surface = read_config_surface(&record, Some(runtime), Some(&cache), None);
+    assert!(!surface.is_pre_spawn);
+    let model = surface.normalized.model.unwrap();
+    assert_eq!(model.value.as_deref(), Some("claude-opus-4"));
+    assert!(matches!(
+        model.write_via,
+        ConfigWriteMechanism::AcpSetConfigOption { .. }
+    ));
+}
+
+#[test]
+fn acp_model_overrides_file_model_with_override_tracking() {
+    let record = test_record();
+    let runtime = test_runtime();
+    let cache = SessionConfigCache {
+        config_options: vec![],
+        available_modes: vec![],
+        available_models: vec![],
+        current_model: Some("acp-model".to_string()),
+        model_overridden: false,
+        goose_native_config: None,
+        captured_at: "".to_string(),
+    };
+
+    let surface = read_config_surface(&record, Some(runtime), Some(&cache), None);
+    let model = surface.normalized.model.unwrap();
+    assert_eq!(model.value.as_deref(), Some("acp-model"));
+    assert_eq!(model.origin, ConfigOrigin::AcpConfigOption);
+    // The goose config file might have a model too — since we can't control
+    // the actual file in a unit test, just verify the override fields are populated
+    // when we manually construct the scenario via build_model_field.
+}
+
+// ── Persona resolution integration tests ────────────────────────────
+//
+// These simulate the call-site pattern in agent_config.rs:
+// 1. Inject persona-resolved values into the record (as if absent)
+// 2. Call read_config_surface (reader tags them BuzzExplicit)
+// 3. Re-tag injected fields to PersonaDefault
+//
+// This exercises the same logic path as get_agent_config_surface without
+// requiring Tauri AppHandle/State infrastructure.
+
+#[test]
+fn persona_model_injection_produces_persona_default_origin() {
+    let mut record = test_record();
+    // Simulate: record has no model, persona provides one.
+    // The call-site injects it before calling the reader.
+    record.model = Some("persona-model".to_string());
+    let runtime = test_runtime();
+
+    let mut surface = read_config_surface(&record, Some(runtime), None, None);
+
+    // Reader sees injected model as BuzzExplicit.
+    let model = surface.normalized.model.as_ref().unwrap();
+    assert_eq!(model.value.as_deref(), Some("persona-model"));
+    assert_eq!(model.origin, ConfigOrigin::BuzzExplicit);
+
+    // Call-site re-tags (simulating had_model == false).
+    if let Some(ref mut field) = surface.normalized.model {
+        if field.origin == ConfigOrigin::BuzzExplicit {
+            field.origin = ConfigOrigin::PersonaDefault;
+        }
+    }
+
+    let model = surface.normalized.model.unwrap();
+    assert_eq!(model.value.as_deref(), Some("persona-model"));
+    assert_eq!(model.origin, ConfigOrigin::PersonaDefault);
+}
+
+// ── Runtime override (Phase 3c) ──────────────────────────────────────
+//
+// A live ModelPicker switch is signalled by `model_overridden: true` in the
+// `session_config_captured` payload. The reader keys the override-active
+// decision off that flag — NOT off `acp_model != persona_model`, which would
+// false-positive when a persona model is edited mid-life.
+
+#[test]
+fn runtime_override_wins_display_when_model_overridden_is_true() {
+    // Persona-linked agent (record.model == None); persona == "persona-model".
+    // A live switch pushed "live-model" to the session and set model_overridden.
+    let record = test_record();
+    let runtime = test_runtime();
+    let cache = SessionConfigCache {
+        config_options: vec![],
+        available_modes: vec![],
+        available_models: vec![],
+        current_model: Some("live-model".to_string()),
+        model_overridden: true,
+        goose_native_config: None,
+        captured_at: "".to_string(),
+    };
+
+    let surface = read_config_surface(
+        &record,
+        Some(runtime),
+        Some(&cache),
+        Some(("persona-model", ConfigOrigin::PersonaDefault)),
+    );
+    let model = surface.normalized.model.unwrap();
+
+    // Override wins the display value with a runtime-override origin.
+    assert_eq!(model.value.as_deref(), Some("live-model"));
+    assert_eq!(model.origin, ConfigOrigin::RuntimeOverride);
+    // Persona is the secondary value (not struck through — the UI keys off
+    // the RuntimeOverride origin to suppress strikethrough).
+    assert_eq!(model.overridden_value.as_deref(), Some("persona-model"));
+    assert_eq!(model.overridden_origin, Some(ConfigOrigin::PersonaDefault));
+}
+
+#[test]
+fn no_runtime_override_when_model_overridden_is_false() {
+    // At spawn the session's current_model == persona model (BUZZ_ACP_MODEL
+    // is set to the persona model) and model_overridden is false. No override;
+    // the field falls through to normal precedence.
+    let record = test_record();
+    let runtime = test_runtime();
+    let cache = SessionConfigCache {
+        config_options: vec![],
+        available_modes: vec![],
+        available_models: vec![],
+        current_model: Some("persona-model".to_string()),
+        model_overridden: false,
+        goose_native_config: None,
+        captured_at: "".to_string(),
+    };
+
+    let surface = read_config_surface(
+        &record,
+        Some(runtime),
+        Some(&cache),
+        Some(("persona-model", ConfigOrigin::PersonaDefault)),
+    );
+    let model = surface.normalized.model.unwrap();
+
+    // model_overridden is false => the override branch is not taken: origin
+    // is the normal precedence result, never RuntimeOverride.
+    assert_ne!(model.origin, ConfigOrigin::RuntimeOverride);
+    assert_eq!(model.value.as_deref(), Some("persona-model"));
+    assert_ne!(model.overridden_origin, Some(ConfigOrigin::PersonaDefault));
+}
+
+#[test]
+fn no_false_positive_override_when_persona_edited_mid_life() {
+    // Persona-linked agent whose persona model was edited A→B while the
+    // session is stale on the old model A. `model_overridden` is false
+    // because no SwitchModel control signal was sent — the session is merely
+    // stale. Despite acp_model("A") != persona_model("B"), no RuntimeOverride
+    // should be displayed.
+    let record = test_record();
+    let runtime = test_runtime();
+    let cache = SessionConfigCache {
+        config_options: vec![],
+        available_modes: vec![],
+        available_models: vec![],
+        current_model: Some("old-persona-model".to_string()),
+        model_overridden: false,
+        goose_native_config: None,
+        captured_at: "".to_string(),
+    };
+
+    let surface = read_config_surface(
+        &record,
+        Some(runtime),
+        Some(&cache),
+        Some(("new-persona-model", ConfigOrigin::PersonaDefault)),
+    );
+    let model = surface.normalized.model.unwrap();
+
+    // model_overridden is false => no RuntimeOverride, even though
+    // acp_model != persona_model. The old divergence-based signal would
+    // have false-positived here. The persona is never surfaced as the
+    // overridden secondary (that marker is exclusive to a real override).
+    assert_ne!(model.origin, ConfigOrigin::RuntimeOverride);
+    assert_ne!(model.overridden_origin, Some(ConfigOrigin::PersonaDefault));
+}
+
+#[test]
+fn persona_provider_injection_produces_persona_default_origin() {
+    let mut record = test_record();
+    // Simulate: record has no provider env var, persona provides one.
+    // The call-site injects it as GOOSE_PROVIDER before calling the reader.
+    record
+        .env_vars
+        .insert("GOOSE_PROVIDER".to_string(), "anthropic".to_string());
+    let runtime = test_runtime();
+
+    let mut surface = read_config_surface(&record, Some(runtime), None, None);
+
+    // Reader sees injected provider as BuzzExplicit.
+    let provider = surface.normalized.provider.as_ref().unwrap();
+    assert_eq!(provider.value.as_deref(), Some("anthropic"));
+    assert_eq!(provider.origin, ConfigOrigin::BuzzExplicit);
+
+    // Call-site re-tags (simulating had_provider == false).
+    if let Some(ref mut field) = surface.normalized.provider {
+        if field.origin == ConfigOrigin::BuzzExplicit {
+            field.origin = ConfigOrigin::PersonaDefault;
+        }
+    }
+
+    let provider = surface.normalized.provider.unwrap();
+    assert_eq!(provider.value.as_deref(), Some("anthropic"));
+    assert_eq!(provider.origin, ConfigOrigin::PersonaDefault);
+}
+
+#[test]
+fn persona_system_prompt_injection_produces_persona_default_origin() {
+    let mut record = test_record();
+    // Simulate: record has no system_prompt, persona provides one via env var.
+    // The call-site injects it as BUZZ_ACP_SYSTEM_PROMPT before calling the reader.
+    record.env_vars.insert(
+        "BUZZ_ACP_SYSTEM_PROMPT".to_string(),
+        "You are a helpful assistant.".to_string(),
+    );
+    let runtime = test_runtime();
+
+    let mut surface = read_config_surface(&record, Some(runtime), None, None);
+
+    // Reader sees injected prompt as BuzzExplicit.
+    let prompt = surface.normalized.system_prompt.as_ref().unwrap();
+    assert_eq!(
+        prompt.value.as_deref(),
+        Some("You are a helpful assistant.")
+    );
+    assert_eq!(prompt.origin, ConfigOrigin::BuzzExplicit);
+
+    // Call-site re-tags (simulating had_prompt == false).
+    if let Some(ref mut field) = surface.normalized.system_prompt {
+        if field.origin == ConfigOrigin::BuzzExplicit {
+            field.origin = ConfigOrigin::PersonaDefault;
+        }
+    }
+
+    let prompt = surface.normalized.system_prompt.unwrap();
+    assert_eq!(
+        prompt.value.as_deref(),
+        Some("You are a helpful assistant.")
+    );
+    assert_eq!(prompt.origin, ConfigOrigin::PersonaDefault);
+}
+
+#[test]
+fn config_file_only_system_prompt_surfaces_as_read_only_config_file_field() {
+    // Record/env has no prompt; the config file does. It must NOT be
+    // dropped — it should surface with ConfigFile origin, read-only.
+    let field = build_system_prompt_field(&None, &Some("File-driven prompt.".to_string())).unwrap();
+    assert_eq!(field.value.as_deref(), Some("File-driven prompt."));
+    assert_eq!(field.origin, ConfigOrigin::ConfigFile);
+    assert!(matches!(field.write_via, ConfigWriteMechanism::ReadOnly));
+    assert!(field.overridden_value.is_none());
+}
+
+#[test]
+fn record_system_prompt_shadows_config_file_prompt_as_secondary() {
+    let field = build_system_prompt_field(
+        &Some("Record prompt.".to_string()),
+        &Some("File prompt.".to_string()),
+    )
+    .unwrap();
+    assert_eq!(field.value.as_deref(), Some("Record prompt."));
+    assert_eq!(field.origin, ConfigOrigin::BuzzExplicit);
+    assert_eq!(field.overridden_value.as_deref(), Some("File prompt."));
+    assert_eq!(field.overridden_origin, Some(ConfigOrigin::ConfigFile));
+}
+
+#[test]
+fn no_system_prompt_from_any_tier_yields_none() {
+    assert!(build_system_prompt_field(&None, &None).is_none());
+}
+
+#[test]
+fn explicit_record_model_not_retagged_when_already_present() {
+    let mut record = test_record();
+    // Record already has its own model — persona resolution should NOT re-tag.
+    record.model = Some("explicit-model".to_string());
+    let runtime = test_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    // had_model == true, so no re-tagging occurs. Origin stays BuzzExplicit.
+    let model = surface.normalized.model.unwrap();
+    assert_eq!(model.value.as_deref(), Some("explicit-model"));
+    assert_eq!(model.origin, ConfigOrigin::BuzzExplicit);
+}
+
+#[test]
+fn extra_env_vars_appear_in_advanced_as_buzz_explicit() {
+    let mut record = test_record();
+    // Normalized keys — must NOT appear in advanced.
+    record
+        .env_vars
+        .insert("GOOSE_MODEL".to_string(), "some-model".to_string());
+    record
+        .env_vars
+        .insert("BUZZ_ACP_SYSTEM_PROMPT".to_string(), "hello".to_string());
+    // Non-normalized key — MUST appear in advanced.
+    record
+        .env_vars
+        .insert("SPROUT_ACP_MEMORY".to_string(), "mem-value".to_string());
+    let runtime = test_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    let advanced_keys: Vec<&str> = surface.advanced.iter().map(|f| f.key.as_str()).collect();
+    assert!(
+        advanced_keys.contains(&"SPROUT_ACP_MEMORY"),
+        "extra env var must appear in advanced"
+    );
+    assert!(
+        !advanced_keys.contains(&"GOOSE_MODEL"),
+        "normalized model key must not appear in advanced"
+    );
+    assert!(
+        !advanced_keys.contains(&"BUZZ_ACP_SYSTEM_PROMPT"),
+        "normalized system prompt key must not appear in advanced"
+    );
+
+    let field = surface
+        .advanced
+        .iter()
+        .find(|f| f.key == "SPROUT_ACP_MEMORY")
+        .unwrap();
+    assert_eq!(field.value.as_deref(), Some("mem-value"));
+    assert_eq!(field.origin, ConfigOrigin::BuzzExplicit);
+    assert!(matches!(
+        field.write_via,
+        ConfigWriteMechanism::RespawnWithEnvVar { ref env_key } if env_key == "SPROUT_ACP_MEMORY"
+    ));
+}
+
+#[test]
+fn extra_env_var_skipped_when_already_in_file_config_extra() {
+    // If a key is in both record.env_vars and file_config.extra, the config
+    // file entry wins (it was already added to advanced). The env var must
+    // not produce a second entry.
+    //
+    // We can't inject into file_config.extra directly in a unit test (it
+    // comes from disk), so we verify the dedup logic via the normalized-key
+    // path: GOOSE_THINKING_EFFORT is a normalized key and must not appear
+    // in advanced even if set in env_vars.
+    let mut record = test_record();
+    record
+        .env_vars
+        .insert("GOOSE_THINKING_EFFORT".to_string(), "high".to_string());
+    let runtime = test_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    let advanced_keys: Vec<&str> = surface.advanced.iter().map(|f| f.key.as_str()).collect();
+    assert!(
+        !advanced_keys.contains(&"GOOSE_THINKING_EFFORT"),
+        "normalized thinking key must not appear in advanced"
+    );
+}

--- a/desktop/src/features/agents/ui/AgentConfigPanel.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigPanel.tsx
@@ -5,12 +5,15 @@ import {
   Brain,
   ChevronDown,
   ChevronRight,
+  Copy,
   Cpu,
   Hash,
   Layers,
+  Lock,
   MessageSquare,
   Server,
 } from "lucide-react";
+import { toast } from "sonner";
 
 import { useAgentConfigSurface } from "../hooks";
 import { cn } from "@/shared/lib/cn";
@@ -25,7 +28,74 @@ import type {
 
 type Props = {
   pubkey: string;
+  advancedMode?: "collapsed" | "flat";
 };
+
+async function copyToClipboard(value: string, label: string) {
+  await navigator.clipboard.writeText(value);
+  toast.success(`Copied ${label}`);
+}
+
+function isReadOnlyField({
+  origin,
+  writeVia,
+}: {
+  origin: ConfigOrigin;
+  writeVia: ConfigWriteMechanism;
+}) {
+  return writeVia.type === "readOnly" || origin === "harnessConstraint";
+}
+
+function ConfigFieldLabel({
+  label,
+  locked,
+}: {
+  label: string;
+  locked: boolean;
+}) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1.5 text-xs font-medium text-foreground">
+      <span className="truncate">{label}</span>
+      {locked ? (
+        <Lock
+          aria-label="Read-only"
+          className="h-3 w-3 shrink-0 text-muted-foreground/70"
+        />
+      ) : null}
+    </span>
+  );
+}
+
+function shouldOfferCopy({
+  fieldKey,
+  origin,
+  value,
+}: {
+  fieldKey?: keyof NormalizedConfig;
+  origin: ConfigOrigin;
+  value: string | null;
+}) {
+  if (!value) {
+    return false;
+  }
+
+  if (
+    fieldKey === "model" ||
+    fieldKey === "provider" ||
+    fieldKey === "maxOutputTokens" ||
+    fieldKey === "contextLimit"
+  ) {
+    return true;
+  }
+
+  if (origin === "envVar") {
+    return true;
+  }
+
+  return value.includes("/") || value.startsWith("~") || value.includes(":");
+}
+
+type RowVariant = "compact" | "profile";
 
 // ── Provenance sentence ──────────────────────────────────────────────────────
 
@@ -33,29 +103,27 @@ function provenanceSentence(
   origin: ConfigOrigin,
   writeVia: ConfigWriteMechanism,
   configFilePath: string | null,
-): string {
+): string | null {
   switch (origin) {
     case "buzzExplicit":
-      return "Set in Buzz";
+      return null;
     case "personaDefault":
-      return "Inherited from persona";
+      return "Persona default";
     case "runtimeOverride":
       return "Live override (this session only)";
     case "harnessConstraint":
       return "Locked by harness";
     case "envVar": {
       if (writeVia.type === "respawnWithEnvVar") {
-        return `From environment variable (${writeVia.envKey})`;
+        return `Environment variable (${writeVia.envKey})`;
       }
-      return "From environment variable";
+      return "Environment variable";
     }
     case "configFile":
-      return configFilePath
-        ? `From config file (${configFilePath})`
-        : "From config file";
+      return configFilePath ? `Config file (${configFilePath})` : "Config file";
     case "acpConfigOption":
     case "acpNativeRead":
-      return "From ACP session";
+      return "ACP session";
   }
 }
 
@@ -87,58 +155,92 @@ function NormalizedRow({
   field,
   isPreSpawn,
   configFilePath,
+  variant = "compact",
 }: {
   fieldKey: keyof NormalizedConfig;
   label: string;
   field: NormalizedField;
   isPreSpawn: boolean;
   configFilePath: string | null;
+  variant?: RowVariant;
 }) {
   const Icon = NORMALIZED_ICONS[fieldKey];
   // ACP-sourced origins only become meaningful post-spawn
   const isAcpOnly =
     field.origin === "acpNativeRead" || field.origin === "acpConfigOption";
+  const displayValue =
+    isPreSpawn && isAcpOnly
+      ? "Available after agent starts"
+      : (field.value ?? "—");
+  const provenance = field.value
+    ? provenanceSentence(field.origin, field.writeVia, configFilePath)
+    : null;
+  const locked = isReadOnlyField(field);
+  const isCopyable =
+    variant === "profile" &&
+    shouldOfferCopy({
+      fieldKey,
+      origin: field.origin,
+      value: field.value,
+    });
 
-  return (
-    <div className="flex items-center gap-3 px-4 py-3">
+  const content = (
+    <>
       <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
         <Icon className="h-4 w-4 text-muted-foreground" />
       </span>
-      <span className="min-w-0 flex-1">
-        <span className="block text-xs font-medium text-foreground">
-          {label}
-        </span>
+      <span className="min-w-0 flex-1 text-left">
+        {variant === "profile" ? (
+          <ConfigFieldLabel label={label} locked={locked} />
+        ) : (
+          <span className="block text-xs font-medium text-foreground">
+            {label}
+          </span>
+        )}
         <span
           className="mt-0.5 block truncate text-sm text-muted-foreground"
           title={field.value ?? undefined}
         >
-          {isPreSpawn && isAcpOnly ? (
-            "Available after agent starts"
-          ) : (
-            <>
-              {field.value ?? "—"}
-              {field.overriddenValue && (
-                <span
-                  className={cn(
-                    "ml-2 text-xs text-muted-foreground/60",
-                    field.origin !== "runtimeOverride" && "line-through",
-                  )}
-                  title={field.overriddenValue ?? undefined}
-                >
-                  {field.overriddenValue}
-                </span>
+          {displayValue}
+          {!(isPreSpawn && isAcpOnly) && field.overriddenValue ? (
+            <span
+              className={cn(
+                "ml-2 text-xs text-muted-foreground/60",
+                field.origin !== "runtimeOverride" && "line-through",
               )}
-            </>
-          )}
+              title={field.overriddenValue ?? undefined}
+            >
+              {field.overriddenValue}
+            </span>
+          ) : null}
         </span>
-        {field.value && (
+        {provenance ? (
           <span className="mt-0.5 block text-2xs text-muted-foreground/70">
-            {provenanceSentence(field.origin, field.writeVia, configFilePath)}
+            {provenance}
           </span>
-        )}
+        ) : null}
       </span>
-    </div>
+      {isCopyable ? (
+        <Copy className="h-4 w-4 shrink-0 text-muted-foreground" />
+      ) : null}
+    </>
   );
+
+  if (isCopyable && field.value) {
+    return (
+      <button
+        aria-label={`Copy ${label}`}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
+        onClick={() => void copyToClipboard(field.value ?? "", label)}
+        title={`Copy ${label}`}
+        type="button"
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return <div className="flex items-center gap-3 px-4 py-3">{content}</div>;
 }
 
 // ── Advanced row ──────────────────────────────────────────────────────────────
@@ -146,35 +248,91 @@ function NormalizedRow({
 function AdvancedRow({
   field,
   configFilePath,
+  variant = "compact",
 }: {
   field: ConfigField;
   configFilePath: string | null;
+  variant?: RowVariant;
 }) {
-  return (
-    <div className="py-2">
-      <div className="text-xs text-muted-foreground">{field.label}</div>
-      <div
-        className="mt-0.5 truncate text-sm font-medium font-mono"
-        title={field.value ?? undefined}
-      >
-        {field.value ?? (
-          <span className="font-sans text-muted-foreground">—</span>
-        )}
-      </div>
-      {field.value && (
-        <div className="mt-0.5 text-2xs text-muted-foreground/70">
-          {provenanceSentence(field.origin, field.writeVia, configFilePath)}
+  const provenance = field.value
+    ? provenanceSentence(field.origin, field.writeVia, configFilePath)
+    : null;
+  const locked = isReadOnlyField(field);
+
+  if (variant === "compact") {
+    return (
+      <div className="py-2">
+        <div className="text-xs text-muted-foreground">{field.label}</div>
+        <div
+          className="mt-0.5 truncate text-sm font-medium font-mono"
+          title={field.value ?? undefined}
+        >
+          {field.value ?? (
+            <span className="font-sans text-muted-foreground">—</span>
+          )}
         </div>
-      )}
-    </div>
+        {provenance ? (
+          <div className="mt-0.5 text-2xs text-muted-foreground/70">
+            {provenance}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  const isCopyable = shouldOfferCopy({
+    origin: field.origin,
+    value: field.value,
+  });
+  const content = (
+    <>
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
+        <Hash className="h-4 w-4 text-muted-foreground" />
+      </span>
+      <span className="min-w-0 flex-1 text-left">
+        <ConfigFieldLabel label={field.label} locked={locked} />
+        <span
+          className="mt-0.5 block truncate text-sm text-muted-foreground"
+          title={field.value ?? undefined}
+        >
+          {field.value ?? "—"}
+        </span>
+        {provenance ? (
+          <span className="mt-0.5 block text-2xs text-muted-foreground/70">
+            {provenance}
+          </span>
+        ) : null}
+      </span>
+      {isCopyable ? (
+        <Copy className="h-4 w-4 shrink-0 text-muted-foreground" />
+      ) : null}
+    </>
   );
+
+  if (isCopyable && field.value) {
+    return (
+      <button
+        aria-label={`Copy ${field.label}`}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
+        onClick={() => void copyToClipboard(field.value ?? "", field.label)}
+        title={`Copy ${field.label}`}
+        type="button"
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return <div className="flex items-center gap-3 px-4 py-3">{content}</div>;
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function AgentConfigPanel({ pubkey }: Props) {
+export function AgentConfigPanel({
+  advancedMode = "collapsed",
+  pubkey,
+}: Props) {
   const [advancedOpen, setAdvancedOpen] = React.useState(false);
-
   const { data, isLoading, error } = useAgentConfigSurface(pubkey);
 
   if (isLoading) {
@@ -204,10 +362,10 @@ export function AgentConfigPanel({ pubkey }: Props) {
       keyof NormalizedConfig,
       NormalizedField | null,
     ][]
-  ).filter(([, field]) => field !== null) as [
-    keyof NormalizedConfig,
-    NormalizedField,
-  ][];
+  ).filter(
+    ([key, field]) =>
+      field !== null && !(advancedMode === "flat" && key === "systemPrompt"),
+  ) as [keyof NormalizedConfig, NormalizedField][];
 
   return (
     <div className="space-y-0.5">
@@ -228,18 +386,31 @@ export function AgentConfigPanel({ pubkey }: Props) {
               field={field}
               isPreSpawn={isPreSpawn}
               configFilePath={configFilePath}
+              variant={advancedMode === "flat" ? "profile" : "compact"}
             />
           ))
         )}
       </div>
 
-      {/* Advanced section */}
-      {advanced.length > 0 && (
+      {advanced.length > 0 && advancedMode === "flat" ? (
+        <div className="divide-y divide-border/50 border-t border-border/50">
+          {advanced.map((field) => (
+            <AdvancedRow
+              key={field.key}
+              field={field}
+              configFilePath={configFilePath}
+              variant="profile"
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {advanced.length > 0 && advancedMode === "collapsed" ? (
         <div className="mt-3 border-t border-border/50 pt-2">
           <button
-            type="button"
             className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
             onClick={() => setAdvancedOpen((v) => !v)}
+            type="button"
           >
             {advancedOpen ? (
               <ChevronDown className="h-3 w-3" />
@@ -249,7 +420,7 @@ export function AgentConfigPanel({ pubkey }: Props) {
             Advanced ({advanced.length})
           </button>
 
-          {advancedOpen && (
+          {advancedOpen ? (
             <div className="mt-1 divide-y divide-border/50">
               {advanced.map((field) => (
                 <AdvancedRow
@@ -259,9 +430,9 @@ export function AgentConfigPanel({ pubkey }: Props) {
                 />
               ))}
             </div>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/agents/ui/AgentConfigPanel.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigPanel.tsx
@@ -371,10 +371,23 @@ export function AgentConfigPanel({
       keyof NormalizedConfig,
       NormalizedField | null,
     ][]
-  ).filter(
-    ([key, field]) =>
-      field !== null && !(advancedMode === "flat" && key === "systemPrompt"),
-  ) as [keyof NormalizedConfig, NormalizedField][];
+  ).filter(([key, field]) => {
+    if (field === null) {
+      return false;
+    }
+    // Flat (profile) mode renders the record/persona system prompt in the
+    // dedicated Instructions block above, so drop it here to avoid the
+    // duplicate — but keep a config-file-sourced prompt, which has no other
+    // home in the profile panel.
+    if (
+      advancedMode === "flat" &&
+      key === "systemPrompt" &&
+      field.origin !== "configFile"
+    ) {
+      return false;
+    }
+    return true;
+  }) as [keyof NormalizedConfig, NormalizedField][];
 
   return (
     <div className="space-y-0.5">

--- a/desktop/src/features/agents/ui/AgentConfigPanel.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigPanel.tsx
@@ -9,8 +9,8 @@ import {
   Cpu,
   Hash,
   Layers,
-  Lock,
   MessageSquare,
+  PenOff,
   Server,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -46,22 +46,27 @@ function isReadOnlyField({
   return writeVia.type === "readOnly" || origin === "harnessConstraint";
 }
 
-function ConfigFieldLabel({
-  label,
-  locked,
-}: {
-  label: string;
-  locked: boolean;
-}) {
+function ConfigFieldLabel({ label }: { label: string }) {
   return (
     <span className="inline-flex min-w-0 items-center gap-1.5 text-xs font-medium text-foreground">
       <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+function ProvenanceHint({
+  locked,
+  provenance,
+}: {
+  locked: boolean;
+  provenance: string;
+}) {
+  return (
+    <span className="mt-0.5 flex items-center gap-1 text-2xs text-muted-foreground/70">
       {locked ? (
-        <Lock
-          aria-label="Read-only"
-          className="h-3 w-3 shrink-0 text-muted-foreground/70"
-        />
+        <PenOff aria-label="Read-only" className="h-3 w-3 shrink-0" />
       ) : null}
+      <span className="min-w-0 truncate">{provenance}</span>
     </span>
   );
 }
@@ -193,7 +198,7 @@ function NormalizedRow({
       </span>
       <span className="min-w-0 flex-1 text-left">
         {variant === "profile" ? (
-          <ConfigFieldLabel label={label} locked={locked} />
+          <ConfigFieldLabel label={label} />
         ) : (
           <span className="block text-xs font-medium text-foreground">
             {label}
@@ -217,9 +222,7 @@ function NormalizedRow({
           ) : null}
         </span>
         {provenance ? (
-          <span className="mt-0.5 block text-2xs text-muted-foreground/70">
-            {provenance}
-          </span>
+          <ProvenanceHint locked={locked} provenance={provenance} />
         ) : null}
       </span>
       {isCopyable ? (
@@ -292,7 +295,7 @@ function AdvancedRow({
         <Hash className="h-4 w-4 text-muted-foreground" />
       </span>
       <span className="min-w-0 flex-1 text-left">
-        <ConfigFieldLabel label={field.label} locked={locked} />
+        <ConfigFieldLabel label={field.label} />
         <span
           className="mt-0.5 block truncate text-sm text-muted-foreground"
           title={field.value ?? undefined}
@@ -300,9 +303,7 @@ function AdvancedRow({
           {field.value ?? "—"}
         </span>
         {provenance ? (
-          <span className="mt-0.5 block text-2xs text-muted-foreground/70">
-            {provenance}
-          </span>
+          <ProvenanceHint locked={locked} provenance={provenance} />
         ) : null}
       </span>
       {isCopyable ? (

--- a/desktop/src/features/agents/ui/AgentConfigPanel.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigPanel.tsx
@@ -103,27 +103,29 @@ function provenanceSentence(
   origin: ConfigOrigin,
   writeVia: ConfigWriteMechanism,
   configFilePath: string | null,
-): string | null {
+): string {
   switch (origin) {
     case "buzzExplicit":
-      return null;
+      return "Set in Buzz";
     case "personaDefault":
-      return "Persona default";
+      return "Inherited from persona";
     case "runtimeOverride":
       return "Live override (this session only)";
     case "harnessConstraint":
       return "Locked by harness";
     case "envVar": {
       if (writeVia.type === "respawnWithEnvVar") {
-        return `Environment variable (${writeVia.envKey})`;
+        return `From environment variable (${writeVia.envKey})`;
       }
-      return "Environment variable";
+      return "From environment variable";
     }
     case "configFile":
-      return configFilePath ? `Config file (${configFilePath})` : "Config file";
+      return configFilePath
+        ? `From config file (${configFilePath})`
+        : "From config file";
     case "acpConfigOption":
     case "acpNativeRead":
-      return "ACP session";
+      return "From ACP session";
   }
 }
 

--- a/desktop/src/features/agents/ui/AgentConfigPanel.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigPanel.tsx
@@ -91,7 +91,15 @@ function shouldOfferCopy({
     return true;
   }
 
-  return value.includes("/") || value.startsWith("~") || value.includes(":");
+  // Heuristic for machine-y values worth copying: filesystem paths ("/" or
+  // "~"), and URI-ish strings (scheme:rest). The colon rule requires the
+  // value to be space-free so prose like "Extension: developer" doesn't
+  // grow a surprising copy affordance.
+  return (
+    value.includes("/") ||
+    value.startsWith("~") ||
+    (value.includes(":") && !value.includes(" "))
+  );
 }
 
 type RowVariant = "compact" | "profile";

--- a/desktop/src/features/agents/ui/AgentConfigPanel.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigPanel.tsx
@@ -13,10 +13,9 @@ import {
   PenOff,
   Server,
 } from "lucide-react";
-import { toast } from "sonner";
-
 import { useAgentConfigSurface } from "../hooks";
 import { cn } from "@/shared/lib/cn";
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { Spinner } from "@/shared/ui/spinner";
 import type {
   ConfigField,
@@ -30,11 +29,6 @@ type Props = {
   pubkey: string;
   advancedMode?: "collapsed" | "flat";
 };
-
-async function copyToClipboard(value: string, label: string) {
-  await navigator.clipboard.writeText(value);
-  toast.success(`Copied ${label}`);
-}
 
 function isReadOnlyField({
   origin,
@@ -236,7 +230,9 @@ function NormalizedRow({
       <button
         aria-label={`Copy ${label}`}
         className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
-        onClick={() => void copyToClipboard(field.value ?? "", label)}
+        onClick={() =>
+          copyTextToClipboard(field.value ?? "", `Copied ${label}`)
+        }
         title={`Copy ${label}`}
         type="button"
       >
@@ -317,7 +313,9 @@ function AdvancedRow({
       <button
         aria-label={`Copy ${field.label}`}
         className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
-        onClick={() => void copyToClipboard(field.value ?? "", field.label)}
+        onClick={() =>
+          copyTextToClipboard(field.value ?? "", `Copied ${field.label}`)
+        }
         title={`Copy ${field.label}`}
         type="button"
       >

--- a/desktop/src/features/agents/ui/CopyButton.tsx
+++ b/desktop/src/features/agents/ui/CopyButton.tsx
@@ -1,6 +1,6 @@
 import { Copy } from "lucide-react";
-import { toast } from "sonner";
 
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { Button, type ButtonProps } from "@/shared/ui/button";
 
 export function CopyButton({
@@ -23,10 +23,7 @@ export function CopyButton({
   return (
     <Button
       className={className}
-      onClick={async () => {
-        await navigator.clipboard.writeText(value);
-        toast.success("Copied to clipboard");
-      }}
+      onClick={() => copyTextToClipboard(value)}
       size={size}
       type="button"
       variant={variant}

--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -13,7 +13,6 @@ import {
   Trash2,
 } from "lucide-react";
 import * as React from "react";
-import { toast } from "sonner";
 
 import { buildMessageLink } from "@/features/messages/lib/messageLink";
 import { EmojiPicker } from "@/features/custom-emoji/ui/EmojiPicker";
@@ -29,6 +28,7 @@ import {
 } from "@/features/messages/ui/useQuickReactionEmojis";
 import { reactionEmojiUrl } from "@/shared/api/customEmoji";
 import { cn } from "@/shared/lib/cn";
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { emojiDisplayName } from "@/shared/lib/emojiName";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { KIND_HUDDLE_STARTED } from "@/shared/constants/kinds";
@@ -56,17 +56,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 const ACTION_BUTTON_CLASS = "h-8 w-8 rounded-full p-0";
 const ACTION_ICON_CLASS = "!h-4 !w-4";
-
-function copyToClipboard(text: string, successMessage: string) {
-  void navigator.clipboard
-    .writeText(text)
-    .then(() => {
-      toast.success(successMessage);
-    })
-    .catch(() => {
-      toast.error("Failed to copy to clipboard");
-    });
-}
 
 function MoreActionsMenu({
   channelId,
@@ -199,7 +188,10 @@ function MoreActionsMenu({
           {hasCopyActions ? (
             <DropdownMenuItem
               onClick={() => {
-                copyToClipboard(message.body, "Message copied to clipboard");
+                copyTextToClipboard(
+                  message.body,
+                  "Message copied to clipboard",
+                );
               }}
             >
               <Copy className="h-4 w-4" />
@@ -228,7 +220,7 @@ function MoreActionsMenu({
                   messageId: message.id,
                   threadRootId: rootId,
                 });
-                copyToClipboard(link, "Link copied to clipboard");
+                copyTextToClipboard(link, "Link copied to clipboard");
               }}
             >
               <Link2 className="h-4 w-4" />

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -771,7 +771,7 @@ export function UserProfilePanel({
   const { agentInfoFields, agentSettingsFields, diagnosticsFields } =
     useProfileFieldBuckets({
       isBot,
-      isOwner,
+      isOwner: viewerIsOwner,
       managedAgent,
       onOpenProfile,
       ownerAvatarUrl: ownerAvatarProfile?.avatarUrl ?? null,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -768,28 +768,24 @@ export function UserProfilePanel({
       viewerIsOwner={viewerIsOwner}
     />
   );
-  const {
-    agentInfoFields,
-    agentSettingsFields,
-    diagnosticsFields,
-    modelLabel,
-  } = useProfileFieldBuckets({
-    isBot,
-    isOwner,
-    managedAgent,
-    onOpenProfile,
-    ownerAvatarUrl: ownerAvatarProfile?.avatarUrl ?? null,
-    ownerDisplayName,
-    ownerHandle,
-    ownerProfilePubkey,
-    ownerPubkey,
-    persona: resolvedPersona,
-    presenceLoaded: presenceQuery.isSuccess,
-    presenceStatus,
-    profile,
-    pubkey: effectivePubkey,
-    relayAgent,
-  });
+  const { agentInfoFields, agentSettingsFields, diagnosticsFields } =
+    useProfileFieldBuckets({
+      isBot,
+      isOwner,
+      managedAgent,
+      onOpenProfile,
+      ownerAvatarUrl: ownerAvatarProfile?.avatarUrl ?? null,
+      ownerDisplayName,
+      ownerHandle,
+      ownerProfilePubkey,
+      ownerPubkey,
+      persona: resolvedPersona,
+      presenceLoaded: presenceQuery.isSuccess,
+      presenceStatus,
+      profile,
+      pubkey: effectivePubkey,
+      relayAgent,
+    });
   const isDiagnosticsLikeView = view === "diagnostics" || view === "logs";
   const managedAgentLogContent = managedAgentLogQuery.data?.content ?? null;
   const logHeaderSubtitle =
@@ -846,7 +842,6 @@ export function UserProfilePanel({
           managedAgent={managedAgent}
           memoriesLoading={memoryQuery.isLoading}
           memoryCount={memoryCount}
-          modelLabel={modelLabel}
           agentInfoFields={agentInfoFields}
           agentSettingsFields={agentSettingsFields}
           diagnosticsFields={diagnosticsFields}
@@ -876,11 +871,7 @@ export function UserProfilePanel({
         <AgentInfoFocusedView metadataFields={agentInfoFields} />
       ) : null}
       {view === "configuration" ? (
-        <AgentConfigurationFocusedView
-          fields={agentSettingsFields}
-          managedAgent={managedAgent}
-          modelLabel={modelLabel}
-        />
+        <AgentConfigurationFocusedView fields={agentSettingsFields} />
       ) : null}
       {view === "instructions" ? (
         <AgentInstructionsFocusedView instruction={agentInstruction} />

--- a/desktop/src/features/profile/ui/UserProfilePanelAgentDetails.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelAgentDetails.tsx
@@ -1,6 +1,5 @@
-import { ChevronRight, Cpu, MessageSquare } from "lucide-react";
+import { ChevronRight, MessageSquare } from "lucide-react";
 
-import type { ManagedAgent } from "@/shared/api/types";
 import { Markdown } from "@/shared/ui/markdown";
 import {
   type ProfileField,
@@ -15,12 +14,8 @@ export const AGENT_DETAILS_FIELD_LABELS = new Set([
 
 export function AgentConfigurationFocusedView({
   fields,
-  managedAgent,
-  modelLabel,
 }: {
   fields: ProfileField[];
-  managedAgent: ManagedAgent | undefined;
-  modelLabel: string;
 }) {
   const runtimeConfigurationFields = fields.filter((field) =>
     AGENT_DETAILS_FIELD_LABELS.has(field.label),
@@ -28,12 +23,7 @@ export function AgentConfigurationFocusedView({
 
   return (
     <div className="pt-4">
-      <AgentConfigurationRows
-        fields={runtimeConfigurationFields}
-        managedAgent={managedAgent}
-        modelLabel={modelLabel}
-        showModel={true}
-      />
+      <AgentConfigurationRows fields={runtimeConfigurationFields} />
     </div>
   );
 }
@@ -41,25 +31,16 @@ export function AgentConfigurationFocusedView({
 function AgentConfigurationRows({
   fields,
   instruction,
-  managedAgent,
-  modelLabel,
   showInstructionPlaceholder,
-  showModel,
 }: {
   fields: ProfileField[];
   instruction?: string | null;
-  managedAgent: ManagedAgent | undefined;
-  modelLabel: string;
   showInstructionPlaceholder?: boolean;
-  showModel: boolean;
 }) {
   const hasRows = hasAgentConfigurationRows({
     fields,
     instruction,
-    managedAgent,
-    modelLabel,
     showInstructionPlaceholder,
-    showModel,
   });
 
   if (!hasRows) {
@@ -71,10 +52,7 @@ function AgentConfigurationRows({
       <AgentDetailsRows
         fields={fields}
         instruction={instruction}
-        managedAgent={managedAgent}
-        modelLabel={modelLabel}
         showInstructionPlaceholder={showInstructionPlaceholder}
-        showModel={showModel}
       />
     </div>
   );
@@ -83,26 +61,17 @@ function AgentConfigurationRows({
 export function AgentDetailsRows({
   fields,
   instruction,
-  managedAgent,
-  modelLabel,
   showInstructionPlaceholder,
-  showModel = false,
 }: {
   fields: ProfileField[];
   instruction?: string | null;
-  managedAgent?: ManagedAgent | undefined;
-  modelLabel?: string;
   showInstructionPlaceholder?: boolean;
-  showModel?: boolean;
 }) {
   const trimmedInstruction = instruction?.trim() ?? "";
   const showInstructions =
     trimmedInstruction.length > 0 || showInstructionPlaceholder === true;
-  const showModelRow =
-    showModel === true &&
-    (managedAgent !== undefined || (modelLabel?.trim().length ?? 0) > 0);
 
-  if (!showInstructions && !showModelRow && fields.length === 0) {
+  if (!showInstructions && fields.length === 0) {
     return null;
   }
 
@@ -110,10 +79,6 @@ export function AgentDetailsRows({
     <>
       {showInstructions ? (
         <AgentInstructionRow instruction={instruction ?? null} />
-      ) : null}
-
-      {showModelRow ? (
-        <AgentModelRow modelLabel={modelLabel ?? "Auto"} />
       ) : null}
 
       {fields.length > 0 ? <ProfileFieldRows fields={fields} /> : null}
@@ -124,25 +89,17 @@ export function AgentDetailsRows({
 function hasAgentConfigurationRows({
   fields,
   instruction,
-  managedAgent,
-  modelLabel,
   showInstructionPlaceholder,
-  showModel,
 }: {
   fields: ProfileField[];
   instruction?: string | null;
-  managedAgent: ManagedAgent | undefined;
-  modelLabel: string;
   showInstructionPlaceholder?: boolean;
-  showModel: boolean;
 }) {
   const trimmedInstruction = instruction?.trim() ?? "";
 
   return (
     trimmedInstruction.length > 0 ||
     showInstructionPlaceholder === true ||
-    (showModel === true &&
-      (managedAgent !== undefined || modelLabel.trim().length > 0)) ||
     fields.length > 0
   );
 }
@@ -240,25 +197,6 @@ export function AgentInstructionsFocusedView({
           </p>
         )}
       </div>
-    </div>
-  );
-}
-
-function AgentModelRow({ modelLabel }: { modelLabel: string }) {
-  return (
-    <div
-      className="flex items-center gap-3 px-4 py-3"
-      data-testid="user-profile-model"
-    >
-      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
-        <Cpu className="h-4 w-4 text-muted-foreground" />
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block text-xs font-medium text-foreground">Model</span>
-        <span className="mt-0.5 block truncate text-sm text-muted-foreground">
-          {modelLabel}
-        </span>
-      </span>
     </div>
   );
 }

--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -134,10 +134,7 @@ export function useProfileFieldBuckets({
           })
         : []),
     ];
-    return {
-      ...bucketProfileFields(metadataFields),
-      modelLabel: managedAgent?.model ?? persona?.model ?? "Auto",
-    };
+    return bucketProfileFields(metadataFields);
   }, [
     isBot,
     isOwner,

--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -249,10 +249,11 @@ export function buildOwnerFields({
   relayAgent: RelayAgent | undefined;
 }): ProfileField[] {
   const fields: ProfileField[] = [];
-  const respondToDisplayValue = managedAgent
-    ? managedAgent.respondTo === "owner-only" && ownerDisplayName
+  const respondTo = managedAgent?.respondTo ?? relayAgent?.respondTo ?? null;
+  const respondToDisplayValue = respondTo
+    ? respondTo === "owner-only" && ownerDisplayName
       ? ownerDisplayName
-      : managedAgent.respondTo.replace(/-/g, " ")
+      : respondTo.replace(/-/g, " ")
     : null;
 
   const ownerClickable = Boolean(onOpenProfile && ownerProfilePubkey);
@@ -394,14 +395,15 @@ export function buildOwnerFields({
       label: "Start on launch",
       testId: "user-profile-start-on-launch",
     });
-    if (respondToDisplayValue) {
-      fields.push({
-        displayValue: respondToDisplayValue,
-        icon: Ear,
-        label: "Respond to",
-        testId: "user-profile-respond-to",
-      });
-    }
+  }
+
+  if (respondToDisplayValue) {
+    fields.push({
+      displayValue: respondToDisplayValue,
+      icon: Ear,
+      label: "Respond to",
+      testId: "user-profile-respond-to",
+    });
   }
 
   if (managedAgent?.lastError) {

--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -60,6 +60,7 @@ const AGENT_INFO_LABELS = new Set([
 ]);
 const AGENT_SETTINGS_LABELS = new Set([
   "Runtime",
+  "Agent profile",
   "Respond to",
   "ACP command",
   "MCP command",
@@ -318,6 +319,14 @@ export function buildOwnerFields({
       icon: Terminal,
       label: "Runtime",
       testId: "user-profile-runtime",
+    });
+  } else if (ownerPubkey) {
+    fields.push({
+      copyValue: ownerPubkey,
+      displayValue: "Declared owner verified",
+      icon: UserRound,
+      label: "Agent profile",
+      testId: "user-profile-agent-profile",
     });
   }
 

--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -11,10 +11,9 @@ import {
   UserRound,
 } from "lucide-react";
 import * as React from "react";
-import { toast } from "sonner";
-
 import { AgentStatusBadge } from "@/features/agents/ui/AgentStatusBadge";
 import { truncatePubkey as truncatePubkeyShort } from "@/features/profile/lib/identity";
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import type {
   AgentPersona,
@@ -32,11 +31,6 @@ const RUNTIME_LABELS: Record<string, string> = {
 
 function runtimeLabel(command: string): string {
   return RUNTIME_LABELS[command] ?? command;
-}
-
-async function copyToClipboard(value: string, label?: string) {
-  await navigator.clipboard.writeText(value);
-  toast.success(label ? `Copied ${label}` : "Copied to clipboard");
 }
 
 export type ProfileField = {
@@ -512,7 +506,9 @@ function ProfileFieldRow({ field }: { field: ProfileField }) {
         aria-label={`Copy ${field.label}`}
         className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
         data-testid={field.testId}
-        onClick={() => void copyToClipboard(field.copyValue ?? "", field.label)}
+        onClick={() =>
+          copyTextToClipboard(field.copyValue ?? "", `Copied ${field.label}`)
+        }
         title={`Copy ${field.label}`}
         type="button"
       >

--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -348,24 +348,6 @@ export function buildOwnerFields({
     });
   }
 
-  if (managedAgent?.model) {
-    fields.push({
-      copyValue: managedAgent.model,
-      displayValue: managedAgent.model,
-      icon: Cpu,
-      label: "Model",
-      testId: "user-profile-model",
-    });
-  } else if (persona?.model) {
-    fields.push({
-      copyValue: persona.model,
-      displayValue: persona.model,
-      icon: Cpu,
-      label: "Model",
-      testId: "user-profile-model",
-    });
-  }
-
   if (managedAgent?.acpCommand) {
     fields.push({
       copyValue: managedAgent.acpCommand,

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -91,7 +91,6 @@ export type ProfileSummaryViewProps = {
   managedAgent: ManagedAgent | undefined;
   memoriesLoading: boolean;
   memoryCount: number | undefined;
-  modelLabel: string;
   agentInfoFields: ProfileField[];
   agentSettingsFields: ProfileField[];
   diagnosticsFields: ProfileField[];
@@ -200,7 +199,6 @@ export function ProfileSummaryView({
   managedAgent,
   memoriesLoading,
   memoryCount,
-  modelLabel,
   agentInfoFields,
   agentSettingsFields,
   diagnosticsFields,
@@ -240,7 +238,6 @@ export function ProfileSummaryView({
     (runtimeConfigurationFields.length > 0 ||
       runtimeSettingsFields.length > 0 ||
       managedAgent !== undefined ||
-      modelLabel.trim().length > 0 ||
       diagnosticsFields.length > 0 ||
       canOpenAgentLogs ||
       showInstructionBlock);
@@ -412,8 +409,6 @@ export function ProfileSummaryView({
                 agentInstruction={agentInstruction}
                 diagnosticsFields={diagnosticsFields}
                 diagnosticsSummary={diagnosticsTrailing}
-                managedAgent={managedAgent}
-                modelLabel={modelLabel}
                 onOpenDiagnostics={onOpenDiagnostics}
                 onOpenInstructions={onOpenInstructions}
                 runtimeConfigurationFields={runtimeConfigurationFields}
@@ -423,7 +418,10 @@ export function ProfileSummaryView({
               />
               {isOwner === true && managedAgent !== undefined ? (
                 <div className="overflow-hidden rounded-2xl bg-muted/20">
-                  <AgentConfigPanel pubkey={managedAgent.pubkey} />
+                  <AgentConfigPanel
+                    advancedMode="flat"
+                    pubkey={managedAgent.pubkey}
+                  />
                 </div>
               ) : null}
             </>

--- a/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
@@ -12,7 +12,6 @@ import {
   ProfileFieldRows,
 } from "@/features/profile/ui/UserProfilePanelFields";
 import type { ProfilePanelTab } from "@/features/profile/ui/UserProfilePanelUtils";
-import type { ManagedAgent } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
@@ -329,8 +328,6 @@ export function ProfileRuntimeTabContent({
   agentInstruction,
   diagnosticsFields,
   diagnosticsSummary,
-  managedAgent,
-  modelLabel,
   onOpenDiagnostics,
   onOpenInstructions,
   runtimeConfigurationFields,
@@ -341,8 +338,6 @@ export function ProfileRuntimeTabContent({
   agentInstruction: string | null;
   diagnosticsFields: ProfileField[];
   diagnosticsSummary: React.ReactNode;
-  managedAgent: ManagedAgent | undefined;
-  modelLabel: string;
   onOpenDiagnostics: () => void;
   onOpenInstructions: () => void;
   runtimeConfigurationFields: ProfileField[];
@@ -357,10 +352,7 @@ export function ProfileRuntimeTabContent({
     (field) => field.label !== "Last error" && field.label !== "Status",
   );
   const hasRuntimeRows =
-    runtimeConfigurationFields.length > 0 ||
-    runtimeSettingsFields.length > 0 ||
-    managedAgent !== undefined ||
-    modelLabel.trim().length > 0;
+    runtimeConfigurationFields.length > 0 || runtimeSettingsFields.length > 0;
 
   if (
     !hasRuntimeRows &&
@@ -396,12 +388,7 @@ export function ProfileRuntimeTabContent({
       ) : null}
       {hasRuntimeRows ? (
         <div className="overflow-hidden rounded-2xl bg-muted/20">
-          <AgentDetailsRows
-            fields={runtimeConfigurationFields}
-            managedAgent={managedAgent}
-            modelLabel={modelLabel}
-            showModel={true}
-          />
+          <AgentDetailsRows fields={runtimeConfigurationFields} />
           {runtimeSettingsFields.length > 0 ? (
             <ProfileFieldRows fields={runtimeSettingsFields} />
           ) : null}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -19,8 +19,7 @@ import {
   Trash2,
 } from "lucide-react";
 
-import { toast } from "sonner";
-
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -109,17 +108,6 @@ function MoveToSectionSubmenu({
       </ContextMenuSubContent>
     </ContextMenuSub>
   );
-}
-
-function copyToClipboard(text: string, successMessage: string) {
-  void navigator.clipboard
-    .writeText(text)
-    .then(() => {
-      toast.success(successMessage);
-    })
-    .catch(() => {
-      toast.error("Failed to copy to clipboard");
-    });
 }
 
 export function ChannelContextMenuItems({
@@ -229,7 +217,7 @@ export function ChannelContextMenuItems({
       <ContextMenuSeparator />
       <ContextMenuItem
         onClick={() =>
-          copyToClipboard(channel.name, "Channel name copied to clipboard")
+          copyTextToClipboard(channel.name, "Channel name copied to clipboard")
         }
       >
         <Copy className="h-4 w-4" />
@@ -237,7 +225,7 @@ export function ChannelContextMenuItems({
       </ContextMenuItem>
       <ContextMenuItem
         onClick={() =>
-          copyToClipboard(channel.id, "Channel ID copied to clipboard")
+          copyTextToClipboard(channel.id, "Channel ID copied to clipboard")
         }
       >
         <Clipboard className="h-4 w-4" />

--- a/desktop/src/shared/lib/clipboard.ts
+++ b/desktop/src/shared/lib/clipboard.ts
@@ -1,0 +1,20 @@
+import { toast } from "sonner";
+
+/**
+ * Copy plain text to the clipboard with a success toast, surfacing
+ * `writeText` rejections (permissions, unfocused document) as an error
+ * toast instead of an unhandled rejection.
+ */
+export function copyTextToClipboard(
+  text: string,
+  successMessage = "Copied to clipboard",
+) {
+  void navigator.clipboard
+    .writeText(text)
+    .then(() => {
+      toast.success(successMessage);
+    })
+    .catch(() => {
+      toast.error("Failed to copy to clipboard");
+    });
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1373,9 +1373,9 @@ function buildMockConfigSurface(pubkey: string): {
   };
 
   // Mixed-provenance showcase — top-level rows carry different origins so the
-  // panel witnesses tightened provenance labels in one frame: no label for
-  // Buzz-native values, plus "Persona default", "Config file (...)" and
-  // "Environment variable (...)".
+  // panel witnesses distinct provenance labels in one frame: "Set in Buzz",
+  // "Inherited from persona", "From config file (...)" and
+  // "From environment variable (...)".
   const multiOriginSurface = {
     runtimeId: "goose",
     runtimeLabel: "Goose",

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1370,10 +1370,10 @@ function buildMockConfigSurface(pubkey: string): {
     },
   };
 
-  // Mixed-provenance showcase — every top-level row carries a DIFFERENT origin
-  // so the panel witnesses four distinct provenance sentences in one frame:
-  // "Set in Buzz", "Inherited from persona", "From config file (...)", and
-  // "From environment variable (...)".
+  // Mixed-provenance showcase — top-level rows carry different origins so the
+  // panel witnesses tightened provenance labels in one frame: no label for
+  // Buzz-native values, plus "Persona default", "Config file (...)" and
+  // "Environment variable (...)".
   const multiOriginSurface = {
     runtimeId: "goose",
     runtimeLabel: "Goose",

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -54,6 +54,8 @@ type MockManagedAgentSeed = {
 type MockRelayAgentSeed = {
   pubkey: string;
   name: string;
+  agentType?: string;
+  capabilities?: string[];
   respondTo?: RawRelayAgent["respond_to"];
   respondToAllowlist?: string[];
   channelNames?: string[];
@@ -1511,10 +1513,10 @@ function resetMockRelayAgents(config?: E2eConfig) {
     mockRelayAgents.push({
       pubkey: seed.pubkey,
       name: seed.name,
-      agent_type: "goose",
+      agent_type: seed.agentType ?? "goose",
       channels: channels.map((channel) => channel.name),
       channel_ids: channels.map((channel) => channel.id),
-      capabilities: ["messages", "channels", "mcp"],
+      capabilities: seed.capabilities ?? ["messages", "channels", "mcp"],
       status: seed.status ?? "online",
       respond_to: seed.respondTo ?? "owner-only",
       respond_to_allowlist: seed.respondToAllowlist ?? [],
@@ -2137,16 +2139,6 @@ const defaultMockRelayAgents: RawRelayAgent[] = [
     status: "away",
     respond_to: "anyone",
     respond_to_allowlist: [],
-  },
-  {
-    pubkey: OWNED_RELAY_AGENT_PUBKEY,
-    name: "nadia",
-    agent_type: "goose",
-    channels: ["agents"],
-    channel_ids: ["94a444a4-c0a3-5966-ab05-530c6ddc2301"],
-    capabilities: ["search", "summaries"],
-    status: "online",
-    respond_to: "anyone",
   },
 ];
 let mockRelayAgents: RawRelayAgent[] = defaultMockRelayAgents.map((agent) => ({

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -2867,6 +2867,18 @@ function getMockMessageStore(channelId: string): RelayEvent[] {
                 content: "Indexing the channel catalog now.",
                 sig: "mocksig".repeat(20).slice(0, 128),
               },
+              // Owned remote relay agent: declared-owned by the mock viewer,
+              // present in the relay registry, but NOT locally managed. This
+              // keeps the profile Runtime-tab owner gate honest.
+              {
+                id: "mock-agents-owned-relay-nadia",
+                pubkey: OWNED_RELAY_AGENT_PUBKEY,
+                created_at: Math.floor(Date.now() / 1000) - 85,
+                kind: 9,
+                tags: [["h", channelId]],
+                content: "Indexing remotely for my owner.",
+                sig: "mocksig".repeat(20).slice(0, 128),
+              },
               // Seed one message per managed agent that is a member of #agents.
               // This lets e2e specs open the profile panel by clicking the
               // agent's avatar in a message-row (the same pattern as charlie).

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1111,6 +1111,21 @@ test("shows and clears activity indicators for active channel agents", async ({
 test("members sidebar exposes view-activity for a viewer-owned relay agent", async ({
   page,
 }) => {
+  // nadia is no longer in the default relay-agent seeds (the no-relay-record
+  // owner path claims that fixture), so seed her relay registry entry here to
+  // exercise the relay-bot classification.
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: OWNED_RELAY_AGENT_PUBKEY,
+        name: "nadia",
+        agentType: "goose",
+        capabilities: ["search", "summaries"],
+        channelNames: ["agents"],
+        respondTo: "anyone",
+      },
+    ],
+  });
   await page.goto("/");
 
   await openMembersSidebar(page, "agents");

--- a/desktop/tests/e2e/config-bridge-screenshots.spec.ts
+++ b/desktop/tests/e2e/config-bridge-screenshots.spec.ts
@@ -175,8 +175,9 @@ test.describe("config bridge screenshots", () => {
 
     const panel = await openAgentProfileFromChannel(page, "Goose Agent");
 
-    // The folded config panel: provenance sentences inline under each value.
-    await expect(panel.getByText("Set in Buzz")).toBeVisible();
+    // Buzz-native fields don't need provenance chrome, but this test still needs
+    // a visible folded-panel row before screenshots settle.
+    await expect(panel.getByText("Model").first()).toBeVisible();
     await settleAnimations(panel);
 
     await panel.screenshot({ path: `${SHOTS}/01-folded-config-panel.png` });
@@ -208,14 +209,13 @@ test.describe("config bridge screenshots", () => {
 
     const panel = await openAgentProfileFromChannel(page, "Multi-Origin Agent");
 
-    // Multiple distinct provenance origins visible at once.
-    await expect(panel.getByText("Set in Buzz")).toBeVisible();
-    await expect(panel.getByText("Inherited from persona")).toBeVisible();
+    // Multiple distinct non-native provenance origins visible at once.
+    await expect(panel.getByText("Persona default")).toBeVisible();
     await expect(
-      panel.getByText("From environment variable (GOOSE_MODE)"),
+      panel.getByText("Environment variable (GOOSE_MODE)"),
     ).toBeVisible();
     await expect(
-      panel.getByText("From config file (~/.config/goose/config.yaml)").first(),
+      panel.getByText("Config file (~/.config/goose/config.yaml)").first(),
     ).toBeVisible();
     await settleAnimations(panel);
 
@@ -238,15 +238,12 @@ test.describe("config bridge screenshots", () => {
     await panel.screenshot({ path: `${SHOTS}/04-pre-spawn-state.png` });
   });
 
-  test("05 — advanced expanded", async ({ page }) => {
+  test("05 — advanced flat list", async ({ page }) => {
     await installMockBridge(page, { managedAgents: MANAGED_AGENTS });
 
     const panel = await openAgentProfileFromChannel(page, "Goose Agent");
 
-    const advancedButton = panel.getByRole("button", { name: /Advanced/i });
-    await advancedButton.click();
-
-    // Wait for advanced fields to appear.
+    // Advanced runtime fields render directly in the profile panel's flat list.
     await expect(panel.getByText("Extension: developer")).toBeVisible();
     await settleAnimations(panel);
 

--- a/desktop/tests/e2e/config-bridge-screenshots.spec.ts
+++ b/desktop/tests/e2e/config-bridge-screenshots.spec.ts
@@ -175,9 +175,8 @@ test.describe("config bridge screenshots", () => {
 
     const panel = await openAgentProfileFromChannel(page, "Goose Agent");
 
-    // Buzz-native fields don't need provenance chrome, but this test still needs
-    // a visible folded-panel row before screenshots settle.
-    await expect(panel.getByText("Model").first()).toBeVisible();
+    // The folded config panel: provenance sentences inline under each value.
+    await expect(panel.getByText("Set in Buzz").first()).toBeVisible();
     await settleAnimations(panel);
 
     await panel.screenshot({ path: `${SHOTS}/01-folded-config-panel.png` });
@@ -209,13 +208,14 @@ test.describe("config bridge screenshots", () => {
 
     const panel = await openAgentProfileFromChannel(page, "Multi-Origin Agent");
 
-    // Multiple distinct non-native provenance origins visible at once.
-    await expect(panel.getByText("Persona default")).toBeVisible();
+    // Multiple distinct provenance origins visible at once.
+    await expect(panel.getByText("Set in Buzz").first()).toBeVisible();
+    await expect(panel.getByText("Inherited from persona")).toBeVisible();
     await expect(
-      panel.getByText("Environment variable (GOOSE_MODE)"),
+      panel.getByText("From environment variable (GOOSE_MODE)"),
     ).toBeVisible();
     await expect(
-      panel.getByText("Config file (~/.config/goose/config.yaml)").first(),
+      panel.getByText("From config file (~/.config/goose/config.yaml)").first(),
     ).toBeVisible();
     await settleAnimations(panel);
 

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -843,7 +843,7 @@ test("declared owner sees runtime tab for a remote relay agent", async ({
 
   // Declared ownership grants read visibility only; local-management write UI
   // stays hidden because this relay agent is not in the managed-agents list.
-  await expect(panel.getByText("Model").first()).toHaveCount(0);
+  await expect(panel.getByText("Model")).toHaveCount(0);
   await expect(
     panel.getByRole("button", { name: /Start|Stop|Deploy/ }),
   ).toHaveCount(0);
@@ -881,7 +881,7 @@ test("declared owner sees runtime tab without a relay-agent record", async ({
 
   // No relay/managed runtime record means no write or management affordance —
   // only the truthful NIP-OA profile signal is rendered in Runtime.
-  await expect(panel.getByText("Model").first()).toHaveCount(0);
+  await expect(panel.getByText("Model")).toHaveCount(0);
   await expect(
     panel.getByRole("button", { name: /Start|Stop|Deploy/ }),
   ).toHaveCount(0);

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -795,6 +795,19 @@ test("renders agent profile ingress subviews from the Playwright mock bridge", a
 test("declared owner sees runtime tab for a remote relay agent", async ({
   page,
 }) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey:
+          "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00",
+        name: "nadia",
+        agentType: "goose",
+        capabilities: ["search", "summaries"],
+        channelNames: ["agents"],
+        respondTo: "anyone",
+      },
+    ],
+  });
   await page.goto("/");
 
   await page.getByTestId("channel-agents").click();
@@ -823,6 +836,44 @@ test("declared owner sees runtime tab for a remote relay agent", async ({
 
   // Declared ownership grants read visibility only; local-management write UI
   // stays hidden because this relay agent is not in the managed-agents list.
+  await expect(panel.getByText("Model").first()).toHaveCount(0);
+  await expect(
+    panel.getByRole("button", { name: /Start|Stop|Deploy/ }),
+  ).toHaveCount(0);
+});
+
+test("declared owner sees runtime tab without a relay-agent record", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+
+  const messageRow = page.getByTestId("message-row").filter({
+    has: page.getByText("Indexing remotely for my owner."),
+  });
+  await expect(messageRow.first()).toBeVisible({ timeout: 5_000 });
+  await messageRow.first().getByRole("button").first().click();
+
+  const panel = page.getByTestId("user-profile-panel");
+  await expect(panel).toBeVisible({ timeout: 10_000 });
+  await expect(panel.getByTestId("user-profile-agent-type")).toHaveCount(0);
+  await expect(panel.getByTestId("user-profile-capabilities")).toHaveCount(0);
+  await expect(panel.getByRole("tab", { name: "Runtime" })).toBeVisible();
+  await panel.getByRole("tab", { name: "Runtime" }).click();
+
+  await expect(panel.getByTestId("user-profile-agent-profile")).toContainText(
+    "Agent profile",
+  );
+  await expect(panel.getByTestId("user-profile-agent-profile")).toContainText(
+    "Declared owner verified",
+  );
+  await expect(panel.getByTestId("user-profile-runtime")).toHaveCount(0);
+  await expect(panel.getByTestId("user-profile-respond-to")).toHaveCount(0);
+
+  // No relay/managed runtime record means no write or management affordance —
+  // only the truthful NIP-OA profile signal is rendered in Runtime.
   await expect(panel.getByText("Model").first()).toHaveCount(0);
   await expect(
     panel.getByRole("button", { name: /Start|Stop|Deploy/ }),

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -792,6 +792,43 @@ test("renders agent profile ingress subviews from the Playwright mock bridge", a
   await expect(page.getByTestId("agent-memory-list")).toContainText("orphan");
 });
 
+test("declared owner sees runtime tab for a remote relay agent", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+
+  const messageRow = page.getByTestId("message-row").filter({
+    has: page.getByText("Indexing remotely for my owner."),
+  });
+  await expect(messageRow.first()).toBeVisible({ timeout: 5_000 });
+  await messageRow.first().getByRole("button").first().click();
+
+  const panel = page.getByTestId("user-profile-panel");
+  await expect(panel).toBeVisible({ timeout: 10_000 });
+  await expect(panel.getByRole("tab", { name: "Runtime" })).toBeVisible();
+  await panel.getByRole("tab", { name: "Runtime" }).click();
+
+  await expect(panel.getByTestId("user-profile-runtime")).toContainText(
+    "Runtime",
+  );
+  await expect(panel.getByTestId("user-profile-runtime")).toContainText(
+    "Goose",
+  );
+  await expect(panel.getByTestId("user-profile-respond-to")).toContainText(
+    "anyone",
+  );
+
+  // Declared ownership grants read visibility only; local-management write UI
+  // stays hidden because this relay agent is not in the managed-agents list.
+  await expect(panel.getByText("Model").first()).toHaveCount(0);
+  await expect(
+    panel.getByRole("button", { name: /Start|Stop|Deploy/ }),
+  ).toHaveCount(0);
+});
+
 test("owned agent absent from relay/managed lists still renders agent framing", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -732,7 +732,14 @@ test("renders agent profile ingress subviews from the Playwright mock bridge", a
 
   await page.getByTestId("user-profile-tab-runtime").click();
   await expectHashSearchParam(page, "profileTab", "runtime");
-  await expect(page.getByTestId("user-profile-model")).toBeVisible();
+  // The dedicated Model row was consolidated into the runtime config panel;
+  // Model now renders as a normalized config row with real provenance.
+  await expect(
+    page
+      .getByTestId("user-profile-panel")
+      .getByText("Model", { exact: true })
+      .first(),
+  ).toBeVisible();
   await expect(page.getByTestId("user-profile-respond-to")).toBeVisible();
 
   await page.getByTestId("user-profile-settings-menu-trigger").click();

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -70,6 +70,8 @@ type MockSearchProfileSeed = {
 type MockRelayAgentSeed = {
   pubkey: string;
   name: string;
+  agentType?: string;
+  capabilities?: string[];
   respondTo?: "owner-only" | "allowlist" | "anyone";
   respondToAllowlist?: string[];
   channelNames?: string[];


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Agent profiles present runtime configuration in a cleaner, easier-to-scan Runtime tab.
**Problem:** Runtime metadata in the agent profile panel had drifted into a redundant, mixed-detail presentation that repeated model/instructions information and did not follow the panel’s existing information architecture. That made it harder to distinguish core runtime facts from configuration provenance.
**Solution:** Consolidate profile runtime details into the existing icon-row card pattern while preserving the pre-branch provenance copy (`Set in Buzz`, `Inherited from persona`, `From config file`, `From ACP session`, etc.). Sparse declared-owner cases stay honest instead of rendering empty placeholders.

<details>
<summary>File changes</summary>

**desktop/src/features/agents/ui/AgentConfigPanel.tsx**
Aligns the runtime config surface with the profile panel card pattern, including copy affordances and read-only lock treatment, while keeping the existing provenance wording.

**desktop/src/features/profile/ui/UserProfilePanel.tsx**
Updates the profile panel composition so agent-owned runtime details are exposed through the consolidated Runtime tab.

**desktop/src/features/profile/ui/UserProfilePanelAgentDetails.tsx**
Simplifies the agent-details presentation and removes redundant runtime/instructions dumping from the profile surface.

**desktop/src/features/profile/ui/UserProfilePanelFields.tsx**
Reuses the shared label/value row treatment for runtime fields and copyable profile metadata.

**desktop/src/features/profile/ui/UserProfilePanelSections.tsx**
Adjusts the section layout so runtime metadata fits the same visual rhythm as the rest of the profile panel.

**desktop/src/features/profile/ui/UserProfilePanelTabs.tsx**
Updates tab availability for managed and declared-owned agents so Runtime appears only where it has meaningful content.

**desktop/src/testing/e2eBridge.ts**
Extends profile/config test fixtures for the runtime metadata states covered by the profile panel.

**desktop/tests/e2e/config-bridge-screenshots.spec.ts**
Updates screenshot bridge coverage for the consolidated profile panel render path and restored provenance wording.

**desktop/tests/e2e/profile.spec.ts**
Adds regression coverage for declared-owner runtime visibility and sparse/no-relay-record behavior.

**desktop/tests/helpers/bridge.ts**
Adds helper support needed by the profile runtime test fixtures.

</details>

### Reproduction Steps

1. Open an agent profile for a managed agent and switch to the **Runtime** tab.
2. Confirm runtime metadata uses the same icon-row card pattern as the rest of the profile panel.
3. Confirm provenance text uses the pre-branch wording (`Set in Buzz`, `Inherited from persona`, `From config file`, `From ACP session`, `From environment variable (...)`).
4. Open a declared-owner agent with relay runtime data and confirm the Runtime tab shows populated runtime/config rows.
5. Open a declared-owner agent without a relay-agent record and confirm the Runtime tab shows only the verified declared-owner signal instead of empty placeholders.
6. Confirm non-owner viewers do not see owner-only runtime controls or write affordances.

### Screenshots/Demos

Runtime examples from the latest review pass after moving the read-only `PenOff` icon inline with provenance hints.

| **Provider / model / env-var / config mix** | **Folded config with inline read-only hint** | **Profile side panel — Configuration section** |
|---|---|---|
| <img width="380" height="851" alt="image" src="https://github.com/user-attachments/assets/c11f77c6-c30f-47db-8720-507c600b5bb6" /> | <img width="380" height="851" alt="image" src="https://github.com/user-attachments/assets/5b910b1f-305b-4c0c-930c-cc01cbde08d3" /> | <img width="380" height="851" alt="image" src="https://github.com/user-attachments/assets/cca3a337-d216-4636-b942-6daf940689ca" /> |

Final gate validation:

- `biome check .` — clean
- `pnpm typecheck` — clean
- `playwright config-bridge-screenshots --project=smoke` — 6/6 passed


