### PR TITLE
Add preferred runtime onboarding

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -11,6 +11,10 @@ web_dir := "web"
 # Turn on to test mesh compute features: `just mesh=1 dev` / `just mesh=1 staging`.
 mesh := ""
 
+# Reset only the current standalone desktop instance before launch.
+# Usage: `just fresh=1 desktop-standalone`.
+fresh := ""
+
 # List all available tasks
 default:
     @just --list
@@ -440,13 +444,20 @@ desktop-standalone *ARGS: _ensure-sidecar-stubs
     TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
     for bin in buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz; do
         cp "${TARGET_DIR}/debug/${bin}" "desktop/src-tauri/binaries/${bin}-${TARGET}"
+        chmod +x "desktop/src-tauri/binaries/${bin}-${TARGET}"
     done
     cd {{desktop_dir}}
     [[ -d node_modules ]] || pnpm install
     unset BUZZ_PRIVATE_KEY BUZZ_SHARE_IDENTITY
+    if [[ -n "{{fresh}}" ]]; then
+        export BUZZ_RESET_WEBVIEW_STATE=1
+    fi
     source ../scripts/instance-env.sh
     INSTANCE_ID=$(node -e "console.log(JSON.parse(process.env.BUZZ_TAURI_CONFIG).identifier)")
     export BUZZ_DEV_KEYRING_SERVICE="buzz-desktop-dev.${BUZZ_INSTANCE_SLUG:-main}"
