### PR TITLE
fix(desktop): eliminate upscroll realization jitter (compensation writer + estimator + certified perf gate)

### DIFF
--- a/desktop/src/features/messages/lib/rowHeightEstimate.test.mjs
+++ b/desktop/src/features/messages/lib/rowHeightEstimate.test.mjs
@@ -36,7 +36,7 @@ test("estimateRowHeight: fenced code adds height by line", () => {
     msg({ body: "see:\n```\na\nb\nc\nd\ne\n```" }),
   );
   const withoutCode = estimateRowHeight(msg({ body: "see:" }));
-  assert.ok(withCode > withoutCode + 80, `code ${withCode} vs ${withoutCode}`);
+  assert.ok(withCode > withoutCode + 100, `code ${withCode} vs ${withoutCode}`);
 });
 
 test("estimateRowHeight: imeta image with dim reserves bounded media height", () => {
@@ -84,10 +84,45 @@ test("estimateRowHeight: imeta dim is not double-counted with its body url", () 
   assert.ok(both < 400, `expected single media reserve, got ${both}`);
 });
 
-test("estimateRowHeight: bare URL line adds a preview card", () => {
+test("estimateRowHeight: unsupported bare URL line does not add a preview card", () => {
   const withUrl = estimateRowHeight(msg({ body: "https://example.com/x" }));
   const withoutUrl = estimateRowHeight(msg({ body: "example" }));
+  assert.ok(withUrl < withoutUrl + 25, `url ${withUrl} vs ${withoutUrl}`);
+});
+
+test("estimateRowHeight: supported GitHub URL line adds a preview card", () => {
+  const withUrl = estimateRowHeight(
+    msg({ body: "https://github.com/block/buzz/pull/1641" }),
+  );
+  const withoutUrl = estimateRowHeight(msg({ body: "example" }));
   assert.ok(withUrl > withoutUrl + 50, `url ${withUrl} vs ${withoutUrl}`);
+});
+
+test("estimateRowHeight: supported Linear and Google URLs add preview cards", () => {
+  const base = estimateRowHeight(msg({ body: "example" }));
+  const linear = estimateRowHeight(
+    msg({ body: "https://linear.app/block/issue/BUZZ-123/fix-scroll" }),
+  );
+  const google = estimateRowHeight(
+    msg({ body: "https://docs.google.com/document/d/abc123/edit" }),
+  );
+  assert.ok(linear > base + 50, `linear ${linear} vs ${base}`);
+  assert.ok(google > base + 50, `google ${google} vs ${base}`);
+});
+
+test("estimateRowHeight: column width option changes prose wrapping", () => {
+  const body = "x".repeat(160);
+  const narrow = estimateRowHeight(msg({ body }), { columnWidthPx: 320 });
+  const fallback = estimateRowHeight(msg({ body }));
+  assert.ok(narrow > fallback + 20, `narrow ${narrow} vs fallback ${fallback}`);
+});
+
+test("estimateRowHeight: markdown structures reserve extra chrome", () => {
+  const table = estimateRowHeight(
+    msg({ body: "| A | B |\n| - | - |\n| 1 | 2 |" }),
+  );
+  const plain = estimateRowHeight(msg({ body: "A B\n- -\n1 2" }));
+  assert.ok(table > plain + 20, `table ${table} vs plain ${plain}`);
 });
 
 test("timelineRowReserveStyle: message item yields containIntrinsicSize", () => {
@@ -95,8 +130,47 @@ test("timelineRowReserveStyle: message item yields containIntrinsicSize", () => 
     kind: "message",
     key: "k",
     entry: { message: msg({ body: "hi" }), summary: null },
+    isContinuation: false,
+    isFollowedByContinuation: false,
   });
   assert.match(String(style.containIntrinsicSize), /^auto \d+px$/);
+});
+
+test("timelineRowReserveStyle: summary rows add summary chrome", () => {
+  const item = {
+    kind: "message",
+    key: "k",
+    entry: {
+      message: msg({ body: "hi" }),
+      summary: {
+        threadHeadId: "m1",
+        replyCount: 3,
+        lastReplyAt: 1,
+        participants: [],
+      },
+    },
+    isContinuation: false,
+    isFollowedByContinuation: false,
+  };
+  const withSummary = Number.parseInt(
+    String(timelineRowReserveStyle(item).containIntrinsicSize).match(
+      /auto (\d+)px/,
+    )?.[1] ?? "0",
+    10,
+  );
+  const withoutSummary = Number.parseInt(
+    String(
+      timelineRowReserveStyle({
+        ...item,
+        entry: { ...item.entry, summary: null },
+      }).containIntrinsicSize,
+    ).match(/auto (\d+)px/)?.[1] ?? "0",
+    10,
+  );
+  assert.ok(
+    withSummary > withoutSummary + 25,
+    `${withSummary} vs ${withoutSummary}`,
+  );
 });
 
 test("timelineRowReserveStyle: divider is short fixed height", () => {

--- a/desktop/src/features/messages/lib/rowHeightEstimate.test.mjs
+++ b/desktop/src/features/messages/lib/rowHeightEstimate.test.mjs
@@ -36,7 +36,7 @@ test("estimateRowHeight: fenced code adds height by line", () => {
     msg({ body: "see:\n```\na\nb\nc\nd\ne\n```" }),
   );
   const withoutCode = estimateRowHeight(msg({ body: "see:" }));
-  assert.ok(withCode > withoutCode + 100, `code ${withCode} vs ${withoutCode}`);
+  assert.ok(withCode > withoutCode + 80, `code ${withCode} vs ${withoutCode}`);
 });
 
 test("estimateRowHeight: imeta image with dim reserves bounded media height", () => {

--- a/desktop/src/features/messages/lib/rowHeightEstimate.ts
+++ b/desktop/src/features/messages/lib/rowHeightEstimate.ts
@@ -1,5 +1,6 @@
 import type * as React from "react";
 
+import { extractSupportedLinkPreviews } from "@/shared/lib/linkPreview";
 import { dimensionsFromDim } from "@/shared/ui/markdown/utils";
 import type { TimelineItem } from "./timelineItems";
 import type { TimelineMessage } from "../types";
@@ -24,15 +25,33 @@ const MEDIA_MAX_WIDTH = 384; // max-w-[min(24rem,100%)]
 const MEDIA_MAX_HEIGHT = 256; // max-h-64
 const TEXT_LINE_HEIGHT = 20;
 const CODE_LINE_HEIGHT = 19;
-const CHARS_PER_LINE = 64; // rough wrap width at the timeline column
+const FALLBACK_CHARS_PER_LINE = 64; // rough wrap width at the timeline column
+const AVERAGE_TEXT_CHAR_WIDTH = 7.2; // text-sm, biased toward common prose
+const ROW_HORIZONTAL_CHROME = 64; // avatar + row gap + inline padding
+const MIN_CHARS_PER_LINE = 32;
+const MAX_CHARS_PER_LINE = 96;
 const ROW_CHROME = 26; // author/time header + denser row padding
 const CONTINUATION_ROW_CHROME = 8; // dense row padding only; header/avatar are hidden
 const MEDIA_BLOCK_MARGIN_TOP = 4; // image/video blocks use mt-1 in markdown
 const REACTION_ROW = 24;
 const PREVIEW_CARD = 70;
+const CODE_BLOCK_CHROME = 18; // pre border/padding above the mono line boxes
+const THREAD_SUMMARY_ROW = 38;
+const FOOTER_ROW = 32;
 const MESSAGE_ITEM_BOTTOM_PADDING = 10; // TimelineMessageList pb-2.5
 const MIN_ESTIMATE = 60; // never reserve less than the old flat floor
 const CONTINUATION_MIN_ESTIMATE = 34;
+
+export type TimelineRowReserveOptions = {
+  /** Timeline column width measured once by the caller; absent keeps the old 64-char estimate. */
+  columnWidthPx?: number;
+  /** Optional row footer chrome. The main channel timeline currently leaves this unset. */
+  hasFooter?: boolean;
+};
+
+type EstimateRowHeightOptions = TimelineRowReserveOptions & {
+  isContinuation?: boolean;
+};
 
 function mediaHeightFromDim(dim: string | undefined): number {
   const dimensions = dimensionsFromDim(dim);
@@ -49,10 +68,27 @@ function mediaReserveHeight(dim: string | undefined): number {
   return MEDIA_BLOCK_MARGIN_TOP + mediaHeightFromDim(dim);
 }
 
-function wrappedLineCount(text: string): number {
+function charsPerLineFromColumnWidth(
+  columnWidthPx: number | undefined,
+): number {
+  if (columnWidthPx == null || !Number.isFinite(columnWidthPx)) {
+    return FALLBACK_CHARS_PER_LINE;
+  }
+
+  const textWidth = Math.max(0, columnWidthPx - ROW_HORIZONTAL_CHROME);
+  return Math.max(
+    MIN_CHARS_PER_LINE,
+    Math.min(
+      MAX_CHARS_PER_LINE,
+      Math.floor(textWidth / AVERAGE_TEXT_CHAR_WIDTH),
+    ),
+  );
+}
+
+function wrappedLineCount(text: string, charsPerLine: number): number {
   let lines = 0;
   for (const raw of text.split("\n")) {
-    lines += Math.max(1, Math.ceil(raw.length / CHARS_PER_LINE));
+    lines += Math.max(1, Math.ceil(raw.length / charsPerLine));
   }
   return lines;
 }
@@ -61,19 +97,25 @@ function wrappedLineCount(text: string): number {
  * Strip fenced code blocks from the body, returning the prose remainder and the
  * total number of code lines (for separate mono line-height accounting).
  */
-function splitFencedCode(body: string): { prose: string; codeLines: number } {
+function splitFencedCode(body: string): {
+  prose: string;
+  codeBlockCount: number;
+  codeLines: number;
+} {
   const parts = body.split(/```/);
   // Even indices are prose, odd indices are inside a fence.
   let prose = "";
+  let codeBlockCount = 0;
   let codeLines = 0;
   for (let i = 0; i < parts.length; i += 1) {
     if (i % 2 === 1) {
+      codeBlockCount += 1;
       codeLines += parts[i].split("\n").length;
     } else {
       prose += parts[i];
     }
   }
-  return { prose, codeLines };
+  return { prose, codeBlockCount, codeLines };
 }
 
 // Image/video file extensions the markdown renderer turns into inline media.
@@ -108,19 +150,73 @@ function stripMediaOnlyLines(text: string): string {
     .join("\n");
 }
 
+function markdownStructureExtraHeight(text: string): number {
+  let extra = 0;
+  let tableRunLines = 0;
+  let listRunLines = 0;
+
+  const flushTableRun = () => {
+    if (tableRunLines >= 2) {
+      // GFM tables have cell padding/borders, so they are taller than the same
+      // raw markdown counted as plain 20px text lines.
+      extra += 14 + tableRunLines * 6;
+    }
+    tableRunLines = 0;
+  };
+  const flushListRun = () => {
+    if (listRunLines >= 2) {
+      // The renderer applies `space-y-1` between list items.
+      extra += (listRunLines - 1) * 4;
+    }
+    listRunLines = 0;
+  };
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    const isTableLine =
+      /^\|.+\|$/.test(trimmed) || /\S\s+\|\s+\S/.test(trimmed);
+    const isListLine = /^(?:[-+*]|\d+[.)])\s+\S/.test(trimmed);
+
+    if (isTableLine) tableRunLines += 1;
+    else flushTableRun();
+
+    if (isListLine) listRunLines += 1;
+    else flushListRun();
+
+    if (/^#{1,3}\s+\S/.test(trimmed)) extra += 8;
+    else if (/^#{4,6}\s+\S/.test(trimmed)) extra += 4;
+
+    if (/^>\s?\S/.test(trimmed)) extra += 4;
+    if (/^(?:---+|\*\*\*+|___+)\s*$/.test(trimmed)) extra += 12;
+  }
+
+  flushTableRun();
+  flushListRun();
+  return extra;
+}
+
 export function estimateRowHeight(
   message: TimelineMessage,
-  { isContinuation = false }: { isContinuation?: boolean } = {},
+  {
+    columnWidthPx,
+    hasFooter = false,
+    isContinuation = false,
+  }: EstimateRowHeightOptions = {},
 ): number {
   const body = message.body ?? "";
-  const { prose, codeLines } = splitFencedCode(body);
+  const { prose, codeBlockCount, codeLines } = splitFencedCode(body);
   const proseForLineCount = stripMediaOnlyLines(prose);
+  const charsPerLine = charsPerLineFromColumnWidth(columnWidthPx);
 
   let height = isContinuation ? CONTINUATION_ROW_CHROME : ROW_CHROME;
   height +=
-    wrappedLineCount(proseForLineCount.trim() === "" ? "" : proseForLineCount) *
-    TEXT_LINE_HEIGHT;
+    wrappedLineCount(
+      proseForLineCount.trim() === "" ? "" : proseForLineCount,
+      charsPerLine,
+    ) * TEXT_LINE_HEIGHT;
   height += codeLines * CODE_LINE_HEIGHT;
+  height += codeBlockCount * CODE_BLOCK_CHROME;
+  height += markdownStructureExtraHeight(proseForLineCount);
 
   const imetaUrls = new Set<string>();
   if (message.tags && message.tags.length > 0) {
@@ -137,16 +233,13 @@ export function estimateRowHeight(
     height += mediaReserveHeight(undefined);
   }
 
-  // A bare non-media URL on its own line usually renders a link-preview card.
-  const hasPreviewUrlLine = body
-    .split("\n")
-    .some(
-      (line) =>
-        /^\s*https?:\/\/\S+\s*$/.test(line) && !MEDIA_URL_RE.test(line.trim()),
-    );
-  if (hasPreviewUrlLine) height += PREVIEW_CARD;
+  // Reserve only cards the renderer can actually produce. Generic bare URLs do
+  // not render preview cards, so keeping the old blanket reserve overestimated
+  // unsupported links by about one card height during first realization.
+  height += extractSupportedLinkPreviews(body).length * PREVIEW_CARD;
 
   if (message.reactions && message.reactions.length > 0) height += REACTION_ROW;
+  if (hasFooter) height += FOOTER_ROW;
 
   return Math.max(
     isContinuation ? CONTINUATION_MIN_ESTIMATE : MIN_ESTIMATE,
@@ -166,14 +259,18 @@ const DIVIDER_HEIGHT = 32;
  */
 export function timelineRowReserveStyle(
   item: TimelineItem,
+  opts: TimelineRowReserveOptions = {},
 ): React.CSSProperties {
   const height =
     item.kind === "message"
       ? estimateRowHeight(item.entry.message, {
+          ...opts,
           isContinuation: item.isContinuation,
-        }) + (item.isFollowedByContinuation ? 0 : MESSAGE_ITEM_BOTTOM_PADDING)
+        }) +
+        (item.entry.summary ? THREAD_SUMMARY_ROW : 0) +
+        (item.isFollowedByContinuation ? 0 : MESSAGE_ITEM_BOTTOM_PADDING)
       : item.kind === "system"
-        ? estimateRowHeight(item.entry.message)
+        ? estimateRowHeight(item.entry.message, opts)
         : DIVIDER_HEIGHT;
   return { containIntrinsicSize: `auto ${height}px` };
 }

--- a/desktop/src/features/messages/lib/rowHeightEstimate.ts
+++ b/desktop/src/features/messages/lib/rowHeightEstimate.ts
@@ -35,7 +35,6 @@ const CONTINUATION_ROW_CHROME = 8; // dense row padding only; header/avatar are 
 const MEDIA_BLOCK_MARGIN_TOP = 4; // image/video blocks use mt-1 in markdown
 const REACTION_ROW = 24;
 const PREVIEW_CARD = 70;
-const CODE_BLOCK_CHROME = 18; // pre border/padding above the mono line boxes
 const THREAD_SUMMARY_ROW = 38;
 const FOOTER_ROW = 32;
 const MESSAGE_ITEM_BOTTOM_PADDING = 10; // TimelineMessageList pb-2.5
@@ -99,23 +98,20 @@ function wrappedLineCount(text: string, charsPerLine: number): number {
  */
 function splitFencedCode(body: string): {
   prose: string;
-  codeBlockCount: number;
   codeLines: number;
 } {
   const parts = body.split(/```/);
   // Even indices are prose, odd indices are inside a fence.
   let prose = "";
-  let codeBlockCount = 0;
   let codeLines = 0;
   for (let i = 0; i < parts.length; i += 1) {
     if (i % 2 === 1) {
-      codeBlockCount += 1;
       codeLines += parts[i].split("\n").length;
     } else {
       prose += parts[i];
     }
   }
-  return { prose, codeBlockCount, codeLines };
+  return { prose, codeLines };
 }
 
 // Image/video file extensions the markdown renderer turns into inline media.
@@ -153,7 +149,6 @@ function stripMediaOnlyLines(text: string): string {
 function markdownStructureExtraHeight(text: string): number {
   let extra = 0;
   let tableRunLines = 0;
-  let listRunLines = 0;
 
   const flushTableRun = () => {
     if (tableRunLines >= 2) {
@@ -163,35 +158,19 @@ function markdownStructureExtraHeight(text: string): number {
     }
     tableRunLines = 0;
   };
-  const flushListRun = () => {
-    if (listRunLines >= 2) {
-      // The renderer applies `space-y-1` between list items.
-      extra += (listRunLines - 1) * 4;
-    }
-    listRunLines = 0;
-  };
 
   for (const line of text.split("\n")) {
     const trimmed = line.trim();
     const isTableLine =
       /^\|.+\|$/.test(trimmed) || /\S\s+\|\s+\S/.test(trimmed);
-    const isListLine = /^(?:[-+*]|\d+[.)])\s+\S/.test(trimmed);
 
     if (isTableLine) tableRunLines += 1;
     else flushTableRun();
 
-    if (isListLine) listRunLines += 1;
-    else flushListRun();
-
-    if (/^#{1,3}\s+\S/.test(trimmed)) extra += 8;
-    else if (/^#{4,6}\s+\S/.test(trimmed)) extra += 4;
-
-    if (/^>\s?\S/.test(trimmed)) extra += 4;
     if (/^(?:---+|\*\*\*+|___+)\s*$/.test(trimmed)) extra += 12;
   }
 
   flushTableRun();
-  flushListRun();
   return extra;
 }
 
@@ -204,7 +183,7 @@ export function estimateRowHeight(
   }: EstimateRowHeightOptions = {},
 ): number {
   const body = message.body ?? "";
-  const { prose, codeBlockCount, codeLines } = splitFencedCode(body);
+  const { prose, codeLines } = splitFencedCode(body);
   const proseForLineCount = stripMediaOnlyLines(prose);
   const charsPerLine = charsPerLineFromColumnWidth(columnWidthPx);
 
@@ -215,7 +194,6 @@ export function estimateRowHeight(
       charsPerLine,
     ) * TEXT_LINE_HEIGHT;
   height += codeLines * CODE_LINE_HEIGHT;
-  height += codeBlockCount * CODE_BLOCK_CHROME;
   height += markdownStructureExtraHeight(proseForLineCount);
 
   const imetaUrls = new Set<string>();

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -21,6 +21,7 @@ import type { TimelineMessage } from "@/features/messages/types";
 import { canManageMessageForCurrentUser } from "@/features/messages/lib/canManageMessage";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ChannelType } from "@/shared/api/types";
+import { useElementWidth } from "@/shared/hooks/use-mobile";
 import { cn } from "@/shared/lib/cn";
 import { DayDivider } from "./DayDivider";
 import { MessageRow } from "./MessageRow";
@@ -178,6 +179,14 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
     [itemsResult.items],
   );
 
+  // Measure the row column once so row-height estimates reserve credible space
+  // for the *actual* wrap width instead of the 64-char fallback. The rows are
+  // `w-full` inside this wrapper, so its width is the row box the estimator
+  // subtracts chrome from. Zero (pre-measure) passes `undefined` to preserve
+  // the estimator's own fallback rather than tripping its min-chars floor.
+  const [columnRef, columnWidthPx] = useElementWidth<HTMLDivElement>();
+  const reserveColumnWidthPx = columnWidthPx > 0 ? columnWidthPx : undefined;
+
   const renderItem = React.useCallback(
     (item: TimelineNonDayItem) => {
       switch (item.kind) {
@@ -256,7 +265,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
   );
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col" ref={columnRef}>
       {dayGroups.map((group) => (
         <section
           className={cn(
@@ -279,7 +288,9 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
             <div
               className="timeline-row-cv"
               key={getTimelineItemKey(item)}
-              style={timelineRowReserveStyle(item)}
+              style={timelineRowReserveStyle(item, {
+                columnWidthPx: reserveColumnWidthPx,
+              })}
             >
               {renderItem(item)}
             </div>

--- a/desktop/src/features/messages/ui/useAnchoredScroll.ts
+++ b/desktop/src/features/messages/ui/useAnchoredScroll.ts
@@ -141,6 +141,56 @@ function computeAnchor(container: HTMLDivElement): AnchorState {
   return { kind: "at-bottom" };
 }
 
+/**
+ * Snapshot the reader's position for realization compensation: the first row
+ * FULLY inside the viewport (its top at/below the scroller top) and that row's
+ * top relative to the scroller top.
+ *
+ * Why *fully* visible and not the top-crossing straddler `computeAnchor` picks:
+ * the CSS scroll-anchoring spec descends past partially-visible candidates and
+ * anchors on the first fully-visible element for exactly the case we hit —
+ * during an upscroll the realizing band is the freshly exposed content hanging
+ * above the fold, so a straddler anchor sits *inside* that churning band and
+ * can't measure the shift below it. The first fully-visible row sits one notch
+ * below the churn, so re-pinning it to its saved offset cancels the net height
+ * change of everything above it (the layout engine sums those deltas for us —
+ * a row resizing below the anchor doesn't move the anchor's top, so it's
+ * excluded for free). Returns null when nothing is fully visible.
+ */
+function snapshotReadingAnchor(
+  container: HTMLDivElement,
+): { id: string; topOffset: number } | null {
+  const containerTop = container.getBoundingClientRect().top;
+  const rows = container.querySelectorAll<HTMLElement>("[data-message-id]");
+  for (const row of rows) {
+    const rect = row.getBoundingClientRect();
+    if (rect.top >= containerTop) {
+      const id = row.dataset.messageId;
+      if (id) return { id, topOffset: rect.top - containerTop };
+    }
+  }
+  return null;
+}
+
+/**
+ * The height the browser is CURRENTLY using to lay out `row`. For a
+ * `content-visibility: auto` row that has never painted this is its
+ * `contain-intrinsic-size` reserve (the estimate) rather than its realized
+ * height; for a row the browser has already realized-and-remembered (the `auto`
+ * keyword) it is that remembered size. We read the computed
+ * `contain-intrinsic-block-size` — Blink returns it as `"<n>px"` or
+ * `"auto <n>px"` — and fall back to the live box height if the property is
+ * empty/unsupported (e.g. WKWebView returning an empty string). Seeding the
+ * resize map with this value is what turns a realization into a MEASURABLE
+ * `realized - reserve` delta instead of an unmeasurable first sighting.
+ */
+function reservedRowHeight(row: HTMLElement): number {
+  const raw = getComputedStyle(row).containIntrinsicBlockSize;
+  const match = raw.match(/(-?\d+(?:\.\d+)?)px/);
+  if (match) return Number.parseFloat(match[1]);
+  return row.getBoundingClientRect().height;
+}
+
 export function useAnchoredScroll({
   scrollContainerRef,
   contentRef,
@@ -181,6 +231,15 @@ export function useAnchoredScroll({
   // ignores transient gaps and keeps chasing the floor. A `ref`, not state — the
   // guard runs on a native scroll event, outside React's render cycle.
   const settlingRef = React.useRef(false);
+  // Baseline for realization/reflow compensation: the first row fully inside
+  // the viewport (top at/below the scroller top) and its top offset, captured
+  // on every scroll event and after every correction. The ResizeObserver
+  // re-pins THIS row to THIS offset — a single measured pin that absorbs the
+  // net height change of everything above it (see `snapshotReadingAnchor`).
+  const readingAnchorRef = React.useRef<{
+    id: string;
+    topOffset: number;
+  } | null>(null);
 
   // Reset everything when the channel changes — the layout effect that runs
   // immediately after this reset is responsible for either jumping to bottom
@@ -315,6 +374,11 @@ export function useAnchoredScroll({
       }
     }
     anchorRef.current = computeAnchor(container);
+    // Baseline the realization-compensation anchor from THIS scroll snapshot —
+    // RO fires after layout, so the "before" position can only come from the
+    // last scroll event (or a prior correction), never from inside the RO
+    // callback. Missing/stale baseline => the RO path skips rather than drifts.
+    readingAnchorRef.current = snapshotReadingAnchor(container);
     const atBottom = anchorRef.current.kind === "at-bottom";
     setIsAtBottom((prev) => (prev === atBottom ? prev : atBottom));
     if (atBottom) {
@@ -452,27 +516,120 @@ export function useAnchoredScroll({
   ]);
 
   // ---------------------------------------------------------------------------
-  // Content resize: while stuck to the bottom, an in-viewport reflow (image
-  // decode, embed expand, late font load) that React isn't driving grows
+  // Content resize: a height change React isn't driving — a bottom-pinned
+  // in-viewport reflow (image decode, embed expand, late font), OR an
+  // off-screen row above the reading position realizing to its true height as
+  // the user scrolls up into it (content-visibility skip -> visible). Both grow
   // `scrollHeight` without a `messages` change, so the layout effect doesn't
-  // fire — re-pin to the new floor here to stay glued. When anchored
-  // mid-history, native scroll anchoring (overflow-anchor) holds the reading
-  // row across the reflow, so there's nothing to do.
+  // fire. The ResizeObserver callback runs in the rendering steps AFTER layout
+  // and BEFORE paint, which makes a `scrollBy` here same-frame invisible — this
+  // is the correct trigger for compensation, not the async-dispatched
+  // `contentvisibilityautostatechange` event (which may fire after the shifted
+  // frame has already painted).
+  //
+  //   - at-bottom: re-pin to the new floor to stay glued.
+  //   - mid-history: `overflow-anchor: none` is set on the scroller and the
+  //     shipped WKWebView has no native anchoring anyway, so nothing holds the
+  //     reading row across the reflow/realization — our writer must. This is
+  //     the fix for the up-scroll jitter AND the latent reflow bug (both were
+  //     previously left to a native anchoring that does not run here).
+  //
+  // Freshness (single-writer + no-fighting-the-wheel): `anchorRef.current` is
+  // re-baselined by `onScroll` every scroll event, and scroll events are
+  // dispatched earlier in the same frame's rendering steps than ResizeObserver
+  // delivery — so when a realization RO fires mid-gesture, the anchor's saved
+  // offset already reflects the user's current scroll position, and the drift
+  // we measure is purely the layout shift above the reading row, not the user's
+  // own wheel delta. We skip while settling a programmatic bottom pin so this
+  // never races the floor-chase in `onScroll`.
   // ---------------------------------------------------------------------------
-  // biome-ignore lint/correctness/useExhaustiveDependencies: channelId is a deliberate re-subscription trigger — the effect body reads only the stable refs, but on a channel switch the keyed scroll container remounts and contentRef.current becomes a fresh node, so the observer must disconnect from the previous channel's detached node and re-observe the live one.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `messages` is an intentional re-sync trigger — on each committed render we (re)observe any newly-mounted `.timeline-row-cv` rows so a row appended by a load-older page starts being watched. The callback reads only stable refs; `channelId` forces a full re-subscribe when the keyed scroll container remounts.
   React.useEffect(() => {
     const content = contentRef.current;
     if (!content || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => {
+    // Last-known laid-out height per observed row. The compensable delta of a
+    // resize is `newHeight - lastHeight`. We SEED each row at observe time with
+    // the height the browser is currently using for layout — for a
+    // `content-visibility: auto` row that has never painted, that is its
+    // `contain-intrinsic-size` reserve (the estimate), NOT its realized height
+    // (which the row does not report until it realizes). Seeding with the
+    // reserve is what makes the very first RO delivery — the realization itself
+    // — yield the true `realized - reserve` delta instead of being silently
+    // swallowed as an unmeasurable first sighting.
+    const lastHeights = new WeakMap<Element, number>();
+    const observer = new ResizeObserver((entries) => {
       const container = scrollContainerRef.current;
       if (!container) return;
+      // A programmatic bottom pin is still settling; `onScroll` owns the
+      // floor-chase, so stay out of its way and don't double-write.
+      if (settlingRef.current) return;
       if (anchorRef.current.kind === "at-bottom") {
+        // Bottom-glue: a row realizing/reflowing while pinned grows the content,
+        // so re-pin to the new floor to stay glued, and refresh the height map
+        // so we don't treat this growth as a mid-history delta later.
+        for (const entry of entries) {
+          lastHeights.set(
+            entry.target,
+            entry.target.getBoundingClientRect().height,
+          );
+        }
         container.scrollTo({ top: container.scrollHeight, behavior: "auto" });
+        return;
+      }
+      // Mid-history: a batch of rows realized/reflowed this frame. The
+      // reading anchor — the first fully-visible row, snapshotted by the last
+      // scroll event — has shifted by the net height change of everything above
+      // it. Re-pin it to its saved offset: a single measured correction (the
+      // layout engine already summed the above-anchor deltas into the row's
+      // top, and rows resizing below the anchor don't move it, so they're
+      // excluded for free). This is the single scroll writer for realization;
+      // `overflow-anchor: none` (and WKWebView's absence of it) mean nothing
+      // else competes. We use the RO batch only as the TRIGGER — we detect that
+      // a row's laid-out height actually changed (seeded from the reserve so a
+      // first-realization delivery counts, not swallowed as a first sighting),
+      // then correct from the anchor's own measured drift, never from summing
+      // per-row deltas.
+      let changed = false;
+      for (const entry of entries) {
+        const row = entry.target as HTMLElement;
+        const height = row.getBoundingClientRect().height;
+        const last = lastHeights.get(row);
+        lastHeights.set(row, height);
+        if (last === undefined) continue; // never seeded (defensive).
+        if (Math.abs(height - last) > 0.5) changed = true;
+      }
+      if (!changed) return;
+      const baseline = readingAnchorRef.current;
+      if (!baseline) return; // no stable pre-batch snapshot: skip, don't drift.
+      const anchorRow = container.querySelector<HTMLElement>(
+        `[data-message-id="${CSS.escape(baseline.id)}"]`,
+      );
+      if (!anchorRow) return;
+      const containerTop = container.getBoundingClientRect().top;
+      const currentTopOffset =
+        anchorRow.getBoundingClientRect().top - containerTop;
+      const drift = currentTopOffset - baseline.topOffset;
+      if (Math.abs(drift) > 0.5) {
+        container.scrollBy(0, drift);
+        // Re-baseline after the correction so the next RO batch measures drift
+        // from where we just pinned, not the pre-correction position.
+        readingAnchorRef.current = snapshotReadingAnchor(container);
       }
     });
-    observer.observe(content);
+    // Observe every timeline row (not the content wrapper): a
+    // `content-visibility: auto` row realizing to its true height is a resize
+    // of THAT row's box but does not reliably fire a ResizeObserver on the
+    // wrapper (Blink does not surface CV realization as an ancestor resize).
+    // The RO callback runs after layout, before paint, so the compensating
+    // `scrollBy` is same-frame invisible.
+    for (const row of content.querySelectorAll<HTMLElement>(
+      ".timeline-row-cv",
+    )) {
+      lastHeights.set(row, reservedRowHeight(row));
+      observer.observe(row);
+    }
     return () => observer.disconnect();
-  }, [channelId, contentRef, scrollContainerRef]);
+  }, [channelId, contentRef, scrollContainerRef, messages]);
 
   // ---------------------------------------------------------------------------
   // Target message handling (deep link, jump-to-reply, etc.). Distinct from

--- a/desktop/src/shared/styles/globals/utilities.css
+++ b/desktop/src/shared/styles/globals/utilities.css
@@ -10,6 +10,18 @@
     contain-intrinsic-size: auto 200px;
   }
 
+  /* The conversation scroller owns its reading position through the JS
+     compensation writer in `useAnchoredScroll` (same-frame `scrollBy` on
+     realization/reflow deltas). Native scroll anchoring must be OFF so it
+     can't double-correct the same delta behind the writer's back: the shipped
+     WKWebView has no `overflow-anchor` at all, while Chromium does — leaving it
+     on means CI (Chromium) and macOS users (WKWebView) run different scroll
+     contracts, which is how the jitter shipped unseen. Forcing it off makes the
+     writer the single scroll authority on every engine. See L-A/L-C findings. */
+  [data-buzz-conversation-scroll] {
+    overflow-anchor: none;
+  }
+
   /* Timeline rows re-pin by measured offset on prepend; the 200px fallback
      over-reserves the common row and shifts that anchor, so reserve low. */
   .timeline-row-cv {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -2224,6 +2224,37 @@ const mockChannels: MockChannel[] = [
       createMockMember(MOCK_IDENTITY_PUBKEY, "member", 1900),
     ],
   }),
+  // Jitter-corpus channel for the upscroll-jitter GATE (upscroll-jitter.perf.ts).
+  // Seeded with 400 structurally HETEROGENEOUS messages (headings, lists,
+  // blockquotes, fenced code, long wrapped prose) so `estimateRowHeight`'s known
+  // biases produce a genuine reserve-vs-true error on every never-painted row.
+  // Its own channel so the uniform `deep-history` seed the load-older specs
+  // depend on stays undisturbed.
+  createMockChannel({
+    id: "feedf00d-0000-4000-8000-000000000008",
+    name: "jitter-corpus",
+    channel_type: "stream",
+    visibility: "open",
+    description: "Heterogeneous history for the upscroll-jitter gate",
+    topic: null,
+    purpose: null,
+    last_message_at: isoMinutesAgo(1),
+    archived_at: null,
+    created_by: ALICE_PUBKEY,
+    topic_set_by: null,
+    topic_set_at: null,
+    purpose_set_by: null,
+    purpose_set_at: null,
+    topic_required: false,
+    max_members: null,
+    nip29_group_id: null,
+    created_minutes_ago: 2000,
+    updated_minutes_ago: 1,
+    members: [
+      createMockMember(ALICE_PUBKEY, "owner", 2000),
+      createMockMember(MOCK_IDENTITY_PUBKEY, "member", 1900),
+    ],
+  }),
 ];
 
 const mockMessages = new Map<string, RelayEvent[]>();
@@ -2930,12 +2961,38 @@ function buildReplyMessageTags(
   return tags;
 }
 
+// Body generator for the jitter-corpus seed. Six structurally distinct row
+// kinds, cycled by index, chosen because `estimateRowHeight` mis-reserves most
+// of them — the reserve-vs-true error the upscroll-jitter gate measures.
+function jitterCorpusBody(i: number): string {
+  switch (i % 6) {
+    case 0:
+      // Short prose — estimator is close here (control rows).
+      return `quick note ${i}`;
+    case 1:
+      // Heading + list: estimated as flat 20px lines; rendered line boxes and
+      // list margins are taller.
+      return `# Heading ${i}\n\n- alpha item ${i}\n- beta item ${i}\n- gamma item ${i}\n- delta item ${i}`;
+    case 2:
+      // Long wrapped prose: real wrap width differs from CHARS_PER_LINE=64.
+      return `This is a deliberately long paragraph number ${i} that wraps across several visual lines depending on the true column width, which the fixed characters-per-line heuristic only approximates and therefore systematically mis-estimates on wide and narrow windows alike.`;
+    case 3:
+      // Blockquote: block margins the flat estimate ignores.
+      return `> quoted reply ${i}\n>\n> second quoted line ${i}\n\nfollow-up prose ${i}`;
+    case 4:
+      // Fenced code: code line-height is modeled, block padding/border is not.
+      return `runtime log ${i}:\n\`\`\`\nconst x = ${i};\nconsole.log(x * 2);\nreturn x;\n\`\`\``;
+    default:
+      // Medium two-paragraph prose.
+      return `paragraph one for row ${i}\n\nparagraph two for row ${i} with a little more text to push it onto a second wrapped line`;
+  }
+}
+
 function getMockMessageStore(channelId: string): RelayEvent[] {
   const existing = mockMessages.get(channelId);
   if (existing) {
     return existing;
   }
-
   const seeded: RelayEvent[] =
     channelId === "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50"
       ? [
@@ -3115,7 +3172,24 @@ function getMockMessageStore(channelId: string): RelayEvent[] {
                 content: `Deep history message #${index}`,
                 sig: "mocksig".repeat(20).slice(0, 128),
               }))
-            : [];
+            : channelId === "feedf00d-0000-4000-8000-000000000008"
+              ? // Heterogeneous corpus for the upscroll-jitter gate. Row height
+                // varies widely AND `estimateRowHeight` is known to misjudge
+                // several of these kinds (headings/lists/blockquotes counted as
+                // flat 20px prose lines; long prose vs the fixed CHARS_PER_LINE
+                // wrap guess; code-fence chrome) — that reserve-vs-true mismatch
+                // is exactly the realization error the gate measures.
+                Array.from({ length: 400 }, (_, index) => ({
+                  id: `mock-jitter-${index}`,
+                  pubkey: index % 2 === 0 ? ALICE_PUBKEY : MOCK_IDENTITY_PUBKEY,
+                  created_at:
+                    Math.floor(Date.now() / 1000) - (400 - index) * 60,
+                  kind: 9,
+                  tags: [["h", channelId]],
+                  content: jitterCorpusBody(index),
+                  sig: "mocksig".repeat(20).slice(0, 128),
+                }))
+              : [];
 
   mockMessages.set(channelId, seeded);
   return seeded;

--- a/desktop/tests/e2e/upscroll-anchor-contract.perf.ts
+++ b/desktop/tests/e2e/upscroll-anchor-contract.perf.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+/**
+ * ANCHOR-CONTRACT GUARD (Wren #4) — companion to `upscroll-jitter.perf.ts`.
+ *
+ * The jitter gate *forces* `overflow-anchor: none` on the scroller before it
+ * measures, to reproduce shipped WKWebView (which has no `overflow-anchor` and
+ * so corrects nothing) on anchoring Chromium. That force is a test convenience,
+ * not a proof: it would stay green even if production ever stopped shipping the
+ * property, silently handing correction back to Chromium's native anchoring and
+ * masking a WKWebView-only regression on device.
+ *
+ * This test closes that gap by reading the PRODUCTION computed style — no test
+ * override — on the real conversation scroller and asserting it resolves to
+ * `none`. We run on Chromium, whose default `overflow-anchor` is `auto`, so a
+ * resolved value of `none` can only have come from the shipped stylesheet
+ * (`utilities.css` `[data-buzz-conversation-scroll]`). The engine-support
+ * assert keeps the check honest: if it ever runs somewhere without the property
+ * at all, we want the loud failure, not a vacuous pass on an empty string.
+ */
+test("CONTRACT: production ships overflow-anchor:none on the conversation scroller", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+
+  await page.getByTestId("channel-jitter-corpus").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("jitter-corpus");
+  const timeline = page.getByTestId("message-timeline");
+  await expect(timeline.locator("[data-message-id]").first()).toBeVisible();
+
+  // Sanity: Chromium DOES support overflow-anchor (default `auto`), so a
+  // resolved `none` below is the production stylesheet's doing, not the engine
+  // returning an empty/unsupported value.
+  const anchorSupported = await page.evaluate(() =>
+    typeof CSS !== "undefined" && typeof CSS.supports === "function"
+      ? CSS.supports("overflow-anchor", "auto")
+      : false,
+  );
+  expect(anchorSupported).toBe(true);
+
+  const resolvedOverflowAnchor = await timeline.evaluate(
+    (element) => getComputedStyle(element).overflowAnchor,
+  );
+  expect(resolvedOverflowAnchor).toBe("none");
+});

--- a/desktop/tests/e2e/upscroll-jitter.perf.ts
+++ b/desktop/tests/e2e/upscroll-jitter.perf.ts
@@ -84,7 +84,8 @@ const MAX_RMS_DEVIATION_PX = 0.6;
 // Fixed synchronous scroll step per notch (px). Constant by construction — no
 // wheel-scaling variance for median-of-run to misread as jitter.
 const STEP = 220;
-const MAX_STEPS = 80; // cap; stop early once we near the top of the window
+const MAX_STEPS = 80; // cap; the walk now survives fetchOlder re-anchors and
+// runs to the true top of history (~77 notches), scoring every paged-in window.
 // Keep the tracked row this far (px) from both viewport edges so it stays
 // realized across the step — no straddling-row un-realization artifact.
 const SAFE_MARGIN = 100;
@@ -95,6 +96,10 @@ type Result = {
   samples: StepSample[];
   reachedTop: boolean;
   rowCount: number;
+  // True once a `fetchOlder` prepend landed and was survived mid-run — the
+  // gate then keeps scoring notches in the newly paged-in population, so it
+  // exercises the pagination half of H1, not just in-window CV realization.
+  prependObserved: boolean;
 };
 
 // Drive one upscroll run and collect per-notch samples. `actuate` selects the
@@ -120,6 +125,11 @@ async function measure(
 
   const samples: StepSample[] = [];
   let reachedTop = false;
+  let prependObserved = false;
+  // Mounted-row count before the walk begins — the baseline a prepend grows.
+  const mountedAtRunStart = await timeline.evaluate(
+    (el) => (el as HTMLDivElement).querySelectorAll("[data-message-id]").length,
+  );
 
   for (let step = 0; step < MAX_STEPS; step += 1) {
     // Pick a row comfortably inside the viewport (SAFE_MARGIN from both edges)
@@ -174,11 +184,17 @@ async function measure(
       (element, args: { id: string; margin: number }) => {
         const el = element as HTMLDivElement;
         const box = el.getBoundingClientRect();
+        const mounted = el.querySelectorAll("[data-message-id]").length;
         const row = el.querySelector<HTMLElement>(
           `[data-message-id="${CSS.escape(args.id)}"]`,
         );
         if (!row)
-          return { top: null, inSafeBand: false, scrollTop: el.scrollTop };
+          return {
+            top: null,
+            inSafeBand: false,
+            scrollTop: el.scrollTop,
+            mounted,
+          };
         const rect = row.getBoundingClientRect();
         return {
           top: rect.top,
@@ -186,6 +202,7 @@ async function measure(
             rect.top > box.top + args.margin &&
             rect.bottom < box.bottom - args.margin,
           scrollTop: el.scrollTop,
+          mounted,
         };
       },
       { id: before.id, margin: SAFE_MARGIN },
@@ -193,6 +210,25 @@ async function measure(
 
     const appliedTop = before.scrollTop - after.scrollTop; // realized px moved up
     if (appliedTop <= 0) {
+      // scrollTop did not decrease. Two causes: (a) we reached the top of
+      // history (scrollTop ~ 0) — the real terminator; or (b) a `fetchOlder`
+      // prepend just landed ~CHANNEL_HISTORY_LIMIT older rows ABOVE the
+      // viewport, so scrollTop jumped UP to preserve the visible content — a
+      // RE-ANCHOR, not the top. Distinguish by mounted-count: a prepend grows
+      // it. On a re-anchor we skip scoring this step (its motion is the
+      // prepend jump, not a fixed STEP notch — scoring it would poison the
+      // metric with a one-off multi-thousand-px move) and CONTINUE; the next
+      // iteration re-baselines a fresh safe-band row in the newly paged-in
+      // window, so scoring resumes ACROSS the prepend. This is what makes the
+      // gate SCORE at least one prepend per run (T1.2) rather than terminate
+      // at the sentinel band — closing the pagination-coverage gap Quinn and
+      // Dawn flagged. Both the writer (GREEN) and the bare estimator (RED)
+      // survive the re-anchor, so RED still fails on the cold-realization
+      // jitter of the paged-in rows and GREEN still holds them to STEP.
+      if (after.mounted > mountedAtRunStart && after.scrollTop > 1) {
+        prependObserved = true;
+        continue;
+      }
       reachedTop = after.scrollTop <= 0;
       break;
     }
@@ -215,6 +251,7 @@ async function measure(
       (el) =>
         (el as HTMLDivElement).querySelectorAll("[data-message-id]").length,
     ),
+    prependObserved,
   };
 }
 
@@ -289,6 +326,9 @@ test("GATE: upscroll motion consistency stays below the realization-jitter thres
   console.log(`steps measured (sync):       ${result.samples.length}`);
   console.log(`reached top of history:      ${result.reachedTop}`);
   console.log(
+    `scored a fetchOlder prepend: ${result.prependObserved}  (T1.2: pagination half exercised)`,
+  );
+  console.log(
     `median per-notch motion:     ${s.median.toFixed(1)}px  (STEP=${STEP})`,
   );
   console.log(
@@ -316,6 +356,18 @@ test("GATE: upscroll motion consistency stays below the realization-jitter thres
   // DOM (de-virtualized), so ~100 mounted rows is the expected window.
   expect(result.rowCount).toBeGreaterThanOrEqual(80);
   expect(result.samples.length).toBeGreaterThan(8);
+
+  // COVERAGE (T1.2): the scored run must cross at least one `fetchOlder`
+  // prepend. Upscroll jitter has TWO sources (Eva's H1 + Quinn's seed trace):
+  // CV-skipped rows in the opening window that realize on entry, AND cold rows
+  // paged in above the viewport when scrollback fires near the top. The gate
+  // measures felt motion whatever the cause, but if the run terminated at the
+  // sentinel band it would only ever certify the first source. We assert it
+  // survived a re-anchor and kept scoring so BOTH sources are under the gate —
+  // pass or fail. This is corpus-structural (400-row seed > 300 limit), so it
+  // holds on the RED baseline and the GREEN fix alike; a run that stops before
+  // scoring a prepend is a coverage regression, not a jitter verdict.
+  expect(result.prependObserved).toBe(true);
 
   // ANTI-CHEAT: the reading row must actually track the input — a frozen or
   // half-applying scroller (near-zero motion, would false-green on deviation)

--- a/desktop/tests/e2e/upscroll-jitter.perf.ts
+++ b/desktop/tests/e2e/upscroll-jitter.perf.ts
@@ -3,165 +3,134 @@ import { expect, test } from "@playwright/test";
 import { installMockBridge } from "../helpers/bridge";
 
 /**
- * UPSCROLL-JITTER GATE (L-E) — the RED-today metric the fix train rides on.
+ * UPSCROLL-JITTER GATE (L-E / T1.1) — the RED-today metric the fix train rides on.
  *
  * Tyler's report: scrolling UP a fully-loaded channel is jumpy in tiny
  * variations; scrolling DOWN is smooth. Eva's H1 says why: rows above the
  * opening viewport have NEVER painted, so they sit at `estimateRowHeight()`
  * reserves under `content-visibility: auto`. Scrolling up, each row realizes
  * at its TRUE height the instant it enters the realization band; the delta
- * (true - estimate) shifts content, and the browser's scroll anchoring only
- * corrects APPROXIMATELY, one lurch per realization. Down is smooth because
- * `contain-intrinsic-size: auto` has already remembered every passed row's
- * exact size.
+ * (true - estimate) shifts content, and (on WKWebView) NOTHING corrects it —
+ * one lurch per realization. Down is smooth because `contain-intrinsic-size:
+ * auto` has already remembered every passed row's exact size.
  *
- * WHAT THIS MEASURES (the honest signal, not a proxy):
- * During a steady upscroll the content already on screen must translate by
- * exactly the wheel delta. If the viewport moves up by D px, every currently
- * visible element's `top` must increase by exactly D. Any residual
- * `(delta_top - D)` is content that jumped for a reason OTHER than the wheel —
- * a realization-induced anchor correction. That residual IS the jump Tyler
- * feels. A perfectly smooth scroll keeps every step's residual at 0.
+ * WHAT THIS MEASURES — MOTION CONSISTENCY, not scrollTop-referenced residual.
+ * (This is the T1.1 reframe. The original gate subtracted the REALIZED
+ * scrollTop delta, which INCLUDES the fix-writer's compensating `scrollBy`, so
+ * the writer cancelled out of the metric and the gate scored raw estimate error
+ * R — invariant to whether the fix ran. Dawn found it; Quinn and Eva confirmed
+ * the algebra. See the diagnostic below for that residual — it is T3's estimator
+ * acceptance number, kept but NON-GATING.)
  *
- * We track a row sitting COMFORTABLY INSIDE the viewport (a SAFE_MARGIN band
- * from both edges) so it stays realized across the whole step — its `top`
- * therefore reflects only true motion, never the ~one-row-height box jump a
- * STRADDLING row suffers when `content-visibility` un-realizes it as it exits
- * the top. When rows ABOVE the tracked row realize this step (true != estimate)
- * and native anchoring is off, the content below them — including our tracked
- * row — shifts down by the accumulated realization delta. That extra motion IS
- * the reading-position jump Tyler feels, and it lands cleanly in the residual.
- * We re-pick the tracked row each step and only score a step when the SAME id
- * stayed inside the safe band both before and after (a partial exit would
- * reintroduce the un-realization artifact). The gate is the WORST single-step
- * residual (peak lurch) plus the RMS residual (sustained micro-jitter) — a user
- * feels both the spike and the accumulated shimmer.
+ * The honest signal: during a steady upscroll a comfortably-visible reading row
+ * must move down the viewport by the SAME amount every notch. We actuate a
+ * fixed synchronous step (`scrollTop -= STEP`) so the input delta is a known
+ * constant every notch — this bypasses Blink's wheel-scaling entirely (a wheel
+ * notch can apply 218/220/222… and median-of-run would misread that per-notch
+ * scaling as jitter; a fixed step cannot). A perfectly-compensated scroll then
+ * moves the reading row by EXACTLY STEP every notch — deviation 0. A broken
+ * scroll lurches: rows realizing ABOVE the reading row shove it by the
+ * realization delta, which varies notch-to-notch, so its per-notch motion
+ * scatters around the run median. The metric is that scatter:
  *
- * VALIDITY (why this is the honest metric, not a proxy): a fully-realized
- * ("prewarmed") channel has NO realization deltas, so this residual collapses
- * to ~0 — the make-or-break control. A uniform channel realizes near-estimate,
- * so it stays low. Only the heterogeneous corpus, whose estimates miss, is RED.
+ *   rowMove_i   = after.top - before.top          (reading row's viewport motion; NO scrollTop reference)
+ *   deviation_i = | rowMove_i - median(rowMove) |
+ *   gate        = peak deviation (worst lurch) and rms deviation (sustained shimmer)
  *
- * WHY IT IS RED TODAY: the `jitter-corpus` seed (e2eBridge.ts) is 400
- * structurally-rich rows whose true height `estimateRowHeight` is known to
- * miss (markdown headings/lists/blockquotes counted as flat 20px prose lines;
- * long prose vs the fixed CHARS_PER_LINE=64 guess; code-fence chrome). Every
- * never-painted row realizes with true != estimate, so a real per-step
- * residual appears. The thresholds sit under the baseline this corpus produces
- * at tip 77bd0e70, so the gate FAILS now and only a genuine estimator/anchor
- * fix turns it green.
+ * WHY THIS ESCAPES THE INVARIANCE that killed the old gate and the co-visible
+ * idea: it references the reading row's own motion ACROSS NOTCHES (temporal
+ * self-reference), never a neighbouring row (spatial) and never the realized
+ * scrollTop. The fix-writer's `scrollBy` moves the row and is NOT subtracted
+ * back out, so it survives into rowMove and the metric SEES it. A uniform
+ * global offset (which is all compensation is) cancels out of any row-vs-row
+ * differential — that is exactly why co-visible and the old residual were
+ * blind, and exactly why per-notch-motion-vs-run-median is not.
  *
- * SCOPE / ENGINE FIDELITY: this runs under Playwright headed Chromium, which
- * ships `overflow-anchor` (native scroll anchoring). The app ships in
- * WKWebView, which — per Eva's L-C finding (Mari) — has NO `overflow-anchor`
- * at all: it corrects NOTHING, so every above-viewport realization delta lands
- * raw on the reading position. To make the red bar honest we therefore FORCE
- * `overflow-anchor: none` on the timeline scroller before measuring, so
- * Chromium reproduces the shipped engine's behavior instead of hiding exactly
- * the drift Tyler feels. We also log `CSS.supports("overflow-anchor","auto")`
- * so the per-engine baseline is on the record. A correct owned-compensation
- * fix (the converged train: `overflow-anchor: none` + same-frame
- * scrollBy(realized − reserved)) zeros this residual on ANY engine — which is
- * the point: it makes Chromium CI test what macOS users actually feel.
+ * ANTI-CHEAT FLOOR: a frozen or half-applying scroller has near-zero motion
+ * variance and would false-green. We assert mean rowMove ≈ STEP so a scroller
+ * that does not actually track the input cannot pass.
+ *
+ * RED-AT-TIP IS A HARD GATE, NOT CEREMONY. median-of-run is only valid if the
+ * corpus produces VARYING realization (dispersion); a degenerate constant-R
+ * corpus would green a broken writer. The tip run being RED IS the proof that
+ * `jitter-corpus` produces that dispersion. If a future corpus edit turns the
+ * tip-run green here, this gate is VOID and must fail loudly — see the assert.
+ *
+ * VALIDITY CONTROL: this metric goes to ~0 only when the reading row tracks the
+ * input every notch — i.e. when a correct owned-compensation fix
+ * (`overflow-anchor: none` + same-frame `scrollBy(realized − reserved)`) holds
+ * it. A synthetic per-notch-varying perfect-comp oracle drives 74/77 notches to
+ * EXACTLY STEP (T1.1 bake-off); the real T2 writer re-pins in the same
+ * ResizeObserver cycle and closes the remaining synthetic-only outliers.
+ *
+ * ENGINE FIDELITY: runs under Playwright headed Chromium, which ships
+ * `overflow-anchor`. The app ships in WKWebView, which — per Eva's L-C finding
+ * (Mari) — has NO `overflow-anchor`: it corrects NOTHING, so every
+ * above-viewport realization delta lands raw on the reading position. We FORCE
+ * `overflow-anchor: none` on the scroller before measuring so Chromium
+ * reproduces the shipped engine, and log `CSS.supports(...)` for the record.
  *
  * Run headed to watch it:
  *   pnpm build && npx playwright test --config=playwright.perf.config.ts \
  *     upscroll-jitter --headed
  */
 
-// Peak single-step residual we tolerate (px). Above this is a realization
-// lurch the eye catches. RED at tip: baseline peaks well above.
-const MAX_PEAK_RESIDUAL_PX = 2.0;
-// RMS residual across steps (px) — the sustained micro-jitter floor.
-const MAX_RMS_RESIDUAL_PX = 0.6;
+// Peak per-notch motion deviation we tolerate (px). Above this is a lurch the
+// eye catches. RED at tip: baseline peaks ~41px on the heterogeneous corpus.
+const MAX_PEAK_DEVIATION_PX = 2.0;
+// RMS motion deviation across notches (px) — the sustained micro-jitter floor.
+const MAX_RMS_DEVIATION_PX = 0.6;
 
-const WHEEL_NOTCH = 220; // px per wheel step (Blink scales the applied delta)
+// Fixed synchronous scroll step per notch (px). Constant by construction — no
+// wheel-scaling variance for median-of-run to misread as jitter.
+const STEP = 220;
 const MAX_STEPS = 80; // cap; stop early once we near the top of the window
 // Keep the tracked row this far (px) from both viewport edges so it stays
 // realized across the step — no straddling-row un-realization artifact.
 const SAFE_MARGIN = 100;
 
-type StepSample = { residual: number; appliedDelta: number };
+type StepSample = { rowMove: number; appliedTop: number; residual: number };
 
 type Result = {
   samples: StepSample[];
-  steps: number;
   reachedTop: boolean;
   rowCount: number;
 };
 
-test("GATE: upscroll anchor residual stays below the realization-jitter threshold", async ({
-  page,
-}) => {
-  await installMockBridge(page);
-  await page.goto("/");
-  await page.waitForFunction(
-    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
-  );
-
-  // The `jitter-corpus` channel is pre-seeded (e2eBridge.ts) with 400
-  // heterogeneous rows in its mock store — no dependence on live-emit timing,
-  // the same reliable cold-load path scroll-history.spec.ts uses.
-  await page.getByTestId("channel-jitter-corpus").click();
-  await expect(page.getByTestId("chat-title")).toHaveText("jitter-corpus");
+// Drive one upscroll run and collect per-notch samples. `actuate` selects the
+// input mode: "sync" (fixed STEP, the gate) or "wheel" (Blink-scaled, printed
+// as a non-gating felt-mode diagnostic — Tyler's real input is a wheel).
+async function measure(
+  page: import("@playwright/test").Page,
+  actuate: "sync" | "wheel",
+): Promise<Result> {
   const timeline = page.getByTestId("message-timeline");
-  await expect(timeline.locator("[data-message-id]").first()).toBeVisible();
-  await page.waitForFunction(() => {
-    const el = document.querySelector(
-      '[data-testid="message-timeline"]',
-    ) as HTMLDivElement | null;
-    return !!el && el.scrollHeight > el.clientHeight + 1000;
-  });
-
-  // Pin to the true bottom so everything above is unpainted (at estimate).
+  // Re-pin to the true bottom so everything above is unpainted (at estimate).
   await timeline.evaluate((element) => {
     const el = element as HTMLDivElement;
     el.scrollTop = el.scrollHeight;
     el.dispatchEvent(new Event("scroll", { bubbles: true }));
   });
   await page.waitForTimeout(150);
-
-  // Log native-anchoring support for this engine, then FORCE it off so
-  // Chromium reproduces the shipped WKWebView (which has no `overflow-anchor`).
-  // Without this, Blink's native anchoring silently corrects the realization
-  // shift and the gate would measure a world macOS users never see.
-  const anchorSupport = await page.evaluate(() =>
-    typeof CSS !== "undefined" && typeof CSS.supports === "function"
-      ? CSS.supports("overflow-anchor", "auto")
-      : false,
-  );
   await timeline.evaluate((element) => {
     (element as HTMLElement).style.overflowAnchor = "none";
   });
-  /* eslint-disable no-console */
-  console.log(
-    `overflow-anchor supported by this engine: ${anchorSupport} ` +
-      `(forced to 'none' on the scroller to mirror shipped WKWebView)`,
-  );
-  /* eslint-enable no-console */
   await page.waitForTimeout(50);
-
-  // Hover so the timeline owns wheel scrolling (mirrors a real reader; also
-  // engages the `:hover` realization rule, utilities.css:21).
   await timeline.hover();
 
   const samples: StepSample[] = [];
   let reachedTop = false;
 
   for (let step = 0; step < MAX_STEPS; step += 1) {
-    // Pick a row sitting comfortably inside the viewport (SAFE_MARGIN from both
-    // edges) so it stays realized across the wheel notch. Capture its top and
-    // the scrollTop BEFORE the notch. reachedTop is decided by scrollTop, not by
-    // whether a safe-band row exists.
+    // Pick a row comfortably inside the viewport (SAFE_MARGIN from both edges)
+    // so it stays realized across the notch. Capture its top + scrollTop BEFORE.
     const before = await timeline.evaluate((element, margin: number) => {
       const el = element as HTMLDivElement;
       const box = el.getBoundingClientRect();
-      const safeTop = box.top + margin;
-      const safeBottom = box.bottom - margin;
       const rows = el.querySelectorAll<HTMLElement>("[data-message-id]");
       for (const row of rows) {
         const rect = row.getBoundingClientRect();
-        if (rect.top > safeTop && rect.bottom < safeBottom) {
+        if (rect.top > box.top + margin && rect.bottom < box.bottom - margin) {
           return {
             id: row.dataset.messageId ?? null,
             top: rect.top,
@@ -176,28 +145,30 @@ test("GATE: upscroll anchor residual stays below the realization-jitter threshol
       reachedTop = true;
       break;
     }
-    if (!before.id) {
-      // No row fully inside the safe band this step (rare: a single row taller
-      // than the band). Nudge up and try the next step rather than scoring it.
-      await page.mouse.wheel(0, -WHEEL_NOTCH);
-      await timeline.evaluate(
-        () =>
-          new Promise<void>((r) =>
-            requestAnimationFrame(() => requestAnimationFrame(() => r())),
-          ),
-      );
-      continue;
-    }
 
-    // One real wheel notch upward, then settle two frames so realization +
-    // any anchor correction land before we read positions back.
-    await page.mouse.wheel(0, -WHEEL_NOTCH);
+    // Actuate one notch upward.
+    if (actuate === "sync") {
+      await timeline.evaluate((element, s: number) => {
+        const el = element as HTMLDivElement;
+        el.scrollTop = Math.max(0, el.scrollTop - s);
+        el.dispatchEvent(new Event("scroll", { bubbles: true }));
+      }, STEP);
+    } else {
+      await page.mouse.wheel(0, -STEP);
+    }
+    // Settle two frames so realization + any writer compensation land before we
+    // read positions back.
     await timeline.evaluate(
       () =>
         new Promise<void>((r) =>
           requestAnimationFrame(() => requestAnimationFrame(() => r())),
         ),
     );
+
+    if (!before.id) {
+      // No safe-band row this step (rare) — nudged already, try the next.
+      continue;
+    }
 
     const after = await timeline.evaluate(
       (element, args: { id: string; margin: number }) => {
@@ -211,8 +182,6 @@ test("GATE: upscroll anchor residual stays below the realization-jitter threshol
         const rect = row.getBoundingClientRect();
         return {
           top: rect.top,
-          // Only score the step if the SAME row is still fully inside the band —
-          // otherwise a partial exit would reintroduce the un-realization jump.
           inSafeBand:
             rect.top > box.top + args.margin &&
             rect.bottom < box.bottom - args.margin,
@@ -222,64 +191,146 @@ test("GATE: upscroll anchor residual stays below the realization-jitter threshol
       { id: before.id, margin: SAFE_MARGIN },
     );
 
-    const appliedDelta = before.scrollTop - after.scrollTop; // px moved up
-    if (appliedDelta <= 0) {
-      // No movement (already at top / wheel absorbed) — stop.
+    const appliedTop = before.scrollTop - after.scrollTop; // realized px moved up
+    if (appliedTop <= 0) {
       reachedTop = after.scrollTop <= 0;
       break;
     }
     if (after.top === null || !after.inSafeBand) {
-      // Tracked row left the safe band this step — skip scoring, keep scrolling.
+      // Tracked row left the safe band — skip scoring, keep scrolling.
       continue;
     }
-    // Smooth: reducing scrollTop by appliedDelta moves the row DOWN the
-    // viewport by exactly appliedDelta. Residual = motion NOT from the wheel,
-    // i.e. realization deltas from rows that crossed the band ABOVE this row.
-    const residual = after.top - before.top - appliedDelta;
-    samples.push({ residual, appliedDelta });
+    const rowMove = after.top - before.top; // viewport motion — the gated signal
+    // NON-GATING diagnostic: motion minus REALIZED scrollTop delta = raw
+    // estimate error R (comp-invariant). This is T3's estimator acceptance
+    // number, printed for the record; it is NOT the gate.
+    const residual = rowMove - appliedTop;
+    samples.push({ rowMove, appliedTop, residual });
   }
 
-  const result: Result = {
+  return {
     samples,
-    steps: samples.length,
     reachedTop,
     rowCount: await timeline.evaluate(
       (el) =>
         (el as HTMLDivElement).querySelectorAll("[data-message-id]").length,
     ),
   };
+}
 
-  const abs = result.samples.map((s) => Math.abs(s.residual));
-  const peak = abs.length ? Math.max(...abs) : 0;
-  const rms = abs.length
-    ? Math.sqrt(abs.reduce((a, r) => a + r * r, 0) / abs.length)
+function stats(samples: StepSample[]) {
+  const moves = samples.map((s) => s.rowMove);
+  const sorted = moves.slice().sort((a, b) => a - b);
+  const median = sorted.length ? sorted[Math.floor(sorted.length / 2)] : 0;
+  const dev = moves.map((m) => Math.abs(m - median));
+  const peakDev = dev.length ? Math.max(...dev) : 0;
+  const rmsDev = dev.length
+    ? Math.sqrt(dev.reduce((a, d) => a + d * d, 0) / dev.length)
     : 0;
-  const mean = abs.length ? abs.reduce((a, r) => a + r, 0) / abs.length : 0;
+  const meanMove = moves.length
+    ? moves.reduce((a, m) => a + m, 0) / moves.length
+    : 0;
+  // Old scrollTop-referenced residual (= estimate error R) — non-gating diag.
+  const resAbs = samples.map((s) => Math.abs(s.residual));
+  const resPeak = resAbs.length ? Math.max(...resAbs) : 0;
+  const resRms = resAbs.length
+    ? Math.sqrt(resAbs.reduce((a, r) => a + r * r, 0) / resAbs.length)
+    : 0;
+  return { median, peakDev, rmsDev, meanMove, resPeak, resRms };
+}
+
+test("GATE: upscroll motion consistency stays below the realization-jitter threshold", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+
+  // The `jitter-corpus` channel is pre-seeded (e2eBridge.ts) with 400
+  // heterogeneous rows in its mock store — the same reliable cold-load path
+  // scroll-history.spec.ts uses, no dependence on live-emit timing.
+  await page.getByTestId("channel-jitter-corpus").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("jitter-corpus");
+  const timeline = page.getByTestId("message-timeline");
+  await expect(timeline.locator("[data-message-id]").first()).toBeVisible();
+  await page.waitForFunction(() => {
+    const el = document.querySelector(
+      '[data-testid="message-timeline"]',
+    ) as HTMLDivElement | null;
+    return !!el && el.scrollHeight > el.clientHeight + 1000;
+  });
+
+  // Log native-anchoring support for this engine (measure() forces it off).
+  const anchorSupport = await page.evaluate(() =>
+    typeof CSS !== "undefined" && typeof CSS.supports === "function"
+      ? CSS.supports("overflow-anchor", "auto")
+      : false,
+  );
+
+  // GATED run: fixed synchronous step (deterministic input, no Blink scaling).
+  const result = await measure(page, "sync");
+  const s = stats(result.samples);
+
+  // NON-GATING felt-mode diagnostic: same metric under a real wheel. Tyler's
+  // input is a wheel; we want the felt number on the record every run even
+  // though Blink's per-notch scaling makes it unsafe to gate on.
+  const wheelResult = await measure(page, "wheel");
+  const w = stats(wheelResult.samples);
 
   /* eslint-disable no-console */
-  console.log("\n=== UPSCROLL JITTER GATE (anchor residual, Chromium) ===");
+  console.log(
+    `overflow-anchor supported by this engine: ${anchorSupport} ` +
+      `(forced to 'none' on the scroller to mirror shipped WKWebView)`,
+  );
+  console.log("\n=== UPSCROLL JITTER GATE (motion consistency, Chromium) ===");
   console.log(`rows mounted (live DOM):     ${result.rowCount}`);
-  console.log(`steps measured:              ${result.steps}`);
+  console.log(`steps measured (sync):       ${result.samples.length}`);
   console.log(`reached top of history:      ${result.reachedTop}`);
   console.log(
-    `peak single-step residual:   ${peak.toFixed(2)}px  (gate <= ${MAX_PEAK_RESIDUAL_PX})`,
+    `median per-notch motion:     ${s.median.toFixed(1)}px  (STEP=${STEP})`,
   );
   console.log(
-    `rms residual:                ${rms.toFixed(2)}px  (gate <= ${MAX_RMS_RESIDUAL_PX})`,
+    `peak motion deviation:       ${s.peakDev.toFixed(2)}px  (gate <= ${MAX_PEAK_DEVIATION_PX})`,
   );
-  console.log(`mean |residual|:             ${mean.toFixed(2)}px`);
-  console.log("(0 == every on-screen row tracked the wheel exactly)");
-  console.log("========================================================\n");
+  console.log(
+    `rms motion deviation:        ${s.rmsDev.toFixed(2)}px  (gate <= ${MAX_RMS_DEVIATION_PX})`,
+  );
+  console.log(
+    `mean per-notch motion:       ${s.meanMove.toFixed(1)}px  (anti-cheat: ~= ${STEP})`,
+  );
+  console.log("--- non-gating diagnostics ---");
+  console.log(
+    `estimate-error R (old resid):peak=${s.resPeak.toFixed(2)}px rms=${s.resRms.toFixed(2)}px  (T3 estimator acceptance number)`,
+  );
+  console.log(
+    `wheel-actuated (felt mode):  peak-dev=${w.peakDev.toFixed(2)}px rms-dev=${w.rmsDev.toFixed(2)}px over ${wheelResult.samples.length} steps`,
+  );
+  console.log("(0 == the reading row tracked the input exactly every notch)");
+  console.log("===========================================================\n");
   /* eslint-enable no-console */
 
-  // Sanity: the run actually exercised a meaningful upscroll. The cold-load
-  // windows the 400-row seed to the newest ~100 rows (CHANNEL_HISTORY_LIMIT),
-  // all in the DOM (de-virtualized), so ~100 mounted rows is the expected
-  // fully-loaded window we scroll within.
+  // Sanity: the run actually exercised a meaningful upscroll. Cold-load windows
+  // the 400-row seed to the newest ~100 rows (CHANNEL_HISTORY_LIMIT), all in the
+  // DOM (de-virtualized), so ~100 mounted rows is the expected window.
   expect(result.rowCount).toBeGreaterThanOrEqual(80);
   expect(result.samples.length).toBeGreaterThan(8);
 
-  // THE GATE. RED at tip 77bd0e70; a real estimator/anchor fix turns it green.
-  expect(peak).toBeLessThanOrEqual(MAX_PEAK_RESIDUAL_PX);
-  expect(rms).toBeLessThanOrEqual(MAX_RMS_RESIDUAL_PX);
+  // ANTI-CHEAT: the reading row must actually track the input — a frozen or
+  // half-applying scroller (near-zero motion, would false-green on deviation)
+  // is caught here because its mean motion falls well below STEP.
+  expect(s.meanMove).toBeGreaterThan(STEP * 0.75);
+
+  // THE GATE — per-notch motion consistency. RED at tip (~41px peak / ~23px rms
+  // on jitter-corpus); a correct owned-compensation fix (T2 writer) drives the
+  // reading row to STEP every notch and turns it green.
+  //
+  // ⚠️ RED-AT-TIP IS LOAD-BEARING: median-of-run is only valid while the corpus
+  // produces VARYING realization. This gate failing at tip IS the proof of that
+  // dispersion. If a future corpus edit makes the tip run PASS here WITHOUT a
+  // compensation fix, this gate is VOID — do not relax the thresholds; restore a
+  // heterogeneous corpus so the gate reds again, or the whole metric is moot.
+  expect(s.peakDev).toBeLessThanOrEqual(MAX_PEAK_DEVIATION_PX);
+  expect(s.rmsDev).toBeLessThanOrEqual(MAX_RMS_DEVIATION_PX);
 });

--- a/desktop/tests/e2e/upscroll-jitter.perf.ts
+++ b/desktop/tests/e2e/upscroll-jitter.perf.ts
@@ -1,0 +1,285 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+/**
+ * UPSCROLL-JITTER GATE (L-E) — the RED-today metric the fix train rides on.
+ *
+ * Tyler's report: scrolling UP a fully-loaded channel is jumpy in tiny
+ * variations; scrolling DOWN is smooth. Eva's H1 says why: rows above the
+ * opening viewport have NEVER painted, so they sit at `estimateRowHeight()`
+ * reserves under `content-visibility: auto`. Scrolling up, each row realizes
+ * at its TRUE height the instant it enters the realization band; the delta
+ * (true - estimate) shifts content, and the browser's scroll anchoring only
+ * corrects APPROXIMATELY, one lurch per realization. Down is smooth because
+ * `contain-intrinsic-size: auto` has already remembered every passed row's
+ * exact size.
+ *
+ * WHAT THIS MEASURES (the honest signal, not a proxy):
+ * During a steady upscroll the content already on screen must translate by
+ * exactly the wheel delta. If the viewport moves up by D px, every currently
+ * visible element's `top` must increase by exactly D. Any residual
+ * `(delta_top - D)` is content that jumped for a reason OTHER than the wheel —
+ * a realization-induced anchor correction. That residual IS the jump Tyler
+ * feels. A perfectly smooth scroll keeps every step's residual at 0.
+ *
+ * We track a row sitting COMFORTABLY INSIDE the viewport (a SAFE_MARGIN band
+ * from both edges) so it stays realized across the whole step — its `top`
+ * therefore reflects only true motion, never the ~one-row-height box jump a
+ * STRADDLING row suffers when `content-visibility` un-realizes it as it exits
+ * the top. When rows ABOVE the tracked row realize this step (true != estimate)
+ * and native anchoring is off, the content below them — including our tracked
+ * row — shifts down by the accumulated realization delta. That extra motion IS
+ * the reading-position jump Tyler feels, and it lands cleanly in the residual.
+ * We re-pick the tracked row each step and only score a step when the SAME id
+ * stayed inside the safe band both before and after (a partial exit would
+ * reintroduce the un-realization artifact). The gate is the WORST single-step
+ * residual (peak lurch) plus the RMS residual (sustained micro-jitter) — a user
+ * feels both the spike and the accumulated shimmer.
+ *
+ * VALIDITY (why this is the honest metric, not a proxy): a fully-realized
+ * ("prewarmed") channel has NO realization deltas, so this residual collapses
+ * to ~0 — the make-or-break control. A uniform channel realizes near-estimate,
+ * so it stays low. Only the heterogeneous corpus, whose estimates miss, is RED.
+ *
+ * WHY IT IS RED TODAY: the `jitter-corpus` seed (e2eBridge.ts) is 400
+ * structurally-rich rows whose true height `estimateRowHeight` is known to
+ * miss (markdown headings/lists/blockquotes counted as flat 20px prose lines;
+ * long prose vs the fixed CHARS_PER_LINE=64 guess; code-fence chrome). Every
+ * never-painted row realizes with true != estimate, so a real per-step
+ * residual appears. The thresholds sit under the baseline this corpus produces
+ * at tip 77bd0e70, so the gate FAILS now and only a genuine estimator/anchor
+ * fix turns it green.
+ *
+ * SCOPE / ENGINE FIDELITY: this runs under Playwright headed Chromium, which
+ * ships `overflow-anchor` (native scroll anchoring). The app ships in
+ * WKWebView, which — per Eva's L-C finding (Mari) — has NO `overflow-anchor`
+ * at all: it corrects NOTHING, so every above-viewport realization delta lands
+ * raw on the reading position. To make the red bar honest we therefore FORCE
+ * `overflow-anchor: none` on the timeline scroller before measuring, so
+ * Chromium reproduces the shipped engine's behavior instead of hiding exactly
+ * the drift Tyler feels. We also log `CSS.supports("overflow-anchor","auto")`
+ * so the per-engine baseline is on the record. A correct owned-compensation
+ * fix (the converged train: `overflow-anchor: none` + same-frame
+ * scrollBy(realized − reserved)) zeros this residual on ANY engine — which is
+ * the point: it makes Chromium CI test what macOS users actually feel.
+ *
+ * Run headed to watch it:
+ *   pnpm build && npx playwright test --config=playwright.perf.config.ts \
+ *     upscroll-jitter --headed
+ */
+
+// Peak single-step residual we tolerate (px). Above this is a realization
+// lurch the eye catches. RED at tip: baseline peaks well above.
+const MAX_PEAK_RESIDUAL_PX = 2.0;
+// RMS residual across steps (px) — the sustained micro-jitter floor.
+const MAX_RMS_RESIDUAL_PX = 0.6;
+
+const WHEEL_NOTCH = 220; // px per wheel step (Blink scales the applied delta)
+const MAX_STEPS = 80; // cap; stop early once we near the top of the window
+// Keep the tracked row this far (px) from both viewport edges so it stays
+// realized across the step — no straddling-row un-realization artifact.
+const SAFE_MARGIN = 100;
+
+type StepSample = { residual: number; appliedDelta: number };
+
+type Result = {
+  samples: StepSample[];
+  steps: number;
+  reachedTop: boolean;
+  rowCount: number;
+};
+
+test("GATE: upscroll anchor residual stays below the realization-jitter threshold", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+
+  // The `jitter-corpus` channel is pre-seeded (e2eBridge.ts) with 400
+  // heterogeneous rows in its mock store — no dependence on live-emit timing,
+  // the same reliable cold-load path scroll-history.spec.ts uses.
+  await page.getByTestId("channel-jitter-corpus").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("jitter-corpus");
+  const timeline = page.getByTestId("message-timeline");
+  await expect(timeline.locator("[data-message-id]").first()).toBeVisible();
+  await page.waitForFunction(() => {
+    const el = document.querySelector(
+      '[data-testid="message-timeline"]',
+    ) as HTMLDivElement | null;
+    return !!el && el.scrollHeight > el.clientHeight + 1000;
+  });
+
+  // Pin to the true bottom so everything above is unpainted (at estimate).
+  await timeline.evaluate((element) => {
+    const el = element as HTMLDivElement;
+    el.scrollTop = el.scrollHeight;
+    el.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  await page.waitForTimeout(150);
+
+  // Log native-anchoring support for this engine, then FORCE it off so
+  // Chromium reproduces the shipped WKWebView (which has no `overflow-anchor`).
+  // Without this, Blink's native anchoring silently corrects the realization
+  // shift and the gate would measure a world macOS users never see.
+  const anchorSupport = await page.evaluate(() =>
+    typeof CSS !== "undefined" && typeof CSS.supports === "function"
+      ? CSS.supports("overflow-anchor", "auto")
+      : false,
+  );
+  await timeline.evaluate((element) => {
+    (element as HTMLElement).style.overflowAnchor = "none";
+  });
+  /* eslint-disable no-console */
+  console.log(
+    `overflow-anchor supported by this engine: ${anchorSupport} ` +
+      `(forced to 'none' on the scroller to mirror shipped WKWebView)`,
+  );
+  /* eslint-enable no-console */
+  await page.waitForTimeout(50);
+
+  // Hover so the timeline owns wheel scrolling (mirrors a real reader; also
+  // engages the `:hover` realization rule, utilities.css:21).
+  await timeline.hover();
+
+  const samples: StepSample[] = [];
+  let reachedTop = false;
+
+  for (let step = 0; step < MAX_STEPS; step += 1) {
+    // Pick a row sitting comfortably inside the viewport (SAFE_MARGIN from both
+    // edges) so it stays realized across the wheel notch. Capture its top and
+    // the scrollTop BEFORE the notch. reachedTop is decided by scrollTop, not by
+    // whether a safe-band row exists.
+    const before = await timeline.evaluate((element, margin: number) => {
+      const el = element as HTMLDivElement;
+      const box = el.getBoundingClientRect();
+      const safeTop = box.top + margin;
+      const safeBottom = box.bottom - margin;
+      const rows = el.querySelectorAll<HTMLElement>("[data-message-id]");
+      for (const row of rows) {
+        const rect = row.getBoundingClientRect();
+        if (rect.top > safeTop && rect.bottom < safeBottom) {
+          return {
+            id: row.dataset.messageId ?? null,
+            top: rect.top,
+            scrollTop: el.scrollTop,
+          };
+        }
+      }
+      return { id: null, top: 0, scrollTop: el.scrollTop };
+    }, SAFE_MARGIN);
+
+    if (before.scrollTop <= 0) {
+      reachedTop = true;
+      break;
+    }
+    if (!before.id) {
+      // No row fully inside the safe band this step (rare: a single row taller
+      // than the band). Nudge up and try the next step rather than scoring it.
+      await page.mouse.wheel(0, -WHEEL_NOTCH);
+      await timeline.evaluate(
+        () =>
+          new Promise<void>((r) =>
+            requestAnimationFrame(() => requestAnimationFrame(() => r())),
+          ),
+      );
+      continue;
+    }
+
+    // One real wheel notch upward, then settle two frames so realization +
+    // any anchor correction land before we read positions back.
+    await page.mouse.wheel(0, -WHEEL_NOTCH);
+    await timeline.evaluate(
+      () =>
+        new Promise<void>((r) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => r())),
+        ),
+    );
+
+    const after = await timeline.evaluate(
+      (element, args: { id: string; margin: number }) => {
+        const el = element as HTMLDivElement;
+        const box = el.getBoundingClientRect();
+        const row = el.querySelector<HTMLElement>(
+          `[data-message-id="${CSS.escape(args.id)}"]`,
+        );
+        if (!row)
+          return { top: null, inSafeBand: false, scrollTop: el.scrollTop };
+        const rect = row.getBoundingClientRect();
+        return {
+          top: rect.top,
+          // Only score the step if the SAME row is still fully inside the band —
+          // otherwise a partial exit would reintroduce the un-realization jump.
+          inSafeBand:
+            rect.top > box.top + args.margin &&
+            rect.bottom < box.bottom - args.margin,
+          scrollTop: el.scrollTop,
+        };
+      },
+      { id: before.id, margin: SAFE_MARGIN },
+    );
+
+    const appliedDelta = before.scrollTop - after.scrollTop; // px moved up
+    if (appliedDelta <= 0) {
+      // No movement (already at top / wheel absorbed) — stop.
+      reachedTop = after.scrollTop <= 0;
+      break;
+    }
+    if (after.top === null || !after.inSafeBand) {
+      // Tracked row left the safe band this step — skip scoring, keep scrolling.
+      continue;
+    }
+    // Smooth: reducing scrollTop by appliedDelta moves the row DOWN the
+    // viewport by exactly appliedDelta. Residual = motion NOT from the wheel,
+    // i.e. realization deltas from rows that crossed the band ABOVE this row.
+    const residual = after.top - before.top - appliedDelta;
+    samples.push({ residual, appliedDelta });
+  }
+
+  const result: Result = {
+    samples,
+    steps: samples.length,
+    reachedTop,
+    rowCount: await timeline.evaluate(
+      (el) =>
+        (el as HTMLDivElement).querySelectorAll("[data-message-id]").length,
+    ),
+  };
+
+  const abs = result.samples.map((s) => Math.abs(s.residual));
+  const peak = abs.length ? Math.max(...abs) : 0;
+  const rms = abs.length
+    ? Math.sqrt(abs.reduce((a, r) => a + r * r, 0) / abs.length)
+    : 0;
+  const mean = abs.length ? abs.reduce((a, r) => a + r, 0) / abs.length : 0;
+
+  /* eslint-disable no-console */
+  console.log("\n=== UPSCROLL JITTER GATE (anchor residual, Chromium) ===");
+  console.log(`rows mounted (live DOM):     ${result.rowCount}`);
+  console.log(`steps measured:              ${result.steps}`);
+  console.log(`reached top of history:      ${result.reachedTop}`);
+  console.log(
+    `peak single-step residual:   ${peak.toFixed(2)}px  (gate <= ${MAX_PEAK_RESIDUAL_PX})`,
+  );
+  console.log(
+    `rms residual:                ${rms.toFixed(2)}px  (gate <= ${MAX_RMS_RESIDUAL_PX})`,
+  );
+  console.log(`mean |residual|:             ${mean.toFixed(2)}px`);
+  console.log("(0 == every on-screen row tracked the wheel exactly)");
+  console.log("========================================================\n");
+  /* eslint-enable no-console */
+
+  // Sanity: the run actually exercised a meaningful upscroll. The cold-load
+  // windows the 400-row seed to the newest ~100 rows (CHANNEL_HISTORY_LIMIT),
+  // all in the DOM (de-virtualized), so ~100 mounted rows is the expected
+  // fully-loaded window we scroll within.
+  expect(result.rowCount).toBeGreaterThanOrEqual(80);
+  expect(result.samples.length).toBeGreaterThan(8);
+
+  // THE GATE. RED at tip 77bd0e70; a real estimator/anchor fix turns it green.
+  expect(peak).toBeLessThanOrEqual(MAX_PEAK_RESIDUAL_PX);
+  expect(rms).toBeLessThanOrEqual(MAX_RMS_RESIDUAL_PX);
+});


### PR DESCRIPTION
## What

Fixes Tyler's reported upscroll-only jitter: "scrolling up in a channel, but not down, is a little jumpy… even in fully loaded channels."

**Root cause (H1, trace-proven):** under `content-visibility: auto`, never-painted rows enter the viewport at their `contain-intrinsic-size` estimate and realize at their true height on entry. On WKWebView there is no `overflow-anchor` support, so every realization delta lurches the reading row. Two sources: CV realization inside the loaded window, and cold `fetchOlder` pagination prepends mid-upscroll. Downscroll never hits this because rows below are already realized.

## The fix train (7 commits, 3 lanes, each cross-reviewed)

1. **Motion-consistency perf gate** (`upscroll-jitter.perf.ts`) — measures per-notch scroll motion of the reading row on a 400-row worst-case corpus. RED on the pre-fix code: **peak deviation 41–48px, rms 23–24px** per 220px notch. Anti-cheat floors (row count, sample count, mean-motion) prevent a trivially-green gate.
2. **Compensation writer** (`useAnchoredScroll.ts` + `overflow-anchor: none` in production CSS) — snapshots an anchor row on scroll, seeds a ResizeObserver from the reserve, applies same-frame `scrollBy(drift)` compensation. Gate goes **GREEN: 0.00px peak / 0.00px rms** — the reading row tracks the input exactly on every notch, including across a live `fetchOlder` prepend.
3. **Estimator improvements** (`rowHeightEstimate.ts`) — supported-preview-only reserve (−56px false reserve on unsupported bare URLs), measured column width wired via `useElementWidth` (estimate-error peak 75→55px on the test corpus). Smaller estimates = smaller realization deltas = less work for the writer, and less CV layout-shift generally.
4. **Anchor-contract guard** (`upscroll-anchor-contract.perf.ts`) — asserts production computed style actually ships `overflow-anchor: none` (the gate forces it to mirror WKWebView; this guard catches stylesheet drift that would silently break on-device while staying green in CI).
5. **Gate scores pagination** (T1.2) — the gate deterministically crosses a `fetchOlder` prepend inside the scored window and asserts it (`prependObserved`), so both jitter sources are certified per run, with a skip-and-re-baseline mechanism that cannot be gamed into skipping genuine jitter notches (skip branch is structurally unreachable when scrollTop actually moved).

## Numbers at this head (fresh build, same-shell rev-parse)

| metric | before (no writer) | after |
|---|---|---|
| peak motion deviation / 220px notch | 41–48px | **0.00px** |
| rms motion deviation | 23–24px | **0.00px** |
| wheel-actuated felt mode | jitters | **0.00/0.00 over 80 steps** |
| prepend scored in gate | — | **true** |
| estimate-error R (diagnostic) | 75px peak | **55px peak** |
| unsupported-URL row reserve | 126px | **70px** (−56px phantom preview card) |

`rowHeightEstimate` unit tests 16/16 · tsc clean · biome clean · pre-push hooks green.

## Review trail

Every lane cross-reviewed by a non-author before integration (Quinn, Perci, Max, Dawn, Sami rotating); full trail in #buzz-gui-performance. Cross-lane invariant held throughout: gate greens only via the writer, estimate-error moves only via the estimator.

## Follow-ups (deliberate, not gaps)

- **T4b**: per-event-id height cache for the head-refetch-unmount case (upscroll path is append-only, needs none; the `onRealizedHeight` seam is deferred until T4b defines a real consumer).
- **On-device WKWebView verification**: gate runs in Chromium with `overflow-anchor` forced off to mirror WKWebView; a manual smoke on macOS Tauri is the final confirmation.
- Estimate-error R is a non-gating diagnostic and window-dependent; compare only within the same gate version.
