### PR TITLE
Polish agent defaults surfaces: app dropdowns + collapsed Advanced env vars

### DIFF
--- a/desktop/src/features/agents/ui/AgentConfigFields.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigFields.tsx
@@ -272,6 +272,16 @@ export function AgentConfigFields({
   const healOnMount =
     fieldModel.dependentValuePolicy.onCatalogMismatch === "onboardingCleanup";
   const userEditedProviderRef = React.useRef(false);
+  // Env vars live under a collapsed Advanced section (matching the create
+  // flow). Auto-open when a required key is missing so the field the user
+  // must fill is never hidden behind the toggle.
+  const [advancedOpen, setAdvancedOpen] = React.useState(false);
+  const requiredAdvancedKeyMissing = advancedRequiredEnvKeys.some(
+    (key) => !(config.env_vars[key] ?? "").trim(),
+  );
+  React.useEffect(() => {
+    if (requiredAdvancedKeyMissing) setAdvancedOpen(true);
+  }, [requiredAdvancedKeyMissing]);
   // Read inside effects via ref so biome's exhaustive-deps stays honest:
   // refs are stable, and healOnMount is captured at declaration.
   const mayMutateDependentFieldsRef = React.useRef(false);
@@ -717,9 +727,23 @@ export function AgentConfigFields({
       ) : null}
 
       {showAdvancedFields ? (
-        <>
-          {/* Env vars */}
-          <div className={blockClassName}>
+        <div className={cn(blockClassName, "space-y-3")}>
+          <button
+            aria-expanded={advancedOpen}
+            className="inline-flex h-9 items-center gap-1.5 text-sm font-medium text-foreground transition-colors hover:text-foreground/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            data-testid="global-agent-advanced-toggle"
+            onClick={() => setAdvancedOpen((current) => !current)}
+            type="button"
+          >
+            <span>Advanced</span>
+            <ChevronDown
+              className={cn(
+                "h-4 w-4 text-muted-foreground transition-transform duration-150 ease-out",
+                advancedOpen && "rotate-180",
+              )}
+            />
+          </button>
+          {advancedOpen ? (
             <EnvVarsEditor
               hiddenKeys={apiKeyEnvVar ? [apiKeyEnvVar] : []}
               inheritedRows={bakedGenericRows}
@@ -733,8 +757,8 @@ export function AgentConfigFields({
                 ),
               )}
             />
-          </div>
-        </>
+          ) : null}
+        </div>
       ) : null}
     </>
   );

--- a/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
+++ b/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
@@ -193,6 +193,7 @@ export function AgentDefaultsEditor({
           onCustomModelEditingChange={setIsCustomModelEditing}
           onIsCustomProviderChange={setIsCustomProvider}
           onValidityChange={setConfigIsValid}
+          useCustomSelect
         />
       )}
 

