### PR TITLE
chore(hooks): use Hermit `just` for pre-push

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,10 +21,10 @@ pre-push:
   parallel: true
   commands:
     rust-tests:
-      run: just test-unit
+      run: bin/just test-unit
     desktop-test:
-      run: just desktop-test
+      run: bin/just desktop-test
     desktop-tauri-test:
-      run: just desktop-tauri-test
+      run: bin/just desktop-tauri-test
     mobile-test:
-      run: just mobile-test
+      run: bin/just mobile-test


### PR DESCRIPTION
### What changed?

The repository pre-push commands now invoke `bin/just` rather than a bare `just`, ensuring each recipe runs through Buzz's Hermit-pinned tools.

Pre-commit commands are intentionally unchanged and can be handled separately.

### Why?

A bare `just` can resolve outside the repository toolchain when Hermit is not already active. The checked-in proxy makes pre-push validation deterministic across developer environments.

### How is it tested?

- `bin/lefthook dump` resolves all four pre-push commands to `bin/just`.
- Targeted `bin/lefthook run pre-push --command rust-tests --force --no-tty` passed.
- A real `git push` passed all repository pre-push commands: Rust, desktop, desktop Tauri, and mobile.
- From a scrubbed environment with `PATH=/usr/bin:/bin:/opt/homebrew/bin` and no incoming Flutter, `bin/just mobile-test` passed all 482 tests; its child process resolved Hermit `bin/flutter` at Flutter 3.41.7.
- `bin/just --version` resolved the checked-in `.just-1.46.0.pkg` proxy; `bin/rustc --version` and `bin/cargo --version` resolved Rust 1.95.0.

Before/after images are not applicable because this only changes local hook tool selection and has no user-visible UI.

