### PR TITLE
fix(dev): install Lefthook hooks into shared .git/hooks dir

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -43,9 +43,16 @@ bootstrap:
 setup: bootstrap
     ./scripts/dev-setup.sh
 
-# Install git hooks via lefthook
+# Install git hooks via lefthook (dispatches from the shared .git/hooks dir so all
+# linked worktrees inherit the same hooks without a worktree-relative .hooks path)
 hooks:
-    git config --local core.hooksPath .hooks
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # --path-format=absolute guarantees an absolute path from every invocation context:
+    # without it, --git-common-dir returns ".git" from the main checkout and a
+    # relative hooksPath would break linked-worktree dispatch just like .hooks did.
+    HOOKS_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/hooks"
+    git config --local core.hooksPath "$HOOKS_DIR"
     lefthook install --force
 
 # ⚠️  Wipe ALL data and recreate a clean environment

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -169,7 +169,12 @@ fi
 # ---- Install git hooks ------------------------------------------------------
 
 log "Installing git hooks..."
-git config --local core.hooksPath .hooks
+# Install into the shared .git/hooks directory using --path-format=absolute so the
+# stored hooksPath is always an absolute path. Without it, --git-common-dir returns
+# ".git" from the main checkout; a relative hooksPath would silently break
+# linked-worktree dispatch (same failure mode as the old worktree-relative .hooks).
+HOOKS_DIR="$(git -C "${REPO_ROOT}" rev-parse --path-format=absolute --git-common-dir)/hooks"
+git -C "${REPO_ROOT}" config --local core.hooksPath "$HOOKS_DIR"
 lefthook install --force
 success "Git hooks installed"
 


### PR DESCRIPTION
## Problem

`just hooks` and `scripts/dev-setup.sh` set `core.hooksPath` to a worktree-relative `.hooks` directory. That directory no longer exists (removed in a prior Lefthook migration), so Git silently skipped every hook. Linked worktrees compounded the failure: even if `.hooks` existed in the main checkout, a relative `hooksPath` resolves relative to the worktree's working tree root, where no such directory exists. Every agent worktree effectively ran with hooks disabled.

## Fix

Replace the relative `.hooks` path with the absolute shared hooks directory in both setup paths.

The key flag is `--path-format=absolute`: without it, `git rev-parse --git-common-dir` returns `.git` from the main checkout, making the stored path relative again. With it, both the main checkout and any linked worktree produce the same absolute path pointing to the main `.git/hooks` directory.

```bash
HOOKS_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/hooks"
git config --local core.hooksPath "$HOOKS_DIR"
lefthook install --force
```

The global `core.hooksPath=.hooks` in `~/.gitconfig` (managed by shell-configs infrastructure) is intentionally left untouched. The local repo override takes precedence for all worktrees in this repo.

## Validation

**Stored config is absolute from the main checkout:**
```
$ cd /Users/wpfleger/Development/buzz
$ git rev-parse --path-format=absolute --git-common-dir
/Users/wpfleger/Development/buzz/.git

$ bash -c 'HOOKS_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/hooks"; echo "$HOOKS_DIR"'
/Users/wpfleger/Development/buzz/.git/hooks  # starts with /
```

**`just hooks` from linked worktree installs to same absolute path:**
```
$ cd .worktrees/duncan-shared-lefthook-path && just hooks
│  core.hooksPath is set locally to '/Users/wpfleger/Development/buzz/.git/hooks'
│  Installing hooks anyway in '/Users/wpfleger/Development/buzz/.git/hooks'
sync hooks: ✔️(pre-commit, pre-push)
```

**Pre-commit dispatches and all hooks pass from linked worktree (real staged files):**
```
✔️ rust-fmt        (0.95s)
✔️ desktop-tauri-fmt (1.45s)
✔️ web-fix         (2.62s)
✔️ desktop-fix     (3.26s)
✔️ mobile-fix      (4.84s)
```

**`dev-setup.sh` HOOKS_DIR from main checkout (with `REPO_ROOT=/path/to/buzz`):**
```
/Users/wpfleger/Development/buzz/.git/hooks  # absolute, starts with /
```