### PR TITLE
copy(desktop): finish the persona→agent rename in rendered UI (B4.1)

### DIFF
--- a/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
@@ -158,7 +158,7 @@ export function AddTeamToChannelDialog({
           <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
             <DialogTitle>Deploy team to channel</DialogTitle>
             <DialogDescription>
-              Create and attach one agent per persona in{" "}
+              Create and attach one agent per member of{" "}
               <strong>{team?.name ?? "this team"}</strong> to the selected
               channel.
             </DialogDescription>
@@ -168,7 +168,7 @@ export function AddTeamToChannelDialog({
             {resolved.length > 0 ? (
               <div className="space-y-1.5">
                 <span className="text-sm font-medium">
-                  Personas ({resolved.length})
+                  Agents ({resolved.length})
                 </span>
                 <div className="flex flex-wrap gap-2">
                   {resolved.map((persona) => (
@@ -237,7 +237,7 @@ export function AddTeamToChannelDialog({
 
             {missingPersonaCount > 0 ? (
               <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                This team references {missingPersonaCount} persona
+                This team references {missingPersonaCount} agent
                 {missingPersonaCount === 1 ? "" : "s"} that{" "}
                 {missingPersonaCount === 1 ? "is" : "are"} no longer in My
                 Agents. Add them back or edit the team before deploying.

--- a/desktop/src/features/agents/ui/BatchImportDialog.tsx
+++ b/desktop/src/features/agents/ui/BatchImportDialog.tsx
@@ -133,7 +133,7 @@ export function BatchImportDialog({
           <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
             <DialogTitle>Import Agents</DialogTitle>
             <DialogDescription>
-              Found {personas.length} persona
+              Found {personas.length} agent
               {personas.length !== 1 ? "s" : ""} in {fileName || "archive"}.
             </DialogDescription>
           </DialogHeader>

--- a/desktop/src/features/agents/ui/BatchImportDialog.tsx
+++ b/desktop/src/features/agents/ui/BatchImportDialog.tsx
@@ -112,7 +112,7 @@ export function BatchImportDialog({
         });
         setStatus("error");
         setErrorMessage(
-          `Imported ${completed} of ${selected.size}. Failed on '${persona.displayName}': ${error instanceof Error ? error.message : String(error)}. Already-imported personas are saved.`,
+          `Imported ${completed} of ${selected.size}. Failed on '${persona.displayName}': ${error instanceof Error ? error.message : String(error)}. Already-imported agents are saved.`,
         );
         return;
       }

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -265,7 +265,7 @@ function AgentSummary({
           ) : null}
           {agent.personaOutOfDate ? (
             <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
-              Persona updated since this agent was created. Respawn to apply the
+              Template updated since this agent was created. Respawn to apply the
               new configuration.
             </p>
           ) : null}

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -265,8 +265,8 @@ function AgentSummary({
           ) : null}
           {agent.personaOutOfDate ? (
             <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
-              Template updated since this agent was created. Respawn to apply the
-              new configuration.
+              Template updated since this agent was created. Respawn to apply
+              the new configuration.
             </p>
           ) : null}
           {channelNames.length > 0 ? (

--- a/desktop/src/features/agents/ui/PersonaImportUpdateDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaImportUpdateDialog.tsx
@@ -90,7 +90,7 @@ export function PersonaImportUpdateDialog({
       setErrorMessage(
         error instanceof Error
           ? error.message
-          : "Failed to apply imported persona update.",
+          : "Failed to apply imported agent update.",
       );
     }
   }

--- a/desktop/src/features/agents/ui/TeamDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamDialog.tsx
@@ -365,11 +365,11 @@ export function TeamDialog({
               <div className="space-y-2">
                 <span className="text-sm font-medium">Agents</span>
                 <p className="text-xs text-muted-foreground">
-                  Select the personas to include in this team.
+                  Select the agents to include in this team.
                 </p>
                 {missingInitialPersonaCount > 0 ? (
                   <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                    This team references {missingInitialPersonaCount} persona
+                    This team references {missingInitialPersonaCount} agent
                     {missingInitialPersonaCount === 1 ? "" : "s"} that{" "}
                     {missingInitialPersonaCount === 1 ? "is" : "are"} no longer
                     in My Agents. Save to remove them, or add them back to My

--- a/desktop/src/features/agents/ui/TeamImportDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamImportDialog.tsx
@@ -106,7 +106,7 @@ export function TeamImportDialog({
         });
         setStatus("error");
         setErrorMessage(
-          `Imported ${completed} of ${personas.length} personas. Failed on '${persona.display_name}': ${error instanceof Error ? error.message : String(error)}. Already-imported personas are saved.`,
+          `Imported ${completed} of ${personas.length} agents. Failed on '${persona.display_name}': ${error instanceof Error ? error.message : String(error)}. Already-imported agents are saved.`,
         );
         return;
       }
@@ -143,14 +143,14 @@ export function TeamImportDialog({
                 </div>
                 <span className="text-xs text-muted-foreground">
                   {personas.length}{" "}
-                  {personas.length === 1 ? "persona" : "personas"}
+                  {personas.length === 1 ? "agent" : "agents"}
                 </span>
               </div>
 
               <div className="space-y-1">
                 <p className="text-sm font-medium">Agents to import</p>
                 <p className="text-xs text-muted-foreground">
-                  Each persona will be created, then grouped into a new team.
+                  Each agent will be created, then grouped into a new team.
                 </p>
               </div>
 
@@ -211,7 +211,7 @@ export function TeamImportDialog({
           >
             {status === "importing"
               ? `Importing ${importedCount}/${personas.length}...`
-              : `Import team (${personas.length} personas)`}
+              : `Import team (${personas.length} agents)`}
           </Button>
         </div>
       </DialogContent>

--- a/desktop/src/features/agents/ui/TeamImportDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamImportDialog.tsx
@@ -142,8 +142,7 @@ export function TeamImportDialog({
                   ) : null}
                 </div>
                 <span className="text-xs text-muted-foreground">
-                  {personas.length}{" "}
-                  {personas.length === 1 ? "agent" : "agents"}
+                  {personas.length} {personas.length === 1 ? "agent" : "agents"}
                 </span>
               </div>
 

--- a/desktop/src/features/agents/ui/TeamsSection.tsx
+++ b/desktop/src/features/agents/ui/TeamsSection.tsx
@@ -217,7 +217,7 @@ export function TeamsSection({
               >
                 {hasMissingPersonas ? (
                   <p className="border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-                    {missingPersonaCount} persona
+                    {missingPersonaCount} agent
                     {missingPersonaCount === 1 ? "" : "s"} in this team{" "}
                     {missingPersonaCount === 1 ? "is" : "are"} no longer in your
                     My Agents. Edit the team to repair it before deploying or

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -320,7 +320,7 @@ export function usePersonaActions() {
     clearFeedback("library");
     setBatchImportResult(null);
     setPersonaNoticeMessage(
-      `Imported ${count} persona${count !== 1 ? "s" : ""}.`,
+      `Imported ${count} agent${count !== 1 ? "s" : ""}.`,
     );
     void queryClient.invalidateQueries({ queryKey: personasQueryKey });
   }

--- a/desktop/src/features/agents/ui/usePersonaImportActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaImportActions.ts
@@ -96,7 +96,7 @@ export function usePersonaImportActions(
     selectedFields: string[];
   }) {
     if (!personaImportTarget || !personaImportTargetPreview) {
-      throw new Error("No persona import update is currently open.");
+      throw new Error("No agent import update is currently open.");
     }
 
     feedback.clearPersonaFeedback();
@@ -140,7 +140,7 @@ export function usePersonaImportActions(
       const message =
         error instanceof Error
           ? error.message
-          : "Failed to apply imported persona update.";
+          : "Failed to apply imported agent update.";
       feedback.setPersonaErrorMessage(message);
       throw error instanceof Error ? error : new Error(message);
     } finally {

--- a/desktop/src/features/agents/ui/useTeamActions.ts
+++ b/desktop/src/features/agents/ui/useTeamActions.ts
@@ -494,7 +494,7 @@ export function useTeamActions(
 
       // Both attempts failed — personas exist but team doesn't.
       actions.setActionErrorMessage(
-        `Imported ${personaIds.length} persona${personaIds.length !== 1 ? "s" : ""} but failed to create team "${teamName}". The personas are saved — create a team manually to group them.`,
+        `Imported ${personaIds.length} agent${personaIds.length !== 1 ? "s" : ""} but failed to create team "${teamName}". The personas are saved — create a team manually to group them.`,
       );
       void queryClient.invalidateQueries({ queryKey: personasQueryKey });
     })();

--- a/desktop/src/features/agents/ui/useTeamActions.ts
+++ b/desktop/src/features/agents/ui/useTeamActions.ts
@@ -482,7 +482,7 @@ export function useTeamActions(
         try {
           await createTeamApi(teamInput);
           actions.setActionNoticeMessage(
-            `Imported team "${teamName}" with ${personaIds.length} persona${personaIds.length !== 1 ? "s" : ""}.`,
+            `Imported team "${teamName}" with ${personaIds.length} agent${personaIds.length !== 1 ? "s" : ""}.`,
           );
           void queryClient.invalidateQueries({ queryKey: personasQueryKey });
           void queryClient.invalidateQueries({ queryKey: teamsQueryKey });
@@ -494,7 +494,7 @@ export function useTeamActions(
 
       // Both attempts failed — personas exist but team doesn't.
       actions.setActionErrorMessage(
-        `Imported ${personaIds.length} agent${personaIds.length !== 1 ? "s" : ""} but failed to create team "${teamName}". The personas are saved — create a team manually to group them.`,
+        `Imported ${personaIds.length} agent${personaIds.length !== 1 ? "s" : ""} but failed to create team "${teamName}". The agents are saved — create a team manually to group them.`,
       );
       void queryClient.invalidateQueries({ queryKey: personasQueryKey });
     })();

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -554,7 +554,7 @@ export function AddChannelBotDialog({
                 value={selectedRuntime?.id ?? RUNTIME_NONE_SENTINEL}
               >
                 <DropdownMenuRadioItem value={RUNTIME_NONE_SENTINEL}>
-                  Use persona defaults
+                  Use agent defaults
                 </DropdownMenuRadioItem>
                 <DropdownMenuSeparator />
                 {providers.map((provider) => (
@@ -640,7 +640,7 @@ export function AddChannelBotDialog({
 
         {selectedCount === 0 ? (
           <div className="rounded-2xl border border-dashed border-border/70 bg-muted/15 px-4 py-4 text-sm text-muted-foreground">
-            Pick one or more personas, or enable Generic to add a custom agent.
+            Pick one or more agents, or enable Generic to add a custom agent.
           </div>
         ) : null}
 

--- a/desktop/src/features/channels/ui/AddChannelBotGenericSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotGenericSection.tsx
@@ -21,7 +21,7 @@ export function AddChannelBotGenericSection({
       <div>
         <div className="text-sm font-medium">Generic agent</div>
         <p className="text-xs text-muted-foreground">
-          Add one custom agent alongside any selected personas.
+          Add one custom agent alongside any selected agents.
         </p>
       </div>
 

--- a/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotPersonasSection.tsx
@@ -120,8 +120,8 @@ export function AddChannelBotPersonasSection({
         <div>
           <div className="text-sm font-medium">Agents</div>
           <p className="text-xs text-muted-foreground">
-            Toggle as many as you want. Each selected persona is added as its
-            own agent. Hover a persona to preview its role.
+            Toggle as many as you want. Each selected agent is added to the
+            channel. Hover an agent to preview its role.
           </p>
         </div>
 

--- a/desktop/src/features/channels/ui/AddChannelBotTeamsSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotTeamsSection.tsx
@@ -74,7 +74,7 @@ export function AddChannelBotTeamsSection({
       <div>
         <div className="text-sm font-medium">Teams</div>
         <p className="text-xs text-muted-foreground">
-          Select a team to toggle all its personas at once.
+          Select a team to toggle all its agents at once.
         </p>
       </div>
 


### PR DESCRIPTION
## What (B4.1 — finish the persona→agent rename)

Follow-up to #1646 (merged before its cross-review verdict landed; reviewer requested changes for ~16 residual user-visible "persona" strings). #1646's exact-match method converted quoted string literals but missed **multi-line JSX text nodes** and pluralization templates — leaving dialogs internally inconsistent. This converts the residuals: 12 files, +21/−21, string-only.

## Copy table

| # | File | Before | After |
|---|------|--------|-------|
| 1 | AddChannelBotDialog.tsx | "Use persona defaults" (dropdown **menu item** — trigger was converted in #1646, menu disagreed with it) | "Use agent defaults" |
| 2 | AddChannelBotDialog.tsx | Pick one or more personas, or enable Generic… | Pick one or more agents, or enable Generic… |
| 3 | AddChannelBotPersonasSection.tsx | Toggle as many as you want. Each selected persona is added as its own agent. Hover a persona to preview its role. | Toggle as many as you want. Each selected agent is added to the channel. Hover an agent to preview its role. |
| 4 | AddChannelBotTeamsSection.tsx | Select a team to toggle all its personas at once. | …all its agents at once. |
| 5 | TeamDialog.tsx | Select the personas to include in this team. | Select the agents to include… |
| 6 | TeamDialog.tsx | This team references {n} persona(s)… | This team references {n} agent(s)… |
| 7 | TeamImportDialog.tsx | {n} persona/personas count label | {n} agent/agents |
| 8 | TeamImportDialog.tsx | Each persona will be created, then grouped into a new team. | Each agent will be created… |
| 9 | TeamImportDialog.tsx | Imported {n} of {m} personas… Already-imported personas are saved. | …agents… Already-imported agents are saved. |
| 10 | TeamImportDialog.tsx | Import team ({n} personas) | Import team ({n} agents) |
| 11 | ManagedAgentRow.tsx | Persona updated since this agent was created. Respawn to apply… | Template updated since this agent was created… (instance-surface rule from #1646) |
| 12 | AddTeamToChannelDialog.tsx | Create and attach one agent per persona in {team} | Create and attach one agent per member of {team} |
| 13 | AddTeamToChannelDialog.tsx | Personas ({n}) | Agents ({n}) |
| 14 | AddTeamToChannelDialog.tsx | This team references {n} persona(s)… | …agent(s)… |
| 15 | TeamsSection.tsx | {n} persona(s) missing count | {n} agent(s) |
| 16 | useTeamActions.ts | Imported {n} persona(s) but failed to create team… | Imported {n} agent(s)… |
| 17 | BatchImportDialog.tsx | Found {n} persona(s) | Found {n} agent(s) |
| 18 | PersonaImportUpdateDialog.tsx + usePersonaImportActions.ts | Failed to apply imported persona update. | Failed to apply imported agent update. |
| 19 | usePersonaImportActions.ts | No persona import update is currently open. | No agent import update is currently open. |

## Not included (category C — awaiting Wes's ruling)

1. "Import persona file" menu item (UnifiedAgentsSection:545) — vocabulary vs file-format carve-out
2. Mention-autocomplete fallback label "persona" (useMentions/mentionRanking)
3. Backend Rust error strings surfacing verbatim in toasts ("Built-in personas cannot be deleted.", etc.)

## Acceptance gate (upgraded from #1646)

Completeness verified by **multiline rendered-text sweep** over `desktop/src` (the reviewer's fixed filter), not table-coverage alone. Post-change sweep output contains only: code identifiers, testids, comments, e2eBridge fixtures, and the three category-C items above. Zero spec edits (no spec asserts on any changed string; verified by grep).

## Validation

tsc clean, biome clean, unit 2098/2098, 59-test agent/persona e2e smoke slice green.
