### PR TITLE
Route lag-tolerant reads to an optional Postgres read replica

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@
 # Database (Postgres 17)
 # -----------------------------------------------------------------------------
 DATABASE_URL=postgres://buzz:buzz_dev@localhost:5432/buzz
+# Optional read-replica URL; unset/blank keeps all reads on the writer.
+# READ_DATABASE_URL=postgres://buzz:buzz_dev@localhost:5433/buzz
 PGHOST=localhost
 PGPORT=5432
 PGUSER=buzz

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -41,6 +41,8 @@ pub mod push;
 pub mod reaction;
 /// Relay-level membership persistence (NIP-43).
 pub mod relay_members;
+/// Replica freshness fence for keyset-cursor read routing.
+pub mod replica_fence;
 /// Thread metadata persistence.
 pub mod thread;
 /// Per-community usage rollup queries for Prometheus gauges.
@@ -177,6 +179,12 @@ pub struct Db {
     /// route here (see [`Db::read`]); locks, transactions, and anything
     /// consistency-critical stays on `pool`.
     pub(crate) read_pool: Option<PgPool>,
+    /// Freshness fence gating cursor-page routing to the replica.
+    ///
+    /// Starts closed; a background probe ([`replica_fence::run_probe`])
+    /// advances it after each verified writer→replica LSN handshake. When
+    /// closed or stale, every cursor page routes to the writer.
+    pub(crate) fence: std::sync::Arc<replica_fence::ReplicaFence>,
 }
 
 /// Snapshot of Postgres connection pool utilisation.
