### PR TITLE
feat(desktop): add tooltips to channel header actions

### DIFF
--- a/desktop/src/features/channels/ui/ChannelMembersBar.tsx
+++ b/desktop/src/features/channels/ui/ChannelMembersBar.tsx
@@ -15,6 +15,7 @@ import { canStartHuddleInChannel } from "@/features/channels/lib/huddleAvailabil
 import type { Channel } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { Button } from "@/shared/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -170,32 +171,42 @@ export function ChannelMembersBar({
       </DropdownMenu>
     ) : (
       <div className="flex items-center gap-[6px]">
-        <Button
-          aria-label={`View channel members (${memberCount})`}
-          className="h-8 px-2.5"
-          data-testid="channel-members-trigger"
-          onClick={onToggleMembers}
-          type="button"
-          variant="outline"
-        >
-          <Users />
-          <span className="min-w-[1ch] text-sm font-medium tabular-nums">
-            {memberCount}
-          </span>
-        </Button>
+        <Tooltip disableHoverableContent>
+          <TooltipTrigger asChild>
+            <Button
+              aria-label={`View channel members (${memberCount})`}
+              className="h-8 px-2.5"
+              data-testid="channel-members-trigger"
+              onClick={onToggleMembers}
+              type="button"
+              variant="outline"
+            >
+              <Users />
+              <span className="min-w-[1ch] text-sm font-medium tabular-nums">
+                {memberCount}
+              </span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Channel members</TooltipContent>
+        </Tooltip>
 
         {huddleIndicator}
 
-        <Button
-          aria-label="Manage channel"
-          data-testid="channel-management-trigger"
-          onClick={onManageChannel}
-          size="icon"
-          type="button"
-          variant="outline"
-        >
-          <Settings2 />
-        </Button>
+        <Tooltip disableHoverableContent>
+          <TooltipTrigger asChild>
+            <Button
+              aria-label="Manage channel"
+              data-testid="channel-management-trigger"
+              onClick={onManageChannel}
+              size="icon"
+              type="button"
+              variant="outline"
+            >
+              <Settings2 />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Channel settings</TooltipContent>
+        </Tooltip>
       </div>
     );
 

--- a/desktop/src/features/huddle/components/HuddleIndicator.tsx
+++ b/desktop/src/features/huddle/components/HuddleIndicator.tsx
@@ -224,18 +224,28 @@ export function HuddleIndicator({
     }
 
     return (
-      <Button
-        aria-label="Start huddle"
-        className={className}
-        data-testid="channel-start-huddle-trigger"
-        disabled={startDisabled || isStarting}
-        onClick={() => onStart()}
-        size="icon"
-        type="button"
-        variant="outline"
-      >
-        <Headphones />
-      </Button>
+      <Tooltip disableHoverableContent>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex"
+            data-testid="channel-huddle-tooltip-trigger"
+          >
+            <Button
+              aria-label="Start huddle"
+              className={className}
+              data-testid="channel-start-huddle-trigger"
+              disabled={startDisabled || isStarting}
+              onClick={() => onStart()}
+              size="icon"
+              type="button"
+              variant="outline"
+            >
+              <Headphones />
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>Huddle</TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2773,6 +2773,21 @@ test("channel header omits the add agent action", async ({ page }) => {
   await expect(page.getByTestId("channel-management-trigger")).toBeVisible();
 });
 
+test("channel header actions show tooltips", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+
+  for (const [testId, label] of [
+    ["channel-members-trigger", "Channel members"],
+    ["channel-huddle-tooltip-trigger", "Huddle"],
+    ["channel-management-trigger", "Channel settings"],
+  ] as const) {
+    await page.getByTestId(testId).hover();
+    await expect(page.getByRole("tooltip", { name: label })).toBeVisible();
+  }
+});
+
 test("members sidebar collapses same-persona managed agents", async ({
   page,
 }) => {


### PR DESCRIPTION
Icon-only actions are not always clear without clicking them first. In my case, I did not understand that the headphones icon starts a huddle and accidentally started one for the channel. 

This PR adds helper text on hover for the Channel members, Huddle, and Channel settings buttons. It reuses the existing tooltip component and styling already used elsewhere in the app, supports the Huddle tooltip even when the button is disabled, and adds an end-to-end test covering all three labels. No button behavior was changed.

## Before this PR

https://github.com/user-attachments/assets/c16aa5de-6c04-45bf-8962-15c83c3327ff

## After this PR

https://github.com/user-attachments/assets/c68ebfb3-a3b4-4673-a281-0e717cb7a091

