### PR TITLE
fix(desktop): launch at sane default window size

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -84,16 +84,14 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(
             tauri_plugin_window_state::Builder::default()
-                // The main window should always launch edge-to-edge in the
-                // available desktop area. Do not let stale saved geometry or
-                // fullscreen state override the maximized launch config.
+                // Restore the user's window size/position (and maximized
+                // state) across launches. First launch falls back to the
+                // centered default bounds in tauri.conf.json instead of
+                // opening edge-to-edge. Visibility stays managed by the app
+                // (window is revealed once React mounts) and fullscreen is
+                // never restored — relaunching into fullscreen is jarring.
                 .with_state_flags(
-                    StateFlags::all()
-                        & !(StateFlags::VISIBLE
-                            | StateFlags::POSITION
-                            | StateFlags::SIZE
-                            | StateFlags::MAXIMIZED
-                            | StateFlags::FULLSCREEN),
+                    StateFlags::all() & !(StateFlags::VISIBLE | StateFlags::FULLSCREEN),
                 )
                 .build(),
         )

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -17,9 +17,9 @@
     "windows": [
       {
         "title": "",
-        "width": 800,
-        "height": 600,
-        "maximized": true,
+        "width": 1280,
+        "height": 800,
+        "center": true,
         "visible": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -234,7 +234,11 @@ export function App() {
   useReloadShortcut();
 
   useLayoutEffect(() => {
-    void getCurrentWindow().show();
+    // The window starts hidden (visible: false in tauri.conf.json) so users
+    // never see an unstyled flash. Reveal it once React mounts, and focus it
+    // explicitly — show() alone can leave the window behind others on launch.
+    const appWindow = getCurrentWindow();
+    void appWindow.show().then(() => appWindow.setFocus());
   }, []);
 
   const [sharedIdentity, setSharedIdentity] = useState<boolean | null>(null);


### PR DESCRIPTION
**Category:** fix
**User Impact:** Buzz Desktop now opens at a comfortable centered size and returns to the user's last chosen window size on future launches.
**Problem:** The desktop app launched maximized on every start, which made fresh dev builds and large displays feel unnecessarily full-screen. Because saved geometry was skipped, user resizing did not survive relaunches, and the hidden-until-ready startup flow could reveal the window behind other apps.
**Solution:** Start from a centered 1280×800 default, restore saved window geometry across launches, and explicitly focus the window after it is shown.

<details>
<summary>File changes</summary>

**desktop/src-tauri/tauri.conf.json**
Updates the main window default from maximized to a centered 1280×800 launch size while keeping the existing minimum size.

**desktop/src-tauri/src/lib.rs**
Lets the window-state plugin restore size, position, and maximized state so a user's chosen geometry sticks between launches. Visibility and fullscreen remain excluded to preserve the app-managed reveal and avoid relaunching into fullscreen.

**desktop/src/app/App.tsx**
Focuses the Tauri window after the React-mounted reveal so the app does not appear underneath other windows at startup.

</details>

## Reproduction Steps

1. Launch Buzz Desktop with no saved window state.
2. Confirm the app opens centered around 1280×800 instead of maximized/full-screen-ish.
3. Resize and/or move the window, quit the app, then launch it again.
4. Confirm the previous size and position are restored.
5. Launch while other windows are present and confirm Buzz comes to the front after the hidden startup window is shown.

## Validation

- `pnpm biome` clean
- `pnpm tsc` clean
- 1549/1549 desktop tests pass
- `cargo fmt --check` clean
- `cargo check` clean

Coordination: buzz://message?channel=d63b9dbc-f4b0-4770-8da0-a5baedac4edc&thread=860b6f23c85089d3ca3a12a79f0973f747e62828302bc65c5e8ccf6bb1dbcb0d
