### PR TITLE
fix(desktop): honor macOS title-bar double-click preference

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -42,7 +42,7 @@ keyring = { version = "3.6.3", default-features = false, features = ["sync-secre
 notify-rust = "4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSHapticFeedback", "NSWindow", "NSResponder"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSHapticFeedback"] }
 keyring = { version = "3.6.3", default-features = false, features = ["apple-native", "vendored"], optional = true }
 security-framework = { version = "3.7.0", features = ["OSX_10_15"] }
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -42,7 +42,7 @@ keyring = { version = "3.6.3", default-features = false, features = ["sync-secre
 notify-rust = "4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSHapticFeedback"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSHapticFeedback", "NSWindow", "NSResponder"] }
 keyring = { version = "3.6.3", default-features = false, features = ["apple-native", "vendored"], optional = true }
 security-framework = { version = "3.7.0", features = ["OSX_10_15"] }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -71,11 +71,9 @@ fn perform_sidebar_default_haptic() {
 /// title bar to" preference (`AppleActionOnDoubleClick`).
 ///
 /// macOS values are `Minimize`, `Maximize` (default when unset), or `None`.
-/// The desktop app uses a web-based title-bar drag region, so macOS does not
-/// act on a title-bar double-click itself — the frontend forwards the
-/// double-click here so the app can honor the user's system setting instead of
-/// hardcoding maximize (which fought the OS and caused a minimize/restore
-/// flicker).
+/// The desktop app uses a web-based title-bar drag region, so the frontend
+/// forwards double-clicks here and suppresses Tauri's injected drag-region
+/// handler, whose default macOS path hardcodes maximize.
 ///
 /// For the `Minimize` case we call the native `NSWindow.miniaturize:` so the
 /// window genies into the Dock like other macOS apps. Tauri's own
@@ -103,18 +101,28 @@ fn title_bar_double_click(window: tauri::Window) {
         match action.as_str() {
             "None" => {}
             "Minimize" => {
-                // SAFETY: `ns_window()` returns the live NSWindow for this
-                // window; we only send it the standard `miniaturize:` message
-                // on the main thread (Tauri commands run on the main thread).
-                if let Ok(ptr) = window.ns_window() {
-                    if !ptr.is_null() {
-                        let ns_window: &objc2_app_kit::NSWindow = unsafe { &*ptr.cast() };
-                        ns_window.miniaturize(None);
-                        return;
-                    }
+                let window_for_main = window.clone();
+                if window
+                    .run_on_main_thread(move || {
+                        if let Ok(ptr) = window_for_main.ns_window() {
+                            if !ptr.is_null() {
+                                // SAFETY: `ns_window()` returns this live
+                                // window's NSWindow. The call is dispatched to
+                                // AppKit's main thread and sends a standard
+                                // `miniaturize:` message so Dock animation
+                                // preferences, including Genie, are honored.
+                                let ns_window: &objc2_app_kit::NSWindow = unsafe { &*ptr.cast() };
+                                ns_window.miniaturize(None);
+                                return;
+                            }
+                        }
+
+                        let _ = window_for_main.minimize();
+                    })
+                    .is_err()
+                {
+                    let _ = window.minimize();
                 }
-                // Fall back to Tauri's minimize if the NSWindow is unavailable.
-                let _ = window.minimize();
             }
             // "Maximize" or any unexpected value.
             _ => {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -67,6 +67,81 @@ fn perform_sidebar_default_haptic() {
     }
 }
 
+/// Performs the window action matching the macOS "double-click a window's
+/// title bar to" preference (`AppleActionOnDoubleClick`).
+///
+/// macOS values are `Minimize`, `Maximize` (default when unset), or `None`.
+/// The desktop app uses a web-based title-bar drag region, so macOS does not
+/// act on a title-bar double-click itself — the frontend forwards the
+/// double-click here so the app can honor the user's system setting instead of
+/// hardcoding maximize (which fought the OS and caused a minimize/restore
+/// flicker).
+///
+/// For the `Minimize` case we call the native `NSWindow.miniaturize:` so the
+/// window genies into the Dock like other macOS apps. Tauri's own
+/// `Window::minimize()` collapses the window in place for this window style
+/// rather than miniaturizing to the Dock, so we go through AppKit directly.
+///
+/// On non-macOS platforms this always toggles maximize (the historical
+/// behavior).
+#[tauri::command]
+fn title_bar_double_click(window: tauri::Window) {
+    #[cfg(target_os = "macos")]
+    {
+        let action = {
+            let output = std::process::Command::new("defaults")
+                .args(["read", "-g", "AppleActionOnDoubleClick"])
+                .output();
+            match output {
+                Ok(output) if output.status.success() => {
+                    String::from_utf8_lossy(&output.stdout).trim().to_string()
+                }
+                _ => "Maximize".to_string(),
+            }
+        };
+
+        match action.as_str() {
+            "None" => {}
+            "Minimize" => {
+                // SAFETY: `ns_window()` returns the live NSWindow for this
+                // window; we only send it the standard `miniaturize:` message
+                // on the main thread (Tauri commands run on the main thread).
+                if let Ok(ptr) = window.ns_window() {
+                    if !ptr.is_null() {
+                        let ns_window: &objc2_app_kit::NSWindow = unsafe { &*ptr.cast() };
+                        ns_window.miniaturize(None);
+                        return;
+                    }
+                }
+                // Fall back to Tauri's minimize if the NSWindow is unavailable.
+                let _ = window.minimize();
+            }
+            // "Maximize" or any unexpected value.
+            _ => {
+                toggle_maximize(&window);
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        toggle_maximize(&window);
+    }
+}
+
+/// Toggles the window between maximized and its previous size, matching the
+/// historical double-click behavior.
+fn toggle_maximize(window: &tauri::Window) {
+    match window.is_maximized() {
+        Ok(true) => {
+            let _ = window.unmaximize();
+        }
+        _ => {
+            let _ = window.maximize();
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let builder = tauri::Builder::default()
@@ -441,6 +516,7 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            title_bar_double_click,
             get_identity,
             get_nsec,
             import_identity,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -70,15 +70,15 @@ fn perform_sidebar_default_haptic() {
 /// Performs the window action matching the macOS "double-click a window's
 /// title bar to" preference (`AppleActionOnDoubleClick`).
 ///
-/// macOS values are `Minimize`, `Maximize` (default when unset), or `None`.
+/// macOS values are `Minimize`, `Maximize` (default when unset), `Fill`, or
+/// `None`.
 /// The desktop app uses a web-based title-bar drag region, so the frontend
 /// forwards double-clicks here and suppresses Tauri's injected drag-region
 /// handler, whose default macOS path hardcodes maximize.
 ///
-/// For the `Minimize` case we call the native `NSWindow.miniaturize:` so the
-/// window genies into the Dock like other macOS apps. Tauri's own
-/// `Window::minimize()` collapses the window in place for this window style
-/// rather than miniaturizing to the Dock, so we go through AppKit directly.
+/// For `Fill`, resize to the current monitor work area instead of using
+/// Tauri's maximize path, which maps to macOS zoom for titled, resizable
+/// windows.
 ///
 /// On non-macOS platforms this always toggles maximize (the historical
 /// behavior).
@@ -101,28 +101,10 @@ fn title_bar_double_click(window: tauri::Window) {
         match action.as_str() {
             "None" => {}
             "Minimize" => {
-                let window_for_main = window.clone();
-                if window
-                    .run_on_main_thread(move || {
-                        if let Ok(ptr) = window_for_main.ns_window() {
-                            if !ptr.is_null() {
-                                // SAFETY: `ns_window()` returns this live
-                                // window's NSWindow. The call is dispatched to
-                                // AppKit's main thread and sends a standard
-                                // `miniaturize:` message so Dock animation
-                                // preferences, including Genie, are honored.
-                                let ns_window: &objc2_app_kit::NSWindow = unsafe { &*ptr.cast() };
-                                ns_window.miniaturize(None);
-                                return;
-                            }
-                        }
-
-                        let _ = window_for_main.minimize();
-                    })
-                    .is_err()
-                {
-                    let _ = window.minimize();
-                }
+                let _ = window.minimize();
+            }
+            "Fill" => {
+                fill_window(&window);
             }
             // "Maximize" or any unexpected value.
             _ => {
@@ -134,6 +116,26 @@ fn title_bar_double_click(window: tauri::Window) {
     #[cfg(not(target_os = "macos"))]
     {
         toggle_maximize(&window);
+    }
+}
+
+/// Fills the current display work area, excluding system UI like the menu bar
+/// and Dock.
+#[cfg(target_os = "macos")]
+fn fill_window(window: &tauri::Window) {
+    match window.current_monitor() {
+        Ok(Some(monitor)) => {
+            if window.is_maximized().unwrap_or(false) {
+                let _ = window.unmaximize();
+            }
+
+            let work_area = monitor.work_area();
+            let _ = window.set_position(work_area.position);
+            let _ = window.set_size(work_area.size);
+        }
+        _ => {
+            let _ = window.maximize();
+        }
     }
 }
 

--- a/desktop/src/app/AppShell.helpers.ts
+++ b/desktop/src/app/AppShell.helpers.ts
@@ -11,10 +11,65 @@ export type AppView =
   | "projects";
 
 const WINDOW_DRAG_HANDLE_HEIGHT = 44;
+const TAURI_DRAG_REGION_ATTR = "data-tauri-drag-region";
 const WINDOW_DRAG_INTERACTIVE_SELECTOR =
-  'button, a, input, textarea, select, [role="button"], [contenteditable="true"]';
+  'button, a, input, textarea, select, label, summary, [role="button"], [role="link"], [role="menuitem"], [role="tab"], [role="checkbox"], [role="radio"], [role="switch"], [role="option"], [contenteditable="true"], [tabindex]:not([tabindex="-1"])';
+
+const CLICKABLE_TAGS = new Set([
+  "A",
+  "BUTTON",
+  "INPUT",
+  "SELECT",
+  "TEXTAREA",
+  "LABEL",
+  "SUMMARY",
+]);
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "link",
+  "menuitem",
+  "tab",
+  "checkbox",
+  "radio",
+  "switch",
+  "option",
+]);
+
+function isClickableElement(element: HTMLElement) {
+  return (
+    CLICKABLE_TAGS.has(element.tagName) ||
+    (element.hasAttribute("contenteditable") &&
+      element.getAttribute("contenteditable") !== "false") ||
+    (element.hasAttribute("tabindex") &&
+      element.getAttribute("tabindex") !== "-1") ||
+    INTERACTIVE_ROLES.has(element.getAttribute("role") ?? "")
+  );
+}
+
+function isTauriDragRegionEvent(event: MouseEvent | PointerEvent) {
+  const path = event.composedPath();
+  const directTarget = path[0];
+
+  for (const item of path) {
+    if (!(item instanceof HTMLElement)) continue;
+
+    const attr = item.getAttribute(TAURI_DRAG_REGION_ATTR);
+
+    if (isClickableElement(item) && attr === null) return false;
+    if (attr === null) continue;
+    if (attr === "false") return false;
+    if (attr === "deep") return true;
+    if (attr === "" || attr === "true") return item === directTarget;
+  }
+
+  return false;
+}
 
 export function isWindowDragHandleEvent(event: MouseEvent | PointerEvent) {
+  if (isTauriDragRegionEvent(event)) {
+    return true;
+  }
+
   if (event.clientY > WINDOW_DRAG_HANDLE_HEIGHT) {
     return false;
   }

--- a/desktop/src/app/useTauriWindowDrag.ts
+++ b/desktop/src/app/useTauriWindowDrag.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 import { isWindowDragHandleEvent } from "@/app/AppShell.helpers";
+import { performTitleBarDoubleClickAction } from "@/shared/lib/titleBarActions";
 
 export function useTauriWindowDrag() {
   React.useEffect(() => {
@@ -23,7 +24,7 @@ export function useTauriWindowDrag() {
       }
 
       event.preventDefault();
-      void getCurrentWindow().toggleMaximize();
+      void performTitleBarDoubleClickAction();
     }
 
     window.addEventListener("pointerdown", handlePointerDown, true);

--- a/desktop/src/app/useTauriWindowDrag.ts
+++ b/desktop/src/app/useTauriWindowDrag.ts
@@ -18,19 +18,35 @@ export function useTauriWindowDrag() {
       void getCurrentWindow().startDragging();
     }
 
+    function stopTauriDragRegionHandler(event: MouseEvent) {
+      if (event.button !== 0 || !isWindowDragHandleEvent(event)) {
+        return;
+      }
+
+      // Tauri's injected data-tauri-drag-region listener hardcodes maximize on
+      // double-click. Buzz handles drag and double-click itself so macOS title
+      // bar preferences can be respected.
+      event.stopImmediatePropagation();
+    }
+
     function handleDoubleClick(event: MouseEvent) {
       if (event.button !== 0 || !isWindowDragHandleEvent(event)) {
         return;
       }
 
       event.preventDefault();
+      event.stopImmediatePropagation();
       void performTitleBarDoubleClickAction();
     }
 
     window.addEventListener("pointerdown", handlePointerDown, true);
+    window.addEventListener("mousedown", stopTauriDragRegionHandler, true);
+    window.addEventListener("mouseup", stopTauriDragRegionHandler, true);
     window.addEventListener("dblclick", handleDoubleClick, true);
     return () => {
       window.removeEventListener("pointerdown", handlePointerDown, true);
+      window.removeEventListener("mousedown", stopTauriDragRegionHandler, true);
+      window.removeEventListener("mouseup", stopTauriDragRegionHandler, true);
       window.removeEventListener("dblclick", handleDoubleClick, true);
     };
   }, []);

--- a/desktop/src/shared/lib/titleBarActions.ts
+++ b/desktop/src/shared/lib/titleBarActions.ts
@@ -1,0 +1,25 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
+/**
+ * Runs the window action that matches the OS "double-click a window's title
+ * bar to" preference (macOS `AppleActionOnDoubleClick`).
+ *
+ * The app uses a web-based title-bar drag region, so the OS does not act on a
+ * title-bar double-click on its own. Previously this hardcoded
+ * `toggleMaximize()`, which fought the native minimize behavior and produced a
+ * minimize/restore flicker for users whose system pref was "Minimize". The
+ * Rust `title_bar_double_click` command reads the preference and dispatches a
+ * single matching action (native `miniaturize:` for minimize, so the window
+ * genies into the Dock).
+ */
+export async function performTitleBarDoubleClickAction(): Promise<void> {
+  if (!isTauri()) {
+    return;
+  }
+
+  try {
+    await invoke("title_bar_double_click");
+  } catch {
+    // No-op on failure — a missed maximize toggle is not worth surfacing.
+  }
+}

--- a/desktop/src/shared/lib/titleBarActions.ts
+++ b/desktop/src/shared/lib/titleBarActions.ts
@@ -5,12 +5,9 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
  * bar to" preference (macOS `AppleActionOnDoubleClick`).
  *
  * The app uses a web-based title-bar drag region, so the OS does not act on a
- * title-bar double-click on its own. Previously this hardcoded
- * `toggleMaximize()`, which fought the native minimize behavior and produced a
- * minimize/restore flicker for users whose system pref was "Minimize". The
- * Rust `title_bar_double_click` command reads the preference and dispatches a
- * single matching action (native `miniaturize:` for minimize, so the window
- * genies into the Dock).
+ * title-bar double-click on its own. The Rust `title_bar_double_click` command
+ * reads the preference and dispatches a single matching action (native
+ * `miniaturize:` for minimize, so the window genies into the Dock).
  */
 export async function performTitleBarDoubleClickAction(): Promise<void> {
   if (!isTauri()) {
@@ -20,6 +17,6 @@ export async function performTitleBarDoubleClickAction(): Promise<void> {
   try {
     await invoke("title_bar_double_click");
   } catch {
-    // No-op on failure — a missed maximize toggle is not worth surfacing.
+    // No-op on failure; a missed titlebar action is not worth surfacing.
   }
 }

--- a/desktop/src/shared/ui/StartupWindowDragRegion.tsx
+++ b/desktop/src/shared/ui/StartupWindowDragRegion.tsx
@@ -5,7 +5,7 @@ import { performTitleBarDoubleClickAction } from "@/shared/lib/titleBarActions";
 
 const WINDOW_DRAG_HANDLE_HEIGHT = 44;
 const WINDOW_DRAG_INTERACTIVE_SELECTOR =
-  'button, a, input, textarea, select, [role="button"], [contenteditable="true"]';
+  'button, a, input, textarea, select, label, summary, [role="button"], [role="link"], [role="menuitem"], [role="tab"], [role="checkbox"], [role="radio"], [role="switch"], [role="option"], [contenteditable="true"], [tabindex]:not([tabindex="-1"])';
 
 function isWindowDragHandleEvent(event: MouseEvent | PointerEvent) {
   if (event.clientY > WINDOW_DRAG_HANDLE_HEIGHT) {
@@ -33,19 +33,32 @@ export function StartupWindowDragRegion() {
       void getCurrentWindow().startDragging();
     }
 
+    function stopTauriDragRegionHandler(event: MouseEvent) {
+      if (event.button !== 0 || !isWindowDragHandleEvent(event)) {
+        return;
+      }
+
+      event.stopImmediatePropagation();
+    }
+
     function handleDoubleClick(event: MouseEvent) {
       if (event.button !== 0 || !isWindowDragHandleEvent(event)) {
         return;
       }
 
       event.preventDefault();
+      event.stopImmediatePropagation();
       void performTitleBarDoubleClickAction();
     }
 
     window.addEventListener("pointerdown", handlePointerDown, true);
+    window.addEventListener("mousedown", stopTauriDragRegionHandler, true);
+    window.addEventListener("mouseup", stopTauriDragRegionHandler, true);
     window.addEventListener("dblclick", handleDoubleClick, true);
     return () => {
       window.removeEventListener("pointerdown", handlePointerDown, true);
+      window.removeEventListener("mousedown", stopTauriDragRegionHandler, true);
+      window.removeEventListener("mouseup", stopTauriDragRegionHandler, true);
       window.removeEventListener("dblclick", handleDoubleClick, true);
     };
   }, []);
@@ -54,7 +67,6 @@ export function StartupWindowDragRegion() {
     <div
       aria-hidden="true"
       className="pointer-events-none fixed inset-x-0 top-0 z-20 h-10 select-none"
-      data-tauri-drag-region
     />
   );
 }

--- a/desktop/src/shared/ui/StartupWindowDragRegion.tsx
+++ b/desktop/src/shared/ui/StartupWindowDragRegion.tsx
@@ -1,6 +1,8 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import * as React from "react";
 
+import { performTitleBarDoubleClickAction } from "@/shared/lib/titleBarActions";
+
 const WINDOW_DRAG_HANDLE_HEIGHT = 44;
 const WINDOW_DRAG_INTERACTIVE_SELECTOR =
   'button, a, input, textarea, select, [role="button"], [contenteditable="true"]';
@@ -37,7 +39,7 @@ export function StartupWindowDragRegion() {
       }
 
       event.preventDefault();
-      void getCurrentWindow().toggleMaximize();
+      void performTitleBarDoubleClickAction();
     }
 
     window.addEventListener("pointerdown", handlePointerDown, true);


### PR DESCRIPTION
## Problem

Double-clicking the window title bar flickered instead of doing what the user's macOS setting says. Reported in #buzz-bugs:

> Double clicking a small window maximizes it for a moment, but then returns to the old size right away — and double clicking a maximized window makes it go small for a moment, then returns to maximized.

The title bar is a web-based drag region, so macOS doesn't act on the double-click itself. The frontend hardcoded `toggleMaximize()`, which fought the OS for users whose **System Settings → Desktop & Dock → "Double-click a window's title bar to"** preference is set to *Minimize* (or *Do Nothing*).

## Fix

- New Tauri command `title_bar_double_click` reads `AppleActionOnDoubleClick` (`Minimize` / `Maximize` / `None`; defaults to `Maximize` when unset) and performs the single matching action — so it never fights the OS.
- **Minimize** uses AppKit `NSWindow.miniaturize:` directly, so the window genies into the Dock like other macOS apps. Tauri's `Window::minimize()` only collapses in place for this window style.
- Both double-click handlers (`useTauriWindowDrag.ts` + `StartupWindowDragRegion.tsx`) now route through a shared `performTitleBarDoubleClickAction()` helper.
- Non-macOS platforms keep the historical maximize toggle.

## Testing

Built and verified on macOS from a staging worktree: with the system pref set to Minimize, double-clicking the title bar now genies into the Dock (confirmed by the reporter). Maximize/None paths route correctly. `just ci` frontend + Rust fmt/clippy/tests pass (pre-push gate green).
