### PR TITLE
feat(media): require auth for relay media reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,11 @@ RELAY_URL=ws://localhost:3000
 # BUZZ_MEDIA_MAX_CONCURRENT_UPLOADS=8
 # BUZZ_MEDIA_MAX_CONCURRENT_UPLOADS_PER_PUBKEY=2
 # BUZZ_MEDIA_UPLOADS_PER_MINUTE=30
+# Require Blossom t=get auth and relay membership for GET/HEAD /media/*.
+# Keep off until desktop/mobile/CLI clients that attach media read auth are deployed.
+# BUZZ_REQUIRE_MEDIA_GET_AUTH=false
+# Legacy alias accepted by the relay while rollout docs catch up:
+# BUZZ_REQUIRE_MEDIA_READ_AUTH=false
 
 # -----------------------------------------------------------------------------
 # Ephemeral Channels (TTL testing)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "buzz-persona",
  "buzz-sdk",
  "buzz-ws-client",
+ "bytes",
  "chrono",
  "clap",
  "diffy",
@@ -958,6 +959,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "buzz-cli",
+ "buzz-core",
  "git-credential-nostr",
  "git-sign-nostr",
  "ignore",

--- a/TESTING.md
+++ b/TESTING.md
@@ -269,6 +269,7 @@ out of the box with `just setup` or `just relay`. Common overrides:
 | `REDIS_URL`                       | `redis://localhost:6379`    | |
 | `BUZZ_REQUIRE_AUTH_TOKEN`       | `false`                     | When true, REST requires NIP-98 (no `X-Pubkey` fallback) |
 | `BUZZ_REQUIRE_RELAY_MEMBERSHIP` | `false`                     | When true, only pubkeys in `relay_members` can connect |
+| `BUZZ_REQUIRE_MEDIA_GET_AUTH`   | `false`                     | When true, `GET`/`HEAD /media/*` require Blossom kind 24242 `t=get` auth plus relay membership. `BUZZ_REQUIRE_MEDIA_READ_AUTH` is accepted as a legacy alias. |
 | `BUZZ_AUTO_MIGRATE`             | `false`                     | Opt in with `true`/`1`/`yes`/`on` to run embedded SQLx migrations on relay startup |
 | `RELAY_OWNER_PUBKEY`              | unset                       | Bootstrapped as `owner` in `relay_members` at first start |
 | `BUZZ_ALLOW_NIP_OA_AUTH`        | `false`                     | Enable NIP-OA owner attestation for membership |

--- a/TESTING.md
+++ b/TESTING.md
@@ -269,7 +269,7 @@ out of the box with `just setup` or `just relay`. Common overrides:
 | `REDIS_URL`                       | `redis://localhost:6379`    | |
 | `BUZZ_REQUIRE_AUTH_TOKEN`       | `false`                     | When true, REST requires NIP-98 (no `X-Pubkey` fallback) |
 | `BUZZ_REQUIRE_RELAY_MEMBERSHIP` | `false`                     | When true, only pubkeys in `relay_members` can connect |
-| `BUZZ_REQUIRE_MEDIA_GET_AUTH`   | `false`                     | When true, `GET`/`HEAD /media/*` require Blossom kind 24242 `t=get` auth plus relay membership. `BUZZ_REQUIRE_MEDIA_READ_AUTH` is accepted as a legacy alias. |
+| `BUZZ_REQUIRE_MEDIA_GET_AUTH`   | `false`                     | When true, `GET`/`HEAD /media/*` require Blossom kind 24242 `t=get` auth plus relay membership. |
 | `BUZZ_AUTO_MIGRATE`             | `false`                     | Opt in with `true`/`1`/`yes`/`on` to run embedded SQLx migrations on relay startup |
 | `RELAY_OWNER_PUBKEY`              | unset                       | Bootstrapped as `owner` in `relay_members` at first start |
 | `BUZZ_ALLOW_NIP_OA_AUTH`        | `false`                     | Enable NIP-OA owner attestation for membership |

--- a/crates/buzz-cli/Cargo.toml
+++ b/crates/buzz-cli/Cargo.toml
@@ -57,6 +57,9 @@ diffy = "0.5"
 # Hex encoding — SHA-256 hash output for Blossom uploads
 hex = { workspace = true }
 
+# Byte buffers returned by authenticated media downloads
+bytes = "1"
+
 # MIME type detection via magic bytes — file upload validation
 infer = "0.19"
 

--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -108,6 +108,212 @@ fn sign_nip98(
     Ok(format!("Nostr {}", B64.encode(json.as_bytes())))
 }
 
