### PR TITLE
refactor(desktop): rename agent config files to agent-config family

### DIFF
--- a/desktop/src/features/agents/ui/AgentAiDefaults.tsx
+++ b/desktop/src/features/agents/ui/AgentAiDefaults.tsx
@@ -1,6 +1,6 @@
 import type * as React from "react";
 import type { InheritedDefault } from "./bakedEnvHelpers";
-import { getPersonaProviderOptions } from "./personaDialogPickers";
+import { getPersonaProviderOptions } from "./agentConfigOptions";
 import { Button } from "@/shared/ui/button";
 
 function providerLabel(providerId: string) {

--- a/desktop/src/features/agents/ui/AgentConfigFields.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigFields.tsx
@@ -1,7 +1,7 @@
 /**
  * Controlled field group for global agent config (provider, model, effort, env vars).
  *
- * Used by GlobalAgentConfigSettingsCard (settings panel) and AgentDefaultsSection
+ * Used by AgentDefaultsSettingsCard (settings panel) and AgentDefaultsSection
  * (onboarding setup step). The parent manages load/save state; this component is
  * purely presentational and calls onConfigChange on every user edit.
  */
@@ -28,11 +28,11 @@ import {
   getProviderApiKeyEnvVar,
   requiredCredentialEnvKeys,
   runtimeSupportsLlmProviderSelection,
-} from "@/features/agents/ui/personaDialogPickers";
+} from "@/features/agents/ui/agentConfigOptions";
 import {
   AgentDropdownSelect,
   AgentModelField,
-} from "@/features/agents/ui/personaProviderModelFields";
+} from "@/features/agents/ui/agentConfigControls";
 import { PersonaProviderApiKeyField } from "@/features/agents/ui/PersonaProviderApiKeyField";
 import { usePersonaModelDiscovery } from "@/features/agents/ui/usePersonaModelDiscovery";
 import {
@@ -61,7 +61,7 @@ const BAKED_STRUCTURED_KEYS = new Set([
   BUZZ_AGENT_THINKING_EFFORT,
 ]);
 
-export type GlobalAgentConfigFieldsProps = {
+export type AgentConfigFieldsProps = {
   bakedEnv: BakedEnvEntry[];
   selectedRuntime: AcpRuntimeCatalogEntry | undefined;
   config: GlobalAgentConfig;
@@ -96,7 +96,7 @@ export type GlobalAgentConfigFieldsProps = {
   useChevronSelectIcon?: boolean;
 };
 
-export function GlobalAgentConfigFields({
+export function AgentConfigFields({
   bakedEnv,
   selectedRuntime,
   config,
@@ -129,7 +129,7 @@ export function GlobalAgentConfigFields({
   unstyled = false,
   useCustomSelect = false,
   useChevronSelectIcon = false,
-}: GlobalAgentConfigFieldsProps) {
+}: AgentConfigFieldsProps) {
   const bakedProvider = React.useMemo(
     () => bakedEnv.find((e) => e.key === "BUZZ_AGENT_PROVIDER")?.value ?? null,
     [bakedEnv],

--- a/desktop/src/features/agents/ui/AgentConfigPanel.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigPanel.tsx
@@ -25,7 +25,7 @@ import type {
   NormalizedConfig,
   NormalizedField,
 } from "@/shared/api/types";
-import { providerDisplayLabel } from "./personaDialogPickers";
+import { providerDisplayLabel } from "./agentConfigOptions";
 
 type Props = {
   pubkey: string;

--- a/desktop/src/features/agents/ui/AgentDefaultsDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefaultsDialog.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 
 import {
-  GlobalAgentConfigEditor,
+  AgentDefaultsEditor,
   type GlobalAgentConfigSaveResult,
-} from "./GlobalAgentConfigEditor";
+} from "./AgentDefaultsEditor";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -23,7 +23,7 @@ import {
   DialogTitle,
 } from "@/shared/ui/dialog";
 
-export function AgentAiDefaultsDialog({
+export function AgentDefaultsDialog({
   open,
   onOpenChange,
   returnFocusRef,
@@ -93,7 +93,7 @@ export function AgentAiDefaultsDialog({
               running agents.
             </DialogDescription>
           </DialogHeader>
-          <GlobalAgentConfigEditor
+          <AgentDefaultsEditor
             onDirtyChange={setDirty}
             onSaveSuccess={handleSaveSuccess}
             onSavingChange={setSaving}

--- a/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
+++ b/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
@@ -21,9 +21,9 @@ import { getBakedBuildEnv, type BakedEnvEntry } from "@/shared/api/tauri";
 import { globalAgentConfigQueryKey } from "@/features/agents/useGlobalAgentConfig";
 import { useAcpRuntimesQuery } from "@/features/agents/hooks";
 import {
-  GlobalAgentConfigFields,
+  AgentConfigFields,
   EMPTY_GLOBAL_CONFIG,
-} from "@/features/agents/ui/GlobalAgentConfigFields";
+} from "@/features/agents/ui/AgentConfigFields";
 import { Button } from "@/shared/ui/button";
 
 type SaveState = "idle" | "saving" | "saved" | "error";
@@ -32,19 +32,19 @@ export type GlobalAgentConfigSaveResult = Awaited<
   ReturnType<typeof setGlobalAgentConfig>
 >;
 
-type GlobalAgentConfigEditorProps = {
+type AgentDefaultsEditorProps = {
   onDirtyChange?: (dirty: boolean) => void;
   onSaveSuccess?: (result: GlobalAgentConfigSaveResult) => void;
   onSavingChange?: (saving: boolean) => void;
   secondaryAction?: React.ReactNode;
 };
 
-export function GlobalAgentConfigEditor({
+export function AgentDefaultsEditor({
   onDirtyChange,
   onSaveSuccess,
   onSavingChange,
   secondaryAction,
-}: GlobalAgentConfigEditorProps) {
+}: AgentDefaultsEditorProps) {
   const [config, setConfig] =
     React.useState<GlobalAgentConfig>(EMPTY_GLOBAL_CONFIG);
   const configRef = React.useRef(config);
@@ -178,7 +178,7 @@ export function GlobalAgentConfigEditor({
           Couldn't load agent defaults. Restart the app to try again.
         </div>
       ) : (
-        <GlobalAgentConfigFields
+        <AgentConfigFields
           bakedEnv={bakedEnv}
           selectedRuntime={buzzAgentRuntime}
           config={config}

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -51,8 +51,8 @@ import {
   PERSONA_LABEL_OPTIONAL_CLASS,
   shouldClearKnownModelForSelectionScope,
   sortPersonaRuntimes,
-} from "./personaDialogPickers";
-import { RequiredFieldLabel } from "./personaProviderModelFields";
+} from "./agentConfigOptions";
+import { RequiredFieldLabel } from "./agentConfigControls";
 import {
   modelDropdownOptions as buildModelDropdownOptions,
   relayMeshModelPickerState,
@@ -70,7 +70,7 @@ import {
 import { useBakedBuildEnvKeysQuery, useRuntimeFileConfigQuery } from "../hooks";
 import { useAgentDialogDefaults } from "./useAgentDialogDefaults";
 import { AgentAiDefaultsNotice } from "./AgentAiDefaults";
-import { AgentAiDefaultsDialog } from "./AgentAiDefaultsDialog";
+import { AgentDefaultsDialog } from "./AgentDefaultsDialog";
 import {
   AgentAiConfigurationModeField,
   HarnessModelDefaultNotice,
@@ -967,7 +967,7 @@ export function AgentDefinitionDialog({
               )
             ) : null}
 
-            <AgentAiDefaultsDialog
+            <AgentDefaultsDialog
               onOpenChange={setAiDefaultsOpen}
               open={runtimeCanChooseLlmProvider && aiDefaultsOpen}
               returnFocusRef={aiDefaultsTriggerRef}

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -43,7 +43,7 @@ import {
   shouldClearKnownModelForSelectionScope,
   sortPersonaRuntimes,
   type PersonaDropdownOption,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 import {
   modelDropdownOptions as buildModelDropdownOptions,
   relayMeshModelPickerState,
@@ -76,10 +76,10 @@ import {
   getBakedModelInheritLabel,
   getBakedProviderInheritLabel,
 } from "./bakedEnvHelpers";
-import { getProviderApiKeyEnvVar } from "./personaDialogPickers";
+import { getProviderApiKeyEnvVar } from "./agentConfigOptions";
 import { useAgentDialogDefaults } from "./useAgentDialogDefaults";
 import { AgentAiDefaultsNotice } from "./AgentAiDefaults";
-import { AgentAiDefaultsDialog } from "./AgentAiDefaultsDialog";
+import { AgentDefaultsDialog } from "./AgentDefaultsDialog";
 import { useProviderApiKeyFieldState } from "./providerApiKeyFieldState";
 
 const ADVANCED_FIELDS_MOTION_TRANSITION = {
@@ -1099,7 +1099,7 @@ export function AgentInstanceEditDialog({
               inheritedProvider={inheritedProviderDefault}
             />
 
-            <AgentAiDefaultsDialog
+            <AgentDefaultsDialog
               onOpenChange={setAiDefaultsOpen}
               open={aiDefaultsOpen}
               returnFocusRef={aiDefaultsTriggerRef}

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/features/agents/openSnapshotImportFromUrlEvent";
 import { AddAgentToChannelDialog } from "./AddAgentToChannelDialog";
 import { AddTeamToChannelDialog } from "./AddTeamToChannelDialog";
-import { AgentAiDefaultsDialog } from "./AgentAiDefaultsDialog";
+import { AgentDefaultsDialog } from "./AgentDefaultsDialog";
 import { AgentDialog } from "./AgentDialog";
 import { PersonaCatalogDialog } from "./PersonaCatalogDialog";
 import { PersonaDeleteDialog } from "./PersonaDeleteDialog";
@@ -241,7 +241,7 @@ export function AgentsView() {
         </div>
       </div>
 
-      <AgentAiDefaultsDialog
+      <AgentDefaultsDialog
         onOpenChange={setIsAiDefaultsOpen}
         open={isAiDefaultsOpen}
         returnFocusRef={aiDefaultsTriggerRef}

--- a/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
+++ b/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
@@ -6,7 +6,7 @@ import {
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
   PERSONA_LABEL_OPTIONAL_CLASS,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 import type { AgentPersona } from "@/shared/api/types";
 import { BuzzAgentModelTuningFields } from "./buzzAgentModelTuningFields";
 import { isBuzzAgentRuntime } from "./buzzAgentConfig";

--- a/desktop/src/features/agents/ui/EnvVarsEditor.test.mjs
+++ b/desktop/src/features/agents/ui/EnvVarsEditor.test.mjs
@@ -462,7 +462,7 @@ test("inheritedRows_masked_secret_local_override_shows_masked_build_value", () =
 test("inheritedRows_structured_keys_excluded_from_generic_rows", () => {
   // BUZZ_AGENT_PROVIDER, BUZZ_AGENT_MODEL, BUZZ_AGENT_THINKING_EFFORT must
   // be excluded from bakedGenericRows (they go to structured fields instead).
-  // This mirrors the BAKED_STRUCTURED_KEYS filter in GlobalAgentConfigSettingsCard.
+  // This mirrors the BAKED_STRUCTURED_KEYS filter in AgentDefaultsSettingsCard.
   const STRUCTURED = new Set([
     "BUZZ_AGENT_PROVIDER",
     "BUZZ_AGENT_MODEL",

--- a/desktop/src/features/agents/ui/EnvVarsEditor.tsx
+++ b/desktop/src/features/agents/ui/EnvVarsEditor.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/shared/lib/cn";
 import {
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 
 export type EnvVarsValue = Record<string, string>;
 

--- a/desktop/src/features/agents/ui/PersonaAdvancedFields.tsx
+++ b/desktop/src/features/agents/ui/PersonaAdvancedFields.tsx
@@ -9,7 +9,7 @@ import {
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
   PERSONA_LABEL_OPTIONAL_CLASS,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 
 export function PersonaAdvancedFields({
   behaviorDraft,

--- a/desktop/src/features/agents/ui/PersonaDropdownField.tsx
+++ b/desktop/src/features/agents/ui/PersonaDropdownField.tsx
@@ -13,7 +13,7 @@ import {
   type PersonaDropdownOption,
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 
 export function PersonaDropdownField({
   contentClassName,

--- a/desktop/src/features/agents/ui/PersonaModelCombobox.tsx
+++ b/desktop/src/features/agents/ui/PersonaModelCombobox.tsx
@@ -7,7 +7,7 @@ import {
   type PersonaDropdownOption,
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 
 type PersonaModelComboboxProps = {
   disabled?: boolean;

--- a/desktop/src/features/agents/ui/PersonaModelField.tsx
+++ b/desktop/src/features/agents/ui/PersonaModelField.tsx
@@ -10,7 +10,7 @@ import {
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
   PERSONA_LABEL_OPTIONAL_CLASS,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 
 type PersonaModelFieldProps = {
   disabled: boolean;

--- a/desktop/src/features/agents/ui/PersonaProviderApiKeyField.tsx
+++ b/desktop/src/features/agents/ui/PersonaProviderApiKeyField.tsx
@@ -3,11 +3,11 @@ import { Eye, EyeOff } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
 import { Input } from "@/shared/ui/input";
-import { RequiredFieldLabel } from "./personaProviderModelFields";
+import { RequiredFieldLabel } from "./agentConfigControls";
 import {
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 
 /**
  * Top-level API key pseudo-field for providers that require a secret

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -14,7 +14,7 @@ import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { PersonaDropdownField } from "./PersonaDropdownField";
-import type { PersonaDropdownOption } from "./personaDialogPickers";
+import type { PersonaDropdownOption } from "./agentConfigOptions";
 
 /**
  * Inbound author gate UI for create/edit agent dialogs.

--- a/desktop/src/features/agents/ui/agentConfigControls.tsx
+++ b/desktop/src/features/agents/ui/agentConfigControls.tsx
@@ -22,7 +22,7 @@ import {
   hasPersonaModelOption,
   providerDisplayLabel,
   type PersonaModelOption,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 import { MODEL_DISCOVERY_LOADING_VALUE } from "./usePersonaModelDiscovery";
 import type { PersonaModelDiscoveryStatus } from "./personaModelDiscoveryStatus";
 

--- a/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
+++ b/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
@@ -6,7 +6,7 @@ import {
   getPersonaModelOptions,
   getPersonaProviderOptions,
   runtimeSupportsLlmProviderSelection,
-} from "./personaDialogPickers.tsx";
+} from "./agentConfigOptions.tsx";
 import { formatModelDiscoveryErrorStatus } from "./personaModelDiscoveryStatus.ts";
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/desktop/src/features/agents/ui/agentConfigOptions.tsx
+++ b/desktop/src/features/agents/ui/agentConfigOptions.tsx
@@ -12,7 +12,7 @@ export { getDefaultPersonaRuntime } from "../lib/resolvePersonaRuntime";
  *
  * All three dialog sites that show a provider picker import this constant —
  * `AgentDefinitionDialog`, `AgentInstanceEditDialog`, and
- * `GlobalAgentConfigSettingsCard` — making it the single source of truth for
+ * `AgentDefaultsSettingsCard` — making it the single source of truth for
  * which provider ids to suppress on Block builds.
  */
 export const BLOCK_BUILD_HIDDEN_PROVIDER_IDS: ReadonlySet<string> = new Set([

--- a/desktop/src/features/agents/ui/agentDefinitionSubmitPayload.ts
+++ b/desktop/src/features/agents/ui/agentDefinitionSubmitPayload.ts
@@ -1,4 +1,4 @@
-import { runtimeSupportsLlmProviderSelection } from "./personaDialogPickers";
+import { runtimeSupportsLlmProviderSelection } from "./agentConfigOptions";
 
 /**
  * Pure helper extracted from the `handleSubmit` path of `AgentDefinitionDialog`

--- a/desktop/src/features/agents/ui/agentInstanceEditPinning.test.mjs
+++ b/desktop/src/features/agents/ui/agentInstanceEditPinning.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 import {
   requiredCredentialEnvKeys,
   runtimeSupportsLlmProviderSelection,
-} from "./personaDialogPickers.tsx";
+} from "./agentConfigOptions.tsx";
 import {
   computeEditAgentFormValidity,
   hasMissingRequiredEnvKey,

--- a/desktop/src/features/agents/ui/bakedEnvHelpers.ts
+++ b/desktop/src/features/agents/ui/bakedEnvHelpers.ts
@@ -9,7 +9,7 @@
  * baked provider is present. Falls back to the raw provider id when the id
  * doesn't appear in the options table.
  *
- * Used in GlobalAgentConfigSettingsCard to relabel the provider dropdown's
+ * Used in AgentDefaultsSettingsCard to relabel the provider dropdown's
  * empty-selection option when a baked build provider is set.
  */
 export function getBakedProviderInheritLabel(

--- a/desktop/src/features/agents/ui/buzzAgentConfig.test.mjs
+++ b/desktop/src/features/agents/ui/buzzAgentConfig.test.mjs
@@ -578,7 +578,7 @@ test("provider id matching is case-insensitive", () => {
 // ---------------------------------------------------------------------------
 
 // Tests below verify the validValues membership check that the auto-clear
-// useEffect in BuzzAgentModelTuningFields and GlobalAgentConfigSettingsCard
+// useEffect in BuzzAgentModelTuningFields and AgentDefaultsSettingsCard
 // use to decide whether to reset the current effort to Inherit.
 
 test("effort max is invalid for OpenAI (should trigger auto-clear)", () => {

--- a/desktop/src/features/agents/ui/buzzAgentModelTuningFields.tsx
+++ b/desktop/src/features/agents/ui/buzzAgentModelTuningFields.tsx
@@ -12,7 +12,7 @@ import type { EnvVarsValue } from "./EnvVarsEditor";
 import {
   AgentDropdownSelect,
   type AgentDropdownOption,
-} from "./personaProviderModelFields";
+} from "./agentConfigControls";
 import {
   BUZZ_AGENT_MAX_CONTEXT_TOKENS,
   BUZZ_AGENT_MAX_OUTPUT_TOKENS,
@@ -26,7 +26,7 @@ import {
  * Shared effort-select dropdown for the `BUZZ_AGENT_THINKING_EFFORT` env var.
  *
  * Used by both `BuzzAgentModelTuningFields` (per-agent/persona dialogs) and
- * `GlobalAgentConfigSettingsCard` (global defaults settings card) to ensure a
+ * `AgentDefaultsSettingsCard` (global defaults settings card) to ensure a
  * single rendering surface for this control.
  *
  * The caller is responsible for the auto-clear `useEffect` that resets the
@@ -79,7 +79,7 @@ export function EffortSelectField({
    * Per-agent callers (BuzzAgentModelTuningFields) pass `"Inherit (agent default)"`
    * to preserve the label that appeared before this component was extracted.
    *
-   * The global-defaults card (GlobalAgentConfigSettingsCard) passes
+   * The global-defaults card (AgentDefaultsSettingsCard) passes
    * `"Default (<effort>)"` when a semantic default exists and nothing is baked
    * in — so OSS users see "Default (medium)" rather than bare "Inherit".
    */

--- a/desktop/src/features/agents/ui/createAgentLocalModeGate.test.mjs
+++ b/desktop/src/features/agents/ui/createAgentLocalModeGate.test.mjs
@@ -30,7 +30,7 @@ import {
   isGloballySatisfiedCredentialKey,
   requiredCredentialEnvKeys,
   runtimeSupportsLlmProviderSelection,
-} from "./personaDialogPickers.tsx";
+} from "./agentConfigOptions.tsx";
 import { hasMissingRequiredEnvKey } from "./personaRuntimeModel.ts";
 import {
   countNonSecretInheritedEnvVars,

--- a/desktop/src/features/agents/ui/editAgentProviderDiscovery.test.mjs
+++ b/desktop/src/features/agents/ui/editAgentProviderDiscovery.test.mjs
@@ -6,7 +6,7 @@ import {
   getPersonaProviderOptions,
   requiredCredentialEnvKeys,
   isMissingRequiredDropdownField,
-} from "./personaDialogPickers.tsx";
+} from "./agentConfigOptions.tsx";
 import {
   computeEditAgentFormValidity,
   hasMissingRequiredEnvKey,
@@ -142,7 +142,7 @@ test("editAgent_providerOptions_includesCurrentIfCustom", () => {
 
 test("editAgent_requiredDropdownField_onlyMarksMissingKnownField", async () => {
   const { isMissingRequiredDropdownField } = await import(
-    "./personaDialogPickers.tsx"
+    "./agentConfigOptions.tsx"
   );
 
   assert.equal(

--- a/desktop/src/features/agents/ui/editAgentRequiredCredentials.test.mjs
+++ b/desktop/src/features/agents/ui/editAgentRequiredCredentials.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 import {
   isGloballySatisfiedCredentialKey,
   requiredCredentialEnvKeys,
-} from "./personaDialogPickers.tsx";
+} from "./agentConfigOptions.tsx";
 import { hasMissingRequiredEnvKey } from "./personaRuntimeModel.ts";
 
 // These tests cover the Edit Agent required-credential gate behaviour added in

--- a/desktop/src/features/agents/ui/providerApiKeyFieldState.ts
+++ b/desktop/src/features/agents/ui/providerApiKeyFieldState.ts
@@ -5,7 +5,7 @@ import {
   getBakedSatisfiedEnvKeys,
   getProviderApiKeyEnvVar,
   isGloballySatisfiedCredentialKey,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 
 export type ProviderApiKeyFieldState = {
   advancedRequiredEnvKeys: readonly string[];

--- a/desktop/src/features/agents/ui/providerEnvVarUpdates.ts
+++ b/desktop/src/features/agents/ui/providerEnvVarUpdates.ts
@@ -1,5 +1,5 @@
 import type { EnvVarsValue } from "./EnvVarsEditor";
-import { getProviderApiKeyEnvVar } from "./personaDialogPickers";
+import { getProviderApiKeyEnvVar } from "./agentConfigOptions";
 
 /**
  * Pure env-var update helpers shared by the persona / create-agent /

--- a/desktop/src/features/agents/ui/relayMeshModelPicker.test.mjs
+++ b/desktop/src/features/agents/ui/relayMeshModelPicker.test.mjs
@@ -5,7 +5,7 @@ import {
   modelDropdownOptions,
   relayMeshModelPickerState,
 } from "./relayMeshModelPicker.ts";
-import { AUTO_MODEL_DROPDOWN_VALUE } from "./personaDialogPickers.tsx";
+import { AUTO_MODEL_DROPDOWN_VALUE } from "./agentConfigOptions.tsx";
 
 const fallback = [{ id: "", label: "Default model" }];
 const live = [

--- a/desktop/src/features/agents/ui/relayMeshModelPicker.ts
+++ b/desktop/src/features/agents/ui/relayMeshModelPicker.ts
@@ -6,7 +6,7 @@ import {
   hasPersonaModelOption,
   type PersonaDropdownOption,
   type PersonaModelOption,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 
 function withSharedComputeAutoOption(
   options: readonly PersonaModelOption[],

--- a/desktop/src/features/agents/ui/runtimeModelProviderSelection.ts
+++ b/desktop/src/features/agents/ui/runtimeModelProviderSelection.ts
@@ -6,7 +6,7 @@ import {
   CUSTOM_PROVIDER_DROPDOWN_VALUE,
   getProviderApiKeyEnvVar,
   shouldClearKnownModelForSelectionScope,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 import { shouldClearModelForRuntimeChange } from "./personaRuntimeModel";
 import {
   envVarsClearingManagedApiKey,

--- a/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
+++ b/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
@@ -10,8 +10,8 @@ import {
   formatModelDiscoveryErrorStatus,
   type PersonaModelDiscoveryStatus,
 } from "./personaModelDiscoveryStatus";
-import type { PersonaModelOption } from "./personaDialogPickers";
-import { providerRequiresExplicitModel } from "./personaDialogPickers";
+import type { PersonaModelOption } from "./agentConfigOptions";
+import { providerRequiresExplicitModel } from "./agentConfigOptions";
 
 export const MODEL_DISCOVERY_LOADING_VALUE = "__model_discovery_loading__";
 

--- a/desktop/src/features/agents/ui/useRequiredCredentialState.ts
+++ b/desktop/src/features/agents/ui/useRequiredCredentialState.ts
@@ -10,7 +10,7 @@ import {
   isGloballySatisfiedCredentialKey,
   requiredCredentialEnvKeys,
   runtimeSupportsLlmProviderSelection,
-} from "./personaDialogPickers";
+} from "./agentConfigOptions";
 import { hasMissingRequiredEnvKey } from "./personaRuntimeModel";
 
 /** Derived required-credential state for the Edit Agent dialog's Advanced section. */

--- a/desktop/src/features/agents/useGlobalAgentConfig.ts
+++ b/desktop/src/features/agents/useGlobalAgentConfig.ts
@@ -31,7 +31,7 @@ export function useGlobalAgentConfig(): {
     queryKey: globalAgentConfigQueryKey,
     queryFn: getGlobalAgentConfig,
     // Config is only mutated via setGlobalAgentConfig — treat as stable until
-    // explicitly invalidated by GlobalAgentConfigSettingsCard after a save.
+    // explicitly invalidated by AgentDefaultsSettingsCard after a save.
     staleTime: Number.POSITIVE_INFINITY,
     // Never show a stale empty flash while a background refetch runs.
     placeholderData: EMPTY_CONFIG,

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -2,12 +2,12 @@ import * as React from "react";
 
 import { useAcpRuntimesQuery } from "@/features/agents/hooks";
 import {
-  GlobalAgentConfigFields,
+  AgentConfigFields,
   EMPTY_GLOBAL_CONFIG,
-} from "@/features/agents/ui/GlobalAgentConfigFields";
+} from "@/features/agents/ui/AgentConfigFields";
 import { BUZZ_AGENT_THINKING_EFFORT } from "@/features/agents/ui/buzzAgentConfig";
-import { runtimeSupportsLlmProviderSelection } from "@/features/agents/ui/personaDialogPickers";
-import { AgentDropdownSelect } from "@/features/agents/ui/personaProviderModelFields";
+import { runtimeSupportsLlmProviderSelection } from "@/features/agents/ui/agentConfigOptions";
+import { AgentDropdownSelect } from "@/features/agents/ui/agentConfigControls";
 import { createSaveCoalescer } from "./saveCoalescer";
 import { getBakedBuildEnv, type BakedEnvEntry } from "@/shared/api/tauri";
 import {
@@ -189,7 +189,7 @@ function AgentDefaultsSection({
             />
           </div>
 
-          <GlobalAgentConfigFields
+          <AgentConfigFields
             bakedEnv={bakedEnv}
             selectedRuntime={selectedRuntime}
             config={config}

--- a/desktop/src/features/onboarding/ui/agentReadiness.ts
+++ b/desktop/src/features/onboarding/ui/agentReadiness.ts
@@ -1,4 +1,4 @@
-import { requiredCredentialEnvKeys } from "@/features/agents/ui/personaDialogPickers";
+import { requiredCredentialEnvKeys } from "@/features/agents/ui/agentConfigOptions";
 import type {
   AcpRuntimeCatalogEntry,
   GlobalAgentConfig,

--- a/desktop/src/features/settings/ui/AgentDefaultsSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/AgentDefaultsSettingsCard.tsx
@@ -1,7 +1,7 @@
-import { GlobalAgentConfigEditor } from "@/features/agents/ui/GlobalAgentConfigEditor";
+import { AgentDefaultsEditor } from "@/features/agents/ui/AgentDefaultsEditor";
 import { SectionHeader } from "@/shared/ui/PageHeader";
 
-export function GlobalAgentConfigSettingsCard() {
+export function AgentDefaultsSettingsCard() {
   return (
     <section
       className="min-w-0 space-y-4"
@@ -11,7 +11,7 @@ export function GlobalAgentConfigSettingsCard() {
         title="Agent defaults"
         description="Provider, model, effort, and environment settings inherited by local agents. Agent-specific settings always take priority."
       />
-      <GlobalAgentConfigEditor />
+      <AgentDefaultsEditor />
     </section>
   );
 }

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -77,7 +77,7 @@ import { MobilePairingCard } from "./MobilePairingCard";
 import { ModerationQueueCard } from "./ModerationQueueCard";
 import { NotificationSettingsCard } from "./NotificationSettingsCard";
 import { PreventSleepSettingsCard } from "./PreventSleepSettingsCard";
-import { GlobalAgentConfigSettingsCard } from "./GlobalAgentConfigSettingsCard";
+import { AgentDefaultsSettingsCard } from "./AgentDefaultsSettingsCard";
 import { HostedCommunitiesSettingsCard } from "./HostedCommunitiesSettingsCard";
 import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
 import { ProfileSettingsCard } from "./ProfileSettingsCard";
@@ -814,7 +814,7 @@ export function renderSettingsSection(
         <div className="space-y-12">
           <PreventSleepSettingsCard />
           <DoctorSettingsPanel />
-          <GlobalAgentConfigSettingsCard />
+          <AgentDefaultsSettingsCard />
         </div>
       );
     case "channel-templates":

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -357,13 +357,13 @@ type E2eConfig = {
     /**
      * The `restarted_count` returned by `set_global_agent_config`. Defaults to
      * 0 (no agents restarted). Set to a positive integer to drive the
-     * "Saved. Restarted N agent(s)." status text in GlobalAgentConfigSettingsCard.
+     * "Saved. Restarted N agent(s)." status text in AgentDefaultsSettingsCard.
      */
     globalConfigRestartedCount?: number;
     /**
      * The `failed_restart_count` returned by `set_global_agent_config`. Defaults
      * to 0. Set to a positive integer to drive the "M failed to restart — check
-     * the Agents tab." status text in GlobalAgentConfigSettingsCard.
+     * the Agents tab." status text in AgentDefaultsSettingsCard.
      */
     globalConfigFailedRestartCount?: number;
     /**

--- a/desktop/tests/e2e/global-agent-config-screenshots.spec.ts
+++ b/desktop/tests/e2e/global-agent-config-screenshots.spec.ts
@@ -175,7 +175,7 @@ test.describe("global agent config screenshots", () => {
     });
   });
 
-  // Shot 01: GlobalAgentConfigSettingsCard populated with provider + model +
+  // Shot 01: AgentDefaultsSettingsCard populated with provider + model +
   // env var — shows the "Agent defaults" card in the Agents view as it looks
   // when a user has set global defaults.
   test("01-global-agent-config-card-populated", async ({ page }) => {

--- a/desktop/tests/e2e/persona-env-vars.spec.ts
+++ b/desktop/tests/e2e/persona-env-vars.spec.ts
@@ -272,7 +272,7 @@ test("env vars editor renders in PersonaDialog new-persona form", async ({
   await page.getByTestId("new-agent-card").click();
   await page.getByRole("menuitem", { name: "Create from scratch" }).click();
 
-  // Scope all env-vars queries to the dialog: GlobalAgentConfigSettingsCard
+  // Scope all env-vars queries to the dialog: AgentDefaultsSettingsCard
   // also renders an EnvVarsEditor in the background settings pane (introduced
   // by this branch), so page-wide testid queries would match both.
   const dialog = page.getByRole("dialog");

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -391,13 +391,13 @@ type MockBridgeOptions = {
   /**
    * The `restarted_count` returned by `set_global_agent_config`. Defaults to
    * 0 (no agents restarted). Set to a positive integer to drive the
-   * "Saved. Restarted N agent(s)." status text in GlobalAgentConfigSettingsCard.
+   * "Saved. Restarted N agent(s)." status text in AgentDefaultsSettingsCard.
    */
   globalConfigRestartedCount?: number;
   /**
    * The `failed_restart_count` returned by `set_global_agent_config`. Defaults
    * to 0. Set to a positive integer to drive the "failed to restart — check
-   * the Agents tab." status text in GlobalAgentConfigSettingsCard.
+   * the Agents tab." status text in AgentDefaultsSettingsCard.
    */
   globalConfigFailedRestartCount?: number;
   /**


### PR DESCRIPTION
## What

Mechanical rename of the agent-configuration UI files to one consistent `agent-config` naming family. **Zero behavior change** — 78 insertions / 78 deletions, all rename-symbol and import-path lines (verified: filtering those out leaves an empty diff). Lint clean, 3,180 unit tests pass, `tsc --noEmit` clean.

| Before | After |
|---|---|
| `GlobalAgentConfigFields.tsx` | `AgentConfigFields.tsx` |
| `GlobalAgentConfigEditor.tsx` | `AgentDefaultsEditor.tsx` |
| `GlobalAgentConfigSettingsCard.tsx` | `AgentDefaultsSettingsCard.tsx` |
| `AgentAiDefaultsDialog.tsx` | `AgentDefaultsDialog.tsx` |
| `personaProviderModelFields.tsx` | `agentConfigControls.tsx` |
| `personaDialogPickers.tsx` | `agentConfigOptions.tsx` (+ its test file) |

## Why

This is PR 1 of the harness/provider/model config consolidation. The canonical config component (`GlobalAgentConfigFields`) is about to be adopted by the per-agent definition and instance dialogs — at which point "Global" becomes actively wrong: the same fields will serve three scopes (global defaults, agent definition, agent instance). The naming rules:

- **"Global"/"Defaults"** only on things genuinely about defaults (the editor wrapper, the Settings card, the defaults dialog)
- **"Persona"** — legacy vocabulary with no user-facing meaning — dies
- One family name (`agent-config`) so the canonical surface is discoverable

## Deliberately NOT renamed

- **`GlobalAgentConfig` data type, `tauriGlobalAgentConfig.ts`, and the `get/set_global_agent_config` Tauri commands** — the persistence layer really is global-scoped; renaming would cross the IPC/Rust boundary for zero benefit.
- **`GlobalAgentConfigSaveResult`** (exported from `AgentDefaultsEditor.tsx`) — kept intentionally: it wraps the IPC result, so the "Global" name honestly marks which side of the boundary it belongs to.
- **`data-testid`s (`global-agent-*`)** — four e2e specs depend on them, including an onboarding spec; renaming them adds risk for no user value.
- **`DefaultConfigStep.tsx` (onboarding)** — import lines updated only, per the workstream's hard rule that onboarding doesn't change.
- **Historical comments in `check-file-sizes.mjs`** that mention old names — they're changelog-style records of past allowlist bumps; rewriting history-describing comments would make them less accurate.

## Verification

- `pnpm exec biome check src tests` — clean
- `pnpm test` — 3,180 pass / 0 fail
- `tsc --noEmit` — clean
- File-size guard passes; no allowlist entries referenced the renamed paths
- Diff audit: no testid, styling, copy, or behavior lines changed
