### PR TITLE
[BOT-1240] fix(mobile): declare exempt encryption for iOS

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<true/>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
### What changed?

Set the iOS `ITSAppUsesNonExemptEncryption` Info.plist declaration to `false` so the app binary matches the planned App Store Connect “standard/exempt encryption” declaration.

### Why?

The TestFlight upload is blocked because Apple reports the Info.plist export-compliance key does not match the app’s export-compliance documentation. The current encryption audit found only standard/published crypto usage and recommends declaring exempt encryption for App Store submission.

### How is it tested?

Validated the Info.plist syntax and ran the mobile test suite.

Linear: [BOT-1240](https://linear.app/squareup/issue/BOT-1240/set-itsappusesnonexemptencryption-in-infoplist).
