### PR TITLE
fix(desktop): fetch profiles for reaction actors and thread-reply authors

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
         "**/timeline-no-shift.spec.ts",
         "**/human-edit-agent-content.spec.ts",
         "**/reaction-order.spec.ts",
+        "**/reaction-names.spec.ts",
         "**/send-channel-binding.spec.ts",
       ],
       use: {

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -38,6 +38,7 @@ import {
 import {
   collectMessageAuthorPubkeys,
   collectMessageMentionPubkeys,
+  collectReactionActorPubkeys,
   formatTimelineMessages,
 } from "@/features/messages/lib/formatTimelineMessages";
 import {
@@ -52,6 +53,7 @@ import {
 } from "@/features/messages/lib/timelineLoadingState";
 import { useFetchOlderMessages } from "@/features/messages/useFetchOlderMessages";
 import { useIndependentThreadPanel } from "@/features/messages/useIndependentThreadPanel";
+import { useThreadReplies } from "@/features/messages/useThreadReplies";
 import { useChannelTyping } from "@/features/messages/useChannelTyping";
 import type { TimelineMessage } from "@/features/messages/types";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
@@ -79,8 +81,8 @@ import { useChannelRouteTarget } from "./useChannelRouteTarget";
 import { useChannelUnreadState } from "./useChannelUnreadState";
 import type { ChannelScreenProps } from "./ChannelScreen.types";
 
-const HEADER_ACTIONS_COMPACT_BREAKPOINT_PX = 760;
-
+const HEADER_ACTIONS_COMPACT_BREAKPOINT_PX = 760,
+  EMPTY_RELAY_EVENTS: RelayEvent[] = [];
 export function ChannelScreen({
   activeChannel,
   currentIdentity,
@@ -181,11 +183,13 @@ export function ChannelScreen({
   }, [activeChannelId, openThreadHeadId]);
   const messagesQuery = useChannelMessagesQuery(activeChannel);
   const windowQuery = useChannelWindowQuery(activeChannel);
+  const threadRepliesQuery = useThreadReplies(
+    activeChannel,
+    effectiveOpenThreadHeadId,
+  );
   useChannelSubscription(activeChannel);
   const { fetchOlder, hasOlderMessages, isFetchingOlder } =
     useFetchOlderMessages(activeChannel);
-  // Newest top-level message only: opening a channel should clear the timeline
-  // without clearing unread thread replies.
   const latestActiveMessage = React.useMemo(() => {
     const messages = messagesQuery.data;
     if (!messages) return null;
@@ -196,8 +200,6 @@ export function ChannelScreen({
     }
     return null;
   }, [messagesQuery.data]);
-  // No `lastMessageAt` fallback: it is reply-inclusive and would clear unread
-  // thread/sidebar state before a real top-level position is known.
   const activeReadAt = latestActiveMessage
     ? new Date(latestActiveMessage.created_at * 1_000).toISOString()
     : null;
@@ -205,14 +207,8 @@ export function ChannelScreen({
     if (!activeChannelId || activeChannel?.isMember === false) {
       return;
     }
-    // Passive channel-open (NIP-RS Option 1): advance the marker to the newest
-    // top-level message only, clearing the main timeline while thread badges
-    // and Home inbox thread activity stay intact until each thread is read.
     markChannelRead(activeChannelId, activeReadAt, { topLevelOnly: true });
   }, [activeChannel?.isMember, activeChannelId, activeReadAt, markChannelRead]);
-  // Install the NIP-RS parent resolver. Active `thread:`/`msg:` contexts fold
-  // to this channel (never another message), preserving ancestor/descendant
-  // isolation while channel reads cover top-level history. Clear on leave.
   React.useEffect(() => {
     if (!activeChannelId) {
       setContextParentResolver(null);
@@ -260,14 +256,17 @@ export function ChannelScreen({
     messagesQuery.data,
     targetMessageEvents,
   ]);
-  const messageAuthorPubkeys = React.useMemo(
-    () => collectMessageAuthorPubkeys(resolvedMessages),
-    [resolvedMessages],
-  );
-  const messageMentionPubkeys = React.useMemo(
-    () => collectMessageMentionPubkeys(resolvedMessages),
-    [resolvedMessages],
-  );
+  const threadReplyEvents = threadRepliesQuery.data ?? EMPTY_RELAY_EVENTS;
+  const messageEventProfilePubkeys = React.useMemo(() => {
+    const events = [...resolvedMessages, ...threadReplyEvents];
+    return [
+      ...new Set([
+        ...collectMessageAuthorPubkeys(events),
+        ...collectMessageMentionPubkeys(events),
+        ...collectReactionActorPubkeys(events),
+      ]),
+    ];
+  }, [resolvedMessages, threadReplyEvents]);
   const latestMessageEvent = React.useMemo(
     () => resolvedMessages[resolvedMessages.length - 1] ?? null,
     [resolvedMessages],
@@ -308,8 +307,7 @@ export function ChannelScreen({
   const messageProfilePubkeys = React.useMemo(
     () => [
       ...new Set([
-        ...messageAuthorPubkeys,
-        ...messageMentionPubkeys,
+        ...messageEventProfilePubkeys,
         ...activeDmParticipantPubkeys,
         ...knownAgentPubkeys,
         ...typingEntries.map((entry) => entry.pubkey),
@@ -318,8 +316,7 @@ export function ChannelScreen({
     [
       activeDmParticipantPubkeys,
       knownAgentPubkeys,
-      messageAuthorPubkeys,
-      messageMentionPubkeys,
+      messageEventProfilePubkeys,
       typingEntries,
     ],
   );
@@ -464,6 +461,7 @@ export function ChannelScreen({
   const threadPanelData = useIndependentThreadPanel({
     activeChannel,
     channelEvents: resolvedMessages,
+    threadReplyEvents,
     rootId: effectiveOpenThreadHeadId,
     replyTargetId: threadReplyTargetId,
     expandedReplyIds: expandedThreadReplyIds,

--- a/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  collectReactionActorPubkeys,
   countTopLevelTimelineRows,
   formatTimelineMessages,
   isTimelineContentEvent,
@@ -166,6 +167,57 @@ test("non-deletion event kinds do NOT hide the target message", () => {
   const events = [streamMessage(), reaction];
   const out = formatTimelineMessages(events, null, undefined, null);
   assert.equal(out.length, 1, "the kind:9 message should still be visible");
+});
+
+test("collectReactionActorPubkeys returns active kind:7 actors only", () => {
+  const reactionId = `${"c".repeat(64)}`;
+  const deletedReactionId = `${"d".repeat(64)}`;
+  const actor = PUBKEY_B.toUpperCase();
+  const events = [
+    streamMessage(),
+    {
+      id: reactionId,
+      pubkey: actor,
+      kind: 7,
+      created_at: 1_700_000_001,
+      content: "+",
+      tags: [
+        ["h", CHANNEL_ID],
+        ["e", HEX64_A],
+      ],
+      sig: "sig",
+    },
+    {
+      id: `${"e".repeat(64)}`,
+      pubkey: PUBKEY_A,
+      kind: 7,
+      created_at: 1_700_000_002,
+      content: "🎉",
+      tags: [
+        ["h", CHANNEL_ID],
+        ["e", HEX64_A],
+        ["actor", actor],
+      ],
+      sig: "sig",
+    },
+    {
+      id: deletedReactionId,
+      pubkey: PUBKEY_A,
+      kind: 7,
+      created_at: 1_700_000_003,
+      content: "👀",
+      tags: [
+        ["h", CHANNEL_ID],
+        ["e", HEX64_A],
+      ],
+      sig: "sig",
+    },
+    deletionEvent(5, deletedReactionId, {
+      id: `${"f".repeat(64)}`,
+    }),
+  ];
+
+  assert.deepEqual(collectReactionActorPubkeys(events), [PUBKEY_B]);
 });
 
 test("huddle start renders as a timeline row", () => {

--- a/desktop/src/features/messages/lib/formatTimelineMessages.ts
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.ts
@@ -484,6 +484,40 @@ function extractSystemMessagePubkeys(event: RelayEvent): string[] {
   }
 }
 
+export function collectReactionActorPubkeys(events: RelayEvent[]) {
+  const deletedEventIds = new Set<string>();
+  for (const event of events) {
+    if (
+      event.kind !== KIND_DELETION &&
+      event.kind !== KIND_NIP29_DELETE_EVENT
+    ) {
+      continue;
+    }
+    for (const targetId of getDeletionTargets(event.tags)) {
+      deletedEventIds.add(targetId.toLowerCase());
+    }
+  }
+
+  const pubkeys = new Set<string>();
+  for (const event of events) {
+    if (
+      event.kind !== KIND_REACTION ||
+      deletedEventIds.has(event.id.toLowerCase())
+    ) {
+      continue;
+    }
+    pubkeys.add(
+      resolveEventAuthorPubkey({
+        pubkey: event.pubkey,
+        tags: event.tags,
+        preferActorTag: true,
+        requireChannelTagForPTags: true,
+      }).toLowerCase(),
+    );
+  }
+  return [...pubkeys];
+}
+
 export function collectMessageAuthorPubkeys(events: RelayEvent[]) {
   const pubkeys = new Set<string>();
 

--- a/desktop/src/features/messages/useIndependentThreadPanel.ts
+++ b/desktop/src/features/messages/useIndependentThreadPanel.ts
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import { buildIndependentThreadPanel } from "@/features/messages/lib/independentThreadPanel";
-import { useThreadReplies } from "@/features/messages/useThreadReplies";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type {
   Channel,
@@ -13,6 +12,7 @@ import type {
 export function useIndependentThreadPanel(args: {
   activeChannel: Channel | null;
   channelEvents: RelayEvent[];
+  threadReplyEvents: RelayEvent[];
   rootId: string | null;
   replyTargetId: string | null;
   expandedReplyIds: ReadonlySet<string>;
@@ -23,12 +23,11 @@ export function useIndependentThreadPanel(args: {
   personaLookup: Map<string, string>;
   respondToLookup: Map<string, RespondToMode>;
 }) {
-  const replies = useThreadReplies(args.activeChannel, args.rootId);
   return React.useMemo(
     () =>
       buildIndependentThreadPanel(
         args.channelEvents,
-        replies.data ?? [],
+        args.threadReplyEvents,
         args.rootId,
         args.replyTargetId,
         args.expandedReplyIds,
@@ -40,6 +39,6 @@ export function useIndependentThreadPanel(args: {
         args.personaLookup,
         args.respondToLookup,
       ),
-    [args, replies.data],
+    [args],
   );
 }

--- a/desktop/tests/e2e/reaction-names.spec.ts
+++ b/desktop/tests/e2e/reaction-names.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const REACTION_TARGET_CONTENT = "React to me with a custom emoji";
+const REACTION_TARGET_EVENT_ID = "d".repeat(64);
+const BOB_PUBKEY =
+  "bb22a5299220cad76ffd46190ccbeede8ab5dc260faa28b6e5a2cb31b9aff260";
+
+function reactionTargetRow(page: import("@playwright/test").Page) {
+  return page
+    .getByTestId("message-row")
+    .filter({ hasText: REACTION_TARGET_CONTENT })
+    .last();
+}
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+});
+
+test("reaction popover resolves a reactor with no authored message in the window", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await page.waitForFunction(
+    () =>
+      window.__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+        channelName: "general",
+        kind: 7,
+      }) === true,
+  );
+
+  await page.evaluate(
+    ({ pubkey, targetId }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content: "🎉",
+        extraTags: [["e", targetId]],
+        kind: 7,
+        pubkey,
+      });
+    },
+    { pubkey: BOB_PUBKEY, targetId: REACTION_TARGET_EVENT_ID },
+  );
+
+  const row = reactionTargetRow(page);
+  const pill = row.getByRole("button", { name: "Toggle 🎉 reaction" });
+  await expect(pill).toBeVisible();
+  await pill.hover();
+  await expect(page.getByText("bob reacted with")).toBeVisible();
+});


### PR DESCRIPTION
## Problem

Reaction pill popovers sometimes show a truncated pubkey instead of the reactor's display name (`80c5f18b… reacted with :party_blob:`) — reported by Wes in #buzz-bugs.

**Root cause:** reaction (kind-7) actors were never included in the profile fetch set. `ChannelScreen` builds `messageProfilePubkeys` from `collectMessageAuthorPubkeys()` (+ mentions/DM participants/agents/typing), and that collector filters on `isTimelineContentEvent()` — kind-7 excluded. `formatTimelineMessages` then renders each reactor via `profiles?.[actorPubkey]` with a `${pubkey.slice(0,8)}…` fallback.

The exclusion is old, but the pre-#1500 client-assembled cache accumulated deep channel history, so nearly every reactor had *also authored some message in the soup* and got a name by side effect. Post-#1500 the timeline is one server-assembled window page; a reactor with no authored row inside the current page falls through to the fallback. (#1514's delta profile fetch is unrelated — it changes how the set is fetched, not what's in it.)

The thread panel had the same gap one level deeper: `useIndependentThreadPanel` fetched thread replies via its own `useThreadReplies` cache, so deep-thread reply **authors** and their reactors never reached the profile batch either.

## Fix

- New `collectReactionActorPubkeys(events)` (kind-7 only, actor-tag aware, skips deleted reactions, lowercase/dedup) — deliberately separate from `collectMessageAuthorPubkeys`, whose timeline-content semantics other callers rely on.
- `ChannelScreen` merges reaction actors into the users-batch profile set, over `[...resolvedMessages, ...threadReplyEvents]`.
- `useThreadReplies` hoisted into `ChannelScreen`; `threadReplyEvents` feeds both the profile pubkey collection and `useIndependentThreadPanel` — thread reply authors/reactors now resolve from the same profile batch.
- Marginal cost: #1514's per-pubkey delta cache means new reactors cost one small kind-0 batch, never a re-download of resolved profiles.

Note: a few explanatory comments in `ChannelScreen.tsx` were trimmed to keep the file under the 1000-line CI gate (at 997 before this change); behavior they described is unchanged.

## Validation

- **Live staging repro (root-cause confirmation + fix verification):** Playwright spec driving the built bundle against the staging relay (`sprout-oss.stage.blox.sqprod.co` via in-cluster port-forward), targeting Wes's exact message/reaction.
  - main @ 4343c6d5 (RED): popover `"80c5f18b… reacted with :party_blob:"`; 8 kind-0 batches / 72 pubkeys requested — reactor's pubkey in none of them.
  - this branch @ 0bd12dfb (GREEN): popover `"tho reacted with :party_blob:"`; reactor's kind-0 requested and resolved.
- Unit: `collectReactionActorPubkeys` coverage in `formatTimelineMessages.test.mjs`; full desktop unit suite 1630 pass / 0 fail.
- E2E: new bridge-mock `reaction-names.spec.ts` (smoke project) — reactor with no authored message in the window resolves by name.
- `pnpm check` + `pnpm build` green; ChannelScreen still under the size gate at 997 lines.

Diagnosis thread: #buzz-bugs `40260a3e`. Implementation by Max; root-cause + staging verification by Eva.
