### PR TITLE
fix: user search returns zero results for partially typed names

### DIFF
--- a/desktop/src-tauri/src/commands/profile.rs
+++ b/desktop/src-tauri/src/commands/profile.rs
@@ -168,6 +168,16 @@ pub async fn get_user_notes(
     Ok(nostr_convert::user_notes_from_events(&events))
 }
 
+fn build_user_search_filter(query: &str, limit: usize, page: u32) -> serde_json::Value {
+    serde_json::json!({
+        "kinds": [0],
+        "search": query,
+        "search_mode": "prefix",
+        "limit": limit,
+        "page": page,
+    })
+}
+
 #[tauri::command]
 pub async fn search_users(
     query: String,
@@ -225,16 +235,14 @@ pub async fn search_users(
     // `content` blob, where a hit in `display_name` is not weighted any higher
     // than a substring hit in `about`. The caller can request later pages via the
     // cursor so the UI cap is only a page size, not a terminal directory ceiling.
-    let events = query_relay(
-        &state,
-        &[serde_json::json!({
-            "kinds": [0],
-            "search": trimmed,
-            "limit": max,
-            "page": page,
-        })],
-    )
-    .await?;
+    //
+    // `search_mode: "prefix"` matters: every caller of this command is a
+    // typeahead surface (member picker, @mention popup, DM recipient search,
+    // topbar people results), so a partially typed name must match. Without it
+    // the relay runs whole-word `websearch_to_tsquery` matching and "tyl"
+    // returns zero results for "Tyler". Same bridge-only extension the topbar
+    // message search uses (see `build_search_messages_filter`).
+    let events = query_relay(&state, &[build_user_search_filter(trimmed, max, page)]).await?;
 
     let mut response = nostr_convert::rank_user_search_results(&events, trimmed, max);
     if events.len() >= max {
@@ -320,5 +328,24 @@ fn empty_profile_info(pubkey: &str) -> ProfileInfo {
         nip05_handle: None,
         owner_pubkey: None,
         has_profile_event: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_search_filter_requests_prefix_mode_for_typeahead() {
+        // Every caller of `search_users` is a typeahead surface. Whole-word
+        // FTS matching returns zero results for a partially typed name
+        // ("tyl" for "Tyler"), which reads as "user doesn't exist" in the
+        // member picker and @mention popup. Pin the mode so it can't drift.
+        let filter = build_user_search_filter("tyl", 25, 1);
+
+        assert_eq!(filter["search"], serde_json::json!("tyl"));
+        assert_eq!(filter["search_mode"], serde_json::json!("prefix"));
+        assert_eq!(filter["limit"], serde_json::json!(25));
+        assert_eq!(filter["page"], serde_json::json!(1));
     }
 }


### PR DESCRIPTION
## Problem

Wes reported a user missing from the add-member picker, and separately from the @mention popup (buzz-bugs thread). It looked like a result-count limit — it isn't. Every hop was traced: GUI asks for 25–50, the Tauri command clamps at 500, the relay bridge and FTS layer clamp at 500. Nothing truncates below what the UI displays.

The real bug: the `search_users` Tauri command — the single backend for **all** user typeahead surfaces (member picker, @mention popup, DM recipient search, topbar people results) — sends a plain NIP-50 search. The relay bridge runs that through `websearch_to_tsquery` whole-word matching, so a partially typed name matches nothing:

Live repro against staging (`sprout-oss.stage`):
| query | before | after (`search_mode: prefix`) |
|---|---|---|
| `tyl` | 0 | 1 (Tyler) |
| `bax` | 0 | 3 (baxen, baxendev, …) |
| `We` | 0 | 10+ |

Zero results reads as "user doesn't exist" — exactly what Wes saw mid-typing.

## Fix

Opt user search into the relay's existing bridge-only `search_mode: "prefix"` extension — the same one the topbar *message* search already uses (`build_search_messages_filter`, messages.rs:134). Prefix mode keeps completed tokens exact and prefix-matches only the trailing token, server-side in Postgres, with all access checks unchanged.

Filter construction is extracted into `build_user_search_filter` and pinned by a unit test, mirroring the messages.rs convention, so the mode can't silently drift.

## Not fixed here (by design)

The specific "Brad" case has a second, non-code cause: his kind:0 `display_name` is `baxen` — no profile on the relay contains "Brad" in its name (verified by paging all 3,443 kind:0 events). No search mode can fix that; it's a profile-naming question.

## Testing

- `just desktop-tauri-test`: 1006 passed, 0 failed (includes new `user_search_filter_requests_prefix_mode_for_typeahead`)
- Live staging repro above via `POST /query` with and without `search_mode`