### PR TITLE
refactor(desktop): single-home the definition form as AgentDefinitionDialog (Phase 1B.3a)

### DIFF
--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -8,6 +8,7 @@ import type {
   UpdatePersonaInput,
 } from "@/shared/api/types";
 import { useFileImportZone } from "@/shared/hooks/useFileImportZone";
+import { useWindowFileDragOver } from "./useWindowFileDragOver";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
@@ -81,7 +82,7 @@ import {
 } from "./usePersonaModelDiscovery";
 import { useBakedBuildEnvKeysQuery, useRuntimeFileConfigQuery } from "../hooks";
 
-type PersonaDialogProps = {
+type AgentDefinitionDialogProps = {
   open: boolean;
   title: string;
   description: string;
@@ -113,7 +114,7 @@ const ADVANCED_FIELDS_MOTION_TRANSITION = {
   ease: [0.23, 1, 0.32, 1],
 } as const;
 
-export function PersonaDialog({
+export function AgentDefinitionDialog({
   open,
   title,
   description,
@@ -128,7 +129,7 @@ export function PersonaDialog({
   onSubmit,
   onImportUpdateFile,
   createFooterSlot,
-}: PersonaDialogProps) {
+}: AgentDefinitionDialogProps) {
   const [displayName, setDisplayName] = React.useState("");
   const [avatarUrl, setAvatarUrl] = React.useState("");
   const [systemPrompt, setSystemPrompt] = React.useState("");
@@ -147,7 +148,6 @@ export function PersonaDialog({
   const [importErrorMessage, setImportErrorMessage] = React.useState<
     string | null
   >(null);
-  const [isWindowFileDragOver, setIsWindowFileDragOver] = React.useState(false);
   const isEditMode = Boolean(initialValues && "id" in initialValues);
   const editPersonaId =
     isEditMode && initialValues && "id" in initialValues
@@ -215,68 +215,9 @@ export function PersonaDialog({
     setRuntime(defaultRuntime.id);
   }, [defaultRuntime, initialValues, open, runtime, runtimesLoading]);
 
-  React.useEffect(() => {
-    if (!open || !canImportPersonaUpdate) {
-      setIsWindowFileDragOver(false);
-      return;
-    }
-
-    let dragDepth = 0;
-
-    function isFileDrag(event: DragEvent): boolean {
-      return Array.from(event.dataTransfer?.types ?? []).includes("Files");
-    }
-
-    function handleWindowDragEnter(event: DragEvent) {
-      if (!isFileDrag(event)) {
-        return;
-      }
-      dragDepth += 1;
-      setIsWindowFileDragOver(true);
-    }
-
-    function handleWindowDragOver(event: DragEvent) {
-      if (!isFileDrag(event)) {
-        return;
-      }
-      event.preventDefault();
-      if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = "copy";
-      }
-      setIsWindowFileDragOver(true);
-    }
-
-    function handleWindowDragLeave(event: DragEvent) {
-      if (!isFileDrag(event)) {
-        return;
-      }
-      dragDepth = Math.max(0, dragDepth - 1);
-      if (dragDepth === 0) {
-        setIsWindowFileDragOver(false);
-      }
-    }
-
-    function handleWindowDrop(event: DragEvent) {
-      if (!isFileDrag(event)) {
-        return;
-      }
-      event.preventDefault();
-      dragDepth = 0;
-      setIsWindowFileDragOver(false);
-    }
-
-    window.addEventListener("dragenter", handleWindowDragEnter);
-    window.addEventListener("dragover", handleWindowDragOver);
-    window.addEventListener("dragleave", handleWindowDragLeave);
-    window.addEventListener("drop", handleWindowDrop);
-
-    return () => {
-      window.removeEventListener("dragenter", handleWindowDragEnter);
-      window.removeEventListener("dragover", handleWindowDragOver);
-      window.removeEventListener("dragleave", handleWindowDragLeave);
-      window.removeEventListener("drop", handleWindowDrop);
-    };
-  }, [canImportPersonaUpdate, open]);
+  const isWindowFileDragOver = useWindowFileDragOver(
+    open && canImportPersonaUpdate,
+  );
 
   React.useEffect(() => {
     if (!open || !importErrorMessage) {
@@ -339,7 +280,6 @@ export function PersonaDialog({
       setIsAvatarUploadPending(false);
       setImportErrorMessage(null);
       setIsImportingUpdate(false);
-      setIsWindowFileDragOver(false);
     }
 
     onOpenChange(next);

--- a/desktop/src/features/agents/ui/AgentDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDialog.tsx
@@ -14,7 +14,7 @@ import {
 } from "./agentCreateIntent";
 import { CreateAgentDialog } from "./CreateAgentDialog";
 import { createPersonaDialogState } from "./personaDialogState";
-import { PersonaDialog } from "./PersonaDialog";
+import { AgentDefinitionDialog } from "./AgentDefinitionDialog";
 
 export type AgentDialogMode = "definition" | "instance";
 
@@ -34,10 +34,10 @@ type AgentDialogProps = {
 
 /**
  * Unified create entry point (Phase 1B.2): routes a create intent to the
- * form that owns it. The definition family renders PersonaDialog in create
- * mode with a "start after create" toggle; the standalone-instance intent
- * renders CreateAgentDialog unchanged. Physical consolidation of the two
- * forms is Phase 1B.3.
+ * form that owns it. The definition family renders AgentDefinitionDialog in
+ * create mode with a "start after create" toggle; the standalone-instance
+ * intent renders CreateAgentDialog unchanged. Physical consolidation of the
+ * two forms is Phase 1B.3.
  */
 export function AgentDialog({
   mode,
@@ -50,7 +50,7 @@ export function AgentDialog({
   onInstanceCreated,
 }: AgentDialogProps) {
   const [startAfterCreate, setStartAfterCreate] = React.useState(true);
-  // Stable identity across toggle flips — PersonaDialog re-initializes its
+  // Stable identity across toggle flips — AgentDefinitionDialog re-initializes its
   // fields whenever `initialValues` changes.
   const initialValues = React.useMemo(
     () => createPersonaDialogState().initialValues,
@@ -70,7 +70,7 @@ export function AgentDialog({
   const copy = definitionCreateDialogState(startAfterCreate);
 
   return (
-    <PersonaDialog
+    <AgentDefinitionDialog
       createFooterSlot={
         <label
           className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground"

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -8,7 +8,7 @@ import { AddTeamToChannelDialog } from "./AddTeamToChannelDialog";
 import { AgentDialog, type AgentDialogMode } from "./AgentDialog";
 import { BatchImportDialog } from "./BatchImportDialog";
 import { PersonaCatalogDialog } from "./PersonaCatalogDialog";
-import { PersonaDialog } from "./PersonaDialog";
+import { AgentDefinitionDialog } from "./AgentDefinitionDialog";
 import { PersonaDeleteDialog } from "./PersonaDeleteDialog";
 import { PersonaImportUpdateDialog } from "./PersonaImportUpdateDialog";
 import { PersonaShareDialog } from "./PersonaShareDialog";
@@ -30,7 +30,8 @@ export function AgentsView() {
   const agents = useManagedAgentActions();
   const personas = usePersonaActions();
   // Exclusivity: create never sets `personaDialogState` (edit/dup/import do),
-  // so the unified create dialog and PersonaDialog never mount together.
+  // so the unified create dialog and the edit/dup/import AgentDefinitionDialog
+  // mount never coexist.
   const [createDialogMode, setCreateDialogMode] =
     React.useState<AgentDialogMode | null>(null);
 
@@ -240,7 +241,7 @@ export function AgentsView() {
         />
       ) : null}
       {personas.personaDialogState ? (
-        <PersonaDialog
+        <AgentDefinitionDialog
           description={personas.personaDialogState.description}
           error={
             personas.updatePersonaMutation.error instanceof Error

--- a/desktop/src/features/agents/ui/agentCreateIntent.ts
+++ b/desktop/src/features/agents/ui/agentCreateIntent.ts
@@ -15,8 +15,8 @@ export type AgentCreateIntent = "definition" | "definition_start" | "instance";
 
 /**
  * Default intent for callers that don't pass one. Un-migrated callers of
- * `usePersonaActions.handleSubmit` (PersonaDialog's duplicate path until B3)
- * must keep today's create-then-start semantics, so the default is
+ * `usePersonaActions.handleSubmit` (AgentDefinitionDialog's duplicate path
+ * until B3) must keep today's create-then-start semantics, so the default is
  * `definition_start`, never `definition`.
  */
 export function resolveCreateIntent(

--- a/desktop/src/features/agents/ui/useWindowFileDragOver.ts
+++ b/desktop/src/features/agents/ui/useWindowFileDragOver.ts
@@ -1,0 +1,74 @@
+import * as React from "react";
+
+/**
+ * Tracks whether a file drag is anywhere over the window. Depth-counted so
+ * child enter/leave churn doesn't flicker the flag; resets when disabled.
+ */
+export function useWindowFileDragOver(enabled: boolean) {
+  const [isWindowFileDragOver, setIsWindowFileDragOver] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      setIsWindowFileDragOver(false);
+      return;
+    }
+
+    let dragDepth = 0;
+
+    function isFileDrag(event: DragEvent): boolean {
+      return Array.from(event.dataTransfer?.types ?? []).includes("Files");
+    }
+
+    function handleWindowDragEnter(event: DragEvent) {
+      if (!isFileDrag(event)) {
+        return;
+      }
+      dragDepth += 1;
+      setIsWindowFileDragOver(true);
+    }
+
+    function handleWindowDragOver(event: DragEvent) {
+      if (!isFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "copy";
+      }
+      setIsWindowFileDragOver(true);
+    }
+
+    function handleWindowDragLeave(event: DragEvent) {
+      if (!isFileDrag(event)) {
+        return;
+      }
+      dragDepth = Math.max(0, dragDepth - 1);
+      if (dragDepth === 0) {
+        setIsWindowFileDragOver(false);
+      }
+    }
+
+    function handleWindowDrop(event: DragEvent) {
+      if (!isFileDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      dragDepth = 0;
+      setIsWindowFileDragOver(false);
+    }
+
+    window.addEventListener("dragenter", handleWindowDragEnter);
+    window.addEventListener("dragover", handleWindowDragOver);
+    window.addEventListener("dragleave", handleWindowDragLeave);
+    window.addEventListener("drop", handleWindowDrop);
+
+    return () => {
+      window.removeEventListener("dragenter", handleWindowDragEnter);
+      window.removeEventListener("dragover", handleWindowDragOver);
+      window.removeEventListener("dragleave", handleWindowDragLeave);
+      window.removeEventListener("drop", handleWindowDrop);
+    };
+  }, [enabled]);
+
+  return isWindowFileDragOver;
+}

--- a/desktop/src/features/profile/ui/UserProfilePersonaDialogs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePersonaDialogs.tsx
@@ -5,7 +5,7 @@ import type {
   UpdatePersonaInput,
 } from "@/shared/api/types";
 import { PersonaDeleteDialog } from "@/features/agents/ui/PersonaDeleteDialog";
-import { PersonaDialog } from "@/features/agents/ui/PersonaDialog";
+import { AgentDefinitionDialog } from "@/features/agents/ui/AgentDefinitionDialog";
 import type { PersonaDialogState } from "@/features/agents/ui/personaDialogState";
 
 export function UserProfilePersonaDialogs({
@@ -35,7 +35,7 @@ export function UserProfilePersonaDialogs({
 }) {
   return (
     <>
-      <PersonaDialog
+      <AgentDefinitionDialog
         description={personaDialogState?.description ?? ""}
         error={updateError ?? createError}
         initialValues={personaDialogState?.initialValues ?? null}


### PR DESCRIPTION
## Phase 1B.3a — single-home the definition form

First slice of Phase 1B.3 (#centralize-personas-and-agents). **Mechanical re-homing, zero behavior change**: `PersonaDialog.tsx` moves to `AgentDefinitionDialog.tsx` (component renamed to match its single-homed role), and its three consumers re-import:

- `AgentDialog` (B2's unified create — definition family)
- `AgentsView` (edit / duplicate / import mount)
- `UserProfilePersonaDialogs` (profile-panel edit / duplicate)

Stacked on #1626 (B2). git records the move at 94% similarity — the body moved, it didn't change.

### What deliberately does NOT change

- **Mount topology & state**: every surface keeps its own dialog state and mounts. B2's mount-exclusivity insurance (create never sets `personaDialogState`) stays load-bearing; the per-surface collapse to a single dialog-state owner is B3b/B3c.
- **Testids, element ids, user-facing copy**: `persona-dialog`, `persona-dialog-submit`, `#persona-runtime`, … move with the form body, so the persona-path e2e specs run unchanged — that is the review criterion for this slice (zero spec edits). Vocabulary renames remain B4.
- **Wire shapes**: untouched, per the standing pin (now explicitly extended to `UpdateManagedAgentInput` for the rest of B3).

### One disclosed extraction (forced by the file-size guard, not preference)

The rename-move landed the file at 1005 lines against the 1000-line guard — B2's `createFooterSlot` + `onSubmit` widening had pushed it near the brink. Root-cause fix rather than a guard exception: the self-contained window file-drag-over effect moves to `useWindowFileDragOver.ts` (behavior-identical: depth-counted enter/leave, copy dropEffect, reset-on-disable — the dep-conjunction collapse and dropped redundant close-reset were both proven no-ops in review). File is now 944 lines — 56 under the guard, real headroom rather than a shave.

### Verification

- tsc, biome (full `src/`), file-size/px-text/pubkey checks clean
- 2061/0 unit tests
- smoke e2e `-g "agent|persona"` 56/56 locally, zero spec edits; full suite in CI
- Cross-reviewed by Pinky (scope pressure-test + independent line-by-line and verification run, channel thread)

### Context

Next slices: B3b re-hosts the instance-edit form around the existing pure modules (`personaRuntimeModel.ts`, `useRequiredCredentialState.ts`) preserving the `[open, agent.pubkey]` reset lifecycle; B3c cuts the profile panel over (cascade kept as-is, re-pointed); B3.5 is an explicit mapping-convergence slice with a per-divergence decision table — three definition→instance mappings exist today and converging them silently inside a cutover PR is exactly what the slice discipline bans.
