### PR TITLE
fix(desktop): only publish mesh status when node participates in shared compute

### DIFF
--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -6,9 +6,9 @@ use crate::{app_state::AppState, mesh_llm, relay};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-struct MeshSharingConfig {
-    enabled: bool,
-    model_id: String,
+pub(crate) struct MeshSharingConfig {
+    pub(crate) enabled: bool,
+    pub(crate) model_id: String,
     max_vram_gb: Option<u64>,
 }
 
@@ -31,7 +31,9 @@ fn save_mesh_sharing_config(app: &AppHandle, config: &MeshSharingConfig) -> Resu
     crate::managed_agents::atomic_write_json(&path, &payload)
 }
 
-fn load_mesh_sharing_config(app: &AppHandle) -> Result<Option<MeshSharingConfig>, String> {
+pub(crate) fn load_mesh_sharing_config(
+    app: &AppHandle,
+) -> Result<Option<MeshSharingConfig>, String> {
     let path = mesh_sharing_config_path(app)?;
     match std::fs::read(&path) {
         Ok(payload) => serde_json::from_slice(&payload)

--- a/desktop/src-tauri/src/mesh_llm/coordinator.rs
+++ b/desktop/src-tauri/src/mesh_llm/coordinator.rs
@@ -39,14 +39,24 @@ pub async fn start_coordinator(app: AppHandle) {
 
     let publisher_app = app.clone();
     let status_publisher = tokio::spawn(async move {
-        // Clear a stale serving status promptly after an app restart. Keep
-        // publishing while stopped too: serving nodes build their admission
-        // allowlist from fresh member statuses, so consumer-only identities
-        // must remain fresh even though they advertise no serving targets.
-        publish_current_status_once(&publisher_app, "startup").await;
+        // Only advertise presence when this node actually participates in
+        // shared compute. A desktop that never shares, has no relay-mesh agent,
+        // and runs no mesh runtime has nothing to serve and nobody to be fresh
+        // for — publishing its status is pure relay noise. Serving/consuming
+        // nodes still need consumer-only freshness for MeshLLM's admission
+        // allowlist, so we keep publishing (including the "stopped" heartbeat)
+        // whenever participation intent is present.
+        //
+        // Re-checked every iteration so enabling Share Compute or adding a
+        // relay-mesh agent starts publishing without an app restart.
+        if wants_status_publishing(&publisher_app).await {
+            publish_current_status_once(&publisher_app, "startup").await;
+        }
         loop {
             tokio::time::sleep(STATUS_PUBLISH_INTERVAL).await;
-            publish_current_status_once(&publisher_app, "heartbeat").await;
+            if wants_status_publishing(&publisher_app).await {
+                publish_current_status_once(&publisher_app, "heartbeat").await;
+            }
         }
     });
     let roster_app = app.clone();
@@ -194,6 +204,45 @@ async fn reconcile_roster(
         .map_err(|error| format!("mesh node restart after roster change failed: {error}"))?;
     *guard = Some(replacement);
     Ok(())
+}
+
+/// Whether this node should advertise its mesh status to the relay.
+///
+/// True when the node actually participates in shared compute:
+/// - a mesh runtime is live (serving or consuming), or
+/// - Share Compute is enabled in saved config, or
+/// - at least one managed agent uses the relay-mesh provider (intends to consume).
+///
+/// When none hold, the desktop has nothing to serve and nobody to stay fresh
+/// for, so publishing a status event is pure relay noise and is skipped.
+/// Re-evaluated on every heartbeat, so toggling Share Compute or adding a
+/// relay-mesh agent begins publishing without an app restart.
+async fn wants_status_publishing(app: &AppHandle) -> bool {
+    let state = app.state::<AppState>();
+
+    // A live runtime always participates (serve or client).
+    if state.mesh_llm_runtime.lock().await.is_some() {
+        return true;
+    }
+
+    // Share Compute opted in via saved config.
+    if let Ok(Some(config)) = crate::commands::mesh_llm::load_mesh_sharing_config(app) {
+        if config.enabled && !config.model_id.trim().is_empty() {
+            return true;
+        }
+    }
+
+    // Any managed agent configured to consume via the relay-mesh provider.
+    if let Ok(records) = crate::managed_agents::load_managed_agents(app) {
+        if records
+            .iter()
+            .any(|record| crate::managed_agents::relay_mesh_model_id(record).is_some())
+        {
+            return true;
+        }
+    }
+
+    false
 }
 
 pub(crate) async fn publish_current_status_once(app: &AppHandle, reason: &str) {


### PR DESCRIPTION
## Summary

Only publish mesh member-status to the relay when this node actually
participates in shared compute.

The mesh coordinator is spawned unconditionally at app launch (gated only by the
`mesh-llm` feature), and its status publisher advertised a signed member-status
event to the relay **every 45s for every mesh-llm desktop** — even one that never
shares, has no relay-mesh agent, and runs no mesh runtime. That is background
relay traffic and presence advertisement the user never asked for.

The mesh **runtime** (the `127.0.0.1` OpenAI ingress + iroh client node) is
already lazy — it only starts when Share Compute is enabled or an agent uses the
relay-mesh provider. This brings status publishing in line with that intent.

## Change

Gate the publisher on a new `wants_status_publishing()` check. Publish only when:

- a mesh runtime is live (serving or consuming), **or**
- Share Compute is enabled in saved config, **or**
- at least one managed agent uses the relay-mesh provider (intends to consume).

Re-checked on every heartbeat, so enabling Share Compute or adding a relay-mesh
agent starts publishing **without an app restart**.

## Why this is safe for admission freshness

MeshLLM serving nodes build their admission allowlist from *fresh* member
statuses, so consumer-only identities must stay fresh. That freshness only
matters for nodes that will actually serve or consume — and those cases are
exactly what the gate keeps publishing for (a relay-mesh agent counts as
intent-to-consume). A desktop with no runtime, no sharing, and no relay-mesh
agent has nothing to serve and nobody to be fresh for, so skipping its status is
pure noise reduction.

## Testing

- `cargo build` (desktop, `--features mesh-llm`), `cargo fmt --check`, and
  `cargo clippy` all clean.
- Behavior is a pure gate around an existing publish call; the runtime start
  paths are unchanged.

## Notes for reviewers

@tlongwell-block you own the coordinator / relay-mesh code — does the
participation gate match the admission-freshness contract you designed? Happy to
adjust the exact predicate (e.g. also require a resolved relay URL / active
workspace) if you'd prefer a stricter gate.
