### PR TITLE
fix(desktop): seed full cached theme vars in boot script

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -27,7 +27,7 @@
     </style>
     <script>
       (() => {
-        var cached, bg, parsed;
+        var cached, bg, parsed, vars, key;
         try {
           cached = window.localStorage.getItem("buzz-theme-cache");
           if (!cached) {
@@ -38,7 +38,21 @@
             return;
           }
           parsed = JSON.parse(cached);
-          bg = parsed.vars["--background"];
+          // Seed the full cached vars map on <html> before paint, mirroring
+          // ThemeProvider.applyCachedVars(). The loading gate's grainient reads
+          // --chart-*, --primary, --foreground, etc. — not just --background —
+          // so seeding only --background would let a cached non-Latte theme
+          // (houston/buzz/custom) paint the splash from the static Catppuccin
+          // :root vars until React mounts.
+          vars = parsed.vars;
+          if (vars) {
+            for (key in vars) {
+              if (Object.hasOwn(vars, key)) {
+                document.documentElement.style.setProperty(key, vars[key]);
+              }
+            }
+          }
+          bg = vars && vars["--background"];
           if (bg) document.documentElement.style.backgroundColor = `hsl(${bg})`;
           // Match the cached light/dark class so themed vars resolve correctly
           // before ThemeProvider mounts.


### PR DESCRIPTION
## What

Follow-up to #1631. The cold-boot inline script in `desktop/index.html` applied only the cached `--background` and the light/dark class before React mounts. But the restored setup loading gate's grainient reads several other theme vars — `--chart-5`, `--chart-3`, `--chart-2`, `--primary`, `--foreground` (`desktop/src/shared/styles/globals/animations.css`, `.buzz-setup-loading-shell` / `.buzz-setup-grainient__wash`).

So with a cached non-Latte theme (`houston`/`buzz`/custom), the pre-React paint resolved those vars from the static Catppuccin `:root` values in `theme.css`, briefly painting a wrong-colored splash grainient until `ThemeProvider.applyCachedVars()` ran on mount.

## Fix

Seed the full cached `vars` map on `documentElement` synchronously in the boot script, mirroring `ThemeProvider.applyCachedVars()` (`desktop/src/shared/theme/ThemeProvider.tsx:209-230`). Now the pre-React paint matches the themed gate for any cached theme, not just the default.

Addresses the last open review thread on #1631.

## Testing

- Desktop biome lint + `check:px-text` green; `index.html` is biome-format-ignored.
- Pre-push clippy + unit tests (rust, desktop, tauri, mobile) green.
- Note: `just ci`'s `desktop-tauri-clippy` currently fails on `main` with pre-existing unused-import/dead-code errors in `agent_settings.rs` and `archive/store.rs` (last touched by #1653/#1634) — unrelated to this one-file frontend change.