### PR TITLE
feat(chart): add relay.deploymentAnnotations for Reloader support

### DIFF
--- a/deploy/charts/buzz/Chart.yaml
+++ b/deploy/charts/buzz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   PostgreSQL and Redis. Configurable for single-node evaluation
   (subcharts on) and HA production (external services, existingSecret).
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 home: https://github.com/block/buzz
 sources:
@@ -25,6 +25,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Initial chart for Buzz relay.
+    - kind: added
+      description: relay.deploymentAnnotations knob for Deployment-level annotations (e.g. Stakater Reloader).
   artifacthub.io/license: Apache-2.0
 
 # Optional eval-only subcharts. Production deploys disable both and point

--- a/deploy/charts/buzz/templates/deployment.yaml
+++ b/deploy/charts/buzz/templates/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "buzz.fullname" . }}
   labels:
     {{- include "buzz.labels" . | nindent 4 }}
+  {{- with .Values.relay.deploymentAnnotations }}
+  # Deployment-level annotations, e.g. Stakater Reloader to auto-roll pods
+  # when an external Secret (DB/Redis creds) rotates.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -133,6 +133,10 @@ relay:
 
   podAnnotations: {}
   podLabels: {}
+  # Annotations on the relay Deployment resource itself (not the pod template).
+  # Set e.g. secret.reloader.stakater.com/reload: <secret-name> to have
+  # Stakater Reloader roll the pods when that Secret rotates.
+  deploymentAnnotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## What

Adds a `relay.deploymentAnnotations` values knob (default `{}`) to the Buzz relay chart, rendered onto the relay **Deployment's own `metadata.annotations`**. Bumps the chart to `0.1.4`.

## Why

The chart only exposed pod-template annotations (`relay.podAnnotations`). [Stakater Reloader](https://github.com/stakater/Reloader) reads its trigger annotations (`secret.reloader.stakater.com/reload`, `reloader.stakater.com/auto`) from the **Deployment's** `metadata.annotations`, not the pod template — so there was no way to opt a deployment into auto-rolling when a Secret changes.

This matters when DB/Redis credentials come from a Secret injected as **pod env vars**: env vars are read once at process start, so if the backing Secret is later updated (e.g. a credential rotation), running pods keep the stale value and can fail auth until they are manually rolled. The chart's existing `checksum/secret` pod annotation only tracks the *chart-managed* Secret, so it doesn't cover externally-managed Secrets.

With this knob a consumer can set:

```yaml
relay:
  deploymentAnnotations:
    secret.reloader.stakater.com/reload: <secret-name>
```

and Reloader will auto-roll the pods when that Secret changes (requires the Reloader controller running in-cluster).

## Rendered output

```yaml
kind: Deployment
metadata:
  name: t-buzz
  labels:
    ...
  annotations:
    secret.reloader.stakater.com/reload: <secret-name>
spec:
  ...
```

Default (unset) renders no `annotations` block — no behavior change for existing consumers.

## Testing

- `helm lint` clean.
- `helm template` verified both cases: default emits no Deployment-level `annotations`; with the value set, the annotation lands at `Deployment.metadata.annotations` (where Reloader reads it), not the pod template.

## Follow-ups (downstream, not in this PR)

- Publish `0.1.4` to the OCI chart repo, then bump the dep + set the annotation in consumer values.
- Requires the Reloader controller to be installed in the target cluster for the annotation to take effect.
