### PR TITLE
fix(desktop): restore chat-first agent creation after mesh rebase

### DIFF
--- a/desktop/src/features/agents/useAgentManagement.ts
+++ b/desktop/src/features/agents/useAgentManagement.ts
@@ -20,7 +20,6 @@ import {
 import {
   availableRuntimesForStart,
   buildInstanceInputForDefinition,
-  mintDefinitionWithPreflight,
   type BackendIntent,
 } from "./lib/instanceInputForDefinition";
 import { useCreatedAgentChannelAttachment } from "./useCreatedAgentChannelAttachment";
@@ -33,7 +32,6 @@ import type {
   CreatePersonaInput,
   UpdatePersonaInput,
 } from "@/shared/api/types";
-import { meshPrepareRelayMeshClient } from "@/shared/api/tauriMesh";
 
 function updateInputFromRequest(
   request: Extract<AgentManagementRequest, { action: "update" }>,
@@ -201,15 +199,10 @@ export function useAgentManagement() {
         undefined,
         runtime.avatarUrl,
       );
-      const persona = await mintDefinitionWithPreflight(
-        intent === "definition_start" ? backendIntent : null,
-        meshPrepareRelayMeshClient,
-        () =>
-          createPersonaMutation.mutateAsync({
-            ...input,
-            avatarUrl,
-          }),
-      );
+      const persona = await createPersonaMutation.mutateAsync({
+        ...input,
+        avatarUrl,
+      });
 
       if (intent === "definition_start") {
         const created = await createAgentMutation.mutateAsync(


### PR DESCRIPTION
`useAgentManagement.ts` still called `mintDefinitionWithPreflight` and `meshPrepareRelayMeshClient`, both removed by #1656. #1878 merged from a base predating that removal and added the file with these stale calls, breaking main's Desktop TypeScript build (`TS2305: Module has no exported member`) since its merge commit.

Applies the same post-#1656 adaptation already used by `usePersonaActions.ts`: call `createPersonaMutation.mutateAsync({ ...input, avatarUrl })` directly and drop the removed mesh preflight wrapper. `buildInstanceInputForDefinition(..., backendIntent)` is unchanged.
