### PR TITLE
fix(desktop): navigate to channel from inbox thread header

### DIFF
--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -788,10 +788,11 @@ export function HomeView({
                     setIsDeletingMessage(false);
                   });
               }}
-              onOpenChannel={(channelId) => {
+              onManageChannel={(channelId) => {
                 handleCloseProfilePanel();
                 setManagedChannelId(channelId);
               }}
+              onOpenContext={onOpenContext}
               onSendReply={async ({
                 content,
                 mediaTags,

--- a/desktop/src/features/home/ui/InboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/InboxDetailPane.tsx
@@ -77,7 +77,12 @@ type InboxDetailPaneProps = {
   latchedDefaultParentId?: string | null;
   onBack?: () => void;
   onDelete: () => void;
-  onOpenChannel: (channelId: string) => void;
+  onManageChannel: (channelId: string) => void;
+  onOpenContext: (
+    channelId: string,
+    messageId: string,
+    threadRootId?: string | null,
+  ) => void;
   onSendReply: (input: {
     content: string;
     mediaTags?: string[][];
@@ -111,7 +116,8 @@ export function InboxDetailPane({
   latchedDefaultParentId = null,
   onBack,
   onDelete,
-  onOpenChannel,
+  onManageChannel,
+  onOpenContext,
   onSendReply,
   onToggleReaction,
 }: InboxDetailPaneProps) {
@@ -318,6 +324,7 @@ export function InboxDetailPane({
   const contextLabel = channelContextName ?? formatInboxTypeLabel(item);
   const hasChannelContext = Boolean(channelContextName);
   const contextChannelId = item.item.channelId;
+  const contextThreadRootId = getThreadReference(item.item.tags).rootId;
 
   const handleSelectReplyTarget = (message: InboxDisplayMessage) => {
     setReplyTargetId((currentReplyTargetId) =>
@@ -358,7 +365,13 @@ export function InboxDetailPane({
                   {canOpenChannel && contextChannelId ? (
                     <button
                       className="flex min-w-0 items-center gap-[4px] text-left text-sm font-semibold leading-5 tracking-tight text-foreground hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      onClick={() => onOpenChannel(contextChannelId)}
+                      onClick={() =>
+                        onOpenContext(
+                          contextChannelId,
+                          item.id,
+                          contextThreadRootId,
+                        )
+                      }
                       title={item.fullTimestampLabel}
                       type="button"
                     >
@@ -394,7 +407,7 @@ export function InboxDetailPane({
                       currentPubkey={currentPubkey}
                       onManageChannel={() => {
                         if (contextChannelId) {
-                          onOpenChannel(contextChannelId);
+                          onManageChannel(contextChannelId);
                         }
                       }}
                       onToggleMembers={() =>

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1706,9 +1706,10 @@ test("manage channel keeps canvas near the top of the sheet", async ({
   expect(canvasBox?.y).toBeLessThan(nameBox?.y);
 });
 
-test("home inbox channel label opens management without leaving home", async ({
-  page,
-}) => {
+async function seedHomeInboxMention(
+  page: import("@playwright/test").Page,
+  itemId: string,
+) {
   await page.goto("/");
   await expect(page.getByTestId("home-inbox-list")).toBeVisible();
   await page.waitForFunction(
@@ -1718,7 +1719,7 @@ test("home inbox channel label opens management without leaving home", async ({
   );
 
   await page.evaluate(
-    ({ channelId, createdAt, currentPubkey, senderPubkey }) => {
+    ({ channelId, createdAt, currentPubkey, itemId: id, senderPubkey }) => {
       const pushFeedItem = (window as MockFeedWindow)
         .__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__;
       if (!pushFeedItem) {
@@ -1726,7 +1727,7 @@ test("home inbox channel label opens management without leaving home", async ({
       }
 
       pushFeedItem({
-        id: "mock-feed-home-channel-panel",
+        id,
         kind: 9,
         pubkey: senderPubkey,
         content: "Please review the home panel routing.",
@@ -1744,16 +1745,40 @@ test("home inbox channel label opens management without leaving home", async ({
       channelId: GENERAL_CHANNEL_ID,
       createdAt: Math.floor(Date.now() / 1000),
       currentPubkey: TEST_IDENTITIES.tyler.pubkey,
+      itemId,
       senderPubkey: TEST_IDENTITIES.alice.pubkey,
     },
   );
 
-  await page
-    .getByTestId("home-inbox-item-mock-feed-home-channel-panel")
-    .click();
+  await page.getByTestId(`home-inbox-item-${itemId}`).click();
+}
+
+test("home inbox channel label navigates to the channel message", async ({
+  page,
+}) => {
+  await seedHomeInboxMention(page, "mock-feed-home-channel-navigate");
+
   await page
     .getByTestId("home-inbox-detail")
     .getByRole("button", { exact: true, name: "general" })
+    .click();
+
+  await expect(page).toHaveURL(
+    new RegExp(`#/channels/${GENERAL_CHANNEL_ID}\\?`),
+  );
+  await expect(page).toHaveURL(/messageId=mock-feed-home-channel-navigate/);
+  await expect(page.getByTestId("message-timeline")).toBeVisible();
+  await expect(page.getByTestId("home-inbox-list")).toHaveCount(0);
+});
+
+test("home inbox manage affordance opens management without leaving home", async ({
+  page,
+}) => {
+  await seedHomeInboxMention(page, "mock-feed-home-channel-panel");
+
+  await page
+    .getByTestId("home-inbox-detail")
+    .getByTestId("channel-management-trigger")
     .click();
 
   await expect(page.getByTestId("channel-management-sheet")).toBeVisible();

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1709,6 +1709,7 @@ test("manage channel keeps canvas near the top of the sheet", async ({
 async function seedHomeInboxMention(
   page: import("@playwright/test").Page,
   itemId: string,
+  tags?: string[][],
 ) {
   await page.goto("/");
   await expect(page.getByTestId("home-inbox-list")).toBeVisible();
@@ -1719,7 +1720,14 @@ async function seedHomeInboxMention(
   );
 
   await page.evaluate(
-    ({ channelId, createdAt, currentPubkey, itemId: id, senderPubkey }) => {
+    ({
+      channelId,
+      createdAt,
+      currentPubkey,
+      itemId: id,
+      senderPubkey,
+      tags: seededTags,
+    }) => {
       const pushFeedItem = (window as MockFeedWindow)
         .__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__;
       if (!pushFeedItem) {
@@ -1734,7 +1742,7 @@ async function seedHomeInboxMention(
         created_at: createdAt,
         channel_id: channelId,
         channel_name: "general",
-        tags: [
+        tags: seededTags ?? [
           ["e", channelId],
           ["p", currentPubkey],
         ],
@@ -1747,6 +1755,7 @@ async function seedHomeInboxMention(
       currentPubkey: TEST_IDENTITIES.tyler.pubkey,
       itemId,
       senderPubkey: TEST_IDENTITIES.alice.pubkey,
+      tags,
     },
   );
 
@@ -1767,6 +1776,31 @@ test("home inbox channel label navigates to the channel message", async ({
     new RegExp(`#/channels/${GENERAL_CHANNEL_ID}\\?`),
   );
   await expect(page).toHaveURL(/messageId=mock-feed-home-channel-navigate/);
+  await expect(page).not.toHaveURL(/threadRootId=/);
+  await expect(page.getByTestId("message-timeline")).toBeVisible();
+  await expect(page.getByTestId("home-inbox-list")).toHaveCount(0);
+});
+
+test("home inbox thread reply mention carries threadRootId to the channel", async ({
+  page,
+}) => {
+  const rootEventId = "mock-feed-home-thread-root";
+  await seedHomeInboxMention(page, "mock-feed-home-thread-navigate", [
+    ["e", rootEventId, "", "root"],
+    ["e", "mock-feed-home-thread-parent", "", "reply"],
+    ["p", TEST_IDENTITIES.tyler.pubkey],
+  ]);
+
+  await page
+    .getByTestId("home-inbox-detail")
+    .getByRole("button", { exact: true, name: "general" })
+    .click();
+
+  await expect(page).toHaveURL(
+    new RegExp(`#/channels/${GENERAL_CHANNEL_ID}\\?`),
+  );
+  await expect(page).toHaveURL(/messageId=mock-feed-home-thread-navigate/);
+  await expect(page).toHaveURL(new RegExp(`threadRootId=${rootEventId}`));
   await expect(page.getByTestId("message-timeline")).toBeVisible();
   await expect(page.getByTestId("home-inbox-list")).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary

Clicking the channel name in the home inbox thread header previously opened the channel **management sheet**. It now navigates to the channel and jumps to the referenced message, which is what the affordance implies. Channel management is still available via the dedicated trigger in the header.

- `InboxDetailPane`: split the single `onOpenChannel` callback into `onManageChannel` (management sheet, used by the manage trigger) and `onOpenContext` (channel + message + thread-root navigation, used by the channel-name button). The thread root is resolved from the item's tags so the jump lands in the right thread.
- `HomeView`: wires the pane to the existing `onOpenContext` navigation handler and keeps the management path on `onManageChannel`.

## Testing

- Split the existing home-inbox E2E test into two (shared seeding helper): one asserting the channel label navigates to `#/channels/<id>?messageId=<id>`, one asserting the manage trigger still opens the management sheet without leaving home.
- Full pre-push suite passed (desktop, mobile, Tauri, Rust tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)