@@ -344,29 +352,51 @@ impl Db {
     ///
     /// When `config.read_database_url` is set, a second pool with the same
     /// sizing is connected to it for lag-tolerant reads (see [`Db::read`]).
+    ///
+    /// The writer pool arms the commit-time `created_at` floor guard
+    /// (migration 0021) on every connection by setting the
+    /// `buzz.created_at_floor` GUC — this is what makes the replica fence
+    /// proof hold for every insert path that goes through this pool.
     pub async fn new(config: &DbConfig) -> Result<Self> {
-        let pool = Self::connect_pool(config, &config.database_url).await?;
+        let pool = Self::connect_pool(config, &config.database_url, true).await?;
         let read_pool = match &config.read_database_url {
-            Some(url) => Some(Self::connect_pool(config, url).await?),
+            Some(url) => Some(Self::connect_pool(config, url, false).await?),
             None => None,
         };
         Ok(Self {
             pool,
             max_connections: config.max_connections,
             read_pool,
+            fence: std::sync::Arc::new(replica_fence::ReplicaFence::new()),
         })
     }
 
     /// Connect one pool with the sizing knobs from `config`.
-    async fn connect_pool(config: &DbConfig, url: &str) -> Result<PgPool> {
-        Ok(PgPoolOptions::new()
+    ///
+    /// `arm_floor_guard` sets the `buzz.created_at_floor` session GUC on
+    /// every connection, arming the deferred commit-time trigger from
+    /// migration 0021. Writer pools must arm it; replica pools are read-only
+    /// so the trigger never fires there.
+    async fn connect_pool(config: &DbConfig, url: &str, arm_floor_guard: bool) -> Result<PgPool> {
+        let mut options = PgPoolOptions::new()
             .max_connections(config.max_connections)
             .min_connections(config.min_connections)
             .acquire_timeout(Duration::from_secs(config.acquire_timeout_secs))
             .max_lifetime(Duration::from_secs(config.max_lifetime_secs))
-            .idle_timeout(Duration::from_secs(config.idle_timeout_secs))
-            .connect(url)
-            .await?)
+            .idle_timeout(Duration::from_secs(config.idle_timeout_secs));
+        if arm_floor_guard {
+            options = options.after_connect(|conn, _meta| {
+                Box::pin(async move {
+                    // `SET` cannot take bind parameters; `set_config` can.
+                    sqlx::query("SELECT set_config('buzz.created_at_floor', $1, false)")
+                        .bind(replica_fence::CREATED_AT_FLOOR_SECS.to_string())
+                        .execute(conn)
+                        .await?;
+                    Ok(())
+                })
+            });
+        }
+        Ok(options.connect(url).await?)
     }
 
     /// Creates a `Db` from an existing `PgPool` (useful in tests).
@@ -375,16 +405,46 @@ impl Db {
             max_connections: pool.options().get_max_connections(),
             pool,
             read_pool: None,
+            fence: std::sync::Arc::new(replica_fence::ReplicaFence::new()),
         }
     }
 
     /// Creates a `Db` from distinct writer and read pools (useful in tests,
     /// where a second database stands in for a lagged replica).
+    ///
+    /// The fence starts closed; tests that want cursor pages served by the
+    /// fake replica must open it via
+    /// [`replica_fence::ReplicaFence::force_open_for_tests`] (see
+    /// [`Db::fence`]).
     pub fn from_pools(pool: PgPool, read_pool: PgPool) -> Self {
         Self {
             max_connections: pool.options().get_max_connections(),
             pool,
             read_pool: Some(read_pool),
+            fence: std::sync::Arc::new(replica_fence::ReplicaFence::new()),
+        }
+    }
+
+    /// The freshness fence gating replica routing (see [`replica_fence`]).
+    pub fn fence(&self) -> &std::sync::Arc<replica_fence::ReplicaFence> {
+        &self.fence
+    }
+
+    /// Spawn the background fence probe when a replica is configured.
+    ///
+    /// Without a running probe the fence stays closed and all cursor pages
+    /// route to the writer — safe, but no replica offload.
+    pub fn spawn_fence_probe(&self) -> bool {
+        match &self.read_pool {
+            Some(read_pool) => {
+                tokio::spawn(replica_fence::run_probe(
+                    self.pool.clone(),
+                    read_pool.clone(),
+                    std::sync::Arc::clone(&self.fence),
+                ));
+                true
+            }
+            None => false,
         }
     }
 
@@ -1893,12 +1953,18 @@ impl Db {
     /// Fetch replies under a root event.
     ///
     /// Routing: the head fetch (`cursor: None`) always reads the writer.
-    /// Cursor-bearing pages read the replica pool when one is configured —
-    /// thread pagination walks forward from oldest to newest, so every page
-    /// except possibly the last covers history a lagged replica already has.
-    /// An under-`limit` replica page is a candidate terminal page: the client
-    /// treats it as EOF, and a lagged replica could truncate the tail. That
-    /// one page is re-run on the writer so the EOF decision is authoritative.
+    /// Cursor-bearing pages may read the replica pool when one is configured
+    /// AND the freshness fence is open ([`replica_fence`]). Thread pagination
+    /// walks forward from oldest to newest, so a replica page is served only
+    /// when it is provably complete:
+    ///
+    /// - an under-`limit` page is a candidate terminal page — the client
+    ///   treats it as EOF, so it is re-run on the writer to keep the EOF
+    ///   decision authoritative (a lagged replica could truncate the tail);
+    /// - a full page whose newest row exceeds the fence could straddle a row
+    ///   the replica has not replayed (commit order is not `created_at`
+    ///   order), so it is also re-run on the writer. Only a full page that
+    ///   sits entirely at or below the fence is served from the replica.
     pub async fn get_thread_replies(
         &self,
         community_id: CommunityId,
@@ -1907,7 +1973,7 @@ impl Db {
         limit: u32,
         cursor: Option<&[u8]>,
     ) -> Result<Vec<thread::ThreadReply>> {
-        if cursor.is_some() && self.has_read_pool() {
+        if cursor.is_some() && self.has_read_pool() && self.fence.verified_through().is_some() {
             let replies = thread::get_thread_replies(
                 self.read(),
                 community_id,
@@ -1917,10 +1983,15 @@ impl Db {
                 cursor,
             )
             .await?;
-            if replies.len() >= limit as usize {
+            let full = replies.len() >= limit as usize;
+            let below_fence = replies
+                .last()
+                .is_some_and(|tail| self.fence.covers(tail.created_at));
+            if full && below_fence {
                 return Ok(replies);
             }
-            // Candidate terminal page — verify against the writer.
+            // Candidate terminal page, or page reaching above the fence —
+            // verify against the writer.
         }
         thread::get_thread_replies(
             &self.pool,
@@ -1945,11 +2016,14 @@ impl Db {
     /// One channel window: top-level rows + summaries + server `has_more`.
     ///
     /// Routing: the head fetch (`cursor: None`) always reads the writer — it
-    /// must include just-committed events. Cursor-bearing pages read the
-    /// replica pool when one is configured: channel scroll-back pages
-    /// *backward* into history strictly older than the cursor
-    /// (`created_at < ts`), which a replica within any sane lag bound already
-    /// has, and the live tail patches the head regardless of pool.
+    /// must include just-committed events. A cursor-bearing page scrolls
+    /// *backward* into history bounded above by the cursor timestamp
+    /// (`created_at < ts`, or `= ts` with the id tiebreak), so it may read
+    /// the replica when one is configured AND the freshness fence covers the
+    /// cursor timestamp: every row the page could contain is then provably
+    /// replayed on the replica ([`replica_fence`]). Pages whose cursor
+    /// reaches above the fence — the freshest sliver of history — stay on
+    /// the writer.
     pub async fn get_channel_window(
         &self,
         community_id: CommunityId,
@@ -1958,10 +2032,9 @@ impl Db {
         cursor: Option<(DateTime<Utc>, Vec<u8>)>,
         kind_filter: Option<&[u32]>,
     ) -> Result<thread::ChannelWindow> {
-        let pool = if cursor.is_some() {
-            self.read()
-        } else {
-            &self.pool
+        let pool = match &cursor {
+            Some((ts, _)) if self.has_read_pool() && self.fence.covers(*ts) => self.read(),
+            _ => &self.pool,
         };
         thread::get_channel_window(pool, community_id, channel_id, limit, cursor, kind_filter).await
     }
@@ -5297,6 +5370,10 @@ mod tests {
         insert_top_level(&replica, community, channel, &marker).await;
 
         let db = Db::from_pools(writer.clone(), replica.clone());
+        // Open the fence through "now": the fixture's history is far in the
+        // past, so every cursor falls below the fence and routing is
+        // eligible. Fence-gating itself is pinned by the fence tests below.
+        db.fence().force_open_for_tests(chrono::Utc::now());
         let cid = CommunityId::from_uuid(community);
 
         // Head fetch (cursor: None) → writer: sees `fresh`, never `marker`.
@@ -5377,6 +5454,8 @@ mod tests {
         }
 
         let db = Db::from_pools(writer.clone(), replica.clone());
+        // Open the fence through "now" — fixture history is far in the past.
+        db.fence().force_open_for_tests(chrono::Utc::now());
         let cid = CommunityId::from_uuid(community);
 
         // Page 1 (no cursor) → writer.
@@ -5443,5 +5522,373 @@ mod tests {
 
         drop_scratch_db(&admin, replica, &rname).await;
         drop_scratch_db(&admin, writer, &wname).await;
+    }
+
+    /// Channel DESC scrollback, out-of-order commit adversary: the replica is
+    /// missing a MIDDLE row (`m2`) because a transaction with an older
+    /// client-signed `created_at` committed late and has not replayed yet.
+    /// The replica's cursor page would be `[m1]` — silently skipping `m2`
+    /// forever, since the next cursor advances past it. The fence must route
+    /// any cursor above it to the writer.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn channel_cursor_above_fence_stays_on_writer_preventing_middle_hole() {
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let (writer, wname) = create_scratch_db(&admin, "fence_cw").await;
+        let (replica, rname) = create_scratch_db(&admin, "fence_cr").await;
+
+        let author = nostr::Keys::generate();
+        let community = Uuid::new_v4();
+        let channel = Uuid::new_v4();
+        seed_community_channel(&writer, community, channel, &author).await;
+        seed_community_channel(&replica, community, channel, &author).await;
+
+        let base = 1_700_000_000u64;
+        let m1 = signed_event_at(&author, "m1", base);
+        let m2 = signed_event_at(&author, "m2-late-commit", base + 10);
+        let m3 = signed_event_at(&author, "m3", base + 20);
+        let m4 = signed_event_at(&author, "m4", base + 30);
+        for ev in [&m1, &m2, &m3, &m4] {
+            insert_top_level(&writer, community, channel, ev).await;
+        }
+        // Replica replayed everything EXCEPT the late-committed m2.
+        for ev in [&m1, &m3, &m4] {
+            insert_top_level(&replica, community, channel, ev).await;
+        }
+
+        let db = Db::from_pools(writer.clone(), replica.clone());
+        let cid = CommunityId::from_uuid(community);
+
+        // Head page (writer): [m4, m3]; cursor lands on m3 (base+20).
+        let head = db
+            .get_channel_window(cid, channel, 2, None, None)
+            .await
+            .expect("head window");
+        let cursor = head.next_cursor.expect("has_more implies next_cursor");
+
+        // Fence closed → cursor page must come from the writer: m2 present.
+        let contents = |w: &thread::ChannelWindow| -> Vec<String> {
+            w.rows
+                .iter()
+                .map(|r| r.stored_event.event.content.clone())
+                .collect()
+        };
+        let page_closed = db
+            .get_channel_window(cid, channel, 10, Some(cursor.clone()), None)
+            .await
+            .expect("cursor page, fence closed");
+        assert_eq!(
+            contents(&page_closed),
+            vec!["m2-late-commit".to_string(), "m1".to_string()],
+            "fence closed: cursor pages route to the writer"
+        );
+
+        // Fence open but BELOW the cursor timestamp (covers base+5 only):
+        // the cursor (base+20) is not covered → writer again.
+        db.fence().force_open_for_tests(
+            chrono::DateTime::from_timestamp(base as i64 + 5, 0).expect("ts"),
+        );
+        let page_below = db
+            .get_channel_window(cid, channel, 10, Some(cursor.clone()), None)
+            .await
+            .expect("cursor page, fence below cursor");
+        assert_eq!(
+            contents(&page_below),
+            vec!["m2-late-commit".to_string(), "m1".to_string()],
+            "cursor above the fence must stay on the writer"
+        );
+
+        // Counterfactual pinning the hazard: were the fence (wrongly) open
+        // through now, the replica would serve the page WITHOUT m2 — the
+        // permanent-skip hole this fence exists to prevent.
+        db.fence().force_open_for_tests(chrono::Utc::now());
+        let page_hazard = db
+            .get_channel_window(cid, channel, 10, Some(cursor), None)
+            .await
+            .expect("cursor page, fence wrongly open");
+        assert_eq!(
+            contents(&page_hazard),
+            vec!["m1".to_string()],
+            "fixture models the inversion: an over-open fence would skip m2"
+        );
+
+        drop_scratch_db(&admin, replica, &rname).await;
+        drop_scratch_db(&admin, writer, &wname).await;
+    }
+
+    /// Thread ASC pagination, out-of-order commit adversary: the replica
+    /// holds a FULL page whose newest row (`r4`) has a later key than a
+    /// not-yet-replayed row (`r3`). The old under-limit check alone would
+    /// serve `[r4]` and the client cursor would advance past `r3` forever.
+    /// The fence rule (full AND tail ≤ fence) must send that page to the
+    /// writer instead.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn thread_full_replica_page_above_fence_is_reverified_on_writer() {
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let (writer, wname) = create_scratch_db(&admin, "fence_tw").await;
+        let (replica, rname) = create_scratch_db(&admin, "fence_tr").await;
+
+        let author = nostr::Keys::generate();
+        let community = Uuid::new_v4();
+        let channel = Uuid::new_v4();
+        seed_community_channel(&writer, community, channel, &author).await;
+        seed_community_channel(&replica, community, channel, &author).await;
+
+        let base = 1_700_000_000u64;
+        let root = signed_event_at(&author, "root", base);
+        for pool in [&writer, &replica] {
+            insert_top_level(pool, community, channel, &root).await;
+        }
+        let replies: Vec<nostr::Event> = (1..=4)
+            .map(|i| signed_event_at(&author, &format!("r{i}"), base + 10 * i as u64))
+            .collect();
+        for reply in &replies {
+            insert_thread_reply(&writer, community, channel, &root, reply).await;
+        }
+        // Replica replayed r1, r2, r4 — the late-committed r3 is missing.
+        for reply in [&replies[0], &replies[1], &replies[3]] {
+            insert_thread_reply(&replica, community, channel, &root, reply).await;
+        }
+
+        let db = Db::from_pools(writer.clone(), replica.clone());
+        let cid = CommunityId::from_uuid(community);
+
+        // Fence covers r2 (base+20) but not r3/r4.
+        db.fence().force_open_for_tests(
+            chrono::DateTime::from_timestamp(base as i64 + 20, 0).expect("ts"),
+        );
+
+        // Page after r2 with limit 1: the replica would return the FULL page
+        // [r4] — but its tail is above the fence, so the writer re-runs it
+        // and returns [r3]. No skip.
+        let page1 = db
+            .get_thread_replies(cid, root.id.as_bytes(), Some(10), 2, None)
+            .await
+            .expect("head page");
+        let cur = thread_cursor(page1.last().expect("head page non-empty"));
+        let page = db
+            .get_thread_replies(cid, root.id.as_bytes(), Some(10), 1, Some(&cur))
+            .await
+            .expect("cursor page");
+        let contents: Vec<&str> = page
+            .iter()
+            .map(|r| r.stored_event.event.content.as_str())
+            .collect();
+        assert_eq!(
+            contents,
+            vec!["r3"],
+            "a full replica page above the fence must be re-run on the writer"
+        );
+
+        // Counterfactual: an over-open fence would serve the replica's [r4],
+        // skipping r3 permanently.
+        db.fence().force_open_for_tests(chrono::Utc::now());
+        let hazard = db
+            .get_thread_replies(cid, root.id.as_bytes(), Some(10), 1, Some(&cur))
+            .await
+            .expect("hazard page");
+        let contents: Vec<&str> = hazard
+            .iter()
+            .map(|r| r.stored_event.event.content.as_str())
+            .collect();
+        assert_eq!(
+            contents,
+            vec!["r4"],
+            "fixture models the inversion: an over-open fence would skip r3"
+        );
+
+        drop_scratch_db(&admin, replica, &rname).await;
+        drop_scratch_db(&admin, writer, &wname).await;
+    }
+
+    /// Commit-time floor guard (migration 0021), exact held-transaction
+    /// adversary: a channel-bearing row whose `created_at` is older than the
+    /// floor at COMMIT time must abort the transaction — the guard runs
+    /// inside commit processing with `clock_timestamp()`, so holding the
+    /// transaction open cannot outrun it. channel_id-NULL rows are
+    /// structurally exempt, and sessions without the GUC are unaffected.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn created_at_floor_guard_aborts_old_channel_rows_at_commit() {
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let (pool, name) = create_scratch_db(&admin, "floor_guard").await;
+
+        let author = nostr::Keys::generate();
+        let community = Uuid::new_v4();
+        let channel = Uuid::new_v4();
+        seed_community_channel(&pool, community, channel, &author).await;
+
+        let insert_raw = |ev: nostr::Event, channel_id: Option<Uuid>| {
+            let pool = pool.clone();
+            async move {
+                let mut tx = pool.begin().await.expect("begin");
+                // Arm the guard for this transaction only (the relay's
+                // writer pool arms it per connection; tests are explicit).
+                sqlx::query("SELECT set_config('buzz.created_at_floor', $1, true)")
+                    .bind(crate::replica_fence::CREATED_AT_FLOOR_SECS.to_string())
+                    .execute(&mut *tx)
+                    .await
+                    .expect("arm guard");
+                sqlx::query(
+                    "INSERT INTO events (community_id, id, pubkey, created_at, kind, tags, \
+                     content, sig, received_at, channel_id) \
+                     VALUES ($1, $2, $3, to_timestamp($4), 9, '[]', $5, $6, NOW(), $7)",
+                )
+                .bind(community)
+                .bind(ev.id.as_bytes().as_slice())
+                .bind(ev.pubkey.to_bytes().as_slice())
+                .bind(ev.created_at.as_secs() as f64)
+                .bind(&ev.content)
+                .bind(ev.sig.serialize().as_slice())
+                .bind(channel_id)
+                .execute(&mut *tx)
+                .await
+                .expect("insert inside tx (guard is deferred to commit)");
+                // Hold the transaction "open" past the insert, then commit —
+                // the deferred guard must still see the stale created_at.
+                sqlx::query("SELECT pg_sleep(0.05)")
+                    .execute(&mut *tx)
+                    .await
+                    .expect("hold tx");
+                tx.commit().await
+            }
+        };
+
+        let now_secs = chrono::Utc::now().timestamp() as u64;
+        let floor = crate::replica_fence::CREATED_AT_FLOOR_SECS as u64;
+
+        // Old channel-bearing row → COMMIT aborts with check_violation.
+        let old = signed_event_at(&author, "old-held-tx", now_secs - floor - 60);
+        let err = insert_raw(old, Some(channel))
+            .await
+            .expect_err("below-floor channel row must abort at COMMIT");
+        let code = match &err {
+            sqlx::Error::Database(db_err) => db_err.code().map(|c| c.to_string()),
+            other => panic!("expected database error, got {other:?}"),
+        };
+        assert_eq!(
+            code.as_deref(),
+            Some("23514"),
+            "guard raises check_violation"
+        );
+
+        // Fresh channel-bearing row → commits.
+        let fresh = signed_event_at(&author, "fresh", now_secs);
+        insert_raw(fresh, Some(channel))
+            .await
+            .expect("fresh row commits under the armed guard");
+
+        // Old row WITHOUT a channel (push lease / profile shapes) →
+        // structurally exempt, commits.
+        let old_global = signed_event_at(&author, "old-global", now_secs - floor - 60);
+        insert_raw(old_global, None)
+            .await
+            .expect("channel_id-NULL rows are exempt from the floor");
+
+        // Unarmed session (no GUC) → guard inert; backfills stay possible
+        // (and must hold the fence closed, per the migration header).
+        let old_backfill = signed_event_at(&author, "old-backfill", now_secs - floor - 60);
+        insert_top_level(&pool, community, channel, &old_backfill).await;
+
+        drop_scratch_db(&admin, pool, &name).await;
+    }
+
+    /// The armed writer pool (`Db::new`) must enforce the floor end-to-end
+    /// through the public insert APIs, and the session GUC must be verifiably
+    /// set on pooled connections.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn armed_pool_rejects_old_channel_inserts_through_public_api() {
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let (seed_pool, name) = create_scratch_db(&admin, "floor_pool").await;
+
+        let author = nostr::Keys::generate();
+        let community = Uuid::new_v4();
+        let channel = Uuid::new_v4();
+        seed_community_channel(&seed_pool, community, channel, &author).await;
+
+        // Connect a Db the production way: after_connect arms the guard.
+        let base = admin_url().await;
+        let idx = base.rfind('/').expect("db url has a path segment");
+        let scratch_url = format!("{}/{}", &base[..idx], name);
+        let db = Db::new(&DbConfig {
+            database_url: scratch_url,
+            max_connections: 2,
+            ..DbConfig::default()
+        })
+        .await
+        .expect("connect armed Db");
+        let cid = CommunityId::from_uuid(community);
+
+        // Perci nit: assert the effective session value, not the intent.
+        let effective: String = sqlx::query_scalar("SHOW buzz.created_at_floor")
+            .fetch_one(&db.pool)
+            .await
+            .expect("SHOW guard GUC");
+        assert_eq!(
+            effective,
+            crate::replica_fence::CREATED_AT_FLOOR_SECS.to_string(),
+            "writer pool must arm the floor guard on every connection"
+        );
+
+        let now_secs = chrono::Utc::now().timestamp() as u64;
+        let floor = crate::replica_fence::CREATED_AT_FLOOR_SECS as u64;
+
+        // insert_event (single INSERT, autocommit): old channel row rejected.
+        let old = signed_event_at(&author, "old-direct", now_secs - floor - 60);
+        let err = event::insert_event(&db.pool, cid, &old, Some(channel))
+            .await
+            .expect_err("armed pool must reject below-floor channel inserts");
+        assert!(
+            err.to_string().contains("below the replica-fence floor"),
+            "unexpected error: {err}"
+        );
+
+        // insert_event_with_thread_metadata (multi-statement tx): same.
+        let old2 = signed_event_at(&author, "old-thread-meta", now_secs - floor - 90);
+        let ts = chrono::DateTime::from_timestamp(old2.created_at.as_secs() as i64, 0)
+            .expect("valid ts");
+        let err = event::insert_event_with_thread_metadata(
+            &db.pool,
+            cid,
+            &old2,
+            Some(channel),
+            Some(event::ThreadMetadataParams {
+                event_id: old2.id.as_bytes(),
+                event_created_at: ts,
+                channel_id: channel,
+                parent_event_id: None,
+                parent_event_created_at: None,
+                root_event_id: None,
+                root_event_created_at: None,
+                depth: 0,
+                broadcast: true,
+            }),
+        )
+        .await
+        .expect_err("armed pool must reject below-floor thread-metadata inserts");
+        assert!(
+            err.to_string().contains("below the replica-fence floor"),
+            "unexpected error: {err}"
+        );
+
+        // Fresh events pass through both APIs.
+        let fresh = signed_event_at(&author, "fresh-direct", now_secs);
+        event::insert_event(&db.pool, cid, &fresh, Some(channel))
+            .await
+            .expect("fresh insert passes the armed guard");
+
+        drop_scratch_db(&admin, seed_pool, &name).await;
+        // db pool still holds connections to the dropped DB; close it.
+        db.pool.close().await;
     }
 }

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -430,22 +430,34 @@ impl Db {
         &self.fence
     }
 
-    /// Spawn the background fence probe when a replica is configured.
+    /// Verify the floor guard end-to-end, then spawn the background fence
+    /// probe. Returns `Ok(false)` when no replica is configured.
     ///
-    /// Without a running probe the fence stays closed and all cursor pages
-    /// route to the writer — safe, but no replica offload.
-    pub fn spawn_fence_probe(&self) -> bool {
-        match &self.read_pool {
-            Some(read_pool) => {
-                tokio::spawn(replica_fence::run_probe(
-                    self.pool.clone(),
-                    read_pool.clone(),
-                    std::sync::Arc::clone(&self.fence),
-                ));
-                true
-            }
-            None => false,
-        }
+    /// Ordering matters (Perci, PR #2084 review): this must run **after**
+    /// the migration decision. On a relay with `BUZZ_AUTO_MIGRATE` off, the
+    /// writer pool arms the GUC regardless, but if migration 0021 has not
+    /// been applied there is no trigger enforcing it — and an LSN probe
+    /// would open the fence over an unenforced floor. So the probe is gated
+    /// on an unconditional two-part verification against the live schema:
+    /// catalog shape ([`replica_fence::verify_floor_guard_catalog`]) and
+    /// observed semantics through this exact pool
+    /// ([`replica_fence::verify_floor_guard_behavior`]).
+    ///
+    /// On any verification failure the probe is never spawned and the fence
+    /// stays closed: every cursor page routes to the writer. The relay keeps
+    /// serving — degraded capacity, never holes.
+    pub async fn spawn_fence_probe(&self) -> Result<bool> {
+        let Some(read_pool) = &self.read_pool else {
+            return Ok(false);
+        };
+        replica_fence::verify_floor_guard_catalog(&self.pool).await?;
+        replica_fence::verify_floor_guard_behavior(&self.pool).await?;
+        tokio::spawn(replica_fence::run_probe(
+            self.pool.clone(),
+            read_pool.clone(),
+            std::sync::Arc::clone(&self.fence),
+        ));
+        Ok(true)
     }
 
     /// The pool for lag-tolerant reads: the read replica when configured,
@@ -5890,5 +5902,178 @@ mod tests {
         drop_scratch_db(&admin, seed_pool, &name).await;
         // db pool still holds connections to the dropped DB; close it.
         db.pool.close().await;
+    }
+
+    /// `spawn_fence_probe` must verify the floor guard before letting the
+    /// probe run — catalog shape AND observed behavior — and refuse on
+    /// sabotage. This is the production gate for a relay running with
+    /// `BUZZ_AUTO_MIGRATE` off: an armed GUC with no enforcing trigger must
+    /// never yield an open fence.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn fence_probe_refuses_to_start_without_verified_floor_guard() {
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let (seed_pool, wname) = create_scratch_db(&admin, "fence_gate_w").await;
+        let (replica_pool, rname) = create_scratch_db(&admin, "fence_gate_r").await;
+        seed_pool.close().await;
+        replica_pool.close().await;
+
+        let base = admin_url().await;
+        let idx = base.rfind('/').expect("db url has a path segment");
+        let db = Db::new(&DbConfig {
+            database_url: format!("{}/{}", &base[..idx], wname),
+            read_database_url: Some(format!("{}/{}", &base[..idx], rname)),
+            max_connections: 2,
+            ..DbConfig::default()
+        })
+        .await
+        .expect("connect armed Db with replica");
+
+        // Healthy schema: verification passes, probe starts.
+        assert!(
+            db.spawn_fence_probe().await.expect("verification passes"),
+            "probe must start on a verified schema"
+        );
+
+        // Sabotage A: catalog-shaped no-op — same trigger, gutted function
+        // body. Catalog check alone would pass; behavior check must refuse.
+        sqlx::query(
+            "CREATE OR REPLACE FUNCTION events_created_at_floor_guard() RETURNS trigger \
+             LANGUAGE plpgsql AS $$ BEGIN RETURN NULL; END $$",
+        )
+        .execute(&db.pool)
+        .await
+        .expect("gut the guard function");
+        let err = db
+            .spawn_fence_probe()
+            .await
+            .expect_err("inert guard body must refuse the probe");
+        assert!(
+            err.to_string().contains("floor guard is inert"),
+            "unexpected error: {err}"
+        );
+
+        // Sabotage B: trigger dropped entirely (the BUZZ_AUTO_MIGRATE=off /
+        // 0021-unapplied shape). Catalog check must refuse.
+        sqlx::query("DROP TRIGGER events_created_at_floor ON events")
+            .execute(&db.pool)
+            .await
+            .expect("drop the guard trigger");
+        let err = db
+            .spawn_fence_probe()
+            .await
+            .expect_err("missing trigger must refuse the probe");
+        assert!(
+            err.to_string().contains("missing or mis-shaped"),
+            "unexpected error: {err}"
+        );
+
+        // In both refusal states the fence never opened.
+        assert!(
+            db.fence().verified_through().is_none(),
+            "fence must remain closed when verification refuses the probe"
+        );
+
+        db.pool.close().await;
+        if let Some(rp) = &db.read_pool {
+            rp.close().await;
+        }
+        let _ = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE IF EXISTS {wname} WITH (FORCE)"
+        )))
+        .execute(&admin)
+        .await;
+        let _ = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE IF EXISTS {rname} WITH (FORCE)"
+        )))
+        .execute(&admin)
+        .await;
+    }
+
+    /// The `UPDATE OF` arm of the floor guard (Perci's second structural
+    /// hole): an old row legitimately admitted with `channel_id` NULL must
+    /// not be movable into keyset windows, and a channel row's `created_at`
+    /// must not be movable below the fence — through raw SQL, at COMMIT.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn floor_guard_blocks_updates_that_move_rows_below_the_fence() {
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let (pool, name) = create_scratch_db(&admin, "floor_upd").await;
+
+        let author = nostr::Keys::generate();
+        let community = Uuid::new_v4();
+        let channel = Uuid::new_v4();
+        seed_community_channel(&pool, community, channel, &author).await;
+
+        let now_secs = chrono::Utc::now().timestamp() as u64;
+        let floor = crate::replica_fence::CREATED_AT_FLOOR_SECS as u64;
+
+        // Seed via unarmed session: one old channel-NULL row, one fresh
+        // channel row.
+        let old_null = signed_event_at(&author, "old-null", now_secs - floor - 120);
+        insert_top_level(&pool, community, channel, &old_null).await;
+        sqlx::query("UPDATE events SET channel_id = NULL WHERE community_id = $1 AND id = $2")
+            .bind(community)
+            .bind(old_null.id.as_bytes().as_slice())
+            .execute(&pool)
+            .await
+            .expect("detach channel (unarmed seed)");
+        let fresh = signed_event_at(&author, "fresh-row", now_secs);
+        insert_top_level(&pool, community, channel, &fresh).await;
+
+        // Armed transaction, deferred to COMMIT (the production shape).
+        let run_armed_update = |sql: &'static str, id: Vec<u8>, age: Option<u64>| {
+            let pool = pool.clone();
+            async move {
+                let mut tx = pool.begin().await.expect("begin");
+                sqlx::query("SELECT set_config('buzz.created_at_floor', $1, true)")
+                    .bind(crate::replica_fence::CREATED_AT_FLOOR_SECS.to_string())
+                    .execute(&mut *tx)
+                    .await
+                    .expect("arm guard");
+                let q = sqlx::query(sql).bind(community).bind(id);
+                let q = match age {
+                    Some(a) => q.bind(a as f64),
+                    None => q,
+                };
+                q.execute(&mut *tx)
+                    .await
+                    .expect("update inside tx (deferred)");
+                tx.commit().await
+            }
+        };
+
+        // channel-NULL → channel-bearing on an old row: COMMIT must abort.
+        let err = run_armed_update(
+            "UPDATE events SET channel_id = community_id WHERE community_id = $1 AND id = $2",
+            old_null.id.as_bytes().to_vec(),
+            None,
+        )
+        .await
+        .expect_err("moving an old channel-NULL row into a channel must abort at COMMIT");
+        assert!(
+            matches!(&err, sqlx::Error::Database(e) if e.code().as_deref() == Some("23514")),
+            "unexpected error: {err}"
+        );
+
+        // created_at rewrite below the floor on a channel row: COMMIT must abort.
+        let err = run_armed_update(
+            "UPDATE events SET created_at = clock_timestamp() - make_interval(secs => $3::double precision) \
+             WHERE community_id = $1 AND id = $2",
+            fresh.id.as_bytes().to_vec(),
+            Some(floor + 120),
+        )
+        .await
+        .expect_err("rewriting created_at below the floor must abort at COMMIT");
+        assert!(
+            matches!(&err, sqlx::Error::Database(e) if e.code().as_deref() == Some("23514")),
+            "unexpected error: {err}"
+        );
+
+        drop_scratch_db(&admin, pool, &name).await;
     }
 }

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -170,6 +170,13 @@ pub struct Db {
     pub(crate) pool: PgPool,
     /// Maximum connections configured for this pool (from [`DbConfig::max_connections`]).
     pub(crate) max_connections: u32,
+    /// Optional read-replica pool (from [`DbConfig::read_database_url`]).
+    ///
+    /// `None` means no replica is configured and every read routes to the
+    /// writer pool — the pre-replica behavior. Only lag-tolerant reads may
+    /// route here (see [`Db::read`]); locks, transactions, and anything
+    /// consistency-critical stays on `pool`.
+    pub(crate) read_pool: Option<PgPool>,
 }
 
 /// Snapshot of Postgres connection pool utilisation.
