### PR TITLE
Fix oversized mobile Manage channel sheet

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -215,6 +215,10 @@ class ChannelDetailPage extends HookConsumerWidget {
                   context: context,
                   isScrollControlled: true,
                   showDragHandle: true,
+                  constraints: BoxConstraints(
+                    maxWidth: 640,
+                    maxHeight: MediaQuery.sizeOf(context).height * 0.9,
+                  ),
                   builder: (_) => ManageChannelSheet(channel: resolvedChannel),
                 );
                 if (shouldClose == true && context.mounted) {

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -117,6 +117,7 @@ Widget _buildTestable({
   ChannelActions Function(Ref ref)? createChannelActions,
   ReadStateNotifier? readStateNotifier,
   _FakeMessagesNotifier? messagesNotifier,
+  String? canvasContent,
 }) {
   final resolvedChannel = channel ?? _testChannel;
   final fakeChannelsNotifier =
@@ -138,8 +139,8 @@ Widget _buildTestable({
         (ref) async => ChannelDetails.fromChannel(resolvedChannel),
       ),
       channelCanvasProvider(_channelId).overrideWith(
-        (ref) async => const ChannelCanvas(
-          content: null,
+        (ref) async => ChannelCanvas(
+          content: canvasContent,
           updatedAt: null,
           authorPubkey: null,
         ),
@@ -369,6 +370,42 @@ void main() {
         findsNothing,
       );
       expect(find.text('Message #general'), findsOneWidget);
+    });
+
+    testWidgets('keeps manage sheet dismissible with a long canvas', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: const [],
+          canvasContent: List.generate(
+            80,
+            (index) => 'Canvas line $index',
+          ).join('\n'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Manage channel'));
+      await tester.pumpAndSettle();
+
+      final sheet = find.byType(BottomSheet);
+      expect(sheet, findsOneWidget);
+      expect(tester.getSize(sheet).height, lessThanOrEqualTo(720));
+
+      final sheetTop = tester.getTopLeft(sheet).dy;
+      await tester.dragFrom(
+        Offset(tester.view.physicalSize.width / 2, sheetTop + 12),
+        const Offset(0, 800),
+      );
+      await tester.pumpAndSettle();
+
+      expect(sheet, findsNothing);
     });
 
     testWidgets('shows empty state when no messages', (tester) async {


### PR DESCRIPTION
## Summary
- cap the Manage channel bottom sheet at 90% of the viewport while preserving Material's 640px desktop width cap
- keep long canvas content scrollable so the drag handle remains reachable
- add a regression test that opens an 80-line canvas on a 400×800 viewport and dismisses the sheet by dragging its handle

## Test plan
- [x] `just mobile-test` (430 passed, 1 skipped)
- [x] `just mobile-fix` (format unchanged; analyze clean)
- [x] focused `channel_detail_page_test.dart` (38 passed)
- [x] independent Brain review and focused test rerun
