### PR TITLE
fix(desktop): preserve live events and window order across channel refreshes

### DIFF
--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -5,19 +5,26 @@ import { toast } from "sonner";
 import {
   channelMessagesKey,
   channelWindowKey,
-  dedupeMessagesById,
-  normalizeTimelineMessages,
-  sortMessages,
   threadRepliesKey,
 } from "@/features/messages/lib/messageQueryKeys";
 import {
   buildReplyTags,
-  getChannelIdFromTags,
   getThreadReference,
   isBroadcastReply,
   normalizeMentionPubkeys,
   resolveReplyRootId,
 } from "@/features/messages/lib/threading";
+import {
+  projectChannelWindowMessages,
+  refreshChannelWindowMessages,
+} from "@/features/messages/lib/projectChannelWindow";
+import { reconcileChannelWindowMessages } from "@/features/messages/lib/channelWindowReconciliation";
+import {
+  mergeMessages,
+  mergeTimelineCacheMessages,
+} from "@/features/messages/lib/messageMerge";
+
+export { mergeMessages, mergeTimelineCacheMessages };
 import { splitOutgoingTags } from "@/features/messages/lib/imetaMediaMarkdown";
 import {
   clearTimeoutState,
@@ -42,7 +49,6 @@ import type { Channel, Identity, RelayEvent } from "@/shared/api/types";
 import { applyEditTagOverlay } from "@/features/messages/lib/applyEditTagOverlay.mjs";
 import {
   emptyChannelWindowStore,
-  flattenChannelWindowEvents,
   mapChannelWindowEvents,
   mergeLiveChannelWindowEvent,
   mergeLiveThreadSummary,
@@ -71,74 +77,6 @@ type MessageQueryContext = {
 
 const CHANNEL_TIMELINE_KINDS = new Set<number>(CHANNEL_TIMELINE_CONTENT_KINDS);
 const CHANNEL_AUX_KINDS = new Set<number>(CHANNEL_AUX_EVENT_KINDS);
-
-function getLocalRenderKey(message: RelayEvent) {
-  return message.localKey ?? message.id;
-}
-
-function isMatchingPendingMessage(pending: RelayEvent, incoming: RelayEvent) {
-  if (
-    !pending.pending ||
-    pending.content !== incoming.content ||
-    pending.kind !== incoming.kind ||
-    pending.pubkey.toLowerCase() !== incoming.pubkey.toLowerCase() ||
-    getChannelIdFromTags(pending.tags) !== getChannelIdFromTags(incoming.tags)
-  ) {
-    return false;
-  }
-
-  const pendingThread = getThreadReference(pending.tags);
-  const incomingThread = getThreadReference(incoming.tags);
-
-  return (
-    pendingThread.parentId === incomingThread.parentId &&
-    pendingThread.rootId === incomingThread.rootId
-  );
-}
-
-function mergeMessagesWithNormalizer(
-  current: RelayEvent[],
-  incoming: RelayEvent,
-  normalize: (messages: RelayEvent[]) => RelayEvent[],
-): RelayEvent[] {
-  const normalizedCurrent = dedupeMessagesById(current);
-  const replacedPending = normalizedCurrent.find((message) =>
-    isMatchingPendingMessage(message, incoming),
-  );
-  const incomingWithLocalKey = replacedPending
-    ? {
-        ...incoming,
-        localKey: replacedPending.localKey ?? replacedPending.id,
-      }
-    : incoming;
-  const incomingLocalKey = getLocalRenderKey(incomingWithLocalKey);
-  const deduped = normalizedCurrent.filter(
-    (message) =>
-      message.id !== incoming.id &&
-      getLocalRenderKey(message) !== incomingLocalKey &&
-      !isMatchingPendingMessage(message, incoming),
-  );
-
-  return normalize([...deduped, incomingWithLocalKey]);
-}
-
-export function mergeMessages(
-  current: RelayEvent[],
-  incoming: RelayEvent,
-): RelayEvent[] {
-  return mergeMessagesWithNormalizer(current, incoming, sortMessages);
-}
-
-export function mergeTimelineCacheMessages(
-  current: RelayEvent[],
-  incoming: RelayEvent,
-): RelayEvent[] {
-  return mergeMessagesWithNormalizer(
-    current,
-    incoming,
-    normalizeTimelineMessages,
-  );
-}
 
 export function createOptimisticMessage(
   channelId: string,
@@ -255,25 +193,6 @@ export function resolveThreadReplyTarget(
   };
 }
 
-function retainRefetchReconciliationEvents(events: RelayEvent[]) {
-  return events.filter((event) => {
-    if (!CHANNEL_TIMELINE_KINDS.has(event.kind)) return false;
-    if (event.pending) return true;
-    const thread = getThreadReference(event.tags);
-    return thread.parentId !== null && !isBroadcastReply(event.tags);
-  });
-}
-
-function mergeRefetchReconciliationEvents(
-  windowEvents: RelayEvent[],
-  previousMessages: RelayEvent[],
-) {
-  const authoritativeIds = new Set(windowEvents.map((event) => event.id));
-  return retainRefetchReconciliationEvents(previousMessages)
-    .filter((event) => !authoritativeIds.has(event.id))
-    .reduce((current, reply) => mergeMessages(current, reply), windowEvents);
-}
-
 export function useChannelWindowQuery(channel: Channel | null) {
   const queryClient = useQueryClient();
   const queryKey = channelWindowKey(channel?.id ?? "none");
@@ -305,9 +224,8 @@ export function useChannelMessagesQuery(channel: Channel | null) {
         queryClient.getQueryData<ChannelWindowStore>(windowKey) ??
         emptyChannelWindowStore();
       const next = replaceNewestChannelWindow(current, page);
-      const windowEvents = flattenChannelWindowEvents(next);
       queryClient.setQueryData(windowKey, next);
-      return mergeRefetchReconciliationEvents(windowEvents, previousMessages);
+      return reconcileChannelWindowMessages(next, previousMessages);
     },
     staleTime: 5 * 60 * 1_000,
     gcTime: 60 * 60 * 1_000,
@@ -320,11 +238,7 @@ export function useChannelSubscription(channel: Channel | null) {
   const channelType = channel?.channelType ?? null;
   const refreshNewestWindow = useEffectEvent(async () => {
     if (!channelId) return;
-    await queryClient.invalidateQueries({
-      queryKey: channelMessagesKey(channelId),
-      exact: true,
-      refetchType: "active",
-    });
+    await refreshChannelWindowMessages(queryClient, channelId);
   });
 
   const appendMessage = useEffectEvent((event: RelayEvent) => {
@@ -371,10 +285,7 @@ export function useChannelSubscription(channel: Channel | null) {
     const next = mergeLiveChannelWindowEvent(current, event, isTimelineRow);
     if (next !== current) {
       queryClient.setQueryData(windowKey, next);
-      queryClient.setQueryData<RelayEvent[]>(
-        channelMessagesKey(channelId),
-        flattenChannelWindowEvents(next),
-      );
+      projectChannelWindowMessages(queryClient, channelId);
     }
 
     if (event.kind === KIND_SYSTEM_MESSAGE) {
@@ -629,10 +540,7 @@ export function useSendMessageMutation(
         optimisticMessage,
       );
       queryClient.setQueryData(windowKey, nextWindow);
-      queryClient.setQueryData<RelayEvent[]>(
-        queryKey,
-        flattenChannelWindowEvents(nextWindow),
-      );
+      projectChannelWindowMessages(queryClient, effectiveChannel.id);
 
       return {
         optimisticId: optimisticMessage.id,
@@ -680,10 +588,7 @@ export function useSendMessageMutation(
         localKey: context.optimisticId,
       });
       queryClient.setQueryData(windowKey, next);
-      queryClient.setQueryData<RelayEvent[]>(
-        context.queryKey,
-        flattenChannelWindowEvents(next),
-      );
+      projectChannelWindowMessages(queryClient, context.channelId);
     },
   });
 }

--- a/desktop/src/features/messages/lib/channelWindowReconciliation.ts
+++ b/desktop/src/features/messages/lib/channelWindowReconciliation.ts
@@ -1,10 +1,11 @@
 import type { RelayEvent } from "@/shared/api/types";
 import { CHANNEL_TIMELINE_CONTENT_KINDS } from "@/shared/constants/kinds";
 import {
+  compareRelayOrder,
   flattenChannelWindowEvents,
   type ChannelWindowStore,
 } from "./channelWindowStore";
-import { mergeMessages } from "./messageMerge";
+import { reconcileIncomingMessage } from "./messageMerge";
 import { getThreadReference, isBroadcastReply } from "./threading";
 
 const CHANNEL_TIMELINE_KINDS = new Set<number>(CHANNEL_TIMELINE_CONTENT_KINDS);
@@ -32,10 +33,49 @@ export function reconcileChannelWindowMessages(
     (event) => !authoritativeIds.has(event.id),
   );
 
-  // Merge authoritative rows last so an acknowledged relay event replaces its
-  // matching optimistic row while preserving the local render key.
-  return windowEvents.reduce(
-    (current, event) => mergeMessages(current, event),
-    retained,
+  // Reconcile acknowledgements against cache-only rows without changing the
+  // authoritative window's order. The render key moves from an optimistic row
+  // to its relay acknowledgement while the relay row remains in its original
+  // cursor position.
+  let cacheOnly = retained;
+  const authoritative = windowEvents.map((event) => {
+    const reconciled = reconcileIncomingMessage(cacheOnly, event);
+    const incoming = reconciled.at(-1);
+    cacheOnly = reconciled.slice(0, -1);
+    return incoming ?? event;
+  });
+
+  return mergeChronologicalMessages(cacheOnly, authoritative);
+}
+
+function mergeChronologicalMessages(
+  cacheOnly: RelayEvent[],
+  authoritative: RelayEvent[],
+) {
+  const retained = [...cacheOnly].sort((left, right) =>
+    compareRelayOrder(right, left),
+  );
+  const merged: RelayEvent[] = [];
+  let retainedIndex = 0;
+  let authoritativeIndex = 0;
+
+  while (
+    retainedIndex < retained.length &&
+    authoritativeIndex < authoritative.length
+  ) {
+    const retainedEvent = retained[retainedIndex];
+    const authoritativeEvent = authoritative[authoritativeIndex];
+    if (compareRelayOrder(retainedEvent, authoritativeEvent) > 0) {
+      merged.push(retainedEvent);
+      retainedIndex += 1;
+    } else {
+      merged.push(authoritativeEvent);
+      authoritativeIndex += 1;
+    }
+  }
+
+  return merged.concat(
+    retained.slice(retainedIndex),
+    authoritative.slice(authoritativeIndex),
   );
 }

--- a/desktop/src/features/messages/lib/channelWindowReconciliation.ts
+++ b/desktop/src/features/messages/lib/channelWindowReconciliation.ts
@@ -1,0 +1,41 @@
+import type { RelayEvent } from "@/shared/api/types";
+import { CHANNEL_TIMELINE_CONTENT_KINDS } from "@/shared/constants/kinds";
+import {
+  flattenChannelWindowEvents,
+  type ChannelWindowStore,
+} from "./channelWindowStore";
+import { mergeMessages } from "./messageMerge";
+import { getThreadReference, isBroadcastReply } from "./threading";
+
+const CHANNEL_TIMELINE_KINDS = new Set<number>(CHANNEL_TIMELINE_CONTENT_KINDS);
+
+function retainRefetchReconciliationEvents(events: RelayEvent[]) {
+  return events.filter((event) => {
+    if (!CHANNEL_TIMELINE_KINDS.has(event.kind)) return false;
+    if (event.pending) return true;
+    const thread = getThreadReference(event.tags);
+    return thread.parentId !== null && !isBroadcastReply(event.tags);
+  });
+}
+
+/**
+ * Project the timeline from the authoritative window while retaining local
+ * pending sends and non-broadcast thread replies the window does not contain.
+ */
+export function reconcileChannelWindowMessages(
+  window: ChannelWindowStore,
+  messages: RelayEvent[],
+) {
+  const windowEvents = flattenChannelWindowEvents(window);
+  const authoritativeIds = new Set(windowEvents.map((event) => event.id));
+  const retained = retainRefetchReconciliationEvents(messages).filter(
+    (event) => !authoritativeIds.has(event.id),
+  );
+
+  // Merge authoritative rows last so an acknowledged relay event replaces its
+  // matching optimistic row while preserving the local render key.
+  return windowEvents.reduce(
+    (current, event) => mergeMessages(current, event),
+    retained,
+  );
+}

--- a/desktop/src/features/messages/lib/channelWindowStore.ts
+++ b/desktop/src/features/messages/lib/channelWindowStore.ts
@@ -57,7 +57,7 @@ function cursorsEqual(
 }
 
 /** Relay order: newest timestamp first, then ascending id within a second. */
-function compareRelayOrder(left: RelayEvent, right: RelayEvent) {
+export function compareRelayOrder(left: RelayEvent, right: RelayEvent) {
   return left.created_at !== right.created_at
     ? right.created_at - left.created_at
     : left.id < right.id

--- a/desktop/src/features/messages/lib/messageMerge.ts
+++ b/desktop/src/features/messages/lib/messageMerge.ts
@@ -13,6 +13,7 @@ function getLocalRenderKey(message: RelayEvent) {
 function isMatchingPendingMessage(pending: RelayEvent, incoming: RelayEvent) {
   if (
     !pending.pending ||
+    incoming.pending ||
     pending.content !== incoming.content ||
     pending.kind !== incoming.kind ||
     pending.pubkey.toLowerCase() !== incoming.pubkey.toLowerCase() ||
@@ -30,10 +31,9 @@ function isMatchingPendingMessage(pending: RelayEvent, incoming: RelayEvent) {
   );
 }
 
-function mergeMessagesWithNormalizer(
+export function reconcileIncomingMessage(
   current: RelayEvent[],
   incoming: RelayEvent,
-  normalize: (messages: RelayEvent[]) => RelayEvent[],
 ): RelayEvent[] {
   const normalizedCurrent = dedupeMessagesById(current);
   const replacedPending = normalizedCurrent.find((message) =>
@@ -49,11 +49,18 @@ function mergeMessagesWithNormalizer(
   const deduped = normalizedCurrent.filter(
     (message) =>
       message.id !== incoming.id &&
-      getLocalRenderKey(message) !== incomingLocalKey &&
-      !isMatchingPendingMessage(message, incoming),
+      getLocalRenderKey(message) !== incomingLocalKey,
   );
 
-  return normalize([...deduped, incomingWithLocalKey]);
+  return [...deduped, incomingWithLocalKey];
+}
+
+function mergeMessagesWithNormalizer(
+  current: RelayEvent[],
+  incoming: RelayEvent,
+  normalize: (messages: RelayEvent[]) => RelayEvent[],
+): RelayEvent[] {
+  return normalize(reconcileIncomingMessage(current, incoming));
 }
 
 export function mergeMessages(

--- a/desktop/src/features/messages/lib/messageMerge.ts
+++ b/desktop/src/features/messages/lib/messageMerge.ts
@@ -1,0 +1,75 @@
+import type { RelayEvent } from "@/shared/api/types";
+import {
+  dedupeMessagesById,
+  normalizeTimelineMessages,
+  sortMessages,
+} from "./messageQueryKeys";
+import { getChannelIdFromTags, getThreadReference } from "./threading";
+
+function getLocalRenderKey(message: RelayEvent) {
+  return message.localKey ?? message.id;
+}
+
+function isMatchingPendingMessage(pending: RelayEvent, incoming: RelayEvent) {
+  if (
+    !pending.pending ||
+    pending.content !== incoming.content ||
+    pending.kind !== incoming.kind ||
+    pending.pubkey.toLowerCase() !== incoming.pubkey.toLowerCase() ||
+    getChannelIdFromTags(pending.tags) !== getChannelIdFromTags(incoming.tags)
+  ) {
+    return false;
+  }
+
+  const pendingThread = getThreadReference(pending.tags);
+  const incomingThread = getThreadReference(incoming.tags);
+
+  return (
+    pendingThread.parentId === incomingThread.parentId &&
+    pendingThread.rootId === incomingThread.rootId
+  );
+}
+
+function mergeMessagesWithNormalizer(
+  current: RelayEvent[],
+  incoming: RelayEvent,
+  normalize: (messages: RelayEvent[]) => RelayEvent[],
+): RelayEvent[] {
+  const normalizedCurrent = dedupeMessagesById(current);
+  const replacedPending = normalizedCurrent.find((message) =>
+    isMatchingPendingMessage(message, incoming),
+  );
+  const incomingWithLocalKey = replacedPending
+    ? {
+        ...incoming,
+        localKey: replacedPending.localKey ?? replacedPending.id,
+      }
+    : incoming;
+  const incomingLocalKey = getLocalRenderKey(incomingWithLocalKey);
+  const deduped = normalizedCurrent.filter(
+    (message) =>
+      message.id !== incoming.id &&
+      getLocalRenderKey(message) !== incomingLocalKey &&
+      !isMatchingPendingMessage(message, incoming),
+  );
+
+  return normalize([...deduped, incomingWithLocalKey]);
+}
+
+export function mergeMessages(
+  current: RelayEvent[],
+  incoming: RelayEvent,
+): RelayEvent[] {
+  return mergeMessagesWithNormalizer(current, incoming, sortMessages);
+}
+
+export function mergeTimelineCacheMessages(
+  current: RelayEvent[],
+  incoming: RelayEvent,
+): RelayEvent[] {
+  return mergeMessagesWithNormalizer(
+    current,
+    incoming,
+    normalizeTimelineMessages,
+  );
+}

--- a/desktop/src/features/messages/lib/pageOlderMessages.ts
+++ b/desktop/src/features/messages/lib/pageOlderMessages.ts
@@ -2,16 +2,12 @@ import type { QueryClient } from "@tanstack/react-query";
 
 import {
   appendOlderChannelWindow,
-  flattenChannelWindowEvents,
   type ChannelWindowStore,
 } from "@/features/messages/lib/channelWindowStore";
+import { projectChannelWindowMessages } from "@/features/messages/lib/projectChannelWindow";
 import { parseChannelWindowResponse } from "@/features/messages/lib/channelWindowResponse";
-import {
-  channelMessagesKey,
-  channelWindowKey,
-} from "@/features/messages/lib/messageQueryKeys";
+import { channelWindowKey } from "@/features/messages/lib/messageQueryKeys";
 import { getChannelWindowEvents } from "@/shared/api/channelWindow";
-import type { RelayEvent } from "@/shared/api/types";
 
 const CHANNEL_WINDOW_PAGE_SIZE = 50;
 export type PageOlderResult = { hasOlderMessages: boolean };
@@ -59,9 +55,6 @@ async function runPage(
   if (!retained) return { hasOlderMessages: true };
   const next = appendOlderChannelWindow(retained, page);
   queryClient.setQueryData(channelWindowKey(channelId), next);
-  queryClient.setQueryData<RelayEvent[]>(
-    channelMessagesKey(channelId),
-    flattenChannelWindowEvents(next),
-  );
+  projectChannelWindowMessages(queryClient, channelId);
   return { hasOlderMessages: page.hasMore };
 }

--- a/desktop/src/features/messages/lib/projectChannelWindow.test.mjs
+++ b/desktop/src/features/messages/lib/projectChannelWindow.test.mjs
@@ -4,7 +4,9 @@ import { QueryClient, QueryObserver } from "@tanstack/react-query";
 
 import { channelMessagesKey, channelWindowKey } from "./messageQueryKeys.ts";
 import {
+  appendOlderChannelWindow,
   emptyChannelWindowStore,
+  flattenChannelWindowEvents,
   mergeLiveChannelWindowEvent,
   replaceNewestChannelWindow,
 } from "./channelWindowStore.ts";
@@ -169,6 +171,84 @@ test("test_projection_replaces_pending_send_with_authoritative_event", () => {
   );
   assert.equal(projected[1]?.id, accepted.id);
   assert.equal(projected[1]?.localKey, pending.id);
+});
+
+test("test_reconciliation_preserves_dense_second_window_order", () => {
+  const first = {
+    ...newestPage([event("a", 100), event("b", 100)]),
+    nextCursor: { createdAt: 100, eventId: event("b", 100).id },
+    hasMore: true,
+  };
+  const store = appendOlderChannelWindow(
+    replaceNewestChannelWindow(emptyChannelWindowStore(), first),
+    {
+      ...newestPage([event("c", 100), event("z", 99)]),
+      startCursor: first.nextCursor,
+    },
+  );
+
+  assert.deepEqual(
+    reconcileChannelWindowMessages(store, []).map((item) => item.content),
+    ["z", "c", "b", "a"],
+  );
+  assert.deepEqual(
+    reconcileChannelWindowMessages(store, []).map((item) => item.id),
+    flattenChannelWindowEvents(store).map((item) => item.id),
+  );
+});
+
+test("test_reconciliation_retains_identical_pending_sends", () => {
+  const harness = createHarness();
+  const first = {
+    ...event("first-pending", 110),
+    content: "hello",
+    pending: true,
+  };
+  const second = {
+    ...event("second-pending", 111),
+    content: "hello",
+    pending: true,
+  };
+
+  const projected = reconcileChannelWindowMessages(
+    harness.client.getQueryData(harness.windowKey),
+    [first, second],
+  );
+
+  assert.deepEqual(
+    projected.map((item) => item.id),
+    [event("initial", 100), first, second].map((item) => item.id),
+  );
+});
+
+test("test_reconciliation_acknowledges_only_one_identical_pending_send", () => {
+  const harness = createHarness();
+  const first = {
+    ...event("first-pending", 110),
+    content: "hello",
+    pending: true,
+  };
+  const second = {
+    ...event("second-pending", 111),
+    content: "hello",
+    pending: true,
+  };
+  const accepted = {
+    ...event("accepted", 110),
+    content: "hello",
+  };
+  const window = replaceNewestChannelWindow(
+    harness.client.getQueryData(harness.windowKey),
+    newestPage([accepted, event("initial", 100)]),
+  );
+
+  const projected = reconcileChannelWindowMessages(window, [first, second]);
+
+  assert.deepEqual(
+    projected.map((item) => item.id),
+    [event("initial", 100), accepted, second].map((item) => item.id),
+  );
+  assert.equal(projected[1]?.localKey, first.id);
 });
 
 test("test_live_projection_retains_pending_send_and_non_broadcast_thread_reply", () => {

--- a/desktop/src/features/messages/lib/projectChannelWindow.test.mjs
+++ b/desktop/src/features/messages/lib/projectChannelWindow.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+
+import { channelMessagesKey, channelWindowKey } from "./messageQueryKeys.ts";
+import {
+  emptyChannelWindowStore,
+  mergeLiveChannelWindowEvent,
+  replaceNewestChannelWindow,
+} from "./channelWindowStore.ts";
+import {
+  projectChannelWindowMessages,
+  refreshChannelWindowMessages,
+} from "./projectChannelWindow.ts";
+import { reconcileChannelWindowMessages } from "./channelWindowReconciliation.ts";
+
+function event(id, createdAt) {
+  return {
+    id: id.padEnd(64, "0"),
+    pubkey: "a".repeat(64),
+    created_at: createdAt,
+    kind: 9,
+    tags: [["h", "channel"]],
+    content: id,
+    sig: "b".repeat(128),
+  };
+}
+
+function newestPage(rows) {
+  return {
+    startCursor: null,
+    rows: rows.map((event) => ({ event, thread: null })),
+    aux: [],
+    nextCursor: null,
+    hasMore: false,
+  };
+}
+
+function createHarness() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const channelId = "channel";
+  const messagesKey = channelMessagesKey(channelId);
+  const windowKey = channelWindowKey(channelId);
+  const initial = event("initial", 100);
+  client.setQueryData(
+    windowKey,
+    replaceNewestChannelWindow(
+      emptyChannelWindowStore(),
+      newestPage([initial]),
+    ),
+  );
+  client.setQueryData(messagesKey, [initial]);
+
+  return { channelId, client, messagesKey, windowKey };
+}
+
+function appendLiveEvent(harness, live) {
+  const current = harness.client.getQueryData(harness.windowKey);
+  const next = mergeLiveChannelWindowEvent(current, live);
+  harness.client.setQueryData(harness.windowKey, next);
+  projectChannelWindowMessages(harness.client, harness.channelId);
+}
+
+function beginRefetch(harness, fetchPage, afterWindowWrite) {
+  let resolveStarted;
+  const started = new Promise((resolve) => {
+    resolveStarted = resolve;
+  });
+  const observer = new QueryObserver(harness.client, {
+    queryKey: harness.messagesKey,
+    queryFn: async () => {
+      resolveStarted();
+      const page = await fetchPage;
+      const current = harness.client.getQueryData(harness.windowKey);
+      const next = replaceNewestChannelWindow(current, page);
+      const previousMessages = harness.client.getQueryData(harness.messagesKey);
+      harness.client.setQueryData(harness.windowKey, next);
+      afterWindowWrite?.();
+      return reconcileChannelWindowMessages(next, previousMessages);
+    },
+  });
+  const unsubscribe = observer.subscribe(() => {});
+  return {
+    started,
+    done: refreshChannelWindowMessages(
+      harness.client,
+      harness.channelId,
+    ).finally(unsubscribe),
+  };
+}
+
+function contents(harness) {
+  return harness.client
+    .getQueryData(harness.messagesKey)
+    .map((event) => event.content);
+}
+
+test("test_live_event_during_fetch_survives_refetch_projection", async () => {
+  const harness = createHarness();
+  const live = event("during-fetch", 110);
+  let resolveFetch;
+  const pendingPage = new Promise((resolve) => {
+    resolveFetch = resolve;
+  });
+  const { started, done } = beginRefetch(harness, pendingPage);
+
+  await started;
+  appendLiveEvent(harness, live);
+  resolveFetch(newestPage([event("initial", 100)]));
+  await done;
+
+  assert.deepEqual(contents(harness), ["initial", "during-fetch"]);
+});
+
+test("test_live_event_after_query_resolution_survives_refetch_projection", async () => {
+  const harness = createHarness();
+  const live = event("post-resolve", 110);
+  const { started, done } = beginRefetch(
+    harness,
+    Promise.resolve(newestPage([event("initial", 100)])),
+    () => queueMicrotask(() => appendLiveEvent(harness, live)),
+  );
+
+  await started;
+  await done;
+
+  assert.deepEqual(contents(harness), ["initial", "post-resolve"]);
+});
+
+test("test_projection_retains_pending_send_and_non_broadcast_thread_reply", async () => {
+  const harness = createHarness();
+  const pending = { ...event("pending", 110), pending: true };
+  const threadReply = {
+    ...event("thread-reply", 120),
+    tags: [
+      ["h", "channel"],
+      ["e", "root", "", "root"],
+      ["e", "parent", "", "reply"],
+    ],
+  };
+  const window = harness.client.getQueryData(harness.windowKey);
+  const projected = reconcileChannelWindowMessages(window, [
+    pending,
+    threadReply,
+  ]);
+
+  assert.deepEqual(
+    projected.map((event) => event.content),
+    ["initial", "pending", "thread-reply"],
+  );
+});
+
+test("test_projection_replaces_pending_send_with_authoritative_event", () => {
+  const harness = createHarness();
+  const pending = { ...event("accepted", 110), pending: true };
+  const accepted = { ...event("accepted", 110), id: "c".repeat(64) };
+  const window = replaceNewestChannelWindow(
+    harness.client.getQueryData(harness.windowKey),
+    newestPage([accepted, event("initial", 100)]),
+  );
+
+  const projected = reconcileChannelWindowMessages(window, [pending]);
+
+  assert.deepEqual(
+    projected.map((event) => event.content),
+    ["initial", "accepted"],
+  );
+  assert.equal(projected[1]?.id, accepted.id);
+  assert.equal(projected[1]?.localKey, pending.id);
+});
+
+test("test_live_projection_retains_pending_send_and_non_broadcast_thread_reply", () => {
+  const harness = createHarness();
+  const pending = { ...event("pending", 110), pending: true };
+  const threadReply = {
+    ...event("thread-reply", 120),
+    tags: [
+      ["h", "channel"],
+      ["e", "root", "", "root"],
+      ["e", "parent", "", "reply"],
+    ],
+  };
+  harness.client.setQueryData(harness.messagesKey, [pending, threadReply]);
+
+  appendLiveEvent(harness, event("live", 130));
+
+  assert.deepEqual(contents(harness), [
+    "initial",
+    "pending",
+    "thread-reply",
+    "live",
+  ]);
+});

--- a/desktop/src/features/messages/lib/projectChannelWindow.ts
+++ b/desktop/src/features/messages/lib/projectChannelWindow.ts
@@ -1,0 +1,35 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import type { RelayEvent } from "@/shared/api/types";
+import { channelMessagesKey, channelWindowKey } from "./messageQueryKeys";
+import {
+  emptyChannelWindowStore,
+  type ChannelWindowStore,
+} from "./channelWindowStore";
+import { reconcileChannelWindowMessages } from "./channelWindowReconciliation";
+
+/** Keep the rendered timeline cache aligned with its authoritative window. */
+export function projectChannelWindowMessages(
+  queryClient: QueryClient,
+  channelId: string,
+) {
+  const window =
+    queryClient.getQueryData<ChannelWindowStore>(channelWindowKey(channelId)) ??
+    emptyChannelWindowStore();
+  queryClient.setQueryData<RelayEvent[]>(
+    channelMessagesKey(channelId),
+    (messages = []) => reconcileChannelWindowMessages(window, messages),
+  );
+}
+
+export async function refreshChannelWindowMessages(
+  queryClient: QueryClient,
+  channelId: string,
+) {
+  await queryClient.invalidateQueries({
+    queryKey: channelMessagesKey(channelId),
+    exact: true,
+    refetchType: "active",
+  });
+  projectChannelWindowMessages(queryClient, channelId);
+}

--- a/desktop/tests/e2e/stream.spec.ts
+++ b/desktop/tests/e2e/stream.spec.ts
@@ -46,12 +46,13 @@ async function ensureTimelineScrollable(
   receiverPage: Page,
   channelName: string,
   prefix: string,
+  minDistance = 160,
 ) {
   for (let index = 0; index < 24; index += 1) {
     const metrics = await getTimelineMetrics(receiverPage);
     if (
       metrics.scrollHeight >
-      metrics.clientHeight + metrics.composerHeight + 160
+      metrics.clientHeight + metrics.composerHeight + minDistance
     ) {
       return;
     }
@@ -67,7 +68,7 @@ async function ensureTimelineScrollable(
 
   const metrics = await getTimelineMetrics(receiverPage);
   expect(metrics.scrollHeight).toBeGreaterThan(
-    metrics.clientHeight + metrics.composerHeight + 160,
+    metrics.clientHeight + metrics.composerHeight + minDistance,
   );
 }
 
@@ -92,6 +93,18 @@ async function createAndJoinSharedStream(
   await expect(memberPage.getByTestId("stream-list")).toContainText(
     channelName,
   );
+
+  // Channel title/sidebar selection can update before the relay has reconciled
+  // the membership event. Wait until both contexts can participate before a
+  // test relies on live delivery between them. The 30s bound tolerates known
+  // slow convergence; a recurring timeout is evidence to investigate the
+  // membership read-after-write path, not a reason to extend this test wait.
+  await expect(ownerPage.getByTestId("message-input")).toBeEnabled({
+    timeout: 30_000,
+  });
+  await expect(memberPage.getByTestId("message-input")).toBeEnabled({
+    timeout: 30_000,
+  });
 }
 
 async function sendChannelMessage(
@@ -172,7 +185,7 @@ async function scrollTimelineAwayFromBottom(page: Page, minDistance = 160) {
       // so waiting for it guarantees the anchor is in the away-from-bottom
       // branch before callers send the message they expect to be counted.
       await expect(page.getByTestId("message-scroll-to-latest")).toBeVisible();
-      return;
+      return metrics.distanceFromBottom;
     }
   }
 
@@ -498,12 +511,23 @@ test("keeps scroll position when new messages arrive above the fold", async ({
     await pageTwo.goto("/");
     await createAndJoinSharedStream(pageOne, pageTwo, channelName);
 
-    await ensureTimelineScrollable(pageOne, pageTwo, channelName, prefix);
+    const minScrollableDistance = 480;
+    const minAwayDistance = 80;
+    await ensureTimelineScrollable(
+      pageOne,
+      pageTwo,
+      channelName,
+      prefix,
+      minScrollableDistance,
+    );
     await expect
       .poll(async () => (await getTimelineMetrics(pageTwo)).distanceFromBottom)
       .toBeLessThan(8);
 
-    await scrollTimelineAwayFromBottom(pageTwo);
+    const distanceBeforeDelivery = await scrollTimelineAwayFromBottom(
+      pageTwo,
+      minAwayDistance,
+    );
 
     await sendChannelMessage(pageOne, {
       channelName,
@@ -515,7 +539,7 @@ test("keeps scroll position when new messages arrive above the fold", async ({
     );
     await expect
       .poll(async () => (await getTimelineMetrics(pageTwo)).distanceFromBottom)
-      .toBeGreaterThan(160);
+      .toBeGreaterThanOrEqual(distanceBeforeDelivery - 8);
 
     await pageTwo.getByTestId("message-scroll-to-latest").click();
 


### PR DESCRIPTION
Live top-level messages, local pending sends, and non-broadcast thread replies could disappear from the rendered timeline during channel-open or reconnect refreshes. The loss occurred in the microtask gap between a refetch resolving and React Query committing its stale materialized snapshot.

`reconcileChannelWindowMessages` now provides the last write for `channelMessagesKey` after each authoritative channel-window update.

- Collapses the five timeline cache writers into one projection seam backed by the authoritative window store.
- Preserves exact `flattenChannelWindowEvents(window)` ordering for authoritative rows and merges retained cache-only rows with `compareRelayOrder`.
- Prevents `isMatchingPendingMessage` from treating a pending optimistic send as an acknowledgement of another pending send.
- Stabilizes the real-relay stream assertion around participant readiness and measured scroll position.

Known limitation: a same-ID relay echo can drop a cached `localKey`, causing React key churn but not message loss; this behavior predates the merge base and is tracked separately.
