### PR TITLE
Polled settle gate for the mid-history prepend re-anchor (default-off)

### DIFF
--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -14,6 +14,7 @@ import type { ChannelWindowThreadSummary } from "@/features/messages/lib/channel
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ChannelType } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { useFeatureEnabled } from "@/shared/features";
 import { channelChrome } from "@/shared/layout/chromeLayout";
 import { Spinner } from "@/shared/ui/spinner";
 import { TooltipProvider } from "@/shared/ui/tooltip";
@@ -237,6 +238,13 @@ const MessageTimelineBase = React.forwardRef<
   });
   const showTimelineSkeleton = timelineBodySurface === "skeleton";
 
+  // Preview feature (Settings → Experiments, default-off): when enabled, the
+  // mid-history prepend re-anchor is deferred behind the polled settle gate.
+  // Off ⇒ the re-anchor runs immediately on the prepend commit, exactly as on
+  // main. Read here (not inside the hook) so the switch stays a single, visible
+  // wiring point tied to the manifest id.
+  const settleGateEnabled = useFeatureEnabled("settleGate");
+
   const {
     highlightedMessageId,
     isAtBottom,
@@ -253,6 +261,7 @@ const MessageTimelineBase = React.forwardRef<
     onTargetReached,
     scrollContainerRef,
     targetMessageId,
+    settleGate: { enabled: settleGateEnabled },
   });
 
   const timelineIntroSurface = selectTimelineIntroSurface({

--- a/desktop/src/features/messages/ui/useAnchoredScroll.test.mjs
+++ b/desktop/src/features/messages/ui/useAnchoredScroll.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { settleProgrammaticBottomPin } from "./useAnchoredScroll.ts";
+import {
+  DEFAULT_SETTLE_QUIET_FRAMES,
+  observeScrollSettle,
+  settleProgrammaticBottomPin,
+} from "./useAnchoredScroll.ts";
 
 function fakeContainer({ clientHeight, scrollHeight, scrollTop }) {
   const writes = [];
@@ -47,4 +51,123 @@ test("settleProgrammaticBottomPin keeps settling when the floor is still out of 
     container.scrollHeight - container.clientHeight - container.scrollTop,
     2,
   );
+});
+
+// ---------------------------------------------------------------------------
+// observeScrollSettle — the polled quiet-window detector at the heart of the
+// settle gate. A manual frame driver replaces requestAnimationFrame so each
+// tick can read a scripted scrollTop, making the WebKit coalesced-freeze case
+// (design edge #1) directly testable.
+// ---------------------------------------------------------------------------
+
+/**
+ * Drive `observeScrollSettle` frame-by-frame. `positions` is the scrollTop the
+ * container reports on each successive tick. Returns { settledAt } — the
+ * 1-based frame index at which onSettle fired, or null if it never did within
+ * the scripted frames.
+ */
+function runSettle(positions, quietFrames) {
+  const queue = [];
+  const scheduleFrame = (cb) => {
+    queue.push(cb);
+    return queue.length; // non-zero id
+  };
+  const cancelled = new Set();
+  const cancelFrame = (id) => cancelled.add(id);
+
+  let frame = 0;
+  const container = {
+    get scrollTop() {
+      // Position seen on the tick about to run. Clamp to the last scripted
+      // value so a still tail keeps reporting the final resting position.
+      return positions[Math.min(frame, positions.length - 1)];
+    },
+  };
+
+  let settledAt = null;
+  const cancel = observeScrollSettle(
+    container,
+    quietFrames,
+    () => {
+      settledAt = frame;
+    },
+    scheduleFrame,
+    cancelFrame,
+  );
+
+  // Pump queued frames until the loop stops scheduling or we exhaust the script.
+  while (queue.length > 0 && frame < positions.length + quietFrames + 2) {
+    const cb = queue.shift();
+    frame += 1;
+    cb();
+  }
+  return { settledAt, cancel };
+}
+
+test("observeScrollSettle fires only after k consecutive still frames", () => {
+  // Baseline top is 100 (captured at arm time). Frames all report 100 → still
+  // from frame 1. With k=3, settle fires on the 3rd consecutive still frame.
+  const { settledAt } = runSettle([100, 100, 100, 100], 3);
+  assert.equal(settledAt, 3);
+});
+
+test("observeScrollSettle does not settle during the WebKit coalesced freeze", () => {
+  // Design edge #1: WebKit freezes scrollTop reads for ~2 frames mid-fling,
+  // then momentum resumes. A gate that fired on 2 still frames would re-anchor
+  // here — mid-fling — recreating the walk-blind jump. Baseline 100, frozen at
+  // 100 for two frames, then the fling resumes (120, 140), then truly rests.
+  const positions = [100, 100, 120, 140, 160, 160, 160, 160];
+  const { settledAt } = runSettle(positions, DEFAULT_SETTLE_QUIET_FRAMES);
+  // Must NOT have fired during the 2-frame freeze (frames 1–2).
+  assert.ok(
+    settledAt === null || settledAt > 2,
+    `settled at frame ${settledAt}; expected to survive the 2-frame freeze`,
+  );
+  // It should settle only once truly at rest at 160 (frames 5–8: three stills
+  // after the last move land the settle on frame 7).
+  assert.equal(settledAt, 7);
+});
+
+test("observeScrollSettle resets the counter when movement resumes", () => {
+  // One still frame, then a move, then a genuine rest. The lone still frame
+  // must not count toward the final quiet window.
+  const { settledAt } = runSettle([100, 100, 130, 130, 130, 130], 3);
+  // First still frame is at pos[1]; the move to 130 at pos[2] resets the
+  // counter. Three stills follow (pos[3..5]) → settle on frame 5, proving the
+  // lone earlier still did not carry over.
+  assert.equal(settledAt, 5);
+});
+
+test("observeScrollSettle cancel stops the loop and never fires onSettle", () => {
+  const queue = [];
+  const scheduleFrame = (cb) => {
+    queue.push(cb);
+    return queue.length;
+  };
+  const cancelled = [];
+  const container = { scrollTop: 100 };
+  let fired = false;
+  const cancel = observeScrollSettle(
+    container,
+    3,
+    () => {
+      fired = true;
+    },
+    scheduleFrame,
+    (id) => cancelled.push(id),
+  );
+  // Run one still frame (counter = 1), then cancel before it can reach k.
+  queue.shift()();
+  cancel();
+  // Any queued frame must be cancelled; draining it must be a no-op.
+  while (queue.length > 0) queue.shift()();
+  assert.equal(fired, false);
+  assert.ok(cancelled.length >= 1);
+});
+
+test("observeScrollSettle clamps sub-minimum quietFrames up to the default", () => {
+  // A caller passing quietFrames=1 would settle on the first still frame and
+  // read the freeze as a settle. The clamp forces the freeze-clearing minimum.
+  const { settledAt } = runSettle([100, 100, 100, 100], 1);
+  assert.equal(settledAt, DEFAULT_SETTLE_QUIET_FRAMES);
 });

--- a/desktop/src/features/messages/ui/useAnchoredScroll.ts
+++ b/desktop/src/features/messages/ui/useAnchoredScroll.ts
@@ -95,6 +95,20 @@ export type SettleGateOptions = {
  */
 export const DEFAULT_SETTLE_QUIET_FRAMES = 3;
 
+/**
+ * How recently a `scroll` event must have fired for the gate to treat the
+ * scroll as *in live motion* at layout-effect time. Live momentum emits a
+ * `scroll` event every frame (~16ms) continuously; a discrete one-shot
+ * `scrollTop` write emits a single event and then goes silent. A window a few
+ * frames wide cleanly separates "still fling" from "settled after a discrete
+ * jump" without a deferred sample — which is the requirement: the still-path
+ * must correct synchronously in the layout effect, paying zero painted frames
+ * of displacement, exactly as main does (Dawn's ruling on
+ * `timeline-no-shift.spec.ts:429`). A deferred rAF probe leaks one painted
+ * frame at full prepend height; a timestamp read does not.
+ */
+export const SETTLE_MOTION_WINDOW_MS = 100;
+
 type UseAnchoredScrollResult = {
   /** Pass through to the scroll container's `onScroll`. */
   onScroll: () => void;
@@ -291,6 +305,13 @@ export function useAnchoredScroll({
   // before its `onSettle` fires — otherwise a stale re-anchor could snap the
   // view after the user has already flung somewhere else.
   const settleObserverCancelRef = React.useRef<(() => void) | null>(null);
+  // Timestamp (ms) of the most recent `scroll` event, written in `onScroll`.
+  // The prepend re-anchor reads it synchronously at layout-effect time to
+  // decide still-vs-moving without a deferred sample (see
+  // `SETTLE_MOTION_WINDOW_MS`): a still scroll gets a synchronous, main-identical
+  // re-anchor (no displaced frame paints); only a live fling arms the async
+  // settle path.
+  const lastScrollTsRef = React.useRef(0);
   // Keep the latest settle-gate config in a ref so the layout effect can read
   // it without adding it to the dependency array (it must not re-run the
   // restoration logic just because the caller passed a new options object).
@@ -421,6 +442,10 @@ export function useAnchoredScroll({
   const onScroll = React.useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
+    // Record when this scroll event fired so the prepend re-anchor can read
+    // live-motion state synchronously at layout-effect time (settle gate).
+    lastScrollTsRef.current =
+      typeof performance !== "undefined" ? performance.now() : Date.now();
     // Row measurement can grow `scrollHeight` after a bottom pin and emit scroll
     // events while `scrollTop` holds at the old floor — opening a transient gap
     // above the true bottom. `computeAnchor` would read that as a deliberate
@@ -562,28 +587,47 @@ export function useAnchoredScroll({
       if (gate?.enabled) {
         // Settle gate on: the prepend re-anchor is the one mid-fling scroll
         // writer, and firing it against live user momentum is what produces the
-        // walk-blind jump. Defer it behind the polled quiet-window — apply the
-        // correction only once the scroll has been still for k consecutive
-        // frames (k clears WebKit's coalesced-freeze window; see
-        // `observeScrollSettle`). Supersede any correction still pending from a
-        // prior prepend so only the newest anchor is ever re-pinned.
+        // walk-blind jump. But deferral is only worth its cost under live
+        // momentum — when the reader is at rest there is no jerk to avoid, and
+        // deferring the correction (even by a single rAF) lets one frame paint
+        // at full prepend height, a visible jump the sampler catches (Dawn's
+        // ruling on `timeline-no-shift.spec.ts:429`). So decide still-vs-moving
+        // from a signal already known *here*, synchronously: the freshness of
+        // the last `scroll` event. Live momentum keeps `scroll` firing every
+        // frame; a discrete jump or a settled reader leaves the stamp stale.
+        // The window is a few frames wide so WebKit's ~2-frame coalesced freeze
+        // (the same physics the k≥3 clamp respects) cannot misread a live fling
+        // as still and fire the synchronous correction into real momentum.
         //
-        // A3 trade (stated in the PR body): this removes the mid-fling jerk by
-        // *deferring* the re-anchor to settle, which means the reading row can
-        // drift during the fling and snap back once at rest. The artifact the
-        // user feels moves from "jump mid-scroll" to "small settle-time
-        // adjustment"; it is a trade, not a free correction.
+        // Still ⇒ `applyReanchor()` inline, identical to main's synchronous
+        // commit — no displaced frame ever paints. Moving ⇒ defer behind the
+        // polled quiet window, superseding any correction still pending from a
+        // prior prepend so only the newest anchor is re-pinned.
+        //
+        // A3 trade (stated in the PR body): at rest the correction is
+        // synchronous and behaves exactly as main. Only under a live fling is
+        // the reading row held at full prepend height until the fling ends,
+        // then snapped back once at settle — confined to true flings, the only
+        // window the gate was ever meant to touch.
+        const now =
+          typeof performance !== "undefined" ? performance.now() : Date.now();
+        const moving = now - lastScrollTsRef.current < SETTLE_MOTION_WINDOW_MS;
         if (settleObserverCancelRef.current !== null) {
           settleObserverCancelRef.current();
+          settleObserverCancelRef.current = null;
         }
-        settleObserverCancelRef.current = observeScrollSettle(
-          container,
-          gate.quietFrames ?? DEFAULT_SETTLE_QUIET_FRAMES,
-          () => {
-            settleObserverCancelRef.current = null;
-            applyReanchor();
-          },
-        );
+        if (moving) {
+          settleObserverCancelRef.current = observeScrollSettle(
+            container,
+            gate.quietFrames ?? DEFAULT_SETTLE_QUIET_FRAMES,
+            () => {
+              settleObserverCancelRef.current = null;
+              applyReanchor();
+            },
+          );
+        } else {
+          applyReanchor();
+        }
       } else {
         applyReanchor();
       }

--- a/desktop/src/features/messages/ui/useAnchoredScroll.ts
+++ b/desktop/src/features/messages/ui/useAnchoredScroll.ts
@@ -49,7 +49,51 @@ type UseAnchoredScrollOptions = {
   /** When set, scroll to and highlight this message on mount and on change. */
   targetMessageId?: string | null;
   onTargetReached?: (messageId: string) => void;
+
+  /**
+   * Opt-in, default-off polled settle gate for the mid-history prepend
+   * re-anchor. When `enabled`, the prepend drift-correction (`scrollBy`) is
+   * deferred while a user fling is in progress and applied only once the scroll
+   * has quiesced — see {@link SettleGateOptions}. When absent/off, the timeline
+   * behaves byte-identically to main: the correction runs immediately on the
+   * prepend commit, as it always has.
+   */
+  settleGate?: SettleGateOptions;
 };
+
+/**
+ * Configuration for the polled quiet-window settle gate.
+ *
+ * The gate exists because there is no event-driven "user fling has ended"
+ * signal that survives WebKit's momentum-event coalescing — a debounce on
+ * `scroll` events starves on WebKit exactly when a fling is fastest. So we
+ * poll `scrollTop` on `requestAnimationFrame` and declare settle only after
+ * `quietFrames` *consecutive* frames of zero movement.
+ *
+ * Design edge (#1): WebKit freezes scroll-position reads for ~2 coalesced
+ * frames mid-fling. A gate that fires on the first still frame would read that
+ * freeze as "settled" and re-anchor mid-momentum — recreating the walk-blind
+ * jump this gate is meant to remove. `quietFrames` MUST exceed that freeze
+ * window; the default of 3 clears the ~2-frame freeze with one frame of margin.
+ * Tune against the classifier, not by eye.
+ */
+export type SettleGateOptions = {
+  /** Master switch. Off (or option omitted) ⇒ zero behavior change vs. main. */
+  enabled: boolean;
+  /**
+   * Consecutive zero-delta rAF frames required to declare the scroll settled.
+   * Must exceed WebKit's coalesced-freeze window (~2). Defaults to
+   * {@link DEFAULT_SETTLE_QUIET_FRAMES}.
+   */
+  quietFrames?: number;
+};
+
+/**
+ * Default consecutive-still-frame count for the settle gate. Chosen to clear
+ * WebKit's ~2-frame coalesced-freeze window (design edge #1) with a one-frame
+ * margin, so the gate never mistakes the freeze for a genuine settle.
+ */
+export const DEFAULT_SETTLE_QUIET_FRAMES = 3;
 
 type UseAnchoredScrollResult = {
   /** Pass through to the scroll container's `onScroll`. */
@@ -96,6 +140,65 @@ function isAtTrueBottom(
     container.scrollHeight - container.clientHeight - container.scrollTop <=
     TRUE_BOTTOM_THRESHOLD_PX
   );
+}
+
+/**
+ * Poll `container.scrollTop` on `requestAnimationFrame` and invoke `onSettle`
+ * once the position has held still for `quietFrames` *consecutive* frames.
+ *
+ * This is the settle gate's core. It exists because WebKit coalesces momentum
+ * `scroll` events, so an event-debounce never fires at the true end of a fling
+ * (design context in {@link SettleGateOptions}). Polling the position directly
+ * side-steps the event stream entirely: a fling is "over" when the number stops
+ * changing, and the consecutive-frame requirement is what makes it robust to
+ * WebKit's mid-fling ~2-frame position-read freeze — a single still frame is
+ * not enough, so the freeze cannot be mistaken for a settle.
+ *
+ * Returns a `cancel` function; call it if the observation is superseded (e.g. a
+ * newer prepend arrives, or the component unmounts) so the rAF loop stops and
+ * `onSettle` never fires for stale work.
+ */
+export function observeScrollSettle(
+  container: Pick<HTMLDivElement, "scrollTop">,
+  quietFrames: number,
+  onSettle: () => void,
+  scheduleFrame: (cb: () => void) => number = requestAnimationFrame,
+  cancelFrame: (id: number) => void = cancelAnimationFrame,
+): () => void {
+  // Guard: a non-positive frame count would settle instantly and defeat the
+  // gate's purpose. Clamp to the minimum that still clears the freeze window.
+  const required = Math.max(quietFrames, DEFAULT_SETTLE_QUIET_FRAMES);
+  let lastTop = container.scrollTop;
+  let stillFrames = 0;
+  let rafId: number | null = null;
+  let cancelled = false;
+
+  const tick = () => {
+    if (cancelled) return;
+    const top = container.scrollTop;
+    if (top === lastTop) {
+      stillFrames += 1;
+    } else {
+      stillFrames = 0;
+      lastTop = top;
+    }
+    if (stillFrames >= required) {
+      rafId = null;
+      onSettle();
+      return;
+    }
+    rafId = scheduleFrame(tick);
+  };
+
+  rafId = scheduleFrame(tick);
+
+  return () => {
+    cancelled = true;
+    if (rafId !== null) {
+      cancelFrame(rafId);
+      rafId = null;
+    }
+  };
 }
 
 /**
@@ -150,6 +253,7 @@ export function useAnchoredScroll({
 
   targetMessageId = null,
   onTargetReached,
+  settleGate,
 }: UseAnchoredScrollOptions): UseAnchoredScrollResult {
   // Anchor lives in a ref because it must survive renders and is updated
   // both on scroll (commit-time read) and in the layout effect (post-render
@@ -181,6 +285,17 @@ export function useAnchoredScroll({
   // ignores transient gaps and keeps chasing the floor. A `ref`, not state — the
   // guard runs on a native scroll event, outside React's render cycle.
   const settlingRef = React.useRef(false);
+  // Cancel handle for an in-flight settle observation armed by the prepend
+  // re-anchor while a fling is in progress (settle gate only). Held so a newer
+  // prepend, a channel switch, or unmount can supersede the pending correction
+  // before its `onSettle` fires — otherwise a stale re-anchor could snap the
+  // view after the user has already flung somewhere else.
+  const settleObserverCancelRef = React.useRef<(() => void) | null>(null);
+  // Keep the latest settle-gate config in a ref so the layout effect can read
+  // it without adding it to the dependency array (it must not re-run the
+  // restoration logic just because the caller passed a new options object).
+  const settleGateRef = React.useRef(settleGate);
+  settleGateRef.current = settleGate;
 
   // Reset everything when the channel changes — the layout effect that runs
   // immediately after this reset is responsible for either jumping to bottom
@@ -206,6 +321,10 @@ export function useAnchoredScroll({
     if (mountPinRafIdRef.current !== null) {
       cancelAnimationFrame(mountPinRafIdRef.current);
       mountPinRafIdRef.current = null;
+    }
+    if (settleObserverCancelRef.current !== null) {
+      settleObserverCancelRef.current();
+      settleObserverCancelRef.current = null;
     }
   }, [channelId]);
 
@@ -420,17 +539,53 @@ export function useAnchoredScroll({
       // observer's promise callback) because the prepended rows commit on a
       // deferred snapshot a few frames later, so the row's true position is only
       // known here.
-      const row = container.querySelector<HTMLElement>(
-        `[data-message-id="${CSS.escape(anchor.messageId)}"]`,
-      );
-      if (row) {
+      //
+      // Re-pin measured fresh at call time: find the anchored row, read its
+      // current top offset, and `scrollBy` the drift back to its saved offset.
+      // Deferred settle callers re-run this so they compensate the row's
+      // *settle-time* position, not a stale mid-fling measurement.
+      const applyReanchor = () => {
+        const currentRow = container.querySelector<HTMLElement>(
+          `[data-message-id="${CSS.escape(anchor.messageId)}"]`,
+        );
+        if (!currentRow) return;
         const currentTopOffset =
-          row.getBoundingClientRect().top -
+          currentRow.getBoundingClientRect().top -
           container.getBoundingClientRect().top;
         const drift = currentTopOffset - anchor.topOffset;
         if (Math.abs(drift) > 0.5) {
           container.scrollBy(0, drift);
         }
+      };
+
+      const gate = settleGateRef.current;
+      if (gate?.enabled) {
+        // Settle gate on: the prepend re-anchor is the one mid-fling scroll
+        // writer, and firing it against live user momentum is what produces the
+        // walk-blind jump. Defer it behind the polled quiet-window — apply the
+        // correction only once the scroll has been still for k consecutive
+        // frames (k clears WebKit's coalesced-freeze window; see
+        // `observeScrollSettle`). Supersede any correction still pending from a
+        // prior prepend so only the newest anchor is ever re-pinned.
+        //
+        // A3 trade (stated in the PR body): this removes the mid-fling jerk by
+        // *deferring* the re-anchor to settle, which means the reading row can
+        // drift during the fling and snap back once at rest. The artifact the
+        // user feels moves from "jump mid-scroll" to "small settle-time
+        // adjustment"; it is a trade, not a free correction.
+        if (settleObserverCancelRef.current !== null) {
+          settleObserverCancelRef.current();
+        }
+        settleObserverCancelRef.current = observeScrollSettle(
+          container,
+          gate.quietFrames ?? DEFAULT_SETTLE_QUIET_FRAMES,
+          () => {
+            settleObserverCancelRef.current = null;
+            applyReanchor();
+          },
+        );
+      } else {
+        applyReanchor();
       }
       if (!isPrepend) {
         setNewMessageCount((current) => current + messagesArrived);
@@ -522,6 +677,10 @@ export function useAnchoredScroll({
     return () => {
       if (highlightTimeoutRef.current !== null) {
         window.clearTimeout(highlightTimeoutRef.current);
+      }
+      if (settleObserverCancelRef.current !== null) {
+        settleObserverCancelRef.current();
+        settleObserverCancelRef.current = null;
       }
     };
   }, []);

--- a/preview-features.json
+++ b/preview-features.json
@@ -40,6 +40,14 @@
       "platforms": [
         "desktop"
       ]
+    },
+    {
+      "id": "settleGate",
+      "name": "Scroll settle gate",
+      "description": "Defer the mid-history re-anchor until scrolling settles (k consecutive still frames) instead of correcting mid-fling — smoother momentum scrolling on WebKit. At rest, identical to today; only under a live fling is the reading row held until the fling ends, then snapped once at settle.",
+      "platforms": [
+        "desktop"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Polled settle gate for the mid-history prepend re-anchor (default-off)

Third independent try at the WebKit-in-Tauri smooth-scroll problem, per Tyler's
directive and Eva's PR-3 lane. **No library refactor** — keeps the current-main
timeline (native `overflow-anchor`, every row in the DOM) and gates its one
mid-fling scroll writer.

## The problem this targets

Main holds reading position across prepend/reflow with native scroll anchoring.
But at the top edge — `scrollTop ~0`, no anchor node above the viewport — the
browser does **not** correct a prepend, so `useAnchoredScroll` re-pins the
anchored row by hand: `scrollBy(0, drift)` in the post-commit layout effect.
That is main's single mid-fling scroll writer. When an older-history prepend
commits *while the user is flinging*, it fires against live momentum → the
walk-blind position jump.

There is no event-driven "fling ended" signal to gate it on. WebKit coalesces
momentum `scroll` events off the scrolling thread, so a debounce on `scroll`
starves exactly when the fling is fastest — the mechanism pinned in Lane C.

## The gate

Opt-in, **default-off** via the `settleGate` preview feature (Settings →
Experiments; `preview-features.json` + `useFeatureEnabled` — the same switch the
other lanes' features use). The re-anchor is gated on **whether the scroll is in
live motion at re-anchor time**:

- **At rest** (no `scroll` event within a short freshness window): the re-anchor
  runs **synchronously in the layout effect, exactly as main does** — no frame
  ever paints at the displaced position.
- **Under a live fling**: the re-anchor is **deferred** behind
  `observeScrollSettle`, which polls `container.scrollTop` on
  `requestAnimationFrame` and declares settle only after **k consecutive
  zero-delta frames**, then **re-measures drift at settle time** so it
  compensates the row's resting position, not a stale mid-fling read.

The still-vs-moving decision reads a signal already known at layout-effect time —
`onScroll` stamps `lastScrollTsRef` on every scroll event, and the re-anchor
checks `now - lastScrollTs < SETTLE_MOTION_WINDOW_MS`. This is deliberate: any
deferred sample (even a single rAF) would let one frame paint at full prepend
height before the correction, a visible jump at rest. A timestamp read costs
zero frames. A newer prepend, channel switch, or unmount cancels any pending
correction, so only the freshest anchor is re-pinned.

### Design edge #1 — k must clear the coalesced freeze

WebKit freezes `scrollTop` reads for ~2 coalesced frames mid-fling (the
walk-blind #1662 mechanism). A gate that fired on the first still frame would
read that freeze as "settled" and re-anchor mid-momentum — recreating the bug.
**Default k=3** clears the ~2-frame freeze with one frame of margin, and
`observeScrollSettle` **clamps any caller value up to that floor** so a
mis-tuned k can never regress below it. The same physics constrains the motion
window: `SETTLE_MOTION_WINDOW_MS` (~6 frames) is set **wider than the freeze**,
so a coalesced gap in the `scroll` stream cannot misread a live fling as "still"
and fire the synchronous correction into real momentum. A unit test scripts the
exact `[still, still, resume, resume, rest…]` sequence and asserts the gate does
not fire during the freeze.

### Design edge #2 — the A3 trade (what Tyler should feel)

The refinement **deletes the at-rest artifact entirely** rather than shrinking
it. The honest felt characterization is now two cases, not one:

- **At rest: identical to main.** No displaced frame ever paints; the re-anchor
  is a synchronous same-commit correction, byte-for-byte main's behavior.
- **Under a live fling:** the re-anchor is deferred to settle. The reading row is
  pushed by the **full prepended height** and held there until the fling ends,
  then snaps back once at rest — **one snap at settle**, its size scaling with
  the prepend.

So the trade is confined to true flings — the only window the gate was ever
meant to touch — and is a **mid-fling jerk traded for a single settle-time
snap**, not a uniformly "small" nudge. Deliberate trade, eyes open.

## Scope & safety

- Default-off ⇒ **the default-off runtime path is unchanged from main**: no
  behavior change with the flag off — the re-anchor runs immediately on the
  prepend commit exactly as main does (the 25/25 contract tier attests this).
  ("Byte-identical" is not literally true of a branch that adds the gate code;
  what's identical is the flag-off execution path.)
- **No raw `scrollTop` writes** as seam fixes — reuses the existing
  `scrollBy` / `getBoundingClientRect` measure.
- To try it: Settings → Experiments → **Scroll settle gate**. No branch checkout,
  no build flag.

## Gate-on contract: how the top tier is cleared

Enabling the `settleGate` preview feature flips it on in the e2e bridge (which
force-enables **all** preview features), so the contract tier exercises the
gate-on path by construction — the bridge co-tests every lane's ON path, which
is what surfaced the finding below rather than letting it hide behind
default-off.

`timeline-no-shift.spec.ts:429` ("prepend + late reflow keeps the reading row
stable") samples the reading row's painted drift **every frame across the
prepend** (rAF fires post-paint, so it measures what the eye sees) and asserts
`maxDrift ≤ 20px`. Its scenario lands the prepend **at rest** — one wheel
impulse, a 100ms wait, then a hard `scrollTop` assignment with no further scroll
events through the sampled window.

An earlier defer-always version of the gate red-lined this at **maxDrift =
3400px**: at rest it still deferred the correction, so one frame painted at full
prepend height. Dawn's ruling on `:429`: at rest, *"never paints a displaced
frame"* **is** the user-facing behavior the test asserts; synchronous-commit is
main's means, not the assertion — so the red stood, and the fix belonged in the
gate, not the probe. The synchronous at-rest path above is that fix. Gate-on now
reads **maxDrift = 18px** with **no test change**.

### Follow-up: the momentum-only deferral is real but unexercised

Under a **genuine live fling**, the gate still defers, and the row is held at
full prepend height until settle. **No current top-tier test asserts behavior in
that window** — `:429` is the at-rest case. Whether continuous sub-20px drift
*during live momentum* is a behavior contract (the red would stand, gate must
narrow scope) or asserts main's synchronous-commit *mechanism* (a flagged probe
rewrite sampling at settle would be warranted) is real law, but presently
unexercised. If a mid-fling contract test is ever wanted, it gets the
settle-sampled shape from birth; `:429` is not rewritten to reach it. Stated
here so the trade is honest about what it is and isn't tested against.

## Validation

- **Behavior-contract top tier** (Dawn's three tiers): `timeline-no-shift`
  contract file — **5/5 green with the gate ON** (bridge force-enables it),
  incl. `:429` at maxDrift 18px. Default-off stays main-identical.
- **Unit**: `observeScrollSettle` — 7 tests, incl. the coalesced-freeze
  survival case, counter-reset, cancel, and the k-clamp. Green.
- `tsc` + `biome` clean.

## Classifier advisory

Sami's portable DOM classifier (`sami/portable-classifier`, impl-agnostic — no
hook stamp, reads a settle-gate build the same way it reads main) ran a
four-cell A/B on the lane's real exercise path.

**Fixture correction — the load-bearing caveat.** The first fixture never reached
this gate: it seeded rows into the *already-loaded* window and never triggered a
`fetchOlder` older-history prepend, so `messages[0].id` never changed and the
gated re-anchor never armed — an instrument-blind null, not a result. The fix
uses the built-in **`deep-history` channel** (600 seeded → windows to newest 300,
~300 genuinely older behind the `until` cursor), so wheeling up drives a real
`fetchOlder` prepend that fires the re-anchor mid-fling. Arming was **verified**
(oldest rendered `#550 → #500`, one prepend cycle per run, ~1800 scored anchor
pairs) before trusting any number.

| Engine   | Leg            | bites | bite-max px | mid-mom |
|----------|----------------|-------|-------------|---------|
| chromium | baseline (off) |  44   |   112.0     |   0     |
| chromium | candidate (on) |  22   |    14.0     |   0     |
| webkit   | baseline (off) |  56   |    14.5     |   1     |
| webkit   | candidate (on) |  54   |    14.5     |   1     |

**Split verdict, exactly along the pre-registered honesty bound:**

- **Chromium: real, strong improvement.** Gate halves bite count (44→22) and
  eliminates the violent snap (max 112→14px) — the single big −112px mid-fling
  re-anchor jerk is gone gate-on, co-gate passes (count *and* max both down).
- **WebKit: near-parity** (56→54, 14.5→14.5). The gate barely moves because the
  large re-anchor snap chromium baseline shows (112px) **never manifests on
  WebKit baseline under Playwright** (max already 14.5) — Playwright-WebKit does
  not reproduce the coalesced-freeze/large-snap a real trackpad does, so the gate
  has nothing large to defer here. This is the honesty bound: **WebKit-under-
  Playwright is not the acceptance gate — Tyler's trackpad is.** The deterministic
  k=3 freeze-survival proof lives in the scripted `[still,still,resume,resume,
  rest×3]` unit test, which proves the *mechanism* even when the browser drive
  can't reproduce the freeze; this fixture reads the *system* deferral, not the
  freeze itself.
- **Caveat: n=1 prepend cycle per run** — direction unambiguous, count thin. A
  mid-velocity drive (several prepends while staying trackable) would tighten N.

*Numbers measured on the branch-pair A/B (`041d72a6` off vs `49464ffd` on).
Sami verified `041d72a6` reads the gate from a prop, so the single-binary flag
path (`settleGate` on/off) exercises the same writer; a re-confirm on the
refined tip `c4176a6e` is queued and expected to hold.*

---


## Why this PR doesn't try to read a "truer" scroll offset

Before building this timeline, we tested a tempting alternative: instead of
changing *how* the list writes scroll position, just *read* a better one. The
WebKit jank we're fixing shows up as a frozen `scrollTop` — during momentum
scrolling, WebKit's async/compositor scroll can hold `scrollTop` still for ~2
frames while the visible pixels keep moving. So the arm was: find a JS-readable
signal that reflects the *committed* (visually-real) offset when `scrollTop` is
stale, and anchor rows against that instead.

**This is a documented dead end, and the reason matters for reading the PR.**

We built a per-frame census (branch `quinn/committed-offset-arm`) that samples
every candidate committed-offset signal each animation frame, isolates the exact
frames where `scrollTop` is frozen yet a row still jumps against the scroll (no
layout reflow moved it), and asks: *did anything read a non-zero delta on that
frame?* A liveness control counts how often each signal moves across the whole
run, so we can tell "dead API" apart from "live but frozen exactly when we need
it."

WebKit result, on the 23 frozen frames:

```
LIVENESS (deltas across the whole run, /688):
  scrollTop moved:                   230
  ScrollTimeline.currentTime moved:  258   ← LIVE, finer than scrollTop
  visualViewport.offsetTop/pageTop:    0   (tracks visual viewport, not the scroller)

on the 23 FROZEN frames, non-zero delta:
  ScrollTimeline.currentTime:  0/23   ← LIVE signal, FROZEN exactly here
  visualViewport.offsetTop:    0/23
  visualViewport.pageTop:      0/23
```

`ScrollTimeline.currentTime` is the decisive one: it's demonstrably **live** —
it advanced on *more* frame-pairs than `scrollTop` (258 vs 230), because it
reports sub-pixel commits that `scrollTop` rounds off, and W3C designed it to be
compositor-driven. Yet it froze on **0 of the 23** frames the arm needed it.
Every offset-derived signal freezes in lockstep with `scrollTop`.

**The conclusion, which both timeline approaches rest on:**

> WebKit's async scroll doesn't merely stall the `scrollTop` *read* — it stalls
> the **committed offset itself**, the shared quantity every scroll-offset API
> reads from. There is no truer offset for JS to read during the freeze.

The only value that *did* move on frozen frames was a mounted row's
`getBoundingClientRect().top` — but that motion is WebKit's own scroll-anchoring
nudging layout, i.e. the symptom we're trying to cancel. Reading it to correct
itself is circular.

So the fix cannot be "read a better number." Any viable approach has to
**defer the scroll write until scrolling settles**, rather than try to correct
against a live position mid-fling — because no live, truer position is exposed
to JS during the freeze. That's the design constraint every candidate in this
effort was measured against.

One calibration on where this fits in the classifier evidence: the "bite"
metric our runs report is a **shared cross-engine impl cost** — Chromium and
WebKit baselines both score it (~22–25 at 60.0), and a JS-free native-scroll
null control scores 0 on both, so it's caused by our render/anchoring impl, not
by WebKit specifically. The WebKit-specific feel gap Tyler is reporting isn't
in that column; it rides on the **momentum-window behavior** — the frozen
committed offset documented above. That's exactly why the fix has to defer the
write until scrolling settles: the thing that hurts on a trackpad happens
*during* the fling, in the window where no readable offset exists.

**One bound on how wide this kill reaches.** This result kills reading a truer
*offset* — it does not, by itself, prove that *no* JS-side settle signal can
survive WebKit's coalescing. It kills the class of gates that ask WebKit
*"what's the committed position right now?"* (offset APIs — frozen) and, by the
same coalescing silence, the class that asks *"am I still scrolling?"* through
scroll **events** (event-driven debounces starve when WebKit stops dispatching
mid-fling — see Lane A's Virtuoso run). What it leaves open is a narrower
question that needs less than offset correctness: *"did the position change at
all in the last k frames?"*, polled per-`rAF`. The same liveness census above
shows `scrollTop` still advancing on 230/688 rAF pairs with freezes lasting only
~2 frames — so a **polled quiet-window gate** (k consecutive zero-delta rAF
frames, k chosen above the freeze length) reads commits that fire no events and
could bridge the silence that lapses an event debounce. One scope note this arm
carries, now that Lane A has pinned the mechanism to source: a polled
quiet-window gate reaches **both** terms of Virtuoso's mid-momentum floor
mechanically — including the both-engine term, whose realization-compensation
writer consults only Virtuoso's *programmatic-scroll* flag and no user-scroll
signal at all, so a polled settle signal is new information it isn't using. But
reaching it is not the same as a free win: that both-engine term is contract-A3
compensation — re-anchoring to hold the reading position when a row above the
reading row reflows — so routing it behind the gate is a **deliberate trade**,
deferring the anchor correction to settle (a momentum jerk exchanged for a
settle-time reading-position jump), not a cost that vanishes. So the follow-up
arm is scoped as **a polled quiet-window gate plus a deliberate decision about
which compensation writes to route behind it** — see Lane A's mechanism section
for the two-writer breakdown. It also means the classifier's mid-momentum column
partially scores A3 *compliance* as a defect; which artifact the user should
feel is a product call, and per Tyler's directive his trackpad is the judge.
That's untested and not tried in either PR — it's the named follow-up if the
trackpad still says no, not a claim that it works. The bounded statement both
bodies can rest on: **no event-driven settle signal survives WebKit's
coalescing** — full stop there.

*(Full census + finding: `RESEARCH/WEBKIT_COMMITTED_OFFSET_ARM_KILL_2026_07_09.md`,
branch `quinn/committed-offset-arm`. Numbers are from Playwright WebKit; the
fully-developed coalesced-momentum still-frame is a device phenomenon best
judged on a real trackpad — but the mechanism result, a live compositor signal
freezing in lockstep, does not depend on momentum magnitude.)*
