### PR TITLE
fix(desktop): refine onboarding copy

### DIFF
--- a/desktop/src/features/onboarding/ui/BackupStep.tsx
+++ b/desktop/src/features/onboarding/ui/BackupStep.tsx
@@ -85,7 +85,7 @@ export function BackupStep({ direction, onBack, onNext }: BackupStepProps) {
     >
       <div className="w-full max-w-[500px] text-center">
         <h1 className="text-title font-normal text-foreground">
-          Your unique identity has been created
+          Your unique identity key has been created
         </h1>
         <p className="mt-5 text-sm leading-6 text-foreground/80">
           This key is stored in your system keychain, but save it some place
@@ -139,8 +139,8 @@ export function BackupStep({ direction, onBack, onNext }: BackupStepProps) {
           <p className="mx-auto mt-6 flex max-w-[440px] items-start justify-center gap-1.5 text-center text-xs leading-5 text-[var(--buzz-onboarding-backup-ink)]">
             <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
             <span>
-              Never share your private key. Anyone can impersonate you and
-              access everything in your account.
+              Never share your private key. Anyone with this key can impersonate
+              you and access everything in your account.
             </span>
           </p>
         ) : null}

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -254,8 +254,9 @@ export function DefaultConfigStep({
           Configure your default model settings
         </h1>
         <p className="mx-auto mt-3 max-w-[440px] text-sm leading-5 text-foreground/80">
-          These settings will be used by your agents in Buzz. You can always
-          change them in your Settings.
+          This will be set as your default model configuration across Buzz. You
+          can always change this in your Settings or give specific agents a
+          different configuration.
         </p>
       </div>
 

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -239,7 +239,7 @@ export function MachineOnboardingFlow({
                 <p className="mt-5 max-w-[440px] text-sm leading-6 text-foreground/80">
                   {identityLost
                     ? "Your identity is no longer in the system keyring. Re-import your nsec to restore it."
-                    : "If you already have a Nostr account, enter your private key below to get started."}
+                    : "If you already have a Buzz account, enter your private key below to get started."}
                 </p>
               </div>
               <div className="buzz-onboarding-key-import-position w-full">

--- a/desktop/tests/e2e/identity-lost.spec.ts
+++ b/desktop/tests/e2e/identity-lost.spec.ts
@@ -27,7 +27,7 @@ test("normal first launch uses the already-persisted identity", async ({
 
   await expect(
     page.getByRole("heading", {
-      name: "Your unique identity has been created",
+      name: "Your unique identity key has been created",
     }),
   ).toBeVisible();
   // Non-landing pages layer the dot grid over the chartreuse→light-blue gradient.

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -969,8 +969,11 @@ test("config page shows Agent defaults form", async ({ page }) => {
   await expect(page.getByLabel("OpenAI API Key")).toHaveCount(0);
   await expect(effortSelect).toBeVisible();
   await expect(
-    page.getByText("This will be set as your default model configuration"),
-  ).toHaveCount(0);
+    page.getByText(
+      "This will be set as your default model configuration across Buzz. You can always change this in your Settings or give specific agents a different configuration.",
+      { exact: true },
+    ),
+  ).toBeVisible();
   await expect(page.getByTestId("agent-readiness-badge")).toHaveCount(0);
 
   await waitForAnimations(page);

--- a/desktop/tests/e2e/onboarding-backup.spec.ts
+++ b/desktop/tests/e2e/onboarding-backup.spec.ts
@@ -21,7 +21,7 @@ test("backup step appears on fresh-key path after profile submit", async ({
   await expect(page.getByTestId("onboarding-page-backup")).toBeVisible();
   await expect(
     page.getByRole("heading", {
-      name: "Your unique identity has been created",
+      name: "Your unique identity key has been created",
     }),
   ).toBeVisible();
 });

--- a/desktop/tests/e2e/onboarding-docked-cta-screenshots.spec.ts
+++ b/desktop/tests/e2e/onboarding-docked-cta-screenshots.spec.ts
@@ -53,7 +53,7 @@ test("machine onboarding: landing, backup, setup docked CTAs", async ({
   await page.getByRole("button", { name: "Create a new identity key" }).click();
   await expect(
     page.getByRole("heading", {
-      name: "Your unique identity has been created",
+      name: "Your unique identity key has been created",
     }),
   ).toBeVisible();
   await waitForAnimations(page);


### PR DESCRIPTION
## Why
Clarify onboarding language around identity keys, account recovery, and the default model configuration.

## What
- Refine the identity-key creation and private-key warning copy
- Describe private-key import in terms of an existing Buzz account
- Clarify how the default model configuration applies across Buzz
- Update exact-heading E2E expectations for the revised identity-key heading

## Risk Assessment
Low — copy and matching test expectations only; no layout, state, navigation, persistence, settings, configuration, or runtime behavior changes.

## References
- `pnpm --dir desktop check`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test` (3,180 passed)
- `pnpm --dir desktop build`
- `git diff --check`

Generated with Peppermint Butler
