### PR TITLE
feat(desktop): add "Copy image" to image right-click context menu

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -190,6 +190,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +908,7 @@ name = "buzz-desktop"
 version = "0.3.45"
 dependencies = [
  "anyhow",
+ "arboard",
  "atomic-write-file",
  "audioadapter-buffers",
  "axum",
@@ -904,6 +925,7 @@ dependencies = [
  "earshot",
  "futures-util",
  "hex",
+ "image",
  "infer",
  "keyring",
  "libc",
@@ -985,6 +1007,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1268,6 +1296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1327,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -2351,6 +2394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,6 +2443,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -2857,6 +2912,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3084,6 +3149,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if 1.0.4",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3662,6 +3738,35 @@ dependencies = [
  "tokio",
  "url",
  "xmltree",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -4978,6 +5083,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5599,6 +5714,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -6803,6 +6919,18 @@ name = "protoc-bin-vendored-win32"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -9344,6 +9472,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10633,6 +10775,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -11947,6 +12095,21 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -95,6 +95,8 @@ tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2.3.3"
 uuid = { version = "1", features = ["v4"] }
 png = "0.18"
+arboard = "3"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "gif"] }
 zip = "8"
 sherpa-onnx = "1.12"
 regex = "1"

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -148,6 +148,58 @@ pub async fn fetch_media_bytes(url: String, state: State<'_, AppState>) -> Resul
     Ok(bytes)
 }
 
+/// Copy an image from a relay media URL directly to the system clipboard.
+///
+/// Fetches the image, decodes it to RGBA8, and writes it to the clipboard via
+/// `arboard`. Same SSRF validation, size cap, and content policy as the download
+/// commands above.
+///
+/// `arboard` requires clipboard access on the main thread on macOS, so the
+/// write is dispatched via `run_on_main_thread` and the result is relayed back
+/// through a one-shot channel.
+#[tauri::command]
+pub async fn copy_image_to_clipboard(
+    url: String,
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let relay_base = relay_api_base_url_with_override(&state);
+    validate_download_url(&url, &relay_base)?;
+
+    let bytes = fetch_blob_bytes(&url, &state).await?;
+    detect_and_validate_mime(&bytes)?;
+
+    let img =
+        image::load_from_memory(&bytes).map_err(|e| format!("failed to decode image: {e}"))?;
+    let rgba = img.to_rgba8();
+    let (width, height) = (rgba.width() as usize, rgba.height() as usize);
+    let raw = rgba.into_raw();
+
+    // arboard requires main-thread access on macOS. Use a sync channel so the
+    // async command can await the result.
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Result<(), String>>(1);
+    app.run_on_main_thread(move || {
+        let result = arboard::Clipboard::new()
+            .map_err(|e| format!("clipboard error: {e}"))
+            .and_then(|mut clipboard| {
+                clipboard
+                    .set_image(arboard::ImageData {
+                        width,
+                        height,
+                        bytes: std::borrow::Cow::Owned(raw),
+                    })
+                    .map_err(|e| format!("clipboard error: {e}"))
+            });
+        // Ignore send errors — the receiver dropped only if the command was
+        // cancelled, in which case nobody is waiting for the result.
+        let _ = tx.send(result);
+    })
+    .map_err(|e| format!("main thread dispatch failed: {e}"))?;
+
+    rx.recv()
+        .map_err(|_| "clipboard result channel closed unexpectedly".to_string())?
+}
+
 /// Fetch blob bytes from a (pre-validated) relay media URL through the app's
 /// HTTP client, enforcing the download size cap. The caller is responsible for
 /// validating the URL origin and for any content-type checks on the result.

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -171,6 +171,14 @@ pub async fn copy_image_to_clipboard(
 
     let img =
         image::load_from_memory(&bytes).map_err(|e| format!("failed to decode image: {e}"))?;
+
+    // Guard against decompression bombs: a small compressed file can decode to
+    // a huge RGBA buffer. Cap at 50 MiB (matching the download size cap).
+    let pixels = img.width() as u64 * img.height() as u64;
+    if pixels * 4 > MAX_DOWNLOAD_BYTES {
+        return Err("image too large to copy to clipboard".to_string());
+    }
+
     let rgba = img.to_rgba8();
     let (width, height) = (rgba.width() as usize, rgba.height() as usize);
     let raw = rgba.into_raw();

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -508,6 +508,7 @@ pub fn run() {
             download_image,
             download_file,
             fetch_media_bytes,
+            copy_image_to_clipboard,
             list_relay_members,
             get_my_relay_membership,
             add_relay_member,

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -515,10 +515,12 @@ function useDismissImageContextMenu(isOpen: boolean, onDismiss: () => void) {
   }, [isOpen, onDismiss]);
 }
 
