### PR TITLE
fix(desktop): widen probe test timing margins for parallel pre-push

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -757,9 +757,9 @@ fn probe_codex_acp_major_version_returns_none_for_hung_direct_child() {
         major, None,
         "hung binary must return None (timeout kills child)"
     );
-    // The timeout is 5 s; give a 2 s margin for slow CI.
+    // The timeout is 5 s; give a 10 s margin for parallel pre-push suites.
     assert!(
-        elapsed.as_secs() < 7,
+        elapsed.as_secs() < 15,
         "probe must complete within timeout bound; elapsed: {elapsed:?}"
     );
 }
@@ -796,9 +796,9 @@ fn probe_codex_acp_major_version_returns_version_when_descendant_holds_pipe_open
     let _ = std::fs::remove_dir_all(dir);
 
     // Must return within ~1 s: non-blocking read, no waiting for descendant.
-    // Give a 3 s margin for slow CI.
+    // Give a 9 s margin for parallel pre-push suites.
     assert!(
-        elapsed.as_secs() < 3,
+        elapsed.as_secs() < 10,
         "probe must not block on descendant pipe; elapsed: {elapsed:?}"
     );
     assert_eq!(


### PR DESCRIPTION
The two `probe_codex_acp_major_version` timing tests assert wall-clock
elapsed time with tight margins (<7 s and <3 s). During `just release-desktop`,
Lefthook runs four test suites in parallel on the pre-push hook, and CPU
contention blows past both bounds (13.4 s and 8.4 s observed).

The probe implementation is unchanged — only the test assertion margins are
widened to tolerate parallel pre-push load:

- `probe_…returns_none_for_hung_direct_child`: 7 s → 15 s (5 s timeout + 10 s margin)
- `probe_…returns_version_when_descendant_holds_pipe_open`: 3 s → 10 s (~1 s expected + 9 s margin)