### PR TITLE
fix(inbox): reply at same thread level as inbox item

### DIFF
--- a/desktop/src/features/home/ui/InboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/InboxDetailPane.tsx
@@ -18,6 +18,7 @@ import {
   hasSameMessageAuthor,
   isWithinGroupingWindow,
 } from "@/features/messages/lib/messageGrouping";
+import { getThreadReference } from "@/features/messages/lib/threading";
 import { MessageComposer } from "@/features/messages/ui/MessageComposer";
 import { UpdateIndicator } from "@/features/settings/UpdateIndicator";
 import type { Channel } from "@/shared/api/types";
@@ -207,7 +208,10 @@ export function InboxDetailPane({
         ];
   const replyTarget =
     displayMessages.find((message) => message.id === replyTargetId) ?? null;
-  const composerParentEventId = replyTarget?.id ?? item.id;
+  const composerParentEventId =
+    replyTarget?.id ??
+    getThreadReference(item.item.tags ?? []).parentId ??
+    item.id;
   const composerReplyTarget =
     replyTarget && replyTarget.id !== item.id
       ? {


### PR DESCRIPTION
When replying to a message directly from the inbox pane, the composer was using the inbox item's own event ID as the `parentEventId`. For a message that is itself a thread reply (level 1), this caused the Rust `resolve_thread_ref` to see `root != parent` and emit both root and reply NIP-10 `e` tags — landing the new message one level deeper than the original (N+1 bug).

**Fix:** `InboxDetailPane.tsx` now derives `composerParentEventId` using `getThreadReference(item.item.tags ?? []).parentId ?? item.id`. This means the reply targets the same parent the inbox item replied to, placing the new message at the same thread depth. For root-level inbox items (`parentId` is null), the fallback to `item.id` preserves existing level-1 reply behavior.

**The explicit sub-message reply path** (`replyTarget?.id`) is unchanged and takes priority, so clicking reply on a specific context message in the detail view still works correctly.

**Files changed:**
- `desktop/src/features/home/ui/InboxDetailPane.tsx` — import `getThreadReference` from `@/features/messages/lib/threading`; update `composerParentEventId` derivation