### PR TITLE
fix(desktop): limit channel composer blur to input

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -674,7 +674,7 @@ export const ChannelPane = React.memo(function ChannelPane({
             </div>
           ) : (
             <div
-              className="pointer-events-none absolute inset-x-0 bottom-0 z-40 bg-background/70 backdrop-blur-md supports-[backdrop-filter]:bg-background/55"
+              className="pointer-events-none absolute inset-x-0 bottom-0 z-40"
               data-testid="channel-composer-overlay"
               ref={composerWrapperRef}
             >
@@ -725,7 +725,10 @@ export const ChannelPane = React.memo(function ChannelPane({
                   }
                   showTopBorder={false}
                 />
-                <div className="min-h-8 overflow-visible bg-transparent px-5 pb-1.5 pt-0">
+                <div
+                  className="min-h-8 overflow-visible bg-background px-5 pb-1.5 pt-0"
+                  data-testid="channel-composer-activity-row"
+                >
                   <div className="flex h-full w-full items-center gap-2 overflow-visible">
                     {hasComposerBotActivity ? (
                       <div className="flex min-w-0 flex-1 overflow-visible">

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1724,7 +1724,25 @@ test("channel date divider keeps the date sticky while the separator rule scroll
       return Number.parseInt(sharedBackdropZIndex, 10);
     })
     .toBeGreaterThan(Number.parseInt(metrics.dividerZIndex, 10));
-  await expect(page.getByTestId("channel-composer-overlay")).toBeVisible();
+  const composerOverlay = page.getByTestId("channel-composer-overlay");
+  await expect(composerOverlay).toBeVisible();
+  await expect(composerOverlay).toHaveCSS("backdrop-filter", "none");
+  await expect(composerOverlay).toHaveCSS(
+    "background-color",
+    "rgba(0, 0, 0, 0)",
+  );
+  await expect(composerOverlay.getByTestId("message-composer")).not.toHaveCSS(
+    "backdrop-filter",
+    "none",
+  );
+  const composerActivityRow = composerOverlay.getByTestId(
+    "channel-composer-activity-row",
+  );
+  await expect(composerActivityRow).toHaveCSS("backdrop-filter", "none");
+  await expect(composerActivityRow).not.toHaveCSS(
+    "background-color",
+    "rgba(0, 0, 0, 0)",
+  );
   await expect
     .poll(async () => {
       const composerOverlayZIndex = await page


### PR DESCRIPTION
## Summary
- remove the full-width backdrop blur from the main channel composer overlay
- retain blur on the inner message composer card
- assert the overlay stays transparent while the composer remains blurred

## Root cause
The main channel overlay acquired background and backdrop-blur classes in #1698, while the thread overlay stayed transparent. Since the shared `MessageComposer` already blurs its own card, the main channel rendered an extra full-width blurry strip around the composer.

## Test plan
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop exec biome check src/features/channels/ui/ChannelPane.tsx tests/e2e/channels.spec.ts`
- `pnpm --dir desktop build`
- `cd desktop && pnpm exec playwright test ./tests/e2e/channels.spec.ts --grep "channel date divider keeps the date sticky"`
- `just desktop-screenshot --name compose-blur-fixed --route /channels/general --active-channel general` (visually inspected)
- pre-push hooks: desktop check/tests, mobile tests, Rust tests, desktop Tauri tests
