### PR TITLE
chore(desktop): use dot access for host header assignment

### DIFF
--- a/desktop/tests/e2e/scrollback-buzzbugs.perf.ts
+++ b/desktop/tests/e2e/scrollback-buzzbugs.perf.ts
@@ -145,7 +145,7 @@ test("MEASURE: scroll-back pagination latency in target channel", async ({
       delete fwd["sec-ch-ua"];
       delete fwd["sec-ch-ua-mobile"];
       delete fwd["sec-ch-ua-platform"];
-      if (COMMUNITY_HOST) fwd["host"] = COMMUNITY_HOST;
+      if (COMMUNITY_HOST) fwd.host = COMMUNITY_HOST;
       const resp = await route.fetch({ headers: fwd });
       const ms = Date.now() - t0;
       const buf = await resp.body();


### PR DESCRIPTION
## Summary

- Replace `fwd["host"]` with `fwd.host` in `desktop/tests/e2e/scrollback-buzzbugs.perf.ts` to satisfy biome `lint/complexity/useLiteralKeys`. Latent violation surfaced by the biome upgrade in #1514, blocking Desktop Core CI on every branch off main.