### PR TITLE
fix(desktop): backfill edits for thread replies so edited replies survive refetch

### DIFF
--- a/desktop/src/features/messages/lib/auxBackfill.test.mjs
+++ b/desktop/src/features/messages/lib/auxBackfill.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   collectAuxEventIdsForDeletionBackfill,
   collectMessageIdsForAuxBackfill,
+  fetchStructuralAuxForMessages,
   mergeAuxEventsWithDeletionBackfill,
 } from "./auxBackfill.ts";
 
@@ -125,4 +126,55 @@ test("merges deletion markers that target cached or fetched auxiliary event ids"
     merged.map((cachedEvent) => cachedEvent.id),
     [fetchedReactionId, cachedReactionDeletionId, fetchedReactionDeletionId],
   );
+});
+
+test("fetchStructuralAuxForMessages returns edits plus their deletion closure", async () => {
+  const replyId = hex("1");
+  const editId = hex("2");
+  const editDeletionId = hex("3");
+  const edit = event(editId, 40003, {
+    content: "edited text",
+    tags: [
+      ["h", CHANNEL_ID],
+      ["e", replyId],
+    ],
+  });
+  const editDeletion = event(editDeletionId, 5, {
+    tags: [
+      ["h", CHANNEL_ID],
+      ["e", editId],
+    ],
+  });
+  const auxCalls = [];
+  const deletionCalls = [];
+
+  const auxEvents = await fetchStructuralAuxForMessages(CHANNEL_ID, [replyId], {
+    fetchAuxEventsForMessages: async (channelId, ids) => {
+      auxCalls.push({ channelId, ids });
+      return [edit];
+    },
+    fetchAuxDeletionEventsForAuxEvents: async (channelId, ids) => {
+      deletionCalls.push({ channelId, ids });
+      return [editDeletion];
+    },
+  });
+
+  assert.deepEqual(auxCalls, [{ channelId: CHANNEL_ID, ids: [replyId] }]);
+  assert.deepEqual(deletionCalls, [{ channelId: CHANNEL_ID, ids: [editId] }]);
+  assert.deepEqual(
+    auxEvents.map((auxEvent) => auxEvent.id),
+    [editId, editDeletionId],
+  );
+});
+
+test("fetchStructuralAuxForMessages skips all fetches for no message ids", async () => {
+  const auxEvents = await fetchStructuralAuxForMessages(CHANNEL_ID, [], {
+    fetchAuxEventsForMessages: async () => {
+      throw new Error("must not fetch aux for an empty id set");
+    },
+    fetchAuxDeletionEventsForAuxEvents: async () => {
+      throw new Error("must not fetch deletions for an empty id set");
+    },
+  });
+  assert.deepEqual(auxEvents, []);
 });

