### PR TITLE
Fix integration test script false failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
               - 'deny.toml'
               - '.github/workflows/ci.yml'
               - 'scripts/run-tests.sh'
+              - 'scripts/tests/**'
               - 'justfile'
             desktop:
               - 'desktop/**'

--- a/Justfile
+++ b/Justfile
@@ -233,8 +233,12 @@ ci: check test-unit desktop-test desktop-build desktop-tauri-check desktop-tauri
 test:
     ./scripts/run-tests.sh all
 
+# Validate the test runner's integration-step status and output handling
+test-runner-script:
+    ./scripts/tests/run-tests-test.sh
+
 # Run unit tests only (no infra needed)
-test-unit:
+test-unit: test-runner-script
     #!/usr/bin/env bash
     if command -v cargo-nextest &>/dev/null; then
         cargo nextest run -p buzz-core -p buzz-auth --lib

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -112,13 +112,8 @@ run_integration_tests() {
   run_test_step "buzz-db tests" \
     cargo test -p buzz-db -- --nocapture
 
-  run_test_step "buzz-auth integration tests" \
-    cargo test -p buzz-auth --test '*' -- --nocapture 2>/dev/null || \
-    run_test_step "buzz-auth (no integration tests found)" true
-
   run_test_step "workspace integration tests" \
-    cargo test --test '*' -- --nocapture 2>/dev/null || \
-    run_test_step "workspace integration tests (none found)" true
+    cargo test --test '*' -- --nocapture
 }
 
 # ---- Main -------------------------------------------------------------------

--- a/scripts/tests/run-tests-test.sh
+++ b/scripts/tests/run-tests-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/scripts" "${TEST_ROOT}/mock-bin"
+cp "${REPO_ROOT}/scripts/run-tests.sh" "${TEST_ROOT}/scripts/run-tests.sh"
+printf '#!/usr/bin/env bash\nexit 0\n' > "${TEST_ROOT}/bin/just"
+chmod +x "${TEST_ROOT}/bin/just"
+
+cat > "${TEST_ROOT}/mock-bin/cargo" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${CARGO_CALLS}"
+if [[ "${2:-}" == "--test" && "${3:-}" == "*" && "${FAIL_WORKSPACE:-0}" == 1 ]]; then
+  echo "visible workspace failure" >&2
+  exit 1
+fi
+MOCK
+chmod +x "${TEST_ROOT}/mock-bin/cargo"
+
+export CARGO_CALLS="${TEST_ROOT}/cargo-calls"
+PATH="${TEST_ROOT}/mock-bin:${PATH}" "${TEST_ROOT}/scripts/run-tests.sh" integration \
+  > "${TEST_ROOT}/success.out" 2> "${TEST_ROOT}/success.err"
+
+if grep -q 'buzz-auth integration tests' "${TEST_ROOT}/success.out"; then
+  echo "unexpected buzz-auth integration step" >&2
+  exit 1
+fi
+if grep -q -- '-p buzz-auth' "${CARGO_CALLS}"; then
+  echo "unexpected buzz-auth cargo invocation" >&2
+  exit 1
+fi
+grep -Fq 'test --test * -- --nocapture' "${CARGO_CALLS}"
+grep -q 'workspace integration tests passed' "${TEST_ROOT}/success.out"
+
+: > "${CARGO_CALLS}"
+if FAIL_WORKSPACE=1 PATH="${TEST_ROOT}/mock-bin:${PATH}" \
+  "${TEST_ROOT}/scripts/run-tests.sh" integration \
+  > "${TEST_ROOT}/failure.out" 2> "${TEST_ROOT}/failure.err"; then
+  echo "expected workspace failure" >&2
+  exit 1
+fi
+
+grep -q 'visible workspace failure' "${TEST_ROOT}/failure.err"
+grep -q 'workspace integration tests FAILED' "${TEST_ROOT}/failure.err"
+grep -q 'fail.*workspace integration tests' "${TEST_ROOT}/failure.out"


### PR DESCRIPTION
### What changed?

- Remove the nonexistent `buzz-auth` integration-test invocation that deterministically recorded a false failure.
- Let the workspace integration step expose real Cargo/test errors instead of suppressing stderr or using an unreachable fallback.
- Add a focused shell regression test and run it through the existing `test-unit` CI path.

### Why?

`run_test_step` records failures but returns success, so the prior `|| ... true` fallbacks were unreachable. Since `buzz-auth` has no integration-test target, every integration run recorded a phantom failure while hiding Cargo's explanation.

### How is it tested?

- `./scripts/run-tests.sh unit` passes (5 steps).
- Focused test-runner regression test passes directly and through `just test-runner-script`.
- Hermit-managed pre-push suites pass.
- Deep dual pre-review completed; its actionable finding to wire the regression test into CI was addressed.

Integration mode now has only the pre-existing, unrelated `git-credential-nostr` permission assertion failure. Its real diagnostics are visible on stderr, and the summary contains no `buzz-auth integration tests` failure.

### Before / After

Images are impractical for this shell-script change; terminal output serves as the before/after evidence.

**Before**

```text
exit=1
Failed (2):
  fail buzz-auth integration tests
  fail workspace integration tests

# The buzz-auth error was hidden by 2>/dev/null.
# Direct command:
error: no test target matches pattern `*` in `buzz-auth` package
```

**After**

```text
integration_exit=1
Passed (1):
  pass buzz-db tests
Failed (1):
  fail workspace integration tests

thread 'missing_key' panicked ... expected exit 1 for missing key
thread 'bad_keyfile_permissions' panicked ... expected exit 1 for insecure keyfile permissions
[run-tests] workspace integration tests FAILED

# `buzz-auth integration tests` is absent.
```

### Commit hook note

The global secret scanner flagged unchanged localhost development defaults at `scripts/run-tests.sh:43` and `.github/workflows/ci.yml:427` (`postgres://buzz:buzz_dev@localhost:5432/buzz`). Both strings already exist on `main` and match the repository's Docker Compose development configuration. After independent confirmation and explicit authorization in the BOT-1316 Buzz thread, this commit used the scanner's documented one-shot `SKIP_SECRET_SCANNING=1` confirmation; every other commit hook remained active and passed. The diff introduces no credential-like strings.

*🤖 This PR was authored with an agent (Buzz: [BOT-1316 thread](https://linear.app/squareup/issue/BOT-1316/fix-false-failure-in-buzz-integration-test-script)).*
