### PR TITLE
feat(desktop): default observer archive on for dev-nest builds

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -96,7 +96,10 @@ const overrides = new Map([
   // for multi-line rustfmt expansion of the skills symlink call site).
   // unified-agent-model 1A.1: inline test module moved to nest/tests.rs,
   // ratcheting 1575 -> 679 (under the 1000 default; entry kept as a ratchet).
-  ["src-tauri/src/managed_agents/nest.rs", 679],
+  // observer-archive dev-default: path_is_dev_nest + nest_is_dev getters
+  // (+25 lines) so observer_archive_default_enabled() keys off the dev nest.
+  // Load-bearing; spends banked ratchet headroom, still well under 1000.
+  ["src-tauri/src/managed_agents/nest.rs", 704],
   // keyring-dev-isolation: agent key migration added copy_agent_keys_between_stores
   // and load_readonly support; file grew past 1000 default. Queued to split.
   ["src-tauri/src/managed_agents/storage.rs", 1325],

--- a/desktop/src-tauri/src/commands/observer_archive.rs
+++ b/desktop/src-tauri/src/commands/observer_archive.rs
@@ -1,21 +1,26 @@
-//! Build-time flag for observer-feed archive default.
+//! Build-time flag and runtime dev-nest check for observer-feed archive default.
 //!
-//! When `BUZZ_BUILD_OBSERVER_ARCHIVE_DEFAULT` is set at build time (internal
-//! builds), `observer_archive_default_enabled()` returns `true` and the
-//! frontend auto-seeds an `owner_p` save subscription for the current identity
-//! on first run.
+//! `observer_archive_default_enabled()` returns `true` when either:
+//! - `BUZZ_BUILD_OBSERVER_ARCHIVE_DEFAULT` was set at build time (internal
+//!   builds bake in the flag via `build.rs`), **or**
+//! - the running binary is using the dev nest (`~/.buzz-dev`), which is the
+//!   case for all dev builds launched with `just staging` or `just dev`.
 //!
-//! OSS builds (env var unset) return `false` — no auto-seeding, user opts in
-//! manually via the Local Archive settings card.
+//! When `true`, the frontend auto-seeds an `owner_p` save subscription for the
+//! current identity on first run, so the observer-feed archive is on by default.
+//!
+//! OSS prod builds (baked flag unset, prod nest `~/.buzz`) return `false` —
+//! no auto-seeding; the user opts in manually via the Local Archive settings card.
 
-/// Returns `true` when an internal build has observer-feed archive default-on.
+/// Returns `true` when observer-feed archive should default to on.
 ///
-/// The frontend calls this once at startup to decide whether to seed the
-/// `owner_p` save subscription.  The result is stable for the lifetime of the
-/// binary — it is baked at compile time.
+/// True when the build has the internal baked flag set, or when the running
+/// binary is using the dev nest (`~/.buzz-dev`). The frontend calls this once
+/// at startup to decide whether to seed the `owner_p` save subscription.
 #[tauri::command]
 pub fn observer_archive_default_enabled() -> bool {
     option_env!("BUZZ_DESKTOP_BUILD_OBSERVER_ARCHIVE_DEFAULT").is_some()
+        || crate::managed_agents::nest_is_dev()
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -106,6 +106,33 @@ pub fn nest_dir() -> Option<PathBuf> {
     }
 }
 
+/// Returns `true` iff `path` ends with the dev-nest directory name (`.buzz-dev`).
+///
+/// Pure function — no globals — so it can be unit-tested without touching the
+/// process-lifetime [`NEST_DIR`] `OnceLock`.
+fn path_is_dev_nest(path: &std::path::Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n == NEST_DIR_DEV)
+        .unwrap_or(false)
+}
+
+/// Returns `true` when the running binary is using the dev nest (`~/.buzz-dev`).
+///
+/// This is `true` for all dev builds — `just staging` and `just dev` — because
+/// [`init_nest_dir`] is called with `is_dev = true` when the Tauri app-data
+/// directory starts with `"xyz.block.buzz.app.dev"`.
+///
+/// Returns `false` when:
+/// - The nest is the production nest (`~/.buzz`, signed DMG).
+/// - [`init_nest_dir`] has not been called yet (unit tests, home dir
+///   unresolvable) — the fallback path is always the prod nest.
+pub fn nest_is_dev() -> bool {
+    nest_dir()
+        .map(|p| path_is_dev_nest(&p))
+        .unwrap_or(false)
+}
+
 /// Creates the Buzz nest at `~/.buzz` if it doesn't already exist.
 ///
 /// Delegates to [`ensure_nest_at`] with the resolved nest directory.

--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -128,9 +128,7 @@ fn path_is_dev_nest(path: &std::path::Path) -> bool {
 /// - [`init_nest_dir`] has not been called yet (unit tests, home dir
 ///   unresolvable) — the fallback path is always the prod nest.
 pub fn nest_is_dev() -> bool {
-    nest_dir()
-        .map(|p| path_is_dev_nest(&p))
-        .unwrap_or(false)
+    nest_dir().map(|p| path_is_dev_nest(&p)).unwrap_or(false)
 }
 
 /// Creates the Buzz nest at `~/.buzz` if it doesn't already exist.

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -909,3 +909,39 @@ fn refresh_skill_overwrites_on_version_bump() {
         "SKILL.md must be refreshed on version bump"
     );
 }
+
+#[test]
+fn test_path_is_dev_nest_dev_path_returns_true() {
+    let path = std::path::Path::new("/Users/someone/.buzz-dev");
+    assert!(
+        path_is_dev_nest(path),
+        ".buzz-dev path must be identified as dev nest"
+    );
+}
+
+#[test]
+fn test_path_is_dev_nest_prod_path_returns_false() {
+    let path = std::path::Path::new("/Users/someone/.buzz");
+    assert!(
+        !path_is_dev_nest(path),
+        ".buzz path must not be identified as dev nest"
+    );
+}
+
+#[test]
+fn test_path_is_dev_nest_unrelated_path_returns_false() {
+    let path = std::path::Path::new("/Users/someone/.buzz-staging");
+    assert!(
+        !path_is_dev_nest(path),
+        "unrelated path must not be identified as dev nest"
+    );
+}
+
+#[test]
+fn test_path_is_dev_nest_root_returns_false() {
+    let path = std::path::Path::new("/");
+    assert!(
+        !path_is_dev_nest(path),
+        "root path must not be identified as dev nest"
+    );
+}


### PR DESCRIPTION
Observer-feed archive defaulted to off for dev builds unless the compile-time flag `BUZZ_BUILD_OBSERVER_ARCHIVE_DEFAULT` was baked in (internal builds only). This required a manual opt-in toggle in every fresh dev environment.

Add a pure path helper `path_is_dev_nest` and a public getter `nest_is_dev` to `nest.rs`. These use the nest's resolved directory name — the same discriminator that already routes the archive to `~/.buzz-dev` vs `~/.buzz` at boot — to determine whether the running binary is a dev build. `observer_archive_default_enabled()` now returns `true` when either the baked compile-time flag is set (internal builds, unchanged behavior) or the running binary is using the dev nest (all `just staging` / `just dev` builds).

Under `cargo test` the `OnceLock` is uninitialized so `nest_dir()` falls back to the prod path, keeping the existing `test_observer_archive_default_enabled_returns_bool` assertion green. Prod DMG builds land in `~/.buzz`, so `path_is_dev_nest` returns `false` there — no regression for OSS or production users.