### PR TITLE
[codex] Clarify empty channel agent copy

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -439,9 +439,9 @@ export const ChannelPane = React.memo(function ChannelPane({
     if (!activeChannel.archivedAt && activeChannel.isMember) {
       if (onAddAgent) {
         actions.push({
-          description: "Add an agent here.",
+          description: "Add an agent or team.",
           icon: <Bot aria-hidden className="h-6 w-6" />,
-          label: "Create agent",
+          label: "Add agent",
           onClick: onAddAgent,
           testId: "channel-intro-action-create-agent",
         });

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -814,6 +814,12 @@ test("empty channel shows intro actions", async ({ page }) => {
     page.getByTestId("channel-intro-action-create-agent"),
   ).toBeVisible();
   await expect(
+    page.getByTestId("channel-intro-action-create-agent-title"),
+  ).toHaveText("Add agent");
+  await expect(
+    page.getByTestId("channel-intro-action-create-agent-description"),
+  ).toHaveText("Add an agent or team.");
+  await expect(
     page.getByTestId("channel-intro-action-add-people"),
   ).toBeVisible();
   await expect(page.getByTestId("welcome-composer-guide-banner")).toHaveCount(


### PR DESCRIPTION
Clarify copy in empty channel state to make it clear that you can add an agent or team of agents (rather than “Create agent” as current)

## Screenshot

![Empty channel Add agent action](https://sprout.up.railway.app/media/96e4177a9d03ff30c854decdf0aacb0d77620ed8bd3df18825391c9961b66409.png)