### PR TITLE
chore(desktop): replace setup ? operators with clean exit

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -458,8 +458,10 @@ pub fn run() {
             // that will be lost on restart, as that silently breaks channel
             // memberships, DMs, and relay identity.
             let state = app_handle.state::<AppState>();
-            resolve_persisted_identity(&app_handle, &state)
-                .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            if let Err(e) = resolve_persisted_identity(&app_handle, &state) {
+                eprintln!("buzz-desktop: fatal: identity resolution failed: {e}");
+                std::process::exit(1);
+            }
 
             // When the identity is in recovery mode (lost = keyring empty after
             // migration, or keyring-locked = keyring unreachable but marker
@@ -476,11 +478,13 @@ pub fn run() {
 
             // Snapshot owner keys after identity resolution; the best-effort
             // event reconcile itself runs off the synchronous setup path below.
-            let owner_keys = state
-                .keys
-                .lock()
-                .map(|k| k.clone())
-                .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+            let owner_keys = match state.keys.lock() {
+                Ok(k) => k.clone(),
+                Err(e) => {
+                    eprintln!("buzz-desktop: fatal: owner keys lock poisoned: {e}");
+                    std::process::exit(1);
+                }
+            };
 
             // Backfill the pinned persona snapshot for any pre-existing agent
             // that predates the record-authoritative-spawn cutover (persona_id


### PR DESCRIPTION
## Summary

- Replace the 2 `?` operators in the Tauri setup closure (`desktop/src-tauri/src/lib.rs`) with `eprintln!` + `std::process::exit(1)` to avoid SIGABRT crash-loops.
- The setup closure runs inside tao's `did_finish_launching` — an `extern "C"` FFI callback where panics cannot unwind. Propagating `Err` via `?` triggers Tauri's `panic!("Failed to setup app: {e}")` at the FFI boundary, which Rust escalates to `panic_cannot_unwind` → SIGABRT. macOS then auto-relaunches the crashed app, creating a crash-loop with confusing OAuth cache errors.
- With `std::process::exit(1)`, fatal setup errors produce a clean process exit with a clear log message instead of a SIGABRT crash report, and macOS treats clean exits differently from crashes (no auto-relaunch pile-up).

Related upstream: [tauri-apps/tao#1171](https://github.com/tauri-apps/tao/issues/1171)