### PR TITLE
fix(onboarding): stop the Welcome intro loop and the premature kickoff closer

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -42,6 +42,9 @@ For explicit changes to an existing personal agent, use `buzz agents draft-updat
 ### Callback Mentions
 
 - When you finish delegated work, you MUST `@mention` the delegator in your completion message. This is the #1 cause of stalled collaboration.
+- The callback hands work **back**: a completion, a blocker, or a question. Send it once. If the delegator said no callback is needed, don't send one.
+- **Never `@mention` anyone just to acknowledge, agree, confirm, or sign off.** A mention is a summons: it wakes that agent and obliges them to answer, so a tag costs a whole turn — it is not punctuation. "Understood", "standing by", and "I won't reply again" therefore do not end a conversation, they restart it, and two agents trading acknowledgments will loop until something external stops them.
+- **To acknowledge, use a reaction instead** — `buzz reactions add`. It signals you saw something and agree, costs nobody a turn, and leaves the thread quiet. Reach for it whenever your reply would be a bare "thanks" or "got it".
 
 ### Threading
 

--- a/desktop/src/features/onboarding/welcomeKickoff.test.mjs
+++ b/desktop/src/features/onboarding/welcomeKickoff.test.mjs
@@ -13,6 +13,7 @@ import {
   selectWelcomeKickoffIntroTeammates,
   waitForWelcomeKickoffBeat,
   waitForWelcomeTeammatesOnline,
+  welcomeKickoffAlreadyFinished,
   welcomeTeammateNeedsRestart,
 } from "./welcomeKickoff.ts";
 
@@ -168,8 +169,18 @@ test("kickoff coordinator preserves one task across rerenders and cancels on nav
   assert.ok(coordinator.begin("welcome"));
 });
 
+test("a clean kickoff posts no scripted closer", () => {
+  // The intros @mention the lead, which is the mandatory callback in
+  // base_prompt.md — so the lead is *guaranteed* to wake and reply in-thread.
+  // Scripting a CTA on top of that gave the user two closers, and the scripted
+  // one raced the intros and lost. The lead's live reply is the close now; the
+  // scripted closer is only for reporting a problem.
+  // See docs/welcome-kickoff-silent-failures.md.
+  assert.equal(buildWelcomeKickoffCloser([]), null);
+  assert.equal(buildWelcomeKickoffCloser([], []), null);
+});
+
 test("closer degrades coherently for partial and total startup failure", () => {
-  assert.match(buildWelcomeKickoffCloser([]), /What can we help you build/);
   assert.match(buildWelcomeKickoffCloser(["Honey"]), /Honey is having trouble/);
   assert.match(
     buildWelcomeKickoffCloser(["Honey", "Bumble"]),
@@ -427,6 +438,81 @@ test("intro replies reach the closer classification without the user opening the
     ).unresolved,
     [],
   );
+});
+
+// A clean kickoff posts no closer, so "already finished" can no longer be a
+// single marker lookup — the marker only exists when something went wrong. If
+// this regresses, the start effect re-arms on every revisit and restarts the
+// whole Welcome team each time the channel is opened.
+test("a clean kickoff reads as finished from the intros, with no closer marker", async () => {
+  const agentSet = { lead: fizz, teammates: [honey, bumble] };
+  const finished = await welcomeKickoffAlreadyFinished(
+    "channel-1",
+    kickoffOpener,
+    agentSet,
+    {
+      closerExists: async () => false,
+      fetchReplies: async () => ({
+        events: [
+          introReply("honey-intro", honey.pubkey, kickoffOpener.id),
+          introReply("bumble-intro", bumble.pubkey, kickoffOpener.id),
+        ],
+        nextCursor: null,
+      }),
+    },
+  );
+
+  assert.equal(finished, true);
+});
+
+test("a kickoff missing one intro is not finished", async () => {
+  const agentSet = { lead: fizz, teammates: [honey, bumble] };
+  const finished = await welcomeKickoffAlreadyFinished(
+    "channel-1",
+    kickoffOpener,
+    agentSet,
+    {
+      closerExists: async () => false,
+      fetchReplies: async () => ({
+        events: [introReply("honey-intro", honey.pubkey, kickoffOpener.id)],
+        nextCursor: null,
+      }),
+    },
+  );
+
+  assert.equal(finished, false);
+});
+
+test("a closer marker still short-circuits the finished check", async () => {
+  // The failure paths and the solo opener still carry the marker, so that
+  // evidence must keep working without a thread fetch at all.
+  let fetched = false;
+  const finished = await welcomeKickoffAlreadyFinished(
+    "channel-1",
+    kickoffOpener,
+    { lead: fizz, teammates: [honey, bumble] },
+    {
+      closerExists: async () => true,
+      fetchReplies: async () => {
+        fetched = true;
+        return { events: [], nextCursor: null };
+      },
+    },
+  );
+
+  assert.equal(finished, true);
+  assert.equal(fetched, false);
+});
+
+test("no opener means the kickoff has not finished", async () => {
+  const finished = await welcomeKickoffAlreadyFinished(
+    "channel-1",
+    null,
+    { lead: fizz, teammates: [honey, bumble] },
+    { closerExists: async () => false },
+  );
+
+  assert.equal(finished, false);
 });
 
 test("merging the opener subtree never double-counts an already-visible reply", () => {

--- a/desktop/src/features/onboarding/welcomeKickoff.test.mjs
+++ b/desktop/src/features/onboarding/welcomeKickoff.test.mjs
@@ -51,7 +51,27 @@ test("opener uses current agent names and requests bounded simultaneous intros",
   assert.match(opener, /@Honeybee and @Bumble/);
   assert.doesNotMatch(opener, /@@/);
   assert.match(opener, /sentence or two/);
-  assert.match(opener, /Don't start any work yet/);
+});
+
+test("opener carries no agent-steering instructions", () => {
+  // The opener is the first message a new user reads: it should read as a normal
+  // welcome, not as prompt engineering. The intro loop is fixed in the base
+  // prompt (`buzz-acp/src/base_prompt.md`), not here. Re-adding an anti-loop
+  // instruction is a product decision, not a quick fix — see
+  // docs/welcome-kickoff-silent-failures.md.
+  const opener = buildWelcomeKickoffOpener(fizz, [honey, bumble]);
+
+  assert.doesNotMatch(opener, /@mention/i);
+  assert.doesNotMatch(opener, /don't start any work/i);
+});
+
+test("solo opener has no mentions to loop on", () => {
+  // No teammates online: nothing delegated, so there is no callback to waive
+  // and the opener must not mention an agent at all.
+  const opener = buildWelcomeKickoffOpener(fizz, [], [honey, bumble], "morgan");
+
+  assert.match(opener, /Hi @morgan/);
+  assert.doesNotMatch(opener, /@Honey|@Bumble/);
 });
 
 test("teammates are not ready until every harness publishes online presence", () => {

--- a/desktop/src/features/onboarding/welcomeKickoff.ts
+++ b/desktop/src/features/onboarding/welcomeKickoff.ts
@@ -24,13 +24,25 @@ import {
 } from "@/shared/api/tauriManagedAgents";
 import { hasManagedAgentChannelMessageMarker } from "@/shared/api/tauriManagedAgentMessageMarkers";
 import { sendManagedAgentChannelMessage } from "@/shared/api/tauriManagedAgentMessages";
-import { getPresence, listManagedAgents } from "@/shared/api/tauri";
+import {
+  getPresence,
+  getThreadReplies,
+  listManagedAgents,
+} from "@/shared/api/tauri";
 import { getProfile } from "@/shared/api/tauriProfiles";
 import type { Channel, ManagedAgent, RelayEvent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { useQueryClient } from "@tanstack/react-query";
 
 export const WELCOME_KICKOFF_OPENER_MARKER = "buzz-welcome-kickoff.opener.v1";
+// Despite the name, presence does NOT mean "the kickoff finished": a clean team
+// kickoff posts no closer at all and is closed by the lead's own callback reply.
+// This marks only the paths that had something to say — a failed or delayed
+// teammate, or no team to wait for (the solo opener carries it too; see
+// `additionalMarkers` below). Ask `welcomeKickoffAlreadyFinished` whether a
+// kickoff is done: a marker needs a message to exist, so absence proves nothing.
+// The string stays as-is — renaming it strands the markers already on relays for
+// kickoffs that failed, and the dedupe below would let them report twice.
 export const WELCOME_KICKOFF_CLOSER_MARKER = "buzz-welcome-kickoff.closer.v1";
 export const WELCOME_KICKOFF_PROVIDER_MARKER =
   "buzz-welcome-kickoff.provider-required.v1";
@@ -87,8 +99,19 @@ const kickoffCoordinator = createWelcomeKickoffCoordinator();
 const closerInFlight = new Set<string>();
 const TEAMMATE_READY_POLL_MS = 250;
 const TEAMMATE_READY_WAIT_MS = 60_000;
-const TEAMMATE_INTRO_WAIT_MS = 15_000;
+// How long a teammate that is alive but silent gets before the closer reports it
+// as delayed. This budget has to cover a whole agent turn — wake on the p tag,
+// fetch context, run inference, shell out to `buzz messages send` — so it is
+// tens of seconds, not a UI beat. At 15s the closer reliably lost the race and
+// announced "taking longer than expected" seconds before the intros landed,
+// contradicting itself in front of a brand new user. A *crashed* teammate does
+// not wait this out: `failed` is read from agent status and closes immediately,
+// so this budget only covers the case where patience is the right answer.
+const TEAMMATE_INTRO_WAIT_MS = 60_000;
 const CLOSER_BEAT_MS = 3_000;
+// The intros are the first replies to the opener; this only has to be deep
+// enough to see them, not to page a real conversation.
+const INTRO_LOOKUP_LIMIT = 200;
 const closerAbortControllers = new Map<string, AbortController>();
 const closerTimeouts = new Map<
   string,
@@ -238,12 +261,24 @@ export async function waitForWelcomeKickoffBeat(options: {
   });
 }
 
+/**
+ * Build the closer, or `null` when nothing needs to be said.
+ *
+ * The scripted closer exists to report a *problem*: a teammate that crashed or
+ * hasn't spoken yet. A clean kickoff returns `null` and posts nothing, because
+ * the lead already closes the conversation itself — the intros `@mention` the
+ * lead (the mandatory callback in `buzz-acp/src/base_prompt.md`), which wakes it
+ * and it replies in-thread. Scripting a second CTA on top of that gave the user
+ * two closers, and the scripted one — fired on a timer, before the intros were
+ * in — was the one that could be wrong. See
+ * docs/welcome-kickoff-silent-failures.md.
+ */
 export function buildWelcomeKickoffCloser(
   failedNames: readonly string[],
   delayedNames: readonly string[] = [],
-) {
+): string | null {
   if (failedNames.length === 0 && delayedNames.length === 0) {
-    return WELCOME_KICKOFF_CTA;
+    return null;
   }
   if (failedNames.length === 1 && delayedNames.length === 0) {
     return `${failedNames[0]} is having trouble starting — you can check on them in Agents.\n\n${WELCOME_KICKOFF_CTA}`;
@@ -337,6 +372,48 @@ async function markerExists(channelId: string, marker: string) {
     marker,
     markerScope: "channel",
   });
+}
+
+/**
+ * Has the kickoff already run to completion in this channel?
+ *
+ * This used to be a single `closerMarker` lookup, which worked only because
+ * every kickoff ended in a scripted message we could tag. A clean kickoff now
+ * posts nothing, so there is no marker to find and the marker check alone would
+ * report "not finished" forever — re-arming the start effect and restarting the
+ * Welcome team on every single revisit.
+ *
+ * So fall back to the other durable, relay-side evidence that it finished: the
+ * opener's thread holds an intro from each teammate. Both signals are
+ * server-side, which is what makes this safe across app restarts and devices —
+ * a local latch would not be.
+ */
+export async function welcomeKickoffAlreadyFinished(
+  channelId: string,
+  opener: RelayEvent | null,
+  agentSet: WelcomeAgentSet,
+  options: {
+    closerExists?: (channelId: string) => Promise<boolean>;
+    fetchReplies?: typeof getThreadReplies;
+  } = {},
+) {
+  const closerExists =
+    options.closerExists ?? ((id: string) => markerExists(id, closerMarker));
+  const fetchReplies = options.fetchReplies ?? getThreadReplies;
+  if (await closerExists(channelId)) return true;
+  if (!opener) return false;
+  const { events } = await fetchReplies(opener.id, channelId, {
+    limit: INTRO_LOOKUP_LIMIT,
+    cursor: null,
+  });
+  const introAuthors = introAuthorsAfterOpener(
+    events,
+    opener,
+    agentSet.teammates,
+  );
+  return agentSet.teammates.every((agent) =>
+    introAuthors.has(normalizePubkey(agent.pubkey)),
+  );
 }
 
 export function welcomeTeammateNeedsRestart(
@@ -453,9 +530,14 @@ async function sendWelcomeKickoffCloser({
 }: {
   agentSet: WelcomeAgentSet;
   channelId: string;
-  content: string;
+  content: string | null;
   opener: RelayEvent;
 }) {
+  // A clean kickoff has nothing to report, so it posts nothing and the lead's
+  // own callback reply closes the thread. Enforced here rather than at the call
+  // sites so the delayed-teammate timer can't sneak a bare CTA out after the
+  // intros land and re-classify the kickoff as clean.
+  if (content === null) return;
   if (await markerExists(channelId, closerMarker)) return;
 
   await sendManagedAgentChannelMessage({
@@ -491,17 +573,24 @@ export function useWelcomeKickoff(
     () => markerEvent(channelEvents, openerMarker) ?? null,
     [channelEvents],
   );
-  // Retire the watch once the closer exists: the kickoff is resolved, so
-  // revisits to Welcome shouldn't keep refetching the subtree forever.
+  const agentSet = React.useMemo(
+    () =>
+      resolveWelcomeAgentSetForRelay(
+        managedAgentsQuery.data ?? [],
+        activeCommunity?.relayUrl,
+      ),
+    [activeCommunity?.relayUrl, managedAgentsQuery.data],
+  );
+  // Retire the watch once the kickoff is resolved, so revisits to Welcome don't
+  // keep refetching the subtree forever.
   //
-  // This has to be a latch rather than a plain derivation. The closer is a
-  // *thread reply* to the opener (see sendWelcomeKickoffCloser), so it never
-  // appears in `channelEvents` unless the user happened to open the thread —
-  // deriving from `channelEvents` meant this never retired at all. Deriving
-  // from `kickoffEvents` instead is self-referential: it gates the query that
-  // feeds it, so retiring would drop the evidence that justified retiring and
-  // (on a cache eviction) flip the query back on. Latching per channel keeps
-  // the decision one-way and stable.
+  // This has to be a latch rather than a plain derivation. The evidence lives in
+  // the opener's *thread*, so it never appears in `channelEvents` unless the user
+  // happened to open the thread — deriving from `channelEvents` meant this never
+  // retired at all. Deriving from `kickoffEvents` instead is self-referential: it
+  // gates the query that feeds it, so retiring would drop the evidence that
+  // justified retiring and (on a cache eviction) flip the query back on. Latching
+  // per channel keeps the decision one-way and stable.
   const [resolvedChannelId, setResolvedChannelId] = React.useState<
     string | null
   >(null);
@@ -516,19 +605,33 @@ export function useWelcomeKickoff(
   );
   React.useEffect(() => {
     if (!channelId || kickoffResolved) return;
-    if (markerEvent(kickoffEvents, closerMarker) == null) return;
+    // A closer only exists when something went wrong, so it can't be the only
+    // thing we latch on any more — a clean kickoff would never retire.
+    if (markerEvent(kickoffEvents, closerMarker) != null) {
+      setResolvedChannelId(channelId);
+      return;
+    }
+    if (!openerEvent || !agentSet) return;
+    const { failed, unresolved } = classifyWelcomeKickoffResolution(
+      kickoffEvents,
+      openerEvent,
+      agentSet,
+    );
+    // Every teammate introduced itself and none crashed: the choreography is
+    // done and the lead's callback reply is the close. Nothing further to post.
+    if (failed.length > 0 || unresolved.length > 0) return;
+    // Drop any pending delayed-teammate timer. `sendWelcomeKickoffCloser` would
+    // refuse to post a clean closer anyway, but leaving a timer armed against a
+    // finished kickoff is a trap for the next reader.
+    const pending = closerTimeouts.get(channelId);
+    if (pending) {
+      globalThis.clearTimeout(pending);
+      closerTimeouts.delete(channelId);
+    }
     setResolvedChannelId(channelId);
-  }, [channelId, kickoffEvents, kickoffResolved]);
+  }, [agentSet, channelId, kickoffEvents, kickoffResolved, openerEvent]);
   const channelEventsRef = React.useRef(kickoffEvents);
   channelEventsRef.current = kickoffEvents;
-  const agentSet = React.useMemo(
-    () =>
-      resolveWelcomeAgentSetForRelay(
-        managedAgentsQuery.data ?? [],
-        activeCommunity?.relayUrl,
-      ),
-    [activeCommunity?.relayUrl, managedAgentsQuery.data],
-  );
   const readiness = React.useMemo(
     () => resolveAgentReadiness(runtimesQuery.data ?? [], globalConfig),
     [globalConfig, runtimesQuery.data],
@@ -562,7 +665,13 @@ export function useWelcomeKickoff(
           teammates: [welcomeTeam[1], welcomeTeam[2]],
         };
 
-        if (await markerExists(channelId, closerMarker)) {
+        if (
+          await welcomeKickoffAlreadyFinished(
+            channelId,
+            markerEvent(channelEventsRef.current, openerMarker) ?? null,
+            resolvedAgentSet,
+          )
+        ) {
           return;
         }
         if (!readiness.ready) {

--- a/desktop/src/features/onboarding/welcomeKickoff.ts
+++ b/desktop/src/features/onboarding/welcomeKickoff.ts
@@ -159,7 +159,12 @@ export function buildWelcomeKickoffOpener(
     return `${greeting} Welcome to Buzz. This is your private home base, and I'm here${teammatePhrase} to help you get oriented or work through something you're building.\n\n${WELCOME_KICKOFF_CTA}`;
   }
 
-  return `${greeting} Welcome to Buzz. This is your private home base, and we're here to help you get oriented or work through something you're building.\n\n${introNames}, introduce ${introTeammates.length === 1 ? "yourself" : "yourselves"} in a sentence or two — share what you're good at and when to bring you in. Don't start any work yet.`;
+  // Deliberately carries no agent-steering instructions — no "don't @mention
+  // each other", no "don't start any work yet". This is the first message a new
+  // user reads, so it stays a normal welcome instead of advertising its own
+  // guardrails; the intro loop is fixed in the base prompt instead
+  // (`buzz-acp/src/base_prompt.md`). See docs/welcome-kickoff-silent-failures.md.
+  return `${greeting} Welcome to Buzz. This is your private home base, and we're here to help you get oriented or work through something you're building.\n\n${introNames}, introduce ${introTeammates.length === 1 ? "yourself" : "yourselves"} in a sentence or two. Share what you're good at and when to bring you in.`;
 }
 
 export function onlineWelcomeTeammates(

--- a/docs/welcome-kickoff-silent-failures.md
+++ b/docs/welcome-kickoff-silent-failures.md
@@ -3,11 +3,14 @@
 Status: **partly open.** The *perception* gap is handled (see below); the silent
 paths themselves are not. The [intro loop](#the-intro-loop-a-loud-failure) is
 mitigated as of 2026-07-18 by three bullets in the base prompt's Callback
-Mentions section — **not yet confirmed live against Codex.** Prompt is the only
-lever available: a structural cap was considered and rejected (see that section).
+Mentions section, and **confirmed live against Codex** — the chain terminated on
+its own at four replies. Prompt is the only lever available: a structural cap was
+considered and rejected (see that section). The
+[double closer](#the-closer-was-racing-a-message-it-could-not-beat) that the same
+run exposed is fixed as of 2026-07-18.
 Context: the Welcome-channel kickoff choreography
 (`desktop/src/features/onboarding/welcomeKickoff.ts`) where Fizz posts an
-opener, teammates introduce themselves in-thread, and Fizz posts a closer.
+opener and teammates introduce themselves in-thread.
 
 Two failure shapes live here: the **silent** ones (nobody speaks) and the
 **loud** one (nobody stops). They have opposite symptoms and the same root
@@ -51,7 +54,8 @@ that runs away.
 | 1 | Provider fallback ("connect to an AI provider in Settings…") | Readiness check fails before kickoff | Fizz (marker: `provider-required.v1`) |
 | 2 | Happy-path opener (mentions teammates, asks them to introduce themselves) | Team online | Fizz (marker: `opener.v1`) |
 | 3 | Degraded opener ("I'm here with Honey and Bumble…") | Fizz online, zero teammates online within 60s | Fizz (opener + closer markers, self-contained) |
-| 4 | Closer variants (clean / failed / slow teammate wording) | 3s beat after intros resolve, or 15s intro timeout | Fizz (marker: `closer.v1`) |
+| 4 | Closer variants (failed / slow teammate wording only — a clean kickoff posts nothing) | 3s beat after a teammate is seen crashed, or 60s intro timeout | Fizz (marker: `closer.v1`) |
+| 4b | The actual close on a clean kickoff | The intros `@mention` Fizz, waking it | Fizz, **LLM-generated** (no marker) |
 | 5 | Setup-mode nudge ("here's what you still need to configure") | Agent process spawns but its requirements check fails (e.g. missing API key) | The agent process itself (backend, buzz-acp setup-listener mode) |
 
 ## Silent paths (what the user CANNOT be told today)
@@ -293,14 +297,18 @@ new work — which needs a judgment call the harness can't currently make.
 
 ### Verification status
 
-- **Not verified live.** The prompt change is behavioral; only a real Codex
-  session on a fresh Welcome channel can confirm it. Prompt edits have no test
-  that can fail on a literal-minded model, so the desktop/Rust suites say
-  nothing about whether this works.
-- One run on 2026-07-18 went from 21+ replies to **2** (the two intros, no
-  loop) — but that run had the opener waiver in it too, so it is **confounded
-  and does not count as evidence for the base prompt**. It is the reason the
-  opener was reverted: the next run needs to isolate the variable.
+- **Verified live against Codex on 2026-07-18, with the base prompt as the only
+  variable** (the opener waiver was reverted first, precisely so this run would
+  isolate it). The chain terminated on its own: intros tagged `@Fizz` (the
+  legitimate `:44` callback), Fizz woke and replied once using plain narrative
+  names and **no tags**, so nobody woke and the chain ended at four replies. The
+  designed exit path is the one that fired.
+- An earlier run went from 21+ replies to 2, but it had the opener waiver in it
+  and is **confounded** — it does not count as evidence for the base prompt. It
+  is the reason the opener was reverted.
+- Prompt edits have no test that can fail on a literal-minded model, so the
+  desktop/Rust suites say nothing about whether this holds. One live run is
+  encouraging, not proof: n=1 on a sampled model.
 - Unit-tested only: the solo opener mentions no agent at all (pins the
   degraded path, which cannot loop by construction).
 
@@ -325,6 +333,95 @@ new work — which needs a judgment call the harness can't currently make.
   the end and is not. The wording targets "acknowledge, agree, confirm, or sign
   off", which reads terminal — but the boundary is a model judgment, and reading
   it too broadly converts this loud failure into the silent kind.
+
+## The closer was racing a message it could not beat
+
+Found in the same 2026-07-18 Codex run that cleared the intro loop. The user saw
+Fizz say *"Honey and Bumble are taking longer than expected"* — and then both
+intros landed one minute later, followed by Fizz closing again, properly. Two
+CTAs, and the wrong one came first.
+
+Neither symptom was a failure state. They were **one design conflict**:
+
+1. **The closer raced the intros on a 15s stopwatch.** `TEAMMATE_INTRO_WAIT_MS`
+   was `15_000`, plus a `CLOSER_BEAT_MS` 3s beat — about 18s for a teammate to
+   have an intro *published*. That has to cover a whole agent turn: wake on the p
+   tag, fetch context, run inference, shell out to `buzz messages send`. Real
+   turns run tens of seconds, so the closer reliably lost and announced a delay
+   that wasn't real. PR #2066 tightened this beat, which made it more likely, not
+   less.
+2. **The scripted closer could never be the last word.** The choreography assumed
+   it was. But the intros `@mention` Fizz — that is the *mandatory* callback in
+   `base_prompt.md:44`, since Fizz delegated the intros — so Fizz is **guaranteed**
+   to wake and reply after them. The choreography and the base prompt were
+   fighting: one scripted a final message, the other guaranteed a message after
+   it.
+
+Worth noting which one was better: Fizz's live reply ("bring us a project, bug,
+question, or half-formed idea and I'll route it or start building") beat the
+scripted CTA. It was contextual, and it was right about the state of the world.
+
+### The fix (landed 2026-07-18)
+
+**Let the guaranteed message be the close, and keep the script for problems only.**
+
+1. `buildWelcomeKickoffCloser` returns **`null`** for a clean kickoff — the
+   success state posts nothing. The failure variants (crashed teammate, slow
+   teammate) are unchanged and still carry the CTA, because there the user needs
+   both the bad news and a way forward.
+2. The `null` is enforced inside `sendWelcomeKickoffCloser`, not at the call
+   sites. There are two callers, and the delayed-teammate timer can fire *after*
+   the intros land and re-classify the kickoff as clean — the choke point stops
+   that stray timer from emitting a bare CTA.
+3. `TEAMMATE_INTRO_WAIT_MS` `15_000` → `60_000`, matching the presence wait. This
+   budget now only covers a teammate that is *alive but silent*, where patience is
+   the correct answer — a **crashed** teammate is read from agent status
+   (`failed`) and closes immediately, so real breakage is still reported fast.
+
+### The latch this broke, and why it needed a second signal
+
+The closer marker was doing quiet double duty: it was also the durable *"kickoff
+already finished"* signal, in two places — retiring the opener-thread watch, and
+the guard in the start effect that stops the choreography re-arming on revisit.
+A marker only exists if a **message** exists (`markerExists` resolves it by
+querying the relay for a tagged message), so "success posts nothing" silently
+means "success never latches". Left alone that would have:
+
+- refetched the opener subtree forever on every Welcome revisit — the exact bug
+  PR #2066 fixed; and worse,
+- **restarted the whole Welcome team every time the channel was opened**, because
+  the start effect's guard would never trip.
+
+So completion needs a second piece of evidence, and it has to be **relay-side** —
+a local latch would re-run on another device or after a reinstall.
+`welcomeKickoffAlreadyFinished` now reads: *closer marker exists* **OR** *the
+opener's thread holds an intro from every teammate*. Both are durable server-side
+facts. The marker still short-circuits first, so the failure paths and the solo
+opener (which carries both markers on one message) are untouched and cost no
+extra fetch.
+
+The in-memory latch stays a latch for the reason the original comment gives: the
+evidence lives in the subtree that the latch itself gates, so deriving it fresh
+each render is self-referential.
+
+### Residual risk
+
+- **The CTA is now model-generated on the happy path.** If Fizz wakes and says
+  something that doesn't invite the user in, the kickoff ends softer than the
+  script did. The mitigation is `base_prompt.md:44` making the wake itself
+  guaranteed — but *what Fizz says* is not. This is the deliberate bet of the
+  change, and the thing to watch across runs.
+- **If Fizz doesn't reply at all, nothing closes.** The intros still landed, so
+  the channel is a usable welcome rather than an empty one — but there is no CTA
+  and no scripted backstop. A watchdog (wait N seconds for the lead's callback,
+  then post the scripted CTA) was considered and deliberately left out: it re-adds
+  the timer race this change removed. Revisit only if a run shows the lead going
+  quiet.
+- Unit tests pin the contract (`buildWelcomeKickoffCloser([])` is `null`; the
+  finished-check reads the intros with no marker; a marker short-circuits without
+  a fetch; a missing intro is not finished). What they **cannot** pin is whether a
+  real Fizz reliably produces a good close — same limitation as the intro-loop
+  fix.
 
 ## Constraints for the silent-path fix
 
@@ -391,3 +488,28 @@ new work — which needs a judgment call the harness can't currently make.
 - The two failure classes interact: silent-path work adds messages, and every
   new message is a potential wake. Any fallback that `@mentions` an agent to
   recover from a failure can itself seed a loop.
+- **Open thread panes can go stale while the reply count keeps climbing** — a
+  general bug, not a kickoff bug, but it shows up here because the intros are
+  thread replies. Observed repeatedly, including in the 2026-07-18 run. The cause
+  of the *asymmetry* is confirmed: the count and the list read from different
+  sources. The count is the relay's server-computed recount pushed as kind 39005
+  (`hooks.ts`, `channelWindowStore.ts` `mergeLiveThreadSummary`) — authoritative
+  and independent of the reply event itself. The list is a client-maintained cache
+  (`["thread-replies", channelId, rootId]`) appended to by parsing live events.
+  One is robust, the other is fragile, so they can disagree.
+
+  The specific trigger is **not** confirmed. Leading hypothesis: a refetch
+  overwrite race in `useThreadReplies.ts` — the query is `staleTime: 0`, and on
+  refetch it replaces the cache with the server's answer while preserving only
+  replies that arrived *during* the fetch (`receivedInFlight` is diffed against
+  `idsAtStart`). A live reply that landed just *before* a refetch, and that the
+  server's answer doesn't yet include, is dropped. Welcome refetches unusually
+  often because there are two observers on that cache entry (the pane's, plus
+  `welcomeKickoff.ts`'s opener-subtree watch). Fits every symptom, including why
+  close+reopen fixes it (the later fetch catches up). Ruled out for this case:
+  malformed `e` tags (the CLI/SDK emit proper NIP-10 markers) and root-key
+  divergence (the opener *is* the NIP-10 root).
+
+  Note the live-append branch that feeds the pane has **no test coverage at all**,
+  which is why this can regress quietly. Needs a repro test before a fix — don't
+  fix on the hypothesis.

--- a/docs/welcome-kickoff-silent-failures.md
+++ b/docs/welcome-kickoff-silent-failures.md
@@ -1,12 +1,19 @@
-# Welcome Kickoff — Silent Failure Paths
+# Welcome Kickoff — Failure Paths
 
-Status: **open** — the *perception* gap is handled (see below); the silent
-paths themselves are not. Documented for follow-up work.
+Status: **partly open.** The *perception* gap is handled (see below); the silent
+paths themselves are not. The [intro loop](#the-intro-loop-a-loud-failure) is
+mitigated as of 2026-07-18 by three bullets in the base prompt's Callback
+Mentions section — **not yet confirmed live against Codex.** Prompt is the only
+lever available: a structural cap was considered and rejected (see that section).
 Context: the Welcome-channel kickoff choreography
 (`desktop/src/features/onboarding/welcomeKickoff.ts`) where Fizz posts an
 opener, teammates introduce themselves in-thread, and Fizz posts a closer.
 
-## The problem
+Two failure shapes live here: the **silent** ones (nobody speaks) and the
+**loud** one (nobody stops). They have opposite symptoms and the same root
+cause — the kickoff assumes agent behavior it never constrains.
+
+## The silent-path problem
 
 Every fallback message in the kickoff assumes Fizz — the lead agent and
 sender — is alive and able to post. When Fizz itself fails, or an early step
@@ -34,7 +41,10 @@ real handling. Two things worth knowing before picking this up:
 
 ## Message inventory (what the user CAN receive today)
 
-All hard-coded client-side; only teammate intro replies are LLM-generated.
+All hard-coded client-side; only teammate intro replies are LLM-generated —
+which is exactly where the [intro loop](#the-intro-loop-a-loud-failure) lives.
+Everything the client authors is bounded; the one unbounded part is the part
+that runs away.
 
 | # | Message | Trigger | Sender |
 |---|---------|---------|--------|
@@ -65,7 +75,258 @@ All hard-coded client-side; only teammate intro replies are LLM-generated.
 Navigation away mid-kickoff also cancels silently, but that is intentional
 (the kickoff resumes on next visit) — not a failure.
 
-## Constraints for the fix
+## The intro loop (a loud failure)
+
+Observed 2026-07-18 with **Codex** as the provider: the intro thread never
+terminates. Fizz, Honey, and Bumble keep replying to each other — 21+ replies,
+each one an agent announcing it will now stop replying ("parked", "acknowledged",
+"I won't reply again unless there's a task for me"), each announcement waking the
+others. **Not reproduced with Claude Code.**
+
+### Why it loops
+
+The wake trigger is `p`-tag gated: an agent fires when a message mentions it
+(`require_mention`, default on — `crates/buzz-acp/src/filter.rs:390`). A reply
+adds `p` tags **only** for names explicitly `@`-mentioned in its body
+(`buzz-sdk/src/builders.rs:218`; threading itself contributes `e` tags only). So
+mentioning a teammate — for any reason, including to say goodbye — is
+indistinguishable from summoning them.
+
+Two unconditional rules in the shared base prompt then close the cycle:
+
+| `crates/buzz-acp/src/base_prompt.md` | Rule |
+|---|---|
+| `:44` | "When you finish delegated work, you **MUST** `@mention` the delegator in your completion message." |
+| `:61` | "**Every turn that processes a user message MUST publish a reply.** … A turn that ends without a published message is a silent failure." |
+
+Composed, they have no exit:
+
+```
+Fizz's opener @-mentions Honey + Bumble        (kickoff, by design)
+  → Honey finishes her intro ("delegated work")
+  → :44 — MUST @mention the delegator          → Fizz wakes
+  → Fizz processed a message
+  → :61 — MUST publish a reply                 → Fizz replies
+  → :44 — acknowledgment @-mentions the two    → Honey + Bumble wake
+  → … (forever)
+```
+
+**The sign-off is the trigger.** "I'll stay quiet until you have a task" is a
+mention, and a mention is a wake. Politeness is the fuel.
+
+Nothing structural brakes this:
+
+- `ignore_self` (`lib.rs:1864`) filters an agent's **own** pubkey only — it does
+  not touch A↔B mutual mentions.
+- The author gate (`RespondTo::OwnerOnly`, the default) admits **siblings** —
+  other agents launched by the same owner (`is_owner_or_sibling`,
+  `lib.rs:166–190`). Agent-to-agent traffic is allowed by design.
+- `max_turns_per_session` defaults to `0` = unlimited (`config.rs:372`).
+- There is no per-thread agent-to-agent turn cap and no human-in-the-loop check.
+
+So the only brake is model discretion — which is precisely the variable that
+differs between providers.
+
+### Why Codex and not Claude Code
+
+**No code path explains it.** Prompt content is identical for both (both are
+protocol ≥ 2, both receive the same `base_prompt.md` + persona `[System]` via
+`pool.rs:1072`). The only per-provider prompt divergence is Goose (custom
+request) and legacy protocol `< 2` (inlined `[System]`) — neither is
+Codex-vs-Claude. Codex's only special-casing is network-sandbox env injection
+(`config.rs:640–668`), which has no prompt effect.
+
+The difference is behavioral: Codex reads `MUST` as a hard constraint and obeys
+it literally every turn; Claude Code treats it as defeasible and exercises
+discretion about when silence is correct. **Which means the current design only
+ever worked by luck** — it depends on a model choosing to violate an explicit
+instruction. Any provider that follows instructions faithfully will loop. Codex
+is not misbehaving here; it is doing what the prompt says.
+
+Corollary for the fix: **prompting alone cannot be the whole answer.** Every
+message in the observed thread is an agent *promising to stop*. They understood
+the instruction and complied verbally while structurally continuing to loop. A
+prompt that says "don't loop" is one more sentence for a literal-minded model to
+acknowledge — in a reply, with a mention.
+
+### Where the prompt fix belongs
+
+`crates/buzz-acp/src/base_prompt.md` — **not** the personas, **not** the team
+instructions. Reasoning:
+
+| Layer | File | Verdict |
+|---|---|---|
+| Base prompt (all agents) | `crates/buzz-acp/src/base_prompt.md` | ✅ **Right home.** The two rules that *cause* the loop live here, unconditional. The cycle is a general property of any mutual-mention agent set — not a Welcome-team quirk. |
+| Team instructions | `desktop/src-tauri/src/managed_agents/teams.rs:59` (`instructions: None` — slot exists, unused) | ⚠️ Scoped to the Welcome Team only. Same loop reappears for any other team or ad-hoc pair. |
+| Per-persona | `desktop/src-tauri/src/managed_agents/personas.rs:22–26` (Fizz/Honey/Bumble) | ❌ Three copies to drift, and every new persona re-introduces the bug. |
+
+Fixing it above the base prompt would leave `:44` and `:61` still saying "always
+reply, always mention the delegator" and layer a contradiction on top. The rules
+need a **termination clause at the source**: bound the "MUST reply" to turns that
+advance work, and carve out acknowledgment-only replies from the "MUST mention
+the delegator" rule (an ack that needs no action should either not be sent or not
+mention). Both edits belong in the same two bullets that created the cycle.
+
+### Constraints for the intro-loop fix
+
+- **Don't break callback mentions.** `:44` exists because a missing callback is
+  "the #1 cause of stalled collaboration" — the reason the rule is unconditional.
+  Loosening it trades a loud failure for a silent one, which is the failure class
+  this doc already tracks. The carve-out must be narrow: acknowledgments that
+  close a loop, not completions that hand work back.
+- **Don't break `:61` either.** It exists to prevent invisible turns. "Reply
+  unless you have nothing to add" invites a model to skip a real answer.
+- Prompt change is **necessary but not sufficient** — pair it with a structural
+  brake so a literal provider cannot loop even if it ignores the prose.
+
+### The fix (landed 2026-07-18)
+
+**Give the acknowledgment somewhere else to go.** The loop is not caused by
+agents wanting to talk too much; it is caused by the only available way to say
+"seen" being a mention, and a mention being a wake. So bound the MUST that forces
+the mention, and hand the impulse a zero-cost outlet.
+
+Three bullets, all in **Callback Mentions** (`base_prompt.md:42`). Nothing else
+changed — no persona, no team instructions, no kickoff copy, no harness code:
+
+1. **Bound the callback.** It hands work *back* — a completion, a blocker, or a
+   question — is sent **once**, and a delegator can waive it. The unconditional
+   MUST itself is **kept**: stalled collaboration is the worse failure (see
+   Constraints).
+2. **Forbid the ack-mention, and say why.** Never `@mention` anyone *just* to
+   acknowledge, agree, confirm, or sign off — *"a mention is a summons… a tag
+   costs a whole turn, it is not punctuation… 'I won't reply again' does not end
+   a conversation, it restarts it."* A literal model needs the mechanism, not
+   just the rule.
+3. **Point at reactions as the alternative.** *"To acknowledge, use a reaction
+   instead — `buzz reactions add`."* This is the load-bearing addition: it
+   redirects rather than suppresses. Telling a model "don't" leaves it with an
+   unresolved impulse; giving it a `p`-tag-free way to signal "seen and agreed"
+   resolves it, **and keeps the human-visible social signal** so the fix doesn't
+   read as stalling. `buzz reactions add` already existed and is already in the
+   command table (`:13`) — the base prompt just never connected it to acking.
+
+### Why `:61` was left alone
+
+An earlier draft also rescoped `:61` ("Every turn that processes a user message
+MUST publish a reply") to humans only, plus an explicit "end the turn silently
+when the exchange is over". **Reverted.** Two reasons:
+
+- **It isn't load-bearing.** A loop needs A's message to *wake* B, and wake is
+  `p`-tag gated. `:61` forces a *reply*, not a *tag* — an untagged reply ends the
+  chain after one message. `:61` governs **noise**, not the loop.
+- **It was the riskiest line in the diff.** Any weakening of "always reply" trades
+  toward the silent failures this same doc tracks. Not worth it for noise.
+
+Corroborating data point (2026-07-18): another Buzz agent (`Eva`) runs the same
+base prompt **including** `:61`, plus a per-agent core memory that says almost
+exactly bullets 2–3 above ("Don't @-tag another agent to merely acknowledge…
+ack with a reaction instead"; "a tag = forced wake-up = a whole invocation").
+It does not loop. So the mention rule alone is sufficient, and `:61` can stay
+as-is.
+
+That memory also **confirms the diagnosis from the other direction**: its
+"complementary rule" (only mention when you need attention, never in narrative)
+was *already in our base prompt at `:40`* the whole time — and the agents still
+looped, because a soft "only… when" loses to a hard MUST two lines below it. The
+per-agent memory works because it scopes the mandatory tag narrowly ("completion
+callbacks are the one mandatory tag") — the same move as bullet 1. Memory fixed
+one agent; the base prompt is where it holds for every agent, including a fresh
+Fizz with no memory.
+
+**Known residual tension:** `:61` still says a turn MUST publish a reply, which a
+literal model may read as outranking "ack with a reaction". Worst case is an
+extra untagged message — noise, not a loop, since it wakes nobody. Accepted
+deliberately; revisit only if observed.
+
+**Deliberately NOT done — telling the teammates not to mention each other in the
+kickoff opener.** Tried and reverted, for two reasons:
+
+- **Product.** The opener is the first thing a new user ever reads. A greeting
+  that visibly negotiates anti-loop rules with its own agents ("don't @mention me
+  or each other") advertises that the product needs intense prompting to behave
+  normally. The fix belongs somewhere the user never sees. The opener now carries
+  **no agent-steering instructions at all** — "Don't start any work yet" went too
+  (nothing has been asked for yet, so it guarded against nothing concrete, and
+  "in a sentence or two" already bounds the intros). Pinned by a test, so
+  re-adding one is a deliberate decision rather than a reflex.
+- **Isolation.** Shipping it alongside the base-prompt edit confounds the test:
+  the opener waiver alone would suppress the loop in the Welcome channel, so a
+  clean run would prove nothing about whether the base prompt actually works —
+  and the base prompt is the part that has to hold for *every* agent in *every*
+  channel, not just this one thread. Keeping the opener ordinary makes the
+  Welcome kickoff an honest test of the general fix.
+
+The `:44` delegator waiver stays in the base prompt as a general capability (any
+delegator, human or agent, can say "no need to report back") — it is simply not
+exercised by the kickoff.
+
+**Deliberately NOT done — a structural turn cap.** Considered and rejected: a
+cap on consecutive agent-authored turns cannot distinguish a loop from a
+long-running task where agents legitimately trade many messages, so it would
+truncate real work. There is no cheap structural signal that separates the two —
+the difference between "parked, standing by" and a useful update is semantic.
+That leaves prompting as the only lever, with the honest caveat below.
+
+**The closer needs no change** — its happy path is the bare CTA and its degraded
+paths use plain names, not `@`, so it emits no `p` tags and cannot wake anyone.
+
+### Residual risk
+
+Prompting is the only mitigation, and prompting is what failed here: every
+message in the observed thread was an agent promising to stop. The bet is that
+the old prompt left a compliant model **no way to say "seen" except a mention**,
+so it complied verbally while looping structurally — and that bounding the MUST
+plus offering reactions as the outlet removes the loop. That is a real bet, not a
+guarantee. It cannot be verified by unit tests; it needs a live Codex run on the
+Welcome flow (see Verification below).
+
+The `Eva` data point (above) is the strongest evidence it will hold: an agent
+carrying essentially these rules in memory demonstrably does not loop. The
+untested part is whether the same words work at **base-prompt salience** rather
+than per-agent-memory salience — memory sits closer to the model, and `:40`
+already proved that a low-salience mention rule loses to a nearby MUST.
+
+If it recurs, the next lever is not a blunt cap but a **semantic** one — e.g. the
+harness declining to wake an agent on a sibling mention whose message adds no
+new work — which needs a judgment call the harness can't currently make.
+
+### Verification status
+
+- **Not verified live.** The prompt change is behavioral; only a real Codex
+  session on a fresh Welcome channel can confirm it. Prompt edits have no test
+  that can fail on a literal-minded model, so the desktop/Rust suites say
+  nothing about whether this works.
+- One run on 2026-07-18 went from 21+ replies to **2** (the two intros, no
+  loop) — but that run had the opener waiver in it too, so it is **confounded
+  and does not count as evidence for the base prompt**. It is the reason the
+  opener was reverted: the next run needs to isolate the variable.
+- Unit-tested only: the solo opener mentions no agent at all (pins the
+  degraded path, which cannot loop by construction).
+
+### Outstanding questions
+
+- Which other providers loop? Only Codex is confirmed, and **Codex-only is not a
+  safe assumption** — the fix is deliberately provider-agnostic and written to
+  be correct for a *perfectly obedient* model. Goose and the legacy `< 2`
+  inlined-`[System]` path take a different prompt route (`pool.rs:181–191`) and
+  are untested.
+- If the base prompt alone does **not** hold, the opener waiver is the known
+  fallback — it worked in the confounded run above. The cost is the product one:
+  the first message a new user reads would carry anti-loop instructions. Prefer
+  fixing the base prompt wording first.
+- Do agents actually reach for `buzz reactions add`? The rule is only as good as
+  the model's willingness to use a tool instead of writing prose. If it gets
+  ignored, the ack-mention prohibition degrades from "redirect" to "suppress",
+  which is the weaker form.
+- Does "never mention just to acknowledge" bleed into pickup acknowledgments for
+  real work (`base_prompt.md:66` expects a pickup ack before follow-up tools)? A
+  pickup ack *precedes* work and is a legitimate mention; a terminal ack follows
+  the end and is not. The wording targets "acknowledge, agree, confirm, or sign
+  off", which reads terminal — but the boundary is a model judgment, and reading
+  it too broadly converts this loud failure into the silent kind.
+
+## Constraints for the silent-path fix
 
 - **Fizz cannot be the messenger** for these paths: she is the thing that
   failed. Any user-visible fallback must come from the client UI itself
@@ -81,7 +342,7 @@ Navigation away mid-kickoff also cancels silently, but that is intentional
   in `desktop/src-tauri/src/managed_agents/readiness.rs` already classifies
   the actionable ones.
 
-## Sketch (to validate later)
+## Sketch for the silent paths (to validate later)
 
 1. Surface a `kickoffError` phase from `useWelcomeKickoff` when the catch
    block fires or the lead's start rejects, with a coarse cause
@@ -100,7 +361,33 @@ Navigation away mid-kickoff also cancels silently, but that is intentional
 ## Related
 
 - Rate-limiting incident: one Welcome agent produced a 42KB log of
-  "rate-limited: quota exceeded" retries within seconds
-  (2026-07-17, remote relay `onboarding.communities.buzz.xyz`). Worth a
-  separate look at buzz-acp publish backoff — a tight retry loop against a
-  quota makes every other send in the session fail too.
+  "rate-limited: quota exceeded" within seconds (2026-07-17, remote relay
+  `onboarding.communities.buzz.xyz`).
+
+  **Rate limiting is downstream of the intro loop, not a cause of it** — checked
+  2026-07-18, and this corrects the earlier note here that assumed "an agent
+  publishing in a tight retry loop":
+  - That string is emitted by the **relay rejecting a publish**
+    (`buzz-relay/src/connection.rs:652`), so the log is 42KB of *rejections*,
+    not of client retries.
+  - There is **no retry/backoff code in buzz-acp's publish path** — the only
+    `fetch_with_retry` usage is for context fetches (`pool.rs:2159`). Nothing
+    supports the tight-retry-loop reading.
+  - Rate limiting cannot *drive* a back-and-forth: a rejected send produces no
+    event, hence no `p` tag, hence no wake. A rate-limited send **breaks** the
+    loop rather than feeding it.
+
+  So the causal arrow is loop → publish volume → quota → rejections. **The intro
+  loop fix does not depend on any rate-limit work**, and the two can be worked
+  independently.
+
+  Still open (hypothesis, unobserved): a provider whose *send* fails may retry it
+  within its own agent loop, since `:61` frames an unpublished message as a silent
+  failure — a literal model may not accept a failed send either. If the 42KB came
+  from one agent's repeated `buzz messages send` attempts, that is the mechanism.
+  **This one is not addressed here** (`:61` was deliberately left as-is — see
+  "Why `:61` was left alone"), so it remains live: a quota rejection has no
+  client-side brake at all. Worth a look at publish backoff independently.
+- The two failure classes interact: silent-path work adds messages, and every
+  new message is a potential wake. Any fallback that `@mentions` an agent to
+  recover from a failure can itself seed a loop.


### PR DESCRIPTION
Two related failures on a brand-new user's very first screen in Buzz — both observed live against Codex on a fresh Welcome channel, both fixed here, both re-verified live.

## 1. The intro loop

Fizz, Honey, and Bumble replied to each other 21+ times, each message announcing it would now stop replying — and each announcement waking the others.

A mention is a wake (agents are p-tag gated), so the only way an agent could say "seen" was to summon someone. Combined with an unconditional MUST in the shared base prompt, that had no exit:

> `:44` When you finish delegated work, you MUST `@mention` the delegator

`:40` already said "only `@mention` when you need their attention" — and they still looped, because a soft "only when" loses to a hard MUST two lines below it. Codex reads MUST literally; Claude Code treats it as defeasible, so the design only ever worked on a model choosing to disobey.

Fixed in the base prompt (not the personas — 3 copies to drift; not team instructions — Welcome-only) with three bullets in **Callback Mentions**:

- **Bound the callback** — it hands work *back*, is sent once, and a delegator can waive it. The MUST itself stays; stalled collaboration is the worse failure.
- **Forbid the ack-mention, and say why** — a tag costs a whole turn, it is not punctuation, so "understood" restarts a conversation rather than ending it. A literal model needs the mechanism, not just the rule.
- **Point at reactions as the outlet** — `buzz reactions add`. This is the load-bearing part: it *redirects* rather than suppresses, and keeps the human-visible social signal so the fix doesn't read as stalling.

`:64` ("every turn MUST publish a reply") is deliberately left alone — it forces a *reply*, not a *tag*, and an untagged reply ends the chain. It governs noise, not the loop.

## 2. The closer that raced a message it could not beat

Fizz posted "Honey and Bumble are taking longer than expected" — seconds before their intros landed. Then it posted a *second* closing message, contradicting the first.

This wasn't a failure state. It was a stopwatch: `TEAMMATE_INTRO_WAIT_MS` (15s) + a 3s beat = ~18s for a real agent to wake on a p-tag, fetch context, run inference, and shell out to `buzz messages send`. A real turn can't beat that.

The deeper problem: the choreography assumed the scripted closer was *last*, while `base_prompt.md:44` **guaranteed** a message after it — the intros tag Fizz, so Fizz wakes and replies. Two closing messages, and the scripted one was the one that could be wrong.

**So the scripted closer is gone on the happy path.** Fizz's own live callback closes the thread — it's contextual, and it's correct about world state. `buildWelcomeKickoffCloser` now returns `null` when there's nothing to report; the scripted message survives only to report a *failed* or genuinely *delayed* teammate, and the timeout is raised to 60s so patience is the answer where patience is right. A crashed teammate still closes immediately — `failed` is read from agent status, not from the clock.

### The latch this broke, and why it needed a second signal

Removing the success closer quietly broke the "already done" guard. Markers are **server-side**: the check asks the relay for a message carrying the marker tag. No message ⇒ no marker ⇒ no evidence. Left alone, a clean kickoff would never retire — it would refetch the opener subtree forever (the bug #2066 fixed) and **restart the whole Welcome team on every revisit**.

Fixed with `welcomeKickoffAlreadyFinished`, which reads completion from the relay-side intro replies instead of from the closer's existence. A local latch was rejected: it would re-run on another device or after reinstall.

The marker's meaning has drifted as a result — `closer.v1` now means "a problem was reported, or there was never a team to wait for" (the solo opener carries it too). The wire string stays: renaming it strands the markers already on relays for kickoffs that failed, and the dedupe would let them report twice. It's documented at the constant instead, because that's what the next person greps.

## Verification

Both halves confirmed live against Codex on a fresh Welcome channel:

- **No doom loop.** The 21-message cascade did not reproduce.
- **Fizz's own reply closed the thread**, with no scripted "taking longer than expected."

Gates: `typecheck`, `pnpm run check`, 30/30 kickoff tests, 3173/3173 desktop tests (+5 new).

## Known adjacent issue, deliberately not fixed here

An open thread pane doesn't live-append new replies while the channel's reply count ticks up correctly (close + reopen shows them). Confirmed asymmetry: the count is server-computed and pushed (kind `39005`); the list is a client-parsed React Query cache. Ruled out: malformed reply tags, and root-key divergence. Leading hypothesis (**unproven**): a refetch overwriting live-appended replies in `useThreadReplies.ts`. That live-append branch has zero test coverage.

It's a general thread bug, not a Welcome bug — this PR touches none of that code. Closed PR #2057 is corroborating evidence: it routed *around* the same broken live path by locally projecting the user's own sends. Tracked separately.
