### PR TITLE
chore(ci): lint desktop Tauri crate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,10 @@ jobs:
         run: just desktop-test
       - name: Desktop build
         run: just desktop-build
+      - name: Desktop Tauri clippy
+        run: just desktop-tauri-clippy
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
       - name: Desktop Tauri check
         run: just desktop-tauri-check
         env:

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -322,7 +322,7 @@ async fn restart_setup_mode_agents_after_install(
                     &global,
                 );
                 let now_ready = matches!(agent_readiness(&effective), AgentReadiness::Ready);
-                let pid_alive = pid.is_some_and(|p| crate::managed_agents::process_is_running(p));
+                let pid_alive = pid.is_some_and(crate::managed_agents::process_is_running);
                 should_restart_after_install(
                     is_local,
                     pid_alive,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -48,9 +48,12 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use tauri::{Emitter, Listener, Manager, RunEvent};
+#[cfg(target_os = "macos")]
+use tauri::Listener;
+use tauri::{Emitter, Manager, RunEvent};
 use tauri_plugin_window_state::StateFlags;
 
+#[cfg(target_os = "macos")]
 const INITIAL_RENDER_READY_EVENT: &str = "initial-render-ready";
 
 #[tauri::command]


### PR DESCRIPTION
## Summary

- Fix the `clippy::redundant_closure` warning in `agent_discovery.rs` by passing `process_is_running` directly to `Option::is_some_and`.
- Gate the initial-render `Listener` import and event-name constant to macOS, matching their only macOS use-site so Linux strict clippy does not compile dead symbols.
- Run `just desktop-tauri-clippy` in the `Desktop Core` CI job with the same CMake policy environment as the adjacent Tauri checks.

`desktop/src-tauri` is excluded from the root Cargo workspace, so the workspace-level `just clippy` gate did not lint this crate. The `Desktop Core` job already installs its Linux Tauri dependencies and caches its workspace, making it the appropriate job for this strict crate-level gate.
