### PR TITLE
feat(desktop): unified AgentDialog create entry point with create intents (Phase 1B.2)

### DIFF
--- a/desktop/src/features/agents/ui/AgentDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDialog.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+
+import type {
+  AcpRuntimeCatalogEntry,
+  CreateManagedAgentResponse,
+  CreatePersonaInput,
+  UpdatePersonaInput,
+} from "@/shared/api/types";
+import { Switch } from "@/shared/ui/switch";
+import {
+  definitionCreateDialogState,
+  intentForStartToggle,
+  type AgentCreateIntent,
+} from "./agentCreateIntent";
+import { CreateAgentDialog } from "./CreateAgentDialog";
+import { createPersonaDialogState } from "./personaDialogState";
+import { PersonaDialog } from "./PersonaDialog";
+
+export type AgentDialogMode = "definition" | "instance";
+
+type AgentDialogProps = {
+  mode: AgentDialogMode;
+  onOpenChange: (open: boolean) => void;
+  definitionError: Error | null;
+  isDefinitionPending: boolean;
+  runtimes: AcpRuntimeCatalogEntry[];
+  runtimesLoading: boolean;
+  onSubmitDefinition: (
+    input: CreatePersonaInput | UpdatePersonaInput,
+    intent: AgentCreateIntent,
+  ) => Promise<boolean>;
+  onInstanceCreated: (result: CreateManagedAgentResponse) => void;
+};
+
+/**
+ * Unified create entry point (Phase 1B.2): routes a create intent to the
+ * form that owns it. The definition family renders PersonaDialog in create
+ * mode with a "start after create" toggle; the standalone-instance intent
+ * renders CreateAgentDialog unchanged. Physical consolidation of the two
+ * forms is Phase 1B.3.
+ */
+export function AgentDialog({
+  mode,
+  onOpenChange,
+  definitionError,
+  isDefinitionPending,
+  runtimes,
+  runtimesLoading,
+  onSubmitDefinition,
+  onInstanceCreated,
+}: AgentDialogProps) {
+  const [startAfterCreate, setStartAfterCreate] = React.useState(true);
+  // Stable identity across toggle flips — PersonaDialog re-initializes its
+  // fields whenever `initialValues` changes.
+  const initialValues = React.useMemo(
+    () => createPersonaDialogState().initialValues,
+    [],
+  );
+
+  if (mode === "instance") {
+    return (
+      <CreateAgentDialog
+        onCreated={onInstanceCreated}
+        onOpenChange={onOpenChange}
+        open
+      />
+    );
+  }
+
+  const copy = definitionCreateDialogState(startAfterCreate);
+
+  return (
+    <PersonaDialog
+      createFooterSlot={
+        <label
+          className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground"
+          htmlFor="agent-dialog-start-toggle"
+        >
+          <Switch
+            checked={startAfterCreate}
+            data-testid="agent-dialog-start-toggle"
+            disabled={isDefinitionPending}
+            id="agent-dialog-start-toggle"
+            onCheckedChange={setStartAfterCreate}
+          />
+          Start agent after create
+        </label>
+      }
+      description={copy.description}
+      error={definitionError}
+      initialValues={initialValues}
+      isPending={isDefinitionPending}
+      onOpenChange={onOpenChange}
+      onSubmit={async (input) => {
+        const submitted = await onSubmitDefinition(
+          input,
+          intentForStartToggle(startAfterCreate),
+        );
+        if (submitted) {
+          onOpenChange(false);
+        }
+      }}
+      open
+      runtimes={runtimes}
+      runtimesLoading={runtimesLoading}
+      submitLabel={copy.submitLabel}
+      title={copy.title}
+    />
+  );
+}

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -5,8 +5,8 @@ import {
 } from "@/features/agents/openCreateAgentEvent";
 import { AddAgentToChannelDialog } from "./AddAgentToChannelDialog";
 import { AddTeamToChannelDialog } from "./AddTeamToChannelDialog";
+import { AgentDialog, type AgentDialogMode } from "./AgentDialog";
 import { BatchImportDialog } from "./BatchImportDialog";
