### PR TITLE
release(helm): buzz chart 0.1.6

### DIFF
--- a/deploy/charts/buzz/Chart.yaml
+++ b/deploy/charts/buzz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   PostgreSQL and Redis. Configurable for single-node evaluation
   (subcharts on) and HA production (external services, existingSecret).
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.1.0"
 home: https://github.com/block/buzz
 sources:
@@ -23,8 +23,8 @@ maintainers:
     url: https://github.com/block
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Allow CPU-only relay autoscaling when no custom-metrics adapter is installed.
+    - kind: added
+      description: Optional READ_DATABASE_URL env (secretKeyRef) enabling relay read-replica routing; absent key preserves prior behavior.
   artifacthub.io/license: Apache-2.0
 
 # Optional eval-only subcharts. Production deploys disable both and point


### PR DESCRIPTION
## What

Bump the buzz Helm chart to **0.1.6** to publish the chart carrying the `READ_DATABASE_URL` wiring merged in #2084 (read-replica routing enablement seam).

Chart delta vs 0.1.5 (already on `main` via #2084):
- Relay Deployment injects `READ_DATABASE_URL` as an **optional** `secretKeyRef` — absent key renders identically to 0.1.5. Enabling replica routing is a deliberate secret change, never a chart-upgrade side effect.
- Render tests cover both chart-managed secret and `secrets.existingSecret` modes.
- `artifacthub.io/changes` updated accordingly.

## Publish path

Merging this PR triggers `auto-tag-on-release-pr-merge.yml` (chart-release/* lane → tag `chart-v0.1.6` → dispatch `helm-chart.yml`), which packages and pushes the chart to `oci://ghcr.io/block/buzz/charts/buzz`.

## Verification

- `helm lint`: pass (icon INFO only)
- `helm unittest`: 39/39 across 9 suites at this commit
