### PR TITLE
fix(mobile): align Android AGP/Gradle/Kotlin with Flutter 3.41.7 (unbreak Android build)

### DIFF
--- a/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/mobile/android/settings.gradle.kts
+++ b/mobile/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "9.2.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.21" apply false
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## What

Realigns the Android build's AGP / Gradle / Kotlin versions to the defaults that our pinned Flutter (3.41.7) actually supports:

| Tool | Before | After |
|------|--------|-------|
| Android Gradle Plugin | 9.2.1 | 8.11.1 |
| Gradle | 9.5.1 | 8.14 |
| Kotlin | 2.3.21 | 2.2.20 |

Three lines across `settings.gradle.kts` and `gradle-wrapper.properties`.

## Why

The Android build has been broken on `main` since **2026-05-20**. Two Renovate PRs bumped the Android toolchain a full major version ahead of what Flutter 3.41.7 supports:

- #672 — Gradle → v9
- #674 — `com.android.application` (AGP) → v9

Under AGP 9, `flutter run` fails in a chain of ways:

1. `kotlin-android` plugin "no longer required since AGP 9.0" (built-in Kotlin).
2. After removing it, the Flutter Gradle plugin throws `NullPointerException` because AGP 9 "only reads the new DSL."
3. Even past that, third-party plugins that still apply `kotlin-android` (e.g. `app_badge_plus`) collide with built-in Kotlin: *"Cannot add extension with name 'kotlin', as there is an extension already registered."*

The chosen versions aren't arbitrary — they're the exact template defaults this Flutter ships, from `flutter_tools/lib/src/android/gradle_utils.dart`:

```
const templateDefaultGradleVersion = '8.14';
const templateAndroidGradlePluginVersion = '8.11.1';
const templateKotlinGradlePluginVersion = '2.2.20';
```

## Testing

- `flutter run` **builds and launches on a physical device** (Pixel 3a XL, Android with `targetSdk` 36) — previously it failed at `assembleDebug`.
- `just mobile-check` passes (dart format + `flutter analyze`: no issues).

## Notes / caveats

- This reverts to AGP 8 to unbreak the build against the currently-pinned Flutter (3.41.7). Migrating the app and its plugins to AGP 9 is a larger, separate effort — happy to go that direction instead if maintainers prefer.
- **CI does not currently compile the Android target**, so it would not detect AGP/Gradle compatibility regressions — which is why #672/#674 sat broken for ~7 weeks. The `mobile` job (`.github/workflows/ci.yml`) runs `flutter pub get`, format check, `flutter analyze`, and `flutter test`, but no Android Gradle / `assembleDebug` build. Suggested follow-up: an Android `assembleDebug` smoke build in CI, and/or Renovate constraints holding AGP/Gradle back until Flutter supports those majors.
