### PR TITLE
fix(mobile): mirror app bar title padding when actions are empty

### DIFF
--- a/mobile/lib/shared/widgets/frosted_app_bar.dart
+++ b/mobile/lib/shared/widgets/frosted_app_bar.dart
@@ -87,6 +87,9 @@ class FrostedAppBar extends StatelessWidget {
                             left: effectiveLeading != null
                                 ? 0
                                 : Grid.gutter - Grid.quarter,
+                            right: actions.isEmpty
+                                ? Grid.gutter - Grid.quarter
+                                : 0,
                           ),
                           child: DefaultTextStyle.merge(
                             style: context.textTheme.titleMedium?.copyWith(


### PR DESCRIPTION
## Summary

The mobile search page's search field touched the right screen edge until the clear (X) button appeared. `FrostedAppBar` pads the title on the left when there is no leading widget, but had no mirrored padding on the right when `actions` is empty.

This mirrors the existing left-padding rule on the right side (3 lines). Title-only bars (Activity, Settings, Pulse, etc.) get the same symmetric inset.

Reported by Wes in `more-mobile-fixes` during the 2026-07-13 mobile QA sweep.

## Before / After

| Before (idle) | After (idle) | After (with clear button) |
|---|---|---|
| ![before](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/1832/before-idle.png) | ![after](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/1832/after-idle.png) | ![withx](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/1832/after-with-clear.png) |

## Testing

- `flutter analyze` clean
- `flutter test` — 443 passed
- Verified both composer states in the iOS simulator (screenshots above)
