### PR TITLE
feat(desktop): add explicit Edit avatar CTA in agent instance edit dialog

### DIFF
--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -20,8 +20,8 @@ const rules = [
 ];
 
 // Decorative / chrome exceptions: `relativePath:lineNumber`. The avatar emoji
-// glyph is a fixed display size sized to its avatar box (not readable message
-// text), so it stays as the lone documented `text-[6rem]` literal.
+// glyphs are fixed display sizes sized to their avatar box (not readable
+// message text), so they are exempted from the readable-text px rule.
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",

--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -25,7 +25,8 @@ const rules = [
 const overrides = new Set([
   "src/features/settings/ui/ProfileSettingsCard.tsx:584",
   "src/features/onboarding/ui/AvatarStep.tsx:89",
-  "src/features/agents/ui/AgentCreationPreview.tsx:711",
+  "src/features/agents/ui/AgentCreationPreview.tsx:666",
+  "src/features/agents/ui/AgentCreationPreview.tsx:747",
 ]);
 
 await runPxTextCheck({

--- a/desktop/src/features/agents/ui/AgentCreationPreview.tsx
+++ b/desktop/src/features/agents/ui/AgentCreationPreview.tsx
@@ -57,6 +57,7 @@ type EmojiMartEmoji = {
 export function AgentCreationPreview({
   avatarUrl,
   disabled = false,
+  hideEditControl = false,
   label,
   onClearAvatar,
   onUploadPendingChange,
@@ -64,6 +65,10 @@ export function AgentCreationPreview({
 }: {
   avatarUrl: string | null;
   disabled?: boolean;
+  /** When true, omit all upload/edit controls and render the avatar as a
+   *  plain display element. Use in contexts where avatar editing is
+   *  handled by an external affordance (e.g. AgentInstanceEditDialog). */
+  hideEditControl?: boolean;
   label: string;
   onClearAvatar?: () => void;
   onUploadPendingChange?: (isPending: boolean) => void;
@@ -643,6 +648,37 @@ export function AgentCreationPreview({
       </fieldset>
     </PopoverContent>
   );
+
+  // Display-only path: no upload controls, no pencil badge, no popover.
+  // Used when the caller provides its own edit affordance.
+  if (hideEditControl) {
+    return (
+      <div className="mx-auto w-full max-w-[220px] lg:sticky lg:top-0">
+        <div className="group/avatar-preview relative m-0 flex min-h-[190px] min-w-0 flex-col items-center justify-center gap-3 rounded-xl border border-transparent p-0">
+          <div className="relative h-36 w-36">
+            {emojiAvatarPreview ? (
+              <div
+                aria-label={`${label} avatar`}
+                className="relative flex h-full w-full shrink-0 items-center justify-center overflow-hidden rounded-full shadow-xs transition-[background-color] duration-200 ease-out"
+                role="img"
+                style={{ backgroundColor: emojiAvatarPreview.color }}
+              >
+                <span className="flex h-full w-full items-center justify-center text-[4rem] leading-none">
+                  {emojiAvatarPreview.emoji}
+                </span>
+              </div>
+            ) : (
+              <ProfileAvatar
+                avatarUrl={avatarUrl}
+                className="h-full w-full text-4xl"
+                label={label}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto w-full max-w-[220px] lg:sticky lg:top-0">

--- a/desktop/src/features/agents/ui/AgentDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDialog.tsx
@@ -45,6 +45,13 @@ type AgentDialogInstanceEditProps = {
   onOpenChange: (open: boolean) => void;
   onUpdated?: (agent: ManagedAgent) => void;
   initialFocus?: EditAgentFocusTarget;
+  /**
+   * Called when the user clicks "Edit avatar" inside the instance-edit dialog.
+   * Caller (UserProfilePanel) is responsible for closing this dialog and
+   * opening the definition-edit dialog. Only passed when the linked definition
+   * is editable (non-built-in, resolved).
+   */
+  onEditLinkedPersona?: () => void;
 };
 
 type AgentDialogDefinitionEditProps = {
@@ -88,6 +95,7 @@ export function AgentDialog(props: AgentDialogProps) {
     return (
       <AgentInstanceEditDialog
         agent={props.agent}
+        onEditLinkedPersona={props.onEditLinkedPersona}
         onOpenChange={props.onOpenChange}
         onUpdated={props.onUpdated}
         open={props.open}

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -87,13 +87,8 @@ export function AgentInstanceEditDialog({
   /** Optional field to scroll/focus when the dialog opens from a card deep-link. */
   initialFocus?: EditAgentFocusTarget;
   open: boolean;
-  /**
-   * Called when the user wants to edit the linked definition's avatar.
-   * The caller (UserProfilePanel) closes this dialog and opens the
-   * definition-edit dialog. Only present when the linked definition is
-   * editable (non-built-in, resolved). If absent, a read-only preview is
-   * shown instead.
-   */
+  /** Present only when the linked definition is editable (non-built-in,
+   * resolved). Caller closes this dialog and enters definition-edit. */
   onEditLinkedPersona?: () => void;
   onOpenChange: (open: boolean) => void;
   onUpdated?: (agent: ManagedAgent) => void;
@@ -831,21 +826,18 @@ export function AgentInstanceEditDialog({
         }
       >
         <div className="grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]">
-          {/* Avatar is definition-level identity (Wes decision 2026-07-09).
-              Render an explicit "Edit avatar" CTA when the linked definition
-              is editable so users can navigate directly to the definition-edit
-              dialog. For built-ins or unresolvable definitions, show a
-              read-only preview with clarifying copy. */}
-          {onEditLinkedPersona ? (
-            <div className="flex flex-col items-center gap-2">
-              <AgentCreationPreview
-                avatarUrl={previewAvatarUrl}
-                disabled
-                label={previewLabel}
-                onClearAvatar={() => setAvatarUrl("")}
-                onUploadPendingChange={setIsAvatarUploadPending}
-                onSelectAvatar={setAvatarUrl}
-              />
+          {/* Avatar is definition-level identity. hideEditControl suppresses
+              the internal pencil badge; the CTA below is the only edit path. */}
+          <div className="flex flex-col items-center gap-2">
+            <AgentCreationPreview
+              avatarUrl={previewAvatarUrl}
+              hideEditControl
+              label={previewLabel}
+              onClearAvatar={() => setAvatarUrl("")}
+              onUploadPendingChange={setIsAvatarUploadPending}
+              onSelectAvatar={setAvatarUrl}
+            />
+            {onEditLinkedPersona ? (
               <Button
                 className="w-full"
                 onClick={() => {
@@ -858,23 +850,12 @@ export function AgentInstanceEditDialog({
               >
                 Edit avatar
               </Button>
-            </div>
-          ) : (
-            <div className="flex flex-col items-center gap-2">
-              <AgentCreationPreview
-                avatarUrl={previewAvatarUrl}
-                disabled
-                label={previewLabel}
-                onClearAvatar={() => setAvatarUrl("")}
-                onUploadPendingChange={setIsAvatarUploadPending}
-                onSelectAvatar={setAvatarUrl}
-              />
+            ) : (
               <p className="text-center text-xs text-muted-foreground">
                 Avatar is shared identity
               </p>
-            </div>
-          )}
-
+            )}
+          </div>
           <div className="space-y-5">
             {/* Agent name */}
             <div className="space-y-1.5">

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -79,6 +79,7 @@ export function AgentInstanceEditDialog({
   agent,
   initialFocus,
   open,
+  onEditLinkedPersona,
   onOpenChange,
   onUpdated,
 }: {
@@ -86,6 +87,14 @@ export function AgentInstanceEditDialog({
   /** Optional field to scroll/focus when the dialog opens from a card deep-link. */
   initialFocus?: EditAgentFocusTarget;
   open: boolean;
+  /**
+   * Called when the user wants to edit the linked definition's avatar.
+   * The caller (UserProfilePanel) closes this dialog and opens the
+   * definition-edit dialog. Only present when the linked definition is
+   * editable (non-built-in, resolved). If absent, a read-only preview is
+   * shown instead.
+   */
+  onEditLinkedPersona?: () => void;
   onOpenChange: (open: boolean) => void;
   onUpdated?: (agent: ManagedAgent) => void;
 }) {
@@ -822,17 +831,49 @@ export function AgentInstanceEditDialog({
         }
       >
         <div className="grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]">
-          {/* Avatar is definition-level identity (Wes decision 2026-07-09,
-              "2a"): edit it on the agent profile; instances inherit and
-              re-sync on restart. Read-only here by design. */}
-          <AgentCreationPreview
-            avatarUrl={previewAvatarUrl}
-            disabled
-            label={previewLabel}
-            onClearAvatar={() => setAvatarUrl("")}
-            onUploadPendingChange={setIsAvatarUploadPending}
-            onSelectAvatar={setAvatarUrl}
-          />
+          {/* Avatar is definition-level identity (Wes decision 2026-07-09).
+              Render an explicit "Edit avatar" CTA when the linked definition
+              is editable so users can navigate directly to the definition-edit
+              dialog. For built-ins or unresolvable definitions, show a
+              read-only preview with clarifying copy. */}
+          {onEditLinkedPersona ? (
+            <div className="flex flex-col items-center gap-2">
+              <AgentCreationPreview
+                avatarUrl={previewAvatarUrl}
+                disabled
+                label={previewLabel}
+                onClearAvatar={() => setAvatarUrl("")}
+                onUploadPendingChange={setIsAvatarUploadPending}
+                onSelectAvatar={setAvatarUrl}
+              />
+              <Button
+                className="w-full"
+                onClick={() => {
+                  handleOpenChange(false);
+                  onEditLinkedPersona();
+                }}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                Edit avatar
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-2">
+              <AgentCreationPreview
+                avatarUrl={previewAvatarUrl}
+                disabled
+                label={previewLabel}
+                onClearAvatar={() => setAvatarUrl("")}
+                onUploadPendingChange={setIsAvatarUploadPending}
+                onSelectAvatar={setAvatarUrl}
+              />
+              <p className="text-center text-xs text-muted-foreground">
+                Avatar is shared identity
+              </p>
+            </div>
+          )}
 
           <div className="space-y-5">
             {/* Agent name */}

--- a/desktop/src/features/agents/ui/agentDialogRouting.test.mjs
+++ b/desktop/src/features/agents/ui/agentDialogRouting.test.mjs
@@ -59,6 +59,7 @@ test("instance-edit routes to AgentInstanceEditDialog with its contract props", 
   assert.equal(element.type, AgentInstanceEditDialog);
   assert.deepEqual(element.props, {
     agent,
+    onEditLinkedPersona: undefined,
     onOpenChange,
     onUpdated,
     open: true,

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -917,6 +917,15 @@ export function UserProfilePanel({
         agent={managedAgent}
         mode="instance-edit"
         initialFocus={editAgentFocus}
+        onEditLinkedPersona={
+          resolvedPersona && !resolvedPersona.isBuiltIn
+            ? () => {
+                setEditAgentOpen(false);
+                setEditAgentFocus(undefined);
+                setPersonaDialogState(editPersonaDialogState(resolvedPersona));
+              }
+            : undefined
+        }
         onOpenChange={(next) => {
           setEditAgentOpen(next);
           if (!next) setEditAgentFocus(undefined);


### PR DESCRIPTION
Avatar editing is definition-authoritative (Wes decision 2026-07-09): `update_persona` propagates avatar changes to all linked agent instances and republishes their `kind:0` profiles. The per-instance edit dialog previously showed a disabled, non-interactive avatar preview — users had no way to discover the working edit path.

This change makes avatar editing discoverable from where users naturally look. When the linked definition is editable (non-built-in, resolved), the instance-edit dialog now renders an explicit **Edit avatar** button below the preview. Clicking it closes the instance dialog and opens the definition-edit dialog via the existing `editPersonaDialogState` path. For built-ins or agents with an unresolvable definition, a read-only preview with "Avatar is shared identity" copy is shown instead.

## Changes

- `AgentInstanceEditDialog.tsx` — replace dead `disabled` avatar preview with an `onEditLinkedPersona`-gated CTA: button when editable, read-only copy when not
- `AgentDialog.tsx` — thread `onEditLinkedPersona` prop through the `instance-edit` arm
- `UserProfilePanel.tsx` — supply `onEditLinkedPersona` when `resolvedPersona && !resolvedPersona.isBuiltIn`; callback closes instance dialog, clears focus state, and enters `editPersonaDialogState(resolvedPersona)`
- `agentDialogRouting.test.mjs` — update contract-props snapshot to include `onEditLinkedPersona`

## What is not changed

`UpdateManagedAgentInput` has no `avatarUrl` field — intentionally. The per-instance write path (PR #1666 approach) is not revived; that reintroduces last-writer-wins on `kind:0` that was the reason #1666 was closed. All avatar writes go through `update_persona` only.