### PR TITLE
fix(desktop): stream large media uploads

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -71,7 +71,7 @@ hex = "0.4"
 ed25519-dalek = "=3.0.0-rc.0"
 tokio = { version = "1", features = ["fs", "sync", "rt", "macros", "time", "net", "io-util"] }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { version = "0.7", features = ["rt", "io"] }
 bytes = "1"
 futures-util = "0.3"
 opus = "0.3"

--- a/desktop/src-tauri/src/commands/media.rs
+++ b/desktop/src-tauri/src/commands/media.rs
@@ -12,7 +12,7 @@ use crate::relay::{
 
 use super::media_transcode::{
     has_heic_extension, is_heic_file, is_video_file, transcode_and_extract_poster,
-    transcode_heic_path_to_jpeg_bytes,
+    transcode_and_extract_poster_path, transcode_heic_path_to_jpeg_bytes,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -141,7 +141,7 @@ const BLOCKED_MIME: &[&str] = &[
 /// control characters, and bounds length to 255. Mirrors the relay's filename
 /// validation so a sanitized name always passes ingest. Returns a fallback when
 /// the result would be empty.
-pub(crate) fn sanitize_filename(name: &str) -> String {
+pub(super) fn sanitize_filename(name: &str) -> String {
     // Keep only the final path segment — defend against `../` and absolute paths
     // regardless of separator style.
     let base = name.rsplit(['/', '\\']).next().unwrap_or(name).trim();
@@ -344,11 +344,7 @@ fn sign_blossom_upload_auth(
         .map_err(|e| e.to_string())
 }
 
-/// Execute the upload HTTP request. Shared by all upload entry points.
-// TODO(v2): Stream large video files to the relay instead of buffering in RAM.
-// Current approach works for videos up to ~100MB but will OOM on 500MB files.
-// Fix: use reqwest's Body::wrap_stream() to stream from the temp file directly.
-// The server already supports streaming upload via process_video_upload.
+/// Execute a buffered upload HTTP request. Shared by byte-based upload entry points.
 fn should_retry_legacy_upload(status: reqwest::StatusCode) -> bool {
     matches!(
         status,
@@ -399,6 +395,123 @@ async fn send_upload_attempt(
         req.body(body).send().await
     };
     response.map_err(|error| classify_request_error(&error))
+}
+
+async fn send_upload_file_attempt(
+    state: &State<'_, AppState>,
+    url: String,
+    auth_header: &str,
+    mime: &str,
+    sha256: &str,
+    path: &std::path::Path,
+    progress: Option<&(tauri::AppHandle, String)>,
+) -> Result<reqwest::Response, String> {
+    use futures_util::StreamExt;
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    };
+    use tokio_util::io::ReaderStream;
+
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| format!("failed to open upload file: {e}"))?;
+    let total = file
+        .metadata()
+        .await
+        .map_err(|e| format!("failed to stat upload file: {e}"))?
+        .len();
+    let sent = Arc::new(AtomicU64::new(0));
+    let progress = progress.cloned();
+    let stream = ReaderStream::new(file).map(move |chunk| {
+        if let (Ok(bytes), Some((app, progress_id))) = (&chunk, &progress) {
+            use tauri::Emitter;
+            let sent = sent.fetch_add(bytes.len() as u64, Ordering::Relaxed) + bytes.len() as u64;
+            let _ = app.emit(
+                "media-upload-progress",
+                serde_json::json!({ "id": progress_id, "sent": sent, "total": total }),
+            );
+        }
+        chunk
+    });
+
+    state
+        .http_client
+        .put(url)
+        .header("Authorization", auth_header)
+        .header("Content-Type", mime)
+        .header("X-SHA-256", sha256)
+        .header(reqwest::header::CONTENT_LENGTH, total)
+        .body(reqwest::Body::wrap_stream(stream))
+        .send()
+        .await
+        .map_err(|error| classify_request_error(&error))
+}
+
+async fn sha256_file(path: &std::path::Path) -> Result<String, String> {
+    use tokio::io::AsyncReadExt;
+
+    let mut file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| format!("failed to open upload file: {e}"))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .await
+            .map_err(|e| format!("failed to hash upload file: {e}"))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+async fn do_upload_file(
+    path: &std::path::Path,
+    mime: &str,
+    state: &State<'_, AppState>,
+    progress: Option<(tauri::AppHandle, String)>,
+) -> Result<BlobDescriptor, String> {
+    let sha256 = sha256_file(path).await?;
+    let base_url = relay_api_base_url_with_override(state);
+    let auth_event = {
+        let keys = state.signing_keys()?;
+        sign_blossom_upload_auth(&keys, &sha256, 3600, &base_url)?
+    };
+    let auth_header = format!(
+        "Nostr {}",
+        URL_SAFE_NO_PAD.encode(auth_event.as_json().as_bytes())
+    );
+
+    let mut response = send_upload_file_attempt(
+        state,
+        format!("{base_url}/upload"),
+        &auth_header,
+        mime,
+        &sha256,
+        path,
+        progress.as_ref(),
+    )
+    .await?;
+    if should_retry_legacy_upload(response.status()) {
+        response = send_upload_file_attempt(
+            state,
+            format!("{base_url}/media/upload"),
+            &auth_header,
+            mime,
+            &sha256,
+            path,
+            progress.as_ref(),
+        )
+        .await?;
+    }
+    if !response.status().is_success() {
+        return Err(relay_error_message(response).await);
+    }
+    parse_json_response::<BlobDescriptor>(response).await
 }
 
 async fn do_upload(
@@ -496,6 +609,17 @@ pub async fn upload_media(
     do_upload(body, &mime, &state, None).await
 }
 
+enum PreparedUpload {
+    Bytes {
+        body: Vec<u8>,
+        mime: String,
+    },
+    File {
+        path: std::path::PathBuf,
+        mime: String,
+    },
+}
+
 /// Read a picked path through the TOCTOU-safe pipeline (fd pin → sniff →
 /// transcode-or-passthrough → MIME validation → upload).
 ///
@@ -503,10 +627,11 @@ pub async fn upload_media(
 /// not an image (videos and non-image files error out; HEIC/HEIF still
 /// transcode to JPEG, which is an image). This keeps discarded/non-image
 /// files from ever leaving the client on image-only surfaces.
-async fn process_picked_path(
+pub(super) async fn process_picked_path(
     path: std::path::PathBuf,
     state: &State<'_, AppState>,
     images_only: bool,
+    progress: Option<(tauri::AppHandle, String)>,
 ) -> Result<BlobDescriptor, String> {
     // Pin the inode by opening the fd BEFORE spawn_blocking. This prevents a
     // local attacker from swapping the file between dialog return and read.
@@ -520,11 +645,10 @@ async fn process_picked_path(
 
     // All sync I/O (sniff, transcode, read) runs off the async runtime to
     // avoid blocking Tokio worker threads during long ffmpeg transcodes.
-    let (body, poster_bytes) =
-        tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, Option<Vec<u8>>), String> {
+    let (prepared, poster_bytes) = tokio::task::spawn_blocking(
+        move || -> Result<(PreparedUpload, Option<Vec<u8>>), String> {
             use std::io::Read;
 
-            // Sniff magic bytes from the pinned fd — no re-open, no TOCTOU.
             let mut header = [0u8; 4096];
             let n = file.read(&mut header).map_err(|e| e.to_string())?;
 
@@ -532,48 +656,57 @@ async fn process_picked_path(
                 if images_only {
                     return Err("Please choose an image file.".to_string());
                 }
-                // ffmpeg needs a path, not an fd. Resolve the fd's real path
-                // so we pass the actual inode's location, not the original
-                // (potentially swapped) pathname. Same pattern as upload_media.
-                // IMPORTANT: keep `file` alive (fd open) until after transcode
-                // completes — this prevents the inode from being unlinked or
-                // the resolved path from becoming stale during the ffmpeg run.
                 let fd_path = fd_real_path(&file)?;
-                let result = transcode_and_extract_poster(&fd_path);
-                drop(file); // release fd only after ffmpeg is done
-                result
+                let (path, poster) = transcode_and_extract_poster_path(&fd_path)?;
+                drop(file);
+                Ok((
+                    PreparedUpload::File {
+                        path,
+                        mime: "video/mp4".to_string(),
+                    },
+                    poster,
+                ))
             } else if heic_by_ext || is_heic_file(&header[..n]) {
-                // HEIC/HEIF still: Chromium/the webview can't decode it, so
-                // transcode to JPEG before upload (mirrors mobile). Resolve the
-                // fd's real path so ffmpeg reads the pinned inode, and keep
-                // `file` alive until the transcode finishes.
                 let fd_path = fd_real_path(&file)?;
-                let result = transcode_heic_path_to_jpeg_bytes(&fd_path).map(|jpeg| (jpeg, None));
-                drop(file); // release fd only after ffmpeg is done
-                result
+                let jpeg = transcode_heic_path_to_jpeg_bytes(&fd_path)?;
+                drop(file);
+                Ok((
+                    PreparedUpload::Bytes {
+                        body: jpeg,
+                        mime: "image/jpeg".to_string(),
+                    },
+                    None,
+                ))
             } else {
-                // Image: read the rest from the already-open fd (TOCTOU-safe).
-                let mut bytes = header[..n].to_vec();
-                file.read_to_end(&mut bytes)
+                let mut body = header[..n].to_vec();
+                file.read_to_end(&mut body)
                     .map_err(|e| format!("failed to read file: {e}"))?;
-                Ok((bytes, None))
+                let mime = detect_and_validate_mime(&body)?;
+                let body = sanitize_image_for_upload(body, &mime)?;
+                Ok((PreparedUpload::Bytes { body, mime }, None))
             }
-        })
-        .await
-        .map_err(|e| format!("transcode task failed: {e}"))??;
+        },
+    )
+    .await
+    .map_err(|e| format!("transcode task failed: {e}"))??;
 
-    let mime = detect_and_validate_mime(&body)?;
-    let body = sanitize_image_for_upload(body, &mime)?;
-
-    // Image-only surfaces (e.g. "Send feedback"): reject anything that didn't
-    // sniff as an image, BEFORE the upload leaves the client.
-    if images_only && !mime.starts_with("image/") {
-        return Err("Please choose an image file.".to_string());
+    if images_only {
+        let mime = match &prepared {
+            PreparedUpload::Bytes { mime, .. } | PreparedUpload::File { mime, .. } => mime,
+        };
+        if !mime.starts_with("image/") {
+            return Err("Please choose an image file.".to_string());
+        }
     }
 
-    // Upload video first, then poster (best-effort). If poster upload fails,
-    // the video descriptor is returned without an image field.
-    let mut descriptor = do_upload(body, &mime, state, None).await?;
+    let mut descriptor = match &prepared {
+        PreparedUpload::Bytes { body, mime } => do_upload(body.clone(), mime, state, None).await?,
+        PreparedUpload::File { path, mime } => {
+            let result = do_upload_file(path, mime, state, progress).await;
+            let _ = tokio::fs::remove_file(path).await;
+            result?
+        }
+    };
 
     if let Some(poster) = poster_bytes {
         match do_upload(poster, "image/jpeg", state, None).await {
@@ -628,7 +761,7 @@ pub async fn pick_and_upload_media(
     let mut descriptors = Vec::with_capacity(file_paths.len());
     for file_path in file_paths {
         let path = file_path.as_path().ok_or("invalid path")?.to_path_buf();
-        let descriptor = process_picked_path(path, &state, false).await?;
+        let descriptor = process_picked_path(path, &state, false, None).await?;
         descriptors.push(descriptor);
     }
 
@@ -669,7 +802,7 @@ pub async fn pick_and_upload_image(
     };
 
     let path = file_path.as_path().ok_or("invalid path")?.to_path_buf();
-    let descriptor = process_picked_path(path, &state, true).await?;
+    let descriptor = process_picked_path(path, &state, true, None).await?;
     Ok(Some(descriptor))
 }
 
@@ -748,190 +881,6 @@ pub async fn upload_media_bytes(
     Ok(descriptor)
 }
 
-// ── Tests ────────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_extract_server_authority_default_ports() {
-        assert_eq!(
-            extract_server_authority("https://relay.example.com"),
-            Some("relay.example.com".to_string())
-        );
-        assert_eq!(
-            extract_server_authority("https://relay.example.com:443"),
-            Some("relay.example.com".to_string())
-        );
-        assert_eq!(
-            extract_server_authority("http://relay.example.com:80"),
-            Some("relay.example.com".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_server_authority_non_default_ports() {
-        assert_eq!(
-            extract_server_authority("http://localhost:3000"),
-            Some("localhost:3000".to_string())
-        );
-        assert_eq!(
-            extract_server_authority("https://relay.example.com:8443"),
-            Some("relay.example.com:8443".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_server_authority_ipv6() {
-        assert_eq!(
-            extract_server_authority("http://[::1]:3000"),
-            Some("[::1]:3000".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_server_authority_invalid() {
-        assert_eq!(extract_server_authority("not-a-url"), None);
-        assert_eq!(extract_server_authority(""), None);
-    }
-
-    #[test]
-    fn test_sign_blossom_get_auth_header_shape() {
-        let keys = Keys::generate();
-        let header = sign_blossom_get_auth_header(&keys, "http://localhost:3000", 600).unwrap();
-        let b64 = header.strip_prefix("Nostr ").expect("Nostr scheme prefix");
-        let json = URL_SAFE_NO_PAD.decode(b64).unwrap();
-        let event = nostr::Event::from_json(std::str::from_utf8(&json).unwrap()).unwrap();
-
-        assert_eq!(event.kind, Kind::from(24242));
-        event.verify().expect("valid signature");
-
-        let tag = |name: &str| -> Option<String> {
-            event.tags.iter().find_map(|t| {
-                let v = t.as_slice();
-                (v.first().map(String::as_str) == Some(name)).then(|| v[1].clone())
-            })
-        };
-        assert_eq!(tag("t").as_deref(), Some("get"));
-        assert_eq!(tag("server").as_deref(), Some("localhost:3000"));
-        // Server-scoped token: no x tag (BUD-01 allows x OR server).
-        assert!(tag("x").is_none());
-        let expiration: u64 = tag("expiration").unwrap().parse().unwrap();
-        let now = Timestamp::now().as_secs();
-        assert!(expiration > now && expiration <= now + 600);
-    }
-
-    #[test]
-    fn test_sign_blossom_get_auth_header_invalid_base_url() {
-        let keys = Keys::generate();
-        assert!(sign_blossom_get_auth_header(&keys, "not-a-url", 600).is_err());
-    }
-
-    #[test]
-    fn test_detect_and_validate_mime_jpeg() {
-        // Minimal JPEG: SOI + EOI
-        let jpeg = [0xFF, 0xD8, 0xFF, 0xE0];
-        assert_eq!(detect_and_validate_mime(&jpeg).unwrap(), "image/jpeg");
-    }
-
-    #[test]
-    fn test_detect_and_validate_mime_accepts_text_as_octet_stream() {
-        // Plain text has no magic bytes — infer returns None, so it's accepted
-        // as opaque binary (served as a download). This is the common Slack case.
-        let text = b"hello world";
-        assert_eq!(
-            detect_and_validate_mime(text).unwrap(),
-            "application/octet-stream"
-        );
-    }
-
-    #[test]
-    fn test_detect_and_validate_mime_rejects_html() {
-        let html = b"<!DOCTYPE html><html><body><script>alert(1)</script></body></html>";
-        assert!(detect_and_validate_mime(html).is_err());
-    }
-
-    #[test]
-    fn test_image_sanitizer_bakes_exif_orientation() {
-        let source = image::RgbImage::from_fn(2, 3, |x, y| {
-            image::Rgb([(x * 80) as u8, (y * 60) as u8, 32])
-        });
-        let mut encoded = Vec::new();
-        image::codecs::jpeg::JpegEncoder::new_with_quality(&mut encoded, 95)
-            .encode_image(&source)
-            .unwrap();
-
-        // Minimal little-endian Exif IFD with Orientation=6 (rotate 90°).
-        let mut exif = b"Exif\0\0II\x2a\0\x08\0\0\0\x01\0".to_vec();
-        exif.extend_from_slice(&[
-            0x12, 0x01, // Orientation tag
-            0x03, 0x00, // SHORT
-            0x01, 0x00, 0x00, 0x00, // count=1
-            0x06, 0x00, 0x00, 0x00, // value=6
-            0x00, 0x00, 0x00, 0x00, // next IFD
-        ]);
-        let segment_len = (exif.len() + 2) as u16;
-        let mut oriented = encoded[..2].to_vec();
-        oriented.extend_from_slice(&[0xff, 0xe1]);
-        oriented.extend_from_slice(&segment_len.to_be_bytes());
-        oriented.extend_from_slice(&exif);
-        oriented.extend_from_slice(&encoded[2..]);
-
-        let sanitized = sanitize_image_for_upload(oriented, "image/jpeg").unwrap();
-        let decoded =
-            image::load_from_memory_with_format(&sanitized, image::ImageFormat::Jpeg).unwrap();
-        assert_eq!((decoded.width(), decoded.height()), (3, 2));
-        assert!(!sanitized.windows(6).any(|bytes| bytes == b"Exif\0\0"));
-    }
-
-    #[test]
-    fn test_animated_png_and_webp_are_not_flattened() {
-        let mut apng = b"\x89PNG\r\n\x1a\n".to_vec();
-        apng.extend_from_slice(&8u32.to_be_bytes());
-        apng.extend_from_slice(b"acTL");
-        apng.extend_from_slice(&[0; 8]);
-        apng.extend_from_slice(&[0; 4]);
-        assert!(is_animated_image(&apng, "image/png"));
-        assert_eq!(
-            sanitize_image_for_upload(apng.clone(), "image/png").unwrap(),
-            apng
-        );
-
-        let mut webp = b"RIFF\x0c\0\0\0WEBPANIM".to_vec();
-        webp.extend_from_slice(&0u32.to_le_bytes());
-        assert!(is_animated_image(&webp, "image/webp"));
-        assert_eq!(
-            sanitize_image_for_upload(webp.clone(), "image/webp").unwrap(),
-            webp
-        );
-    }
-
-    #[test]
-    fn test_legacy_upload_retry_statuses_are_narrow() {
-        assert!(should_retry_legacy_upload(reqwest::StatusCode::NOT_FOUND));
-        assert!(should_retry_legacy_upload(
-            reqwest::StatusCode::METHOD_NOT_ALLOWED
-        ));
-        assert!(!should_retry_legacy_upload(
-            reqwest::StatusCode::UNPROCESSABLE_ENTITY
-        ));
-        assert!(!should_retry_legacy_upload(
-            reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE
-        ));
-    }
-
-    #[test]
-    fn test_sanitize_filename() {
-        assert_eq!(sanitize_filename("report.pdf"), "report.pdf");
-        // Strips directory components and traversal.
-        assert_eq!(sanitize_filename("../../etc/passwd"), "passwd");
-        assert_eq!(sanitize_filename("/abs/path/notes.txt"), "notes.txt");
-        assert_eq!(sanitize_filename(r"C:\Users\me\doc.docx"), "doc.docx");
-        // Empty / separator-only falls back.
-        assert_eq!(sanitize_filename(""), "file");
-        assert_eq!(sanitize_filename("/"), "file");
-        // Control chars removed.
-        assert_eq!(sanitize_filename("a\nb\tc.txt"), "abc.txt");
-    }
-}
+#[path = "media_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/commands/media.rs
+++ b/desktop/src-tauri/src/commands/media.rs
@@ -12,7 +12,7 @@ use crate::relay::{
 
 use super::media_transcode::{
     has_heic_extension, is_heic_file, is_video_file, transcode_and_extract_poster,
-    transcode_and_extract_poster_path, transcode_heic_path_to_jpeg_bytes,
+    transcode_and_extract_poster_path, transcode_heic_path_to_jpeg_bytes, TranscodeProgress,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -383,7 +383,7 @@ async fn send_upload_attempt(
             sent += chunk.len() as u64;
             let _ = app.emit(
                 "media-upload-progress",
-                serde_json::json!({ "id": progress_id, "sent": sent, "total": total }),
+                serde_json::json!({ "id": progress_id, "phase": "uploading", "sent": sent, "total": total }),
             );
             Ok::<bytes::Bytes, std::io::Error>(chunk)
         }));
@@ -429,7 +429,7 @@ async fn send_upload_file_attempt(
             let sent = sent.fetch_add(bytes.len() as u64, Ordering::Relaxed) + bytes.len() as u64;
             let _ = app.emit(
                 "media-upload-progress",
-                serde_json::json!({ "id": progress_id, "sent": sent, "total": total }),
+                serde_json::json!({ "id": progress_id, "phase": "uploading", "sent": sent, "total": total }),
             );
         }
         chunk
@@ -632,6 +632,7 @@ pub(super) async fn process_picked_path(
     state: &State<'_, AppState>,
     images_only: bool,
     progress: Option<(tauri::AppHandle, String)>,
+    cancel: Option<tokio_util::sync::CancellationToken>,
 ) -> Result<BlobDescriptor, String> {
     // Pin the inode by opening the fd BEFORE spawn_blocking. This prevents a
     // local attacker from swapping the file between dialog return and read.
@@ -642,6 +643,12 @@ pub(super) async fn process_picked_path(
     // extension still tells us the webview can't render them. Computed before
     // the closure since `path` isn't moved in.
     let heic_by_ext = has_heic_extension(&path);
+
+    let transcode_progress = progress.as_ref().map(|(app, id)| TranscodeProgress {
+        app: app.clone(),
+        id: id.clone(),
+        cancel,
+    });
 
     // All sync I/O (sniff, transcode, read) runs off the async runtime to
     // avoid blocking Tokio worker threads during long ffmpeg transcodes.
@@ -657,7 +664,8 @@ pub(super) async fn process_picked_path(
                     return Err("Please choose an image file.".to_string());
                 }
                 let fd_path = fd_real_path(&file)?;
-                let (path, poster) = transcode_and_extract_poster_path(&fd_path)?;
+                let (path, poster) =
+                    transcode_and_extract_poster_path(&fd_path, transcode_progress)?;
                 drop(file);
                 Ok((
                     PreparedUpload::File {
@@ -761,7 +769,7 @@ pub async fn pick_and_upload_media(
     let mut descriptors = Vec::with_capacity(file_paths.len());
     for file_path in file_paths {
         let path = file_path.as_path().ok_or("invalid path")?.to_path_buf();
-        let descriptor = process_picked_path(path, &state, false, None).await?;
+        let descriptor = process_picked_path(path, &state, false, None, None).await?;
         descriptors.push(descriptor);
     }
 
@@ -802,7 +810,7 @@ pub async fn pick_and_upload_image(
     };
 
     let path = file_path.as_path().ok_or("invalid path")?.to_path_buf();
-    let descriptor = process_picked_path(path, &state, true, None).await?;
+    let descriptor = process_picked_path(path, &state, true, None, None).await?;
     Ok(Some(descriptor))
 }
 

--- a/desktop/src-tauri/src/commands/media_staged.rs
+++ b/desktop/src-tauri/src/commands/media_staged.rs
@@ -1,0 +1,67 @@
+use tauri::State;
+use tokio::io::AsyncWriteExt;
+
+use crate::app_state::AppState;
+
+use super::media::{process_picked_path, sanitize_filename, BlobDescriptor};
+
+#[tauri::command]
+pub async fn begin_staged_media_upload() -> Result<String, String> {
+    let upload_id = uuid::Uuid::new_v4().to_string();
+    let path = staged_upload_path(&upload_id)?;
+    tokio::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .await
+        .map_err(|e| format!("failed to create staged upload: {e}"))?;
+    Ok(upload_id)
+}
+
+fn staged_upload_path(upload_id: &str) -> Result<std::path::PathBuf, String> {
+    let parsed = uuid::Uuid::parse_str(upload_id).map_err(|_| "invalid upload id".to_string())?;
+    Ok(std::env::temp_dir().join(format!("buzz-staged-upload-{parsed}")))
+}
+
+#[tauri::command]
+pub async fn append_staged_media_chunk(upload_id: String, data: Vec<u8>) -> Result<(), String> {
+    if data.is_empty() || data.len() > 1024 * 1024 {
+        return Err("upload chunk must contain 1 byte to 1 MiB".to_string());
+    }
+    let path = staged_upload_path(&upload_id)?;
+    let mut file = tokio::fs::OpenOptions::new()
+        .append(true)
+        .open(path)
+        .await
+        .map_err(|e| format!("failed to open staged upload: {e}"))?;
+    file.write_all(&data)
+        .await
+        .map_err(|e| format!("failed to write staged upload: {e}"))
+}
+
+#[tauri::command]
+pub async fn cancel_staged_media_upload(upload_id: String) -> Result<(), String> {
+    let path = staged_upload_path(&upload_id)?;
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("failed to remove staged upload: {error}")),
+    }
+}
+
+#[tauri::command]
+pub async fn finish_staged_media_upload(
+    upload_id: String,
+    filename: Option<String>,
+    progress_id: Option<String>,
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<BlobDescriptor, String> {
+    let path = staged_upload_path(&upload_id)?;
+    let progress = progress_id.map(|id| (app, id));
+    let result = process_picked_path(path.clone(), &state, false, progress).await;
+    let _ = tokio::fs::remove_file(path).await;
+    let mut descriptor = result?;
+    descriptor.filename = filename.as_deref().map(sanitize_filename);
+    Ok(descriptor)
+}

--- a/desktop/src-tauri/src/commands/media_staged.rs
+++ b/desktop/src-tauri/src/commands/media_staged.rs
@@ -1,9 +1,18 @@
+use std::sync::{Mutex, OnceLock};
+
 use tauri::State;
 use tokio::io::AsyncWriteExt;
+use tokio_util::sync::CancellationToken;
 
 use crate::app_state::AppState;
 
 use super::media::{process_picked_path, sanitize_filename, BlobDescriptor};
+
+fn active_uploads() -> &'static Mutex<std::collections::HashMap<String, CancellationToken>> {
+    static ACTIVE: OnceLock<Mutex<std::collections::HashMap<String, CancellationToken>>> =
+        OnceLock::new();
+    ACTIVE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
 
 #[tauri::command]
 pub async fn begin_staged_media_upload() -> Result<String, String> {
@@ -23,18 +32,38 @@ fn staged_upload_path(upload_id: &str) -> Result<std::path::PathBuf, String> {
     Ok(std::env::temp_dir().join(format!("buzz-staged-upload-{parsed}")))
 }
 
+/// Append one chunk to a staged upload.
+///
+/// The chunk rides Tauri's **raw binary IPC** (the request body is an
+/// `ArrayBuffer`, not a JSON `number[]`). The old JSON path turned every
+/// megabyte into a ~1M-element JS array + `JSON.stringify`/parse on the
+/// webview's render thread, which visibly janked typing during an upload.
+/// The `upload_id` travels as a request header so the body stays pure bytes.
 #[tauri::command]
-pub async fn append_staged_media_chunk(upload_id: String, data: Vec<u8>) -> Result<(), String> {
+pub async fn append_staged_media_chunk(request: tauri::ipc::Request<'_>) -> Result<(), String> {
+    let upload_id = request
+        .headers()
+        .get("upload-id")
+        .and_then(|value| value.to_str().ok())
+        .ok_or("missing upload-id header")?;
+
+    let data = match request.body() {
+        tauri::ipc::InvokeBody::Raw(bytes) => bytes.as_slice(),
+        tauri::ipc::InvokeBody::Json(_) => {
+            return Err("staged chunk must be sent as raw bytes".to_string())
+        }
+    };
     if data.is_empty() || data.len() > 1024 * 1024 {
         return Err("upload chunk must contain 1 byte to 1 MiB".to_string());
     }
-    let path = staged_upload_path(&upload_id)?;
+
+    let path = staged_upload_path(upload_id)?;
     let mut file = tokio::fs::OpenOptions::new()
         .append(true)
         .open(path)
         .await
         .map_err(|e| format!("failed to open staged upload: {e}"))?;
-    file.write_all(&data)
+    file.write_all(data)
         .await
         .map_err(|e| format!("failed to write staged upload: {e}"))
 }
@@ -42,6 +71,13 @@ pub async fn append_staged_media_chunk(upload_id: String, data: Vec<u8>) -> Resu
 #[tauri::command]
 pub async fn cancel_staged_media_upload(upload_id: String) -> Result<(), String> {
     let path = staged_upload_path(&upload_id)?;
+    if let Some(cancel) = active_uploads()
+        .lock()
+        .map_err(|error| error.to_string())?
+        .get(&upload_id)
+    {
+        cancel.cancel();
+    }
     match tokio::fs::remove_file(path).await {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -59,7 +95,16 @@ pub async fn finish_staged_media_upload(
 ) -> Result<BlobDescriptor, String> {
     let path = staged_upload_path(&upload_id)?;
     let progress = progress_id.map(|id| (app, id));
-    let result = process_picked_path(path.clone(), &state, false, progress).await;
+    let cancel = CancellationToken::new();
+    active_uploads()
+        .lock()
+        .map_err(|error| error.to_string())?
+        .insert(upload_id.clone(), cancel.clone());
+    let result = process_picked_path(path.clone(), &state, false, progress, Some(cancel)).await;
+    active_uploads()
+        .lock()
+        .map_err(|error| error.to_string())?
+        .remove(&upload_id);
     let _ = tokio::fs::remove_file(path).await;
     let mut descriptor = result?;
     descriptor.filename = filename.as_deref().map(sanitize_filename);

--- a/desktop/src-tauri/src/commands/media_tests.rs
+++ b/desktop/src-tauri/src/commands/media_tests.rs
@@ -1,0 +1,182 @@
+use super::*;
+
+#[test]
+fn test_extract_server_authority_default_ports() {
+    assert_eq!(
+        extract_server_authority("https://relay.example.com"),
+        Some("relay.example.com".to_string())
+    );
+    assert_eq!(
+        extract_server_authority("https://relay.example.com:443"),
+        Some("relay.example.com".to_string())
+    );
+    assert_eq!(
+        extract_server_authority("http://relay.example.com:80"),
+        Some("relay.example.com".to_string())
+    );
+}
+
+#[test]
+fn test_extract_server_authority_non_default_ports() {
+    assert_eq!(
+        extract_server_authority("http://localhost:3000"),
+        Some("localhost:3000".to_string())
+    );
+    assert_eq!(
+        extract_server_authority("https://relay.example.com:8443"),
+        Some("relay.example.com:8443".to_string())
+    );
+}
+
+#[test]
+fn test_extract_server_authority_ipv6() {
+    assert_eq!(
+        extract_server_authority("http://[::1]:3000"),
+        Some("[::1]:3000".to_string())
+    );
+}
+
+#[test]
+fn test_extract_server_authority_invalid() {
+    assert_eq!(extract_server_authority("not-a-url"), None);
+    assert_eq!(extract_server_authority(""), None);
+}
+
+#[test]
+fn test_sign_blossom_get_auth_header_shape() {
+    let keys = Keys::generate();
+    let header = sign_blossom_get_auth_header(&keys, "http://localhost:3000", 600).unwrap();
+    let b64 = header.strip_prefix("Nostr ").expect("Nostr scheme prefix");
+    let json = URL_SAFE_NO_PAD.decode(b64).unwrap();
+    let event = nostr::Event::from_json(std::str::from_utf8(&json).unwrap()).unwrap();
+
+    assert_eq!(event.kind, Kind::from(24242));
+    event.verify().expect("valid signature");
+
+    let tag = |name: &str| -> Option<String> {
+        event.tags.iter().find_map(|t| {
+            let v = t.as_slice();
+            (v.first().map(String::as_str) == Some(name)).then(|| v[1].clone())
+        })
+    };
+    assert_eq!(tag("t").as_deref(), Some("get"));
+    assert_eq!(tag("server").as_deref(), Some("localhost:3000"));
+    // Server-scoped token: no x tag (BUD-01 allows x OR server).
+    assert!(tag("x").is_none());
+    let expiration: u64 = tag("expiration").unwrap().parse().unwrap();
+    let now = Timestamp::now().as_secs();
+    assert!(expiration > now && expiration <= now + 600);
+}
+
+#[test]
+fn test_sign_blossom_get_auth_header_invalid_base_url() {
+    let keys = Keys::generate();
+    assert!(sign_blossom_get_auth_header(&keys, "not-a-url", 600).is_err());
+}
+
+#[test]
+fn test_detect_and_validate_mime_jpeg() {
+    // Minimal JPEG: SOI + EOI
+    let jpeg = [0xFF, 0xD8, 0xFF, 0xE0];
+    assert_eq!(detect_and_validate_mime(&jpeg).unwrap(), "image/jpeg");
+}
+
+#[test]
+fn test_detect_and_validate_mime_accepts_text_as_octet_stream() {
+    // Plain text has no magic bytes — infer returns None, so it's accepted
+    // as opaque binary (served as a download). This is the common Slack case.
+    let text = b"hello world";
+    assert_eq!(
+        detect_and_validate_mime(text).unwrap(),
+        "application/octet-stream"
+    );
+}
+
+#[test]
+fn test_detect_and_validate_mime_rejects_html() {
+    let html = b"<!DOCTYPE html><html><body><script>alert(1)</script></body></html>";
+    assert!(detect_and_validate_mime(html).is_err());
+}
+
+#[test]
+fn test_image_sanitizer_bakes_exif_orientation() {
+    let source = image::RgbImage::from_fn(2, 3, |x, y| {
+        image::Rgb([(x * 80) as u8, (y * 60) as u8, 32])
+    });
+    let mut encoded = Vec::new();
+    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut encoded, 95)
+        .encode_image(&source)
+        .unwrap();
+
+    // Minimal little-endian Exif IFD with Orientation=6 (rotate 90°).
+    let mut exif = b"Exif\0\0II\x2a\0\x08\0\0\0\x01\0".to_vec();
+    exif.extend_from_slice(&[
+        0x12, 0x01, // Orientation tag
+        0x03, 0x00, // SHORT
+        0x01, 0x00, 0x00, 0x00, // count=1
+        0x06, 0x00, 0x00, 0x00, // value=6
+        0x00, 0x00, 0x00, 0x00, // next IFD
+    ]);
+    let segment_len = (exif.len() + 2) as u16;
+    let mut oriented = encoded[..2].to_vec();
+    oriented.extend_from_slice(&[0xff, 0xe1]);
+    oriented.extend_from_slice(&segment_len.to_be_bytes());
+    oriented.extend_from_slice(&exif);
+    oriented.extend_from_slice(&encoded[2..]);
+
+    let sanitized = sanitize_image_for_upload(oriented, "image/jpeg").unwrap();
+    let decoded =
+        image::load_from_memory_with_format(&sanitized, image::ImageFormat::Jpeg).unwrap();
+    assert_eq!((decoded.width(), decoded.height()), (3, 2));
+    assert!(!sanitized.windows(6).any(|bytes| bytes == b"Exif\0\0"));
+}
+
+#[test]
+fn test_animated_png_and_webp_are_not_flattened() {
+    let mut apng = b"\x89PNG\r\n\x1a\n".to_vec();
+    apng.extend_from_slice(&8u32.to_be_bytes());
+    apng.extend_from_slice(b"acTL");
+    apng.extend_from_slice(&[0; 8]);
+    apng.extend_from_slice(&[0; 4]);
+    assert!(is_animated_image(&apng, "image/png"));
+    assert_eq!(
+        sanitize_image_for_upload(apng.clone(), "image/png").unwrap(),
+        apng
+    );
+
+    let mut webp = b"RIFF\x0c\0\0\0WEBPANIM".to_vec();
+    webp.extend_from_slice(&0u32.to_le_bytes());
+    assert!(is_animated_image(&webp, "image/webp"));
+    assert_eq!(
+        sanitize_image_for_upload(webp.clone(), "image/webp").unwrap(),
+        webp
+    );
+}
+
+#[test]
+fn test_legacy_upload_retry_statuses_are_narrow() {
+    assert!(should_retry_legacy_upload(reqwest::StatusCode::NOT_FOUND));
+    assert!(should_retry_legacy_upload(
+        reqwest::StatusCode::METHOD_NOT_ALLOWED
+    ));
+    assert!(!should_retry_legacy_upload(
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY
+    ));
+    assert!(!should_retry_legacy_upload(
+        reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE
+    ));
+}
+
+#[test]
+fn test_sanitize_filename() {
+    assert_eq!(sanitize_filename("report.pdf"), "report.pdf");
+    // Strips directory components and traversal.
+    assert_eq!(sanitize_filename("../../etc/passwd"), "passwd");
+    assert_eq!(sanitize_filename("/abs/path/notes.txt"), "notes.txt");
+    assert_eq!(sanitize_filename(r"C:\Users\me\doc.docx"), "doc.docx");
+    // Empty / separator-only falls back.
+    assert_eq!(sanitize_filename(""), "file");
+    assert_eq!(sanitize_filename("/"), "file");
+    // Control chars removed.
+    assert_eq!(sanitize_filename("a\nb\tc.txt"), "abc.txt");
+}

--- a/desktop/src-tauri/src/commands/media_transcode.rs
+++ b/desktop/src-tauri/src/commands/media_transcode.rs
@@ -173,85 +173,215 @@ pub(super) fn run_ffmpeg_with_timeout(
     }
 }
 
-/// Transcode any video file to H.264/AAC/MP4/fast-start via ffmpeg.
+/// Correlates ffmpeg progress with one renderer upload job.
+#[derive(Clone)]
+pub(super) struct TranscodeProgress {
+    pub app: tauri::AppHandle,
+    pub id: String,
+    pub cancel: Option<tokio_util::sync::CancellationToken>,
+}
+
+fn probe_video_duration(source: &std::path::Path) -> Option<f64> {
+    let ffprobe = resolve_command("ffprobe")?;
+    let output = ffmpeg_command(&ffprobe)
+        .args([
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+        ])
+        .arg(source)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()?
+        .trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|seconds| seconds.is_finite() && *seconds > 0.0)
+}
+
+fn emit_transcode_progress(progress: &TranscodeProgress, processed_us: u64, total_us: u64) {
+    use tauri::Emitter;
+    let _ = progress.app.emit(
+        "media-upload-progress",
+        serde_json::json!({
+            "id": progress.id,
+            "phase": "processing",
+            "sent": processed_us.min(total_us),
+            "total": total_us,
+        }),
+    );
+}
+
+/// Transcode any video file to a web-compatible, size-efficient MP4.
 ///
-/// Always re-encodes — handles HEVC, VP9, ProRes, non-faststart MP4, 10-bit,
-/// wrong pixel format, MOV containers, etc. Output is guaranteed to pass the
-/// relay's `validate_video_file()`.
+/// Video is capped at 1920×1080 without upscaling, encoded as H.264 CRF 24
+/// with AAC audio, and stripped of source metadata. H.264/AAC is deliberately
+/// preferred over smaller but less interoperable HEVC/AV1 output because the
+/// result must play in every supported Buzz webview and browser.
 ///
 /// Returns the path to a temp file. Caller must clean up.
 pub(super) fn transcode_to_mp4(
     source: &std::path::Path,
     ffmpeg: &std::path::Path,
+    progress: Option<TranscodeProgress>,
 ) -> Result<std::path::PathBuf, String> {
-    // UUID-based temp path — unique across concurrent uploads.
     let output = std::env::temp_dir().join(format!("buzz-transcode-{}.mp4", uuid::Uuid::new_v4()));
+    let duration_us = probe_video_duration(source).map(|seconds| (seconds * 1_000_000.0) as u64);
 
-    let result = run_ffmpeg_with_timeout(
-        ffmpeg_command(ffmpeg)
-            .args([
-                "-y",
-                "-nostdin",
-                "-loglevel",
-                "error",
-                "-protocol_whitelist",
-                "file,pipe",
-            ]) // suppress progress spam — prevents stderr pipe deadlock
-            .arg("-i")
-            .arg(source) // OsStr — handles non-UTF-8 paths on Unix
-            .args([
-                "-map",
-                "0:v:0",
-                "-map",
-                "0:a:0?",
-                "-map_metadata",
-                "-1",
-                "-map_chapters",
-                "-1",
-                "-sn",
-                "-dn",
-                "-fflags",
-                "+bitexact",
-                "-flags:v",
-                "+bitexact",
-                "-flags:a",
-                "+bitexact",
-                "-c:v",
-                "libx264",
-                "-preset",
-                "fast",
-                "-crf",
-                "23",
-                "-pix_fmt",
-                "yuv420p",
-                "-vf",
-                "pad=ceil(iw/2)*2:ceil(ih/2)*2",
-                "-c:a",
-                "aac",
-                "-b:a",
-                "128k",
-                "-movflags",
-                "+faststart",
-                "-metadata",
-                "encoder=",
-            ])
-            .arg(&output)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped()),
-        FFMPEG_TIMEOUT,
-    )?;
+    let mut command = ffmpeg_command(ffmpeg);
+    command
+        .args([
+            "-y",
+            "-nostdin",
+            "-loglevel",
+            "error",
+            "-nostats",
+            "-protocol_whitelist",
+            "file,pipe",
+        ])
+        .arg("-i")
+        .arg(source)
+        .args([
+            "-map",
+            "0:v:0",
+            "-map",
+            "0:a:0?",
+            "-map_metadata",
+            "-1",
+            "-map_chapters",
+            "-1",
+            "-sn",
+            "-dn",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-crf",
+            "24",
+            "-pix_fmt",
+            "yuv420p",
+            "-vf",
+            "scale=w=min(1920\\,iw):h=min(1080\\,ih):force_original_aspect_ratio=decrease:force_divisible_by=2,setsar=1",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "96k",
+            "-movflags",
+            "+faststart",
+            "-metadata",
+            "encoder=",
+            "-progress",
+            "pipe:1",
+        ])
+        .arg(&output)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
 
-    if !result.status.success() {
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to spawn ffmpeg: {e}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("failed to read ffmpeg progress")?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("failed to read ffmpeg diagnostics")?;
+    let (tx, rx) = std::sync::mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        use std::io::BufRead;
+        for line in std::io::BufReader::new(stdout)
+            .lines()
+            .map_while(Result::ok)
+        {
+            if let Some(value) = line.strip_prefix("out_time_us=") {
+                if let Ok(value) = value.parse::<u64>() {
+                    let _ = tx.send(value);
+                }
+            }
+        }
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let mut pipe = stderr;
+        let _ = std::io::Read::read_to_end(&mut pipe, &mut bytes);
+        bytes
+    });
+
+    let deadline = std::time::Instant::now() + FFMPEG_TIMEOUT;
+    let mut last_percent = u64::MAX;
+    let status = loop {
+        while let Ok(processed_us) = rx.try_recv() {
+            if let (Some(progress), Some(total_us)) = (&progress, duration_us) {
+                let percent = processed_us.saturating_mul(100) / total_us.max(1);
+                if percent != last_percent {
+                    last_percent = percent;
+                    emit_transcode_progress(progress, processed_us, total_us);
+                }
+            }
+        }
+        if progress
+            .as_ref()
+            .and_then(|progress| progress.cancel.as_ref())
+            .is_some_and(tokio_util::sync::CancellationToken::is_cancelled)
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = reader.join();
+            let _ = stderr_reader.join();
+            let _ = std::fs::remove_file(&output);
+            return Err("Video conversion canceled".to_string());
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if std::time::Instant::now() <= deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = reader.join();
+                let _ = stderr_reader.join();
+                let _ = std::fs::remove_file(&output);
+                return Err(format!(
+                    "ffmpeg timed out after {}s",
+                    FFMPEG_TIMEOUT.as_secs()
+                ));
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = reader.join();
+                let _ = stderr_reader.join();
+                let _ = std::fs::remove_file(&output);
+                return Err(format!("failed to wait on ffmpeg: {error}"));
+            }
+        }
+    };
+    let _ = reader.join();
+    let stderr = stderr_reader.join().unwrap_or_default();
+
+    if !status.success() {
         let _ = std::fs::remove_file(&output);
-        let stderr = String::from_utf8_lossy(&result.stderr);
+        let stderr = String::from_utf8_lossy(&stderr);
         let detail = stderr
             .lines()
             .rev()
-            .find(|l| !l.is_empty() && !l.starts_with("  "))
+            .find(|line| !line.is_empty() && !line.starts_with("  "))
             .unwrap_or("unknown error");
         return Err(format!("Video conversion failed: {detail}"));
     }
-
+    if let (Some(progress), Some(total_us)) = (&progress, duration_us) {
+        emit_transcode_progress(progress, total_us, total_us);
+    }
     Ok(output)
 }
 
@@ -417,9 +547,10 @@ pub(super) fn extract_poster_frame(
 /// best-effort because the video remains usable without a thumbnail.
 pub(super) fn transcode_and_extract_poster_path(
     source: &std::path::Path,
+    progress: Option<TranscodeProgress>,
 ) -> Result<(std::path::PathBuf, Option<Vec<u8>>), String> {
     let ffmpeg_path = find_ffmpeg()?;
-    let transcoded = transcode_to_mp4(source, &ffmpeg_path)?;
+    let transcoded = transcode_to_mp4(source, &ffmpeg_path, progress)?;
 
     let poster_bytes = match extract_poster_frame(&transcoded, &ffmpeg_path) {
         Ok(poster_path) => {
@@ -440,7 +571,7 @@ pub(super) fn transcode_and_extract_poster_path(
 pub(super) fn transcode_and_extract_poster(
     source: &std::path::Path,
 ) -> Result<(Vec<u8>, Option<Vec<u8>>), String> {
-    let (transcoded, poster_bytes) = transcode_and_extract_poster_path(source)?;
+    let (transcoded, poster_bytes) = transcode_and_extract_poster_path(source, None)?;
     let video_bytes =
         std::fs::read(&transcoded).map_err(|e| format!("failed to read transcoded file: {e}"));
     let _ = std::fs::remove_file(&transcoded);
@@ -577,6 +708,55 @@ mod tests {
     }
 
     #[test]
+    fn test_transcode_to_mp4_caps_at_1080p_without_upscaling() {
+        let Ok(ffmpeg) = find_ffmpeg() else {
+            eprintln!("skipping dimension round-trip: ffmpeg not found");
+            return;
+        };
+        let Some(ffprobe) = resolve_command("ffprobe") else {
+            eprintln!("skipping dimension round-trip: ffprobe not found");
+            return;
+        };
+        let source =
+            std::env::temp_dir().join(format!("buzz-dimension-test-{}.mp4", uuid::Uuid::new_v4()));
+        let generated = std::process::Command::new(&ffmpeg)
+            .args(["-y", "-loglevel", "error", "-f", "lavfi", "-i"])
+            .arg("color=c=blue:s=2560x1440:r=1:d=0.1")
+            .args(["-frames:v", "1", "-c:v", "libx264"])
+            .arg(&source)
+            .output()
+            .expect("generate oversized fixture");
+        if !generated.status.success() {
+            eprintln!("skipping dimension round-trip: ffmpeg cannot encode H.264");
+            let _ = std::fs::remove_file(&source);
+            return;
+        }
+
+        let output = transcode_to_mp4(&source, &ffmpeg, None).expect("transcode fixture");
+        let dimensions = std::process::Command::new(ffprobe)
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height",
+                "-of",
+                "csv=s=x:p=0",
+            ])
+            .arg(&output)
+            .output()
+            .expect("probe output dimensions");
+        let _ = std::fs::remove_file(&source);
+        let _ = std::fs::remove_file(&output);
+        assert!(dimensions.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&dimensions.stdout).trim(),
+            "1920x1080"
+        );
+    }
+
+    #[test]
     fn test_transcode_to_mp4_drops_source_metadata() {
         let Ok(ffmpeg) = find_ffmpeg() else {
             eprintln!("skipping metadata round-trip: ffmpeg not found");
@@ -606,7 +786,7 @@ mod tests {
             return;
         }
 
-        let output = transcode_to_mp4(&source, &ffmpeg).expect("transcode fixture");
+        let output = transcode_to_mp4(&source, &ffmpeg, None).expect("transcode fixture");
         let bytes = std::fs::read(&output).expect("read transcoded video");
         let _ = std::fs::remove_file(&source);
         let _ = std::fs::remove_file(&output);

--- a/desktop/src-tauri/src/commands/media_transcode.rs
+++ b/desktop/src-tauri/src/commands/media_transcode.rs
@@ -410,17 +410,17 @@ pub(super) fn extract_poster_frame(
     Ok(output)
 }
 
-/// Transcode video and extract poster frame. Returns (video_bytes, Option<poster_bytes>).
+/// Transcode video and extract a poster frame without loading the video into RAM.
 ///
-/// Poster extraction is best-effort — if it fails, returns `None` for the poster
-/// and the video bytes are still valid. All temp files are cleaned up.
-pub(super) fn transcode_and_extract_poster(
+/// Returns the transcoded temp-file path plus optional poster bytes. The caller
+/// owns the video path and must remove it after upload. Poster extraction is
+/// best-effort because the video remains usable without a thumbnail.
+pub(super) fn transcode_and_extract_poster_path(
     source: &std::path::Path,
-) -> Result<(Vec<u8>, Option<Vec<u8>>), String> {
+) -> Result<(std::path::PathBuf, Option<Vec<u8>>), String> {
     let ffmpeg_path = find_ffmpeg()?;
     let transcoded = transcode_to_mp4(source, &ffmpeg_path)?;
 
-    // Extract poster from the transcoded file (not the original — guarantees decodability).
     let poster_bytes = match extract_poster_frame(&transcoded, &ffmpeg_path) {
         Ok(poster_path) => {
             let bytes = std::fs::read(&poster_path).ok();
@@ -433,6 +433,14 @@ pub(super) fn transcode_and_extract_poster(
         }
     };
 
+    Ok((transcoded, poster_bytes))
+}
+
+/// Compatibility helper for byte-based upload entry points.
+pub(super) fn transcode_and_extract_poster(
+    source: &std::path::Path,
+) -> Result<(Vec<u8>, Option<Vec<u8>>), String> {
+    let (transcoded, poster_bytes) = transcode_and_extract_poster_path(source)?;
     let video_bytes =
         std::fs::read(&transcoded).map_err(|e| format!("failed to read transcoded file: {e}"));
     let _ = std::fs::remove_file(&transcoded);

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -23,6 +23,7 @@ mod legacy_storage;
 mod link_preview;
 pub(crate) mod media;
 mod media_download;
+mod media_staged;
 mod media_transcode;
 #[cfg(feature = "mesh-llm")]
 pub(crate) mod mesh_llm;
@@ -72,6 +73,7 @@ pub use legacy_storage::*;
 pub use link_preview::*;
 pub use media::*;
 pub use media_download::*;
+pub use media_staged::*;
 #[cfg(feature = "mesh-llm")]
 pub use mesh_llm::*;
 pub use messages::*;

--- a/desktop/src-tauri/src/commands/window_vibrancy.rs
+++ b/desktop/src-tauri/src/commands/window_vibrancy.rs
@@ -67,3 +67,20 @@ pub fn set_window_vibrancy(
         Ok(())
     }
 }
+
+/// Perform the native alignment haptic used by sidebar controls.
+#[tauri::command]
+pub fn perform_sidebar_default_haptic() {
+    #[cfg(target_os = "macos")]
+    {
+        use objc2_app_kit::{
+            NSHapticFeedbackManager, NSHapticFeedbackPattern, NSHapticFeedbackPerformanceTime,
+            NSHapticFeedbackPerformer,
+        };
+
+        NSHapticFeedbackManager::defaultPerformer().performFeedbackPattern_performanceTime(
+            NSHapticFeedbackPattern::Alignment,
+            NSHapticFeedbackPerformanceTime::Now,
+        );
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -64,37 +64,6 @@ use tauri_plugin_window_state::StateFlags;
 #[cfg(target_os = "macos")]
 const INITIAL_RENDER_READY_EVENT: &str = "initial-render-ready";
 #[tauri::command]
-fn perform_sidebar_default_haptic() {
-    #[cfg(target_os = "macos")]
-    {
-        use objc2_app_kit::{
-            NSHapticFeedbackManager, NSHapticFeedbackPattern, NSHapticFeedbackPerformanceTime,
-            NSHapticFeedbackPerformer,
-        };
-
-        NSHapticFeedbackManager::defaultPerformer().performFeedbackPattern_performanceTime(
-            NSHapticFeedbackPattern::Alignment,
-            NSHapticFeedbackPerformanceTime::Now,
-        );
-    }
-}
-
-/// Performs the window action matching the macOS "double-click a window's
-/// title bar to" preference (`AppleActionOnDoubleClick`).
-///
-/// macOS values are `Minimize`, `Maximize` (default when unset), `Fill`, or
-/// `None`.
-/// The desktop app uses a web-based title-bar drag region, so the frontend
-/// forwards double-clicks here and suppresses Tauri's injected drag-region
-/// handler, whose default macOS path hardcodes maximize.
-///
-/// For `Fill`, resize to the current monitor work area instead of using
-/// Tauri's maximize path, which maps to macOS zoom for titled, resizable
-/// windows.
-///
-/// On non-macOS platforms this always toggles maximize (the historical
-/// behavior).
-#[tauri::command]
 fn title_bar_double_click(window: tauri::Window) {
     #[cfg(target_os = "macos")]
     {
@@ -838,6 +807,10 @@ pub fn run() {
             upload_media,
             pick_and_upload_media,
             pick_and_upload_image,
+            begin_staged_media_upload,
+            append_staged_media_chunk,
+            finish_staged_media_upload,
+            cancel_staged_media_upload,
             upload_media_bytes,
             download_image,
             download_file,

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -29,6 +29,7 @@ import { msgContextKey } from "@/features/channels/readState/readStateFormat";
 import { useMembershipNotifications } from "@/features/channels/useMembershipNotifications";
 import { useFeedItemState } from "@/features/home/useFeedItemState";
 import { useThreadFollows } from "@/features/messages/lib/useThreadFollows";
+import { UploadIndicator } from "@/features/messages/ui/UploadIndicator";
 import {
   useHomeFeedNotifications,
   useHomeFeedNotificationState,
@@ -89,7 +90,6 @@ import { useMessageDeepLinks } from "@/shared/useMessageDeepLinks";
 import { SidebarInset, SidebarProvider } from "@/shared/ui/sidebar";
 import { RelayConnectionOverlay } from "@/app/RelayConnectionOverlay";
 import { useSidebarRelayConnectionCard } from "@/features/sidebar/ui/useSidebarRelayConnectionCard";
-
 const LazySettingsScreen = React.lazy(async () => {
   const module = await import("@/features/settings/ui/SettingsScreen");
   return { default: module.SettingsScreen };
@@ -153,7 +153,6 @@ export function AppShell() {
     () => deriveShellRoute(location.pathname),
     [location.pathname],
   );
-  // Settings lives in history so back returns to the previous app entry.
   const settingsOpen = location.pathname === "/settings";
   const locationSearchSection = (location.search as { section?: unknown })
     .section;
@@ -757,6 +756,7 @@ export function AppShell() {
                 className="buzz-huddle-shell relative h-dvh overflow-hidden overscroll-none"
                 data-huddle-open={isHuddleDrawerOpen}
               >
+                <UploadIndicator onOpenChannel={goChannel} />
                 <div
                   className={cn(
                     "buzz-huddle-app-surface z-10 flex min-h-0 flex-row overflow-hidden bg-background",

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -174,7 +174,7 @@ export const ChannelPane = React.memo(function ChannelPane({
     activeChannel,
     currentPubkey,
   );
-  const mainComposerMedia = useMediaUpload();
+  const mainComposerMedia = useMediaUpload(activeChannel?.id ?? null);
   const isNonMemberView =
     activeChannel !== null &&
     !activeChannel.isMember &&

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -7,6 +7,7 @@ import { getOverrides } from "@/shared/features";
 import { resetMediaCaches } from "@/shared/lib/mediaUrl";
 import { clearSearchHitEventCache } from "@/app/navigation/searchHitEventCache";
 import { initDraftStore } from "@/features/messages/lib/useDrafts";
+import { resetUploadJobs } from "@/features/messages/lib/uploadJobsStore";
 import { resetRenderScopedReactionHydration } from "@/features/messages/lib/renderScopedReactions";
 import {
   resetActiveAgentTurnsStore,
@@ -40,6 +41,7 @@ function resetCommunityState(): void {
   resetRenderScopedReactionHydration();
   clearSearchHitEventCache();
   clearMarkdownNodeCache();
+  resetUploadJobs();
 }
 
 type CommunityInitResult =

--- a/desktop/src/features/messages/lib/uploadJobsStore.ts
+++ b/desktop/src/features/messages/lib/uploadJobsStore.ts
@@ -1,0 +1,391 @@
+import * as React from "react";
+
+import {
+  type BlobDescriptor,
+  appendStagedMediaChunk,
+  beginStagedMediaUpload,
+  cancelStagedMediaUpload,
+  finishStagedMediaUpload,
+} from "@/shared/api/tauri";
+
+import { captureVideoPosterFrame } from "./videoPoster";
+
+/**
+ * Background upload-jobs store.
+ *
+ * Media uploads used to live in component-local state inside `useMediaUpload`,
+ * so an in-flight upload's spinner vanished the moment you navigated away from
+ * its channel, and its completion (the descriptor) was written into unmounted
+ * state and lost. This module hoists the whole upload lifecycle into a
+ * workspace-scoped singleton:
+ *
+ *   • The upload **driver** (stage → transcode/upload) runs here, independent of
+ *     any React component, so it survives navigation.
+ *   • Each job is tagged with the `channelId` it was started in. The composer
+ *     renders only its own channel's jobs, so uploads stay attached to the
+ *     entry field where they began and never follow you to another channel.
+ *   • Finished descriptors land in a per-channel completion buffer; the composer
+ *     drains it on mount (or immediately, if already mounted), so a video that
+ *     finishes while you're elsewhere is waiting in the right composer when you
+ *     return.
+ *   • A channel-independent indicator can subscribe to *all* active jobs.
+ *
+ * Reset on community switch via `resetUploadJobs()` (wired into
+ * `resetCommunityState`), matching the other workspace-scoped singletons.
+ */
+
+const MEDIA_UPLOAD_CHUNK_BYTES = 1024 * 1024;
+
+/**
+ * Store job ids live in a high numeric range so they never collide with the
+ * composer's own small, per-mount preview ids. `cancelUpload` routes by range,
+ * which lets store-driven previews and local (annotation/paperclip) previews
+ * share the numeric `UploadingAttachmentPreview.id` space without a refactor.
+ */
+export const UPLOAD_JOB_ID_BASE = 1_000_000_000;
+
+export type UploadPhase =
+  | "reading"
+  | "processing"
+  | "uploading"
+  | "done"
+  | "error";
+
+export type UploadJob = {
+  /** Numeric id ≥ UPLOAD_JOB_ID_BASE (see note above). */
+  id: number;
+  channelId: string;
+  filename: string;
+  mediaType: string;
+  posterUrl?: string;
+  /** Monotonic 0–100. */
+  pct: number;
+  phase: UploadPhase;
+  error?: string;
+};
+
+type Completion = { jobId: number; descriptor: BlobDescriptor };
+
+// ── Module state ─────────────────────────────────────────────────────────────
+let jobs = new Map<number, UploadJob>();
+let completedByChannel = new Map<string, Completion[]>();
+const canceledIds = new Set<number>();
+const uploadIdByJob = new Map<number, string>();
+let nextJobId = UPLOAD_JOB_ID_BASE;
+
+// ── Reactivity (mirrors useDrafts' version-counter pattern) ──────────────────
+const subscribers = new Set<() => void>();
+let version = 0;
+
+function bump(): void {
+  version += 1;
+  for (const sub of subscribers) sub();
+}
+
+export function subscribeUploadJobs(callback: () => void): () => void {
+  subscribers.add(callback);
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+export function getUploadJobsVersion(): number {
+  return version;
+}
+
+// ── Rust progress events → uploading phase ───────────────────────────────────
+let listenerReady = false;
+let unlisten: (() => void) | null = null;
+
+/** Correlation id the Rust `media-upload-progress` events carry for a job. */
+function progressId(jobId: number): string {
+  return `composer-upload-${jobId}`;
+}
+
+function parseJobProgressId(id: string): number | null {
+  const match = /^composer-upload-(\d+)$/.exec(id);
+  if (!match) return null;
+  const jobId = Number(match[1]);
+  return jobId >= UPLOAD_JOB_ID_BASE ? jobId : null;
+}
+
+function ensureProgressListener(): void {
+  if (listenerReady) return;
+  listenerReady = true;
+  void (async () => {
+    try {
+      const { listen } = await import("@tauri-apps/api/event");
+      const dispose = await listen<{
+        id: string;
+        phase?: "processing" | "uploading";
+        sent: number;
+        total: number;
+      }>("media-upload-progress", (event) => {
+        const { id, phase = "uploading", sent, total } = event.payload;
+        if (total <= 0) return;
+        const jobId = parseJobProgressId(id);
+        if (jobId === null) return;
+        const frac = Math.min(1, sent / total);
+        if (phase === "processing") {
+          // Staging is 0–10%; measured ffmpeg work occupies 10–80%.
+          setPhasePct(jobId, "processing", 10 + frac * 70);
+        } else {
+          // Actual HTTP body bytes occupy 80–99%.
+          setPhasePct(jobId, "uploading", 80 + frac * 19);
+        }
+      });
+      if (listenerReady) {
+        unlisten = dispose;
+      } else {
+        dispose();
+      }
+    } catch {
+      // Non-Tauri runtime (web dev, e2e mock) — no byte-level progress.
+    }
+  })();
+}
+
+// ── Percentage model ─────────────────────────────────────────────────────────
+// Phases use measurements rather than pretending elapsed wall time is progress:
+//   reading/staging → 0–10%   (source bytes handed to Rust)
+//   processing      → 10–80%  (ffmpeg out_time / probed duration)
+//   uploading       → 80–99%  (actual HTTP bytes-sent / output size)
+//   done            → 100%
+function setPhasePct(jobId: number, phase: UploadPhase, pct: number): void {
+  const job = jobs.get(jobId);
+  if (!job) return;
+  const next = Math.max(job.pct, Math.min(100, Math.round(pct)));
+  if (job.phase === phase && job.pct === next) return;
+  job.phase = phase;
+  job.pct = next;
+  bump();
+}
+
+// ── The upload driver ────────────────────────────────────────────────────────
+const CANCELED = Symbol("upload-canceled");
+
+async function runUpload(
+  jobId: number,
+  channelId: string,
+  file: File,
+): Promise<void> {
+  const total = file.size || 0;
+  let uploadId: string | undefined;
+  try {
+    uploadId = await beginStagedMediaUpload();
+    if (canceledIds.has(jobId)) throw CANCELED;
+    uploadIdByJob.set(jobId, uploadId);
+
+    const reader = file.stream().getReader();
+    let staged = 0;
+    let pending = new Uint8Array(0);
+    for (;;) {
+      if (canceledIds.has(jobId)) throw CANCELED;
+      const { done, value } = await reader.read();
+      if (done) break;
+      let bytes = value;
+      if (pending.length > 0) {
+        const combined = new Uint8Array(pending.length + value.length);
+        combined.set(pending);
+        combined.set(value, pending.length);
+        bytes = combined;
+        pending = new Uint8Array(0);
+      }
+      let offset = 0;
+      while (bytes.length - offset >= MEDIA_UPLOAD_CHUNK_BYTES) {
+        const chunk = bytes.subarray(offset, offset + MEDIA_UPLOAD_CHUNK_BYTES);
+        await appendStagedMediaChunk(uploadId, chunk);
+        staged += chunk.length;
+        offset += MEDIA_UPLOAD_CHUNK_BYTES;
+        if (total > 0) setPhasePct(jobId, "reading", (staged / total) * 10);
+      }
+      pending = bytes.slice(offset);
+    }
+    if (pending.length > 0) {
+      await appendStagedMediaChunk(uploadId, pending);
+      staged += pending.length;
+      if (total > 0) setPhasePct(jobId, "reading", (staged / total) * 10);
+    }
+
+    if (canceledIds.has(jobId)) throw CANCELED;
+    setPhasePct(jobId, "processing", 10);
+
+    const descriptor = await finishStagedMediaUpload(
+      uploadId,
+      file.name,
+      progressId(jobId),
+    );
+    if (canceledIds.has(jobId)) throw CANCELED;
+
+    const job = jobs.get(jobId);
+    if (job) {
+      job.phase = "done";
+      job.pct = 100;
+    }
+    const list = completedByChannel.get(channelId) ?? [];
+    list.push({ jobId, descriptor });
+    completedByChannel.set(channelId, list);
+    bump();
+  } catch (error) {
+    if (uploadId) await cancelStagedMediaUpload(uploadId);
+    uploadIdByJob.delete(jobId);
+    if (error === CANCELED || canceledIds.has(jobId)) {
+      jobs.delete(jobId);
+      canceledIds.delete(jobId);
+      bump();
+      return;
+    }
+    const job = jobs.get(jobId);
+    if (job) {
+      job.phase = "error";
+      job.error = String(error);
+      bump();
+    }
+  }
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/** Start a background upload for `file`, attached to `channelId`. Returns the job id. */
+export function startChannelUpload(channelId: string, file: File): number {
+  ensureProgressListener();
+  const id = ++nextJobId;
+  jobs.set(id, {
+    id,
+    channelId,
+    filename: file.name,
+    mediaType: file.type,
+    pct: 0,
+    phase: "reading",
+  });
+  bump();
+
+  if (file.type.startsWith("video/")) {
+    void captureVideoPosterFrame(file).then((poster) => {
+      const job = jobs.get(id);
+      if (poster && job) {
+        job.posterUrl = poster.posterUrl;
+        bump();
+      }
+    });
+  }
+
+  void runUpload(id, channelId, file);
+  return id;
+}
+
+/** Cancel a job — stops staging, deletes its temp file, discards any result. */
+export function cancelUploadJob(jobId: number): void {
+  canceledIds.add(jobId);
+  const uploadId = uploadIdByJob.get(jobId);
+  if (uploadId) void cancelStagedMediaUpload(uploadId);
+  const job = jobs.get(jobId);
+  // If already terminal, the driver won't observe the flag — remove directly.
+  if (job && (job.phase === "done" || job.phase === "error")) {
+    jobs.delete(jobId);
+    canceledIds.delete(jobId);
+    dropCompletion(job.channelId, jobId);
+  }
+  bump();
+}
+
+function dropCompletion(channelId: string, jobId: number): void {
+  const list = completedByChannel.get(channelId);
+  if (!list) return;
+  const next = list.filter((c) => c.jobId !== jobId);
+  if (next.length === 0) completedByChannel.delete(channelId);
+  else completedByChannel.set(channelId, next);
+}
+
+/** Jobs currently attached to `channelId` (excludes claimed/done). */
+export function getChannelUploadJobs(channelId: string): UploadJob[] {
+  const out: UploadJob[] = [];
+  for (const job of jobs.values()) {
+    if (job.channelId === channelId && job.phase !== "done") out.push(job);
+  }
+  return out;
+}
+
+/** All in-flight jobs across every channel (for the global indicator). */
+export function getActiveUploadJobs(): UploadJob[] {
+  const out: UploadJob[] = [];
+  for (const job of jobs.values()) {
+    if (
+      job.phase === "reading" ||
+      job.phase === "processing" ||
+      job.phase === "uploading"
+    ) {
+      out.push(job);
+    }
+  }
+  return out;
+}
+
+/** Drain finished descriptors for a channel. Removes the drained jobs. */
+export function takeChannelCompletions(channelId: string): BlobDescriptor[] {
+  const list = completedByChannel.get(channelId);
+  if (!list || list.length === 0) return EMPTY_DESCRIPTORS;
+  completedByChannel.delete(channelId);
+  for (const { jobId } of list) jobs.delete(jobId);
+  bump();
+  return list.map((c) => c.descriptor);
+}
+
+/** Drain errored jobs for a channel. Removes the drained jobs. */
+export function takeChannelErrors(channelId: string): string[] {
+  const errors: string[] = [];
+  const drained: number[] = [];
+  for (const job of jobs.values()) {
+    if (job.channelId === channelId && job.phase === "error") {
+      errors.push(job.error ?? "Upload failed");
+      drained.push(job.id);
+    }
+  }
+  if (drained.length === 0) return EMPTY_ERRORS;
+  for (const id of drained) jobs.delete(id);
+  bump();
+  return errors;
+}
+
+const EMPTY_DESCRIPTORS: BlobDescriptor[] = [];
+const EMPTY_ERRORS: string[] = [];
+
+/** Tear down on community switch. */
+export function resetUploadJobs(): void {
+  jobs = new Map();
+  completedByChannel = new Map();
+  canceledIds.clear();
+  uploadIdByJob.clear();
+  nextJobId = UPLOAD_JOB_ID_BASE;
+  if (unlisten) {
+    unlisten();
+    unlisten = null;
+  }
+  listenerReady = false;
+  bump();
+}
+
+// ── React hooks ──────────────────────────────────────────────────────────────
+
+/** Jobs for one channel, re-rendering as they progress. */
+export function useChannelUploadJobs(channelId: string | null): UploadJob[] {
+  const v = React.useSyncExternalStore(
+    subscribeUploadJobs,
+    getUploadJobsVersion,
+  );
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `v` (the store version) is the recompute trigger — the selector reads live module state.
+  return React.useMemo(
+    () => (channelId ? getChannelUploadJobs(channelId) : []),
+    [channelId, v],
+  );
+}
+
+/** All active jobs, for the channel-independent indicator. */
+export function useActiveUploadJobs(): UploadJob[] {
+  const v = React.useSyncExternalStore(
+    subscribeUploadJobs,
+    getUploadJobsVersion,
+  );
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `v` (the store version) is the recompute trigger — the selector reads live module state.
+  return React.useMemo(() => getActiveUploadJobs(), [v]);
+}

--- a/desktop/src/features/messages/lib/useMediaUpload.ts
+++ b/desktop/src/features/messages/lib/useMediaUpload.ts
@@ -4,8 +4,19 @@ import {
   type BlobDescriptor,
   pickAndUploadMedia,
   uploadMediaBytes,
-  uploadMediaFile,
 } from "@/shared/api/tauri";
+
+import { captureVideoPosterFrame } from "./videoPoster";
+import {
+  UPLOAD_JOB_ID_BASE,
+  cancelUploadJob,
+  getUploadJobsVersion,
+  startChannelUpload,
+  subscribeUploadJobs,
+  takeChannelCompletions,
+  takeChannelErrors,
+  useChannelUploadJobs,
+} from "./uploadJobsStore";
 
 /**
  * First 4 hex chars of the sha256 — used as a short display name.
@@ -44,97 +55,14 @@ function isFileDrag(event: React.DragEvent<HTMLElement>): boolean {
   return event.dataTransfer?.types.includes("Files") ?? false;
 }
 
-function waitForMediaEvent(
-  element: HTMLMediaElement,
-  eventName: string,
-  timeoutMs: number,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const timeoutId = window.setTimeout(() => {
-      cleanup();
-      reject(new Error(`Timed out waiting for ${eventName}`));
-    }, timeoutMs);
-
-    function cleanup() {
-      window.clearTimeout(timeoutId);
-      element.removeEventListener(eventName, onEvent);
-      element.removeEventListener("error", onError);
-    }
-
-    function onEvent() {
-      cleanup();
-      resolve();
-    }
-
-    function onError() {
-      cleanup();
-      reject(new Error(`Could not load media for ${eventName}`));
-    }
-
-    element.addEventListener(eventName, onEvent, { once: true });
-    element.addEventListener("error", onError, { once: true });
-  });
-}
-
-type CapturedVideoPoster = {
-  dim: string;
-  posterUrl: string;
-};
-
-async function captureVideoPosterFrame(
-  file: File,
-): Promise<CapturedVideoPoster | null> {
-  if (!file.type.startsWith("video/")) return null;
-
-  const objectUrl = URL.createObjectURL(file);
-  const video = document.createElement("video");
-  video.muted = true;
-  video.playsInline = true;
-  video.preload = "metadata";
-
-  try {
-    video.src = objectUrl;
-    await waitForMediaEvent(video, "loadedmetadata", 3_000);
-
-    const duration = Number.isFinite(video.duration) ? video.duration : 0;
-    const seekTime = duration > 0.2 ? 0.1 : 0;
-    if (seekTime > 0) {
-      const seeked = waitForMediaEvent(video, "seeked", 2_000);
-      video.currentTime = seekTime;
-      await seeked.catch(() => undefined);
-    } else if (video.readyState < 2) {
-      await waitForMediaEvent(video, "loadeddata", 2_000).catch(
-        () => undefined,
-      );
-    }
-
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-
-    if (video.videoWidth === 0 || video.videoHeight === 0) return null;
-
-    const maxWidth = 640;
-    const scale = Math.min(1, maxWidth / video.videoWidth);
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.max(1, Math.round(video.videoWidth * scale));
-    canvas.height = Math.max(1, Math.round(video.videoHeight * scale));
-
-    const context = canvas.getContext("2d");
-    if (!context) return null;
-    context.drawImage(video, 0, 0, canvas.width, canvas.height);
-    return {
-      dim: `${video.videoWidth}x${video.videoHeight}`,
-      posterUrl: canvas.toDataURL("image/jpeg", 0.82),
-    };
-  } catch {
-    return null;
-  } finally {
-    URL.revokeObjectURL(objectUrl);
-    video.removeAttribute("src");
-    video.load();
-  }
-}
-
-export function useMediaUpload() {
+/**
+ * @param channelId The channel this composer is attached to. Background upload
+ *   jobs are keyed by it so in-flight uploads stay with the entry field where
+ *   they began, survive navigating away and back, and never follow you to
+ *   another channel. Falls back to a shared key when absent.
+ */
+export function useMediaUpload(channelId?: string | null) {
+  const channelKey = channelId ?? "__composer__";
   const [uploadState, setUploadState] = React.useState<UploadState>({
     status: "idle",
   });
@@ -250,6 +178,40 @@ export function useMediaUpload() {
   const nextSlotRef = React.useRef(0);
   const nextUploadingPreviewIdRef = React.useRef(0);
 
+  // ── Background upload jobs (drag/drop, paste, editor paste) ──────────────
+  // These run in the workspace-scoped store, keyed by channel, so they survive
+  // navigation and feed the global indicator. This composer renders only its
+  // own channel's jobs and drains their finished descriptors into `imetaSlots`.
+  const storeJobs = useChannelUploadJobs(channelId ?? null);
+  const jobsVersion = React.useSyncExternalStore(
+    subscribeUploadJobs,
+    getUploadJobsVersion,
+  );
+  // biome-ignore lint/correctness/useExhaustiveDependencies: jobsVersion is the reactive trigger — it re-runs the drain whenever the store changes (mount, or a job finishing while this channel is open).
+  React.useEffect(() => {
+    const done = takeChannelCompletions(channelKey);
+    if (done.length > 0) {
+      nextSlotRef.current += done.length;
+      setImetaSlots((prev) => [...prev, ...done]);
+    }
+    const errors = takeChannelErrors(channelKey);
+    if (errors.length > 0) {
+      setUploadState({ status: "error", message: errors[errors.length - 1] });
+    }
+  }, [channelKey, jobsVersion]);
+
+  const storePreviews = React.useMemo<UploadingAttachmentPreview[]>(
+    () =>
+      storeJobs.map((job) => ({
+        id: job.id,
+        filename: job.filename,
+        type: job.mediaType,
+        posterUrl: job.posterUrl,
+        progress: job.pct,
+      })),
+    [storeJobs],
+  );
+
   const isUploadCanceled = React.useCallback(
     (previewId?: number) =>
       previewId !== undefined &&
@@ -301,6 +263,12 @@ export function useMediaUpload() {
 
   const cancelUpload = React.useCallback(
     (previewId: number) => {
+      // Store-driven jobs live in a high id range — hand them to the store,
+      // which aborts staging, deletes the temp file, and discards any result.
+      if (previewId >= UPLOAD_JOB_ID_BASE) {
+        cancelUploadJob(previewId);
+        return;
+      }
       canceledUploadingPreviewIdsRef.current.add(previewId);
       const slotIndex = uploadingPreviewsRef.current.find(
         (preview) => preview.id === previewId,
@@ -316,46 +284,6 @@ export function useMediaUpload() {
       finishUpload(previewId);
     },
     [finishUpload],
-  );
-
-  /** Reserve `count` null slots at the end; returns the starting index. */
-  const reserveSlots = React.useCallback((count: number): number => {
-    const startIndex = nextSlotRef.current;
-    nextSlotRef.current += count;
-    setImetaSlots((prev) => {
-      // Pad prev if needed (should already be the right length, but be safe)
-      const padded =
-        prev.length < startIndex
-          ? [...prev, ...new Array<null>(startIndex - prev.length).fill(null)]
-          : prev;
-      return [...padded, ...new Array<null>(count).fill(null)];
-    });
-    return startIndex;
-  }, []);
-
-  /** Fill a previously-reserved slot by index. */
-  const fillSlot = React.useCallback(
-    (index: number, descriptor: BlobDescriptor, previewId?: number) => {
-      if (isUploadCanceled(previewId)) return;
-      setImetaSlots((prev) => {
-        const next = [...prev];
-        next[index] = descriptor;
-        return next;
-      });
-      finishUpload(previewId);
-    },
-    [finishUpload, isUploadCanceled],
-  );
-
-  /** Append a single descriptor (no pre-reserved slot). */
-  const onUploaded = React.useCallback(
-    (descriptor: BlobDescriptor, previewId?: number) => {
-      if (isUploadCanceled(previewId)) return;
-      nextSlotRef.current += 1;
-      setImetaSlots((prev) => [...prev, descriptor]);
-      finishUpload(previewId);
-    },
-    [finishUpload, isUploadCanceled],
   );
 
   const onUploadError = React.useCallback(
@@ -389,7 +317,7 @@ export function useMediaUpload() {
   }, [finishUpload, isUploadCanceled, onUploadError, reserveUploadingPreview]);
 
   const handleDrop = React.useCallback(
-    async (event: React.DragEvent<HTMLElement>) => {
+    (event: React.DragEvent<HTMLElement>) => {
       event.preventDefault();
       dragDepthRef.current = 0;
       setIsDragOver(false);
@@ -398,30 +326,14 @@ export function useMediaUpload() {
 
       // Accept any file. The Tauri layer and the relay enforce the deny-list
       // (active-content + executables) and size caps; everything else uploads.
-      const validFiles = files;
-
-      setUploadingCount((c) => c + validFiles.length);
-      const baseIndex = reserveSlots(validFiles.length);
-
-      for (let i = 0; i < validFiles.length; i++) {
-        const file = validFiles[i];
-        const slotIndex = baseIndex + i;
-        const previewId = reserveUploadingPreview(file, slotIndex);
-        // Fire-and-forget each upload concurrently — slot preserves order
-        (async () => {
-          try {
-            const descriptor = await uploadMediaFile(
-              file,
-              uploadProgressId(previewId),
-            );
-            fillSlot(slotIndex, descriptor, previewId);
-          } catch (err) {
-            onUploadError(err, previewId);
-          }
-        })();
+      // Each upload becomes a background job attached to this channel — it runs
+      // independent of this component's lifetime and its descriptor is drained
+      // back into `imetaSlots` on completion.
+      for (const file of files) {
+        startChannelUpload(channelKey, file);
       }
     },
-    [reserveSlots, fillSlot, onUploadError, reserveUploadingPreview],
+    [channelKey],
   );
 
   const handleDragEnter = React.useCallback(
@@ -489,45 +401,19 @@ export function useMediaUpload() {
 
       event.preventDefault();
 
-      setUploadingCount((c) => c + mediaFiles.length);
-      const baseIndex = reserveSlots(mediaFiles.length);
-
-      for (let i = 0; i < mediaFiles.length; i++) {
-        const file = mediaFiles[i];
-        const slotIndex = baseIndex + i;
-        const previewId = reserveUploadingPreview(file, slotIndex);
-        (async () => {
-          try {
-            const descriptor = await uploadMediaFile(
-              file,
-              uploadProgressId(previewId),
-            );
-            fillSlot(slotIndex, descriptor, previewId);
-          } catch (err) {
-            onUploadError(err, previewId);
-          }
-        })();
+      for (const file of mediaFiles) {
+        startChannelUpload(channelKey, file);
       }
     },
-    [reserveSlots, fillSlot, onUploadError, reserveUploadingPreview],
+    [channelKey],
   );
 
   /** Upload a File directly — used by Tiptap's editorProps.handlePaste. */
   const uploadFile = React.useCallback(
-    async (file: File) => {
-      const previewId = reserveUploadingPreview(file);
-      setUploadingCount((c) => c + 1);
-      try {
-        const descriptor = await uploadMediaFile(
-          file,
-          uploadProgressId(previewId),
-        );
-        onUploaded(descriptor, previewId);
-      } catch (err) {
-        onUploadError(err, previewId);
-      }
+    (file: File) => {
+      startChannelUpload(channelKey, file);
     },
-    [onUploaded, onUploadError, reserveUploadingPreview],
+    [channelKey],
   );
 
   /**
@@ -621,7 +507,14 @@ export function useMediaUpload() {
     [],
   );
 
-  const isUploading = uploadingCount > 0;
+  // Local previews (annotation/paperclip) + background store jobs for this
+  // channel. Store jobs carry ids ≥ UPLOAD_JOB_ID_BASE so they never collide.
+  const allUploadingPreviews = React.useMemo(
+    () => [...uploadingPreviews, ...storePreviews],
+    [uploadingPreviews, storePreviews],
+  );
+  const totalUploadingCount = uploadingCount + storeJobs.length;
+  const isUploading = totalUploadingCount > 0;
 
   return React.useMemo(
     () => ({
@@ -643,8 +536,8 @@ export function useMediaUpload() {
       setUploadState,
       uploadEditedAttachment,
       uploadFile,
-      uploadingCount,
-      uploadingPreviews,
+      uploadingCount: totalUploadingCount,
+      uploadingPreviews: allUploadingPreviews,
       uploadState,
     }),
     [
@@ -664,8 +557,8 @@ export function useMediaUpload() {
       setPendingImeta,
       uploadEditedAttachment,
       uploadFile,
-      uploadingCount,
-      uploadingPreviews,
+      totalUploadingCount,
+      allUploadingPreviews,
       uploadState,
     ],
   );

--- a/desktop/src/features/messages/lib/useMediaUpload.ts
+++ b/desktop/src/features/messages/lib/useMediaUpload.ts
@@ -4,6 +4,7 @@ import {
   type BlobDescriptor,
   pickAndUploadMedia,
   uploadMediaBytes,
+  uploadMediaFile,
 } from "@/shared/api/tauri";
 
 /**
@@ -409,11 +410,8 @@ export function useMediaUpload() {
         // Fire-and-forget each upload concurrently — slot preserves order
         (async () => {
           try {
-            const buffer = await file.arrayBuffer();
-            if (isUploadCanceled(previewId)) return;
-            const descriptor = await uploadMediaBytes(
-              [...new Uint8Array(buffer)],
-              file.name,
+            const descriptor = await uploadMediaFile(
+              file,
               uploadProgressId(previewId),
             );
             fillSlot(slotIndex, descriptor, previewId);
@@ -423,13 +421,7 @@ export function useMediaUpload() {
         })();
       }
     },
-    [
-      reserveSlots,
-      fillSlot,
-      isUploadCanceled,
-      onUploadError,
-      reserveUploadingPreview,
-    ],
+    [reserveSlots, fillSlot, onUploadError, reserveUploadingPreview],
   );
 
   const handleDragEnter = React.useCallback(
@@ -506,11 +498,8 @@ export function useMediaUpload() {
         const previewId = reserveUploadingPreview(file, slotIndex);
         (async () => {
           try {
-            const buffer = await file.arrayBuffer();
-            if (isUploadCanceled(previewId)) return;
-            const descriptor = await uploadMediaBytes(
-              [...new Uint8Array(buffer)],
-              file.name,
+            const descriptor = await uploadMediaFile(
+              file,
               uploadProgressId(previewId),
             );
             fillSlot(slotIndex, descriptor, previewId);
@@ -520,13 +509,7 @@ export function useMediaUpload() {
         })();
       }
     },
-    [
-      reserveSlots,
-      fillSlot,
-      isUploadCanceled,
-      onUploadError,
-      reserveUploadingPreview,
-    ],
+    [reserveSlots, fillSlot, onUploadError, reserveUploadingPreview],
   );
 
   /** Upload a File directly — used by Tiptap's editorProps.handlePaste. */
@@ -535,11 +518,8 @@ export function useMediaUpload() {
       const previewId = reserveUploadingPreview(file);
       setUploadingCount((c) => c + 1);
       try {
-        const buffer = await file.arrayBuffer();
-        if (isUploadCanceled(previewId)) return;
-        const descriptor = await uploadMediaBytes(
-          [...new Uint8Array(buffer)],
-          file.name,
+        const descriptor = await uploadMediaFile(
+          file,
           uploadProgressId(previewId),
         );
         onUploaded(descriptor, previewId);
@@ -547,7 +527,7 @@ export function useMediaUpload() {
         onUploadError(err, previewId);
       }
     },
-    [isUploadCanceled, onUploaded, onUploadError, reserveUploadingPreview],
+    [onUploaded, onUploadError, reserveUploadingPreview],
   );
 
   /**

--- a/desktop/src/features/messages/lib/videoPoster.ts
+++ b/desktop/src/features/messages/lib/videoPoster.ts
@@ -1,0 +1,95 @@
+/**
+ * Client-side video poster capture. Shared by the composer upload hook and the
+ * background upload-jobs store so both can show a thumbnail while a video
+ * uploads. Pure DOM helpers — no React, no Tauri.
+ */
+
+function waitForMediaEvent(
+  element: HTMLMediaElement,
+  eventName: string,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for ${eventName}`));
+    }, timeoutMs);
+
+    function cleanup() {
+      window.clearTimeout(timeoutId);
+      element.removeEventListener(eventName, onEvent);
+      element.removeEventListener("error", onError);
+    }
+
+    function onEvent() {
+      cleanup();
+      resolve();
+    }
+
+    function onError() {
+      cleanup();
+      reject(new Error(`Could not load media for ${eventName}`));
+    }
+
+    element.addEventListener(eventName, onEvent, { once: true });
+    element.addEventListener("error", onError, { once: true });
+  });
+}
+
+export type CapturedVideoPoster = {
+  dim: string;
+  posterUrl: string;
+};
+
+export async function captureVideoPosterFrame(
+  file: File,
+): Promise<CapturedVideoPoster | null> {
+  if (!file.type.startsWith("video/")) return null;
+
+  const objectUrl = URL.createObjectURL(file);
+  const video = document.createElement("video");
+  video.muted = true;
+  video.playsInline = true;
+  video.preload = "metadata";
+
+  try {
+    video.src = objectUrl;
+    await waitForMediaEvent(video, "loadedmetadata", 3_000);
+
+    const duration = Number.isFinite(video.duration) ? video.duration : 0;
+    const seekTime = duration > 0.2 ? 0.1 : 0;
+    if (seekTime > 0) {
+      const seeked = waitForMediaEvent(video, "seeked", 2_000);
+      video.currentTime = seekTime;
+      await seeked.catch(() => undefined);
+    } else if (video.readyState < 2) {
+      await waitForMediaEvent(video, "loadeddata", 2_000).catch(
+        () => undefined,
+      );
+    }
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    if (video.videoWidth === 0 || video.videoHeight === 0) return null;
+
+    const maxWidth = 640;
+    const scale = Math.min(1, maxWidth / video.videoWidth);
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(video.videoWidth * scale));
+    canvas.height = Math.max(1, Math.round(video.videoHeight * scale));
+
+    const context = canvas.getContext("2d");
+    if (!context) return null;
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+    return {
+      dim: `${video.videoWidth}x${video.videoHeight}`,
+      posterUrl: canvas.toDataURL("image/jpeg", 0.82),
+    };
+  } catch {
+    return null;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+    video.removeAttribute("src");
+    video.load();
+  }
+}

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -233,9 +233,9 @@ function MessageComposerImpl({
     typingRootEventId,
   );
 
-  // We pass a custom setter that both updates React state AND inserts
-  // markdown into the Tiptap editor when media upload completes.
-  const internalMedia = useMediaUpload();
+  // When a parent supplies `mediaController`, its hook owns the channel jobs.
+  // Keep this unconditional fallback off that channel to avoid double-draining.
+  const internalMedia = useMediaUpload(mediaController ? null : channelId);
   const media = mediaController ?? internalMedia;
   const ownsDropZone = mediaController === undefined;
 

--- a/desktop/src/features/messages/ui/UploadIndicator.tsx
+++ b/desktop/src/features/messages/ui/UploadIndicator.tsx
@@ -1,0 +1,48 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/shared/lib/cn";
+import { useActiveUploadJobs } from "@/features/messages/lib/uploadJobsStore";
+
+type UploadIndicatorProps = {
+  /** Jump to the channel an upload belongs to. */
+  onOpenChannel: (channelId: string) => void;
+};
+
+/**
+ * Channel-independent, always-mounted upload indicator.
+ *
+ * Uploads run in the workspace-scoped `uploadJobsStore`, not in any composer,
+ * so this pill stays put while you navigate around. It shows aggregate
+ * progress across every in-flight upload and, on click, opens the channel of
+ * the oldest active one.
+ */
+export function UploadIndicator({ onOpenChannel }: UploadIndicatorProps) {
+  const jobs = useActiveUploadJobs();
+  if (jobs.length === 0) return null;
+
+  const pct = Math.round(
+    jobs.reduce((sum, job) => sum + job.pct, 0) / jobs.length,
+  );
+  const label =
+    jobs.length === 1
+      ? (jobs[0].filename ?? "Uploading…")
+      : `Uploading ${jobs.length} files`;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenChannel(jobs[0].channelId)}
+      data-testid="global-upload-indicator"
+      className={cn(
+        "fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full",
+        "border border-border/60 bg-background/95 px-3 py-1.5 shadow-lg backdrop-blur",
+        "text-sm text-foreground/90 transition-colors hover:bg-accent",
+      )}
+      title={`${label} — ${pct}%`}
+    >
+      <Loader2 className="size-4 animate-spin text-foreground/70" />
+      <span className="max-w-40 truncate">{label}</span>
+      <span className="tabular-nums text-foreground/60">{pct}%</span>
+    </button>
+  );
+}

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -559,17 +559,68 @@ export async function pickAndUploadMedia(): Promise<BlobDescriptor[]> {
 
 const MEDIA_UPLOAD_CHUNK_BYTES = 1024 * 1024;
 
+/** Open a staged upload slot in the OS temp dir; returns its id. */
+export async function beginStagedMediaUpload(): Promise<string> {
+  return invokeTauri<string>("begin_staged_media_upload", {});
+}
+
+/**
+ * Append one chunk of a staged upload as **raw bytes**.
+ *
+ * The chunk is sent over Tauri's binary IPC (an `ArrayBuffer` body) rather
+ * than a JSON `number[]`. Serializing a ~1M-element array per megabyte on the
+ * render thread was what janked typing during large uploads; raw bytes skip
+ * that entirely. `uploadId` travels as a header so the body stays pure bytes.
+ */
+export async function appendStagedMediaChunk(
+  uploadId: string,
+  chunk: Uint8Array,
+): Promise<void> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  // `.slice()` yields a tight copy backed by its own ArrayBuffer — a subarray
+  // view would ship the entire underlying stream buffer.
+  await invoke("append_staged_media_chunk", chunk.slice(), {
+    headers: { "upload-id": uploadId },
+  });
+}
+
+/** Transcode + upload a completed staged file; returns its descriptor. */
+export async function finishStagedMediaUpload(
+  uploadId: string,
+  filename: string,
+  progressId?: string,
+): Promise<BlobDescriptor> {
+  return invokeTauri<BlobDescriptor>("finish_staged_media_upload", {
+    uploadId,
+    filename,
+    progressId,
+  });
+}
+
+/** Delete a staged upload's temp file (cancel / cleanup). Best-effort. */
+export async function cancelStagedMediaUpload(uploadId: string): Promise<void> {
+  await invokeTauri("cancel_staged_media_upload", { uploadId }).catch(
+    () => undefined,
+  );
+}
+
 /**
  * Stage a browser File in bounded chunks, then let Rust transcode and stream it.
  * This avoids materializing the entire file as a JS number array or Rust Vec.
+ *
+ * `onStaged` reports cumulative bytes handed to Rust so callers can render a
+ * real "reading" phase before the HTTP upload (and its byte-level progress
+ * events) begins.
  */
 export async function uploadMediaFile(
   file: File,
   progressId?: string,
+  onStaged?: (stagedBytes: number) => void,
 ): Promise<BlobDescriptor> {
-  const uploadId = await invokeTauri<string>("begin_staged_media_upload", {});
+  const uploadId = await beginStagedMediaUpload();
   try {
     const reader = file.stream().getReader();
+    let staged = 0;
     let pending = new Uint8Array(0);
     for (;;) {
       const { done, value } = await reader.read();
@@ -584,31 +635,22 @@ export async function uploadMediaFile(
       }
       let offset = 0;
       while (bytes.length - offset >= MEDIA_UPLOAD_CHUNK_BYTES) {
-        await invokeTauri("append_staged_media_chunk", {
-          uploadId,
-          data: Array.from(
-            bytes.subarray(offset, offset + MEDIA_UPLOAD_CHUNK_BYTES),
-          ),
-        });
+        const chunk = bytes.subarray(offset, offset + MEDIA_UPLOAD_CHUNK_BYTES);
+        await appendStagedMediaChunk(uploadId, chunk);
+        staged += chunk.length;
+        onStaged?.(staged);
         offset += MEDIA_UPLOAD_CHUNK_BYTES;
       }
       pending = bytes.slice(offset);
     }
     if (pending.length > 0) {
-      await invokeTauri("append_staged_media_chunk", {
-        uploadId,
-        data: Array.from(pending),
-      });
+      await appendStagedMediaChunk(uploadId, pending);
+      staged += pending.length;
+      onStaged?.(staged);
     }
-    return await invokeTauri<BlobDescriptor>("finish_staged_media_upload", {
-      uploadId,
-      filename: file.name,
-      progressId,
-    });
+    return await finishStagedMediaUpload(uploadId, file.name, progressId);
   } catch (error) {
-    await invokeTauri("cancel_staged_media_upload", { uploadId }).catch(
-      () => undefined,
-    );
+    await cancelStagedMediaUpload(uploadId);
     throw error;
   }
 }

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -557,6 +557,62 @@ export async function pickAndUploadMedia(): Promise<BlobDescriptor[]> {
   return invokeTauri<BlobDescriptor[]>("pick_and_upload_media", {});
 }
 
+const MEDIA_UPLOAD_CHUNK_BYTES = 1024 * 1024;
+
+/**
+ * Stage a browser File in bounded chunks, then let Rust transcode and stream it.
+ * This avoids materializing the entire file as a JS number array or Rust Vec.
+ */
+export async function uploadMediaFile(
+  file: File,
+  progressId?: string,
+): Promise<BlobDescriptor> {
+  const uploadId = await invokeTauri<string>("begin_staged_media_upload", {});
+  try {
+    const reader = file.stream().getReader();
+    let pending = new Uint8Array(0);
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      let bytes = value;
+      if (pending.length > 0) {
+        const combined = new Uint8Array(pending.length + value.length);
+        combined.set(pending);
+        combined.set(value, pending.length);
+        bytes = combined;
+        pending = new Uint8Array(0);
+      }
+      let offset = 0;
+      while (bytes.length - offset >= MEDIA_UPLOAD_CHUNK_BYTES) {
+        await invokeTauri("append_staged_media_chunk", {
+          uploadId,
+          data: Array.from(
+            bytes.subarray(offset, offset + MEDIA_UPLOAD_CHUNK_BYTES),
+          ),
+        });
+        offset += MEDIA_UPLOAD_CHUNK_BYTES;
+      }
+      pending = bytes.slice(offset);
+    }
+    if (pending.length > 0) {
+      await invokeTauri("append_staged_media_chunk", {
+        uploadId,
+        data: Array.from(pending),
+      });
+    }
+    return await invokeTauri<BlobDescriptor>("finish_staged_media_upload", {
+      uploadId,
+      filename: file.name,
+      progressId,
+    });
+  } catch (error) {
+    await invokeTauri("cancel_staged_media_upload", { uploadId }).catch(
+      () => undefined,
+    );
+    throw error;
+  }
+}
+
 export async function uploadMediaBytes(
   data: number[],
   filename?: string,

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -9753,6 +9753,12 @@ export function maybeInstallE2eTauriMocks() {
         return await resolveMockUploadDescriptors(activeConfig);
       case "pick_and_upload_image":
         return (await resolveMockUploadDescriptors(activeConfig))[0] ?? null;
+      case "begin_staged_media_upload":
+        return crypto.randomUUID();
+      case "append_staged_media_chunk":
+      case "cancel_staged_media_upload":
+        return null;
+      case "finish_staged_media_upload":
       case "upload_media_bytes":
         return (await resolveMockUploadDescriptors(activeConfig))[0];
       case "fetch_media_bytes": {

--- a/desktop/tests/e2e/file-attachment.spec.ts
+++ b/desktop/tests/e2e/file-attachment.spec.ts
@@ -88,6 +88,19 @@ test("dropping a file on the channel column attaches it to the composer", async 
   await expect(page.getByTestId("message-composer")).toContainText(
     "quarterly-report.pdf",
   );
+  const uploadCommands = await page.evaluate(
+    () =>
+      (window as Window & { __BUZZ_E2E_COMMANDS__?: string[] })
+        .__BUZZ_E2E_COMMANDS__ ?? [],
+  );
+  expect(uploadCommands).toEqual(
+    expect.arrayContaining([
+      "begin_staged_media_upload",
+      "append_staged_media_chunk",
+      "finish_staged_media_upload",
+    ]),
+  );
+  expect(uploadCommands).not.toContain("upload_media_bytes");
 });
 
 test("forum posts emit a FileCard for generic attachments, not a broken image", async ({


### PR DESCRIPTION
## Why
Large drag/drop and pasted video uploads expanded the entire file into a JavaScript number array, which could exhaust or stall the Desktop webview. The native path also buffered transcoded video before sending it, and upload progress did not represent the lengthy transcode phase.

## What
- Stage browser `File` uploads through Tauri raw binary IPC in bounded 1 MiB chunks
- Stream transcoded videos from disk through reqwest instead of loading them into RAM
- Normalize video before upload to H.264/AAC MP4, cap it at 1920×1080 without upscaling, use CRF 24 / medium / 96k audio, strip metadata, and enable fast-start
- Report measured staging, ffmpeg processing, and HTTP byte progress instead of simulated progress
- Keep upload jobs attached to their originating channel across navigation, with a global indicator and cancellation cleanup
- Keep existing byte-based paths for smaller generated media and verify drag/drop uses the staged path

## Risk Assessment
Medium — this changes drag/drop and paste file uploads in Desktop plus video encoding defaults. Temp files are UUID-scoped and cleaned up on success, failure, or cancellation; cancellation now terminates an active ffmpeg transcode.

## References
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml` (1478 passed, 13 ignored; plus 3 diagnostic tests)
- `pnpm typecheck`
- `pnpm check`
- `pnpm test` (3180 passed)
- `pnpm exec playwright test tests/e2e/file-attachment.spec.ts --project=smoke` (3 passed)
- The pre-push aggregate reran Rust tests after `origin/main` moved and exposed 5 unrelated Codex adapter discovery failures; the same full Rust suite passed immediately before fetch at this commit.

Generated with Fizz
