### PR TITLE
Fix Goose agent instruction fallback

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -570,6 +570,13 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
         .collect()
 }
 
+pub(crate) fn agent_command_supports_session_system_prompt(command: &str) -> bool {
+    // Goose advertises ACP protocol v2 but ignores `session/new.systemPrompt`
+    // in versions observed in the wild. Keep Buzz instructions in the user
+    // prompt for Goose until it has a stable, broadly available prompt API.
+    normalize_agent_command_identity(command) != "goose"
+}
+
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
@@ -1481,6 +1488,21 @@ mod tests {
         assert_eq!(normalize_agent_command_identity("   "), "");
         assert_eq!(normalize_agent_command_identity("/"), "");
         assert_eq!(normalize_agent_command_identity("///"), "");
+    }
+
+    #[test]
+    fn session_system_prompt_compatibility_disables_goose_only() {
+        assert!(!agent_command_supports_session_system_prompt("goose"));
+        assert!(!agent_command_supports_session_system_prompt(
+            "C:\\Program Files\\Goose\\goose.exe"
+        ));
+        assert!(agent_command_supports_session_system_prompt("buzz-agent"));
+        assert!(agent_command_supports_session_system_prompt(
+            "/usr/local/bin/codex-acp"
+        ));
+        assert!(agent_command_supports_session_system_prompt(
+            "custom-acp-runtime"
+        ));
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -28,7 +28,10 @@ use buzz_core::observer::{
     OBSERVER_MAX_PLAINTEXT_LEN,
 };
 use clap::Parser;
-use config::{Config, DedupMode, ModelsArgs, MultipleEventHandling, RespondTo, SubscribeMode};
+use config::{
+    agent_command_supports_session_system_prompt, Config, DedupMode, ModelsArgs,
+    MultipleEventHandling, RespondTo, SubscribeMode,
+};
 use filter::SubscriptionRule;
 use futures_util::FutureExt;
 use nostr::{PublicKey, ToBech32};
@@ -1133,6 +1136,8 @@ async fn tokio_main() -> Result<()> {
     // We attempt each spawn under a 60-second timeout; failures are logged and
     // skipped. If ALL agents fail we return an error. A partial pool is valid —
     // the harness continues with reduced capacity and logs a warning.
+    let command_supports_session_system_prompt =
+        agent_command_supports_session_system_prompt(&config.agent_command);
     let mut agent_slots: Vec<Option<OwnedAgent>> = Vec::with_capacity(config.agents as usize);
     for i in 0..config.agents as usize {
         // Spawn OUTSIDE the timeout so we always own the child for cleanup.
@@ -1178,7 +1183,8 @@ async fn tokio_main() -> Result<()> {
                             model_capabilities: None,
                             desired_model: config.model.clone(),
                             model_overridden: false,
-                            protocol_version,
+                            supports_session_system_prompt: protocol_version >= 2
+                                && command_supports_session_system_prompt,
                         }));
                     }
                     Ok(Err(e)) => {
@@ -1617,7 +1623,8 @@ async fn tokio_main() -> Result<()> {
                         model_capabilities: None,
                         desired_model: config.model.clone(),
                         model_overridden: false,
-                        protocol_version,
+                        supports_session_system_prompt: protocol_version >= 2
+                            && command_supports_session_system_prompt,
                     };
                     pool.return_agent(agent);
                     tracing::info!(agent = rr.index, "respawn complete");
@@ -3168,10 +3175,18 @@ fn dispatch_heartbeat(
         .heartbeat_prompt
         .clone()
         .unwrap_or_else(default_heartbeat_prompt);
-    // For legacy agents (protocol_version < 2), prepend base_prompt to the
-    // heartbeat user message since they don't receive it via session/new.
-    let prompt_text =
-        pool::prepend_base_for_legacy(agent.protocol_version, ctx.base_prompt, &prompt_text);
+    // For legacy/compatibility fallback agents, prepend Buzz instructions to
+    // the heartbeat user message since they don't receive them via session/new.
+    let prompt_text = pool::prepend_system_context_for_fallback(
+        agent.supports_session_system_prompt,
+        &ctx.cwd,
+        ctx.base_prompt,
+        ctx.system_prompt.as_deref(),
+        ctx.team_instructions.as_deref(),
+        None,
+        None,
+        &prompt_text,
+    );
     let result_tx = pool.result_tx();
     let ctx_clone = Arc::clone(ctx);
     let agent_index = agent.index;
@@ -3510,33 +3525,46 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
 }
 
 #[cfg(test)]
-mod heartbeat_base_prompt_tests {
+mod heartbeat_system_context_tests {
     use super::*;
 
-    // Pins the heartbeat dispatch path (dispatch_heartbeat, ~line 2359): a
-    // legacy agent WITH a base_prompt must get [Base] prepended to the
-    // heartbeat user message, composed as `[Base]\n{bp}\n\n{prompt}`. This is
-    // the second half of the round-2 regression (the first being initial_message).
+    // Pins the heartbeat dispatch path: an agent without session-system-prompt
+    // support must get Buzz instructions prepended to the heartbeat user
+    // message. This is the second half of the round-2 regression (the first
+    // being initial_message).
 
     #[test]
-    fn test_heartbeat_legacy_agent_gets_base_prepended() {
-        // protocol_version 1 + Some(base_prompt): heartbeat prompt is prefixed
-        // with the [Base] section exactly as the legacy session/new path would.
+    fn test_heartbeat_fallback_agent_gets_system_context() {
         let prompt = "[System: Heartbeat]\nrun feed get";
-        let composed = pool::prepend_base_for_legacy(1, Some("you are a helpful agent"), prompt);
+        let composed = pool::prepend_system_context_for_fallback(
+            false,
+            "/",
+            Some("base text"),
+            Some("persona text"),
+            Some("team text"),
+            None,
+            None,
+            prompt,
+        );
         assert_eq!(
             composed,
-            "[Base]\nyou are a helpful agent\n\n[System: Heartbeat]\nrun feed get"
+            "[Base]\nbase text\n\n[System]\npersona text\n\n[Team Instructions]\nteam text\n\n[System: Heartbeat]\nrun feed get"
         );
-        assert!(composed.starts_with("[Base]\nyou are a helpful agent\n\n"));
     }
 
     #[test]
-    fn test_heartbeat_modern_agent_omits_base() {
-        // protocol_version 2 gets base_prompt via session/new; the heartbeat
-        // prompt is sent verbatim.
+    fn test_heartbeat_supported_agent_omits_fallback_context() {
         let prompt = "[System: Heartbeat]\nrun feed get";
-        let composed = pool::prepend_base_for_legacy(2, Some("you are a helpful agent"), prompt);
+        let composed = pool::prepend_system_context_for_fallback(
+            true,
+            "/",
+            Some("base text"),
+            Some("persona text"),
+            Some("team text"),
+            None,
+            None,
+            prompt,
+        );
         assert_eq!(composed, prompt);
     }
 }
@@ -4152,9 +4180,9 @@ mod error_outcome_emission_tests {
             model_capabilities: None,
             desired_model: None,
             model_overridden: false,
-            // Error branches under test never read this; 1 is the legacy
-            // non-systemPrompt path, the simplest valid value.
-            protocol_version: 1,
+            // Error branches under test never read this; keep the legacy
+            // non-systemPrompt path as the simplest valid shape.
+            supports_session_system_prompt: false,
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -154,9 +154,10 @@ pub struct OwnedAgent {
     /// desktop reader to distinguish a genuine runtime override from a stale
     /// session whose persona model was edited. Reset on spawn/restart.
     pub model_overridden: bool,
-    /// Protocol version reported by the agent in its initialize response.
-    /// Agents declaring >= 2 support `systemPrompt` in session/new.
-    pub protocol_version: u32,
+    /// Whether this runtime should receive Buzz instructions via
+    /// `session/new.systemPrompt`. Some runtimes advertise protocol v2 but
+    /// ignore that field, so support is protocol plus runtime compatibility.
+    pub supports_session_system_prompt: bool,
 }
 
 /// Pool of agents with take-and-return ownership semantics.
@@ -704,12 +705,11 @@ async fn create_session_and_apply_model(
 ) -> Result<String, AcpError> {
     // Combine base_prompt + system_prompt + agent core + canvas metadata into a
     // single systemPrompt value for the session/new request. Only sent when the
-    // agent declares protocol version >= 2 (supports systemPrompt); legacy agents
-    // ignore it and receive the same content as user-message sections via
-    // `format_prompt`. Core carries its own `[Agent Memory — core]` header, and
-    // canvas carries its own `[Channel Canvas]` header; both are appended with a
-    // blank-line separator.
-    let combined_system_prompt: Option<String> = if agent.protocol_version >= 2 {
+    // runtime reliably applies session system prompts; fallback agents receive
+    // the same content as user-message sections via `format_prompt`. Core
+    // carries its own `[Agent Memory — core]` header, and canvas carries its own
+    // `[Channel Canvas]` header; both are appended with a blank-line separator.
+    let combined_system_prompt: Option<String> = if agent.supports_session_system_prompt {
         with_canvas(
             with_core(
                 with_team(
@@ -952,41 +952,40 @@ async fn apply_permission_mode(
     Ok(())
 }
 
-/// Prepend the `[Base]` section to a user-message body for legacy agents.
+/// Prepend the full Buzz instruction context when a runtime cannot reliably
+/// consume `session/new.systemPrompt`.
 ///
-/// Legacy agents (`protocol_version < 2`) don't receive `base_prompt` via the
-/// system role in `session/new`, so it must ride along in the user message.
-/// Agents with `protocol_version >= 2`, or any agent without a `base_prompt`,
-/// get `body` unchanged. The gate lives here so the heartbeat and
-/// initial-message dispatch paths can't drift apart again.
-pub(crate) fn prepend_base_for_legacy(
-    protocol_version: u32,
+/// This is used for pre-built prompts that bypass `queue::format_prompt`, such
+/// as `initial_message` and heartbeats. Regular channel turns use the same gate
+/// through `FormatPromptArgs::has_system_prompt_support`.
+pub(crate) fn prepend_system_context_for_fallback(
+    supports_session_system_prompt: bool,
+    cwd: &str,
     base_prompt: Option<&str>,
-    body: &str,
-) -> String {
-    match base_prompt {
-        Some(bp) if protocol_version < 2 => {
-            format!("{}\n\n{body}", crate::queue::base_section(bp))
-        }
-        _ => body.to_string(),
-    }
-}
-
-/// Prepend the `[Channel Canvas]` section to the legacy initial-message body.
-///
-/// Protocol-v2 agents already receive the canvas in `systemPrompt`; only
-/// legacy (protocol_version < 2) agents need it injected here so it arrives
-/// before the first prompt — the same "every turn" semantics as per-turn core.
-/// Heartbeats never have an initial_message, so the caller is responsible for
-/// not passing a canvas when `source` is `Heartbeat`.
-pub(crate) fn prepend_canvas_for_legacy(
-    protocol_version: u32,
+    system_prompt: Option<&str>,
+    team_instructions: Option<&str>,
+    agent_core: Option<&str>,
     agent_canvas: Option<&str>,
     body: &str,
 ) -> String {
-    match agent_canvas {
-        Some(canvas) if protocol_version < 2 => format!("{canvas}\n\n{body}"),
-        _ => body.to_string(),
+    if supports_session_system_prompt {
+        return body.to_string();
+    }
+
+    let context = with_canvas(
+        with_core(
+            with_team(
+                framed_system_prompt(cwd, base_prompt, system_prompt),
+                team_instructions,
+            ),
+            agent_core,
+        ),
+        agent_canvas,
+    );
+
+    match context {
+        Some(context) => format!("{context}\n\n{body}"),
+        None => body.to_string(),
     }
 }
 
@@ -1190,10 +1189,10 @@ pub async fn run_prompt_task(
 
     //
     // Core memory is delivered inside the system prompt the harness already
-    // builds (system role for protocol >= 2, the `[System]` user-message
-    // section for legacy agents). To put it on the wire at `session/new` for
-    // modern agents, the fetch must run *before* the session is created — so
-    // we do it here and cache the rendered section in `state.core_sections`.
+    // builds (system role for supported runtimes, the `[System]` user-message
+    // section for fallback agents). To put it on the wire at `session/new` for
+    // supported runtimes, the fetch must run *before* the session is created —
+    // so we do it here and cache the rendered section in `state.core_sections`.
     //
     // Core is keyed by (agent_keys, owner) — both fixed for the process — so
     // it is identical across channels; the per-channel cache just avoids a
@@ -1415,18 +1414,18 @@ pub async fn run_prompt_task(
                 target: "pool::session",
                 "sending initial_message to session {session_id} for channel {cid}"
             );
-            // For agents with systemPrompt support (protocol_version >= 2),
-            // base_prompt is delivered via the system role in session/new.
-            // Legacy agents receive it via [Base] in the user message instead.
-            // Canvas is also injected here for legacy agents: protocol-v2 agents
-            // already have it in systemPrompt; legacy agents need it before the
-            // first prompt, matching the "every turn" per-turn delivery semantics.
-            let init_msg =
-                prepend_base_for_legacy(agent.protocol_version, ctx.base_prompt, initial_msg);
-            let init_msg = prepend_canvas_for_legacy(
-                agent.protocol_version,
+            // For agents with systemPrompt support, Buzz instructions are
+            // delivered via session/new. Compatibility fallbacks receive the
+            // same context in this first user message instead.
+            let init_msg = prepend_system_context_for_fallback(
+                agent.supports_session_system_prompt,
+                &ctx.cwd,
+                ctx.base_prompt,
+                ctx.system_prompt.as_deref(),
+                ctx.team_instructions.as_deref(),
+                agent_core.as_deref(),
                 agent_canvas.as_deref(),
-                &init_msg,
+                initial_msg,
             );
             let init_result = agent
                 .acp
@@ -1585,7 +1584,7 @@ pub async fn run_prompt_task(
                 channel_info: channel_info.as_ref(),
                 conversation_context: conversation_context.as_ref(),
                 profile_lookup: profile_lookup.as_ref(),
-                has_system_prompt_support: agent.protocol_version >= 2,
+                has_system_prompt_support: agent.supports_session_system_prompt,
                 base_prompt: ctx.base_prompt,
                 system_prompt: ctx.system_prompt.as_deref(),
                 team_instructions: ctx.team_instructions.as_deref(),
@@ -3400,106 +3399,67 @@ mod tests {
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
 
-    // These pin the initial_message dispatch path (run_prompt_task, ~line 855):
-    // a legacy agent WITH a base_prompt must get [Base] prepended to the user
-    // message. This is the exact regression that shipped in the round-2 bug.
+    // These pin pre-built prompt dispatch paths (`initial_message`, heartbeat):
+    // an agent without session-system-prompt delivery must receive the same Buzz
+    // instruction context in the user message that supported agents receive via
+    // `session/new.systemPrompt`.
 
     #[test]
-    fn test_initial_message_legacy_agent_gets_base_prepended() {
-        // protocol_version 1 + Some(base_prompt): [Base] rides along in the
-        // user message, composed as `[Base]\n{bp}\n\n{initial_msg}`.
-        let composed = prepend_base_for_legacy(1, Some("you are a helpful agent"), "hello channel");
-        assert_eq!(composed, "[Base]\nyou are a helpful agent\n\nhello channel");
-        assert!(composed.starts_with("[Base]\nyou are a helpful agent\n\n"));
-    }
-
-    #[test]
-    fn test_initial_message_modern_agent_omits_base() {
-        // protocol_version 2 receives base_prompt via session/new, so the user
-        // message is left untouched even when a base_prompt is present.
-        let composed = prepend_base_for_legacy(2, Some("you are a helpful agent"), "hello channel");
-        assert_eq!(composed, "hello channel");
-    }
-
-    #[test]
-    fn test_initial_message_legacy_agent_without_base_is_unchanged() {
-        // No base_prompt configured: nothing to prepend regardless of version.
-        let composed = prepend_base_for_legacy(1, None, "hello channel");
-        assert_eq!(composed, "hello channel");
-    }
-
-    // ── prepend_canvas_for_legacy ─────────────────────────────────────────────
-
-    #[test]
-    fn test_initial_message_legacy_agent_gets_canvas_prepended() {
-        // Legacy agents (protocol_version < 2) receive the canvas section before
-        // the initial-message body so it arrives before the first prompt.
-        let canvas = "[Channel Canvas]\nCanvas revision (event ID): abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234\nLast modified: 2024-01-15T10:30:00Z\nFetch current content with: buzz canvas get --channel 00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
-        let composed = prepend_canvas_for_legacy(1, Some(canvas), "do the thing");
-        assert!(
-            composed.starts_with("[Channel Canvas]"),
-            "canvas must precede the body"
+    fn test_initial_message_fallback_gets_full_system_context() {
+        let composed = prepend_system_context_for_fallback(
+            false,
+            "/",
+            Some("base text"),
+            Some("persona text"),
+            Some("team text"),
+            Some("[Agent Memory — core]\ncore text"),
+            Some("[Channel Canvas]\ncanvas text"),
+            "hello channel",
         );
-        assert!(
-            composed.ends_with("do the thing"),
-            "body must follow the canvas"
-        );
-        assert!(
-            composed.contains("\n\ndo the thing"),
-            "canvas and body separated by blank line"
-        );
-    }
-
-    #[test]
-    fn test_initial_message_modern_agent_omits_canvas_from_body() {
-        // Protocol-v2 agents receive canvas in systemPrompt; it must NOT be
-        // duplicated in the initial-message user turn.
-        let canvas = "[Channel Canvas]\nsome section";
-        let composed = prepend_canvas_for_legacy(2, Some(canvas), "do the thing");
         assert_eq!(
-            composed, "do the thing",
-            "modern agent initial message must not contain canvas"
-        );
-        assert!(
-            !composed.contains("[Channel Canvas]"),
-            "canvas must be absent from modern agent initial message"
+            composed,
+            "[Base]\nbase text\n\n[System]\npersona text\n\n[Team Instructions]\nteam text\n\n[Agent Memory — core]\ncore text\n\n[Channel Canvas]\ncanvas text\n\nhello channel"
         );
     }
 
     #[test]
-    fn test_initial_message_legacy_agent_no_canvas_is_unchanged() {
-        // No canvas present: body passes through unmodified.
-        let composed = prepend_canvas_for_legacy(1, None, "do the thing");
-        assert_eq!(composed, "do the thing");
+    fn test_initial_message_supported_agent_omits_fallback_context() {
+        let composed = prepend_system_context_for_fallback(
+            true,
+            "/",
+            Some("base text"),
+            Some("persona text"),
+            Some("team text"),
+            Some("[Agent Memory — core]\ncore text"),
+            Some("[Channel Canvas]\ncanvas text"),
+            "hello channel",
+        );
+        assert_eq!(composed, "hello channel");
+        assert!(!composed.contains("[System]"));
+        assert!(!composed.contains("[Channel Canvas]"));
     }
 
     #[test]
-    fn test_initial_message_legacy_canvas_and_base_compose_correctly() {
-        // Verify the full composition order when both base and canvas are present:
-        // [Base] → canvas section → initial-message body.
-        let canvas = "[Channel Canvas]\ncanvas content";
-        let base_composed = prepend_base_for_legacy(1, Some("be helpful"), "do the thing");
-        let full = prepend_canvas_for_legacy(1, Some(canvas), &base_composed);
-        assert!(
-            full.starts_with("[Channel Canvas]"),
-            "canvas must be first in composed message"
+    fn test_initial_message_fallback_without_context_is_unchanged() {
+        let composed =
+            prepend_system_context_for_fallback(false, "/", None, None, None, None, None, "hello");
+        assert_eq!(composed, "hello");
+    }
+
+    #[test]
+    fn test_initial_message_fallback_workspace_precedes_base() {
+        let composed = prepend_system_context_for_fallback(
+            false,
+            "/Users/me/.buzz",
+            Some("base text"),
+            None,
+            None,
+            None,
+            None,
+            "hello",
         );
-        assert!(
-            full.contains("[Base]"),
-            "base must be present in composed message"
-        );
-        assert!(
-            full.ends_with("do the thing"),
-            "body must be last in composed message"
-        );
-        // Order: canvas → base → body
-        let canvas_pos = full.find("[Channel Canvas]").unwrap();
-        let base_pos = full.find("[Base]").unwrap();
-        let body_pos = full.find("do the thing").unwrap();
-        assert!(
-            canvas_pos < base_pos && base_pos < body_pos,
-            "order must be: canvas → base → body"
-        );
+        assert!(composed.starts_with("[Workspace]\n"));
+        assert!(composed.contains("\n\n[Base]\nbase text\n\nhello"));
     }
 
     // Pin the session/new systemPrompt framing: each present prompt carries its
@@ -4507,7 +4467,7 @@ mod tests {
             model_capabilities: None,
             desired_model: None,
             model_overridden: false,
-            protocol_version: 2,
+            supports_session_system_prompt: true,
         };
 
         // Simulate dispatch: install a steer receiver (normally done by
@@ -4562,7 +4522,7 @@ mod tests {
             model_capabilities: None,
             desired_model: None,
             model_overridden: false,
-            protocol_version: 2,
+            supports_session_system_prompt: true,
         };
 
         // Simulate a completed turn: `steer_rx` was consumed by the read loop

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1326,19 +1326,20 @@ pub struct FormatPromptArgs<'a> {
     pub profile_lookup: Option<&'a PromptProfileLookup>,
     /// When true, base_prompt and system_prompt are delivered via the system
     /// role (session/new) and omitted from the user message. When false
-    /// (legacy agents), they are injected as `[Base]` and `[System]` sections.
+    /// (legacy agents or runtime compatibility fallbacks), they are injected as
+    /// `[Base]` and `[System]` sections.
     pub has_system_prompt_support: bool,
-    /// Base prompt content for legacy agents (protocol_version < 2).
+    /// Base prompt content for agents without session-system-prompt delivery.
     pub base_prompt: Option<&'a str>,
-    /// System prompt content for legacy agents (protocol_version < 2).
+    /// System prompt content for agents without session-system-prompt delivery.
     pub system_prompt: Option<&'a str>,
-    /// Team instructions for legacy agents, rendered after `[System]`.
+    /// Team instructions for fallback agents, rendered after `[System]`.
     pub team_instructions: Option<&'a str>,
-    /// Rendered `[Channel Canvas]` metadata section for legacy agents.
+    /// Rendered `[Channel Canvas]` metadata section for fallback agents.
     ///
-    /// For modern agents (protocol_version >= 2) the section is delivered via
-    /// the system role in session/new; omit here to avoid duplication.
-    /// For legacy agents it rides in the user message on every turn of the
+    /// For agents with session-system-prompt delivery the section is delivered
+    /// via the system role in session/new; omit here to avoid duplication.
+    /// For fallback agents it rides in the user message on every turn of the
     /// session, alongside `[Base]`/`[System]`/`[Agent Memory — core]`.
     pub agent_canvas: Option<&'a str>,
 }
@@ -1355,8 +1356,8 @@ pub(crate) fn base_section(base_prompt: &str) -> String {
 /// Format a [`FlushBatch`] into the per-section prompt blocks for the agent.
 ///
 /// Produces a stable prompt with these sections (in order):
-/// 0. `[Base]` — base prompt (only for legacy agents without systemPrompt support)
-/// 1. `[System]` — system prompt (only for legacy agents without systemPrompt support)
+/// 0. `[Base]` — base prompt (only for agents without systemPrompt support)
+/// 1. `[System]` — system prompt (only for agents without systemPrompt support)
 /// 2. `[Agent Memory — core]` — if agent core memory is set
 /// 3. `[Context]` — scope, channel name, and contextual hints for the agent
 /// 4. `[Thread Context]` or `[Conversation Context]` — if fetched
@@ -1370,8 +1371,9 @@ pub(crate) fn base_section(base_prompt: &str) -> String {
 /// joining the blocks (legacy agents see a single `\n` between sections rather
 /// than a blank line; sections self-delimit with their `[Header]` line).
 ///
-/// For agents with `protocol_version >= 2`, base_prompt and system_prompt are
-/// delivered via the system role in `session/new` and omitted from this message.
+/// For agents with session-system-prompt delivery, base_prompt and system_prompt
+/// are delivered via the system role in `session/new` and omitted from this
+/// message.
 pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<String> {
     // Scope is always derived from the LAST event in the batch — that's the
     // one the agent is responding to. Thread/DM context is supplementary info
@@ -1392,9 +1394,9 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
 
     let mut sections: Vec<String> = Vec::with_capacity(7);
 
-    // For legacy agents (protocol_version < 2), inject base_prompt and
-    // system_prompt as user-message sections. Modern agents receive these
-    // via the system role in session/new.
+    // For fallback agents, inject base_prompt and system_prompt as user-message
+    // sections. Supported agents receive these via the system role in
+    // session/new.
     if !args.has_system_prompt_support {
         if let Some(bp) = args.base_prompt {
             sections.push(base_section(bp));
@@ -1412,15 +1414,15 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     }
 
     // NIP-AE agent core memory (rendered by `engram_fetch::build_core_section`).
-    // For modern agents (protocol_version >= 2), core is delivered via the
+    // For agents with session-system-prompt delivery, core is delivered via the
     // system role in session/new, so it is omitted here to avoid duplication.
-    // Legacy agents have no system role, so core rides in the user message
-    // alongside `[Base]`/`[System]`.
+    // Fallback agents have no reliable system role, so core rides in the user
+    // message alongside `[Base]`/`[System]`.
     if !args.has_system_prompt_support {
         if let Some(core) = args.agent_core {
             sections.push(core.to_string());
         }
-        // Channel canvas metadata — same delivery semantics as core for legacy agents.
+        // Channel canvas metadata — same delivery semantics as core for fallback agents.
         if let Some(canvas) = args.agent_canvas {
             sections.push(canvas.to_string());
         }
@@ -2235,9 +2237,9 @@ mod tests {
 
     #[test]
     fn test_format_prompt_modern_agent_omits_core_from_user_message() {
-        // Modern agents (protocol_version >= 2) receive core via the system
-        // role in session/new, so format_prompt must NOT also emit it in the
-        // user message — otherwise core would double-render.
+        // Supported agents receive core via the system role in session/new, so
+        // format_prompt must NOT also emit it in the user message — otherwise
+        // core would double-render.
         let ch = Uuid::new_v4();
         let event = make_event("hi");
         let batch = FlushBatch {
@@ -2261,7 +2263,7 @@ mod tests {
         .join("\n\n");
         assert!(
             !prompt.contains("[Agent Memory — core]"),
-            "modern agents must not get core in the user message; got: {prompt}"
+            "supported agents must not get core in the user message; got: {prompt}"
         );
         assert!(prompt.starts_with("[Context]"));
     }
@@ -2402,11 +2404,11 @@ mod tests {
         // Neither section should appear — they are delivered via session/new
         assert!(
             !prompt.contains("[Base]"),
-            "[Base] should be suppressed for modern agents"
+            "[Base] should be suppressed for supported agents"
         );
         assert!(
             !prompt.contains("[System]"),
-            "[System] should be suppressed for modern agents"
+            "[System] should be suppressed for supported agents"
         );
         assert!(prompt.starts_with("[Context]"));
     }


### PR DESCRIPTION
## Summary

- Treat Goose as an ACP runtime compatibility fallback for session system prompts.
- Keep Buzz instructions in user-message sections for Goose while preserving `session/new.systemPrompt` for supported protocol-v2 runtimes.
- Apply the same fallback context to pre-built prompts such as `initial_message` and heartbeats.

## Root Cause

Buzz used `protocolVersion >= 2` as the sole signal that an ACP runtime would apply `session/new.systemPrompt`. Local Goose `1.33.1` reports protocol v2 but does not apply that field, and its `_goose/unstable/session/system-prompt/set` method is unavailable locally. As a result, configured Agent Instruction content was omitted from Goose-visible prompts.

## Validation

- `cargo test -p buzz-acp`