### PR TITLE
fix(desktop): pass GlobalAgentConfig to spawn_config_hash in tests

### DIFF
--- a/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
@@ -437,7 +437,12 @@ fn missing_definition_leaves_materialized_runtime_in_hash() {
 
     assert_ne!(
         spawn_config_hash(&rec, no_personas, "wss://ws.example", &Default::default()),
-        spawn_config_hash(&no_runtime, no_personas, "wss://ws.example", &Default::default()),
+        spawn_config_hash(
+            &no_runtime,
+            no_personas,
+            "wss://ws.example",
+            &Default::default()
+        ),
         "materialized runtime must still affect hash when definition is absent"
     );
 }

--- a/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
@@ -398,8 +398,8 @@ fn definition_runtime_edit_changes_hash_for_materialized_record() {
     let before = [persona("pers", Some("goose"), "prompt")];
     let after = [persona("pers", Some("claude"), "prompt")];
     assert_ne!(
-        spawn_config_hash(&rec, &before, "wss://ws.example"),
-        spawn_config_hash(&rec, &after, "wss://ws.example"),
+        spawn_config_hash(&rec, &before, "wss://ws.example", &Default::default()),
+        spawn_config_hash(&rec, &after, "wss://ws.example", &Default::default()),
         "definition runtime edit must badge a materialized, override-free instance"
     );
 }
@@ -416,8 +416,8 @@ fn agent_command_override_beats_definition_runtime_change() {
     let before = [persona("pers", Some("goose"), "prompt")];
     let after = [persona("pers", Some("claude"), "prompt")];
     assert_eq!(
-        spawn_config_hash(&rec, &before, "wss://ws.example"),
-        spawn_config_hash(&rec, &after, "wss://ws.example"),
+        spawn_config_hash(&rec, &before, "wss://ws.example", &Default::default()),
+        spawn_config_hash(&rec, &after, "wss://ws.example", &Default::default()),
         "explicit override must win regardless of definition runtime change"
     );
 }
@@ -436,8 +436,8 @@ fn missing_definition_leaves_materialized_runtime_in_hash() {
     no_runtime.runtime = None;
 
     assert_ne!(
-        spawn_config_hash(&rec, no_personas, "wss://ws.example"),
-        spawn_config_hash(&no_runtime, no_personas, "wss://ws.example"),
+        spawn_config_hash(&rec, no_personas, "wss://ws.example", &Default::default()),
+        spawn_config_hash(&no_runtime, no_personas, "wss://ws.example", &Default::default()),
         "materialized runtime must still affect hash when definition is absent"
     );
 }


### PR DESCRIPTION
Three tests added in #1448 called `spawn_config_hash` with 3 arguments after the function gained a 4th `global: &GlobalAgentConfig` parameter in that same PR. All other call sites in the file were correctly updated, but these three new tests were missed, breaking compilation of `Desktop Core` (Linux) and `Windows Rust` with 6× `E0061: this function takes 4 arguments but 3 were supplied`.

The `&no_runtime` call site in `missing_definition_leaves_materialized_runtime_in_hash` also exceeded rustfmt's line-length limit once the 4th arg was added, causing `desktop-tauri-fmt-check` to fail.

- Add `&Default::default()` as the 4th arg to the 6 affected `spawn_config_hash` calls in `definition_runtime_edit_changes_hash_for_materialized_record`, `agent_command_override_beats_definition_runtime_change`, and `missing_definition_leaves_materialized_runtime_in_hash`
- Reformat the `&no_runtime` call site to multi-line to satisfy `cargo fmt`