### PR TITLE
fix(desktop): remove "Remove all stopped" bulk action from agents menu

### DIFF
--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -86,9 +86,6 @@ export function AgentsView() {
               isAgentsLoading={agents.managedAgentsQuery.isLoading}
               startingAgentPubkey={agents.startingAgentPubkey}
               startingPersonaIds={agents.startingPersonaIds}
-              onBulkRemoveStopped={() => {
-                void agents.handleBulkRemoveStopped();
-              }}
               onBulkStopRunning={() => {
                 void agents.handleBulkStopRunning();
               }}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -1,11 +1,5 @@
 import * as React from "react";
-import {
-  ChevronDown,
-  ChevronRight,
-  Ellipsis,
-  OctagonX,
-  Trash2,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, Ellipsis, OctagonX } from "lucide-react";
 
 import { formatAgentModelLabel } from "@/features/agents/lib/formatAgentModelLabel";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
@@ -38,7 +32,6 @@ type UnifiedAgentsSectionProps = {
   isAgentsLoading: boolean;
   startingAgentPubkey: string | null;
   startingPersonaIds: ReadonlySet<string>;
-  onBulkRemoveStopped: () => void;
   onBulkStopRunning: () => void;
   onOpenAgentProfile: (
     pubkey: string,
@@ -77,7 +70,6 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     isAgentsLoading,
     startingAgentPubkey,
     startingPersonaIds,
-    onBulkRemoveStopped,
     onBulkStopRunning,
     onOpenAgentProfile,
     onOpenPersonaProfile,
@@ -102,9 +94,6 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
 
   const runningCount = agents.filter((agent) =>
     isManagedAgentActive(agent),
-  ).length;
-  const stoppedCount = agents.filter(
-    (agent) => agent.status === "stopped" || agent.status === "not_deployed",
   ).length;
   const { groups, ungrouped, unknown } = React.useMemo(
     () => buildUnifiedGroups(personas, agents),
@@ -164,8 +153,6 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
         handleFileChange={handleFileChange}
         isActionPending={isActionPending}
         runningCount={runningCount}
-        stoppedCount={stoppedCount}
-        onBulkRemoveStopped={onBulkRemoveStopped}
         onBulkStopRunning={onBulkStopRunning}
       />
 
@@ -426,8 +413,6 @@ function SectionHeader({
   handleFileChange,
   isActionPending,
   runningCount,
-  stoppedCount,
-  onBulkRemoveStopped,
   onBulkStopRunning,
 }: {
   agentCount: number;
@@ -435,8 +420,6 @@ function SectionHeader({
   handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   isActionPending: boolean;
   runningCount: number;
-  stoppedCount: number;
-  onBulkRemoveStopped: () => void;
   onBulkStopRunning: () => void;
 }) {
   return (
@@ -478,14 +461,6 @@ function SectionHeader({
             >
               <OctagonX className="h-4 w-4" />
               Stop all running ({runningCount})
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-destructive focus:text-destructive"
-              disabled={isActionPending || stoppedCount === 0}
-              onClick={onBulkRemoveStopped}
-            >
-              <Trash2 className="h-4 w-4" />
-              Remove all stopped ({stoppedCount})
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -375,37 +375,6 @@ export function useManagedAgentActions() {
     );
   }
 
-  async function handleBulkRemoveStopped() {
-    const targets = managedAgents.filter(
-      (a) => a.status === "stopped" || a.status === "not_deployed",
-    );
-    const executed = await runBulkAction(
-      targets,
-      "Remove",
-      "removal",
-      async (a) => {
-        await deleteManagedAgent(a);
-        await removeAgentFromAllChannels(a.pubkey);
-      },
-    );
-    if (
-      executed &&
-      logAgentPubkey &&
-      targets.some((a) => a.pubkey === logAgentPubkey)
-    ) {
-      setLogAgentPubkey(null);
-    }
-  }
-
-  async function deleteManagedAgent(agent: ManagedAgent) {
-    const isDeployedRemote =
-      agent.backend.type === "provider" && agent.backendAgentId;
-    await deleteMutation.mutateAsync({
-      pubkey: agent.pubkey,
-      forceRemoteDelete: isDeployedRemote ? true : undefined,
-    });
-  }
-
   const isPending =
     createAgentMutation.isPending ||
     startMutation.isPending ||
@@ -448,7 +417,6 @@ export function useManagedAgentActions() {
     handleToggleStartOnAppLaunch,
     handleAddedToChannel,
     handleBulkStopRunning,
-    handleBulkRemoveStopped,
     refetchManagedAgents: () => void managedAgentsQuery.refetch(),
     refetchRelayAgents: () => void relayAgentsQuery.refetch(),
   };


### PR DESCRIPTION
This removes the "Remove all stopped (n)" item from the agents nav overflow menu, keeping "Stop all running (n)".

It was a holdover from before the persona/instance consolidation, when removing stopped instances just cleaned up dead process entries beneath a durable persona. Now that a stopped agent is the agent itself, the bulk action would delete agent records from disk, remove their keys from the keyring, and publish kind:5 tombstones to the relay — all behind a single confirm. It also had no built-in guard: the target filter was purely status-based (`ManagedAgentSummary` doesn't expose `is_builtin`), so a stopped built-in agent would have been mass-deleted even though the per-agent menu deliberately routes built-ins to deactivate instead of delete.

Individual removal from each agent card (which does carry the built-in protection) still covers the delete use case, and stopping agents in bulk is non-destructive, so that one stays.
