### PR TITLE
feat(acp): follow mentioned threads

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -50,6 +50,10 @@ pub enum ConfigError {
 #[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
 pub enum SubscribeMode {
     Mentions,
+    /// Follow a conversation after an explicit mention, without subscribing the
+    /// agent to unrelated channel traffic at the prompt boundary.
+    #[value(name = "thread-follow")]
+    ThreadFollow,
     All,
     Config,
 }
@@ -1172,6 +1176,26 @@ pub fn resolve_channel_filters(
                 );
             }
         }
+        SubscribeMode::ThreadFollow => {
+            let kinds = config.kinds_override.clone().unwrap_or_else(|| {
+                vec![
+                    KIND_STREAM_MESSAGE,
+                    KIND_WORKFLOW_APPROVAL_REQUESTED,
+                    KIND_STREAM_REMINDER,
+                ]
+            });
+            for ch in &target_channels {
+                result.insert(
+                    *ch,
+                    ChannelFilter {
+                        kinds: Some(kinds.clone()),
+                        // Thread membership is dynamic, so this broad relay
+                        // filter is paired with ThreadFollowState's local gate.
+                        require_mention: false,
+                    },
+                );
+            }
+        }
         SubscribeMode::All => {
             for ch in &target_channels {
                 result.insert(
@@ -1267,6 +1291,16 @@ pub fn resolve_dynamic_channel_filter(
                 ]
             })),
             require_mention: !config.no_mention_filter,
