### PR TITLE
feat: add owner-gated community soft delete

### DIFF
--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -307,6 +307,7 @@ impl Db {
             SELECT id, host
             FROM communities
             WHERE lower(host) = lower($1)
+              AND deleted_at IS NULL
             "#,
         )
         .bind(normalized_host)
@@ -341,6 +342,7 @@ impl Db {
             JOIN relay_members rm ON rm.community_id = c.id
             WHERE rm.pubkey = $1
               AND rm.role = 'owner'
+              AND c.deleted_at IS NULL
             ORDER BY c.created_at ASC, c.host ASC
             "#,
         )
@@ -378,6 +380,7 @@ impl Db {
             SELECT host
             FROM communities
             WHERE id = $1
+              AND deleted_at IS NULL
             "#,
         )
         .bind(community_id.as_uuid())
@@ -447,7 +450,7 @@ impl Db {
             r#"
             INSERT INTO communities (host)
             VALUES ($1)
-            ON CONFLICT (lower(host)) DO UPDATE SET host = communities.host
+            ON CONFLICT (lower(host)) WHERE deleted_at IS NULL DO UPDATE SET host = communities.host
             RETURNING id, host, (xmax = 0) AS created
             "#,
         )
@@ -484,7 +487,7 @@ impl Db {
             r#"
             INSERT INTO communities (host)
             VALUES ($1)
-            ON CONFLICT (lower(host)) DO NOTHING
+            ON CONFLICT (lower(host)) WHERE deleted_at IS NULL DO NOTHING
             RETURNING id, host
             "#,
         )
@@ -512,6 +515,7 @@ impl Db {
                 WHERE lower(c.host) = lower($1)
                   AND lower(rm.pubkey) = lower($2)
                   AND rm.role = 'owner'
+                  AND c.deleted_at IS NULL
                 "#,
             )
             .bind(normalized_host)
@@ -530,6 +534,39 @@ impl Db {
             id: CommunityId::from_uuid(id),
             host,
         }))
+    }
+
+    /// Soft-deletes an active community if `owner_pubkey` still owns it.
+    ///
+    /// The owner predicate and state transition execute in one statement so an
+    /// ownership change cannot race between authorization and deletion. Returns
+    /// `true` only when the active community row was updated.
+    pub async fn soft_delete_community_owned_by(
+        &self,
+        community_id: CommunityId,
+        owner_pubkey: &str,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE communities c
+            SET deleted_at = NOW()
+            WHERE c.id = $1
+              AND c.deleted_at IS NULL
+              AND EXISTS (
+                  SELECT 1
+                  FROM relay_members rm
+                  WHERE rm.community_id = c.id
+                    AND lower(rm.pubkey) = lower($2)
+                    AND rm.role = 'owner'
+              )
+            "#,
+        )
+        .bind(community_id.as_uuid())
+        .bind(owner_pubkey)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() == 1)
     }
 
     /// Returns the community that owns a channel, if the channel exists.
@@ -3053,6 +3090,78 @@ mod tests {
             .await
             .expect("post-rotation retry");
         assert!(post_rotation_retry.is_none());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn soft_delete_hides_community_and_recreate_uses_new_uuid() {
+        let db = setup_db().await;
+        let host = format!("soft-delete-{}.example", Uuid::new_v4().simple());
+        let owner = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let other = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        let original = db
+            .create_community_with_owner(&host, owner)
+            .await
+            .expect("create original community")
+            .expect("new host");
+        assert!(!db
+            .soft_delete_community_owned_by(original.id, other)
+            .await
+            .expect("reject non-owner delete"));
+        assert!(db
+            .lookup_community_by_host(&host)
+            .await
+            .expect("lookup active community")
+            .is_some());
+
+        assert!(db
+            .soft_delete_community_owned_by(original.id, owner)
+            .await
+            .expect("delete owned community"));
+        assert!(db
+            .lookup_community_by_host(&host)
+            .await
+            .expect("lookup deleted community")
+            .is_none());
+        assert!(db
+            .lookup_community_host(original.id)
+            .await
+            .expect("reverse lookup deleted community")
+            .is_none());
+        assert!(db
+            .list_communities_owned_by(owner)
+            .await
+            .expect("list owned communities")
+            .iter()
+            .all(|community| community.id != original.id));
+        assert!(!db
+            .soft_delete_community_owned_by(original.id, owner)
+            .await
+            .expect("repeat delete"));
+
+        let recreated = db
+            .create_community_with_owner(&host, owner)
+            .await
+            .expect("recreate community")
+            .expect("deleted host is reusable");
+        assert_ne!(recreated.id, original.id);
+
+        let old_owner_role: Option<String> = sqlx::query_scalar(
+            "SELECT role FROM relay_members WHERE community_id = $1 AND pubkey = $2",
+        )
+        .bind(original.id.as_uuid())
+        .bind(owner)
+        .fetch_optional(&db.pool)
+        .await
+        .expect("old owner role");
+        assert_eq!(old_owner_role.as_deref(), Some("owner"));
+        let active = db
+            .lookup_community_by_host(&host)
+            .await
+            .expect("lookup recreated community")
+            .expect("recreated community active");
+        assert_eq!(active.id, recreated.id);
     }
 
     #[tokio::test]

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -471,7 +471,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 6);
+        assert_eq!(migrations.len(), 7);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -548,6 +548,13 @@ mod tests {
             .sql
             .as_str()
             .contains("CREATE TABLE moderation_actions"));
