### PR TITLE
show owner badges for duplicate-named agents

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
         "**/timeline-no-shift.spec.ts",
         "**/human-edit-agent-content.spec.ts",
         "**/reaction-order.spec.ts",
+        "**/duplicate-agent-avatars.spec.ts",
       ],
       use: {
         ...devices["Desktop Chrome"],

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -50,7 +50,10 @@ import { useLoadMissingAncestors } from "@/features/messages/useLoadMissingAnces
 import { useThreadReplies } from "@/features/messages/useThreadReplies";
 import { useChannelTyping } from "@/features/messages/useChannelTyping";
 import type { TimelineMessage } from "@/features/messages/types";
-import { useUsersBatchQuery } from "@/features/profile/hooks";
+import {
+  useAgentOwnerProfilesQuery,
+  useUsersBatchQuery,
+} from "@/features/profile/hooks";
 import { mergeCurrentProfileIntoLookup } from "@/features/profile/lib/identity";
 import type { RelayEvent, RespondToMode, SearchHit } from "@/shared/api/types";
 import { useChannelFind } from "@/features/search/useChannelFind";
@@ -347,6 +350,11 @@ export function ChannelScreen({
       (messageProfilePubkeys.length > 0 &&
         (messageProfilesQuery.isPending ||
           messageProfilesQuery.isPlaceholderData)));
+  // Owners referenced by agent profiles (NIP-OA ownerPubkey) are a
+  // second-level fetch; see useAgentOwnerProfilesQuery.
+  const agentOwnerProfilesQuery = useAgentOwnerProfilesQuery(
+    messageProfilesQuery.data?.profiles,
+  );
   const {
     agentSessionCandidates,
     botTypingEntries,
@@ -387,7 +395,12 @@ export function ChannelScreen({
   const messageProfiles = React.useMemo(() => {
     const base =
       mergeCurrentProfileIntoLookup(
-        messageProfilesQuery.data?.profiles,
+        {
+          // Owner profiles first: an owner who also authored messages keeps
+          // their richer first-batch entry.
+          ...agentOwnerProfilesQuery.data?.profiles,
+          ...messageProfilesQuery.data?.profiles,
+        },
         currentProfile,
       ) ?? {};
     return mergeAgentNamesIntoProfiles(
@@ -397,6 +410,7 @@ export function ChannelScreen({
       currentPubkey,
     );
   }, [
+    agentOwnerProfilesQuery.data?.profiles,
     currentProfile,
     currentPubkey,
     managedAgents,

--- a/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
@@ -512,3 +512,155 @@ test("CHANNEL_TIMELINE_CONTENT_KINDS matches isTimelineContentEvent", () => {
     );
   }
 });
+
+// --- agentOwner: duplicate-agent-name disambiguation ---------------------
+
+const OWNER_PUBKEY =
+  "3333333333333333333333333333333333333333333333333333333333333333";
+const AGENT_PUBKEY_A =
+  "4444444444444444444444444444444444444444444444444444444444444444";
+const AGENT_PUBKEY_B =
+  "5555555555555555555555555555555555555555555555555555555555555555";
+
+function botMember(pubkey, displayName) {
+  return {
+    pubkey,
+    role: "bot",
+    isAgent: true,
+    joinedAt: "2026-01-01T00:00:00Z",
+    displayName,
+  };
+}
+
+function agentProfiles() {
+  return {
+    [AGENT_PUBKEY_A]: {
+      displayName: "Bart",
+      avatarUrl: null,
+      nip05Handle: null,
+      ownerPubkey: OWNER_PUBKEY,
+      isAgent: true,
+    },
+    [AGENT_PUBKEY_B]: {
+      displayName: "Bart",
+      avatarUrl: null,
+      nip05Handle: null,
+      ownerPubkey: PUBKEY_B,
+      isAgent: true,
+    },
+    [OWNER_PUBKEY]: {
+      displayName: "Taylor",
+      avatarUrl: "https://example.com/taylor.png",
+      nip05Handle: null,
+      ownerPubkey: null,
+    },
+  };
+}
+
+test("agentOwner set when two agents share a display name", () => {
+  const [message] = formatTimelineMessages(
+    [streamMessage({ pubkey: AGENT_PUBKEY_A })],
+    null,
+    undefined,
+    null,
+    agentProfiles(),
+    [botMember(AGENT_PUBKEY_A, "Bart"), botMember(AGENT_PUBKEY_B, "Bart")],
+  );
+  assert.deepEqual(message.agentOwner, {
+    pubkey: OWNER_PUBKEY,
+    displayName: "Taylor",
+    avatarUrl: "https://example.com/taylor.png",
+  });
+});
+
+test("agentOwner omitted for a uniquely named agent", () => {
+  const profiles = agentProfiles();
+  profiles[AGENT_PUBKEY_B] = {
+    ...profiles[AGENT_PUBKEY_B],
+    displayName: "Lisa",
+  };
+  const [message] = formatTimelineMessages(
+    [streamMessage({ pubkey: AGENT_PUBKEY_A })],
+    null,
+    undefined,
+    null,
+    profiles,
+    [botMember(AGENT_PUBKEY_A, "Bart"), botMember(AGENT_PUBKEY_B, "Lisa")],
+  );
+  assert.equal(message.agentOwner, undefined);
+});
+
+test("agentOwner omitted for human authors even on name collision", () => {
+  const profiles = agentProfiles();
+  profiles[PUBKEY_A] = {
+    displayName: "Bart",
+    avatarUrl: null,
+    nip05Handle: null,
+    ownerPubkey: null,
+  };
+  const [message] = formatTimelineMessages(
+    [streamMessage({ pubkey: PUBKEY_A })],
+    null,
+    undefined,
+    null,
+    profiles,
+    [
+      { ...botMember(PUBKEY_A, "Bart"), role: "member", isAgent: false },
+      botMember(AGENT_PUBKEY_A, "Bart"),
+      botMember(AGENT_PUBKEY_B, "Bart"),
+    ],
+  );
+  assert.equal(message.agentOwner, undefined);
+});
+
+test("agentOwner omitted when the agent has no ownerPubkey", () => {
+  const profiles = agentProfiles();
+  profiles[AGENT_PUBKEY_A] = {
+    ...profiles[AGENT_PUBKEY_A],
+    ownerPubkey: null,
+  };
+  const [message] = formatTimelineMessages(
+    [streamMessage({ pubkey: AGENT_PUBKEY_A })],
+    null,
+    undefined,
+    null,
+    profiles,
+    [botMember(AGENT_PUBKEY_A, "Bart"), botMember(AGENT_PUBKEY_B, "Bart")],
+  );
+  assert.equal(message.agentOwner, undefined);
+});
+
+test("agentOwner falls back to null profile fields for unknown owner", () => {
+  const profiles = agentProfiles();
+  delete profiles[OWNER_PUBKEY];
+  const [message] = formatTimelineMessages(
+    [streamMessage({ pubkey: AGENT_PUBKEY_A })],
+    null,
+    undefined,
+    null,
+    profiles,
+    [botMember(AGENT_PUBKEY_A, "Bart"), botMember(AGENT_PUBKEY_B, "Bart")],
+  );
+  assert.deepEqual(message.agentOwner, {
+    pubkey: OWNER_PUBKEY,
+    displayName: null,
+    avatarUrl: null,
+  });
+});
+
+test("agent name matching is case-insensitive", () => {
+  const profiles = agentProfiles();
+  profiles[AGENT_PUBKEY_B] = {
+    ...profiles[AGENT_PUBKEY_B],
+    displayName: "bart",
+  };
+  const [message] = formatTimelineMessages(
+    [streamMessage({ pubkey: AGENT_PUBKEY_A })],
+    null,
+    undefined,
+    null,
+    profiles,
+    [botMember(AGENT_PUBKEY_A, "Bart"), botMember(AGENT_PUBKEY_B, "bart")],
+  );
+  assert.equal(message.agentOwner?.pubkey, OWNER_PUBKEY);
+});

--- a/desktop/src/features/messages/lib/formatTimelineMessages.ts
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.ts
@@ -196,6 +196,30 @@ export function formatTimelineMessages(
       roleByPubkey.set(member.pubkey.toLowerCase(), member.role);
     }
   }
+  // Agent display names that appear more than once among this room's agent
+  // members. Messages from these agents get an inline owner avatar so humans
+  // can tell same-named clones apart.
+  const duplicateAgentNames = (() => {
+    const counts = new Map<string, number>();
+    for (const member of members ?? []) {
+      if (!member.isAgent && member.role !== "bot") {
+        continue;
+      }
+      const name = (
+        profiles?.[member.pubkey.toLowerCase()]?.displayName?.trim() ||
+        member.displayName?.trim() ||
+        ""
+      ).toLowerCase();
+      if (!name) {
+        continue;
+      }
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    return new Set(
+      [...counts].filter(([, count]) => count > 1).map(([name]) => name),
+    );
+  })();
+
   const deletedEventIds = new Set<string>();
   for (const event of events) {
     // Both kind:5 and kind:9005 are deletion markers; mirror the relay.
@@ -412,6 +436,26 @@ export function formatTimelineMessages(
     const thread = getThreadReference(event.tags);
     const edit = editsByTargetId.get(event.id);
     const role = roleByPubkey.get(authorPubkey.toLowerCase());
+    const authorProfile = profiles?.[authorPubkey.toLowerCase()];
+    const agentOwner = (() => {
+      const isAgentAuthor = role === "bot" || authorProfile?.isAgent === true;
+      if (
+        !isAgentAuthor ||
+        !duplicateAgentNames.has(author.trim().toLowerCase())
+      ) {
+        return undefined;
+      }
+      const ownerPubkey = authorProfile?.ownerPubkey;
+      if (!ownerPubkey) {
+        return undefined;
+      }
+      const ownerProfile = profiles?.[ownerPubkey.toLowerCase()];
+      return {
+        pubkey: ownerPubkey,
+        displayName: ownerProfile?.displayName ?? null,
+        avatarUrl: ownerProfile?.avatarUrl ?? null,
+      };
+    })();
     return {
       id: event.id,
       renderKey: event.localKey ?? event.id,
@@ -429,6 +473,7 @@ export function formatTimelineMessages(
         role === "bot"
           ? personaLookup?.get(authorPubkey.toLowerCase())
           : undefined,
+      agentOwner,
       respondTo:
         role === "bot"
           ? respondToLookup?.get(authorPubkey.toLowerCase())

--- a/desktop/src/features/messages/types.ts
+++ b/desktop/src/features/messages/types.ts
@@ -22,6 +22,15 @@ export type TimelineMessage = {
   role?: string;
   /** For bot messages, the display name of the persona this bot was created from. */
   personaDisplayName?: string;
+  /**
+   * For bot messages whose display name collides with another agent in the
+   * same room: the owner's profile, rendered inline to disambiguate clones.
+   */
+  agentOwner?: {
+    pubkey: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+  };
   /** For bot messages, the respond-to mode (who can interact with this bot). */
   respondTo?: "owner-only" | "allowlist" | "anyone";
   time: string;

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -4,7 +4,10 @@ import type { TimelineMessage } from "@/features/messages/types";
 import { HuddleAttachment } from "@/features/huddle/components/HuddleAttachment";
 import { MessageReactions } from "@/features/messages/ui/MessageReactions";
 import { useReactionHandler } from "@/features/messages/ui/useReactionHandler";
-import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import {
+  truncatePubkey,
+  type UserProfileLookup,
+} from "@/features/profile/lib/identity";
 import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
 import { useRemindLater } from "@/features/reminders/ui/RemindMeLaterProvider";
 import {
@@ -418,6 +421,39 @@ export const MessageRow = React.memo(
       <MessageAuthorText as="h3">{message.author}</MessageAuthorText>
     );
 
+    // "Username's {agentname}." — popover identity for same-named agents.
+    const agentOwnerLabel = message.agentOwner
+      ? `${
+          message.agentOwner.displayName?.trim() ||
+          truncatePubkey(message.agentOwner.pubkey)
+        }'s ${message.author}.`
+      : undefined;
+
+    // Inline owner avatar disambiguating agents whose display name collides
+    // with another agent in this room. h-4 matches the header's leading-4
+    // line box, so the row height stays untouched; self-center keeps it off
+    // the baseline (baseline-aligning a replaced box would grow the line).
+    const agentOwnerAvatarNode = message.agentOwner ? (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="flex shrink-0 self-center"
+            data-testid="message-agent-owner-avatar"
+          >
+            <UserAvatar
+              avatarUrl={message.agentOwner.avatarUrl}
+              displayName={
+                message.agentOwner.displayName?.trim() ||
+                truncatePubkey(message.agentOwner.pubkey)
+              }
+              size="2xs"
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{agentOwnerLabel}</TooltipContent>
+      </Tooltip>
+    ) : null;
+
     const actionBarNode = (
       <div
         className={cn(
@@ -499,6 +535,7 @@ export const MessageRow = React.memo(
             pubkey={message.pubkey}
             role={profilePopoverRole}
             botIdenticonValue={message.author}
+            displayNameOverride={agentOwnerLabel}
           >
             <button
               className="truncate rounded leading-4 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
@@ -510,6 +547,7 @@ export const MessageRow = React.memo(
         ) : (
           authorNode
         )}
+        {agentOwnerAvatarNode}
         {inlineMetadataNode}
         {message.personaDisplayName &&
         message.personaDisplayName !== message.author ? (
@@ -785,6 +823,12 @@ export const MessageRow = React.memo(
     prev.message.tags === next.message.tags &&
     prev.message.role === next.message.role &&
     prev.message.personaDisplayName === next.message.personaDisplayName &&
+    // Field-wise: agentOwner is rebuilt each formatter pass, so reference
+    // equality would defeat the memo for disambiguated rows.
+    prev.message.agentOwner?.pubkey === next.message.agentOwner?.pubkey &&
+    prev.message.agentOwner?.displayName ===
+      next.message.agentOwner?.displayName &&
+    prev.message.agentOwner?.avatarUrl === next.message.agentOwner?.avatarUrl &&
     prev.agentPubkeys === next.agentPubkeys &&
     prev.collapseDepthGuideActions === next.collapseDepthGuideActions &&
     prev.collapseDescendantsLabel === next.collapseDescendantsLabel &&

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -447,6 +447,7 @@ export const MessageRow = React.memo(
                 truncatePubkey(message.agentOwner.pubkey)
               }
               size="2xs"
+              testId="message-agent-owner-avatar"
             />
           </span>
         </TooltipTrigger>

--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -418,3 +418,27 @@ export function useUpdateProfileMutation() {
     },
   });
 }
+
+/**
+ * Second-level profile fetch for agent owners: agents declare a NIP-OA
+ * `ownerPubkey`, but the owner may be neither an author nor a member of the
+ * room, so the first users batch misses them. Their profile feeds the inline
+ * owner avatar that disambiguates same-named agents.
+ */
+export function useAgentOwnerProfilesQuery(
+  profiles: UsersBatchResponse["profiles"] | undefined,
+) {
+  const ownerPubkeys = React.useMemo(() => {
+    const pubkeys = new Set<string>();
+    for (const profile of Object.values(profiles ?? {})) {
+      if (profile.ownerPubkey) {
+        pubkeys.add(profile.ownerPubkey.toLowerCase());
+      }
+    }
+    return [...pubkeys];
+  }, [profiles]);
+
+  return useUsersBatchQuery(ownerPubkeys, {
+    enabled: ownerPubkeys.length > 0,
+  });
+}

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -58,6 +58,11 @@ type UserProfilePopoverProps = {
   role?: string;
   /** Value used to generate the BotIdenticon glyph (typically the author name). */
   botIdenticonValue?: string;
+  /**
+   * Replaces the resolved display name in the popover header. Used to
+   * disambiguate same-named agents ("Username's {agentname}.").
+   */
+  displayNameOverride?: string;
 };
 
 const HOVER_OPEN_DELAY_MS = 500;
@@ -169,6 +174,7 @@ export function UserProfilePopover({
   enableProfilePanel = true,
   role,
   botIdenticonValue,
+  displayNameOverride,
 }: UserProfilePopoverProps) {
   const [open, setOpen] = React.useState(false);
   const [pendingAction, setPendingAction] = React.useState<
@@ -222,7 +228,8 @@ export function UserProfilePopover({
       relayAgentsQuery.isPending ||
       managedAgentsQuery.isPending ||
       usersBatchQuery.isPending);
-  const displayName = profile?.displayName ?? truncatePubkey(pubkey);
+  const displayName =
+    displayNameOverride ?? profile?.displayName ?? truncatePubkey(pubkey);
   // Owner signal mirrors UserProfilePanel: a declared NIP-OA owner whose agent
   // runs elsewhere holds no local seckey, so key custody (`isOwner`) alone
   // wrongly hides the affordance from them — and gating on bot-ness alone shows

--- a/desktop/src/shared/ui/UserAvatar.tsx
+++ b/desktop/src/shared/ui/UserAvatar.tsx
@@ -6,9 +6,10 @@ import { getInitials } from "@/shared/lib/initials";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { Avatar, AvatarFallback, AvatarImage } from "@/shared/ui/avatar";
 
-type UserAvatarSize = "xs" | "sm" | "md";
+type UserAvatarSize = "2xs" | "xs" | "sm" | "md";
 
 const sizeClasses: Record<UserAvatarSize, string> = {
+  "2xs": "h-4 w-4 text-3xs",
   xs: "h-5 w-5 text-3xs",
   sm: "h-6 w-6 text-2xs",
   md: "h-9 w-9 text-xs",

--- a/desktop/src/shared/ui/UserAvatar.tsx
+++ b/desktop/src/shared/ui/UserAvatar.tsx
@@ -68,7 +68,10 @@ export function UserAvatar({
             : "bg-secondary text-secondary-foreground",
         )}
         data-testid={testId ? `${testId}-fallback` : undefined}
-        delayMs={200}
+        // The delay exists to avoid an initials flash while an image loads.
+        // With no image source there is nothing to wait for — render the
+        // initials immediately or the avatar paints as an empty box.
+        delayMs={src ? 200 : undefined}
       >
         {initials}
       </AvatarFallback>

--- a/desktop/tests/e2e/duplicate-agent-avatars.spec.ts
+++ b/desktop/tests/e2e/duplicate-agent-avatars.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const SHOTS = "test-results/duplicate-agent-avatars";
+
+// Two managed agents sharing the display name "Scout", owned by different
+// humans (alice and bob), plus a uniquely named control agent. The inline
+// owner avatar must appear only on the duplicate-named agents' rows.
+const SCOUT_A_PUBKEY =
+  "aaaa000000000000000000000000000000000000000000000000000000000001";
+const SCOUT_B_PUBKEY =
+  "aaaa000000000000000000000000000000000000000000000000000000000002";
+const SOLO_PUBKEY =
+  "aaaa000000000000000000000000000000000000000000000000000000000003";
+
+async function emitMockMessage(page: Page, content: string, pubkey: string) {
+  const event = await page.evaluate(
+    ({ msg, pk }) => {
+      return (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            pubkey?: string;
+          }) => { id: string };
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content: msg,
+        pubkey: pk,
+      });
+    },
+    { msg: content, pk: pubkey },
+  );
+  if (!event) {
+    throw new Error("Mock message emitter is not installed");
+  }
+  return event;
+}
+
+async function waitForMockLiveSubscription(page: Page) {
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () =>
+          (
+            window as Window & {
+              __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                channelName: string;
+              }) => boolean;
+            }
+          ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+            channelName: "general",
+          }) ?? false,
+      ),
+    )
+    .toBe(true);
+}
+
+async function waitForTimelineSettled(page: Page) {
+  await expect(page.locator("[data-render-pending]")).toHaveCount(0);
+}
+
+test("duplicate-named agents get an inline owner avatar; unique agents do not", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: SCOUT_A_PUBKEY,
+        name: "Scout",
+        status: "running",
+        channelNames: ["general"],
+      },
+      {
+        pubkey: SCOUT_B_PUBKEY,
+        name: "Scout",
+        status: "running",
+        channelNames: ["general"],
+      },
+      {
+        pubkey: SOLO_PUBKEY,
+        name: "Ranger",
+        status: "running",
+        channelNames: ["general"],
+      },
+    ],
+    // Seeded after managed agents, so these override the default
+    // owner (the mock viewer) with two distinct humans.
+    searchProfiles: [
+      {
+        pubkey: SCOUT_A_PUBKEY,
+        displayName: "Scout",
+        ownerPubkey: TEST_IDENTITIES.alice.pubkey,
+        isAgent: true,
+      },
+      {
+        pubkey: SCOUT_B_PUBKEY,
+        displayName: "Scout",
+        ownerPubkey: TEST_IDENTITIES.bob.pubkey,
+        isAgent: true,
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page);
+
+  await emitMockMessage(page, "Scout A reporting in.", SCOUT_A_PUBKEY);
+  await emitMockMessage(page, "Scout B reporting in.", SCOUT_B_PUBKEY);
+  await emitMockMessage(page, "Ranger here, no twin.", SOLO_PUBKEY);
+  await waitForTimelineSettled(page);
+
+  const scoutARow = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Scout A reporting in." });
+  const scoutBRow = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Scout B reporting in." });
+  const rangerRow = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Ranger here, no twin." });
+
+  // Both same-named agents carry the inline owner avatar…
+  await expect(
+    scoutARow.getByTestId("message-agent-owner-avatar"),
+  ).toBeVisible();
+  await expect(
+    scoutBRow.getByTestId("message-agent-owner-avatar"),
+  ).toBeVisible();
+  // …the uniquely named agent does not.
+  await expect(rangerRow.getByTestId("message-agent-owner-avatar")).toHaveCount(
+    0,
+  );
+
+  // The disambiguated row must not be taller than the plain agent row.
+  const scoutBox = await scoutARow.boundingBox();
+  const rangerBox = await rangerRow.boundingBox();
+  if (!scoutBox || !rangerBox) {
+    throw new Error("Expected both message rows to be visible.");
+  }
+  expect(scoutBox.height).toBe(rangerBox.height);
+
+  await page.screenshot({
+    path: `${SHOTS}/01-timeline-duplicate-agents.png`,
+    fullPage: false,
+  });
+
+  // Hovering the agent's name opens the balloon with the possessive identity.
+  await scoutARow.getByTestId("message-author").first().hover();
+  const popover = page.getByTestId("user-profile-popover");
+  await expect(popover).toBeVisible();
+  await expect(popover.getByText("alice's Scout.")).toBeVisible();
+
+  await page.screenshot({
+    path: `${SHOTS}/02-balloon-owners-scout.png`,
+    fullPage: false,
+  });
+});

--- a/desktop/tests/e2e/duplicate-agent-avatars.spec.ts
+++ b/desktop/tests/e2e/duplicate-agent-avatars.spec.ts
@@ -14,6 +14,12 @@ const SCOUT_B_PUBKEY =
 const SOLO_PUBKEY =
   "aaaa000000000000000000000000000000000000000000000000000000000003";
 
+// 8x8 solid teal PNG. A data URL keeps the avatar-image path hermetic — no
+// network fetch, no relay proxy — while still exercising Radix's real
+// image-load lifecycle (AvatarImage only renders once the img has loaded).
+const ALICE_AVATAR_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAFElEQVR4nGMUWTCNARtgwio6aCUABdEBWlX6zykAAAAASUVORK5CYII=";
+
 async function emitMockMessage(page: Page, content: string, pubkey: string) {
   const event = await page.evaluate(
     ({ msg, pk }) => {
@@ -87,7 +93,8 @@ test("duplicate-named agents get an inline owner avatar; unique agents do not", 
       },
     ],
     // Seeded after managed agents, so these override the default
-    // owner (the mock viewer) with two distinct humans.
+    // owner (the mock viewer) with two distinct humans. Alice carries an
+    // avatar image; bob has none, exercising the initials fallback.
     searchProfiles: [
       {
         pubkey: SCOUT_A_PUBKEY,
@@ -100,6 +107,15 @@ test("duplicate-named agents get an inline owner avatar; unique agents do not", 
         displayName: "Scout",
         ownerPubkey: TEST_IDENTITIES.bob.pubkey,
         isAgent: true,
+      },
+      {
+        pubkey: TEST_IDENTITIES.alice.pubkey,
+        displayName: "alice",
+        avatarUrl: ALICE_AVATAR_DATA_URL,
+      },
+      {
+        pubkey: TEST_IDENTITIES.bob.pubkey,
+        displayName: "bob",
       },
     ],
   });
@@ -123,13 +139,33 @@ test("duplicate-named agents get an inline owner avatar; unique agents do not", 
     .getByTestId("message-row")
     .filter({ hasText: "Ranger here, no twin." });
 
-  // Both same-named agents carry the inline owner avatar…
-  await expect(
-    scoutARow.getByTestId("message-agent-owner-avatar"),
-  ).toBeVisible();
-  await expect(
-    scoutBRow.getByTestId("message-agent-owner-avatar"),
-  ).toBeVisible();
+  // Both same-named agents carry the inline owner avatar. The wrapper being
+  // visible is not enough — assert actual painted content. Owner profiles
+  // arrive via a second-level batch fetch, so give the cold first render
+  // time to settle instead of racing it.
+  const scoutABadge = scoutARow.getByTestId("message-agent-owner-avatar");
+  const scoutBBadge = scoutBRow.getByTestId("message-agent-owner-avatar");
+  await expect(scoutABadge).toBeVisible({ timeout: 15_000 });
+  await expect(scoutBBadge).toBeVisible({ timeout: 15_000 });
+
+  // Alice has an avatar image — a real, fully loaded <img> must render.
+  const aliceImage = scoutABadge.getByTestId(
+    "message-agent-owner-avatar-image",
+  );
+  await expect(aliceImage).toBeVisible({ timeout: 15_000 });
+  expect(
+    await aliceImage.evaluate(
+      (img: HTMLImageElement) => img.complete && img.naturalWidth > 0,
+    ),
+  ).toBe(true);
+
+  // Bob has no avatar URL — the initials fallback must paint visible text.
+  const bobFallback = scoutBBadge.getByTestId(
+    "message-agent-owner-avatar-fallback",
+  );
+  await expect(bobFallback).toBeVisible({ timeout: 15_000 });
+  await expect(bobFallback).toHaveText("B");
+
   // …the uniquely named agent does not.
   await expect(rangerRow.getByTestId("message-agent-owner-avatar")).toHaveCount(
     0,


### PR DESCRIPTION
**Category:** new-feature
**User Impact:** When multiple agents in a room share the same name, users can tell them apart by the owning user's avatar shown inline next to the agent name.
**Problem:** Duplicate-named agents currently appear identical in the message timeline, which makes it hard to know which human owns or configured each agent. The first implementation reserved the inline badge space but could render a blank fallback during cold loads.
**Solution:** Detect duplicate agent names within the room, attach the agent owner's profile to those timeline messages, and render a 16px owner badge between the agent name and timestamp without increasing row height. The owner popover label now reads `Username's {agentname}.`, and avatar-less owners paint initials immediately instead of showing an empty fallback window.

<details>
<summary>File changes</summary>

**desktop/playwright.config.ts**
Adds the duplicate-agent avatar smoke spec to the smoke project so the user-facing timeline behavior runs in CI.

**desktop/src/features/channels/ui/ChannelScreen.tsx**
Fetches second-level agent owner profiles and merges them into the timeline profile lookup so owner badges have display names and avatars even when owners did not author messages in the room.

**desktop/src/features/messages/lib/formatTimelineMessages.ts**
Detects duplicate agent display names among room members and annotates only those agent messages with owner profile data for rendering.

**desktop/src/features/messages/lib/formatTimelineMessages.test.mjs**
Adds unit coverage for duplicate-name detection, unique-agent omission, human-author omission, missing owner handling, unknown owner fallback, and case-insensitive matching.

**desktop/src/features/messages/types.ts**
Adds `agentOwner` metadata to timeline messages for duplicate-agent disambiguation.

**desktop/src/features/messages/ui/MessageRow.tsx**
Renders the inline owner avatar between the agent name and timestamp, keeps it within the row line box, and passes the disambiguated popover label.

**desktop/src/features/profile/hooks.ts**
Adds a helper query for fetching profiles referenced by agent `ownerPubkey` fields.

**desktop/src/features/profile/ui/UserProfilePopover.tsx**
Allows the popover header display name to be overridden for the `Username's {agentname}.` label.

**desktop/src/shared/ui/UserAvatar.tsx**
Adds the 16px `2xs` avatar size and renders initials immediately when there is no image source, avoiding an empty fallback window.

**desktop/tests/e2e/duplicate-agent-avatars.spec.ts**
Adds smoke coverage for two same-named agents and one unique control: loaded owner image, initials fallback, no badge for the unique agent, unchanged row height, and the requested popover copy.

</details>

## Reproduction Steps

1. Open a room with two agents that share the same displayed name and a third uniquely named agent.
2. Confirm the duplicate-named agents show a small owner badge between the agent name and timestamp.
3. Confirm one owner badge can render an avatar image and another can render initials when no avatar URL exists.
4. Confirm the uniquely named agent has no inline owner badge.
5. Hover a duplicate-named agent and confirm the balloon reads `Username's {agentname}.`.
6. Compare duplicate and unique rows and confirm the inline badge does not increase row height.

## Screenshots/Demos

**Timeline** — Scout A shows alice's teal avatar image inline, Scout B shows bob's `B` initials, and Ranger shows no badge. Row heights match.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/60479b18-2044-41de-84c0-62ef34296c6c" />

**Balloon** — duplicate-agent popover reads `alice's Scout.`.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/a5c70d75-37b4-4348-a915-46b9a07a0ab9" />

## Validation

- `pnpm --dir desktop check`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test`
- `pnpm --dir desktop build`
- `pnpm --dir desktop exec playwright test duplicate-agent-avatars --project=smoke`
- Marge live-build gate on the feature branch before rebase: biome check, typecheck, 1481 unit tests, build, and duplicate-agent e2e cold 3/3 all green. I rebased onto latest `origin/main` before opening this draft PR and reran the focused validation above.
