### PR TITLE
fix(desktop): load downloaded mesh runtime on signed macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,10 @@ jobs:
           DMG_PATH: ${{ steps.unsigned.outputs.dmg }}
         run: desktop/scripts/set-dmg-finder-text-size.sh "$DMG_PATH" 14
 
+      # mdx-ios-codesign-helper discovers this file by its exact lowercase basename.
+      - name: Stage signing entitlements
+        run: cp desktop/src-tauri/Entitlements.plist "${RUNNER_TEMP}/entitlements.plist"
+
       - name: Codesign and Notarize
         id: codesign
         uses: block/apple-codesign-action@679535d1ab7c5a7c18e6f9afcba3464512cc3dde # v1.1.0
@@ -210,7 +214,7 @@ jobs:
           osx-codesign-role: ${{ secrets.OSX_CODESIGN_ROLE }}
           codesign-s3-bucket: ${{ secrets.CODESIGN_S3_BUCKET }}
           unsigned-artifact-path: ${{ steps.unsigned.outputs.dmg }}
-          entitlements-plist-path: desktop/src-tauri/Entitlements.plist
+          entitlements-plist-path: ${{ runner.temp }}/entitlements.plist
           artifact-name: buzz-${{ github.sha }}-${{ github.run_id }}-arm64
 
       - name: Replace DMG and rebuild updater archive
@@ -246,6 +250,8 @@ jobs:
           codesign --verify --deep --strict --verbose=2 \
             desktop/src-tauri/target/release/bundle/macos/Buzz.app
           spctl --assess --type execute --verbose=4 \
+            desktop/src-tauri/target/release/bundle/macos/Buzz.app
+          desktop/scripts/verify-macos-entitlements.sh \
             desktop/src-tauri/target/release/bundle/macos/Buzz.app
 
       - name: Locate build artifacts
@@ -369,6 +375,10 @@ jobs:
           DMG_PATH: ${{ steps.unsigned.outputs.dmg }}
         run: desktop/scripts/set-dmg-finder-text-size.sh "$DMG_PATH" 14
 
+      # mdx-ios-codesign-helper discovers this file by its exact lowercase basename.
+      - name: Stage signing entitlements
+        run: cp desktop/src-tauri/Entitlements.plist "${RUNNER_TEMP}/entitlements.plist"
+
       - name: Codesign and Notarize
         id: codesign
         uses: block/apple-codesign-action@679535d1ab7c5a7c18e6f9afcba3464512cc3dde # v1.1.0
@@ -376,7 +386,7 @@ jobs:
           osx-codesign-role: ${{ secrets.OSX_CODESIGN_ROLE }}
           codesign-s3-bucket: ${{ secrets.CODESIGN_S3_BUCKET }}
           unsigned-artifact-path: ${{ steps.unsigned.outputs.dmg }}
-          entitlements-plist-path: desktop/src-tauri/Entitlements.plist
+          entitlements-plist-path: ${{ runner.temp }}/entitlements.plist
           artifact-name: buzz-${{ github.sha }}-${{ github.run_id }}-x64
 
       - name: Replace DMG and rebuild updater archive
@@ -411,6 +421,7 @@ jobs:
           APP_DIR="desktop/src-tauri/target/${TARGET}/release/bundle/macos/Buzz.app"
           codesign --verify --deep --strict --verbose=2 "$APP_DIR"
           spctl --assess --type execute --verbose=4 "$APP_DIR"
+          desktop/scripts/verify-macos-entitlements.sh "$APP_DIR"
 
       - name: Locate updater archive
         id: artifacts

