### PR TITLE
chore(relay): make web UI opt-in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,9 +92,10 @@ COPY --from=builder    /build/target/release/buzz-admin /usr/local/bin/buzz-admi
 COPY --from=builder    /build/target/release/buzz-pair-relay /usr/local/bin/buzz-pair-relay
 COPY --from=web-builder /build/web/dist                 /srv/buzz/web
 
-ENV BUZZ_WEB_DIR=/srv/buzz/web
+# The web UI is bundled but disabled by default. Set
+# BUZZ_WEB_DIR=/srv/buzz/web to opt in.
 
-# 3000: app (WS + REST + web UI)  ·  8080: /_liveness, /_readiness  ·  9102: /metrics
+# 3000: app (WS + REST)  ·  8080: /_liveness, /_readiness  ·  9102: /metrics
 EXPOSE 3000 8080 9102
 
 USER buzz:buzz

--- a/TESTING.md
+++ b/TESTING.md
@@ -272,6 +272,7 @@ out of the box with `just setup` or `just relay`. Common overrides:
 | `BUZZ_AUTO_MIGRATE`             | `false`                     | Opt in with `true`/`1`/`yes`/`on` to run embedded SQLx migrations on relay startup |
 | `RELAY_OWNER_PUBKEY`              | unset                       | Bootstrapped as `owner` in `relay_members` at first start |
 | `BUZZ_ALLOW_NIP_OA_AUTH`        | `false`                     | Enable NIP-OA owner attestation for membership |
+| `BUZZ_WEB_DIR`                  | unset                       | Set to the bundled `/srv/buzz/web` in the container to opt in to the browser web UI |
 
 CLI-side, only two matter for testing:
 


### PR DESCRIPTION
## Summary

- stop enabling the bundled browser web UI by default in the production image
- keep the bundle in the image so operators can opt in with `BUZZ_WEB_DIR=/srv/buzz/web`
- document the default and container opt-in value in `TESTING.md`

This does not change relay routing, WebSocket behavior, NIP-11, smart-HTTP Git, APIs, or in-client Git. With the UI disabled, browser `GET /` falls back to NIP-11 JSON. The shared SPA's `/invite/<code>` route is also unavailable unless the UI is enabled.

## Validation

- `cargo test -p buzz-relay --all-targets` — 582 passed, 16 ignored; auxiliary relay tests passed
- `pnpm --dir web check`
- web production build
- live local relay probe, default/unset: `/` returned NIP-11 JSON
- live local relay probe, `BUZZ_WEB_DIR=web/dist`: `/` returned the SPA HTML
- NIP-11 content negotiation remained functional in both modes
- Hermit Rust 1.95.0 pre-push suites: desktop, mobile, Rust, and desktop Tauri all passed
- focused `cargo test -p buzz-push-gateway -- --nocapture`: 15 passed, 6 ignored

## Deployment audit

Current remote heads do not override the opt-in variable:

- Blox staging `block-coder-tf-stacks` (`sprout`) leaves `BUZZ_WEB_DIR` unset
- `bb-block` has no `BUZZ_WEB_DIR` or `SPROUT_WEB_DIR` override
- `bb-public` has no `BUZZ_WEB_DIR` or `SPROUT_WEB_DIR` override
