### PR TITLE
fix(desktop): retain live rows in exhausted windows

### DIFF
--- a/desktop/src/features/messages/lib/channelWindowStore.test.mjs
+++ b/desktop/src/features/messages/lib/channelWindowStore.test.mjs
@@ -154,12 +154,27 @@ test("live backdated rows stay outside pages and render in order", () => {
   );
 });
 
-test("live rows below the oldest retained boundary wait for paging", () => {
+test("live rows below an open oldest boundary wait for paging", () => {
   const store = replaceNewestChannelWindow(
     emptyChannelWindowStore(),
     page(null, [event("n", 110), event("a", 100)]),
   );
   assert.equal(mergeLiveChannelWindowEvent(store, event("old", 90)), store);
+});
+
+test("same-second live rows enter an exhausted short window regardless of id order", () => {
+  const store = replaceNewestChannelWindow(
+    emptyChannelWindowStore(),
+    page(null, [event("a", 100), event("m", 100)], { hasMore: false }),
+  );
+  const live = event("z", 100);
+  const withLive = mergeLiveChannelWindowEvent(store, live);
+
+  assert.notEqual(withLive, store);
+  assert.deepEqual(
+    flattenChannelWindowEvents(withLive).map((item) => item.content),
+    ["z", "m", "a"],
+  );
 });
 
 test("live aux stays separate from authoritative page closure", () => {

--- a/desktop/src/features/messages/lib/channelWindowStore.ts
+++ b/desktop/src/features/messages/lib/channelWindowStore.ts
@@ -178,7 +178,7 @@ export function mergeLiveThreadSummary(
 
 /**
  * Merge a live top-level event without mutating authoritative page boundaries.
- * Events below the oldest loaded boundary wait for ordinary relay pagination.
+ * Events below an open oldest boundary wait for ordinary relay pagination.
  */
 export function mergeLiveChannelWindowEvent(
   current: ChannelWindowStore,
@@ -205,7 +205,9 @@ export function mergeLiveChannelWindowEvent(
   }
   const oldestPage = current.pages[current.pages.length - 1];
   const oldest = oldestPage?.rows[oldestPage.rows.length - 1]?.event;
-  if (oldest && compareRelayOrder(event, oldest) >= 0) return current;
+  if (oldestPage?.hasMore && oldest && compareRelayOrder(event, oldest) >= 0) {
+    return current;
+  }
   return {
     ...current,
     liveOverlay: current.liveOverlay


### PR DESCRIPTION
## Summary

Live top-level events could disappear before scrolling began when a short channel's first page was already exhausted. `mergeLiveChannelWindowEvent` compared a same-second event's Nostr ID against the oldest loaded row and discarded it as below the retained boundary, even when `hasMore=false` meant no unloaded boundary existed.

- Defer below-boundary live rows only while the oldest page remains open (`hasMore=true`).
- Preserve live rows in exhausted windows regardless of same-second ID ordering.
- Add deterministic regression coverage for that ordering case.

This is separate from #1802: that PR fixed a refresh/cache overwrite race; this fixes event loss at the live-window boundary. It keeps the existing scroll contracts intact and does not increase timeouts or retries.

## Validation

- Focused channel-window/project tests: 33/33 passed
- Full desktop unit suite: 2,763/2,763 passed
- Typecheck passed
- Lint/check passed
- Desktop build passed (existing unrelated warnings only)

Local real-relay E2E repetition could not run because no relay was listening on `localhost:3000`; CI should provide the integration signal. Several consecutive integration/scroll-shard passes are still required before treating the recurring missing-seed signature as stabilized.
