### PR TITLE
fix desktop canvas header blur in split channel management

### DIFF
--- a/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
@@ -353,14 +353,15 @@ export function ChannelManagementSheet({
         </DialogPrimitive.Portal>
       ) : null}
       {isSplitLayout ? (
+        // No translucent backdrop-blur surface here: `backdrop-filter`
+        // creates a stacking context that traps the z-40 panel header below
+        // the shared z-30 header blur strip in split layout. The pane sits on
+        // the opaque `bg-background` from PANEL_BASE_CLASS instead.
         <DialogPrimitive.Content
           className={cn(
             PANEL_BASE_CLASS,
             "h-full w-full cursor-default overflow-hidden border-l-0 p-0",
             animateSplitEnter && PANEL_ENTER_MOTION_CLASS,
-            isDark
-              ? "bg-background/85 backdrop-blur-xl supports-backdrop-filter:bg-background/75"
-              : "bg-background",
           )}
           data-testid="channel-management-sheet"
           onEscapeKeyDown={(event) => event.preventDefault()}


### PR DESCRIPTION
**Category:** fix
**User Impact:** The Canvas panel header stays readable and clickable in dark-mode split layouts.
**Problem:** Opening Canvas from channel management in dark mode could blur out the header controls, leaving the back and close buttons present but visually hidden behind the shared channel header strip.
**Solution:** Remove the inert translucent blur surface from the docked channel-management dialog wrapper so it no longer creates a stacking context above the Canvas header. Overlay and standalone panel chrome keep their existing blur behavior.

<details>
<summary>File changes</summary>

**desktop/src/features/channels/ui/ChannelManagementSheet.tsx**
Drops the dark-mode `backdrop-blur-xl` surface from the split-layout `DialogPrimitive.Content` and documents why the docked pane should stay on the opaque base background. This prevents `backdrop-filter` from trapping the Canvas header beneath the shared channel header blur strip while leaving overlay/standalone mode unchanged.

</details>

### Reproduction Steps

1. Run the desktop app in dark mode at a width that uses the split auxiliary pane.
2. Open a channel's management panel.
3. Open the Canvas view from channel management.
4. Confirm the back affordance, `Canvas` title, and close action remain crisp and visible in the header.

### Screenshots/Demos

Marge reproduced the regression on latest `origin/main` and verified the fix on this branch.

Before (`origin/main`) — title, back, and close blurred out:
<img width="500" height="160" alt="image" src="https://github.com/user-attachments/assets/0ac04155-f0b5-4004-a3a0-01d1b9c0ec04" />

After (`d3fe2dad`) — back, `Canvas` title, and close are crisp:
<img width="500" height="160" alt="image" src="https://github.com/user-attachments/assets/abcb4079-3839-4a71-bf0c-ec279ef420ea" />

Full pane before / after:
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/d0fcea3c-e834-4975-adff-8879d01ca895" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/0bd9ba9c-bbe6-4c69-94c7-65edcd4a9b22" />

### Validation

- `biome check .` ✅
- `pnpm check` ✅
- `tsc --noEmit` ✅
- Unit tests: 1629 passed ✅
- E2E: `channel-shared-header-backdrop` + `channel-controls` — 9 passed ✅
- Push hooks with Hermit activated: desktop, mobile, Rust, and Tauri tests passed ✅
