### PR TITLE
Polish onboarding runtime error states

### DIFF
--- a/desktop/src/features/onboarding/ui/RuntimeErrorTooltip.tsx
+++ b/desktop/src/features/onboarding/ui/RuntimeErrorTooltip.tsx
@@ -1,0 +1,49 @@
+import { AlertTriangle } from "lucide-react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+
+type RuntimeErrorTooltipProps = {
+  className?: string;
+  detail: string;
+  label: string;
+  showIcon?: boolean;
+  testId?: string;
+};
+
+export function RuntimeErrorTooltip({
+  className,
+  detail,
+  label,
+  showIcon = false,
+  testId,
+}: RuntimeErrorTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          aria-label={`${label}. ${detail}`}
+          className={className}
+          data-testid={testId}
+          role="status"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: Focus exposes the error tooltip to keyboard users without adding a nested card action
+          tabIndex={0}
+        >
+          {showIcon ? (
+            <AlertTriangle
+              aria-hidden="true"
+              className="h-3.5 w-3.5 shrink-0"
+            />
+          ) : null}
+          <span className="min-w-0 truncate">{label}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent
+        className="max-w-80 text-left"
+        side="bottom"
+        sideOffset={12}
+      >
+        <span className="leading-4">{detail}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -579,20 +579,37 @@ function RuntimeCard({
           setupFlashToken={setupFlashToken}
         />
         {!isAvailable && runtimeDetailText(runtime) ? (
-          <p className="max-w-[13rem] text-2xs leading-4 text-muted-foreground">
+          <p
+            aria-hidden={installError ? "true" : undefined}
+            className={cn(
+              "max-w-[13rem] text-2xs leading-4 text-muted-foreground",
+              installError && "invisible",
+            )}
+          >
             {runtimeDetailText(runtime)}
           </p>
         ) : null}
       </div>
       {installError ? (
-        <p
-          className="pointer-events-none absolute inset-x-3 bottom-2 flex min-w-0 items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap text-xs leading-4 text-destructive"
-          data-testid={`onboarding-runtime-error-${runtime.id}`}
-          title={installError}
-        >
-          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          <span className="min-w-0 truncate">Setup failed</span>
-        </p>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <p
+              className="absolute inset-x-3 bottom-2 flex min-w-0 items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap text-xs leading-4 text-destructive"
+              data-testid={`onboarding-runtime-error-${runtime.id}`}
+            >
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              <span className="min-w-0 truncate">Setup failed</span>
+            </p>
+          </TooltipTrigger>
+          <TooltipContent
+            className="max-w-80 bg-black text-left text-xs text-white shadow-sm"
+            side="top"
+          >
+            <p className="text-xs leading-4 text-white">
+              {runtimeDetailText(runtime)}
+            </p>
+          </TooltipContent>
+        </Tooltip>
       ) : (
         <RuntimeAuthError runtime={runtime} />
       )}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -153,6 +153,7 @@ function RuntimeStatus({
       runtime.authStatus.status === "logged_out",
   });
   const connectMutation = useConnectAcpRuntimeMutation();
+  const runtimesQuery = useAcpRuntimesQuery();
   const authMethods = getOnboardingAuthMethods(
     runtime,
     methodsQuery.data?.methods ?? [],
@@ -198,7 +199,7 @@ function RuntimeStatus({
         </Button>
         {methodsQuery.error instanceof Error ? (
           <span className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
-            Couldn’t load sign-in options.
+            Sign-in unavailable
           </span>
         ) : null}
         {connectMutation.error instanceof Error ? (
@@ -206,7 +207,7 @@ function RuntimeStatus({
             className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
             title={connectMutation.error.message}
           >
-            {connectMutation.error.message}
+            Sign-in failed
           </span>
         ) : null}
       </div>
@@ -226,8 +227,45 @@ function RuntimeStatus({
     );
   }
 
-  if (installError) {
-    return <div aria-hidden="true" className="h-5" />;
+  if (
+    runtime.availability === "available" &&
+    runtime.authStatus.status === "unknown"
+  ) {
+    return (
+      <Button
+        aria-label={`Check ${runtime.label} again`}
+        className="buzz-onboarding-runtime-setup h-5 rounded-full bg-[var(--buzz-welcome-chartreuse)]/30 px-2.5 font-mono !text-badge font-normal uppercase text-foreground hover:bg-[var(--buzz-welcome-chartreuse)]/40"
+        disabled={runtimesQuery.isFetching}
+        onClick={(event) => {
+          event.stopPropagation();
+          void runtimesQuery.refetch();
+        }}
+        type="button"
+        variant="ghost"
+      >
+        {runtimesQuery.isFetching ? "CHECKING…" : "CHECK AGAIN"}
+      </Button>
+    );
+  }
+
+  if (installError && runtime.canAutoInstall) {
+    return (
+      <Button
+        aria-label={`Retry ${runtime.label} setup`}
+        className="buzz-onboarding-runtime-setup h-5 rounded-full bg-[var(--buzz-welcome-chartreuse)]/30 px-2.5 font-mono !text-badge font-normal uppercase text-foreground hover:bg-[var(--buzz-welcome-chartreuse)]/40"
+        data-setup-flash={isSetupFlashing ? "true" : undefined}
+        data-testid={`onboarding-runtime-install-${runtime.id}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          onSelect();
+          onInstall();
+        }}
+        type="button"
+        variant="ghost"
+      >
+        SET UP
+      </Button>
+    );
   }
 
   if (runtimeIsInstalled(runtime) || installSuccess) {
@@ -401,7 +439,7 @@ function runtimeDetailText(runtime: AcpRuntimeCatalogEntry): string {
   if (runtime.availability === "cli_missing") {
     return "ACP adapter detected; CLI missing.";
   }
-  return "Not installed yet.";
+  return "";
 }
 
 function isSupportedOnboardingAuthMethod(
@@ -451,39 +489,25 @@ function getOnboardingAuthMethods(
   return supported;
 }
 
-function RuntimeAuthActions({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
-  const runtimesQuery = useAcpRuntimesQuery();
-
+function RuntimeAuthError({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
   if (runtime.authStatus.status === "config_invalid") {
     return (
       <p
         className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
         title={runtime.authStatus.diagnostic}
       >
-        {runtime.authStatus.diagnostic}
+        Configuration invalid
       </p>
     );
   }
-  if (runtime.authStatus.status === "unknown") {
+  if (
+    runtime.availability === "available" &&
+    runtime.authStatus.status === "unknown"
+  ) {
     return (
-      <div className="flex flex-col items-center gap-1.5">
-        <span className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
-          Couldn’t verify authentication.
-        </span>
-        <Button
-          disabled={runtimesQuery.isFetching}
-          className="h-6 rounded-full px-2 text-2xs"
-          onClick={(event) => {
-            event.stopPropagation();
-            void runtimesQuery.refetch();
-          }}
-          size="sm"
-          type="button"
-          variant="ghost"
-        >
-          {runtimesQuery.isFetching ? "Checking…" : "Check again"}
-        </Button>
-      </div>
+      <p className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
+        Status unavailable
+      </p>
     );
   }
   return null;
@@ -554,24 +578,11 @@ function RuntimeCard({
           runtime={runtime}
           setupFlashToken={setupFlashToken}
         />
-        {!isAvailable ? (
-          <p
-            aria-hidden={installError ? "true" : undefined}
-            className={cn(
-              "max-w-[13rem] text-2xs leading-4 text-muted-foreground",
-              installError && "invisible",
-            )}
-          >
+        {!isAvailable && runtimeDetailText(runtime) ? (
+          <p className="max-w-[13rem] text-2xs leading-4 text-muted-foreground">
             {runtimeDetailText(runtime)}
           </p>
         ) : null}
-        {installError ? (
-          <div aria-hidden="true" className="invisible">
-            <RuntimeAuthActions runtime={runtime} />
-          </div>
-        ) : (
-          <RuntimeAuthActions runtime={runtime} />
-        )}
       </div>
       {installError ? (
         <p
@@ -580,9 +591,11 @@ function RuntimeCard({
           title={installError}
         >
           <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          <span className="min-w-0 truncate">{installError}</span>
+          <span className="min-w-0 truncate">Setup failed</span>
         </p>
-      ) : null}
+      ) : (
+        <RuntimeAuthError runtime={runtime} />
+      )}
     </div>
   );
 }

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -129,6 +129,26 @@ function useSetupFlashState(setupFlashToken: number) {
   return isFlashing;
 }
 
+function RuntimeErrorTooltip({
+  children,
+  detail,
+}: {
+  children: React.ReactNode;
+  detail: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent
+        className="max-w-80 bg-black text-left text-xs text-white shadow-sm"
+        side="top"
+      >
+        <p className="text-xs leading-4 text-white">{detail}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function RuntimeStatus({
   installError,
   installSuccess,
@@ -198,17 +218,18 @@ function RuntimeStatus({
           SET UP
         </Button>
         {methodsQuery.error instanceof Error ? (
-          <span className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
-            Sign-in unavailable
-          </span>
+          <RuntimeErrorTooltip detail="Couldn’t load sign-in options.">
+            <span className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
+              Sign-in unavailable
+            </span>
+          </RuntimeErrorTooltip>
         ) : null}
         {connectMutation.error instanceof Error ? (
-          <span
-            className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
-            title={connectMutation.error.message}
-          >
-            Sign-in failed
-          </span>
+          <RuntimeErrorTooltip detail="Couldn’t start sign-in. Try again.">
+            <span className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
+              Sign-in failed
+            </span>
+          </RuntimeErrorTooltip>
         ) : null}
       </div>
     );
@@ -492,12 +513,11 @@ function getOnboardingAuthMethods(
 function RuntimeAuthError({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
   if (runtime.authStatus.status === "config_invalid") {
     return (
-      <p
-        className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
-        title={runtime.authStatus.diagnostic}
-      >
-        Configuration invalid
-      </p>
+      <RuntimeErrorTooltip detail="Check this runtime’s configuration and try again.">
+        <p className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
+          Configuration invalid
+        </p>
+      </RuntimeErrorTooltip>
     );
   }
   if (
@@ -505,9 +525,11 @@ function RuntimeAuthError({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
     runtime.authStatus.status === "unknown"
   ) {
     return (
-      <p className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
-        Status unavailable
-      </p>
+      <RuntimeErrorTooltip detail="Couldn’t verify authentication.">
+        <p className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
+          Status unavailable
+        </p>
+      </RuntimeErrorTooltip>
     );
   }
   return null;
@@ -591,25 +613,15 @@ function RuntimeCard({
         ) : null}
       </div>
       {installError ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <p
-              className="absolute inset-x-3 bottom-2 flex min-w-0 items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap text-xs leading-4 text-destructive"
-              data-testid={`onboarding-runtime-error-${runtime.id}`}
-            >
-              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-              <span className="min-w-0 truncate">Setup failed</span>
-            </p>
-          </TooltipTrigger>
-          <TooltipContent
-            className="max-w-80 bg-black text-left text-xs text-white shadow-sm"
-            side="top"
+        <RuntimeErrorTooltip detail={runtimeDetailText(runtime)}>
+          <p
+            className="absolute inset-x-3 bottom-2 flex min-w-0 items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap text-xs leading-4 text-destructive"
+            data-testid={`onboarding-runtime-error-${runtime.id}`}
           >
-            <p className="text-xs leading-4 text-white">
-              {runtimeDetailText(runtime)}
-            </p>
-          </TooltipContent>
-        </Tooltip>
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            <span className="min-w-0 truncate">Setup failed</span>
+          </p>
+        </RuntimeErrorTooltip>
       ) : (
         <RuntimeAuthError runtime={runtime} />
       )}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -23,6 +23,7 @@ import {
   runtimeCanBeSelected,
 } from "./onboardingRuntimeSelection";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
+import { RuntimeErrorTooltip } from "./RuntimeErrorTooltip";
 import { OnboardingFooter } from "./OnboardingFooter";
 import { getRuntimeDisplayLabel, RuntimeIcon } from "./RuntimeIcon";
 import {
@@ -129,26 +130,6 @@ function useSetupFlashState(setupFlashToken: number) {
   return isFlashing;
 }
 
-function RuntimeErrorTooltip({
-  children,
-  detail,
-}: {
-  children: React.ReactNode;
-  detail: string;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent
-        className="max-w-80 bg-black text-left text-xs text-white shadow-sm"
-        side="top"
-      >
-        <p className="text-xs leading-4 text-white">{detail}</p>
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
 function RuntimeStatus({
   installError,
   installSuccess,
@@ -218,18 +199,18 @@ function RuntimeStatus({
           SET UP
         </Button>
         {methodsQuery.error instanceof Error ? (
-          <RuntimeErrorTooltip detail="Couldn’t load sign-in options.">
-            <span className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
-              Sign-in unavailable
-            </span>
-          </RuntimeErrorTooltip>
+          <RuntimeErrorTooltip
+            className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
+            detail="Couldn’t load sign-in options."
+            label="Sign-in unavailable"
+          />
         ) : null}
         {connectMutation.error instanceof Error ? (
-          <RuntimeErrorTooltip detail="Couldn’t start sign-in. Try again.">
-            <span className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
-              Sign-in failed
-            </span>
-          </RuntimeErrorTooltip>
+          <RuntimeErrorTooltip
+            className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
+            detail="Couldn’t start sign-in. Try again."
+            label="Sign-in failed"
+          />
         ) : null}
       </div>
     );
@@ -513,11 +494,11 @@ function getOnboardingAuthMethods(
 function RuntimeAuthError({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
   if (runtime.authStatus.status === "config_invalid") {
     return (
-      <RuntimeErrorTooltip detail="Check this runtime’s configuration and try again.">
-        <p className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
-          Configuration invalid
-        </p>
-      </RuntimeErrorTooltip>
+      <RuntimeErrorTooltip
+        className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
+        detail="Check this runtime’s configuration and try again."
+        label="Configuration invalid"
+      />
     );
   }
   if (
@@ -525,11 +506,11 @@ function RuntimeAuthError({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
     runtime.authStatus.status === "unknown"
   ) {
     return (
-      <RuntimeErrorTooltip detail="Couldn’t verify authentication.">
-        <p className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
-          Status unavailable
-        </p>
-      </RuntimeErrorTooltip>
+      <RuntimeErrorTooltip
+        className="absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
+        detail="Couldn’t verify authentication."
+        label="Status unavailable"
+      />
     );
   }
   return null;
@@ -613,15 +594,13 @@ function RuntimeCard({
         ) : null}
       </div>
       {installError ? (
-        <RuntimeErrorTooltip detail={runtimeDetailText(runtime)}>
-          <p
-            className="absolute inset-x-3 bottom-2 flex min-w-0 items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap text-xs leading-4 text-destructive"
-            data-testid={`onboarding-runtime-error-${runtime.id}`}
-          >
-            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-            <span className="min-w-0 truncate">Setup failed</span>
-          </p>
-        </RuntimeErrorTooltip>
+        <RuntimeErrorTooltip
+          className="absolute inset-x-3 bottom-2 flex min-w-0 items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap text-xs leading-4 text-destructive"
+          detail={runtimeDetailText(runtime)}
+          label="Setup failed"
+          showIcon
+          testId={`onboarding-runtime-error-${runtime.id}`}
+        />
       ) : (
         <RuntimeAuthError runtime={runtime} />
       )}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -197,12 +197,15 @@ function RuntimeStatus({
           SET UP
         </Button>
         {methodsQuery.error instanceof Error ? (
-          <span className="text-2xs text-destructive">
+          <span className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
             Couldn’t load sign-in options.
           </span>
         ) : null}
         {connectMutation.error instanceof Error ? (
-          <span className="text-2xs text-destructive">
+          <span
+            className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
+            title={connectMutation.error.message}
+          >
             {connectMutation.error.message}
           </span>
         ) : null}
@@ -224,11 +227,7 @@ function RuntimeStatus({
   }
 
   if (installError) {
-    return (
-      <div className="flex h-8 w-8 items-center justify-center">
-        <AlertTriangle className="h-4 w-4 text-destructive" />
-      </div>
-    );
+    return <div aria-hidden="true" className="h-5" />;
   }
 
   if (runtimeIsInstalled(runtime) || installSuccess) {
@@ -457,15 +456,18 @@ function RuntimeAuthActions({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
 
   if (runtime.authStatus.status === "config_invalid") {
     return (
-      <p className="mt-2 text-2xs leading-4 text-destructive">
+      <p
+        className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive"
+        title={runtime.authStatus.diagnostic}
+      >
         {runtime.authStatus.diagnostic}
       </p>
     );
   }
   if (runtime.authStatus.status === "unknown") {
     return (
-      <div className="mt-2 flex flex-col items-center gap-1.5">
-        <span className="text-2xs text-muted-foreground">
+      <div className="flex flex-col items-center gap-1.5">
+        <span className="pointer-events-none absolute inset-x-3 bottom-2 truncate text-xs leading-4 text-destructive">
           Couldn’t verify authentication.
         </span>
         <Button
@@ -552,18 +554,35 @@ function RuntimeCard({
           runtime={runtime}
           setupFlashToken={setupFlashToken}
         />
-        {!isAvailable && !installError ? (
-          <p className="max-w-[13rem] text-2xs leading-4 text-muted-foreground">
+        {!isAvailable ? (
+          <p
+            aria-hidden={installError ? "true" : undefined}
+            className={cn(
+              "max-w-[13rem] text-2xs leading-4 text-muted-foreground",
+              installError && "invisible",
+            )}
+          >
             {runtimeDetailText(runtime)}
           </p>
         ) : null}
         {installError ? (
-          <p className="max-w-[13rem] text-2xs leading-4 text-destructive">
-            {installError}
-          </p>
-        ) : null}
-        <RuntimeAuthActions runtime={runtime} />
+          <div aria-hidden="true" className="invisible">
+            <RuntimeAuthActions runtime={runtime} />
+          </div>
+        ) : (
+          <RuntimeAuthActions runtime={runtime} />
+        )}
       </div>
+      {installError ? (
+        <p
+          className="pointer-events-none absolute inset-x-3 bottom-2 flex min-w-0 items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap text-xs leading-4 text-destructive"
+          data-testid={`onboarding-runtime-error-${runtime.id}`}
+          title={installError}
+        >
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          <span className="min-w-0 truncate">{installError}</span>
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -596,7 +596,7 @@ function RuntimeCard({
       {installError ? (
         <RuntimeErrorTooltip
           className="absolute inset-x-3 bottom-2 flex min-w-0 items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap text-xs leading-4 text-destructive"
-          detail={runtimeDetailText(runtime)}
+          detail="Setup couldn’t be completed. Try again."
           label="Setup failed"
           showIcon
           testId={`onboarding-runtime-error-${runtime.id}`}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -128,6 +128,7 @@ type E2eConfig = {
     acpRuntimesCatalog?: RawAcpRuntimeCatalogEntry[];
     acpRuntimesDelayMs?: number;
     acpAuthMethods?: Record<string, RawAcpAuthMethodsResult>;
+    acpAuthMethodsError?: string;
     connectAcpRuntimeResult?: RawConnectAcpRuntimeResult;
     connectAcpRuntimeDelayMs?: number;
     connectAcpRuntimeError?: string;
@@ -6699,6 +6700,10 @@ async function handleDiscoverAcpAuthMethods(
   args: { runtimeId?: string },
   config: E2eConfig | undefined,
 ): Promise<RawAcpAuthMethodsResult> {
+  const error = config?.mock?.acpAuthMethodsError;
+  if (error) {
+    throw new Error(error);
+  }
   const runtimeId = args.runtimeId ?? "";
   const configured = config?.mock?.acpAuthMethods?.[runtimeId];
   if (configured) {

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -636,13 +636,14 @@ for (const authStatus of [
       await setupButton.click();
       await expect(card).toHaveAttribute("aria-checked", "true");
     } else if (authStatus.status === "unknown") {
+      await expect(card.getByText("Status unavailable")).toBeVisible();
       await expect(
-        card.getByText("Couldn’t verify authentication"),
-      ).toBeVisible();
+        card.getByRole("button", { name: "Check Claude again" }),
+      ).toHaveText("CHECK AGAIN");
       await card.click();
       await expect(card).toHaveAttribute("aria-checked", "true");
     } else {
-      await expect(card.getByText("Fix Claude config")).toBeVisible();
+      await expect(card.getByText("Configuration invalid")).toBeVisible();
       await card.click();
       await expect(card).toHaveAttribute("aria-checked", "true");
     }
@@ -714,11 +715,18 @@ test("failed install pins a single-line 12px error without moving card content",
   const detailTopBefore = await detail.evaluate(
     (element) => element.getBoundingClientRect().top,
   );
+  const setupTopBefore = await setupButton.evaluate(
+    (element) => element.getBoundingClientRect().top,
+  );
 
   await setupButton.click();
 
   const error = page.getByTestId("onboarding-runtime-error-claude");
   await expect(error).toBeVisible();
+  await expect(error).toHaveText(/Setup failed/);
+  await expect(error).toHaveAttribute("title", new RegExp(installError));
+  await expect(setupButton).toBeVisible();
+  await expect(setupButton).toHaveText("SET UP");
   await expect(error).toHaveCSS("font-size", "12px");
   await expect(error).toHaveCSS("position", "absolute");
   await expect(error).toHaveCSS("white-space", "nowrap");
@@ -729,6 +737,11 @@ test("failed install pins a single-line 12px error without moving card content",
   expect(
     await detail.evaluate((element) => element.getBoundingClientRect().top),
   ).toBe(detailTopBefore);
+  expect(
+    await setupButton.evaluate(
+      (element) => element.getBoundingClientRect().top,
+    ),
+  ).toBe(setupTopBefore);
 });
 
 test("successful install still waits for refreshed runtime readiness", async ({

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -724,13 +724,18 @@ test("failed install pins a single-line 12px error without moving card content",
   const error = page.getByTestId("onboarding-runtime-error-claude");
   await expect(error).toBeVisible();
   await expect(error).toHaveText(/Setup failed/);
-  await expect(error).toHaveAttribute("title", new RegExp(installError));
+  await expect(error).not.toHaveAttribute("title");
   await expect(setupButton).toBeVisible();
   await expect(setupButton).toHaveText("SET UP");
   await expect(error).toHaveCSS("font-size", "12px");
   await expect(error).toHaveCSS("position", "absolute");
   await expect(error).toHaveCSS("white-space", "nowrap");
   await expect(error.locator("span")).toHaveCSS("text-overflow", "ellipsis");
+  await error.hover();
+  await expect(
+    page.getByRole("tooltip").getByText("CLI detected; ACP adapter missing."),
+  ).toBeVisible();
+  await expect(page.getByRole("tooltip")).not.toContainText(installError);
   expect(
     await heading.evaluate((element) => element.getBoundingClientRect().top),
   ).toBe(headingTopBefore);

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -636,7 +636,9 @@ for (const authStatus of [
       await setupButton.click();
       await expect(card).toHaveAttribute("aria-checked", "true");
     } else if (authStatus.status === "unknown") {
-      const error = card.getByText("Status unavailable");
+      const error = card.getByRole("status", {
+        name: /Status unavailable/,
+      });
       await expect(error).toBeVisible();
       await expect(error).toHaveCSS("font-size", "12px");
       await expect(error).toHaveCSS("position", "absolute");
@@ -650,7 +652,9 @@ for (const authStatus of [
       await card.click();
       await expect(card).toHaveAttribute("aria-checked", "true");
     } else {
-      const error = card.getByText("Configuration invalid");
+      const error = card.getByRole("status", {
+        name: /Configuration invalid/,
+      });
       await expect(error).toBeVisible();
       await expect(error).toHaveCSS("font-size", "12px");
       await expect(error).toHaveCSS("position", "absolute");
@@ -717,7 +721,7 @@ test("unavailable sign-in options use the compact error and tooltip pattern", as
   const setupButton = card.getByTestId(
     "onboarding-runtime-instructions-claude",
   );
-  const error = card.getByText("Sign-in unavailable");
+  const error = card.getByRole("status", { name: /Sign-in unavailable/ });
   await expect(error).toBeVisible();
   await expect(error).toHaveCSS("font-size", "12px");
   await expect(error).toHaveCSS("position", "absolute");
@@ -775,7 +779,7 @@ test("failed sign-in uses the compact error and tooltip pattern", async ({
 
   await setupButton.click();
 
-  const error = card.getByText("Sign-in failed");
+  const error = card.getByRole("status", { name: /Sign-in failed/ });
   await expect(error).toBeVisible();
   await expect(error).toHaveCSS("font-size", "12px");
   await expect(error).toHaveCSS("position", "absolute");
@@ -786,6 +790,28 @@ test("failed sign-in uses the compact error and tooltip pattern", async ({
     "Couldn’t start sign-in. Try again.",
   );
   await expect(page.getByRole("tooltip")).not.toContainText(connectionError);
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("tooltip")).toBeHidden();
+  await error.focus();
+  const tooltip = page.getByRole("tooltip");
+  await expect(tooltip).toHaveText("Couldn’t start sign-in. Try again.");
+  await expect(error).toHaveAccessibleName(
+    "Sign-in failed. Couldn’t start sign-in. Try again.",
+  );
+  const [cardBox, setupBox, tooltipBox] = await Promise.all([
+    card.boundingBox(),
+    setupButton.boundingBox(),
+    tooltip.boundingBox(),
+  ]);
+  expect(cardBox).not.toBeNull();
+  expect(setupBox).not.toBeNull();
+  expect(tooltipBox).not.toBeNull();
+  expect(tooltipBox?.y).toBeGreaterThanOrEqual(
+    (cardBox?.y ?? 0) + (cardBox?.height ?? 0),
+  );
+  expect(tooltipBox?.y).toBeGreaterThanOrEqual(
+    (setupBox?.y ?? 0) + (setupBox?.height ?? 0),
+  );
   await expect(setupButton).toBeVisible();
   expect(
     await heading.evaluate((element) => element.getBoundingClientRect().top),

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -636,14 +636,31 @@ for (const authStatus of [
       await setupButton.click();
       await expect(card).toHaveAttribute("aria-checked", "true");
     } else if (authStatus.status === "unknown") {
-      await expect(card.getByText("Status unavailable")).toBeVisible();
+      const error = card.getByText("Status unavailable");
+      await expect(error).toBeVisible();
+      await expect(error).toHaveCSS("font-size", "12px");
+      await expect(error).toHaveCSS("position", "absolute");
+      await error.hover();
+      await expect(page.getByRole("tooltip")).toHaveText(
+        "Couldn’t verify authentication.",
+      );
       await expect(
         card.getByRole("button", { name: "Check Claude again" }),
       ).toHaveText("CHECK AGAIN");
       await card.click();
       await expect(card).toHaveAttribute("aria-checked", "true");
     } else {
-      await expect(card.getByText("Configuration invalid")).toBeVisible();
+      const error = card.getByText("Configuration invalid");
+      await expect(error).toBeVisible();
+      await expect(error).toHaveCSS("font-size", "12px");
+      await expect(error).toHaveCSS("position", "absolute");
+      await error.hover();
+      await expect(page.getByRole("tooltip")).toHaveText(
+        "Check this runtime’s configuration and try again.",
+      );
+      await expect(page.getByRole("tooltip")).not.toContainText(
+        "Fix Claude config",
+      );
       await card.click();
       await expect(card).toHaveAttribute("aria-checked", "true");
     }
@@ -677,6 +694,107 @@ test("setup cards only show checks after user selection", async ({ page }) => {
   await expect(
     page.getByTestId("onboarding-runtime-installed-goose"),
   ).toHaveText("INSTALLED");
+});
+
+test("unavailable sign-in options use the compact error and tooltip pattern", async ({
+  page,
+}) => {
+  const discoveryError = "Auth discovery failed with sensitive details";
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("claude", { status: "logged_out" }),
+      ],
+      acpAuthMethodsError: discoveryError,
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const card = page.getByTestId("onboarding-runtime-claude");
+  const setupButton = card.getByTestId(
+    "onboarding-runtime-instructions-claude",
+  );
+  const error = card.getByText("Sign-in unavailable");
+  await expect(error).toBeVisible();
+  await expect(error).toHaveCSS("font-size", "12px");
+  await expect(error).toHaveCSS("position", "absolute");
+  await expect(error).toHaveCSS("white-space", "nowrap");
+  await expect(error).not.toHaveAttribute("title");
+  await error.hover();
+  await expect(page.getByRole("tooltip")).toHaveText(
+    "Couldn’t load sign-in options.",
+  );
+  await expect(page.getByRole("tooltip")).not.toContainText(discoveryError);
+  await expect(setupButton).toBeVisible();
+  await expect(setupButton).toHaveText("SET UP");
+});
+
+test("failed sign-in uses the compact error and tooltip pattern", async ({
+  page,
+}) => {
+  const connectionError = "Terminal launch failed with sensitive details";
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("claude", { status: "logged_out" }),
+      ],
+      acpAuthMethods: {
+        claude: {
+          methods: [
+            {
+              id: "login",
+              name: "Sign in",
+              description: null,
+              type: "terminal",
+            },
+          ],
+        },
+      },
+      connectAcpRuntimeError: connectionError,
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const card = page.getByTestId("onboarding-runtime-claude");
+  const setupButton = card.getByTestId(
+    "onboarding-runtime-instructions-claude",
+  );
+  const heading = card.getByRole("heading", { name: "Claude" });
+  const headingTopBefore = await heading.evaluate(
+    (element) => element.getBoundingClientRect().top,
+  );
+  const setupTopBefore = await setupButton.evaluate(
+    (element) => element.getBoundingClientRect().top,
+  );
+
+  await setupButton.click();
+
+  const error = card.getByText("Sign-in failed");
+  await expect(error).toBeVisible();
+  await expect(error).toHaveCSS("font-size", "12px");
+  await expect(error).toHaveCSS("position", "absolute");
+  await expect(error).toHaveCSS("white-space", "nowrap");
+  await expect(error).not.toHaveAttribute("title");
+  await error.hover();
+  await expect(page.getByRole("tooltip")).toHaveText(
+    "Couldn’t start sign-in. Try again.",
+  );
+  await expect(page.getByRole("tooltip")).not.toContainText(connectionError);
+  await expect(setupButton).toBeVisible();
+  expect(
+    await heading.evaluate((element) => element.getBoundingClientRect().top),
+  ).toBe(headingTopBefore);
+  expect(
+    await setupButton.evaluate(
+      (element) => element.getBoundingClientRect().top,
+    ),
+  ).toBe(setupTopBefore);
 });
 
 test("failed install pins a single-line 12px error without moving card content", async ({

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -678,6 +678,59 @@ test("setup cards only show checks after user selection", async ({ page }) => {
   ).toHaveText("INSTALLED");
 });
 
+test("failed install pins a single-line 12px error without moving card content", async ({
+  page,
+}) => {
+  const installError = "Install already in progress with additional details";
+  await installMockBridge(
+    page,
+    {
+      installAcpRuntimeResult: {
+        success: false,
+        steps: [
+          {
+            step: "Install adapter",
+            command: "npm install adapter",
+            success: false,
+            stdout: "",
+            stderr: installError,
+            exit_code: 1,
+          },
+        ],
+      },
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const card = page.getByTestId("onboarding-runtime-claude");
+  const setupButton = page.getByTestId("onboarding-runtime-install-claude");
+  const heading = card.getByRole("heading", { name: "Claude" });
+  const headingTopBefore = await heading.evaluate(
+    (element) => element.getBoundingClientRect().top,
+  );
+  const detail = card.getByText("CLI detected; ACP adapter missing.");
+  const detailTopBefore = await detail.evaluate(
+    (element) => element.getBoundingClientRect().top,
+  );
+
+  await setupButton.click();
+
+  const error = page.getByTestId("onboarding-runtime-error-claude");
+  await expect(error).toBeVisible();
+  await expect(error).toHaveCSS("font-size", "12px");
+  await expect(error).toHaveCSS("position", "absolute");
+  await expect(error).toHaveCSS("white-space", "nowrap");
+  await expect(error.locator("span")).toHaveCSS("text-overflow", "ellipsis");
+  expect(
+    await heading.evaluate((element) => element.getBoundingClientRect().top),
+  ).toBe(headingTopBefore);
+  expect(
+    await detail.evaluate((element) => element.getBoundingClientRect().top),
+  ).toBe(detailTopBefore);
+});
+
 test("successful install still waits for refreshed runtime readiness", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -876,9 +876,9 @@ test("failed install pins a single-line 12px error without moving card content",
   await expect(error).toHaveCSS("white-space", "nowrap");
   await expect(error.locator("span")).toHaveCSS("text-overflow", "ellipsis");
   await error.hover();
-  await expect(
-    page.getByRole("tooltip").getByText("CLI detected; ACP adapter missing."),
-  ).toBeVisible();
+  await expect(page.getByRole("tooltip")).toHaveText(
+    "Setup couldn’t be completed. Try again.",
+  );
   await expect(page.getByRole("tooltip")).not.toContainText(installError);
   expect(
     await heading.evaluate((element) => element.getBoundingClientRect().top),

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -130,6 +130,7 @@ type MockBridgeOptions = {
   acpRuntimesCatalog?: Record<string, unknown>[];
   acpRuntimesDelayMs?: number;
   acpAuthMethods?: Record<string, { methods: Record<string, unknown>[] }>;
+  acpAuthMethodsError?: string;
   connectAcpRuntimeResult?: { launched: boolean };
   connectAcpRuntimeDelayMs?: number;
   connectAcpRuntimeError?: string;


### PR DESCRIPTION
## Why
Keep onboarding harness-card errors compact and readable without shifting card content or obscuring the setup action.

## What
- Pin short 12px error labels to the bottom of runtime cards while preserving their existing content positions
- Show sanitized explanatory detail in an accessible, theme-aware tooltip below the card
- Keep setup and retry actions in the existing pill affordance
- Add deterministic Playwright coverage for install, sign-in, authentication-status, and configuration errors

## Risk Assessment
Low — the production change is limited to onboarding runtime-card error presentation and existing action placement. The remaining changes are E2E-only mock support and regression coverage.

## References
- Final visual: https://sprout-oss.stage.blox.sqprod.co/media/11337f0ff35ca3fb525cb8b408f620ec691cdaa1e890b4eac4d6b68cf655ec57.png
- Verified with repository pre-push gates plus focused Playwright error-state coverage

Generated with Peppermint Butler
