### PR TITLE
fix(desktop): bound overlay scrollbars

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -676,6 +676,7 @@ export const ChannelPane = React.memo(function ChannelPane({
             messages={visibleMessages}
             firstUnreadMessageId={firstUnreadMessageId}
             unreadCount={unreadCount}
+            composerOverlayRef={composerWrapperRef}
             onDelete={onDelete}
             onEdit={onEdit}
             onMarkUnread={onMarkUnread}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -23,9 +23,9 @@ import type { ThreadPanelLayoutProps } from "@/features/channels/lib/threadPanel
 import { useEscapeKey } from "@/shared/hooks/useEscapeKey";
 import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
 import { cn } from "@/shared/lib/cn";
-import { AuxiliaryPanel } from "@/shared/layout/AuxiliaryPanel";
-import { AuxiliaryPanelBody } from "@/shared/layout/AuxiliaryPanel";
 import {
+  AuxiliaryPanel,
+  AuxiliaryPanelBody,
   AuxiliaryPanelHeader,
   AuxiliaryPanelHeaderGroup,
   AuxiliaryPanelTitle,
@@ -35,6 +35,7 @@ import {
   THREAD_PANEL_COMPOSER_GUTTER_CLASS,
   THREAD_PANEL_MESSAGE_GUTTER_CLASS,
 } from "@/features/messages/lib/messageThreadPanelLayout";
+import { OverlayScrollbar } from "@/shared/ui/OverlayScrollbar";
 import { Button } from "@/shared/ui/button";
 import { Separator } from "@/shared/ui/separator";
 import type { VideoReviewContext } from "@/shared/ui/VideoPlayer";
@@ -541,7 +542,7 @@ export function MessageThreadPanel({
 
   const threadScrollRegion = (
     <AuxiliaryPanelBody
-      className="overflow-y-auto overflow-x-hidden overscroll-contain pb-24"
+      className="buzz-content-scrollbar overflow-y-auto overflow-x-hidden overscroll-contain pb-24"
       data-buzz-conversation-scroll
       data-testid="message-thread-body"
       onScroll={onScroll}
@@ -949,7 +950,13 @@ export function MessageThreadPanel({
       transparentChrome={transparentChrome}
       widthPx={widthPx}
     >
-      {threadScrollRegion}
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        {threadScrollRegion}
+        <OverlayScrollbar
+          composerRef={threadComposerWrapperRef}
+          scrollRef={threadBodyRef}
+        />
+      </div>
     </AuxiliaryPanel>
   );
 }

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -15,6 +15,7 @@ import type { ChannelType } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { channelChrome } from "@/shared/layout/chromeLayout";
 import { Spinner } from "@/shared/ui/spinner";
+import { OverlayScrollbar } from "@/shared/ui/OverlayScrollbar";
 import { TooltipProvider } from "@/shared/ui/tooltip";
 import { UnreadPill, unreadCountLabel } from "@/shared/ui/UnreadPill";
 import { ChannelIntroBlock, type ChannelIntro } from "./ChannelIntroBlock";
@@ -68,6 +69,8 @@ type MessageTimelineProps = {
   /** Optional external ref to the scroll container — used by the parent to
    *  observe scroll position or adjust padding dynamically. */
   scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
+  /** Composer overlay used to bound the custom scrollbar above the dock. */
+  composerOverlayRef?: React.RefObject<HTMLElement | null>;
   /** True when the timeline has the composer overlay below it. */
   hasComposerOverlay?: boolean;
   isFetchingOlder?: boolean;
@@ -187,6 +190,7 @@ const MessageTimelineBase = React.forwardRef<
     onToggleReaction,
     unfollowThreadById,
     scrollContainerRef: externalScrollRef,
+    composerOverlayRef,
     searchActiveMessageId = null,
     searchMatchingMessageIds,
     searchQuery,
@@ -700,6 +704,7 @@ const MessageTimelineBase = React.forwardRef<
             (!useTimelineVirtualizer || !showMessageList) &&
               cn(
                 "overflow-y-auto overflow-x-hidden overscroll-contain px-2 pt-1",
+                "buzz-content-scrollbar",
                 hasComposerOverlay
                   ? "pb-[var(--composer-overlay-height,6rem)]"
                   : "pb-4",
@@ -823,6 +828,14 @@ const MessageTimelineBase = React.forwardRef<
             </div>
           )}
         </div>
+
+        {composerOverlayRef ? (
+          <OverlayScrollbar
+            composerRef={composerOverlayRef}
+            resetKey={`${scrollContainerDomKey}:${hasComposerOverlay}`}
+            scrollRef={activeScrollContainerRef}
+          />
+        ) : null}
 
         {!isAtBottom ? (
           <div

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -568,7 +568,7 @@ function VirtualizedTimelineRows({
       <PreserveVirtualizedItemVisibilityContext value={isPrepend}>
         <VList
           ref={listRef}
-          className="h-full min-h-0 w-full overflow-y-auto overflow-x-hidden overscroll-contain px-2 pt-[var(--channel-top-chrome-height,4.5rem)]"
+          className="buzz-content-scrollbar h-full min-h-0 w-full overflow-y-auto overflow-x-hidden overscroll-contain px-2 pt-[var(--channel-top-chrome-height,4.5rem)]"
           data={items}
           item={VirtualizedTimelineItemShell}
           itemSize={estimateItemSize}

--- a/desktop/src/shared/hooks/useOverlayScrollbar.test.mjs
+++ b/desktop/src/shared/hooks/useOverlayScrollbar.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  acquireBodySelectionLock,
+  calculateOverlayScrollbarGeometry,
+  calculateScrollTopFromThumbDrag,
+} from "./useOverlayScrollbar.ts";
+
+test("restores selection after overlapping drags finish in either order", () => {
+  for (const releaseOrder of ["first-first", "second-first"]) {
+    const style = { userSelect: "text" };
+    const releaseFirstDrag = acquireBodySelectionLock(style);
+    const releaseSecondDrag = acquireBodySelectionLock(style);
+
+    assert.equal(style.userSelect, "none");
+
+    if (releaseOrder === "first-first") {
+      releaseFirstDrag();
+      assert.equal(style.userSelect, "none");
+      releaseSecondDrag();
+    } else {
+      releaseSecondDrag();
+      assert.equal(style.userSelect, "none");
+      releaseFirstDrag();
+    }
+
+    assert.equal(style.userSelect, "text");
+  }
+});
+
+test("selection lock release is idempotent across finish and cleanup", () => {
+  const style = { userSelect: "contain" };
+  const releaseDrag = acquireBodySelectionLock(style);
+
+  releaseDrag();
+  releaseDrag();
+
+  assert.equal(style.userSelect, "contain");
+
+  const releaseNextDrag = acquireBodySelectionLock(style);
+  assert.equal(style.userSelect, "none");
+  releaseNextDrag();
+  assert.equal(style.userSelect, "contain");
+});
+
+test("bounds the thumb above the composer at maximum scroll", () => {
+  for (const bottomInset of [64, 96, 180]) {
+    const clientHeight = 600;
+    const scrollHeight = 3_000;
+    const geometry = calculateOverlayScrollbarGeometry({
+      bottomInset,
+      clientHeight,
+      scrollHeight,
+      scrollTop: scrollHeight - clientHeight,
+    });
+
+    assert.ok(geometry);
+    assert.equal(geometry.trackHeight, clientHeight - bottomInset);
+    assert.equal(
+      geometry.thumbOffset + geometry.thumbHeight,
+      geometry.trackHeight,
+    );
+  }
+});
+
+test("uses a minimum grab target without exceeding the bounded track", () => {
+  const geometry = calculateOverlayScrollbarGeometry({
+    bottomInset: 120,
+    clientHeight: 400,
+    scrollHeight: 40_000,
+    scrollTop: 20_000,
+  });
+
+  assert.ok(geometry);
+  assert.equal(geometry.thumbHeight, 24);
+  assert.ok(geometry.thumbOffset >= 0);
+  assert.ok(
+    geometry.thumbOffset + geometry.thumbHeight <= geometry.trackHeight,
+  );
+});
+
+test("clamps overscrolled positions into the available thumb travel", () => {
+  const beforeStart = calculateOverlayScrollbarGeometry({
+    bottomInset: 100,
+    clientHeight: 500,
+    scrollHeight: 2_000,
+    scrollTop: -50,
+  });
+  const afterEnd = calculateOverlayScrollbarGeometry({
+    bottomInset: 100,
+    clientHeight: 500,
+    scrollHeight: 2_000,
+    scrollTop: 2_000,
+  });
+
+  assert.ok(beforeStart);
+  assert.ok(afterEnd);
+  assert.equal(beforeStart.thumbOffset, 0);
+  assert.equal(afterEnd.thumbOffset, afterEnd.maxThumbOffset);
+});
+
+test("hides when content does not overflow or the visible track is too small", () => {
+  assert.equal(
+    calculateOverlayScrollbarGeometry({
+      bottomInset: 100,
+      clientHeight: 500,
+      scrollHeight: 500,
+      scrollTop: 0,
+    }),
+    null,
+  );
+  assert.equal(
+    calculateOverlayScrollbarGeometry({
+      bottomInset: 480,
+      clientHeight: 500,
+      scrollHeight: 2_000,
+      scrollTop: 0,
+    }),
+    null,
+  );
+});
+
+test("maps a full bounded-thumb drag across the full scroll range", () => {
+  const geometry = calculateOverlayScrollbarGeometry({
+    bottomInset: 120,
+    clientHeight: 600,
+    scrollHeight: 3_000,
+    scrollTop: 0,
+  });
+
+  assert.ok(geometry);
+  assert.equal(
+    calculateScrollTopFromThumbDrag({
+      deltaY: geometry.maxThumbOffset,
+      dragStartScrollTop: 0,
+      maxThumbOffset: geometry.maxThumbOffset,
+      scrollRange: geometry.scrollRange,
+    }),
+    geometry.scrollRange,
+  );
+});
+
+test("clamps thumb drags at both ends of the scroll range", () => {
+  assert.equal(
+    calculateScrollTopFromThumbDrag({
+      deltaY: -1_000,
+      dragStartScrollTop: 300,
+      maxThumbOffset: 200,
+      scrollRange: 1_500,
+    }),
+    0,
+  );
+  assert.equal(
+    calculateScrollTopFromThumbDrag({
+      deltaY: 1_000,
+      dragStartScrollTop: 300,
+      maxThumbOffset: 200,
+      scrollRange: 1_500,
+    }),
+    1_500,
+  );
+});

--- a/desktop/src/shared/hooks/useOverlayScrollbar.ts
+++ b/desktop/src/shared/hooks/useOverlayScrollbar.ts
@@ -1,0 +1,284 @@
+import * as React from "react";
+
+const MIN_THUMB_HEIGHT = 24;
+const IDLE_FADE_DELAY_MS = 700;
+
+type UserSelectStyle = {
+  userSelect: string;
+};
+
+let bodySelectionLockCount = 0;
+let bodySelectionLockStyle: UserSelectStyle | null = null;
+let bodySelectionPreviousValue = "";
+
+/**
+ * Disables body text selection until every overlapping scrollbar drag releases
+ * its lock. The returned release function is safe to call more than once.
+ */
+export function acquireBodySelectionLock(
+  style: UserSelectStyle = document.body.style,
+): () => void {
+  if (bodySelectionLockCount === 0) {
+    bodySelectionLockStyle = style;
+    bodySelectionPreviousValue = style.userSelect;
+    style.userSelect = "none";
+  }
+  bodySelectionLockCount += 1;
+
+  let isReleased = false;
+  return () => {
+    if (isReleased) return;
+    isReleased = true;
+    bodySelectionLockCount -= 1;
+
+    if (bodySelectionLockCount === 0) {
+      if (bodySelectionLockStyle) {
+        bodySelectionLockStyle.userSelect = bodySelectionPreviousValue;
+      }
+      bodySelectionLockStyle = null;
+      bodySelectionPreviousValue = "";
+    }
+  };
+}
+
+export type OverlayScrollbarGeometry = {
+  maxThumbOffset: number;
+  scrollRange: number;
+  thumbHeight: number;
+  thumbOffset: number;
+  trackHeight: number;
+};
+
+type OverlayScrollbarGeometryInput = {
+  bottomInset: number;
+  clientHeight: number;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+type OverlayScrollbarDragInput = {
+  deltaY: number;
+  dragStartScrollTop: number;
+  maxThumbOffset: number;
+  scrollRange: number;
+};
+
+export function calculateOverlayScrollbarGeometry({
+  bottomInset,
+  clientHeight,
+  scrollHeight,
+  scrollTop,
+}: OverlayScrollbarGeometryInput): OverlayScrollbarGeometry | null {
+  const scrollRange = scrollHeight - clientHeight;
+  const trackHeight = clientHeight - Math.max(0, bottomInset);
+  if (scrollRange <= 0 || trackHeight <= MIN_THUMB_HEIGHT) {
+    return null;
+  }
+
+  const thumbHeight = Math.min(
+    trackHeight,
+    Math.max(MIN_THUMB_HEIGHT, (clientHeight / scrollHeight) * trackHeight),
+  );
+  const maxThumbOffset = trackHeight - thumbHeight;
+  const clampedScrollTop = Math.min(Math.max(scrollTop, 0), scrollRange);
+  const thumbOffset = (clampedScrollTop / scrollRange) * maxThumbOffset;
+
+  return {
+    maxThumbOffset,
+    scrollRange,
+    thumbHeight,
+    thumbOffset,
+    trackHeight,
+  };
+}
+
+export function calculateScrollTopFromThumbDrag({
+  deltaY,
+  dragStartScrollTop,
+  maxThumbOffset,
+  scrollRange,
+}: OverlayScrollbarDragInput): number {
+  if (maxThumbOffset <= 0 || scrollRange <= 0) {
+    return Math.min(Math.max(dragStartScrollTop, 0), Math.max(scrollRange, 0));
+  }
+
+  const scrollDelta = (deltaY / maxThumbOffset) * scrollRange;
+  return Math.min(Math.max(dragStartScrollTop + scrollDelta, 0), scrollRange);
+}
+
+type UseOverlayScrollbarOptions = {
+  composerRef: React.RefObject<HTMLElement | null>;
+  resetKey?: unknown;
+  scrollRef: React.RefObject<HTMLElement | null>;
+  thumbRef: React.RefObject<HTMLDivElement | null>;
+};
+
+export function useOverlayScrollbar({
+  composerRef,
+  resetKey,
+  scrollRef,
+  thumbRef,
+}: UseOverlayScrollbarOptions) {
+  React.useEffect(() => {
+    void resetKey;
+    const scrollElement = scrollRef.current;
+    const thumbElement = thumbRef.current;
+    if (!scrollElement || !thumbElement) return;
+
+    let fadeTimer: ReturnType<typeof setTimeout> | null = null;
+    let isDragging = false;
+    let isHovering = false;
+    let dragPointerId: number | null = null;
+    let dragStartY = 0;
+    let dragStartScrollTop = 0;
+    let releaseBodySelectionLock: (() => void) | null = null;
+
+    const clearFadeTimer = () => {
+      if (fadeTimer !== null) {
+        globalThis.clearTimeout(fadeTimer);
+        fadeTimer = null;
+      }
+    };
+
+    const hideThumb = () => {
+      clearFadeTimer();
+      thumbElement.style.opacity = "0";
+      thumbElement.style.pointerEvents = "none";
+    };
+
+    const updateGeometry = (): OverlayScrollbarGeometry | null => {
+      const geometry = calculateOverlayScrollbarGeometry({
+        bottomInset: composerRef.current?.getBoundingClientRect().height ?? 0,
+        clientHeight: scrollElement.clientHeight,
+        scrollHeight: scrollElement.scrollHeight,
+        scrollTop: scrollElement.scrollTop,
+      });
+      if (!geometry) {
+        hideThumb();
+        return null;
+      }
+
+      thumbElement.style.height = `${geometry.thumbHeight}px`;
+      thumbElement.style.transform = `translateY(${geometry.thumbOffset}px)`;
+      thumbElement.style.pointerEvents = "auto";
+      return geometry;
+    };
+
+    const scheduleFade = () => {
+      clearFadeTimer();
+      if (isDragging || isHovering) return;
+      fadeTimer = globalThis.setTimeout(() => {
+        thumbElement.style.opacity = "0";
+        fadeTimer = null;
+      }, IDLE_FADE_DELAY_MS);
+    };
+
+    const showThumb = () => {
+      if (!updateGeometry()) return;
+      thumbElement.style.opacity = "1";
+      scheduleFade();
+    };
+
+    const restoreSelection = () => {
+      releaseBodySelectionLock?.();
+      releaseBodySelectionLock = null;
+    };
+
+    const finishDrag = (pointerId: number) => {
+      if (!isDragging || pointerId !== dragPointerId) return;
+      isDragging = false;
+      dragPointerId = null;
+      if (thumbElement.hasPointerCapture(pointerId)) {
+        thumbElement.releasePointerCapture(pointerId);
+      }
+      restoreSelection();
+      scheduleFade();
+    };
+
+    const handleScroll = () => showThumb();
+    const handlePointerEnter = () => {
+      isHovering = true;
+      clearFadeTimer();
+      showThumb();
+    };
+    const handlePointerLeave = () => {
+      isHovering = false;
+      scheduleFade();
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      if (isDragging || event.button !== 0 || !updateGeometry()) return;
+      event.preventDefault();
+      event.stopPropagation();
+      isDragging = true;
+      dragPointerId = event.pointerId;
+      dragStartY = event.clientY;
+      dragStartScrollTop = scrollElement.scrollTop;
+      releaseBodySelectionLock = acquireBodySelectionLock();
+      thumbElement.setPointerCapture(event.pointerId);
+      clearFadeTimer();
+      thumbElement.style.opacity = "1";
+    };
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!isDragging || event.pointerId !== dragPointerId) return;
+      const geometry = updateGeometry();
+      if (!geometry || geometry.maxThumbOffset <= 0) return;
+      scrollElement.scrollTop = calculateScrollTopFromThumbDrag({
+        deltaY: event.clientY - dragStartY,
+        dragStartScrollTop,
+        maxThumbOffset: geometry.maxThumbOffset,
+        scrollRange: geometry.scrollRange,
+      });
+      thumbElement.style.opacity = "1";
+    };
+    const handlePointerUp = (event: PointerEvent) =>
+      finishDrag(event.pointerId);
+    const handleLostPointerCapture = (event: PointerEvent) =>
+      finishDrag(event.pointerId);
+
+    scrollElement.addEventListener("scroll", handleScroll, { passive: true });
+    // Match the sidebar scrollbar: entering anywhere in the scrollable pane
+    // reveals the thumb, so a short thumb does not need to be found while it
+    // is transparent.
+    scrollElement.addEventListener("pointerenter", handlePointerEnter);
+    scrollElement.addEventListener("pointerleave", handlePointerLeave);
+    thumbElement.addEventListener("pointerenter", handlePointerEnter);
+    thumbElement.addEventListener("pointerleave", handlePointerLeave);
+    thumbElement.addEventListener("pointerdown", handlePointerDown);
+    thumbElement.addEventListener("pointermove", handlePointerMove);
+    thumbElement.addEventListener("pointerup", handlePointerUp);
+    thumbElement.addEventListener("pointercancel", handlePointerUp);
+    thumbElement.addEventListener(
+      "lostpointercapture",
+      handleLostPointerCapture,
+    );
+
+    const resizeObserver = new ResizeObserver(showThumb);
+    resizeObserver.observe(scrollElement);
+    // Virtua owns measurement of its resizing inner content. Observing that
+    // same node here disrupts its prepend-anchor delivery order.
+    if (composerRef.current) {
+      resizeObserver.observe(composerRef.current);
+    }
+
+    showThumb();
+
+    return () => {
+      clearFadeTimer();
+      resizeObserver.disconnect();
+      scrollElement.removeEventListener("scroll", handleScroll);
+      scrollElement.removeEventListener("pointerenter", handlePointerEnter);
+      scrollElement.removeEventListener("pointerleave", handlePointerLeave);
+      thumbElement.removeEventListener("pointerenter", handlePointerEnter);
+      thumbElement.removeEventListener("pointerleave", handlePointerLeave);
+      thumbElement.removeEventListener("pointerdown", handlePointerDown);
+      thumbElement.removeEventListener("pointermove", handlePointerMove);
+      thumbElement.removeEventListener("pointerup", handlePointerUp);
+      thumbElement.removeEventListener("pointercancel", handlePointerUp);
+      thumbElement.removeEventListener(
+        "lostpointercapture",
+        handleLostPointerCapture,
+      );
+      restoreSelection();
+    };
+  }, [composerRef, resetKey, scrollRef, thumbRef]);
+}

--- a/desktop/src/shared/ui/OverlayScrollbar.tsx
+++ b/desktop/src/shared/ui/OverlayScrollbar.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+import { useOverlayScrollbar } from "@/shared/hooks/useOverlayScrollbar";
+
+type OverlayScrollbarProps = {
+  composerRef: React.RefObject<HTMLElement | null>;
+  resetKey?: unknown;
+  scrollElement?: HTMLElement | null;
+  scrollRef?: React.RefObject<HTMLElement | null>;
+};
+
+export function OverlayScrollbar({
+  composerRef,
+  resetKey,
+  scrollElement,
+  scrollRef,
+}: OverlayScrollbarProps) {
+  const thumbRef = React.useRef<HTMLDivElement>(null);
+  const scrollElementRef = React.useMemo(
+    () => ({ current: scrollElement ?? null }),
+    [scrollElement],
+  );
+  useOverlayScrollbar({
+    composerRef,
+    resetKey,
+    scrollRef: scrollRef ?? scrollElementRef,
+    thumbRef,
+  });
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute right-[3px] top-0 z-50 w-2 touch-none rounded-full bg-border/80 opacity-0 transition-opacity duration-200"
+      data-buzz-overlay-scrollbar
+      ref={thumbRef}
+    />
+  );
+}

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -954,6 +954,63 @@ test("opens a single-level thread panel with inline expansion", async ({
   ).toHaveCount(0);
 });
 
+test("reveals a short thread scrollbar when hovering anywhere in the pane", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+
+  const threadHeadId = await page.evaluate(() => {
+    const threadHead = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "general",
+      content: "Scrollbar pane-hover thread",
+      createdAt: 1_710_000_000,
+    });
+    if (!threadHead) throw new Error("Failed to seed thread head");
+
+    for (let index = 0; index < 40; index += 1) {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content: `Scrollbar pane-hover reply ${index}`,
+        createdAt: 1_710_000_001 + index,
+        parentEventId: threadHead.id,
+      });
+    }
+
+    return threadHead.id;
+  });
+
+  await page.getByTestId("channel-general").click();
+  const threadSummary = page.locator(
+    `[data-testid="message-thread-summary"][data-thread-head-id="${threadHeadId}"]`,
+  );
+  await expect(threadSummary).toBeVisible();
+  await threadSummary.click();
+
+  const threadPanel = page.getByTestId("message-thread-panel");
+  const threadBody = threadPanel.getByTestId("message-thread-body");
+  const scrollbarThumb = threadPanel.locator("[data-buzz-overlay-scrollbar]");
+  await expect
+    .poll(() =>
+      threadBody.evaluate(
+        (element) => element.scrollHeight - element.clientHeight,
+      ),
+    )
+    .toBeGreaterThan(0);
+  await expect(scrollbarThumb).toHaveCSS("opacity", "0");
+
+  // Deliberately hover the message area, away from the narrow thumb gutter.
+  const threadBodyBox = await threadBody.boundingBox();
+  if (!threadBodyBox) throw new Error("Expected measurable thread body");
+  await page.mouse.move(
+    threadBodyBox.x + 20,
+    threadBodyBox.y + threadBodyBox.height / 2,
+  );
+  await expect(scrollbarThumb).toHaveCSS("opacity", "1");
+});
+
 test("thread panel width uses session storage and reset handle", async ({
   page,
 }) => {


### PR DESCRIPTION
## Why
Thread and main-timeline scrollbar thumbs can move behind the composer, making them impossible to grab, and dragging a small native thumb can select message text instead of scrolling.

## What
- Add a bounded overlay scrollbar for thread panels and main timelines, including virtualized timelines
- Reserve the composer height, enforce a minimum grab target, and map pointer drags across the full scroll range
- Reveal the thumb when the pointer enters anywhere in the scrollable pane, matching the sidebar behavior while retaining scroll-time visibility and idle fade
- Coordinate text-selection suppression across overlapping drags and restore it safely on release or cleanup
- Preserve the existing mouse cursor and avoid observing Virtua's inner measurement container so prepends retain their scroll anchor
- Add focused regression coverage for bounded geometry, drag clamping, concurrent selection-lock lifetimes, and pane-hover visibility

## Risk Assessment
Low to moderate — this is limited to desktop message scrolling and does not change message data or relay behavior. Reviewers should focus on pointer capture across mouse, pen, and touch hardware, pane-hover visibility, and composer resizing.

## Validation
- `just ci`
- Pre-push hooks: branch skew, organization policy, desktop checks/tests, Rust tests, Tauri tests, and mobile tests
- Focused pane-hover browser regression: pass
- Scroll-history and cascading-virtualization smoke regressions: 4/4 pass across two repetitions

Generated with Codex
