### PR TITLE
feat(desktop): graduate community rail

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -75,7 +75,6 @@ import { useCommunities } from "@/features/communities/useCommunities";
 import { useAddCommunityDialogState } from "@/features/communities/addCommunityPrefill";
 import { useApplyTemplate } from "@/features/channel-templates/useApplyTemplate";
 import { relayClient } from "@/shared/api/relayClient";
-import { useFeatureEnabled } from "@/shared/features";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { useRelayAutoHeal } from "@/shared/api/useRelayAutoHeal";
 import { useDeferredStartup } from "@/shared/hooks/useDeferredStartup";
@@ -103,7 +102,7 @@ export function AppShell() {
   useWebviewScrollBoundaryLock();
 
   const communitiesHook = useCommunities();
-  const communityRailEnabled = useFeatureEnabled("workspaceRail");
+  const hasCommunityRail = communitiesHook.communities.length > 1;
   const addCommunityDialog = useAddCommunityDialogState();
   const [isChannelManagementOpen, setIsChannelManagementOpen] =
     React.useState(false);
@@ -762,7 +761,7 @@ export function AppShell() {
                     isHuddleDrawerOpen && "buzz-huddle-app-surface-open",
                   )}
                 >
-                  {communityRailEnabled ? (
+                  {hasCommunityRail ? (
                     <CommunityRail
                       activeCommunityId={
                         communitiesHook.activeCommunity?.id ?? null
@@ -779,10 +778,7 @@ export function AppShell() {
                       <AppTopChrome
                         canGoBack={canGoBack}
                         canGoForward={canGoForward}
-                        hasCommunityRail={
-                          communityRailEnabled &&
-                          communitiesHook.communities.length > 1
-                        }
+                        hasCommunityRail={hasCommunityRail}
                         onGoBack={goBack}
                         onGoForward={goForward}
                       />
@@ -935,10 +931,7 @@ export function AppShell() {
                         <RelayConnectionOverlay
                           card={relayConnectionCard}
                           errorMessage={channelsErrorMessage}
-                          hasCommunityRail={
-                            communityRailEnabled &&
-                            communitiesHook.communities.length > 1
-                          }
+                          hasCommunityRail={hasCommunityRail}
                           isHuddleDrawerOpen={isHuddleDrawerOpen}
                         />
                       </div>

--- a/desktop/src/shared/features/resolveEnabled.test.mjs
+++ b/desktop/src/shared/features/resolveEnabled.test.mjs
@@ -13,12 +13,12 @@ describe("resolveEnabled (preview-only)", () => {
   });
 
   it("uses an enabled manifest default when no override exists", () => {
-    assert.equal(resolveEnabled("workspaceRail", {}, true), true);
+    assert.equal(resolveEnabled("defaultOnFeature", {}, true), true);
   });
 
   it("lets an explicit opt-out override an enabled default", () => {
     assert.equal(
-      resolveEnabled("workspaceRail", { workspaceRail: false }, true),
+      resolveEnabled("defaultOnFeature", { defaultOnFeature: false }, true),
       false,
     );
   });

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { installMockBridge } from "../helpers/bridge";
+import { FEATURE_OVERRIDES_STORAGE_KEY } from "../helpers/features";
 
 const RELAY_URL = "ws://localhost:3000";
 
@@ -32,11 +33,20 @@ async function seedCommunities(
 }
 
 test.describe("community rail", () => {
-  test("shows a button per community and highlights the active one", async ({
+  test("shows the rail with multiple communities despite a stale opt-out", async ({
     page,
   }) => {
-    await installMockBridge(page, undefined, { skipCommunitySeed: true });
+    await installMockBridge(page, undefined, {
+      seedPreviewFeatures: false,
+      skipCommunitySeed: true,
+    });
     await seedCommunities(page, [COMMUNITY_A, COMMUNITY_B], COMMUNITY_A.id);
+    await page.addInitScript((overridesKey) => {
+      window.localStorage.setItem(
+        overridesKey,
+        JSON.stringify({ workspaceRail: false }),
+      );
+    }, FEATURE_OVERRIDES_STORAGE_KEY);
     await page.goto("/");
 
     const rail = page.getByTestId("community-rail");

--- a/preview-features.json
+++ b/preview-features.json
@@ -26,15 +26,6 @@
       ]
     },
     {
-      "id": "workspaceRail",
-      "name": "Community Rail",
-      "defaultEnabled": true,
-      "description": "Far-left rail for switching communities with cross-community unread indicators",
-      "platforms": [
-        "desktop"
-      ]
-    },
-    {
       "id": "forum",
       "name": "Forum Channels",
       "description": "Forum-style threaded channels for long-form discussions",


### PR DESCRIPTION
## Why
The community rail is established behavior, but an old experiment opt-out can still hide it. Users with multiple communities should always see the rail.

## What
- Remove the community rail from the preview feature manifest
- Show and account for the rail whenever the user has more than one community
- Cover stale `workspaceRail: false` overrides and preserve single-community behavior

## Risk Assessment
Low — this only changes the rail visibility gate. Users with one community continue to see no rail.

## References
- Desktop Biome check, typecheck, 2,999 unit tests, and production build passed
- Community rail E2E suite passed: 7/7
- Full pre-push integration tests were blocked by the local Postgres `buzz` user's password authentication

Generated with Astro
