### PR TITLE
perf(db): index thread reply keyset pagination

### DIFF
--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -625,7 +625,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 31);
+        assert_eq!(migrations.len(), 32);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -1057,6 +1057,25 @@ mod tests {
             .as_str()
             .contains("error_code"));
         assert!(include_str!("../../../schema/schema.sql").contains("error_code          TEXT"));
+
+        // Thread subtree pagination uses the full tenant/root/keyset tuple. Keep
+        // the covering index additive so brownfield migration checksums remain
+        // stable.
+        assert_eq!(migrations[31].version, 32);
+        assert!(migrations[31]
+            .sql
+            .as_str()
+            .contains("CREATE INDEX IF NOT EXISTS idx_thread_metadata_root_keyset"));
+        assert!(migrations[31]
+            .sql
+            .as_str()
+            .contains("(community_id, root_event_id, event_created_at, event_id)"));
+        assert!(!migrations[0]
+            .sql
+            .as_str()
+            .contains("idx_thread_metadata_root_keyset"));
+        assert!(include_str!("../../../schema/schema.sql")
+            .contains("CREATE INDEX idx_thread_metadata_root_keyset"));
     }
 
     #[test]

--- a/migrations/0032_thread_metadata_keyset_index.sql
+++ b/migrations/0032_thread_metadata_keyset_index.sql
@@ -1,0 +1,21 @@
+-- ── Thread reply keyset pagination index ─────────────────────────────────────
+-- Thread subtree reads filter by tenant and root, then page in ascending
+-- (event_created_at, event_id) order. Include the keyset columns so PostgreSQL
+-- can satisfy both the filter and ordering from one index scan.
+--
+-- Lock note: built without CONCURRENTLY because sqlx runs each migration inside
+-- a transaction and CREATE INDEX CONCURRENTLY cannot run in one. This takes a
+-- SHARE lock on `thread_metadata` (blocking writes, not reads) for the duration
+-- of the build. `thread_metadata` is on the event insertion path and may be
+-- large on brownfield databases, so operators should pre-build it by hand before
+-- deploying this migration:
+--
+--   CREATE INDEX CONCURRENTLY idx_thread_metadata_root_keyset
+--       ON thread_metadata (community_id, root_event_id, event_created_at, event_id);
+--
+-- IF NOT EXISTS then makes this migration a no-op on that database.
+--
+-- Additive migration: previously applied files must not change checksum.
+
+CREATE INDEX IF NOT EXISTS idx_thread_metadata_root_keyset
+    ON thread_metadata (community_id, root_event_id, event_created_at, event_id);

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -531,6 +531,8 @@ CREATE TABLE thread_metadata (
 
 CREATE INDEX idx_thread_metadata_parent ON thread_metadata (community_id, parent_event_id);
 CREATE INDEX idx_thread_metadata_root ON thread_metadata (community_id, root_event_id);
+CREATE INDEX idx_thread_metadata_root_keyset
+    ON thread_metadata (community_id, root_event_id, event_created_at, event_id);
 CREATE INDEX idx_thread_metadata_channel_depth
     ON thread_metadata (community_id, channel_id, depth, event_created_at);
 CREATE INDEX idx_thread_metadata_event_id ON thread_metadata (community_id, event_id);


### PR DESCRIPTION
## Summary
- add migration `0032_thread_metadata_keyset_index` for thread-reply pagination
- index `(community_id, root_event_id, event_created_at, event_id)` to match the tenant/root filter and `(event_created_at, event_id)` keyset order in `get_thread_replies`
- update the desired schema and pin the migration version/index shape in the embedded migrator test
- make the migration brownfield-safe with `CREATE INDEX IF NOT EXISTS` plus an operator prebuild note for the exact `CREATE INDEX CONCURRENTLY` command
- keep the change additive so checksums for already-applied migrations remain unchanged

## Rebase notes
- rebased the original change onto current `main`
- resolved the migration-number conflict by moving this migration from `0028` to `0032`, after the migrations now present on `main`
- retained a single focused commit and the original ready-for-review state

## Brownfield rollout
sqlx runs migrations inside a transaction, so the checked-in migration cannot use `CREATE INDEX CONCURRENTLY` directly. The migration uses `CREATE INDEX IF NOT EXISTS`, documents that the in-migration build takes a `SHARE` lock on `thread_metadata` and blocks writes while it runs, and gives operators this exact prebuild command for large brownfield databases:

```sql
CREATE INDEX CONCURRENTLY idx_thread_metadata_root_keyset
    ON thread_metadata (community_id, root_event_id, event_created_at, event_id);
```

`IF NOT EXISTS` then makes migration `0032` a no-op on databases where operators prebuilt the index.

## Validation
- final pushed head: `173b2d21dde16789353f8a69102dc222942e7775`
- `cargo fmt --all -- --check` passed
- `git diff --check` passed
- `cargo test -p buzz-db migration::tests --lib` passed (10 passed; 5 existing Postgres-backed tests ignored by annotation)
- `just ci` passed locally after the review fix, before the final amend, including the full desktop Tauri workspace tests
- `cargo build --profile ci -p buzz-relay -p git-credential-nostr` passed locally
- `just test` was attempted, but integration setup was blocked by an existing local Redis listener on `127.0.0.1:6379`; per follow-up instruction, no unrelated multi-hour suites were rerun after the final amend, and GitHub CI should cover the final head
