### PR TITLE
Hide non-invocable member agents from @-mention autocomplete

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -6,6 +6,7 @@ import {
   getMentionableAgentPubkeys,
   getSharedChannelIds,
   relayAgentIsSharedWithUser,
+  shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
 
 const CURRENT_PUBKEY = "a".repeat(64);
@@ -132,6 +133,87 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   });
 
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
+});
+
+test("shouldHideAgentFromMentions: never hides non-agents", () => {
+  assert.equal(
+    shouldHideAgentFromMentions({
+      isAgent: false,
+      isMember: false,
+      pubkey: PUB_A,
+      mentionableAgentPubkeys: new Set(),
+      directoryAgentPubkeys: new Set([PUB_A]),
+    }),
+    false,
+  );
+});
+
+test("shouldHideAgentFromMentions: shows invocable agents even when non-member", () => {
+  assert.equal(
+    shouldHideAgentFromMentions({
+      isAgent: true,
+      isMember: false,
+      pubkey: PUB_A,
+      mentionableAgentPubkeys: new Set([PUB_A]),
+      directoryAgentPubkeys: new Set([PUB_A]),
+    }),
+    false,
+  );
+});
+
+test("shouldHideAgentFromMentions: hides non-member non-invocable agents", () => {
+  assert.equal(
+    shouldHideAgentFromMentions({
+      isAgent: true,
+      isMember: false,
+      pubkey: PUB_A,
+      mentionableAgentPubkeys: new Set(),
+      directoryAgentPubkeys: new Set(),
+    }),
+    true,
+  );
+});
+
+test("shouldHideAgentFromMentions: hides member agents with an explicit not-invocable directory entry (Fizz)", () => {
+  assert.equal(
+    shouldHideAgentFromMentions({
+      isAgent: true,
+      isMember: true,
+      pubkey: PUB_A,
+      mentionableAgentPubkeys: new Set(),
+      directoryAgentPubkeys: new Set([PUB_A]),
+    }),
+    true,
+  );
+});
+
+test("shouldHideAgentFromMentions: shows member agents with unknown invocability (not in directory)", () => {
+  assert.equal(
+    shouldHideAgentFromMentions({
+      isAgent: true,
+      isMember: true,
+      pubkey: PUB_A,
+      mentionableAgentPubkeys: new Set(),
+      directoryAgentPubkeys: new Set(),
+    }),
+    false,
+  );
+});
+
+test("shouldHideAgentFromMentions: normalizes the pubkey before lookup", () => {
+  const mixedCase = "Ab".repeat(32);
+  const normalized = mixedCase.toLowerCase();
+
+  assert.equal(
+    shouldHideAgentFromMentions({
+      isAgent: true,
+      isMember: true,
+      pubkey: mixedCase,
+      mentionableAgentPubkeys: new Set(),
+      directoryAgentPubkeys: new Set([normalized]),
+    }),
+    true,
+  );
 });
 
 test("coalesceAgentAutocompleteCandidates: merges agents with the same persona id", () => {

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,6 +54,31 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
+export function shouldHideAgentFromMentions({
+  isAgent,
+  isMember,
+  pubkey,
+  mentionableAgentPubkeys,
+  directoryAgentPubkeys,
+}: {
+  isAgent: boolean;
+  isMember: boolean;
+  pubkey: string;
+  mentionableAgentPubkeys: ReadonlySet<string>;
+  directoryAgentPubkeys: ReadonlySet<string>;
+}) {
+  if (!isAgent) return false;
+  const normalized = normalizePubkey(pubkey);
+  // Invocable => always show.
+  if (mentionableAgentPubkeys.has(normalized)) return false;
+  // Non-member, non-invocable => hide (preserves prior behavior).
+  if (!isMember) return true;
+  // Member (Option B): hide only when we have an explicit not-invocable
+  // signal — a relay directory (kind:10100) entry that excludes us.
+  // Unknown invocability (not in directory) => show.
+  return directoryAgentPubkeys.has(normalized);
+}
+
 type AgentAutocompleteCandidate = {
   pubkey?: string;
   displayName?: string | null;

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -76,6 +76,14 @@ export function shouldHideAgentFromMentions({
   // Member (Option B): hide only when we have an explicit not-invocable
   // signal — a relay directory (kind:10100) entry that excludes us.
   // Unknown invocability (not in directory) => show.
+  //
+  // NOTE: this assumes `directoryAgentPubkeys` and `mentionableAgentPubkeys`
+  // share the same source query (`relayAgentsQuery.data`), so directory
+  // presence without membership in `mentionableAgentPubkeys` is a real
+  // explicit-exclusion signal. If a future change sources the directory set
+  // from a different query, an agent that's directory-present but whose
+  // mentionability is still loading could be hidden prematurely — keep the
+  // two sets derived from the same query.
   return directoryAgentPubkeys.has(normalized);
 }
 

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,6 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
+  shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
   useInfiniteUserSearchQuery,
@@ -209,6 +210,15 @@ export function useMentions(
       ),
     [relayAgentsQuery.data],
   );
+  const directoryAgentPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (relayAgentsQuery.data ?? []).map((agent) =>
+          normalizePubkey(agent.pubkey),
+        ),
+      ),
+    [relayAgentsQuery.data],
+  );
   const sharedChannelIds = React.useMemo(
     () => getSharedChannelIds(channelsQuery.data),
     [channelsQuery.data],
@@ -269,9 +279,13 @@ export function useMentions(
         return;
       }
       if (
-        candidate.isAgent &&
-        !candidate.isMember &&
-        !mentionableAgentPubkeys.has(pubkey)
+        shouldHideAgentFromMentions({
+          isAgent: candidate.isAgent === true,
+          isMember: candidate.isMember === true,
+          pubkey,
+          mentionableAgentPubkeys,
+          directoryAgentPubkeys,
+        })
       ) {
         return;
       }
@@ -425,6 +439,7 @@ export function useMentions(
     userSearchResults,
     canSearchGlobalUsers,
     currentPubkey,
+    directoryAgentPubkeys,
     isArchivedDiscovery,
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,


### PR DESCRIPTION
## Problem

Agents you can't invoke — e.g. `Fizz`, owned by another team — still show up in the composer's `@`-mention autocomplete when they've been added to a channel as members.

The autocomplete already has an invocability filter (`useMentions.ts`), but it only applied to agents that **aren't** channel members:

```ts
if (candidate.isAgent && !candidate.isMember && !mentionableAgentPubkeys.has(pubkey)) return;
```

Fizz is added to the channel as a member by its owning team, so `!candidate.isMember` is false, the check is skipped, and Fizz always appears — even though the backend (`author_allowed` in `buzz-acp`) would reject a mention of it.

## Fix

Extract the show/hide decision into a pure, tested helper `shouldHideAgentFromMentions(...)` and apply it to **all** agent candidates, member or not. The "can I invoke this agent" set (`getMentionableAgentPubkeys`) is unchanged and continues to mirror the backend gate.

Semantics (member agents are the new case):

| candidate | result |
|---|---|
| not an agent | show |
| invocable (in `mentionableAgentPubkeys`) | show |
| non-member & not invocable | **hide** (unchanged prior behavior) |
| member & not invocable & **in** relay directory (kind:10100) | **hide** (this is Fizz) |
| member & not invocable & **not** in directory (unknown / still loading) | show |

The last row is deliberate: we only hide a member agent when we have an *explicit* not-invocable signal (a directory entry that excludes the current user). If the agent's directory profile is missing or still loading, invocability is unknown and we keep showing it — we never hide an agent we can't confirm is non-invocable. `useMentions` builds a `directoryAgentPubkeys` set from `relayAgentsQuery.data` to supply that signal.

## Tests

Adds unit tests in `agentAutocompleteEligibility.test.mjs` covering every branch, including both member cases (Fizz hidden; unknown-invocability shown) and npub/hex pubkey normalization.

- `node --test` → 17/17 pass
- `biome check` (3 changed files) → clean
- `tsc --noEmit` → 0 errors
