### PR TITLE
fix(desktop): make doctor installs retryable with per-runtime progress and auth status

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -91,6 +91,7 @@ export default defineConfig({
         "**/channel-sort.spec.ts",
         "**/identity-lost.spec.ts",
         "**/global-agent-config-screenshots.spec.ts",
+        "**/doctor-states.spec.ts",
       ],
       use: {
         ...devices["Desktop Chrome"],

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -152,7 +152,10 @@ const overrides = new Map([
   // outdated-adapter and garbage-version-output paths through the codex id gate
   // (+140 lines: make_codex_runtime helper, PATH_MUTEX serializer, 2 test fns).
   // Load-bearing test coverage; queued to split with the file generally.
-  ["src-tauri/src/managed_agents/readiness.rs", 1750],
+  // +1: pub(crate) mod cli_probe declaration for doctor auth probe access.
+  // +3: auth_probe_args: None + login_hint: None added to make_cli_runtime and
+  // make_codex_runtime stubs (new KnownAcpRuntime fields).
+  ["src-tauri/src/managed_agents/readiness.rs", 1754],
   // applyWorkspace reposDir parameter plus the validateReposDir binding,
   // threaded through Tauri invokes for configurable repos_dir, plus the
   // harness-persona-sync `harnessOverride` create-input bit — load-bearing
@@ -179,10 +182,14 @@ const overrides = new Map([
   // baked-env fold-in: getBakedBuildEnv + BakedEnvEntry type adds ~28 lines.
   // doctor-npm-eacces-preflight: hint field on RawInstallStepResult + mapper
   // passthrough (+2 lines).
-  ["src/shared/api/tauri.ts", 1273],
+  // doctor-install-reliability: node_required + auth_status + login_hint fields
+  // added to RawAcpRuntimeCatalogEntry + fromRawAcpRuntimeCatalogEntry mapper (+8).
+  ["src/shared/api/tauri.ts", 1281],
   // doctor-npm-eacces-preflight: hint field added to InstallStepResult (+1 line).
   // codex-acp-package-swap: "adapter_outdated" variant added to AcpAvailabilityStatus (+1 line).
-  ["src/shared/api/types.ts", 1002],
+  // doctor-install-reliability: AuthStatus tagged union + nodeRequired/authStatus/
+  // loginHint fields on AcpRuntimeCatalogEntry (+14 lines). Load-bearing new feature.
+  ["src/shared/api/types.ts", 1016],
   // readiness-gate: PersonaDialog.tsx threads computeLocalModeGate +
   // requiredCredentialEnvKeys + RequiredFieldLabel so the "New agent" dialog
   // shows required markers and credential amber rows (parity with
@@ -224,7 +231,20 @@ const overrides = new Map([
   // (+18 lines), codex_adapter_availability/is_outdated helpers (+16 lines),
   // cross-platform probe contract. All load-bearing — required for correct
   // probe behaviour on Windows and descendant-process edge cases.
-  ["src-tauri/src/managed_agents/discovery.rs", 810],
+  // doctor-install-reliability: refreshable login_shell_path cache,
+  // find_nvm_default_bin + parse_semver_tag helpers, auth probe cache +
+  // probe_auth_status/cached_auth_status, runtime_needs_npm, probe_args_for,
+  // PartialEntry struct, and updated discover_acp_runtimes with parallel auth
+  // probes. Load-bearing fresh-install reliability fixes. (+289 lines)
+  // doctor-install-reliability review fixes: LoginShellPath enum + double-checked
+  // locking, is_safe_nvm_tag security validation, classify_probe_output helper,
+  // auth_probe_args on KnownAcpRuntime (removes probe_args_for indirection),
+  // process-level timeout replacing inner-thread pattern. (+75 lines)
+  ["src-tauri/src/managed_agents/discovery.rs", 1171],
+  // rebase over codex-acp-package-swap: its version-probe tests union with the
+  // doctor-install-reliability nvm/login-shell/semver tests — each side alone
+  // stayed under the 1000 default; the union exceeds it.
+  ["src-tauri/src/managed_agents/discovery/tests.rs", 1029],
   // identity-import-keyring: the identity resolution state machine's behavioral
   // matrix (46 tests over FakeIdentityStore — probe × marker × file cells,
   // adoption / read-back-corruption / marker-failure arms, recovery-mode
@@ -339,7 +359,9 @@ const overrides = new Map([
   // in this PR; queued to split with the command module refactor.
   // +17: baked-env-global-unify: BUZZ_AGENT_THINKING_EFFORT added to
   // is_safe_to_reveal allowlist + baked_env_thinking_effort_is_unmasked test.
-  ["src-tauri/src/commands/agent_config.rs", 1019],
+  // +1: doctor-install-reliability: login_hint: None added to goose_runtime test stub.
+  // +1: doctor-install-reliability review fixes: auth_probe_args: None added to stub.
+  ["src-tauri/src/commands/agent_config.rs", 1021],
   // draft-persistence predicate: submit-time `loadDraft` check + inline comment
   // + deps-array entry in submitMessage closes the never-persisted-boundary
   // defect (Thufir Pass-3 finding). Load-bearing correctness fix; queued to

--- a/desktop/src-tauri/src/commands/agent_config.rs
+++ b/desktop/src-tauri/src/commands/agent_config.rs
@@ -599,6 +599,8 @@ mod tests {
             max_tokens_env_var: Some("GOOSE_MAX_TOKENS"),
             context_limit_env_var: Some("GOOSE_CONTEXT_LIMIT"),
             required_normalized_fields: &["model", "provider"],
+            login_hint: None,
+            auth_probe_args: None,
         }
     }
 

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -4,9 +4,9 @@ use tauri::State;
 use crate::{
     app_state::AppState,
     managed_agents::{
-        command_availability, AcpRuntimeCatalogEntry, DiscoverManagedAgentPrereqsRequest,
-        InstallRuntimeResult, InstallStepResult, ManagedAgentPrereqsInfo, RelayAgentInfo,
-        DEFAULT_ACP_COMMAND,
+        command_availability, is_npm_global_install, AcpRuntimeCatalogEntry,
+        DiscoverManagedAgentPrereqsRequest, InstallRuntimeResult, InstallStepResult,
+        ManagedAgentPrereqsInfo, RelayAgentInfo, DEFAULT_ACP_COMMAND,
     },
     nostr_convert,
     relay::query_relay,
@@ -62,6 +62,7 @@ pub(crate) fn plan_adapter_install<'c>(
 pub async fn discover_acp_providers() -> Result<Vec<AcpRuntimeCatalogEntry>, String> {
     tokio::task::spawn_blocking(|| {
         crate::managed_agents::clear_resolve_cache();
+        crate::managed_agents::refresh_login_shell_path();
         crate::managed_agents::discover_acp_runtimes()
     })
     .await
@@ -78,6 +79,13 @@ pub async fn install_acp_runtime(runtime_id: String) -> Result<InstallRuntimeRes
 /// Err(_) = infrastructure failure (panic, concurrency guard).
 /// Ok({success: false}) = an install step failed (stderr captured in steps).
 fn install_acp_runtime_blocking(runtime_id: &str) -> Result<InstallRuntimeResult, String> {
+    // Re-fetch the login-shell PATH so a Node.js installation that happened
+    // after app launch (or after a previous failed install) is visible to this
+    // run and to the subsequent discover_acp_providers call.
+    crate::managed_agents::refresh_login_shell_path();
+    // Clear the resolve cache so newly-installed binaries are found.
+    crate::managed_agents::clear_resolve_cache();
+
     // Prevent concurrent installs for the same runtime.
     {
         let mut set = active_installs()
@@ -374,12 +382,6 @@ fn floor_char_boundary(s: &str, mut index: usize) -> usize {
 }
 
 // ── npm EACCES preflight ──────────────────────────────────────────────────────
-
-/// Returns true when `command` is an npm global install invocation.
-fn is_npm_global_install(command: &str) -> bool {
-    let t = command.trim_start();
-    t.starts_with("npm install -g ") || t.starts_with("npm i -g ")
-}
 
 /// Guidance text for the EACCES / unwritable-prefix case.
 fn npm_eacces_guidance(command: &str) -> String {

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -36,6 +36,8 @@ fn test_runtime() -> &'static KnownAcpRuntime {
         max_tokens_env_var: Some("GOOSE_MAX_TOKENS"),
         context_limit_env_var: Some("GOOSE_CONTEXT_LIMIT"),
         required_normalized_fields: &["model", "provider"],
+        login_hint: None,
+        auth_probe_args: None,
     }
 }
 
@@ -547,6 +549,8 @@ fn buzz_agent_runtime() -> &'static KnownAcpRuntime {
         max_tokens_env_var: Some("BUZZ_AGENT_MAX_OUTPUT_TOKENS"),
         context_limit_env_var: Some("BUZZ_AGENT_MAX_CONTEXT_TOKENS"),
         required_normalized_fields: &["model", "provider"],
+        login_hint: None,
+        auth_probe_args: None,
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -1,8 +1,10 @@
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 use crate::managed_agents::{
-    AcpAvailabilityStatus, AcpRuntimeCatalogEntry, CommandAvailabilityInfo,
+    AcpAvailabilityStatus, AcpRuntimeCatalogEntry, AuthStatus, CommandAvailabilityInfo,
 };
 
 pub(crate) struct KnownAcpRuntime {
@@ -56,6 +58,12 @@ pub(crate) struct KnownAcpRuntime {
     /// Used by the config bridge to mark fields as required in the UI.
     /// Keys match the camelCase names used in `NormalizedConfig` (e.g. "model", "provider").
     pub required_normalized_fields: &'static [&'static str],
+    /// Human-readable hint shown in Doctor when the runtime is available but not
+    /// authenticated. `None` for runtimes that have no login step (goose, buzz-agent).
+    pub login_hint: Option<&'static str>,
+    /// CLI args for probing authentication status. `args[0]` is the binary name;
+    /// the remainder are the subcommand. `None` for runtimes with no login step.
+    pub auth_probe_args: Option<&'static [&'static str]>,
 }
 
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
@@ -114,6 +122,8 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         max_tokens_env_var: Some("GOOSE_MAX_TOKENS"),
         context_limit_env_var: Some("GOOSE_CONTEXT_LIMIT"),
         required_normalized_fields: &["model", "provider"],
+        login_hint: None,
+        auth_probe_args: None,
     },
     KnownAcpRuntime {
         id: "claude",
@@ -142,6 +152,8 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         max_tokens_env_var: None,
         context_limit_env_var: None,
         required_normalized_fields: &[],
+        login_hint: Some("Run the Claude CLI to complete authentication."),
+        auth_probe_args: Some(&["claude", "auth", "status"]),
     },
     KnownAcpRuntime {
         id: "codex",
@@ -170,6 +182,9 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         max_tokens_env_var: None,
         context_limit_env_var: None,
         required_normalized_fields: &[],
+        login_hint: Some("Run `codex login` to authenticate."),
+        // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
+        auth_probe_args: Some(&["codex", "login", "status"]),
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -198,6 +213,8 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         max_tokens_env_var: Some("BUZZ_AGENT_MAX_OUTPUT_TOKENS"),
         context_limit_env_var: Some("BUZZ_AGENT_MAX_CONTEXT_TOKENS"),
         required_normalized_fields: &["model", "provider"],
+        login_hint: None,
+        auth_probe_args: None,
     },
 ];
 
@@ -509,6 +526,19 @@ fn resolve_command_uncached(command: &str) -> Option<PathBuf> {
         }
     }
 
+    // Check nvm's default Node.js bin directory — nvm initializes via
+    // ~/.zshrc (interactive) which is not loaded by a login shell, so
+    // `node`, `npm`, and npm-global shims installed there are otherwise
+    // invisible.
+    if let Some(home) = dirs::home_dir() {
+        if let Some(nvm_bin) = find_nvm_default_bin(&home) {
+            let candidate = nvm_bin.join(executable_basename(command));
+            if is_executable_file(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+
     None
 }
 
@@ -547,22 +577,284 @@ fn find_via_login_shell(command: &str) -> Option<PathBuf> {
     (path.is_absolute() && is_executable_file(&path)).then_some(path)
 }
 
+/// Three-state backing store for the login-shell PATH cache.
+#[derive(Clone)]
+enum LoginShellPath {
+    /// Cache has never been populated; the next call will spawn a login shell.
+    Uninit,
+    /// A login shell was invoked; the inner value is the PATH it returned
+    /// (`None` when the shell produced no output).
+    Probed(Option<String>),
+}
+
+fn path_cache() -> &'static std::sync::Mutex<LoginShellPath> {
+    use std::sync::{Mutex, OnceLock};
+    static CACHE: OnceLock<Mutex<LoginShellPath>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(LoginShellPath::Uninit))
+}
+
+fn fetch_login_shell_path_inner() -> Option<String> {
+    let stdout = run_in_login_shell(&["-l", "-c", "echo $PATH"])?;
+    let last_line = stdout.lines().rfind(|l| !l.trim().is_empty())?;
+    Some(last_line.trim().to_string())
+}
+
 /// Return the user's full PATH from a login shell.
-/// Cached via OnceLock so we only spawn one shell per app lifetime.
+///
+/// The result is cached after the first call. Call [`refresh_login_shell_path`]
+/// to invalidate the cache so the next call re-fetches — e.g. after the user
+/// installs Node.js mid-session and clicks Retry.
+///
+/// The lock is never held while the login shell spawns: we check for a cached
+/// value, release the lock, run the shell, then re-lock to write. Two concurrent
+/// callers may both run the shell (last-writer-wins is fine — both produce the
+/// same result), but neither blocks a concurrent agent spawn on the Mutex.
 pub fn login_shell_path() -> Option<String> {
-    use std::sync::OnceLock;
-    static CACHED: OnceLock<Option<String>> = OnceLock::new();
-    CACHED
-        .get_or_init(|| {
-            let stdout = run_in_login_shell(&["-l", "-c", "echo $PATH"])?;
-            let last_line = stdout.lines().rfind(|l| !l.trim().is_empty())?;
-            Some(last_line.trim().to_string())
+    // Fast path: return cached result without spawning a shell.
+    {
+        let guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
+        if let LoginShellPath::Probed(ref result) = *guard {
+            return result.clone();
+        }
+    }
+
+    // Slow path: spawn shell outside any lock.
+    let result = fetch_login_shell_path_inner();
+
+    // Write back; last-writer-wins is safe here.
+    {
+        let mut guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
+        *guard = LoginShellPath::Probed(result.clone());
+    }
+
+    result
+}
+
+/// Invalidate the login-shell PATH cache so the next [`login_shell_path`] call
+/// re-fetches from a fresh login shell.
+///
+/// Called before every install/retry operation and on Doctor Re-run so a
+/// newly-installed tool becomes visible without restarting the app.
+pub(crate) fn refresh_login_shell_path() {
+    let mut guard = path_cache().lock().unwrap_or_else(|e| e.into_inner());
+    *guard = LoginShellPath::Uninit;
+}
+
+#[cfg(test)]
+fn is_login_shell_path_uninit() -> bool {
+    matches!(
+        *path_cache().lock().unwrap_or_else(|e| e.into_inner()),
+        LoginShellPath::Uninit
+    )
+}
+
+/// Return `true` when `tag` is a safe nvm alias/version tag that can be joined
+/// onto a `PathBuf` without escaping the nvm root.
+///
+/// nvm uses tags like `v22.1.0` or `lts/hydrogen`. We allow ASCII alphanumeric
+/// plus `. - / _` and require that no path component is `..` and that the tag
+/// does not start with `/` (which would replace the base in `PathBuf::join`).
+fn is_safe_nvm_tag(tag: &str) -> bool {
+    if tag.is_empty() {
+        return false;
+    }
+    // An absolute path in the alias file would let PathBuf::join silently
+    // replace the nvm root with an attacker-controlled path.
+    if tag.starts_with('/') {
+        return false;
+    }
+    // Reject any .. component to prevent upward traversal.
+    for component in tag.split('/') {
+        if component == ".." {
+            return false;
+        }
+    }
+    // Allow only the characters nvm uses in real tag names.
+    tag.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '/' | '_'))
+}
+
+/// Locate the `bin` directory for nvm's default Node.js version.
+///
+/// Reads `~/.nvm/alias/default`; resolves at most one alias hop to handle
+/// nvm alias chains; falls back to the highest-semver directory under
+/// `~/.nvm/versions/node/`. Returns the `bin` subdirectory only when it exists.
+///
+/// Cheap: at most two file reads or one `read_dir`. Never cached — computed
+/// fresh per call so a mid-session `nvm install` is visible at the next spawn.
+pub fn find_nvm_default_bin(home: &Path) -> Option<PathBuf> {
+    let nvm_root = home.join(".nvm");
+    let versions_root = nvm_root.join("versions").join("node");
+
+    // 1. Try alias/default, with at most one hop.
+    let default_alias = nvm_root.join("alias").join("default");
+    if let Ok(content) = std::fs::read_to_string(&default_alias) {
+        let tag = content.trim().to_string();
+        if is_safe_nvm_tag(&tag) {
+            let candidate = versions_root.join(&tag).join("bin");
+            if candidate.is_dir() {
+                return Some(candidate);
+            }
+            // One alias hop: ~/.nvm/alias/<tag>
+            let hop_file = nvm_root.join("alias").join(&tag);
+            if let Ok(hop_content) = std::fs::read_to_string(&hop_file) {
+                let hop_tag = hop_content.trim().to_string();
+                if is_safe_nvm_tag(&hop_tag) {
+                    let hop_candidate = versions_root.join(&hop_tag).join("bin");
+                    if hop_candidate.is_dir() {
+                        return Some(hop_candidate);
+                    }
+                }
+            }
+        }
+    }
+
+    // 2. Fall back to highest-semver directory under ~/.nvm/versions/node/.
+    let entries = std::fs::read_dir(&versions_root).ok()?;
+    let best = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name();
+            let s = name.to_string_lossy().into_owned();
+            parse_semver_tag(&s).map(|v| (v, s))
         })
-        .clone()
+        .max_by(|(a, _), (b, _)| a.cmp(b));
+
+    let (_, tag) = best?;
+    let bin = versions_root.join(&tag).join("bin");
+    bin.is_dir().then_some(bin)
+}
+
+/// Parse a `vMAJ.MIN.PATCH` (or `vMAJ.MIN.PATCH-extra`) tag into a numeric
+/// triple for semver comparison.
+fn parse_semver_tag(s: &str) -> Option<(u64, u64, u64)> {
+    let s = s.strip_prefix('v')?;
+    let mut parts = s.splitn(3, '.');
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let minor = parts.next()?.parse::<u64>().ok()?;
+    let patch_str = parts.next()?;
+    let patch = patch_str.split('-').next()?.parse::<u64>().ok()?;
+    Some((major, minor, patch))
 }
 
 pub(crate) fn find_command(command: &str) -> Option<PathBuf> {
     resolve_command(command)
+}
+
+/// Returns true when the runtime has at least one adapter install step that
+/// is an npm global install. Used to determine whether Node.js is required.
+fn runtime_needs_npm(runtime: &KnownAcpRuntime) -> bool {
+    runtime
+        .adapter_install_commands
+        .iter()
+        .any(|cmd| is_npm_global_install(cmd))
+}
+
+/// Returns `true` when `cmd` is an `npm install -g` invocation.
+///
+/// Used by Doctor to determine whether Node.js is required before running an
+/// install step, and by the npm EACCES preflight in the install command path.
+pub(crate) fn is_npm_global_install(cmd: &str) -> bool {
+    let t = cmd.trim_start();
+    t.starts_with("npm install -g ") || t.starts_with("npm i -g ")
+}
+
+/// Run a CLI auth probe with a 10-second process-level timeout.
+///
+/// Spawns the probe CLI as a child process. Stdout and stderr are drained on
+/// background threads to prevent pipe-buffer deadlock. On timeout the child is
+/// killed and `Unknown` is returned; no orphaned threads or processes are left
+/// behind. Returns `Unknown` on timeout.
+fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
+    use crate::managed_agents::readiness::cli_probe;
+
+    let augmented_path = cli_probe::augmented_path();
+
+    let mut command = std::process::Command::new(binary_path);
+    command.args(&probe_args[1..]);
+    if let Some(ref path) = augmented_path {
+        command.env("PATH", path);
+    }
+    command
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = match command.spawn() {
+        Ok(c) => c,
+        Err(_) => return AuthStatus::Unknown,
+    };
+
+    // Drain stdout/stderr on background threads to prevent pipe-buffer deadlock.
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+
+    let stdout_thread = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut pipe) = stdout_pipe {
+            let _ = pipe.read_to_end(&mut buf);
+        }
+    });
+    let stderr_thread = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut pipe) = stderr_pipe {
+            let _ = pipe.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    // Save PID for kill-on-timeout before moving child into the wait thread.
+    let child_pid = child.id();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let wait_thread = std::thread::spawn(move || {
+        let _ = tx.send(child.wait());
+    });
+
+    // 10-second timeout for auth probes.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let exit_status = loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(child_pid as i32, libc::SIGTERM);
+            }
+            #[cfg(not(unix))]
+            let _ = child_pid;
+            drop(rx);
+            let _ = wait_thread.join();
+            let _ = stdout_thread.join();
+            let _ = stderr_thread.join();
+            return AuthStatus::Unknown;
+        }
+        match rx.recv_timeout(Duration::from_millis(100).min(remaining)) {
+            Ok(Ok(status)) => break status,
+            Ok(Err(_)) => {
+                let _ = wait_thread.join();
+                let _ = stdout_thread.join();
+                let _ = stderr_thread.join();
+                return AuthStatus::Unknown;
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                let _ = stdout_thread.join();
+                let _ = stderr_thread.join();
+                return AuthStatus::Unknown;
+            }
+        }
+    };
+
+    let _ = wait_thread.join();
+    let _ = stdout_thread.join();
+    let stderr_bytes = stderr_thread.join().unwrap_or_default();
+
+    match cli_probe::classify_probe_output(&stderr_bytes, exit_status.success()) {
+        cli_probe::ProbeOutcome::LoggedIn => AuthStatus::LoggedIn,
+        cli_probe::ProbeOutcome::LoggedOut => AuthStatus::LoggedOut,
+        cli_probe::ProbeOutcome::ConfigInvalid { stderr_excerpt } => AuthStatus::ConfigInvalid {
+            diagnostic: stderr_excerpt,
+        },
+    }
 }
 
 pub fn command_availability(command: &str) -> CommandAvailabilityInfo {
@@ -719,11 +1011,17 @@ pub(crate) fn codex_adapter_is_outdated(path: &Path) -> bool {
     codex_adapter_availability(path) == AcpAvailabilityStatus::AdapterOutdated
 }
 
+/// Intermediate struct built before the (potentially slow) auth probe phase.
+struct PartialEntry {
+    runtime: &'static KnownAcpRuntime,
+    entry: AcpRuntimeCatalogEntry,
+}
+
 pub fn discover_acp_runtimes() -> Vec<AcpRuntimeCatalogEntry> {
-    KNOWN_ACP_RUNTIMES
+    // Phase 1: build all entries (fast — no probes yet).
+    let mut partials: Vec<PartialEntry> = KNOWN_ACP_RUNTIMES
         .iter()
         .map(|runtime| {
-            // Try to find the ACP adapter binary.
             let adapter_result = runtime
                 .commands
                 .iter()
@@ -779,22 +1077,88 @@ pub fn discover_acp_runtimes() -> Vec<AcpRuntimeCatalogEntry> {
                 }
             };
 
-            AcpRuntimeCatalogEntry {
-                id: runtime.id.to_string(),
-                label: runtime.label.to_string(),
-                avatar_url: runtime.avatar_url.to_string(),
+            // node_required: an npm adapter step is pending AND node/npm are absent.
+            let node_required = matches!(
                 availability,
-                command,
-                binary_path,
-                default_args,
-                mcp_command: runtime.mcp_command.map(str::to_string),
-                install_hint,
-                install_instructions_url: runtime.install_instructions_url.to_string(),
-                can_auto_install,
-                underlying_cli_path,
+                AcpAvailabilityStatus::AdapterMissing | AcpAvailabilityStatus::NotInstalled
+            ) && runtime_needs_npm(runtime)
+                && resolve_command("npm").is_none()
+                && resolve_command("node").is_none();
+
+            PartialEntry {
+                runtime,
+                entry: AcpRuntimeCatalogEntry {
+                    id: runtime.id.to_string(),
+                    label: runtime.label.to_string(),
+                    avatar_url: runtime.avatar_url.to_string(),
+                    availability,
+                    command,
+                    binary_path,
+                    default_args,
+                    mcp_command: runtime.mcp_command.map(str::to_string),
+                    install_hint,
+                    install_instructions_url: runtime.install_instructions_url.to_string(),
+                    can_auto_install,
+                    underlying_cli_path,
+                    node_required,
+                    // Filled in by the probe phase below.
+                    auth_status: AuthStatus::Unknown,
+                    login_hint: None,
+                },
             }
         })
-        .collect()
+        .collect();
+
+    // Phase 2: run auth probes in parallel for entries that need them.
+    // Spawn one thread per probeable entry; total cost = max(probe latency).
+    let probe_handles: Vec<(usize, std::thread::JoinHandle<AuthStatus>)> = partials
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, partial)| {
+            if partial.entry.availability != AcpAvailabilityStatus::Available {
+                return None;
+            }
+            let probe_args = partial.runtime.auth_probe_args?;
+            // Need the resolved binary path for the CLI (e.g. the actual `claude` binary).
+            let binary_path = resolve_command(probe_args[0])?;
+            let probe_args_owned: Vec<String> = probe_args.iter().map(|s| s.to_string()).collect();
+
+            let handle = std::thread::spawn(move || {
+                let refs: Vec<&str> = probe_args_owned.iter().map(String::as_str).collect();
+                probe_auth_status(&binary_path, &refs)
+            });
+            Some((idx, handle))
+        })
+        .collect();
+
+    // Collect probe results and patch entries.
+    for (idx, handle) in probe_handles {
+        let status = handle.join().unwrap_or(AuthStatus::Unknown);
+        let partial = &mut partials[idx];
+        partial.entry.login_hint =
+            if matches!(status, AuthStatus::LoggedIn | AuthStatus::NotApplicable) {
+                None
+            } else {
+                partial.runtime.login_hint.map(str::to_string)
+            };
+        partial.entry.auth_status = status;
+    }
+
+    // Fill NotApplicable / Unknown for non-probed entries.
+    for partial in &mut partials {
+        if partial.entry.auth_status == AuthStatus::Unknown {
+            partial.entry.auth_status = if partial.entry.availability
+                == AcpAvailabilityStatus::Available
+                && partial.runtime.auth_probe_args.is_none()
+            {
+                AuthStatus::NotApplicable
+            } else {
+                AuthStatus::Unknown
+            };
+        }
+    }
+
+    partials.into_iter().map(|p| p.entry).collect()
 }
 
 pub fn managed_agent_avatar_url(command: &str) -> Option<String> {

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -4,9 +4,11 @@ use super::overrides::{divergent_agent_command_override, update_time_agent_comma
 use super::{
     apply_agent_command_update, classify_runtime, codex_adapter_availability,
     codex_adapter_is_outdated, create_time_agent_command_override, default_agent_command,
-    effective_agent_command, find_via_login_shell, managed_agent_avatar_url, normalize_agent_args,
-    probe_codex_acp_major_version, record_agent_command, BUZZ_AGENT_AVATAR_URL,
-    CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL, GOOSE_AVATAR_URL,
+    effective_agent_command, find_nvm_default_bin, find_via_login_shell,
+    is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
+    parse_semver_tag, probe_codex_acp_major_version, record_agent_command,
+    refresh_login_shell_path, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
+    GOOSE_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -805,4 +807,222 @@ fn probe_codex_acp_major_version_returns_version_when_descendant_holds_pipe_open
         Some(1),
         "1.x version must be parsed even when descendant holds pipe open"
     );
+}
+
+// ── parse_semver_tag ──────────────────────────────────────────────────────────
+
+#[test]
+fn parse_semver_tag_accepts_plain_version() {
+    assert_eq!(parse_semver_tag("v20.11.1"), Some((20, 11, 1)));
+}
+
+#[test]
+fn parse_semver_tag_accepts_prerelease_suffix() {
+    assert_eq!(parse_semver_tag("v18.0.0-rc1"), Some((18, 0, 0)));
+}
+
+#[test]
+fn parse_semver_tag_rejects_missing_v_prefix() {
+    assert_eq!(parse_semver_tag("20.11.1"), None);
+}
+
+#[test]
+fn parse_semver_tag_rejects_non_numeric() {
+    assert_eq!(parse_semver_tag("vX.Y.Z"), None);
+}
+
+#[test]
+fn semver_ordering_chooses_highest() {
+    let mut tags = [
+        parse_semver_tag("v16.0.0").unwrap(),
+        parse_semver_tag("v20.11.1").unwrap(),
+        parse_semver_tag("v18.12.0").unwrap(),
+    ];
+    tags.sort();
+    assert_eq!(tags.last(), parse_semver_tag("v20.11.1").as_ref());
+}
+
+// ── find_nvm_default_bin ──────────────────────────────────────────────────────
+
+#[cfg(unix)]
+fn make_nvm_version_dir(home: &std::path::Path, tag: &str) {
+    let bin = home.join(".nvm/versions/node").join(tag).join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+}
+
+#[cfg(unix)]
+fn write_alias(home: &std::path::Path, name: &str, content: &str) {
+    let alias_dir = home.join(".nvm/alias");
+    std::fs::create_dir_all(&alias_dir).unwrap();
+    std::fs::write(alias_dir.join(name), content).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn find_nvm_default_bin_returns_dir_from_alias_default() {
+    let home = tempfile::tempdir().unwrap();
+    make_nvm_version_dir(home.path(), "v20.11.1");
+    write_alias(home.path(), "default", "v20.11.1\n");
+
+    let result = find_nvm_default_bin(home.path());
+    assert_eq!(
+        result,
+        Some(home.path().join(".nvm/versions/node/v20.11.1/bin"))
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn find_nvm_default_bin_follows_one_alias_hop() {
+    let home = tempfile::tempdir().unwrap();
+    make_nvm_version_dir(home.path(), "v18.0.0");
+    // alias/default → "lts/hydrogen", alias/lts/hydrogen → "v18.0.0"
+    write_alias(home.path(), "default", "lts/hydrogen\n");
+    let alias_dir = home.path().join(".nvm/alias/lts");
+    std::fs::create_dir_all(&alias_dir).unwrap();
+    std::fs::write(alias_dir.join("hydrogen"), "v18.0.0\n").unwrap();
+
+    let result = find_nvm_default_bin(home.path());
+    assert_eq!(
+        result,
+        Some(home.path().join(".nvm/versions/node/v18.0.0/bin"))
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn find_nvm_default_bin_falls_back_to_highest_semver() {
+    let home = tempfile::tempdir().unwrap();
+    make_nvm_version_dir(home.path(), "v16.0.0");
+    make_nvm_version_dir(home.path(), "v20.11.1");
+    make_nvm_version_dir(home.path(), "v18.12.0");
+    // No alias/default file.
+
+    let result = find_nvm_default_bin(home.path());
+    assert_eq!(
+        result,
+        Some(home.path().join(".nvm/versions/node/v20.11.1/bin"))
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn find_nvm_default_bin_returns_none_when_nvm_absent() {
+    let home = tempfile::tempdir().unwrap();
+    // No ~/.nvm directory.
+    assert_eq!(find_nvm_default_bin(home.path()), None);
+}
+
+#[cfg(unix)]
+#[test]
+fn find_nvm_default_bin_returns_none_when_versions_dir_empty() {
+    let home = tempfile::tempdir().unwrap();
+    let versions_dir = home.path().join(".nvm/versions/node");
+    std::fs::create_dir_all(&versions_dir).unwrap();
+    assert_eq!(find_nvm_default_bin(home.path()), None);
+}
+
+// ── refresh_login_shell_path ──────────────────────────────────────────────────
+
+#[test]
+fn refresh_login_shell_path_clears_cache() {
+    // Populate the cache with a first call.
+    let before = super::login_shell_path();
+    assert!(
+        !is_login_shell_path_uninit(),
+        "cache must be Probed(…) after a login_shell_path() call"
+    );
+
+    // Refresh must reset the cache to Uninit so the next call re-fetches.
+    refresh_login_shell_path();
+    assert!(
+        is_login_shell_path_uninit(),
+        "cache must be Uninit immediately after refresh_login_shell_path()"
+    );
+
+    // Re-fetching must produce the same value (deterministic in this environment).
+    let after = super::login_shell_path();
+    assert_eq!(
+        before, after,
+        "login_shell_path must return the same value after refresh + re-fetch"
+    );
+    // And the cache is Probed again.
+    assert!(
+        !is_login_shell_path_uninit(),
+        "cache must be Probed(…) after the second login_shell_path() call"
+    );
+}
+
+// ── is_safe_nvm_tag ───────────────────────────────────────────────────────────
+
+#[test]
+fn is_safe_nvm_tag_accepts_version_tags() {
+    assert!(is_safe_nvm_tag("v20.11.1"));
+    assert!(is_safe_nvm_tag("v18.0.0-rc1"));
+    assert!(is_safe_nvm_tag("lts/hydrogen"));
+    assert!(is_safe_nvm_tag("v22.1.0"));
+}
+
+#[test]
+fn is_safe_nvm_tag_rejects_absolute_paths() {
+    assert!(!is_safe_nvm_tag("/tmp/evil"));
+    assert!(!is_safe_nvm_tag("/usr/local/bin"));
+    assert!(!is_safe_nvm_tag("/"));
+}
+
+#[test]
+fn is_safe_nvm_tag_rejects_dotdot_traversal() {
+    assert!(!is_safe_nvm_tag("../../../etc/passwd"));
+    assert!(!is_safe_nvm_tag("v20.11.1/../../../etc"));
+    assert!(!is_safe_nvm_tag(".."));
+}
+
+#[test]
+fn is_safe_nvm_tag_rejects_junk_charset() {
+    assert!(!is_safe_nvm_tag("v20.11.1; rm -rf ~"));
+    assert!(!is_safe_nvm_tag("v20.11.1\n/tmp/evil"));
+    assert!(!is_safe_nvm_tag("v20.11.1\0"));
+    assert!(!is_safe_nvm_tag("$(evil)"));
+}
+
+#[test]
+fn is_safe_nvm_tag_rejects_empty() {
+    assert!(!is_safe_nvm_tag(""));
+}
+
+// ── find_nvm_default_bin alias security ──────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+fn find_nvm_default_bin_rejects_absolute_path_alias() {
+    let home = tempfile::tempdir().unwrap();
+    // Alias points at an absolute path — PathBuf::join would replace the base.
+    write_alias(home.path(), "default", "/tmp/evil\n");
+    // Must NOT return Some("/tmp/evil/bin") — must fall through to semver scan.
+    let result = find_nvm_default_bin(home.path());
+    // No version dirs exist, so result must be None (not Some("/tmp/evil/bin")).
+    assert_eq!(result, None, "absolute-path alias must be rejected");
+}
+
+#[cfg(unix)]
+#[test]
+fn find_nvm_default_bin_rejects_dotdot_traversal_alias() {
+    let home = tempfile::tempdir().unwrap();
+    write_alias(home.path(), "default", "../../etc/passwd\n");
+    let result = find_nvm_default_bin(home.path());
+    assert_eq!(result, None, "dotdot traversal alias must be rejected");
+}
+
+#[cfg(unix)]
+#[test]
+fn find_nvm_default_bin_rejects_absolute_hop_tag() {
+    let home = tempfile::tempdir().unwrap();
+    // First hop points at a safe tag that resolves to another alias file which
+    // then contains an absolute path.
+    write_alias(home.path(), "default", "lts/testing\n");
+    let lts_dir = home.path().join(".nvm/alias/lts");
+    std::fs::create_dir_all(&lts_dir).unwrap();
+    std::fs::write(lts_dir.join("testing"), "/tmp/evil\n").unwrap();
+    let result = find_nvm_default_bin(home.path());
+    assert_eq!(result, None, "absolute-path hop tag must be rejected");
 }

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -55,7 +55,7 @@ use crate::managed_agents::{
     types::{AcpAvailabilityStatus, ManagedAgentRecord, PersonaRecord},
 };
 
-mod cli_probe;
+pub(crate) mod cli_probe;
 
 // ── EffectiveAgentEnv ─────────────────────────────────────────────────────────
 
@@ -969,6 +969,8 @@ mod tests {
             max_tokens_env_var: None,
             context_limit_env_var: None,
             required_normalized_fields: &[],
+            login_hint: None,
+            auth_probe_args: None,
         }
     }
 
@@ -1163,6 +1165,8 @@ mod tests {
             max_tokens_env_var: None,
             context_limit_env_var: None,
             required_normalized_fields: &[],
+            login_hint: None,
+            auth_probe_args: None,
         }
     }
 

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
@@ -2,19 +2,26 @@ use std::path::Path;
 
 use crate::managed_agents::runtime::build_augmented_path;
 
-pub(super) fn augmented_path() -> Option<String> {
+/// Build the augmented PATH for CLI probes, including nvm's default Node.js
+/// bin directory so `#!/usr/bin/env node` shims (e.g. codex-acp) resolve.
+pub(crate) fn augmented_path() -> Option<String> {
+    let home = dirs::home_dir();
+    let nvm_bin = home
+        .as_deref()
+        .and_then(crate::managed_agents::find_nvm_default_bin);
     build_augmented_path(
-        dirs::home_dir(),
+        home,
         std::env::current_exe()
             .ok()
             .and_then(|exe| exe.parent().map(std::path::Path::to_path_buf)),
         crate::managed_agents::login_shell_path(),
+        nvm_bin,
     )
 }
 
 /// Outcome of a CLI login-status probe.
 #[derive(Debug, PartialEq, Eq)]
-pub(super) enum ProbeOutcome {
+pub(crate) enum ProbeOutcome {
     /// The CLI reported a successful login (exit 0).
     LoggedIn,
     /// The CLI exited non-zero without a config-parse signal — treat as
@@ -44,7 +51,7 @@ const CONFIG_PARSE_SIGNALS: &[&str] = &["error loading configuration", "unknown 
 /// bypassed. Injects the same augmented PATH used for launched agents so
 /// script shims with `/usr/bin/env <interpreter>` shebangs can find runtimes
 /// such as node/python when the app was launched with a bare GUI PATH.
-pub(super) fn login_probe(
+pub(crate) fn login_probe(
     binary_path: &Path,
     probe_args: &[&str],
     augmented_path: Option<&str>,
@@ -57,22 +64,32 @@ pub(super) fn login_probe(
 
     match command.output() {
         Ok(o) if o.status.success() => ProbeOutcome::LoggedIn,
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            let stderr_lower = stderr.to_lowercase();
-            if CONFIG_PARSE_SIGNALS
-                .iter()
-                .all(|sig| stderr_lower.contains(sig))
-            {
-                let excerpt = stderr.trim().lines().next().unwrap_or("").to_string();
-                ProbeOutcome::ConfigInvalid {
-                    stderr_excerpt: excerpt,
-                }
-            } else {
-                ProbeOutcome::LoggedOut
-            }
-        }
+        Ok(o) => classify_probe_output(&o.stderr, false),
         Err(_) => ProbeOutcome::LoggedOut,
+    }
+}
+
+/// Classify collected probe output into a `ProbeOutcome`.
+///
+/// Shared between `login_probe` (which has the full `Output`) and the
+/// process-level timeout path in `probe_auth_status` (which drains stderr
+/// on a background thread and collects it separately).
+pub(crate) fn classify_probe_output(stderr_bytes: &[u8], exit_success: bool) -> ProbeOutcome {
+    if exit_success {
+        return ProbeOutcome::LoggedIn;
+    }
+    let stderr = String::from_utf8_lossy(stderr_bytes);
+    let stderr_lower = stderr.to_lowercase();
+    if CONFIG_PARSE_SIGNALS
+        .iter()
+        .all(|sig| stderr_lower.contains(sig))
+    {
+        let excerpt = stderr.trim().lines().next().unwrap_or("").to_string();
+        ProbeOutcome::ConfigInvalid {
+            stderr_excerpt: excerpt,
+        }
+    } else {
+        ProbeOutcome::LoggedOut
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1530,14 +1530,19 @@ pub fn spawn_agent_child(
 
     // Augment PATH for DMG launches so child processes can find:
     //   - bundled CLI via ~/.local/bin symlink
+    //   - nvm-managed node/npm (nvm initializes only in interactive shells)
     //   - bundled sidecars (buzz, buzz-acp, etc.) via exe parent (Contents/MacOS/)
     //   - runtimes (node, python, etc.) via login shell PATH
+    let nvm_bin = dirs::home_dir()
+        .as_deref()
+        .and_then(super::find_nvm_default_bin);
     let augmented_path = build_augmented_path(
         dirs::home_dir(),
         std::env::current_exe()
             .ok()
             .and_then(|exe| exe.parent().map(std::path::Path::to_path_buf)),
         login_shell_path(),
+        nvm_bin,
     );
 
     let mut command = std::process::Command::new(&resolved_acp_command);

--- a/desktop/src-tauri/src/managed_agents/runtime/path.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/path.rs
@@ -4,10 +4,11 @@ use std::path::PathBuf;
 
 /// Assemble the augmented `PATH` for a launched managed-agent child process.
 ///
-/// Concatenates, in priority order: `<home>/.local/bin` (the bundled CLI
-/// symlink), the running executable's parent dir (DMG sidecars under
-/// `Contents/MacOS/`), and the user's login-shell `PATH` (runtimes like
-/// node/python).
+/// Concatenates, in priority order:
+///   1. `<home>/.local/bin` — bundled CLI symlink
+///   2. `nvm_bin` — nvm's default Node.js bin dir (if the user uses nvm)
+///   3. exe parent dir — DMG sidecars under `Contents/MacOS/`
+///   4. user's login-shell `PATH` — runtimes like node/python from other managers
 ///
 /// `shell_path` is the raw colon-delimited string from a login shell, so it is
 /// split into individual entries before joining. Pushing it as a single segment
@@ -19,10 +20,14 @@ pub(in crate::managed_agents) fn build_augmented_path(
     home: Option<PathBuf>,
     exe_parent: Option<PathBuf>,
     shell_path: Option<String>,
+    nvm_bin: Option<PathBuf>,
 ) -> Option<String> {
     let mut parts: Vec<PathBuf> = Vec::new();
     if let Some(home) = home {
         parts.push(home.join(".local").join("bin"));
+    }
+    if let Some(nvm_bin) = nvm_bin {
+        parts.push(nvm_bin);
     }
     if let Some(parent) = exe_parent {
         parts.push(parent);
@@ -55,6 +60,7 @@ mod tests {
             Some(PathBuf::from("/home/agent")),
             Some(PathBuf::from("/Applications/Buzz.app/Contents/MacOS")),
             Some("/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin".to_string()),
+            None,
         );
         assert_eq!(
             result.as_deref(),
@@ -67,13 +73,48 @@ mod tests {
 
     #[test]
     fn none_when_no_inputs() {
-        assert_eq!(build_augmented_path(None, None, None), None);
+        assert_eq!(build_augmented_path(None, None, None, None), None);
     }
 
     #[cfg(unix)]
     #[test]
     fn shell_path_only() {
-        let result = build_augmented_path(None, None, Some("/usr/bin:/bin".to_string()));
+        let result = build_augmented_path(None, None, Some("/usr/bin:/bin".to_string()), None);
         assert_eq!(result.as_deref(), Some("/usr/bin:/bin"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nvm_bin_inserted_after_local_bin_before_exe_parent() {
+        let result = build_augmented_path(
+            Some(PathBuf::from("/home/user")),
+            Some(PathBuf::from("/Applications/Buzz.app/Contents/MacOS")),
+            Some("/usr/bin:/bin".to_string()),
+            Some(PathBuf::from("/home/user/.nvm/versions/node/v20.0.0/bin")),
+        );
+        assert_eq!(
+            result.as_deref(),
+            Some(
+                "/home/user/.local/bin:\
+/home/user/.nvm/versions/node/v20.0.0/bin:\
+/Applications/Buzz.app/Contents/MacOS:\
+/usr/bin:/bin"
+            ),
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nvm_bin_none_does_not_add_segment() {
+        let result = build_augmented_path(
+            Some(PathBuf::from("/home/user")),
+            Some(PathBuf::from("/usr/local/bin")),
+            None,
+            None,
+        );
+        assert_eq!(
+            result.as_deref(),
+            Some("/home/user/.local/bin:/usr/local/bin"),
+        );
     }
 }

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -536,6 +536,28 @@ pub enum AcpAvailabilityStatus {
     NotInstalled,
 }
 
+/// Authentication/login status for a CLI-based ACP runtime.
+///
+/// Serializes as a tagged union `{ status: "...", diagnostic?: "..." }` so
+/// the TypeScript side can exhaustively switch on `status`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum AuthStatus {
+    /// The CLI reported a successful login.
+    LoggedIn,
+    /// The CLI exited non-zero without a config-parse signal.
+    LoggedOut,
+    /// The CLI exited non-zero and its stderr contains a config-parse error.
+    ConfigInvalid {
+        /// Trimmed excerpt of the stderr message.
+        diagnostic: String,
+    },
+    /// This runtime does not have a login step (e.g. goose, buzz-agent).
+    NotApplicable,
+    /// Probe was not attempted (runtime unavailable or probe timed out).
+    Unknown,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AcpRuntimeCatalogEntry {
     pub id: String,
@@ -551,6 +573,14 @@ pub struct AcpRuntimeCatalogEntry {
     /// true when at least one automated install step is available
     pub can_auto_install: bool,
     pub underlying_cli_path: Option<String>,
+    /// true when an npm adapter step is pending but Node.js / npm is absent.
+    /// The UI hides the Install button and shows a Node.js install callout.
+    pub node_required: bool,
+    /// Login/authentication status for CLI-based runtimes.
+    pub auth_status: AuthStatus,
+    /// Hint for completing authentication, shown when `auth_status` is not `logged_in`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub login_hint: Option<String>,
 }
 
 /// Result of a single install step (CLI or adapter).

--- a/desktop/src/features/settings/ui/DoctorSettingsPanel.tsx
+++ b/desktop/src/features/settings/ui/DoctorSettingsPanel.tsx
@@ -6,6 +6,7 @@ import {
   Download,
   ExternalLink,
   RefreshCw,
+  XCircle,
 } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
@@ -14,7 +15,7 @@ import {
   useInstallAcpRuntimeMutation,
 } from "@/features/agents/hooks";
 import { describeResolvedCommand } from "@/features/agents/ui/agentUi";
-import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
+import type { AcpRuntimeCatalogEntry, AuthStatus } from "@/shared/api/types";
 import { getInstallErrorMessage } from "@/shared/lib/installError";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
@@ -40,18 +41,51 @@ function StatusIcon({
   }
 }
 
+function AuthStatusBadge({ authStatus }: { authStatus: AuthStatus }) {
+  switch (authStatus.status) {
+    case "logged_in":
+      return (
+        <span className="inline-flex items-center gap-1 text-xs text-status-added">
+          <CheckCircle2 className="h-3 w-3" />
+          Authenticated
+        </span>
+      );
+    case "logged_out":
+      return (
+        <span className="inline-flex items-center gap-1 text-xs text-warning">
+          <AlertTriangle className="h-3 w-3" />
+          Not authenticated
+        </span>
+      );
+    case "config_invalid":
+      return (
+        <span className="inline-flex items-center gap-1 text-xs text-destructive">
+          <XCircle className="h-3 w-3" />
+          Config error
+        </span>
+      );
+    case "not_applicable":
+    case "unknown":
+      return null;
+  }
+}
+
 function InstallActions({
+  hasError,
   isInstalling,
   onInstall,
   runtime,
 }: {
+  hasError: boolean;
   isInstalling: boolean;
   onInstall: () => void;
   runtime: AcpRuntimeCatalogEntry;
 }) {
+  const showInstall = runtime.canAutoInstall && !runtime.nodeRequired;
+
   return (
     <div className="mt-2 flex items-center gap-2">
-      {runtime.canAutoInstall ? (
+      {showInstall ? (
         <Button
           disabled={isInstalling}
           onClick={onInstall}
@@ -61,10 +95,12 @@ function InstallActions({
         >
           {isInstalling ? (
             <RefreshCw className="h-4 w-4 animate-spin" />
+          ) : hasError ? (
+            <RefreshCw className="h-4 w-4" />
           ) : (
             <Download className="h-4 w-4" />
           )}
-          {isInstalling ? "Installing..." : "Install"}
+          {isInstalling ? "Installing..." : hasError ? "Retry" : "Install"}
         </Button>
       ) : null}
       <button
@@ -76,6 +112,48 @@ function InstallActions({
         View instructions
       </button>
     </div>
+  );
+}
+
+/**
+ * Node.js callout when required, or the install actions when it is not.
+ * Used for both `adapter_missing` and `not_installed` availability states.
+ * The `cli_missing` branch is intentionally excluded — its install path does
+ * not involve npm, so no Node.js gate applies.
+ */
+function NodeRequiredOrInstall({
+  hasError,
+  isInstalling,
+  onInstall,
+  runtime,
+}: {
+  hasError: boolean;
+  isInstalling: boolean;
+  onInstall: () => void;
+  runtime: AcpRuntimeCatalogEntry;
+}) {
+  if (runtime.nodeRequired) {
+    return (
+      <p className="mt-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-sm text-amber-700 dark:text-amber-400">
+        Node.js is required to install this adapter.{" "}
+        <button
+          className="underline underline-offset-2 hover:no-underline"
+          onClick={() => void openUrl("https://nodejs.org")}
+          type="button"
+        >
+          Install Node.js
+        </button>
+        , then click Re-run.
+      </p>
+    );
+  }
+  return (
+    <InstallActions
+      hasError={hasError}
+      isInstalling={isInstalling}
+      onInstall={onInstall}
+      runtime={runtime}
+    />
   );
 }
 
@@ -158,6 +236,27 @@ function RuntimeRow({
                 </p>
               </>
             )}
+            {/*
+             * Auth badge renders only for `available` runtimes: non-available
+             * entries always have auth_status: unknown (no probe was run), which
+             * AuthStatusBadge maps to null. Rendering it here is self-consistent.
+             */}
+            {runtime.authStatus.status !== "not_applicable" &&
+            runtime.authStatus.status !== "unknown" ? (
+              <div className="mt-2">
+                <AuthStatusBadge authStatus={runtime.authStatus} />
+              </div>
+            ) : null}
+            {/* Login hint shown when not logged in or the config is invalid */}
+            {runtime.loginHint &&
+            runtime.authStatus.status !== "not_applicable" &&
+            runtime.authStatus.status !== "unknown" ? (
+              <p className="mt-1 text-sm text-muted-foreground">
+                {runtime.authStatus.status === "config_invalid"
+                  ? `Config error: ${runtime.authStatus.diagnostic}`
+                  : runtime.loginHint}
+              </p>
+            ) : null}
           </>
         ) : runtime.availability === "adapter_missing" ? (
           <>
@@ -171,7 +270,8 @@ function RuntimeRow({
             <p className="mt-1 text-sm font-normal text-muted-foreground">
               {runtime.installHint}
             </p>
-            <InstallActions
+            <NodeRequiredOrInstall
+              hasError={installError !== null}
               isInstalling={isInstalling}
               onInstall={onInstall}
               runtime={runtime}
@@ -203,6 +303,7 @@ function RuntimeRow({
               {runtime.installHint}
             </p>
             <InstallActions
+              hasError={installError !== null}
               isInstalling={isInstalling}
               onInstall={onInstall}
               runtime={runtime}
@@ -221,6 +322,7 @@ function RuntimeRow({
               {runtime.installHint}
             </p>
             <InstallActions
+              hasError={installError !== null}
               isInstalling={isInstalling}
               onInstall={onInstall}
               runtime={runtime}
@@ -234,7 +336,8 @@ function RuntimeRow({
             <p className="mt-1 text-sm font-normal text-muted-foreground">
               {runtime.installHint}
             </p>
-            <InstallActions
+            <NodeRequiredOrInstall
+              hasError={installError !== null}
               isInstalling={isInstalling}
               onInstall={onInstall}
               runtime={runtime}
@@ -265,12 +368,20 @@ export function DoctorSettingsPanel() {
   const [installResults, setInstallResults] = React.useState<
     Record<string, { success: boolean; error: string | null }>
   >({});
+  // Per-runtime installing state: tracks which runtime IDs have an in-flight
+  // install so concurrent installs each show their own spinner correctly.
+  const [installingIds, setInstallingIds] = React.useState<Set<string>>(
+    new Set(),
+  );
 
   function handleInstall(runtimeId: string) {
+    // Clear any previous result for this runtime before retrying.
     setInstallResults((prev) => ({
       ...prev,
       [runtimeId]: { success: false, error: null },
     }));
+    setInstallingIds((prev) => new Set(prev).add(runtimeId));
+
     installMutation.mutate(runtimeId, {
       onSuccess: (result) => {
         if (result.success) {
@@ -296,6 +407,13 @@ export function DoctorSettingsPanel() {
             error: error instanceof Error ? error.message : "Install failed.",
           },
         }));
+      },
+      onSettled: () => {
+        setInstallingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(runtimeId);
+          return next;
+        });
       },
     });
   }
@@ -343,10 +461,7 @@ export function DoctorSettingsPanel() {
               <RuntimeRow
                 installError={installResults[runtime.id]?.error ?? null}
                 installSuccess={installResults[runtime.id]?.success ?? false}
-                isInstalling={
-                  installMutation.isPending &&
-                  installMutation.variables === runtime.id
-                }
+                isInstalling={installingIds.has(runtime.id)}
                 key={runtime.id}
                 onInstall={() => handleInstall(runtime.id)}
                 runtime={runtime}

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -37,6 +37,7 @@ import type {
   UpdateManagedAgentInput,
   AcpAvailabilityStatus,
   AcpRuntimeCatalogEntry,
+  AuthStatus,
   CommandAvailability,
   InstallRuntimeResult,
   OpenDmInput,
@@ -228,6 +229,10 @@ export type RawAcpRuntimeCatalogEntry = {
   install_instructions_url: string;
   can_auto_install: boolean;
   underlying_cli_path: string | null;
+  node_required: boolean;
+  /** Tagged union with snake_case status values — same shape as `AuthStatus`. */
+  auth_status: AuthStatus;
+  login_hint?: string;
 };
 
 export type RawInstallStepResult = {
@@ -896,6 +901,9 @@ function fromRawAcpRuntimeCatalogEntry(
     installInstructionsUrl: entry.install_instructions_url,
     canAutoInstall: entry.can_auto_install,
     underlyingCliPath: entry.underlying_cli_path,
+    nodeRequired: entry.node_required,
+    authStatus: entry.auth_status,
+    loginHint: entry.login_hint ?? null,
   };
 }
 

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -550,6 +550,14 @@ export type AcpAvailabilityStatus =
   | "cli_missing"
   | "not_installed";
 
+/** Authentication/login status for a CLI-based ACP runtime. */
+export type AuthStatus =
+  | { status: "logged_in" }
+  | { status: "logged_out" }
+  | { status: "config_invalid"; diagnostic: string }
+  | { status: "not_applicable" }
+  | { status: "unknown" };
+
 export type AcpRuntimeCatalogEntry = {
   id: string;
   label: string;
@@ -563,6 +571,12 @@ export type AcpRuntimeCatalogEntry = {
   installInstructionsUrl: string;
   canAutoInstall: boolean;
   underlyingCliPath: string | null;
+  /** True when an npm adapter step is pending but Node.js / npm is absent. */
+  nodeRequired: boolean;
+  /** Login/auth status for CLI-based runtimes. */
+  authStatus: AuthStatus;
+  /** Hint for completing authentication; null when not applicable or already logged in. */
+  loginHint: string | null;
 };
 
 /** An AcpRuntimeCatalogEntry that is confirmed available — command and binaryPath are non-null. */

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -109,6 +109,10 @@ type E2eConfig = {
     acpRuntimesCatalog?: RawAcpRuntimeCatalogEntry[];
     activePersonaIds?: string[];
     installAcpRuntimeResult?: RawInstallRuntimeResult;
+    /** Sequence of results for successive `install_acp_runtime` calls.
+     *  Call N returns results[N]; when exhausted the last entry repeats.
+     *  Takes precedence over `installAcpRuntimeResult`. */
+    installAcpRuntimeResults?: RawInstallRuntimeResult[];
     managedAgentPrereqs?: {
       acp?: MockCommandAvailability;
       mcp?: MockCommandAvailability;
@@ -6130,6 +6134,9 @@ async function handleDiscoverAcpRuntimes(
       install_instructions_url: "https://block.github.io/goose/",
       can_auto_install: true,
       underlying_cli_path: null,
+      node_required: false,
+      auth_status: { status: "not_applicable" },
+      login_hint: undefined,
     },
     {
       id: "claude",
@@ -6145,6 +6152,9 @@ async function handleDiscoverAcpRuntimes(
         "https://www.npmjs.com/package/@anthropic-ai/claude-agent-acp",
       can_auto_install: true,
       underlying_cli_path: "/usr/local/bin/claude",
+      node_required: false,
+      auth_status: { status: "unknown" },
+      login_hint: undefined,
     },
     {
       id: "codex",
@@ -6160,6 +6170,9 @@ async function handleDiscoverAcpRuntimes(
       install_instructions_url: "https://github.com/openai/codex",
       can_auto_install: false,
       underlying_cli_path: null,
+      node_required: false,
+      auth_status: { status: "unknown" },
+      login_hint: undefined,
     },
     {
       id: "buzz-agent",
@@ -6174,9 +6187,16 @@ async function handleDiscoverAcpRuntimes(
       install_instructions_url: "https://github.com/block/buzz",
       can_auto_install: false,
       underlying_cli_path: null,
+      node_required: false,
+      auth_status: { status: "not_applicable" },
+      login_hint: undefined,
     },
   ];
 }
+
+// Per-page install call counter. Reset each test run because this module is
+// re-evaluated via addInitScript, so the counter starts at 0 for every test.
+let installCallCount = 0;
 
 async function handleInstallAcpRuntime(
   args: {
@@ -6184,6 +6204,12 @@ async function handleInstallAcpRuntime(
   },
   config: E2eConfig | undefined,
 ): Promise<RawInstallRuntimeResult> {
+  const sequence = config?.mock?.installAcpRuntimeResults;
+  if (sequence && sequence.length > 0) {
+    const idx = Math.min(installCallCount, sequence.length - 1);
+    installCallCount++;
+    return sequence[idx];
+  }
   const configured = config?.mock?.installAcpRuntimeResult;
   if (configured) {
     return configured;

--- a/desktop/tests/e2e/doctor-states.spec.ts
+++ b/desktop/tests/e2e/doctor-states.spec.ts
@@ -1,0 +1,331 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
+import { openSettings } from "../helpers/settings";
+
+const SHOTS = "test-results/screenshots-doctor";
+
+// ── Shared catalog fixture data ───────────────────────────────────────────────
+
+/**
+ * A goose runtime that is available and needs no auth step — used as a neutral
+ * backdrop so the Doctor panel has realistic content beyond the row under test.
+ */
+const GOOSE_AVAILABLE = {
+  id: "goose",
+  label: "Goose",
+  avatar_url: "",
+  availability: "available",
+  command: "goose",
+  binary_path: "/usr/local/bin/goose",
+  default_args: ["acp"],
+  mcp_command: null,
+  install_hint: "",
+  install_instructions_url: "https://block.github.io/goose/",
+  can_auto_install: false,
+  underlying_cli_path: null,
+  node_required: false,
+  auth_status: { status: "not_applicable" },
+};
+
+/** buzz-agent is always available and has no auth step. */
+const BUZZ_AGENT_AVAILABLE = {
+  id: "buzz-agent",
+  label: "Buzz Agent",
+  avatar_url: "",
+  availability: "available",
+  command: "buzz-agent",
+  binary_path: "/usr/local/bin/buzz-agent",
+  default_args: [],
+  mcp_command: "buzz-dev-mcp",
+  install_hint: "",
+  install_instructions_url: "https://github.com/block/buzz",
+  can_auto_install: false,
+  underlying_cli_path: null,
+  node_required: false,
+  auth_status: { status: "not_applicable" },
+};
+
+/**
+ * Claude available and logged in — used as a neutral entry when claude is not
+ * the runtime under test, and as the base for the auth states being tested.
+ */
+const CLAUDE_AVAILABLE_LOGGED_IN = {
+  id: "claude",
+  label: "Claude Code",
+  avatar_url: "",
+  availability: "available",
+  command: "claude-agent-acp",
+  binary_path: "/usr/local/bin/claude-agent-acp",
+  default_args: [],
+  mcp_command: null,
+  install_hint: "",
+  install_instructions_url:
+    "https://github.com/agentclientprotocol/claude-agent-acp",
+  can_auto_install: true,
+  underlying_cli_path: "/usr/local/bin/claude",
+  node_required: false,
+  auth_status: { status: "logged_in" },
+};
+
+/**
+ * Codex not-installed base — tweak `availability`, `auth_status`, and
+ * `node_required` in each test as needed.
+ */
+const CODEX_NOT_INSTALLED = {
+  id: "codex",
+  label: "Codex",
+  avatar_url: "",
+  availability: "not_installed",
+  command: null,
+  binary_path: null,
+  default_args: [],
+  mcp_command: null,
+  install_hint: "Install the Codex CLI, then install the ACP adapter via npm.",
+  install_instructions_url: "https://github.com/zed-industries/codex-acp",
+  can_auto_install: true,
+  underlying_cli_path: null,
+  node_required: false,
+  auth_status: { status: "unknown" },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe("Doctor panel state screenshots", () => {
+  test.use({ viewport: { width: 1280, height: 720 } });
+
+  test.beforeEach(async ({ page }) => {
+    page.on("pageerror", (err) => {
+      console.error(
+        "PAGE ERROR:",
+        err.message,
+        err.stack?.split("\n").slice(0, 3).join("\n"),
+      );
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        console.error("CONSOLE ERROR:", msg.text().slice(0, 300));
+      }
+    });
+  });
+
+  /**
+   * 01 — available runtime that passed the auth probe: green "Authenticated"
+   * badge appears below the binary path.
+   */
+  test("01-auth-logged-in", async ({ page }) => {
+    await installMockBridge(page, {
+      acpRuntimesCatalog: [
+        GOOSE_AVAILABLE,
+        CLAUDE_AVAILABLE_LOGGED_IN,
+        CODEX_NOT_INSTALLED,
+        BUZZ_AGENT_AVAILABLE,
+      ],
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await openSettings(page, "doctor");
+
+    const row = page.getByTestId("doctor-runtime-claude");
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row).toContainText("Authenticated");
+
+    await row.scrollIntoViewIfNeeded();
+    await waitForAnimations(page);
+    await row.screenshot({ path: `${SHOTS}/01-auth-logged-in.png` });
+  });
+
+  /**
+   * 02 — available runtime that failed the auth probe: amber "Not
+   * authenticated" badge + login hint shown below the binary path.
+   */
+  test("02-auth-logged-out", async ({ page }) => {
+    await installMockBridge(page, {
+      acpRuntimesCatalog: [
+        GOOSE_AVAILABLE,
+        CLAUDE_AVAILABLE_LOGGED_IN,
+        {
+          ...CODEX_NOT_INSTALLED,
+          availability: "available",
+          command: "codex-acp",
+          binary_path: "/usr/local/bin/codex-acp",
+          underlying_cli_path: "/usr/local/bin/codex",
+          auth_status: { status: "logged_out" },
+          login_hint: "Run `codex login` to authenticate.",
+        },
+        BUZZ_AGENT_AVAILABLE,
+      ],
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await openSettings(page, "doctor");
+
+    const row = page.getByTestId("doctor-runtime-codex");
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row).toContainText("Not authenticated");
+    await expect(row).toContainText("Run `codex login` to authenticate.");
+
+    await row.scrollIntoViewIfNeeded();
+    await waitForAnimations(page);
+    await row.screenshot({ path: `${SHOTS}/02-auth-logged-out.png` });
+  });
+
+  /**
+   * 03 — available runtime whose CLI has a config-parse error: red "Config
+   * error" badge + diagnostic excerpt shown below the binary path.
+   */
+  test("03-auth-config-error", async ({ page }) => {
+    const diagnostic =
+      "error loading configuration: ~/.claude/settings.json: unknown key foo";
+    await installMockBridge(page, {
+      acpRuntimesCatalog: [
+        GOOSE_AVAILABLE,
+        {
+          ...CLAUDE_AVAILABLE_LOGGED_IN,
+          auth_status: { status: "config_invalid", diagnostic },
+          login_hint: "Run the Claude CLI to complete authentication.",
+        },
+        CODEX_NOT_INSTALLED,
+        BUZZ_AGENT_AVAILABLE,
+      ],
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await openSettings(page, "doctor");
+
+    const row = page.getByTestId("doctor-runtime-claude");
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row).toContainText("Config error");
+    await expect(row).toContainText("error loading configuration");
+
+    await row.scrollIntoViewIfNeeded();
+    await waitForAnimations(page);
+    await row.screenshot({ path: `${SHOTS}/03-auth-config-error.png` });
+  });
+
+  /**
+   * 04 — adapter_missing runtime with node_required: true: the amber "Node.js
+   * is required…" callout replaces the Install button so the user cannot
+   * inadvertently trigger a doomed npm install.
+   */
+  test("04-node-required", async ({ page }) => {
+    await installMockBridge(page, {
+      acpRuntimesCatalog: [
+        GOOSE_AVAILABLE,
+        CLAUDE_AVAILABLE_LOGGED_IN,
+        {
+          ...CODEX_NOT_INSTALLED,
+          availability: "adapter_missing",
+          underlying_cli_path: "/usr/local/bin/codex",
+          node_required: true,
+          install_hint:
+            "Install the Codex ACP adapter: npm install -g @zed-industries/codex-acp",
+        },
+        BUZZ_AGENT_AVAILABLE,
+      ],
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await openSettings(page, "doctor");
+
+    const row = page.getByTestId("doctor-runtime-codex");
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row).toContainText("Node.js is required");
+    // Exact-name match so "Install Node.js" (inside the callout) is not counted.
+    await expect(
+      row.getByRole("button", { name: "Install", exact: true }),
+    ).toHaveCount(0);
+
+    await row.scrollIntoViewIfNeeded();
+    await waitForAnimations(page);
+    await row.screenshot({ path: `${SHOTS}/04-node-required.png` });
+  });
+
+  /**
+   * 05 — a failed install renders a "Retry" button; clicking Retry succeeds.
+   *
+   * The mock is configured with a two-call sequence:
+   *   call 1 → failure (E404)
+   *   call 2 → success
+   * This exercises the full Retry UX path: fail state → click Retry →
+   * spinner → success banner.
+   */
+  test("05-retry-after-failure", async ({ page }) => {
+    await installMockBridge(page, {
+      acpRuntimesCatalog: [
+        GOOSE_AVAILABLE,
+        CLAUDE_AVAILABLE_LOGGED_IN,
+        {
+          ...CODEX_NOT_INSTALLED,
+          can_auto_install: true,
+          node_required: false,
+        },
+        BUZZ_AGENT_AVAILABLE,
+      ],
+      installAcpRuntimeResults: [
+        {
+          success: false,
+          steps: [
+            {
+              step: "adapter",
+              command: "npm install -g @zed-industries/codex-acp",
+              success: false,
+              stdout: "",
+              stderr: "npm ERR! code E404\nnpm ERR! 404 Not Found",
+              exit_code: 1,
+            },
+          ],
+        },
+        {
+          success: true,
+          steps: [
+            {
+              step: "adapter",
+              command: "npm install -g @zed-industries/codex-acp",
+              success: true,
+              stdout: "added 1 package",
+              stderr: "",
+              exit_code: 0,
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await openSettings(page, "doctor");
+
+    const row = page.getByTestId("doctor-runtime-codex");
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    // Trigger the first install — the mock returns a failure.
+    const installBtn = row.getByRole("button", { name: "Install" });
+    await expect(installBtn).toBeVisible({ timeout: 5_000 });
+    await installBtn.click();
+
+    // After failure: Retry button appears and the error message is visible.
+    const retryBtn = row.getByRole("button", { name: "Retry" });
+    await expect(retryBtn).toBeVisible({ timeout: 5_000 });
+    await expect(row).toContainText("Step");
+    await expect(row).toContainText("failed");
+
+    await row.scrollIntoViewIfNeeded();
+    await waitForAnimations(page);
+    await row.screenshot({ path: `${SHOTS}/05-retry-after-failure.png` });
+
+    // Click Retry — the mock returns success on the second call.
+    await retryBtn.click();
+
+    // Error paragraph must disappear and per-runtime spinner must appear,
+    // then the success banner must render.
+    await expect(row).not.toContainText("failed", { timeout: 5_000 });
+    await expect(row.getByText("Installed successfully!")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await row.scrollIntoViewIfNeeded();
+    await waitForAnimations(page);
+    await row.screenshot({ path: `${SHOTS}/05-retry-success.png` });
+  });
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -107,6 +107,35 @@ export type MockAgentMemoryListing = {
 
 type MockBridgeOptions = {
   acpRuntimesCatalog?: Record<string, unknown>[];
+  /** Override the result returned by the `install_acp_runtime` mock command.
+   *  Pass `{ success: false, steps: [...] }` to exercise error/Retry states. */
+  installAcpRuntimeResult?: {
+    success: boolean;
+    steps: {
+      step: string;
+      command: string;
+      success: boolean;
+      stdout: string;
+      stderr: string;
+      exit_code: number | null;
+      hint?: string;
+    }[];
+  };
+  /** Sequence of results for successive `install_acp_runtime` calls. Call N
+   *  returns results[N]; when exhausted the last entry repeats. Takes precedence
+   *  over `installAcpRuntimeResult`. Use for fail-then-succeed Retry tests. */
+  installAcpRuntimeResults?: Array<{
+    success: boolean;
+    steps: {
+      step: string;
+      command: string;
+      success: boolean;
+      stdout: string;
+      stderr: string;
+      exit_code: number | null;
+      hint?: string;
+    }[];
+  }>;
   activePersonaIds?: string[];
   /**
    * Listing returned by the mocked `get_agent_memory` command. Pass a single


### PR DESCRIPTION
Stack: this PR → #1767

Fixes the Doctor (harness install) failures hit on a fresh Mac with no dev tools (OSS desktop build):

- **Installs are retryable without restarting the app.** The login-shell `PATH` was cached in a `OnceLock` for the app's lifetime, so installing Node.js after a failed install could never help until relaunch. The cache is now a refreshable three-state `LoginShellPath` enum — every install/retry and Doctor Re-run re-fetches it (`refresh_login_shell_path()`), the login shell spawns outside the cache lock so a concurrent agent spawn never blocks on it, and failed install rows show a Retry button with the error kept visible until retried.
- **nvm-managed Node.js is found, with alias content validated.** nvm initializes in `~/.zshrc` (interactive shells only), so login shells never see it and `codex-acp`-style `#!/usr/bin/env node` shims failed at launch with `env: node: No such file or directory`. Command resolution, CLI probes, and the agent-spawn `PATH` now include nvm's default version bin dir (`find_nvm_default_bin`: reads `alias/default` with one alias hop, falling back to the highest installed version under `~/.nvm/versions/node/`). Alias tags are validated before any path join (`is_safe_nvm_tag` rejects absolute paths, `..` traversal, and non-nvm characters) — `PathBuf::join` replaces its base when handed an absolute path, so an unvalidated `~/.nvm/alias/default` could otherwise steer the agent-spawn `PATH` to arbitrary binaries.
- **Missing Node.js is surfaced up front.** When an adapter needs `npm install -g` but neither `node` nor `npm` resolves, the runtime row hides the Install button and shows a "Node.js is required" callout linking to nodejs.org (a shared `NodeRequiredOrInstall` component backs both the `adapter_missing` and `not_installed` states), instead of failing mid-install with `zsh:1: command not found: npm`.
- **Concurrent installs each keep their own spinner.** Install progress was derived from the shared mutation's last `variables`, so starting a second install stopped the first's spinner (backend installs already ran concurrently). Progress is now tracked per runtime id.
- **Doctor shows CLI auth status.** Available claude/codex runtimes are probed (`claude auth status` / `codex login status`, declared per runtime via `auth_probe_args` on `KnownAcpRuntime`) and render "Authenticated", "Not authenticated" with a login hint, or "Config error: <diagnostic>". Probes run in parallel with a 10-second process-level timeout that kills the probe child on expiry, so a hung CLI cannot accumulate orphaned processes across Re-runs. Every discovery probes fresh — there is no result cache. Runtimes without a login step (goose, buzz-agent) show nothing.

The Doctor states (auth badges, node-required callout, retry flow) are covered by a Playwright screenshot spec (`doctor-states.spec.ts`) driving them through configurable bridge mocks, including a fail-then-succeed install sequence that exercises Retry end to end.
