### PR TITLE
fix(desktop): stop edit-channel dialog hanging on "Saving..."

### DIFF
--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -268,8 +268,20 @@ export function useUpdateChannelMutation(channelId: string | null) {
         ),
       );
     },
-    onSettled: async () => {
-      await invalidateChannelState(queryClient, channelId);
+    onSettled: () => {
+      // refetchType "none": onSuccess already cached the relay-returned detail;
+      // awaiting the full channel-list refetch kept the edit dialog stuck on
+      // "Saving..." (same failure #1360 fixed for create).
+      void queryClient.invalidateQueries({
+        queryKey: channelsQueryKey,
+        refetchType: "none",
+      });
+      if (channelId) {
+        void queryClient.invalidateQueries({
+          queryKey: channelDetailQueryKey(channelId),
+          refetchType: "none",
+        });
+      }
     },
   });
 }
@@ -285,8 +297,9 @@ export function useSetChannelTopicMutation(channelId: string | null) {
 
       return setChannelTopic({ ...input, channelId });
     },
-    onSettled: async () => {
-      await invalidateChannelState(queryClient, channelId);
+    onSettled: () => {
+      // fire-and-forget: awaiting the channels-list refetch blocks the dialog
+      void invalidateChannelState(queryClient, channelId);
     },
   });
 }
@@ -302,8 +315,9 @@ export function useSetChannelPurposeMutation(channelId: string | null) {
 
       return setChannelPurpose({ ...input, channelId });
     },
-    onSettled: async () => {
-      await invalidateChannelState(queryClient, channelId);
+    onSettled: () => {
+      // fire-and-forget: awaiting the channels-list refetch blocks the dialog
+      void invalidateChannelState(queryClient, channelId);
     },
   });
 }


### PR DESCRIPTION
## Problem

Editing a channel (e.g. toggling Private off) left the dialog stuck on **"Saving..."** indefinitely, even though the setting was actually applied — force-closing the dialog showed the change had landed.

## Root cause

`handleSaveChannelEdits` closes the dialog only after `mutateAsync` resolves, and React Query's `mutateAsync` also awaits `onSettled`. The `onSettled` for `useUpdateChannelMutation` / `useSetChannelTopicMutation` / `useSetChannelPurposeMutation` did `await invalidateChannelState(...)`, which awaits a **full refetch of the `["channels"]` list query** — the expensive `get_channels` fan-out (paged 39002 scan + 39000 metadata + per-channel last-message filter). With many channels, or any stalled relay round-trip (the desktop reqwest client has no request timeout), the dialog never closed. The kind:9002 write lands first, which is why the setting applied anyway.

This is the same failure class as #1360, which fixed it for channel **create** only.

## Fix

- `useUpdateChannelMutation.onSettled`: invalidate list + detail with `refetchType: "none"` — `onSuccess` already writes the relay-returned `ChannelDetail` into both caches, so no immediate refetch is needed.
- `useSetChannelTopicMutation` / `useSetChannelPurposeMutation`: keep the invalidation (these return `void`, so a refetch is still wanted) but fire-and-forget instead of awaiting it.

The dialog now closes as soon as each write confirms.

## Testing

- `tsc --noEmit` clean, `biome lint` clean, 1757/1757 unit tests pass.
- Manually verified in the dev app: toggling Private and saving closes the dialog immediately; channel list/detail reconcile in the background.
