### PR TITLE
fix(acp): teach agents to send real newlines

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -19,7 +19,7 @@ The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ
 | `buzz repos` | `create`, `get`, `list` |
 | `buzz upload` | `file` |
 
-Run `buzz --help` or `buzz <group> --help` for full usage. `buzz agents draft-create` and `buzz agents draft-update` require `BUZZ_AUTH_TAG`; if it is missing, explain that this managed agent cannot open owner-reviewed agent drafts from chat.
+Run `buzz --help` or `buzz <group> --help` for full usage. For multiline message content, pass real newline bytes through stdin: `printf 'first\n\nsecond\n' | buzz messages send ... --content -`. Do not write `--content 'first\n\nsecond'`: single-quoted shell strings preserve `\n` literally, so recipients will see the backslash characters. `buzz agents draft-create` and `buzz agents draft-update` require `BUZZ_AUTH_TAG`; if it is missing, explain that this managed agent cannot open owner-reviewed agent drafts from chat.
 
 ## Conversational Agent Creation
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3277,6 +3277,14 @@ mod agent_draft_prompt_tests {
         assert!(prompt.contains("owner saves it"));
         assert!(prompt.contains("Do not ask about runtime, provider, model, credentials"));
     }
+
+    #[test]
+    fn shared_base_prompt_teaches_real_newlines_for_multiline_messages() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("pass real newline bytes through stdin"));
+        assert!(prompt.contains("single-quoted shell strings preserve `\\n` literally"));
+        assert!(prompt.contains("buzz messages send ... --content -"));
+    }
 }
 
 fn default_heartbeat_prompt() -> String {


### PR DESCRIPTION
## Summary

- teach managed agents to pass multiline message bodies through stdin
- call out that single-quoted `\n` is published literally
- pin the guidance with a prompt regression test

## Root cause

The reported message contained literal backslash-n characters before it reached Buzz. Actual newline bytes are already preserved by `buzz messages send` and rendered by the desktop Markdown path. Client-side unescaping would corrupt intentional `\n` in code and prose.

## Test plan

- `cargo test -p buzz-acp shared_base_prompt_teaches_real_newlines_for_multiline_messages`
- full pre-push hook (desktop checks/tests, mobile tests, Rust tests)
