### PR TITLE
feat(buzz-agent): config parity — thinking effort, model switching, normalized token limits

### DIFF
--- a/crates/buzz-agent/src/agent.rs
+++ b/crates/buzz-agent/src/agent.rs
@@ -23,6 +23,9 @@ const ERROR_REFLECTION_SUFFIX: &str =
 
 pub struct RunCtx<'a> {
     pub cfg: &'a Config,
+    /// Effective model for this session. Usually equals `cfg.model`; overridden
+    /// per-session by `session/set_model`. All LLM calls use this value.
+    pub effective_model: &'a str,
     pub session_id: &'a str,
     pub system_prompt: &'a str,
     pub llm: &'a Llm,
@@ -113,7 +116,7 @@ impl RunCtx<'_> {
             let response = tokio::select! {
                 biased;
                 _ = self.cancel.changed() => return Ok(StopReason::Cancelled),
-                r = self.llm.complete(self.cfg, self.system_prompt, self.history, &tools) => r?,
+                r = self.llm.complete(self.cfg, self.system_prompt, self.history, &tools, self.effective_model) => r?,
                 _ = async {
                     // Keepalive ticker: emit a lightweight session update every 30s
                     // while waiting on the LLM provider. This resets the ACP harness

--- a/crates/buzz-agent/src/catalog.rs
+++ b/crates/buzz-agent/src/catalog.rs
@@ -32,6 +32,39 @@ pub struct ModelEntry {
 pub const DATABRICKS_V2_KNOWN_MODELS: &[&str] =
     &["databricks-gpt-5-5", "databricks-claude-opus-4-7"];
 
+/// Returns the discovery-failure fallback catalog for a Databricks provider.
+///
+/// This is the list of models advertised by `session/new` when
+/// `discover_databricks_models` returns an error (e.g., no token available).
+///
+/// - `DatabricksV2` falls back to [`DATABRICKS_V2_KNOWN_MODELS`] so the
+///   model-picker is always populated for AI Gateway v2 users.
+/// - Legacy `Databricks` falls back to only the configured model — the
+///   `DATABRICKS_V2_KNOWN_MODELS` IDs are AI Gateway v2 endpoints that the
+///   `/serving-endpoints/{model}/invocations` API may not serve.
+///
+/// Extracting this as a pure function makes the split testable without
+/// spawning an async runtime or making network calls.
+pub fn discovery_failure_fallback(provider: Provider, configured_model: &str) -> Vec<ModelEntry> {
+    match provider {
+        Provider::DatabricksV2 => DATABRICKS_V2_KNOWN_MODELS
+            .iter()
+            .map(|id| ModelEntry {
+                id: id.to_string(),
+                name: id.to_string(),
+            })
+            .collect(),
+        Provider::Databricks => vec![ModelEntry {
+            id: configured_model.to_string(),
+            name: configured_model.to_string(),
+        }],
+        _ => vec![ModelEntry {
+            id: configured_model.to_string(),
+            name: configured_model.to_string(),
+        }],
+    }
+}
+
 /// Discover available models for a Databricks provider.
 ///
 /// Returns a non-empty `Vec<ModelEntry>` on success. Returns

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -218,14 +218,17 @@ fn gpt5_token_matches(lower_model: &str, token: &str) -> bool {
     false
 }
 
-/// Like `gpt5_token_matches` but additionally rejects short purely-numeric suffixes — used
-/// for the base `gpt-5` / `gpt5` token to avoid false-matching unrecognized version segments.
+/// Like `gpt5_token_matches` but additionally rejects short version-like numeric suffixes —
+/// used for the base `gpt-5` / `gpt5` token to avoid false-matching unrecognized versions.
 ///
 /// After a `-` separator:
 /// - `-<non-digit>…` e.g. `-pro` → **accepted** (capability suffix, no digits)
-/// - `-<digits><non-digit>…` e.g. `-4o`, `-1106-preview` → **accepted** (digit+variant)
-/// - `-<1-3 digits><end-of-string>` e.g. `-10`, `-5` → **rejected** (bare version number)
-/// - `-<4+ digits><end-of-string>` e.g. `-1106`, `-0514` → **accepted** (date segment)
+/// - `digit_run == 1-3` AND the char right after the digits is a **letter** e.g. `-4o` →
+///   **accepted** (real variant shape: digit + letter)
+/// - `digit_run == 1-3` AND the char after the digits is end-of-string, `-`, `.`, or other
+///   separator e.g. `-10`, `-10-preview` → **rejected** (version-like suffix)
+/// - `digit_run >= 4` regardless of what follows e.g. `-1106`, `-1106-preview`, `-0514` →
+///   **accepted** (date/build segment)
 fn gpt5_base_matches(lower_model: &str, token: &str) -> bool {
     let mut start = 0;
     while let Some(pos) = lower_model[start..].find(token) {
@@ -241,13 +244,17 @@ fn gpt5_base_matches(lower_model: &str, token: &str) -> bool {
             if digit_run == 0 {
                 // No leading digit (e.g. '-pro'): capability suffix → accepted.
                 true
-            } else if !tail[digit_run..].is_empty() {
-                // Digit run followed by non-digit (e.g. '-4o', '-1106-preview'): variant → accepted.
+            } else if digit_run >= 4 {
+                // 4+ digit run (e.g. '-1106', '-1106-preview', '-0514'): date/build → accepted.
                 true
             } else {
-                // Pure digit run (nothing after digits). Accept only if it looks like a date
-                // (4+ digits). Short pure-number suffixes (1–3 digits) are version-like → rejected.
-                digit_run >= 4
+                // 1-3 digit run: accepted only if the char right after the digits is a letter
+                // (real variant shape like '-4o'). Separator/EOS after short digits is
+                // version-like (e.g. '-10', '-10-preview') → rejected.
+                tail[digit_run..]
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_alphabetic())
             }
         } else {
             // Dot, letter, or other non-hyphen character directly after token → not base.
@@ -2178,6 +2185,41 @@ mod tests {
         assert!(
             openai_efforts_for_model("databricks-gpt-5-10").is_none(),
             "databricks-gpt-5-10 must pass through (short numeric suffix)"
+        );
+        // Short numeric suffix + textual continuation (e.g. a hypothetical 'gpt-5.10-preview')
+        // must also pass through — the digit count (1-3) determines version-like, regardless of
+        // what follows.
+        assert!(
+            openai_efforts_for_model("gpt-5-10-preview").is_none(),
+            "gpt-5-10-preview must pass through (short numeric version suffix with text tail)"
+        );
+        assert!(
+            openai_efforts_for_model("databricks-gpt-5-10-preview").is_none(),
+            "databricks-gpt-5-10-preview must pass through (short numeric version suffix with text tail)"
+        );
+    }
+
+    #[test]
+    fn openai_efforts_for_model_boundary_date_segment_with_suffix_is_base() {
+        // 4+ digit date segment followed by a textual suffix must still resolve to the base
+        // table — the date length (>=4) determines it's a build/date, not a version number.
+        let result = openai_efforts_for_model("gpt-5-1106-preview");
+        assert!(
+            result.is_some(),
+            "gpt-5-1106-preview must match base table (4-digit date segment)"
+        );
+        let supported = result.unwrap();
+        assert!(
+            supported.contains(&ThinkingEffort::Minimal),
+            "gpt-5-1106-preview (base) must support minimal"
+        );
+        assert!(
+            !supported.contains(&ThinkingEffort::None),
+            "gpt-5-1106-preview (base) must NOT support none"
+        );
+        assert!(
+            !supported.contains(&ThinkingEffort::XHigh),
+            "gpt-5-1106-preview (base) must NOT support xhigh"
         );
     }
 

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -4,59 +4,89 @@ pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Reasoning/thinking effort level for providers that support it.
 ///
-/// Set via `BUZZ_AGENT_THINKING_EFFORT` (`low|medium|high`).
+/// Set via `BUZZ_AGENT_THINKING_EFFORT` (`none|minimal|low|medium|high|xhigh|max`).
 /// When unset the provider's default behaviour is preserved — no thinking
 /// config is sent in the request body.
 ///
-/// Mapping to provider wire fields:
-/// - Anthropic Messages: `thinking.budget_tokens` — low=1024, medium=8192, high=32768.
-/// - OpenAI Responses: `reasoning.effort` — "low", "medium", "high".
-/// - OpenAI Chat Completions: `reasoning_effort` — "low", "medium", "high".
-/// - Databricks: routed by model family (Claude → Anthropic mapping, GPT-5 → Responses, MLflow → Chat).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Provider support (doc-verified, July 2025):
+/// - **Anthropic adaptive**: `low|medium|high|xhigh|max` (model-dependent; see `anthropic_thinking_config`).
+///   `none`/`minimal` are not Anthropic values — rejected at startup.
+/// - **Anthropic manual budget** (claude-3*, opus-4-5): `low|medium|high`; `xhigh`/`max` clamp to high budget.
+/// - **OpenAI Responses / Chat Completions**: `none|minimal|low|medium|high|xhigh` (provider pass-through).
+///   `max` is not an OpenAI value — rejected at startup.
+/// - **Databricks**: routed by model family (Claude → Anthropic mapping, GPT-5 → Responses, MLflow → Chat).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ThinkingEffort {
+    None,
+    Minimal,
     Low,
     Medium,
     High,
+    XHigh,
+    Max,
 }
 
 impl ThinkingEffort {
-    /// Map level to an Anthropic `budget_tokens` value for legacy Claude 3.x models.
+    /// Map level to an Anthropic `budget_tokens` value for legacy Claude 3.x / Opus 4.5 models.
+    /// `XHigh` and `Max` clamp to the high budget value; the API cap at `max_output_tokens-1`
+    /// is applied separately in `anthropic_thinking_config`.
     pub fn anthropic_budget_tokens(self) -> u32 {
         match self {
             ThinkingEffort::Low => 1_024,
             ThinkingEffort::Medium => 8_192,
-            ThinkingEffort::High => 32_768,
+            ThinkingEffort::High | ThinkingEffort::XHigh | ThinkingEffort::Max => 32_768,
+            // None/Minimal are not valid for Anthropic (rejected at startup); treat as zero
+            // defensively so a misconfigured call doesn't accidentally enable thinking.
+            ThinkingEffort::None | ThinkingEffort::Minimal => 0,
         }
     }
 
     /// Map level to an OpenAI `reasoning.effort` / `reasoning_effort` string.
     pub fn openai_effort_str(self) -> &'static str {
         match self {
+            ThinkingEffort::None => "none",
+            ThinkingEffort::Minimal => "minimal",
             ThinkingEffort::Low => "low",
             ThinkingEffort::Medium => "medium",
             ThinkingEffort::High => "high",
+            ThinkingEffort::XHigh => "xhigh",
+            ThinkingEffort::Max => "max",
+        }
+    }
+
+    /// Map level to an Anthropic `output_config.effort` string.
+    /// Returns the level string if supported, or the highest supported level for the model.
+    /// Caller must apply model-level clamping via `clamp_for_anthropic_adaptive`.
+    pub fn anthropic_effort_str(self) -> &'static str {
+        match self {
+            ThinkingEffort::Low => "low",
+            ThinkingEffort::Medium => "medium",
+            ThinkingEffort::High => "high",
+            ThinkingEffort::XHigh => "xhigh",
+            ThinkingEffort::Max => "max",
+            // None/Minimal are rejected at startup for Anthropic; defensive fallback.
+            ThinkingEffort::None | ThinkingEffort::Minimal => "low",
         }
     }
 }
 
 /// Build the Anthropic thinking/effort request fields for the given model and effort level.
 ///
-/// API shape selection (per Anthropic docs — https://platform.claude.com/docs/en/build-with-claude/effort
-/// and https://platform.claude.com/docs/en/build-with-claude/extended-thinking):
+/// API shape selection (per Anthropic extended-thinking support table,
+/// https://platform.claude.com/docs/en/build-with-claude/extended-thinking, July 2025):
 ///
 /// **Adaptive families** — `thinking: {type:"adaptive"}` + `output_config: {effort}`.
-/// Doc-verified models (effort page, July 2025): Claude Opus 4.8/4.7/4.6, Sonnet 5/4.6, Opus 4.5.
-/// These models require `thinking:{type:"adaptive"}` to enable thinking; without it, requests
-/// run without thinking even when `output_config.effort` is set.
-/// Matched by prefix: `claude-opus-4-`, `claude-sonnet-5`, `claude-sonnet-4-6`.
+/// These models use adaptive thinking; `thinking:{type:"adaptive"}` is required to enable
+/// thinking — without it requests run without thinking even when `output_config.effort` is set.
+/// Doc-verified (extended-thinking table): Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5.x, Sonnet 4.6.
+/// Matched by explicit version strings (no wildcard over version numbers).
 ///
 /// **Manual-budget families** — `thinking: {type:"enabled", budget_tokens}`.
 /// `budget_tokens` is capped at `max_output_tokens - 1` (required by the API).
-/// Matched by prefix: `claude-3`.
+/// Doc-verified: claude-3* (legacy), claude-opus-4-5 (effort page: "uses manual thinking").
 ///
 /// **Everything else** — omit both fields. This includes unknown/future `claude-*` names
-/// that are not yet doc-verified. Safer to omit than to guess an unverified shape.
+/// not yet in the support table. Safer to omit than to guess an unverified shape.
 ///
 /// The Databricks `databricks-` prefix is stripped before matching so that
 /// `databricks-claude-opus-4-7` routes to the adaptive bucket.
@@ -74,8 +104,9 @@ pub fn anthropic_thinking_config(
         .strip_prefix("databricks-")
         .unwrap_or(effective_model);
 
-    if model.starts_with("claude-3") {
-        // Legacy manual-budget shape: budget_tokens must be strictly < max_tokens.
+    if is_manual_budget_model(model) {
+        // Manual-budget shape: budget_tokens must be strictly < max_tokens.
+        // XHigh/Max clamp to the high budget value (32768) per anthropic_budget_tokens().
         let budget = effort
             .anthropic_budget_tokens()
             .min(max_output_tokens.saturating_sub(1));
@@ -86,30 +117,89 @@ pub fn anthropic_thinking_config(
     } else if is_adaptive_thinking_model(model) {
         // Adaptive families: thinking must be explicitly enabled via type:"adaptive".
         // output_config.effort controls the depth. Both fields are required together.
+        // Apply per-model effort clamping: if the requested level exceeds the model's
+        // doc-verified maximum, clamp down to the highest supported level with a warning.
+        let clamped = clamp_adaptive_effort(model, effort);
         (
             Some(json!({ "type": "adaptive" })),
-            Some(json!({ "effort": effort.openai_effort_str() })),
+            Some(json!({ "effort": clamped.anthropic_effort_str() })),
         )
     } else {
         // Unrecognised or unverified model name — omit both fields rather than guess.
-        // This includes unknown future claude-* names not yet in the allowlist.
+        // This includes unknown future claude-* names not yet in the support table.
         (None, None)
     }
 }
 
+/// Clamp the requested effort level to the highest doc-verified level for the given adaptive model.
+///
+/// Doc-verified availability (Anthropic effort page, July 2025):
+/// - `max`: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5.x, Sonnet 4.6
+/// - `xhigh`: Opus 4.8, Opus 4.7, Sonnet 5.x only (NOT Opus 4.6, NOT Sonnet 4.6)
+/// - `low|medium|high`: all adaptive families
+///
+/// If the requested level is not available for the model, clamps down to the highest
+/// supported level below the requested one, and logs a warning. This is dynamic (not
+/// startup-time) because `session/set_model` can change the model after startup.
+///
+/// `model` must already have the `databricks-` prefix stripped.
+pub fn clamp_adaptive_effort(model: &str, effort: ThinkingEffort) -> ThinkingEffort {
+    // Models that support all levels including xhigh (and max).
+    let supports_xhigh = model.starts_with("claude-opus-4-7")
+        || model.starts_with("claude-opus-4-8")
+        || model.starts_with("claude-sonnet-5");
+    // Models that support max but NOT xhigh (Opus 4.6, Sonnet 4.6).
+    // All adaptive models support low/medium/high.
+
+    let clamped = if supports_xhigh {
+        effort // all levels pass through
+    } else if effort == ThinkingEffort::XHigh {
+        // xhigh not available for this model; clamp to high (the highest supported below xhigh).
+        ThinkingEffort::High
+    } else {
+        effort // low/medium/high/max all pass through for Opus 4.6 / Sonnet 4.6
+    };
+
+    if clamped != effort {
+        tracing::warn!(
+            model,
+            requested = effort.openai_effort_str(),
+            clamped = clamped.openai_effort_str(),
+            "BUZZ_AGENT_THINKING_EFFORT is not available for this model; clamping to highest supported level"
+        );
+    }
+    clamped
+}
+
+/// Returns true for Claude model families that use manual thinking budgets (doc-verified, July 2025).
+///
+/// Source: https://platform.claude.com/docs/en/build-with-claude/extended-thinking (support table)
+/// - claude-3*: legacy manual budget (all Claude 3.x variants).
+/// - claude-opus-4-5: effort page states "uses manual thinking, where effort works alongside
+///   the thinking token budget" — manual bucket, not adaptive.
+///
+/// `model` must already have the `databricks-` prefix stripped.
+fn is_manual_budget_model(model: &str) -> bool {
+    model.starts_with("claude-3") || model == "claude-opus-4-5"
+}
+
 /// Returns true for Claude model families that use adaptive thinking (doc-verified, July 2025).
 ///
-/// Verified against https://platform.claude.com/docs/en/build-with-claude/effort:
-/// Claude Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6, Opus 4.5.
+/// Source: https://platform.claude.com/docs/en/build-with-claude/extended-thinking (support table)
+/// Adaptive thinking models: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5.x, Sonnet 4.6.
+/// Note: Opus 4.5 is NOT in this bucket — it uses manual budget (see `is_manual_budget_model`).
+/// No prefix wildcards over version numbers; each entry is doc-verified explicitly.
 ///
 /// `model` must already have the `databricks-` prefix stripped.
 fn is_adaptive_thinking_model(model: &str) -> bool {
-    // claude-opus-4-* covers Opus 4.5, 4.6, 4.7, 4.8 and any future Opus 4.x releases.
-    // claude-sonnet-5* covers Sonnet 5.x.
-    // claude-sonnet-4-6 covers Sonnet 4.6 exactly (not Sonnet 4.5 or earlier which
-    // are not in the effort-supported list).
-    model.starts_with("claude-opus-4-")
+    // Exact version strings for Opus 4.x adaptive models (4.6, 4.7, 4.8).
+    // Opus 4.5 is excluded — manual budget only.
+    model.starts_with("claude-opus-4-6")
+        || model.starts_with("claude-opus-4-7")
+        || model.starts_with("claude-opus-4-8")
+        // Sonnet 5.x (any patch/date suffix after "claude-sonnet-5").
         || model.starts_with("claude-sonnet-5")
+        // Sonnet 4.6 exactly (not Sonnet 4.5 or earlier — not in the adaptive table).
         || model.starts_with("claude-sonnet-4-6")
 }
 
@@ -117,11 +207,15 @@ fn is_adaptive_thinking_model(model: &str) -> bool {
 pub fn parse_thinking_effort(raw: Option<&str>) -> Result<Option<ThinkingEffort>, String> {
     match raw.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
         None | Some("") => Ok(None),
+        Some("none") => Ok(Some(ThinkingEffort::None)),
+        Some("minimal") => Ok(Some(ThinkingEffort::Minimal)),
         Some("low") => Ok(Some(ThinkingEffort::Low)),
         Some("medium") => Ok(Some(ThinkingEffort::Medium)),
         Some("high") => Ok(Some(ThinkingEffort::High)),
+        Some("xhigh") => Ok(Some(ThinkingEffort::XHigh)),
+        Some("max") => Ok(Some(ThinkingEffort::Max)),
         Some(other) => Err(format!(
-            "config: BUZZ_AGENT_THINKING_EFFORT={other} not supported (use low|medium|high)"
+            "config: BUZZ_AGENT_THINKING_EFFORT={other} not supported (use none|minimal|low|medium|high|xhigh|max)"
         )),
     }
 }
@@ -419,6 +513,30 @@ impl Config {
                 "config: BUZZ_AGENT_MCP_RESTART_MAX_MS must be >= BUZZ_AGENT_MCP_RESTART_BASE_MS"
                     .into(),
             );
+        }
+        // Provider-level effort validation (fail-fast, clear error).
+        // `none`/`minimal` are not Anthropic values — rejected at startup.
+        // `max` is not an OpenAI value — rejected at startup.
+        // Model-level clamping (e.g. xhigh on Opus 4.6) is dynamic: happens at request
+        // build time because `session/set_model` can change the model after startup.
+        if let Some(effort) = self.thinking_effort {
+            let is_anthropic =
+                matches!(self.provider, Provider::Anthropic | Provider::DatabricksV2);
+            let is_openai = matches!(self.provider, Provider::OpenAi | Provider::Databricks);
+            if is_anthropic && matches!(effort, ThinkingEffort::None | ThinkingEffort::Minimal) {
+                return Err(format!(
+                    "config: BUZZ_AGENT_THINKING_EFFORT={} is not valid for Anthropic providers \
+                     (allowed: low|medium|high|xhigh|max)",
+                    effort.openai_effort_str()
+                ));
+            }
+            if is_openai && matches!(effort, ThinkingEffort::Max) {
+                return Err(
+                    "config: BUZZ_AGENT_THINKING_EFFORT=max is not valid for OpenAI/Databricks \
+                     providers (allowed: none|minimal|low|medium|high|xhigh)"
+                        .into(),
+                );
+            }
         }
         Ok(())
     }
@@ -775,9 +893,13 @@ mod tests {
     #[test]
     fn parse_thinking_effort_round_trips_all_values() {
         for (raw, expected) in [
+            ("none", ThinkingEffort::None),
+            ("minimal", ThinkingEffort::Minimal),
             ("low", ThinkingEffort::Low),
             ("medium", ThinkingEffort::Medium),
             ("high", ThinkingEffort::High),
+            ("xhigh", ThinkingEffort::XHigh),
+            ("max", ThinkingEffort::Max),
         ] {
             assert_eq!(
                 parse_thinking_effort(Some(raw)).unwrap(),
@@ -810,7 +932,10 @@ mod tests {
     fn parse_thinking_effort_rejects_unknown_value() {
         let err = parse_thinking_effort(Some("extreme")).unwrap_err();
         assert!(err.contains("BUZZ_AGENT_THINKING_EFFORT=extreme"), "{err}");
-        assert!(err.contains("low|medium|high"), "{err}");
+        assert!(
+            err.contains("none|minimal|low|medium|high|xhigh|max"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -818,13 +943,46 @@ mod tests {
         assert_eq!(ThinkingEffort::Low.anthropic_budget_tokens(), 1_024);
         assert_eq!(ThinkingEffort::Medium.anthropic_budget_tokens(), 8_192);
         assert_eq!(ThinkingEffort::High.anthropic_budget_tokens(), 32_768);
+        // XHigh and Max clamp to the high budget value for manual-budget models.
+        assert_eq!(ThinkingEffort::XHigh.anthropic_budget_tokens(), 32_768);
+        assert_eq!(ThinkingEffort::Max.anthropic_budget_tokens(), 32_768);
+        // None/Minimal are rejected at startup for Anthropic; defensive zero.
+        assert_eq!(ThinkingEffort::None.anthropic_budget_tokens(), 0);
+        assert_eq!(ThinkingEffort::Minimal.anthropic_budget_tokens(), 0);
     }
 
     #[test]
     fn thinking_effort_openai_effort_str_mapping() {
+        assert_eq!(ThinkingEffort::None.openai_effort_str(), "none");
+        assert_eq!(ThinkingEffort::Minimal.openai_effort_str(), "minimal");
         assert_eq!(ThinkingEffort::Low.openai_effort_str(), "low");
         assert_eq!(ThinkingEffort::Medium.openai_effort_str(), "medium");
         assert_eq!(ThinkingEffort::High.openai_effort_str(), "high");
+        assert_eq!(ThinkingEffort::XHigh.openai_effort_str(), "xhigh");
+        assert_eq!(ThinkingEffort::Max.openai_effort_str(), "max");
+    }
+
+    #[test]
+    fn thinking_effort_anthropic_effort_str_mapping() {
+        assert_eq!(ThinkingEffort::Low.anthropic_effort_str(), "low");
+        assert_eq!(ThinkingEffort::Medium.anthropic_effort_str(), "medium");
+        assert_eq!(ThinkingEffort::High.anthropic_effort_str(), "high");
+        assert_eq!(ThinkingEffort::XHigh.anthropic_effort_str(), "xhigh");
+        assert_eq!(ThinkingEffort::Max.anthropic_effort_str(), "max");
+        // Defensive fallback for invalid Anthropic values (caught at startup validation).
+        assert_eq!(ThinkingEffort::None.anthropic_effort_str(), "low");
+        assert_eq!(ThinkingEffort::Minimal.anthropic_effort_str(), "low");
+    }
+
+    #[test]
+    fn thinking_effort_ord_ordering() {
+        // PartialOrd/Ord must reflect the ordered hierarchy.
+        assert!(ThinkingEffort::None < ThinkingEffort::Minimal);
+        assert!(ThinkingEffort::Minimal < ThinkingEffort::Low);
+        assert!(ThinkingEffort::Low < ThinkingEffort::Medium);
+        assert!(ThinkingEffort::Medium < ThinkingEffort::High);
+        assert!(ThinkingEffort::High < ThinkingEffort::XHigh);
+        assert!(ThinkingEffort::XHigh < ThinkingEffort::Max);
     }
 
     // ---- anthropic_thinking_config helper — per-family tests ----
@@ -897,14 +1055,39 @@ mod tests {
     }
 
     #[test]
+    fn anthropic_thinking_config_opus_4_5_emits_manual_budget() {
+        // Opus 4.5 — manual budget (NOT adaptive; effort page: "uses manual thinking").
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-opus-4-5", ThinkingEffort::High, 65_536);
+        let t = thinking.expect("thinking must be present for claude-opus-4-5");
+        assert_eq!(t["type"], "enabled");
+        assert_eq!(t["budget_tokens"], 32_768); // High budget fits under 65536
+        assert!(
+            output_config.is_none(),
+            "output_config must be absent for claude-opus-4-5 (manual budget)"
+        );
+    }
+
+    #[test]
+    fn anthropic_thinking_config_opus_4_5_budget_capped() {
+        // Opus 4.5 manual budget is capped at max_output_tokens - 1.
+        let (thinking, _) =
+            anthropic_thinking_config("claude-opus-4-5", ThinkingEffort::High, 1024);
+        let t = thinking.unwrap();
+        assert_eq!(t["budget_tokens"], 1023); // capped: min(32768, 1024-1)
+    }
+
+    #[test]
     fn anthropic_thinking_config_unknown_claude_omits_both_fields() {
         // An unknown/future "claude-*" name that is not in the allowlist → omit both fields.
         // This prevents sending an unverified shape to an unrecognized model.
+        // Includes Opus 4.9 (future version), which is NOT in the doc-verified adaptive list.
         for model in &[
             "claude-haiku-4-5",
             "claude-sonnet-4-5",
             "claude-unknown-9-1",
             "claude-future-model",
+            "claude-opus-4-9",
         ] {
             let (thinking, output_config) =
                 anthropic_thinking_config(model, ThinkingEffort::High, 32_768);
@@ -968,5 +1151,317 @@ mod tests {
         let oc =
             output_config.expect("output_config must be present for databricks-claude-opus-4-8");
         assert_eq!(oc["effort"], "medium");
+    }
+
+    // ---- clamp_adaptive_effort — per-model clamping tests ----
+
+    #[test]
+    fn clamp_adaptive_effort_xhigh_passes_through_for_opus_4_7() {
+        // Opus 4.7 supports xhigh — no clamping.
+        assert_eq!(
+            clamp_adaptive_effort("claude-opus-4-7", ThinkingEffort::XHigh),
+            ThinkingEffort::XHigh
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_xhigh_passes_through_for_opus_4_8() {
+        // Opus 4.8 supports xhigh — no clamping.
+        assert_eq!(
+            clamp_adaptive_effort("claude-opus-4-8", ThinkingEffort::XHigh),
+            ThinkingEffort::XHigh
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_xhigh_passes_through_for_sonnet_5() {
+        // Sonnet 5 supports xhigh — no clamping.
+        assert_eq!(
+            clamp_adaptive_effort("claude-sonnet-5-20250901", ThinkingEffort::XHigh),
+            ThinkingEffort::XHigh
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_xhigh_clamped_to_high_for_opus_4_6() {
+        // Opus 4.6 does NOT support xhigh (only low/medium/high/max) — clamp to high.
+        assert_eq!(
+            clamp_adaptive_effort("claude-opus-4-6", ThinkingEffort::XHigh),
+            ThinkingEffort::High
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_xhigh_clamped_to_high_for_sonnet_4_6() {
+        // Sonnet 4.6 does NOT support xhigh — clamp to high.
+        assert_eq!(
+            clamp_adaptive_effort("claude-sonnet-4-6", ThinkingEffort::XHigh),
+            ThinkingEffort::High
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_max_passes_through_for_opus_4_6() {
+        // Opus 4.6 supports max — no clamping.
+        assert_eq!(
+            clamp_adaptive_effort("claude-opus-4-6", ThinkingEffort::Max),
+            ThinkingEffort::Max
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_max_passes_through_for_opus_4_7() {
+        // Opus 4.7 supports max — no clamping.
+        assert_eq!(
+            clamp_adaptive_effort("claude-opus-4-7", ThinkingEffort::Max),
+            ThinkingEffort::Max
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_max_passes_through_for_opus_4_8() {
+        // Opus 4.8 supports max — no clamping.
+        assert_eq!(
+            clamp_adaptive_effort("claude-opus-4-8", ThinkingEffort::Max),
+            ThinkingEffort::Max
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_low_medium_high_never_clamped() {
+        // low/medium/high pass through for all adaptive models.
+        for model in &[
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-sonnet-5-20250901",
+            "claude-sonnet-4-6",
+        ] {
+            for effort in [
+                ThinkingEffort::Low,
+                ThinkingEffort::Medium,
+                ThinkingEffort::High,
+            ] {
+                assert_eq!(
+                    clamp_adaptive_effort(model, effort),
+                    effort,
+                    "model={model} effort={effort:?}"
+                );
+            }
+        }
+    }
+
+    // ---- anthropic_thinking_config — xhigh/max body-shape assertions ----
+
+    #[test]
+    fn anthropic_thinking_config_opus_4_8_xhigh_emits_xhigh_effort() {
+        // Opus 4.8 supports xhigh; output_config.effort must be "xhigh".
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-opus-4-8", ThinkingEffort::XHigh, 32_768);
+        let t = thinking.expect("thinking must be present for claude-opus-4-8");
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.expect("output_config must be present for claude-opus-4-8");
+        assert_eq!(oc["effort"], "xhigh");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_opus_4_8_max_emits_max_effort() {
+        // Opus 4.8 supports max; output_config.effort must be "max".
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-opus-4-8", ThinkingEffort::Max, 32_768);
+        let t = thinking.expect("thinking must be present for claude-opus-4-8");
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.expect("output_config must be present for claude-opus-4-8");
+        assert_eq!(oc["effort"], "max");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_opus_4_7_xhigh_emits_xhigh_effort() {
+        // Opus 4.7 supports xhigh.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-opus-4-7", ThinkingEffort::XHigh, 32_768);
+        let t = thinking.unwrap();
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.unwrap();
+        assert_eq!(oc["effort"], "xhigh");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_opus_4_6_xhigh_clamps_to_high() {
+        // Opus 4.6 does NOT support xhigh → clamp to high.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-opus-4-6", ThinkingEffort::XHigh, 32_768);
+        let t = thinking.unwrap();
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.unwrap();
+        assert_eq!(
+            oc["effort"], "high",
+            "xhigh must clamp to high for claude-opus-4-6"
+        );
+    }
+
+    #[test]
+    fn anthropic_thinking_config_opus_4_6_max_passes_through() {
+        // Opus 4.6 supports max — passes through without clamping.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-opus-4-6", ThinkingEffort::Max, 32_768);
+        let t = thinking.unwrap();
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.unwrap();
+        assert_eq!(oc["effort"], "max");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_manual_bucket_xhigh_clamps_to_high_budget() {
+        // Manual-budget models (claude-3*, opus-4-5): xhigh clamps to high budget (32_768).
+        for model in &["claude-3-7-sonnet-20250219", "claude-opus-4-5"] {
+            let (thinking, output_config) =
+                anthropic_thinking_config(model, ThinkingEffort::XHigh, 65_536);
+            let t = thinking.expect("thinking must be present");
+            assert_eq!(t["type"], "enabled");
+            assert_eq!(
+                t["budget_tokens"], 32_768,
+                "xhigh must clamp to high budget for manual model {model}"
+            );
+            assert!(output_config.is_none());
+        }
+    }
+
+    #[test]
+    fn anthropic_thinking_config_manual_bucket_max_clamps_to_high_budget() {
+        // Manual-budget models: max also clamps to high budget (32_768).
+        let (thinking, _) =
+            anthropic_thinking_config("claude-opus-4-5", ThinkingEffort::Max, 65_536);
+        let t = thinking.unwrap();
+        assert_eq!(t["type"], "enabled");
+        assert_eq!(t["budget_tokens"], 32_768);
+    }
+
+    // ---- provider-level validation tests ----
+
+    /// Build a minimal Config with the given provider and thinking_effort, bypassing from_env().
+    /// Uses `Config::for_discovery` as a base and patches the fields we care about.
+    fn make_config_for_validation(
+        provider: Provider,
+        thinking_effort: Option<ThinkingEffort>,
+    ) -> Config {
+        let mut cfg = Config::for_discovery(provider, "key".into(), "https://example.com".into());
+        cfg.model = "some-model".into();
+        cfg.thinking_effort = thinking_effort;
+        // for_discovery sets max_output_tokens=1 and max_context_tokens=200_001 which satisfies
+        // the context > output constraint. Adjust to something valid for further checks.
+        cfg.max_output_tokens = 1024;
+        cfg.max_context_tokens = 200_000 + 1024;
+        // Restore mandatory positive values that for_discovery zeroes out.
+        cfg.mcp_max_restart_attempts = 1;
+        cfg.mcp_restart_base_ms = 1;
+        cfg.mcp_restart_max_ms = 1;
+        cfg.max_parallel_tools = 1;
+        cfg.llm_timeout = Duration::from_secs(1);
+        cfg.tool_timeout = Duration::from_secs(1);
+        cfg.mcp_init_timeout = Duration::from_secs(1);
+        cfg
+    }
+
+    #[test]
+    fn validate_rejects_none_effort_for_anthropic() {
+        let cfg = make_config_for_validation(Provider::Anthropic, Some(ThinkingEffort::None));
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.contains("BUZZ_AGENT_THINKING_EFFORT=none"),
+            "error must name the value: {err}"
+        );
+        assert!(
+            err.contains("not valid for Anthropic"),
+            "error must name the provider: {err}"
+        );
+        assert!(
+            err.contains("low|medium|high|xhigh|max"),
+            "error must name allowed values: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_minimal_effort_for_anthropic() {
+        let cfg = make_config_for_validation(Provider::Anthropic, Some(ThinkingEffort::Minimal));
+        let err = cfg.validate().unwrap_err();
+        assert!(err.contains("BUZZ_AGENT_THINKING_EFFORT=minimal"), "{err}");
+        assert!(err.contains("not valid for Anthropic"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_none_effort_for_databricks_v2() {
+        // DatabricksV2 routes to Anthropic Messages — same rejection.
+        let cfg = make_config_for_validation(Provider::DatabricksV2, Some(ThinkingEffort::None));
+        let err = cfg.validate().unwrap_err();
+        assert!(err.contains("BUZZ_AGENT_THINKING_EFFORT=none"), "{err}");
+        assert!(err.contains("not valid for Anthropic"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_max_effort_for_openai() {
+        let cfg = make_config_for_validation(Provider::OpenAi, Some(ThinkingEffort::Max));
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.contains("BUZZ_AGENT_THINKING_EFFORT=max"),
+            "error must name the value: {err}"
+        );
+        assert!(
+            err.contains("not valid for OpenAI"),
+            "error must name the provider: {err}"
+        );
+        assert!(
+            err.contains("none|minimal|low|medium|high|xhigh"),
+            "error must name allowed values: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_max_effort_for_databricks() {
+        // Databricks legacy uses OpenAI Chat wire format — same rejection.
+        let cfg = make_config_for_validation(Provider::Databricks, Some(ThinkingEffort::Max));
+        let err = cfg.validate().unwrap_err();
+        assert!(err.contains("BUZZ_AGENT_THINKING_EFFORT=max"), "{err}");
+        assert!(err.contains("not valid for OpenAI/Databricks"), "{err}");
+    }
+
+    #[test]
+    fn validate_accepts_xhigh_for_anthropic() {
+        // xhigh is valid for Anthropic providers — model-level clamping is dynamic.
+        let cfg = make_config_for_validation(Provider::Anthropic, Some(ThinkingEffort::XHigh));
+        assert!(
+            cfg.validate().is_ok(),
+            "xhigh must be accepted at startup for Anthropic"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_max_for_anthropic() {
+        // max is valid for Anthropic providers.
+        let cfg = make_config_for_validation(Provider::Anthropic, Some(ThinkingEffort::Max));
+        assert!(cfg.validate().is_ok(), "max must be accepted for Anthropic");
+    }
+
+    #[test]
+    fn validate_accepts_xhigh_for_openai() {
+        // xhigh is valid for OpenAI providers (server-validated per-model).
+        let cfg = make_config_for_validation(Provider::OpenAi, Some(ThinkingEffort::XHigh));
+        assert!(cfg.validate().is_ok(), "xhigh must be accepted for OpenAI");
+    }
+
+    #[test]
+    fn validate_accepts_none_and_minimal_for_openai() {
+        // none/minimal are valid OpenAI effort values.
+        let cfg_none = make_config_for_validation(Provider::OpenAi, Some(ThinkingEffort::None));
+        assert!(
+            cfg_none.validate().is_ok(),
+            "none must be accepted for OpenAI"
+        );
+        let cfg_minimal =
+            make_config_for_validation(Provider::OpenAi, Some(ThinkingEffort::Minimal));
+        assert!(
+            cfg_minimal.validate().is_ok(),
+            "minimal must be accepted for OpenAI"
+        );
     }
 }

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -42,13 +42,24 @@ impl ThinkingEffort {
 
 /// Build the Anthropic thinking/effort request fields for the given model and effort level.
 ///
-/// API shape selection (per Anthropic SDK and docs):
-/// - Claude 3.x models: `thinking: {type:"enabled", budget_tokens}` (manual budget).
-///   `budget_tokens` is capped at `max_output_tokens - 1` so it is always strictly less
-///   than `max_tokens` as required by the API.
-/// - Claude 4+ and Sonnet-5+ (modern Claude): `output_config: {effort: "low"|"medium"|"high"}`.
-///   These models use the high-level effort abstraction and may not support manual budgets.
-/// - Unrecognized model: neither field is emitted (safe omit; unknown API shape).
+/// API shape selection (per Anthropic docs — https://platform.claude.com/docs/en/build-with-claude/effort
+/// and https://platform.claude.com/docs/en/build-with-claude/extended-thinking):
+///
+/// **Adaptive families** — `thinking: {type:"adaptive"}` + `output_config: {effort}`.
+/// Doc-verified models (effort page, July 2025): Claude Opus 4.8/4.7/4.6, Sonnet 5/4.6, Opus 4.5.
+/// These models require `thinking:{type:"adaptive"}` to enable thinking; without it, requests
+/// run without thinking even when `output_config.effort` is set.
+/// Matched by prefix: `claude-opus-4-`, `claude-sonnet-5`, `claude-sonnet-4-6`.
+///
+/// **Manual-budget families** — `thinking: {type:"enabled", budget_tokens}`.
+/// `budget_tokens` is capped at `max_output_tokens - 1` (required by the API).
+/// Matched by prefix: `claude-3`.
+///
+/// **Everything else** — omit both fields. This includes unknown/future `claude-*` names
+/// that are not yet doc-verified. Safer to omit than to guess an unverified shape.
+///
+/// The Databricks `databricks-` prefix is stripped before matching so that
+/// `databricks-claude-opus-4-7` routes to the adaptive bucket.
 ///
 /// Returns `(thinking_field, output_config_field)` where each is `None` if not applicable.
 pub fn anthropic_thinking_config(
@@ -64,7 +75,7 @@ pub fn anthropic_thinking_config(
         .unwrap_or(effective_model);
 
     if model.starts_with("claude-3") {
-        // Legacy shape: manual budget, must be strictly < max_tokens.
+        // Legacy manual-budget shape: budget_tokens must be strictly < max_tokens.
         let budget = effort
             .anthropic_budget_tokens()
             .min(max_output_tokens.saturating_sub(1));
@@ -72,13 +83,34 @@ pub fn anthropic_thinking_config(
             Some(json!({ "type": "enabled", "budget_tokens": budget })),
             None,
         )
-    } else if model.starts_with("claude-") {
-        // Modern Claude (4+, sonnet-5, etc.): use output_config.effort.
-        (None, Some(json!({ "effort": effort.openai_effort_str() })))
+    } else if is_adaptive_thinking_model(model) {
+        // Adaptive families: thinking must be explicitly enabled via type:"adaptive".
+        // output_config.effort controls the depth. Both fields are required together.
+        (
+            Some(json!({ "type": "adaptive" })),
+            Some(json!({ "effort": effort.openai_effort_str() })),
+        )
     } else {
-        // Unrecognised model name — omit both fields rather than guess.
+        // Unrecognised or unverified model name — omit both fields rather than guess.
+        // This includes unknown future claude-* names not yet in the allowlist.
         (None, None)
     }
+}
+
+/// Returns true for Claude model families that use adaptive thinking (doc-verified, July 2025).
+///
+/// Verified against https://platform.claude.com/docs/en/build-with-claude/effort:
+/// Claude Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6, Opus 4.5.
+///
+/// `model` must already have the `databricks-` prefix stripped.
+fn is_adaptive_thinking_model(model: &str) -> bool {
+    // claude-opus-4-* covers Opus 4.5, 4.6, 4.7, 4.8 and any future Opus 4.x releases.
+    // claude-sonnet-5* covers Sonnet 5.x.
+    // claude-sonnet-4-6 covers Sonnet 4.6 exactly (not Sonnet 4.5 or earlier which
+    // are not in the effort-supported list).
+    model.starts_with("claude-opus-4-")
+        || model.starts_with("claude-sonnet-5")
+        || model.starts_with("claude-sonnet-4-6")
 }
 
 /// Parse `BUZZ_AGENT_THINKING_EFFORT`. Pure (env-free) for testability.
@@ -821,16 +853,85 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_thinking_config_modern_claude_emits_output_config_effort() {
-        // Claude 4+ / sonnet-5+ → `output_config.effort`; no budget_tokens.
+    fn anthropic_thinking_config_opus_4_8_emits_adaptive_and_effort() {
+        // Opus 4.8 — adaptive family. Requires thinking:{type:"adaptive"} to enable thinking.
         let (thinking, output_config) =
-            anthropic_thinking_config("claude-opus-4-5", ThinkingEffort::Medium, 32_768);
+            anthropic_thinking_config("claude-opus-4-8", ThinkingEffort::High, 32_768);
+        let t = thinking.expect("thinking must be present for claude-opus-4-8");
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.expect("output_config must be present for claude-opus-4-8");
+        assert_eq!(oc["effort"], "high");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_opus_4_7_emits_adaptive_and_effort() {
+        // Opus 4.7 — adaptive family.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-opus-4-7", ThinkingEffort::Medium, 32_768);
+        let t = thinking.expect("thinking must be present for claude-opus-4-7");
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.expect("output_config must be present for claude-opus-4-7");
+        assert_eq!(oc["effort"], "medium");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_sonnet_5_emits_adaptive_and_effort() {
+        // Sonnet 5 — adaptive family.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-sonnet-5-20250901", ThinkingEffort::Low, 32_768);
+        let t = thinking.expect("thinking must be present for claude-sonnet-5");
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.expect("output_config must be present for claude-sonnet-5");
+        assert_eq!(oc["effort"], "low");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_sonnet_4_6_emits_adaptive_and_effort() {
+        // Sonnet 4.6 — adaptive family. Docs explicitly list "Combine effort with adaptive thinking."
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-sonnet-4-6", ThinkingEffort::High, 32_768);
+        let t = thinking.expect("thinking must be present for claude-sonnet-4-6");
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.expect("output_config must be present for claude-sonnet-4-6");
+        assert_eq!(oc["effort"], "high");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_unknown_claude_omits_both_fields() {
+        // An unknown/future "claude-*" name that is not in the allowlist → omit both fields.
+        // This prevents sending an unverified shape to an unrecognized model.
+        for model in &[
+            "claude-haiku-4-5",
+            "claude-sonnet-4-5",
+            "claude-unknown-9-1",
+            "claude-future-model",
+        ] {
+            let (thinking, output_config) =
+                anthropic_thinking_config(model, ThinkingEffort::High, 32_768);
+            assert!(
+                thinking.is_none(),
+                "thinking must be absent for unverified claude model: {model}"
+            );
+            assert!(
+                output_config.is_none(),
+                "output_config must be absent for unverified claude model: {model}"
+            );
+        }
+    }
+
+    #[test]
+    fn anthropic_thinking_config_non_claude_omits_both_fields() {
+        // Non-Anthropic model names (gpt-5, llama, etc.) → omit both fields.
+        let (thinking, output_config) =
+            anthropic_thinking_config("gpt-4o-mini", ThinkingEffort::High, 32_768);
         assert!(
             thinking.is_none(),
-            "thinking must be absent for modern claude"
+            "thinking must be absent for non-claude model"
         );
-        let oc = output_config.expect("output_config must be present for modern claude");
-        assert_eq!(oc["effort"], "medium");
+        assert!(
+            output_config.is_none(),
+            "output_config must be absent for non-claude model"
+        );
     }
 
     #[test]
@@ -844,27 +945,28 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_thinking_config_databricks_prefix_stripped_for_modern_claude() {
-        // Databricks gateway prefix stripping applies to modern Claude too.
+    fn anthropic_thinking_config_databricks_prefix_stripped_for_opus_4_7() {
+        // Databricks gateway prefix stripping applies to adaptive Claude families too.
         let (thinking, output_config) =
             anthropic_thinking_config("databricks-claude-opus-4-7", ThinkingEffort::High, 32_768);
-        assert!(thinking.is_none());
-        let oc = output_config.expect("output_config must be present for databricks-claude-opus-4");
+        let t = thinking
+            .expect("thinking:{type:adaptive} must be present for databricks-claude-opus-4-7");
+        assert_eq!(t["type"], "adaptive");
+        let oc =
+            output_config.expect("output_config must be present for databricks-claude-opus-4-7");
         assert_eq!(oc["effort"], "high");
     }
 
     #[test]
-    fn anthropic_thinking_config_unrecognized_model_omits_both_fields() {
-        // Non-Anthropic model names (gpt-5, llama, etc.) → omit both fields.
+    fn anthropic_thinking_config_databricks_prefix_stripped_for_opus_4_8() {
+        // Databricks gateway prefix stripping applies to Opus 4.8 too.
         let (thinking, output_config) =
-            anthropic_thinking_config("gpt-4o-mini", ThinkingEffort::High, 32_768);
-        assert!(
-            thinking.is_none(),
-            "thinking must be absent for non-claude model"
-        );
-        assert!(
-            output_config.is_none(),
-            "output_config must be absent for non-claude model"
-        );
+            anthropic_thinking_config("databricks-claude-opus-4-8", ThinkingEffort::Medium, 32_768);
+        let t = thinking
+            .expect("thinking:{type:adaptive} must be present for databricks-claude-opus-4-8");
+        assert_eq!(t["type"], "adaptive");
+        let oc =
+            output_config.expect("output_config must be present for databricks-claude-opus-4-8");
+        assert_eq!(oc["effort"], "medium");
     }
 }

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -245,13 +245,12 @@ fn openai_efforts_for_model(model: &str) -> Option<&'static [ThinkingEffort]> {
         || lower.contains("gpt5.5")
         || lower.contains("gpt-5-5")
         || lower.contains("gpt5-5")
-    {
-        Some(GPT5_5_AND_5_4)
-    } else if lower.contains("gpt-5.4")
+        || lower.contains("gpt-5.4")
         || lower.contains("gpt5.4")
         || lower.contains("gpt-5-4")
         || lower.contains("gpt5-4")
     {
+        // gpt-5.5 and gpt-5.4 share the same effort availability table.
         Some(GPT5_5_AND_5_4)
     } else if lower.contains("gpt-5.1")
         || lower.contains("gpt5.1")
@@ -300,7 +299,7 @@ fn resolve_openai_effort(
             _ => None,
         };
         // All supported values sorted by distance (abs diff in ordinal), upward ties win.
-        let mut by_dist: Vec<ThinkingEffort> = supported.iter().copied().collect();
+        let mut by_dist: Vec<ThinkingEffort> = supported.to_vec();
         by_dist.sort_by_key(|&e| {
             let dist = (e as i32 - requested as i32).unsigned_abs();
             // Prefer upward (e > requested) to break ties between equidistant values.

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -134,8 +134,9 @@ pub fn anthropic_thinking_config(
 /// Clamp the requested effort level to the highest doc-verified level for the given adaptive model.
 ///
 /// Doc-verified availability (Anthropic effort page, July 2025):
-/// - `max`: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5.x, Sonnet 4.6
-/// - `xhigh`: Opus 4.8, Opus 4.7, Sonnet 5.x only (NOT Opus 4.6, NOT Sonnet 4.6)
+/// - `max`: Opus 4.8, 4.7, 4.6; Sonnet 5.x, 4.6; Fable 5; Mythos 5; Mythos Preview
+/// - `xhigh`: Opus 4.8, 4.7; Sonnet 5.x; Fable 5; Mythos 5
+///   (NOT Opus 4.6, Sonnet 4.6, or Mythos Preview)
 /// - `low|medium|high`: all adaptive families
 ///
 /// If the requested level is not available for the model, clamps down to the highest
@@ -147,9 +148,11 @@ pub fn clamp_adaptive_effort(model: &str, effort: ThinkingEffort) -> ThinkingEff
     // Models that support all levels including xhigh (and max).
     let supports_xhigh = model.starts_with("claude-opus-4-7")
         || model.starts_with("claude-opus-4-8")
-        || model.starts_with("claude-sonnet-5");
-    // Models that support max but NOT xhigh (Opus 4.6, Sonnet 4.6).
-    // All adaptive models support low/medium/high.
+        || model.starts_with("claude-sonnet-5")
+        || model.starts_with("claude-fable-5")
+        || model.starts_with("claude-mythos-5");
+    // NOTE: claude-mythos-preview does NOT support xhigh (xhigh → clamp to high).
+    // All adaptive models support low/medium/high and max.
 
     let clamped = if supports_xhigh {
         effort // all levels pass through
@@ -157,7 +160,7 @@ pub fn clamp_adaptive_effort(model: &str, effort: ThinkingEffort) -> ThinkingEff
         // xhigh not available for this model; clamp to high (the highest supported below xhigh).
         ThinkingEffort::High
     } else {
-        effort // low/medium/high/max all pass through for Opus 4.6 / Sonnet 4.6
+        effort // low/medium/high/max all pass through for the other adaptive families
     };
 
     if clamped != effort {
@@ -169,6 +172,57 @@ pub fn clamp_adaptive_effort(model: &str, effort: ThinkingEffort) -> ThinkingEff
         );
     }
     clamped
+}
+
+/// Normalize the effort value for an OpenAI-shaped request body (Chat Completions or Responses).
+///
+/// OpenAI-shaped bodies (`openai_body`, `responses_body`) accept `none|minimal|low|medium|high|xhigh`
+/// but NOT `max` — `max` is not a valid OpenAI reasoning effort value.
+///
+/// This function is the single source of truth for the `max` → `xhigh` clamp on OpenAI paths.
+/// It is called at request-build time (not startup) because `session/set_model` on a
+/// `DatabricksV2` session can switch between Claude and GPT routes mid-session; startup
+/// validation cannot guarantee the value is safe for the current route.
+///
+/// Returns `None` if `effort` should not be included in the request (not currently possible
+/// on OpenAI paths — all non-`None` inputs produce a value — but included for symmetry
+/// with `normalize_effort_for_anthropic_route`).
+pub fn normalize_effort_for_openai_route(effort: ThinkingEffort) -> ThinkingEffort {
+    if effort == ThinkingEffort::Max {
+        tracing::warn!(
+            requested = "max",
+            clamped = "xhigh",
+            "BUZZ_AGENT_THINKING_EFFORT=max is not valid for OpenAI-shaped requests; clamping to xhigh"
+        );
+        ThinkingEffort::XHigh
+    } else {
+        effort
+    }
+}
+
+/// Normalize the effort value for an Anthropic-shaped request body (Messages API).
+///
+/// Anthropic-shaped bodies (`anthropic_body`) do not have a `none` or `minimal` concept —
+/// the thinking block is either present (with a level) or absent. When `none` or `minimal`
+/// is configured, we omit the thinking fields entirely and log a warning (omission = provider
+/// default = no thinking). This handles `DatabricksV2` sessions where the route can switch
+/// from GPT to Claude via `session/set_model` after startup.
+///
+/// Returns `None` to signal "omit thinking fields", or the original effort if it is a valid
+/// Anthropic level.
+pub fn normalize_effort_for_anthropic_route(effort: ThinkingEffort) -> Option<ThinkingEffort> {
+    match effort {
+        ThinkingEffort::None | ThinkingEffort::Minimal => {
+            tracing::warn!(
+                requested = effort.openai_effort_str(),
+                "BUZZ_AGENT_THINKING_EFFORT={} is not expressible as an Anthropic thinking level; \
+                 omitting thinking fields (provider default = no thinking)",
+                effort.openai_effort_str()
+            );
+            None
+        }
+        other => Some(other),
+    }
 }
 
 /// Returns true for Claude model families that use manual thinking budgets (doc-verified, July 2025).
@@ -185,8 +239,13 @@ fn is_manual_budget_model(model: &str) -> bool {
 
 /// Returns true for Claude model families that use adaptive thinking (doc-verified, July 2025).
 ///
-/// Source: https://platform.claude.com/docs/en/build-with-claude/extended-thinking (support table)
-/// Adaptive thinking models: Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5.x, Sonnet 4.6.
+/// Sources: https://platform.claude.com/docs/en/build-with-claude/extended-thinking (support table)
+///          https://platform.claude.com/docs/en/build-with-claude/effort (effort page)
+///
+/// Adaptive thinking models (always-on or default-on):
+///   Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5.x, Sonnet 4.6,
+///   Fable 5 (always-on), Mythos 5 (always-on), Mythos Preview (default-on).
+///
 /// Note: Opus 4.5 is NOT in this bucket — it uses manual budget (see `is_manual_budget_model`).
 /// No prefix wildcards over version numbers; each entry is doc-verified explicitly.
 ///
@@ -201,6 +260,12 @@ fn is_adaptive_thinking_model(model: &str) -> bool {
         || model.starts_with("claude-sonnet-5")
         // Sonnet 4.6 exactly (not Sonnet 4.5 or earlier — not in the adaptive table).
         || model.starts_with("claude-sonnet-4-6")
+        // Fable 5 and Mythos 5 (always-on adaptive thinking, July 2025).
+        || model.starts_with("claude-fable-5")
+        || model.starts_with("claude-mythos-5")
+        // Mythos Preview (default-on adaptive thinking, July 2025).
+        // Note: xhigh is NOT available on Mythos Preview — clamp_adaptive_effort handles this.
+        || model.starts_with("claude-mythos-preview")
 }
 
 /// Parse `BUZZ_AGENT_THINKING_EFFORT`. Pure (env-free) for testability.
@@ -519,18 +584,25 @@ impl Config {
         // `max` is not an OpenAI value — rejected at startup.
         // Model-level clamping (e.g. xhigh on Opus 4.6) is dynamic: happens at request
         // build time because `session/set_model` can change the model after startup.
+        //
+        // DatabricksV2 is intentionally EXCLUDED from startup validation: it dispatches
+        // across Anthropic Messages, OpenAI Responses, and MLflow Chat routes at request
+        // build time based on the effective model. No single effort value is invalid for
+        // all three routes, so provider-wide startup rejection is wrong. Route-aware effort
+        // normalization is applied instead via `normalize_effort_for_openai_route` /
+        // `normalize_effort_for_anthropic_route` at request build time in `llm.rs`.
         if let Some(effort) = self.thinking_effort {
-            let is_anthropic =
-                matches!(self.provider, Provider::Anthropic | Provider::DatabricksV2);
-            let is_openai = matches!(self.provider, Provider::OpenAi | Provider::Databricks);
-            if is_anthropic && matches!(effort, ThinkingEffort::None | ThinkingEffort::Minimal) {
+            let is_pure_anthropic = matches!(self.provider, Provider::Anthropic);
+            let is_pure_openai = matches!(self.provider, Provider::OpenAi | Provider::Databricks);
+            if is_pure_anthropic && matches!(effort, ThinkingEffort::None | ThinkingEffort::Minimal)
+            {
                 return Err(format!(
                     "config: BUZZ_AGENT_THINKING_EFFORT={} is not valid for Anthropic providers \
                      (allowed: low|medium|high|xhigh|max)",
                     effort.openai_effort_str()
                 ));
             }
-            if is_openai && matches!(effort, ThinkingEffort::Max) {
+            if is_pure_openai && matches!(effort, ThinkingEffort::Max) {
                 return Err(
                     "config: BUZZ_AGENT_THINKING_EFFORT=max is not valid for OpenAI/Databricks \
                      providers (allowed: none|minimal|low|medium|high|xhigh)"
@@ -1390,12 +1462,24 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_none_effort_for_databricks_v2() {
-        // DatabricksV2 routes to Anthropic Messages — same rejection.
-        let cfg = make_config_for_validation(Provider::DatabricksV2, Some(ThinkingEffort::None));
-        let err = cfg.validate().unwrap_err();
-        assert!(err.contains("BUZZ_AGENT_THINKING_EFFORT=none"), "{err}");
-        assert!(err.contains("not valid for Anthropic"), "{err}");
+    fn validate_accepts_all_efforts_for_databricks_v2() {
+        // DatabricksV2 dispatches across Anthropic/OpenAI/MLflow routes at request build time.
+        // No effort value is invalid for all three routes — startup rejects none.
+        for effort in [
+            ThinkingEffort::None,
+            ThinkingEffort::Minimal,
+            ThinkingEffort::Low,
+            ThinkingEffort::Medium,
+            ThinkingEffort::High,
+            ThinkingEffort::XHigh,
+            ThinkingEffort::Max,
+        ] {
+            let cfg = make_config_for_validation(Provider::DatabricksV2, Some(effort));
+            assert!(
+                cfg.validate().is_ok(),
+                "DatabricksV2 must accept {effort:?} at startup (route-aware normalization at request build)"
+            );
+        }
     }
 
     #[test]
@@ -1463,5 +1547,209 @@ mod tests {
             cfg_minimal.validate().is_ok(),
             "minimal must be accepted for OpenAI"
         );
+    }
+
+    // ---- normalize_effort_for_openai_route ----
+
+    #[test]
+    fn normalize_openai_route_clamps_max_to_xhigh() {
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::Max),
+            ThinkingEffort::XHigh
+        );
+    }
+
+    #[test]
+    fn normalize_openai_route_passes_through_all_other_values() {
+        for effort in [
+            ThinkingEffort::None,
+            ThinkingEffort::Minimal,
+            ThinkingEffort::Low,
+            ThinkingEffort::Medium,
+            ThinkingEffort::High,
+            ThinkingEffort::XHigh,
+        ] {
+            assert_eq!(
+                normalize_effort_for_openai_route(effort),
+                effort,
+                "normalize_effort_for_openai_route must pass through {effort:?}"
+            );
+        }
+    }
+
+    // ---- normalize_effort_for_anthropic_route ----
+
+    #[test]
+    fn normalize_anthropic_route_none_yields_none() {
+        assert_eq!(
+            normalize_effort_for_anthropic_route(ThinkingEffort::None),
+            None,
+            "none must yield None (omit thinking fields)"
+        );
+    }
+
+    #[test]
+    fn normalize_anthropic_route_minimal_yields_none() {
+        assert_eq!(
+            normalize_effort_for_anthropic_route(ThinkingEffort::Minimal),
+            None,
+            "minimal must yield None (omit thinking fields)"
+        );
+    }
+
+    #[test]
+    fn normalize_anthropic_route_passes_through_valid_values() {
+        for effort in [
+            ThinkingEffort::Low,
+            ThinkingEffort::Medium,
+            ThinkingEffort::High,
+            ThinkingEffort::XHigh,
+            ThinkingEffort::Max,
+        ] {
+            assert_eq!(
+                normalize_effort_for_anthropic_route(effort),
+                Some(effort),
+                "normalize_effort_for_anthropic_route must pass through {effort:?}"
+            );
+        }
+    }
+
+    // ---- F2: Fable 5 / Mythos 5 / Mythos Preview adaptive thinking ----
+
+    #[test]
+    fn anthropic_thinking_config_fable_5_emits_adaptive_and_effort() {
+        // Fable 5 — always-on adaptive thinking.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-fable-5", ThinkingEffort::High, 32_768);
+        let t = thinking.expect("thinking must be present for claude-fable-5");
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.expect("output_config must be present for claude-fable-5");
+        assert_eq!(oc["effort"], "high");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_mythos_5_emits_adaptive_and_effort() {
+        // Mythos 5 — always-on adaptive thinking.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-mythos-5", ThinkingEffort::Medium, 32_768);
+        let t = thinking.expect("thinking must be present for claude-mythos-5");
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.expect("output_config must be present for claude-mythos-5");
+        assert_eq!(oc["effort"], "medium");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_mythos_preview_emits_adaptive_and_effort() {
+        // Mythos Preview — default-on adaptive thinking.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-mythos-preview", ThinkingEffort::Low, 32_768);
+        let t = thinking.expect("thinking must be present for claude-mythos-preview");
+        assert_eq!(t["type"], "adaptive");
+        let oc = output_config.expect("output_config must be present for claude-mythos-preview");
+        assert_eq!(oc["effort"], "low");
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_xhigh_passes_through_for_fable_5() {
+        // Fable 5 supports xhigh.
+        assert_eq!(
+            clamp_adaptive_effort("claude-fable-5", ThinkingEffort::XHigh),
+            ThinkingEffort::XHigh
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_xhigh_passes_through_for_mythos_5() {
+        // Mythos 5 supports xhigh.
+        assert_eq!(
+            clamp_adaptive_effort("claude-mythos-5", ThinkingEffort::XHigh),
+            ThinkingEffort::XHigh
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_xhigh_clamped_to_high_for_mythos_preview() {
+        // Mythos Preview does NOT support xhigh — clamp to high.
+        assert_eq!(
+            clamp_adaptive_effort("claude-mythos-preview", ThinkingEffort::XHigh),
+            ThinkingEffort::High
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_max_passes_through_for_fable_5() {
+        // Fable 5 supports max.
+        assert_eq!(
+            clamp_adaptive_effort("claude-fable-5", ThinkingEffort::Max),
+            ThinkingEffort::Max
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_max_passes_through_for_mythos_5() {
+        // Mythos 5 supports max.
+        assert_eq!(
+            clamp_adaptive_effort("claude-mythos-5", ThinkingEffort::Max),
+            ThinkingEffort::Max
+        );
+    }
+
+    #[test]
+    fn clamp_adaptive_effort_max_passes_through_for_mythos_preview() {
+        // Mythos Preview supports max.
+        assert_eq!(
+            clamp_adaptive_effort("claude-mythos-preview", ThinkingEffort::Max),
+            ThinkingEffort::Max
+        );
+    }
+
+    #[test]
+    fn anthropic_thinking_config_fable_5_xhigh_emits_xhigh() {
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-fable-5", ThinkingEffort::XHigh, 32_768);
+        let t = thinking.unwrap();
+        assert_eq!(t["type"], "adaptive");
+        assert_eq!(output_config.unwrap()["effort"], "xhigh");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_mythos_5_xhigh_emits_xhigh() {
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-mythos-5", ThinkingEffort::XHigh, 32_768);
+        let t = thinking.unwrap();
+        assert_eq!(t["type"], "adaptive");
+        assert_eq!(output_config.unwrap()["effort"], "xhigh");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_mythos_preview_xhigh_clamps_to_high() {
+        // Mythos Preview does NOT support xhigh → clamp to high.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-mythos-preview", ThinkingEffort::XHigh, 32_768);
+        let t = thinking.unwrap();
+        assert_eq!(t["type"], "adaptive");
+        assert_eq!(
+            output_config.unwrap()["effort"],
+            "high",
+            "xhigh must clamp to high for claude-mythos-preview"
+        );
+    }
+
+    #[test]
+    fn anthropic_thinking_config_fable_5_max_passes_through() {
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-fable-5", ThinkingEffort::Max, 32_768);
+        let t = thinking.unwrap();
+        assert_eq!(t["type"], "adaptive");
+        assert_eq!(output_config.unwrap()["effort"], "max");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_mythos_preview_max_passes_through() {
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-mythos-preview", ThinkingEffort::Max, 32_768);
+        let t = thinking.unwrap();
+        assert_eq!(t["type"], "adaptive");
+        assert_eq!(output_config.unwrap()["effort"], "max");
     }
 }

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -205,8 +205,8 @@ pub fn normalize_effort_for_openai_route(effort: ThinkingEffort) -> ThinkingEffo
 /// Anthropic-shaped bodies (`anthropic_body`) do not have a `none` or `minimal` concept —
 /// the thinking block is either present (with a level) or absent. When `none` or `minimal`
 /// is configured, we omit the thinking fields entirely and log a warning (omission = provider
-/// default = no thinking). This handles `DatabricksV2` sessions where the route can switch
-/// from GPT to Claude via `session/set_model` after startup.
+/// default; default-on/always-on adaptive models may still think). This handles `DatabricksV2`
+/// sessions where the route can switch from GPT to Claude via `session/set_model` after startup.
 ///
 /// Returns `None` to signal "omit thinking fields", or the original effort if it is a valid
 /// Anthropic level.
@@ -216,7 +216,7 @@ pub fn normalize_effort_for_anthropic_route(effort: ThinkingEffort) -> Option<Th
             tracing::warn!(
                 requested = effort.openai_effort_str(),
                 "BUZZ_AGENT_THINKING_EFFORT={} is not expressible as an Anthropic thinking level; \
-                 omitting thinking fields (provider default = no thinking)",
+                 omitting thinking fields (provider default; default-on/always-on adaptive models may still think)",
                 effort.openai_effort_str()
             );
             None

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -2,6 +2,57 @@ use std::time::Duration;
 
 pub const PROTOCOL_VERSION: u32 = 2;
 
+/// Reasoning/thinking effort level for providers that support it.
+///
+/// Set via `BUZZ_AGENT_THINKING_EFFORT` (`low|medium|high`).
+/// When unset the provider's default behaviour is preserved — no thinking
+/// config is sent in the request body.
+///
+/// Mapping to provider wire fields:
+/// - Anthropic Messages: `thinking.budget_tokens` — low=1024, medium=8192, high=32768.
+/// - OpenAI Responses: `reasoning.effort` — "low", "medium", "high".
+/// - OpenAI Chat Completions: `reasoning_effort` — "low", "medium", "high".
+/// - Databricks: routed by model family (Claude → Anthropic mapping, GPT-5 → Responses, MLflow → Chat).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThinkingEffort {
+    Low,
+    Medium,
+    High,
+}
+
+impl ThinkingEffort {
+    /// Map level to an Anthropic `budget_tokens` value.
+    pub fn anthropic_budget_tokens(self) -> u32 {
+        match self {
+            ThinkingEffort::Low => 1_024,
+            ThinkingEffort::Medium => 8_192,
+            ThinkingEffort::High => 32_768,
+        }
+    }
+
+    /// Map level to an OpenAI `reasoning.effort` / `reasoning_effort` string.
+    pub fn openai_effort_str(self) -> &'static str {
+        match self {
+            ThinkingEffort::Low => "low",
+            ThinkingEffort::Medium => "medium",
+            ThinkingEffort::High => "high",
+        }
+    }
+}
+
+/// Parse `BUZZ_AGENT_THINKING_EFFORT`. Pure (env-free) for testability.
+pub fn parse_thinking_effort(raw: Option<&str>) -> Result<Option<ThinkingEffort>, String> {
+    match raw.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+        None | Some("") => Ok(None),
+        Some("low") => Ok(Some(ThinkingEffort::Low)),
+        Some("medium") => Ok(Some(ThinkingEffort::Medium)),
+        Some("high") => Ok(Some(ThinkingEffort::High)),
+        Some(other) => Err(format!(
+            "config: BUZZ_AGENT_THINKING_EFFORT={other} not supported (use low|medium|high)"
+        )),
+    }
+}
+
 pub const MAX_PROMPT_BYTES: usize = 1024 * 1024;
 pub const MAX_SYSTEM_PROMPT_BYTES: usize = 512 * 1024;
 /// Total per-result byte ceiling (text + images). Sized for image-bearing
@@ -94,6 +145,9 @@ pub struct Config {
     /// OpenAI endpoint selection. See [`OpenAiApi`].
     pub openai_api: OpenAiApi,
     pub hints_enabled: bool,
+    /// Thinking/reasoning effort level. `None` = use provider default (no
+    /// thinking config sent). Set via `BUZZ_AGENT_THINKING_EFFORT`.
+    pub thinking_effort: Option<ThinkingEffort>,
 }
 
 impl Config {
@@ -187,6 +241,7 @@ impl Config {
             stop_max_rejections: parse_env("BUZZ_AGENT_STOP_MAX_REJECTIONS", 3u32)?,
             hook_servers: parse_hook_servers_env("MCP_HOOK_SERVERS"),
             hints_enabled: parse_env("BUZZ_AGENT_NO_HINTS", 0u8)? == 0,
+            thinking_effort: parse_thinking_effort(env("BUZZ_AGENT_THINKING_EFFORT").as_deref())?,
         };
         cfg.validate()?;
         Ok(cfg)
@@ -226,6 +281,7 @@ impl Config {
             stop_max_rejections: 0,
             hook_servers: HookServers::None,
             hints_enabled: false,
+            thinking_effort: None,
         }
     }
 
@@ -641,5 +697,60 @@ mod tests {
     fn resolve_model_returns_none_when_both_absent() {
         let result = resolve_model(None, None);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_thinking_effort_round_trips_all_values() {
+        for (raw, expected) in [
+            ("low", ThinkingEffort::Low),
+            ("medium", ThinkingEffort::Medium),
+            ("high", ThinkingEffort::High),
+        ] {
+            assert_eq!(
+                parse_thinking_effort(Some(raw)).unwrap(),
+                Some(expected),
+                "raw={raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_thinking_effort_none_and_empty_yield_none() {
+        assert_eq!(parse_thinking_effort(None).unwrap(), None);
+        assert_eq!(parse_thinking_effort(Some("")).unwrap(), None);
+        assert_eq!(parse_thinking_effort(Some("   ")).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_thinking_effort_is_case_insensitive() {
+        assert_eq!(
+            parse_thinking_effort(Some("HIGH")).unwrap(),
+            Some(ThinkingEffort::High)
+        );
+        assert_eq!(
+            parse_thinking_effort(Some("  Medium  ")).unwrap(),
+            Some(ThinkingEffort::Medium)
+        );
+    }
+
+    #[test]
+    fn parse_thinking_effort_rejects_unknown_value() {
+        let err = parse_thinking_effort(Some("extreme")).unwrap_err();
+        assert!(err.contains("BUZZ_AGENT_THINKING_EFFORT=extreme"), "{err}");
+        assert!(err.contains("low|medium|high"), "{err}");
+    }
+
+    #[test]
+    fn thinking_effort_anthropic_budget_tokens_mapping() {
+        assert_eq!(ThinkingEffort::Low.anthropic_budget_tokens(), 1_024);
+        assert_eq!(ThinkingEffort::Medium.anthropic_budget_tokens(), 8_192);
+        assert_eq!(ThinkingEffort::High.anthropic_budget_tokens(), 32_768);
+    }
+
+    #[test]
+    fn thinking_effort_openai_effort_str_mapping() {
+        assert_eq!(ThinkingEffort::Low.openai_effort_str(), "low");
+        assert_eq!(ThinkingEffort::Medium.openai_effort_str(), "medium");
+        assert_eq!(ThinkingEffort::High.openai_effort_str(), "high");
     }
 }

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -28,7 +28,7 @@ pub enum ThinkingEffort {
 
 impl ThinkingEffort {
     /// Map level to an Anthropic `budget_tokens` value for legacy Claude 3.x / Opus 4.5 models.
-    /// `XHigh` and `Max` clamp to the high budget value; the API cap at `max_output_tokens-1`
+    /// `XHigh` and `Max` clamp to the high budget value; the answer-room reserve of 1024 tokens
     /// is applied separately in `anthropic_thinking_config`.
     pub fn anthropic_budget_tokens(self) -> u32 {
         match self {
@@ -191,6 +191,76 @@ pub fn clamp_adaptive_effort(model: &str, effort: ThinkingEffort) -> ThinkingEff
     clamped
 }
 
+/// Returns true if `lower_model` contains `token` as a bounded family segment — i.e., the
+/// token is immediately followed by end-of-string or a `-` separator (not a digit or letter).
+///
+/// This prevents:
+/// - `gpt-5.1` from matching `gpt-5.10` (digit follows the `1`)
+/// - `gpt-5-1` from matching `gpt-5-1106` (digit follows the `1`)
+/// - `gpt-5-4` from matching `gpt-5-4o` (letter follows the `4`)
+///
+/// Gateway prefixes (`databricks-`) and date/build suffixes (`-2025-04-01`) are allowed
+/// because they start with `-` which is the only permitted boundary character.
+fn gpt5_token_matches(lower_model: &str, token: &str) -> bool {
+    let mut start = 0;
+    while let Some(pos) = lower_model[start..].find(token) {
+        let abs = start + pos;
+        let after = abs + token.len();
+        // The character immediately after the token must be end-of-string or '-'.
+        // Any alphanumeric character (digit OR letter) means this is a longer token, not
+        // the family we're looking for.
+        let safe_suffix = lower_model[after..].chars().next().is_none_or(|c| c == '-');
+        if safe_suffix {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
+/// Like `gpt5_token_matches` but additionally rejects short purely-numeric suffixes — used
+/// for the base `gpt-5` / `gpt5` token to avoid false-matching unrecognized version segments.
+///
+/// After a `-` separator:
+/// - `-<non-digit>…` e.g. `-pro` → **accepted** (capability suffix, no digits)
+/// - `-<digits><non-digit>…` e.g. `-4o`, `-1106-preview` → **accepted** (digit+variant)
+/// - `-<1-3 digits><end-of-string>` e.g. `-10`, `-5` → **rejected** (bare version number)
+/// - `-<4+ digits><end-of-string>` e.g. `-1106`, `-0514` → **accepted** (date segment)
+fn gpt5_base_matches(lower_model: &str, token: &str) -> bool {
+    let mut start = 0;
+    while let Some(pos) = lower_model[start..].find(token) {
+        let abs = start + pos;
+        let after = abs + token.len();
+        let rest = &lower_model[after..];
+        let safe_suffix = if rest.is_empty() {
+            // End of string — clean boundary.
+            true
+        } else if let Some(tail) = rest.strip_prefix('-') {
+            // Count leading digits in the suffix component.
+            let digit_run: usize = tail.chars().take_while(|c| c.is_ascii_digit()).count();
+            if digit_run == 0 {
+                // No leading digit (e.g. '-pro'): capability suffix → accepted.
+                true
+            } else if !tail[digit_run..].is_empty() {
+                // Digit run followed by non-digit (e.g. '-4o', '-1106-preview'): variant → accepted.
+                true
+            } else {
+                // Pure digit run (nothing after digits). Accept only if it looks like a date
+                // (4+ digits). Short pure-number suffixes (1–3 digits) are version-like → rejected.
+                digit_run >= 4
+            }
+        } else {
+            // Dot, letter, or other non-hyphen character directly after token → not base.
+            false
+        };
+        if safe_suffix {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
 /// Returns the set of `reasoning.effort` values supported by a given OpenAI model family.
 ///
 /// Doc-verified availability (OpenAI model pages, July 2025):
@@ -213,6 +283,9 @@ pub fn clamp_adaptive_effort(model: &str, effort: ThinkingEffort) -> ThinkingEff
 ///
 /// `model` is a raw model name (may include Databricks gateway prefixes or date suffixes).
 /// Unknown models return `None` — caller treats `None` as "server-validated pass-through".
+/// Versioned tokens use `gpt5_token_matches` (end-of-string or `-` boundary, blocking digit
+/// and letter continuations). The base token uses `gpt5_base_matches`, which additionally
+/// rejects short `-<1-3 digit>` suffixes that look like two-digit version numbers.
 fn openai_efforts_for_model(model: &str) -> Option<&'static [ThinkingEffort]> {
     // Effort ordered from lowest to highest for each family.
     const GPT5_PRO: &[ThinkingEffort] = &[ThinkingEffort::High];
@@ -239,26 +312,26 @@ fn openai_efforts_for_model(model: &str) -> Option<&'static [ThinkingEffort]> {
     let lower = model.to_ascii_lowercase();
     // Check gpt-5-pro before gpt-5.5 / gpt-5.4 etc. to avoid the `-pro` name
     // matching the base "gpt-5" prefix first.
-    if lower.contains("gpt-5-pro") || lower.contains("gpt5-pro") {
+    if gpt5_token_matches(&lower, "gpt-5-pro") || gpt5_token_matches(&lower, "gpt5-pro") {
         Some(GPT5_PRO)
-    } else if lower.contains("gpt-5.5")
-        || lower.contains("gpt5.5")
-        || lower.contains("gpt-5-5")
-        || lower.contains("gpt5-5")
-        || lower.contains("gpt-5.4")
-        || lower.contains("gpt5.4")
-        || lower.contains("gpt-5-4")
-        || lower.contains("gpt5-4")
+    } else if gpt5_token_matches(&lower, "gpt-5.5")
+        || gpt5_token_matches(&lower, "gpt5.5")
+        || gpt5_token_matches(&lower, "gpt-5-5")
+        || gpt5_token_matches(&lower, "gpt5-5")
+        || gpt5_token_matches(&lower, "gpt-5.4")
+        || gpt5_token_matches(&lower, "gpt5.4")
+        || gpt5_token_matches(&lower, "gpt-5-4")
+        || gpt5_token_matches(&lower, "gpt5-4")
     {
         // gpt-5.5 and gpt-5.4 share the same effort availability table.
         Some(GPT5_5_AND_5_4)
-    } else if lower.contains("gpt-5.1")
-        || lower.contains("gpt5.1")
-        || lower.contains("gpt-5-1")
-        || lower.contains("gpt5-1")
+    } else if gpt5_token_matches(&lower, "gpt-5.1")
+        || gpt5_token_matches(&lower, "gpt5.1")
+        || gpt5_token_matches(&lower, "gpt-5-1")
+        || gpt5_token_matches(&lower, "gpt5-1")
     {
         Some(GPT5_1)
-    } else if lower.contains("gpt-5") || lower.contains("gpt5") {
+    } else if gpt5_base_matches(&lower, "gpt-5") || gpt5_base_matches(&lower, "gpt5") {
         // Base gpt-5 (no version suffix matching any of the above).
         Some(GPT5_BASE)
     } else {
@@ -2038,6 +2111,96 @@ mod tests {
         assert!(openai_efforts_for_model("llama-4").is_none());
         assert!(openai_efforts_for_model("claude-opus-4-8").is_none());
         assert!(openai_efforts_for_model("gpt-4o").is_none());
+    }
+
+    // ---- Boundary-safe matching: version digits must not false-match longer versions ----
+
+    #[test]
+    fn openai_efforts_for_model_boundary_dated_base_ids_are_not_versioned() {
+        // gpt-5-1106: the "-1" is not version 5.1 — it's a date segment on the base model.
+        // Must fall through to base table, not gpt-5.1.
+        let result = openai_efforts_for_model("gpt-5-1106");
+        let base = openai_efforts_for_model("gpt-5").unwrap();
+        assert_eq!(
+            result,
+            Some(base),
+            "gpt-5-1106 must match base table (not gpt-5.1): got {result:?}"
+        );
+        // Crucially, must NOT support None (that's a gpt-5.1 property, not base).
+        assert!(
+            !result.unwrap().contains(&ThinkingEffort::None),
+            "gpt-5-1106 must NOT support none — base table only has minimal"
+        );
+    }
+
+    #[test]
+    fn openai_efforts_for_model_boundary_gpt5_4o_is_base_not_5_4() {
+        // gpt-5-4o: the "-4" could false-match the gpt-5.4 family, but "4o" is a
+        // capability suffix on the base gpt-5 model, not version 5.4.
+        // Must fall through to base table.
+        let result = openai_efforts_for_model("gpt-5-4o");
+        let base = openai_efforts_for_model("gpt-5").unwrap();
+        assert_eq!(
+            result,
+            Some(base),
+            "gpt-5-4o must match base table (not gpt-5.4): got {result:?}"
+        );
+        // Crucially, must NOT support XHigh (that's a gpt-5.4 property, not base).
+        assert!(
+            !result.unwrap().contains(&ThinkingEffort::XHigh),
+            "gpt-5-4o must NOT support xhigh — that's a gpt-5.4 property and would 400"
+        );
+    }
+
+    #[test]
+    fn openai_efforts_for_model_boundary_multi_digit_versions_pass_through() {
+        // Dotted two-digit versions (gpt-5.10, gpt5.10, gpt-5.50) must not match any known
+        // single-digit family — the digit boundary check on dotted tokens blocks them.
+        // These return None (server-validated pass-through).
+        assert!(
+            openai_efforts_for_model("gpt-5.10").is_none(),
+            "gpt-5.10 must pass through (unknown future model)"
+        );
+        assert!(
+            openai_efforts_for_model("gpt5.10").is_none(),
+            "gpt5.10 must pass through (unknown future model)"
+        );
+        assert!(
+            openai_efforts_for_model("gpt-5.50").is_none(),
+            "gpt-5.50 must pass through (not gpt-5.5)"
+        );
+        // Dash two-digit versions (gpt-5-10, databricks-gpt-5-10) look like short numeric
+        // version segments and must also pass through as unknown — not bucketed as base.
+        assert!(
+            openai_efforts_for_model("gpt-5-10").is_none(),
+            "gpt-5-10 must pass through (short numeric suffix = potential unrecognized version)"
+        );
+        assert!(
+            openai_efforts_for_model("databricks-gpt-5-10").is_none(),
+            "databricks-gpt-5-10 must pass through (short numeric suffix)"
+        );
+    }
+
+    #[test]
+    fn openai_efforts_for_model_boundary_databricks_prefixed_still_matches() {
+        // Databricks-prefixed names (gateway forwarding) must still resolve to the right table.
+        let result = openai_efforts_for_model("databricks-gpt-5-5");
+        assert_eq!(
+            result,
+            openai_efforts_for_model("gpt-5.5"),
+            "databricks-gpt-5-5 must match gpt-5.5 family table"
+        );
+    }
+
+    #[test]
+    fn openai_efforts_for_model_boundary_date_suffixed_still_matches() {
+        // Date-suffixed names (e.g. gpt-5.1-2025-04-01) must still resolve to the right family.
+        let result = openai_efforts_for_model("gpt-5.1-2025-04-01");
+        assert_eq!(
+            result,
+            openai_efforts_for_model("gpt-5.1"),
+            "gpt-5.1-2025-04-01 must match gpt-5.1 family table"
+        );
     }
 
     #[test]

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -82,7 +82,9 @@ impl ThinkingEffort {
 /// Matched by explicit version strings (no wildcard over version numbers).
 ///
 /// **Manual-budget families** — `thinking: {type:"enabled", budget_tokens}`.
-/// `budget_tokens` is capped at `max_output_tokens - 1` (required by the API).
+/// `budget_tokens` is clamped to `min(level_budget, max_output_tokens - 1024)` to preserve
+/// at least 1024 answer tokens. If the result is < 1024 (i.e., `max_output_tokens <= 2047`),
+/// thinking is omitted entirely with a `warn!`.
 /// Doc-verified: claude-3* (legacy), claude-opus-4-5 (effort page: "uses manual thinking").
 ///
 /// **Everything else** — omit both fields. This includes unknown/future `claude-*` names
@@ -105,11 +107,26 @@ pub fn anthropic_thinking_config(
         .unwrap_or(effective_model);
 
     if is_manual_budget_model(model) {
-        // Manual-budget shape: budget_tokens must be strictly < max_tokens.
-        // XHigh/Max clamp to the high budget value (32768) per anthropic_budget_tokens().
-        let budget = effort
-            .anthropic_budget_tokens()
-            .min(max_output_tokens.saturating_sub(1));
+        // Manual-budget shape: budget_tokens must be strictly < max_tokens AND must leave
+        // at least MIN_ANSWER_TOKENS (1024) for the visible answer. The Anthropic API
+        // requires budget_tokens < max_tokens AND budget_tokens >= 1024.
+        //
+        // Clamp: budget = min(level_budget, max_output_tokens - MIN_ANSWER_TOKENS).
+        // If result < MIN_ANSWER_TOKENS, thinking would starve the answer — omit thinking
+        // entirely and warn instead of emitting an invalid or answer-starving budget.
+        const MIN_ANSWER_TOKENS: u32 = 1024;
+        let level_budget = effort.anthropic_budget_tokens();
+        let headroom = max_output_tokens.saturating_sub(MIN_ANSWER_TOKENS);
+        let budget = level_budget.min(headroom);
+        if budget < MIN_ANSWER_TOKENS {
+            tracing::warn!(
+                max_output_tokens,
+                level_budget,
+                headroom,
+                "BUZZ_AGENT_THINKING_EFFORT: max_output_tokens too small to fit thinking budget + answer headroom; omitting thinking fields"
+            );
+            return (None, None);
+        }
         (
             Some(json!({ "type": "enabled", "budget_tokens": budget })),
             None,
@@ -174,29 +191,190 @@ pub fn clamp_adaptive_effort(model: &str, effort: ThinkingEffort) -> ThinkingEff
     clamped
 }
 
+/// Returns the set of `reasoning.effort` values supported by a given OpenAI model family.
+///
+/// Doc-verified availability (OpenAI model pages, July 2025):
+///
+/// | Model        | Supported effort values                   |
+/// |-------------|-------------------------------------------|
+/// | gpt-5-pro   | `high` only                               |
+/// | gpt-5.5     | `none, low, medium, high, xhigh`          |
+/// | gpt-5.4     | `none, low, medium, high, xhigh`          |
+/// | gpt-5.1     | `none, low, medium, high`                 |
+/// | gpt-5 (base)| `minimal, low, medium, high`              |
+/// | unknown     | not doc-verified — pass through unchanged |
+///
+/// Note the `none` vs `minimal` split: `gpt-5` (base) supports `minimal` but not `none`;
+/// `gpt-5.1`/`gpt-5.4`/`gpt-5.5` support `none` but not `minimal`. These are matched via
+/// nearest-supported fallback in `normalize_effort_for_openai_route`.
+///
+/// Match order: `-pro` variant checked before versioned strings to prevent `gpt-5-pro` from
+/// falling into the `gpt-5` base bucket (substring "gpt-5" is shared).
+///
+/// `model` is a raw model name (may include Databricks gateway prefixes or date suffixes).
+/// Unknown models return `None` — caller treats `None` as "server-validated pass-through".
+fn openai_efforts_for_model(model: &str) -> Option<&'static [ThinkingEffort]> {
+    // Effort ordered from lowest to highest for each family.
+    const GPT5_PRO: &[ThinkingEffort] = &[ThinkingEffort::High];
+    const GPT5_5_AND_5_4: &[ThinkingEffort] = &[
+        ThinkingEffort::None,
+        ThinkingEffort::Low,
+        ThinkingEffort::Medium,
+        ThinkingEffort::High,
+        ThinkingEffort::XHigh,
+    ];
+    const GPT5_1: &[ThinkingEffort] = &[
+        ThinkingEffort::None,
+        ThinkingEffort::Low,
+        ThinkingEffort::Medium,
+        ThinkingEffort::High,
+    ];
+    const GPT5_BASE: &[ThinkingEffort] = &[
+        ThinkingEffort::Minimal,
+        ThinkingEffort::Low,
+        ThinkingEffort::Medium,
+        ThinkingEffort::High,
+    ];
+
+    let lower = model.to_ascii_lowercase();
+    // Check gpt-5-pro before gpt-5.5 / gpt-5.4 etc. to avoid the `-pro` name
+    // matching the base "gpt-5" prefix first.
+    if lower.contains("gpt-5-pro") || lower.contains("gpt5-pro") {
+        Some(GPT5_PRO)
+    } else if lower.contains("gpt-5.5")
+        || lower.contains("gpt5.5")
+        || lower.contains("gpt-5-5")
+        || lower.contains("gpt5-5")
+    {
+        Some(GPT5_5_AND_5_4)
+    } else if lower.contains("gpt-5.4")
+        || lower.contains("gpt5.4")
+        || lower.contains("gpt-5-4")
+        || lower.contains("gpt5-4")
+    {
+        Some(GPT5_5_AND_5_4)
+    } else if lower.contains("gpt-5.1")
+        || lower.contains("gpt5.1")
+        || lower.contains("gpt-5-1")
+        || lower.contains("gpt5-1")
+    {
+        Some(GPT5_1)
+    } else if lower.contains("gpt-5") || lower.contains("gpt5") {
+        // Base gpt-5 (no version suffix matching any of the above).
+        Some(GPT5_BASE)
+    } else {
+        // Unknown model — not doc-verified; server validates.
+        None
+    }
+}
+
+/// Resolve the nearest supported effort level for a given OpenAI model.
+///
+/// When the requested effort is not in the model's supported set, falls back to the
+/// nearest supported level using this preference order:
+///
+/// - `none` ↔ `minimal` are each other's first fallback (the none/minimal split across
+///   model families means the "closest analogue" is the other form before jumping to `low`).
+/// - Above that pair: upward clamp first, then downward (prefer more thinking over less).
+/// - `xhigh` falls back to `high` when not supported (no model skips from `high` to `xhigh`).
+/// - `max` is first clamped to `xhigh` by `normalize_effort_for_openai_route` before this
+///   function is reached; this function never sees `max`.
+///
+/// Logs a `warn!` on every substitution.
+fn resolve_openai_effort(
+    model: &str,
+    requested: ThinkingEffort,
+    supported: &[ThinkingEffort],
+) -> ThinkingEffort {
+    if supported.contains(&requested) {
+        return requested;
+    }
+
+    // Build a candidate list ordered by preference: the "other" form of none/minimal first,
+    // then the levels sorted nearest to requested (ascending distance).
+    let candidates: Vec<ThinkingEffort> = {
+        // none ↔ minimal are each other's first fallback.
+        let peer = match requested {
+            ThinkingEffort::None => Some(ThinkingEffort::Minimal),
+            ThinkingEffort::Minimal => Some(ThinkingEffort::None),
+            _ => None,
+        };
+        // All supported values sorted by distance (abs diff in ordinal), upward ties win.
+        let mut by_dist: Vec<ThinkingEffort> = supported.iter().copied().collect();
+        by_dist.sort_by_key(|&e| {
+            let dist = (e as i32 - requested as i32).unsigned_abs();
+            // Prefer upward (e > requested) to break ties between equidistant values.
+            let up = if e >= requested { 0u32 } else { 1 };
+            (dist, up)
+        });
+        // Peer first, then by distance.
+        let mut result = Vec::new();
+        if let Some(p) = peer {
+            if supported.contains(&p) {
+                result.push(p);
+            }
+        }
+        for e in by_dist {
+            if !result.contains(&e) {
+                result.push(e);
+            }
+        }
+        result
+    };
+
+    let resolved = candidates
+        .into_iter()
+        .next()
+        .expect("supported is non-empty");
+
+    tracing::warn!(
+        %model,
+        requested = requested.openai_effort_str(),
+        resolved = resolved.openai_effort_str(),
+        "BUZZ_AGENT_THINKING_EFFORT={} is not supported by this OpenAI model; using nearest supported level",
+        requested.openai_effort_str(),
+    );
+    resolved
+}
+
 /// Normalize the effort value for an OpenAI-shaped request body (Chat Completions or Responses).
 ///
-/// OpenAI-shaped bodies (`openai_body`, `responses_body`) accept `none|minimal|low|medium|high|xhigh`
-/// but NOT `max` — `max` is not a valid OpenAI reasoning effort value.
+/// Two normalizations are applied in order:
 ///
-/// This function is the single source of truth for the `max` → `xhigh` clamp on OpenAI paths.
-/// It is called at request-build time (not startup) because `session/set_model` on a
-/// `DatabricksV2` session can switch between Claude and GPT routes mid-session; startup
-/// validation cannot guarantee the value is safe for the current route.
+/// 1. **`max` → `xhigh` clamp**: `max` is not a valid OpenAI reasoning effort value; clamped
+///    at this step. The pure-OpenAI startup validator already rejects `max` at startup, so this
+///    clamp only fires on `DatabricksV2` sessions that routed to the OpenAI path.
 ///
-/// Returns `None` if `effort` should not be included in the request (not currently possible
-/// on OpenAI paths — all non-`None` inputs produce a value — but included for symmetry
-/// with `normalize_effort_for_anthropic_route`).
-pub fn normalize_effort_for_openai_route(effort: ThinkingEffort) -> ThinkingEffort {
-    if effort == ThinkingEffort::Max {
+/// 2. **Per-model effort availability**: for doc-verified OpenAI model families, the requested
+///    level (post-clamp) is checked against the model's supported set. If not supported, the
+///    nearest supported level is substituted (see `resolve_openai_effort` for preference order).
+///    Unknown/unverified models are passed through unchanged — the server validates.
+///
+/// Applies to pure-OpenAI request paths AND DBv2 OpenAI-shaped routes.
+///
+/// Doc-verified model table (July 2025):
+/// - `gpt-5-pro`: `high` only
+/// - `gpt-5.5`, `gpt-5.4`: `none, low, medium, high, xhigh`
+/// - `gpt-5.1`: `none, low, medium, high`
+/// - `gpt-5` (base): `minimal, low, medium, high`
+/// - unknown: pass through (server-validated)
+pub fn normalize_effort_for_openai_route(effort: ThinkingEffort, model: &str) -> ThinkingEffort {
+    // Step 1: clamp max → xhigh (max is not a valid OpenAI value).
+    let clamped = if effort == ThinkingEffort::Max {
         tracing::warn!(
             requested = "max",
-            clamped = "xhigh",
+            resolved = "xhigh",
             "BUZZ_AGENT_THINKING_EFFORT=max is not valid for OpenAI-shaped requests; clamping to xhigh"
         );
         ThinkingEffort::XHigh
     } else {
         effort
+    };
+
+    // Step 2: per-model effort availability check.
+    match openai_efforts_for_model(model) {
+        Some(supported) => resolve_openai_effort(model, clamped, supported),
+        None => clamped, // unknown model — pass through
     }
 }
 
@@ -1061,16 +1239,38 @@ mod tests {
 
     #[test]
     fn anthropic_thinking_config_claude3_emits_budget_tokens() {
-        // Claude 3.x → `thinking.budget_tokens`; capped at max_output_tokens - 1.
+        // Claude 3.x → `thinking.budget_tokens`; clamped to min(level_budget, max_output - 1024).
+        // max_output_tokens = 4096: headroom = 4096 - 1024 = 3072; High budget (32768) → 3072.
         let (thinking, output_config) =
-            anthropic_thinking_config("claude-3-7-sonnet-20250219", ThinkingEffort::High, 1024);
+            anthropic_thinking_config("claude-3-7-sonnet-20250219", ThinkingEffort::High, 4096);
         let t = thinking.expect("thinking field must be present for claude-3");
         assert_eq!(t["type"], "enabled");
-        assert_eq!(t["budget_tokens"], 1023); // capped: min(32768, 1024-1)
+        assert_eq!(t["budget_tokens"], 3072); // capped: min(32768, 4096-1024)
         assert!(
             output_config.is_none(),
             "output_config must be absent for claude-3"
         );
+    }
+
+    #[test]
+    fn anthropic_thinking_config_claude3_omits_thinking_when_max_output_too_small() {
+        // max_output_tokens = 2047: headroom = 2047 - 1024 = 1023 < 1024 → omit thinking.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-3-7-sonnet-20250219", ThinkingEffort::High, 2047);
+        assert!(
+            thinking.is_none(),
+            "thinking must be omitted when max_output_tokens - 1024 < 1024 (budget would starve answer)"
+        );
+        assert!(output_config.is_none());
+    }
+
+    #[test]
+    fn anthropic_thinking_config_claude3_emits_thinking_at_boundary_2048() {
+        // max_output_tokens = 2048: headroom = 2048 - 1024 = 1024 ≥ 1024 → emit budget = 1024.
+        let (thinking, _) =
+            anthropic_thinking_config("claude-3-7-sonnet-20250219", ThinkingEffort::High, 2048);
+        let t = thinking.expect("thinking must be present when max_output_tokens = 2048");
+        assert_eq!(t["budget_tokens"], 1024); // min(32768, 2048-1024) = 1024
     }
 
     #[test]
@@ -1142,11 +1342,33 @@ mod tests {
 
     #[test]
     fn anthropic_thinking_config_opus_4_5_budget_capped() {
-        // Opus 4.5 manual budget is capped at max_output_tokens - 1.
+        // Opus 4.5 manual budget is clamped to min(level_budget, max_output_tokens - 1024).
+        // max_output_tokens = 4096: headroom = 4096 - 1024 = 3072; High budget (32768) → 3072.
         let (thinking, _) =
-            anthropic_thinking_config("claude-opus-4-5", ThinkingEffort::High, 1024);
+            anthropic_thinking_config("claude-opus-4-5", ThinkingEffort::High, 4096);
         let t = thinking.unwrap();
-        assert_eq!(t["budget_tokens"], 1023); // capped: min(32768, 1024-1)
+        assert_eq!(t["budget_tokens"], 3072); // min(32768, 4096-1024)
+    }
+
+    #[test]
+    fn anthropic_thinking_config_opus_4_5_omits_thinking_when_max_output_1025() {
+        // max_output_tokens = 1025: headroom = 1025 - 1024 = 1 < 1024 → omit thinking.
+        let (thinking, _) =
+            anthropic_thinking_config("claude-opus-4-5", ThinkingEffort::High, 1025);
+        assert!(
+            thinking.is_none(),
+            "thinking must be omitted when max_output_tokens - 1024 < 1024"
+        );
+    }
+
+    #[test]
+    fn anthropic_thinking_config_manual_budget_low_emits_1024_when_fits() {
+        // Low budget (1024 tokens) exactly fits when max_output_tokens = 2048.
+        // headroom = 2048 - 1024 = 1024; min(1024, 1024) = 1024 ≥ 1024 → emit.
+        let (thinking, _) =
+            anthropic_thinking_config("claude-3-7-sonnet-20250219", ThinkingEffort::Low, 2048);
+        let t = thinking.expect("Low budget (1024) must be emitted when max_output_tokens = 2048");
+        assert_eq!(t["budget_tokens"], 1024);
     }
 
     #[test]
@@ -1553,14 +1775,16 @@ mod tests {
 
     #[test]
     fn normalize_openai_route_clamps_max_to_xhigh() {
+        // Use an unknown model so only the max→xhigh clamp fires, not per-model logic.
         assert_eq!(
-            normalize_effort_for_openai_route(ThinkingEffort::Max),
+            normalize_effort_for_openai_route(ThinkingEffort::Max, "llama-4"),
             ThinkingEffort::XHigh
         );
     }
 
     #[test]
-    fn normalize_openai_route_passes_through_all_other_values() {
+    fn normalize_openai_route_passes_through_all_other_values_for_unknown_model() {
+        // Unknown/unverified models pass through unchanged (server-validated).
         for effort in [
             ThinkingEffort::None,
             ThinkingEffort::Minimal,
@@ -1570,9 +1794,9 @@ mod tests {
             ThinkingEffort::XHigh,
         ] {
             assert_eq!(
-                normalize_effort_for_openai_route(effort),
+                normalize_effort_for_openai_route(effort, "unknown-future-model"),
                 effort,
-                "normalize_effort_for_openai_route must pass through {effort:?}"
+                "normalize_effort_for_openai_route must pass through {effort:?} for unknown model"
             );
         }
     }
@@ -1751,5 +1975,191 @@ mod tests {
         let t = thinking.unwrap();
         assert_eq!(t["type"], "adaptive");
         assert_eq!(output_config.unwrap()["effort"], "max");
+    }
+
+    // ---- openai_efforts_for_model / normalize_effort_for_openai_route per-model table ----
+
+    #[test]
+    fn openai_efforts_for_model_gpt5_pro_high_only() {
+        // gpt-5-pro: high only — any other value must be substituted.
+        let supported = openai_efforts_for_model("gpt-5-pro").expect("gpt-5-pro must be in table");
+        assert_eq!(
+            supported,
+            &[ThinkingEffort::High],
+            "gpt-5-pro supports only high"
+        );
+    }
+
+    #[test]
+    fn openai_efforts_for_model_gpt5_5_includes_xhigh() {
+        let supported = openai_efforts_for_model("gpt-5.5").expect("gpt-5.5 must be in table");
+        assert!(
+            supported.contains(&ThinkingEffort::XHigh),
+            "gpt-5.5 must support xhigh"
+        );
+        assert!(
+            supported.contains(&ThinkingEffort::None),
+            "gpt-5.5 must support none"
+        );
+    }
+
+    #[test]
+    fn openai_efforts_for_model_gpt5_1_excludes_xhigh_and_minimal() {
+        let supported = openai_efforts_for_model("gpt-5.1").expect("gpt-5.1 must be in table");
+        assert!(
+            !supported.contains(&ThinkingEffort::XHigh),
+            "gpt-5.1 must NOT support xhigh"
+        );
+        assert!(
+            !supported.contains(&ThinkingEffort::Minimal),
+            "gpt-5.1 must NOT support minimal"
+        );
+        assert!(
+            supported.contains(&ThinkingEffort::None),
+            "gpt-5.1 must support none"
+        );
+    }
+
+    #[test]
+    fn openai_efforts_for_model_gpt5_base_excludes_none_includes_minimal() {
+        let supported = openai_efforts_for_model("gpt-5").expect("gpt-5 base must be in table");
+        assert!(
+            !supported.contains(&ThinkingEffort::None),
+            "gpt-5 base must NOT support none"
+        );
+        assert!(
+            supported.contains(&ThinkingEffort::Minimal),
+            "gpt-5 base must support minimal"
+        );
+    }
+
+    #[test]
+    fn openai_efforts_for_model_unknown_returns_none() {
+        // Unknown models are not doc-verified — caller treats as server-validated pass-through.
+        assert!(openai_efforts_for_model("llama-4").is_none());
+        assert!(openai_efforts_for_model("claude-opus-4-8").is_none());
+        assert!(openai_efforts_for_model("gpt-4o").is_none());
+    }
+
+    #[test]
+    fn openai_efforts_for_model_pro_before_base_gpt5() {
+        // gpt-5-pro must match the -pro table, not the base gpt-5 table.
+        let pro = openai_efforts_for_model("gpt-5-pro").unwrap();
+        let base = openai_efforts_for_model("gpt-5").unwrap();
+        assert_ne!(
+            pro, base,
+            "gpt-5-pro and gpt-5 base must hit different table entries"
+        );
+        assert_eq!(pro, &[ThinkingEffort::High]);
+    }
+
+    #[test]
+    fn normalize_openai_route_gpt5_pro_high_passes_through() {
+        // gpt-5-pro: high is the only supported value → high passes through unchanged.
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::High, "gpt-5-pro"),
+            ThinkingEffort::High
+        );
+    }
+
+    #[test]
+    fn normalize_openai_route_gpt5_pro_anything_but_high_becomes_high() {
+        // gpt-5-pro: any effort other than high must resolve to high.
+        for effort in [
+            ThinkingEffort::None,
+            ThinkingEffort::Minimal,
+            ThinkingEffort::Low,
+            ThinkingEffort::Medium,
+            ThinkingEffort::XHigh,
+        ] {
+            assert_eq!(
+                normalize_effort_for_openai_route(effort, "gpt-5-pro"),
+                ThinkingEffort::High,
+                "gpt-5-pro: {effort:?} must resolve to high"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_openai_route_gpt5_base_none_becomes_minimal() {
+        // gpt-5 base supports minimal but not none. none → minimal (peer fallback).
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::None, "gpt-5"),
+            ThinkingEffort::Minimal,
+            "gpt-5 base: none must fall back to minimal (peer)"
+        );
+    }
+
+    #[test]
+    fn normalize_openai_route_gpt5_5_minimal_becomes_none() {
+        // gpt-5.5 supports none but not minimal. minimal → none (peer fallback).
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::Minimal, "gpt-5.5"),
+            ThinkingEffort::None,
+            "gpt-5.5: minimal must fall back to none (peer)"
+        );
+    }
+
+    #[test]
+    fn normalize_openai_route_gpt5_1_xhigh_becomes_high() {
+        // gpt-5.1 does not support xhigh → nearest supported below xhigh is high.
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::XHigh, "gpt-5.1"),
+            ThinkingEffort::High,
+            "gpt-5.1: xhigh must resolve to high"
+        );
+    }
+
+    #[test]
+    fn normalize_openai_route_gpt5_4_xhigh_passes_through() {
+        // gpt-5.4 supports xhigh → pass through unchanged.
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::XHigh, "gpt-5.4"),
+            ThinkingEffort::XHigh
+        );
+    }
+
+    #[test]
+    fn normalize_openai_route_gpt5_5_xhigh_passes_through() {
+        // gpt-5.5 supports xhigh → pass through unchanged.
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::XHigh, "gpt-5.5"),
+            ThinkingEffort::XHigh
+        );
+    }
+
+    #[test]
+    fn normalize_openai_route_gpt5_dash_suffix_variants_match_correctly() {
+        // Databricks-prefixed or date-suffixed names must still hit the right family.
+        // "gpt-5.5" and "gpt-5-5" are treated identically; ditto for other families.
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::XHigh, "gpt-5-5"),
+            ThinkingEffort::XHigh,
+            "gpt-5-5 (dash) must match gpt-5.5 table"
+        );
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::None, "gpt-5-1"),
+            ThinkingEffort::None,
+            "gpt-5-1 (dash) must match gpt-5.1 table"
+        );
+    }
+
+    #[test]
+    fn normalize_openai_route_unknown_model_passthrough() {
+        // Unknown models: all values pass through without substitution (server-validated).
+        for effort in [
+            ThinkingEffort::None,
+            ThinkingEffort::Minimal,
+            ThinkingEffort::Low,
+            ThinkingEffort::Medium,
+            ThinkingEffort::High,
+            ThinkingEffort::XHigh,
+        ] {
+            assert_eq!(
+                normalize_effort_for_openai_route(effort, "llama-4"),
+                effort,
+                "unknown model: {effort:?} must pass through unchanged"
+            );
+        }
     }
 }

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -21,7 +21,7 @@ pub enum ThinkingEffort {
 }
 
 impl ThinkingEffort {
-    /// Map level to an Anthropic `budget_tokens` value.
+    /// Map level to an Anthropic `budget_tokens` value for legacy Claude 3.x models.
     pub fn anthropic_budget_tokens(self) -> u32 {
         match self {
             ThinkingEffort::Low => 1_024,
@@ -37,6 +37,47 @@ impl ThinkingEffort {
             ThinkingEffort::Medium => "medium",
             ThinkingEffort::High => "high",
         }
+    }
+}
+
+/// Build the Anthropic thinking/effort request fields for the given model and effort level.
+///
+/// API shape selection (per Anthropic SDK and docs):
+/// - Claude 3.x models: `thinking: {type:"enabled", budget_tokens}` (manual budget).
+///   `budget_tokens` is capped at `max_output_tokens - 1` so it is always strictly less
+///   than `max_tokens` as required by the API.
+/// - Claude 4+ and Sonnet-5+ (modern Claude): `output_config: {effort: "low"|"medium"|"high"}`.
+///   These models use the high-level effort abstraction and may not support manual budgets.
+/// - Unrecognized model: neither field is emitted (safe omit; unknown API shape).
+///
+/// Returns `(thinking_field, output_config_field)` where each is `None` if not applicable.
+pub fn anthropic_thinking_config(
+    effective_model: &str,
+    effort: ThinkingEffort,
+    max_output_tokens: u32,
+) -> (Option<serde_json::Value>, Option<serde_json::Value>) {
+    use serde_json::json;
+    // Normalise the model name for matching: strip Databricks gateway prefixes
+    // (e.g. "databricks-claude-opus-4-7" → "claude-opus-4-7").
+    let model = effective_model
+        .strip_prefix("databricks-")
+        .unwrap_or(effective_model);
+
+    if model.starts_with("claude-3") {
+        // Legacy shape: manual budget, must be strictly < max_tokens.
+        let budget = effort
+            .anthropic_budget_tokens()
+            .min(max_output_tokens.saturating_sub(1));
+        (
+            Some(json!({ "type": "enabled", "budget_tokens": budget })),
+            None,
+        )
+    } else if model.starts_with("claude-") {
+        // Modern Claude (4+, sonnet-5, etc.): use output_config.effort.
+        (None, Some(json!({ "effort": effort.openai_effort_str() })))
+    } else {
+        // Unrecognised model name — omit both fields rather than guess.
+        (None, None)
     }
 }
 
@@ -752,5 +793,78 @@ mod tests {
         assert_eq!(ThinkingEffort::Low.openai_effort_str(), "low");
         assert_eq!(ThinkingEffort::Medium.openai_effort_str(), "medium");
         assert_eq!(ThinkingEffort::High.openai_effort_str(), "high");
+    }
+
+    // ---- anthropic_thinking_config helper — per-family tests ----
+
+    #[test]
+    fn anthropic_thinking_config_claude3_emits_budget_tokens() {
+        // Claude 3.x → `thinking.budget_tokens`; capped at max_output_tokens - 1.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-3-7-sonnet-20250219", ThinkingEffort::High, 1024);
+        let t = thinking.expect("thinking field must be present for claude-3");
+        assert_eq!(t["type"], "enabled");
+        assert_eq!(t["budget_tokens"], 1023); // capped: min(32768, 1024-1)
+        assert!(
+            output_config.is_none(),
+            "output_config must be absent for claude-3"
+        );
+    }
+
+    #[test]
+    fn anthropic_thinking_config_claude3_budget_uncapped_when_fits() {
+        // High budget fits comfortably under a large max_output_tokens.
+        let (thinking, _) =
+            anthropic_thinking_config("claude-3-7-sonnet-20250219", ThinkingEffort::High, 65_536);
+        let t = thinking.unwrap();
+        assert_eq!(t["budget_tokens"], 32_768);
+    }
+
+    #[test]
+    fn anthropic_thinking_config_modern_claude_emits_output_config_effort() {
+        // Claude 4+ / sonnet-5+ → `output_config.effort`; no budget_tokens.
+        let (thinking, output_config) =
+            anthropic_thinking_config("claude-opus-4-5", ThinkingEffort::Medium, 32_768);
+        assert!(
+            thinking.is_none(),
+            "thinking must be absent for modern claude"
+        );
+        let oc = output_config.expect("output_config must be present for modern claude");
+        assert_eq!(oc["effort"], "medium");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_databricks_prefix_stripped_for_claude3() {
+        // Databricks gateway prefixes like "databricks-claude-3-..." must be stripped.
+        let (thinking, output_config) =
+            anthropic_thinking_config("databricks-claude-3-5-sonnet", ThinkingEffort::Low, 8_192);
+        let t = thinking.expect("thinking must be present after stripping databricks- prefix");
+        assert_eq!(t["type"], "enabled");
+        assert!(output_config.is_none());
+    }
+
+    #[test]
+    fn anthropic_thinking_config_databricks_prefix_stripped_for_modern_claude() {
+        // Databricks gateway prefix stripping applies to modern Claude too.
+        let (thinking, output_config) =
+            anthropic_thinking_config("databricks-claude-opus-4-7", ThinkingEffort::High, 32_768);
+        assert!(thinking.is_none());
+        let oc = output_config.expect("output_config must be present for databricks-claude-opus-4");
+        assert_eq!(oc["effort"], "high");
+    }
+
+    #[test]
+    fn anthropic_thinking_config_unrecognized_model_omits_both_fields() {
+        // Non-Anthropic model names (gpt-5, llama, etc.) → omit both fields.
+        let (thinking, output_config) =
+            anthropic_thinking_config("gpt-4o-mini", ThinkingEffort::High, 32_768);
+        assert!(
+            thinking.is_none(),
+            "thinking must be absent for non-claude model"
+        );
+        assert!(
+            output_config.is_none(),
+            "output_config must be absent for non-claude model"
+        );
     }
 }

--- a/crates/buzz-agent/src/handoff.rs
+++ b/crates/buzz-agent/src/handoff.rs
@@ -36,6 +36,7 @@ impl RunCtx<'_> {
                 HANDOFF_SYSTEM_PROMPT,
                 &prompt,
                 HANDOFF_MAX_OUTPUT_TOKENS,
+                self.effective_model,
             ) => match r {
                 Ok(s) if !s.trim().is_empty() => s,
                 Ok(_) => {

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -477,7 +477,13 @@ async fn set_model_session(app: &Arc<App>, id: Value, params: Value, wire_tx: &W
     }
     let mut sessions = app.sessions.lock().await;
     let Some(s) = sessions.get_mut(&p.session_id) else {
-        return reject(wire_tx, id, INVALID_PARAMS, "session/set_model: unknown session").await;
+        return reject(
+            wire_tx,
+            id,
+            INVALID_PARAMS,
+            "session/set_model: unknown session",
+        )
+        .await;
     };
     s.effective_model = Some(p.model_id.clone());
     tracing::info!(
@@ -488,7 +494,10 @@ async fn set_model_session(app: &Arc<App>, id: Value, params: Value, wire_tx: &W
     drop(sessions);
     wire::send(
         wire_tx,
-        wire::ok(id, json!({ "sessionId": p.session_id, "modelId": p.model_id })),
+        wire::ok(
+            id,
+            json!({ "sessionId": p.session_id, "modelId": p.model_id }),
+        ),
     )
     .await;
 }

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -391,7 +391,10 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
     let available_models: Vec<Value> = {
         use crate::config::Provider;
         match app.cfg.provider {
-            Provider::Databricks | Provider::DatabricksV2 => {
+            Provider::DatabricksV2 => {
+                // AI Gateway v2 supports model switching across the published catalog.
+                // On discovery failure, fall back to the statically-known v2 model IDs
+                // so the response is never empty even without a browser token.
                 let entries = app
                     .models_cache
                     .get_or_init(|| async {
@@ -399,8 +402,6 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
                             Ok(models) => models,
                             Err(e) => {
                                 tracing::warn!("model catalog discovery failed: {e}; using known-models fallback");
-                                // Fall back to the statically-known models list so the
-                                // response is never empty even without a browser token.
                                 DATABRICKS_V2_KNOWN_MODELS
                                     .iter()
                                     .map(|id| crate::catalog::ModelEntry {
@@ -408,6 +409,32 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
                                         name: id.to_string(),
                                     })
                                     .collect()
+                            }
+                        }
+                    })
+                    .await;
+                entries
+                    .iter()
+                    .map(|m| json!({ "modelId": m.id, "name": m.name }))
+                    .collect()
+            }
+            Provider::Databricks => {
+                // Legacy Databricks model serving routes to a single endpoint per model.
+                // The DATABRICKS_V2_KNOWN_MODELS list is AI Gateway v2 IDs that
+                // `/serving-endpoints/{model}/invocations` may not serve — do not advertise
+                // them for legacy Databricks. On discovery failure, advertise only the
+                // configured model.
+                let entries = app
+                    .models_cache
+                    .get_or_init(|| async {
+                        match discover_databricks_models(&app.cfg).await {
+                            Ok(models) => models,
+                            Err(e) => {
+                                tracing::warn!("model catalog discovery failed: {e}; advertising configured model only");
+                                vec![crate::catalog::ModelEntry {
+                                    id: app.cfg.model.clone(),
+                                    name: app.cfg.model.clone(),
+                                }]
                             }
                         }
                     })
@@ -738,4 +765,35 @@ fn session_token() -> Result<String, String> {
     let mut b = [0u8; 8];
     getrandom::fill(&mut b).map_err(|e| format!("rng: getrandom failed: {e}"))?;
     Ok(b.iter().map(|x| format!("{x:02x}")).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::DATABRICKS_V2_KNOWN_MODELS;
+
+    /// Regression: legacy `Provider::Databricks` must not advertise v2 AI Gateway model IDs
+    /// as its discovery fallback. The `DATABRICKS_V2_KNOWN_MODELS` list contains AI Gateway
+    /// v2 endpoint IDs that `/serving-endpoints/{model}/invocations` may not serve.
+    ///
+    /// This test verifies that the v2 fallback list is non-empty (so there IS a distinction
+    /// between the two providers' fallback behavior to protect) and that each entry looks like
+    /// an AI Gateway v2 ID format (not a legacy serving endpoint name). The actual split is
+    /// in `session_new`; this documents the invariant that justifies it.
+    #[test]
+    fn databricks_v2_known_models_nonempty_and_not_legacy_format() {
+        assert!(
+            !DATABRICKS_V2_KNOWN_MODELS.is_empty(),
+            "DATABRICKS_V2_KNOWN_MODELS must be non-empty — it is the v2 discovery fallback"
+        );
+        // v2 model IDs include family name + version (e.g. "databricks-claude-opus-4-7",
+        // "databricks-meta-llama-4-maverick"). None should look like a bare serving endpoint
+        // name (which would not include a vendor/family prefix like "databricks-").
+        for id in DATABRICKS_V2_KNOWN_MODELS {
+            assert!(
+                id.contains('-'),
+                "v2 model ID {id:?} must contain a hyphen (AI Gateway v2 format)"
+            );
+        }
+    }
 }

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -40,9 +40,10 @@ struct App {
     llm: Arc<Llm>,
     sessions: Mutex<HashMap<String, Session>>,
     /// Cached model catalog for Databricks providers. Populated lazily on the
-    /// first `session/new` call. `None` means discovery hasn't run yet or the
-    /// provider is not Databricks; an empty vec means discovery ran but returned
-    /// no models (auth missing or list empty).
+    /// first successful `session/new` discovery call. When discovery fails (e.g.
+    /// auth missing or a transient network error) the cell is intentionally left
+    /// empty so the next `session/new` call retries — a transient failure never
+    /// pins the degraded fallback catalog for the process lifetime.
     models_cache: tokio::sync::OnceCell<Vec<ModelEntry>>,
 }
 
@@ -280,6 +281,32 @@ async fn initialize(id: Value, params: Value, wire_tx: &WireSender) {
     .await;
 }
 
+/// Resolve the Databricks model catalog for one `session/new` call.
+///
+/// Tries to use a previously-cached successful discovery result. If the cache is empty,
+/// runs `discover` and — on success — populates the cache for future calls. On failure
+/// the cell is intentionally left empty so the next session retries; the provider-aware
+/// fallback is returned for the immediate response only.
+///
+/// Extracted from `session_new` so that tests can drive this path with an injected
+/// discovery future without requiring a full `App` / transport stack.
+async fn resolve_models_catalog(
+    cache: &tokio::sync::OnceCell<Vec<ModelEntry>>,
+    provider: crate::config::Provider,
+    model: &str,
+    discover: impl std::future::Future<Output = Result<Vec<ModelEntry>, AgentError>>,
+) -> Vec<ModelEntry> {
+    match cache.get_or_try_init(|| discover).await {
+        Ok(cached) => cached.clone(),
+        Err(e) => {
+            tracing::warn!(
+                "model catalog discovery failed: {e}; using fallback (will retry next session)"
+            );
+            crate::catalog::discovery_failure_fallback(provider, model)
+        }
+    }
+}
+
 async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSender) {
     let p: SessionNewParams = match decode(params, "session/new") {
         Ok(p) => p,
@@ -397,23 +424,13 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
         use crate::config::Provider;
         match app.cfg.provider {
             Provider::Databricks | Provider::DatabricksV2 => {
-                // Try to get a previously-cached successful discovery result; if the cell is
-                // empty, run discovery now. `get_or_try_init` only populates the cell on `Ok`
-                // — an `Err` leaves it empty so the next session retries rather than
-                // re-serving a stale transient-failure fallback forever.
-                let models = match app
-                    .models_cache
-                    .get_or_try_init(|| async { discover_databricks_models(&app.cfg).await })
-                    .await
-                {
-                    Ok(cached) => cached.clone(),
-                    Err(e) => {
-                        tracing::warn!(
-                            "model catalog discovery failed: {e}; using fallback (will retry next session)"
-                        );
-                        crate::catalog::discovery_failure_fallback(app.cfg.provider, &app.cfg.model)
-                    }
-                };
+                let models = resolve_models_catalog(
+                    &app.models_cache,
+                    app.cfg.provider,
+                    &app.cfg.model,
+                    discover_databricks_models(&app.cfg),
+                )
+                .await;
                 models
                     .iter()
                     .map(|m| json!({ "modelId": m.id, "name": m.name }))
@@ -744,40 +761,60 @@ fn session_token() -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::catalog::{discovery_failure_fallback, DATABRICKS_V2_KNOWN_MODELS};
+    use crate::catalog::{discovery_failure_fallback, ModelEntry, DATABRICKS_V2_KNOWN_MODELS};
     use crate::config::Provider;
+    use crate::types::AgentError;
 
-    /// Regression: discovery errors must not pin the models_cache for the process lifetime.
+    /// Regression: a discovery error must not pin the models_cache for the process lifetime.
     ///
-    /// `session_new` uses `get_or_try_init` so an `Err` leaves the `OnceCell` empty and a
-    /// subsequent `session/new` call retries discovery. This test verifies that contract
-    /// directly against `tokio::sync::OnceCell` — the same type used in `AppState`.
+    /// `resolve_models_catalog` uses `get_or_try_init` so an `Err` leaves the `OnceCell`
+    /// empty and the next `session/new` retries discovery. This test calls
+    /// `resolve_models_catalog` directly — the same function `session_new` calls — so
+    /// reverting `session_new` to `get_or_init` (or any other cache-on-error variant) would
+    /// break this test, not just the standalone `OnceCell` semantics.
     #[tokio::test]
     async fn models_cache_does_not_pin_on_discovery_error() {
-        let cell: tokio::sync::OnceCell<Vec<String>> = tokio::sync::OnceCell::new();
+        let cache: tokio::sync::OnceCell<Vec<ModelEntry>> = tokio::sync::OnceCell::new();
+        let provider = Provider::DatabricksV2;
+        let model = "my-configured-model";
 
-        // First call — discovery fails. Cell must remain empty.
-        let first = cell
-            .get_or_try_init(|| async { Err::<Vec<String>, &str>("transient failure") })
-            .await;
-        assert!(first.is_err(), "get_or_try_init must propagate the error");
+        // First call — discovery fails. Cell must remain empty; fallback returned.
+        let first = crate::resolve_models_catalog(&cache, provider, model, async {
+            Err::<Vec<ModelEntry>, AgentError>(AgentError::LlmAuth("transient failure".into()))
+        })
+        .await;
         assert!(
-            cell.get().is_none(),
-            "cell must be empty after an error — discovery retry will be attempted next session"
+            cache.get().is_none(),
+            "cell must be empty after a discovery error — next session must retry"
         );
-
-        // Second call — discovery succeeds. Cell is now populated.
-        let second = cell
-            .get_or_try_init(|| async { Ok::<Vec<String>, &str>(vec!["model-a".to_string()]) })
-            .await;
+        let expected_fallback = discovery_failure_fallback(provider, model);
         assert_eq!(
-            second.unwrap(),
-            &["model-a"],
-            "second call must succeed and populate cell"
+            first, expected_fallback,
+            "error path must return the provider-aware fallback"
+        );
+
+        // Second call — discovery succeeds. Cell is now populated and returned.
+        let discovered = vec![ModelEntry {
+            id: "databricks-meta-llama-3-1-70b-instruct".into(),
+            name: "databricks-meta-llama-3-1-70b-instruct".into(),
+        }];
+        let discovered_clone = discovered.clone();
+        let second = crate::resolve_models_catalog(&cache, provider, model, async move {
+            Ok::<Vec<ModelEntry>, AgentError>(discovered_clone)
+        })
+        .await;
+        assert_eq!(
+            second, discovered,
+            "second call must return the discovered catalog"
         );
         assert!(
-            cell.get().is_some(),
-            "cell must be populated after a successful discovery"
+            cache.get().is_some(),
+            "cell must be populated after successful discovery"
+        );
+        assert_eq!(
+            cache.get().unwrap(),
+            &discovered,
+            "cache must hold the successful discovery result"
         );
     }
 

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -402,13 +402,10 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
                             Ok(models) => models,
                             Err(e) => {
                                 tracing::warn!("model catalog discovery failed: {e}; using known-models fallback");
-                                DATABRICKS_V2_KNOWN_MODELS
-                                    .iter()
-                                    .map(|id| crate::catalog::ModelEntry {
-                                        id: id.to_string(),
-                                        name: id.to_string(),
-                                    })
-                                    .collect()
+                                crate::catalog::discovery_failure_fallback(
+                                    app.cfg.provider,
+                                    &app.cfg.model,
+                                )
                             }
                         }
                     })
@@ -431,10 +428,10 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
                             Ok(models) => models,
                             Err(e) => {
                                 tracing::warn!("model catalog discovery failed: {e}; advertising configured model only");
-                                vec![crate::catalog::ModelEntry {
-                                    id: app.cfg.model.clone(),
-                                    name: app.cfg.model.clone(),
-                                }]
+                                crate::catalog::discovery_failure_fallback(
+                                    app.cfg.provider,
+                                    &app.cfg.model,
+                                )
                             }
                         }
                     })
@@ -769,30 +766,75 @@ fn session_token() -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::catalog::DATABRICKS_V2_KNOWN_MODELS;
+    use crate::catalog::{discovery_failure_fallback, DATABRICKS_V2_KNOWN_MODELS};
+    use crate::config::Provider;
 
     /// Regression: legacy `Provider::Databricks` must not advertise v2 AI Gateway model IDs
-    /// as its discovery fallback. The `DATABRICKS_V2_KNOWN_MODELS` list contains AI Gateway
-    /// v2 endpoint IDs that `/serving-endpoints/{model}/invocations` may not serve.
-    ///
-    /// This test verifies that the v2 fallback list is non-empty (so there IS a distinction
-    /// between the two providers' fallback behavior to protect) and that each entry looks like
-    /// an AI Gateway v2 ID format (not a legacy serving endpoint name). The actual split is
-    /// in `session_new`; this documents the invariant that justifies it.
+    /// on discovery failure (Wes W1). This test calls `discovery_failure_fallback` directly —
+    /// the same helper used by `session_new` — and verifies the split behavior. It FAILS if
+    /// the arm is un-split (i.e., if both providers return the v2 catalog on failure).
     #[test]
-    fn databricks_v2_known_models_nonempty_and_not_legacy_format() {
-        assert!(
-            !DATABRICKS_V2_KNOWN_MODELS.is_empty(),
-            "DATABRICKS_V2_KNOWN_MODELS must be non-empty — it is the v2 discovery fallback"
+    fn databricks_discovery_failure_fallback_legacy_returns_configured_model_only() {
+        let configured = "my-serving-endpoint";
+        let result = discovery_failure_fallback(Provider::Databricks, configured);
+
+        // Legacy Databricks must advertise exactly the configured model — nothing more.
+        assert_eq!(
+            result.len(),
+            1,
+            "legacy Databricks fallback must contain exactly one entry, got: {result:?}"
         );
-        // v2 model IDs include family name + version (e.g. "databricks-claude-opus-4-7",
-        // "databricks-meta-llama-4-maverick"). None should look like a bare serving endpoint
-        // name (which would not include a vendor/family prefix like "databricks-").
-        for id in DATABRICKS_V2_KNOWN_MODELS {
+        assert_eq!(
+            result[0].id, configured,
+            "legacy Databricks fallback must be the configured model"
+        );
+
+        // Crucially: must NOT contain any DATABRICKS_V2_KNOWN_MODELS entry.
+        let v2_ids: Vec<&str> = DATABRICKS_V2_KNOWN_MODELS.to_vec();
+        for id in &result {
             assert!(
-                id.contains('-'),
-                "v2 model ID {id:?} must contain a hyphen (AI Gateway v2 format)"
+                !v2_ids.contains(&id.id.as_str()),
+                "legacy Databricks fallback must not include v2 ID '{}' — that endpoint \
+                 may not be served by /serving-endpoints/{{model}}/invocations",
+                id.id
             );
         }
+    }
+
+    #[test]
+    fn databricks_discovery_failure_fallback_v2_returns_known_models_catalog() {
+        let configured = "my-configured-model";
+        let result = discovery_failure_fallback(Provider::DatabricksV2, configured);
+
+        // DatabricksV2 must return the full DATABRICKS_V2_KNOWN_MODELS list.
+        assert_eq!(
+            result.len(),
+            DATABRICKS_V2_KNOWN_MODELS.len(),
+            "DatabricksV2 fallback must return all known models"
+        );
+        let result_ids: Vec<&str> = result.iter().map(|m| m.id.as_str()).collect();
+        for known_id in DATABRICKS_V2_KNOWN_MODELS {
+            assert!(
+                result_ids.contains(known_id),
+                "DatabricksV2 fallback must include known model '{known_id}'"
+            );
+        }
+    }
+
+    #[test]
+    fn databricks_discovery_failure_fallback_split_verified() {
+        // This test FAILS if the v1/v2 arms are merged back into one — it directly verifies
+        // that the two providers' error-path behavior diverges (Wes W1 protection).
+        let v1 = discovery_failure_fallback(Provider::Databricks, "my-endpoint");
+        let v2 = discovery_failure_fallback(Provider::DatabricksV2, "my-endpoint");
+
+        let v1_ids: Vec<&str> = v1.iter().map(|m| m.id.as_str()).collect();
+        let v2_ids: Vec<&str> = v2.iter().map(|m| m.id.as_str()).collect();
+
+        assert_ne!(
+            v1_ids, v2_ids,
+            "Provider::Databricks and Provider::DatabricksV2 must return different \
+             fallback catalogs — if they are equal, the W1 arm split has been reverted"
+        );
     }
 }

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -31,14 +31,19 @@ use crate::mcp::McpRegistry;
 use crate::types::{ContentBlock, HistoryItem};
 use crate::wire::{
     classify, Inbound, InitializeParams, SessionCancelParams, SessionNewParams,
-    SessionPromptParams, SessionSteerParams, WireMsg, WireSender, INVALID_PARAMS, METHOD_NOT_FOUND,
-    PARSE_ERROR,
+    SessionPromptParams, SessionSetModelParams, SessionSteerParams, WireMsg, WireSender,
+    INVALID_PARAMS, METHOD_NOT_FOUND, PARSE_ERROR,
 };
 
 struct App {
     cfg: Config,
     llm: Arc<Llm>,
     sessions: Mutex<HashMap<String, Session>>,
+    /// Cached model catalog for Databricks providers. Populated lazily on the
+    /// first `session/new` call. `None` means discovery hasn't run yet or the
+    /// provider is not Databricks; an empty vec means discovery ran but returned
+    /// no models (auth missing or list empty).
+    models_cache: tokio::sync::OnceCell<Vec<ModelEntry>>,
 }
 
 struct Session {
@@ -71,6 +76,10 @@ struct Session {
     /// with it so the gate can account for history appended since.
     last_request_history_bytes: Option<usize>,
     effective_system_prompt: Arc<str>,
+    /// Per-session model override set by `session/set_model`. When `Some`,
+    /// overrides `App::cfg.model` for all LLM calls on this session. Persists
+    /// across `session/prompt` calls until changed.
+    effective_model: Option<String>,
 }
 
 fn die(msg: String) -> ! {
@@ -135,6 +144,7 @@ async fn async_main() {
         cfg,
         llm,
         sessions: Mutex::new(HashMap::new()),
+        models_cache: tokio::sync::OnceCell::new(),
     });
     let (wire_tx, wire_rx) = mpsc::channel::<WireMsg>(64);
     let writer = tokio::spawn(wire::writer_task(wire_rx));
@@ -206,6 +216,9 @@ async fn handle_request(
             tokio::spawn(async move { session_new(&app, id, params, &wire_tx).await });
         }
         "session/prompt" => spawn_prompt(app.clone(), id, params, wire_tx.clone()),
+        "session/set_model" => {
+            set_model_session(app, id, params, wire_tx).await;
+        }
         "session/cancel" => {
             cancel_session(app, params).await;
             wire::send(wire_tx, wire::ok(id, Value::Null)).await;
@@ -365,10 +378,63 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
             last_request_input_tokens: None,
             last_request_history_bytes: None,
             effective_system_prompt,
+            effective_model: None,
         },
     );
     drop(sessions);
-    wire::send(wire_tx, wire::ok(id, json!({ "sessionId": session_id }))).await;
+
+    // Build a models catalog for the `session/new` response. For Databricks
+    // providers this advertises available models so the desktop ModelPicker and
+    // pool can resolve `session/set_model` switches. For Anthropic/OpenAI we
+    // report only the configured model — live switching on those providers
+    // effectively requires respawn.
+    let available_models: Vec<Value> = {
+        use crate::config::Provider;
+        match app.cfg.provider {
+            Provider::Databricks | Provider::DatabricksV2 => {
+                let entries = app
+                    .models_cache
+                    .get_or_init(|| async {
+                        match discover_databricks_models(&app.cfg).await {
+                            Ok(models) => models,
+                            Err(e) => {
+                                tracing::warn!("model catalog discovery failed: {e}; using known-models fallback");
+                                // Fall back to the statically-known models list so the
+                                // response is never empty even without a browser token.
+                                DATABRICKS_V2_KNOWN_MODELS
+                                    .iter()
+                                    .map(|id| crate::catalog::ModelEntry {
+                                        id: id.to_string(),
+                                        name: id.to_string(),
+                                    })
+                                    .collect()
+                            }
+                        }
+                    })
+                    .await;
+                entries
+                    .iter()
+                    .map(|m| json!({ "modelId": m.id, "name": m.name }))
+                    .collect()
+            }
+            _ => vec![json!({ "modelId": app.cfg.model, "name": app.cfg.model })],
+        }
+    };
+
+    wire::send(
+        wire_tx,
+        wire::ok(
+            id,
+            json!({
+                "sessionId": session_id,
+                "models": {
+                    "currentModelId": app.cfg.model,
+                    "availableModels": available_models,
+                },
+            }),
+        ),
+    )
+    .await;
 }
 
 fn decode<T: serde::de::DeserializeOwned>(params: Value, stage: &str) -> Result<T, String> {
@@ -385,6 +451,46 @@ async fn cancel_session(app: &Arc<App>, params: Value) {
             let _ = s.cancel_tx.send(true);
         }
     }
+}
+
+/// Handle `session/set_model`: apply a per-session model override immediately.
+///
+/// Validation:
+/// - Unknown `sessionId` → `invalid_params`.
+/// - Empty `modelId` → `invalid_params`.
+///
+/// On success: stores `model_id` on the session and responds `{ sessionId, modelId }`.
+/// The override is picked up by the next `session/prompt` call on this session.
+async fn set_model_session(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSender) {
+    let p: SessionSetModelParams = match decode(params, "session/set_model") {
+        Ok(p) => p,
+        Err(m) => return reject(wire_tx, id, INVALID_PARAMS, &m).await,
+    };
+    if p.model_id.trim().is_empty() {
+        return reject(
+            wire_tx,
+            id,
+            INVALID_PARAMS,
+            "session/set_model: modelId must not be empty",
+        )
+        .await;
+    }
+    let mut sessions = app.sessions.lock().await;
+    let Some(s) = sessions.get_mut(&p.session_id) else {
+        return reject(wire_tx, id, INVALID_PARAMS, "session/set_model: unknown session").await;
+    };
+    s.effective_model = Some(p.model_id.clone());
+    tracing::info!(
+        session_id = %p.session_id,
+        model_id = %p.model_id,
+        "session/set_model: model overridden"
+    );
+    drop(sessions);
+    wire::send(
+        wire_tx,
+        wire::ok(id, json!({ "sessionId": p.session_id, "modelId": p.model_id })),
+    )
+    .await;
 }
 
 /// Handle `_goose/unstable/session/steer`: queue user input into the in-flight
@@ -487,6 +593,7 @@ async fn run_prompt(app: Arc<App>, id: Value, params: Value, wire_tx: WireSender
         mut last_request_history_bytes,
         mut cancel_rx,
         effective_system_prompt,
+        effective_model_override,
         run_id,
         mut steer_rx,
     ) = match acquire_session(&app, &p.session_id).await {
@@ -512,8 +619,13 @@ async fn run_prompt(app: Arc<App>, id: Value, params: Value, wire_tx: WireSender
         ),
     )
     .await;
+    // Resolve effective model: session override wins over config default.
+    let effective_model_str = effective_model_override
+        .as_deref()
+        .unwrap_or(&app.cfg.model);
     let mut ctx = RunCtx {
         cfg: &app.cfg,
+        effective_model: effective_model_str,
         session_id: &sid,
         system_prompt: &effective_system_prompt,
         llm: &app.llm,
@@ -570,6 +682,7 @@ async fn acquire_session(
         Option<usize>,
         watch::Receiver<bool>,
         Arc<str>,
+        Option<String>,
         String,
         mpsc::UnboundedReceiver<Vec<ContentBlock>>,
     ),
@@ -593,6 +706,7 @@ async fn acquire_session(
     s.active_run_id = Some(run_id.clone());
     let (steer_tx, steer_rx) = mpsc::unbounded_channel();
     s.steer_tx = Some(steer_tx);
+    let effective_model = s.effective_model.clone();
     Ok((
         s.id.clone(),
         s.mcp.clone(),
@@ -605,6 +719,7 @@ async fn acquire_session(
         s.last_request_history_bytes,
         rx,
         Arc::clone(&s.effective_system_prompt),
+        effective_model,
         run_id,
         steer_rx,
     ))

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -388,55 +388,33 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
     // pool can resolve `session/set_model` switches. For Anthropic/OpenAI we
     // report only the configured model — live switching on those providers
     // effectively requires respawn.
+    //
+    // `models_cache` caches only a successful discovery result (`get_or_try_init`
+    // leaves the cell empty on error so the next `session/new` call retries). On
+    // discovery failure the fallback is used for the immediate response without
+    // being written to the cell.
     let available_models: Vec<Value> = {
         use crate::config::Provider;
         match app.cfg.provider {
-            Provider::DatabricksV2 => {
-                // AI Gateway v2 supports model switching across the published catalog.
-                // On discovery failure, fall back to the statically-known v2 model IDs
-                // so the response is never empty even without a browser token.
-                let entries = app
+            Provider::Databricks | Provider::DatabricksV2 => {
+                // Try to get a previously-cached successful discovery result; if the cell is
+                // empty, run discovery now. `get_or_try_init` only populates the cell on `Ok`
+                // — an `Err` leaves it empty so the next session retries rather than
+                // re-serving a stale transient-failure fallback forever.
+                let models = match app
                     .models_cache
-                    .get_or_init(|| async {
-                        match discover_databricks_models(&app.cfg).await {
-                            Ok(models) => models,
-                            Err(e) => {
-                                tracing::warn!("model catalog discovery failed: {e}; using known-models fallback");
-                                crate::catalog::discovery_failure_fallback(
-                                    app.cfg.provider,
-                                    &app.cfg.model,
-                                )
-                            }
-                        }
-                    })
-                    .await;
-                entries
-                    .iter()
-                    .map(|m| json!({ "modelId": m.id, "name": m.name }))
-                    .collect()
-            }
-            Provider::Databricks => {
-                // Legacy Databricks model serving routes to a single endpoint per model.
-                // The DATABRICKS_V2_KNOWN_MODELS list is AI Gateway v2 IDs that
-                // `/serving-endpoints/{model}/invocations` may not serve — do not advertise
-                // them for legacy Databricks. On discovery failure, advertise only the
-                // configured model.
-                let entries = app
-                    .models_cache
-                    .get_or_init(|| async {
-                        match discover_databricks_models(&app.cfg).await {
-                            Ok(models) => models,
-                            Err(e) => {
-                                tracing::warn!("model catalog discovery failed: {e}; advertising configured model only");
-                                crate::catalog::discovery_failure_fallback(
-                                    app.cfg.provider,
-                                    &app.cfg.model,
-                                )
-                            }
-                        }
-                    })
-                    .await;
-                entries
+                    .get_or_try_init(|| async { discover_databricks_models(&app.cfg).await })
+                    .await
+                {
+                    Ok(cached) => cached.clone(),
+                    Err(e) => {
+                        tracing::warn!(
+                            "model catalog discovery failed: {e}; using fallback (will retry next session)"
+                        );
+                        crate::catalog::discovery_failure_fallback(app.cfg.provider, &app.cfg.model)
+                    }
+                };
+                models
                     .iter()
                     .map(|m| json!({ "modelId": m.id, "name": m.name }))
                     .collect()
@@ -768,6 +746,40 @@ fn session_token() -> Result<String, String> {
 mod tests {
     use crate::catalog::{discovery_failure_fallback, DATABRICKS_V2_KNOWN_MODELS};
     use crate::config::Provider;
+
+    /// Regression: discovery errors must not pin the models_cache for the process lifetime.
+    ///
+    /// `session_new` uses `get_or_try_init` so an `Err` leaves the `OnceCell` empty and a
+    /// subsequent `session/new` call retries discovery. This test verifies that contract
+    /// directly against `tokio::sync::OnceCell` — the same type used in `AppState`.
+    #[tokio::test]
+    async fn models_cache_does_not_pin_on_discovery_error() {
+        let cell: tokio::sync::OnceCell<Vec<String>> = tokio::sync::OnceCell::new();
+
+        // First call — discovery fails. Cell must remain empty.
+        let first = cell
+            .get_or_try_init(|| async { Err::<Vec<String>, &str>("transient failure") })
+            .await;
+        assert!(first.is_err(), "get_or_try_init must propagate the error");
+        assert!(
+            cell.get().is_none(),
+            "cell must be empty after an error — discovery retry will be attempted next session"
+        );
+
+        // Second call — discovery succeeds. Cell is now populated.
+        let second = cell
+            .get_or_try_init(|| async { Ok::<Vec<String>, &str>(vec!["model-a".to_string()]) })
+            .await;
+        assert_eq!(
+            second.unwrap(),
+            &["model-a"],
+            "second call must succeed and populate cell"
+        );
+        assert!(
+            cell.get().is_some(),
+            "cell must be populated after a successful discovery"
+        );
+    }
 
     /// Regression: legacy `Provider::Databricks` must not advertise v2 AI Gateway model IDs
     /// on discovery failure (Wes W1). This test calls `discovery_failure_fallback` directly —

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -769,7 +769,6 @@ fn session_token() -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::catalog::DATABRICKS_V2_KNOWN_MODELS;
 
     /// Regression: legacy `Provider::Databricks` must not advertise v2 AI Gateway model IDs

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -1648,7 +1648,28 @@ mod tests {
 
     #[test]
     fn anthropic_body_emits_adaptive_thinking_for_opus_4() {
-        // Adaptive Claude (claude-opus-4-*) → thinking:{type:"adaptive"} + output_config.effort.
+        // Adaptive Claude (claude-opus-4-6/4.7/4.8) → thinking:{type:"adaptive"} + output_config.effort.
+        // Note: Opus 4.5 is NOT adaptive — it uses manual budget.
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 32_768;
+        let body = anthropic_body(
+            &c,
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-opus-4-7",
+            Some(ThinkingEffort::High),
+        );
+        assert_eq!(
+            body["thinking"]["type"], "adaptive",
+            "thinking must be {{type:adaptive}} for claude-opus-4-7"
+        );
+        assert_eq!(body["output_config"]["effort"], "high");
+    }
+
+    #[test]
+    fn anthropic_body_emits_manual_budget_for_opus_4_5() {
+        // Opus 4.5 uses manual budget (effort page: "uses manual thinking").
         let mut c = cfg(Provider::Anthropic);
         c.max_output_tokens = 32_768;
         let body = anthropic_body(
@@ -1659,11 +1680,12 @@ mod tests {
             "claude-opus-4-5",
             Some(ThinkingEffort::High),
         );
-        assert_eq!(
-            body["thinking"]["type"], "adaptive",
-            "thinking must be {{type:adaptive}} for claude-opus-4-5"
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["thinking"]["budget_tokens"], 32_767); // capped: min(32768, 32768-1)
+        assert!(
+            body.get("output_config").is_none(),
+            "output_config must be absent for claude-opus-4-5 (manual budget)"
         );
-        assert_eq!(body["output_config"]["effort"], "high");
     }
 
     #[test]
@@ -1766,6 +1788,96 @@ mod tests {
             None,
         );
         assert_eq!(body["model"], "override-model");
+    }
+
+    #[test]
+    fn anthropic_body_opus_4_8_xhigh_emits_xhigh_effort() {
+        // Body-shape regression: xhigh on Opus 4.8 must emit output_config.effort="xhigh".
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 32_768;
+        let body = anthropic_body(
+            &c,
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-opus-4-8",
+            Some(ThinkingEffort::XHigh),
+        );
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"], "xhigh");
+    }
+
+    #[test]
+    fn anthropic_body_opus_4_8_max_emits_max_effort() {
+        // Body-shape regression: max on Opus 4.8 must emit output_config.effort="max".
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 32_768;
+        let body = anthropic_body(
+            &c,
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-opus-4-8",
+            Some(ThinkingEffort::Max),
+        );
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"], "max");
+    }
+
+    #[test]
+    fn openai_body_emits_xhigh_effort() {
+        // xhigh is a valid OpenAI effort value — must pass through.
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "model",
+            Some(ThinkingEffort::XHigh),
+        );
+        assert_eq!(body["reasoning_effort"], "xhigh");
+    }
+
+    #[test]
+    fn openai_body_emits_none_effort() {
+        // none is a valid OpenAI effort value.
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "model",
+            Some(ThinkingEffort::None),
+        );
+        assert_eq!(body["reasoning_effort"], "none");
+    }
+
+    #[test]
+    fn responses_body_emits_xhigh_effort() {
+        // xhigh is a valid Responses API effort value.
+        let body = responses_body(
+            &cfg_responses(),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "model",
+            Some(ThinkingEffort::XHigh),
+        );
+        assert_eq!(body["reasoning"]["effort"], "xhigh");
+    }
+
+    #[test]
+    fn responses_body_emits_minimal_effort() {
+        // minimal is a valid Responses API effort value.
+        let body = responses_body(
+            &cfg_responses(),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "model",
+            Some(ThinkingEffort::Minimal),
+        );
+        assert_eq!(body["reasoning"]["effort"], "minimal");
     }
 
     /// Regression: a connection that is accepted and then dropped before any

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 use serde_json::{json, Value};
 
 use crate::auth::{PkceOAuthConfig, PkceOAuthTokenSource, StaticTokenSource, TokenSource};
-use crate::config::{is_openai_host, Config, OpenAiApi, Provider};
+use crate::config::{is_openai_host, Config, OpenAiApi, Provider, ThinkingEffort};
 use crate::types::{
     AgentError, HistoryItem, LlmResponse, ProviderStop, ToolCall, ToolDef, ToolResultContent,
 };
@@ -66,11 +66,16 @@ impl Llm {
         system_prompt: &str,
         history: &[HistoryItem],
         tools: &[ToolDef],
+        effective_model: &str,
     ) -> Result<LlmResponse, AgentError> {
+        let effort = cfg.thinking_effort;
         match cfg.provider {
             Provider::Anthropic => {
                 let v = self
-                    .post_anthropic(cfg, &anthropic_body(cfg, system_prompt, history, tools))
+                    .post_anthropic(
+                        cfg,
+                        &anthropic_body(cfg, system_prompt, history, tools, effective_model, effort),
+                    )
                     .await?;
                 parse_anthropic(v)
             }
@@ -78,12 +83,26 @@ impl Llm {
                 self.openai_request(cfg, |use_responses| {
                     if use_responses {
                         (
-                            responses_body(cfg, system_prompt, history, tools),
+                            responses_body(
+                                cfg,
+                                system_prompt,
+                                history,
+                                tools,
+                                effective_model,
+                                effort,
+                            ),
                             parse_responses as OpenAiParse,
                         )
                     } else {
                         (
-                            openai_body(cfg, system_prompt, history, tools),
+                            openai_body(
+                                cfg,
+                                system_prompt,
+                                history,
+                                tools,
+                                effective_model,
+                                effort,
+                            ),
                             parse_openai as OpenAiParse,
                         )
                     }
@@ -93,15 +112,36 @@ impl Llm {
             Provider::DatabricksV2 => {
                 self.databricks_v2_request(cfg, |route| match route {
                     DatabricksV2Route::OpenAiResponses => (
-                        responses_body(cfg, system_prompt, history, tools),
+                        responses_body(
+                            cfg,
+                            system_prompt,
+                            history,
+                            tools,
+                            effective_model,
+                            effort,
+                        ),
                         parse_responses as OpenAiParse,
                     ),
                     DatabricksV2Route::AnthropicMessages => (
-                        anthropic_body(cfg, system_prompt, history, tools),
+                        anthropic_body(
+                            cfg,
+                            system_prompt,
+                            history,
+                            tools,
+                            effective_model,
+                            effort,
+                        ),
                         parse_anthropic as OpenAiParse,
                     ),
                     DatabricksV2Route::MlflowChatCompletions => (
-                        openai_body(cfg, system_prompt, history, tools),
+                        openai_body(
+                            cfg,
+                            system_prompt,
+                            history,
+                            tools,
+                            effective_model,
+                            effort,
+                        ),
                         parse_openai as OpenAiParse,
                     ),
                 })
@@ -116,11 +156,12 @@ impl Llm {
         system_prompt: &str,
         user_prompt: &str,
         max_output_tokens: u32,
+        effective_model: &str,
     ) -> Result<String, AgentError> {
         match cfg.provider {
             Provider::Anthropic => {
                 let body = json!({
-                    "model": cfg.model,
+                    "model": effective_model,
                     "max_tokens": max_output_tokens,
                     "system": system_prompt,
                     "messages": [{
@@ -136,7 +177,7 @@ impl Llm {
                         if use_responses {
                             (
                                 json!({
-                                    "model": cfg.model,
+                                    "model": effective_model,
                                     "max_output_tokens": max_output_tokens,
                                     "instructions": system_prompt,
                                     "input": user_prompt,
@@ -146,7 +187,7 @@ impl Llm {
                         } else {
                             (
                                 json!({
-                                    "model": cfg.model,
+                                    "model": effective_model,
                                     "stream": false,
                                     "max_completion_tokens": max_output_tokens,
                                     "messages": [
@@ -166,7 +207,7 @@ impl Llm {
                     .databricks_v2_request(cfg, |route| match route {
                         DatabricksV2Route::OpenAiResponses => (
                             json!({
-                                "model": cfg.model,
+                                "model": effective_model,
                                 "max_output_tokens": max_output_tokens,
                                 "instructions": system_prompt,
                                 "input": user_prompt,
@@ -175,7 +216,7 @@ impl Llm {
                         ),
                         DatabricksV2Route::AnthropicMessages => (
                             json!({
-                                "model": cfg.model,
+                                "model": effective_model,
                                 "max_tokens": max_output_tokens,
                                 "system": system_prompt,
                                 "messages": [{
@@ -187,7 +228,7 @@ impl Llm {
                         ),
                         DatabricksV2Route::MlflowChatCompletions => (
                             json!({
-                                "model": cfg.model,
+                                "model": effective_model,
                                 "stream": false,
                                 "max_completion_tokens": max_output_tokens,
                                 "messages": [
@@ -330,6 +371,8 @@ fn anthropic_body(
     system_prompt: &str,
     history: &[HistoryItem],
     tools: &[ToolDef],
+    effective_model: &str,
+    effort: Option<ThinkingEffort>,
 ) -> Value {
     let mut messages: Vec<Value> = Vec::new();
     let mut pending: Vec<Value> = Vec::new();
@@ -377,8 +420,14 @@ fn anthropic_body(
         "name": t.name, "description": t.description, "input_schema": t.input_schema })
         })
         .collect();
-    let mut body = json!({ "model": cfg.model, "max_tokens": cfg.max_output_tokens,
+    let mut body = json!({ "model": effective_model, "max_tokens": cfg.max_output_tokens,
         "system": system_prompt, "messages": messages });
+    if let Some(e) = effort {
+        body["thinking"] = json!({
+            "type": "enabled",
+            "budget_tokens": e.anthropic_budget_tokens(),
+        });
+    }
     if !tools_json.is_empty() {
         body["tools"] = Value::Array(tools_json);
     }
@@ -403,6 +452,8 @@ fn openai_body(
     system_prompt: &str,
     history: &[HistoryItem],
     tools: &[ToolDef],
+    effective_model: &str,
+    effort: Option<ThinkingEffort>,
 ) -> Value {
     let mut messages: Vec<Value> = vec![json!({ "role": "system", "content": system_prompt })];
     // Images returned from tool calls ride on a trailing `role:"user"`
@@ -463,8 +514,11 @@ fn openai_body(
             "parameters": t.input_schema } })
         })
         .collect();
-    let mut body = json!({ "model": cfg.model, "stream": false,
+    let mut body = json!({ "model": effective_model, "stream": false,
         "max_completion_tokens": cfg.max_output_tokens, "messages": messages });
+    if let Some(e) = effort {
+        body["reasoning_effort"] = json!(e.openai_effort_str());
+    }
     if !tools_json.is_empty() {
         body["tools"] = Value::Array(tools_json);
         body["tool_choice"] = json!("auto");
@@ -511,6 +565,8 @@ fn responses_body(
     system_prompt: &str,
     history: &[HistoryItem],
     tools: &[ToolDef],
+    effective_model: &str,
+    effort: Option<ThinkingEffort>,
 ) -> Value {
     let mut input: Vec<Value> = Vec::with_capacity(history.len());
     for item in history {
@@ -574,11 +630,14 @@ fn responses_body(
         .collect();
 
     let mut body = json!({
-        "model": cfg.model,
+        "model": effective_model,
         "instructions": system_prompt,
         "max_output_tokens": cfg.max_output_tokens,
         "input": input,
     });
+    if let Some(e) = effort {
+        body["reasoning"] = json!({ "effort": e.openai_effort_str() });
+    }
     if !tools_json.is_empty() {
         body["tools"] = Value::Array(tools_json);
         body["tool_choice"] = json!("auto");
@@ -1106,6 +1165,7 @@ mod tests {
             anthropic_api_version: "2023-06-01".into(),
             openai_api: OpenAiApi::Chat,
             hints_enabled: true,
+            thinking_effort: None,
         }
     }
 
@@ -1136,7 +1196,7 @@ mod tests {
 
     #[test]
     fn anthropic_tool_result_preserves_image_block() {
-        let body = anthropic_body(&cfg(Provider::Anthropic), "system", &image_history(), &[]);
+        let body = anthropic_body(&cfg(Provider::Anthropic), "system", &image_history(), &[], "model", None);
         let content = &body["messages"][2]["content"][0]["content"];
         assert_eq!(content[0]["type"], "text");
         assert_eq!(content[1]["type"], "image");
@@ -1185,6 +1245,8 @@ mod tests {
             "system",
             &[HistoryItem::User("hi".into())],
             &tools,
+            "model",
+            None,
         );
         assert_eq!(body["model"], "model");
         assert_eq!(body["instructions"], "system");
@@ -1213,7 +1275,7 @@ mod tests {
         // function_call item *must* appear in `input[]` before its matching
         // function_call_output, otherwise the API rejects with
         // "No tool call found for call_id ...".
-        let body = responses_body(&cfg_responses(), "system", &tool_call_history(), &[]);
+        let body = responses_body(&cfg_responses(), "system", &tool_call_history(), &[], "model", None);
         let input = body["input"].as_array().unwrap();
 
         // [0] user, [1] assistant text, [2] function_call, [3] function_call_output
@@ -1252,7 +1314,7 @@ mod tests {
                 }],
             },
         ];
-        let body = responses_body(&cfg_responses(), "system", &history, &[]);
+        let body = responses_body(&cfg_responses(), "system", &history, &[], "model", None);
         let input = body["input"].as_array().unwrap();
         assert_eq!(input.len(), 2);
         assert_eq!(input[0]["role"], "user");
@@ -1261,7 +1323,7 @@ mod tests {
 
     #[test]
     fn responses_body_image_tool_result_attaches_input_image() {
-        let body = responses_body(&cfg_responses(), "system", &image_history(), &[]);
+        let body = responses_body(&cfg_responses(), "system", &image_history(), &[], "model", None);
         let input = body["input"].as_array().unwrap();
         // function_call_output carries the text part; image rides on a
         // trailing user message as `input_image`.
@@ -1388,7 +1450,7 @@ mod tests {
 
     #[test]
     fn openai_tool_result_adds_followup_image_user_message() {
-        let body = openai_body(&cfg(Provider::OpenAi), "system", &image_history(), &[]);
+        let body = openai_body(&cfg(Provider::OpenAi), "system", &image_history(), &[], "model", None);
         assert_eq!(body["messages"][3]["role"], "tool");
         assert!(body["messages"][3]["content"]
             .as_str()
@@ -1459,7 +1521,7 @@ mod tests {
                 is_error: false,
             }),
         ];
-        let body = openai_body(&cfg(Provider::OpenAi), "system", &history, &[]);
+        let body = openai_body(&cfg(Provider::OpenAi), "system", &history, &[], "model", None);
         let messages = body["messages"].as_array().unwrap();
         // [0] system, [1] user, [2] assistant(tool_calls), [3] tool A, [4] tool B, [5] user(images)
         assert_eq!(messages.len(), 6, "messages: {messages:#?}");
@@ -1475,6 +1537,135 @@ mod tests {
         assert_eq!(imgs.len(), 2);
         assert_eq!(imgs[0]["image_url"]["url"], "data:image/png;base64,aaa");
         assert_eq!(imgs[1]["image_url"]["url"], "data:image/png;base64,bbb");
+    }
+
+    // ---- ThinkingEffort body-shape tests ----
+
+    #[test]
+    fn anthropic_body_omits_thinking_when_effort_none() {
+        let body = anthropic_body(
+            &cfg(Provider::Anthropic),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "model",
+            None,
+        );
+        assert!(
+            body.get("thinking").is_none(),
+            "thinking must be absent when effort is None"
+        );
+    }
+
+    #[test]
+    fn anthropic_body_emits_thinking_when_effort_high() {
+        let body = anthropic_body(
+            &cfg(Provider::Anthropic),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-3-7-sonnet-20250219",
+            Some(ThinkingEffort::High),
+        );
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["thinking"]["budget_tokens"], 32_768);
+    }
+
+    #[test]
+    fn anthropic_body_emits_thinking_low_budget() {
+        let body = anthropic_body(
+            &cfg(Provider::Anthropic),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-3-7-sonnet-20250219",
+            Some(ThinkingEffort::Low),
+        );
+        assert_eq!(body["thinking"]["budget_tokens"], 1_024);
+    }
+
+    #[test]
+    fn openai_body_omits_reasoning_effort_when_none() {
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "model",
+            None,
+        );
+        assert!(
+            body.get("reasoning_effort").is_none(),
+            "reasoning_effort must be absent when effort is None"
+        );
+    }
+
+    #[test]
+    fn openai_body_emits_reasoning_effort_medium() {
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "model",
+            Some(ThinkingEffort::Medium),
+        );
+        assert_eq!(body["reasoning_effort"], "medium");
+    }
+
+    #[test]
+    fn responses_body_omits_reasoning_when_effort_none() {
+        let body = responses_body(
+            &cfg_responses(),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "model",
+            None,
+        );
+        assert!(
+            body.get("reasoning").is_none(),
+            "reasoning must be absent when effort is None"
+        );
+    }
+
+    #[test]
+    fn responses_body_emits_reasoning_effort_low() {
+        let body = responses_body(
+            &cfg_responses(),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "model",
+            Some(ThinkingEffort::Low),
+        );
+        assert_eq!(body["reasoning"]["effort"], "low");
+    }
+
+    #[test]
+    fn effective_model_overrides_cfg_model_in_anthropic_body() {
+        let body = anthropic_body(
+            &cfg(Provider::Anthropic),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "override-model",
+            None,
+        );
+        assert_eq!(body["model"], "override-model");
+    }
+
+    #[test]
+    fn effective_model_overrides_cfg_model_in_openai_body() {
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "override-model",
+            None,
+        );
+        assert_eq!(body["model"], "override-model");
     }
 
     /// Regression: a connection that is accepted and then dropped before any

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -74,13 +74,20 @@ impl Llm {
                 let v = self
                     .post_anthropic(
                         cfg,
-                        &anthropic_body(cfg, system_prompt, history, tools, effective_model, effort),
+                        &anthropic_body(
+                            cfg,
+                            system_prompt,
+                            history,
+                            tools,
+                            effective_model,
+                            effort,
+                        ),
                     )
                     .await?;
                 parse_anthropic(v)
             }
             Provider::OpenAi | Provider::Databricks => {
-                self.openai_request(cfg, |use_responses| {
+                self.openai_request(cfg, effective_model, |use_responses| {
                     if use_responses {
                         (
                             responses_body(
@@ -110,38 +117,17 @@ impl Llm {
                 .await
             }
             Provider::DatabricksV2 => {
-                self.databricks_v2_request(cfg, |route| match route {
+                self.databricks_v2_request(cfg, effective_model, |route| match route {
                     DatabricksV2Route::OpenAiResponses => (
-                        responses_body(
-                            cfg,
-                            system_prompt,
-                            history,
-                            tools,
-                            effective_model,
-                            effort,
-                        ),
+                        responses_body(cfg, system_prompt, history, tools, effective_model, effort),
                         parse_responses as OpenAiParse,
                     ),
                     DatabricksV2Route::AnthropicMessages => (
-                        anthropic_body(
-                            cfg,
-                            system_prompt,
-                            history,
-                            tools,
-                            effective_model,
-                            effort,
-                        ),
+                        anthropic_body(cfg, system_prompt, history, tools, effective_model, effort),
                         parse_anthropic as OpenAiParse,
                     ),
                     DatabricksV2Route::MlflowChatCompletions => (
-                        openai_body(
-                            cfg,
-                            system_prompt,
-                            history,
-                            tools,
-                            effective_model,
-                            effort,
-                        ),
+                        openai_body(cfg, system_prompt, history, tools, effective_model, effort),
                         parse_openai as OpenAiParse,
                     ),
                 })
@@ -173,7 +159,7 @@ impl Llm {
             }
             Provider::OpenAi | Provider::Databricks => {
                 let r = self
-                    .openai_request(cfg, |use_responses| {
+                    .openai_request(cfg, effective_model, |use_responses| {
                         if use_responses {
                             (
                                 json!({
@@ -204,7 +190,7 @@ impl Llm {
             }
             Provider::DatabricksV2 => {
                 let r = self
-                    .databricks_v2_request(cfg, |route| match route {
+                    .databricks_v2_request(cfg, effective_model, |route| match route {
                         DatabricksV2Route::OpenAiResponses => (
                             json!({
                                 "model": effective_model,
@@ -258,7 +244,12 @@ impl Llm {
     /// host), POST, and on `auto` retry once on Responses if the provider
     /// asks for it. `build` is called with `use_responses` so callers
     /// only construct the body actually needed.
-    async fn openai_request<F>(&self, cfg: &Config, mut build: F) -> Result<LlmResponse, AgentError>
+    async fn openai_request<F>(
+        &self,
+        cfg: &Config,
+        effective_model: &str,
+        mut build: F,
+    ) -> Result<LlmResponse, AgentError>
     where
         F: FnMut(bool) -> (Value, OpenAiParse) + Send,
     {
@@ -268,14 +259,21 @@ impl Llm {
 
         if use_responses {
             let (b, p) = build(true);
-            return p(self.post_openai(cfg, "/responses", &b).await?);
+            return p(self
+                .post_openai(cfg, "/responses", &b, effective_model)
+                .await?);
         }
         let (b, p) = build(false);
-        match self.post_openai(cfg, "/chat/completions", &b).await {
+        match self
+            .post_openai(cfg, "/chat/completions", &b, effective_model)
+            .await
+        {
             Ok(v) => p(v),
             Err(e) if cfg.openai_api == OpenAiApi::Auto && self.try_upgrade(&e) => {
                 let (b, p) = build(true);
-                p(self.post_openai(cfg, "/responses", &b).await?)
+                p(self
+                    .post_openai(cfg, "/responses", &b, effective_model)
+                    .await?)
             }
             Err(e) => Err(e),
         }
@@ -284,15 +282,16 @@ impl Llm {
     async fn databricks_v2_request<F>(
         &self,
         cfg: &Config,
+        effective_model: &str,
         build: F,
     ) -> Result<LlmResponse, AgentError>
     where
         F: FnOnce(DatabricksV2Route) -> (Value, OpenAiParse) + Send,
     {
-        let route = databricks_v2_route_for_model(&cfg.model);
+        let route = databricks_v2_route_for_model(effective_model);
         let (body, parse) = build(route);
         parse(
-            self.post_openai(cfg, databricks_v2_path(route), &body)
+            self.post_openai(cfg, databricks_v2_path(route), &body, effective_model)
                 .await?,
         )
     }
@@ -307,6 +306,7 @@ impl Llm {
         cfg: &Config,
         path: &str,
         body: &Value,
+        effective_model: &str,
     ) -> Result<Value, AgentError> {
         let (url, body_owned);
         let body_ref: &Value = match cfg.provider {
@@ -314,7 +314,7 @@ impl Llm {
                 url = format!(
                     "{}/serving-endpoints/{}/invocations",
                     cfg.base_url.trim_end_matches('/'),
-                    cfg.model
+                    effective_model
                 );
                 body_owned = strip_model(body);
                 &body_owned
@@ -423,10 +423,14 @@ fn anthropic_body(
     let mut body = json!({ "model": effective_model, "max_tokens": cfg.max_output_tokens,
         "system": system_prompt, "messages": messages });
     if let Some(e) = effort {
-        body["thinking"] = json!({
-            "type": "enabled",
-            "budget_tokens": e.anthropic_budget_tokens(),
-        });
+        let (thinking, output_config) =
+            crate::config::anthropic_thinking_config(effective_model, e, cfg.max_output_tokens);
+        if let Some(t) = thinking {
+            body["thinking"] = t;
+        }
+        if let Some(oc) = output_config {
+            body["output_config"] = oc;
+        }
     }
     if !tools_json.is_empty() {
         body["tools"] = Value::Array(tools_json);
@@ -1196,7 +1200,14 @@ mod tests {
 
     #[test]
     fn anthropic_tool_result_preserves_image_block() {
-        let body = anthropic_body(&cfg(Provider::Anthropic), "system", &image_history(), &[], "model", None);
+        let body = anthropic_body(
+            &cfg(Provider::Anthropic),
+            "system",
+            &image_history(),
+            &[],
+            "model",
+            None,
+        );
         let content = &body["messages"][2]["content"][0]["content"];
         assert_eq!(content[0]["type"], "text");
         assert_eq!(content[1]["type"], "image");
@@ -1275,7 +1286,14 @@ mod tests {
         // function_call item *must* appear in `input[]` before its matching
         // function_call_output, otherwise the API rejects with
         // "No tool call found for call_id ...".
-        let body = responses_body(&cfg_responses(), "system", &tool_call_history(), &[], "model", None);
+        let body = responses_body(
+            &cfg_responses(),
+            "system",
+            &tool_call_history(),
+            &[],
+            "model",
+            None,
+        );
         let input = body["input"].as_array().unwrap();
 
         // [0] user, [1] assistant text, [2] function_call, [3] function_call_output
@@ -1323,7 +1341,14 @@ mod tests {
 
     #[test]
     fn responses_body_image_tool_result_attaches_input_image() {
-        let body = responses_body(&cfg_responses(), "system", &image_history(), &[], "model", None);
+        let body = responses_body(
+            &cfg_responses(),
+            "system",
+            &image_history(),
+            &[],
+            "model",
+            None,
+        );
         let input = body["input"].as_array().unwrap();
         // function_call_output carries the text part; image rides on a
         // trailing user message as `input_image`.
@@ -1450,7 +1475,14 @@ mod tests {
 
     #[test]
     fn openai_tool_result_adds_followup_image_user_message() {
-        let body = openai_body(&cfg(Provider::OpenAi), "system", &image_history(), &[], "model", None);
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &image_history(),
+            &[],
+            "model",
+            None,
+        );
         assert_eq!(body["messages"][3]["role"], "tool");
         assert!(body["messages"][3]["content"]
             .as_str()
@@ -1521,7 +1553,14 @@ mod tests {
                 is_error: false,
             }),
         ];
-        let body = openai_body(&cfg(Provider::OpenAi), "system", &history, &[], "model", None);
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &history,
+            &[],
+            "model",
+            None,
+        );
         let messages = body["messages"].as_array().unwrap();
         // [0] system, [1] user, [2] assistant(tool_calls), [3] tool A, [4] tool B, [5] user(images)
         assert_eq!(messages.len(), 6, "messages: {messages:#?}");
@@ -1559,6 +1598,8 @@ mod tests {
 
     #[test]
     fn anthropic_body_emits_thinking_when_effort_high() {
+        // claude-3.x model → manual budget_tokens shape.
+        // max_output_tokens in cfg() is 1024; High budget (32768) gets capped to 1023.
         let body = anthropic_body(
             &cfg(Provider::Anthropic),
             "system",
@@ -1568,11 +1609,31 @@ mod tests {
             Some(ThinkingEffort::High),
         );
         assert_eq!(body["thinking"]["type"], "enabled");
+        // budget_tokens capped at max_output_tokens - 1 = 1023
+        assert_eq!(body["thinking"]["budget_tokens"], 1023);
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn anthropic_body_emits_thinking_high_uncapped_when_budget_fits() {
+        // When max_output_tokens is large enough, budget_tokens is not capped.
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 65_536;
+        let body = anthropic_body(
+            &c,
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-3-7-sonnet-20250219",
+            Some(ThinkingEffort::High),
+        );
         assert_eq!(body["thinking"]["budget_tokens"], 32_768);
     }
 
     #[test]
     fn anthropic_body_emits_thinking_low_budget() {
+        // Low budget (1024) fits inside max_output_tokens (1024) only if strictly <.
+        // min(1024, 1024-1) = 1023 — Low is capped when max_output_tokens == 1024.
         let body = anthropic_body(
             &cfg(Provider::Anthropic),
             "system",
@@ -1581,7 +1642,46 @@ mod tests {
             "claude-3-7-sonnet-20250219",
             Some(ThinkingEffort::Low),
         );
-        assert_eq!(body["thinking"]["budget_tokens"], 1_024);
+        // Low budget is exactly at the boundary — gets capped to max_output_tokens-1.
+        assert_eq!(body["thinking"]["budget_tokens"], 1023);
+    }
+
+    #[test]
+    fn anthropic_body_emits_output_config_effort_for_modern_claude() {
+        // Modern Claude (claude-4+, sonnet-5+) → `output_config.effort`; no budget_tokens.
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 32_768;
+        let body = anthropic_body(
+            &c,
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-opus-4-5",
+            Some(ThinkingEffort::High),
+        );
+        assert!(
+            body.get("thinking").is_none(),
+            "thinking must be absent for modern claude"
+        );
+        assert_eq!(body["output_config"]["effort"], "high");
+    }
+
+    #[test]
+    fn anthropic_body_omits_both_fields_for_unrecognized_model() {
+        // Non-Anthropic models (gpt-5, llama, etc.) → omit both fields rather than guess.
+        let body = anthropic_body(
+            &cfg(Provider::Anthropic),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "gpt-4o",
+            Some(ThinkingEffort::High),
+        );
+        assert!(body.get("thinking").is_none(), "thinking must be absent");
+        assert!(
+            body.get("output_config").is_none(),
+            "output_config must be absent"
+        );
     }
 
     #[test]
@@ -1952,7 +2052,7 @@ mod tests {
         c.base_url = base;
 
         let out = llm
-            .post_openai(&c, "/v1/x", &json!({}))
+            .post_openai(&c, "/v1/x", &json!({}), "model")
             .await
             .expect("retry with fresh token should succeed");
         assert_eq!(out, json!({ "ok": true }));
@@ -1960,7 +2060,10 @@ mod tests {
 
         // Second call's 401 must trigger its own refresh — the guard cannot
         // be a stored flag that an earlier turn already tripped.
-        let out2 = llm.post_openai(&c, "/v1/x", &json!({})).await.unwrap();
+        let out2 = llm
+            .post_openai(&c, "/v1/x", &json!({}), "model")
+            .await
+            .unwrap();
         assert_eq!(out2, json!({ "ok": true }));
         assert_eq!(
             auth.refreshes.load(Ordering::SeqCst),
@@ -1984,7 +2087,10 @@ mod tests {
         let mut c = cfg(Provider::OpenAi);
         c.base_url = base;
 
-        let err = llm.post_openai(&c, "/v1/x", &json!({})).await.unwrap_err();
+        let err = llm
+            .post_openai(&c, "/v1/x", &json!({}), "model")
+            .await
+            .unwrap_err();
         assert!(matches!(err, AgentError::LlmAuth(_)), "got {err:?}");
         assert_eq!(
             auth.refreshes.load(Ordering::SeqCst),
@@ -2009,7 +2115,10 @@ mod tests {
         let mut c = cfg(Provider::OpenAi);
         c.base_url = base;
 
-        let err = llm.post_openai(&c, "/v1/x", &json!({})).await.unwrap_err();
+        let err = llm
+            .post_openai(&c, "/v1/x", &json!({}), "model")
+            .await
+            .unwrap_err();
         assert!(matches!(err, AgentError::LlmAuth(_)), "got {err:?}");
         assert_eq!(
             auth.refreshes.load(Ordering::SeqCst),
@@ -2035,7 +2144,7 @@ mod tests {
         c.base_url = base;
 
         let out = llm
-            .post_openai(&c, "/v1/x", &json!({}))
+            .post_openai(&c, "/v1/x", &json!({}), "model")
             .await
             .expect("retry with fresh token should clear the 403");
         assert_eq!(out, json!({ "ok": true }));

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -91,28 +91,18 @@ impl Llm {
             }
             Provider::OpenAi | Provider::Databricks => {
                 self.openai_request(cfg, effective_model, |use_responses| {
+                    // Normalize effort for model-specific availability (per-model table; max is
+                    // already rejected at startup for pure OpenAI, but other per-model corrections
+                    // like none→minimal on gpt-5 base still apply).
+                    let e = effort.map(|ef| normalize_effort_for_openai_route(ef, effective_model));
                     if use_responses {
                         (
-                            responses_body(
-                                cfg,
-                                system_prompt,
-                                history,
-                                tools,
-                                effective_model,
-                                effort,
-                            ),
+                            responses_body(cfg, system_prompt, history, tools, effective_model, e),
                             parse_responses as OpenAiParse,
                         )
                     } else {
                         (
-                            openai_body(
-                                cfg,
-                                system_prompt,
-                                history,
-                                tools,
-                                effective_model,
-                                effort,
-                            ),
+                            openai_body(cfg, system_prompt, history, tools, effective_model, e),
                             parse_openai as OpenAiParse,
                         )
                     }
@@ -122,8 +112,9 @@ impl Llm {
             Provider::DatabricksV2 => {
                 self.databricks_v2_request(cfg, effective_model, |route| match route {
                     DatabricksV2Route::OpenAiResponses => {
-                        // OpenAI Responses path: normalize effort (max → xhigh).
-                        let e = effort.map(normalize_effort_for_openai_route);
+                        // OpenAI Responses path: normalize effort (max → xhigh, per-model table).
+                        let e =
+                            effort.map(|ef| normalize_effort_for_openai_route(ef, effective_model));
                         (
                             responses_body(cfg, system_prompt, history, tools, effective_model, e),
                             parse_responses as OpenAiParse,
@@ -138,8 +129,9 @@ impl Llm {
                         )
                     }
                     DatabricksV2Route::MlflowChatCompletions => {
-                        // MLflow Chat path (OpenAI-shaped): normalize effort (max → xhigh).
-                        let e = effort.map(normalize_effort_for_openai_route);
+                        // MLflow Chat path (OpenAI-shaped): normalize effort (max → xhigh, per-model table).
+                        let e =
+                            effort.map(|ef| normalize_effort_for_openai_route(ef, effective_model));
                         (
                             openai_body(cfg, system_prompt, history, tools, effective_model, e),
                             parse_openai as OpenAiParse,
@@ -1614,9 +1606,11 @@ mod tests {
     #[test]
     fn anthropic_body_emits_thinking_when_effort_high() {
         // claude-3.x model → manual budget_tokens shape.
-        // max_output_tokens in cfg() is 1024; High budget (32768) gets capped to 1023.
+        // Use max_output_tokens = 4096 so budget fits: headroom = 4096 - 1024 = 3072.
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 4096;
         let body = anthropic_body(
-            &cfg(Provider::Anthropic),
+            &c,
             "system",
             &[HistoryItem::User("hi".into())],
             &[],
@@ -1624,9 +1618,47 @@ mod tests {
             Some(ThinkingEffort::High),
         );
         assert_eq!(body["thinking"]["type"], "enabled");
-        // budget_tokens capped at max_output_tokens - 1 = 1023
-        assert_eq!(body["thinking"]["budget_tokens"], 1023);
+        // budget_tokens = min(32768, 4096-1024) = 3072
+        assert_eq!(body["thinking"]["budget_tokens"], 3072);
         assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn anthropic_body_omits_thinking_when_max_output_too_small() {
+        // max_output_tokens = 2047: headroom = 2047 - 1024 = 1023 < 1024 → omit thinking.
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 2047;
+        let body = anthropic_body(
+            &c,
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-3-7-sonnet-20250219",
+            Some(ThinkingEffort::High),
+        );
+        assert!(
+            body.get("thinking").is_none(),
+            "thinking must be omitted when max_output_tokens leaves < 1024 for budget"
+        );
+    }
+
+    #[test]
+    fn anthropic_body_emits_thinking_at_boundary_2048() {
+        // max_output_tokens = 2048: headroom = 2048 - 1024 = 1024 ≥ 1024 → emit.
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 2048;
+        let body = anthropic_body(
+            &c,
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-3-7-sonnet-20250219",
+            Some(ThinkingEffort::High),
+        );
+        let t = body
+            .get("thinking")
+            .expect("thinking must be present at boundary 2048");
+        assert_eq!(t["budget_tokens"], 1024); // min(32768, 2048-1024)
     }
 
     #[test]
@@ -1647,18 +1679,20 @@ mod tests {
 
     #[test]
     fn anthropic_body_emits_thinking_low_budget() {
-        // Low budget (1024) fits inside max_output_tokens (1024) only if strictly <.
-        // min(1024, 1024-1) = 1023 — Low is capped when max_output_tokens == 1024.
+        // Low budget (1024 tokens) exactly fits when max_output_tokens = 2048.
+        // headroom = 2048 - 1024 = 1024; min(1024, 1024) = 1024 ≥ 1024 → emit.
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 2048;
         let body = anthropic_body(
-            &cfg(Provider::Anthropic),
+            &c,
             "system",
             &[HistoryItem::User("hi".into())],
             &[],
             "claude-3-7-sonnet-20250219",
             Some(ThinkingEffort::Low),
         );
-        // Low budget is exactly at the boundary — gets capped to max_output_tokens-1.
-        assert_eq!(body["thinking"]["budget_tokens"], 1023);
+        // Low budget (1024) fits exactly at the boundary — emitted without capping.
+        assert_eq!(body["thinking"]["budget_tokens"], 1024);
     }
 
     #[test]
@@ -1685,6 +1719,7 @@ mod tests {
     #[test]
     fn anthropic_body_emits_manual_budget_for_opus_4_5() {
         // Opus 4.5 uses manual budget (effort page: "uses manual thinking").
+        // max_output_tokens = 32768; headroom = 32768 - 1024 = 31744; min(32768, 31744) = 31744.
         let mut c = cfg(Provider::Anthropic);
         c.max_output_tokens = 32_768;
         let body = anthropic_body(
@@ -1696,7 +1731,7 @@ mod tests {
             Some(ThinkingEffort::High),
         );
         assert_eq!(body["thinking"]["type"], "enabled");
-        assert_eq!(body["thinking"]["budget_tokens"], 32_767); // capped: min(32768, 32768-1)
+        assert_eq!(body["thinking"]["budget_tokens"], 31_744); // min(32768, 32768-1024)
         assert!(
             body.get("output_config").is_none(),
             "output_config must be absent for claude-opus-4-5 (manual budget)"
@@ -1904,27 +1939,30 @@ mod tests {
 
     #[test]
     fn dbv2_openai_route_max_effort_clamped_to_xhigh_in_responses_body() {
-        // DBv2 GPT-5 route: max → clamped to xhigh by normalize_effort_for_openai_route
-        // before reaching responses_body. The body must carry "xhigh", never "max".
-        let clamped = crate::config::normalize_effort_for_openai_route(ThinkingEffort::Max);
+        // DBv2 GPT-5.5 route: max → clamped to xhigh by normalize_effort_for_openai_route
+        // before reaching responses_body. gpt-5.5 supports xhigh so the final value is xhigh.
+        let clamped =
+            crate::config::normalize_effort_for_openai_route(ThinkingEffort::Max, "gpt-5.5");
         let body = responses_body(
             &cfg_responses(),
             "system",
             &[HistoryItem::User("hi".into())],
             &[],
-            "gpt-5",
+            "gpt-5.5",
             Some(clamped),
         );
         assert_eq!(
             body["reasoning"]["effort"], "xhigh",
-            "DBv2 GPT-5 route: max must be clamped to xhigh before responses_body"
+            "DBv2 GPT-5.5 route: max must be clamped to xhigh before responses_body"
         );
     }
 
     #[test]
     fn dbv2_mlflow_route_max_effort_clamped_to_xhigh_in_openai_body() {
-        // DBv2 MLflow route: max → clamped to xhigh by normalize_effort_for_openai_route.
-        let clamped = crate::config::normalize_effort_for_openai_route(ThinkingEffort::Max);
+        // DBv2 MLflow route (unknown model): max → clamped to xhigh by normalize_effort_for_openai_route.
+        // Unknown models pass through after the max→xhigh clamp.
+        let clamped =
+            crate::config::normalize_effort_for_openai_route(ThinkingEffort::Max, "llama-4");
         let body = openai_body(
             &cfg(Provider::OpenAi),
             "system",
@@ -1941,28 +1979,34 @@ mod tests {
 
     #[test]
     fn dbv2_openai_route_none_minimal_pass_through_in_responses_body() {
-        // DBv2 GPT-5 route: none and minimal are valid OpenAI effort values.
-        // normalize_effort_for_openai_route passes them through unchanged.
-        for effort in [ThinkingEffort::None, ThinkingEffort::Minimal] {
-            let normalized = crate::config::normalize_effort_for_openai_route(effort);
-            assert_eq!(
-                normalized, effort,
-                "OpenAI normalizer must not touch none/minimal"
-            );
-            let body = responses_body(
-                &cfg_responses(),
-                "system",
-                &[HistoryItem::User("hi".into())],
-                &[],
-                "gpt-5",
-                Some(normalized),
-            );
-            assert_eq!(
-                body["reasoning"]["effort"],
-                effort.openai_effort_str(),
-                "DBv2 GPT-5 route: {effort:?} must be emitted as-is"
-            );
-        }
+        // Verify that supported values pass through for the respective model families.
+        // gpt-5.5 supports none (but not minimal); gpt-5 base supports minimal (but not none).
+        let none_normalized =
+            crate::config::normalize_effort_for_openai_route(ThinkingEffort::None, "gpt-5.5");
+        assert_eq!(
+            none_normalized,
+            ThinkingEffort::None,
+            "OpenAI normalizer must not touch none for gpt-5.5"
+        );
+        let minimal_normalized =
+            crate::config::normalize_effort_for_openai_route(ThinkingEffort::Minimal, "gpt-5");
+        assert_eq!(
+            minimal_normalized,
+            ThinkingEffort::Minimal,
+            "OpenAI normalizer must not touch minimal for gpt-5 base"
+        );
+        let body = responses_body(
+            &cfg_responses(),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "gpt-5.5",
+            Some(none_normalized),
+        );
+        assert_eq!(
+            body["reasoning"]["effort"], "none",
+            "DBv2 GPT-5.5 route: none must be emitted as-is"
+        );
     }
 
     #[test]
@@ -2013,20 +2057,22 @@ mod tests {
         assert_eq!(thinking_before.unwrap()["type"], "adaptive");
         assert_eq!(oc_before.unwrap()["effort"], "max");
 
-        // After switch to GPT-5 route: normalize max → xhigh for responses_body
-        let clamped = crate::config::normalize_effort_for_openai_route(ThinkingEffort::Max);
+        // After switch to GPT-5.5 route: normalize max → xhigh for responses_body
+        // (gpt-5.5 supports xhigh, so the clamp result is xhigh, not further reduced)
+        let clamped =
+            crate::config::normalize_effort_for_openai_route(ThinkingEffort::Max, "gpt-5.5");
         assert_eq!(clamped, ThinkingEffort::XHigh);
         let body_after = responses_body(
             &cfg_responses(),
             "system",
             &[HistoryItem::User("hi".into())],
             &[],
-            "gpt-5",
+            "gpt-5.5",
             Some(clamped),
         );
         assert_eq!(
             body_after["reasoning"]["effort"], "xhigh",
-            "After set_model to GPT-5: max must be clamped to xhigh"
+            "After set_model to GPT-5.5: max must be clamped to xhigh"
         );
     }
 

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -5,7 +5,10 @@ use reqwest::Client;
 use serde_json::{json, Value};
 
 use crate::auth::{PkceOAuthConfig, PkceOAuthTokenSource, StaticTokenSource, TokenSource};
-use crate::config::{is_openai_host, Config, OpenAiApi, Provider, ThinkingEffort};
+use crate::config::{
+    is_openai_host, normalize_effort_for_anthropic_route, normalize_effort_for_openai_route,
+    Config, OpenAiApi, Provider, ThinkingEffort,
+};
 use crate::types::{
     AgentError, HistoryItem, LlmResponse, ProviderStop, ToolCall, ToolDef, ToolResultContent,
 };
@@ -118,18 +121,30 @@ impl Llm {
             }
             Provider::DatabricksV2 => {
                 self.databricks_v2_request(cfg, effective_model, |route| match route {
-                    DatabricksV2Route::OpenAiResponses => (
-                        responses_body(cfg, system_prompt, history, tools, effective_model, effort),
-                        parse_responses as OpenAiParse,
-                    ),
-                    DatabricksV2Route::AnthropicMessages => (
-                        anthropic_body(cfg, system_prompt, history, tools, effective_model, effort),
-                        parse_anthropic as OpenAiParse,
-                    ),
-                    DatabricksV2Route::MlflowChatCompletions => (
-                        openai_body(cfg, system_prompt, history, tools, effective_model, effort),
-                        parse_openai as OpenAiParse,
-                    ),
+                    DatabricksV2Route::OpenAiResponses => {
+                        // OpenAI Responses path: normalize effort (max → xhigh).
+                        let e = effort.map(normalize_effort_for_openai_route);
+                        (
+                            responses_body(cfg, system_prompt, history, tools, effective_model, e),
+                            parse_responses as OpenAiParse,
+                        )
+                    }
+                    DatabricksV2Route::AnthropicMessages => {
+                        // Anthropic Messages path: normalize effort (none|minimal → omit).
+                        let e = effort.and_then(normalize_effort_for_anthropic_route);
+                        (
+                            anthropic_body(cfg, system_prompt, history, tools, effective_model, e),
+                            parse_anthropic as OpenAiParse,
+                        )
+                    }
+                    DatabricksV2Route::MlflowChatCompletions => {
+                        // MLflow Chat path (OpenAI-shaped): normalize effort (max → xhigh).
+                        let e = effort.map(normalize_effort_for_openai_route);
+                        (
+                            openai_body(cfg, system_prompt, history, tools, effective_model, e),
+                            parse_openai as OpenAiParse,
+                        )
+                    }
                 })
                 .await
             }
@@ -1878,6 +1893,138 @@ mod tests {
             Some(ThinkingEffort::Minimal),
         );
         assert_eq!(body["reasoning"]["effort"], "minimal");
+    }
+
+    // ---- DatabricksV2 route-aware effort normalization (body-level assertions) ----
+    //
+    // The DBv2 `complete()` dispatch applies `normalize_effort_for_openai_route` /
+    // `normalize_effort_for_anthropic_route` before calling body builders. These tests
+    // verify the body shape that results from the already-normalized effort values — i.e.,
+    // they confirm the body builders correctly serialize the values the dispatch passes them.
+
+    #[test]
+    fn dbv2_openai_route_max_effort_clamped_to_xhigh_in_responses_body() {
+        // DBv2 GPT-5 route: max → clamped to xhigh by normalize_effort_for_openai_route
+        // before reaching responses_body. The body must carry "xhigh", never "max".
+        let clamped = crate::config::normalize_effort_for_openai_route(ThinkingEffort::Max);
+        let body = responses_body(
+            &cfg_responses(),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "gpt-5",
+            Some(clamped),
+        );
+        assert_eq!(
+            body["reasoning"]["effort"], "xhigh",
+            "DBv2 GPT-5 route: max must be clamped to xhigh before responses_body"
+        );
+    }
+
+    #[test]
+    fn dbv2_mlflow_route_max_effort_clamped_to_xhigh_in_openai_body() {
+        // DBv2 MLflow route: max → clamped to xhigh by normalize_effort_for_openai_route.
+        let clamped = crate::config::normalize_effort_for_openai_route(ThinkingEffort::Max);
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "llama-4",
+            Some(clamped),
+        );
+        assert_eq!(
+            body["reasoning_effort"], "xhigh",
+            "DBv2 MLflow route: max must be clamped to xhigh before openai_body"
+        );
+    }
+
+    #[test]
+    fn dbv2_openai_route_none_minimal_pass_through_in_responses_body() {
+        // DBv2 GPT-5 route: none and minimal are valid OpenAI effort values.
+        // normalize_effort_for_openai_route passes them through unchanged.
+        for effort in [ThinkingEffort::None, ThinkingEffort::Minimal] {
+            let normalized = crate::config::normalize_effort_for_openai_route(effort);
+            assert_eq!(
+                normalized, effort,
+                "OpenAI normalizer must not touch none/minimal"
+            );
+            let body = responses_body(
+                &cfg_responses(),
+                "system",
+                &[HistoryItem::User("hi".into())],
+                &[],
+                "gpt-5",
+                Some(normalized),
+            );
+            assert_eq!(
+                body["reasoning"]["effort"],
+                effort.openai_effort_str(),
+                "DBv2 GPT-5 route: {effort:?} must be emitted as-is"
+            );
+        }
+    }
+
+    #[test]
+    fn dbv2_claude_route_none_effort_omits_thinking_fields() {
+        // DBv2 Claude route: none → normalize_effort_for_anthropic_route returns None → omit.
+        let normalized = crate::config::normalize_effort_for_anthropic_route(ThinkingEffort::None);
+        assert_eq!(
+            normalized, None,
+            "Anthropic normalizer must return None for ThinkingEffort::None"
+        );
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 32_768;
+        let body = anthropic_body(
+            &c,
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "claude-opus-4-8",
+            normalized, // None → omit thinking fields
+        );
+        assert!(
+            body.get("thinking").is_none(),
+            "DBv2 Claude route: none effort must omit thinking fields"
+        );
+        assert!(
+            body.get("output_config").is_none(),
+            "DBv2 Claude route: none effort must omit output_config"
+        );
+    }
+
+    #[test]
+    fn dbv2_session_set_model_route_switch_max_emits_correctly() {
+        // Simulates a session/set_model switch from a Claude model to a GPT-5 model
+        // when thinking_effort=max. Before the switch: Claude route → max passes through
+        // as Anthropic "max". After the switch: GPT-5 route → max clamped to xhigh.
+        let mut c = cfg(Provider::Anthropic);
+        c.max_output_tokens = 32_768;
+
+        // Before switch: claude-opus-4-8 with effort=max → adaptive shape, effort="max"
+        let (thinking_before, oc_before) = crate::config::anthropic_thinking_config(
+            "claude-opus-4-8",
+            ThinkingEffort::Max,
+            32_768,
+        );
+        assert_eq!(thinking_before.unwrap()["type"], "adaptive");
+        assert_eq!(oc_before.unwrap()["effort"], "max");
+
+        // After switch to GPT-5 route: normalize max → xhigh for responses_body
+        let clamped = crate::config::normalize_effort_for_openai_route(ThinkingEffort::Max);
+        assert_eq!(clamped, ThinkingEffort::XHigh);
+        let body_after = responses_body(
+            &cfg_responses(),
+            "system",
+            &[HistoryItem::User("hi".into())],
+            &[],
+            "gpt-5",
+            Some(clamped),
+        );
+        assert_eq!(
+            body_after["reasoning"]["effort"], "xhigh",
+            "After set_model to GPT-5: max must be clamped to xhigh"
+        );
     }
 
     /// Regression: a connection that is accepted and then dropped before any

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -1647,8 +1647,8 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_body_emits_output_config_effort_for_modern_claude() {
-        // Modern Claude (claude-4+, sonnet-5+) → `output_config.effort`; no budget_tokens.
+    fn anthropic_body_emits_adaptive_thinking_for_opus_4() {
+        // Adaptive Claude (claude-opus-4-*) → thinking:{type:"adaptive"} + output_config.effort.
         let mut c = cfg(Provider::Anthropic);
         c.max_output_tokens = 32_768;
         let body = anthropic_body(
@@ -1659,9 +1659,9 @@ mod tests {
             "claude-opus-4-5",
             Some(ThinkingEffort::High),
         );
-        assert!(
-            body.get("thinking").is_none(),
-            "thinking must be absent for modern claude"
+        assert_eq!(
+            body["thinking"]["type"], "adaptive",
+            "thinking must be {{type:adaptive}} for claude-opus-4-5"
         );
         assert_eq!(body["output_config"]["effort"], "high");
     }

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -1994,10 +1994,13 @@ mod tests {
     }
 
     #[test]
-    fn dbv2_session_set_model_route_switch_max_emits_correctly() {
-        // Simulates a session/set_model switch from a Claude model to a GPT-5 model
-        // when thinking_effort=max. Before the switch: Claude route → max passes through
-        // as Anthropic "max". After the switch: GPT-5 route → max clamped to xhigh.
+    fn dbv2_route_switch_max_body_level_simulation() {
+        // Body-level simulation of a session/set_model switch from a Claude model to a GPT-5
+        // model when thinking_effort=max. Calls body builders and normalizers directly (not
+        // through the ACP session/set_model path or DatabricksV2 dispatch) to verify the
+        // correct output shape for each side of the route switch.
+        // Before the switch: Claude route → max passes through as Anthropic "max".
+        // After the switch: GPT-5 route → max clamped to xhigh.
         let mut c = cfg(Provider::Anthropic);
         c.max_output_tokens = 32_768;
 

--- a/crates/buzz-agent/src/wire.rs
+++ b/crates/buzz-agent/src/wire.rs
@@ -80,6 +80,16 @@ pub struct SessionSteerParams {
     pub expected_run_id: String,
 }
 
+/// Params for `session/set_model`: override the active model for an existing
+/// session without respawning. Applied immediately; subsequent prompts on this
+/// session use `model_id` instead of the configured `BUZZ_AGENT_MODEL`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSetModelParams {
+    pub session_id: String,
+    pub model_id: String,
+}
+
 pub fn classify(msg: &Value) -> Inbound {
     if !msg.is_object() || msg.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
         return Inbound::Invalid {

--- a/crates/buzz-agent/tests/databricks_oauth.rs
+++ b/crates/buzz-agent/tests/databricks_oauth.rs
@@ -708,3 +708,233 @@ async fn databricks_v2_other_models_route_through_ai_gateway_mlflow_chat() {
         req.body
     );
 }
+
+// ---------- session/set_model integration tests ----------
+
+/// Helper: run initialize + session/new + optional set_model + session/prompt on a
+/// freshly-spawned harness against the given stub server base URL. Returns the
+/// session/prompt response and the session ID so callers can also call set_model.
+async fn run_with_set_model(
+    provider: &str,
+    base: &str,
+    initial_model: &str,
+    switch_to_model: Option<&str>,
+) -> (String, serde_json::Value) {
+    let mut h = AgentHarness::spawn_provider(provider, base, initial_model).await;
+    h.send(
+        "initialize",
+        json!({ "protocolVersion": 1, "clientCapabilities": {} }),
+    )
+    .await;
+    h.recv_for(1).await;
+    h.send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
+        .await;
+    let r = h.recv_for(2).await;
+    let sid = r["result"]["sessionId"].as_str().unwrap().to_string();
+
+    if let Some(new_model) = switch_to_model {
+        h.send(
+            "session/set_model",
+            json!({ "sessionId": sid, "modelId": new_model }),
+        )
+        .await;
+        let set_r = h.recv_for(3).await;
+        // Verify the response carries the expected modelId.
+        assert_eq!(
+            set_r["result"]["modelId"],
+            json!(new_model),
+            "set_model response must echo the new modelId"
+        );
+        h.send(
+            "session/prompt",
+            json!({ "sessionId": sid, "prompt": [{ "type": "text", "text": "say ok" }] }),
+        )
+        .await;
+        let prompt_r = h.recv_for(4).await;
+        (sid, prompt_r)
+    } else {
+        h.send(
+            "session/prompt",
+            json!({ "sessionId": sid, "prompt": [{ "type": "text", "text": "say ok" }] }),
+        )
+        .await;
+        let prompt_r = h.recv_for(3).await;
+        (sid, prompt_r)
+    }
+}
+
+/// After session/set_model switches from model A to model B, the next
+/// session/prompt must route to B's Databricks serving-endpoint URL and
+/// strip the `model` field from the body (legacy Databricks behaviour).
+#[tokio::test]
+async fn session_set_model_switches_databricks_legacy_route() {
+    let initial_model = "initial-model";
+    let switched_model = "switched-model";
+
+    // Two canned responses: one for the discovery call (session/new),
+    // one for the LLM call after the switch.
+    let canned = vec![
+        json!({ "endpoints": [], "next_page_token": null }), // discovery
+        json!({                                               // LLM response
+            "id": "x",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "ok" },
+                "finish_reason": "stop"
+            }]
+        }),
+    ];
+    let (base, captured) = spawn_capturing_server(canned).await;
+    run_with_set_model("databricks", &base, initial_model, Some(switched_model)).await;
+
+    let reqs = captured.lock().await;
+    let llm_reqs: Vec<_> = reqs
+        .iter()
+        .filter(|r| {
+            !r.path.starts_with("/api/2.0/serving-endpoints")
+                && !r.path.starts_with("/api/ai-gateway/v2/endpoints")
+        })
+        .collect();
+    assert_eq!(
+        llm_reqs.len(),
+        1,
+        "expected exactly one LLM request after switch"
+    );
+    let req = &llm_reqs[0];
+
+    // The request must go to the SWITCHED model endpoint, not the initial one.
+    assert_eq!(
+        req.path.as_str(),
+        format!("/serving-endpoints/{switched_model}/invocations"),
+        "Databricks legacy must route to the switched model endpoint"
+    );
+    // The body must not include `model` (Databricks rejects it).
+    assert!(
+        req.body.get("model").is_none(),
+        "request body must NOT include `model` after switch: {:?}",
+        req.body
+    );
+}
+
+/// After session/set_model switches a Databricks v2 session from a GPT-5 model
+/// (OpenAI Responses route) to a Claude model (Anthropic Messages route),
+/// the next prompt must hit the Anthropic AI Gateway path.
+#[tokio::test]
+async fn session_set_model_switches_databricks_v2_route() {
+    let initial_model = "databricks-gpt-5-5"; // → OpenAI Responses
+    let switched_model = "databricks-claude-opus-4-7"; // → Anthropic Messages
+
+    let canned = vec![
+        json!({ "endpoints": [], "next_page_token": null }), // discovery (v2: /api/ai-gateway/v2/endpoints)
+        json!({                                               // LLM response (Anthropic Messages shape)
+            "stop_reason": "end_turn",
+            "content": [{ "type": "text", "text": "ok" }]
+        }),
+    ];
+    let (base, captured) = spawn_capturing_server(canned).await;
+    run_with_set_model("databricks_v2", &base, initial_model, Some(switched_model)).await;
+
+    let reqs = captured.lock().await;
+    let llm_reqs: Vec<_> = reqs
+        .iter()
+        .filter(|r| {
+            !r.path.starts_with("/api/2.0/serving-endpoints")
+                && !r.path.starts_with("/api/ai-gateway/v2/endpoints")
+        })
+        .collect();
+    assert_eq!(
+        llm_reqs.len(),
+        1,
+        "expected exactly one LLM request after v2 route switch"
+    );
+    let req = &llm_reqs[0];
+
+    assert_eq!(
+        req.path.as_str(),
+        "/ai-gateway/anthropic/v1/messages",
+        "After switching to a Claude model, Databricks v2 must route to Anthropic Messages"
+    );
+    assert_eq!(
+        req.body["model"],
+        json!(switched_model),
+        "body must carry the switched model ID"
+    );
+}
+
+/// session/set_model with an unknown session ID must return an invalid_params
+/// error without touching any LLM endpoint.
+#[tokio::test]
+async fn session_set_model_unknown_session_returns_error() {
+    // Spawn with a single discovery canned response; no LLM response needed.
+    let canned = vec![json!({ "endpoints": [], "next_page_token": null })];
+    let (base, _captured) = spawn_capturing_server(canned).await;
+
+    let mut h = AgentHarness::spawn_provider("databricks", &base, "some-model").await;
+    h.send(
+        "initialize",
+        json!({ "protocolVersion": 1, "clientCapabilities": {} }),
+    )
+    .await;
+    h.recv_for(1).await;
+    h.send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
+        .await;
+    h.recv_for(2).await;
+
+    // Call set_model with a bogus session ID.
+    h.send(
+        "session/set_model",
+        json!({ "sessionId": "nonexistent-session-id", "modelId": "new-model" }),
+    )
+    .await;
+    let r = h.recv_for(3).await;
+
+    assert!(
+        r.get("error").is_some(),
+        "set_model with unknown session must return an error: {:?}",
+        r
+    );
+    let msg = r["error"]["message"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("unknown session"),
+        "error message must mention unknown session, got: {msg}"
+    );
+}
+
+/// session/set_model with an empty modelId must return an invalid_params error.
+#[tokio::test]
+async fn session_set_model_empty_model_id_returns_error() {
+    let canned = vec![json!({ "endpoints": [], "next_page_token": null })];
+    let (base, _captured) = spawn_capturing_server(canned).await;
+
+    let mut h = AgentHarness::spawn_provider("databricks", &base, "some-model").await;
+    h.send(
+        "initialize",
+        json!({ "protocolVersion": 1, "clientCapabilities": {} }),
+    )
+    .await;
+    h.recv_for(1).await;
+    h.send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
+        .await;
+    let r = h.recv_for(2).await;
+    let sid = r["result"]["sessionId"].as_str().unwrap().to_string();
+
+    // Empty string modelId.
+    h.send(
+        "session/set_model",
+        json!({ "sessionId": sid, "modelId": "" }),
+    )
+    .await;
+    let r = h.recv_for(3).await;
+
+    assert!(
+        r.get("error").is_some(),
+        "set_model with empty modelId must return an error: {:?}",
+        r
+    );
+    let msg = r["error"]["message"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("modelId"),
+        "error message must mention modelId, got: {msg}"
+    );
+}

--- a/crates/buzz-agent/tests/databricks_oauth.rs
+++ b/crates/buzz-agent/tests/databricks_oauth.rs
@@ -544,14 +544,33 @@ async fn run_single_prompt(provider: &str, base: &str, model: &str) {
 async fn run_captured_prompt(
     provider: &str,
     model: &str,
-    canned: Vec<serde_json::Value>,
+    llm_canned: Vec<serde_json::Value>,
 ) -> CapturedRequest {
-    let (base, captured) = spawn_capturing_server(canned).await;
+    // session/new triggers model catalog discovery against the same stub server.
+    // Prepend a minimal valid discovery response (empty endpoints list) so the
+    // discovery call is served cleanly and the LLM canned responses follow.
+    // Legacy Databricks discovery hits /api/2.0/serving-endpoints;
+    // Databricks v2 discovery hits /api/ai-gateway/v2/endpoints.
+    let discovery_resp = json!({ "endpoints": [], "next_page_token": null });
+    let mut all_canned = vec![discovery_resp];
+    all_canned.extend(llm_canned);
+
+    let (base, captured) = spawn_capturing_server(all_canned).await;
     run_single_prompt(provider, &base, model).await;
 
+    // Filter out discovery requests — keep only the LLM invocation(s).
+    // Discovery paths: /api/2.0/serving-endpoints, /api/ai-gateway/v2/endpoints*
+    // LLM paths: /serving-endpoints/*, /ai-gateway/anthropic/*, /ai-gateway/openai/*, /ai-gateway/mlflow/*
     let reqs = captured.lock().await;
-    assert_eq!(reqs.len(), 1, "expected exactly one LLM request");
-    reqs[0].clone()
+    let llm_reqs: Vec<_> = reqs
+        .iter()
+        .filter(|r| {
+            !r.path.starts_with("/api/2.0/serving-endpoints")
+                && !r.path.starts_with("/api/ai-gateway/v2/endpoints")
+        })
+        .collect();
+    assert_eq!(llm_reqs.len(), 1, "expected exactly one LLM request");
+    llm_reqs[0].clone()
 }
 
 #[tokio::test]

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -102,7 +102,10 @@ const overrides = new Map([
   // agents keep an installed runtime alias when the primary command is absent.
   // Load-bearing, not generic debt.
   // config-bridge: schema-driven field extraction adds ~26 lines. Queued to split.
-  ["src-tauri/src/managed_agents/discovery.rs", 1111],
+  // config-parity: max_tokens_env_var + context_limit_env_var fields added to
+  // KnownAcpRuntime (2 fields × 4 runtimes + discovery tests = ~13 lines).
+  // Load-bearing — required for buzz-agent normalized config parity.
+  ["src-tauri/src/managed_agents/discovery.rs", 1124],
   // migration_tests.rs carries the harness-sync migration coverage plus the
   // patch_json_records owner-only writeback regression test (SECURITY.md:90
   // crash-safe 0o600 fallback). Load-bearing security + feature coverage, not

--- a/desktop/src-tauri/src/commands/agent_config.rs
+++ b/desktop/src-tauri/src/commands/agent_config.rs
@@ -404,6 +404,8 @@ mod tests {
             config_file_format: Some("yaml"),
             supports_acp_native_config: true,
             thinking_env_var: Some("GOOSE_THINKING_EFFORT"),
+            max_tokens_env_var: Some("GOOSE_MAX_TOKENS"),
+            context_limit_env_var: Some("GOOSE_CONTEXT_LIMIT"),
             required_normalized_fields: &["model", "provider"],
         }
     }

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
@@ -481,7 +481,7 @@ fn build_numeric_env_field(
 }
 
 /// Record/env prompt wins (BuzzExplicit, respawnable); a config-file prompt it
-/// shadows is reported as the overridden secondary.
+/// shadows is reported as the overridden secondary. A config-file-only prompt
 /// — no record/env value to shadow it — is surfaced directly (read-only)
 /// instead of being dropped: a prompt that drives the agent should always be
 /// visible somewhere in the panel.

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
@@ -44,6 +44,8 @@ pub(crate) fn read_config_surface(
     let required_fields: &[&str] = runtime_meta
         .map(|m| m.required_normalized_fields)
         .unwrap_or(&[]);
+    let max_tokens_env_var = runtime_meta.and_then(|m| m.max_tokens_env_var);
+    let context_limit_env_var = runtime_meta.and_then(|m| m.context_limit_env_var);
 
     // Tier 1b: ACP configOptions from session cache.
     // For unstable/switchable agents, current_model comes from the `models`
@@ -95,25 +97,16 @@ pub(crate) fn read_config_surface(
             is_pre_spawn,
             session_cache,
         ),
-        max_output_tokens: file_config
-            .max_output_tokens
-            .as_ref()
-            .map(|v| NormalizedField {
-                value: Some(v.clone()),
-                origin: ConfigOrigin::ConfigFile,
-                write_via: ConfigWriteMechanism::ReadOnly,
-                overridden_value: None,
-                overridden_origin: None,
-                is_required: false,
-            }),
-        context_limit: file_config.context_limit.as_ref().map(|v| NormalizedField {
-            value: Some(v.clone()),
-            origin: ConfigOrigin::ConfigFile,
-            write_via: ConfigWriteMechanism::ReadOnly,
-            overridden_value: None,
-            overridden_origin: None,
-            is_required: false,
-        }),
+        max_output_tokens: build_numeric_env_field(
+            max_tokens_env_var,
+            &record.env_vars,
+            &file_config.max_output_tokens,
+        ),
+        context_limit: build_numeric_env_field(
+            context_limit_env_var,
+            &record.env_vars,
+            &file_config.context_limit,
+        ),
         system_prompt: build_system_prompt_field(
             &record
                 .system_prompt
@@ -142,6 +135,8 @@ pub(crate) fn read_config_surface(
         model_env_var,
         provider_env_var,
         thinking_env_var,
+        max_tokens_env_var,
+        context_limit_env_var,
         Some("BUZZ_ACP_SYSTEM_PROMPT"),
     ]
     .into_iter()
@@ -452,8 +447,41 @@ fn build_thinking_field(
     })
 }
 
+/// Numeric fields (max_output_tokens, context_limit) — env-var tier wins over
+/// config-file tier. When an env var key is given and present in the record's
+/// env_vars map the field is BuzzExplicit + RespawnWithEnvVar; otherwise if the
+/// config file supplied a value it is ConfigFile + ReadOnly; otherwise None.
+fn build_numeric_env_field(
+    env_var: Option<&'static str>,
+    record_env: &std::collections::BTreeMap<String, String>,
+    file_value: &Option<String>,
+) -> Option<NormalizedField> {
+    if let Some(key) = env_var {
+        if let Some(v) = record_env.get(key) {
+            return Some(NormalizedField {
+                value: Some(v.clone()),
+                origin: ConfigOrigin::BuzzExplicit,
+                write_via: ConfigWriteMechanism::RespawnWithEnvVar {
+                    env_key: key.to_string(),
+                },
+                overridden_value: file_value.clone(),
+                overridden_origin: file_value.as_ref().map(|_| ConfigOrigin::ConfigFile),
+                is_required: false,
+            });
+        }
+    }
+    file_value.as_ref().map(|v| NormalizedField {
+        value: Some(v.clone()),
+        origin: ConfigOrigin::ConfigFile,
+        write_via: ConfigWriteMechanism::ReadOnly,
+        overridden_value: None,
+        overridden_origin: None,
+        is_required: false,
+    })
+}
+
 /// Record/env prompt wins (BuzzExplicit, respawnable); a config-file prompt it
-/// shadows is reported as the overridden secondary. A config-file-only prompt
+/// shadows is reported as the overridden secondary.
 /// — no record/env value to shadow it — is surfaced directly (read-only)
 /// instead of being dropped: a prompt that drives the agent should always be
 /// visible somewhere in the panel.

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -33,6 +33,8 @@ fn test_runtime() -> &'static KnownAcpRuntime {
         config_file_format: Some("yaml"),
         supports_acp_native_config: true,
         thinking_env_var: Some("GOOSE_THINKING_EFFORT"),
+        max_tokens_env_var: Some("GOOSE_MAX_TOKENS"),
+        context_limit_env_var: Some("GOOSE_CONTEXT_LIMIT"),
         required_normalized_fields: &["model", "provider"],
     }
 }
@@ -493,5 +495,163 @@ fn extra_env_var_skipped_when_already_in_file_config_extra() {
     assert!(
         !advanced_keys.contains(&"GOOSE_THINKING_EFFORT"),
         "normalized thinking key must not appear in advanced"
+    );
+}
+
+// ── buzz-agent normalized env-var field tests ───────────────────────────────
+//
+// buzz-agent uses env vars (not a config file) for max_output_tokens and
+// context_limit. build_numeric_env_field must surface these as BuzzExplicit
+// when the env var is present in record.env_vars, and must not double-surface
+// them in the advanced tier.
+
+fn buzz_agent_runtime() -> &'static KnownAcpRuntime {
+    &KnownAcpRuntime {
+        id: "buzz-agent",
+        label: "Buzz Agent",
+        commands: &["buzz-agent"],
+        aliases: &[],
+        avatar_url: "",
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: None,
+        cli_install_commands: &[],
+        adapter_install_commands: &[],
+        install_instructions_url: "",
+        cli_install_hint: "",
+        adapter_install_hint: "",
+        skill_dir: None,
+        supports_acp_model_switching: true,
+        model_env_var: Some("BUZZ_AGENT_MODEL"),
+        provider_env_var: Some("BUZZ_AGENT_PROVIDER"),
+        provider_locked: false,
+        default_env: &[],
+        config_file_path: None,
+        config_file_format: None,
+        supports_acp_native_config: false,
+        thinking_env_var: Some("BUZZ_AGENT_THINKING_EFFORT"),
+        max_tokens_env_var: Some("BUZZ_AGENT_MAX_OUTPUT_TOKENS"),
+        context_limit_env_var: Some("BUZZ_AGENT_MAX_CONTEXT_TOKENS"),
+        required_normalized_fields: &["model", "provider"],
+    }
+}
+
+#[test]
+fn buzz_agent_max_output_tokens_from_env_is_buzz_explicit() {
+    let mut record = test_record();
+    record
+        .env_vars
+        .insert("BUZZ_AGENT_MAX_OUTPUT_TOKENS".to_string(), "8192".to_string());
+    let runtime = buzz_agent_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    let field = surface.normalized.max_output_tokens.unwrap();
+    assert_eq!(field.value.as_deref(), Some("8192"));
+    assert_eq!(field.origin, ConfigOrigin::BuzzExplicit);
+    assert!(matches!(
+        field.write_via,
+        ConfigWriteMechanism::RespawnWithEnvVar { ref env_key }
+            if env_key == "BUZZ_AGENT_MAX_OUTPUT_TOKENS"
+    ));
+}
+
+#[test]
+fn buzz_agent_context_limit_from_env_is_buzz_explicit() {
+    let mut record = test_record();
+    record.env_vars.insert(
+        "BUZZ_AGENT_MAX_CONTEXT_TOKENS".to_string(),
+        "100000".to_string(),
+    );
+    let runtime = buzz_agent_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    let field = surface.normalized.context_limit.unwrap();
+    assert_eq!(field.value.as_deref(), Some("100000"));
+    assert_eq!(field.origin, ConfigOrigin::BuzzExplicit);
+    assert!(matches!(
+        field.write_via,
+        ConfigWriteMechanism::RespawnWithEnvVar { ref env_key }
+            if env_key == "BUZZ_AGENT_MAX_CONTEXT_TOKENS"
+    ));
+}
+
+#[test]
+fn buzz_agent_max_tokens_absent_when_no_env_var_or_file() {
+    // buzz-agent has no config file, and env var is not set.
+    let record = test_record();
+    let runtime = buzz_agent_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    assert!(
+        surface.normalized.max_output_tokens.is_none(),
+        "max_output_tokens must be None when env var not set and no config file"
+    );
+    assert!(
+        surface.normalized.context_limit.is_none(),
+        "context_limit must be None when env var not set and no config file"
+    );
+}
+
+#[test]
+fn buzz_agent_max_tokens_env_var_not_double_surfaced_in_advanced() {
+    let mut record = test_record();
+    record
+        .env_vars
+        .insert("BUZZ_AGENT_MAX_OUTPUT_TOKENS".to_string(), "4096".to_string());
+    record
+        .env_vars
+        .insert("BUZZ_AGENT_MAX_CONTEXT_TOKENS".to_string(), "50000".to_string());
+    let runtime = buzz_agent_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    let advanced_keys: Vec<&str> = surface.advanced.iter().map(|f| f.key.as_str()).collect();
+    assert!(
+        !advanced_keys.contains(&"BUZZ_AGENT_MAX_OUTPUT_TOKENS"),
+        "max_output_tokens must not appear in advanced when normalized"
+    );
+    assert!(
+        !advanced_keys.contains(&"BUZZ_AGENT_MAX_CONTEXT_TOKENS"),
+        "context_limit must not appear in advanced when normalized"
+    );
+}
+
+#[test]
+fn buzz_agent_thinking_effort_from_env_is_buzz_explicit() {
+    let mut record = test_record();
+    record
+        .env_vars
+        .insert("BUZZ_AGENT_THINKING_EFFORT".to_string(), "high".to_string());
+    let runtime = buzz_agent_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    let field = surface.normalized.thinking_effort.unwrap();
+    assert_eq!(field.value.as_deref(), Some("high"));
+    assert_eq!(field.origin, ConfigOrigin::BuzzExplicit);
+    assert!(matches!(
+        field.write_via,
+        ConfigWriteMechanism::RespawnWithEnvVar { ref env_key }
+            if env_key == "BUZZ_AGENT_THINKING_EFFORT"
+    ));
+}
+
+#[test]
+fn buzz_agent_thinking_effort_env_var_not_double_surfaced_in_advanced() {
+    let mut record = test_record();
+    record
+        .env_vars
+        .insert("BUZZ_AGENT_THINKING_EFFORT".to_string(), "medium".to_string());
+    let runtime = buzz_agent_runtime();
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    let advanced_keys: Vec<&str> = surface.advanced.iter().map(|f| f.key.as_str()).collect();
+    assert!(
+        !advanced_keys.contains(&"BUZZ_AGENT_THINKING_EFFORT"),
+        "thinking_effort must not appear in advanced when normalized"
     );
 }

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -539,9 +539,10 @@ fn buzz_agent_runtime() -> &'static KnownAcpRuntime {
 #[test]
 fn buzz_agent_max_output_tokens_from_env_is_buzz_explicit() {
     let mut record = test_record();
-    record
-        .env_vars
-        .insert("BUZZ_AGENT_MAX_OUTPUT_TOKENS".to_string(), "8192".to_string());
+    record.env_vars.insert(
+        "BUZZ_AGENT_MAX_OUTPUT_TOKENS".to_string(),
+        "8192".to_string(),
+    );
     let runtime = buzz_agent_runtime();
 
     let surface = read_config_surface(&record, Some(runtime), None, None);
@@ -598,12 +599,14 @@ fn buzz_agent_max_tokens_absent_when_no_env_var_or_file() {
 #[test]
 fn buzz_agent_max_tokens_env_var_not_double_surfaced_in_advanced() {
     let mut record = test_record();
-    record
-        .env_vars
-        .insert("BUZZ_AGENT_MAX_OUTPUT_TOKENS".to_string(), "4096".to_string());
-    record
-        .env_vars
-        .insert("BUZZ_AGENT_MAX_CONTEXT_TOKENS".to_string(), "50000".to_string());
+    record.env_vars.insert(
+        "BUZZ_AGENT_MAX_OUTPUT_TOKENS".to_string(),
+        "4096".to_string(),
+    );
+    record.env_vars.insert(
+        "BUZZ_AGENT_MAX_CONTEXT_TOKENS".to_string(),
+        "50000".to_string(),
+    );
     let runtime = buzz_agent_runtime();
 
     let surface = read_config_surface(&record, Some(runtime), None, None);
@@ -642,9 +645,10 @@ fn buzz_agent_thinking_effort_from_env_is_buzz_explicit() {
 #[test]
 fn buzz_agent_thinking_effort_env_var_not_double_surfaced_in_advanced() {
     let mut record = test_record();
-    record
-        .env_vars
-        .insert("BUZZ_AGENT_THINKING_EFFORT".to_string(), "medium".to_string());
+    record.env_vars.insert(
+        "BUZZ_AGENT_THINKING_EFFORT".to_string(),
+        "medium".to_string(),
+    );
     let runtime = buzz_agent_runtime();
 
     let surface = read_config_surface(&record, Some(runtime), None, None);

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -47,6 +47,11 @@ pub(crate) struct KnownAcpRuntime {
     pub config_file_format: Option<&'static str>,
     pub supports_acp_native_config: bool, // tier 1a: config/read+write
     pub thinking_env_var: Option<&'static str>,
+    /// Env var for normalizing `max_output_tokens`. `None` when the harness
+    /// does not have a first-class env var for this field (config-file only).
+    pub max_tokens_env_var: Option<&'static str>,
+    /// Env var for normalizing `context_limit`. `None` when not applicable.
+    pub context_limit_env_var: Option<&'static str>,
     /// Normalized field keys that must be set for this harness to function.
     /// Used by the config bridge to mark fields as required in the UI.
     /// Keys match the camelCase names used in `NormalizedConfig` (e.g. "model", "provider").
@@ -106,6 +111,8 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         config_file_format: Some("yaml"),
         supports_acp_native_config: true,
         thinking_env_var: Some("GOOSE_THINKING_EFFORT"),
+        max_tokens_env_var: Some("GOOSE_MAX_TOKENS"),
+        context_limit_env_var: Some("GOOSE_CONTEXT_LIMIT"),
         required_normalized_fields: &["model", "provider"],
     },
     KnownAcpRuntime {
@@ -132,6 +139,8 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         config_file_format: Some("json"),
         supports_acp_native_config: false,
         thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
         required_normalized_fields: &[],
     },
     KnownAcpRuntime {
@@ -158,6 +167,8 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         config_file_format: Some("toml"),
         supports_acp_native_config: false,
         thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
         required_normalized_fields: &[],
     },
     KnownAcpRuntime {
@@ -183,7 +194,9 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         config_file_path: None,
         config_file_format: None,
         supports_acp_native_config: false,
-        thinking_env_var: None,
+        thinking_env_var: Some("BUZZ_AGENT_THINKING_EFFORT"),
+        max_tokens_env_var: Some("BUZZ_AGENT_MAX_OUTPUT_TOKENS"),
+        context_limit_env_var: Some("BUZZ_AGENT_MAX_CONTEXT_TOKENS"),
         required_normalized_fields: &["model", "provider"],
     },
 ];


### PR DESCRIPTION
Closes three config bridge gaps for buzz-agent: thinking/effort entirely absent, max-tokens/context env vars not normalized, and the advertised live model switch always failing with `unsupported_model`.

## Changes

**`BUZZ_AGENT_THINKING_EFFORT`** (`none|minimal|low|medium|high|xhigh|max`): parsed in `config.rs` (case-insensitive, pure/env-free). Provider-level startup validation rejects impossible values for pure Anthropic/OpenAI providers. DatabricksV2 is excluded from startup validation — it dispatches across three routes at request build time, so route-aware normalization (`normalize_effort_for_openai_route` / `normalize_effort_for_anthropic_route`) runs instead. Model-level clamping is also dynamic (request-build time) because `session/set_model` can change the model after startup.

**`session/set_model`**: `Session.effective_model` override field; `set_model_session` validates the session exists and the `modelId` is non-empty — catalog membership is enforced by the client pool honoring the `availableModels` it advertised; routing layer uses `effective_model` end-to-end. `session/new` returns `{ currentModelId, availableModels }`.

**`max_output_tokens` / `context_limit` normalization**: `KnownAcpRuntime` gains `max_tokens_env_var` / `context_limit_env_var` fields (all four runtimes); `build_numeric_env_field` helper applies env-var → file tiering.

**Model-aware OpenAI effort normalization**: `normalize_effort_for_openai_route` now accepts a model parameter and applies per-model effort availability (doc-verified, July 2025). Uses boundary-safe matching (end-of-string or `-` separator required after version token — letters and digits block; base token additionally rejects short numeric suffixes that look like unrecognized version numbers like `-10`). Unknown models pass through unchanged — server-validated. Closes a live 400 risk from emitting unsupported effort values.

**Answer-room budget clamp**: Manual-budget path now uses `budget = min(level_budget, max_output_tokens - 1024)`. If result < 1024, thinking is omitted entirely with a `warn!` instead of emitting an answer-starving or invalid budget.

**Catalog provider split**: `session/new` legacy `Provider::Databricks` on discovery failure now advertises only the configured model instead of `DATABRICKS_V2_KNOWN_MODELS` (AI Gateway v2 IDs that `/serving-endpoints/{model}/invocations` may not serve).

## Effort value matrix

### Pure Anthropic provider

| Value | Adaptive families¹ | Manual-budget families² | Startup |
|-------|---------------------|-------------------------|---------|
| `none` | — | — | ❌ rejected |
| `minimal` | — | — | ❌ rejected |
| `low` | `output_config.effort="low"` | `budget_tokens=1024` | ✅ |
| `medium` | `output_config.effort="medium"` | `budget_tokens=8192` | ✅ |
| `high` | `output_config.effort="high"` | `budget_tokens=32768` | ✅ |
| `xhigh` | xhigh families³: `"xhigh"`; others: clamp→`"high"` | clamp→32768 budget | ✅ |
| `max` | `output_config.effort="max"` (all adaptive families) | clamp→32768 budget | ✅ |

¹ Adaptive (emit `thinking:{type:"adaptive"}` + `output_config.effort`): `claude-opus-4-6/4-7/4-8`, `claude-sonnet-4-6`, `claude-sonnet-5*`, `claude-fable-5`, `claude-mythos-5`, `claude-mythos-preview`

² Manual-budget (emit `thinking:{type:"enabled", budget_tokens}` clamped to `min(level_budget, max_output_tokens - 1024)`; omit if result < 1024): `claude-3*`, `claude-opus-4-5`

³ xhigh-capable subset: Opus 4.7, 4.8, Sonnet 5.x, Fable 5, Mythos 5 — `xhigh` on all others (Opus 4.6, Sonnet 4.6, Mythos Preview) clamps to `high`

Unrecognised `claude-*` names not in the verified table → both fields omitted (safe fallback).

### Pure OpenAI / Databricks (legacy) provider — per-model effort availability

| Value | gpt-5-pro | gpt-5.5 / gpt-5.4 | gpt-5.1 | gpt-5 (base) | unknown |
|-------|-----------|-------------------|---------|--------------|---------|
| `none` | →`high` | ✅ | ✅ | →`minimal` | ✅ |
| `minimal` | →`high` | →`none` | →`none` | ✅ | ✅ |
| `low` | →`high` | ✅ | ✅ | ✅ | ✅ |
| `medium` | →`high` | ✅ | ✅ | ✅ | ✅ |
| `high` | ✅ | ✅ | ✅ | ✅ | ✅ |
| `xhigh` | →`high` | ✅ | →`high` | →`high` | ✅ |
| `max` | startup ❌ (pure OpenAI) / →`xhigh` (DBv2) | same | same | same | same |

`none`↔`minimal` are each other's first fallback (none/minimal split across model families). Substitutions emit `warn!`. Unknown models pass through unchanged.

### DatabricksV2 provider (all values accepted at startup; route-aware normalization at request build)

| Value | GPT-5 route (Responses) | MLflow route (Chat) | Claude route (Messages) |
|-------|-------------------------|---------------------|-------------------------|
| `none`/`minimal` | per-model table above | per-model table above | **omit thinking fields** (warn) |
| `low`–`xhigh` | per-model table above | per-model table above | Anthropic mapping above |
| `max` | **clamp→xhigh** then per-model table | **clamp→xhigh** then per-model table | Anthropic mapping above |

## Test coverage

- 305 unit tests passing (`cargo test -p buzz-agent`)
- `just desktop-tauri-fmt-check`: clean
- Parse round-trips all 7 values; rejects invalid
- Provider validation (Anthropic rejects none/minimal, OpenAI rejects max, DatabricksV2 accepts all)
- Normalize helpers round-trips + per-model table (gpt-5-pro high-only, gpt-5 none→minimal, gpt-5.5 minimal→none, gpt-5.1 xhigh→high, unknown passthrough)
- Answer-room clamp boundary tests: max_output_tokens 2047 (omit), 2048 (emit 1024), 1025 (omit), 4096 (emit 3072)
- DBv2 route tests: max clamped on GPT-5.5/MLflow, none/minimal pass-through on GPT-5.5, none omits thinking fields on Claude route, route-switch body-level simulation (Claude→GPT-5.5 with max)
- Per-model clamp: Opus 4.6/Sonnet 4.6/Mythos Preview xhigh→high; Opus 4.7/4.8/Sonnet 5/Fable 5/Mythos 5 xhigh pass-through
- OpenAI matcher boundary tests: `gpt-5-4o`/`gpt-5-1106` → base (not 5.4/5.1); `gpt-5.10`/`gpt-5-10`/`gpt-5.50`/`databricks-gpt-5-10` → None (unknown pass-through); `databricks-gpt-5-5`/`gpt-5.1-2025-04-01` still match correctly
- Catalog split: `discovery_failure_fallback` pure helper tested directly — asserts legacy Databricks = configured model only, DatabricksV2 = DATABRICKS_V2_KNOWN_MODELS, the two differ (arm-split verified)
- 4 ACP integration tests for `session/set_model` + Databricks routing
