### PR TITLE
fix(justfile): resolve cargo target dir for staging sidecar copy

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -355,7 +355,8 @@ staging *ARGS: bootstrap _ensure-sidecar-stubs
     fi
     # Replace the 0-byte sidecar stub with the real CLI binary so tauri dev picks it up.
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
-    cp target/release/buzz "desktop/src-tauri/binaries/buzz-${TARGET}"
+    TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
+    cp "${TARGET_DIR}/release/buzz" "desktop/src-tauri/binaries/buzz-${TARGET}"
     chmod +x "desktop/src-tauri/binaries/buzz-${TARGET}"
     cd {{desktop_dir}}
     export BUZZ_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co"


### PR DESCRIPTION
## Summary

The `just staging` recipe copied the CLI sidecar binary from a hardcoded `target/release/buzz` path. On machines where cargo's target directory is redirected (e.g. via `CARGO_TARGET_DIR` or a `build.target-dir` config), that path doesn't exist and the copy fails.

This resolves the actual target directory via `cargo metadata --format-version 1 --no-deps` and copies the built `buzz` binary from `<target_directory>/release/buzz` instead.

## Test plan

- Ran `just staging` on a machine with a redirected cargo target dir; the sidecar stub is now replaced with the real CLI binary and `tauri dev` picks it up.
- Full local test suite passed on push (rust, desktop, desktop-tauri, mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)