### PR TITLE
fix(desktop): sentence-case runtime descriptions in onboarding setup

### DIFF
--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -325,10 +325,14 @@ function RuntimeDetails({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
     runtime.command &&
     runtime.binaryPath
   ) {
+    const description = describeResolvedCommand(
+      runtime.command,
+      runtime.binaryPath,
+    );
     return (
       <>
         <p className="mt-2 text-sm leading-5 text-muted-foreground">
-          {describeResolvedCommand(runtime.command, runtime.binaryPath)}
+          {description.charAt(0).toUpperCase() + description.slice(1)}
         </p>
         {runtime.defaultArgs.length > 0 ? (
           <p className="mt-1 text-xs text-muted-foreground/80">


### PR DESCRIPTION
Before:
<img width="938" height="84" alt="Screenshot 2026-07-16 at 4 24 31 pm" src="https://github.com/user-attachments/assets/b953c81c-b95e-43a4-9afb-754416791d01" />


## Summary

The resolved-command description shown under each runtime in the onboarding setup step (`RuntimeDetails` in `SetupStep.tsx`) was rendered exactly as returned by `describeResolvedCommand`, which starts lowercase. This capitalizes the first character so the description reads as a proper sentence.

## Changes

- `desktop/src/features/onboarding/ui/SetupStep.tsx`: extract the `describeResolvedCommand(...)` result into a local and uppercase its first character before rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)