### PR TITLE
feat(desktop): surface needsRestart badge on live UI surfaces

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
         "**/local-archive-screenshots.spec.ts",
         "**/agent-readiness-screenshots.spec.ts",
         "**/agent-error-state-screenshots.spec.ts",
+        "**/needs-restart-screenshots.spec.ts",
         "**/edit-agent.spec.ts",
         "**/doctor-cta-screenshots.spec.ts",
         "**/pubkey-display-screenshots.spec.ts",

--- a/desktop/src/features/agents/ui/AgentIdentityCard.tsx
+++ b/desktop/src/features/agents/ui/AgentIdentityCard.tsx
@@ -13,6 +13,8 @@ type AgentIdentityCardProps = {
   label: string;
   modelLabel?: string | null;
   onClick: () => void;
+  /** Optional badge rendered below the label (e.g. "Restart required"). */
+  statusBadge?: ReactNode;
 };
 
 export function AgentIdentityCard({
@@ -24,6 +26,7 @@ export function AgentIdentityCard({
   label,
   modelLabel,
   onClick,
+  statusBadge,
 }: AgentIdentityCardProps) {
   const trimmedAvatarUrl = avatarUrl?.trim() || null;
 
@@ -74,6 +77,7 @@ export function AgentIdentityCard({
             {modelLabel}
           </span>
         ) : null}
+        {statusBadge}
       </div>
     </div>
   );

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { ChevronDown, ChevronRight, Ellipsis, OctagonX } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Ellipsis,
+  OctagonX,
+  RefreshCw,
+} from "lucide-react";
 
 import { formatAgentModelLabel } from "@/features/agents/lib/formatAgentModelLabel";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
@@ -9,6 +15,7 @@ import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
 import type { ProfilePanelOpenOptions } from "@/shared/context/ProfilePanelContext";
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
 import { useFileImportZone } from "@/shared/hooks/useFileImportZone";
+import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import {
   DropdownMenu,
@@ -344,6 +351,14 @@ function AgentPersonaCard({
         }
         onOpenPersonaProfile(persona);
       }}
+      statusBadge={
+        agent?.needsRestart ? (
+          <Badge className="gap-1" variant="warning">
+            <RefreshCw className="h-3 w-3" />
+            Restart required
+          </Badge>
+        ) : null
+      }
     />
   );
 }
@@ -400,6 +415,14 @@ function StandaloneAgentCard({
           opensRuntimeTab ? { tab: "runtime" } : undefined,
         );
       }}
