### PR TITLE
feat(desktop): show owners in agent hover cards

### DIFF
--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -23,7 +23,10 @@ import {
 import { useIsManagedAgent } from "@/features/agent-memory/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
-import { ownsAuthorAgent } from "@/features/profile/lib/identity";
+import {
+  formatOwnerLabel,
+  ownsAuthorAgent,
+} from "@/features/profile/lib/identity";
 import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import { useUserStatusQuery } from "@/features/user-status/hooks";
@@ -205,6 +208,11 @@ export function UserProfilePopover({
     (a) => a.pubkey === pubkey,
   );
   const profile = profileQuery.data;
+  const ownerPubkey = profile?.ownerPubkey ?? null;
+  const ownerProfileQuery = useUsersBatchQuery(
+    ownerPubkey ? [ownerPubkey] : [],
+    { enabled: open && Boolean(ownerPubkey) },
+  );
   const normalizedPubkey = normalizePubkey(pubkey);
   const isAgentByOaOwner = Boolean(
     usersBatchQuery.data?.profiles[normalizedPubkey]?.isAgent,
@@ -232,6 +240,13 @@ export function UserProfilePopover({
   const isOwner = useIsManagedAgent(isBotProfile ? pubkey : null);
   const identityQuery = useIdentityQuery();
   const currentPubkey = identityQuery.data?.pubkey;
+  const ownerLabel = isBotProfile
+    ? formatOwnerLabel(
+        ownerPubkey,
+        currentPubkey,
+        ownerProfileQuery.data?.profiles,
+      )
+    : null;
   const isSelf =
     currentPubkey !== undefined &&
     currentPubkey.toLowerCase() === pubkey.toLowerCase();
@@ -511,6 +526,14 @@ export function UserProfilePopover({
             />
           ) : null}
         </div>
+        {isBotProfile && ownerLabel ? (
+          <p
+            className="mt-0.5 truncate text-xs leading-4 text-muted-foreground"
+            data-testid={`user-profile-popover-owner-${pubkey}`}
+          >
+            owned by {ownerLabel}
+          </p>
+        ) : null}
         {profileSubheader ? (
           <p
             className="mt-0.5 truncate text-xs leading-4 text-muted-foreground"

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -6,6 +6,8 @@ import {
   TEST_IDENTITIES,
 } from "../helpers/bridge";
 
+const MOCK_VIEWER_PUBKEY = "deadbeef".repeat(8);
+
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
 });
@@ -26,6 +28,8 @@ const CASEY_PROFILE_PUBKEY =
   "1111111111111111111111111111111111111111111111111111111111111111";
 const PROFILE_ONLY_AGENT_PUBKEY =
   "8f83d6b7f3d74f7d933ae3a54dd8c6cc85c7f98e531c16e5a827b953441a8d67";
+const OWNED_AGENT_PROFILE_PUBKEY =
+  "1212121212121212121212121212121212121212121212121212121212121212";
 const SYSTEM_MESSAGE_KIND = 40099;
 const DM_THREAD_AGENT_MENTION_ERROR_TEXT =
   "Agents must already be in a DM to be mentioned in its threads. Start a new conversation that includes the agent.";
@@ -1697,6 +1701,150 @@ test("clicking a mention chip in a forum post opens the profile panel", async ({
   await expect(page.getByRole("button", { name: "Back to posts" })).toHaveCount(
     0,
   );
+});
+
+test("agent profile popover shows its owner", async ({ page }) => {
+  await installMockBridge(page, {
+    searchProfiles: [
+      {
+        pubkey: OWNED_AGENT_PROFILE_PUBKEY,
+        displayName: "Bumble",
+        ownerPubkey: TEST_IDENTITIES.bob.pubkey,
+        isAgent: true,
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  await emitMockMessage(page, "general", "Bumble checking in.", {
+    pubkey: OWNED_AGENT_PROFILE_PUBKEY,
+  });
+  await waitForTimelineSettled(page);
+
+  const bumbleMessage = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Bumble checking in." })
+    .first();
+  await bumbleMessage.locator("button").first().hover();
+
+  const profilePopover = page.locator(
+    '[data-testid="user-profile-popover"][data-state="open"]',
+  );
+  await expect(profilePopover).toBeVisible();
+  await expect(
+    profilePopover.getByTestId(
+      `user-profile-popover-owner-${OWNED_AGENT_PROFILE_PUBKEY}`,
+    ),
+  ).toHaveText("owned by bob");
+});
+
+test("agent profile popover labels an agent owned by the viewer as you", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    searchProfiles: [
+      {
+        pubkey: OWNED_AGENT_PROFILE_PUBKEY,
+        displayName: "Bumble",
+        ownerPubkey: MOCK_VIEWER_PUBKEY,
+        isAgent: true,
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  await emitMockMessage(page, "general", "Bumble checking in.", {
+    pubkey: OWNED_AGENT_PROFILE_PUBKEY,
+  });
+  await waitForTimelineSettled(page);
+
+  const bumbleMessage = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Bumble checking in." })
+    .first();
+  await bumbleMessage.locator("button").first().hover();
+
+  const profilePopover = page.locator(
+    '[data-testid="user-profile-popover"][data-state="open"]',
+  );
+  await expect(profilePopover).toBeVisible();
+  await expect(
+    profilePopover.getByTestId(
+      `user-profile-popover-owner-${OWNED_AGENT_PROFILE_PUBKEY}`,
+    ),
+  ).toHaveText("owned by you");
+});
+
+test("agent profile popover falls back to the owner's pubkey", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    searchProfiles: [
+      {
+        pubkey: OWNED_AGENT_PROFILE_PUBKEY,
+        displayName: "Bumble",
+        ownerPubkey: CASEY_PROFILE_PUBKEY,
+        isAgent: true,
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  await emitMockMessage(page, "general", "Bumble checking in.", {
+    pubkey: OWNED_AGENT_PROFILE_PUBKEY,
+  });
+  await waitForTimelineSettled(page);
+
+  const bumbleMessage = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Bumble checking in." })
+    .first();
+  await bumbleMessage.locator("button").first().hover();
+
+  const profilePopover = page.locator(
+    '[data-testid="user-profile-popover"][data-state="open"]',
+  );
+  await expect(profilePopover).toBeVisible();
+  await expect(
+    profilePopover.getByTestId(
+      `user-profile-popover-owner-${OWNED_AGENT_PROFILE_PUBKEY}`,
+    ),
+  ).toHaveText("owned by 11111111…1111");
+});
+
+test("human profile popover does not show an owner", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  await emitMockMessage(page, "general", "Bob checking in.", {
+    pubkey: TEST_IDENTITIES.bob.pubkey,
+  });
+  await waitForTimelineSettled(page);
+
+  const bobMessage = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Bob checking in." })
+    .first();
+  await bobMessage.locator("button").first().hover();
+
+  const profilePopover = page.locator(
+    '[data-testid="user-profile-popover"][data-state="open"]',
+  );
+  await expect(profilePopover).toBeVisible();
+  await expect(
+    profilePopover.locator('[data-testid^="user-profile-popover-owner-"]'),
+  ).toHaveCount(0);
 });
 
 test("owned bot profile only exposes message action", async ({ page }) => {


### PR DESCRIPTION
### What changed?

Agent hover cards now show `owned by …`, using the same owner-name, `you`, and truncated-pubkey formatting as mention autocomplete. Human hover cards remain unchanged.

### Why?

When agents share a display name, the hover card should identify who owns each agent just as autocomplete already does.

### How is it tested?

Build and run.

Added tests:

- [`mentions.spec.ts`](https://github.com/block/buzz/tree/main/desktop/tests/e2e/mentions.spec.ts) — resolved owner names, viewer-owned agents, pubkey fallback, and human-card omission

### Before / after

| Before | After |
| --- | --- |
| ![Agent hover card without an owner label](https://raw.githubusercontent.com/block/buzz/0371a384240cd85b7eb781e51c2e278874cabecc/pr-2015--01-before.png) | ![Agent hover card showing owned by bob](https://raw.githubusercontent.com/block/buzz/0371a384240cd85b7eb781e51c2e278874cabecc/pr-2015--02-after.png) |

*🤖 This PR was authored [with an agent](codex://threads/00967ad6df0877484127291ba02cc922927e5280ca6436e57e69355a352290f1).*
