### PR TITLE
test(desktop): deflake mid-scroll older-history spinner smoke test

### DIFF
--- a/desktop/tests/e2e/scroll-history.spec.ts
+++ b/desktop/tests/e2e/scroll-history.spec.ts
@@ -1577,15 +1577,25 @@ test("older-history spinner stays visible in viewport while fetching mid-scroll"
   const timeline = page.getByTestId("message-timeline");
   await expect(timeline.locator("[data-message-id]").first()).toBeVisible();
 
-  await timeline.hover();
-  await page.mouse.wheel(0, -1_500);
-  await page.waitForTimeout(100);
-  await page.mouse.wheel(0, 1_000);
-  await page.waitForTimeout(100);
-  await page.mouse.wheel(0, -1_000);
+  // Trigger the older fetch near the top, then move the reader mid-scroll
+  // while the fetch is still in flight. Set scrollTop directly instead of
+  // mouse.wheel: wheel deltas vary across CI environments and can land the
+  // timeline at scrollTop 0, which is the one position this test must avoid.
+  await timeline.evaluate((element) => {
+    const timelineElement = element as HTMLDivElement;
+    timelineElement.scrollTop = 150;
+    timelineElement.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
 
   const indicator = page.getByTestId("message-timeline-fetching-older");
   await expect(indicator).toBeVisible({ timeout: 2_000 });
+
+  await timeline.evaluate((element) => {
+    const timelineElement = element as HTMLDivElement;
+    timelineElement.scrollTop = timelineElement.clientHeight;
+    timelineElement.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  await expect(indicator).toBeVisible();
 
   const { scrollTop } = await getTimelineMetrics(page);
   expect(scrollTop).toBeGreaterThan(8);


### PR DESCRIPTION
## Why

`main` CI is intermittently red on **Desktop Smoke E2E (4)**: the `scroll-history.spec.ts` test *"older-history spinner stays visible in viewport while fetching mid-scroll"* fails `expect(scrollTop).toBeGreaterThan(8)` with `0` on all 3 retries (runs [28915175821](https://github.com/block/buzz/actions/runs/28915175821), [28891719863](https://github.com/block/buzz/actions/runs/28891719863)). The test file hadn't changed since #1533 and the failing commits didn't touch scroll code — it's test flake, not a product regression.

## What

The test drove the timeline with three `mouse.wheel` gestures separated by fixed 100ms sleeps, then asserted the timeline ended up mid-scroll. Wheel delta handling varies across CI environments, so the net position sometimes landed at `scrollTop 0` — the one position the test must avoid.

Replaced the wheel choreography with deterministic `scrollTop` writes:
1. park at `scrollTop = 150` to trigger the older-history fetch (same pattern the sibling "never overlap" test uses),
2. wait for the spinner,
3. jump one viewport down while the 2s-delayed fetch is still in flight,
4. assert the spinner is still visible, pinned within the viewport, and the reader is away from the top.

Same assertion targets as before — only the flaky input choreography changed.

## Verification

- `--repeat-each=10` on the target test: **10/10 pass**
- Full `scroll-history.spec.ts` smoke suite: **15/15 pass**
- `pnpm typecheck`, `pnpm lint`, `pnpm check`: clean

(Note: two other recent red runs on main were runner-infra apt failures installing Playwright deps — `packages.microsoft.com` clearsign errors — self-healing, not addressable in-repo.)
