### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
`RUSTSEC-2026-0204` flags an invalid pointer dereference in the `fmt::Pointer` impl for `crossbeam-epoch`'s `Atomic`/`Shared` (dereferences an invalid pointer, e.g. one from `Atomic::null`). `crossbeam-epoch` reaches the tree only transitively — via `moka`, `metrics-util`, `crossbeam-deque` (through `ignore`), and `iroh` (through `hickory-resolver`) — so no source change introduced it. `cargo-deny check` began failing the `advisories` gate on every push to `main` the moment the advisory published, independent of the code being merged.

`0.9.20` is the patched release named by the advisory. This is a lockfile-only bump — no `deny.toml` ignore, since a safe upgrade exists (unlike the existing ignore entries, which have no upstream fix).

`cargo-deny check advisories` passes locally on this branch (`advisories ok`).
