### PR TITLE
fix(desktop): stop Leave-channel dialog from freezing the app

### DIFF
--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -387,7 +387,11 @@ export function ChannelGroupSection({
     items.length > 0 ? (
       <SidebarMenu data-testid={listTestId}>
         {items.map((channel) => (
-          <ContextMenu key={channel.id}>
+          // modal={false}: menu items (e.g. Leave channel) open a modal
+          // AlertDialog. A modal ContextMenu would leave `pointer-events: none`
+          // stuck on <body> when it closes as the dialog mounts, freezing the
+          // whole app. Non-modal avoids installing that body guard entirely.
+          <ContextMenu key={channel.id} modal={false}>
             <ContextMenuTrigger asChild>
               <SidebarMenuItem className="content-visibility-auto-row">
                 {draggable ? (
@@ -572,7 +576,10 @@ export function CustomChannelSection({
               isDragging && "opacity-30",
             )}
           >
-            <ContextMenu>
+            {/* modal={false}: Rename/Delete section open a modal dialog;
+                a modal ContextMenu would leave `pointer-events: none` stuck on
+                <body> after it closes, freezing the app. */}
+            <ContextMenu modal={false}>
               <ContextMenuTrigger asChild>
                 <div className="relative" {...dragHandleProps}>
                   <SidebarGroupLabel asChild>
@@ -673,7 +680,10 @@ export function CustomChannelSection({
                 {channels.length > 0 ? (
                   <SidebarMenu>
                     {channels.map((channel) => (
-                      <ContextMenu key={channel.id}>
+                      // modal={false}: see note on the other channel ContextMenu
+                      // above — avoids the pointer-events lockup when Leave
+                      // channel's AlertDialog opens.
+                      <ContextMenu key={channel.id} modal={false}>
                         <ContextMenuTrigger asChild>
                           <SidebarMenuItem>
                             <DraggableChannelRow channelId={channel.id}>

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -22,6 +22,20 @@ async function storedSidebarWidth(page: Page) {
   );
 }
 
+// Regression guard for the "Leave channel" lockup: opening a modal AlertDialog
+// from a modal Radix ContextMenu leaves `pointer-events: none` stuck on <body>
+// after the dialog closes, freezing the whole app. The fix makes the sidebar
+// context menus non-modal. This asserts the app is still interactive.
+async function expectAppClickable(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => getComputedStyle(document.body).pointerEvents),
+    )
+    .not.toBe("none");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+}
+
 async function dragSidebarRail(page: Page, deltaX: number) {
   const sidebarRail = page.locator('[data-sidebar="rail"]');
   await expect(sidebarRail).toBeVisible();
@@ -40,6 +54,29 @@ async function dragSidebarRail(page: Page, deltaX: number) {
   await page.mouse.move(startX + deltaX, startY, { steps: 8 });
   await page.mouse.up();
 }
+
+test("leaving a channel from the context menu never freezes the app", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+
+  // Cancel path: dialog opens from the context menu, then is dismissed.
+  await page.getByTestId("channel-random").click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Leave channel" }).click();
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByRole("alertdialog")).toHaveCount(0);
+  await expectAppClickable(page);
+
+  // Confirm path: same overlay lifecycle, plus the leave mutation.
+  await page.getByTestId("channel-random").click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Leave channel" }).click();
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+  await page.getByRole("button", { name: "Leave" }).click();
+  await expect(page.getByRole("alertdialog")).toHaveCount(0);
+  await expectAppClickable(page);
+});
 
 test("fades the pinned sidebar chrome edges", async ({ page }) => {
   await page.goto("/");


### PR DESCRIPTION
## Problem

Right-click a channel in the sidebar → **Leave channel**. The confirm dialog appears, but selecting **either** button (Cancel *or* Leave) freezes the whole app — nothing is clickable afterward.

## Root cause

The "Leave channel" item opens a modal Radix `AlertDialog` from inside the modal Radix `ContextMenu`. A modal context menu renders through Radix's modal content path, which installs a `RemoveScroll` + `pointer-events: none` guard on `<body>`. The `AlertDialog` manages the same `<body>` style. As the menu closes while the dialog mounts, Radix's async add/remove of that guard races, and `pointer-events: none` is left stuck on `<body>` after the dialog closes — regardless of which button was clicked (both just flip the dialog's `open` to `false`). The result is a fully unclickable app. The leave mutation is not involved (Cancel never runs it).

This path regressed when **#1428** (workspace-rail unread observer, branched before #1424 and merged after) accidentally merge-stomped **#1424**, which had fixed this and added a regression test. Current `main` was back to the pre-#1424 synchronous `onClick` with no fix and no test.

## Fix

Set `modal={false}` on the sidebar `<ContextMenu>` roots. A non-modal context menu uses Radix's non-modal content path, which installs **neither** the `RemoveScroll` nor the `pointer-events: none` body guard — so there is no second `<body>` layer to race with the dialog, and the failure mode is removed at the source, independent of JS-engine timing.

- Chosen over re-adding a `setTimeout` defer (the #1424 approach): a defer only shrinks the race window and stays timing-dependent. The app ships on macOS **WKWebView**, which can't be validated in the Chromium-based e2e suite, so an engine-independent fix is safer here.
- This is `modal={false}` on the **ContextMenu**, not the `AlertDialog`. The destructive-confirm dialog stays fully modal — focus trap and scroll lock on the confirm are unchanged.
- Applied to the default **Channels** list (`ChannelGroupSection`) and the custom-section menus (`CustomChannelSection`), so the identical latent freeze on **Rename / Delete section** is fixed too.

## Test

Restores the regression test #1428 dropped, in `desktop/tests/e2e/sidebar.spec.ts`, now covering **both** the Cancel and Leave paths — it asserts `document.body` never keeps `pointer-events: none` and that the app remains interactive after the dialog closes.

## Notes for reviewers

- The e2e suite runs in Chromium; the production app runs in macOS WKWebView. A green Chromium run alone did not catch the original freeze, which is part of why this uses the engine-independent `modal={false}` rather than a timing-based defer.

## Test plan

- [ ] CI (lint + desktop e2e)
- [ ] Manual: right-click a channel → Leave channel → Cancel → app stays interactive
- [ ] Manual: right-click a channel → Leave channel → Leave → app stays interactive
- [ ] Manual: right-click a custom section → Delete section → Cancel/Delete → app stays interactive
