### PR TITLE
chore(deps): update rust crate chrono to v0.4.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2677,9 +2677,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if 1.0.4",


### PR DESCRIPTION
## Why

Renovate #1050 (chrono 0.4.44 → 0.4.45) fails the Windows Rust clippy job: `could not compile wmi (lib) due to 16 previous errors`.

Root cause: chrono 0.4.45 bumps its `windows-link` requirement to `^0.2`, and cargo's re-resolution during renovate's `cargo update chrono` also collapsed unrelated duplicate windows crates *downward* — `iana-time-zone` and `wmi` dropped from `windows-core 0.62.2` to `0.61.2`, and `generator` dropped to `windows-link 0.1.3`/`windows-result 0.3.4`. `wmi 0.18.4` doesn't compile against the older `windows-core` interface traits.

## What

Same chrono bump, minus the collateral downgrades (`Cargo.lock` only):

- `chrono` 0.4.44 → 0.4.45
- `generator` 0.8.8 → 0.8.9 (restores `windows-link 0.2.1` / `windows-result 0.4.1`)
- `iana-time-zone` and `wmi` kept on `windows-core 0.62.2` — both requirements allow it (`>=0.56, <=0.62` and `>=0.59, <0.63`)

Supersedes #1050; renovate will detect 0.4.45 on main and close it.

## Verification

- Reproduced #1050's exact bad diff locally via `cargo update chrono --precise 0.4.45`
- `cargo metadata --locked` passes — lockfile self-consistent
- `cargo clippy --workspace --locked` clean locally (macOS); the Windows clippy job on this PR's CI is the authoritative check for the original failure
