### PR TITLE
chore(desktop): add AppShell.tsx file-size override to unblock main CI

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -202,6 +202,11 @@ const overrides = new Map([
   // mapper. This is the existing API boundary; split remains queued.
   // team-instructions-first-class: createManagedAgent Tauri bridge threads the
   // new teamId input through to the backend (+1 line).
+  // #1970 merge-skew: add-community deep-link wiring (+4) was based before
+  // #1923 (+3) landed, so PR CI was green while the merged total crossed the
+  // cap (996 -> 1003). Pre-existing red on main, not one PR's feature debt.
+  // Queued to split with the rest of this list.
+  ["src/app/AppShell.tsx", 1003],
   ["src/shared/api/tauri.ts", 1305],
   // doctor-npm-eacces-preflight: hint field added to InstallStepResult (+1 line).
   // codex-acp-package-swap: "adapter_outdated" variant added to AcpAvailabilityStatus (+1 line).


### PR DESCRIPTION
## Summary

Adds a file-size ratchet override for `src/app/AppShell.tsx` (1003 lines) to `desktop/scripts/check-file-sizes.mjs`.

Main CI has been red since #1970 merged: #1923 took `AppShell.tsx` from 996 to 999 lines, then #1970 (+4 net) ran its PR CI green on a base cut before #1923 landed — the merged total of 1003 only exists on `main`, crossing the 1000-line cap with no override entry. Every open PR inherits this red via merge-ref CI until `main` itself is fixed.