### PR TITLE
feat(desktop): universal activity ingresses and explicit panel scope

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         "**/profile-active-turn.spec.ts",
         "**/config-bridge-screenshots.spec.ts",
         "**/observer-feed-screenshots.spec.ts",
+        "**/activity-scope-label-screenshots.spec.ts",
         "**/file-attachment.spec.ts",
         "**/image-attachment-gallery.spec.ts",
         "**/video-attachment.spec.ts",

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -145,6 +145,8 @@ export function useAppNavigation() {
     (
       channelId: string,
       options?: {
+        /** Open the agent activity pane for this agent pubkey on arrival. */
+        agentSession?: string;
         messageId?: string;
         replace?: boolean;
         threadRootId?: string | null;
@@ -156,12 +158,17 @@ export function useAppNavigation() {
           params: {
             channelId,
           },
-          search: options?.messageId
-            ? {
-                messageId: options.messageId,
-                threadRootId: options.threadRootId ?? undefined,
-              }
-            : {},
+          search: {
+            ...(options?.messageId
+              ? {
+                  messageId: options.messageId,
+                  threadRootId: options.threadRootId ?? undefined,
+                }
+              : {}),
+            ...(options?.agentSession
+              ? { agentSession: options.agentSession }
+              : {}),
+          },
         },
         {
           replace: options?.replace,

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -7,6 +7,7 @@ import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
 import { Badge } from "@/shared/ui/badge";
 import { AgentStatusBadge } from "@/features/agents/ui/AgentStatusBadge";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
+import { useOpenAgentActivity } from "@/features/agents/useOpenAgentActivity";
 import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
 import { useNow } from "@/shared/lib/useNow";
 import type {
@@ -202,6 +203,7 @@ function AgentSummary({
   presenceStatus: PresenceStatus | undefined;
 }) {
   const { goChannel } = useAppNavigation();
+  const { openAgentActivity } = useOpenAgentActivity();
 
   return (
     <div className="min-w-0">
@@ -275,7 +277,11 @@ function AgentSummary({
                   channelId={channel.id}
                   name={channel.name}
                   anchorAt={channel.anchorAt}
-                  onNavigate={goChannel}
+                  // Deep-link straight into the agent's activity pane in the
+                  // working channel, not just the channel timeline.
+                  onNavigate={(channelId) =>
+                    openAgentActivity(agent.pubkey, { channelId })
+                  }
                 />
               ))}
             </div>

--- a/desktop/src/features/agents/useOpenAgentActivity.test.mjs
+++ b/desktop/src/features/agents/useOpenAgentActivity.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  isChannelOpenable,
+  resolveOpenableActivityChannelId,
+} from "./useOpenAgentActivity.ts";
+
+describe("isChannelOpenable", () => {
+  it("allows joined channels regardless of visibility", () => {
+    assert.equal(
+      isChannelOpenable({ isMember: true, visibility: "private" }),
+      true,
+    );
+    assert.equal(
+      isChannelOpenable({ isMember: true, visibility: "open" }),
+      true,
+    );
+  });
+
+  it("allows open channels the viewer hasn't joined (read-only)", () => {
+    assert.equal(
+      isChannelOpenable({ isMember: false, visibility: "open" }),
+      true,
+    );
+  });
+
+  it("rejects private channels the viewer hasn't joined", () => {
+    assert.equal(
+      isChannelOpenable({ isMember: false, visibility: "private" }),
+      false,
+    );
+  });
+
+  it("rejects channels missing from the viewer's channel list", () => {
+    assert.equal(isChannelOpenable(undefined), false);
+  });
+});
+
+describe("resolveOpenableActivityChannelId", () => {
+  it("prefers the first openable working channel", () => {
+    assert.equal(
+      resolveOpenableActivityChannelId({
+        agentChannelIds: ["member-1"],
+        openableChannelIds: new Set(["working-2", "member-1"]),
+        workingChannelIds: ["working-1", "working-2"],
+      }),
+      "working-2",
+    );
+  });
+
+  it("falls back to the agent's first openable member channel", () => {
+    assert.equal(
+      resolveOpenableActivityChannelId({
+        agentChannelIds: ["hidden-2", "member-1"],
+        openableChannelIds: new Set(["member-1"]),
+        workingChannelIds: ["hidden-1"],
+      }),
+      "member-1",
+    );
+  });
+
+  it("returns null when the agent is only active in inaccessible rooms", () => {
+    assert.equal(
+      resolveOpenableActivityChannelId({
+        agentChannelIds: ["hidden-2"],
+        openableChannelIds: new Set(["unrelated"]),
+        workingChannelIds: ["hidden-1"],
+      }),
+      null,
+    );
+  });
+
+  it("returns null with no candidate channels at all", () => {
+    assert.equal(
+      resolveOpenableActivityChannelId({
+        agentChannelIds: [],
+        openableChannelIds: new Set(),
+        workingChannelIds: [],
+      }),
+      null,
+    );
+  });
+});

--- a/desktop/src/features/agents/useOpenAgentActivity.ts
+++ b/desktop/src/features/agents/useOpenAgentActivity.ts
@@ -100,6 +100,12 @@ export function useOpenAgentActivity() {
       return resolveOpenableActivityChannelId({
         agentChannelIds: relayAgent?.channelIds ?? [],
         openableChannelIds,
+        // Deliberately an unsubscribed snapshot: this callback runs on click
+        // (and in canOpenAgentActivity), not in render, so we don't need to
+        // recompute when working state changes — its deps are only
+        // [channels, relayAgents]. Worst case the preferred working-channel
+        // target lags a just-changed signal; the member-channel fallback in
+        // resolveOpenableActivityChannelId keeps the destination valid.
         workingChannelIds: getAgentWorkingState(pubkey).channels.map(
           (working) => working.channelId,
         ),
@@ -113,9 +119,20 @@ export function useOpenAgentActivity() {
       if (!pubkey) {
         return false;
       }
-      return Boolean(onOpenAgentSession) || resolveChannelId(pubkey) !== null;
+      if (onOpenAgentSession) {
+        return true;
+      }
+      // While channels are still loading, resolveChannelId can only see an
+      // empty openable set and would report a transient false. Stay
+      // optimistic until channels resolve so "View activity log" doesn't
+      // flicker in on cold start; openAgentActivity still guards the actual
+      // navigation.
+      if (channels === undefined) {
+        return true;
+      }
+      return resolveChannelId(pubkey) !== null;
     },
-    [onOpenAgentSession, resolveChannelId],
+    [channels, onOpenAgentSession, resolveChannelId],
   );
 
   const openAgentActivity = React.useCallback(

--- a/desktop/src/features/agents/useOpenAgentActivity.ts
+++ b/desktop/src/features/agents/useOpenAgentActivity.ts
@@ -1,0 +1,161 @@
+import * as React from "react";
+import { toast } from "sonner";
+
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useChannelsQuery } from "@/features/channels/hooks";
+import { useAgentSession } from "@/shared/context/AgentSessionContext";
+import type { Channel } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { getAgentWorkingState } from "./agentWorkingSignal";
+import { useRelayAgentsQuery } from "./hooks";
+
+const INACCESSIBLE_ACTIVITY_MESSAGE =
+  "This agent is active in a channel you haven't joined, so its activity can't be opened from here.";
+
+/**
+ * Can the viewer actually open this channel? Joined channels always;
+ * open-visibility channels are readable without joining. Channels missing
+ * from the viewer's channel list (e.g. private rooms they aren't in) are
+ * not navigable destinations.
+ */
+export function isChannelOpenable(
+  channel: Pick<Channel, "isMember" | "visibility"> | undefined,
+): boolean {
+  return (
+    channel !== undefined && (channel.isMember || channel.visibility === "open")
+  );
+}
+
+/**
+ * Pick the channel to land in when opening an agent's activity from a
+ * non-channel route: the agent's first working channel the viewer can open,
+ * else the agent's first member channel the viewer can open, else null.
+ */
+export function resolveOpenableActivityChannelId({
+  agentChannelIds,
+  openableChannelIds,
+  workingChannelIds,
+}: {
+  agentChannelIds: readonly string[];
+  openableChannelIds: ReadonlySet<string>;
+  workingChannelIds: readonly string[];
+}): string | null {
+  for (const channelId of workingChannelIds) {
+    if (openableChannelIds.has(channelId)) {
+      return channelId;
+    }
+  }
+  for (const channelId of agentChannelIds) {
+    if (openableChannelIds.has(channelId)) {
+      return channelId;
+    }
+  }
+  return null;
+}
+
+/**
+ * Universal ingress for opening an agent's activity pane.
+ *
+ * Inside a channel screen the AgentSessionContext handler opens the pane in
+ * place. Everywhere else (agents page, home profile panel, popovers reached
+ * from non-channel routes) there is no provider, so we navigate to a channel
+ * with the `agentSession` search param instead — preferring a channel the
+ * agent is currently working in (unified working signal), then falling back
+ * to the first channel the agent is a member of.
+ *
+ * Navigation only ever targets channels the viewer can actually open
+ * (joined, or open visibility). Owner-global ingestion means the working
+ * signal can report activity in rooms the viewer can't access; deep-linking
+ * there would land on a screen they can't read. In that case we surface a
+ * safe warning instead of navigating — no channel content, no trap-door.
+ *
+ * This replaces the old behavior where "View activity log" silently
+ * disappeared on routes without an AgentSessionProvider.
+ */
+export function useOpenAgentActivity() {
+  const { onOpenAgentSession } = useAgentSession();
+  const { goChannel } = useAppNavigation();
+  const relayAgentsQuery = useRelayAgentsQuery();
+  const relayAgents = relayAgentsQuery.data;
+  const channelsQuery = useChannelsQuery();
+  const channels = channelsQuery.data;
+
+  const findOpenableChannel = React.useCallback(
+    (channelId: string): boolean =>
+      isChannelOpenable(channels?.find((entry) => entry.id === channelId)),
+    [channels],
+  );
+
+  const resolveChannelId = React.useCallback(
+    (pubkey: string): string | null => {
+      const key = normalizePubkey(pubkey);
+      const relayAgent = relayAgents?.find(
+        (agent) => normalizePubkey(agent.pubkey) === key,
+      );
+      const openableChannelIds = new Set(
+        (channels ?? [])
+          .filter((channel) => isChannelOpenable(channel))
+          .map((channel) => channel.id),
+      );
+      return resolveOpenableActivityChannelId({
+        agentChannelIds: relayAgent?.channelIds ?? [],
+        openableChannelIds,
+        workingChannelIds: getAgentWorkingState(pubkey).channels.map(
+          (working) => working.channelId,
+        ),
+      });
+    },
+    [channels, relayAgents],
+  );
+
+  const canOpenAgentActivity = React.useCallback(
+    (pubkey: string | null | undefined): boolean => {
+      if (!pubkey) {
+        return false;
+      }
+      return Boolean(onOpenAgentSession) || resolveChannelId(pubkey) !== null;
+    },
+    [onOpenAgentSession, resolveChannelId],
+  );
+
+  const openAgentActivity = React.useCallback(
+    (pubkey: string, options?: { channelId?: string | null }): boolean => {
+      // An explicit channel target (e.g. clicking a "Working in #channel"
+      // badge) navigates so the pane opens scoped to that channel — but only
+      // when the viewer can actually open that channel. Scoping the pane to
+      // an inaccessible room (in place or via navigation) would expose that
+      // room's activity content, so we warn and stop instead.
+      if (options?.channelId) {
+        if (!findOpenableChannel(options.channelId)) {
+          toast.warning(INACCESSIBLE_ACTIVITY_MESSAGE);
+          return false;
+        }
+        if (!onOpenAgentSession) {
+          void goChannel(options.channelId, { agentSession: pubkey });
+          return true;
+        }
+        onOpenAgentSession(pubkey, options.channelId);
+        return true;
+      }
+      if (onOpenAgentSession) {
+        onOpenAgentSession(pubkey);
+        return true;
+      }
+      const channelId = resolveChannelId(pubkey);
+      if (channelId) {
+        void goChannel(channelId, { agentSession: pubkey });
+        return true;
+      }
+      // The agent may be working somewhere, just nowhere the viewer can open.
+      // Say so plainly rather than failing silently — without leaking which
+      // room, or navigating into it.
+      if (getAgentWorkingState(pubkey).channels.length > 0) {
+        toast.warning(INACCESSIBLE_ACTIVITY_MESSAGE);
+      }
+      return false;
+    },
+    [findOpenableChannel, goChannel, onOpenAgentSession, resolveChannelId],
+  );
+
+  return { canOpenAgentActivity, openAgentActivity };
+}

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -53,6 +53,7 @@ import {
   useTranscriptTimestampsEnabled,
 } from "@/features/agents/ui/transcriptTimestampPreference";
 import type { ChannelAgentSessionAgent } from "./useChannelAgentSessions";
+import { useChannelsQuery } from "@/features/channels/hooks";
 
 type AgentSessionThreadPanelProps = {
   agent: ChannelAgentSessionAgent;
@@ -126,6 +127,29 @@ export function AgentSessionThreadPanel({
       ? undefined
       : `Last updated ${new Date(latestActivityAt).toLocaleString()}`;
   const rawFeedScopeKey = `${agent.pubkey}:${sessionChannelId ?? "all"}`;
+  // Scope label input: prefer the passed channel's name; when the pane is
+  // channel-scoped without a full Channel object (#1380's channelId prop),
+  // resolve the name from the channels cache.
+  const channelsQuery = useChannelsQuery({
+    enabled: Boolean(sessionChannelId),
+  });
+  const scopeChannelName = React.useMemo(() => {
+    if (!sessionChannelId) {
+      return null;
+    }
+    if (channel && channel.id === sessionChannelId) {
+      return channel.name;
+    }
+    return (
+      channelsQuery.data?.find((entry) => entry.id === sessionChannelId)
+        ?.name ?? null
+    );
+  }, [channel, channelsQuery.data, sessionChannelId]);
+  const scopeLabel = sessionChannelId
+    ? scopeChannelName
+      ? `#${scopeChannelName}`
+      : "1 channel"
+    : "All channels";
   const [rawFeedState, setRawFeedState] = React.useState(() => ({
     scopeKey: rawFeedScopeKey,
     show: false,
@@ -323,6 +347,14 @@ export function AgentSessionThreadPanel({
           subtitleTitle={lastUpdatedTitle}
           title={showRawFeed ? "Raw ACP Activity" : "Activity"}
         />
+        {/* Scope label: makes channel-targeted vs all-channels state obvious
+            (an all-channels pane can look "wrong" without it). */}
+        <span
+          className="min-w-0 shrink truncate text-xs text-muted-foreground"
+          data-testid="agent-session-scope-label"
+        >
+          {scopeLabel}
+        </span>
       </AuxiliaryPanelHeaderGroup>
       {agentHeaderActions}
     </>

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -80,7 +80,7 @@ import {
 } from "@/features/profile/ui/UserProfilePanelUtils";
 import { useProfileDmAction } from "@/features/profile/ui/useProfileDmAction";
 import { useUserStatusQuery } from "@/features/user-status/hooks";
-import { useAgentSession } from "@/shared/context/AgentSessionContext";
+import { useOpenAgentActivity } from "@/features/agents/useOpenAgentActivity";
 import { useEscapeKey } from "@/shared/hooks/useEscapeKey";
 import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
 import { AuxiliaryPanelBody } from "@/shared/layout/AuxiliaryPanel";
@@ -229,7 +229,7 @@ export function UserProfilePanel({
   const contactListQuery = useContactListQuery(currentPubkey);
   const followMutation = useFollowMutation(currentPubkey);
   const unfollowMutation = useUnfollowMutation(currentPubkey);
-  const { onOpenAgentSession } = useAgentSession();
+  const { canOpenAgentActivity, openAgentActivity } = useOpenAgentActivity();
   const { goChannel } = useAppNavigation();
   const profile = resolvePanelProfile({
     managedAgent,
@@ -301,7 +301,9 @@ export function UserProfilePanel({
     pubkeyLower.length > 0 &&
     pubkeyLower === currentPubkey.toLowerCase();
   const canViewActivity =
-    viewerIsOwner && Boolean(onOpenAgentSession) && Boolean(effectivePubkey);
+    viewerIsOwner &&
+    Boolean(effectivePubkey) &&
+    canOpenAgentActivity(effectivePubkey);
   const canOpenAgentLogs =
     isOwner === true && managedAgent?.backend.type === "local";
   const canInstantiateAgent =
@@ -662,9 +664,9 @@ export function UserProfilePanel({
   const handleOpenActivity = React.useCallback(
     (channelId?: string | null) => {
       if (!effectivePubkey) return;
-      onOpenAgentSession?.(effectivePubkey, channelId ?? null);
+      openAgentActivity(effectivePubkey, { channelId: channelId ?? null });
     },
-    [effectivePubkey, onOpenAgentSession],
+    [effectivePubkey, openAgentActivity],
   );
 
   const handleOpenChannel = React.useCallback(

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -37,7 +37,7 @@ import {
   mergeTimelineCacheMessages,
 } from "@/features/messages/hooks";
 import { buildWaveMessageContent } from "@/features/messages/lib/waveMessage";
-import { useAgentSession } from "@/shared/context/AgentSessionContext";
+import { useOpenAgentActivity } from "@/features/agents/useOpenAgentActivity";
 import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 import { sendChannelMessage } from "@/shared/api/tauri";
 import type { Channel, RelayEvent } from "@/shared/api/types";
@@ -200,7 +200,7 @@ export function UserProfilePopover({
   });
   const userStatusQuery = useUserStatusQuery(open ? [pubkey] : []);
 
-  const { onOpenAgentSession } = useAgentSession();
+  const { canOpenAgentActivity, openAgentActivity } = useOpenAgentActivity();
   const { openProfilePanel } = useProfilePanel();
   const canOpenProfilePanel = enableProfilePanel && Boolean(openProfilePanel);
   const relayAgent = relayAgentsQuery.data?.find((a) => a.pubkey === pubkey);
@@ -245,7 +245,7 @@ export function UserProfilePopover({
   const isCurrentUserOwner = ownsAuthorAgent(profile, currentPubkey);
   const viewerIsOwner = isCurrentUserOwner || isOwner === true;
   const canViewActivity =
-    isBotProfile && viewerIsOwner && Boolean(onOpenAgentSession);
+    isBotProfile && viewerIsOwner && canOpenAgentActivity(pubkey);
   const presenceStatus = presenceQuery.data?.[pubkey.toLowerCase()];
   const userStatus = userStatusQuery.data?.[pubkey.toLowerCase()];
   const userStatusText = userStatus?.text.trim() ?? "";
@@ -609,7 +609,7 @@ export function UserProfilePopover({
               data-testid={`user-profile-view-activity-${pubkey}`}
               onClick={() => {
                 setOpen(false);
-                onOpenAgentSession?.(pubkey);
+                openAgentActivity(pubkey);
               }}
               type="button"
             >

--- a/desktop/tests/e2e/activity-scope-label-screenshots.spec.ts
+++ b/desktop/tests/e2e/activity-scope-label-screenshots.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const SHOTS = "test-results/activity-scope-label";
+
+const AGENT_PUBKEY = TEST_IDENTITIES.tyler.pubkey;
+const AGENTS_CHANNEL_ID = "94a444a4-c0a3-5966-ab05-530c6ddc2301"; // #agents
+
+// Open the activity pane via profile → "View activity" (same ingress the
+// observer-feed screenshot spec uses).
+async function openActivityFromChannel(
+  page: import("@playwright/test").Page,
+  channelTestId: string,
+  channelTitle: string,
+) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId(channelTestId).click();
+  await expect(page.getByTestId("chat-title")).toHaveText(channelTitle);
+
+  const messageRow = page
+    .getByTestId("message-row")
+    .filter({ has: page.getByText("Observer Agent", { exact: false }) });
+  await expect(messageRow.first()).toBeVisible({ timeout: 8_000 });
+  await messageRow.first().getByRole("button").first().click();
+
+  const profilePanel = page.getByTestId("user-profile-panel");
+  await expect(profilePanel).toBeVisible({ timeout: 10_000 });
+
+  const activityBtn = page.getByTestId(
+    `user-profile-view-activity-${AGENT_PUBKEY}`,
+  );
+  await expect(activityBtn).toBeVisible({ timeout: 5_000 });
+  await activityBtn.click();
+
+  const panel = page.getByTestId("agent-session-thread-panel");
+  await expect(panel).toBeVisible({ timeout: 10_000 });
+  return panel;
+}
+
+test.describe("activity panel scope label", () => {
+  test("channel-targeted pane shows the channel name", async ({ page }) => {
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: AGENT_PUBKEY,
+          name: "Observer Agent",
+          status: "running" as const,
+          channelNames: ["agents"],
+        },
+      ],
+    });
+
+    const panel = await openActivityFromChannel(
+      page,
+      "channel-agents",
+      "agents",
+    );
+    await expect(page.getByTestId("agent-session-scope-label")).toHaveText(
+      "#agents",
+    );
+
+    await waitForAnimations(page);
+    await panel.screenshot({ path: `${SHOTS}/01-channel-scoped.png` });
+  });
+
+  test("unscoped pane shows All channels", async ({ page }) => {
+    // The agent lives in #random only. Restoring an agentSession URL on
+    // #agents (where the agent is not in the activity list) puts the pane in
+    // all-channels scope — the state that looked silently broken before the
+    // scope label existed. The app uses a hash router, so the deep link goes
+    // in the hash.
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: AGENT_PUBKEY,
+          name: "Observer Agent",
+          status: "running" as const,
+          channelNames: ["random"],
+        },
+      ],
+    });
+
+    await page.goto(
+      `/#/channels/${AGENTS_CHANNEL_ID}?agentSession=${AGENT_PUBKEY}`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await expect(page.getByTestId("chat-title")).toHaveText("agents");
+
+    const panel = page.getByTestId("agent-session-thread-panel");
+    await expect(panel).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("agent-session-scope-label")).toHaveText(
+      "All channels",
+    );
+
+    await waitForAnimations(page);
+    await panel.screenshot({ path: `${SHOTS}/02-all-channels.png` });
+  });
+});


### PR DESCRIPTION
> **Stacked on #1494** (`tho/agent-working-signal`). Merge order: #1492 → #1493 → #1494 → this.

## Overview

**Category:** improvement
**User Impact:** You can open an agent's activity log from anywhere in the app — the agents page, home profile panels, profile popovers, and "Working in #channel" badges now all lead directly into the activity pane — and the pane clearly labels whether it's showing one channel or all channels.

**Problem:** The activity pane was only reachable from inside a channel screen: "View activity log" silently disappeared on `/agents` and home because those routes had no `AgentSessionProvider`, working badges dropped you on the channel timeline instead of the agent's activity, and the pane gave no hint whether it was channel-scoped or showing everything — which repeatedly made an all-channels pane look broken during the liveness debugging pass.

**Solution:** A reusable `useOpenAgentActivity` ingress: in-channel it uses the existing context handler; everywhere else it navigates with the (already-supported) `agentSession` search param, preferring a channel the agent is currently working in via the unified working signal. All profile/badge ingresses adopt it, and the pane header gains an explicit scope label.

<details>
<summary>File changes</summary>

**desktop/src/features/agents/useOpenAgentActivity.ts**
New universal ingress hook: context handler when present, else `goChannel(channelId, { agentSession })` targeting the agent's working channel (unified signal) or first member channel; exposes `canOpenAgentActivity` for gating.

**desktop/src/app/navigation/useAppNavigation.ts**
`goChannel` accepts an `agentSession` option; the channel route already validates and restores that search param.

**desktop/src/features/profile/ui/UserProfilePanel.tsx**, **desktop/src/features/profile/ui/UserProfilePopover.tsx**
"View activity log" gates switch from `Boolean(onOpenAgentSession)` to `canOpenAgentActivity` — the affordance now works on `/agents` and home, not only inside channels.

**desktop/src/features/agents/ui/ManagedAgentRow.tsx**
"Working in #channel" badges open the agent's activity pane in that channel instead of the bare timeline.

**desktop/src/features/profile/ui/UserProfilePanelSections.tsx**
Profile working badges deep-link into activity for owners; non-owners still get the channel timeline (the pane's data is owner-scoped).

**desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx**
Header scope label: `#channel` when channel-targeted, `All channels` otherwise.

</details>

## Reproduction Steps

1. Go to the Agents page, open an agent's profile — "Activity log" now appears and works (previously hidden off-channel). Clicking it lands in the agent's working channel with the activity pane open.
2. While an agent is working, click its "Working in #channel" badge on the agents list or profile — you land in the activity pane for that channel, not just the timeline.
3. Open an agent's activity from a profile that isn't in the channel's activity list — the pane header now reads "All channels" instead of looking silently unscoped; channel-targeted panes show `#channel-name`.
4. Automated: `cd desktop && pnpm test` (1573/1573), `pnpm typecheck`, `pnpm check`, `pnpm build` all green.

## Notes / deferred

- Feed/inbox `agent_activity` items still open the message context; giving them an "open activity" affordance is a small follow-up on top of `useOpenAgentActivity`.
- The members-sidebar vs profile `canViewActivity` gate difference (local-backend vs declared-owner) is intentionally untouched here.
- Screenshots of the scope label will be posted with `scripts/post-screenshots.sh` before this leaves draft.