### PR TITLE
docs: activate Hermit before running just dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ just setup && just build
 
 **Every day:**
 ```bash
+. ./bin/activate-hermit
 just dev   # starts the relay + desktop app together
 ```
 


### PR DESCRIPTION
The README only tells you to activate Hermit during initial setup, but that activation doesn’t carry over to a new terminal aka every day use.  As a result, following the “Every day” instructions fails with just: command not found.

Feel free to close the PR if it's not necessary, I just encountered this asa blocker on my setup when doing max pain path of building things from source.