### PR TITLE
fix(observer): widen live subscription lookback to capture session/prompt

### DIFF
--- a/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
@@ -1232,3 +1232,111 @@ test("steer ingress bundles its prompt context into the steer prompt segment, no
     "steer context must not leak as a standalone metadata row",
   );
 });
+
+// --- session/prompt late delivery (live subscription timing race) ---
+
+test("buildTranscript correctly renders prompt segment when session/prompt arrives after status lifecycle events", () => {
+  // Simulates the live-subscription timing race: status events (commands, mode,
+  // usage) arrive first because the desktop subscribed slightly after turn start,
+  // then session/prompt arrives later (e.g. via reconnect replay or archive
+  // backfill). buildTranscript is called in out-of-order sequence order but
+  // processTranscriptEvent handles insertion — the full rebuild path in
+  // appendAgentEvent (slow path for out-of-order) re-processes events sorted by
+  // timestamp+seq, so the prompt segment must appear.
+  const TURN = "turn-oot";
+  const SESS = "sess-oot";
+  const CH = "22222222-2222-2222-2222-222222222222";
+  const AUTHOR_HEX = "b".repeat(64);
+  const EVENT_HEX = "d".repeat(64);
+
+  const makeEvent = (seq, kind, timestamp, payload) => ({
+    seq,
+    kind,
+    timestamp,
+    agentIndex: 0,
+    channelId: CH,
+    sessionId: SESS,
+    turnId: TURN,
+    payload,
+  });
+
+  // Status events arrive first (lower seq but same timestamp as prompt)
+  const commandsEvent = makeEvent(
+    2,
+    "acp_read",
+    "2026-06-18T00:01:01Z",
+    {
+      method: "session/update",
+      params: {
+        sessionId: SESS,
+        update: {
+          sessionUpdate: "available_commands_update",
+          availableCommands: ["cmd1", "cmd2"],
+        },
+      },
+    },
+  );
+
+  const modeEvent = makeEvent(
+    3,
+    "acp_read",
+    "2026-06-18T00:01:01Z",
+    {
+      method: "session/update",
+      params: {
+        sessionId: SESS,
+        update: { sessionUpdate: "current_mode_update", currentModeId: "code" },
+      },
+    },
+  );
+
+  // session/prompt has the lowest seq — it was published first but arrived last
+  const promptEvent = makeEvent(
+    1,
+    "acp_write",
+    "2026-06-18T00:01:00Z",
+    {
+      method: "session/prompt",
+      params: {
+        sessionId: SESS,
+        prompt: [
+          {
+            type: "text",
+            text: `[Buzz event: @mention]\nEvent ID: ${EVENT_HEX.toUpperCase()}\nFrom: Alice (hex: ${AUTHOR_HEX})\nContent: please help`,
+          },
+          { type: "text", text: "[Context]\nScope: thread" },
+        ],
+      },
+    },
+  );
+
+  // Deliver events out of order: status first, then prompt
+  const items = buildTranscript([commandsEvent, modeEvent, promptEvent]);
+
+  const userMsg = items.find(
+    (i) => i.type === "message" && i.role === "user",
+  );
+  assert.ok(
+    userMsg,
+    "user message item must be present even when session/prompt arrives after status events",
+  );
+  assert.equal(
+    userMsg.text,
+    "please help",
+    "user message text extracted from session/prompt Content: line",
+  );
+
+  const blocks = buildTranscriptDisplayBlocks(items);
+  const turnBlock = blocks.find((b) => b.kind === "turn");
+  assert.ok(turnBlock, "expected a turn block");
+  const promptSegment = turnBlock.segments.find((s) => s.kind === "prompt");
+  assert.ok(
+    promptSegment,
+    "prompt segment must be present when session/prompt arrives out-of-order",
+  );
+  assert.equal(
+    promptSegment.user.text,
+    "please help",
+    "prompt segment carries the correct user text",
+  );
+});

--- a/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
@@ -1261,61 +1261,44 @@ test("buildTranscript correctly renders prompt segment when session/prompt arriv
   });
 
   // Status events arrive first (lower seq but same timestamp as prompt)
