### PR TITLE
test(desktop): make omission-preservation test discriminate on instructions

### DIFF
--- a/desktop/src-tauri/src/commands/personas/inbound_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/inbound_tests.rs
@@ -468,6 +468,10 @@ fn inbound_team_omitted_fields_preserve_local() {
     // Sietch Tabr wipe: an old-shaped (or genuinely field-omitting) event
     // must not blank out a team that has real membership/instructions.
     let mut teams = vec![local_team()];
+    // Give local_team real instructions so preservation is discriminating:
+    // the pre-fix blind-overwrite bug would collapse this to `None`, while
+    // the fix must leave it untouched on an omitted field.
+    teams[0].instructions = Some("local instructions".to_string());
     apply_inbound_team(
         &mut teams,
         TEAM_ID.to_string(),
@@ -481,8 +485,9 @@ fn inbound_team_omitted_fields_preserve_local() {
         "shared non-optional field still overwrites"
     );
     assert_eq!(
-        t.instructions, None,
-        "local had no instructions; omission preserves that (no-op)"
+        t.instructions,
+        Some("local instructions".to_string()),
+        "omitted instructions preserves local value rather than wiping it"
     );
     assert_eq!(
         t.persona_ids,


### PR DESCRIPTION
Follow-up to #1985, which merged before this fix landed on the branch. `inbound_team_omitted_fields_preserve_local` initialized local `instructions` to `None`, so the omitted-fields preservation assertion couldn't distinguish the fix (preserve local) from the pre-fix blind-overwrite bug (write inbound `None` over local `None`) — both produced the same result. Seeds local `instructions` with a real value before applying the omitted event so the assertion only passes under the corrected overwrite-only-on-`Some` reconciliation.

Test-only change, tree-identical to the version reviewed in #1985's thread (`9033456832`).

Related: #1985