### PR TITLE
fix(ui): relabel agent owner attribution from "owned by" to "managed by"

### DIFF
--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -895,7 +895,7 @@ function AddMemberSearchResultRow({
             </div>
             {ownerLabel ? (
               <span className="block truncate text-xs text-muted-foreground">
-                owned by {ownerLabel}
+                managed by {ownerLabel}
               </span>
             ) : null}
           </div>

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -184,16 +184,16 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
                         className="min-w-0 truncate"
                         title={
                           suggestion.ownerLabel && suggestion.notInChannel
-                            ? `owned by ${suggestion.ownerLabel} · not in channel`
+                            ? `managed by ${suggestion.ownerLabel} · not in channel`
                             : suggestion.ownerLabel
-                              ? `owned by ${suggestion.ownerLabel}`
+                              ? `managed by ${suggestion.ownerLabel}`
                               : "not in channel"
                         }
                       >
                         {suggestion.ownerLabel && suggestion.notInChannel
-                          ? `owned by ${suggestion.ownerLabel} · not in channel`
+                          ? `managed by ${suggestion.ownerLabel} · not in channel`
                           : suggestion.ownerLabel
-                            ? `owned by ${suggestion.ownerLabel}`
+                            ? `managed by ${suggestion.ownerLabel}`
                             : "not in channel"}
                       </span>
                     ) : null}

