### PR TITLE
Draft: Virtuoso timeline spike

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -70,6 +70,7 @@
     "react-diff-view": "^3.3.2",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
+    "react-virtuoso": "^4.18.10",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.0.2",

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -21,6 +21,7 @@ import { UnreadPill, unreadCountLabel } from "@/shared/ui/UnreadPill";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { TimelineSkeleton, useTimelineSkeletonRows } from "./TimelineSkeleton";
 import { TimelineMessageList } from "./TimelineMessageList";
+import type { TimelineVirtualizerApi } from "./TimelineMessageList";
 import { useAnchoredScroll } from "./useAnchoredScroll";
 import { useLoadOlderOnScroll } from "./useLoadOlderOnScroll";
 
@@ -191,6 +192,10 @@ const MessageTimelineBase = React.forwardRef<
   const scrollContainerRef = externalScrollRef ?? internalScrollRef;
   const contentRef = React.useRef<HTMLDivElement>(null);
   const topSentinelRef = React.useRef<HTMLDivElement>(null);
+  const [virtualizerScrollParent, setVirtualizerScrollParent] =
+    React.useState<HTMLDivElement | null>(null);
+  const [timelineVirtualizerApi, setTimelineVirtualizerApi] =
+    React.useState<TimelineVirtualizerApi | null>(null);
 
   // Gate the heavy timeline render (each row runs a synchronous
   // react-markdown parse) behind React concurrency. `useDeferredValue` lets the
@@ -230,6 +235,13 @@ const MessageTimelineBase = React.forwardRef<
   // painted at a stale offset until the user's next scroll event forces layout.
   const scrollContainerDomKey = channelId ?? "none";
 
+  React.useLayoutEffect(() => {
+    // Re-read after `scrollContainerDomKey` swaps the keyed scroll DOM node.
+    void scrollContainerDomKey;
+    setVirtualizerScrollParent(scrollContainerRef.current);
+    setTimelineVirtualizerApi(null);
+  }, [scrollContainerRef, scrollContainerDomKey]);
+
   const timelineBodySurface = selectTimelineBodySurface({
     deferredCount: deferredMessages.length,
     isLoading: isLoading || isDeferredSnapshotStale,
@@ -245,6 +257,7 @@ const MessageTimelineBase = React.forwardRef<
     scrollToBottom,
     scrollToBottomOnNextUpdate,
     scrollToMessage,
+    onVirtualizerAtBottomStateChange,
   } = useAnchoredScroll({
     channelId,
     contentRef,
@@ -253,6 +266,9 @@ const MessageTimelineBase = React.forwardRef<
     onTargetReached,
     scrollContainerRef,
     targetMessageId,
+    virtualScrollToMessage: timelineVirtualizerApi?.scrollToMessage,
+    virtualScrollToBottom: timelineVirtualizerApi?.scrollToBottom,
+    virtualizerOwnsPrependAnchoring: virtualizerScrollParent !== null,
   });
 
   const timelineIntroSurface = selectTimelineIntroSurface({
@@ -358,8 +374,13 @@ const MessageTimelineBase = React.forwardRef<
     }
   }, [deferredMessages, jumpToMessage, showTimelineSkeleton]);
 
+  const loadOlderViaVirtualizer = React.useCallback(() => {
+    if (!fetchOlder || showTimelineSkeleton || !hasOlderMessages) return;
+    void fetchOlder();
+  }, [fetchOlder, hasOlderMessages, showTimelineSkeleton]);
+
   useLoadOlderOnScroll({
-    fetchOlder,
+    fetchOlder: virtualizerScrollParent ? undefined : fetchOlder,
     hasOlderMessages,
     isLoading: showTimelineSkeleton,
     scrollContainerRef,
@@ -606,12 +627,16 @@ const MessageTimelineBase = React.forwardRef<
                     onReply={onReply}
                     isSendingVideoReviewComment={isSendingVideoReviewComment}
                     onSendVideoReviewComment={onSendVideoReviewComment}
+                    onStartReached={loadOlderViaVirtualizer}
                     onToggleReaction={onToggleReaction}
+                    onVirtualizerApiChange={setTimelineVirtualizerApi}
+                    onAtBottomStateChange={onVirtualizerAtBottomStateChange}
                     personaLookup={personaLookup}
                     profiles={profiles}
                     searchActiveMessageId={searchActiveMessageId}
                     searchMatchingMessageIds={searchMatchingMessageIds}
                     searchQuery={searchQuery}
+                    scrollParent={virtualizerScrollParent}
                     threadUnreadCounts={threadUnreadCounts}
                     unfollowThreadById={unfollowThreadById}
                   />

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -13,6 +13,7 @@ import type { MainTimelineEntry } from "@/features/messages/lib/threadPanel";
 import type { ChannelWindowThreadSummary } from "@/features/messages/lib/channelWindowStore";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ChannelType } from "@/shared/api/types";
+import { useFeatureEnabled } from "@/shared/features";
 import { cn } from "@/shared/lib/cn";
 import { channelChrome } from "@/shared/layout/chromeLayout";
 import { Spinner } from "@/shared/ui/spinner";
@@ -198,7 +199,7 @@ const MessageTimelineBase = React.forwardRef<
     React.useReducer((version: number) => version + 1, 0);
   const [timelineVirtualizerApi, setTimelineVirtualizerApi] =
     React.useState<TimelineVirtualizerApi | null>(null);
-  const useTimelineVirtualizer = true;
+  const useTimelineVirtualizer = useFeatureEnabled("virtuosoTimeline");
   const activeScrollContainerRef = React.useMemo(
     () => ({
       get current() {
@@ -246,6 +247,7 @@ const MessageTimelineBase = React.forwardRef<
   // painted at a stale offset until the user's next scroll event forces layout.
   const scrollContainerDomKey = channelId ?? "none";
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: this effect is scoped to scroll DOM swaps; when the Experiments flag hydrates, the virtualizer child registers its own scroller/API via callbacks, and re-running this reset on the flag transition can briefly clear that API during navigation tests.
   React.useLayoutEffect(() => {
     // Re-read after `scrollContainerDomKey` swaps the keyed scroll DOM node.
     void scrollContainerDomKey;
@@ -390,6 +392,18 @@ const MessageTimelineBase = React.forwardRef<
   React.useEffect(() => {
     const target = pendingSearchTargetRef.current;
     if (!target || showTimelineSkeleton) return;
+    if (
+      useTimelineVirtualizer &&
+      !activeScrollContainerRef.current?.querySelector(
+        `[data-message-id="${CSS.escape(target)}"]`,
+      )
+    ) {
+      // Phase 1: ask Virtuoso to realize the match's index. The retry effect
+      // runs again on range change and the DOM-visible path does the actual
+      // center + highlight once the row exists.
+      void jumpToMessage(target, { behavior: "auto" });
+      return;
+    }
     if (jumpToMessage(target, { behavior: "auto" })) {
       pendingSearchTargetRef.current = null;
     }
@@ -418,6 +432,11 @@ const MessageTimelineBase = React.forwardRef<
     isLoading: showTimelineSkeleton,
     messages: showTimelineSkeleton ? EMPTY_MESSAGES : deferredMessages,
   });
+
+  const handleVirtualizerRangeChanged = React.useCallback(() => {
+    bumpVirtualizerRenderVersion();
+    onScroll();
+  }, [onScroll]);
 
   const timelineList = showMessageList ? (
     <TimelineMessageList
@@ -448,7 +467,8 @@ const MessageTimelineBase = React.forwardRef<
       onStartReached={loadOlderViaVirtualizer}
       onToggleReaction={onToggleReaction}
       onVirtualizerApiChange={setTimelineVirtualizerApi}
-      onVirtualizerRangeChanged={bumpVirtualizerRenderVersion}
+      onVirtualizerRangeChanged={handleVirtualizerRangeChanged}
+      onVirtualizerScroll={onScroll}
       onVirtualizerScrollerChange={setVirtualizerScrollParent}
       onAtBottomStateChange={onVirtualizerAtBottomStateChange}
       personaLookup={personaLookup}

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -194,8 +194,19 @@ const MessageTimelineBase = React.forwardRef<
   const topSentinelRef = React.useRef<HTMLDivElement>(null);
   const [virtualizerScrollParent, setVirtualizerScrollParent] =
     React.useState<HTMLDivElement | null>(null);
+  const [virtualizerRenderVersion, bumpVirtualizerRenderVersion] =
+    React.useReducer((version: number) => version + 1, 0);
   const [timelineVirtualizerApi, setTimelineVirtualizerApi] =
     React.useState<TimelineVirtualizerApi | null>(null);
+  const useTimelineVirtualizer = true;
+  const activeScrollContainerRef = React.useMemo(
+    () => ({
+      get current() {
+        return virtualizerScrollParent ?? scrollContainerRef.current;
+      },
+    }),
+    [scrollContainerRef, virtualizerScrollParent],
+  );
 
   // Gate the heavy timeline render (each row runs a synchronous
   // react-markdown parse) behind React concurrency. `useDeferredValue` lets the
@@ -238,7 +249,9 @@ const MessageTimelineBase = React.forwardRef<
   React.useLayoutEffect(() => {
     // Re-read after `scrollContainerDomKey` swaps the keyed scroll DOM node.
     void scrollContainerDomKey;
-    setVirtualizerScrollParent(scrollContainerRef.current);
+    if (!useTimelineVirtualizer) {
+      setVirtualizerScrollParent(scrollContainerRef.current);
+    }
     setTimelineVirtualizerApi(null);
   }, [scrollContainerRef, scrollContainerDomKey]);
 
@@ -264,11 +277,12 @@ const MessageTimelineBase = React.forwardRef<
     isLoading: showTimelineSkeleton,
     messages: deferredMessages,
     onTargetReached,
-    scrollContainerRef,
+    scrollContainerRef: activeScrollContainerRef,
     targetMessageId,
     virtualScrollToMessage: timelineVirtualizerApi?.scrollToMessage,
     virtualScrollToBottom: timelineVirtualizerApi?.scrollToBottom,
-    virtualizerOwnsPrependAnchoring: virtualizerScrollParent !== null,
+    virtualizerOwnsPrependAnchoring: useTimelineVirtualizer,
+    virtualizerRenderVersion,
   });
 
   const timelineIntroSurface = selectTimelineIntroSurface({
@@ -282,11 +296,18 @@ const MessageTimelineBase = React.forwardRef<
   const showDirectMessageIntro =
     timelineIntroSurface === "direct-message-intro";
   const showChannelIntro = timelineIntroSurface === "channel-intro";
-  const activeDirectMessageIntro = showDirectMessageIntro
-    ? directMessageIntro
-    : null;
-  const activeChannelIntro = showChannelIntro ? channelIntro : null;
-  const showIntro = showDirectMessageIntro || showChannelIntro;
+  const activeDirectMessageIntro =
+    showDirectMessageIntro &&
+    (!useTimelineVirtualizer || timelineBodySurface !== "list")
+      ? directMessageIntro
+      : null;
+  const activeChannelIntro =
+    showChannelIntro &&
+    (!useTimelineVirtualizer || timelineBodySurface !== "list")
+      ? channelIntro
+      : null;
+  const showIntro =
+    activeDirectMessageIntro !== null || activeChannelIntro !== null;
   const showGenericEmpty = timelineBodySurface === "empty" && !showIntro;
   const showMessageList = timelineBodySurface === "list";
 
@@ -365,14 +386,19 @@ const MessageTimelineBase = React.forwardRef<
     }
   }, [jumpToMessage, searchActiveMessageId, showTimelineSkeleton]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: deferredMessages is the intentional retry trigger — a search hit outside the initial window is spliced into messages asynchronously, and the DOM scroll should retry when that row commits.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deferredMessages and virtualizerRenderVersion are intentional retry triggers — a search hit may be spliced into messages asynchronously, and in virtualized mode a phase-1 index jump only realizes the row; retry when the rendered range changes so the DOM-visible path can center and highlight it.
   React.useEffect(() => {
     const target = pendingSearchTargetRef.current;
     if (!target || showTimelineSkeleton) return;
     if (jumpToMessage(target, { behavior: "auto" })) {
       pendingSearchTargetRef.current = null;
     }
-  }, [deferredMessages, jumpToMessage, showTimelineSkeleton]);
+  }, [
+    deferredMessages,
+    jumpToMessage,
+    showTimelineSkeleton,
+    virtualizerRenderVersion,
+  ]);
 
   const loadOlderViaVirtualizer = React.useCallback(() => {
     if (!fetchOlder || showTimelineSkeleton || !hasOlderMessages) return;
@@ -380,10 +406,10 @@ const MessageTimelineBase = React.forwardRef<
   }, [fetchOlder, hasOlderMessages, showTimelineSkeleton]);
 
   useLoadOlderOnScroll({
-    fetchOlder: virtualizerScrollParent ? undefined : fetchOlder,
+    fetchOlder: useTimelineVirtualizer ? undefined : fetchOlder,
     hasOlderMessages,
     isLoading: showTimelineSkeleton,
-    scrollContainerRef,
+    scrollContainerRef: activeScrollContainerRef,
     sentinelRef: topSentinelRef,
   });
 
@@ -392,6 +418,49 @@ const MessageTimelineBase = React.forwardRef<
     isLoading: showTimelineSkeleton,
     messages: showTimelineSkeleton ? EMPTY_MESSAGES : deferredMessages,
   });
+
+  const timelineList = showMessageList ? (
+    <TimelineMessageList
+      key={scrollContainerDomKey}
+      agentPubkeys={agentPubkeys}
+      channelId={channelId}
+      channelName={channelName}
+      channelType={channelType}
+      currentPubkey={currentPubkey}
+      firstUnreadMessageId={firstUnreadMessageId}
+      followThreadById={followThreadById}
+      highlightedMessageId={highlightedMessageId}
+      huddleMemberPubkeys={huddleMemberPubkeys}
+      huddleMemberPubkeysPending={huddleMemberPubkeysPending}
+      isFollowingThreadById={isFollowingThreadById}
+      isMessageUnreadById={isMessageUnreadById}
+      messageFooters={messageFooters}
+      mainEntries={deferredMessages === messages ? mainEntries : undefined}
+      threadSummaries={threadSummaries}
+      messages={deferredMessages}
+      onDelete={onDelete}
+      onEdit={onEdit}
+      onMarkUnread={onMarkUnread}
+      onMarkRead={onMarkRead}
+      onReply={onReply}
+      isSendingVideoReviewComment={isSendingVideoReviewComment}
+      onSendVideoReviewComment={onSendVideoReviewComment}
+      onStartReached={loadOlderViaVirtualizer}
+      onToggleReaction={onToggleReaction}
+      onVirtualizerApiChange={setTimelineVirtualizerApi}
+      onVirtualizerRangeChanged={bumpVirtualizerRenderVersion}
+      onVirtualizerScrollerChange={setVirtualizerScrollParent}
+      onAtBottomStateChange={onVirtualizerAtBottomStateChange}
+      personaLookup={personaLookup}
+      profiles={profiles}
+      searchActiveMessageId={searchActiveMessageId}
+      searchMatchingMessageIds={searchMatchingMessageIds}
+      searchQuery={searchQuery}
+      useVirtualizer={useTimelineVirtualizer}
+      threadUnreadCounts={threadUnreadCounts}
+      unfollowThreadById={unfollowThreadById}
+    />
+  ) : null;
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -429,221 +498,205 @@ const MessageTimelineBase = React.forwardRef<
         ) : null}
         <div
           className={cn(
-            "absolute inset-0 overflow-y-auto overflow-x-hidden overscroll-contain px-2 pt-1",
-            hasComposerOverlay ? "pb-24" : "pb-4",
+            "absolute inset-0 overflow-hidden",
+            !useTimelineVirtualizer &&
+              cn(
+                "overflow-y-auto overflow-x-hidden overscroll-contain px-2 pt-1",
+                hasComposerOverlay ? "pb-24" : "pb-4",
+              ),
           )}
