### PR TITLE
Add channel-wide @everyone and @here mentions

### DIFF
--- a/crates/buzz-core/src/channel_mentions.rs
+++ b/crates/buzz-core/src/channel_mentions.rs
@@ -1,0 +1,75 @@
+//! Channel-wide mention tag parsing shared by relay and desktop validation.
+
+use nostr::Tag;
+
+/// Marker stored in the fourth field of an audience `p` tag.
+pub const CHANNEL_MENTION_RECIPIENT_MARKER_PREFIX: &str = "buzz:audience:";
+/// Non-notifying tag used to preserve reserved mention rendering metadata.
+pub const CHANNEL_MENTION_REFERENCE_TAG: &str = "buzz-audience-ref";
+/// Maximum exact recipients that fit comfortably below Buzz's default frame limit.
+pub const MAX_CHANNEL_MENTION_RECIPIENTS: usize = 4_000;
+
+/// Return the exact recipient encoded by an audience tag.
+///
+/// Valid tags are `['p', '<hex-pubkey>', '', 'buzz:audience:everyone|here']`.
+/// Keeping the recipient in a standard `p` tag preserves NIP-01 `#p`
+/// subscriptions and notification interoperability for clients that ignore
+/// Buzz's trailing marker.
+pub fn channel_mention_recipient(tag: &Tag) -> Option<&str> {
+    let parts = tag.as_slice();
+    if parts.len() != 4
+        || parts[0] != "p"
+        || !parts[2].is_empty()
+        || channel_mention_recipient_mode(tag).is_none()
+    {
+        return None;
+    }
+    Some(parts[1].as_str())
+}
+
+/// Return the audience mode encoded in a recipient `p` tag.
+pub fn channel_mention_recipient_mode(tag: &Tag) -> Option<&str> {
+    let parts = tag.as_slice();
+    if parts.len() != 4 || parts[0] != "p" || !parts[2].is_empty() {
+        return None;
+    }
+    match parts[3].as_str() {
+        "buzz:audience:everyone" => Some("everyone"),
+        "buzz:audience:here" => Some("here"),
+        _ => None,
+    }
+}
+
+/// Return the reserved mention mode encoded by a rendering reference tag.
+pub fn channel_mention_reference_mode(tag: &Tag) -> Option<&str> {
+    let parts = tag.as_slice();
+    if parts.len() != 2
+        || parts[0] != CHANNEL_MENTION_REFERENCE_TAG
+        || (parts[1] != "everyone" && parts[1] != "here")
+    {
+        return None;
+    }
+    Some(parts[1].as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_exact_recipient_tags() {
+        let pubkey = "a".repeat(64);
+        let tag = Tag::parse(["p", pubkey.as_str(), "", "buzz:audience:here"]).expect("tag");
+        assert_eq!(channel_mention_recipient(&tag), Some(pubkey.as_str()));
+        assert_eq!(channel_mention_recipient_mode(&tag), Some("here"));
+    }
+
+    #[test]
+    fn rejects_unknown_modes_and_shapes() {
+        let pubkey = "a".repeat(64);
+        let unknown = Tag::parse(["p", pubkey.as_str(), "", "buzz:audience:away"]).expect("tag");
+        let missing = Tag::parse(["p", pubkey.as_str()]).expect("tag");
+        assert_eq!(channel_mention_recipient(&unknown), None);
+        assert_eq!(channel_mention_recipient(&missing), None);
+    }
+}

--- a/crates/buzz-core/src/lib.rs
+++ b/crates/buzz-core/src/lib.rs
@@ -9,6 +9,8 @@
 pub mod agent_turn_metric;
 /// Channel and membership enums shared across crates.
 pub mod channel;
+/// Exact-recipient channel-wide mention tag parsing.
+pub mod channel_mentions;
 /// NIP-AE Agent Engrams — slug grammar, conversation key, d-tag derivation,
 /// body parse/serialize, envelope build/validate, head selection.
 pub mod engram;

--- a/crates/buzz-db/src/channel.rs
+++ b/crates/buzz-db/src/channel.rs
@@ -538,6 +538,41 @@ pub async fn is_member(
     Ok(cnt > 0)
 }
 
+/// Returns `true` if every supplied pubkey is an active member of the channel.
+///
+/// The query is bounded by the caller-provided pubkeys rather than the size of
+/// the channel roster. An empty input is vacuously valid.
+pub async fn are_members(
+    pool: &PgPool,
+    community_id: CommunityId,
+    channel_id: Uuid,
+    pubkeys: &[Vec<u8>],
+) -> Result<bool> {
+    if pubkeys.is_empty() {
+        return Ok(true);
+    }
+    let unique_pubkeys: std::collections::HashSet<&Vec<u8>> = pubkeys.iter().collect();
+
+    let mut qb: sqlx::QueryBuilder<Postgres> = sqlx::QueryBuilder::new(
+        "SELECT COUNT(DISTINCT cm.pubkey) AS cnt FROM channel_members cm \
+         JOIN channels c ON cm.community_id = c.community_id AND cm.channel_id = c.id AND c.deleted_at IS NULL \
+         WHERE cm.community_id = ",
+    );
+    qb.push_bind(community_id.as_uuid());
+    qb.push(" AND cm.channel_id = ");
+    qb.push_bind(channel_id);
+    qb.push(" AND cm.removed_at IS NULL AND cm.pubkey IN (");
+    let mut separated = qb.separated(", ");
+    for pubkey in &unique_pubkeys {
+        separated.push_bind(pubkey.as_slice());
+    }
+    qb.push(")");
+
+    let row = qb.build().fetch_one(pool).await?;
+    let count: i64 = row.try_get("cnt")?;
+    Ok(count == unique_pubkeys.len() as i64)
+}
+
 /// Returns all active members of the given channel.
 ///
 /// Returns an empty list if the channel has been soft-deleted.
@@ -553,7 +588,6 @@ pub async fn get_members(
         JOIN channels c ON cm.community_id = c.community_id AND cm.channel_id = c.id AND c.deleted_at IS NULL
         WHERE cm.community_id = $1 AND cm.channel_id = $2 AND cm.removed_at IS NULL
         ORDER BY cm.joined_at ASC
-        LIMIT 1000
         "#,
     )
     .bind(community_id.as_uuid())
@@ -1751,6 +1785,55 @@ mod tests {
             .await
             .expect("load accessible channel ids");
         assert_eq!(channel_ids.len(), channel_count as usize);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn channel_member_roster_and_targeted_lookup_cross_the_four_thousand_boundary() {
+        let database_url =
+            std::env::var("BUZZ_TEST_DATABASE_URL").unwrap_or_else(|_| TEST_DB_URL.to_string());
+        let pool = PgPool::connect(&database_url)
+            .await
+            .expect("connect to test DB");
+        let community_id = make_test_community(&pool).await;
+        let community = CommunityId::from_uuid(community_id);
+        let owner = random_pubkey();
+        let channel = create_test_channel(
+            &pool,
+            community_id,
+            "channel-mention-boundary",
+            ChannelType::Stream,
+            ChannelVisibility::Open,
+            None,
+            &owner,
+            None,
+        )
+        .await
+        .expect("create channel");
+
+        sqlx::query(
+            r#"
+            INSERT INTO channel_members (community_id, channel_id, pubkey, role)
+            SELECT $1, $2, decode(lpad(to_hex(n), 64, '0'), 'hex'), 'member'::member_role
+            FROM generate_series(1, 4001) n
+            "#,
+        )
+        .bind(community_id)
+        .bind(channel.id)
+        .execute(&pool)
+        .await
+        .expect("insert members across the channel mention boundary");
+
+        let members = get_members(&pool, community, channel.id)
+            .await
+            .expect("load complete member roster");
+        assert_eq!(members.len(), 4_002, "owner plus 4,001 recipients");
+
+        let last_member = hex::decode(format!("{:064x}", 4_001)).expect("hex pubkey");
+        assert!(members.iter().any(|member| member.pubkey == last_member));
+        assert!(are_members(&pool, community, channel.id, &[last_member])
+            .await
+            .expect("validate later-joined member"));
     }
 
     /// A random non-admin, non-owner user cannot remove someone else's bot.

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -1534,6 +1534,16 @@ impl Db {
         channel::is_member(&self.pool, community_id, channel_id, pubkey).await
     }
 
+    /// Returns `true` if every supplied pubkey is an active member.
+    pub async fn are_members(
+        &self,
+        community_id: CommunityId,
+        channel_id: Uuid,
+        pubkeys: &[Vec<u8>],
+    ) -> Result<bool> {
+        channel::are_members(&self.pool, community_id, channel_id, pubkeys).await
+    }
+
     /// Returns all active members of a channel.
     pub async fn get_members(
         &self,

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -510,6 +510,111 @@ fn check_token_channel_access(auth: &IngestAuth, channel_id: Uuid) -> Result<(),
     Ok(())
 }
 
+async fn validate_channel_mention_audience(
+    community_id: CommunityId,
+    channel_id: Uuid,
+    event: &Event,
+    state: &AppState,
+) -> Result<(), String> {
+    let mut reference_modes = std::collections::HashSet::new();
+    let mut recipients = Vec::new();
+
+    for tag in event.tags.iter() {
+        if let (Some(mode), Some(recipient)) = (
+            buzz_core::channel_mentions::channel_mention_recipient_mode(tag),
+            buzz_core::channel_mentions::channel_mention_recipient(tag),
+        ) {
+            recipients.push((mode.to_string(), recipient.to_string()));
+            continue;
+        }
+
+        let parts = tag.as_slice();
+        if parts.first().map(String::as_str) == Some("p")
+            && parts.get(3).is_some_and(|marker| {
+                marker.starts_with(
+                    buzz_core::channel_mentions::CHANNEL_MENTION_RECIPIENT_MARKER_PREFIX,
+                )
+            })
+        {
+            return Err("malformed channel mention recipient tag".into());
+        }
+        match parts.first().map(String::as_str) {
+            Some(buzz_core::channel_mentions::CHANNEL_MENTION_REFERENCE_TAG) => {
+                let mode = buzz_core::channel_mentions::channel_mention_reference_mode(tag)
+                    .ok_or_else(|| "malformed audience-ref tag".to_string())?;
+                reference_modes.insert(mode.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    if reference_modes.is_empty() && recipients.is_empty() {
+        return Ok(());
+    }
+
+    let kind = event_kind_u32(event);
+    if !matches!(
+        kind,
+        KIND_STREAM_MESSAGE | KIND_STREAM_MESSAGE_EDIT | KIND_FORUM_POST | KIND_FORUM_COMMENT
+    ) {
+        return Err("channel mention tags are only valid on messages and edits".into());
+    }
+
+    if recipients
+        .iter()
+        .any(|(mode, _)| !reference_modes.contains(mode))
+    {
+        return Err("audience recipient tag is missing its audience-ref marker".into());
+    }
+    if recipients.len() > buzz_core::channel_mentions::MAX_CHANNEL_MENTION_RECIPIENTS {
+        return Err(format!(
+            "channel mention audience exceeds {} recipients",
+            buzz_core::channel_mentions::MAX_CHANNEL_MENTION_RECIPIENTS
+        ));
+    }
+
+    let author = event.pubkey.to_bytes().to_vec();
+    let author_hex = event.pubkey.to_hex();
+    let author_is_member = state
+        .db
+        .is_member(community_id, channel_id, &author)
+        .await
+        .map_err(|error| format!("database error checking channel membership: {error}"))?;
+    if !author_is_member {
+        return Err("only channel members may use @everyone or @here".into());
+    }
+
+    let mut unique_recipients = std::collections::HashSet::new();
+    let mut recipient_pubkeys = Vec::with_capacity(recipients.len());
+    for (_, recipient) in recipients {
+        let normalized = recipient.to_ascii_lowercase();
+        if normalized.len() != 64 || !normalized.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            return Err("audience recipient must be a 64-character hex pubkey".into());
+        }
+        if normalized == author_hex {
+            return Err("channel mention audience must not include the sender".into());
+        }
+        if !unique_recipients.insert(normalized.clone()) {
+            return Err("channel mention audience contains a duplicate recipient".into());
+        }
+        recipient_pubkeys.push(
+            hex::decode(normalized)
+                .map_err(|_| "audience recipient must be a 64-character hex pubkey")?,
+        );
+    }
+
+    let recipients_are_members = state
+        .db
+        .are_members(community_id, channel_id, &recipient_pubkeys)
+        .await
+        .map_err(|error| format!("database error checking channel membership: {error}"))?;
+    if !recipients_are_members {
+        return Err("channel mention audience contains a non-member".into());
+    }
+
+    Ok(())
+}
+
 /// Owned thread metadata for the DB insert.
 pub(crate) struct ThreadMetadataOwned {
     pub event_id: Vec<u8>,
@@ -1727,6 +1832,10 @@ async fn ingest_event_inner(
             );
             auth_result.map_err(IngestError::Rejected)?;
         }
+
+        validate_channel_mention_audience(tenant.community(), ch_id, &event, state)
+            .await
+            .map_err(|error| IngestError::Rejected(format!("invalid: {error}")))?;
     }
 
     // Handled directly — these mutate relay_members and do NOT get stored.

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -935,6 +935,17 @@ async fn emit_addressable_discovery_event(
     Ok(())
 }
 
+fn group_member_tags(group_id: &str, members: &[MemberRecord]) -> anyhow::Result<Vec<Tag>> {
+    let mut tags: Vec<Tag> = vec![Tag::parse(["d", group_id])?];
+    for member in members {
+        let pubkey_hex = hex::encode(&member.pubkey);
+        // NIP-29 convention: ["p", pubkey, relay_url, role]. Empty relay_url
+        // because the canonical relay is implicit (this event is signed by it).
+        tags.push(Tag::parse(["p", &pubkey_hex, "", &member.role])?);
+    }
+    Ok(tags)
+}
+
 /// Emit NIP-29 group discovery events (39000, 39001, 39002) signed by the relay keypair.
 /// Called after group creation, metadata changes, or membership changes.
 /// Events are stored channel-scoped (`channel_id = Some(...)`) so that existing
@@ -1038,13 +1049,7 @@ pub async fn emit_group_discovery_events(
     }
 
     {
-        let mut tags: Vec<Tag> = vec![Tag::parse(["d", &group_id])?];
-        for m in &members {
-            let pubkey_hex = hex::encode(&m.pubkey);
-            // NIP-29 convention: ["p", pubkey, relay_url, role]. Empty relay_url
-            // because the canonical relay is implicit (this event is signed by it).
-            tags.push(Tag::parse(["p", &pubkey_hex, "", &m.role])?);
-        }
+        let tags = group_member_tags(&group_id, &members)?;
         emit_addressable_discovery_event(
             tenant,
             state,
@@ -3327,5 +3332,34 @@ mod tests {
         }];
 
         assert!(actor_is_channel_owner_or_admin(&members, &actor));
+    }
+
+    #[test]
+    fn group_member_roster_preserves_the_channel_mention_overflow_boundary() {
+        let channel_id = Uuid::new_v4();
+        let member_count = buzz_core::channel_mentions::MAX_CHANNEL_MENTION_RECIPIENTS + 2;
+        let members: Vec<MemberRecord> = (0..member_count)
+            .map(|index| MemberRecord {
+                channel_id,
+                pubkey: hex::decode(format!("{index:064x}")).expect("hex pubkey"),
+                role: "member".to_string(),
+                joined_at: chrono::Utc::now(),
+                invited_by: None,
+                removed_at: None,
+            })
+            .collect();
+
+        let tags = group_member_tags(&channel_id.to_string(), &members).expect("member tags");
+
+        assert_eq!(tags.len(), member_count + 1, "d tag plus every member");
+        assert_eq!(
+            tags.last().expect("last member tag").as_slice(),
+            [
+                "p",
+                format!("{:064x}", member_count - 1).as_str(),
+                "",
+                "member",
+            ]
+        );
     }
 }

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         "**/profile-custom-emoji-status.spec.ts",
         "**/custom-emoji-ui.spec.ts",
         "**/channel-mute.spec.ts",
+        "**/channel-mentions.spec.ts",
         "**/channel-star.spec.ts",
         "**/channel-controls.spec.ts",
         "**/active-turn-resilience.spec.ts",

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -881,6 +881,7 @@ pub async fn edit_message(
     // edited body against the original). Only these get a `p` tag, so a typo-fix
     // edit that leaves the mention set unchanged never re-wakes anyone.
     mention_pubkeys: Option<Vec<String>>,
+    mention_tags: Option<Vec<Vec<String>>>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let channel_uuid = uuid::Uuid::parse_str(&channel_id)
@@ -895,6 +896,7 @@ pub async fn edit_message(
     let emoji = emoji_tags.unwrap_or_default();
     let mentions = mention_pubkeys.unwrap_or_default();
     let mention_refs: Vec<&str> = mentions.iter().map(|s| s.as_str()).collect();
+    let mention_metadata = mention_tags.unwrap_or_default();
     let builder = events::build_message_edit(
         channel_uuid,
         target_eid,
@@ -902,6 +904,7 @@ pub async fn edit_message(
         &media_tags,
         &emoji,
         &mention_refs,
+        &mention_metadata,
     )?;
     submit_event(builder, &state).await?;
     Ok(())

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -13,6 +13,8 @@ use buzz_core_pkg::kind::{KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST};
 use nostr::{EventBuilder, EventId, Kind, Tag};
 use uuid::Uuid;
 
+mod channel_mentions;
+
 // ── Constants ────────────────────────────────────────────────────────────────
 
 /// Maximum content size — matches buzz-sdk (64 KiB).
@@ -74,23 +76,6 @@ fn mention_tags(mentions: &[&str]) -> Result<Vec<Tag>, String> {
         }
     }
     Ok(tags)
-}
-
-fn mention_reference_tags(mentions: &[Vec<String>], tags: &mut Vec<Tag>) -> Result<(), String> {
-    for mention in mentions {
-        if mention.first().map(String::as_str) != Some("mention") {
-            return Err(format!(
-                "mention reference tags must use 'mention' prefix (got {:?})",
-                mention.first()
-            ));
-        }
-        let Some(pubkey) = mention.get(1) else {
-            return Err("mention reference tag missing pubkey".into());
-        };
-        check_pubkey(pubkey)?;
-        tags.push(tag(vec!["mention", &pubkey.to_ascii_lowercase()])?);
-    }
-    Ok(())
 }
 
 /// Validate and append imeta tags. Rejects any tag whose first element is not "imeta"
@@ -332,7 +317,7 @@ pub fn build_message_with_client_tags(
     tags.extend(mention_tags(mentions)?);
     imeta_tags(media_tags, &mut tags)?;
     emoji_tags(custom_emoji_tags, &mut tags)?;
-    mention_reference_tags(mention_ref_tags, &mut tags)?;
+    channel_mentions::append(mention_ref_tags, &mut tags)?;
     append_client_tags(client_tags, &mut tags)?;
     Ok(EventBuilder::new(Kind::Custom(9), content).tags(tags))
 }
@@ -366,7 +351,7 @@ pub fn build_forum_post(
     let mut tags = vec![tag(vec!["h", &channel_id.to_string()])?];
     tags.extend(mention_tags(mentions)?);
     imeta_tags(media_tags, &mut tags)?;
-    mention_reference_tags(mention_ref_tags, &mut tags)?;
+    channel_mentions::append(mention_ref_tags, &mut tags)?;
     Ok(EventBuilder::new(Kind::Custom(45001), content).tags(tags))
 }
 
@@ -384,7 +369,7 @@ pub fn build_forum_comment(
     tags.extend(thread_tags(thread_ref)?);
     tags.extend(mention_tags(mentions)?);
     imeta_tags(media_tags, &mut tags)?;
-    mention_reference_tags(mention_ref_tags, &mut tags)?;
+    channel_mentions::append(mention_ref_tags, &mut tags)?;
     Ok(EventBuilder::new(Kind::Custom(45003), content).tags(tags))
 }
 
@@ -407,6 +392,7 @@ pub fn build_message_edit(
     media_tags: &[Vec<String>],
     custom_emoji_tags: &[Vec<String>],
     mentions: &[&str],
+    mention_ref_tags: &[Vec<String>],
 ) -> Result<EventBuilder, String> {
     check_content(content)?;
     let mut tags = vec![
@@ -416,6 +402,7 @@ pub fn build_message_edit(
     tags.extend(mention_tags(mentions)?);
     imeta_tags(media_tags, &mut tags)?;
     emoji_tags(custom_emoji_tags, &mut tags)?;
+    channel_mentions::append(mention_ref_tags, &mut tags)?;
     Ok(EventBuilder::new(Kind::Custom(40003), content).tags(tags))
 }
 
@@ -935,7 +922,8 @@ mod tests {
         let target =
             EventId::from_hex("d24da132115ca0a46233cf4c2ad8338fbf914250cbcaa9181a6dd59533cb5ac1")
                 .unwrap();
-        let builder = build_message_edit(channel, target, "hi @alice", &[], &[], mentions).unwrap();
+        let builder =
+            build_message_edit(channel, target, "hi @alice", &[], &[], mentions, &[]).unwrap();
         let secret = nostr::SecretKey::from_hex(
             "0000000000000000000000000000000000000000000000000000000000000003",
         )

--- a/desktop/src-tauri/src/events/channel_mentions.rs
+++ b/desktop/src-tauri/src/events/channel_mentions.rs
@@ -1,0 +1,108 @@
+use nostr::Tag;
+
+use super::{check_pubkey, tag};
+
+pub(super) fn append(metadata: &[Vec<String>], tags: &mut Vec<Tag>) -> Result<(), String> {
+    for item in metadata {
+        match item.first().map(String::as_str) {
+            Some("mention") => {
+                let Some(pubkey) = item.get(1) else {
+                    return Err("mention reference tag missing pubkey".into());
+                };
+                if item.len() != 2 {
+                    return Err("mention reference tag must have exactly two fields".into());
+                }
+                check_pubkey(pubkey)?;
+                tags.push(tag(vec!["mention", &pubkey.to_ascii_lowercase()])?);
+            }
+            Some("buzz-audience-ref") => {
+                let mode = validate_mode(item.get(1))?;
+                if item.len() != 2 {
+                    return Err("buzz-audience-ref tag must have exactly two fields".into());
+                }
+                tags.push(tag(vec!["buzz-audience-ref", mode])?);
+            }
+            Some("p")
+                if item
+                    .get(3)
+                    .is_some_and(|marker| marker.starts_with("buzz:audience:")) =>
+            {
+                let Some(pubkey) = item.get(1) else {
+                    return Err("channel mention p tag missing recipient pubkey".into());
+                };
+                if item.len() != 4 || !item[2].is_empty() {
+                    return Err("channel mention p tag must have exactly four fields".into());
+                }
+                check_pubkey(pubkey)?;
+                let mode = validate_recipient_marker(item.get(3))?;
+                let expected_marker = format!("buzz:audience:{mode}");
+                if item[3] != expected_marker {
+                    return Err("channel mention p tag marker does not match its mode".into());
+                }
+                tags.push(tag(vec![
+                    "p",
+                    &pubkey.to_ascii_lowercase(),
+                    "",
+                    &expected_marker,
+                ])?);
+            }
+            prefix => {
+                return Err(format!(
+                    "mention metadata tag has unsupported prefix {prefix:?}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_recipient_marker(marker: Option<&String>) -> Result<&str, String> {
+    match marker.map(String::as_str) {
+        Some("buzz:audience:everyone") => Ok("everyone"),
+        Some("buzz:audience:here") => Ok("here"),
+        _ => Err("channel mention p tag has an unsupported marker".into()),
+    }
+}
+
+fn validate_mode(mode: Option<&String>) -> Result<&str, String> {
+    match mode.map(String::as_str) {
+        Some("everyone") => Ok("everyone"),
+        Some("here") => Ok("here"),
+        _ => Err("channel mention mode must be 'everyone' or 'here'".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn appends_standard_p_tag_with_audience_marker() {
+        let pubkey = "a".repeat(64);
+        let metadata = vec![
+            vec!["buzz-audience-ref".into(), "here".into()],
+            vec![
+                "p".into(),
+                pubkey.clone(),
+                String::new(),
+                "buzz:audience:here".into(),
+            ],
+        ];
+        let mut tags = Vec::new();
+
+        append(&metadata, &mut tags).expect("valid audience tags");
+
+        assert_eq!(tags[0].as_slice(), ["buzz-audience-ref", "here"]);
+        assert_eq!(
+            tags[1].as_slice(),
+            ["p", pubkey.as_str(), "", "buzz:audience:here"]
+        );
+    }
+
+    #[test]
+    fn rejects_unmarked_p_tag_in_metadata_channel() {
+        let metadata = vec![vec!["p".into(), "a".repeat(64)]];
+        let error = append(&metadata, &mut Vec::new()).expect_err("must reject");
+        assert!(error.contains("unsupported prefix"));
+    }
+}

--- a/desktop/src/app/useAppShellDesktopNotifications.ts
+++ b/desktop/src/app/useAppShellDesktopNotifications.ts
@@ -5,7 +5,7 @@ import {
   toSearchHit,
 } from "@/app/AppShell.helpers";
 import { getThreadReference } from "@/features/messages/lib/threading";
-import { hasMentionForEvent } from "@/features/notifications/lib/shouldNotify";
+import { hasAnyMentionForEvent } from "@/features/notifications/lib/shouldNotify";
 import type { NotificationSettings } from "@/features/notifications/hooks";
 import {
   listenForDesktopNotificationActions,
@@ -94,7 +94,7 @@ export function useAppShellDesktopNotifications({
       // Replies that @-mention the user are owned by the home-feed mention
       // path — skip them here so they don't notify (and sound) twice.
       const normalizedPubkey = pubkey?.trim().toLowerCase() ?? "";
-      if (hasMentionForEvent(event, normalizedPubkey)) {
+      if (hasAnyMentionForEvent(event, normalizedPubkey)) {
         return;
       }
 

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -26,7 +26,7 @@ import {
   isBroadcastReply,
 } from "@/features/messages/lib/threading";
 import {
-  hasMentionForEvent,
+  hasAnyMentionForEvent,
   isHighPriorityEventForUser,
   shouldNotifyForEvent,
 } from "@/features/notifications/lib/shouldNotify";
@@ -368,7 +368,7 @@ export function useUnreadChannels(
     (event: RelayEvent): boolean => {
       if (normalizedPubkey === null) return false;
       if (event.pubkey.toLowerCase() === normalizedPubkey) return false;
-      if (!hasMentionForEvent(event, normalizedPubkey)) return false;
+      if (!hasAnyMentionForEvent(event, normalizedPubkey)) return false;
       const { rootId } = getThreadReference(event.tags);
       if (rootId === null) return false;
       const target = mentionedRootIdsRef.current;

--- a/desktop/src/features/forum/hooks.ts
+++ b/desktop/src/features/forum/hooks.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { splitOutgoingTags } from "@/features/messages/lib/imetaMediaMarkdown";
 
 import { getForumPosts, getForumThread } from "@/shared/api/forum";
 import { useRelaySelfQuery } from "@/features/moderation/hooks";
@@ -75,13 +76,18 @@ export function useCreateForumPostMutation(channel: Channel | null) {
         throw new Error("No channel selected.");
       }
 
+      const { mediaTags: imetaTags, mentionTags } =
+        splitOutgoingTags(mediaTags);
+
       return sendChannelMessage(
         channel.id,
         content,
         null,
-        mediaTags,
+        imetaTags,
         mentionPubkeys,
         KIND_FORUM_POST,
+        undefined,
+        mentionTags,
       );
     },
     onSuccess: () => {
@@ -161,13 +167,18 @@ export function useCreateForumReplyMutation(channel: Channel | null) {
         throw new Error("No channel selected.");
       }
 
+      const { mediaTags: imetaTags, mentionTags } =
+        splitOutgoingTags(mediaTags);
+
       return sendChannelMessage(
         channel.id,
         content,
         parentEventId,
-        mediaTags,
+        imetaTags,
         mentionPubkeys,
         KIND_FORUM_COMMENT,
+        undefined,
+        mentionTags,
       );
     },
     onSuccess: (_data, variables) => {

--- a/desktop/src/features/forum/ui/ForumComposer.tsx
+++ b/desktop/src/features/forum/ui/ForumComposer.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { EditorContent } from "@tiptap/react";
+import { toast } from "sonner";
 import { buildOutgoingMessage } from "@/features/messages/lib/imetaMediaMarkdown";
 import { useChannelLinks } from "@/features/messages/lib/useChannelLinks";
 import type { ChannelSuggestion } from "@/features/messages/lib/useChannelLinks";
@@ -208,6 +209,11 @@ export function ForumComposer({
     }
 
     const pubkeys = mentions.extractMentionPubkeys(trimmed);
+    const channelMentionError = mentions.getChannelMentionError(trimmed);
+    if (channelMentionError) {
+      toast.error(channelMentionError);
+      return;
+    }
 
     // Reuse the shared send-path builder so forum/notes posts emit the same
     // body + imeta as chat: generic files become `[filename](url)` links with a
@@ -217,6 +223,11 @@ export function ForumComposer({
       trimmed,
       currentPendingImeta,
     );
+    const channelMentionTags = mentions.extractChannelMentionTags(trimmed);
+    const outgoingTags =
+      mediaTags || channelMentionTags.length > 0
+        ? [...(mediaTags ?? []), ...channelMentionTags]
+        : undefined;
 
     // Save draft state so we can restore on failure.
     const savedContent = contentRef.current;
@@ -230,7 +241,7 @@ export function ForumComposer({
     channelLinks.clearChannels();
     setIsEmojiPickerOpen(false);
 
-    const result = onSubmitRef.current(finalContent, pubkeys, mediaTags);
+    const result = onSubmitRef.current(finalContent, pubkeys, outgoingTags);
     const collapseCompactComposer = () => {
       if (compact) setIsCompactExpanded(false);
     };
@@ -252,6 +263,8 @@ export function ForumComposer({
     media.pendingImetaRef,
     media.setPendingImeta,
     mentions.extractMentionPubkeys,
+    mentions.extractChannelMentionTags,
+    mentions.getChannelMentionError,
     mentions.clearMentions,
     channelLinks.clearChannels,
     richText.clearContent,

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -457,7 +457,12 @@ export function useSendMessageMutation(
       // Messages carrying media OR custom-emoji tags MUST go through REST so
       // the relay's tag validation runs. The WebSocket path emits no extra
       // tags, so emoji-only messages would otherwise lose their emoji tag.
-      if (parentEventId || imetaTags.length > 0 || emojiTags.length > 0) {
+      if (
+        parentEventId ||
+        imetaTags.length > 0 ||
+        emojiTags.length > 0 ||
+        mentionTags.length > 0
+      ) {
         const cachedMessages =
           queryClient.getQueryData<RelayEvent[]>(
             channelMessagesKey(effectiveChannel.id),
@@ -699,7 +704,11 @@ export function useEditMessageMutation(channel: Channel | null) {
       // Split so each rides its own validated Tauri arg — emoji tags must NOT
       // go through the imeta-only `mediaTags` channel (the Rust `imeta_tags`
       // guard rejects any non-imeta prefix), mirroring the send path.
-      const { mediaTags: imetaTags, emojiTags } = splitOutgoingTags(mediaTags);
+      const {
+        mediaTags: imetaTags,
+        emojiTags,
+        mentionTags,
+      } = splitOutgoingTags(mediaTags);
 
       await editMessage(
         channel.id,
@@ -708,6 +717,7 @@ export function useEditMessageMutation(channel: Channel | null) {
         imetaTags,
         emojiTags,
         mentionPubkeys,
+        mentionTags,
       );
     },
     onSuccess: (_data, { eventId, content, mediaTags }) => {

--- a/desktop/src/features/messages/lib/applyEditTagOverlay.mjs
+++ b/desktop/src/features/messages/lib/applyEditTagOverlay.mjs
@@ -22,6 +22,9 @@
  *     `:shortcode:` that the original rendered fine. Preserving on empty is
  *     strictly safe: an orphaned emoji tag whose shortcode is no longer in the
  *     body resolves nothing, so it can't cause a stale render.
+ *   - `buzz-audience-ref` tags come exclusively from the edit, because they describe
+ *     which reserved channel mentions remain in the edited body. Notification
+ *     recipient tags (`audience`) remain immutable like ordinary `p` tags.
  *   - all other tag kinds (`h`, `e`, `p` mentions, etc.) come exclusively
  *     from the original — the edit can't rewrite channel membership,
  *     thread refs, or mention targets.
@@ -35,9 +38,16 @@ export function applyEditTagOverlay(originalTags, editTags) {
   // the edit actually supplies emoji tags; otherwise the original's are kept.
   const droppedFromOriginal =
     editEmoji.length > 0
-      ? (t) => t[0] !== "imeta" && t[0] !== "emoji"
-      : (t) => t[0] !== "imeta";
+      ? (t) =>
+          t[0] !== "imeta" && t[0] !== "emoji" && t[0] !== "buzz-audience-ref"
+      : (t) => t[0] !== "imeta" && t[0] !== "buzz-audience-ref";
   const baseFromOriginal = originalTags.filter(droppedFromOriginal);
   const overlaidFromEdit = editTags.filter((t) => t[0] === "imeta");
-  return [...baseFromOriginal, ...overlaidFromEdit, ...editEmoji];
+  const editAudienceRefs = editTags.filter((t) => t[0] === "buzz-audience-ref");
+  return [
+    ...baseFromOriginal,
+    ...overlaidFromEdit,
+    ...editEmoji,
+    ...editAudienceRefs,
+  ];
 }

--- a/desktop/src/features/messages/lib/applyEditTagOverlay.test.mjs
+++ b/desktop/src/features/messages/lib/applyEditTagOverlay.test.mjs
@@ -201,3 +201,24 @@ test("imeta and emoji are overlaid together from the edit", () => {
     ["rickroll"],
   );
 });
+
+test("edit replaces channel-wide render refs without rewriting recipient p-tags", () => {
+  const recipient = ["p", "a".repeat(64), "", "buzz:audience:everyone"];
+  const original = [
+    ["h", "uuid"],
+    ["buzz-audience-ref", "everyone"],
+    recipient,
+  ];
+  const edit = [
+    ["h", "uuid"],
+    ["e", "x"],
+    ["buzz-audience-ref", "here"],
+  ];
+
+  const out = applyEditTagOverlay(original, edit);
+  assert.deepEqual(
+    out.filter((tag) => tag[0] === "buzz-audience-ref"),
+    [["buzz-audience-ref", "here"]],
+  );
+  assert.ok(out.includes(recipient));
+});

--- a/desktop/src/features/messages/lib/channelMentions.test.mjs
+++ b/desktop/src/features/messages/lib/channelMentions.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildChannelMentionTags,
+  channelMentionModes,
+  getChannelMentionAudienceLimitError,
+  hasChannelMentionForPubkey,
+  isChannelWideMentionEvent,
+} from "./channelMentions.ts";
+
+const SELF = "a".repeat(64);
+const ONLINE = "b".repeat(64);
+const AWAY = "c".repeat(64);
+const OFFLINE = "d".repeat(64);
+
+test("channelMentionModes recognizes reserved mentions outside code", () => {
+  assert.deepEqual(channelMentionModes("hi @everyone and @here"), [
+    "everyone",
+    "here",
+  ]);
+  assert.deepEqual(channelMentionModes("`@everyone`"), []);
+});
+
+test("@everyone snapshots every other channel member", () => {
+  assert.deepEqual(
+    buildChannelMentionTags({
+      memberPubkeys: [SELF, ONLINE, AWAY, ONLINE.toUpperCase()],
+      selfPubkey: SELF,
+      text: "Heads up @everyone",
+    }),
+    [
+      ["buzz-audience-ref", "everyone"],
+      ["p", ONLINE, "", "buzz:audience:everyone"],
+      ["p", AWAY, "", "buzz:audience:everyone"],
+    ],
+  );
+});
+
+test("@here snapshots only online members", () => {
+  const tags = buildChannelMentionTags({
+    memberPubkeys: [SELF, ONLINE, AWAY, OFFLINE],
+    presence: { [ONLINE]: "online", [AWAY]: "away", [OFFLINE]: "offline" },
+    selfPubkey: SELF,
+    text: "Heads up @here",
+  });
+
+  assert.deepEqual(tags, [
+    ["buzz-audience-ref", "here"],
+    ["p", ONLINE, "", "buzz:audience:here"],
+  ]);
+  assert.equal(hasChannelMentionForPubkey(tags, ONLINE.toUpperCase()), true);
+  assert.equal(hasChannelMentionForPubkey(tags, AWAY), false);
+  assert.equal(isChannelWideMentionEvent(tags), true);
+  assert.equal(
+    isChannelWideMentionEvent([
+      ["p", ONLINE, "", "buzz:audience:here", "unexpected"],
+    ]),
+    false,
+  );
+});
+
+test("an unchanged channel mention edit preserves rendering without renotifying", () => {
+  assert.deepEqual(
+    buildChannelMentionTags({
+      memberPubkeys: [SELF, ONLINE],
+      originalText: "hello @everyone",
+      selfPubkey: SELF,
+      text: "hello @everyone!",
+    }),
+    [["buzz-audience-ref", "everyone"]],
+  );
+});
+
+test("@everyone supersedes @here notification recipients", () => {
+  assert.deepEqual(
+    buildChannelMentionTags({
+      memberPubkeys: [SELF, ONLINE, AWAY],
+      presence: { [ONLINE]: "online", [AWAY]: "away" },
+      selfPubkey: SELF,
+      text: "@here @everyone",
+    }),
+    [
+      ["buzz-audience-ref", "everyone"],
+      ["buzz-audience-ref", "here"],
+      ["p", ONLINE, "", "buzz:audience:everyone"],
+      ["p", AWAY, "", "buzz:audience:everyone"],
+    ],
+  );
+});
+
+test("@everyone preserves standard p-tag delivery beyond the direct mention cap", () => {
+  const members = Array.from({ length: 51 }, (_, index) =>
+    (index + 1).toString(16).padStart(64, "0"),
+  );
+  const tags = buildChannelMentionTags({
+    memberPubkeys: [SELF, ...members],
+    selfPubkey: SELF,
+    text: "Heads up @everyone",
+  });
+
+  assert.equal(tags.length, 52);
+  assert.equal(tags.filter((tag) => tag[0] === "p").length, 51);
+  assert.deepEqual(tags.at(-1), [
+    "p",
+    members.at(-1),
+    "",
+    "buzz:audience:everyone",
+  ]);
+});
+
+test("channel-wide mention limit accepts 4,000 recipients and rejects 4,001", () => {
+  assert.equal(getChannelMentionAudienceLimitError(4_000), null);
+  assert.equal(
+    getChannelMentionAudienceLimitError(4_001),
+    "Channel-wide mentions support up to 4,000 recipients.",
+  );
+});

--- a/desktop/src/features/messages/lib/channelMentions.ts
+++ b/desktop/src/features/messages/lib/channelMentions.ts
@@ -1,0 +1,113 @@
+import type { PresenceLookup } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { hasMention } from "./hasMention";
+
+export const CHANNEL_MENTION_RECIPIENT_MARKER_PREFIX = "buzz:audience:";
+export const CHANNEL_MENTION_REFERENCE_TAG = "buzz-audience-ref";
+export const MAX_CHANNEL_MENTION_RECIPIENTS = 4_000;
+
+export type ChannelMentionMode = "everyone" | "here";
+
+export const CHANNEL_MENTION_SUGGESTIONS: ReadonlyArray<{
+  annotation: string;
+  displayName: ChannelMentionMode;
+}> = [
+  {
+    displayName: "everyone",
+    annotation: "Notify everyone in this channel",
+  },
+  {
+    displayName: "here",
+    annotation: "Notify everyone online in this channel",
+  },
+];
+
+export function channelMentionModes(text: string): ChannelMentionMode[] {
+  return CHANNEL_MENTION_SUGGESTIONS.flatMap(({ displayName }) =>
+    hasMention(text, displayName) ? [displayName] : [],
+  );
+}
+
+export function getChannelMentionRecipient(tag: readonly string[]) {
+  if (
+    tag.length !== 4 ||
+    tag[0] !== "p" ||
+    !tag[1] ||
+    tag[2] !== "" ||
+    (tag[3] !== "buzz:audience:everyone" && tag[3] !== "buzz:audience:here")
+  ) {
+    return null;
+  }
+
+  return normalizePubkey(tag[1]);
+}
+
+export function isChannelMentionRecipientTag(tag: readonly string[]) {
+  return getChannelMentionRecipient(tag) !== null;
+}
+
+export function isChannelWideMentionEvent(tags: readonly string[][]) {
+  return tags.some(isChannelMentionRecipientTag);
+}
+
+export function getChannelMentionAudienceLimitError(recipientCount: number) {
+  return recipientCount > MAX_CHANNEL_MENTION_RECIPIENTS
+    ? `Channel-wide mentions support up to ${MAX_CHANNEL_MENTION_RECIPIENTS.toLocaleString()} recipients.`
+    : null;
+}
+
+export function hasChannelMentionForPubkey(
+  tags: readonly string[][],
+  pubkey: string,
+) {
+  const normalized = normalizePubkey(pubkey);
+  return (
+    normalized.length > 0 &&
+    tags.some((tag) => getChannelMentionRecipient(tag) === normalized)
+  );
+}
+
+export function buildChannelMentionTags(input: {
+  memberPubkeys: Iterable<string>;
+  originalText?: string;
+  presence?: PresenceLookup;
+  selfPubkey: string;
+  text: string;
+}): string[][] {
+  const modes = channelMentionModes(input.text);
+  if (modes.length === 0) return [];
+
+  const originalModes = new Set(channelMentionModes(input.originalText ?? ""));
+  const referenceTags = modes.map((mode) => [
+    CHANNEL_MENTION_REFERENCE_TAG,
+    mode,
+  ]);
+  const memberPubkeys = [
+    ...new Set([...input.memberPubkeys].map(normalizePubkey)),
+  ]
+    .filter(Boolean)
+    .filter((pubkey) => pubkey !== normalizePubkey(input.selfPubkey));
+
+  // @everyone is the superset. If both reserved mentions appear, one exact
+  // recipient snapshot is enough and avoids duplicate notification rows.
+  const notifyModes = modes.includes("everyone")
+    ? ["everyone" as const]
+    : modes;
+  const recipientTags = notifyModes.flatMap((mode) => {
+    if (originalModes.has(mode)) return [];
+    const recipients =
+      mode === "everyone"
+        ? memberPubkeys
+        : memberPubkeys.filter(
+            (pubkey) => input.presence?.[pubkey] === "online",
+          );
+    return recipients.map((pubkey) => [
+      "p",
+      pubkey,
+      "",
+      `${CHANNEL_MENTION_RECIPIENT_MARKER_PREFIX}${mode}`,
+    ]);
+  });
+
+  return [...referenceTags, ...recipientTags];
+}

--- a/desktop/src/features/messages/lib/flushMentionDebounce.ts
+++ b/desktop/src/features/messages/lib/flushMentionDebounce.ts
@@ -15,6 +15,7 @@ import {
   mapMentionCandidateToSuggestion,
   type MentionSuggestionCandidate,
 } from "./mentionSuggestionMapping";
+import { CHANNEL_MENTION_SUGGESTIONS } from "./channelMentions";
 
 type MentionCandidateWithUI = MentionCandidateForRanking &
   MentionSuggestionCandidate;
@@ -56,6 +57,21 @@ export function flushMentionDebounce<T extends MentionCandidateWithUI>(opts: {
 
   if (!mention || mention.query.length === 0) {
     return null;
+  }
+
+  const channelSuggestion = CHANNEL_MENTION_SUGGESTIONS.find(
+    ({ displayName }) => displayName.startsWith(mention.query.toLowerCase()),
+  );
+  if (channelSuggestion) {
+    return {
+      type: "match",
+      suggestion: {
+        ...channelSuggestion,
+        audience: channelSuggestion.displayName,
+        kind: "audience",
+      },
+      startIndex: mention.startIndex,
+    };
   }
 
   const ranked = rankMentionCandidates(

--- a/desktop/src/features/messages/lib/imetaMediaMarkdown.test.mjs
+++ b/desktop/src/features/messages/lib/imetaMediaMarkdown.test.mjs
@@ -666,6 +666,13 @@ const MENTION_REF = [
   "mention",
   "1111111111111111111111111111111111111111111111111111111111111111",
 ];
+const CHANNEL_MENTION_REF = ["buzz-audience-ref", "everyone"];
+const CHANNEL_MENTION_RECIPIENT = [
+  "p",
+  "2222222222222222222222222222222222222222222222222222222222222222",
+  "",
+  "buzz:audience:everyone",
+];
 
 test("splitOutgoingTags: undefined input yields three empty arrays", () => {
   assert.deepEqual(splitOutgoingTags(undefined), {
@@ -702,6 +709,20 @@ test("splitOutgoingTags: separates reference-only mention tags", () => {
   assert.deepEqual(mediaTags, [IMETA]);
   assert.deepEqual(emojiTags, [EMOJI_A]);
   assert.deepEqual(mentionTags, [MENTION_REF]);
+});
+
+test("splitOutgoingTags: routes validated channel mention metadata together", () => {
+  const { mediaTags, emojiTags, mentionTags } = splitOutgoingTags([
+    IMETA,
+    CHANNEL_MENTION_REF,
+    CHANNEL_MENTION_RECIPIENT,
+  ]);
+  assert.deepEqual(mediaTags, [IMETA]);
+  assert.deepEqual(emojiTags, []);
+  assert.deepEqual(mentionTags, [
+    CHANNEL_MENTION_REF,
+    CHANNEL_MENTION_RECIPIENT,
+  ]);
 });
 
 test("splitOutgoingTags: unknown prefixes stay with mediaTags (injection defense)", () => {

--- a/desktop/src/features/messages/lib/imetaMediaMarkdown.ts
+++ b/desktop/src/features/messages/lib/imetaMediaMarkdown.ts
@@ -366,7 +366,11 @@ export function splitOutgoingTags(tags: string[][] | undefined): {
   for (const tag of tags ?? []) {
     if (tag[0] === "emoji") {
       emojiTags.push(tag);
-    } else if (tag[0] === "mention") {
+    } else if (
+      tag[0] === "mention" ||
+      tag[0] === "buzz-audience-ref" ||
+      (tag[0] === "p" && tag[3]?.startsWith("buzz:audience:"))
+    ) {
       mentionTags.push(tag);
     } else {
       mediaTags.push(tag);

--- a/desktop/src/features/messages/lib/mentionCandidates.ts
+++ b/desktop/src/features/messages/lib/mentionCandidates.ts
@@ -9,6 +9,11 @@ export type TeamMentionMember = {
   pubkey?: string;
 };
 
+export type PersonaMentionTarget = {
+  displayName: string;
+  persona: AgentPersona;
+};
+
 export type MentionCandidate = {
   kind: "identity" | "persona" | "team";
   pubkey?: string;
@@ -129,4 +134,29 @@ export function formatTeamMention(
   members: readonly TeamMentionMember[],
 ) {
   return `${teamName}(${members.map((member) => `@${member.displayName}`).join(" ")}) `;
+}
+
+export function buildSearchableMentionNames(
+  reservedNames: readonly string[],
+  candidates: readonly Pick<
+    MentionCandidate,
+    "displayName" | "personaName" | "secondaryLabel"
+  >[],
+) {
+  const names = [...reservedNames];
+  const seen = new Set(names.map((name) => name.toLowerCase()));
+  for (const candidate of candidates) {
+    for (const name of [
+      candidate.displayName,
+      candidate.personaName,
+      candidate.secondaryLabel,
+    ]) {
+      const trimmed = name?.trim();
+      if (trimmed && !seen.has(trimmed.toLowerCase())) {
+        names.push(trimmed);
+        seen.add(trimmed.toLowerCase());
+      }
+    }
+  }
+  return names;
 }

--- a/desktop/src/features/messages/lib/useChannelMentions.ts
+++ b/desktop/src/features/messages/lib/useChannelMentions.ts
@@ -1,0 +1,93 @@
+import * as React from "react";
+
+import { usePresenceQuery } from "@/features/presence/hooks";
+import {
+  buildChannelMentionTags,
+  CHANNEL_MENTION_SUGGESTIONS,
+  channelMentionModes,
+  getChannelMentionAudienceLimitError,
+} from "./channelMentions";
+import type { MentionSuggestion } from "../ui/MentionAutocomplete";
+
+export function useChannelMentions(
+  memberPubkeys: ReadonlySet<string>,
+  membersResolved: boolean,
+  currentPubkey: string | null,
+) {
+  const memberPubkeyList = React.useMemo(
+    () => [...memberPubkeys],
+    [memberPubkeys],
+  );
+  const presenceQuery = usePresenceQuery(memberPubkeyList, {
+    enabled: membersResolved && memberPubkeyList.length > 0,
+  });
+
+  const suggestionsForQuery = React.useCallback(
+    (query: string): MentionSuggestion[] => {
+      const normalizedQuery = query.trim().toLowerCase();
+      return CHANNEL_MENTION_SUGGESTIONS.filter(({ displayName }) =>
+        displayName.startsWith(normalizedQuery),
+      ).map(({ annotation, displayName }) => ({
+        annotation,
+        audience: displayName,
+        displayName,
+        kind: "audience",
+      }));
+    },
+    [],
+  );
+
+  const extractChannelMentionTags = React.useCallback(
+    (text: string, originalText?: string): string[][] =>
+      buildChannelMentionTags({
+        memberPubkeys,
+        originalText,
+        presence: presenceQuery.data,
+        selfPubkey: currentPubkey ?? "",
+        text,
+      }),
+    [currentPubkey, memberPubkeys, presenceQuery.data],
+  );
+
+  const getChannelMentionError = React.useCallback(
+    (text: string, originalText?: string): string | null => {
+      const modes = channelMentionModes(text);
+      if (modes.length === 0) return null;
+      const originalModes = new Set(channelMentionModes(originalText ?? ""));
+      const notifyModes = modes.includes("everyone")
+        ? ["everyone" as const]
+        : modes;
+      const newNotifyModes = notifyModes.filter(
+        (mode) => !originalModes.has(mode),
+      );
+      if (newNotifyModes.length === 0) return null;
+      if (!membersResolved || !currentPubkey) {
+        return "Checking channel members. Try again in a moment.";
+      }
+      if (newNotifyModes.includes("here") && presenceQuery.data === undefined) {
+        return "Checking who is online. Try again in a moment.";
+      }
+      const self = currentPubkey.toLowerCase();
+      const recipientCount = newNotifyModes.includes("everyone")
+        ? memberPubkeyList.filter((pubkey) => pubkey !== self).length
+        : memberPubkeyList.filter(
+            (pubkey) =>
+              pubkey !== self && presenceQuery.data?.[pubkey] === "online",
+          ).length;
+      return getChannelMentionAudienceLimitError(recipientCount);
+    },
+    [currentPubkey, memberPubkeyList, membersResolved, presenceQuery.data],
+  );
+
+  const names = React.useMemo(
+    () => CHANNEL_MENTION_SUGGESTIONS.map(({ displayName }) => displayName),
+    [],
+  );
+
+  return {
+    extractChannelMentionTags,
+    getChannelMentionError,
+    names,
+    suggestionsForQuery,
+  };
+}

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -25,7 +25,6 @@ import {
 import { useIdentityQuery } from "@/shared/api/hooks";
 import type { AutocompleteEdit } from "./useRichTextEditor";
 import type {
-  AgentPersona,
   ChannelMember,
   ChannelType,
   UserSearchResult,
@@ -41,17 +40,16 @@ import { rankMentionCandidates } from "./mentionRanking";
 import { mapMentionCandidateToSuggestion } from "./mentionSuggestionMapping";
 import {
   buildTeamMentionCandidates,
+  buildSearchableMentionNames,
   formatTeamMention,
   globalSearchIdentityKey,
   type MentionCandidate,
   mentionCandidateLabel,
+  type PersonaMentionTarget,
 } from "./mentionCandidates";
+import { useChannelMentions } from "./useChannelMentions";
 const MENTION_DEBOUNCE_MS = 120;
 const MENTION_SUGGESTION_LIMIT = 50;
-export type PersonaMentionTarget = {
-  displayName: string;
-  persona: AgentPersona;
-};
 type UseMentionsOptions = {
   channelType?: ChannelType | null;
 };
@@ -92,7 +90,6 @@ export function useMentions(
   const mentionMapRef = React.useRef<Map<string, string>>(new Map());
   const personaMentionMapRef = React.useRef<Map<string, string>>(new Map());
   const previousSuggestionsRef = React.useRef<MentionSuggestion[]>([]);
-  void options?.channelType;
   const mentionSearchQuery = mentionQuery?.trim() ?? "";
   const canSearchGlobalPeople = mentionSearchQuery.length > 0;
   const identityQuery = useIdentityQuery();
@@ -236,6 +233,11 @@ export function useMentions(
     () =>
       new Set((members ?? []).map((member) => normalizePubkey(member.pubkey))),
     [members],
+  );
+  const channelMentions = useChannelMentions(
+    memberPubkeys,
+    members !== undefined,
+    currentPubkey,
   );
   const mentionCandidates = React.useMemo<MentionCandidate[]>(() => {
     const candidatesByPubkey = new Map<string, MentionCandidate>();
@@ -455,25 +457,11 @@ export function useMentions(
   });
 
   const searchableNames = React.useMemo<string[]>(() => {
-    const names: string[] = [];
-    const seen = new Set<string>();
-
-    for (const candidate of mentionCandidatesWithTeams) {
-      for (const name of [
-        candidate.displayName,
-        candidate.personaName,
-        candidate.secondaryLabel,
-      ]) {
-        const trimmed = name?.trim();
-        if (trimmed && !seen.has(trimmed.toLowerCase())) {
-          names.push(trimmed);
-          seen.add(trimmed.toLowerCase());
-        }
-      }
-    }
-
-    return names;
-  }, [mentionCandidatesWithTeams]);
+    return buildSearchableMentionNames(
+      channelMentions.names,
+      mentionCandidatesWithTeams,
+    );
+  }, [channelMentions.names, mentionCandidatesWithTeams]);
 
   const highlightNames = React.useMemo<string[]>(() => {
     const names: string[] = [];
@@ -535,7 +523,10 @@ export function useMentions(
       return [];
     }
 
-    return rankMentionCandidates(
+    const channelSuggestions =
+      channelMentions.suggestionsForQuery(mentionQuery);
+
+    const peopleSuggestions = rankMentionCandidates(
       mentionCandidatesWithTeams,
       mentionQuery,
       activePersonaIds,
@@ -554,8 +545,10 @@ export function useMentions(
           profiles,
         }),
       );
+    return [...channelSuggestions, ...peopleSuggestions];
   }, [
     activePersonaIds,
+    channelMentions.suggestionsForQuery,
     currentPubkey,
     mentionCandidatesWithTeams,
     mentionQuery,
@@ -625,6 +618,9 @@ export function useMentions(
       const personaMentions = personaMentionMapRef.current;
       const selectedMentions = teamMembers ?? [suggestion];
       for (const selected of selectedMentions) {
+        if (selected.kind === "audience") {
+          continue;
+        }
         if (selected.kind === "persona" && selected.personaId) {
           personaMentions.set(selected.displayName, selected.personaId);
           mentions.delete(selected.displayName);
@@ -971,10 +967,12 @@ export function useMentions(
   return {
     cancelMentionAutocomplete,
     clearMentions,
+    extractChannelMentionTags: channelMentions.extractChannelMentionTags,
     extractMentionPersonas,
     extractMentionPubkeys,
     getDraftMentionRefs,
     getMentionDisplayName,
+    getChannelMentionError: channelMentions.getChannelMentionError,
     handleMentionKeyDown,
     hasResolvedMembers: members !== undefined,
     insertMention,
@@ -983,7 +981,7 @@ export function useMentions(
     isAgentPubkey,
     isManagedAgentPubkey,
     isMentionOpen,
-    knownNames: highlightNames,
+    knownNames: ([] as string[]).concat(channelMentions.names, highlightNames),
     memberPubkeys,
     mentionSelectedIndex,
     registerMentionPubkey,

--- a/desktop/src/features/messages/ui/MentionAutocomplete.tsx
+++ b/desktop/src/features/messages/ui/MentionAutocomplete.tsx
@@ -18,7 +18,9 @@ export type MentionSuggestion = {
   personaId?: string;
   teamId?: string;
   teamMembers?: TeamMentionMember[];
-  kind?: "identity" | "persona" | "team";
+  kind?: "audience" | "identity" | "persona" | "team";
+  audience?: "everyone" | "here";
+  annotation?: string;
   displayName: string;
   avatarUrl?: string | null;
   isAgent?: boolean;
@@ -97,6 +99,7 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
         {suggestions.map((suggestion, index) => {
           const suggestionKey =
             suggestion.pubkey ??
+            (suggestion.audience ? `audience-${suggestion.audience}` : null) ??
             (suggestion.personaId ? `persona-${suggestion.personaId}` : null) ??
             (suggestion.teamId ? `team-${suggestion.teamId}` : null) ??
             suggestion.displayName;
@@ -125,7 +128,7 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
               tabIndex={-1}
               type="button"
             >
-              {suggestion.kind === "team" ? (
+              {suggestion.kind === "team" || suggestion.kind === "audience" ? (
                 <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
                   <Users aria-hidden="true" className="h-4 w-4" />
                 </span>
@@ -144,7 +147,8 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
                 >
                   {suggestion.displayName}
                 </span>
-                {suggestion.kind === "team" ||
+                {suggestion.kind === "audience" ||
+                suggestion.kind === "team" ||
                 suggestion.isAgent ||
                 suggestion.role ||
                 suggestion.ownerLabel ||
@@ -157,7 +161,9 @@ export const MentionAutocomplete = React.memo(function MentionAutocomplete({
                         : "text-muted-foreground",
                     )}
                   >
-                    {suggestion.kind === "team" ? (
+                    {suggestion.kind === "audience" ? (
+                      <span>{suggestion.annotation}</span>
+                    ) : suggestion.kind === "team" ? (
                       <span className="inline-flex shrink-0 items-center gap-1">
                         <Users aria-hidden="true" className="h-3.5 w-3.5" />
                         team · {suggestion.teamMembers?.length ?? 0} agents

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { EditorContent } from "@tiptap/react";
+import { toast } from "sonner";
 import { useChannelLinks } from "@/features/messages/lib/useChannelLinks";
 import { handleAgentSnapshotPaste } from "@/features/messages/lib/agentSnapshotClipboard";
 import { useComposerAutofocus } from "@/features/messages/lib/useComposerAutofocus";
@@ -21,15 +22,11 @@ import {
 } from "@/features/messages/lib/imetaMediaMarkdown";
 
 import { useAttachmentEditing } from "@/features/messages/lib/useAttachmentEditing";
-import {
-  type MediaUploadController,
-  useMediaUpload,
-} from "@/features/messages/lib/useMediaUpload";
+import { useMediaUpload } from "@/features/messages/lib/useMediaUpload";
 import { useMentions } from "@/features/messages/lib/useMentions";
 import { diffAddedMentionPubkeys } from "@/features/messages/lib/threading";
 import { getPersistentAgentAudienceScope } from "@/features/messages/lib/persistentAgentAudience";
 import { useIdentityQuery } from "@/shared/api/hooks";
-import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import {
   hasMentionClipboardHtml,
   normalizeMentionClipboardHtml,
@@ -45,7 +42,6 @@ import { useComposerSpoilerParticles } from "@/features/messages/lib/useComposer
 import { useTypingBroadcast } from "@/features/messages/useTypingBroadcast";
 import { getBuzzCodeBlockClipboardText } from "@/shared/lib/codeBlockClipboard";
 import { cn } from "@/shared/lib/cn";
-import type { ChannelType } from "@/shared/api/types";
 import { ChannelAutocomplete } from "./ChannelAutocomplete";
 import { ComposerReplyEditBanner } from "./ComposerReplyEditBanner";
 import { ComposerAttachments, DropZoneOverlay } from "./ComposerAttachments";
@@ -60,95 +56,7 @@ import { useMentionSendFlow } from "./useMentionSendFlow";
 import { usePersistentAgentMentionHydration } from "./usePersistentAgentMentionHydration";
 import { useComposerContentState } from "./useComposerContentState";
 import { useDraftPersistLifecycle } from "./useDraftPersistSnapshot";
-
-type MessageComposerAudienceContext = {
-  type: "thread";
-  threadRootId: string;
-  initialAgentPubkeys?: readonly string[];
-};
-type MessageComposerProps = {
-  audienceContext?: MessageComposerAudienceContext | null;
-  channelId?: string | null;
-  channelName: string;
-  channelType?: ChannelType | null;
-  containerClassName?: string;
-  disabled?: boolean;
-  draftKey?: string;
-  /**
-   * When provided, the composer fires `submitMessage` once on mount after
-   * the draft matching this key has been loaded into the editor. This powers
-   * the "Send message" confirm-dialog flow in the Drafts panel. The callback
-   * `onAutoSubmitComplete` must clear the trigger (e.g. remove `?autoSend`
-   * from the URL) — it is called synchronously before `submitMessage` fires
-   * so the param is gone before any navigation the send might cause.
-   *
-   * Fires at most once per mount: a stable key value that persists across
-   * re-renders does NOT re-fire.
-   */
-  autoSubmitDraftKey?: string | null;
-  /** Called when the auto-submit fires so the parent can clear the trigger. */
-  onAutoSubmitComplete?: () => void;
-  editTarget?: {
-    author: string;
-    body: string;
-    id: string;
-    /**
-     * NIP-92 imeta attachments on the original event, in tag order. Loaded
-     * into the composer's pending-imeta state on edit-open so the user sees
-     * them as removable thumbnails (just like the send path) and can add
-     * more. The submit path emits a fresh full imeta tag set on the edit
-     * event; the receiver overlays it.
-     */
-    imetaMedia?: ImetaMedia[];
-  } | null;
-  isSending?: boolean;
-  mediaController?: MediaUploadController;
-  onCancelEdit?: () => void;
-  onCancelReply?: () => void;
-  /**
-   * Invoked when the user presses ↑ in an empty composer that is not already
-   * in edit mode. The owner should locate the most recent message authored by
-   * the current user within this composer's scope (main timeline, DM, or
-   * thread) and enter edit mode for it. Return `true` if a target was found
-   * and edit mode was entered, so the composer can swallow the keystroke;
-   * return `false` to let the arrow key fall through normally.
-   */
-  onEditLastOwnMessage?: () => boolean;
-  onEditSave?: (
-    content: string,
-    mediaTags?: string[][],
-    mentionPubkeys?: string[],
-  ) => Promise<void>;
-  /** Captures send context synchronously before awaits can change navigation. */
-  onCaptureSendContext?: () => {
-    parentEventId: string | null;
-    threadHeadId: string | null;
-  } | null;
-  /** Resolves the channel required to prepare mentions before sending. */
-  onPrepareSendChannel?: (pubkeys?: string[]) => Promise<string | null>;
-  onPreparingMentionSendChange?: (isPreparing: boolean) => void;
-  onSend: (
-    content: string,
-    mentionPubkeys: string[],
-    mediaTags?: string[][],
-    channelId?: string | null,
-    threadContext?: {
-      parentEventId: string | null;
-      threadHeadId: string | null;
-    } | null,
-  ) => Promise<void>;
-  placeholder?: string;
-  profiles?: UserProfileLookup;
-  replyTarget?: {
-    author: string;
-    body: string;
-    id: string;
-  } | null;
-  showTopBorder?: boolean;
-  toolbarExtraActions?: React.ReactNode;
-  typingParentEventId?: string | null;
-  typingRootEventId?: string | null;
-};
+import type { MessageComposerProps } from "./messageComposerTypes";
 
 function MessageComposerImpl({
   audienceContext = null,
@@ -622,18 +530,30 @@ function MessageComposerImpl({
       // NIP-30: attach `["emoji", shortcode, url]` tags for custom emoji in the
       // edited body, exactly like the send path. Without this an edited message
       // ships with no emoji tags, so the receiver can't resolve a `:shortcode:`
-      // and renders the literal text. `?? []` preserves edit semantics (a
-      // defined-but-empty media set means "wipe attachments").
-      const outgoingTags =
+      // and renders the literal text. Keep channel-mention metadata in sync too.
+      const baseOutgoingTags =
         mergeOutgoingTags(
           mediaTags,
           buildCustomEmojiTags(finalContent, customEmoji),
         ) ?? [];
+      const channelMentionError = mentions.getChannelMentionError(
+        finalContent,
+        editTargetRef.current.body,
+      );
+      if (channelMentionError) {
+        toast.error(channelMentionError);
+        return;
+      }
+      const channelMentionTags = mentions.extractChannelMentionTags(
+        finalContent,
+        editTargetRef.current.body,
+      );
+      const outgoingTags = [...baseOutgoingTags, ...channelMentionTags];
 
       // Notify only mentions this edit *newly adds* (see
       // diffAddedMentionPubkeys): a typo-fix edit that leaves the mention set
-      // unchanged emits no `p` tags and re-wakes nobody. Computed before the
-      // composer state is cleared below.
+      // unchanged emits no direct `p` tags and re-wakes nobody. Computed before
+      // the composer state is cleared below.
       const addedMentionPubkeys = diffAddedMentionPubkeys(
         extractMentionPubkeysRef.current(editTargetRef.current.body),
         extractMentionPubkeysRef.current(finalContent),
@@ -719,6 +639,8 @@ function MessageComposerImpl({
     mentionSendFlow.isPreparingMentionSend,
     mentionSendFlow.sendMessageWithMentionFlow,
     mentions.clearMentions,
+    mentions.extractChannelMentionTags,
+    mentions.getChannelMentionError,
     richText.clearContent,
     richText.setContent,
     setComposerContent,

--- a/desktop/src/features/messages/ui/messageComposerTypes.ts
+++ b/desktop/src/features/messages/ui/messageComposerTypes.ts
@@ -1,0 +1,96 @@
+import type * as React from "react";
+
+import type { MediaUploadController } from "@/features/messages/lib/useMediaUpload";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import type { ChannelType } from "@/shared/api/types";
+import type { ImetaMedia } from "@/features/messages/lib/imetaMediaMarkdown";
+
+type MessageComposerAudienceContext = {
+  type: "thread";
+  threadRootId: string;
+  initialAgentPubkeys?: readonly string[];
+};
+
+export type MessageComposerProps = {
+  audienceContext?: MessageComposerAudienceContext | null;
+  channelId?: string | null;
+  channelName: string;
+  channelType?: ChannelType | null;
+  containerClassName?: string;
+  disabled?: boolean;
+  draftKey?: string;
+  /**
+   * When provided, the composer fires `submitMessage` once on mount after
+   * the draft matching this key has been loaded into the editor. This powers
+   * the "Send message" confirm-dialog flow in the Drafts panel. The callback
+   * `onAutoSubmitComplete` must clear the trigger (e.g. remove `?autoSend`
+   * from the URL) — it is called synchronously before `submitMessage` fires
+   * so the param is gone before any navigation the send might cause.
+   *
+   * Fires at most once per mount: a stable key value that persists across
+   * re-renders does NOT re-fire.
+   */
+  autoSubmitDraftKey?: string | null;
+  /** Called when the auto-submit fires so the parent can clear the trigger. */
+  onAutoSubmitComplete?: () => void;
+  editTarget?: {
+    author: string;
+    body: string;
+    id: string;
+    /**
+     * NIP-92 imeta attachments on the original event, in tag order. Loaded
+     * into the composer's pending-imeta state on edit-open so the user sees
+     * them as removable thumbnails (just like the send path) and can add
+     * more. The submit path emits a fresh full imeta tag set on the edit
+     * event; the receiver overlays it.
+     */
+    imetaMedia?: ImetaMedia[];
+  } | null;
+  isSending?: boolean;
+  mediaController?: MediaUploadController;
+  onCancelEdit?: () => void;
+  onCancelReply?: () => void;
+  /**
+   * Invoked when the user presses ↑ in an empty composer that is not already
+   * in edit mode. The owner should locate the most recent message authored by
+   * the current user within this composer's scope (main timeline, DM, or
+   * thread) and enter edit mode for it. Return `true` if a target was found
+   * and edit mode was entered, so the composer can swallow the keystroke;
+   * return `false` to let the arrow key fall through normally.
+   */
+  onEditLastOwnMessage?: () => boolean;
+  onEditSave?: (
+    content: string,
+    mediaTags?: string[][],
+    mentionPubkeys?: string[],
+  ) => Promise<void>;
+  /** Captures send context synchronously before awaits can change navigation. */
+  onCaptureSendContext?: () => {
+    parentEventId: string | null;
+    threadHeadId: string | null;
+  } | null;
+  /** Resolves the channel required to prepare mentions before sending. */
+  onPrepareSendChannel?: (pubkeys?: string[]) => Promise<string | null>;
+  onPreparingMentionSendChange?: (isPreparing: boolean) => void;
+  onSend: (
+    content: string,
+    mentionPubkeys: string[],
+    mediaTags?: string[][],
+    channelId?: string | null,
+    threadContext?: {
+      parentEventId: string | null;
+      threadHeadId: string | null;
+    } | null,
+  ) => Promise<void>;
+  placeholder?: string;
+  profiles?: UserProfileLookup;
+  replyTarget?: {
+    author: string;
+    body: string;
+    id: string;
+  } | null;
+  showTopBorder?: boolean;
+  toolbarExtraActions?: React.ReactNode;
+  typingParentEventId?: string | null;
+  typingRootEventId?: string | null;
+};

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -665,6 +665,13 @@ export function useMentionSendFlow({
           return;
         }
 
+        const channelMentionError = mentions.getChannelMentionError(trimmed);
+        if (channelMentionError) {
+          setNonMemberPromptError(channelMentionError);
+          toast.error(channelMentionError);
+          return;
+        }
+
         let effectiveChannelId = capturedChannelId;
         if (!effectiveChannelId && onPrepareSendChannel) {
           effectiveChannelId = await onPrepareSendChannel();
@@ -708,10 +715,15 @@ export function useMentionSendFlow({
           pendingImeta,
           spoileredAttachmentUrls,
         );
-        const outgoingTags = mergeOutgoingTags(
+        const baseOutgoingTags = mergeOutgoingTags(
           mediaTags,
           buildCustomEmojiTags(finalContent, customEmoji),
         );
+        const channelMentionTags = mentions.extractChannelMentionTags(trimmed);
+        const outgoingTags =
+          baseOutgoingTags || channelMentionTags.length > 0
+            ? [...(baseOutgoingTags ?? []), ...channelMentionTags]
+            : undefined;
         const nonMemberPubkeys = getNonMemberMentionPubkeys(pubkeys);
         let promptNonMemberPubkeys = nonMemberPubkeys.filter(
           (pubkey) =>
@@ -773,6 +785,8 @@ export function useMentionSendFlow({
       getNonMemberMentionPubkeys,
       getDmThreadAgentMentionError,
       mentions.extractMentionPubkeys,
+      mentions.extractChannelMentionTags,
+      mentions.getChannelMentionError,
       mentions.isAgentPubkey,
       mentions.isManagedAgentPubkey,
       onPrepareSendChannel,

--- a/desktop/src/features/notifications/hooks.ts
+++ b/desktop/src/features/notifications/hooks.ts
@@ -4,6 +4,7 @@ import { useHomeFeedQuery } from "@/features/home/hooks";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel, FeedItem, HomeFeedResponse } from "@/shared/api/types";
+import { isChannelWideMentionEvent } from "@/features/messages/lib/channelMentions";
 import {
   getDesktopNotificationPermissionState,
   requestDesktopNotificationAccess,
@@ -442,7 +443,7 @@ export function useHomeFeedNotificationState(
       if (
         item.channelId &&
         mutedChannelIds?.has(item.channelId) &&
-        item.category !== "mention"
+        (item.category !== "mention" || isChannelWideMentionEvent(item.tags))
       ) {
         continue;
       }

--- a/desktop/src/features/notifications/lib/shouldNotify.ts
+++ b/desktop/src/features/notifications/lib/shouldNotify.ts
@@ -3,6 +3,10 @@ import {
   getThreadReference,
   isBroadcastReply,
 } from "@/features/messages/lib/threading";
+import {
+  hasChannelMentionForPubkey,
+  isChannelMentionRecipientTag,
+} from "@/features/messages/lib/channelMentions";
 
 export function hasMentionForEvent(
   event: RelayEvent,
@@ -11,8 +15,28 @@ export function hasMentionForEvent(
   return (
     currentPubkey.length > 0 &&
     event.tags.some(
-      (tag) => tag[0] === "p" && tag[1]?.toLowerCase() === currentPubkey,
+      (tag) =>
+        tag[0] === "p" &&
+        !isChannelMentionRecipientTag(tag) &&
+        tag[1]?.toLowerCase() === currentPubkey,
     )
+  );
+}
+
+export function hasChannelMentionForEvent(
+  event: RelayEvent,
+  currentPubkey: string,
+): boolean {
+  return hasChannelMentionForPubkey(event.tags, currentPubkey);
+}
+
+export function hasAnyMentionForEvent(
+  event: RelayEvent,
+  currentPubkey: string,
+): boolean {
+  return (
+    hasMentionForEvent(event, currentPubkey) ||
+    hasChannelMentionForEvent(event, currentPubkey)
   );
 }
 
@@ -52,6 +76,10 @@ export function shouldNotifyForEvent(
     return false;
   }
 
+  if (hasChannelMentionForEvent(event, currentPubkey)) {
+    return true;
+  }
+
   if (parentId === null) {
     return true;
   }
@@ -79,12 +107,7 @@ export function isHighPriorityEventForUser(
   event: RelayEvent,
   currentPubkey: string,
 ): boolean {
-  if (
-    currentPubkey.length > 0 &&
-    event.tags.some(
-      (tag) => tag[0] === "p" && tag[1]?.toLowerCase() === currentPubkey,
-    )
-  ) {
+  if (hasAnyMentionForEvent(event, currentPubkey)) {
     return true;
   }
   if (isBroadcastReply(event.tags)) {

--- a/desktop/src/features/notifications/lib/shouldNotifyChannelMutes.test.mjs
+++ b/desktop/src/features/notifications/lib/shouldNotifyChannelMutes.test.mjs
@@ -28,6 +28,12 @@ function makeEvent(tags = [], overrides = {}) {
 const rootTag = (id) => ["e", id, "", "root"];
 const replyTag = (id) => ["e", id, "", "reply"];
 const pTag = (pubkey) => ["p", pubkey];
+const channelMentionTag = (pubkey, mode = "everyone") => [
+  "p",
+  pubkey,
+  "",
+  `buzz:audience:${mode}`,
+];
 const broadcastTag = () => ["broadcast", "1"];
 const hTag = (channelId) => ["h", channelId];
 
@@ -78,6 +84,37 @@ test("mention in muted channel still notifies (mention fires before mute check)"
       followedRootIds: EMPTY,
       authoredRootIds: EMPTY,
       mutedChannelIds: new Set([CHANNEL_ID]),
+      channelId: CHANNEL_ID,
+    }),
+    true,
+  );
+});
+
+test("channel-wide mention in muted channel is suppressed", () => {
+  const event = makeEvent([hTag(CHANNEL_ID), channelMentionTag(PUBKEY)]);
+  assert.equal(hasMentionForEvent(event, PUBKEY), false);
+  assert.equal(
+    shouldNotifyForEvent(event, PUBKEY, {
+      participatedRootIds: EMPTY,
+      followedRootIds: EMPTY,
+      authoredRootIds: EMPTY,
+      mutedChannelIds: new Set([CHANNEL_ID]),
+      channelId: CHANNEL_ID,
+    }),
+    false,
+  );
+});
+
+test("channel-wide mention in an unmuted channel notifies", () => {
+  const event = makeEvent([
+    hTag(CHANNEL_ID),
+    channelMentionTag(PUBKEY, "here"),
+  ]);
+  assert.equal(
+    shouldNotifyForEvent(event, PUBKEY, {
+      participatedRootIds: EMPTY,
+      followedRootIds: EMPTY,
+      authoredRootIds: EMPTY,
       channelId: CHANNEL_ID,
     }),
     true,

--- a/desktop/src/features/notifications/use-feed-desktop-notifications.ts
+++ b/desktop/src/features/notifications/use-feed-desktop-notifications.ts
@@ -25,6 +25,7 @@ import {
   slotForFeedKind,
 } from "./lib/sound";
 import type { NotificationSettings } from "./hooks";
+import { isChannelWideMentionEvent } from "@/features/messages/lib/channelMentions";
 
 const HOME_FEED_SEEN_STORAGE_KEY = "buzz-home-feed-seen.v1";
 const HOME_FEED_SEEN_MAX_ITEMS = 500;
@@ -172,7 +173,8 @@ export function useFeedDesktopNotifications(
             (item) =>
               !item.channelId ||
               !mutedChannelIds?.has(item.channelId) ||
-              item.category === "mention",
+              (item.category === "mention" &&
+                !isChannelWideMentionEvent(item.tags)),
           )
       : [];
 

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -577,6 +577,7 @@ export async function editMessage(
   mediaTags?: string[][],
   emojiTags?: string[][],
   mentionPubkeys?: string[],
+  mentionTags?: string[][],
 ): Promise<void> {
   await invokeTauri("edit_message", {
     channelId,
@@ -585,6 +586,7 @@ export async function editMessage(
     mediaTags: mediaTags ?? [],
     emojiTags: emojiTags ?? [],
     mentionPubkeys: mentionPubkeys ?? null,
+    mentionTags: mentionTags ?? [],
   });
 }
 

--- a/desktop/src/shared/lib/resolveMentionNames.test.mjs
+++ b/desktop/src/shared/lib/resolveMentionNames.test.mjs
@@ -110,6 +110,16 @@ test("includes aliases from mention reference tags", () => {
   });
 });
 
+test("channel-wide reference tags render without recipient profiles", () => {
+  assert.deepEqual(
+    resolveMentionProps([["buzz-audience-ref", "everyone"]], undefined),
+    {
+      mentionNames: ["everyone"],
+      mentionPubkeysByName: undefined,
+    },
+  );
+});
+
 test("every rendered name resolves to a pubkey (outputs stay in sync)", () => {
   const tags = [
     ["p", PUBKEY],

--- a/desktop/src/shared/lib/resolveMentionNames.ts
+++ b/desktop/src/shared/lib/resolveMentionNames.ts
@@ -65,7 +65,7 @@ export function resolveMentionProps(
   tags: string[][] | undefined,
   profiles: Record<string, UserProfileSummary> | undefined,
 ): ResolvedMentionProps {
-  if (!profiles || !tags) {
+  if (!tags) {
     return { mentionNames: undefined, mentionPubkeysByName: undefined };
   }
 
@@ -73,8 +73,16 @@ export function resolveMentionProps(
   const pubkeysByName: Record<string, string> = {};
 
   for (const tag of tags) {
+    if (
+      tag[0] === "buzz-audience-ref" &&
+      (tag[1] === "everyone" || tag[1] === "here")
+    ) {
+      names.add(tag[1]);
+      continue;
+    }
+
     const pubkey = getMentionTagPubkey(tag);
-    if (!pubkey) {
+    if (!pubkey || !profiles) {
       continue;
     }
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -7668,6 +7668,7 @@ async function handleSendChannelMessage(
     mentionPubkeys?: string[];
     mediaTags?: string[][] | null;
     emojiTags?: string[][] | null;
+    mentionTags?: string[][] | null;
   },
   config: E2eConfig | undefined,
 ): Promise<RawSendChannelMessageResponse> {
@@ -7688,7 +7689,8 @@ async function handleSendChannelMessage(
   // emoji renderer keeps resolving `:shortcode:` after the round-trip.
   const emojiTags = args.emojiTags ?? [];
   // Both kinds end up on the stored event's tag set, just like the real relay.
-  const extraTags = [...mediaTags, ...emojiTags];
+  const mentionTags = args.mentionTags ?? [];
+  const extraTags = [...mediaTags, ...emojiTags, ...mentionTags];
   const identity = getIdentity(config);
   if (!identity) {
     const createdAt = Math.floor(Date.now() / 1000);
@@ -7909,12 +7911,14 @@ async function handleEditMessage(
     content: string;
     mediaTags?: string[][] | null;
     emojiTags?: string[][] | null;
+    mentionTags?: string[][] | null;
   },
   config: E2eConfig | undefined,
 ): Promise<void> {
   const mediaTags = args.mediaTags ?? [];
   const emojiTags = args.emojiTags ?? [];
-  const extraTags = [...mediaTags, ...emojiTags];
+  const mentionTags = args.mentionTags ?? [];
+  const extraTags = [...mediaTags, ...emojiTags, ...mentionTags];
   const tags = [["h", args.channelId], ["e", args.eventId], ...extraTags];
   const content = args.content.trim();
   const identity = getIdentity(config);

--- a/desktop/tests/e2e/channel-mentions.spec.ts
+++ b/desktop/tests/e2e/channel-mentions.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const MIRA_PUBKEY =
+  "8f83d6b7f3d74f7d933ae3a54dd8c6cc85c7f98e531c16e5a827b953441a8d67";
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+});
+
+async function lastChannelMentionTags(page: Page) {
+  return page.evaluate(() => {
+    const entries =
+      (
+        window as Window & {
+          __BUZZ_E2E_COMMAND_PAYLOADS__?: Array<{
+            command: string;
+            payload: { mentionTags?: string[][] | null };
+          }>;
+        }
+      ).__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [];
+    return (
+      entries.findLast((entry) => entry.command === "send_channel_message")
+        ?.payload.mentionTags ?? null
+    );
+  });
+}
+
+test("@everyone autocomplete explains and sends an exact standard p-tag snapshot", async ({
+  page,
+}) => {
+  const input = page.getByTestId("message-input");
+  await input.fill("Ship it @ev");
+
+  const suggestion = page.getByTestId("mention-suggestion-audience-everyone");
+  await expect(suggestion).toContainText("everyone");
+  await expect(suggestion).toContainText("Notify everyone in this channel");
+  await suggestion.click();
+  await expect(input).toHaveText("Ship it @everyone ");
+
+  await page.getByTestId("send-message").click();
+  await expect(input).toBeEmpty();
+
+  await expect
+    .poll(() => lastChannelMentionTags(page))
+    .toEqual([
+      ["buzz-audience-ref", "everyone"],
+      ["p", TEST_IDENTITIES.alice.pubkey, "", "buzz:audience:everyone"],
+      ["p", TEST_IDENTITIES.bob.pubkey, "", "buzz:audience:everyone"],
+      ["p", MIRA_PUBKEY, "", "buzz:audience:everyone"],
+    ]);
+});
+
+test("@here snapshots only members whose active presence is online", async ({
+  page,
+}) => {
+  const input = page.getByTestId("message-input");
+  await input.fill("Online folks @he");
+
+  const suggestion = page.getByTestId("mention-suggestion-audience-here");
+  await expect(suggestion).toContainText(
+    "Notify everyone online in this channel",
+  );
+  await suggestion.click();
+  await page.getByTestId("send-message").click();
+
+  await expect
+    .poll(() => lastChannelMentionTags(page))
+    .toEqual([
+      ["buzz-audience-ref", "here"],
+      ["p", TEST_IDENTITIES.alice.pubkey, "", "buzz:audience:here"],
+      ["p", MIRA_PUBKEY, "", "buzz:audience:here"],
+    ]);
+});


### PR DESCRIPTION
## What changed

- Add channel-wide `@everyone` and active-presence `@here` mentions for any channel member.
- Respect channel mutes across live notifications, unread state, optimistic sends, edits, and history.
- Preserve Nostr interoperability with standard recipient `p` tags plus a validated Buzz audience marker.
- Add autocomplete entries using the established mention-row styling and the copy “Notify everyone in this channel” / “Notify everyone online in this channel.”
- Enforce a 4,000-recipient ceiling and validate sender/recipient membership without truncating large channel rosters.

## Why

Channel members need an explicit way to notify everyone or only currently online members without bypassing mute preferences. The initial implementation exposed a hidden 1,000-row database roster limit beneath the advertised 4,000-recipient contract; this version removes that truncation and uses direct, bounded membership checks.

## Validation

- Desktop tests: 3,192/3,192 passed.
- Desktop typecheck, repository checks, and production build passed.
- Focused Playwright channel-mention flow: 2/2 passed.
- Core audience tests: 2/2 passed.
- Tauri audience tests: 2/2 passed; compile check passed.
- Relay 4,002-member roster regression: 1/1 passed; DB and relay compile checks passed.
- Rust formatting and `git diff --check` passed.
- Final code/UI review passed.

The Postgres-backed 4,002-member integration regression compiles but could not execute locally because no Postgres or Docker daemon was available. It must pass in CI before merge.

## Visuals

- [`@everyone` autocomplete row](https://flint.communities.buzz.xyz/media/50ae89b6183b58afcb7e62c59fb7ede4f4d837950ac6c3c757efa6ea3dc77383.png)
- [`@here` autocomplete row](https://flint.communities.buzz.xyz/media/77e90f327fb1e50bcd693a63453ea262cb0446efad64a365478439d598cd6569.png)
