### PR TITLE
feat(acp): surface channel canvas metadata in agent system context

### DIFF
--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2135,31 +2135,32 @@ async fn fetch_canvas_section(channel_id: Uuid, rest: &RestClient) -> Option<Str
 /// Extracted as a pure function so tests can exercise the parsing/validation
 /// logic without async machinery or relay connectivity.
 ///
-/// Returns `None` on: empty array, blank content, invalid event ID format,
-/// or any missing required field.
+/// Returns `None` on: empty array, blank content, malformed/partial event JSON
+/// (requires a complete, structurally valid Nostr event), or an out-of-range
+/// `created_at` timestamp. Never falls back to epoch or raw integers.
 pub(crate) fn canvas_section_from_query_response(
     events: &[serde_json::Value],
     channel_uuid: &str,
 ) -> Option<String> {
-    let ev = events.first()?;
+    let raw = events.first()?;
 
-    let id = ev.get("id").and_then(|v| v.as_str()).unwrap_or("");
-    let created_at = ev.get("created_at").and_then(|v| v.as_i64()).unwrap_or(0);
-    let content = ev.get("content").and_then(|v| v.as_str()).unwrap_or("");
-
-    // Validate: event ID must be 64 lowercase hex chars.
-    if id.len() != 64 || !id.chars().all(|c| c.is_ascii_hexdigit()) {
-        tracing::warn!(
-            target: "canvas::fetch",
-            channel = %channel_uuid,
-            "canvas event has invalid id {:?} — emitting no section",
-            id
-        );
-        return None;
-    }
+    // Deserialise as a complete Nostr Event. Partial objects (missing pubkey,
+    // sig, kind, or tags) are rejected here rather than trusted implicitly.
+    let event = match serde_json::from_value::<nostr::Event>(raw.clone()) {
+        Ok(ev) => ev,
+        Err(err) => {
+            tracing::warn!(
+                target: "canvas::fetch",
+                channel = %channel_uuid,
+                %err,
+                "canvas query returned a malformed event — emitting no section",
+            );
+            return None;
+        }
+    };
 
     // Blank content means the canvas was cleared; do not fall back to older events.
-    if content.trim().is_empty() {
+    if event.content.trim().is_empty() {
         tracing::debug!(
             target: "canvas::fetch",
             channel = %channel_uuid,
@@ -2168,9 +2169,23 @@ pub(crate) fn canvas_section_from_query_response(
         return None;
     }
 
-    let timestamp = chrono::DateTime::from_timestamp(created_at, 0)
-        .map(|dt| dt.to_rfc3339())
-        .unwrap_or_else(|| format!("{created_at}"));
+    let id = event.id.to_hex();
+
+    // Convert the Nostr timestamp to a UTC RFC3339 string with Z suffix.
+    // If chrono rejects the value (out-of-range), fail open — emit no section.
+    let ts_secs = event.created_at.as_secs() as i64;
+    let timestamp = match chrono::DateTime::from_timestamp(ts_secs, 0) {
+        Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        None => {
+            tracing::warn!(
+                target: "canvas::fetch",
+                channel = %channel_uuid,
+                ts_secs,
+                "canvas event has out-of-range created_at — emitting no section",
+            );
+            return None;
+        }
+    };
 
     tracing::info!(
         target: "canvas::fetch",
@@ -2178,7 +2193,7 @@ pub(crate) fn canvas_section_from_query_response(
         event_id = %id,
         "injected channel canvas metadata section into system prompt"
     );
-    Some(render_canvas_section(id, &timestamp, channel_uuid))
+    Some(render_canvas_section(&id, &timestamp, channel_uuid))
 }
 
 /// Render the `[Channel Canvas]` metadata section string.
@@ -4419,22 +4434,33 @@ mod tests {
 
     // ── canvas_section_from_query_response ───────────────────────────────────
 
-    const VALID_ID: &str = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
     const CHANNEL_UUID: &str = "00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
+
+    /// Build a real, cryptographically signed Nostr event for canvas tests.
+    ///
+    /// `nostr::Event` requires all fields (pubkey, sig, kind, tags, id) to
+    /// deserialise successfully, so we use `EventBuilder` + `Keys` rather than
+    /// a bare `serde_json::json!({...})` object.
+    fn make_canvas_event_value(content: &str) -> serde_json::Value {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(buzz_core::kind::KIND_CANVAS as u16), content)
+            .sign_with_keys(&keys)
+            .expect("sign");
+        serde_json::to_value(&event).expect("serialise")
+    }
 
     #[test]
     fn test_canvas_section_from_query_response_happy_path() {
-        let events = vec![serde_json::json!({
-            "id": VALID_ID,
-            "created_at": 1705312200_i64,
-            "content": "# Team instructions\nBe helpful."
-        })];
-        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+        let ev = make_canvas_event_value("# Team instructions\nBe helpful.");
+        let id = ev["id"].as_str().unwrap().to_string();
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
         let section = result.expect("expected Some");
-        assert!(section.contains(VALID_ID));
+        assert!(section.contains(&id), "section must contain the event id");
         assert!(section.contains("buzz canvas get --channel"));
         assert!(section.contains(CHANNEL_UUID));
         assert!(section.starts_with("[Channel Canvas]"));
+        // Timestamp must use Z suffix, not +00:00
+        assert!(section.contains('Z'), "timestamp must use Z suffix");
     }
 
     #[test]
@@ -4445,12 +4471,8 @@ mod tests {
 
     #[test]
     fn test_canvas_section_from_query_response_blank_content_returns_none() {
-        let events = vec![serde_json::json!({
-            "id": VALID_ID,
-            "created_at": 1705312200_i64,
-            "content": "   "
-        })];
-        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+        let ev = make_canvas_event_value("   ");
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
         assert!(
             result.is_none(),
             "blank content must return None (cleared canvas)"
@@ -4459,58 +4481,86 @@ mod tests {
 
     #[test]
     fn test_canvas_section_from_query_response_empty_content_returns_none() {
-        let events = vec![serde_json::json!({
-            "id": VALID_ID,
+        let ev = make_canvas_event_value("");
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
+        assert!(result.is_none());
+    }
+
+    /// A bare JSON object with a plausible-looking id but missing pubkey/sig/kind/tags
+    /// must be rejected — not silently accepted with partial metadata.
+    #[test]
+    fn test_canvas_section_from_query_response_partial_object_returns_none() {
+        let partial = serde_json::json!({
+            "id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
             "created_at": 1705312200_i64,
-            "content": ""
-        })];
-        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+            "content": "some instructions"
+        });
+        let result = canvas_section_from_query_response(&[partial], CHANNEL_UUID);
+        assert!(
+            result.is_none(),
+            "partial event object (missing pubkey/sig/kind/tags) must return None"
+        );
+    }
+
+    /// A JSON object that looks like an event but has `created_at` as a string
+    /// must be rejected — the nostr::Event parser enforces integer type.
+    #[test]
+    fn test_canvas_section_from_query_response_string_timestamp_returns_none() {
+        let keys = Keys::generate();
+        let mut ev = serde_json::to_value(
+            EventBuilder::new(Kind::Custom(buzz_core::kind::KIND_CANVAS as u16), "content")
+                .sign_with_keys(&keys)
+                .expect("sign"),
+        )
+        .expect("serialise");
+        // Corrupt created_at to a string value.
+        ev["created_at"] = serde_json::Value::String("2026-03-15T16:30:00+00:00".into());
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
+        assert!(
+            result.is_none(),
+            "string created_at must be rejected by nostr::Event deserialiser"
+        );
+    }
+
+    /// A JSON object that looks like an event but is missing `created_at`
+    /// must be rejected — nostr::Event requires the field.
+    #[test]
+    fn test_canvas_section_from_query_response_missing_timestamp_returns_none() {
+        let keys = Keys::generate();
+        let mut ev = serde_json::to_value(
+            EventBuilder::new(Kind::Custom(buzz_core::kind::KIND_CANVAS as u16), "content")
+                .sign_with_keys(&keys)
+                .expect("sign"),
+        )
+        .expect("serialise");
+        ev.as_object_mut().unwrap().remove("created_at");
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
+        assert!(
+            result.is_none(),
+            "missing created_at must be rejected by nostr::Event deserialiser"
+        );
+    }
+
+    #[test]
+    fn test_canvas_section_from_query_response_non_array_object_returns_none() {
+        // Passing a single JSON object (not wrapped in a Vec) exercises the
+        // empty-array fast-path because serde_json::Value::Array is never matched.
+        let result = canvas_section_from_query_response(&[], CHANNEL_UUID);
         assert!(result.is_none());
     }
 
     #[test]
-    fn test_canvas_section_from_query_response_invalid_id_short_returns_none() {
-        let events = vec![serde_json::json!({
-            "id": "abc123",
-            "created_at": 1705312200_i64,
-            "content": "some instructions"
-        })];
-        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
-        assert!(result.is_none(), "short id must return None");
-    }
-
-    #[test]
-    fn test_canvas_section_from_query_response_invalid_id_non_hex_returns_none() {
-        let events = vec![serde_json::json!({
-            "id": "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
-            "created_at": 1705312200_i64,
-            "content": "some instructions"
-        })];
-        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
-        assert!(result.is_none(), "non-hex id must return None");
-    }
-
-    #[test]
-    fn test_canvas_section_from_query_response_missing_id_returns_none() {
-        let events = vec![serde_json::json!({
-            "created_at": 1705312200_i64,
-            "content": "some instructions"
-        })];
-        // id defaults to "" which fails the 64-char check
-        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_canvas_section_from_query_response_zero_timestamp_uses_epoch() {
-        let events = vec![serde_json::json!({
-            "id": VALID_ID,
-            "created_at": 0_i64,
-            "content": "some instructions"
-        })];
-        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
-        let section = result.expect("epoch timestamp is valid");
-        // The epoch renders as a valid RFC3339 string, not a fallback integer.
-        assert!(section.contains("1970-01-01") || section.contains("0"));
+    fn test_canvas_section_from_query_response_timestamp_uses_z_suffix() {
+        let ev = make_canvas_event_value("instructions");
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
+        let section = result.expect("valid event must produce a section");
+        assert!(
+            section.contains('Z'),
+            "RFC3339 timestamp must use Z suffix, not +00:00"
+        );
+        assert!(
+            !section.contains("+00:00"),
+            "timestamp must not use +00:00 offset"
+        );
     }
 }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1193,24 +1193,30 @@ pub async fn run_prompt_task(
     // never for heartbeats, cached until session invalidation.
     //
     // DM check: use startup channel_info first; lazy-fetch only when missing.
-    // A confirmed DM never receives a canvas section.
+    // A confirmed DM never receives a canvas section. If the channel type cannot
+    // be determined (metadata absent and lazy fetch fails/unknown), skip the canvas
+    // rather than assuming non-DM — failing closed on DM ambiguity is safer.
     //
-    // Failure modes all fail open: no event, blank content, malformed response,
-    // REST error, or timeout each produce `None` and never block session creation.
+    // I3 lifecycle: hold the fetched section in a local `pending_canvas` and
+    // commit it to `canvas_sections` only after session creation succeeds. This
+    // prevents a stale revision A surviving a failed create and being re-used by
+    // the next attempt after the canvas was cleared.
+    let mut pending_canvas: Option<(Uuid, String)> = None;
     if let PromptSource::Channel(cid) = &source {
         let is_new_channel_session = !agent.state.sessions.contains_key(cid);
         if is_new_channel_session && !agent.state.canvas_sections.contains_key(cid) {
             // Resolve DM status: prefer the startup cache, lazy-fetch as fallback.
+            // Unknown → treat as DM (fail-closed).
             let is_dm = match ctx.channel_info.get(cid) {
                 Some(ci) => ci.channel_type == "dm",
                 None => fetch_channel_info(*cid, &ctx.rest_client)
                     .await
                     .map(|ci| ci.channel_type == "dm")
-                    .unwrap_or(false),
+                    .unwrap_or(true),
             };
             if !is_dm {
                 if let Some(section) = fetch_canvas_section(*cid, &ctx.rest_client).await {
-                    agent.state.canvas_sections.insert(*cid, section);
+                    pending_canvas = Some((*cid, section));
                 }
             }
         }
@@ -1224,8 +1230,14 @@ pub async fn run_prompt_task(
     };
 
     // The canvas metadata section — channel-scoped, absent for heartbeats/DMs.
+    // Prefer the committed cache; fall back to pending (for new sessions being created now).
     let agent_canvas: Option<String> = match &source {
-        PromptSource::Channel(cid) => agent.state.canvas_sections.get(cid).cloned(),
+        PromptSource::Channel(cid) => agent
+            .state
+            .canvas_sections
+            .get(cid)
+            .cloned()
+            .or_else(|| pending_canvas.as_ref().map(|(_, s)| s.clone())),
         PromptSource::Heartbeat => None,
     };
 
@@ -1249,6 +1261,10 @@ pub async fn run_prompt_task(
                             "created session {sid} for channel {cid}"
                         );
                         agent.state.sessions.insert(*cid, sid.clone());
+                        // Commit canvas only after session creation succeeds (I3).
+                        if let Some((pending_cid, section)) = pending_canvas.take() {
+                            agent.state.canvas_sections.insert(pending_cid, section);
+                        }
                         (sid, true)
                     }
                     Err(AcpError::AgentExited) => {
@@ -1263,6 +1279,8 @@ pub async fn run_prompt_task(
                         return;
                     }
                     Err(e) => {
+                        // Session creation failed; pending canvas was never committed,
+                        // so the next retry will re-fetch a fresh revision.
                         send_prompt_result(
                             &result_tx,
                             agent,
@@ -2159,6 +2177,45 @@ pub(crate) fn canvas_section_from_query_response(
         }
     };
 
+    // Verify the event's id and signature agree with its content.
+    // A structurally complete but tampered event must not supply trusted metadata.
+    if let Err(err) = event.verify() {
+        tracing::warn!(
+            target: "canvas::fetch",
+            channel = %channel_uuid,
+            %err,
+            "canvas event failed signature verification — emitting no section",
+        );
+        return None;
+    }
+
+    // Validate kind: must be KIND_CANVAS (40100).
+    if event.kind != nostr::Kind::Custom(buzz_core::kind::KIND_CANVAS as u16) {
+        tracing::warn!(
+            target: "canvas::fetch",
+            channel = %channel_uuid,
+            kind = %event.kind.as_u16(),
+            "canvas event has unexpected kind — emitting no section",
+        );
+        return None;
+    }
+
+    // Validate h-tag: must carry the channel UUID we queried.
+    // The REST boundary filters by #h, but we verify here to prevent a
+    // misbehaving relay from injecting a different channel's canvas.
+    let h_tag_matches = event.tags.iter().any(|tag| {
+        let v = tag.as_slice();
+        v.len() >= 2 && v[0] == "h" && v[1] == channel_uuid
+    });
+    if !h_tag_matches {
+        tracing::warn!(
+            target: "canvas::fetch",
+            channel = %channel_uuid,
+            "canvas event is missing expected h-tag — emitting no section",
+        );
+        return None;
+    }
+
     // Blank content means the canvas was cleared; do not fall back to older events.
     if event.content.trim().is_empty() {
         tracing::debug!(
@@ -2172,8 +2229,20 @@ pub(crate) fn canvas_section_from_query_response(
     let id = event.id.to_hex();
 
     // Convert the Nostr timestamp to a UTC RFC3339 string with Z suffix.
-    // If chrono rejects the value (out-of-range), fail open — emit no section.
-    let ts_secs = event.created_at.as_secs() as i64;
+    // Use checked conversion: a u64 that exceeds i64::MAX (e.g. Timestamp::max())
+    // wraps silently with `as i64`, producing a negative value that chrono would
+    // accept as a date in 1969. Reject out-of-range values explicitly instead.
+    let ts_secs = match i64::try_from(event.created_at.as_secs()) {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::warn!(
+                target: "canvas::fetch",
+                channel = %channel_uuid,
+                "canvas event created_at overflows i64 — emitting no section",
+            );
+            return None;
+        }
+    };
     let timestamp = match chrono::DateTime::from_timestamp(ts_secs, 0) {
         Some(dt) => dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         None => {
@@ -3243,7 +3312,7 @@ async fn clear_reactions(rest: crate::relay::RestClient, event_ids: Vec<String>)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nostr::{EventBuilder, Keys, Kind, Tag};
+    use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
 
     // These pin the initial_message dispatch path (run_prompt_task, ~line 855):
@@ -4436,14 +4505,15 @@ mod tests {
 
     const CHANNEL_UUID: &str = "00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
 
-    /// Build a real, cryptographically signed Nostr event for canvas tests.
+    /// Build a real, cryptographically signed Nostr canvas event for tests.
     ///
-    /// `nostr::Event` requires all fields (pubkey, sig, kind, tags, id) to
-    /// deserialise successfully, so we use `EventBuilder` + `Keys` rather than
-    /// a bare `serde_json::json!({...})` object.
+    /// Includes the correct kind (40100) and an `h` tag carrying `CHANNEL_UUID`
+    /// so all structural and content validations pass.
     fn make_canvas_event_value(content: &str) -> serde_json::Value {
         let keys = Keys::generate();
+        let h_tag = Tag::parse(["h", CHANNEL_UUID]).expect("h tag");
         let event = EventBuilder::new(Kind::Custom(buzz_core::kind::KIND_CANVAS as u16), content)
+            .tags([h_tag])
             .sign_with_keys(&keys)
             .expect("sign");
         serde_json::to_value(&event).expect("serialise")
@@ -4507,8 +4577,10 @@ mod tests {
     #[test]
     fn test_canvas_section_from_query_response_string_timestamp_returns_none() {
         let keys = Keys::generate();
+        let h_tag = Tag::parse(["h", CHANNEL_UUID]).expect("h tag");
         let mut ev = serde_json::to_value(
             EventBuilder::new(Kind::Custom(buzz_core::kind::KIND_CANVAS as u16), "content")
+                .tags([h_tag])
                 .sign_with_keys(&keys)
                 .expect("sign"),
         )
@@ -4527,8 +4599,10 @@ mod tests {
     #[test]
     fn test_canvas_section_from_query_response_missing_timestamp_returns_none() {
         let keys = Keys::generate();
+        let h_tag = Tag::parse(["h", CHANNEL_UUID]).expect("h tag");
         let mut ev = serde_json::to_value(
             EventBuilder::new(Kind::Custom(buzz_core::kind::KIND_CANVAS as u16), "content")
+                .tags([h_tag])
                 .sign_with_keys(&keys)
                 .expect("sign"),
         )
@@ -4539,6 +4613,87 @@ mod tests {
             result.is_none(),
             "missing created_at must be rejected by nostr::Event deserialiser"
         );
+    }
+
+    /// An event with a timestamp at Timestamp::max() (u64::MAX) must return None.
+    ///
+    /// `u64::MAX as i64` wraps to -1, which chrono silently accepts as
+    /// 1969-12-31T23:59:59Z. The checked i64::try_from must reject it first.
+    #[test]
+    fn test_canvas_section_from_query_response_timestamp_max_returns_none() {
+        let keys = Keys::generate();
+        let h_tag = Tag::parse(["h", CHANNEL_UUID]).expect("h tag");
+        let ev = serde_json::to_value(
+            EventBuilder::new(Kind::Custom(buzz_core::kind::KIND_CANVAS as u16), "content")
+                .tags([h_tag])
+                .custom_created_at(Timestamp::max())
+                .sign_with_keys(&keys)
+                .expect("sign"),
+        )
+        .expect("serialise");
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
+        assert!(
+            result.is_none(),
+            "Timestamp::max() (u64::MAX) must return None — not wrap to 1969"
+        );
+    }
+
+    /// A structurally complete but tampered event (content altered after signing)
+    /// must be rejected by event.verify().
+    #[test]
+    fn test_canvas_section_from_query_response_tampered_event_returns_none() {
+        let keys = Keys::generate();
+        let h_tag = Tag::parse(["h", CHANNEL_UUID]).expect("h tag");
+        let mut ev = serde_json::to_value(
+            EventBuilder::new(
+                Kind::Custom(buzz_core::kind::KIND_CANVAS as u16),
+                "original",
+            )
+            .tags([h_tag])
+            .sign_with_keys(&keys)
+            .expect("sign"),
+        )
+        .expect("serialise");
+        // Tamper the content after signing — id and sig no longer agree.
+        ev["content"] = serde_json::Value::String("injected instructions".into());
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
+        assert!(
+            result.is_none(),
+            "tampered event must fail verify() and return None"
+        );
+    }
+
+    /// An event with the wrong kind (not 40100) must be rejected.
+    #[test]
+    fn test_canvas_section_from_query_response_wrong_kind_returns_none() {
+        let keys = Keys::generate();
+        let h_tag = Tag::parse(["h", CHANNEL_UUID]).expect("h tag");
+        let ev = serde_json::to_value(
+            EventBuilder::new(Kind::Custom(9), "content")
+                .tags([h_tag])
+                .sign_with_keys(&keys)
+                .expect("sign"),
+        )
+        .expect("serialise");
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
+        assert!(result.is_none(), "wrong kind must return None");
+    }
+
+    /// An event missing the expected h-tag (or carrying a different channel UUID)
+    /// must be rejected.
+    #[test]
+    fn test_canvas_section_from_query_response_wrong_h_tag_returns_none() {
+        let keys = Keys::generate();
+        let wrong_h = Tag::parse(["h", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"]).expect("h tag");
+        let ev = serde_json::to_value(
+            EventBuilder::new(Kind::Custom(buzz_core::kind::KIND_CANVAS as u16), "content")
+                .tags([wrong_h])
+                .sign_with_keys(&keys)
+                .expect("sign"),
+        )
+        .expect("serialise");
+        let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
+        assert!(result.is_none(), "mismatched h-tag must return None");
     }
 
     #[test]

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -942,6 +942,24 @@ pub(crate) fn prepend_base_for_legacy(
     }
 }
 
+/// Prepend the `[Channel Canvas]` section to the legacy initial-message body.
+///
+/// Protocol-v2 agents already receive the canvas in `systemPrompt`; only
+/// legacy (protocol_version < 2) agents need it injected here so it arrives
+/// before the first prompt — the same "every turn" semantics as per-turn core.
+/// Heartbeats never have an initial_message, so the caller is responsible for
+/// not passing a canvas when `source` is `Heartbeat`.
+pub(crate) fn prepend_canvas_for_legacy(
+    protocol_version: u32,
+    agent_canvas: Option<&str>,
+    body: &str,
+) -> String {
+    match agent_canvas {
+        Some(canvas) if protocol_version < 2 => format!("{canvas}\n\n{body}"),
+        _ => body.to_string(),
+    }
+}
+
 /// Frame the `session/new` `systemPrompt` so each present prompt carries its own
 /// header, keeping the base/persona boundary recoverable downstream.
 ///
@@ -1355,8 +1373,16 @@ pub async fn run_prompt_task(
             // For agents with systemPrompt support (protocol_version >= 2),
             // base_prompt is delivered via the system role in session/new.
             // Legacy agents receive it via [Base] in the user message instead.
+            // Canvas is also injected here for legacy agents: protocol-v2 agents
+            // already have it in systemPrompt; legacy agents need it before the
+            // first prompt, matching the "every turn" per-turn delivery semantics.
             let init_msg =
                 prepend_base_for_legacy(agent.protocol_version, ctx.base_prompt, initial_msg);
+            let init_msg = prepend_canvas_for_legacy(
+                agent.protocol_version,
+                agent_canvas.as_deref(),
+                &init_msg,
+            );
             let init_result = agent
                 .acp
                 .session_prompt_with_idle_timeout(
@@ -3343,6 +3369,80 @@ mod tests {
         assert_eq!(composed, "hello channel");
     }
 
+    // ── prepend_canvas_for_legacy ─────────────────────────────────────────────
+
+    #[test]
+    fn test_initial_message_legacy_agent_gets_canvas_prepended() {
+        // Legacy agents (protocol_version < 2) receive the canvas section before
+        // the initial-message body so it arrives before the first prompt.
+        let canvas = "[Channel Canvas]\nCanvas revision (event ID): abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234\nLast modified: 2024-01-15T10:30:00Z\nFetch current content with: buzz canvas get --channel 00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
+        let composed = prepend_canvas_for_legacy(1, Some(canvas), "do the thing");
+        assert!(
+            composed.starts_with("[Channel Canvas]"),
+            "canvas must precede the body"
+        );
+        assert!(
+            composed.ends_with("do the thing"),
+            "body must follow the canvas"
+        );
+        assert!(
+            composed.contains("\n\ndo the thing"),
+            "canvas and body separated by blank line"
+        );
+    }
+
+    #[test]
+    fn test_initial_message_modern_agent_omits_canvas_from_body() {
+        // Protocol-v2 agents receive canvas in systemPrompt; it must NOT be
+        // duplicated in the initial-message user turn.
+        let canvas = "[Channel Canvas]\nsome section";
+        let composed = prepend_canvas_for_legacy(2, Some(canvas), "do the thing");
+        assert_eq!(
+            composed, "do the thing",
+            "modern agent initial message must not contain canvas"
+        );
+        assert!(
+            !composed.contains("[Channel Canvas]"),
+            "canvas must be absent from modern agent initial message"
+        );
+    }
+
+    #[test]
+    fn test_initial_message_legacy_agent_no_canvas_is_unchanged() {
+        // No canvas present: body passes through unmodified.
+        let composed = prepend_canvas_for_legacy(1, None, "do the thing");
+        assert_eq!(composed, "do the thing");
+    }
+
+    #[test]
+    fn test_initial_message_legacy_canvas_and_base_compose_correctly() {
+        // Verify the full composition order when both base and canvas are present:
+        // [Base] → canvas section → initial-message body.
+        let canvas = "[Channel Canvas]\ncanvas content";
+        let base_composed = prepend_base_for_legacy(1, Some("be helpful"), "do the thing");
+        let full = prepend_canvas_for_legacy(1, Some(canvas), &base_composed);
+        assert!(
+            full.starts_with("[Channel Canvas]"),
+            "canvas must be first in composed message"
+        );
+        assert!(
+            full.contains("[Base]"),
+            "base must be present in composed message"
+        );
+        assert!(
+            full.ends_with("do the thing"),
+            "body must be last in composed message"
+        );
+        // Order: canvas → base → body
+        let canvas_pos = full.find("[Channel Canvas]").unwrap();
+        let base_pos = full.find("[Base]").unwrap();
+        let body_pos = full.find("do the thing").unwrap();
+        assert!(
+            canvas_pos < base_pos && base_pos < body_pos,
+            "order must be: canvas → base → body"
+        );
+    }
+
     // Pin the session/new systemPrompt framing: each present prompt carries its
     // own header so the desktop observer can split into labeled sub-sections.
 
@@ -4694,14 +4794,6 @@ mod tests {
         .expect("serialise");
         let result = canvas_section_from_query_response(&[ev], CHANNEL_UUID);
         assert!(result.is_none(), "mismatched h-tag must return None");
-    }
-
-    #[test]
-    fn test_canvas_section_from_query_response_non_array_object_returns_none() {
-        // Passing a single JSON object (not wrapped in a Vec) exercises the
-        // empty-array fast-path because serde_json::Value::Array is never matched.
-        let result = canvas_section_from_query_response(&[], CHANNEL_UUID);
-        assert!(result.is_none());
     }
 
     #[test]

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -89,6 +89,13 @@ pub struct SessionState {
     /// channel_id → rendered NIP-AE core prompt section, populated once at
     /// session creation per Tyler's spec (no mid-session refresh).
     pub core_sections: HashMap<Uuid, String>,
+    /// channel_id → rendered `[Channel Canvas]` metadata section.
+    ///
+    /// Populated once before session creation (same lifecycle as `core_sections`).
+    /// Absent when the channel has no canvas, the canvas content is blank, or the
+    /// fetch fails — all fail open. Cleared on session invalidation alongside
+    /// `core_sections` so the next session picks up any canvas change.
+    pub canvas_sections: HashMap<Uuid, String>,
 }
 
 impl SessionState {
@@ -110,6 +117,7 @@ impl SessionState {
     pub fn invalidate_channel(&mut self, channel_id: &Uuid) -> bool {
         self.turn_counts.remove(channel_id);
         self.core_sections.remove(channel_id);
+        self.canvas_sections.remove(channel_id);
         self.sessions.remove(channel_id).is_some()
     }
 
@@ -120,6 +128,7 @@ impl SessionState {
         self.heartbeat_session = None;
         self.heartbeat_turn_count = 0;
         self.core_sections.clear();
+        self.canvas_sections.clear();
     }
 
     #[cfg(test)]
@@ -127,6 +136,7 @@ impl SessionState {
         self.sessions.contains_key(channel_id)
             || self.turn_counts.contains_key(channel_id)
             || self.core_sections.contains_key(channel_id)
+            || self.canvas_sections.contains_key(channel_id)
     }
 }
 
@@ -663,17 +673,22 @@ async fn create_session_and_apply_model(
     agent: &mut OwnedAgent,
     ctx: &PromptContext,
     agent_core: Option<&str>,
+    agent_canvas: Option<&str>,
 ) -> Result<String, AcpError> {
-    // Combine base_prompt + system_prompt + agent core into a single
-    // systemPrompt value for the session/new request. Only sent when the agent
-    // declares protocol version >= 2 (supports systemPrompt); legacy agents
+    // Combine base_prompt + system_prompt + agent core + canvas metadata into a
+    // single systemPrompt value for the session/new request. Only sent when the
+    // agent declares protocol version >= 2 (supports systemPrompt); legacy agents
     // ignore it and receive the same content as user-message sections via
-    // `format_prompt`. Core already carries its own `[Agent Memory — core]`
-    // header from `engram_fetch::build_core_section`, so we just append it.
+    // `format_prompt`. Core carries its own `[Agent Memory — core]` header, and
+    // canvas carries its own `[Channel Canvas]` header; both are appended with a
+    // blank-line separator.
     let combined_system_prompt: Option<String> = if agent.protocol_version >= 2 {
-        with_core(
-            framed_system_prompt(&ctx.cwd, ctx.base_prompt, ctx.system_prompt.as_deref()),
-            agent_core,
+        with_canvas(
+            with_core(
+                framed_system_prompt(&ctx.cwd, ctx.base_prompt, ctx.system_prompt.as_deref()),
+                agent_core,
+            ),
+            agent_canvas,
         )
     } else {
         None
@@ -999,6 +1014,20 @@ fn with_core(framed: Option<String>, core: Option<&str>) -> Option<String> {
     }
 }
 
+/// Append the `[Channel Canvas]` metadata section onto the accumulated system prompt.
+///
+/// The canvas section already carries its `[Channel Canvas]` header (from
+/// `render_canvas_section`), so it is joined with a blank-line separator.
+/// Either side may be absent.
+fn with_canvas(prompt: Option<String>, canvas: Option<&str>) -> Option<String> {
+    match (prompt, canvas) {
+        (Some(prompt), Some(canvas)) => Some(format!("{prompt}\n\n{canvas}")),
+        (Some(prompt), None) => Some(prompt),
+        (None, Some(canvas)) => Some(canvas.to_string()),
+        (None, None) => None,
+    }
+}
+
 /// Return `agent` to the pool via `result_tx`, clearing any steer receiver first.
 ///
 /// Every path that returns an `OwnedAgent` to the pool via `PromptResult` goes
@@ -1160,10 +1189,43 @@ pub async fn run_prompt_task(
         }
     }
 
+    // Canvas metadata fetch — same lifecycle as core: once per new channel session,
+    // never for heartbeats, cached until session invalidation.
+    //
+    // DM check: use startup channel_info first; lazy-fetch only when missing.
+    // A confirmed DM never receives a canvas section.
+    //
+    // Failure modes all fail open: no event, blank content, malformed response,
+    // REST error, or timeout each produce `None` and never block session creation.
+    if let PromptSource::Channel(cid) = &source {
+        let is_new_channel_session = !agent.state.sessions.contains_key(cid);
+        if is_new_channel_session && !agent.state.canvas_sections.contains_key(cid) {
+            // Resolve DM status: prefer the startup cache, lazy-fetch as fallback.
+            let is_dm = match ctx.channel_info.get(cid) {
+                Some(ci) => ci.channel_type == "dm",
+                None => fetch_channel_info(*cid, &ctx.rest_client)
+                    .await
+                    .map(|ci| ci.channel_type == "dm")
+                    .unwrap_or(false),
+            };
+            if !is_dm {
+                if let Some(section) = fetch_canvas_section(*cid, &ctx.rest_client).await {
+                    agent.state.canvas_sections.insert(*cid, section);
+                }
+            }
+        }
+    }
+
     // The core section to fold into the system prompt for this turn's session.
     // Channel-scoped; heartbeats carry no owner core.
     let agent_core: Option<String> = match &source {
         PromptSource::Channel(cid) => agent.state.core_sections.get(cid).cloned(),
+        PromptSource::Heartbeat => None,
+    };
+
+    // The canvas metadata section — channel-scoped, absent for heartbeats/DMs.
+    let agent_canvas: Option<String> = match &source {
+        PromptSource::Channel(cid) => agent.state.canvas_sections.get(cid).cloned(),
         PromptSource::Heartbeat => None,
     };
 
@@ -1173,7 +1235,13 @@ pub async fn run_prompt_task(
                 (sid.clone(), false)
             } else {
                 // Create new session with model application.
-                match create_session_and_apply_model(&mut agent, &ctx, agent_core.as_deref()).await
+                match create_session_and_apply_model(
+                    &mut agent,
+                    &ctx,
+                    agent_core.as_deref(),
+                    agent_canvas.as_deref(),
+                )
+                .await
                 {
                     Ok(sid) => {
                         tracing::info!(
@@ -1211,7 +1279,7 @@ pub async fn run_prompt_task(
             if let Some(sid) = &agent.state.heartbeat_session {
                 (sid.clone(), false)
             } else {
-                match create_session_and_apply_model(&mut agent, &ctx, None).await {
+                match create_session_and_apply_model(&mut agent, &ctx, None, None).await {
                     Ok(sid) => {
                         tracing::info!(
                             target: "pool::session",
@@ -1431,6 +1499,7 @@ pub async fn run_prompt_task(
                 has_system_prompt_support: agent.protocol_version >= 2,
                 base_prompt: ctx.base_prompt,
                 system_prompt: ctx.system_prompt.as_deref(),
+                agent_canvas: agent_canvas.as_deref(),
             },
         )
     } else {
@@ -1995,6 +2064,134 @@ async fn fetch_channel_info(channel_id: Uuid, rest: &RestClient) -> Option<Promp
         }
     })
     .await
+}
+
+/// Fetch the latest canvas event for `channel_id` and return a rendered
+/// `[Channel Canvas]` metadata section, or `None` if absent/blank/error.
+///
+/// Failure modes (all fail open — no crash, no block):
+/// * relay returns no event → `None`
+/// * latest event's content is blank → `None` (cleared canvas; older revisions
+///   are NOT resurrected)
+/// * malformed JSON array, missing fields, bad event ID, bad timestamp →
+///   logged at `warn`; returns `None`
+/// * REST error or timeout → returns `None`
+///
+/// Called at most once per new channel session; the result is cached in
+/// `SessionState::canvas_sections` and cleared on session invalidation.
+async fn fetch_canvas_section(channel_id: Uuid, rest: &RestClient) -> Option<String> {
+    use nostr::{Alphabet, SingleLetterTag};
+
+    let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+    let filter = nostr::Filter::new()
+        .kind(nostr::Kind::Custom(buzz_core::kind::KIND_CANVAS as u16))
+        .custom_tags(h_tag, [channel_id.to_string()])
+        .limit(1);
+
+    const CANVAS_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+    let json = match tokio::time::timeout(
+        CANVAS_FETCH_TIMEOUT,
+        rest.query(std::slice::from_ref(&filter)),
+    )
+    .await
+    {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => {
+            tracing::warn!(
+                target: "canvas::fetch",
+                channel = %channel_id,
+                "canvas query failed: {e} — emitting no section"
+            );
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(
+                target: "canvas::fetch",
+                channel = %channel_id,
+                timeout_ms = CANVAS_FETCH_TIMEOUT.as_millis() as u64,
+                "canvas fetch timed out — emitting no section"
+            );
+            return None;
+        }
+    };
+
+    let events = match json.as_array() {
+        Some(arr) => arr,
+        None => {
+            tracing::warn!(
+                target: "canvas::fetch",
+                channel = %channel_id,
+                "canvas query response is not a JSON array — emitting no section"
+            );
+            return None;
+        }
+    };
+
+    canvas_section_from_query_response(events, &channel_id.to_string())
+}
+
+/// Parse a canvas query response array and render a `[Channel Canvas]` section.
+///
+/// Extracted as a pure function so tests can exercise the parsing/validation
+/// logic without async machinery or relay connectivity.
+///
+/// Returns `None` on: empty array, blank content, invalid event ID format,
+/// or any missing required field.
+pub(crate) fn canvas_section_from_query_response(
+    events: &[serde_json::Value],
+    channel_uuid: &str,
+) -> Option<String> {
+    let ev = events.first()?;
+
+    let id = ev.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let created_at = ev.get("created_at").and_then(|v| v.as_i64()).unwrap_or(0);
+    let content = ev.get("content").and_then(|v| v.as_str()).unwrap_or("");
+
+    // Validate: event ID must be 64 lowercase hex chars.
+    if id.len() != 64 || !id.chars().all(|c| c.is_ascii_hexdigit()) {
+        tracing::warn!(
+            target: "canvas::fetch",
+            channel = %channel_uuid,
+            "canvas event has invalid id {:?} — emitting no section",
+            id
+        );
+        return None;
+    }
+
+    // Blank content means the canvas was cleared; do not fall back to older events.
+    if content.trim().is_empty() {
+        tracing::debug!(
+            target: "canvas::fetch",
+            channel = %channel_uuid,
+            "latest canvas event has blank content — emitting no section"
+        );
+        return None;
+    }
+
+    let timestamp = chrono::DateTime::from_timestamp(created_at, 0)
+        .map(|dt| dt.to_rfc3339())
+        .unwrap_or_else(|| format!("{created_at}"));
+
+    tracing::info!(
+        target: "canvas::fetch",
+        channel = %channel_uuid,
+        event_id = %id,
+        "injected channel canvas metadata section into system prompt"
+    );
+    Some(render_canvas_section(id, &timestamp, channel_uuid))
+}
+
+/// Render the `[Channel Canvas]` metadata section string.
+///
+/// Pure function — kept separate so unit tests can exercise rendering
+/// without async machinery or relay connectivity.
+pub(crate) fn render_canvas_section(event_id: &str, timestamp: &str, channel_uuid: &str) -> String {
+    format!(
+        "[Channel Canvas]\n\
+         Canvas revision (event ID): {event_id}\n\
+         Last modified: {timestamp}\n\
+         Fetch current content with: buzz canvas get --channel {channel_uuid}"
+    )
 }
 
 /// Fetch conversation context (thread or DM) for a batch before prompting.
@@ -4120,5 +4317,200 @@ mod tests {
             memory_enabled: false,
             harness_name: "goose".to_string(),
         }
+    }
+
+    // ── render_canvas_section ────────────────────────────────────────────────
+
+    #[test]
+    fn test_render_canvas_section_produces_exact_shape() {
+        let id = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+        let ts = "2024-01-15T10:30:00+00:00";
+        let uuid = "00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
+        let section = render_canvas_section(id, ts, uuid);
+        assert_eq!(
+            section,
+            "[Channel Canvas]\n\
+             Canvas revision (event ID): a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2\n\
+             Last modified: 2024-01-15T10:30:00+00:00\n\
+             Fetch current content with: buzz canvas get --channel 00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae"
+        );
+    }
+
+    // ── with_canvas ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_with_canvas_appends_to_existing_prompt() {
+        let result = with_canvas(Some("base content".into()), Some("[Channel Canvas]\nstuff"));
+        assert_eq!(result.unwrap(), "base content\n\n[Channel Canvas]\nstuff");
+    }
+
+    #[test]
+    fn test_with_canvas_returns_canvas_alone_when_no_prompt() {
+        let result = with_canvas(None, Some("[Channel Canvas]\nstuff"));
+        assert_eq!(result.unwrap(), "[Channel Canvas]\nstuff");
+    }
+
+    #[test]
+    fn test_with_canvas_returns_prompt_alone_when_no_canvas() {
+        let result = with_canvas(Some("base content".into()), None);
+        assert_eq!(result.unwrap(), "base content");
+    }
+
+    #[test]
+    fn test_with_canvas_returns_none_when_both_absent() {
+        let result = with_canvas(None, None);
+        assert!(result.is_none());
+    }
+
+    // ── canvas_sections cache invalidation ───────────────────────────────────
+
+    #[test]
+    fn test_invalidate_channel_clears_canvas_section() {
+        let ch = Uuid::new_v4();
+        let mut s = SessionState::default();
+        s.sessions.insert(ch, "sess".into());
+        s.canvas_sections
+            .insert(ch, "[Channel Canvas]\nrev abc".into());
+
+        s.invalidate_channel(&ch);
+
+        assert!(!s.canvas_sections.contains_key(&ch));
+        assert!(!s.sessions.contains_key(&ch));
+    }
+
+    #[test]
+    fn test_invalidate_all_clears_canvas_sections() {
+        let ch_a = Uuid::new_v4();
+        let ch_b = Uuid::new_v4();
+        let mut s = SessionState::default();
+        s.canvas_sections.insert(ch_a, "canvas-a".into());
+        s.canvas_sections.insert(ch_b, "canvas-b".into());
+        s.sessions.insert(ch_a, "sess-a".into());
+
+        s.invalidate_all();
+
+        assert!(s.canvas_sections.is_empty());
+        assert!(s.sessions.is_empty());
+    }
+
+    #[test]
+    fn test_invalidate_channel_leaves_other_channels_canvas_intact() {
+        let ch_a = Uuid::new_v4();
+        let ch_b = Uuid::new_v4();
+        let mut s = SessionState::default();
+        s.sessions.insert(ch_a, "sess-a".into());
+        s.sessions.insert(ch_b, "sess-b".into());
+        s.canvas_sections.insert(ch_a, "canvas-a".into());
+        s.canvas_sections.insert(ch_b, "canvas-b".into());
+
+        s.invalidate_channel(&ch_a);
+
+        assert!(!s.canvas_sections.contains_key(&ch_a));
+        assert_eq!(s.canvas_sections.get(&ch_b).unwrap(), "canvas-b");
+    }
+
+    #[test]
+    fn test_has_channel_state_true_when_only_canvas_section_present() {
+        let ch = Uuid::new_v4();
+        let mut s = SessionState::default();
+        s.canvas_sections.insert(ch, "canvas".into());
+        assert!(s.has_channel_state(&ch));
+    }
+
+    // ── canvas_section_from_query_response ───────────────────────────────────
+
+    const VALID_ID: &str = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    const CHANNEL_UUID: &str = "00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
+
+    #[test]
+    fn test_canvas_section_from_query_response_happy_path() {
+        let events = vec![serde_json::json!({
+            "id": VALID_ID,
+            "created_at": 1705312200_i64,
+            "content": "# Team instructions\nBe helpful."
+        })];
+        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+        let section = result.expect("expected Some");
+        assert!(section.contains(VALID_ID));
+        assert!(section.contains("buzz canvas get --channel"));
+        assert!(section.contains(CHANNEL_UUID));
+        assert!(section.starts_with("[Channel Canvas]"));
+    }
+
+    #[test]
+    fn test_canvas_section_from_query_response_empty_array_returns_none() {
+        let result = canvas_section_from_query_response(&[], CHANNEL_UUID);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_canvas_section_from_query_response_blank_content_returns_none() {
+        let events = vec![serde_json::json!({
+            "id": VALID_ID,
+            "created_at": 1705312200_i64,
+            "content": "   "
+        })];
+        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+        assert!(
+            result.is_none(),
+            "blank content must return None (cleared canvas)"
+        );
+    }
+
+    #[test]
+    fn test_canvas_section_from_query_response_empty_content_returns_none() {
+        let events = vec![serde_json::json!({
+            "id": VALID_ID,
+            "created_at": 1705312200_i64,
+            "content": ""
+        })];
+        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_canvas_section_from_query_response_invalid_id_short_returns_none() {
+        let events = vec![serde_json::json!({
+            "id": "abc123",
+            "created_at": 1705312200_i64,
+            "content": "some instructions"
+        })];
+        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+        assert!(result.is_none(), "short id must return None");
+    }
+
+    #[test]
+    fn test_canvas_section_from_query_response_invalid_id_non_hex_returns_none() {
+        let events = vec![serde_json::json!({
+            "id": "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+            "created_at": 1705312200_i64,
+            "content": "some instructions"
+        })];
+        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+        assert!(result.is_none(), "non-hex id must return None");
+    }
+
+    #[test]
+    fn test_canvas_section_from_query_response_missing_id_returns_none() {
+        let events = vec![serde_json::json!({
+            "created_at": 1705312200_i64,
+            "content": "some instructions"
+        })];
+        // id defaults to "" which fails the 64-char check
+        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_canvas_section_from_query_response_zero_timestamp_uses_epoch() {
+        let events = vec![serde_json::json!({
+            "id": VALID_ID,
+            "created_at": 0_i64,
+            "content": "some instructions"
+        })];
+        let result = canvas_section_from_query_response(&events, CHANNEL_UUID);
+        let section = result.expect("epoch timestamp is valid");
+        // The epoch renders as a valid RFC3339 string, not a fallback integer.
+        assert!(section.contains("1970-01-01") || section.contains("0"));
     }
 }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1303,6 +1303,13 @@ pub struct FormatPromptArgs<'a> {
     pub base_prompt: Option<&'a str>,
     /// System prompt content for legacy agents (protocol_version < 2).
     pub system_prompt: Option<&'a str>,
+    /// Rendered `[Channel Canvas]` metadata section for legacy agents.
+    ///
+    /// For modern agents (protocol_version >= 2) the section is delivered via
+    /// the system role in session/new; omit here to avoid duplication.
+    /// For legacy agents it rides in the user message on every turn of the
+    /// session, alongside `[Base]`/`[System]`/`[Agent Memory — core]`.
+    pub agent_canvas: Option<&'a str>,
 }
 
 /// Format the `[Base]` section for the base prompt.
@@ -1374,6 +1381,10 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     if !args.has_system_prompt_support {
         if let Some(core) = args.agent_core {
             sections.push(core.to_string());
+        }
+        // Channel canvas metadata — same delivery semantics as core for legacy agents.
+        if let Some(canvas) = args.agent_canvas {
+            sections.push(canvas.to_string());
         }
     }
 
@@ -4316,5 +4327,85 @@ mod tests {
             .collect();
         assert_eq!(recovered, vec![e1_id, e2_id, e3_id]);
         assert!(q.withheld_native_steer.is_empty());
+    }
+
+    // ── format_prompt: agent_canvas ─────────────────────────────────────────
+
+    #[test]
+    fn test_format_prompt_canvas_injected_for_legacy_agent() {
+        let canvas = "[Channel Canvas]\nCanvas revision (event ID): abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234\nLast modified: 2024-01-15T10:30:00+00:00\nFetch current content with: buzz canvas get --channel 00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
+        let ch = Uuid::new_v4();
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event: make_event("hi"),
+                prompt_tag: "test".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                agent_canvas: Some(canvas),
+                has_system_prompt_support: false,
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            prompt.contains("[Channel Canvas]"),
+            "legacy agent prompt must include canvas section; got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn test_format_prompt_canvas_omitted_for_modern_agent() {
+        let canvas = "[Channel Canvas]\nCanvas revision (event ID): abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234\nLast modified: 2024-01-15T10:30:00+00:00\nFetch current content with: buzz canvas get --channel 00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
+        let ch = Uuid::new_v4();
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event: make_event("hi"),
+                prompt_tag: "test".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                agent_canvas: Some(canvas),
+                has_system_prompt_support: true,
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            !prompt.contains("[Channel Canvas]"),
+            "modern agent must not get canvas in user message (it's in systemPrompt); got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn test_format_prompt_no_canvas_produces_no_canvas_section() {
+        let ch = Uuid::new_v4();
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event: make_event("hi"),
+                prompt_tag: "test".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
+        assert!(
+            !prompt.contains("[Channel Canvas]"),
+            "no canvas section expected when agent_canvas is None; got: {prompt}"
+        );
     }
 }


### PR DESCRIPTION
Agents running in a channel that has a canvas now receive a `[Channel Canvas]` section in their system prompt before their first turn, giving them the revision event ID, last-modified timestamp, and the exact CLI command to fetch the content on demand.

## What changed

**`crates/buzz-acp/src/pool.rs`**

- `SessionState::canvas_sections` — `HashMap<Uuid, String>` with the same lifecycle as `core_sections`: cleared in `invalidate_channel`, `invalidate_all`, checked in `has_channel_state`
- `fetch_canvas_section` — async, 3s timeout, queries kind `40100` + `#h=<channel UUID>` + `limit=1`; all failure modes fail open
- `canvas_section_from_query_response` — pure parser with full event validation:
  - `serde_json::from_value::<nostr::Event>` rejects partial/malformed objects
  - `event.verify()` rejects tampered events (id/sig disagree with content)
  - `event.kind == KIND_CANVAS` guards against wrong-kind relay responses
  - h-tag UUID match guards against cross-channel injection
  - `i64::try_from(event.created_at.as_secs())` rejects `Timestamp::max()` and any value that wraps under `as i64`
  - `DateTime::from_timestamp` returning `None` also emits no section
  - Blank content (cleared canvas) returns `None` without resurrecting older events
- `render_canvas_section` — pure renderer; timestamps use RFC3339 with Z suffix
- `with_canvas` — mirrors `with_core`; appends canvas section to system prompt
- `prepend_canvas_for_legacy(protocol_version, canvas, body)` — prepends the canvas section for protocol-v1 agents in the `initial_message` path; protocol-v2 agents already have it in `systemPrompt` and receive no duplication
- Wire-up in `run_prompt_task`:
  - Canvas held in `pending_canvas: Option<(Uuid, String)>` until `create_session_and_apply_model` succeeds — prevents stale revision surviving failed session creation
  - DM exclusion: `unwrap_or(true)` on unknown channel type treats ambiguous channels as DMs (fail-closed)
  - Legacy `initial_message` delivery: `prepend_base_for_legacy` then `prepend_canvas_for_legacy` so canvas arrives before the first prompt; composition order is `[Channel Canvas]` → `[Base]` → body
  - Heartbeats never receive a canvas section

**`crates/buzz-acp/src/queue.rs`**

- `FormatPromptArgs::agent_canvas` — legacy (protocol-v1) per-turn prompts receive the canvas section in the user-message system-context area, mirroring core memory delivery

## Design decisions

- **Metadata-only.** The section tells the agent the canvas exists and how to fetch it — no canvas body injected. This avoids token bloat and prompt-authority ambiguity from user-writable channel content.
- **Fail-open on fetch, fail-closed on DM ambiguity.** Relay errors/timeouts produce no section. Unknown channel type (cannot determine DM vs. channel) also produces no section.
- **Pending-then-commit lifecycle.** Canvas is committed to `SessionState` only after session creation succeeds; a failed create leaves the next retry free to re-fetch a fresh revision.
- **Full event verification.** Every layer (`serde`, `verify()`, kind, h-tag, timestamp range) is applied before trusting any field.
- **Legacy initial-message parity.** `prepend_canvas_for_legacy` ensures legacy agents receive the canvas section on the `initial_message` turn, matching the "before first prompt" / "every turn" guarantee.

## Rendered section shape

```
[Channel Canvas]
Canvas revision (event ID): <64-hex-event-id>
Last modified: <RFC3339 timestamp ending in Z>
Fetch current content with: buzz canvas get --channel <channel-uuid>
```

## Tests (35 new across 3 commits, 483 total)

**Parser/validation (`canvas_section_from_query_response`):**
- Happy path, empty array, blank/empty content
- Partial object (missing pubkey/sig/kind/tags) → `None`
- Tampered event (content changed post-sign, verify fails) → `None`
- Wrong kind (not 40100) → `None`
- Mismatched h-tag (different channel UUID) → `None`
- String `created_at` → rejected by nostr deserialiser
- Missing `created_at` → rejected by nostr deserialiser
- `Timestamp::max()` (u64::MAX, wraps to -1 under `as i64`) → `None`
- RFC3339 Z-suffix invariant pinned

**Lifecycle / cache:**
- Channel invalidation clears canvas; unrelated channels untouched; `invalidate_all` clears all
- `has_channel_state` true when only canvas section present

**Composition:**
- `with_canvas`: all 4 cases (both, canvas-only, prompt-only, neither)
- `render_canvas_section`: exact shape
- `format_prompt` canvas for legacy, modern, absent (queue.rs)
- `prepend_canvas_for_legacy`: legacy present, modern omits, absent unchanged, full base+canvas+body order