+      statusBadge={
+        agent.needsRestart ? (
+          <Badge className="gap-1" variant="warning">
+            <RefreshCw className="h-3 w-3" />
+            Restart required
+          </Badge>
+        ) : null
+      }
     />
   );
 }

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -398,6 +398,9 @@ export function ProfileSummaryView({
             <>
               <ProfileRuntimeTabContent
                 agentInstruction={agentInstruction}
+                autoRestartEnabled={
+                  managedAgent?.autoRestartOnConfigChange ?? false
+                }
                 diagnosticsFields={diagnosticsFields}
                 diagnosticsSummary={diagnosticsTrailing}
                 needsRestart={managedAgent?.needsRestart ?? false}

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -400,6 +400,7 @@ export function ProfileSummaryView({
                 agentInstruction={agentInstruction}
                 diagnosticsFields={diagnosticsFields}
                 diagnosticsSummary={diagnosticsTrailing}
+                needsRestart={managedAgent?.needsRestart ?? false}
                 onOpenDiagnostics={onOpenDiagnostics}
                 onOpenInstructions={onOpenInstructions}
                 runtimeConfigurationFields={runtimeConfigurationFields}

--- a/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
@@ -791,8 +791,8 @@ export function ProfileRuntimeTabContent({
             </p>
             <p className="mt-0.5 text-xs text-muted-foreground">
               {autoRestartEnabled
-                ? "Configuration changed since this agent started. Buzz can restart it automatically after ~3 minutes idle, or restart manually to apply now."
-                : "Configuration changed since this agent started. Automatic restart is off for this agent \u2014 restart manually to apply the changes."}
+                ? "Configuration changed since this agent started. Buzz can restart it automatically after ~3 minutes idle, or stop and respawn it to apply now."
+                : "Configuration changed since this agent started. Automatic restart is off for this agent \u2014 stop and respawn it to apply the changes."}
             </p>
           </div>
         </div>

--- a/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
@@ -733,6 +733,7 @@ function ArchiveStatusTooltip() {
 
 export function ProfileRuntimeTabContent({
   agentInstruction,
+  autoRestartEnabled = false,
   diagnosticsFields,
   diagnosticsSummary,
   needsRestart = false,
@@ -744,6 +745,8 @@ export function ProfileRuntimeTabContent({
   showInstructionBlock,
 }: {
   agentInstruction: string | null;
+  /** Whether the per-agent auto-restart toggle is ON. */
+  autoRestartEnabled?: boolean;
   diagnosticsFields: ProfileField[];
   diagnosticsSummary: React.ReactNode;
   /** True when the running agent's config has drifted from what it was spawned with. */
@@ -787,9 +790,9 @@ export function ProfileRuntimeTabContent({
               Restart required
             </p>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Configuration changed since this agent started. It will restart
-              automatically after ~3 minutes idle, or restart manually for
-              immediate effect.
+              {autoRestartEnabled
+                ? "Configuration changed since this agent started. Buzz can restart it automatically after ~3 minutes idle, or restart manually to apply now."
+                : "Configuration changed since this agent started. Automatic restart is off for this agent \u2014 restart manually to apply the changes."}
             </p>
           </div>
         </div>

--- a/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
@@ -1,6 +1,13 @@
 import * as React from "react";
 import type { LucideIcon } from "lucide-react";
-import { Activity, Archive, ChevronRight, Info, Wrench } from "lucide-react";
+import {
+  Activity,
+  Archive,
+  ChevronRight,
+  Info,
+  RefreshCw,
+  Wrench,
+} from "lucide-react";
 
 import type { ActiveTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
@@ -728,6 +735,7 @@ export function ProfileRuntimeTabContent({
   agentInstruction,
   diagnosticsFields,
   diagnosticsSummary,
+  needsRestart = false,
   onOpenDiagnostics,
   onOpenInstructions,
   runtimeConfigurationFields,
@@ -738,6 +746,8 @@ export function ProfileRuntimeTabContent({
   agentInstruction: string | null;
   diagnosticsFields: ProfileField[];
   diagnosticsSummary: React.ReactNode;
+  /** True when the running agent's config has drifted from what it was spawned with. */
+  needsRestart?: boolean;
   onOpenDiagnostics: () => void;
   onOpenInstructions: () => void;
   runtimeConfigurationFields: ProfileField[];
@@ -766,6 +776,24 @@ export function ProfileRuntimeTabContent({
 
   return (
     <div className="space-y-2">
+      {needsRestart ? (
+        <div
+          className="flex items-start gap-3 rounded-2xl bg-amber-500/10 px-4 py-3"
+          data-testid="needs-restart-banner"
+        >
+          <RefreshCw className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <div className="min-w-0 text-sm">
+            <p className="font-medium text-amber-600 dark:text-amber-400">
+              Restart required
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Configuration changed since this agent started. It will restart
+              automatically after ~3 minutes idle, or restart manually for
+              immediate effect.
+            </p>
+          </div>
+        </div>
+      ) : null}
       {showInstructionBlock ? (
         <div className="overflow-hidden rounded-2xl bg-muted/20">
           <AgentInstructionRow

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -69,6 +69,7 @@ type MockManagedAgentSeed = {
   lastError?: string | null;
   lastErrorCode?: number | null;
   needsRestart?: boolean;
+  autoRestartOnConfigChange?: boolean;
   respondTo?: RawManagedAgent["respond_to"];
   respondToAllowlist?: string[];
 };
@@ -1734,7 +1735,7 @@ function buildSeededManagedAgent(seed: MockManagedAgentSeed): MockManagedAgent {
     needs_restart: seed.needsRestart ?? false,
     log_path: `/tmp/mock-agent-${seed.pubkey}.log`,
     start_on_app_launch: true,
-    auto_restart_on_config_change: true,
+    auto_restart_on_config_change: seed.autoRestartOnConfigChange ?? true,
     backend: seed.backend ?? { type: "local" },
     backend_agent_id: null,
     respond_to: seed.respondTo ?? "owner-only",

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -68,6 +68,7 @@ type MockManagedAgentSeed = {
   backend?: RawManagedAgent["backend"];
   lastError?: string | null;
   lastErrorCode?: number | null;
+  needsRestart?: boolean;
   respondTo?: RawManagedAgent["respond_to"];
   respondToAllowlist?: string[];
 };
@@ -537,6 +538,7 @@ type RawManagedAgent = {
   last_exit_code: number | null;
   last_error: string | null;
   last_error_code: number | null;
+  needs_restart?: boolean;
   log_path: string;
   start_on_app_launch: boolean;
   auto_restart_on_config_change?: boolean;
@@ -1197,6 +1199,7 @@ function cloneManagedAgent(agent: MockManagedAgent): RawManagedAgent {
     last_exit_code: agent.last_exit_code,
     last_error: agent.last_error,
     last_error_code: agent.last_error_code,
+    needs_restart: agent.needs_restart ?? false,
     log_path: agent.log_path,
     start_on_app_launch: agent.start_on_app_launch,
     auto_restart_on_config_change: agent.auto_restart_on_config_change ?? true,
@@ -1728,6 +1731,7 @@ function buildSeededManagedAgent(seed: MockManagedAgentSeed): MockManagedAgent {
     last_exit_code: null,
     last_error: seed.lastError ?? null,
     last_error_code: seed.lastErrorCode ?? null,
+    needs_restart: seed.needsRestart ?? false,
     log_path: `/tmp/mock-agent-${seed.pubkey}.log`,
     start_on_app_launch: true,
     auto_restart_on_config_change: true,

--- a/desktop/tests/e2e/needs-restart-screenshots.spec.ts
+++ b/desktop/tests/e2e/needs-restart-screenshots.spec.ts
@@ -3,8 +3,9 @@
  *
  * Exercises two surfaces:
  *   - Agent grid card: warning badge ("Restart required") on standalone and
- *     persona-backed cards when `needsRestart: true`.
- *   - Profile panel Runtime tab: amber banner explaining auto-restart behavior.
+ *     persona-backed cards when `needsRestart: true`, absent when false.
+ *   - Profile panel Runtime tab: amber banner with copy branched on the
+ *     per-agent auto-restart toggle.
  */
 
 import { expect, test } from "@playwright/test";
@@ -27,6 +28,14 @@ const PERSONA_AGENT = {
   personaId: "builtin:fizz",
   status: "running" as const,
   needsRestart: true,
+};
+
+/** A running agent with no config drift — badge must be absent. */
+const NO_DRIFT_AGENT = {
+  pubkey: TEST_IDENTITIES.tyler.pubkey,
+  name: "Stable Agent",
+  status: "running" as const,
+  needsRestart: false,
 };
 
 async function gotoAgentsView(page: import("@playwright/test").Page) {
@@ -55,17 +64,30 @@ test.describe("needs-restart screenshots", () => {
 
   test("01-grid-standalone-restart-badge", async ({ page }) => {
     await installMockBridge(page, {
-      managedAgents: [STANDALONE_AGENT],
+      managedAgents: [STANDALONE_AGENT, NO_DRIFT_AGENT],
     });
 
     await gotoAgentsView(page);
 
+    // Drifted card shows the badge.
     const agentCard = page.getByTestId(
       `managed-agent-${STANDALONE_AGENT.pubkey}`,
     );
     await expect(agentCard).toBeVisible({ timeout: 10_000 });
-    await waitForAnimations(page);
+    await expect(
+      agentCard.getByText("Restart required", { exact: true }),
+    ).toBeVisible();
 
+    // Non-drifted card does NOT show the badge.
+    const stableCard = page.getByTestId(
+      `managed-agent-${NO_DRIFT_AGENT.pubkey}`,
+    );
+    await expect(stableCard).toBeVisible({ timeout: 10_000 });
+    await expect(
+      stableCard.getByText("Restart required", { exact: true }),
+    ).toHaveCount(0);
+
+    await waitForAnimations(page);
     await agentCard.screenshot({
       path: `${SHOTS}/01-grid-standalone-restart-badge.png`,
     });
@@ -83,8 +105,11 @@ test.describe("needs-restart screenshots", () => {
       `persona-agent-row-${PERSONA_AGENT.personaId}`,
     );
     await expect(personaCard).toBeVisible({ timeout: 10_000 });
-    await waitForAnimations(page);
+    await expect(
+      personaCard.getByText("Restart required", { exact: true }),
+    ).toBeVisible();
 
+    await waitForAnimations(page);
     await personaCard.screenshot({
       path: `${SHOTS}/02-grid-persona-restart-badge.png`,
     });
@@ -113,10 +138,50 @@ test.describe("needs-restart screenshots", () => {
     // Wait for the restart banner to appear.
     const banner = panel.getByTestId("needs-restart-banner");
     await expect(banner).toBeVisible({ timeout: 10_000 });
-    await waitForAnimations(page);
 
+    // Auto-restart defaults ON — verify the enabled copy.
+    await expect(
+      banner.getByText("Buzz can restart it automatically"),
+    ).toBeVisible();
+
+    await waitForAnimations(page);
     await banner.screenshot({
       path: `${SHOTS}/03-runtime-tab-restart-banner.png`,
+    });
+  });
+
+  test("04-runtime-tab-restart-banner-auto-off", async ({ page }) => {
+    const agentAutoOff = {
+      ...STANDALONE_AGENT,
+      autoRestartOnConfigChange: false,
+    };
+
+    await installMockBridge(page, {
+      managedAgents: [agentAutoOff],
+    });
+
+    await gotoAgentsView(page);
+
+    const agentButton = page.getByRole("button", {
+      name: `${agentAutoOff.name} agent profile`,
+    });
+    await expect(agentButton).toBeVisible({ timeout: 10_000 });
+    await agentButton.click();
+
+    const panel = page.getByTestId("user-profile-panel");
+    await expect(panel).toBeVisible({ timeout: 10_000 });
+
+    await panel.getByRole("tab", { name: "Runtime" }).click();
+
+    const banner = panel.getByTestId("needs-restart-banner");
+    await expect(banner).toBeVisible({ timeout: 10_000 });
+
+    // Auto-restart OFF — verify the disabled copy.
+    await expect(banner.getByText("Automatic restart is off")).toBeVisible();
+
+    await waitForAnimations(page);
+    await banner.screenshot({
+      path: `${SHOTS}/04-runtime-tab-restart-banner-auto-off.png`,
     });
   });
 });

--- a/desktop/tests/e2e/needs-restart-screenshots.spec.ts
+++ b/desktop/tests/e2e/needs-restart-screenshots.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Screenshot spec for the needsRestart badge and banner (PR #1853).
+ *
+ * Exercises two surfaces:
+ *   - Agent grid card: warning badge ("Restart required") on standalone and
+ *     persona-backed cards when `needsRestart: true`.
+ *   - Profile panel Runtime tab: amber banner explaining auto-restart behavior.
+ */
+
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
+
+const SHOTS = "test-results/pr-1853-screenshots";
+
+const STANDALONE_AGENT = {
+  pubkey: TEST_IDENTITIES.alice.pubkey,
+  name: "Local Agent",
+  status: "running" as const,
+  needsRestart: true,
+};
+
+const PERSONA_AGENT = {
+  pubkey: TEST_IDENTITIES.bob.pubkey,
+  name: "Persona Agent",
+  personaId: "builtin:fizz",
+  status: "running" as const,
+  needsRestart: true,
+};
+
+async function gotoAgentsView(page: import("@playwright/test").Page) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("open-agents-view")).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByTestId("open-agents-view").click();
+  await expect(page.getByTestId("agents-library-personas")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe("needs-restart screenshots", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test.beforeEach(async ({ page }) => {
+    page.on("pageerror", (err) => {
+      console.error(
+        "PAGE ERROR:",
+        err.message,
+        err.stack?.split("\n").slice(0, 5).join("\n"),
+      );
+    });
+  });
+
+  test("01-grid-standalone-restart-badge", async ({ page }) => {
+    await installMockBridge(page, {
+      managedAgents: [STANDALONE_AGENT],
+    });
+
+    await gotoAgentsView(page);
+
+    const agentCard = page.getByTestId(
+      `managed-agent-${STANDALONE_AGENT.pubkey}`,
+    );
+    await expect(agentCard).toBeVisible({ timeout: 10_000 });
+    await waitForAnimations(page);
+
+    await agentCard.screenshot({
+      path: `${SHOTS}/01-grid-standalone-restart-badge.png`,
+    });
+  });
+
+  test("02-grid-persona-restart-badge", async ({ page }) => {
+    await installMockBridge(page, {
+      activePersonaIds: ["builtin:fizz"],
+      managedAgents: [PERSONA_AGENT],
+    });
+
+    await gotoAgentsView(page);
+
+    const personaCard = page.getByTestId(
+      `persona-agent-row-${PERSONA_AGENT.personaId}`,
+    );
+    await expect(personaCard).toBeVisible({ timeout: 10_000 });
+    await waitForAnimations(page);
+
+    await personaCard.screenshot({
+      path: `${SHOTS}/02-grid-persona-restart-badge.png`,
+    });
+  });
+
+  test("03-runtime-tab-restart-banner", async ({ page }) => {
+    await installMockBridge(page, {
+      managedAgents: [STANDALONE_AGENT],
+    });
+
+    await gotoAgentsView(page);
+
+    // Click the agent card to open the profile panel.
+    const agentButton = page.getByRole("button", {
+      name: `${STANDALONE_AGENT.name} agent profile`,
+    });
+    await expect(agentButton).toBeVisible({ timeout: 10_000 });
+    await agentButton.click();
+
+    const panel = page.getByTestId("user-profile-panel");
+    await expect(panel).toBeVisible({ timeout: 10_000 });
+
+    // Switch to the Runtime tab.
+    await panel.getByRole("tab", { name: "Runtime" }).click();
+
+    // Wait for the restart banner to appear.
+    const banner = panel.getByTestId("needs-restart-banner");
+    await expect(banner).toBeVisible({ timeout: 10_000 });
+    await waitForAnimations(page);
+
+    await banner.screenshot({
+      path: `${SHOTS}/03-runtime-tab-restart-banner.png`,
+    });
+  });
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -54,6 +54,7 @@ type MockManagedAgentSeed = {
     | { type: "provider"; id: string; config: Record<string, unknown> };
   lastError?: string | null;
   lastErrorCode?: number | null;
+  needsRestart?: boolean;
   respondTo?: "owner-only" | "allowlist" | "anyone";
   respondToAllowlist?: string[];
 };

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -55,6 +55,7 @@ type MockManagedAgentSeed = {
   lastError?: string | null;
   lastErrorCode?: number | null;
   needsRestart?: boolean;
+  autoRestartOnConfigChange?: boolean;
   respondTo?: "owner-only" | "allowlist" | "anyone";
   respondToAllowlist?: string[];
 };


### PR DESCRIPTION
## Summary

Surface the backend-computed `needsRestart` flag in the two live agent UI surfaces — the flag has been dead code since #1199 orphaned `ManagedAgentRow`.

- **Agents grid card** — `AgentIdentityCard` accepts an optional `statusBadge` slot; both grid call sites pass an amber "Restart required" badge when `agent.needsRestart` is true.
- **Agent profile Runtime tab** — amber banner at the top of `ProfileRuntimeTabContent` with copy branched on the per-agent `autoRestartOnConfigChange` toggle: hedged auto-restart language when ON, explicit "off" guidance when OFF.
- **Screenshot spec** — 4 Playwright cases (standalone badge, persona badge, banner auto-on, banner auto-off) with card-scoped badge text assertions and false-state coverage for non-drifted agents.

UI surfacing only — zero changes to the auto-restart policy loop, `AUTO_RESTART_QUIESCENCE_MS`, or the summary builder. `ManagedAgentRow`/`AgentGroupRows` intentionally untouched (separate in-flight branch owns removal).