### PR TITLE
feat(desktop): emoji avatar picker for agents + reliable picker scroll

### DIFF
--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -25,7 +25,7 @@ const rules = [
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",
-  "src/features/agents/ui/AgentCreationPreview.tsx:685",
+  "src/features/agents/ui/AgentCreationPreview.tsx:688",
 ]);
 
 await runPxTextCheck({

--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -25,7 +25,7 @@ const rules = [
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",
-  "src/features/agents/ui/AgentCreationPreview.tsx:688",
+  "src/features/agents/ui/AgentCreationPreview.tsx:698",
 ]);
 
 await runPxTextCheck({

--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -25,7 +25,7 @@ const rules = [
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",
-  "src/features/agents/ui/AgentCreationPreview.tsx:691",
+  "src/features/agents/ui/AgentCreationPreview.tsx:681",
 ]);
 
 await runPxTextCheck({

--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -25,6 +25,7 @@ const rules = [
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",
+  "src/features/agents/ui/AgentCreationPreview.tsx:691",
 ]);
 
 await runPxTextCheck({

--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -25,7 +25,7 @@ const rules = [
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",
-  "src/features/agents/ui/AgentCreationPreview.tsx:681",
+  "src/features/agents/ui/AgentCreationPreview.tsx:685",
 ]);
 
 await runPxTextCheck({

--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -25,7 +25,7 @@ const rules = [
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",
-  "src/features/agents/ui/AgentCreationPreview.tsx:698",
+  "src/features/agents/ui/AgentCreationPreview.tsx:703",
 ]);
 
 await runPxTextCheck({

--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -25,7 +25,7 @@ const rules = [
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",
-  "src/features/agents/ui/AgentCreationPreview.tsx:703",
+  "src/features/agents/ui/AgentCreationPreview.tsx:702",
 ]);
 
 await runPxTextCheck({

--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -25,7 +25,7 @@ const rules = [
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",
-  "src/features/agents/ui/AgentCreationPreview.tsx:702",
+  "src/features/agents/ui/AgentCreationPreview.tsx:711",
 ]);
 
 await runPxTextCheck({

--- a/desktop/src/features/agents/channelAgents.ts
+++ b/desktop/src/features/agents/channelAgents.ts
@@ -6,6 +6,7 @@ import {
 } from "@/features/agents/agentReuse";
 export { findReusableAgent } from "@/features/agents/agentReuse";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { resolveManagedAgentAvatarUrl } from "@/features/agents/ui/managedAgentAvatar";
 import {
   addChannelMembers,
   createManagedAgent,
@@ -13,7 +14,6 @@ import {
   listManagedAgents,
   startManagedAgent,
   updateManagedAgent,
-  uploadMediaBytes,
 } from "@/shared/api/tauri";
 import type {
   AcpRuntime,
@@ -341,21 +341,12 @@ export async function createChannelManagedAgent(
     }
   }
 
-  // If the avatar is a data URI (e.g. from a persona PNG card import),
-  // upload it to get a hosted URL the relay can serve.
-  let resolvedAvatarUrl = input.avatarUrl?.trim() || undefined;
-  if (resolvedAvatarUrl?.startsWith("data:image/")) {
-    try {
-      const [, b64] = resolvedAvatarUrl.split(",", 2);
-      if (!b64) throw new Error("empty data URI payload");
-      const bytes = Array.from(atob(b64), (c) => c.charCodeAt(0));
-      const blob = await uploadMediaBytes(bytes);
-      resolvedAvatarUrl = blob.url;
-    } catch (err) {
-      console.warn("Avatar upload failed, proceeding without avatar:", err);
-      resolvedAvatarUrl = undefined;
-    }
-  }
+  // Resolve the avatar for the channel-managed agent. Base64 data URIs (e.g.
+  // from a persona PNG card import) are uploaded to a hosted URL the relay can
+  // serve; percent-encoded emoji SVG data URLs pass through unchanged so the
+  // selected emoji survives deployment. Shared with agent creation so both
+  // paths handle emoji avatars identically.
+  const resolvedAvatarUrl = await resolveManagedAgentAvatarUrl(input.avatarUrl);
 
   const isProviderMode = input.backend?.type === "provider";
 

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -446,7 +446,6 @@ export function AgentCreationPreview({
                 autoCorrect="off"
                 className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
                 disabled={disabled || isUploading}
-                onBlur={() => applyAvatarUrl()}
                 onChange={(event) => setAvatarUrlDraft(event.target.value)}
                 onKeyDown={(event) => {
                   if (event.key === "Enter") {

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -1,14 +1,38 @@
+import emojiData from "@emoji-mart/data";
+import Picker from "@emoji-mart/react";
 import * as React from "react";
 import { Pencil, Plus } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import {
+  AVATAR_COLORS,
+  AVATAR_COLOR_SWATCHES,
+  CUSTOM_AVATAR_COLOR_SWATCH,
+  DEFAULT_CUSTOM_HUE,
+  DEFAULT_CUSTOM_SATURATION,
+  DEFAULT_CUSTOM_VALUE,
+  DEFAULT_EMOJI_AVATAR_COLOR,
+  EMOJI_MART_CATEGORIES,
+  type AvatarColorSwatch,
+  emojiAvatarDataUrl,
+  hexToHsv,
+  hsvToHex,
+  normalizeHue,
+  parseEmojiAvatarDataUrl,
+  contrastColorForBackground,
+  useEmojiMartStyles,
+  useEmojiMartThemeVars,
+} from "@/features/profile/ui/ProfileAvatarEditor.utils";
+import { AvatarCustomColorPanel } from "@/features/profile/ui/AvatarCustomColorPanel";
 import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
+import { useEmojiBurst } from "@/shared/ui/EmojiBurstProvider";
 import { Input } from "@/shared/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
+import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 
 function isAvatarFileDrag(event: React.DragEvent<HTMLElement>) {
   return Array.from(event.dataTransfer.types).includes("Files");
@@ -18,6 +42,12 @@ const AVATAR_APPLY_MOTION_TRANSITION = {
   duration: 0.14,
   ease: [0.23, 1, 0.32, 1],
 } as const;
+
+type AvatarTab = "upload" | "emoji";
+
+type EmojiMartEmoji = {
+  native?: string;
+};
 
 export function AgentCreationPreview({
   avatarUrl,
@@ -40,8 +70,23 @@ export function AgentCreationPreview({
   const [avatarUrlDraft, setAvatarUrlDraft] = React.useState("");
   const [isAvatarUrlInputFocused, setIsAvatarUrlInputFocused] =
     React.useState(false);
+  const [activeTab, setActiveTab] = React.useState<AvatarTab>("upload");
+  const [selectedEmoji, setSelectedEmoji] = React.useState<string | null>(null);
+  const [selectedColor, setSelectedColor] = React.useState(
+    DEFAULT_EMOJI_AVATAR_COLOR,
+  );
+  const [customHue, setCustomHue] = React.useState(DEFAULT_CUSTOM_HUE);
+  const [customSaturation, setCustomSaturation] = React.useState(
+    DEFAULT_CUSTOM_SATURATION,
+  );
+  const [customValue, setCustomValue] = React.useState(DEFAULT_CUSTOM_VALUE);
+  const [isCustomColorPickerOpen, setIsCustomColorPickerOpen] =
+    React.useState(false);
   const avatarDragDepthRef = React.useRef(0);
   const shouldReduceMotion = useReducedMotion();
+  const emojiPickerContainerRef = React.useRef<HTMLDivElement | null>(null);
+  const emojiMartThemeVars = useEmojiMartThemeVars();
+  const { burstEmoji } = useEmojiBurst();
   const {
     inputRef: avatarUploadInputRef,
     isUploading,
@@ -54,6 +99,13 @@ export function AgentCreationPreview({
     onUploadSuccess: onSelectAvatar,
   });
 
+  useEmojiMartStyles(emojiPickerContainerRef, activeTab === "emoji");
+
+  const customColorDraft = React.useMemo(
+    () => hsvToHex(customHue, customSaturation, customValue),
+    [customHue, customSaturation, customValue],
+  );
+
   React.useEffect(() => {
     onUploadPendingChange?.(isUploading);
     return () => {
@@ -61,12 +113,40 @@ export function AgentCreationPreview({
     };
   }, [isUploading, onUploadPendingChange]);
 
+  // Sync emoji state from avatarUrl when the popover opens
   React.useEffect(() => {
     if (isAvatarMenuOpen) {
       setAvatarUrlDraft("");
       setIsAvatarUrlInputFocused(false);
+
+      const parsed = parseEmojiAvatarDataUrl(avatarUrl ?? "");
+      if (parsed) {
+        setSelectedEmoji(parsed.emoji);
+        setSelectedColor(parsed.color);
+        setActiveTab("emoji");
+      } else {
+        setActiveTab("upload");
+      }
     }
-  }, [isAvatarMenuOpen]);
+  }, [isAvatarMenuOpen, avatarUrl]);
+
+  // Keep the custom color picker in sync when the selected color changes
+  React.useEffect(() => {
+    if (!isCustomColorPickerOpen || !selectedEmoji) {
+      return;
+    }
+    const nextAvatarUrl = emojiAvatarDataUrl(selectedEmoji, customColorDraft);
+    if (avatarUrl === nextAvatarUrl) {
+      return;
+    }
+    onSelectAvatar(nextAvatarUrl);
+  }, [
+    avatarUrl,
+    customColorDraft,
+    isCustomColorPickerOpen,
+    onSelectAvatar,
+    selectedEmoji,
+  ]);
 
   function applyAvatarUrl() {
     const nextUrl = avatarUrlDraft.trim();
@@ -76,6 +156,43 @@ export function AgentCreationPreview({
     clearUploadError();
     onSelectAvatar(nextUrl);
     setIsAvatarMenuOpen(false);
+  }
+
+  function applyEmojiAvatar(emoji: string, color = selectedColor) {
+    onSelectAvatar(emojiAvatarDataUrl(emoji, color));
+  }
+
+  function handleColorSelect(swatch: AvatarColorSwatch) {
+    if (disabled) {
+      return;
+    }
+    if (swatch === CUSTOM_AVATAR_COLOR_SWATCH) {
+      if (!selectedEmoji) {
+        return;
+      }
+      openCustomColorPicker();
+      return;
+    }
+    setSelectedColor(swatch);
+    if (selectedEmoji) {
+      applyEmojiAvatar(selectedEmoji, swatch);
+    }
+  }
+
+  function openCustomColorPicker() {
+    const nextColor = hexToHsv(selectedColor);
+    setCustomHue(normalizeHue(nextColor.hue));
+    setCustomSaturation(nextColor.saturation);
+    setCustomValue(nextColor.value);
+    setIsCustomColorPickerOpen(true);
+  }
+
+  function commitCustomColor() {
+    setSelectedColor(customColorDraft);
+    if (selectedEmoji) {
+      applyEmojiAvatar(selectedEmoji, customColorDraft);
+    }
+    setIsCustomColorPickerOpen(false);
   }
 
   const avatarClipStyle = React.useMemo<React.CSSProperties>(
@@ -154,85 +271,261 @@ export function AgentCreationPreview({
     [clearUploadError, disabled, isUploading, uploadAvatarFile],
   );
 
+  const shouldShowColorControls =
+    activeTab === "emoji" && selectedEmoji !== null;
+  const isCustomColorPickerVisible =
+    isCustomColorPickerOpen && shouldShowColorControls;
+
   const avatarMenuContent = (
-    <PopoverContent align="center" className="w-72 space-y-1 p-1">
-      <button
-        className="flex min-h-9 w-full items-center rounded-lg px-2.5 text-left text-sm outline-hidden transition-colors duration-150 ease-out hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
-        disabled={disabled || isUploading}
-        onClick={() => {
-          clearUploadError();
-          openUploadPicker();
-          setIsAvatarMenuOpen(false);
+    <PopoverContent
+      align="center"
+      className="w-[340px] p-3"
+      side="bottom"
+      sideOffset={8}
+    >
+      <Tabs
+        className="w-full"
+        onValueChange={(tab) => {
+          setActiveTab(tab as AvatarTab);
+          setIsCustomColorPickerOpen(false);
         }}
-        type="button"
+        value={activeTab}
       >
-        Upload an image
-      </button>
-      <form
-        className="flex min-h-9 items-center gap-2 rounded-lg px-2.5 py-1.5 transition-colors duration-150 ease-out focus-within:bg-muted/50"
-        onSubmit={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          applyAvatarUrl();
-        }}
-      >
-        <label className="sr-only" htmlFor="agent-avatar-url">
-          Use a URL
-        </label>
-        <Input
-          autoCapitalize="none"
-          autoComplete="off"
-          autoCorrect="off"
-          className={cn(
-            "h-7 min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-sm shadow-none outline-none focus-visible:ring-0",
-            isAvatarUrlInputFocused
-              ? "placeholder:text-muted-foreground/55"
-              : "placeholder:text-popover-foreground",
-          )}
-          disabled={disabled || isUploading}
-          id="agent-avatar-url"
-          onBlur={() => setIsAvatarUrlInputFocused(false)}
-          onChange={(event) => setAvatarUrlDraft(event.target.value)}
-          onFocus={() => setIsAvatarUrlInputFocused(true)}
-          placeholder={isAvatarUrlInputFocused ? "https://..." : "Use a URL"}
-          spellCheck={false}
-          value={avatarUrlDraft}
-        />
-        <AnimatePresence initial={false}>
-          {hasAvatarUrlDraft ? (
-            <motion.div
-              animate={{ opacity: 1, scale: 1, width: "auto" }}
-              className="overflow-hidden"
-              exit={{ opacity: 0, scale: 0.96, width: 0 }}
-              initial={{ opacity: 0, scale: 0.96, width: 0 }}
-              key="apply-avatar-url"
-              transition={applyButtonTransition}
+        <TabsList className="mb-3 grid h-9 w-full grid-cols-2 rounded-lg bg-muted p-0.5">
+          <TabsTrigger
+            className="h-full rounded-md text-xs font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
+            value="upload"
+          >
+            Image
+          </TabsTrigger>
+          <TabsTrigger
+            className="h-full rounded-md text-xs font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
+            value="emoji"
+          >
+            Emoji
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {activeTab === "upload" ? (
+        <div className="space-y-1">
+          <button
+            className="flex min-h-9 w-full items-center rounded-lg px-2.5 text-left text-sm outline-hidden transition-colors duration-150 ease-out hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+            disabled={disabled || isUploading}
+            onClick={() => {
+              clearUploadError();
+              openUploadPicker();
+              setIsAvatarMenuOpen(false);
+            }}
+            type="button"
+          >
+            Upload an image
+          </button>
+          <form
+            className="flex min-h-9 items-center gap-2 rounded-lg px-2.5 py-1.5 transition-colors duration-150 ease-out focus-within:bg-muted/50"
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              applyAvatarUrl();
+            }}
+          >
+            <label className="sr-only" htmlFor="agent-avatar-url">
+              Use a URL
+            </label>
+            <Input
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              className={cn(
+                "h-7 min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-sm shadow-none outline-none focus-visible:ring-0",
+                isAvatarUrlInputFocused
+                  ? "placeholder:text-muted-foreground/55"
+                  : "placeholder:text-popover-foreground",
+              )}
+              disabled={disabled || isUploading}
+              id="agent-avatar-url"
+              onBlur={() => setIsAvatarUrlInputFocused(false)}
+              onChange={(event) => setAvatarUrlDraft(event.target.value)}
+              onFocus={() => setIsAvatarUrlInputFocused(true)}
+              placeholder={
+                isAvatarUrlInputFocused ? "https://..." : "Use a URL"
+              }
+              spellCheck={false}
+              value={avatarUrlDraft}
+            />
+            <AnimatePresence initial={false}>
+              {hasAvatarUrlDraft ? (
+                <motion.div
+                  animate={{ opacity: 1, scale: 1, width: "auto" }}
+                  className="overflow-hidden"
+                  exit={{ opacity: 0, scale: 0.96, width: 0 }}
+                  initial={{ opacity: 0, scale: 0.96, width: 0 }}
+                  key="apply-avatar-url"
+                  transition={applyButtonTransition}
+                >
+                  <Button
+                    className="h-7 px-2 text-xs"
+                    disabled={disabled || isUploading}
+                    size="xs"
+                    type="submit"
+                  >
+                    Apply
+                  </Button>
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
+          </form>
+          {hasAvatar && onClearAvatar ? (
+            <button
+              className="flex min-h-9 w-full items-center rounded-lg px-2.5 text-left text-sm text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+              disabled={disabled || isUploading}
+              onClick={() => {
+                onClearAvatar();
+                setIsAvatarMenuOpen(false);
+              }}
+              type="button"
             >
-              <Button
-                className="h-7 px-2 text-xs"
-                disabled={disabled || isUploading}
-                size="xs"
-                type="submit"
-              >
-                Apply
-              </Button>
-            </motion.div>
+              Remove avatar
+            </button>
           ) : null}
-        </AnimatePresence>
-      </form>
-      {hasAvatar && onClearAvatar ? (
-        <button
-          className="flex min-h-9 w-full items-center rounded-lg px-2.5 text-left text-sm text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
-          disabled={disabled || isUploading}
-          onClick={() => {
-            onClearAvatar();
-            setIsAvatarMenuOpen(false);
-          }}
-          type="button"
-        >
-          Remove avatar
-        </button>
-      ) : null}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div
+            className="buzz-emoji-mart relative z-0 h-[280px] overflow-hidden rounded-lg bg-muted"
+            ref={emojiPickerContainerRef}
+            style={emojiMartThemeVars}
+          >
+            <Picker
+              categories={EMOJI_MART_CATEGORIES}
+              data={emojiData}
+              dynamicWidth
+              emojiButtonRadius="999px"
+              emojiButtonSize={44}
+              emojiSize={32}
+              icons="outline"
+              navPosition="bottom"
+              onEmojiSelect={(emoji: EmojiMartEmoji, event?: MouseEvent) => {
+                if (disabled) {
+                  return;
+                }
+                if (!emoji.native) {
+                  return;
+                }
+                const nextColor =
+                  selectedEmoji === null
+                    ? (AVATAR_COLORS[
+                        Math.floor(Math.random() * AVATAR_COLORS.length)
+                      ] ?? DEFAULT_EMOJI_AVATAR_COLOR)
+                    : selectedColor;
+                burstEmoji(emoji.native, event);
+                setSelectedEmoji(emoji.native);
+                setSelectedColor(nextColor);
+                applyEmojiAvatar(emoji.native, nextColor);
+              }}
+              previewPosition="none"
+              searchPosition="none"
+              set="native"
+              skinTonePosition="none"
+              theme="auto"
+            />
+          </div>
+
+          <div
+            aria-hidden={!shouldShowColorControls}
+            className={cn(
+              "origin-top overflow-hidden transition-[max-height,margin,opacity,transform] duration-200 ease-out",
+              shouldShowColorControls
+                ? "max-h-64 scale-100 opacity-100"
+                : "max-h-0 scale-[0.96] opacity-0",
+            )}
+            inert={shouldShowColorControls ? undefined : true}
+          >
+            <div className="grid grid-cols-8 justify-items-center gap-2 rounded-lg bg-muted p-3">
+              {AVATAR_COLOR_SWATCHES.map((swatch) => {
+                const isCustomSwatch = swatch === CUSTOM_AVATAR_COLOR_SWATCH;
+                const isSelected = isCustomSwatch
+                  ? !AVATAR_COLORS.some(
+                      (color) =>
+                        color.toUpperCase() === selectedColor.toUpperCase(),
+                    )
+                  : swatch.toUpperCase() === selectedColor.toUpperCase();
+
+                return (
+                  <button
+                    aria-label={
+                      isCustomSwatch
+                        ? selectedEmoji
+                          ? "Choose custom color"
+                          : "Choose an emoji first"
+                        : `Use ${swatch} background`
+                    }
+                    aria-pressed={isSelected}
+                    className={cn(
+                      "relative h-7 w-7 rounded-full border border-border transition-transform duration-150 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      isCustomSwatch &&
+                        !selectedEmoji &&
+                        "cursor-not-allowed opacity-45 hover:scale-100 focus-visible:scale-100",
+                    )}
+                    disabled={isCustomSwatch && !selectedEmoji}
+                    key={swatch}
+                    onClick={() => handleColorSelect(swatch)}
+                    style={{
+                      background: isCustomSwatch
+                        ? isSelected
+                          ? selectedColor
+                          : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
+                        : swatch,
+                    }}
+                    type="button"
+                  >
+                    {isSelected ? (
+                      <span
+                        className="absolute inset-0.5 rounded-full border-2"
+                        style={{
+                          borderColor: contrastColorForBackground(
+                            isCustomSwatch ? selectedColor : swatch,
+                          ),
+                        }}
+                      />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <AvatarCustomColorPanel
+            colorDraft={customColorDraft}
+            hue={customHue}
+            onCommit={commitCustomColor}
+            onHueChange={setCustomHue}
+            onSaturationValueChange={(nextSaturation, nextValue) => {
+              setCustomSaturation(nextSaturation);
+              setCustomValue(nextValue);
+            }}
+            saturation={customSaturation}
+            testIdPrefix="agent-avatar"
+            value={customValue}
+            visible={isCustomColorPickerVisible}
+          />
+
+          {hasAvatar && onClearAvatar ? (
+            <button
+              className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+              disabled={disabled}
+              onClick={() => {
+                onClearAvatar();
+                setSelectedEmoji(null);
+                setIsAvatarMenuOpen(false);
+              }}
+              type="button"
+            >
+              Remove avatar
+            </button>
+          ) : null}
+        </div>
+      )}
     </PopoverContent>
   );
 

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Link2, Pencil, Plus, UploadCloud } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
+import { MaskedAvatarBadgeFrame } from "@/features/profile/ui/MaskedAvatarBadgeFrame";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import {
   AVATAR_COLORS,
@@ -63,7 +64,6 @@ export function AgentCreationPreview({
   onUploadPendingChange?: (isPending: boolean) => void;
   onSelectAvatar: (avatarUrl: string) => void;
 }) {
-  const avatarEditClipId = React.useId().replace(/:/g, "");
   const [isDragOverAvatar, setIsDragOverAvatar] = React.useState(false);
   const [isAvatarMenuOpen, setIsAvatarMenuOpen] = React.useState(false);
   const [avatarUrlDraft, setAvatarUrlDraft] = React.useState("");
@@ -200,13 +200,6 @@ export function AgentCreationPreview({
     setIsCustomColorPickerOpen(false);
   }
 
-  const avatarClipStyle = React.useMemo<React.CSSProperties>(
-    () => ({
-      clipPath: `url(#${avatarEditClipId})`,
-      transform: "translateZ(0)",
-    }),
-    [avatarEditClipId],
-  );
   const hasAvatar = (avatarUrl?.trim().length ?? 0) > 0;
   const emojiAvatarPreview = React.useMemo(
     () => parseEmojiAvatarDataUrl(avatarUrl ?? ""),
@@ -646,61 +639,8 @@ export function AgentCreationPreview({
 
         <div className="relative h-36 w-36">
           {hasAvatar ? (
-            <>
-              <svg
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-0 h-full w-full"
-                fill="none"
-                height="144"
-                viewBox="0 0 144 144"
-                width="144"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <clipPath clipPathUnits="userSpaceOnUse" id={avatarEditClipId}>
-                  <path
-                    clipRule="evenodd"
-                    d="M100.734 83.3298C102.415 84.1574 104.616 83.8757 105.495 82.2207C109.647 74.3981 112 65.4738 112 56C112 25.0721 86.9279 0 56 0C25.0721 0 0 25.0721 0 56C0 86.9279 25.0721 112 56 112C65.4738 112 74.3981 109.647 82.2207 105.495C83.8757 104.616 84.1574 102.415 83.3298 100.734C82.4783 99.0047 82 97.0582 82 95C82 87.8203 87.8203 82 95 82C97.0582 82 99.0047 82.4783 100.734 83.3298Z"
-                    fillRule="evenodd"
-                    transform="translate(-25.875 -25.875) scale(1.575)"
-                  />
-                </clipPath>
-              </svg>
-
-              <div className="relative h-full w-full" style={avatarClipStyle}>
-                {emojiAvatarPreview ? (
-                  <div
-                    aria-label={`${label} avatar`}
-                    className="relative flex h-full w-full shrink-0 items-center justify-center overflow-hidden rounded-full shadow-xs transition-[background-color] duration-200 ease-out"
-                    role="img"
-                    style={{
-                      backgroundColor: emojiAvatarPreview.color,
-                    }}
-                  >
-                    <span
-                      className={cn(
-                        "buzz-avatar-emoji-glyph flex h-full w-full items-center justify-center text-[4rem] leading-none",
-                        squishKey > 0 && "buzz-avatar-squish",
-                      )}
-                      key={squishKey}
-                    >
-                      {emojiAvatarPreview.emoji}
-                    </span>
-                  </div>
-                ) : (
-                  <ProfileAvatar
-                    avatarUrl={avatarUrl}
-                    className={cn(
-                      "h-full w-full text-4xl transition-shadow duration-150",
-                      isDragOverAvatar &&
-                        !isAvatarMenuOpen &&
-                        "ring-2 ring-primary/30",
-                    )}
-                    label={label}
-                  />
-                )}
-              </div>
-
-              <div className="absolute bottom-0 right-0 z-10 flex h-[42px] w-[42px] items-center justify-center rounded-full bg-background">
+            <MaskedAvatarBadgeFrame
+              badge={
                 <Popover
                   open={isAvatarMenuOpen}
                   onOpenChange={setIsAvatarMenuOpen}
@@ -725,41 +665,101 @@ export function AgentCreationPreview({
                   </PopoverTrigger>
                   {avatarMenuContent}
                 </Popover>
-              </div>
-            </>
-          ) : (
-            <Popover open={isAvatarMenuOpen} onOpenChange={setIsAvatarMenuOpen}>
-              <PopoverTrigger asChild>
-                <button
-                  aria-label="Add avatar"
+              }
+              badgeBox={{ bottom: 0, height: 42, right: 0, width: 42 }}
+              className="h-36 w-36"
+              cutout={{ cx: 123, cy: 123, r: 24 }}
+              size={144}
+            >
+              {emojiAvatarPreview ? (
+                <div
+                  aria-label={`${label} avatar`}
+                  className="relative flex h-full w-full shrink-0 items-center justify-center overflow-hidden rounded-full shadow-xs transition-[background-color] duration-200 ease-out"
+                  role="img"
+                  style={{
+                    backgroundColor: emojiAvatarPreview.color,
+                  }}
+                >
+                  <span
+                    className={cn(
+                      "flex h-full w-full items-center justify-center text-[4rem] leading-none",
+                      squishKey > 0 && "buzz-avatar-squish",
+                    )}
+                    key={squishKey}
+                    style={
+                      {
+                        "--buzz-avatar-emoji-offset-x": "0px",
+                        "--buzz-avatar-emoji-offset-y": "4px",
+                      } as React.CSSProperties
+                    }
+                  >
+                    {emojiAvatarPreview.emoji}
+                  </span>
+                </div>
+              ) : (
+                <ProfileAvatar
+                  avatarUrl={avatarUrl}
                   className={cn(
-                    "group/add-avatar relative flex h-full w-full items-center justify-center rounded-full border-2 border-dashed border-border bg-background text-primary shadow-xs transition-[background-color,border-color,color,box-shadow] duration-150 ease-out hover:border-primary/50 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-70",
+                    "h-full w-full text-4xl transition-shadow duration-150",
                     isDragOverAvatar &&
                       !isAvatarMenuOpen &&
-                      "border-primary/70 bg-primary/5 ring-2 ring-primary/15",
+                      "ring-2 ring-primary/30",
                   )}
-                  disabled={disabled || isUploading}
-                  title="Add avatar"
-                  type="button"
+                  label={label}
+                />
+              )}
+            </MaskedAvatarBadgeFrame>
+          ) : (
+            <MaskedAvatarBadgeFrame
+              badge={
+                <Popover
+                  open={isAvatarMenuOpen}
+                  onOpenChange={setIsAvatarMenuOpen}
                 >
-                  {isUploading ? (
-                    <Spinner
-                      aria-label="Uploading avatar"
-                      className="h-4 w-4 border-2"
-                    />
-                  ) : (
-                    <>
-                      <Plus aria-hidden="true" className="h-14 w-14" />
-                      {/* Pencil badge on empty state */}
-                      <span className="absolute bottom-0 right-0 flex h-9 w-9 items-center justify-center rounded-full bg-sidebar-active text-sidebar-active-foreground shadow-lg">
+                  <PopoverTrigger asChild>
+                    <button
+                      aria-label="Add avatar"
+                      className="flex h-9 w-9 items-center justify-center rounded-full bg-sidebar-active text-sidebar-active-foreground shadow-lg transition-[background-color,scale] duration-150 ease-out hover:scale-[1.04] hover:bg-sidebar-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:opacity-90 disabled:hover:scale-100"
+                      disabled={disabled || isUploading}
+                      title="Add avatar"
+                      type="button"
+                    >
+                      {isUploading ? (
+                        <Spinner
+                          aria-label="Uploading avatar"
+                          className="h-4 w-4 border-2"
+                        />
+                      ) : (
                         <Pencil className="h-4 w-4" />
-                      </span>
-                    </>
-                  )}
-                </button>
-              </PopoverTrigger>
-              {avatarMenuContent}
-            </Popover>
+                      )}
+                    </button>
+                  </PopoverTrigger>
+                  {avatarMenuContent}
+                </Popover>
+              }
+              badgeBox={{ bottom: 0, height: 42, right: 0, width: 42 }}
+              className="h-36 w-36"
+              cutout={{ cx: 123, cy: 123, r: 24 }}
+              size={144}
+            >
+              <div
+                className={cn(
+                  "flex h-full w-full items-center justify-center rounded-full border-2 border-dashed border-border bg-background text-primary shadow-xs transition-[background-color,border-color,color,box-shadow] duration-150 ease-out",
+                  isDragOverAvatar &&
+                    !isAvatarMenuOpen &&
+                    "border-primary/70 bg-primary/5 ring-2 ring-primary/15",
+                )}
+              >
+                {isUploading ? (
+                  <Spinner
+                    aria-label="Uploading avatar"
+                    className="h-4 w-4 border-2"
+                  />
+                ) : (
+                  <Plus aria-hidden="true" className="h-14 w-14" />
+                )}
+              </div>
+            </MaskedAvatarBadgeFrame>
           )}
         </div>
 

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -297,7 +297,6 @@ export function AgentCreationPreview({
       popoverDragDepthRef.current += 1;
       event.dataTransfer.dropEffect = "copy";
       setIsPopoverDragOver(true);
-      // Switch to image tab when dragging a file
       setActiveTab("image");
     },
     [disabled],
@@ -367,22 +366,15 @@ export function AgentCreationPreview({
       {/* Single drop zone covering the entire popover */}
       <fieldset
         aria-label="Avatar picker"
-        className="relative m-0 border-0 p-0"
+        className={cn(
+          "relative m-0 rounded-lg border-2 border-transparent p-0 transition-[border-color,background-color] duration-150",
+          isPopoverDragOver && "border-dashed border-primary bg-primary/5",
+        )}
         onDragEnter={handlePopoverDragEnter}
         onDragLeave={handlePopoverDragLeave}
         onDragOver={handlePopoverDragOver}
         onDrop={handlePopoverDrop}
       >
-        {/* Full-popover drop overlay */}
-        {isPopoverDragOver ? (
-          <div className="absolute inset-0 z-50 flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-primary bg-primary/10">
-            <UploadCloud className="h-8 w-8 text-primary" />
-            <span className="text-sm font-medium text-primary">
-              Drop image here
-            </span>
-          </div>
-        ) : null}
-
         <Tabs
           className="w-full"
           onValueChange={(tab) => {
@@ -411,9 +403,7 @@ export function AgentCreationPreview({
           <div className="grid gap-2.5">
             {/* Click to browse zone */}
             <button
-              className={cn(
-                "relative flex h-[80px] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-200 ease-out hover:bg-muted/80 disabled:opacity-60",
-              )}
+              className="relative flex h-[80px] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-200 ease-out hover:bg-muted/80 disabled:opacity-60"
               disabled={disabled || isUploading}
               onClick={() => {
                 clearUploadError();
@@ -434,13 +424,13 @@ export function AgentCreationPreview({
               </span>
             </button>
 
-            {/* URL input — same style as profile editor */}
+            {/* URL input */}
             <div className="flex h-10 items-center gap-2.5 rounded-lg bg-muted px-3">
-              <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
               <input
                 autoCapitalize="none"
                 autoCorrect="off"
-                className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground"
+                className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
                 disabled={disabled || isUploading}
                 onBlur={() => applyAvatarUrl()}
                 onChange={(event) => setAvatarUrlDraft(event.target.value)}
@@ -500,10 +490,10 @@ export function AgentCreationPreview({
             ) : null}
           </div>
         ) : (
-          <div className="grid gap-3">
-            {/* Emoji picker */}
+          <div className="relative grid content-start gap-3">
+            {/* Emoji picker — no overflow-hidden so internal scroll works */}
             <div
-              className="buzz-emoji-mart relative z-0 h-[280px] overflow-hidden rounded-lg bg-muted"
+              className="buzz-emoji-mart relative z-0 h-[280px] rounded-lg bg-muted"
               ref={emojiPickerContainerRef}
               style={emojiMartThemeVars}
             >
@@ -743,7 +733,7 @@ export function AgentCreationPreview({
                 <button
                   aria-label="Add avatar"
                   className={cn(
-                    "flex h-full w-full items-center justify-center rounded-full border-2 border-dashed border-border bg-background text-primary shadow-xs transition-[background-color,border-color,color,box-shadow] duration-150 ease-out hover:border-primary/50 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-70",
+                    "group/add-avatar relative flex h-full w-full items-center justify-center rounded-full border-2 border-dashed border-border bg-background text-primary shadow-xs transition-[background-color,border-color,color,box-shadow] duration-150 ease-out hover:border-primary/50 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-70",
                     isDragOverAvatar &&
                       !isAvatarMenuOpen &&
                       "border-primary/70 bg-primary/5 ring-2 ring-primary/15",
@@ -758,7 +748,13 @@ export function AgentCreationPreview({
                       className="h-4 w-4 border-2"
                     />
                   ) : (
-                    <Plus aria-hidden="true" className="h-14 w-14" />
+                    <>
+                      <Plus aria-hidden="true" className="h-14 w-14" />
+                      {/* Pencil badge on empty state */}
+                      <span className="absolute bottom-0 right-0 flex h-9 w-9 items-center justify-center rounded-full bg-sidebar-active text-sidebar-active-foreground shadow-lg">
+                        <Pencil className="h-4 w-4" />
+                      </span>
+                    </>
                   )}
                 </button>
               </PopoverTrigger>

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -137,6 +137,11 @@ export function AgentCreationPreview({
         setSelectedColor(parsed.color);
         setActiveTab("emoji");
       } else {
+        // Non-emoji avatar (image/URL or empty): clear any stale emoji
+        // selection so a later color-swatch tap can't re-apply an old emoji
+        // over the current avatar.
+        setSelectedEmoji(null);
+        setSelectedColor(DEFAULT_EMOJI_AVATAR_COLOR);
         setActiveTab("image");
       }
     }

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -1,7 +1,7 @@
 import emojiData from "@emoji-mart/data";
 import Picker from "@emoji-mart/react";
 import * as React from "react";
-import { Pencil, Plus } from "lucide-react";
+import { Link2, Pencil, Plus, UploadCloud } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
@@ -15,12 +15,12 @@ import {
   DEFAULT_EMOJI_AVATAR_COLOR,
   EMOJI_MART_CATEGORIES,
   type AvatarColorSwatch,
+  contrastColorForBackground,
   emojiAvatarDataUrl,
   hexToHsv,
   hsvToHex,
   normalizeHue,
   parseEmojiAvatarDataUrl,
-  contrastColorForBackground,
   useEmojiMartStyles,
   useEmojiMartThemeVars,
 } from "@/features/profile/ui/ProfileAvatarEditor.utils";
@@ -29,7 +29,6 @@ import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { useEmojiBurst } from "@/shared/ui/EmojiBurstProvider";
-import { Input } from "@/shared/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
@@ -43,7 +42,7 @@ const AVATAR_APPLY_MOTION_TRANSITION = {
   ease: [0.23, 1, 0.32, 1],
 } as const;
 
-type AvatarTab = "upload" | "emoji";
+type AvatarTab = "image" | "emoji";
 
 type EmojiMartEmoji = {
   native?: string;
@@ -68,9 +67,7 @@ export function AgentCreationPreview({
   const [isDragOverAvatar, setIsDragOverAvatar] = React.useState(false);
   const [isAvatarMenuOpen, setIsAvatarMenuOpen] = React.useState(false);
   const [avatarUrlDraft, setAvatarUrlDraft] = React.useState("");
-  const [isAvatarUrlInputFocused, setIsAvatarUrlInputFocused] =
-    React.useState(false);
-  const [activeTab, setActiveTab] = React.useState<AvatarTab>("upload");
+  const [activeTab, setActiveTab] = React.useState<AvatarTab>("image");
   const [selectedEmoji, setSelectedEmoji] = React.useState<string | null>(null);
   const [selectedColor, setSelectedColor] = React.useState(
     DEFAULT_EMOJI_AVATAR_COLOR,
@@ -82,7 +79,9 @@ export function AgentCreationPreview({
   const [customValue, setCustomValue] = React.useState(DEFAULT_CUSTOM_VALUE);
   const [isCustomColorPickerOpen, setIsCustomColorPickerOpen] =
     React.useState(false);
+  const [isImageDropActive, setIsImageDropActive] = React.useState(false);
   const avatarDragDepthRef = React.useRef(0);
+  const imageDragDepthRef = React.useRef(0);
   const shouldReduceMotion = useReducedMotion();
   const emojiPickerContainerRef = React.useRef<HTMLDivElement | null>(null);
   const emojiMartThemeVars = useEmojiMartThemeVars();
@@ -96,7 +95,10 @@ export function AgentCreationPreview({
     uploadFile: uploadAvatarFile,
     handleFileChange: handleAvatarUploadFileChange,
   } = useAvatarUpload({
-    onUploadSuccess: onSelectAvatar,
+    onUploadSuccess: (url) => {
+      onSelectAvatar(url);
+      setIsAvatarMenuOpen(false);
+    },
   });
 
   useEmojiMartStyles(emojiPickerContainerRef, activeTab === "emoji");
@@ -117,7 +119,6 @@ export function AgentCreationPreview({
   React.useEffect(() => {
     if (isAvatarMenuOpen) {
       setAvatarUrlDraft("");
-      setIsAvatarUrlInputFocused(false);
 
       const parsed = parseEmojiAvatarDataUrl(avatarUrl ?? "");
       if (parsed) {
@@ -125,7 +126,7 @@ export function AgentCreationPreview({
         setSelectedColor(parsed.color);
         setActiveTab("emoji");
       } else {
-        setActiveTab("upload");
+        setActiveTab("image");
       }
     }
   }, [isAvatarMenuOpen, avatarUrl]);
@@ -202,7 +203,6 @@ export function AgentCreationPreview({
     }),
     [avatarEditClipId],
   );
-  const hasAvatarUrlDraft = avatarUrlDraft.trim().length > 0;
   const hasAvatar = (avatarUrl?.trim().length ?? 0) > 0;
   const applyButtonTransition = shouldReduceMotion
     ? { duration: 0 }
@@ -271,10 +271,8 @@ export function AgentCreationPreview({
     [clearUploadError, disabled, isUploading, uploadAvatarFile],
   );
 
-  const shouldShowColorControls =
-    activeTab === "emoji" && selectedEmoji !== null;
   const isCustomColorPickerVisible =
-    isCustomColorPickerOpen && shouldShowColorControls;
+    isCustomColorPickerOpen && selectedEmoji !== null;
 
   const avatarMenuContent = (
     <PopoverContent
@@ -294,7 +292,7 @@ export function AgentCreationPreview({
         <TabsList className="mb-3 grid h-9 w-full grid-cols-2 rounded-lg bg-muted p-0.5">
           <TabsTrigger
             className="h-full rounded-md text-xs font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
-            value="upload"
+            value="image"
           >
             Image
           </TabsTrigger>
@@ -307,77 +305,151 @@ export function AgentCreationPreview({
         </TabsList>
       </Tabs>
 
-      {activeTab === "upload" ? (
-        <div className="space-y-1">
+      {activeTab === "image" ? (
+        <div className="grid gap-2.5">
+          {/* Drop / browse zone — mini version of profile editor */}
           <button
-            className="flex min-h-9 w-full items-center rounded-lg px-2.5 text-left text-sm outline-hidden transition-colors duration-150 ease-out hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+            className={cn(
+              "relative flex h-[80px] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-200 ease-out hover:bg-muted/80 disabled:opacity-60",
+              isImageDropActive &&
+                "border-primary bg-primary/10 text-primary ring-1 ring-primary/35 hover:bg-primary/10",
+            )}
             disabled={disabled || isUploading}
             onClick={() => {
               clearUploadError();
               openUploadPicker();
-              setIsAvatarMenuOpen(false);
+            }}
+            onDragEnter={(event) => {
+              if (disabled || !isAvatarFileDrag(event)) {
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation();
+              imageDragDepthRef.current += 1;
+              event.dataTransfer.dropEffect = "copy";
+              setIsImageDropActive(true);
+            }}
+            onDragLeave={(event) => {
+              if (!isAvatarFileDrag(event)) {
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation();
+              imageDragDepthRef.current = Math.max(
+                0,
+                imageDragDepthRef.current - 1,
+              );
+              if (imageDragDepthRef.current === 0) {
+                setIsImageDropActive(false);
+              }
+            }}
+            onDragOver={(event) => {
+              if (disabled || !isAvatarFileDrag(event)) {
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation();
+              event.dataTransfer.dropEffect = "copy";
+              setIsImageDropActive(true);
+            }}
+            onDrop={(event) => {
+              if (!isAvatarFileDrag(event)) {
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation();
+              imageDragDepthRef.current = 0;
+              setIsImageDropActive(false);
+              const file = event.dataTransfer.files[0];
+              if (!file || disabled || isUploading) {
+                return;
+              }
+              clearUploadError();
+              void uploadAvatarFile(file);
             }}
             type="button"
           >
-            Upload an image
-          </button>
-          <form
-            className="flex min-h-9 items-center gap-2 rounded-lg px-2.5 py-1.5 transition-colors duration-150 ease-out focus-within:bg-muted/50"
-            onSubmit={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              applyAvatarUrl();
-            }}
-          >
-            <label className="sr-only" htmlFor="agent-avatar-url">
-              Use a URL
-            </label>
-            <Input
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
+            {isUploading ? (
+              <Spinner
+                aria-hidden
+                className="h-5 w-5 border-2 text-muted-foreground"
+              />
+            ) : (
+              <UploadCloud
+                className={cn(
+                  "h-5 w-5 text-muted-foreground transition-colors duration-200 ease-out",
+                  isImageDropActive && "text-primary",
+                )}
+              />
+            )}
+            <span
               className={cn(
-                "h-7 min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-sm shadow-none outline-none focus-visible:ring-0",
-                isAvatarUrlInputFocused
-                  ? "placeholder:text-muted-foreground/55"
-                  : "placeholder:text-popover-foreground",
+                "text-xs font-medium text-muted-foreground transition-colors duration-200 ease-out",
+                isImageDropActive && "text-primary",
               )}
+            >
+              {isUploading
+                ? "Uploading..."
+                : isImageDropActive
+                  ? "Drop image here"
+                  : "Drop or browse"}
+            </span>
+          </button>
+
+          {/* URL input — same style as profile editor */}
+          <div className="flex h-10 items-center gap-2.5 rounded-lg bg-muted px-3">
+            <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <input
+              autoCapitalize="none"
+              autoCorrect="off"
+              className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground"
               disabled={disabled || isUploading}
-              id="agent-avatar-url"
-              onBlur={() => setIsAvatarUrlInputFocused(false)}
+              onBlur={() => applyAvatarUrl()}
               onChange={(event) => setAvatarUrlDraft(event.target.value)}
-              onFocus={() => setIsAvatarUrlInputFocused(true)}
-              placeholder={
-                isAvatarUrlInputFocused ? "https://..." : "Use a URL"
-              }
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  applyAvatarUrl();
+                }
+              }}
+              placeholder="Paste a URL"
               spellCheck={false}
+              type="url"
               value={avatarUrlDraft}
             />
             <AnimatePresence initial={false}>
-              {hasAvatarUrlDraft ? (
+              {avatarUrlDraft.trim().length > 0 ? (
                 <motion.div
                   animate={{ opacity: 1, scale: 1, width: "auto" }}
                   className="overflow-hidden"
                   exit={{ opacity: 0, scale: 0.96, width: 0 }}
                   initial={{ opacity: 0, scale: 0.96, width: 0 }}
-                  key="apply-avatar-url"
+                  key="apply-url"
                   transition={applyButtonTransition}
                 >
                   <Button
-                    className="h-7 px-2 text-xs"
+                    className="h-6 px-2 text-2xs"
                     disabled={disabled || isUploading}
+                    onClick={() => applyAvatarUrl()}
                     size="xs"
-                    type="submit"
+                    type="button"
                   >
                     Apply
                   </Button>
                 </motion.div>
               ) : null}
             </AnimatePresence>
-          </form>
+          </div>
+
+          {uploadErrorMessage ? (
+            <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive">
+              {uploadErrorMessage}
+            </p>
+          ) : null}
+
           {hasAvatar && onClearAvatar ? (
             <button
-              className="flex min-h-9 w-full items-center rounded-lg px-2.5 text-left text-sm text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+              className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
               disabled={disabled || isUploading}
               onClick={() => {
                 onClearAvatar();
@@ -390,9 +462,10 @@ export function AgentCreationPreview({
           ) : null}
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="grid gap-3">
+          {/* Emoji picker */}
           <div
-            className="buzz-emoji-mart relative z-0 h-[280px] overflow-hidden rounded-lg bg-muted"
+            className="buzz-emoji-mart relative z-0 h-[240px] overflow-hidden rounded-lg bg-muted"
             ref={emojiPickerContainerRef}
             style={emojiMartThemeVars}
           >
@@ -431,68 +504,58 @@ export function AgentCreationPreview({
             />
           </div>
 
-          <div
-            aria-hidden={!shouldShowColorControls}
-            className={cn(
-              "origin-top overflow-hidden transition-[max-height,margin,opacity,transform] duration-200 ease-out",
-              shouldShowColorControls
-                ? "max-h-64 scale-100 opacity-100"
-                : "max-h-0 scale-[0.96] opacity-0",
-            )}
-            inert={shouldShowColorControls ? undefined : true}
-          >
-            <div className="grid grid-cols-8 justify-items-center gap-2 rounded-lg bg-muted p-3">
-              {AVATAR_COLOR_SWATCHES.map((swatch) => {
-                const isCustomSwatch = swatch === CUSTOM_AVATAR_COLOR_SWATCH;
-                const isSelected = isCustomSwatch
-                  ? !AVATAR_COLORS.some(
-                      (color) =>
-                        color.toUpperCase() === selectedColor.toUpperCase(),
-                    )
-                  : swatch.toUpperCase() === selectedColor.toUpperCase();
+          {/* Color swatches — always visible */}
+          <div className="grid grid-cols-8 justify-items-center gap-2 rounded-lg bg-muted p-3">
+            {AVATAR_COLOR_SWATCHES.map((swatch) => {
+              const isCustomSwatch = swatch === CUSTOM_AVATAR_COLOR_SWATCH;
+              const isSelected = isCustomSwatch
+                ? !AVATAR_COLORS.some(
+                    (color) =>
+                      color.toUpperCase() === selectedColor.toUpperCase(),
+                  )
+                : swatch.toUpperCase() === selectedColor.toUpperCase();
 
-                return (
-                  <button
-                    aria-label={
-                      isCustomSwatch
-                        ? selectedEmoji
-                          ? "Choose custom color"
-                          : "Choose an emoji first"
-                        : `Use ${swatch} background`
-                    }
-                    aria-pressed={isSelected}
-                    className={cn(
-                      "relative h-7 w-7 rounded-full border border-border transition-transform duration-150 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                      isCustomSwatch &&
-                        !selectedEmoji &&
-                        "cursor-not-allowed opacity-45 hover:scale-100 focus-visible:scale-100",
-                    )}
-                    disabled={isCustomSwatch && !selectedEmoji}
-                    key={swatch}
-                    onClick={() => handleColorSelect(swatch)}
-                    style={{
-                      background: isCustomSwatch
-                        ? isSelected
-                          ? selectedColor
-                          : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
-                        : swatch,
-                    }}
-                    type="button"
-                  >
-                    {isSelected ? (
-                      <span
-                        className="absolute inset-0.5 rounded-full border-2"
-                        style={{
-                          borderColor: contrastColorForBackground(
-                            isCustomSwatch ? selectedColor : swatch,
-                          ),
-                        }}
-                      />
-                    ) : null}
-                  </button>
-                );
-              })}
-            </div>
+              return (
+                <button
+                  aria-label={
+                    isCustomSwatch
+                      ? selectedEmoji
+                        ? "Choose custom color"
+                        : "Choose an emoji first"
+                      : `Use ${swatch} background`
+                  }
+                  aria-pressed={isSelected}
+                  className={cn(
+                    "relative h-7 w-7 rounded-full border border-border transition-transform duration-150 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    isCustomSwatch &&
+                      !selectedEmoji &&
+                      "cursor-not-allowed opacity-45 hover:scale-100 focus-visible:scale-100",
+                  )}
+                  disabled={isCustomSwatch && !selectedEmoji}
+                  key={swatch}
+                  onClick={() => handleColorSelect(swatch)}
+                  style={{
+                    background: isCustomSwatch
+                      ? isSelected
+                        ? selectedColor
+                        : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
+                      : swatch,
+                  }}
+                  type="button"
+                >
+                  {isSelected ? (
+                    <span
+                      className="absolute inset-0.5 rounded-full border-2"
+                      style={{
+                        borderColor: contrastColorForBackground(
+                          isCustomSwatch ? selectedColor : swatch,
+                        ),
+                      }}
+                    />
+                  ) : null}
+                </button>
+              );
+            })}
           </div>
 
           <AvatarCustomColorPanel

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -30,7 +30,12 @@ import { useAvatarUpload } from "@/features/profile/useAvatarUpload";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { useEmojiBurst } from "@/shared/ui/EmojiBurstProvider";
-import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 
@@ -102,7 +107,10 @@ export function AgentCreationPreview({
     },
   });
 
-  useEmojiMartStyles(emojiPickerContainerRef, isAvatarMenuOpen);
+  useEmojiMartStyles(
+    emojiPickerContainerRef,
+    isAvatarMenuOpen && activeTab === "emoji",
+  );
 
   const customColorDraft = React.useMemo(
     () => hsvToHex(customHue, customSaturation, customValue),
@@ -376,15 +384,23 @@ export function AgentCreationPreview({
           }}
           value={activeTab}
         >
-          <TabsList className="mb-3 grid h-9 w-full grid-cols-2 rounded-lg bg-muted p-0.5">
+          <TabsList className="relative isolate mb-3 grid h-9 w-full grid-cols-2 overflow-hidden rounded-lg bg-muted p-0.5">
+            <div
+              aria-hidden="true"
+              className="absolute bottom-0.5 left-0.5 top-0.5 z-0 rounded-md bg-background shadow-sm transition-transform duration-[250ms] ease-out"
+              style={{
+                transform: `translateX(${activeTab === "emoji" ? 100 : 0}%)`,
+                width: "calc((100% - 4px) / 2)",
+              }}
+            />
             <TabsTrigger
-              className="h-full rounded-md text-xs font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
+              className="relative z-10 h-full rounded-md bg-transparent text-xs font-medium shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:shadow-none"
               value="image"
             >
               Image
             </TabsTrigger>
             <TabsTrigger
-              className="h-full rounded-md text-xs font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
+              className="relative z-10 h-full rounded-md bg-transparent text-xs font-medium shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:shadow-none"
               value="emoji"
             >
               Emoji
@@ -392,227 +408,225 @@ export function AgentCreationPreview({
           </TabsList>
         </Tabs>
 
-        <div className={activeTab === "image" ? "grid gap-2.5" : "hidden"}>
-          {/* Click to browse zone */}
-          <button
-            className="relative flex h-[80px] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-200 ease-out hover:bg-muted/80 disabled:opacity-60"
-            disabled={disabled || isUploading}
-            onClick={() => {
-              clearUploadError();
-              openUploadPicker();
-            }}
-            type="button"
-          >
-            {isUploading ? (
-              <Spinner
-                aria-hidden
-                className="h-5 w-5 border-2 text-muted-foreground"
-              />
-            ) : (
-              <UploadCloud className="h-5 w-5 text-muted-foreground" />
-            )}
-            <span className="text-xs font-medium text-muted-foreground">
-              {isUploading ? "Uploading..." : "Drop or browse"}
-            </span>
-          </button>
-
-          {/* URL input */}
-          <div className="flex h-10 items-center gap-2.5 rounded-lg bg-muted px-3">
-            <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
-            <input
-              autoCapitalize="none"
-              autoCorrect="off"
-              className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
+        {activeTab === "image" ? (
+          <div className="grid gap-2.5">
+            {/* Click to browse zone */}
+            <button
+              className="relative flex h-[80px] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-200 ease-out hover:bg-muted/80 disabled:opacity-60"
               disabled={disabled || isUploading}
-              onBlur={() => applyAvatarUrl()}
-              onChange={(event) => setAvatarUrlDraft(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  applyAvatarUrl();
-                }
+              onClick={() => {
+                clearUploadError();
+                openUploadPicker();
               }}
-              placeholder="Paste a URL"
-              spellCheck={false}
-              type="url"
-              value={avatarUrlDraft}
-            />
-            <AnimatePresence initial={false}>
-              {avatarUrlDraft.trim().length > 0 ? (
-                <motion.div
-                  animate={{ opacity: 1, scale: 1, width: "auto" }}
-                  className="overflow-hidden"
-                  exit={{ opacity: 0, scale: 0.96, width: 0 }}
-                  initial={{ opacity: 0, scale: 0.96, width: 0 }}
-                  key="apply-url"
-                  transition={applyButtonTransition}
-                >
-                  <Button
-                    className="h-6 px-2 text-2xs"
-                    disabled={disabled || isUploading}
-                    onClick={() => applyAvatarUrl()}
-                    size="xs"
+              type="button"
+            >
+              {isUploading ? (
+                <Spinner
+                  aria-hidden
+                  className="h-5 w-5 border-2 text-muted-foreground"
+                />
+              ) : (
+                <UploadCloud className="h-5 w-5 text-muted-foreground" />
+              )}
+              <span className="text-xs font-medium text-muted-foreground">
+                {isUploading ? "Uploading..." : "Drop or browse"}
+              </span>
+            </button>
+
+            {/* URL input */}
+            <div className="flex h-10 items-center gap-2.5 rounded-lg bg-muted px-3">
+              <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+              <input
+                autoCapitalize="none"
+                autoCorrect="off"
+                className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
+                disabled={disabled || isUploading}
+                onBlur={() => applyAvatarUrl()}
+                onChange={(event) => setAvatarUrlDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    applyAvatarUrl();
+                  }
+                }}
+                placeholder="Paste a URL"
+                spellCheck={false}
+                type="url"
+                value={avatarUrlDraft}
+              />
+              <AnimatePresence initial={false}>
+                {avatarUrlDraft.trim().length > 0 ? (
+                  <motion.div
+                    animate={{ opacity: 1, scale: 1, width: "auto" }}
+                    className="overflow-hidden"
+                    exit={{ opacity: 0, scale: 0.96, width: 0 }}
+                    initial={{ opacity: 0, scale: 0.96, width: 0 }}
+                    key="apply-url"
+                    transition={applyButtonTransition}
+                  >
+                    <Button
+                      className="h-6 px-2 text-2xs"
+                      disabled={disabled || isUploading}
+                      onClick={() => applyAvatarUrl()}
+                      size="xs"
+                      type="button"
+                    >
+                      Apply
+                    </Button>
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+            </div>
+
+            {uploadErrorMessage ? (
+              <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive">
+                {uploadErrorMessage}
+              </p>
+            ) : null}
+
+            {hasAvatar && onClearAvatar ? (
+              <button
+                className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+                disabled={disabled || isUploading}
+                onClick={() => {
+                  onClearAvatar();
+                  setIsAvatarMenuOpen(false);
+                }}
+                type="button"
+              >
+                Remove avatar
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {activeTab === "emoji" ? (
+          <div className="relative grid content-start gap-3">
+            <div
+              className="buzz-emoji-mart relative z-0 h-[280px] overflow-hidden rounded-lg bg-muted"
+              ref={emojiPickerContainerRef}
+              style={emojiMartThemeVars}
+            >
+              <Picker
+                categories={EMOJI_MART_CATEGORIES}
+                data={emojiData}
+                dynamicWidth
+                emojiButtonRadius="999px"
+                emojiButtonSize={44}
+                emojiSize={32}
+                icons="outline"
+                navPosition="bottom"
+                onEmojiSelect={(emoji: EmojiMartEmoji, event?: MouseEvent) => {
+                  if (disabled) {
+                    return;
+                  }
+                  if (!emoji.native) {
+                    return;
+                  }
+                  const nextColor =
+                    selectedEmoji === null
+                      ? (AVATAR_COLORS[
+                          Math.floor(Math.random() * AVATAR_COLORS.length)
+                        ] ?? DEFAULT_EMOJI_AVATAR_COLOR)
+                      : selectedColor;
+                  burstEmoji(emoji.native, event);
+                  setSelectedEmoji(emoji.native);
+                  setSelectedColor(nextColor);
+                  applyEmojiAvatar(emoji.native, nextColor);
+                }}
+                previewPosition="none"
+                searchPosition="none"
+                set="native"
+                skinTonePosition="none"
+                theme="auto"
+              />
+            </div>
+
+            {/* Color swatches — always visible */}
+            <div className="grid grid-cols-12 justify-items-center gap-1.5 rounded-lg bg-muted p-3">
+              {AVATAR_COLOR_SWATCHES.map((swatch) => {
+                const isCustomSwatch = swatch === CUSTOM_AVATAR_COLOR_SWATCH;
+                const isSelected = isCustomSwatch
+                  ? !AVATAR_COLORS.some(
+                      (color) =>
+                        color.toUpperCase() === selectedColor.toUpperCase(),
+                    )
+                  : swatch.toUpperCase() === selectedColor.toUpperCase();
+
+                return (
+                  <button
+                    aria-label={
+                      isCustomSwatch
+                        ? selectedEmoji
+                          ? "Choose custom color"
+                          : "Choose an emoji first"
+                        : `Use ${swatch} background`
+                    }
+                    aria-pressed={isSelected}
+                    className={cn(
+                      "relative h-6 w-6 rounded-full border border-border transition-transform duration-150 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      isCustomSwatch &&
+                        !selectedEmoji &&
+                        "cursor-not-allowed opacity-45 hover:scale-100 focus-visible:scale-100",
+                    )}
+                    disabled={isCustomSwatch && !selectedEmoji}
+                    key={swatch}
+                    onClick={() => handleColorSelect(swatch)}
+                    style={{
+                      background: isCustomSwatch
+                        ? isSelected
+                          ? selectedColor
+                          : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
+                        : swatch,
+                    }}
                     type="button"
                   >
-                    Apply
-                  </Button>
-                </motion.div>
-              ) : null}
-            </AnimatePresence>
-          </div>
+                    {isSelected ? (
+                      <span
+                        className="absolute inset-0.5 rounded-full border-2"
+                        style={{
+                          borderColor: contrastColorForBackground(
+                            isCustomSwatch ? selectedColor : swatch,
+                          ),
+                        }}
+                      />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
 
-          {uploadErrorMessage ? (
-            <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive">
-              {uploadErrorMessage}
-            </p>
-          ) : null}
-
-          {hasAvatar && onClearAvatar ? (
-            <button
-              className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
-              disabled={disabled || isUploading}
-              onClick={() => {
-                onClearAvatar();
-                setIsAvatarMenuOpen(false);
+            <AvatarCustomColorPanel
+              colorDraft={customColorDraft}
+              hue={customHue}
+              onCommit={commitCustomColor}
+              onHueChange={setCustomHue}
+              onSaturationValueChange={(nextSaturation, nextValue) => {
+                setCustomSaturation(nextSaturation);
+                setCustomValue(nextValue);
               }}
-              type="button"
-            >
-              Remove avatar
-            </button>
-          ) : null}
-        </div>
-
-        <div
-          className={
-            activeTab === "emoji"
-              ? "relative grid content-start gap-3"
-              : "hidden"
-          }
-        >
-          <div
-            className="buzz-emoji-mart relative z-0 h-[280px] overflow-hidden rounded-lg bg-muted"
-            ref={emojiPickerContainerRef}
-            style={emojiMartThemeVars}
-          >
-            <Picker
-              categories={EMOJI_MART_CATEGORIES}
-              data={emojiData}
-              dynamicWidth
-              emojiButtonRadius="999px"
-              emojiButtonSize={44}
-              emojiSize={32}
-              icons="outline"
-              navPosition="bottom"
-              onEmojiSelect={(emoji: EmojiMartEmoji, event?: MouseEvent) => {
-                if (disabled) {
-                  return;
-                }
-                if (!emoji.native) {
-                  return;
-                }
-                const nextColor =
-                  selectedEmoji === null
-                    ? (AVATAR_COLORS[
-                        Math.floor(Math.random() * AVATAR_COLORS.length)
-                      ] ?? DEFAULT_EMOJI_AVATAR_COLOR)
-                    : selectedColor;
-                burstEmoji(emoji.native, event);
-                setSelectedEmoji(emoji.native);
-                setSelectedColor(nextColor);
-                applyEmojiAvatar(emoji.native, nextColor);
-              }}
-              previewPosition="none"
-              searchPosition="none"
-              set="native"
-              skinTonePosition="none"
-              theme="auto"
+              saturation={customSaturation}
+              testIdPrefix="agent-avatar"
+              value={customValue}
+              visible={isCustomColorPickerVisible}
             />
+
+            {hasAvatar && onClearAvatar ? (
+              <button
+                className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+                disabled={disabled}
+                onClick={() => {
+                  onClearAvatar();
+                  setSelectedEmoji(null);
+                  setIsAvatarMenuOpen(false);
+                }}
+                type="button"
+              >
+                Remove avatar
+              </button>
+            ) : null}
           </div>
-
-          {/* Color swatches — always visible */}
-          <div className="grid grid-cols-12 justify-items-center gap-1.5 rounded-lg bg-muted p-3">
-            {AVATAR_COLOR_SWATCHES.map((swatch) => {
-              const isCustomSwatch = swatch === CUSTOM_AVATAR_COLOR_SWATCH;
-              const isSelected = isCustomSwatch
-                ? !AVATAR_COLORS.some(
-                    (color) =>
-                      color.toUpperCase() === selectedColor.toUpperCase(),
-                  )
-                : swatch.toUpperCase() === selectedColor.toUpperCase();
-
-              return (
-                <button
-                  aria-label={
-                    isCustomSwatch
-                      ? selectedEmoji
-                        ? "Choose custom color"
-                        : "Choose an emoji first"
-                      : `Use ${swatch} background`
-                  }
-                  aria-pressed={isSelected}
-                  className={cn(
-                    "relative h-6 w-6 rounded-full border border-border transition-transform duration-150 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    isCustomSwatch &&
-                      !selectedEmoji &&
-                      "cursor-not-allowed opacity-45 hover:scale-100 focus-visible:scale-100",
-                  )}
-                  disabled={isCustomSwatch && !selectedEmoji}
-                  key={swatch}
-                  onClick={() => handleColorSelect(swatch)}
-                  style={{
-                    background: isCustomSwatch
-                      ? isSelected
-                        ? selectedColor
-                        : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
-                      : swatch,
-                  }}
-                  type="button"
-                >
-                  {isSelected ? (
-                    <span
-                      className="absolute inset-0.5 rounded-full border-2"
-                      style={{
-                        borderColor: contrastColorForBackground(
-                          isCustomSwatch ? selectedColor : swatch,
-                        ),
-                      }}
-                    />
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-
-          <AvatarCustomColorPanel
-            colorDraft={customColorDraft}
-            hue={customHue}
-            onCommit={commitCustomColor}
-            onHueChange={setCustomHue}
-            onSaturationValueChange={(nextSaturation, nextValue) => {
-              setCustomSaturation(nextSaturation);
-              setCustomValue(nextValue);
-            }}
-            saturation={customSaturation}
-            testIdPrefix="agent-avatar"
-            value={customValue}
-            visible={isCustomColorPickerVisible}
-          />
-
-          {hasAvatar && onClearAvatar ? (
-            <button
-              className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
-              disabled={disabled}
-              onClick={() => {
-                onClearAvatar();
-                setSelectedEmoji(null);
-                setIsAvatarMenuOpen(false);
-              }}
-              type="button"
-            >
-              Remove avatar
-            </button>
-          ) : null}
-        </div>
+        ) : null}
       </fieldset>
     </PopoverContent>
   );
@@ -640,131 +654,103 @@ export function AgentCreationPreview({
           type="file"
         />
 
-        <div className="relative h-36 w-36">
-          {hasAvatar ? (
-            <MaskedAvatarBadgeFrame
-              badge={
-                <Popover
-                  open={isAvatarMenuOpen}
-                  onOpenChange={setIsAvatarMenuOpen}
+        <Popover open={isAvatarMenuOpen} onOpenChange={setIsAvatarMenuOpen}>
+          <PopoverAnchor asChild>
+            <div className="relative h-36 w-36">
+              {hasAvatar ? (
+                <MaskedAvatarBadgeFrame
+                  badge={
+                    <PopoverTrigger asChild>
+                      <button
+                        aria-label="Edit avatar"
+                        className="flex h-9 w-9 items-center justify-center rounded-full bg-sidebar-active text-sidebar-active-foreground shadow-lg transition-[background-color,scale] duration-150 ease-out hover:scale-[1.04] hover:bg-sidebar-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:opacity-90 disabled:hover:scale-100"
+                        disabled={disabled || isUploading}
+                        title="Edit avatar"
+                        type="button"
+                      >
+                        {isUploading ? (
+                          <Spinner
+                            aria-label="Uploading avatar"
+                            className="h-4 w-4 border-2"
+                          />
+                        ) : (
+                          <Pencil className="h-4 w-4" />
+                        )}
+                      </button>
+                    </PopoverTrigger>
+                  }
+                  badgeBox={{ bottom: 0, height: 42, right: 0, width: 42 }}
+                  className="h-36 w-36"
+                  cutout={{ cx: 123, cy: 123, r: 24 }}
+                  size={144}
                 >
-                  <PopoverTrigger asChild>
-                    <button
-                      aria-label="Edit avatar"
-                      className="flex h-9 w-9 items-center justify-center rounded-full bg-sidebar-active text-sidebar-active-foreground shadow-lg transition-[background-color,scale] duration-150 ease-out hover:scale-[1.04] hover:bg-sidebar-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:opacity-90 disabled:hover:scale-100"
-                      disabled={disabled || isUploading}
-                      title="Edit avatar"
-                      type="button"
+                  {emojiAvatarPreview ? (
+                    <div
+                      aria-label={`${label} avatar`}
+                      className="relative flex h-full w-full shrink-0 items-center justify-center overflow-hidden rounded-full shadow-xs transition-[background-color] duration-200 ease-out"
+                      role="img"
+                      style={{
+                        backgroundColor: emojiAvatarPreview.color,
+                      }}
                     >
-                      {isUploading ? (
-                        <Spinner
-                          aria-label="Uploading avatar"
-                          className="h-4 w-4 border-2"
-                        />
-                      ) : (
-                        <Pencil className="h-4 w-4" />
+                      <span
+                        className={cn(
+                          "flex h-full w-full items-center justify-center text-[4rem] leading-none",
+                          squishKey > 0 && "buzz-avatar-squish",
+                        )}
+                        key={squishKey}
+                        style={
+                          {
+                            "--buzz-avatar-emoji-offset-x": "0px",
+                            "--buzz-avatar-emoji-offset-y": "0px",
+                          } as React.CSSProperties
+                        }
+                      >
+                        {emojiAvatarPreview.emoji}
+                      </span>
+                    </div>
+                  ) : (
+                    <ProfileAvatar
+                      avatarUrl={avatarUrl}
+                      className={cn(
+                        "h-full w-full text-4xl transition-shadow duration-150",
+                        isDragOverAvatar &&
+                          !isAvatarMenuOpen &&
+                          "ring-2 ring-primary/30",
                       )}
-                    </button>
-                  </PopoverTrigger>
-                  {avatarMenuContent}
-                </Popover>
-              }
-              badgeBox={{ bottom: 0, height: 42, right: 0, width: 42 }}
-              className="h-36 w-36"
-              cutout={{ cx: 123, cy: 123, r: 24 }}
-              size={144}
-            >
-              {emojiAvatarPreview ? (
-                <div
-                  aria-label={`${label} avatar`}
-                  className="relative flex h-full w-full shrink-0 items-center justify-center overflow-hidden rounded-full shadow-xs transition-[background-color] duration-200 ease-out"
-                  role="img"
-                  style={{
-                    backgroundColor: emojiAvatarPreview.color,
-                  }}
-                >
-                  <span
-                    className={cn(
-                      "flex h-full w-full items-center justify-center text-[4rem] leading-none",
-                      squishKey > 0 && "buzz-avatar-squish",
-                    )}
-                    key={squishKey}
-                    style={
-                      {
-                        "--buzz-avatar-emoji-offset-x": "0px",
-                        "--buzz-avatar-emoji-offset-y": "0px",
-                      } as React.CSSProperties
-                    }
-                  >
-                    {emojiAvatarPreview.emoji}
-                  </span>
-                </div>
-              ) : (
-                <ProfileAvatar
-                  avatarUrl={avatarUrl}
-                  className={cn(
-                    "h-full w-full text-4xl transition-shadow duration-150",
-                    isDragOverAvatar &&
-                      !isAvatarMenuOpen &&
-                      "ring-2 ring-primary/30",
+                      label={label}
+                    />
                   )}
-                  label={label}
-                />
+                </MaskedAvatarBadgeFrame>
+              ) : (
+                <PopoverTrigger asChild>
+                  <button
+                    aria-label="Add avatar"
+                    className={cn(
+                      "flex h-36 w-36 items-center justify-center rounded-full border-2 border-dashed border-border bg-background text-primary shadow-xs transition-[background-color,border-color,color,box-shadow,scale] duration-150 ease-out hover:scale-[1.02] hover:border-primary/60 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:opacity-60 disabled:hover:scale-100",
+                      isDragOverAvatar &&
+                        !isAvatarMenuOpen &&
+                        "border-primary/70 bg-primary/5 ring-2 ring-primary/15",
+                    )}
+                    disabled={disabled || isUploading}
+                    title="Add avatar"
+                    type="button"
+                  >
+                    {isUploading ? (
+                      <Spinner
+                        aria-label="Uploading avatar"
+                        className="h-4 w-4 border-2"
+                      />
+                    ) : (
+                      <Plus aria-hidden="true" className="h-14 w-14" />
+                    )}
+                  </button>
+                </PopoverTrigger>
               )}
-            </MaskedAvatarBadgeFrame>
-          ) : (
-            <MaskedAvatarBadgeFrame
-              badge={
-                <Popover
-                  open={isAvatarMenuOpen}
-                  onOpenChange={setIsAvatarMenuOpen}
-                >
-                  <PopoverTrigger asChild>
-                    <button
-                      aria-label="Add avatar"
-                      className="flex h-9 w-9 items-center justify-center rounded-full bg-sidebar-active text-sidebar-active-foreground shadow-lg transition-[background-color,scale] duration-150 ease-out hover:scale-[1.04] hover:bg-sidebar-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:opacity-90 disabled:hover:scale-100"
-                      disabled={disabled || isUploading}
-                      title="Add avatar"
-                      type="button"
-                    >
-                      {isUploading ? (
-                        <Spinner
-                          aria-label="Uploading avatar"
-                          className="h-4 w-4 border-2"
-                        />
-                      ) : (
-                        <Pencil className="h-4 w-4" />
-                      )}
-                    </button>
-                  </PopoverTrigger>
-                  {avatarMenuContent}
-                </Popover>
-              }
-              badgeBox={{ bottom: 0, height: 42, right: 0, width: 42 }}
-              className="h-36 w-36"
-              cutout={{ cx: 123, cy: 123, r: 24 }}
-              size={144}
-            >
-              <div
-                className={cn(
-                  "flex h-full w-full items-center justify-center rounded-full border-2 border-dashed border-border bg-background text-primary shadow-xs transition-[background-color,border-color,color,box-shadow] duration-150 ease-out",
-                  isDragOverAvatar &&
-                    !isAvatarMenuOpen &&
-                    "border-primary/70 bg-primary/5 ring-2 ring-primary/15",
-                )}
-              >
-                {isUploading ? (
-                  <Spinner
-                    aria-label="Uploading avatar"
-                    className="h-4 w-4 border-2"
-                  />
-                ) : (
-                  <Plus aria-hidden="true" className="h-14 w-14" />
-                )}
-              </div>
-            </MaskedAvatarBadgeFrame>
-          )}
-        </div>
+            </div>
+          </PopoverAnchor>
+          {avatarMenuContent}
+        </Popover>
 
         {uploadErrorMessage ? (
           <p className="max-w-full rounded-md bg-background/95 px-2 py-1 text-center text-xs text-destructive shadow-xs">

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -102,7 +102,7 @@ export function AgentCreationPreview({
     },
   });
 
-  useEmojiMartStyles(emojiPickerContainerRef, activeTab === "emoji");
+  useEmojiMartStyles(emojiPickerContainerRef, isAvatarMenuOpen);
 
   const customColorDraft = React.useMemo(
     () => hsvToHex(customHue, customSaturation, customValue),
@@ -392,224 +392,227 @@ export function AgentCreationPreview({
           </TabsList>
         </Tabs>
 
-        {activeTab === "image" ? (
-          <div className="grid gap-2.5">
-            {/* Click to browse zone */}
+        <div className={activeTab === "image" ? "grid gap-2.5" : "hidden"}>
+          {/* Click to browse zone */}
+          <button
+            className="relative flex h-[80px] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-200 ease-out hover:bg-muted/80 disabled:opacity-60"
+            disabled={disabled || isUploading}
+            onClick={() => {
+              clearUploadError();
+              openUploadPicker();
+            }}
+            type="button"
+          >
+            {isUploading ? (
+              <Spinner
+                aria-hidden
+                className="h-5 w-5 border-2 text-muted-foreground"
+              />
+            ) : (
+              <UploadCloud className="h-5 w-5 text-muted-foreground" />
+            )}
+            <span className="text-xs font-medium text-muted-foreground">
+              {isUploading ? "Uploading..." : "Drop or browse"}
+            </span>
+          </button>
+
+          {/* URL input */}
+          <div className="flex h-10 items-center gap-2.5 rounded-lg bg-muted px-3">
+            <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+            <input
+              autoCapitalize="none"
+              autoCorrect="off"
+              className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
+              disabled={disabled || isUploading}
+              onBlur={() => applyAvatarUrl()}
+              onChange={(event) => setAvatarUrlDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  applyAvatarUrl();
+                }
+              }}
+              placeholder="Paste a URL"
+              spellCheck={false}
+              type="url"
+              value={avatarUrlDraft}
+            />
+            <AnimatePresence initial={false}>
+              {avatarUrlDraft.trim().length > 0 ? (
+                <motion.div
+                  animate={{ opacity: 1, scale: 1, width: "auto" }}
+                  className="overflow-hidden"
+                  exit={{ opacity: 0, scale: 0.96, width: 0 }}
+                  initial={{ opacity: 0, scale: 0.96, width: 0 }}
+                  key="apply-url"
+                  transition={applyButtonTransition}
+                >
+                  <Button
+                    className="h-6 px-2 text-2xs"
+                    disabled={disabled || isUploading}
+                    onClick={() => applyAvatarUrl()}
+                    size="xs"
+                    type="button"
+                  >
+                    Apply
+                  </Button>
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
+          </div>
+
+          {uploadErrorMessage ? (
+            <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive">
+              {uploadErrorMessage}
+            </p>
+          ) : null}
+
+          {hasAvatar && onClearAvatar ? (
             <button
-              className="relative flex h-[80px] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-200 ease-out hover:bg-muted/80 disabled:opacity-60"
+              className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
               disabled={disabled || isUploading}
               onClick={() => {
-                clearUploadError();
-                openUploadPicker();
+                onClearAvatar();
+                setIsAvatarMenuOpen(false);
               }}
               type="button"
             >
-              {isUploading ? (
-                <Spinner
-                  aria-hidden
-                  className="h-5 w-5 border-2 text-muted-foreground"
-                />
-              ) : (
-                <UploadCloud className="h-5 w-5 text-muted-foreground" />
-              )}
-              <span className="text-xs font-medium text-muted-foreground">
-                {isUploading ? "Uploading..." : "Drop or browse"}
-              </span>
+              Remove avatar
             </button>
+          ) : null}
+        </div>
 
-            {/* URL input */}
-            <div className="flex h-10 items-center gap-2.5 rounded-lg bg-muted px-3">
-              <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
-              <input
-                autoCapitalize="none"
-                autoCorrect="off"
-                className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground/50"
-                disabled={disabled || isUploading}
-                onBlur={() => applyAvatarUrl()}
-                onChange={(event) => setAvatarUrlDraft(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.preventDefault();
-                    applyAvatarUrl();
-                  }
-                }}
-                placeholder="Paste a URL"
-                spellCheck={false}
-                type="url"
-                value={avatarUrlDraft}
-              />
-              <AnimatePresence initial={false}>
-                {avatarUrlDraft.trim().length > 0 ? (
-                  <motion.div
-                    animate={{ opacity: 1, scale: 1, width: "auto" }}
-                    className="overflow-hidden"
-                    exit={{ opacity: 0, scale: 0.96, width: 0 }}
-                    initial={{ opacity: 0, scale: 0.96, width: 0 }}
-                    key="apply-url"
-                    transition={applyButtonTransition}
-                  >
-                    <Button
-                      className="h-6 px-2 text-2xs"
-                      disabled={disabled || isUploading}
-                      onClick={() => applyAvatarUrl()}
-                      size="xs"
-                      type="button"
-                    >
-                      Apply
-                    </Button>
-                  </motion.div>
-                ) : null}
-              </AnimatePresence>
-            </div>
-
-            {uploadErrorMessage ? (
-              <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive">
-                {uploadErrorMessage}
-              </p>
-            ) : null}
-
-            {hasAvatar && onClearAvatar ? (
-              <button
-                className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
-                disabled={disabled || isUploading}
-                onClick={() => {
-                  onClearAvatar();
-                  setIsAvatarMenuOpen(false);
-                }}
-                type="button"
-              >
-                Remove avatar
-              </button>
-            ) : null}
-          </div>
-        ) : (
-          <div className="relative grid content-start gap-3">
-            {/* Emoji picker — no overflow-hidden so internal scroll works */}
-            <div
-              className="buzz-emoji-mart relative z-0 h-[280px] rounded-lg bg-muted"
-              ref={emojiPickerContainerRef}
-              style={emojiMartThemeVars}
-            >
-              <Picker
-                categories={EMOJI_MART_CATEGORIES}
-                data={emojiData}
-                dynamicWidth
-                emojiButtonRadius="999px"
-                emojiButtonSize={44}
-                emojiSize={32}
-                icons="outline"
-                navPosition="bottom"
-                onEmojiSelect={(emoji: EmojiMartEmoji, event?: MouseEvent) => {
-                  if (disabled) {
-                    return;
-                  }
-                  if (!emoji.native) {
-                    return;
-                  }
-                  const nextColor =
-                    selectedEmoji === null
-                      ? (AVATAR_COLORS[
-                          Math.floor(Math.random() * AVATAR_COLORS.length)
-                        ] ?? DEFAULT_EMOJI_AVATAR_COLOR)
-                      : selectedColor;
-                  burstEmoji(emoji.native, event);
-                  setSelectedEmoji(emoji.native);
-                  setSelectedColor(nextColor);
-                  applyEmojiAvatar(emoji.native, nextColor);
-                }}
-                previewPosition="none"
-                searchPosition="none"
-                set="native"
-                skinTonePosition="none"
-                theme="auto"
-              />
-            </div>
-
-            {/* Color swatches — always visible */}
-            <div className="grid grid-cols-12 justify-items-center gap-1.5 rounded-lg bg-muted p-3">
-              {AVATAR_COLOR_SWATCHES.map((swatch) => {
-                const isCustomSwatch = swatch === CUSTOM_AVATAR_COLOR_SWATCH;
-                const isSelected = isCustomSwatch
-                  ? !AVATAR_COLORS.some(
-                      (color) =>
-                        color.toUpperCase() === selectedColor.toUpperCase(),
-                    )
-                  : swatch.toUpperCase() === selectedColor.toUpperCase();
-
-                return (
-                  <button
-                    aria-label={
-                      isCustomSwatch
-                        ? selectedEmoji
-                          ? "Choose custom color"
-                          : "Choose an emoji first"
-                        : `Use ${swatch} background`
-                    }
-                    aria-pressed={isSelected}
-                    className={cn(
-                      "relative h-6 w-6 rounded-full border border-border transition-transform duration-150 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                      isCustomSwatch &&
-                        !selectedEmoji &&
-                        "cursor-not-allowed opacity-45 hover:scale-100 focus-visible:scale-100",
-                    )}
-                    disabled={isCustomSwatch && !selectedEmoji}
-                    key={swatch}
-                    onClick={() => handleColorSelect(swatch)}
-                    style={{
-                      background: isCustomSwatch
-                        ? isSelected
-                          ? selectedColor
-                          : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
-                        : swatch,
-                    }}
-                    type="button"
-                  >
-                    {isSelected ? (
-                      <span
-                        className="absolute inset-0.5 rounded-full border-2"
-                        style={{
-                          borderColor: contrastColorForBackground(
-                            isCustomSwatch ? selectedColor : swatch,
-                          ),
-                        }}
-                      />
-                    ) : null}
-                  </button>
-                );
-              })}
-            </div>
-
-            <AvatarCustomColorPanel
-              colorDraft={customColorDraft}
-              hue={customHue}
-              onCommit={commitCustomColor}
-              onHueChange={setCustomHue}
-              onSaturationValueChange={(nextSaturation, nextValue) => {
-                setCustomSaturation(nextSaturation);
-                setCustomValue(nextValue);
+        <div
+          className={
+            activeTab === "emoji"
+              ? "relative grid content-start gap-3"
+              : "hidden"
+          }
+        >
+          <div
+            className="buzz-emoji-mart relative z-0 h-[280px] overflow-hidden rounded-lg bg-muted"
+            ref={emojiPickerContainerRef}
+            style={emojiMartThemeVars}
+          >
+            <Picker
+              categories={EMOJI_MART_CATEGORIES}
+              data={emojiData}
+              dynamicWidth
+              emojiButtonRadius="999px"
+              emojiButtonSize={44}
+              emojiSize={32}
+              icons="outline"
+              navPosition="bottom"
+              onEmojiSelect={(emoji: EmojiMartEmoji, event?: MouseEvent) => {
+                if (disabled) {
+                  return;
+                }
+                if (!emoji.native) {
+                  return;
+                }
+                const nextColor =
+                  selectedEmoji === null
+                    ? (AVATAR_COLORS[
+                        Math.floor(Math.random() * AVATAR_COLORS.length)
+                      ] ?? DEFAULT_EMOJI_AVATAR_COLOR)
+                    : selectedColor;
+                burstEmoji(emoji.native, event);
+                setSelectedEmoji(emoji.native);
+                setSelectedColor(nextColor);
+                applyEmojiAvatar(emoji.native, nextColor);
               }}
-              saturation={customSaturation}
-              testIdPrefix="agent-avatar"
-              value={customValue}
-              visible={isCustomColorPickerVisible}
+              previewPosition="none"
+              searchPosition="none"
+              set="native"
+              skinTonePosition="none"
+              theme="auto"
             />
-
-            {hasAvatar && onClearAvatar ? (
-              <button
-                className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
-                disabled={disabled}
-                onClick={() => {
-                  onClearAvatar();
-                  setSelectedEmoji(null);
-                  setIsAvatarMenuOpen(false);
-                }}
-                type="button"
-              >
-                Remove avatar
-              </button>
-            ) : null}
           </div>
-        )}
+
+          {/* Color swatches — always visible */}
+          <div className="grid grid-cols-12 justify-items-center gap-1.5 rounded-lg bg-muted p-3">
+            {AVATAR_COLOR_SWATCHES.map((swatch) => {
+              const isCustomSwatch = swatch === CUSTOM_AVATAR_COLOR_SWATCH;
+              const isSelected = isCustomSwatch
+                ? !AVATAR_COLORS.some(
+                    (color) =>
+                      color.toUpperCase() === selectedColor.toUpperCase(),
+                  )
+                : swatch.toUpperCase() === selectedColor.toUpperCase();
+
+              return (
+                <button
+                  aria-label={
+                    isCustomSwatch
+                      ? selectedEmoji
+                        ? "Choose custom color"
+                        : "Choose an emoji first"
+                      : `Use ${swatch} background`
+                  }
+                  aria-pressed={isSelected}
+                  className={cn(
+                    "relative h-6 w-6 rounded-full border border-border transition-transform duration-150 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    isCustomSwatch &&
+                      !selectedEmoji &&
+                      "cursor-not-allowed opacity-45 hover:scale-100 focus-visible:scale-100",
+                  )}
+                  disabled={isCustomSwatch && !selectedEmoji}
+                  key={swatch}
+                  onClick={() => handleColorSelect(swatch)}
+                  style={{
+                    background: isCustomSwatch
+                      ? isSelected
+                        ? selectedColor
+                        : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
+                      : swatch,
+                  }}
+                  type="button"
+                >
+                  {isSelected ? (
+                    <span
+                      className="absolute inset-0.5 rounded-full border-2"
+                      style={{
+                        borderColor: contrastColorForBackground(
+                          isCustomSwatch ? selectedColor : swatch,
+                        ),
+                      }}
+                    />
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+
+          <AvatarCustomColorPanel
+            colorDraft={customColorDraft}
+            hue={customHue}
+            onCommit={commitCustomColor}
+            onHueChange={setCustomHue}
+            onSaturationValueChange={(nextSaturation, nextValue) => {
+              setCustomSaturation(nextSaturation);
+              setCustomValue(nextValue);
+            }}
+            saturation={customSaturation}
+            testIdPrefix="agent-avatar"
+            value={customValue}
+            visible={isCustomColorPickerVisible}
+          />
+
+          {hasAvatar && onClearAvatar ? (
+            <button
+              className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+              disabled={disabled}
+              onClick={() => {
+                onClearAvatar();
+                setSelectedEmoji(null);
+                setIsAvatarMenuOpen(false);
+              }}
+              type="button"
+            >
+              Remove avatar
+            </button>
+          ) : null}
+        </div>
       </fieldset>
     </PopoverContent>
   );
@@ -689,7 +692,7 @@ export function AgentCreationPreview({
                     style={
                       {
                         "--buzz-avatar-emoji-offset-x": "0px",
-                        "--buzz-avatar-emoji-offset-y": "4px",
+                        "--buzz-avatar-emoji-offset-y": "0px",
                       } as React.CSSProperties
                     }
                   >

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -77,6 +77,11 @@ export function AgentCreationPreview({
   const [selectedColor, setSelectedColor] = React.useState(
     DEFAULT_EMOJI_AVATAR_COLOR,
   );
+  // Whether the user has explicitly picked a color swatch (vs. the default).
+  // The color grid is always visible, so a user can choose a background color
+  // before their first emoji — in that case the first emoji must honor the
+  // chosen color instead of a random one.
+  const [hasChosenColor, setHasChosenColor] = React.useState(false);
   const [customHue, setCustomHue] = React.useState(DEFAULT_CUSTOM_HUE);
   const [customSaturation, setCustomSaturation] = React.useState(
     DEFAULT_CUSTOM_SATURATION,
@@ -135,6 +140,7 @@ export function AgentCreationPreview({
       if (parsed) {
         setSelectedEmoji(parsed.emoji);
         setSelectedColor(parsed.color);
+        setHasChosenColor(true);
         setActiveTab("emoji");
       } else {
         // Non-emoji avatar (image/URL or empty): clear any stale emoji
@@ -142,6 +148,7 @@ export function AgentCreationPreview({
         // over the current avatar.
         setSelectedEmoji(null);
         setSelectedColor(DEFAULT_EMOJI_AVATAR_COLOR);
+        setHasChosenColor(false);
         setActiveTab("image");
       }
     }
@@ -192,6 +199,7 @@ export function AgentCreationPreview({
       return;
     }
     setSelectedColor(swatch);
+    setHasChosenColor(true);
     if (selectedEmoji) {
       applyEmojiAvatar(selectedEmoji, swatch);
     }
@@ -207,6 +215,7 @@ export function AgentCreationPreview({
 
   function commitCustomColor() {
     setSelectedColor(customColorDraft);
+    setHasChosenColor(true);
     if (selectedEmoji) {
       applyEmojiAvatar(selectedEmoji, customColorDraft);
     }
@@ -528,7 +537,7 @@ export function AgentCreationPreview({
                     return;
                   }
                   const nextColor =
-                    selectedEmoji === null
+                    selectedEmoji === null && !hasChosenColor
                       ? (AVATAR_COLORS[
                           Math.floor(Math.random() * AVATAR_COLORS.length)
                         ] ?? DEFAULT_EMOJI_AVATAR_COLOR)

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -79,9 +79,10 @@ export function AgentCreationPreview({
   const [customValue, setCustomValue] = React.useState(DEFAULT_CUSTOM_VALUE);
   const [isCustomColorPickerOpen, setIsCustomColorPickerOpen] =
     React.useState(false);
-  const [isImageDropActive, setIsImageDropActive] = React.useState(false);
+  const [isPopoverDragOver, setIsPopoverDragOver] = React.useState(false);
+  const [squishKey, setSquishKey] = React.useState(0);
   const avatarDragDepthRef = React.useRef(0);
-  const imageDragDepthRef = React.useRef(0);
+  const popoverDragDepthRef = React.useRef(0);
   const shouldReduceMotion = useReducedMotion();
   const emojiPickerContainerRef = React.useRef<HTMLDivElement | null>(null);
   const emojiMartThemeVars = useEmojiMartThemeVars();
@@ -119,6 +120,8 @@ export function AgentCreationPreview({
   React.useEffect(() => {
     if (isAvatarMenuOpen) {
       setAvatarUrlDraft("");
+      setIsPopoverDragOver(false);
+      popoverDragDepthRef.current = 0;
 
       const parsed = parseEmojiAvatarDataUrl(avatarUrl ?? "");
       if (parsed) {
@@ -161,6 +164,7 @@ export function AgentCreationPreview({
 
   function applyEmojiAvatar(emoji: string, color = selectedColor) {
     onSelectAvatar(emojiAvatarDataUrl(emoji, color));
+    setSquishKey((key) => key + 1);
   }
 
   function handleColorSelect(swatch: AvatarColorSwatch) {
@@ -204,13 +208,18 @@ export function AgentCreationPreview({
     [avatarEditClipId],
   );
   const hasAvatar = (avatarUrl?.trim().length ?? 0) > 0;
+  const emojiAvatarPreview = React.useMemo(
+    () => parseEmojiAvatarDataUrl(avatarUrl ?? ""),
+    [avatarUrl],
+  );
   const applyButtonTransition = shouldReduceMotion
     ? { duration: 0 }
     : AVATAR_APPLY_MOTION_TRANSITION;
 
+  // Outer avatar drag — only active when popover is closed
   const handleAvatarDragEnter = React.useCallback(
     (event: React.DragEvent<HTMLFieldSetElement>) => {
-      if (disabled || !isAvatarFileDrag(event)) {
+      if (disabled || isAvatarMenuOpen || !isAvatarFileDrag(event)) {
         return;
       }
       event.preventDefault();
@@ -219,12 +228,12 @@ export function AgentCreationPreview({
       event.dataTransfer.dropEffect = "copy";
       setIsDragOverAvatar(true);
     },
-    [disabled],
+    [disabled, isAvatarMenuOpen],
   );
 
   const handleAvatarDragOver = React.useCallback(
     (event: React.DragEvent<HTMLFieldSetElement>) => {
-      if (disabled || !isAvatarFileDrag(event)) {
+      if (disabled || isAvatarMenuOpen || !isAvatarFileDrag(event)) {
         return;
       }
       event.preventDefault();
@@ -232,12 +241,12 @@ export function AgentCreationPreview({
       event.dataTransfer.dropEffect = "copy";
       setIsDragOverAvatar(true);
     },
-    [disabled],
+    [disabled, isAvatarMenuOpen],
   );
 
   const handleAvatarDragLeave = React.useCallback(
     (event: React.DragEvent<HTMLFieldSetElement>) => {
-      if (!isAvatarFileDrag(event)) {
+      if (isAvatarMenuOpen || !isAvatarFileDrag(event)) {
         return;
       }
       event.preventDefault();
@@ -247,18 +256,92 @@ export function AgentCreationPreview({
         setIsDragOverAvatar(false);
       }
     },
-    [],
+    [isAvatarMenuOpen],
   );
 
   const handleAvatarDrop = React.useCallback(
     (event: React.DragEvent<HTMLFieldSetElement>) => {
-      if (!isAvatarFileDrag(event)) {
+      if (isAvatarMenuOpen || !isAvatarFileDrag(event)) {
         return;
       }
       event.preventDefault();
       event.stopPropagation();
       avatarDragDepthRef.current = 0;
       setIsDragOverAvatar(false);
+
+      const file = event.dataTransfer.files[0];
+      if (!file || disabled || isUploading) {
+        return;
+      }
+
+      clearUploadError();
+      void uploadAvatarFile(file);
+    },
+    [
+      clearUploadError,
+      disabled,
+      isAvatarMenuOpen,
+      isUploading,
+      uploadAvatarFile,
+    ],
+  );
+
+  // Popover-level drag — one big drop zone for the entire popover
+  const handlePopoverDragEnter = React.useCallback(
+    (event: React.DragEvent<HTMLElement>) => {
+      if (disabled || !isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      popoverDragDepthRef.current += 1;
+      event.dataTransfer.dropEffect = "copy";
+      setIsPopoverDragOver(true);
+      // Switch to image tab when dragging a file
+      setActiveTab("image");
+    },
+    [disabled],
+  );
+
+  const handlePopoverDragOver = React.useCallback(
+    (event: React.DragEvent<HTMLElement>) => {
+      if (disabled || !isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.dataTransfer.dropEffect = "copy";
+    },
+    [disabled],
+  );
+
+  const handlePopoverDragLeave = React.useCallback(
+    (event: React.DragEvent<HTMLElement>) => {
+      if (!isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      popoverDragDepthRef.current = Math.max(
+        0,
+        popoverDragDepthRef.current - 1,
+      );
+      if (popoverDragDepthRef.current === 0) {
+        setIsPopoverDragOver(false);
+      }
+    },
+    [],
+  );
+
+  const handlePopoverDrop = React.useCallback(
+    (event: React.DragEvent<HTMLElement>) => {
+      if (!isAvatarFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      popoverDragDepthRef.current = 0;
+      setIsPopoverDragOver(false);
 
       const file = event.dataTransfer.files[0];
       if (!file || disabled || isUploading) {
@@ -277,318 +360,274 @@ export function AgentCreationPreview({
   const avatarMenuContent = (
     <PopoverContent
       align="center"
-      className="w-[340px] p-3"
+      className="w-[400px] p-3"
       side="bottom"
       sideOffset={8}
     >
-      <Tabs
-        className="w-full"
-        onValueChange={(tab) => {
-          setActiveTab(tab as AvatarTab);
-          setIsCustomColorPickerOpen(false);
-        }}
-        value={activeTab}
+      {/* Single drop zone covering the entire popover */}
+      <fieldset
+        aria-label="Avatar picker"
+        className="relative m-0 border-0 p-0"
+        onDragEnter={handlePopoverDragEnter}
+        onDragLeave={handlePopoverDragLeave}
+        onDragOver={handlePopoverDragOver}
+        onDrop={handlePopoverDrop}
       >
-        <TabsList className="mb-3 grid h-9 w-full grid-cols-2 rounded-lg bg-muted p-0.5">
-          <TabsTrigger
-            className="h-full rounded-md text-xs font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
-            value="image"
-          >
-            Image
-          </TabsTrigger>
-          <TabsTrigger
-            className="h-full rounded-md text-xs font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
-            value="emoji"
-          >
-            Emoji
-          </TabsTrigger>
-        </TabsList>
-      </Tabs>
-
-      {activeTab === "image" ? (
-        <div className="grid gap-2.5">
-          {/* Drop / browse zone — mini version of profile editor */}
-          <button
-            className={cn(
-              "relative flex h-[80px] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-200 ease-out hover:bg-muted/80 disabled:opacity-60",
-              isImageDropActive &&
-                "border-primary bg-primary/10 text-primary ring-1 ring-primary/35 hover:bg-primary/10",
-            )}
-            disabled={disabled || isUploading}
-            onClick={() => {
-              clearUploadError();
-              openUploadPicker();
-            }}
-            onDragEnter={(event) => {
-              if (disabled || !isAvatarFileDrag(event)) {
-                return;
-              }
-              event.preventDefault();
-              event.stopPropagation();
-              imageDragDepthRef.current += 1;
-              event.dataTransfer.dropEffect = "copy";
-              setIsImageDropActive(true);
-            }}
-            onDragLeave={(event) => {
-              if (!isAvatarFileDrag(event)) {
-                return;
-              }
-              event.preventDefault();
-              event.stopPropagation();
-              imageDragDepthRef.current = Math.max(
-                0,
-                imageDragDepthRef.current - 1,
-              );
-              if (imageDragDepthRef.current === 0) {
-                setIsImageDropActive(false);
-              }
-            }}
-            onDragOver={(event) => {
-              if (disabled || !isAvatarFileDrag(event)) {
-                return;
-              }
-              event.preventDefault();
-              event.stopPropagation();
-              event.dataTransfer.dropEffect = "copy";
-              setIsImageDropActive(true);
-            }}
-            onDrop={(event) => {
-              if (!isAvatarFileDrag(event)) {
-                return;
-              }
-              event.preventDefault();
-              event.stopPropagation();
-              imageDragDepthRef.current = 0;
-              setIsImageDropActive(false);
-              const file = event.dataTransfer.files[0];
-              if (!file || disabled || isUploading) {
-                return;
-              }
-              clearUploadError();
-              void uploadAvatarFile(file);
-            }}
-            type="button"
-          >
-            {isUploading ? (
-              <Spinner
-                aria-hidden
-                className="h-5 w-5 border-2 text-muted-foreground"
-              />
-            ) : (
-              <UploadCloud
-                className={cn(
-                  "h-5 w-5 text-muted-foreground transition-colors duration-200 ease-out",
-                  isImageDropActive && "text-primary",
-                )}
-              />
-            )}
-            <span
-              className={cn(
-                "text-xs font-medium text-muted-foreground transition-colors duration-200 ease-out",
-                isImageDropActive && "text-primary",
-              )}
-            >
-              {isUploading
-                ? "Uploading..."
-                : isImageDropActive
-                  ? "Drop image here"
-                  : "Drop or browse"}
+        {/* Full-popover drop overlay */}
+        {isPopoverDragOver ? (
+          <div className="absolute inset-0 z-50 flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-primary bg-primary/10">
+            <UploadCloud className="h-8 w-8 text-primary" />
+            <span className="text-sm font-medium text-primary">
+              Drop image here
             </span>
-          </button>
+          </div>
+        ) : null}
 
-          {/* URL input — same style as profile editor */}
-          <div className="flex h-10 items-center gap-2.5 rounded-lg bg-muted px-3">
-            <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            <input
-              autoCapitalize="none"
-              autoCorrect="off"
-              className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground"
+        <Tabs
+          className="w-full"
+          onValueChange={(tab) => {
+            setActiveTab(tab as AvatarTab);
+            setIsCustomColorPickerOpen(false);
+          }}
+          value={activeTab}
+        >
+          <TabsList className="mb-3 grid h-9 w-full grid-cols-2 rounded-lg bg-muted p-0.5">
+            <TabsTrigger
+              className="h-full rounded-md text-xs font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
+              value="image"
+            >
+              Image
+            </TabsTrigger>
+            <TabsTrigger
+              className="h-full rounded-md text-xs font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
+              value="emoji"
+            >
+              Emoji
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        {activeTab === "image" ? (
+          <div className="grid gap-2.5">
+            {/* Click to browse zone */}
+            <button
+              className={cn(
+                "relative flex h-[80px] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg border border-transparent bg-muted text-foreground transition-[background-color,border-color,box-shadow,color] duration-200 ease-out hover:bg-muted/80 disabled:opacity-60",
+              )}
               disabled={disabled || isUploading}
-              onBlur={() => applyAvatarUrl()}
-              onChange={(event) => setAvatarUrlDraft(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  applyAvatarUrl();
-                }
+              onClick={() => {
+                clearUploadError();
+                openUploadPicker();
               }}
-              placeholder="Paste a URL"
-              spellCheck={false}
-              type="url"
-              value={avatarUrlDraft}
-            />
-            <AnimatePresence initial={false}>
-              {avatarUrlDraft.trim().length > 0 ? (
-                <motion.div
-                  animate={{ opacity: 1, scale: 1, width: "auto" }}
-                  className="overflow-hidden"
-                  exit={{ opacity: 0, scale: 0.96, width: 0 }}
-                  initial={{ opacity: 0, scale: 0.96, width: 0 }}
-                  key="apply-url"
-                  transition={applyButtonTransition}
-                >
-                  <Button
-                    className="h-6 px-2 text-2xs"
-                    disabled={disabled || isUploading}
-                    onClick={() => applyAvatarUrl()}
-                    size="xs"
+              type="button"
+            >
+              {isUploading ? (
+                <Spinner
+                  aria-hidden
+                  className="h-5 w-5 border-2 text-muted-foreground"
+                />
+              ) : (
+                <UploadCloud className="h-5 w-5 text-muted-foreground" />
+              )}
+              <span className="text-xs font-medium text-muted-foreground">
+                {isUploading ? "Uploading..." : "Drop or browse"}
+              </span>
+            </button>
+
+            {/* URL input — same style as profile editor */}
+            <div className="flex h-10 items-center gap-2.5 rounded-lg bg-muted px-3">
+              <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <input
+                autoCapitalize="none"
+                autoCorrect="off"
+                className="min-w-0 flex-1 bg-transparent text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground"
+                disabled={disabled || isUploading}
+                onBlur={() => applyAvatarUrl()}
+                onChange={(event) => setAvatarUrlDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    applyAvatarUrl();
+                  }
+                }}
+                placeholder="Paste a URL"
+                spellCheck={false}
+                type="url"
+                value={avatarUrlDraft}
+              />
+              <AnimatePresence initial={false}>
+                {avatarUrlDraft.trim().length > 0 ? (
+                  <motion.div
+                    animate={{ opacity: 1, scale: 1, width: "auto" }}
+                    className="overflow-hidden"
+                    exit={{ opacity: 0, scale: 0.96, width: 0 }}
+                    initial={{ opacity: 0, scale: 0.96, width: 0 }}
+                    key="apply-url"
+                    transition={applyButtonTransition}
+                  >
+                    <Button
+                      className="h-6 px-2 text-2xs"
+                      disabled={disabled || isUploading}
+                      onClick={() => applyAvatarUrl()}
+                      size="xs"
+                      type="button"
+                    >
+                      Apply
+                    </Button>
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+            </div>
+
+            {uploadErrorMessage ? (
+              <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive">
+                {uploadErrorMessage}
+              </p>
+            ) : null}
+
+            {hasAvatar && onClearAvatar ? (
+              <button
+                className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+                disabled={disabled || isUploading}
+                onClick={() => {
+                  onClearAvatar();
+                  setIsAvatarMenuOpen(false);
+                }}
+                type="button"
+              >
+                Remove avatar
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          <div className="grid gap-3">
+            {/* Emoji picker */}
+            <div
+              className="buzz-emoji-mart relative z-0 h-[280px] overflow-hidden rounded-lg bg-muted"
+              ref={emojiPickerContainerRef}
+              style={emojiMartThemeVars}
+            >
+              <Picker
+                categories={EMOJI_MART_CATEGORIES}
+                data={emojiData}
+                dynamicWidth
+                emojiButtonRadius="999px"
+                emojiButtonSize={44}
+                emojiSize={32}
+                icons="outline"
+                navPosition="bottom"
+                onEmojiSelect={(emoji: EmojiMartEmoji, event?: MouseEvent) => {
+                  if (disabled) {
+                    return;
+                  }
+                  if (!emoji.native) {
+                    return;
+                  }
+                  const nextColor =
+                    selectedEmoji === null
+                      ? (AVATAR_COLORS[
+                          Math.floor(Math.random() * AVATAR_COLORS.length)
+                        ] ?? DEFAULT_EMOJI_AVATAR_COLOR)
+                      : selectedColor;
+                  burstEmoji(emoji.native, event);
+                  setSelectedEmoji(emoji.native);
+                  setSelectedColor(nextColor);
+                  applyEmojiAvatar(emoji.native, nextColor);
+                }}
+                previewPosition="none"
+                searchPosition="none"
+                set="native"
+                skinTonePosition="none"
+                theme="auto"
+              />
+            </div>
+
+            {/* Color swatches — always visible */}
+            <div className="grid grid-cols-12 justify-items-center gap-1.5 rounded-lg bg-muted p-3">
+              {AVATAR_COLOR_SWATCHES.map((swatch) => {
+                const isCustomSwatch = swatch === CUSTOM_AVATAR_COLOR_SWATCH;
+                const isSelected = isCustomSwatch
+                  ? !AVATAR_COLORS.some(
+                      (color) =>
+                        color.toUpperCase() === selectedColor.toUpperCase(),
+                    )
+                  : swatch.toUpperCase() === selectedColor.toUpperCase();
+
+                return (
+                  <button
+                    aria-label={
+                      isCustomSwatch
+                        ? selectedEmoji
+                          ? "Choose custom color"
+                          : "Choose an emoji first"
+                        : `Use ${swatch} background`
+                    }
+                    aria-pressed={isSelected}
+                    className={cn(
+                      "relative h-6 w-6 rounded-full border border-border transition-transform duration-150 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      isCustomSwatch &&
+                        !selectedEmoji &&
+                        "cursor-not-allowed opacity-45 hover:scale-100 focus-visible:scale-100",
+                    )}
+                    disabled={isCustomSwatch && !selectedEmoji}
+                    key={swatch}
+                    onClick={() => handleColorSelect(swatch)}
+                    style={{
+                      background: isCustomSwatch
+                        ? isSelected
+                          ? selectedColor
+                          : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
+                        : swatch,
+                    }}
                     type="button"
                   >
-                    Apply
-                  </Button>
-                </motion.div>
-              ) : null}
-            </AnimatePresence>
-          </div>
+                    {isSelected ? (
+                      <span
+                        className="absolute inset-0.5 rounded-full border-2"
+                        style={{
+                          borderColor: contrastColorForBackground(
+                            isCustomSwatch ? selectedColor : swatch,
+                          ),
+                        }}
+                      />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
 
-          {uploadErrorMessage ? (
-            <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive">
-              {uploadErrorMessage}
-            </p>
-          ) : null}
-
-          {hasAvatar && onClearAvatar ? (
-            <button
-              className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
-              disabled={disabled || isUploading}
-              onClick={() => {
-                onClearAvatar();
-                setIsAvatarMenuOpen(false);
+            <AvatarCustomColorPanel
+              colorDraft={customColorDraft}
+              hue={customHue}
+              onCommit={commitCustomColor}
+              onHueChange={setCustomHue}
+              onSaturationValueChange={(nextSaturation, nextValue) => {
+                setCustomSaturation(nextSaturation);
+                setCustomValue(nextValue);
               }}
-              type="button"
-            >
-              Remove avatar
-            </button>
-          ) : null}
-        </div>
-      ) : (
-        <div className="grid gap-3">
-          {/* Emoji picker */}
-          <div
-            className="buzz-emoji-mart relative z-0 h-[240px] overflow-hidden rounded-lg bg-muted"
-            ref={emojiPickerContainerRef}
-            style={emojiMartThemeVars}
-          >
-            <Picker
-              categories={EMOJI_MART_CATEGORIES}
-              data={emojiData}
-              dynamicWidth
-              emojiButtonRadius="999px"
-              emojiButtonSize={44}
-              emojiSize={32}
-              icons="outline"
-              navPosition="bottom"
-              onEmojiSelect={(emoji: EmojiMartEmoji, event?: MouseEvent) => {
-                if (disabled) {
-                  return;
-                }
-                if (!emoji.native) {
-                  return;
-                }
-                const nextColor =
-                  selectedEmoji === null
-                    ? (AVATAR_COLORS[
-                        Math.floor(Math.random() * AVATAR_COLORS.length)
-                      ] ?? DEFAULT_EMOJI_AVATAR_COLOR)
-                    : selectedColor;
-                burstEmoji(emoji.native, event);
-                setSelectedEmoji(emoji.native);
-                setSelectedColor(nextColor);
-                applyEmojiAvatar(emoji.native, nextColor);
-              }}
-              previewPosition="none"
-              searchPosition="none"
-              set="native"
-              skinTonePosition="none"
-              theme="auto"
+              saturation={customSaturation}
+              testIdPrefix="agent-avatar"
+              value={customValue}
+              visible={isCustomColorPickerVisible}
             />
+
+            {hasAvatar && onClearAvatar ? (
+              <button
+                className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+                disabled={disabled}
+                onClick={() => {
+                  onClearAvatar();
+                  setSelectedEmoji(null);
+                  setIsAvatarMenuOpen(false);
+                }}
+                type="button"
+              >
+                Remove avatar
+              </button>
+            ) : null}
           </div>
-
-          {/* Color swatches — always visible */}
-          <div className="grid grid-cols-8 justify-items-center gap-2 rounded-lg bg-muted p-3">
-            {AVATAR_COLOR_SWATCHES.map((swatch) => {
-              const isCustomSwatch = swatch === CUSTOM_AVATAR_COLOR_SWATCH;
-              const isSelected = isCustomSwatch
-                ? !AVATAR_COLORS.some(
-                    (color) =>
-                      color.toUpperCase() === selectedColor.toUpperCase(),
-                  )
-                : swatch.toUpperCase() === selectedColor.toUpperCase();
-
-              return (
-                <button
-                  aria-label={
-                    isCustomSwatch
-                      ? selectedEmoji
-                        ? "Choose custom color"
-                        : "Choose an emoji first"
-                      : `Use ${swatch} background`
-                  }
-                  aria-pressed={isSelected}
-                  className={cn(
-                    "relative h-7 w-7 rounded-full border border-border transition-transform duration-150 ease-out hover:scale-[1.15] focus-visible:scale-[1.15] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    isCustomSwatch &&
-                      !selectedEmoji &&
-                      "cursor-not-allowed opacity-45 hover:scale-100 focus-visible:scale-100",
-                  )}
-                  disabled={isCustomSwatch && !selectedEmoji}
-                  key={swatch}
-                  onClick={() => handleColorSelect(swatch)}
-                  style={{
-                    background: isCustomSwatch
-                      ? isSelected
-                        ? selectedColor
-                        : "conic-gradient(from 0deg, #ff4d4d, #ffe75c, #73ef75, #63c6f2, #b141ff, #ff4d4d)"
-                      : swatch,
-                  }}
-                  type="button"
-                >
-                  {isSelected ? (
-                    <span
-                      className="absolute inset-0.5 rounded-full border-2"
-                      style={{
-                        borderColor: contrastColorForBackground(
-                          isCustomSwatch ? selectedColor : swatch,
-                        ),
-                      }}
-                    />
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-
-          <AvatarCustomColorPanel
-            colorDraft={customColorDraft}
-            hue={customHue}
-            onCommit={commitCustomColor}
-            onHueChange={setCustomHue}
-            onSaturationValueChange={(nextSaturation, nextValue) => {
-              setCustomSaturation(nextSaturation);
-              setCustomValue(nextValue);
-            }}
-            saturation={customSaturation}
-            testIdPrefix="agent-avatar"
-            value={customValue}
-            visible={isCustomColorPickerVisible}
-          />
-
-          {hasAvatar && onClearAvatar ? (
-            <button
-              className="flex min-h-8 w-full items-center justify-center rounded-lg text-xs text-destructive outline-hidden transition-colors duration-150 ease-out hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
-              disabled={disabled}
-              onClick={() => {
-                onClearAvatar();
-                setSelectedEmoji(null);
-                setIsAvatarMenuOpen(false);
-              }}
-              type="button"
-            >
-              Remove avatar
-            </button>
-          ) : null}
-        </div>
-      )}
+        )}
+      </fieldset>
     </PopoverContent>
   );
 
@@ -599,6 +638,7 @@ export function AgentCreationPreview({
         className={cn(
           "group/avatar-preview relative m-0 flex min-h-[190px] min-w-0 flex-col items-center justify-center gap-3 rounded-xl border border-transparent p-0 transition-[background-color,border-color,box-shadow] duration-150",
           isDragOverAvatar &&
+            !isAvatarMenuOpen &&
             "border-dashed border-primary/70 bg-primary/5 ring-2 ring-primary/15",
         )}
         onDragEnter={handleAvatarDragEnter}
@@ -637,14 +677,37 @@ export function AgentCreationPreview({
               </svg>
 
               <div className="relative h-full w-full" style={avatarClipStyle}>
-                <ProfileAvatar
-                  avatarUrl={avatarUrl}
-                  className={cn(
-                    "h-full w-full text-4xl transition-shadow duration-150",
-                    isDragOverAvatar && "ring-2 ring-primary/30",
-                  )}
-                  label={label}
-                />
+                {emojiAvatarPreview ? (
+                  <div
+                    aria-label={`${label} avatar`}
+                    className="relative flex h-full w-full shrink-0 items-center justify-center overflow-hidden rounded-full shadow-xs transition-[background-color] duration-200 ease-out"
+                    role="img"
+                    style={{
+                      backgroundColor: emojiAvatarPreview.color,
+                    }}
+                  >
+                    <span
+                      className={cn(
+                        "buzz-avatar-emoji-glyph flex h-full w-full items-center justify-center text-[4rem] leading-none",
+                        squishKey > 0 && "buzz-avatar-squish",
+                      )}
+                      key={squishKey}
+                    >
+                      {emojiAvatarPreview.emoji}
+                    </span>
+                  </div>
+                ) : (
+                  <ProfileAvatar
+                    avatarUrl={avatarUrl}
+                    className={cn(
+                      "h-full w-full text-4xl transition-shadow duration-150",
+                      isDragOverAvatar &&
+                        !isAvatarMenuOpen &&
+                        "ring-2 ring-primary/30",
+                    )}
+                    label={label}
+                  />
+                )}
               </div>
 
               <div className="absolute bottom-0 right-0 z-10 flex h-[42px] w-[42px] items-center justify-center rounded-full bg-background">
@@ -682,6 +745,7 @@ export function AgentCreationPreview({
                   className={cn(
                     "flex h-full w-full items-center justify-center rounded-full border-2 border-dashed border-border bg-background text-primary shadow-xs transition-[background-color,border-color,color,box-shadow] duration-150 ease-out hover:border-primary/50 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-70",
                     isDragOverAvatar &&
+                      !isAvatarMenuOpen &&
                       "border-primary/70 bg-primary/5 ring-2 ring-primary/15",
                   )}
                   disabled={disabled || isUploading}

--- a/desktop/src/features/agents/ui/managedAgentAvatar.test.mjs
+++ b/desktop/src/features/agents/ui/managedAgentAvatar.test.mjs
@@ -21,6 +21,16 @@ test("resolveManagedAgentAvatarUrl uploads data image URIs", async () => {
   assert.equal(uploaded, "https://relay.example/avatar.png");
 });
 
+test("resolveManagedAgentAvatarUrl passes emoji svg data URLs through", async () => {
+  const emojiUrl =
+    "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3C%2Fsvg%3E";
+  const uploaded = await resolveManagedAgentAvatarUrl(emojiUrl, async () => {
+    throw new Error("should not upload inline emoji svg data URLs");
+  });
+
+  assert.equal(uploaded, emojiUrl);
+});
+
 test("resolveManagedAgentAvatarUrl passes non-data URLs through", async () => {
   const uploaded = await resolveManagedAgentAvatarUrl(
     " https://relay.example/already-hosted.png ",

--- a/desktop/src/features/agents/ui/managedAgentAvatar.ts
+++ b/desktop/src/features/agents/ui/managedAgentAvatar.ts
@@ -21,6 +21,14 @@ export async function resolveManagedAgentAvatarUrl(
     return resolvedAvatarUrl;
   }
 
+  // Emoji avatars are stored as inline, percent-encoded SVG data URLs
+  // (`data:image/svg+xml,%3C...`) — the same self-contained form profile
+  // persists. They are not base64 and must not be run through `atob`/upload;
+  // pass them through unchanged so the emoji survives agent creation.
+  if (!isBase64DataUri(resolvedAvatarUrl)) {
+    return resolvedAvatarUrl;
+  }
+
   try {
     const [, b64] = resolvedAvatarUrl.split(",", 2);
     if (!b64) {
@@ -37,6 +45,11 @@ export async function resolveManagedAgentAvatarUrl(
 async function defaultUploadMediaBytes(data: number[], filename?: string) {
   const { uploadMediaBytes } = await import("@/shared/api/tauri");
   return uploadMediaBytes(data, filename);
+}
+
+function isBase64DataUri(dataUri: string) {
+  const header = dataUri.slice(0, dataUri.indexOf(","));
+  return header.includes(";base64");
 }
 
 function safeFallbackAvatarUrl(avatarUrl: string | null | undefined) {

--- a/desktop/src/features/profile/ui/ProfileAvatarEditor.utils.ts
+++ b/desktop/src/features/profile/ui/ProfileAvatarEditor.utils.ts
@@ -430,6 +430,86 @@ export function dataTransferHasImage(dataTransfer: DataTransfer | null) {
   );
 }
 
+function normalizedWheelDeltaY(event: WheelEvent, scrollElement: HTMLElement) {
+  if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+    return event.deltaY * 16;
+  }
+
+  if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+    return event.deltaY * scrollElement.clientHeight;
+  }
+
+  return event.deltaY;
+}
+
+function clampScrollTop(scrollElement: HTMLElement, scrollTop: number) {
+  const maxScrollTop = Math.max(
+    0,
+    scrollElement.scrollHeight - scrollElement.clientHeight,
+  );
+  return Math.max(0, Math.min(maxScrollTop, scrollTop));
+}
+
+// Wheel events are retargeted to the emoji-mart host outside its shadow root,
+// so the browser does not reliably apply the default scroll to `.scroll`.
+function installEmojiMartWheelScroll(shadowRoot: ShadowRoot) {
+  let removeWheelListener: (() => void) | null = null;
+  let currentScrollElement: HTMLElement | null = null;
+
+  function connectScrollElement() {
+    const nextScrollElement = shadowRoot.querySelector<HTMLElement>(".scroll");
+
+    if (nextScrollElement === currentScrollElement) {
+      return;
+    }
+
+    removeWheelListener?.();
+    currentScrollElement = nextScrollElement;
+
+    if (!nextScrollElement) {
+      removeWheelListener = null;
+      return;
+    }
+
+    const handleWheel = (event: WheelEvent) => {
+      if (event.defaultPrevented || event.ctrlKey || event.deltaY === 0) {
+        return;
+      }
+
+      const deltaY = normalizedWheelDeltaY(event, nextScrollElement);
+      const nextScrollTop = clampScrollTop(
+        nextScrollElement,
+        nextScrollElement.scrollTop + deltaY,
+      );
+
+      if (nextScrollTop === nextScrollElement.scrollTop) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      nextScrollElement.scrollTop = nextScrollTop;
+    };
+
+    nextScrollElement.addEventListener("wheel", handleWheel, {
+      passive: false,
+    });
+    removeWheelListener = () => {
+      nextScrollElement.removeEventListener("wheel", handleWheel);
+    };
+  }
+
+  connectScrollElement();
+
+  const observer = new MutationObserver(connectScrollElement);
+  observer.observe(shadowRoot, { childList: true, subtree: true });
+
+  return () => {
+    observer.disconnect();
+    removeWheelListener?.();
+  };
+}
+
 export function useEmojiMartStyles(
   containerRef: React.RefObject<HTMLDivElement | null>,
   enabled: boolean,
@@ -440,6 +520,7 @@ export function useEmojiMartStyles(
     }
 
     let animationFrame = 0;
+    let removeWheelScroll: (() => void) | null = null;
 
     const installEmojiMartStyles = () => {
       const host = containerRef.current?.querySelector("em-emoji-picker");
@@ -456,12 +537,15 @@ export function useEmojiMartStyles(
         style.textContent = EMOJI_MART_SHADOW_CSS;
         shadowRoot.appendChild(style);
       }
+
+      removeWheelScroll ??= installEmojiMartWheelScroll(shadowRoot);
     };
 
     animationFrame = window.requestAnimationFrame(installEmojiMartStyles);
 
     return () => {
       window.cancelAnimationFrame(animationFrame);
+      removeWheelScroll?.();
     };
   }, [containerRef, enabled]);
 }

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -230,6 +230,49 @@ test("built-in personas are used from the catalog dialog", async ({ page }) => {
   await expect.poll(() => getCatalogOrder(page)).toEqual(initialCatalogOrder);
 });
 
+test("agent avatar emoji picker scrolls inside its popover", async ({
+  page,
+}) => {
+  await gotoApp(page);
+  await page.getByTestId("open-agents-view").click();
+  await page.getByTestId("new-agent-card").click();
+  await page.getByRole("menuitem", { name: "New agent" }).click();
+
+  await expect(page.getByTestId("persona-dialog")).toBeVisible();
+  await page.getByLabel("Add avatar").click();
+  await page.getByRole("tab", { name: "Emoji" }).click();
+  await expect(page.locator("em-emoji-picker")).toBeVisible();
+
+  await page.waitForFunction(() => {
+    const picker = document.querySelector("em-emoji-picker");
+    const scroll = picker?.shadowRoot?.querySelector(".scroll");
+    return (
+      scroll instanceof HTMLElement && scroll.scrollHeight > scroll.clientHeight
+    );
+  });
+
+  const before = await page.locator("em-emoji-picker").evaluate((picker) => {
+    const scroll = picker.shadowRoot?.querySelector(".scroll");
+    return scroll instanceof HTMLElement ? scroll.scrollTop : -1;
+  });
+
+  const box = await page.locator("em-emoji-picker").boundingBox();
+  if (!box) {
+    throw new Error("Could not measure emoji picker bounds.");
+  }
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(0, 500);
+
+  await expect
+    .poll(async () =>
+      page.locator("em-emoji-picker").evaluate((picker) => {
+        const scroll = picker.shadowRoot?.querySelector(".scroll");
+        return scroll instanceof HTMLElement ? scroll.scrollTop : -1;
+      }),
+    )
+    .toBeGreaterThan(before);
+});
+
 test("agent catalog can reopen from the populated library header", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

Adds an **emoji avatar picker** to the agent creation/edit avatar popover, alongside the existing image-upload flow, and makes the emoji grid reliably scrollable inside the popover.

Selecting an emoji renders a centered glyph on a colored circle (with a matched pencil-badge mask), and the color can be tuned from the swatch row or a custom color panel.

## Screenshots

**Filled emoji avatar** — centered glyph on a colored circle with the masked pencil badge:

![avatar preview](https://raw.githubusercontent.com/block/buzz/fed6a8d6fc067fbc771879b6a73be143afbff23a/emoji-avatar--05-avatar-preview.png)

**Emoji tab** — scrollable picker + compact 12-column color swatches:

![emoji tab](https://raw.githubusercontent.com/block/buzz/fed6a8d6fc067fbc771879b6a73be143afbff23a/emoji-avatar--02-emoji-tab.png)

**After selecting an emoji** — auto-assigned color, custom-color swatch enabled, "Remove avatar":

![emoji selected](https://raw.githubusercontent.com/block/buzz/fed6a8d6fc067fbc771879b6a73be143afbff23a/emoji-avatar--03-emoji-selected.png)

**Image tab** — drop-or-browse zone + URL input, one big popover-wide drop target:

![image tab](https://raw.githubusercontent.com/block/buzz/fed6a8d6fc067fbc771879b6a73be143afbff23a/emoji-avatar--04-image-tab.png)

## Changes

- **AgentCreationPreview.tsx** — Image/Emoji segment control with sliding-pill motion; unified empty/filled states into one `Popover` + stable `PopoverAnchor` (no reposition on select); emoji-tab-gated style injection + conditional Picker mount; centered glyph (zeroed offset) and `MaskedAvatarBadgeFrame` pencil badge.
- **ProfileAvatarEditor.utils.ts** — Shared `useEmojiMartStyles` now installs a manual `wheel` handler on emoji-mart's `.scroll` region. WKWebView retargets wheel events outside the shadow root, so the default scroll never fired; the handler normalizes delta mode, clamps `scrollTop`, and reconnects via `MutationObserver`. Profile benefits too.
- **agents.spec.ts** — E2E regression test that wheels the picker and asserts `scrollTop` increases.
- **check-px-text.mjs** — Allowlist the decorative `text-[4rem]` emoji glyph (matches existing `AvatarStep` / `ProfileSettingsCard` entries).

## Testing

- `tsc --noEmit` ✅ · biome ✅ · `check:px-text` ✅ · `check:file-sizes` ✅
- E2E `agents.spec.ts` — 10/10 pass (incl. new emoji-scroll test)
- Frontend-only change; Rust lint/tests not applicable.
