### PR TITLE
feat(join-policy): separate Content Guidelines from Terms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -211,6 +211,7 @@ RUST_LOG=buzz_relay=debug,buzz_db=debug,buzz_auth=debug,buzz_pubsub=debug,tower_
 # Optional relay join policy. Markdown is served by the relay so every join
 # surface can present the same documents. Each document and the independent age
 # attestation are optional; configuring any one enables policy acceptance.
+# BUZZ_CONTENT_GUIDELINES_MARKDOWN="# Content Guidelines\n\nFull guidelines here."
 # BUZZ_TERMS_OF_SERVICE_MARKDOWN="# Terms of Service\n\nFull terms here."
 # BUZZ_PRIVACY_POLICY_MARKDOWN="# Privacy Policy\n\nFull policy here."
 # BUZZ_AGE_ATTESTATION_REQUIRED=true

--- a/crates/buzz-relay/src/api/invites.rs
+++ b/crates/buzz-relay/src/api/invites.rs
@@ -76,6 +76,7 @@ pub async fn join_policy(State(state): State<Arc<AppState>>) -> Json<Value> {
     match &state.config.join_policy {
         Some(policy) => Json(serde_json::json!({
             "policy": {
+                "content_guidelines_markdown": policy.content_guidelines_markdown,
                 "terms_markdown": policy.terms_markdown,
                 "privacy_markdown": policy.privacy_markdown,
                 "age_attestation_required": policy.age_attestation_required,
@@ -84,6 +85,15 @@ pub async fn join_policy(State(state): State<Arc<AppState>>) -> Json<Value> {
         })),
         None => Json(serde_json::json!({})),
     }
+}
+
+/// `GET /api/join-policy/content-guidelines` — Content Guidelines as a standalone HTML page.
+pub async fn join_policy_content_guidelines(
+    State(state): State<Arc<AppState>>,
+) -> Result<Html<String>, (StatusCode, Json<Value>)> {
+    policy_document_page(&state, "Content Guidelines", |policy| {
+        policy.content_guidelines_markdown.as_deref()
+    })
 }
 
 /// `GET /api/join-policy/terms` — Terms of Service as a standalone HTML page.
@@ -675,6 +685,7 @@ mod tests {
         let mut state_inner = (*state).clone();
         let mut config = state_inner.config.as_ref().clone();
         config.join_policy = Some(crate::config::JoinPolicyConfig {
+            content_guidelines_markdown: Some("# Content Guidelines".to_string()),
             terms_markdown: Some("# Terms".to_string()),
             privacy_markdown: Some("# Privacy".to_string()),
             age_attestation_required: true,
@@ -1264,16 +1275,21 @@ mod tests {
             }
         };
 
-        // Unconfigured relay: both documents 404.
+        // Unconfigured relay: all documents 404.
+        let response = get_page(state.clone(), "/api/join-policy/content-guidelines").await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
         let response = get_page(state.clone(), "/api/join-policy/terms").await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         let response = get_page(state.clone(), "/api/join-policy/privacy").await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-        // Configure terms only — terms serves HTML, privacy still 404s.
+        // Configure guidelines and terms — both serve HTML, privacy still 404s.
         let mut state_inner = (*state).clone();
         let mut config = state_inner.config.as_ref().clone();
         config.join_policy = Some(crate::config::JoinPolicyConfig {
+            content_guidelines_markdown: Some(
+                "# Content Guidelines\n\nBe kind to people and agents.".to_string(),
+            ),
             terms_markdown: Some("# Terms\n\nNo funny business.".to_string()),
             privacy_markdown: None,
             age_attestation_required: false,
@@ -1281,6 +1297,15 @@ mod tests {
         });
         state_inner.config = Arc::new(config);
         let state = Arc::new(state_inner);
+
+        let response = get_page(state.clone(), "/api/join-policy/content-guidelines").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("read body");
+        let page = String::from_utf8(bytes.to_vec()).expect("utf8");
+        assert!(page.contains("<h1>Content Guidelines</h1>"), "{page}");
+        assert!(page.contains("Be kind to people and agents."), "{page}");
 
         let response = get_page(state.clone(), "/api/join-policy/terms").await;
         assert_eq!(response.status(), StatusCode::OK);

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -27,6 +27,8 @@ pub enum ConfigError {
 /// Relay-hosted policy content presented on join surfaces.
 #[derive(Debug, Clone)]
 pub struct JoinPolicyConfig {
+    /// Operator-provided Content Guidelines document in Markdown.
+    pub content_guidelines_markdown: Option<String>,
     /// Operator-provided Terms of Service document in Markdown.
     pub terms_markdown: Option<String>,
     /// Operator-provided Privacy Policy document in Markdown.
@@ -665,21 +667,28 @@ impl Config {
             }
             Ok(value)
         };
+        let content_guidelines_markdown = read_policy_markdown("BUZZ_CONTENT_GUIDELINES_MARKDOWN")?;
         let terms_markdown = read_policy_markdown("BUZZ_TERMS_OF_SERVICE_MARKDOWN")?;
         let privacy_markdown = read_policy_markdown("BUZZ_PRIVACY_POLICY_MARKDOWN")?;
         let age_attestation_required = parse_optional_bool("BUZZ_AGE_ATTESTATION_REQUIRED")?;
-        let join_policy = if terms_markdown.is_none()
+        let join_policy = if content_guidelines_markdown.is_none()
+            && terms_markdown.is_none()
             && privacy_markdown.is_none()
             && !age_attestation_required
         {
             None
         } else {
             let mut hasher = Sha256::new();
+            if let Some(markdown) = &content_guidelines_markdown {
+                hasher.update(markdown.as_bytes());
+                hasher.update([0]);
+            }
             hasher.update(terms_markdown.as_deref().unwrap_or_default().as_bytes());
             hasher.update([0]);
             hasher.update(privacy_markdown.as_deref().unwrap_or_default().as_bytes());
             hasher.update([0, u8::from(age_attestation_required)]);
             Some(JoinPolicyConfig {
+                content_guidelines_markdown,
                 terms_markdown,
                 privacy_markdown,
                 age_attestation_required,
@@ -822,6 +831,42 @@ mod tests {
             config.huddle_audio_available,
             "huddle_audio_available should default to true so single-pod (N=1) keeps today's huddle behavior"
         );
+    }
+
+    #[test]
+    fn content_guidelines_enable_join_policy_and_change_its_version() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let env_names = [
+            "BUZZ_CONTENT_GUIDELINES_MARKDOWN",
+            "BUZZ_TERMS_OF_SERVICE_MARKDOWN",
+            "BUZZ_PRIVACY_POLICY_MARKDOWN",
+            "BUZZ_AGE_ATTESTATION_REQUIRED",
+        ];
+        let previous = env_names.map(|name| (name, std::env::var_os(name)));
+        for name in env_names {
+            std::env::remove_var(name);
+        }
+
+        std::env::set_var("BUZZ_CONTENT_GUIDELINES_MARKDOWN", "# Guidelines v1");
+        let first = Config::from_env().expect("content guidelines policy");
+        std::env::set_var("BUZZ_CONTENT_GUIDELINES_MARKDOWN", "# Guidelines v2");
+        let second = Config::from_env().expect("updated content guidelines policy");
+
+        for (name, value) in previous {
+            if let Some(value) = value {
+                std::env::set_var(name, value);
+            } else {
+                std::env::remove_var(name);
+            }
+        }
+
+        let first = first.join_policy.expect("join policy enabled");
+        let second = second.join_policy.expect("join policy enabled");
+        assert_eq!(
+            first.content_guidelines_markdown.as_deref(),
+            Some("# Guidelines v1")
+        );
+        assert_ne!(first.version, second.version);
     }
 
     #[test]

--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -87,6 +87,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // Policy documents as standalone pages — desktop opens these in the
         // system browser instead of rendering the Markdown in-app.
         .route(
+            "/api/join-policy/content-guidelines",
+            get(api::invites::join_policy_content_guidelines),
+        )
+        .route(
             "/api/join-policy/terms",
             get(api::invites::join_policy_terms),
         )

--- a/desktop/src/features/communities/ui/AddCommunityDialog.tsx
+++ b/desktop/src/features/communities/ui/AddCommunityDialog.tsx
@@ -147,10 +147,14 @@ export function AddCommunityDialog({
         }
         if (
           policy &&
-          (policy.termsMarkdown || policy.privacyMarkdown) &&
+          (policy.contentGuidelinesMarkdown ||
+            policy.termsMarkdown ||
+            policy.privacyMarkdown) &&
           !agreementConfirmed
         ) {
-          setInviteError("Agree to the Terms of Service and Privacy Policy.");
+          setInviteError(
+            "Confirm that you have read the Content Guidelines and agree to the Terms of Service and Privacy Policy.",
+          );
           return;
         }
 
@@ -399,7 +403,9 @@ export function AddCommunityDialog({
                 Boolean(joinPolicy?.ageAttestationRequired && !ageConfirmed) ||
                 Boolean(
                   joinPolicy &&
-                    (joinPolicy.termsMarkdown || joinPolicy.privacyMarkdown) &&
+                    (joinPolicy.contentGuidelinesMarkdown ||
+                      joinPolicy.termsMarkdown ||
+                      joinPolicy.privacyMarkdown) &&
                     !agreementConfirmed,
                 )
               }

--- a/desktop/src/features/communities/ui/CommunityEditForm.tsx
+++ b/desktop/src/features/communities/ui/CommunityEditForm.tsx
@@ -126,10 +126,14 @@ export function CommunityEditForm({
             return;
           }
           if (
-            (policy.termsMarkdown || policy.privacyMarkdown) &&
+            (policy.contentGuidelinesMarkdown ||
+              policy.termsMarkdown ||
+              policy.privacyMarkdown) &&
             !agreementConfirmed
           ) {
-            setError("Agree to the Terms of Service and Privacy Policy.");
+            setError(
+              "Confirm that you have read the Content Guidelines and agree to the Terms of Service and Privacy Policy.",
+            );
             return;
           }
         } catch (policyError) {
@@ -311,7 +315,9 @@ export function CommunityEditForm({
             Boolean(joinPolicy?.ageAttestationRequired && !ageConfirmed) ||
             Boolean(
               joinPolicy &&
-                (joinPolicy.termsMarkdown || joinPolicy.privacyMarkdown) &&
+                (joinPolicy.contentGuidelinesMarkdown ||
+                  joinPolicy.termsMarkdown ||
+                  joinPolicy.privacyMarkdown) &&
                 !agreementConfirmed,
             )
           }

--- a/desktop/src/features/onboarding/ui/InviteRedeemForm.tsx
+++ b/desktop/src/features/onboarding/ui/InviteRedeemForm.tsx
@@ -133,10 +133,14 @@ export function InviteRedeemForm({
           return;
         }
         if (
-          (policy.termsMarkdown || policy.privacyMarkdown) &&
+          (policy.contentGuidelinesMarkdown ||
+            policy.termsMarkdown ||
+            policy.privacyMarkdown) &&
           !agreementConfirmed
         ) {
-          setPolicyError("Agree to the Terms of Service and Privacy Policy.");
+          setPolicyError(
+            "Confirm that you have read the Content Guidelines and agree to the Terms of Service and Privacy Policy.",
+          );
           return;
         }
 
@@ -296,7 +300,9 @@ export function InviteRedeemForm({
           Boolean(joinPolicy?.ageAttestationRequired && !ageConfirmed) ||
           Boolean(
             joinPolicy &&
-              (joinPolicy.termsMarkdown || joinPolicy.privacyMarkdown) &&
+              (joinPolicy.contentGuidelinesMarkdown ||
+                joinPolicy.termsMarkdown ||
+                joinPolicy.privacyMarkdown) &&
               !agreementConfirmed,
           )
         }

--- a/desktop/src/features/onboarding/ui/JoinPolicyNotice.tsx
+++ b/desktop/src/features/onboarding/ui/JoinPolicyNotice.tsx
@@ -18,8 +18,9 @@ type JoinPolicyNoticeProps = {
 /**
  * Join-policy consent block shown on every join surface.
  *
- * The Terms/Privacy links open the relay-hosted document pages
- * (`/api/join-policy/terms|privacy`) in the system browser via the OS
+ * The Content Guidelines, Terms, and Privacy links open the relay-hosted
+ * document pages (`/api/join-policy/content-guidelines|terms|privacy`) in the
+ * system browser via the OS
  * opener. They must NOT navigate or render in-app: these surfaces exist
  * before onboarding completes, where the router (required by the message
  * Markdown component) is not mounted — an in-app render tears down the
@@ -57,9 +58,12 @@ export function JoinPolicyNotice({
         </div>
       ) : null}
 
-      {policy.termsMarkdown || policy.privacyMarkdown ? (
+      {policy.contentGuidelinesMarkdown ||
+      policy.termsMarkdown ||
+      policy.privacyMarkdown ? (
         <div className="flex items-start gap-3">
           <Checkbox
+            aria-label="I have read the Content Guidelines and agree to the Buzz Terms of Service and Privacy Policy."
             checked={agreementConfirmed}
             className="mt-0.5"
             id={agreementConfirmationId}
@@ -71,7 +75,25 @@ export function JoinPolicyNotice({
             className="cursor-pointer text-xs leading-5 text-muted-foreground"
             htmlFor={agreementConfirmationId}
           >
-            I agree to the Buzz{" "}
+            I have read the{" "}
+            {policy.contentGuidelinesMarkdown ? (
+              <Button
+                className="h-auto p-0 align-baseline text-xs no-underline hover:underline focus-visible:no-underline"
+                onClick={(event) => {
+                  event.preventDefault();
+                  void openUrl(
+                    joinPolicyDocumentUrl(relayWsUrl, "content-guidelines"),
+                  );
+                }}
+                type="button"
+                variant="link"
+              >
+                Content Guidelines
+              </Button>
+            ) : (
+              "Content Guidelines"
+            )}{" "}
+            and agree to the Buzz{" "}
             {policy.termsMarkdown ? (
               <Button
                 className="h-auto p-0 align-baseline text-xs no-underline hover:underline focus-visible:no-underline"
@@ -84,8 +106,10 @@ export function JoinPolicyNotice({
               >
                 Terms of Service
               </Button>
-            ) : null}
-            {policy.termsMarkdown && policy.privacyMarkdown ? " and " : null}
+            ) : (
+              "Terms of Service"
+            )}{" "}
+            and{" "}
             {policy.privacyMarkdown ? (
               <Button
                 className="h-auto p-0 align-baseline text-xs no-underline hover:underline focus-visible:no-underline"
@@ -98,7 +122,9 @@ export function JoinPolicyNotice({
               >
                 Privacy Policy
               </Button>
-            ) : null}
+            ) : (
+              "Privacy Policy"
+            )}
             .
           </label>
         </div>

--- a/desktop/src/shared/api/invites.test.mjs
+++ b/desktop/src/shared/api/invites.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getJoinPolicy } from "./invites.ts";
+import { getJoinPolicy, joinPolicyDocumentUrl } from "./invites.ts";
 
 function withFetch(response, run) {
   const originalFetch = globalThis.fetch;
@@ -14,11 +14,27 @@ function withFetch(response, run) {
   });
 }
 
+test("joinPolicyDocumentUrl creates independent document URLs", () => {
+  assert.equal(
+    joinPolicyDocumentUrl("wss://relay.example", "content-guidelines"),
+    "https://relay.example/api/join-policy/content-guidelines",
+  );
+  assert.equal(
+    joinPolicyDocumentUrl("wss://relay.example", "terms"),
+    "https://relay.example/api/join-policy/terms",
+  );
+  assert.equal(
+    joinPolicyDocumentUrl("wss://relay.example", "privacy"),
+    "https://relay.example/api/join-policy/privacy",
+  );
+});
+
 test("getJoinPolicy maps relay-hosted Markdown and age requirements", async () => {
   await withFetch(
     new Response(
       JSON.stringify({
         policy: {
+          content_guidelines_markdown: "# Content Guidelines",
           terms_markdown: "# Terms",
           privacy_markdown: "# Privacy",
           age_attestation_required: true,
@@ -29,6 +45,7 @@ test("getJoinPolicy maps relay-hosted Markdown and age requirements", async () =
     ),
     async () => {
       assert.deepEqual(await getJoinPolicy("wss://relay.example"), {
+        contentGuidelinesMarkdown: "# Content Guidelines",
         termsMarkdown: "# Terms",
         privacyMarkdown: "# Privacy",
         ageAttestationRequired: true,

--- a/desktop/src/shared/api/invites.ts
+++ b/desktop/src/shared/api/invites.ts
@@ -24,6 +24,7 @@ export type MintedInvite = {
 };
 
 export type JoinPolicy = {
+  contentGuidelinesMarkdown?: string;
   termsMarkdown?: string;
   privacyMarkdown?: string;
   ageAttestationRequired: boolean;
@@ -100,7 +101,7 @@ async function invitePost<T>(
 /** Absolute URL of a relay-hosted policy document page (system-browser target). */
 export function joinPolicyDocumentUrl(
   relayWsUrl: string,
-  document: "terms" | "privacy",
+  document: "content-guidelines" | "terms" | "privacy",
 ): string {
   const base = relayHttpFromWs(relayWsUrl);
   return `${base.replace(/\/+$/, "")}/api/join-policy/${document}`;
@@ -132,6 +133,7 @@ export async function getJoinPolicy(
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   const raw = (await response.json()) as {
     policy?: {
+      content_guidelines_markdown?: string;
       terms_markdown?: string;
       privacy_markdown?: string;
       age_attestation_required: boolean;
@@ -140,6 +142,7 @@ export async function getJoinPolicy(
   };
   return raw.policy
     ? {
+        contentGuidelinesMarkdown: raw.policy.content_guidelines_markdown,
         termsMarkdown: raw.policy.terms_markdown,
         privacyMarkdown: raw.policy.privacy_markdown,
         ageAttestationRequired: raw.policy.age_attestation_required,

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -1641,6 +1641,7 @@ test("denied on relay A then paste relay B invite URL switches community to B", 
       contentType: "application/json",
       body: JSON.stringify({
         policy: {
+          content_guidelines_markdown: "# Content Guidelines",
           terms_markdown: "# Terms",
           privacy_markdown: "# Privacy",
           age_attestation_required: true,
@@ -1690,7 +1691,9 @@ test("denied on relay A then paste relay B invite URL switches community to B", 
   await expect(page.getByText("I am 18 years of age or older.")).toBeVisible();
   await page.getByLabel("I am 18 years of age or older.").check();
   await page
-    .getByLabel("I agree to the Buzz Terms of Service and Privacy Policy.")
+    .getByLabel(
+      "I have read the Content Guidelines and agree to the Buzz Terms of Service and Privacy Policy.",
+    )
     .check();
   await page.getByTestId("invite-redeem-submit").click();
 

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -68,6 +68,7 @@ test("automatically shows relay join requirements near the relay URL", async ({
         contentType: "application/json",
         body: JSON.stringify({
           policy: {
+            content_guidelines_markdown: "# Content Guidelines",
             terms_markdown: "# Terms",
             privacy_markdown: "# Privacy",
             age_attestation_required: true,
@@ -85,10 +86,37 @@ test("automatically shows relay join requirements near the relay URL", async ({
 
   const ageConfirmation = page.getByLabel("I am 18 years of age or older.");
   const agreementConfirmation = page.getByLabel(
-    "I agree to the Buzz Terms of Service and Privacy Policy.",
+    "I have read the Content Guidelines and agree to the Buzz Terms of Service and Privacy Policy.",
   );
   await expect(ageConfirmation).toBeVisible();
   await expect(agreementConfirmation).toBeVisible();
+  for (const [name, path] of [
+    ["Content Guidelines", "content-guidelines"],
+    ["Terms of Service", "terms"],
+    ["Privacy Policy", "privacy"],
+  ] as const) {
+    await page.getByRole("button", { name }).click();
+    await expect
+      .poll(() =>
+        page.evaluate((expectedPath) => {
+          const log = (
+            window as Window & {
+              __BUZZ_E2E_COMMAND_LOG__?: Array<{
+                command: string;
+                payload: { url?: string };
+              }>;
+            }
+          ).__BUZZ_E2E_COMMAND_LOG__;
+          return log?.some(
+            (entry) =>
+              entry.command === "plugin:opener|open_url" &&
+              entry.payload?.url ===
+                `https://policy.example.com/api/join-policy/${expectedPath}`,
+          );
+        }, path),
+      )
+      .toBe(true);
+  }
   await expect(
     page.getByText("Review this relay's join policy below."),
   ).toHaveCount(0);

--- a/web/src/features/invite/ui/InviteJoinPolicyNotice.tsx
+++ b/web/src/features/invite/ui/InviteJoinPolicyNotice.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 type InviteJoinPolicy = {
+  content_guidelines_markdown?: string;
   terms_markdown?: string;
   privacy_markdown?: string;
   age_attestation_required: boolean;
@@ -111,13 +112,33 @@ export function InviteJoinPolicyNotice({
         </PolicyCheckbox>
       ) : null}
 
-      {policy.terms_markdown || policy.privacy_markdown ? (
+      {policy.content_guidelines_markdown ||
+      policy.terms_markdown ||
+      policy.privacy_markdown ? (
         <PolicyCheckbox
-          accessibleLabel="I agree to the Buzz Terms of Service and Privacy Policy."
+          accessibleLabel="I have read the Content Guidelines and agree to the Buzz Terms of Service and Privacy Policy."
           checked={agreementConfirmed}
           onCheckedChange={onAgreementConfirmedChange}
         >
-          I agree to the Buzz{" "}
+          I have read the{" "}
+          {policy.content_guidelines_markdown ? (
+            <button
+              className="text-black no-underline underline-offset-4 hover:text-black/70 hover:underline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-black"
+              type="button"
+              onClick={(event) =>
+                stopLabelActivation(
+                  event,
+                  "Content Guidelines",
+                  policy.content_guidelines_markdown ?? "",
+                )
+              }
+            >
+              Content Guidelines
+            </button>
+          ) : (
+            "Content Guidelines"
+          )}{" "}
+          and agree to the Buzz{" "}
           {policy.terms_markdown ? (
             <button
               className="text-black no-underline underline-offset-4 hover:text-black/70 hover:underline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-black"

--- a/web/src/features/invite/ui/InvitePage.tsx
+++ b/web/src/features/invite/ui/InvitePage.tsx
@@ -9,6 +9,7 @@ import { InviteJoinPolicyNotice } from "./InviteJoinPolicyNotice";
 
 const DOWNLOAD_URL = "https://github.com/block/buzz/releases/latest";
 type JoinPolicy = {
+  content_guidelines_markdown?: string;
   terms_markdown?: string;
   privacy_markdown?: string;
   age_attestation_required: boolean;
@@ -70,12 +71,15 @@ export function InvitePage({ code }: { code: string }) {
     Boolean(policy?.age_attestation_required && !ageConfirmed) ||
     Boolean(
       policy &&
-        (policy.terms_markdown || policy.privacy_markdown) &&
+        (policy.content_guidelines_markdown ||
+          policy.terms_markdown ||
+          policy.privacy_markdown) &&
         !agreementConfirmed,
     );
   const hasPolicyRequirements = Boolean(
     policy &&
       (policy.age_attestation_required ||
+        policy.content_guidelines_markdown ||
         policy.terms_markdown ||
         policy.privacy_markdown),
   );

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -19,6 +19,7 @@ test("invite requires age and legal consent before opening Buzz", async ({
       contentType: "application/json",
       body: JSON.stringify({
         policy: {
+          content_guidelines_markdown: "# Content Guidelines",
           terms_markdown: "# Terms",
           privacy_markdown: "# Privacy",
           age_attestation_required: true,
@@ -31,7 +32,7 @@ test("invite requires age and legal consent before opening Buzz", async ({
 
   const ageConfirmation = page.getByLabel("I am 18 years of age or older.");
   const agreementConfirmation = page.getByLabel(
-    "I agree to the Buzz Terms of Service and Privacy Policy.",
+    "I have read the Content Guidelines and agree to the Buzz Terms of Service and Privacy Policy.",
   );
   const acceptInvite = page.getByRole("button", {
     name: "Accept invite in Buzz",
@@ -41,8 +42,12 @@ test("invite requires age and legal consent before opening Buzz", async ({
   await expect(agreementConfirmation).toBeVisible();
   await expect(acceptInvite).toBeDisabled();
 
+  const contentGuidelinesLink = page.getByRole("button", {
+    name: "Content Guidelines",
+  });
   const termsLink = page.getByRole("button", { name: "Terms of Service" });
   const privacyLink = page.getByRole("button", { name: "Privacy Policy" });
+  await expect(contentGuidelinesLink).toHaveCSS("text-decoration-line", "none");
   await expect(termsLink).toHaveCSS("text-decoration-line", "none");
   await expect(privacyLink).toHaveCSS("text-decoration-line", "none");
   await termsLink.hover();
@@ -50,6 +55,14 @@ test("invite requires age and legal consent before opening Buzz", async ({
   await page.mouse.move(0, 0);
   await privacyLink.hover();
   await expect(privacyLink).toHaveCSS("text-decoration-line", "underline");
+
+  await contentGuidelinesLink.click();
+  const guidelinesDialog = page.getByRole("dialog", {
+    name: "Content Guidelines",
+  });
+  await expect(guidelinesDialog).toBeVisible();
+  await expect(guidelinesDialog).toContainText("Content Guidelines");
+  await page.getByRole("button", { name: "Close" }).click();
 
   await page
     .locator("label")
@@ -60,7 +73,8 @@ test("invite requires age and legal consent before opening Buzz", async ({
   await page
     .locator("label")
     .filter({
-      hasText: "I agree to the Buzz Terms of Service and Privacy Policy.",
+      hasText:
+        "I have read the Content Guidelines and agree to the Buzz Terms of Service and Privacy Policy.",
     })
     .click({ position: { x: 8, y: 8 } });
   await expect(agreementConfirmation).toBeChecked();


### PR DESCRIPTION
## Summary
- expose Content Guidelines as a relay document independent from Terms of Service
- update desktop community, onboarding, invite-redemption, and join-policy surfaces to use the requested consent copy with three independently clickable documents
- update the invite-link web UI to present the same three distinct document links
- add relay, API, desktop E2E, and web E2E coverage for the independent URLs

## Consent copy
> I have read the Content Guidelines and agree to the Buzz Terms of Service and Privacy Policy.

## Verification
- desktop production build
- focused desktop Playwright coverage
- relay configuration test
- formatting/checks
- distinct-link assertions in desktop and web E2E coverage

## Deployment
Requires the companion `squareup/bb-public` configuration PR to populate `BUZZ_CONTENT_GUIDELINES_MARKDOWN` separately from `BUZZ_TERMS_OF_SERVICE_MARKDOWN`.
