### PR TITLE
Align onboarding step headers

### DIFF
--- a/crates/buzz-pair-relay/src/lib.rs
+++ b/crates/buzz-pair-relay/src/lib.rs
@@ -104,6 +104,7 @@ struct Sub {
 pub struct Relay {
     subs: Mutex<Vec<Sub>>,
     conn_count: AtomicU32,
+    max_conns: u32,
     next_conn_id: AtomicU64,
     /// Global dedup vec — entries expire after ENTRY_TTL; rejects at DEDUP_CAP after eviction.
     seen_ids: Mutex<Vec<([u8; 32], tokio::time::Instant)>>,
@@ -119,9 +120,19 @@ impl Default for Relay {
 
 impl Relay {
     pub fn new() -> Self {
+        Self::with_max_conns(MAX_CONNS)
+    }
+
+    /// Create a relay with a custom connection cap.
+    ///
+    /// This is primarily used by integration tests so cap behavior can be
+    /// exercised without requiring more file descriptors than some local
+    /// environments allow. Production callers should use [`Relay::new`].
+    pub fn with_max_conns(max_conns: u32) -> Self {
         Self {
             subs: Mutex::new(Vec::new()),
             conn_count: AtomicU32::new(0),
+            max_conns,
             next_conn_id: AtomicU64::new(0),
             seen_ids: Mutex::new(Vec::new()),
             delivered: Mutex::new(HashMap::new()),
@@ -947,7 +958,7 @@ async fn http_service(
     }
 
     // Reserve slot before upgrading.
-    if relay.conn_count.fetch_add(1, Ordering::Relaxed) >= MAX_CONNS {
+    if relay.conn_count.fetch_add(1, Ordering::Relaxed) >= relay.max_conns {
         relay.conn_count.fetch_sub(1, Ordering::Relaxed);
         let mut r = Response::new(Full::default());
         *r.status_mut() = StatusCode::SERVICE_UNAVAILABLE;

--- a/crates/buzz-pair-relay/tests/integration.rs
+++ b/crates/buzz-pair-relay/tests/integration.rs
@@ -32,10 +32,13 @@ type WS = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 
 /// Start a relay on a random port, return the WebSocket URL.
 async fn start_relay() -> String {
+    start_relay_with(Relay::new()).await
+}
+
+async fn start_relay_with(relay: Relay) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
-    let relay = Arc::new(Relay::new());
-    tokio::spawn(run_server(listener, relay));
+    tokio::spawn(run_server(listener, Arc::new(relay)));
     format!("ws://127.0.0.1:{}", addr.port())
 }
 
@@ -580,20 +583,21 @@ async fn test_invalid_hex_in_event_id() {
     assert_eq!(resp[2], false);
 }
 
-/// 17. Global connection cap: 128 connections succeed; 129th is rejected.
-///     After closing one, a new connection succeeds.
+/// 17. Global connection cap: configured max connections succeed; the next is
+///     rejected. After closing one, a new connection succeeds.
 #[tokio::test]
 async fn test_global_conn_cap() {
-    let url = start_relay().await;
+    let max_conns = 16;
+    let url = start_relay_with(Relay::with_max_conns(max_conns)).await;
 
-    let mut conns: Vec<WS> = Vec::with_capacity(128);
-    for _ in 0..128 {
+    let mut conns: Vec<WS> = Vec::with_capacity(max_conns as usize);
+    for _ in 0..max_conns {
         conns.push(connect(&url).await);
     }
 
-    // 129th should fail (server returns 503).
+    // One over the configured limit should fail (server returns 503).
     let result = connect_async(&url).await;
-    assert!(result.is_err(), "expected 129th connection to fail");
+    assert!(result.is_err(), "expected capped connection to fail");
 
     // Close one connection.
     let mut dropped = conns.pop().unwrap();
@@ -984,11 +988,12 @@ async fn test_close_handshake() {
     assert_closed(&mut ws).await;
 }
 
-/// 35. Connection counter does not leak: open/close 5 connections, then open
-///     128 more — all should succeed.
+/// 35. Connection counter does not leak: open/close some connections, then
+///     fill the configured cap — all should succeed.
 #[tokio::test]
 async fn test_conn_counter_no_leak() {
-    let url = start_relay().await;
+    let max_conns = 16;
+    let url = start_relay_with(Relay::with_max_conns(max_conns)).await;
 
     // Open and close 5 connections.
     for _ in 0..5 {
@@ -998,12 +1003,12 @@ async fn test_conn_counter_no_leak() {
     // Give the relay time to decrement counters.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    // Now open 128 connections — all should succeed.
-    let mut conns: Vec<WS> = Vec::with_capacity(128);
-    for _ in 0..128 {
+    // Now open connections up to the cap — all should succeed.
+    let mut conns: Vec<WS> = Vec::with_capacity(max_conns as usize);
+    for _ in 0..max_conns {
         conns.push(connect(&url).await);
     }
-    assert_eq!(conns.len(), 128);
+    assert_eq!(conns.len(), max_conns as usize);
 }
 
 /// 36. Fan-out drops do not close the subscriber connection.

--- a/desktop/src/features/communities/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/communities/ui/WelcomeSetup.tsx
@@ -25,6 +25,7 @@ import { Input } from "@/shared/ui/input";
 import { StartupWindowDragRegion } from "@/shared/ui/StartupWindowDragRegion";
 import { useSystemColorScheme } from "@/shared/theme/useSystemColorScheme";
 import { OnboardingChrome } from "@/features/onboarding/ui/OnboardingChrome";
+import { OnboardingStepHeader } from "@/features/onboarding/ui/OnboardingStepHeader";
 import { writeTextToClipboard } from "@/shared/lib/clipboard";
 
 type WelcomeSetupPage = "welcome" | "join" | "invite";
@@ -136,15 +137,16 @@ export function WelcomeSetup({
               effect={welcomeEffect}
               transitionKey={`welcome-${welcomeEffect}-${transitionDirection}`}
             >
-              <div className="w-full max-w-[760px]">
-                <h1 className="text-title font-normal">
-                  Join or create a community
-                </h1>
-                <p className="mt-3 text-sm leading-6 text-foreground/80">
-                  Choose how you’d like to get started. If you have an invite
-                  link, you can open it directly to continue setup.
-                </p>
-              </div>
+              <OnboardingStepHeader
+                className="max-w-[760px]"
+                description={
+                  <>
+                    Choose how you’d like to get started. If you have an invite
+                    link, you can open it directly to continue setup.
+                  </>
+                }
+                title="Join or create a community"
+              />
               <div className="mt-28 flex w-full flex-col items-center gap-6">
                 <button
                   className={COMMUNITY_OPTION_CARD_CLASS}
@@ -186,15 +188,15 @@ export function WelcomeSetup({
               direction={transitionDirection}
               transitionKey={`join-${transitionDirection}`}
             >
-              <div className="w-full max-w-[500px]">
-                <h1 className="text-title font-normal">
-                  Request access to community
-                </h1>
-                <p className="mt-3 text-sm leading-6 text-foreground/80">
-                  Ask the community host to send you an invite link or add you
-                  directly using your public key.
-                </p>
-              </div>
+              <OnboardingStepHeader
+                description={
+                  <>
+                    Ask the community host to send you an invite link or add you
+                    directly using your public key.
+                  </>
+                }
+                title="Request access to community"
+              />
               <div className="flex w-full flex-1 items-center justify-center pb-4 pt-12">
                 <div className="w-full max-w-4xl space-y-7">
                   <div>
@@ -315,15 +317,15 @@ export function WelcomeSetup({
               direction={transitionDirection}
               transitionKey={`invite-${transitionDirection}`}
             >
-              <div className="w-full max-w-[500px]">
-                <h1 className="text-title font-normal">
-                  Enter your invite link
-                </h1>
-                <p className="mt-3 text-sm leading-6 text-foreground/80">
-                  If you have an invite link for a community, paste it below to
-                  continue setup.
-                </p>
-              </div>
+              <OnboardingStepHeader
+                description={
+                  <>
+                    If you have an invite link for a community, paste it below
+                    to continue setup.
+                  </>
+                }
+                title="Enter your invite link"
+              />
               <div className="flex w-full flex-1 items-center justify-center pb-4 pt-12">
                 <InviteRedeemForm
                   defaultRelayUrl={

--- a/desktop/src/features/onboarding/ui/AvatarStep.tsx
+++ b/desktop/src/features/onboarding/ui/AvatarStep.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/shared/ui/button";
 import { Spinner } from "@/shared/ui/spinner";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { OnboardingFooter } from "./OnboardingFooter";
+import { OnboardingStepHeader } from "./OnboardingStepHeader";
 import { AnimatePresence, motion } from "motion/react";
 import * as React from "react";
 import {
@@ -328,14 +329,11 @@ export function AvatarStep({
         transition={AVATAR_POSITION_MOTION_TRANSITION}
       >
         <div className="flex w-full flex-col items-center text-center lg:items-start lg:text-left">
-          <div className="w-full max-w-[500px]">
-            <h1 className="text-title font-normal text-foreground">
-              Next, add a display image
-            </h1>
-            <p className="mt-5 text-sm leading-6 text-muted-foreground">
-              Choose an image or emoji as your avatar
-            </p>
-          </div>
+          <OnboardingStepHeader
+            description="Choose an image or emoji as your avatar"
+            descriptionClassName="text-muted-foreground lg:mx-0"
+            title="Next, add a display image"
+          />
 
           <div className="mt-12 grid justify-items-center gap-3 lg:justify-items-start">
             <div className="relative h-48 w-48">

--- a/desktop/src/features/onboarding/ui/BackupStep.tsx
+++ b/desktop/src/features/onboarding/ui/BackupStep.tsx
@@ -10,6 +10,7 @@ import {
   type OnboardingTransitionDirection,
   OnboardingSlideTransition,
 } from "./OnboardingSlideTransition";
+import { OnboardingStepHeader } from "./OnboardingStepHeader";
 import {
   NsecMaskedDisplay,
   ONBOARDING_KEY_FRAME_CLASS,
@@ -83,15 +84,15 @@ export function BackupStep({ direction, onBack, onNext }: BackupStepProps) {
       direction={direction}
       transitionKey={`backup-${direction}`}
     >
-      <div className="w-full max-w-[500px] text-center">
-        <h1 className="text-title font-normal text-foreground">
-          Your unique identity has been created
-        </h1>
-        <p className="mt-5 text-sm leading-6 text-foreground/80">
-          This key is stored in your system keychain, but save it some place
-          safe in case you ever need to restore your account.
-        </p>
-      </div>
+      <OnboardingStepHeader
+        description={
+          <>
+            This key is stored in your system keychain, but save it some place
+            safe in case you ever need to restore your account.
+          </>
+        }
+        title="Your unique identity has been created"
+      />
 
       <div className="mt-10 w-full max-w-4xl">
         {isLoading ? (

--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -33,6 +33,7 @@ import {
   OnboardingChrome,
 } from "./OnboardingChrome";
 import { OnboardingFooter, OnboardingFooterProvider } from "./OnboardingFooter";
+import { OnboardingStepHeader } from "./OnboardingStepHeader";
 import {
   ONBOARDING_KEY_FRAME_CLASS,
   ONBOARDING_KEY_ROW_CLASS,
@@ -232,11 +233,16 @@ export function CommunityOnboardingFlow({
       await finish();
     } catch (error) {
       update({
+        stage: "team-intro",
         error: error instanceof Error ? error.message : String(error),
       });
       setIsPending(false);
     }
   }, [finish, isPending, queryClient, relayUrl, update]);
+  const backToProfile = React.useCallback(() => {
+    if (isPending) return;
+    update({ stage: "profile", error: undefined });
+  }, [isPending, update]);
 
   const isProfileStage = transaction?.stage === "profile";
   const isTeamStage =
@@ -343,7 +349,7 @@ export function CommunityOnboardingFlow({
           className={cn(
             "relative w-full text-center",
             isProfileStage || isTeamStage
-              ? "buzz-onboarding-step-frame flex flex-col justify-center"
+              ? "buzz-onboarding-step-frame flex flex-col items-center"
               : "flex min-h-dvh flex-col justify-center py-8",
             isProfileStage
               ? "max-w-4xl"
@@ -412,11 +418,16 @@ export function CommunityOnboardingFlow({
             ) : (
               <>
                 <div data-testid="community-profile-main">
-                  <h1 className="text-title font-normal">Build your profile</h1>
-                  <p className="mx-auto mt-3 max-w-[380px] text-sm leading-6 text-foreground/80">
-                    Add a name and avatar. They’ll show up on your messages,
-                    reactions, and agent handoffs.
-                  </p>
+                  <OnboardingStepHeader
+                    description={
+                      <>
+                        Add a name and avatar. They’ll show up on your messages,
+                        reactions, and agent handoffs.
+                      </>
+                    }
+                    descriptionClassName="max-w-[380px]"
+                    title="Build your profile"
+                  />
                   <div className="mt-10 w-full max-w-4xl">
                     <div
                       className={ONBOARDING_KEY_FRAME_CLASS}
@@ -481,69 +492,73 @@ export function CommunityOnboardingFlow({
             )
           ) : (
             <>
-              <h1 className="text-title font-normal">Meet your starter team</h1>
-              <p className="mx-auto mt-3 max-w-[400px] text-sm leading-6 text-foreground/80">
-                Buzz lets you bring multiple agents into the same workspace.
-                This team will help you get started using Buzz.
-              </p>
-              {starterPersonas.length > 0 ? (
-                <div className="mt-10 flex flex-wrap justify-center gap-8">
-                  {starterPersonas.map((persona) => {
-                    const animationUrl =
-                      STARTER_PERSONA_ANIMATIONS[persona.displayName];
-                    return (
-                      <div
-                        className="flex w-40 flex-col items-center gap-3"
-                        key={persona.id}
-                      >
-                        {animationUrl ? (
-                          <img
-                            alt={`${persona.displayName} animated character`}
-                            className="h-40 w-40 object-contain"
-                            data-testid={`starter-persona-${persona.displayName.toLowerCase()}`}
-                            src={animationUrl}
-                          />
-                        ) : (
-                          <ProfileAvatar
-                            avatarUrl={persona.avatarUrl}
-                            className="h-28 w-28 text-3xl"
-                            label={persona.displayName}
-                          />
-                        )}
-                        <span className="font-mono text-xs font-medium uppercase tracking-[0.15em]">
-                          {persona.displayName}
-                        </span>
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : null}
+              <OnboardingStepHeader
+                description={
+                  <>
+                    Buzz lets you bring multiple agents into the same workspace.
+                    Your team will help you get started using Buzz.
+                  </>
+                }
+                descriptionClassName="max-w-[400px]"
+                title="Meet your starter team"
+              />
+              <div className="flex w-full flex-1 items-center justify-center py-10">
+                {starterPersonas.length > 0 ? (
+                  <div className="flex flex-wrap justify-center gap-8">
+                    {starterPersonas.map((persona) => {
+                      const animationUrl =
+                        STARTER_PERSONA_ANIMATIONS[persona.displayName];
+                      return (
+                        <div
+                          className="flex w-40 flex-col items-center gap-3"
+                          key={persona.id}
+                        >
+                          {animationUrl ? (
+                            <img
+                              alt={`${persona.displayName} animated character`}
+                              className="h-40 w-40 object-contain"
+                              data-testid={`starter-persona-${persona.displayName.toLowerCase()}`}
+                              src={animationUrl}
+                            />
+                          ) : (
+                            <ProfileAvatar
+                              avatarUrl={persona.avatarUrl}
+                              className="h-28 w-28 text-3xl"
+                              label={persona.displayName}
+                            />
+                          )}
+                          <span className="font-mono text-xs font-medium uppercase tracking-[0.15em]">
+                            {persona.displayName}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : null}
+              </div>
               {transaction.error ? (
-                <p className="mt-4 text-sm text-destructive">
-                  {transaction.error}
-                </p>
+                <p className="text-sm text-destructive">{transaction.error}</p>
               ) : null}
               <OnboardingFooter>
                 <Button
                   className={ONBOARDING_PRIMARY_CTA_CLASS}
+                  data-testid="community-team-intro-enter"
                   disabled={isPending || transaction.stage === "entering"}
                   onClick={() => void finalize()}
                 >
-                  {transaction.stage === "finalizing" ||
-                  transaction.stage === "entering"
+                  {isPending || transaction.stage === "entering"
                     ? "Preparing Welcome…"
-                    : `Enter ${transaction.communityName}`}
+                    : "Take me to Buzz"}
                 </Button>
-                {transaction.error ? (
-                  <Button
-                    className="h-9 rounded-full bg-foreground/10 px-5 hover:bg-foreground/15"
-                    disabled={isPending}
-                    onClick={() => void finish()}
-                    variant="ghost"
-                  >
-                    Skip for now
-                  </Button>
-                ) : null}
+                <Button
+                  className="h-9 rounded-full bg-foreground/10 px-5 hover:bg-foreground/15"
+                  data-testid="community-team-intro-back"
+                  disabled={isPending || transaction.stage === "entering"}
+                  onClick={backToProfile}
+                  variant="ghost"
+                >
+                  Back
+                </Button>
               </OnboardingFooter>
             </>
           )}

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -26,6 +26,7 @@ import {
   type OnboardingTransitionDirection,
   OnboardingSlideTransition,
 } from "./OnboardingSlideTransition";
+import { OnboardingStepHeader } from "./OnboardingStepHeader";
 import type { DefaultConfigStepActions } from "./types";
 
 type DefaultConfigStepProps = {
@@ -249,15 +250,16 @@ export function DefaultConfigStep({
       direction={direction}
       transitionKey={`default-config-${direction}`}
     >
-      <div className="w-full max-w-[500px] text-center">
-        <h1 className="text-title font-normal text-foreground">
-          Configure your default model settings
-        </h1>
-        <p className="mx-auto mt-3 max-w-[440px] text-sm leading-5 text-foreground/80">
-          These settings will be used by your agents in Buzz. You can always
-          change them in your Settings.
-        </p>
-      </div>
+      <OnboardingStepHeader
+        description={
+          <>
+            These settings will be used by your agents in Buzz. You can always
+            change them in your Settings.
+          </>
+        }
+        descriptionClassName="leading-5"
+        title="Configure your default model settings"
+      />
 
       <div className="flex w-full flex-1 items-center justify-center py-10">
         <div className="w-full max-w-[328px]">

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -22,6 +22,7 @@ import {
   OnboardingChrome,
 } from "./OnboardingChrome";
 import { OnboardingFooterProvider } from "./OnboardingFooter";
+import { OnboardingStepHeader } from "./OnboardingStepHeader";
 import {
   getPreferredRuntimeIdForSelection,
   runtimeSelectionNeedsDefaultsStep,
@@ -230,18 +231,17 @@ export function MachineOnboardingFlow({
               effect="fade"
               transitionKey="machine-key-import"
             >
-              <div className="shrink-0">
-                <h1 className="text-title font-normal text-foreground">
-                  {identityLost
-                    ? "Re-import your key"
-                    : "Enter your private key"}
-                </h1>
-                <p className="mt-5 max-w-[440px] text-sm leading-6 text-foreground/80">
-                  {identityLost
+              <OnboardingStepHeader
+                className="shrink-0"
+                description={
+                  identityLost
                     ? "Your identity is no longer in the system keyring. Re-import your nsec to restore it."
-                    : "If you already have a Nostr account, enter your private key below to get started."}
-                </p>
-              </div>
+                    : "If you already have a Nostr account, enter your private key below to get started."
+                }
+                title={
+                  identityLost ? "Re-import your key" : "Enter your private key"
+                }
+              />
               <div className="buzz-onboarding-key-import-position w-full">
                 <NostrKeyImportForm
                   backLabel={identityLost ? "Start new identity" : "Back"}

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -18,6 +18,7 @@ import { StartupWindowDragRegion } from "@/shared/ui/StartupWindowDragRegion";
 import { AvatarStep } from "./AvatarStep";
 import { OnboardingChrome } from "./OnboardingChrome";
 import { OnboardingFooterProvider } from "./OnboardingFooter";
+import { OnboardingStepHeader } from "./OnboardingStepHeader";
 import { MembershipDenied } from "./MembershipDenied";
 import { NostrKeyImportForm } from "./NostrKeyImportForm";
 import { useCommunities } from "@/features/communities/useCommunities";
@@ -521,30 +522,32 @@ export function OnboardingFlow({
                 transitionKey={`key-import-${transitionDirection}`}
               >
                 <div className="w-full max-w-[440px]">
-                  {identityLost ? (
-                    <>
-                      <h1 className="text-title font-normal text-foreground">
-                        Re-import your key
-                      </h1>
-                      <p className="mt-5 text-sm leading-6 text-muted-foreground">
-                        Your identity is no longer in the system keyring.
-                        Re-import your nsec to restore it — Buzz will restart to
-                        finish recovery. Or go back to start a new identity with
-                        a fresh key.
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <h1 className="text-title font-normal text-foreground">
-                        Use your existing key
-                      </h1>
-                      <p className="mt-5 text-sm leading-6 text-muted-foreground">
-                        Import your Nostr private key to use that identity with
-                        Buzz. If this key already has a profile on the relay,
-                        your name and avatar are restored automatically.
-                      </p>
-                    </>
-                  )}
+                  <OnboardingStepHeader
+                    className="max-w-[440px]"
+                    description={
+                      identityLost ? (
+                        <>
+                          Your identity is no longer in the system keyring.
+                          Re-import your nsec to restore it — Buzz will restart
+                          to finish recovery. Or go back to start a new identity
+                          with a fresh key.
+                        </>
+                      ) : (
+                        <>
+                          Import your Nostr private key to use that identity
+                          with Buzz. If this key already has a profile on the
+                          relay, your name and avatar are restored
+                          automatically.
+                        </>
+                      )
+                    }
+                    descriptionClassName="text-muted-foreground"
+                    title={
+                      identityLost
+                        ? "Re-import your key"
+                        : "Use your existing key"
+                    }
+                  />
                 </div>
 
                 {persistError ? (

--- a/desktop/src/features/onboarding/ui/OnboardingStepHeader.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingStepHeader.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/shared/lib/cn";
+
+export function OnboardingStepHeader({
+  className,
+  description,
+  descriptionClassName,
+  title,
+}: {
+  className?: string;
+  description: ReactNode;
+  descriptionClassName?: string;
+  title: ReactNode;
+}) {
+  return (
+    <div className={cn("w-full max-w-[500px] text-center", className)}>
+      <h1 className="text-title font-normal text-foreground">{title}</h1>
+      <p
+        className={cn(
+          "mx-auto mt-3 max-w-[440px] text-sm leading-6 text-foreground/80",
+          descriptionClassName,
+        )}
+      >
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/features/onboarding/ui/ProfileStep.tsx
+++ b/desktop/src/features/onboarding/ui/ProfileStep.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/shared/ui/button";
 import { Spinner } from "@/shared/ui/spinner";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { OnboardingFooter } from "./OnboardingFooter";
+import { OnboardingStepHeader } from "./OnboardingStepHeader";
 import {
   type OnboardingTransitionDirection,
   type OnboardingTransitionEffect,
@@ -219,15 +220,17 @@ export function ProfileStep({
       effect={transitionEffect}
       transitionKey={`profile-${direction}`}
     >
-      <div className="w-full max-w-2xl">
-        <h1 className="text-title font-normal text-foreground">
-          What should we call you?
-        </h1>
-        <p className="mt-5 text-sm leading-6 text-muted-foreground">
-          Pick the name people and agents will see in Buzz. You can change it
-          anytime.
-        </p>
-      </div>
+      <OnboardingStepHeader
+        className="max-w-2xl"
+        description={
+          <>
+            Pick the name people and agents will see in Buzz. You can change it
+            anytime.
+          </>
+        }
+        descriptionClassName="text-muted-foreground"
+        title="What should we call you?"
+      />
 
       <label
         className="mt-12 flex w-full cursor-text flex-col items-center"

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -24,6 +24,7 @@ import {
 } from "./onboardingRuntimeSelection";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { OnboardingFooter } from "./OnboardingFooter";
+import { OnboardingStepHeader } from "./OnboardingStepHeader";
 import { getRuntimeDisplayLabel, RuntimeIcon } from "./RuntimeIcon";
 import {
   type OnboardingTransitionDirection,
@@ -725,20 +726,22 @@ function RuntimeProvidersSection({
 
   return (
     <section className="flex min-h-full w-full flex-col items-center">
-      <div className="w-full max-w-[820px] text-center">
-        <h1 className="text-title font-normal text-foreground">
-          Use the models that fit the task
-        </h1>
-        <p className="mx-auto mt-3 max-w-[760px] text-sm leading-6 text-foreground/90">
-          <span>
-            Connect your model providers here. Each agent can use the one that’s
-            best for their work.
-          </span>
-          <span className="mt-1 block">
-            Choose at least one to start using Buzz.
-          </span>
-        </p>
-      </div>
+      <OnboardingStepHeader
+        className="max-w-[820px]"
+        description={
+          <>
+            <span>
+              Connect your model providers here. Each agent can use the one
+              that’s best for their work.
+            </span>
+            <span className="mt-1 block">
+              Choose at least one to start using Buzz.
+            </span>
+          </>
+        }
+        descriptionClassName="max-w-[760px] text-foreground/90"
+        title="Use the models that fit the task"
+      />
 
       <div className="flex w-full flex-1 flex-col items-center justify-center gap-8 py-10">
         <GitBashPrerequisiteCard />


### PR DESCRIPTION
## Why
Make the final onboarding team-intro step visually consistent with the rest of onboarding and keep local pre-push checks reliable on machines with lower file descriptor limits.

## What
- Add a shared onboarding step header component and use it across onboarding screens
- Update the team-intro body layout and CTAs to match the requested flow
- Reduce pair-relay cap-test file descriptor pressure with a configurable test cap

## Risk Assessment
Low — UI changes are scoped to onboarding surfaces, and the pair-relay production connection cap remains unchanged via `Relay::new`.

## References
- Verified by pre-push hooks during `git push`
- Verified `cargo test -p buzz-pair-relay`

Generated with Goose
