### PR TITLE
fix(deps): restore windows-* crates downgraded by chrono bump (fixes Windows Rust on main)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,8 +2686,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -3277,7 +3277,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9584,7 +9584,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows 0.62.2",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Main's **Windows Rust** job is failing (3 consecutive runs) since #1050 merged. Renovate's lockfile regen for the chrono 0.4.45 bump also silently **downgraded** `windows-core` 0.62.2 → 0.61.2 (plus `windows-link` 0.2.1 → 0.1.3 and `windows-result` 0.4.1 → 0.3.4) for `iana-time-zone`, `wmi`, and `generator`. `wmi 0.18.4` depends on `windows 0.62.2`, which can't compile against `windows-core 0.61.2` — hence the `IWbemObjectSink: windows_core::Interface` trait errors.

Windows Rust isn't a required status check, so the red slipped through the renovate approval sweep.

## What

Lockfile-only: restore the three windows-* crate versions to what main had before #1050. Chrono stays at 0.4.45. Verified with `cargo metadata --locked` (lockfile consistent) and the diff is exactly the 4 reverted downgrade lines.
