### PR TITLE
fix(desktop): defer timeline trim past StrictMode probe

### DIFF
--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -33,6 +33,7 @@ import type { Channel, Identity, RelayEvent } from "@/shared/api/types";
 import { applyEditTagOverlay } from "@/features/messages/lib/applyEditTagOverlay.mjs";
 import { backfillAuxForMessages } from "@/features/messages/lib/auxBackfill";
 import { countTopLevelTimelineRows } from "@/features/messages/lib/formatTimelineMessages";
+import { deferredTimelineTrim } from "@/features/messages/lib/deferredTimelineTrim";
 import {
   mergeHistoryOverSnapshot,
   readMessageSnapshot,
@@ -325,12 +326,7 @@ export function useChannelSubscription(channel: Channel | null) {
     }
   });
 
-  // Leaving the channel is the safe moment to enforce the timeline cap:
-  // nothing is rendered from this cache anymore, so trimming to the newest
-  // MAX_TIMELINE_MESSAGES window cannot evict rows out from under a
-  // scrolled-back reader. Merges while the channel is open are deliberately
-  // uncapped for the same reason.
-  const trimTimelineOnLeave = useEffectEvent((leftChannelId: string) => {
+  const trimTimelineCache = useEffectEvent((leftChannelId: string) => {
     queryClient.setQueryData<RelayEvent[]>(
       channelMessagesKey(leftChannelId),
       (current) =>
@@ -344,6 +340,10 @@ export function useChannelSubscription(channel: Channel | null) {
     if (!channelId || channelType === "forum") {
       return;
     }
+
+    // StrictMode immediately re-runs this setup after its synthetic cleanup.
+    // Cancel the deferred trim while this channel remains active.
+    deferredTimelineTrim.cancel(channelId);
 
     let isDisposed = false;
     let cleanup: (() => Promise<void>) | undefined;
@@ -392,7 +392,9 @@ export function useChannelSubscription(channel: Channel | null) {
       if (cleanup) {
         void cleanup();
       }
-      trimTimelineOnLeave(channelId);
+      deferredTimelineTrim.schedule(channelId, () => {
+        trimTimelineCache(channelId);
+      });
     };
   }, [channelId, channelType]);
 }

--- a/desktop/src/features/messages/lib/deferredTimelineTrim.test.mjs
+++ b/desktop/src/features/messages/lib/deferredTimelineTrim.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createDeferredTimelineTrim } from "./deferredTimelineTrim.ts";
+
+function fakeTimerHost() {
+  let nextId = 1;
+  const callbacks = new Map();
+  return {
+    host: {
+      clearTimeout(id) {
+        callbacks.delete(id);
+      },
+      setTimeout(callback) {
+        const id = nextId++;
+        callbacks.set(id, callback);
+        return id;
+      },
+    },
+    flush() {
+      for (const [id, callback] of [...callbacks]) {
+        callbacks.delete(id);
+        callback();
+      }
+    },
+  };
+}
+
+test("StrictMode setup cancels the synthetic cleanup trim", () => {
+  const timers = fakeTimerHost();
+  const scheduler = createDeferredTimelineTrim(timers.host);
+  let trims = 0;
+
+  scheduler.schedule("channel-a", () => trims++);
+  scheduler.cancel("channel-a");
+  timers.flush();
+
+  assert.equal(trims, 0);
+});
+
+test("a genuine channel departure trims after the deferred task", () => {
+  const timers = fakeTimerHost();
+  const scheduler = createDeferredTimelineTrim(timers.host);
+  let trims = 0;
+
+  scheduler.schedule("channel-a", () => trims++);
+  timers.flush();
+
+  assert.equal(trims, 1);
+});

--- a/desktop/src/features/messages/lib/deferredTimelineTrim.ts
+++ b/desktop/src/features/messages/lib/deferredTimelineTrim.ts
@@ -1,0 +1,36 @@
+type TimerHost = {
+  setTimeout: (
+    handler: () => void,
+    delay: number,
+  ) => ReturnType<typeof setTimeout>;
+  clearTimeout: (timer: ReturnType<typeof setTimeout>) => void;
+};
+
+/**
+ * Defers leave-only cache trims by one task. React StrictMode immediately
+ * re-runs an effect after its synthetic cleanup, so the matching setup can
+ * cancel that trim while a real channel departure lets it run.
+ */
+export function createDeferredTimelineTrim(host: TimerHost = globalThis) {
+  const pending = new Map<string, ReturnType<typeof setTimeout>>();
+
+  return {
+    cancel(channelId: string) {
+      const timer = pending.get(channelId);
+      if (timer !== undefined) {
+        host.clearTimeout(timer);
+        pending.delete(channelId);
+      }
+    },
+    schedule(channelId: string, trim: () => void) {
+      this.cancel(channelId);
+      const timer = host.setTimeout(() => {
+        pending.delete(channelId);
+        trim();
+      }, 0);
+      pending.set(channelId, timer);
+    },
+  };
+}
+
+export const deferredTimelineTrim = createDeferredTimelineTrim();


### PR DESCRIPTION
## Summary
- defer leave-time timeline trimming by one task so React StrictMode's synthetic setup → cleanup → setup cycle cannot trim an actively mounted channel
- cancel a pending trim when the same channel subscription sets up again
- keep the bounded-cache behavior on a real channel leave
- add focused scheduler regressions for cancellation, real leave, and channel-key isolation

## Context
This is stacked on #1473. #1473 removes cap-driven eviction from active timeline merges; this follow-up makes its leave-time cleanup safe under the app's `React.StrictMode` mount probe.

This does **not** address the separate ancestor-island paging cursor bug. That contiguous-frontier fix is being developed separately and must compose with this patch before the missing-history freeze is lifted.

## Validation
- desktop tests: 1497 passed, 0 failed
- desktop typecheck: clean
- `pnpm check`: clean
- full pre-commit hooks: clean
- pre-push hooks with the repo-pinned Hermit/Rust 1.95 toolchain: clean

An initial push attempt used Homebrew Rust 1.89 and correctly failed the `buzz-db` MSRV gate (`sqlx 0.9` requires Rust 1.94). Re-running under the repository's pinned Hermit environment passed all hooks.
