### PR TITLE
feat(desktop): reasoning off by default for mesh shared-compute (DRAFT/WIP)

### DIFF
--- a/desktop/src-tauri/src/mesh_llm/mod.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod.rs
@@ -269,6 +269,67 @@ async fn ensure_model_downloaded(model: &str) -> anyhow::Result<()> {
         .map_err(|error| anyhow::anyhow!("downloading {model} failed: {error}"))
 }
 
+/// Write Buzz's serve-side mesh-llm config and return its path.
+///
+/// Buzz normally lets mesh-llm synthesise an *isolated* throwaway config
+/// (see `prepare_isolated_config` in mesh-llm-host-runtime) that only disables
+/// the telemetry + blobstore plugins. Pointing the embedded serve node at an
+/// explicit `config_path` suppresses that helper, so this file must:
+///
+///   1. Re-assert the same no-leak plugin disables Buzz relies on.
+///   2. Pin reasoning **off by default**, so shared-compute consumers (goose,
+///      Buzz agents) don't burn hidden "thinking" tokens on every turn.
+///      Clients may still opt back in per request (`reasoning_effort`,
+///      `chat_template_kwargs.enable_thinking`, …).
+///
+/// This is a *separate* file from mesh-llm's global `config.toml`; Buzz never
+/// reads or writes the user's global mesh config. Re-written on every serve
+/// start so the reasoning-off default is always re-asserted.
+///
+/// NOTE (draft): the reasoning-off *default* is not yet runtime-verified on the
+/// embedded v0.73.1 runtime — see the PR description. Per-request silencing is
+/// proven; the config-surface default needs an e2e check.
+fn ensure_buzz_serve_config() -> anyhow::Result<std::path::PathBuf> {
+    use mesh_llm_host_runtime::crypto::default_keystore_path;
+
+    // Sibling of the owner keystore in the mesh data dir (~/.mesh-llm), but a
+    // distinct filename so we never touch the global config.toml.
+    let keystore = default_keystore_path()
+        .map_err(|error| anyhow::anyhow!("cannot resolve mesh data dir: {error}"))?;
+    let dir = keystore
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("mesh keystore path has no parent directory"))?;
+    std::fs::create_dir_all(dir)
+        .map_err(|error| anyhow::anyhow!("create mesh data dir {}: {error}", dir.display()))?;
+    let path = dir.join("buzz-serve-config.toml");
+
+    const CONTENTS: &str = "\
+# Managed by Buzz — regenerated on every shared-compute serve start.
+# Separate from mesh-llm's global config.toml; do not hand-edit.
+
+[[plugin]]
+name = \"telemetry\"
+enabled = false
+
+[[plugin]]
+name = \"blobstore\"
+enabled = false
+
+# Reasoning OFF by default so agent consumers don't burn hidden thinking
+# tokens. chat_template_kwargs.enable_thinking mirrors mesh-llm's own
+# apply_enable_thinking() knob; reasoning_enabled is the config-surface analogue.
+[defaults.request_defaults]
+reasoning_enabled = false
+
+[defaults.request_defaults.chat_template_kwargs]
+enable_thinking = false
+";
+
+    std::fs::write(&path, CONTENTS)
+        .map_err(|error| anyhow::anyhow!("write Buzz serve config {}: {error}", path.display()))?;
+    Ok(path)
+}
+
 impl DesktopMeshRuntime {
     pub async fn start(request: StartMeshNodeRequest) -> anyhow::Result<Self> {
         validate_no_leak_request(&request)?;
@@ -295,6 +356,11 @@ impl DesktopMeshRuntime {
                     .model(model)
                     .api_port(mesh_api_port()?)
                     .console_port(mesh_console_port()?)
+                    // Buzz-owned serve config: re-asserts the telemetry/blobstore
+                    // no-leak disables (which taking config_path suppresses in
+                    // mesh-llm's prepare_isolated_config) and pins reasoning off
+                    // by default so agent consumers don't burn thinking tokens.
+                    .config_path(ensure_buzz_serve_config()?)
                     // No-leak invariants: never publish mesh presence, never
                     // auto-discover other meshes, no public Nostr relays.
                     // Iroh relays are transport-only and enabled by default


### PR DESCRIPTION
## What

Make **reasoning off the default** for Buzz shared-compute serve nodes, so
reasoning models don't burn hidden "thinking" tokens on every agent turn.

Motivation: trying `Qwen3.6-35B-A3B` (4-bit) as an agentic model for goose /
Buzz agents. It tool-calls fine, but it's a reasoning model — a **one-word
reply cost 161 completion tokens** because of hidden thinking. Under the agent
harness that's slow and expensive on every turn.

## Approach (buzz-only — no mesh-llm change, no global config change)

Today Buzz lets mesh-llm synthesise an *isolated* throwaway serve config
(`prepare_isolated_config` in `mesh-llm-host-runtime`) that disables only the
`telemetry` + `blobstore` plugins. Nothing sets a reasoning default, so the
model serves with its native thinking behaviour on.

This PR points the embedded serve node at a **Buzz-owned config file** via the
SDK builder's existing `.config_path()` method:

- `ensure_buzz_serve_config()` writes `~/.mesh-llm/buzz-serve-config.toml`
  (a **distinct file** — never the user's global `config.toml`).
- It re-asserts the telemetry/blobstore no-leak disables (taking `config_path`
  suppresses mesh-llm's synthesised isolated config, so we must carry them).
- It adds a reasoning-off request default.
- Clients can still opt back into thinking per request.

```toml
[[plugin]]
name = "telemetry"
enabled = false

[[plugin]]
name = "blobstore"
enabled = false

[defaults.request_defaults]
reasoning_enabled = false

[defaults.request_defaults.chat_template_kwargs]
enable_thinking = false
```

## Why this seam is safe

- `mesh-llm-sdk`'s `EmbeddedServeConfig::builder()` already exposes
  `config_path()` (via the shared `impl_common_builder_methods!` macro) — no
  mesh-llm change needed.
- `config_path` resolves to a **single TOML file used verbatim**
  (`mesh-llm-config/src/store.rs::config_path`), not a directory. Missing file
  → `MeshConfig::default()`, so a bad path can't wedge serving.
- Buzz never reads or writes the global `~/.mesh-llm/config.toml`.

## ⚠️ DRAFT — what's proven vs. not

**Proven:**
- Per-request reasoning-off knobs work on the model: `reasoning_effort:"none"`,
  top-level `enable_thinking:false`, and `chat_template_kwargs.enable_thinking:false`
  each dropped a 1-word reply from **161 → 3** completion tokens. Tool-calling
  still works.
- The `config_path` plumbing (file path, verbatim, safe fallback).
- `cargo check --features mesh-llm` passes; `cargo fmt` clean.

**NOT yet proven (needs whoever picks this up):**
- The reasoning-off **config default** silencing end-to-end. In a live test via
  `MESH_LLM_CONFIG` (same resolver as `config_path`), `reasoning_enabled = false`
  as a *config default* did **not** silence (still 161 tokens).
- `chat_template_kwargs.enable_thinking = false` as a *config default* was never
  cleanly measured (a run hit a transient `route_to_target` error).
- Those live tests ran against the **mesh-llm 0.72.1 CLI**; the app embeds
  **0.73.1** (this branch's pin). Behaviour must be confirmed on the embedded
  runtime the app actually uses.

So this is a **scaffold**: mechanism verified and compiling, but the config
content that actually turns thinking off is not yet confirmed on the real
runtime. The two likely follow-ups:
1. Confirm which `request_defaults` key mesh-llm 0.73.1 honours as a *default*
   (vs. only per-request), and keep just that one; or
2. If config defaults don't propagate to inbound requests, inject the knob at
   request time instead (bigger change — Buzz is the server, so this would mean
   a request-rewriting shim in front of the embedded node).

## Test notes

- Model: `unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_M` (mesh-llm's 4-bit resolution
  of `:Q4_K_M`), Metal, Apple Silicon.
- To verify end-to-end: `just mesh=1 dev`, Settings → Share compute, serve that
  model, then `POST /v1/chat/completions` (no reasoning field) and check
  `usage.completion_tokens` for a one-word prompt — want a low count, not ~160.

## Files

- `desktop/src-tauri/src/mesh_llm/mod.rs` — `ensure_buzz_serve_config()` +
  `.config_path(...)` on the serve builder.
