### PR TITLE
fix(desktop): keep shared-compute consumers admitted

### DIFF
--- a/desktop/src-tauri/src/commands/workspace.rs
+++ b/desktop/src-tauri/src/commands/workspace.rs
@@ -175,6 +175,14 @@ pub async fn apply_workspace(
     .await
     .map_err(|e| format!("spawn_blocking failed: {e}"))??;
 
+    // The coordinator starts before React applies the selected workspace, so
+    // its startup publication may have used the fallback relay and placeholder
+    // identity. Republish immediately with the now-active relay and member key.
+    // This also makes a consumer-only MeshLLM owner visible for admission
+    // without waiting for the next heartbeat.
+    #[cfg(feature = "mesh-llm")]
+    crate::mesh_llm::publish_current_status_once(&restore_app, "workspace apply").await;
+
     let state = restore_app.state::<AppState>();
     if state
         .managed_agent_restore_pending

--- a/desktop/src-tauri/src/mesh_llm/coordinator.rs
+++ b/desktop/src-tauri/src/mesh_llm/coordinator.rs
@@ -38,13 +38,14 @@ pub async fn start_coordinator(app: AppHandle) {
 
     let publisher_app = app.clone();
     let status_publisher = tokio::spawn(async move {
-        // Clear a stale serving status promptly after an app restart. Once the
-        // node is stopped, the explicit stopped event is sufficient; only a
-        // running node needs periodic freshness heartbeats.
+        // Clear a stale serving status promptly after an app restart. Keep
+        // publishing while stopped too: serving nodes build their admission
+        // allowlist from fresh member statuses, so consumer-only identities
+        // must remain fresh even though they advertise no serving targets.
         publish_current_status_once(&publisher_app, "startup").await;
         loop {
             tokio::time::sleep(STATUS_PUBLISH_INTERVAL).await;
-            publish_running_status_once(&publisher_app).await;
+            publish_current_status_once(&publisher_app, "heartbeat").await;
         }
     });
     let roster_app = app.clone();
@@ -118,13 +119,6 @@ pub(crate) async fn publish_stopped_status_once(app: &AppHandle, reason: &str) {
     }
 }
 
-async fn publish_running_status_once(app: &AppHandle) {
-    let state = app.state::<AppState>();
-    if let Err(error) = publish_running_status_for_state(&state).await {
-        eprintln!("buzz-mesh: periodic status report failed: {error}");
-    }
-}
-
 async fn publish_current_status_for_state(state: &AppState) -> Result<(), String> {
     let identity = super::ensure_owner_identity()
         .map_err(|error| format!("failed to load mesh owner identity: {error}"))?;
@@ -146,23 +140,6 @@ async fn publish_stopped_status_for_state(state: &AppState) -> Result<(), String
     let identity = super::ensure_owner_identity()
         .map_err(|error| format!("failed to load mesh owner identity: {error}"))?;
     let mut payload = stopped_status_payload(&identity);
-    bind_payload_to_member(state, &identity, &mut payload)?;
-    publish_status_report(state, payload).await
-}
-
-async fn publish_running_status_for_state(state: &AppState) -> Result<(), String> {
-    let identity = super::ensure_owner_identity()
-        .map_err(|error| format!("failed to load mesh owner identity: {error}"))?;
-    let mut payload = {
-        let runtime = state.mesh_llm_runtime.lock().await;
-        let Some(runtime) = runtime.as_ref() else {
-            return Ok(());
-        };
-        runtime
-            .status_report_payload()
-            .await
-            .map_err(|error| error.to_string())?
-    };
     bind_payload_to_member(state, &identity, &mut payload)?;
     publish_status_report(state, payload).await
 }
@@ -234,7 +211,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn heartbeat_leaves_room_before_status_expires() {
+    fn member_heartbeat_leaves_room_before_admission_status_expires() {
         assert!(
             STATUS_PUBLISH_INTERVAL.as_secs() * 2 < super::super::discovery::STATUS_FRESHNESS_SECS
         );


### PR DESCRIPTION
## Summary

- republish the local MeshLLM owner status immediately after the active workspace relay and identity are applied
- keep consumer-only/stopped MeshLLM owner identities fresh with the existing 45-second status heartbeat

## Root cause

The shared-compute coordinator starts before the frontend applies the selected workspace. Its one-time startup publication can therefore use the localhost relay fallback and placeholder identity. The periodic publisher previously skipped clients without a running MeshLLM node, so a consumer-only client never corrected that publication.

Serving nodes derive their admission allowlist from fresh, member-signed status events and ignore events older than 120 seconds. As a result, a relay member consuming shared compute could be absent from the serving node's allowlist, causing MeshLLM startup to block until Buzz's outer timeout.

## Impact

Consumer-only clients now become visible on the correct relay as soon as workspace configuration is installed and remain eligible for admission while Buzz is running. Stopped status still advertises no serving targets, so this does not make consumers selectable as compute providers.

## Validation

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --features mesh-llm mesh_llm --lib` — 32 passed, 0 failed, 1 ignored
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --features mesh-llm --all-targets -- -D warnings`