+        assert_eq!(migrations[6].version, 7);
+        assert!(migrations[6].sql.as_str().contains("ADD COLUMN deleted_at"));
+        assert!(migrations[6]
+            .sql
+            .as_str()
+            .contains("WHERE deleted_at IS NULL"));
+
         for action in crate::moderation::MODERATION_ACTION_CHECK_VOCAB {
             assert!(
                 migrations[5].sql.as_str().contains(&format!("'{action}'")),

--- a/crates/buzz-pubsub/src/conn_control.rs
+++ b/crates/buzz-pubsub/src/conn_control.rs
@@ -3,7 +3,8 @@
 //! Under horizontal scaling a member's live connections may land on any pod,
 //! so a moderation action taken on one pod (a ban) must reach the pod holding
 //! the victim's socket. This module carries connection-control intents — today
-//! only "disconnect this pubkey" — to every pod, which each apply locally
+//! "disconnect this pubkey" and "disconnect this community" — to every pod,
+//! which each apply locally
 //! against their own [`crate::ConnectionManager`].
 //!
 //! This is deliberately a **separate** channel from `cache_invalidation`: a
@@ -54,6 +55,8 @@ pub fn parse_conn_control_channel(channel: &str) -> Option<CommunityId> {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "op")]
 pub enum ConnControl {
+    /// Disconnect every live connection bound to the carrying community.
+    DisconnectCommunity,
     /// Disconnect every live connection authenticated as `pubkey` in the
     /// carrying community — live ban enforcement. `pubkey` is 32 raw bytes.
     /// `event_id` and `reason` reproduce the same NIP-01 `OK` frame the origin
@@ -195,6 +198,13 @@ mod tests {
         let a = ctx(0x1234, "a.example");
         let extended = format!("{}:extra", conn_control_channel(&a));
         assert_eq!(parse_conn_control_channel(&extended), None);
+    }
+
+    #[test]
+    fn disconnect_community_command_serde_round_trips() {
+        let cmd = ConnControl::DisconnectCommunity;
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert_eq!(serde_json::from_str::<ConnControl>(&json).unwrap(), cmd);
     }
 
     #[test]

--- a/crates/buzz-relay/src/api/operator.rs
+++ b/crates/buzz-relay/src/api/operator.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Query, RawQuery, State},
+    extract::{Path, Query, RawQuery, State},
     http::{HeaderMap, StatusCode},
     response::Json,
 };
@@ -15,7 +15,8 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::handlers::community_provisioning::{
-    normalize_candidate_host, validate_pubkey_hex, ProvisionCommunityRequest,
+    normalize_candidate_host, validate_pubkey_hex, DeleteCommunityRequest,
+    ProvisionCommunityRequest,
 };
 use crate::state::AppState;
 