--- a/desktop/src/features/messages/lib/auxBackfill.ts
+++ b/desktop/src/features/messages/lib/auxBackfill.ts
@@ -66,6 +66,54 @@ export async function mergeAuxEventsWithDeletionBackfill(input: {
 }
 
 /**
+ * Structural aux closure (edits/deletions + deletions of those aux events)
+ * for an explicit set of message ids, returned to the caller instead of being
+ * merged into the channel cache. The thread-replies fetch uses this: the
+ * server thread-subtree query resolves deletions itself but returns content
+ * kinds only, so a reply's kind:40003 edit never rides along — without this
+ * backfill a refetch (thread reopen, channel switch) renders the original,
+ * un-edited text.
+ */
+export type StructuralAuxFetchDeps = {
+  fetchAuxEventsForMessages: (
+    channelId: string,
+    messageIds: string[],
+  ) => Promise<RelayEvent[]>;
+  fetchAuxDeletionEventsForAuxEvents: (
+    channelId: string,
+    auxEventIds: string[],
+  ) => Promise<RelayEvent[]>;
+};
+
+const defaultStructuralAuxDeps: StructuralAuxFetchDeps = {
+  fetchAuxEventsForMessages: (channelId, messageIds) =>
+    relayClient.fetchAuxEventsByReference(
+      channelId,
+      messageIds,
+      buildChannelStructuralAuxFilter,
+    ),
+  fetchAuxDeletionEventsForAuxEvents: (channelId, auxEventIds) =>
+    relayClient.fetchAuxDeletionEventsForAuxEvents(channelId, auxEventIds),
+};
+
+export async function fetchStructuralAuxForMessages(
+  channelId: string,
+  messageIds: string[],
+  deps: StructuralAuxFetchDeps = defaultStructuralAuxDeps,
+): Promise<RelayEvent[]> {
+  if (messageIds.length === 0) {
+    return [];
+  }
+  const auxEvents = await deps.fetchAuxEventsForMessages(channelId, messageIds);
+  return mergeAuxEventsWithDeletionBackfill({
+    channelId,
+    cachedEvents: [],
+    fetchedAuxEvents: auxEvents,
+    fetchAuxEventsForMessages: deps.fetchAuxDeletionEventsForAuxEvents,
+  });
+}
+
+/**
  * After a content-kinds-only history fetch, pull structural auxiliary events
  * (edits/deletions) that reference the loaded messages — keyed by `#e` over
  * their ids, not by a time window — and merge them into the same channel cache.

--- a/desktop/src/features/messages/useThreadReplies.ts
+++ b/desktop/src/features/messages/useThreadReplies.ts
@@ -1,11 +1,42 @@
 import { useQuery } from "@tanstack/react-query";
 
+import {
+  collectMessageIdsForAuxBackfill,
+  fetchStructuralAuxForMessages,
+} from "@/features/messages/lib/auxBackfill";
 import { threadRepliesKey } from "@/features/messages/lib/messageQueryKeys";
 import { getThreadReplies } from "@/shared/api/tauri";
 import type { Channel, RelayEvent, ThreadCursor } from "@/shared/api/types";
 
 const THREAD_PAGE_LIMIT = 200;
 const MAX_THREAD_PAGES = 500;
+
+/**
+ * Append the structural aux closure (edits/deletions) for the fetched replies.
+ * The server thread-subtree query resolves deletions itself but omits
+ * kind:40003 edits, so a bare refetch would render every edited reply with its
+ * original text. Best-effort: an aux failure logs and returns the replies
+ * unadorned rather than failing the whole thread load.
+ */
+async function withStructuralAux(
+  channelId: string,
+  replies: RelayEvent[],
+): Promise<RelayEvent[]> {
+  try {
+    const auxEvents = await fetchStructuralAuxForMessages(
+      channelId,
+      collectMessageIdsForAuxBackfill(replies),
+    );
+    return auxEvents.length > 0 ? [...replies, ...auxEvents] : replies;
+  } catch (error) {
+    console.error(
+      "Failed to backfill thread reply edits for channel",
+      channelId,
+      error,
+    );
+    return replies;
+  }
+}
 
 /** Fetch a thread subtree into a cache independent from channel window pages. */
 export function useThreadReplies(
@@ -31,7 +62,8 @@ export function useThreadReplies(
           { limit: THREAD_PAGE_LIMIT, cursor },
         );
         replies.push(...response.events);
-        if (!response.nextCursor) return replies;
+        if (!response.nextCursor)
+          return withStructuralAux(activeChannel.id, replies);
         cursor = response.nextCursor;
       }
       throw new Error(


### PR DESCRIPTION
## Problem

Editing a **thread reply** shows the updated text live, but switching channels (or reopening the thread) reverts it to the original text. Very reproducible; reported by Aaron and Wes.

## Root cause

The thread-replies read path omits edit events:

- `get_thread_replies` returns content-kind events only — no kind-40003 (edit) aux events, unlike the channel-window path whose `WINDOW_AUX_KINDS` closure includes them.
- The client had no aux backfill on this path either. Live it *looks* edited only because the streamed 40003 gets merged into the `thread-replies` cache by `appendMessage`.
- `useThreadReplies` uses `staleTime: 0`, so any refetch replaces the cache with the aux-less server response, clobbering the live-merged edit — the message "un-edits" itself.

Top-level messages are unaffected (window path includes 40003s). Deletions are unaffected (resolved server-side in the subtree query). The hole is edit-specific to thread replies.

## Fix

After the thread-replies page loop, backfill the structural aux closure — kind-40003 edits referencing the fetched reply ids, plus deletions of those edits — by `#e`, reusing the existing `auxBackfill` machinery (`fetchAuxEventsByReference` / `buildChannelStructuralAuxFilter`). The refetch path now returns the same event set the live path accumulates; `formatTimelineMessages` already overlays 40003s downstream.

Works against the relay as deployed today — verified by replaying the exact backfill filter against staging (returns the 40003 with edited content).

## Verification

- All 2033 desktop unit tests pass, incl. 2 new tests for the backfill helper.
- e2e smoke: 397 passed / 2 failed / 1 skipped — both failures (`channels.spec.ts:876`, `custom-emoji.spec.ts:375`) reproduce identically on the parent commit `cdf982bd`, i.e. pre-existing locally and unrelated to this change.
- Relay-side repro fixtures and probe scripts confirmed the root cause before the fix (edit persists on relay; thread fetch omits it).

## Follow-up (out of scope)

The long-term shape is server-side: give `get_thread_replies` the same `include_aux` closure the channel-window path has (one round trip, fixes mobile clients too). Noting rather than gating this fix on a relay deploy.
