### PR TITLE
Limit onboarding avatars to images and emoji

### DIFF
--- a/desktop/src/features/onboarding/ui/AvatarStep.tsx
+++ b/desktop/src/features/onboarding/ui/AvatarStep.tsx
@@ -1,6 +1,5 @@
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import {
-  type AvatarMode,
   parseEmojiAvatarDataUrl,
   ProfileAvatarEditor,
 } from "@/features/profile/ui/ProfileAvatarEditor";
@@ -271,60 +270,15 @@ export function AvatarStep({
   } = actions;
   const { avatar, isSaving, isUploadingAvatar, name, saveRecovery } = state;
   const [avatarSquishKey, setAvatarSquishKey] = React.useState(0);
-  const [avatarEditorMode, setAvatarEditorMode] =
-    React.useState<AvatarMode>("image");
-  const [animatedPreviewEl, setAnimatedPreviewEl] =
-    React.useState<HTMLDivElement | null>(null);
-  const [isAnimatedPreviewActive, setIsAnimatedPreviewActive] =
-    React.useState(false);
-  const [animatedPreviewCaption, setAnimatedPreviewCaption] = React.useState<
-    string | null
-  >(null);
-  const [pendingAnimatedAvatarUrl, setPendingAnimatedAvatarUrl] =
-    React.useState<string | null>(null);
   const [isCustomColorPickerOpen, setIsCustomColorPickerOpen] =
     React.useState(false);
   const hasAvatarDraft = avatar.draftUrl.trim().length > 0;
   const canSubmit = hasAvatarDraft && !isSaving && !isUploadingAvatar;
-  const isAutoAdvancingAnimatedAvatar = pendingAnimatedAvatarUrl !== null;
-  const shouldHideActionsForAnimatedAvatar =
-    avatarEditorMode === "animated" &&
-    (!hasAvatarDraft || isAutoAdvancingAnimatedAvatar);
-  const areActionsHidden =
-    isCustomColorPickerOpen || shouldHideActionsForAnimatedAvatar;
   const previewName =
     name.draftValue.trim() || name.savedValue.trim() || "Your avatar";
   const animateEmojiAvatarChange = React.useCallback(() => {
     setAvatarSquishKey((key) => key + 1);
   }, []);
-  const handleAnimatedAvatarApply = React.useCallback((url: string) => {
-    setPendingAnimatedAvatarUrl(url);
-  }, []);
-
-  React.useEffect(() => {
-    if (!pendingAnimatedAvatarUrl) {
-      return;
-    }
-    if (avatar.draftUrl !== pendingAnimatedAvatarUrl) {
-      return;
-    }
-    if (saveRecovery.errorMessage) {
-      setPendingAnimatedAvatarUrl(null);
-      return;
-    }
-    if (isSaving || isUploadingAvatar) {
-      return;
-    }
-
-    submit();
-  }, [
-    avatar.draftUrl,
-    isSaving,
-    isUploadingAvatar,
-    pendingAnimatedAvatarUrl,
-    saveRecovery.errorMessage,
-    submit,
-  ]);
 
   return (
     <OnboardingSlideTransition
@@ -336,7 +290,7 @@ export function AvatarStep({
       <motion.div
         className="grid w-full max-w-[1080px] items-start gap-12 lg:grid-cols-[minmax(300px,420px)_minmax(0,500px)] lg:gap-16"
         layout="position"
-        layoutDependency={`${avatarEditorMode}-${isCustomColorPickerOpen}`}
+        layoutDependency={isCustomColorPickerOpen}
         transition={AVATAR_POSITION_MOTION_TRANSITION}
       >
         <div className="flex w-full flex-col items-center text-center lg:items-start lg:text-left">
@@ -350,59 +304,32 @@ export function AvatarStep({
           </div>
 
           <div className="mt-12 grid justify-items-center gap-3 lg:justify-items-start">
-            <div className="relative h-48 w-48">
-              <div
-                className="pointer-events-none absolute inset-0 z-10"
-                data-testid="onboarding-avatar-animated-preview-slot"
-                ref={setAnimatedPreviewEl}
-              />
-              {isAnimatedPreviewActive ? null : (
-                <AvatarPreview
-                  avatarSquishKey={avatarSquishKey}
-                  avatarUrl={avatar.draftUrl}
-                  previewName={previewName}
-                />
-              )}
-            </div>
-
-            <AnimatePresence initial={false}>
-              {animatedPreviewCaption ? (
-                <motion.p
-                  animate={{ opacity: 1, y: 0 }}
-                  className="w-48 text-center text-sm font-medium text-muted-foreground"
-                  exit={{ opacity: 0, y: -4 }}
-                  initial={{ opacity: 0, y: 4 }}
-                  transition={AVATAR_ACTIONS_MOTION_TRANSITION}
-                >
-                  {animatedPreviewCaption}
-                </motion.p>
-              ) : null}
-            </AnimatePresence>
+            <AvatarPreview
+              avatarSquishKey={avatarSquishKey}
+              avatarUrl={avatar.draftUrl}
+              previewName={previewName}
+            />
           </div>
         </div>
 
         <motion.div
           className="w-full"
           layout="position"
-          layoutDependency={`${avatarEditorMode}-${isCustomColorPickerOpen}`}
+          layoutDependency={isCustomColorPickerOpen}
           transition={AVATAR_POSITION_MOTION_TRANSITION}
         >
           <ProfileAvatarEditor
-            animatedPreviewContainer={animatedPreviewEl}
             avatarUrl={avatar.draftUrl}
             disabled={isSaving}
             emojiPickerTheme="auto"
             emojiPickerThemeVars={NEUTRAL_EMOJI_PICKER_THEME_VARS}
-            onAnimatedAvatarApply={handleAnimatedAvatarApply}
-            onAnimatedPreviewActiveChange={setIsAnimatedPreviewActive}
-            onAnimatedPreviewCaptionChange={setAnimatedPreviewCaption}
             onCustomColorPickerOpenChange={setIsCustomColorPickerOpen}
             onEmojiAvatarChange={animateEmojiAvatarChange}
-            onModeChange={setAvatarEditorMode}
             onUploadingChange={onUploadingChange}
             onUrlChange={updateAvatarUrl}
             previewName={previewName}
             testIdPrefix="onboarding-avatar"
+            visibleModes={["image", "emoji"]}
           />
 
           {saveRecovery.errorMessage ? (
@@ -412,7 +339,7 @@ export function AvatarStep({
           <AvatarStepActions
             canSubmit={canSubmit}
             currentStep={currentStep}
-            hidden={areActionsHidden}
+            hidden={isCustomColorPickerOpen}
             isSaving={isSaving}
             isUploadingAvatar={isUploadingAvatar}
             onBack={back}

--- a/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatarEditor.tsx
@@ -70,6 +70,7 @@ type ProfileAvatarEditorProps = {
   avatarUrl: string;
   previewName: string;
   onUrlChange: (url: string) => void;
+  visibleModes?: readonly AvatarMode[];
   emojiPickerTheme?: "auto" | "dark" | "light";
   emojiPickerThemeVars?: React.CSSProperties;
   onEmojiAvatarChange?: () => void;
@@ -132,6 +133,7 @@ export function ProfileAvatarEditor({
   modeTabsContainer,
   onAnimatedPreviewActiveChange,
   onAnimatedPreviewCaptionChange,
+  visibleModes = MODE_TAB_ORDER,
 }: ProfileAvatarEditorProps) {
   const { burstEmoji } = useEmojiBurst();
   const shouldReduceMotion = useReducedMotion();
@@ -485,37 +487,29 @@ export function ProfileAvatarEditor({
     >
       <TabsList
         aria-label="Avatar type"
-        className="relative isolate grid h-14 w-full grid-cols-3 overflow-hidden rounded-full bg-muted p-1 text-muted-foreground"
+        className="relative isolate grid h-14 w-full overflow-hidden rounded-full bg-muted p-1 text-muted-foreground"
+        style={{
+          gridTemplateColumns: `repeat(${visibleModes.length}, minmax(0, 1fr))`,
+        }}
       >
         <div
           aria-hidden="true"
           className="absolute bottom-1 left-1 top-1 z-0 rounded-full bg-background shadow transition-transform duration-[250ms] ease-out"
           style={{
-            transform: `translateX(${MODE_TAB_ORDER.indexOf(mode) * 100}%)`,
-            width: "calc((100% - 8px) / 3)",
+            transform: `translateX(${visibleModes.indexOf(mode) * 100}%)`,
+            width: `calc((100% - 8px) / ${visibleModes.length})`,
           }}
         />
-        <TabsTrigger
-          className="relative z-10 h-full rounded-full bg-transparent text-sm font-medium shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
-          disabled={isInputDisabled}
-          value="image"
-        >
-          Image
-        </TabsTrigger>
-        <TabsTrigger
-          className="relative z-10 h-full rounded-full bg-transparent text-sm font-medium shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
-          disabled={isInputDisabled}
-          value="emoji"
-        >
-          Emoji
-        </TabsTrigger>
-        <TabsTrigger
-          className="relative z-10 h-full rounded-full bg-transparent text-sm font-medium shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
-          disabled={isInputDisabled}
-          value="animated"
-        >
-          Animated
-        </TabsTrigger>
+        {visibleModes.map((visibleMode) => (
+          <TabsTrigger
+            className="relative z-10 h-full rounded-full bg-transparent text-sm font-medium capitalize shadow-none transition-colors data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+            disabled={isInputDisabled}
+            key={visibleMode}
+            value={visibleMode}
+          >
+            {visibleMode[0].toUpperCase() + visibleMode.slice(1)}
+          </TabsTrigger>
+        ))}
       </TabsList>
     </Tabs>
   );

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -719,7 +719,12 @@ test("avatar step reveals preset backgrounds after the first emoji pick", async 
   await page.getByTestId("onboarding-next").click();
   await expect(page.getByTestId("onboarding-page-avatar")).toBeVisible();
 
-  await page.getByRole("tab", { name: "Emoji" }).click();
+  const avatarTypeTabs = page.getByRole("tablist", { name: "Avatar type" });
+  await expect(avatarTypeTabs.getByRole("tab")).toHaveText(["Image", "Emoji"]);
+  await expect(
+    avatarTypeTabs.getByRole("tab", { name: "Animated" }),
+  ).toHaveCount(0);
+  await avatarTypeTabs.getByRole("tab", { name: "Emoji" }).click();
 
   const colorGridShell = page.getByTestId("onboarding-avatar-color-grid-shell");
   await expect(colorGridShell).toHaveAttribute("aria-hidden", "true");
@@ -732,6 +737,18 @@ test("avatar step reveals preset backgrounds after the first emoji pick", async 
     "background-color",
     "rgb(255, 255, 255)",
   );
+
+  await page.getByTestId("onboarding-next").click();
+  await expect(page.getByTestId("onboarding-gate")).toHaveCount(0);
+  await expect
+    .poll(async () => {
+      const profile = await invokeMockCommand<{ avatar_url: string | null }>(
+        page,
+        "get_profile",
+      );
+      return profile.avatar_url;
+    })
+    .toMatch(/^data:image\/svg\+xml,/);
 });
 
 test("avatar step accepts an avatar URL before completing onboarding", async ({


### PR DESCRIPTION
## Summary
- make the shared avatar editor's visible modes configurable while preserving its Image / Emoji / Animated default
- limit onboarding avatar creation to Image / Emoji and remove its animated-capture-only state
- verify onboarding shows exactly two tabs and persists emoji avatars through the existing SVG data URL representation

## Validation
- `pnpm --dir desktop build` (passes; existing dynamic-import/chunk-size warnings only)
- `pnpm --dir desktop exec playwright test --project=integration tests/e2e/onboarding.spec.ts --grep 'avatar step'` (3 passed)
- Biome check on changed files
