### PR TITLE
fix(desktop): publish new agent profiles to active relay

### DIFF
--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -886,9 +886,13 @@ pub async fn create_managed_agent(
     // ── Phase 4: sync agent profile on relay (async, outside lock) ───────────
     // Use the avatar persisted on the record so the published profile and any
     // later reconciliation agree on the same value.
+    let profile_relay_url = crate::relay::effective_agent_relay_url(
+        &resolved_relay_url,
+        &relay_ws_url_with_override(&state),
+    );
     let profile_sync_error = (sync_managed_agent_profile(
         &state,
-        &resolved_relay_url,
+        &profile_relay_url,
         &agent_keys,
         &name,
         resolved_avatar_url.as_deref(),
@@ -1212,11 +1216,13 @@ pub(crate) async fn reconcile_agent_profile(
         }
     };
 
-    if expected_avatar.is_empty() {
-        return Ok(());
-    }
+    let expected_avatar = if expected_avatar.is_empty() {
+        None
+    } else {
+        Some(expected_avatar)
+    };
 
-    if !profile_needs_sync(existing.as_ref(), &data.name, Some(&expected_avatar)) {
+    if !profile_needs_sync(existing.as_ref(), &data.name, expected_avatar.as_deref()) {
         return Ok(());
     }
 
@@ -1228,7 +1234,7 @@ pub(crate) async fn reconcile_agent_profile(
         &relay_url,
         &agent_keys,
         &data.name,
-        Some(&expected_avatar),
+        expected_avatar.as_deref(),
         data.auth_tag.as_deref(),
     )
     .await

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -83,6 +83,11 @@ fn profile_needs_sync_when_missing() {
 }
 
 #[test]
+fn profile_needs_sync_when_missing_even_without_expected_avatar() {
+    assert!(profile_needs_sync(None, "Duncan", None));
+}
+
+#[test]
 fn profile_needs_sync_when_name_diverges() {
     let existing = profile(Some("Stilgar"), Some("https://x/a.png"));
     assert!(profile_needs_sync(


### PR DESCRIPTION
## Summary
- publish new managed-agent kind:0 profiles to the effective active relay instead of an empty per-agent relay string
- allow startup profile reconciliation to publish missing name-only profiles even when no avatar fallback exists
- add coverage for missing-profile reconciliation without an expected avatar

## Root cause
Fresh managed-agent records store an empty `relay_url` to mean “use the active workspace relay”. The creation-time profile sync passed that empty string straight to `sync_managed_agent_profile`, so the HTTP publish target could fall back to an invalid/blank base instead of resolving the workspace relay. The later startup reconciliation had the same effective-relay resolution, but it returned early when no avatar was available, so a name-only blank agent could still remain without a kind:0.

## Validation
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml profile_needs_sync -- --nocapture`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check` (passes; existing unrelated Biome info in `tests/e2e/scrollback-buzzbugs.perf.ts`)
- push pre-push hook suites passed with repo `bin/` rustup on PATH: desktop-test, desktop-tauri-test, mobile-test, rust-tests