--- a/desktop/src/features/messages/ui/MessageAgentOwner.tsx
+++ b/desktop/src/features/messages/ui/MessageAgentOwner.tsx
@@ -15,7 +15,7 @@ export function MessageAgentOwner({
       data-testid="message-agent-owner"
     >
       <span className="sr-only">
-        {ownerLabel ? "Agent owned by" : "Agent; owner unavailable"}
+        {ownerLabel ? "Agent managed by" : "Agent; owner unavailable"}
       </span>
       {ownerPubkey && ownerLabel ? (
         <>
@@ -24,7 +24,7 @@ export function MessageAgentOwner({
             className="inline-flex shrink-0 items-baseline gap-1 leading-4"
           >
             <Bot className="relative -top-px h-3.5 w-3.5 self-center" />
-            <span>owned by</span>
+            <span>managed by</span>
           </span>
           <UserProfilePopover
             pubkey={ownerPubkey}

--- a/desktop/src/features/messages/ui/NewMessageResultRow.tsx
+++ b/desktop/src/features/messages/ui/NewMessageResultRow.tsx
@@ -135,7 +135,7 @@ export function NewMessageResultRow({
               </div>
               {ownerLabel ? (
                 <span className="block truncate text-xs text-muted-foreground">
-                  owned by {ownerLabel}
+                  managed by {ownerLabel}
                 </span>
               ) : null}
             </div>

--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -47,7 +47,7 @@ export type ProfileField = {
 
 const AGENT_INFO_LABELS = new Set([
   "Public key",
-  "Owned by",
+  "Managed by",
   "NIP-05",
   "Agent type",
   "Capabilities",
@@ -277,12 +277,12 @@ export function buildOwnerFields({
         </span>
       ),
       icon: UserRound,
-      label: "Owned by",
+      label: "Managed by",
       onClick:
         ownerClickable && ownerProfilePubkey
           ? () => onOpenProfile?.(ownerProfilePubkey)
           : undefined,
-      testId: "user-profile-owned-by",
+      testId: "user-profile-managed-by",
     });
   }
 
@@ -407,17 +407,17 @@ export function buildOwnerFields({
 function orderProfileFields(fields: ProfileField[]) {
   const visibilityLabel = "Visibility";
   const publicKeyLabel = "Public key";
-  const ownedByLabel = "Owned by";
+  const managedByLabel = "Managed by";
   const statusLabel = "Status";
   return [
     ...fields.filter((field) => field.label === visibilityLabel),
     ...fields.filter((field) => field.label === publicKeyLabel),
-    ...fields.filter((field) => field.label === ownedByLabel),
+    ...fields.filter((field) => field.label === managedByLabel),
     ...fields.filter(
       (field) =>
         field.label !== visibilityLabel &&
         field.label !== publicKeyLabel &&
-        field.label !== ownedByLabel &&
+        field.label !== managedByLabel &&
         field.copyValue,
     ),
     ...fields.filter((field) => field.label === statusLabel),
@@ -425,7 +425,7 @@ function orderProfileFields(fields: ProfileField[]) {
       if (
         field.label === visibilityLabel ||
         field.label === publicKeyLabel ||
-        field.label === ownedByLabel ||
+        field.label === managedByLabel ||
         field.label === statusLabel
       ) {
         return false;

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -534,7 +534,7 @@ export function UserProfilePopover({
             className="mt-0.5 truncate text-xs leading-4 text-muted-foreground"
             data-testid={`user-profile-popover-owner-${pubkey}`}
           >
-            owned by {ownerLabel}
+            managed by {ownerLabel}
           </p>
         ) : null}
         {profileSubheader ? (

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -300,7 +300,7 @@ test("thread autocomplete keeps multiple long names readable in a narrow panel",
       row.getByTestId("mention-suggestion-avatar-fallback"),
     ).toBeVisible();
     await expect(row.getByText("agent")).toBeVisible();
-    await expect(row.getByText("owned by you")).toBeVisible();
+    await expect(row.getByText("managed by you")).toBeVisible();
 
     await expect(row.getByText(name)).not.toHaveCSS(
       "text-overflow",
@@ -1738,7 +1738,7 @@ test("agent profile popover shows its owner", async ({ page }) => {
     profilePopover.getByTestId(
       `user-profile-popover-owner-${OWNED_AGENT_PROFILE_PUBKEY}`,
     ),
-  ).toHaveText("owned by bob");
+  ).toHaveText("managed by bob");
 });
 
 test("agent profile popover labels an agent owned by the viewer as you", async ({
@@ -1778,7 +1778,7 @@ test("agent profile popover labels an agent owned by the viewer as you", async (
     profilePopover.getByTestId(
       `user-profile-popover-owner-${OWNED_AGENT_PROFILE_PUBKEY}`,
     ),
-  ).toHaveText("owned by you");
+  ).toHaveText("managed by you");
 });
 
 test("agent profile popover falls back to the owner's pubkey", async ({
@@ -1818,7 +1818,7 @@ test("agent profile popover falls back to the owner's pubkey", async ({
     profilePopover.getByTestId(
       `user-profile-popover-owner-${OWNED_AGENT_PROFILE_PUBKEY}`,
     ),
-  ).toHaveText("owned by 11111111…1111");
+  ).toHaveText("managed by 11111111…1111");
 });
 
 test("human profile popover does not show an owner", async ({ page }) => {

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -123,18 +123,20 @@ test("agent owner label identifies the agent and owner", async ({ page }) => {
 
   await expect(ownerTreatment.locator("svg")).toBeVisible();
   await expect(
-    ownerTreatment.getByText("owned by", { exact: true }),
+    ownerTreatment.getByText("managed by", { exact: true }),
   ).toBeVisible();
   await expect(ownerTreatment.locator(".font-semibold")).toHaveText("bob");
   await expect(ownerTreatment.getByRole("button")).toHaveAccessibleName("bob");
-  await expect(ownerTreatment.locator(".sr-only")).toHaveText("Agent owned by");
+  await expect(ownerTreatment.locator(".sr-only")).toHaveText(
+    "Agent managed by",
+  );
 
   const joinedRow = page
     .getByTestId("system-message-row")
     .filter({ hasText: "alice" })
     .filter({ hasText: "joined the channel" });
   await expect(joinedRow.getByTestId("message-agent-owner")).toContainText(
-    "owned bybob",
+    "managed bybob",
   );
 });
 

--- a/desktop/tests/e2e/pubkey-display-screenshots.spec.ts
+++ b/desktop/tests/e2e/pubkey-display-screenshots.spec.ts
@@ -91,7 +91,7 @@ test("new-DM agent name swaps to its public key on name hover", async ({
 
   const agentName = agentResult.getByTestId(`new-dm-name-${AGENT_PUBKEY}`);
   const agentNpub = agentResult.getByTestId(`new-dm-npub-${AGENT_PUBKEY}`);
-  await expect(agentResult).toContainText("owned by you");
+  await expect(agentResult).toContainText("managed by you");
   await expect(agentName).toContainText("Pinky");
   await expect(agentNpub).toHaveCSS("opacity", "0");
 
@@ -127,7 +127,7 @@ test("new-DM agent name swaps to its public key on name hover", async ({
   await expect(
     settledAgentName.getByText("Pinky", { exact: true }),
   ).not.toHaveCSS("opacity", "1");
-  await expect(settledAgentResult).toContainText("owned by you");
+  await expect(settledAgentResult).toContainText("managed by you");
   await waitForAnimations(page);
   await page.getByTestId("new-message-page").screenshot({
     path: `${SHOTS}/new-dm-agent-name-hover.png`,

--- a/mobile/lib/features/channels/compose_bar.dart
+++ b/mobile/lib/features/channels/compose_bar.dart
@@ -135,7 +135,7 @@ class ComposeBar extends HookConsumerWidget {
         false;
 
     // Preload profiles for channel members, mentionable agents, and their
-    // owners so @mention suggestions show names ("owned by …" included).
+    // owners so @mention suggestions show names ("managed by …" included).
     final relayAgents = ref.watch(agentDirectoryProvider).asData?.value;
     final agentOwners = ref.watch(agentOwnersProvider).asData?.value;
     useEffect(
@@ -240,7 +240,7 @@ class ComposeBar extends HookConsumerWidget {
               .take(_mentionSuggestionLimit)
               .toList();
 
-    // Resolve owner names for the visible "owned by …" subtitles.
+    // Resolve owner names for the visible "managed by …" subtitles.
     useEffect(() {
       final ownerPubkeys = [for (final s in suggestions) ?s.ownerPubkey];
       if (ownerPubkeys.isNotEmpty) {

--- a/mobile/lib/features/channels/compose_bar/suggestions.dart
+++ b/mobile/lib/features/channels/compose_bar/suggestions.dart
@@ -76,7 +76,7 @@ class _MentionSuggestions extends StatelessWidget {
 
 /// The secondary info line under a mention suggestion — mirrors desktop's
 /// `MentionAutocomplete` subtitle: bot icon + "agent" (or an "admin" badge
-/// for human admins), then "owned by …" / "not in channel".
+/// for human admins), then "managed by …" / "not in channel".
 abstract final class _MentionSuggestionInfo {
   static Widget? build(
     BuildContext context, {
@@ -93,9 +93,9 @@ abstract final class _MentionSuggestionInfo {
 
     final String? detail;
     if (ownerLabel != null && notInChannel) {
-      detail = 'owned by $ownerLabel \u00b7 not in channel';
+      detail = 'managed by $ownerLabel \u00b7 not in channel';
     } else if (ownerLabel != null) {
-      detail = 'owned by $ownerLabel';
+      detail = 'managed by $ownerLabel';
     } else if (notInChannel) {
       detail = 'not in channel';
     } else {

--- a/mobile/lib/features/channels/mentions/mention_candidates.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates.dart
@@ -70,7 +70,7 @@ bool agentIsSharedWithUser(
       agent.channelIds.any(sharedChannelIds.contains);
 }
 
-/// Format the "owned by …" label. Mirrors desktop's `formatOwnerLabel`.
+/// Format the "managed by …" label. Mirrors desktop's `formatOwnerLabel`.
 String? formatOwnerLabel(
   String? ownerPubkey,
   String? currentPubkey,


### PR DESCRIPTION
## What

Relabels agent owner attribution across all user-visible surfaces from **"owned by"** to **"managed by"**, per copy review in buzz-launch (2026-07-19).

## Where

- **Desktop:** message header owner treatment (`MessageAgentOwner`), mention autocomplete subtitles + titles, members sidebar add-member rows, new-message search result rows, profile popover owner line, profile panel "Managed by" field label (plus its ordering constant and testId `user-profile-owned-by` -> `user-profile-managed-by`; the testId had exactly one reference).
- **Mobile:** compose bar mention suggestion subtitles (`suggestions.dart`), plus comments that quote the label.
- **Tests:** e2e assertions in `mentions.spec.ts`, `messaging.spec.ts`, `pubkey-display-screenshots.spec.ts` updated to the new copy.

Not touched: backend/relay "owned by" strings about channels, tokens, and repos (ownership semantics, not the agent label), and code comments describing ownership behavior.

## Testing

At 58b0a2f50:
- `tsc --noEmit` clean (desktop).
- `pnpm build` then Playwright on the three touched specs: **87 passed, 1 failed** — the failure (`messaging.spec.ts` "shows your avatar on your own message...") is untouched by this diff and **passes solo**; parallelism flake.
- `dart format` + `flutter analyze` clean via pre-commit hooks (mobile).
