### PR TITLE
fix(desktop): fetch channel member profiles in timeline

### DIFF
--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -310,6 +310,7 @@ export function ChannelScreen({
       ...new Set([
         ...messageAuthorPubkeys,
         ...messageMentionPubkeys,
+        ...(channelMembers ?? []).map((member) => member.pubkey),
         ...activeDmParticipantPubkeys,
         ...knownAgentPubkeys,
         ...typingEntries.map((entry) => entry.pubkey),
@@ -317,6 +318,7 @@ export function ChannelScreen({
     ],
     [
       activeDmParticipantPubkeys,
+      channelMembers,
       knownAgentPubkeys,
       messageAuthorPubkeys,
       messageMentionPubkeys,
@@ -603,9 +605,7 @@ export function ChannelScreen({
   } = useChannelAgentSessions({
     activeChannel,
     activeChannelId,
-    // Loaded only once none of the three agent queries are in their initial
-    // fetch, so a channel with genuinely zero agents still auto-closes a stale
-    // agentSession param (a disabled query reports isLoading=false — fine).
+    // Wait until agent queries leave initial load before resolving stale agentSession params.
     agentsLoaded:
       !channelMembersQuery.isLoading &&
       !managedAgentsQuery.isLoading &&


### PR DESCRIPTION
## Summary
- Include current channel member pubkeys in ChannelScreen's batched profile lookup so member join/add system messages can resolve names/avatars immediately.
- Keep the delta profile fetch behavior from PR #1514; this only expands the requested key set when the channel-members query supplies members.

## Validation
- pnpm --dir desktop typecheck
- pnpm --dir desktop check:file-sizes
- pnpm --dir desktop check (passes with existing warnings in tests/e2e/scrollback-buzzbugs.perf.ts and src/features/pulse/hooks.ts)
- git push pre-push hook suites passed: desktop-test, desktop-tauri-test, mobile-test, rust-tests