### PR TITLE
fix(desktop): preserve snapshot attachment URLs

### DIFF
--- a/desktop/src/shared/ui/markdownFileCard.test.mjs
+++ b/desktop/src/shared/ui/markdownFileCard.test.mjs
@@ -227,17 +227,22 @@ test("resolveSnapshotCard: uppercase .AGENT.JSON classifies as snapshot card", (
 
 // ── snapshot card thumbnails ─────────────────────────────────────────────────
 
-test("resolveSnapshotCard: .agent.png uses its own URL as thumb", () => {
+test("resolveSnapshotCard: keeps canonical PNG URL for actions", () => {
   const card = resolveSnapshotCard(
     { m: "image/png", size: 2048, filename: "bot.agent.png", x: SHA256 },
     PNG_URL,
     "",
   );
   assert.ok(card !== null);
-  // PNG attachment URL is rewritten by rewriteRelayUrl — just verify it's set
+  assert.equal(card.href, PNG_URL);
   assert.ok(
     card.thumb != null,
     "PNG card must have a thumb set from its own URL",
+  );
+  assert.notEqual(
+    card.thumb,
+    card.href,
+    "only the display thumbnail may use the local media proxy",
   );
 });
 

--- a/desktop/src/shared/ui/markdownFileCard.ts
+++ b/desktop/src/shared/ui/markdownFileCard.ts
@@ -86,7 +86,7 @@ export function resolveSnapshotCard(
   const snapshotKind: "agent" | "team" = isJson || isPng ? "agent" : "team";
 
   return {
-    href: rewriteRelayUrl(href),
+    href,
     filename,
     size: entry.size,
     sha256,


### PR DESCRIPTION
## Summary
- preserve canonical relay attachment URLs for snapshot import and download actions
- proxy only PNG thumbnail display URLs
- cover the action/display URL split with a regression test

## Verification
- `node --test desktop/src/shared/ui/markdownFileCard.test.mjs` (27/27)
- desktop typecheck
- Biome
- diff check

Fixes:
<img width="297" height="127" alt="d73a0078342f99226dcb23023ed476cd1716ac7ba25ef8e21e8ff44aba76ac08" src="https://github.com/user-attachments/assets/6d4278c9-a34a-4d6a-8a25-fe78a9f76602" />


