### PR TITLE
fix(composer): flush debounced autocomplete detection on Tab/Enter

### DIFF
--- a/desktop/src/features/messages/lib/mentionCandidates.ts
+++ b/desktop/src/features/messages/lib/mentionCandidates.ts
@@ -1,0 +1,81 @@
+import type { ChannelRole, UserSearchResult } from "@/shared/api/types";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+export type MentionCandidate = {
+  kind: "identity" | "persona";
+  pubkey?: string;
+  personaId?: string;
+  displayName: string | null;
+  avatarUrl?: string | null;
+  isMember: boolean;
+  role?: ChannelRole | null;
+  personaName?: string | null;
+  secondaryLabel?: string | null;
+  ownerPubkey?: string | null;
+  isAgent: boolean;
+  isManagedAgent?: boolean;
+  isGlobalSearchResult?: boolean;
+};
+
+export function mentionCandidateLabel(candidate: MentionCandidate) {
+  return candidate.displayName ?? candidate.pubkey?.slice(0, 8) ?? "persona";
+}
+
+export function globalSearchIdentityKey(candidate: MentionCandidate) {
+  if (
+    !candidate.isGlobalSearchResult ||
+    candidate.isMember ||
+    candidate.isAgent
+  ) {
+    return null;
+  }
+
+  const label = candidate.displayName?.trim().toLowerCase();
+  if (!label) {
+    return null;
+  }
+
+  const secondaryLabel = candidate.secondaryLabel?.trim().toLowerCase() ?? "";
+  return `global-person:${label}:${secondaryLabel}`;
+}
+
+export function formatSearchUserDisplayName(user: UserSearchResult) {
+  return user.displayName?.trim() || user.nip05Handle?.trim() || null;
+}
+
+export function formatSearchUserSecondaryLabel(user: UserSearchResult) {
+  const displayName = user.displayName?.trim();
+  const nip05Handle = user.nip05Handle?.trim();
+
+  if (displayName && nip05Handle) {
+    return nip05Handle;
+  }
+
+  return null;
+}
+
+export function formatOwnerLabel(
+  ownerPubkey: string | null | undefined,
+  currentPubkey: string | null | undefined,
+  ownerProfiles?: UserProfileLookup,
+) {
+  if (!ownerPubkey) {
+    return null;
+  }
+
+  const normalizedOwnerPubkey = normalizePubkey(ownerPubkey);
+  if (
+    currentPubkey &&
+    normalizedOwnerPubkey === normalizePubkey(currentPubkey)
+  ) {
+    return "you";
+  }
+
+  const owner = ownerProfiles?.[normalizedOwnerPubkey];
+  return (
+    owner?.displayName?.trim() ||
+    owner?.nip05Handle?.trim() ||
+    `${ownerPubkey.slice(0, 8)}…`
+  );
+}

--- a/desktop/src/features/messages/lib/useChannelLinks.ts
+++ b/desktop/src/features/messages/lib/useChannelLinks.ts
@@ -16,7 +16,7 @@ export function useChannelLinks() {
   const { channels } = useChannelNavigation();
 
   const [channelQuery, setChannelQuery] = React.useState<string | null>(null);
-  const [channelStartIndex, setChannelStartIndex] = React.useState(0);
+  const channelStartIndexRef = React.useRef(0);
   const [channelSelectedIndex, setChannelSelectedIndex] = React.useState(0);
 
   const debounceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
@@ -52,24 +52,33 @@ export function useChannelLinks() {
     };
   }, []);
 
