### PR TITLE
fix(release): mark workspace safe for git in containerized Linux release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,6 +528,9 @@ jobs:
           ref: ${{ github.event_name == 'push' && github.ref || inputs.ref }}
           persist-credentials: false
 
+      - name: Mark workspace safe for git (containerized job)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2


### PR DESCRIPTION
`release-linux` is the only release job that runs in a container. Its checkout workspace is owned by the runner UID while subsequent commands run as root, causing Git's dubious-ownership protection to reject the repository when `gh release upload` resolves it.

Add the workspace as a Git safe directory immediately after checkout. This covers both Linux `gh release upload` steps: the versioned release upload that failed in [run 29219996637](https://github.com/block/buzz/actions/runs/29219996637) and the rolling release upload.