@@ -209,6 +216,10 @@ impl UsageMetricsLeader {
 pub struct DbConfig {
     /// Postgres connection URL (usually sourced from `DATABASE_URL`).
     pub database_url: String,
+    /// Optional read-replica connection URL (usually sourced from
+    /// `READ_DATABASE_URL`, e.g. an Aurora `cluster-ro-` endpoint). `None`
+    /// disables replica routing: [`Db::read`] falls back to the writer pool.
+    pub read_database_url: Option<String>,
     /// Maximum number of connections in the pool.
     pub max_connections: u32,
     /// Minimum number of idle connections to maintain.
@@ -228,6 +239,7 @@ impl Default for DbConfig {
     fn default() -> Self {
         Self {
             database_url: "postgres://buzz:buzz_dev@localhost:5432/buzz".to_string(), // sadscan:disable np.postgres.1
+            read_database_url: None,
             max_connections: 20,
             min_connections: 2,
             acquire_timeout_secs: 3,
@@ -329,19 +341,32 @@ pub struct TokenSummary {
 
 impl Db {
     /// Creates a new `Db` by connecting a Postgres pool with the given config.
+    ///
+    /// When `config.read_database_url` is set, a second pool with the same
+    /// sizing is connected to it for lag-tolerant reads (see [`Db::read`]).
     pub async fn new(config: &DbConfig) -> Result<Self> {
-        let pool = PgPoolOptions::new()
+        let pool = Self::connect_pool(config, &config.database_url).await?;
+        let read_pool = match &config.read_database_url {
+            Some(url) => Some(Self::connect_pool(config, url).await?),
+            None => None,
+        };
+        Ok(Self {
+            pool,
+            max_connections: config.max_connections,
+            read_pool,
+        })
+    }
+
+    /// Connect one pool with the sizing knobs from `config`.
+    async fn connect_pool(config: &DbConfig, url: &str) -> Result<PgPool> {
+        Ok(PgPoolOptions::new()
             .max_connections(config.max_connections)
             .min_connections(config.min_connections)
             .acquire_timeout(Duration::from_secs(config.acquire_timeout_secs))
             .max_lifetime(Duration::from_secs(config.max_lifetime_secs))
             .idle_timeout(Duration::from_secs(config.idle_timeout_secs))
-            .connect(&config.database_url)
-            .await?;
-        Ok(Self {
-            pool,
-            max_connections: config.max_connections,
-        })
+            .connect(url)
+            .await?)
     }
 
     /// Creates a `Db` from an existing `PgPool` (useful in tests).
@@ -349,7 +374,34 @@ impl Db {
         Self {
             max_connections: pool.options().get_max_connections(),
             pool,
+            read_pool: None,
         }
+    }
+
+    /// Creates a `Db` from distinct writer and read pools (useful in tests,
+    /// where a second database stands in for a lagged replica).
+    pub fn from_pools(pool: PgPool, read_pool: PgPool) -> Self {
+        Self {
+            max_connections: pool.options().get_max_connections(),
+            pool,
+            read_pool: Some(read_pool),
+        }
+    }
+
+    /// The pool for lag-tolerant reads: the read replica when configured,
+    /// otherwise the writer pool.
+    ///
+    /// Routing contract — a query may use this pool only when a stale (bounded
+    /// replication lag) result is acceptable to its caller. Keyset-cursor
+    /// pagination over immutable history qualifies; head-of-channel fetches,
+    /// auth/membership checks, locks, and anything inside a transaction do not.
+    pub fn read(&self) -> &PgPool {
+        self.read_pool.as_ref().unwrap_or(&self.pool)
+    }
+
+    /// Whether a distinct read-replica pool is configured.
+    pub fn has_read_pool(&self) -> bool {
+        self.read_pool.is_some()
     }
 
     /// Run pending database migrations.
@@ -373,6 +425,15 @@ impl Db {
             idle: self.pool.num_idle() as u32,
             max: self.max_connections,
         }
+    }
+
+    /// Pool utilisation stats for the read-replica pool, when configured.
+    pub fn read_pool_stats(&self) -> Option<DbPoolStats> {
+        self.read_pool.as_ref().map(|p| DbPoolStats {
+            size: p.size(),
+            idle: p.num_idle() as u32,
+            max: self.max_connections,
+        })
     }
 
     /// Try to acquire the detached session advisory lock for relay usage metrics.
@@ -1830,6 +1891,14 @@ impl Db {
     }
 
     /// Fetch replies under a root event.
+    ///
+    /// Routing: the head fetch (`cursor: None`) always reads the writer.
+    /// Cursor-bearing pages read the replica pool when one is configured —
+    /// thread pagination walks forward from oldest to newest, so every page
+    /// except possibly the last covers history a lagged replica already has.
+    /// An under-`limit` replica page is a candidate terminal page: the client
+    /// treats it as EOF, and a lagged replica could truncate the tail. That
+    /// one page is re-run on the writer so the EOF decision is authoritative.
     pub async fn get_thread_replies(
         &self,
         community_id: CommunityId,
@@ -1838,6 +1907,21 @@ impl Db {
         limit: u32,
         cursor: Option<&[u8]>,
     ) -> Result<Vec<thread::ThreadReply>> {
+        if cursor.is_some() && self.has_read_pool() {
+            let replies = thread::get_thread_replies(
+                self.read(),
+                community_id,
+                root_event_id,
+                depth_limit,
+                limit,
+                cursor,
+            )
+            .await?;
+            if replies.len() >= limit as usize {
+                return Ok(replies);
+            }
+            // Candidate terminal page — verify against the writer.
+        }
         thread::get_thread_replies(
             &self.pool,
             community_id,
@@ -1859,6 +1943,13 @@ impl Db {
     }
 
     /// One channel window: top-level rows + summaries + server `has_more`.
+    ///
+    /// Routing: the head fetch (`cursor: None`) always reads the writer — it
+    /// must include just-committed events. Cursor-bearing pages read the
+    /// replica pool when one is configured: channel scroll-back pages
+    /// *backward* into history strictly older than the cursor
+    /// (`created_at < ts`), which a replica within any sane lag bound already
+    /// has, and the live tail patches the head regardless of pool.
     pub async fn get_channel_window(
         &self,
         community_id: CommunityId,
@@ -1867,15 +1958,12 @@ impl Db {
         cursor: Option<(DateTime<Utc>, Vec<u8>)>,
         kind_filter: Option<&[u32]>,
     ) -> Result<thread::ChannelWindow> {
-        thread::get_channel_window(
-            &self.pool,
-            community_id,
-            channel_id,
-            limit,
-            cursor,
-            kind_filter,
-        )
-        .await
+        let pool = if cursor.is_some() {
+            self.read()
+        } else {
+            &self.pool
+        };
+        thread::get_channel_window(pool, community_id, channel_id, limit, cursor, kind_filter).await
     }
 
     /// Look up a single thread_metadata row by event_id.
@@ -5015,5 +5103,345 @@ mod tests {
             groups_a_after.is_empty(),
             "A's reaction must be gone after A removes it"
         );
+    }
+
+    // ---- Read-replica routing ------------------------------------------------
+    //
+    // These tests pin the routing contract of `Db::read()` and the two routed
+    // methods. A second scratch database stands in for the replica; the
+    // fixtures are deliberately DIVERGENT (rows that exist in only one of the
+    // two databases) so every assertion observes which pool actually served
+    // the query instead of trusting the routing code's word for it.
+
+    async fn admin_url() -> String {
+        std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| TEST_DB_URL.into())
+    }
+
+    /// Create a fresh scratch database on the same server and run migrations.
+    /// Returns (pool, db_name); callers should `drop_scratch_db` when done.
+    async fn create_scratch_db(admin: &PgPool, prefix: &str) -> (PgPool, String) {
+        let name = format!("{}_{}", prefix, Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!("CREATE DATABASE {name}")))
+            .execute(admin)
+            .await
+            .expect("create scratch db");
+        let base = admin_url().await;
+        // Swap the database path segment of the admin URL for the scratch name.
+        let scratch_url = {
+            let idx = base.rfind('/').expect("db url has a path segment");
+            format!("{}/{}", &base[..idx], name)
+        };
+        let pool = PgPool::connect(&scratch_url)
+            .await
+            .expect("connect scratch db");
+        migration::run_migrations(&pool)
+            .await
+            .expect("migrate scratch db");
+        (pool, name)
+    }
+
+    async fn drop_scratch_db(admin: &PgPool, pool: PgPool, name: &str) {
+        pool.close().await;
+        let _ = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE IF EXISTS {name} WITH (FORCE)"
+        )))
+        .execute(admin)
+        .await;
+    }
+
+    /// Insert identical community + channel rows into a database so the same
+    /// (community, channel) ids resolve in both writer and replica.
+    async fn seed_community_channel(
+        pool: &PgPool,
+        community: Uuid,
+        channel: Uuid,
+        author: &nostr::Keys,
+    ) {
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community)
+            .bind(format!("replica-routing-{}.example", community.simple()))
+            .execute(pool)
+            .await
+            .expect("insert community");
+        crate::channel::create_channel_with_id(
+            pool,
+            CommunityId::from_uuid(community),
+            channel,
+            &format!("replica-routing-{channel}"),
+            crate::channel::ChannelType::Stream,
+            crate::channel::ChannelVisibility::Open,
+            None,
+            author.public_key().to_bytes().as_slice(),
+            None,
+        )
+        .await
+        .expect("create channel");
+    }
+
+    fn signed_event_at(keys: &nostr::Keys, content: &str, secs: u64) -> nostr::Event {
+        nostr::EventBuilder::new(nostr::Kind::Custom(9), content)
+            .custom_created_at(nostr::Timestamp::from(secs))
+            .sign_with_keys(keys)
+            .expect("sign event")
+    }
+
+    async fn insert_top_level(pool: &PgPool, community: Uuid, channel: Uuid, ev: &nostr::Event) {
+        let ts =
+            chrono::DateTime::from_timestamp(ev.created_at.as_secs() as i64, 0).expect("valid ts");
+        event::insert_event_with_thread_metadata(
+            pool,
+            CommunityId::from_uuid(community),
+            ev,
+            Some(channel),
+            Some(event::ThreadMetadataParams {
+                event_id: ev.id.as_bytes(),
+                event_created_at: ts,
+                channel_id: channel,
+                parent_event_id: None,
+                parent_event_created_at: None,
+                root_event_id: None,
+                root_event_created_at: None,
+                depth: 0,
+                broadcast: true,
+            }),
+        )
+        .await
+        .expect("insert top-level event");
+    }
+
+    async fn insert_thread_reply(
+        pool: &PgPool,
+        community: Uuid,
+        channel: Uuid,
+        root: &nostr::Event,
+        reply: &nostr::Event,
+    ) {
+        let reply_ts = chrono::DateTime::from_timestamp(reply.created_at.as_secs() as i64, 0)
+            .expect("valid ts");
+        let root_ts = chrono::DateTime::from_timestamp(root.created_at.as_secs() as i64, 0)
+            .expect("valid ts");
+        event::insert_event_with_thread_metadata(
+            pool,
+            CommunityId::from_uuid(community),
+            reply,
+            Some(channel),
+            Some(event::ThreadMetadataParams {
+                event_id: reply.id.as_bytes(),
+                event_created_at: reply_ts,
+                channel_id: channel,
+                parent_event_id: Some(root.id.as_bytes()),
+                parent_event_created_at: Some(root_ts),
+                root_event_id: Some(root.id.as_bytes()),
+                root_event_created_at: Some(root_ts),
+                depth: 1,
+                broadcast: false,
+            }),
+        )
+        .await
+        .expect("insert reply");
+    }
+
+    /// Composite thread cursor: 8-byte BE seconds + raw event id.
+    fn thread_cursor(reply: &crate::thread::ThreadReply) -> Vec<u8> {
+        let mut cur = reply.created_at.timestamp().to_be_bytes().to_vec();
+        cur.extend_from_slice(&reply.event_id);
+        cur
+    }
+
+    #[tokio::test]
+    async fn read_falls_back_to_writer_when_no_replica_configured() {
+        // Pure wiring test — connect_lazy never touches the network.
+        let pool = sqlx::PgPool::connect_lazy(TEST_DB_URL).expect("lazy pool");
+        let db = Db::from_pool(pool);
+        assert!(!db.has_read_pool());
+        assert!(
+            std::ptr::eq(db.read(), &db.pool),
+            "read() must be the writer pool when no replica is configured"
+        );
+        assert!(db.read_pool_stats().is_none());
+    }
+
+    /// Channel window: head fetch (no cursor) reads the WRITER; cursor pages
+    /// read the REPLICA. Divergent fixtures prove which pool served each.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn channel_window_routes_head_to_writer_and_cursor_pages_to_replica() {
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let (writer, wname) = create_scratch_db(&admin, "routing_w").await;
+        let (replica, rname) = create_scratch_db(&admin, "routing_r").await;
+
+        let author = nostr::Keys::generate();
+        let community = Uuid::new_v4();
+        let channel = Uuid::new_v4();
+        seed_community_channel(&writer, community, channel, &author).await;
+        seed_community_channel(&replica, community, channel, &author).await;
+
+        // Shared history (both databases): m1 < m2 < m3.
+        let base = 1_700_000_000u64;
+        let m1 = signed_event_at(&author, "m1", base);
+        let m2 = signed_event_at(&author, "m2", base + 10);
+        let m3 = signed_event_at(&author, "m3", base + 20);
+        for pool in [&writer, &replica] {
+            for ev in [&m1, &m2, &m3] {
+                insert_top_level(pool, community, channel, ev).await;
+            }
+        }
+        // Lag: the newest event exists only on the writer.
+        let fresh = signed_event_at(&author, "fresh-writer-only", base + 30);
+        insert_top_level(&writer, community, channel, &fresh).await;
+        // Marker: exists only on the "replica" (unphysical for a real replica,
+        // but it makes replica-served pages unambiguous).
+        let marker = signed_event_at(&author, "replica-only-marker", base + 5);
+        insert_top_level(&replica, community, channel, &marker).await;
+
+        let db = Db::from_pools(writer.clone(), replica.clone());
+        let cid = CommunityId::from_uuid(community);
+
+        // Head fetch (cursor: None) → writer: sees `fresh`, never `marker`.
+        let head = db
+            .get_channel_window(cid, channel, 2, None, None)
+            .await
+            .expect("head window");
+        let head_contents: Vec<String> = head
+            .rows
+            .iter()
+            .map(|r| r.stored_event.event.content.clone())
+            .collect();
+        assert_eq!(
+            head_contents,
+            vec!["fresh-writer-only".to_string(), "m3".to_string()],
+            "head fetch must be served by the writer"
+        );
+
+        // Cursor page → replica: sees `marker`, never `fresh`.
+        let cursor = head.next_cursor.expect("has_more implies next_cursor");
+        let page2 = db
+            .get_channel_window(cid, channel, 10, Some(cursor), None)
+            .await
+            .expect("cursor window");
+        let page2_contents: Vec<String> = page2
+            .rows
+            .iter()
+            .map(|r| r.stored_event.event.content.clone())
+            .collect();
+        assert_eq!(
+            page2_contents,
+            vec![
+                "m2".to_string(),
+                "replica-only-marker".to_string(),
+                "m1".to_string()
+            ],
+            "cursor page must be served by the replica"
+        );
+
+        drop_scratch_db(&admin, replica, &rname).await;
+        drop_scratch_db(&admin, writer, &wname).await;
+    }
+
+    /// Thread replies: head fetch reads the writer; a FULL cursor page is
+    /// served by the replica; an UNDER-limit cursor page (candidate terminal
+    /// page) is re-run on the writer so a lagged replica can never truncate
+    /// the tail into a false EOF.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn thread_replies_cursor_pages_route_to_replica_with_writer_terminal_verification() {
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let (writer, wname) = create_scratch_db(&admin, "routing_tw").await;
+        let (replica, rname) = create_scratch_db(&admin, "routing_tr").await;
+
+        let author = nostr::Keys::generate();
+        let community = Uuid::new_v4();
+        let channel = Uuid::new_v4();
+        seed_community_channel(&writer, community, channel, &author).await;
+        seed_community_channel(&replica, community, channel, &author).await;
+
+        let base = 1_700_000_000u64;
+        let root = signed_event_at(&author, "root", base);
+        for pool in [&writer, &replica] {
+            insert_top_level(pool, community, channel, &root).await;
+        }
+
+        // Writer holds replies r1..r5; the lagged replica only has r1..r3.
+        let replies: Vec<nostr::Event> = (1..=5)
+            .map(|i| signed_event_at(&author, &format!("r{i}"), base + 10 * i as u64))
+            .collect();
+        for reply in &replies {
+            insert_thread_reply(&writer, community, channel, &root, reply).await;
+        }
+        for reply in &replies[..3] {
+            insert_thread_reply(&replica, community, channel, &root, reply).await;
+        }
+
+        let db = Db::from_pools(writer.clone(), replica.clone());
+        let cid = CommunityId::from_uuid(community);
+
+        // Page 1 (no cursor) → writer.
+        let page1 = db
+            .get_thread_replies(cid, root.id.as_bytes(), Some(10), 2, None)
+            .await
+            .expect("page 1");
+        let contents: Vec<&str> = page1
+            .iter()
+            .map(|r| r.stored_event.event.content.as_str())
+            .collect();
+        assert_eq!(contents, vec!["r1", "r2"], "head page from writer");
+
+        // Page 2: replica serves a FULL page (r3 exists there) — but wait:
+        // replica has r1..r3, page after r2 with limit 2 returns only [r3]
+        // (under limit) → terminal-verification re-runs on the writer, which
+        // returns [r3, r4]. A lag-truncated EOF must never surface.
+        let cur2 = thread_cursor(page1.last().expect("page 1 non-empty"));
+        let page2 = db
+            .get_thread_replies(cid, root.id.as_bytes(), Some(10), 2, Some(&cur2))
+            .await
+            .expect("page 2");
+        let contents: Vec<&str> = page2
+            .iter()
+            .map(|r| r.stored_event.event.content.as_str())
+            .collect();
+        assert_eq!(
+            contents,
+            vec!["r3", "r4"],
+            "under-limit replica page must be re-verified on the writer"
+        );
+
+        // Full-page replica serve: with limit 1, the page after r2 is [r3] —
+        // exactly `limit` rows, so the replica result stands. Prove it came
+        // from the replica with a replica-only divergent reply.
+        let ghost = signed_event_at(&author, "replica-only-ghost", base + 25);
+        insert_thread_reply(&replica, community, channel, &root, &ghost).await;
+        let page_replica = db
+            .get_thread_replies(cid, root.id.as_bytes(), Some(10), 1, Some(&cur2))
+            .await
+            .expect("full replica page");
+        let contents: Vec<&str> = page_replica
+            .iter()
+            .map(|r| r.stored_event.event.content.as_str())
+            .collect();
+        assert_eq!(
+            contents,
+            vec!["replica-only-ghost"],
+            "a full cursor page must be served by the replica"
+        );
+
+        // Same query with no replica configured reads the writer and cannot
+        // see the ghost.
+        let db_writer_only = Db::from_pool(writer.clone());
+        let page_writer = db_writer_only
+            .get_thread_replies(cid, root.id.as_bytes(), Some(10), 1, Some(&cur2))
+            .await
+            .expect("writer-only page");
+        let contents: Vec<&str> = page_writer
+            .iter()
+            .map(|r| r.stored_event.event.content.as_str())
+            .collect();
+        assert_eq!(contents, vec!["r3"], "unset replica falls back to writer");
+
+        drop_scratch_db(&admin, replica, &rname).await;
+        drop_scratch_db(&admin, writer, &wname).await;
     }
 }

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -14,6 +14,39 @@ static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("../../migrations");
 pub async fn run_migrations(pool: &PgPool) -> Result<()> {
     reject_legacy_nip_rs_cardinality_ambiguity(pool).await?;
     MIGRATOR.run(pool).await?;
+    verify_created_at_floor_guard_coverage(pool).await?;
+    Ok(())
+}
+
+/// The replica-fence proof (see `replica_fence`) requires the commit-time
+/// `created_at` floor trigger from migration 0021 on **every** writable
+/// `events` partition. `CREATE TABLE .. PARTITION OF` clones parent triggers,
+/// but a partition attached with `ATTACH PARTITION` or created by an older
+/// code path would silently escape the guard — so startup fails closed if any
+/// partition lacks it.
+async fn verify_created_at_floor_guard_coverage(pool: &PgPool) -> Result<()> {
+    let uncovered: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT c.relname::text
+        FROM pg_inherits i
+        JOIN pg_class c ON c.oid = i.inhrelid
+        WHERE i.inhparent = 'events'::regclass
+          AND NOT EXISTS (
+              SELECT 1 FROM pg_trigger t
+              WHERE t.tgrelid = c.oid
+                AND t.tgname = 'events_created_at_floor'
+          )
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+    if !uncovered.is_empty() {
+        return Err(crate::DbError::InvalidData(format!(
+            "events partition(s) missing the created_at floor guard trigger \
+             (replica-fence safety): {}",
+            uncovered.join(", ")
+        )));
+    }
     Ok(())
 }
 
