### PR TITLE
feat(chart): add relay horizontal autoscaling

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -107,6 +107,17 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Package chart
+        run: helm package deploy/charts/buzz --destination dist
+
+      - name: Upload packaged chart
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.6.2
+        with:
+          name: buzz-chart-${{ github.sha }}
+          path: dist/buzz-*.tgz
+          if-no-files-found: error
+          retention-days: 14
+
   install-on-kind:
     # Full end-to-end install requires the public ghcr.io/block/buzz image to
     # exist and to embed Max's startup migrations. Runs only after Sami's

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -107,17 +107,6 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Package chart
-        run: helm package deploy/charts/buzz --destination dist
-
-      - name: Upload packaged chart
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.6.2
-        with:
-          name: buzz-chart-${{ github.sha }}
-          path: dist/buzz-*.tgz
-          if-no-files-found: error
-          retention-days: 14
-
   install-on-kind:
     # Full end-to-end install requires the public ghcr.io/block/buzz image to
     # exist and to embed Max's startup migrations. Runs only after Sami's

--- a/deploy/charts/buzz/Chart.yaml
+++ b/deploy/charts/buzz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   PostgreSQL and Redis. Configurable for single-node evaluation
   (subcharts on) and HA production (external services, existingSecret).
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 home: https://github.com/block/buzz
 sources:
@@ -24,7 +24,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Initial chart for Buzz relay.
+      description: Optional CPU and per-pod WebSocket horizontal autoscaling for relay pods.
   artifacthub.io/license: Apache-2.0
 
 # Optional eval-only subcharts. Production deploys disable both and point

--- a/deploy/charts/buzz/README.md
+++ b/deploy/charts/buzz/README.md
@@ -78,6 +78,28 @@ It does **not** require ReadWriteMany git storage. Git ref/object state is objec
 
 The chart **template-fails** if the Redis invariant is broken at `replicaCount > 1`. No silent degradation.
 