@@ -166,6 +167,55 @@ pub async fn provision_community(
         {
             tracing::error!(error = %msg, "operator community persistence failed");
             Err(internal_error("operator community persistence failed"))
+        }
+        Err(msg) => Err(api_error(StatusCode::BAD_REQUEST, &msg)),
+    }
+}
+
+/// Soft-delete a community after validating an operator-proxied owner request.
+pub async fn delete_community(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(host): Path<String>,
+    RawQuery(raw_query): RawQuery,
+    Query(request): Query<DeleteCommunityRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let path = format!("/operator/communities/{host}");
+    let pubkey = authorize_operator_request(
+        &state,
+        &headers,
+        "DELETE",
+        &path,
+        raw_query.as_deref(),
+        None,
+    )
+    .await?;
+
+    match crate::handlers::community_provisioning::delete_community(
+        &state,
+        &pubkey,
+        &host,
+        &request.owner_pubkey,
+    )
+    .await
+    {
+        Ok(response) => Ok(Json(serde_json::to_value(response).map_err(|e| {
+            tracing::error!("failed to serialize delete-community response: {e}");
+            internal_error("operator delete response serialization failed")
+        })?)),
+        Err(msg) if msg.starts_with("actor not authorized") => {
+            Err(api_error(StatusCode::FORBIDDEN, &msg))
+        }
+        Err(msg) if msg == "community not found" => Err(api_error(StatusCode::NOT_FOUND, &msg)),
+        Err(msg) if msg == "provided pubkey is not the community owner" => {
+            Err(api_error(StatusCode::FORBIDDEN, &msg))
+        }
+        Err(msg)
+            if msg.starts_with("failed to look up community:")
+                || msg.starts_with("failed to delete community:") =>
+        {
+            tracing::error!(error = %msg, "operator community deletion failed");
+            Err(internal_error("operator community deletion failed"))
         }
         Err(msg) => Err(api_error(StatusCode::BAD_REQUEST, &msg)),
     }
@@ -498,6 +548,71 @@ mod tests {
             json.get("owner_pubkey").and_then(Value::as_str),
             Some(owner_hex.as_str())
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn delete_requires_matching_owner_and_hides_community() {
+        let operator = Keys::generate();
+        let owner = Keys::generate();
+        let outsider = Keys::generate();
+        let Some(state) = operator_test_state(std::slice::from_ref(&operator)).await else {
+            return;
+        };
+        let host = format!("delete-community-{}.example", Uuid::new_v4().simple());
+        let original = state
+            .db
+            .create_community_with_owner(&host, &owner.public_key().to_hex())
+            .await
+            .expect("create community")
+            .expect("new community");
+
+        let outsider_query = format!("owner_pubkey={}", outsider.public_key().to_hex());
+        let outsider_url =
+            format!("http://{INGRESS_HOST}/operator/communities/{host}?{outsider_query}");
+        let outsider_auth = nip98_auth_header(&operator, &outsider_url, "DELETE", None);
+        let response = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/operator/communities/{host}?{outsider_query}"))
+                    .header(header::HOST, INGRESS_HOST)
+                    .header(header::AUTHORIZATION, outsider_auth)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let owner_query = format!("owner_pubkey={}", owner.public_key().to_hex());
+        let owner_url = format!("http://{INGRESS_HOST}/operator/communities/{host}?{owner_query}");
+        let owner_auth = nip98_auth_header(&operator, &owner_url, "DELETE", None);
+        let response = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/operator/communities/{host}?{owner_query}"))
+                    .header(header::HOST, INGRESS_HOST)
+                    .header(header::AUTHORIZATION, owner_auth)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = read_json(response).await;
+        assert_eq!(json.get("status").and_then(Value::as_str), Some("deleted"));
+        assert_eq!(
+            json.get("community_id").and_then(Value::as_str),
+            Some(original.id.to_string().as_str())
+        );
+        assert!(state
+            .db
+            .lookup_community_by_host(&host)
+            .await
+            .expect("lookup community")
+            .is_none());
     }
 
     #[tokio::test]

--- a/crates/buzz-relay/src/handlers/community_provisioning.rs
+++ b/crates/buzz-relay/src/handlers/community_provisioning.rs
@@ -53,6 +53,24 @@ pub struct ProvisionCommunityRequest {
     pub create_only: bool,
 }
 
+/// Query parameters for `DELETE /operator/communities/{host}`.
+#[derive(Debug, Deserialize)]
+pub struct DeleteCommunityRequest {
+    /// Pubkey asserted by the operator proxy as the deleting community owner.
+    pub owner_pubkey: String,
+}
+
+/// JSON response from `DELETE /operator/communities/{host}`.
+#[derive(Debug, Serialize)]
+pub struct DeleteCommunityResponse {
+    /// UUID of the community row that was soft-deleted.
+    pub community_id: String,
+    /// Canonical host stored on the deleted community row.
+    pub host: String,
+    /// Always `deleted` for a successful response.
+    pub status: &'static str,
+}
+
 /// JSON response from `POST /operator/communities`.
 #[derive(Debug, Serialize)]
 pub struct ProvisionCommunityResponse {
@@ -306,6 +324,65 @@ pub async fn provision_community(
         host: record.host,
         status: if record.created { "created" } else { "existed" },
         owner_pubkey: initial_owner,
+    })
+}
+
+/// Soft-delete a community after verifying the operator's owner assertion.
+///
+/// The NIP-98 signer is a deployment operator acting as a trusted proxy. The
+/// asserted owner must still hold `role = 'owner'` on the active community; the
+/// database checks that predicate atomically with the state transition.
+pub async fn delete_community(
+    state: &Arc<AppState>,
+    operator_pubkey: &nostr::PublicKey,
+    host: &str,
+    owner_pubkey: &str,
+) -> Result<DeleteCommunityResponse, String> {
+    let operator_hex = operator_pubkey.to_hex();
+    if !state
+        .config
+        .relay_operator_pubkeys
+        .iter()
+        .any(|pk| pk == &operator_hex)
+    {
+        return Err("actor not authorized: not a relay operator".to_string());
+    }
+
+    let normalized_host = normalize_candidate_host(host)?;
+    let owner_hex = validate_pubkey_hex(owner_pubkey)
+        .ok_or_else(|| "invalid owner_pubkey: expected 64-char hex pubkey".to_string())?;
+    let community = state
+        .db
+        .lookup_community_by_host(&normalized_host)
+        .await
+        .map_err(|e| format!("failed to look up community: {e}"))?
+        .ok_or_else(|| "community not found".to_string())?;
+
+    let deleted = state
+        .db
+        .soft_delete_community_owned_by(community.id, &owner_hex)
+        .await
+        .map_err(|e| format!("failed to delete community: {e}"))?;
+    if !deleted {
+        return Err("provided pubkey is not the community owner".to_string());
+    }
+
+    let tenant = buzz_core::tenant::TenantContext::resolved(community.id, community.host.clone());
+    let disconnected = state.disconnect_community_clusterwide(&tenant);
+
+    info!(
+        operator = %operator_hex,
+        community = %community.id,
+        host = %community.host,
+        owner = %owner_hex,
+        disconnected,
+        "community soft-deleted via operator endpoint"
+    );
+
+    Ok(DeleteCommunityResponse {
+        community_id: community.id.to_string(),
+        host: community.host,
+        status: "deleted",
     })
 }
 

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -749,6 +749,11 @@ async fn main() -> anyhow::Result<()> {
             loop {
                 match rx.recv().await {
                     Ok(scoped) => match scoped.command {
+                        buzz_pubsub::conn_control::ConnControl::DisconnectCommunity => {
+                            state_for_conn_ctrl
+                                .conn_manager
+                                .disconnect_community(scoped.community_id);
+                        }
                         buzz_pubsub::conn_control::ConnControl::DisconnectPubkey {
                             pubkey,
                             event_id,

--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -68,6 +68,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             "/operator/communities/availability",
             get(api::operator::community_availability),
         )
+        .route(
+            "/operator/communities/{host}",
+            axum::routing::delete(api::operator::delete_community),
+        )
         // Relay invites: mint (owner/admin) + claim (membership-gate exempt)
         .route("/api/invites", post(api::invites::mint_invite))
         .route("/api/invites/claim", post(api::invites::claim_invite))

--- a/crates/buzz-relay/src/state.rs
+++ b/crates/buzz-relay/src/state.rs
@@ -194,6 +194,30 @@ impl ConnectionManager {
         closed
     }
 
+    /// Disconnect every live connection bound to `community`.
+    ///
+    /// Community deletion must terminate already-bound sockets; host lookup only
+    /// protects new handshakes, while existing connections retain their resolved
+    /// tenant id for their lifetime. Returns the number of local sockets closed.
+    pub fn disconnect_community(&self, community: CommunityId) -> usize {
+        let conn_ids = self
+            .connections
+            .iter()
+            .filter_map(|entry| (entry.community_id == community).then_some(*entry.key()))
+            .collect::<Vec<_>>();
+        let mut closed = 0;
+        for conn_id in conn_ids {
+            if let Some(entry) = self.connections.get(&conn_id) {
+                if entry.community_id != community {
+                    continue;
+                }
+                entry.cancel.cancel();
+                closed += 1;
+            }
+        }
+        closed
+    }
+
     /// Return the server-resolved community that the connection's host bound to.
     pub fn community_for_conn(&self, conn_id: Uuid) -> Option<CommunityId> {
         self.connections
@@ -775,6 +799,22 @@ impl AppState {
         closed
     }
 
+    /// Disconnect all sockets for a soft-deleted community on every relay pod.
+    pub fn disconnect_community_clusterwide(&self, tenant: &TenantContext) -> usize {
+        let closed = self.conn_manager.disconnect_community(tenant.community());
+        let pubsub = Arc::clone(&self.pubsub);
+        let tenant = tenant.clone();
+        tokio::spawn(async move {
+            if let Err(e) = pubsub
+                .publish_conn_control(&tenant, &ConnControl::DisconnectCommunity)
+                .await
+            {
+                tracing::warn!("Failed to publish community disconnect: {e}");
+            }
+        });
+        closed
+    }
+
     /// Get accessible channel IDs with a 10-second cache. Falls back to DB on miss.
     pub async fn get_accessible_channel_ids_cached(
         &self,
@@ -1258,6 +1298,45 @@ mod tests {
             Some("private".to_string()),
             "A's channel deletion must not evict B's cache entries"
         );
+    }
+
+    #[tokio::test]
+    async fn disconnect_community_closes_only_matching_tenant() {
+        let community_a = CommunityId::from_uuid(Uuid::from_u128(0xaaaa));
+        let community_b = CommunityId::from_uuid(Uuid::from_u128(0xbbbb));
+        let mgr = ConnectionManager::new();
+        let conn_a = Uuid::new_v4();
+        let (tx_a, _rx_a) = mpsc::channel(4);
+        let (ctrl_tx_a, _ctrl_rx_a) = mpsc::channel(1);
+        let cancel_a = CancellationToken::new();
+        mgr.register(
+            conn_a,
+            tx_a,
+            ctrl_tx_a,
+            cancel_a.clone(),
+            community_a,
+            Arc::new(AtomicU8::new(0)),
+            Arc::new(Mutex::new(HashMap::new())),
+            3,
+        );
+        let conn_b = Uuid::new_v4();
+        let (tx_b, _rx_b) = mpsc::channel(4);
+        let (ctrl_tx_b, _ctrl_rx_b) = mpsc::channel(1);
+        let cancel_b = CancellationToken::new();
+        mgr.register(
+            conn_b,
+            tx_b,
+            ctrl_tx_b,
+            cancel_b.clone(),
+            community_b,
+            Arc::new(AtomicU8::new(0)),
+            Arc::new(Mutex::new(HashMap::new())),
+            3,
+        );
+
+        assert_eq!(mgr.disconnect_community(community_a), 1);
+        assert!(cancel_a.is_cancelled());
+        assert!(!cancel_b.is_cancelled());
     }
 
     #[tokio::test]

--- a/migrations/0007_community_soft_delete.sql
+++ b/migrations/0007_community_soft_delete.sql
@@ -1,0 +1,10 @@
+-- Soft-delete communities while allowing a deleted hostname to be provisioned
+-- as a new, isolated tenant. Child rows remain attached to the deleted UUID.
+ALTER TABLE communities
+    ADD COLUMN deleted_at TIMESTAMPTZ;
+
+DROP INDEX idx_communities_host;
+
+CREATE UNIQUE INDEX idx_communities_host
+    ON communities (lower(host))
+    WHERE deleted_at IS NULL;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -55,10 +55,12 @@ CREATE TABLE communities (
     host            VARCHAR(255) NOT NULL,
     signing_key     BYTEA,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at      TIMESTAMPTZ,
     CONSTRAINT chk_communities_id_not_nil CHECK (id <> '00000000-0000-0000-0000-000000000000'::uuid)
 );
 
-CREATE UNIQUE INDEX idx_communities_host ON communities (lower(host));
+CREATE UNIQUE INDEX idx_communities_host ON communities (lower(host))
+    WHERE deleted_at IS NULL;
 
 -- ── Channels ──────────────────────────────────────────────────────────────────
 -- Conformance: "Channels and channel membership". `community_id` immutable.


### PR DESCRIPTION
## Summary
- add `DELETE /operator/communities/{host}?owner_pubkey=...` with NIP-98 operator authentication and an atomic current-owner predicate
- soft-delete community rows and make active hostname uniqueness partial so recreation gets a fresh UUID without linking old tenant data
- fail host/reverse-host/list reads closed for deleted communities and disconnect already-bound sockets across relay pods

## Testing
- `cargo check -p buzz-db -p buzz-pubsub -p buzz-relay`
- `cargo test -p buzz-db -p buzz-pubsub -p buzz-relay --no-run`
- `cargo clippy -p buzz-db -p buzz-pubsub -p buzz-relay --all-targets -- -D warnings`
- migration tests, DB soft-delete/recreate integration test, operator delete integration test
- pre-commit and pre-push hooks
