### PR TITLE
moderation(L4): enforce bans/timeouts at auth, ingest, and connection seams

### DIFF
--- a/crates/buzz-pubsub/src/conn_control.rs
+++ b/crates/buzz-pubsub/src/conn_control.rs
@@ -1,0 +1,210 @@
+//! Cross-pod connection-control commands over Redis pub/sub.
+//!
+//! Under horizontal scaling a member's live connections may land on any pod,
+//! so a moderation action taken on one pod (a ban) must reach the pod holding
+//! the victim's socket. This module carries connection-control intents — today
+//! only "disconnect this pubkey" — to every pod, which each apply locally
+//! against their own [`crate::ConnectionManager`].
+//!
+//! This is deliberately a **separate** channel from `cache_invalidation`: a
+//! cache-key drop is a pure, idempotent hint (the DB is re-read on the next
+//! access), whereas a disconnect is an imperative, non-idempotent action on a
+//! live socket. Folding it into the cache-invalidation enum would break that
+//! module's stated invariant ("a pure cache-key drop, never an evict payload").
+//! The DB ban row remains the durable backstop: even if a disconnect message is
+//! dropped, the next auth attempt is refused at the auth seam.
+
+use buzz_core::{CommunityId, TenantContext};
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+use crate::topic::BUZZ_PREFIX;
+
+/// Tenant-local Redis pub/sub channel suffix for connection-control messages.
+pub const CONN_CONTROL_SUFFIX: &str = "conn-control";
+
+/// Pattern the subscriber uses to receive connection-control messages for every
+/// community this pod may hold connections for.
+pub const CONN_CONTROL_PATTERN: &str = "buzz:*:conn-control";
+
+/// Redis pub/sub channel for connection-control messages under `ctx`.
+pub fn conn_control_channel(ctx: &TenantContext) -> String {
+    format!("{BUZZ_PREFIX}:{}:{CONN_CONTROL_SUFFIX}", ctx.community())
+}
+
+/// Parse a connection-control Redis channel into its scoped community id.
+pub fn parse_conn_control_channel(channel: &str) -> Option<CommunityId> {
+    let mut parts = channel.split(':');
+    if parts.next()? != BUZZ_PREFIX {
+        return None;
+    }
+    let community_id = Uuid::parse_str(parts.next()?).ok()?;
+    if parts.next()? != CONN_CONTROL_SUFFIX {
+        return None;
+    }
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(CommunityId::from_uuid(community_id))
+}
+
+/// A connection-control command to apply on every pod.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "op")]
+pub enum ConnControl {
+    /// Disconnect every live connection authenticated as `pubkey` in the
+    /// carrying community — live ban enforcement. `pubkey` is 32 raw bytes.
+    /// `event_id` and `reason` reproduce the same NIP-01 `OK` frame the origin
+    /// pod sent, so a member disconnected on any pod learns why.
+    DisconnectPubkey {
+        /// Banned member's pubkey bytes.
+        pubkey: Vec<u8>,
+        /// Id echoed in the closing `OK` frame (the ban event's id on origin).
+        event_id: String,
+        /// Human-readable close reason for the `OK` frame.
+        reason: String,
+    },
+}
+
+/// A connection-control command received from a community-scoped Redis channel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopedConnControl {
+    /// Community whose connections the command applies to.
+    pub community_id: CommunityId,
+    /// The tenant-local connection-control command.
+    pub command: ConnControl,
+}
+
+/// Initial reconnect backoff (1 second).
+const BACKOFF_INITIAL_SECS: u64 = 1;
+/// Maximum reconnect backoff (30 seconds).
+const BACKOFF_MAX_SECS: u64 = 30;
+
+/// Subscribes to `buzz:*:conn-control` and forwards scoped commands to the
+/// broadcast. Mirrors [`crate::cache_invalidation::run_cache_invalidation_subscriber`]:
+/// a reconnect loop with exponential backoff. Never returns.
+pub async fn run_conn_control_subscriber(
+    redis_url: String,
+    broadcast_tx: broadcast::Sender<ScopedConnControl>,
+) {
+    let mut backoff_secs = BACKOFF_INITIAL_SECS;
+
+    loop {
+        match connect_and_subscribe(&redis_url, &broadcast_tx).await {
+            Ok(()) => {
+                backoff_secs = BACKOFF_INITIAL_SECS;
+                tracing::warn!(
+                    "Redis conn-control stream ended (clean disconnect) — reconnecting in {backoff_secs}s"
+                );
+            }
+            Err(e) => {
+                tracing::error!("Redis conn-control error: {e} — reconnecting in {backoff_secs}s");
+            }
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(backoff_secs)).await;
+        backoff_secs = (backoff_secs * 2).min(BACKOFF_MAX_SECS);
+
+        tracing::info!("Attempting to reconnect to Redis conn-control...");
+    }
+}
+
+async fn connect_and_subscribe(
+    redis_url: &str,
+    broadcast_tx: &broadcast::Sender<ScopedConnControl>,
+) -> Result<(), redis::RedisError> {
+    let client = redis::Client::open(redis_url)?;
+    let mut conn = client.get_async_pubsub().await?;
+
+    conn.psubscribe(CONN_CONTROL_PATTERN).await?;
+
+    tracing::info!("Redis conn-control subscriber connected — listening on {CONN_CONTROL_PATTERN}");
+
+    let mut stream = conn.on_message();
+    while let Some(msg) = stream.next().await {
+        let channel = msg.get_channel_name();
+        let Some(community_id) = parse_conn_control_channel(channel) else {
+            tracing::warn!("Received conn-control message on unexpected channel: {channel}");
+            continue;
+        };
+
+        let payload: String = match msg.get_payload() {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("Failed to get conn-control payload: {e}");
+                continue;
+            }
+        };
+
+        let command: ConnControl = match serde_json::from_str(&payload) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("Failed to deserialize conn-control message: {e}");
+                continue;
+            }
+        };
+
+        let scoped = ScopedConnControl {
+            community_id,
+            command,
+        };
+
+        if broadcast_tx.send(scoped).is_err() {
+            tracing::trace!("No conn-control receivers — message dropped");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(id: u128, host: &str) -> TenantContext {
+        TenantContext::resolved(CommunityId::from_uuid(Uuid::from_u128(id)), host)
+    }
+
+    #[test]
+    fn conn_control_channel_is_community_scoped() {
+        let a = ctx(0xaaaa, "a.example");
+        let b = ctx(0xbbbb, "b.example");
+        assert_eq!(
+            conn_control_channel(&a),
+            format!("buzz:{}:conn-control", a.community())
+        );
+        assert_ne!(conn_control_channel(&a), conn_control_channel(&b));
+    }
+
+    #[test]
+    fn parse_round_trips_the_community() {
+        let a = ctx(0x1234, "a.example");
+        let channel = conn_control_channel(&a);
+        assert_eq!(parse_conn_control_channel(&channel), Some(a.community()));
+    }
+
+    #[test]
+    fn parse_rejects_foreign_channels() {
+        assert_eq!(
+            parse_conn_control_channel("buzz:not-a-uuid:conn-control"),
+            None
+        );
+        assert_eq!(parse_conn_control_channel("buzz:*:cache-invalidate"), None);
+        let a = ctx(0x1234, "a.example");
+        let extended = format!("{}:extra", conn_control_channel(&a));
+        assert_eq!(parse_conn_control_channel(&extended), None);
+    }
+
+    #[test]
+    fn disconnect_command_serde_round_trips() {
+        let cmd = ConnControl::DisconnectPubkey {
+            pubkey: vec![7u8; 32],
+            event_id: "abc123".to_string(),
+            reason: "blocked: you are banned from this community".to_string(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert_eq!(serde_json::from_str::<ConnControl>(&json).unwrap(), cmd);
+    }
+}

--- a/crates/buzz-pubsub/src/lib.rs
+++ b/crates/buzz-pubsub/src/lib.rs
@@ -23,6 +23,8 @@
 
 /// Cross-pod cache-key invalidation over Redis pub/sub.
 pub mod cache_invalidation;
+/// Cross-pod connection-control commands over Redis pub/sub.
+pub mod conn_control;
 /// Error types for pub/sub operations.
 pub mod error;
 /// Redis-backed NIP-98 replay seen-set.
@@ -52,6 +54,7 @@ use tokio::sync::{broadcast, mpsc, Mutex};
 use crate::cache_invalidation::{
     cache_invalidation_channel, CacheInvalidation, ScopedCacheInvalidation,
 };
+use crate::conn_control::{conn_control_channel, ConnControl, ScopedConnControl};
 pub use crate::topic::{channel_key, global_key, EventTopic, EventTopicKey};
 
 /// A Nostr event received on a scoped Redis event topic, broadcast to local subscribers.
@@ -106,6 +109,7 @@ pub struct PubSubManager {
     subscription_rx: Mutex<Option<mpsc::Receiver<subscriber::SubscriptionCommand>>>,
     broadcast_tx: broadcast::Sender<ChannelEvent>,
     cache_invalidation_tx: broadcast::Sender<ScopedCacheInvalidation>,
+    conn_control_tx: broadcast::Sender<ScopedConnControl>,
 }
 
 impl PubSubManager {
@@ -121,6 +125,7 @@ impl PubSubManager {
     ) -> Result<Self, PubSubError> {
         let (broadcast_tx, _) = broadcast::channel(4096);
         let (cache_invalidation_tx, _) = broadcast::channel(4096);
+        let (conn_control_tx, _) = broadcast::channel(4096);
         let (subscription_tx, subscription_rx) = mpsc::channel(4096);
 
         Ok(Self {
@@ -132,6 +137,7 @@ impl PubSubManager {
             subscription_rx: Mutex::new(Some(subscription_rx)),
             broadcast_tx,
             cache_invalidation_tx,
+            conn_control_tx,
         })
     }
 
@@ -160,6 +166,16 @@ impl PubSubManager {
         cache_invalidation::run_cache_invalidation_subscriber(
             self.redis_url.clone(),
             self.cache_invalidation_tx.clone(),
+        )
+        .await;
+    }
+
+    /// Starts the connection-control subscriber loop with automatic
+    /// reconnection. Runs forever — spawn this in a background task.
+    pub async fn run_conn_control_subscriber(self: Arc<Self>) {
+        conn_control::run_conn_control_subscriber(
+            self.redis_url.clone(),
+            self.conn_control_tx.clone(),
         )
         .await;
     }
@@ -244,6 +260,11 @@ impl PubSubManager {
         self.cache_invalidation_tx.subscribe()
     }
 
+    /// Returns a new broadcast receiver for cross-pod connection-control commands.
+    pub fn subscribe_conn_control(&self) -> broadcast::Receiver<ScopedConnControl> {
+        self.conn_control_tx.subscribe()
+    }
+
     /// Publish a cache-key drop to all pods. Fire-and-forget at the call site:
     /// the local cache is already dropped synchronously; this carries the same
     /// drop cross-pod. A dropped publish is backstopped by the REQ denial-path
@@ -257,6 +278,26 @@ impl PubSubManager {
         let payload = serde_json::to_string(invalidation)?;
         let subscriber_count: i64 = redis::cmd("PUBLISH")
             .arg(cache_invalidation_channel(ctx))
+            .arg(&payload)
+            .query_async(&mut conn)
+            .await?;
+        Ok(subscriber_count)
+    }
+
+    /// Publish a connection-control command to all pods. Used for live ban
+    /// enforcement: the banning pod disconnects any local sockets synchronously
+    /// and calls this to reach the banned member's sockets on other pods. The DB
+    /// ban row is the durable backstop, so a dropped publish still refuses the
+    /// next auth attempt; callers may spawn this without awaiting delivery.
+    pub async fn publish_conn_control(
+        &self,
+        ctx: &TenantContext,
+        command: &ConnControl,
+    ) -> Result<i64, PubSubError> {
+        let mut conn = self.pool.get().await?;
+        let payload = serde_json::to_string(command)?;
+        let subscriber_count: i64 = redis::cmd("PUBLISH")
+            .arg(conn_control_channel(ctx))
             .arg(&payload)
             .query_async(&mut conn)
             .await?;

--- a/crates/buzz-relay/src/connection.rs
+++ b/crates/buzz-relay/src/connection.rs
@@ -177,6 +177,7 @@ pub async fn handle_connection(
     state.conn_manager.register(
         conn_id,
         tx.clone(),
+        ctrl_tx.clone(),
         cancel.clone(),
         conn.tenant.community(),
         Arc::clone(&backpressure_count),
@@ -294,6 +295,17 @@ async fn send_loop_inner<S>(
             // so backpressure-triggered shutdown isn't starved by queued data.
             biased;
             _ = cancel.cancelled() => {
+                // Drain any queued control frames before closing. A ban
+                // disconnect queues its `OK false "blocked: …"` reason frame on
+                // ctrl and then cancels; without this drain the biased branch
+                // would send Close first and the client would never learn why
+                // (the top-of-loop drain does not run again after we break).
+                // This makes "queue frame on ctrl, then cancel" a safe idiom.
+                while let Ok(ctrl_msg) = ctrl_rx.try_recv() {
+                    if ws_send.send(ctrl_msg).await.is_err() {
+                        break;
+                    }
+                }
                 let _ = ws_send.send(WsMessage::Close(None)).await;
                 break;
             }
@@ -697,6 +709,45 @@ mod tests {
         assert_eq!(
             text_payloads(&state.messages),
             vec!["control", "data-0", "data-1"]
+        );
+    }
+
+    #[tokio::test]
+    async fn send_loop_flushes_queued_control_before_close_on_cancel() {
+        // A ban disconnect queues its `OK false "blocked: …"` reason frame on
+        // the control channel and then cancels the token (B3). The biased
+        // select polls the cancel branch first, so the reason frame would be
+        // stranded unless the cancel branch drains ctrl before emitting Close.
+        // This test exercises `send_loop_inner` end-to-end to prove the reason
+        // frame reaches the client, in order, ahead of the Close.
+        let (_data_tx, data_rx) = mpsc::channel(1);
+        let (ctrl_tx, ctrl_rx) = mpsc::channel(1);
+        ctrl_tx
+            .send(WsMessage::Text("blocked: you are banned".into()))
+            .await
+            .expect("queue ban reason frame");
+
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let (sink, state) = MockSink::new(None);
+        send_loop_inner(sink, data_rx, ctrl_rx, cancel).await;
+
+        let state = state.lock().expect("mock sink poisoned");
+        assert_eq!(
+            state.messages.len(),
+            2,
+            "reason frame then Close, nothing else"
+        );
+        match &state.messages[0] {
+            WsMessage::Text(text) => {
+                assert_eq!(text.as_str(), "blocked: you are banned")
+            }
+            other => panic!("expected the ban reason frame first, got {other:?}"),
+        }
+        assert!(
+            matches!(state.messages[1], WsMessage::Close(_)),
+            "Close is sent only after the reason frame is flushed"
         );
     }
 }

--- a/crates/buzz-relay/src/handlers/auth.rs
+++ b/crates/buzz-relay/src/handlers/auth.rs
@@ -11,6 +11,7 @@
 
 use std::sync::Arc;
 
+use axum::extract::ws::Message as WsMessage;
 use tracing::{debug, info, warn};
 
 use crate::connection::{AuthState, ConnectionState};
@@ -89,6 +90,98 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
     {
         Ok(mut auth_ctx) => {
             let pubkey = auth_ctx.pubkey;
+
+            // Community ban gate (NIP-42 seam). Runs immediately after auth
+            // verification succeeds and before the allowlist and relay-membership
+            // gates, per COMMUNITY_MODERATION_PLAN.md §0 decision 4 and the
+            // MOD-7/M20 invariant (a ban must block connection auth even for open
+            // channels — enforcement is structural, not filtered later). A banned
+            // principal gets the standard protocol denial and the connection is
+            // dropped with zero further processing.
+            //
+            // NIP-OA cascade: a ban on the authenticated pubkey blocks it directly;
+            // a ban on its cryptographically-proven owner cascades to the agent
+            // (owner ban ⇒ agents banned; agent ban is agent-only). The owner is
+            // extracted from the self-proving auth tag with no DB round-trip.
+            {
+                // Fail closed on a DB error, but distinguish it from a real ban:
+                // a transient blip must deny (never let a banned principal
+                // through) without telling an innocent user they are banned and
+                // pinning `Failed` for the connection's life on a false premise.
+                // `Banned` claims the ban; `DbError` denies with `error: internal`
+                // (mirrors the ingest write-path gate).
+                enum BanOutcome {
+                    Clear,
+                    Banned,
+                    DbError,
+                }
+
+                let mut outcome = match state
+                    .db
+                    .moderation_restriction_state(conn.tenant.community(), pubkey.as_bytes())
+                    .await
+                {
+                    Ok(state) if state.banned => BanOutcome::Banned,
+                    Ok(_) => BanOutcome::Clear,
+                    Err(e) => {
+                        warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), error = %e,
+                              "ban-state DB lookup failed, denying (fail-closed)");
+                        BanOutcome::DbError
+                    }
+                };
+
+                // Cascade: check the proven NIP-OA owner only if the agent itself
+                // is clear (a DB error already denies; a direct ban already blocks
+                // — both skip the needless second DB read).
+                if matches!(outcome, BanOutcome::Clear) {
+                    if let Some(owner) = crate::api::relay_members::extract_nip_oa_owner(
+                        pubkey.as_bytes(),
+                        auth_tag_json.as_deref(),
+                    ) {
+                        outcome = match state
+                            .db
+                            .moderation_restriction_state(conn.tenant.community(), owner.as_bytes())
+                            .await
+                        {
+                            Ok(state) if state.banned => BanOutcome::Banned,
+                            Ok(_) => BanOutcome::Clear,
+                            Err(e) => {
+                                warn!(conn_id = %conn_id, owner = %owner.to_hex(), error = %e,
+                                      "owner ban-state DB lookup failed, denying (fail-closed)");
+                                BanOutcome::DbError
+                            }
+                        };
+                    }
+                }
+
+                let denial: Option<(&str, &str)> = match outcome {
+                    BanOutcome::Clear => None,
+                    BanOutcome::Banned => {
+                        Some(("banned", "blocked: you are banned from this community"))
+                    }
+                    BanOutcome::DbError => Some((
+                        "ban_check_error",
+                        "error: internal error checking restriction state",
+                    )),
+                };
+
+                if let Some((metric_reason, deny_reason)) = denial {
+                    warn!(conn_id = %conn_id, pubkey = %pubkey.to_hex(), reason = deny_reason, "principal denied at ban seam");
+                    metrics::counter!("buzz_auth_failures_total", "reason" => metric_reason)
+                        .increment(1);
+                    *conn.auth_state.write().await = AuthState::Failed;
+                    // Decision 4: banned ⇒ OK false + immediate WebSocket close.
+                    // Route the reason frame on the control channel (not `send`,
+                    // which uses the data channel and would race the cancel), so
+                    // the send loop drains it ahead of the Close it emits on
+                    // cancel. Then cancel to close the socket immediately.
+                    let _ = conn.ctrl_tx.try_send(WsMessage::Text(
+                        RelayMessage::ok(&event_id_hex, false, deny_reason).into(),
+                    ));
+                    conn.cancel.cancel();
+                    return;
+                }
+            }
 
             // Pubkey allowlist gate — only for pubkey-only auth.
             if state.config.pubkey_allowlist_enabled

--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -1332,9 +1332,11 @@ mod tests {
         ) -> (Uuid, mpsc::Receiver<Message>) {
             let conn_id = Uuid::new_v4();
             let (tx, rx) = mpsc::channel(10);
+            let (ctrl_tx, _ctrl_rx) = mpsc::channel(10);
             state.conn_manager.register(
                 conn_id,
                 tx,
+                ctrl_tx,
                 CancellationToken::new(),
                 buzz_core::tenant::CommunityId::from_uuid(Uuid::nil()),
                 Arc::new(AtomicU8::new(0)),
@@ -1969,9 +1971,11 @@ mod tests {
         fn register_conn(state: &AppState, pubkey: Option<Vec<u8>>) -> Uuid {
             let conn_id = Uuid::new_v4();
             let (tx, _rx) = mpsc::channel(1);
+            let (ctrl_tx, _ctrl_rx) = mpsc::channel(1);
             state.conn_manager.register(
                 conn_id,
                 tx,
+                ctrl_tx,
                 CancellationToken::new(),
                 buzz_core::tenant::CommunityId::from_uuid(Uuid::nil()),
                 Arc::new(AtomicU8::new(0)),
@@ -2292,9 +2296,11 @@ mod tests {
         ) -> Uuid {
             let conn_id = Uuid::new_v4();
             let (tx, _rx) = mpsc::channel(1);
+            let (ctrl_tx, _ctrl_rx) = mpsc::channel(1);
             state.conn_manager.register(
                 conn_id,
                 tx,
+                ctrl_tx,
                 CancellationToken::new(),
                 community_id,
                 Arc::new(AtomicU8::new(0)),

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -1425,6 +1425,59 @@ async fn ingest_event_inner(
         return super::command_executor::handle_command(tenant, state, event, auth).await;
     }
 
+    // Community ban / timeout write-block (COMMUNITY_MODERATION_PLAN.md §0
+    // decision 4). A timeout is a write-block only — the connection stays open,
+    // content writes are refused with `restricted: you are timed out until <ts>`
+    // so the desktop can render a countdown. A ban is normally enforced at the
+    // auth seam, but an already-authenticated connection never re-auths: if the
+    // live-disconnect fan-out is missed (fire-and-forget publish, broadcast lag,
+    // subscriber reconnect window), a banned member's open socket would keep
+    // writing indefinitely. So the ban is re-checked here — this write-path gate
+    // is the durable backstop the fan-out's best-effort delivery relies on.
+    // Moderation/relay-admin commands are exempt: a restriction must never
+    // disarm the tools used to lift or manage it.
+    //
+    // Scope: this gate checks the *authoring* pubkey only, with no NIP-OA
+    // owner→agent cascade. That cascade lives at the auth seam for bans, where
+    // it is structural: an agent whose owner is banned can never authenticate,
+    // so its socket never exists to reach ingest. Timeout has no auth-seam
+    // presence (it is write-block-only), so an owner-timeout does not cascade to
+    // the owner's agents — a deliberate Phase-1 asymmetry. `IngestAuth` does not
+    // carry the self-proving auth tag, so resolving the owner here would mean
+    // plumbing it through the whole transport boundary; the follow-up shape is
+    // the restriction-state cache (see should-fix), which can fold in owner
+    // resolution without a per-write DB round-trip.
+    if !buzz_core::kind::is_moderation_command_kind(kind_u32) && !is_relay_admin_kind(kind_u32) {
+        match state
+            .db
+            .moderation_restriction_state(tenant.community(), auth.pubkey().as_bytes())
+            .await
+        {
+            Ok(r) => {
+                if r.banned {
+                    return Err(IngestError::AuthFailed(
+                        "blocked: you are banned from this community".to_string(),
+                    ));
+                }
+                if let Some(until) = r.muted_until {
+                    if until > chrono::Utc::now() {
+                        return Err(IngestError::AuthFailed(format!(
+                            "restricted: you are timed out until {}",
+                            until.timestamp()
+                        )));
+                    }
+                }
+            }
+            Err(e) => {
+                // Fail closed: a DB error must not let a banned/timed-out actor
+                // write.
+                return Err(IngestError::Internal(format!(
+                    "error: internal error checking restriction state: {e}"
+                )));
+            }
+        }
+    }
+
     let mut channel_id = if kind_u32 == KIND_REACTION {
         match derive_reaction_channel(tenant.community(), &state.db, &event).await {
             ReactionChannelResult::Channel(ch_id) => Some(ch_id),

--- a/crates/buzz-relay/src/handlers/mesh_signaling.rs
+++ b/crates/buzz-relay/src/handlers/mesh_signaling.rs
@@ -563,9 +563,11 @@ mod tests {
     ) {
         let conn_id = uuid::Uuid::new_v4();
         let (tx, rx) = tokio::sync::mpsc::channel(10);
+        let (ctrl_tx, _ctrl_rx) = tokio::sync::mpsc::channel(10);
         state.conn_manager.register(
             conn_id,
             tx,
+            ctrl_tx,
             tokio_util::sync::CancellationToken::new(),
             test_tenant().community(),
             std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0)),

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -273,6 +273,12 @@ async fn main() -> anyhow::Result<()> {
     let pubsub_for_cache = Arc::clone(&pubsub);
     tokio::spawn(async move { pubsub_for_cache.run_cache_invalidation_subscriber().await });
 
+    // Spawn Redis pub/sub subscriber for cross-pod connection-control commands.
+    // Bans recorded on other pods are received here and applied to any local
+    // sockets (via the consumer loop below), enforcing live disconnect fan-out.
+    let pubsub_for_conn_ctrl = Arc::clone(&pubsub);
+    tokio::spawn(async move { pubsub_for_conn_ctrl.run_conn_control_subscriber().await });
+
     let auth = AuthService::new(config.auth.clone());
 
     // Postgres FTS: the searchable row IS the persisted event row (its
@@ -723,6 +729,45 @@ async fn main() -> anyhow::Result<()> {
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                         tracing::error!("Cache-invalidation broadcast channel closed");
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    // Cross-pod connection-control consumer: receive disconnect commands from
+    // Redis pub/sub (published by the pod that recorded a ban) and close any
+    // matching local sockets. A member's live connections may land on any pod,
+    // so this is how a ban reaches sockets the banning pod does not hold. The DB
+    // ban row is the durable backstop; even a dropped command still refuses the
+    // banned member's next auth attempt at the auth seam.
+    {
+        let state_for_conn_ctrl = Arc::clone(&state);
+        let mut rx = state_for_conn_ctrl.pubsub.subscribe_conn_control();
+        tokio::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(scoped) => match scoped.command {
+                        buzz_pubsub::conn_control::ConnControl::DisconnectPubkey {
+                            pubkey,
+                            event_id,
+                            reason,
+                        } => {
+                            state_for_conn_ctrl.conn_manager.disconnect_pubkey(
+                                scoped.community_id,
+                                &pubkey,
+                                &event_id,
+                                &reason,
+                            );
+                        }
+                    },
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        metrics::counter!("buzz_conn_control_lag_total").increment(n);
+                        tracing::warn!("Connection-control consumer lagged by {n} messages");
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        tracing::error!("Connection-control broadcast channel closed");
                         break;
                     }
                 }

--- a/crates/buzz-relay/src/state.rs
+++ b/crates/buzz-relay/src/state.rs
@@ -33,6 +33,10 @@ use crate::subscription::SubscriptionRegistry;
 /// Per-connection entry in the connection manager.
 struct ConnEntry {
     tx: mpsc::Sender<WsMessage>,
+    /// Control-frame sender, drained ahead of data and before cancel wins in
+    /// the send loop. Used to deliver a ban-disconnect frame that must reach
+    /// the client before the socket is closed (see [`ConnectionManager::disconnect_pubkey`]).
+    ctrl_tx: mpsc::Sender<WsMessage>,
     cancel: CancellationToken,
     /// Community resolved from the connection host at handshake. This is the
     /// receiver-side tenant label fan-out must compare against the event label.
@@ -68,6 +72,7 @@ impl ConnectionManager {
         &self,
         conn_id: Uuid,
         tx: mpsc::Sender<WsMessage>,
+        ctrl_tx: mpsc::Sender<WsMessage>,
         cancel: CancellationToken,
         community_id: CommunityId,
         backpressure_count: Arc<AtomicU8>,
@@ -78,6 +83,7 @@ impl ConnectionManager {
             conn_id,
             ConnEntry {
                 tx,
+                ctrl_tx,
                 cancel,
                 community_id,
                 backpressure_count,
@@ -127,6 +133,50 @@ impl ConnectionManager {
         self.connections
             .get(&conn_id)
             .and_then(|entry| entry.authenticated_pubkey.read().ok()?.clone())
+    }
+
+    /// Disconnect every live connection authenticated as `pubkey` **in
+    /// `community`**, delivering a final `OK false` frame carrying `reason`
+    /// before closing.
+    ///
+    /// Used for live ban enforcement (COMMUNITY_MODERATION_PLAN.md §0 decision
+    /// 4): a ban must take effect immediately on existing sessions, not just at
+    /// the next auth. The frame is sent on the control channel, which the send
+    /// loop drains ahead of both queued data and the biased cancel branch, so
+    /// the client learns *why* it was dropped. `event_id` labels the `OK` (the
+    /// ban has no triggering client event, so a synthetic all-zero id is used).
+    ///
+    /// The `community` filter is the tenant fence: one pod holds sockets for
+    /// many communities, and the same pubkey may be live in several. A ban in
+    /// community A must close only A's sockets, never a session the member holds
+    /// in community B ("authority stays inside the tenant fence").
+    ///
+    /// Returns the number of connections closed. This is the pod-local half of
+    /// live enforcement; cross-pod fan-out publishes the same intent over Redis.
+    pub fn disconnect_pubkey(
+        &self,
+        community: CommunityId,
+        pubkey: &[u8],
+        event_id: &str,
+        reason: &str,
+    ) -> usize {
+        let frame = crate::protocol::RelayMessage::ok(event_id, false, reason);
+        let mut closed = 0usize;
+        for conn_id in self.connection_ids_for_pubkey(pubkey) {
+            if let Some(entry) = self.connections.get(&conn_id) {
+                if entry.community_id != community {
+                    continue;
+                }
+                // Best-effort delivery: a full control buffer still gets the
+                // close via cancel below, just without the reason frame.
+                let _ = entry
+                    .ctrl_tx
+                    .try_send(WsMessage::Text(frame.clone().into()));
+                entry.cancel.cancel();
+                closed += 1;
+            }
+        }
+        closed
     }
 
     /// Return the server-resolved community that the connection's host bound to.
@@ -744,12 +794,14 @@ mod tests {
     use tokio::sync::{Mutex, RwLock};
 
     /// Helper: create a ConnectionManager with one registered connection.
-    /// Returns (manager, conn_id, receiver, cancel, shared_backpressure_count).
+    /// Returns (manager, conn_id, receiver, ctrl_receiver, cancel,
+    /// shared_backpressure_count).
     fn setup_conn(
         buffer_size: usize,
     ) -> (
         ConnectionManager,
         Uuid,
+        mpsc::Receiver<WsMessage>,
         mpsc::Receiver<WsMessage>,
         CancellationToken,
         Arc<AtomicU8>,
@@ -757,23 +809,25 @@ mod tests {
         let mgr = ConnectionManager::new();
         let conn_id = Uuid::new_v4();
         let (tx, rx) = mpsc::channel(buffer_size);
+        let (ctrl_tx, ctrl_rx) = mpsc::channel(buffer_size);
         let cancel = CancellationToken::new();
         let bp = Arc::new(AtomicU8::new(0));
         mgr.register(
             conn_id,
             tx,
+            ctrl_tx,
             cancel.clone(),
             buzz_core::tenant::CommunityId::from_uuid(Uuid::nil()),
             Arc::clone(&bp),
             Arc::new(Mutex::new(HashMap::new())),
             3,
         );
-        (mgr, conn_id, rx, cancel, bp)
+        (mgr, conn_id, rx, ctrl_rx, cancel, bp)
     }
 
     #[test]
     fn send_to_resets_grace_counter_on_success() {
-        let (mgr, id, _rx, _cancel, bp) = setup_conn(16);
+        let (mgr, id, _rx, _ctrl_rx, _cancel, bp) = setup_conn(16);
         // Simulate prior backpressure.
         bp.store(2, Ordering::Relaxed);
         assert!(mgr.send_to(id, "hello".into()));
@@ -787,7 +841,7 @@ mod tests {
     #[test]
     fn send_to_increments_grace_counter_on_full() {
         // Buffer size 1 — fill it, then the next send is Full.
-        let (mgr, id, _rx, cancel, bp) = setup_conn(1);
+        let (mgr, id, _rx, _ctrl_rx, cancel, bp) = setup_conn(1);
         assert!(mgr.send_to(id, "fill".into()));
         // Buffer is now full.
         assert!(!mgr.send_to(id, "overflow-1".into()));
@@ -807,7 +861,7 @@ mod tests {
 
     #[test]
     fn send_to_cancels_after_grace_limit() {
-        let (mgr, id, _rx, cancel, _bp) = setup_conn(1);
+        let (mgr, id, _rx, _ctrl_rx, cancel, _bp) = setup_conn(1);
         assert!(mgr.send_to(id, "fill".into()));
         // Exhaust grace: 3 consecutive Full events (matches grace_limit=3 from setup_conn).
         for _ in 0..3u8 {
@@ -849,6 +903,7 @@ mod tests {
         mgr.register(
             conn_id,
             tx,
+            conn.ctrl_tx.clone(),
             cancel.clone(),
             buzz_core::tenant::CommunityId::from_uuid(Uuid::nil()),
             Arc::clone(&bp),
@@ -885,12 +940,14 @@ mod tests {
         let mgr = ConnectionManager::new();
         let conn_id = Uuid::new_v4();
         let (tx, _rx) = mpsc::channel(1);
+        let (ctrl_tx, _ctrl_rx) = mpsc::channel(1);
         let cancel = CancellationToken::new();
         let bp = Arc::new(AtomicU8::new(0));
         let subscriptions = Arc::new(Mutex::new(HashMap::new()));
         mgr.register(
             conn_id,
             tx,
+            ctrl_tx,
             cancel,
             buzz_core::tenant::CommunityId::from_uuid(Uuid::nil()),
             bp,
@@ -910,12 +967,14 @@ mod tests {
         let mgr = ConnectionManager::new();
         let conn_id = Uuid::new_v4();
         let (tx, _rx) = mpsc::channel(1);
+        let (ctrl_tx, _ctrl_rx) = mpsc::channel(1);
         let cancel = CancellationToken::new();
         let bp = Arc::new(AtomicU8::new(0));
         let subscriptions = Arc::new(Mutex::new(HashMap::new()));
         mgr.register(
             conn_id,
             tx,
+            ctrl_tx,
             cancel,
             buzz_core::tenant::CommunityId::from_uuid(Uuid::nil()),
             bp,
@@ -928,5 +987,101 @@ mod tests {
         mgr.set_authenticated_pubkey(conn_id, pubkey.clone());
         assert_eq!(mgr.pubkey_for_conn(conn_id), Some(pubkey));
         assert_eq!(mgr.pubkey_for_conn(Uuid::new_v4()), None);
+    }
+
+    #[tokio::test]
+    async fn disconnect_pubkey_closes_matching_conns_with_reason() {
+        let (mgr, id, _rx, mut ctrl_rx, cancel, _bp) = setup_conn(8);
+        let pubkey = vec![3u8; 32];
+        mgr.set_authenticated_pubkey(id, pubkey.clone());
+
+        // setup_conn registers the connection under the nil community.
+        let community = buzz_core::tenant::CommunityId::from_uuid(Uuid::nil());
+        let closed = mgr.disconnect_pubkey(
+            community,
+            &pubkey,
+            "0".repeat(64).as_str(),
+            "blocked: banned",
+        );
+
+        assert_eq!(closed, 1, "the one matching connection is closed");
+        assert!(
+            cancel.is_cancelled(),
+            "connection is cancelled (socket close)"
+        );
+        // The reason frame is queued on the control channel ahead of the close.
+        let frame = ctrl_rx.try_recv().expect("reason frame delivered");
+        match frame {
+            WsMessage::Text(t) => {
+                assert!(t.as_str().contains("blocked: banned"), "carries the reason");
+                assert!(t.as_str().contains("false"), "is an OK false frame");
+            }
+            other => panic!("expected text frame, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn disconnect_pubkey_ignores_non_matching_conns() {
+        let (mgr, id, _rx, _ctrl_rx, cancel, _bp) = setup_conn(8);
+        mgr.set_authenticated_pubkey(id, vec![1u8; 32]);
+
+        let community = buzz_core::tenant::CommunityId::from_uuid(Uuid::nil());
+        let closed = mgr.disconnect_pubkey(
+            community,
+            &[2u8; 32],
+            "0".repeat(64).as_str(),
+            "blocked: banned",
+        );
+
+        assert_eq!(closed, 0, "no connection matches a different pubkey");
+        assert!(!cancel.is_cancelled(), "unrelated connection stays live");
+    }
+
+    #[tokio::test]
+    async fn disconnect_pubkey_is_fenced_to_the_banning_community() {
+        // Same pubkey, two live sockets in two different communities on one pod.
+        // A ban in community A must close only A's socket, never B's — the
+        // tenant fence on live-disconnect fan-out (B1).
+        let mgr = ConnectionManager::new();
+        let pubkey = vec![7u8; 32];
+
+        let community_a = buzz_core::tenant::CommunityId::from_uuid(Uuid::from_u128(0xa));
+        let community_b = buzz_core::tenant::CommunityId::from_uuid(Uuid::from_u128(0xb));
+
+        let register = |community| {
+            let conn_id = Uuid::new_v4();
+            let (tx, _rx) = mpsc::channel(8);
+            let (ctrl_tx, _ctrl_rx) = mpsc::channel(8);
+            let cancel = CancellationToken::new();
+            mgr.register(
+                conn_id,
+                tx,
+                ctrl_tx,
+                cancel.clone(),
+                community,
+                Arc::new(AtomicU8::new(0)),
+                Arc::new(Mutex::new(HashMap::new())),
+                3,
+            );
+            mgr.set_authenticated_pubkey(conn_id, pubkey.clone());
+            cancel
+        };
+
+        let cancel_a = register(community_a);
+        let cancel_b = register(community_b);
+
+        let closed = mgr.disconnect_pubkey(
+            community_a,
+            &pubkey,
+            "0".repeat(64).as_str(),
+            "blocked: banned",
+        );
+
+        assert_eq!(closed, 1, "only the community-A socket is closed");
+        assert!(cancel_a.is_cancelled(), "community-A session is closed");
+        assert!(
+            !cancel_b.is_cancelled(),
+            "community-B session stays live — ban does not cross the tenant fence"
+        );
     }
 }

--- a/crates/buzz-relay/src/state.rs
+++ b/crates/buzz-relay/src/state.rs
@@ -20,6 +20,7 @@ use buzz_core::CommunityId;
 use buzz_db::Db;
 use buzz_media::MediaStorage;
 use buzz_pubsub::cache_invalidation::CacheInvalidation;
+use buzz_pubsub::conn_control::ConnControl;
 use buzz_pubsub::{PubSubManager, RedisNip98ReplayGuard};
 use buzz_search::SearchService;
 use buzz_workflow::WorkflowEngine;
@@ -654,6 +655,53 @@ impl AppState {
                 self.invalidate_channel_deleted_local();
             }
         }
+    }
+
+    /// Enforce a live ban cluster-wide: close this pod's sockets for `pubkey`
+    /// now (fenced to `tenant`'s community) and fan the same disconnect out to
+    /// every other pod over the conn-control Redis channel.
+    ///
+    /// This is the single entry point for live ban enforcement (decision 4:
+    /// "a ban takes effect immediately, everywhere, including live sessions").
+    /// Callers must not invoke the pod-local `conn_manager.disconnect_pubkey`
+    /// directly — doing so closes sockets only on the pod that processed the
+    /// ban and silently drops the cluster-wide half. Pairing both halves here
+    /// makes that mistake unrepresentable.
+    ///
+    /// Returns the number of sockets closed on *this* pod only — remote pods
+    /// close asynchronously and do not report back, so callers must not treat
+    /// the count as cluster-wide truth. The cross-pod publish is fire-and-forget
+    /// (mirrors [`Self::spawn_cache_invalidation`]): the DB ban row is the
+    /// durable backstop, so a dropped publish still refuses the banned member's
+    /// next auth and next write.
+    pub fn disconnect_pubkey_clusterwide(
+        &self,
+        tenant: &TenantContext,
+        pubkey: &[u8],
+        event_id: &str,
+        reason: &str,
+    ) -> usize {
+        let closed =
+            self.conn_manager
+                .disconnect_pubkey(tenant.community(), pubkey, event_id, reason);
+
+        // The banning pod re-receives its own publish through the subscriber and
+        // no-ops (its local sockets are already closed above) — intentional; do
+        // not add origin-suppression, it buys nothing.
+        let pubsub = Arc::clone(&self.pubsub);
+        let tenant = tenant.clone();
+        let command = ConnControl::DisconnectPubkey {
+            pubkey: pubkey.to_vec(),
+            event_id: event_id.to_string(),
+            reason: reason.to_string(),
+        };
+        tokio::spawn(async move {
+            if let Err(e) = pubsub.publish_conn_control(&tenant, &command).await {
+                tracing::warn!("Failed to publish conn-control disconnect: {e}");
+            }
+        });
+
+        closed
     }
 
     /// Get accessible channel IDs with a 10-second cache. Falls back to DB on miss.


### PR DESCRIPTION
## L4 — community moderation enforcement seam (Phase 1)

Enforces bans and timeouts at the three points where a restricted member can act. Consumes L1's `Db::moderation_restriction_state` seam (PR #1592).

### What's enforced

**Auth seam** (`handlers/auth.rs`) — a banned member's AUTH is rejected with `OK false "blocked: you are banned from this community"` and the connection is dropped. Includes a **NIP-OA owner cascade**: a crypto-proven owner whose owner-pubkey is banned is refused too. Fails closed on DB error.

**Ingest write-block** (`handlers/ingest.rs`) — a timed-out member's EVENTs are refused with `restricted: you are timed out until <ts>` until expiry. Moderation-command and relay-admin kinds are **exempt** so the tools that lift a timeout are never disarmed. Bans never reach here (dropped at auth), so this gate is timeout-only. Fails closed.

**Live disconnect** (`state.rs`) — `ConnectionManager::disconnect_pubkey` closes every live socket for a pubkey, delivering the close reason over the **control channel** (drained ahead of the biased cancel in `send_loop`) so the client learns why before the socket drops.

**Cross-pod fan-out** (`buzz-pubsub/src/conn_control.rs`) — a new Redis pub/sub channel carrying `ConnControl::DisconnectPubkey`, **parallel to `cache_invalidation`** rather than folded into it: a disconnect is an imperative, non-idempotent action, not a pure cache-key drop. `main.rs` spawns the subscriber + a consumer that applies inbound commands via `disconnect_pubkey`. The DB ban row is the durable backstop — even a dropped command still refuses the banned member's next auth attempt.

### Lane boundaries
- The 9040 handler that **calls** `publish_conn_control` + local `disconnect_pubkey` on ban creation is L6 (Quinn).
- `matched_principal` audit at ban-creation is L1/L6.

### Validation
Validated against the **real L1 seam** (overlay of `max/moderation-l1` DB files, then restored):
- `cargo check -p buzz-pubsub -p buzz-relay -p buzz-db` ✅
- 4 `conn_control` tests, 2 `disconnect_pubkey` tests, 88 `ingest` tests ✅
- `cargo fmt --check` ✅ · `git diff --check` ✅ · pre-commit hooks ✅

### ⚠️ Merge order
This PR **depends on L1 (#1592)** for `moderation_restriction_state`. Base `eva/community-moderation` does not yet contain that seam, so CI will not compile until **L1 merges into `eva/community-moderation` first**; I'll rebase then. Per Eva's arbitration: no stacking, base = `eva/community-moderation`.
