### PR TITLE
fix(release): run Linux release job under bash not dash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -465,6 +465,11 @@ jobs:
       # AppImage tools (linuxdeploy, appimagetool) are themselves AppImages.
       # Containers lack FUSE, so we must use the extract-and-run fallback.
       APPIMAGE_EXTRACT_AND_RUN: "1"
+    # This job runs in a container where the default run shell is dash;
+    # the AppImage steps below use bash-only syntax ([[ ]], mapfile, arrays).
+    defaults:
+      run:
+        shell: bash
     outputs:
       archive_name: ${{ steps.linux-artifacts.outputs.archive_name }}
       sig: ${{ steps.read-sig.outputs.sig }}


### PR DESCRIPTION
The `release-linux` job runs inside `container: ubuntu:22.04`, where GitHub defaults `run:` steps to `/bin/sh` (dash, not bash). #1567 introduced bash-only syntax (`[[ ... ]]`, `mapfile`, array expansion) into several steps of that job but never set `shell: bash`.

Under dash, `[[` is "not found" — the `if` evaluates false, the else branch fires, and the job emits the misleading error `No pinned SHA256 for appimagetool-x86_64` even though the arch detection and pinned hash are both correct. This caused the 0.4.0 Linux release build to fail at [runs/29121102791/job/86456171048](https://github.com/block/buzz/actions/runs/29121102791/job/86456171048).

Because `release.yml` only triggers on tag push or `workflow_dispatch` (never `pull_request`), the bash-isms shipped in #1567 without ever running in CI. The 0.4.0 tag was the first execution since that PR merged.

## Change

Add `defaults.run.shell: bash` to the `release-linux` job. This fixes all seven bash-isms at once (lines 547, 598, 602, 617, 624, 634, 640) — `[[ ]]`, `mapfile`, and array expansion — without touching any logic.

No other jobs are modified.

Unblocks the 0.4.0 Linux release.