### PR TITLE
feat(desktop): add shared models to Share compute

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -34,6 +34,8 @@ export default defineConfig({
         "**/channel-controls.spec.ts",
         "**/active-turn-resilience.spec.ts",
         "**/profile-active-turn.spec.ts",
+        "**/mesh-compute.spec.ts",
+        "**/mesh-compute-screenshots.spec.ts",
         "**/config-bridge-screenshots.spec.ts",
         "**/observer-feed-screenshots.spec.ts",
         "**/core-memory-screenshots.spec.ts",

--- a/desktop/src-tauri/src/mesh_llm/catalog.rs
+++ b/desktop/src-tauri/src/mesh_llm/catalog.rs
@@ -57,6 +57,89 @@ pub struct MeshCatalogEntry {
     pub fit: ModelFit,
     pub installed: bool,
     pub recommended: bool,
+    /// A "shared" model is a layer-package (`meshllm/…-layers`) that is too big
+    /// for any single machine and runs split across several members. When true,
+    /// serving it does nothing until enough members join and host it together;
+    /// mesh-llm then auto-splits it across the group.
+    pub shared: bool,
+    /// For shared models: rough number of members needed to host this model on
+    /// machines like this one. Advisory only — the mesh decides the real split.
+    pub estimated_members: Option<u32>,
+}
+
+/// A curated shared (split) model — a `meshllm/…-layers` layer package that is
+/// too large for a single node and is served split across several members.
+///
+/// These are intentionally hand-picked (not the full ~79-entry generated
+/// catalog) so the Advanced → "Join a shared model" list stays legible: one
+/// solid pick per size tier, from a 2-machine demo up to a genuine
+/// "no single box could ever fit this" showcase. Refs are the canonical
+/// `meshllm/*-layers` HuggingFace repos.
+struct SharedModel {
+    /// Layer-package ref served verbatim (e.g. `meshllm/Qwen3-235B-A22B-UD-Q4_K_XL-layers`).
+    name: &'static str,
+    /// Display size of the full model, e.g. "134GB".
+    size: &'static str,
+    /// One-line human description for the picker row.
+    description: &'static str,
+}
+
+/// Curated shared/split models, smallest → largest. Sizes are the full
+/// (unsplit) model footprint, which is what determines how many members are
+/// needed. `estimated_members` is derived per-machine at build time.
+const SHARED_MODELS: &[SharedModel] = &[
+    SharedModel {
+        name: "meshllm/Qwen3-8B-Q4_K_M-layers",
+        size: "5.0GB",
+        description: "Small demo split — runs across two machines. Good for trying shared compute.",
+    },
+    SharedModel {
+        name: "meshllm/Qwen3-32B-UD-Q4_K_XL-layers",
+        size: "20GB",
+        description: "Mid-size model split across a few members.",
+    },
+    SharedModel {
+        name: "meshllm/Llama-3.3-70B-Instruct-Q3_K_M-layers",
+        size: "34GB",
+        description: "70B-class general model, hosted by the group.",
+    },
+    SharedModel {
+        name: "meshllm/gpt-oss-120b-UD-Q4_K_XL-layers",
+        size: "65GB",
+        description: "120B open model — needs several members together.",
+    },
+    SharedModel {
+        name: "meshllm/Qwen3-235B-A22B-UD-Q4_K_XL-layers",
+        size: "134GB",
+        description: "Large 235B model. Too big for one machine — the group hosts it.",
+    },
+    SharedModel {
+        name: "meshllm/Qwen3-Coder-480B-A35B-Instruct-UD-Q4_K_XL-layers",
+        size: "294GB",
+        description: "480B coding model. A serious group effort across many members.",
+    },
+    SharedModel {
+        name: "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers",
+        size: "382GB",
+        description: "Frontier 671B-class model. Hosted only by a large group together.",
+    },
+];
+
+/// Estimate how many members like this machine are needed to host `model_gb`,
+/// leaving realistic per-node headroom. Conservative: assumes each member
+/// contributes at most ~80% of usable AI memory to its slice, and always
+/// needs at least two participants to form a split. `None` when hardware
+/// capacity is unknown.
+fn estimate_members(model_gb: f64, vram_gb: f64) -> Option<u32> {
+    if vram_gb <= 0.0 {
+        return None;
+    }
+    let per_node = vram_gb * 0.8;
+    if per_node <= 0.0 {
+        return Some(2);
+    }
+    let needed = (model_gb / per_node).ceil() as u32;
+    Some(needed.max(2))
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -70,7 +153,11 @@ pub struct MeshModelCatalog {
     /// Best-fit catalog name for this hardware, if any.
     pub recommended: Option<String>,
     /// Ranked: recommended first, then by fit, then larger first within a fit.
+    /// These are single-machine ("solo") models.
     pub entries: Vec<MeshCatalogEntry>,
+    /// Curated shared/split models (`meshllm/…-layers`), smallest → largest.
+    /// Each is too big for one machine and runs split across several members.
+    pub shared: Vec<MeshCatalogEntry>,
 }
 
 /// Survey hardware and rank the curated catalog for this machine.
@@ -127,6 +214,8 @@ fn build_catalog(
                 size: m.size.clone(),
                 size_gb,
                 description: m.description.clone(),
+                shared: false,
+                estimated_members: None,
             }
         })
         .collect();
@@ -143,12 +232,35 @@ fn build_catalog(
             .then(b.size_gb.total_cmp(&a.size_gb))
     });
 
