### PR TITLE
fix(observer): use lifecycle item title as verb instead of hardcoded "Status"

### DIFF
--- a/desktop/src/features/agents/ui/activityRenderClasses/LifecycleActivity.tsx
+++ b/desktop/src/features/agents/ui/activityRenderClasses/LifecycleActivity.tsx
@@ -121,9 +121,9 @@ export function LifecycleActivity(props: ActivityRenderClassItemProps) {
   return (
     <ActivityRow testId="transcript-lifecycle-item" title={timestampTitle}>
       <ActivityRowLabel
-        object={[props.item.title, props.item.text].filter(Boolean).join(" · ")}
+        object={props.item.text || undefined}
         openToneScope="none"
-        verb="Status"
+        verb={props.item.title}
       />
     </ActivityRow>
   );

--- a/desktop/tests/e2e/observer-feed-screenshots.spec.ts
+++ b/desktop/tests/e2e/observer-feed-screenshots.spec.ts
@@ -585,7 +585,7 @@ test.describe("observer feed screenshots", () => {
       },
     ]);
 
-    await expect(feedPanel.getByText("Commands")).toBeVisible({
+    await expect(feedPanel.getByText("Commands", { exact: true })).toBeVisible({
       timeout: 5_000,
     });
     await settleAnimations(feedPanel);


### PR DESCRIPTION
## Summary

- Lifecycle items in the observer feed (Commands, Mode, Usage, Config) were all prefixed with a hardcoded `verb="Status"`, rendering as `Status Commands · ...` instead of `Commands · ...`.
- Changed `LifecycleActivity.tsx` to use the item's `title` as the verb and `text` as the object, matching what each item actually represents.