### PR TITLE
ci: build the relay once and cache it by source hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,20 +283,44 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
+      # Reuse the compiled relay when no input that reaches the binary changed
+      # (desktop-only PRs hit this every time). Key must cover everything the
+      # binary embeds: crates/** plus migrations/** (sqlx migrate! in buzz-db).
+      - name: Restore relay binary cache
+        id: relay-bin-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            target/ci/buzz-relay
+            target/ci/git-credential-nostr
+          key: relay-bin-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+        if: steps.relay-bin-cache.outputs.cache-hit != 'true'
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: steps.relay-bin-cache.outputs.cache-hit != 'true'
         with:
           workspaces: |
             .
             desktop/src-tauri
           save-if: ${{ github.event_name != 'pull_request' }}
       - name: Build relay
-        run: cargo build --profile ci -p buzz-relay
+        if: steps.relay-bin-cache.outputs.cache-hit != 'true'
+        run: cargo build --profile ci -p buzz-relay -p git-credential-nostr
+      - name: Save relay binary cache
+        if: steps.relay-bin-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            target/ci/buzz-relay
+            target/ci/git-credential-nostr
+          key: relay-bin-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
       - name: Upload relay binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: desktop-e2e-relay
-          path: target/ci/buzz-relay
+          path: |
+            target/ci/buzz-relay
+            target/ci/git-credential-nostr
           if-no-files-found: error
           retention-days: 1
 
@@ -623,7 +647,7 @@ jobs:
     name: Relay E2E
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [changes]
+    needs: [changes, desktop-e2e-relay]
     if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
     permissions:
       contents: read
@@ -633,8 +657,17 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.event_name != 'pull_request' }}
+      # Reuse the relay + git-credential-nostr built by Desktop E2E Relay
+      # instead of compiling them a second time.
+      - name: Download relay binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: desktop-e2e-relay
+          path: target/ci
       - name: Start relay
-        run: ./scripts/start-relay-for-tests.sh
+        run: |
+          chmod +x ./target/ci/buzz-relay ./target/ci/git-credential-nostr
+          ./scripts/start-relay-for-tests.sh --no-build
       - name: Relay E2E tests
         run: cargo test -p buzz-test-client --test e2e_persona --test e2e_nostr_interop -- --ignored --nocapture
         env:

--- a/scripts/start-relay-for-tests.sh
+++ b/scripts/start-relay-for-tests.sh
@@ -7,10 +7,11 @@
 # and polls readiness.
 #
 # Usage:
-#   ./scripts/start-relay-for-tests.sh [--profile <cargo-profile>]
+#   ./scripts/start-relay-for-tests.sh [--profile <cargo-profile>] [--no-build]
 #
 # Options:
 #   --profile <profile>   Cargo build profile (default: ci)
+#   --no-build            Use existing target/<profile>/ binaries (CI artifact reuse)
 #
 # Exports:
 #   RELAY_URL=ws://localhost:3000
@@ -23,6 +24,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # ── Defaults ──────────────────────────────────────────────────────────────────
 
 CARGO_PROFILE="${CARGO_PROFILE:-ci}"
+SKIP_BUILD=false
 
 # ── Parse args ────────────────────────────────────────────────────────────────
 
@@ -31,6 +33,10 @@ while [[ $# -gt 0 ]]; do
     --profile)
       CARGO_PROFILE="$2"
       shift 2
+      ;;
+    --no-build)
+      SKIP_BUILD=true
+      shift
       ;;
     *)
       echo "Unknown option: $1" >&2
@@ -128,9 +134,19 @@ ok "Community seeded"
 
 # ── Build relay ──────────────────────────────────────────────────────────────
 
-log "Building relay (profile: ${CARGO_PROFILE})..."
-cargo build --profile "${CARGO_PROFILE}" -p buzz-relay -p git-credential-nostr
-ok "Relay built"
+if [[ "${SKIP_BUILD}" == "true" ]]; then
+  for bin in buzz-relay git-credential-nostr; do
+    if [[ ! -x "./target/${CARGO_PROFILE}/${bin}" ]]; then
+      err "--no-build: ./target/${CARGO_PROFILE}/${bin} missing or not executable"
+      exit 1
+    fi
+  done
+  log "Skipping relay build (--no-build); using existing target/${CARGO_PROFILE}/ binaries"
+else
+  log "Building relay (profile: ${CARGO_PROFILE})..."
+  cargo build --profile "${CARGO_PROFILE}" -p buzz-relay -p git-credential-nostr
+  ok "Relay built"
+fi
 
 # ── Start relay ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

CI wall-clock regularly exceeds 20 minutes (e.g. #1936 hit 27 min). Per-job timing on recent runs shows the critical path is one serial chain:

```
Desktop E2E Relay (8.2–8.9 min, full buzz-relay compile)
  → Desktop E2E Integration shards (5–6 min green; up to 17.7 min with retries)
```

Two root causes:

1. **`Desktop E2E Relay` recompiles buzz-relay from scratch on every run** — even desktop-only PRs that touch zero Rust — because `Swatinem/rust-cache` caches dependencies but deliberately prunes workspace-crate artifacts. Both integration shards wait serially behind the build.
2. **`Relay E2E` compiles the same binaries a second time** inside `start-relay-for-tests.sh` (~9 min of duplicated runner time for ~1 min of tests).

## Change

- **Cache the built binaries** (`target/ci/{buzz-relay,git-credential-nostr}`) with `actions/cache`, keyed on the hash of everything that reaches them: `crates/**`, `migrations/**` (embedded via `sqlx::migrate!` in buzz-db), `Cargo.toml`/`Cargo.lock`, `rust-toolchain.toml`, `.cargo/config.toml`, and the workflow itself. On a hit the build (and mold/rust-cache setup) is skipped entirely.
- **`Relay E2E` now depends on `Desktop E2E Relay`** and downloads the `desktop-e2e-relay` artifact instead of rebuilding. `start-relay-for-tests.sh` gains a `--no-build` flag that verifies the binaries exist and skips `cargo build`; local usage without the flag is unchanged.
- The artifact now also carries `git-credential-nostr`, which Relay E2E's nostr-interop tests need (`GIT_CREDENTIAL_NOSTR_BIN`), so `Desktop E2E Relay` builds both (it previously built only `buzz-relay`; the script already built both).

## Safety

- No test behavior changes — the exact same binaries run the exact same suites. On any cache miss (any Rust/migration/toolchain/config change) the build runs exactly as before.
- The cache key is a pure source hash: a stale binary can only be served if *no* input changed, in which case it's identical to what a rebuild would produce.
- `actionlint` clean; `--no-build` guard fails fast with a clear error if binaries are missing.

## Expected impact

| Scenario | Before | After |
|----------|--------|-------|
| Desktop-only PR (e.g. #1936), green | ~15 min | ~7–8 min (relay in seconds) |
| Rust PR, green | ~15 min | ~15 min first run, faster on re-runs of same source |
| Relay E2E runner time | ~10 min | ~2 min |

Follow-up candidates (not in this PR, behavior-affecting): drop Playwright CI `retries: 2 → 1`, workspace-crate caching for Rust PRs, more e2e shards.
