### PR TITLE
Open community creation signup from desktop

### DIFF
--- a/desktop/src/features/communities/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/communities/ui/WelcomeSetup.tsx
@@ -37,7 +37,7 @@ type WelcomeSetupProps = {
   onBack: () => void;
 };
 
-const CREATE_COMMUNITY_URL = "https://buzz.xyz";
+const CREATE_COMMUNITY_URL = "https://app.builderlab.xyz/signup?returnTo=/buzz";
 const LOCAL_DEV_RELAY_URLS = new Set([
   "ws://localhost:3000",
   "ws://127.0.0.1:3000",

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -636,7 +636,9 @@ test("first-community choices expose npub and invite input", async ({
           ?.payload;
       }),
     )
-    .toMatchObject({ url: "https://buzz.xyz" });
+    .toMatchObject({
+      url: "https://app.builderlab.xyz/signup?returnTo=/buzz",
+    });
 
   await page.getByRole("button", { name: "Add me to a community" }).click();
   await expect(page.getByTestId("welcome-join-npub")).toHaveText(


### PR DESCRIPTION
## Summary
- send the desktop “I want to create a community” action directly to the Buzz signup flow
- return authenticated users to `/buzz` for identity linking and community creation
- update the onboarding E2E assertion for the new destination

## Verification
- `just desktop-check`
- `just desktop-test`
- pre-push checks: desktop, mobile, Tauri, and Rust tests
- 
<img width="1253" height="869" alt="Screenshot 2026-07-18 at 8 35 39 PM" src="https://github.com/user-attachments/assets/6edd92f9-21ad-48ce-a446-88f8f680360c" />

should open to:

<img width="1751" height="1209" alt="Screenshot 2026-07-18 at 8 36 18 PM" src="https://github.com/user-attachments/assets/dca34be8-71a5-4e5a-a8c5-a44e367025ef" />
