### PR TITLE
moderation(L6): verify moderation reads against full request URL incl. query

### DIFF
--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path, Query, State},
+    extract::{Path, Query, RawQuery, State},
     http::{HeaderMap, StatusCode},
     response::Json,
 };
@@ -1647,10 +1647,20 @@ async fn synthesize_presence(
 
 /// Shared prelude for a moderation read: bind tenant, verify NIP-98 GET auth,
 /// replay-check, and confirm the caller may view the queue.
+///
+/// `raw_query` is the request's raw query string (from [`axum::extract::RawQuery`]),
+/// e.g. `Some("limit=20&status=open")`. NIP-98 signs the *full* request URL, so the
+/// client's `u` tag includes any query string; the expected URL reconstructed here
+/// must therefore append the same query verbatim or query-bearing reads
+/// (`reports?limit=…`, `audit?limit=…`) 401 on a URL mismatch. Query-less reads
+/// (`restricted`) pass `None` and keep the bare-path expectation. The verbatim
+/// request query is used (not a re-serialized parse) so the match stays byte-exact
+/// with what the client signed regardless of param order or encoding.
 async fn authorize_moderation_read(
     state: &Arc<AppState>,
     headers: &HeaderMap,
     path: &str,
+    raw_query: Option<&str>,
 ) -> Result<TenantContext, (StatusCode, Json<Value>)> {
     let raw_host = headers
         .get(axum::http::header::HOST)
@@ -1665,7 +1675,11 @@ async fn authorize_moderation_read(
             )
         })?;
 
-    let url = nip98_expected_url(&state.config.relay_url, &tenant, path);
+    let path_with_query = match raw_query {
+        Some(q) if !q.is_empty() => format!("{path}?{q}"),
+        _ => path.to_string(),
+    };
+    let url = nip98_expected_url(&state.config.relay_url, &tenant, &path_with_query);
     let (pubkey, event_id_bytes) =
         verify_bridge_auth(headers, "GET", &url, None, state.config.require_auth_token)?;
     check_nip98_replay(state, &tenant, event_id_bytes).await?;
