### PR TITLE
chore(hooks): scope pre-push tests by path

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,12 +19,32 @@ pre-commit:
 
 pre-push:
   parallel: true
+  # Compare the commit being pushed with its configured push ref. This two-endpoint
+  # diff may over-select after divergence, which is safer; CI remains authoritative.
+  # On detection failure (including a new branch without an upstream), lefthook.yml
+  # is the sentinel that runs every suite. Every command glob must keep this path.
+  files: |
+    sh -c '
+      push_ref=$(git rev-parse --verify "@{push}" 2>/dev/null) || {
+        echo "warning: cannot resolve @{push}; running all pre-push test suites" >&2
+        printf "%s\n" lefthook.yml
+        exit 0
+      }
+      git -c core.quotePath=false diff --name-only "$push_ref" HEAD || {
+        echo "warning: cannot detect pushed files; running all pre-push test suites" >&2
+        printf "%s\n" lefthook.yml
+      }
+    '
   commands:
     rust-tests:
-      run: just test-unit
+      glob: "{crates/**,migrations/**,schema/**,Cargo.toml,Cargo.lock,rust-toolchain.toml,deny.toml,.github/workflows/ci.yml,scripts/run-tests.sh,justfile,lefthook.yml}"
+      run: 'just test-unit && : {files}'
     desktop-test:
-      run: just desktop-test
+      glob: "{desktop/**,pnpm-lock.yaml,crates/**,migrations/**,schema/**,Cargo.toml,Cargo.lock,rust-toolchain.toml,deny.toml,.github/workflows/ci.yml,scripts/run-tests.sh,justfile,lefthook.yml}"
+      run: 'just desktop-test && : {files}'
     desktop-tauri-test:
-      run: just desktop-tauri-test
+      glob: "{desktop/**,pnpm-lock.yaml,crates/**,migrations/**,schema/**,Cargo.toml,Cargo.lock,rust-toolchain.toml,deny.toml,.github/workflows/ci.yml,scripts/run-tests.sh,justfile,lefthook.yml}"
+      run: 'just desktop-tauri-test && : {files}'
     mobile-test:
-      run: just mobile-test
+      glob: "{mobile/**,.github/workflows/ci.yml,lefthook.yml}"
+      run: 'just mobile-test && : {files}'


### PR DESCRIPTION
### What changed?

Path-scope the four repository pre-push test suites to the same Rust, desktop, and mobile filters used by CI. Detection uses a two-endpoint diff against `@{push}` and fails closed by selecting every suite when the push ref or diff cannot be resolved.

### Why?

Unrelated platform suites currently block pushes: Rust-only changes run Flutter tests, while mobile-only changes run Rust and desktop tests. This keeps the local convenience gate focused while CI remains authoritative.

### How is it tested?

Focused validation matrix:

| Scenario | Selected suites |
| --- | --- |
| Rust path | Rust + both desktop suites |
| Desktop / desktop-rust path | Both desktop suites |
| Mobile path | Mobile suite |
| Unrelated docs path | None |
| `pnpm-lock.yaml` | Both desktop suites |
| `justfile` / `scripts/run-tests.sh` | Rust + both desktop suites |
| CI workflow / `lefthook.yml` | All four suites |
| New branch without upstream | All four suites (fail-closed sentinel) |
| Divergent force push | Suites matching the replacement commit range |
| Unchanged push / branch deletion | None |
| Injected diff failure | All four suites (fail-closed sentinel) |

`lefthook validate`, Rust tests, desktop tests, and desktop Tauri tests pass. Mobile validation could not run because Flutter is not installed on this workstation (`flutter: command not found`). Deep Claude pre-review completed; its verified custom-file-source concern was addressed by making every command consume `{files}`. No screenshots: this hook-only change has no user-visible UI.

*🤖 This PR was authored with an agent; the creating Codex session URL was unavailable in the Buzz runtime.*
