### PR TITLE
chore(mobile): declare non-exempt encryption usage in Info.plist

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -24,6 +24,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<true/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
## Summary

Sets `ITSAppUsesNonExemptEncryption` to `true` in the iOS `Info.plist` for App Store export compliance.

The Flutter app implements NIP-44 v2 encryption in-app (`mobile/lib/shared/crypto/nip44.dart`: ChaCha20 + HMAC-SHA256 + HKDF via `pointycastle`, plus secp256k1 ECDH) rather than relying solely on Apple's OS encryption. Per Apple's export compliance rules, that makes the app's encryption non-exempt, so the key must be `true`. All algorithms are published standards (IETF/SECG), so the app classifies as mass-market 5D992.c under License Exception ENC §740.17(b)(1) — no CCATS or document uploads required; the remaining compliance answers are given once in App Store Connect.

Setting the key in the plist answers the encryption prompt up front so TestFlight and App Store submissions aren't blocked per build.

## Test plan

- [x] Pre-commit and pre-push hooks pass (fmt, analyze, unit tests)
- [ ] Confirm next TestFlight upload no longer prompts for encryption compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)