### PR TITLE
test(desktop): fix Escape-before-mount race in channel browser e2e

### DIFF
--- a/desktop/tests/e2e/channel-browser.spec.ts
+++ b/desktop/tests/e2e/channel-browser.spec.ts
@@ -257,8 +257,16 @@ test("canceling section create does not affect the next global create", async ({
   await page
     .getByTestId(`section-actions-${CUSTOM_SECTION.id}-quick-create`)
     .click();
+  // Gate on the dialog mounting before dismissing it. Escape sent before mount
+  // is dropped (no handler yet), and not.toBeVisible() then passes vacuously
+  // against a dialog that hasn't rendered — so the dialog opens *after* the
+  // assertion and its overlay swallows every later click.
+  await expect(page.getByTestId("channel-browser-dialog")).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("channel-browser-dialog")).not.toBeVisible();
+  // The overlay outlives the content by one exit animation; wait for it to
+  // detach so it can't intercept the next click.
+  await expect(page.getByTestId("dialog-overlay")).toHaveCount(0);
 
   await page.getByTestId("section-actions-channels-quick-create").click();
   const channelName = `global-after-cancel-${Date.now()}`;


### PR DESCRIPTION
## Why

`channel-browser.spec.ts:251 › canceling section create does not affect the next global create` fails intermittently in CI — it's currently red on at least two unrelated branches (#2097 and `cynthiac/profile-polish`), and it never reproduces locally on a fast machine.

## Root cause

The test clicks quick-create and sends `Escape` on the very next line:

```ts
await page.getByTestId(`section-actions-${CUSTOM_SECTION.id}-quick-create`).click();
await page.keyboard.press("Escape");
await expect(page.getByTestId("channel-browser-dialog")).not.toBeVisible();
```

On a slow runner the dialog hasn't mounted when `Escape` lands, so the keypress hits no handler and is dropped. `not.toBeVisible()` then passes **vacuously** — the dialog isn't merely hidden, it doesn't exist yet. The dialog mounts *after* the assertion, and its `data-state="open"` overlay intercepts pointer events for the rest of the test, timing out the next `quick-create` click at 30s.

That's why the CI log shows an overlay that is `open` rather than animating closed:

```
<div data-state="open" ... data-testid="dialog-overlay" ...> intercepts pointer events
```

A probe confirmed the sequence directly — at the instant the spec asserts "not visible," `dialog-overlay` count is `0`, and the overlay appears immediately afterward.

## Fix

Gate on the dialog actually being visible before dismissing it — the pattern this same file already uses at line ~498 — then wait for the overlay to detach so it can't outlive the content by one exit animation and swallow the next click.

## Testing

A/B under 20× CDP CPU throttling (imitating the CI runner):

| sequence | result |
|---|---|
| old (no mount gate) | **fails** — reproduces the exact CI error, `dialog-overlay ... intercepts pointer events` |
| new (this PR) | **passes** |

Full spec `channel-browser.spec.ts`: 29/29 serial. Test-only change — no product code touched.