### PR TITLE
fix(desktop): filter punctuation from avatar initials

### DIFF
--- a/desktop/src/features/communities/ui/CommunityIconSettingsCard.tsx
+++ b/desktop/src/features/communities/ui/CommunityIconSettingsCard.tsx
@@ -9,7 +9,7 @@ import {
   communityIconQueryKey,
 } from "@/features/communities/useCommunityIcons";
 import { useCommunities } from "@/features/communities/useCommunities";
-import { communityInitials } from "@/features/sidebar/ui/CommunityRail";
+import { getInitials } from "@/shared/lib/initials";
 import { setCommunityIcon } from "@/shared/api/communityProfile";
 import { Button } from "@/shared/ui/button";
 
@@ -72,9 +72,7 @@ export function CommunityIconSettingsCard() {
   }
 
   const icon = iconQuery.data ?? null;
-  const initials = activeCommunity
-    ? communityInitials(activeCommunity.name)
-    : "";
+  const initials = activeCommunity ? getInitials(activeCommunity.name) : "";
 
   return (
     <div className="space-y-1.5" data-testid="community-icon-settings">

--- a/desktop/src/features/sidebar/ui/CommunityRail.test.mjs
+++ b/desktop/src/features/sidebar/ui/CommunityRail.test.mjs
@@ -1,25 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import {
-  communityInitials,
-  communityRailIndicators,
-} from "./CommunityRail.tsx";
-
-describe("communityInitials", () => {
-  it("filters punctuation before deriving initials", () => {
-    assert.equal(communityInitials("B (relay)"), "BR");
-  });
-  it("handles a leading symbol on a single word", () => {
-    assert.equal(communityInitials("(staging)"), "S");
-  });
-  it("still returns plain initials for normal names", () => {
-    assert.equal(communityInitials("Bravo Beta"), "BB");
-  });
-  it("returns empty for a symbol-only name (caller falls back)", () => {
-    assert.equal(communityInitials("()"), "");
-  });
-});
+import { communityRailIndicators } from "./CommunityRail.tsx";
 
 describe("communityRailIndicators", () => {
   it("shows no badge for an observed community with unread but no mentions", () => {

--- a/desktop/src/features/sidebar/ui/CommunityRail.tsx
+++ b/desktop/src/features/sidebar/ui/CommunityRail.tsx
@@ -36,12 +36,6 @@ type CommunityRailProps = {
 
 const MAX_BADGE = 99;
 
-// Strip punctuation before initials so "B (relay)" yields "BR", not "B(".
-export function communityInitials(name: string): string {
-  const cleaned = name.replace(/[^\p{L}\p{N}\s]/gu, " ");
-  return getInitials(cleaned);
-}
-
 /**
  * Presentation decisions for one community button, derived from its observed
  * mention state. Pure so it can be unit-tested without a DOM. The `state` guard
@@ -129,7 +123,7 @@ function CommunityButton({
                     src={iconUrl}
                   />
                 ) : (
-                  communityInitials(community.name) || "🐝"
+                  getInitials(community.name) || "🐝"
                 )}
               </span>
               {showBadge ? (

--- a/desktop/src/shared/lib/initials.test.mjs
+++ b/desktop/src/shared/lib/initials.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getInitials } from "./initials.ts";
+
+describe("getInitials", () => {
+  it("filters punctuation before deriving initials", () => {
+    assert.equal(getInitials("B (relay)"), "BR");
+  });
+
+  it("handles a leading symbol on a single word", () => {
+    assert.equal(getInitials("(staging)"), "S");
+  });
+
+  it("still returns plain initials for normal names", () => {
+    assert.equal(getInitials("Bravo Beta"), "BB");
+  });
+
+  it("returns empty for a symbol-only name", () => {
+    assert.equal(getInitials("()"), "");
+  });
+});

--- a/desktop/src/shared/lib/initials.ts
+++ b/desktop/src/shared/lib/initials.ts
@@ -1,6 +1,7 @@
 /** Derive up to two uppercase initials from a display name. */
 export function getInitials(name: string): string {
   return name
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
     .trim()
     .split(/\s+/)
     .map((part) => part[0] ?? "")


### PR DESCRIPTION
## Summary
- filter punctuation in the shared initials helper
- use that helper directly for community rail and community icon fallbacks
- cover punctuation, leading symbols, normal names, and symbol-only names

## Testing
- `pnpm test` (2,886 passed)
- `pnpm typecheck`
- focused `biome check` for changed files

## Notes
- Full `pnpm check` is blocked by two unrelated existing unused-code warnings in `tests/e2e/inbox-live-update.spec.ts` and `tests/e2e/typing-latency.perf.ts`.
