### PR TITLE
fix(desktop): keep Private toggle when picking a channel template

### DIFF
--- a/desktop/src/features/sidebar/lib/useCreateChannelForm.ts
+++ b/desktop/src/features/sidebar/lib/useCreateChannelForm.ts
@@ -78,6 +78,7 @@ export function useCreateChannelForm({
   >(null);
   const [typePopoverOpen, setTypePopoverOpen] = React.useState(false);
   const nameInputRef = React.useRef<HTMLInputElement>(null);
+  const visibilityTouchedRef = React.useRef(false);
 
   const templatesQuery = useChannelTemplatesQuery();
   const templates = templatesQuery.data ?? [];
@@ -96,6 +97,7 @@ export function useCreateChannelForm({
     setErrorMessage(null);
     setSelectedTemplateId(null);
     setTypePopoverOpen(false);
+    visibilityTouchedRef.current = false;
 
     if (!autoFocusName) return;
 
@@ -123,7 +125,7 @@ export function useCreateChannelForm({
       if (!templateId) {
         setSelectedTemplateId(null);
         setDescription("");
-        setVisibility("open");
+        if (!visibilityTouchedRef.current) setVisibility("open");
         setErrorMessage(null);
         return;
       }
@@ -135,7 +137,7 @@ export function useCreateChannelForm({
 
       setSelectedTemplateId(templateId);
       setDescription(template.description ?? "");
-      setVisibility(template.visibility);
+      if (!visibilityTouchedRef.current) setVisibility(template.visibility);
       setErrorMessage(null);
     },
     [templates],
@@ -195,7 +197,10 @@ export function useCreateChannelForm({
       setErrorMessage(null);
     },
     visibility,
-    setVisibility,
+    setVisibility: (value: ChannelVisibility) => {
+      visibilityTouchedRef.current = true;
+      setVisibility(value);
+    },
     ephemeral,
     setEphemeral,
     durationLabel,


### PR DESCRIPTION
## Problem

In the create-channel form, toggling **Private** on and then changing the **Template** dropdown silently deselected the switch — the template's visibility unconditionally overwrote the user's explicit choice (and clearing the template reset it to open).

## Fix

Track whether the user has touched the Private switch (`visibilityTouchedRef`). The template dropdown only applies its visibility when the switch is untouched; an explicit user choice always wins. The flag resets when the form (re)opens.

One file, +8/−3: `desktop/src/features/sidebar/lib/useCreateChannelForm.ts`.

## Testing

- `pnpm typecheck`, `pnpm check` (biome + size/px/pubkey guards) — clean
- `pnpm test` — 3122 pass
- Pre-push hooks (desktop-check/test, rust-tests, tauri-test, mobile-test) — green
