### PR TITLE
remove relay field from invite link step

### DIFF
--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -410,7 +410,6 @@ function CommunityApp({
       // Show welcome setup for first-run users with no communities
       appContent = (
         <WelcomeSetup
-          defaultRelayUrl={community.defaultRelayUrl}
           initialPage={resumeFirstCommunityJoin ? "join" : undefined}
           onBack={onBackToMachineConfig}
         />

--- a/desktop/src/features/communities/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/communities/ui/WelcomeSetup.tsx
@@ -31,26 +31,16 @@ type WelcomeSetupPage = "welcome" | "join" | "invite";
 type WelcomeTransitionMode = "initial" | OnboardingTransitionDirection;
 
 type WelcomeSetupProps = {
-  defaultRelayUrl: string;
   initialPage?: WelcomeSetupPage;
   initialTransitionMode?: WelcomeTransitionMode;
   onBack: () => void;
 };
 
 const CREATE_COMMUNITY_URL = "https://app.builderlab.xyz/signup?returnTo=/buzz";
-const LOCAL_DEV_RELAY_URLS = new Set([
-  "ws://localhost:3000",
-  "ws://127.0.0.1:3000",
-]);
 const COMMUNITY_OPTION_CARD_CLASS =
   "flex min-h-24 w-full max-w-[352px] items-center justify-center rounded-xl bg-white/75 px-6 py-4 text-center text-sm font-normal leading-6 text-foreground transition-colors duration-150 ease-out hover:bg-white/85 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/35";
 
-function isLocalDevRelayUrl(relayUrl: string) {
-  return LOCAL_DEV_RELAY_URLS.has(relayUrl.trim().replace(/\/$/, ""));
-}
-
 export function WelcomeSetup({
-  defaultRelayUrl,
   initialPage = "welcome",
   initialTransitionMode = "initial",
   onBack,
@@ -324,11 +314,6 @@ export function WelcomeSetup({
               </div>
               <div className="flex w-full flex-1 items-center justify-center pb-4 pt-12">
                 <InviteRedeemForm
-                  defaultRelayUrl={
-                    isLocalDevRelayUrl(defaultRelayUrl)
-                      ? undefined
-                      : defaultRelayUrl
-                  }
                   error={null}
                   isRedeeming={false}
                   onCancel={() => showPage("welcome")}

--- a/desktop/src/features/onboarding/ui/InviteRedeemForm.tsx
+++ b/desktop/src/features/onboarding/ui/InviteRedeemForm.tsx
@@ -108,6 +108,8 @@ export function InviteRedeemForm({
     ("relayWsUrl" in parsed ||
       (isBareCode && bareCodeRelayUrl.trim().length > 0));
   const isOnboardingSpotlight = variant === "onboarding-spotlight";
+  const showInvalidInviteTip =
+    isOnboardingSpotlight && inviteInput.trim().length > 0 && !canSubmit;
 
   const handleSubmit = React.useCallback(
     async (event: React.FormEvent) => {
@@ -309,6 +311,20 @@ export function InviteRedeemForm({
           />
         </div>
       )}
+
+      {isOnboardingSpotlight ? (
+        <p
+          aria-hidden={!showInvalidInviteTip}
+          aria-live="polite"
+          className={cn(
+            "min-h-5 w-full max-w-4xl text-center text-sm text-[#717106] transition-opacity duration-150 ease-out",
+            showInvalidInviteTip ? "opacity-100" : "opacity-0",
+          )}
+          data-testid="invalid-invite-tip"
+        >
+          Please enter a valid invite link
+        </p>
+      ) : null}
 
       {needsRelayField ? (
         <div

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -728,6 +728,29 @@ test("first-community choices expose npub and invite input", async ({
   ).toBe(true);
   await expect(page.getByTestId("invite-redeem-submit")).toHaveText("Next");
   await expect(page.getByTestId("invite-redeem-submit")).toBeDisabled();
+  const inviteFrame = page.getByTestId("invite-redeem-input-frame");
+  const initialInviteFrameBox = await inviteFrame.boundingBox();
+  expect(initialInviteFrameBox).not.toBeNull();
+  const invalidInviteTip = page.getByTestId("invalid-invite-tip");
+  await expect(invalidInviteTip).toHaveAttribute("aria-hidden", "true");
+  await expect(invalidInviteTip).toHaveCSS("opacity", "0");
+
+  await inviteInput.fill("awefi");
+  await expect(page.getByLabel("Relay URL")).toHaveCount(0);
+  await expect(page.getByTestId("invite-redeem-submit")).toBeDisabled();
+  await expect(invalidInviteTip).toBeVisible();
+  await expect(invalidInviteTip).toHaveAttribute("aria-hidden", "false");
+  await expect(invalidInviteTip).toHaveCSS("opacity", "1");
+  await expect(invalidInviteTip).toHaveCSS("color", "rgb(113, 113, 6)");
+  await expect(invalidInviteTip).toHaveCSS("text-align", "center");
+  const invalidInviteFrameBox = await inviteFrame.boundingBox();
+  expect(invalidInviteFrameBox?.y).toBe(initialInviteFrameBox?.y);
+
+  await inviteInput.fill("https://default.example.com/invite/abc123");
+  await expect(page.getByLabel("Relay URL")).toHaveCount(0);
+  await expect(page.getByTestId("invite-redeem-submit")).toBeEnabled();
+  await expect(invalidInviteTip).toHaveAttribute("aria-hidden", "true");
+  await expect(invalidInviteTip).toHaveCSS("opacity", "0");
 });
 
 test("first-community shows the scenario cards for localhost", async ({


### PR DESCRIPTION
## Why
The first-community **Enter your invite link** step treated arbitrary non-empty text as a relay-code fallback. That exposed a **Relay URL** field and enabled **Next**, even though the user had not entered an invite link.

## What
- Require a valid invite URL on the first-community invite step instead of falling back to the configured relay URL
- Keep the relay URL field hidden for invalid input and keep **Next** disabled
- Show a centered `Please enter a valid invite link` tip for non-empty invalid input
- Reserve the tip row and fade its opacity so validation does not shift the invite container
- Hide the inactive tip from the accessibility tree
- Remove the obsolete `defaultRelayUrl` prop and local-relay fallback helper from `WelcomeSetup`
- Add focused E2E coverage for invalid/valid transitions, exact tip presentation, accessibility state, and stable container position

## Risk Assessment
Low — this is scoped to first-community invite-link validation and presentation. It does not change invite parsing, submission, relay communication, persistence, or navigation. Existing membership-recovery behavior remains unchanged.

## References
- `pnpm exec biome check src/app/App.tsx src/features/communities/ui/WelcomeSetup.tsx src/features/onboarding/ui/InviteRedeemForm.tsx tests/e2e/onboarding.spec.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec playwright test tests/e2e/onboarding.spec.ts --grep "first-community choices expose npub and invite input"`
- Full pre-push suite passed

Generated with Peppermint Butler
