### PR TITLE
Let agents follow a thread after a mention

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -50,6 +50,10 @@ pub enum ConfigError {
 #[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
 pub enum SubscribeMode {
     Mentions,
+    /// Follow a conversation after an explicit mention, without subscribing the
+    /// agent to unrelated channel traffic at the prompt boundary.
+    #[value(name = "thread-follow")]
+    ThreadFollow,
     All,
     Config,
 }
@@ -1172,6 +1176,26 @@ pub fn resolve_channel_filters(
                 );
             }
         }
+        SubscribeMode::ThreadFollow => {
+            let kinds = config.kinds_override.clone().unwrap_or_else(|| {
+                vec![
+                    KIND_STREAM_MESSAGE,
+                    KIND_WORKFLOW_APPROVAL_REQUESTED,
+                    KIND_STREAM_REMINDER,
+                ]
+            });
+            for ch in &target_channels {
+                result.insert(
+                    *ch,
+                    ChannelFilter {
+                        kinds: Some(kinds.clone()),
+                        // Thread membership is dynamic, so this broad relay
+                        // filter is paired with ThreadFollowState's local gate.
+                        require_mention: false,
+                    },
+                );
+            }
+        }
         SubscribeMode::All => {
             for ch in &target_channels {
                 result.insert(
@@ -1267,6 +1291,16 @@ pub fn resolve_dynamic_channel_filter(
                 ]
             })),
             require_mention: !config.no_mention_filter,