+        }),
+        SubscribeMode::ThreadFollow => Some(ChannelFilter {
+            kinds: Some(config.kinds_override.clone().unwrap_or_else(|| {
+                vec![
+                    KIND_STREAM_MESSAGE,
+                    KIND_WORKFLOW_APPROVAL_REQUESTED,
+                    KIND_STREAM_REMINDER,
+                ]
+            })),
+            require_mention: false,
         }),
         SubscribeMode::All => Some(ChannelFilter {
             kinds: config.kinds_override.clone(),
@@ -1623,6 +1657,26 @@ mod tests {
     fn codex_network_env_schemeless_string_returns_none() {
         // A bare string with no scheme fails Url::parse — graceful None return.
         assert!(codex_network_env("codex-acp", "not-a-url").is_none());
+    }
+
+    #[test]
+    fn test_thread_follow_mode_subscribes_to_default_kinds_without_mention_filter() {
+        let config = test_config(SubscribeMode::ThreadFollow);
+        let channels = vec![Uuid::new_v4()];
+        let result = resolve_channel_filters(&config, &channels, &[]);
+        let filter = result.get(&channels[0]).expect("channel should be present");
+        assert!(!filter.require_mention);
+        assert_eq!(
+            filter
+                .kinds
+                .as_ref()
+                .expect("thread-follow has bounded kinds"),
+            &vec![
+                buzz_core::kind::KIND_STREAM_MESSAGE,
+                buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED,
+                buzz_core::kind::KIND_STREAM_REMINDER,
+            ]
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -9,6 +9,7 @@ mod pool;
 mod queue;
 mod relay;
 mod setup_mode;
+mod thread_follow;
 mod usage;
 
 pub use usage::TurnUsage;
@@ -41,6 +42,9 @@ use pool::{
 };
 use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
 use relay::{HarnessRelay, RelayEventPublisher};
+use thread_follow::{
+    ThreadFollowAdmission, ThreadFollowState, DEFAULT_FOLLOW_TTL, DEFAULT_MAX_FOLLOWED_THREADS,
+};
 use tokio::sync::{mpsc, watch};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
@@ -1383,6 +1387,26 @@ async fn tokio_main() -> Result<()> {
                 prompt_tag: Some("@mention".into()),
             }]
         }
+        SubscribeMode::ThreadFollow => {
+            vec![SubscriptionRule {
+                name: "thread-follow".into(),
+                channels: filter::ChannelScope::All("all".into()),
+                kinds: config.kinds_override.clone().unwrap_or_else(|| {
+                    vec![
+                        KIND_STREAM_MESSAGE,
+                        KIND_WORKFLOW_APPROVAL_REQUESTED,
+                        KIND_STREAM_REMINDER,
+                    ]
+                }),
+                // The relay must deliver non-mentioned replies; ThreadFollowState
+                // restores the stricter local admission policy below.
+                require_mention: false,
+                filter: None,
+                compiled_filter: None,
+                consecutive_timeouts: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+                prompt_tag: Some("thread-follow".into()),
+            }]
+        }
         SubscribeMode::All => {
             vec![SubscriptionRule {
                 name: "all".into(),
@@ -1441,6 +1465,8 @@ async fn tokio_main() -> Result<()> {
     let dedup_mode = config.dedup_mode;
     let mut queue =
         EventQueue::new(dedup_mode).with_in_flight_deadline(config.max_turn_duration_secs);
+    let mut thread_follow = (config.subscribe_mode == SubscribeMode::ThreadFollow)
+        .then(|| ThreadFollowState::new(DEFAULT_FOLLOW_TTL, DEFAULT_MAX_FOLLOWED_THREADS));
 
     let base_prompt_content = config.base_prompt_content.take();
     let ctx = Arc::new(PromptContext {
@@ -1833,6 +1859,7 @@ async fn tokio_main() -> Result<()> {
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
+                                    thread_follow.as_mut().map(|state| state.remove_channel(ch));
                                     typing_channels.remove(&ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
@@ -2009,6 +2036,18 @@ async fn tokio_main() -> Result<()> {
                                     continue;
                                 }
                             };
+                            let thread_follow_admission = thread_follow.as_mut().map(|state| {
+                                state.classify(
+                                    buzz_event.channel_id,
+                                    &buzz_event.event,
+                                    &pubkey_hex,
+                                    std::time::Instant::now(),
+                                )
+                            });
+                            if matches!(thread_follow_admission, Some(ThreadFollowAdmission::Reject)) {
+                                tracing::debug!(channel_id = %buzz_event.channel_id, "thread-follow admission — dropping unrelated event");
+                                continue;
+                            }
                             // Capture author pubkey before queue.push() moves
                             // buzz_event.event (needed for mode gate below).
                             let author_hex = buzz_event.event.pubkey.to_hex();
@@ -2037,6 +2076,11 @@ async fn tokio_main() -> Result<()> {
                             // guard's cleanup may race with this add, leaving a
                             // cosmetic stale 👀. Acceptable — see ReactionGuard docs.
                             if accepted {
+                                if let (Some(state), Some(admission)) =
+                                    (thread_follow.as_mut(), thread_follow_admission.as_ref())
+                                {
+                                    state.record(buzz_event.channel_id, admission, std::time::Instant::now());
+                                }
                                 let rc = ctx.rest_client.clone();
                                 let eid = event_id_hex.clone();
                                 tokio::spawn(async move {

--- a/crates/buzz-acp/src/thread_follow.rs
+++ b/crates/buzz-acp/src/thread_follow.rs
@@ -1,0 +1,211 @@
+//! In-memory admission state for `--subscribe thread-follow`.
+//!
+//! The relay must deliver non-mentioned replies for this mode, so its NIP-01
+//! filter is deliberately broader than a mention filter. This state restores a
+//! strict local boundary before events enter the queue: an event is admitted
+//! only when it explicitly mentions this agent or belongs to a thread that a
+//! previously accepted mention opened.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use nostr::Event;
+use uuid::Uuid;
+
+use crate::queue::parse_thread_tags;
+
+/// Keep only recent active conversations. State is process-local and is
+/// intentionally lost on restart, which fails closed rather than turning the
+/// harness into a persistent channel-wide listener.
+pub const DEFAULT_FOLLOW_TTL: Duration = Duration::from_secs(60 * 60);
+pub const DEFAULT_MAX_FOLLOWED_THREADS: usize = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadFollowAdmission {
+    /// An explicit mention is always eligible and starts (or refreshes) a lease.
+    Mention { root_event_id: String },
+    /// A later message belongs to an active followed thread.
+    Followed { root_event_id: String },
+    /// Neither explicitly mentioned nor part of a followed thread.
+    Reject,
+}
+
+/// Bounded, per-channel thread-follow leases.
+#[derive(Debug)]
+pub struct ThreadFollowState {
+    followed: HashMap<(Uuid, String), Instant>,
+    ttl: Duration,
+    capacity: usize,
+}
+
+impl ThreadFollowState {
+    pub fn new(ttl: Duration, capacity: usize) -> Self {
+        Self {
+            followed: HashMap::new(),
+            ttl,
+            capacity,
+        }
+    }
+
+    /// Classify an event without mutating state. Call [`record`] only after the
+    /// event has been accepted by the queue, so dropped duplicate events cannot
+    /// create or extend a follow lease.
+    pub fn classify(
+        &mut self,
+        channel_id: Uuid,
+        event: &Event,
+        agent_pubkey_hex: &str,
+        now: Instant,
+    ) -> ThreadFollowAdmission {
+        self.prune_expired(now);
+        let thread = parse_thread_tags(event);
+        let root_event_id = thread.root_event_id.unwrap_or_else(|| event.id.to_hex());
+        let mentioned = thread
+            .mentioned_pubkeys
+            .iter()
+            .any(|pubkey| pubkey == agent_pubkey_hex);
+
+        if mentioned {
+            return ThreadFollowAdmission::Mention { root_event_id };
+        }
+        if self
+            .followed
+            .contains_key(&(channel_id, root_event_id.clone()))
+        {
+            ThreadFollowAdmission::Followed { root_event_id }
+        } else {
+            ThreadFollowAdmission::Reject
+        }
+    }
+
+    /// Record an event that was admitted to the queue. Both explicit mentions
+    /// and followed replies refresh the idle lease while preserving the bounded
+    /// number of tracked thread roots.
+    pub fn record(&mut self, channel_id: Uuid, admission: &ThreadFollowAdmission, now: Instant) {
+        let root_event_id = match admission {
+            ThreadFollowAdmission::Mention { root_event_id }
+            | ThreadFollowAdmission::Followed { root_event_id } => root_event_id,
+            ThreadFollowAdmission::Reject => return,
+        };
+        self.prune_expired(now);
+        let key = (channel_id, root_event_id.clone());
+        if !self.followed.contains_key(&key) && self.followed.len() >= self.capacity {
+            if let Some(oldest) = self
+                .followed
+                .iter()
+                .min_by_key(|(_, last_active)| **last_active)
+                .map(|(key, _)| key.clone())
+            {
+                self.followed.remove(&oldest);
+            }
+        }
+        self.followed.insert(key, now);
+    }
+
+    pub fn remove_channel(&mut self, channel_id: Uuid) {
+        self.followed
+            .retain(|(channel, _), _| *channel != channel_id);
+    }
+
+    fn prune_expired(&mut self, now: Instant) {
+        self.followed
+            .retain(|_, last_active| now.duration_since(*last_active) <= self.ttl);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    fn event(tags: &[Vec<&str>]) -> Event {
+        let tags = tags
+            .iter()
+            .map(|tag| Tag::parse(tag.clone()).unwrap())
+            .collect::<Vec<_>>();
+        EventBuilder::new(Kind::Custom(9), "message")
+            .tags(tags)
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+    }
+
+    #[test]
+    fn follows_only_the_thread_started_by_a_mention() {
+        let channel = Uuid::new_v4();
+        let agent = "a".repeat(64);
+        let now = Instant::now();
+        let mut state = ThreadFollowState::new(DEFAULT_FOLLOW_TTL, 10);
+        let mention = event(&[vec!["p", &agent]]);
+        let admission = state.classify(channel, &mention, &agent, now);
+        assert!(matches!(admission, ThreadFollowAdmission::Mention { .. }));
+        let root = mention.id.to_hex();
+        state.record(channel, &admission, now);
+
+        let reply = event(&[vec!["e", &root, "", "reply"]]);
+        assert!(matches!(
+            state.classify(channel, &reply, &agent, now),
+            ThreadFollowAdmission::Followed { .. }
+        ));
+
+        let unrelated = event(&[]);
+        assert_eq!(
+            state.classify(channel, &unrelated, &agent, now),
+            ThreadFollowAdmission::Reject
+        );
+    }
+
+    #[test]
+    fn follows_nested_replies_but_not_another_channel() {
+        let channel = Uuid::new_v4();
+        let other_channel = Uuid::new_v4();
+        let agent = "a".repeat(64);
+        let now = Instant::now();
+        let mut state = ThreadFollowState::new(DEFAULT_FOLLOW_TTL, 10);
+        let root = "b".repeat(64);
+        let mention = event(&[vec!["e", &root, "", "reply"], vec!["p", &agent]]);
+        let admission = state.classify(channel, &mention, &agent, now);
+        state.record(channel, &admission, now);
+        let nested = event(&[
+            vec!["e", &root, "", "root"],
+            vec!["e", &"c".repeat(64), "", "reply"],
+        ]);
+        assert!(matches!(
+            state.classify(channel, &nested, &agent, now),
+            ThreadFollowAdmission::Followed { .. }
+        ));
+        assert_eq!(
+            state.classify(other_channel, &nested, &agent, now),
+            ThreadFollowAdmission::Reject
+        );
+    }
+
+    #[test]
+    fn expires_and_evicts_oldest_thread() {
+        let channel = Uuid::new_v4();
+        let agent = "a".repeat(64);
+        let now = Instant::now();
+        let mut state = ThreadFollowState::new(Duration::from_secs(10), 1);
+        let first = event(&[vec!["p", &agent]]);
+        let first_admission = state.classify(channel, &first, &agent, now);
+        state.record(channel, &first_admission, now);
+        let second = event(&[vec!["p", &agent]]);
+        let second_admission =
+            state.classify(channel, &second, &agent, now + Duration::from_secs(1));
+        state.record(channel, &second_admission, now + Duration::from_secs(1));
+        let first_reply = event(&[vec!["e", &first.id.to_hex(), "", "reply"]]);
+        assert_eq!(
+            state.classify(channel, &first_reply, &agent, now + Duration::from_secs(1)),
+            ThreadFollowAdmission::Reject
+        );
+        let second_reply = event(&[vec!["e", &second.id.to_hex(), "", "reply"]]);
+        assert_eq!(
+            state.classify(
+                channel,
+                &second_reply,
+                &agent,
+                now + Duration::from_secs(12)
+            ),
+            ThreadFollowAdmission::Reject
+        );
+    }
+}


### PR DESCRIPTION
An agent conversation should work like a conversation.

Today, after someone mentions an agent in a thread, every follow-up needs another mention. The only alternative is subscribing the agent to the whole channel. That makes a thread feel less like a conversation and more like a series of disconnected commands.

This adds `--subscribe thread-follow`.

A mention invites an agent into a thread. After that, replies in the same thread can continue normally without repeatedly writing `@agent`. Messages elsewhere in the channel still do not wake it.

The intended model is simple:

- the **channel** is the shared room;
- the **thread** is a smaller conversation within it;
- a mention is an invitation to join that conversation;
- the agent remains available there while it is active, then quietly stops following it after inactivity.

This matters more as a thread includes several people or agents. Requiring everyone to re-mention the agent on every message breaks the rhythm. Listening to the entire channel is worse: it creates noise, surprise, and unwanted work.

## What this PR does

- Adds opt-in `--subscribe thread-follow` to the ACP harness.
- Starts following a thread when an eligible author explicitly mentions the agent.
- Accepts later replies only under that thread's NIP-10 root.
- Drops unrelated channel traffic before it reaches the queue or model.
- Leaves existing `mentions`, `all`, and `config` modes unchanged.

It does **not** loosen `respond_to`. The normal owner/allowlist author check runs before thread-follow logic.

Follow state is deliberately small and temporary: it is local to the harness process, isolated per channel, holds at most 100 thread roots, expires after one idle hour, and is cleared on restart or channel removal. In other words, it fails closed rather than quietly becoming a permanent channel subscription.

## Why ACP-only for now

This is the smallest place to establish the runtime behavior. There is no new protocol, persistence model, or Desktop setting in this PR. If maintainers agree the interaction is right, a UI control and clearer user-facing language can follow without locking them in before that decision.

## Tests

`cargo fmt --check` and `cargo test -p buzz-acp --lib` pass (534 tests). The new tests cover:

- a top-level mention opening a conversation;
- direct and nested replies continuing it;
- messages in another thread or channel being ignored;
- lease expiry and bounded eviction.

## Questions for maintainers

1. Is `thread-follow` the right name and place for this control?
2. Is temporary in-memory state the right first version, or should a followed conversation survive a harness restart?
3. Should a future version provide an explicit way for a person or agent to leave/close the conversation, rather than relying only on inactivity?
