### PR TITLE
feat(mobile): add external release signing mode for central APK Signer pipelines

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -42,6 +42,11 @@ environment:
 The keystore path must be absolute, and the keystore must remain outside the
 repository. Development and debug builds do not require these variables.
 
+Release pipelines that sign through the central APK Signer service instead of
+a local upload keystore must set `BUZZ_ANDROID_RELEASE_SIGNING=external`. That
+mode produces an unsigned release bundle and refuses to run if any
+`BUZZ_ANDROID_UPLOAD_*` value is also set.
+
 ## Architecture
 
 ```

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -19,6 +19,28 @@ val uploadSigningValues =
 val missingUploadSigningValues = uploadSigningValues.filterValues { it.isNullOrBlank() }.keys
 val hasUploadSigning = missingUploadSigningValues.isEmpty()
 
+// Release signing modes:
+//   - "upload-keystore" (default): sign with the CI-vended upload keystore;
+//     release builds fail loudly when any credential is missing.
+//   - "external": deliberately produce an UNSIGNED release bundle for a
+//     pipeline that signs through the central APK Signer service (Cashkite,
+//     BOT-1234). No keystore material may be present in this mode.
+val releaseSigningMode =
+    providers.environmentVariable("BUZZ_ANDROID_RELEASE_SIGNING").orNull ?: "upload-keystore"
+val externalReleaseSigning = releaseSigningMode == "external"
+if (releaseSigningMode !in setOf("upload-keystore", "external")) {
+    throw GradleException(
+        "BUZZ_ANDROID_RELEASE_SIGNING must be \"upload-keystore\" or \"external\", got: " +
+            releaseSigningMode,
+    )
+}
+if (externalReleaseSigning && uploadSigningValues.values.any { !it.isNullOrBlank() }) {
+    throw GradleException(
+        "BUZZ_ANDROID_RELEASE_SIGNING=external must not be combined with " +
+            "BUZZ_ANDROID_UPLOAD_* credentials; unset one of them.",
+    )
+}
+
 android {
     namespace = "xyz.block.buzz.mobile"
     compileSdk = flutter.compileSdkVersion
@@ -67,10 +89,17 @@ gradle.taskGraph.whenReady {
     val buildsRelease = allTasks.any { task ->
         task.project == project && task.name in setOf("assembleRelease", "bundleRelease")
     }
+    if (buildsRelease && externalReleaseSigning) {
+        // External signing: the unsigned bundle goes to the central APK
+        // Signer. All keystore checks are intentionally skipped; the
+        // guard above already rejected any BUZZ_ANDROID_UPLOAD_* values.
+        return@whenReady
+    }
     if (buildsRelease && !hasUploadSigning) {
         throw GradleException(
             "Release builds require Android upload signing credentials. Missing: " +
-                missingUploadSigningValues.sorted().joinToString(", "),
+                missingUploadSigningValues.sorted().joinToString(", ") +
+                ". For central APK Signer pipelines set BUZZ_ANDROID_RELEASE_SIGNING=external.",
         )
     }
     if (buildsRelease) {


### PR DESCRIPTION
### What changed?

Adds an explicit release signing mode to the Android build, controlled by `BUZZ_ANDROID_RELEASE_SIGNING`:

- **`upload-keystore`** (default): unchanged behavior — `assembleRelease`/`bundleRelease` fail loudly unless all `BUZZ_ANDROID_UPLOAD_*` credentials are present and valid.
- **`external`**: deliberately produces an **unsigned** release bundle for pipelines that sign through the central APK Signer service (Cashkite, BOT-1234). This mode refuses to run if any `BUZZ_ANDROID_UPLOAD_*` value is also set, so local keystore signing and external signing can never mix. Unknown mode values throw.

Documented in `mobile/README.md`.

### Why?

The `buzz-android-release` Cashkite pipeline (squareup/buzz-releases#58, squareup/buzz-releases#63) signs via APK Signer's `/sign-aab`, which requires an **unsigned** input AAB. Today `mobile/android/app/build.gradle.kts` throws on any release build without upload-keystore credentials, so the pipeline would fail before signing (flagged by Builderbot on buzz-releases#63). This change adds a narrow, opt-in escape hatch instead of weakening the default enforcement.

Note: this must be included in a new mobile release tag (e.g. `mobile-v0.4.6`) before the pipeline's first trial run, since the pipeline builds from a tagged `sprout_ref`.

### How is it tested?

`dart format` clean, `flutter analyze` no issues, full pre-push suite green (including `mobile-test`). Gradle logic validated by review: the `external` guard runs before the task graph check and rejects mixed configuration; the default path is byte-for-byte the previous behavior plus a hint in the error message.

Local `flutter build appbundle` runs (with/without the env var) were not possible on this machine (no local Android SDK); the buzz-releases pipeline trial will exercise the external mode end-to-end before any Play upload.

Before/After images: not applicable — build configuration only, no user-visible surface.

Linear: [BOT-1234](https://linear.app/squareup/issue/BOT-1234)

*🤖 This PR was authored by goblin (Buzz agent).*