-import { CreateAgentDialog } from "./CreateAgentDialog";
 import { PersonaCatalogDialog } from "./PersonaCatalogDialog";
 import { PersonaDialog } from "./PersonaDialog";
 import { PersonaDeleteDialog } from "./PersonaDeleteDialog";
@@ -29,6 +29,17 @@ export function AgentsView() {
   const { openPersonaProfilePanel, openProfilePanel } = useProfilePanel();
   const agents = useManagedAgentActions();
   const personas = usePersonaActions();
+  // Exclusivity: create never sets `personaDialogState` (edit/dup/import do),
+  // so the unified create dialog and PersonaDialog never mount together.
+  const [createDialogMode, setCreateDialogMode] =
+    React.useState<AgentDialogMode | null>(null);
+
+  function openUnifiedCreate(mode: AgentDialogMode) {
+    if (mode === "definition") {
+      personas.prepareCreate();
+    }
+    setCreateDialogMode(mode);
+  }
   const teamActions = useTeamActions(
     {
       setActionNoticeMessage: agents.setActionNoticeMessage,
@@ -50,13 +61,13 @@ export function AgentsView() {
 
   React.useEffect(() => {
     if (consumePendingOpenCreateAgent()) {
-      agents.setIsCreateOpen(true);
+      setCreateDialogMode("instance");
     }
 
     return subscribeOpenCreateAgent(() => {
-      agents.setIsCreateOpen(true);
+      setCreateDialogMode("instance");
     });
-  }, [agents.setIsCreateOpen]);
+  }, []);
 
   return (
     <>
@@ -83,7 +94,7 @@ export function AgentsView() {
                 void agents.handleBulkStopRunning();
               }}
               onCreateAgent={() => {
-                agents.setIsCreateOpen(true);
+                openUnifiedCreate("instance");
               }}
               onOpenAgentProfile={(pubkey, options) => {
                 openProfilePanel?.(pubkey, options);
@@ -117,7 +128,9 @@ export function AgentsView() {
               }
               isPersonasLoading={personas.personasQuery.isLoading}
               isPersonasPending={personas.isPending}
-              onCreatePersona={personas.openCreate}
+              onCreatePersona={() => {
+                openUnifiedCreate("definition");
+              }}
               onChooseCatalog={personas.openCatalog}
               onDuplicatePersona={personas.openDuplicate}
               onEditPersona={personas.openEdit}
@@ -171,14 +184,27 @@ export function AgentsView() {
         </div>
       </div>
 
-      {agents.isCreateOpen ? (
-        <CreateAgentDialog
-          onCreated={(result) => {
+      {createDialogMode ? (
+        <AgentDialog
+          definitionError={
+            personas.createPersonaMutation.error instanceof Error
+              ? personas.createPersonaMutation.error
+              : null
+          }
+          isDefinitionPending={personas.isPending}
+          mode={createDialogMode}
+          onInstanceCreated={(result) => {
             agents.setLogAgentPubkey(result.agent.pubkey);
             agents.setCreatedAgent(result);
           }}
-          onOpenChange={agents.setIsCreateOpen}
-          open={agents.isCreateOpen}
+          onOpenChange={(open) => {
+            if (!open) {
+              setCreateDialogMode(null);
+            }
+          }}
+          onSubmitDefinition={personas.handleSubmit}
+          runtimes={personas.acpRuntimesQuery.data ?? []}
+          runtimesLoading={personas.acpRuntimesQuery.isLoading}
         />
       ) : null}
       {agents.agentToAddToChannel ? (

--- a/desktop/src/features/agents/ui/PersonaDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDialog.tsx
@@ -93,12 +93,19 @@ type PersonaDialogProps = {
   runtimes: AcpRuntimeCatalogEntry[];
   runtimesLoading?: boolean;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (input: CreatePersonaInput | UpdatePersonaInput) => Promise<void>;
+  onSubmit: (
+    input: CreatePersonaInput | UpdatePersonaInput,
+  ) => Promise<unknown>;
   onImportUpdateFile?: (
     personaId: string,
     fileBytes: number[],
     fileName: string,
   ) => Promise<void>;
+  /**
+   * Rendered in the footer's left slot in create mode only — edit mode's
+   * import button owns that slot (`canImportPersonaUpdate`).
+   */
+  createFooterSlot?: React.ReactNode;
 };
 
 const ADVANCED_FIELDS_MOTION_TRANSITION = {
@@ -120,6 +127,7 @@ export function PersonaDialog({
   onOpenChange,
   onSubmit,
   onImportUpdateFile,
+  createFooterSlot,
 }: PersonaDialogProps) {
   const [displayName, setDisplayName] = React.useState("");
   const [avatarUrl, setAvatarUrl] = React.useState("");
@@ -761,7 +769,9 @@ export function PersonaDialog({
                     ) : null}
                   </button>
                 </>
-              ) : null}
+              ) : (
+                createFooterSlot
+              )}
             </div>
 
             <div className="flex items-center gap-2">

--- a/desktop/src/features/agents/ui/agentCreateIntent.test.mjs
+++ b/desktop/src/features/agents/ui/agentCreateIntent.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  definitionCreateDialogState,
+  intentForStartToggle,
+  resolveCreateIntent,
+} from "./agentCreateIntent.ts";
+import { createPersonaDialogState } from "./personaDialogState.ts";
+
+test("resolveCreateIntent defaults to quick-start for un-migrated callers", () => {
+  // PersonaDialog's duplicate path calls handleSubmit without an intent until
+  // B3 migrates it; the default must preserve today's create-then-start
+  // behavior or duplicate silently becomes definition-only.
+  assert.equal(resolveCreateIntent(undefined), "definition_start");
+});
+
+test("resolveCreateIntent passes explicit intents through", () => {
+  assert.equal(resolveCreateIntent("definition"), "definition");
+  assert.equal(resolveCreateIntent("definition_start"), "definition_start");
+  assert.equal(resolveCreateIntent("instance"), "instance");
+});
+
+test("intentForStartToggle maps the toggle to definition-family intents", () => {
+  assert.equal(intentForStartToggle(true), "definition_start");
+  assert.equal(intentForStartToggle(false), "definition");
+});
+
+test("toggle-on dialog copy is exactly the legacy create copy", () => {
+  assert.deepEqual(
+    definitionCreateDialogState(true),
+    createPersonaDialogState(),
+  );
+});
+
+test("toggle-off dialog copy differs only in description", () => {
+  const legacy = createPersonaDialogState();
+  const definitionOnly = definitionCreateDialogState(false);
+  assert.equal(definitionOnly.title, legacy.title);
+  assert.equal(definitionOnly.submitLabel, legacy.submitLabel);
+  assert.deepEqual(definitionOnly.initialValues, legacy.initialValues);
+  assert.notEqual(definitionOnly.description, legacy.description);
+  assert.match(definitionOnly.description, /without starting/);
+});

--- a/desktop/src/features/agents/ui/agentCreateIntent.ts
+++ b/desktop/src/features/agents/ui/agentCreateIntent.ts
@@ -1,0 +1,53 @@
+import {
+  createPersonaDialogState,
+  type PersonaDialogState,
+} from "./personaDialogState";
+
+/**
+ * What the user is creating from the unified create dialog.
+ *
+ * - `definition` — a keyless agent definition (persona record) only.
+ * - `definition_start` — definition plus an immediately created + spawned
+ *   managed instance linked via `personaId` (today's quick-start flow).
+ * - `instance` — a standalone keyed managed agent (no definition record).
+ */
+export type AgentCreateIntent = "definition" | "definition_start" | "instance";
+
+/**
+ * Default intent for callers that don't pass one. Un-migrated callers of
+ * `usePersonaActions.handleSubmit` (PersonaDialog's duplicate path until B3)
+ * must keep today's create-then-start semantics, so the default is
+ * `definition_start`, never `definition`.
+ */
+export function resolveCreateIntent(
+  intent?: AgentCreateIntent,
+): AgentCreateIntent {
+  return intent ?? "definition_start";
+}
+
+/** Maps the "Start agent after create" toggle to a definition-family intent. */
+export function intentForStartToggle(
+  startAfterCreate: boolean,
+): AgentCreateIntent {
+  return startAfterCreate ? "definition_start" : "definition";
+}
+
+/**
+ * Dialog copy for the definition-family create dialog. The toggle-on copy is
+ * derived from `createPersonaDialogState` so it cannot drift from the legacy
+ * create flow it replaces.
+ */
+export function definitionCreateDialogState(
+  startAfterCreate: boolean,
+): PersonaDialogState {
+  const legacy = createPersonaDialogState();
+  if (startAfterCreate) {
+    return legacy;
+  }
+
+  return {
+    ...legacy,
+    description:
+      "Create an agent profile without starting an instance. You can start it from its card at any time.",
+  };
+}

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -33,6 +33,10 @@ import {
   importPersonaDialogState,
   type PersonaDialogState,
 } from "./personaDialogState";
+import {
+  resolveCreateIntent,
+  type AgentCreateIntent,
+} from "./agentCreateIntent";
 import { resolveManagedAgentAvatarUrl } from "./managedAgentAvatar";
 import { usePersonaImportActions } from "./usePersonaImportActions";
 
@@ -154,9 +158,12 @@ export function usePersonaActions() {
     setPersonaErrorMessage(null);
   }
 
-  async function handleSubmit(input: CreatePersonaInput | UpdatePersonaInput) {
+  async function handleSubmit(
+    input: CreatePersonaInput | UpdatePersonaInput,
+    intent?: AgentCreateIntent,
+  ): Promise<boolean> {
     if (isPersonaSubmitPending) {
-      return;
+      return false;
     }
 
     clearFeedback("library");
@@ -173,7 +180,7 @@ export function usePersonaActions() {
           setPersonaErrorMessage(
             "Choose an available provider for this agent.",
           );
-          return;
+          return false;
         }
 
         const avatarUrl = await resolveManagedAgentAvatarUrl(
@@ -185,6 +192,12 @@ export function usePersonaActions() {
           ...input,
           avatarUrl,
         });
+
+        if (resolveCreateIntent(intent) === "definition") {
+          setPersonaNoticeMessage(`Created ${persona.displayName}.`);
+          setPersonaDialogState(null);
+          return true;
+        }
         const agentInput: CreateManagedAgentInput = {
           name: persona.displayName,
           acpCommand: "buzz-acp",
@@ -227,10 +240,12 @@ export function usePersonaActions() {
         }
       }
       setPersonaDialogState(null);
+      return true;
     } catch (error) {
       setPersonaErrorMessage(
         error instanceof Error ? error.message : "Failed to save persona.",
       );
+      return false;
     } finally {
       setIsPersonaSubmitPending(false);
     }
@@ -321,9 +336,13 @@ export function usePersonaActions() {
     void queryClient.invalidateQueries({ queryKey: personasQueryKey });
   }
 
-  function openCreate() {
+  function prepareCreate() {
     clearFeedback("library");
     setShouldLoadAcpRuntimes(true);
+  }
+
+  function openCreate() {
+    prepareCreate();
     setPersonaDialogState(createPersonaDialogState());
   }
 
@@ -420,6 +439,7 @@ export function usePersonaActions() {
     handleExport,
     handleBatchImportComplete,
     openCreate,
+    prepareCreate,
     openEdit,
     openDuplicate,
     openCatalog,


### PR DESCRIPTION
## Phase 1B.2 — unified AgentDialog create entry point

Second slice of Phase 1B (UI unification, #centralize-personas-and-agents). Routes both create entry points on the Agents surface through a single `AgentDialog` that owns the **create intent**:

| Intent | What it creates | Form rendered |
|---|---|---|
| `definition_start` (default) | definition + linked, spawned instance (`personaId`) — today's quick-start | `PersonaDialog` (create mode) with "Start agent after create" toggle **on** |
| `definition` | definition only — **new behavior**, see below | same form, toggle **off** |
| `instance` | standalone keyed managed agent | `CreateAgentDialog`, unchanged |

Stacked on #1624 (B1 shared sections). Wire shapes (`CreatePersonaInput` / `CreateManagedAgentInput`) untouched — frontend recomposition only; independent of #1623 (A2).

### Composition: pass-through router, not a new form

`AgentDialog` (~110 lines) is an intent router. The definition family renders `PersonaDialog` itself in create mode (via a new 2-line `createFooterSlot` prop — footer-left is empty in create mode; edit's import button owns it otherwise); the instance intent renders `CreateAgentDialog` unchanged. A new standalone form would have duplicated ~400 lines that B3 deletes anyway; physical consolidation of the forms into one file is B3's job. Consequence: B1's shared sections are consumed **transitively** (both forms already use them).

**Entry point implies intent** — "New agent" opens the definition family, "Custom agent" and the `open-create-agent` event open the instance form. There is no in-dialog mode picker; don't read `AgentDialog` expecting one.

### Sequencing stays hook-side

`usePersonaActions.handleSubmit(input, intent?)` keeps ownership of create-then-instance (it already holds the mutations, feedback surfaces, and SecretRevealDialog plumbing). The definition intent is the existing create branch **minus the instance step**; upstream (runtime guard, avatar resolve) and downstream (instance step, error taxonomy, dialog close, pending reset) are untouched. Return type widens to `Promise<boolean>` so the unified mount can close on success — legacy callers ignore the return.

`definition_start` preserves **this hook's** semantics (`harnessOverride: true`, hard-error on unavailable runtime, `resolveManagedAgentAvatarUrl` before create feeding both records) — *not* `handleStartPersona`'s card-start mapping, which diverges (conditional `harnessOverride`, `resolvePersonaRuntime` fallback) and stays untouched on the card path. Converging the two definition→instance mappings is a real cleanup but belongs to a visible future slice, not this PR.

### Intent defaults pin legacy behavior

`resolveCreateIntent` defaults to `definition_start`: PersonaDialog's **duplicate** path still calls `handleSubmit` without an intent until B3, and create/duplicate both always quick-start today. A unit test pins the default so duplicate can't silently become definition-only. The toggle-on dialog copy is derived from `createPersonaDialogState` and deepEqual-pinned against it — it cannot drift from the flow it replaces.

### Divergence flags (per the B1 rule: each intent preserves the flow it replaces)

- **`lockedRuntimeReset`** stays per-form by construction: definition intents replace PersonaDialog-create → `"full"`; instance replaces CreateAgentDialog → `"provider-only"`. The flag choice is a consequence of the replaces-rule, not a judgment call.
- **Definition-only is genuinely new behavior** — today's UI has no way to create a definition without starting an instance ("Create an agent profile **and start its managed agent instance**"). This is the Phase-1 "definition without instance" goal, disclosed as new rather than dressed as recomposition. Skip-step-2 in the hook; notice copy "Created X."
- **Runtime-required guard kept as-is** for definition-only: create mode still requires choosing an available runtime, even though a definition-only record arguably shouldn't need one. Relaxing it is a product question (below), not smuggled in.

### Both-paths-alive (weaker form for one path — explicit)

- `CreateAgentDialog`: **fully alive and reachable** — it *is* the instance form, byte-identical.
- `PersonaDialog` create mode: in-tree but unreachable via UI (edit/duplicate/import mounts remain live). Rollback = one-line revert of the `AgentsView` mount wiring; `openCreate` is intact in the hook, unwired.
- Mount exclusivity: create no longer sets `personaDialogState` (`prepareCreate` split out of `openCreate` primes feedback/runtime-load without it), so the old and new `PersonaDialog` mounts — which share testids until B4's rename — can never coexist. Comment at the mount site names the assumption.

### Testids

The definition form reuses PersonaDialog's existing testids/ids (`persona-dialog`, `persona-dialog-submit`, `#persona-runtime`, …), so the existing create-path e2e specs run unchanged — verified locally. Renames are B4's vocabulary flip. New: `agent-dialog-start-toggle`.

### Open product questions for @wesbillman (none block this PR)

1. Does "Persona" survive as the catalog name? (B4)
2. Create-flow default: quick-start vs definition-first? (currently quick-start = today's de-facto behavior; one constant to flip)
3. Should definition-only creation still require choosing an available runtime? (guard kept as-is here)

### Verification

- tsc, biome (full `src/`), file-size/px-text/pubkey checks clean
- 2061/0 unit tests (5 new: intent resolver default pin, toggle mapping, copy derivation pins)
- smoke e2e `-g "agent|persona"` 56/56 locally; full suite in CI
- Cross-reviewed by Pinky (scope pre-pass + line-by-line on the diff, this thread)
