### PR TITLE
feat(agents): group sequential activity tools

### DIFF
--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -469,6 +469,10 @@ function SameKindSummaryItem({
   const variant = useAgentSessionTranscriptVariant();
   const timestampsEnabled = useTranscriptTimestampsEnabled();
   const showTimestamp = timestampsEnabled && variant !== "compactPreview";
+  // Mixed bursts expand to their child segments in original order: raw tool
+  // rows plus nested same-kind summaries that joined the burst (which stay
+  // expandable to their own child rows).
+  const childSegments = summary.segments ?? null;
 
   return (
     <>
@@ -485,30 +489,52 @@ function SameKindSummaryItem({
         <ActivityRowContent
           className={cn(
             "flex flex-col",
-            expandsToToolItems ? "gap-0.5" : "gap-1 pl-5",
+            expandsToToolItems || childSegments ? "gap-0.5" : "gap-1 pl-5",
           )}
         >
-          {expandsToToolItems
-            ? summary.items.map((item) => (
-                <TranscriptItemView
-                  agentAvatarUrl={agentAvatarUrl}
-                  agentName={agentName}
-                  agentPubkey={agentPubkey}
-                  item={item}
-                  key={item.id}
-                  profiles={profiles}
-                />
-              ))
-            : summary.items.map((item) => (
-                <p
-                  className="truncate text-xs text-muted-foreground"
-                  key={item.id}
-                >
-                  {item.type === "tool"
-                    ? item.descriptor.preview || item.descriptor.label
-                    : item.title}
-                </p>
-              ))}
+          {childSegments
+            ? childSegments.map((child) =>
+                child.kind === "summary" ? (
+                  <SameKindSummaryItem
+                    agentAvatarUrl={agentAvatarUrl}
+                    agentName={agentName}
+                    agentPubkey={agentPubkey}
+                    key={child.summary.id}
+                    profiles={profiles}
+                    summary={child.summary}
+                  />
+                ) : (
+                  <TranscriptItemView
+                    agentAvatarUrl={agentAvatarUrl}
+                    agentName={agentName}
+                    agentPubkey={agentPubkey}
+                    item={child.item}
+                    key={child.item.id}
+                    profiles={profiles}
+                  />
+                ),
+              )
+            : expandsToToolItems
+              ? summary.items.map((item) => (
+                  <TranscriptItemView
+                    agentAvatarUrl={agentAvatarUrl}
+                    agentName={agentName}
+                    agentPubkey={agentPubkey}
+                    item={item}
+                    key={item.id}
+                    profiles={profiles}
+                  />
+                ))
+              : summary.items.map((item) => (
+                  <p
+                    className="truncate text-xs text-muted-foreground"
+                    key={item.id}
+                  >
+                    {item.type === "tool"
+                      ? item.descriptor.preview || item.descriptor.label
+                      : item.title}
+                  </p>
+                ))}
         </ActivityRowContent>
       </ActivityRow>
       {showTimestamp ? (

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -386,7 +386,9 @@ function getTurnSegmentKey(turnId: string, segment: TranscriptTurnSegment) {
     return `turn:${turnId}:setup`;
   }
   if (segment.kind === "prompt") {
-    return `turn:${turnId}:prompt`;
+    // A turn can hold multiple prompt segments (initial prompt + mid-turn
+    // steers), so key on the user message id rather than the bare turn id.
+    return `turn:${turnId}:prompt:${segment.user.id}`;
   }
   if (segment.kind === "summary") {
     return segment.summary.id;

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
 } from "@/shared/ui/dialog";
 import { Toggle } from "@/shared/ui/toggle";
+import { AnimatedCount } from "@/shared/ui/AnimatedCount";
 import { FuzzyLogo } from "@/shared/ui/buzz-logo/FuzzyLogo";
 import type { PromptSection, TranscriptItem } from "./agentSessionTypes";
 import { TurnLivenessIndicator } from "./TurnLivenessIndicator";
@@ -34,6 +35,7 @@ import {
   ActivityRowContent,
   ActivityRowLabel,
   type ActivityRowStats,
+  splitActivityRowCountedObject,
   splitActivityRowLabel,
 } from "./activityRenderClasses/ActivityRow";
 import { TranscriptTimestamp } from "./activityRenderClasses/TranscriptTimestamp";
@@ -578,15 +580,33 @@ function ToolRunSummaryLabel({
   label: string;
   stats?: ActivityRowStats | null;
 }) {
+  const animationPreferenceEnabled = useTranscriptAnimationEnabled();
   const parts = splitActivityRowLabel(label);
 
   if (!parts) {
     return <span className="truncate text-sm font-medium">{label}</span>;
   }
 
+  // Streaming bursts grow their count in place ("Ran 16 tool calls" →
+  // "Ran 17 tool calls"); rolling the digits odometer-style makes the
+  // increment legible. AnimatedCount keeps an sr-only static value and
+  // falls back to static text under prefers-reduced-motion.
+  const countedObject =
+    animationPreferenceEnabled && typeof parts.object === "string"
+      ? splitActivityRowCountedObject(parts.object)
+      : null;
+  const object = countedObject ? (
+    <>
+      <AnimatedCount value={countedObject.count} />
+      {countedObject.rest}
+    </>
+  ) : (
+    parts.object
+  );
+
   return (
     <ActivityRowLabel
-      object={parts.object}
+      object={object}
       openToneScope="summary"
       stats={stats}
       verb={parts.verb}

--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -455,10 +455,10 @@ function SameKindSummaryItem({
 }) {
   const groupedFileEditDiffs = React.useMemo(
     () =>
-      summary.renderClass === "file-edit"
+      summary.renderClass === "file-edit" || summary.variant === "mixed"
         ? getGroupedFileEditDiffs(summary.items)
         : [],
-    [summary.items, summary.renderClass],
+    [summary.items, summary.renderClass, summary.variant],
   );
   const groupedFileEditStats = summarizeFileEditDiffs(groupedFileEditDiffs);
   const expandsToToolItems = summary.items.every(

--- a/desktop/src/features/agents/ui/activityRenderClasses/ActivityRow.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/ActivityRow.tsx
@@ -191,3 +191,24 @@ export function splitActivityRowLabel(
   );
   return match ? { verb: match[1], object: match[2] } : null;
 }
+
+export type ActivityRowCountedObject = {
+  count: number;
+  rest: string;
+};
+
+/**
+ * Split a summary label object like "16 tool calls" into its leading count
+ * and the trailing text (" tool calls"), so the number can animate through
+ * AnimatedCount while streaming bursts grow. Returns null when the object
+ * does not lead with a count.
+ */
+export function splitActivityRowCountedObject(
+  object: string,
+): ActivityRowCountedObject | null {
+  const match = object.match(/^(\d+)(\s.+)$/);
+  if (!match) return null;
+  const count = Number(match[1]);
+  if (!Number.isFinite(count)) return null;
+  return { count, rest: match[2] };
+}

--- a/desktop/src/features/agents/ui/activityRenderClasses/activityRowLabelParts.test.mjs
+++ b/desktop/src/features/agents/ui/activityRenderClasses/activityRowLabelParts.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  splitActivityRowCountedObject,
+  splitActivityRowLabel,
+} from "./ActivityRow.tsx";
+
+test("splitActivityRowLabel splits verb-led summary labels", () => {
+  assert.deepEqual(splitActivityRowLabel("Ran 16 tool calls"), {
+    verb: "Ran",
+    object: "16 tool calls",
+  });
+  assert.equal(splitActivityRowLabel("Thinking"), null);
+});
+
+test("splitActivityRowCountedObject splits a leading count", () => {
+  assert.deepEqual(splitActivityRowCountedObject("16 tool calls"), {
+    count: 16,
+    rest: " tool calls",
+  });
+  assert.deepEqual(splitActivityRowCountedObject("3 files"), {
+    count: 3,
+    rest: " files",
+  });
+  assert.deepEqual(splitActivityRowCountedObject("12 Buzz relay ops"), {
+    count: 12,
+    rest: " Buzz relay ops",
+  });
+});
+
+test("splitActivityRowCountedObject leaves non-counted objects alone", () => {
+  assert.equal(splitActivityRowCountedObject("npm install"), null);
+  assert.equal(splitActivityRowCountedObject("2 "), null);
+  assert.equal(splitActivityRowCountedObject("16"), null);
+  assert.equal(splitActivityRowCountedObject("file 16"), null);
+});

--- a/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
@@ -1179,3 +1179,56 @@ test("observer feed renders system-prompt before prompt-context in display order
     "system-prompt item must have turnId=null",
   );
 });
+
+test("steer ingress bundles its prompt context into the steer prompt segment, not a standalone row", () => {
+  // The stray "Prompt context · 1 section" row was leaking from the goose
+  // session/steer path: it upserted metadata without an acpSource, so display
+  // grouping never consumed it into a prompt bundle. It must now ride behind
+  // the steer message bubble's checks-icon dialog like session/prompt context.
+  const events = [
+    {
+      seq: 1,
+      timestamp: "2026-07-01T10:00:00.000Z",
+      kind: "acp_write",
+      agentIndex: 0,
+      channelId: "ch-1",
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      payload: {
+        jsonrpc: "2.0",
+        id: 5,
+        method: "_goose/unstable/session/steer",
+        params: {
+          sessionId: "sess-1",
+          prompt: [
+            {
+              type: "text",
+              text: `[Buzz event: @mention]\nEvent ID: ${"e".repeat(64)}\nFrom: x (hex: ${"f".repeat(64)})\nContent: steer me`,
+            },
+            { type: "text", text: "[Thread context]\nPrior messages here." },
+          ],
+        },
+      },
+    },
+  ];
+
+  const rawItems = buildTranscript(events);
+  const steerMessage = rawItems.find((item) => item.type === "message");
+  const steerContext = rawItems.find((item) => item.type === "metadata");
+  assert.equal(steerMessage?.acpSource, "session/steer:user");
+  assert.equal(steerContext?.acpSource, "session/steer:context");
+
+  const [block] = buildTranscriptDisplayBlocks(rawItems);
+  assert.equal(block.kind, "turn");
+  const promptSegment = block.segments.find(
+    (segment) => segment.kind === "prompt",
+  );
+  assert.ok(promptSegment, "expected steer message to render a prompt bundle");
+  assert.equal(promptSegment.context?.id, steerContext.id);
+  assert.ok(
+    !block.segments.some(
+      (segment) => segment.kind === "item" && segment.item.type === "metadata",
+    ),
+    "steer context must not leak as a standalone metadata row",
+  );
+});

--- a/desktop/src/features/agents/ui/agentSessionTranscript.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.ts
@@ -906,7 +906,7 @@ export function processTranscriptEvent(
             event.timestamp,
             ctx,
             parsedPrompt.userPubkey,
-            undefined,
+            "session/steer:user",
             parsedPrompt.userEventId,
           );
         }
@@ -918,6 +918,7 @@ export function processTranscriptEvent(
             parsedPrompt.sections,
             event.timestamp,
             ctx,
+            "session/steer:context",
           );
         }
       }

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -304,20 +304,32 @@ test("buildTranscriptDisplayBlocks groups mixed consecutive eligible tool runs",
   );
 });
 
-test("buildTranscriptDisplayBlocks keeps short mixed tool runs expanded", () => {
+test("buildTranscriptDisplayBlocks groups tool bursts at threshold 2", () => {
   const [block] = buildTranscriptDisplayBlocks([
     mkTool("read-1", "Read file", "file-read", "read_file"),
     mkTool("shell-1", "Ran command", "shell", "shell:command"),
   ]);
 
   assert.equal(block.kind, "turn");
+  assert.equal(block.segments.length, 1);
+  assert.equal(block.segments[0].kind, "summary");
+  assert.equal(block.segments[0].summary.variant, "mixed");
+  assert.equal(block.segments[0].summary.label, "Ran 2 tool calls");
+});
+
+test("buildTranscriptDisplayBlocks keeps a lone eligible tool row expanded", () => {
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("read-1", "Read file", "file-read", "read_file"),
+  ]);
+
+  assert.equal(block.kind, "turn");
   assert.deepEqual(
     block.segments.map((segment) => segment.kind),
-    ["item", "item"],
+    ["item"],
   );
 });
 
-test("buildTranscriptDisplayBlocks prefers same-kind summaries over mixed grouping", () => {
+test("buildTranscriptDisplayBlocks nests same-kind summaries inside tool bursts", () => {
   const [block] = buildTranscriptDisplayBlocks([
     mkTool("read-1", "Read file", "file-read", "read_file"),
     mkTool("read-2", "Read file", "file-read", "read_file"),
@@ -327,12 +339,49 @@ test("buildTranscriptDisplayBlocks prefers same-kind summaries over mixed groupi
   ]);
 
   assert.equal(block.kind, "turn");
+  assert.equal(block.segments.length, 1);
+  assert.equal(block.segments[0].kind, "summary");
+  assert.equal(block.segments[0].summary.variant, "mixed");
+  assert.equal(block.segments[0].summary.label, "Ran 5 tool calls");
+  // Child segments preserve the same-kind summary as an intact nested node.
   assert.deepEqual(
-    block.segments.map((segment) => segment.kind),
+    block.segments[0].summary.segments.map((child) => child.kind),
     ["summary", "item", "item"],
   );
-  assert.equal(block.segments[0].summary.variant, "same-kind");
-  assert.equal(block.segments[0].summary.label, "Read 3 files");
+  assert.equal(
+    block.segments[0].summary.segments[0].summary.label,
+    "Read 3 files",
+  );
+  // Flat leaf items preserve original order.
+  assert.deepEqual(
+    block.segments[0].summary.items.map((item) => item.id),
+    ["read-1", "read-2", "read-3", "shell-1", "skill-1"],
+  );
+});
+
+test("buildTranscriptDisplayBlocks collapses alternating search/read bursts into one summary", () => {
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("shell-1", "Ran command", "shell", "shell:command"),
+    mkTool("read-1", "Read file", "file-read", "read_file"),
+    mkTool("read-2", "Read file", "file-read", "read_file"),
+    mkTool("read-3", "Read file", "file-read", "read_file"),
+    mkTool("shell-2", "Ran command", "shell", "shell:command"),
+    mkTool("read-4", "Read file", "file-read", "read_file"),
+    mkTool("read-5", "Read file", "file-read", "read_file"),
+    mkTool("read-6", "Read file", "file-read", "read_file"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.equal(block.segments.length, 1);
+  assert.equal(block.segments[0].kind, "summary");
+  assert.equal(block.segments[0].summary.variant, "mixed");
+  assert.equal(block.segments[0].summary.label, "Ran 8 tool calls");
+  assert.deepEqual(
+    block.segments[0].summary.segments.map((child) =>
+      child.kind === "summary" ? child.summary.label : child.item.id,
+    ),
+    ["shell-1", "Read 3 files", "shell-2", "Read 3 files"],
+  );
 });
 
 test("buildTranscriptDisplayBlocks keeps messages out of mixed tool runs", () => {
@@ -347,9 +396,17 @@ test("buildTranscriptDisplayBlocks keeps messages out of mixed tool runs", () =>
   assert.equal(block.kind, "turn");
   assert.deepEqual(
     block.segments.map((segment) => segment.kind),
-    ["item", "item", "item", "item", "item"],
+    ["summary", "item", "summary"],
   );
-  assert.equal(block.segments[2].item.id, "assistant");
+  assert.equal(block.segments[1].item.id, "assistant");
+  assert.deepEqual(
+    block.segments[0].summary.items.map((item) => item.id),
+    ["read-1", "shell-1"],
+  );
+  assert.deepEqual(
+    block.segments[2].summary.items.map((item) => item.id),
+    ["read-2", "shell-2"],
+  );
 });
 
 test("buildTranscriptDisplayBlocks breaks failed tools out of mixed tool runs", () => {
@@ -460,9 +517,17 @@ test("buildTranscriptDisplayBlocks breaks same-kind runs on an ineligible row", 
   assert.equal(block.kind, "turn");
   assert.deepEqual(
     block.segments.map((segment) => segment.kind),
-    ["item", "item", "item", "item", "item"],
+    ["summary", "item", "summary"],
   );
-  assert.equal(block.segments[2].item.id, "fail-1");
+  assert.equal(block.segments[1].item.id, "fail-1");
+  assert.deepEqual(
+    block.segments[0].summary.items.map((item) => item.id),
+    ["read-1", "read-2"],
+  );
+  assert.deepEqual(
+    block.segments[2].summary.items.map((item) => item.id),
+    ["read-3", "read-4"],
+  );
 });
 
 test("buildTranscriptDisplayBlocks bundles steer message with steer context behind the prompt segment", () => {

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -343,14 +343,14 @@ test("buildTranscriptDisplayBlocks nests same-kind summaries inside tool bursts"
   assert.equal(block.segments[0].kind, "summary");
   assert.equal(block.segments[0].summary.variant, "mixed");
   assert.equal(block.segments[0].summary.label, "Ran 5 tool calls");
-  // Child segments preserve the same-kind summary as an intact nested node.
+  // Mixed summaries are the only visible burst summary; nested same-kind
+  // summaries flatten back to leaf rows to avoid redundant rows such as
+  // "Ran 16 tool calls" → "Ran 12 commands".
   assert.deepEqual(
-    block.segments[0].summary.segments.map((child) => child.kind),
-    ["summary", "item", "item"],
-  );
-  assert.equal(
-    block.segments[0].summary.segments[0].summary.label,
-    "Read 3 files",
+    block.segments[0].summary.segments.map((child) =>
+      child.kind === "item" ? child.item.id : child.summary.label,
+    ),
+    ["read-1", "read-2", "read-3", "shell-1", "skill-1"],
   );
   // Flat leaf items preserve original order.
   assert.deepEqual(
@@ -380,7 +380,16 @@ test("buildTranscriptDisplayBlocks collapses alternating search/read bursts into
     block.segments[0].summary.segments.map((child) =>
       child.kind === "summary" ? child.summary.label : child.item.id,
     ),
-    ["shell-1", "Read 3 files", "shell-2", "Read 3 files"],
+    [
+      "shell-1",
+      "read-1",
+      "read-2",
+      "read-3",
+      "shell-2",
+      "read-4",
+      "read-5",
+      "read-6",
+    ],
   );
 });
 

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -396,6 +396,75 @@ test("flattenDisplayBlocks preserves child order through mixed summaries", () =>
   );
 });
 
+test("buildTranscriptDisplayBlocks never same-kind groups failed tools", () => {
+  const mkFailed = (id) => ({
+    ...mkTool(id, "Ran command failed", "error", "shell:command"),
+    isError: true,
+  });
+
+  const [block] = buildTranscriptDisplayBlocks([
+    mkFailed("fail-1"),
+    mkFailed("fail-2"),
+    mkFailed("fail-3"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.deepEqual(
+    block.segments.map((segment) => segment.kind),
+    ["item", "item", "item"],
+  );
+});
+
+test("buildTranscriptDisplayBlocks never same-kind groups status tool rows", () => {
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("status-1", "Context compacted", "status", "status:post-compact"),
+    mkTool("status-2", "Context compacted", "status", "status:post-compact"),
+    mkTool("status-3", "Context compacted", "status", "status:post-compact"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.deepEqual(
+    block.segments.map((segment) => segment.kind),
+    ["item", "item", "item"],
+  );
+});
+
+test("buildTranscriptDisplayBlocks never same-kind groups suppressed tool rows", () => {
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("stop-1", "Checked todos", "suppressed", "suppressed:stop-hook"),
+    mkTool("stop-2", "Checked todos", "suppressed", "suppressed:stop-hook"),
+    mkTool("stop-3", "Checked todos", "suppressed", "suppressed:stop-hook"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.deepEqual(
+    block.segments.map((segment) => segment.kind),
+    ["item", "item", "item"],
+  );
+});
+
+test("buildTranscriptDisplayBlocks breaks same-kind runs on an ineligible row", () => {
+  const failed = {
+    ...mkTool("fail-1", "Read file failed", "error", "read_file"),
+    isError: true,
+  };
+
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("read-1", "Read file", "file-read", "read_file"),
+    mkTool("read-2", "Read file", "file-read", "read_file"),
+    failed,
+    mkTool("read-3", "Read file", "file-read", "read_file"),
+    mkTool("read-4", "Read file", "file-read", "read_file"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.deepEqual(
+    block.segments.map((segment) => segment.kind),
+    ["item", "item", "item", "item", "item"],
+  );
+  assert.equal(block.segments[2].item.id, "fail-1");
+});
+
 function mkTool(id, label, renderClass = "generic", groupKey = label) {
   return {
     id,

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -465,6 +465,79 @@ test("buildTranscriptDisplayBlocks breaks same-kind runs on an ineligible row", 
   assert.equal(block.segments[2].item.id, "fail-1");
 });
 
+test("buildTranscriptDisplayBlocks bundles steer message with steer context behind the prompt segment", () => {
+  const steerMessage = {
+    id: "steer:chan-1:turn-1",
+    type: "message",
+    role: "user",
+    title: "Buzz event",
+    text: "@Bart new steer instruction",
+    timestamp: baseTimestamp,
+    acpSource: "session/steer:user",
+    turnId: "turn-1",
+    sessionId: "sess-1",
+    channelId: "chan-1",
+  };
+  const steerContext = {
+    id: "steer-context:chan-1:turn-1",
+    type: "metadata",
+    title: "Prompt context",
+    sections: [{ title: "Thread history", body: "prior messages" }],
+    timestamp: baseTimestamp,
+    acpSource: "session/steer:context",
+    turnId: "turn-1",
+    sessionId: "sess-1",
+    channelId: "chan-1",
+  };
+
+  const [block] = buildTranscriptDisplayBlocks([
+    assistantMessage("assistant", "Working on it.", "turn-1"),
+    steerMessage,
+    steerContext,
+    toolCall("tool", "turn-1"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.deepEqual(
+    block.segments.map((segment) => segment.kind),
+    ["item", "prompt", "item"],
+  );
+  const steerSegment = block.segments[1];
+  assert.equal(steerSegment.user.id, "steer:chan-1:turn-1");
+  assert.equal(steerSegment.context?.id, "steer-context:chan-1:turn-1");
+  assert.equal(steerSegment.systemPrompt, null);
+  assert.deepEqual(steerSegment.setup, []);
+  // No standalone "Prompt context" metadata row leaks into the feed.
+  assert.ok(
+    !block.segments.some(
+      (segment) => segment.kind === "item" && segment.item.type === "metadata",
+    ),
+  );
+});
+
+test("buildTranscriptDisplayBlocks keeps orphan steer context visible when no steer message exists", () => {
+  const steerContext = {
+    id: "steer-context:chan-1:turn-1",
+    type: "metadata",
+    title: "Prompt context",
+    sections: [{ title: "Thread history", body: "prior messages" }],
+    timestamp: baseTimestamp,
+    acpSource: "session/steer:context",
+    turnId: "turn-1",
+    sessionId: "sess-1",
+    channelId: "chan-1",
+  };
+
+  const [block] = buildTranscriptDisplayBlocks([
+    steerContext,
+    toolCall("tool", "turn-1"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  const flattened = flattenDisplayBlocks([block]).map((item) => item.id);
+  assert.ok(flattened.includes("steer-context:chan-1:turn-1"));
+});
+
 function mkTool(id, label, renderClass = "generic", groupKey = label) {
   return {
     id,

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -285,8 +285,119 @@ test("buildTranscriptDisplayBlocks groups consecutive file edit tool runs", () =
   );
 });
 
-test("buildTranscriptDisplayBlocks keeps non-contiguous same-kind runs expanded", () => {
-  const mkTool = (id, label, renderClass = "generic", groupKey = label) => ({
+test("buildTranscriptDisplayBlocks groups mixed consecutive eligible tool runs", () => {
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("read-1", "Read file", "file-read", "read_file"),
+    mkTool("shell-1", "Ran command", "shell", "shell:command"),
+    mkTool("read-2", "Read file", "file-read", "read_file"),
+    mkTool("read-3", "Read file", "file-read", "read_file"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.equal(block.segments.length, 1);
+  assert.equal(block.segments[0].kind, "summary");
+  assert.equal(block.segments[0].summary.variant, "mixed");
+  assert.equal(block.segments[0].summary.label, "Ran 4 tool calls");
+  assert.deepEqual(
+    block.segments[0].summary.items.map((item) => item.id),
+    ["read-1", "shell-1", "read-2", "read-3"],
+  );
+});
+
+test("buildTranscriptDisplayBlocks keeps short mixed tool runs expanded", () => {
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("read-1", "Read file", "file-read", "read_file"),
+    mkTool("shell-1", "Ran command", "shell", "shell:command"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.deepEqual(
+    block.segments.map((segment) => segment.kind),
+    ["item", "item"],
+  );
+});
+
+test("buildTranscriptDisplayBlocks prefers same-kind summaries over mixed grouping", () => {
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("read-1", "Read file", "file-read", "read_file"),
+    mkTool("read-2", "Read file", "file-read", "read_file"),
+    mkTool("read-3", "Read file", "file-read", "read_file"),
+    mkTool("shell-1", "Ran command", "shell", "shell:command"),
+    mkTool("skill-1", "Read skill", "skill-read", "skill:load"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.deepEqual(
+    block.segments.map((segment) => segment.kind),
+    ["summary", "item", "item"],
+  );
+  assert.equal(block.segments[0].summary.variant, "same-kind");
+  assert.equal(block.segments[0].summary.label, "Read 3 files");
+});
+
+test("buildTranscriptDisplayBlocks keeps messages out of mixed tool runs", () => {
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("read-1", "Read file", "file-read", "read_file"),
+    mkTool("shell-1", "Ran command", "shell", "shell:command"),
+    assistantMessage("assistant", "Here is what I found.", "turn-1"),
+    mkTool("read-2", "Read file", "file-read", "read_file"),
+    mkTool("shell-2", "Ran command", "shell", "shell:command"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.deepEqual(
+    block.segments.map((segment) => segment.kind),
+    ["item", "item", "item", "item", "item"],
+  );
+  assert.equal(block.segments[2].item.id, "assistant");
+});
+
+test("buildTranscriptDisplayBlocks breaks failed tools out of mixed tool runs", () => {
+  const failed = {
+    ...mkTool("shell-fail", "Ran command failed", "error", "shell:command"),
+    isError: true,
+  };
+
+  const [block] = buildTranscriptDisplayBlocks([
+    mkTool("read-1", "Read file", "file-read", "read_file"),
+    mkTool("shell-1", "Ran command", "shell", "shell:command"),
+    mkTool("skill-1", "Read skill", "skill-read", "skill:load"),
+    failed,
+    mkTool("read-2", "Read file", "file-read", "read_file"),
+    mkTool("shell-2", "Ran command", "shell", "shell:command"),
+    mkTool("image-1", "Viewed image", "image", "view_image"),
+  ]);
+
+  assert.equal(block.kind, "turn");
+  assert.deepEqual(
+    block.segments.map((segment) => segment.kind),
+    ["summary", "item", "summary"],
+  );
+  assert.equal(block.segments[0].summary.variant, "mixed");
+  assert.equal(block.segments[0].summary.label, "Ran 3 tool calls");
+  assert.equal(block.segments[1].item.id, "shell-fail");
+  assert.equal(block.segments[2].summary.variant, "mixed");
+  assert.deepEqual(
+    block.segments[2].summary.items.map((item) => item.id),
+    ["read-2", "shell-2", "image-1"],
+  );
+});
+
+test("flattenDisplayBlocks preserves child order through mixed summaries", () => {
+  const blocks = buildTranscriptDisplayBlocks([
+    mkTool("read-1", "Read file", "file-read", "read_file"),
+    mkTool("shell-1", "Ran command", "shell", "shell:command"),
+    mkTool("edit-1", "Edited file", "file-edit", "file-edit:str_replace"),
+  ]);
+
+  assert.deepEqual(
+    flattenDisplayBlocks(blocks).map((item) => item.id),
+    ["read-1", "shell-1", "edit-1"],
+  );
+});
+
+function mkTool(id, label, renderClass = "generic", groupKey = label) {
+  return {
     id,
     type: "tool",
     renderClass,
@@ -310,18 +421,5 @@ test("buildTranscriptDisplayBlocks keeps non-contiguous same-kind runs expanded"
     turnId: "turn-1",
     sessionId: "sess-1",
     channelId: "chan-1",
-  });
-
-  const [block] = buildTranscriptDisplayBlocks([
-    mkTool("read-1", "Read file", "file-read", "read_file"),
-    mkTool("shell-1", "Ran command", "shell", "shell:command"),
-    mkTool("read-2", "Read file", "file-read", "read_file"),
-    mkTool("read-3", "Read file", "file-read", "read_file"),
-  ]);
-
-  assert.equal(block.kind, "turn");
-  assert.deepEqual(
-    block.segments.map((segment) => segment.kind),
-    ["item", "item", "item", "item"],
-  );
-});
+  };
+}

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -42,12 +42,28 @@ function isUserPrompt(
   );
 }
 
+function isSteerPrompt(
+  item: TranscriptItem,
+): item is Extract<TranscriptItem, { type: "message" }> {
+  return (
+    item.type === "message" &&
+    item.role === "user" &&
+    item.acpSource === "session/steer:user"
+  );
+}
+
 function isPromptContext(
   item: TranscriptItem,
 ): item is Extract<TranscriptItem, { type: "metadata" }> {
   return (
     item.type === "metadata" && item.acpSource === "session/prompt:context"
   );
+}
+
+function isSteerContext(
+  item: TranscriptItem,
+): item is Extract<TranscriptItem, { type: "metadata" }> {
+  return item.type === "metadata" && item.acpSource === "session/steer:context";
 }
 
 function isSystemPrompt(
@@ -80,16 +96,41 @@ function classifyTurnItems(
   const userPrompt = items.find(isUserPrompt) ?? null;
   const setupLifecycle = items.filter(isSetupLifecycle);
   const promptContext = items.find(isPromptContext) ?? null;
+  // Steer context rides behind the steer message bubble's checks-icon dialog
+  // (same ingress treatment as session/prompt context) instead of rendering
+  // as a standalone "Prompt context" metadata row.
+  const steerContexts = items.filter(isSteerContext);
   const consumed = new Set<TranscriptItem>();
 
   if (userPrompt) consumed.add(userPrompt);
   for (const item of setupLifecycle) consumed.add(item);
   if (promptContext) consumed.add(promptContext);
+  for (const item of steerContexts) consumed.add(item);
 
   const activity = items.filter((item) => !consumed.has(item));
+  const pendingSteerContexts = [...steerContexts];
+
+  const activitySegments: TranscriptTurnSegment[] = activity.map((item) => {
+    if (isSteerPrompt(item)) {
+      return {
+        kind: "prompt",
+        user: item,
+        systemPrompt: null,
+        context: pendingSteerContexts.shift() ?? null,
+        setup: [],
+      };
+    }
+    return { kind: "item", item };
+  });
+
+  // Steer context without a matched steer message keeps its standalone row so
+  // the metadata is never silently dropped.
+  for (const orphan of pendingSteerContexts) {
+    activitySegments.push({ kind: "item", item: orphan });
+  }
 
   if (!userPrompt) {
-    return groupToolSegments(activity.map((item) => ({ kind: "item", item })));
+    return groupToolSegments(activitySegments);
   }
 
   const segments: TranscriptTurnSegment[] = [
@@ -100,11 +141,8 @@ function classifyTurnItems(
       context: promptContext,
       setup: setupLifecycle,
     },
+    ...activitySegments,
   ];
-
-  for (const item of activity) {
-    segments.push({ kind: "item", item });
-  }
 
   return groupToolSegments(segments);
 }

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -185,7 +185,7 @@ function groupMixedToolRuns(
   const grouped: TranscriptTurnSegment[] = [];
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i];
-    if (segment.kind !== "item" || !isMixedRunEligible(segment.item)) {
+    if (segment.kind !== "item" || !isGroupingEligible(segment.item)) {
       grouped.push(segment);
       continue;
     }
@@ -193,7 +193,7 @@ function groupMixedToolRuns(
     let j = i + 1;
     while (j < segments.length) {
       const next = segments[j];
-      if (next.kind !== "item" || !isMixedRunEligible(next.item)) break;
+      if (next.kind !== "item" || !isGroupingEligible(next.item)) break;
       run.push(next.item);
       j += 1;
     }
@@ -218,7 +218,7 @@ function groupMixedToolRuns(
   return grouped;
 }
 
-const MIXED_RUN_ELIGIBLE_RENDER_CLASSES = new Set<
+const GROUPING_ELIGIBLE_RENDER_CLASSES = new Set<
   NonNullable<TranscriptItem["renderClass"]>
 >([
   "file-read",
@@ -231,22 +231,24 @@ const MIXED_RUN_ELIGIBLE_RENDER_CLASSES = new Set<
   "generic",
 ]);
 
-function isMixedRunEligible(item: TranscriptItem): boolean {
+/**
+ * Shared eligibility for both grouping passes. Failed tools (isError or
+ * reclassified renderClass "error"), messages, permissions, status, and
+ * suppressed rows are never grouped and break runs, so intervention points
+ * stay visible.
+ */
+function isGroupingEligible(item: TranscriptItem): boolean {
   if (item.type !== "tool" || item.isError) return false;
   const renderClass = getRenderClass(item);
   return (
-    renderClass != null && MIXED_RUN_ELIGIBLE_RENDER_CLASSES.has(renderClass)
+    renderClass != null && GROUPING_ELIGIBLE_RENDER_CLASSES.has(renderClass)
   );
 }
 
 function sameKindKey(item: TranscriptItem): string | null {
-  if (item.type !== "tool") return null;
-  const renderClass = getRenderClass(item);
-  if (renderClass === "message") {
-    return null;
-  }
+  if (!isGroupingEligible(item) || item.type !== "tool") return null;
   const descriptor = item.descriptor ?? classifyToolItem(item);
-  return descriptor.groupKey ?? renderClass;
+  return descriptor.groupKey ?? getRenderClass(item);
 }
 
 function sameKindLabel(item: TranscriptItem, count: number): string {

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -17,18 +17,30 @@ export type TranscriptDisplayBlock =
   | { kind: "single"; item: TranscriptItem }
   | { kind: "turn"; turnId: string; segments: TranscriptTurnSegment[] };
 
+export type TranscriptToolRunChildSegment =
+  | { kind: "item"; item: TranscriptItem }
+  | { kind: "summary"; summary: TranscriptToolRunSummary };
+
 export type TranscriptToolRunSummary = {
   id: string;
   label: string;
   count: number;
+  /** Flat leaf tool items in original order (nested summaries expanded). */
   items: TranscriptItem[];
   renderClass: TranscriptItem["renderClass"] | null;
   /**
    * "same-kind" summaries collapse runs sharing one semantic groupKey and get
-   * specific labels ("Read 3 files"). "mixed" summaries are the fallback for
-   * adjacent eligible tool runs of differing kinds ("Ran 5 tool calls").
+   * specific labels ("Read 3 files"). "mixed" summaries collapse broader
+   * bursts of routine tool work ("Ran 9 tool calls") and may contain nested
+   * same-kind summaries as children.
    */
   variant: "same-kind" | "mixed";
+  /**
+   * Child segments in original order for mixed bursts — raw tool rows plus
+   * any same-kind summaries that joined the burst. Absent on same-kind
+   * summaries, whose children are just `items`.
+   */
+  segments?: TranscriptToolRunChildSegment[];
   timestamp: string;
 };
 
@@ -208,14 +220,16 @@ function groupSameKindSegments(
   return grouped;
 }
 
-const MIXED_RUN_MINIMUM_LENGTH = 3;
+const MIXED_RUN_MINIMUM_SEGMENTS = 2;
 
 /**
- * Fallback pass: collapse adjacent eligible tool rows of differing kinds that
- * the same-kind pass left expanded (e.g. read → shell → read) into one
- * "Ran N tool calls" summary. Existing same-kind summaries, messages, errors,
- * permissions, and status rows break runs, so they stay visible and any failed
- * tool (reclassified to renderClass "error") is never buried.
+ * Burst pass: collapse an interleave-tolerant run of routine tool work into
+ * one "Ran N tool calls" summary. Both leftover raw eligible tool rows and
+ * same-kind summaries produced by the first pass participate, so alternating
+ * patterns like search → read-summary → search → read-summary collapse into a
+ * single supervision row whose children are the original segments in order.
+ * Messages, permissions, errors/failed tools, and status/suppressed rows
+ * break bursts, so intervention points stay visible.
  */
 function groupMixedToolRuns(
   segments: TranscriptTurnSegment[],
@@ -223,37 +237,54 @@ function groupMixedToolRuns(
   const grouped: TranscriptTurnSegment[] = [];
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i];
-    if (segment.kind !== "item" || !isGroupingEligible(segment.item)) {
+    if (!isBurstParticipant(segment)) {
       grouped.push(segment);
       continue;
     }
-    const run = [segment.item];
+    const run: TranscriptToolRunChildSegment[] = [segment];
     let j = i + 1;
     while (j < segments.length) {
       const next = segments[j];
-      if (next.kind !== "item" || !isGroupingEligible(next.item)) break;
-      run.push(next.item);
+      if (!isBurstParticipant(next)) break;
+      run.push(next);
       j += 1;
     }
-    if (run.length >= MIXED_RUN_MINIMUM_LENGTH) {
+    if (run.length >= MIXED_RUN_MINIMUM_SEGMENTS) {
+      const items = run.flatMap((child) =>
+        child.kind === "item" ? [child.item] : child.summary.items,
+      );
       grouped.push({
         kind: "summary",
         summary: {
-          id: `summary:mixed:${run[0].id}`,
-          label: `Ran ${run.length} tool calls`,
-          count: run.length,
-          items: run,
+          id: `summary:mixed:${items[0].id}`,
+          label: `Ran ${items.length} tool calls`,
+          count: items.length,
+          items,
           renderClass: null,
           variant: "mixed",
-          timestamp: run[0].timestamp,
+          segments: run,
+          timestamp: items[0].timestamp,
         },
       });
     } else {
-      grouped.push(...run.map((item) => ({ kind: "item" as const, item })));
+      grouped.push(...run);
     }
     i = j - 1;
   }
   return grouped;
+}
+
+/**
+ * Burst participants are raw eligible tool rows and same-kind summaries
+ * (already-collapsed routine tool work). Mixed summaries never re-enter.
+ */
+function isBurstParticipant(
+  segment: TranscriptTurnSegment,
+): segment is TranscriptToolRunChildSegment {
+  if (segment.kind === "item") {
+    return isGroupingEligible(segment.item);
+  }
+  return segment.kind === "summary" && segment.summary.variant === "same-kind";
 }
 
 const GROUPING_ELIGIBLE_RENDER_CLASSES = new Set<

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -253,6 +253,15 @@ function groupMixedToolRuns(
       const items = run.flatMap((child) =>
         child.kind === "item" ? [child.item] : child.summary.items,
       );
+      // Mixed bursts are already the visual summary. Expanding nested
+      // same-kind summaries here creates redundant rows like
+      // "Ran 16 tool calls" → "Ran 12 commands". Keep same-kind summaries as
+      // grouping inputs, but flatten the mixed summary's visible children back
+      // to leaf tool rows.
+      const childSegments = items.map((item) => ({
+        kind: "item" as const,
+        item,
+      }));
       grouped.push({
         kind: "summary",
         summary: {
@@ -262,7 +271,7 @@ function groupMixedToolRuns(
           items,
           renderClass: null,
           variant: "mixed",
-          segments: run,
+          segments: childSegments,
           timestamp: items[0].timestamp,
         },
       });

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -3,7 +3,7 @@ import { classifyToolItem } from "./agentSessionToolClassifier";
 
 export type TranscriptTurnSegment =
   | { kind: "item"; item: TranscriptItem }
-  | { kind: "summary"; summary: TranscriptSameKindSummary }
+  | { kind: "summary"; summary: TranscriptToolRunSummary }
   | { kind: "setup"; items: Extract<TranscriptItem, { type: "lifecycle" }>[] }
   | {
       kind: "prompt";
@@ -17,12 +17,18 @@ export type TranscriptDisplayBlock =
   | { kind: "single"; item: TranscriptItem }
   | { kind: "turn"; turnId: string; segments: TranscriptTurnSegment[] };
 
-export type TranscriptSameKindSummary = {
+export type TranscriptToolRunSummary = {
   id: string;
   label: string;
   count: number;
   items: TranscriptItem[];
   renderClass: TranscriptItem["renderClass"] | null;
+  /**
+   * "same-kind" summaries collapse runs sharing one semantic groupKey and get
+   * specific labels ("Read 3 files"). "mixed" summaries are the fallback for
+   * adjacent eligible tool runs of differing kinds ("Ran 5 tool calls").
+   */
+  variant: "same-kind" | "mixed";
   timestamp: string;
 };
 
@@ -83,9 +89,7 @@ function classifyTurnItems(
   const activity = items.filter((item) => !consumed.has(item));
 
   if (!userPrompt) {
-    return groupSameKindSegments(
-      activity.map((item) => ({ kind: "item", item })),
-    );
+    return groupToolSegments(activity.map((item) => ({ kind: "item", item })));
   }
 
   const segments: TranscriptTurnSegment[] = [
@@ -102,7 +106,23 @@ function classifyTurnItems(
     segments.push({ kind: "item", item });
   }
 
-  return groupSameKindSegments(segments);
+  return groupToolSegments(segments);
+}
+
+/**
+ * Two-pass tool grouping:
+ * 1. Same-kind runs collapse into summaries with specific labels
+ *    ("Read 3 files", "Edited 2 files").
+ * 2. Leftover adjacent eligible tool rows of differing kinds collapse into a
+ *    mixed fallback summary ("Ran 5 tool calls").
+ *
+ * Messages, errors, permissions, and status/lifecycle rows never join either
+ * pass, so intervention points stay visible.
+ */
+function groupToolSegments(
+  segments: TranscriptTurnSegment[],
+): TranscriptTurnSegment[] {
+  return groupMixedToolRuns(groupSameKindSegments(segments));
 }
 
 function groupSameKindSegments(
@@ -137,6 +157,7 @@ function groupSameKindSegments(
           count: run.length,
           items: run,
           renderClass: getRenderClass(run[0]),
+          variant: "same-kind",
           timestamp: run[0].timestamp,
         },
       });
@@ -147,6 +168,75 @@ function groupSameKindSegments(
     }
   }
   return grouped;
+}
+
+const MIXED_RUN_MINIMUM_LENGTH = 3;
+
+/**
+ * Fallback pass: collapse adjacent eligible tool rows of differing kinds that
+ * the same-kind pass left expanded (e.g. read → shell → read) into one
+ * "Ran N tool calls" summary. Existing same-kind summaries, messages, errors,
+ * permissions, and status rows break runs, so they stay visible and any failed
+ * tool (reclassified to renderClass "error") is never buried.
+ */
+function groupMixedToolRuns(
+  segments: TranscriptTurnSegment[],
+): TranscriptTurnSegment[] {
+  const grouped: TranscriptTurnSegment[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (segment.kind !== "item" || !isMixedRunEligible(segment.item)) {
+      grouped.push(segment);
+      continue;
+    }
+    const run = [segment.item];
+    let j = i + 1;
+    while (j < segments.length) {
+      const next = segments[j];
+      if (next.kind !== "item" || !isMixedRunEligible(next.item)) break;
+      run.push(next.item);
+      j += 1;
+    }
+    if (run.length >= MIXED_RUN_MINIMUM_LENGTH) {
+      grouped.push({
+        kind: "summary",
+        summary: {
+          id: `summary:mixed:${run[0].id}`,
+          label: `Ran ${run.length} tool calls`,
+          count: run.length,
+          items: run,
+          renderClass: null,
+          variant: "mixed",
+          timestamp: run[0].timestamp,
+        },
+      });
+    } else {
+      grouped.push(...run.map((item) => ({ kind: "item" as const, item })));
+    }
+    i = j - 1;
+  }
+  return grouped;
+}
+
+const MIXED_RUN_ELIGIBLE_RENDER_CLASSES = new Set<
+  NonNullable<TranscriptItem["renderClass"]>
+>([
+  "file-read",
+  "skill-read",
+  "shell",
+  "relay-op",
+  "file-edit",
+  "image",
+  "plan",
+  "generic",
+]);
+
+function isMixedRunEligible(item: TranscriptItem): boolean {
+  if (item.type !== "tool" || item.isError) return false;
+  const renderClass = getRenderClass(item);
+  return (
+    renderClass != null && MIXED_RUN_ELIGIBLE_RENDER_CLASSES.has(renderClass)
+  );
 }
 
 function sameKindKey(item: TranscriptItem): string | null {

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -366,7 +366,7 @@ export function AgentSessionThreadPanel({
         <ManagedAgentSessionPanel
           agent={agent}
           channelId={sessionChannelId}
-          className="border-0 bg-transparent p-0 shadow-none"
+          className="border-0 bg-transparent px-0 py-2 shadow-none"
           emptyDescription={
             sessionChannelId
               ? `Mention ${agent.name} in the channel to see its work here.`


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Agent activity feeds are quieter because routine consecutive tool work collapses into clearer summary rows with animated count updates as the work grows.
**Problem:** Consecutive tool calls made agent transcripts feel busy, especially when read/search/shell work alternated and defeated same-kind grouping. A first pass at broader grouping also exposed redundant nested summaries like **Ran 16 tool calls** expanding to **Ran 12 commands**.
**Solution:** This PR keeps user prompts, messages, failures, permissions, lifecycle/status, and metadata visible while broadening only eligible routine tool bursts into one mixed summary. Mixed summaries now expand directly to leaf tool rows, and count-led summary labels reuse the existing local `AnimatedCount` flourish instead of vendoring number-flow or adding a dependency.

<details>
<summary>File changes</summary>

**desktop/playwright.config.ts**
Removes obsolete screenshot/test wiring that no longer applies to the updated activity surface.

**desktop/scripts/check-file-sizes.mjs**
Drops a temporary file-size allowance that is no longer needed after the activity-scope cleanup.

**desktop/src-tauri/src/managed_agents/personas.rs**
Keeps persona test fixtures aligned with the current managed-agent activity assumptions.

**desktop/src-tauri/src/managed_agents/personas/tests.rs**
Updates managed-agent persona tests after removing observer/working-signal plumbing.

**desktop/src/app/AppShell.tsx**
Removes old app-level active-agent wiring now handled through the streamlined activity surfaces.

**desktop/src/app/navigation/useAppNavigation.ts**
Keeps navigation behavior aligned with the simplified activity/profile routing.

**desktop/src/features/agents/activeAgentTurnsStore.test.mjs**
Removes tests for the deleted active-agent turn store.

**desktop/src/features/agents/activeAgentTurnsStore.ts**
Simplifies active-turn tracking after removing the old activity signal store.

**desktop/src/features/agents/agentWorkingSignal.test.mjs**
Removes tests for the deleted agent working-signal helper.

**desktop/src/features/agents/agentWorkingSignal.ts**
Removes the old derived working-signal path in favor of the current transcript/session activity model.

**desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx**
Renders turn-grouped transcript segments, mixed tool-run summaries, flattened summary expansion content, and animated count-led summary labels.

**desktop/src/features/agents/ui/ManagedAgentRow.tsx**
Keeps managed-agent row activity display aligned with the updated activity model.

**desktop/src/features/agents/ui/activityRenderClasses/ActivityRow.tsx**
Adds support for splitting count-led summary objects so the numeric prefix can be rendered with `AnimatedCount` while preserving the readable label.

**desktop/src/features/agents/ui/activityRenderClasses/activityRowLabelParts.test.mjs**
Adds coverage for count-led label splitting and non-count label fallbacks.

**desktop/src/features/agents/ui/agentSessionTranscript.test.mjs**
Updates transcript expectations for status/lifecycle handling in the quieter activity feed.

**desktop/src/features/agents/ui/agentSessionTranscript.ts**
Keeps transcript item classification compatible with the new grouping and status guardrails.

**desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs**
Adds coverage for same-kind grouping, mixed consecutive tool bursts, guardrails for failures/status/suppressed rows, steer context placement, flattened mixed-summary expansion, and burst boundaries.

**desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts**
Builds display blocks by turn, routes prompt/context metadata into the right UI affordance, groups eligible same-kind tools, groups broader mixed tool bursts, and prevents nested duplicate summaries.

**desktop/src/features/agents/ui/useManagedAgentActions.ts**
Keeps managed-agent action state compatible with the simplified activity signal flow.

**desktop/src/features/agents/useAgentObserverIngestion.test.mjs**
Removes tests for deleted observer-ingestion plumbing.

**desktop/src/features/agents/useAgentObserverIngestion.ts**
Removes old observer-ingestion state that is no longer needed for activity display.

**desktop/src/features/agents/useOpenAgentActivity.test.mjs**
Removes tests for deleted open-agent activity plumbing.

**desktop/src/features/agents/useOpenAgentActivity.ts**
Removes old open-activity state in favor of current profile/thread-panel activity entry points.

**desktop/src/features/agents/usePreventSleep.ts**
Keeps prevent-sleep behavior aligned with the updated agent activity lifecycle.

**desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx**
Adds breathing room to the activity transcript panel and keeps the thread panel aligned with the new display blocks.

**desktop/src/features/channels/ui/BotActivityBar.tsx**
Simplifies bot activity display now that transcript grouping carries more of the feed-noise reduction.

**desktop/src/features/channels/ui/ChannelPane.tsx**
Updates channel pane activity wiring to match the simplified agent activity model.

**desktop/src/features/channels/ui/ChannelScreen.tsx**
Keeps channel screen state aligned with the updated activity surfaces.

**desktop/src/features/channels/ui/useChannelActivityTyping.test.mjs**
Removes tests for deleted channel activity typing helper.

**desktop/src/features/channels/ui/useChannelActivityTyping.ts**
Removes old typing/activity helper that is no longer part of the current activity path.

**desktop/src/features/profile/ui/UserProfilePanel.tsx**
Keeps profile-panel activity entry points aligned with the updated agent session transcript panel.

**desktop/src/features/profile/ui/UserProfilePanelSections.tsx**
Updates profile section wiring for the simplified agent activity model.

**desktop/src/features/profile/ui/UserProfilePopover.tsx**
Keeps profile popover activity affordances aligned with the current activity flow.

**desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts**
Simplifies active working-channel derivation after removing old agent working signals.

**desktop/src/features/workspaces/useWorkspaceInit.ts**
Removes initialization wiring for deleted activity/working-signal state.

**desktop/src/testing/e2eBridge.ts**
Updates the test bridge to support the current activity transcript scenarios.

**desktop/tests/e2e/activity-scope-label-screenshots.spec.ts**
Removes stale screenshot coverage for the previous activity-scope label behavior.

</details>

### Reproduction Steps

1. Open an agent activity transcript with a turn containing consecutive routine tool calls.
2. Confirm same-kind runs still collapse into specific summaries such as **Read 3 files** or **Ran 12 commands** when they stand alone.
3. Confirm mixed/interleaved routine bursts collapse into one summary such as **Ran 16 tool calls**.
4. Expand that mixed summary and confirm it shows the underlying leaf tool rows directly, not a nested duplicate summary like **Ran 12 commands**.
5. Let a live grouped tool burst grow and confirm the numeric count rolls with the existing odometer-style animation while reduced-motion users get static text.
6. Confirm prompts, assistant/user messages, errors, permissions, status/lifecycle rows, and metadata boundaries remain visible instead of being swallowed by grouping.

### Screenshots/Demos

Marge captured the latest build at `2e2a99b5` with a more realistic research/edit/verify turn. The screenshots show the intended two-tier drill-down: collapsed group, opened group with individual tool rows still closed, then one leaf row opened for detail.

| State | Preview | What to look for |
| --- | --- | --- |
| Collapsed | <img width="380" height="851" alt="image" src="https://github.com/user-attachments/assets/fe6b6b48-7fad-4702-b9aa-7e4d528a3e86" /> | The whole research/edit/verify loop reads as one grouped summary row. |
| Group open, leaves closed | <img width="380" height="851" alt="image" src="https://github.com/user-attachments/assets/99304675-4016-4454-928d-4df514aa38e5" /> | Opening the group reveals the tool-call sequence as collapsed leaf rows, without opening every result at once. |
| One leaf open | <img width="380" height="851" alt="image" src="https://github.com/user-attachments/assets/f2bf7783-5e92-4077-9f18-07d25f0e87b6" /> | Each leaf can be expanded independently to inspect params and result details. |

**Regression proof** — the earlier screenshot pair confirmed the nested-summary bug is gone: before the fix a mixed group expanded into a redundant nested **Ran 12 commands** row; after the fix it expanded directly to leaf tool rows.

| Before | After |
| --- | --- |
| <img width="380" height="851" alt="image" src="https://github.com/user-attachments/assets/da162802-6cec-436a-afda-c0e8abde2503" /> | <img width="380" height="851" alt="image" src="https://github.com/user-attachments/assets/9a8de876-8915-401d-b387-908551198506" /> |

### Validation

- Marge reproduced the nested-summary bug at parent `85b244b7` and verified the fix at `9601b73a` with before/after screenshots.
- `biome check .` clean.
- `tsc --noEmit` clean.
- Full desktop unit suite passed at 1902/1902 after the AnimatedCount update.
- Push hooks passed on `2e2a99b5`.

Coordination: buzz://message?channel=2393ad5d-dbb4-4ea3-9b3b-36f432443238&thread=fc0758f5bcf34658ad3ed6bb13eb6fbbb7f65e3b48128381a774c57429b95ec0


