### PR TITLE
chore(mobile): Configure Android Play identity and signing

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -29,6 +29,19 @@ flutter test
 
 Or from the repo root: `just mobile-check` and `just mobile-test`.
 
+## Android release signing
+
+Android release builds fail unless all upload-key inputs are supplied through the
+environment:
+
+- `BUZZ_ANDROID_UPLOAD_KEYSTORE_PATH`: path to a CI-vended keystore file
+- `BUZZ_ANDROID_UPLOAD_KEYSTORE_PASSWORD`
+- `BUZZ_ANDROID_UPLOAD_KEY_ALIAS`
+- `BUZZ_ANDROID_UPLOAD_KEY_PASSWORD`
+
+The keystore path must be absolute, and the keystore must remain outside the
+repository. Development and debug builds do not require these variables.
+
 ## Architecture
 
 ```

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -5,8 +5,22 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+val uploadKeystorePath = providers.environmentVariable("BUZZ_ANDROID_UPLOAD_KEYSTORE_PATH").orNull
+val uploadKeystorePassword = providers.environmentVariable("BUZZ_ANDROID_UPLOAD_KEYSTORE_PASSWORD").orNull
+val uploadKeyAlias = providers.environmentVariable("BUZZ_ANDROID_UPLOAD_KEY_ALIAS").orNull
+val uploadKeyPassword = providers.environmentVariable("BUZZ_ANDROID_UPLOAD_KEY_PASSWORD").orNull
+val uploadSigningValues =
+    mapOf(
+        "BUZZ_ANDROID_UPLOAD_KEYSTORE_PATH" to uploadKeystorePath,
+        "BUZZ_ANDROID_UPLOAD_KEYSTORE_PASSWORD" to uploadKeystorePassword,
+        "BUZZ_ANDROID_UPLOAD_KEY_ALIAS" to uploadKeyAlias,
+        "BUZZ_ANDROID_UPLOAD_KEY_PASSWORD" to uploadKeyPassword,
+    )
+val missingUploadSigningValues = uploadSigningValues.filterValues { it.isNullOrBlank() }.keys
+val hasUploadSigning = missingUploadSigningValues.isEmpty()
+
 android {
-    namespace = "com.buzz.buzz_mobile"
+    namespace = "xyz.block.buzz.mobile"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -20,8 +34,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.buzz.buzz_mobile"
+        applicationId = "xyz.block.buzz.mobile"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -30,11 +43,54 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        if (hasUploadSigning) {
+            create("upload") {
+                storeFile = file(requireNotNull(uploadKeystorePath))
+                storePassword = uploadKeystorePassword
+                keyAlias = uploadKeyAlias
+                keyPassword = uploadKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            if (hasUploadSigning) {
+                signingConfig = signingConfigs.getByName("upload")
+            }
+        }
+    }
+}
+
+gradle.taskGraph.whenReady {
+    val buildsRelease = allTasks.any { task ->
+        task.project == project && task.name in setOf("assembleRelease", "bundleRelease")
+    }
+    if (buildsRelease && !hasUploadSigning) {
+        throw GradleException(
+            "Release builds require Android upload signing credentials. Missing: " +
+                missingUploadSigningValues.sorted().joinToString(", "),
+        )
+    }
+    if (buildsRelease) {
+        val configuredKeystore = File(requireNotNull(uploadKeystorePath))
+        if (!configuredKeystore.isAbsolute) {
+            throw GradleException(
+                "BUZZ_ANDROID_UPLOAD_KEYSTORE_PATH must be absolute: $configuredKeystore",
+            )
+        }
+        val keystore = file(configuredKeystore)
+        val repositoryRoot = rootProject.projectDir.parentFile.parentFile.canonicalFile
+        if (keystore.canonicalFile.toPath().startsWith(repositoryRoot.toPath())) {
+            throw GradleException(
+                "BUZZ_ANDROID_UPLOAD_KEYSTORE_PATH must be outside the repository: $keystore",
+            )
+        }
+        if (!keystore.isFile || !keystore.canRead()) {
+            throw GradleException(
+                "BUZZ_ANDROID_UPLOAD_KEYSTORE_PATH is not a readable file: $keystore",
+            )
         }
     }
 }

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <application
         android:label="Buzz"

--- a/mobile/android/app/src/main/kotlin/xyz/block/buzz/mobile/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/xyz/block/buzz/mobile/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.buzz.buzz_mobile
+package xyz.block.buzz.mobile
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory


### PR DESCRIPTION
### What changed?

- Set the Android namespace and application ID to `xyz.block.buzz.mobile`, including the matching `MainActivity` package.
- Require CI-vended upload signing credentials for release AAB/APK lifecycle builds.
- Reject relative, unreadable, or repository-contained keystore paths and document the four-variable interface.
- Add release network permission.

### Why?

Establishes Buzz's permanent Google Play package identity and ensures release artifacts cannot silently use debug or repository-local signing material.

### How is it tested?

Built and inspected a signed release AAB using a temporary external keystore. Verified missing credentials and invalid keystore paths fail closed. Flutter analysis and commit hooks pass. The required deep-dual pre-review loop completed with no actionable findings.

Focused existing validation:

- `flutter analyze`
- Android release bundle signing and package/class inspection
