### PR TITLE
Resolve people search by pubkey and alias

### DIFF
--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -1591,8 +1591,9 @@ impl Db {
         community_id: CommunityId,
         query: &str,
         limit: u32,
+        offset: u32,
     ) -> Result<Vec<user::UserSearchProfile>> {
-        user::search_users(&self.pool, community_id, query, limit).await
+        user::search_users(&self.pool, community_id, query, limit, offset).await
     }
 
     /// Atomically set agent owner — only if no owner is currently assigned.

--- a/crates/buzz-db/src/user.rs
+++ b/crates/buzz-db/src/user.rs
@@ -31,6 +31,9 @@ pub struct UserSearchProfile {
     pub avatar_url: Option<String>,
     /// NIP-05 identifier (user@domain).
     pub nip05_handle: Option<String>,
+    /// Whether this user has ever published a kind:0 metadata event, including
+    /// one that has since been soft-deleted.
+    pub has_metadata_history: bool,
 }
 
 /// Ensure a user record exists for the given pubkey (upsert).
@@ -243,25 +246,50 @@ pub async fn search_users(
     let limit = limit.clamp(1, 500) as i64;
     let offset = offset.min(100_000) as i64;
 
-    let rows = sqlx::query_as::<_, (Vec<u8>, Option<String>, Option<String>, Option<String>)>(
+    let rows = sqlx::query_as::<
+        _,
+        (
+            Vec<u8>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            bool,
+        ),
+    >(
         r#"
-        SELECT pubkey, display_name, avatar_url, nip05_handle
-        FROM users
-        WHERE community_id = $1
-          AND (LOWER(COALESCE(display_name, '')) LIKE $2 ESCAPE '\'
-           OR LOWER(COALESCE(nip05_handle, '')) LIKE $2 ESCAPE '\'
-           OR LOWER(encode(pubkey, 'hex')) LIKE $2 ESCAPE '\')
+        SELECT
+            u.pubkey,
+            u.display_name,
+            u.avatar_url,
+            u.nip05_handle,
+            EXISTS (
+                SELECT 1
+                FROM events e
+                WHERE e.community_id = u.community_id
+                  AND e.pubkey = u.pubkey
+                  AND e.kind = 0
+            ) AS has_metadata_history
+        FROM users u
+        WHERE u.community_id = $1
+          AND (LOWER(COALESCE(u.display_name, '')) LIKE $2 ESCAPE '\'
+           OR LOWER(COALESCE(u.nip05_handle, '')) LIKE $2 ESCAPE '\'
+           OR LOWER(encode(u.pubkey, 'hex')) LIKE $2 ESCAPE '\')
         ORDER BY
             CASE
-                WHEN LOWER(COALESCE(display_name, '')) = $3 THEN 0
-                WHEN LOWER(COALESCE(nip05_handle, '')) = $3 THEN 1
-                WHEN LOWER(encode(pubkey, 'hex')) = $3 THEN 2
-                WHEN LOWER(COALESCE(display_name, '')) LIKE $4 ESCAPE '\' THEN 3
-                WHEN LOWER(COALESCE(nip05_handle, '')) LIKE $4 ESCAPE '\' THEN 4
-                WHEN LOWER(encode(pubkey, 'hex')) LIKE $4 ESCAPE '\' THEN 5
+                WHEN LOWER(COALESCE(u.display_name, '')) = $3 THEN 0
+                WHEN LOWER(COALESCE(u.nip05_handle, '')) = $3 THEN 1
+                WHEN LOWER(encode(u.pubkey, 'hex')) = $3 THEN 2
+                WHEN LOWER(COALESCE(u.display_name, '')) LIKE $4 ESCAPE '\' THEN 3
+                WHEN LOWER(COALESCE(u.nip05_handle, '')) LIKE $4 ESCAPE '\' THEN 4
+                WHEN LOWER(encode(u.pubkey, 'hex')) LIKE $4 ESCAPE '\' THEN 5
                 ELSE 6
             END,
-            COALESCE(NULLIF(display_name, ''), NULLIF(nip05_handle, ''), LOWER(encode(pubkey, 'hex')))
+            COALESCE(
+                NULLIF(u.display_name, ''),
+                NULLIF(u.nip05_handle, ''),
+                LOWER(encode(u.pubkey, 'hex'))
+            ),
+            LOWER(encode(u.pubkey, 'hex'))
         LIMIT $5 OFFSET $6
         "#,
     )
@@ -277,11 +305,14 @@ pub async fn search_users(
     Ok(rows
         .into_iter()
         .map(
-            |(pubkey, display_name, avatar_url, nip05_handle)| UserSearchProfile {
-                pubkey,
-                display_name,
-                avatar_url,
-                nip05_handle,
+            |(pubkey, display_name, avatar_url, nip05_handle, has_metadata_history)| {
+                UserSearchProfile {
+                    pubkey,
+                    display_name,
+                    avatar_url,
+                    nip05_handle,
+                    has_metadata_history,
+                }
             },
         )
         .collect())
@@ -651,6 +682,51 @@ mod tests {
         assert_eq!(escape_like("alice"), "alice");
         assert_eq!(escape_like("bob@example.com"), "bob@example.com");
         assert_eq!(escape_like(""), "");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn search_users_pages_tied_rows_by_pubkey() {
+        let db = setup_db().await;
+        let community = make_community(&db.pool).await;
+        let pubkeys = vec![
+            vec![0x30; 32],
+            vec![0x10; 32],
+            vec![0x40; 32],
+            vec![0x20; 32],
+        ];
+
+        for pubkey in &pubkeys {
+            ensure_user(&db.pool, community, pubkey)
+                .await
+                .expect("ensure tied user");
+            update_user_profile(&db.pool, community, pubkey, Some("Alex"), None, None, None)
+                .await
+                .expect("set tied display name");
+        }
+
+        let first_page = search_users(&db.pool, community, "alex", 2, 0)
+            .await
+            .expect("query first page");
+        let second_page = search_users(&db.pool, community, "alex", 2, 2)
+            .await
+            .expect("query second page");
+        let actual: Vec<Vec<u8>> = first_page
+            .into_iter()
+            .chain(second_page)
+            .map(|user| user.pubkey)
+            .collect();
+
+        assert_eq!(
+            actual,
+            vec![
+                vec![0x10; 32],
+                vec![0x20; 32],
+                vec![0x30; 32],
+                vec![0x40; 32],
+            ],
+            "tied users must cross page boundaries in deterministic pubkey order"
+        );
     }
 
     /// A user with "owner_only" policy but no agent_owner_pubkey set should

--- a/crates/buzz-db/src/user.rs
+++ b/crates/buzz-db/src/user.rs
@@ -221,11 +221,16 @@ fn escape_like(input: &str) -> String {
 /// Search users by display name, NIP-05 handle, or pubkey prefix.
 ///
 /// Empty queries return an empty vec and do not hit the database.
+///
+/// `offset` is 0-based and used for bridge people-directory paging (the desktop
+/// member picker pages with `page`/`limit`). Clamped so a huge offset cannot
+/// force an unbounded scan beyond the page window.
 pub async fn search_users(
     pool: &PgPool,
     community_id: CommunityId,
     query: &str,
     limit: u32,
+    offset: u32,
 ) -> Result<Vec<UserSearchProfile>> {
     let normalized = query.trim().to_lowercase();
     if normalized.is_empty() {
@@ -236,6 +241,7 @@ pub async fn search_users(
     let contains_pattern = format!("%{escaped}%");
     let prefix_pattern = format!("{escaped}%");
     let limit = limit.clamp(1, 500) as i64;
+    let offset = offset.min(100_000) as i64;
 
     let rows = sqlx::query_as::<_, (Vec<u8>, Option<String>, Option<String>, Option<String>)>(
         r#"
@@ -256,7 +262,7 @@ pub async fn search_users(
                 ELSE 6
             END,
             COALESCE(NULLIF(display_name, ''), NULLIF(nip05_handle, ''), LOWER(encode(pubkey, 'hex')))
-        LIMIT $5
+        LIMIT $5 OFFSET $6
         "#,
     )
     .bind(community_id.as_uuid())
@@ -264,6 +270,7 @@ pub async fn search_users(
     .bind(&normalized)
     .bind(&prefix_pattern)
     .bind(limit)
+    .bind(offset)
     .fetch_all(pool)
     .await?;
 

--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -1339,10 +1339,7 @@ fn synthetic_kind0_from_user(user: &buzz_db::user::UserSearchProfile) -> Option<
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        content.insert(
-            "display_name".to_string(),
-            Value::String(name.to_string()),
-        );
+        content.insert("display_name".to_string(), Value::String(name.to_string()));
         content.insert("name".to_string(), Value::String(name.to_string()));
     }
     if let Some(picture) = user
@@ -1444,6 +1441,13 @@ async fn handle_people_directory_search(
             if let Ok(v) = serde_json::to_value(&se.event) {
                 events.push(v);
             }
+            continue;
+        }
+
+        // A user with kind:0 history but no live stored profile deleted it.
+        // Do not resurrect the soft-deleted fields still cached in `users`.
+        // Users who never published kind:0 remain eligible for synthesis.
+        if user.has_metadata_history {
             continue;
         }
 
@@ -3082,9 +3086,7 @@ mod tests {
             .search("alice");
         assert!(!is_people_directory_search(&with_author));
 
-        let messages = nostr::Filter::new()
-            .kind(Kind::Custom(9))
-            .search("alice");
+        let messages = nostr::Filter::new().kind(Kind::Custom(9)).search("alice");
         assert!(!is_people_directory_search(&messages));
     }
 
@@ -3096,6 +3098,7 @@ mod tests {
             display_name: Some("Alice".into()),
             avatar_url: Some("https://example.com/a.png".into()),
             nip05_handle: Some("alice@example.com".into()),
+            has_metadata_history: false,
         };
         let event = synthetic_kind0_from_user(&user).expect("synthetic event");
         assert_eq!(event.kind, Kind::Metadata);

--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -1289,8 +1289,187 @@ fn search_hit_accepted(
     true
 }
 
+/// True when this filter is a pure people-directory search: only kind:0, no
+/// authors / time / tag constraints. Those queries should hit the `users`
+/// table (display name, NIP-05 handle, pubkey hex) rather than FTS over kind:0
+/// JSON content — FTS never indexes the author pubkey, so searching by hex
+/// always returned zero results and aliases only matched when they happened to
+/// appear as whole tokens inside the content blob.
+fn is_people_directory_search(filter: &nostr::Filter) -> bool {
+    let Some(kinds) = filter.kinds.as_ref() else {
+        return false;
+    };
+    if kinds.len() != 1 || kinds.iter().next().map(|k| k.as_u16()) != Some(0) {
+        return false;
+    }
+    if filter.authors.as_ref().is_some_and(|a| !a.is_empty()) {
+        return false;
+    }
+    if filter.ids.as_ref().is_some_and(|i| !i.is_empty()) {
+        return false;
+    }
+    if filter.since.is_some() || filter.until.is_some() {
+        return false;
+    }
+    // Any single-letter tag constraint means this is not a directory listing.
+    if !filter.generic_tags.is_empty() {
+        return false;
+    }
+    true
+}
+
+/// Build a synthetic kind:0 profile event from a `users` row so existing
+/// desktop/mobile parsers (`user_search_result_from_event`, mobile
+/// `DirectoryUser`) keep working without a new response shape.
+///
+/// The event is **not** re-signed as the subject — HTTP bridge clients
+/// deserialize without verifying (see desktop `query_relay` / mobile
+/// fetchHistory). The `pubkey` field must be the subject so typeahead
+/// ranking and add-member target the right identity. Id/sig are
+/// deterministic placeholders derived from the subject pubkey.
+fn synthetic_kind0_from_user(user: &buzz_db::user::UserSearchProfile) -> Option<nostr::Event> {
+    if user.pubkey.len() != 32 {
+        return None;
+    }
+
+    let mut content = serde_json::Map::new();
+    if let Some(name) = user
+        .display_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        content.insert(
+            "display_name".to_string(),
+            Value::String(name.to_string()),
+        );
+        content.insert("name".to_string(), Value::String(name.to_string()));
+    }
+    if let Some(picture) = user
+        .avatar_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        content.insert("picture".to_string(), Value::String(picture.to_string()));
+    }
+    if let Some(nip05) = user
+        .nip05_handle
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        content.insert("nip05".to_string(), Value::String(nip05.to_string()));
+    }
+
+    // Deterministic 32-byte id/sig placeholders so clients can dedupe and
+    // deserialize. Not cryptographically meaningful — never submitted.
+    let mut id_bytes = [0u8; 32];
+    id_bytes[0] = 0x5a; // marker: synthetic people-directory row
+    id_bytes[1..].copy_from_slice(&user.pubkey[..31]);
+    let mut sig_bytes = [0u8; 64];
+    sig_bytes[..32].copy_from_slice(&user.pubkey);
+    sig_bytes[32..].copy_from_slice(&user.pubkey);
+
+    let event_json = serde_json::json!({
+        "id": hex::encode(id_bytes),
+        "pubkey": hex::encode(&user.pubkey),
+        "created_at": 0,
+        "kind": 0,
+        "tags": [],
+        "content": Value::Object(content).to_string(),
+        "sig": hex::encode(sig_bytes),
+    });
+
+    serde_json::from_value(event_json).ok()
+}
+
+/// People-directory path: search the `users` table and return synthetic kind:0
+/// events. Prefer real stored kind:0 events when present so NIP-OA auth tags
+/// (agent ownership) survive; fall back to the synthetic event otherwise.
+async fn handle_people_directory_search(
+    state: &AppState,
+    tenant: &buzz_core::tenant::TenantContext,
+    search_text: &str,
+    limit: u32,
+    page: u32,
+    seen_ids: &mut std::collections::HashSet<[u8; 32]>,
+    events: &mut Vec<Value>,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    let offset = page.saturating_sub(1).saturating_mul(limit);
+    let rows = state
+        .db
+        .search_users(tenant.community(), search_text, limit, offset)
+        .await
+        .map_err(|e| internal_error(&format!("people directory search error: {e}")))?;
+
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    // Prefer real kind:0 events when they exist so agent auth tags remain.
+    let authors: Vec<Vec<u8>> = rows.iter().map(|u| u.pubkey.clone()).collect();
+    let mut query = buzz_db::event::EventQuery::for_community(tenant.community());
+    query.kinds = Some(vec![0]);
+    query.authors = Some(authors);
+    query.global_only = true;
+    // One latest profile per author is enough; pull a bit of headroom.
+    query.limit = Some((rows.len() as i64).saturating_mul(2).max(limit as i64));
+
+    let stored = state
+        .db
+        .query_events(&query)
+        .await
+        .map_err(|e| internal_error(&format!("people directory profile fetch error: {e}")))?;
+
+    // Keep the newest kind:0 per author.
+    let mut latest_by_author: std::collections::HashMap<Vec<u8>, &buzz_core::StoredEvent> =
+        std::collections::HashMap::new();
+    for se in &stored {
+        let key = se.event.pubkey.to_bytes().to_vec();
+        match latest_by_author.get(&key) {
+            Some(prev) if prev.event.created_at >= se.event.created_at => {}
+            _ => {
+                latest_by_author.insert(key, se);
+            }
+        }
+    }
+
+    for user in &rows {
+        if let Some(se) = latest_by_author.get(&user.pubkey) {
+            let id = se.event.id.to_bytes();
+            if !seen_ids.insert(id) {
+                continue;
+            }
+            if let Ok(v) = serde_json::to_value(&se.event) {
+                events.push(v);
+            }
+            continue;
+        }
+
+        // No stored kind:0 — synthesize from the users-table row so pubkey /
+        // alias / display_name search still surfaces the person.
+        let Some(event) = synthetic_kind0_from_user(user) else {
+            continue;
+        };
+        let id = event.id.to_bytes();
+        if !seen_ids.insert(id) {
+            continue;
+        }
+        if let Ok(v) = serde_json::to_value(&event) {
+            events.push(v);
+        }
+    }
+
+    Ok(())
+}
+
 /// Handle search filters by routing to Postgres FTS, then fetching full events
 /// from DB. Supports a bridge-only `page` extension over the FTS result set.
+///
+/// Pure kind:0 people-directory filters take a dedicated path through the
+/// `users` table so display name / NIP-05 / pubkey-hex typeahead works even
+/// when the author has no searchable kind:0 content blob.
 async fn handle_bridge_search(
     state: &AppState,
     raw_filters: &[Value],
@@ -1324,6 +1503,23 @@ async fn handle_bridge_search(
 
         let limit = filter.limit.unwrap_or(100).min(500) as u32;
         if limit == 0 {
+            continue;
+        }
+
+        // People directory (member picker / DM / @mention / topbar people):
+        // only kind:0, no other NIP-01 constraints. Route to the users table
+        // so pubkey hex and aliases resolve even without a content FTS hit.
+        if is_people_directory_search(filter) {
+            handle_people_directory_search(
+                state,
+                tenant,
+                &search_text,
+                limit,
+                search_page,
+                &mut seen_ids,
+                &mut events,
+            )
+            .await?;
             continue;
         }
 
@@ -2873,5 +3069,40 @@ mod tests {
             search_hit_accepted(&filter, &stored, &[], &viewer),
             "owner must still receive their own snapshot"
         );
+    }
+
+    #[test]
+    fn people_directory_search_detects_pure_kind0() {
+        let pure = nostr::Filter::new().kind(Kind::Metadata).search("alice");
+        assert!(is_people_directory_search(&pure));
+
+        let with_author = nostr::Filter::new()
+            .kind(Kind::Metadata)
+            .author(Keys::generate().public_key())
+            .search("alice");
+        assert!(!is_people_directory_search(&with_author));
+
+        let messages = nostr::Filter::new()
+            .kind(Kind::Custom(9))
+            .search("alice");
+        assert!(!is_people_directory_search(&messages));
+    }
+
+    #[test]
+    fn synthetic_kind0_uses_subject_pubkey_and_profile_fields() {
+        let pubkey = Keys::generate().public_key().to_bytes().to_vec();
+        let user = buzz_db::user::UserSearchProfile {
+            pubkey: pubkey.clone(),
+            display_name: Some("Alice".into()),
+            avatar_url: Some("https://example.com/a.png".into()),
+            nip05_handle: Some("alice@example.com".into()),
+        };
+        let event = synthetic_kind0_from_user(&user).expect("synthetic event");
+        assert_eq!(event.kind, Kind::Metadata);
+        assert_eq!(event.pubkey.to_bytes().to_vec(), pubkey);
+        let content: Value = serde_json::from_str(&event.content).expect("json content");
+        assert_eq!(content["display_name"], "Alice");
+        assert_eq!(content["nip05"], "alice@example.com");
+        assert_eq!(content["picture"], "https://example.com/a.png");
     }
 }

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -39,6 +39,27 @@ fn relay_http_url() -> String {
         .to_string()
 }
 
+/// Query the HTTP bridge's pure kind:0 people-directory path.
+async fn query_people(search: &str, requester_pubkey: &str) -> Vec<serde_json::Value> {
+    let response = reqwest::Client::new()
+        .post(format!("{}/query", relay_http_url()))
+        .header("X-Pubkey", requester_pubkey)
+        .json(&serde_json::json!([{
+            "kinds": [0],
+            "search": search,
+            "limit": 20,
+        }]))
+        .send()
+        .await
+        .expect("query people directory");
+    assert!(
+        response.status().is_success(),
+        "people-directory query failed: {}",
+        response.status()
+    );
+    response.json().await.expect("people-directory JSON")
+}
+
 /// Create a real channel via a signed kind:9007 event submitted to POST /events.
 async fn create_test_channel(keys: &Keys) -> String {
     let client = reqwest::Client::new();
@@ -856,6 +877,56 @@ async fn test_kind0_nip05_sync() {
     assert!(
         nip05_body2["names"][&unique_name].is_null(),
         "NIP-05 should not resolve after handle was cleared"
+    );
+
+    client.disconnect().await.expect("disconnect");
+}
+
+/// A deleted kind:0 must not be reconstructed from stale denormalized user fields.
+#[tokio::test]
+#[ignore]
+async fn test_people_search_does_not_resurrect_deleted_kind0() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let pubkey_hex = keys.public_key().to_hex();
+    let unique_name = format!("deleted-profile-{}", uuid::Uuid::new_v4().simple());
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let profile = EventBuilder::new(
+        Kind::Metadata,
+        serde_json::json!({ "display_name": unique_name }).to_string(),
+    )
+    .sign_with_keys(&keys)
+    .expect("sign profile");
+    let profile_id = profile.id.to_hex();
+    let published = client.send_event(profile).await.expect("publish profile");
+    assert!(
+        published.accepted,
+        "profile rejected: {}",
+        published.message
+    );
+
+    let before = query_people(&unique_name, &pubkey_hex).await;
+    assert!(
+        before.iter().any(|event| event["pubkey"] == pubkey_hex),
+        "published profile should be returned by people search"
+    );
+
+    let deletion = EventBuilder::new(Kind::EventDeletion, "")
+        .tags([Tag::parse(["e", &profile_id]).expect("deletion e tag")])
+        .sign_with_keys(&keys)
+        .expect("sign deletion");
+    let deleted = client.send_event(deletion).await.expect("delete profile");
+    assert!(
+        deleted.accepted,
+        "profile deletion rejected: {}",
+        deleted.message
+    );
+
+    let after = query_people(&unique_name, &pubkey_hex).await;
+    assert!(
+        after.iter().all(|event| event["pubkey"] != pubkey_hex),
+        "deleted profile must not be synthesized from stale users fields"
     );
 
     client.disconnect().await.expect("disconnect");

--- a/desktop/src-tauri/src/nostr_convert/user_search.rs
+++ b/desktop/src-tauri/src/nostr_convert/user_search.rs
@@ -164,6 +164,7 @@ fn match_score(q: &str, display_name: &str, nip05: &str, pubkey_hex: &str) -> u3
     const NIP05_PREFIX: u32 = 600;
     const NIP05_CONTAINS: u32 = 500;
     const PUBKEY_PREFIX: u32 = 400;
+    const PUBKEY_CONTAINS: u32 = 300;
 
     let score_field = |field: &str, exact: u32, prefix: u32, contains: u32| -> u32 {
         if field.is_empty() {
@@ -186,11 +187,7 @@ fn match_score(q: &str, display_name: &str, nip05: &str, pubkey_hex: &str) -> u3
         DISPLAY_CONTAINS,
     );
     let nip05_score = score_field(nip05, NIP05_EXACT, NIP05_PREFIX, NIP05_CONTAINS);
-    let pubkey_score = if !pubkey_hex.is_empty() && pubkey_hex.starts_with(q) {
-        PUBKEY_PREFIX
-    } else {
-        0
-    };
+    let pubkey_score = score_field(pubkey_hex, PUBKEY_PREFIX, PUBKEY_PREFIX, PUBKEY_CONTAINS);
 
     display_score.max(nip05_score).max(pubkey_score)
 }
@@ -318,6 +315,19 @@ mod tests {
         );
         let r = rank_user_search_results(&[e], "alice", 10);
         assert!(r.users.is_empty());
+    }
+
+    #[test]
+    fn rank_matches_mid_string_pubkey_hex() {
+        let keys = nostr::Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        let needle = &pubkey[8..16];
+        let e = EventBuilder::new(Kind::Metadata, r#"{"display_name":"Bob"}"#)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let r = rank_user_search_results(&[e], needle, 10);
+        assert_eq!(r.users.len(), 1);
+        assert_eq!(r.users[0].pubkey, pubkey);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Desktop people search (members sidebar, DM picker, @mentions, topbar people) returned zero results for pubkey hex and often for aliases
- Root cause: pure kind:0 directory queries only hit NIP-50 FTS over kind:0 **content**. Author pubkeys are not in that index, so hex search can never match; the existing `buzz_db::search_users` (name / NIP-05 / pubkey) was unused
- Fix: route pure kind:0 search filters on the HTTP bridge through the `users` table, prefer real stored kind:0 profiles when present (keeps NIP-OA agent tags), synthesize a directory-shaped kind:0 otherwise, and score mid-string pubkey matches in the desktop re-ranker

## Test plan
- [x] `cargo test -p buzz-relay --lib people_directory` / `synthetic_kind0`
- [x] desktop unit: `rank_matches_mid_string_pubkey_hex`
- [x] `cargo check -p buzz-db -p buzz-relay`
- [ ] CI green (relay image rebuild required for staging/prod)
- [ ] Manual against a relay with this fix: open Members → search a known display name / NIP-05 local part / pubkey prefix → results appear
- [ ] Manual: search by mid-string pubkey hex substring → result appears
- [ ] Manual: message search / channel-scoped search still uses FTS (unchanged path)

Related: mobile add-people surface is https://github.com/block/buzz/pull/1706 (separate gap). This PR is the search backend that both clients depend on.
