### PR TITLE
Fix community profile onboarding back navigation

### DIFF
--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -334,16 +334,6 @@ export function CommunityOnboardingFlow({
                   >
                     Next
                   </Button>
-                  <Button
-                    className="h-9 rounded-full bg-foreground/10 px-6 hover:bg-foreground/15"
-                    data-testid="community-profile-back"
-                    disabled={isPending || isUploadingAvatar}
-                    onClick={clear}
-                    type="button"
-                    variant="ghost"
-                  >
-                    Back
-                  </Button>
                 </OnboardingFooter>
               </>
             )

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -767,7 +767,7 @@ test("first-community shows the scenario cards for localhost", async ({
   ).toBeVisible();
 });
 
-test("first-community profile step uses onboarding Next and Back controls", async ({
+test("connected first-community profile step cannot discard resumable onboarding", async ({
   page,
 }) => {
   await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
@@ -786,6 +786,7 @@ test("first-community profile step uses onboarding Next and Back controls", asyn
           stage: "profile",
           relayUrl: "wss://default.example.com",
           communityName: "Default",
+          communityId: "e2e-default-community",
           createdAt: timestamp,
           updatedAt: timestamp,
         }),
@@ -799,7 +800,6 @@ test("first-community profile step uses onboarding Next and Back controls", asyn
   await installMockBridge(page, undefined, {
     relayWsUrl: "wss://default.example.com",
     skipOnboardingSeed: true,
-    skipCommunitySeed: true,
   });
   await page.goto("/");
 
@@ -858,12 +858,7 @@ test("first-community profile step uses onboarding Next and Back controls", asyn
   ).toBe(true);
   await expect(page.getByTestId("community-profile-next")).toHaveText("Next");
   await expect(page.getByTestId("community-profile-next")).toBeDisabled();
-  await expect(page.getByTestId("community-profile-back")).toHaveText("Back");
-
-  await page.getByTestId("community-profile-back").click();
-  await expect(
-    page.getByRole("button", { name: "Add me to a community" }),
-  ).toBeVisible();
+  await expect(page.getByTestId("community-profile-back")).toHaveCount(0);
   await expect
     .poll(() =>
       page.evaluate(
@@ -871,7 +866,7 @@ test("first-community profile step uses onboarding Next and Back controls", asyn
         COMMUNITY_ONBOARDING_TRANSACTION_STORAGE_KEY,
       ),
     )
-    .toBeNull();
+    .not.toBeNull();
 });
 
 test("identity fallback text does not count as a real onboarding name", async ({


### PR DESCRIPTION
## Summary
- remove the post-connect profile Back action that cleared resumable community onboarding state
- update the regression to model an already-connected community
- assert the profile stage keeps its transaction and cannot fall through to legacy onboarding

## Test plan
- `pnpm --dir desktop exec playwright test onboarding.spec.ts --project=integration` (37 passed)
- `just desktop-check`
- `just desktop-test` (3,120 passed)
- `just desktop-typecheck`
- pre-push hooks: branch-skew, desktop checks/tests, mobile tests, desktop Tauri tests, Rust tests
