### PR TITLE
fix(desktop): hide relay mesh option when mesh-llm feature is absent

### DIFF
--- a/desktop/src/features/mesh-compute/ui/RelayMeshAgentSection.tsx
+++ b/desktop/src/features/mesh-compute/ui/RelayMeshAgentSection.tsx
@@ -69,6 +69,13 @@ export function RelayMeshAgentSection({
   // an arbitrary one — the warning must reflect what'll actually happen.
   const [overrides, setOverrides] = React.useState<string[]>([]);
 
+  // Null means the first availability fetch hasn't succeeded — either still
+  // loading, or the backend was built without mesh-llm and never will resolve.
+  // Hide the card entirely rather than showing a permanently disabled toggle.
+  if (availability === null) {
+    return null;
+  }
+
   const targets = availability?.serveTargets ?? [];
   const selectedValue = targetEndpointAddr;
 


### PR DESCRIPTION
Builds compiled without the `mesh-llm` Cargo feature showed the "Run on relay mesh" card in the create-agent dialog permanently greyed out with "mesh-llm feature not enabled" — a toggle you could never use. The card is now hidden entirely in that case.

The gate is `availability === null` from `useMeshAvailability`: when the feature isn't compiled in, the Tauri `mesh_availability` stub errors forever so availability never resolves and the card never renders. When the feature is compiled in, the command always returns a value (even relay-unreachable resolves to unavailable-with-reason), so the card appears after the first fetch and keeps its existing greyed "unavailable right now" state — that one is transient and actionable, so it stays visible. Submission is unaffected when the card is hidden: the draft's `runOn` stays `local` and `resolveBackendIntent` emits no backend intent.
