### PR TITLE
release: push gateway chart 0.1.0

### DIFF
--- a/deploy/charts/buzz-push-gateway/Chart.yaml
+++ b/deploy/charts/buzz-push-gateway/Chart.yaml
@@ -1,4 +1,6 @@
 apiVersion: v2
+# Published to oci://ghcr.io/block/buzz/charts via push-chart-release/<version>
+# branches (see docs/push-gateway-deployment.md, "Gateway chart release").
 name: buzz-push-gateway
 description: Public capability-gated APNs last-hop gateway for Buzz
 version: 0.1.0


### PR DESCRIPTION
First publication of the `buzz-push-gateway` Helm chart introduced in #1770.

Chart `version`/`appVersion` are already `0.1.0` on main, so this release PR carries only a Chart.yaml comment documenting the release lane — the branch name is the release mechanism.

**On merge** (per `docs/push-gateway-deployment.md`, "Gateway chart release"):
- `auto-tag-on-release-pr-merge.yml` matches `push-chart-release/*`, tags the merge commit `push-chart-v0.1.0`, and dispatches `push-gateway-helm-chart.yml` with `version=0.1.0` / `ref=push-chart-v0.1.0`.
- The publisher verifies tag↔commit↔chart-version agreement, then pushes `oci://ghcr.io/block/buzz/charts/buzz-push-gateway:0.1.0`.

**Validation at this head:**
- `deploy/charts/buzz-push-gateway/tests/render.sh` — pass (lint + default render + injected production render + rendered-shape asserts)
- `deploy/charts/buzz-push-gateway/tests/release-contract.sh` — pass (cross-workflow lane strings pinned)

Consumer: bb-public Argo will depend on this OCI chart (same pattern as the main `buzz` chart), with `httpRoute.enabled=false` behind Istio ingress. Deploying the gateway itself remains gated on Apple credential provisioning and a dedicated gateway database — tracked in the bb-public rollout, not this PR.