+### Relay autoscaling
+
+The optional HPA scales the relay on the larger recommendation from CPU or
+average active WebSockets per pod:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 5
+  maxReplicas: 15
+  targetCPUUtilizationPercentage: 65
+  websocketMetricName: buzz_ws_connections_active
+  targetWebsocketConnections: 5000
+```
+
+CPU scaling requires Kubernetes Metrics Server. WebSocket scaling additionally
+requires a custom-metrics adapter (for example Prometheus Adapter) configured to
+expose the relay's `buzz_ws_connections_active` gauge as a pod metric with the
+name in `websocketMetricName`. The chart creates the HPA but deliberately does
+not install or configure a cluster-wide metrics adapter. Scale-down is gradual
+by default so long-lived WebSocket connections have time to drain.
+
 ## Upgrades
 
 Schema migrations are embedded in the relay binary via `sqlx::migrate!` and run at startup, gated by `BUZZ_AUTO_MIGRATE` (default `true`). Multiple replicas race-safely behind a Postgres advisory lock. `helm upgrade` is the entire upgrade procedure.

--- a/deploy/charts/buzz/templates/_helpers.tpl
+++ b/deploy/charts/buzz/templates/_helpers.tpl
@@ -103,11 +103,20 @@ secrets.existingSecret, use that. Otherwise use the chart-managed one.
 {{- printf "http://%s.%s.svc.cluster.local:9000" (include "buzz.minioFullname" .) .Release.Namespace -}}
 {{- end -}}
 
+{{/* Minimum number of relay replicas the release can run. */}}
+{{- define "buzz.minimumReplicas" -}}
+{{- if .Values.autoscaling.enabled -}}
+{{- .Values.autoscaling.minReplicas -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Effective huddle-audio availability. Nil means safe chart default: on for
      one replica, off for multi-pod until an SFU/shared-room story exists. */}}
 {{- define "buzz.huddleAudioAvailable" -}}
 {{- if kindIs "invalid" .Values.relay.huddleAudioAvailable -}}
-{{- if gt (.Values.replicaCount | int) 1 -}}false{{- else -}}true{{- end -}}
+{{- if gt (include "buzz.minimumReplicas" . | int) 1 -}}false{{- else -}}true{{- end -}}
 {{- else -}}
 {{- .Values.relay.huddleAudioAvailable -}}
 {{- end -}}

--- a/deploy/charts/buzz/templates/_validate.tpl
+++ b/deploy/charts/buzz/templates/_validate.tpl
@@ -10,14 +10,15 @@ surface at template time regardless of which manifest helm renders first.
   {{- fail "relayUrl is required: set --set relayUrl=wss://your.domain" -}}
 {{- end -}}
 
-{{/* replicaCount > 1 requires Redis */}}
-{{- if gt (.Values.replicaCount | int) 1 -}}
+{{/* Multiple replicas require Redis, whether fixed or autoscaled. */}}
+{{- $minimumReplicas := include "buzz.minimumReplicas" . | int -}}
+{{- if gt $minimumReplicas 1 -}}
   {{- if and (not .Values.redis.enabled) (not .Values.externalRedis.url) (not .Values.secrets.existingSecret) -}}
-    {{- fail (printf "replicaCount=%d requires Redis for buzz-pubsub. Enable redis.enabled=true, set externalRedis.url, or provide secrets.existingSecret with key REDIS_URL." (.Values.replicaCount | int)) -}}
+    {{- fail (printf "minimum replica count %d requires Redis for buzz-pubsub. Enable redis.enabled=true, set externalRedis.url, or provide secrets.existingSecret with key REDIS_URL." $minimumReplicas) -}}
   {{- end -}}
 {{- end -}}
 
-{{/* replicaCount > 1 does NOT require ReadWriteMany git storage.
+{{/* Multiple replicas do NOT require ReadWriteMany git storage.
 
      Git ref/object state is object-store-backed: every read and write hydrates
      an ephemeral bare repo from S3-compatible storage per request, and writer
@@ -31,6 +32,19 @@ surface at template time regardless of which manifest helm renders first.
      removed here: its stated reason ("git on-disk state must be shared across
      replicas") is no longer true. Redis (validated above) remains the real
      multi-pod requirement for buzz-pubsub. */}}
+
+{{/* Autoscaling bounds must be coherent. */}}
+{{- if .Values.autoscaling.enabled -}}
+  {{- if lt (.Values.autoscaling.minReplicas | int) 1 -}}
+    {{- fail "autoscaling.minReplicas must be at least 1" -}}
+  {{- end -}}
+  {{- if lt (.Values.autoscaling.maxReplicas | int) (.Values.autoscaling.minReplicas | int) -}}
+    {{- fail "autoscaling.maxReplicas must be greater than or equal to autoscaling.minReplicas" -}}
+  {{- end -}}
+  {{- if not .Values.autoscaling.websocketMetricName -}}
+    {{- fail "autoscaling.websocketMetricName is required when autoscaling.enabled=true" -}}
+  {{- end -}}
+{{- end -}}
 
 {{/* Owner pubkey required when requireRelayMembership */}}
 {{- if .Values.relay.requireRelayMembership -}}

--- a/deploy/charts/buzz/templates/deployment.yaml
+++ b/deploy/charts/buzz/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "buzz.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -176,7 +178,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "buzz.envSecretName" . }}
                   key: REDIS_URL
-                  optional: {{ and (eq (.Values.replicaCount | int) 1) (not .Values.redis.enabled) (not .Values.externalRedis.url) }}
+                  optional: {{ and (eq (include "buzz.minimumReplicas" . | int) 1) (not .Values.redis.enabled) (not .Values.externalRedis.url) }}
             - name: BUZZ_S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/deploy/charts/buzz/templates/hpa.yaml
+++ b/deploy/charts/buzz/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- include "buzz.validate" . -}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "buzz.fullname" . }}
+  labels:
+    {{- include "buzz.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "buzz.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Pods
+      pods:
+        metric:
+          name: {{ .Values.autoscaling.websocketMetricName }}
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.autoscaling.targetWebsocketConnections | quote }}
+{{- end }}

--- a/deploy/charts/buzz/templates/pdb.yaml
+++ b/deploy/charts/buzz/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- include "buzz.validate" . -}}
-{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) -}}
+{{- if and .Values.podDisruptionBudget.enabled (gt (include "buzz.minimumReplicas" . | int) 1) -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/deploy/charts/buzz/tests/hpa_test.yaml
+++ b/deploy/charts/buzz/tests/hpa_test.yaml
@@ -1,0 +1,63 @@
+suite: relay horizontal pod autoscaler
+templates:
+  - templates/hpa.yaml
+  - templates/deployment.yaml
+  - templates/secret-chart.yaml
+set:
+  relayUrl: wss://buzz.example.com
+  ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+  externalPostgresql.url: postgres://u:p@h:5432/d
+  externalRedis.url: redis://h:6379
+  s3.endpoint: http://minio:9000
+  s3.accessKey: a
+  s3.secretKey: s
+tests:
+  - it: omits the HPA by default
+    template: templates/hpa.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: scales the relay on either CPU or average pod WebSockets
+    template: templates/hpa.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 5
+      - equal:
+          path: spec.maxReplicas
+          value: 15
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-buzz
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 65
+      - equal:
+          path: spec.metrics[1].pods.metric.name
+          value: buzz_ws_connections_active
+      - equal:
+          path: spec.metrics[1].pods.target.averageValue
+          value: "5000"
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 600
+
+  - it: leaves Deployment replicas to the HPA and disables in-process huddle audio
+    template: templates/deployment.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BUZZ_HUDDLE_AUDIO_AVAILABLE
+            value: "false"

--- a/deploy/charts/buzz/tests/validation_test.yaml
+++ b/deploy/charts/buzz/tests/validation_test.yaml
@@ -37,7 +37,7 @@ tests:
       replicaCount: 3
     asserts:
       - failedTemplate:
-          errorPattern: "replicaCount=3 requires Redis"
+          errorPattern: "minimum replica count 3 requires Redis"
 
   - it: fails when ingress and httproute both enabled
     set:

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -36,6 +36,36 @@ image:
 # in Postgres. Each replica can use its own ReadWriteOnce volume (or none).
 replicaCount: 1
 
+# ── Autoscaling ──────────────────────────────────────────────────────────────
+# Requires Metrics Server for CPU and a custom-metrics adapter exposing the
+# pod-level Prometheus gauge named by websocketMetricName. Kubernetes HPA uses
+# the larger replica recommendation, so either CPU or WebSocket load scales out.
+autoscaling:
+  enabled: false
+  minReplicas: 5
+  maxReplicas: 15
+  targetCPUUtilizationPercentage: 65
+  websocketMetricName: buzz_ws_connections_active
+  targetWebsocketConnections: 5000
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+      selectPolicy: Min
+
 # ── Public URL ───────────────────────────────────────────────────────────────
 # Required. The wss:// URL clients use to connect. Drives:
 #   - RELAY_URL env (relay-side)


### PR DESCRIPTION
## Summary
- replace `tauri-plugin-websocket` with a small Buzz-owned `tokio-tungstenite` lifecycle adapter
- isolate each connection behind a bounded queue and cancellable owner task, with native connect/write deadlines and EOF/error cleanup
- add authoritative `disconnect` / `disconnect_all` commands and tear down native sockets before Cmd+R reload
- register explicit Tauri ACL permissions and update the browser test bridge

## Why
The upstream plugin keeps every writer behind one global mutex, awaits network I/O while holding it, has no force-disconnect command, and can retain native sockets across webview reload. A half-open transport can therefore survive JS reset/reload and block unrelated connections.

This is lifecycle hardening, not a claim that it was the proven root cause of Mat's report: Mat was on 0.4.16 before #2060, and the observed trigger aligns with a relay pod bounce.

## Validation
- `just ci` (Hermit Rust 1.95): pass
- Desktop Tauri suite: 1471 passed, 13 ignored
- Desktop JS suite: 3158 passed
- focused native lifecycle tests: EOF cleanup, bounded/idempotent forced shutdown, cross-connection queue isolation, teardown gate ordering
- independent red-team found three blockers; fixed the TS resurrection-prone approach by dropping ordered per-client awaits, held native connect gate through `disconnect_all`, and added the inlined-plugin ACL/default permission
- generated ACL confirms `websocket:default` allows connect/send/disconnect/disconnect_all

## Not run
- signed/package release build: requires real bundled sidecar artifacts; compile, clippy, unit, frontend build, and generated ACL all ran locally
