### PR TITLE
feat(onboarding): add Meet your team page

### DIFF
--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -9,14 +9,12 @@ import {
 import { initializeWelcomeChannel } from "@/features/onboarding/hooks";
 import { useClaimInvite } from "@/features/onboarding/useClaimInvite";
 import { AvatarUpload } from "@/features/profile/ui/AvatarUpload";
-import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { updateProfile } from "@/shared/api/tauriProfiles";
 import { getIdentity } from "@/shared/api/tauriIdentity";
-import { listPersonas } from "@/shared/api/tauriPersonas";
-import type { AgentPersona } from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { StartupWindowDragRegion } from "@/shared/ui/StartupWindowDragRegion";
+import { StarterTeamCards } from "./StarterTeamCards";
 
 export function CommunityOnboardingFlow({
   onConnect,
@@ -28,26 +26,7 @@ export function CommunityOnboardingFlow({
   const [displayName, setDisplayName] = React.useState("");
   const [avatarUrl, setAvatarUrl] = React.useState("");
   const [isUploadingAvatar, setIsUploadingAvatar] = React.useState(false);
-  const [starterPersonas, setStarterPersonas] = React.useState<AgentPersona[]>(
-    [],
-  );
   const [isPending, setIsPending] = React.useState(false);
-
-  React.useEffect(() => {
-    if (transaction?.stage !== "team-intro") return;
-    void listPersonas()
-      .then((personas) =>
-        setStarterPersonas(
-          ["Fizz", "Honey", "Bumble"].flatMap((name) => {
-            const persona = personas.find(
-              (candidate) => candidate.displayName === name,
-            );
-            return persona ? [persona] : [];
-          }),
-        ),
-      )
-      .catch(() => setStarterPersonas([]));
-  }, [transaction?.stage]);
 
   useClaimInvite();
 
@@ -179,25 +158,9 @@ export function CommunityOnboardingFlow({
               Fizz helps you build, Honey helps you communicate, and Bumble
               helps you research. They’ll be ready when you need them.
             </p>
-            {starterPersonas.length > 0 ? (
-              <div className="mt-7 flex justify-center gap-5">
-                {starterPersonas.map((persona) => (
-                  <div
-                    className="flex w-20 flex-col items-center gap-2"
-                    key={persona.id}
-                  >
-                    <ProfileAvatar
-                      avatarUrl={persona.avatarUrl}
-                      className="h-14 w-14"
-                      label={persona.displayName}
-                    />
-                    <span className="text-sm font-medium">
-                      {persona.displayName}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            ) : null}
+            <div className="mt-7">
+              <StarterTeamCards />
+            </div>
             {transaction.error ? (
               <p className="mt-4 text-sm text-destructive">
                 {transaction.error}

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -12,8 +12,14 @@ import { BackupStep } from "./BackupStep";
 import { NostrKeyImportForm } from "./NostrKeyImportForm";
 import { OnboardingSlideTransition } from "./OnboardingSlideTransition";
 import { SetupStep } from "./SetupStep";
+import { StarterTeamCards } from "./StarterTeamCards";
 
-type MachinePage = "identity" | "key-import" | "backup" | "setup";
+type MachinePage =
+  | "identity"
+  | "key-import"
+  | "backup"
+  | "setup"
+  | "team-intro";
 
 export function MachineOnboardingFlow({
   complete,
@@ -166,15 +172,50 @@ export function MachineOnboardingFlow({
             onNext={() => setPage("setup")}
             totalSteps={3}
           />
-        ) : (
+        ) : page === "setup" ? (
           <SetupStep
             actions={{
               back: () =>
                 setPage(identityWasImported ? "key-import" : "backup"),
-              complete: () => complete(selectedPubkey ?? undefined),
+              complete: () => setPage("team-intro"),
             }}
             direction="forward"
           />
+        ) : (
+          <OnboardingSlideTransition
+            className="flex w-full max-w-[500px] flex-col items-center text-center"
+            direction="forward"
+            transitionKey="machine-team-intro"
+          >
+            <h1 className="text-3xl font-semibold tracking-tight">
+              Meet your team
+            </h1>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              Fizz helps you build, Honey helps you communicate, and Bumble
+              helps you research. They’ll be ready when you need them.
+            </p>
+            <div className="mt-7">
+              <StarterTeamCards />
+            </div>
+            <div className="mt-8 flex w-full flex-col gap-3">
+              <Button
+                className="h-10 w-full"
+                data-testid="onboarding-team-continue"
+                onClick={() => complete(selectedPubkey ?? undefined)}
+                type="button"
+              >
+                Continue
+              </Button>
+              <Button
+                className="h-10 w-full text-muted-foreground hover:text-accent-foreground"
+                onClick={() => setPage("setup")}
+                type="button"
+                variant="ghost"
+              >
+                Back
+              </Button>
+            </div>
+          </OnboardingSlideTransition>
         )}
       </div>
     </div>

--- a/desktop/src/features/onboarding/ui/StarterTeamCards.tsx
+++ b/desktop/src/features/onboarding/ui/StarterTeamCards.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+import { listPersonas } from "@/shared/api/tauriPersonas";
+import type { AgentPersona } from "@/shared/api/types";
+
+const STARTER_PERSONA_NAMES = ["Fizz", "Honey", "Bumble"];
+
+export function StarterTeamCards() {
+  const [personas, setPersonas] = React.useState<AgentPersona[]>([]);
+
+  React.useEffect(() => {
+    void listPersonas()
+      .then((availablePersonas) =>
+        setPersonas(
+          STARTER_PERSONA_NAMES.flatMap((name) => {
+            const persona = availablePersonas.find(
+              (candidate) => candidate.displayName === name,
+            );
+            return persona ? [persona] : [];
+          }),
+        ),
+      )
+      .catch(() => setPersonas([]));
+  }, []);
+
+  if (personas.length === 0) return null;
+
+  return (
+    <div className="flex justify-center gap-5" data-testid="starter-team-cards">
+      {personas.map((persona) => (
+        <div className="flex w-20 flex-col items-center gap-2" key={persona.id}>
+          <ProfileAvatar
+            avatarUrl={persona.avatarUrl}
+            className="h-14 w-14"
+            label={persona.displayName}
+          />
+          <span className="text-sm font-medium">{persona.displayName}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -86,6 +86,35 @@ test("setup page Re-check button triggers runtimes refetch", async ({
   await expect(recheckBtn).toBeVisible();
 });
 
+test("Finish opens the display-only starter team page before completing setup", async ({
+  page,
+}) => {
+  await installMockBridge(page, undefined, {
+    skipCommunitySeed: true,
+    skipOnboardingSeed: true,
+  });
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  await page.getByTestId("onboarding-finish").click();
+
+  await expect(
+    page.getByRole("heading", { name: "Meet your team" }),
+  ).toBeVisible();
+  const cards = page.getByTestId("starter-team-cards");
+  await expect(cards.getByText("Fizz", { exact: true })).toBeVisible();
+  await expect(cards.getByText("Honey", { exact: true })).toBeVisible();
+  await expect(cards.getByText("Bumble", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("machine-onboarding-gate")).toBeVisible();
+
+  await page.getByTestId("onboarding-team-continue").click();
+
+  await expect(page.getByTestId("machine-onboarding-gate")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Join a community" }),
+  ).toBeVisible();
+});
+
 test("Finish button is always enabled on setup page regardless of readiness", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- add a display-only **Meet your team** page after machine setup and before community selection
- show Fizz, Honey, and Bumble without adding defaults or persistence behavior
- extract the existing starter persona rendering so machine and community onboarding share presentation without sharing flow state

## Test plan
- `cd desktop && pnpm build`
- `cd desktop && pnpm exec playwright test tests/e2e/onboarding-agent-defaults.spec.ts --project=smoke` (6 passed)
- focused Biome check on all changed files
