### PR TITLE
feat(db): implement community moderation persistence

### DIFF
--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -2203,6 +2203,15 @@ impl Db {
         moderation::get_report(&self.pool, community, report_id).await
     }
 
+    /// Fetch one moderation report by signed NIP-56 report event id.
+    pub async fn get_moderation_report_by_event(
+        &self,
+        community: CommunityId,
+        report_event_id: &[u8],
+    ) -> Result<Option<moderation::ReportRecord>> {
+        moderation::get_report_by_event(&self.pool, community, report_event_id).await
+    }
+
     /// Resolve, dismiss, or escalate an open moderation report.
     pub async fn resolve_moderation_report(
         &self,

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -2175,6 +2175,142 @@ impl Db {
         relay_members::backfill_from_allowlist(&self.pool, community).await
     }
 
+    /// Insert a tenant-scoped NIP-56 report row, idempotent by report event id.
+    pub async fn insert_moderation_report(
+        &self,
+        community: CommunityId,
+        report: moderation::NewReport<'_>,
+    ) -> Result<Uuid> {
+        moderation::insert_report(&self.pool, community, report).await
+    }
+
+    /// List moderation reports for a community, newest first.
+    pub async fn list_moderation_reports(
+        &self,
+        community: CommunityId,
+        status: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<moderation::ReportRecord>> {
+        moderation::list_reports(&self.pool, community, status, limit).await
+    }
+
+    /// Fetch one moderation report by row id.
+    pub async fn get_moderation_report(
+        &self,
+        community: CommunityId,
+        report_id: Uuid,
+    ) -> Result<Option<moderation::ReportRecord>> {
+        moderation::get_report(&self.pool, community, report_id).await
+    }
+
+    /// Resolve, dismiss, or escalate an open moderation report.
+    pub async fn resolve_moderation_report(
+        &self,
+        community: CommunityId,
+        report_id: Uuid,
+        status: &str,
+        resolved_by: &[u8],
+        action_id: Option<Uuid>,
+    ) -> Result<bool> {
+        moderation::resolve_report(
+            &self.pool,
+            community,
+            report_id,
+            status,
+            resolved_by,
+            action_id,
+        )
+        .await
+    }
+
+    /// Upsert a community ban for a member pubkey.
+    pub async fn ban_community_member(
+        &self,
+        community: CommunityId,
+        pubkey: &[u8],
+        actor: &[u8],
+        reason: Option<&str>,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<()> {
+        moderation::ban_member(&self.pool, community, pubkey, actor, reason, expires_at).await
+    }
+
+    /// Lift a community ban for a member pubkey.
+    pub async fn unban_community_member(
+        &self,
+        community: CommunityId,
+        pubkey: &[u8],
+        actor: &[u8],
+    ) -> Result<bool> {
+        moderation::unban_member(&self.pool, community, pubkey, actor).await
+    }
+
+    /// Upsert a community timeout/write-block for a member pubkey.
+    pub async fn timeout_community_member(
+        &self,
+        community: CommunityId,
+        pubkey: &[u8],
+        actor: &[u8],
+        muted_until: DateTime<Utc>,
+        reason: Option<&str>,
+    ) -> Result<()> {
+        moderation::timeout_member(&self.pool, community, pubkey, actor, muted_until, reason).await
+    }
+
+    /// Clear a community timeout/write-block for a member pubkey.
+    pub async fn untimeout_community_member(
+        &self,
+        community: CommunityId,
+        pubkey: &[u8],
+        actor: &[u8],
+    ) -> Result<bool> {
+        moderation::untimeout_member(&self.pool, community, pubkey, actor).await
+    }
+
+    /// Fetch the active ban/timeout restriction state for enforcement hot paths.
+    pub async fn moderation_restriction_state(
+        &self,
+        community: CommunityId,
+        pubkey: &[u8],
+    ) -> Result<moderation::RestrictionState> {
+        moderation::restriction_state(&self.pool, community, pubkey).await
+    }
+
+    /// Fetch the full ban/timeout row for a member pubkey.
+    pub async fn get_community_ban(
+        &self,
+        community: CommunityId,
+        pubkey: &[u8],
+    ) -> Result<Option<moderation::BanRecord>> {
+        moderation::get_ban(&self.pool, community, pubkey).await
+    }
+
+    /// List currently restricted members in a community.
+    pub async fn list_community_restrictions(
+        &self,
+        community: CommunityId,
+    ) -> Result<Vec<moderation::BanRecord>> {
+        moderation::list_restricted(&self.pool, community).await
+    }
+
+    /// Insert a moderation audit action row.
+    pub async fn insert_moderation_action(
+        &self,
+        community: CommunityId,
+        action: moderation::NewAction<'_>,
+    ) -> Result<Uuid> {
+        moderation::insert_action(&self.pool, community, action).await
+    }
+
+    /// List moderation audit action rows, newest first.
+    pub async fn list_moderation_actions(
+        &self,
+        community: CommunityId,
+        limit: i64,
+    ) -> Result<Vec<moderation::ActionRecord>> {
+        moderation::list_actions(&self.pool, community, limit).await
+    }
+
     /// Return the current owner of git repo name `repo_id` in `community`, or
     /// `None` if unreserved. See [`git_repo::repo_name_owner`].
     pub async fn repo_name_owner(

--- a/crates/buzz-db/src/moderation.rs
+++ b/crates/buzz-db/src/moderation.rs
@@ -242,6 +242,29 @@ pub async fn get_report(
     row.map(row_to_report).transpose()
 }
 
+/// Fetch one report by signed NIP-56 report event id.
+pub async fn get_report_by_event(
+    pool: &PgPool,
+    community: CommunityId,
+    report_event_id: &[u8],
+) -> Result<Option<ReportRecord>> {
+    let row = sqlx::query(
+        r#"
+        SELECT id, report_event_id, reporter_pubkey, target_kind, target_event_id,
+               target_pubkey, target_blob_sha256, channel_id, report_type, note,
+               status, resolved_by, resolved_at, action_id, created_at
+        FROM moderation_reports
+        WHERE community_id = $1 AND report_event_id = $2
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(report_event_id)
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_report).transpose()
+}
+
 /// Mark a report resolved/dismissed/escalated, linking the audit action.
 /// Returns `false` if the report was not found or already closed.
 pub async fn resolve_report(
@@ -795,6 +818,14 @@ mod tests {
             .await
             .expect("get report")
             .expect("report exists");
+        let row_by_event = get_report_by_event(&pool, community, &report_event_id)
+            .await
+            .expect("get report by event id")
+            .expect("report exists by event id");
+        assert_eq!(
+            row_by_event.id, first_id,
+            "report event id lookup must return the same row"
+        );
         assert_eq!(
             row.status, "resolved",
             "re-ingest must not reopen the report"

--- a/crates/buzz-db/src/moderation.rs
+++ b/crates/buzz-db/src/moderation.rs
@@ -15,7 +15,7 @@
 //! through the integration thread.
 
 use chrono::{DateTime, Utc};
-use sqlx::PgPool;
+use sqlx::{PgPool, Row as _};
 use uuid::Uuid;
 
 use crate::error::Result;
@@ -144,6 +144,8 @@ pub struct ActionRecord {
     pub public_reason: Option<String>,
     /// Mod-only reason.
     pub private_reason: Option<String>,
+    /// NIP-OA principal matched by enforcement, when relevant.
+    pub matched_principal: Option<String>,
     /// Action time.
     pub created_at: DateTime<Utc>,
 }
@@ -151,88 +153,234 @@ pub struct ActionRecord {
 /// Insert a new report row. Idempotent on `(community, report_event_id)`:
 /// re-ingesting the same signed report is a no-op returning the existing id.
 pub async fn insert_report(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _report: NewReport<'_>,
+    pool: &PgPool,
+    community: CommunityId,
+    report: NewReport<'_>,
 ) -> Result<Uuid> {
-    todo!("L1 (Max): INSERT ... ON CONFLICT (community_id, report_event_id) DO NOTHING + return id")
+    let (target_kind, target_event_id, target_pubkey, target_blob_sha256) = match &report.target {
+        ReportTarget::Event(id) => ("event", Some(id.as_slice()), None, None),
+        ReportTarget::Pubkey(pubkey) => ("pubkey", None, Some(pubkey.as_slice()), None),
+        ReportTarget::Blob(sha256) => ("blob", None, None, Some(sha256.as_slice())),
+    };
+
+    let row = sqlx::query(
+        r#"
+        INSERT INTO moderation_reports (
+            community_id, report_event_id, reporter_pubkey, target_kind,
+            target_event_id, target_pubkey, target_blob_sha256, channel_id,
+            report_type, note
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ON CONFLICT (community_id, report_event_id) DO UPDATE SET
+            report_event_id = EXCLUDED.report_event_id
+        RETURNING id
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(report.report_event_id)
+    .bind(report.reporter_pubkey)
+    .bind(target_kind)
+    .bind(target_event_id)
+    .bind(target_pubkey)
+    .bind(target_blob_sha256)
+    .bind(report.channel_id)
+    .bind(report.report_type)
+    .bind(report.note)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(row.try_get("id")?)
 }
 
 /// List reports for the moderation queue, newest first.
 /// `status = None` lists all; `Some("open")` etc. filters.
 pub async fn list_reports(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _status: Option<&str>,
-    _limit: i64,
+    pool: &PgPool,
+    community: CommunityId,
+    status: Option<&str>,
+    limit: i64,
 ) -> Result<Vec<ReportRecord>> {
-    todo!("L1 (Max)")
+    let rows = sqlx::query(
+        r#"
+        SELECT id, report_event_id, reporter_pubkey, target_kind, target_event_id,
+               target_pubkey, target_blob_sha256, channel_id, report_type, note,
+               status, resolved_by, resolved_at, action_id, created_at
+        FROM moderation_reports
+        WHERE community_id = $1 AND ($2::text IS NULL OR status = $2)
+        ORDER BY created_at DESC
+        LIMIT $3
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(status)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_report).collect()
 }
 
 /// Fetch one report by row id.
 pub async fn get_report(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _report_id: Uuid,
+    pool: &PgPool,
+    community: CommunityId,
+    report_id: Uuid,
 ) -> Result<Option<ReportRecord>> {
-    todo!("L1 (Max)")
+    let row = sqlx::query(
+        r#"
+        SELECT id, report_event_id, reporter_pubkey, target_kind, target_event_id,
+               target_pubkey, target_blob_sha256, channel_id, report_type, note,
+               status, resolved_by, resolved_at, action_id, created_at
+        FROM moderation_reports
+        WHERE community_id = $1 AND id = $2
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(report_id)
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_report).transpose()
 }
 
 /// Mark a report resolved/dismissed/escalated, linking the audit action.
 /// Returns `false` if the report was not found or already closed.
 pub async fn resolve_report(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _report_id: Uuid,
-    _status: &str,
-    _resolved_by: &[u8],
-    _action_id: Option<Uuid>,
+    pool: &PgPool,
+    community: CommunityId,
+    report_id: Uuid,
+    status: &str,
+    resolved_by: &[u8],
+    action_id: Option<Uuid>,
 ) -> Result<bool> {
-    todo!("L1 (Max)")
+    let result = sqlx::query(
+        r#"
+        UPDATE moderation_reports
+        SET status = $3, resolved_by = $4, resolved_at = now(), action_id = $5
+        WHERE community_id = $1 AND id = $2 AND status = 'open'
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(report_id)
+    .bind(status)
+    .bind(resolved_by)
+    .bind(action_id)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
 }
 
 /// Upsert a ban: sets `banned = true` with optional expiry + reason.
 pub async fn ban_member(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _pubkey: &[u8],
-    _actor: &[u8],
-    _reason: Option<&str>,
-    _expires_at: Option<DateTime<Utc>>,
+    pool: &PgPool,
+    community: CommunityId,
+    pubkey: &[u8],
+    actor: &[u8],
+    reason: Option<&str>,
+    expires_at: Option<DateTime<Utc>>,
 ) -> Result<()> {
-    todo!("L1 (Max): INSERT ... ON CONFLICT (community_id, pubkey) DO UPDATE")
+    sqlx::query(
+        r#"
+        INSERT INTO community_bans (
+            community_id, pubkey, banned, ban_expires_at, ban_reason, actor_pubkey
+        ) VALUES ($1, $2, true, $3, $4, $5)
+        ON CONFLICT (community_id, pubkey) DO UPDATE SET
+            banned = true,
+            ban_expires_at = EXCLUDED.ban_expires_at,
+            ban_reason = EXCLUDED.ban_reason,
+            actor_pubkey = EXCLUDED.actor_pubkey,
+            updated_at = now()
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .bind(expires_at)
+    .bind(reason)
+    .bind(actor)
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }
 
 /// Lift a ban. Returns `false` if the member was not banned.
 pub async fn unban_member(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _pubkey: &[u8],
-    _actor: &[u8],
+    pool: &PgPool,
+    community: CommunityId,
+    pubkey: &[u8],
+    actor: &[u8],
 ) -> Result<bool> {
-    todo!("L1 (Max)")
+    let result = sqlx::query(
+        r#"
+        UPDATE community_bans
+        SET banned = false, ban_expires_at = NULL, ban_reason = NULL,
+            actor_pubkey = $3, updated_at = now()
+        WHERE community_id = $1 AND pubkey = $2 AND banned = true
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .bind(actor)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
 }
 
 /// Upsert a timeout: sets `muted_until` + reason.
 pub async fn timeout_member(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _pubkey: &[u8],
-    _actor: &[u8],
-    _muted_until: DateTime<Utc>,
-    _reason: Option<&str>,
+    pool: &PgPool,
+    community: CommunityId,
+    pubkey: &[u8],
+    actor: &[u8],
+    muted_until: DateTime<Utc>,
+    reason: Option<&str>,
 ) -> Result<()> {
-    todo!("L1 (Max)")
+    sqlx::query(
+        r#"
+        INSERT INTO community_bans (
+            community_id, pubkey, muted_until, mute_reason, actor_pubkey
+        ) VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (community_id, pubkey) DO UPDATE SET
+            muted_until = EXCLUDED.muted_until,
+            mute_reason = EXCLUDED.mute_reason,
+            actor_pubkey = EXCLUDED.actor_pubkey,
+            updated_at = now()
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .bind(muted_until)
+    .bind(reason)
+    .bind(actor)
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }
 
 /// Clear a timeout early. Returns `false` if the member was not timed out.
 pub async fn untimeout_member(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _pubkey: &[u8],
-    _actor: &[u8],
+    pool: &PgPool,
+    community: CommunityId,
+    pubkey: &[u8],
+    actor: &[u8],
 ) -> Result<bool> {
-    todo!("L1 (Max)")
+    let result = sqlx::query(
+        r#"
+        UPDATE community_bans
+        SET muted_until = NULL, mute_reason = NULL,
+            actor_pubkey = $3, updated_at = now()
+        WHERE community_id = $1 AND pubkey = $2 AND muted_until > now()
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .bind(actor)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
 }
 
 /// Restriction snapshot consumed by the auth-seam gate (L4) and write gates.
@@ -251,41 +399,190 @@ pub struct RestrictionState {
 /// Fetch the current restriction state for a pubkey in one community.
 /// Missing row ⇒ `RestrictionState::default()` (unrestricted).
 pub async fn restriction_state(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _pubkey: &[u8],
+    pool: &PgPool,
+    community: CommunityId,
+    pubkey: &[u8],
 ) -> Result<RestrictionState> {
-    todo!("L1 (Max): single SELECT evaluating ban expiry + mute window in SQL")
+    let row = sqlx::query(
+        r#"
+        SELECT
+            (banned AND (ban_expires_at IS NULL OR ban_expires_at > now())) AS banned,
+            CASE WHEN muted_until > now() THEN muted_until ELSE NULL END AS muted_until
+        FROM community_bans
+        WHERE community_id = $1 AND pubkey = $2
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        Some(row) => Ok(RestrictionState {
+            banned: row.try_get("banned")?,
+            muted_until: row.try_get("muted_until")?,
+        }),
+        None => Ok(RestrictionState::default()),
+    }
 }
 
 /// Fetch the full ban/timeout row (moderation queue / audit views).
 pub async fn get_ban(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _pubkey: &[u8],
+    pool: &PgPool,
+    community: CommunityId,
+    pubkey: &[u8],
 ) -> Result<Option<BanRecord>> {
-    todo!("L1 (Max)")
+    let row = sqlx::query(
+        r#"
+        SELECT pubkey,
+               (banned AND (ban_expires_at IS NULL OR ban_expires_at > now())) AS banned,
+               ban_expires_at, ban_reason, muted_until,
+               mute_reason, actor_pubkey, updated_at
+        FROM community_bans
+        WHERE community_id = $1 AND pubkey = $2
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_ban).transpose()
 }
 
 /// List currently-restricted members (active ban or timeout) for the queue.
-pub async fn list_restricted(_pool: &PgPool, _community: CommunityId) -> Result<Vec<BanRecord>> {
-    todo!("L1 (Max)")
+pub async fn list_restricted(pool: &PgPool, community: CommunityId) -> Result<Vec<BanRecord>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT pubkey,
+               (banned AND (ban_expires_at IS NULL OR ban_expires_at > now())) AS banned,
+               ban_expires_at, ban_reason, muted_until,
+               mute_reason, actor_pubkey, updated_at
+        FROM community_bans
+        WHERE community_id = $1
+          AND (
+              (banned AND (ban_expires_at IS NULL OR ban_expires_at > now()))
+              OR muted_until > now()
+          )
+        ORDER BY updated_at DESC
+        "#,
+    )
+    .bind(community.as_uuid())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_ban).collect()
 }
 
 /// Insert a moderation audit row, returning its id.
 pub async fn insert_action(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _action: NewAction<'_>,
+    pool: &PgPool,
+    community: CommunityId,
+    action: NewAction<'_>,
 ) -> Result<Uuid> {
-    todo!("L1 (Max)")
+    let row = sqlx::query(
+        r#"
+        INSERT INTO moderation_actions (
+            community_id, actor_pubkey, action, target_pubkey, target_event_id,
+            channel_id, reason_code, public_reason, private_reason, matched_principal
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        RETURNING id
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(action.actor_pubkey)
+    .bind(action.action)
+    .bind(action.target_pubkey)
+    .bind(action.target_event_id)
+    .bind(action.channel_id)
+    .bind(action.reason_code)
+    .bind(action.public_reason)
+    .bind(action.private_reason)
+    .bind(action.matched_principal)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(row.try_get("id")?)
 }
 
 /// List audit rows, newest first (`buzz moderation audit`).
 pub async fn list_actions(
-    _pool: &PgPool,
-    _community: CommunityId,
-    _limit: i64,
+    pool: &PgPool,
+    community: CommunityId,
+    limit: i64,
 ) -> Result<Vec<ActionRecord>> {
-    todo!("L1 (Max)")
+    let rows = sqlx::query(
+        r#"
+        SELECT id, actor_pubkey, action, target_pubkey, target_event_id, channel_id,
+               reason_code, public_reason, private_reason, matched_principal, created_at
+        FROM moderation_actions
+        WHERE community_id = $1
+        ORDER BY created_at DESC
+        LIMIT $2
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_action).collect()
+}
+
+fn row_to_report(row: sqlx::postgres::PgRow) -> Result<ReportRecord> {
+    let target_kind: String = row.try_get("target_kind")?;
+    let target = match target_kind.as_str() {
+        "event" => ReportTarget::Event(row.try_get("target_event_id")?),
+        "pubkey" => ReportTarget::Pubkey(row.try_get("target_pubkey")?),
+        "blob" => ReportTarget::Blob(row.try_get("target_blob_sha256")?),
+        other => {
+            return Err(crate::error::DbError::InvalidData(format!(
+                "invalid report target_kind: {other}"
+            )))
+        }
+    };
+
+    Ok(ReportRecord {
+        id: row.try_get("id")?,
+        report_event_id: row.try_get("report_event_id")?,
+        reporter_pubkey: row.try_get("reporter_pubkey")?,
+        target,
+        channel_id: row.try_get("channel_id")?,
+        report_type: row.try_get("report_type")?,
+        note: row.try_get("note")?,
+        status: row.try_get("status")?,
+        resolved_by: row.try_get("resolved_by")?,
+        resolved_at: row.try_get("resolved_at")?,
+        action_id: row.try_get("action_id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+fn row_to_ban(row: sqlx::postgres::PgRow) -> Result<BanRecord> {
+    Ok(BanRecord {
+        pubkey: row.try_get("pubkey")?,
+        banned: row.try_get("banned")?,
+        ban_expires_at: row.try_get("ban_expires_at")?,
+        ban_reason: row.try_get("ban_reason")?,
+        muted_until: row.try_get("muted_until")?,
+        mute_reason: row.try_get("mute_reason")?,
+        actor_pubkey: row.try_get("actor_pubkey")?,
+        updated_at: row.try_get("updated_at")?,
+    })
+}
+
+fn row_to_action(row: sqlx::postgres::PgRow) -> Result<ActionRecord> {
+    Ok(ActionRecord {
+        id: row.try_get("id")?,
+        actor_pubkey: row.try_get("actor_pubkey")?,
+        action: row.try_get("action")?,
+        target_pubkey: row.try_get("target_pubkey")?,
+        target_event_id: row.try_get("target_event_id")?,
+        channel_id: row.try_get("channel_id")?,
+        reason_code: row.try_get("reason_code")?,
+        public_reason: row.try_get("public_reason")?,
+        private_reason: row.try_get("private_reason")?,
+        matched_principal: row.try_get("matched_principal")?,
+        created_at: row.try_get("created_at")?,
+    })
 }

--- a/crates/buzz-db/src/moderation.rs
+++ b/crates/buzz-db/src/moderation.rs
@@ -586,3 +586,261 @@ fn row_to_action(row: sqlx::postgres::PgRow) -> Result<ActionRecord> {
         created_at: row.try_get("created_at")?,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use uuid::Uuid;
+
+    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz";
+
+    async fn setup_pool() -> PgPool {
+        let database_url = std::env::var("BUZZ_TEST_DATABASE_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .unwrap_or_else(|_| TEST_DB_URL.to_owned());
+        PgPool::connect(&database_url)
+            .await
+            .expect("connect to test DB")
+    }
+
+    async fn make_test_community(pool: &PgPool) -> CommunityId {
+        let id = Uuid::new_v4();
+        let host = format!("moderation-test-{}.example", id.simple());
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(id)
+            .bind(host)
+            .execute(pool)
+            .await
+            .expect("insert test community");
+        CommunityId::from_uuid(id)
+    }
+
+    fn random_32() -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(32);
+        bytes.extend_from_slice(Uuid::new_v4().as_bytes());
+        bytes.extend_from_slice(Uuid::new_v4().as_bytes());
+        bytes
+    }
+
+    fn new_report<'a>(
+        report_event_id: &'a [u8],
+        reporter_pubkey: &'a [u8],
+        target_event_id: &'a [u8],
+        note: Option<&'a str>,
+    ) -> NewReport<'a> {
+        NewReport {
+            report_event_id,
+            reporter_pubkey,
+            target: ReportTarget::Event(target_event_id.to_vec()),
+            channel_id: None,
+            report_type: "spam",
+            note,
+        }
+    }
+
+    /// Community moderation restrictions are tenant-scoped. This guards the same
+    /// mutation class as the TLA⁺ tenant-fence invariant: a ban in community A
+    /// must not restrict the same pubkey in community B, through either the hot
+    /// `restriction_state` read or the queue-facing `list_restricted` read.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn restrictions_are_confined_to_their_community() {
+        let pool = setup_pool().await;
+        let community_a = make_test_community(&pool).await;
+        let community_b = make_test_community(&pool).await;
+        let pubkey = random_32();
+        let actor = random_32();
+
+        ban_member(
+            &pool,
+            community_a,
+            &pubkey,
+            &actor,
+            Some("tenant fence test"),
+            None,
+        )
+        .await
+        .expect("ban in community A");
+
+        let state_a = restriction_state(&pool, community_a, &pubkey)
+            .await
+            .expect("restriction_state A");
+        assert!(state_a.banned, "pubkey must be banned in community A");
+
+        let state_b = restriction_state(&pool, community_b, &pubkey)
+            .await
+            .expect("restriction_state B");
+        assert!(
+            !state_b.banned && state_b.muted_until.is_none(),
+            "ban in A must not restrict the same pubkey in community B"
+        );
+
+        let restricted_a = list_restricted(&pool, community_a)
+            .await
+            .expect("list restricted A");
+        assert!(
+            restricted_a.iter().any(|row| row.pubkey == pubkey),
+            "community A restricted list must include the banned pubkey"
+        );
+
+        let restricted_b = list_restricted(&pool, community_b)
+            .await
+            .expect("list restricted B");
+        assert!(
+            restricted_b.iter().all(|row| row.pubkey != pubkey),
+            "community B restricted list must not include community A's ban"
+        );
+    }
+
+    /// Ban expiry is evaluated in SQL, while a live timeout on the same row keeps
+    /// the member restricted for writes. This protects the one-row/two-restriction
+    /// shape used by L4's auth and ingest gates.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn expired_ban_does_not_hide_active_timeout() {
+        let pool = setup_pool().await;
+        let community = make_test_community(&pool).await;
+        let pubkey = random_32();
+        let actor = random_32();
+
+        ban_member(
+            &pool,
+            community,
+            &pubkey,
+            &actor,
+            Some("expired ban"),
+            Some(Utc::now() - Duration::hours(1)),
+        )
+        .await
+        .expect("insert expired ban");
+        timeout_member(
+            &pool,
+            community,
+            &pubkey,
+            &actor,
+            Utc::now() + Duration::hours(1),
+            Some("active timeout"),
+        )
+        .await
+        .expect("insert active timeout");
+
+        let state = restriction_state(&pool, community, &pubkey)
+            .await
+            .expect("restriction_state");
+        assert!(!state.banned, "expired ban must evaluate inactive");
+        assert!(
+            state.muted_until.is_some(),
+            "active timeout must survive an expired ban on the same row"
+        );
+
+        let ban = get_ban(&pool, community, &pubkey)
+            .await
+            .expect("get ban")
+            .expect("restriction row exists");
+        assert!(
+            !ban.banned,
+            "get_ban must also evaluate expired ban inactive"
+        );
+        assert!(ban.muted_until.is_some(), "get_ban must preserve timeout");
+
+        let restricted = list_restricted(&pool, community)
+            .await
+            .expect("list restricted");
+        let listed = restricted
+            .iter()
+            .find(|row| row.pubkey == pubkey)
+            .expect("timeout-only row remains listed");
+        assert!(
+            !listed.banned,
+            "list_restricted reports expired ban inactive"
+        );
+        assert!(
+            listed.muted_until.is_some(),
+            "list_restricted preserves timeout"
+        );
+    }
+
+    /// Re-ingesting the same signed report is idempotent by event id and must not
+    /// reopen or otherwise reset a report that a moderator already resolved.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn report_reingest_returns_same_id_and_preserves_resolution() {
+        let pool = setup_pool().await;
+        let community = make_test_community(&pool).await;
+        let report_event_id = random_32();
+        let reporter = random_32();
+        let target_event_id = random_32();
+        let resolver = random_32();
+
+        let report = new_report(&report_event_id, &reporter, &target_event_id, Some("first"));
+        let first_id = insert_report(&pool, community, report)
+            .await
+            .expect("insert report");
+
+        assert!(
+            resolve_report(&pool, community, first_id, "resolved", &resolver, None)
+                .await
+                .expect("resolve report"),
+            "first resolve should close the report"
+        );
+
+        let duplicate = new_report(&report_event_id, &reporter, &target_event_id, Some("retry"));
+        let second_id = insert_report(&pool, community, duplicate)
+            .await
+            .expect("re-ingest report");
+        assert_eq!(first_id, second_id, "re-ingest must return the same row id");
+
+        let row = get_report(&pool, community, first_id)
+            .await
+            .expect("get report")
+            .expect("report exists");
+        assert_eq!(
+            row.status, "resolved",
+            "re-ingest must not reopen the report"
+        );
+        assert!(
+            row.resolved_at.is_some(),
+            "resolution timestamp is preserved"
+        );
+        assert_eq!(
+            row.resolved_by.as_deref(),
+            Some(resolver.as_slice()),
+            "resolving moderator is preserved"
+        );
+    }
+
+    /// `resolve_report` is a guarded transition out of `open`; a second resolve
+    /// on a closed report must be a no-op and return `false`.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn resolve_report_returns_false_after_report_is_closed() {
+        let pool = setup_pool().await;
+        let community = make_test_community(&pool).await;
+        let report_event_id = random_32();
+        let reporter = random_32();
+        let target_event_id = random_32();
+        let resolver = random_32();
+
+        let report_id = insert_report(
+            &pool,
+            community,
+            new_report(&report_event_id, &reporter, &target_event_id, None),
+        )
+        .await
+        .expect("insert report");
+
+        assert!(
+            resolve_report(&pool, community, report_id, "dismissed", &resolver, None)
+                .await
+                .expect("first resolve"),
+            "first resolve should update the open report"
+        );
+        assert!(
+            !resolve_report(&pool, community, report_id, "resolved", &resolver, None)
+                .await
+                .expect("second resolve"),
+            "second resolve should return false once the report is closed"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 Community Moderation L1 DB persistence against the pinned contract tip (`4c58489b`):

- fills `crates/buzz-db/src/moderation.rs` for tenant-scoped report queue rows, ban/timeout rows, restriction-state reads, restricted-member listing, and moderation audit rows
- adds stable `Db::moderation_*` / moderation wrapper methods in `crates/buzz-db/src/lib.rs` for L3/L4/L6 callers
- keeps enforcement seam as `Db::moderation_restriction_state(community, pubkey)`
- includes `matched_principal` in audit reads for NIP-OA enforcement audit detail

## Validation

- `PATH="$PWD/bin:$PATH" cargo fmt --check`
- `git diff --check`
- `PATH="$PWD/bin:$PATH" cargo check -p buzz-db -p buzz-relay`
- pre-commit hook passed during commit
- pre-push hook passed during push

## Notes

No integration tests were added in this lane; this is the narrow L1 persistence implementation for the scaffolded contract, with callers/integration tests expected in L3/L4/L6 lanes.
