### PR TITLE
ci(mobile): compile Android debug APK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
               - 'pnpm-lock.yaml'
             mobile:
               - 'mobile/**'
+              - '.github/workflows/ci.yml'
 
   rust-lint:
     name: Rust Lint
@@ -734,6 +735,8 @@ jobs:
         run: cd mobile && flutter analyze
       - name: Test
         run: cd mobile && flutter test
+      - name: Build Android debug APK
+        run: just mobile-build-android
 
   security:
     name: Security

--- a/Justfile
+++ b/Justfile
@@ -446,6 +446,10 @@ mobile-check:
 mobile-test:
     unset GIT_DIR GIT_WORK_TREE; cd {{mobile_dir}} && flutter test
 
+# Compile an unsigned Android debug APK
+mobile-build-android:
+    unset GIT_DIR GIT_WORK_TREE; cd {{mobile_dir}} && flutter build apk --debug --no-pub
+
 # Run the mobile app on iOS simulator
 mobile-dev:
     #!/usr/bin/env bash


### PR DESCRIPTION
## What

Add an Android debug APK compile step to the existing Mobile CI job:

```sh
just mobile-build-android
```

## Why

The Mobile job currently runs formatting, analysis, and Flutter tests without compiling the Android target. That allowed incompatible AGP/Gradle upgrades to leave Android broken for weeks without CI detecting it; #1775 repaired that mismatch.

The Just recipe provides the same canonical command locally and in CI. This establishes the smallest useful regression gate now, while keeping Android application ID, release signing, artifact publishing, and distribution as separate follow-up work.

## Validation

- Clean local build from current main: `flutter build apk --debug`
- Result: success in 149 seconds; 181 MB APK
- Workflow YAML parses successfully
- `git diff --check`

