### PR TITLE
feat(desktop): pulse thread ingress rows while an agent works in the thread

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -364,7 +364,8 @@ export const ChannelPane = React.memo(function ChannelPane({
   // Thread ingress working badges: derive once per typing update, keyed on a
   // stable sorted string so the Set identity (and every memoized row below it)
   // only changes when the set of working threads changes — not on each 1s
-  // typing prune tick or entry-array recreation.
+  // typing prune tick or entry-array recreation. Splitting on "," is safe
+  // because thread head ids are hex64 event ids and can never contain commas.
   const workingThreadHeadIdKey =
     threadScopedBotTypingHeadIdKey(botTypingEntries);
   const workingThreadHeadIds = React.useMemo<ReadonlySet<string>>(

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -45,6 +45,7 @@ import {
   mentionsKnownAgent,
 } from "@/features/channels/ui/ChannelPane.helpers";
 import type { ChannelPaneProps } from "@/features/channels/ui/ChannelPane.types";
+import { threadScopedBotTypingHeadIdKey } from "@/features/channels/ui/useChannelActivityTyping";
 import * as agentSessionSelection from "@/features/channels/ui/agentSessionSelection";
 import { Button } from "@/shared/ui/button";
 import { buildMainTimelineEntries } from "@/features/messages/lib/threadPanel";
@@ -55,6 +56,10 @@ import { KIND_SYSTEM_MESSAGE } from "@/shared/constants/kinds";
 import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
 import { channelChrome } from "@/shared/layout/chromeLayout";
 import { cn } from "@/shared/lib/cn";
+
+/** Stable empty set so no-typing renders keep a constant identity. */
+const EMPTY_WORKING_THREAD_HEAD_IDS: ReadonlySet<string> = new Set();
+
 export const ChannelPane = React.memo(function ChannelPane({
   activeChannel,
   agentPubkeys,
@@ -356,6 +361,19 @@ export const ChannelPane = React.memo(function ChannelPane({
   }, [botTypingEntries, openThreadHeadId]);
   const hasThreadComposerBotActivity =
     threadComposerBotTypingPubkeys.length > 0;
+  // Thread ingress working badges: derive once per typing update, keyed on a
+  // stable sorted string so the Set identity (and every memoized row below it)
+  // only changes when the set of working threads changes — not on each 1s
+  // typing prune tick or entry-array recreation.
+  const workingThreadHeadIdKey =
+    threadScopedBotTypingHeadIdKey(botTypingEntries);
+  const workingThreadHeadIds = React.useMemo<ReadonlySet<string>>(
+    () =>
+      workingThreadHeadIdKey
+        ? new Set(workingThreadHeadIdKey.split(","))
+        : EMPTY_WORKING_THREAD_HEAD_IDS,
+    [workingThreadHeadIdKey],
+  );
   const directMessageIntro = React.useMemo(
     () =>
       buildDirectMessageIntro({
@@ -624,6 +642,7 @@ export const ChannelPane = React.memo(function ChannelPane({
             searchQuery={channelFind.query}
             targetMessageId={targetMessageId}
             threadUnreadCounts={threadUnreadCounts}
+            workingThreadHeadIds={workingThreadHeadIds}
           />
           {isNonMemberView ? (
             <div

--- a/desktop/src/features/channels/ui/useChannelActivityTyping.test.mjs
+++ b/desktop/src/features/channels/ui/useChannelActivityTyping.test.mjs
@@ -8,7 +8,10 @@ import {
   resetAgentWorkingSignal,
 } from "../../agents/agentWorkingSignal.ts";
 import { resetActiveAgentTurnsStore } from "../../agents/activeAgentTurnsStore.ts";
-import { channelScopedBotTypingPubkeyKey } from "./useChannelActivityTyping.ts";
+import {
+  channelScopedBotTypingPubkeyKey,
+  threadScopedBotTypingHeadIdKey,
+} from "./useChannelActivityTyping.ts";
 
 const AGENT =
   "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234";
@@ -37,6 +40,44 @@ describe("channelScopedBotTypingPubkeyKey", () => {
       { pubkey: AGENT, threadHeadId: null },
     ]);
     assert.equal(key, `${AGENT},${AGENT_2}`);
+  });
+});
+
+describe("threadScopedBotTypingHeadIdKey", () => {
+  it("excludes channel-scoped typing entries", () => {
+    const key = threadScopedBotTypingHeadIdKey([
+      { pubkey: AGENT, threadHeadId: null },
+    ]);
+    assert.equal(key, "");
+  });
+
+  it("keeps thread-scoped entries and drops channel-scoped ones", () => {
+    const key = threadScopedBotTypingHeadIdKey([
+      { pubkey: AGENT, threadHeadId: null },
+      { pubkey: AGENT_2, threadHeadId: "thread-1" },
+    ]);
+    assert.equal(key, "thread-1");
+  });
+
+  it("dedupes multiple agents in the same thread and sorts head ids", () => {
+    const key = threadScopedBotTypingHeadIdKey([
+      { pubkey: AGENT, threadHeadId: "thread-2" },
+      { pubkey: AGENT_2, threadHeadId: "thread-1" },
+      { pubkey: AGENT, threadHeadId: "thread-1" },
+    ]);
+    assert.equal(key, "thread-1,thread-2");
+  });
+
+  it("is stable across entry order so memoized row state keeps identity", () => {
+    const first = threadScopedBotTypingHeadIdKey([
+      { pubkey: AGENT, threadHeadId: "thread-1" },
+      { pubkey: AGENT_2, threadHeadId: "thread-2" },
+    ]);
+    const second = threadScopedBotTypingHeadIdKey([
+      { pubkey: AGENT_2, threadHeadId: "thread-2" },
+      { pubkey: AGENT, threadHeadId: "thread-1" },
+    ]);
+    assert.equal(first, second);
   });
 });
 

--- a/desktop/src/features/channels/ui/useChannelActivityTyping.ts
+++ b/desktop/src/features/channels/ui/useChannelActivityTyping.ts
@@ -31,6 +31,25 @@ export function channelScopedBotTypingPubkeyKey(
     .join(",");
 }
 
+/**
+ * Stable key of thread head ids with active bot typing. Deduped and sorted so
+ * the key (and anything memoized on it) only changes identity when the set of
+ * working threads actually changes — not on every typing prune tick. Channel
+ * -scoped entries (`threadHeadId === null`) are excluded; they belong to
+ * channel-level surfaces.
+ */
+export function threadScopedBotTypingHeadIdKey(
+  entries: readonly Pick<TypingIndicatorEntry, "threadHeadId">[],
+): string {
+  const headIds = new Set<string>();
+  for (const entry of entries) {
+    if (entry.threadHeadId !== null) {
+      headIds.add(entry.threadHeadId);
+    }
+  }
+  return [...headIds].sort().join(",");
+}
+
 export function useChannelActivityTyping({
   activeChannel,
   activeChannelId,

--- a/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx
@@ -59,6 +59,7 @@ export function MessageThreadSummaryRow({
   depth = 0,
   depthGuideDepths,
   highlightThreadLineDepths,
+  isAgentWorking = false,
   message,
   onCollapseDepthGuide,
   onCollapseDepthGuideHoverChange,
@@ -72,6 +73,8 @@ export function MessageThreadSummaryRow({
   depth?: number;
   depthGuideDepths?: ReadonlyArray<number>;
   highlightThreadLineDepths?: ReadonlyArray<number>;
+  /** True when an agent is actively working (bot typing) in this thread. */
+  isAgentWorking?: boolean;
   message: TimelineMessage;
   onCollapseDepthGuide?: (message: TimelineMessage) => void;
   onCollapseDepthGuideHoverChange?: (
@@ -95,9 +98,10 @@ export function MessageThreadSummaryRow({
     THREAD_SUMMARY_SURFACE_AVATAR_INSET_REM,
   )})`;
   const replyLabel = summary.replyCount === 1 ? "reply" : "replies";
+  const workingSuffix = isAgentWorking ? ", agent working" : "";
   const summaryAriaLabel = summary.lastReplyAt
-    ? `View thread with ${summary.replyCount} ${replyLabel}, last reply ${formatThreadSummaryLastReplyTime(summary.lastReplyAt)}`
-    : `View thread with ${summary.replyCount} ${replyLabel}`;
+    ? `View thread with ${summary.replyCount} ${replyLabel}, last reply ${formatThreadSummaryLastReplyTime(summary.lastReplyAt)}${workingSuffix}`
+    : `View thread with ${summary.replyCount} ${replyLabel}${workingSuffix}`;
   const guideDepths = depthGuideDepths
     ? [...depthGuideDepths]
     : Array.from({ length: Math.max(0, depth - 1) }, (_, index) => index + 1);
@@ -240,6 +244,13 @@ export function MessageThreadSummaryRow({
             />
           ))}
         </div>
+        {isAgentWorking ? (
+          <span
+            aria-hidden="true"
+            className="relative z-10 h-1.5 w-1.5 shrink-0 rounded-full bg-primary motion-safe:animate-pulse"
+            data-testid="message-thread-summary-working-badge"
+          />
+        ) : null}
         <div className="relative z-10 min-w-0">
           <div>
             <span className="font-medium transition-colors group-hover:text-foreground">

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -97,6 +97,8 @@ type MessageTimelineProps = {
   unreadCount?: number;
   /** Per-thread unread counts keyed by thread root id. */
   threadUnreadCounts?: ReadonlyMap<string, number>;
+  /** Thread root ids with an agent actively working (bot typing). */
+  workingThreadHeadIds?: ReadonlySet<string>;
 };
 
 type ChannelIntroAction = {
@@ -184,6 +186,7 @@ const MessageTimelineBase = React.forwardRef<
     firstUnreadMessageId = null,
     unreadCount = 0,
     threadUnreadCounts,
+    workingThreadHeadIds,
   }: MessageTimelineProps,
   ref,
 ) {
@@ -614,6 +617,7 @@ const MessageTimelineBase = React.forwardRef<
                     searchQuery={searchQuery}
                     threadUnreadCounts={threadUnreadCounts}
                     unfollowThreadById={unfollowThreadById}
+                    workingThreadHeadIds={workingThreadHeadIds}
                   />
                 </div>
               ) : null}

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -81,6 +81,8 @@ type TimelineMessageListProps = {
   searchQuery?: string;
   /** Per-thread unread counts keyed by thread root id. */
   threadUnreadCounts?: ReadonlyMap<string, number>;
+  /** Thread root ids with an agent actively working (bot typing). */
+  workingThreadHeadIds?: ReadonlySet<string>;
 };
 
 export const TimelineMessageList = React.memo(function TimelineMessageList({
@@ -114,6 +116,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
   searchQuery,
   threadUnreadCounts,
   unfollowThreadById,
+  workingThreadHeadIds,
 }: TimelineMessageListProps) {
   const entries = React.useMemo(
     () =>
@@ -224,6 +227,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
               videoReviewContext={videoReviewContextById.get(
                 item.entry.message.id,
               )}
+              workingThreadHeadIds={workingThreadHeadIds}
             />
           );
       }
@@ -252,6 +256,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
       threadUnreadCounts,
       unfollowThreadById,
       videoReviewContextById,
+      workingThreadHeadIds,
     ],
   );
 
@@ -338,6 +343,7 @@ type MessageRowItemProps = Pick<
   | "searchQuery"
   | "threadUnreadCounts"
   | "unfollowThreadById"
+  | "workingThreadHeadIds"
 > & {
   entry: MainTimelineEntry;
   footer: React.ReactNode;
@@ -374,6 +380,7 @@ function MessageRowItem({
   threadUnreadCounts,
   unfollowThreadById,
   videoReviewContext,
+  workingThreadHeadIds,
 }: MessageRowItemProps) {
   const { message, summary } = entry;
   const canManage = canManageMessageForCurrentUser(
@@ -429,6 +436,7 @@ function MessageRowItem({
         />
         <MessageThreadSummaryRow
           depth={message.depth}
+          isAgentWorking={workingThreadHeadIds?.has(message.id) ?? false}
           message={message}
           onOpenThread={onReply}
           showDepthGuides={false}

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -283,6 +283,13 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
           {group.items.map((item) => (
             <div
               className="timeline-row-cv"
+              data-agent-working={
+                item.kind === "message" &&
+                item.entry.summary != null &&
+                workingThreadHeadIds?.has(item.entry.message.id)
+                  ? "true"
+                  : undefined
+              }
               key={getTimelineItemKey(item)}
               style={timelineRowReserveStyle(item)}
             >

--- a/desktop/src/features/messages/useChannelTyping.test.mjs
+++ b/desktop/src/features/messages/useChannelTyping.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getTypingScopeId } from "./useChannelTyping.ts";
+
+const ROOT = "aaaa".repeat(16);
+const PARENT = "bbbb".repeat(16);
+const CHANNEL = "11111111-1111-1111-1111-111111111111";
+
+describe("getTypingScopeId", () => {
+  it("returns null for channel-scoped typing (no e tags)", () => {
+    assert.equal(getTypingScopeId({ tags: [["h", CHANNEL]] }), null);
+  });
+
+  it("uses the reply parent for direct replies to the thread head", () => {
+    // Direct replies tag only the parent (root === parent, so no root tag).
+    assert.equal(
+      getTypingScopeId({
+        tags: [
+          ["h", CHANNEL],
+          ["e", ROOT, "", "reply"],
+        ],
+      }),
+      ROOT,
+    );
+  });
+
+  it("prefers the thread root over the reply parent for nested replies", () => {
+    // Nested replies tag both root and their immediate parent; thread
+    // surfaces (ingress badge, open-thread composer) key on the root.
+    assert.equal(
+      getTypingScopeId({
+        tags: [
+          ["h", CHANNEL],
+          ["e", ROOT, "", "root"],
+          ["e", PARENT, "", "reply"],
+        ],
+      }),
+      ROOT,
+    );
+  });
+});

--- a/desktop/src/features/messages/useChannelTyping.ts
+++ b/desktop/src/features/messages/useChannelTyping.ts
@@ -57,8 +57,15 @@ function isTypingCompletionEvent(event: RelayEvent | null | undefined) {
   );
 }
 
-function getTypingScopeId(event: RelayEvent) {
-  return getThreadReference(event.tags).parentId ?? null;
+/**
+ * Thread scope for a typing/completion event: the thread root, not the
+ * immediate reply parent. Agents replying deep in a thread tag their nested
+ * parent, but every thread surface (ingress badge, open-thread composer)
+ * keys on the thread head id. Exported for tests.
+ */
+export function getTypingScopeId(event: Pick<RelayEvent, "tags">) {
+  const reference = getThreadReference(event.tags);
+  return reference.rootId ?? reference.parentId ?? null;
 }
 
 function getTypingStateKey(pubkey: string, threadHeadId: string | null) {

--- a/desktop/src/shared/styles/globals/utilities.css
+++ b/desktop/src/shared/styles/globals/utilities.css
@@ -22,6 +22,15 @@
     content-visibility: visible;
   }
 
+  /* Rows with an animated working badge must stay painted: under
+     content-visibility: auto the browser may skip/throttle rendering work for
+     off-screen or contained rows, which makes the badge pulse stutter on
+     closed thread ingress rows (the open-thread panel has no containment and
+     animates smoothly). Scoped to the 1-2 rows with active agent work. */
+  .timeline-row-cv[data-agent-working="true"] {
+    content-visibility: visible;
+  }
+
   .content-visibility-auto-interactive {
     content-visibility: auto;
     contain-intrinsic-size: auto 200px;


### PR DESCRIPTION
## Summary

Adds a subtle pulsing badge to thread ingress rows (`MessageThreadSummaryRow`) when an agent is actively working (bot typing) in that thread.

## Approach

- New `threadScopedBotTypingHeadIdKey` helper in `useChannelActivityTyping.ts` — deduped, sorted key of thread head ids with active bot typing (channel-scoped entries excluded).
- `ChannelPane` derives one memoized `ReadonlySet<string>` from that key. Identity only changes when the *set of working threads* changes — not on each 1s typing prune tick.
- Set flows `MessageTimeline` → `TimelineMessageList` → `MessageRowItem`; each `MessageThreadSummaryRow` receives only `isAgentWorking: boolean`. No row ever sees raw typing entries.
- Badge: `h-1.5 w-1.5 rounded-full bg-primary motion-safe:animate-pulse` dot next to participant avatars, with an `aria-label` suffix for screen readers.
- Channel-level working surfaces untouched — thread-only typing stays out of `agentWorkingSignal`.

## Performance

- Stable-key trick means zero row re-renders on prune ticks while the working set is unchanged.
- When the set *does* change, only `TimelineMessageList` re-renders its callback path — `MessageRow` is memoized and its props don't include the set, so heavy markdown rows stay put.
- No per-row timers or animated layout.

## Testing

- 4 new unit tests on the key helper (null exclusion, mixed entries, dedup, order stability).
- All existing tests pass: typecheck ✅, pnpm test 1926/1926 ✅, pnpm check (biome + file sizes + px-text) ✅.

## Files changed

- `desktop/src/features/channels/ui/useChannelActivityTyping.ts`
- `desktop/src/features/channels/ui/useChannelActivityTyping.test.mjs`
- `desktop/src/features/channels/ui/ChannelPane.tsx`
- `desktop/src/features/messages/ui/MessageTimeline.tsx`
- `desktop/src/features/messages/ui/TimelineMessageList.tsx`
- `desktop/src/features/messages/ui/MessageThreadSummaryRow.tsx`