### PR TITLE
Add back action to community profile onboarding

### DIFF
--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -496,7 +496,7 @@ export function CommunityOnboardingFlow({
                 )}
               >
                 <Button
-                  className={ONBOARDING_PRIMARY_CTA_CLASS}
+                  className={`${ONBOARDING_PRIMARY_CTA_CLASS} w-20`}
                   data-testid="community-profile-next"
                   disabled={
                     !displayName.trim() || isPending || isUploadingAvatar
@@ -505,6 +505,16 @@ export function CommunityOnboardingFlow({
                   type="button"
                 >
                   Next
+                </Button>
+                <Button
+                  className="h-9 w-20 rounded-full bg-foreground/10 px-6 hover:bg-foreground/15"
+                  data-testid="community-profile-back"
+                  disabled={isPending || isUploadingAvatar}
+                  onClick={onCancel}
+                  type="button"
+                  variant="ghost"
+                >
+                  Back
                 </Button>
               </OnboardingFooter>
               <Dialog

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -971,7 +971,7 @@ test("canceling a join to an existing inactive community preserves it", async ({
     .toEqual(["active-community", "existing-community"]);
 });
 
-test("connected first-community profile step cannot discard resumable onboarding", async ({
+test("connected first-community profile step offers equal-width Next and Back controls", async ({
   page,
 }) => {
   await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
@@ -1226,9 +1226,26 @@ test("connected first-community profile step cannot discard resumable onboarding
   await page.keyboard.press("Escape");
   await expect(avatarDialog).toHaveCount(0);
   await expect(avatarButton).toBeFocused();
-  await expect(page.getByTestId("community-profile-next")).toHaveText("Next");
-  await expect(page.getByTestId("community-profile-next")).toBeDisabled();
-  await expect(page.getByTestId("community-profile-back")).toHaveCount(0);
+  const nextButton = page.getByTestId("community-profile-next");
+  const backButton = page.getByTestId("community-profile-back");
+  await expect(nextButton).toHaveText("Next");
+  await expect(nextButton).toBeDisabled();
+  await expect(backButton).toHaveText("Back");
+  await expect(backButton).toBeEnabled();
+  const [nextBox, backBox] = await Promise.all([
+    nextButton.boundingBox(),
+    backButton.boundingBox(),
+  ]);
+  if (!nextBox || !backBox) {
+    throw new Error("Could not measure community profile navigation controls");
+  }
+  expect(Math.abs(nextBox.width - backBox.width)).toBeLessThanOrEqual(1);
+  expect(nextBox.width).toBeLessThanOrEqual(160);
+
+  await backButton.click();
+  await expect(
+    page.getByRole("heading", { name: "Request access to community" }),
+  ).toBeVisible();
   await expect
     .poll(() =>
       page.evaluate(
@@ -1236,7 +1253,7 @@ test("connected first-community profile step cannot discard resumable onboarding
         COMMUNITY_ONBOARDING_TRANSACTION_STORAGE_KEY,
       ),
     )
-    .not.toBeNull();
+    .toBeNull();
 });
 
 test("membership denial on community profile save offers recovery", async ({


### PR DESCRIPTION
## Why
The main community profile onboarding step lost its Back action when the previous implementation was removed to avoid bypassing parent cleanup. Users should be able to return safely with controls consistent with adjacent onboarding steps.

## What
- Restore Back through the parent cancellation and cleanup path
- Match Back and Next to the compact, equal-width onboarding control treatment
- Add regression coverage for state, sizing, navigation, and transaction cleanup

## Risk Assessment
Low — the change is limited to one onboarding action and focused end-to-end coverage. Back reuses the existing parent cleanup path rather than introducing new persistence behavior.

## References
- [After screenshot](https://sprout-oss.stage.blox.sqprod.co/media/8b240c1a5a1ed99c0a415fcf8bc8aeb5c1c424bfa516366c8c6ed6526c522e52.png)
- Verified with production build, focused Playwright coverage, Biome, push hooks, and diff/scope checks

Generated with Peppermint Butler
