### PR TITLE
fix(desktop): paint Buzz gradient on the workspace rail

### DIFF
--- a/desktop/src/shared/styles/globals/theme.css
+++ b/desktop/src/shared/styles/globals/theme.css
@@ -178,11 +178,14 @@
  *
  * The gradient is applied to every `bg-sidebar` canvas surface INSIDE the app
  * shell (`.group\/sidebar-wrapper` — the top chrome bar, the sidebar column,
- * and the inset margin behind the white content card), PLUS the portaled
- * mobile sidebar (the `SheetContent` rendered by the offcanvas branch on
- * narrow viewports, marked `[data-sidebar="sidebar"][data-mobile="true"]`).
- * The mobile sheet lives in a `SheetPortal` outside the shell wrapper, so it
- * needs its own precise selector rather than re-broadening to every portal.
+ * and the inset margin behind the white content card), PLUS two chrome
+ * surfaces rendered OUTSIDE that wrapper: the portaled mobile sidebar (the
+ * `SheetContent` rendered by the offcanvas branch on narrow viewports, marked
+ * `[data-sidebar="sidebar"][data-mobile="true"]`) and the workspace rail (the
+ * Discord-style relay column on the far left, `[data-testid="workspace-rail"]`,
+ * a sibling of the wrapper gated behind the `workspaceRail` feature flag).
+ * Both live outside `.group\/sidebar-wrapper`, so each needs its own precise
+ * selector rather than re-broadening to every portal.
  * Scoping this way keeps the branding on the app chrome and off unrelated
  * `bg-sidebar` consumers rendered in portals outside the shell (e.g. the
  * persona catalog dialog). `background-attachment: fixed` anchors the gradient
@@ -218,7 +221,8 @@
   .group\/sidebar-wrapper
   .bg-sidebar:not([data-buzz-flat]),
 :root[data-buzz-sidebar]
-  [data-sidebar="sidebar"][data-mobile="true"].bg-sidebar {
+  [data-sidebar="sidebar"][data-mobile="true"].bg-sidebar,
+:root[data-buzz-sidebar] [data-testid="workspace-rail"].bg-sidebar {
   background-color: transparent;
   background-image: linear-gradient(
     to bottom,


### PR DESCRIPTION
## Problem

When the `workspaceRail` experiment is enabled, the Discord-style relay
column (the "relay rail") on the far left did **not** pick up the Buzz
branded gradient — it rendered as flat grey while the sidebar next to it
carried the gradient, breaking the continuous-canvas look.

## Root cause

The branded gradient selector is scoped to `bg-sidebar` surfaces **inside**
`.group/sidebar-wrapper`. But the `WorkspaceRail` `<nav>` is rendered as a
**sibling** of that wrapper in `AppShell` (it sits outside so it can span
the full height alongside the collapsible sidebar). Its `bg-sidebar` class
therefore never matched the gradient rule and fell back to the flat grey
`--sidebar-background`.

## Fix

Add a precise selector for `[data-testid="workspace-rail"].bg-sidebar` to
the gradient rule — the same "own selector for a surface outside the
wrapper" pattern already used for the portaled mobile sidebar sheet. Because
the gradient is `background-attachment: fixed` sized to `100vw 100vh`, the
rail and sidebar align pixel-for-pixel and read as one continuous surface.

## Verification

- `just ci` green (fmt + clippy + desktop lint + unit tests + builds + mobile).
- Extended `buzz-theme-screenshots.spec.ts` with light + dark rail cases that
  clip across rail + sidebar to guard against regression. All 7 theme
  screenshot tests pass.

### Buzz Light — rail + sidebar
![light](https://raw.githubusercontent.com/block/buzz/8246f8fb9a2446dcf25d6a43b93345bcfe02c5ba/pr-1636--06-buzz-light-rail.png)

### Buzz Dark — rail + sidebar
![dark](https://raw.githubusercontent.com/block/buzz/8246f8fb9a2446dcf25d6a43b93345bcfe02c5ba/pr-1636--07-buzz-dark-rail.png)