+  /** Match channels for a query, mirroring the `channelSuggestions` memo. */
+  const matchChannels = React.useCallback(
+    (query: string): ChannelSuggestion[] => {
+      const lowerQuery = query.toLowerCase();
+      return channels
+        .filter(
+          (ch) =>
+            ch.channelType !== "dm" &&
+            ch.name.toLowerCase().includes(lowerQuery),
+        )
+        .slice(0, 8)
+        .map((ch) => ({
+          id: ch.id,
+          name: ch.name,
+          channelType: ch.channelType as "stream" | "forum",
+        }));
+    },
+    [channels],
+  );
+
   const channelSuggestions = React.useMemo<ChannelSuggestion[]>(() => {
     if (channelQuery === null) {
       return [];
     }
 
-    const lowerQuery = channelQuery.toLowerCase();
-    return channels
-      .filter(
-        (ch) =>
-          ch.channelType !== "dm" && ch.name.toLowerCase().includes(lowerQuery),
-      )
-      .slice(0, 8)
-      .map((ch) => ({
-        id: ch.id,
-        name: ch.name,
-        channelType: ch.channelType as "stream" | "forum",
-      }));
-  }, [channels, channelQuery]);
+    return matchChannels(channelQuery);
+  }, [matchChannels, channelQuery]);
 
   const isChannelOpen = channelQuery !== null && channelSuggestions.length > 0;
 
@@ -86,12 +95,12 @@ export function useChannelLinks() {
       setChannelSelectedIndex(0);
 
       return {
-        replaceFromOffset: channelStartIndex,
+        replaceFromOffset: channelStartIndexRef.current,
         replaceToOffset: selectionEnd,
         insertText,
       };
     },
