### PR TITLE
Welcome channel: Browse channels card, browser sorting, shortcut hint placement

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -643,6 +643,7 @@ export function AppShell() {
             markAllChannelsRead,
             markChannelRead,
             markChannelUnread,
+            openBrowseChannels: handleOpenBrowseChannels,
             openCreateChannel: handleOpenCreateChannel,
             openChannelManagement: (channelId?: string) => {
               setManagedChannelId(

--- a/desktop/src/app/AppShellContext.tsx
+++ b/desktop/src/app/AppShellContext.tsx
@@ -15,6 +15,7 @@ type AppShellContextValue = {
     options?: { topLevelOnly?: boolean },
   ) => void;
   markChannelUnread: (channelId: string) => void;
+  openBrowseChannels: () => void;
   openCreateChannel: () => void;
   openChannelManagement: (channelId?: string) => void;
   // NIP-RS read marker for a channel as a unix-seconds timestamp, or null
@@ -56,6 +57,7 @@ const AppShellContext = React.createContext<AppShellContextValue>({
   markAllChannelsRead: () => {},
   markChannelRead: () => {},
   markChannelUnread: () => {},
+  openBrowseChannels: () => {},
   openCreateChannel: () => {},
   openChannelManagement: () => {},
   getChannelReadAt: () => null,

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { ArrowUpDown, Compass, Search, X, type LucideIcon } from "lucide-react";
+import { Compass, Search, X, type LucideIcon } from "lucide-react";
 
 import type { Channel } from "@/shared/api/types";
+import { ListSortAscending } from "@/shared/ui/icons";
 import {
   Dialog,
   DialogClose,
@@ -369,7 +370,7 @@ export function ChannelBrowserDialog({
                   type="button"
                   variant="ghost"
                 >
-                  <ArrowUpDown />
+                  <ListSortAscending />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -1,14 +1,8 @@
 import * as React from "react";
-import {
-  ArrowDownAZ,
-  ArrowDownWideNarrow,
-  Compass,
-  Search,
-  X,
-  type LucideIcon,
-} from "lucide-react";
+import { Compass, Search, X, type LucideIcon } from "lucide-react";
 
 import type { Channel } from "@/shared/api/types";
+import { ListSortAscending } from "@/shared/ui/icons";
 import {
   Dialog,
   DialogClose,
@@ -23,10 +17,23 @@ import {
   MODAL_SEARCH_SHELL_CLASS,
 } from "@/shared/ui/modalSearchStyles";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
 
 const BROWSE_CHANNELS_SHORTCUT_HINT = "\u21E7\u2318O";
 type BrowserTab = "all" | "joined" | "archived";
 type ChannelSort = "alphabetical" | "members";
+
+const CHANNEL_SORT_OPTIONS: { label: string; value: ChannelSort }[] = [
+  { label: "Alphabetical", value: "alphabetical" },
+  { label: "Most members", value: "members" },
+];
 
 function BrowseState({
   icon: Icon,
@@ -351,29 +358,42 @@ export function ChannelBrowserDialog({
             >
               {BROWSE_CHANNELS_SHORTCUT_HINT}
             </span>
-            <Button
-              aria-label={`Sort ${entityLabel}s by ${
-                sort === "alphabetical" ? "most members" : "alphabetical order"
-              }`}
-              aria-pressed={sort === "members"}
-              data-testid="channel-browser-sort"
-              onClick={() => {
-                setSort((current) =>
-                  current === "alphabetical" ? "members" : "alphabetical",
-                );
-                setSelectedIndex(null);
-              }}
-              size="icon-xs"
-              title={sort === "alphabetical" ? "Alphabetical" : "Most members"}
-              type="button"
-              variant="ghost"
-            >
-              {sort === "alphabetical" ? (
-                <ArrowDownAZ />
-              ) : (
-                <ArrowDownWideNarrow />
-              )}
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  aria-label={`Sort ${entityLabel}s: ${
+                    sort === "alphabetical" ? "Alphabetical" : "Most members"
+                  }`}
+                  data-testid="channel-browser-sort"
+                  onClick={(event) => event.preventDefault()}
+                  size="icon-xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <ListSortAscending />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  onValueChange={(value) => {
+                    setSort(value as ChannelSort);
+                    setSelectedIndex(null);
+                  }}
+                  value={sort}
+                >
+                  {CHANNEL_SORT_OPTIONS.map((option) => (
+                    <DropdownMenuRadioItem
+                      data-testid={`channel-browser-sort-${option.value}`}
+                      key={option.value}
+                      value={option.value}
+                    >
+                      {option.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </DialogHeader>
 

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -26,7 +26,6 @@ import {
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 
-const BROWSE_CHANNELS_SHORTCUT_HINT = "\u21E7\u2318O";
 type BrowserTab = "all" | "joined" | "archived";
 type ChannelSort = "alphabetical" | "members";
 
@@ -351,13 +350,6 @@ export function ChannelBrowserDialog({
               type="text"
               value={query}
             />
-            <span
-              className={`hidden shrink-0 text-xs text-muted-foreground/50 transition-opacity duration-150 ease-out group-focus-within/search:opacity-0 sm:block ${
-                query.length > 0 ? "opacity-0" : "opacity-100"
-              }`}
-            >
-              {BROWSE_CHANNELS_SHORTCUT_HINT}
-            </span>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Compass, Search, X, type LucideIcon } from "lucide-react";
+import { ArrowUpDown, Compass, Search, X, type LucideIcon } from "lucide-react";
 
 import type { Channel } from "@/shared/api/types";
 import {
@@ -16,9 +16,23 @@ import {
   MODAL_SEARCH_SHELL_CLASS,
 } from "@/shared/ui/modalSearchStyles";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
 
 const BROWSE_CHANNELS_SHORTCUT_HINT = "\u21E7\u2318O";
 type BrowserTab = "all" | "joined" | "archived";
+type ChannelSort = "alphabetical" | "members";
+
+const CHANNEL_SORT_OPTIONS: { label: string; value: ChannelSort }[] = [
+  { label: "Alphabetical", value: "alphabetical" },
+  { label: "Most members", value: "members" },
+];
 
 function BrowseState({
   icon: Icon,
@@ -61,6 +75,7 @@ export function ChannelBrowserDialog({
 }: ChannelBrowserDialogProps) {
   const [query, setQuery] = React.useState("");
   const [activeTab, setActiveTab] = React.useState<BrowserTab>("all");
+  const [sort, setSort] = React.useState<ChannelSort>("alphabetical");
   const [selectedIndex, setSelectedIndex] = React.useState<number | null>(null);
   const [joiningChannelId, setJoiningChannelId] = React.useState<string | null>(
     null,
@@ -130,13 +145,15 @@ export function ChannelBrowserDialog({
         ? joinedChannels
         : matchingChannels;
 
-  const orderedVisibleChannels = React.useMemo(
-    () => [
-      ...visibleChannels.filter((channel) => !channel.isMember),
-      ...visibleChannels.filter((channel) => channel.isMember),
-    ],
-    [visibleChannels],
-  );
+  const orderedVisibleChannels = React.useMemo(() => {
+    return [...visibleChannels].sort((a, b) => {
+      if (sort === "members" && b.memberCount !== a.memberCount) {
+        return b.memberCount - a.memberCount;
+      }
+
+      return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    });
+  }, [sort, visibleChannels]);
 
   const allTabLabel = isForumMode ? "All forums" : "All channels";
 
@@ -201,6 +218,7 @@ export function ChannelBrowserDialog({
     if (!open) {
       setQuery("");
       setActiveTab("all");
+      setSort("alphabetical");
       setSelectedIndex(null);
       setJoiningChannelId(null);
       return;
@@ -275,10 +293,7 @@ export function ChannelBrowserDialog({
               <span className="sr-only">Close</span>
             </DialogClose>
           </div>
-          <label
-            className={MODAL_SEARCH_SHELL_CLASS}
-            htmlFor="channel-browser-search"
-          >
+          <div className={MODAL_SEARCH_SHELL_CLASS}>
             <Search className="h-4 w-4 shrink-0 text-muted-foreground/55 transition-colors duration-150 ease-out group-hover/search:text-muted-foreground group-focus-within/search:text-foreground" />
             <input
               autoCapitalize="none"
@@ -342,7 +357,43 @@ export function ChannelBrowserDialog({
             >
               {BROWSE_CHANNELS_SHORTCUT_HINT}
             </span>
-          </label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  aria-label={`Sort ${entityLabel}s: ${
+                    sort === "alphabetical" ? "Alphabetical" : "Most members"
+                  }`}
+                  data-testid="channel-browser-sort"
+                  onClick={(event) => event.preventDefault()}
+                  size="icon-xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <ArrowUpDown />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  onValueChange={(value) => {
+                    setSort(value as ChannelSort);
+                    setSelectedIndex(null);
+                  }}
+                  value={sort}
+                >
+                  {CHANNEL_SORT_OPTIONS.map((option) => (
+                    <DropdownMenuRadioItem
+                      data-testid={`channel-browser-sort-${option.value}`}
+                      key={option.value}
+                      value={option.value}
+                    >
+                      {option.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </DialogHeader>
 
         <div className="h-[min(60vh,30rem)] overflow-hidden">

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -294,62 +294,67 @@ export function ChannelBrowserDialog({
             </DialogClose>
           </div>
           <div className={MODAL_SEARCH_SHELL_CLASS}>
-            <Search className="h-4 w-4 shrink-0 text-muted-foreground/55 transition-colors duration-150 ease-out group-hover/search:text-muted-foreground group-focus-within/search:text-foreground" />
-            <input
-              autoCapitalize="none"
-              autoCorrect="off"
-              className={MODAL_SEARCH_INPUT_CLASS}
-              data-testid="channel-browser-search"
-              id="channel-browser-search"
-              onChange={(event) => {
-                setQuery(event.target.value);
-                setSelectedIndex(null);
-              }}
-              onKeyDown={(event) => {
-                if (
-                  event.key === "ArrowDown" &&
-                  orderedVisibleChannels.length > 0
-                ) {
-                  event.preventDefault();
-                  setSelectedIndex((current) =>
-                    current === null
-                      ? 0
-                      : Math.min(
-                          current + 1,
-                          orderedVisibleChannels.length - 1,
-                        ),
-                  );
-                  return;
-                }
+            <label
+              className="flex min-w-0 flex-1 cursor-text items-center gap-3"
+              htmlFor="channel-browser-search"
+            >
+              <Search className="h-4 w-4 shrink-0 text-muted-foreground/55 transition-colors duration-150 ease-out group-hover/search:text-muted-foreground group-focus-within/search:text-foreground" />
+              <input
+                autoCapitalize="none"
+                autoCorrect="off"
+                className={MODAL_SEARCH_INPUT_CLASS}
+                data-testid="channel-browser-search"
+                id="channel-browser-search"
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                  setSelectedIndex(null);
+                }}
+                onKeyDown={(event) => {
+                  if (
+                    event.key === "ArrowDown" &&
+                    orderedVisibleChannels.length > 0
+                  ) {
+                    event.preventDefault();
+                    setSelectedIndex((current) =>
+                      current === null
+                        ? 0
+                        : Math.min(
+                            current + 1,
+                            orderedVisibleChannels.length - 1,
+                          ),
+                    );
+                    return;
+                  }
 
-                if (
-                  event.key === "ArrowUp" &&
-                  orderedVisibleChannels.length > 0
-                ) {
-                  event.preventDefault();
-                  setSelectedIndex((current) =>
-                    current === null
-                      ? orderedVisibleChannels.length - 1
-                      : Math.max(current - 1, 0),
-                  );
-                  return;
-                }
+                  if (
+                    event.key === "ArrowUp" &&
+                    orderedVisibleChannels.length > 0
+                  ) {
+                    event.preventDefault();
+                    setSelectedIndex((current) =>
+                      current === null
+                        ? orderedVisibleChannels.length - 1
+                        : Math.max(current - 1, 0),
+                    );
+                    return;
+                  }
 
-                if (
-                  event.key === "Enter" &&
-                  !event.nativeEvent.isComposing &&
-                  orderedVisibleChannels.length > 0
-                ) {
-                  event.preventDefault();
-                  handleSelect(selectedItem ?? orderedVisibleChannels[0]);
-                }
-              }}
-              placeholder={searchPlaceholder}
-              ref={inputRef}
-              spellCheck={false}
-              type="text"
-              value={query}
-            />
+                  if (
+                    event.key === "Enter" &&
+                    !event.nativeEvent.isComposing &&
+                    orderedVisibleChannels.length > 0
+                  ) {
+                    event.preventDefault();
+                    handleSelect(selectedItem ?? orderedVisibleChannels[0]);
+                  }
+                }}
+                placeholder={searchPlaceholder}
+                ref={inputRef}
+                spellCheck={false}
+                type="text"
+                value={query}
+              />
+            </label>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -357,7 +362,6 @@ export function ChannelBrowserDialog({
                     sort === "alphabetical" ? "Alphabetical" : "Most members"
                   }`}
                   data-testid="channel-browser-sort"
-                  onClick={(event) => event.preventDefault()}
                   size="icon-xs"
                   type="button"
                   variant="ghost"

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -1,8 +1,14 @@
 import * as React from "react";
-import { Compass, Search, X, type LucideIcon } from "lucide-react";
+import {
+  ArrowDownAZ,
+  ArrowDownWideNarrow,
+  Compass,
+  Search,
+  X,
+  type LucideIcon,
+} from "lucide-react";
 
 import type { Channel } from "@/shared/api/types";
-import { ListSortAscending } from "@/shared/ui/icons";
 import {
   Dialog,
   DialogClose,
@@ -17,23 +23,10 @@ import {
   MODAL_SEARCH_SHELL_CLASS,
 } from "@/shared/ui/modalSearchStyles";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/shared/ui/dropdown-menu";
 
 const BROWSE_CHANNELS_SHORTCUT_HINT = "\u21E7\u2318O";
 type BrowserTab = "all" | "joined" | "archived";
 type ChannelSort = "alphabetical" | "members";
-
-const CHANNEL_SORT_OPTIONS: { label: string; value: ChannelSort }[] = [
-  { label: "Alphabetical", value: "alphabetical" },
-  { label: "Most members", value: "members" },
-];
 
 function BrowseState({
   icon: Icon,
@@ -358,42 +351,29 @@ export function ChannelBrowserDialog({
             >
               {BROWSE_CHANNELS_SHORTCUT_HINT}
             </span>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  aria-label={`Sort ${entityLabel}s: ${
-                    sort === "alphabetical" ? "Alphabetical" : "Most members"
-                  }`}
-                  data-testid="channel-browser-sort"
-                  onClick={(event) => event.preventDefault()}
-                  size="icon-xs"
-                  type="button"
-                  variant="ghost"
-                >
-                  <ListSortAscending />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Sort by</DropdownMenuLabel>
-                <DropdownMenuRadioGroup
-                  onValueChange={(value) => {
-                    setSort(value as ChannelSort);
-                    setSelectedIndex(null);
-                  }}
-                  value={sort}
-                >
-                  {CHANNEL_SORT_OPTIONS.map((option) => (
-                    <DropdownMenuRadioItem
-                      data-testid={`channel-browser-sort-${option.value}`}
-                      key={option.value}
-                      value={option.value}
-                    >
-                      {option.label}
-                    </DropdownMenuRadioItem>
-                  ))}
-                </DropdownMenuRadioGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <Button
+              aria-label={`Sort ${entityLabel}s by ${
+                sort === "alphabetical" ? "most members" : "alphabetical order"
+              }`}
+              aria-pressed={sort === "members"}
+              data-testid="channel-browser-sort"
+              onClick={() => {
+                setSort((current) =>
+                  current === "alphabetical" ? "members" : "alphabetical",
+                );
+                setSelectedIndex(null);
+              }}
+              size="icon-xs"
+              title={sort === "alphabetical" ? "Alphabetical" : "Most members"}
+              type="button"
+              variant="ghost"
+            >
+              {sort === "alphabetical" ? (
+                <ArrowDownAZ />
+              ) : (
+                <ArrowDownWideNarrow />
+              )}
+            </Button>
           </div>
         </DialogHeader>
 

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Compass, Search, X, type LucideIcon } from "lucide-react";
 
 import type { Channel } from "@/shared/api/types";
-import { ListSortAscending } from "@/shared/ui/icons";
+import { ListSortDescending } from "@/shared/ui/icons";
 import {
   Dialog,
   DialogClose,
@@ -370,7 +370,7 @@ export function ChannelBrowserDialog({
                   type="button"
                   variant="ghost"
                 >
-                  <ListSortAscending />
+                  <ListSortDescending />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Bot, Hash, LogIn, Plus, Sparkles, UserPlus } from "lucide-react";
+import { HashSearch } from "@/shared/ui/icons";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useMediaUpload } from "@/features/messages/lib/useMediaUpload";
 import { MessageComposer } from "@/features/messages/ui/MessageComposer";
@@ -100,6 +101,7 @@ export const ChannelPane = React.memo(function ChannelPane({
   onChannelManagementDeleted,
   onCloseProfilePanel,
   onAddAgent,
+  onBrowseChannels,
   onCreateChannel,
   onCloseThread,
   onDelete,
@@ -437,6 +439,24 @@ export const ChannelPane = React.memo(function ChannelPane({
 
     const actions = [];
     if (isWelcomeChannel(activeChannel)) {
+      if (onBrowseChannels) {
+        actions.push({
+          icon: <HashSearch aria-hidden className="h-6 w-6" />,
+          label: "Browse channels",
+          onClick: onBrowseChannels,
+          testId: "welcome-intro-action-browse-channels",
+        });
+      }
+
+      if (onCreateChannel) {
+        actions.push({
+          icon: <Plus aria-hidden className="h-6 w-6" />,
+          label: "Create a channel",
+          onClick: onCreateChannel,
+          testId: "welcome-intro-action-create-channel",
+        });
+      }
+
       if (onAddAgent) {
         actions.push({
           icon: <Bot aria-hidden className="h-6 w-6" />,
@@ -447,15 +467,6 @@ export const ChannelPane = React.memo(function ChannelPane({
                 messageTimelineRef.current?.scrollToBottomOnNextUpdate(),
             }),
           testId: "welcome-intro-action-create-agent",
-        });
-      }
-
-      if (onCreateChannel) {
-        actions.push({
-          icon: <Plus aria-hidden className="h-6 w-6" />,
-          label: "Create a channel",
-          onClick: onCreateChannel,
-          testId: "welcome-intro-action-create-channel",
         });
       }
 
@@ -496,7 +507,13 @@ export const ChannelPane = React.memo(function ChannelPane({
       channelName: activeChannel.name,
       description: getChannelIntroDescription(activeChannel),
     };
-  }, [activeChannel, onAddAgent, onCreateChannel, onOpenMembers]);
+  }, [
+    activeChannel,
+    onAddAgent,
+    onBrowseChannels,
+    onCreateChannel,
+    onOpenMembers,
+  ]);
 
   const visibleMessages = React.useMemo(() => {
     if (!isWelcomeChannel(activeChannel)) {

--- a/desktop/src/features/channels/ui/ChannelPane.types.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.types.ts
@@ -71,6 +71,7 @@ export type ChannelPaneProps = {
   onChannelManagementDeleted?: () => void;
   onCloseProfilePanel: () => void;
   onAddAgent?: (options?: { beforeSend?: () => void }) => void;
+  onBrowseChannels?: () => void;
   onCreateChannel?: () => void;
   onCloseThread: () => void;
   onDelete?: (message: TimelineMessage) => void;

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -93,6 +93,7 @@ export function ChannelScreen({
   targetMessageId,
 }: ChannelScreenProps) {
   const { goHome } = useAppNavigation();
+  const { openBrowseChannels, ...appShell } = useAppShell();
   const {
     markChannelRead,
     markChannelUnread,
@@ -108,7 +109,7 @@ export function ChannelScreen({
     isNotifiedForThread,
     isThreadMuted,
     readStateVersion,
-  } = useAppShell();
+  } = appShell;
   const {
     channelManagementOpen,
     clearAutoSend,
@@ -665,12 +666,10 @@ export function ChannelScreen({
       setThreadScrollTargetId(null);
       return;
     }
-
     if (openThreadHeadMessage && !threadReplyTargetId) {
       setThreadReplyTargetId(openThreadHeadMessage.id);
       return;
     }
-
     if (threadReplyTargetId && !threadReplyTargetMessage) {
       setThreadReplyTargetId(openThreadHeadMessage?.id ?? null);
     }
@@ -856,6 +855,7 @@ export function ChannelScreen({
                   hasOlderMessages={hasOlderMessages}
                   historyExhausted={historyExhausted}
                   onAddAgent={handleOpenAddBot}
+                  onBrowseChannels={openBrowseChannels}
                   onCreateChannel={openCreateChannel}
                   onOpenMembers={handleOpenMembersSidebar}
                   isFetchingOlder={isFetchingOlder}

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -4,6 +4,7 @@ import { cacheSearchHitEvent } from "@/app/navigation/searchHitEventCache";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import { useActiveChannelHeader } from "@/features/channels/useActiveChannelHeader";
 import { useChannelPaneHandlers } from "@/features/channels/useChannelPaneHandlers";
+import { useThreadTargetSync } from "@/features/channels/useThreadTargetSync";
 import {
   useChannelMembersQuery,
   useJoinChannelMutation,
@@ -93,7 +94,6 @@ export function ChannelScreen({
   targetMessageId,
 }: ChannelScreenProps) {
   const { goHome } = useAppNavigation();
-  const { openBrowseChannels, ...appShell } = useAppShell();
   const {
     markChannelRead,
     markChannelUnread,
@@ -101,6 +101,7 @@ export function ChannelScreen({
     getMessageReadAt,
     markMessageRead,
     setContextParentResolver,
+    openBrowseChannels,
     openCreateChannel,
     openChannelManagement: openGlobalChannelManagement,
     followThread,
@@ -109,7 +110,7 @@ export function ChannelScreen({
     isNotifiedForThread,
     isThreadMuted,
     readStateVersion,
-  } = appShell;
+  } = useAppShell();
   const {
     channelManagementOpen,
     clearAutoSend,
@@ -655,38 +656,21 @@ export function ChannelScreen({
     targetMessageId,
     timelineMessages,
   });
-  React.useEffect(() => {
-    if (openThreadHeadId && !openThreadHeadMessage) {
-      if (isTimelineLoading) {
-        return;
-      }
-      clearOptimisticThreadOverride();
-      setOpenThreadHeadId(null, { replace: true });
-      setExpandedThreadReplyIds(new Set());
-      setThreadScrollTargetId(null);
-      return;
-    }
-    if (openThreadHeadMessage && !threadReplyTargetId) {
-      setThreadReplyTargetId(openThreadHeadMessage.id);
-      return;
-    }
-    if (threadReplyTargetId && !threadReplyTargetMessage) {
-      setThreadReplyTargetId(openThreadHeadMessage?.id ?? null);
-    }
-    if (editTargetId && !editTargetMessage) {
-      setEditTargetId(null);
-    }
-  }, [
+  useThreadTargetSync({
     clearOptimisticThreadOverride,
     editTargetId,
     editTargetMessage,
     isTimelineLoading,
     openThreadHeadId,
     openThreadHeadMessage,
+    setEditTargetId,
+    setExpandedThreadReplyIds,
     setOpenThreadHeadId,
+    setThreadReplyTargetId,
+    setThreadScrollTargetId,
     threadReplyTargetId,
     threadReplyTargetMessage,
-  ]);
+  });
 
   const hasAuxiliaryPanel = Boolean(
     effectiveOpenThreadHeadId ||

--- a/desktop/src/features/channels/useThreadTargetSync.ts
+++ b/desktop/src/features/channels/useThreadTargetSync.ts
@@ -1,0 +1,79 @@
+import * as React from "react";
+
+import type { PanelValueSetter } from "@/features/channels/ui/useChannelPanelHistoryState";
+import type { TimelineMessage } from "@/features/messages/types";
+
+/**
+ * Keeps thread-panel and edit-composer targets consistent with the messages
+ * that are actually loaded: closes the thread panel when its head message
+ * disappears, seeds the reply target from the thread head, and clears stale
+ * reply/edit targets that no longer resolve to a message.
+ */
+export function useThreadTargetSync({
+  clearOptimisticThreadOverride,
+  editTargetId,
+  editTargetMessage,
+  isTimelineLoading,
+  openThreadHeadId,
+  openThreadHeadMessage,
+  setEditTargetId,
+  setExpandedThreadReplyIds,
+  setOpenThreadHeadId,
+  setThreadReplyTargetId,
+  setThreadScrollTargetId,
+  threadReplyTargetId,
+  threadReplyTargetMessage,
+}: {
+  clearOptimisticThreadOverride: () => void;
+  editTargetId: string | null;
+  editTargetMessage: TimelineMessage | null;
+  isTimelineLoading: boolean;
+  openThreadHeadId: string | null;
+  openThreadHeadMessage: TimelineMessage | null;
+  setEditTargetId: (id: string | null) => void;
+  setExpandedThreadReplyIds: (ids: Set<string>) => void;
+  setOpenThreadHeadId: PanelValueSetter;
+  setThreadReplyTargetId: (id: string | null) => void;
+  setThreadScrollTargetId: (id: string | null) => void;
+  threadReplyTargetId: string | null;
+  threadReplyTargetMessage: TimelineMessage | null;
+}) {
+  React.useEffect(() => {
+    if (openThreadHeadId && !openThreadHeadMessage) {
+      if (isTimelineLoading) {
+        return;
+      }
+      clearOptimisticThreadOverride();
+      setOpenThreadHeadId(null, { replace: true });
+      setExpandedThreadReplyIds(new Set());
+      setThreadScrollTargetId(null);
+      return;
+    }
+
+    if (openThreadHeadMessage && !threadReplyTargetId) {
+      setThreadReplyTargetId(openThreadHeadMessage.id);
+      return;
+    }
+
+    if (threadReplyTargetId && !threadReplyTargetMessage) {
+      setThreadReplyTargetId(openThreadHeadMessage?.id ?? null);
+    }
+    if (editTargetId && !editTargetMessage) {
+      setEditTargetId(null);
+    }
+  }, [
+    clearOptimisticThreadOverride,
+    editTargetId,
+    editTargetMessage,
+    isTimelineLoading,
+    openThreadHeadId,
+    openThreadHeadMessage,
+    setEditTargetId,
+    setExpandedThreadReplyIds,
+    setOpenThreadHeadId,
+    setThreadReplyTargetId,
+    setThreadScrollTargetId,
+    threadReplyTargetId,
+    threadReplyTargetMessage,
+  ]);
+}

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -582,7 +582,7 @@ const MessageTimelineBase = React.forwardRef<
     () =>
       activeChannelIntro ? (
         <div
-          className="flex w-full max-w-2xl flex-col items-start px-3 pb-4 pt-2 text-left"
+          className="flex w-full flex-col items-start px-3 pb-4 pt-2 text-left"
           data-testid="message-channel-intro"
         >
           <div className="flex h-[60px] w-[60px] items-center justify-center rounded-2xl border border-border/70 bg-muted/40 text-muted-foreground">
@@ -590,10 +590,10 @@ const MessageTimelineBase = React.forwardRef<
               <Hash aria-hidden className="h-7 w-7" />
             )}
           </div>
-          <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
+          <p className="mt-4 max-w-2xl truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
             #{activeChannelIntro.channelName}
           </p>
-          <p className="mt-1 max-w-full text-sm leading-5 text-muted-foreground">
+          <p className="mt-1 max-w-2xl text-sm leading-5 text-muted-foreground">
             This is the beginning of the{" "}
             <span className="font-medium text-foreground">
               {activeChannelIntro.channelKindLabel}
@@ -839,7 +839,7 @@ const MessageTimelineBase = React.forwardRef<
 
                 {activeChannelIntro ? (
                   <div
-                    className="mt-auto flex w-full max-w-2xl flex-col items-start px-3 py-2 text-left"
+                    className="mt-auto flex w-full flex-col items-start px-3 py-2 text-left"
                     data-testid="message-channel-intro"
                   >
                     <div
@@ -850,10 +850,10 @@ const MessageTimelineBase = React.forwardRef<
                         <Hash aria-hidden className="h-7 w-7" />
                       )}
                     </div>
-                    <p className="mt-4 max-w-full truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
+                    <p className="mt-4 max-w-2xl truncate text-xl font-semibold leading-7 tracking-tight text-foreground">
                       #{activeChannelIntro.channelName}
                     </p>
-                    <p className="mt-1 max-w-full text-sm leading-5 text-muted-foreground">
+                    <p className="mt-1 max-w-2xl text-sm leading-5 text-muted-foreground">
                       This is the beginning of the{" "}
                       <span className="font-medium text-foreground">
                         {activeChannelIntro.channelKindLabel}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -58,6 +58,7 @@ import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurn
 import type { ChannelSection } from "@/features/sidebar/lib/useChannelSections";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { getPlatformKeysById } from "@/shared/lib/keyboard-shortcuts";
 import { HashSearch } from "@/shared/ui/icons";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 
@@ -201,7 +202,9 @@ export function SectionActionsMenu({
           <DropdownMenuItem onSelect={() => deferMenuAction(onBrowse)}>
             <HashSearch className="h-4 w-4" />
             <span>{browseLabel ?? "Browse channels"}</span>
-            <DropdownMenuShortcut>⇧⌘O</DropdownMenuShortcut>
+            <DropdownMenuShortcut>
+              {getPlatformKeysById("browse-channels")}
+            </DropdownMenuShortcut>
           </DropdownMenuItem>
         ) : null}
         {onCreate ? (

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -28,6 +28,7 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -200,6 +201,7 @@ export function SectionActionsMenu({
           <DropdownMenuItem onSelect={() => deferMenuAction(onBrowse)}>
             <HashSearch className="h-4 w-4" />
             <span>{browseLabel ?? "Browse channels"}</span>
+            <DropdownMenuShortcut>⇧⌘O</DropdownMenuShortcut>
           </DropdownMenuItem>
         ) : null}
         {onCreate ? (

--- a/desktop/src/shared/lib/keyboard-shortcuts.ts
+++ b/desktop/src/shared/lib/keyboard-shortcuts.ts
@@ -250,3 +250,13 @@ export function getShortcutsByCategory(): Map<
 export function getPlatformKeys(shortcut: KeyboardShortcut): string {
   return isMacPlatform() ? shortcut.keys : shortcut.keysWindows;
 }
+
+/**
+ * Platform-appropriate key hint for a shortcut in {@link KEYBOARD_SHORTCUTS},
+ * or null when the id is unknown. Use this for inline hints (menus, tooltips)
+ * so they stay in sync with the canonical shortcut registry.
+ */
+export function getPlatformKeysById(id: string): string | null {
+  const shortcut = KEYBOARD_SHORTCUTS.find((s) => s.id === id);
+  return shortcut ? getPlatformKeys(shortcut) : null;
+}

--- a/desktop/src/shared/ui/icons.ts
+++ b/desktop/src/shared/ui/icons.ts
@@ -8,3 +8,9 @@ export const HashSearch = createLucideIcon("hash-search", [
   ["path", { d: "m21 21-1.9-1.9", key: "1g2n9r" }],
   ["circle", { cx: "17", cy: "17", r: "3", key: "18b49y" }],
 ]);
+
+export const ListSortAscending = createLucideIcon("list-sort-ascending", [
+  ["path", { d: "M3 19h18", key: "awlh7x" }],
+  ["path", { d: "M15 12H3", key: "1d0spu" }],
+  ["path", { d: "M9 5H3", key: "1x7s71" }],
+]);

--- a/desktop/src/shared/ui/icons.ts
+++ b/desktop/src/shared/ui/icons.ts
@@ -9,8 +9,8 @@ export const HashSearch = createLucideIcon("hash-search", [
   ["circle", { cx: "17", cy: "17", r: "3", key: "18b49y" }],
 ]);
 
-export const ListSortAscending = createLucideIcon("list-sort-ascending", [
-  ["path", { d: "M3 19h18", key: "awlh7x" }],
+export const ListSortDescending = createLucideIcon("list-sort-descending", [
   ["path", { d: "M15 12H3", key: "1d0spu" }],
-  ["path", { d: "M9 5H3", key: "1x7s71" }],
+  ["path", { d: "M3 5h18", key: "d7x3do" }],
+  ["path", { d: "M9 19H3", key: "11jz4a" }],
 ]);

--- a/desktop/src/shared/ui/icons.ts
+++ b/desktop/src/shared/ui/icons.ts
@@ -8,9 +8,3 @@ export const HashSearch = createLucideIcon("hash-search", [
   ["path", { d: "m21 21-1.9-1.9", key: "1g2n9r" }],
   ["circle", { cx: "17", cy: "17", r: "3", key: "18b49y" }],
 ]);
-
-export const ListSortAscending = createLucideIcon("list-sort-ascending", [
-  ["path", { d: "M3 19h18", key: "awlh7x" }],
-  ["path", { d: "M15 12H3", key: "1d0spu" }],
-  ["path", { d: "M9 5H3", key: "1x7s71" }],
-]);

--- a/desktop/tests/e2e/channel-browser.spec.ts
+++ b/desktop/tests/e2e/channel-browser.spec.ts
@@ -66,11 +66,8 @@ test("channel browser sorts alphabetically or by member count", async ({
     /#secret-projects/,
   ]);
 
-  await expect(page.getByTestId("channel-browser-sort")).toHaveAttribute(
-    "aria-label",
-    "Sort channels by most members",
-  );
   await page.getByTestId("channel-browser-sort").click();
+  await page.getByTestId("channel-browser-sort-members").click();
 
   await expect(rows).toHaveText([
     /#general/,
@@ -85,11 +82,7 @@ test("channel browser sorts alphabetically or by member count", async ({
   ]);
   await expect(page.getByTestId("channel-browser-sort")).toHaveAttribute(
     "aria-label",
-    "Sort channels by alphabetical order",
-  );
-  await expect(page.getByTestId("channel-browser-sort")).toHaveAttribute(
-    "aria-pressed",
-    "true",
+    "Sort channels: Most members",
   );
 });
 

--- a/desktop/tests/e2e/channel-browser.spec.ts
+++ b/desktop/tests/e2e/channel-browser.spec.ts
@@ -66,8 +66,11 @@ test("channel browser sorts alphabetically or by member count", async ({
     /#secret-projects/,
   ]);
 
+  await expect(page.getByTestId("channel-browser-sort")).toHaveAttribute(
+    "aria-label",
+    "Sort channels by most members",
+  );
   await page.getByTestId("channel-browser-sort").click();
-  await page.getByTestId("channel-browser-sort-members").click();
 
   await expect(rows).toHaveText([
     /#general/,
@@ -82,7 +85,11 @@ test("channel browser sorts alphabetically or by member count", async ({
   ]);
   await expect(page.getByTestId("channel-browser-sort")).toHaveAttribute(
     "aria-label",
-    "Sort channels: Most members",
+    "Sort channels by alphabetical order",
+  );
+  await expect(page.getByTestId("channel-browser-sort")).toHaveAttribute(
+    "aria-pressed",
+    "true",
   );
 });
 

--- a/desktop/tests/e2e/channel-browser.spec.ts
+++ b/desktop/tests/e2e/channel-browser.spec.ts
@@ -46,6 +46,46 @@ test("channel browser shows channels not yet joined", async ({ page }) => {
   await expect(page.getByTestId("browse-channel-general")).toBeVisible();
 });
 
+test("channel browser sorts alphabetically or by member count", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await openChannelBrowser(page);
+  const rows = page.locator('[data-testid^="browse-channel-"]');
+
+  await expect(rows).toHaveText([
+    /#agents/,
+    /#all-replies/,
+    /#deep-history/,
+    /#design/,
+    /#engineering/,
+    /#general/,
+    /#random/,
+    /#sales/,
+    /#secret-projects/,
+  ]);
+
+  await page.getByTestId("channel-browser-sort").click();
+  await page.getByTestId("channel-browser-sort-members").click();
+
+  await expect(rows).toHaveText([
+    /#general/,
+    /#agents/,
+    /#engineering/,
+    /#random/,
+    /#all-replies/,
+    /#deep-history/,
+    /#design/,
+    /#sales/,
+    /#secret-projects/,
+  ]);
+  await expect(page.getByTestId("channel-browser-sort")).toHaveAttribute(
+    "aria-label",
+    "Sort channels: Most members",
+  );
+});
+
 test("channel browser search filters by name", async ({ page }) => {
   await page.goto("/");
 

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -265,6 +265,28 @@ async function expectWelcomeView(page: Page) {
     "A few good first steps",
   );
   await expect(
+    page.getByTestId("message-channel-intro").getByRole("button"),
+  ).toHaveText(["Browse channels", "Create a channel", "Create an agent"]);
+  await expect(
+    page.getByTestId("welcome-intro-action-browse-channels"),
+  ).toBeVisible();
+  await expectWiderThanTall(
+    page.getByTestId("welcome-intro-action-browse-channels"),
+  );
+  await expectIntroActionIconStackedAboveTitle(
+    page.getByTestId("welcome-intro-action-browse-channels"),
+    "Browse channels",
+  );
+  await page.getByTestId("welcome-intro-action-browse-channels").click();
+  await expect(page.getByTestId("channel-browser-dialog")).toBeVisible();
+  await expect(page.getByTestId("channel-browser-search")).toBeFocused();
+  await expect(page.getByRole("tab", { name: "All channels" })).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("channel-browser-dialog")).toHaveCount(0);
+  await expect(
     page.getByTestId("welcome-intro-action-create-channel"),
   ).toBeVisible();
   await expectWiderThanTall(

--- a/desktop/tests/e2e/welcome-agent-modal-screenshots.spec.ts
+++ b/desktop/tests/e2e/welcome-agent-modal-screenshots.spec.ts
@@ -72,20 +72,9 @@ test.describe("welcome and channel agent entry points", () => {
     await page.getByTestId("create-channel-private-toggle").click();
     await page.getByTestId("create-channel-submit").click();
     await expect(page.getByTestId("chat-title")).toHaveText("Welcome");
-    const agentCard = await page
-      .getByTestId("welcome-intro-action-create-agent")
-      .boundingBox();
-    const channelCard = await page
-      .getByTestId("welcome-intro-action-create-channel")
-      .boundingBox();
-    expect(agentCard).not.toBeNull();
-    expect(channelCard).not.toBeNull();
-    if (agentCard && channelCard) {
-      const sameRow = Math.abs(agentCard.y - channelCard.y) < 1;
-      expect(sameRow ? agentCard.x : agentCard.y).toBeLessThan(
-        sameRow ? channelCard.x : channelCard.y,
-      );
-    }
+    await expect(
+      page.getByTestId("message-channel-intro").getByRole("button"),
+    ).toHaveText(["Browse channels", "Create a channel", "Create an agent"]);
     await page.getByTestId("welcome-intro-action-create-agent").click();
     const dialog = page.getByRole("dialog");
     await expect(


### PR DESCRIPTION
## What

Improves channel discovery for new users, anchored on the Welcome channel:

1. **"Browse channels" Welcome card** — a new first onboarding card in the private Welcome channel, ahead of "Create a channel" and "Create an agent" (discover → organize → automate). It opens the existing Browse Channels dialog in stream mode with search focused and the All channels tab active. Uses the shared `HashSearch` icon from the sidebar action.
2. **Channel browser sorting** — a sort popover inside the Browse Channels search bar (all entry points): **Alphabetical** (default) or **Most members**, with alphabetical tie-breaking. Applies across tabs, search results, channels, and forums. Resets when the dialog closes.
3. **Shortcut hint moved to the sidebar** — the `⇧⌘O` hint used to live inside the browser dialog's search field, where it appeared/disappeared with focus and visually read as belonging to the new sort button. It now sits on the sidebar's "Browse channels" menu item — the command it actually invokes — and is platform-aware via the canonical shortcut registry (`Shift+Ctrl+O` on Windows/Linux).

## Implementation notes

- **Intro layout**: the channel intro previously capped the whole block at `max-w-2xl`. The action row now uses the available timeline width (cards stay fixed-width, horizontally scrollable at narrow sizes) while name/description keep the readable `max-w-2xl` cap. Applies to both timeline render paths.
- **Wiring**: `openBrowseChannels` is exposed through `AppShellContext` and passed as a prop down `ChannelScreen → ChannelPane`, matching the existing `onCreateChannel`/`onAddAgent` pattern (prop-based to preserve `ChannelPane`'s `React.memo`).
- **File split**: `ChannelScreen.tsx` crossed the 979-line guard, so the thread/edit-target reconciliation effect moved to a new `useThreadTargetSync` hook rather than slipping under with formatting tricks.
- **Search field structure**: the dialog's search shell is now a `div` with an inner `label` wrapping icon + input, so the sort button isn't nested in the label while click-to-focus and the input's label association are preserved.
- New `getPlatformKeysById()` helper lets inline hints (menus, tooltips) pull from `KEYBOARD_SHORTCUTS` so they can't drift from the Settings shortcuts card.

## Testing

- `onboarding.spec.ts`: asserts card order (Browse → Create channel → Create agent), card layout, and that clicking opens the browser with search focused on the All channels tab.
- `channel-browser.spec.ts`: new sort test covering default alphabetical order, switching to Most members, and the trigger's aria-label.
- Full local gate: biome + guards, typecheck, 2931 unit tests, 12 channel-browser E2E, onboarding integration E2E — all green.

Screenshots in a follow-up comment.
