### PR TITLE
chore(renovate): stop rebase churn between weekly sweeps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "prCreation": "immediate",
   "automerge": true,
+  "rebaseWhen": "conflicted",
   "recreateWhen": "always",
   "separateMinorPatch": true,
   "postUpdateOptions": ["cargo:updateLockfile"],


### PR DESCRIPTION
## Why

We're moving renovate to a **weekly human sweep** model (per discussion in wrangle-renovate): renovate opens PRs Monday 00:00–04:00 UTC, a human approves the green ones in one pass, and GitHub auto-merge (already enabled by renovate on each PR) lands them as CI finishes.

The one config gap: with `automerge: true`, renovate's `rebaseWhen` defaults to `behind-base-branch` — so **every merge to main rebases all open renovate PRs and re-runs the full CI matrix on each** (~16 jobs × 9 PRs today). Between weekly sweeps that's pure CI waste, since the PRs only need to stay conflict-free until Monday.

## What

Set `rebaseWhen: "conflicted"` — rebase only when a PR actually conflicts with main.

## Trade-off (from the renovate docs)

`rebaseWhen: conflicted` + automerge means two updates could merge back-to-back without being tested *together* against the final main. Our required checks still run on each PR's merge result at approval time, and the weekly sweep is human-supervised, so the residual risk is small — and it's the same risk we already accept for any two human PRs merged in quick succession. If we ever see a bad interaction, reverting this one line restores the old behavior.
