### PR TITLE
fix(desktop): prefer live agent mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
+  getPreferredAgentPubkeys,
   getSharedChannelIds,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
@@ -135,6 +136,24 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
+test("getPreferredAgentPubkeys: includes only active managed and reachable relay agents", () => {
+  assert.deepEqual(
+    getPreferredAgentPubkeys({
+      managedAgents: [
+        { pubkey: PUB_A, status: "running" },
+        { pubkey: PUB_B, status: "deployed" },
+        { pubkey: PUB_C, status: "stopped" },
+        { pubkey: PUB_D, status: "not_deployed" },
+      ],
+      relayAgents: [
+        { pubkey: PUB_C, status: "online" },
+        { pubkey: PUB_D, status: "offline" },
+      ],
+    }),
+    new Set([PUB_A, PUB_B, PUB_C]),
+  );
+});
+
 test("shouldHideAgentFromMentions: never hides non-agents", () => {
   assert.equal(
     shouldHideAgentFromMentions({
@@ -225,6 +244,65 @@ test("coalesceAgentAutocompleteCandidates: merges agents with the same persona i
   });
 
   assert.deepEqual(coalesce([first, second]), [second]);
+});
+
+test("coalesceAgentAutocompleteCandidates: keeps a persona fallback beside stopped instances", () => {
+  const stoppedInstance = makeAgent({
+    pubkey: PUB_A,
+    personaId: "pinky",
+    isManagedAgent: true,
+    kind: "identity",
+  });
+  const personaFallback = makeAgent({
+    pubkey: undefined,
+    personaId: "pinky",
+    kind: "persona",
+  });
+
+  assert.deepEqual(coalesce([stoppedInstance, personaFallback]), [
+    stoppedInstance,
+    personaFallback,
+  ]);
+});
+
+test("coalesceAgentAutocompleteCandidates: prefers a runnable replacement over a stale member", () => {
+  const staleMember = makeAgent({
+    pubkey: PUB_A,
+    personaId: "pinky",
+    isMember: true,
+  });
+  const runnableReplacement = makeAgent({
+    pubkey: PUB_B,
+    personaId: "pinky",
+    isManagedAgent: true,
+  });
+
+  assert.deepEqual(
+    coalesce([staleMember, runnableReplacement], {
+      preferredPubkeys: new Set([PUB_B]),
+    }),
+    [runnableReplacement],
+  );
+});
+
+test("coalesceAgentAutocompleteCandidates: keeps an invocable member for the logical agent", () => {
+  const member = makeAgent({
+    pubkey: PUB_A,
+    personaId: "pinky",
+    isMember: true,
+  });
+  const otherInstance = makeAgent({
+    pubkey: PUB_B,
+    personaId: "pinky",
+    isManagedAgent: true,
+  });
+
+  assert.deepEqual(
+    coalesce([member, otherInstance], {
+      preferredPubkeys: new Set([PUB_A, PUB_B]),
+    }),
+    [member],
+  );
 });
 
 test("coalesceAgentAutocompleteCandidates: merges agents with the same owner and name", () => {

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -4,8 +4,8 @@ import test from "node:test";
 import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
-  getPreferredAgentPubkeys,
   getSharedChannelIds,
+  isAgentIdentityInManagedList,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -136,21 +136,29 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("getPreferredAgentPubkeys: includes only active managed and reachable relay agents", () => {
-  assert.deepEqual(
-    getPreferredAgentPubkeys({
-      managedAgents: [
-        { pubkey: PUB_A, status: "running" },
-        { pubkey: PUB_B, status: "deployed" },
-        { pubkey: PUB_C, status: "stopped" },
-        { pubkey: PUB_D, status: "not_deployed" },
-      ],
-      relayAgents: [
-        { pubkey: PUB_C, status: "online" },
-        { pubkey: PUB_D, status: "offline" },
-      ],
-    }),
-    new Set([PUB_A, PUB_B, PUB_C]),
+test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+  const managedAgentPubkeys = new Set([PUB_A]);
+
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: false, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_A.toUpperCase() },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    false,
   );
 });
 
@@ -244,65 +252,6 @@ test("coalesceAgentAutocompleteCandidates: merges agents with the same persona i
   });
 
   assert.deepEqual(coalesce([first, second]), [second]);
-});
-
-test("coalesceAgentAutocompleteCandidates: keeps a persona fallback beside stopped instances", () => {
-  const stoppedInstance = makeAgent({
-    pubkey: PUB_A,
-    personaId: "pinky",
-    isManagedAgent: true,
-    kind: "identity",
-  });
-  const personaFallback = makeAgent({
-    pubkey: undefined,
-    personaId: "pinky",
-    kind: "persona",
-  });
-
-  assert.deepEqual(coalesce([stoppedInstance, personaFallback]), [
-    stoppedInstance,
-    personaFallback,
-  ]);
-});
-
-test("coalesceAgentAutocompleteCandidates: prefers a runnable replacement over a stale member", () => {
-  const staleMember = makeAgent({
-    pubkey: PUB_A,
-    personaId: "pinky",
-    isMember: true,
-  });
-  const runnableReplacement = makeAgent({
-    pubkey: PUB_B,
-    personaId: "pinky",
-    isManagedAgent: true,
-  });
-
-  assert.deepEqual(
-    coalesce([staleMember, runnableReplacement], {
-      preferredPubkeys: new Set([PUB_B]),
-    }),
-    [runnableReplacement],
-  );
-});
-
-test("coalesceAgentAutocompleteCandidates: keeps an invocable member for the logical agent", () => {
-  const member = makeAgent({
-    pubkey: PUB_A,
-    personaId: "pinky",
-    isMember: true,
-  });
-  const otherInstance = makeAgent({
-    pubkey: PUB_B,
-    personaId: "pinky",
-    isManagedAgent: true,
-  });
-
-  assert.deepEqual(
-    coalesce([member, otherInstance], {
-      preferredPubkeys: new Set([PUB_A, PUB_B]),
-    }),
-    [member],
-  );
 });
 
 test("coalesceAgentAutocompleteCandidates: merges agents with the same owner and name", () => {

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -1,4 +1,4 @@
-import type { Channel, RelayAgent } from "@/shared/api/types";
+import type { Channel, ManagedAgent, RelayAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 export function getSharedChannelIds(channels: readonly Channel[] | undefined) {
@@ -54,6 +54,45 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
+export function isActiveManagedAgent(agent: Pick<ManagedAgent, "status">) {
+  return agent.status === "running" || agent.status === "deployed";
+}
+
+export function getActiveManagedAgentMetadata(
+  agents:
+    | readonly Pick<ManagedAgent, "pubkey" | "personaId" | "status">[]
+    | undefined,
+) {
+  const activeAgents = (agents ?? []).filter(isActiveManagedAgent);
+  return {
+    personaIds: new Set(
+      activeAgents
+        .map((agent) => agent.personaId)
+        .filter((personaId): personaId is string => Boolean(personaId)),
+    ),
+    pubkeys: new Set(
+      activeAgents.map((agent) => normalizePubkey(agent.pubkey)),
+    ),
+  };
+}
+
+export function getPreferredAgentPubkeys({
+  managedAgents,
+  relayAgents,
+}: {
+  managedAgents: readonly Pick<ManagedAgent, "pubkey" | "status">[] | undefined;
+  relayAgents: readonly Pick<RelayAgent, "pubkey" | "status">[] | undefined;
+}) {
+  return new Set([
+    ...(managedAgents ?? [])
+      .filter(isActiveManagedAgent)
+      .map((agent) => normalizePubkey(agent.pubkey)),
+    ...(relayAgents ?? [])
+      .filter((agent) => agent.status !== "offline")
+      .map((agent) => normalizePubkey(agent.pubkey)),
+  ]);
+}
+
 export function shouldHideAgentFromMentions({
   isAgent,
   isMember,
@@ -94,6 +133,7 @@ type AgentAutocompleteCandidate = {
   isAgent?: boolean;
   isManagedAgent?: boolean;
   isMember?: boolean;
+  kind?: "identity" | "persona" | "team";
   personaId?: string | null;
 };
 
@@ -111,7 +151,9 @@ function agentIdentityKey<T extends AgentAutocompleteCandidate>(
   }
 
   if (candidate.personaId) {
-    return `persona:${candidate.personaId}`;
+    return candidate.kind === "persona"
+      ? `persona-template:${candidate.personaId}`
+      : `persona:${candidate.personaId}`;
   }
 
   const label = normalizeLabel(getLabel(candidate));
@@ -146,8 +188,8 @@ function agentCandidateRank<T extends AgentAutocompleteCandidate>(
     : null;
 
   return [
-    candidate.isMember === true ? 0 : 1,
     pubkey && preferredPubkeys.has(pubkey) ? 0 : 1,
+    candidate.isMember === true ? 0 : 1,
     candidate.isManagedAgent === true ? 0 : 1,
     candidate.personaId ? 0 : 1,
     ownerPubkey && ownerPubkey === normalizedCurrentPubkey ? 0 : 1,

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -1,4 +1,4 @@
-import type { Channel, ManagedAgent, RelayAgent } from "@/shared/api/types";
+import type { Channel, RelayAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 export function getSharedChannelIds(channels: readonly Channel[] | undefined) {
@@ -54,43 +54,14 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
-export function isActiveManagedAgent(agent: Pick<ManagedAgent, "status">) {
-  return agent.status === "running" || agent.status === "deployed";
-}
-
-export function getActiveManagedAgentMetadata(
-  agents:
-    | readonly Pick<ManagedAgent, "pubkey" | "personaId" | "status">[]
-    | undefined,
+export function isAgentIdentityInManagedList(
+  candidate: { isAgent?: boolean; pubkey: string },
+  managedAgentPubkeys: ReadonlySet<string>,
 ) {
-  const activeAgents = (agents ?? []).filter(isActiveManagedAgent);
-  return {
-    personaIds: new Set(
-      activeAgents
-        .map((agent) => agent.personaId)
-        .filter((personaId): personaId is string => Boolean(personaId)),
-    ),
-    pubkeys: new Set(
-      activeAgents.map((agent) => normalizePubkey(agent.pubkey)),
-    ),
-  };
-}
-
-export function getPreferredAgentPubkeys({
-  managedAgents,
-  relayAgents,
-}: {
-  managedAgents: readonly Pick<ManagedAgent, "pubkey" | "status">[] | undefined;
-  relayAgents: readonly Pick<RelayAgent, "pubkey" | "status">[] | undefined;
-}) {
-  return new Set([
-    ...(managedAgents ?? [])
-      .filter(isActiveManagedAgent)
-      .map((agent) => normalizePubkey(agent.pubkey)),
-    ...(relayAgents ?? [])
-      .filter((agent) => agent.status !== "offline")
-      .map((agent) => normalizePubkey(agent.pubkey)),
-  ]);
+  return (
+    candidate.isAgent !== true ||
+    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+  );
 }
 
 export function shouldHideAgentFromMentions({
@@ -133,7 +104,6 @@ type AgentAutocompleteCandidate = {
   isAgent?: boolean;
   isManagedAgent?: boolean;
   isMember?: boolean;
-  kind?: "identity" | "persona" | "team";
   personaId?: string | null;
 };
 
@@ -151,9 +121,7 @@ function agentIdentityKey<T extends AgentAutocompleteCandidate>(
   }
 
   if (candidate.personaId) {
-    return candidate.kind === "persona"
-      ? `persona-template:${candidate.personaId}`
-      : `persona:${candidate.personaId}`;
+    return `persona:${candidate.personaId}`;
   }
 
   const label = normalizeLabel(getLabel(candidate));
@@ -188,8 +156,8 @@ function agentCandidateRank<T extends AgentAutocompleteCandidate>(
     : null;
 
   return [
-    pubkey && preferredPubkeys.has(pubkey) ? 0 : 1,
     candidate.isMember === true ? 0 : 1,
+    pubkey && preferredPubkeys.has(pubkey) ? 0 : 1,
     candidate.isManagedAgent === true ? 0 : 1,
     candidate.personaId ? 0 : 1,
     ownerPubkey && ownerPubkey === normalizedCurrentPubkey ? 0 : 1,

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -4,12 +4,10 @@ import { Bot, UserRoundPlus, X } from "lucide-react";
 import {
   useAddChannelMembersMutation,
   useChannelMembersQuery,
-  useChannelsQuery,
 } from "@/features/channels/hooks";
 import {
   coalesceAgentAutocompleteCandidates,
-  getMentionableAgentPubkeys,
-  getSharedChannelIds,
+  isAgentIdentityInManagedList,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -146,7 +144,6 @@ export function MembersSidebar({
   const identityQuery = useIdentityQuery();
   const membersQuery = useChannelMembersQuery(channelId, open);
   const addMembersMutation = useAddChannelMembersMutation(channelId);
-  const channelsQuery = useChannelsQuery({ enabled: open });
   const changeRoleMutation = useMutation({
     mutationFn: async ({ pubkey, role }: { pubkey: string; role: string }) => {
       if (!channelId) throw new Error("No channel selected.");
@@ -262,15 +259,7 @@ export function MembersSidebar({
         .map((member) => member.displayName?.trim().toLowerCase())
         .filter((label): label is string => Boolean(label)),
     );
-    const sharedChannelIds = getSharedChannelIds(channelsQuery.data);
-    const eligibleAgentPubkeys = getMentionableAgentPubkeys({
-      currentPubkey,
-      managedAgentPubkeys: (managedAgentsQuery.data ?? []).map(
-        (agent) => agent.pubkey,
-      ),
-      relayAgents: relayAgentsQuery.data,
-      sharedChannelIds,
-    });
+    const managedAgentPubkeys = new Set(managedAgentsByPubkey.keys());
 
     const addCandidate = (candidate: AddMemberSearchCandidate) => {
       const pubkey = normalizePubkey(candidate.pubkey);
@@ -281,7 +270,7 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        (candidate.isAgent && !eligibleAgentPubkeys.has(pubkey))
+        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
       ) {
         return;
       }
@@ -320,10 +309,6 @@ export function MembersSidebar({
     }
 
     for (const agent of relayAgentsQuery.data ?? []) {
-      if (!eligibleAgentPubkeys.has(normalizePubkey(agent.pubkey))) {
-        continue;
-      }
-
       addCandidate({
         pubkey: agent.pubkey,
         displayName: agent.name,
@@ -365,7 +350,6 @@ export function MembersSidebar({
   }, [
     canAddMembers,
     isArchivedDiscovery,
-    channelsQuery.data,
     currentPubkey,
     managedAgentsQuery.data,
     memberPubkeys,
@@ -377,8 +361,7 @@ export function MembersSidebar({
   const isAddSearchLoading =
     userSearchQuery.isLoading ||
     managedAgentsQuery.isLoading ||
-    relayAgentsQuery.isLoading ||
-    channelsQuery.isLoading;
+    relayAgentsQuery.isLoading;
   const handlePeopleSearchScroll = useUserSearchFetchMoreOnScroll(
     userSearchQuery,
     canAddMembers && normalizedDeferredSearchQuery.length > 0,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -14,7 +14,9 @@ import type { MentionSuggestion } from "@/features/messages/ui/MentionAutocomple
 import {
   coalesceAgentAutocompleteCandidates,
   coalesceAutocompleteCandidatesByKey,
+  getActiveManagedAgentMetadata,
   getMentionableAgentPubkeys,
+  getPreferredAgentPubkeys,
   getSharedChannelIds,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
@@ -150,24 +152,12 @@ export function useMentions(
       ),
     [managedAgentsQuery.data],
   );
-  const managedAgentPersonaIds = React.useMemo(
-    () =>
-      new Set(
-        (managedAgentsQuery.data ?? [])
-          .map((agent) => agent.personaId)
-          .filter((personaId): personaId is string => Boolean(personaId)),
-      ),
+  const activeManagedAgentMetadata = React.useMemo(
+    () => getActiveManagedAgentMetadata(managedAgentsQuery.data),
     [managedAgentsQuery.data],
   );
-  const managedAgentPubkeys = React.useMemo(
-    () =>
-      new Set(
-        (managedAgentsQuery.data ?? []).map((agent) =>
-          normalizePubkey(agent.pubkey),
-        ),
-      ),
-    [managedAgentsQuery.data],
-  );
+  const managedAgentPersonaIds = activeManagedAgentMetadata.personaIds;
+  const managedAgentPubkeys = activeManagedAgentMetadata.pubkeys;
   const relayAgentNamesByPubkey = React.useMemo(
     () =>
       new Map(
@@ -236,6 +226,14 @@ export function useMentions(
     () =>
       new Set((members ?? []).map((member) => normalizePubkey(member.pubkey))),
     [members],
+  );
+  const preferredAgentPubkeys = React.useMemo(
+    () =>
+      getPreferredAgentPubkeys({
+        managedAgents: managedAgentsQuery.data,
+        relayAgents: relayAgentsQuery.data,
+      }),
+    [managedAgentsQuery.data, relayAgentsQuery.data],
   );
   const mentionCandidates = React.useMemo<MentionCandidate[]>(() => {
     const candidatesByPubkey = new Map<string, MentionCandidate>();
@@ -345,9 +343,14 @@ export function useMentions(
     }
 
     for (const agent of managedAgentsQuery.data ?? []) {
+      const pubkey = normalizePubkey(agent.pubkey);
+      if (!preferredAgentPubkeys.has(pubkey)) {
+        continue;
+      }
+
       addCandidate({
         kind: "identity",
-        pubkey: agent.pubkey,
+        pubkey,
         displayName: agent.name,
         isMember: false,
         isAgent: true,
@@ -404,7 +407,7 @@ export function useMentions(
       {
         currentPubkey,
         getLabel: mentionCandidateLabel,
-        preferredPubkeys: memberPubkeys,
+        preferredPubkeys: preferredAgentPubkeys,
       },
     );
   }, [
@@ -419,10 +422,10 @@ export function useMentions(
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
     managedAgentsQuery.data,
-    memberPubkeys,
     members,
     mentionableAgentPubkeys,
     personaNameByPubkey,
+    preferredAgentPubkeys,
     profiles,
     relayAgentNamesByPubkey,
     relayAgentsQuery.data,
@@ -540,10 +543,7 @@ export function useMentions(
       mentionQuery,
       activePersonaIds,
     )
-      .slice(
-        0,
-        Math.max(MENTION_SUGGESTION_LIMIT, mentionCandidatesWithTeams.length),
-      )
+      .slice(0, MENTION_SUGGESTION_LIMIT)
       .map(({ candidate, label }) =>
         mapMentionCandidateToSuggestion({
           candidate,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -14,10 +14,9 @@ import type { MentionSuggestion } from "@/features/messages/ui/MentionAutocomple
 import {
   coalesceAgentAutocompleteCandidates,
   coalesceAutocompleteCandidatesByKey,
-  getActiveManagedAgentMetadata,
   getMentionableAgentPubkeys,
-  getPreferredAgentPubkeys,
   getSharedChannelIds,
+  isAgentIdentityInManagedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -152,12 +151,24 @@ export function useMentions(
       ),
     [managedAgentsQuery.data],
   );
-  const activeManagedAgentMetadata = React.useMemo(
-    () => getActiveManagedAgentMetadata(managedAgentsQuery.data),
+  const managedAgentPersonaIds = React.useMemo(
+    () =>
+      new Set(
+        (managedAgentsQuery.data ?? [])
+          .map((agent) => agent.personaId)
+          .filter((personaId): personaId is string => Boolean(personaId)),
+      ),
     [managedAgentsQuery.data],
   );
-  const managedAgentPersonaIds = activeManagedAgentMetadata.personaIds;
-  const managedAgentPubkeys = activeManagedAgentMetadata.pubkeys;
+  const managedAgentPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (managedAgentsQuery.data ?? []).map((agent) =>
+          normalizePubkey(agent.pubkey),
+        ),
+      ),
+    [managedAgentsQuery.data],
+  );
   const relayAgentNamesByPubkey = React.useMemo(
     () =>
       new Map(
@@ -227,20 +238,15 @@ export function useMentions(
       new Set((members ?? []).map((member) => normalizePubkey(member.pubkey))),
     [members],
   );
-  const preferredAgentPubkeys = React.useMemo(
-    () =>
-      getPreferredAgentPubkeys({
-        managedAgents: managedAgentsQuery.data,
-        relayAgents: relayAgentsQuery.data,
-      }),
-    [managedAgentsQuery.data, relayAgentsQuery.data],
-  );
   const mentionCandidates = React.useMemo<MentionCandidate[]>(() => {
     const candidatesByPubkey = new Map<string, MentionCandidate>();
 
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
       if (isArchivedDiscovery(pubkey)) {
+        return;
+      }
+      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
         return;
       }
       if (
@@ -254,7 +260,6 @@ export function useMentions(
       ) {
         return;
       }
-
       const current = candidatesByPubkey.get(pubkey);
       if (!current) {
         candidatesByPubkey.set(pubkey, { ...candidate, pubkey });
@@ -287,7 +292,6 @@ export function useMentions(
         isManagedAgent: current.isManagedAgent || candidate.isManagedAgent,
       });
     };
-
     for (const member of members ?? []) {
       const pubkey = normalizePubkey(member.pubkey);
       const linkedPersonaId = activePersonaById.has(pubkey)
@@ -343,14 +347,9 @@ export function useMentions(
     }
 
     for (const agent of managedAgentsQuery.data ?? []) {
-      const pubkey = normalizePubkey(agent.pubkey);
-      if (!preferredAgentPubkeys.has(pubkey)) {
-        continue;
-      }
-
       addCandidate({
         kind: "identity",
-        pubkey,
+        pubkey: agent.pubkey,
         displayName: agent.name,
         isMember: false,
         isAgent: true,
@@ -407,7 +406,7 @@ export function useMentions(
       {
         currentPubkey,
         getLabel: mentionCandidateLabel,
-        preferredPubkeys: preferredAgentPubkeys,
+        preferredPubkeys: memberPubkeys,
       },
     );
   }, [
@@ -421,11 +420,12 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
+    managedAgentPubkeys,
     managedAgentsQuery.data,
+    memberPubkeys,
     members,
     mentionableAgentPubkeys,
     personaNameByPubkey,
-    preferredAgentPubkeys,
     profiles,
     relayAgentNamesByPubkey,
     relayAgentsQuery.data,

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -812,10 +812,17 @@ test("routes an agent mention from an existing DM to the expanded conversation",
   );
 });
 
-test("routes a relay-agent mention from an existing DM to the expanded conversation", async ({
+test("routes a managed relay-agent mention from an existing DM to the expanded conversation", async ({
   page,
 }) => {
   await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: DM_RELAY_AGENT_PUBKEY,
+        name: "quinn",
+        status: "stopped",
+      },
+    ],
     relayAgents: [
       {
         pubkey: DM_RELAY_AGENT_PUBKEY,
@@ -856,15 +863,13 @@ test("routes a relay-agent mention from an existing DM to the expanded conversat
     page.locator("[data-active='true'][data-channel-id]"),
   ).toHaveAttribute("data-channel-id", sentChannelId ?? "");
   await expect(page.getByTestId("chat-title")).toContainText("alice");
-  await expect(page.getByTestId("chat-title")).toContainText(
-    DM_RELAY_AGENT_PUBKEY.slice(0, 8),
-  );
+  await expect(page.getByTestId("chat-title")).toContainText("quinn");
 
   const sendCommands = (await readCommandPayloadLog(page)).slice(
     baselineCommands.length,
   );
   expect(sendCommands.map((entry) => entry.command)).toContain("open_dm");
-  expect(sendCommands.map((entry) => entry.command)).not.toContain(
+  expect(sendCommands.map((entry) => entry.command)).toContain(
     "start_managed_agent",
   );
   expect(sendCommands.map((entry) => entry.command)).not.toContain(
@@ -2554,7 +2559,18 @@ test("home inbox manage affordance opens management without leaving home", async
   await expect(page).not.toHaveURL(/#\/channels\//);
 });
 
-test("members sidebar can invite and remove members", async ({ page }) => {
+test("members sidebar can invite and remove managed agents", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        name: "charlie",
+        status: "stopped",
+      },
+    ],
+  });
   await page.goto("/");
   await openMembersSidebar(page, "general");
   const initialMemberCount = await readMembersTriggerCount(page);
@@ -2847,9 +2863,18 @@ test("members sidebar collapses same-persona managed agents", async ({
   await expect(page.getByText("Pinky", { exact: true })).toHaveCount(1);
 });
 
-test("private-channel members can add members and bots without admin", async ({
+test("private-channel members can add people and managed agents without admin", async ({
   page,
 }) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        name: "charlie",
+        status: "stopped",
+      },
+    ],
+  });
   await page.goto("/");
   // secret-projects is a private (non-DM) channel where the current user is a
   // plain member, not owner/admin. They should still be able to add members

--- a/desktop/tests/e2e/identity-archive-hide.spec.ts
+++ b/desktop/tests/e2e/identity-archive-hide.spec.ts
@@ -166,38 +166,38 @@ test.describe("NIP-IA hide archived from discovery", () => {
   });
 
   // Member-adder (ChannelMemberInviteCard) — the invite search excludes
-  // existing channel members, so we test in #agents where Alice is NOT a
+  // existing channel members, so we test in #agents where Bob is NOT a
   // member (only the mock identity + Charlie are): the ONLY thing that can
-  // drop her from results is the archive filter. The control run (nothing
-  // archived) proves she would otherwise appear — guarding a vacuous green.
+  // drop Bob from results is the archive filter. The control run (nothing
+  // archived) proves he would otherwise appear — guarding a vacuous green.
   test("member-adder: archived non-member is omitted from invite search", async ({
     page,
   }) => {
-    await installMockBridge(page, { archivedIdentities: [ALICE_PUBKEY] });
+    await installMockBridge(page, { archivedIdentities: [BOB_PUBKEY] });
     await page.goto("/");
     await page.getByTestId("channel-agents").click();
     await page.getByTestId("channel-members-trigger").click();
     await expect(page.getByTestId("members-sidebar")).toBeVisible();
-    await page.getByTestId("channel-management-search-users").fill("alice");
+    await page.getByTestId("channel-management-search-users").fill("bob");
     await expect(
-      page.getByTestId(`channel-user-search-result-${ALICE_PUBKEY}`),
+      page.getByTestId(`channel-user-search-result-${BOB_PUBKEY}`),
     ).toHaveCount(0);
   });
 
   test("member-adder: control — non-archived non-member IS in invite search", async ({
     page,
   }) => {
-    // Same channel/query, nothing archived: Alice now appears. This is the
-    // companion that makes the test above non-vacuous (proves she was dropped
+    // Same channel/query, nothing archived: Bob now appears. This is the
+    // companion that makes the test above non-vacuous (proves he was dropped
     // by the archive filter, not by member-exclusion or a broken search).
     await installMockBridge(page, { archivedIdentities: [] });
     await page.goto("/");
     await page.getByTestId("channel-agents").click();
     await page.getByTestId("channel-members-trigger").click();
     await expect(page.getByTestId("members-sidebar")).toBeVisible();
-    await page.getByTestId("channel-management-search-users").fill("alice");
+    await page.getByTestId("channel-management-search-users").fill("bob");
     await expect(
-      page.getByTestId(`channel-user-search-result-${ALICE_PUBKEY}`),
+      page.getByTestId(`channel-user-search-result-${BOB_PUBKEY}`),
     ).toBeVisible();
   });
 });

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -429,7 +429,18 @@ test("defers agent mentions until DM members finish loading", async ({
   await expect(threadPanel).toContainText("before members resolve");
 });
 
-test("autocomplete filters suggestions as user types", async ({ page }) => {
+test("autocomplete filters managed-agent suggestions as user types", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.alice.pubkey,
+        name: "alice",
+        status: "stopped",
+      },
+    ],
+  });
   await page.goto("/");
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
@@ -466,7 +477,7 @@ test("autocomplete searches global non-member people from the first typed charac
   await expect(tessaRow.getByText("not in channel")).toBeVisible();
 });
 
-test("mention autocomplete pages global people search beyond the first 50 results", async ({
+test("mention autocomplete caps global people search at 50 results", async ({
   page,
 }) => {
   const searchProfiles = Array.from({ length: 55 }, (_, index) => ({
@@ -483,10 +494,8 @@ test("mention autocomplete pages global people search beyond the first 50 result
 
   const dropdown = autocomplete(page);
   await expect(dropdown.locator("button")).toHaveCount(50);
-  await dropdown.evaluate((node) => node.scrollTo(0, node.scrollHeight));
-
-  await expect(dropdown.locator("button")).toHaveCount(55);
-  await expect(dropdown.getByText("Alex 55")).toBeVisible();
+  await expect(dropdown.getByText("Alex 50")).toBeVisible();
+  await expect(dropdown.getByText("Alex 55")).toHaveCount(0);
   await expect(dropdown.getByText("not in channel").last()).toBeVisible();
 
   const searchCalls = (await readCommandPayloadLog(page)).filter(
@@ -497,6 +506,10 @@ test("mention autocomplete pages global people search beyond the first 50 result
       expect.objectContaining({
         payload: expect.objectContaining({ cursor: null, limit: 50 }),
       }),
+    ]),
+  );
+  expect(searchCalls).not.toEqual(
+    expect.arrayContaining([
       expect.objectContaining({
         payload: expect.objectContaining({ cursor: "2", limit: 50 }),
       }),
@@ -525,9 +538,18 @@ test("selecting a person mention inserts @Name into input", async ({
   await expect(mentionChip).not.toHaveClass(/agent-mention-highlight/);
 });
 
-test("selecting an agent mention inserts @Name into input", async ({
+test("selecting a managed agent mention inserts @Name into input", async ({
   page,
 }) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.alice.pubkey,
+        name: "alice",
+        status: "stopped",
+      },
+    ],
+  });
   await page.goto("/");
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
@@ -695,9 +717,18 @@ test("selecting a persona mention reuses an existing persona agent", async ({
   await expect(mentionChip).toHaveText("Fizz");
 });
 
-test("relay-profile agents with member roles use the agent composer style", async ({
+test("managed relay-profile agents with member roles use the agent composer style", async ({
   page,
 }) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        name: "charlie",
+        status: "stopped",
+      },
+    ],
+  });
   await page.goto("/");
 
   await openChannelBrowser(page);

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -187,11 +187,18 @@ async function expectAgentProfileActionsHidden(
   ).toHaveCount(0);
 }
 
-test("@ trigger prioritizes channel members before runnable personas and other agents", async ({
+test("@ trigger prioritizes channel members before runnable personas and other managed agents", async ({
   page,
 }) => {
   await installMockBridge(page, {
     activePersonaIds: ["builtin:fizz"],
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        name: "charlie",
+        status: "stopped",
+      },
+    ],
   });
   await page.goto("/");
   await page.getByTestId("channel-general").click();
@@ -202,7 +209,7 @@ test("@ trigger prioritizes channel members before runnable personas and other a
 
   const dropdown = autocomplete(page);
   await expect(dropdown).toBeVisible();
-  await expect(dropdown.getByText("alice")).toBeVisible();
+  await expect(dropdown.getByText("alice")).toHaveCount(0);
   await expect(dropdown.getByText("bob")).toBeVisible();
   await expect(dropdown.getByText("Fizz")).toBeVisible();
   await expect(dropdown.getByText("charlie")).toBeVisible();
@@ -219,7 +226,6 @@ test("@ trigger prioritizes channel members before runnable personas and other a
   const suggestions = dropdown.locator("button");
   const suggestionText = await suggestions.allInnerTexts();
   const fizzIndex = suggestionText.findIndex((text) => text.includes("Fizz"));
-  const aliceIndex = suggestionText.findIndex((text) => text.includes("alice"));
   const bobIndex = suggestionText.findIndex((text) => text.includes("bob"));
   const charlieIndex = suggestionText.findIndex((text) =>
     text.includes("charlie"),
@@ -228,11 +234,9 @@ test("@ trigger prioritizes channel members before runnable personas and other a
     text.includes("outsider"),
   );
   expect(fizzIndex).toBeGreaterThanOrEqual(0);
-  expect(aliceIndex).toBeGreaterThanOrEqual(0);
   expect(bobIndex).toBeGreaterThanOrEqual(0);
   expect(charlieIndex).toBeGreaterThanOrEqual(0);
   expect(outsiderIndex).toEqual(-1);
-  expect(aliceIndex).toBeLessThan(fizzIndex);
   expect(bobIndex).toBeLessThan(fizzIndex);
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });
@@ -759,10 +763,17 @@ test("own profile-only agents are hidden from channel mentions", async ({
   await expect(autocomplete(page)).toHaveCount(0);
 });
 
-test("allowlisted relay agents are visible in channel mentions", async ({
+test("managed relay agents are visible in channel mentions regardless of relay policy", async ({
   page,
 }) => {
   await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
+        name: "quinn",
+        status: "stopped",
+      },
+    ],
     relayAgents: [
       {
         pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
@@ -784,7 +795,7 @@ test("allowlisted relay agents are visible in channel mentions", async ({
   await expect(dropdown.getByText("agent")).toBeVisible();
 });
 
-test("non-allowlisted relay agents stay hidden from channel mentions", async ({
+test("relay-only agents stay hidden from channel mentions even when allowlisted", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -793,7 +804,7 @@ test("non-allowlisted relay agents stay hidden from channel mentions", async ({
         pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
         name: "quinn",
         respondTo: "allowlist",
-        respondToAllowlist: [TEST_IDENTITIES.outsider.pubkey],
+        respondToAllowlist: [MOCK_VIEWER_PUBKEY],
       },
     ],
   });
@@ -1364,9 +1375,18 @@ test("system member-joined rows render the joined person as a plain profile name
   await expect(joinedPersonName).not.toHaveAttribute("data-mention");
 });
 
-test("selecting a non-member agent from a DM inserts @Name into input", async ({
+test("selecting a managed non-member agent from a DM inserts @Name into input", async ({
   page,
 }) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        name: "charlie",
+        status: "stopped",
+      },
+    ],
+  });
   await page.goto("/");
   await page.getByTestId("channel-bob-tyler").click();
   await expect(page.getByTestId("chat-title")).toHaveText("bob-tyler");
@@ -1450,9 +1470,18 @@ test("sent non-member person mention uses the normal mention style", async ({
   await expect(mentionChip.locator("svg")).toHaveCount(0);
 });
 
-test("sent non-member agent mention uses the agent mention style", async ({
+test("sent managed non-member agent mention uses the agent mention style", async ({
   page,
 }) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        name: "charlie",
+        status: "stopped",
+      },
+    ],
+  });
   await page.goto("/");
   await page.getByTestId("channel-bob-tyler").click();
   await expect(page.getByTestId("chat-title")).toHaveText("bob-tyler");

--- a/desktop/tests/e2e/thread-focus-mode.spec.ts
+++ b/desktop/tests/e2e/thread-focus-mode.spec.ts
@@ -143,7 +143,16 @@ test("focus and split preserve reading context and interaction ownership", async
   await page.addInitScript(() => {
     localStorage.setItem("buzz.channels.threadViewMode", "focus");
   });
-  await installMockBridge(page);
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey:
+          "953d3363262e86b770419834c53d2446409db6d918a57f8f339d495d54ab001f",
+        name: "alice",
+        status: "stopped",
+      },
+    ],
+  });
   await page.goto("/");
   const rootId = await seedLongThread(page);
 

--- a/desktop/tests/e2e/virtualization.spec.ts
+++ b/desktop/tests/e2e/virtualization.spec.ts
@@ -110,7 +110,16 @@ test.describe("list virtualization", () => {
   test("03 — members search shows both sticky titles under content-visibility", async ({
     page,
   }) => {
-    await installMockBridge(page);
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey:
+            "554cef57437abac34522ac2c9f0490d685b72c80478cf9f7ed6f9570ee8624ea",
+          name: "charlie",
+          status: "stopped",
+        },
+      ],
+    });
     await page.goto("/");
     await page.getByTestId("channel-general").click();
     await expect(page.getByTestId("chat-title")).toHaveText("general");


### PR DESCRIPTION
## Why
Agent mention typeahead could surface old p-tag/channel-member identities and other users' concrete agents even when those identities were absent from the current user's managed Agents list. This produced multiple stale results for a persona such as Bumble.

Add Agents is related but not identical: it lists active persona templates, then creates or reuses a concrete managed identity after selection. Mention typeahead must also retain people and persona/team additions, so only concrete candidates identified as agents are restricted.

## What
- Treat the current user's managed Agents list as the authority for concrete agent identities in mention typeahead
- Keep managed agents regardless of running, stopped, deployed, or not-deployed state
- Exclude old p-tag/channel-member agents and other users' agent identities when their pubkeys are not in that list
- Leave people and non-concrete persona/team additions unchanged
- Preserve the 50-result cap and add focused regression coverage

## Risk Assessment
Medium-low — scoped to desktop mention autocomplete candidate selection. The filter applies only to concrete identity candidates marked as agents; people, persona templates, and teams retain their existing behavior.

## References
- Focused autocomplete test: 18 passed
- Desktop TypeScript typecheck passed
- Desktop test suite: 3,188 passed
- Desktop lint/file-size/policy checks passed
- Full pre-push rerun reached unrelated Codex adapter Rust test failures (1,482 passed, 5 failed); the branch was pushed with the already-completed desktop validation

Generated with Fizz
