### PR TITLE
docs: trial branch-deployed privacy and support pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+---
+title: Buzz Privacy and Support
+---
+
+# Buzz privacy and support
+
+Information for people using the Buzz collaboration app.
+
+- [Privacy policy](privacy.html)
+- [Support](support.html)
+- [Source code](https://github.com/block/buzz)
+
+Buzz is an open-source project from Block, Inc.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,60 @@
+---
+title: Buzz Privacy Policy
+---
+
+# Buzz privacy policy
+
+**Effective July 14, 2026**
+
+This policy describes how the Buzz mobile and desktop applications handle information. Buzz is an open-source collaboration app from Block, Inc. that connects people and software agents through a Nostr-compatible relay.
+
+[Home](index.html) · [Support](support.html) · [Source code](https://github.com/block/buzz)
+
+## How Buzz works
+
+Buzz connects to a relay associated with a workspace. A relay may be operated by Block, your organization, or another party. The operator of the relay you use controls that relay's storage, access, and retention practices. If another organization provides your workspace, contact that organization for details about its practices.
+
+## Information handled by Buzz
+
+Depending on how you use Buzz, the app and your selected relay may handle:
+
+- **Identity and workspace information**, such as a Nostr public key, display name, avatar, workspace name, relay address, and membership or role information.
+- **Content you provide**, including messages, reactions, status information, channel content, and files, photos, or videos you choose to upload.
+- **Collaboration activity**, such as message timestamps, read state, channel membership, replies, mentions, and agent activity needed to provide app features.
+- **Connection and operational information**, such as network requests, relay authentication events, and server logs that a relay operator may process to secure, operate, and troubleshoot its service.
+
+Buzz uses this information to connect to your workspace, deliver collaboration features, maintain app state, secure the service, and troubleshoot problems.
+
+## Information stored on your device
+
+The app stores workspace connection details and your Nostr identity credential on your device. On mobile devices, workspace credentials are stored using the operating system's secure-storage facility. The app also stores local preferences, such as theme, channel organization, mute or star choices, and read state.
+
+Your Nostr private key controls your identity. Do not share it. Anyone who has it may be able to act as you.
+
+## Sharing and visibility
+
+Messages, profile information, uploaded media, and other collaboration activity are sent to your selected relay and may be visible to workspace members according to the workspace's permissions. Content may also be processed by software agents or service providers that you or your workspace operator choose to use.
+
+Buzz does not include advertising SDKs or third-party analytics SDKs in its mobile app, and the app does not use this information for targeted advertising.
+
+## Retention and deletion
+
+Retention depends on the relay and workspace you use. Buzz lets you request deletion of your own messages where the relay and your permissions support it. Removing a workspace from the mobile app deletes that workspace's locally stored credentials and connection information from the app, but does not by itself delete information already sent to a relay or copies visible to other participants.
+
+Because Buzz uses a distributed protocol, a deletion request sent to one relay may not remove copies previously stored by other relays, participants, agents, backups, or external systems. For requests concerning relay-hosted data, contact the operator of your workspace or relay.
+
+## Security
+
+Buzz uses cryptographic signing for Nostr events and supports encrypted network connections to relays. No system is completely secure. Protect your device and private key, use a relay operator you trust, and avoid sharing sensitive information in public issue reports.
+
+## Children
+
+Buzz is intended for workplace and developer collaboration. It is not directed to children.
+
+## Changes to this policy
+
+We may update this policy as Buzz changes. We will post revisions on this page and update the effective date above.
+
+## Contact
+
+For general, non-sensitive questions about this policy, use the public contact option on the [Buzz support page](support.html). Do not post personal or sensitive information in a public issue. For access, deletion, or other requests concerning data controlled by your workspace or relay operator, contact that operator directly.

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,29 @@
+---
+title: Buzz Support
+---
+
+# Buzz support
+
+Get help with the Buzz mobile and desktop applications.
+
+[Home](index.html) · [Privacy policy](privacy.html) · [Source code](https://github.com/block/buzz)
+
+## Get help or report a bug
+
+Use the public [Buzz issue tracker](https://github.com/block/buzz/issues/new/choose) to report a reproducible problem or request a feature. Before opening a new issue, [search existing issues](https://github.com/block/buzz/issues) for a solution.
+
+Include your Buzz version, device and operating-system version, what you expected, what happened, and steps that reproduce the problem.
+
+**Do not include private keys, access tokens, passwords, private messages, personal information, or other sensitive data in a public issue.**
+
+## Workspace and account access
+
+Buzz connects to a workspace through a relay. If you cannot pair, connect, access a channel, or manage workspace-hosted data, contact the administrator or relay operator that provided your workspace. The open-source maintainers cannot restore a lost Nostr private key or change permissions on a relay they do not operate.
+
+## Security vulnerabilities
+
+Do not disclose a suspected security vulnerability in a public issue. Follow the private reporting instructions in the repository's [security policy](https://github.com/block/buzz/security/policy).
+
+## Privacy questions
+
+For questions about the [Buzz privacy policy](privacy.html), open a [public support issue](https://github.com/block/buzz/issues/new/choose) only if the question contains no sensitive information. For data stored by your workspace or relay, contact that workspace's administrator or relay operator directly.


### PR DESCRIPTION
### What changed?

Add the same Buzz privacy-policy and support content proposed in [#1861](https://github.com/block/buzz/pull/1861), expressed as three Markdown pages under `docs/`:

- `docs/index.md`
- `docs/privacy.md`
- `docs/support.md`

This comparison deliberately adds no Actions workflow, `.nojekyll` file, checker script, or custom styling.

### Why?

This trials GitHub Pages' lower-machinery branch-deploy mode so the two approaches can be compared side by side.

If this alternative is chosen, the repository Pages setting must be changed after merge to **Deploy from a branch → `main` → `/docs`**. This PR does not change the live Pages source while both alternatives remain open.

Tradeoffs compared with #1861:

- no pre-merge site/link validation;
- GitHub/Jekyll default theme rendering rather than controlled HTML/CSS;
- public Pages content must live under `/docs` on `main`.

### How is it tested?

Verified the three Markdown files have valid front matter, expected headings, and local page targets. Checked the diff for whitespace errors.

*🤖 This PR was authored [with an agent](codex://threads/c0f081e0f810cdc2fe11f490819ac3ce759d16ae3103bbc0f1a890cd0cac636a).*