+fn relay_server_tag(relay_url: &str) -> Option<String> {
+    let authority = buzz_core::tenant::relay_url_authority(relay_url);
+    if authority.is_empty() {
+        None
+    } else {
+        Some(authority)
+    }
+}
+
+fn is_safe_media_path_segment(sha256_ext: &str) -> bool {
+    let segments: Vec<&str> = sha256_ext.split('.').collect();
+    match segments.as_slice() {
+        [hash] => is_lower_hex_sha256(hash),
+        [hash, ext] => is_lower_hex_sha256(hash) && is_safe_media_ext(ext),
+        [hash, "thumb", "jpg"] => is_lower_hex_sha256(hash),
+        _ => false,
+    }
+}
+
+fn is_lower_hex_sha256(value: &str) -> bool {
+    value.len() == 64 && value.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+}
+
+fn is_safe_media_ext(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 8
+        && value.chars().all(|c| matches!(c, 'a'..='z' | '0'..='9'))
+}
+
+fn media_url_from_input(relay_url: &str, input: &str) -> Result<String, CliError> {
+    let input = input.trim();
+    if input.starts_with("http://") || input.starts_with("https://") {
+        let parsed = url::Url::parse(input)
+            .map_err(|e| CliError::Usage(format!("invalid media URL: {e}")))?;
+        if !parsed.path().starts_with("/media/") {
+            return Err(CliError::Usage(
+                "media URL must point at a /media/ path".to_string(),
+            ));
+        }
+        let Some(sha256_ext) = parsed.path().strip_prefix("/media/") else {
+            return Err(CliError::Usage(
+                "media URL must point at a /media/ path".to_string(),
+            ));
+        };
+        if !is_safe_media_path_segment(sha256_ext) {
+            return Err(CliError::Usage(
+                "media path must be sha256, sha256.ext, or sha256.thumb.jpg".to_string(),
+            ));
+        }
+        let relay = url::Url::parse(relay_url)
+            .map_err(|e| CliError::Usage(format!("invalid relay URL: {e}")))?;
+        if parsed.scheme() != relay.scheme()
+            || parsed.host_str() != relay.host_str()
+            || parsed.port_or_known_default() != relay.port_or_known_default()
+        {
+            return Err(CliError::Usage(
+                "refusing to sign media GET for a non-relay origin".to_string(),
+            ));
+        }
+        return Ok(input.to_string());
+    }
+    if input.contains("://") {
+        return Err(CliError::Usage(
+            "media URL must use http:// or https://".to_string(),
+        ));
+    }
+
+    let sha256_ext = input.trim_start_matches("/media/");
+    if sha256_ext.is_empty() {
+        return Err(CliError::Usage(
+            "media input must be a URL or sha256[.ext]".to_string(),
+        ));
+    }
+    if !is_safe_media_path_segment(sha256_ext) {
+        return Err(CliError::Usage(
+            "media input must be sha256, sha256.ext, or sha256.thumb.jpg".to_string(),
+        ));
+    }
+    Ok(format!(
+        "{}/media/{sha256_ext}",
+        relay_url.trim_end_matches('/')
+    ))
+}
+
+fn sign_blossom_get(keys: &Keys, media_url: &str) -> Result<String, CliError> {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use nostr::Timestamp;
+
+    let now = Timestamp::now().as_secs();
+    let exp_str = (now + 600).to_string();
+    let domain = relay_server_tag(media_url)
+        .ok_or_else(|| CliError::Usage(format!("invalid media URL: {media_url}")))?;
+    let tags = vec![
+        Tag::parse(["t", "get"]).map_err(|e| CliError::Other(e.to_string()))?,
+        Tag::parse(["expiration", &exp_str]).map_err(|e| CliError::Other(e.to_string()))?,
+        Tag::parse(["server", &domain]).map_err(|e| CliError::Other(e.to_string()))?,
+    ];
+
+    let auth_event = EventBuilder::new(Kind::from(24242), "Get media")
+        .tags(tags)
+        .sign_with_keys(keys)
+        .map_err(|e| CliError::Other(format!("signing failed: {e}")))?;
+
+    Ok(format!(
+        "Nostr {}",
+        URL_SAFE_NO_PAD.encode(auth_event.as_json().as_bytes())
+    ))
+}
+
+#[cfg(test)]
+mod media_download_tests {
+    use super::*;
+
+    #[test]
+    fn media_url_from_sha_uses_relay_media_path() {
+        let hash = "a".repeat(64);
+        assert_eq!(
+            media_url_from_input("https://relay.example", &format!("{hash}.jpg")).unwrap(),
+            format!("https://relay.example/media/{hash}.jpg")
+        );
+        assert_eq!(
+            media_url_from_input("https://relay.example/", &format!("/media/{hash}.jpg")).unwrap(),
+            format!("https://relay.example/media/{hash}.jpg")
+        );
+    }
+
+    #[test]
+    fn media_url_accepts_only_same_relay_media_urls() {
+        let hash = "a".repeat(64);
+        assert!(media_url_from_input(
+            "https://relay.example:443",
+            &format!("https://relay.example/media/{hash}.jpg")
+        )
+        .is_ok());
+        assert!(media_url_from_input(
+            "https://relay.example",
+            &format!("http://relay.example/media/{hash}.jpg")
+        )
+        .is_err());
+        assert!(media_url_from_input(
+            "https://relay.example",
+            &format!("https://evil.example/media/{hash}.jpg")
+        )
+        .is_err());
+        assert!(media_url_from_input(
+            "https://relay.example",
+            &format!("https://relay.example/media-evil/{hash}.jpg")
+        )
+        .is_err());
+        assert!(media_url_from_input(
+            "https://relay.example",
+            &format!("ftp://relay.example/media/{hash}.jpg")
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn media_url_rejects_path_confusion_and_non_hash_inputs() {
+        for input in [
+            "abc123.jpg",
+            "../evil",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/evil.jpg",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.JPG",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.eviltoolong",
+            "https://relay.example/media/abc123.jpg",
+            "https://relay.example/media/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.JPG",
+        ] {
+            assert!(
+                media_url_from_input("https://relay.example", input).is_err(),
+                "input should be rejected: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn media_get_auth_header_is_server_scoped() {
+        let keys = Keys::generate();
+        let hash = "a".repeat(64);
+        let header = sign_blossom_get(
+            &keys,
+            &format!("https://relay.example:443/media/{hash}.jpg"),
+        )
+        .unwrap();
+        let encoded = header.strip_prefix("Nostr ").unwrap();
+        let json = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(encoded)
+            .unwrap();
+        let event = nostr::Event::from_json(std::str::from_utf8(&json).unwrap()).unwrap();
+        event.verify().unwrap();
+        assert_eq!(event.kind, Kind::from(24242));
+
+        let tags: Vec<Vec<String>> = event
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .collect();
+        assert!(tags.iter().any(|tag| tag.as_slice() == ["t", "get"]));
+        assert!(tags
+            .iter()
+            .any(|tag| tag.as_slice() == ["server", "relay.example"]));
+        assert!(!tags
+            .iter()
+            .any(|tag| tag.first().map(String::as_str) == Some("x")));
+    }
+}
+
 pub struct BuzzClient {
     http: reqwest::Client,
     relay_url: String, // base URL, no trailing slash, e.g. "https://relay.buzz.place"
@@ -358,16 +564,9 @@ impl BuzzClient {
             Tag::parse(["expiration", &exp_str]).map_err(|e| CliError::Other(e.to_string()))?,
         ];
         // Extract server domain from relay URL for BUD-11 server tag
-        if let Ok(parsed) = url::Url::parse(&self.relay_url) {
-            if let Some(host) = parsed.host_str() {
-                let domain = match parsed.port() {
-                    Some(port) => format!("{host}:{port}"),
-                    None => host.to_string(),
-                };
-                blossom_tags.push(
-                    Tag::parse(["server", &domain]).map_err(|e| CliError::Other(e.to_string()))?,
-                );
-            }
+        if let Some(domain) = relay_server_tag(&self.relay_url) {
+            blossom_tags
+                .push(Tag::parse(["server", &domain]).map_err(|e| CliError::Other(e.to_string()))?);
         }
 
         let auth_event = EventBuilder::new(Kind::from(24242), "Upload file")
@@ -407,6 +606,28 @@ impl BuzzClient {
         resp.json::<BlobDescriptor>()
             .await
             .map_err(|e| CliError::Other(format!("invalid upload response: {e}")))
+    }
+
+    /// Download a Blossom media blob using BUD-01 `t=get` auth.
+    pub async fn download_media(&self, input: &str) -> Result<bytes::Bytes, CliError> {
+        let url = media_url_from_input(&self.relay_url, input)?;
+        let auth_header = sign_blossom_get(&self.keys, &url)?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(120))
+            // Do not forward Authorization or x-auth-tag to redirect targets.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| CliError::Other(format!("http client init failed: {e}")))?;
+        let req = client.get(&url).header("Authorization", auth_header);
+
+        let resp = self.with_auth_tag(req).send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(CliError::Relay { status, body });
+        }
+
+        resp.bytes().await.map_err(CliError::Network)
     }
 
     async fn handle_response(&self, resp: reqwest::Response) -> Result<String, CliError> {

--- a/crates/buzz-cli/src/commands/upload.rs
+++ b/crates/buzz-cli/src/commands/upload.rs
@@ -13,3 +13,24 @@ pub async fn dispatch(cmd: crate::UploadCmd, client: &BuzzClient) -> Result<(), 
         }
     }
 }
+
+pub async fn dispatch_media(cmd: crate::MediaCmd, client: &BuzzClient) -> Result<(), CliError> {
+    match cmd {
+        crate::MediaCmd::Get { input, output } => {
+            let bytes = client.download_media(&input).await?;
+            match output.as_deref() {
+                Some(path) if path != "-" => {
+                    std::fs::write(path, &bytes)
+                        .map_err(|e| CliError::Other(format!("could not write {path}: {e}")))?;
+                }
+                _ => {
+                    use std::io::Write;
+                    std::io::stdout()
+                        .write_all(&bytes)
+                        .map_err(|e| CliError::Other(format!("could not write stdout: {e}")))?;
+                }
+            }
+            Ok(())
+        }
+    }
+}

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -209,6 +209,9 @@ enum Cmd {
     /// Open, update, list, and set status on git pull requests (NIP-34)
     #[command(subcommand)]
     Pr(PrCmd),
+    /// Upload and download relay Blossom media
+    #[command(subcommand)]
+    Media(MediaCmd),
     /// Upload files to the relay's Blossom store
     #[command(subcommand)]
     Upload(UploadCmd),
@@ -1392,6 +1395,18 @@ pub enum UploadCmd {
     },
 }
 
+#[derive(Subcommand)]
+pub enum MediaCmd {
+    /// Download relay media with Blossom get auth
+    Get {
+        /// Relay media URL or sha256[.ext] path segment
+        input: String,
+        /// Output path. Omit or use '-' to write raw bytes to stdout.
+        #[arg(short, long)]
+        output: Option<String>,
+    },
+}
+
 /// Subcommands for `buzz mem`.
 #[derive(Subcommand)]
 pub enum MemCmd {
@@ -1640,6 +1655,7 @@ async fn run(cli: Cli) -> Result<(), CliError> {
         Cmd::Patches(sub) => commands::patches::dispatch(sub, &client).await,
         Cmd::Issues(sub) => commands::issues::dispatch(sub, &client).await,
         Cmd::Pr(sub) => commands::pr::dispatch(sub, &client).await,
+        Cmd::Media(sub) => commands::upload::dispatch_media(sub, &client).await,
         Cmd::Upload(sub) => commands::upload::dispatch(sub, &client).await,
         Cmd::Mem(sub) => commands::mem::dispatch(sub, &client).await,
         Cmd::Moderation(sub) => commands::moderation::dispatch(sub, &client, &cli.format).await,
@@ -1668,6 +1684,7 @@ mod tests {
             "emoji",
             "feed",
             "issues",
+            "media",
             "mem",
             "messages",
             "moderation",
@@ -1801,6 +1818,7 @@ mod tests {
             names(&cmd, "issues"),
             vec!["create", "get", "list", "status"]
         );
+        assert_eq!(names(&cmd, "media"), vec!["get"]);
         assert_eq!(names(&cmd, "upload"), vec!["file"]);
         assert_eq!(names(&cmd, "pack"), vec!["inspect", "validate"]);
         assert_eq!(
@@ -1828,6 +1846,7 @@ mod tests {
             ("emoji", 5),
             ("feed", 1),
             ("issues", 4),
+            ("media", 1),
             ("messages", 8),
             ("pack", 2),
             ("patches", 4),

--- a/crates/buzz-dev-mcp/Cargo.toml
+++ b/crates/buzz-dev-mcp/Cargo.toml
@@ -38,6 +38,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 reqwest = { workspace = true }
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
+buzz-core = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", default-features = false, features = ["signal", "process"] }

--- a/crates/buzz-dev-mcp/src/view_image.rs
+++ b/crates/buzz-dev-mcp/src/view_image.rs
@@ -48,6 +48,9 @@ pub(crate) const MAX_PIXELS: u64 = 64 * 1024 * 1024;
 pub(crate) const MAX_DECODER_ALLOC: u64 = 256 * 1024 * 1024;
 /// Connect + read timeout for URL fetches.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+/// Lifetime of a Blossom `t=get` read token for relay media fetches.
+/// Matches the desktop client's `MEDIA_GET_AUTH_EXPIRY_SECS`.
+const MEDIA_GET_AUTH_EXPIRY_SECS: u64 = 600;
 
 /// Build the decoder allocation cap. Centralised so the resize path uses the
 /// same value tests can reason about.
@@ -221,23 +224,140 @@ fn decode_data_url(src: &str) -> Result<Vec<u8>, String> {
         .map_err(|e| format!("data: URL base64 decode failed: {e}"))
 }
 
+/// True when `target` is a relay-hosted Blossom media URL: an http(s) URL
+/// whose path is under `/media/` and whose authority (host + effective port)
+/// matches the configured relay URL. The relay URL may use ws/wss schemes —
+/// the url crate's known default ports (ws=80/wss=443) make those compare
+/// equal to their http/https counterparts.
+///
+/// Safety contract: this is the *only* gate that decides whether we attach a
+/// signed auth header. It must never match arbitrary third-party origins,
+/// where the bearer token would leak.
+fn is_relay_media_url(target: &reqwest::Url, relay: &reqwest::Url) -> bool {
+    if !matches!(target.scheme(), "http" | "https") {
+        return false;
+    }
+    if !target.path().starts_with("/media/") {
+        return false;
+    }
+    target.host_str().is_some()
+        && target.host_str() == relay.host_str()
+        && target.port_or_known_default() == relay.port_or_known_default()
+}
+
+/// Sign a Blossom (BUD-01) `t=get` authorization event, server-scoped to
+/// `authority` (`host[:port]`), and return the full `Authorization` header
+/// value. Mirrors the desktop client's signer: kind 24242, `t=get`,
+/// `expiration`, `server` tag — no `x` tag (BUD-01 allows x OR server).
+fn sign_media_get_auth(keys: &nostr::Keys, authority: &str) -> Result<String, String> {
+    use nostr::{EventBuilder, JsonUtil, Kind, Tag, Timestamp};
+    let now = Timestamp::now().as_secs();
+    let tags = vec![
+        Tag::parse(["t", "get"]).map_err(|e| e.to_string())?,
+        Tag::parse([
+            "expiration",
+            &(now + MEDIA_GET_AUTH_EXPIRY_SECS).to_string(),
+        ])
+        .map_err(|e| e.to_string())?,
+        Tag::parse(["server", authority]).map_err(|e| e.to_string())?,
+    ];
+    let event = EventBuilder::new(Kind::from(24242), "Get buzz-media")
+        .tags(tags)
+        .sign_with_keys(keys)
+        .map_err(|e| e.to_string())?;
+    Ok(format!(
+        "Nostr {}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(event.as_json().as_bytes())
+    ))
+}
+
+/// `host[:port]` for the `server` tag, normalized the same way relay tenant
+/// lookup normalizes Host/RELAY_URL. Explicit non-default ports and IPv6
+/// brackets are preserved; default ports collapse to the bare host.
+fn server_authority(url: &reqwest::Url) -> Option<String> {
+    let authority = buzz_core::tenant::relay_url_authority(url.as_str());
+    if authority.is_empty() {
+        None
+    } else {
+        Some(authority)
+    }
+}
+
+/// Mint a `t=get` Authorization header for `url` when it is relay-hosted
+/// media and `BUZZ_PRIVATE_KEY` is available; `None` otherwise.
+///
+/// Fail-open by design: while the relay's media-read-auth flag is off, an
+/// unauthenticated request still succeeds, so a missing/invalid key degrades
+/// to an unsigned fetch instead of an error. Once the flag is on, the fetch
+/// 403s and the error path below names the missing key.
+fn relay_media_get_auth(url: &reqwest::Url) -> Option<String> {
+    let relay = std::env::var("BUZZ_RELAY_URL").ok()?;
+    let relay = reqwest::Url::parse(&relay).ok()?;
+    if !is_relay_media_url(url, &relay) {
+        return None;
+    }
+    let key = std::env::var("BUZZ_PRIVATE_KEY").ok()?;
+    let keys = match nostr::Keys::parse(&key) {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::warn!("BUZZ_PRIVATE_KEY invalid; fetching relay media unauthenticated: {e}");
+            return None;
+        }
+    };
+    let authority = server_authority(url)?;
+    match sign_media_get_auth(&keys, &authority) {
+        Ok(header) => Some(header),
+        Err(e) => {
+            tracing::warn!("media get auth signing failed; fetching unauthenticated: {e}");
+            None
+        }
+    }
+}
+
 /// Fetch an http(s) URL with a streaming read and a hard byte cap.
 /// Refuses up-front if `Content-Length` advertises more than the cap.
+/// Relay-hosted `/media/` URLs get a signed Blossom `t=get` header when
+/// `BUZZ_RELAY_URL` + `BUZZ_PRIVATE_KEY` are configured.
 async fn fetch_url(url: &str) -> Result<Vec<u8>, ErrorData> {
-    let client = reqwest::Client::builder()
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| invalid_params(format!("invalid URL: {url} ({e})")))?;
+    let auth = relay_media_get_auth(&parsed);
+    let mut client_builder = reqwest::Client::builder()
         .connect_timeout(FETCH_TIMEOUT)
-        .timeout(FETCH_TIMEOUT)
+        .timeout(FETCH_TIMEOUT);
+    if auth.is_some() {
+        // Do not forward Buzz auth headers to a redirect target. reqwest strips
+        // Authorization cross-host, but `x-auth-tag` is not on reqwest's
+        // sensitive-header list.
+        client_builder = client_builder.redirect(reqwest::redirect::Policy::none());
+    }
+    let client = client_builder
         .build()
         .map_err(|e| ErrorData::internal_error(format!("http client init failed: {e}"), None))?;
-    let resp = client
-        .get(url)
+    let mut req = client.get(parsed);
+    let authed = auth.is_some();
+    if let Some(header) = auth {
+        req = req.header("Authorization", header);
+        if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
+            if !auth_tag.trim().is_empty() {
+                req = req.header("x-auth-tag", auth_tag);
+            }
+        }
+    }
+    let resp = req
         .send()
         .await
         .map_err(|e| ErrorData::internal_error(format!("fetch failed: {url} ({e})"), None))?;
     if !resp.status().is_success() {
+        let status = resp.status();
+        if matches!(status.as_u16(), 401 | 403) && !authed {
+            return Err(invalid_params(format!(
+                "fetch {url} returned HTTP {status} — this relay requires authenticated media \
+                 reads; set BUZZ_PRIVATE_KEY (and BUZZ_RELAY_URL) to a member identity"
+            )));
+        }
         return Err(invalid_params(format!(
-            "fetch {url} returned HTTP {}",
-            resp.status()
+            "fetch {url} returned HTTP {status}"
         )));
     }
     if let Some(len) = resp.content_length() {
@@ -933,5 +1053,84 @@ mod tests {
         webp.extend_from_slice(b"VP8 ");
         assert_eq!(sniff_mime(&webp).unwrap(), "image/webp");
         sniff_mime(b"not-an-image").unwrap_err();
+    }
+
+    fn u(s: &str) -> reqwest::Url {
+        reqwest::Url::parse(s).unwrap()
+    }
+
+    #[test]
+    fn relay_media_url_matches_relay_host_only() {
+        let relay = u("http://relay.example.com:3000");
+        // Exact authority + /media/ path → match.
+        assert!(is_relay_media_url(
+            &u("http://relay.example.com:3000/media/abc.png"),
+            &relay
+        ));
+        // Different host / port / path → no match (token must not leak).
+        assert!(!is_relay_media_url(
+            &u("http://evil.example.com:3000/media/abc.png"),
+            &relay
+        ));
+        assert!(!is_relay_media_url(
+            &u("http://relay.example.com:4000/media/abc.png"),
+            &relay
+        ));
+        assert!(!is_relay_media_url(
+            &u("http://relay.example.com:3000/other/abc.png"),
+            &relay
+        ));
+        // Path prefix must be a real segment boundary under /media/.
+        assert!(!is_relay_media_url(
+            &u("http://relay.example.com:3000/mediafake/abc.png"),
+            &relay
+        ));
+    }
+
+    #[test]
+    fn relay_media_url_ws_scheme_and_default_ports() {
+        // wss relay ↔ https media on default ports compare equal.
+        assert!(is_relay_media_url(
+            &u("https://relay.example.com/media/abc.png"),
+            &u("wss://relay.example.com")
+        ));
+        assert!(is_relay_media_url(
+            &u("http://localhost:3000/media/abc.png"),
+            &u("ws://localhost:3000")
+        ));
+        // http media against a wss (443) relay must NOT match.
+        assert!(!is_relay_media_url(
+            &u("http://relay.example.com/media/abc.png"),
+            &u("wss://relay.example.com")
+        ));
+    }
+
+    #[test]
+    fn media_get_auth_header_shape() {
+        use nostr::JsonUtil;
+        let keys = nostr::Keys::generate();
+        let header = sign_media_get_auth(&keys, "localhost:3000").unwrap();
+        let b64 = header.strip_prefix("Nostr ").expect("Nostr scheme prefix");
+        let json = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(b64)
+            .unwrap();
+        let event = nostr::Event::from_json(std::str::from_utf8(&json).unwrap()).unwrap();
+
+        assert_eq!(event.kind, nostr::Kind::from(24242));
+        event.verify().expect("valid signature");
+
+        let tag = |name: &str| -> Option<String> {
+            event.tags.iter().find_map(|t| {
+                let v = t.as_slice();
+                (v.first().map(String::as_str) == Some(name)).then(|| v[1].clone())
+            })
+        };
+        assert_eq!(tag("t").as_deref(), Some("get"));
+        assert_eq!(tag("server").as_deref(), Some("localhost:3000"));
+        // Server-scoped token: no x tag (BUD-01 allows x OR server).
+        assert!(tag("x").is_none());
+        let expiration: u64 = tag("expiration").unwrap().parse().unwrap();
+        let now = nostr::Timestamp::now().as_secs();
+        assert!(expiration > now && expiration <= now + MEDIA_GET_AUTH_EXPIRY_SECS);
     }
 }

--- a/crates/buzz-media/src/auth.rs
+++ b/crates/buzz-media/src/auth.rs
@@ -2,18 +2,35 @@
 
 use crate::error::MediaError;
 
-/// Verify kind:24242 event validity per BUD-11:
+/// Blossom kind:24242 verbs Buzz currently accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlossomVerb {
+    Upload,
+    Get,
+}
+
+impl BlossomVerb {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Upload => "upload",
+            Self::Get => "get",
+        }
+    }
+}
+
+/// Verify common kind:24242 Blossom auth event validity:
 ///   1. Schnorr signature
 ///   2. kind == 24242
-///   3. `t` tag == "upload"
+///   3. `t` tag matches `verb`
 ///   4. `expiration` tag in the future
 ///   5. `created_at` in the past (with 5s clock-skew tolerance)
 ///   6. If `server` tags present, our domain must appear in at least one
 ///
-/// Does NOT check the `x` tag — that requires the body hash, computed later.
-/// Call this BEFORE trusting the event's pubkey for scope resolution.
-pub fn verify_blossom_auth_event(
+/// Does NOT check verb-specific scope tags (`x` for upload, `x` OR `server`
+/// for get). Call this BEFORE trusting the event's pubkey for scope resolution.
+pub fn verify_blossom_auth_event_for_verb(
     auth_event: &nostr::Event,
+    verb: BlossomVerb,
     server_domain: Option<&str>,
     max_age_secs: u64,
 ) -> Result<(), MediaError> {
@@ -42,7 +59,7 @@ pub fn verify_blossom_auth_event(
         match kind.as_str() {
             "t" => {
                 if let Some(v) = tag.content() {
-                    if v != "upload" {
+                    if v != verb.as_str() {
                         return Err(MediaError::InvalidAuthVerb);
                     }
                     found_t = true;
@@ -123,6 +140,18 @@ pub fn verify_blossom_auth_event(
     Ok(())
 }
 
+/// Verify common upload auth event validity.
+///
+/// Kept as the upload-shaped public wrapper for existing callers; new verb-aware
+/// code should prefer [`verify_blossom_auth_event_for_verb`].
+pub fn verify_blossom_auth_event(
+    auth_event: &nostr::Event,
+    server_domain: Option<&str>,
+    max_age_secs: u64,
+) -> Result<(), MediaError> {
+    verify_blossom_auth_event_for_verb(auth_event, BlossomVerb::Upload, server_domain, max_age_secs)
+}
+
 /// Normalize a Blossom `server` tag value (or a bound tenant host) into the
 /// canonical host form used as the community lookup key.
 ///
@@ -149,7 +178,12 @@ pub fn verify_blossom_upload_auth(
     server_domain: Option<&str>,
     max_age_secs: u64,
 ) -> Result<(), MediaError> {
-    verify_blossom_auth_event(auth_event, server_domain, max_age_secs)?;
+    verify_blossom_auth_event_for_verb(
+        auth_event,
+        BlossomVerb::Upload,
+        server_domain,
+        max_age_secs,
+    )?;
 
     // At least one x tag must match the body sha256 (BUD-11 §6)
     let has_matching_x = auth_event
@@ -159,6 +193,46 @@ pub fn verify_blossom_upload_auth(
 
     if !has_matching_x {
         return Err(MediaError::HashMismatch);
+    }
+
+    Ok(())
+}
+
+/// Verify a kind:24242 Blossom get auth event for one requested blob.
+///
+/// BUD-01 permits either blob-scoped authorization (`x` tag matches `sha256`)
+/// or server-scoped authorization (`server` tag matches this relay host). The
+/// latter intentionally grants reads for all blobs on the host until expiration;
+/// callers must still apply relay membership after this verifier returns.
+pub fn verify_blossom_get_auth(
+    auth_event: &nostr::Event,
+    sha256: &str,
+    server_domain: Option<&str>,
+    max_age_secs: u64,
+) -> Result<(), MediaError> {
+    verify_blossom_auth_event_for_verb(auth_event, BlossomVerb::Get, server_domain, max_age_secs)?;
+
+    let has_matching_x = auth_event
+        .tags
+        .iter()
+        .any(|tag| tag.kind().to_string() == "x" && (tag.content() == Some(sha256)));
+
+    let has_matching_server = match server_domain {
+        Some(domain) => {
+            let want = normalize_server_host(domain);
+            auth_event.tags.iter().any(|tag| {
+                tag.kind().to_string() == "server"
+                    && tag
+                        .content()
+                        .map(|value| normalize_server_host(value) == want)
+                        .unwrap_or(false)
+            })
+        }
+        None => false,
+    };
+
+    if !has_matching_x && !has_matching_server {
+        return Err(MediaError::InsufficientScope);
     }
 
     Ok(())
@@ -197,6 +271,104 @@ mod tests {
         let sha256 = "a".repeat(64);
         let event = build_valid_auth(&keys, &sha256);
         assert!(verify_blossom_auth_event(&event, None, 600).is_ok());
+    }
+
+    fn build_get_auth(keys: &Keys, tags: Vec<Tag>) -> nostr::Event {
+        EventBuilder::new(Kind::from(24242), "Get buzz-media")
+            .tags(tags)
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_verify_get_accepts_matching_x_without_server_tag() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 300).to_string();
+        let event = build_get_auth(
+            &keys,
+            vec![
+                Tag::parse(["t", "get"]).unwrap(),
+                Tag::parse(["x", &sha256]).unwrap(),
+                Tag::parse(["expiration", &exp_str]).unwrap(),
+            ],
+        );
+
+        assert!(verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600).is_ok());
+    }
+
+    #[test]
+    fn test_verify_get_accepts_matching_server_without_x_tag() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 300).to_string();
+        let event = build_get_auth(
+            &keys,
+            vec![
+                Tag::parse(["t", "get"]).unwrap(),
+                Tag::parse(["server", "https://Relay.Example./media/ignored"]).unwrap(),
+                Tag::parse(["expiration", &exp_str]).unwrap(),
+            ],
+        );
+
+        assert!(verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600).is_ok());
+    }
+
+    #[test]
+    fn test_verify_get_rejects_upload_verb() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let event = build_valid_auth(&keys, &sha256);
+
+        assert!(matches!(
+            verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600),
+            Err(MediaError::InvalidAuthVerb)
+        ));
+    }
+
+    #[test]
+    fn test_verify_get_requires_x_or_server_scope() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let other_hash = "b".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 300).to_string();
+        let event = build_get_auth(
+            &keys,
+            vec![
+                Tag::parse(["t", "get"]).unwrap(),
+                Tag::parse(["x", &other_hash]).unwrap(),
+                Tag::parse(["expiration", &exp_str]).unwrap(),
+            ],
+        );
+
+        assert!(matches!(
+            verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600),
+            Err(MediaError::InsufficientScope)
+        ));
+    }
+
+    #[test]
+    fn test_verify_get_rejects_wrong_server_scope() {
+        let keys = Keys::generate();
+        let sha256 = "a".repeat(64);
+        let now = Timestamp::now().as_secs();
+        let exp_str = (now + 300).to_string();
+        let event = build_get_auth(
+            &keys,
+            vec![
+                Tag::parse(["t", "get"]).unwrap(),
+                Tag::parse(["server", "other.example"]).unwrap(),
+                Tag::parse(["expiration", &exp_str]).unwrap(),
+            ],
+        );
+
+        assert!(matches!(
+            verify_blossom_get_auth(&event, &sha256, Some("relay.example"), 600),
+            Err(MediaError::ServerMismatch)
+        ));
     }
 
     #[test]

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -38,6 +38,10 @@ pub(crate) struct AuthenticatedUpload {
     _upload_permit: UploadPermit,
 }
 
+struct MediaReadAuth {
+    tenant: TenantContext,
+}
+
 const MEDIA_UPLOAD_RATE_WINDOW: Duration = Duration::from_secs(60);
 
 struct UploadPermit {
@@ -431,6 +435,42 @@ async fn bind_media_read_tenant(
         .map_err(|_| MediaError::NotFound)
 }
 
+async fn authenticate_media_read(
+    state: &AppState,
+    headers: &HeaderMap,
+    sha256_ext: &str,
+) -> Result<MediaReadAuth, MediaError> {
+    let tenant = bind_media_read_tenant(state, headers).await?;
+
+    if !state.config.require_media_get_auth {
+        return Ok(MediaReadAuth { tenant });
+    }
+
+    let auth_event = extract_blossom_auth(headers)?;
+    let sha256 = sha256_ext.split('.').next().unwrap_or(sha256_ext);
+    buzz_media::auth::verify_blossom_get_auth(&auth_event, sha256, Some(tenant.host()), 3600)?;
+
+    let auth_tag = headers.get("x-auth-tag").and_then(|v| v.to_str().ok());
+    crate::api::relay_members::enforce_relay_membership(
+        state,
+        tenant.community(),
+        auth_event.pubkey.as_bytes(),
+        auth_tag,
+    )
+    .await
+    .map_err(|_| MediaError::RelayMembershipRequired)?;
+
+    Ok(MediaReadAuth { tenant })
+}
+
+fn blob_cache_control(require_auth: bool) -> &'static str {
+    if require_auth {
+        "private, max-age=31536000, immutable"
+    } else {
+        "public, max-age=31536000, immutable"
+    }
+}
+
 /// Whether a path-segment extension is a safe token.
 ///
 /// The sidecar's `ext` field is the *authoritative* extension — the serve and
@@ -516,7 +556,10 @@ pub async fn get_blob(
     req_headers: HeaderMap,
 ) -> Result<Response, MediaError> {
     validate_media_path(&sha256_ext)?;
-    let tenant = bind_media_read_tenant(&state, &req_headers).await?;
+    let require_media_get_auth = state.config.require_media_get_auth;
+    let media_auth = authenticate_media_read(&state, &req_headers, &sha256_ext).await?;
+    let tenant = media_auth.tenant;
+    let cache_control = blob_cache_control(require_media_get_auth);
 
     // Sidecar gate FIRST — reject before any blob I/O. Storage is not authoritative.
     let content_type = if sha256_ext.ends_with(".thumb.jpg") {
@@ -587,7 +630,7 @@ pub async fn get_blob(
                 .header(header::CONTENT_TYPE, &content_type)
                 .header(header::CONTENT_LENGTH, total.to_string())
                 .header(header::CONTENT_DISPOSITION, disposition)
-                .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
+                .header(header::CACHE_CONTROL, cache_control)
                 .header(header::CONTENT_SECURITY_POLICY, "default-src 'none'")
                 .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
                 .header(header::ACCEPT_RANGES, "bytes")
@@ -633,7 +676,7 @@ pub async fn get_blob(
                         .header(header::CONTENT_LENGTH, chunk.len().to_string())
                         .header(header::CONTENT_DISPOSITION, disposition)
                         .header(header::ACCEPT_RANGES, "bytes")
-                        .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
+                        .header(header::CACHE_CONTROL, cache_control)
                         .header(header::CONTENT_SECURITY_POLICY, "default-src 'none'")
                         .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
                         .body(axum::body::Body::from(chunk))
@@ -699,7 +742,10 @@ pub async fn head_blob(
     Path(sha256_ext): Path<String>,
 ) -> Result<Response, MediaError> {
     validate_media_path(&sha256_ext)?;
-    let tenant = bind_media_read_tenant(&state, &headers).await?;
+    let require_media_get_auth = state.config.require_media_get_auth;
+    let media_auth = authenticate_media_read(&state, &headers, &sha256_ext).await?;
+    let tenant = media_auth.tenant;
+    let cache_control = blob_cache_control(require_media_get_auth);
 
     // Sidecar gate FIRST — reject before any blob I/O.
     let content_type = if sha256_ext.ends_with(".thumb.jpg") {
@@ -740,7 +786,7 @@ pub async fn head_blob(
                     ("content-type", content_type.as_str()),
                     ("content-length", size_str.as_str()),
                     ("accept-ranges", "bytes"),
-                    ("cache-control", "public, max-age=31536000, immutable"),
+                    ("cache-control", cache_control),
                 ],
             )
                 .into_response())
@@ -807,13 +853,24 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+    };
+    use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag, Timestamp};
+    use tower::ServiceExt;
     use uuid::Uuid;
 
     const VALID_HASH: &str = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
 
     async fn test_state() -> Arc<AppState> {
+        test_state_with_media_get_auth(false).await
+    }
+
+    async fn test_state_with_media_get_auth(require_media_get_auth: bool) -> Arc<AppState> {
         let mut config = crate::config::Config::from_env().expect("default config loads");
         config.require_relay_membership = false;
+        config.require_media_get_auth = require_media_get_auth;
         config.redis_url = "redis://127.0.0.1:1".to_string();
         config.media_uploads_per_minute = 1;
         config.media_max_concurrent_uploads = 2;
@@ -821,6 +878,9 @@ mod tests {
 
         let pool = sqlx::PgPool::connect_lazy(&config.database_url).expect("lazy pg pool");
         let db = buzz_db::Db::from_pool(pool.clone());
+        db.ensure_configured_community("relay.example")
+            .await
+            .expect("seed relay.example community for host-bound media tests");
         let redis_pool = deadpool_redis::Config::from_url(&config.redis_url)
             .create_pool(Some(deadpool_redis::Runtime::Tokio1))
             .expect("redis pool");
@@ -850,6 +910,148 @@ mod tests {
             media_storage,
         );
         Arc::new(state)
+    }
+
+    async fn media_get_auth_router(require_media_get_auth: bool) -> axum::Router {
+        let state = test_state_with_media_get_auth(require_media_get_auth).await;
+        axum::Router::new()
+            .route(
+                "/media/{sha256_ext}",
+                axum::routing::get(get_blob).head(head_blob),
+            )
+            .with_state(state)
+    }
+
+    fn media_get_auth_header(keys: &Keys, tags: Vec<Tag>) -> String {
+        let event = EventBuilder::new(Kind::from(24242), "Get media")
+            .tags(tags)
+            .sign_with_keys(keys)
+            .expect("sign get auth");
+        format!(
+            "Nostr {}",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(event.as_json().as_bytes())
+        )
+    }
+
+    fn media_get_tags_for(host: &str, sha256: Option<&str>) -> Vec<Tag> {
+        let now = Timestamp::now().as_secs();
+        let expiration = (now + 300).to_string();
+        let mut tags = vec![
+            Tag::parse(["t", "get"]).expect("t tag"),
+            Tag::parse(["expiration", &expiration]).expect("expiration tag"),
+            Tag::parse(["server", host]).expect("server tag"),
+        ];
+        if let Some(sha256) = sha256 {
+            tags.push(Tag::parse(["x", sha256]).expect("x tag"));
+        }
+        tags
+    }
+
+    fn media_request(method: &str, auth: Option<String>) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(format!("/media/{VALID_HASH}.jpg"))
+            .header(header::HOST, "relay.example");
+        if let Some(auth) = auth {
+            builder = builder.header(header::AUTHORIZATION, auth);
+        }
+        builder.body(Body::empty()).expect("request")
+    }
+
+    #[tokio::test]
+    async fn media_get_auth_flag_off_allows_unauthenticated_read_until_sidecar_gate() {
+        let response = media_get_auth_router(false)
+            .await
+            .oneshot(media_request("GET", None))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn media_get_auth_flag_on_rejects_unauthenticated_get_and_head_before_sidecar_gate() {
+        for method in ["GET", "HEAD"] {
+            let response = media_get_auth_router(true)
+                .await
+                .oneshot(media_request(method, None))
+                .await
+                .expect("response");
+
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{method}");
+        }
+    }
+
+    #[tokio::test]
+    async fn media_get_auth_flag_on_valid_server_scoped_token_reaches_sidecar_gate() {
+        let keys = Keys::generate();
+        let auth = media_get_auth_header(&keys, media_get_tags_for("relay.example", None));
+        let response = media_get_auth_router(true)
+            .await
+            .oneshot(media_request("GET", Some(auth)))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn media_get_auth_flag_on_rejects_upload_verb_wrong_server_and_wrong_x() {
+        let keys = Keys::generate();
+        let now = Timestamp::now().as_secs();
+        let expiration = (now + 300).to_string();
+        let cases = [
+            vec![
+                Tag::parse(["t", "upload"]).expect("t tag"),
+                Tag::parse(["expiration", &expiration]).expect("expiration tag"),
+                Tag::parse(["server", "relay.example"]).expect("server tag"),
+            ],
+            vec![
+                Tag::parse(["t", "get"]).expect("t tag"),
+                Tag::parse(["expiration", &expiration]).expect("expiration tag"),
+                Tag::parse(["server", "evil.example"]).expect("server tag"),
+            ],
+            vec![
+                Tag::parse(["t", "get"]).expect("t tag"),
+                Tag::parse(["expiration", &expiration]).expect("expiration tag"),
+                Tag::parse(["x", &"f".repeat(64)]).expect("x tag"),
+            ],
+        ];
+
+        for tags in cases {
+            let auth = media_get_auth_header(&keys, tags);
+            let response = media_get_auth_router(true)
+                .await
+                .oneshot(media_request("GET", Some(auth)))
+                .await
+                .expect("response");
+
+            assert_ne!(response.status(), StatusCode::NOT_FOUND);
+            assert!(
+                response.status() == StatusCode::UNAUTHORIZED
+                    || response.status() == StatusCode::FORBIDDEN,
+                "unexpected status {}",
+                response.status()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn media_get_auth_flag_on_accepts_range_header_only_after_auth() {
+        let keys = Keys::generate();
+        let auth = media_get_auth_header(&keys, media_get_tags_for("relay.example", None));
+        let mut request = media_request("GET", Some(auth));
+        request
+            .headers_mut()
+            .insert(header::RANGE, "bytes=0-0".parse().expect("range header"));
+
+        let response = media_get_auth_router(true)
+            .await
+            .oneshot(request)
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -540,7 +540,6 @@ impl Config {
             .unwrap_or(30);
 
         let require_media_get_auth = std::env::var("BUZZ_REQUIRE_MEDIA_GET_AUTH")
-            .or_else(|_| std::env::var("BUZZ_REQUIRE_MEDIA_READ_AUTH"))
             .map(|v| {
                 v == "true"
                     || v == "1"
@@ -746,27 +745,6 @@ mod tests {
             config.huddle_audio_available,
             "huddle_audio_available should default to true so single-pod (N=1) keeps today's huddle behavior"
         );
-    }
-
-    #[test]
-    fn media_get_auth_accepts_read_auth_legacy_alias() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        let previous_get = std::env::var_os("BUZZ_REQUIRE_MEDIA_GET_AUTH");
-        let previous_read = std::env::var_os("BUZZ_REQUIRE_MEDIA_READ_AUTH");
-        std::env::remove_var("BUZZ_REQUIRE_MEDIA_GET_AUTH");
-        std::env::set_var("BUZZ_REQUIRE_MEDIA_READ_AUTH", "on");
-
-        let config = Config::from_env().expect("config");
-        assert!(config.require_media_get_auth);
-
-        match previous_get {
-            Some(value) => std::env::set_var("BUZZ_REQUIRE_MEDIA_GET_AUTH", value),
-            None => std::env::remove_var("BUZZ_REQUIRE_MEDIA_GET_AUTH"),
-        }
-        match previous_read {
-            Some(value) => std::env::set_var("BUZZ_REQUIRE_MEDIA_READ_AUTH", value),
-            None => std::env::remove_var("BUZZ_REQUIRE_MEDIA_READ_AUTH"),
-        }
     }
 
     #[test]

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -160,6 +160,10 @@ pub struct Config {
     /// Maximum media upload starts accepted from one pubkey per minute.
     pub media_uploads_per_minute: u32,
 
+    /// Require Blossom kind:24242 `t=get` auth plus relay membership before
+    /// serving media GET/HEAD. Default off for staged client rollout.
+    pub require_media_get_auth: bool,
+
     /// Optional override for ephemeral channel TTL (in seconds).
     /// When set, any channel created with a TTL tag will use this value instead
     /// of the client-provided one. Useful for testing ephemeral expiry quickly.
@@ -535,6 +539,16 @@ impl Config {
             .filter(|&v| v > 0)
             .unwrap_or(30);
 
+        let require_media_get_auth = std::env::var("BUZZ_REQUIRE_MEDIA_GET_AUTH")
+            .or_else(|_| std::env::var("BUZZ_REQUIRE_MEDIA_READ_AUTH"))
+            .map(|v| {
+                v == "true"
+                    || v == "1"
+                    || v.eq_ignore_ascii_case("yes")
+                    || v.eq_ignore_ascii_case("on")
+            })
+            .unwrap_or(false);
+
         let ephemeral_ttl_override = std::env::var("BUZZ_EPHEMERAL_TTL_OVERRIDE")
             .ok()
             .and_then(|v| v.parse::<i32>().ok())
@@ -663,6 +677,7 @@ impl Config {
             media_max_concurrent_uploads,
             media_max_concurrent_uploads_per_pubkey,
             media_uploads_per_minute,
+            require_media_get_auth,
             ephemeral_ttl_override,
             git_repo_path,
             git_max_pack_bytes,
@@ -724,9 +739,34 @@ mod tests {
             "serve_git_web_gui should default to false"
         );
         assert!(
+            !config.require_media_get_auth,
+            "require_media_get_auth should default to false for staged client rollout"
+        );
+        assert!(
             config.huddle_audio_available,
             "huddle_audio_available should default to true so single-pod (N=1) keeps today's huddle behavior"
         );
+    }
+
+    #[test]
+    fn media_get_auth_accepts_read_auth_legacy_alias() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let previous_get = std::env::var_os("BUZZ_REQUIRE_MEDIA_GET_AUTH");
+        let previous_read = std::env::var_os("BUZZ_REQUIRE_MEDIA_READ_AUTH");
+        std::env::remove_var("BUZZ_REQUIRE_MEDIA_GET_AUTH");
+        std::env::set_var("BUZZ_REQUIRE_MEDIA_READ_AUTH", "on");
+
+        let config = Config::from_env().expect("config");
+        assert!(config.require_media_get_auth);
+
+        match previous_get {
+            Some(value) => std::env::set_var("BUZZ_REQUIRE_MEDIA_GET_AUTH", value),
+            None => std::env::remove_var("BUZZ_REQUIRE_MEDIA_GET_AUTH"),
+        }
+        match previous_read {
+            Some(value) => std::env::set_var("BUZZ_REQUIRE_MEDIA_READ_AUTH", value),
+            None => std::env::remove_var("BUZZ_REQUIRE_MEDIA_READ_AUTH"),
+        }
     }
 
     #[test]

--- a/deploy/charts/buzz/templates/NOTES.txt
+++ b/deploy/charts/buzz/templates/NOTES.txt
@@ -62,6 +62,10 @@
 {{- if not .Values.relay.requireRelayMembership }}
   ⚠ relay.requireRelayMembership=false — relay is OPEN. Anyone can publish.
 {{- end }}
+{{- if not .Values.relay.requireMediaGetAuth }}
+  ⚠ relay.requireMediaGetAuth=false — media GET/HEAD reads are not auth-gated.
+    Keep this false only during staged client rollout.
+{{- end }}
 {{- if not .Values.migrate.autoMigrate }}
   ⚠ migrate.autoMigrate=false — relay startup will NOT run sqlx migrations.
     You must run `buzz-admin migrate` against the database before every

--- a/deploy/charts/buzz/templates/deployment.yaml
+++ b/deploy/charts/buzz/templates/deployment.yaml
@@ -115,6 +115,7 @@ spec:
             - { name: BUZZ_SEND_BUFFER,            value: {{ .Values.relay.sendBuffer | quote }} }
             - { name: BUZZ_REQUIRE_AUTH_TOKEN,     value: {{ .Values.relay.requireAuthToken | quote }} }
             - { name: BUZZ_REQUIRE_RELAY_MEMBERSHIP, value: {{ .Values.relay.requireRelayMembership | quote }} }
+            - { name: BUZZ_REQUIRE_MEDIA_GET_AUTH, value: {{ .Values.relay.requireMediaGetAuth | quote }} }
             - { name: BUZZ_ALLOW_NIP_OA_AUTH,      value: {{ .Values.relay.allowNipOaAuth | quote }} }
             - { name: BUZZ_PUBKEY_ALLOWLIST,       value: {{ .Values.relay.pubkeyAllowlist | quote }} }
             {{- if .Values.relay.corsOrigins }}

--- a/deploy/charts/buzz/values.schema.json
+++ b/deploy/charts/buzz/values.schema.json
@@ -61,6 +61,7 @@
         "sendBuffer": { "type": "integer", "minimum": 1 },
         "requireAuthToken": { "type": "boolean" },
         "requireRelayMembership": { "type": "boolean" },
+        "requireMediaGetAuth": { "type": "boolean" },
         "allowNipOaAuth": { "type": "boolean" },
         "huddleAudioAvailable": {
           "type": ["boolean", "null"],

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -75,6 +75,10 @@ relay:
   sendBuffer: 1000
   requireAuthToken: true
   requireRelayMembership: true
+  # Staged rollout gate for authenticated media reads. When true, relay
+  # GET/HEAD /media/* requires Blossom kind 24242 t=get plus relay membership.
+  # Keep false until deployed desktop/mobile/CLI clients attach read auth.
+  requireMediaGetAuth: false
   allowNipOaAuth: true
   pubkeyAllowlist: false
   corsOrigins: []

--- a/desktop/src-tauri/src/commands/media.rs
+++ b/desktop/src-tauri/src/commands/media.rs
@@ -163,6 +163,73 @@ pub(crate) fn detect_and_validate_mime(body: &[u8]) -> Result<String, String> {
     Ok(mime)
 }
 
+/// Lifetime of a Blossom `t=get` read token. Ten minutes keeps a token alive
+/// across a video's range-request stream while staying well inside the
+/// server's `created_at` freshness window (3600s, matching upload).
+pub(crate) const MEDIA_GET_AUTH_EXPIRY_SECS: u64 = 600;
+
+/// Sign a Blossom (BUD-01) `t=get` authorization event, server-scoped to the
+/// relay's authority, and return the full `Authorization` header value.
+///
+/// Server-scoped (a `server` tag, no `x` tag): one token authorizes reads of
+/// any blob on that host for its lifetime, which keeps avatar-grid bursts and
+/// video range requests cheap. This is deliberately broader than per-blob
+/// scoping and is safe only because the relay still enforces NIP-43
+/// membership on the verified pubkey — and because callers only attach this
+/// header to requests bound for the relay origin itself.
+pub(crate) fn sign_blossom_get_auth_header(
+    keys: &Keys,
+    base_url: &str,
+    expiry_secs: u64,
+) -> Result<String, String> {
+    let server = extract_server_authority(base_url)
+        .ok_or_else(|| "cannot derive server authority from relay URL".to_string())?;
+    let now = Timestamp::now().as_secs();
+    let tags = vec![
+        Tag::parse(vec!["t", "get"]).map_err(|e| e.to_string())?,
+        Tag::parse(vec!["expiration", &(now + expiry_secs).to_string()])
+            .map_err(|e| e.to_string())?,
+        Tag::parse(vec!["server".to_string(), server]).map_err(|e| e.to_string())?,
+    ];
+    let event = EventBuilder::new(Kind::from(24242), "Get buzz-media")
+        .tags(tags)
+        .sign_with_keys(keys)
+        .map_err(|e| e.to_string())?;
+    Ok(format!(
+        "Nostr {}",
+        URL_SAFE_NO_PAD.encode(event.as_json().as_bytes())
+    ))
+}
+
+/// Mint a `t=get` Authorization header value for a relay media fetch, or
+/// `None` when signing is unavailable (identity in recovery mode).
+///
+/// Fail-open by design: while the relay's `BUZZ_REQUIRE_MEDIA_GET_AUTH` flag
+/// is off, an unauthenticated request still succeeds, so degrading to no
+/// header (instead of erroring) keeps media rendering during key recovery.
+/// Once the flag is on, these requests will 403 — the correct outcome for an
+/// identity that can't prove membership.
+///
+/// Safety contract: callers must only attach the returned header to URLs
+/// constructed from (or validated against) the app's own relay base URL —
+/// never to third-party origins, where the bearer token would leak.
+pub(crate) fn mint_media_get_auth(state: &AppState, base_url: &str) -> Option<String> {
+    let keys = match state.signing_keys() {
+        Ok(k) => k,
+        Err(e) => {
+            eprintln!("buzz-desktop: media get auth unavailable (unsigned request): {e}");
+            return None;
+        }
+    };
+    match sign_blossom_get_auth_header(&keys, base_url, MEDIA_GET_AUTH_EXPIRY_SECS) {
+        Ok(header) => Some(header),
+        Err(e) => {
+            eprintln!("buzz-desktop: media get auth signing failed (unsigned request): {e}");
+            None
+        }
+    }
+}
+
 fn sign_blossom_upload_auth(
     keys: &Keys,
     sha256: &str,
@@ -594,6 +661,38 @@ mod tests {
     fn test_extract_server_authority_invalid() {
         assert_eq!(extract_server_authority("not-a-url"), None);
         assert_eq!(extract_server_authority(""), None);
+    }
+
+    #[test]
+    fn test_sign_blossom_get_auth_header_shape() {
+        let keys = Keys::generate();
+        let header = sign_blossom_get_auth_header(&keys, "http://localhost:3000", 600).unwrap();
+        let b64 = header.strip_prefix("Nostr ").expect("Nostr scheme prefix");
+        let json = URL_SAFE_NO_PAD.decode(b64).unwrap();
+        let event = nostr::Event::from_json(std::str::from_utf8(&json).unwrap()).unwrap();
+
+        assert_eq!(event.kind, Kind::from(24242));
+        event.verify().expect("valid signature");
+
+        let tag = |name: &str| -> Option<String> {
+            event.tags.iter().find_map(|t| {
+                let v = t.as_slice();
+                (v.first().map(String::as_str) == Some(name)).then(|| v[1].clone())
+            })
+        };
+        assert_eq!(tag("t").as_deref(), Some("get"));
+        assert_eq!(tag("server").as_deref(), Some("localhost:3000"));
+        // Server-scoped token: no x tag (BUD-01 allows x OR server).
+        assert!(tag("x").is_none());
+        let expiration: u64 = tag("expiration").unwrap().parse().unwrap();
+        let now = Timestamp::now().as_secs();
+        assert!(expiration > now && expiration <= now + 600);
+    }
+
+    #[test]
+    fn test_sign_blossom_get_auth_header_invalid_base_url() {
+        let keys = Keys::generate();
+        assert!(sign_blossom_get_auth_header(&keys, "not-a-url", 600).is_err());
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -4,7 +4,7 @@ use tauri::State;
 
 use crate::app_state::AppState;
 use crate::commands::export_util::save_bytes_with_dialog;
-use crate::commands::media::{detect_and_validate_mime, sanitize_filename};
+use crate::commands::media::{detect_and_validate_mime, mint_media_get_auth, sanitize_filename};
 use crate::commands::{
     personas::{
         decode_snapshot_from_bytes, MAX_SNAPSHOT_JSON_BYTES, MAX_SNAPSHOT_PNG_BYTES, PNG_MAGIC,
@@ -271,13 +271,17 @@ async fn fetch_blob_bytes_with_cap(
     cap: u64,
 ) -> Result<Vec<u8>, String> {
     // Fetch bytes via the app's HTTP client (goes through WARP tunnel).
-    let resp = state
-        .http_client
-        .get(url)
-        .timeout(DOWNLOAD_TIMEOUT)
-        .send()
-        .await
-        .map_err(|e| classify_request_error(&e))?;
+    let mut req = state.http_client.get(url).timeout(DOWNLOAD_TIMEOUT);
+
+    // Every caller pre-validates `url` against the relay origin via
+    // `validate_download_url`, satisfying the mint_media_get_auth safety
+    // contract (the token never leaves the relay origin).
+    let relay_base = relay_api_base_url_with_override(state);
+    if let Some(auth) = mint_media_get_auth(state, &relay_base) {
+        req = req.header("authorization", auth);
+    }
+
+    let resp = req.send().await.map_err(|e| classify_request_error(&e))?;
 
     if !resp.status().is_success() {
         return Err(relay_error_message(resp).await);

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -19,7 +19,7 @@ mod identity;
 mod identity_archive;
 mod legacy_storage;
 mod link_preview;
-mod media;
+pub(crate) mod media;
 mod media_download;
 mod media_transcode;
 #[cfg(feature = "mesh-llm")]

--- a/desktop/src-tauri/src/media_proxy.rs
+++ b/desktop/src-tauri/src/media_proxy.rs
@@ -11,6 +11,7 @@ use tauri::{http, Manager};
 use tokio::net::TcpListener;
 
 use crate::app_state::AppState;
+use crate::commands::media::mint_media_get_auth;
 use crate::relay;
 
 /// Defense-in-depth cap: refuse to buffer responses larger than this into RAM.
@@ -55,6 +56,12 @@ async fn proxy_handler(AxumState(state): AxumState<ProxyState>, req: Request) ->
         .client
         .get(&upstream_url)
         .timeout(std::time::Duration::from_secs(120));
+
+    // `upstream_url` is always `{relay base}{path}`, so the token can't reach
+    // a third-party origin (mint_media_get_auth safety contract).
+    if let Some(auth) = mint_media_get_auth(&app_state, &base_url) {
+        upstream = upstream.header("authorization", auth);
+    }
 
     if let Some(range) = req.headers().get("range") {
         if let Ok(v) = range.to_str() {
@@ -177,6 +184,13 @@ pub async fn handle_buzz_media(
         .http_client
         .get(&upstream_url)
         .timeout(std::time::Duration::from_secs(60));
+
+    // `upstream_url` is always `{relay base}{path}`, so the token can't reach
+    // a third-party origin (mint_media_get_auth safety contract).
+    if let Some(auth) = mint_media_get_auth(&state, &base) {
+        upstream = upstream.header("authorization", auth);
+    }
+
     if let Some(range) = request.headers().get("range") {
         if let Ok(v) = range.to_str() {
             upstream = upstream.header("range", v);

--- a/mobile/lib/features/channels/compose_bar/attachments.dart
+++ b/mobile/lib/features/channels/compose_bar/attachments.dart
@@ -96,14 +96,17 @@ class _AttachmentStrip extends StatelessWidget {
                             ),
                           ),
                         )
-                      : Image.network(
-                          previewUrl,
-                          fit: BoxFit.cover,
-                          errorBuilder: (_, _, _) => ColoredBox(
-                            color: context.colors.surface,
-                            child: Icon(
-                              LucideIcons.image,
-                              color: context.colors.onSurfaceVariant,
+                      : Consumer(
+                          builder: (context, ref, _) => Image.network(
+                            previewUrl,
+                            headers: mediaGetHeadersFor(ref, previewUrl),
+                            fit: BoxFit.cover,
+                            errorBuilder: (_, _, _) => ColoredBox(
+                              color: context.colors.surface,
+                              child: Icon(
+                                LucideIcons.image,
+                                color: context.colors.onSurfaceVariant,
+                              ),
                             ),
                           ),
                         ),

--- a/mobile/lib/features/channels/media_viewer_page.dart
+++ b/mobile/lib/features/channels/media_viewer_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:video_player/video_player.dart';
 
+import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme.dart';
 
 const _imageViewerPushDuration = Duration(milliseconds: 280);
@@ -275,6 +276,10 @@ class _MediaImageViewerPageState extends State<MediaImageViewerPage>
                         tag: widget.heroTag,
                         child: Image.network(
                           widget.imageUrl,
+                          headers: mediaGetHeadersForContext(
+                            context,
+                            widget.imageUrl,
+                          ),
                           fit: BoxFit.contain,
                           semanticLabel: widget.semanticLabel,
                           errorBuilder: (_, _, _) => const _MediaLoadFailure(
@@ -348,7 +353,10 @@ class _MediaVideoViewerPageState extends State<MediaVideoViewerPage> {
   @override
   void initState() {
     super.initState();
-    _controller = VideoPlayerController.networkUrl(Uri.parse(widget.videoUrl));
+    _controller = VideoPlayerController.networkUrl(
+      Uri.parse(widget.videoUrl),
+      httpHeaders: mediaGetHeadersForContext(context, widget.videoUrl),
+    );
     _initializeFuture = _controller
         .initialize()
         .then((_) async {
@@ -451,6 +459,7 @@ class _VideoLoadingPoster extends StatelessWidget {
           if (posterUrl != null)
             Image.network(
               posterUrl!,
+              headers: mediaGetHeadersForContext(context, posterUrl!),
               fit: BoxFit.cover,
               errorBuilder: (_, _, _) => _videoPlaceholder(context),
             )

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -9,6 +9,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../shared/clipboard_utils.dart';
+import '../../shared/relay/relay.dart';
 import '../../shared/syntax_highlight.dart';
 import '../../shared/theme/theme.dart';
 import '../custom_emoji/custom_emoji.dart';
@@ -220,7 +221,7 @@ List<CustomEmoji> _mergeCustomEmoji(
   return merged;
 }
 
-class _MessageImagePreview extends HookWidget {
+class _MessageImagePreview extends HookConsumerWidget {
   final String url;
   final ImetaEntry? imeta;
   final String semanticLabel;
@@ -232,7 +233,7 @@ class _MessageImagePreview extends HookWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final heroTag = useMemoized(() => Object());
     final layout = _resolveImagePreviewLayout(context, imeta?.aspectRatio);
 
@@ -255,6 +256,7 @@ class _MessageImagePreview extends HookWidget {
             tag: heroTag,
             child: Image.network(
               url,
+              headers: mediaGetHeadersFor(ref, url),
               fit: layout.fit,
               semanticLabel: semanticLabel,
               errorBuilder: (_, _, _) => _MediaPreviewFallback(
@@ -297,6 +299,7 @@ class _MessageVideoPreview extends StatelessWidget {
                 if (posterUrl != null)
                   Image.network(
                     posterUrl,
+                    headers: mediaGetHeadersForContext(context, posterUrl),
                     fit: BoxFit.cover,
                     errorBuilder: (_, _, _) => const _MediaPreviewFallback(
                       icon: LucideIcons.video,

--- a/mobile/lib/features/custom_emoji/custom_emoji_render.dart
+++ b/mobile/lib/features/custom_emoji/custom_emoji_render.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:gpt_markdown/custom_widgets/markdown_config.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../shared/relay/relay.dart';
 
 import 'custom_emoji.dart';
 
@@ -29,14 +32,17 @@ class CustomEmojiImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final fallbackStyle = DefaultTextStyle.of(context).style;
-    return Image.network(
-      url,
-      width: size,
-      height: size,
-      fit: BoxFit.contain,
-      filterQuality: FilterQuality.medium,
-      semanticLabel: ':$shortcode:',
-      errorBuilder: (_, _, _) => Text(':$shortcode:', style: fallbackStyle),
+    return Consumer(
+      builder: (context, ref, _) => Image.network(
+        url,
+        headers: mediaGetHeadersFor(ref, url),
+        width: size,
+        height: size,
+        fit: BoxFit.contain,
+        filterQuality: FilterQuality.medium,
+        semanticLabel: ':$shortcode:',
+        errorBuilder: (_, _, _) => Text(':$shortcode:', style: fallbackStyle),
+      ),
     );
   }
 }

--- a/mobile/lib/shared/relay/media_auth.dart
+++ b/mobile/lib/shared/relay/media_auth.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+
+import 'package:flutter/widgets.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+import 'relay_provider.dart';
+
+const _mediaGetAuthKind = 24242;
+const _mediaGetAuthLifetimeSeconds = 600;
+
+/// Builds BUD-01 Blossom `t=get` auth headers for relay-host media URLs.
+///
+/// Returns an empty map for non-relay URLs or when no signing key is available,
+/// so callers can safely use this on arbitrary profile/custom-emoji URLs without
+/// leaking Buzz credentials to third-party hosts.
+@immutable
+class MediaGetAuthService {
+  final String _baseUrl;
+  final String? _nsec;
+  final DateTime Function() _now;
+
+  const MediaGetAuthService({
+    required String baseUrl,
+    required String? nsec,
+    DateTime Function()? now,
+  }) : _baseUrl = baseUrl,
+       _nsec = nsec,
+       _now = now ?? DateTime.now;
+
+  Map<String, String> headersFor(String url) {
+    final nsec = _nsec;
+    if (nsec == null || nsec.isEmpty) return const {};
+    final uri = Uri.tryParse(url);
+    final relayUri = Uri.tryParse(_baseUrl);
+    if (uri == null || relayUri == null) return const {};
+    if (!_isRelayMediaUrl(uri, relayUri)) return const {};
+
+    try {
+      final authEvent = _buildGetAuthEvent(nsec);
+      final encoded = base64Url
+          .encode(utf8.encode(authEvent.toJson()))
+          .replaceAll('=', '');
+      return {'Authorization': 'Nostr $encoded'};
+    } catch (_) {
+      // Read auth is best-effort: while the relay rollout flag is off, an
+      // unsigned fetch still works. Once the flag is on, this request will 403
+      // instead of crashing the widget tree because local key material is bad.
+      return const {};
+    }
+  }
+
+  bool _isRelayMediaUrl(Uri uri, Uri relayUri) {
+    if (uri.scheme != 'http' && uri.scheme != 'https') return false;
+    if (uri.host.isEmpty || relayUri.host.isEmpty) return false;
+    // Extract the URL's origin and path. Query strings are ignored for media
+    // host/path detection, matching the fetch target shape used by descriptors.
+    final base = '${uri.scheme}://${uri.authority}';
+    final mediaAuthority = extractServerAuthority(base);
+    final relayAuthority = extractServerAuthority(_baseUrl);
+    if (mediaAuthority == null || relayAuthority == null) return false;
+    if (mediaAuthority.toLowerCase() != relayAuthority.toLowerCase()) {
+      return false;
+    }
+    return uri.path.startsWith('/media/');
+  }
+
+  nostr.Event _buildGetAuthEvent(String nsec) {
+    final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
+    if (privkeyHex.isEmpty) {
+      throw Exception('Invalid nsec');
+    }
+
+    final expiration =
+        (_now().millisecondsSinceEpoch ~/ 1000) + _mediaGetAuthLifetimeSeconds;
+    final tags = <List<String>>[
+      ['t', 'get'],
+      ['expiration', '$expiration'],
+      if (extractServerAuthority(_baseUrl) case final authority?)
+        ['server', authority],
+    ];
+
+    return nostr.Event.from(
+      kind: _mediaGetAuthKind,
+      content: 'Get buzz-media',
+      tags: tags,
+      secretKey: privkeyHex,
+      verify: false,
+    );
+  }
+}
+
+final mediaGetAuthServiceProvider = Provider<MediaGetAuthService>((ref) {
+  final config = ref.watch(relayConfigProvider);
+  return MediaGetAuthService(baseUrl: config.baseUrl, nsec: config.nsec);
+});
+
+Map<String, String> mediaGetHeadersFor(WidgetRef ref, String url) {
+  return ref.read(mediaGetAuthServiceProvider).headersFor(url);
+}
+
+Map<String, String> mediaGetHeadersForContext(
+  BuildContext context,
+  String url,
+) {
+  final container = ProviderScope.containerOf(context, listen: false);
+  return container.read(mediaGetAuthServiceProvider).headersFor(url);
+}
+
+String? extractServerAuthority(String baseUrl) {
+  final uri = Uri.parse(baseUrl);
+  if (uri.host.isEmpty) return null;
+  final host = uri.host.contains(':') ? '[${uri.host}]' : uri.host;
+  final port = uri.hasPort ? uri.port : null;
+  final authority = port == null ? host : '$host:$port';
+  return _normalizeAuthority(authority);
+}
+
+String _normalizeAuthority(String authority) {
+  var normalized = authority.trim().toLowerCase();
+  if (normalized.endsWith('.')) {
+    normalized = normalized.substring(0, normalized.length - 1);
+  }
+  if (normalized.endsWith(':443')) {
+    return normalized.substring(0, normalized.length - ':443'.length);
+  }
+  if (normalized.endsWith(':80')) {
+    return normalized.substring(0, normalized.length - ':80'.length);
+  }
+  return normalized;
+}

--- a/mobile/lib/shared/relay/media_upload.dart
+++ b/mobile/lib/shared/relay/media_upload.dart
@@ -9,6 +9,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:nostr/nostr.dart' as nostr;
 import 'package:pointycastle/digests/sha256.dart';
 
+import 'media_auth.dart';
 import 'relay_provider.dart';
 
 const _mediaUploadPath = '/media/upload';
@@ -311,7 +312,7 @@ class MediaUploadService {
       ['t', 'upload'],
       ['x', sha256],
       ['expiration', '$expiration'],
-      if (_extractServerAuthority(_baseUrl) case final authority?)
+      if (extractServerAuthority(_baseUrl) case final authority?)
         ['server', authority],
     ];
 
@@ -618,13 +619,6 @@ Future<String> _transcodePickedVideoToMp4(String filePath) async {
     throw Exception('Failed to convert video to MP4.');
   }
   return result;
-}
-
-String? _extractServerAuthority(String baseUrl) {
-  final uri = Uri.parse(baseUrl);
-  if (uri.host.isEmpty) return null;
-  final host = uri.host.contains(':') ? '[${uri.host}]' : uri.host;
-  return uri.hasPort ? '$host:${uri.port}' : host;
 }
 
 Future<Uint8List> _transcodePickedImageToJpeg(Uint8List bytes) async {

--- a/mobile/lib/shared/relay/relay.dart
+++ b/mobile/lib/shared/relay/relay.dart
@@ -1,4 +1,5 @@
 export 'app_lifecycle_provider.dart';
+export 'media_auth.dart';
 export 'media_upload.dart';
 export 'nostr_filters.dart';
 export 'nostr_models.dart';

--- a/mobile/lib/shared/widgets/avatar_image.dart
+++ b/mobile/lib/shared/widgets/avatar_image.dart
@@ -3,6 +3,9 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../relay/relay.dart';
 
 /// A circular avatar that supports both remote URLs and inline image data.
 ///
@@ -97,10 +100,13 @@ class _AvatarImageContentState extends State<AvatarImageContent> {
         fit: widget.fit,
         errorBuilder: (_, _, _) => centeredFallback,
       ),
-      _NetworkAvatarSource(:final url) => Image.network(
-        url,
-        fit: widget.fit,
-        errorBuilder: (_, _, _) => centeredFallback,
+      _NetworkAvatarSource(:final url) => Consumer(
+        builder: (context, ref, _) => Image.network(
+          url,
+          headers: mediaGetHeadersFor(ref, url),
+          fit: widget.fit,
+          errorBuilder: (_, _, _) => centeredFallback,
+        ),
       ),
       null => centeredFallback,
     };

--- a/mobile/test/shared/relay/media_upload_test.dart
+++ b/mobile/test/shared/relay/media_upload_test.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 import 'package:image_picker/image_picker.dart';
 import 'package:nostr/nostr.dart' as nostr;
+import 'package:buzz/shared/relay/media_auth.dart';
 import 'package:buzz/shared/relay/media_upload.dart';
 
 final _pngBytes = Uint8List.fromList([
@@ -232,6 +233,92 @@ void main() {
 
   tearDownAll(() {
     _setMockMediaUploadPlatformHandler(null);
+  });
+
+  group('MediaGetAuthService', () {
+    test('signs relay media get requests with a server-scoped token', () {
+      final keychain = nostr.Keys.generate();
+      final service = MediaGetAuthService(
+        baseUrl: 'https://Relay.Example:443',
+        nsec: keychain.nsec,
+        now: () => DateTime.fromMillisecondsSinceEpoch(1700000000000),
+      );
+
+      final headers = service.headersFor(
+        'https://relay.example:443/media/${'a' * 64}.jpg',
+      );
+
+      final authHeader = headers['Authorization'];
+      expect(authHeader, startsWith('Nostr '));
+      final encoded = authHeader!.substring('Nostr '.length);
+      final decoded = utf8.decode(
+        base64Url.decode(base64Url.normalize(encoded)),
+      );
+      final authEvent = jsonDecode(decoded) as Map<String, dynamic>;
+      expect(authEvent['kind'], 24242);
+      expect(authEvent['pubkey'], keychain.public);
+      expect(authEvent['content'], 'Get buzz-media');
+      expect(authEvent['tags'], contains(equals(['t', 'get'])));
+      expect(authEvent['tags'], contains(equals(['server', 'relay.example'])));
+      expect(authEvent['tags'], contains(equals(['expiration', '1700000600'])));
+    });
+
+    test('does not sign non-relay or non-media URLs', () {
+      final service = MediaGetAuthService(
+        baseUrl: 'https://relay.example',
+        nsec: nostr.Keys.generate().nsec,
+      );
+
+      expect(
+        service.headersFor('https://evil.example/media/${'a' * 64}.jpg'),
+        isEmpty,
+      );
+      expect(service.headersFor('https://relay.example/avatar.png'), isEmpty);
+    });
+
+    test('normalizes default ports and rejects path-prefix lookalikes', () {
+      final service = MediaGetAuthService(
+        baseUrl: 'https://Relay.Example:443',
+        nsec: nostr.Keys.generate().nsec,
+      );
+
+      expect(
+        service.headersFor('https://relay.example/media/${'a' * 64}.jpg'),
+        isNotEmpty,
+      );
+      expect(
+        service.headersFor('https://relay.example/media-evil/${'a' * 64}.jpg'),
+        isEmpty,
+      );
+      expect(
+        service.headersFor('ftp://relay.example/media/${'a' * 64}.jpg'),
+        isEmpty,
+      );
+    });
+
+    test('does not sign without a key', () {
+      final service = MediaGetAuthService(
+        baseUrl: 'https://relay.example',
+        nsec: null,
+      );
+
+      expect(
+        service.headersFor('https://relay.example/media/${'a' * 64}.jpg'),
+        isEmpty,
+      );
+    });
+
+    test('does not throw or sign when the stored key is invalid', () {
+      final service = MediaGetAuthService(
+        baseUrl: 'https://relay.example',
+        nsec: 'not-an-nsec',
+      );
+
+      expect(
+        service.headersFor('https://relay.example/media/${'a' * 64}.jpg'),
+        isEmpty,
+      );
+    });
   });
 
   group('MediaUploadService', () {


### PR DESCRIPTION
## Summary
- Require authenticated Blossom/BUD-01 `t=get` tokens for `GET` and `HEAD /media/*` when `BUZZ_REQUIRE_MEDIA_GET_AUTH` is enabled (`BUZZ_REQUIRE_MEDIA_READ_AUTH` alias accepted for rollout wording).
- Enforce relay membership after token verification and before sidecar/blob access; switch auth-gated blob responses to private immutable cache control.
- Attach authenticated media-read headers across desktop proxy/download/import paths, mobile image/video/avatar/custom emoji fetches, dev MCP `view_image`, and CLI `buzz media get`.
- Harden CLI/dev MCP against cross-origin auth leakage by refusing/avoiding redirects when auth headers are attached, and only sign relay-host `/media/` URLs.

## Validation
- `git rev-parse HEAD` on `wren/authed-media-get`: `8cd18cfa2697e42750960370e3f87822efe6a860`
- `git ls-remote --heads origin wren/authed-media-get`: `8cd18cfa2697e42750960370e3f87822efe6a860`
- Push pre-push hook passed with Hermit toolchain:
  - `desktop-check`
  - `desktop-test`
  - `mobile-test`
  - `rust-tests`
  - `desktop-tauri-test`

## Red-team checks covered in code/tests/review
- Unauthenticated GET/HEAD denied before sidecar/blob lookup when flag is on.
- Upload-shaped token rejection.
- Wrong `server` tag rejection.
- Wrong `x` tag rejection.
- Relay-host-only client signing.
- CLI/dev MCP no-redirect behavior for signed requests.
- Server-scoped `t=get` tokens are intentional and still membership-gated.

## Follow-up
- Composed e2e still needs to run against a flag-on relay: desktop proxy + `view_image` with `BUZZ_REQUIRE_MEDIA_READ_AUTH=true`.