--- a/desktop/src/features/settings/ui/SettingsView.tsx
+++ b/desktop/src/features/settings/ui/SettingsView.tsx
@@ -330,7 +330,7 @@ export function SettingsView({
             data-testid="settings-content-scroll"
           >
             <div
-              className="mx-auto flex h-full w-full max-w-4xl flex-col gap-4"
+              className="mx-auto flex min-h-full w-full max-w-4xl flex-col gap-4"
               data-testid={`settings-panel-${section}`}
             >
               {renderSettingsSection(section, {

--- a/desktop/tests/e2e/agent-lifecycle-feedback.spec.ts
+++ b/desktop/tests/e2e/agent-lifecycle-feedback.spec.ts
@@ -54,7 +54,12 @@ async function makeGlobalDefaultsDirty(
   page: import("@playwright/test").Page,
   effort = "high",
 ) {
-  await page.locator("#global-agent-thinking-effort").selectOption(effort);
+  // The defaults editor renders the app's styled dropdown (not a native
+  // <select>): open the trigger, then click the option row.
+  await page.getByTestId("global-agent-thinking-effort-select").click();
+  await page
+    .getByTestId(`global-agent-thinking-effort-select-option-${effort}`)
+    .click();
 }
 
 test.describe("agent lifecycle feedback screenshots", () => {
@@ -369,7 +374,7 @@ test.describe("agent lifecycle feedback screenshots", () => {
     await openAiDefaultsSettings(page);
 
     const card = page.getByTestId("settings-global-agent-config");
-    const effort = page.locator("#global-agent-thinking-effort");
+    const effort = page.getByTestId("global-agent-thinking-effort-select");
     const saveButton = page.getByRole("button", { name: "Save defaults" });
 
     await makeGlobalDefaultsDirty(page, "high");
@@ -377,14 +382,14 @@ test.describe("agent lifecycle feedback screenshots", () => {
     await saveButton.click();
 
     // While the save is held open by the mock delay, make a newer edit.
-    await effort.selectOption("low");
+    await makeGlobalDefaultsDirty(page, "low");
 
     // The save resolves with the OLD submitted config; the newer edit must
     // survive and the card must stay dirty so it can be saved again.
     await expect(card.getByText("Saved.", { exact: true })).toBeVisible({
       timeout: 10_000,
     });
-    await expect(effort).toHaveValue("low");
+    await expect(effort).toHaveAttribute("data-value", "low");
     await expect(saveButton).toBeEnabled();
   });
 });

--- a/desktop/tests/e2e/agent-provider-dropdowns.spec.ts
+++ b/desktop/tests/e2e/agent-provider-dropdowns.spec.ts
@@ -64,15 +64,22 @@ test.describe("agent provider dropdown screenshots", () => {
     await installMockBridge(page);
     await openAiDefaultsSettings(page);
 
-    const providerSelect = page.locator("#global-agent-provider");
+    const providerSelect = page.getByTestId("global-agent-provider");
     await expect(providerSelect).toBeVisible({ timeout: 5_000 });
 
-    // Regression: both v1 and v2 must be present on OSS.
-    const optionTexts = await providerSelect.evaluate((el: HTMLSelectElement) =>
-      Array.from(el.options).map((o) => o.text.trim()),
-    );
-    expect(optionTexts).toContain("Databricks");
-    expect(optionTexts).toContain("Databricks v2");
+    // Regression: both v1 and v2 must be present on OSS. The defaults editor
+    // renders the app's styled dropdown, so open it and assert option rows.
+    await providerSelect.click();
+    await expect(
+      page.getByTestId("global-agent-provider-option-databricks"),
+    ).toHaveText("Databricks");
+    await expect(
+      page.getByTestId("global-agent-provider-option-databricks_v2"),
+    ).toHaveText("Databricks v2");
+    await page.keyboard.press("Escape");
+    await expect(
+      page.getByTestId("global-agent-provider-option-databricks"),
+    ).toHaveCount(0);
 
     await waitForAnimations(page);
 
@@ -104,18 +111,24 @@ test.describe("agent provider dropdown screenshots", () => {
     });
     await openAiDefaultsSettings(page);
 
-    const effortSelect = page.locator("#global-agent-thinking-effort");
+    const effortSelect = page.getByTestId(
+      "global-agent-thinking-effort-select",
+    );
     await expect(effortSelect).toBeVisible({ timeout: 5_000 });
 
     // Regression: the zero-value option must show the provider's default
-    // effort rather than a bare "Inherit".
-    const zeroOptionText = await effortSelect.evaluate(
-      (el: HTMLSelectElement) =>
-        Array.from(el.options)
-          .find((o) => o.value === "")
-          ?.text.trim() ?? "",
-    );
-    expect(zeroOptionText).toBe("Default (medium)");
+    // effort rather than a bare "Inherit". The styled dropdown renders the
+    // zero value as the closed trigger's label (nothing is persisted) and as
+    // the "empty" option row when opened.
+    await expect(effortSelect).toHaveText("Default (medium)");
+    await effortSelect.click();
+    await expect(
+      page.getByTestId("global-agent-thinking-effort-select-option-empty"),
+    ).toHaveText("Default (medium)");
+    await page.keyboard.press("Escape");
+    await expect(
+      page.getByTestId("global-agent-thinking-effort-select-option-empty"),
+    ).toHaveCount(0);
 
     await waitForAnimations(page);
 


### PR DESCRIPTION
## Context

Kenny's onboarding-config review pass (7/19) flagged two polish items on the Agent defaults surfaces (Settings → Agents card, and the "Agent defaults" modal on the Agents page):

1. Dropdowns fall back to the native macOS `<select>` instead of the app's styled dropdown that onboarding already uses.
2. Environment variables render always-expanded instead of under a collapsed **Advanced** section like the create flow.

Both surfaces already render through the shared `AgentConfigFields` component, so this is presentation-only — no persistence, spawn, or config-model changes.

## What this PR does

- **App dropdowns on evergreen surfaces:** `AgentDefaultsEditor` now passes `useCustomSelect`, so the Settings card and the defaults modal render the same styled dropdowns onboarding uses. The native `<select>` branch stays in the component (deleting it is planned for the PR that moves the harness picker inside the component).
- **Collapsed Advanced section:** in full disclosure, the env-vars editor now sits behind an **Advanced** toggle matching the create dialog's pattern. It auto-opens when a required env key is missing, so a field the user must fill is never hidden.
- **Settings footer whitespace restored on tall panels:** the settings scroll area always had `pb-12` bottom padding, but the panel wrapper's `h-full` pinned its box to the viewport height, so any panel taller than the viewport (like Agents) overflowed past the box and lost the padding — the Save defaults button sat flush against the bottom. One-word fix: `h-full` → `min-h-full`, restoring the intended breathing room on every tall settings panel, not just Agents.

## What this PR does not do

- No onboarding changes — onboarding already used the custom dropdowns; its disclosure preset is untouched (pinned by `agentConfigFieldsContract.test.mjs`).
- No model-name prefix stripping (Kenny's third item) — that's model identity, not presentation, and is tracked separately.
- No behavior changes to saving, inheritance, or spawn.

## Verification

- `just ci` ✅ (fmt, clippy, lint, unit tests, builds)
- Contract tests pin the disclosure presets ✅


<img width="1624" height="1061" alt="Screenshot 2026-07-20 at 10 53 20 AM" src="https://github.com/user-attachments/assets/98bdd324-a949-4038-a275-6f2f17fa9fe3" />

<img width="1003" height="580" alt="image" src="https://github.com/user-attachments/assets/7ee5b45c-cbb2-4d96-a73f-4b37521954a3" />

