### PR TITLE
feat(desktop): eagerTimelineLayout preview — lay out fetched rows immediately (no content-visibility skipping)

### DIFF
--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -22,6 +22,7 @@ import { canManageMessageForCurrentUser } from "@/features/messages/lib/canManag
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ChannelType } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { useFeatureEnabled } from "@/shared/features";
 import { DayDivider } from "./DayDivider";
 import { MessageRow } from "./MessageRow";
 import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
@@ -115,6 +116,12 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
   threadUnreadCounts,
   unfollowThreadById,
 }: TimelineMessageListProps) {
+  // eagerTimelineLayout preview: opt every row out of content-visibility
+  // skipping so the full fetched window lays out immediately at exact heights
+  // (no estimate→true re-realization, and none of the anchored-scroll
+  // corrections it forces, during scrolling).
+  const eagerTimelineLayout = useFeatureEnabled("eagerTimelineLayout");
+
   const entries = React.useMemo(
     () =>
       mainEntries ??
@@ -277,7 +284,10 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
           )}
           {group.items.map((item) => (
             <div
-              className="timeline-row-cv"
+              className={cn(
+                "timeline-row-cv",
+                eagerTimelineLayout && "timeline-row-cv-eager",
+              )}
               key={getTimelineItemKey(item)}
               style={timelineRowReserveStyle(item)}
             >

--- a/desktop/src/shared/styles/globals/utilities.css
+++ b/desktop/src/shared/styles/globals/utilities.css
@@ -22,6 +22,15 @@
     content-visibility: visible;
   }
 
+  /* eagerTimelineLayout preview: realize every fetched row's layout up front.
+     Heights are exact from first paint, so scrolling never triggers the
+     estimate→true height re-realization (and the anchored-scroll position
+     corrections it forces). The reserve style stays on the wrapper but is
+     inert without size containment. */
+  .timeline-row-cv.timeline-row-cv-eager {
+    content-visibility: visible;
+  }
+
   .content-visibility-auto-interactive {
     content-visibility: auto;
     contain-intrinsic-size: auto 200px;

--- a/desktop/tests/e2e/timeline-no-shift.spec.ts
+++ b/desktop/tests/e2e/timeline-no-shift.spec.ts
@@ -562,6 +562,11 @@ test("de-virtualized timeline rows apply content-visibility", async ({
 }, testInfo) => {
   testInfo.setTimeout(45_000);
 
+  // The e2e bridge opts every preview feature in, so `eagerTimelineLayout`
+  // is ON here: rows must compute `visible` (eagerly laid out). The
+  // flag-off spec below covers the default `auto` path. Both guard against
+  // a typo'd/removed wrapper class shipping inert — a bad utility name is
+  // invisible to typecheck.
   await installMockBridge(page);
   await page.goto("/");
   await waitForMockTimelineBridge(page);
@@ -573,22 +578,46 @@ test("de-virtualized timeline rows apply content-visibility", async ({
   const timeline = page.getByTestId("message-timeline");
   await expect(timeline.locator("[data-message-id]").first()).toBeVisible();
 
-  // Guards against a typo'd/removed wrapper class shipping inert — a bad
-  // utility name is invisible to typecheck.
-  const hasContentVisibility = await timeline
+  expect(await firstRowContentVisibility(timeline)).toBe("visible");
+});
+
+test("timeline rows skip offscreen layout when eager layout is off", async ({
+  page,
+}, testInfo) => {
+  testInfo.setTimeout(45_000);
+
+  await installMockBridge(page, undefined, { seedPreviewFeatures: false });
+  await page.goto("/");
+  await waitForMockTimelineBridge(page);
+  await seedNoShiftTimeline(page);
+
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const timeline = page.getByTestId("message-timeline");
+  await expect(timeline.locator("[data-message-id]").first()).toBeVisible();
+
+  expect(await firstRowContentVisibility(timeline)).toBe("auto");
+});
+
+/** Computed `content-visibility` of the first message row's `timeline-row-cv`
+ *  wrapper, or "missing" when no wrapper is found between row and scroller. */
+function firstRowContentVisibility(timeline: Locator): Promise<string> {
+  return timeline
     .locator("[data-message-id]")
     .first()
     .evaluate((element) => {
       const scroller = element.closest('[data-testid="message-timeline"]');
       let node: HTMLElement | null = element.parentElement;
       while (node && node !== scroller) {
-        if (getComputedStyle(node).contentVisibility === "auto") return true;
+        if (node.classList.contains("timeline-row-cv")) {
+          return getComputedStyle(node).contentVisibility;
+        }
         node = node.parentElement;
       }
-      return false;
+      return "missing";
     });
-  expect(hasContentVisibility).toBe(true);
-});
+}
 
 test("thread panel late row reflow keeps the reading reply stable", async ({
   page,

--- a/preview-features.json
+++ b/preview-features.json
@@ -40,6 +40,14 @@
       "platforms": [
         "desktop"
       ]
+    },
+    {
+      "id": "eagerTimelineLayout",
+      "name": "Eager timeline layout",
+      "description": "Lay out every fetched message row immediately instead of skipping offscreen rows (content-visibility). Heights are exact from the start, so scrolling never triggers height re-realizations or position corrections mid-fling — at the cost of a one-time layout of the full loaded window.",
+      "platforms": [
+        "desktop"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

New `eagerTimelineLayout` preview feature (default **off**): when enabled, every fetched message row is laid out **immediately** — timeline rows opt out of `content-visibility: auto` skipping, so the full loaded window realizes at exact heights at commit time instead of pay-as-you-scroll.

Standalone off `main`, independent of the Virtuoso (#1672-lane), TanStack, and polled-settle-gate (#1676) drafts. Try each individually.

## Why (the lazy-layout angle)

Fetched pages already mount fully into the DOM — no virtualizer since #1338, and the per-row markdown parse is paid eagerly at the deferred commit from #1022. What's *not* eager is layout: each row wears `content-visibility: auto` plus a heuristic `contain-intrinsic-size` reserve (`rowHeightEstimate.ts`). Offscreen rows skip layout until they scroll near the viewport, then realize at their **true** height.

Estimate ≠ truth. Every realization during a fling changes `scrollHeight` above the viewport, and `useAnchoredScroll` compensates — the same compensation-write family behind the trackpad complaints. #1676 gates **when** those writes happen; this flag removes **why the heights change at all** for already-loaded history: heights are exact from first paint, so scrolling triggers zero re-realizations and zero corrections.

**Cost (disclosed):** one-time layout of the full loaded window (~50 rows/page, grows with scrollback) at commit instead of amortized over scrolling. Channel-entry cost rides the existing `useDeferredValue` low-priority commit, so it yields to input — but a very deep session window is laid out in one pass. That trade is the point of the experiment; your trackpad judges both ends.

## Mechanics (4 files, +64/−8)

- `preview-features.json` — new `eagerTimelineLayout` entry (desktop). **Flip it: Settings → Experiments → "Eager timeline layout".**
- `TimelineMessageList.tsx` — rows add `timeline-row-cv-eager` when the flag is on. The reserve style stays on the wrapper (inert without size containment), so flag-off is byte-identical to main.
- `utilities.css` — `.timeline-row-cv.timeline-row-cv-eager { content-visibility: visible; }`.
- `timeline-no-shift.spec.ts` — the wiring guard now asserts the eager path (the e2e bridge opts every preview feature in, per arc law), and a new sibling spec with `seedPreviewFeatures: false` pins the default `auto` path.

## Classifier numbers (ADVISORY — per arc law, the trackpad is the judge)

Portable classifier frozen at `sami/portable-classifier` `5e5bd4a5` (+ null control `c4c82963`), same corpus, same built-bundle methodology, run at this tip:

| engine | config | post-momentum bites | bite max px | momentum frames |
|---|---|---|---|---|
| chromium | flag OFF (≡ main) | 19 | 60.0 | 226 |
| chromium | flag ON | **0** | **0.0** | 223 |
| webkit | flag OFF (≡ main) | 22 | 60.0 | 236 |
| webkit | flag ON | **0** | **0.0** | 237–238 |

Flag-ON repeated twice per engine — stable at 0/0.0 with healthy momentum-frame populations (the null control established there is no instrument floor, so bite→0 is a real result, not saturation). Reversal frames and tracking-failure counts also go 19–22 → 0 on both engines. The bite column is engine-independent impl cost; the WebKit-specific feel gap additionally rides the frozen-offset stall documented in the #1676 Lane C section — this PR removes the height-change *input* to that machinery rather than gating its writes.

## Verification

- typecheck, biome, 2217/2217 unit tests
- `timeline-no-shift` 6/6 (incl. new flag-OFF spec), `scroll-history` + `overscroll-boundary` + `channel-window-mock-paging` + `live-broadcast-reply-timeline` 20/20, `messaging` 31/31 — all against the built bundle with previews forced ON
- Flag-off path pinned by e2e: rows compute `content-visibility: auto` exactly as on main

## Follow-ups if this wins

- Delete `rowHeightEstimate.ts` + the reserve plumbing outright (kept here so flag-off stays byte-identical)
- Decide whether the `:hover`/`:focus-within` un-pause rule and #1354's action-bar clip workaround are still needed
