### PR TITLE
fix(desktop): stop showing /dev/null in diff labels, keep type badge visible

### DIFF
--- a/desktop/src/features/messages/lib/parseDiff.ts
+++ b/desktop/src/features/messages/lib/parseDiff.ts
@@ -33,6 +33,14 @@ export function parseUnifiedDiff(content: string): ParsedDiffResult {
   }
 }
 
+export const DIFF_TYPE_LABELS: Record<DiffType, string> = {
+  add: "New file",
+  copy: "Copied",
+  delete: "Deleted",
+  modify: "Modified",
+  rename: "Renamed",
+};
+
 export function getDiffFileLabel(
   file: FileData,
   fallbackFilePath?: string,
@@ -45,6 +53,39 @@ export function getDiffFileLabel(
   }
 
   return newPath || oldPath || fallbackFilePath || "diff";
+}
+
+export function shouldShowDiffFileHeader(
+  label: string,
+  fileCount: number,
+  fallbackFilePath?: string,
+): boolean {
+  return fileCount > 1 || !fallbackFilePath || label !== fallbackFilePath;
+}
+
+/**
+ * Badge for the diff card's title bar. Set only when the diff is a single
+ * file whose per-file header is collapsed (its label just repeats the card
+ * title) and whose change type is notable — so "New file"/"Deleted" isn't
+ * lost with the header.
+ */
+export function getDiffTitleBadge(
+  content: string,
+  fallbackFilePath?: string,
+): string | undefined {
+  const { files } = parseUnifiedDiff(content);
+  if (files.length !== 1) {
+    return undefined;
+  }
+
+  const file = files[0];
+  const label = getDiffFileLabel(file, fallbackFilePath);
+  if (shouldShowDiffFileHeader(label, files.length, fallbackFilePath)) {
+    return undefined;
+  }
+
+  const diffType = normalizeDiffType(file.type);
+  return diffType === "modify" ? undefined : DIFF_TYPE_LABELS[diffType];
 }
 
 export function countDiffFileChanges(file: FileData) {

--- a/desktop/src/features/messages/lib/parseDiff.ts
+++ b/desktop/src/features/messages/lib/parseDiff.ts
@@ -37,11 +37,14 @@ export function getDiffFileLabel(
   file: FileData,
   fallbackFilePath?: string,
 ): string {
-  if (file.oldPath && file.newPath && file.oldPath !== file.newPath) {
-    return `${file.oldPath} -> ${file.newPath}`;
+  const oldPath = file.oldPath === "/dev/null" ? undefined : file.oldPath;
+  const newPath = file.newPath === "/dev/null" ? undefined : file.newPath;
+
+  if (oldPath && newPath && oldPath !== newPath) {
+    return `${oldPath} -> ${newPath}`;
   }
 
-  return file.newPath || file.oldPath || fallbackFilePath || "diff";
+  return newPath || oldPath || fallbackFilePath || "diff";
 }
 
 export function countDiffFileChanges(file: FileData) {

--- a/desktop/src/features/messages/ui/DiffMessage.tsx
+++ b/desktop/src/features/messages/ui/DiffMessage.tsx
@@ -57,7 +57,7 @@ export default function DiffMessage({
     >
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50 bg-muted/40">
         <FileDiff className="h-4 w-4 shrink-0 text-muted-foreground" />
-        <span className="flex-1 truncate font-mono text-xs text-foreground/80">
+        <span className="min-w-0 truncate font-mono text-xs text-foreground/80">
           {filePath ?? "diff"}
         </span>
         {titleBadge && (
@@ -65,51 +65,53 @@ export default function DiffMessage({
             {titleBadge}
           </span>
         )}
-        {shortSha && (
-          <span className="text-xs text-muted-foreground font-mono">
-            {commitUrl ? (
+        <div className="ml-auto flex items-center gap-2">
+          {shortSha && (
+            <span className="text-xs text-muted-foreground font-mono">
+              {commitUrl ? (
+                <a
+                  className="hover:underline"
+                  href={commitUrl}
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
+                  {shortSha}
+                </a>
+              ) : (
+                shortSha
+              )}
+            </span>
+          )}
+          {safeRepoUrl && !commitUrl && (
+            <span className="text-xs text-muted-foreground">
               <a
                 className="hover:underline"
-                href={commitUrl}
+                href={safeRepoUrl}
                 rel="noreferrer noopener"
                 target="_blank"
               >
-                {shortSha}
+                {getHostname(safeRepoUrl)}
               </a>
-            ) : (
-              shortSha
-            )}
-          </span>
-        )}
-        {safeRepoUrl && !commitUrl && (
-          <span className="text-xs text-muted-foreground">
-            <a
-              className="hover:underline"
-              href={safeRepoUrl}
-              rel="noreferrer noopener"
-              target="_blank"
-            >
-              {getHostname(safeRepoUrl)}
-            </a>
-          </span>
-        )}
-        {onExpand && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label="Expand diff"
-                className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
-                onClick={onExpand}
-                size="sm"
-                type="button"
-                variant="ghost"
-              >
-                <Maximize2 className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Expand diff</TooltipContent>
-          </Tooltip>
-        )}
+            </span>
+          )}
+          {onExpand && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  aria-label="Expand diff"
+                  className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+                  onClick={onExpand}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  <Maximize2 className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Expand diff</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
       </div>
 
       {description && (

--- a/desktop/src/features/messages/ui/DiffMessage.tsx
+++ b/desktop/src/features/messages/ui/DiffMessage.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { FileDiff, Maximize2 } from "lucide-react";
 
+import { getDiffTitleBadge } from "@/features/messages/lib/parseDiff";
 import { isSafeUrl } from "@/shared/lib/url";
 import { Button } from "@/shared/ui/button";
 import { useSmoothCorners } from "@/shared/ui/smoothCorners";
@@ -39,6 +40,11 @@ export default function DiffMessage({
 
   const safeRepoUrl = isSafeUrl(repoUrl) ? repoUrl : undefined;
 
+  const titleBadge = React.useMemo(
+    () => getDiffTitleBadge(content, filePath),
+    [content, filePath],
+  );
+
   const commitUrl =
     safeRepoUrl && commitSha ? `${safeRepoUrl}/commit/${commitSha}` : undefined;
 
@@ -54,6 +60,11 @@ export default function DiffMessage({
         <span className="flex-1 truncate font-mono text-xs text-foreground/80">
           {filePath ?? "diff"}
         </span>
+        {titleBadge && (
+          <span className="shrink-0 rounded-md border border-border/60 px-1.5 py-0.5 text-2xs uppercase tracking-[0.14em] text-muted-foreground">
+            {titleBadge}
+          </span>
+        )}
         {shortSha && (
           <span className="text-xs text-muted-foreground font-mono">
             {commitUrl ? (

--- a/desktop/src/features/messages/ui/DiffMessageExpanded.tsx
+++ b/desktop/src/features/messages/ui/DiffMessageExpanded.tsx
@@ -39,7 +39,7 @@ export default function DiffMessageExpanded({
       <DialogContent className="max-w-5xl w-full h-[80vh] flex flex-col p-0 gap-0">
         <DialogHeader className="shrink-0 border-b border-border/50 px-4 py-3 pr-14">
           <div className="flex flex-wrap items-center gap-2">
-            <DialogTitle className="min-w-0 flex-1 truncate font-mono text-sm font-medium">
+            <DialogTitle className="min-w-0 truncate font-mono text-sm font-medium">
               {filePath ?? "Diff Viewer"}
             </DialogTitle>
             {titleBadge && (
@@ -47,7 +47,7 @@ export default function DiffMessageExpanded({
                 {titleBadge}
               </span>
             )}
-            <div className="flex items-center gap-1 rounded-lg border border-border/60 bg-muted/30 p-1">
+            <div className="ml-auto flex items-center gap-1 rounded-lg border border-border/60 bg-muted/30 p-1">
               <Button
                 className="h-7 px-2"
                 onClick={() => {

--- a/desktop/src/features/messages/ui/DiffMessageExpanded.tsx
+++ b/desktop/src/features/messages/ui/DiffMessageExpanded.tsx
@@ -1,6 +1,7 @@
 import { Rows3, SplitSquareVertical } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import { getDiffTitleBadge } from "@/features/messages/lib/parseDiff";
 import { DiffViewer } from "@/features/messages/ui/DiffViewer";
 import { Button } from "@/shared/ui/button";
 import {
@@ -23,6 +24,11 @@ export default function DiffMessageExpanded({
 }: DiffMessageExpandedProps) {
   const [viewType, setViewType] = useState<"split" | "unified">("unified");
 
+  const titleBadge = useMemo(
+    () => getDiffTitleBadge(content, filePath),
+    [content, filePath],
+  );
+
   return (
     <Dialog
       onOpenChange={(open) => {
@@ -36,6 +42,11 @@ export default function DiffMessageExpanded({
             <DialogTitle className="min-w-0 flex-1 truncate font-mono text-sm font-medium">
               {filePath ?? "Diff Viewer"}
             </DialogTitle>
+            {titleBadge && (
+              <span className="shrink-0 rounded-md border border-border/60 px-1.5 py-0.5 text-2xs uppercase tracking-[0.14em] text-muted-foreground">
+                {titleBadge}
+              </span>
+            )}
             <div className="flex items-center gap-1 rounded-lg border border-border/60 bg-muted/30 p-1">
               <Button
                 className="h-7 px-2"

--- a/desktop/src/features/messages/ui/DiffViewer.tsx
+++ b/desktop/src/features/messages/ui/DiffViewer.tsx
@@ -79,10 +79,13 @@ export function DiffViewer({
       <div className="space-y-3">
         {files.map((file) => {
           const label = getDiffFileLabel(file, fallbackFilePath);
-          const showFileHeader =
-            files.length > 1 || !fallbackFilePath || label !== fallbackFilePath;
           const { additions, deletions } = countDiffFileChanges(file);
           const diffType = normalizeDiffType(file.type);
+          const showFileHeader =
+            files.length > 1 ||
+            !fallbackFilePath ||
+            label !== fallbackFilePath ||
+            diffType !== "modify";
           const fileKey = [
             file.oldPath || "",
             file.newPath || "",

--- a/desktop/src/features/messages/ui/DiffViewer.tsx
+++ b/desktop/src/features/messages/ui/DiffViewer.tsx
@@ -4,9 +4,11 @@ import { useMemo } from "react";
 
 import {
   countDiffFileChanges,
+  DIFF_TYPE_LABELS,
   getDiffFileLabel,
   normalizeDiffType,
   parseUnifiedDiff,
+  shouldShowDiffFileHeader,
 } from "@/features/messages/lib/parseDiff";
 import { cn } from "@/shared/lib/cn";
 import "./DiffViewer.css";
@@ -17,14 +19,6 @@ type DiffViewerProps = {
   viewType?: ViewType;
   className?: string;
 };
-
-const DIFF_TYPE_LABELS = {
-  add: "New file",
-  copy: "Copied",
-  delete: "Deleted",
-  modify: "Modified",
-  rename: "Renamed",
-} as const;
 
 function FileChangeBadge({
   tone,
@@ -81,11 +75,11 @@ export function DiffViewer({
           const label = getDiffFileLabel(file, fallbackFilePath);
           const { additions, deletions } = countDiffFileChanges(file);
           const diffType = normalizeDiffType(file.type);
-          const showFileHeader =
-            files.length > 1 ||
-            !fallbackFilePath ||
-            label !== fallbackFilePath ||
-            diffType !== "modify";
+          const showFileHeader = shouldShowDiffFileHeader(
+            label,
+            files.length,
+            fallbackFilePath,
+          );
           const fileKey = [
             file.oldPath || "",
             file.newPath || "",


### PR DESCRIPTION
## Summary

Diff message cards showed `/dev/null` as if it were a real path — new files rendered labels like `/dev/null -> path/to/file` (and deleted files the reverse). This PR cleans up the label and reworks where the New file/Deleted type badge lives so it never disappears.

### Changes

- **`getDiffFileLabel` treats `/dev/null` as an absent path** — new files show just the new path, deleted files just the old path; the `->` arrow only appears for genuine renames/copies.
- **The type badge moves to the diff card's title bar when the per-file header is collapsed.** For single-file diffs the per-file header is skipped when it would only repeat the card title — which previously took the New file/Deleted badge with it. A new `getDiffTitleBadge` helper surfaces the badge in the card title (inline card and expanded dialog) exactly when the header is hidden and the change type is notable, so the badge renders in exactly one place.
- **Badge placement matches the per-file header layout** — it sits immediately beside the (truncating) file path, with the commit SHA / repo link / expand button (or the Unified/Split toggle in the expanded dialog) grouped to the right with `ml-auto`.
- `DIFF_TYPE_LABELS` and the header-visibility check moved into `parseDiff.ts` as shared helpers so the title badge and header can't drift out of sync.

### Testing

- `just desktop-check`, `just desktop-typecheck`, `just desktop-test` (2270 tests) all pass.
- Verified badge logic against the real `react-diff-view` parser: badge shows in the title only for single-file notable-type diffs whose header is collapsed; header (with its own badge) still renders for multi-file diffs, missing/mismatched `filePath`, and renames.
- Screenshots below captured via `just desktop-screenshot` with an injected kind-40008 new-file diff message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
