### PR TITLE
fix(desktop): restore default community join option

### DIFF
--- a/desktop/src/features/communities/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/communities/ui/WelcomeSetup.tsx
@@ -64,6 +64,13 @@ export function WelcomeSetup({
     setPage(nextPage);
   }, []);
 
+  const handleDefaultCommunity = React.useCallback(() => {
+    communityOnboarding.start({
+      source: "first-community",
+      relayUrl: defaultRelayUrl,
+    });
+  }, [communityOnboarding, defaultRelayUrl]);
+
   const handleInviteRedeem = React.useCallback(
     (relayWsUrl: string, code: string) => {
       communityOnboarding.start({
@@ -107,6 +114,15 @@ export function WelcomeSetup({
               Choose how you want to get started.
             </p>
             <div className="mt-8 flex w-full flex-col gap-3">
+              {isLocalDevRelayUrl(defaultRelayUrl) ? null : (
+                <Button
+                  className="h-10 w-full"
+                  onClick={handleDefaultCommunity}
+                  type="button"
+                >
+                  Join default community
+                </Button>
+              )}
               <Button
                 className="h-10 w-full"
                 onClick={() => showPage("join")}

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -581,6 +581,9 @@ test("first-community choices expose npub and invite input", async ({
   await page.goto("/");
 
   await expect(
+    page.getByRole("button", { name: "Join default community" }),
+  ).toBeVisible();
+  await expect(
     page.getByRole("button", { name: "Join a community" }),
   ).toBeVisible();
   await expect(
@@ -618,6 +621,31 @@ test("first-community choices expose npub and invite input", async ({
     page.getByRole("heading", { name: "I have an invite link" }),
   ).toBeVisible();
   await expect(page.getByTestId("invite-redeem-input")).toBeVisible();
+});
+
+test("first-community hides the default option for localhost", async ({
+  page,
+}) => {
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
+  await page.addInitScript((pubkey) => {
+    window.localStorage.setItem(
+      `buzz-machine-onboarding-complete.v2:${pubkey}`,
+      "true",
+    );
+  }, BLANK_TYLER_IDENTITY.pubkey);
+  await installMockBridge(page, undefined, {
+    relayWsUrl: "ws://localhost:3000",
+    skipOnboardingSeed: true,
+    skipCommunitySeed: true,
+  });
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("button", { name: "Join default community" }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Join a community" }),
+  ).toBeVisible();
 });
 
 test("identity fallback text does not count as a real onboarding name", async ({


### PR DESCRIPTION
## Summary
- restore the first-launch **Join default community** action when the bundled relay is non-local
- route it through the existing community onboarding connect stage
- cover non-local visibility and localhost hiding in Playwright E2E

## Test plan
- `pnpm build` (desktop)
- `pnpm exec playwright test tests/e2e/onboarding.spec.ts --project=integration --grep 'first-community'` (2 passed)
- pre-commit hooks
- pre-push hooks (all passed)

Fixes the regression introduced in #1936.

Requested by @wesbillman.
