### PR TITLE
fix(personas): remove goose runtime pin from Fizz built-in

### DIFF
--- a/desktop/src-tauri/src/managed_agents/personas.rs
+++ b/desktop/src-tauri/src/managed_agents/personas.rs
@@ -119,7 +119,7 @@ const BUILT_IN_PERSONAS: &[BuiltInPersona] = &[
             "Orchard", "Buzz",
         ],
         model: None,
-        runtime: Some("goose"),
+        runtime: None,
         default_active: true,
     },
     BuiltInPersona {

--- a/desktop/src-tauri/src/managed_agents/personas/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/personas/tests.rs
@@ -1,8 +1,9 @@
 use super::{
-    ensure_persona_ids_are_active, ensure_persona_is_active, merge_personas,
-    migrate_retired_personas, validate_persona_activation_change, validate_persona_deletion,
-    BUILT_IN_PERSONAS, RETIRED_PERSONAS,
+    built_in_persona_records, ensure_persona_ids_are_active, ensure_persona_is_active,
+    merge_personas, migrate_retired_personas, validate_persona_activation_change,
+    validate_persona_deletion, BUILT_IN_PERSONAS, RETIRED_PERSONAS,
 };
+use crate::managed_agents::discovery::{default_agent_command, effective_agent_command};
 use crate::managed_agents::validate_team_id;
 use crate::managed_agents::PersonaRecord;
 
@@ -35,7 +36,7 @@ fn merge_personas_adds_missing_built_ins() {
     assert!(records.iter().all(|record| record.is_builtin));
     assert!(records
         .iter()
-        .any(|record| record.id == "builtin:fizz" && record.runtime.as_deref() == Some("goose")));
+        .any(|record| record.id == "builtin:fizz" && record.runtime.is_none()));
     assert!(records
         .iter()
         .any(|record| record.id == "builtin:product-strategist" && !record.is_active));
@@ -478,4 +479,38 @@ fn migrate_is_idempotent() {
 
     // 4. Run again on result of (3) — should be no-op.
     assert!(!migrate_retired_personas(&mut stored_pre_demotion, now));
+}
+
+// ── Fizz default harness ──────────────────────────────────────────────────────
+
+#[test]
+fn fizz_builtin_has_no_pinned_runtime() {
+    // The Fizz built-in must not hard-pin a runtime so it inherits the
+    // bundled default (buzz-agent) rather than requiring goose on PATH.
+    let records = built_in_persona_records("2026-01-01T00:00:00Z");
+    let fizz = records
+        .iter()
+        .find(|r| r.id == "builtin:fizz")
+        .expect("builtin:fizz must exist");
+    assert_eq!(
+        fizz.runtime, None,
+        "Fizz built-in must not pin a runtime — it should inherit the default"
+    );
+}
+
+#[test]
+fn fizz_builtin_resolves_to_buzz_agent() {
+    // With no runtime pin, effective_agent_command must fall through to
+    // default_agent_command(), which resolves the bundled buzz-agent.
+    let records = built_in_persona_records("2026-01-01T00:00:00Z");
+    assert_eq!(
+        effective_agent_command(Some("builtin:fizz"), &records, None),
+        default_agent_command(),
+        "Fizz must resolve to the bundled default harness, not goose"
+    );
+    assert_eq!(
+        effective_agent_command(Some("builtin:fizz"), &records, None),
+        "buzz-agent",
+        "Fizz must resolve to buzz-agent specifically"
+    );
 }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1706,7 +1706,7 @@ function resetMockPersonas(config?: E2eConfig) {
     display_name: persona.display_name,
     avatar_url: persona.avatar_url,
     system_prompt: persona.system_prompt,
-    runtime: persona.id === "builtin:fizz" ? "goose" : null,
+    runtime: null,
     model: null,
     provider: null,
     name_pool: [],
@@ -6574,7 +6574,7 @@ async function handleCreateManagedAgent(
     persona_id: args.input.personaId ?? null,
     relay_url: args.input.relayUrl ?? DEFAULT_RELAY_WS_URL,
     acp_command: args.input.acpCommand ?? "buzz-acp",
-    agent_command: args.input.agentCommand ?? "goose",
+    agent_command: args.input.agentCommand ?? "buzz-agent",
     agent_args:
       args.input.agentArgs && args.input.agentArgs.length > 0
         ? [...args.input.agentArgs]

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -6568,17 +6568,21 @@ async function handleCreateManagedAgent(
     .replace(/-/g, "")
     .padEnd(64, "0")
     .slice(0, 64);
+  const agentCommand = args.input.agentCommand ?? "buzz-agent";
+  const agentArgs =
+    args.input.agentArgs && args.input.agentArgs.length > 0
+      ? [...args.input.agentArgs]
+      : agentCommand === "goose"
+        ? ["acp"]
+        : [];
   const managedAgent: MockManagedAgent = {
     pubkey,
     name,
     persona_id: args.input.personaId ?? null,
     relay_url: args.input.relayUrl ?? DEFAULT_RELAY_WS_URL,
     acp_command: args.input.acpCommand ?? "buzz-acp",
-    agent_command: args.input.agentCommand ?? "buzz-agent",
-    agent_args:
-      args.input.agentArgs && args.input.agentArgs.length > 0
-        ? [...args.input.agentArgs]
-        : ["acp"],
+    agent_command: agentCommand,
+    agent_args: agentArgs,
     mcp_command: args.input.mcpCommand ?? "",
     turn_timeout_seconds: args.input.turnTimeoutSeconds ?? 320,
     idle_timeout_seconds: args.input.idleTimeoutSeconds ?? null,


### PR DESCRIPTION
## Summary

Fizz's built-in persona was hard-pinned to `goose` via `runtime: Some("goose")` in `BUILT_IN_PERSONAS`. The `effective_agent_command` resolution order gives persona runtime precedence over the system default, so every Fizz instance would attempt to spawn `goose` regardless of the bundled `buzz-agent` default introduced in an earlier PR.

Setting `runtime` to `None` lets Fizz inherit `default_agent_command()`, which resolves the bundled `buzz-agent` — no `goose` install required on the user's machine.

`merge_personas` treats built-in `runtime` as canonical and overwrites persisted records on next load, so existing users are corrected automatically without a separate migration.

The E2E mock bridge (`e2eBridge.ts`) also had two stale `goose` references that diverged from the now-fixed backend defaults — both updated to align with the production path.

## Changes

- `personas.rs`: `runtime: Some("goose")` → `None` on the `builtin:fizz` entry in `BUILT_IN_PERSONAS`
- `personas/tests.rs`: Add `fizz_builtin_has_no_pinned_runtime` and `fizz_builtin_resolves_to_buzz_agent` tests; update `merge_personas_adds_missing_built_ins` to assert `runtime.is_none()` instead of `Some("goose")`
- `e2eBridge.ts` line 1709: Remove Fizz special-case ternary (`runtime: "goose"`) — all built-in mocks now use `runtime: null`, mirroring the Rust side
- `e2eBridge.ts` line 6577: Persona-less create fallback `agent_command ?? "goose"` → `?? "buzz-agent"` to match the backend default