### PR TITLE
fix(desktop): simplify sign out settings row

### DIFF
--- a/desktop/scripts/check-px-text.mjs
+++ b/desktop/scripts/check-px-text.mjs
@@ -19,14 +19,15 @@ const rules = [
   },
 ];
 
-// Decorative / chrome exceptions: `relativePath:lineNumber`. The avatar emoji
-// glyphs are fixed display sizes sized to their avatar box (not readable
-// message text), so they are exempted from the readable-text px rule.
+// Decorative / chrome exceptions: `relativePath:matchedLiteral`. The avatar
+// emoji glyphs are fixed display sizes sized to their avatar box (not readable
+// message text), so they are exempted from the readable-text px rule. Matching
+// the literal keeps these exceptions stable when unrelated edits move lines.
 const overrides = new Set([
-  "src/features/settings/ui/ProfileSettingsCard.tsx:712",
-  "src/features/onboarding/ui/AvatarStep.tsx:95",
-  "src/features/agents/ui/AgentCreationPreview.tsx:666",
-  "src/features/agents/ui/AgentCreationPreview.tsx:747",
+  "src/features/settings/ui/ProfileSettingsCard.tsx:text-[6rem]",
+  "src/features/onboarding/ui/AvatarStep.tsx:text-[6rem]",
+  "src/features/agents/ui/AgentCreationPreview.tsx:text-[4rem]",
+  "src/features/agents/ui/AgentCreationPreview.tsx:text-[6rem]",
 ]);
 
 await runPxTextCheck({

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -31,6 +31,7 @@ import {
   parseEmojiAvatarDataUrl,
 } from "@/features/profile/ui/ProfileAvatarEditor";
 import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Spinner } from "@/shared/ui/spinner";
 import { Textarea } from "@/shared/ui/textarea";
@@ -954,36 +955,31 @@ export function ProfileSettingsCard({
         </div>
       </div>
 
-      <div className="mt-8" data-testid="settings-signout">
-        <SettingsSectionHeader
-          title="Sign out"
-          description="Removes your identity key and all local app data from this device. Back up your private key (nsec) before proceeding — this cannot be undone."
-        />
-        <div className="overflow-hidden rounded-xl border border-destructive/20 bg-background/70 shadow-xs">
-          <div className="flex items-center justify-between gap-4 px-4 py-3">
-            <div className="min-w-0 space-y-1">
-              <p className="text-sm font-medium">Clear data and sign out</p>
-              <p className="text-sm text-muted-foreground">
-                Wipes the keychain, agent settings, and app cache, then
-                relaunches Buzz into first-run setup.
-              </p>
-            </div>
-            <button
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-destructive/30 bg-destructive/5 px-3 py-1.5 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
-              data-testid="signout-open-dialog"
-              disabled={isSignOutPending}
-              onClick={() => setIsSignOutOpen(true)}
-              type="button"
-            >
-              {isSignOutPending ? (
-                <Spinner
-                  aria-label="Signing out"
-                  className="h-4 w-4 border-2"
-                />
-              ) : null}
-              {isSignOutPending ? "Signing out…" : "Sign Out"}
-            </button>
+      <div
+        className="mt-8 border-t border-border/60 pb-6 pt-5"
+        data-testid="settings-signout"
+      >
+        <div className="flex items-center justify-between gap-4 px-1">
+          <div className="min-w-0 space-y-1">
+            <h2 className="text-sm font-medium">Sign out</h2>
+            <p className="text-sm text-muted-foreground">
+              Removes your identity key and all local app data from this device.
+              Back up your private key (nsec) first — this cannot be undone.
+            </p>
           </div>
+          <Button
+            className="shrink-0"
+            data-testid="signout-open-dialog"
+            disabled={isSignOutPending}
+            onClick={() => setIsSignOutOpen(true)}
+            type="button"
+            variant="destructive"
+          >
+            {isSignOutPending ? (
+              <Spinner aria-label="Signing out" className="h-4 w-4 border-2" />
+            ) : null}
+            {isSignOutPending ? "Signing out…" : "Sign Out"}
+          </Button>
         </div>
         <AlertDialog
           onOpenChange={(open) => {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,6 +22,8 @@ pre-push:
   commands:
     rust-tests:
       run: just test-unit
+    desktop-check:
+      run: just desktop-check
     desktop-test:
       run: just desktop-test
     desktop-tauri-test:

--- a/scripts/check-px-text-core.mjs
+++ b/scripts/check-px-text-core.mjs
@@ -50,7 +50,7 @@ async function walkFiles(directory) {
  * @param {string} options.projectRoot Absolute path the rule roots resolve against.
  * @param {Array<{root: string, extensions: Set<string>}>} options.rules Where to scan.
  * @param {string} options.label Human label for the failure header.
- * @param {Set<string>} [options.overrides] Allowlisted "relativePath:lineNumber" entries.
+ * @param {Set<string>} [options.overrides] Allowlisted "relativePath:matchedLiteral" entries.
  * @param {string} options.scriptPath Path mentioned in the failure hint.
  */
 export async function runPxTextCheck({
@@ -94,16 +94,15 @@ export async function runPxTextCheck({
     const lines = content.split(/\r?\n/);
     lines.forEach((line, index) => {
       const lineNumber = index + 1;
-      const key = `${relativePath}:${lineNumber}`;
-      if (overrides.has(key)) {
-        return;
-      }
       const matches = [
         ...(line.match(TEXT_ARBITRARY_RE) ?? []),
         ...(line.match(FONT_SIZE_PX_RE) ?? []),
       ];
       for (const match of matches) {
-        violations.push({ relativePath, lineNumber, match });
+        const key = `${relativePath}:${match}`;
+        if (!overrides.has(key)) {
+          violations.push({ relativePath, lineNumber, match });
+        }
       }
     });
   }
@@ -119,7 +118,7 @@ export async function runPxTextCheck({
         "tokens) so the text scales with Cmd +/- zoom and stays on one scale. " +
         "If this size is " +
         "genuinely decorative/chrome (not readable message text), add a " +
-        `narrowly scoped \`relativePath:lineNumber\` exception in \`${scriptPath}\`.`,
+        `narrowly scoped \`relativePath:matchedLiteral\` exception in \`${scriptPath}\`.`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- replace the oversized Sign out section and nested card with one compact divider row
- use the shared destructive button styling
- retain the existing confirmation flow and add explicit bottom spacing
- make the px-text guard's decorative exceptions stable across unrelated line movement

## Before
![Before — oversized Sign out header, nested card, and edge-hugging action](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/1903/signout-before.png)

## After
![After — compact divided row, standard destructive button, and bottom padding](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/1903/signout-after.png)

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm check`
- focused Playwright sign-out checks (2 passed)