+    // Shared/split models: curated layer packages, presented smallest → largest.
+    // Every one is `fit: TooLarge` for a single node by definition (that is the
+    // whole point) — the "fit" story for these is "how many members", carried by
+    // `estimated_members`, not the solo fit code.
+    let shared: Vec<MeshCatalogEntry> = SHARED_MODELS
+        .iter()
+        .map(|m| {
+            let size_gb = parse_size_gb(m.size);
+            MeshCatalogEntry {
+                fit: ModelFit::TooLarge,
+                installed: false,
+                recommended: false,
+                name: m.name.to_string(),
+                size: m.size.to_string(),
+                size_gb,
+                description: m.description.to_string(),
+                shared: true,
+                estimated_members: estimate_members(size_gb, vram_gb),
+            }
+        })
+        .collect();
+
     MeshModelCatalog {
         gpu_name,
         vram_display: format_rated_capacity(vram_bytes),
         vram_gb,
         recommended,
         entries,
+        shared,
     }
 }
 
@@ -210,6 +322,58 @@ mod tests {
         assert_eq!(
             catalog.recommended,
             auto_model_pack(62.0).into_iter().next()
+        );
+    }
+
+    #[test]
+    fn shared_models_are_present_ranked_and_marked() {
+        let catalog = build_catalog(Some("Test GPU".into()), 24_000_000_000, 24.0, &[]);
+        assert!(
+            !catalog.shared.is_empty(),
+            "curated shared catalog must not be empty"
+        );
+        // Every shared entry is a layer package and flagged shared + TooLarge.
+        for entry in &catalog.shared {
+            assert!(
+                entry.shared,
+                "shared entry must have shared=true: {entry:?}"
+            );
+            assert!(
+                entry.name.contains("-layers"),
+                "shared entry must be a layer package: {}",
+                entry.name
+            );
+            assert_eq!(
+                entry.fit,
+                ModelFit::TooLarge,
+                "shared entries are too large for one node by definition"
+            );
+        }
+        // Presented smallest → largest.
+        let sizes: Vec<f64> = catalog.shared.iter().map(|e| e.size_gb).collect();
+        assert!(
+            sizes.windows(2).all(|w| w[0] <= w[1]),
+            "shared models must be ordered smallest → largest: {sizes:?}"
+        );
+    }
+
+    #[test]
+    fn estimate_members_needs_at_least_two_and_scales_with_size() {
+        // Tiny model on a big machine still needs the two-participant minimum.
+        assert_eq!(estimate_members(5.0, 96.0), Some(2));
+        // A model needing more than one node's ~80% share needs more members.
+        // 134GB / (24 * 0.8 = 19.2) = 6.98 -> 7 members.
+        assert_eq!(estimate_members(134.0, 24.0), Some(7));
+        // Unknown capacity yields no estimate.
+        assert_eq!(estimate_members(134.0, 0.0), None);
+    }
+
+    #[test]
+    fn solo_entries_are_not_shared() {
+        let catalog = build_catalog(None, 96_000_000_000, 96.0, &[]);
+        assert!(
+            catalog.entries.iter().all(|e| !e.shared),
+            "solo catalog entries must never be marked shared"
         );
     }
 

--- a/desktop/src/features/mesh-compute/sharedModel.test.mjs
+++ b/desktop/src/features/mesh-compute/sharedModel.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isSharedModelRef, sharedModelShortName } from "./sharedModel.ts";
+
+/** Minimal catalog fixture with one solo and two shared models. */
+const catalog = {
+  gpuName: "Test GPU",
+  vramDisplay: "24 GB",
+  vramGb: 24,
+  recommended: "Qwen3-8B-Q4_K_M",
+  entries: [
+    {
+      name: "Qwen3-8B-Q4_K_M",
+      size: "5.0GB",
+      sizeGb: 5,
+      description: "",
+      fit: "comfortable",
+      installed: false,
+      recommended: true,
+      shared: false,
+      estimatedMembers: null,
+    },
+  ],
+  shared: [
+    {
+      name: "meshllm/Qwen3-8B-Q4_K_M-layers",
+      size: "5.0GB",
+      sizeGb: 5,
+      description: "",
+      fit: "too_large",
+      installed: false,
+      recommended: false,
+      shared: true,
+      estimatedMembers: 2,
+    },
+    {
+      name: "meshllm/Qwen3-235B-A22B-UD-Q4_K_XL-layers",
+      size: "134GB",
+      sizeGb: 134,
+      description: "",
+      fit: "too_large",
+      installed: false,
+      recommended: false,
+      shared: true,
+      estimatedMembers: 7,
+    },
+  ],
+};
+
+test("isSharedModelRef: matches a shared model by exact name", () => {
+  assert.equal(
+    isSharedModelRef("meshllm/Qwen3-235B-A22B-UD-Q4_K_XL-layers", catalog),
+    true,
+  );
+});
+
+test("isSharedModelRef: trims whitespace before matching", () => {
+  assert.equal(
+    isSharedModelRef("  meshllm/Qwen3-8B-Q4_K_M-layers  ", catalog),
+    true,
+  );
+});
+
+test("isSharedModelRef: a solo model is not shared", () => {
+  assert.equal(isSharedModelRef("Qwen3-8B-Q4_K_M", catalog), false);
+});
+
+test("isSharedModelRef: unknown ref is not shared", () => {
+  assert.equal(isSharedModelRef("some/other-model", catalog), false);
+});
+
+test("isSharedModelRef: empty ref is not shared", () => {
+  assert.equal(isSharedModelRef("", catalog), false);
+  assert.equal(isSharedModelRef("   ", catalog), false);
+});
+
+test("isSharedModelRef: null catalog is not shared", () => {
+  assert.equal(isSharedModelRef("meshllm/Qwen3-8B-Q4_K_M-layers", null), false);
+});
+
+test("sharedModelShortName: strips meshllm/ prefix and -layers suffix", () => {
+  assert.equal(
+    sharedModelShortName("meshllm/Qwen3-235B-A22B-UD-Q4_K_XL-layers"),
+    "Qwen3-235B-A22B-UD-Q4_K_XL",
+  );
+});
+
+test("sharedModelShortName: leaves a plain name unchanged", () => {
+  assert.equal(sharedModelShortName("Qwen3-8B-Q4_K_M"), "Qwen3-8B-Q4_K_M");
+});