+        }),
+        SubscribeMode::ThreadFollow => Some(ChannelFilter {
+            kinds: Some(config.kinds_override.clone().unwrap_or_else(|| {
+                vec![
+                    KIND_STREAM_MESSAGE,
+                    KIND_WORKFLOW_APPROVAL_REQUESTED,
+                    KIND_STREAM_REMINDER,
+                ]
+            })),
+            require_mention: false,
         }),
         SubscribeMode::All => Some(ChannelFilter {
             kinds: config.kinds_override.clone(),
@@ -1623,6 +1657,26 @@ mod tests {
     fn codex_network_env_schemeless_string_returns_none() {
         // A bare string with no scheme fails Url::parse — graceful None return.
         assert!(codex_network_env("codex-acp", "not-a-url").is_none());
+    }
+
+    #[test]
+    fn test_thread_follow_mode_subscribes_to_default_kinds_without_mention_filter() {
+        let config = test_config(SubscribeMode::ThreadFollow);
+        let channels = vec![Uuid::new_v4()];
+        let result = resolve_channel_filters(&config, &channels, &[]);
+        let filter = result.get(&channels[0]).expect("channel should be present");
+        assert!(!filter.require_mention);
+        assert_eq!(
+            filter
+                .kinds
+                .as_ref()
+                .expect("thread-follow has bounded kinds"),
+            &vec![
+                buzz_core::kind::KIND_STREAM_MESSAGE,
+                buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED,
+                buzz_core::kind::KIND_STREAM_REMINDER,
+            ]
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -9,6 +9,7 @@ mod pool;
 mod queue;
 mod relay;
 mod setup_mode;
+mod thread_follow;
 mod usage;
 
 pub use usage::TurnUsage;
@@ -41,6 +42,9 @@ use pool::{
 };
 use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
 use relay::{HarnessRelay, RelayEventPublisher};
+use thread_follow::{
+    ThreadFollowAdmission, ThreadFollowState, DEFAULT_FOLLOW_TTL, DEFAULT_MAX_FOLLOWED_THREADS,
+};
 use tokio::sync::{mpsc, watch};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
@@ -1383,6 +1387,26 @@ async fn tokio_main() -> Result<()> {
                 prompt_tag: Some("@mention".into()),
             }]
         }
+        SubscribeMode::ThreadFollow => {
+            vec![SubscriptionRule {
+                name: "thread-follow".into(),
+                channels: filter::ChannelScope::All("all".into()),
+                kinds: config.kinds_override.clone().unwrap_or_else(|| {
+                    vec![
+                        KIND_STREAM_MESSAGE,
+                        KIND_WORKFLOW_APPROVAL_REQUESTED,
+                        KIND_STREAM_REMINDER,
+                    ]
+                }),
+                // The relay must deliver non-mentioned replies; ThreadFollowState
+                // restores the stricter local admission policy below.
+                require_mention: false,
+                filter: None,
+                compiled_filter: None,
+                consecutive_timeouts: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+                prompt_tag: Some("thread-follow".into()),
+            }]
+        }
         SubscribeMode::All => {
             vec![SubscriptionRule {
                 name: "all".into(),
@@ -1441,6 +1465,8 @@ async fn tokio_main() -> Result<()> {
     let dedup_mode = config.dedup_mode;
     let mut queue =
         EventQueue::new(dedup_mode).with_in_flight_deadline(config.max_turn_duration_secs);
+    let mut thread_follow = (config.subscribe_mode == SubscribeMode::ThreadFollow)
+        .then(|| ThreadFollowState::new(DEFAULT_FOLLOW_TTL, DEFAULT_MAX_FOLLOWED_THREADS));
 
     let base_prompt_content = config.base_prompt_content.take();
     let ctx = Arc::new(PromptContext {
@@ -1833,6 +1859,7 @@ async fn tokio_main() -> Result<()> {
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
+                                    thread_follow.as_mut().map(|state| state.remove_channel(ch));
                                     typing_channels.remove(&ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
@@ -2009,6 +2036,18 @@ async fn tokio_main() -> Result<()> {
                                     continue;
                                 }
                             };
+                            let thread_follow_admission = thread_follow.as_mut().map(|state| {
+                                state.classify(
+                                    buzz_event.channel_id,
+                                    &buzz_event.event,
+                                    &pubkey_hex,
+                                    std::time::Instant::now(),
+                                )
+                            });
+                            if matches!(thread_follow_admission, Some(ThreadFollowAdmission::Reject)) {
+                                tracing::debug!(channel_id = %buzz_event.channel_id, "thread-follow admission — dropping unrelated event");
+                                continue;
+                            }
                             // Capture author pubkey before queue.push() moves
                             // buzz_event.event (needed for mode gate below).
                             let author_hex = buzz_event.event.pubkey.to_hex();
@@ -2037,6 +2076,11 @@ async fn tokio_main() -> Result<()> {
                             // guard's cleanup may race with this add, leaving a
                             // cosmetic stale 👀. Acceptable — see ReactionGuard docs.
                             if accepted {
+                                if let (Some(state), Some(admission)) =
+                                    (thread_follow.as_mut(), thread_follow_admission.as_ref())
+                                {
+                                    state.record(buzz_event.channel_id, admission, std::time::Instant::now());
+                                }
                                 let rc = ctx.rest_client.clone();
                                 let eid = event_id_hex.clone();
                                 tokio::spawn(async move {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -42,9 +42,7 @@ use pool::{
 };
 use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
 use relay::{HarnessRelay, RelayEventPublisher};
-use thread_follow::{
-    ThreadFollowAdmission, ThreadFollowState, DEFAULT_FOLLOW_TTL, DEFAULT_MAX_FOLLOWED_THREADS,
-};
+use thread_follow::{ThreadFollowAdmission, ThreadFollowState, DEFAULT_MAX_FOLLOWED_THREADS};
 use tokio::sync::{mpsc, watch};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
@@ -1466,7 +1464,7 @@ async fn tokio_main() -> Result<()> {
     let mut queue =
         EventQueue::new(dedup_mode).with_in_flight_deadline(config.max_turn_duration_secs);
     let mut thread_follow = (config.subscribe_mode == SubscribeMode::ThreadFollow)
-        .then(|| ThreadFollowState::new(DEFAULT_FOLLOW_TTL, DEFAULT_MAX_FOLLOWED_THREADS));
+        .then(|| ThreadFollowState::new(DEFAULT_MAX_FOLLOWED_THREADS));
 
     let base_prompt_content = config.base_prompt_content.take();
     let ctx = Arc::new(PromptContext {

--- a/crates/buzz-acp/src/thread_follow.rs
+++ b/crates/buzz-acp/src/thread_follow.rs
@@ -1,0 +1,211 @@
+//! In-memory admission state for `--subscribe thread-follow`.
+//!
+//! The relay must deliver non-mentioned replies for this mode, so its NIP-01
+//! filter is deliberately broader than a mention filter. This state restores a
+//! strict local boundary before events enter the queue: an event is admitted
+//! only when it explicitly mentions this agent or belongs to a thread that a
+//! previously accepted mention opened.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use nostr::Event;
+use uuid::Uuid;
+
+use crate::queue::parse_thread_tags;
+
+/// Keep only recent active conversations. State is process-local and is
+/// intentionally lost on restart, which fails closed rather than turning the
+/// harness into a persistent channel-wide listener.
+pub const DEFAULT_FOLLOW_TTL: Duration = Duration::from_secs(60 * 60);
+pub const DEFAULT_MAX_FOLLOWED_THREADS: usize = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadFollowAdmission {
+    /// An explicit mention is always eligible and starts (or refreshes) a lease.
+    Mention { root_event_id: String },
+    /// A later message belongs to an active followed thread.
+    Followed { root_event_id: String },
+    /// Neither explicitly mentioned nor part of a followed thread.
+    Reject,
+}
+
+/// Bounded, per-channel thread-follow leases.
+#[derive(Debug)]
+pub struct ThreadFollowState {
+    followed: HashMap<(Uuid, String), Instant>,
+    ttl: Duration,
+    capacity: usize,
+}
+
+impl ThreadFollowState {
+    pub fn new(ttl: Duration, capacity: usize) -> Self {
+        Self {
+            followed: HashMap::new(),
+            ttl,
+            capacity,
+        }
+    }
+
+    /// Classify an event without mutating state. Call [`record`] only after the
+    /// event has been accepted by the queue, so dropped duplicate events cannot
+    /// create or extend a follow lease.
+    pub fn classify(
+        &mut self,
+        channel_id: Uuid,
+        event: &Event,
+        agent_pubkey_hex: &str,
+        now: Instant,
+    ) -> ThreadFollowAdmission {
+        self.prune_expired(now);
+        let thread = parse_thread_tags(event);
+        let root_event_id = thread.root_event_id.unwrap_or_else(|| event.id.to_hex());
+        let mentioned = thread
+            .mentioned_pubkeys
+            .iter()
+            .any(|pubkey| pubkey == agent_pubkey_hex);
+
+        if mentioned {
+            return ThreadFollowAdmission::Mention { root_event_id };
+        }
+        if self
+            .followed
+            .contains_key(&(channel_id, root_event_id.clone()))
+        {
+            ThreadFollowAdmission::Followed { root_event_id }
+        } else {
+            ThreadFollowAdmission::Reject
+        }
+    }
+
+    /// Record an event that was admitted to the queue. Both explicit mentions
+    /// and followed replies refresh the idle lease while preserving the bounded
+    /// number of tracked thread roots.
+    pub fn record(&mut self, channel_id: Uuid, admission: &ThreadFollowAdmission, now: Instant) {
+        let root_event_id = match admission {
+            ThreadFollowAdmission::Mention { root_event_id }
+            | ThreadFollowAdmission::Followed { root_event_id } => root_event_id,
+            ThreadFollowAdmission::Reject => return,
+        };
+        self.prune_expired(now);
+        let key = (channel_id, root_event_id.clone());
+        if !self.followed.contains_key(&key) && self.followed.len() >= self.capacity {
+            if let Some(oldest) = self
+                .followed
+                .iter()
+                .min_by_key(|(_, last_active)| **last_active)
+                .map(|(key, _)| key.clone())
+            {
+                self.followed.remove(&oldest);
+            }
+        }
+        self.followed.insert(key, now);
+    }
+
+    pub fn remove_channel(&mut self, channel_id: Uuid) {
+        self.followed
+            .retain(|(channel, _), _| *channel != channel_id);
+    }
+
+    fn prune_expired(&mut self, now: Instant) {
+        self.followed
+            .retain(|_, last_active| now.duration_since(*last_active) <= self.ttl);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    fn event(tags: &[Vec<&str>]) -> Event {
+        let tags = tags
+            .iter()
+            .map(|tag| Tag::parse(tag.clone()).unwrap())
+            .collect::<Vec<_>>();
+        EventBuilder::new(Kind::Custom(9), "message")
+            .tags(tags)
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+    }
+
+    #[test]
+    fn follows_only_the_thread_started_by_a_mention() {
+        let channel = Uuid::new_v4();
+        let agent = "a".repeat(64);
+        let now = Instant::now();
+        let mut state = ThreadFollowState::new(DEFAULT_FOLLOW_TTL, 10);
+        let mention = event(&[vec!["p", &agent]]);
+        let admission = state.classify(channel, &mention, &agent, now);
+        assert!(matches!(admission, ThreadFollowAdmission::Mention { .. }));
+        let root = mention.id.to_hex();
+        state.record(channel, &admission, now);
+
+        let reply = event(&[vec!["e", &root, "", "reply"]]);
+        assert!(matches!(
+            state.classify(channel, &reply, &agent, now),
+            ThreadFollowAdmission::Followed { .. }
+        ));
+
+        let unrelated = event(&[]);
+        assert_eq!(
+            state.classify(channel, &unrelated, &agent, now),
+            ThreadFollowAdmission::Reject
+        );
+    }
+
+    #[test]
+    fn follows_nested_replies_but_not_another_channel() {
+        let channel = Uuid::new_v4();
+        let other_channel = Uuid::new_v4();
+        let agent = "a".repeat(64);
+        let now = Instant::now();
+        let mut state = ThreadFollowState::new(DEFAULT_FOLLOW_TTL, 10);
+        let root = "b".repeat(64);
+        let mention = event(&[vec!["e", &root, "", "reply"], vec!["p", &agent]]);
+        let admission = state.classify(channel, &mention, &agent, now);
+        state.record(channel, &admission, now);
+        let nested = event(&[
+            vec!["e", &root, "", "root"],
+            vec!["e", &"c".repeat(64), "", "reply"],
+        ]);
+        assert!(matches!(
+            state.classify(channel, &nested, &agent, now),
+            ThreadFollowAdmission::Followed { .. }
+        ));
+        assert_eq!(
+            state.classify(other_channel, &nested, &agent, now),
+            ThreadFollowAdmission::Reject
+        );
+    }
+
+    #[test]
+    fn expires_and_evicts_oldest_thread() {
+        let channel = Uuid::new_v4();
+        let agent = "a".repeat(64);
+        let now = Instant::now();
+        let mut state = ThreadFollowState::new(Duration::from_secs(10), 1);
+        let first = event(&[vec!["p", &agent]]);
+        let first_admission = state.classify(channel, &first, &agent, now);
+        state.record(channel, &first_admission, now);
+        let second = event(&[vec!["p", &agent]]);
+        let second_admission =
+            state.classify(channel, &second, &agent, now + Duration::from_secs(1));
+        state.record(channel, &second_admission, now + Duration::from_secs(1));
+        let first_reply = event(&[vec!["e", &first.id.to_hex(), "", "reply"]]);
+        assert_eq!(
+            state.classify(channel, &first_reply, &agent, now + Duration::from_secs(1)),
+            ThreadFollowAdmission::Reject
+        );
+        let second_reply = event(&[vec!["e", &second.id.to_hex(), "", "reply"]]);
+        assert_eq!(
+            state.classify(
+                channel,
+                &second_reply,
+                &agent,
+                now + Duration::from_secs(12)
+            ),
+            ThreadFollowAdmission::Reject
+        );
+    }
+}

--- a/crates/buzz-acp/src/thread_follow.rs
+++ b/crates/buzz-acp/src/thread_follow.rs
@@ -7,17 +7,19 @@
 //! previously accepted mention opened.
 
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use nostr::Event;
 use uuid::Uuid;
 
 use crate::queue::parse_thread_tags;
 
-/// Keep only recent active conversations. State is process-local and is
-/// intentionally lost on restart, which fails closed rather than turning the
-/// harness into a persistent channel-wide listener.
-pub const DEFAULT_FOLLOW_TTL: Duration = Duration::from_secs(60 * 60);
+/// Bounded, per-channel thread-follow state.
+///
+/// State is process-local and intentionally lost on restart. A thread remains
+/// followed until the agent is restarted, leaves the channel, or its entry is
+/// evicted to make room for a newer conversation. This keeps the feature's
+/// contract explicit: there is no hidden idle timeout that can end a thread.
 pub const DEFAULT_MAX_FOLLOWED_THREADS: usize = 100;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,19 +32,17 @@ pub enum ThreadFollowAdmission {
     Reject,
 }
 
-/// Bounded, per-channel thread-follow leases.
+/// Bounded, per-channel followed thread roots.
 #[derive(Debug)]
 pub struct ThreadFollowState {
     followed: HashMap<(Uuid, String), Instant>,
-    ttl: Duration,
     capacity: usize,
 }
 
 impl ThreadFollowState {
-    pub fn new(ttl: Duration, capacity: usize) -> Self {
+    pub fn new(capacity: usize) -> Self {
         Self {
             followed: HashMap::new(),
-            ttl,
             capacity,
         }
     }
@@ -55,9 +55,8 @@ impl ThreadFollowState {
         channel_id: Uuid,
         event: &Event,
         agent_pubkey_hex: &str,
-        now: Instant,
+        _now: Instant,
     ) -> ThreadFollowAdmission {
-        self.prune_expired(now);
         let thread = parse_thread_tags(event);
         let root_event_id = thread.root_event_id.unwrap_or_else(|| event.id.to_hex());
         let mentioned = thread
@@ -79,15 +78,14 @@ impl ThreadFollowState {
     }
 
     /// Record an event that was admitted to the queue. Both explicit mentions
-    /// and followed replies refresh the idle lease while preserving the bounded
-    /// number of tracked thread roots.
+    /// and followed replies preserve the followed root while enforcing a
+    /// bounded number of tracked conversations.
     pub fn record(&mut self, channel_id: Uuid, admission: &ThreadFollowAdmission, now: Instant) {
         let root_event_id = match admission {
             ThreadFollowAdmission::Mention { root_event_id }
             | ThreadFollowAdmission::Followed { root_event_id } => root_event_id,
             ThreadFollowAdmission::Reject => return,
         };
-        self.prune_expired(now);
         let key = (channel_id, root_event_id.clone());
         if !self.followed.contains_key(&key) && self.followed.len() >= self.capacity {
             if let Some(oldest) = self
@@ -105,11 +103,6 @@ impl ThreadFollowState {
     pub fn remove_channel(&mut self, channel_id: Uuid) {
         self.followed
             .retain(|(channel, _), _| *channel != channel_id);
-    }
-
-    fn prune_expired(&mut self, now: Instant) {
-        self.followed
-            .retain(|_, last_active| now.duration_since(*last_active) <= self.ttl);
     }
 }
 
@@ -134,7 +127,7 @@ mod tests {
         let channel = Uuid::new_v4();
         let agent = "a".repeat(64);
         let now = Instant::now();
-        let mut state = ThreadFollowState::new(DEFAULT_FOLLOW_TTL, 10);
+        let mut state = ThreadFollowState::new(10);
         let mention = event(&[vec!["p", &agent]]);
         let admission = state.classify(channel, &mention, &agent, now);
         assert!(matches!(admission, ThreadFollowAdmission::Mention { .. }));
@@ -160,7 +153,7 @@ mod tests {
         let other_channel = Uuid::new_v4();
         let agent = "a".repeat(64);
         let now = Instant::now();
-        let mut state = ThreadFollowState::new(DEFAULT_FOLLOW_TTL, 10);
+        let mut state = ThreadFollowState::new(10);
         let root = "b".repeat(64);
         let mention = event(&[vec!["e", &root, "", "reply"], vec!["p", &agent]]);
         let admission = state.classify(channel, &mention, &agent, now);
@@ -180,32 +173,31 @@ mod tests {
     }
 
     #[test]
-    fn expires_and_evicts_oldest_thread() {
+    fn evicts_oldest_thread_but_does_not_expire_an_active_thread() {
         let channel = Uuid::new_v4();
         let agent = "a".repeat(64);
         let now = Instant::now();
-        let mut state = ThreadFollowState::new(Duration::from_secs(10), 1);
+        let mut state = ThreadFollowState::new(1);
         let first = event(&[vec!["p", &agent]]);
         let first_admission = state.classify(channel, &first, &agent, now);
         state.record(channel, &first_admission, now);
         let second = event(&[vec!["p", &agent]]);
-        let second_admission =
-            state.classify(channel, &second, &agent, now + Duration::from_secs(1));
-        state.record(channel, &second_admission, now + Duration::from_secs(1));
+        let second_admission = state.classify(channel, &second, &agent, now);
+        state.record(channel, &second_admission, now);
         let first_reply = event(&[vec!["e", &first.id.to_hex(), "", "reply"]]);
         assert_eq!(
-            state.classify(channel, &first_reply, &agent, now + Duration::from_secs(1)),
+            state.classify(channel, &first_reply, &agent, now),
             ThreadFollowAdmission::Reject
         );
         let second_reply = event(&[vec!["e", &second.id.to_hex(), "", "reply"]]);
-        assert_eq!(
+        assert!(matches!(
             state.classify(
                 channel,
                 &second_reply,
                 &agent,
-                now + Duration::from_secs(12)
+                now + std::time::Duration::from_secs(60 * 60 * 24)
             ),
-            ThreadFollowAdmission::Reject
-        );
+            ThreadFollowAdmission::Followed { .. }
+        ));
     }
 }

--- a/desktop/src-tauri/src/commands/agent_config.rs
+++ b/desktop/src-tauri/src/commands/agent_config.rs
@@ -643,6 +643,7 @@ mod tests {
             last_error_code: None,
             respond_to: RespondTo::OwnerOnly,
             respond_to_allowlist: vec![],
+            conversation_mode: Default::default(),
             display_name: None,
             slug: None,
             runtime: None,

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -894,6 +894,9 @@ pub async fn update_managed_agent(
         if input.respond_to_allowlist.is_some() {
             record.respond_to_allowlist = prospective_allowlist;
         }
+        if let Some(conversation_mode) = input.conversation_mode {
+            record.conversation_mode = conversation_mode;
+        }
 
         record.updated_at = now_iso();
 

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -720,6 +720,7 @@ pub async fn create_managed_agent(
             last_error_code: None,
             respond_to: minted.respond_to,
             respond_to_allowlist: minted.respond_to_allowlist.clone(),
+            conversation_mode: input.conversation_mode,
             display_name: None,
             slug: None,
             runtime: None,

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -47,6 +47,7 @@ fn bare_agent_record(
         last_error_code: None,
         respond_to: RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         display_name: None,
         slug: None,
         runtime: None,

--- a/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
@@ -55,6 +55,7 @@ fn make_agent(
         last_error_code: None,
         respond_to: RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         display_name: None,
         slug: None,
         runtime: None,

--- a/desktop/src-tauri/src/commands/personas/inbound_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/inbound_tests.rs
@@ -197,6 +197,7 @@ fn local_agent() -> ManagedAgentRecord {
         last_error_code: None,
         respond_to: crate::managed_agents::RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         display_name: None,
         slug: None,
         runtime: None,

--- a/desktop/src-tauri/src/commands/personas/name_propagation_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/name_propagation_tests.rs
@@ -44,6 +44,7 @@ fn agent(persona_id: &str, name: &str, display_name: Option<&str>) -> ManagedAge
         last_error_code: None,
         respond_to: Default::default(),
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         display_name: display_name.map(str::to_string),
         slug: None,
         runtime: None,

--- a/desktop/src-tauri/src/commands/personas/snapshot/import.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/import.rs
@@ -474,6 +474,7 @@ pub async fn confirm_agent_snapshot_import(
             // are always consistent at mint time.
             respond_to: minted.respond_to,
             respond_to_allowlist: minted.respond_to_allowlist.clone(),
+            conversation_mode: Default::default(),
             is_builtin: false,
             is_active: true,
             source_team: None,

--- a/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
@@ -60,6 +60,7 @@ fn make_definition(slug: &str) -> ManagedAgentRecord {
         last_error_code: None,
         respond_to: RespondTo::default(),
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         runtime: None,
         name_pool: vec![],
         is_builtin: false,

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -597,6 +597,7 @@ pub async fn confirm_team_snapshot_import(
                     .unwrap_or_default()
             },
             respond_to_allowlist: definition.respond_to_allowlist.clone(),
+            conversation_mode: Default::default(),
             is_builtin: false,
             is_active: true,
             source_team: None,

--- a/desktop/src-tauri/src/commands/team_snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot/tests.rs
@@ -212,6 +212,7 @@ fn team_export_with_instance_and_memory_level_uses_supplied_entries() {
         last_error_code: None,
         respond_to: crate::managed_agents::RespondTo::default(),
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         is_builtin: false,
         is_active: true,
         source_team: None,

--- a/desktop/src-tauri/src/managed_agents/agent_events.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_events.rs
@@ -200,6 +200,7 @@ mod tests {
             last_error_code: None,
             respond_to: RespondTo::Allowlist,
             respond_to_allowlist: vec!["79be667e".to_string()],
+            conversation_mode: Default::default(),
             // Unified-model fields carry real values so the exclusion test
             // proves they are absent from the wire, not vacuously empty.
             display_name: Some("Display Name Secretish".to_string()),

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot.rs
@@ -521,6 +521,7 @@ mod tests {
             last_error_code: Some(42), // MUST NOT appear
             respond_to: RespondTo::default(),
             respond_to_allowlist: vec!["pubkey1hex".to_string()],
+            conversation_mode: Default::default(),
             slug: Some("test-agent".to_string()),
             runtime: Some("goose".to_string()),
             name_pool: vec!["Alice".to_string(), "Bob".to_string()],

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -99,6 +99,7 @@ fn test_record() -> ManagedAgentRecord {
         last_error_code: None,
         respond_to: crate::managed_agents::types::RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         display_name: None,
         slug: None,
         runtime: None,

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -269,6 +269,7 @@ fn record_with(
         last_error_code: None,
         respond_to: Default::default(),
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         display_name: None,
         slug: None,
         runtime: runtime.map(str::to_string),

--- a/desktop/src-tauri/src/managed_agents/global_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/global_config/tests.rs
@@ -337,6 +337,7 @@ fn bare_record() -> ManagedAgentRecord {
         last_error_code: None,
         respond_to: RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         display_name: None,
         slug: None,
         runtime: None,

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -473,6 +473,7 @@ fn make_agent(name: &str, persona_id: Option<&str>) -> ManagedAgentRecord {
         last_error_code: None,
         respond_to: RespondTo::default(),
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         env_vars: std::collections::BTreeMap::new(),
         display_name: None,
         slug: None,

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -1330,6 +1330,7 @@ mod tests {
             last_error_code: None,
             respond_to: Default::default(),
             respond_to_allowlist: vec![],
+            conversation_mode: Default::default(),
             display_name: None,
             slug: None,
             runtime: None,

--- a/desktop/src-tauri/src/managed_agents/relay_mesh.rs
+++ b/desktop/src-tauri/src/managed_agents/relay_mesh.rs
@@ -153,6 +153,7 @@ mod tests {
             last_error_code: None,
             respond_to: RespondTo::OwnerOnly,
             respond_to_allowlist: vec![],
+            conversation_mode: Default::default(),
             display_name: None,
             slug: None,
             runtime: None,

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1396,6 +1396,7 @@ pub fn build_managed_agent_summary(
         log_path,
         respond_to: record.respond_to,
         respond_to_allowlist: record.respond_to_allowlist.clone(),
+        conversation_mode: record.conversation_mode,
     })
 }
 
@@ -1783,6 +1784,14 @@ pub fn spawn_agent_child(
     for key in &gate_remove {
         command.env_remove(key);
     }
+
+    // Conversation behavior is separate from the author gate: it controls
+    // whether the harness can admit unmentioned replies in a previously
+    // authorized thread, never who may seed that thread.
+    command.env(
+        "BUZZ_ACP_SUBSCRIBE",
+        record.conversation_mode.as_acp_subscribe(),
+    );
 
     command.env("BUZZ_ACP_RELAY_OBSERVER", "true");
 

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -162,6 +162,7 @@ fn fixture(
         last_error_code: None,
         respond_to,
         respond_to_allowlist: allowlist,
+        conversation_mode: Default::default(),
         display_name: None,
         slug: None,
         runtime: None,

--- a/desktop/src-tauri/src/managed_agents/spawn_hash.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_hash.rs
@@ -115,6 +115,10 @@ pub(crate) fn spawn_config_hash(
     record.provider.hash(&mut hasher);
     record.auth_tag.hash(&mut hasher);
     record.respond_to.as_str().hash(&mut hasher);
+    record
+        .conversation_mode
+        .as_acp_subscribe()
+        .hash(&mut hasher);
     // The allowlist is hashed as the env receives it: spawn sets
     // BUZZ_ACP_RESPOND_TO_ALLOWLIST only in allowlist mode, and normalized
     // (trim/lowercase/dedup via `validate_respond_to_allowlist`) — so edits

--- a/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
@@ -43,6 +43,7 @@ fn record() -> ManagedAgentRecord {
         last_error_code: None,
         respond_to: Default::default(),
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         display_name: None,
         slug: None,
         runtime: None,
@@ -87,6 +88,17 @@ fn hash_is_deterministic() {
     assert_eq!(
         spawn_config_hash(&rec, &[], &[], "wss://ws.example", &Default::default()),
         spawn_config_hash(&rec, &[], &[], "wss://ws.example", &Default::default())
+    );
+}
+
+#[test]
+fn conversation_behavior_edit_changes_hash() {
+    let rec = record();
+    let mut edited = rec.clone();
+    edited.conversation_mode = ConversationMode::ThreadFollow;
+    assert_ne!(
+        spawn_config_hash(&rec, &[], &[], "wss://ws.example", &Default::default()),
+        spawn_config_hash(&edited, &[], &[], "wss://ws.example", &Default::default())
     );
 }
 

--- a/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::managed_agents::types::RespondTo;
+use crate::managed_agents::types::{ConversationMode, RespondTo};
 use std::collections::BTreeMap;
 
 fn record() -> ManagedAgentRecord {

--- a/desktop/src-tauri/src/managed_agents/team_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/team_snapshot.rs
@@ -296,6 +296,7 @@ mod tests {
             last_error_code: None,
             respond_to: RespondTo::default(),
             respond_to_allowlist: vec![],
+            conversation_mode: Default::default(),
             slug: Some(name.to_string()),
             runtime: Some("goose".to_string()),
             name_pool: vec![],

--- a/desktop/src-tauri/src/managed_agents/teams_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/teams_tests.rs
@@ -202,6 +202,7 @@ fn managed_agent(name: &str) -> ManagedAgentRecord {
         last_error_code: None,
         respond_to: crate::managed_agents::RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
+        conversation_mode: Default::default(),
         display_name: None,
         slug: None,
         runtime: None,

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -124,6 +124,7 @@ impl AgentDefinition {
             last_error_code: None,
             respond_to: RespondTo::default(),
             respond_to_allowlist: Vec::new(),
+            conversation_mode: Default::default(),
             display_name: Some(self.display_name),
             slug: Some(self.id),
             runtime: self.runtime,
@@ -326,6 +327,11 @@ pub struct ManagedAgentRecord {
     /// Preserved across mode toggles so users don't lose state.
     #[serde(default)]
     pub respond_to_allowlist: Vec<String>,
+    /// Controls whether an authorized mention is required for every message or
+    /// opens a scoped thread conversation. Defaults to existing mention-only
+    /// behavior for saved agents.
+    #[serde(default)]
+    pub conversation_mode: ConversationMode,
     /// Optional display name distinct from the unique `name` handle. Absorbed
     /// from `AgentDefinition.display_name` (unified agent model, Phase 1A).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -514,6 +520,7 @@ pub struct ManagedAgentSummary {
     pub log_path: String,
     pub respond_to: RespondTo,
     pub respond_to_allowlist: Vec<String>,
+    pub conversation_mode: ConversationMode,
 }
 
 #[derive(Debug, Serialize)]
@@ -762,6 +769,29 @@ pub enum RespondTo {
     OwnerOnly,
     Allowlist,
     Anyone,
+}
+
+/// Controls how an authorized invitation continues in a channel.
+///
+/// This is deliberately separate from [`RespondTo`]: `respond_to` answers who
+/// may invite an agent; conversation mode answers whether that invitation
+/// grants the agent access to later replies in the same thread.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConversationMode {
+    #[default]
+    Mentions,
+    ThreadFollow,
+}
+
+impl ConversationMode {
+    /// Value understood by buzz-acp's `--subscribe` / `BUZZ_ACP_SUBSCRIBE`.
+    pub fn as_acp_subscribe(self) -> &'static str {
+        match self {
+            Self::Mentions => "mentions",
+            Self::ThreadFollow => "thread-follow",
+        }
+    }
 }
 
 impl RespondTo {

--- a/desktop/src-tauri/src/managed_agents/types/requests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/requests.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use super::{
     default_start_on_app_launch, validate_respond_to_allowlist, AgentDefinition, BackendKind,
-    RelayMeshConfig, RespondTo,
+    ConversationMode, RelayMeshConfig, RespondTo,
 };
 
 /// The NIP-AP behavioral group as one grouped request field.
@@ -183,6 +183,8 @@ pub struct CreateManagedAgentRequest {
     #[serde(default)]
     pub respond_to_allowlist: Vec<String>,
     #[serde(default)]
+    pub conversation_mode: ConversationMode,
+    #[serde(default)]
     pub relay_mesh: Option<RelayMeshConfig>,
 }
 
@@ -249,6 +251,10 @@ pub struct UpdateManagedAgentRequest {
     /// normalized server-side).
     #[serde(default)]
     pub respond_to_allowlist: Option<Vec<String>>,
+    /// Absent = don't touch. Present = change how mentions continue in a
+    /// channel, independently from the inbound author gate.
+    #[serde(default)]
+    pub conversation_mode: Option<ConversationMode>,
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -93,7 +93,7 @@ fn managed_agent_record_with_auth_tag_round_trips() {
 
 // ── Inbound author gate tests ────────────────────────────────────────
 
-use super::{validate_respond_to_allowlist, RespondTo};
+use super::{validate_respond_to_allowlist, ConversationMode, RespondTo};
 
 #[test]
 fn respond_to_default_is_owner_only() {
@@ -157,6 +157,16 @@ fn managed_agent_record_without_respond_to_fields_defaults_to_owner_only() {
     .expect("legacy record without respond_to fields should deserialize");
     assert_eq!(record.respond_to, RespondTo::OwnerOnly);
     assert!(record.respond_to_allowlist.is_empty());
+    assert_eq!(record.conversation_mode, ConversationMode::Mentions);
+}
+
+#[test]
+fn conversation_mode_maps_to_the_acp_subscription_value() {
+    assert_eq!(ConversationMode::Mentions.as_acp_subscribe(), "mentions");
+    assert_eq!(
+        ConversationMode::ThreadFollow.as_acp_subscribe(),
+        "thread-follow"
+    );
 }
 
 #[test]

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -16,6 +16,7 @@ import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlA
 import type {
   ManagedAgent,
   RespondToMode,
+  ConversationMode,
   UpdateManagedAgentInput,
 } from "@/shared/api/types";
 import type { EditAgentFocusTarget } from "@/features/agents/openEditAgentEvent";
@@ -153,6 +154,8 @@ export function AgentInstanceEditDialog({
   const [respondToAllowlist, setRespondToAllowlist] = React.useState<string[]>(
     agent.respondToAllowlist,
   );
+  const [conversationMode, setConversationMode] =
+    React.useState<ConversationMode>(agent.conversationMode);
   const [showAdvancedFields, setShowAdvancedFields] = React.useState(false);
   const [avatarUrl, setAvatarUrl] = React.useState(agent.avatarUrl ?? "");
   const [isAvatarUploadPending, setIsAvatarUploadPending] =
@@ -189,6 +192,7 @@ export function AgentInstanceEditDialog({
       setAutoRestartOnConfigChange(agent.autoRestartOnConfigChange);
       setRespondTo(agent.respondTo);
       setRespondToAllowlist(agent.respondToAllowlist);
+      setConversationMode(agent.conversationMode);
       setAvatarUrl(agent.avatarUrl ?? "");
       setShowAdvancedFields(false);
       setIsAvatarUploadPending(false);
@@ -704,6 +708,10 @@ export function AgentInstanceEditDialog({
           ? undefined
           : submitEnvVars,
         respondTo: respondTo !== agent.respondTo ? respondTo : undefined,
+        conversationMode:
+          conversationMode !== agent.conversationMode
+            ? conversationMode
+            : undefined,
         // The allowlist is preserved across mode toggles in local UI state
         // (so a user can flip away from allowlist and back without losing
         // their entries), but we only send it on the wire when (a) it
@@ -1136,6 +1144,7 @@ export function AgentInstanceEditDialog({
                       agentArgs={agentArgs}
                       agentCommand={agentCommand}
                       autoRestartOnConfigChange={autoRestartOnConfigChange}
+                      conversationMode={conversationMode}
                       disabled={updateMutation.isPending}
                       envVars={envVars}
                       fileSatisfiedEnvKeys={fileSatisfiedEnvKeys}
@@ -1162,6 +1171,7 @@ export function AgentInstanceEditDialog({
                       onAgentArgsChange={setAgentArgs}
                       onAgentCommandChange={setAgentCommand}
                       onAutoRestartChange={setAutoRestartOnConfigChange}
+                      onConversationModeChange={setConversationMode}
                       onEnvVarsChange={setEnvVars}
                       onInheritHarnessChange={setInheritHarness}
                       onParallelismChange={setParallelism}

--- a/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
+++ b/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
@@ -7,7 +7,7 @@ import {
   PERSONA_FIELD_SHELL_CLASS,
   PERSONA_LABEL_OPTIONAL_CLASS,
 } from "./personaDialogPickers";
-import type { AgentPersona } from "@/shared/api/types";
+import type { AgentPersona, ConversationMode } from "@/shared/api/types";
 import { BuzzAgentModelTuningFields } from "./buzzAgentModelTuningFields";
 import { isBuzzAgentRuntime } from "./buzzAgentConfig";
 
@@ -16,6 +16,7 @@ export function EditAgentAdvancedFields({
   agentArgs,
   agentCommand,
   autoRestartOnConfigChange,
+  conversationMode,
   disabled,
   envVars,
   fileSatisfiedEnvKeys,
@@ -40,12 +41,14 @@ export function EditAgentAdvancedFields({
   onParallelismChange,
   onRelayUrlChange,
   onAutoRestartChange,
+  onConversationModeChange,
   onSystemPromptChange,
 }: {
   acpCommand: string;
   agentArgs: string;
   agentCommand: string;
   autoRestartOnConfigChange: boolean;
+  conversationMode: ConversationMode;
   disabled: boolean;
   envVars: EnvVarsValue;
   fileSatisfiedEnvKeys: readonly string[];
@@ -78,6 +81,7 @@ export function EditAgentAdvancedFields({
   onParallelismChange: (value: string) => void;
   onRelayUrlChange: (value: string) => void;
   onAutoRestartChange: (value: boolean) => void;
+  onConversationModeChange: (value: ConversationMode) => void;
   onSystemPromptChange: (value: string) => void;
 }) {
   return (
@@ -125,6 +129,35 @@ export function EditAgentAdvancedFields({
           {autoRestartOnConfigChange
             ? "Restarts this agent automatically when its configuration changes, once it is idle and connected."
             : "Configuration changes only show the restart badge; restart manually to apply them."}
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          className="text-sm font-medium text-foreground"
+          htmlFor="edit-agent-conversation-mode"
+        >
+          Conversation behavior
+        </label>
+        <select
+          className={cn(
+            "flex h-11 w-full rounded-md border border-input bg-background px-3 text-sm shadow-xs",
+            PERSONA_FIELD_CONTROL_CLASS,
+          )}
+          disabled={disabled}
+          id="edit-agent-conversation-mode"
+          onChange={(event) =>
+            onConversationModeChange(event.target.value as ConversationMode)
+          }
+          value={conversationMode}
+        >
+          <option value="mentions">Mention for each message</option>
+          <option value="thread-follow">Stay in thread after a mention</option>
+        </select>
+        <p className="text-xs text-muted-foreground">
+          {conversationMode === "thread-follow"
+            ? "An authorized mention invites this agent into that thread. Replies there continue normally; messages elsewhere in the channel do not reach it."
+            : "The agent needs an authorized @mention for each message."}
         </p>
       </div>
 

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -148,9 +148,11 @@ export type RawManagedAgent = {
   backend: ManagedAgentBackend;
   backend_agent_id: string | null;
   // Optional: pre-feature mock fixtures may omit these. Mapped to
-  // `"owner-only"` / `[]` in `fromRawManagedAgent`.
+  // "owner-only" / [] in `fromRawManagedAgent`.
   respond_to?: ManagedAgent["respondTo"];
   respond_to_allowlist?: string[];
+  // Optional for pre-feature fixtures; defaults to mention-only behavior.
+  conversation_mode?: ManagedAgent["conversationMode"];
 };
 
 type RawCreateManagedAgentResponse = {
@@ -684,6 +686,7 @@ export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {
     // Real agent records always include them (defaulted server-side).
     respondTo: agent.respond_to ?? "owner-only",
     respondToAllowlist: agent.respond_to_allowlist ?? [],
+    conversationMode: agent.conversation_mode ?? "mentions",
   };
 }
 
@@ -830,6 +833,7 @@ export async function createManagedAgent(input: CreateManagedAgentInput) {
         backend: input.backend,
         respondTo: input.respondTo,
         respondToAllowlist: input.respondToAllowlist,
+        conversationMode: input.conversationMode,
         relayMesh: input.relayMesh,
       },
     },

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -384,7 +384,14 @@ export type ManagedAgent = {
    * `"allowlist"`. Preserved across mode toggles.
    */
   respondToAllowlist: string[];
+  /** Whether an authorized mention is required for each message, or opens a
+   * scoped thread conversation. */
+  conversationMode: ConversationMode;
 };
+
+/** Conversation admission policy. Separate from `RespondToMode`, which
+ * controls who may invite an agent. */
+export type ConversationMode = "mentions" | "thread-follow";
 
 /**
  * Inbound author gate mode. Mirrors `buzz-acp`'s `--respond-to` CLI flag.
@@ -446,6 +453,8 @@ export type CreateManagedAgentInput = {
    * normalized server-side (must be 64 hex chars each).
    */
   respondToAllowlist?: string[];
+  /** Defaults to mention-only behavior. */
+  conversationMode?: ConversationMode;
   relayMesh?: RelayMeshConfig;
 };
 
@@ -701,6 +710,8 @@ export type UpdateManagedAgentInput = {
    * (validated & normalized server-side).
    */
   respondToAllowlist?: string[];
+  /** Absent = don't touch. Present = set conversation admission behavior. */
+  conversationMode?: ConversationMode;
 };
 export type AgentPersona = {
   id: string;


### PR DESCRIPTION
## What this changes

Adds an optional conversation setting for an agent: **Stay in thread after a mention**.

When enabled, an authorized @mention opens a one-hour follow window for that one thread. Later messages in that thread are delivered to the agent as context without another @mention. Messages in every other thread and elsewhere in the channel are ignored.

This does **not** make the agent reply to every message. It only keeps the agent informed. The agent still decides when a response is useful.

## Where to change it

In the agent editor, open Advanced settings and choose either:

- **Mention for each message** (the existing default)
- **Stay in thread after a mention**

## Safety limits

- Existing agents retain mention-only behavior unless changed.
- Only an already-authorized author can open a followed thread.
- Follow state is kept separately per channel and expires after one hour of inactivity.
- It is in memory only, so an agent restart forgets old followed threads rather than listening more broadly.
- At most 100 active threads are retained; the oldest one is removed first.
- An agent leaving a channel loses all followed threads in that channel.

## Implementation

- Adds `thread-follow` as a harness subscription mode.
- Locally filters the relay's broader delivery so only direct mentions or messages in an active followed thread reach the agent queue.
- Persists the setting through Desktop records, API requests, snapshots, and runtime restart detection.
- Adds the agent-editor control and explanatory copy.

## Verification

Passed:

```text
cargo test -p buzz-acp                 # 534 passed
pnpm --dir desktop typecheck
pnpm --dir desktop lint
cargo fmt --check
git diff --check
```

`cargo test --manifest-path desktop/src-tauri/Cargo.toml` could not run in this environment because CMake is not installed and `audiopus_sys` needs it to build bundled Opus.