### PR TITLE
docs(readme): add Getting started section routing install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,34 @@ Agents are part of the room, not haunted cron jobs.
 
 ---
 
+## Getting started
+
+New to Buzz? Pick the path that matches you.
+
+### I just want to try the app
+
+Grab a packaged build from the [latest release](https://github.com/block/buzz/releases/latest) — macOS (`.dmg`), Linux (`.AppImage` / `.deb`), or Windows (`.exe`). Install it like any other app.
+
+By default the app connects to `ws://localhost:3000`. To try Buzz without running anything yourself, point it at Block's public relay:
+
+```
+wss://sprout.up.railway.app
+```
+
+Set `BUZZ_RELAY_URL` to that before launching, or switch the relay from inside the app. You can also point it at a relay you're running or one someone shared with you — or follow **Build & run from source** below to stand one up locally.
+
+### I work at Block
+
+Don't build from source, and don't use the OSS release — use the internal build. It comes pre-wired to the Block relay and agent provider, so it works out of the box with nothing to configure.
+
+Download the latest build from [`squareup/buzz-releases` releases](https://github.com/squareup/buzz-releases/releases/latest) and install it.
+
+### I want to build & run from source
+
+See **Quick start** below — this is the developer / self-host path.
+
+---
+
 ## Quick start
 
 You'll need [Docker](https://docs.docker.com/get-docker/) and [Hermit](https://cashapp.github.io/hermit/) (or Rust 1.88+, Node 24+, pnpm 10+, `just`).

--- a/README.md
+++ b/README.md
@@ -117,13 +117,7 @@ New to Buzz? Pick the path that matches you.
 
 Grab a packaged build from the [latest release](https://github.com/block/buzz/releases/latest) — macOS (`.dmg`), Linux (`.AppImage` / `.deb`), or Windows (`.exe`). Install it like any other app.
 
-By default the app connects to `ws://localhost:3000`. To try Buzz without running anything yourself, point it at Block's public relay:
-
-```
-wss://sprout.up.railway.app
-```
-
-Set `BUZZ_RELAY_URL` to that before launching, or switch the relay from inside the app. You can also point it at a relay you're running or one someone shared with you — or follow **Build & run from source** below to stand one up locally.
+By default the app connects to `ws://localhost:3000`. To point it at a relay you're running or one someone shared with you, set `BUZZ_RELAY_URL` before launching, or switch the relay from inside the app. If you don't have a relay yet, follow **Build & run from source** below to stand one up locally.
 
 ### I work at Block
 


### PR DESCRIPTION
## Summary

The README's only onboarding path was build-from-source (`Quick start`), which sent every new user — including Block employees — through a full Rust workspace build. This adds a `## Getting started` section above `Quick start` with three tracks:

- **Try the app** — download a packaged release, connect to a relay via `BUZZ_RELAY_URL` or in-app settings
- **Block employee** — use the internal build from `squareup/buzz-releases` (pre-wired relay + provider)
- **Build from source** — links to the existing `Quick start`