### PR TITLE
fix(release): install AppImage bundling system deps for Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -494,6 +494,7 @@ jobs:
             build-essential \
             ca-certificates \
             curl \
+            desktop-file-utils \
             file \
             git \
             libasound2-dev \
@@ -505,6 +506,7 @@ jobs:
             libxdo-dev \
             patchelf \
             pkg-config \
+            squashfs-tools \
             wget \
             xdg-utils
           # Install GitHub CLI — preinstalled on runners but absent in containers.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -505,7 +505,8 @@ jobs:
             libxdo-dev \
             patchelf \
             pkg-config \
-            wget
+            wget \
+            xdg-utils
           # Install GitHub CLI — preinstalled on runners but absent in containers.
           # wget and ca-certificates are now available from the step above.
           mkdir -p -m 755 /etc/apt/keyrings


### PR DESCRIPTION
The `release-linux` job runs inside a bare `ubuntu:22.04` container. Unlike GitHub's `ubuntu-latest` hosted runners, this container does not include AppImage toolchain dependencies in its default package set.

Three packages are required but absent:

- `xdg-utils` — provides `xdg-mime`, which `tauri-bundler` shells out to during AppImage bundling. This was the direct failure in run [29123405897](https://github.com/block/buzz/actions/runs/29123405897/job/86463498065): `xdg-mime binary not found /usr/bin/xdg-mime: No such file or directory (os error 2)`.
- `squashfs-tools` — provides `mksquashfs`/`unsquashfs`, required by the AppImage toolchain (appimagetool, linuxdeploy) to pack/unpack the squashfs filesystem inside an AppImage.
- `desktop-file-utils` — provides `desktop-file-validate`, used by appimagetool and linuxdeploy to validate the `.desktop` file embedded in the AppDir during AppImage creation.

All three are preinstalled on `ubuntu-latest` runners but absent in the bare container — same root cause class as the `curl`/`git`/`gh` additions in earlier commits.

**Confirmed missing** via containerized simulation in the exact pinned image (`ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982`) with `--platform linux/amd64`. No other jobs or steps are touched.

This unblocks the 0.4.0 Linux release after #1733 resolved the dash/bash shell dialect failure.