### PR TITLE
fix(desktop): retain live rows after window exhaustion

### DIFF
--- a/desktop/src/features/messages/lib/channelWindowStore.test.mjs
+++ b/desktop/src/features/messages/lib/channelWindowStore.test.mjs
@@ -154,12 +154,36 @@ test("live backdated rows stay outside pages and render in order", () => {
   );
 });
 
-test("live rows below the oldest retained boundary wait for paging", () => {
+test("live rows below an open oldest boundary wait for paging", () => {
   const store = replaceNewestChannelWindow(
     emptyChannelWindowStore(),
     page(null, [event("n", 110), event("a", 100)]),
   );
   assert.equal(mergeLiveChannelWindowEvent(store, event("old", 90)), store);
+});
+
+test("same-second live rows enter an exhausted short window regardless of id order", () => {
+  const store = replaceNewestChannelWindow(
+    emptyChannelWindowStore(),
+    page(null, [event("a", 100), event("m", 100)], { hasMore: false }),
+  );
+  const live = event("z", 100);
+  const withLive = mergeLiveChannelWindowEvent(store, live);
+
+  assert.notEqual(withLive, store);
+  assert.deepEqual(
+    flattenChannelWindowEvents(withLive).map((item) => item.content),
+    ["z", "m", "a"],
+  );
+});
+
+test("older live rows stay below an exhausted window", () => {
+  const store = replaceNewestChannelWindow(
+    emptyChannelWindowStore(),
+    page(null, [event("a", 100)], { hasMore: false }),
+  );
+
+  assert.equal(mergeLiveChannelWindowEvent(store, event("old", 99)), store);
 });
 
 test("live aux stays separate from authoritative page closure", () => {

--- a/desktop/src/features/messages/lib/channelWindowStore.ts
+++ b/desktop/src/features/messages/lib/channelWindowStore.ts
@@ -178,7 +178,7 @@ export function mergeLiveThreadSummary(
 
 /**
  * Merge a live top-level event without mutating authoritative page boundaries.
- * Events below the oldest loaded boundary wait for ordinary relay pagination.
+ * Events below an open oldest boundary wait for ordinary relay pagination.
  */
 export function mergeLiveChannelWindowEvent(
   current: ChannelWindowStore,
@@ -205,7 +205,13 @@ export function mergeLiveChannelWindowEvent(
   }
   const oldestPage = current.pages[current.pages.length - 1];
   const oldest = oldestPage?.rows[oldestPage.rows.length - 1]?.event;
-  if (oldest && compareRelayOrder(event, oldest) >= 0) return current;
+  if (
+    oldest &&
+    (event.created_at < oldest.created_at ||
+      (oldestPage.hasMore && compareRelayOrder(event, oldest) >= 0))
+  ) {
+    return current;
+  }
   return {
     ...current,
     liveOverlay: current.liveOverlay


### PR DESCRIPTION
## Summary
- retain live rows when the oldest channel window is exhausted
- continue deferring rows below an open pagination boundary
- cover same-second live events whose IDs sort after the current tail

## Why
`mergeLiveChannelWindowEvent` treated the last loaded row as an exclusion boundary even when the relay had reported `hasMore: false`. In short newly-created channels, live messages sharing the same second could therefore be discarded based only on ID order. This produced the repeated missing-final-seed failures in `stream.spec.ts` after #1802.

## Validation
- `channelWindowStore.test.mjs` (25/25)
- `pnpm --dir desktop typecheck`
- Biome check on changed files
