### PR TITLE
fix(desktop): avoid forwarding click event as channel callback

### DIFF
--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -729,7 +729,7 @@ export function AppSidebar({
                       actionsTestId="section-actions-channels"
                       listTestId="stream-list"
                       quickCreateLabel="Browse channels"
-                      onQuickCreateClick={onBrowseChannels}
+                      onQuickCreateClick={() => onBrowseChannels?.()}
                       showQuickCreate
                       onMarkAllRead={onMarkAllChannelsRead}
                       onMarkChannelRead={onMarkChannelRead}

--- a/desktop/tests/e2e/channel-browser.spec.ts
+++ b/desktop/tests/e2e/channel-browser.spec.ts
@@ -213,13 +213,22 @@ test("channel browser ranks the best match first", async ({ page }) => {
   );
 });
 
-test("sidebar add-channel button opens the browser", async ({ page }) => {
+test("sidebar add-channel button creates without treating the click as a callback", async ({
+  page,
+}) => {
   await page.goto("/");
   await expect(page.getByTestId("app-sidebar")).toBeVisible();
 
   await page.getByTestId("section-actions-channels-quick-create").click();
 
   await expect(page.getByTestId("channel-browser-dialog")).toBeVisible();
+  const channelName = `sidebar-created-${Date.now()}`;
+  await page.getByTestId("channel-browser-search").fill(channelName);
+  await page.getByTestId("channel-browser-create-row").click();
+  await page.getByTestId("create-channel-submit").click();
+
+  await expect(page.getByTestId("channel-browser-dialog")).not.toBeVisible();
+  await expect(page.getByTestId("stream-list")).toContainText(channelName);
 });
 
 test("custom section add button creates directly into that section", async ({


### PR DESCRIPTION
## Summary
- prevent the Channels header quick-create click event from being stored as the optional channel-created callback
- extend the sidebar channel-browser E2E test through successful channel creation

## Root cause
`openBrowseChannels` accepts an optional success callback. Passing it directly to the React click prop forwarded the click event as that argument, so channel creation later attempted to invoke the event via `createSuccessRef.current`.

## Test plan
- `just desktop-check`
- targeted `desktop/tests/e2e/channel-browser.spec.ts` test (`1 passed`)
- pre-push hooks: desktop checks/tests, mobile tests, Rust tests, desktop Tauri tests
