### PR TITLE
fix(desktop): hash spawn config as the env receives it, not raw record fields

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1752,7 +1752,7 @@ pub fn spawn_agent_child(
     if let Some(toolsets) = &record.mcp_toolsets {
         command.env("BUZZ_TOOLSETS", toolsets);
     } else {
-        command.env("BUZZ_TOOLSETS", "default,canvas,forums,dms,media");
+        command.env("BUZZ_TOOLSETS", super::types::DEFAULT_MCP_TOOLSETS);
     }
     command.env_remove("BUZZ_ACP_PRIVATE_KEY");
     command.env_remove("BUZZ_ACP_API_TOKEN");

--- a/desktop/src-tauri/src/managed_agents/spawn_hash.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_hash.rs
@@ -92,11 +92,31 @@ pub(crate) fn spawn_config_hash(
     record.provider.hash(&mut hasher);
     record.auth_tag.hash(&mut hasher);
     record.respond_to.as_str().hash(&mut hasher);
-    record.respond_to_allowlist.hash(&mut hasher);
+    // The allowlist is hashed as the env receives it: spawn sets
+    // BUZZ_ACP_RESPOND_TO_ALLOWLIST only in allowlist mode, and normalized
+    // (trim/lowercase/dedup via `validate_respond_to_allowlist`) — so edits
+    // that don't survive normalization, or edits while another mode is
+    // active, must not badge. A list spawn would reject hashes raw: the
+    // stamped hash comes from a successful spawn, so any invalid edit
+    // correctly compares unequal.
+    if record.respond_to == super::types::RespondTo::Allowlist {
+        super::types::validate_respond_to_allowlist(&record.respond_to_allowlist)
+            .unwrap_or_else(|_| record.respond_to_allowlist.clone())
+            .hash(&mut hasher);
+    }
     record.idle_timeout_seconds.hash(&mut hasher);
-    record.max_turn_duration_seconds.hash(&mut hasher);
+    // Spawn writes BUZZ_ACP_MAX_TURN_DURATION and BUZZ_TOOLSETS with defaults
+    // filled in, so None and an explicit default are the same spawned value.
+    record
+        .max_turn_duration_seconds
+        .unwrap_or(super::types::DEFAULT_AGENT_MAX_TURN_DURATION_SECONDS)
+        .hash(&mut hasher);
     record.parallelism.hash(&mut hasher);
-    record.mcp_toolsets.hash(&mut hasher);
+    record
+        .mcp_toolsets
+        .as_deref()
+        .unwrap_or(super::types::DEFAULT_MCP_TOOLSETS)
+        .hash(&mut hasher);
     record.persona_team_dir.hash(&mut hasher);
     record.persona_name_in_team.hash(&mut hasher);
 

--- a/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::managed_agents::types::RespondTo;
 use std::collections::BTreeMap;
 
 fn record() -> ManagedAgentRecord {
@@ -183,7 +184,101 @@ fn workspace_relay_change_ignored_for_pinned_record_relay() {
 fn respond_to_allowlist_edit_changes_hash() {
     let rec = record();
     let mut edited = record();
+    edited.respond_to = RespondTo::Allowlist;
     edited.respond_to_allowlist = vec!["a".repeat(64)];
+    assert_ne!(
+        spawn_config_hash(&rec, &[], "wss://ws.example"),
+        spawn_config_hash(&edited, &[], "wss://ws.example")
+    );
+}
+
+#[test]
+fn allowlist_ignored_when_mode_is_not_allowlist() {
+    // Spawn only sets BUZZ_ACP_RESPOND_TO_ALLOWLIST in allowlist mode, so
+    // editing the (dormant) list under owner-only must not badge.
+    let rec = record();
+    let mut edited = record();
+    edited.respond_to_allowlist = vec!["a".repeat(64)];
+    assert_eq!(
+        spawn_config_hash(&rec, &[], "wss://ws.example"),
+        spawn_config_hash(&edited, &[], "wss://ws.example")
+    );
+}
+
+#[test]
+fn allowlist_normalization_equivalent_edits_do_not_change_hash() {
+    // The env receives the normalized list (trim/lowercase/dedup), so edits
+    // that normalize to the same value must not badge.
+    let mut rec = record();
+    rec.respond_to = RespondTo::Allowlist;
+    rec.respond_to_allowlist = vec!["a".repeat(64)];
+    let mut edited = rec.clone();
+    edited.respond_to_allowlist = vec![
+        format!(" {} ", "A".repeat(64)), // whitespace + case
+        "a".repeat(64),                  // duplicate
+    ];
+    assert_eq!(
+        spawn_config_hash(&rec, &[], "wss://ws.example"),
+        spawn_config_hash(&edited, &[], "wss://ws.example")
+    );
+}
+
+#[test]
+fn allowlist_content_edit_still_changes_hash() {
+    let mut rec = record();
+    rec.respond_to = RespondTo::Allowlist;
+    rec.respond_to_allowlist = vec!["a".repeat(64)];
+    let mut edited = rec.clone();
+    edited.respond_to_allowlist = vec!["b".repeat(64)];
+    assert_ne!(
+        spawn_config_hash(&rec, &[], "wss://ws.example"),
+        spawn_config_hash(&edited, &[], "wss://ws.example")
+    );
+}
+
+#[test]
+fn explicit_default_max_turn_duration_does_not_change_hash() {
+    // Spawn writes BUZZ_ACP_MAX_TURN_DURATION with the default filled in, so
+    // None → Some(default) is the same spawned value and must not badge.
+    let rec = record();
+    let mut edited = record();
+    edited.max_turn_duration_seconds =
+        Some(crate::managed_agents::types::DEFAULT_AGENT_MAX_TURN_DURATION_SECONDS);
+    assert_eq!(
+        spawn_config_hash(&rec, &[], "wss://ws.example"),
+        spawn_config_hash(&edited, &[], "wss://ws.example")
+    );
+}
+
+#[test]
+fn non_default_max_turn_duration_changes_hash() {
+    let rec = record();
+    let mut edited = record();
+    edited.max_turn_duration_seconds = Some(42);
+    assert_ne!(
+        spawn_config_hash(&rec, &[], "wss://ws.example"),
+        spawn_config_hash(&edited, &[], "wss://ws.example")
+    );
+}
+
+#[test]
+fn explicit_default_toolsets_do_not_change_hash() {
+    // Spawn falls BUZZ_TOOLSETS back to the default set, so None → an
+    // explicit copy of the default is the same spawned value.
+    let rec = record();
+    let mut edited = record();
+    edited.mcp_toolsets = Some(crate::managed_agents::types::DEFAULT_MCP_TOOLSETS.to_string());
+    assert_eq!(
+        spawn_config_hash(&rec, &[], "wss://ws.example"),
+        spawn_config_hash(&edited, &[], "wss://ws.example")
+    );
+}
+
+#[test]
+fn non_default_toolsets_change_hash() {
+    let rec = record();
+    let mut edited = record();
+    edited.mcp_toolsets = Some("default,canvas".to_string());
     assert_ne!(
         spawn_config_hash(&rec, &[], "wss://ws.example"),
         spawn_config_hash(&edited, &[], "wss://ws.example")

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -768,6 +768,9 @@ pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
 /// 1 hour — absolute wall-clock safety cap per turn.
 pub const DEFAULT_AGENT_MAX_TURN_DURATION_SECONDS: u64 = 3600;
 pub const DEFAULT_AGENT_PARALLELISM: u32 = 24;
+/// Toolsets injected as `BUZZ_TOOLSETS` when the record doesn't pin its own —
+/// single source of truth for the spawn env and the spawn-config hash.
+pub const DEFAULT_MCP_TOOLSETS: &str = "default,canvas,forums,dms,media";
 
 fn default_agent_parallelism() -> u32 {
     DEFAULT_AGENT_PARALLELISM


### PR DESCRIPTION
Follow-up to #1602 (restart-required badge), parked behind the spawn_hash persona-resolution rewrite that landed in #1618.

## Defect

The spawn-config hash digested **raw record values** while the spawn env receives **normalized ones**, so three field edits badged running agents even when a restart would run the exact same process:

| Field | Spawn env behavior | Hash behavior (before) |
|---|---|---|
| `respond_to_allowlist` | `BUZZ_ACP_RESPOND_TO_ALLOWLIST` set **only in allowlist mode**, from `validate_respond_to_allowlist` output (trim/lowercase/dedup) | raw list, hashed in every mode |
| `max_turn_duration_seconds` | `BUZZ_ACP_MAX_TURN_DURATION` written with default filled in | raw `Option` — `None` ≠ `Some(default)` |
| `mcp_toolsets` | `BUZZ_TOOLSETS` falls back to the default set | raw `Option` — `None` ≠ explicit default |

Equal spawned env + unequal raw field = spurious badge.

## Fix

Hash what the env receives:

- **Allowlist**: hashed only when `respond_to == Allowlist`, normalized via the same `validate_respond_to_allowlist` spawn uses. On validation error the raw list is hashed — spawn rejects invalid lists, so a stamped hash always came from a valid one and the invalid edit correctly compares unequal (badge = honest "restart would change/fail" signal).
- **Max turn duration**: hashed with `DEFAULT_AGENT_MAX_TURN_DURATION_SECONDS` filled in, matching the env write.
- **Toolsets**: hashed through a new `DEFAULT_MCP_TOOLSETS` const in `types.rs`, which also replaces the string literal in `runtime.rs`'s spawn path — hash and env now share one source of truth and cannot drift.

`respond_to` mode itself stays hashed unconditionally: toggling modes is spawn-visible and must badge.

## Tests

+8 in `spawn_hash/tests.rs` (17 total): equivalence AND sensitivity in both directions for all three fields — dormant-list edits under owner-only don't badge, real allowlist content edits do; normalization-equivalent edits don't, content changes do; `None` ↔ explicit default doesn't, non-default values do.

Full desktop-tauri suite: 1048 passed / 0 failed. Clippy `--all-targets` clean, fmt clean, file-size check clean.

Cross-reviewed and approved by Brain in #centralize-personas-and-agents (verified against `build_respond_to_env` and the runtime.rs env writes; independently ran the suite).
