### PR TITLE
fix(mobile): highlight full multi-word mentions

### DIFF
--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -112,10 +112,10 @@ class MessageContent extends HookConsumerWidget {
           var segment = mentionParts[i];
           for (final name in mentionNames.values) {
             if (name.contains(' ')) {
-              final nbspName = name.replaceAll(' ', '\u00A0');
+              final normalizedName = _markdownMentionName(name);
               segment = segment.replaceAllMapped(
                 RegExp('@${RegExp.escape(name)}', caseSensitive: false),
-                (m) => '@$nbspName',
+                (m) => '@$normalizedName',
               );
             }
           }
@@ -716,13 +716,13 @@ RegExp _buildPrefixPattern({
   );
 }
 
+String _markdownMentionName(String name) => name.replaceAll(' ', '\u00A0');
+
 Iterable<String> _mentionAliases(Iterable<String> mentionNames) sync* {
   for (final name in mentionNames) {
     final trimmed = name.trim();
     if (trimmed.isEmpty) continue;
-    // Message preprocessing replaces spaces in full-name mentions with
-    // non-breaking spaces, so the matching alias must use the same form.
-    yield trimmed.replaceAll(' ', '\u00A0');
+    yield _markdownMentionName(trimmed);
     final firstName = trimmed.split(RegExp(r'\s+')).first;
     if (firstName.isNotEmpty) {
       yield firstName;

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -720,6 +720,8 @@ Iterable<String> _mentionAliases(Iterable<String> mentionNames) sync* {
   for (final name in mentionNames) {
     final trimmed = name.trim();
     if (trimmed.isEmpty) continue;
+    // Message preprocessing replaces spaces in full-name mentions with
+    // non-breaking spaces, so the matching alias must use the same form.
     yield trimmed.replaceAll(' ', '\u00A0');
     final firstName = trimmed.split(RegExp(r'\s+')).first;
     if (firstName.isNotEmpty) {

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -720,7 +720,7 @@ Iterable<String> _mentionAliases(Iterable<String> mentionNames) sync* {
   for (final name in mentionNames) {
     final trimmed = name.trim();
     if (trimmed.isEmpty) continue;
-    yield trimmed;
+    yield trimmed.replaceAll(' ', '\u00A0');
     final firstName = trimmed.split(RegExp(r'\s+')).first;
     if (firstName.isNotEmpty) {
       yield firstName;

--- a/mobile/test/features/channels/message_content_test.dart
+++ b/mobile/test/features/channels/message_content_test.dart
@@ -732,6 +732,23 @@ void main() {
         expect(find.text('@Alice'), findsOneWidget);
       });
 
+      testWidgets('highlights an entire multi-word display name', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          _testable(
+            const MessageContent(
+              content: 'Hey @Kenny Lopez can you review this?',
+              mentionNames: {'pk1': 'Kenny Lopez'},
+            ),
+          ),
+        );
+
+        expect(find.text('@Kenny Lopez'), findsOneWidget);
+        expect(find.text('@Kenny'), findsNothing);
+        expect(_allRichText(tester), isNot(contains('Lopez Lopez')));
+      });
+
       testWidgets('renders unknown @mention as-is', (tester) async {
         await tester.pumpWidget(
           _testable(


### PR DESCRIPTION
### What changed?

- Match the non-breaking-space form used by mobile markdown preprocessing when resolving multi-word mention aliases.
- Add regression coverage proving a full display name renders as one highlighted mention instead of duplicating the surname.

### Why?

Mobile currently highlights only the first name in a full-name mention and leaves a duplicate surname as plain text.

### How is it tested?

Added tests:

- [`MessageContent @mentions`](https://github.com/block/buzz/tree/main/mobile/test/features/channels/message_content_test.dart)

Focused mobile validation and static analysis pass.
