### PR TITLE
fix(desktop): render thread facepile oldest-replier-first

### DIFF
--- a/desktop/src/features/messages/lib/threadPanel.test.mjs
+++ b/desktop/src/features/messages/lib/threadPanel.test.mjs
@@ -631,11 +631,38 @@ test("buildMainTimelineEntries renders a relay-only thread summary", () => {
     threadHeadId: "root",
     replyCount: 4,
     lastReplyAt: 9,
+    // Relay returns participants most-recent-first (["alice", "bob"]); the
+    // facepile renders them oldest-first so the last replier lands rightmost.
     participants: [
-      { id: "alice", author: "Alice", avatarUrl: "alice.png" },
       { id: "bob", author: "bob", avatarUrl: null },
+      { id: "alice", author: "Alice", avatarUrl: "alice.png" },
     ],
   });
+});
+
+test("buildMainTimelineEntries keeps the 3 most-recent relay participants oldest-first", () => {
+  const root = message({ id: "root", createdAt: 1 });
+  const summaries = new Map([
+    [
+      "root",
+      {
+        replyCount: 4,
+        descendantCount: 4,
+        lastReplyAt: 9,
+        // Relay order is most-recent-first; only the top 3 are displayed.
+        participantPubkeys: ["newest", "middle", "oldest-shown", "dropped"],
+      },
+    ],
+  ]);
+
+  const [entry] = buildMainTimelineEntries([root], new Set(), summaries);
+
+  // Top-3 taken (drops "dropped"), then reversed to oldest-first so the last
+  // replier ("newest") renders rightmost.
+  assert.deepEqual(
+    entry.summary?.participants.map((participant) => participant.id),
+    ["oldest-shown", "middle", "newest"],
+  );
 });
 
 test("buildMainTimelineEntries merges local knowledge over the relay floor", () => {

--- a/desktop/src/features/messages/lib/threadPanel.ts
+++ b/desktop/src/features/messages/lib/threadPanel.ts
@@ -392,11 +392,18 @@ function buildRelayThreadSummary(
     threadHeadId: messageId,
     replyCount: summary.descendantCount,
     lastReplyAt: summary.lastReplyAt,
-    participants: summary.participantPubkeys.slice(0, 3).map((pubkey) => ({
-      id: pubkey,
-      author: profiles?.[pubkey.toLowerCase()]?.displayName ?? pubkey,
-      avatarUrl: profiles?.[pubkey.toLowerCase()]?.avatarUrl ?? null,
-    })),
+    // The relay returns `participantPubkeys` most-recent-first. Take the 3 most
+    // recent, then reverse to oldest-first so the facepile renders the last
+    // replier at the end (rightmost) — matching the client-assembled path
+    // (`buildSummaryForDirectReplies`, which also reverses to oldest-first).
+    participants: summary.participantPubkeys
+      .slice(0, 3)
+      .reverse()
+      .map((pubkey) => ({
+        id: pubkey,
+        author: profiles?.[pubkey.toLowerCase()]?.displayName ?? pubkey,
+        avatarUrl: profiles?.[pubkey.toLowerCase()]?.avatarUrl ?? null,
+      })),
   };
 }
 


### PR DESCRIPTION
## Summary

The thread summary facepile was showing the **last person to reply first** (leftmost). This reverses it back to **oldest-replier-first**, so the most recent replier lands at the end (rightmost) — the behavior before PR #1500.

## Root cause

PR #1500 ("GUI read-model overhaul") moved thread summaries to a relay-assembled model:

- The relay returns participant pubkeys **most-recent-first** (`crates/buzz-db/src/thread.rs`, `ORDER BY last_seen DESC`).
- The new `buildRelayThreadSummary` in `desktop/src/features/messages/lib/threadPanel.ts` rendered them as-is (`participantPubkeys.slice(0, 3)`), so the last replier appeared first.

The pre-#1500 client-assembled path (`buildSummaryForDirectReplies`) reverses to oldest-first. This restores agreement between the two paths.

## Change

One-line fix: take the top-3 (most recent) relay participants, then `.reverse()` to oldest-first before mapping to display objects.

## Tests

- Updated `buildMainTimelineEntries renders a relay-only thread summary` to expect oldest-first order.
- Added a 4-participant test locking in "keep top-3 most recent, display oldest-first".
- Full desktop JS suite green (2030 passing); biome lint + format clean.

## Note on CI

`just ci` currently fails on **pre-existing Rust clippy errors** in `desktop/src-tauri` (`archive/mod_tests.rs`, `commands/personas/writeback.rs`, `managed_agents/config_bridge/claude.rs`) — all in files this PR does not touch. This change is TypeScript-only; pre-push hooks (fmt, clippy, all unit tests across Rust/desktop/Tauri/mobile) passed on push.
