### PR TITLE
fix(acp): sort flushed batch events chronologically so replies thread under the right message

### DIFF
--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1592,7 +1592,7 @@ pub(crate) fn native_steer_framing() -> (&'static str, &'static str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nostr::{EventBuilder, Keys, Kind};
+    use nostr::{EventBuilder, Keys, Kind, Timestamp};
     use std::time::Duration;
 
     /// Build a test event with the given content and kind.
@@ -1620,6 +1620,26 @@ mod tests {
             channel_id,
             event: make_event(content),
             received_at: Instant::now() - age,
+            prompt_tag: "test".into(),
+        }
+    }
+
+    /// Build a QueuedEvent with an explicit Nostr `created_at` timestamp.
+    fn make_queued_created_at(
+        channel_id: Uuid,
+        content: &str,
+        created_at_secs: u64,
+    ) -> QueuedEvent {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), content)
+            .custom_created_at(Timestamp::from(created_at_secs))
+            .tags([])
+            .sign_with_keys(&keys)
+            .unwrap();
+        QueuedEvent {
+            channel_id,
+            event,
+            received_at: Instant::now(),
             prompt_tag: "test".into(),
         }
     }
@@ -1720,6 +1740,34 @@ mod tests {
         // All drained.
         assert_eq!(pending_count(&q), 0);
         assert_eq!(q.queues.len(), 0);
+    }
+
+    #[test]
+    fn test_flush_orders_replayed_events_chronologically() {
+        // Relay replay after a reconnect/restart delivers stored events newest
+        // first (`ORDER BY created_at DESC`), but `format_prompt` derives the
+        // reply anchor and scope from the LAST batch event on the assumption
+        // that it is the newest. The drained batch must therefore be
+        // chronological regardless of delivery order.
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+
+        q.push(make_queued_created_at(ch, "newest", 2_000));
+        q.push(make_queued_created_at(ch, "oldest", 1_000));
+
+        let batch = q.flush_next().expect("should return batch");
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(batch.events[0].event.content, "oldest");
+        assert_eq!(batch.events[1].event.content, "newest");
+
+        // The rendered prompt's reply anchor must cite the newest event, so
+        // the agent's reply threads under the message it is responding to.
+        let newest_id = batch.events[1].event.id.to_hex();
+        let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
+        assert!(
+            prompt.contains(&format!("--reply-to {newest_id}")),
+            "reply anchor must target the newest event; prompt was:\n{prompt}"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -314,7 +314,7 @@ impl EventQueue {
         // Drain up to MAX_BATCH_EVENTS; leave any remainder in the queue.
         let queue = self.queues.entry(channel_id).or_default();
         let drain_count = MAX_BATCH_EVENTS.min(queue.len());
-        let events: Vec<BatchEvent> = queue
+        let mut events: Vec<BatchEvent> = queue
             .drain(..drain_count)
             .map(|qe| BatchEvent {
                 event: qe.event,
@@ -322,6 +322,11 @@ impl EventQueue {
                 received_at: qe.received_at,
             })
             .collect();
+        // Relay replay delivers stored events newest-first (`ORDER BY
+        // created_at DESC`), but batch consumers — `format_prompt` scope and
+        // reply-anchor selection — require the LAST event to be the newest.
+        // Stable sort: same-second events keep delivery order.
+        events.sort_by_key(|be| be.event.created_at);
 
         // Remove the queue entry if now empty.
         if self.queues.get(&channel_id).is_some_and(|q| q.is_empty()) {


### PR DESCRIPTION
## Why

When the ACP harness restarts or reconnects while @mentions are pending, the missed events are replayed from the relay's stored-event query, which returns them newest-first (`ORDER BY created_at DESC`). The per-channel queue preserves delivery order, and `format_prompt` derives the reply anchor and scope from the **last** batch event on the documented assumption that it is the newest — "that's the one the agent is responding to."

With a replayed batch that assumption inverts: the last event is the *oldest* mention, so the `--reply-to` anchor points at the wrong message and the agent's replies land in the wrong thread. Observed with two top-level mentions sent while an agent's harness was down — after a stop/start, both replies threaded under the first message.

## What

`EventQueue::flush_next` now sorts the drained batch chronologically by `created_at` at the single seam where batches are assembled, restoring the invariant for every consumer. The sort is stable, so same-second events keep their delivery order.

Note: a batch containing several top-level human mentions still gets a single reply anchor (the newest). Per-mention anchors would need a prompt-format change and feel out of scope for this fix — happy to file a follow-up issue if the team agrees it's worth doing.

## Test plan

- New unit test pushes two mentions newest-first (simulating replay) and asserts the flushed batch is chronological and the rendered `--reply-to` anchor cites the newest event. It fails before the fix (anchor cites the oldest mention) and passes after.
- `cargo test -p buzz-acp --lib` — 506 passed.
- `cargo fmt --check` and `cargo clippy -p buzz-acp --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)