### PR TITLE
fix(desktop): preserve profile descriptions across communities

### DIFF
--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -73,6 +73,7 @@ async function persistSelfProfile(
     version: 1,
     displayName: profile.displayName,
     avatarUrl: profile.avatarUrl,
+    about: profile.about,
     avatarDataUrl,
     updatedAt: Date.now(),
     // Only persist the presence bit when true — no-event fallbacks
@@ -106,7 +107,7 @@ export function useProfileQuery(enabled = true) {
             pubkey,
             displayName: cached.displayName,
             avatarUrl: cached.avatarUrl,
-            about: null,
+            about: cached.about,
             nip05Handle: null,
             ownerPubkey: null,
             // Only true when the cache entry was explicitly written with a

--- a/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
+++ b/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
@@ -53,6 +53,7 @@ test("parseSelfProfileCache: valid v1 payload round-trips", () => {
     version: 1,
     displayName: "Alice",
     avatarUrl: "https://relay.example.com/media/abc.jpg",
+    about: "Building better communities",
     avatarDataUrl: "data:image/jpeg;base64,/9j/4A==",
     updatedAt: 1700000000000,
   };
@@ -65,6 +66,7 @@ test("parseSelfProfileCache: null fields are preserved", () => {
     version: 1,
     displayName: null,
     avatarUrl: null,
+    about: null,
     avatarDataUrl: null,
     updatedAt: 0,
   };

--- a/desktop/src/features/profile/lib/selfProfileStorage.ts
+++ b/desktop/src/features/profile/lib/selfProfileStorage.ts
@@ -36,6 +36,7 @@ export type SelfProfileCache = {
   displayName: string | null;
   /** Original relay URL from the kind-0 profile event. */
   avatarUrl: string | null;
+  about: string | null;
   /**
    * Base64 data URL captured while the relay was reachable. Capped at 256 KB
    * to keep localStorage usage bounded. Null if never captured or too large.
@@ -58,6 +59,7 @@ const DEFAULT_CACHE: SelfProfileCache = Object.freeze({
   version: 1,
   displayName: null,
   avatarUrl: null,
+  about: null,
   avatarDataUrl: null,
   updatedAt: 0,
 });
@@ -85,6 +87,7 @@ export function parseSelfProfileCache(json: unknown): SelfProfileCache | null {
   const displayName =
     typeof obj.displayName === "string" ? obj.displayName : null;
   const avatarUrl = typeof obj.avatarUrl === "string" ? obj.avatarUrl : null;
+  const about = typeof obj.about === "string" ? obj.about : null;
   // Defense-in-depth: avatarDataUrl flows into an <img src> sink; only accept
   // values that are provably safe image data URLs.
   const avatarDataUrl =
@@ -105,6 +108,7 @@ export function parseSelfProfileCache(json: unknown): SelfProfileCache | null {
     version: 1,
     displayName,
     avatarUrl,
+    about,
     avatarDataUrl,
     updatedAt,
     ...(hasProfileEvent !== undefined && { hasProfileEvent }),

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -164,6 +164,52 @@ test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
 });
 
+test("keeps the saved profile description after a community round trip", async ({
+  page,
+}) => {
+  const communities = [
+    {
+      id: "profile-community-a",
+      name: "Alpha",
+      relayUrl: "ws://localhost:3000",
+      addedAt: "2026-01-01T00:00:00.000Z",
+    },
+    {
+      id: "profile-community-b",
+      name: "Bravo",
+      relayUrl: "ws://localhost:3001",
+      addedAt: "2026-01-02T00:00:00.000Z",
+    },
+  ];
+  await page.addInitScript((seed) => {
+    window.localStorage.setItem("buzz-communities", JSON.stringify(seed));
+    window.localStorage.setItem("buzz-active-community-id", seed[0].id);
+  }, communities);
+  await page.goto("/");
+
+  const description = "Description that should survive switching";
+  await openSettings(page, "profile");
+  await page.getByTestId("profile-metadata-edit").click();
+  await page.getByTestId("profile-about").fill(description);
+  await page.getByTestId("profile-metadata-edit").click();
+  await expect(page.getByTestId("profile-about-value")).toHaveText(description);
+  await page.getByTestId("settings-back-to-app").click();
+
+  const communityA = page.getByTestId(
+    "community-rail-button-profile-community-a",
+  );
+  const communityB = page.getByTestId(
+    "community-rail-button-profile-community-b",
+  );
+  await communityB.click();
+  await expect(communityB).toHaveAttribute("aria-current", "true");
+  await communityA.click();
+  await expect(communityA).toHaveAttribute("aria-current", "true");
+
+  await openSettings(page, "profile");
+  await expect(page.getByTestId("profile-about-value")).toHaveText(description);
+});
+
 test("updates the relay-backed profile from settings", async ({ page }) => {
   const stamp = Date.now();
   const displayName = `Tyler QA ${stamp}`;


### PR DESCRIPTION
This fixes profile descriptions appearing empty after switching to another community and back. The existing per-community profile cache now stores and restores the description, with a regression test covering the full community round trip.

## Before this PR

https://github.com/user-attachments/assets/b2c6cee6-66c1-4ed7-89b7-c67efd5bc818

## After this PR

https://github.com/user-attachments/assets/211c4108-db1d-402a-acbc-f7ad2c4bd615

