### PR TITLE
test(desktop): model membership relay in invite QR spec

### DIFF
--- a/desktop/tests/e2e/invite-qr-download.spec.ts
+++ b/desktop/tests/e2e/invite-qr-download.spec.ts
@@ -4,7 +4,9 @@ import { installMockBridge } from "../helpers/bridge";
 import { openSettings } from "../helpers/settings";
 
 test.beforeEach(async ({ page }) => {
-  await installMockBridge(page);
+  await installMockBridge(page, {
+    relayRequiresMembership: true,
+  });
   await page.route("**/api/invites", async (route) => {
     await route.fulfill({
       contentType: "application/json",


### PR DESCRIPTION
## Summary
- declare the invite QR smoke spec's NIP-43 membership-relay requirement
- preserve the seeded owner fixture so the owner-only Community access section renders
- avoid timeout changes or product-code changes

## Root cause
#2107 made open-relay mocks correctly skip membership snapshot loading. This spec exercises an owner-only membership setting but still used the now-open default fixture, so `settings-nav-community-members` could never exist.

## Test plan
- `cd desktop && pnpm build:e2e && pnpm exec playwright test tests/e2e/invite-qr-download.spec.ts --project=smoke --repeat-each=10 --workers=1` (10/10 passed)
