### PR TITLE
feat(desktop): "Also send to #channel" broadcast opt-in for thread replies

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
         "**/home-collapsed-top-chrome.spec.ts",
         "**/top-chrome-zoom-clearance.spec.ts",
         "**/thread-unread.spec.ts",
+        "**/thread-broadcast.spec.ts",
         "**/community-rail.spec.ts",
         "**/boot-splash.spec.ts",
         "**/thread-reply-anchor-roleplay.spec.ts",

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -85,7 +85,9 @@ const overrides = new Map([
   // the two p-gate filters can't drift) plus two guard unit tests. The file was
   // already at 995; this load-bearing correctness fix crossed 1000. Not generic
   // debt growth. Approved override; queued to split with the rest of this list.
-  ["src-tauri/src/commands/messages.rs", 1082],
+  // thread-reply-broadcast: `broadcast: Option<bool>` IPC param threaded into
+  // build_message (+3 lines) — NIP-CW "Also send to #channel". Queued to split.
+  ["src-tauri/src/commands/messages.rs", 1085],
   // Residual repos_dir integration in ensure_nest_at: REPOS is provisioned
   // outside NEST_DIRS (it may be a symlink), so it needs its own create +
   // chmod-only-when-real-dir handling plus integration test coverage. The
@@ -202,7 +204,9 @@ const overrides = new Map([
   // mapper. This is the existing API boundary; split remains queued.
   // team-instructions-first-class: createManagedAgent Tauri bridge threads the
   // new teamId input through to the backend (+1 line).
-  ["src/shared/api/tauri.ts", 1305],
+  // thread-reply-broadcast: sendChannelMessage threads the NIP-CW broadcast
+  // opt-in through the IPC payload (+2 lines).
+  ["src/shared/api/tauri.ts", 1307],
   // doctor-npm-eacces-preflight: hint field added to InstallStepResult (+1 line).
   // codex-acp-package-swap: "adapter_outdated" variant added to AcpAvailabilityStatus (+1 line).
   // doctor-install-reliability: AuthStatus tagged union + nodeRequired/authStatus/
@@ -324,7 +328,10 @@ const overrides = new Map([
   // already here) for the single-toggle mark-read/unread menu item — a small
   // overage from load-bearing per-message plumbing, not generic debt growth.
   // Approved override; still queued to split with the rest of this list.
-  ["src/features/messages/ui/MessageThreadPanel.tsx", 1006],
+  // thread-reply-broadcast: one-shot "Also send to #channel" opt-in (NIP-CW) —
+  // checkbox row under the composer + submit-time capture state (+39 lines).
+  // Load-bearing feature growth; queued to split.
+  ["src/features/messages/ui/MessageThreadPanel.tsx", 1045],
   // AgentConfigPanel footer fold into ProfileFieldGroup for the config-bridge
   // panel — a small overage from load-bearing UI plumbing, not generic debt
   // growth. Approved override; still queued to split with the rest of this list.

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -484,6 +484,7 @@ pub async fn send_channel_message(
     mention_tags: Option<Vec<Vec<String>>>,
     mention_pubkeys: Option<Vec<String>>,
     kind: Option<u32>,
+    broadcast: Option<bool>,
     state: State<'_, AppState>,
 ) -> Result<SendChannelMessageResponse, String> {
     let channel_uuid = uuid::Uuid::parse_str(&channel_id)
@@ -537,6 +538,7 @@ pub async fn send_channel_message(
                 &media,
                 &emoji,
                 &mention_refs_only,
+                broadcast.unwrap_or(false),
             )?
         }
     };
@@ -734,6 +736,7 @@ pub async fn send_managed_agent_channel_message(
         &[],
         &[],
         &[],
+        false,
         &client_tags,
     )?;
     let result =

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -287,6 +287,7 @@ pub fn build_remove_member(channel_id: Uuid, target_pubkey: &str) -> Result<Even
 // ── Messages ─────────────────────────────────────────────────────────────────
 
 /// Kind 9 — stream message.
+#[allow(clippy::too_many_arguments)]
 pub fn build_message(
     channel_id: Uuid,
     content: &str,
@@ -295,6 +296,7 @@ pub fn build_message(
     media_tags: &[Vec<String>],
     custom_emoji_tags: &[Vec<String>],
     mention_ref_tags: &[Vec<String>],
+    broadcast: bool,
 ) -> Result<EventBuilder, String> {
     build_message_with_client_tags(
         channel_id,
@@ -304,6 +306,7 @@ pub fn build_message(
         media_tags,
         custom_emoji_tags,
         mention_ref_tags,
+        broadcast,
         &[],
     )
 }
@@ -313,6 +316,12 @@ pub fn build_message(
 /// This is intentionally narrower than arbitrary extra tags: callers can add
 /// only `["client", ...]` tags, which are useful for idempotency markers but
 /// cannot forge channel/thread/mention metadata.
+///
+/// `broadcast` appends the NIP-CW `["broadcast", "1"]` tag — the author's
+/// opt-in to surface a thread reply on the channel timeline as well as in its
+/// thread. It only applies to replies: without a `thread_ref` the flag is
+/// ignored (the tag is defined for replies only; the relay treats it as inert
+/// elsewhere).
 #[allow(clippy::too_many_arguments)]
 pub fn build_message_with_client_tags(
     channel_id: Uuid,
@@ -322,12 +331,16 @@ pub fn build_message_with_client_tags(
     media_tags: &[Vec<String>],
     custom_emoji_tags: &[Vec<String>],
     mention_ref_tags: &[Vec<String>],
+    broadcast: bool,
     client_tags: &[Vec<String>],
 ) -> Result<EventBuilder, String> {
     check_content(content)?;
     let mut tags = vec![tag(vec!["h", &channel_id.to_string()])?];
     if let Some(tr) = thread_ref {
         tags.extend(thread_tags(tr)?);
+        if broadcast {
+            tags.push(tag(vec!["broadcast", "1"])?);
+        }
     }
     tags.extend(mention_tags(mentions)?);
     imeta_tags(media_tags, &mut tags)?;
@@ -833,6 +846,58 @@ pub fn build_approval_deny(token: &str, note: Option<&str>) -> Result<EventBuild
 mod tests {
     use super::*;
     use nostr::Keys;
+
+    fn message_tags(thread_ref: Option<&ThreadRef>, broadcast: bool) -> Vec<Vec<String>> {
+        let channel_id = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let builder = build_message(
+            channel_id,
+            "hello",
+            thread_ref,
+            &[],
+            &[],
+            &[],
+            &[],
+            broadcast,
+        )
+        .expect("build_message");
+        let secret = nostr::SecretKey::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        )
+        .unwrap();
+        let event = builder.sign_with_keys(&Keys::new(secret)).unwrap();
+        event.tags.iter().map(|t| t.as_slice().to_vec()).collect()
+    }
+
+    fn has_broadcast_tag(tags: &[Vec<String>]) -> bool {
+        tags.iter()
+            .any(|t| t.len() >= 2 && t[0] == "broadcast" && t[1] == "1")
+    }
+
+    /// NIP-CW: a broadcast reply carries the exact tag `["broadcast", "1"]`.
+    #[test]
+    fn message_reply_broadcast_tag() {
+        const PARENT_HEX: &str = "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+        let parent = EventId::from_hex(PARENT_HEX).unwrap();
+        let thread_ref = ThreadRef {
+            root_event_id: parent,
+            parent_event_id: parent,
+        };
+
+        let tags = message_tags(Some(&thread_ref), true);
+        assert!(has_broadcast_tag(&tags));
+
+        // Off by default.
+        let tags = message_tags(Some(&thread_ref), false);
+        assert!(!has_broadcast_tag(&tags));
+    }
+
+    /// Broadcast is defined for replies only — a top-level message never
+    /// carries the tag, even when a caller asks for it.
+    #[test]
+    fn message_top_level_ignores_broadcast() {
+        let tags = message_tags(None, true);
+        assert!(!has_broadcast_tag(&tags));
+    }
 
     /// Builder layout regression for the NIP-IA owner-of-agent archive flow.
     /// Compares against `docs/nips/NIP-IA.md` §Vector 1.

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -297,14 +297,22 @@ pub(crate) fn spawn_transcription_task(
                 .clone();
 
             let p_tags: Vec<&str> = agent_pubkeys.iter().map(|s| s.as_str()).collect();
-            let builder =
-                match events::build_message(channel_uuid, &t, None, &p_tags, &[], &[], &[]) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        eprintln!("buzz-desktop: STT build_message: {e}");
-                        continue;
-                    }
-                };
+            let builder = match events::build_message(
+                channel_uuid,
+                &t,
+                None,
+                &p_tags,
+                &[],
+                &[],
+                &[],
+                false,
+            ) {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!("buzz-desktop: STT build_message: {e}");
+                    continue;
+                }
+            };
             let event = match builder.sign_with_keys(&keys) {
                 Ok(e) => e,
                 Err(e) => {

--- a/desktop/src/features/channels/ui/ChannelPane.types.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.types.ts
@@ -3,6 +3,7 @@ import type { BotActivityAgent } from "@/features/channels/ui/BotActivityBar";
 import type { ChannelAgentSessionAgent } from "@/features/channels/ui/useChannelAgentSessions";
 import type { ImetaMedia } from "@/features/messages/lib/imetaMediaMarkdown";
 import type { MainTimelineEntry } from "@/features/messages/lib/threadPanel";
+import type { ThreadSendContext } from "@/features/messages/lib/threading";
 import type { ChannelWindowThreadSummary } from "@/features/messages/lib/channelWindowStore";
 import type { TimelineMessage } from "@/features/messages/types";
 import type { TypingIndicatorEntry } from "@/features/messages/useChannelTyping";
@@ -105,10 +106,7 @@ export type ChannelPaneProps = {
     mentionPubkeys: string[],
     mediaTags?: string[][],
     channelId?: string | null,
-    threadContext?: {
-      parentEventId: string | null;
-      threadHeadId: string | null;
-    } | null,
+    threadContext?: ThreadSendContext | null,
   ) => Promise<void>;
   onTargetReached?: (messageId: string) => void;
   onToggleReaction?: (

--- a/desktop/src/features/channels/useChannelPaneHandlers.ts
+++ b/desktop/src/features/channels/useChannelPaneHandlers.ts
@@ -7,6 +7,7 @@ import type {
   useToggleReactionMutation,
 } from "@/features/messages/hooks";
 import { resolveThreadReplyTarget } from "@/features/messages/hooks";
+import type { ThreadSendContext } from "@/features/messages/lib/threading";
 
 /**
  * Stable callback references for ChannelPane so that keystroke-driven
@@ -261,10 +262,7 @@ export function useChannelPaneHandlers({
       mentionPubkeys: string[],
       mediaTags?: string[][],
       channelId?: string | null,
-      threadContext?: {
-        parentEventId: string | null;
-        threadHeadId: string | null;
-      } | null,
+      threadContext?: ThreadSendContext | null,
     ) => {
       // Resolve target using captured submit-time context (race-free) or live
       // refs (legacy path). When threadContext is supplied, no live-ref reads
@@ -297,6 +295,9 @@ export function useChannelPaneHandlers({
         parentEventId,
         mediaTags,
         channelId: channelId ?? undefined,
+        // Broadcast rides the captured submit-time context only — the legacy
+        // live-ref path has no checkbox state to honor.
+        broadcast: threadContext?.broadcast === true,
       });
 
       // Only update thread UI state if the user is still viewing the same

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -13,6 +13,7 @@ import {
   isBroadcastReply,
   normalizeMentionPubkeys,
   resolveReplyRootId,
+  type ThreadSendContext,
 } from "@/features/messages/lib/threading";
 import {
   projectChannelWindowMessages,
@@ -86,6 +87,7 @@ export function createOptimisticMessage(
   mentionPubkeys: string[] = [],
   parentEventId: string | null = null,
   mediaTags: string[][] = [],
+  broadcast = false,
 ): RelayEvent {
   const localKey = `optimistic-${crypto.randomUUID()}`;
   const tags: string[][] = [];
@@ -98,6 +100,7 @@ export function createOptimisticMessage(
         parentEventId,
         resolveReplyRootId(parentEventId, currentMessages),
         mentionPubkeys,
+        broadcast,
       ),
     );
   } else {
@@ -184,10 +187,7 @@ export function resolveSendChannel(
  * Returns null when no parentEventId can be resolved (caller should bail).
  */
 export function resolveThreadReplyTarget(
-  threadContext:
-    | { parentEventId: string | null; threadHeadId: string | null }
-    | null
-    | undefined,
+  threadContext: ThreadSendContext | null | undefined,
   liveReplyTargetId: string | null | undefined,
   liveThreadHeadId: string | null | undefined,
 ): { parentEventId: string; threadHeadId: string | null } | null {
@@ -401,6 +401,8 @@ export function useSendMessageMutation(
       mentionPubkeys?: string[];
       parentEventId?: string | null;
       mediaTags?: string[][];
+      /** NIP-CW: surface a thread reply on the channel timeline too. */
+      broadcast?: boolean;
     },
     MessageQueryContext | undefined
   >({
@@ -411,6 +413,7 @@ export function useSendMessageMutation(
       mentionPubkeys,
       parentEventId,
       mediaTags,
+      broadcast,
     }) => {
       // Prefer a channel captured by the caller at compose time. Otherwise,
       // resolve a captured id from the shared channel cache so navigation
@@ -465,6 +468,7 @@ export function useSendMessageMutation(
           undefined,
           emojiTags,
           mentionTags,
+          parentEventId ? broadcast : undefined,
         );
 
         // Build tags matching relay-emitted shape: h, author p, mention ps, reply es, imeta, emoji.
@@ -477,6 +481,7 @@ export function useSendMessageMutation(
               parentEventId,
               resolveReplyRootId(parentEventId, cachedMessages),
               mentionPubkeys,
+              broadcast ?? false,
             )
           : [];
         const baseTags = parentEventId
@@ -523,6 +528,7 @@ export function useSendMessageMutation(
       mentionPubkeys,
       parentEventId,
       mediaTags,
+      broadcast,
     }) => {
       // Mirror mutationFn's target resolution so the optimistic message lands
       // in the cache for the same channel as the real send. A caller-supplied
@@ -558,6 +564,7 @@ export function useSendMessageMutation(
         mentionPubkeys ?? [],
         parentEventId ?? null,
         mediaTags ?? [],
+        broadcast ?? false,
       );
 
       const nextWindow = mergeLiveChannelWindowEvent(

--- a/desktop/src/features/messages/lib/threadPanel.test.mjs
+++ b/desktop/src/features/messages/lib/threadPanel.test.mjs
@@ -8,6 +8,7 @@ import {
   buildThreadPanelDataFromIndex,
   buildThreadPanelIndex,
   buildThreadSummaryFromVisibleEntries,
+  canBroadcastThreadReply,
   hasNestedThreadBranches,
   shouldRenderUnreadDivider,
 } from "./threadPanel.ts";
@@ -700,4 +701,40 @@ test("buildMainTimelineEntries merges local knowledge over the relay floor", () 
     entry.summary?.participants.map((participant) => participant.id),
     ["relay", "local"],
   );
+});
+
+test("canBroadcastThreadReply allows direct replies to a top-level thread head", () => {
+  const threadHead = message({ id: "root" });
+
+  // No explicit reply target — composer defaults to replying to the head.
+  assert.equal(canBroadcastThreadReply(threadHead, null), true);
+
+  // Explicit reply target that is the thread head itself.
+  assert.equal(canBroadcastThreadReply(threadHead, { id: "root" }), true);
+});
+
+test("canBroadcastThreadReply rejects nested reply targets", () => {
+  const threadHead = message({ id: "root" });
+
+  assert.equal(
+    canBroadcastThreadReply(threadHead, { id: "nested-reply" }),
+    false,
+  );
+});
+
+test("canBroadcastThreadReply rejects thread heads that are themselves replies", () => {
+  const nestedHead = message({
+    id: "branch",
+    parentId: "root",
+    rootId: "root",
+    depth: 1,
+  });
+
+  assert.equal(canBroadcastThreadReply(nestedHead, null), false);
+  assert.equal(canBroadcastThreadReply(nestedHead, { id: "branch" }), false);
+});
+
+test("canBroadcastThreadReply rejects a missing thread head", () => {
+  assert.equal(canBroadcastThreadReply(null, null), false);
+  assert.equal(canBroadcastThreadReply(null, { id: "root" }), false);
 });

--- a/desktop/src/features/messages/lib/threadPanel.ts
+++ b/desktop/src/features/messages/lib/threadPanel.ts
@@ -428,6 +428,23 @@ function mergeThreadSummaries(
   };
 }
 
+/**
+ * Whether the thread composer may offer "Also send to #channel" (NIP-CW
+ * broadcast). Only a depth-1 reply — a direct reply to a *root* thread head —
+ * ever surfaces on the channel timeline, so the toggle is limited to that
+ * configuration: replying to the thread head itself (no nested reply target),
+ * where the head opens the thread rather than replying into one.
+ */
+export function canBroadcastThreadReply(
+  threadHead: Pick<TimelineMessage, "id" | "parentId"> | null,
+  replyTargetMessage: Pick<TimelineMessage, "id"> | null,
+): boolean {
+  if (!threadHead || threadHead.parentId != null) {
+    return false;
+  }
+  return replyTargetMessage == null || replyTargetMessage.id === threadHead.id;
+}
+
 export function buildMainTimelineEntries(
   messages: TimelineMessage[],
   unreadReplyIds: ReadonlySet<string> = new Set(),

--- a/desktop/src/features/messages/lib/threading.test.mjs
+++ b/desktop/src/features/messages/lib/threading.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildReplyTags } from "./threading.ts";
+
+const CHANNEL_ID = "channel-1";
+const AUTHOR = "author-pubkey";
+
+function hasBroadcastTag(tags) {
+  return tags.some(
+    (tag) => tag.length >= 2 && tag[0] === "broadcast" && tag[1] === "1",
+  );
+}
+
+test("buildReplyTags omits the broadcast tag by default", () => {
+  const tags = buildReplyTags(CHANNEL_ID, AUTHOR, "root", "root");
+
+  assert.equal(hasBroadcastTag(tags), false);
+});
+
+test("buildReplyTags adds the NIP-CW broadcast tag when requested", () => {
+  const tags = buildReplyTags(CHANNEL_ID, AUTHOR, "root", "root", [], true);
+
+  assert.equal(hasBroadcastTag(tags), true);
+  // Thread e-tags must stay last so relay-side parsing is unaffected.
+  assert.deepEqual(tags.at(-1), ["e", "root", "", "reply"]);
+});
+
+test("buildReplyTags keeps depth-1 reply shape with broadcast enabled", () => {
+  const tags = buildReplyTags(CHANNEL_ID, AUTHOR, "root", "root", [], true);
+
+  assert.deepEqual(tags, [
+    ["p", AUTHOR],
+    ["h", CHANNEL_ID],
+    ["broadcast", "1"],
+    ["e", "root", "", "reply"],
+  ]);
+});
+
+test("buildReplyTags supports broadcast on nested replies (root + reply e-tags)", () => {
+  // The UI only offers broadcast for direct replies to the thread head, but
+  // the tag builder itself stays orthogonal to that policy.
+  const tags = buildReplyTags(CHANNEL_ID, AUTHOR, "parent", "root", [], true);
+
+  assert.equal(hasBroadcastTag(tags), true);
+  assert.deepEqual(tags.slice(-2), [
+    ["e", "root", "", "root"],
+    ["e", "parent", "", "reply"],
+  ]);
+});

--- a/desktop/src/features/messages/lib/threading.ts
+++ b/desktop/src/features/messages/lib/threading.ts
@@ -5,6 +5,17 @@ export type ThreadReference = {
   rootId: string | null;
 };
 
+/**
+ * Submit-time thread-reply context, captured synchronously by the thread
+ * panel before any async sends. `broadcast` opts the reply into the channel
+ * timeline (NIP-CW `["broadcast", "1"]`) — Slack's "Also send to #channel".
+ */
+export type ThreadSendContext = {
+  parentEventId: string | null;
+  threadHeadId: string | null;
+  broadcast?: boolean;
+};
+
 function getEventTags(tags: string[][]) {
   return tags.filter((tag) => tag[0] === "e" && typeof tag[1] === "string");
 }
@@ -80,6 +91,7 @@ export function buildReplyTags(
   parentEventId: string,
   rootEventId: string,
   mentionPubkeys: string[] = [],
+  broadcast = false,
 ) {
   const tags: string[][] = [
     ["p", authorPubkey],
@@ -91,6 +103,12 @@ export function buildReplyTags(
   // Best-effort normalization — relay performs authoritative validation.
   for (const pubkey of normalizeMentionPubkeys(mentionPubkeys, authorPubkey)) {
     tags.push(["p", pubkey]);
+  }
+
+  // NIP-CW: `["broadcast", "1"]` surfaces the reply on the channel timeline
+  // as well as in its thread ("Also send to #channel").
+  if (broadcast) {
+    tags.push(["broadcast", "1"]);
   }
 
   if (parentEventId === rootEventId) {

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -24,6 +24,7 @@ import {
   useMediaUpload,
 } from "@/features/messages/lib/useMediaUpload";
 import { useMentions } from "@/features/messages/lib/useMentions";
+import type { ThreadSendContext } from "@/features/messages/lib/threading";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import {
   hasMentionClipboardHtml,
@@ -104,10 +105,7 @@ type MessageComposerProps = {
   onEditLastOwnMessage?: () => boolean;
   onEditSave?: (content: string, mediaTags?: string[][]) => Promise<void>;
   /** Captures send context synchronously before awaits can change navigation. */
-  onCaptureSendContext?: () => {
-    parentEventId: string | null;
-    threadHeadId: string | null;
-  } | null;
+  onCaptureSendContext?: () => ThreadSendContext | null;
   /** Resolves the channel required to prepare mentions before sending. */
   onPrepareSendChannel?: (pubkeys?: string[]) => Promise<string | null>;
   onPreparingMentionSendChange?: (isPreparing: boolean) => void;
@@ -116,10 +114,7 @@ type MessageComposerProps = {
     mentionPubkeys: string[],
     mediaTags?: string[][],
     channelId?: string | null,
-    threadContext?: {
-      parentEventId: string | null;
-      threadHeadId: string | null;
-    } | null,
+    threadContext?: ThreadSendContext | null,
   ) => Promise<void>;
   placeholder?: string;
   profiles?: UserProfileLookup;

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -3,6 +3,7 @@ import { ArrowDown } from "lucide-react";
 
 import {
   buildThreadSummaryFromVisibleEntries,
+  canBroadcastThreadReply,
   hasNestedThreadBranches,
   type MainTimelineEntry,
 } from "@/features/messages/lib/threadPanel";
@@ -12,6 +13,7 @@ import {
 } from "@/features/messages/lib/messageGrouping";
 import type { ImetaMedia } from "@/features/messages/lib/imetaMediaMarkdown";
 import { canManageMessageForCurrentUser } from "@/features/messages/lib/canManageMessage";
+import type { ThreadSendContext } from "@/features/messages/lib/threading";
 import type { TimelineMessage } from "@/features/messages/types";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel } from "@/shared/api/types";
@@ -26,6 +28,7 @@ import {
   AuxiliaryPanelTitle,
 } from "@/shared/layout/AuxiliaryPanel";
 import { Button } from "@/shared/ui/button";
+import { Checkbox } from "@/shared/ui/checkbox";
 import { Skeleton } from "@/shared/ui/skeleton";
 import type { VideoReviewContext } from "@/shared/ui/VideoPlayer";
 import { MessageComposer } from "./MessageComposer";
@@ -72,10 +75,7 @@ type MessageThreadPanelProps = {
     mentionPubkeys: string[],
     mediaTags?: string[][],
     channelId?: string | null,
-    threadContext?: {
-      parentEventId: string | null;
-      threadHeadId: string | null;
-    } | null,
+    threadContext?: ThreadSendContext | null,
   ) => Promise<void>;
   onToggleReaction?: (
     message: TimelineMessage,
@@ -364,12 +364,60 @@ export function MessageThreadPanel({
   const replyTargetMessageRef = React.useRef(replyTargetMessage);
   replyTargetMessageRef.current = replyTargetMessage;
 
-  const onCaptureSendContext = React.useCallback(
-    () => ({
-      parentEventId: replyTargetMessageRef.current?.id ?? threadHeadId,
+  // "Also send to #channel" (NIP-CW broadcast): a one-shot opt-in to surface
+  // the next reply on the channel timeline as well as in this thread. Stored
+  // as the thread-head id it applies to (same pattern as
+  // collapsedThreadHeadId) so switching threads inherently clears it.
+  const [broadcastThreadHeadId, setBroadcastThreadHeadId] = React.useState<
+    string | null
+  >(null);
+  const broadcastToChannel =
+    broadcastThreadHeadId != null && broadcastThreadHeadId === threadHeadId;
+  const broadcastToChannelRef = React.useRef(broadcastToChannel);
+  broadcastToChannelRef.current = broadcastToChannel;
+  const broadcastCheckboxId = React.useId();
+  const threadHeadIsRoot = threadHead != null && threadHead.parentId == null;
+  const threadHeadIsRootRef = React.useRef(threadHeadIsRoot);
+  threadHeadIsRootRef.current = threadHeadIsRoot;
+
+  const onCaptureSendContext = React.useCallback(() => {
+    const replyTarget = replyTargetMessageRef.current;
+    return {
+      parentEventId: replyTarget?.id ?? threadHeadId,
       threadHeadId,
-    }),
-    [threadHeadId],
+      // Belt and braces: even if the checkbox was checked before the user
+      // picked a nested reply target, never broadcast a depth ≥ 2 reply.
+      broadcast:
+        broadcastToChannelRef.current &&
+        canBroadcastThreadReply(
+          threadHeadIsRootRef.current && threadHeadId
+            ? { id: threadHeadId, parentId: null }
+            : null,
+          replyTarget,
+        ),
+    };
+  }, [threadHeadId]);
+
+  // A completed send consumes the opt-in — the next reply starts unchecked,
+  // matching Slack. Failed sends keep the checkbox so a retry still broadcasts.
+  const handleComposerSend = React.useCallback(
+    async (
+      content: string,
+      mentionPubkeys: string[],
+      mediaTags?: string[][],
+      sendChannelId?: string | null,
+      threadContext?: ThreadSendContext | null,
+    ) => {
+      await onSend(
+        content,
+        mentionPubkeys,
+        mediaTags,
+        sendChannelId,
+        threadContext,
+      );
+      setBroadcastThreadHeadId(null);
+    },
+    [onSend],
   );
 
   const collapseThreadHeadReplies = React.useCallback(() => {
@@ -896,13 +944,45 @@ export function MessageThreadPanel({
             onCaptureSendContext={onCaptureSendContext}
             onEditLastOwnMessage={onEditLastOwnMessage}
             onEditSave={onEditSave}
-            onSend={onSend}
+            onSend={handleComposerSend}
             placeholder={`Reply in thread to ${threadHead.author}`}
             profiles={profiles}
             replyTarget={composerReplyTarget}
             typingParentEventId={threadHead.id}
             typingRootEventId={threadHead.rootId}
           />
+          {!editTarget &&
+          canBroadcastThreadReply(threadHead, replyTargetMessage) ? (
+            <div
+              className={cn(
+                "bg-background pt-1.5",
+                THREAD_PANEL_COMPOSER_GUTTER_CLASS,
+              )}
+            >
+              <div className="mx-auto flex w-full max-w-4xl items-center gap-2">
+                <Checkbox
+                  checked={broadcastToChannel}
+                  data-testid="thread-broadcast-checkbox"
+                  disabled={disabled || !channelId}
+                  id={broadcastCheckboxId}
+                  onCheckedChange={(checked) =>
+                    setBroadcastThreadHeadId(
+                      checked === true ? threadHead.id : null,
+                    )
+                  }
+                />
+                <label
+                  className="cursor-pointer select-none text-xs text-muted-foreground"
+                  data-testid="thread-broadcast-label"
+                  htmlFor={broadcastCheckboxId}
+                >
+                  {channel?.channelType === "dm"
+                    ? "Also send as direct message"
+                    : `Also send to #${channelName}`}
+                </label>
+              </div>
+            </div>
+          ) : null}
           <div
             className={cn(
               "min-h-8 bg-background pb-1.5 pt-0",

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -23,6 +23,7 @@ import type { UseMentionsResult } from "@/features/messages/lib/useMentions";
 import type { UseRichTextEditorResult } from "@/features/messages/lib/useRichTextEditor";
 import type { UseDraftsResult } from "@/features/messages/lib/useDrafts";
 import type { CustomEmoji } from "@/shared/lib/remarkCustomEmoji";
+import type { ThreadSendContext } from "@/features/messages/lib/threading";
 import type { AcpRuntime, ChannelType, ManagedAgent } from "@/shared/api/types";
 import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
 import { MENTION_REFERENCE_TAG } from "@/shared/lib/resolveMentionNames";
@@ -31,10 +32,7 @@ import { buildCustomEmojiTags } from "@/shared/lib/customEmojiTags";
 type PendingNonMemberMentionSend = {
   capturedChannelId: string | null;
   /** Thread context captured at submit time — null for main-timeline sends. */
-  capturedThreadContext: {
-    parentEventId: string | null;
-    threadHeadId: string | null;
-  } | null;
+  capturedThreadContext: ThreadSendContext | null;
   finalContent: string;
   mentionPubkeys: string[];
   nonMemberPubkeys: string[];
@@ -50,10 +48,7 @@ type PendingNonMemberMentionSend = {
 type SendMessageWithMentionFlowInput = {
   capturedChannelId: string | null;
   /** Thread context captured at submit time — null for main-timeline sends. */
-  capturedThreadContext?: {
-    parentEventId: string | null;
-    threadHeadId: string | null;
-  } | null;
+  capturedThreadContext?: ThreadSendContext | null;
   pendingImeta: ImetaMedia[];
   sentDraftKey: string | null | undefined;
   spoileredAttachmentUrls?: ReadonlySet<string>;
@@ -78,10 +73,7 @@ type UseMentionSendFlowOptions = {
       mentionPubkeys: string[],
       mediaTags?: string[][],
       channelId?: string | null,
-      threadContext?: {
-        parentEventId: string | null;
-        threadHeadId: string | null;
-      } | null,
+      threadContext?: ThreadSendContext | null,
     ) => Promise<void>
   >;
   richText: Pick<UseRichTextEditorResult, "clearContent" | "setContent">;

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -712,6 +712,7 @@ export async function sendChannelMessage(
   kind?: number,
   emojiTags?: string[][],
   mentionTags?: string[][],
+  broadcast?: boolean,
 ): Promise<SendChannelMessageResult> {
   const response = await invokeTauri<RawSendChannelMessageResult>(
     "send_channel_message",
@@ -724,6 +725,7 @@ export async function sendChannelMessage(
       mentionTags: mentionTags ?? null,
       mentionPubkeys: mentionPubkeys ?? null,
       kind: kind ?? null,
+      broadcast: broadcast ?? null,
     },
   );
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -3190,14 +3190,21 @@ function buildReplyMessageTags(
   parentEventId: string,
   rootEventId: string,
   mentionPubkeys: string[] | undefined,
+  broadcast = false,
 ) {
   // Preserve the reply tag ordering that the desktop message hooks already
-  // expect locally: author p, h, mention ps, then thread e-tags.
+  // expect locally: author p, h, mention ps, broadcast, then thread e-tags.
   const tags: string[][] = [
     ["p", authorPubkey],
     ["h", channelId],
   ];
   appendMentionTags(tags, mentionPubkeys, authorPubkey);
+
+  // NIP-CW: `["broadcast", "1"]` surfaces the reply on the channel timeline
+  // as well as in its thread — mirrors the real relay's stored event.
+  if (broadcast) {
+    tags.push(["broadcast", "1"]);
+  }
 
   if (parentEventId === rootEventId) {
     tags.push(["e", rootEventId, "", "reply"]);
@@ -7408,6 +7415,7 @@ async function handleSendChannelMessage(
     mentionPubkeys?: string[];
     mediaTags?: string[][] | null;
     emojiTags?: string[][] | null;
+    broadcast?: boolean | null;
   },
   config: E2eConfig | undefined,
 ): Promise<RawSendChannelMessageResponse> {
@@ -7499,6 +7507,7 @@ async function handleSendChannelMessage(
           args.parentEventId,
           rootEventId,
           args.mentionPubkeys,
+          args.broadcast === true,
         ),
         ...extraTags,
       ],
@@ -7526,6 +7535,7 @@ async function handleSendChannelMessage(
         args.parentEventId,
         args.parentEventId,
         args.mentionPubkeys,
+        args.broadcast === true,
       )
     : buildTopLevelMessageTags(
         args.channelId,

--- a/desktop/tests/e2e/thread-broadcast.spec.ts
+++ b/desktop/tests/e2e/thread-broadcast.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+// NIP-CW broadcast ("Also send to #channel"): a thread reply opted in via the
+// composer checkbox surfaces on the channel timeline as well as in its thread.
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await expect(page.getByTestId("message-timeline")).toContainText(
+    "Welcome to #general",
+  );
+});
+
+async function openThreadOnFirstRootMessage(
+  page: import("@playwright/test").Page,
+) {
+  const rootMessage = page
+    .getByTestId("message-timeline")
+    .getByTestId("message-row")
+    .first();
+  await rootMessage.hover();
+  await rootMessage.getByRole("button", { name: "Reply" }).click();
+  const threadPanel = page.getByTestId("message-thread-panel");
+  await expect(threadPanel).toBeVisible();
+  return threadPanel;
+}
+
+test("broadcast reply lands on the channel timeline and the opt-in is one-shot", async ({
+  page,
+}) => {
+  const timestamp = Date.now();
+  const broadcastReply = `Broadcast reply ${timestamp}`;
+  const threadOnlyReply = `Thread-only reply ${timestamp}`;
+
+  const timeline = page.getByTestId("message-timeline");
+  const threadPanel = await openThreadOnFirstRootMessage(page);
+  const threadComposer = threadPanel.locator('[data-testid="message-input"]');
+  const threadSendButton = threadPanel.getByTestId("send-message");
+  const threadReplies = threadPanel.getByTestId("message-thread-replies");
+  const broadcastCheckbox = threadPanel.getByTestId(
+    "thread-broadcast-checkbox",
+  );
+
+  // Direct reply to the thread head — the opt-in is offered and labeled.
+  await expect(broadcastCheckbox).toBeVisible();
+  await expect(threadPanel.getByTestId("thread-broadcast-label")).toHaveText(
+    "Also send to #general",
+  );
+  await expect(broadcastCheckbox).not.toBeChecked();
+
+  await broadcastCheckbox.click();
+  await expect(broadcastCheckbox).toBeChecked();
+
+  await threadComposer.fill(broadcastReply);
+  await threadSendButton.click();
+  await expect(threadReplies).toContainText(broadcastReply);
+
+  // Unlike a plain thread reply, the broadcast reply is also a timeline row.
+  await expect(
+    timeline.getByTestId("message-row").filter({ hasText: broadcastReply }),
+  ).toHaveCount(1);
+
+  // The opt-in is consumed by the send — the next reply is thread-only.
+  await expect(broadcastCheckbox).not.toBeChecked();
+
+  await threadComposer.fill(threadOnlyReply);
+  await threadSendButton.click();
+  await expect(threadReplies).toContainText(threadOnlyReply);
+  await expect(
+    timeline.getByTestId("message-row").filter({ hasText: threadOnlyReply }),
+  ).toHaveCount(0);
+});
+
+test("broadcast opt-in is hidden when targeting a nested reply", async ({
+  page,
+}) => {
+  const timestamp = Date.now();
+  const firstReply = `Nesting seed reply ${timestamp}`;
+
+  const threadPanel = await openThreadOnFirstRootMessage(page);
+  const threadComposer = threadPanel.locator('[data-testid="message-input"]');
+  const threadSendButton = threadPanel.getByTestId("send-message");
+  const threadReplies = threadPanel.getByTestId("message-thread-replies");
+  const broadcastCheckbox = threadPanel.getByTestId(
+    "thread-broadcast-checkbox",
+  );
+
+  await expect(broadcastCheckbox).toBeVisible();
+  await threadComposer.fill(firstReply);
+  await threadSendButton.click();
+
+  const replyRow = threadReplies
+    .getByTestId("message-row")
+    .filter({ hasText: firstReply });
+  await expect(replyRow).toBeVisible();
+
+  // Target the depth-1 reply — the next send would be depth 2, which NIP-CW
+  // never surfaces on the channel timeline, so the opt-in disappears.
+  await replyRow.hover();
+  await replyRow.getByRole("button", { name: "Reply" }).click();
+  await expect(broadcastCheckbox).toHaveCount(0);
+});


### PR DESCRIPTION
Adds Slack's "Also send to #channel" to the desktop thread composer, using the NIP-CW broadcast reply semantics the protocol already defines (`["broadcast", "1"]`). The relay ingest, SDK, CLI, and both clients' rendering already support broadcast replies — this PR adds the missing authoring surface on desktop.

## What

A checkbox under the thread composer lets the author surface their next reply on the channel timeline as well as in its thread:

- **Offered only where the spec allows it**: NIP-CW defines broadcast for depth-1 replies, so the toggle appears only when replying directly to a root thread head (`canBroadcastThreadReply`). It hides when targeting a nested reply, when the thread head is itself a reply, or while editing.
- **One-shot, like Slack**: a successful send consumes the opt-in; the next reply starts unchecked. A failed send keeps it checked so a retry still broadcasts. Switching threads clears it (state keyed to the thread-head id, same pattern as `collapsedThreadHeadId`).
- **Belt and braces at submit time**: the captured send context re-checks eligibility, so a checkbox checked before switching to a nested reply target can never emit a depth ≥ 2 broadcast.
- **DM channels** label the toggle "Also send as direct message".

## How

- `events.rs`: `build_message(..., broadcast)` appends `["broadcast", "1"]` to replies only — the flag is inert without a `thread_ref`, so non-reply sends can never carry the tag. The managed-agent and huddle-transcription paths pass `false`.
- `send_channel_message` accepts `broadcast: Option<bool>` over IPC; the TS bridge (`sendChannelMessage`) threads it through for replies only.
- Optimistic message and server-echo tag reconstruction include the tag, so the reply appears on the timeline immediately (`buildMainTimelineEntries` already surfaces broadcast replies).
- The submit-time capture path (`ThreadSendContext`, now a shared type replacing four inline copies) carries `broadcast` through the mention-flow confirmation dialog, so a deferred send after a non-member mention prompt still broadcasts.
- E2E mock bridge mirrors the relay's stored-event shape for broadcast replies.

## Testing

- Rust: `build_message` emits the tag on replies when requested, never on top-level messages (`message_reply_broadcast_tag`, `message_top_level_ignores_broadcast`).
- Unit: `buildReplyTags` tag shape/ordering with broadcast; `canBroadcastThreadReply` eligibility matrix (threading.test.mjs, threadPanel.test.mjs).
- Playwright (`thread-broadcast.spec.ts`): broadcast reply lands on the channel timeline while a plain reply doesn't; opt-in resets after send; toggle hides when targeting a nested reply.
- `pnpm check`, `tsc --noEmit`, biome, clippy, `cargo test` (Tauri, 1400 pass), desktop unit suite (2893 pass) all green. File-size guard overrides bumped per the documented convention (three files already on the queued-to-split list).
