### PR TITLE
fix(desktop): stop timeline cap from evicting scrolled-in history mid-read

### DIFF
--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -113,15 +113,21 @@ export function mergeMessages(
   return mergeMessagesWithNormalizer(current, incoming, sortMessages);
 }
 
+/**
+ * Merge one incoming event (live subscription, optimistic send, edit overlay)
+ * into the timeline cache. Sort + dedupe only — deliberately NOT capped.
+ *
+ * This merge fires constantly while the user may be scrolled back; capping it
+ * evicted paged-in history out from under the reader (the "June 12 messages
+ * flicker away" bug). The MAX_TIMELINE_MESSAGES bound is applied instead when
+ * the channel is left (see useChannelSubscription's cleanup) and on cold
+ * snapshot paints — moments when no scrolled-back timeline is on screen.
+ */
 export function mergeTimelineCacheMessages(
   current: RelayEvent[],
   incoming: RelayEvent,
 ): RelayEvent[] {
-  return mergeMessagesWithNormalizer(
-    current,
-    incoming,
-    normalizeTimelineMessages,
-  );
+  return mergeMessages(current, incoming);
 }
 
 export function createOptimisticMessage(
@@ -319,6 +325,21 @@ export function useChannelSubscription(channel: Channel | null) {
     }
   });
 
+  // Leaving the channel is the safe moment to enforce the timeline cap:
+  // nothing is rendered from this cache anymore, so trimming to the newest
+  // MAX_TIMELINE_MESSAGES window cannot evict rows out from under a
+  // scrolled-back reader. Merges while the channel is open are deliberately
+  // uncapped for the same reason.
+  const trimTimelineOnLeave = useEffectEvent((leftChannelId: string) => {
+    queryClient.setQueryData<RelayEvent[]>(
+      channelMessagesKey(leftChannelId),
+      (current) =>
+        current && current.length > 0
+          ? normalizeTimelineMessages(current)
+          : current,
+    );
+  });
+
   useEffect(() => {
     if (!channelId || channelType === "forum") {
       return;
@@ -371,6 +392,7 @@ export function useChannelSubscription(channel: Channel | null) {
       if (cleanup) {
         void cleanup();
       }
+      trimTimelineOnLeave(channelId);
     };
   }, [channelId, channelType]);
 }

--- a/desktop/src/features/messages/lib/messageQueryKeys.test.mjs
+++ b/desktop/src/features/messages/lib/messageQueryKeys.test.mjs
@@ -263,3 +263,33 @@ test("sortMessages tiebreaks same-second events on id, order-independent", () =>
   assert.deepEqual(forward, reverse);
   assert.deepEqual(forward, [a.id, b.id, c.id]);
 });
+
+test("fresh-newest revalidation over an expanded cache never evicts scrolled-in history", () => {
+  // Regression: a channel holding more content events than the timeline cap
+  // (the user paged back to an old day), then a background revalidation
+  // merges the newest history window over it. The old rows must survive —
+  // capping this merge evicted the day being read (the "June 12 messages
+  // flicker away" bug).
+  const expandedCache = [];
+  for (let index = 0; index < 37; index += 1) {
+    expandedCache.push(
+      event({ id: id("jun", index), createdAt: 1_000 + index }),
+    );
+  }
+  for (let index = 0; index < 2_500; index += 1) {
+    expandedCache.push(
+      event({ id: id("mid", index), createdAt: 10_000 + index }),
+    );
+  }
+  const freshNewestPage = [];
+  for (let index = 0; index < 60; index += 1) {
+    freshNewestPage.push(
+      event({ id: id("fresh", index), createdAt: 50_000 + index }),
+    );
+  }
+
+  const merged = mergeTimelineHistoryMessages(expandedCache, freshNewestPage);
+
+  assert.equal(merged.filter((item) => item.id.startsWith("jun")).length, 37);
+  assert.equal(merged.filter((item) => item.kind === 9).length, 2_597);
+});

--- a/desktop/src/features/messages/lib/messageQueryKeys.ts
+++ b/desktop/src/features/messages/lib/messageQueryKeys.ts
@@ -96,37 +96,21 @@ export function normalizeTimelineMessages(messages: RelayEvent[]) {
   return capNewestTimelineMessages(sortMessages(messages));
 }
 
