### PR TITLE
fix(desktop): composite harness loader opacity

### DIFF
--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -673,7 +673,7 @@ function RuntimeProvidersLoadingState() {
       data-testid="onboarding-runtime-loading"
       role="status"
     >
-      <div className="flex flex-col items-center text-foreground/35">
+      <div className="flex flex-col items-center text-foreground opacity-35">
         <FlappingBee className="h-auto w-16" />
         <p className="mt-5 text-2xl font-normal leading-8">
           Finding your providers...


### PR DESCRIPTION
## Why
The harness-selection loader applied translucent color to each SVG layer independently, making overlapping wing and body pieces appear darker than the rest of the bee.

## What
- Apply opacity to the composed loading-state group instead of its individual SVG layers
- Preserve the existing 35% treatment and wing animation

## Risk Assessment
Low — one visual-only utility-class change scoped to the onboarding harness discovery loading state.

## References
- `pnpm typecheck`
- Focused Biome check
- Focused Playwright loading-state test
- Full pre-push test suite

Generated with Peppermint Butler