-    [channelStartIndex],
+    [],
   );
 
   const updateChannelQuery = React.useCallback(
@@ -114,7 +123,7 @@ export function useChannelLinks() {
         );
         if (channel) {
           setChannelQuery(channel.query);
-          setChannelStartIndex(channel.startIndex);
+          channelStartIndexRef.current = channel.startIndex;
           setChannelSelectedIndex(0);
         } else {
           setChannelQuery(null);
@@ -166,6 +175,34 @@ export function useChannelLinks() {
           !event.shiftKey)
       ) {
         event.preventDefault();
+
+        // Flush pending debounced detection so a fast Tab/Enter commits the
+        // match for the text actually typed, not a stale suggestion list.
+        if (debounceTimerRef.current !== null) {
+          clearTimeout(debounceTimerRef.current);
+          debounceTimerRef.current = null;
+          const channel = detectPrefixQuery(
+            "#",
+            latestValueRef.current,
+            latestCursorRef.current,
+            knownNamesLowerRef.current,
+          );
+          if (!channel) {
+            setChannelQuery(null);
+            return { handled: true };
+          }
+          channelStartIndexRef.current = channel.startIndex;
+          if (channel.query !== channelQuery) {
+            const fresh = matchChannels(channel.query);
+            if (fresh.length === 0) {
+              setChannelQuery(channel.query);
+              setChannelSelectedIndex(0);
+              return { handled: true };
+            }
+            return { handled: true, suggestion: fresh[0] };
+          }
+        }
+
         return {
           handled: true,
           suggestion: channelSuggestions[channelSelectedIndex],
@@ -180,7 +217,13 @@ export function useChannelLinks() {
 
       return { handled: false };
     },
-    [isChannelOpen, channelSelectedIndex, channelSuggestions],
+    [
+      channelQuery,
+      channelSelectedIndex,
+      channelSuggestions,
+      isChannelOpen,
+      matchChannels,
+    ],
   );
 
   return {

--- a/desktop/src/features/messages/lib/useEmojiAutocomplete.ts
+++ b/desktop/src/features/messages/lib/useEmojiAutocomplete.ts
@@ -44,7 +44,7 @@ function detectEmojiQuery(
 
 export function useEmojiAutocomplete(customEmoji: CustomEmoji[] = []) {
   const [emojiQuery, setEmojiQuery] = React.useState<string | null>(null);
-  const [emojiStartIndex, setEmojiStartIndex] = React.useState(0);
+  const emojiStartIndexRef = React.useRef(0);
   const [emojiSelectedIndex, setEmojiSelectedIndex] = React.useState(0);
   const [suggestions, setSuggestions] = React.useState<EmojiSuggestion[]>([]);
 
@@ -141,13 +141,13 @@ export function useEmojiAutocomplete(customEmoji: CustomEmoji[] = []) {
       setEmojiSelectedIndex(0);
 
       return {
-        replaceFromOffset: emojiStartIndex,
+        replaceFromOffset: emojiStartIndexRef.current,
         replaceToOffset: selectionEnd,
         insertText,
         ...(isCustom ? { customEmojiShortcode: suggestion.id } : {}),
       };
     },
-    [emojiStartIndex],
+    [],
   );
 
   const updateEmojiQuery = React.useCallback(
@@ -167,7 +167,7 @@ export function useEmojiAutocomplete(customEmoji: CustomEmoji[] = []) {
         );
         if (result) {
           setEmojiQuery(result.query);
-          setEmojiStartIndex(result.startIndex);
+          emojiStartIndexRef.current = result.startIndex;
         } else {
           setEmojiQuery(null);
         }
@@ -219,6 +219,28 @@ export function useEmojiAutocomplete(customEmoji: CustomEmoji[] = []) {
           !event.shiftKey)
       ) {
         event.preventDefault();
+
+        // Flush pending debounced detection so a fast Tab/Enter never commits
+        // a suggestion from a stale query. Emoji search is async, so when the
+        // query changed we refresh the dropdown instead of committing.
+        if (debounceTimerRef.current !== null) {
+          clearTimeout(debounceTimerRef.current);
+          debounceTimerRef.current = null;
+          const result = detectEmojiQuery(
+            latestValueRef.current,
+            latestCursorRef.current,
+          );
+          if (!result) {
+            setEmojiQuery(null);
+            return { handled: true };
+          }
+          emojiStartIndexRef.current = result.startIndex;
+          if (result.query !== emojiQuery) {
+            setEmojiQuery(result.query);
+            return { handled: true };
+          }
+        }
+
         return {
           handled: true,
           suggestion: suggestions[emojiSelectedIndex],
@@ -233,7 +255,7 @@ export function useEmojiAutocomplete(customEmoji: CustomEmoji[] = []) {
 
       return { handled: false };
     },
-    [isEmojiAutocompleteOpen, emojiSelectedIndex, suggestions],
+    [isEmojiAutocompleteOpen, emojiQuery, emojiSelectedIndex, suggestions],
   );
 
   return {

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -26,57 +26,25 @@ import type { AutocompleteEdit } from "./useRichTextEditor";
 import type {
   AgentPersona,
   ChannelMember,
-  ChannelRole,
   ChannelType,
-  UserSearchResult,
 } from "@/shared/api/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { detectPrefixQuery } from "@/shared/lib/detectPrefixQuery";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { trimMapToSize } from "@/shared/lib/trimMapToSize";
 import { hasMention } from "./hasMention";
+import {
+  formatOwnerLabel,
+  formatSearchUserDisplayName,
+  formatSearchUserSecondaryLabel,
+  globalSearchIdentityKey,
+  type MentionCandidate,
+  mentionCandidateLabel,
+} from "./mentionCandidates";
 import { rankMentionCandidates } from "./mentionRanking";
 
 const MENTION_DEBOUNCE_MS = 120;
 const MENTION_SUGGESTION_LIMIT = 50;
-
-type MentionCandidate = {
-  kind: "identity" | "persona";
-  pubkey?: string;
-  personaId?: string;
-  displayName: string | null;
-  avatarUrl?: string | null;
-  isMember: boolean;
-  role?: ChannelRole | null;
-  personaName?: string | null;
-  secondaryLabel?: string | null;
-  ownerPubkey?: string | null;
-  isAgent: boolean;
-  isManagedAgent?: boolean;
-  isGlobalSearchResult?: boolean;
-};
-
-function mentionCandidateLabel(candidate: MentionCandidate) {
-  return candidate.displayName ?? candidate.pubkey?.slice(0, 8) ?? "persona";
-}
-
-function globalSearchIdentityKey(candidate: MentionCandidate) {
-  if (
-    !candidate.isGlobalSearchResult ||
-    candidate.isMember ||
-    candidate.isAgent
-  ) {
-    return null;
-  }
-
-  const label = candidate.displayName?.trim().toLowerCase();
-  if (!label) {
-    return null;
-  }
-
-  const secondaryLabel = candidate.secondaryLabel?.trim().toLowerCase() ?? "";
-  return `global-person:${label}:${secondaryLabel}`;
-}
 
 export type PersonaMentionTarget = {
   displayName: string;
@@ -87,46 +55,6 @@ type UseMentionsOptions = {
   channelType?: ChannelType | null;
 };
 
-function formatSearchUserDisplayName(user: UserSearchResult) {
-  return user.displayName?.trim() || user.nip05Handle?.trim() || null;
-}
-
-function formatSearchUserSecondaryLabel(user: UserSearchResult) {
-  const displayName = user.displayName?.trim();
-  const nip05Handle = user.nip05Handle?.trim();
-
-  if (displayName && nip05Handle) {
-    return nip05Handle;
-  }
-
-  return null;
-}
-
-function formatOwnerLabel(
-  ownerPubkey: string | null | undefined,
-  currentPubkey: string | null | undefined,
-  ownerProfiles?: UserProfileLookup,
-) {
-  if (!ownerPubkey) {
-    return null;
-  }
-
-  const normalizedOwnerPubkey = normalizePubkey(ownerPubkey);
-  if (
-    currentPubkey &&
-    normalizedOwnerPubkey === normalizePubkey(currentPubkey)
-  ) {
-    return "you";
-  }
-
-  const owner = ownerProfiles?.[normalizedOwnerPubkey];
-  return (
-    owner?.displayName?.trim() ||
-    owner?.nip05Handle?.trim() ||
-    `${ownerPubkey.slice(0, 8)}…`
-  );
-}
-
 export function useMentions(
   channelId: string | null,
   externalMembers?: ChannelMember[],
@@ -134,7 +62,7 @@ export function useMentions(
   options?: UseMentionsOptions,
 ) {
   const [mentionQuery, setMentionQuery] = React.useState<string | null>(null);
-  const [mentionStartIndex, setMentionStartIndex] = React.useState(0);
+  const mentionStartIndexRef = React.useRef(0);
   const [mentionSelectedIndex, setMentionSelectedIndex] = React.useState(0);
   const [selectedMentionNames, setSelectedMentionNames] = React.useState<
     string[]
@@ -702,12 +630,12 @@ export function useMentions(
       setMentionSelectedIndex(0);
 
       return {
-        replaceFromOffset: mentionStartIndex,
+        replaceFromOffset: mentionStartIndexRef.current,
         replaceToOffset: selectionEnd,
         insertText,
       };
     },
-    [knownAgentPubkeys, mentionStartIndex],
+    [knownAgentPubkeys],
   );
 
   const registerMentionPubkey = React.useCallback(
@@ -802,7 +730,7 @@ export function useMentions(
         );
         if (mention) {
           setMentionQuery(mention.query);
-          setMentionStartIndex(mention.startIndex);
+          mentionStartIndexRef.current = mention.startIndex;
           setMentionSelectedIndex(0);
         } else {
           setMentionQuery(null);
@@ -923,6 +851,47 @@ export function useMentions(
           !event.shiftKey)
       ) {
         event.preventDefault();
+
+        // Flush pending debounced detection so a fast Tab/Enter commits the
+        // match for the text actually typed, not a stale suggestion list.
+        if (debounceTimerRef.current !== null) {
+          clearTimeout(debounceTimerRef.current);
+          debounceTimerRef.current = null;
+          const mention = detectPrefixQuery(
+            "@",
+            latestValueRef.current,
+            latestCursorRef.current,
+            searchableNamesLowerRef.current,
+          );
+          if (!mention) {
+            setMentionQuery(null);
+            return { handled: true };
+          }
+          mentionStartIndexRef.current = mention.startIndex;
+          if (mention.query !== mentionQuery) {
+            const top = rankMentionCandidates(
+              mentionCandidates,
+              mention.query,
+              activePersonaIds,
+            )[0];
+            if (!top) {
+              setMentionQuery(mention.query);
+              setMentionSelectedIndex(0);
+              return { handled: true };
+            }
+            return {
+              handled: true,
+              suggestion: {
+                displayName: top.label,
+                isAgent: top.candidate.isAgent,
+                kind: top.candidate.kind,
+                personaId: top.candidate.personaId,
+                pubkey: top.candidate.pubkey,
+              },
+            };
+          }
+        }
+
         return { handled: true, suggestion: suggestions[mentionSelectedIndex] };
       }
 
@@ -934,7 +903,14 @@ export function useMentions(
 
       return { handled: false };
     },
-    [isMentionOpen, mentionSelectedIndex, suggestions],
+    [
+      activePersonaIds,
+      isMentionOpen,
+      mentionCandidates,
+      mentionQuery,
+      mentionSelectedIndex,
+      suggestions,
+    ],
   );
 
   return {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -378,6 +378,26 @@ test("selecting a person mention inserts @Name into input", async ({
   await expect(mentionChip).not.toHaveClass(/agent-mention-highlight/);
 });
 
+test("fast Tab right after typing commits the typed match, not a stale list", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  // Open the dropdown with a bare "@" (unfiltered list, bob is not first).
+  await input.fill("Hey @");
+  await expect(autocomplete(page)).toBeVisible();
+
+  // Type the filter and Tab inside the 120ms detection debounce window —
+  // this must commit the match for "bo", not the stale unfiltered top entry.
+  await page.keyboard.type("bo");
+  await page.keyboard.press("Tab");
+
+  await expect(input).toHaveText("Hey @bob ");
+});
+
 test("selecting an agent mention inserts @Name into input", async ({
   page,
 }) => {


### PR DESCRIPTION
## Problem

Reported by DK: typing `@cl` and quickly hitting Tab right after the composer regains focus commits "@Fizz" (the first entry of the *unfiltered* list) instead of the intended match, forcing him to back it out and retype.

## Root cause

Composer autocomplete detection is debounced 120 ms (`MENTION_DEBOUNCE_MS`, introduced in #222 to reduce input lag): keystrokes only stash the latest text in refs and schedule `setMentionQuery` for later. But `handleMentionKeyDown` commits Tab/Enter **synchronously** against `suggestions[selectedIndex]` — a list ranked for the *previous* query. Type inside the debounce window and Tab commits the stale list's top entry. The `#channel` and `:emoji:` autocompletes share the identical pattern.

## Fix

On Tab/Enter, if a detection is pending, flush it synchronously:

- **Mentions / channel links** — re-run detection on the latest text (already in refs) and, when the query changed, re-rank synchronously and commit the fresh top match. A single fast Tab now inserts what you actually typed. If the fresh query matches nothing, the keypress is swallowed instead of committing garbage.
- **Emoji** — results come from an async search, so a stale Tab refreshes the dropdown for the new query instead of committing a wrong pick.
- All three hooks also move the insert start-index from state to a ref, so the replaced text range can't lag behind the committed query either.

`useMentions.ts` crossed the 1000-line guard with the flush branch, so the pure candidate helpers (`MentionCandidate` type, label/owner formatters) moved to a new `mentionCandidates.ts` — no logic changes there.

## Testing

- New Playwright regression test: open dropdown with bare `@`, type `bo` + Tab inside the debounce window, assert `@bob` is inserted. Verified it **fails against the unpatched code** and passes with the fix.
- Full `mentions.spec.ts` e2e suite: 31/31 passing.
- `pnpm test` (1625 unit tests), `pnpm typecheck`, `pnpm check` (biome + file sizes) all green.

Fixes the race DK reported in typing-improvements.
