### PR TITLE
fix: skip membership lookup for open relays

### DIFF
--- a/desktop/src-tauri/src/commands/relay_members.rs
+++ b/desktop/src-tauri/src/commands/relay_members.rs
@@ -1,10 +1,39 @@
+use serde::Deserialize;
 use tauri::State;
 
 use crate::{
     app_state::AppState,
     events, nostr_convert,
-    relay::{query_relay, submit_event},
+    relay::{
+        classify_request_error, parse_json_response, query_relay, relay_api_base_url_with_override,
+        relay_error_message, submit_event,
+    },
 };
+
+#[derive(Deserialize)]
+struct RelayInformationDocument {
+    #[serde(default)]
+    supported_nips: Vec<u32>,
+}
+
+#[tauri::command]
+pub async fn relay_requires_membership(state: State<'_, AppState>) -> Result<bool, String> {
+    let url = format!("{}/info", relay_api_base_url_with_override(&state));
+    let response = state
+        .http_client
+        .get(url)
+        .header("Accept", "application/nostr+json")
+        .send()
+        .await
+        .map_err(|error| classify_request_error(&error))?;
+
+    if !response.status().is_success() {
+        return Err(relay_error_message(response).await);
+    }
+
+    let info = parse_json_response::<RelayInformationDocument>(response).await?;
+    Ok(info.supported_nips.contains(&43))
+}
 
 #[tauri::command]
 pub async fn list_relay_members(state: State<'_, AppState>) -> Result<serde_json::Value, String> {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,4 @@
-// Deep async call chains under Tauri command futures exceed the default query depth when computing layouts.
-#![recursion_limit = "256"]
+#![recursion_limit = "256"] // Deep Tauri command futures exceed the default layout query depth.
 mod app_state;
 mod archive;
 mod builderlab;
@@ -749,6 +748,7 @@ pub fn run() {
             copy_image_to_clipboard,
             copy_text_to_clipboard,
             fetch_snapshot_bytes,
+            relay_requires_membership,
             list_relay_members,
             get_my_relay_membership,
             add_relay_member,

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/features/profile/hooks";
 import { relayClient } from "@/shared/api/relayClient";
 import { getMyRelayMembershipLookup } from "@/shared/api/relayMembers";
+import { isRelayUnreachableError } from "@/shared/lib/relayError";
 import {
   getIdentity,
   importIdentity,
@@ -57,6 +58,10 @@ async function checkMembershipStatus(): Promise<MembershipCheckResult> {
     return "ok";
   } catch (error) {
     if (isRelayMembershipDeniedError(error)) return "denied";
+    // Native Tauri commands report connectivity failures with the stable
+    // "relay unreachable:" prefix (see desktop/src-tauri/src/relay.rs), which
+    // the legacy browser-fetch substrings below do not match.
+    if (isRelayUnreachableError(error)) return "unreachable";
     if (error instanceof Error) {
       const msg = error.message.toLowerCase();
       if (

--- a/desktop/src/shared/api/relayMembers.test.mjs
+++ b/desktop/src/shared/api/relayMembers.test.mjs
@@ -1,7 +1,39 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { shouldWarnMissingMembershipSnapshot } from "./relayMembers.ts";
+import {
+  loadRelayMembershipLookup,
+  shouldWarnMissingMembershipSnapshot,
+} from "./relayMembers.ts";
+
+test("open relays skip the membership snapshot request", async () => {
+  const lookup = await loadRelayMembershipLookup("a".repeat(64), false, () =>
+    assert.fail("open relays must not request a membership snapshot"),
+  );
+
+  assert.deepEqual(lookup, {
+    snapshotFound: false,
+    membershipRequired: false,
+    membership: null,
+  });
+});
+
+test("membership relays request their membership snapshot", async () => {
+  const pubkey = "a".repeat(64);
+  let requestCount = 0;
+  const lookup = await loadRelayMembershipLookup(pubkey, true, async () => {
+    requestCount += 1;
+    return {
+      created_at: 1,
+      tags: [["member", pubkey, "admin"]],
+    };
+  });
+
+  assert.equal(requestCount, 1);
+  assert.equal(lookup.snapshotFound, true);
+  assert.equal(lookup.membershipRequired, true);
+  assert.equal(lookup.membership?.role, "admin");
+});
 
 test("missing snapshot warns when the relay requires membership", () => {
   assert.equal(

--- a/desktop/src/shared/api/relayMembers.ts
+++ b/desktop/src/shared/api/relayMembers.ts
@@ -1,5 +1,5 @@
 import { relayClient } from "@/shared/api/relayClient";
-import { getRelayHttpUrl, signRelayEvent } from "@/shared/api/tauri";
+import { invokeTauri, signRelayEvent } from "@/shared/api/tauri";
 import { getIdentity } from "@/shared/api/tauriIdentity";
 import type {
   RelayEvent,
@@ -123,18 +123,7 @@ export async function listRelayMembers(): Promise<RelayMember[]> {
 }
 
 async function relayRequiresMembership(): Promise<boolean> {
-  const base = (await getRelayHttpUrl()).replace(/\/+$/, "");
-  const response = await fetch(`${base}/info`, {
-    headers: { Accept: "application/nostr+json" },
-  });
-  if (!response.ok) {
-    throw new Error(`Relay information request failed (${response.status}).`);
-  }
-  const info = (await response.json()) as { supported_nips?: unknown };
-  return (
-    Array.isArray(info.supported_nips) &&
-    info.supported_nips.some((nip) => nip === 43)
-  );
+  return invokeTauri<boolean>("relay_requires_membership");
 }
 
 export async function getMyRelayMembershipLookup(): Promise<RelayMembershipLookup> {

--- a/desktop/src/shared/api/relayMembers.ts
+++ b/desktop/src/shared/api/relayMembers.ts
@@ -105,6 +105,18 @@ async function fetchMembershipListEvent(): Promise<RelayEvent | null> {
   return events[events.length - 1] ?? null;
 }
 
+/** Loads the NIP-43 snapshot only when the relay advertises membership support. */
+export async function loadRelayMembershipLookup(
+  pubkey: string,
+  membershipRequired: boolean,
+  fetchSnapshot: () => Promise<RelayEvent | null> = fetchMembershipListEvent,
+): Promise<RelayMembershipLookup> {
+  if (!membershipRequired) {
+    return relayMembershipLookupFromEvent(null, pubkey, false);
+  }
+  return relayMembershipLookupFromEvent(await fetchSnapshot(), pubkey, true);
+}
+
 export async function listRelayMembers(): Promise<RelayMember[]> {
   const event = await fetchMembershipListEvent();
   return event ? relayMembersFromEvent(event) : [];
@@ -126,13 +138,11 @@ async function relayRequiresMembership(): Promise<boolean> {
 }
 
 export async function getMyRelayMembershipLookup(): Promise<RelayMembershipLookup> {
-  const [{ pubkey }, event] = await Promise.all([
+  const [{ pubkey }, membershipRequired] = await Promise.all([
     getIdentity(),
-    fetchMembershipListEvent(),
+    relayRequiresMembership(),
   ]);
-  const membershipRequired =
-    event !== null || (await relayRequiresMembership());
-  return relayMembershipLookupFromEvent(event, pubkey, membershipRequired);
+  return loadRelayMembershipLookup(pubkey, membershipRequired);
 }
 
 export async function getMyRelayMembership(): Promise<RelayMember | null> {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -9419,6 +9419,8 @@ export function maybeInstallE2eTauriMocks() {
       }
       case "get_relay_http_url":
         return getRelayHttpUrl(activeConfig);
+      case "relay_requires_membership":
+        return true;
       case "discover_acp_providers":
         return handleDiscoverAcpRuntimes(activeConfig);
       case "discover_acp_auth_methods":

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -246,6 +246,8 @@ type E2eConfig = {
     // fail open (no mod-DM detection), matching the Rust command's contract.
     relaySelf?: string | null;
     oaOwnerIsMe?: boolean;
+    /** Whether the mock relay advertises NIP-43 membership support. Defaults to false. */
+    relayRequiresMembership?: boolean;
     relayRole?: "owner" | "admin" | "member" | null;
     // Descriptors returned by the mocked `pick_and_upload_media` /
     // `upload_media_bytes` commands. Lets a spec drive the attachment flow
@@ -9420,7 +9422,7 @@ export function maybeInstallE2eTauriMocks() {
       case "get_relay_http_url":
         return getRelayHttpUrl(activeConfig);
       case "relay_requires_membership":
-        return true;
+        return activeConfig?.mock?.relayRequiresMembership ?? false;
       case "discover_acp_providers":
         return handleDiscoverAcpRuntimes(activeConfig);
       case "discover_acp_auth_methods":

--- a/desktop/tests/e2e/identity-archive.spec.ts
+++ b/desktop/tests/e2e/identity-archive.spec.ts
@@ -72,6 +72,7 @@ test.describe("NIP-IA archive button gate", () => {
   }) => {
     await installMockBridge(page, {
       relayRole: "admin",
+      relayRequiresMembership: true,
       oaOwnerIsMe: false,
       archivedIdentities: [],
     });
@@ -122,6 +123,7 @@ test.describe("NIP-IA archive button gate", () => {
   }) => {
     await installMockBridge(page, {
       relayRole: "admin",
+      relayRequiresMembership: true,
       oaOwnerIsMe: false,
       archivedIdentities: [ALICE_PUBKEY],
     });

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -26,28 +26,14 @@ async function setRelayConnectionState(
   page: Page,
   state: RelayConnectionState,
 ) {
-  if (state !== "connected") {
-    await page.waitForFunction(() => {
-      const win = window as Window & {
-        __BUZZ_E2E_GET_RELAY_CONNECTION_STATE__?: () => string;
-        __BUZZ_E2E_SET_RELAY_CONNECTION_STATE__?: unknown;
-      };
-      return (
-        typeof win.__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__ === "function" &&
-        typeof win.__BUZZ_E2E_GET_RELAY_CONNECTION_STATE__ === "function" &&
-        win.__BUZZ_E2E_GET_RELAY_CONNECTION_STATE__() === "connected"
-      );
-    });
-  } else {
-    await page.waitForFunction(
-      () =>
-        typeof (
-          window as Window & {
-            __BUZZ_E2E_SET_RELAY_CONNECTION_STATE__?: unknown;
-          }
-        ).__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__ === "function",
-    );
-  }
+  await page.waitForFunction(
+    () =>
+      typeof (
+        window as Window & {
+          __BUZZ_E2E_SET_RELAY_CONNECTION_STATE__?: unknown;
+        }
+      ).__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__ === "function",
+  );
   await page.evaluate((nextState) => {
     const testWindow = window as Window & {
       __BUZZ_E2E_SET_RELAY_CONNECTION_STATE__?: (
@@ -58,6 +44,12 @@ async function setRelayConnectionState(
       testWindow.__BUZZ_E2E_SET_RELAY_CONNECTION_STATE__;
     if (!setConnectionState) {
       throw new Error("Mock relay connection state helper is not installed.");
+    }
+    // Open-relay onboarding may not start a socket before the test exercises
+    // connectivity UI. Establish the same connected baseline explicitly so a
+    // delayed mock handshake cannot overwrite the degraded state.
+    if (nextState !== "connected") {
+      setConnectionState("connected");
     }
     setConnectionState(nextState);
   }, state);
@@ -2337,6 +2329,27 @@ test("existing relay profile with display name auto-completes onboarding", async
   await expectHomeView(page);
 });
 
+test("open relay skips membership gating during onboarding", async ({
+  page,
+}) => {
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
+  await installMockBridge(
+    page,
+    {
+      relayRequiresMembership: false,
+      relayRole: null,
+    },
+    { skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+
+  await page.getByTestId("onboarding-display-name").fill("Morty QA");
+  await page.getByTestId("onboarding-next").click();
+
+  await expect(page.getByTestId("onboarding-page-avatar")).toBeVisible();
+  await expect(page.getByTestId("membership-denied")).toHaveCount(0);
+});
+
 test("membership denial can import a different invited key", async ({
   page,
 }) => {
@@ -2344,6 +2357,7 @@ test("membership denial can import a different invited key", async ({
   await installMockBridge(
     page,
     {
+      relayRequiresMembership: true,
       relayRole: null,
     },
     { skipOnboardingSeed: true },
@@ -2482,6 +2496,7 @@ test("membership denied shows all four affordances and change-community edits no
   await installMockBridge(
     page,
     {
+      relayRequiresMembership: true,
       relayRole: null,
     },
     { skipOnboardingSeed: true },
@@ -2557,6 +2572,7 @@ test("cancel from profile Back preserves drafts and denied Back returns to inter
   await installMockBridge(
     page,
     {
+      relayRequiresMembership: true,
       relayRole: null,
     },
     { skipOnboardingSeed: true },
@@ -2600,6 +2616,7 @@ test("denied on relay A then paste relay B invite URL switches community to B", 
   await installMockBridge(
     page,
     {
+      relayRequiresMembership: true,
       relayRole: null,
     },
     { skipOnboardingSeed: true },

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -271,6 +271,8 @@ type MockBridgeOptions = {
    * (owner-path branch of the gate).
    */
   oaOwnerIsMe?: boolean;
+  /** Whether the mock relay advertises NIP-43 membership support. Defaults to false. */
+  relayRequiresMembership?: boolean;
   /**
    * Active identity's role in the seeded `mockRelayMembers`. `null` removes
    * the active identity from the membership list entirely (admin-path branch

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -610,16 +610,6 @@ export async function installBridge(page: Page, options: BridgeOptions) {
       ? TEST_IDENTITIES[options.user ?? "tyler"]
       : undefined;
 
-  if (options.mode === "mock") {
-    const relayHttpUrl = options.relayHttpUrl ?? DEFAULT_RELAY_HTTP_URL;
-    await page.route(`${relayHttpUrl.replace(/\/+$/, "")}/info`, (route) =>
-      route.fulfill({
-        body: JSON.stringify({ supported_nips: [43] }),
-        contentType: "application/nostr+json",
-      }),
-    );
-  }
-
   // Most specs seed a community so useCommunityInit doesn't show WelcomeSetup.
   // skipOnboardingSeed only controls the onboarding-completion flag.
   if (!options.skipCommunitySeed) {

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -610,6 +610,16 @@ export async function installBridge(page: Page, options: BridgeOptions) {
       ? TEST_IDENTITIES[options.user ?? "tyler"]
       : undefined;
 
+  if (options.mode === "mock") {
+    const relayHttpUrl = options.relayHttpUrl ?? DEFAULT_RELAY_HTTP_URL;
+    await page.route(`${relayHttpUrl.replace(/\/+$/, "")}/info`, (route) =>
+      route.fulfill({
+        body: JSON.stringify({ supported_nips: [43] }),
+        contentType: "application/nostr+json",
+      }),
+    );
+  }
+
   // Most specs seed a community so useCommunityInit doesn't show WelcomeSetup.
   // skipOnboardingSeed only controls the onboarding-completion flag.
   if (!options.skipCommunitySeed) {


### PR DESCRIPTION
## summary

- check nip-11 before requesting the nip-43 membership snapshot
- skip the snapshot request when relay membership is unsupported
- cover open and membership relay behavior

## testing

- targeted relay membership tests
- desktop typecheck
- biome
- pre-commit hooks
- pre-push hooks