### PR TITLE
feat(desktop): enable native spellcheck in message composer

### DIFF
--- a/desktop/src/features/messages/lib/mentionHighlightExtension.ts
+++ b/desktop/src/features/messages/lib/mentionHighlightExtension.ts
@@ -304,11 +304,22 @@ function addMatchesForPatterns(
         decorations.push(
           Decoration.inline(from, from + 1, {
             class: "agent-mention-at-hidden",
+            spellcheck: "false",
           }),
         );
-        decorations.push(Decoration.inline(from + 1, to, { class: className }));
+        decorations.push(
+          Decoration.inline(from + 1, to, {
+            class: className,
+            spellcheck: "false",
+          }),
+        );
       } else {
-        decorations.push(Decoration.inline(from, to, { class: className }));
+        decorations.push(
+          Decoration.inline(from, to, {
+            class: className,
+            spellcheck: "false",
+          }),
+        );
       }
       match = pattern.exec(text);
     }

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -208,6 +208,16 @@ export function useRichTextEditor({
           // should keep the literal "#", not convert to a heading node.
           // Users type #channel-name and the "#" would get eaten otherwise.
           heading: false,
+          // Suppress spellcheck inside inline code spans — code identifiers
+          // are not natural language and should not show red squiggles.
+          code: {
+            HTMLAttributes: { spellcheck: "false" },
+          },
+          // Code blocks already render as <pre><code> which browsers skip
+          // for spellcheck, but be explicit for consistency.
+          codeBlock: {
+            HTMLAttributes: { spellcheck: "false" },
+          },
           // Disable the trailing-node plugin — it forces an empty paragraph
           // after block nodes (lists, blockquotes, code blocks) which creates
           // a phantom empty line in the compact message composer.

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -417,7 +417,7 @@ export function useRichTextEditor({
           autocorrect: "off",
           class: `${MESSAGE_MARKDOWN_CLASS} min-h-0 resize-none overflow-y-hidden border-0 bg-transparent px-0 py-0 text-sm leading-5 text-foreground shadow-none focus-visible:ring-0 caret-foreground outline-hidden max-w-none`,
           "data-testid": "message-input",
-          spellcheck: "false",
+          spellcheck: "true",
         },
         // ArrowUp in an empty composer → edit your last message (Slack
         // parity). Handled here in ProseMirror's own DOM `keydown` hook —


### PR DESCRIPTION
Flips the Tiptap editor's `spellcheck` attribute from `false` to `true` so macOS provides the red underline on misspelled words and the standard right-click → spelling suggestions context menu.

`autocorrect` remains `off` to avoid unwanted inline auto-replacement.

## Changes
- `desktop/src/features/messages/lib/useRichTextEditor.ts`: `spellcheck: "false"" → `spellcheck: "true"`

## Testing
- Typed misspelled words in the message composer → red underline appears
- Right-click on misspelled word → macOS spelling suggestions shown
- Autocorrect does not fire (no surprise replacements)