### PR TITLE
Add pre-push branch-skew guard and changed-spec e2e recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -224,6 +224,11 @@ desktop-e2e-smoke:
 desktop-e2e-integration: _ensure-migrations
     cd {{desktop_dir}} && pnpm test:e2e:integration
 
+# Run only the e2e specs changed vs origin/main (both projects) before pushing
+desktop-e2e-pre-push: _ensure-migrations
+    git fetch origin main
+    cd {{desktop_dir}} && pnpm build && pnpm exec playwright test --only-changed=origin/main
+
 # Run all checks suitable for CI / pre-push (no infra needed)
 ci: check test-unit desktop-test desktop-build desktop-tauri-check desktop-tauri-test web-build mobile-test
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,8 @@ pre-commit:
 pre-push:
   parallel: true
   commands:
+    branch-skew:
+      run: ./scripts/check-branch-skew.sh
     rust-tests:
       run: just test-unit
     desktop-check:

--- a/scripts/check-branch-skew.sh
+++ b/scripts/check-branch-skew.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Pre-push guard: CI checks the PR merged with main, so local runs on a
+# skewed branch can pass while CI fails. Block the push only when
+# origin/main has changed files this branch also touches.
+set -euo pipefail
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" = "main" ] || [ "$branch" = "HEAD" ]; then
+  exit 0
+fi
+
+git fetch --quiet origin main || true
+git rev-parse --verify --quiet origin/main >/dev/null || exit 0
+
+base=$(git merge-base HEAD origin/main)
+if [ "$base" = "$(git rev-parse origin/main)" ]; then
+  exit 0
+fi
+
+overlap=$(comm -12 \
+  <(git diff --name-only "$base" origin/main -- | sort) \
+  <(git diff --name-only "$base" HEAD -- | sort))
+
+if [ -z "$overlap" ]; then
+  exit 0
+fi
+
+{
+  echo "Branch is behind origin/main, and main changed files this branch also touches:"
+  echo "$overlap" | sed 's/^/  /'
+  echo "Local checks ran on a tree CI will never test. Run 'git merge origin/main',"
+  echo "resolve, re-run checks, then push."
+} >&2
+exit 1


### PR DESCRIPTION
## Why

PR #1936 burned multiple CI round-trips on failures that were catchable locally:

1. **Merge skew** — CI lints/tests the PR *merged with main*. A branch behind main passed local `desktop-check` honestly, then failed CI on a duplicate `case` label main had grown in the same file.
2. **Project mismatch** — only the smoke Playwright project was run locally; the touched `onboarding.spec.ts` lives in the *integration* project, so 16 stale assertions reached CI unseen.

## What

- **`scripts/check-branch-skew.sh`** wired into lefthook `pre-push`: fails only when `origin/main` has changed files the branch also touched since diverging, with instructions to merge main and re-run checks. Silent and ~1s when up to date or when the skew doesn't overlap — no slowdown on the common path.
- **`just desktop-e2e-pre-push`**: builds and runs only the Playwright specs changed vs `origin/main` via `--only-changed`, selecting across both smoke and integration projects by file (so a project mismatch can't produce a vacuous green). Verified locally: selects the 37 onboarding tests when that spec is touched, 0 tests on a clean tree.

## Verification

- Guard: exit 0 up-to-date; exit 1 with file list on real overlap (repro'd against a main-side change); exit 0 on non-overlapping skew.
- The guard ran live in this branch's own pre-push (1.5s, pass).
- `just --summary` parses; `--only-changed` selection verified in both directions.

`--only-changed` keys off spec/helper file changes, not app source — full CI remains the backstop for untouched specs.