@@ -549,7 +582,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 20);
+        assert_eq!(migrations.len(), 21);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -820,6 +853,13 @@ mod tests {
             .sql
             .as_str()
             .contains("CREATE TABLE join_policy_acceptances"));
+
+        // Replica-fence commit-time floor guard on channel-bearing events.
+        assert_eq!(migrations[20].version, 21);
+        assert!(migrations[20]
+            .sql
+            .as_str()
+            .contains("events_created_at_floor_guard"));
         assert!(!migrations[0]
             .sql
             .as_str()
@@ -1066,7 +1106,7 @@ mod tests {
         run_migrations(&pool)
             .await
             .expect("retry succeeds after operator repair");
-        assert_eq!(applied_versions(&pool).await.last().copied(), Some(20));
+        assert_eq!(applied_versions(&pool).await.last().copied(), Some(21));
     }
 
     #[tokio::test]

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -14,39 +14,14 @@ static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("../../migrations");
 pub async fn run_migrations(pool: &PgPool) -> Result<()> {
     reject_legacy_nip_rs_cardinality_ambiguity(pool).await?;
     MIGRATOR.run(pool).await?;
-    verify_created_at_floor_guard_coverage(pool).await?;
-    Ok(())
-}
-
-/// The replica-fence proof (see `replica_fence`) requires the commit-time
-/// `created_at` floor trigger from migration 0021 on **every** writable
-/// `events` partition. `CREATE TABLE .. PARTITION OF` clones parent triggers,
-/// but a partition attached with `ATTACH PARTITION` or created by an older
-/// code path would silently escape the guard — so startup fails closed if any
-/// partition lacks it.
-async fn verify_created_at_floor_guard_coverage(pool: &PgPool) -> Result<()> {
-    let uncovered: Vec<String> = sqlx::query_scalar(
-        r#"
-        SELECT c.relname::text
-        FROM pg_inherits i
-        JOIN pg_class c ON c.oid = i.inhrelid
-        WHERE i.inhparent = 'events'::regclass
-          AND NOT EXISTS (
-              SELECT 1 FROM pg_trigger t
-              WHERE t.tgrelid = c.oid
-                AND t.tgname = 'events_created_at_floor'
-          )
-        "#,
-    )
-    .fetch_all(pool)
-    .await?;
-    if !uncovered.is_empty() {
-        return Err(crate::DbError::InvalidData(format!(
-            "events partition(s) missing the created_at floor guard trigger \
-             (replica-fence safety): {}",
-            uncovered.join(", ")
-        )));
-    }
+    // The replica-fence proof (see `replica_fence`) requires the commit-time
+    // `created_at` floor trigger from migration 0021 — correctly shaped — on
+    // the `events` parent and every partition. `CREATE TABLE .. PARTITION OF`
+    // clones parent triggers, but a partition attached with `ATTACH
+    // PARTITION` or created by an older code path would silently escape the
+    // guard, so migration fails closed if any is missing. (The fence probe
+    // re-runs this same check at startup on non-migrating relays.)
+    crate::replica_fence::verify_floor_guard_catalog(pool).await?;
     Ok(())
 }
 

--- a/crates/buzz-db/src/replica_fence.rs
+++ b/crates/buzz-db/src/replica_fence.rs
@@ -1,0 +1,471 @@
+//! Replica freshness fence for keyset-cursor read routing.
+//!
+//! A read replica may serve a cursor page only when every row the page could
+//! contain is provably present on the replica. The proof rests on two parts:
+//!
+//! 1. **Commit-time floor** (migration 0021): a deferred constraint trigger
+//!    aborts, at COMMIT, any transaction inserting a channel-bearing `events`
+//!    row with `created_at` more than `floor` seconds before commit time
+//!    (`clock_timestamp()`, evaluated inside commit processing). Enforcement
+//!    is armed per session via the `buzz.created_at_floor` GUC, which the
+//!    relay's writer pool sets on every connection.
+//! 2. **Ordered LSN handshake** (this module): on one pinned writer
+//!    connection, three separately-awaited statements sample
+//!    `S = clock_timestamp()`, then scan `pg_stat_activity` for the oldest
+//!    open transaction, then capture `L = pg_current_wal_lsn()` **last**.
+//!    Once the replica reports `pg_last_wal_replay_lsn() >= L`, every
+//!    transaction partitions into exactly three buckets:
+//!      (a) finished before the activity scan — its commit WAL precedes `L`,
+//!          so the replica has replayed it;
+//!      (b) open at the activity scan — represented by `xact_start`, so it is
+//!          bounded by the `oldest_xact_start` term;
+//!      (c) started after the activity scan — its deferred floor guard runs
+//!          after `S`, so it cannot commit a row with
+//!          `created_at < S - floor`.
+//!    There is no fourth bucket. The fence therefore advances to
+//!    `min(oldest_xact_start, S) - floor - clock_margin`, and every
+//!    channel-window row with `created_at <= fence` is on the replica.
+//!
+//! Everything fails **closed**: probe errors, masked `pg_stat_activity`
+//! visibility, NULL/absent replica LSN (Aurora observability differences),
+//! non-advancing replay, or probe staleness all close the fence, which routes
+//! all reads back to the writer — degraded capacity, never holes.
+//!
+//! Operational bypasses (sessions without the GUC, `session_replication_role
+//! = replica` restores) are outside the proof by design and require holding
+//! the fence closed for their duration; see `migrations/0021`.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use sqlx::{PgPool, Row};
+
+/// Seconds of `created_at` history the commit-time floor guard tolerates.
+///
+/// Must exceed the relay's ingest envelope (±900 s) by enough slack that a
+/// legitimately accepted event still commits within the floor even under
+/// slow validation/lock waits. The writer pool arms the guard with this value
+/// and the fence subtracts it; the two uses must never diverge.
+pub const CREATED_AT_FLOOR_SECS: i64 = 960;
+
+/// Safety margin subtracted from the fence on top of the floor.
+///
+/// All proof timestamps (`clock_timestamp()`, `xact_start`, the guard's
+/// clock) come from the writer host, so this only needs to absorb
+/// `created_at` second-truncation and scheduling noise, not clock skew
+/// between machines.
+pub const FENCE_CLOCK_MARGIN_SECS: i64 = 5;
+
+/// How often the probe samples the writer and checks the replica.
+pub const PROBE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// A fence older than this is stale: the probe has stopped confirming
+/// freshness and the fence closes until a new handshake completes.
+pub const FENCE_STALENESS: Duration = Duration::from_secs(30);
+
+/// Sentinel: fence closed (no verified replica coverage).
+const CLOSED: i64 = i64::MIN;
+
+/// Shared fence state. `Db` holds an `Arc` of this; the probe task advances
+/// it and cursor routing consults it.
+#[derive(Debug)]
+pub struct ReplicaFence {
+    /// Unix micros of the newest verified-complete timestamp, or `CLOSED`.
+    fence_micros: AtomicI64,
+    /// Unix micros when the fence was last advanced (staleness check).
+    updated_micros: AtomicI64,
+}
+
+impl ReplicaFence {
+    /// A new fence, initially closed.
+    pub fn new() -> Self {
+        Self {
+            fence_micros: AtomicI64::new(CLOSED),
+            updated_micros: AtomicI64::new(CLOSED),
+        }
+    }
+
+    /// Close the fence: all cursor reads route to the writer.
+    pub fn close(&self) {
+        self.fence_micros.store(CLOSED, Ordering::Relaxed);
+    }
+
+    fn advance(&self, fence: DateTime<Utc>) {
+        self.fence_micros
+            .store(fence.timestamp_micros(), Ordering::Relaxed);
+        self.updated_micros
+            .store(Utc::now().timestamp_micros(), Ordering::Relaxed);
+    }
+
+    /// The current fence, or `None` when closed or stale.
+    ///
+    /// Rows with `created_at <= fence` are verified present on the replica.
+    pub fn verified_through(&self) -> Option<DateTime<Utc>> {
+        let raw = self.fence_micros.load(Ordering::Relaxed);
+        if raw == CLOSED {
+            return None;
+        }
+        let updated = self.updated_micros.load(Ordering::Relaxed);
+        let age_micros = Utc::now().timestamp_micros().saturating_sub(updated);
+        if age_micros > FENCE_STALENESS.as_micros() as i64 {
+            return None;
+        }
+        DateTime::from_timestamp_micros(raw)
+    }
+
+    /// Whether the replica verifiably holds every channel-window row at or
+    /// before `ts`.
+    pub fn covers(&self, ts: DateTime<Utc>) -> bool {
+        self.verified_through().is_some_and(|fence| ts <= fence)
+    }
+
+    /// Test hook: force the fence open through `ts` without a probe.
+    /// Used by routing tests that stand up a divergent fake replica.
+    pub fn force_open_for_tests(&self, ts: DateTime<Utc>) {
+        self.advance(ts);
+    }
+}
+
+impl Default for ReplicaFence {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One writer-side sample of the ordered handshake.
+#[derive(Debug)]
+struct WriterSample {
+    /// `S`: writer `clock_timestamp()` captured first.
+    sampled_at: DateTime<Utc>,
+    /// Oldest open transaction among other client backends at scan time,
+    /// or `None` when no transaction was open.
+    oldest_xact_start: Option<DateTime<Utc>>,
+    /// `L`: writer `pg_current_wal_lsn()` captured last, as text.
+    wal_lsn: String,
+}
+
+/// Errors that close the fence. All variants are logged and treated
+/// identically: fail closed.
+#[derive(Debug, thiserror::Error)]
+pub enum ProbeError {
+    /// A probe query against writer or replica failed.
+    #[error("writer probe query failed: {0}")]
+    Writer(#[from] sqlx::Error),
+    /// `pg_stat_activity` hid state for another backend that could hold an
+    /// open transaction — the oldest-xact term cannot be trusted.
+    #[error(
+        "pg_stat_activity visibility incomplete: {masked} other client backend(s) with masked or \
+         unrecognized state — probe role needs pg_monitor"
+    )]
+    MaskedActivity {
+        /// Number of other client backends with masked/unknown state.
+        masked: i64,
+    },
+    /// The replica returned NULL for the replay-LSN comparison.
+    #[error("replica did not report a comparable replay LSN")]
+    ReplicaLsnUnavailable,
+}
+
+/// Take one ordered writer sample: S, then activity scan, then L **last**.
+///
+/// The three statements are separately awaited on a single pinned connection;
+/// a single SELECT would not guarantee evaluation order across the
+/// subexpressions, reopening the race this ordering exists to close.
+async fn sample_writer(writer: &PgPool) -> Result<WriterSample, ProbeError> {
+    let mut conn = writer.acquire().await?;
+
+    // 1. S first.
+    let sampled_at: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(&mut *conn)
+        .await?;
+
+    // 2. Activity scan. Classification (fail closed on anything unknown):
+    //    - `backend_type IS NULL` → masked. CRITICAL: an unprivileged view
+    //      masks `backend_type` itself along with `state`/`xact_start`
+    //      (verified on PG 16/17), so filtering on
+    //      `backend_type = 'client backend'` would silently EXCLUDE masked
+    //      rows and fail open. Masked rows must be detected before any
+    //      backend-type filter;
+    //    - client backend with `state IS NULL`, or a transactional/unknown
+    //      state with NULL `xact_start` → masked → error;
+    //    - client backend, `state = 'idle'`, NULL `xact_start`
+    //                                 → no transaction → safely ignore;
+    //    - any row with non-NULL `xact_start` (any backend type)
+    //                                 → include in the minimum. Background
+    //      workers cannot insert events rows, but counting them is the
+    //      conservative direction (a long autovacuum merely holds the fence
+    //      back), and it keeps the classification simple.
+    //    Scope is every other backend regardless of role or application
+    //    name: an admin psql transaction writes under the same trigger and
+    //    must be representable in the oldest-xact term.
+    //
+    //    Prepared transactions (2PC) are a bucket of their own: while
+    //    prepared they have left `pg_stat_activity` but can still commit
+    //    after `L`. Their deferred floor guard already ran at PREPARE, so
+    //    `pg_prepared_xacts.prepared` bounds their rows exactly like
+    //    `xact_start`; fold it into the same minimum.
+    let row = sqlx::query(
+        r#"
+        SELECT
+            least(
+                (SELECT min(xact_start)
+                   FROM pg_stat_activity
+                  WHERE pid <> pg_backend_pid()),
+                (SELECT min(prepared) FROM pg_prepared_xacts)
+            ) AS oldest_xact_start,
+            (SELECT count(*)
+               FROM pg_stat_activity
+              WHERE pid <> pg_backend_pid()
+                AND (backend_type IS NULL
+                     OR (backend_type = 'client backend'
+                         AND (state IS NULL
+                              OR (state <> 'idle' AND xact_start IS NULL))))
+            ) AS masked
+        "#,
+    )
+    .fetch_one(&mut *conn)
+    .await?;
+    let masked: i64 = row.get("masked");
+    if masked > 0 {
+        return Err(ProbeError::MaskedActivity { masked });
+    }
+    let oldest_xact_start: Option<DateTime<Utc>> = row.get("oldest_xact_start");
+
+    // 3. L last.
+    let wal_lsn: String = sqlx::query_scalar("SELECT pg_current_wal_lsn()::text")
+        .fetch_one(&mut *conn)
+        .await?;
+
+    Ok(WriterSample {
+        sampled_at,
+        oldest_xact_start,
+        wal_lsn,
+    })
+}
+
+/// Whether the replica has replayed at least through `wal_lsn`.
+///
+/// The comparison happens on the replica in pg_lsn domain. The
+/// `pg_is_in_recovery()` gate is load-bearing: after crash recovery or
+/// promotion a *primary* returns a static non-NULL `pg_last_wal_replay_lsn()`
+/// rather than NULL, so NULL-checking alone would not reliably detect a
+/// misrouted "replica" URL. Not-in-recovery, NULL replay LSN, or Aurora
+/// hiding either is an error → fence closes.
+async fn replica_covers(replica: &PgPool, wal_lsn: &str) -> Result<bool, ProbeError> {
+    let covered: Option<bool> = sqlx::query_scalar(
+        r#"
+        SELECT CASE
+            WHEN pg_is_in_recovery() THEN pg_last_wal_replay_lsn() >= $1::pg_lsn
+            ELSE NULL
+        END
+        "#,
+    )
+    .bind(wal_lsn)
+    .fetch_one(replica)
+    .await?;
+    covered.ok_or(ProbeError::ReplicaLsnUnavailable)
+}
+
+/// Run one full handshake and, on success, advance the fence.
+///
+/// Returns the new fence value for observability. `Ok(None)` means the
+/// replica has not yet replayed past the sample; the fence is left as-is
+/// (staleness will close it if this persists).
+pub async fn probe_once(
+    writer: &PgPool,
+    replica: &PgPool,
+    fence: &ReplicaFence,
+) -> Result<Option<DateTime<Utc>>, ProbeError> {
+    let sample = sample_writer(writer).await?;
+    if !replica_covers(replica, &sample.wal_lsn).await? {
+        return Ok(None);
+    }
+    let lower = match sample.oldest_xact_start {
+        Some(oldest) => oldest.min(sample.sampled_at),
+        None => sample.sampled_at,
+    };
+    let new_fence = lower
+        - chrono::Duration::seconds(CREATED_AT_FLOOR_SECS)
+        - chrono::Duration::seconds(FENCE_CLOCK_MARGIN_SECS);
+    fence.advance(new_fence);
+    Ok(Some(new_fence))
+}
+
+/// Background probe loop: sample every `PROBE_INTERVAL`, close the fence on
+/// any error. Runs for the life of the process.
+pub async fn run_probe(writer: PgPool, replica: PgPool, fence: Arc<ReplicaFence>) {
+    let mut interval = tokio::time::interval(PROBE_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        interval.tick().await;
+        match probe_once(&writer, &replica, &fence).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                // Replica behind the sample: leave the fence; staleness
+                // closes it if the replica stays behind.
+                tracing::debug!("replica fence: replay behind writer sample");
+            }
+            Err(e) => {
+                fence.close();
+                tracing::warn!(error = %e, "replica fence probe failed; fence closed");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz"; // sadscan:disable np.postgres.1
+
+    fn test_db_url() -> String {
+        std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| TEST_DB_URL.into())
+    }
+
+    #[test]
+    fn fence_starts_closed_and_opens_on_advance() {
+        let fence = ReplicaFence::new();
+        assert!(fence.verified_through().is_none(), "must start closed");
+        assert!(!fence.covers(Utc::now() - chrono::Duration::days(365)));
+
+        let ts = Utc::now();
+        fence.advance(ts);
+        assert_eq!(fence.verified_through(), Some(ts));
+        assert!(fence.covers(ts - chrono::Duration::seconds(1)));
+        assert!(fence.covers(ts), "boundary is inclusive");
+        assert!(!fence.covers(ts + chrono::Duration::seconds(1)));
+
+        fence.close();
+        assert!(fence.verified_through().is_none(), "close() must close");
+        assert!(!fence.covers(ts - chrono::Duration::days(365)));
+    }
+
+    #[test]
+    fn stale_fence_reads_as_closed() {
+        let fence = ReplicaFence::new();
+        let ts = Utc::now();
+        fence
+            .fence_micros
+            .store(ts.timestamp_micros(), Ordering::Relaxed);
+        // Last update older than the staleness budget.
+        let stale = (Utc::now()
+            - chrono::Duration::from_std(FENCE_STALENESS).expect("duration")
+            - chrono::Duration::seconds(1))
+        .timestamp_micros();
+        fence.updated_micros.store(stale, Ordering::Relaxed);
+        assert!(
+            fence.verified_through().is_none(),
+            "a fence the probe stopped confirming must read as closed"
+        );
+    }
+
+    /// The activity scan must (a) represent another session's open
+    /// transaction in the oldest-xact term and (b) ignore plain-idle
+    /// sessions, per the agreed classification.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn sample_writer_sees_open_transactions_and_ignores_idle() {
+        let pool = PgPool::connect(&test_db_url()).await.expect("connect");
+
+        // A plain idle session: pinned connection, no transaction.
+        let idle_pool = PgPool::connect(&test_db_url()).await.expect("connect idle");
+        let _idle_conn = idle_pool.acquire().await.expect("idle conn");
+
+        let before = sample_writer(&pool).await.expect("sample without tx");
+
+        // Now hold a transaction open on a second connection.
+        let tx_pool = PgPool::connect(&test_db_url()).await.expect("connect tx");
+        let mut tx = tx_pool.begin().await.expect("begin");
+        sqlx::query("SELECT 1")
+            .execute(&mut *tx)
+            .await
+            .expect("touch tx");
+
+        let during = sample_writer(&pool).await.expect("sample with open tx");
+        let oldest = during
+            .oldest_xact_start
+            .expect("open transaction must appear in the oldest-xact term");
+        assert!(
+            oldest <= during.sampled_at,
+            "xact_start precedes the sample that observed it"
+        );
+        // S is captured before the activity scan, L after: the sample's
+        // ordering invariant.
+        assert!(during.sampled_at >= before.sampled_at);
+
+        tx.rollback().await.expect("rollback");
+    }
+
+    /// An unprivileged probe role sees NULL `state`/`xact_start` for other
+    /// sessions' rows in `pg_stat_activity`. The oldest-xact term is then
+    /// untrustworthy and the sample must fail closed (`MaskedActivity`) —
+    /// never silently `MIN()` the hidden row away.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn sample_writer_fails_closed_when_activity_is_masked() {
+        let admin = PgPool::connect(&test_db_url()).await.expect("connect");
+
+        // Hold a transaction open as the privileged user: this is the row
+        // the unprivileged probe must notice it cannot classify.
+        let tx_pool = PgPool::connect(&test_db_url()).await.expect("connect tx");
+        let mut tx = tx_pool.begin().await.expect("begin");
+        sqlx::query("SELECT 1")
+            .execute(&mut *tx)
+            .await
+            .expect("touch tx");
+
+        // An unprivileged login role (no pg_monitor): pg_stat_activity masks
+        // other sessions' state columns for it.
+        let role = format!("fence_probe_{}", uuid::Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "CREATE ROLE {role} LOGIN PASSWORD 'fence_probe_test'" // sadscan:disable np.postgres.1
+        )))
+        .execute(&admin)
+        .await
+        .expect("create unprivileged role");
+
+        let base = test_db_url();
+        let unpriv_url = {
+            let rest = base.strip_prefix("postgres://").expect("pg url");
+            let at = rest.rfind('@').expect("credentials in url");
+            format!("postgres://{role}:fence_probe_test@{}", &rest[at + 1..])
+        };
+        let unpriv = PgPool::connect(&unpriv_url).await.expect("connect unpriv");
+
+        let err = sample_writer(&unpriv)
+            .await
+            .expect_err("masked pg_stat_activity must fail closed");
+        assert!(
+            matches!(err, ProbeError::MaskedActivity { masked } if masked >= 1),
+            "expected MaskedActivity, got {err:?}"
+        );
+
+        tx.rollback().await.expect("rollback");
+        unpriv.close().await;
+        sqlx::query(sqlx::AssertSqlSafe(format!("DROP ROLE {role}")))
+            .execute(&admin)
+            .await
+            .expect("drop role");
+    }
+
+    /// A primary (non-replica) database returns NULL from
+    /// `pg_last_wal_replay_lsn()`; the probe must fail closed, never
+    /// synthesize freshness. This is also the Aurora-observability guard:
+    /// if the reader endpoint hides replay LSNs, routing stays writer-only.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn probe_fails_closed_when_replica_lsn_unavailable() {
+        let pool = PgPool::connect(&test_db_url()).await.expect("connect");
+        let fence = ReplicaFence::new();
+        fence.advance(Utc::now()); // pretend a previous handshake succeeded
+
+        // Using the primary as its own "replica": replay LSN is NULL.
+        let err = probe_once(&pool, &pool, &fence)
+            .await
+            .expect_err("NULL replay LSN must be an error");
+        assert!(matches!(err, ProbeError::ReplicaLsnUnavailable));
+    }
+}

