### PR TITLE
fix(desktop): clean up Remind me later dialog footer and loading state

### DIFF
--- a/desktop/src/features/reminders/ui/RemindMeLaterDialog.tsx
+++ b/desktop/src/features/reminders/ui/RemindMeLaterDialog.tsx
@@ -1,4 +1,4 @@
-import { CalendarClock, Clock } from "lucide-react";
+import { CalendarClock, Clock, Loader2 } from "lucide-react";
 import * as React from "react";
 import { toast } from "sonner";
 
@@ -102,17 +102,6 @@ export function RemindMeLaterDialog({
               value={customTime}
             />
           </div>
-          <Button
-            className="w-full"
-            disabled={create.isPending || customTimestamp === null}
-            onClick={() => {
-              if (customTimestamp === null) return;
-              submit(customTimestamp);
-            }}
-            variant="default"
-          >
-            Set reminder
-          </Button>
         </div>
 
         <div className="space-y-2">
@@ -132,13 +121,27 @@ export function RemindMeLaterDialog({
           />
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="sm:justify-between">
           <Button
             variant="ghost"
             onClick={() => onOpenChange(false)}
             disabled={create.isPending}
           >
             Cancel
+          </Button>
+          <Button
+            disabled={create.isPending || customTimestamp === null}
+            onClick={() => {
+              if (customTimestamp === null) return;
+              submit(customTimestamp);
+            }}
+            variant="default"
+          >
+            {create.isPending ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              "Set reminder"
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/desktop/src/features/reminders/ui/RemindMeLaterDialog.tsx
+++ b/desktop/src/features/reminders/ui/RemindMeLaterDialog.tsx
@@ -130,6 +130,7 @@ export function RemindMeLaterDialog({
             Cancel
           </Button>
           <Button
+            className="relative"
             disabled={create.isPending || customTimestamp === null}
             onClick={() => {
               if (customTimestamp === null) return;
@@ -137,11 +138,16 @@ export function RemindMeLaterDialog({
             }}
             variant="default"
           >
+            {/* The hidden label keeps the button width stable while the
+                spinner overlays it. */}
+            <span className={create.isPending ? "invisible" : undefined}>
+              Set reminder
+            </span>
             {create.isPending ? (
-              <Loader2 className="animate-spin" />
-            ) : (
-              "Set reminder"
-            )}
+              <span className="absolute inset-0 flex items-center justify-center">
+                <Loader2 className="animate-spin" />
+              </span>
+            ) : null}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary

- Move the **Set reminder** button out of the custom-time section and into the dialog footer, opposite **Cancel** (`sm:justify-between`), so the dialog has a single, conventional action row.
- While the create-reminder mutation is pending, overlay a `Loader2` spinner on the button and hide the label with `invisible` instead of removing it — this keeps the button width stable so the footer doesn't shift while the spinner shows.

Old: 
<img height="300" alt="Screenshot 2026-07-15 at 2 22 16 pm" src="https://github.com/user-attachments/assets/7fa725b5-e16e-4566-9e84-cc584b9579ce" />

New (spinner appears in the set reminder while sending instead of the text):
<img height="300" alt="Screenshot 2026-07-15 at 3 36 36 pm" src="https://github.com/user-attachments/assets/b548b947-550d-4a6b-8911-054fa2786ed5" />

## Testing

- `just ci` (fmt, clippy, desktop lint, unit tests) passed on push via pre-push hooks — desktop-test, rust-tests, mobile-test, and desktop-tauri-test all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)