-  const commandsEvent = makeEvent(
-    2,
-    "acp_read",
-    "2026-06-18T00:01:01Z",
-    {
-      method: "session/update",
-      params: {
-        sessionId: SESS,
-        update: {
-          sessionUpdate: "available_commands_update",
-          availableCommands: ["cmd1", "cmd2"],
-        },
+  const commandsEvent = makeEvent(2, "acp_read", "2026-06-18T00:01:01Z", {
+    method: "session/update",
+    params: {
+      sessionId: SESS,
+      update: {
+        sessionUpdate: "available_commands_update",
+        availableCommands: ["cmd1", "cmd2"],
       },
     },
-  );
+  });
 
-  const modeEvent = makeEvent(
-    3,
-    "acp_read",
-    "2026-06-18T00:01:01Z",
-    {
-      method: "session/update",
-      params: {
-        sessionId: SESS,
-        update: { sessionUpdate: "current_mode_update", currentModeId: "code" },
-      },
+  const modeEvent = makeEvent(3, "acp_read", "2026-06-18T00:01:01Z", {
+    method: "session/update",
+    params: {
+      sessionId: SESS,
+      update: { sessionUpdate: "current_mode_update", currentModeId: "code" },
     },
-  );
+  });
 
   // session/prompt has the lowest seq — it was published first but arrived last
-  const promptEvent = makeEvent(
-    1,
-    "acp_write",
-    "2026-06-18T00:01:00Z",
-    {
-      method: "session/prompt",
-      params: {
-        sessionId: SESS,
-        prompt: [
-          {
-            type: "text",
-            text: `[Buzz event: @mention]\nEvent ID: ${EVENT_HEX.toUpperCase()}\nFrom: Alice (hex: ${AUTHOR_HEX})\nContent: please help`,
-          },
-          { type: "text", text: "[Context]\nScope: thread" },
-        ],
-      },
+  const promptEvent = makeEvent(1, "acp_write", "2026-06-18T00:01:00Z", {
+    method: "session/prompt",
+    params: {
+      sessionId: SESS,
+      prompt: [
+        {
+          type: "text",
+          text: `[Buzz event: @mention]\nEvent ID: ${EVENT_HEX.toUpperCase()}\nFrom: Alice (hex: ${AUTHOR_HEX})\nContent: please help`,
+        },
+        { type: "text", text: "[Context]\nScope: thread" },
+      ],
     },
-  );
+  });
 
   // Deliver events out of order: status first, then prompt
   const items = buildTranscript([commandsEvent, modeEvent, promptEvent]);
 
-  const userMsg = items.find(
-    (i) => i.type === "message" && i.role === "user",
-  );
+  const userMsg = items.find((i) => i.type === "message" && i.role === "user");
   assert.ok(
     userMsg,
     "user message item must be present even when session/prompt arrives after status events",

--- a/desktop/src/shared/api/observerRelay.test.mjs
+++ b/desktop/src/shared/api/observerRelay.test.mjs
@@ -30,3 +30,33 @@ test("subscribeToAgentObserverFrames requests a replay-capable limit with a sinc
 
   mock.reset();
 });
+
+// Regression guard: the live subscription lookback MUST be at least 300s so
+// session/prompt frames from long-running active turns are captured when the
+// desktop subscribes mid-turn. This test mocks Date.now() to a fixed epoch and
+// asserts the computed `since` equals exactly (now/1000 - 300). It MUST fail
+// if OBSERVER_LIVE_LOOKBACK_SECS is reverted to 0 or less than 300.
+test("subscribeToAgentObserverFrames since is at least 300s before now", () => {
+  // Pin Date.now() to a known value so the assertion is deterministic.
+  const FIXED_NOW_MS = 1_750_000_000_000;
+  const expectedSince = Math.floor(FIXED_NOW_MS / 1_000) - 300;
+
+  mock.method(Date, "now", () => FIXED_NOW_MS);
+
+  const calls = [];
+  mock.method(relayClient, "subscribeLive", (filter) => {
+    calls.push(filter);
+    return () => {};
+  });
+
+  subscribeToAgentObserverFrames("owner-pubkey", () => {});
+
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0].since,
+    expectedSince,
+    `observer since must be now-300s (${expectedSince}) so session/prompt frames from long-running turns are captured — zero lookback recreates the lifecycle-only turn bug`,
+  );
+
+  mock.reset();
+});

--- a/desktop/src/shared/api/observerRelay.ts
+++ b/desktop/src/shared/api/observerRelay.ts
@@ -5,11 +5,11 @@ import { relayClient } from "./relayClient";
 
 // How far back (in seconds) the live subscription looks on connect/reconnect.
 // session/prompt is the first frame emitted at turn start, so it can arrive
-// before the desktop subscribes when the agent was already running. A 60s
-// lookback ensures those frames are included. The archive backfill deduplicates
-// any frames that also arrive via the local Tauri archive, so there is no
-// double-processing risk.
-const OBSERVER_LIVE_LOOKBACK_SECS = 60;
+// before the desktop subscribes when the agent was already running. A 5-minute
+// lookback covers long-running active turns (coding/review turns routinely
+// exceed 60s). The archive backfill deduplicates any frames already in the
+// local Tauri archive, so there is no double-processing risk.
+const OBSERVER_LIVE_LOOKBACK_SECS = 300;
 
 export function subscribeToAgentObserverFrames(
   ownerPubkey: string,

--- a/desktop/src/shared/api/observerRelay.ts
+++ b/desktop/src/shared/api/observerRelay.ts
@@ -3,6 +3,14 @@ import type { RelayEvent } from "@/shared/api/types";
 import { KIND_AGENT_OBSERVER_FRAME } from "@/shared/constants/kinds";
 import { relayClient } from "./relayClient";
 
+// How far back (in seconds) the live subscription looks on connect/reconnect.
+// session/prompt is the first frame emitted at turn start, so it can arrive
+// before the desktop subscribes when the agent was already running. A 60s
+// lookback ensures those frames are included. The archive backfill deduplicates
+// any frames that also arrive via the local Tauri archive, so there is no
+// double-processing risk.
+const OBSERVER_LIVE_LOOKBACK_SECS = 60;
+
 export function subscribeToAgentObserverFrames(
   ownerPubkey: string,
   onEvent: (event: RelayEvent) => void,
@@ -12,11 +20,13 @@ export function subscribeToAgentObserverFrames(
       kinds: [KIND_AGENT_OBSERVER_FRAME],
       "#p": [ownerPubkey],
       // The high `limit` lets reconnect replay recover observer frames missed
-      // during a drop. `since` still suppresses launch-time history; only the
-      // reconnect replay window is backfilled. A `limit: 0` here would truncate
-      // that replay to zero rows, dropping the gap (NIP-01: limit 0 = no rows).
+      // during a drop. `since` provides a short lookback window so session/prompt
+      // frames from recently-started turns are not silently dropped when the
+      // subscription starts after the agent has already emitted them. Older
+      // history is served by the archive path (ingestArchivedObserverEvents).
+      // The appendAgentEvent dedup on (seq, timestamp) prevents double-processing.
       limit: 1000,
-      since: Math.floor(Date.now() / 1_000),
+      since: Math.floor(Date.now() / 1_000) - OBSERVER_LIVE_LOOKBACK_SECS,
     },
     onEvent,
   );


### PR DESCRIPTION
## Problem

The observer live subscription used `since: now` (current Unix second), which silently dropped `session/prompt` frames published before the subscription was established. This caused the prompt section (user message bubble + context dialog) to be absent from the observer feed when the desktop opened or reconnected while a turn was already in progress.

`session/prompt` is the **first** frame emitted at turn start. When the desktop subscribes mid-turn — on app launch, after a reconnect drop, or when opening the agent panel — the frame has a `created_at` in the past and is excluded by the `since` filter. Status frames (`commands`, `mode`, `usage`) arrive in real-time and pass the filter, so the turn renders with lifecycle items but no prompt segment.

## Root Cause

`subscribeToAgentObserverFrames` in `observerRelay.ts`:

```ts
since: Math.floor(Date.now() / 1_000),  // ← excludes anything published even 1s ago
```

## Fix

Widen `since` by `OBSERVER_LIVE_LOOKBACK_SECS` (300 seconds / 5 minutes):

```ts
since: Math.floor(Date.now() / 1_000) - OBSERVER_LIVE_LOOKBACK_SECS,
```

5 minutes covers long-running active turns (coding/review turns routinely exceed 60s). The `limit: 1000` bounds the result set. `appendAgentEvent` deduplicates on `(seq, timestamp)`, so frames already loaded via the local Tauri archive backfill path are silently dropped — no double-processing.

## Tests

- **Relay filter regression** (`observerRelay.test.mjs`): mocks `Date.now()` to a fixed epoch and asserts `since === Math.floor(now/1000) - 300`. Fails if `OBSERVER_LIVE_LOOKBACK_SECS` is reverted to 0 — the previous `since > 0` assertion would not catch this.
- **Out-of-order delivery** (`agentSessionTranscript.test.mjs`): delivers status events before `session/prompt` and asserts the prompt segment appears in the final display blocks.

2272 tests pass. `pnpm check` clean.