### PR TITLE
fix(desktop): route first community deep links into onboarding

### DIFF
--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -40,7 +40,10 @@ import { CommunityApplyErrorScreen } from "@/features/communities/ui/CommunityAp
 import { CommunityChangeOverlay } from "@/features/communities/ui/CommunityChangeOverlay";
 import { createBuzzQueryClient } from "@/shared/api/queryClient";
 import { isSharedIdentity as isSharedIdentityCmd } from "@/shared/api/tauri";
-import { listenForDeepLinks } from "@/shared/deep-link";
+import {
+  type AddCommunityDeepLinkPayload,
+  listenForDeepLinks,
+} from "@/shared/deep-link";
 import { cn } from "@/shared/lib/cn";
 import { BuzzMark } from "@/shared/ui/buzz-logo/BuzzMark";
 import { FlappingBee } from "@/shared/ui/buzz-logo/FlappingBee";
@@ -421,6 +424,18 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
     [machine.complete],
   );
 
+  const openAddCommunity = useCallback(
+    (payload: AddCommunityDeepLinkPayload & { requestId: string }) =>
+      activeCommunity
+        ? requestAddCommunityPrefill(payload)
+        : communityOnboarding.start({
+            source: "add-community",
+            relayUrl: payload.relayUrl,
+            communityName: payload.name,
+          }),
+    [activeCommunity, communityOnboarding.start],
+  );
+
   // Deep links are captured here — above the machine-onboarding gate — not in
   // CommunityApp. The Rust side queues them; draining into the persisted
   // community-onboarding transaction immediately means an invite opened on a
@@ -429,13 +444,13 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
   useEffect(() => {
     const unlisten = listenForDeepLinks({
       startCommunityOnboarding: communityOnboarding.start,
-      openAddCommunity: requestAddCommunityPrefill,
+      openAddCommunity,
       onAddCommunityAvailable: onAddCommunityPrefillAvailable,
     });
     return () => {
       void unlisten.then((fn) => fn());
     };
-  }, [communityOnboarding.start]);
+  }, [communityOnboarding.start, openAddCommunity]);
 
   if (machine.stage === "reset-failed") return <ResetFailedScreen />;
   if (machine.stage === "keyring-locked") return <KeyringLockedScreen />;

--- a/desktop/tests/e2e/deep-link-invite.spec.ts
+++ b/desktop/tests/e2e/deep-link-invite.spec.ts
@@ -110,6 +110,38 @@ test("connect deep link shows a static acknowledgment during setup", async ({
     .toContain('"acknowledged":true');
 });
 
+test("add-community deep link starts onboarding when no community is configured", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    { pendingCommunityDeepLinks: [PENDING_ADD_COMMUNITY_LINK] },
+    { skipCommunitySeed: true },
+  );
+  await page.goto("/");
+
+  await expect(page.getByTestId("community-onboarding-flow")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Build your profile" }),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (key) => window.localStorage.getItem(key),
+        TRANSACTION_STORAGE_KEY,
+      ),
+    )
+    .toContain('"source":"add-community"');
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (key) => window.localStorage.getItem(key),
+        TRANSACTION_STORAGE_KEY,
+      ),
+    )
+    .toContain('"communityName":"Acme Team"');
+});
+
 test("add-community deep link opens one editable prefill and acknowledges the queue", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- route public `add-community` deep links into community onboarding when Desktop has no configured community
- preserve the editable Add Community dialog for existing installs
- cover both routes in the deep-link E2E spec

## Defect
Rust retained and delivered the link, but Desktop acknowledged it after parking an AppShell dialog prefill. With zero communities, AppShell never mounted because WelcomeSetup gated it, so the link appeared inert.

## Validation
- new zero-community E2E failed on `origin/main` (no `community-onboarding-flow`)
- `pnpm exec playwright test tests/e2e/deep-link-invite.spec.ts --project=smoke` (7 passed)
- pre-commit and pre-push hooks passed

## Non-goals
- browser/Desktop identity ownership handoff
- default relay behavior
