### PR TITLE
fix(build): allow vendored opus to configure under CMake 4

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,9 @@
 # builds and much faster macOS link. Need lldb locals? Override per-shell:
 # CARGO_PROFILE_DEV_DEBUG=2
 debug = "line-tables-only"
+
+[env]
+# CMake 4 (pinned by hermit) removed compat with projects declaring
+# cmake_minimum_required < 3.5; audiopus_sys's vendored opus declares 3.1.
+# Same workaround CI uses. A value already set in the environment wins.
+CMAKE_POLICY_VERSION_MINIMUM = "3.5"


### PR DESCRIPTION
## Summary

- `just dev` fails on any machine without a system `libopus`: `audiopus_sys`'s build script falls back to compiling its vendored opus with CMake, whose `CMakeLists.txt` declares `cmake_minimum_required(VERSION 3.1)`, and the hermit-pinned CMake 4.3.1 removed compatibility with declared minimums below 3.5:

  ```
  CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.
  ```

- CI already sets `CMAKE_POLICY_VERSION_MINIMUM: "3.5"` on every Tauri-crate build step in `ci.yml` and `release.yml`. This applies the same workaround to local builds via `[env]` in the shared `.cargo/config.toml`, covering `just dev`, direct `cargo` invocations, `rust-analyzer`, and git worktrees.
- A value already present in the environment takes precedence, so CI is unaffected; CMake < 4 ignores the variable, and machines with a system `libopus` never reach the CMake path at all.
- `audiopus_sys` 0.2.2 is the latest release of a dormant crate, so there is no upstream fix to upgrade into.