### PR TITLE
chore(desktop): move biome-ignore comments to assertion lines in pulse hooks

### DIFF
--- a/desktop/src/features/pulse/hooks.ts
+++ b/desktop/src/features/pulse/hooks.ts
@@ -33,8 +33,8 @@ export const pulseQueryKeys = {
 export function useLikedNotesQuery(pubkey?: string, enabled = true) {
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.likedNotes(pubkey ?? ""),
-    // biome-ignore lint/style/noNonNullAssertion: guarded by enabled: !!pubkey
     queryFn: async () =>
+      // biome-ignore lint/style/noNonNullAssertion: guarded by enabled: !!pubkey
       withoutProjectComments(await getLikedNotes(pubkey!, 50)),
     enabled: enabled && !!pubkey,
     staleTime: 15_000,
@@ -46,8 +46,8 @@ export function useLikedNotesQuery(pubkey?: string, enabled = true) {
 export function useMyNotesQuery(pubkey?: string) {
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.myNotes(pubkey ?? ""),
-    // biome-ignore lint/style/noNonNullAssertion: guarded by enabled: !!pubkey
     queryFn: async () =>
+      // biome-ignore lint/style/noNonNullAssertion: guarded by enabled: !!pubkey
       withoutProjectComments(await getUserNotes(pubkey!, { limit: 50 })),
     enabled: !!pubkey,
     staleTime: 15_000,


### PR DESCRIPTION
This PR fixes a main-wide biome lint failure that blocks CI on all open PRs including #1542.

biome now requires \`biome-ignore\` suppression comments to sit on the line immediately above the violation. Both \`noNonNullAssertion\` suppressions in \`pulse/hooks.ts\` were placed on \`queryFn: async () =>\` — two lines above the \`pubkey!\` assertions — so they had no effect and also triggered \`suppressions/unused\` warnings.

- Move each \`biome-ignore lint/style/noNonNullAssertion\` comment to sit directly above the \`withoutProjectComments(await ...)\` line containing \`pubkey!\`

Verified: \`biome check src/features/pulse/hooks.ts\` → 0 errors, 0 warnings after this change.