### PR TITLE
fix(composer): address image-editor follow-up nits on #1491

### DIFF
--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -138,14 +138,21 @@ pub async fn download_file(
 ///
 /// Same SSRF validation, size cap, and content policy as the download
 /// commands above.
+///
+/// Returns `tauri::ipc::Response` so the bytes cross IPC as a raw buffer
+/// instead of a JSON number array (which would be ~3x the size to
+/// serialize and deserialize at the 50 MiB cap).
 #[tauri::command]
-pub async fn fetch_media_bytes(url: String, state: State<'_, AppState>) -> Result<Vec<u8>, String> {
+pub async fn fetch_media_bytes(
+    url: String,
+    state: State<'_, AppState>,
+) -> Result<tauri::ipc::Response, String> {
     let relay_base = relay_api_base_url_with_override(&state);
     validate_download_url(&url, &relay_base)?;
 
     let bytes = fetch_blob_bytes(&url, &state).await?;
     detect_and_validate_mime(&bytes)?;
-    Ok(bytes)
+    Ok(tauri::ipc::Response::new(bytes))
 }
 
 /// Fetch blob bytes from a (pre-validated) relay media URL through the app's

--- a/desktop/src/features/messages/lib/useMediaUpload.ts
+++ b/desktop/src/features/messages/lib/useMediaUpload.ts
@@ -208,8 +208,9 @@ export function useMediaUpload() {
   /**
    * Pre-edit originals of annotated attachments, keyed by the annotated
    * attachment's URL. Powers "revert to original" in the composer lightbox.
-   * In-memory only — cleared implicitly when the attachment leaves the
-   * composer (send, remove, draft switch).
+   * In-memory only, by design — cleared implicitly when the attachment
+   * leaves the composer (send, remove, draft switch). Persisting revert
+   * across a draft round-trip is an explicit non-goal (#1491 review).
    */
   const [originalsByUrl, setOriginalsByUrl] = React.useState<
     Map<string, BlobDescriptor>

--- a/desktop/src/features/messages/ui/ComposerAttachments.tsx
+++ b/desktop/src/features/messages/ui/ComposerAttachments.tsx
@@ -304,6 +304,10 @@ const MediaAttachmentItem = React.forwardRef<
                           className={cn(
                             LIGHTBOX_BUTTON_CLASS,
                             "h-auto min-w-0",
+                            // Active state: swap the circular pill for the
+                            // shared button radius with a visible ring so a
+                            // spoilered attachment reads as "selected".
+                            "data-[state=on]:rounded-lg data-[state=on]:bg-black/50 data-[state=on]:text-white data-[state=on]:ring-2 data-[state=on]:ring-white/80",
                           )}
                           data-testid="composer-attachment-spoiler"
                           onPressedChange={() =>

--- a/desktop/src/features/messages/ui/ComposerAttachments.tsx
+++ b/desktop/src/features/messages/ui/ComposerAttachments.tsx
@@ -304,10 +304,14 @@ const MediaAttachmentItem = React.forwardRef<
                           className={cn(
                             LIGHTBOX_BUTTON_CLASS,
                             "h-auto min-w-0",
-                            // Active state: swap the circular pill for the
-                            // shared button radius with a visible ring so a
-                            // spoilered attachment reads as "selected".
-                            "data-[state=on]:rounded-lg data-[state=on]:bg-black/50 data-[state=on]:text-white data-[state=on]:ring-2 data-[state=on]:ring-white/80",
+                            // Active state driven by component state, not
+                            // Radix's data-state: the TooltipTrigger clobbers
+                            // the Toggle's data-state attribute. Swap the
+                            // circular pill for the shared button radius with
+                            // a visible ring so a spoilered attachment reads
+                            // as "selected" on the dark lightbox backdrop.
+                            isSpoilered &&
+                              "rounded-lg bg-white/25 text-white ring-2 ring-white",
                           )}
                           data-testid="composer-attachment-spoiler"
                           onPressedChange={() =>

--- a/desktop/src/features/messages/ui/ComposerAttachments.tsx
+++ b/desktop/src/features/messages/ui/ComposerAttachments.tsx
@@ -126,11 +126,17 @@ const MediaAttachmentItem = React.forwardRef<
   // stable Escape listener, so the handler would otherwise see a stale mode.
   const modeRef = React.useRef(mode);
   modeRef.current = mode;
+  // Gates Escape while the editor's save upload is in flight: dismissing
+  // edit mode mid-save would look like a cancel while the swap still lands.
+  const editorSavingRef = React.useRef(false);
+  const handleEditorSavingChange = React.useCallback((saving: boolean) => {
+    editorSavingRef.current = saving;
+  }, []);
   const handleEscapeKeyDown = React.useCallback((event: KeyboardEvent) => {
     if (modeRef.current === "edit") {
       // Escape leaves canvas mode but keeps the lightbox open.
       event.preventDefault();
-      setMode("view");
+      if (!editorSavingRef.current) setMode("view");
     }
   }, []);
 
@@ -235,6 +241,7 @@ const MediaAttachmentItem = React.forwardRef<
                   sourceType={attachment.type}
                   onCancel={handleEditorCancel}
                   onSave={handleEditorSave}
+                  onSavingChange={handleEditorSavingChange}
                 />
               ) : isVideo ? (
                 // biome-ignore lint/a11y/useMediaCaption: user-uploaded video, no captions available

--- a/desktop/src/features/messages/ui/ComposerImageEditor.tsx
+++ b/desktop/src/features/messages/ui/ComposerImageEditor.tsx
@@ -121,6 +121,8 @@ type ComposerImageEditorProps = {
   onCancel: () => void;
   /** Upload the annotated PNG; rejection keeps the editor open. */
   onSave: (bytes: Uint8Array) => Promise<void>;
+  /** Notifies the parent while a save is in flight (used to gate Escape). */
+  onSavingChange?: (saving: boolean) => void;
 };
 
 /**
@@ -136,6 +138,7 @@ export function ComposerImageEditor({
   sourceType,
   onCancel,
   onSave,
+  onSavingChange,
 }: ComposerImageEditorProps) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
   const activeStrokeRef = React.useRef<EditorStroke | null>(null);
@@ -158,6 +161,18 @@ export function ComposerImageEditor({
   } | null>(null);
   const [saving, setSaving] = React.useState(false);
   const [saveError, setSaveError] = React.useState<string | null>(null);
+
+  const setSavingState = React.useCallback(
+    (next: boolean) => {
+      setSaving(next);
+      onSavingChange?.(next);
+    },
+    [onSavingChange],
+  );
+
+  // Reset the parent's gate if we unmount mid-save (success closes the
+  // lightbox and unmounts this component before the flag is cleared here).
+  React.useEffect(() => () => onSavingChange?.(false), [onSavingChange]);
 
   const handleImageLoad = React.useCallback(
     (event: React.SyntheticEvent<HTMLImageElement>) => {
@@ -280,7 +295,7 @@ export function ComposerImageEditor({
 
   const handleSave = React.useCallback(async () => {
     if (saving || strokes.length === 0) return;
-    setSaving(true);
+    setSavingState(true);
     setSaveError(null);
     try {
       const bytes = await renderAnnotatedPng(sourceUrl, sourceType, strokes);
@@ -288,9 +303,9 @@ export function ComposerImageEditor({
       // On success the parent closes the lightbox and unmounts this component.
     } catch {
       setSaveError("Could not save the drawing. Please try again.");
-      setSaving(false);
+      setSavingState(false);
     }
-  }, [onSave, saving, sourceType, sourceUrl, strokes]);
+  }, [onSave, saving, setSavingState, sourceType, sourceUrl, strokes]);
 
   const hasStrokes = strokes.length > 0;
 

--- a/desktop/src/shared/api/tauriMedia.ts
+++ b/desktop/src/shared/api/tauriMedia.ts
@@ -11,6 +11,8 @@ import { invokeTauri } from "./tauri";
 export async function fetchMediaBytes(
   url: string,
 ): Promise<Uint8Array<ArrayBuffer>> {
-  const bytes = await invokeTauri<number[]>("fetch_media_bytes", { url });
+  // The Rust command replies with `tauri::ipc::Response`, so the bytes
+  // arrive as a raw ArrayBuffer rather than a JSON number array.
+  const bytes = await invokeTauri<ArrayBuffer>("fetch_media_bytes", { url });
   return new Uint8Array(bytes);
 }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -8603,11 +8603,12 @@ export function maybeInstallE2eTauriMocks() {
       case "upload_media_bytes":
         return (await resolveMockUploadDescriptors(activeConfig))[0];
       case "fetch_media_bytes": {
-        // The real command fetches relay media through Rust reqwest. In E2E
-        // the browser fetch suffices — specs serve the URL via page.route.
+        // The real command fetches relay media through Rust reqwest and
+        // replies with raw bytes (`tauri::ipc::Response` → ArrayBuffer). In
+        // E2E the browser fetch suffices — specs serve the URL via page.route.
         const response = await fetch((payload as { url: string }).url);
         if (!response.ok) throw new Error(`fetch failed: ${response.status}`);
-        return Array.from(new Uint8Array(await response.arrayBuffer()));
+        return await response.arrayBuffer();
       }
       case "download_image":
       case "download_file":


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Image annotation opens faster for large uploads and behaves more consistently if a save is already in progress.
**Problem:** Follow-up review on #1491 called out a few sharp edges in composer image editing: fetched image bytes were serialized as JSON arrays, Escape could look like cancel while a save still completed, and the revert affordance’s draft behavior needed an explicit scope decision.
**Solution:** Return fetched image bytes over Tauri IPC as a raw buffer, gate Escape while the editor is saving, and document the in-memory-only revert behavior as the intended follow-up boundary.

<details>
<summary>File changes</summary>

**desktop/src-tauri/src/commands/media_download.rs**
Returns image-editor media bytes as `tauri::ipc::Response` so large images cross IPC as raw bytes instead of JSON number arrays while preserving existing validation and size caps.

**desktop/src/features/messages/lib/useMediaUpload.ts**
Documents the revert-originals map as intentionally in-memory-only, recording draft round-trip persistence as outside this follow-up’s scope.

**desktop/src/features/messages/ui/ComposerAttachments.tsx**
Tracks the image editor’s save state in the lightbox and prevents Escape from leaving edit mode while a save upload is in flight.

**desktop/src/features/messages/ui/ComposerImageEditor.tsx**
Reports save-in-flight state to the parent and clears that signal on unmount so the lightbox Escape guard stays accurate.

**desktop/src/shared/api/tauriMedia.ts**
Reads `fetch_media_bytes` responses as an `ArrayBuffer` and wraps them in a `Uint8Array` for the editor.

**desktop/src/testing/e2eBridge.ts**
Updates the E2E mock for `fetch_media_bytes` to return the same raw `ArrayBuffer` shape as the Tauri command.

</details>

### Reproduction Steps

1. Open the desktop composer and attach an image.
2. Open the attachment lightbox, enter draw mode, add a stroke, and save.
3. Confirm the edited attachment replaces the original and can still be reverted while the composer remains active.
4. Start another edit and press Escape before saving; the editor should leave draw mode normally.
5. While a save is in progress, Escape should no longer make the UI look canceled while the attachment swap still lands.

### Validation

- GitHub CI: previously green after rerunning one unrelated smoke failure; latest run for `770c71ef` is in progress with no failures observed yet.
- Marge final gate: approved in-thread for focused scope/correctness; follow-up spoiler active-state re-check passed on `770c71ef` with independent screenshot verification.
- Local checks from final gate: `biome check .`, file-sizes, px-text, tsc, `pnpm test` 1885/1885, desktop-tauri fmt-check, and `cargo check` passed; local clippy findings were pre-existing outside this PR.


### Screenshots / Mocks

| Editor lightbox idle | Editor lightbox active annotation |
| --- | --- |
| <img width="1280" height="860" alt="Editor lightbox idle" src="https://github.com/user-attachments/assets/441cf522-ad95-4e27-8f91-684de22dd8b7" /> | <img width="1280" height="860" alt="Editor lightbox with freehand annotation and brush cursor visible" src="https://github.com/user-attachments/assets/6cbae1da-a9b3-4bb5-b6f5-c7f1f514e3e5" /> |



| Spoiler inactive | Spoiler active |
| --- | --- |
| <img width="336" height="96" alt="Spoiler toggle inactive" src="https://github.com/user-attachments/assets/ffd9ed9f-5522-4723-8376-5ac03094a852" /> | <img width="336" height="96" alt="Spoiler toggle active with rounded shared-button ring" src="https://github.com/user-attachments/assets/b8445246-b2f3-411c-80c7-5a140d87e60c" /> |

### Coordination

buzz://message?channel=99a4d0c9-e02b-49e3-aa81-e637c4fd0292&thread=790c65884f4b236b88f23b9c7a82dd904d4113a8822bc1c8df3c4f7896896ff8




