### PR TITLE
fix(desktop): exit cleanly on fatal setup errors instead of SIGABRT

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -423,8 +423,10 @@ pub fn run() {
             // that will be lost on restart, as that silently breaks channel
             // memberships, DMs, and relay identity.
             let state = app_handle.state::<AppState>();
-            resolve_persisted_identity(&app_handle, &state)
-                .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            if let Err(e) = resolve_persisted_identity(&app_handle, &state) {
+                eprintln!("buzz-desktop: fatal: identity resolution failed: {e}");
+                std::process::exit(1);
+            }
 
             // When the identity is in recovery mode (lost = keyring empty after
             // migration, or keyring-locked = keyring unreachable but marker
@@ -441,11 +443,13 @@ pub fn run() {
 
             // Snapshot owner keys after identity resolution; the best-effort
             // event reconcile itself runs off the synchronous setup path below.
-            let owner_keys = state
-                .keys
-                .lock()
-                .map(|k| k.clone())
-                .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+            let owner_keys = match state.keys.lock() {
+                Ok(k) => k.clone(),
+                Err(e) => {
+                    eprintln!("buzz-desktop: fatal: identity keys poisoned: {e}");
+                    std::process::exit(1);
+                }
+            };
 
             // Backfill the pinned persona snapshot for any pre-existing agent
             // that predates the record-authoritative-spawn cutover (persona_id


### PR DESCRIPTION
## Problem

When the Tauri setup closure returns `Err`, Tauri's `app.rs` calls `panic!("Failed to setup app: {e}")`. Because setup runs inside tao's `did_finish_launching` — an `extern "C"` FFI callback — Rust cannot unwind across the ABI boundary. The runtime escalates to `panic_cannot_unwind` → SIGABRT.

macOS treats SIGABRT as a crash and auto-relaunches the app. If the root cause is persistent (e.g., a corrupted keyring entry), every relaunch panics again, producing a 6-crash pile-up before macOS gives up. This is tracked upstream as [tao#1171](https://github.com/tauri-apps/tao/issues/1171) (still open).

## Crash chain

```
setup closure returns Err
  → Tauri: panic!("Failed to setup app: {e}")
    → tao did_finish_launching (extern "C")
      → panic_cannot_unwind
        → SIGABRT
          → macOS auto-relaunch → repeat × 6
```

## Fix

Replace the 2 `?` operators in the setup closure that could trigger this path with explicit `eprintln! + process::exit(1)`:

- **Identity resolution** (`resolve_persisted_identity`): fatal because an ephemeral identity breaks channel memberships, DMs, and relay identity across restarts.
- **Keys mutex access** (`state.keys.lock()`): fatal because a poisoned mutex means another thread panicked while holding it — the app state is unrecoverable.

`process::exit(1)` produces a clean exit with no crash report. macOS does not auto-relaunch on clean exits, breaking the crash-loop.