-function isOlderHistoryPage(current: RelayEvent[], history: RelayEvent[]) {
-  if (current.length === 0 || history.length === 0) {
-    return false;
-  }
-
-  const sortedCurrent = sortMessages(current);
-  const sortedHistory = sortMessages(history);
-  const newestHistory = sortedHistory[sortedHistory.length - 1]?.created_at;
-  const oldestCurrent = sortedCurrent[0]?.created_at;
-
-  if (newestHistory === undefined || oldestCurrent === undefined) {
-    return false;
-  }
-
-  return newestHistory <= oldestCurrent;
-}
-
-function normalizeTimelineHistoryMessages(
-  current: RelayEvent[],
-  history: RelayEvent[],
-) {
-  return sortMessages([...current, ...history]);
-}
-
+/**
+ * Merge a batch of events (older scrollback page, reconnect/revalidation
+ * window, live gap-fill) into the timeline cache. Sort + dedupe only — the
+ * {@link MAX_TIMELINE_MESSAGES} cap is deliberately NOT applied here.
+ *
+ * Capping merges into an already-painted timeline evicts history out from
+ * under a reader: page back to an old day in a channel holding more than the
+ * cap, and the next capped merge (live append, revalidation) silently deletes
+ * the rows being read. The cap is applied only by
+ * {@link normalizeTimelineMessages} at moments when nothing is rendered —
+ * the cold-snapshot paint and the channel-leave trim in `hooks.ts`.
+ */
 export function mergeTimelineHistoryMessages(
   current: RelayEvent[],
   history: RelayEvent[],
 ) {
-  if (isOlderHistoryPage(current, history)) {
-    return normalizeTimelineHistoryMessages(current, history);
-  }
-
-  return normalizeTimelineMessages([...current, ...history]);
+  return sortMessages([...current, ...history]);
 }


### PR DESCRIPTION
## The bug (Tyler's "missing messages" report)

Sometimes all of June 12's messages show in #buzz-bugs; sometimes one or two; sometimes none.

**Root cause:** `MAX_TIMELINE_MESSAGES = 2000` cap, applied inconsistently across merge paths. #buzz-bugs holds **2,770 kind-9 events since June 12** (measured via CLI pagination against the relay; the June-12 set itself is a stable 37 ids across 8+ repeated reads — the relay is fine). June 12 sits past the cap.

The flicker mechanism:
1. Scrollback merges were **uncapped** (`isOlderHistoryPage` special case) — you *can* page back to June 12 and see all 37. Cache now holds 2,700+ content events.
2. The next capped merge — any live event (`mergeTimelineCacheMessages`), or a fresh-history revalidation whose merge fell into the non-older branch of `mergeTimelineHistoryMessages` — trims the cache back to the newest 2,000, **silently evicting June 12 while it's on screen**.
3. Where the cap boundary lands decides what survives: all 37, a couple, or none. Exactly the reported symptom.

Reproduced with the repo's own `normalizeTimelineMessages`: 37 "June 12" rows + 2,764 newer rows → 0 survivors.

Predates the current perf PRs — the cap is from #212; #1105 refined it to count content events; #1452's longer-lived caches (gcTime 60min + persisted snapshots) made caches big enough for people to hit it routinely.

## The fix

Principle (per review discussion with Wren): **no merge into a potentially-on-screen timeline applies the cap; the cap is enforced only at moments when nothing is rendered from the cache.**

- `mergeTimelineHistoryMessages` → sort + dedupe only. Drops the `isOlderHistoryPage` branch split entirely — older-page merges and newest-window revalidations now behave identically, so a background refetch over an expanded cache can no longer evict scrolled-in history (this covers the revalidation-without-live-event case).
- `mergeTimelineCacheMessages` (live append / optimistic send) → same, now an alias of `mergeMessages`.
- The DOM bound survives where it's safe:
  - cold snapshot paint (`placeholderData`) — already capped, unchanged;
  - **new:** trim-on-leave in `useChannelSubscription`'s cleanup — leaving the channel re-applies `normalizeTimelineMessages`, so a long session can't grow caches unboundedly.

Net: while a channel is open its timeline only grows (bounded in practice by scrollback batches, 200/page × 3/pass); the moment you leave, it trims to 2,000 newest.

## Validation

- New regression test: 2,537-event expanded cache + fresh newest-page merge → all 37 old rows survive (red on main, green here).
- `pnpm --dir desktop test`: 1495/0. `pnpm check`, `pnpm --dir desktop typecheck`: clean.
- All existing cap tests (aux events don't consume the window, huddle starts count, capped old content) still pass — the capped normalizer itself is unchanged.

Fixes the merge-freeze blocker reported in #buzz-gui-performance.
