### PR TITLE
Experiment with compositor-native timeline scrolling

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -96,7 +96,10 @@ const LazySettingsScreen = React.lazy(async () => {
 export function AppShell() {
   useWebviewZoomShortcuts();
   useTauriWindowDrag();
-  useWebviewScrollBoundaryLock();
+  const compositorTimelineScrollEnabled = useFeatureEnabled(
+    "compositorTimelineScroll",
+  );
+  useWebviewScrollBoundaryLock(!compositorTimelineScrollEnabled);
 
   const workspacesHook = useWorkspaces();
   const workspaceRailEnabled = useFeatureEnabled("workspaceRail");

--- a/desktop/src/shared/hooks/useWebviewScrollBoundaryLock.ts
+++ b/desktop/src/shared/hooks/useWebviewScrollBoundaryLock.ts
@@ -80,8 +80,12 @@ function isConversationScroller(element: HTMLElement) {
  * remain; every other boundary — including all horizontal ones — is locked and
  * cannot chain to the viewport.
  */
-export function useWebviewScrollBoundaryLock() {
+export function useWebviewScrollBoundaryLock(enabled = true) {
   React.useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     function handleWheel(event: WheelEvent) {
       if (event.defaultPrevented || event.ctrlKey) {
         return;
@@ -137,5 +141,5 @@ export function useWebviewScrollBoundaryLock() {
     return () => {
       window.removeEventListener("wheel", handleWheel, { capture: true });
     };
-  }, []);
+  }, [enabled]);
 }

--- a/desktop/tests/e2e/overscroll-boundary.spec.ts
+++ b/desktop/tests/e2e/overscroll-boundary.spec.ts
@@ -28,7 +28,38 @@ async function dispatchWheelPrevented(
 }
 
 test.beforeEach(async ({ page }) => {
-  await installMockBridge(page);
+  // Boundary-lock contracts exercise the stable/default path. Most E2E suites
+  // opt every preview feature in, but compositorTimelineScroll intentionally
+  // removes this listener so trackpad scrolling can stay off the main thread.
+  await installMockBridge(page, undefined, { seedPreviewFeatures: false });
+});
+
+test("compositor timeline scrolling leaves timeline wheel events unhandled", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "buzz-feature-overrides-v1",
+      JSON.stringify({ compositorTimelineScroll: true }),
+    );
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("message-timeline")).toBeVisible();
+
+  // The diagnostic path removes the global non-passive listener rather than
+  // merely returning early for conversations. The fixed-height shell and CSS
+  // overscroll backstop remain; JS no longer blocks timeline scrolling.
+  await expect(
+    dispatchWheelPrevented(page, '[data-testid="message-timeline"]', {
+      deltaY: -120,
+    }),
+  ).resolves.toBe(false);
+  await expect(
+    dispatchWheelPrevented(page, '[data-testid="message-timeline"]', {
+      deltaX: -120,
+    }),
+  ).resolves.toBe(false);
 });
 
 test("locks viewport rubber-band outside conversation scrollers", async ({

--- a/preview-features.json
+++ b/preview-features.json
@@ -40,6 +40,14 @@
       "platforms": [
         "desktop"
       ]
+    },
+    {
+      "id": "compositorTimelineScroll",
+      "name": "Compositor timeline scrolling",
+      "description": "Lets the webview handle timeline trackpad gestures without a global blocking wheel listener",
+      "platforms": [
+        "desktop"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Hypothesis

The app-wide capture-phase, non-passive `wheel` listener runs for every trackpad packet. Even when conversation scrolling is allowed, it walks `event.composedPath()`, reads computed styles, and inspects scroll geometry on the main thread. This draft provides a clean A/B test of compositor-native timeline wheel delivery; it is a focused diagnostic, not yet a proven fix.

## Change

- add the desktop preview feature **Compositor timeline scrolling**
- when enabled, do not install the global JavaScript wheel boundary lock
- retain the fixed-height shell and CSS `overscroll-behavior` viewport backstop
- preserve existing boundary-lock behavior by default
- cover both flag-off contracts and flag-on timeline wheel delivery in Playwright

## Trackpad test

1. Build/run this branch.
2. Open **Settings → Experiments**.
3. Enable **Compositor timeline scrolling**.
4. Restart/reopen the app if the current window does not immediately reflect it.
5. Compare long-timeline trackpad scrolling while scrolled up with the experiment off vs. on.

Please also note whether viewport elastic/rubber-band behavior differs outside the timeline; removing the global lock may expose platform-specific behavior.

## Validation

- `pnpm --dir desktop lint` (passes; one unrelated pre-existing optional-chain warning)
- `pnpm --dir desktop test` (2,266 passed)
- `pnpm --dir desktop build`
- `pnpm --dir desktop exec playwright test tests/e2e/overscroll-boundary.spec.ts` (3 passed, after a fresh build/server)
- pre-commit hooks: passed
- pre-push: desktop, mobile, and desktop-Tauri suites passed; unrelated `buzz-db` suite could not start because local Rust 1.89 is below `sqlx` 0.9's required Rust 1.94
