### PR TITLE
[poc] Improve channels browse discoverability

### DIFF
--- a/desktop/src/features/search/ui/SearchResultItem.tsx
+++ b/desktop/src/features/search/ui/SearchResultItem.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/features/profile/lib/identity";
 import type { Channel, SearchHit, UserSearchResult } from "@/shared/api/types";
 import { Badge } from "@/shared/ui/badge";
+import { HashSearch } from "@/shared/ui/icons";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
 export type SearchResult =
@@ -24,7 +25,7 @@ export type SearchResult =
       kind: "action";
       action: {
         description?: string;
-        id: "create-agent" | "create-channel";
+        id: "browse-channels" | "create-agent" | "create-channel";
         title: string;
       };
     }
@@ -69,7 +70,11 @@ export function resultIcon(
   channelLookup: ReadonlyMap<string, Channel>,
 ) {
   if (result.kind === "action") {
-    return result.action.id === "create-agent" ? Bot : Plus;
+    return result.action.id === "browse-channels"
+      ? HashSearch
+      : result.action.id === "create-agent"
+        ? Bot
+        : Plus;
   }
 
   if (result.kind === "user") {

--- a/desktop/src/features/search/ui/TopbarSearch.tsx
+++ b/desktop/src/features/search/ui/TopbarSearch.tsx
@@ -34,6 +34,7 @@ type TopbarSearchProps = {
   onOpenChannel: (channelId: string) => void;
   onOpenResult: (hit: SearchHit) => void;
   onOpenUser?: (user: UserSearchResult) => void | Promise<void>;
+  onBrowseChannels?: () => void | Promise<void>;
   onCreateAgent?: () => void | Promise<void>;
   onCreateChannel?: () => void | Promise<void>;
   suggestionChannels?: Channel[];
@@ -393,6 +394,7 @@ export function TopbarSearch({
   onOpenChannel,
   onOpenResult,
   onOpenUser,
+  onBrowseChannels,
   onCreateAgent,
   onCreateChannel,
   suggestionChannels,
@@ -426,6 +428,16 @@ export function TopbarSearch({
   const suggestionActionResults = React.useMemo(() => {
     const actions: SearchResult[] = [];
 
+    if (onBrowseChannels) {
+      actions.push({
+        kind: "action",
+        action: {
+          id: "browse-channels",
+          title: "Browse channels",
+        },
+      });
+    }
+
     if (onCreateChannel) {
       actions.push({
         kind: "action",
@@ -447,7 +459,7 @@ export function TopbarSearch({
     }
 
     return actions;
-  }, [onCreateAgent, onCreateChannel]);
+  }, [onBrowseChannels, onCreateAgent, onCreateChannel]);
   const suggestionResults = React.useMemo(
     () => [...suggestedResults, ...suggestionActionResults],
     [suggestedResults, suggestionActionResults],
@@ -513,21 +525,20 @@ export function TopbarSearch({
 
       if (result.kind === "action") {
         setSelectedMenuIndex(0);
-        if (result.action.id === "create-channel") {
-          openAfterExit(() => {
-            void onCreateChannel?.();
-          });
-        } else {
-          openAfterExit(() => {
-            void onCreateAgent?.();
-          });
-        }
+        const action =
+          result.action.id === "browse-channels"
+            ? onBrowseChannels
+            : result.action.id === "create-channel"
+              ? onCreateChannel
+              : onCreateAgent;
+        openAfterExit(() => void action?.());
         return;
       }
 
       onOpenResult(result.hit);
     },
     [
+      onBrowseChannels,
       onCreateAgent,
       onCreateChannel,
       onOpenChannel,

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -540,6 +540,7 @@ export function AppSidebar({
           channelLabels={dmChannelLabels}
           currentPubkey={currentPubkey}
           homeBadgeCount={homeBadgeCount}
+          onBrowseChannels={onBrowseChannels}
           onCreateAgent={onCreateAgent}
           onCreateChannel={handleOpenCreateChannel}
           onOpenDm={onOpenDm}
@@ -692,6 +693,7 @@ export function AppSidebar({
                     listTestId="stream-list"
                     onBrowseClick={onBrowseChannels}
                     onCreateClick={() => openCreateDialog("stream")}
+                    showPrimaryActions
                     showQuickCreate
                     onMarkAllRead={onMarkAllChannelsRead}
                     onMarkChannelRead={onMarkChannelRead}

--- a/desktop/src/features/sidebar/ui/AppSidebarPinnedHeader.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebarPinnedHeader.tsx
@@ -24,6 +24,7 @@ type AppSidebarPinnedHeaderProps = {
   channelLabels: Record<string, string>;
   currentPubkey?: string;
   homeBadgeCount: number;
+  onBrowseChannels?: () => void;
   onCreateAgent: () => void;
   onCreateChannel: () => void;
   onOpenDm: (input: { pubkeys: string[] }) => Promise<void>;
@@ -44,6 +45,7 @@ export function AppSidebarPinnedHeader({
   channelLabels,
   currentPubkey,
   homeBadgeCount,
+  onBrowseChannels,
   onCreateAgent,
   onCreateChannel,
   onOpenDm,
@@ -66,6 +68,7 @@ export function AppSidebarPinnedHeader({
         channels={searchChannels}
         currentPubkey={currentPubkey}
         focusRequest={searchFocusRequest}
+        onBrowseChannels={onBrowseChannels}
         onOpenChannel={onSelectChannel}
         onOpenResult={onOpenSearchResult}
         onOpenUser={(user) => onOpenDm({ pubkeys: [user.pubkey] })}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -72,12 +72,7 @@ const SORT_OPTIONS: { value: ChannelSortMode; label: string }[] = [
   { value: "alpha", label: "A–Z" },
 ];
 
-/**
- * A single always-visible "+" quick action shown at the right edge of a
- * section header, to the left of the ⋮ menu. Used for the most common
- * per-section create action (New channel, New message) while every other
- * action stays folded into {@link SectionActionsMenu}.
- */
+/** A compact section-header action with an accessible label. */
 export function SectionQuickAction({
   label,
   onClick,
@@ -109,12 +104,53 @@ export function SectionQuickAction({
   );
 }
 
-/**
- * The single "more actions" menu shown at the right edge of every sidebar
- * section header (Starred, Channels, Forums, Direct messages, and each custom
- * section). Items render only when their handler is provided; a Sort radio
- * group is appended whenever a sort preference is supplied.
- */
+function SectionSortMenu({
+  sectionLabel,
+  sortMode,
+  onSortModeChange,
+  onOpenChange,
+  testId,
+}: {
+  sectionLabel: string;
+  sortMode: ChannelSortMode;
+  onSortModeChange: (mode: ChannelSortMode) => void;
+  onOpenChange?: (open: boolean) => void;
+  testId?: string;
+}) {
+  const label = `Sort ${sectionLabel}`;
+
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label={label}
+          className={SECTION_ICON_BUTTON_CLASS}
+          data-testid={testId}
+          onClick={(event) => event.stopPropagation()}
+          onPointerDown={(event) => event.stopPropagation()}
+          title={label}
+          type="button"
+        >
+          <ArrowUpDown className="h-4 w-4" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          onValueChange={(value) => onSortModeChange(value as ChannelSortMode)}
+          value={sortMode}
+        >
+          {SORT_OPTIONS.map((option) => (
+            <DropdownMenuRadioItem key={option.value} value={option.value}>
+              {option.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Overflow actions shared by sidebar section headers. */
 export function SectionActionsMenu({
   sectionLabel,
   testId,
@@ -337,6 +373,7 @@ export function ChannelGroupSection({
   listTestId,
   onBrowseClick,
   onCreateClick,
+  showPrimaryActions,
   showQuickCreate,
   onMarkAllRead,
   onMarkChannelRead,
@@ -374,6 +411,7 @@ export function ChannelGroupSection({
   listTestId: string;
   onBrowseClick?: () => void;
   onCreateClick?: () => void;
+  showPrimaryActions?: boolean;
   showQuickCreate?: boolean;
   onMarkChannelRead: (
     channelId: string,
@@ -484,6 +522,15 @@ export function ChannelGroupSection({
         title={title}
         actions={
           <>
+            {showPrimaryActions && onBrowseClick ? (
+              <SectionQuickAction
+                icon={HashSearch}
+                label={browseLabel ?? "Browse channels"}
+                onClick={onBrowseClick}
+                testId="section-browse-channels"
+                visibilityClassName=""
+              />
+            ) : null}
             {showQuickCreate && onCreateClick ? (
               <SectionQuickAction
                 label={createLabel ?? "Create channel"}
@@ -491,21 +538,35 @@ export function ChannelGroupSection({
                 testId={
                   actionsTestId ? `${actionsTestId}-quick-create` : undefined
                 }
+                visibilityClassName={showPrimaryActions ? "" : undefined}
               />
             ) : null}
-            <SectionActionsMenu
-              sectionLabel={title}
-              testId={actionsTestId}
-              onOpenChange={setActionsMenuOpen}
-              hasUnread={hasUnread}
-              onMarkAllRead={onMarkAllRead}
-              onBrowse={onBrowseClick}
-              browseLabel={browseLabel}
-              onCreate={onCreateClick}
-              createLabel={createLabel}
-              sortMode={sortMode}
-              onSortModeChange={onSortModeChange}
-            />
+            {showPrimaryActions && sortMode && onSortModeChange ? (
+              <SectionSortMenu
+                sectionLabel={title}
+                sortMode={sortMode}
+                onSortModeChange={onSortModeChange}
+                onOpenChange={setActionsMenuOpen}
+                testId="section-sort-channels"
+              />
+            ) : null}
+            {!showPrimaryActions || (hasUnread && onMarkAllRead) ? (
+              <SectionActionsMenu
+                sectionLabel={title}
+                testId={actionsTestId}
+                onOpenChange={setActionsMenuOpen}
+                hasUnread={hasUnread}
+                onMarkAllRead={onMarkAllRead}
+                onBrowse={showPrimaryActions ? undefined : onBrowseClick}
+                browseLabel={browseLabel}
+                onCreate={showPrimaryActions ? undefined : onCreateClick}
+                createLabel={createLabel}
+                sortMode={showPrimaryActions ? undefined : sortMode}
+                onSortModeChange={
+                  showPrimaryActions ? undefined : onSortModeChange
+                }
+              />
+            ) : null}
           </>
         }
       />

--- a/desktop/tests/e2e/channel-sort.spec.ts
+++ b/desktop/tests/e2e/channel-sort.spec.ts
@@ -61,18 +61,20 @@ test.describe("per-group channel sort", () => {
     await installMockBridge(page);
     await openApp(page);
 
-    // Hover the Channels header to reveal the action cluster, then open the
-    // sort dropdown and choose Recent.
+    // Browse, create, and sort are primary actions: they stay visible without
+    // requiring hover or a trip through the overflow menu.
     const streamList = page.getByTestId("stream-list");
     await expect(streamList).toBeVisible();
-    await page.getByText("Channels", { exact: true }).hover();
-    const trigger = page.getByTestId("section-actions-channels");
-    await expect(trigger).toBeVisible();
+    const browse = page.getByTestId("section-browse-channels");
+    const create = page.getByTestId("section-actions-channels-quick-create");
+    const trigger = page.getByTestId("section-sort-channels");
+    for (const action of [browse, create, trigger]) {
+      await expect(action).toBeVisible();
+      await expect(action).toHaveCSS("opacity", "1");
+    }
     await waitForAnimations(page);
     await page.screenshot({ path: `${SHOTS}/01-channels-sort-ingress.png` });
     await trigger.click();
-    // Sort is now a submenu flyout — open it before the radio items render.
-    await page.getByRole("menuitem", { name: "Sort" }).click();
     await expect(
       page.getByRole("menuitemradio", { name: "Recent" }),
     ).toBeVisible();

--- a/desktop/tests/e2e/smoke.spec.ts
+++ b/desktop/tests/e2e/smoke.spec.ts
@@ -305,6 +305,16 @@ test("opens sidebar search with the shortcut and loads the exact result", async 
   );
 });
 
+test("browses channels from the search actions", async ({ page }) => {
+  await page.goto("/");
+  await focusSidebarSearchWithShortcut(page);
+
+  await page.getByTestId("search-result-action-browse-channels").click();
+
+  await expect(page.getByTestId("search-results")).toHaveCount(0);
+  await expect(page.getByTestId("channel-browser-dialog")).toBeVisible();
+});
+
 test("opens channel matches from search", async ({ page }) => {
   await page.goto("/");
 

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -670,30 +670,12 @@ export async function installRelayBridge(
   });
 }
 
-// The sidebar no longer renders a "browse channels" icon button; the channel
-// browser is opened via the primary-modifier + Shift + O keyboard shortcut.
 export async function openChannelBrowser(page: Page) {
   await page.getByTestId("app-sidebar").waitFor({ state: "visible" });
-  const isMacBrowser = await page.evaluate(() =>
-    /mac|iphone|ipad|ipod/i.test(navigator.platform),
-  );
-  await page.evaluate((isMac) => {
-    window.dispatchEvent(
-      new KeyboardEvent("keydown", {
-        bubbles: true,
-        cancelable: true,
-        ctrlKey: !isMac,
-        key: "O",
-        metaKey: isMac,
-        shiftKey: true,
-      }),
-    );
-  }, isMacBrowser);
+  await page.getByTestId("section-browse-channels").click();
 }
 
-// Section header actions (create channel, new DM, mark all read, sort) now
-// live inside a per-section "more actions" (⋮) menu instead of standalone
-// header icon buttons. These helpers open that menu and pick an item.
+// Secondary section actions still live in each section's overflow menu.
 async function openSectionMenu(page: Page, actionsTestId: string) {
   const trigger = page.getByTestId(actionsTestId);
   await trigger.scrollIntoViewIfNeeded();
@@ -701,8 +683,7 @@ async function openSectionMenu(page: Page, actionsTestId: string) {
 }
 
 export async function openCreateChannelDialog(page: Page) {
-  await openSectionMenu(page, "section-actions-channels");
-  await page.getByRole("menuitem", { name: "New channel" }).click();
+  await page.getByTestId("section-actions-channels-quick-create").click();
 }
 
 export async function openNewMessagePage(page: Page) {


### PR DESCRIPTION
This PR is proof of concept that can push the discussion for #1896 forward. 

It attempts to solve a problem where a user (ehm, me) joined a workspace which had no default channels, leading a brand new user on a journey to find channels to join on a very first interaction with the app. I think in normal circumstances a newly joined user should never be faced with a problem of not having any channels in a newly joined community, so perhaps a simpler solution should be tried first.

## Before this PR
<img width="1093" height="488" alt="Screenshot 2026-07-15 at 10 50 52" src="https://github.com/user-attachments/assets/3283aa2b-fb6b-4704-b775-d68a319fe92b" />
<img width="1083" height="622" alt="Screenshot 2026-07-15 at 10 50 57" src="https://github.com/user-attachments/assets/612abfb6-05c1-479c-ac8e-0d08c1f7f669" />

## After this PR
<img width="932" height="490" alt="Screenshot 2026-07-15 at 10 50 24" src="https://github.com/user-attachments/assets/30da46a4-00b5-4ebd-9cd8-d03ade6f46a3" />
<img width="929" height="671" alt="Screenshot 2026-07-15 at 10 51 12" src="https://github.com/user-attachments/assets/640246b9-2ec2-407b-b7b3-8370fe7625f6" />

I'm not opinionated or won't be offended, if this was already discussed, someone ships a better PR or the doesn't match direction of the project, feel free to close it! 😄 
