### PR TITLE
fix(setup): fix syntax error in seed-local-community.sh

### DIFF
--- a/scripts/seed-local-community.sh
+++ b/scripts/seed-local-community.sh
@@ -67,7 +67,11 @@ for h in hosts:
 if not seen:
     raise SystemExit("could not derive a host from RELAY_URL")
 
-print(",\n".join(f"    ('{h.replace("'", "''")}')" for h in seen))
+lines = []
+for h in seen:
+    escaped = h.replace(chr(39), chr(39) * 2)
+    lines.append(f"    ('{escaped}')")
+print(",\n".join(lines))
 PY
 )
 


### PR DESCRIPTION
## Summary
- Fix a syntax error in `scripts/seed-local-community.sh` caused by bad character escaping.

## Test plan
- [ ] Run `scripts/seed-local-community.sh` locally against a fresh relay and verify it seeds without shell errors.