--- a/crates/buzz-db/src/replica_fence.rs
+++ b/crates/buzz-db/src/replica_fence.rs
@@ -134,6 +134,196 @@ impl Default for ReplicaFence {
     }
 }
 
+/// Catalog-level verification that the commit-time floor guard (migration
+/// 0021) is present and correctly shaped on the `events` parent AND every
+/// partition: right function, `DEFERRABLE INITIALLY DEFERRED`, row-level,
+/// AFTER, firing on both INSERT and UPDATE (an UPDATE can move an exempt
+/// channel-NULL row into the guarded set, or rewrite `created_at` downward).
+///
+/// This is a name-and-shape check only; it cannot detect a sabotaged
+/// function body. [`verify_floor_guard_behavior`] proves the semantics.
+pub async fn verify_floor_guard_catalog(pool: &PgPool) -> crate::Result<()> {
+    // tgtype bits: 1 = ROW, 2 = BEFORE, 4 = INSERT, 16 = UPDATE, 64 = INSTEAD.
+    // Required: ROW + INSERT + UPDATE set, BEFORE + INSTEAD clear.
+    let missing: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT c.relname::text
+        FROM (
+            SELECT 'events'::regclass AS oid
+            UNION ALL
+            SELECT inhrelid FROM pg_inherits WHERE inhparent = 'events'::regclass
+        ) rels
+        JOIN pg_class c ON c.oid = rels.oid
+        WHERE NOT EXISTS (
+            SELECT 1 FROM pg_trigger t
+            WHERE t.tgrelid = rels.oid
+              AND t.tgname = 'events_created_at_floor'
+              AND t.tgfoid = 'events_created_at_floor_guard'::regproc
+              AND t.tgdeferrable
+              AND t.tginitdeferred
+              AND t.tgtype & 1 = 1      -- row-level
+              AND t.tgtype & 2 = 0      -- AFTER, not BEFORE
+              AND t.tgtype & 64 = 0     -- not INSTEAD OF
+              AND t.tgtype & 4 = 4      -- fires on INSERT
+              AND t.tgtype & 16 = 16    -- fires on UPDATE
+        )
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+    if !missing.is_empty() {
+        return Err(crate::error::DbError::InvalidData(format!(
+            "created_at floor guard trigger missing or mis-shaped on: {} \
+             (replica fence must stay closed)",
+            missing.join(", ")
+        )));
+    }
+    Ok(())
+}
+
+/// Behavioral verification of the floor guard, end-to-end through the armed
+/// pool. A catalog check cannot detect a no-op function body or an unarmed
+/// pool; this proves the semantics the fence proof cites, inside one
+/// rolled-back transaction:
+///
+/// 1. the pool's session GUC equals [`CREATED_AT_FLOOR_SECS`] (arming);
+/// 2. an old channel-bearing INSERT raises `check_violation` (23514);
+/// 3. a fresh channel-bearing INSERT commits;
+/// 4. rewriting a fresh row's `created_at` below the floor raises;
+/// 5. an old channel-NULL INSERT is exempt, but flipping its `channel_id`
+///    on raises (the `UPDATE OF` arm).
+///
+/// `SET CONSTRAINTS ALL IMMEDIATE` makes the deferred trigger fire per
+/// statement so each adversary is observable under a savepoint; deferral to
+/// COMMIT is separately pinned by the held-transaction fixture.
+pub async fn verify_floor_guard_behavior(pool: &PgPool) -> crate::Result<()> {
+    use crate::error::DbError;
+
+    let expect_violation = |res: Result<sqlx::postgres::PgQueryResult, sqlx::Error>,
+                            what: &str|
+     -> crate::Result<()> {
+        match res {
+            Err(sqlx::Error::Database(e)) if e.code().as_deref() == Some("23514") => Ok(()),
+            Ok(_) => Err(DbError::InvalidData(format!(
+                "floor guard is inert: {what} was accepted (replica fence must stay closed)"
+            ))),
+            Err(e) => Err(DbError::InvalidData(format!(
+                "floor guard verification failed unexpectedly on {what}: {e}"
+            ))),
+        }
+    };
+
+    let mut tx = pool.begin().await?;
+
+    // 1. Pool arming (Perci: assert the effective value, not the intent).
+    let armed: String = sqlx::query_scalar("SHOW buzz.created_at_floor")
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| {
+            DbError::InvalidData(format!(
+                "buzz.created_at_floor GUC not set on this pool: {e}"
+            ))
+        })?;
+    if armed != CREATED_AT_FLOOR_SECS.to_string() {
+        return Err(DbError::InvalidData(format!(
+            "buzz.created_at_floor is '{armed}', expected '{CREATED_AT_FLOOR_SECS}': \
+             pool is not armed"
+        )));
+    }
+
+    sqlx::query("SET CONSTRAINTS ALL IMMEDIATE")
+        .execute(&mut *tx)
+        .await?;
+
+    // Scratch community satisfying the FK; the whole transaction rolls back.
+    let community = uuid::Uuid::new_v4();
+    sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+        .bind(community)
+        .bind(format!("fence-verify-{}.invalid", community.simple()))
+        .execute(&mut *tx)
+        .await?;
+    let channel = uuid::Uuid::new_v4();
+
+    let insert = |tx_id: [u8; 32], age_secs: i64, ch: Option<uuid::Uuid>| {
+        sqlx::query(
+            "INSERT INTO events (community_id, id, pubkey, created_at, kind, tags, \
+             content, sig, received_at, channel_id) \
+             VALUES ($1, $2, $3, clock_timestamp() - make_interval(secs => $4::double precision), \
+             9, '[]', 'fence-verify', $5, NOW(), $6)",
+        )
+        .bind(community)
+        .bind(tx_id.to_vec())
+        .bind(vec![0u8; 32])
+        .bind(age_secs as f64)
+        .bind(vec![0u8; 64])
+        .bind(ch)
+    };
+    let old_age = CREATED_AT_FLOOR_SECS + 60;
+
+    // 2. Old channel-bearing insert must raise.
+    sqlx::query("SAVEPOINT floor_probe")
+        .execute(&mut *tx)
+        .await?;
+    let res = insert(rand_id(), old_age, Some(channel))
+        .execute(&mut *tx)
+        .await;
+    expect_violation(res, "an old channel-bearing INSERT")?;
+    sqlx::query("ROLLBACK TO SAVEPOINT floor_probe")
+        .execute(&mut *tx)
+        .await?;
+
+    // 3. Fresh channel-bearing insert must pass.
+    let fresh_id = rand_id();
+    insert(fresh_id, 0, Some(channel)).execute(&mut *tx).await?;
+
+    // 4. Rewriting created_at below the floor must raise (in- or
+    //    cross-partition, either arm of the guard catches the NEW row).
+    sqlx::query("SAVEPOINT floor_probe")
+        .execute(&mut *tx)
+        .await?;
+    let res = sqlx::query(
+        "UPDATE events SET created_at = clock_timestamp() - make_interval(secs => $1::double precision) \
+         WHERE community_id = $2 AND id = $3",
+    )
+    .bind(old_age as f64)
+    .bind(community)
+    .bind(fresh_id.to_vec())
+    .execute(&mut *tx)
+    .await;
+    expect_violation(res, "rewriting created_at below the floor")?;
+    sqlx::query("ROLLBACK TO SAVEPOINT floor_probe")
+        .execute(&mut *tx)
+        .await?;
+
+    // 5. Old channel-NULL insert is exempt; flipping channel_id on must raise.
+    let null_id = rand_id();
+    insert(null_id, old_age, None).execute(&mut *tx).await?;
+    sqlx::query("SAVEPOINT floor_probe")
+        .execute(&mut *tx)
+        .await?;
+    let res = sqlx::query("UPDATE events SET channel_id = $1 WHERE community_id = $2 AND id = $3")
+        .bind(channel)
+        .bind(community)
+        .bind(null_id.to_vec())
+        .execute(&mut *tx)
+        .await;
+    expect_violation(res, "moving an old channel-NULL row into a channel")?;
+    sqlx::query("ROLLBACK TO SAVEPOINT floor_probe")
+        .execute(&mut *tx)
+        .await?;
+
+    tx.rollback().await?;
+    Ok(())
+}
+
+fn rand_id() -> [u8; 32] {
+    let mut id = [0u8; 32];
+    for chunk in id.chunks_mut(16) {
+        chunk.copy_from_slice(&uuid::Uuid::new_v4().into_bytes()[..chunk.len()]);
+    }
+    id
+}
+
 /// One writer-side sample of the ordered handshake.
 #[derive(Debug)]
 struct WriterSample {

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -53,6 +53,9 @@ pub struct Config {
     pub bind_addr: SocketAddr,
     /// Postgres database connection URL.
     pub database_url: String,
+    /// Optional read-replica connection URL (e.g. an Aurora `cluster-ro-`
+    /// endpoint). Unset means all reads stay on the writer.
+    pub read_database_url: Option<String>,
     /// Redis connection URL used by the pub/sub manager.
     pub redis_url: String,
     /// Public WebSocket URL of this relay, advertised in NIP-11.
@@ -376,6 +379,11 @@ impl Config {
 
         let database_url = std::env::var("DATABASE_URL")
             .unwrap_or_else(|_| "postgres://buzz:buzz_dev@localhost:5432/buzz".to_string()); // sadscan:disable np.postgres.1
+
+        let read_database_url = std::env::var("READ_DATABASE_URL")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
 
         let redis_url =
             std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
@@ -811,6 +819,7 @@ impl Config {
         Ok(Self {
             bind_addr,
             database_url,
+            read_database_url,
             redis_url,
             relay_url,
             pairing_relay_url,
@@ -913,6 +922,34 @@ mod tests {
         assert!(
             config.huddle_audio_available,
             "huddle_audio_available should default to true so single-pod (N=1) keeps today's huddle behavior"
+        );
+    }
+
+    #[test]
+    fn read_database_url_unset_or_blank_is_none() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let previous = std::env::var_os("READ_DATABASE_URL");
+
+        std::env::remove_var("READ_DATABASE_URL");
+        let unset = Config::from_env().expect("config").read_database_url;
+
+        std::env::set_var("READ_DATABASE_URL", "   ");
+        let blank = Config::from_env().expect("config").read_database_url;
+
+        std::env::set_var("READ_DATABASE_URL", "postgres://buzz:pw@replica:5432/buzz"); // sadscan:disable np.postgres.1
+        let set = Config::from_env().expect("config").read_database_url;
+
+        if let Some(value) = previous {
+            std::env::set_var("READ_DATABASE_URL", value);
+        } else {
+            std::env::remove_var("READ_DATABASE_URL");
+        }
+
+        assert_eq!(unset, None, "unset READ_DATABASE_URL must disable routing");
+        assert_eq!(blank, None, "blank READ_DATABASE_URL must disable routing");
+        assert_eq!(
+            set.as_deref(),
+            Some("postgres://buzz:pw@replica:5432/buzz") // sadscan:disable np.postgres.1
         );
     }
 

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -142,13 +142,18 @@ async fn main() -> anyhow::Result<()> {
 
     let db_config = DbConfig {
         database_url: config.database_url.clone(),
+        read_database_url: config.read_database_url.clone(),
         ..DbConfig::default()
     };
     let db = Db::new(&db_config).await.map_err(|e| {
         error!("Failed to connect to Postgres: {e}");
         anyhow::anyhow!("DB connection failed: {e}")
     })?;
-    info!("Postgres connected");
+    if db.has_read_pool() {
+        info!("Postgres connected (writer + read replica)");
+    } else {
+        info!("Postgres connected");
+    }
 
     let auto_migrate =
         buzz_auto_migrate_enabled(std::env::var("BUZZ_AUTO_MIGRATE").ok().as_deref());
@@ -339,13 +344,21 @@ async fn main() -> anyhow::Result<()> {
     // Postgres FTS: the searchable row IS the persisted event row (its
     // `tsvector` column is populated by the `insert_event` write), so there is
     // no external collection to provision — the search service just queries the
-    // same Postgres over its own pool.
+    // same Postgres over its own pool. Search is lag-tolerant, so it prefers
+    // the read replica when one is configured.
+    let search_db_url = config
+        .read_database_url
+        .as_deref()
+        .unwrap_or(&config.database_url);
     let search_pool = sqlx::postgres::PgPoolOptions::new()
-        .connect(&config.database_url)
+        .connect(search_db_url)
         .await
         .map_err(|e| anyhow::anyhow!("Search DB connection failed: {e}"))?;
     let search = SearchService::new(search_pool);
-    info!("Search service ready (Postgres FTS)");
+    info!(
+        replica = config.read_database_url.is_some(),
+        "Search service ready (Postgres FTS)"
+    );
 
     let workflow_config = buzz_workflow::WorkflowConfig::default();
     let workflow_engine = Arc::new(WorkflowEngine::new(db.clone(), workflow_config));
@@ -918,6 +931,14 @@ async fn main() -> anyhow::Result<()> {
                 metrics::gauge!("buzz_db_pool_idle").set(db_stats.idle as f64);
                 metrics::gauge!("buzz_db_pool_active").set(active as f64);
                 metrics::gauge!("buzz_db_pool_max").set(db_stats.max as f64);
+
+                if let Some(read_stats) = pool_state.db.read_pool_stats() {
+                    let read_active = read_stats.size.saturating_sub(read_stats.idle);
+                    metrics::gauge!("buzz_db_read_pool_size").set(read_stats.size as f64);
+                    metrics::gauge!("buzz_db_read_pool_idle").set(read_stats.idle as f64);
+                    metrics::gauge!("buzz_db_read_pool_active").set(read_active as f64);
+                    metrics::gauge!("buzz_db_read_pool_max").set(read_stats.max as f64);
+                }
 
                 let rs = pool_state.redis_pool.status();
                 metrics::gauge!("buzz_redis_pool_available").set(rs.available as f64);

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -151,12 +151,6 @@ async fn main() -> anyhow::Result<()> {
     })?;
     if db.has_read_pool() {
         info!("Postgres connected (writer + read replica)");
-        // Freshness fence probe: cursor pages route to the replica only for
-        // history the probe has verified as fully replayed. Until the first
-        // successful handshake the fence is closed and all reads stay on the
-        // writer.
-        db.spawn_fence_probe();
-        info!("Replica fence probe started");
     } else {
         info!("Postgres connected");
     }
@@ -175,6 +169,26 @@ async fn main() -> anyhow::Result<()> {
 
     if let Err(e) = db.ensure_future_partitions(3).await {
         error!("Failed to ensure partitions: {e}");
+    }
+
+    // Freshness fence probe: cursor pages route to the replica only for
+    // history the probe has verified as fully replayed. Deliberately AFTER
+    // the migration decision: spawn_fence_probe first verifies the
+    // commit-time floor guard (catalog shape + observed behavior through the
+    // armed pool) against the live schema, so a relay running with
+    // BUZZ_AUTO_MIGRATE off and migration 0021 unapplied can never open the
+    // fence over an unenforced floor. Verification failure is loud but
+    // non-fatal: the fence stays closed and every cursor page routes to the
+    // writer.
+    match db.spawn_fence_probe().await {
+        Ok(true) => info!("Replica fence probe started (floor guard verified)"),
+        Ok(false) => {}
+        Err(e) => {
+            error!(
+                "Replica fence disabled — floor guard verification failed: {e}. \
+                 All cursor reads stay on the writer."
+            );
+        }
     }
 
     // NIP-43: if membership enforcement is on, a valid owner pubkey is required.

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -151,6 +151,12 @@ async fn main() -> anyhow::Result<()> {
     })?;
     if db.has_read_pool() {
         info!("Postgres connected (writer + read replica)");
+        // Freshness fence probe: cursor pages route to the replica only for
+        // history the probe has verified as fully replayed. Until the first
+        // successful handshake the fence is closed and all reads stay on the
+        // writer.
+        db.spawn_fence_probe();
+        info!("Replica fence probe started");
     } else {
         info!("Postgres connected");
     }
@@ -938,6 +944,20 @@ async fn main() -> anyhow::Result<()> {
                     metrics::gauge!("buzz_db_read_pool_idle").set(read_stats.idle as f64);
                     metrics::gauge!("buzz_db_read_pool_active").set(read_active as f64);
                     metrics::gauge!("buzz_db_read_pool_max").set(read_stats.max as f64);
+
+                    // Fence observability: 1 when replica routing is
+                    // eligible, and the verified-freshness lag in seconds.
+                    // Closed/stale fence reports open=0 with lag untouched.
+                    match pool_state.db.fence().verified_through() {
+                        Some(fence_ts) => {
+                            let lag = (chrono::Utc::now() - fence_ts).num_seconds();
+                            metrics::gauge!("buzz_db_replica_fence_open").set(1.0);
+                            metrics::gauge!("buzz_db_replica_fence_lag_seconds").set(lag as f64);
+                        }
+                        None => {
+                            metrics::gauge!("buzz_db_replica_fence_open").set(0.0);
+                        }
+                    }
                 }
 
                 let rs = pool_state.redis_pool.status();

--- a/deploy/charts/buzz/examples/secret-sample.yaml
+++ b/deploy/charts/buzz/examples/secret-sample.yaml
@@ -8,6 +8,7 @@
 #   BUZZ_RELAY_PRIVATE_KEY        — 64-char hex; relay identity (do NOT rotate)
 #   BUZZ_GIT_HOOK_HMAC_SECRET     — 32+ chars; required when replicaCount > 1
 #   DATABASE_URL                  — postgres://...
+#   READ_DATABASE_URL             — postgres://... (optional read-replica; omit to disable read routing)
 #   REDIS_URL                     — redis://...  (required when replicaCount > 1)
 #   BUZZ_S3_ACCESS_KEY
 #   BUZZ_S3_SECRET_KEY

--- a/deploy/charts/buzz/templates/deployment.yaml
+++ b/deploy/charts/buzz/templates/deployment.yaml
@@ -171,6 +171,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "buzz.envSecretName" . }}
                   key: DATABASE_URL
+            - name: READ_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "buzz.envSecretName" . }}
+                  key: READ_DATABASE_URL
+                  optional: true
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:

--- a/deploy/charts/buzz/tests/secrets_test.yaml
+++ b/deploy/charts/buzz/tests/secrets_test.yaml
@@ -59,6 +59,47 @@ tests:
                 optional: true
         template: templates/deployment.yaml
 
+  - it: Deployment env points READ_DATABASE_URL at existingSecret as optional
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+      secrets.existingSecret: "buzz-secrets"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: READ_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: buzz-secrets
+                key: READ_DATABASE_URL
+                optional: true
+        template: templates/deployment.yaml
+
+  - it: READ_DATABASE_URL stays optional against the chart-managed Secret
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: READ_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-buzz-relay
+                key: READ_DATABASE_URL
+                optional: true
+        template: templates/deployment.yaml
+
   - it: RELAY_OWNER_PUBKEY env is set (not BUZZ_RELAY_OWNER_PUBKEY)
     set:
       relayUrl: wss://buzz.example.com

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -58,6 +58,7 @@ ownerPubkey: ""
 #   BUZZ_RELAY_PRIVATE_KEY        — 64-char hex; relay identity (rotation = identity change)
 #   BUZZ_GIT_HOOK_HMAC_SECRET     — 32+ chars; required when replicaCount > 1
 #   DATABASE_URL                  — full Postgres URL (preferred over externalPostgresql.url)
+#   READ_DATABASE_URL             — optional Postgres read-replica URL; omit to keep all reads on the writer
 #   REDIS_URL                     — full Redis URL with auth
 #   BUZZ_S3_ACCESS_KEY            — S3 access key
 #   BUZZ_S3_SECRET_KEY            — S3 secret key

--- a/migrations/0021_created_at_fence_floor.sql
+++ b/migrations/0021_created_at_fence_floor.sql
@@ -1,0 +1,67 @@
+-- Replica-fence floor: make the ingest-time created_at envelope a commit-time
+-- storage invariant for channel-window rows.
+--
+-- Why: cursor (keyset) pages may be served by a read replica behind a
+-- "fence" timestamp. The fence proof requires that once a replica has
+-- replayed past a sampled writer LSN, no transaction can later commit an
+-- events row whose created_at is older than (commit time - floor). The
+-- ingest handler checks |created_at - now| <= 900s at acceptance time, but
+-- acceptance and commit are separated by unbounded async work, and several
+-- writers (workflow sink, side effects, replace_*) bypass ingest entirely.
+--
+-- Mechanism: a DEFERRABLE INITIALLY DEFERRED constraint trigger runs inside
+-- COMMIT processing, re-evaluating clock_timestamp() (NOT now(), which is
+-- frozen at transaction start) so the bound is measured at commit, not at
+-- INSERT. A transaction that holds an old-created_at insert open past the
+-- floor budget is aborted at COMMIT and can never introduce a below-fence
+-- row. Verified on PostgreSQL 16 against a partitioned table.
+--
+-- Scope: rows with channel_id IS NOT NULL — exactly the rows that channel
+-- windows and thread pagination serve. channel_id-NULL rows (push leases,
+-- profile/discovery snapshots) legitimately carry client-signed historical
+-- timestamps and never appear in keyset-paged windows.
+--
+-- Enforcement is opt-in per session via the buzz.created_at_floor GUC
+-- (seconds). The relay's writer pool sets it on every connection
+-- (after_connect); when the GUC is unset or blank the guard is a no-op so
+-- pg_restore/backfills and test fixtures that legitimately write historical
+-- rows keep working. There is deliberately NO in-band bypass for
+-- channel-bearing rows (the only structural exemption is channel_id IS
+-- NULL, which never appears in keyset-paged windows): any operational
+-- backfill of channel rows must run on a connection without the GUC — i.e.
+-- outside the relay's writer pool — and the operator must hold the replica
+-- breaker closed from before the backfill transaction begins until its WAL
+-- is replayed on the replica (see Db::read routing docs). Disabling
+-- triggers via session_replication_role = replica (pg_restore) is likewise
+-- a breaker-closed operation.
+--
+-- Partition coverage: a constraint trigger created on the partitioned
+-- parent is cloned onto every existing partition and onto partitions
+-- created later (`CREATE TABLE .. PARTITION OF`), so partition rotation
+-- keeps the guard. Row-level triggers also fire for COPY. Coverage across
+-- the partition topology is asserted by a buzz-db test.
+
+CREATE FUNCTION events_created_at_floor_guard() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    floor_secs numeric := nullif(current_setting('buzz.created_at_floor', true), '')::numeric;
+BEGIN
+    IF floor_secs IS NOT NULL
+       AND floor_secs > 0
+       AND NEW.channel_id IS NOT NULL
+       AND NEW.created_at < clock_timestamp() - make_interval(secs => floor_secs)
+    THEN
+        RAISE EXCEPTION
+            'events.created_at % is more than % s before commit time %; below the replica-fence floor',
+            NEW.created_at, floor_secs, clock_timestamp()
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NULL;
+END
+$$;
+
+CREATE CONSTRAINT TRIGGER events_created_at_floor
+    AFTER INSERT ON events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION events_created_at_floor_guard();

--- a/migrations/0021_created_at_fence_floor.sql
+++ b/migrations/0021_created_at_fence_floor.sql
@@ -60,8 +60,15 @@ BEGIN
 END
 $$;
 
+-- INSERT OR UPDATE OF: an UPDATE can move a previously exempt row into the
+-- guarded set (channel_id NULL -> NOT NULL) or move a channel row's
+-- created_at below the fence, so both mutation paths re-run the guard on the
+-- NEW row. Partition-key note: a created_at rewrite that crosses partition
+-- bounds is executed as DELETE + INSERT, which fires the cloned AFTER INSERT
+-- guard on the destination partition; an in-partition rewrite fires the
+-- UPDATE OF arm. Either way the NEW row is checked.
 CREATE CONSTRAINT TRIGGER events_created_at_floor
-    AFTER INSERT ON events
+    AFTER INSERT OR UPDATE OF created_at, channel_id ON events
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW
     EXECUTE FUNCTION events_created_at_floor_guard();

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -867,8 +867,14 @@ BEGIN
 END
 $$;
 
+-- INSERT OR UPDATE OF: an UPDATE can move a previously exempt row into the
+-- guarded set (channel_id NULL -> NOT NULL) or move a channel row's
+-- created_at below the fence, so both mutation paths re-run the guard on the
+-- NEW row. A created_at rewrite that crosses partition bounds runs as
+-- DELETE + INSERT and hits the cloned AFTER INSERT guard on the destination
+-- partition; an in-partition rewrite fires the UPDATE OF arm.
 CREATE CONSTRAINT TRIGGER events_created_at_floor
-    AFTER INSERT ON events
+    AFTER INSERT OR UPDATE OF created_at, channel_id ON events
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW
     EXECUTE FUNCTION events_created_at_floor_guard();

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -837,6 +837,42 @@ CREATE TRIGGER events_enqueue_push_match
 AFTER INSERT ON events
 FOR EACH ROW EXECUTE FUNCTION enqueue_push_match_job();
 
+-- Replica-fence floor guard (keep in sync with migrations/0021). A deferred
+-- constraint trigger re-checks, inside COMMIT processing, that channel-bearing
+-- event rows are no older than `buzz.created_at_floor` seconds before commit
+-- time (clock_timestamp(), NOT the transaction-frozen now()). This turns the
+-- relay's ingest-time created_at envelope into a commit-time storage
+-- invariant, which is what lets keyset-cursor pages below the replica fence
+-- be served by a read replica without holes. Enforcement is armed per session
+-- via the GUC (set by the relay's writer pool on connect); sessions without
+-- the GUC (pg_restore, manual backfills) bypass it and must hold the replica
+-- fence closed for their duration. The only structural exemption is
+-- channel_id IS NULL: those rows never appear in keyset-paged windows.
+CREATE FUNCTION events_created_at_floor_guard() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    floor_secs numeric := nullif(current_setting('buzz.created_at_floor', true), '')::numeric;
+BEGIN
+    IF floor_secs IS NOT NULL
+       AND floor_secs > 0
+       AND NEW.channel_id IS NOT NULL
+       AND NEW.created_at < clock_timestamp() - make_interval(secs => floor_secs)
+    THEN
+        RAISE EXCEPTION
+            'events.created_at % is more than % s before commit time %; below the replica-fence floor',
+            NEW.created_at, floor_secs, clock_timestamp()
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NULL;
+END
+$$;
+
+CREATE CONSTRAINT TRIGGER events_created_at_floor
+    AFTER INSERT ON events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION events_created_at_floor_guard();
+
 -- Durable, deployment-global authority for the public NIP-PL push gateway.
 -- This state is intentionally outside relay community tenancy: installations
 -- delegate to relay signing keys and may authorize multiple relay deployments.

--- a/scripts/attach-schema-partitions.sql
+++ b/scripts/attach-schema-partitions.sql
@@ -14,10 +14,12 @@ BEGIN
         WHERE inhparent = 'events'::regclass
           AND inhrelid = 'events_p_past'::regclass
     ) THEN
-        -- pgschema may copy the parent trigger onto standalone children. Drop
-        -- that copy before ATTACH; PostgreSQL recreates inherited parent
-        -- triggers while attaching and rejects a same-named child trigger.
+        -- pgschema may copy parent triggers onto standalone children. Drop
+        -- those copies before ATTACH; PostgreSQL recreates inherited parent
+        -- triggers while attaching and rejects same-named child triggers
+        -- (both the push-match trigger and the replica-fence floor guard).
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p_past;
+        DROP TRIGGER IF EXISTS events_created_at_floor ON events_p_past;
         ALTER TABLE events ATTACH PARTITION events_p_past
             FOR VALUES FROM (MINVALUE) TO ('2026-01-01');
     END IF;
@@ -28,6 +30,7 @@ BEGIN
           AND inhrelid = 'events_p2026_01'::regclass
     ) THEN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_01;
+        DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_01;
         ALTER TABLE events ATTACH PARTITION events_p2026_01
             FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
     END IF;
@@ -38,6 +41,7 @@ BEGIN
           AND inhrelid = 'events_p2026_02'::regclass
     ) THEN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_02;
+        DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_02;
         ALTER TABLE events ATTACH PARTITION events_p2026_02
             FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
     END IF;
@@ -48,6 +52,7 @@ BEGIN
           AND inhrelid = 'events_p2026_03'::regclass
     ) THEN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_03;
