### PR TITLE
fix(desktop): fix workspace rail badge disappearance and persist mark-as-unread

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -275,6 +275,12 @@ const overrides = new Map([
   // at the 1000 ceiling; comment-only overage, not code growth. Queued to
   // split with the rest of this list.
   ["src/features/channels/ui/ChannelScreen.tsx", 1002],
+  // forced-unread persistence: markChannelUnread now writes through to
+  // forcedUnreadStore (localStorage) so the sidebar badge survives reload and
+  // the rail observer can read it. Three clear points added (markChannelRead,
+  // markAllChannelsRead, drainSyncedAdvances). Load-bearing fix, not generic
+  // debt growth. Queued to split with the rest of this list.
+  ["src/features/channels/useUnreadChannels.ts", 1017],
   // Shared UI was added to this guard after splitting globals/markdown so
   // large shared renderers cannot grow further while follow-up splits land.
   // +33 for config-nudge detect-and-render + author-auth gate (normalizePubkey guard).

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -280,7 +280,7 @@ const overrides = new Map([
   // the rail observer can read it. Three clear points added (markChannelRead,
   // markAllChannelsRead, drainSyncedAdvances). Load-bearing fix, not generic
   // debt growth. Queued to split with the rest of this list.
-  ["src/features/channels/useUnreadChannels.ts", 1017],
+  ["src/features/channels/useUnreadChannels.ts", 1022],
   // Shared UI was added to this guard after splitting globals/markdown so
   // large shared renderers cannot grow further while follow-up splits land.
   // +33 for config-nudge detect-and-render + author-auth gate (normalizePubkey guard).

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -133,12 +133,20 @@ export function AppShell() {
   // markChannelRead({ topLevelOnly: true }) for the previous workspace's
   // channel, advancing its NIP-RS markers and causing the rail badge to vanish
   // on the next 30s poll (A→B→A→B disappearance bug).
+  // Guard: skip goHome() when re-selecting the already-active workspace so
+  // the current channel is not unexpectedly cleared.
   const handleSwitchWorkspace = React.useCallback(
     (id: string) => {
-      void goHome();
+      if (id !== workspacesHook.activeWorkspace?.id) {
+        void goHome();
+      }
       workspacesHook.switchWorkspace(id);
     },
-    [goHome, workspacesHook.switchWorkspace],
+    [
+      goHome,
+      workspacesHook.activeWorkspace?.id,
+      workspacesHook.switchWorkspace,
+    ],
   );
   const { selectedChannelId, selectedView } = React.useMemo(
     () => deriveShellRoute(location.pathname),

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -128,6 +128,18 @@ export function AppShell() {
   } = useAppNavigation();
   const { canGoBack, canGoForward, goBack, goForward } =
     useBackForwardControls();
+  // Navigate home before switching workspaces so the outgoing channel URL is
+  // cleared. Without this, ChannelScreen's read effect continues firing
+  // markChannelRead({ topLevelOnly: true }) for the previous workspace's
+  // channel, advancing its NIP-RS markers and causing the rail badge to vanish
+  // on the next 30s poll (A→B→A→B disappearance bug).
+  const handleSwitchWorkspace = React.useCallback(
+    (id: string) => {
+      void goHome();
+      workspacesHook.switchWorkspace(id);
+    },
+    [goHome, workspacesHook.switchWorkspace],
+  );
   const { selectedChannelId, selectedView } = React.useMemo(
     () => deriveShellRoute(location.pathname),
     [location.pathname],
@@ -659,7 +671,7 @@ export function AppShell() {
                       }
                       onAddWorkspace={() => setIsAddWorkspaceOpen(true)}
                       onRemoveWorkspace={workspacesHook.removeWorkspace}
-                      onSwitchWorkspace={workspacesHook.switchWorkspace}
+                      onSwitchWorkspace={handleSwitchWorkspace}
                       onUpdateWorkspace={workspacesHook.updateWorkspace}
                       workspaces={workspacesHook.workspaces}
                     />
@@ -739,7 +751,7 @@ export function AppShell() {
                           isPresencePending={presenceSession.isPending}
                           onAddWorkspace={(workspace) => {
                             const id = workspacesHook.addWorkspace(workspace);
-                            workspacesHook.switchWorkspace(id);
+                            handleSwitchWorkspace(id);
                           }}
                           onAddWorkspaceOpenChange={setIsAddWorkspaceOpen}
                           onNewDmOpenChange={setIsNewDmOpen}
@@ -747,7 +759,7 @@ export function AppShell() {
                           onOpenAddWorkspace={() => setIsAddWorkspaceOpen(true)}
                           onUpdateWorkspace={workspacesHook.updateWorkspace}
                           onRemoveWorkspace={workspacesHook.removeWorkspace}
-                          onSwitchWorkspace={workspacesHook.switchWorkspace}
+                          onSwitchWorkspace={handleSwitchWorkspace}
                           onCreateAgent={() =>
                             void goAgents().then(requestOpenCreateAgent)
                           }

--- a/desktop/src/features/channels/forcedUnreadStore.ts
+++ b/desktop/src/features/channels/forcedUnreadStore.ts
@@ -1,15 +1,56 @@
-import { makeRootIdStore } from "@/features/channels/unreadRootIdStore";
-
 /**
- * Per-pubkey localStorage store for channels manually marked unread via
+ * Per-pubkey localStorage record store for channels manually marked unread via
  * right-click → "mark unread". Keyed by channelId (not thread-root). Persisted
  * so the sidebar badge survives reload and the rail observer can read it for
  * inactive workspaces.
  *
- * Cleared on: channel-open, identity change, and when a cross-device synced
- * read-marker covers the channel (drainSyncedAdvances path in useUnreadChannels).
+ * Each entry stores the channel's own NIP-RS read marker (unix seconds) at the
+ * moment mark-unread was invoked, or null if no marker existed yet. The rail
+ * observer gates the forced-unread OR on this baseline: if the observed synced
+ * read marker has since advanced past markerAtWhenForced, the cross-device read
+ * wins and the dot is not lit.
+ *
+ * On identity change, the in-memory map is swapped to the current pubkey's
+ * persisted data. Old pubkey data is NOT wiped from localStorage.
  *
  * NOT synced to the relay — NIP-RS markers are monotonic and cannot represent
  * a retrograde "unread" state. localStorage is best-effort (per-device).
  */
-export const forcedUnreadStore = makeRootIdStore("buzz-forced-unread.v1");
+
+/** channelId → NIP-RS read marker (unix seconds) at force-time, or null */
+export type ForcedUnreadMap = Record<string, number | null>;
+
+const STORAGE_PREFIX = "buzz-forced-unread.v1";
+const storageKey = (pubkey: string) => `${STORAGE_PREFIX}:${pubkey}`;
+
+export const forcedUnreadStore = {
+  read(pubkey: string): ForcedUnreadMap {
+    try {
+      const raw = window.localStorage.getItem(storageKey(pubkey));
+      if (!raw) return {};
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      )
+        return {};
+      const result: ForcedUnreadMap = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof k === "string" && (v === null || typeof v === "number")) {
+          result[k] = v as number | null;
+        }
+      }
+      return result;
+    } catch {
+      return {};
+    }
+  },
+  write(pubkey: string, map: ForcedUnreadMap): void {
+    try {
+      window.localStorage.setItem(storageKey(pubkey), JSON.stringify(map));
+    } catch {
+      // Ignore storage errors (private browsing, quota exceeded).
+    }
+  },
+};

--- a/desktop/src/features/channels/forcedUnreadStore.ts
+++ b/desktop/src/features/channels/forcedUnreadStore.ts
@@ -1,0 +1,15 @@
+import { makeRootIdStore } from "@/features/channels/unreadRootIdStore";
+
+/**
+ * Per-pubkey localStorage store for channels manually marked unread via
+ * right-click → "mark unread". Keyed by channelId (not thread-root). Persisted
+ * so the sidebar badge survives reload and the rail observer can read it for
+ * inactive workspaces.
+ *
+ * Cleared on: channel-open, identity change, and when a cross-device synced
+ * read-marker covers the channel (drainSyncedAdvances path in useUnreadChannels).
+ *
+ * NOT synced to the relay — NIP-RS markers are monotonic and cannot represent
+ * a retrograde "unread" state. localStorage is best-effort (per-device).
+ */
+export const forcedUnreadStore = makeRootIdStore("buzz-forced-unread.v1");

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -17,6 +17,7 @@ import {
 } from "@/features/channels/unreadChannelCounts";
 import { useReadState } from "@/features/channels/readState/useReadState";
 import { makeRootIdStore } from "@/features/channels/unreadRootIdStore";
+import { forcedUnreadStore } from "@/features/channels/forcedUnreadStore";
 import {
   getThreadReference,
   isBroadcastReply,
@@ -228,10 +229,13 @@ export function useUnreadChannels(
   channelsRef.current = channels;
 
   // Channels manually marked unread this session (e.g., right-click → "mark
-  // unread"). Because NIP-RS read markers are monotonic, this in-session flag
-  // is what makes the badge appear *now* without lowering synced read state.
-  // Cleared when the user opens the channel.
-  const forcedUnreadRef = React.useRef(new Set<string>());
+  // unread"). Because NIP-RS read markers are monotonic, this flag is what
+  // makes the badge appear without lowering synced read state. Persisted to
+  // localStorage (buzz-forced-unread.v1) so it survives reload and is visible
+  // to the rail observer for inactive workspaces.
+  const forcedUnreadRef = React.useRef(
+    pubkey ? forcedUnreadStore.read(pubkey) : new Set<string>(),
+  );
 
   // When a synced event advances a read marker (cross-device mark-as-read),
   // remove from forcedUnreadRef so the dot clears immediately.
@@ -244,7 +248,12 @@ export function useUnreadChannels(
         anyNew = true;
       }
     }
-    if (anyNew) bumpLatestVersion();
+    if (anyNew) {
+      if (pubkey) {
+        forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
+      }
+      bumpLatestVersion();
+    }
   }, [readStateVersion, drainSyncedAdvances]);
 
   // Root event IDs of threads where the current user has replied at least once.
@@ -292,14 +301,18 @@ export function useUnreadChannels(
     0,
   );
 
-  // Reset all in-session state when the identity or relay changes. Unread
-  // tracking depends only on NIP-RS read markers + observed relay events for
-  // this user; nothing here is persisted across restarts.
+  // Reset all in-session state when the identity or relay changes. In-memory
+  // caches are cleared; persisted stores are loaded for the new pubkey (so
+  // forced-unread, participation, etc. are correct for the new identity).
   // biome-ignore lint/correctness/useExhaustiveDependencies: pubkey/relayClient are intentional reset signals
   React.useEffect(() => {
     latestByChannelRef.current = new Map();
     observedUnreadEventsByChannelRef.current = new Map();
-    forcedUnreadRef.current = new Set();
+    // Load persisted forced-unread set for the new pubkey (do NOT clear the
+    // store — another device's data should survive identity switches here).
+    forcedUnreadRef.current = pubkey
+      ? forcedUnreadStore.read(pubkey)
+      : new Set();
     caughtUpChannelsRef.current = new Set();
     participatedRootIdsRef.current = pubkey
       ? participationStore.read(pubkey)
@@ -333,6 +346,9 @@ export function useUnreadChannels(
       { topLevelOnly = false }: { topLevelOnly?: boolean } = {},
     ) => {
       if (forcedUnreadRef.current.delete(channelId)) {
+        if (pubkey) {
+          forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
+        }
         bumpLatestVersion();
       }
       const observedLatest = topLevelOnly
@@ -355,18 +371,25 @@ export function useUnreadChannels(
         bumpLatestVersion();
       }
     },
-    [markContextRead],
+    [markContextRead, pubkey],
   );
 
-  // Manually mark a channel unread (e.g., right-click → "mark unread"). Sets
-  // the in-session forced flag so the sidebar badge appears immediately. NIP-RS
-  // read markers are monotonic, so we do not publish a lower timestamp.
-  const markChannelUnread = React.useCallback((channelId: string) => {
-    if (!forcedUnreadRef.current.has(channelId)) {
-      forcedUnreadRef.current.add(channelId);
-      bumpLatestVersion();
-    }
-  }, []);
+  // Manually mark a channel unread (e.g., right-click → "mark unread"). Persists
+  // the flag to localStorage (buzz-forced-unread.v1) so it survives reload and
+  // is visible to the rail observer for inactive workspaces. NIP-RS markers are
+  // monotonic, so we do not publish a lower timestamp.
+  const markChannelUnread = React.useCallback(
+    (channelId: string) => {
+      if (!forcedUnreadRef.current.has(channelId)) {
+        forcedUnreadRef.current.add(channelId);
+        if (pubkey) {
+          forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
+        }
+        bumpLatestVersion();
+      }
+    },
+    [pubkey],
+  );
 
   // Record the thread root of an EXTERNAL message that @-mentioned the user.
   // Keyed on the thread root so the badge gate trips for a mention recipient
@@ -940,8 +963,11 @@ export function useUnreadChannels(
       latestByChannelRef.current.delete(channelId);
       observedUnreadEventsByChannelRef.current.delete(channelId);
     }
+    if (pubkey) {
+      forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
+    }
     bumpLatestVersion();
-  }, [getEffectiveTimestamp, markContextRead]);
+  }, [getEffectiveTimestamp, markContextRead, pubkey]);
 
   // Identity-stable snapshots of the membership sets for the notify gate.
   // Re-derived only when membershipVersion bumps (a set actually changed), so

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -249,7 +249,7 @@ export function useUnreadChannels(
     const advanced = drainSyncedAdvances();
     let anyNew = false;
     for (const channelId of advanced) {
-      if (channelId in forcedUnreadRef.current) {
+      if (Object.hasOwn(forcedUnreadRef.current, channelId)) {
         delete forcedUnreadRef.current[channelId];
         anyNew = true;
       }
@@ -349,7 +349,7 @@ export function useUnreadChannels(
       readAt: string | null | undefined,
       { topLevelOnly = false }: { topLevelOnly?: boolean } = {},
     ) => {
-      if (channelId in forcedUnreadRef.current) {
+      if (Object.hasOwn(forcedUnreadRef.current, channelId)) {
         delete forcedUnreadRef.current[channelId];
         if (pubkey) {
           forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
@@ -385,7 +385,7 @@ export function useUnreadChannels(
   // NIP-RS markers are monotonic, so we do not publish a lower timestamp.
   const markChannelUnread = React.useCallback(
     (channelId: string) => {
-      if (!(channelId in forcedUnreadRef.current)) {
+      if (!Object.hasOwn(forcedUnreadRef.current, channelId)) {
         forcedUnreadRef.current[channelId] = getOwnTimestamp(channelId);
         if (pubkey) {
           forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
@@ -848,7 +848,7 @@ export function useUnreadChannels(
       for (const channel of channels) {
         if (channel.id === activeChannelId) continue;
 
-        if (channel.id in forcedUnreadRef.current) {
+        if (Object.hasOwn(forcedUnreadRef.current, channel.id)) {
           // Forced-unread is dot tier only — not high-priority.
           unread.add(channel.id);
           counts.set(channel.id, 1);

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -17,7 +17,10 @@ import {
 } from "@/features/channels/unreadChannelCounts";
 import { useReadState } from "@/features/channels/readState/useReadState";
 import { makeRootIdStore } from "@/features/channels/unreadRootIdStore";
-import { forcedUnreadStore } from "@/features/channels/forcedUnreadStore";
+import {
+  forcedUnreadStore,
+  type ForcedUnreadMap,
+} from "@/features/channels/forcedUnreadStore";
 import {
   getThreadReference,
   isBroadcastReply,
@@ -230,11 +233,13 @@ export function useUnreadChannels(
 
   // Channels manually marked unread this session (e.g., right-click → "mark
   // unread"). Because NIP-RS read markers are monotonic, this flag is what
-  // makes the badge appear without lowering synced read state. Persisted to
-  // localStorage (buzz-forced-unread.v1) so it survives reload and is visible
-  // to the rail observer for inactive workspaces.
-  const forcedUnreadRef = React.useRef(
-    pubkey ? forcedUnreadStore.read(pubkey) : new Set<string>(),
+  // makes the badge appear without lowering synced read state. Each entry
+  // stores the channel's NIP-RS read marker (unix seconds) at force-time, or
+  // null if no marker existed yet. Persisted to localStorage
+  // (buzz-forced-unread.v1) so it survives reload and is visible to the rail
+  // observer for inactive workspaces.
+  const forcedUnreadRef = React.useRef<ForcedUnreadMap>(
+    pubkey ? forcedUnreadStore.read(pubkey) : {},
   );
 
   // When a synced event advances a read marker (cross-device mark-as-read),
@@ -244,7 +249,8 @@ export function useUnreadChannels(
     const advanced = drainSyncedAdvances();
     let anyNew = false;
     for (const channelId of advanced) {
-      if (forcedUnreadRef.current.delete(channelId)) {
+      if (channelId in forcedUnreadRef.current) {
+        delete forcedUnreadRef.current[channelId];
         anyNew = true;
       }
     }
@@ -308,11 +314,9 @@ export function useUnreadChannels(
   React.useEffect(() => {
     latestByChannelRef.current = new Map();
     observedUnreadEventsByChannelRef.current = new Map();
-    // Load persisted forced-unread set for the new pubkey (do NOT clear the
+    // Load persisted forced-unread map for the new pubkey (do NOT clear the
     // store — another device's data should survive identity switches here).
-    forcedUnreadRef.current = pubkey
-      ? forcedUnreadStore.read(pubkey)
-      : new Set();
+    forcedUnreadRef.current = pubkey ? forcedUnreadStore.read(pubkey) : {};
     caughtUpChannelsRef.current = new Set();
     participatedRootIdsRef.current = pubkey
       ? participationStore.read(pubkey)
@@ -345,7 +349,8 @@ export function useUnreadChannels(
       readAt: string | null | undefined,
       { topLevelOnly = false }: { topLevelOnly?: boolean } = {},
     ) => {
-      if (forcedUnreadRef.current.delete(channelId)) {
+      if (channelId in forcedUnreadRef.current) {
+        delete forcedUnreadRef.current[channelId];
         if (pubkey) {
           forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
         }
@@ -375,20 +380,20 @@ export function useUnreadChannels(
   );
 
   // Manually mark a channel unread (e.g., right-click → "mark unread"). Persists
-  // the flag to localStorage (buzz-forced-unread.v1) so it survives reload and
-  // is visible to the rail observer for inactive workspaces. NIP-RS markers are
-  // monotonic, so we do not publish a lower timestamp.
+  // the current NIP-RS read marker as baseline to localStorage so the rail
+  // observer can detect when a cross-device read has since covered the force.
+  // NIP-RS markers are monotonic, so we do not publish a lower timestamp.
   const markChannelUnread = React.useCallback(
     (channelId: string) => {
-      if (!forcedUnreadRef.current.has(channelId)) {
-        forcedUnreadRef.current.add(channelId);
+      if (!(channelId in forcedUnreadRef.current)) {
+        forcedUnreadRef.current[channelId] = getOwnTimestamp(channelId);
         if (pubkey) {
           forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
         }
         bumpLatestVersion();
       }
     },
-    [pubkey],
+    [getOwnTimestamp, pubkey],
   );
 
   // Record the thread root of an EXTERNAL message that @-mentioned the user.
@@ -843,7 +848,7 @@ export function useUnreadChannels(
       for (const channel of channels) {
         if (channel.id === activeChannelId) continue;
 
-        if (forcedUnreadRef.current.has(channel.id)) {
+        if (channel.id in forcedUnreadRef.current) {
           // Forced-unread is dot tier only — not high-priority.
           unread.add(channel.id);
           counts.set(channel.id, 1);
@@ -952,7 +957,7 @@ export function useUnreadChannels(
 
   const markAllChannelsRead = React.useCallback(() => {
     for (const channelId of unreadChannelIdsRef.current) {
-      forcedUnreadRef.current.delete(channelId);
+      delete forcedUnreadRef.current[channelId];
       const unixSeconds =
         latestByChannelRef.current.get(channelId) ??
         getEffectiveTimestamp(channelId) ??

--- a/desktop/src/features/workspaces/workspaceUnreadObserver.test.mjs
+++ b/desktop/src/features/workspaces/workspaceUnreadObserver.test.mjs
@@ -640,3 +640,178 @@ test("fetchWorkspaceUnread threaded reply whose root is in mutedRootIds → hasU
 
   assert.deepEqual(result, { hasUnread: false, mentionCount: 0 });
 });
+
+// ── Forced-unread persistence gate tests ─────────────────────────────────
+
+// A relay that serves one channel (CHANNEL_ID) as a member channel,
+// with no read state and no incoming events.
+function quietRelay() {
+  return relayFor([
+    // 1. member events
+    () => [
+      event({
+        tags: [
+          ["d", CHANNEL_ID],
+          ["p", PUBKEY],
+        ],
+      }),
+    ],
+    // 2. metadata events (parallel with visibility)
+    () => [
+      event({
+        tags: [
+          ["d", CHANNEL_ID],
+          ["t", "stream"],
+        ],
+      }),
+    ],
+    // 3. visibility events
+    () => [],
+    // 4. read-state events (parallel with mutes)
+    () => [],
+    // 5. mutes events
+    () => [],
+    // 6. unread events — none
+    () => [],
+    // 7. mention events — none
+    () => [],
+  ]);
+}
+
+test("fetchWorkspaceUnread forced-unread channel lights rail dot (hasUnread:true)", async () => {
+  const relay = quietRelay();
+
+  const result = await fetchWorkspaceUnread({
+    client: relay,
+    pubkey: PUBKEY,
+    nowSeconds: 100,
+    decryptReadState: async (v) => v,
+    decryptMutes: async (v) => v,
+    readThreadRelationships: readRelationships(),
+    // Forced-unread set contains CHANNEL_ID
+    readForcedUnread: () => new Set([CHANNEL_ID]),
+  });
+
+  assert.deepEqual(result, { hasUnread: true, mentionCount: 0 });
+});
+
+test("fetchWorkspaceUnread forced-unread channel not in member list → hasUnread:false", async () => {
+  // The channel is marked forced-unread but the user is not a member of ANY
+  // channel — forced-unread is not consulted when the channel set is empty.
+  const relay = relayFor([
+    // 1. member events — empty
+    () => [],
+  ]);
+
+  const result = await fetchWorkspaceUnread({
+    client: relay,
+    pubkey: PUBKEY,
+    nowSeconds: 100,
+    decryptReadState: async (v) => v,
+    decryptMutes: async (v) => v,
+    readThreadRelationships: readRelationships(),
+    readForcedUnread: () => new Set([CHANNEL_ID]),
+  });
+
+  assert.deepEqual(result, { hasUnread: false, mentionCount: 0 });
+});
+
+test("fetchWorkspaceUnread forced-unread channel that is also muted → hasUnread:false", async () => {
+  const relay = relayFor([
+    // 1. member events
+    () => [
+      event({
+        tags: [
+          ["d", CHANNEL_ID],
+          ["p", PUBKEY],
+        ],
+      }),
+    ],
+    // 2. metadata
+    () => [
+      event({
+        tags: [
+          ["d", CHANNEL_ID],
+          ["t", "stream"],
+        ],
+      }),
+    ],
+    // 3. visibility
+    () => [],
+    // 4. read-state (parallel with mutes)
+    () => [],
+    // 5. mutes — CHANNEL_ID is muted
+    () => [
+      event({
+        pubkey: PUBKEY,
+        content: mutesContent([CHANNEL_ID]),
+      }),
+    ],
+    // No per-channel fetches expected — muted channel is skipped
+  ]);
+
+  const result = await fetchWorkspaceUnread({
+    client: relay,
+    pubkey: PUBKEY,
+    nowSeconds: 100,
+    decryptReadState: async (v) => v,
+    decryptMutes: async (v) => v,
+    readThreadRelationships: readRelationships(),
+    // CHANNEL_ID is both forced-unread AND muted — mute wins
+    readForcedUnread: () => new Set([CHANNEL_ID]),
+  });
+
+  assert.deepEqual(result, { hasUnread: false, mentionCount: 0 });
+});
+
+test("fetchWorkspaceUnread readForcedUnread returns empty set → falls through to relay gate", async () => {
+  // No forced-unread, but there IS a real unread event → hasUnread:true via relay
+  const relay = relayFor([
+    // 1. member events
+    () => [
+      event({
+        tags: [
+          ["d", CHANNEL_ID],
+          ["p", PUBKEY],
+        ],
+      }),
+    ],
+    // 2. metadata
+    () => [
+      event({
+        tags: [
+          ["d", CHANNEL_ID],
+          ["t", "stream"],
+        ],
+      }),
+    ],
+    // 3. visibility
+    () => [],
+    // 4. read-state
+    () => [],
+    // 5. mutes
+    () => [],
+    // 6. unread events
+    () => [
+      event({
+        id: "real-unread".padEnd(64, "0"),
+        created_at: 20,
+        tags: [["h", CHANNEL_ID]],
+      }),
+    ],
+    // 7. mention events
+    () => [],
+  ]);
+
+  const result = await fetchWorkspaceUnread({
+    client: relay,
+    pubkey: PUBKEY,
+    nowSeconds: 100,
+    decryptReadState: async (v) => v,
+    decryptMutes: async (v) => v,
+    readThreadRelationships: readRelationships(),
+    readForcedUnread: () => new Set(), // empty — no forced-unread
+  });
+
+  assert.deepEqual(result, { hasUnread: true, mentionCount: 0 });
+});

--- a/desktop/src/features/workspaces/workspaceUnreadObserver.test.mjs
+++ b/desktop/src/features/workspaces/workspaceUnreadObserver.test.mjs
@@ -678,6 +678,55 @@ function quietRelay() {
   ]);
 }
 
+// A relay that serves one channel (CHANNEL_ID) with a synced read marker at
+// the given unix-second timestamp and no new incoming events.
+function quietRelayWithReadState(readAtSeconds) {
+  return relayFor([
+    // 1. member events
+    () => [
+      event({
+        tags: [
+          ["d", CHANNEL_ID],
+          ["p", PUBKEY],
+        ],
+      }),
+    ],
+    // 2. metadata events (parallel with visibility)
+    () => [
+      event({
+        tags: [
+          ["d", CHANNEL_ID],
+          ["t", "stream"],
+        ],
+      }),
+    ],
+    // 3. visibility events
+    () => [],
+    // 4. read-state events (parallel with mutes)
+    () => [
+      event({
+        pubkey: PUBKEY,
+        created_at: 200,
+        tags: [
+          ["d", "read-state:test"],
+          ["t", "read-state"],
+        ],
+        content: JSON.stringify({
+          v: 1,
+          client_id: "client",
+          contexts: { [CHANNEL_ID]: readAtSeconds },
+        }),
+      }),
+    ],
+    // 5. mutes events
+    () => [],
+    // 6. unread events — none (marker covers everything)
+    () => [],
+    // 7. mention events — none
+    () => [],
+  ]);
+}
+
 test("fetchWorkspaceUnread forced-unread channel lights rail dot (hasUnread:true)", async () => {
   const relay = quietRelay();
 
@@ -688,8 +737,8 @@ test("fetchWorkspaceUnread forced-unread channel lights rail dot (hasUnread:true
     decryptReadState: async (v) => v,
     decryptMutes: async (v) => v,
     readThreadRelationships: readRelationships(),
-    // Forced-unread set contains CHANNEL_ID
-    readForcedUnread: () => new Set([CHANNEL_ID]),
+    // Forced-unread map: CHANNEL_ID forced when marker was null (no prior read)
+    readForcedUnread: () => ({ [CHANNEL_ID]: null }),
   });
 
   assert.deepEqual(result, { hasUnread: true, mentionCount: 0 });
@@ -710,7 +759,7 @@ test("fetchWorkspaceUnread forced-unread channel not in member list → hasUnrea
     decryptReadState: async (v) => v,
     decryptMutes: async (v) => v,
     readThreadRelationships: readRelationships(),
-    readForcedUnread: () => new Set([CHANNEL_ID]),
+    readForcedUnread: () => ({ [CHANNEL_ID]: null }),
   });
 
   assert.deepEqual(result, { hasUnread: false, mentionCount: 0 });
@@ -758,13 +807,13 @@ test("fetchWorkspaceUnread forced-unread channel that is also muted → hasUnrea
     decryptMutes: async (v) => v,
     readThreadRelationships: readRelationships(),
     // CHANNEL_ID is both forced-unread AND muted — mute wins
-    readForcedUnread: () => new Set([CHANNEL_ID]),
+    readForcedUnread: () => ({ [CHANNEL_ID]: null }),
   });
 
   assert.deepEqual(result, { hasUnread: false, mentionCount: 0 });
 });
 
-test("fetchWorkspaceUnread readForcedUnread returns empty set → falls through to relay gate", async () => {
+test("fetchWorkspaceUnread readForcedUnread returns empty map → falls through to relay gate", async () => {
   // No forced-unread, but there IS a real unread event → hasUnread:true via relay
   const relay = relayFor([
     // 1. member events
@@ -810,8 +859,63 @@ test("fetchWorkspaceUnread readForcedUnread returns empty set → falls through 
     decryptReadState: async (v) => v,
     decryptMutes: async (v) => v,
     readThreadRelationships: readRelationships(),
-    readForcedUnread: () => new Set(), // empty — no forced-unread
+    readForcedUnread: () => ({}), // empty — no forced-unread
   });
 
   assert.deepEqual(result, { hasUnread: true, mentionCount: 0 });
+});
+
+test("fetchWorkspaceUnread forced-unread + synced marker advanced PAST baseline → hasUnread:false", async () => {
+  // markerAtWhenForced = 50, observed readAt = 100 (100 > 50 → cross-device read wins)
+  const relay = quietRelayWithReadState(100);
+
+  const result = await fetchWorkspaceUnread({
+    client: relay,
+    pubkey: PUBKEY,
+    nowSeconds: 200,
+    decryptReadState: async (v) => v,
+    decryptMutes: async (v) => v,
+    readThreadRelationships: readRelationships(),
+    // Forced at marker=50; synced marker is now 100 — covers the force
+    readForcedUnread: () => ({ [CHANNEL_ID]: 50 }),
+  });
+
+  assert.deepEqual(result, { hasUnread: false, mentionCount: 0 });
+});
+
+test("fetchWorkspaceUnread forced-unread + synced marker NOT advanced past baseline → hasUnread:true", async () => {
+  // markerAtWhenForced = 100, observed readAt = 100 (equal → force still stands)
+  const relay = quietRelayWithReadState(100);
+
+  const result = await fetchWorkspaceUnread({
+    client: relay,
+    pubkey: PUBKEY,
+    nowSeconds: 200,
+    decryptReadState: async (v) => v,
+    decryptMutes: async (v) => v,
+    readThreadRelationships: readRelationships(),
+    // Forced at marker=100; synced marker is still 100 — no newer read
+    readForcedUnread: () => ({ [CHANNEL_ID]: 100 }),
+  });
+
+  assert.deepEqual(result, { hasUnread: true, mentionCount: 0 });
+});
+
+test("fetchWorkspaceUnread forced-unread with null baseline + synced marker present → hasUnread:false", async () => {
+  // markerAtWhenForced = null (no marker at force-time), but readAt = 50 now
+  // A cross-device read appeared after the force → do NOT light the dot
+  const relay = quietRelayWithReadState(50);
+
+  const result = await fetchWorkspaceUnread({
+    client: relay,
+    pubkey: PUBKEY,
+    nowSeconds: 200,
+    decryptReadState: async (v) => v,
+    decryptMutes: async (v) => v,
+    readThreadRelationships: readRelationships(),
+    // Forced when no marker existed; a cross-device read has since appeared
+    readForcedUnread: () => ({ [CHANNEL_ID]: null }),
+  });
+
+  assert.deepEqual(result, { hasUnread: false, mentionCount: 0 });
 });

--- a/desktop/src/features/workspaces/workspaceUnreadObserver.ts
+++ b/desktop/src/features/workspaces/workspaceUnreadObserver.ts
@@ -237,7 +237,7 @@ export async function fetchWorkspaceUnread(args: {
     // read has covered the channel (the drain path in useUnreadChannels only
     // runs while the workspace is active, so the store may not be pruned for
     // inactive workspaces).
-    if (!hasUnread && channel.id in forcedUnreadMap) {
+    if (!hasUnread && Object.hasOwn(forcedUnreadMap, channel.id)) {
       const markerAtWhenForced = forcedUnreadMap[channel.id];
       if (
         readAt === null ||

--- a/desktop/src/features/workspaces/workspaceUnreadObserver.ts
+++ b/desktop/src/features/workspaces/workspaceUnreadObserver.ts
@@ -1,4 +1,5 @@
 import { makeRootIdStore } from "@/features/channels/unreadRootIdStore";
+import { forcedUnreadStore } from "@/features/channels/forcedUnreadStore";
 import { DM_NOTIFIABLE_EVENT_KINDS } from "@/features/channels/isDmNotifiableKind";
 import { mergeReadStateEvents } from "@/features/channels/readState/readStateSnapshot";
 import {
@@ -155,6 +156,7 @@ export async function fetchWorkspaceUnread(args: {
   decryptReadState?: (ciphertext: string) => Promise<string>;
   decryptMutes?: (ciphertext: string) => Promise<string>;
   readThreadRelationships?: (pubkey: string) => ThreadRelationships;
+  readForcedUnread?: (pubkey: string) => ReadonlySet<string>;
 }): Promise<WorkspaceUnreadObserverResult> {
   const { client, pubkey } = args;
   const normalizedPubkey = pubkey.toLowerCase();
@@ -162,6 +164,8 @@ export async function fetchWorkspaceUnread(args: {
   const decryptMutes = args.decryptMutes ?? nip44DecryptFromSelf;
   const readRelationships =
     args.readThreadRelationships ?? defaultReadThreadRelationships;
+  const readForcedUnread =
+    args.readForcedUnread ?? ((pk) => forcedUnreadStore.read(pk));
 
   const channels = await fetchObservedChannels(client, pubkey);
   if (channels.length === 0) {
@@ -210,11 +214,23 @@ export async function fetchWorkspaceUnread(args: {
     mutedRootIds,
   } = readRelationships(normalizedPubkey);
 
+  // Channels manually marked unread on this device. Since forced-unread is
+  // already drained when markChannelRead is called (channel-open) and by
+  // drainSyncedAdvances (cross-device read), the stored set is trustworthy
+  // as-is. We simply OR it into hasUnread — no additional relay fetch needed.
+  const forcedUnreadChannelIds = readForcedUnread(normalizedPubkey);
+
   let hasUnread = false;
   let mentionCount = 0;
 
   for (const channel of channels) {
     if (mutedIds.has(channel.id)) continue;
+
+    // Forced-unread channels light the dot without a relay fetch.
+    if (!hasUnread && forcedUnreadChannelIds.has(channel.id)) {
+      hasUnread = true;
+    }
+
     const readAt = readState.get(channel.id) ?? null;
     const since = readAt === null ? 0 : readAt + 1;
     const kinds = unreadKindsForChannel(channel.channelType);

--- a/desktop/src/features/workspaces/workspaceUnreadObserver.ts
+++ b/desktop/src/features/workspaces/workspaceUnreadObserver.ts
@@ -1,5 +1,8 @@
 import { makeRootIdStore } from "@/features/channels/unreadRootIdStore";
-import { forcedUnreadStore } from "@/features/channels/forcedUnreadStore";
+import {
+  forcedUnreadStore,
+  type ForcedUnreadMap,
+} from "@/features/channels/forcedUnreadStore";
 import { DM_NOTIFIABLE_EVENT_KINDS } from "@/features/channels/isDmNotifiableKind";
 import { mergeReadStateEvents } from "@/features/channels/readState/readStateSnapshot";
 import {
@@ -156,7 +159,7 @@ export async function fetchWorkspaceUnread(args: {
   decryptReadState?: (ciphertext: string) => Promise<string>;
   decryptMutes?: (ciphertext: string) => Promise<string>;
   readThreadRelationships?: (pubkey: string) => ThreadRelationships;
-  readForcedUnread?: (pubkey: string) => ReadonlySet<string>;
+  readForcedUnread?: (pubkey: string) => ForcedUnreadMap;
 }): Promise<WorkspaceUnreadObserverResult> {
   const { client, pubkey } = args;
   const normalizedPubkey = pubkey.toLowerCase();
@@ -214,11 +217,10 @@ export async function fetchWorkspaceUnread(args: {
     mutedRootIds,
   } = readRelationships(normalizedPubkey);
 
-  // Channels manually marked unread on this device. Since forced-unread is
-  // already drained when markChannelRead is called (channel-open) and by
-  // drainSyncedAdvances (cross-device read), the stored set is trustworthy
-  // as-is. We simply OR it into hasUnread — no additional relay fetch needed.
-  const forcedUnreadChannelIds = readForcedUnread(normalizedPubkey);
+  // Channels manually marked unread on this device. Stored as a record of
+  // { channelId: markerAtWhenForced } so the observer can gate the dot on
+  // whether a cross-device read has since advanced past the stored baseline.
+  const forcedUnreadMap = readForcedUnread(normalizedPubkey);
 
   let hasUnread = false;
   let mentionCount = 0;
@@ -226,12 +228,25 @@ export async function fetchWorkspaceUnread(args: {
   for (const channel of channels) {
     if (mutedIds.has(channel.id)) continue;
 
-    // Forced-unread channels light the dot without a relay fetch.
-    if (!hasUnread && forcedUnreadChannelIds.has(channel.id)) {
-      hasUnread = true;
+    // Compute readAt first so the forced-unread gate can compare against it.
+    const readAt = readState.get(channel.id) ?? null;
+
+    // Forced-unread lights the dot without a relay fetch, but only if the
+    // synced read marker has NOT advanced past the stored baseline. This
+    // prevents stale forced-unread from lighting the rail after a cross-device
+    // read has covered the channel (the drain path in useUnreadChannels only
+    // runs while the workspace is active, so the store may not be pruned for
+    // inactive workspaces).
+    if (!hasUnread && channel.id in forcedUnreadMap) {
+      const markerAtWhenForced = forcedUnreadMap[channel.id];
+      if (
+        readAt === null ||
+        (markerAtWhenForced !== null && readAt <= markerAtWhenForced)
+      ) {
+        hasUnread = true;
+      }
     }
 
-    const readAt = readState.get(channel.id) ?? null;
     const since = readAt === null ? 0 : readAt + 1;
     const kinds = unreadKindsForChannel(channel.channelType);
 

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "paths": {


### PR DESCRIPTION
## What

Two independent rail-unread fixes:

### Fix 1: Clear URL on workspace switch (A→B→A→B badge vanishes)

The router is a module singleton ( outside any React component), so switching workspaces did not reset . `ChannelScreen`'s read effect kept firing `markChannelRead({ topLevelOnly: true })` for the previous workspace's channel — advancing its NIP-RS read markers via a 5s debounce publish. The next 30s rail poll saw the advanced markers and returned `hasUnread:false`, dropping A's badge after A→B→A→B.

**Fix:** wrap all three `onSwitchWorkspace` call sites in a memoized `handleSwitchWorkspace` that calls `goHome()` first, clearing the URL before the workspace teardown. `ChannelScreen` unmounts cleanly, no spurious marker advance.

### Fix 2: Persist mark-as-unread to localStorage + show in rail

`markChannelUnread` (right-click → Mark as Unread) wrote only to an in-memory `React.useRef` flag — cleared on reload, invisible to the rail observer which reads only NIP-RS relay state.

**Fix:** introduce `forcedUnreadStore` — a per-pubkey localStorage store using the existing `makeRootIdStore` pattern. Three write-through clear points mirror the existing in-memory semantics: channel-open, identity change, and cross-device synced read advance. The rail observer reads the store and ORs matching channels into `hasUnread` (muted channels still win).

NIP-RS markers are monotonic and cannot represent a retrograde unread state, so localStorage is the honest best-effort for per-device persistence. No relay sync.

## Tests

- 4 new observer tests: forced-unread lights dot, non-member ignored, muted channel wins, empty-set falls through to relay gate
- Existing 19 observer tests continue to pass (2496 total)

## Gates

- `just desktop-typecheck` ✅
- `just desktop-build` ✅  
- `just desktop-check` ✅ (2 pre-existing warnings, 0 errors)
- `just desktop-test` ✅ 2496 pass, 0 fail