### PR TITLE
fix(desktop): show thread replies loader

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -138,6 +138,7 @@ export const ChannelPane = React.memo(function ChannelPane({
   targetMessageId,
   threadHeadMessage,
   threadMessages,
+  threadMessagesPending = false,
   threadPanelWidthPx,
   threadScrollTargetId,
   threadTypingPubkeys,
@@ -831,6 +832,7 @@ export const ChannelPane = React.memo(function ChannelPane({
               threadHeadVideoReviewContext={threadHeadVideoReviewContext}
               widthPx={threadPanelWidthPx}
               threadReplies={threadMessages}
+              threadRepliesPending={threadMessagesPending}
               threadUnreadCount={threadUnreadCounts?.get(threadHeadMessage.id)}
               threadReplyUnreadCounts={threadReplyUnreadCounts}
               threadTypingPubkeys={threadTypingPubkeys}

--- a/desktop/src/features/channels/ui/ChannelPane.types.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.types.ts
@@ -137,6 +137,7 @@ export type ChannelPaneProps = {
   profilePanelView: ProfilePanelView;
   threadHeadMessage: TimelineMessage | null;
   threadMessages: MainTimelineEntry[];
+  threadMessagesPending?: boolean;
   threadPanelWidthPx: number;
   threadTypingPubkeys: string[];
   threadReplyTargetMessage: TimelineMessage | null;

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -969,6 +969,7 @@ export function ChannelScreen({
                   targetMessageId={mainTimelineTargetMessageId}
                   threadHeadMessage={displayedThreadHeadMessage}
                   threadMessages={displayedThreadMessages}
+                  threadMessagesPending={threadRepliesQuery.isPending}
                   threadPanelWidthPx={threadPanelWidthPx}
                   threadTypingPubkeys={threadTypingPubkeys}
                   threadReplyTargetMessage={displayedThreadReplyTargetMessage}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -88,6 +88,7 @@ type MessageThreadPanelProps = {
   scrollTargetId: string | null;
   threadHead: TimelineMessage | null;
   threadReplies: MainTimelineEntry[];
+  threadRepliesPending?: boolean;
   threadUnreadCount?: number;
   threadReplyUnreadCounts?: ReadonlyMap<string, number>;
   threadTypingPubkeys: string[];
@@ -332,6 +333,7 @@ export function MessageThreadPanel({
   threadHead,
   threadHeadVideoReviewContext,
   threadReplies,
+  threadRepliesPending = false,
   threadUnreadCount,
   threadReplyUnreadCounts,
   threadTypingPubkeys,
@@ -589,7 +591,7 @@ export function MessageThreadPanel({
     useAnchoredScroll({
       channelId: threadHeadId,
       contentRef: threadContentRef,
-      isLoading: repliesRenderState === "pending",
+      isLoading: threadRepliesPending || repliesRenderState === "pending",
       messages: threadMessages,
       onTargetReached: onScrollTargetResolved,
       scrollContainerRef: threadBodyRef,
@@ -664,7 +666,15 @@ export function MessageThreadPanel({
           className={cn(THREAD_PANEL_MESSAGE_GUTTER_CLASS, "pb-3 pt-0")}
           data-testid="message-thread-replies"
         >
-          {repliesRenderState === "list" ? (
+          {threadRepliesPending ? (
+            <div
+              className="space-y-2.5 pt-1"
+              data-testid="message-thread-replies-loading"
+            >
+              <ThreadMessageSkeleton />
+              <ThreadMessageSkeleton />
+            </div>
+          ) : repliesRenderState === "list" ? (
             visibleThreadHeadSummary ? (
               <div
                 className="space-y-0"


### PR DESCRIPTION
## Summary
- keep the known thread head and composer visible while replies load
- show existing skeleton rows in the reply region during the initial query
- render the empty state only after a completed empty response

## Validation
- `pnpm typecheck`
- `pnpm exec biome check src/features/messages/ui/MessageThreadPanel.tsx src/features/channels/ui/ChannelPane.tsx src/features/channels/ui/ChannelPane.types.ts src/features/channels/ui/ChannelScreen.tsx`
- `pnpm test` (2,546 passed)
- `pnpm build`
- `pnpm exec playwright test tests/e2e/messaging.spec.ts --grep "thread panel width uses session storage and reset handle" --project smoke --reporter=line`