+        DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_03;
         ALTER TABLE events ATTACH PARTITION events_p2026_03
             FOR VALUES FROM ('2026-03-01') TO ('2026-04-01');
     END IF;
@@ -58,6 +63,7 @@ BEGIN
           AND inhrelid = 'events_p2026_04'::regclass
     ) THEN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_04;
+        DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_04;
         ALTER TABLE events ATTACH PARTITION events_p2026_04
             FOR VALUES FROM ('2026-04-01') TO ('2026-05-01');
     END IF;
@@ -68,6 +74,7 @@ BEGIN
           AND inhrelid = 'events_p2026_05'::regclass
     ) THEN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_05;
+        DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_05;
         ALTER TABLE events ATTACH PARTITION events_p2026_05
             FOR VALUES FROM ('2026-05-01') TO ('2026-06-01');
     END IF;
@@ -78,6 +85,7 @@ BEGIN
           AND inhrelid = 'events_p2026_06'::regclass
     ) THEN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_06;
+        DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_06;
         ALTER TABLE events ATTACH PARTITION events_p2026_06
             FOR VALUES FROM ('2026-06-01') TO ('2026-07-01');
     END IF;
@@ -88,6 +96,7 @@ BEGIN
           AND inhrelid = 'events_p_future'::regclass
     ) THEN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p_future;