--- a/desktop/scripts/verify-macos-entitlements.sh
+++ b/desktop/scripts/verify-macos-entitlements.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Fail a macOS release if the signing service dropped Buzz's entitlements.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <path-to-Buzz.app>" >&2
+  exit 2
+fi
+
+APP_PATH="$1"
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+
+[[ -d "$APP_PATH" ]] || { echo "Missing app bundle: $APP_PATH" >&2; exit 1; }
+[[ -f "$INFO_PLIST" ]] || { echo "Missing app Info.plist: $INFO_PLIST" >&2; exit 1; }
+
+EXECUTABLE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$INFO_PLIST")"
+EXECUTABLE_PATH="$APP_PATH/Contents/MacOS/$EXECUTABLE_NAME"
+[[ -f "$EXECUTABLE_PATH" ]] || { echo "Missing app executable: $EXECUTABLE_PATH" >&2; exit 1; }
+
+ENTITLEMENTS="$(mktemp -t buzz-entitlements)"
+trap 'rm -f "$ENTITLEMENTS"' EXIT
+
+codesign --display --entitlements "$ENTITLEMENTS" --xml "$EXECUTABLE_PATH" 2>/dev/null
+[[ -s "$ENTITLEMENTS" ]] || {
+  echo "Signed app has no embedded entitlements: $EXECUTABLE_PATH" >&2
+  exit 1
+}
+
+required_entitlements=(
+  com.apple.security.device.audio-input
+  com.apple.security.device.camera
+  com.apple.security.cs.disable-library-validation
+)
+
+for entitlement in "${required_entitlements[@]}"; do
+  value="$(/usr/libexec/PlistBuddy -c "Print :$entitlement" "$ENTITLEMENTS" 2>/dev/null || true)"
+  if [[ "$value" != "true" ]]; then
+    echo "Signed app is missing required entitlement: $entitlement" >&2
+    exit 1
+  fi
+done
+
+echo "Verified required macOS entitlements on $EXECUTABLE_PATH"

--- a/desktop/src-tauri/Entitlements.plist
+++ b/desktop/src-tauri/Entitlements.plist
@@ -6,5 +6,8 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
+    <!-- MeshLLM installs versioned native runtimes outside the app bundle. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>

--- a/desktop/src-tauri/src/mesh_llm/mod.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod.rs
@@ -228,7 +228,9 @@ async fn initialize_mesh_native_runtime() -> anyhow::Result<()> {
     // requiring a separate `mesh-llm runtime install` command.
     mesh_llm_host_runtime::initialize_host_runtime()
         .await
-        .map_err(|error| anyhow::anyhow!("mesh native runtime failed to install or load: {error}"))
+        .map_err(|error| {
+            anyhow::anyhow!("mesh native runtime failed to install or load: {error:#}")
+        })
 }
 
 /// Tokio worker stack size for the runtime that polls mesh-llm futures.


### PR DESCRIPTION
Fix for: 

<img width="1932" height="1022" alt="image" src="https://github.com/user-attachments/assets/fa8ffcc5-3e60-4176-a0bb-cb914b49ae24" />

cc @matbalez 

Mesh llm downloads hardware specific support for inference on demand, so needs permission to use that. 

This also patches the build to use "entitlements" lower case, as the block tools look for lower case, not upper as is normal macos convention/tauri. Small thing, but necessary I believe. 

I tested a self signed version of this and it was able to download the model infra.



## Summary

- allow the hardened macOS app to load MeshLLM native runtime dylibs downloaded into the versioned cache
- stage the entitlement file with the exact lowercase basename expected by mdx-ios-codesign-helper
- fail release builds if signing drops any required macOS entitlement
- include the complete native-loader error chain in user-visible failures

## Root cause

Buzz v0.4.6 is hardened and Developer ID signed by Block, while the MeshLLM v0.73.1 runtime dylibs are ad-hoc/linker signed without a Team ID. macOS library validation rejects them with “mapping process and mapped file (non-platform) have different Team IDs.”

The release workflow supplied Entitlements.plist, but mdx-ios-codesign-helper searches case-sensitively for a root-level entitlements.plist. Consequently, the signed v0.4.6 executable had no embedded entitlements.

The runtime installer still requires the release-manifest SHA-256 checksum before installing downloaded libraries.

## Validation

- reproduced the Team-ID dlopen failure using the exact v0.73.1 arm64 runtime and a hardened Developer ID signed probe
- verified the same libllama.dylib loads when disable-library-validation is embedded
- confirmed the shipped v0.4.6 app fails the new entitlement gate
- re-signed the shipped app with these entitlements; strict deep signature verification and the new gate pass
- cargo test --manifest-path desktop/src-tauri/Cargo.toml --features mesh-llm mesh_llm --lib: 32 passed, 1 hardware-only test ignored
- pre-commit and pre-push hooks passed, including desktop, Rust, Tauri, and mobile tests