### PR TITLE
fix(desktop): prevent menu-to-dialog UI lockups

### DIFF
--- a/desktop/src/features/forum/ui/DeleteActionMenu.tsx
+++ b/desktop/src/features/forum/ui/DeleteActionMenu.tsx
@@ -22,7 +22,7 @@ export function DeleteActionMenu({ label, onConfirm }: DeleteActionMenuProps) {
 
   return (
     <div className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <button
             className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"

--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -116,7 +116,7 @@ function MoreActionsMenu({
 
   return (
     <>
-      <DropdownMenu open={open} onOpenChange={onOpenChange}>
+      <DropdownMenu modal={false} open={open} onOpenChange={onOpenChange}>
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>

--- a/desktop/src/features/relay-members/ui/RelayMembersCard.tsx
+++ b/desktop/src/features/relay-members/ui/RelayMembersCard.tsx
@@ -116,7 +116,7 @@ function MemberRow({
       </div>
 
       {showActions ? (
-        <DropdownMenu>
+        <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
             <Button
               data-testid={`relay-member-actions-${member.pubkey}`}

--- a/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
@@ -234,7 +234,7 @@ function TemplateRow({
         </div>
       </div>
 
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button
             className="h-7 w-7 shrink-0 opacity-0 group-hover:opacity-100"

--- a/desktop/src/features/sidebar/ui/WorkspaceRail.tsx
+++ b/desktop/src/features/sidebar/ui/WorkspaceRail.tsx
@@ -99,7 +99,7 @@ function WorkspaceButton({
       : workspace.name;
 
   return (
-    <ContextMenu>
+    <ContextMenu modal={false}>
       <Tooltip>
         <TooltipTrigger asChild>
           <ContextMenuTrigger asChild>

--- a/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
+++ b/desktop/src/features/workspaces/ui/WorkspaceSwitcher.tsx
@@ -281,7 +281,11 @@ export function WorkspaceSwitcher({
     ) : null;
 
   const switcherDropdown = (
-    <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
+    <DropdownMenu
+      modal={false}
+      open={dropdownOpen}
+      onOpenChange={setDropdownOpen}
+    >
       <DropdownMenuTrigger asChild>
         {variant === "profile" ? (
           <button

--- a/desktop/tests/e2e/workspace-rail.spec.ts
+++ b/desktop/tests/e2e/workspace-rail.spec.ts
@@ -55,6 +55,38 @@ test.describe("workspace rail", () => {
     await expect(page.getByTestId("workspace-rail-add")).toBeVisible();
   });
 
+  test("restores pointer events after dismissing workspace settings", async ({
+    page,
+  }) => {
+    await installMockBridge(page, undefined, { skipWorkspaceSeed: true });
+    await seedWorkspaces(page, [WORKSPACE_A, WORKSPACE_B], WORKSPACE_A.id);
+    await page.goto("/");
+
+    const workspaceButton = page.getByTestId(
+      `workspace-rail-button-${WORKSPACE_A.id}`,
+    );
+    await workspaceButton.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Workspace settings" }).click();
+
+    await expect(
+      page.getByRole("dialog", { name: "Edit Workspace" }),
+    ).toBeVisible();
+    await page.mouse.click(0, 0);
+
+    await expect(
+      page.getByRole("dialog", { name: "Edit Workspace" }),
+    ).toHaveCount(0);
+    await expect(page.locator("body")).not.toHaveCSS("pointer-events", "none");
+    await page.getByTestId(`workspace-rail-button-${WORKSPACE_B.id}`).click();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.localStorage.getItem("buzz-active-workspace-id"),
+        ),
+      )
+      .toBe(WORKSPACE_B.id);
+  });
+
   test("switches the active workspace on click", async ({ page }) => {
     await installMockBridge(page, undefined, { skipWorkspaceSeed: true });
     await seedWorkspaces(page, [WORKSPACE_A, WORKSPACE_B], WORKSPACE_A.id);


### PR DESCRIPTION
## Summary

- make Radix menu roots non-modal when their actions open dialogs or confirmation surfaces
- cover the workspace rail settings outside-dismiss lockup with an end-to-end regression
- apply the established sidebar fix to the other audited menu-to-dialog transitions

## Why

A modal Radix menu and a dialog can overlap during the handoff. Both manage the global pointer-events guard, and dismissing the dialog outside can leave `pointer-events: none` on `<body>`, making the app unclickable. Non-modal menus avoid installing that competing body guard.

## Test plan

- `pnpm exec biome check` on changed files
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec playwright test tests/e2e/workspace-rail.spec.ts` (7 passed)
