### PR TITLE
style(desktop): match PendingInviteGate to startup interstitials

### DIFF
--- a/desktop/src/features/onboarding/ui/PendingInviteGate.tsx
+++ b/desktop/src/features/onboarding/ui/PendingInviteGate.tsx
@@ -1,6 +1,8 @@
 import { useCommunityOnboarding } from "@/features/onboarding/communityOnboarding";
+import { useSystemColorScheme } from "@/shared/theme/useSystemColorScheme";
 import { Button } from "@/shared/ui/button";
 import { FlappingBee } from "@/shared/ui/buzz-logo/FlappingBee";
+import { StartupWindowDragRegion } from "@/shared/ui/StartupWindowDragRegion";
 
 /**
  * Acknowledge a community deep link received before machine onboarding is
@@ -9,15 +11,18 @@ import { FlappingBee } from "@/shared/ui/buzz-logo/FlappingBee";
  */
 export function PendingInviteGate() {
   const { transaction, update, clear } = useCommunityOnboarding();
+  const systemColorScheme = useSystemColorScheme();
 
   if (!transaction) return null;
 
   return (
     <div
-      className="buzz-onboarding-neutral-theme fixed inset-0 z-50 flex items-center justify-center bg-background px-4 py-8 text-foreground"
+      className="buzz-onboarding-neutral-theme buzz-startup-shell fixed inset-0 z-50 flex items-center justify-center bg-background px-4 py-8 text-foreground"
+      data-system-color-scheme={systemColorScheme}
       data-testid="pending-invite-gate"
     >
-      <div className="flex w-full max-w-[440px] flex-col items-center text-center">
+      <StartupWindowDragRegion />
+      <div className="relative flex w-full max-w-[500px] flex-col items-center text-center">
         <FlappingBee className="h-auto w-24" />
         <h1 className="mt-6 text-3xl font-semibold tracking-tight">
           Opening community link
@@ -25,7 +30,7 @@ export function PendingInviteGate() {
         <p className="mt-3 text-sm leading-6 text-muted-foreground">
           You’ll connect to {transaction.communityName} once setup is finished.
         </p>
-        <div className="mt-8 flex w-full flex-col gap-3">
+        <div className="mt-8 flex w-full max-w-[300px] flex-col gap-3">
           <Button
             className="h-10 w-full"
             data-testid="pending-invite-continue"


### PR DESCRIPTION
## Why

`PendingInviteGate` — the "Opening community link" screen shown when a community deep link arrives before machine onboarding finishes — carried `buzz-onboarding-neutral-theme` but **not** `buzz-startup-shell`. That combination is what `components.css` keys the shared chartreuse→light-blue gradient + dot-grid background off of, so the gate rendered on flat white and looked out of place against the startup screens it sits alongside.

## What

Aligns the gate with its siblings (`RecoveryScreen.tsx`, `KeyringLockedScreen.tsx`):

- Add `buzz-startup-shell` alongside `buzz-onboarding-neutral-theme`, keeping `fixed inset-0 z-50` (this is an overlay above `MachineOnboardingFlow`).
- Add `data-system-color-scheme` via the `useSystemColorScheme()` hook, matching `RecoveryScreen`.
- Add `<StartupWindowDragRegion />` as the first child.
- Match the sibling layout: inner container `relative … max-w-[500px]`, button stack `max-w-[300px]`.

Copy, both handlers, the `FlappingBee` logo, `variant="ghost"` on Cancel, and all three `data-testid`s (`pending-invite-gate`, `pending-invite-continue`, `pending-invite-cancel`) are unchanged. Design-system `Button` variants only.

The title keeps its `mt-6` — the sibling screens have no logo, so their titles sit flush; here it needs to clear the `FlappingBee`.

**Styling only — no functional change.**

## Testing

- `desktop/tests/e2e/deep-link-invite.spec.ts` — 7/7 passing (it asserts against this screen).
- `biome check`, `tsc --noEmit`, `pnpm check:px-text` — clean.
- Verified visually; screenshot in a comment below.

Note: the pre-push `test` gate flaked once on `buzz-agent`'s `cancelled_turn_with_usage_emits_notification_before_response` under full parallel load. It passes 3/3 in isolation and 3/3 as a full suite, and this diff touches one `.tsx` file — unrelated, pre-existing. The retried push was fully green.