### PR TITLE
fix(desktop): keep sidebar section actions visible while ⋮ menu is open

### DIFF
--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -240,6 +240,7 @@ export function AppSidebar({
   const [isNewDmOpenInternal, setIsNewDmOpenInternal] = React.useState(false);
   const isNewDmOpen = isNewDmOpenProp ?? isNewDmOpenInternal;
   const setIsNewDmOpen = onNewDmOpenChange ?? setIsNewDmOpenInternal;
+  const [dmActionsMenuOpen, setDmActionsMenuOpen] = React.useState(false);
   const scrollRef = React.useRef<HTMLDivElement>(null);
   useSidebarScrollLock(scrollRef);
 
@@ -760,6 +761,7 @@ export function AppSidebar({
                       <SectionActionsMenu
                         sectionLabel="direct messages"
                         testId="section-actions-dms"
+                        onOpenChange={setDmActionsMenuOpen}
                         onNewMessage={() => setIsNewDmOpen(true)}
                         sortMode={sortModeFor("dms")}
                         onSortModeChange={(mode) => setSortModeFor("dms", mode)}
@@ -783,6 +785,7 @@ export function AppSidebar({
                   selectedChannelId={selectedChannelId}
                   testId="dm-list"
                   title="Direct messages"
+                  sectionActionsOpen={dmActionsMenuOpen}
                   unreadChannelCounts={unreadChannelCounts}
                   unreadChannelIds={unreadChannelIds}
                   mutedChannelIds={mutedChannelIds}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -10,7 +10,7 @@ import {
   Trash2,
 } from "lucide-react";
 
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import type * as React from "react";
 
 import type { ChannelSortMode } from "@/features/sidebar/lib/channelSortPreference";
@@ -63,7 +63,7 @@ import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 const SECTION_LABEL_BUTTON_CLASS =
   "group/section-label flex w-fit max-w-[calc(100%-3rem)] cursor-pointer appearance-none items-center gap-1 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
 const SECTION_LABEL_CHEVRON_CLASS =
-  "relative size-2.5 shrink-0 text-current opacity-0 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/section-label:opacity-100 group-focus-within/sidebar-section:opacity-100 group-focus-visible/section-label:opacity-100";
+  "relative size-2.5 shrink-0 text-current opacity-0 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/section-label:opacity-100 group-focus-within/sidebar-section:opacity-100 group-focus-visible/section-label:opacity-100 group-data-[section-actions-open=true]/sidebar-section:opacity-100";
 const SECTION_LABEL_CHEVRON_ICON_CLASS =
   "absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2";
 
@@ -119,6 +119,7 @@ export function SectionActionsMenu({
   sectionLabel,
   testId,
   visibilityClassName = SECTION_ACTION_VISIBILITY_CLASS,
+  onOpenChange,
   hasUnread,
   onMarkAllRead,
   onBrowse,
@@ -139,6 +140,7 @@ export function SectionActionsMenu({
   sectionLabel: string;
   testId?: string;
   visibilityClassName?: string;
+  onOpenChange?: (open: boolean) => void;
   hasUnread?: boolean;
   onMarkAllRead?: () => void;
   onBrowse?: () => void;
@@ -161,7 +163,7 @@ export function SectionActionsMenu({
   const showSort = Boolean(sortMode && onSortModeChange);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
         <button
           aria-label={`More actions for ${sectionLabel}`}
@@ -403,6 +405,7 @@ export function ChannelGroupSection({
   onLeaveChannel?: (channel: Channel) => void;
 }) {
   const contentId = `sidebar-${listTestId}`;
+  const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
 
   const channelList =
     items.length > 0 ? (
@@ -472,6 +475,7 @@ export function ChannelGroupSection({
   const sectionContent = (
     <SidebarGroup
       className={cn("group/sidebar-section select-none", groupClassName)}
+      data-section-actions-open={actionsMenuOpen || undefined}
     >
       <ChannelSectionHeader
         contentId={contentId}
@@ -492,6 +496,7 @@ export function ChannelGroupSection({
             <SectionActionsMenu
               sectionLabel={title}
               testId={actionsTestId}
+              onOpenChange={setActionsMenuOpen}
               hasUnread={hasUnread}
               onMarkAllRead={onMarkAllRead}
               onBrowse={onBrowseClick}
@@ -592,6 +597,7 @@ export function CustomChannelSection({
   onLeaveChannel?: (channel: Channel) => void;
 }) {
   const contentId = `sidebar-section-${section.id}`;
+  const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
 
   return (
     <SortableSectionShell sectionId={section.id}>
@@ -602,6 +608,7 @@ export function CustomChannelSection({
               "group/sidebar-section select-none",
               isDragging && "opacity-30",
             )}
+            data-section-actions-open={actionsMenuOpen || undefined}
           >
             {/* modal={false}: Rename/Delete section open a modal dialog;
                 a modal ContextMenu would leave `pointer-events: none` stuck on
@@ -652,6 +659,7 @@ export function CustomChannelSection({
                     <SectionActionsMenu
                       sectionLabel={section.name}
                       testId={`section-actions-${section.id}`}
+                      onOpenChange={setActionsMenuOpen}
                       hasUnread={hasUnread}
                       onMarkAllRead={onMarkSectionRead}
                       onRenameSection={onRenameSection}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -40,7 +40,7 @@ import {
 const SECTION_LABEL_BUTTON_CLASS =
   "group/section-label flex w-fit max-w-[calc(100%-3rem)] cursor-pointer appearance-none items-center gap-1 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
 const SECTION_LABEL_CHEVRON_CLASS =
-  "relative size-2.5 shrink-0 text-current opacity-0 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/section-label:opacity-100 group-focus-within/sidebar-section:opacity-100 group-focus-visible/section-label:opacity-100";
+  "relative size-2.5 shrink-0 text-current opacity-0 transition-[color,opacity] group-hover/sidebar-section:opacity-100 group-hover/section-label:opacity-100 group-focus-within/sidebar-section:opacity-100 group-focus-visible/section-label:opacity-100 group-data-[section-actions-open=true]/sidebar-section:opacity-100";
 const SECTION_LABEL_CHEVRON_ICON_CLASS =
   "absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2";
 const SIDEBAR_ROW_ACTION_VISIBILITY_CLASS =
@@ -357,6 +357,7 @@ export function SidebarSection({
   mutedChannelIds,
   onMuteChannel,
   onUnmuteChannel,
+  sectionActionsOpen,
 }: {
   action?: React.ReactNode;
   activeWorkingByChannelId?: ReadonlyMap<string, ActiveChannelTurnSummary>;
@@ -383,6 +384,7 @@ export function SidebarSection({
   mutedChannelIds?: ReadonlySet<string>;
   onMuteChannel?: (channelId: string) => void;
   onUnmuteChannel?: (channelId: string) => void;
+  sectionActionsOpen?: boolean;
 }) {
   if (items.length === 0 && !action && !emptyState) {
     return null;
@@ -392,7 +394,10 @@ export function SidebarSection({
   const canToggle = Boolean(onToggleCollapsed);
 
   return (
-    <SidebarGroup className="group/sidebar-section select-none">
+    <SidebarGroup
+      className="group/sidebar-section select-none"
+      data-section-actions-open={sectionActionsOpen || undefined}
+    >
       <div className="relative">
         <SidebarGroupLabel asChild={canToggle}>
           {canToggle ? (

--- a/desktop/src/features/sidebar/ui/sidebarSectionStyles.ts
+++ b/desktop/src/features/sidebar/ui/sidebarSectionStyles.ts
@@ -2,4 +2,4 @@ export const SECTION_ICON_BUTTON_CLASS =
   "flex size-6 items-center justify-center rounded-[4px] p-1 text-sidebar-foreground/50 transition-colors hover:bg-sidebar-border/35 hover:text-sidebar-foreground focus-visible:bg-sidebar-border/35 focus-visible:text-sidebar-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring [&>svg]:size-4 [&>svg]:shrink-0";
 
 export const SECTION_ACTION_VISIBILITY_CLASS =
-  "opacity-0 transition-opacity group-hover/sidebar-section:opacity-100 group-focus-within/sidebar-section:opacity-100";
+  "opacity-0 transition-opacity group-hover/sidebar-section:opacity-100 group-focus-within/sidebar-section:opacity-100 group-data-[section-actions-open=true]/sidebar-section:opacity-100";


### PR DESCRIPTION
## Problem

Sidebar section header controls (the ⋮ actions menu, the quick `+` create button, and the collapse chevron) are only revealed on `group-hover` of the section. Opening the ⋮ popover moves the pointer off the header, ending hover — so all three controls fade to `opacity-0` and an open menu appears to belong to an empty section.

## Fix

Each section now sets `data-section-actions-open` while its ⋮ menu is open, and the reveal classes gain a `group-data-[section-actions-open=true]` variant. The ⋮ trigger, the `+`, and the chevron all stay visible for the whole section (Channels, Forums, Starred, custom sections, and Direct messages) until the menu closes.

## Changes (4 files, +21/−5)

- `sidebarSectionStyles.ts` + `CustomChannelSection.tsx` chevron class — added a `group-data-[section-actions-open=true]` reveal variant.
- `CustomChannelSection.tsx` / `SidebarSection.tsx` / `AppSidebar.tsx` — each section tracks its ⋮ menu open state and sets `data-section-actions-open` on the section root.

## Verification

Desktop `tsc`, `biome check`, and `check:px-text` all clean on this diff. Verified in a staging build: opening any section's ⋮ menu keeps the header controls visible.

> Note: `just ci`'s `desktop-tauri-clippy` step is red from a pre-existing clippy 1.95.0 regression on files this PR does not touch (`archive/mod_tests.rs`, `personas/writeback.rs`, `claude.rs`) — identical to `origin/main`, not introduced here.
