### PR TITLE
feat(desktop): contribution heatmap and graphical cards on projects overview

### DIFF
--- a/desktop/src/features/projects/hooks.ts
+++ b/desktop/src/features/projects/hooks.ts
@@ -84,6 +84,8 @@ export type ProjectActivitySummary = {
     createdAt: number;
     title: string;
   } | null;
+  /** Activity event counts bucketed by local-time day key ("YYYY-MM-DD"). */
+  activityByDay: Record<string, number>;
 };
 
 export type {

--- a/desktop/src/features/projects/projectActivity.mjs
+++ b/desktop/src/features/projects/projectActivity.mjs
@@ -17,6 +17,15 @@ function normalizePubkey(pubkey) {
   return /^[a-fA-F0-9]{64}$/.test(pubkey) ? pubkey.toLowerCase() : null;
 }
 
+// Local-time day key ("YYYY-MM-DD") so contribution graphs align with the
+// viewer's calendar, matching how GitHub buckets contribution days.
+function activityDayKey(createdAtSeconds) {
+  const date = new Date(createdAtSeconds * 1000);
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
 function ensureSummary(summaryByRepoAddress, repoAddress) {
   const existing = summaryByRepoAddress.get(repoAddress);
   if (existing) return existing;
@@ -30,6 +39,7 @@ function ensureSummary(summaryByRepoAddress, repoAddress) {
     updatedAt: 0,
     participantPubkeys: [],
     latestCommit: null,
+    activityByDay: {},
   };
   summaryByRepoAddress.set(repoAddress, summary);
   return summary;
@@ -60,6 +70,9 @@ export function summarizeProjectActivityEvents(events, projects) {
 
     summary.activityCount += 1;
     summary.updatedAt = Math.max(summary.updatedAt, event.created_at);
+
+    const dayKey = activityDayKey(event.created_at);
+    summary.activityByDay[dayKey] = (summary.activityByDay[dayKey] ?? 0) + 1;
 
     if (event.kind === 1621) {
       summary.issueCount += 1;

--- a/desktop/src/features/projects/ui/ProjectsContributionGraph.tsx
+++ b/desktop/src/features/projects/ui/ProjectsContributionGraph.tsx
@@ -1,0 +1,146 @@
+import { cn } from "@/shared/lib/cn";
+
+const WEEK_COUNT = 26;
+const DAYS_PER_WEEK = 7;
+
+// Intensity ramp shared by the cells and the "Less … More" legend.
+const LEVEL_CLASSES = [
+  "bg-muted/60 dark:bg-muted/40",
+  "bg-emerald-500/30",
+  "bg-emerald-500/50",
+  "bg-emerald-500/75",
+  "bg-emerald-500",
+];
+
+function dayKeyOf(date: Date) {
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function levelFor(count: number) {
+  if (count <= 0) return 0;
+  if (count <= 2) return 1;
+  if (count <= 5) return 2;
+  if (count <= 9) return 3;
+  return 4;
+}
+
+/** Week columns (each 7 days, Sunday first) ending with the current week. */
+function buildWeeks(today: Date) {
+  const start = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate() - today.getDay() - (WEEK_COUNT - 1) * DAYS_PER_WEEK,
+  );
+
+  return Array.from({ length: WEEK_COUNT }, (_, weekIndex) =>
+    Array.from({ length: DAYS_PER_WEEK }, (_, dayIndex) => {
+      const date = new Date(start);
+      date.setDate(start.getDate() + weekIndex * DAYS_PER_WEEK + dayIndex);
+      return date;
+    }),
+  );
+}
+
+function monthLabels(weeks: Date[][]) {
+  return weeks.map((week, index) => {
+    if (index === 0) return "";
+    const month = week[0].getMonth();
+    return month !== weeks[index - 1][0].getMonth()
+      ? week[0].toLocaleDateString(undefined, { month: "short" })
+      : "";
+  });
+}
+
+/**
+ * GitHub-style activity heatmap for the last 26 weeks, fed by per-day
+ * activity counts (see `ProjectActivitySummary.activityByDay`).
+ */
+export function ProjectsContributionGraph({
+  activityByDay,
+  className,
+}: {
+  activityByDay: Record<string, number>;
+  className?: string;
+}) {
+  const today = new Date();
+  const weeks = buildWeeks(today);
+  const labels = monthLabels(weeks);
+  const gridTemplateColumns = `repeat(${weeks.length}, minmax(0, 1fr))`;
+  const todayKey = dayKeyOf(today);
+
+  let totalContributions = 0;
+  for (const week of weeks) {
+    for (const day of week) {
+      const key = dayKeyOf(day);
+      if (key > todayKey) continue;
+      totalContributions += activityByDay[key] ?? 0;
+    }
+  }
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <div className="grid gap-1" style={{ gridTemplateColumns }}>
+        {labels.map((label, index) => (
+          <span
+            className="overflow-visible whitespace-nowrap text-2xs font-medium text-muted-foreground"
+            // Columns are positional; labels have no stable content key.
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-size grid
+            key={index}
+          >
+            {label}
+          </span>
+        ))}
+      </div>
+      <div
+        className="grid grid-flow-col grid-rows-7 gap-1"
+        style={{ gridTemplateColumns }}
+      >
+        {weeks.map((week) =>
+          week.map((day) => {
+            const key = dayKeyOf(day);
+            if (key > todayKey) {
+              return <span aria-hidden className="aspect-square" key={key} />;
+            }
+            const count = activityByDay[key] ?? 0;
+            const dateLabel = day.toLocaleDateString(undefined, {
+              month: "short",
+              day: "numeric",
+            });
+            return (
+              <span
+                className={cn(
+                  "aspect-square w-full rounded-[3px]",
+                  LEVEL_CLASSES[levelFor(count)],
+                )}
+                key={key}
+                title={
+                  count > 0
+                    ? `${count} ${count === 1 ? "event" : "events"} · ${dateLabel}`
+                    : `No activity · ${dateLabel}`
+                }
+              />
+            );
+          }),
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-2 pt-1">
+        <p className="text-xs text-muted-foreground">
+          {totalContributions} {totalContributions === 1 ? "event" : "events"}{" "}
+          in the last 6 months
+        </p>
+        <div className="flex items-center gap-1.5 text-2xs text-muted-foreground">
+          Less
+          {LEVEL_CLASSES.map((levelClass) => (
+            <span
+              className={cn("h-2.5 w-2.5 rounded-[3px]", levelClass)}
+              key={levelClass}
+            />
+          ))}
+          More
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectsOverviewPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectsOverviewPanel.tsx
@@ -14,6 +14,7 @@ import { normalizePubkey } from "@/shared/lib/pubkey";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { OverviewRailSection } from "./ProjectOverviewPanel";
+import { ProjectsContributionGraph } from "./ProjectsContributionGraph";
 
 export type ProjectsOverviewSection =
   | "repositories"
@@ -30,8 +31,8 @@ type ProjectsOverviewPanelProps = {
   summaries?: Record<string, ProjectActivitySummary>;
 };
 
-function pluralize(count: number, singular: string, plural = `${singular}s`) {
-  return `${count} ${count === 1 ? singular : plural}`;
+function unitLabel(count: number, singular: string, plural = `${singular}s`) {
+  return count === 1 ? singular : plural;
 }
 
 function projectPeople(
@@ -78,34 +79,52 @@ function overviewStats(
   );
 }
 
+function overviewActivityByDay(
+  projects: Project[],
+  summaries: Record<string, ProjectActivitySummary> | undefined,
+) {
+  const merged: Record<string, number> = {};
+  for (const project of projects) {
+    const byDay = summaries?.[project.repoAddress]?.activityByDay;
+    if (!byDay) continue;
+    for (const [day, count] of Object.entries(byDay)) {
+      merged[day] = (merged[day] ?? 0) + count;
+    }
+  }
+  return merged;
+}
+
 function StatPill({
+  count,
   icon: Icon,
   label,
   onClick,
-  value,
+  unit,
 }: {
+  count: number;
   icon: React.ComponentType<{ className?: string }>;
   label: string;
   onClick: () => void;
-  value: string;
+  unit: string;
 }) {
   return (
     <button
-      className="flex items-center gap-3 rounded-xl bg-card px-3 py-2.5 text-left shadow-xs transition-colors hover:bg-muted/40"
+      className="flex flex-col rounded-xl bg-card px-3.5 py-3 text-left shadow-xs transition-colors hover:bg-muted/40"
       onClick={onClick}
       type="button"
     >
-      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
-        <Icon className="h-4 w-4 text-muted-foreground" />
-      </span>
-      <div className="min-w-0">
-        <span className="block text-xs font-medium text-foreground">
+      <span className="flex w-full items-center justify-between gap-2">
+        <span className="text-xs font-medium text-muted-foreground">
           {label}
         </span>
-        <span className="mt-0.5 block truncate text-sm text-muted-foreground">
-          {value}
+        <Icon className="h-3.5 w-3.5 text-muted-foreground/70" />
+      </span>
+      <span className="mt-2 flex min-w-0 items-baseline gap-1.5">
+        <span className="text-2xl font-semibold leading-none tracking-tight text-foreground">
+          {count}
         </span>
-      </div>
+        <span className="truncate text-xs text-muted-foreground">{unit}</span>
+      </span>
     </button>
   );
 }
@@ -120,46 +139,67 @@ export function ProjectsOverviewPanel({
 }: ProjectsOverviewPanelProps) {
   const stats = overviewStats(projects, summaries);
   const people = overviewPeople(projects, summaries);
+  const activityByDay = overviewActivityByDay(projects, summaries);
 
   return (
     <section className="mb-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">
-      <div className="overflow-hidden rounded-2xl border border-border/50 bg-muted/20 p-4">
-        <div className="flex min-w-0 items-start gap-3">
-          <WorkspaceEmojiIcon className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted/60 text-2xl" />
-          <div className="-mt-1 min-w-0 flex-1 space-y-0.5">
-            <h2 className="text-xl font-semibold leading-7 tracking-tight text-foreground">
-              {relayName} Projects
-            </h2>
-            <p className="max-w-2xl text-sm font-normal text-muted-foreground">
-              Browse shared repositories, pull requests, and local project
-              checkouts in this workspace.
-            </p>
+      <div className="min-w-0 space-y-4">
+        <div className="overflow-hidden rounded-2xl border border-border/50 bg-muted/20 p-4">
+          <div className="flex min-w-0 items-start gap-3">
+            <WorkspaceEmojiIcon className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted/60 text-2xl" />
+            <div className="-mt-1 min-w-0 flex-1 space-y-0.5">
+              <h2 className="text-xl font-semibold leading-7 tracking-tight text-foreground">
+                {relayName} Projects
+              </h2>
+              <p className="max-w-2xl text-sm font-normal text-muted-foreground">
+                Browse shared repositories, pull requests, and local project
+                checkouts in this workspace.
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+            <StatPill
+              count={projects.length}
+              icon={FolderGit2}
+              label="Repositories"
+              onClick={() => onSelectSection("repositories")}
+              unit={unitLabel(projects.length, "project")}
+            />
+            <StatPill
+              count={stats.prs}
+              icon={GitPullRequest}
+              label="Pull requests"
+              onClick={() => onSelectSection("prs")}
+              unit={unitLabel(stats.prs, "PR")}
+            />
+            <StatPill
+              count={localRepositoryCount}
+              icon={Radio}
+              label="Local"
+              onClick={() => onSelectSection("local")}
+              unit={unitLabel(localRepositoryCount, "checkout")}
+            />
+            <StatPill
+              count={stats.issues}
+              icon={CircleDot}
+              label="Issues"
+              onClick={() => onSelectSection("issues")}
+              unit={unitLabel(stats.issues, "issue")}
+            />
           </div>
         </div>
-        <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-          <StatPill
-            icon={FolderGit2}
-            label="Repositories"
-            onClick={() => onSelectSection("repositories")}
-            value={pluralize(projects.length, "project")}
-          />
-          <StatPill
-            icon={GitPullRequest}
-            label="Pull requests"
-            onClick={() => onSelectSection("prs")}
-            value={pluralize(stats.prs, "PR")}
-          />
-          <StatPill
-            icon={Radio}
-            label="Local"
-            onClick={() => onSelectSection("local")}
-            value={pluralize(localRepositoryCount, "checkout")}
-          />
-          <StatPill
-            icon={CircleDot}
-            label="Issues"
-            onClick={() => onSelectSection("issues")}
-            value={pluralize(stats.issues, "issue")}
+        <div className="overflow-hidden rounded-2xl border border-border/50 bg-muted/20 p-4">
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-sm font-semibold text-foreground">
+              Contribution activity
+            </h3>
+            <span className="text-xs text-muted-foreground">
+              Commits, PRs & issues across all projects
+            </span>
+          </div>
+          <ProjectsContributionGraph
+            activityByDay={activityByDay}
+            className="mt-3"
           />
         </div>
       </div>

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -1,8 +1,9 @@
 import {
-  CalendarDays,
+  CircleDot,
   FolderGit2,
   GitCommit,
   GitFork,
+  GitPullRequest,
   MoreHorizontal,
   TerminalSquare,
   Trash2,
@@ -37,7 +38,6 @@ import {
 } from "@/features/projects/ui/ProjectsToolbar";
 import { hasLocalCheckout } from "@/features/projects/lib/projectLocalRepos";
 import {
-  formatCreatedDate,
   formatExactTimestamp,
   getActivityLabel,
   getClonePathLabel,
@@ -121,18 +121,34 @@ function ClonePathLabel({ project }: { project: Project }) {
   );
 }
 
-function ClonePathIcon({ project }: { project: Project }) {
-  const fullUrl = project.cloneUrls[0] ?? getClonePathLabel(project);
+function ProjectUpdatedLabel({
+  profiles,
+  project,
+  summary,
+}: {
+  profiles?: UserProfileLookup;
+  project: Project;
+  summary: ProjectActivitySummary | undefined;
+}) {
+  const updatedAt = getProjectUpdatedAt(project, summary);
+  const latestCommit = summary?.latestCommit;
+  const authorLabel = latestCommit?.author
+    ? resolveUserLabel({ profiles, pubkey: latestCommit.author })
+    : null;
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="relative z-10 flex shrink-0 items-center text-muted-foreground/80">
-          <GitFork className="h-3.5 w-3.5" />
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
+          Updated {relativeTime(updatedAt)}
         </span>
       </TooltipTrigger>
-      <TooltipContent className="max-w-96 break-all font-mono">
-        {fullUrl}
+      <TooltipContent className="max-w-96 break-words">
+        {latestCommit
+          ? `${latestCommit.title || latestCommit.commit.slice(0, 7)}${
+              authorLabel ? ` · ${authorLabel}` : ""
+            } · ${formatExactTimestamp(latestCommit.createdAt)}`
+          : `Created ${formatExactTimestamp(project.createdAt)}`}
       </TooltipContent>
     </Tooltip>
   );
@@ -191,51 +207,77 @@ function ProjectPeopleStack({
   );
 }
 
-function LatestCommitLabel({
-  profiles,
-  project,
+const PROJECT_STAT_ITEMS = [
+  {
+    key: "commitCount",
+    icon: GitCommit,
+    iconClass: "text-emerald-500",
+    barClass: "bg-emerald-500",
+    label: (count: number) => (count === 1 ? "commit" : "commits"),
+  },
+  {
+    key: "prCount",
+    icon: GitPullRequest,
+    iconClass: "text-violet-500",
+    barClass: "bg-violet-500",
+    label: (count: number) => (count === 1 ? "PR" : "PRs"),
+  },
+  {
+    key: "issueCount",
+    icon: CircleDot,
+    iconClass: "text-amber-500",
+    barClass: "bg-amber-500",
+    label: (count: number) => (count === 1 ? "issue" : "issues"),
+  },
+] as const;
+
+function ProjectStatsRow({
   summary,
 }: {
-  profiles?: UserProfileLookup;
-  project: Project;
   summary: ProjectActivitySummary | undefined;
 }) {
-  const latestCommit = summary?.latestCommit;
-  if (!latestCommit) {
-    return (
-      <MetadataItem icon={CalendarDays}>
-        {formatCreatedDate(project.createdAt)}
-      </MetadataItem>
-    );
-  }
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+      {PROJECT_STAT_ITEMS.map(({ key, icon: Icon, iconClass, label }) => {
+        const count = summary?.[key] ?? 0;
+        return (
+          <span className="flex items-center gap-1" key={key}>
+            <Icon className={cn("h-3.5 w-3.5 shrink-0", iconClass)} />
+            <span className="font-medium text-foreground">{count}</span>
+            {label(count)}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
 
-  const authorLabel = latestCommit.author
-    ? resolveUserLabel({ profiles, pubkey: latestCommit.author })
-    : null;
-  const commitLabel = latestCommit.title || latestCommit.commit.slice(0, 7);
-  // Middle truncation: the commit title gives way while the trailing
-  // author + time stay pinned and always visible.
-  const tail = `${authorLabel ? ` · ${authorLabel}` : ""} · ${relativeTime(
-    latestCommit.createdAt,
-  )}`;
+// Segmented commits/PRs/issues distribution — the card's "progress bar".
+function ProjectActivityBar({
+  summary,
+}: {
+  summary: ProjectActivitySummary | undefined;
+}) {
+  const counts = PROJECT_STAT_ITEMS.map(({ key, barClass }) => ({
+    barClass,
+    count: summary?.[key] ?? 0,
+  }));
+  const total = counts.reduce((sum, item) => sum + item.count, 0);
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="flex min-w-0 items-center gap-1.5">
-          <GitCommit className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
-          <span className="flex min-w-0">
-            <span className="min-w-0 truncate">{commitLabel}</span>
-            <span className="shrink-0 whitespace-pre">{tail}</span>
-          </span>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent className="max-w-96 break-words">
-        {commitLabel}
-        {authorLabel ? ` · ${authorLabel}` : ""} ·{" "}
-        {formatExactTimestamp(latestCommit.createdAt)}
-      </TooltipContent>
-    </Tooltip>
+    <div className="flex h-1.5 w-full gap-px overflow-hidden rounded-full bg-muted/60">
+      {total > 0
+        ? counts
+            .filter((item) => item.count > 0)
+            .map((item) => (
+              <div
+                className={cn("h-full rounded-full", item.barClass)}
+                key={item.barClass}
+                style={{ width: `${(item.count / total) * 100}%` }}
+              />
+            ))
+        : null}
+    </div>
   );
 }
 
@@ -247,21 +289,6 @@ function StatusPill({ status }: { status: string }) {
   return (
     <span className="shrink-0 rounded-full bg-muted/60 px-2 pb-[3px] pt-[5px] text-2xs font-semibold uppercase leading-none tracking-[0.18em] text-muted-foreground">
       {status}
-    </span>
-  );
-}
-
-function MetadataItem({
-  icon: Icon,
-  children,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  children: React.ReactNode;
-}) {
-  return (
-    <span className="flex min-w-0 items-center gap-1.5">
-      <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
-      <span className="min-w-0 truncate">{children}</span>
     </span>
   );
 }
@@ -436,33 +463,27 @@ function ProjectGridCard({
 }) {
   return (
     <Card
-      className="group relative flex min-h-48 flex-col overflow-hidden rounded-2xl border-border/50 bg-muted/20 p-4 shadow-none transition-colors duration-150 hover:bg-muted/30"
+      className="group relative flex min-h-44 flex-col overflow-hidden rounded-2xl border-border/50 bg-muted/20 p-4 shadow-none transition-colors duration-150 hover:bg-muted/30"
       data-testid={`project-card-${project.dtag}`}
     >
       <ProjectCardButton onOpen={onOpen} project={project} />
       <div className="flex min-h-0 flex-1 flex-col gap-3">
-        <div className="flex min-w-0 items-start justify-between gap-3">
-          <div className="min-w-0 space-y-1.5">
-            <div className="flex min-w-0 items-center gap-2">
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
-                <FolderGit2 className="h-4 w-4 text-muted-foreground" />
-              </span>
-              <div className="min-w-0 space-y-1">
-                <span className="block truncate text-sm font-semibold text-foreground">
-                  {project.name}
-                </span>
-                <div className="flex min-w-0 items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                  <LatestCommitLabel
-                    profiles={profiles}
-                    project={project}
-                    summary={summary}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="relative z-10 flex items-center gap-1">
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted/60">
+              <FolderGit2 className="h-4 w-4 text-muted-foreground" />
+            </span>
+            <span className="min-w-0 truncate text-sm font-semibold text-foreground">
+              {project.name}
+            </span>
             <StatusPill status={project.status} />
+          </div>
+          <div className="relative z-10 flex shrink-0 items-center gap-1">
+            <ProjectUpdatedLabel
+              profiles={profiles}
+              project={project}
+              summary={summary}
+            />
             <ProjectActionsMenu
               canDelete={canDelete}
               disabled={deleteDisabled}
@@ -478,22 +499,18 @@ function ProjectGridCard({
           {project.description || "A shared space for internal git work."}
         </p>
 
-        <div className="mt-auto rounded-xl bg-muted/60 px-2.5 py-2">
+        <div className="mt-auto space-y-2.5">
           <div className="flex min-w-0 items-center justify-between gap-2">
-            <div className="relative z-10 flex shrink-0 items-center gap-1">
+            <ProjectStatsRow summary={summary} />
+            <div className="relative z-10 flex shrink-0 items-center">
               <ProjectPeopleStack
                 profiles={profiles}
                 pubkeys={people}
                 workOwnerPubkey={project.owner}
               />
             </div>
-            <div className="flex min-w-0 items-center gap-2">
-              <p className="truncate text-xs font-medium text-muted-foreground">
-                {getActivityLabel(summary)}
-              </p>
-              <ClonePathIcon project={project} />
-            </div>
           </div>
+          <ProjectActivityBar summary={summary} />
         </div>
       </div>
     </Card>

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -17,9 +17,18 @@ import {
   KIND_AGENT_OBSERVER_FRAME,
   KIND_DM_VISIBILITY,
   KIND_EVENT_REMINDER,
+  KIND_GIT_ISSUE,
+  KIND_GIT_PATCH,
+  KIND_GIT_PR_UPDATE,
+  KIND_GIT_PULL_REQUEST,
+  KIND_GIT_STATUS_CLOSED,
+  KIND_GIT_STATUS_DRAFT,
+  KIND_GIT_STATUS_MERGED,
+  KIND_GIT_STATUS_OPEN,
   KIND_HUDDLE_STARTED,
   KIND_MEMBER_ADDED_NOTIFICATION,
   KIND_MEMBER_REMOVED_NOTIFICATION,
+  KIND_REPO_ANNOUNCEMENT,
   KIND_STREAM_MESSAGE_EDIT,
   KIND_SYSTEM_MESSAGE,
   KIND_USER_STATUS,
@@ -517,6 +526,7 @@ type MockSubscription = {
 };
 
 type MockFilter = {
+  "#a"?: string[];
   "#d"?: string[];
   "#e"?: string[];
   "#h"?: string[];
@@ -3873,6 +3883,174 @@ function handleGetLikedNotes(): RawUserNotesResponse {
 // accepts 64-hex `e` tags (getDeletionTargets in formatTimelineMessages.ts), so
 // a kind:5 targeting a 32-hex reaction id would be silently ignored and the
 // reaction pill would never clear on toggle-off.
+// --- Mock projects (NIP-34 repo announcements + git activity) ---
+// Deterministic fixtures so the Projects view (cards, stat pills, and the
+// contribution heatmap) renders with data in screenshots and e2e specs.
+
+const MOCK_PROJECT_SEEDS = [
+  {
+    dtag: "buzz",
+    name: "buzz",
+    description:
+      "Relay, desktop, and mobile clients for the Buzz workspace platform.",
+    owner: MOCK_IDENTITY_PUBKEY,
+    contributors: [ALICE_PUBKEY, BOB_PUBKEY, CHARLIE_PUBKEY],
+    activityLevel: 4,
+  },
+  {
+    dtag: "relay-tools",
+    name: "relay-tools",
+    description: "Operator tooling and admin CLI for relay deployments.",
+    owner: ALICE_PUBKEY,
+    contributors: [MOCK_IDENTITY_PUBKEY, BOB_PUBKEY],
+    activityLevel: 2,
+  },
+  {
+    dtag: "design-system",
+    name: "design-system",
+    description: "Shared UI tokens, typography ramps, and component library.",
+    owner: BOB_PUBKEY,
+    contributors: [ALICE_PUBKEY],
+    activityLevel: 1,
+  },
+] as const;
+
+const MOCK_PROJECT_SUBJECTS = [
+  "Fix reconnect backoff jitter",
+  "Polish overview cards",
+  "Add contribution heatmap",
+  "Refactor filter matching",
+  "Speed up event dedup",
+  "Handle empty clone URLs",
+  "Update onboarding copy",
+  "Tighten p-gate checks",
+];
+
+const MOCK_PROJECT_KINDS = new Set<number>([
+  KIND_REPO_ANNOUNCEMENT,
+  KIND_GIT_PATCH,
+  KIND_GIT_PULL_REQUEST,
+  KIND_GIT_PR_UPDATE,
+  KIND_GIT_ISSUE,
+  KIND_GIT_STATUS_OPEN,
+  KIND_GIT_STATUS_MERGED,
+  KIND_GIT_STATUS_CLOSED,
+  KIND_GIT_STATUS_DRAFT,
+]);
+
+function mulberry32(seed: number) {
+  let state = seed;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+let mockProjectEventStore: RelayEvent[] | null = null;
+
+function buildMockProjectEvents(): RelayEvent[] {
+  const events: RelayEvent[] = [];
+  const daySeconds = 86_400;
+  const now = Math.floor(Date.now() / 1000);
+  const historyDays = 26 * 7;
+
+  for (const [projectIndex, seed] of MOCK_PROJECT_SEEDS.entries()) {
+    const repoAddress = `${KIND_REPO_ANNOUNCEMENT}:${seed.owner}:${seed.dtag}`;
+    const authors = [seed.owner, ...seed.contributors];
+    const random = mulberry32(projectIndex + 1);
+
+    events.push(
+      createMockEvent(
+        KIND_REPO_ANNOUNCEMENT,
+        seed.description,
+        [
+          ["d", seed.dtag],
+          ["name", seed.name],
+          ["description", seed.description],
+          ["clone", `https://relay.example.com/git/${seed.dtag}.git`],
+          ...seed.contributors.map((pubkey) => ["p", pubkey]),
+        ],
+        seed.owner,
+        now - (historyDays + 30 + projectIndex) * daySeconds,
+        `mock-project-${seed.dtag}`.replace(/[^a-zA-Z0-9]/g, ""),
+      ),
+    );
+
+    for (let dayOffset = historyDays; dayOffset >= 0; dayOffset -= 1) {
+      // Roughly half the days are quiet; busy days scale with activityLevel.
+      if (random() < 0.5) continue;
+      const dayEventCount = 1 + Math.floor(random() * seed.activityLevel);
+
+      for (let index = 0; index < dayEventCount; index += 1) {
+        const createdAt =
+          now - dayOffset * daySeconds - Math.floor(random() * 10) * 3_600;
+        const author = authors[Math.floor(random() * authors.length)];
+        const subject =
+          MOCK_PROJECT_SUBJECTS[
+            Math.floor(random() * MOCK_PROJECT_SUBJECTS.length)
+          ];
+        const commitHash = `${seed.dtag}${dayOffset}x${index}`
+          .padEnd(40, "0")
+          .slice(0, 40);
+        const roll = random();
+        const kind =
+          roll < 0.7
+            ? KIND_GIT_PATCH
+            : roll < 0.85
+              ? KIND_GIT_PULL_REQUEST
+              : KIND_GIT_ISSUE;
+        const tags = [
+          ["a", repoAddress],
+          ["subject", subject],
+          ...(kind === KIND_GIT_ISSUE ? [] : [["c", commitHash]]),
+        ];
+
+        events.push(createMockEvent(kind, subject, tags, author, createdAt));
+      }
+    }
+  }
+
+  return events;
+}
+
+function getMockProjectEventStore(): RelayEvent[] {
+  mockProjectEventStore ??= buildMockProjectEvents();
+  return mockProjectEventStore;
+}
+
+function filterMockProjectEvents(filter: MockFilter): RelayEvent[] {
+  const authors = filter.authors?.map((author) => author.toLowerCase());
+  return getMockProjectEventStore()
+    .filter((event) => {
+      if (filter.kinds && !filter.kinds.includes(event.kind)) return false;
+      if (authors && !authors.includes(event.pubkey.toLowerCase())) {
+        return false;
+      }
+      if (
+        filter["#d"] &&
+        !event.tags.some(
+          (tag) => tag[0] === "d" && filter["#d"]?.includes(tag[1]),
+        )
+      ) {
+        return false;
+      }
+      if (
+        filter["#a"] &&
+        !event.tags.some(
+          (tag) => tag[0] === "a" && filter["#a"]?.includes(tag[1]),
+        )
+      ) {
+        return false;
+      }
+      return true;
+    })
+    .sort((left, right) => right.created_at - left.created_at)
+    .slice(0, filter.limit ?? 500);
+}
+
 function mockEventId(): string {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
@@ -7096,6 +7274,14 @@ function sendToMockSocket(args: {
       const authors = filter.authors?.map((a) => a.toLowerCase());
       for (const event of mockReminderEvents) {
         if (authors && !authors.includes(event.pubkey.toLowerCase())) continue;
+        sendWsText(socket.handler, ["EVENT", subId, event]);
+      }
+      sendWsText(socket.handler, ["EOSE", subId]);
+      return;
+    }
+
+    if (filter.kinds?.some((kind) => MOCK_PROJECT_KINDS.has(kind))) {
+      for (const event of filterMockProjectEvents(filter)) {
         sendWsText(socket.handler, ["EVENT", subId, event]);
       }
       sendWsText(socket.handler, ["EOSE", subId]);


### PR DESCRIPTION
## Summary

- Adds a GitHub-style **contribution activity heatmap** (last 26 weeks) to the Projects overview, aggregated across all projects, with month labels, per-day hover tooltips, and a Less→More legend. Backed by a new per-day `activityByDay` histogram on `ProjectActivitySummary` — no new relay queries, it reuses the events already fetched for activity summaries.
- Restyles the overview **stat pills into graphical metric cards** (label + icon on top, big number with unit) — still clickable to jump to each filtered section.
- **Redesigns project grid cards**: one-row header (icon + name + status, "Updated X ago" with latest-commit tooltip, actions menu), colored commit/PR/issue counts, and a segmented distribution bar in matching colors. List rows are unchanged.
- Seeds the **e2e mock bridge** with deterministic repo announcements and ~6 months of generated git activity so `/projects` renders with data in screenshots and specs (it previously had no project fixtures at all).

## Test plan

- [x] `biome check` + `tsc --noEmit` clean
- [x] Desktop unit tests pass (1558 tests)
- [x] Screenshot of `/projects` via `just desktop-screenshot` (posted below)
- [ ] Verify overview against a live relay with real project activity