### PR TITLE
fix(desktop): restore saved window geometry on launch

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -84,17 +84,9 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(
             tauri_plugin_window_state::Builder::default()
-                // The main window should always launch edge-to-edge in the
-                // available desktop area. Do not let stale saved geometry or
-                // fullscreen state override the maximized launch config.
-                .with_state_flags(
-                    StateFlags::all()
-                        & !(StateFlags::VISIBLE
-                            | StateFlags::POSITION
-                            | StateFlags::SIZE
-                            | StateFlags::MAXIMIZED
-                            | StateFlags::FULLSCREEN),
-                )
+                // Visibility is excluded: the window starts hidden and the
+                // frontend shows it once ready.
+                .with_state_flags(StateFlags::all() & !StateFlags::VISIBLE)
                 .build(),
         )
         .plugin(tauri_plugin_websocket::init())


### PR DESCRIPTION
## Problem

The desktop app opens maximized on **every** launch, ignoring the user's last window size/position.

PR #925 made maximized launch the default by setting `"maximized": true` in `tauri.conf.json` *and* stripping `POSITION | SIZE | MAXIMIZED | FULLSCREEN` from the window-state plugin's restore flags — so saved geometry was explicitly discarded each launch.

## Fix

Restore the plugin's full state flags (back to pre-#925 `StateFlags::all() & !VISIBLE`), keeping `"maximized": true` in the config.

Behavior:
- **First-ever launch** (no saved state file): plugin skips restore → config applies → maximized.
- **Every launch after**: saved geometry/maximized/fullscreen state is restored.

Verified against tauri-plugin-window-state 2.4.1 source: the plugin skips restore when no saved state exists, and treats the all-zeros state file left behind by the stripped flags as "no state" — so existing installs still get one maximized launch, then remembering kicks in.

## Testing

- `cargo check` green
- `just fmt-check` + `just desktop-tauri-fmt-check` green
- Manual: launch → resize/move → quit → relaunch restores geometry; deleting `.window-state.json` → launch is maximized.
