### PR TITLE
Fix live agent reactions in Inbox and channels

### DIFF
--- a/desktop/src/features/channels/unreadReadMarker.test.mjs
+++ b/desktop/src/features/channels/unreadReadMarker.test.mjs
@@ -16,7 +16,10 @@ import {
   resolveChannelReadMarker,
   resolveObservedUnreadRootId,
 } from "./useUnreadChannels.ts";
-import { isChannelUnreadTriggerKind } from "./useLiveChannelUpdates.ts";
+import {
+  isChannelUnreadTriggerKind,
+  withChannelTagFallback,
+} from "./useLiveChannelUpdates.ts";
 import {
   KIND_HUDDLE_ENDED,
   KIND_HUDDLE_STARTED,
@@ -56,6 +59,35 @@ test("receiveThenReopen_frontierAtLatestArrival_clobbersDivider", () => {
 
   assert.equal(marker.firstUnreadMessageId, null);
   assert.equal(marker.unreadCount, 0);
+});
+
+test("live reaction without h tag inherits its subscription channel", () => {
+  const reaction = {
+    id: "reaction",
+    kind: 7,
+    pubkey: "agent",
+    created_at: 1,
+    content: "👀",
+    tags: [["e", "message"]],
+  };
+
+  assert.deepEqual(withChannelTagFallback(reaction, "channel-a").tags, [
+    ["e", "message"],
+    ["h", "channel-a"],
+  ]);
+});
+
+test("live event with h tag is preserved", () => {
+  const message = {
+    id: "message",
+    kind: KIND_STREAM_MESSAGE,
+    pubkey: "author",
+    created_at: 1,
+    content: "hello",
+    tags: [["h", "channel-from-event"]],
+  };
+
+  assert.equal(withChannelTagFallback(message, "other-channel"), message);
 });
 
 test("dmHuddleStart_isDmOnlyUnreadTrigger", () => {

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -88,6 +88,15 @@ export function isChannelUnreadTriggerKind(kind: number, isDmChannel: boolean) {
     : UNREAD_TRIGGER_KINDS.has(kind);
 }
 
+export function withChannelTagFallback(
+  event: RelayEvent,
+  channelId: string,
+): RelayEvent {
+  return getChannelIdFromTags(event.tags)
+    ? event
+    : { ...event, tags: [...event.tags, ["h", channelId]] };
+}
+
 function isExternalMentionEvent(event: RelayEvent, currentPubkey: string) {
   return (
     currentPubkey.length > 0 && event.pubkey.toLowerCase() !== currentPubkey
@@ -359,7 +368,8 @@ export function useLiveChannelUpdates(
                 limit: 1000,
                 since: Math.floor(Date.now() / 1_000),
               },
-              handleIncomingMessage,
+              (event) =>
+                handleIncomingMessage(withChannelTagFallback(event, channelId)),
             );
             if (isCancelled) {
               void dispose().catch(() => {});

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -7707,13 +7707,10 @@ async function handleAddReaction(
   }
 
   const emoji = args.emoji.trim();
-  // `h` routes the live event to the channel store (getChannelIdFromTags);
-  // `e` names the reaction target. For a custom emoji, the NIP-30
-  // `["emoji", shortcode, url]` tag carries the image URL.
-  const tags: string[][] = [
-    ["h", channelId],
-    ["e", args.eventId],
-  ];
+  // Real add_reaction events carry only the target `e` tag. Channel live
+  // subscriptions already know which channel matched and restore that context
+  // before merging the event into the timeline cache.
+  const tags: string[][] = [["e", args.eventId]];
   if (args.emojiUrl) {
     const shortcode = emoji.replace(/^:+/, "").replace(/:+$/, "").toLowerCase();
     tags.push(["emoji", shortcode, args.emojiUrl]);

--- a/desktop/tests/e2e/inbox-reactions.spec.ts
+++ b/desktop/tests/e2e/inbox-reactions.spec.ts
@@ -121,6 +121,24 @@ test("inbox reaction on a thread-reply mention persists after refetch", async ({
   await expect(detail).toContainText("please react to this");
 
   const selectedMessage = page.getByTestId("home-inbox-selected-message");
+
+  // Deliver a live reaction with the real add_reaction wire shape: `e` target,
+  // no `h` channel tag. The Inbox must render it without waiting for another
+  // message or a context refetch.
+  await page.evaluate(async (eventId) => {
+    const invoke = (
+      window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+          command: string,
+          payload?: Record<string, unknown>,
+        ) => Promise<unknown>;
+      }
+    ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+    if (!invoke) throw new Error("Mock Tauri invoke bridge is unavailable.");
+    await invoke("add_reaction", { eventId, emoji: "❤️" });
+  }, replyEvent.id);
+  await expect(selectedMessage.getByLabel("Toggle ❤️ reaction")).toBeVisible();
+
   await selectedMessage.hover();
   await selectedMessage
     .getByRole("button", { name: "React with :+1:" })


### PR DESCRIPTION
## Summary
- retain the known subscription channel when live events omit an `h` tag
- mirror the production kind-7 reaction shape in the browser test bridge
- cover immediate live reaction rendering in Inbox and existing channel/thread reaction flows

## Defect
Kind-7 reactions emitted by `add_reaction` identify their target with an `e` tag but carry no `h` tag. The global per-channel live subscription knew the matching channel, but dropped that context before the event reached `handleIncomingMessage`, which discarded it before cache merge.

## Validation
- `just desktop-check`
- `just desktop-test` — 2,911 passed
- `pnpm build`
- focused Playwright smoke flows — 6 passed:
  - Inbox live reaction + persistence after refetch
  - normal channel reactions
  - thread reaction during in-flight refetch
  - custom emoji reaction
  - system-message reaction
  - reaction ordering
- pre-push hooks passed
