### PR TITLE
fix(desktop): restore onboarding provider choices

### DIFF
--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -199,9 +199,6 @@ function AgentDefaultsSection({
             disableModelSelectDuringDiscovery={false}
             effortPlaceholderLabel="Select effort level"
             keepSelectedModelValueLabel
-            hideUnconfiguredCredentialProviders={
-              selectedRuntimeId === "buzz-agent"
-            }
             modelPlaceholderLabel="Select a model"
             onConfigChange={(next) => {
               // Always apply optimistically so the UI never reverts mid-save,

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -742,10 +742,10 @@ test("config page shows Agent defaults form", async ({ page }) => {
   await page.getByTestId("global-agent-provider").click();
   await expect(
     page.getByTestId("global-agent-provider-option-anthropic"),
-  ).toHaveCount(0);
+  ).toBeVisible();
   await expect(
     page.getByTestId("global-agent-provider-option-openai"),
-  ).toHaveCount(0);
+  ).toBeVisible();
   await expect(
     page.getByTestId("global-agent-provider-option-__custom_provider__"),
   ).toHaveCount(0);


### PR DESCRIPTION
## Summary

- restore credential-backed provider choices in Buzz onboarding
- keep the compact onboarding form while allowing users to choose providers before credentials are configured
- update the onboarding regression expectation for Anthropic and OpenAI

## Testing

- `cd desktop && pnpm check`
- `cd desktop && pnpm typecheck`
- `cd desktop && pnpm test` (3,158 passed)
- `cd desktop && pnpm build`
- `cd desktop && pnpm exec playwright test tests/e2e/onboarding-agent-defaults.spec.ts --project=smoke` (30 passed)
- pre-commit hooks
- pre-push hooks