--- a/desktop/src/features/mesh-compute/sharedModel.ts
+++ b/desktop/src/features/mesh-compute/sharedModel.ts
@@ -1,0 +1,30 @@
+import type { MeshModelCatalog } from "@/shared/api/tauriMesh";
+
+/**
+ * Is `ref` one of the curated shared/split models?
+ *
+ * Shared models are layer-packages (`meshllm/…-layers`) that are too big for
+ * one machine and run split across several members. Serving one does nothing
+ * until enough members join; the mesh then auto-splits it across the group.
+ *
+ * Detection is an exact-name match against the catalog's `shared` list — that
+ * is what drives the cohort-aware status copy ("waiting for members" vs a
+ * plain solo "starting").
+ */
+export function isSharedModelRef(
+  ref: string,
+  catalog: MeshModelCatalog | null,
+): boolean {
+  if (!catalog) return false;
+  const trimmed = ref.trim();
+  if (trimmed.length === 0) return false;
+  return catalog.shared.some((m) => m.name === trimmed);
+}
+
+/**
+ * Short, human display name for a shared layer-package ref, e.g.
+ * `meshllm/Qwen3-235B-A22B-UD-Q4_K_XL-layers` → `Qwen3-235B-A22B-UD-Q4_K_XL`.
+ */
+export function sharedModelShortName(ref: string): string {
+  return ref.replace(/^meshllm\//, "").replace(/-layers$/, "");
+}

--- a/desktop/src/features/mesh-compute/ui/MeshComputeSettingsCard.tsx
+++ b/desktop/src/features/mesh-compute/ui/MeshComputeSettingsCard.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ChevronDown, Cpu } from "lucide-react";
+import { ChevronDown, Cpu, Users } from "lucide-react";
 
 import { Input } from "@/shared/ui/input";
 import { Switch } from "@/shared/ui/switch";
@@ -23,6 +23,7 @@ import {
 } from "@/features/settings/ui/SettingsOptionGroup";
 import { SettingsSectionHeader } from "@/features/settings/ui/SettingsSectionHeader";
 import { classifyModelRef } from "../classifyModelRef";
