### PR TITLE
fix(scripts): make seed-local-community.sh parse on macOS bash 3.2

### DIFF
--- a/scripts/seed-local-community.sh
+++ b/scripts/seed-local-community.sh
@@ -67,7 +67,7 @@ for h in hosts:
 if not seen:
     raise SystemExit("could not derive a host from RELAY_URL")
 
-print(",\n".join(f"    ('{h.replace("'", "''")}')" for h in seen))
+print(",\n".join("    ('{}')".format(h.replace("'", "''")) for h in seen))
 PY
 )
 


### PR DESCRIPTION
## Problem

`just reset` / `just setup` fail on a stock macOS machine during community seeding:

```
scripts/seed-local-community.sh: line 94: unexpected EOF while looking for matching `"'
error: Recipe `reset` failed on line 54 with exit code 2
```

## Root cause

Line 70 nests double quotes inside a double-quoted f-string:

```python
print(",\n".join(f"    ('{h.replace("'", "''")}')" for h in seen))
```

This breaks stock macOS in **two independent ways**:

1. **bash 3.2 (macOS `/bin/bash`, what `#!/usr/bin/env bash` resolves to without Homebrew bash):** the here-doc-inside-`$(...)` scanner chokes on the nested `"` and dies **at parse time** — Python is never invoked. Verified with `bash -n` (parse-only) and a shim `python3` that confirms Python never launches.
2. **Python < 3.12:** quote reuse inside f-strings is only legal since PEP 701. Apple's CLT `/usr/bin/python3` is 3.9.6 and fails with `SyntaxError: f-string: unmatched '('` — so even users with a modern bash hit a wall if they don't have Homebrew Python.

CI (Linux, bash 5) and devs with Homebrew bash/python never see either failure, which is how it slipped through.

## Fix

One line — replace the f-string with `str.format()`:

```python
print(",\n".join("    ('{}')".format(h.replace("'", "''")) for h in seen))
```

## Verification

| Check | Before | After |
|---|---|---|
| `/bin/bash -n scripts/seed-local-community.sh` (bash 3.2.57) | ❌ `unexpected EOF` | ✅ parses |
| Python 3.9.6 (Apple CLT) accepts the expression | ❌ `SyntaxError` | ✅ |
| Script output | n/a (crashes) | Byte-identical, incl. SQL escaping (`o'brien` → `o''brien`) |
| End-to-end: `bash scripts/seed-local-community.sh` against local Postgres | ❌ | ✅ `INSERT 0 4`, all four loopback hosts seeded |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