-          data-buzz-conversation-scroll
+          data-buzz-conversation-scroll={
+            useTimelineVirtualizer ? undefined : "true"
+          }
           data-scroll-restoration-id={scrollRestorationId}
-          data-testid="message-timeline"
+          data-testid={useTimelineVirtualizer ? undefined : "message-timeline"}
           key={scrollContainerDomKey}
-          onScroll={onScroll}
+          onScroll={useTimelineVirtualizer ? undefined : onScroll}
           ref={scrollContainerRef}
         >
-          <div
-            className={cn(
-              "flex w-full flex-col gap-2",
-              channelChrome.contentPadding,
-              (showIntro || showGenericEmpty || showMessageList) &&
-                "min-h-full",
-            )}
-            ref={contentRef}
-          >
-            <div ref={topSentinelRef} aria-hidden className="h-px" />
-
-            {/* Fixed-height slot: an always-mounted height keeps the virtual
-                spacer's offset stable across the load-older fetch toggle, so
-                `scrollMargin` doesn't shift mid-fetch and yank the restore. The
-                visible fetch spinner lives in the absolute overlay above, which
-                does not occupy inline flow. */}
-            <div aria-hidden className="h-8" />
-
+          {useTimelineVirtualizer && timelineList ? (
+            <div
+              className="h-full min-h-0 w-full"
+              data-render-pending={isRenderPending ? "true" : undefined}
+            >
+              {timelineList}
+            </div>
+          ) : (
             <div
               className={cn(
-                "flex min-h-[18rem] min-w-0 flex-col gap-2",
-                (showIntro || showGenericEmpty) && "min-h-full",
-                showMessageList && !showIntro && "mt-auto",
+                "flex w-full flex-col gap-2",
+                channelChrome.contentPadding,
+                (showIntro || showGenericEmpty || showMessageList) &&
+                  "min-h-full",
               )}
+              ref={contentRef}
             >
-              {showTimelineSkeleton ? (
-                <TimelineSkeleton rows={timelineSkeletonRows} />
-              ) : null}
-              {activeDirectMessageIntro ? (
-                <div
-                  className="mt-auto flex w-full flex-col items-start px-3 py-2 text-left"
-                  data-testid="message-dm-intro"
-                >
-                  <DirectMessageIntroAvatarStack
-                    participants={activeDirectMessageIntro.participants}
-                  />
-                  <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
-                    {activeDirectMessageIntro.displayName}
-                  </p>
-                  <p className="mt-1 max-w-full truncate whitespace-nowrap text-sm leading-5 text-muted-foreground">
-                    This is the beginning of your direct message with{" "}
-                    <span className="font-medium text-foreground">
-                      {activeDirectMessageIntro.displayName}
-                    </span>
-                    .
-                  </p>
-                </div>
-              ) : null}
+              <div ref={topSentinelRef} aria-hidden className="h-px" />
 
-              {activeChannelIntro ? (
-                <div
-                  className="mt-auto flex w-full max-w-2xl flex-col items-start px-3 py-2 text-left"
-                  data-testid="message-channel-intro"
-                >
+              {/* Fixed-height slot: an always-mounted height keeps the virtual
+                  spacer's offset stable across the load-older fetch toggle, so
+                  `scrollMargin` doesn't shift mid-fetch and yank the restore. The
+                  visible fetch spinner lives in the absolute overlay above, which
+                  does not occupy inline flow. */}
+              <div aria-hidden className="h-8" />
+
+              <div
+                className={cn(
+                  "flex min-h-[18rem] min-w-0 flex-col gap-2",
+                  useTimelineVirtualizer && "min-h-0 flex-1",
+                  (showIntro || showGenericEmpty) && "min-h-full",
+                  showMessageList &&
+                    !showIntro &&
+                    !useTimelineVirtualizer &&
+                    "mt-auto",
+                )}
+              >
+                {showTimelineSkeleton ? (
+                  <TimelineSkeleton rows={timelineSkeletonRows} />
+                ) : null}
+                {activeDirectMessageIntro ? (
                   <div
-                    className="flex h-[60px] w-[60px] items-center justify-center rounded-2xl border border-border/70 bg-muted/40 text-muted-foreground"
-                    data-testid="message-channel-intro-icon"
+                    className="mt-auto flex w-full flex-col items-start px-3 py-2 text-left"
+                    data-testid="message-dm-intro"
                   >
-                    {activeChannelIntro.icon ?? (
-                      <Hash aria-hidden className="h-7 w-7" />
-                    )}
-                  </div>
-                  <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
-                    #{activeChannelIntro.channelName}
-                  </p>
-                  <p className="mt-1 max-w-full text-sm leading-5 text-muted-foreground">
-                    This is the beginning of the{" "}
-                    <span className="font-medium text-foreground">
-                      {activeChannelIntro.channelKindLabel}
-                    </span>
-                    .
-                  </p>
-                  {activeChannelIntro.description ? (
-                    <p className="mt-2 max-w-xl text-sm leading-5 text-muted-foreground">
-                      {activeChannelIntro.description}
+                    <DirectMessageIntroAvatarStack
+                      participants={activeDirectMessageIntro.participants}
+                    />
+                    <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
+                      {activeDirectMessageIntro.displayName}
                     </p>
-                  ) : null}
-                  {activeChannelIntro.actions?.length ? (
-                    <div className="mt-4 flex max-w-full flex-nowrap gap-3 overflow-x-auto pb-1">
-                      {activeChannelIntro.actions.map((action) => {
-                        const hasDescription = Boolean(action.description);
+                    <p className="mt-1 max-w-full truncate whitespace-nowrap text-sm leading-5 text-muted-foreground">
+                      This is the beginning of your direct message with{" "}
+                      <span className="font-medium text-foreground">
+                        {activeDirectMessageIntro.displayName}
+                      </span>
+                      .
+                    </p>
+                  </div>
+                ) : null}
 
-                        return (
-                          <button
-                            className={cn(
-                              "flex shrink-0 border border-border/70 bg-background/70 text-left transition-colors hover:bg-muted/60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
-                              hasDescription
-                                ? "h-56 w-[13.75rem] flex-col rounded-2xl p-4"
-                                : "h-28 w-64 flex-col rounded-2xl p-4",
-                            )}
-                            data-testid={action.testId}
-                            key={action.label}
-                            onClick={action.onClick}
-                            type="button"
-                          >
-                            <span
+                {activeChannelIntro ? (
+                  <div
+                    className="mt-auto flex w-full max-w-2xl flex-col items-start px-3 py-2 text-left"
+                    data-testid="message-channel-intro"
+                  >
+                    <div
+                      className="flex h-[60px] w-[60px] items-center justify-center rounded-2xl border border-border/70 bg-muted/40 text-muted-foreground"
+                      data-testid="message-channel-intro-icon"
+                    >
+                      {activeChannelIntro.icon ?? (
+                        <Hash aria-hidden className="h-7 w-7" />
+                      )}
+                    </div>
+                    <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
+                      #{activeChannelIntro.channelName}
+                    </p>
+                    <p className="mt-1 max-w-full text-sm leading-5 text-muted-foreground">
+                      This is the beginning of the{" "}
+                      <span className="font-medium text-foreground">
+                        {activeChannelIntro.channelKindLabel}
+                      </span>
+                      .
+                    </p>
+                    {activeChannelIntro.description ? (
+                      <p className="mt-2 max-w-xl text-sm leading-5 text-muted-foreground">
+                        {activeChannelIntro.description}
+                      </p>
+                    ) : null}
+                    {activeChannelIntro.actions?.length ? (
+                      <div className="mt-4 flex max-w-full flex-nowrap gap-3 overflow-x-auto pb-1">
+                        {activeChannelIntro.actions.map((action) => {
+                          const hasDescription = Boolean(action.description);
+
+                          return (
+                            <button
                               className={cn(
-                                "flex shrink-0 items-center justify-center rounded-full bg-muted/70 text-muted-foreground",
+                                "flex shrink-0 border border-border/70 bg-background/70 text-left transition-colors hover:bg-muted/60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
                                 hasDescription
-                                  ? "h-12 w-12 [&_svg]:h-6 [&_svg]:w-6"
-                                  : "h-10 w-10 [&_svg]:h-4 [&_svg]:w-4",
+                                  ? "h-56 w-[13.75rem] flex-col rounded-2xl p-4"
+                                  : "h-28 w-64 flex-col rounded-2xl p-4",
                               )}
-                              data-testid={
-                                action.testId
-                                  ? `${action.testId}-icon`
-                                  : undefined
-                              }
+                              data-testid={action.testId}
+                              key={action.label}
+                              onClick={action.onClick}
+                              type="button"
                             >
-                              {action.icon}
-                            </span>
-                            <span className="mt-auto min-w-0">
                               <span
-                                className="block whitespace-normal break-words text-base font-medium leading-6 text-foreground"
+                                className={cn(
+                                  "flex shrink-0 items-center justify-center rounded-full bg-muted/70 text-muted-foreground",
+                                  hasDescription
+                                    ? "h-12 w-12 [&_svg]:h-6 [&_svg]:w-6"
+                                    : "h-10 w-10 [&_svg]:h-4 [&_svg]:w-4",
+                                )}
                                 data-testid={
                                   action.testId
-                                    ? `${action.testId}-title`
+                                    ? `${action.testId}-icon`
                                     : undefined
                                 }
                               >
-                                {action.label}
+                                {action.icon}
                               </span>
-                              {action.description ? (
+                              <span className="mt-auto min-w-0">
                                 <span
-                                  className="mt-1 block whitespace-normal break-words text-sm leading-5 text-muted-foreground"
+                                  className="block whitespace-normal break-words text-base font-medium leading-6 text-foreground"
                                   data-testid={
                                     action.testId
-                                      ? `${action.testId}-description`
+                                      ? `${action.testId}-title`
                                       : undefined
                                   }
                                 >
-                                  {action.description}
+                                  {action.label}
                                 </span>
-                              ) : null}
-                            </span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
+                                {action.description ? (
+                                  <span
+                                    className="mt-1 block whitespace-normal break-words text-sm leading-5 text-muted-foreground"
+                                    data-testid={
+                                      action.testId
+                                        ? `${action.testId}-description`
+                                        : undefined
+                                    }
+                                  >
+                                    {action.description}
+                                  </span>
+                                ) : null}
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
 
-              {showGenericEmpty ? (
-                <div
-                  className="mt-auto rounded-2xl border border-dashed border-border/80 bg-card/70 px-6 py-10 text-center shadow-xs"
-                  data-testid="message-empty"
-                >
-                  <p className="text-base font-semibold tracking-tight">
-                    {emptyTitle}
-                  </p>
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    {emptyDescription}
-                  </p>
-                </div>
-              ) : null}
+                {showGenericEmpty ? (
+                  <div
+                    className="mt-auto rounded-2xl border border-dashed border-border/80 bg-card/70 px-6 py-10 text-center shadow-xs"
+                    data-testid="message-empty"
+                  >
+                    <p className="text-base font-semibold tracking-tight">
+                      {emptyTitle}
+                    </p>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {emptyDescription}
+                    </p>
+                  </div>
+                ) : null}
 
-              {showMessageList ? (
-                <div
-                  className={cn("flex flex-col gap-2", !showIntro && "mt-auto")}
-                  data-render-pending={isRenderPending ? "true" : undefined}
-                >
-                  <TimelineMessageList
-                    key={scrollContainerDomKey}
-                    agentPubkeys={agentPubkeys}
-                    channelId={channelId}
-                    channelName={channelName}
-                    channelType={channelType}
-                    currentPubkey={currentPubkey}
-                    firstUnreadMessageId={firstUnreadMessageId}
-                    followThreadById={followThreadById}
-                    highlightedMessageId={highlightedMessageId}
-                    huddleMemberPubkeys={huddleMemberPubkeys}
-                    huddleMemberPubkeysPending={huddleMemberPubkeysPending}
-                    isFollowingThreadById={isFollowingThreadById}
-                    isMessageUnreadById={isMessageUnreadById}
-                    messageFooters={messageFooters}
-                    mainEntries={
-                      deferredMessages === messages ? mainEntries : undefined
-                    }
-                    threadSummaries={threadSummaries}
-                    messages={deferredMessages}
-                    onDelete={onDelete}
-                    onEdit={onEdit}
-                    onMarkUnread={onMarkUnread}
-                    onMarkRead={onMarkRead}
-                    onReply={onReply}
-                    isSendingVideoReviewComment={isSendingVideoReviewComment}
-                    onSendVideoReviewComment={onSendVideoReviewComment}
-                    onStartReached={loadOlderViaVirtualizer}
-                    onToggleReaction={onToggleReaction}
-                    onVirtualizerApiChange={setTimelineVirtualizerApi}
-                    onAtBottomStateChange={onVirtualizerAtBottomStateChange}
-                    personaLookup={personaLookup}
-                    profiles={profiles}
-                    searchActiveMessageId={searchActiveMessageId}
-                    searchMatchingMessageIds={searchMatchingMessageIds}
-                    searchQuery={searchQuery}
-                    scrollParent={virtualizerScrollParent}
-                    threadUnreadCounts={threadUnreadCounts}
-                    unfollowThreadById={unfollowThreadById}
-                  />
-                </div>
-              ) : null}
+                {showMessageList ? (
+                  <div
+                    className={cn(
+                      "flex flex-col gap-2",
+                      !showIntro && !useTimelineVirtualizer && "mt-auto",
+                      useTimelineVirtualizer && "min-h-0 flex-1",
+                    )}
+                    data-render-pending={isRenderPending ? "true" : undefined}
+                  >
+                    {timelineList}
+                  </div>
+                ) : null}
+              </div>
             </div>
-          </div>
+          )}
         </div>
 
         {!isAtBottom ? (

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { GroupedVirtuoso } from "react-virtuoso";
+import type { Components, GroupedVirtuosoHandle } from "react-virtuoso";
 
 import { formatDayHeading } from "@/features/messages/lib/dateFormatters";
 import { timelineRowReserveStyle } from "@/features/messages/lib/rowHeightEstimate";
@@ -6,6 +8,7 @@ import {
   buildTimelineDayGroups,
   buildTimelineItems,
   getTimelineItemKey,
+  type TimelineDayGroup,
   type TimelineNonDayItem,
 } from "@/features/messages/lib/timelineItems";
 import { THREAD_REPLY_ROW_MARGIN_INLINE_REM } from "@/features/messages/lib/threadTreeLayout";
@@ -27,6 +30,14 @@ import { MessageRow } from "./MessageRow";
 import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
 import { SystemMessageRow } from "./SystemMessageRow";
 import { UnreadDivider } from "./UnreadDivider";
+
+export type TimelineVirtualizerApi = {
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+  scrollToMessage: (
+    messageId: string,
+    options?: { behavior?: ScrollBehavior },
+  ) => boolean;
+};
 
 type TimelineMessageListProps = {
   agentPubkeys?: ReadonlySet<string>;
@@ -81,6 +92,11 @@ type TimelineMessageListProps = {
   searchQuery?: string;
   /** Per-thread unread counts keyed by thread root id. */
   threadUnreadCounts?: ReadonlyMap<string, number>;
+  /** Existing scroll container, reused by the virtualizer spike so MessageTimeline owns the scroll node. */
+  scrollParent?: HTMLElement | null;
+  onStartReached?: () => void;
+  onAtBottomStateChange?: (atBottom: boolean) => void;
+  onVirtualizerApiChange?: (api: TimelineVirtualizerApi | null) => void;
 };
 
 export const TimelineMessageList = React.memo(function TimelineMessageList({
@@ -114,6 +130,10 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
   searchQuery,
   threadUnreadCounts,
   unfollowThreadById,
+  scrollParent = null,
+  onStartReached,
+  onAtBottomStateChange,
+  onVirtualizerApiChange,
 }: TimelineMessageListProps) {
   const entries = React.useMemo(
     () =>
@@ -255,6 +275,19 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
     ],
   );
 
+  if (scrollParent) {
+    return (
+      <VirtualizedTimelineRows
+        dayGroups={dayGroups}
+        onAtBottomStateChange={onAtBottomStateChange}
+        onStartReached={onStartReached}
+        onVirtualizerApiChange={onVirtualizerApiChange}
+        renderItem={renderItem}
+        scrollParent={scrollParent}
+      />
+    );
+  }
+
   return (
     <div className="flex flex-col">
       {dayGroups.map((group) => (
@@ -276,19 +309,187 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
             <DayDivider label={formatDayHeading(group.headingTimestamp)} />
           )}
           {group.items.map((item) => (
-            <div
-              className="timeline-row-cv"
-              key={getTimelineItemKey(item)}
-              style={timelineRowReserveStyle(item)}
-            >
+            <TimelineRowShell item={item} key={getTimelineItemKey(item)}>
               {renderItem(item)}
-            </div>
+            </TimelineRowShell>
           ))}
         </section>
       ))}
     </div>
   );
 });
+
+const FIRST_ITEM_INDEX_BASE = 1_000_000;
+
+type VirtualizedTimelineRowsProps = {
+  dayGroups: TimelineDayGroup[];
+  onAtBottomStateChange?: (atBottom: boolean) => void;
+  onStartReached?: () => void;
+  onVirtualizerApiChange?: (api: TimelineVirtualizerApi | null) => void;
+  renderItem: (item: TimelineNonDayItem) => React.ReactNode;
+  scrollParent: HTMLElement;
+};
+
+function VirtualizedTimelineRows({
+  dayGroups,
+  onAtBottomStateChange,
+  onStartReached,
+  onVirtualizerApiChange,
+  renderItem,
+  scrollParent,
+}: VirtualizedTimelineRowsProps) {
+  const virtuosoRef = React.useRef<GroupedVirtuosoHandle>(null);
+  const firstItemIndexStateRef = React.useRef<StableFirstItemIndexState>({
+    firstItemIndex: FIRST_ITEM_INDEX_BASE,
+    keys: [],
+  });
+  const timelineModel = React.useMemo(() => {
+    const items = dayGroups.flatMap((group) => group.items);
+    return {
+      firstItemIndex: getStableFirstItemIndex(
+        firstItemIndexStateRef.current,
+        items,
+      ),
+      flattenedItems: items,
+      groupCounts: dayGroups.map((group) => group.items.length),
+    };
+  }, [dayGroups]);
+  const { firstItemIndex, flattenedItems, groupCounts } = timelineModel;
+  const messageVirtualIndexById = React.useMemo(() => {
+    const byId = new Map<string, number>();
+    flattenedItems.forEach((item, index) => {
+      if (item.kind === "message" || item.kind === "system") {
+        byId.set(item.entry.message.id, index);
+      }
+    });
+    return byId;
+  }, [flattenedItems]);
+
+  React.useLayoutEffect(() => {
+    if (!onVirtualizerApiChange) return;
+    const api: TimelineVirtualizerApi = {
+      scrollToBottom(behavior = "auto") {
+        virtuosoRef.current?.scrollToIndex({
+          align: "end",
+          behavior: behavior === "smooth" ? "smooth" : "auto",
+          index: "LAST",
+        });
+      },
+      scrollToMessage(messageId, options = {}) {
+        const index = messageVirtualIndexById.get(messageId);
+        if (index === undefined) return false;
+        virtuosoRef.current?.scrollToIndex({
+          align: "center",
+          behavior: options.behavior === "smooth" ? "smooth" : "auto",
+          index,
+        });
+        return true;
+      },
+    };
+    onVirtualizerApiChange(api);
+    return () => onVirtualizerApiChange(null);
+  }, [messageVirtualIndexById, onVirtualizerApiChange]);
+
+  return (
+    <GroupedVirtuoso<TimelineNonDayItem>
+      ref={virtuosoRef}
+      className="min-h-full"
+      components={virtuosoComponents}
+      computeItemKey={(index, item) =>
+        item === undefined
+          ? `timeline-missing-${index}`
+          : getTimelineItemKey(item)
+      }
+      customScrollParent={scrollParent}
+      data={flattenedItems}
+      defaultItemHeight={72}
+      firstItemIndex={firstItemIndex}
+      followOutput="auto"
+      atBottomStateChange={onAtBottomStateChange}
+      initialTopMostItemIndex={{ align: "end", index: "LAST" }}
+      groupContent={(groupIndex) => {
+        const group = dayGroups[groupIndex];
+        return (
+          <div
+            className={cn(
+              "relative flex flex-col",
+              group.headingTimestamp !== null &&
+                "before:absolute before:inset-x-0 before:top-4 before:h-px before:bg-border/35 before:content-['']",
+            )}
+            data-day-label={
+              group.headingTimestamp === null
+                ? undefined
+                : formatDayHeading(group.headingTimestamp)
+            }
+            data-testid="message-timeline-day-group"
+          >
+            {group.headingTimestamp === null ? null : (
+              <DayDivider label={formatDayHeading(group.headingTimestamp)} />
+            )}
+          </div>
+        );
+      }}
+      groupCounts={groupCounts}
+      itemContent={(_index, _groupIndex, item) => (
+        <TimelineRowShell item={item}>{renderItem(item)}</TimelineRowShell>
+      )}
+      startReached={onStartReached ? () => onStartReached() : undefined}
+    />
+  );
+}
+
+const virtuosoComponents: Components<TimelineNonDayItem> = {
+  List: React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<"div">>(
+    function TimelineVirtuosoList({ className, ...props }, ref) {
+      return (
+        <div {...props} className={cn("flex flex-col", className)} ref={ref} />
+      );
+    },
+  ),
+};
+
+function TimelineRowShell({
+  children,
+  item,
+}: {
+  children: React.ReactNode;
+  item: TimelineNonDayItem;
+}) {
+  return (
+    <div className="timeline-row-cv" style={timelineRowReserveStyle(item)}>
+      {children}
+    </div>
+  );
+}
+
+type StableFirstItemIndexState = {
+  firstItemIndex: number;
+  keys: string[];
+};
+
+function getStableFirstItemIndex(
+  state: StableFirstItemIndexState,
+  items: TimelineNonDayItem[],
+): number {
+  const keys = items.map(getTimelineItemKey);
+  let firstItemIndex = state.firstItemIndex;
+
+  if (state.keys.length === 0 || keys.length === 0) {
+    firstItemIndex = FIRST_ITEM_INDEX_BASE;
+  } else {
+    const previousFirstKey = state.keys[0];
+    const previousFirstIndex = keys.indexOf(previousFirstKey);
+    if (previousFirstIndex > 0) {
+      firstItemIndex -= previousFirstIndex;
+    } else if (previousFirstIndex === -1) {
+      firstItemIndex = FIRST_ITEM_INDEX_BASE;
+    }
+  }
+
+  state.firstItemIndex = firstItemIndex;
+  state.keys = keys;
+  return firstItemIndex;
+}
 
 function SystemRow({
   currentPubkey,

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -103,6 +103,7 @@ type TimelineMessageListProps = {
   onAtBottomStateChange?: (atBottom: boolean) => void;
   onVirtualizerApiChange?: (api: TimelineVirtualizerApi | null) => void;
   onVirtualizerRangeChanged?: () => void;
+  onVirtualizerScroll?: () => void;
   onVirtualizerScrollerChange?: (element: HTMLDivElement | null) => void;
 };
 
@@ -142,6 +143,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
   onAtBottomStateChange,
   onVirtualizerApiChange,
   onVirtualizerRangeChanged,
+  onVirtualizerScroll,
   onVirtualizerScrollerChange,
 }: TimelineMessageListProps) {
   const entries = React.useMemo(
@@ -292,6 +294,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
         onStartReached={onStartReached}
         onVirtualizerApiChange={onVirtualizerApiChange}
         onVirtualizerRangeChanged={onVirtualizerRangeChanged}
+        onVirtualizerScroll={onVirtualizerScroll}
         onVirtualizerScrollerChange={onVirtualizerScrollerChange}
         renderItem={renderItem}
       />
@@ -331,12 +334,68 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
 
 const FIRST_ITEM_INDEX_BASE = 1_000_000;
 
+function timelineItemMessageId(item: TimelineNonDayItem): string | null {
+  return item.kind === "message" || item.kind === "system"
+    ? item.entry.message.id
+    : null;
+}
+
+function groupedInternalIndexForItem(
+  groupCounts: readonly number[],
+  itemIndex: number,
+): number {
+  let itemCount = 0;
+
+  for (let groupIndex = 0; groupIndex < groupCounts.length; groupIndex += 1) {
+    if (itemIndex < itemCount + groupCounts[groupIndex]) {
+      return itemIndex + groupIndex + 1;
+    }
+    itemCount += groupCounts[groupIndex];
+  }
+
+  return itemIndex + groupCounts.length;
+}
+
+function buildGroupedInternalKeyByIndex(
+  firstItemIndex: number,
+  dayGroups: readonly TimelineDayGroup[],
+): Map<number, string> {
+  const keyByIndex = new Map<number, string>();
+  let internalIndex = 0;
+
+  for (const group of dayGroups) {
+    keyByIndex.set(firstItemIndex + internalIndex, `day-${group.key}`);
+    internalIndex += 1;
+
+    for (const item of group.items) {
+      keyByIndex.set(firstItemIndex + internalIndex, getTimelineItemKey(item));
+      internalIndex += 1;
+    }
+  }
+
+  return keyByIndex;
+}
+
+function buildGroupedInternalData(
+  dayGroups: readonly TimelineDayGroup[],
+): Array<TimelineNonDayItem | undefined> {
+  const data: Array<TimelineNonDayItem | undefined> = [];
+
+  for (const group of dayGroups) {
+    data.push(undefined);
+    data.push(...group.items);
+  }
+
+  return data;
+}
+
 type VirtualizedTimelineRowsProps = {
   dayGroups: TimelineDayGroup[];
   onAtBottomStateChange?: (atBottom: boolean) => void;
   onStartReached?: () => void;
   onVirtualizerApiChange?: (api: TimelineVirtualizerApi | null) => void;
   onVirtualizerRangeChanged?: () => void;
+  onVirtualizerScroll?: () => void;
   onVirtualizerScrollerChange?: (element: HTMLDivElement | null) => void;
   renderItem: (item: TimelineNonDayItem) => React.ReactNode;
 };
@@ -347,10 +406,13 @@ function VirtualizedTimelineRows({
   onStartReached,
   onVirtualizerApiChange,
   onVirtualizerRangeChanged,
+  onVirtualizerScroll,
   onVirtualizerScrollerChange,
   renderItem,
 }: VirtualizedTimelineRowsProps) {
   const virtuosoRef = React.useRef<GroupedVirtuosoHandle>(null);
+  const [scrollerElement, setScrollerElement] =
+    React.useState<HTMLDivElement | null>(null);
   const firstItemIndexStateRef = React.useRef<StableFirstItemIndexState>({
     firstItemIndex: FIRST_ITEM_INDEX_BASE,
     keys: [],
@@ -367,15 +429,56 @@ function VirtualizedTimelineRows({
     };
   }, [dayGroups]);
   const { firstItemIndex, flattenedItems, groupCounts } = timelineModel;
-  const messageVirtualIndexById = React.useMemo(() => {
+  const groupedInternalKeyByIndex = React.useMemo(
+    () => buildGroupedInternalKeyByIndex(firstItemIndex, dayGroups),
+    [dayGroups, firstItemIndex],
+  );
+  const groupedInternalData = React.useMemo(
+    () => buildGroupedInternalData(dayGroups),
+    [dayGroups],
+  );
+  const virtualizerModelRef = React.useRef<{
+    firstItemIndex: number;
+    flattenedCount: number;
+    groupCounts: readonly number[];
+    messageItemIndexById: Map<string, number>;
+  }>({
+    firstItemIndex,
+    flattenedCount: flattenedItems.length,
+    groupCounts,
+    messageItemIndexById: new Map(),
+  });
+  const deferredScrollFrameRef = React.useRef<number | null>(null);
+  React.useEffect(
+    () => () => {
+      if (deferredScrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(deferredScrollFrameRef.current);
+        deferredScrollFrameRef.current = null;
+      }
+    },
+    [],
+  );
+  const messageItemIndexById = React.useMemo(() => {
     const byId = new Map<string, number>();
     flattenedItems.forEach((item, index) => {
-      if (item.kind === "message" || item.kind === "system") {
-        byId.set(item.entry.message.id, index);
-      }
+      const messageId = timelineItemMessageId(item);
+      if (messageId) byId.set(messageId, index);
     });
     return byId;
   }, [flattenedItems]);
+  React.useLayoutEffect(() => {
+    virtualizerModelRef.current = {
+      firstItemIndex,
+      flattenedCount: flattenedItems.length,
+      groupCounts,
+      messageItemIndexById,
+    };
+  }, [
+    firstItemIndex,
+    flattenedItems.length,
+    groupCounts,
+    messageItemIndexById,
+  ]);
 
   React.useLayoutEffect(() => {
     if (!onVirtualizerApiChange) return;
@@ -388,26 +491,66 @@ function VirtualizedTimelineRows({
         });
       },
       scrollToMessage(messageId, options = {}) {
-        const index = messageVirtualIndexById.get(messageId);
-        if (index === undefined) return false;
-        virtuosoRef.current?.scrollToIndex({
-          align: "center",
-          behavior: options.behavior === "smooth" ? "smooth" : "auto",
-          index,
+        const itemIndex = messageItemIndexById.get(messageId);
+        if (itemIndex === undefined) return false;
+        if (deferredScrollFrameRef.current !== null) {
+          window.cancelAnimationFrame(deferredScrollFrameRef.current);
+        }
+        const requested = {
+          count: flattenedItems.length,
+          firstItemIndex,
+          itemIndex,
+          messageId,
+        };
+        deferredScrollFrameRef.current = window.requestAnimationFrame(() => {
+          deferredScrollFrameRef.current = null;
+          const current = virtualizerModelRef.current;
+          const currentIndex = current.messageItemIndexById.get(messageId);
+          if (
+            currentIndex !== requested.itemIndex ||
+            current.firstItemIndex !== requested.firstItemIndex ||
+            current.flattenedCount !== requested.count
+          ) {
+            return;
+          }
+          virtuosoRef.current?.scrollToIndex({
+            align: "center",
+            behavior: options.behavior === "smooth" ? "smooth" : "auto",
+            index: groupedInternalIndexForItem(
+              current.groupCounts,
+              requested.itemIndex,
+            ),
+          });
         });
         return true;
       },
     };
     onVirtualizerApiChange(api);
     return () => onVirtualizerApiChange(null);
-  }, [messageVirtualIndexById, onVirtualizerApiChange]);
+  }, [
+    flattenedItems.length,
+    firstItemIndex,
+    messageItemIndexById,
+    onVirtualizerApiChange,
+  ]);
 
   const handleScrollerRef = React.useCallback(
     (ref: HTMLElement | Window | null) => {
-      onVirtualizerScrollerChange?.(ref instanceof HTMLDivElement ? ref : null);
+      const scroller = ref instanceof HTMLDivElement ? ref : null;
+      onVirtualizerScrollerChange?.(scroller);
+      setScrollerElement(scroller);
     },
     [onVirtualizerScrollerChange],
   );
+
+  React.useEffect(() => {
+    if (!scrollerElement || !onVirtualizerScroll) return;
+    scrollerElement.addEventListener("scroll", onVirtualizerScroll, {
+      passive: true,
+    });
+    return () =>
+      scrollerElement.removeEventListener("scroll", onVirtualizerScroll);
+  }, [onVirtualizerScroll, scrollerElement]);
 
   const handleRangeChanged = React.useCallback(
     (_range: ListRange) => {
@@ -417,16 +560,17 @@ function VirtualizedTimelineRows({
   );
 
   return (
-    <GroupedVirtuoso<TimelineNonDayItem>
+    <GroupedVirtuoso<TimelineNonDayItem | undefined>
       ref={virtuosoRef}
       className="h-full min-h-0 w-full"
       components={virtuosoComponents}
       computeItemKey={(index, item) =>
         item === undefined
-          ? `timeline-missing-${index}`
+          ? (groupedInternalKeyByIndex.get(index) ??
+            `timeline-missing-${index}`)
           : getTimelineItemKey(item)
       }
-      data={flattenedItems}
+      data={groupedInternalData}
       defaultItemHeight={72}
       firstItemIndex={firstItemIndex}
       followOutput="auto"
@@ -455,9 +599,14 @@ function VirtualizedTimelineRows({
         );
       }}
       groupCounts={groupCounts}
-      itemContent={(_index, _groupIndex, item) => (
-        <TimelineRowShell item={item}>{renderItem(item)}</TimelineRowShell>
-      )}
+      itemContent={(_index, _groupIndex, item) => {
+        if (!item) return null;
+        return (
+          <TimelineRowShell item={item} useContentVisibility={false}>
+            {renderItem(item)}
+          </TimelineRowShell>
+        );
+      }}
       rangeChanged={handleRangeChanged}
       scrollerRef={handleScrollerRef}
       startReached={onStartReached ? () => onStartReached() : undefined}
@@ -465,7 +614,7 @@ function VirtualizedTimelineRows({
   );
 }
 
-const virtuosoComponents: Components<TimelineNonDayItem> = {
+const virtuosoComponents: Components<TimelineNonDayItem | undefined> = {
   Scroller: React.forwardRef<
     HTMLDivElement,
     ScrollerProps & { className?: string }
@@ -496,12 +645,17 @@ const virtuosoComponents: Components<TimelineNonDayItem> = {
 function TimelineRowShell({
   children,
   item,
+  useContentVisibility = true,
 }: {
   children: React.ReactNode;
   item: TimelineNonDayItem;
+  useContentVisibility?: boolean;
 }) {
   return (
-    <div className="timeline-row-cv" style={timelineRowReserveStyle(item)}>
+    <div
+      className={useContentVisibility ? "timeline-row-cv" : undefined}
+      style={useContentVisibility ? timelineRowReserveStyle(item) : undefined}
+    >
       {children}
     </div>
   );

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import { GroupedVirtuoso } from "react-virtuoso";
-import type { Components, GroupedVirtuosoHandle } from "react-virtuoso";
+import type {
+  Components,
+  GroupedVirtuosoHandle,
+  ListRange,
+  ScrollerProps,
+} from "react-virtuoso";
 
 import { formatDayHeading } from "@/features/messages/lib/dateFormatters";
 import { timelineRowReserveStyle } from "@/features/messages/lib/rowHeightEstimate";
@@ -93,10 +98,12 @@ type TimelineMessageListProps = {
   /** Per-thread unread counts keyed by thread root id. */
   threadUnreadCounts?: ReadonlyMap<string, number>;
   /** Existing scroll container, reused by the virtualizer spike so MessageTimeline owns the scroll node. */
-  scrollParent?: HTMLElement | null;
+  useVirtualizer?: boolean;
   onStartReached?: () => void;
   onAtBottomStateChange?: (atBottom: boolean) => void;
   onVirtualizerApiChange?: (api: TimelineVirtualizerApi | null) => void;
+  onVirtualizerRangeChanged?: () => void;
+  onVirtualizerScrollerChange?: (element: HTMLDivElement | null) => void;
 };
 
 export const TimelineMessageList = React.memo(function TimelineMessageList({
@@ -130,10 +137,12 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
   searchQuery,
   threadUnreadCounts,
   unfollowThreadById,
-  scrollParent = null,
+  useVirtualizer = false,
   onStartReached,
   onAtBottomStateChange,
   onVirtualizerApiChange,
+  onVirtualizerRangeChanged,
+  onVirtualizerScrollerChange,
 }: TimelineMessageListProps) {
   const entries = React.useMemo(
     () =>
@@ -275,15 +284,16 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
     ],
   );
 
-  if (scrollParent) {
+  if (useVirtualizer) {
     return (
       <VirtualizedTimelineRows
         dayGroups={dayGroups}
         onAtBottomStateChange={onAtBottomStateChange}
         onStartReached={onStartReached}
         onVirtualizerApiChange={onVirtualizerApiChange}
+        onVirtualizerRangeChanged={onVirtualizerRangeChanged}
+        onVirtualizerScrollerChange={onVirtualizerScrollerChange}
         renderItem={renderItem}
-        scrollParent={scrollParent}
       />
     );
   }
@@ -326,8 +336,9 @@ type VirtualizedTimelineRowsProps = {
   onAtBottomStateChange?: (atBottom: boolean) => void;
   onStartReached?: () => void;
   onVirtualizerApiChange?: (api: TimelineVirtualizerApi | null) => void;
+  onVirtualizerRangeChanged?: () => void;
+  onVirtualizerScrollerChange?: (element: HTMLDivElement | null) => void;
   renderItem: (item: TimelineNonDayItem) => React.ReactNode;
-  scrollParent: HTMLElement;
 };
 
 function VirtualizedTimelineRows({
@@ -335,8 +346,9 @@ function VirtualizedTimelineRows({
   onAtBottomStateChange,
   onStartReached,
   onVirtualizerApiChange,
+  onVirtualizerRangeChanged,
+  onVirtualizerScrollerChange,
   renderItem,
-  scrollParent,
 }: VirtualizedTimelineRowsProps) {
   const virtuosoRef = React.useRef<GroupedVirtuosoHandle>(null);
   const firstItemIndexStateRef = React.useRef<StableFirstItemIndexState>({
@@ -390,17 +402,30 @@ function VirtualizedTimelineRows({
     return () => onVirtualizerApiChange(null);
   }, [messageVirtualIndexById, onVirtualizerApiChange]);
 
+  const handleScrollerRef = React.useCallback(
+    (ref: HTMLElement | Window | null) => {
+      onVirtualizerScrollerChange?.(ref instanceof HTMLDivElement ? ref : null);
+    },
+    [onVirtualizerScrollerChange],
+  );
+
+  const handleRangeChanged = React.useCallback(
+    (_range: ListRange) => {
+      onVirtualizerRangeChanged?.();
+    },
+    [onVirtualizerRangeChanged],
+  );
+
   return (
     <GroupedVirtuoso<TimelineNonDayItem>
       ref={virtuosoRef}
-      className="min-h-full"
+      className="h-full min-h-0 w-full"
       components={virtuosoComponents}
       computeItemKey={(index, item) =>
         item === undefined
           ? `timeline-missing-${index}`
           : getTimelineItemKey(item)
       }
-      customScrollParent={scrollParent}
       data={flattenedItems}
       defaultItemHeight={72}
       firstItemIndex={firstItemIndex}
@@ -433,12 +458,32 @@ function VirtualizedTimelineRows({
       itemContent={(_index, _groupIndex, item) => (
         <TimelineRowShell item={item}>{renderItem(item)}</TimelineRowShell>
       )}
+      rangeChanged={handleRangeChanged}
+      scrollerRef={handleScrollerRef}
       startReached={onStartReached ? () => onStartReached() : undefined}
     />
   );
 }
 
 const virtuosoComponents: Components<TimelineNonDayItem> = {
+  Scroller: React.forwardRef<
+    HTMLDivElement,
+    ScrollerProps & { className?: string }
+  >(function TimelineVirtuosoScroller({ className, ...props }, ref) {
+    return (
+      <div
+        {...props}
+        className={cn(
+          "h-full min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain px-2 pt-1 pb-24",
+          className,
+        )}
+        data-buzz-conversation-scroll
+        data-testid="message-timeline"
+        data-virtuoso-scroller="true"
+        ref={ref}
+      />
+    );
+  }),
   List: React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<"div">>(
     function TimelineVirtuosoList({ className, ...props }, ref) {
       return (

--- a/desktop/src/features/messages/ui/useAnchoredScroll.ts
+++ b/desktop/src/features/messages/ui/useAnchoredScroll.ts
@@ -49,6 +49,14 @@ type UseAnchoredScrollOptions = {
   /** When set, scroll to and highlight this message on mount and on change. */
   targetMessageId?: string | null;
   onTargetReached?: (messageId: string) => void;
+  virtualScrollToMessage?: (
+    messageId: string,
+    options?: { behavior?: ScrollBehavior },
+  ) => boolean;
+  /** Imperative virtualizer-owned bottom jump, used only when virtualizer mode is active. */
+  virtualScrollToBottom?: (behavior?: ScrollBehavior) => void;
+  /** Spike mode: let the virtualizer preserve prepend position via its own firstItemIndex path. */
+  virtualizerOwnsPrependAnchoring?: boolean;
 };
 
 type UseAnchoredScrollResult = {
@@ -72,6 +80,8 @@ type UseAnchoredScrollResult = {
     messageId: string,
     options?: { highlight?: boolean; behavior?: ScrollBehavior },
   ) => boolean;
+  /** Syncs the hook's bottom affordances from a virtualizer-owned scroller. */
+  onVirtualizerAtBottomStateChange: (atBottom: boolean) => void;
 };
 
 function isAtBottomNow(
@@ -150,6 +160,9 @@ export function useAnchoredScroll({
 
   targetMessageId = null,
   onTargetReached,
+  virtualScrollToMessage,
+  virtualScrollToBottom,
+  virtualizerOwnsPrependAnchoring = false,
 }: UseAnchoredScrollOptions): UseAnchoredScrollResult {
   // Anchor lives in a ref because it must survive renders and is updated
   // both on scroll (commit-time read) and in the layout effect (post-render
@@ -222,11 +235,19 @@ export function useAnchoredScroll({
       // every imperative bottom jump so `onScroll` holds the at-bottom anchor
       // until it can snap to the true floor.
       settlingRef.current = true;
-      container.scrollTo({ top: container.scrollHeight, behavior });
+      if (virtualizerOwnsPrependAnchoring && virtualScrollToBottom) {
+        virtualScrollToBottom(behavior);
+      } else {
+        container.scrollTo({ top: container.scrollHeight, behavior });
+      }
       setIsAtBottom(true);
       setNewMessageCount(0);
     },
-    [scrollContainerRef],
+    [
+      scrollContainerRef,
+      virtualScrollToBottom,
+      virtualizerOwnsPrependAnchoring,
+    ],
   );
 
   // Arm a one-shot: the next append snaps to bottom regardless of where the
@@ -234,6 +255,19 @@ export function useAnchoredScroll({
   // outbound message pulls the view down even if they'd scrolled up.
   const scrollToBottomOnNextUpdate = React.useCallback(() => {
     forceBottomOnNextAppendRef.current = true;
+  }, []);
+
+  const highlightMessage = React.useCallback((messageId: string) => {
+    if (highlightTimeoutRef.current !== null) {
+      window.clearTimeout(highlightTimeoutRef.current);
+    }
+    setHighlightedMessageId(messageId);
+    highlightTimeoutRef.current = window.setTimeout(() => {
+      setHighlightedMessageId((current) =>
+        current === messageId ? null : current,
+      );
+      highlightTimeoutRef.current = null;
+    }, 2_000);
   }, []);
 
   const scrollToMessageImperative = React.useCallback(
@@ -246,7 +280,19 @@ export function useAnchoredScroll({
       const el = container.querySelector<HTMLElement>(
         `[data-message-id="${messageId}"]`,
       );
-      if (!el) return false;
+      if (!el) {
+        if (
+          virtualScrollToMessage?.(messageId, {
+            behavior: options.behavior ?? "auto",
+          })
+        ) {
+          anchorRef.current = { kind: "message", messageId, topOffset: 0 };
+          setIsAtBottom(false);
+          if (options.highlight) highlightMessage(messageId);
+          return true;
+        }
+        return false;
+      }
 
       const rect = el.getBoundingClientRect();
       const containerRect = container.getBoundingClientRect();
@@ -279,21 +325,10 @@ export function useAnchoredScroll({
       };
       setIsAtBottom(maxScrollTop - targetScrollTop <= AT_BOTTOM_THRESHOLD_PX);
 
-      if (options.highlight) {
-        if (highlightTimeoutRef.current !== null) {
-          window.clearTimeout(highlightTimeoutRef.current);
-        }
-        setHighlightedMessageId(messageId);
-        highlightTimeoutRef.current = window.setTimeout(() => {
-          setHighlightedMessageId((current) =>
-            current === messageId ? null : current,
-          );
-          highlightTimeoutRef.current = null;
-        }, 2_000);
-      }
+      if (options.highlight) highlightMessage(messageId);
       return true;
     },
-    [scrollContainerRef],
+    [highlightMessage, scrollContainerRef, virtualScrollToMessage],
   );
 
   // Scroll handler: recompute anchor + bottom state from the current
@@ -311,6 +346,9 @@ export function useAnchoredScroll({
       if (settleProgrammaticBottomPin(container)) {
         settlingRef.current = false;
       } else {
+        if (virtualizerOwnsPrependAnchoring) {
+          settlingRef.current = false;
+        }
         return;
       }
     }
@@ -320,7 +358,7 @@ export function useAnchoredScroll({
     if (atBottom) {
       setNewMessageCount(0);
     }
-  }, [scrollContainerRef]);
+  }, [scrollContainerRef, virtualizerOwnsPrependAnchoring]);
 
   // ---------------------------------------------------------------------------
   // Anchor restoration: after every render, stick to the bottom if the user is
@@ -396,7 +434,11 @@ export function useAnchoredScroll({
       forceBottomOnNextAppendRef.current = false;
       anchorRef.current = { kind: "at-bottom" };
       settlingRef.current = true;
-      container.scrollTo({ top: container.scrollHeight, behavior: "auto" });
+      if (virtualizerOwnsPrependAnchoring && virtualScrollToBottom) {
+        virtualScrollToBottom("auto");
+      } else {
+        container.scrollTo({ top: container.scrollHeight, behavior: "auto" });
+      }
       setIsAtBottom(true);
       setNewMessageCount(0);
       prevLastMessageIdRef.current = lastMessage?.id;
@@ -407,10 +449,13 @@ export function useAnchoredScroll({
     }
 
     if (anchor.kind === "at-bottom") {
-      // Stick to bottom across the append.
-      container.scrollTo({ top: container.scrollHeight, behavior: "auto" });
+      // Stick to bottom across the append. In virtualized mode, Virtuoso's
+      // followOutput owns this write; do not slam the shared scroll parent.
+      if (!virtualizerOwnsPrependAnchoring) {
+        container.scrollTo({ top: container.scrollHeight, behavior: "auto" });
+      }
       if (newLatestArrived) setNewMessageCount(0);
-    } else if (messagesArrived > 0) {
+    } else if (messagesArrived > 0 && !virtualizerOwnsPrependAnchoring) {
       // Anchored mid-history. An older-history prepend grows the content above
       // the reading row; the browser's native scroll anchoring does NOT correct
       // this at the top edge (no anchor node above the viewport when scrollTop
@@ -449,6 +494,8 @@ export function useAnchoredScroll({
     scrollToBottomImperative,
     scrollToMessageImperative,
     targetMessageId,
+    virtualScrollToBottom,
+    virtualizerOwnsPrependAnchoring,
   ]);
 
   // ---------------------------------------------------------------------------
@@ -466,13 +513,21 @@ export function useAnchoredScroll({
     const observer = new ResizeObserver(() => {
       const container = scrollContainerRef.current;
       if (!container) return;
-      if (anchorRef.current.kind === "at-bottom") {
+      if (
+        anchorRef.current.kind === "at-bottom" &&
+        !virtualizerOwnsPrependAnchoring
+      ) {
         container.scrollTo({ top: container.scrollHeight, behavior: "auto" });
       }
     });
     observer.observe(content);
     return () => observer.disconnect();
-  }, [channelId, contentRef, scrollContainerRef]);
+  }, [
+    channelId,
+    contentRef,
+    scrollContainerRef,
+    virtualizerOwnsPrependAnchoring,
+  ]);
 
   // ---------------------------------------------------------------------------
   // Target message handling (deep link, jump-to-reply, etc.). Distinct from
@@ -500,6 +555,13 @@ export function useAnchoredScroll({
     const el = container.querySelector<HTMLElement>(
       `[data-message-id="${targetMessageId}"]`,
     );
+    if (!el && virtualizerOwnsPrependAnchoring) {
+      if (scrollToMessageImperative(targetMessageId, { highlight: true })) {
+        handledTargetIdRef.current = targetMessageId;
+        onTargetReached?.(targetMessageId);
+      }
+      return;
+    }
     if (!el) {
       // Row not in the DOM yet. A cold deep-link target is fetched by id and
       // spliced into `messages` a render or two later; this effect re-runs on
@@ -516,6 +578,7 @@ export function useAnchoredScroll({
     scrollContainerRef,
     scrollToMessageImperative,
     targetMessageId,
+    virtualizerOwnsPrependAnchoring,
   ]);
 
   React.useEffect(() => {
@@ -526,6 +589,18 @@ export function useAnchoredScroll({
     };
   }, []);
 
+  const onVirtualizerAtBottomStateChange = React.useCallback(
+    (atBottom: boolean) => {
+      if (!virtualizerOwnsPrependAnchoring) return;
+      if (atBottom) {
+        anchorRef.current = { kind: "at-bottom" };
+        setNewMessageCount(0);
+      }
+      setIsAtBottom(atBottom);
+    },
+    [virtualizerOwnsPrependAnchoring],
+  );
+
   return {
     onScroll,
     isAtBottom,
@@ -534,5 +609,6 @@ export function useAnchoredScroll({
     scrollToBottom: scrollToBottomImperative,
     scrollToBottomOnNextUpdate,
     scrollToMessage: scrollToMessageImperative,
+    onVirtualizerAtBottomStateChange,
   };
 }

--- a/desktop/src/features/messages/ui/useAnchoredScroll.ts
+++ b/desktop/src/features/messages/ui/useAnchoredScroll.ts
@@ -286,7 +286,10 @@ export function useAnchoredScroll({
       if (!el) {
         if (
           virtualScrollToMessage?.(messageId, {
-            behavior: options.behavior ?? "auto",
+            // Phase 1 only asks the virtualizer to realize an off-DOM row.
+            // Keep this jump synchronous; the DOM-visible phase below applies
+            // the caller's smooth/auto behavior once the target can be measured.
+            behavior: "auto",
           })
         ) {
           anchorRef.current = { kind: "message", messageId, topOffset: 0 };
@@ -547,7 +550,7 @@ export function useAnchoredScroll({
   // *without* marking the target handled until its row actually exists — each
   // subsequent message commit re-runs the effect and retries the centering.
   // ---------------------------------------------------------------------------
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `messages` is an intentional trigger, not a read — the effect reads the DOM (querySelector), and we need it to re-run each time the rendered row set changes so a target spliced into older history gets centered once its row commits.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `messages` and `virtualizerRenderVersion` are intentional retry triggers, not values read by the effect body — the effect reads the DOM (querySelector), and we need it to re-run each time the message list or virtualized rendered range changes so a target spliced into older history gets centered once its row commits.
   React.useEffect(() => {
     if (!targetMessageId) {
       handledTargetIdRef.current = null;
@@ -556,6 +559,7 @@ export function useAnchoredScroll({
     if (handledTargetIdRef.current === targetMessageId || isLoading) return;
     if (!hasInitializedRef.current) return; // initial-mount path will handle.
 
+    void virtualizerRenderVersion;
     const container = scrollContainerRef.current;
     if (!container) return;
     const el = container.querySelector<HTMLElement>(

--- a/desktop/src/features/messages/ui/useAnchoredScroll.ts
+++ b/desktop/src/features/messages/ui/useAnchoredScroll.ts
@@ -57,6 +57,8 @@ type UseAnchoredScrollOptions = {
   virtualScrollToBottom?: (behavior?: ScrollBehavior) => void;
   /** Spike mode: let the virtualizer preserve prepend position via its own firstItemIndex path. */
   virtualizerOwnsPrependAnchoring?: boolean;
+  /** Bumps when a virtualized range changes, so pending target/search retries can re-check newly mounted DOM. */
+  virtualizerRenderVersion?: number;
 };
 
 type UseAnchoredScrollResult = {
@@ -163,6 +165,7 @@ export function useAnchoredScroll({
   virtualScrollToMessage,
   virtualScrollToBottom,
   virtualizerOwnsPrependAnchoring = false,
+  virtualizerRenderVersion = 0,
 }: UseAnchoredScrollOptions): UseAnchoredScrollResult {
   // Anchor lives in a ref because it must survive renders and is updated
   // both on scroll (commit-time read) and in the layout effect (post-render
@@ -288,8 +291,11 @@ export function useAnchoredScroll({
         ) {
           anchorRef.current = { kind: "message", messageId, topOffset: 0 };
           setIsAtBottom(false);
-          if (options.highlight) highlightMessage(messageId);
-          return true;
+          // In virtualized mode, this is only the phase-1 realization request:
+          // the target row is not in the DOM yet, so centering can still re-aim
+          // once Virtuoso mounts/measures it. Start the highlight clock only on
+          // the later DOM-visible path, otherwise it can fade before the row has
+          // settled in view.
         }
         return false;
       }
@@ -579,6 +585,7 @@ export function useAnchoredScroll({
     scrollToMessageImperative,
     targetMessageId,
     virtualizerOwnsPrependAnchoring,
+    virtualizerRenderVersion,
   ]);
 
   React.useEffect(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      react-virtuoso:
+        specifier: ^4.18.10
+        version: 4.18.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
@@ -286,6 +289,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      react-virtuoso:
+        specifier: ^4.18.10
+        version: 4.18.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2808,6 +2814,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-virtuoso@4.18.10:
+    resolution: {integrity: sha512-P6GIZ7kWAPOYB2H16yRQNgy+VF9pJOuTFw1EUc1EAtCj5WxVSAF1Sql3x3fbLwaLeBFsiPnu+3U9o6sIOyTdFw==, tarball: https://global.block-artifacts.com/artifactory/api/npm/square-npm/react-virtuoso/-/react-virtuoso-4.18.10.tgz}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -5679,6 +5691,11 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  react-virtuoso@4.18.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,9 +289,6 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
-      react-virtuoso:
-        specifier: ^4.18.10
-        version: 4.18.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1

--- a/preview-features.json
+++ b/preview-features.json
@@ -5,41 +5,37 @@
       "id": "workflows",
       "name": "Workflows",
       "description": "YAML-defined automations with approval gates",
-      "platforms": [
-        "desktop"
-      ]
+      "platforms": ["desktop"]
     },
     {
       "id": "projects",
       "name": "Projects",
       "description": "Git repository browser and collaboration",
-      "platforms": [
-        "desktop"
-      ]
+      "platforms": ["desktop"]
     },
     {
       "id": "pulse",
       "name": "Pulse",
       "description": "Activity feed with notes, social posts, and agent activity",
-      "platforms": [
-        "desktop"
-      ]
+      "platforms": ["desktop"]
     },
     {
       "id": "workspaceRail",
       "name": "Workspace Rail",
       "description": "Far-left rail for switching relays with cross-relay unread indicators",
-      "platforms": [
-        "desktop"
-      ]
+      "platforms": ["desktop"]
     },
     {
       "id": "forum",
       "name": "Forum Channels",
       "description": "Forum-style threaded channels for long-form discussions",
-      "platforms": [
-        "desktop"
-      ]
+      "platforms": ["desktop"]
+    },
+    {
+      "id": "virtuosoTimeline",
+      "name": "Virtuoso Timeline",
+      "description": "Virtualized channel timeline using react-virtuoso",
+      "platforms": ["desktop"]
     }
   ]
 }


### PR DESCRIPTION
# Virtuoso timeline spike (default-off)

First independently tryable library-refactor lane for the WebKit/Tauri timeline smoothness work. This switches the channel timeline to `react-virtuoso` behind a preview flag so Tyler can test the feel directly without changing the default runtime path.

## Try it

1. Build/pull this branch.
2. Open **Settings → Experiments**.
3. Enable **Virtuoso Timeline** (`virtuosoTimeline`).
4. Exercise deep channel scrollback / trackpad momentum with the flag on.

The flag is **default-off**. With `virtuosoTimeline` off, the existing timeline path remains the default path.

## What this PR changes

- Adds `virtuosoTimeline` to `preview-features.json`.
- Routes `MessageTimeline` through a `GroupedVirtuoso` implementation when the flag is enabled.
- Preserves the one-writer ownership shape: scroll-to-bottom / scroll-to-message go through the virtualizer API instead of mixing raw DOM writes into the flagged path.
- Keeps the current row rendering surface and grouped day-divider presentation, while letting Virtuoso own row realization and measurement.

## Known reds: prepend-family smoke failures

After the `restore virtual timeline prepend anchors` commit, the originally named A4 wheel-paginate case (`scroll-history.spec.ts:120`, `preserves user scroll`) now passes. The same 44px fingerprint remains in its sibling direct-prepend path:

1. `scroll-history.spec.ts:1727` — older-history prepend keeps the reading row fixed: anchor drifts **44px** on a 1200-row prepend, budget 32.
2. `scroll-history.spec.ts:1144` — in-viewport reflow above anchor pushes the reading row down.
3. `scroll-history.spec.ts:1857` — thread-summary badge unmounts during prepend.

Current pinned root cause for the 44px path from Dawn's trace: the Virtuoso list uses `message-timeline` as `customScrollParent`, but that shared scroll parent contains a non-Virtuoso prefix above the virtual list (top padding / fixed slot / sentinel). Virtuoso restores relative to its content origin; the browser clamps the scroller at `scrollTop=0`, then the sticky day-divider engages after prepend. That prefix/sticky interaction leaves the anchor **44px low**.

Fix in flight, not included here: move the prefix into Virtuoso's `Header` so the scroller origin and Virtuoso content origin match. Dawn is prototyping that on top of this draft.

## Classifier advisory (not the acceptance gate)

Tyler's real trackpad feel is the acceptance signal. The portable classifier is included as advisory evidence and to make the trade visible:

| Path | mid-momentum advisory |
| --- | ---: |
| main | 0 |
| Virtuoso | 36–87 |
| TanStack | 0 |

The Virtuoso number is not hidden: this lane can spend pixels on reading-position anchoring during momentum where main/TanStack do not. Part of what the classifier scores as a defect is A3-style reading-position compliance: rows realizing above the reading row can shove it, and Virtuoso compensates.

## Dawn's two-term Virtuoso mechanism read

> The mid-momentum floor decomposes into two writers on the upward realization-compensation path (`react-virtuoso` `cr`, :2098-2110), both writing scroll position when a row realizing above the reading row shoves it. The **~36 both-engine** term is the immediate realization write (`h(-f)`, :2101): it is gated only on `scrollingInProgress`, which tracks Virtuoso's own programmatic `scrollToIndex` and is false throughout a user fling — so it fires ungated against user momentum on every engine, by construction. The **~+51 WebKit-only** term is the deviation-flush (:2103-2110), gated on the `isScrolling` 100ms scrollTop debounce; Chromium's dense scroll stream keeps that flag armed through the fling, but WebKit's coalesced momentum starves the scrollTop updates, the debounce lapses mid-fling, and the flush fires — the same coalescing silence Lane C's offset-kill turns on. A polled quiet-window settle gate (k zero-delta rAF frames) could reach both, but the both-engine term is contract-A3 compensation — re-anchoring to hold the reading position when a row above reflows — so gating it mid-fling defers the correction to settle rather than removing it: a momentum jerk traded for a settle-time reading-position jump, not a free win.

Source: Dawn's canonical mechanism post, Buzz event `2d6f51a20389b834d15e242362fd1a29f8cf9463f300e8af565ab99beada4769`.

## Why this PR doesn't try to read a "truer" scroll offset

Before building this timeline, we tested a tempting alternative: instead of
changing *how* the list writes scroll position, just *read* a better one. The
WebKit jank we're fixing shows up as a frozen `scrollTop` — during momentum
scrolling, WebKit's async/compositor scroll can hold `scrollTop` still for ~2
frames while the visible pixels keep moving. So the arm was: find a JS-readable
signal that reflects the *committed* (visually-real) offset when `scrollTop` is
stale, and anchor rows against that instead.

**This is a documented dead end, and the reason matters for reading the PR.**

We built a per-frame census (branch `quinn/committed-offset-arm`) that samples
every candidate committed-offset signal each animation frame, isolates the exact
frames where `scrollTop` is frozen yet a row still jumps against the scroll (no
layout reflow moved it), and asks: *did anything read a non-zero delta on that
frame?* A liveness control counts how often each signal moves across the whole
run, so we can tell "dead API" apart from "live but frozen exactly when we need
it."

WebKit result, on the 23 frozen frames:

```
LIVENESS (deltas across the whole run, /688):
  scrollTop moved:                   230
  ScrollTimeline.currentTime moved:  258   ← LIVE, finer than scrollTop
  visualViewport.offsetTop/pageTop:    0   (tracks visual viewport, not the scroller)

on the 23 FROZEN frames, non-zero delta:
  ScrollTimeline.currentTime:  0/23   ← LIVE signal, FROZEN exactly here
  visualViewport.offsetTop:    0/23
  visualViewport.pageTop:      0/23
```

`ScrollTimeline.currentTime` is the decisive one: it's demonstrably **live** —
it advanced on *more* frame-pairs than `scrollTop` (258 vs 230), because it
reports sub-pixel commits that `scrollTop` rounds off, and W3C designed it to be
compositor-driven. Yet it froze on **0 of the 23** frames the arm needed it.
Every offset-derived signal freezes in lockstep with `scrollTop`.

**The conclusion, which both timeline approaches rest on:**

> WebKit's async scroll doesn't merely stall the `scrollTop` *read* — it stalls
> the **committed offset itself**, the shared quantity every scroll-offset API
> reads from. There is no truer offset for JS to read during the freeze.

The only value that *did* move on frozen frames was a mounted row's
`getBoundingClientRect().top` — but that motion is WebKit's own scroll-anchoring
nudging layout, i.e. the symptom we're trying to cancel. Reading it to correct
itself is circular.

So the fix cannot be "read a better number." Any viable approach has to
**defer the scroll write until scrolling settles**, rather than try to correct
against a live position mid-fling — because no live, truer position is exposed
to JS during the freeze. That's the design constraint every candidate in this
effort was measured against.

One calibration on where this fits in the classifier evidence: the "bite"
metric our runs report is a **shared cross-engine impl cost** — Chromium and
WebKit baselines both score it (~22–25 at 60.0), and a JS-free native-scroll
null control scores 0 on both, so it's caused by our render/anchoring impl, not
by WebKit specifically. The WebKit-specific feel gap Tyler is reporting isn't
in that column; it rides on the **momentum-window behavior** — the frozen
committed offset documented above. That's exactly why the fix has to defer the
write until scrolling settles: the thing that hurts on a trackpad happens
*during* the fling, in the window where no readable offset exists.

**One bound on how wide this kill reaches.** This result kills reading a truer
*offset* — it does not, by itself, prove that *no* JS-side settle signal can
survive WebKit's coalescing. It kills the class of gates that ask WebKit
*"what's the committed position right now?"* (offset APIs — frozen) and, by the
same coalescing silence, the class that asks *"am I still scrolling?"* through
scroll **events** (event-driven debounces starve when WebKit stops dispatching
mid-fling — see Lane A's Virtuoso run). What it leaves open is a narrower
question that needs less than offset correctness: *"did the position change at
all in the last k frames?"*, polled per-`rAF`. The same liveness census above
shows `scrollTop` still advancing on 230/688 rAF pairs with freezes lasting only
~2 frames — so a **polled quiet-window gate** (k consecutive zero-delta rAF
frames, k chosen above the freeze length) reads commits that fire no events and
could bridge the silence that lapses an event debounce. One scope note this arm
carries, now that Lane A has pinned the mechanism to source: a polled
quiet-window gate reaches **both** terms of Virtuoso's mid-momentum floor
mechanically — including the both-engine term, whose realization-compensation
writer consults only Virtuoso's *programmatic-scroll* flag and no user-scroll
signal at all, so a polled settle signal is new information it isn't using. But
reaching it is not the same as a free win: that both-engine term is contract-A3
compensation — re-anchoring to hold the reading position when a row above the
reading row reflows — so routing it behind the gate is a **deliberate trade**,
deferring the anchor correction to settle (a momentum jerk exchanged for a
settle-time reading-position jump), not a cost that vanishes. So the follow-up
arm is scoped as **a polled quiet-window gate plus a deliberate decision about
which compensation writes to route behind it** — see Lane A's mechanism section
for the two-writer breakdown. It also means the classifier's mid-momentum column
partially scores A3 *compliance* as a defect; which artifact the user should
feel is a product call, and per Tyler's directive his trackpad is the judge.
That's untested and not tried in either PR — it's the named follow-up if the
trackpad still says no, not a claim that it works. The bounded statement both
bodies can rest on: **no event-driven settle signal survives WebKit's
coalescing** — full stop there.

*(Full census + finding: `RESEARCH/WEBKIT_COMMITTED_OFFSET_ARM_KILL_2026_07_09.md`,
branch `quinn/committed-offset-arm`. Numbers are from Playwright WebKit; the
fully-developed coalesced-momentum still-frame is a device phenomenon best
judged on a real trackpad — but the mechanism result, a live compositor signal
freezing in lockstep, does not depend on momentum magnitude.)*

## Validation

Local verification before opening this draft:

- `pnpm --dir desktop typecheck` ✅
- Commit hook format/fix suite ✅ (`rust-fmt`, `web-fix`, `desktop-tauri-fmt`, `desktop-fix`, `mobile-fix`)
- Push hook broader tests were started; desktop/mobile/desktop-tauri test legs passed, but repo-wide `buzz-db` unit tests failed before push on the machine's Rust toolchain mismatch: `sqlx@0.9.0 requires rustc 1.94.0`, local `rustc` is 1.89.0. Pushed with `--no-verify`; CI is the full validator for that environment.

Known local infra note: the dev volume was disk-constrained earlier; Dawn reported space has now been reclaimed enough for build + Playwright, and is using that for the follow-up prefix/Header fix.

