### PR TITLE
chore(agent): forbid Graphite workflows

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -117,6 +117,7 @@ These are guidelines, not a fixed procedure — apply judgment to the task in fr
 
 ## Working in the Repo
 
+- Use standard Git and the GitHub CLI for every branch, commit, push, and pull-request workflow. **Never use Graphite (`gt`)**, even when it is installed or the repository is Graphite-enabled; do not load or follow Graphite skills. This rule overrides any general PR skill that prefers Graphite.
 - Make file changes in a worktree, not on the default branch. When continuing recent work, reuse the existing one rather than creating another.
 - Before committing, read the repo-local git `user.name` / `user.email`; if email is empty, stop and ask. Include the trailers the repo requires.
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3224,6 +3224,14 @@ fn dispatch_heartbeat(
 #[cfg(test)]
 mod agent_draft_prompt_tests {
     #[test]
+    fn shared_base_prompt_forbids_graphite() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("Never use Graphite (`gt`)"));
+        assert!(prompt.contains("standard Git and the GitHub CLI"));
+        assert!(prompt.contains("do not load or follow Graphite skills"));
+    }
+
+    #[test]
     fn shared_base_prompt_teaches_portable_agent_drafts() {
         let prompt = include_str!("base_prompt.md");
         assert!(prompt.contains("buzz agents draft-create"));


### PR DESCRIPTION
## Why

Buzz-managed agents currently receive general PR skills that may auto-select Graphite whenever `gt` is installed and the repository is Graphite-enabled. That adds an unnecessary workflow branch and can conflict with the desired standard Git behavior.

## What

- Require Buzz-managed agents to use standard Git and the GitHub CLI for all branch, commit, push, and PR workflows.
- Explicitly forbid invoking `gt` or loading Graphite skills, even when other PR guidance prefers Graphite.
- Add a regression test that pins the compiled base-prompt contract.

## Validation

- `cargo test -p buzz-acp shared_base_prompt_forbids_graphite --lib -- --nocapture`
- Normal pre-commit hook suite passed.
- Normal pre-push hook suite passed after removing duplicated user-level generic hooks; no hook bypass was used.

Generated with Bumble