+import { isSharedModelRef, sharedModelShortName } from "../sharedModel";
 import {
   downloadPercent,
   formatDownloadBytes,
@@ -56,9 +57,13 @@ function writeDraft(key: string, value: string): void {
 /**
  * Settings → Compute → Share compute.
  *
- * One toggle, one model field, an "Already installed" picklist, an Advanced
- * group. User-facing copy describes the shared-compute behavior without
- * exposing implementation protocols or raw mesh controls.
+ * A "Recommended" solo picker (models that fit this machine) plus an
+ * "Advanced" group that adds a free-text model field, the installed picklist,
+ * a VRAM cap, and a "Join a shared model" section. Shared models are curated
+ * `meshllm/…-layers` layer-packages that are too big for one machine — serving
+ * one does nothing until enough members join, then the mesh auto-splits it
+ * across the group. All copy describes behavior without exposing raw mesh
+ * protocol controls.
  */
 export function MeshComputeSettingsCard() {
   const { status, error, refresh } = useMeshNodeStatus();
@@ -137,6 +142,12 @@ export function MeshComputeSettingsCard() {
     refClass.kind !== "unknown" &&
     !actionInFlight &&
     status?.state !== "starting";
+  const selectedIsShared = isSharedModelRef(modelInput, catalog);
+
+  const pick = React.useCallback((name: string) => {
+    setModelInput(name);
+    writeDraft(MODEL_DRAFT_STORAGE_KEY, name);
+  }, []);
 
   async function handleToggle(next: boolean) {
     setActionError(null);
@@ -166,6 +177,9 @@ export function MeshComputeSettingsCard() {
       resetDownloadProgress();
     }
   }
+
+  const soloEntries = catalog?.entries ?? [];
+  const sharedEntries = catalog?.shared ?? [];
 
   return (
     <section className="min-w-0" data-testid="settings-mesh-share-compute">
@@ -202,7 +216,11 @@ export function MeshComputeSettingsCard() {
             >
               Share this machine
             </label>
-            <StatusLine pendingAction={pendingAction} status={status} />
+            <StatusLine
+              isSharedModel={selectedIsShared}
+              pendingAction={pendingAction}
+              status={status}
+            />
           </div>
           <Switch
             checked={isOn}
@@ -213,70 +231,28 @@ export function MeshComputeSettingsCard() {
           />
         </SettingsOptionRow>
 
+        {/* Recommended: solo models that fit this machine. This is the common
+            path — pick one and share. */}
         <div className="px-4 pb-4 pt-5">
           <label
             className="mb-3 flex items-center gap-2 text-sm font-medium"
             htmlFor="mesh-share-compute-model"
           >
             <Cpu className="h-4 w-4 text-muted-foreground" />
-            Model
+            Recommended model
           </label>
-          <div className="flex flex-col gap-2">
-            <Input
-              data-testid="mesh-share-compute-model"
+          {catalog && soloEntries.length > 0 ? (
+            <CatalogPicker
+              catalog={catalog}
               disabled={controlsDisabled}
-              id="mesh-share-compute-model"
-              onChange={(e) => {
-                const next = e.target.value;
-                setModelInput(next);
-                writeDraft(MODEL_DRAFT_STORAGE_KEY, next);
-              }}
-              placeholder="Qwen3-8B-Q4_K_M or hf://meshllm/qwen3-8b@main"
-              value={modelInput}
+              onPick={pick}
+              selected={modelInput.trim()}
             />
+          ) : (
             <p className="text-sm font-normal text-muted-foreground">
-              Choose a suggested model below, or enter a model reference or
-              local file. Buzz downloads remote models when sharing starts.
+              Open Advanced to enter a model reference to share.
             </p>
-            {catalog && catalog.entries.length > 0 ? (
-              <CatalogPicker
-                catalog={catalog}
-                disabled={controlsDisabled}
-                onPick={(name) => {
-                  setModelInput(name);
-                  writeDraft(MODEL_DRAFT_STORAGE_KEY, name);
-                }}
-                selected={modelInput.trim()}
-              />
-            ) : null}
-            {installedModels.length > 0 ? (
-              <div className="mt-1">
-                <p className="text-sm font-normal text-muted-foreground">
-                  Already installed on this machine:
-                </p>
-                <ul
-                  className="mt-1 flex flex-wrap gap-1.5"
-                  data-testid="mesh-share-compute-installed-list"
-                >
-                  {installedModels.map((m) => (
-                    <li key={m.id}>
-                      <button
-                        className="rounded border border-border/60 bg-muted/20 px-2 py-0.5 text-sm hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-50"
-                        disabled={controlsDisabled}
-                        onClick={() => {
-                          setModelInput(m.id);
-                          writeDraft(MODEL_DRAFT_STORAGE_KEY, m.id);
-                        }}
-                        type="button"
-                      >
-                        {m.name ?? m.id}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-          </div>
+          )}
         </div>
 
         <details
@@ -295,35 +271,100 @@ export function MeshComputeSettingsCard() {
             />
             Advanced
           </summary>
-          <div className="mt-3 flex flex-col gap-2">
-            <label className="text-sm font-medium" htmlFor="mesh-vram">
-              Max VRAM (GB)
-            </label>
-            <Input
-              data-testid="mesh-share-compute-vram"
-              id="mesh-vram"
-              inputMode="decimal"
-              onChange={(e) => {
-                const next = e.target.value;
-                setMaxVramGb(next);
-                writeDraft(MAX_VRAM_DRAFT_STORAGE_KEY, next);
-              }}
-              placeholder="No limit"
-              value={maxVramGb}
-            />
-            {status?.consoleUrl ? (
+
+          <div className="mt-3 flex flex-col gap-5">
+            {/* Serve a specific model solo (free text + installed picklist). */}
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium" htmlFor="mesh-model-input">
+                Serve a model solo
+              </label>
+              <Input
+                data-testid="mesh-share-compute-model"
+                disabled={controlsDisabled}
+                id="mesh-model-input"
+                onChange={(e) => {
+                  const next = e.target.value;
+                  setModelInput(next);
+                  writeDraft(MODEL_DRAFT_STORAGE_KEY, next);
+                }}
+                placeholder="Qwen3-8B-Q4_K_M or hf://meshllm/qwen3-8b@main"
+                value={modelInput}
+              />
               <p className="text-sm font-normal text-muted-foreground">
-                Debug console:{" "}
-                <a
-                  className="underline"
-                  href={status.consoleUrl}
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  {status.consoleUrl}
-                </a>
+                Enter a model reference or local file. Buzz downloads remote
+                models when sharing starts.
               </p>
+              {installedModels.length > 0 ? (
+                <div className="mt-1">
+                  <p className="text-sm font-normal text-muted-foreground">
+                    Already installed on this machine:
+                  </p>
+                  <ul
+                    className="mt-1 flex flex-wrap gap-1.5"
+                    data-testid="mesh-share-compute-installed-list"
+                  >
+                    {installedModels.map((m) => (
+                      <li key={m.id}>
+                        <button
+                          className="rounded border border-border/60 bg-muted/20 px-2 py-0.5 text-sm hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-50"
+                          disabled={controlsDisabled}
+                          onClick={() => pick(m.id)}
+                          type="button"
+                        >
+                          {m.name ?? m.id}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </div>
+
+            {/* Join a shared model: layer-packages too big for one machine. */}
+            {catalog && sharedEntries.length > 0 ? (
+              <SharedModelPicker
+                catalog={catalog}
+                disabled={controlsDisabled}
+                onPick={pick}
+                selected={modelInput.trim()}
+              />
             ) : null}
+
+            {/* VRAM cap. */}
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium" htmlFor="mesh-vram">
+                Max VRAM (GB)
+              </label>
+              <Input
+                data-testid="mesh-share-compute-vram"
+                id="mesh-vram"
+                inputMode="decimal"
+                onChange={(e) => {
+                  const next = e.target.value;
+                  setMaxVramGb(next);
+                  writeDraft(MAX_VRAM_DRAFT_STORAGE_KEY, next);
+                }}
+                placeholder="No limit"
+                value={maxVramGb}
+              />
+              <p className="text-sm font-normal text-muted-foreground">
+                Limit how much of this machine's memory to contribute. For
+                shared models, a lower limit means you host a smaller slice.
+              </p>
+              {status?.consoleUrl ? (
+                <p className="text-sm font-normal text-muted-foreground">
+                  Debug console:{" "}
+                  <a
+                    className="underline"
+                    href={status.consoleUrl}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {status.consoleUrl}
+                  </a>
+                </p>
+              ) : null}
+            </div>
           </div>
         </details>
       </SettingsOptionGroup>
@@ -335,11 +376,6 @@ export function MeshComputeSettingsCard() {
   );
 }
 
-/**
- * Renders the lifecycle/health text under the toggle. Maps Max's `state` ×
- * `health` matrix to honest copy — no "starting…" stuck forever when mesh
- * is actually downloading weights or has failed.
- */
 /**
  * Live model-download progress: name, bytes, percent bar. Rendered above the
  * option group while the backend streams mesh-download-progress events —
@@ -399,9 +435,10 @@ const FIT_CLASS: Record<MeshCatalogEntry["fit"], string> = {
 };
 
 /**
- * Hardware-ranked curated model list (mesh-console's diagnose pattern).
+ * Hardware-ranked curated solo model list (mesh-console's diagnose pattern).
  * Click a row to fill the model field. Models too large for this machine are
- * listed but disabled — honest about why, instead of hiding them.
+ * listed but disabled — honest about why (and directs to the shared section
+ * for models that genuinely can't run on one box).
  */
 function CatalogPicker({
   catalog,
@@ -483,10 +520,85 @@ function CatalogPicker({
   );
 }
 
+/**
+ * Shared/split model picker. These are curated `meshllm/…-layers` packages
+ * that are too big for one machine and run split across several members.
+ * Unlike the solo picker, "too large" is expected — the fit story here is
+ * "how many members", and the honest cost is speed.
+ */
+function SharedModelPicker({
+  catalog,
+  disabled,
+  onPick,
+  selected,
+}: {
+  catalog: MeshModelCatalog;
+  disabled: boolean;
+  onPick: (name: string) => void;
+  selected: string;
+}) {
+  return (
+    <div className="flex flex-col gap-2" data-testid="mesh-shared-model-picker">
+      <p className="flex items-center gap-2 text-sm font-medium">
+        <Users className="h-4 w-4 text-muted-foreground" />
+        Join a shared model
+      </p>
+      <p className="text-sm font-normal text-muted-foreground">
+        These models are too big for one machine. Buzz runs them split across
+        members who host them together — sharing starts once enough members
+        join. They run slower than a single-machine model: the group trades
+        speed for size.
+      </p>
+      <ul className="mt-1 flex flex-col gap-1">
+        {catalog.shared.map((entry) => {
+          const isSelected = entry.name === selected;
+          return (
+            <li key={entry.name}>
+              <button
+                className={cn(
+                  "flex w-full flex-col gap-0.5 rounded border px-2 py-1.5 text-left",
+                  isSelected
+                    ? "border-primary/60 bg-primary/10"
+                    : "border-border/60 bg-muted/20 hover:bg-muted/40",
+                  "disabled:cursor-not-allowed disabled:opacity-50",
+                )}
+                data-testid={`mesh-shared-${entry.name}`}
+                disabled={disabled}
+                onClick={() => onPick(entry.name)}
+                title={entry.description}
+                type="button"
+              >
+                <span className="flex items-baseline gap-2 text-sm">
+                  <span className="min-w-0 truncate font-medium">
+                    {sharedModelShortName(entry.name)}
+                  </span>
+                  <span className="shrink-0 text-muted-foreground">
+                    {entry.size}
+                  </span>
+                  {entry.estimatedMembers != null ? (
+                    <span className="shrink-0 rounded bg-primary/15 px-1.5 text-2xs font-medium text-primary">
+                      ~{entry.estimatedMembers} members
+                    </span>
+                  ) : null}
+                </span>
+                <span className="text-2xs font-normal text-muted-foreground">
+                  {entry.description}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 function StatusLine({
+  isSharedModel,
   pendingAction,
   status,
 }: {
+  isSharedModel: boolean;
   pendingAction: "start" | "stop" | null;
   status: MeshNodeStatus | null;
 }) {
@@ -508,11 +620,21 @@ function StatusLine({
     );
   }
   if (state === "starting") {
-    const reason =
-      health.status === "degraded" || health.status === "failed"
-        ? health.reason
-        : "Starting…";
-    return <p className="text-sm text-muted-foreground">{reason}</p>;
+    if (health.status === "degraded" || health.status === "failed") {
+      return <p className="text-sm text-muted-foreground">{health.reason}</p>;
+    }
+    // Shared models spend "starting" waiting for a quorum of members to join
+    // before the mesh can split and serve. Say so plainly instead of a
+    // solo-flavored "Starting…" that looks stuck. (Coarse by design: we don't
+    // yet have a member count from the SDK — just "needs more members".)
+    if (isSharedModel) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          Waiting for more members to join before this shared model can run.
+        </p>
+      );
+    }
+    return <p className="text-sm text-muted-foreground">Starting…</p>;
   }
   if (state === "running") {
     if (health.status === "failed") {
@@ -526,6 +648,14 @@ function StatusLine({
       return (
         <p className="text-sm text-amber-600 dark:text-amber-400">
           Active{modelLabel ? ` — ${modelLabel}` : ""}. {health.reason}
+        </p>
+      );
+    }
+    if (isSharedModel) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          Running{modelLabel ? ` ${modelLabel}` : ""} with the group. You're
+          hosting part of it.
         </p>
       );
     }

--- a/desktop/src/shared/api/tauriMesh.ts
+++ b/desktop/src/shared/api/tauriMesh.ts
@@ -68,6 +68,17 @@ export type MeshCatalogEntry = {
   fit: MeshModelFit;
   installed: boolean;
   recommended: boolean;
+  /**
+   * A "shared" model is a layer-package (`meshllm/…-layers`) too big for one
+   * machine. Serving it does nothing until enough members join and host it
+   * together; the mesh then auto-splits it across the group.
+   */
+  shared: boolean;
+  /**
+   * For shared models: rough number of members like this machine needed to
+   * host the model together. Advisory — the mesh decides the real split.
+   */
+  estimatedMembers: number | null;
 };
 
 export type MeshModelCatalog = {
@@ -75,8 +86,16 @@ export type MeshModelCatalog = {
   vramDisplay: string;
   vramGb: number;
   recommended: string | null;
-  /** Ranked: recommended first, then by fit, then larger first within a fit. */
+  /**
+   * Ranked single-machine ("solo") models: recommended first, then by fit,
+   * then larger first within a fit.
+   */
   entries: MeshCatalogEntry[];
+  /**
+   * Curated shared/split models (`meshllm/…-layers`), smallest → largest.
+   * Each is too big for one machine and runs split across several members.
+   */
+  shared: MeshCatalogEntry[];
 };
 
 /**

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -2503,7 +2503,7 @@ const mockMeshState: {
   admitted: boolean;
   models: Array<{ id: string; name: string | null }>;
   denyReason: string;
-  nodeState: "off" | "running";
+  nodeState: "off" | "starting" | "running";
   nodeMode: "serve" | "client" | null;
 } = {
   admitted: true,
@@ -8432,7 +8432,7 @@ export function maybeInstallE2eTauriMocks() {
     injectObserverEventsForE2E(agentPubkey, events);
   };
   const meshNodeStatus = (
-    state: "off" | "running",
+    state: "off" | "starting" | "running",
     mode: "serve" | "client" | null,
   ) => ({
     state,
@@ -8471,9 +8471,15 @@ export function maybeInstallE2eTauriMocks() {
         return meshNodeStatus(mockMeshState.nodeState, mockMeshState.nodeMode);
       case "mesh_start_node": {
         const req = (
-          payload as { request?: { mode?: "serve" | "client" } } | null
+          payload as {
+            request?: { mode?: "serve" | "client"; modelId?: string };
+          } | null
         )?.request;
-        mockMeshState.nodeState = "running";
+        // Shared models (layer packages) hold in "starting" — the mesh is
+        // waiting for enough members to join before it can split and serve.
+        // Solo models go straight to "running".
+        const isSharedModel = (req?.modelId ?? "").includes("-layers");
+        mockMeshState.nodeState = isSharedModel ? "starting" : "running";
         mockMeshState.nodeMode = req?.mode ?? "serve";
         return meshNodeStatus(mockMeshState.nodeState, mockMeshState.nodeMode);
       }
@@ -8481,6 +8487,63 @@ export function maybeInstallE2eTauriMocks() {
         mockMeshState.nodeState = "off";
         mockMeshState.nodeMode = null;
         return meshNodeStatus("off", null);
+      case "mesh_model_catalog":
+        return {
+          gpuName: "Apple M-series",
+          vramDisplay: "24 GB",
+          vramGb: 24,
+          recommended: "Qwen3-8B-Q4_K_M",
+          entries: [
+            {
+              name: "Qwen3-8B-Q4_K_M",
+              size: "5.0GB",
+              sizeGb: 5,
+              description: "Fast general model.",
+              fit: "comfortable",
+              installed: false,
+              recommended: true,
+              shared: false,
+              estimatedMembers: null,
+            },
+            {
+              name: "Qwen3-32B-UD-Q4_K_XL",
+              size: "20GB",
+              sizeGb: 20,
+              description: "Larger general model.",
+              fit: "tight",
+              installed: false,
+              recommended: false,
+              shared: false,
+              estimatedMembers: null,
+            },
+          ],
+          shared: [
+            {
+              name: "meshllm/Qwen3-8B-Q4_K_M-layers",
+              size: "5.0GB",
+              sizeGb: 5,
+              description:
+                "Small demo split — runs across two machines. Good for trying shared compute.",
+              fit: "too_large",
+              installed: false,
+              recommended: false,
+              shared: true,
+              estimatedMembers: 2,
+            },
+            {
+              name: "meshllm/Qwen3-235B-A22B-UD-Q4_K_XL-layers",
+              size: "134GB",
+              sizeGb: 134,
+              description:
+                "Large 235B model. Too big for one machine — the group hosts it.",
+              fit: "too_large",
+              installed: false,
+              recommended: false,
+              shared: true,
+              estimatedMembers: 7,
+            },
+          ],
+        };
       case "get_identity": {
         const isLost =
           !mockIdentityLostCleared && activeConfig?.mock?.identityLost === true;

--- a/desktop/tests/e2e/mesh-compute-screenshots.spec.ts
+++ b/desktop/tests/e2e/mesh-compute-screenshots.spec.ts
@@ -1,0 +1,28 @@
+import { test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
+import { openSettings } from "../helpers/settings";
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+});
+
+test("share-compute recommended + advanced shared models", async ({ page }) => {
+  await page.goto("/");
+  await openSettings(page, "compute");
+
+  const card = page.getByTestId("settings-mesh-share-compute");
+  await card.scrollIntoViewIfNeeded();
+  await waitForAnimations(page);
+  await card.screenshot({
+    path: "test-results/screenshots/01-share-compute-recommended.png",
+  });
+
+  // Expand Advanced to reveal the "Join a shared model" section.
+  await card.getByText("Advanced").click();
+  await waitForAnimations(page);
+  await card.screenshot({
+    path: "test-results/screenshots/02-share-compute-advanced-shared.png",
+  });
+});

--- a/desktop/tests/e2e/mesh-compute.spec.ts
+++ b/desktop/tests/e2e/mesh-compute.spec.ts
@@ -19,14 +19,14 @@ test("Share compute has a clear empty state and starts and stops sharing", async
 
   const card = page.getByTestId("settings-mesh-share-compute");
   const toggle = page.getByTestId("mesh-share-compute-toggle");
-  const model = page.getByTestId("mesh-share-compute-model");
 
   await expect(card).toContainText("Not sharing right now");
-  await expect(card).toContainText(
-    "Choose a suggested model below, or enter a model reference or local file",
-  );
+  await expect(card).toContainText("Recommended model");
   await expect(toggle).toBeDisabled();
 
+  // The free-text model field lives under Advanced now.
+  await card.getByText("Advanced").click();
+  const model = page.getByTestId("mesh-share-compute-model");
   await model.fill("hf://demo/SmolLM2-135M-Instruct-GGUF:Q4_K_M");
   await expect(card).toContainText(
     "Buzz downloads remote models when sharing starts",
@@ -50,4 +50,34 @@ test("Share compute has a clear empty state and starts and stops sharing", async
       page.evaluate(() => (window as E2eWindow).__BUZZ_E2E_COMMANDS__ ?? []),
     )
     .toContain("mesh_stop_node");
+});
+
+test("Advanced offers shared models and shows a waiting-for-members state", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await openSettings(page, "compute");
+
+  const card = page.getByTestId("settings-mesh-share-compute");
+  const toggle = page.getByTestId("mesh-share-compute-toggle");
+
+  await card.getByText("Advanced").click();
+
+  // The shared-model picker lists layer packages with a member estimate and an
+  // honest slower-than-solo warning.
+  const sharedPicker = page.getByTestId("mesh-shared-model-picker");
+  await expect(sharedPicker).toContainText("Join a shared model");
+  await expect(sharedPicker).toContainText("the group trades speed for size");
+  await expect(sharedPicker).toContainText("~7 members");
+
+  // Selecting a shared model and starting shows the cohort waiting state
+  // instead of a plain solo "Starting…".
+  await page
+    .getByTestId("mesh-shared-meshllm/Qwen3-235B-A22B-UD-Q4_K_XL-layers")
+    .click();
+  await toggle.click();
+  await expect(toggle).toBeChecked();
+  await expect(card).toContainText(
+    "Waiting for more members to join before this shared model can run",
+  );
 });

--- a/docs/mesh-share-compute-shared-models.md
+++ b/docs/mesh-share-compute-shared-models.md
@@ -1,0 +1,108 @@
+# Share compute: recommended solo models + shared (split) models
+
+This adds a **shared model** path to Settings → Compute → **Share compute**,
+alongside the existing solo-serving flow, and restructures the card into a
+**Recommended** section (the common path) and an **Advanced** section (power
+users + shared models).
+
+## Why
+
+Today Share compute only serves *whole* models that fit on one machine. But
+mesh-llm can run a single model **split across several members** ("Skippy
+splits" / staged layer-range distributed inference), which is the only way to
+host models too large for any single box (Qwen3-235B, DeepSeek-V3.2, …).
+
+The mesh runtime already does the hard part:
+
+- **Implicit split.** When a model doesn't fit locally (fails the
+  `local_capacity < model_bytes × 1.10` check), the runtime chooses the split
+  path automatically — no explicit flag needed.
+- **Waits for a quorum.** The serve startup loop treats "not enough
+  participants" as a *durable waiting state*, not a failure: it emits
+  "Split waiting for peers" and retries on membership changes until ≥2 eligible
+  members hosting the same model form a quorum, then splits and serves.
+
+So Buzz's job is just to **set the table**: offer splittable models and reflect
+the waiting/running state. The mesh decides whether there's enough capacity and
+does the splitting itself.
+
+## What this PR does
+
+### Recommended (solo) — the common path
+The curated, hardware-ranked solo picker is now the default, front-and-center
+"Recommended model" section. Unchanged behavior: pick a model that fits this
+machine and share it.
+
+### Advanced
+Collapsed by default. Contains:
+
+1. **Serve a model solo** — the free-text model field + "already installed"
+   picklist (moved here from the top).
+2. **Join a shared model** — a curated list of `meshllm/…-layers` layer
+   packages, smallest → largest, each too big for one machine. Rows show size
+   and a rough `~N members` estimate for this hardware, plus an honest
+   up-front warning: *"They run slower than a single-machine model: the group
+   trades speed for size."*
+3. **Max VRAM (GB)** — reframed: for shared models a lower cap means you host a
+   smaller slice.
+
+### Cohort-aware status (coarse, by design)
+The toggle's status line is now shared-model-aware, built entirely on the
+**existing** SDK status (`state` / `health`) — no upstream mesh-llm change:
+
+| State | Solo copy | Shared copy |
+|---|---|---|
+| `starting` | "Starting…" | **"Waiting for more members to join before this shared model can run."** |
+| `running` | "Sharing {model} with relay members." | **"Running {model} with the group. You're hosting part of it."** |
+
+This is deliberately coarse — we can say *"needs more members"* vs *"running"*,
+but not yet *"3 of 4 members"*, because the SDK's `MeshNodeStatus` does not yet
+expose a participant count. That richer "X of N ready" progress is a **future
+enhancement** gated on an upstream mesh-llm status field
+(`WaitingForParticipants { have, need }`); it is intentionally out of scope
+here so the v1 ships on today's SDK.
+
+## How a shared model actually runs (no code changes needed to the SDK)
+
+1. A member picks a `meshllm/…-layers` model in Advanced → Join a shared model.
+2. Buzz calls `mesh_start_node` with that ref (same path as solo).
+3. It's too big to fit locally → the mesh runtime picks the split path.
+4. The node advertises interest and **waits** (status shows "Waiting for more
+   members…").
+5. As other members pick the same model in the same community mesh, capacity
+   accumulates; once ≥2 eligible members are present, the mesh plans the
+   topology, assigns layer ranges, and serves. Status flips to "Running … with
+   the group."
+
+## Scope / honesty notes
+
+- **No mesh-llm changes.** Everything works against the pinned `v0.73.1` SDK.
+- **No forced split.** Buzz relies on *implicit* split (model too large) — it
+  never forces a split of a model that would fit one box (the SDK has no such
+  flag). This matches the "host something too big for one machine" use case.
+- **Curated, not exhaustive.** The shared list is a hand-picked subset (one
+  pick per size tier) for legibility, not the full ~79-entry `meshllm/…-layers`
+  catalog.
+- **Latency is real.** Split models add a network hop per token per stage; the
+  UI warns about this before the user commits.
+
+## Files
+
+- `desktop/src-tauri/src/mesh_llm/catalog.rs` — `SharedModel` list,
+  `estimate_members`, `shared`/`estimated_members` fields, `shared` list on the
+  catalog. New tests.
+- `desktop/src/shared/api/tauriMesh.ts` — `MeshCatalogEntry.shared` /
+  `.estimatedMembers`, `MeshModelCatalog.shared`.
+- `desktop/src/features/mesh-compute/ui/MeshComputeSettingsCard.tsx` —
+  Recommended + Advanced restructure, `SharedModelPicker`, cohort-aware
+  `StatusLine`.
+- `desktop/src/features/mesh-compute/sharedModel.ts` (+ test) — `isSharedModelRef`,
+  `sharedModelShortName`.
+- `desktop/src/testing/e2eBridge.ts` — mock `mesh_model_catalog` (incl. `shared`).
+
+## Tests
+
+- Rust: `mesh_llm::catalog` (7 tests) — shared list present/ordered/flagged,
+  member estimation, solo entries never shared.
+- TS: `sharedModel.test.mjs` (9 tests) — shared detection + short-name.
+- `just ci` gates: biome, tsc, frontend build, rust fmt + clippy — all green.


### PR DESCRIPTION
The idea here is to show curated models, and an advanced section where people can choose to run really large model - then things "wait" until enough members share compute in a buzz server community. 

Then ... magic happens!

not a core functionality change more just making it clearer to buzz consumers what mesh llm can do.

## Summary

- add curated shared/split model choices under **Settings → Compute → Share compute**
- keep the recommended solo model as the default path and put manual, installed, and shared model selection under **Advanced**
- estimate the number of members needed from local AI memory and show a waiting-for-members state for shared models
- use the existing mesh-llm node path and implicit split/quorum behavior; no mesh SDK changes

This carries the single feature commit from `michaelneale/buzz:feat/mesh-share-compute-shared-models` onto current `block/buzz` `main`.

## Behavior and scope

- shared catalog entries use `meshllm/*-layers` model references
- models that are too large for one machine wait for enough relay members and then run split across them
- the UI deliberately reports only coarse waiting/running state because the current SDK does not expose live participant counts
- copy calls out the size-for-speed tradeoff of shared models

The implementation notes and current limitations are in `docs/mesh-share-compute-shared-models.md`.

## Verification

- `just ci` — passed
- `pnpm exec playwright test --project=smoke tests/e2e/mesh-compute.spec.ts tests/e2e/mesh-compute-screenshots.spec.ts` — 3 passed
- recommended and advanced screenshot captures are distinct and visually checked
- pre-push hooks — passed
