### PR TITLE
chore(desktop): remove dead archive-migration and keyring load_readonly helpers

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -131,7 +131,8 @@ const overrides = new Map([
   // databricks-v1-to-v2-migration: databricks-v2 hyphen-alias added to all
   // host/credential match arms + 30+ readiness tests for provider aliases,
   // missing-host, and DATABRICKS_MODEL fallback. Load-bearing correctness fix.
-  ["src-tauri/src/managed_agents/readiness.rs", 1546],
+  // #1613 augmented-PATH readiness probes grew the file +3 past the prior cap.
+  ["src-tauri/src/managed_agents/readiness.rs", 1549],
   // applyWorkspace reposDir parameter plus the validateReposDir binding,
   // threaded through Tauri invokes for configurable repos_dir, plus the
   // harness-persona-sync `harnessOverride` create-input bit — load-bearing

--- a/desktop/src-tauri/src/archive/store.rs
+++ b/desktop/src-tauri/src/archive/store.rs
@@ -76,32 +76,6 @@ CREATE TABLE IF NOT EXISTS archive_migrations (
 );
 ";
 
-// ── Migration helpers ────────────────────────────────────────────────────────
-
-/// Returns true if a named migration has already been applied.
-pub fn migration_applied(conn: &Connection, name: &str) -> Result<bool, String> {
-    // The table is created in SCHEMA above, so it always exists after open.
-    let count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM archive_migrations WHERE name = ?1",
-            params![name],
-            |row| row.get(0),
-        )
-        .map_err(|e| format!("migration_applied query: {e}"))?;
-    Ok(count > 0)
-}
-
-/// Mark a named migration as applied (idempotent: no-op if already recorded).
-pub fn mark_migration_applied(conn: &Connection, name: &str, now: i64) -> Result<(), String> {
-    conn.execute(
-        "INSERT INTO archive_migrations (name, applied_at) VALUES (?1, ?2)
-         ON CONFLICT (name) DO NOTHING",
-        params![name, now],
-    )
-    .map_err(|e| format!("mark_migration_applied: {e}"))?;
-    Ok(())
-}
-
 // ── Open / init ─────────────────────────────────────────────────────────────
 
 /// Open (or create) the archive database at the given path.

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -62,9 +62,6 @@ trait KeyStore {
     /// Read a key. `Ok(None)` is "no such entry" (absent); `Err` is a backend
     /// failure (keyring unreachable) — the caller MUST NOT collapse the two.
     fn load(&self, name: &str) -> Result<Option<String>, String>;
-    /// Read a key without any side effects (no legacy-key migration, no writes).
-    /// `Ok(None)` when the blob or the key is absent; `Err` only on backend failure.
-    fn load_readonly(&self, name: &str) -> Result<Option<String>, String>;
     /// Read the entire blob as a map without any side effects.
     /// `Ok(None)` when no blob exists yet; `Err` only on backend failure.
     /// Callers must not call `migrate_legacy_key` — this is a read-only view.
@@ -82,9 +79,6 @@ impl KeyStore for SecretStore {
     }
     fn load(&self, name: &str) -> Result<Option<String>, String> {
         SecretStore::load(self, name)
-    }
-    fn load_readonly(&self, name: &str) -> Result<Option<String>, String> {
-        SecretStore::load_readonly(self, name)
     }
     fn load_all_readonly(&self) -> Result<Option<HashMap<String, String>>, String> {
         SecretStore::load_all_readonly(self)
@@ -809,10 +803,6 @@ mod tests {
             }
             *self.read_count.borrow_mut() += 1;
             Ok(self.stored.borrow().get(name).cloned())
-        }
-        fn load_readonly(&self, name: &str) -> Result<Option<String>, String> {
-            // The fake has no side effects, so load_readonly is identical to load.
-            self.load(name)
         }
         fn load_all_readonly(&self) -> Result<Option<HashMap<String, String>>, String> {
             if !self.reachable {

--- a/desktop/src-tauri/src/secret_store.rs
+++ b/desktop/src-tauri/src/secret_store.rs
@@ -577,30 +577,6 @@ impl SecretStore {
 
     /// Read the secret for `key` without any legacy-migration side effects.
     ///
-    /// Unlike [`load`](Self::load), this method never calls
-    /// `migrate_legacy_key` and therefore never writes to or deletes from the
-    /// keyring. Use this when the caller must guarantee the store is not
-    /// mutated — for example, when reading from a foreign service (prod) to
-    /// copy values into a dev service.
-    ///
-    /// Returns `Ok(Some(value))` when the key is present in the blob,
-    /// `Ok(None)` when the blob is absent or the key is not in it, and `Err`
-    /// only when the backend is unavailable.
-    pub fn load_readonly(&self, key: &str) -> Result<Option<String>, String> {
-        #[cfg(feature = "system-keyring")]
-        {
-            match self.load_blob()? {
-                Some(map) => Ok(map.get(key).cloned()),
-                None => Ok(None),
-            }
-        }
-        #[cfg(not(feature = "system-keyring"))]
-        {
-            let _ = key;
-            Err("system-keyring feature disabled".to_string())
-        }
-    }
-
     /// Read the entire blob without any legacy-migration side effects.
     ///
     /// Returns the full key→value map when a blob exists, `Ok(None)` when no


### PR DESCRIPTION
## Summary

- Delete `migration_applied` and `mark_migration_applied` from `archive/store.rs` — zero callers on main, warn on every `cargo build`.
- Delete `load_readonly` from the `KeyStore` trait, its `SecretStore` impl, and its test-fake impl in `storage.rs`.
- Delete `SecretStore::load_readonly` from `secret_store.rs` — sole caller was the trait impl above.
- Raise the `readiness.rs` size cap 1546 → 1549 in `check-file-sizes.mjs` — #1613 grew the file past the cap and has had main's Desktop Core red since; this PR carries the sanctioned bump.

All four items are dead code that produce `unused` warnings. `load_all_readonly` (the live sibling) is untouched.