### PR TITLE
copy(desktop): the word "persona" leaves the UI (Phase 1B.4)

### DIFF
--- a/desktop/src/features/agents/lib/resolvePersonaRuntime.ts
+++ b/desktop/src/features/agents/lib/resolvePersonaRuntime.ts
@@ -73,7 +73,7 @@ export function resolvePersonaRuntime(
     return {
       runtime: defaultRuntime,
       warnings: [
-        `Persona is configured for runtime "${personaRuntimeId}" but it is not available. Using ${defaultRuntime.label} instead.`,
+        `This agent is configured for runtime "${personaRuntimeId}" but it is not available. Using ${defaultRuntime.label} instead.`,
       ],
       isOverridden: true,
     };
@@ -82,7 +82,7 @@ export function resolvePersonaRuntime(
   return {
     runtime: null,
     warnings: [
-      `Persona is configured for runtime "${personaRuntimeId}" but it is not available, and no other runtimes were found.`,
+      `This agent is configured for runtime "${personaRuntimeId}" but it is not available, and no other runtimes were found.`,
     ],
     isOverridden: false,
   };

--- a/desktop/src/features/agents/ui/AgentConfigPanel.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigPanel.tsx
@@ -115,7 +115,7 @@ function provenanceSentence(
     case "buzzExplicit":
       return "Set in Buzz";
     case "personaDefault":
-      return "Inherited from persona";
+      return "Inherited from template";
     case "runtimeOverride":
       return "Live override (this session only)";
     case "harnessConstraint":

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -235,7 +235,7 @@ export function AgentInstanceEditDialog({
   // The runtime id that will actually be active after submit. When inheriting,
   // resolve from the LINKED PERSONA's runtime — that is what will run once the
   // override is cleared. Deriving from agent.agentCommand here is wrong for a
-  // pinned agent that just toggled "Inherit runtime from persona": the override
+  // pinned agent that just toggled "Inherit runtime from template": the override
   // (e.g. a Claude pin) is still present on the record, so it would resolve to
   // the old pin instead of the persona's runtime, hiding required credentials.
   // Fall back to the agent.agentCommand dual-match (command path, then id) only

--- a/desktop/src/features/agents/ui/BatchImportDialog.tsx
+++ b/desktop/src/features/agents/ui/BatchImportDialog.tsx
@@ -131,7 +131,7 @@ export function BatchImportDialog({
       <DialogContent className="max-w-2xl overflow-hidden p-0">
         <div className="flex max-h-[85vh] flex-col">
           <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
-            <DialogTitle>Import Personas</DialogTitle>
+            <DialogTitle>Import Agents</DialogTitle>
             <DialogDescription>
               Found {personas.length} persona
               {personas.length !== 1 ? "s" : ""} in {fileName || "archive"}.

--- a/desktop/src/features/agents/ui/CreateAgentDialog.tsx
+++ b/desktop/src/features/agents/ui/CreateAgentDialog.tsx
@@ -828,7 +828,7 @@ export function CreateAgentDialog({
             <EnvVarsEditor
               disabled={createMutation.isPending}
               fileSatisfiedKeys={fileSatisfiedEnvKeys}
-              helperText="Injected at spawn. Overrides the persona's env vars on collision."
+              helperText="Injected at spawn. Overrides the template's env vars on collision."
               onChange={setEnvVars}
               requiredKeys={requiredEnvKeys}
               value={envVars}

--- a/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
+++ b/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
@@ -70,7 +70,7 @@ export function EditAgentAdvancedFields({
 }) {
   return (
     <div className="space-y-5 pt-2">
-      {/* Inherit runtime from persona */}
+      {/* Inherit runtime from template */}
       {linkedPersona ? (
         <div className="space-y-1.5">
           <label
@@ -83,14 +83,14 @@ export function EditAgentAdvancedFields({
               onChange={(event) => onInheritHarnessChange(event.target.checked)}
               type="checkbox"
             />
-            Inherit runtime from persona
+            Inherit runtime from template
           </label>
           <p className="text-xs text-muted-foreground">
             {inheritHarness
-              ? `Uses the ${linkedPersona.displayName} persona's runtime${
+              ? `Uses the ${linkedPersona.displayName} template's runtime${
                   linkedPersona.runtime ? ` (${linkedPersona.runtime})` : ""
-                }. Editing the persona and respawning propagates the new runtime.`
-              : "Pins this agent to a specific runtime command, overriding the persona's runtime."}
+                }. Editing the template and respawning propagates the new runtime.`
+              : "Pins this agent to a specific runtime command, overriding the template's runtime."}
           </p>
         </div>
       ) : null}
@@ -366,9 +366,9 @@ export function EditAgentAdvancedFields({
       <EnvVarsEditor
         disabled={disabled}
         fileSatisfiedKeys={fileSatisfiedEnvKeys}
-        helperText="Per-agent env vars. Override the persona's vars on collision."
+        helperText="Per-agent env vars. Override the template's vars on collision."
         inheritedFrom={inheritedEnvVars}
-        inheritedLabel="persona"
+        inheritedLabel="template"
         onChange={onEnvVarsChange}
         requiredKeys={requiredEnvKeys}
         value={envVars}

--- a/desktop/src/features/agents/ui/EnvVarsEditor.tsx
+++ b/desktop/src/features/agents/ui/EnvVarsEditor.tsx
@@ -424,7 +424,7 @@ export function EnvVarsEditor({
 
 /**
  * Render a masked preview of an inherited (persona) env value so the agent
- * dialog can show "Overrides persona value •••• (last 4)" without exposing
+ * dialog can show "Overrides template value •••• (last 4)" without exposing
  * the persona's actual secret to anyone viewing the agent UI. Empty values
  * render as "(empty)" so the user can still tell the persona had a value
  * set at all.

--- a/desktop/src/features/agents/ui/ModelPicker.tsx
+++ b/desktop/src/features/agents/ui/ModelPicker.tsx
@@ -101,7 +101,7 @@ export function ModelPicker({
       acpConfigOption: "from ACP config",
       envVar: "from env",
       configFile: "from config file",
-      personaDefault: "persona default",
+      personaDefault: "template default",
       runtimeOverride: "live override",
     };
     return labels[origin] ?? null;

--- a/desktop/src/features/agents/ui/PersonaCatalogDetailsSheet.tsx
+++ b/desktop/src/features/agents/ui/PersonaCatalogDetailsSheet.tsx
@@ -126,7 +126,7 @@ export function PersonaCatalogDetailsSheet({
                   <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                     Type
                   </p>
-                  <p className="mt-2 text-sm font-medium">Built-in persona</p>
+                  <p className="mt-2 text-sm font-medium">Built-in agent</p>
                 </div>
                 <div className="rounded-xl border border-border/70 bg-card/70 p-4">
                   <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">

--- a/desktop/src/features/agents/ui/PersonaCatalogDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaCatalogDialog.tsx
@@ -282,7 +282,7 @@ function PersonaCatalogDetail({ persona }: { persona: AgentPersona }) {
         items={[
           {
             label: "Type",
-            value: persona.isBuiltIn ? "Built-in persona" : "Custom persona",
+            value: persona.isBuiltIn ? "Built-in agent" : "Custom agent",
           },
           {
             label: "Preferred model",

--- a/desktop/src/features/agents/ui/PersonaDeleteDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDeleteDialog.tsx
@@ -28,11 +28,11 @@ export function PersonaDeleteDialog({
     <AlertDialog onOpenChange={onOpenChange} open={open}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete persona?</AlertDialogTitle>
+          <AlertDialogTitle>Delete agent?</AlertDialogTitle>
           <AlertDialogDescription>
             {persona
               ? `Delete ${persona.displayName}. Existing agents keep their copied settings, but this template will no longer be available for new deployments.`
-              : "Delete this persona."}
+              : "Delete this agent."}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/desktop/src/features/agents/ui/PersonaImportUpdateDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaImportUpdateDialog.tsx
@@ -131,7 +131,7 @@ export function PersonaImportUpdateDialog({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden p-0">
         <DialogHeader className="shrink-0 space-y-1 border-b border-border/60 px-6 py-5 pr-14">
-          <DialogTitle>Import persona</DialogTitle>
+          <DialogTitle>Import agent</DialogTitle>
         </DialogHeader>
 
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">

--- a/desktop/src/features/agents/ui/TeamDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamDialog.tsx
@@ -363,7 +363,7 @@ export function TeamDialog({
               </div>
 
               <div className="space-y-2">
-                <span className="text-sm font-medium">Personas</span>
+                <span className="text-sm font-medium">Agents</span>
                 <p className="text-xs text-muted-foreground">
                   Select the personas to include in this team.
                 </p>
@@ -384,7 +384,7 @@ export function TeamDialog({
                   <div
                     className="max-h-60 space-y-1 overflow-y-auto rounded-lg border border-border/70 p-2"
                     role="listbox"
-                    aria-label="Personas"
+                    aria-label="Agents"
                     aria-multiselectable="true"
                   >
                     {orderedPersonas.map((persona) => {

--- a/desktop/src/features/agents/ui/TeamImportDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamImportDialog.tsx
@@ -148,7 +148,7 @@ export function TeamImportDialog({
               </div>
 
               <div className="space-y-1">
-                <p className="text-sm font-medium">Personas to import</p>
+                <p className="text-sm font-medium">Agents to import</p>
                 <p className="text-xs text-muted-foreground">
                   Each persona will be created, then grouped into a new team.
                 </p>

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -232,7 +232,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               agents={unknown}
               collapsed={collapsed}
               groupKey="__unknown__"
-              label="Unknown Persona"
+              label="Unknown Agent"
               startingAgentPubkey={startingAgentPubkey}
               onToggle={toggle}
               onOpenAgentProfile={onOpenAgentProfile}

--- a/desktop/src/features/agents/ui/personaLibraryCopy.ts
+++ b/desktop/src/features/agents/ui/personaLibraryCopy.ts
@@ -1,14 +1,14 @@
 export const personaLibraryCopy = {
   title: "My agents",
   description:
-    "The personas you have chosen for this app. Use them to create teams and launch agents.",
+    "The agents you have chosen for this app. Use them to create teams and launch agents.",
   chooseFromCatalog: "Choose from catalog",
   createNew: "New agent",
   customAgent: "Custom agent",
   import: "Import",
   emptyTitle: "No agents yet",
   emptyDescription:
-    "Choose one from Agent Catalog, add your own persona, or import one to get started.",
+    "Choose one from Agent Catalog, create your own, or import one to get started.",
   emptyImportHint:
     "Or drop a .persona.md, .persona.json, .persona.png, or .zip file here to import.",
 } as const;
@@ -30,14 +30,14 @@ export const personaCatalogCopy = {
   availableState: "Available",
   detailSelectedTitle: "Selected for My Agents",
   detailSelectedDescription:
-    "Turn this off to remove the persona from teams and agent creation in this app.",
+    "Turn this off to remove the agent from teams and agent creation in this app.",
   detailAvailableTitle: "Available in Agent Catalog",
   detailAvailableDescription:
-    "Turn this on to make the persona available for teams and agent creation.",
+    "Turn this on to make the agent available for teams and agent creation.",
   useAction: "Add agent",
   addedAction: "Added to My Agents",
   teamEmptyState:
-    "No personas in My Agents yet. Create one or choose one from Agent Catalog first.",
+    "No agents in My Agents yet. Create one or choose one from Agent Catalog first.",
 } as const;
 
 export function getPersonaCatalogSelectionActionCopy(isActive: boolean) {

--- a/desktop/src/features/agents/ui/personaRuntimeModel.ts
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.ts
@@ -119,7 +119,7 @@ export function hasMissingRequiredEnvKey(
  * The ONE exception is the inherit-TRANSITION-from-a-harness-pin: a previously
  * harness-pinned agent (e.g. Claude — `agent.agentCommandOverride != null` at
  * dialog open) has its `provider` cleared and carries no persona credential,
- * then the user checks "Inherit runtime from persona" for a provider-backed
+ * then the user checks "Inherit runtime from template" for a provider-backed
  * persona (e.g. buzz-agent/Anthropic). Persisting the local (empty) provider +
  * credential-less env would save an agent that fails readiness on next start.
  * Only in that case — inheriting AND the local provider is empty AND the agent

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -232,7 +232,7 @@ export function usePersonaActions() {
       return true;
     } catch (error) {
       setPersonaErrorMessage(
-        error instanceof Error ? error.message : "Failed to save persona.",
+        error instanceof Error ? error.message : "Failed to save agent.",
       );
       return false;
     } finally {
@@ -248,7 +248,7 @@ export function usePersonaActions() {
       setPersonaToDelete(null);
     } catch (error) {
       setPersonaErrorMessage(
-        error instanceof Error ? error.message : "Failed to delete persona.",
+        error instanceof Error ? error.message : "Failed to delete agent.",
       );
     }
   }
@@ -271,8 +271,8 @@ export function usePersonaActions() {
         error instanceof Error
           ? error.message
           : active
-            ? "Failed to select persona for My Agents."
-            : "Failed to deselect persona from My Agents.",
+            ? "Failed to select agent for My Agents."
+            : "Failed to deselect agent from My Agents.",
       );
     }
   }
@@ -291,11 +291,11 @@ export function usePersonaActions() {
         setBatchImportResult(result);
         setBatchImportFileName(fileName);
       } else {
-        setPersonaErrorMessage("No valid personas found in file.");
+        setPersonaErrorMessage("No valid agents found in file.");
       }
     } catch (err) {
       setPersonaErrorMessage(
-        err instanceof Error ? err.message : "Failed to parse persona file.",
+        err instanceof Error ? err.message : "Failed to parse agent file.",
       );
     }
   }
@@ -310,7 +310,7 @@ export function usePersonaActions() {
       },
       onError: (error) => {
         setPersonaErrorMessage(
-          error instanceof Error ? error.message : "Failed to export persona.",
+          error instanceof Error ? error.message : "Failed to export agent.",
         );
       },
     });

--- a/desktop/src/features/agents/ui/usePersonaImportActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaImportActions.ts
@@ -48,7 +48,7 @@ export function usePersonaImportActions(
       (candidate) => candidate.id === personaId,
     );
     if (!persona) {
-      const message = "Persona not found. Refresh and try again.";
+      const message = "Agent not found. Refresh and try again.";
       feedback.setPersonaErrorMessage(message);
       throw new Error(message);
     }
@@ -56,7 +56,7 @@ export function usePersonaImportActions(
     try {
       const result = await parsePersonaFiles(fileBytes, fileName);
       if (result.personas.length === 0) {
-        const message = "No valid personas found in file.";
+        const message = "No valid agents found in file.";
         feedback.setPersonaErrorMessage(message);
         throw new Error(message);
       }
@@ -66,7 +66,7 @@ export function usePersonaImportActions(
       feedback.setPersonaDialogState(null);
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "Failed to parse persona file.";
+        err instanceof Error ? err.message : "Failed to parse agent file.";
       feedback.setPersonaErrorMessage(message);
       throw err instanceof Error ? err : new Error(message);
     }

--- a/desktop/src/features/agents/ui/useTeamActions.ts
+++ b/desktop/src/features/agents/ui/useTeamActions.ts
@@ -158,7 +158,7 @@ export function useTeamActions(
     actions.setActionErrorMessage(null);
     setTeamDialogState({
       title: "Create team",
-      description: "Group personas together for quick deployment to channels.",
+      description: "Group agents together for quick deployment to channels.",
       submitLabel: "Create team",
       initialValues: {
         name: "",

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -433,7 +433,7 @@ export function AddChannelBotDialog({
     ? "Loading runtimes..."
     : providers.length === 0
       ? "No runtimes found"
-      : (selectedRuntime?.label ?? "Use persona defaults");
+      : (selectedRuntime?.label ?? "Use agent defaults");
   const addButtonLabel = createBotsMutation.isPending
     ? selectedCount > 1
       ? `Adding ${selectedCount}...`
@@ -447,7 +447,7 @@ export function AddChannelBotDialog({
       <ChooserDialogContent
         className="max-w-3xl"
         data-testid="add-channel-bot-dialog"
-        description="Select any combination of saved personas, or turn on Generic for a one-off custom agent."
+        description="Select any combination of saved agents, or turn on Generic for a one-off custom agent."
         footer={
           <>
             <Button
@@ -567,8 +567,8 @@ export function AddChannelBotDialog({
           </DropdownMenu>
           <p className="text-xs text-muted-foreground">
             {isOverrideActive
-              ? "All agents will use this runtime, overriding persona preferences."
-              : "Each persona uses its preferred runtime. Choose a runtime above to override all."}
+              ? "All agents will use this runtime, overriding their configured preferences."
+              : "Each agent uses its preferred runtime. Choose a runtime above to override all."}
           </p>
         </div>
 

--- a/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
@@ -118,7 +118,7 @@ export function AddChannelBotPersonasSection({
     <div className="space-y-3">
       <div className="space-y-3">
         <div>
-          <div className="text-sm font-medium">Personas</div>
+          <div className="text-sm font-medium">Agents</div>
           <p className="text-xs text-muted-foreground">
             Toggle as many as you want. Each selected persona is added as its
             own agent. Hover a persona to preview its role.
@@ -215,7 +215,7 @@ export function AddChannelBotPersonasSection({
         </TooltipProvider>
 
         {isLoading ? (
-          <p className="text-xs text-muted-foreground">Loading personas...</p>
+          <p className="text-xs text-muted-foreground">Loading agents...</p>
         ) : null}
       </div>
     </div>

--- a/desktop/src/features/onboarding/welcomeGuide.ts
+++ b/desktop/src/features/onboarding/welcomeGuide.ts
@@ -96,7 +96,7 @@ async function ensureWelcomeGuidePersonaActive() {
     (persona) => persona.id === WELCOME_GUIDE_PERSONA_ID,
   );
   if (!guidePersona) {
-    throw new Error(`${WELCOME_GUIDE_AGENT_NAME} persona not found.`);
+    throw new Error(`${WELCOME_GUIDE_AGENT_NAME} agent not found.`);
   }
   if (!guidePersona.isActive) {
     await setPersonaActive(WELCOME_GUIDE_PERSONA_ID, true);

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1445,7 +1445,7 @@ function buildMockConfigSurface(pubkey: string): {
 
   // Mixed-provenance showcase — top-level rows carry different origins so the
   // panel witnesses distinct provenance labels in one frame: "Set in Buzz",
-  // "Inherited from persona", "From config file (...)" and
+  // "Inherited from template", "From config file (...)" and
   // "From environment variable (...)".
   const multiOriginSurface = {
     runtimeId: "goose",

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -336,7 +336,7 @@ test("catalog detail pane shows the full persona details", async ({ page }) => {
     "You are Fizz.",
   );
   await expect(page.getByTestId("persona-catalog-detail-pane")).toContainText(
-    "Built-in persona",
+    "Built-in agent",
   );
   await expect(page.getByTestId("persona-catalog-detail-pane")).toContainText(
     "Preferred model",
@@ -409,7 +409,7 @@ test("custom personas can be shown in the agent catalog", async ({ page }) => {
   ).toContainText("Analyst");
   await selectCatalogPersona(page, analystPersonaId);
   await expect(page.getByTestId("persona-catalog-detail-pane")).toContainText(
-    "Custom persona",
+    "Custom agent",
   );
   await expect(
     page.getByTestId(`persona-catalog-use-agent-target-${analystPersonaId}`),

--- a/desktop/tests/e2e/config-bridge-screenshots.spec.ts
+++ b/desktop/tests/e2e/config-bridge-screenshots.spec.ts
@@ -210,7 +210,7 @@ test.describe("config bridge screenshots", () => {
 
     // Multiple distinct provenance origins visible at once.
     await expect(panel.getByText("Set in Buzz").first()).toBeVisible();
-    await expect(panel.getByText("Inherited from persona")).toBeVisible();
+    await expect(panel.getByText("Inherited from template")).toBeVisible();
     await expect(
       panel.getByText("From environment variable (GOOSE_MODE)"),
     ).toBeVisible();


### PR DESCRIPTION
## What (Phase 1B.4 — the word "persona" leaves the UI)

Executes Wes's decision: "persona" dies completely as user-visible vocabulary. Every user-facing string becomes **"agent"** — or **"template"** inside instance-edit/config surfaces, where "agent" already means the running instance ("Inherit runtime from agent" would be absurd). String-only: **zero** testid/selector/identifier changes, zero behavior changes, 26 files, +52/−52.

**Out of scope (deliberate):** ~3,800 code-internal identifiers (`personaId`, `PersonaRecord`, `usePersonaActions`, testids, filenames) — invisible to users; renaming is a future mechanical slice. File-extension strings (`.persona.md`/`.persona.json`/`.persona.png`) stay — literal formats, not vocabulary. e2eBridge fixture data stays.

## Full copy table (line-by-line approval artifact)

| # | File | Before | After |
|---|------|--------|-------|
| 1 | personaLibraryCopy.ts | The personas you have chosen for this app… | The agents you have chosen for this app… |
| 2 | personaLibraryCopy.ts | …add your own persona, or import one… | …create your own, or import one… |
| 3 | personaLibraryCopy.ts | Turn this off to remove the persona from teams… | Turn this off to remove the agent from teams… |
| 4 | personaLibraryCopy.ts | Turn this on to make the persona available… | Turn this on to make the agent available… |
| 5 | personaLibraryCopy.ts | No personas in My Agents yet… | No agents in My Agents yet… |
| 6 | PersonaCatalogDialog.tsx | Built-in persona / Custom persona | Built-in agent / Custom agent |
| 7 | PersonaCatalogDetailsSheet.tsx | Built-in persona | Built-in agent |
| 8 | AddChannelBotDialog.tsx | Use persona defaults | Use agent defaults |
| 9 | AddChannelBotDialog.tsx | Select any combination of saved personas… | Select any combination of saved agents… |
| 10 | AddChannelBotDialog.tsx | …overriding persona preferences. | …overriding their configured preferences. |
| 11 | AddChannelBotDialog.tsx | Each persona uses its preferred runtime… | Each agent uses its preferred runtime… |
| 12 | AddChannelBotPersonasSection.tsx | Personas / Loading personas... | Agents / Loading agents... |
| 13 | TeamDialog.tsx | Personas (tab + aria-label) | Agents |
| 14 | BatchImportDialog.tsx | Import Personas | Import Agents |
| 15 | PersonaImportUpdateDialog.tsx | Import persona | Import agent |
| 16 | TeamImportDialog.tsx | Personas to import | Agents to import |
| 17 | useTeamActions.ts | Group personas together for quick deployment… | Group agents together for quick deployment… |
| 18 | EditAgentAdvancedFields.tsx | Inherit runtime from persona | Inherit runtime from template |
| 19 | EditAgentAdvancedFields.tsx | Uses the {name} persona's runtime… Editing the persona and respawning… | Uses the {name} template's runtime… Editing the template and respawning… |
| 20 | EditAgentAdvancedFields.tsx | …overriding the persona's runtime. | …overriding the template's runtime. |
| 21 | EditAgentAdvancedFields.tsx | Per-agent env vars. Override the persona's vars on collision. | …Override the template's vars on collision. |
| 22 | EditAgentAdvancedFields.tsx | inheritedLabel="persona" → renders "Overrides persona value ••••" | inheritedLabel="template" |
| 23 | AgentConfigPanel.tsx | Inherited from persona | Inherited from template |
| 24 | ModelPicker.tsx | persona default | template default |
| 25 | CreateAgentDialog.tsx | Injected at spawn. Overrides the persona's env vars on collision. | …Overrides the template's env vars on collision. |
| 26 | UnifiedAgentsSection.tsx | Unknown Persona | Unknown Agent |
| 27 | PersonaDeleteDialog.tsx | Delete persona? / Delete this persona. | Delete agent? / Delete this agent. |
| 28 | welcomeGuide.ts | {name} persona not found. | {name} agent not found. |
| 29 | usePersonaActions.ts | Failed to save/delete/select/deselect/export persona; No valid personas found in file; Failed to parse persona file. | …agent… (×7) |
| 30 | usePersonaImportActions.ts | Persona not found. Refresh and try again. / No valid personas… / Failed to parse persona file. | Agent not found… / No valid agents… / Failed to parse agent file. |
| 31 | resolvePersonaRuntime.ts | Persona is configured for runtime "…" but it is not available… (×2) | This agent is configured for runtime "…" but it is not available… |

## Spec edits (bounded up front, in lockstep with rows 6 and 23)

- `agents.spec.ts:339` "Built-in persona" → "Built-in agent"; `:412` "Custom persona" → "Custom agent"
- `config-bridge-screenshots.spec.ts:213` "Inherited from persona" → "Inherited from template"

Comments updated only where they quoted the exact changed copy (EnvVarsEditor, personaRuntimeModel, AgentInstanceEditDialog, e2eBridge) so docs don't lie.

## Validation

- tsc clean, biome clean (all 26 files)
- Unit: **2098/2098**
- e2e: 59-test agent/persona smoke slice green + config-bridge-screenshots 6/6 (the three edited assertions pass against the new copy)