+    if [[ -n "{{fresh}}" ]]; then
+        ../scripts/reset-desktop-standalone-state.sh "$INSTANCE_ID" "$BUZZ_DEV_KEYRING_SERVICE"
+    fi
     trap '../scripts/cleanup-instance-agents.sh "$INSTANCE_ID" || true' EXIT
     echo "Starting standalone desktop on Vite port ${BUZZ_VITE_PORT}; no relay services were started"
     pnpm exec tauri dev --config "$BUZZ_TAURI_CONFIG" {{ARGS}}

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1320,13 +1320,14 @@ async fn tokio_main() -> Result<()> {
 
     let mut relay_observer_control_rx = None;
     let mut relay_observer_publisher_task = None;
+    let mut relay_observer_publisher = None;
     if config.relay_observer {
         if let (Some(observer), Some(owner_pubkey_hex)) =
             (observer.clone(), owner_cache.pubkey.clone())
         {
             match PublicKey::from_hex(&owner_pubkey_hex) {
                 Ok(owner_pubkey) => {
-                    relay_observer_publisher_task = Some(spawn_relay_observer_publisher(
+                    relay_observer_publisher = Some((
                         observer,
                         relay.event_publisher(),
                         config.keys.clone(),
@@ -1402,12 +1403,27 @@ async fn tokio_main() -> Result<()> {
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
+    let mut subscribed_channel_ids = HashSet::with_capacity(channel_filters.len());
     for (channel_id, filter) in &channel_filters {
         if let Err(e) = relay.subscribe_channel(*channel_id, filter.clone()).await {
             tracing::warn!("failed to subscribe to channel {channel_id}: {e}");
         } else {
+            subscribed_channel_ids.insert(*channel_id);
             tracing::info!("subscribed to channel {channel_id}");
         }
+    }
+
+    if let Some((observer, publisher, keys, agent_pubkey, owner_pubkey, owner)) =
+        relay_observer_publisher.take()
+    {
+        relay_observer_publisher_task = Some(spawn_relay_observer_publisher(
+            observer,
+            publisher,
+            keys,
+            agent_pubkey,
+            owner_pubkey,
+            owner,
+        ));
     }
 
     // Online means the harness can receive work, not merely that its socket is
@@ -1788,15 +1804,20 @@ async fn tokio_main() -> Result<()> {
                                     // stripped for a legitimately re-added channel.
                                     removed_channels.remove(&ch);
 
-                                    if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
+                                    if subscribed_channel_ids.contains(&ch) {
+                                        tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
+                                    } else if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
                                         tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
                                         if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
                                             tracing::warn!("failed to subscribe to new channel {ch}: {e}");
+                                        } else {
+                                            subscribed_channel_ids.insert(ch);
                                         }
                                     } else {
                                         tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
                                     }
                                 } else {
+                                    subscribed_channel_ids.remove(&ch);
                                     tracing::info!(channel_id = %ch, "membership notification: unsubscribing from channel");
                                     if let Err(e) = relay.unsubscribe_channel(ch).await {
                                         tracing::warn!("failed to unsubscribe from channel {ch}: {e}");

--- a/desktop/src-tauri/src/commands/agent_auth.rs
+++ b/desktop/src-tauri/src/commands/agent_auth.rs
@@ -88,7 +88,11 @@ fn connect_acp_runtime_blocking(
         .ok_or_else(|| "auth method is no longer advertised by this adapter".to_string())?;
 
     if uses_terminal_auth(method)? {
-        launch_terminal_auth(&request.runtime_id, method)?;
+        if method.id == "claude-login" && terminal_auth_meta_command(method)?.is_some() {
+            run_claude_login(&request.runtime_id, method)?;
+        } else {
+            launch_terminal_auth(&request.runtime_id, method)?;
+        }
         return Ok(ConnectAcpRuntimeResult { launched: true });
     }
 
@@ -211,6 +215,29 @@ fn command_error(label: &str, output: &std::process::Output) -> String {
     }
 }
 
+fn run_claude_login(runtime_id: &str, method: &AcpAuthMethod) -> Result<(), String> {
+    let runtime = known_acp_runtime_exact(runtime_id)
+        .ok_or_else(|| format!("unknown ACP runtime: {runtime_id}"))?;
+    let argv = adapter_terminal_argv(runtime.label, method, "")?;
+    let (command, args) = argv
+        .split_first()
+        .ok_or_else(|| "Claude login command is empty".to_string())?;
+    let status = Command::new(command)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| format!("failed to run Claude login: {error}"))?;
+    if !status.success() {
+        return Err(format!(
+            "Claude login failed (exit {})",
+            status.code().unwrap_or(-1)
+        ));
+    }
+    Ok(())
+}
+
 fn launch_terminal_auth(runtime_id: &str, method: &AcpAuthMethod) -> Result<(), String> {
     let runtime = known_acp_runtime_exact(runtime_id)
         .ok_or_else(|| format!("unknown ACP runtime: {runtime_id}"))?;
@@ -251,6 +278,9 @@ fn adapter_terminal_argv(
         .unwrap_or_else(|| command.to_string());
     let mut argv = vec![command_path];
     argv.extend(args.iter().cloned());
+    if method.id == "claude-login" && terminal_auth_meta_command(method)?.is_some() {
+        argv.extend(["auth".to_string(), "login".to_string()]);
+    }
     Ok(argv)
 }
 
@@ -564,6 +594,24 @@ mod tests {
         let method: AcpAuthMethod = serde_json::from_str(raw).unwrap();
         assert_eq!(method.method_type, None);
         assert!(uses_terminal_auth(&method).unwrap());
+    }
+
+    #[test]
+    fn claude_terminal_meta_starts_login_flow() {
+        let _guard = crate::managed_agents::lock_path_mutex();
+        let method: AcpAuthMethod = serde_json::from_str(
+            r#"{"_meta":{"terminal-auth":{"args":["/tmp/claude-cli.js"],"command":"definitely-not-on-path-node"}},"id":"claude-login","name":"Log in with Claude"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            adapter_terminal_argv("Claude Code", &method, "unused").unwrap(),
+            vec![
+                "definitely-not-on-path-node".to_string(),
+                "/tmp/claude-cli.js".to_string(),
+                "auth".to_string(),
+                "login".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/agent_auth.rs
+++ b/desktop/src-tauri/src/commands/agent_auth.rs
@@ -3,6 +3,9 @@ use std::{
     process::{Command, Stdio},
 };
 
+#[cfg(target_os = "macos")]
+use std::{fs, io::Write, os::unix::fs::PermissionsExt};
+
 use serde_json::Value;
 
 use serde::{Deserialize, Serialize};
@@ -308,6 +311,7 @@ fn terminal_auth_meta_command(method: &AcpAuthMethod) -> Result<Option<Vec<Strin
     Ok((!argv.is_empty()).then_some(argv))
 }
 
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 fn spawn_without_stdio(mut command: Command) -> Result<(), String> {
     command
         .stdin(Stdio::null())
@@ -320,14 +324,36 @@ fn spawn_without_stdio(mut command: Command) -> Result<(), String> {
 
 #[cfg(target_os = "macos")]
 fn launch_visible_terminal(argv: &[String]) -> Result<(), String> {
-    let command = shell_join(argv);
-    let script = format!(
-        "tell application \"Terminal\"\n  activate\n  do script {}\nend tell",
-        applescript_string(&command)
-    );
-    let mut command = Command::new("osascript");
-    command.arg("-e").arg(script);
-    spawn_without_stdio(command)
+    let mut script = tempfile::Builder::new()
+        .prefix("buzz-auth-")
+        .suffix(".command")
+        .tempfile()
+        .map_err(|error| format!("failed to create terminal login script: {error}"))?;
+    writeln!(
+        script,
+        "#!/bin/sh\ntrap 'rm -f -- \"$0\"' EXIT\n{}",
+        shell_join(argv)
+    )
+    .map_err(|error| format!("failed to write terminal login script: {error}"))?;
+    fs::set_permissions(script.path(), fs::Permissions::from_mode(0o700))
+        .map_err(|error| format!("failed to prepare terminal login script: {error}"))?;
+    let script = script
+        .into_temp_path()
+        .keep()
+        .map_err(|error| format!("failed to preserve terminal login script: {error}"))?;
+
+    let status = Command::new("open")
+        .arg(&script)
+        .status()
+        .map_err(|error| format!("failed to open terminal: {error}"))?;
+    if !status.success() {
+        let _ = fs::remove_file(&script);
+        return Err(format!(
+            "failed to open terminal (exit {})",
+            status.code().unwrap_or(-1)
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
@@ -392,11 +418,6 @@ fn shell_escape(arg: &str) -> String {
         return arg.to_string();
     }
     format!("'{}'", arg.replace('\'', "'\\''"))
-}
-
-#[cfg(target_os = "macos")]
-fn applescript_string(value: &str) -> String {
-    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/commands/agent_auth.rs
+++ b/desktop/src-tauri/src/commands/agent_auth.rs
@@ -84,7 +84,7 @@ fn connect_acp_runtime_blocking(
         .find(|candidate| candidate.id == request.method_id)
         .ok_or_else(|| "auth method is no longer advertised by this adapter".to_string())?;
 
-    if method.method_type.as_deref() == Some("terminal") {
+    if uses_terminal_auth(method)? {
         launch_terminal_auth(&request.runtime_id, method)?;
         return Ok(ConnectAcpRuntimeResult { launched: true });
     }
@@ -251,6 +251,11 @@ fn adapter_terminal_argv(
     Ok(argv)
 }
 
+fn uses_terminal_auth(method: &AcpAuthMethod) -> Result<bool, String> {
+    Ok(method.method_type.as_deref() == Some("terminal")
+        || terminal_auth_meta_command(method)?.is_some())
+}
+
 fn terminal_auth_meta_command(method: &AcpAuthMethod) -> Result<Option<Vec<String>>, String> {
     let Some(meta) = method.meta.as_ref() else {
         return Ok(None);
@@ -398,7 +403,7 @@ fn applescript_string(value: &str) -> String {
 mod tests {
     use super::{
         adapter_terminal_argv, append_inherited_path, run_buzz_acp_auth_command_with_paths,
-        shell_escape, shell_join, windows_terminal_args, AcpAuthMethod,
+        shell_escape, shell_join, uses_terminal_auth, windows_terminal_args, AcpAuthMethod,
     };
 
     /// Windows regression: the augmented PATH there holds only Buzz-managed
@@ -530,6 +535,14 @@ mod tests {
         let method: AcpAuthMethod = serde_json::from_str(raw).unwrap();
         assert_eq!(method.method_type.as_deref(), Some("terminal"));
         assert_eq!(method.command[0], "claude");
+    }
+
+    #[test]
+    fn claude_terminal_meta_routes_around_unimplemented_authenticate() {
+        let raw = r#"{"_meta":{"terminal-auth":{"args":["/tmp/claude-cli.js"],"command":"node","label":"Claude Login"}},"description":"Run `claude /login` in the terminal","id":"claude-login","name":"Log in with Claude"}"#;
+        let method: AcpAuthMethod = serde_json::from_str(raw).unwrap();
+        assert_eq!(method.method_type, None);
+        assert!(uses_terminal_auth(&method).unwrap());
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/global_config/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/global_config/mod.rs
@@ -63,6 +63,10 @@ pub struct GlobalAgentConfig {
     /// a model. `None` = no global default.
     #[serde(default)]
     pub model: Option<String>,
+
+    /// Preferred ACP runtime for definitions without an explicit runtime.
+    #[serde(default)]
+    pub preferred_runtime: Option<String>,
 }
 
 /// Validate a `GlobalAgentConfig` before persisting it.

--- a/desktop/src-tauri/src/managed_agents/global_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/global_config/tests.rs
@@ -266,6 +266,7 @@ fn roundtrip_serialization() {
         env_vars: BTreeMap::from([("ANTHROPIC_API_KEY".to_string(), "sk-test".to_string())]),
         provider: Some("anthropic".to_string()),
         model: Some("claude-opus-4".to_string()),
+        preferred_runtime: Some("claude".to_string()),
     };
     let json = serde_json::to_string(&config).expect("serialize");
     let back: GlobalAgentConfig = serde_json::from_str(&json).expect("deserialize");
@@ -582,6 +583,7 @@ fn populated_global_config_round_trips() {
             .collect(),
         provider: Some("anthropic".to_string()),
         model: Some("claude-opus-4-5".to_string()),
+        preferred_runtime: None,
     };
     let json = serde_json::to_string(&original).expect("serialization must not fail");
     let decoded: GlobalAgentConfig =

--- a/desktop/src/features/agents/lib/instanceInputForDefinition.test.mjs
+++ b/desktop/src/features/agents/lib/instanceInputForDefinition.test.mjs
@@ -120,6 +120,23 @@ test("row 3: plain avatar URLs pass through; base64 data URIs upload via the inj
   assert.equal(uploads.length, 1, "upload must go through the injected fn");
 });
 
+test("row 3: failed persona avatar upload never substitutes the runtime avatar", async () => {
+  const input = await buildInstanceInputForDefinition(
+    persona({
+      id: "builtin:fizz",
+      displayName: "Fizz",
+      avatarUrl: "data:image/png;base64,aGk=",
+    }),
+    claudeRuntime,
+    async () => {
+      throw new Error("upload failed");
+    },
+  );
+
+  assert.equal(input.avatarUrl, undefined);
+  assert.notEqual(input.avatarUrl, claudeRuntime.avatarUrl);
+});
+
 test("mapping carries the runtime and definition fields", async () => {
   const input = await buildInstanceInputForDefinition(persona(), gooseRuntime);
   assert.equal(input.name, "Test Agent");

--- a/desktop/src/features/agents/lib/instanceInputForDefinition.ts
+++ b/desktop/src/features/agents/lib/instanceInputForDefinition.ts
@@ -50,10 +50,7 @@ export function resolveStartRuntimeForDefinition(
   // Use the buzz-agent-first preference (buzz-agent → goose → first available)
   // so a freshly installed goose never beats the bundled buzz-agent sidecar
   // for runtime-less personas (item 13 regression guard).
-  const defaultRuntime = getDefaultPersonaRuntime(
-    runtimes,
-    preferredRuntimeId,
-  );
+  const defaultRuntime = getDefaultPersonaRuntime(runtimes, preferredRuntimeId);
   const { runtime, warnings, isOverridden }: ResolvePersonaRuntimeResult =
     resolvePersonaRuntime(persona.runtime, runtimes, defaultRuntime);
 

--- a/desktop/src/features/agents/lib/instanceInputForDefinition.ts
+++ b/desktop/src/features/agents/lib/instanceInputForDefinition.ts
@@ -119,7 +119,6 @@ export async function buildInstanceInputForDefinition(
   const avatarUrl = await resolveManagedAgentAvatarUrl(
     persona.avatarUrl,
     upload,
-    runtime.avatarUrl,
   );
 
   const base = {

--- a/desktop/src/features/agents/lib/instanceInputForDefinition.ts
+++ b/desktop/src/features/agents/lib/instanceInputForDefinition.ts
@@ -45,11 +45,15 @@ export async function availableRuntimesForStart(
 export function resolveStartRuntimeForDefinition(
   persona: AgentPersona,
   runtimes: readonly AcpRuntime[],
+  preferredRuntimeId?: string | null,
 ): { runtime: AcpRuntime; warnings: string[] } {
   // Use the buzz-agent-first preference (buzz-agent → goose → first available)
   // so a freshly installed goose never beats the bundled buzz-agent sidecar
   // for runtime-less personas (item 13 regression guard).
-  const defaultRuntime = getDefaultPersonaRuntime(runtimes);
+  const defaultRuntime = getDefaultPersonaRuntime(
+    runtimes,
+    preferredRuntimeId,
+  );
   const { runtime, warnings, isOverridden }: ResolvePersonaRuntimeResult =
     resolvePersonaRuntime(persona.runtime, runtimes, defaultRuntime);
 

--- a/desktop/src/features/agents/lib/resolvePersonaRuntime.ts
+++ b/desktop/src/features/agents/lib/resolvePersonaRuntime.ts
@@ -12,11 +12,13 @@ import type { AcpRuntime, AcpRuntimeCatalogEntry } from "@/shared/api/types";
  */
 export function getDefaultPersonaRuntime<T extends AcpRuntimeCatalogEntry>(
   runtimes: readonly T[],
+  preferredRuntimeId?: string | null,
 ): T | null {
   const available = runtimes.filter(
     (runtime) => runtime.availability === "available",
   );
   return (
+    available.find((runtime) => runtime.id === preferredRuntimeId) ??
     available.find((runtime) => runtime.id === "buzz-agent") ??
     available.find((runtime) => runtime.id === "goose") ??
     available[0] ??

--- a/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
@@ -5,6 +5,7 @@ import {
   useAvailableAcpRuntimes,
   useCreateChannelManagedAgentsMutation,
 } from "@/features/agents/hooks";
+import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import type { CreateChannelManagedAgentsResult } from "@/features/agents/channelAgents";
 import {
   emptyResolvedTeamPersonas,
@@ -50,6 +51,7 @@ export function AddTeamToChannelDialog({
   onOpenChange,
   onDeployed,
 }: AddTeamToChannelDialogProps) {
+  const { globalConfig } = useGlobalAgentConfig();
   const channelsQuery = useChannelsQuery();
   const providersQuery = useAvailableAcpRuntimes();
   const [channelId, setChannelId] = React.useState("");
@@ -69,7 +71,10 @@ export function AddTeamToChannelDialog({
   const runtimes = providersQuery.data ?? [];
   // Use the buzz-agent-first preference so the team-deploy fallback mirrors the
   // single-agent start path (buzz-agent → goose → first available).
-  const defaultProvider = getDefaultPersonaRuntime(runtimes);
+  const defaultProvider = getDefaultPersonaRuntime(
+    runtimes,
+    globalConfig.preferred_runtime,
+  );
 
   const teamPersonaResolution = React.useMemo(
     () =>

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -156,9 +156,17 @@ export function AgentDefinitionDialog({
   const [showAdvancedFields, setShowAdvancedFields] = React.useState(false);
   const [isAvatarUploadPending, setIsAvatarUploadPending] =
     React.useState(false);
+  const {
+    globalConfig,
+    inheritedDefaults: {
+      provider: inheritedProviderDefault,
+      model: inheritedModelDefault,
+    },
+    inheritedEnvVars: inheritedEnvVarsForAdvanced,
+  } = useAgentDialogDefaults({ open });
   const defaultRuntime = React.useMemo(
-    () => getDefaultPersonaRuntime(runtimes),
-    [runtimes],
+    () => getDefaultPersonaRuntime(runtimes, globalConfig.preferred_runtime),
+    [globalConfig.preferred_runtime, runtimes],
   );
   const shouldReduceMotion = useReducedMotion();
   const initialModelProviderEditableWithoutRuntime = Boolean(
@@ -331,14 +339,6 @@ export function AgentDefinitionDialog({
   // Used to silence requirements already satisfied there.
   const { data: runtimeFileConfig, isLoading: fileConfigLoading } =
     useRuntimeFileConfigQuery(runtime, { enabled: open });
-  const {
-    globalConfig,
-    inheritedDefaults: {
-      provider: inheritedProviderDefault,
-      model: inheritedModelDefault,
-    },
-    inheritedEnvVars: inheritedEnvVarsForAdvanced,
-  } = useAgentDialogDefaults({ open });
   function handleAiConfigurationModeChange(nextMode: AgentAiConfigurationMode) {
     setAiConfigurationMode(nextMode);
     setIsCustomProviderEditing(false);

--- a/desktop/src/features/agents/ui/GlobalAgentConfigFields.tsx
+++ b/desktop/src/features/agents/ui/GlobalAgentConfigFields.tsx
@@ -45,6 +45,7 @@ export const EMPTY_GLOBAL_CONFIG: GlobalAgentConfig = {
   env_vars: {},
   provider: null,
   model: null,
+  preferred_runtime: null,
 };
 
 /** Baked env keys that route to structured controls, not the generic env editor. */

--- a/desktop/src/features/agents/ui/personaDialogPickers.test.mjs
+++ b/desktop/src/features/agents/ui/personaDialogPickers.test.mjs
@@ -75,6 +75,23 @@ test("getPersonaProviderOptions appends (current) tail for an unknown saved prov
 
 // ── getDefaultPersonaRuntime — buzz-agent first ───────────────────────────────
 
+test("getDefaultPersonaRuntime honors an available global preference", () => {
+  const runtimes = [
+    makeRuntime("buzz-agent"),
+    makeRuntime("goose"),
+    makeRuntime("claude"),
+  ];
+  assert.equal(getDefaultPersonaRuntime(runtimes, "claude")?.id, "claude");
+});
+
+test("getDefaultPersonaRuntime ignores an unavailable global preference", () => {
+  const runtimes = [
+    makeRuntime("buzz-agent"),
+    makeRuntime("claude", "not_installed"),
+  ];
+  assert.equal(getDefaultPersonaRuntime(runtimes, "claude")?.id, "buzz-agent");
+});
+
 test("getDefaultPersonaRuntime returns buzz-agent over goose when both are available", () => {
   const runtimes = [
     makeRuntime("goose"),

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -12,6 +12,7 @@ import {
   useStopManagedAgentMutation,
   useDeleteManagedAgentMutation,
 } from "@/features/agents/hooks";
+import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { usePresenceQuery } from "@/features/presence/hooks";
 import type {
@@ -35,6 +36,7 @@ import {
 } from "../lib/instanceInputForDefinition";
 
 export function useManagedAgentActions() {
+  const { globalConfig } = useGlobalAgentConfig();
   const relayAgentsQuery = useRelayAgentsQuery();
   const managedAgentsQuery = useManagedAgentsQuery();
   const [shouldLoadChannels, setShouldLoadChannels] = React.useState(false);
@@ -193,6 +195,7 @@ export function useManagedAgentActions() {
       const { runtime, warnings } = resolveStartRuntimeForDefinition(
         persona,
         runtimes,
+        globalConfig.preferred_runtime,
       );
       const input = await buildInstanceInputForDefinition(persona, runtime);
 

--- a/desktop/src/features/agents/useGlobalAgentConfig.ts
+++ b/desktop/src/features/agents/useGlobalAgentConfig.ts
@@ -18,6 +18,7 @@ const EMPTY_CONFIG: GlobalAgentConfig = {
   env_vars: {},
   provider: null,
   model: null,
+  preferred_runtime: null,
 };
 
 export const globalAgentConfigQueryKey = ["globalAgentConfig"] as const;

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -2,6 +2,10 @@ import * as React from "react";
 import type { QueryClient } from "@tanstack/react-query";
 
 import {
+  getGlobalAgentConfig,
+  setGlobalAgentConfig,
+} from "@/shared/api/tauriGlobalAgentConfig";
+import {
   getIdentity,
   importIdentity,
   persistCurrentIdentity,
@@ -40,6 +44,50 @@ export function MachineOnboardingFlow({
   const [selectedPubkey, setSelectedPubkey] = React.useState<string | null>(
     null,
   );
+  const [selectedRuntimeId, setSelectedRuntimeId] = React.useState<string | null>(
+    null,
+  );
+  const [pendingRuntimeId, setPendingRuntimeId] = React.useState<string | null>(
+    null,
+  );
+  const [isRuntimeSelectionSaving, setIsRuntimeSelectionSaving] =
+    React.useState(false);
+  const [runtimeSelectionError, setRuntimeSelectionError] = React.useState<
+    string | null
+  >(null);
+  const runtimeSaveSequence = React.useRef(0);
+
+  const persistPreferredRuntime = React.useCallback(async (runtimeId: string) => {
+    const sequence = runtimeSaveSequence.current + 1;
+    runtimeSaveSequence.current = sequence;
+    setPendingRuntimeId(runtimeId);
+    setRuntimeSelectionError(null);
+    setIsRuntimeSelectionSaving(true);
+    try {
+      const current = await getGlobalAgentConfig();
+      const result = await setGlobalAgentConfig({
+        ...current,
+        preferred_runtime: runtimeId,
+      });
+      if (runtimeSaveSequence.current === sequence) {
+        setSelectedRuntimeId(result.config.preferred_runtime);
+        setPendingRuntimeId(null);
+      }
+    } catch (cause) {
+      if (runtimeSaveSequence.current === sequence) {
+        setPendingRuntimeId(null);
+        setRuntimeSelectionError(
+          cause instanceof Error
+            ? cause.message
+            : "Couldn’t save your preferred runtime.",
+        );
+      }
+    } finally {
+      if (runtimeSaveSequence.current === sequence) {
+        setIsRuntimeSelectionSaving(false);
+      }
+    }
+  }, []);
 
   const loadFreshIdentity = React.useCallback(async () => {
     setIsPending(true);
@@ -188,9 +236,25 @@ export function MachineOnboardingFlow({
               actions={{
                 back: () =>
                   setPage(identityWasImported ? "key-import" : "backup"),
-                next: () => setPage("config"),
+                next: () => {
+                  if (!selectedRuntimeId) return;
+                  if (
+                    selectedRuntimeId === "claude" ||
+                    selectedRuntimeId === "codex"
+                  ) {
+                    complete(selectedPubkey ?? undefined);
+                    return;
+                  }
+                  setPage("config");
+                },
               }}
               direction="forward"
+              isSelectionSaving={isRuntimeSelectionSaving}
+              onSelectedRuntimeChange={(runtimeId) => {
+                void persistPreferredRuntime(runtimeId);
+              }}
+              selectionError={runtimeSelectionError}
+              selectedRuntimeId={pendingRuntimeId ?? selectedRuntimeId}
             />
           ) : (
             <DefaultConfigStep

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -44,9 +44,9 @@ export function MachineOnboardingFlow({
   const [selectedPubkey, setSelectedPubkey] = React.useState<string | null>(
     null,
   );
-  const [selectedRuntimeId, setSelectedRuntimeId] = React.useState<string | null>(
-    null,
-  );
+  const [selectedRuntimeId, setSelectedRuntimeId] = React.useState<
+    string | null
+  >(null);
   const [pendingRuntimeId, setPendingRuntimeId] = React.useState<string | null>(
     null,
   );
@@ -57,37 +57,40 @@ export function MachineOnboardingFlow({
   >(null);
   const runtimeSaveSequence = React.useRef(0);
 
-  const persistPreferredRuntime = React.useCallback(async (runtimeId: string) => {
-    const sequence = runtimeSaveSequence.current + 1;
-    runtimeSaveSequence.current = sequence;
-    setPendingRuntimeId(runtimeId);
-    setRuntimeSelectionError(null);
-    setIsRuntimeSelectionSaving(true);
-    try {
-      const current = await getGlobalAgentConfig();
-      const result = await setGlobalAgentConfig({
-        ...current,
-        preferred_runtime: runtimeId,
-      });
-      if (runtimeSaveSequence.current === sequence) {
-        setSelectedRuntimeId(result.config.preferred_runtime);
-        setPendingRuntimeId(null);
+  const persistPreferredRuntime = React.useCallback(
+    async (runtimeId: string) => {
+      const sequence = runtimeSaveSequence.current + 1;
+      runtimeSaveSequence.current = sequence;
+      setPendingRuntimeId(runtimeId);
+      setRuntimeSelectionError(null);
+      setIsRuntimeSelectionSaving(true);
+      try {
+        const current = await getGlobalAgentConfig();
+        const result = await setGlobalAgentConfig({
+          ...current,
+          preferred_runtime: runtimeId,
+        });
+        if (runtimeSaveSequence.current === sequence) {
+          setSelectedRuntimeId(result.config.preferred_runtime);
+          setPendingRuntimeId(null);
+        }
+      } catch (cause) {
+        if (runtimeSaveSequence.current === sequence) {
+          setPendingRuntimeId(null);
+          setRuntimeSelectionError(
+            cause instanceof Error
+              ? cause.message
+              : "Couldn’t save your preferred runtime.",
+          );
+        }
+      } finally {
+        if (runtimeSaveSequence.current === sequence) {
+          setIsRuntimeSelectionSaving(false);
+        }
       }
-    } catch (cause) {
-      if (runtimeSaveSequence.current === sequence) {
-        setPendingRuntimeId(null);
-        setRuntimeSelectionError(
-          cause instanceof Error
-            ? cause.message
-            : "Couldn’t save your preferred runtime.",
-        );
-      }
-    } finally {
-      if (runtimeSaveSequence.current === sequence) {
-        setIsRuntimeSelectionSaving(false);
-      }
-    }
-  }, []);
+    },
+    [],
+  );
 
   const loadFreshIdentity = React.useCallback(async () => {
     setIsPending(true);

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -297,6 +297,14 @@ function isSupportedOnboardingAuthMethod(
   return !/api[-_ ]?key/i.test(`${method.id} ${method.name}`);
 }
 
+function onboardingAuthMethodLabel(
+  runtime: AcpRuntimeCatalogEntry,
+  method: { name: string },
+) {
+  if (runtime.id === "codex") return "Log in";
+  return method.name || "Sign in";
+}
+
 function RuntimeAuthActions({
   onAuthenticated,
   runtime,
@@ -374,7 +382,9 @@ function RuntimeAuthActions({
             type="button"
             variant="outline"
           >
-            {connectMutation.isPending ? "Opening…" : method.name || "Sign in"}
+            {connectMutation.isPending
+              ? "Opening…"
+              : onboardingAuthMethodLabel(runtime, method)}
           </Button>
         ))
       ) : (
@@ -579,6 +589,15 @@ function RuntimeProvidersSection({
   selectedRuntimeId: string | null;
 }) {
   const { errorMessage, isChecking, items } = runtimeProviders;
+  const runtimeOrder = ["claude", "codex", "goose", "buzz-agent"];
+  const orderedItems = [...items].sort((left, right) => {
+    const leftIndex = runtimeOrder.indexOf(left.id);
+    const rightIndex = runtimeOrder.indexOf(right.id);
+    return (
+      (leftIndex === -1 ? runtimeOrder.length : leftIndex) -
+      (rightIndex === -1 ? runtimeOrder.length : rightIndex)
+    );
+  });
   const installMutation = useInstallAcpRuntimeMutation();
   const [installResults, setInstallResults] = React.useState<
     Record<string, InstallResultState>
@@ -631,7 +650,7 @@ function RuntimeProvidersSection({
           className="flex flex-wrap items-stretch justify-center gap-4"
           role="radiogroup"
         >
-          {items.map((runtime) => (
+          {orderedItems.map((runtime) => (
             <RuntimeCard
               installError={installResults[runtime.id]?.error ?? null}
               installSuccess={installResults[runtime.id]?.success ?? false}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -104,13 +104,11 @@ function RuntimeIcon({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
 
 function RuntimeStatus({
   installError,
-  installSuccess,
   isInstalling,
   onInstall,
   runtime,
 }: {
   installError: string | null;
-  installSuccess: boolean;
   isInstalling: boolean;
   onInstall: () => void;
   runtime: AcpRuntimeCatalogEntry;
@@ -135,7 +133,7 @@ function RuntimeStatus({
     );
   }
 
-  if (runtime.availability === "available" || installSuccess) {
+  if (runtime.availability === "available" && runtimeCanBeSelected(runtime)) {
     return (
       <div
         aria-label={`${runtime.label} available`}
@@ -291,6 +289,14 @@ function runtimeDetailText(runtime: AcpRuntimeCatalogEntry): string {
   return "Not installed yet.";
 }
 
+function isSupportedOnboardingAuthMethod(
+  runtime: AcpRuntimeCatalogEntry,
+  method: { id: string; name: string },
+) {
+  if (runtime.id !== "codex") return true;
+  return !/api[-_ ]?key/i.test(`${method.id} ${method.name}`);
+}
+
 function RuntimeAuthActions({
   onAuthenticated,
   runtime,
@@ -336,7 +342,9 @@ function RuntimeAuthActions({
   }
   if (runtime.authStatus.status !== "logged_out") return null;
 
-  const methods = methodsQuery.data?.methods ?? [];
+  const methods = (methodsQuery.data?.methods ?? []).filter((method) =>
+    isSupportedOnboardingAuthMethod(runtime, method),
+  );
   return (
     <div className="mt-2 flex flex-col items-center gap-1.5">
       {methodsQuery.isLoading ? (
@@ -355,7 +363,9 @@ function RuntimeAuthActions({
                 },
                 {
                   onSuccess: () => {
-                    if (runtime.id === "claude") onAuthenticated();
+                    if (runtime.id === "claude" || runtime.id === "codex") {
+                      onAuthenticated();
+                    }
                   },
                 },
               );
@@ -445,7 +455,6 @@ function RuntimeCard({
       <div className="absolute right-2 top-2">
         <RuntimeStatus
           installError={installError}
-          installSuccess={installSuccess}
           isInstalling={isInstalling}
           onInstall={onInstall}
           runtime={runtime}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -291,7 +291,13 @@ function runtimeDetailText(runtime: AcpRuntimeCatalogEntry): string {
   return "Not installed yet.";
 }
 
-function RuntimeAuthActions({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
+function RuntimeAuthActions({
+  onAuthenticated,
+  runtime,
+}: {
+  onAuthenticated: () => void;
+  runtime: AcpRuntimeCatalogEntry;
+}) {
   const runtimesQuery = useAcpRuntimesQuery();
   const methodsQuery = useAcpAuthMethodsQuery(runtime.id, {
     enabled:
@@ -342,10 +348,17 @@ function RuntimeAuthActions({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
             key={method.id}
             onClick={(event) => {
               event.stopPropagation();
-              connectMutation.mutate({
-                methodId: method.id,
-                runtimeId: runtime.id,
-              });
+              connectMutation.mutate(
+                {
+                  methodId: method.id,
+                  runtimeId: runtime.id,
+                },
+                {
+                  onSuccess: () => {
+                    if (runtime.id === "claude") onAuthenticated();
+                  },
+                },
+              );
             }}
             size="sm"
             type="button"
@@ -481,7 +494,7 @@ function RuntimeCard({
         {selected ? (
           <p className="mt-1 text-2xs font-medium text-primary">Preferred</p>
         ) : null}
-        <RuntimeAuthActions runtime={runtime} />
+        <RuntimeAuthActions onAuthenticated={onSelect} runtime={runtime} />
       </div>
     </div>
   );
@@ -678,7 +691,10 @@ function SetupStepContent({
 
       <OnboardingFooter>
         {selectionError ? (
-          <p className="max-w-sm text-center text-xs text-destructive" role="alert">
+          <p
+            className="max-w-sm text-center text-xs text-destructive"
+            role="alert"
+          >
             {selectionError}
           </p>
         ) : null}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -405,6 +405,7 @@ function RuntimeCard({
   const canSelect = runtimeCanBeSelected(runtime) && !selectionDisabled;
 
   return (
+    // biome-ignore lint/a11y/useSemanticElements: Cannot use <input> because this card contains nested setup and details buttons, which require interactive content
     <div
       aria-checked={selected}
       aria-disabled={!canSelect}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -10,7 +10,9 @@ import {
 } from "lucide-react";
 
 import {
+  useAcpAuthMethodsQuery,
   useAcpRuntimesQuery,
+  useConnectAcpRuntimeMutation,
   useInstallAcpRuntimeMutation,
   useGitBashPrerequisiteQuery,
 } from "@/features/agents/hooks";
@@ -23,6 +25,7 @@ import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Spinner } from "@/shared/ui/spinner";
+import { runtimeCanBeSelected } from "./onboardingRuntimeSelection";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { OnboardingFooter } from "./OnboardingFooter";
 import {
@@ -34,11 +37,19 @@ import type { SetupStepActions, SetupStepState } from "./types";
 type SetupStepProps = {
   actions: SetupStepActions;
   direction: OnboardingTransitionDirection;
+  isSelectionSaving: boolean;
+  onSelectedRuntimeChange: (runtimeId: string) => void;
+  selectionError: string | null;
+  selectedRuntimeId: string | null;
 };
 
 type SetupStepContentProps = {
   actions: SetupStepActions;
   direction: OnboardingTransitionDirection;
+  isSelectionSaving: boolean;
+  onSelectedRuntimeChange: (runtimeId: string) => void;
+  selectionError: string | null;
+  selectedRuntimeId: string | null;
   state: SetupStepState;
 };
 
@@ -280,31 +291,142 @@ function runtimeDetailText(runtime: AcpRuntimeCatalogEntry): string {
   return "Not installed yet.";
 }
 
+function RuntimeAuthActions({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
+  const runtimesQuery = useAcpRuntimesQuery();
+  const methodsQuery = useAcpAuthMethodsQuery(runtime.id, {
+    enabled:
+      runtime.availability === "available" &&
+      runtime.authStatus.status === "logged_out",
+  });
+  const connectMutation = useConnectAcpRuntimeMutation();
+
+  if (runtime.authStatus.status === "config_invalid") {
+    return (
+      <p className="mt-2 text-2xs leading-4 text-destructive">
+        {runtime.authStatus.diagnostic}
+      </p>
+    );
+  }
+  if (runtime.authStatus.status === "unknown") {
+    return (
+      <div className="mt-2 flex flex-col items-center gap-1.5">
+        <span className="text-2xs text-muted-foreground">
+          Couldn’t verify authentication.
+        </span>
+        <Button
+          disabled={runtimesQuery.isFetching}
+          onClick={(event) => {
+            event.stopPropagation();
+            void runtimesQuery.refetch();
+          }}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          {runtimesQuery.isFetching ? "Checking…" : "Check again"}
+        </Button>
+      </div>
+    );
+  }
+  if (runtime.authStatus.status !== "logged_out") return null;
+
+  const methods = methodsQuery.data?.methods ?? [];
+  return (
+    <div className="mt-2 flex flex-col items-center gap-1.5">
+      {methodsQuery.isLoading ? (
+        <span className="text-2xs text-muted-foreground">Loading sign-in…</span>
+      ) : methods.length > 0 ? (
+        methods.map((method) => (
+          <Button
+            disabled={connectMutation.isPending}
+            key={method.id}
+            onClick={(event) => {
+              event.stopPropagation();
+              connectMutation.mutate({
+                methodId: method.id,
+                runtimeId: runtime.id,
+              });
+            }}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {connectMutation.isPending ? "Opening…" : method.name || "Sign in"}
+          </Button>
+        ))
+      ) : (
+        <span className="text-2xs text-muted-foreground">
+          {methodsQuery.error instanceof Error
+            ? "Couldn’t load sign-in options."
+            : runtime.loginHint || "Sign in from the CLI."}
+        </span>
+      )}
+      {connectMutation.error instanceof Error ? (
+        <span className="text-2xs text-destructive">
+          {connectMutation.error.message}
+        </span>
+      ) : null}
+      <Button
+        disabled={runtimesQuery.isFetching}
+        onClick={(event) => {
+          event.stopPropagation();
+          void Promise.all([runtimesQuery.refetch(), methodsQuery.refetch()]);
+        }}
+        size="sm"
+        type="button"
+        variant="ghost"
+      >
+        {runtimesQuery.isFetching ? "Checking…" : "Check again"}
+      </Button>
+    </div>
+  );
+}
+
 function RuntimeCard({
   installError,
   installSuccess,
   isInstalling,
   onInstall,
+  onSelect,
   runtime,
+  selectionDisabled,
+  selected,
 }: {
   installError: string | null;
   installSuccess: boolean;
   isInstalling: boolean;
   onInstall: () => void;
+  onSelect: () => void;
   runtime: AcpRuntimeCatalogEntry;
+  selectionDisabled: boolean;
+  selected: boolean;
 }) {
   const isAvailable = runtime.availability === "available" || installSuccess;
+  const canSelect = runtimeCanBeSelected(runtime) && !selectionDisabled;
 
   return (
     <div
+      aria-checked={selected}
+      aria-disabled={!canSelect}
       className={cn(
         "relative flex min-h-40 w-40 flex-col items-center justify-center gap-3 rounded-2xl bg-white/85 p-4 text-center",
         isAvailable
           ? "shadow-[0_0_55px_25px_rgba(255,255,255,0.85)]"
           : "shadow-[0_0_45px_18px_rgba(255,255,255,0.55)] opacity-90",
         installError && "ring-1 ring-destructive/40",
+        selected && "ring-2 ring-primary",
+        canSelect && "cursor-pointer hover:bg-white",
       )}
       data-testid={`onboarding-runtime-${runtime.id}`}
+      onClick={canSelect ? onSelect : undefined}
+      onKeyDown={(event) => {
+        if (canSelect && (event.key === "Enter" || event.key === " ")) {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      role="radio"
+      tabIndex={canSelect ? 0 : -1}
     >
       <div className="absolute right-2 top-2">
         <RuntimeStatus
@@ -355,6 +477,10 @@ function RuntimeCard({
         {installSuccess && runtime.availability !== "available" ? (
           <p className="mt-1 text-2xs leading-4 text-primary">Installed</p>
         ) : null}
+        {selected ? (
+          <p className="mt-1 text-2xs font-medium text-primary">Preferred</p>
+        ) : null}
+        <RuntimeAuthActions runtime={runtime} />
       </div>
     </div>
   );
@@ -419,9 +545,15 @@ function GitBashPrerequisiteCard() {
 }
 
 function RuntimeProvidersSection({
+  isSelectionSaving,
+  onSelectedRuntimeChange,
   runtimeProviders,
+  selectedRuntimeId,
 }: {
+  isSelectionSaving: boolean;
+  onSelectedRuntimeChange: (runtimeId: string) => void;
   runtimeProviders: SetupStepState["runtimeProviders"];
+  selectedRuntimeId: string | null;
 }) {
   const { errorMessage, isChecking, items } = runtimeProviders;
   const installMutation = useInstallAcpRuntimeMutation();
@@ -471,7 +603,11 @@ function RuntimeProvidersSection({
       <GitBashPrerequisiteCard />
 
       {items.length > 0 ? (
-        <div className="flex flex-wrap items-stretch justify-center gap-4">
+        <div
+          aria-label="Preferred agent harness"
+          className="flex flex-wrap items-stretch justify-center gap-4"
+          role="radiogroup"
+        >
           {items.map((runtime) => (
             <RuntimeCard
               installError={installResults[runtime.id]?.error ?? null}
@@ -482,7 +618,10 @@ function RuntimeProvidersSection({
               }
               key={runtime.id}
               onInstall={() => handleInstall(runtime.id)}
+              onSelect={() => onSelectedRuntimeChange(runtime.id)}
               runtime={runtime}
+              selectionDisabled={isSelectionSaving}
+              selected={selectedRuntimeId === runtime.id}
             />
           ))}
         </div>
@@ -512,6 +651,10 @@ function RuntimeProvidersSection({
 function SetupStepContent({
   actions,
   direction,
+  isSelectionSaving,
+  onSelectedRuntimeChange,
+  selectionError,
+  selectedRuntimeId,
   state,
 }: SetupStepContentProps) {
   const { runtimeProviders } = state;
@@ -525,16 +668,27 @@ function SetupStepContent({
       direction={direction}
       transitionKey={`setup-${direction}`}
     >
-      <RuntimeProvidersSection runtimeProviders={runtimeProviders} />
+      <RuntimeProvidersSection
+        isSelectionSaving={isSelectionSaving}
+        onSelectedRuntimeChange={onSelectedRuntimeChange}
+        runtimeProviders={runtimeProviders}
+        selectedRuntimeId={selectedRuntimeId}
+      />
 
       <OnboardingFooter>
+        {selectionError ? (
+          <p className="max-w-sm text-center text-xs text-destructive" role="alert">
+            {selectionError}
+          </p>
+        ) : null}
         <Button
           className={ONBOARDING_PRIMARY_CTA_CLASS}
           data-testid="onboarding-setup-next"
+          disabled={!selectedRuntimeId || isSelectionSaving}
           onClick={actions.next}
           type="button"
         >
-          Next
+          {isSelectionSaving ? "Saving…" : "Next"}
         </Button>
 
         <Button
@@ -551,10 +705,25 @@ function SetupStepContent({
   );
 }
 
-export function SetupStep({ actions, direction }: SetupStepProps) {
+export function SetupStep({
+  actions,
+  direction,
+  isSelectionSaving,
+  onSelectedRuntimeChange,
+  selectionError,
+  selectedRuntimeId,
+}: SetupStepProps) {
   const state = useSetupStepState();
 
   return (
-    <SetupStepContent actions={actions} direction={direction} state={state} />
+    <SetupStepContent
+      actions={actions}
+      direction={direction}
+      isSelectionSaving={isSelectionSaving}
+      onSelectedRuntimeChange={onSelectedRuntimeChange}
+      selectionError={selectionError}
+      selectedRuntimeId={selectedRuntimeId}
+      state={state}
+    />
   );
 }

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runtimeCanBeSelected } from "./onboardingRuntimeSelection.ts";
+
+function runtime(id, availability, status) {
+  return { id, availability, authStatus: { status } };
+}
+
+test("Claude and Codex require available authenticated CLIs", () => {
+  for (const id of ["claude", "codex"]) {
+    assert.equal(runtimeCanBeSelected(runtime(id, "available", "logged_in")), true);
+    assert.equal(runtimeCanBeSelected(runtime(id, "available", "not_applicable")), true);
+    assert.equal(runtimeCanBeSelected(runtime(id, "available", "logged_out")), false);
+    assert.equal(runtimeCanBeSelected(runtime(id, "available", "config_invalid")), false);
+    assert.equal(runtimeCanBeSelected(runtime(id, "available", "unknown")), false);
+    assert.equal(runtimeCanBeSelected(runtime(id, "not_installed", "logged_in")), false);
+  }
+});
+
+test("Buzz Agent and Goose remain selectable when available", () => {
+  for (const id of ["buzz-agent", "goose"]) {
+    assert.equal(runtimeCanBeSelected(runtime(id, "available", "not_applicable")), true);
+    assert.equal(runtimeCanBeSelected(runtime(id, "not_installed", "not_applicable")), false);
+  }
+});
+
+test("unknown runtimes are not onboarding choices", () => {
+  assert.equal(runtimeCanBeSelected(runtime("custom", "available", "logged_in")), false);
+});

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -9,22 +9,49 @@ function runtime(id, availability, status) {
 
 test("Claude and Codex require available authenticated CLIs", () => {
   for (const id of ["claude", "codex"]) {
-    assert.equal(runtimeCanBeSelected(runtime(id, "available", "logged_in")), true);
-    assert.equal(runtimeCanBeSelected(runtime(id, "available", "not_applicable")), true);
-    assert.equal(runtimeCanBeSelected(runtime(id, "available", "logged_out")), false);
-    assert.equal(runtimeCanBeSelected(runtime(id, "available", "config_invalid")), false);
-    assert.equal(runtimeCanBeSelected(runtime(id, "available", "unknown")), false);
-    assert.equal(runtimeCanBeSelected(runtime(id, "not_installed", "logged_in")), false);
+    assert.equal(
+      runtimeCanBeSelected(runtime(id, "available", "logged_in")),
+      true,
+    );
+    assert.equal(
+      runtimeCanBeSelected(runtime(id, "available", "not_applicable")),
+      true,
+    );
+    assert.equal(
+      runtimeCanBeSelected(runtime(id, "available", "logged_out")),
+      false,
+    );
+    assert.equal(
+      runtimeCanBeSelected(runtime(id, "available", "config_invalid")),
+      false,
+    );
+    assert.equal(
+      runtimeCanBeSelected(runtime(id, "available", "unknown")),
+      false,
+    );
+    assert.equal(
+      runtimeCanBeSelected(runtime(id, "not_installed", "logged_in")),
+      false,
+    );
   }
 });
 
 test("Buzz Agent and Goose remain selectable when available", () => {
   for (const id of ["buzz-agent", "goose"]) {
-    assert.equal(runtimeCanBeSelected(runtime(id, "available", "not_applicable")), true);
-    assert.equal(runtimeCanBeSelected(runtime(id, "not_installed", "not_applicable")), false);
+    assert.equal(
+      runtimeCanBeSelected(runtime(id, "available", "not_applicable")),
+      true,
+    );
+    assert.equal(
+      runtimeCanBeSelected(runtime(id, "not_installed", "not_applicable")),
+      false,
+    );
   }
 });
 
 test("unknown runtimes are not onboarding choices", () => {
-  assert.equal(runtimeCanBeSelected(runtime("custom", "available", "logged_in")), false);
+  assert.equal(
+    runtimeCanBeSelected(runtime("custom", "available", "logged_in")),
+    false,
+  );
 });

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -1,0 +1,12 @@
+import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
+
+export function runtimeCanBeSelected(runtime: AcpRuntimeCatalogEntry) {
+  if (runtime.availability !== "available") return false;
+  if (runtime.id === "claude" || runtime.id === "codex") {
+    return (
+      runtime.authStatus.status === "logged_in" ||
+      runtime.authStatus.status === "not_applicable"
+    );
+  }
+  return runtime.id === "buzz-agent" || runtime.id === "goose";
+}

--- a/desktop/src/features/onboarding/welcomeGuide.test.mjs
+++ b/desktop/src/features/onboarding/welcomeGuide.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   activateWelcomeTeamPersonasSequentially,
+  buildWelcomeStarterCreateInput,
   LEGACY_WELCOME_GUIDE_SYSTEM_PROMPT,
   pickWelcomeGuideAgent,
   pickWelcomeGuideAgentForRelay,
@@ -150,6 +151,58 @@ test("starter persona activation is serialized to protect the shared store", asy
   );
 
   assert.deepEqual(calls, ["builtin:fizz", "builtin:honey", "builtin:bumble"]);
+});
+
+test("all Welcome starters use the onboarding runtime preference", async () => {
+  const claude = {
+    id: "claude",
+    label: "Claude",
+    avatarUrl: "https://runtime/claude.png",
+    availability: "available",
+    command: "claude-code-acp",
+    binaryPath: "/bin/claude-code-acp",
+    defaultArgs: [],
+    mcpCommand: null,
+    installHint: "",
+    installInstructionsUrl: "",
+    canAutoInstall: false,
+    underlyingCliPath: "/bin/claude",
+  };
+  const buzzAgent = {
+    ...claude,
+    id: "buzz-agent",
+    label: "Buzz Agent",
+    command: "buzz-agent",
+  };
+
+  for (const starter of WELCOME_TEAM_STARTERS) {
+    const input = await buildWelcomeStarterCreateInput(
+      starter,
+      {
+        id: starter.personaId,
+        displayName: starter.name,
+        systemPrompt: `${starter.name} prompt`,
+        model: null,
+        provider: null,
+        runtime: null,
+        avatarUrl: null,
+        envVars: {},
+        isBuiltIn: true,
+        isActive: true,
+      },
+      [buzzAgent, claude],
+      "claude",
+      RELAY_A,
+    );
+
+    assert.equal(input.agentCommand, "claude-code-acp");
+    assert.equal(input.harnessOverride, true);
+    assert.equal(input.personaId, starter.personaId);
+    assert.equal(input.teamId, WELCOME_TEAM_ID);
+    assert.equal(input.relayUrl, RELAY_A);
+    assert.equal(input.spawnAfterCreate, false);
+    assert.equal(input.startOnAppLaunch, false);
+  }
 });
 
 test("welcome team starter definitions and role identities are stable", () => {

--- a/desktop/src/features/onboarding/welcomeGuide.ts
+++ b/desktop/src/features/onboarding/welcomeGuide.ts
@@ -245,7 +245,9 @@ async function provisionWelcomeTeam(
     discoverAcpRuntimes(),
     getGlobalAgentConfig(),
   ]);
-  const personasById = new Map(personas.map((persona) => [persona.id, persona]));
+  const personasById = new Map(
+    personas.map((persona) => [persona.id, persona]),
+  );
   const runtimes = runtimeCatalog.filter(
     (runtime): runtime is AcpRuntime => runtime.availability === "available",
   );

--- a/desktop/src/features/onboarding/welcomeGuide.ts
+++ b/desktop/src/features/onboarding/welcomeGuide.ts
@@ -1,12 +1,23 @@
 import {
+  buildInstanceInputForDefinition,
+  resolveStartRuntimeForDefinition,
+} from "@/features/agents/lib/instanceInputForDefinition";
+import {
   addChannelMembers,
   createManagedAgent,
+  discoverAcpRuntimes,
   getChannelMembers,
   listManagedAgents,
   updateManagedAgent,
 } from "@/shared/api/tauri";
+import { getGlobalAgentConfig } from "@/shared/api/tauriGlobalAgentConfig";
 import { listPersonas, setPersonaActive } from "@/shared/api/tauriPersonas";
-import type { ManagedAgent } from "@/shared/api/types";
+import type {
+  AcpRuntime,
+  AgentPersona,
+  CreateManagedAgentInput,
+  ManagedAgent,
+} from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 export const WELCOME_GUIDE_AGENT_NAME = "Fizz";
@@ -195,6 +206,29 @@ async function ensureWelcomeTeamMembership(
   }
 }
 
+export async function buildWelcomeStarterCreateInput(
+  starter: WelcomeTeamStarterDefinition,
+  persona: AgentPersona,
+  runtimes: readonly AcpRuntime[],
+  preferredRuntimeId: string | null,
+  relayUrl?: string | null,
+): Promise<CreateManagedAgentInput> {
+  const { runtime } = resolveStartRuntimeForDefinition(
+    persona,
+    runtimes,
+    preferredRuntimeId,
+  );
+  return {
+    ...(await buildInstanceInputForDefinition(persona, runtime)),
+    name: starter.name,
+    teamId: WELCOME_TEAM_ID,
+    relayUrl: relayUrl ?? undefined,
+    spawnAfterCreate: false,
+    startOnAppLaunch: false,
+    respondTo: "owner-only",
+  };
+}
+
 /**
  * Ensure the complete built-in Welcome Team is ready for kickoff.
  * The team itself is Rust-seeded; this only activates personas, creates any
@@ -206,6 +240,15 @@ async function provisionWelcomeTeam(
 ): Promise<WelcomeTeamAgents> {
   const existingAgents = await listManagedAgents();
   await ensureWelcomeTeamPersonasActive();
+  const [personas, runtimeCatalog, globalConfig] = await Promise.all([
+    listPersonas(),
+    discoverAcpRuntimes(),
+    getGlobalAgentConfig(),
+  ]);
+  const personasById = new Map(personas.map((persona) => [persona.id, persona]));
+  const runtimes = runtimeCatalog.filter(
+    (runtime): runtime is AcpRuntime => runtime.availability === "available",
+  );
 
   const agents: ManagedAgent[] = [];
   for (const starter of WELCOME_TEAM_STARTERS) {
@@ -219,15 +262,19 @@ async function provisionWelcomeTeam(
       continue;
     }
 
-    const created = await createManagedAgent({
-      name: starter.name,
-      personaId: starter.personaId,
-      teamId: WELCOME_TEAM_ID,
-      relayUrl: relayUrl ?? undefined,
-      spawnAfterCreate: false,
-      startOnAppLaunch: false,
-      respondTo: "owner-only",
-    });
+    const persona = personasById.get(starter.personaId);
+    if (!persona) {
+      throw new Error(`${starter.name} agent not found.`);
+    }
+    const created = await createManagedAgent(
+      await buildWelcomeStarterCreateInput(
+        starter,
+        persona,
+        runtimes,
+        globalConfig.preferred_runtime,
+        relayUrl,
+      ),
+    );
     agents.push(created.agent);
   }
   const [lead, honey, bumble] = agents;

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -25,6 +25,7 @@ import {
   useUpdateManagedAgentMutation,
   useUpdatePersonaMutation,
 } from "@/features/agents/hooks";
+import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import { AddAgentToChannelDialog } from "@/features/agents/ui/AddAgentToChannelDialog";
 import {
   availableRuntimesForStart,
@@ -125,6 +126,7 @@ export function UserProfilePanel({
   widthPx,
   transparentChrome = false,
 }: UserProfilePanelProps) {
+  const { globalConfig } = useGlobalAgentConfig();
   const isOverlay = useIsThreadPanelOverlay();
   const isSplitLayout = layout === "split";
   useEscapeKey(onClose, isOverlay || isSinglePanelView);
@@ -417,6 +419,7 @@ export function UserProfilePanel({
       const { runtime, warnings } = resolveStartRuntimeForDefinition(
         personaToStart,
         runtimes,
+        globalConfig.preferred_runtime,
       );
 
       for (const warning of warnings) {
@@ -436,6 +439,7 @@ export function UserProfilePanel({
     [
       availableRuntimesQuery,
       createAgentMutation.mutateAsync,
+      globalConfig.preferred_runtime,
       managedAgentsQuery.refetch,
       relayAgentsQuery.refetch,
     ],

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -984,6 +984,8 @@ export type GlobalAgentConfig = {
   provider: string | null;
   /** Global fallback model identifier. Null = no global default. */
   model: string | null;
+  /** Preferred ACP runtime for agents without a persona-specific runtime. */
+  preferred_runtime: string | null;
 };
 
 /**

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -290,6 +290,7 @@ type E2eConfig = {
       env_vars: Record<string, string>;
       provider: string | null;
       model: string | null;
+      preferred_runtime?: string | null;
     };
     /** Baked build env returned by the display and key-name Tauri commands. */
     bakedBuildEnv?: Array<{
@@ -6696,6 +6697,12 @@ async function handleConnectAcpRuntime(
 // re-evaluated via addInitScript, so the counter starts at 0 for every test.
 let installCallCount = 0;
 let addChannelMembersCallCount = 0;
+let mockGlobalAgentConfig: {
+  env_vars: Record<string, string>;
+  provider: string | null;
+  model: string | null;
+  preferred_runtime?: string | null;
+} | null = null;
 
 // Per-page get_nsec call counter for sequenced error testing.
 let nsecCallCount = 0;
@@ -8444,6 +8451,9 @@ export function maybeInstallE2eTauriMocks() {
     return;
   }
 
+  mockGlobalAgentConfig = config.mock?.globalAgentConfig
+    ? { ...config.mock.globalAgentConfig }
+    : null;
   resetMockRelayMembers(config);
   resetMockRelayAgents(config);
   resetMockManagedAgents(config);
@@ -9456,13 +9466,13 @@ export function maybeInstallE2eTauriMocks() {
         return null;
       }
       case "get_global_agent_config": {
-        // Return the mock global agent config if provided; otherwise return
-        // an empty config (no global provider, model, or env vars).
+        // Return the mutable persisted mock value, seeded from the test config.
         return (
-          config?.mock?.globalAgentConfig ?? {
+          mockGlobalAgentConfig ?? {
             env_vars: {},
             provider: null,
             model: null,
+            preferred_runtime: null,
           }
         );
       }
@@ -9476,6 +9486,7 @@ export function maybeInstallE2eTauriMocks() {
               env_vars: Record<string, string>;
               provider: string | null;
               model: string | null;
+              preferred_runtime: string | null;
             };
           }
         ).config;
@@ -9490,6 +9501,7 @@ export function maybeInstallE2eTauriMocks() {
         if (saveDelayMs > 0) {
           await new Promise((resolve) => setTimeout(resolve, saveDelayMs));
         }
+        mockGlobalAgentConfig = savedConfig;
         // In the E2E environment there are no running agents to restart, so
         // the counts default to 0 unless a spec drives them explicitly.
         return {

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -82,9 +82,7 @@ test("authenticated Claude persists as preferred and skips detailed config", asy
   await installMockBridge(
     page,
     {
-      acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_in" }),
-      ],
+      acpRuntimesCatalog: [availableRuntime("claude", { status: "logged_in" })],
     },
     { skipCommunitySeed: true, skipOnboardingSeed: true },
   );
@@ -109,12 +107,58 @@ test("authenticated Claude persists as preferred and skips detailed config", asy
   expect(savedConfig?.preferred_runtime).toBe("claude");
 });
 
+test("successful Claude sign-in selects it as preferred", async ({ page }) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("claude", { status: "logged_out" }),
+      ],
+      acpAuthMethods: {
+        claude: {
+          methods: [
+            {
+              id: "claude-login",
+              name: "Sign in",
+              description: null,
+              type: "terminal",
+            },
+          ],
+        },
+      },
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+  await waitForAnimations(page);
+
+  const card = page.getByTestId("onboarding-runtime-claude");
+  await card.getByRole("button", { name: "Sign in" }).click({ force: true });
+  await expect(card.getByText("Preferred")).toBeVisible();
+  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
+
+  const savedConfig = await page.evaluate(() =>
+    (
+      window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+          command: string,
+          payload: unknown,
+        ) => Promise<{ preferred_runtime: string | null }>;
+      }
+    ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("get_global_agent_config", null),
+  );
+  expect(savedConfig?.preferred_runtime).toBe("claude");
+});
+
 for (const authStatus of [
   { status: "logged_out" as const },
   { status: "unknown" as const },
   { status: "config_invalid" as const, diagnostic: "Fix Claude config" },
 ]) {
-  test(`Claude ${authStatus.status} state cannot be selected`, async ({ page }) => {
+  test(`Claude ${authStatus.status} state cannot be selected`, async ({
+    page,
+  }) => {
     await installMockBridge(
       page,
       {
@@ -142,7 +186,9 @@ for (const authStatus of [
     if (authStatus.status === "logged_out") {
       await expect(card.getByRole("button", { name: "Sign in" })).toBeVisible();
     } else if (authStatus.status === "unknown") {
-      await expect(card.getByText("Couldn’t verify authentication")).toBeVisible();
+      await expect(
+        card.getByText("Couldn’t verify authentication"),
+      ).toBeVisible();
     } else {
       await expect(card.getByText("Fix Claude config")).toBeVisible();
     }

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -5,6 +5,31 @@ import { passThroughBackupStep } from "../helpers/onboarding";
 
 const SHOTS = "test-results/screenshots-onboarding";
 
+function availableRuntime(
+  id: "buzz-agent" | "claude" | "codex" | "goose",
+  authStatus:
+    | { status: "config_invalid"; diagnostic: string }
+    | { status: "logged_in" | "logged_out" | "not_applicable" | "unknown" },
+) {
+  return {
+    id,
+    label: id === "buzz-agent" ? "Buzz Agent" : id,
+    avatar_url: "",
+    availability: "available",
+    command: id,
+    binary_path: `/usr/local/bin/${id}`,
+    default_args: [],
+    mcp_command: null,
+    install_hint: "",
+    install_instructions_url: "https://example.com",
+    can_auto_install: false,
+    underlying_cli_path: null,
+    node_required: false,
+    auth_status: authStatus,
+    login_hint: `Sign in to ${id}`,
+  };
+}
+
 /** Drive to the harness setup page (page 3) via the full onboarding flow. */
 async function navigateToSetupPage(
   page: Parameters<typeof installMockBridge>[0],
@@ -19,8 +44,109 @@ async function navigateToConfigPage(
   page: Parameters<typeof installMockBridge>[0],
 ) {
   await navigateToSetupPage(page);
+  await page.getByTestId("onboarding-runtime-buzz-agent").click();
+  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
   await page.getByTestId("onboarding-setup-next").click();
   await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+}
+
+test("requires a preferred runtime and routes detailed runtimes to config", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("buzz-agent", { status: "not_applicable" }),
+      ],
+      setGlobalAgentConfigDelayMs: 200,
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const next = page.getByTestId("onboarding-setup-next");
+  await expect(next).toBeDisabled();
+  await page.getByTestId("onboarding-runtime-buzz-agent").click();
+  await expect(next).toHaveText("Saving…");
+  await expect(next).toBeDisabled();
+  await expect(next).toBeEnabled();
+  await next.click();
+  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+});
+
+test("authenticated Claude persists as preferred and skips detailed config", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("claude", { status: "logged_in" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  await page.getByTestId("onboarding-runtime-claude").click();
+  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
+  await page.getByTestId("onboarding-setup-next").click();
+  await expect(page.getByTestId("machine-onboarding-gate")).toHaveCount(0);
+
+  const savedConfig = await page.evaluate(() =>
+    (
+      window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+          command: string,
+          payload: unknown,
+        ) => Promise<{ preferred_runtime: string | null }>;
+      }
+    ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("get_global_agent_config", null),
+  );
+  expect(savedConfig?.preferred_runtime).toBe("claude");
+});
+
+for (const authStatus of [
+  { status: "logged_out" as const },
+  { status: "unknown" as const },
+  { status: "config_invalid" as const, diagnostic: "Fix Claude config" },
+]) {
+  test(`Claude ${authStatus.status} state cannot be selected`, async ({ page }) => {
+    await installMockBridge(
+      page,
+      {
+        acpRuntimesCatalog: [availableRuntime("claude", authStatus)],
+        acpAuthMethods: {
+          claude: {
+            methods: [
+              {
+                id: "login",
+                name: "Sign in",
+                description: null,
+                type: "terminal",
+              },
+            ],
+          },
+        },
+      },
+      { skipCommunitySeed: true, skipOnboardingSeed: true },
+    );
+    await page.goto("/");
+    await navigateToSetupPage(page);
+
+    const card = page.getByTestId("onboarding-runtime-claude");
+    await expect(card).toHaveAttribute("aria-disabled", "true");
+    if (authStatus.status === "logged_out") {
+      await expect(card.getByRole("button", { name: "Sign in" })).toBeVisible();
+    } else if (authStatus.status === "unknown") {
+      await expect(card.getByText("Couldn’t verify authentication")).toBeVisible();
+    } else {
+      await expect(card.getByText("Fix Claude config")).toBeVisible();
+    }
+  });
 }
 
 test("config page shows Agent defaults form", async ({ page }) => {
@@ -43,13 +169,16 @@ test("config page shows Agent defaults form", async ({ page }) => {
   });
 });
 
-test("config page shows configure-later hint when no CLI runtime or buzz-agent config", async ({
+test("config page shows configure-later hint without Buzz Agent model config", async ({
   page,
 }) => {
-  // Seed empty ACP runtimes so no CLI harness is available.
   await installMockBridge(
     page,
-    { acpRuntimesCatalog: [] },
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("buzz-agent", { status: "not_applicable" }),
+      ],
+    },
     { skipCommunitySeed: true, skipOnboardingSeed: true },
   );
   await page.goto("/");
@@ -74,7 +203,11 @@ test("Finish button is always enabled on config page regardless of readiness", a
 }) => {
   await installMockBridge(
     page,
-    { acpRuntimesCatalog: [] },
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("buzz-agent", { status: "not_applicable" }),
+      ],
+    },
     { skipCommunitySeed: true, skipOnboardingSeed: true },
   );
   await page.goto("/");
@@ -143,7 +276,12 @@ test("rapid consecutive provider changes both survive — later change wins", as
   // make a second edit before the first response arrives.
   await installMockBridge(
     page,
-    { acpRuntimesCatalog: [], setGlobalAgentConfigDelayMs: 300 },
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("buzz-agent", { status: "not_applicable" }),
+      ],
+      setGlobalAgentConfigDelayMs: 300,
+    },
     { skipCommunitySeed: true, skipOnboardingSeed: true },
   );
   await page.goto("/");

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -188,9 +188,10 @@ test("successful Codex sign-in hides API key auth and selects it as preferred", 
     0,
   );
   await expect(card.getByLabel("Codex available")).toHaveCount(0);
-  await card
-    .getByRole("button", { name: "Sign in with ChatGPT" })
-    .click({ force: true });
+  await expect(
+    card.getByRole("button", { name: "Sign in with ChatGPT" }),
+  ).toHaveCount(0);
+  await card.getByRole("button", { name: "Log in" }).click({ force: true });
   await expect(card.getByText("Preferred")).toBeVisible();
   await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
 
@@ -225,6 +226,35 @@ test("runtime checkmarks only show for configured harnesses", async ({
 
   await expect(page.getByLabel("Claude available")).toHaveCount(0);
   await expect(page.getByLabel("codex available")).toBeVisible();
+});
+
+test("runtime cards use the preferred onboarding order", async ({ page }) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("buzz-agent", { status: "not_applicable" }),
+        availableRuntime("goose", { status: "not_applicable" }),
+        availableRuntime("codex", { status: "logged_in" }),
+        availableRuntime("claude", { status: "logged_in" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const runtimeOrder = await page
+    .getByRole("radio")
+    .evaluateAll((cards) =>
+      cards.map((card) => card.getAttribute("data-testid")),
+    );
+  expect(runtimeOrder).toEqual([
+    "onboarding-runtime-claude",
+    "onboarding-runtime-codex",
+    "onboarding-runtime-goose",
+    "onboarding-runtime-buzz-agent",
+  ]);
 });
 
 for (const authStatus of [

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -151,6 +151,82 @@ test("successful Claude sign-in selects it as preferred", async ({ page }) => {
   expect(savedConfig?.preferred_runtime).toBe("claude");
 });
 
+test("successful Codex sign-in hides API key auth and selects it as preferred", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [availableRuntime("codex", { status: "logged_out" })],
+      acpAuthMethods: {
+        codex: {
+          methods: [
+            {
+              id: "api-key",
+              name: "Use API key",
+              description: null,
+              type: "input",
+            },
+            {
+              id: "chat-gpt",
+              name: "Sign in with ChatGPT",
+              description: null,
+              type: "browser",
+            },
+          ],
+        },
+      },
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+  await waitForAnimations(page);
+
+  const card = page.getByTestId("onboarding-runtime-codex");
+  await expect(card.getByRole("button", { name: "Use API key" })).toHaveCount(
+    0,
+  );
+  await expect(card.getByLabel("Codex available")).toHaveCount(0);
+  await card
+    .getByRole("button", { name: "Sign in with ChatGPT" })
+    .click({ force: true });
+  await expect(card.getByText("Preferred")).toBeVisible();
+  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
+
+  const savedConfig = await page.evaluate(() =>
+    (
+      window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+          command: string,
+          payload: unknown,
+        ) => Promise<{ preferred_runtime: string | null }>;
+      }
+    ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("get_global_agent_config", null),
+  );
+  expect(savedConfig?.preferred_runtime).toBe("codex");
+});
+
+test("runtime checkmarks only show for configured harnesses", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("claude", { status: "logged_out" }),
+        availableRuntime("codex", { status: "logged_in" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  await expect(page.getByLabel("Claude available")).toHaveCount(0);
+  await expect(page.getByLabel("codex available")).toBeVisible();
+});
+
 for (const authStatus of [
   { status: "logged_out" as const },
   { status: "unknown" as const },

--- a/scripts/reset-desktop-standalone-state.sh
+++ b/scripts/reset-desktop-standalone-state.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Reset only one standalone desktop development instance.
+set -euo pipefail
+
+instance_id="${1:-}"
+keyring_service="${2:-}"
+
+if [[ "$instance_id" != "xyz.block.buzz.app.dev" && "$instance_id" != xyz.block.buzz.app.dev.* ]]; then
+    echo "reset-desktop-standalone-state: refusing non-dev bundle identifier: $instance_id" >&2
+    exit 1
+fi
+if [[ "$keyring_service" != "buzz-desktop-dev" && "$keyring_service" != buzz-desktop-dev.* ]]; then
+    echo "reset-desktop-standalone-state: refusing non-dev keyring service: $keyring_service" >&2
+    exit 1
+fi
+
+remove_path() {
+    local path="$1"
+    if [[ -e "$path" || -L "$path" ]]; then
+        echo "Removing $path"
+        rm -rf -- "$path"
+    fi
+}
+
+case "${BUZZ_TEST_PLATFORM:-$(uname -s)}" in
+    Darwin)
+        remove_path "$HOME/Library/Application Support/$instance_id"
+        remove_path "$HOME/Library/Caches/$instance_id"
+        remove_path "$HOME/Library/WebKit/$instance_id"
+        remove_path "$HOME/Library/HTTPStorages/$instance_id"
+        remove_path "$HOME/Library/Saved Application State/$instance_id.savedState"
+        remove_path "$HOME/Library/Preferences/$instance_id.plist"
+        if command -v security >/dev/null 2>&1; then
+            while security delete-generic-password -s "$keyring_service" >/dev/null 2>&1; do :; done
+        fi
+        ;;
+    Linux)
+        remove_path "${XDG_DATA_HOME:-$HOME/.local/share}/$instance_id"
+        remove_path "${XDG_CONFIG_HOME:-$HOME/.config}/$instance_id"
+        remove_path "${XDG_CACHE_HOME:-$HOME/.cache}/$instance_id"
+        ;;
+    *)
+        echo "reset-desktop-standalone-state: unsupported platform" >&2
+        exit 1
+        ;;
+esac
+
+echo "Standalone state removed for $instance_id; relay and database data were not touched"

--- a/scripts/test-reset-desktop-standalone-state.sh
+++ b/scripts/test-reset-desktop-standalone-state.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+export HOME="$tmp/home"
+export BUZZ_TEST_PLATFORM=Darwin
+mkdir -p "$HOME/Library/Application Support/xyz.block.buzz.app.dev.example"
+mkdir -p "$HOME/Library/Application Support/xyz.block.buzz.app.dev.other"
+mkdir -p "$HOME/Library/Application Support/xyz.block.buzz.app"
+mkdir -p "$HOME/.buzz-dev"
+touch "$HOME/.buzz-dev/keep"
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/security" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$HOME/security-calls"
+exit 1
+MOCK
+chmod +x "$tmp/bin/security"
+export PATH="$tmp/bin:$PATH"
+
+"$repo_root/scripts/reset-desktop-standalone-state.sh" \
+    xyz.block.buzz.app.dev.example buzz-desktop-dev.example
+
+[[ ! -e "$HOME/Library/Application Support/xyz.block.buzz.app.dev.example" ]]
+[[ -d "$HOME/Library/Application Support/xyz.block.buzz.app.dev.other" ]]
+[[ -d "$HOME/Library/Application Support/xyz.block.buzz.app" ]]
+[[ -f "$HOME/.buzz-dev/keep" ]]
+grep -Fx -- "delete-generic-password -s buzz-desktop-dev.example" "$HOME/security-calls" >/dev/null
+
+if "$repo_root/scripts/reset-desktop-standalone-state.sh" \
+    xyz.block.buzz.app buzz-desktop >/dev/null 2>&1; then
+    echo "expected production scope guard to reject reset" >&2
+    exit 1
+fi
+
+echo "standalone desktop reset scope test passed"


### PR DESCRIPTION
## Summary
- require users to choose and persist a preferred agent harness during onboarding
- make Claude and Codex onboarding auth-aware, with hidden Claude login, simplified Codex login, automatic selection after successful auth, and readiness-backed checkmarks
- provision the Welcome team with the selected runtime while preserving persona avatars when media upload fails
- add a safe fresh standalone replay target and prevent duplicate onboarding subscriptions/observer bursts

## Verification
- desktop build + TypeScript
- desktop test suite: 3,113 tests
- `desktop/tests/e2e/onboarding-agent-defaults.spec.ts`: 14/14
- `buzz-acp`: 520 tests
- native auth tests: 13 tests
- standalone onboarding smoke: Claude and Codex auth flows manually exercised; Welcome avatars verified

## Notes
- Codex API-key auth is intentionally hidden during onboarding because that advertised method did not complete successfully; the supported browser login remains available as **Log in**
- runtime order is Claude, Codex, Goose, Buzz Agent