-function ImageDownloadContextMenu({
+function ImageContextMenu({
+  onCopy,
   onDownload,
   position,
 }: {
+  onCopy: () => void;
   onDownload: () => void;
   position: ImageContextMenuPosition;
 }) {
@@ -535,6 +537,13 @@ function ImageDownloadContextMenu({
       <button
         type="button"
         className="flex min-h-9 w-full cursor-default select-none items-center rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden hover:bg-muted/50 hover:text-foreground"
+        onClick={onCopy}
+      >
+        Copy image
+      </button>
+      <button
+        type="button"
+        className="flex min-h-9 w-full cursor-default select-none items-center rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden hover:bg-muted/50 hover:text-foreground"
         onClick={onDownload}
       >
         Download image
@@ -547,6 +556,7 @@ function ImageZoomOverlay({
   alt,
   galleryIndex = 0,
   galleryItems,
+  onCopy,
   onDownload,
   onClose,
   resolvedSrc,
@@ -557,6 +567,7 @@ function ImageZoomOverlay({
   alt: string | undefined;
   galleryIndex?: number;
   galleryItems?: ImageGalleryItem[];
+  onCopy: (src: string | undefined) => void;
   onDownload: (src: string | undefined) => void;
   onClose: () => void;
   resolvedSrc: string;
@@ -1063,6 +1074,11 @@ function ImageZoomOverlay({
     },
     [canDownloadCurrentImage, markControlGesture],
   );
+  const handleMenuCopy = React.useCallback(() => {
+    setMenu(null);
+    markControlGesture();
+    onCopy(currentItem.src);
+  }, [currentItem.src, markControlGesture, onCopy]);
   const handleMenuDownload = React.useCallback(() => {
     setMenu(null);
     markControlGesture();
@@ -1292,7 +1308,8 @@ function ImageZoomOverlay({
         </div>
       </div>
       {menu && canDownloadCurrentImage ? (
-        <ImageDownloadContextMenu
+        <ImageContextMenu
+          onCopy={handleMenuCopy}
           onDownload={handleMenuDownload}
           position={menu}
         />
@@ -1460,6 +1477,19 @@ function ImageBlock({ alt, dim, resolvedSrc, src }: ImageBlockProps) {
     }
   };
 
+  const handleCopyImage = React.useCallback((copySrc: string | undefined) => {
+    setMenu(null);
+    if (!copySrc) return;
+    invokeTauri("copy_image_to_clipboard", { url: copySrc })
+      .then(() => {
+        toast.success("Image copied to clipboard");
+      })
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : "Copy failed";
+        toast.error(msg);
+      });
+  }, []);
+
   const handleDownload = React.useCallback(
     (downloadSrc: string | undefined) => {
       setMenu(null);
@@ -1510,7 +1540,8 @@ function ImageBlock({ alt, dim, resolvedSrc, src }: ImageBlockProps) {
         />
       </button>
       {menu && src ? (
-        <ImageDownloadContextMenu
+        <ImageContextMenu
+          onCopy={() => handleCopyImage(src)}
           onDownload={() => handleDownload(src)}
           position={menu}
         />
@@ -1520,6 +1551,7 @@ function ImageBlock({ alt, dim, resolvedSrc, src }: ImageBlockProps) {
           alt={alt}
           galleryIndex={lightboxState.galleryIndex}
           galleryItems={lightboxState.galleryItems}
+          onCopy={handleCopyImage}
           onDownload={handleDownload}
           onClose={() => setLightboxState(null)}
           resolvedSrc={resolvedSrc}

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -524,6 +524,8 @@ function ImageContextMenu({
   onDownload: () => void;
   position: ImageContextMenuPosition;
 }) {
+  const itemClass =
+    "flex min-h-9 w-full cursor-default select-none items-center rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden hover:bg-muted/50 hover:text-foreground";
   return (
     <div
       className={cn(
@@ -534,18 +536,10 @@ function ImageContextMenu({
       data-image-lightbox-controls=""
       style={{ ...POPOVER_SHADOW_STYLE, left: position.x, top: position.y }}
     >
-      <button
-        type="button"
-        className="flex min-h-9 w-full cursor-default select-none items-center rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden hover:bg-muted/50 hover:text-foreground"
-        onClick={onCopy}
-      >
+      <button type="button" className={itemClass} onClick={onCopy}>
         Copy image
       </button>
-      <button
-        type="button"
-        className="flex min-h-9 w-full cursor-default select-none items-center rounded-lg py-2 pl-2 pr-4 text-sm outline-hidden hover:bg-muted/50 hover:text-foreground"
-        onClick={onDownload}
-      >
+      <button type="button" className={itemClass} onClick={onDownload}>
         Download image
       </button>
     </div>
@@ -620,7 +614,7 @@ function ImageZoomOverlay({
   const zoomIdleTimerRef = React.useRef<number | null>(null);
   const hasPreviousImage = currentIndex > 0;
   const hasNextImage = currentIndex < items.length - 1;
-  const canDownloadCurrentImage = Boolean(currentItem.src);
+  const canActOnCurrentImage = Boolean(currentItem.src);
   useSmoothCorners(imageFrameSurfaceRef);
 
   const galleryTransitionFilter =
@@ -1068,11 +1062,11 @@ function ImageZoomOverlay({
       event.stopPropagation();
       event.nativeEvent.stopImmediatePropagation();
       markControlGesture();
-      if (canDownloadCurrentImage) {
+      if (canActOnCurrentImage) {
         setMenu({ x: event.clientX, y: event.clientY });
       }
     },
-    [canDownloadCurrentImage, markControlGesture],
+    [canActOnCurrentImage, markControlGesture],
   );
   const handleMenuCopy = React.useCallback(() => {
     setMenu(null);
@@ -1259,7 +1253,7 @@ function ImageZoomOverlay({
           <button
             aria-label="Download image"
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors hover:bg-muted-foreground/10 hover:text-foreground outline-hidden focus-visible:ring-2 focus-visible:ring-ring/70 disabled:pointer-events-none disabled:opacity-45"
-            disabled={!canDownloadCurrentImage}
+            disabled={!canActOnCurrentImage}
             type="button"
             onClick={(event) => {
               event.stopPropagation();
@@ -1307,7 +1301,7 @@ function ImageZoomOverlay({
           </span>
         </div>
       </div>
-      {menu && canDownloadCurrentImage ? (
+      {menu && canActOnCurrentImage ? (
         <ImageContextMenu
           onCopy={handleMenuCopy}
           onDownload={handleMenuDownload}
@@ -1482,7 +1476,7 @@ function ImageBlock({ alt, dim, resolvedSrc, src }: ImageBlockProps) {
     if (!copySrc) return;
     invokeTauri("copy_image_to_clipboard", { url: copySrc })
       .then(() => {
-        toast.success("Image copied to clipboard");
+        toast.success("Copied to clipboard");
       })
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : "Copy failed";

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -8619,6 +8619,8 @@ export function maybeInstallE2eTauriMocks() {
         // FileCard / image-menu click handlers resolve. Specs assert the
         // command was invoked via `__BUZZ_E2E_COMMANDS__`, not the dialog.
         return true;
+      case "copy_image_to_clipboard":
+        return;
       case "get_event":
         return handleGetEvent(
           payload as Parameters<typeof handleGetEvent>[0],

--- a/desktop/tests/e2e/image-attachment-gallery.spec.ts
+++ b/desktop/tests/e2e/image-attachment-gallery.spec.ts
@@ -399,3 +399,43 @@ test("forum markdown images use the markdown root as their gallery scope", async
     page.getByRole("button", { name: "Previous image" }),
   ).toBeVisible();
 });
+
+test("right-click image shows Copy image and invokes copy command", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  await page.getByTestId("message-input").fill("copy me");
+  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByTestId("send-message").click();
+  await expect(page.getByText("Sending")).toHaveCount(0);
+
+  const row = page
+    .getByTestId("message-row")
+    .filter({ hasText: "copy me" })
+    .last();
+  const trigger = row.getByTestId("message-image-lightbox-trigger").first();
+  await expect(trigger).toBeVisible();
+
+  await trigger.click({ button: "right" });
+
+  const copyButton = page.getByRole("button", { name: "Copy image" });
+  await expect(copyButton).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Download image" }),
+  ).toBeVisible();
+
+  await copyButton.click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as Window & { __BUZZ_E2E_COMMANDS__?: string[] })
+            .__BUZZ_E2E_COMMANDS__ ?? [],
+      ),
+    )
+    .toContain("copy_image_to_clipboard");
+});


### PR DESCRIPTION
Adds a "Copy image" option to the right-click context menu on images in chat messages, appearing above the existing "Download image" option. Users can now copy an image directly to the clipboard and paste it into the composer in another channel without saving it to disk first.

The web Clipboard API only accepts `image/png` and triggers a macOS system permission prompt in WKWebView, so copy is handled by a new `copy_image_to_clipboard` Tauri command in `media_download.rs`. It reuses the existing SSRF-validated `fetch_blob_bytes` / `validate_download_url` pipeline, decodes to RGBA8 with the `image` crate (JPEG, PNG, WebP, GIF), then writes to the system clipboard via `arboard` dispatched on the main thread. `arboard` handles platform-specific clipboard formats natively: TIFF on macOS, CF_DIB on Windows, PNG on Linux. No image bytes cross IPC — only the relay URL is sent to the command.

- New `copy_image_to_clipboard` Tauri command with the same SSRF/size/MIME security guarantees as `download_image`, plus an RGBA pixel-count cap (50 MiB) to prevent OOM from decompression bombs
- `ImageDownloadContextMenu` renamed to `ImageContextMenu` with `onCopy` prop; menu item className extracted to a shared constant
- `handleCopyImage` wired in both inline thumbnail (`ImageBlock`) and lightbox (`ImageZoomOverlay`) with success/error toasts
- `canDownloadCurrentImage` renamed to `canActOnCurrentImage` to reflect it now gates both actions
- Added `arboard = "3"` and `image = "0.25"` (jpeg/png/webp/gif features) to `desktop/src-tauri/Cargo.toml`
- E2E test added for the copy image context menu item; bridge stub added for the new command