### PR TITLE
Show unread activity on collapsed sidebar sections

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -865,7 +865,6 @@ export function AppShell() {
                           onCreateChannel={handleCreateChannel}
                           onCreateForum={handleCreateForum}
                           onHideDm={handleHideDm}
-                          onMarkAllChannelsRead={markAllChannelsRead}
                           onMarkChannelRead={markChannelRead}
                           onMarkChannelUnread={markChannelUnread}
                           onBrowseChannels={handleOpenBrowseChannels}

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -481,6 +481,15 @@ export function AppSidebar({
       ),
     [directMessages, dmChannelLabels, sortModeFor],
   );
+  const unassignedChannelsHaveUnread = sectionBuckets.unassigned.some(
+    (channel) => unreadChannelIds.has(channel.id),
+  );
+  const forumsHaveUnread = forumChannels.some((channel) =>
+    unreadChannelIds.has(channel.id),
+  );
+  const directMessagesHaveUnread = sortedDirectMessages.some((channel) =>
+    unreadChannelIds.has(channel.id),
+  );
   const sidebarLoadingShape = useSidebarLoadingShape({
     activeCommunityId: activeCommunity?.id,
     currentPubkey,
@@ -709,7 +718,7 @@ export function AppSidebar({
                     ))}
                     <ChannelGroupSection
                       draggable
-                      hasUnread={unreadChannelIds.size > 0}
+                      hasUnread={unassignedChannelsHaveUnread}
                       isCollapsed={collapsedGroups.channels}
                       isActiveChannel={selectedView === "channel"}
                       activeWorkingByChannelId={activeWorkingByChannelId}
@@ -749,7 +758,7 @@ export function AppSidebar({
                   <FeatureGate feature="forum">
                     <ChannelGroupSection
                       createLabel="New forum"
-                      hasUnread={unreadChannelIds.size > 0}
+                      hasUnread={forumsHaveUnread}
                       isCollapsed={collapsedGroups.forums}
                       isActiveChannel={selectedView === "channel"}
                       activeWorkingByChannelId={activeWorkingByChannelId}
@@ -787,6 +796,15 @@ export function AppSidebar({
                           sectionLabel="direct messages"
                           testId="section-actions-dms"
                           onOpenChange={setDmActionsMenuOpen}
+                          hasUnread={directMessagesHaveUnread}
+                          onMarkAllRead={() => {
+                            for (const channel of sortedDirectMessages) {
+                              onMarkChannelRead(
+                                channel.id,
+                                channel.lastMessageAt,
+                              );
+                            }
+                          }}
                           onNewMessage={onNewMessage}
                           sortMode={sortModeFor("dms")}
                           onSortModeChange={(mode) =>
@@ -796,6 +814,7 @@ export function AppSidebar({
                       </div>
                     }
                     dmParticipantsByChannelId={dmParticipantsByChannelId}
+                    hasUnread={directMessagesHaveUnread}
                     isCollapsed={collapsedGroups.directMessages}
                     isActiveChannel={selectedView === "channel"}
                     activeWorkingByChannelId={activeWorkingByChannelId}

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -130,7 +130,6 @@ type AppSidebarProps = {
     channelId: string,
     lastMessageAt: string | null | undefined,
   ) => void;
-  onMarkAllChannelsRead: () => void;
   onBrowseChannels?: (onCreated?: (channelId: string) => void) => void;
   onOpenDm: (input: { pubkeys: string[] }) => Promise<void>;
   onUpdateCommunity: (
@@ -200,7 +199,6 @@ export function AppSidebar({
   onHideDm,
   onMarkChannelUnread,
   onMarkChannelRead,
-  onMarkAllChannelsRead,
   onBrowseChannels,
   onOpenDm,
   onUpdateCommunity,
@@ -732,7 +730,11 @@ export function AppSidebar({
                       quickCreateLabel="Add channel"
                       onQuickCreateClick={onBrowseChannels}
                       showQuickCreate
-                      onMarkAllRead={onMarkAllChannelsRead}
+                      onMarkAllRead={() => {
+                        for (const channel of sectionBuckets.unassigned) {
+                          onMarkChannelRead(channel.id, channel.lastMessageAt);
+                        }
+                      }}
                       onMarkChannelRead={onMarkChannelRead}
                       onMarkChannelUnread={onMarkChannelUnread}
                       onSelectChannel={onSelectChannel}
@@ -770,7 +772,11 @@ export function AppSidebar({
                       actionsTestId="section-actions-forums"
                       listTestId="forum-list"
                       onCreateClick={() => openCreateDialog("forum")}
-                      onMarkAllRead={onMarkAllChannelsRead}
+                      onMarkAllRead={() => {
+                        for (const channel of forumChannels) {
+                          onMarkChannelRead(channel.id, channel.lastMessageAt);
+                        }
+                      }}
                       onMarkChannelRead={onMarkChannelRead}
                       onMarkChannelUnread={onMarkChannelUnread}
                       onSelectChannel={onSelectChannel}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -292,7 +292,7 @@ function SectionUnreadIndicator({ testId }: { testId: string }) {
   return (
     <span
       aria-hidden="true"
-      className="h-2 w-2 shrink-0 rounded-full bg-primary"
+      className="ml-0.5 size-1.5 shrink-0 rounded-full bg-primary"
       data-testid={testId}
       title="Contains unread channels"
     />

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -288,8 +288,20 @@ export function SectionActionsMenu({
   );
 }
 
+function SectionUnreadIndicator({ testId }: { testId: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="h-2 w-2 shrink-0 rounded-full bg-primary"
+      data-testid={testId}
+      title="Contains unread channels"
+    />
+  );
+}
+
 function ChannelSectionHeader({
   contentId,
+  hasUnread,
   isCollapsed,
   onToggleCollapsed,
   title,
@@ -297,6 +309,7 @@ function ChannelSectionHeader({
   actions,
 }: {
   contentId: string;
+  hasUnread?: boolean;
   isCollapsed: boolean;
   onToggleCollapsed: () => void;
   title: string;
@@ -315,6 +328,14 @@ function ChannelSectionHeader({
           type="button"
         >
           <span data-sidebar-section-title>{title}</span>
+          {isCollapsed && hasUnread ? (
+            <>
+              <SectionUnreadIndicator
+                testId={`${testId}-section-unread-indicator`}
+              />
+              <span className="sr-only">Contains unread channels</span>
+            </>
+          ) : null}
           <span aria-hidden="true" className={SECTION_LABEL_CHEVRON_CLASS}>
             <ChevronDown
               className={cn(
@@ -493,6 +514,7 @@ export function ChannelGroupSection({
     >
       <ChannelSectionHeader
         contentId={contentId}
+        hasUnread={hasUnread}
         isCollapsed={isCollapsed}
         onToggleCollapsed={onToggleCollapsed}
         title={title}
@@ -663,6 +685,16 @@ export function CustomChannelSection({
                       >
                         {section.name}
                       </span>
+                      {isCollapsed && hasUnread ? (
+                        <>
+                          <SectionUnreadIndicator
+                            testId={`section-unread-indicator-${section.id}`}
+                          />
+                          <span className="sr-only">
+                            Contains unread channels
+                          </span>
+                        </>
+                      ) : null}
                       <span
                         aria-hidden="true"
                         className={SECTION_LABEL_CHEVRON_CLASS}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -418,7 +418,7 @@ export function SidebarSection({
                 <>
                   <span
                     aria-hidden="true"
-                    className="h-2 w-2 shrink-0 rounded-full bg-primary"
+                    className="ml-0.5 size-1.5 shrink-0 rounded-full bg-primary"
                     data-testid={`${testId}-section-unread-indicator`}
                     title="Contains unread channels"
                   />

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -343,6 +343,7 @@ export function SidebarSection({
   emptyState,
   items,
   channelLabels,
+  hasUnread = false,
   isCollapsed,
   isActiveChannel,
   presenceByChannelId,
@@ -367,6 +368,7 @@ export function SidebarSection({
   emptyState?: React.ReactNode;
   items: Channel[];
   channelLabels?: Record<string, string>;
+  hasUnread?: boolean;
   isCollapsed?: boolean;
   isActiveChannel: boolean;
   presenceByChannelId?: Record<string, PresenceStatus>;
@@ -412,6 +414,17 @@ export function SidebarSection({
               type="button"
             >
               <span data-sidebar-section-title>{title}</span>
+              {isCollapsed && hasUnread ? (
+                <>
+                  <span
+                    aria-hidden="true"
+                    className="h-2 w-2 shrink-0 rounded-full bg-primary"
+                    data-testid={`${testId}-section-unread-indicator`}
+                    title="Contains unread channels"
+                  />
+                  <span className="sr-only">Contains unread channels</span>
+                </>
+              ) : null}
               <span aria-hidden="true" className={SECTION_LABEL_CHEVRON_CLASS}>
                 <ChevronDown
                   className={cn(

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { waitForAnimations } from "../helpers/animations";
+
 import { KIND_TYPING_INDICATOR } from "../../src/shared/constants/kinds";
 import {
   TEST_IDENTITIES,
@@ -2136,6 +2138,7 @@ test("collapsed custom section surfaces hidden unread state and mark-all clears 
   await expect(sectionLabel).toHaveAccessibleName(
     "Important Contains unread channels",
   );
+  await waitForAnimations(page);
   await page.screenshot({
     path: testInfo.outputPath("collapsed-custom-section-unread.png"),
     clip: { x: 0, y: 0, width: 300, height: 720 },
@@ -2208,6 +2211,7 @@ test("collapsed built-in sections show only their own unread state", async ({
   await expect(
     page.getByTestId("dm-list-section-unread-indicator"),
   ).toHaveCount(0);
+  await waitForAnimations(page);
   await page.screenshot({
     path: testInfo.outputPath("collapsed-built-in-section-unread.png"),
     clip: { x: 0, y: 0, width: 300, height: 720 },

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "../helpers/bridge";
 
 const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const RANDOM_CHANNEL_ID = "9dae0116-799b-5071-a0a8-fdd30a91a35d";
 const AGENTS_CHANNEL_ID = "94a444a4-c0a3-5966-ab05-530c6ddc2301";
 const MOCK_IDENTITY_PUBKEY = "deadbeef".repeat(8);
 // Relay-only agent owned by the mock viewer (see e2eBridge.ts
@@ -2080,6 +2081,115 @@ test("typing indicator shows avatars and maintains stable name order", async ({
   await expect(
     page.getByTestId("message-typing-indicator-label"),
   ).toContainText("alice and bob are typing");
+});
+
+test("collapsed custom section surfaces hidden unread state and mark-all clears it", async ({
+  page,
+}, testInfo) => {
+  const sectionId = "unread-section";
+  await page.addInitScript(
+    ({ channelId, pubkey, sectionId }) => {
+      window.localStorage.setItem(
+        `buzz-channel-sections.v1:${pubkey}`,
+        JSON.stringify({
+          version: 1,
+          sections: [
+            { id: sectionId, name: "Important", icon: "🔔", order: 0 },
+          ],
+          assignments: { [channelId]: sectionId },
+        }),
+      );
+    },
+    {
+      channelId: RANDOM_CHANNEL_ID,
+      pubkey: MOCK_IDENTITY_PUBKEY,
+      sectionId,
+    },
+  );
+
+  await page.goto("/");
+  await waitForMockLiveSubscription(page, "random");
+
+  const sectionLabel = page
+    .getByTestId(`section-title-${sectionId}`)
+    .locator("..");
+  await sectionLabel.click();
+  await expect(sectionLabel).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByTestId("channel-random")).toHaveCount(0);
+  await expect(
+    page.getByTestId(`section-unread-indicator-${sectionId}`),
+  ).toHaveCount(0);
+
+  await page.evaluate((pubkey) => {
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "random",
+      content: "Hidden unread update for Important",
+      kind: 40002,
+      pubkey,
+    });
+  }, TEST_IDENTITIES.alice.pubkey);
+
+  const sectionUnread = page.getByTestId(
+    `section-unread-indicator-${sectionId}`,
+  );
+  await expect(sectionUnread).toBeVisible();
+  await expect(sectionLabel).toHaveAccessibleName(
+    "Important Contains unread channels",
+  );
+  await page.screenshot({
+    path: testInfo.outputPath("collapsed-custom-section-unread.png"),
+  });
+
+  await sectionLabel.hover();
+  await page.getByTestId(`section-actions-${sectionId}`).click();
+  await page.getByRole("menuitem", { name: "Mark all as read" }).click();
+  await expect(sectionUnread).toHaveCount(0);
+
+  await sectionLabel.click();
+  await expect(sectionLabel).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByTestId("channel-random")).toBeVisible();
+});
+
+test("collapsed built-in sections show only their own unread state", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/");
+  await waitForMockLiveSubscription(page, "random");
+
+  // The shared mock fixture seeds older unread activity. Clear it so this test
+  // isolates the live event below rather than depending on fixture history.
+  await page.getByTestId("section-actions-channels").click();
+  await page.getByRole("menuitem", { name: "Mark all as read" }).click();
+  await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
+
+  const channelsLabel = page.getByTestId("stream-list-section-label");
+  const forumsLabel = page.getByTestId("forum-list-section-label");
+  const dmLabel = page.getByTestId("dm-list-section-label");
+  await channelsLabel.click();
+  await forumsLabel.click();
+  await dmLabel.click();
+
+  await page.evaluate((pubkey) => {
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "random",
+      content: "Unread update scoped to Channels",
+      kind: 40002,
+      pubkey,
+    });
+  }, TEST_IDENTITIES.alice.pubkey);
+
+  await expect(
+    page.getByTestId("stream-list-section-unread-indicator"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("forum-list-section-unread-indicator"),
+  ).toHaveCount(0);
+  await expect(
+    page.getByTestId("dm-list-section-unread-indicator"),
+  ).toHaveCount(0);
+  await page.screenshot({
+    path: testInfo.outputPath("collapsed-built-in-section-unread.png"),
+  });
 });
 
 test("sidebar shows unread indicator for newly active channels", async ({

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -15,6 +15,9 @@ const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
 const RANDOM_CHANNEL_ID = "9dae0116-799b-5071-a0a8-fdd30a91a35d";
 const AGENTS_CHANNEL_ID = "94a444a4-c0a3-5966-ab05-530c6ddc2301";
 const MOCK_IDENTITY_PUBKEY = "deadbeef".repeat(8);
+const COLLAPSED_CUSTOM_SECTION_TEST =
+  "collapsed custom section surfaces hidden unread state and mark-all clears it";
+const UNREAD_SECTION_ID = "unread-section";
 // Relay-only agent owned by the mock viewer (see e2eBridge.ts
 // OWNED_RELAY_AGENT_PUBKEY). Classified as a bot via mockRelayAgents and
 // owned-by-viewer via its mockProfiles owner_pubkey, so the sidebar
@@ -468,7 +471,29 @@ async function expectIntroActionsShareRow(
   }
 }
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }, testInfo) => {
+  if (testInfo.title === COLLAPSED_CUSTOM_SECTION_TEST) {
+    await page.addInitScript(
+      ({ channelId, pubkey, sectionId }) => {
+        window.localStorage.setItem(
+          `buzz-channel-sections.v1:${pubkey}`,
+          JSON.stringify({
+            version: 1,
+            sections: [
+              { id: sectionId, name: "Important", icon: "🔔", order: 0 },
+            ],
+            assignments: { [channelId]: sectionId },
+          }),
+        );
+      },
+      {
+        channelId: RANDOM_CHANNEL_ID,
+        pubkey: MOCK_IDENTITY_PUBKEY,
+        sectionId: UNREAD_SECTION_ID,
+      },
+    );
+  }
+
   await installMockBridge(page);
 });
 
@@ -2085,29 +2110,8 @@ test("typing indicator shows avatars and maintains stable name order", async ({
   ).toContainText("alice and bob are typing");
 });
 
-test("collapsed custom section surfaces hidden unread state and mark-all clears it", async ({
-  page,
-}, testInfo) => {
-  const sectionId = "unread-section";
-  await page.addInitScript(
-    ({ channelId, pubkey, sectionId }) => {
-      window.localStorage.setItem(
-        `buzz-channel-sections.v1:${pubkey}`,
-        JSON.stringify({
-          version: 1,
-          sections: [
-            { id: sectionId, name: "Important", icon: "🔔", order: 0 },
-          ],
-          assignments: { [channelId]: sectionId },
-        }),
-      );
-    },
-    {
-      channelId: RANDOM_CHANNEL_ID,
-      pubkey: MOCK_IDENTITY_PUBKEY,
-      sectionId,
-    },
-  );
+test(COLLAPSED_CUSTOM_SECTION_TEST, async ({ page }, testInfo) => {
+  const sectionId = UNREAD_SECTION_ID;
 
   await page.goto("/");
   await waitForMockLiveSubscription(page, "random");

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2138,7 +2138,21 @@ test("collapsed custom section surfaces hidden unread state and mark-all clears 
   );
   await page.screenshot({
     path: testInfo.outputPath("collapsed-custom-section-unread.png"),
+    clip: { x: 0, y: 0, width: 300, height: 720 },
   });
+
+  // Expanded sections rely on their channel rows, so the header signal must
+  // disappear instead of duplicating unread state.
+  await sectionLabel.click();
+  await expect(sectionLabel).toHaveAttribute("aria-expanded", "true");
+  await expect(sectionUnread).toHaveCount(0);
+  await expect(page.getByTestId("channel-random")).toHaveCSS(
+    "font-weight",
+    "600",
+  );
+  await sectionLabel.click();
+  await expect(sectionLabel).toHaveAttribute("aria-expanded", "false");
+  await expect(sectionUnread).toBeVisible();
 
   await sectionLabel.hover();
   await page.getByTestId(`section-actions-${sectionId}`).click();
@@ -2156,10 +2170,17 @@ test("collapsed built-in sections show only their own unread state", async ({
   await page.goto("/");
   await waitForMockLiveSubscription(page, "random");
 
-  // The shared mock fixture seeds older unread activity. Clear it so this test
-  // isolates the live event below rather than depending on fixture history.
+  // The shared mock fixture seeds older unread activity. Clear each rendered
+  // built-in group so this test isolates the live events below.
   await page.getByTestId("section-actions-channels").click();
   await page.getByRole("menuitem", { name: "Mark all as read" }).click();
+  await page.getByTestId("section-actions-forums").click();
+  const forumMarkAll = page.getByRole("menuitem", { name: "Mark all as read" });
+  if ((await forumMarkAll.count()) > 0) {
+    await forumMarkAll.click();
+  } else {
+    await page.keyboard.press("Escape");
+  }
   await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
 
   const channelsLabel = page.getByTestId("stream-list-section-label");
@@ -2189,7 +2210,33 @@ test("collapsed built-in sections show only their own unread state", async ({
   ).toHaveCount(0);
   await page.screenshot({
     path: testInfo.outputPath("collapsed-built-in-section-unread.png"),
+    clip: { x: 0, y: 0, width: 300, height: 720 },
   });
+
+  await page.getByTestId("section-actions-channels").click();
+  await page.getByRole("menuitem", { name: "Mark all as read" }).click();
+  await expect(
+    page.getByTestId("stream-list-section-unread-indicator"),
+  ).toHaveCount(0);
+
+  await waitForMockLiveSubscription(page, "alice-tyler");
+  await page.evaluate((pubkey) => {
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "alice-tyler",
+      content: "Unread update scoped to Direct messages",
+      pubkey,
+    });
+  }, TEST_IDENTITIES.alice.pubkey);
+
+  await expect(
+    page.getByTestId("dm-list-section-unread-indicator"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("stream-list-section-unread-indicator"),
+  ).toHaveCount(0);
+  await expect(
+    page.getByTestId("forum-list-section-unread-indicator"),
+  ).toHaveCount(0);
 });
 
 test("sidebar shows unread indicator for newly active channels", async ({


### PR DESCRIPTION
## Summary

- show a primary-color unread dot on collapsed custom, Channels, Forums, and Direct messages section headers
- scope each section's unread state and “Mark all as read” action to the channels it actually renders
- add Direct messages mark-all parity intentionally, while preserving Shift+Esc as the global mark-all shortcut
- include screen-reader text and collapsed/expanded behavior coverage

Slack uses a similar collapsed-section signal, providing precedent for this lightweight treatment. The dot is informational and appears only while a section is collapsed so it does not duplicate channel-row unread styling.

## Testing

- `pnpm exec biome check src/app/AppShell.tsx src/features/sidebar/ui/AppSidebar.tsx src/features/sidebar/ui/CustomChannelSection.tsx src/features/sidebar/ui/SidebarSection.tsx tests/e2e/channels.spec.ts`
- `pnpm typecheck`
- `pnpm exec playwright test tests/e2e/channels.spec.ts --project=smoke --grep "collapsed (custom|built-in) section"` — 2 passed
- `pnpm exec playwright test tests/e2e/channels.spec.ts --project=smoke` — 63 passed before the review follow-ups; focused tests rerun afterward
- local pre-push desktop, Rust, and desktop-Tauri checks passed
- explicit DCO author/signoff identity check passed for both commits

## Review notes

An adversarial review specifically challenged section scoping, collapsed-only rendering, accessibility, mark-all semantics, and whether the tests could pass with broken behavior. Follow-up changes scoped Channels/Forums actions to their rendered arrays, added expanded-state coverage, and added a positive Direct messages scoping case. A delta review found no remaining blockers.

## Screenshots

Cropped sidebar screenshots are attached in [this PR comment](https://github.com/block/buzz/pull/2042#issuecomment-5007255557).