### PR TITLE
fix(desktop): let sidebar action card description wrap over multiple lines

### DIFF
--- a/desktop/src/shared/styles/globals/animations.css
+++ b/desktop/src/shared/styles/globals/animations.css
@@ -424,8 +424,7 @@
   display: inline-block;
   line-height: var(--buzz-sidebar-action-description-line-height);
   max-width: 100%;
-  overflow: hidden;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 .buzz-sidebar-action-description__motion {
@@ -443,10 +442,16 @@
   will-change: transform;
 }
 
+/* The roll-up reel animates between two fixed one-line slots, so text is
+   clipped to a single line only while the transition plays; the settled
+   state above wraps freely. */
 .buzz-sidebar-action-description__reel > span {
   display: block;
   height: var(--buzz-sidebar-action-description-line-height);
   line-height: var(--buzz-sidebar-action-description-line-height);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @keyframes buzz-sidebar-action-description-roll-up {


### PR DESCRIPTION
## Summary
Before
<img width="291" height="161" alt="Screenshot 2026-07-15 at 9 39 41 am" src="https://github.com/user-attachments/assets/60de6e6a-46aa-4523-91eb-92b7acfa1925" />

After
<img width="300" height="213" alt="Screenshot 2026-07-15 at 11 54 39 am" src="https://github.com/user-attachments/assets/335a282f-471d-4829-b723-0b7cd1327a9a" />

The relay connection card's subtitle (e.g. "Complete any prompts opened by the reconnect helper to continue." in the waiting-to-reconnect state) was clipped to a single line by `white-space: nowrap` + `overflow: hidden` on the settled description, cutting longer descriptions off mid-word.

- Let the settled description wrap freely (`overflow-wrap: break-word`) so the card grows to fit its text.
- Move the single-line clipping (now with an ellipsis) onto the roll-up reel slots, which only need a fixed one-line height while the description-change animation plays.

## Changes

- `desktop/src/shared/styles/globals/animations.css` — drop the nowrap/hidden clipping from `.buzz-sidebar-action-description`; add `overflow: hidden` / `text-overflow: ellipsis` / `white-space: nowrap` to the reel's per-line slots instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)