### PR TITLE
fix(desktop): close mention popup after an exact name + trailing space

### DIFF
--- a/desktop/src/shared/lib/detectPrefixQuery.test.mjs
+++ b/desktop/src/shared/lib/detectPrefixQuery.test.mjs
@@ -96,6 +96,30 @@ test("multi-word: glued-to-word prefix still rejected", () => {
   assert.equal(at("#", "x#buzz de", CHANNELS), null);
 });
 
+// ── Completed mention: exact name + trailing space closes the query ───────────
+
+test("exact name followed by space does not stay open for a longer name", () => {
+  // "pinky" is complete; "pinky and the brain" sharing the prefix must not
+  // keep the popup open and steal Enter/Tab.
+  const names = ["pinky", "brain", "pinky and the brain"];
+  assert.equal(at("@", "@pinky ", names), null);
+});
+
+test("typing past the space toward the longer name re-opens the query", () => {
+  const names = ["pinky", "brain", "pinky and the brain"];
+  assert.deepEqual(at("@", "@pinky a", names), {
+    query: "pinky a",
+    startIndex: 0,
+  });
+});
+
+test("multi-word name still completes word by word when no shorter exact match", () => {
+  assert.deepEqual(at("@", "@bob ", PEOPLE), {
+    query: "bob ",
+    startIndex: 0,
+  });
+});
+
 // ── Empty / no-match guards unchanged ─────────────────────────────────────────
 
 test("bare prefix after ( yields empty single-word query, not multi-word", () => {

--- a/desktop/src/shared/lib/detectPrefixQuery.ts
+++ b/desktop/src/shared/lib/detectPrefixQuery.ts
@@ -54,6 +54,15 @@ export function detectPrefixQuery(
         break;
       }
       const lowerCandidate = candidate.toLowerCase();
+      // A trailing space after an exact known name means the mention is
+      // complete — don't keep the query open just because a longer name
+      // (e.g. a team) shares the prefix.
+      if (
+        lowerCandidate.endsWith(" ") &&
+        knownNamesLower.includes(lowerCandidate.trimEnd())
+      ) {
+        break;
+      }
       const isPrefix = knownNamesLower.some((name) =>
         name.startsWith(lowerCandidate),
       );


### PR DESCRIPTION
## Problem

Since #1918 added multi-word team-name matching to mention autocomplete, typing `@Pinky ` (name + trailing space) keeps the mention popup open, because `"pinky "` is still a prefix of the team name `"Pinky and the Brain"`. At that point the team is the **only** suggestion left, so the next Enter/Tab steals the already-completed mention and expands the whole team instead.

## Fix

In `detectPrefixQuery`'s multi-word path: if the text before a trailing space is an **exact** known name, treat the mention as complete and close the query. Typing further toward the longer name (e.g. `@pinky a`) re-opens it, so team names remain fully reachable.

## Testing

- New unit tests: exact-name + space closes (`@pinky ` → null), typing past the space re-opens (`@pinky a`), and multi-word names without a shorter exact match still complete word-by-word (`@bob ` → `bob jones`).
- Full desktop unit suite: 3106 pass.
