### PR TITLE
Add KLIPY GIF search to message composers

### DIFF
--- a/desktop/src/features/custom-emoji/ui/EmojiPicker.tsx
+++ b/desktop/src/features/custom-emoji/ui/EmojiPicker.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 
 import { buildCustomEmojiCategory } from "@/features/custom-emoji/emojiMartCategory";
 import { useCustomEmoji } from "@/features/custom-emoji/hooks";
+import { useTheme } from "@/shared/theme/ThemeProvider";
 
 // emoji-mart builds its searchable index synchronously inside `init`, which
 // `<Picker>` calls on mount — so the first reaction popover open paid the full
@@ -105,13 +106,17 @@ type EmojiPickerProps = {
   autoFocus?: boolean;
   /** Called with the chosen emoji as a string: `native` glyph or `:shortcode:`. */
   onSelect: (emoji: string) => void;
+  /** Number of emoji columns. Defaults to the compact picker used elsewhere. */
+  perLine?: number;
 };
 
 export const EmojiPicker = React.memo(function EmojiPicker({
   autoFocus = false,
   onSelect,
+  perLine = 8,
 }: EmojiPickerProps) {
   const customEmoji = useCustomEmoji();
+  const { isDark } = useTheme();
   const custom = React.useMemo(
     () => buildCustomEmojiCategory(customEmoji),
     [customEmoji],
@@ -139,11 +144,11 @@ export const EmojiPicker = React.memo(function EmojiPicker({
             onSelect(value);
           }
         }}
-        perLine={8}
+        perLine={perLine}
         previewPosition="bottom"
         set="native"
         skinTonePosition="search"
-        theme="auto"
+        theme={isDark ? "dark" : "light"}
       />
     </div>
   );

--- a/desktop/src/features/forum/ui/ForumComposer.tsx
+++ b/desktop/src/features/forum/ui/ForumComposer.tsx
@@ -492,6 +492,7 @@ export function ForumComposer({
                 ) : undefined
               }
               formattingDisabled={disabled ?? false}
+              gifUploadController={media}
               isEmojiPickerOpen={isEmojiPickerOpen}
               isFormattingOpen={isFormattingOpen}
               isSending={isSending ?? false}

--- a/desktop/src/features/gifs/api.test.mjs
+++ b/desktop/src/features/gifs/api.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { klipyGifFilename, normalizeKlipyGifs } from "./api.ts";
+
+const GIF_ASSET = {
+  url: "https://static.klipy.com/example.gif",
+  width: 640,
+  height: 360,
+  size: 42,
+};
+
+test("normalizeKlipyGifs selects a compact preview and medium GIF", () => {
+  const [gif] = normalizeKlipyGifs([
+    {
+      id: 7,
+      title: "  Ship it  ",
+      slug: "ship-it",
+      type: "gif",
+      file: {
+        md: { gif: GIF_ASSET },
+        sm: {
+          webp: {
+            url: "https://static.klipy.com/preview.webp",
+            width: 220,
+            height: 124,
+            size: 12,
+          },
+        },
+      },
+    },
+  ]);
+
+  assert.equal(gif.title, "Ship it");
+  assert.equal(gif.original.url, GIF_ASSET.url);
+  assert.equal(gif.preview.url, "https://static.klipy.com/preview.webp");
+});
+
+test("normalizeKlipyGifs omits ads and malformed file records", () => {
+  const gifs = normalizeKlipyGifs([
+    { id: 1, slug: "ad", type: "ad" },
+    { id: 2, slug: "missing", type: "gif", file: {} },
+  ]);
+
+  assert.deepEqual(gifs, []);
+});
+
+test("klipyGifFilename sanitizes provider slugs", () => {
+  const filename = klipyGifFilename({
+    id: 1,
+    original: GIF_ASSET,
+    preview: GIF_ASSET,
+    slug: "  That's a wrap!  ",
+    title: "That's a wrap",
+  });
+
+  assert.equal(filename, "that-s-a-wrap.gif");
+});

--- a/desktop/src/features/gifs/api.ts
+++ b/desktop/src/features/gifs/api.ts
@@ -1,0 +1,197 @@
+const KLIPY_API_ROOT = "https://api.klipy.com/api/v1";
+const KLIPY_CUSTOMER_ID_STORAGE_KEY = "buzz:klipy-customer-id:v1";
+
+type KlipyAsset = {
+  height?: number;
+  size?: number;
+  url?: string;
+  width?: number;
+};
+
+type KlipyFileSet = {
+  gif?: KlipyAsset;
+  jpg?: KlipyAsset;
+  webp?: KlipyAsset;
+};
+
+type KlipyRawGif = {
+  file?: {
+    hd?: KlipyFileSet;
+    md?: KlipyFileSet;
+    sm?: KlipyFileSet;
+    xs?: KlipyFileSet;
+  };
+  id?: number;
+  slug?: string;
+  title?: string;
+  type?: string;
+};
+
+type KlipyResponse = {
+  data?: {
+    data?: KlipyRawGif[];
+  };
+  errors?: {
+    message?: string[];
+  };
+  result?: boolean;
+};
+
+export type KlipyGif = {
+  id: number;
+  original: Required<KlipyAsset>;
+  preview: Required<KlipyAsset>;
+  slug: string;
+  title: string;
+};
+
+function configuredApiKey(): string {
+  return import.meta.env?.VITE_KLIPY_API_KEY?.trim() ?? "";
+}
+
+export function isKlipyConfigured(): boolean {
+  return configuredApiKey().length > 0;
+}
+
+function customerId(): string {
+  if (typeof window === "undefined") return "buzz-desktop";
+
+  try {
+    const existing = window.localStorage.getItem(KLIPY_CUSTOMER_ID_STORAGE_KEY);
+    if (existing) return existing;
+
+    const created = globalThis.crypto.randomUUID();
+    window.localStorage.setItem(KLIPY_CUSTOMER_ID_STORAGE_KEY, created);
+    return created;
+  } catch {
+    return "buzz-desktop";
+  }
+}
+
+function isCompleteAsset(
+  asset: KlipyAsset | undefined,
+): asset is Required<KlipyAsset> {
+  return (
+    typeof asset?.url === "string" &&
+    asset.url.length > 0 &&
+    typeof asset.width === "number" &&
+    typeof asset.height === "number" &&
+    typeof asset.size === "number"
+  );
+}
+
+function firstCompleteAsset(
+  ...assets: Array<KlipyAsset | undefined>
+): Required<KlipyAsset> | null {
+  return assets.find(isCompleteAsset) ?? null;
+}
+
+/**
+ * Normalize KLIPY's mixed media response to GIF-only results. The API can
+ * interleave ad/content records without a file payload; those are intentionally
+ * omitted until Buzz has an explicit third-party ad surface.
+ */
+export function normalizeKlipyGifs(items: KlipyRawGif[]): KlipyGif[] {
+  const gifs: KlipyGif[] = [];
+
+  for (const item of items) {
+    if (item.type !== "gif" || !item.file || !item.slug) continue;
+
+    const original = firstCompleteAsset(
+      item.file.md?.gif,
+      item.file.hd?.gif,
+      item.file.sm?.gif,
+      item.file.xs?.gif,
+    );
+    const preview = firstCompleteAsset(
+      item.file.sm?.webp,
+      item.file.sm?.gif,
+      item.file.xs?.webp,
+      item.file.xs?.gif,
+      item.file.md?.webp,
+      original ?? undefined,
+    );
+    if (!original || !preview) continue;
+
+    gifs.push({
+      id: item.id ?? gifs.length,
+      original,
+      preview,
+      slug: item.slug,
+      title: item.title?.trim() || "GIF",
+    });
+  }
+
+  return gifs;
+}
+
+function apiUrl(path: string): URL {
+  const apiKey = configuredApiKey();
+  if (!apiKey) {
+    throw new Error("KLIPY is not configured for this build");
+  }
+  return new URL(`${KLIPY_API_ROOT}/${encodeURIComponent(apiKey)}/${path}`);
+}
+
+function responseError(response: KlipyResponse, status: number): Error {
+  const message = response.errors?.message?.filter(Boolean).join(" ");
+  return new Error(message || `KLIPY request failed (${status})`);
+}
+
+export async function fetchKlipyGifs(
+  query: string,
+  signal?: AbortSignal,
+): Promise<KlipyGif[]> {
+  const normalizedQuery = query.trim();
+  const path = normalizedQuery ? "gifs/search" : "gifs/trending";
+  const url = apiUrl(path);
+  url.searchParams.set("page", "1");
+  url.searchParams.set("per_page", "24");
+  url.searchParams.set("customer_id", customerId());
+  url.searchParams.set("locale", navigator.language || "en-US");
+  if (normalizedQuery) url.searchParams.set("q", normalizedQuery);
+
+  const httpResponse = await fetch(url, { signal });
+  const response = (await httpResponse.json()) as KlipyResponse;
+  if (!httpResponse.ok || response.result === false) {
+    throw responseError(response, httpResponse.status);
+  }
+
+  return normalizeKlipyGifs(response.data?.data ?? []);
+}
+
+export function klipyGifFilename(gif: KlipyGif): string {
+  const safeSlug = gif.slug
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return `${safeSlug || "klipy-gif"}.gif`;
+}
+
+export async function downloadKlipyGif(gif: KlipyGif): Promise<File> {
+  const response = await fetch(gif.original.url);
+  if (!response.ok) {
+    throw new Error(`Could not download GIF (${response.status})`);
+  }
+
+  const blob = await response.blob();
+  return new File([blob], klipyGifFilename(gif), {
+    type: blob.type || "image/gif",
+  });
+}
+
+/** Record the provider's share event after the user chooses a GIF. */
+export async function trackKlipyGifShare(slug: string): Promise<void> {
+  const response = await fetch(
+    apiUrl(`gifs/share/${encodeURIComponent(slug)}`),
+    {
+      body: JSON.stringify({ customer_id: customerId() }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Could not record KLIPY share (${response.status})`);
+  }
+}

--- a/desktop/src/features/gifs/ui/KlipyGifPicker.tsx
+++ b/desktop/src/features/gifs/ui/KlipyGifPicker.tsx
@@ -1,0 +1,141 @@
+import { useQuery } from "@tanstack/react-query";
+import { LoaderCircle, Search } from "lucide-react";
+import * as React from "react";
+
+import {
+  fetchKlipyGifs,
+  isKlipyConfigured,
+  type KlipyGif,
+} from "@/features/gifs/api";
+import { Input } from "@/shared/ui/input";
+import { Skeleton } from "@/shared/ui/skeleton";
+
+type KlipyGifPickerProps = {
+  onSelect: (gif: KlipyGif) => void;
+};
+
+const LOADING_SKELETONS = [
+  "tall-a",
+  "short-a",
+  "short-b",
+  "tall-b",
+  "short-c",
+  "short-d",
+  "tall-c",
+  "short-e",
+  "short-f",
+  "tall-d",
+] as const;
+
+export const KlipyGifPicker = React.memo(function KlipyGifPicker({
+  onSelect,
+}: KlipyGifPickerProps) {
+  const [search, setSearch] = React.useState("");
+  const [debouncedSearch, setDebouncedSearch] = React.useState("");
+
+  React.useEffect(() => {
+    const timeout = window.setTimeout(
+      () => setDebouncedSearch(search.trim()),
+      250,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  const configured = isKlipyConfigured();
+  const gifsQuery = useQuery({
+    enabled: configured,
+    queryFn: ({ signal }) => fetchKlipyGifs(debouncedSearch, signal),
+    queryKey: ["klipy-gifs", debouncedSearch],
+    staleTime: 5 * 60 * 1_000,
+  });
+
+  return (
+    <div className="flex h-[435px] w-[352px] flex-col bg-popover text-popover-foreground">
+      <div className="border-b border-border/60 p-2.5">
+        <div className="relative">
+          <Search
+            aria-hidden
+            className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            aria-label="Search KLIPY"
+            autoFocus
+            className="h-9 pl-8 pr-8"
+            disabled={!configured}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search KLIPY"
+            type="search"
+            value={search}
+          />
+          {gifsQuery.isFetching ? (
+            <LoaderCircle
+              aria-hidden
+              className="absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground"
+            />
+          ) : null}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {!configured ? (
+          <div className="flex h-full items-center justify-center px-8 text-center text-sm text-muted-foreground">
+            GIF search is not configured for this build.
+          </div>
+        ) : gifsQuery.isPending ? (
+          <div className="grid grid-cols-2 gap-1.5">
+            <span className="sr-only">Loading GIFs</span>
+            {LOADING_SKELETONS.map((id) => (
+              <Skeleton
+                className={id.startsWith("tall") ? "h-28" : "h-20"}
+                key={id}
+              />
+            ))}
+          </div>
+        ) : gifsQuery.isError ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              {gifsQuery.error.message}
+            </p>
+            <button
+              className="text-sm font-medium text-primary hover:underline"
+              onClick={() => void gifsQuery.refetch()}
+              type="button"
+            >
+              Try again
+            </button>
+          </div>
+        ) : gifsQuery.data.length === 0 ? (
+          <div className="flex h-full items-center justify-center px-8 text-center text-sm text-muted-foreground">
+            No GIFs found.
+          </div>
+        ) : (
+          <div className="columns-2 gap-1.5" data-testid="klipy-gif-grid">
+            {gifsQuery.data.map((gif) => (
+              <button
+                aria-label={`Choose ${gif.title}`}
+                className="mb-1.5 block w-full break-inside-avoid overflow-hidden rounded-lg bg-muted outline-hidden ring-offset-background transition-[filter,transform] hover:brightness-110 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:scale-[0.98]"
+                key={`${gif.id}-${gif.slug}`}
+                onClick={() => onSelect(gif)}
+                title={gif.title}
+                type="button"
+              >
+                <img
+                  alt={gif.title}
+                  className="block h-auto w-full"
+                  height={gif.preview.height}
+                  loading="lazy"
+                  src={gif.preview.url}
+                  width={gif.preview.width}
+                />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="border-t border-border/60 px-3 py-2 text-center text-2xs text-muted-foreground">
+        Powered by KLIPY
+      </div>
+    </div>
+  );
+});

--- a/desktop/src/features/messages/ui/ComposerEmojiPicker.tsx
+++ b/desktop/src/features/messages/ui/ComposerEmojiPicker.tsx
@@ -1,13 +1,25 @@
-import { SmilePlus } from "lucide-react";
+import { Images, Smile, SmilePlus } from "lucide-react";
 import * as React from "react";
 
 import { EmojiPicker } from "@/features/custom-emoji/ui/EmojiPicker";
+import {
+  downloadKlipyGif,
+  type KlipyGif,
+  trackKlipyGifShare,
+} from "@/features/gifs/api";
+import { KlipyGifPicker } from "@/features/gifs/ui/KlipyGifPicker";
+import type { MediaUploadController } from "@/features/messages/lib/useMediaUpload";
 import { Button } from "@/shared/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 type ComposerEmojiPickerProps = {
   disabled?: boolean;
+  gifUploadController: Pick<
+    MediaUploadController,
+    "setUploadState" | "uploadFile"
+  >;
   /** Called when the popover closes without an emoji selection (Escape,
    *  click-outside). Use this to restore focus to the editor. */
   onClose?: () => void;
@@ -19,19 +31,41 @@ type ComposerEmojiPickerProps = {
 
 export const ComposerEmojiPicker = React.memo(function ComposerEmojiPicker({
   disabled = false,
+  gifUploadController,
   onClose,
   onEmojiSelect,
   onOpenChange,
   onTriggerMouseDown,
   open,
 }: ComposerEmojiPickerProps) {
+  const handleGifSelect = React.useCallback(
+    (gif: KlipyGif) => {
+      onOpenChange(false);
+      void downloadKlipyGif(gif)
+        .then(gifUploadController.uploadFile)
+        .catch((error: unknown) => {
+          gifUploadController.setUploadState({
+            status: "error",
+            message: String(error),
+          });
+        });
+      // Provider analytics must never block the user's attachment flow.
+      void trackKlipyGifShare(gif.slug).catch(() => undefined);
+    },
+    [
+      gifUploadController.setUploadState,
+      gifUploadController.uploadFile,
+      onOpenChange,
+    ],
+  );
+
   return (
     <Popover onOpenChange={onOpenChange} open={open}>
       <Tooltip disableHoverableContent>
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>
             <Button
-              aria-label="Insert emoji"
+              aria-label="Insert emoji or GIF"
               data-testid="composer-emoji-button"
               disabled={disabled}
               onMouseDown={onTriggerMouseDown}
@@ -43,7 +77,7 @@ export const ComposerEmojiPicker = React.memo(function ComposerEmojiPicker({
             </Button>
           </PopoverTrigger>
         </TooltipTrigger>
-        <TooltipContent>Insert emoji</TooltipContent>
+        <TooltipContent>Emoji and GIFs</TooltipContent>
       </Tooltip>
       <PopoverContent
         align="start"
@@ -64,7 +98,27 @@ export const ComposerEmojiPicker = React.memo(function ComposerEmojiPicker({
         side="top"
         sideOffset={10}
       >
-        <EmojiPicker autoFocus onSelect={onEmojiSelect} />
+        <Tabs
+          className="w-[352px] overflow-hidden rounded-2xl bg-popover"
+          defaultValue="emoji"
+        >
+          <TabsList className="h-11 w-full rounded-none border-b border-border/60 bg-popover p-1.5">
+            <TabsTrigger className="h-8 flex-1 gap-1.5" value="emoji">
+              <Smile aria-hidden className="h-4 w-4" />
+              Emoji
+            </TabsTrigger>
+            <TabsTrigger className="h-8 flex-1 gap-1.5" value="gifs">
+              <Images aria-hidden className="h-4 w-4" />
+              GIFs
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent className="m-0" value="emoji">
+            <EmojiPicker autoFocus onSelect={onEmojiSelect} perLine={9} />
+          </TabsContent>
+          <TabsContent className="m-0" value="gifs">
+            <KlipyGifPicker onSelect={handleGifSelect} />
+          </TabsContent>
+        </Tabs>
       </PopoverContent>
     </Popover>
   );

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -997,6 +997,7 @@ function MessageComposerImpl({
               editor={richText.editor}
               extraActions={toolbarExtraActions}
               formattingDisabled={disabled}
+              gifUploadController={media}
               isEmojiPickerOpen={isEmojiPickerOpen}
               isFormattingOpen={isFormattingOpen}
               isSending={isSending}

--- a/desktop/src/features/messages/ui/MessageComposerToolbar.tsx
+++ b/desktop/src/features/messages/ui/MessageComposerToolbar.tsx
@@ -3,6 +3,7 @@ import type { Editor } from "@tiptap/react";
 import { AnimatePresence, motion } from "motion/react";
 import { ALargeSmall, ArrowUp, AtSign, Paperclip, X } from "lucide-react";
 
+import type { MediaUploadController } from "@/features/messages/lib/useMediaUpload";
 import { Button } from "@/shared/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { ComposerEmojiPicker } from "./ComposerEmojiPicker";
@@ -22,6 +23,7 @@ export const MessageComposerToolbar = React.memo(
     editor,
     extraActions,
     formattingDisabled,
+    gifUploadController,
     isEmojiPickerOpen,
     isFormattingOpen,
     isSending,
@@ -39,6 +41,10 @@ export const MessageComposerToolbar = React.memo(
     editor: Editor | null;
     extraActions?: React.ReactNode;
     formattingDisabled: boolean;
+    gifUploadController: Pick<
+      MediaUploadController,
+      "setUploadState" | "uploadFile"
+    >;
     isEmojiPickerOpen: boolean;
     isFormattingOpen: boolean;
     isSending: boolean;
@@ -194,6 +200,7 @@ export const MessageComposerToolbar = React.memo(
                 </Tooltip>
                 <ComposerEmojiPicker
                   disabled={composerDisabled}
+                  gifUploadController={gifUploadController}
                   onClose={() => editor?.commands.focus()}
                   onEmojiSelect={onEmojiSelect}
                   onOpenChange={onEmojiPickerOpenChange}

--- a/desktop/src/vite-env.d.ts
+++ b/desktop/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_KLIPY_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

- adds Emoji and GIF tabs to message and forum composers
- supports KLIPY trending/search results and uploads the selected GIF through Buzz's existing media flow
- keeps Emoji Mart aligned with Buzz's theme and picker width

@wesbillman @tlongwell-block — support for GIF search was pretty straightforward to add; this is a working end-to-end implementation.

## Next steps before release

Business-side help needed:

- request a KLIPY production API key
- confirm that posting selected GIFs into Buzz media storage is covered by KLIPY's terms
- confirm the required ad model, official attribution, and privacy disclosure

Engineering follow-up after those decisions: wire the production key into release builds, hide the tab when unconfigured, add the official KLIPY branding, and harden pagination and download-size limits.

## Validation

- tested trending, search, selection, upload, and light/dark themes in the staging app
- 2,912 desktop unit tests pass
- desktop typecheck, formatting checks, and production build pass
- the broader local Rust gate was attempted but exhausted machine disk; GitHub CI will run the complete gate
