### PR TITLE
[codex] Add view activity label to agent popover

### DIFF
--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -255,6 +255,9 @@ export function BotActivityComposerAction({
                   size="sm"
                 />
                 <span className="min-w-0 flex-1 truncate">{agent.name}</span>
+                <span className="shrink-0 whitespace-nowrap text-xs font-medium opacity-80">
+                  View activity
+                </span>
                 <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />
               </button>
             );

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1077,15 +1077,16 @@ test("shows and clears activity indicators for active channel agents", async ({
   }, TEST_IDENTITIES.alice.pubkey);
 
   await expect(page.getByTestId("bot-activity-composer-trigger")).toBeVisible();
-  await page.getByTestId("bot-activity-composer-trigger").click();
   await expect(
-    page.getByTestId(
-      `bot-activity-composer-item-${TEST_IDENTITIES.alice.pubkey}`,
-    ),
-  ).toBeVisible();
-  await page
-    .getByTestId(`bot-activity-composer-item-${TEST_IDENTITIES.alice.pubkey}`)
-    .click({ force: true });
+    page.getByTestId("bot-activity-composer-trigger"),
+  ).not.toContainText("View activity");
+  await page.getByTestId("bot-activity-composer-trigger").click();
+  const aliceActivityItem = page.getByTestId(
+    `bot-activity-composer-item-${TEST_IDENTITIES.alice.pubkey}`,
+  );
+  await expect(aliceActivityItem).toBeVisible();
+  await expect(aliceActivityItem).toContainText("View activity");
+  await aliceActivityItem.click({ force: true });
   await expect(page.getByTestId("agent-session-thread-panel")).toBeVisible();
   await expect(page.getByTestId("agent-session-thread-panel")).toContainText(
     "alice",


### PR DESCRIPTION
Make it more discoverable for the user to find agent acitivity in the hover popover by including a “View activity” label

![Corrected hover popover](https://sprout.up.railway.app/media/e882b037dbe964d523027b4479dcf0f35e0b61628be531db754325281c496e35.png)
