### PR TITLE
fix(desktop): isolate dev keyring from production and make BUZZ_SHARE_IDENTITY keyring-aware

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -95,6 +95,9 @@ const overrides = new Map([
   // unified-agent-model 1A.1: inline test module moved to nest/tests.rs,
   // ratcheting 1575 -> 679 (under the 1000 default; entry kept as a ratchet).
   ["src-tauri/src/managed_agents/nest.rs", 679],
+  // keyring-dev-isolation: agent key migration added copy_agent_keys_between_stores
+  // and load_readonly support; file grew past 1000 default. Queued to split.
+  ["src-tauri/src/managed_agents/storage.rs", 1145],
   // harness-persona-sync: persona-runtime resolution threaded into the spawn
   // path here. Load-bearing feature growth; queued to split in the resolver
   // unify refactor followup. +26 for resolve_effective_prompt_model_provider
@@ -213,7 +216,7 @@ const overrides = new Map([
   // cross-process keychain race fix (D3): interprocess lock + BlobLockGuard +
   // uid-keyed lockfile path + behavioral tests add ~303 lines. Load-bearing
   // security fix for the lost-update race that stranded agent keys.
-  ["src-tauri/src/secret_store.rs", 1043],
+  ["src-tauri/src/secret_store.rs", 1075],
   // keyring-dev-isolation: keyring_service() fn (7 lines) replaces the const
   // to return "buzz-desktop-dev" in debug builds. Load-bearing isolation fix.
   ["src-tauri/src/app_state.rs", 1042],

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -214,7 +214,7 @@ const overrides = new Map([
   // uid-keyed lockfile path + behavioral tests add ~303 lines. Load-bearing
   // security fix for the lost-update race that stranded agent keys.
   ["src-tauri/src/secret_store.rs", 1043],
-  // keyring-dev-isolation: keyring_service() fn (9 lines) replaces the const
+  // keyring-dev-isolation: keyring_service() fn (7 lines) replaces the const
   // to return "buzz-desktop-dev" in debug builds. Load-bearing isolation fix.
   ["src-tauri/src/app_state.rs", 1042],
   // multi-slot splitting + no-op suppression (#1309): the ReadStateManager

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -214,7 +214,9 @@ const overrides = new Map([
   // uid-keyed lockfile path + behavioral tests add ~303 lines. Load-bearing
   // security fix for the lost-update race that stranded agent keys.
   ["src-tauri/src/secret_store.rs", 1043],
-  ["src-tauri/src/app_state.rs", 1033],
+  // keyring-dev-isolation: keyring_service() fn (9 lines) replaces the const
+  // to return "buzz-desktop-dev" in debug builds. Load-bearing isolation fix.
+  ["src-tauri/src/app_state.rs", 1042],
   // multi-slot splitting + no-op suppression (#1309): the ReadStateManager
   // class grew from ~700 lines to ~1019 with the addition of
   // splitContextsIntoBudgetedSlots (pure fn + 5 tests), publishSplitSlots,

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -97,7 +97,7 @@ const overrides = new Map([
   ["src-tauri/src/managed_agents/nest.rs", 679],
   // keyring-dev-isolation: agent key migration added copy_agent_keys_between_stores
   // and load_readonly support; file grew past 1000 default. Queued to split.
-  ["src-tauri/src/managed_agents/storage.rs", 1145],
+  ["src-tauri/src/managed_agents/storage.rs", 1325],
   // harness-persona-sync: persona-runtime resolution threaded into the spawn
   // path here. Load-bearing feature growth; queued to split in the resolver
   // unify refactor followup. +26 for resolve_effective_prompt_model_provider
@@ -195,7 +195,8 @@ const overrides = new Map([
   // + inner fn with baked-env gate + 26 tests. Load-bearing correctness fix.
   // am review fix: also clear stale V1 model field on provider rewrite +
   // new model-clear test. Load-bearing chimera fix.
-  ["src-tauri/src/migration.rs", 1402],
+  // keyring-dev-isolation: run_boot_migrations wires agent-key migration.
+  ["src-tauri/src/migration.rs", 1415],
   // onMarkRead + isUnread prop threading (mirrors the onMarkUnread prop
   // already here) for the single-toggle mark-read/unread menu item — a small
   // overage from load-bearing per-message plumbing, not generic debt growth.
@@ -216,7 +217,7 @@ const overrides = new Map([
   // cross-process keychain race fix (D3): interprocess lock + BlobLockGuard +
   // uid-keyed lockfile path + behavioral tests add ~303 lines. Load-bearing
   // security fix for the lost-update race that stranded agent keys.
-  ["src-tauri/src/secret_store.rs", 1075],
+  ["src-tauri/src/secret_store.rs", 1110],
   // keyring-dev-isolation: keyring_service() fn (7 lines) replaces the const
   // to return "buzz-desktop-dev" in debug builds. Load-bearing isolation fix.
   ["src-tauri/src/app_state.rs", 1042],

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -184,7 +184,16 @@ pub fn resolve_persisted_identity(app: &AppHandle, state: &AppState) -> Result<(
 
 /// Service name for the desktop OS keyring. Shared by the human identity key
 /// and managed-agent keys (each addressed by a distinct key name within it).
-pub(crate) const KEYRING_SERVICE: &str = "buzz-desktop";
+///
+/// Debug builds use a distinct service name so dev and production keyring
+/// entries never collide on the same machine.
+pub(crate) fn keyring_service() -> &'static str {
+    if cfg!(debug_assertions) {
+        "buzz-desktop-dev"
+    } else {
+        "buzz-desktop"
+    }
+}
 
 /// Keyring key name for the human identity nsec.
 const IDENTITY_KEY_NAME: &str = "identity";
@@ -238,7 +247,7 @@ fn load_or_create_identity(data_dir: &std::path::Path) -> Result<Keys, String> {
         return load_file_or_generate(&legacy_path, data_dir);
     }
 
-    let store = crate::secret_store::SecretStore::shared(KEYRING_SERVICE);
+    let store = crate::secret_store::SecretStore::shared(keyring_service());
     resolve_identity_with_store(store, &legacy_path, data_dir)
 }
 

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -6,7 +6,7 @@ use std::{
 
 use tauri::{AppHandle, Manager};
 
-use crate::app_state::KEYRING_SERVICE;
+use crate::app_state::keyring_service;
 use crate::managed_agents::ManagedAgentRecord;
 use crate::secret_store::{KeyringProbe, SecretStore};
 
@@ -23,7 +23,7 @@ fn agent_keyring_name(pubkey: &str) -> String {
 /// races on concurrent blob writes.
 fn agent_secret_store() -> Option<&'static SecretStore> {
     if cfg!(feature = "system-keyring") {
-        Some(SecretStore::shared(KEYRING_SERVICE))
+        Some(SecretStore::shared(keyring_service()))
     } else {
         None
     }

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fs::{self, File, OpenOptions},
     io::{Read as _, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
@@ -64,9 +65,15 @@ trait KeyStore {
     /// Read a key without any side effects (no legacy-key migration, no writes).
     /// `Ok(None)` when the blob or the key is absent; `Err` only on backend failure.
     fn load_readonly(&self, name: &str) -> Result<Option<String>, String>;
+    /// Read the entire blob as a map without any side effects.
+    /// `Ok(None)` when no blob exists yet; `Err` only on backend failure.
+    /// Callers must not call `migrate_legacy_key` — this is a read-only view.
+    fn load_all_readonly(&self) -> Result<Option<HashMap<String, String>>, String>;
     /// Write `value` and read it back to confirm before the caller strips the
     /// inline copy.
     fn write_and_verify(&self, name: &str, value: &str) -> Result<(), String>;
+    /// Insert all entries from `entries` in a single blob mutation.
+    fn store_all(&self, entries: &HashMap<String, String>) -> Result<(), String>;
 }
 
 impl KeyStore for SecretStore {
@@ -79,12 +86,18 @@ impl KeyStore for SecretStore {
     fn load_readonly(&self, name: &str) -> Result<Option<String>, String> {
         SecretStore::load_readonly(self, name)
     }
+    fn load_all_readonly(&self) -> Result<Option<HashMap<String, String>>, String> {
+        SecretStore::load_all_readonly(self)
+    }
     fn write_and_verify(&self, name: &str, value: &str) -> Result<(), String> {
         self.store(name, value)?;
         match self.load(name)? {
             Some(stored) if stored == value => Ok(()),
             _ => Err("keyring read-back verify failed".to_string()),
         }
+    }
+    fn store_all(&self, entries: &HashMap<String, String>) -> Result<(), String> {
+        SecretStore::store_all(self, entries)
     }
 }
 
@@ -410,44 +423,80 @@ pub fn migrate_agent_keys_to_dev_service(app: &tauri::AppHandle) {
     copy_agent_keys_between_stores(&pubkeys, &prod_store, dev_store);
 }
 
+/// Marker key stored inside the dev blob after a successful agent-key migration.
+/// Its presence means all agent keys that existed in the prod service at
+/// migration time have been copied; subsequent dev boots skip the migration
+/// entirely (no prod keyring access).
+#[cfg(debug_assertions)]
+const DEV_MIGRATION_MARKER: &str = "_dev_migration_v1";
+
 /// Testable core of [`migrate_agent_keys_to_dev_service`]: copy `agent:<pubkey>`
-/// entries from `src` to `dst` for each pubkey, skipping entries that already
-/// exist in `dst` (idempotency) and entries absent from `src` (new agents that
-/// will mint fresh keys). Does NOT copy `"identity"`.
+/// entries from `src` to `dst` for each pubkey, then write a migration-complete
+/// marker so future boots skip the entire function with zero prod-keyring access.
+///
+/// On the first migration boot:
+///   1. One `dst.load_all_readonly()` — dev blob read (1 keychain prompt)
+///   2. One `src.load_all_readonly()` — prod blob read (1 keychain prompt)
+///   3. One `dst.store_all()` — dev blob write (same service as #1; macOS may
+///      skip the ACL prompt if the initial grant was "Always Allow")
+///
+/// On subsequent boots (marker already present):
+///   1. One `dst.load_all_readonly()` — dev blob read (1 keychain prompt)
+///   Returns immediately — prod keyring is NEVER accessed.
+///
+/// Idempotency: keys already present in `dst` are not overwritten (the agent
+/// may have rotated their key in the dev service after initial migration).
+/// New agents (pubkey not in `src`) are silently skipped — they will mint a
+/// fresh key on their next onboarding run.
 #[cfg(debug_assertions)]
 fn copy_agent_keys_between_stores(pubkeys: &[String], src: &impl KeyStore, dst: &impl KeyStore) {
+    // One read of the dev blob. If the migration-complete marker is present,
+    // all prior agent keys are already in the dev service — skip entirely.
+    let dst_map: HashMap<String, String> = match dst.load_all_readonly() {
+        Ok(Some(map)) if map.contains_key(DEV_MIGRATION_MARKER) => {
+            return; // already migrated: 0 prod keyring accesses
+        }
+        Ok(Some(map)) => map,
+        Ok(None) => HashMap::new(),
+        Err(e) => {
+            eprintln!("buzz-desktop: keyring-dev-migration: cannot read dev keyring: {e}");
+            return;
+        }
+    };
+
+    // One read of the prod blob.
+    let src_map: HashMap<String, String> = match src.load_all_readonly() {
+        Ok(Some(map)) => map,
+        Ok(None) => HashMap::new(), // prod has no blob yet — nothing to copy
+        Err(e) => {
+            eprintln!("buzz-desktop: keyring-dev-migration: cannot read prod keyring: {e}");
+            return;
+        }
+    };
+
+    // Compute the set of entries to write: agent keys absent from dst, plus
+    // the migration-complete marker.
+    let mut to_write: HashMap<String, String> = HashMap::new();
     let mut copied = 0usize;
     for pubkey in pubkeys {
         let name = agent_keyring_name(pubkey);
-
-        // Idempotency: if the dst keyring already has this key, skip.
-        match dst.load(&name) {
-            Ok(Some(_)) => continue,
-            Ok(None) => {}
-            Err(_) => continue, // dst keyring unreachable — skip silently
+        if dst_map.contains_key(&name) {
+            continue; // already in dev service — do not overwrite (idempotent)
         }
-
-        // Read from src keyring (read-only: must not mutate the source service).
-        let nsec = match src.load_readonly(&name) {
-            Ok(Some(v)) => v,
-            Ok(None) => continue, // not in src keyring — new key, minted fresh later
-            Err(e) => {
-                eprintln!(
-                    "buzz-desktop: keyring-dev-migration: cannot read agent {pubkey} from source keyring: {e}"
-                );
-                continue;
-            }
-        };
-
-        // Write to dst keyring.
-        if let Err(e) = dst.write_and_verify(&name, &nsec) {
-            eprintln!(
-                "buzz-desktop: keyring-dev-migration: cannot write agent {pubkey} to dev service: {e}"
-            );
-            continue;
+        if let Some(nsec) = src_map.get(&name) {
+            to_write.insert(name, nsec.clone());
+            copied += 1;
         }
+        // absent from src → new agent, will mint a fresh key
+    }
 
-        copied += 1;
+    // Always write the marker so future boots skip the prod read entirely,
+    // even when there were no keys to copy (empty dev environment).
+    to_write.insert(DEV_MIGRATION_MARKER.to_string(), "done".to_string());
+
+    if let Err(e) = dst.store_all(&to_write) {
+        eprintln!("buzz-desktop: keyring-dev-migration: cannot write to dev keyring: {e}");
+        return;
     }
 
     if copied > 0 {
@@ -704,6 +753,7 @@ mod tests {
         fail_verify: bool,
         stored: RefCell<HashMap<String, String>>,
         write_count: RefCell<usize>,
+        read_count: RefCell<usize>,
     }
 
     impl FakeKeyStore {
@@ -713,6 +763,7 @@ mod tests {
                 fail_verify: false,
                 stored: RefCell::new(HashMap::new()),
                 write_count: RefCell::new(0),
+                read_count: RefCell::new(0),
             }
         }
         fn unreachable() -> Self {
@@ -721,6 +772,7 @@ mod tests {
                 fail_verify: false,
                 stored: RefCell::new(HashMap::new()),
                 write_count: RefCell::new(0),
+                read_count: RefCell::new(0),
             }
         }
         fn verify_fails() -> Self {
@@ -729,6 +781,7 @@ mod tests {
                 fail_verify: true,
                 stored: RefCell::new(HashMap::new()),
                 write_count: RefCell::new(0),
+                read_count: RefCell::new(0),
             }
         }
         /// Seed a key as already present in the keyring.
@@ -754,11 +807,25 @@ mod tests {
             if !self.reachable {
                 return Err("keyring backend unreachable".to_string());
             }
+            *self.read_count.borrow_mut() += 1;
             Ok(self.stored.borrow().get(name).cloned())
         }
         fn load_readonly(&self, name: &str) -> Result<Option<String>, String> {
             // The fake has no side effects, so load_readonly is identical to load.
             self.load(name)
+        }
+        fn load_all_readonly(&self) -> Result<Option<HashMap<String, String>>, String> {
+            if !self.reachable {
+                return Err("keyring backend unreachable".to_string());
+            }
+            *self.read_count.borrow_mut() += 1;
+            let map = self.stored.borrow().clone();
+            // Return None when completely empty (simulates no blob written yet).
+            if map.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(map))
+            }
         }
         fn write_and_verify(&self, name: &str, value: &str) -> Result<(), String> {
             if self.fail_verify {
@@ -768,6 +835,20 @@ mod tests {
             self.stored
                 .borrow_mut()
                 .insert(name.to_string(), value.to_string());
+            Ok(())
+        }
+        fn store_all(&self, entries: &HashMap<String, String>) -> Result<(), String> {
+            if !self.reachable {
+                return Err("keyring backend unreachable".to_string());
+            }
+            if self.fail_verify {
+                return Err("read-back verify failed".to_string());
+            }
+            *self.write_count.borrow_mut() += 1;
+            let mut stored = self.stored.borrow_mut();
+            for (k, v) in entries {
+                stored.insert(k.clone(), v.clone());
+            }
             Ok(())
         }
     }
@@ -1053,7 +1134,8 @@ mod tests {
 
     #[test]
     fn copy_agent_keys_copies_keys_present_in_src_to_dst() {
-        // Keys in src but not in dst must be copied.
+        // Keys in src but not in dst must be copied in a single bulk write,
+        // and the migration-complete marker must be set.
         let src = FakeKeyStore::reachable()
             .with_key(&agent_keyring_name("agent-alpha"), "nsec1alpha")
             .with_key(&agent_keyring_name("agent-beta"), "nsec1beta");
@@ -1081,6 +1163,26 @@ mod tests {
             Some("nsec1beta"),
             "agent-beta must be copied from src to dst"
         );
+        assert_eq!(
+            dst.stored
+                .borrow()
+                .get(super::DEV_MIGRATION_MARKER)
+                .map(String::as_str),
+            Some("done"),
+            "migration-complete marker must be set after first migration"
+        );
+        // Bulk write: exactly 1 store_all call.
+        assert_eq!(
+            *dst.write_count.borrow(),
+            1,
+            "must perform exactly one bulk write"
+        );
+        // Src accessed exactly once (bulk blob read).
+        assert_eq!(
+            *src.read_count.borrow(),
+            1,
+            "src must be read exactly once (bulk)"
+        );
     }
 
     #[test]
@@ -1103,25 +1205,41 @@ mod tests {
             Some("nsec1new"),
             "key already in dst must not be overwritten by migration"
         );
+        // Marker must still be written even though no new keys were copied.
         assert_eq!(
-            *dst.write_count.borrow(),
-            0,
-            "no writes should occur when key already present in dst"
+            dst.stored
+                .borrow()
+                .get(super::DEV_MIGRATION_MARKER)
+                .map(String::as_str),
+            Some("done"),
+            "marker must be set even when all keys are already present"
         );
     }
 
     #[test]
     fn copy_agent_keys_skips_keys_absent_from_src() {
         // A pubkey with no entry in src (new agent that will mint a fresh key)
-        // must be silently skipped — no write to dst.
+        // must be silently skipped — no agent key written to dst.
         let src = FakeKeyStore::reachable(); // empty
         let dst = FakeKeyStore::reachable();
 
         super::copy_agent_keys_between_stores(&["new-agent".to_string()], &src, &dst);
 
         assert!(
-            dst.stored.borrow().is_empty(),
-            "absent src key must produce no write to dst"
+            dst.stored
+                .borrow()
+                .get(&agent_keyring_name("new-agent"))
+                .is_none(),
+            "absent src key must produce no agent key write to dst"
+        );
+        // Marker must still be written.
+        assert_eq!(
+            dst.stored
+                .borrow()
+                .get(super::DEV_MIGRATION_MARKER)
+                .map(String::as_str),
+            Some("done"),
+            "marker must be set even when no keys were present in src"
         );
     }
 
@@ -1138,5 +1256,65 @@ mod tests {
 
         // No writes attempted to an unreachable dst.
         assert_eq!(*dst.write_count.borrow(), 0);
+        // Src must not have been accessed (failed on dst read, returned early).
+        assert_eq!(
+            *src.read_count.borrow(),
+            0,
+            "src must not be accessed when dst is unreachable"
+        );
+    }
+
+    #[test]
+    fn copy_agent_keys_skips_entirely_when_marker_present() {
+        // After the first migration, the marker is in dst. Subsequent calls
+        // must return immediately — the prod keyring (src) must never be read.
+        let src =
+            FakeKeyStore::reachable().with_key(&agent_keyring_name("agent-alpha"), "nsec1alpha");
+        let dst = FakeKeyStore::reachable()
+            .with_key(super::DEV_MIGRATION_MARKER, "done")
+            .with_key(&agent_keyring_name("agent-alpha"), "nsec1dev");
+
+        super::copy_agent_keys_between_stores(&["agent-alpha".to_string()], &src, &dst);
+
+        // Src must not have been accessed at all.
+        assert_eq!(
+            *src.read_count.borrow(),
+            0,
+            "src must not be read when migration-complete marker is present"
+        );
+        // Dst must not have been written.
+        assert_eq!(
+            *dst.write_count.borrow(),
+            0,
+            "dst must not be written when migration-complete marker is present"
+        );
+        // Dev key must remain unchanged.
+        assert_eq!(
+            dst.stored
+                .borrow()
+                .get(&agent_keyring_name("agent-alpha"))
+                .map(String::as_str),
+            Some("nsec1dev"),
+            "dev key must not be overwritten on subsequent boots"
+        );
+    }
+
+    #[test]
+    fn copy_agent_keys_writes_marker_even_with_empty_agent_list() {
+        // An empty pubkey list (no agents yet) must still write the marker so
+        // future boots skip the prod read.
+        let src = FakeKeyStore::reachable();
+        let dst = FakeKeyStore::reachable();
+
+        super::copy_agent_keys_between_stores(&[], &src, &dst);
+
+        assert_eq!(
+            dst.stored
+                .borrow()
+                .get(super::DEV_MIGRATION_MARKER)
+                .map(String::as_str),
+            Some("done"),
+            "marker must be set even when pubkey list is empty"
+        );
     }
 }

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -355,6 +355,106 @@ fn persist_agent_keys_with(store: &impl KeyStore, records: &mut [ManagedAgentRec
         }
     }
 }
+
+/// One-time migration of agent keys from the production keyring service
+/// (`"buzz-desktop"`) to the dev service (`"buzz-desktop-dev"`). Only runs
+/// in debug builds — release builds never touch `"buzz-desktop"` from this
+/// path.
+///
+/// Idempotent: skips any key that already exists in the dev service so
+/// repeated boots after migration are no-ops. Leaves the production keyring
+/// untouched — a dev build and a prod install can coexist without sharing
+/// keys after this migration.
+///
+/// Call this at boot before `hydrate_keys` runs (i.e. before
+/// `load_managed_agents` is called) so agents find their keys on first boot
+/// after the service-name change.
+#[cfg(debug_assertions)]
+pub fn migrate_agent_keys_to_dev_service(app: &tauri::AppHandle) {
+    if !cfg!(feature = "system-keyring") {
+        return;
+    }
+
+    // Read the JSON store for pubkeys only — we want every instance
+    // record without running hydrate_keys (which would try the dev
+    // keyring that is empty, and log noisy "has no key" warnings).
+    let records = match load_agent_store(app) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("buzz-desktop: keyring-dev-migration: cannot read agent store: {e}");
+            return;
+        }
+    };
+
+    let pubkeys: Vec<String> = records
+        .into_iter()
+        .filter(|r| !r.pubkey.is_empty())
+        .map(|r| r.pubkey)
+        .collect();
+
+    if pubkeys.is_empty() {
+        return;
+    }
+
+    // A fresh non-singleton store for the prod service — its own empty
+    // cache so reads go to the OS keyring without polluting the dev
+    // singleton's cache.
+    let prod_store = crate::secret_store::SecretStore::keyring("buzz-desktop");
+    let dev_store = crate::secret_store::SecretStore::shared(keyring_service());
+    copy_agent_keys_between_stores(&pubkeys, &prod_store, dev_store);
+}
+
+/// Testable core of [`migrate_agent_keys_to_dev_service`]: copy `agent:<pubkey>`
+/// entries from `src` to `dst` for each pubkey, skipping entries that already
+/// exist in `dst` (idempotency) and entries absent from `src` (new agents that
+/// will mint fresh keys). Does NOT copy `"identity"`.
+#[cfg(debug_assertions)]
+fn copy_agent_keys_between_stores(
+    pubkeys: &[String],
+    src: &impl KeyStore,
+    dst: &impl KeyStore,
+) {
+    let mut copied = 0usize;
+    for pubkey in pubkeys {
+        let name = agent_keyring_name(pubkey);
+
+        // Idempotency: if the dst keyring already has this key, skip.
+        match dst.load(&name) {
+            Ok(Some(_)) => continue,
+            Ok(None) => {}
+            Err(_) => continue, // dst keyring unreachable — skip silently
+        }
+
+        // Read from src keyring.
+        let nsec = match src.load(&name) {
+            Ok(Some(v)) => v,
+            Ok(None) => continue, // not in src keyring — new key, minted fresh later
+            Err(e) => {
+                eprintln!(
+                    "buzz-desktop: keyring-dev-migration: cannot read agent {pubkey} from source keyring: {e}"
+                );
+                continue;
+            }
+        };
+
+        // Write to dst keyring.
+        if let Err(e) = dst.write_and_verify(&name, &nsec) {
+            eprintln!(
+                "buzz-desktop: keyring-dev-migration: cannot write agent {pubkey} to dev service: {e}"
+            );
+            continue;
+        }
+
+        copied += 1;
+    }
+
+    if copied > 0 {
+        eprintln!(
+            "buzz-desktop: keyring-dev-migration: copied {copied} agent key(s) from buzz-desktop"
+        );
+    }
+}
+
 /// Remove an agent's key from the keyring (best-effort). Called when an agent
 /// is deleted so its secret does not linger in the OS store.
 pub fn delete_agent_key(pubkey: &str) {
@@ -941,5 +1041,102 @@ mod tests {
             strip_ansi_escapes::strip_str(input),
             "2026-05-27T15:16:32  INFO buzz_acp: starting"
         );
+    }
+
+    // ── keyring-dev-migration tests ────────────────────────────────────────
+
+    #[test]
+    fn copy_agent_keys_copies_keys_present_in_src_to_dst() {
+        // Keys in src but not in dst must be copied.
+        let src = FakeKeyStore::reachable()
+            .with_key(&agent_keyring_name("agent-alpha"), "nsec1alpha")
+            .with_key(&agent_keyring_name("agent-beta"), "nsec1beta");
+        let dst = FakeKeyStore::reachable();
+
+        super::copy_agent_keys_between_stores(
+            &[
+                "agent-alpha".to_string(),
+                "agent-beta".to_string(),
+            ],
+            &src,
+            &dst,
+        );
+
+        assert_eq!(
+            dst.stored.borrow().get(&agent_keyring_name("agent-alpha")).map(String::as_str),
+            Some("nsec1alpha"),
+            "agent-alpha must be copied from src to dst"
+        );
+        assert_eq!(
+            dst.stored.borrow().get(&agent_keyring_name("agent-beta")).map(String::as_str),
+            Some("nsec1beta"),
+            "agent-beta must be copied from src to dst"
+        );
+    }
+
+    #[test]
+    fn copy_agent_keys_skips_keys_already_in_dst() {
+        // Idempotency: a key already present in dst must NOT be overwritten
+        // — the agent may have rotated their key in the dev service.
+        let src = FakeKeyStore::reachable()
+            .with_key(&agent_keyring_name("agent-alpha"), "nsec1old");
+        let dst = FakeKeyStore::reachable()
+            .with_key(&agent_keyring_name("agent-alpha"), "nsec1new");
+
+        super::copy_agent_keys_between_stores(
+            &["agent-alpha".to_string()],
+            &src,
+            &dst,
+        );
+
+        // dst value must remain unchanged — src must not overwrite it.
+        assert_eq!(
+            dst.stored.borrow().get(&agent_keyring_name("agent-alpha")).map(String::as_str),
+            Some("nsec1new"),
+            "key already in dst must not be overwritten by migration"
+        );
+        assert_eq!(
+            *dst.write_count.borrow(),
+            0,
+            "no writes should occur when key already present in dst"
+        );
+    }
+
+    #[test]
+    fn copy_agent_keys_skips_keys_absent_from_src() {
+        // A pubkey with no entry in src (new agent that will mint a fresh key)
+        // must be silently skipped — no write to dst.
+        let src = FakeKeyStore::reachable(); // empty
+        let dst = FakeKeyStore::reachable();
+
+        super::copy_agent_keys_between_stores(
+            &["new-agent".to_string()],
+            &src,
+            &dst,
+        );
+
+        assert!(
+            dst.stored.borrow().is_empty(),
+            "absent src key must produce no write to dst"
+        );
+    }
+
+    #[test]
+    fn copy_agent_keys_skips_all_when_dst_unreachable() {
+        // When dst keyring is unreachable the migration must be a no-op — never
+        // data-loss (failing to write is fine; the agent will re-mint on next
+        // onboarding run).
+        let src = FakeKeyStore::reachable()
+            .with_key(&agent_keyring_name("agent-alpha"), "nsec1alpha");
+        let dst = FakeKeyStore::unreachable();
+
+        super::copy_agent_keys_between_stores(
+            &["agent-alpha".to_string()],
+            &src,
+            &dst,
+        );
+
+        // No writes attempted to an unreachable dst.
+        assert_eq!(*dst.write_count.borrow(), 0);
     }
 }

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -61,6 +61,9 @@ trait KeyStore {
     /// Read a key. `Ok(None)` is "no such entry" (absent); `Err` is a backend
     /// failure (keyring unreachable) — the caller MUST NOT collapse the two.
     fn load(&self, name: &str) -> Result<Option<String>, String>;
+    /// Read a key without any side effects (no legacy-key migration, no writes).
+    /// `Ok(None)` when the blob or the key is absent; `Err` only on backend failure.
+    fn load_readonly(&self, name: &str) -> Result<Option<String>, String>;
     /// Write `value` and read it back to confirm before the caller strips the
     /// inline copy.
     fn write_and_verify(&self, name: &str, value: &str) -> Result<(), String>;
@@ -72,6 +75,9 @@ impl KeyStore for SecretStore {
     }
     fn load(&self, name: &str) -> Result<Option<String>, String> {
         SecretStore::load(self, name)
+    }
+    fn load_readonly(&self, name: &str) -> Result<Option<String>, String> {
+        SecretStore::load_readonly(self, name)
     }
     fn write_and_verify(&self, name: &str, value: &str) -> Result<(), String> {
         self.store(name, value)?;
@@ -425,8 +431,8 @@ fn copy_agent_keys_between_stores(
             Err(_) => continue, // dst keyring unreachable — skip silently
         }
 
-        // Read from src keyring.
-        let nsec = match src.load(&name) {
+        // Read from src keyring (read-only: must not mutate the source service).
+        let nsec = match src.load_readonly(&name) {
             Ok(Some(v)) => v,
             Ok(None) => continue, // not in src keyring — new key, minted fresh later
             Err(e) => {
@@ -753,6 +759,10 @@ mod tests {
                 return Err("keyring backend unreachable".to_string());
             }
             Ok(self.stored.borrow().get(name).cloned())
+        }
+        fn load_readonly(&self, name: &str) -> Result<Option<String>, String> {
+            // The fake has no side effects, so load_readonly is identical to load.
+            self.load(name)
         }
         fn write_and_verify(&self, name: &str, value: &str) -> Result<(), String> {
             if self.fail_verify {

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -415,11 +415,7 @@ pub fn migrate_agent_keys_to_dev_service(app: &tauri::AppHandle) {
 /// exist in `dst` (idempotency) and entries absent from `src` (new agents that
 /// will mint fresh keys). Does NOT copy `"identity"`.
 #[cfg(debug_assertions)]
-fn copy_agent_keys_between_stores(
-    pubkeys: &[String],
-    src: &impl KeyStore,
-    dst: &impl KeyStore,
-) {
+fn copy_agent_keys_between_stores(pubkeys: &[String], src: &impl KeyStore, dst: &impl KeyStore) {
     let mut copied = 0usize;
     for pubkey in pubkeys {
         let name = agent_keyring_name(pubkey);
@@ -1064,21 +1060,24 @@ mod tests {
         let dst = FakeKeyStore::reachable();
 
         super::copy_agent_keys_between_stores(
-            &[
-                "agent-alpha".to_string(),
-                "agent-beta".to_string(),
-            ],
+            &["agent-alpha".to_string(), "agent-beta".to_string()],
             &src,
             &dst,
         );
 
         assert_eq!(
-            dst.stored.borrow().get(&agent_keyring_name("agent-alpha")).map(String::as_str),
+            dst.stored
+                .borrow()
+                .get(&agent_keyring_name("agent-alpha"))
+                .map(String::as_str),
             Some("nsec1alpha"),
             "agent-alpha must be copied from src to dst"
         );
         assert_eq!(
-            dst.stored.borrow().get(&agent_keyring_name("agent-beta")).map(String::as_str),
+            dst.stored
+                .borrow()
+                .get(&agent_keyring_name("agent-beta"))
+                .map(String::as_str),
             Some("nsec1beta"),
             "agent-beta must be copied from src to dst"
         );
@@ -1088,20 +1087,19 @@ mod tests {
     fn copy_agent_keys_skips_keys_already_in_dst() {
         // Idempotency: a key already present in dst must NOT be overwritten
         // — the agent may have rotated their key in the dev service.
-        let src = FakeKeyStore::reachable()
-            .with_key(&agent_keyring_name("agent-alpha"), "nsec1old");
-        let dst = FakeKeyStore::reachable()
-            .with_key(&agent_keyring_name("agent-alpha"), "nsec1new");
+        let src =
+            FakeKeyStore::reachable().with_key(&agent_keyring_name("agent-alpha"), "nsec1old");
+        let dst =
+            FakeKeyStore::reachable().with_key(&agent_keyring_name("agent-alpha"), "nsec1new");
 
-        super::copy_agent_keys_between_stores(
-            &["agent-alpha".to_string()],
-            &src,
-            &dst,
-        );
+        super::copy_agent_keys_between_stores(&["agent-alpha".to_string()], &src, &dst);
 
         // dst value must remain unchanged — src must not overwrite it.
         assert_eq!(
-            dst.stored.borrow().get(&agent_keyring_name("agent-alpha")).map(String::as_str),
+            dst.stored
+                .borrow()
+                .get(&agent_keyring_name("agent-alpha"))
+                .map(String::as_str),
             Some("nsec1new"),
             "key already in dst must not be overwritten by migration"
         );
@@ -1119,11 +1117,7 @@ mod tests {
         let src = FakeKeyStore::reachable(); // empty
         let dst = FakeKeyStore::reachable();
 
-        super::copy_agent_keys_between_stores(
-            &["new-agent".to_string()],
-            &src,
-            &dst,
-        );
+        super::copy_agent_keys_between_stores(&["new-agent".to_string()], &src, &dst);
 
         assert!(
             dst.stored.borrow().is_empty(),
@@ -1136,15 +1130,11 @@ mod tests {
         // When dst keyring is unreachable the migration must be a no-op — never
         // data-loss (failing to write is fine; the agent will re-mint on next
         // onboarding run).
-        let src = FakeKeyStore::reachable()
-            .with_key(&agent_keyring_name("agent-alpha"), "nsec1alpha");
+        let src =
+            FakeKeyStore::reachable().with_key(&agent_keyring_name("agent-alpha"), "nsec1alpha");
         let dst = FakeKeyStore::unreachable();
 
-        super::copy_agent_keys_between_stores(
-            &["agent-alpha".to_string()],
-            &src,
-            &dst,
-        );
+        super::copy_agent_keys_between_stores(&["agent-alpha".to_string()], &src, &dst);
 
         // No writes attempted to an unreachable dst.
         assert_eq!(*dst.write_count.borrow(), 0);

--- a/desktop/src-tauri/src/migration.rs
+++ b/desktop/src-tauri/src/migration.rs
@@ -145,6 +145,16 @@ pub fn run_boot_migrations(app: &tauri::AppHandle) {
 
     migrate_legacy_app_data_dir(app);
     sync_shared_agent_data(app);
+    // Dev-build-only: copy any agent keys that exist in the production
+    // keyring ("buzz-desktop") into the dev service ("buzz-desktop-dev")
+    // so existing agents don't lose their keys after the service-name split.
+    // Must run after sync_shared_agent_data (JSON symlinked) and before
+    // any load_managed_agents call (which runs hydrate_keys against the
+    // dev service and would log "has no key" for un-migrated entries).
+    #[cfg(debug_assertions)]
+    if is_dev {
+        crate::managed_agents::migrate_agent_keys_to_dev_service(app);
+    }
     migrate_packs_to_teams(app);
     reconcile_persona_team_dirs(app);
     migrate_persona_provider_to_runtime(app);

--- a/desktop/src-tauri/src/secret_store.rs
+++ b/desktop/src-tauri/src/secret_store.rs
@@ -601,6 +601,43 @@ impl SecretStore {
         }
     }
 
+    /// Read the entire blob without any legacy-migration side effects.
+    ///
+    /// Returns the full key→value map when a blob exists, `Ok(None)` when no
+    /// blob has been written yet, and `Err` only when the backend is
+    /// unavailable. Never calls `migrate_legacy_key`.
+    pub fn load_all_readonly(&self) -> Result<Option<HashMap<String, String>>, String> {
+        #[cfg(feature = "system-keyring")]
+        {
+            self.load_blob()
+        }
+        #[cfg(not(feature = "system-keyring"))]
+        {
+            Err("system-keyring feature disabled".to_string())
+        }
+    }
+
+    /// Insert all entries from `entries` into the blob in a single mutation.
+    ///
+    /// Entries that already exist in the blob are overwritten; entries not
+    /// present in `entries` are left unchanged. If the resulting blob is
+    /// identical to what is already stored, no keychain write occurs.
+    pub fn store_all(&self, entries: &HashMap<String, String>) -> Result<(), String> {
+        #[cfg(feature = "system-keyring")]
+        {
+            self.mutate_blob(|map| {
+                for (k, v) in entries {
+                    map.insert(k.clone(), v.clone());
+                }
+            })
+        }
+        #[cfg(not(feature = "system-keyring"))]
+        {
+            let _ = entries;
+            Err("system-keyring feature disabled".to_string())
+        }
+    }
+
     /// On first launch after upgrading from the per-key DPK format, read the
     /// old DPK entry for `key`, write it into a new blob, and delete the old
     /// item. Returns `Ok(None)` when no old entry exists.

--- a/desktop/src-tauri/src/secret_store.rs
+++ b/desktop/src-tauri/src/secret_store.rs
@@ -575,6 +575,25 @@ impl SecretStore {
         }
     }
 
+    /// Read the secret for `key` without any legacy-migration side effects.
+    ///
+    /// Unlike [`load`](Self::load), this method never calls
+    /// `migrate_legacy_key` and therefore never writes to or deletes from the
+    /// keyring. Use this when the caller must guarantee the store is not
+    /// mutated — for example, when reading from a foreign service (prod) to
+    /// copy values into a dev service.
+    ///
+    /// Returns `Ok(Some(value))` when the key is present in the blob,
+    /// `Ok(None)` when the blob is absent or the key is not in it, and `Err`
+    /// only when the backend is unavailable.
+    #[cfg(feature = "system-keyring")]
+    pub fn load_readonly(&self, key: &str) -> Result<Option<String>, String> {
+        match self.load_blob()? {
+            Some(map) => Ok(map.get(key).cloned()),
+            None => Ok(None),
+        }
+    }
+
     /// On first launch after upgrading from the per-key DPK format, read the
     /// old DPK entry for `key`, write it into a new blob, and delete the old
     /// item. Returns `Ok(None)` when no old entry exists.

--- a/desktop/src-tauri/src/secret_store.rs
+++ b/desktop/src-tauri/src/secret_store.rs
@@ -586,11 +586,18 @@ impl SecretStore {
     /// Returns `Ok(Some(value))` when the key is present in the blob,
     /// `Ok(None)` when the blob is absent or the key is not in it, and `Err`
     /// only when the backend is unavailable.
-    #[cfg(feature = "system-keyring")]
     pub fn load_readonly(&self, key: &str) -> Result<Option<String>, String> {
-        match self.load_blob()? {
-            Some(map) => Ok(map.get(key).cloned()),
-            None => Ok(None),
+        #[cfg(feature = "system-keyring")]
+        {
+            match self.load_blob()? {
+                Some(map) => Ok(map.get(key).cloned()),
+                None => Ok(None),
+            }
+        }
+        #[cfg(not(feature = "system-keyring"))]
+        {
+            let _ = key;
+            Err("system-keyring feature disabled".to_string())
         }
     }
 

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -203,7 +203,7 @@ function OnboardingLoadingGate() {
               tabIndex={-1}
               type="button"
             >
-              Continue with Block Inc. workspace
+              Continue with default workspace
             </Button>
 
             <Button

--- a/desktop/src/features/channels/lib/ephemeralChannel.ts
+++ b/desktop/src/features/channels/lib/ephemeralChannel.ts
@@ -14,6 +14,9 @@ type EphemeralChannelLike = Pick<Channel, "ttlSeconds" | "ttlDeadline">;
 
 export const EPHEMERAL_CHANNEL_LABEL = "Ephemeral";
 
+/** Default TTL for ephemeral channels: 7 days of inactivity. */
+export const DEFAULT_EPHEMERAL_TTL_SECONDS = 7 * 24 * 60 * 60;
+
 export type EphemeralChannelDisplay = {
   detailLabel: string | null;
   tooltipLabel: string;

--- a/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/features/channels/hooks";
 import { compareMembersByRole } from "@/features/channels/lib/memberUtils";
 import {
+  DEFAULT_EPHEMERAL_TTL_SECONDS,
   formatTtlDuration,
   parseTtlDuration,
 } from "@/features/channels/lib/ephemeralChannel";
@@ -94,8 +95,6 @@ type ChannelManagementSheetProps = {
   open: boolean;
   transparentChrome?: boolean;
 };
-
-const DEFAULT_EPHEMERAL_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 export function ChannelManagementSheet({
   animateSplitEnter = false,
@@ -549,7 +548,7 @@ export function ChannelManagementSheet({
                         >
                           {ttlInvalid
                             ? "Enter a duration like 1d, 12h, or 30m."
-                            : "Defaults to 1d when left empty. Resets the deletion countdown from now whenever changed."}
+                            : "Defaults to 7d when left empty. Resets the deletion countdown from now whenever changed."}
                         </p>
                       </div>
                     ) : null}

--- a/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
+++ b/desktop/src/features/sidebar/ui/CreateChannelDialog.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ClockFading, Hash, type LucideIcon } from "lucide-react";
 import * as React from "react";
 
 import { useChannelTemplatesQuery } from "@/features/channel-templates/hooks";
+import { DEFAULT_EPHEMERAL_TTL_SECONDS } from "@/features/channels/lib/ephemeralChannel";
 import type { ChannelTemplate, ChannelVisibility } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
@@ -12,8 +13,6 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Switch } from "@/shared/ui/switch";
 import { Textarea } from "@/shared/ui/textarea";
 
-/** Default TTL for ephemeral channels: 7 days of inactivity. */
-const EPHEMERAL_TTL_SECONDS = 604800;
 const CREATE_FIELD_SHELL_CLASS =
   "rounded-xl border border-input bg-muted/40 transition-colors duration-150 ease-out hover:border-muted-foreground/40 focus-within:border-muted-foreground/50";
 const CREATE_FIELD_CONTROL_CLASS =
@@ -125,7 +124,7 @@ export function CreateChannelDialog({
         name: trimmedName,
         description: description.trim() || undefined,
         visibility,
-        ttlSeconds: ephemeral ? EPHEMERAL_TTL_SECONDS : undefined,
+        ttlSeconds: ephemeral ? DEFAULT_EPHEMERAL_TTL_SECONDS : undefined,
         templateId: selectedTemplateId ?? undefined,
       });
 

--- a/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/workspaces/ui/WelcomeSetup.tsx
@@ -249,7 +249,7 @@ export function WelcomeSetup({
                   }}
                   type="button"
                 >
-                  Continue with Block Inc. workspace
+                  Continue with default workspace
                 </Button>
               )}
 

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -595,7 +595,7 @@ test("first-run default workspace handoff gives immediate stepper feedback", asy
 
   await expect(page.getByText("Welcome to Buzz")).toBeVisible();
   await page
-    .getByRole("button", { name: "Continue with Block Inc. workspace" })
+    .getByRole("button", { name: "Continue with default workspace" })
     .click();
 
   await page.waitForTimeout(80);
@@ -603,7 +603,7 @@ test("first-run default workspace handoff gives immediate stepper feedback", asy
     0,
   );
   await expect(
-    page.getByRole("button", { name: "Continue with Block Inc. workspace" }),
+    page.getByRole("button", { name: "Continue with default workspace" }),
   ).toBeVisible();
   await expect(page.getByRole("progressbar")).toHaveAttribute(
     "aria-valuenow",
@@ -671,7 +671,7 @@ test("welcome presents custom workspace setup as joining a workspace", async ({
   await page.goto("/");
 
   await expect(
-    page.getByRole("button", { name: "Continue with Block Inc. workspace" }),
+    page.getByRole("button", { name: "Continue with default workspace" }),
   ).toHaveCount(0);
   await page.getByRole("button", { name: "Join a workspace" }).click();
 

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -53,14 +53,14 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
                     _BUZZ_NSEC=$(security find-generic-password \
                         -s "buzz-desktop-dev" -a "secrets" -w 2>/dev/null \
                         | python3 -c "import json,sys; print(json.load(sys.stdin).get('identity',''))" \
-                        2>/dev/null)
+                        2>/dev/null) || true
                     ;;
                 Linux)
                     CANONICAL_KEY="$HOME/.local/share/xyz.block.buzz.app.dev/identity.key"
                     LEGACY_CANONICAL_KEY="$HOME/.local/share/xyz.block.sprout.app.dev/identity.key"
                     _BUZZ_NSEC=$(secret-tool lookup service buzz-desktop-dev username secrets 2>/dev/null \
                         | python3 -c "import json,sys; print(json.load(sys.stdin).get('identity',''))" \
-                        2>/dev/null)
+                        2>/dev/null) || true
                     ;;
                 *)
                     CANONICAL_KEY=""

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -42,42 +42,15 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         # identifier is kept so concurrent instances don't collide on
         # tauri-plugin-single-instance or the app data directory.
         if [[ "${BUZZ_SHARE_IDENTITY:-0}" == "1" ]]; then
-            # Try the OS keyring first (post-migration: identity.key no longer
-            # exists after the keyring migration in #1568). Fall back to the
-            # identity.key file for pre-migration installs.
-            _BUZZ_NSEC=""
-            case "$(uname -s)" in
-                Darwin)
-                    CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.buzz.app.dev/identity.key"
-                    LEGACY_CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.sprout.app.dev/identity.key"
-                    _BUZZ_NSEC=$(security find-generic-password \
-                        -s "buzz-desktop-dev" -a "secrets" -w 2>/dev/null \
-                        | python3 -c "import json,sys; print(json.load(sys.stdin).get('identity',''))" \
-                        2>/dev/null) || true
-                    ;;
-                Linux)
-                    CANONICAL_KEY="$HOME/.local/share/xyz.block.buzz.app.dev/identity.key"
-                    LEGACY_CANONICAL_KEY="$HOME/.local/share/xyz.block.sprout.app.dev/identity.key"
-                    _BUZZ_NSEC=$(secret-tool lookup service buzz-desktop-dev username secrets 2>/dev/null \
-                        | python3 -c "import json,sys; print(json.load(sys.stdin).get('identity',''))" \
-                        2>/dev/null) || true
-                    ;;
-                *)
-                    CANONICAL_KEY=""
-                    LEGACY_CANONICAL_KEY=""
-                    ;;
-            esac
-
-            if [[ -n "$_BUZZ_NSEC" ]]; then
-                export BUZZ_PRIVATE_KEY="$_BUZZ_NSEC"
-            elif [[ -n "$CANONICAL_KEY" && -f "$CANONICAL_KEY" ]]; then
+            CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.buzz.app.dev/identity.key"
+            LEGACY_CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.sprout.app.dev/identity.key"
+            if [[ -f "$CANONICAL_KEY" ]]; then
                 export BUZZ_PRIVATE_KEY="$(cat "$CANONICAL_KEY")"
-            elif [[ -n "$LEGACY_CANONICAL_KEY" && -f "$LEGACY_CANONICAL_KEY" ]]; then
+            elif [[ -f "$LEGACY_CANONICAL_KEY" ]]; then
                 export BUZZ_PRIVATE_KEY="$(cat "$LEGACY_CANONICAL_KEY")"
             else
-                echo "⚠ BUZZ_SHARE_IDENTITY=1 but no identity found in keyring or at ${CANONICAL_KEY:-<unsupported platform>} — run Buzz from repo root first" >&2
+                echo "⚠ BUZZ_SHARE_IDENTITY=1 but no identity found at $CANONICAL_KEY or $LEGACY_CANONICAL_KEY — run Buzz from repo root first" >&2
             fi
-            unset _BUZZ_NSEC
         fi
 
         ICON_DIR="$WORKTREE_ROOT/desktop/src-tauri/target/dev-icons"

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -44,13 +44,35 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         if [[ "${BUZZ_SHARE_IDENTITY:-0}" == "1" ]]; then
             CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.buzz.app.dev/identity.key"
             LEGACY_CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.sprout.app.dev/identity.key"
-            if [[ -f "$CANONICAL_KEY" ]]; then
+
+            # Try the OS keyring first (post-migration: identity.key no longer
+            # exists after the keyring migration in #1568). Fall back to the
+            # file for pre-migration installs.
+            _BUZZ_NSEC=""
+            case "$(uname -s)" in
+                Darwin)
+                    _BUZZ_NSEC=$(security find-generic-password \
+                        -s "buzz-desktop-dev" -a "secrets" -w 2>/dev/null \
+                        | python3 -c "import json,sys; print(json.load(sys.stdin).get('identity',''))" \
+                        2>/dev/null)
+                    ;;
+                Linux)
+                    _BUZZ_NSEC=$(secret-tool lookup service buzz-desktop-dev username secrets 2>/dev/null \
+                        | python3 -c "import json,sys; print(json.load(sys.stdin).get('identity',''))" \
+                        2>/dev/null)
+                    ;;
+            esac
+
+            if [[ -n "$_BUZZ_NSEC" ]]; then
+                export BUZZ_PRIVATE_KEY="$_BUZZ_NSEC"
+            elif [[ -f "$CANONICAL_KEY" ]]; then
                 export BUZZ_PRIVATE_KEY="$(cat "$CANONICAL_KEY")"
             elif [[ -f "$LEGACY_CANONICAL_KEY" ]]; then
                 export BUZZ_PRIVATE_KEY="$(cat "$LEGACY_CANONICAL_KEY")"
             else
-                echo "⚠ BUZZ_SHARE_IDENTITY=1 but no identity found at $CANONICAL_KEY or $LEGACY_CANONICAL_KEY — run Buzz from repo root first" >&2
+                echo "⚠ BUZZ_SHARE_IDENTITY=1 but no identity found in keyring or at $CANONICAL_KEY — run Buzz from repo root first" >&2
             fi
+            unset _BUZZ_NSEC
         fi
 
         ICON_DIR="$WORKTREE_ROOT/desktop/src-tauri/target/dev-icons"

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -42,35 +42,40 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         # identifier is kept so concurrent instances don't collide on
         # tauri-plugin-single-instance or the app data directory.
         if [[ "${BUZZ_SHARE_IDENTITY:-0}" == "1" ]]; then
-            CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.buzz.app.dev/identity.key"
-            LEGACY_CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.sprout.app.dev/identity.key"
-
             # Try the OS keyring first (post-migration: identity.key no longer
             # exists after the keyring migration in #1568). Fall back to the
-            # file for pre-migration installs.
+            # identity.key file for pre-migration installs.
             _BUZZ_NSEC=""
             case "$(uname -s)" in
                 Darwin)
+                    CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.buzz.app.dev/identity.key"
+                    LEGACY_CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.sprout.app.dev/identity.key"
                     _BUZZ_NSEC=$(security find-generic-password \
                         -s "buzz-desktop-dev" -a "secrets" -w 2>/dev/null \
                         | python3 -c "import json,sys; print(json.load(sys.stdin).get('identity',''))" \
                         2>/dev/null)
                     ;;
                 Linux)
+                    CANONICAL_KEY="$HOME/.local/share/xyz.block.buzz.app.dev/identity.key"
+                    LEGACY_CANONICAL_KEY="$HOME/.local/share/xyz.block.sprout.app.dev/identity.key"
                     _BUZZ_NSEC=$(secret-tool lookup service buzz-desktop-dev username secrets 2>/dev/null \
                         | python3 -c "import json,sys; print(json.load(sys.stdin).get('identity',''))" \
                         2>/dev/null)
+                    ;;
+                *)
+                    CANONICAL_KEY=""
+                    LEGACY_CANONICAL_KEY=""
                     ;;
             esac
 
             if [[ -n "$_BUZZ_NSEC" ]]; then
                 export BUZZ_PRIVATE_KEY="$_BUZZ_NSEC"
-            elif [[ -f "$CANONICAL_KEY" ]]; then
+            elif [[ -n "$CANONICAL_KEY" && -f "$CANONICAL_KEY" ]]; then
                 export BUZZ_PRIVATE_KEY="$(cat "$CANONICAL_KEY")"
-            elif [[ -f "$LEGACY_CANONICAL_KEY" ]]; then
+            elif [[ -n "$LEGACY_CANONICAL_KEY" && -f "$LEGACY_CANONICAL_KEY" ]]; then
                 export BUZZ_PRIVATE_KEY="$(cat "$LEGACY_CANONICAL_KEY")"
             else
-                echo "⚠ BUZZ_SHARE_IDENTITY=1 but no identity found in keyring or at $CANONICAL_KEY — run Buzz from repo root first" >&2
+                echo "⚠ BUZZ_SHARE_IDENTITY=1 but no identity found in keyring or at ${CANONICAL_KEY:-<unsupported platform>} — run Buzz from repo root first" >&2
             fi
             unset _BUZZ_NSEC
         fi


### PR DESCRIPTION
Two related fixes for dev identity isolation, plus follow-on fixes discovered during local testing.

**Keyring isolation** (`app_state.rs`, `managed_agents/storage.rs`): debug builds now use service name `"buzz-desktop-dev"` so a `just dev` launch without `BUZZ_PRIVATE_KEY` set cannot silently read or overwrite the installed app's keyring entry. The advisory lockfile path also keys off the service name, so dev and prod builds no longer contend. `keyring_service()` fn replaces the `KEYRING_SERVICE` const; both existing call sites updated.

**Keyring dev-migration** (`managed_agents/storage.rs`, `migration.rs`): on first dev-build boot after this change, `migrate_agent_keys_to_dev_service()` copies existing `agent:<pubkey>` entries from `"buzz-desktop"` into `"buzz-desktop-dev"`. Idempotent (skips keys already present), non-destructive (prod keyring untouched), debug-only (`#[cfg(debug_assertions)]`). Prevents the "has no key in JSON or keyring" spam for developers who had agents configured before this change.

**Hardcoded label** (`WelcomeSetup.tsx`, `App.tsx`): `"Continue with Block Inc. workspace"` → `"Continue with default workspace"` in both the interactive button and the loading skeleton.

**`BUZZ_SHARE_IDENTITY` keyring fix** (`scripts/instance-env.sh`): the feature was written before keyring migration (#1568). After migration `identity.key` is deleted, so the script emitted a warning and fell through to a fresh identity on every worktree launch — silently breaking shared identity. The script now tries the OS keyring first (`security` on macOS, `secret-tool` on Linux, service `buzz-desktop-dev`), falls back to `identity.key` for pre-migration installs. Keyring reads guard against `set -euo pipefail` with `|| true` so a missing entry (common on first boot) doesn't kill the script.

**Ephemeral TTL constant** (`ephemeralChannel.ts`, `CreateChannelDialog.tsx`, `ChannelManagementSheet.tsx`): extracted `DEFAULT_EPHEMERAL_TTL_SECONDS = 7 * 24 * 60 * 60` into a shared constant; removed duplicate local copies; fixed help text `"1d"` → `"7d"`.

**Files changed:**
- `desktop/src-tauri/src/app_state.rs`
- `desktop/src-tauri/src/managed_agents/storage.rs`
- `desktop/src-tauri/src/migration.rs`
- `desktop/src/features/workspaces/ui/WelcomeSetup.tsx`
- `desktop/src/app/App.tsx`
- `desktop/scripts/check-file-sizes.mjs`
- `desktop/src/features/channels/lib/ephemeralChannel.ts`
- `desktop/src/features/sidebar/ui/CreateChannelDialog.tsx`
- `desktop/src/features/channels/ui/ChannelManagementSheet.tsx`
- `scripts/instance-env.sh`
- `desktop/tests/e2e/onboarding.spec.ts`