+        DROP TRIGGER IF EXISTS events_created_at_floor ON events_p_future;
         ALTER TABLE events ATTACH PARTITION events_p_future
             FOR VALUES FROM ('2026-07-01') TO (MAXVALUE);
     END IF;


### PR DESCRIPTION
## What

When `READ_DATABASE_URL` is set (e.g. an Aurora `cluster-ro-` endpoint), three lag-tolerant read classes move off the writer — server-only, zero client changes, and **unset env is byte-for-byte today's behavior**:

1. **FTS search → replica.** The dedicated search pool prefers the replica URL. Search is lag-tolerant by construction and is the canary for replica traffic. Correctness backstop for free: replica FTS hits are re-fetched from the **writer** canonical store (`get_events_by_ids`) and re-authorized, so search can never surface an event the writer doesn't have.
2. **`Db::read()` seam.** Optional second `PgPool` with writer fallback when unconfigured. Zero call-site churn.
3. **Cursor-bearing pages → replica.** Channel scroll-back and thread pagination pass a keyset cursor over immutable history; cursor pages route to `read()`, head fetches (`cursor: None`) stay on the writer. **Terminal-page writer verification** for forward thread pagination: an under-`limit` replica page is a candidate EOF, so that one page re-runs on the writer — a lagged replica can never truncate a thread tail into a false EOF (per Perci's review of the design).

Scaling then becomes knobs we already have in bb-public (`num_read_replicas`, reader `instance_class`, Aurora reader autoscaling as follow-up) — capacity without touching the writer or the app.

## Observability

`buzz_db_read_pool_{size,idle,active,max}` Prometheus gauges (emitted only when the replica pool exists), startup log markers (`Postgres connected (writer + read replica)`, search `replica=true`).

## Testing

**Unit/integration** — divergent writer/replica fixtures make routing *observable*: a writer-only "fresh" event and a replica-only "marker" prove which pool served each page (head→writer, cursor→replica, writer terminal-page re-run, writer-fallback-when-unset). `buzz-db`: 80 unit + 106 Postgres-backed integration, all green at this head. `buzz-relay`: 687 passed, 1 failed — `mesh_demo::demo_join_forwarded_arm_round_trips_echo`, network-dependent, **reproduces on clean `origin/main` (ca384d082) in the same environment**; pre-existing, not this change.

**Live local (TESTING.md-style HARD pass, real data)** — restored a production-scale dump (598 MB, 780K events, sha256-verified) into a writer + replica pair, then deliberately diverged them (fresh relay writes land only on the writer; a marker row injected only into the replica — a frozen replica is a maximally-lagged reader). Relay with `READ_DATABASE_URL`, verified at the wire via CLI + raw `/query`:

- Head fetch → writer (fresh present, marker absent). Cursor walk of full channel history (11 pages) → replica (marker surfaced, zero writer-only leakage).
- Search → replica, dispositively: a writer-only event with a confirmed writer-side FTS match is missed by relay search (query ran on the replica); replica-only FTS hits are dropped by the writer re-fetch.
- Thread forward pagination under maximal lag (replica has zero thread rows, every page under-fills): all 14/14 writer-only replies collected, correct EOF, no false truncation — terminal-page re-verification working live.
- **Playwright GUI**: fresh-built bundle, scroll-back perf spec against the live relay — cursor pages fired through the real IntersectionObserver → keyset path; `pg_stat_database` deltas during the run show the replica serving the cursor pages.
- **Flag-off control**: same binary, no `READ_DATABASE_URL` — no read-pool gauges, no replica reads, head + 10-page walk fully served by the writer.

## Context

Part 1 of the read-scaling plan discussed in buzz-bb-block-deploy (Eva + Perci + Tyler). Head-fetch offload (overlap gate + SUBACK + cold-state writer bypass) stacks on the `Db::read()` seam later; nothing here blocks it.

## Deployment & operational tradeoffs

- **Enablement (Helm):** the chart injects `READ_DATABASE_URL` as an *optional* `secretKeyRef` on the relay Deployment. Add the key to the release secret (chart-managed or `secrets.existingSecret`) to enable routing; omit it and the env is unset = routing disabled = exactly prior behavior. Render tests cover both secret modes. Documented in `values.yaml`, `examples/secret-sample.yaml`, and `.env.example`.
- **No transparent mid-query failover:** if the replica dies while serving a routed cursor/search query, that in-flight query errors rather than silently retrying on the writer. Subsequent cursor traffic returns to the writer via fence closure; search remains bound to its configured endpoint. Deliberate: retry-on-writer would double worst-case load exactly when the database tier is already unhealthy.
- **Replica connection ceiling:** with a reader configured, a pod can open up to 20 (read pool) + 10 (search pool, SQLx default) = 30 connections to the replica endpoint, alongside writer 20 + audit 5. Capacity-check `max_connections` on the reader instance class against pod count before rollout.

(Both tradeoffs surfaced in Max's independent red-team review; the chart gap it found is fixed in `c27baf384`.)
