### PR TITLE
fix(desktop): async-ify the auto-restart setter after the perf-sweep merge collision

### DIFF
--- a/desktop/src-tauri/src/commands/agent_settings.rs
+++ b/desktop/src-tauri/src/commands/agent_settings.rs
@@ -56,42 +56,46 @@ pub async fn set_managed_agent_start_on_app_launch(
 }
 
 #[tauri::command]
-pub fn set_managed_agent_auto_restart(
+pub async fn set_managed_agent_auto_restart(
     pubkey: String,
     auto_restart_on_config_change: bool,
     app: AppHandle,
-    state: State<'_, AppState>,
 ) -> Result<ManagedAgentSummary, String> {
-    let _store_guard = state
-        .managed_agents_store_lock
-        .lock()
-        .map_err(|error| error.to_string())?;
-    let mut records = load_managed_agents(&app)?;
-    let mut runtimes = state
-        .managed_agent_processes
-        .lock()
-        .map_err(|error| error.to_string())?;
+    tokio::task::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let _store_guard = state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|error| error.to_string())?;
+        let mut records = load_managed_agents(&app)?;
+        let mut runtimes = state
+            .managed_agent_processes
+            .lock()
+            .map_err(|error| error.to_string())?;
 
-    let (sync_changed, exited_pubkeys) =
-        sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
-    if sync_changed {
+        let (sync_changed, exited_pubkeys) =
+            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+        if sync_changed {
+            save_managed_agents(&app, &records)?;
+        }
+        for pubkey in &exited_pubkeys {
+            state.clear_session_cache(pubkey);
+        }
+
+        {
+            let record = find_managed_agent_mut(&mut records, &pubkey)?;
+            record.auto_restart_on_config_change = auto_restart_on_config_change;
+            record.updated_at = now_iso();
+        }
+
         save_managed_agents(&app, &records)?;
-    }
-    for pubkey in &exited_pubkeys {
-        state.clear_session_cache(pubkey);
-    }
-
-    {
-        let record = find_managed_agent_mut(&mut records, &pubkey)?;
-        record.auto_restart_on_config_change = auto_restart_on_config_change;
-        record.updated_at = now_iso();
-    }
-
-    save_managed_agents(&app, &records)?;
-    let record = records
-        .iter()
-        .find(|record| record.pubkey == pubkey)
-        .ok_or_else(|| format!("agent {pubkey} not found"))?;
-    let personas = load_personas(&app).unwrap_or_default();
-    build_managed_agent_summary(&app, record, &runtimes, &personas)
+        let record = records
+            .iter()
+            .find(|record| record.pubkey == pubkey)
+            .ok_or_else(|| format!("agent {pubkey} not found"))?;
+        let personas = load_personas(&app).unwrap_or_default();
+        build_managed_agent_summary(&app, record, &runtimes, &personas)
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }


### PR DESCRIPTION
## What

Main is red after #1649: a **semantic merge collision** with #1641 (perf sweep), which landed between #1649's branch cut and its merge. #1641 rewrote `agent_settings.rs` to the async/`spawn_blocking` pattern and swapped the `State` import for `Manager`; #1649 added `set_managed_agent_auto_restart` in the file's prior synchronous style (`State<'_, AppState>` param). Each PR was green on its own branch; their union fails `cargo check`:

```
error[E0425]: cannot find type `State` in this scope
  --> src/commands/agent_settings.rs:63:12
```

## Fix

Rewrite the setter to the file's current pattern — `async` + `spawn_blocking`, `app.state::<AppState>()` inside the closure. Same body, same semantics, now off the main UI thread like its `set_managed_agent_start_on_app_launch` sibling (which #1641 converted the same way). One file, mechanical.

## Validation

- `cargo check` clean (the exact failing gate on main), clippy clean, both fmt gates clean
- Rust tests: 1057/1057