@@ -1711,9 +1725,16 @@ fn clamp_limit(requested: Option<i64>) -> i64 {
 pub async fn moderation_reports(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
     Query(q): Query<ModerationReadQuery>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let tenant = authorize_moderation_read(&state, &headers, "/moderation/reports").await?;
+    let tenant = authorize_moderation_read(
+        &state,
+        &headers,
+        "/moderation/reports",
+        raw_query.as_deref(),
+    )
+    .await?;
     let rows = state
         .db
         .list_moderation_reports(
@@ -1730,9 +1751,12 @@ pub async fn moderation_reports(
 pub async fn moderation_audit(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
     Query(q): Query<ModerationReadQuery>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let tenant = authorize_moderation_read(&state, &headers, "/moderation/audit").await?;
+    let tenant =
+        authorize_moderation_read(&state, &headers, "/moderation/audit", raw_query.as_deref())
+            .await?;
     let rows = state
         .db
         .list_moderation_actions(tenant.community(), clamp_limit(q.limit))
@@ -1746,7 +1770,8 @@ pub async fn moderation_restricted(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let tenant = authorize_moderation_read(&state, &headers, "/moderation/restricted").await?;
+    let tenant =
+        authorize_moderation_read(&state, &headers, "/moderation/restricted", None).await?;
     let rows = state
         .db
         .list_community_restrictions(tenant.community())
@@ -2097,6 +2122,133 @@ mod tests {
             keys.public_key(),
             "returned pubkey must be the signer's"
         );
+    }
+
+    /// Mirror of the query-reconstruction `authorize_moderation_read` performs
+    /// before calling [`nip98_expected_url`], so the tests below pin the exact
+    /// seam without a DB harness. Kept in lockstep with the production match arm.
+    fn moderation_read_expected_url(
+        config_relay_url: &str,
+        tenant: &TenantContext,
+        path: &str,
+        raw_query: Option<&str>,
+    ) -> String {
+        let path_with_query = match raw_query {
+            Some(q) if !q.is_empty() => format!("{path}?{q}"),
+            _ => path.to_string(),
+        };
+        nip98_expected_url(config_relay_url, tenant, &path_with_query)
+    }
+
+    /// L7 read-auth blocker (Wren, #1591 sweep): the CLI signs the *full*
+    /// request URL — including `?limit=…&status=…` — but the relay used to
+    /// reconstruct the expected URL from the bare path only, so
+    /// `buzz moderation reports` / `audit` 401'd on a NIP-98 URL mismatch in
+    /// normal use. This pins that a query-bearing GET verifies iff the expected
+    /// URL carries the same query verbatim. Bites if the query is ever dropped
+    /// from `authorize_moderation_read`'s expected-URL reconstruction.
+    #[test]
+    fn moderation_read_query_bearing_nip98_event_verifies_with_matching_query() {
+        let keys = Keys::generate();
+        // CLI signs the URL it actually requests, query and all.
+        let signed_url = "https://host-a.example/moderation/reports?limit=20&status=open";
+        let event_json = build_nip98_event_json(&keys, signed_url, "GET");
+        let headers = nip98_auth_headers(&event_json);
+
+        let tenant_a = fresh_tenant("host-a.example");
+        let expected_url = moderation_read_expected_url(
+            "wss://config-host.example",
+            &tenant_a,
+            "/moderation/reports",
+            Some("limit=20&status=open"),
+        );
+
+        let (pubkey, _event_id_bytes) =
+            verify_bridge_auth(&headers, "GET", &expected_url, None, true)
+                .expect("query-bearing moderation read must verify against the same query");
+        assert_eq!(pubkey, keys.public_key());
+    }
+
+    /// Anti-regression control proving the fix is load-bearing: the same
+    /// query-bearing event MUST be rejected when the expected URL omits the
+    /// query — the pre-fix behavior. If this ever passes, the relay has
+    /// silently reverted to bare-path reconstruction.
+    #[test]
+    fn moderation_read_query_bearing_nip98_event_rejected_against_bare_path() {
+        let keys = Keys::generate();
+        let signed_url = "https://host-a.example/moderation/reports?limit=20&status=open";
+        let event_json = build_nip98_event_json(&keys, signed_url, "GET");
+        let headers = nip98_auth_headers(&event_json);
+
+        let tenant_a = fresh_tenant("host-a.example");
+        // No query — the broken pre-fix reconstruction.
+        let bare_url = moderation_read_expected_url(
+            "wss://config-host.example",
+            &tenant_a,
+            "/moderation/reports",
+            None,
+        );
+
+        let (status, body) = verify_bridge_auth(&headers, "GET", &bare_url, None, true)
+            .expect_err("query-signed event MUST NOT match a bare-path expected URL");
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let msg = body
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            msg.contains("URL mismatch"),
+            "rejection must be a URL mismatch; got body = {body:?}"
+        );
+    }
+
+    /// `audit?limit=20` — the second query-bearing read path — verifies the
+    /// same way. Pins that the reconstruction is generic over the path, not
+    /// special-cased to `reports`.
+    #[test]
+    fn moderation_read_audit_query_bearing_nip98_event_verifies() {
+        let keys = Keys::generate();
+        let signed_url = "https://host-a.example/moderation/audit?limit=20";
+        let event_json = build_nip98_event_json(&keys, signed_url, "GET");
+        let headers = nip98_auth_headers(&event_json);
+
+        let tenant_a = fresh_tenant("host-a.example");
+        let expected_url = moderation_read_expected_url(
+            "wss://config-host.example",
+            &tenant_a,
+            "/moderation/audit",
+            Some("limit=20"),
+        );
+
+        let (pubkey, _event_id_bytes) =
+            verify_bridge_auth(&headers, "GET", &expected_url, None, true)
+                .expect("audit query-bearing read must verify");
+        assert_eq!(pubkey, keys.public_key());
+    }
+
+    /// `restricted` has no query and passes `None`, so its expected URL stays
+    /// the bare path — a query-less signed event verifies. Pins Wren's
+    /// "preserve restricted no-query behavior" checklist item.
+    #[test]
+    fn moderation_read_restricted_no_query_still_verifies() {
+        let keys = Keys::generate();
+        let signed_url = "https://host-a.example/moderation/restricted";
+        let event_json = build_nip98_event_json(&keys, signed_url, "GET");
+        let headers = nip98_auth_headers(&event_json);
+
+        let tenant_a = fresh_tenant("host-a.example");
+        let expected_url = moderation_read_expected_url(
+            "wss://config-host.example",
+            &tenant_a,
+            "/moderation/restricted",
+            None,
+        );
+        assert_eq!(expected_url, "https://host-a.example/moderation/restricted");
+
+        let (pubkey, _event_id_bytes) =
+            verify_bridge_auth(&headers, "GET", &expected_url, None, true)
+                .expect("query-less restricted read must verify against the bare path");
+        assert_eq!(pubkey, keys.public_key());
     }
 
     /// `nip98_expected_url` derives host from `tenant`, not from


### PR DESCRIPTION
Fixes the NIP-98 read-auth mismatch Wren found in the #1591 L7 sweep: CLI signs the full request URL (query included), relay verified against the bare path only → `buzz moderation reports` / `audit` 401'd in normal use.

**Fix:** `authorize_moderation_read` takes the request's raw query (axum `RawQuery`) and appends it verbatim to the path before building the NIP-98 expected URL. `restricted` passes `None`, keeps bare-path expectation.

**Tests (4, bridge.rs):** query-bearing GET verifies iff expected URL carries the same query (`reports?limit=20&status=open`, `audit?limit=20`); anti-regression control proves the same event is rejected against the bare path; `restricted` still verifies query-less.

Validation on base `80594133`: fmt --check, clippy -p buzz-relay --all-targets -D warnings, buzz-relay --lib 503/503 green. Delta is bridge.rs only, +157/-5.

Co-authored-by: Tyler Longwell <tlongwell@block.xyz>
Signed-off-by: Tyler Longwell <tlongwell@block.xyz>