### PR TITLE
fix(desktop): dedupe replayed thread reply notifications

### DIFF
--- a/desktop/src/features/channels/threadReplyNotificationDedupe.test.mjs
+++ b/desktop/src/features/channels/threadReplyNotificationDedupe.test.mjs
@@ -1,0 +1,638 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  replayLiveSubscriptions,
+  replayReconnectHistoryPages,
+} from "@/shared/api/relayReconnectReplay";
+import { buildChannelFilter } from "@/shared/api/relayChannelFilters";
+import {
+  handleRelayClosed,
+  handleSubscriptionEose,
+} from "@/shared/api/relayClosedRecovery";
+import {
+  shouldDeliverThreadReplyDesktopNotification,
+  ThreadReplyNotificationDedupe,
+  THREAD_REPLY_SEEN_MAX_ITEMS,
+} from "./threadReplyNotificationDedupe.ts";
+import {
+  disposeStaleLiveChannelSubscriptions,
+  reconcileAfterLiveSubscriptionAdditions,
+} from "./useLiveChannelUpdates.ts";
+
+function memoryStorage(initialRecords = []) {
+  const values = new Map();
+  let seeded = false;
+  let writeCount = 0;
+  return {
+    getItem: (key) => {
+      if (!seeded && initialRecords.length > 0) {
+        values.set(key, JSON.stringify(initialRecords));
+        seeded = true;
+      }
+      return values.get(key) ?? null;
+    },
+    setItem: (key, value) => {
+      writeCount += 1;
+      values.set(key, value);
+    },
+    get writeCount() {
+      return writeCount;
+    },
+  };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+test("reconnect prunes before newest-first replay and retains the boundary ID", async () => {
+  const dedupe = new ThreadReplyNotificationDedupe("user", memoryStorage());
+  const notified = [];
+
+  dedupe.setChannelReplayFloor("channel", 900);
+  assert.equal(dedupe.record("channel", "boundary", 996), true);
+
+  // The original live filter starts at 900, so the 996 boundary event remains
+  // inside the history window that the relay can restore.
+  dedupe.handleConnectionState("reconnecting");
+
+  const newestPage = Array.from({ length: 500 }, (_, index) => ({
+    id: `offline-${index}`,
+    created_at: 1_501 + index,
+  }));
+  const pages = [newestPage, [{ id: "boundary", created_at: 996 }]];
+  await replayReconnectHistoryPages({
+    subscription: {
+      mode: "live",
+      filter: { kinds: [], limit: 500 },
+      onEvent: (event) => {
+        if (dedupe.record("channel", event.id, event.created_at)) {
+          notified.push(event.id);
+        }
+      },
+    },
+    since: 995,
+    until: 2_000,
+    isActive: () => true,
+    requestHistory: async () => pages.shift() ?? [],
+  });
+
+  assert.equal(notified.length, 500);
+  assert.equal(notified.includes("offline-0"), true);
+  assert.equal(notified.includes("boundary"), false);
+  assert.equal(
+    dedupe.record("channel", "boundary", 996),
+    false,
+    "newest replay delivery must not evict the older boundary event",
+  );
+});
+
+test("offline arrival notifies once and is persisted across remount", () => {
+  const storage = memoryStorage();
+  const first = new ThreadReplyNotificationDedupe("user", storage);
+
+  first.setChannelReplayFloor("channel", 100);
+  first.handleConnectionState("reconnecting");
+
+  assert.equal(first.record("channel", "offline", 200), true);
+  assert.equal(first.record("channel", "offline", 200), false);
+  first.flush();
+
+  const remounted = new ThreadReplyNotificationDedupe("user", storage);
+  remounted.setChannelReplayFloor("channel", 100);
+  remounted.handleConnectionState("reconnecting");
+  assert.equal(remounted.record("channel", "offline", 200), false);
+});
+
+test("late restored-live duplicate stays suppressed until EOSE completes", async () => {
+  const dedupe = new ThreadReplyNotificationDedupe("user", memoryStorage());
+  const notified = [];
+  const onEvent = (event) => {
+    if (dedupe.record("channel", event.id, event.created_at)) {
+      notified.push(event.id);
+    }
+  };
+  const subscription = {
+    mode: "live",
+    filter: {
+      ...buildChannelFilter("channel", 1_000),
+      since: 900,
+    },
+    onEvent,
+    lastSeenCreatedAt: 1_000,
+  };
+  const subscriptions = new Map([["live", subscription]]);
+
+  dedupe.setChannelReplayFloor("channel", 900);
+  assert.equal(dedupe.record("channel", "boundary", 996), true);
+  dedupe.handleConnectionState("reconnecting");
+
+  const replayPromise = replayLiveSubscriptions({
+    subscriptions,
+    now: 2_000,
+    sendRaw: async () => {},
+    requestHistory: async () => [{ id: "offline", created_at: 2_000 }],
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  // The restored live REQ can deliver its duplicate after HTTP paging. EOSE
+  // is the barrier that must keep the connection in replay mode until this
+  // callback has been handed to the client event buffer.
+  onEvent({ id: "boundary", created_at: 996 });
+  subscription.resolveReconnectEose();
+  await replayPromise;
+  dedupe.handleConnectionState("connected");
+
+  assert.deepEqual(notified, ["offline"]);
+});
+
+test("subscription replay suppresses duplicates after connection reports connected", async () => {
+  const dedupe = new ThreadReplyNotificationDedupe("user", memoryStorage());
+  const notified = [];
+  const onEvent = (event) => {
+    if (dedupe.record("channel", event.id, event.created_at)) {
+      notified.push(event.id);
+    }
+  };
+  const subscription = {
+    mode: "live",
+    filter: {
+      ...buildChannelFilter("channel", 1_000),
+      since: 900,
+    },
+    onEvent,
+    lastSeenCreatedAt: 1_000,
+    onClosedRecoveryStateChange: (replaying) =>
+      dedupe.handleSubscriptionReplayState(replaying),
+  };
+  const subscriptions = new Map([["live", subscription]]);
+
+  dedupe.setChannelReplayFloor("channel", 900);
+  assert.equal(dedupe.record("channel", "boundary", 996), true);
+  dedupe.handleConnectionState("reconnecting");
+  dedupe.handleConnectionState("connected");
+
+  const replayPromise = replayLiveSubscriptions({
+    subscriptions,
+    now: 2_000,
+    sendRaw: async () => {},
+    requestHistory: async () => [{ id: "offline", created_at: 2_000 }],
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  onEvent({ id: "boundary", created_at: 996 });
+  subscription.resolveReconnectEose();
+  await replayPromise;
+
+  assert.deepEqual(notified, ["offline"]);
+});
+
+test("active-channel reply is recorded before desktop suppression", () => {
+  const dedupe = new ThreadReplyNotificationDedupe("user", memoryStorage());
+
+  dedupe.setChannelReplayFloor("channel", 100);
+  const firstSeen = dedupe.record("channel", "active-reply", 100);
+  assert.equal(
+    shouldDeliverThreadReplyDesktopNotification({
+      isFirstSeen: firstSeen,
+      isEligible: true,
+      isActiveChannel: true,
+      notifyForActiveChannel: false,
+    }),
+    false,
+  );
+
+  dedupe.handleConnectionState("reconnecting");
+  const replayFirstSeen = dedupe.record("channel", "active-reply", 100);
+  assert.equal(
+    shouldDeliverThreadReplyDesktopNotification({
+      isFirstSeen: replayFirstSeen,
+      isEligible: true,
+      isActiveChannel: false,
+      notifyForActiveChannel: false,
+    }),
+    false,
+    "navigating away before reconnect must not surface a stale notification",
+  );
+});
+
+test("reply observed while ineligible cannot notify after eligibility changes", () => {
+  const dedupe = new ThreadReplyNotificationDedupe("user", memoryStorage());
+  dedupe.reconcileActiveChannels(["channel"]);
+  dedupe.setChannelReplayFloor("channel", 100);
+
+  const firstSeen = dedupe.record("channel", "muted-reply", 100);
+  assert.equal(
+    shouldDeliverThreadReplyDesktopNotification({
+      isFirstSeen: firstSeen,
+      isEligible: false,
+      isActiveChannel: false,
+      notifyForActiveChannel: false,
+    }),
+    false,
+  );
+
+  dedupe.handleConnectionState("reconnecting");
+  const replayFirstSeen = dedupe.record("channel", "muted-reply", 100);
+  assert.equal(
+    shouldDeliverThreadReplyDesktopNotification({
+      isFirstSeen: replayFirstSeen,
+      isEligible: true,
+      isActiveChannel: false,
+      notifyForActiveChannel: false,
+    }),
+    false,
+    "unmute/follow changes must not turn a replay into a stale notification",
+  );
+});
+
+test("startup reconciliation removes departed records before cap eviction", () => {
+  const activeRecord = {
+    eventId: "active-boundary",
+    channelId: "active",
+    createdAt: 1,
+  };
+  const departedRecords = Array.from(
+    { length: THREAD_REPLY_SEEN_MAX_ITEMS },
+    (_, index) => ({
+      eventId: `departed-${index}`,
+      channelId: "departed",
+      createdAt: index + 2,
+    }),
+  );
+  const dedupe = new ThreadReplyNotificationDedupe(
+    "user",
+    memoryStorage([activeRecord, ...departedRecords]),
+  );
+
+  dedupe.reconcileActiveChannels(["active"]);
+  dedupe.setChannelReplayFloor("active", 0);
+
+  assert.equal(
+    dedupe.record("active", "active-boundary", 1),
+    false,
+    "departed records must be removed before they can evict an active ID",
+  );
+  assert.equal(dedupe.record("departed", "departed-0", 2), false);
+  dedupe.reconcileActiveChannels(["active", "departed"]);
+  dedupe.setChannelReplayFloor("departed", 0);
+  assert.equal(dedupe.record("departed", "departed-0", 2), true);
+});
+
+test("startup provisional target retains its persisted same-second boundary", () => {
+  const boundary = {
+    eventId: "persisted-boundary",
+    channelId: "target",
+    createdAt: 100,
+  };
+  const dedupe = new ThreadReplyNotificationDedupe(
+    "user",
+    memoryStorage([boundary]),
+  );
+
+  dedupe.reconcileActiveChannels(["target"]);
+  dedupe.setChannelReplayFloor("target", 100);
+
+  assert.equal(
+    dedupe.record("target", boundary.eventId, boundary.createdAt),
+    false,
+    "a target channel must stay persisted while its subscription settles",
+  );
+});
+
+test("channel removal deletes its replay floor and persisted records", () => {
+  const storage = memoryStorage();
+  const dedupe = new ThreadReplyNotificationDedupe("user", storage);
+  dedupe.reconcileActiveChannels(["active", "departed"]);
+  dedupe.setChannelReplayFloor("active", 0);
+  dedupe.setChannelReplayFloor("departed", 0);
+  assert.equal(dedupe.record("active", "active-reply", 1), true);
+  assert.equal(dedupe.record("departed", "departed-reply", 2), true);
+
+  dedupe.reconcileActiveChannels(["active"]);
+
+  const remounted = new ThreadReplyNotificationDedupe("user", storage);
+  remounted.reconcileActiveChannels(["active"]);
+  remounted.setChannelReplayFloor("active", 0);
+  assert.equal(remounted.record("active", "active-reply", 1), false);
+  remounted.reconcileActiveChannels(["active", "departed"]);
+  remounted.setChannelReplayFloor("departed", 0);
+  assert.equal(remounted.record("departed", "departed-reply", 2), true);
+});
+
+test("canceled sync cannot overwrite replacement reconciliation", async () => {
+  const dedupe = new ThreadReplyNotificationDedupe("user", memoryStorage());
+  const additionA = deferred();
+  const additionB = deferred();
+  let currentGeneration = 1;
+  let syncACancelled = false;
+
+  const syncA = reconcileAfterLiveSubscriptionAdditions({
+    additions: [additionA.promise],
+    isCurrentSync: () => !syncACancelled && currentGeneration === 1,
+    reconcile: () => dedupe.reconcileActiveChannels([]),
+  });
+
+  syncACancelled = true;
+  currentGeneration = 2;
+  dedupe.reconcileActiveChannels([]);
+  dedupe.setChannelReplayFloor("replacement", 100);
+  const syncB = reconcileAfterLiveSubscriptionAdditions({
+    additions: [additionB.promise],
+    isCurrentSync: () => currentGeneration === 2,
+    reconcile: () => dedupe.reconcileActiveChannels(["replacement"]),
+  });
+
+  additionA.resolve();
+  assert.equal(await syncA, false);
+  assert.equal(
+    dedupe.record("replacement", "live-reply", 100),
+    true,
+    "a stale sync must not reject an event delivered before sync B resolves",
+  );
+
+  additionB.resolve();
+  assert.equal(await syncB, true);
+  dedupe.handleConnectionState("reconnecting");
+  assert.equal(
+    dedupe.record("replacement", "live-reply", 100),
+    false,
+    "the live sighting must stay recorded when the same event replays",
+  );
+});
+
+test("superseding pending sync provisionally retains the target boundary", async () => {
+  const boundary = {
+    eventId: "pending-boundary",
+    channelId: "replacement",
+    createdAt: 100,
+  };
+  const dedupe = new ThreadReplyNotificationDedupe(
+    "user",
+    memoryStorage([boundary]),
+  );
+  const addition = deferred();
+
+  dedupe.reconcileActiveChannels(["replacement"]);
+  dedupe.setChannelReplayFloor("replacement", 100);
+  const sync = reconcileAfterLiveSubscriptionAdditions({
+    additions: [addition.promise],
+    isCurrentSync: () => true,
+    reconcile: () => dedupe.reconcileActiveChannels(["replacement"]),
+  });
+
+  assert.equal(
+    dedupe.record("replacement", boundary.eventId, boundary.createdAt),
+    false,
+  );
+  addition.resolve();
+  assert.equal(await sync, true);
+});
+
+test("identity handoff disposes old recovery ownership before recreating", () => {
+  const oldStorage = memoryStorage();
+  const nextStorage = memoryStorage();
+  const oldDedupe = new ThreadReplyNotificationDedupe("old", oldStorage);
+  const nextDedupe = new ThreadReplyNotificationDedupe("next", nextStorage);
+  oldDedupe.reconcileActiveChannels(["channel"]);
+  oldDedupe.handleSubscriptionRecoveryState(true);
+  const oldWritesDuringRecovery = oldStorage.writeCount;
+  let disposeCalls = 0;
+  const activeSubs = new Map([
+    [
+      "channel",
+      {
+        replayFloor: 100,
+        dedupe: oldDedupe,
+        dispose: async () => {
+          disposeCalls += 1;
+          oldDedupe.handleSubscriptionRecoveryState(false);
+        },
+      },
+    ],
+  ]);
+
+  disposeStaleLiveChannelSubscriptions({
+    activeSubs,
+    targetIds: new Set(["channel"]),
+    dedupe: nextDedupe,
+  });
+  assert.equal(disposeCalls, 1);
+  assert.equal(activeSubs.size, 0);
+  assert.equal(oldStorage.writeCount, oldWritesDuringRecovery + 1);
+
+  nextDedupe.reconcileActiveChannels(["channel"]);
+  nextDedupe.handleSubscriptionRecoveryState(true);
+  const nextWritesDuringRecovery = nextStorage.writeCount;
+  assert.equal(nextDedupe.record("channel", "next-replay", 100), true);
+  assert.equal(nextStorage.writeCount, nextWritesDuringRecovery);
+  nextDedupe.handleSubscriptionRecoveryState(false);
+  assert.equal(nextStorage.writeCount, nextWritesDuringRecovery + 1);
+});
+
+test("full-cap newest-first CLOSED recovery retains the older boundary ID", () => {
+  const originalWindow = globalThis.window;
+  const scheduled = [];
+  globalThis.window = {
+    clearTimeout: () => {},
+    setTimeout: (callback, delay) => {
+      scheduled.push({ callback, delay });
+      return scheduled.length;
+    },
+  };
+  try {
+    const dedupe = new ThreadReplyNotificationDedupe("user", undefined);
+    dedupe.reconcileActiveChannels(["channel"]);
+    dedupe.setChannelReplayFloor("channel", 0);
+    assert.equal(dedupe.record("channel", "boundary", 1), true);
+    for (let index = 1; index < THREAD_REPLY_SEEN_MAX_ITEMS; index += 1) {
+      assert.equal(dedupe.record("channel", `seen-${index}`, index + 1), true);
+    }
+
+    const subscription = {
+      mode: "live",
+      filter: { kinds: [9], "#h": ["channel"], limit: 1_000, since: 0 },
+      onEvent: () => {},
+      onClosedRecoveryStateChange: (recovering) =>
+        dedupe.handleSubscriptionRecoveryState(recovering),
+    };
+    const subscriptions = new Map([["live-1", subscription]]);
+    handleRelayClosed({
+      subscriptions,
+      subId: "live-1",
+      message: "error: database unavailable",
+      sendReq: async () => {},
+    });
+
+    assert.deepEqual(
+      scheduled.map(({ delay }) => delay).sort((left, right) => left - right),
+      [1_000, 8_000],
+    );
+    assert.equal(dedupe.record("channel", "newest-replay", 2_001), true);
+    assert.equal(
+      dedupe.record("channel", "boundary", 1),
+      false,
+      "cap eviction must remain suspended until the older replay page arrives",
+    );
+
+    handleSubscriptionEose({
+      subscriptions,
+      subId: "live-1",
+      closeSubscription: async () => {},
+    });
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test("overlapping socket and CLOSED recovery flush only after both complete", () => {
+  const storage = memoryStorage();
+  const dedupe = new ThreadReplyNotificationDedupe("user", storage);
+  dedupe.reconcileActiveChannels(["channel"]);
+  const writesBeforeReplay = storage.writeCount;
+
+  dedupe.handleSubscriptionRecoveryState(true);
+  dedupe.handleConnectionState("reconnecting");
+  assert.equal(dedupe.record("channel", "offline", 100), true);
+  dedupe.handleSubscriptionRecoveryState(false);
+  assert.equal(storage.writeCount, writesBeforeReplay);
+
+  dedupe.handleConnectionState("connected");
+  assert.equal(storage.writeCount, writesBeforeReplay + 1);
+});
+
+test("stalled socket acquires replay ownership before CLOSED recovery ends", () => {
+  const dedupe = new ThreadReplyNotificationDedupe("user", undefined);
+  dedupe.reconcileActiveChannels(["channel"]);
+  dedupe.setChannelReplayFloor("channel", 0);
+  assert.equal(dedupe.record("channel", "boundary", 1), true);
+  for (let index = 1; index < THREAD_REPLY_SEEN_MAX_ITEMS; index += 1) {
+    assert.equal(dedupe.record("channel", `seen-${index}`, index + 1), true);
+  }
+
+  dedupe.handleSubscriptionRecoveryState(true);
+  assert.equal(dedupe.record("channel", "newest-replay", 2_001), true);
+  dedupe.handleConnectionState("stalled");
+  dedupe.handleSubscriptionRecoveryState(false);
+  assert.equal(
+    dedupe.record("channel", "boundary", 1),
+    false,
+    "stalled reset must retain the boundary until socket replay completes",
+  );
+  dedupe.handleConnectionState("reconnecting");
+  dedupe.handleConnectionState("connected");
+});
+
+test("pruning is per-channel and follows each live filter's actual since", () => {
+  const dedupe = new ThreadReplyNotificationDedupe("user", memoryStorage());
+
+  dedupe.reconcileActiveChannels(["busy", "quiet"]);
+  dedupe.setChannelReplayFloor("busy", 900);
+  dedupe.setChannelReplayFloor("quiet", 0);
+  assert.equal(dedupe.record("busy", "busy-old", 994), true);
+  assert.equal(dedupe.record("busy", "busy-floor", 995), true);
+  assert.equal(dedupe.record("quiet", "quiet-boundary", 96), true);
+
+  dedupe.setChannelReplayFloor("busy", 995);
+  dedupe.setChannelReplayFloor("quiet", 95);
+
+  assert.equal(dedupe.record("busy", "busy-old", 994), true);
+  assert.equal(dedupe.record("busy", "busy-floor", 995), false);
+  assert.equal(
+    dedupe.record("quiet", "quiet-boundary", 96),
+    false,
+    "busy-channel replay floor must not evict quiet-channel records",
+  );
+});
+
+test("size cap evicts oldest records only after replay completes", () => {
+  const dedupe = new ThreadReplyNotificationDedupe("user", memoryStorage());
+
+  dedupe.reconcileActiveChannels(["channel"]);
+  dedupe.setChannelReplayFloor("channel", 0);
+  dedupe.handleConnectionState("reconnecting");
+  for (let index = 0; index <= THREAD_REPLY_SEEN_MAX_ITEMS; index += 1) {
+    assert.equal(dedupe.record("channel", `event-${index}`, index + 1), true);
+  }
+
+  assert.equal(
+    dedupe.record("channel", "event-0", 1),
+    false,
+    "cap must remain suspended while older replay pages can still arrive",
+  );
+
+  dedupe.handleConnectionState("connected");
+  assert.equal(dedupe.record("channel", "event-0", 1), true);
+  assert.equal(
+    dedupe.record(
+      "channel",
+      `event-${THREAD_REPLY_SEEN_MAX_ITEMS}`,
+      THREAD_REPLY_SEEN_MAX_ITEMS + 1,
+    ),
+    false,
+    "newest records must survive the cap",
+  );
+});
+
+test("replay coalesces persistence and stores the final capped set", () => {
+  const storage = memoryStorage();
+  const dedupe = new ThreadReplyNotificationDedupe("user", storage);
+
+  dedupe.reconcileActiveChannels(["channel"]);
+  dedupe.setChannelReplayFloor("channel", 0);
+  dedupe.handleConnectionState("reconnecting");
+  const writesBeforeReplay = storage.writeCount;
+
+  for (let index = 0; index <= THREAD_REPLY_SEEN_MAX_ITEMS; index += 1) {
+    assert.equal(dedupe.record("channel", `replay-${index}`, index + 1), true);
+  }
+
+  assert.equal(
+    storage.writeCount,
+    writesBeforeReplay,
+    "replayed events must not synchronously rewrite the growing cache",
+  );
+
+  dedupe.handleConnectionState("connected");
+  assert.equal(storage.writeCount, writesBeforeReplay + 1);
+
+  const remounted = new ThreadReplyNotificationDedupe("user", storage);
+  remounted.reconcileActiveChannels(["channel"]);
+  remounted.setChannelReplayFloor("channel", 0);
+  assert.equal(remounted.record("channel", "replay-0", 1), true);
+  assert.equal(
+    remounted.record(
+      "channel",
+      `replay-${THREAD_REPLY_SEEN_MAX_ITEMS}`,
+      THREAD_REPLY_SEEN_MAX_ITEMS + 1,
+    ),
+    false,
+    "the single replay flush must persist the capped newest records",
+  );
+});
+
+test("storage failure disables repeated serialization attempts", () => {
+  let writeCount = 0;
+  const storage = {
+    getItem: () => null,
+    setItem: () => {
+      writeCount += 1;
+      throw new Error("quota exceeded");
+    },
+  };
+  const dedupe = new ThreadReplyNotificationDedupe("user", storage);
+
+  dedupe.reconcileActiveChannels(["channel"]);
+  dedupe.setChannelReplayFloor("channel", 0);
+  for (let index = 0; index < 100; index += 1) {
+    assert.equal(dedupe.record("channel", `event-${index}`, index), true);
+  }
+
+  assert.equal(writeCount, 1);
+  assert.equal(dedupe.record("channel", "event-99", 99), false);
+});

--- a/desktop/src/features/channels/threadReplyNotificationDedupe.ts
+++ b/desktop/src/features/channels/threadReplyNotificationDedupe.ts
@@ -1,0 +1,287 @@
+import type { ConnectionState } from "@/shared/api/relayClientShared";
+
+const STORAGE_KEY_PREFIX = "buzz-thread-reply-desktop-seen.v1";
+export const THREAD_REPLY_SEEN_MAX_ITEMS = 2_000;
+
+type SeenThreadReply = {
+  eventId: string;
+  channelId: string;
+  createdAt: number;
+};
+
+type SeenStorage = Pick<Storage, "getItem" | "setItem">;
+
+function storageKey(pubkey: string) {
+  return `${STORAGE_KEY_PREFIX}:${pubkey}`;
+}
+
+function defaultStorage(): SeenStorage | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function isSeenThreadReply(value: unknown): value is SeenThreadReply {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<SeenThreadReply>;
+  return (
+    typeof candidate.eventId === "string" &&
+    typeof candidate.channelId === "string" &&
+    typeof candidate.createdAt === "number" &&
+    Number.isFinite(candidate.createdAt)
+  );
+}
+
+function readSeenThreadReplies(
+  pubkey: string,
+  storage: SeenStorage | undefined,
+): SeenThreadReply[] {
+  if (!storage || pubkey.length === 0) {
+    return [];
+  }
+
+  try {
+    const rawValue = storage.getItem(storageKey(pubkey));
+    if (!rawValue) {
+      return [];
+    }
+
+    const parsed: unknown = JSON.parse(rawValue);
+    return Array.isArray(parsed) ? parsed.filter(isSeenThreadReply) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Remembers thread replies already offered to the desktop notification path.
+ *
+ * Reconnect history is delivered newest-page first, so cap eviction is
+ * suspended during socket reconnect and retryable CLOSED recovery; otherwise
+ * a burst could discard an older boundary ID before its replay page arrives.
+ * Age eviction follows each broad subscription's original `since`, because
+ * that is the actual history window restored by both recovery paths.
+ */
+export class ThreadReplyNotificationDedupe {
+  private readonly pubkey: string;
+  private readonly storage: SeenStorage | undefined;
+  private readonly seenById = new Map<string, SeenThreadReply>();
+  private readonly channelReplayFloors = new Map<string, number>();
+  private activeChannelIds: Set<string> | undefined;
+  private connectionReplayInProgress = false;
+  private subscriptionReplayCount = 0;
+  private persistenceDirty = false;
+  private persistenceDisabled = false;
+
+  constructor(
+    pubkey: string,
+    storage: SeenStorage | undefined = defaultStorage(),
+  ) {
+    this.pubkey = pubkey;
+    this.storage = storage;
+    for (const record of readSeenThreadReplies(pubkey, storage)) {
+      this.seenById.set(record.eventId, record);
+    }
+    // Do not cap persisted data until active channels are known. Departed
+    // records must be removed before they can displace an active-channel ID.
+  }
+
+  /** Removes replay state for channels without an active broad subscription. */
+  reconcileActiveChannels(channelIds: Iterable<string>) {
+    const activeChannelIds = new Set(channelIds);
+    for (const channelId of this.channelReplayFloors.keys()) {
+      if (!activeChannelIds.has(channelId)) {
+        this.channelReplayFloors.delete(channelId);
+      }
+    }
+    for (const [eventId, record] of this.seenById) {
+      if (!activeChannelIds.has(record.channelId)) {
+        this.seenById.delete(eventId);
+      }
+    }
+
+    this.activeChannelIds = activeChannelIds;
+    this.pruneAllChannels();
+    if (!this.isReplayInProgress()) {
+      this.enforceSizeCap();
+    }
+    this.persist();
+  }
+
+  setChannelReplayFloor(channelId: string, replayFloor: number) {
+    this.activeChannelIds?.add(channelId);
+    this.channelReplayFloors.set(channelId, replayFloor);
+    if (this.activeChannelIds && !this.isReplayInProgress()) {
+      this.pruneChannel(channelId, replayFloor);
+      this.enforceSizeCap();
+      this.persist();
+    }
+  }
+
+  /** Records an observed reply and returns true only for its first sighting. */
+  record(channelId: string, eventId: string, createdAt: number) {
+    if (this.activeChannelIds && !this.activeChannelIds.has(channelId)) {
+      return false;
+    }
+    if (this.seenById.has(eventId)) {
+      return false;
+    }
+
+    this.seenById.set(eventId, { eventId, channelId, createdAt });
+    if (this.activeChannelIds && !this.isReplayInProgress()) {
+      this.enforceSizeCap();
+    }
+    this.persist();
+    return true;
+  }
+
+  handleConnectionState(state: ConnectionState) {
+    if (state === "reconnecting" || state === "stalled") {
+      if (!this.connectionReplayInProgress) {
+        const replayWasInProgress = this.isReplayInProgress();
+        this.connectionReplayInProgress = true;
+        if (replayWasInProgress) return;
+        // The original long-lived live REQ is restored on reconnect, so its
+        // immutable `since` is the actual replay floor for persisted IDs.
+        this.beginReplay();
+      }
+      return;
+    }
+
+    if (state === "connected" && this.connectionReplayInProgress) {
+      this.connectionReplayInProgress = false;
+      this.finishReplayIfIdle();
+    }
+  }
+
+  handleSubscriptionRecoveryState(recovering: boolean) {
+    this.handleSubscriptionReplayState(recovering);
+  }
+
+  handleSubscriptionReplayState(replaying: boolean) {
+    if (replaying) {
+      const replayWasInProgress = this.isReplayInProgress();
+      this.subscriptionReplayCount += 1;
+      if (!replayWasInProgress) {
+        this.beginReplay();
+      }
+      return;
+    }
+
+    if (this.subscriptionReplayCount === 0) return;
+    this.subscriptionReplayCount -= 1;
+    this.finishReplayIfIdle();
+  }
+
+  /** Flushes pending replay state when this dedupe instance is handed off. */
+  flush() {
+    this.pruneAllChannels();
+    if (this.activeChannelIds) {
+      this.enforceSizeCap();
+    }
+    this.flushPersistence();
+  }
+
+  private pruneAllChannels() {
+    for (const [channelId, replayFloor] of this.channelReplayFloors) {
+      this.pruneChannel(channelId, replayFloor);
+    }
+  }
+
+  private pruneChannel(channelId: string, replayFloor: number) {
+    for (const [eventId, record] of this.seenById) {
+      if (record.channelId === channelId && record.createdAt < replayFloor) {
+        this.seenById.delete(eventId);
+      }
+    }
+  }
+
+  private enforceSizeCap() {
+    const excess = this.seenById.size - THREAD_REPLY_SEEN_MAX_ITEMS;
+    if (excess <= 0) {
+      return;
+    }
+
+    const oldest = [...this.seenById.values()]
+      .sort((left, right) => left.createdAt - right.createdAt)
+      .slice(0, excess);
+    for (const record of oldest) {
+      this.seenById.delete(record.eventId);
+    }
+  }
+
+  private persist() {
+    this.persistenceDirty = true;
+    if (this.isReplayInProgress()) {
+      return;
+    }
+    this.flushPersistence();
+  }
+
+  private isReplayInProgress() {
+    return this.connectionReplayInProgress || this.subscriptionReplayCount > 0;
+  }
+
+  private beginReplay() {
+    this.pruneAllChannels();
+    this.persist();
+  }
+
+  private finishReplayIfIdle() {
+    if (this.isReplayInProgress()) return;
+    this.pruneAllChannels();
+    if (this.activeChannelIds) {
+      this.enforceSizeCap();
+    }
+    this.persist();
+  }
+
+  private flushPersistence() {
+    if (!this.persistenceDirty) {
+      return;
+    }
+    if (!this.storage || this.pubkey.length === 0 || this.persistenceDisabled) {
+      this.persistenceDirty = false;
+      return;
+    }
+
+    try {
+      this.storage.setItem(
+        storageKey(this.pubkey),
+        JSON.stringify([...this.seenById.values()]),
+      );
+      this.persistenceDirty = false;
+    } catch {
+      // In-memory dedupe still works when localStorage is unavailable/full.
+      // Disable more serialization attempts for this instance so a full store
+      // cannot add repeated main-thread work after the first failed flush.
+      this.persistenceDisabled = true;
+      this.persistenceDirty = false;
+    }
+  }
+}
+
+export function shouldDeliverThreadReplyDesktopNotification({
+  isFirstSeen,
+  isEligible,
+  isActiveChannel,
+  notifyForActiveChannel,
+}: {
+  isFirstSeen: boolean;
+  isEligible: boolean;
+  isActiveChannel: boolean;
+  notifyForActiveChannel: boolean;
+}) {
+  return (
+    isFirstSeen && isEligible && (!isActiveChannel || notifyForActiveChannel)
+  );
+}

--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -22,6 +22,10 @@ import {
 
 import { isDmNotifiableKind } from "./isDmNotifiableKind";
 import { refreshChannelsWhenIdle } from "./refreshChannelsWhenIdle";
+import {
+  shouldDeliverThreadReplyDesktopNotification,
+  ThreadReplyNotificationDedupe,
+} from "./threadReplyNotificationDedupe";
 
 export type UseLiveChannelUpdatesOptions = {
   currentPubkey?: string;
@@ -70,6 +74,45 @@ export type UseLiveChannelUpdatesOptions = {
 
 const LIVE_SUBSCRIPTION_RETRY_BASE_MS = 1_000;
 const LIVE_SUBSCRIPTION_RETRY_MAX_MS = 30_000;
+
+type LiveChannelSubscription = {
+  dispose: () => Promise<void>;
+  replayFloor: number;
+  dedupe: ThreadReplyNotificationDedupe;
+};
+
+export function disposeStaleLiveChannelSubscriptions({
+  activeSubs,
+  targetIds,
+  dedupe,
+}: {
+  activeSubs: Map<string, LiveChannelSubscription>;
+  targetIds: ReadonlySet<string>;
+  dedupe: ThreadReplyNotificationDedupe;
+}) {
+  for (const [channelId, active] of activeSubs) {
+    if (targetIds.has(channelId) && active.dedupe === dedupe) continue;
+    activeSubs.delete(channelId);
+    void active.dispose().catch(() => {});
+  }
+}
+
+export async function reconcileAfterLiveSubscriptionAdditions({
+  additions,
+  isCurrentSync,
+  reconcile,
+}: {
+  additions: Promise<unknown>[];
+  isCurrentSync: () => boolean;
+  reconcile: () => void;
+}) {
+  await Promise.allSettled(additions);
+  if (!isCurrentSync()) {
+    return false;
+  }
+  reconcile();
+  return true;
+}
 
 // get_channels is an expensive O(channels) relay fan-out. Incoming traffic for
 // non-active channels arrives in bursts, so coalesce the refetch into a single
@@ -176,6 +219,21 @@ export function useLiveChannelUpdates(
     [channels],
   );
   const dmSubscriptionStartedAtRef = React.useRef(0);
+  const threadReplyDedupeRef = React.useRef<{
+    pubkey: string;
+    value: ThreadReplyNotificationDedupe;
+  } | null>(null);
+  if (threadReplyDedupeRef.current?.pubkey !== normalizedCurrentPubkey) {
+    threadReplyDedupeRef.current = {
+      pubkey: normalizedCurrentPubkey,
+      value: new ThreadReplyNotificationDedupe(normalizedCurrentPubkey),
+    };
+  }
+  const threadReplyDedupe = threadReplyDedupeRef.current.value;
+  const pendingThreadReplyDedupeFlushRef = React.useRef<{
+    dedupe: ThreadReplyNotificationDedupe;
+    timeout: number;
+  } | null>(null);
 
   // Reset subscription timestamp when identity changes.
   React.useEffect(() => {
@@ -280,6 +338,12 @@ export function useLiveChannelUpdates(
     handleDmEvent(event, isFirstNotificationDelivery);
 
     if (isExternalTriggerEvent && isFirstNotificationDelivery) {
+      // Eligibility can change after delivery (mute, follow, participation),
+      // so record first sight before consulting that mutable state.
+      const isFirstSeenThreadReply =
+        isThreadedReply && !isDmChannel
+          ? threadReplyDedupe.record(channelId, event.id, event.created_at)
+          : false;
       const shouldNotify = shouldNotifyForEvent(
         event,
         normalizedCurrentPubkey,
@@ -304,11 +368,15 @@ export function useLiveChannelUpdates(
         }
       }
 
-      if (shouldNotify && isThreadedReply) {
-        if (
-          !dmChannelMap.has(channelId) &&
-          (channelId !== activeChannelId || options.notifyForActiveChannel)
-        ) {
+      if (isThreadedReply) {
+        const shouldDeliverDesktopNotification =
+          shouldDeliverThreadReplyDesktopNotification({
+            isFirstSeen: isFirstSeenThreadReply,
+            isEligible: shouldNotify,
+            isActiveChannel: channelId === activeChannelId,
+            notifyForActiveChannel: options.notifyForActiveChannel ?? false,
+          });
+        if (shouldDeliverDesktopNotification) {
           options.onThreadReplyDesktopNotification?.(channelId, event);
         }
       }
@@ -330,6 +398,12 @@ export function useLiveChannelUpdates(
     );
   });
 
+  const handleLiveChannelEvent = React.useEffectEvent(
+    (channelId: string, event: RelayEvent) => {
+      handleIncomingMessage(withChannelTagFallback(event, channelId));
+    },
+  );
+
   const handleMentionEvent = React.useEffectEvent((event: RelayEvent) => {
     if (!isExternalMentionEvent(event, normalizedCurrentPubkey)) {
       return;
@@ -344,6 +418,32 @@ export function useLiveChannelUpdates(
   });
 
   React.useEffect(() => {
+    const pendingFlush = pendingThreadReplyDedupeFlushRef.current;
+    if (pendingFlush?.dedupe === threadReplyDedupe) {
+      window.clearTimeout(pendingFlush.timeout);
+      pendingThreadReplyDedupeFlushRef.current = null;
+    }
+    const unsubscribe = relayClient.subscribeToConnectionState((state) => {
+      threadReplyDedupe.handleConnectionState(state);
+    });
+    return () => {
+      unsubscribe();
+      // Delay handoff flushing by one task so React StrictMode's immediate
+      // effect cleanup/setup cycle can cancel it for the same live instance.
+      const timeout = window.setTimeout(() => {
+        threadReplyDedupe.flush();
+        if (pendingThreadReplyDedupeFlushRef.current?.timeout === timeout) {
+          pendingThreadReplyDedupeFlushRef.current = null;
+        }
+      }, 0);
+      pendingThreadReplyDedupeFlushRef.current = {
+        dedupe: threadReplyDedupe,
+        timeout,
+      };
+    };
+  }, [threadReplyDedupe]);
+
+  React.useEffect(() => {
     return relayClient.subscribeToReconnects(() => {
       void queryClient.invalidateQueries({ queryKey: channelsQueryKey });
 
@@ -353,23 +453,36 @@ export function useLiveChannelUpdates(
     });
   }, [queryClient]);
 
-  const liveSubsRef = React.useRef(new Map<string, () => Promise<void>>());
+  const liveSubsRef = React.useRef(new Map<string, LiveChannelSubscription>());
+  const liveSyncGenerationRef = React.useRef(0);
 
   React.useEffect(() => {
     let isCancelled = false;
     let retryTimeout: number | undefined;
     let retryAttempt = 0;
+    const syncGeneration = liveSyncGenerationRef.current + 1;
+    liveSyncGenerationRef.current = syncGeneration;
+    const isCurrentSync = () =>
+      !isCancelled && liveSyncGenerationRef.current === syncGeneration;
 
     const syncSubs = async (): Promise<boolean> => {
+      if (!isCurrentSync()) {
+        return true;
+      }
       const activeSubs = liveSubsRef.current;
       const targetIds = new Set(channelIdsKey ? channelIdsKey.split(",") : []);
 
-      for (const [channelId, dispose] of activeSubs) {
-        if (!targetIds.has(channelId)) {
-          activeSubs.delete(channelId);
-          void dispose().catch(() => {});
-        }
+      disposeStaleLiveChannelSubscriptions({
+        activeSubs,
+        targetIds,
+        dedupe: threadReplyDedupe,
+      });
+      for (const [channelId, active] of activeSubs) {
+        threadReplyDedupe.setChannelReplayFloor(channelId, active.replayFloor);
       }
+      // Keep target channels provisionally active while their subscriptions
+      // settle so same-second replay cannot lose persisted boundary IDs.
+      threadReplyDedupe.reconcileActiveChannels(targetIds);
 
       if (targetIds.size > 0) {
         // Record the subscription start time so handleDmEvent can distinguish
@@ -382,21 +495,31 @@ export function useLiveChannelUpdates(
         .filter((channelId) => !activeSubs.has(channelId))
         .map(async (channelId) => {
           try {
+            const subscriptionSince = Math.floor(Date.now() / 1_000);
+            threadReplyDedupe.setChannelReplayFloor(
+              channelId,
+              subscriptionSince,
+            );
             const dispose = await relayClient.subscribeLive(
               {
                 kinds: [...CHANNEL_EVENT_KINDS],
                 "#h": [channelId],
                 limit: 1000,
-                since: Math.floor(Date.now() / 1_000),
+                since: subscriptionSince,
               },
-              (event) =>
-                handleIncomingMessage(withChannelTagFallback(event, channelId)),
+              (event) => handleLiveChannelEvent(channelId, event),
+              (recovering) =>
+                threadReplyDedupe.handleSubscriptionRecoveryState(recovering),
             );
-            if (isCancelled) {
+            if (!isCurrentSync()) {
               void dispose().catch(() => {});
               return;
             }
-            activeSubs.set(channelId, dispose);
+            activeSubs.set(channelId, {
+              dispose,
+              replayFloor: subscriptionSince,
+              dedupe: threadReplyDedupe,
+            });
           } catch (err) {
             anyFailed = true;
             console.error(
@@ -406,7 +529,15 @@ export function useLiveChannelUpdates(
             );
           }
         });
-      await Promise.allSettled(additions);
+      const didReconcile = await reconcileAfterLiveSubscriptionAdditions({
+        additions,
+        isCurrentSync,
+        reconcile: () =>
+          threadReplyDedupe.reconcileActiveChannels(activeSubs.keys()),
+      });
+      if (!didReconcile) {
+        return true;
+      }
       return !anyFailed;
     };
 
@@ -436,7 +567,7 @@ export function useLiveChannelUpdates(
         window.clearTimeout(retryTimeout);
       }
     };
-  }, [channelIdsKey]);
+  }, [channelIdsKey, threadReplyDedupe]);
 
   // Subscribe to mention events per channel with a diff-based manager: only
   // subscribe newly-added channels and unsubscribe removed ones on each sync.
@@ -541,7 +672,7 @@ export function useLiveChannelUpdates(
     return () => {
       channelsInvalidateRef.current?.cancel();
 
-      for (const dispose of liveSubsRef.current.values()) {
+      for (const { dispose } of liveSubsRef.current.values()) {
         void dispose().catch(() => {});
       }
       liveSubsRef.current.clear();

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -27,10 +27,10 @@ import {
   buildGlobalStreamFilter,
 } from "@/shared/api/relayChannelFilters";
 import {
-  clearClosedRetry,
   handleRelayClosed,
   handleSubscriptionEose,
   prepareSubscriptionEvent,
+  releaseLiveSubscription,
 } from "@/shared/api/relayClosedRecovery";
 import { replayLiveSubscriptions } from "@/shared/api/relayReconnectReplay";
 import {
@@ -44,6 +44,7 @@ import {
   requestHistoryGated,
 } from "@/shared/api/relayGateBoundary";
 import { RelayConnectionStateEmitter } from "@/shared/api/relayConnectionStateEmitter";
+import { deliverBufferedSubscriptionEvents } from "@/shared/api/relayEventBuffer";
 import {
   isServiceRestartClose,
   isWebSocketClose,
@@ -150,7 +151,7 @@ export class RelayClient {
         window.clearTimeout(sub.timeout);
         sub.reject(error);
       } else {
-        clearClosedRetry(sub);
+        releaseLiveSubscription(sub);
       }
       this.subscriptions.delete(subId);
     }
@@ -406,12 +407,12 @@ export class RelayClient {
   async subscribeToAllStreamMessages(onEvent: (event: RelayEvent) => void) {
     return this.subscribe(buildGlobalStreamFilter(50), onEvent);
   }
-
   async subscribeLive(
     filter: RelaySubscriptionFilter,
     onEvent: (event: RelayEvent) => void,
+    onClosedRecoveryStateChange?: (recovering: boolean) => void,
   ) {
-    return this.subscribe(filter, onEvent);
+    return this.subscribe(filter, onEvent, onClosedRecoveryStateChange);
   }
 
   async subscribeToChannelMentionEvents(
@@ -426,10 +427,9 @@ export class RelayClient {
   }
 
   async preconnect() {
-    // Explicit re-engagement. If the session went terminal (auth rejection)
-    // the caller is asking us to try again, so clear the latch. A manual
-    // reconnect also bypasses the current delay once; ordinary operations do
-    // not, so background traffic cannot continuously defeat backoff.
+    // Explicit re-engagement after auth rejection clears the terminal latch.
+    // Manual reconnect also bypasses the current delay once; ordinary
+    // background traffic must wait for scheduled backoff.
     this.terminal = false;
     this.keepAliveRequested = true;
     if (this.reconnectTimeout !== null) {
@@ -567,8 +567,10 @@ export class RelayClient {
       }, BACKOFF_RESET_STABLE_MS);
 
       this.connectionStateEmitter.set("connected");
-      await this.replayLiveSubscriptions();
       this.stallWatchdog.start();
+      await this.replayLiveSubscriptions();
+      if (generation !== this.connectionGeneration)
+        throw new Error("Relay changed during subscription replay.");
       this.emitReconnectIfNeeded();
     } catch (error) {
       const connectionError = this.normalizeRelayError(
@@ -585,6 +587,7 @@ export class RelayClient {
   private async subscribe(
     filter: RelaySubscriptionFilter,
     onEvent: (event: RelayEvent) => void,
+    onClosedRecoveryStateChange?: (recovering: boolean) => void,
   ) {
     await this.ensureConnected();
 
@@ -606,6 +609,8 @@ export class RelayClient {
       mode: "live",
       filter,
       onEvent,
+      onClosedRecoveryStateChange,
+      onClosedRecoveryTimeout: (error) => this.resetConnection(error),
       resolveReady,
     });
 
@@ -628,7 +633,7 @@ export class RelayClient {
       }
 
       this.subscriptions.delete(subId);
-      clearClosedRetry(active);
+      releaseLiveSubscription(active);
       await this.closeSubscription(subId);
     };
   }
@@ -866,17 +871,11 @@ export class RelayClient {
   }
 
   private flushEventBuffer() {
+    window.clearTimeout(this.flushTimeout ?? undefined);
     this.flushTimeout = null;
     const buffer = this.eventBuffer;
     this.eventBuffer = [];
-
-    // Re-lookup: subscriptions removed during batch window are intentionally skipped.
-    for (const { subId, event } of buffer) {
-      const subscription = this.subscriptions.get(subId);
-      if (subscription?.mode === "live") {
-        subscription.onEvent(event);
-      }
-    }
+    deliverBufferedSubscriptionEvents(buffer, this.subscriptions);
   }
 
   private handleEose(subId: string) {
@@ -884,6 +883,7 @@ export class RelayClient {
       subscriptions: this.subscriptions,
       subId,
       closeSubscription: (id) => this.closeSubscription(id),
+      beforeLiveRecoveryComplete: () => this.flushEventBuffer(),
     });
   }
 
@@ -939,6 +939,7 @@ export class RelayClient {
         visibleChannelId: this.visibleChannelId,
         isActive: () => this.connectionGeneration === generation,
       });
+      this.flushEventBuffer();
     } catch (error) {
       const reconnectError =
         error instanceof Error
@@ -1070,9 +1071,7 @@ export class RelayClient {
         continue;
       }
 
-      subscription.resolveReady?.();
-      subscription.resolveReady = undefined;
-      clearClosedRetry(subscription);
+      releaseLiveSubscription(subscription);
     }
 
     for (const [eventId, pendingEvent] of this.pendingEvents) {

--- a/desktop/src/shared/api/relayClientShared.ts
+++ b/desktop/src/shared/api/relayClientShared.ts
@@ -58,8 +58,14 @@ type LiveSubscription = {
   mode: "live";
   filter: RelaySubscriptionFilter;
   onEvent: (event: RelayEvent) => void;
+  onClosedRecoveryStateChange?: (recovering: boolean) => void;
+  onClosedRecoveryTimeout?: (error: Error) => void;
   resolveReady?: () => void;
+  resolveReconnectEose?: () => void;
+  refreshReconnectEoseTimeout?: () => void;
   lastSeenCreatedAt?: number;
+  closedRecoveryInProgress?: boolean;
+  closedRecoveryTimeout?: number;
   closedRetryAttempt?: number;
   closedRetryTimeout?: number;
 };

--- a/desktop/src/shared/api/relayClosedRecovery.test.mjs
+++ b/desktop/src/shared/api/relayClosedRecovery.test.mjs
@@ -4,11 +4,13 @@ import test from "node:test";
 import {
   handleRelayClosed,
   handleSubscriptionEose,
+  releaseLiveSubscription,
 } from "./relayClosedRecovery.ts";
 import {
   requestFirstEventGated,
   requestHistoryGated,
 } from "./relayGateBoundary.ts";
+import { replayLiveSubscriptions } from "./relayReconnectReplay.ts";
 
 // ── Fake-timer setup ──────────────────────────────────────────────────────────
 // The rate-limit gate and closed-retry logic use window.setTimeout/clearTimeout.
@@ -262,6 +264,7 @@ test("first-event request resolves null when EOSE arrives without an event", asy
 
 test("production CLOSED handler removes terminal live subscriptions", () => {
   let readyCalls = 0;
+  let reconnectEoseCalls = 0;
   const subscriptions = new Map([
     [
       "live-1",
@@ -271,6 +274,9 @@ test("production CLOSED handler removes terminal live subscriptions", () => {
         onEvent: () => {},
         resolveReady: () => {
           readyCalls += 1;
+        },
+        resolveReconnectEose: () => {
+          reconnectEoseCalls += 1;
         },
       },
     ],
@@ -283,6 +289,333 @@ test("production CLOSED handler removes terminal live subscriptions", () => {
   });
   assert.equal(subscriptions.has("live-1"), false);
   assert.equal(readyCalls, 1);
+  assert.equal(reconnectEoseCalls, 1);
+});
+
+test("retryable CLOSED preserves the original long-lived filter", async () => {
+  const originalWindow = globalThis.window;
+  const scheduled = [];
+  globalThis.window = {
+    clearTimeout: () => {},
+    setTimeout: (callback, delay) => {
+      scheduled.push({ callback, delay });
+      return 42;
+    },
+  };
+  try {
+    const sentFilters = [];
+    const subscriptions = new Map([
+      [
+        "live-1",
+        {
+          mode: "live",
+          filter: {
+            kinds: [9],
+            "#h": ["channel-1"],
+            limit: 1_000,
+            since: 900,
+          },
+          onEvent: () => {},
+          lastSeenCreatedAt: 1_000,
+        },
+      ],
+    ]);
+
+    handleRelayClosed({
+      subscriptions,
+      subId: "live-1",
+      message: "error: database unavailable",
+      sendReq: async (_subId, filter) => {
+        sentFilters.push(filter);
+      },
+    });
+
+    assert.deepEqual(
+      scheduled.map(({ delay }) => delay),
+      [8_000, 1_000],
+    );
+    scheduled.find(({ delay }) => delay === 1_000).callback();
+    await Promise.resolve();
+    assert.deepEqual(sentFilters, [
+      {
+        kinds: [9],
+        "#h": ["channel-1"],
+        limit: 1_000,
+        since: 900,
+      },
+    ]);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test("retryable CLOSED recovery drains buffered events before completing", () => {
+  const originalWindow = globalThis.window;
+  const scheduled = [];
+  globalThis.window = {
+    clearTimeout: () => {},
+    setTimeout: (callback, delay) => {
+      scheduled.push({ callback, delay });
+      return scheduled.length;
+    },
+  };
+  try {
+    const lifecycle = [];
+    const subscription = {
+      mode: "live",
+      filter: { kinds: [9], limit: 50 },
+      onEvent: () => {},
+      onClosedRecoveryStateChange: (recovering) =>
+        lifecycle.push(recovering ? "recovering" : "live"),
+    };
+    const subscriptions = new Map([["live-1", subscription]]);
+    const closedInput = {
+      subscriptions,
+      subId: "live-1",
+      message: "error: database unavailable",
+      sendReq: async () => {},
+    };
+
+    handleRelayClosed(closedInput);
+    handleRelayClosed(closedInput);
+    assert.deepEqual(lifecycle, ["recovering"]);
+    assert.deepEqual(
+      scheduled.map(({ delay }) => delay),
+      [8_000, 1_000],
+    );
+
+    handleSubscriptionEose({
+      subscriptions,
+      subId: "live-1",
+      closeSubscription: async () => {},
+      beforeLiveRecoveryComplete: () => lifecycle.push("drained"),
+    });
+    assert.deepEqual(lifecycle, ["recovering", "drained", "live"]);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test("repeated retryable CLOSED cannot extend the reconnect EOSE deadline", async () => {
+  const originalWindow = globalThis.window;
+  const scheduled = [];
+  globalThis.window = {
+    clearTimeout: () => {},
+    setTimeout: (callback, delay) => {
+      scheduled.push({ callback, delay });
+      return scheduled.length;
+    },
+  };
+  try {
+    const subscription = {
+      mode: "live",
+      filter: {
+        kinds: [9],
+        "#h": ["channel-1"],
+        limit: 1_000,
+        since: 900,
+      },
+      onEvent: () => {},
+      lastSeenCreatedAt: 1_000,
+    };
+    const subscriptions = new Map([["live-1", subscription]]);
+    const sentFilters = [];
+    const replayOutcome = replayLiveSubscriptions({
+      subscriptions,
+      now: 2_000,
+      eoseTimeoutMs: 10,
+      sendRaw: async () => {},
+      requestHistory: async () => [],
+    }).then(
+      () => "resolved",
+      (error) => error,
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      handleRelayClosed({
+        subscriptions,
+        subId: "live-1",
+        message: "error: database unavailable",
+        sendReq: async (_subId, filter) => {
+          sentFilters.push(filter);
+        },
+      });
+      assert.equal(scheduled.filter(({ delay }) => delay === 8_000).length, 1);
+      scheduled.find(({ delay }) => delay === 1_000 * 2 ** attempt).callback();
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    const outcome = await replayOutcome;
+    assert.equal(outcome instanceof Error, true);
+    assert.match(outcome.message, /EOSE/);
+    assert.equal(subscription.resolveReconnectEose, undefined);
+    assert.deepEqual(
+      sentFilters.map((filter) => filter.since),
+      [900, 900, 900],
+    );
+    releaseLiveSubscription(subscription);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test("standalone CLOSED recovery has a bounded EOSE deadline", async () => {
+  const originalWindow = globalThis.window;
+  const scheduled = [];
+  const clearedTimeouts = [];
+  globalThis.window = {
+    clearTimeout: (timeout) => clearedTimeouts.push(timeout),
+    setTimeout: (callback, delay) => {
+      scheduled.push({ callback, delay, id: scheduled.length + 1 });
+      return scheduled.length;
+    },
+  };
+  try {
+    const lifecycle = [];
+    let timeoutError;
+    const subscription = {
+      mode: "live",
+      filter: { kinds: [9], limit: 50 },
+      onEvent: () => {},
+      onClosedRecoveryStateChange: (recovering) => lifecycle.push(recovering),
+      onClosedRecoveryTimeout: (error) => {
+        assert.equal(subscription.closedRecoveryInProgress, true);
+        timeoutError = error;
+        releaseLiveSubscription(subscription);
+      },
+    };
+    const subscriptions = new Map([["live-1", subscription]]);
+
+    handleRelayClosed({
+      subscriptions,
+      subId: "live-1",
+      message: "error: database unavailable",
+      sendReq: async () => {},
+    });
+    scheduled.find(({ delay }) => delay === 1_000).callback();
+    await Promise.resolve();
+    assert.deepEqual(lifecycle, [true]);
+
+    scheduled.find(({ delay }) => delay === 8_000).callback();
+    assert.match(timeoutError.message, /EOSE/);
+    assert.deepEqual(lifecycle, [true, false]);
+    assert.equal(subscription.closedRecoveryTimeout, undefined);
+    assert.equal(clearedTimeouts.includes(1), false);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test("socket reset starts CLOSED retry backoff from the base delay", () => {
+  const originalWindow = globalThis.window;
+  const scheduled = [];
+  globalThis.window = {
+    clearTimeout: () => {},
+    setTimeout: (callback, delay) => {
+      scheduled.push({ callback, delay });
+      return scheduled.length;
+    },
+  };
+  try {
+    const subscription = {
+      mode: "live",
+      filter: { kinds: [9], limit: 50 },
+      onEvent: () => {},
+      closedRetryAttempt: 4,
+      onClosedRecoveryTimeout: () => releaseLiveSubscription(subscription),
+    };
+    const subscriptions = new Map([["live-1", subscription]]);
+    const closedInput = {
+      subscriptions,
+      subId: "live-1",
+      message: "error: database unavailable",
+      sendReq: async () => {},
+    };
+
+    handleRelayClosed(closedInput);
+    assert.deepEqual(
+      scheduled.map(({ delay }) => delay),
+      [8_000, 16_000],
+    );
+    scheduled.find(({ delay }) => delay === 8_000).callback();
+    assert.equal(subscription.closedRetryAttempt, 0);
+
+    handleRelayClosed(closedInput);
+    assert.deepEqual(
+      scheduled.slice(2).map(({ delay }) => delay),
+      [8_000, 1_000],
+    );
+    assert.equal(subscription.closedRetryAttempt, 1);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test("live EOSE releases the reconnect replay barrier", () => {
+  let reconnectEoseCalls = 0;
+  const subscriptions = new Map([
+    [
+      "live-1",
+      {
+        mode: "live",
+        filter: { kinds: [9], limit: 50 },
+        onEvent: () => {},
+        resolveReconnectEose: () => {
+          reconnectEoseCalls += 1;
+        },
+      },
+    ],
+  ]);
+
+  handleSubscriptionEose({
+    subscriptions,
+    subId: "live-1",
+    closeSubscription: () => Promise.resolve(),
+  });
+
+  assert.equal(reconnectEoseCalls, 1);
+  assert.equal(subscriptions.get("live-1").resolveReconnectEose, undefined);
+});
+
+test("live subscription cleanup releases every reconnect waiter", () => {
+  const originalWindow = globalThis.window;
+  const clearedTimeouts = [];
+  globalThis.window = {
+    clearTimeout: (timeout) => clearedTimeouts.push(timeout),
+  };
+  try {
+    let readyCalls = 0;
+    let reconnectEoseCalls = 0;
+    const subscription = {
+      mode: "live",
+      filter: { kinds: [9], limit: 50 },
+      onEvent: () => {},
+      resolveReady: () => {
+        readyCalls += 1;
+      },
+      resolveReconnectEose: () => {
+        reconnectEoseCalls += 1;
+      },
+      closedRetryTimeout: 42,
+      closedRetryAttempt: 4,
+      closedRecoveryInProgress: true,
+      closedRecoveryTimeout: 43,
+    };
+
+    releaseLiveSubscription(subscription);
+
+    assert.equal(readyCalls, 1);
+    assert.equal(reconnectEoseCalls, 1);
+    assert.equal(subscription.resolveReady, undefined);
+    assert.equal(subscription.resolveReconnectEose, undefined);
+    assert.equal(subscription.closedRetryTimeout, undefined);
+    assert.equal(subscription.closedRetryAttempt, 0);
+    assert.equal(subscription.closedRecoveryTimeout, undefined);
+    assert.deepEqual(clearedTimeouts, [42, 43]);
+  } finally {
+    globalThis.window = originalWindow;
+  }
 });
 
 // ── Rate-limited CLOSED core behaviour (F5) ───────────────────────────────────
@@ -342,24 +675,27 @@ test("rate-limited CLOSED activates the rate-limit gate with the parsed hint", (
   assert.equal(isRateLimited(), false);
 });
 
-test("rate-limited CLOSED retry delay is max(backoff, gate remaining), not just hint", () => {
+test("rate-limit delay stays gate-aware until the recovery deadline resets it", () => {
   resetAll(0);
   // Activate a long gate first (20s), then send a shorter-hint CLOSED (5s).
-  // The retry delay must use the gate remaining time (20s), not the hint (5s).
+  // The retry is initially scheduled for the gate's remaining time (20s), but
+  // the bounded 8s recovery deadline must release it first so a fresh socket
+  // does not inherit a retry attempt that outlives its own replay deadline.
   activateRateLimit(20); // gate expires at 20_000 ms
 
   const firedAt = [];
-  const subscriptions = new Map([
-    [
-      "live-1",
-      {
-        mode: "live",
-        filter: { kinds: [9], "#h": ["ch-1"], limit: 50 },
-        onEvent: () => {},
-        resolveReady: () => {},
-      },
-    ],
-  ]);
+  let recoveryTimeouts = 0;
+  const subscription = {
+    mode: "live",
+    filter: { kinds: [9], "#h": ["ch-1"], limit: 50 },
+    onEvent: () => {},
+    resolveReady: () => {},
+    onClosedRecoveryTimeout: () => {
+      recoveryTimeouts += 1;
+      releaseLiveSubscription(subscription);
+    },
+  };
+  const subscriptions = new Map([["live-1", subscription]]);
   handleRelayClosed({
     subscriptions,
     subId: "live-1",
@@ -377,10 +713,20 @@ test("rate-limited CLOSED retry delay is max(backoff, gate remaining), not just 
     0,
     "retry must not fire before gate remaining time",
   );
+  assert.equal(
+    [...pendingTimers.values()].filter(({ fireAt }) => fireAt === 20_000)
+      .length,
+    2,
+    "gate expiry and retry must both be scheduled at the longer gate boundary",
+  );
 
-  // Should fire at 20s.
+  tickTo(8_001);
+  assert.equal(recoveryTimeouts, 1, "recovery deadline must fire first");
+  assert.equal(subscription.closedRetryAttempt, 0);
+
+  // The old generation's retry was cleared by release and must not fire later.
   tickTo(20_001);
-  assert.equal(firedAt.length, 1, "retry must fire after gate remaining time");
+  assert.equal(firedAt.length, 0);
 });
 
 test("non-rate-limited retryable CLOSED still schedules a retry", () => {

--- a/desktop/src/shared/api/relayClosedRecovery.ts
+++ b/desktop/src/shared/api/relayClosedRecovery.ts
@@ -13,13 +13,72 @@ import type { RelayEvent } from "@/shared/api/types";
 
 const RETRY_BASE_DELAY_MS = 1_000;
 const RETRY_MAX_DELAY_MS = 30_000;
+export const CLOSED_RECOVERY_EOSE_TIMEOUT_MS = 8_000;
 
 type LiveSubscription = Extract<RelaySubscription, { mode: "live" }>;
+
+function setClosedRecoveryState(
+  subscription: LiveSubscription,
+  recovering: boolean,
+) {
+  if (Boolean(subscription.closedRecoveryInProgress) === recovering) return;
+  if (!recovering && subscription.closedRecoveryTimeout !== undefined) {
+    window.clearTimeout(subscription.closedRecoveryTimeout);
+    subscription.closedRecoveryTimeout = undefined;
+  }
+  subscription.closedRecoveryInProgress = recovering || undefined;
+  subscription.onClosedRecoveryStateChange?.(recovering);
+}
+
+function armClosedRecoveryTimeout({
+  subscriptions,
+  subId,
+  subscription,
+}: {
+  subscriptions: Map<string, RelaySubscription>;
+  subId: string;
+  subscription: LiveSubscription;
+}) {
+  if (subscription.closedRecoveryTimeout !== undefined) return;
+  subscription.closedRecoveryTimeout = window.setTimeout(() => {
+    subscription.closedRecoveryTimeout = undefined;
+    if (
+      subscriptions.get(subId) !== subscription ||
+      !subscription.closedRecoveryInProgress
+    ) {
+      return;
+    }
+    const error = new Error(
+      `Timed out waiting for relay EOSE while recovering subscription ${subId}.`,
+    );
+    if (subscription.onClosedRecoveryTimeout) {
+      subscription.onClosedRecoveryTimeout(error);
+      return;
+    }
+    subscriptions.delete(subId);
+    releaseLiveSubscription(subscription);
+  }, CLOSED_RECOVERY_EOSE_TIMEOUT_MS);
+}
+
+export function resolveReconnectEose(subscription: LiveSubscription) {
+  const resolve = subscription.resolveReconnectEose;
+  subscription.resolveReconnectEose = undefined;
+  resolve?.();
+}
 
 export function clearClosedRetry(subscription: LiveSubscription) {
   if (subscription.closedRetryTimeout === undefined) return;
   window.clearTimeout(subscription.closedRetryTimeout);
   subscription.closedRetryTimeout = undefined;
+}
+
+export function releaseLiveSubscription(subscription: LiveSubscription) {
+  subscription.resolveReady?.();
+  subscription.resolveReady = undefined;
+  resolveReconnectEose(subscription);
+  clearClosedRetry(subscription);
+  subscription.closedRetryAttempt = 0;
+  setClosedRecoveryState(subscription, false);
 }
 
 export function handleRelayClosed({
@@ -81,10 +140,15 @@ function recoverLiveSubscriptionFromClosed({
   if (closedClass === "terminal") {
     // Auth/access/filter failure — permanently remove the subscription so it
     // doesn't silently loop.
+    resolveReconnectEose(subscription);
+    clearClosedRetry(subscription);
+    setClosedRecoveryState(subscription, false);
     subscriptions.delete(subId);
     return;
   }
 
+  setClosedRecoveryState(subscription, true);
+  armClosedRecoveryTimeout({ subscriptions, subId, subscription });
   if (subscription.closedRetryTimeout !== undefined) return;
 
   const attempt = subscription.closedRetryAttempt ?? 0;
@@ -112,7 +176,12 @@ function recoverLiveSubscriptionFromClosed({
     subscription.closedRetryTimeout = undefined;
     if (subscriptions.get(subId) !== subscription) return;
     void sendReq(subId, subscription.filter).catch((error) => {
-      if (subscriptions.get(subId) !== subscription) return;
+      if (
+        subscriptions.get(subId) !== subscription ||
+        !subscription.closedRecoveryInProgress
+      ) {
+        return;
+      }
       console.error("Failed to restore closed relay subscription", error);
       recoverLiveSubscriptionFromClosed({
         subscriptions,
@@ -138,6 +207,7 @@ export function prepareSubscriptionEvent(
   }
   subscription.closedRetryAttempt = 0;
   clearClosedRetry(subscription);
+  subscription.refreshReconnectEoseTimeout?.();
   subscription.lastSeenCreatedAt = Math.max(
     subscription.lastSeenCreatedAt ?? 0,
     event.created_at,
@@ -149,18 +219,25 @@ export function handleSubscriptionEose({
   subscriptions,
   subId,
   closeSubscription,
+  beforeLiveRecoveryComplete,
 }: {
   subscriptions: Map<string, RelaySubscription>;
   subId: string;
   closeSubscription: (subId: string) => Promise<void>;
+  beforeLiveRecoveryComplete?: () => void;
 }) {
   const subscription = subscriptions.get(subId);
   if (!subscription) return;
   if (subscription.mode === "live") {
+    if (subscription.closedRecoveryInProgress) {
+      beforeLiveRecoveryComplete?.();
+    }
+    resolveReconnectEose(subscription);
     subscription.resolveReady?.();
     subscription.resolveReady = undefined;
     subscription.closedRetryAttempt = 0;
     clearClosedRetry(subscription);
+    setClosedRecoveryState(subscription, false);
     return;
   }
   window.clearTimeout(subscription.timeout);

--- a/desktop/src/shared/api/relayEventBuffer.test.mjs
+++ b/desktop/src/shared/api/relayEventBuffer.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { deliverBufferedSubscriptionEvents } from "./relayEventBuffer.ts";
+
+test("event-buffer drain delivers only still-live subscriptions in order", () => {
+  const delivered = [];
+  const subscriptions = new Map([
+    [
+      "live",
+      {
+        mode: "live",
+        filter: { kinds: [9], limit: 50 },
+        onEvent: (event) => delivered.push(event.id),
+      },
+    ],
+    [
+      "history",
+      {
+        mode: "history",
+        events: [],
+        resolve: () => {},
+        reject: () => {},
+        timeout: 1,
+      },
+    ],
+  ]);
+
+  deliverBufferedSubscriptionEvents(
+    [
+      { subId: "removed", event: { id: "removed" } },
+      { subId: "live", event: { id: "first" } },
+      { subId: "history", event: { id: "history" } },
+      { subId: "live", event: { id: "second" } },
+    ],
+    subscriptions,
+  );
+
+  assert.deepEqual(delivered, ["first", "second"]);
+});

--- a/desktop/src/shared/api/relayEventBuffer.ts
+++ b/desktop/src/shared/api/relayEventBuffer.ts
@@ -1,0 +1,15 @@
+import type { RelaySubscription } from "@/shared/api/relayClientShared";
+import type { RelayEvent } from "@/shared/api/types";
+
+export function deliverBufferedSubscriptionEvents(
+  buffer: Array<{ subId: string; event: RelayEvent }>,
+  subscriptions: Map<string, RelaySubscription>,
+) {
+  // Re-lookup: subscriptions removed during the batch window are skipped.
+  for (const { subId, event } of buffer) {
+    const subscription = subscriptions.get(subId);
+    if (subscription?.mode === "live") {
+      subscription.onEvent(event);
+    }
+  }
+}

--- a/desktop/src/shared/api/relayReconnectReplay.test.mjs
+++ b/desktop/src/shared/api/relayReconnectReplay.test.mjs
@@ -7,6 +7,7 @@ import {
   REPLAY_BATCH_SIZE,
 } from "./relayReconnectReplay.ts";
 import { buildChannelFilter } from "./relayChannelFilters.ts";
+import { prepareSubscriptionEvent } from "./relayClosedRecovery.ts";
 
 // ── Fake-timer + Date.now setup for gate tests ────────────────────────────────
 
@@ -179,6 +180,7 @@ test("replay sends all subs in one batch when count equals REPLAY_BATCH_SIZE", a
     subscriptions,
     sendRaw: async (payload) => {
       sentIds.push(payload[1]);
+      subscriptions.get(payload[1])?.resolveReconnectEose?.();
     },
     requestHistory: async () => [],
     setTimeoutFn: (fn, _ms) => {
@@ -215,6 +217,7 @@ test("replay splits subscriptions into batches of REPLAY_BATCH_SIZE", async () =
     subscriptions,
     sendRaw: async (payload) => {
       sentIds.push(payload[1]);
+      subscriptions.get(payload[1])?.resolveReconnectEose?.();
     },
     requestHistory: async () => [],
     setTimeoutFn: (fn, _ms) => {
@@ -271,6 +274,7 @@ test("visible channel subscription is sent first", async () => {
     subscriptions,
     sendRaw: async (payload) => {
       sentOrder.push(payload[1]);
+      subscriptions.get(payload[1])?.resolveReconnectEose?.();
     },
     requestHistory: async () => [],
     visibleChannelId: "ch-visible",
@@ -287,21 +291,23 @@ test("replay waits for rate-limit gate before sending REQs", async () => {
   activateRateLimit(5); // gate active for 5 seconds
 
   const sentIds = [];
+  const subscriptions = new Map([
+    [
+      "sub-1",
+      {
+        mode: "live",
+        filter: { kinds: [9], "#h": ["ch-1"], limit: 50 },
+        onEvent: () => {},
+        lastSeenCreatedAt: undefined,
+      },
+    ],
+  ]);
 
   const replayPromise = replayLiveSubscriptions({
-    subscriptions: new Map([
-      [
-        "sub-1",
-        {
-          mode: "live",
-          filter: { kinds: [9], "#h": ["ch-1"], limit: 50 },
-          onEvent: () => {},
-          lastSeenCreatedAt: undefined,
-        },
-      ],
-    ]),
+    subscriptions,
     sendRaw: async (payload) => {
       sentIds.push(payload[1]);
+      subscriptions.get(payload[1])?.resolveReconnectEose?.();
     },
     requestHistory: async () => [],
     setTimeoutFn: (fn, _ms) => {
@@ -316,6 +322,42 @@ test("replay waits for rate-limit gate before sending REQs", async () => {
   await replayPromise;
 
   assert.equal(sentIds.length, 1, "REQ sent after gate expired");
+});
+
+test("replay lifecycle starts before waiting for the rate-limit gate", async () => {
+  resetGate(0);
+  activateRateLimit(5);
+
+  const lifecycle = [];
+  const subscriptions = new Map([
+    [
+      "sub-1",
+      {
+        mode: "live",
+        filter: { kinds: [9], "#h": ["ch-1"], limit: 50 },
+        onEvent: () => {},
+        lastSeenCreatedAt: undefined,
+        onClosedRecoveryStateChange: (replaying) => lifecycle.push(replaying),
+      },
+    ],
+  ]);
+
+  const replayPromise = replayLiveSubscriptions({
+    subscriptions,
+    sendRaw: async (payload) => {
+      subscriptions.get(payload[1])?.resolveReconnectEose?.();
+    },
+    requestHistory: async () => [],
+    setTimeoutFn: (fn, _ms) => {
+      fn();
+      return 0;
+    },
+  });
+
+  assert.deepEqual(lifecycle, [true]);
+  tickTo(5_001);
+  await replayPromise;
+  assert.deepEqual(lifecycle, [true, false]);
 });
 
 // ── Connection-generation guard ───────────────────────────────────────────────
@@ -357,6 +399,29 @@ test("stale replay sends no REQs when generation advances while gate was active"
   assert.equal(sentIds.length, 0, "no REQs sent for a stale replay");
 });
 
+test("generation advancing during REQ send leaves no stale EOSE deadline", async () => {
+  resetGate();
+  let generationActive = true;
+  const subscription = {
+    mode: "live",
+    filter: { kinds: [9], "#h": ["ch-1"], limit: 50 },
+    onEvent: () => {},
+    lastSeenCreatedAt: undefined,
+  };
+
+  await replayLiveSubscriptions({
+    subscriptions: new Map([["sub-1", subscription]]),
+    sendRaw: async () => {
+      generationActive = false;
+    },
+    requestHistory: async () => [],
+    isActive: () => generationActive,
+    eoseTimeoutMs: 5,
+  });
+
+  assert.equal(subscription.resolveReconnectEose, undefined);
+});
+
 // ── Paged replay (existing behaviour) ────────────────────────────────────────
 
 test("channel reconnect replay pages the missed window until a short page", async () => {
@@ -369,7 +434,10 @@ test("channel reconnect replay pages the missed window until a short page", asyn
     eventRange("middle", 1002, 500),
     eventRange("oldest", 995, 8),
   ];
-  const filter = buildChannelFilter("channel-1", 50);
+  const filter = {
+    ...buildChannelFilter("channel-1", 1_000),
+    since: 900,
+  };
   const subscriptions = new Map([
     [
       "live-1",
@@ -387,6 +455,7 @@ test("channel reconnect replay pages the missed window until a short page", asyn
     now: 2000,
     sendRaw: async (payload) => {
       sentPayloads.push(payload);
+      subscriptions.get(payload[1])?.resolveReconnectEose?.();
     },
     requestHistory: async (filter) => {
       historyFilters.push(filter);
@@ -401,7 +470,8 @@ test("channel reconnect replay pages the missed window until a short page", asyn
       {
         kinds: filter.kinds,
         "#h": ["channel-1"],
-        limit: 50,
+        limit: 1_000,
+        since: 900,
       },
     ],
   ]);
@@ -429,6 +499,163 @@ test("channel reconnect replay pages the missed window until a short page", asyn
     },
   ]);
   assert.equal(delivered.length, 1008);
+});
+
+test("reconnect replay waits for restored live EOSE before completing", async () => {
+  const subscription = {
+    mode: "live",
+    filter: {
+      ...buildChannelFilter("channel-1", 1_000),
+      since: 900,
+    },
+    onEvent: () => {},
+    lastSeenCreatedAt: 1_000,
+  };
+  const subscriptions = new Map([["live-1", subscription]]);
+  let replayCompleted = false;
+
+  const replayPromise = replayLiveSubscriptions({
+    subscriptions,
+    now: 2_000,
+    sendRaw: async () => {},
+    requestHistory: async () => [],
+  }).then(() => {
+    replayCompleted = true;
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(replayCompleted, false);
+  assert.equal(typeof subscription.resolveReconnectEose, "function");
+
+  subscription.resolveReconnectEose();
+  await replayPromise;
+  assert.equal(replayCompleted, true);
+});
+
+test("restored live filter delivers post-EOSE events below the catch-up floor", async () => {
+  const delivered = [];
+  const subscription = {
+    mode: "live",
+    filter: {
+      ...buildChannelFilter("channel-1", 1_000),
+      since: 900,
+    },
+    onEvent: (received) => delivered.push(received.id),
+    lastSeenCreatedAt: 1_000,
+  };
+  const subscriptions = new Map([["live-1", subscription]]);
+  let restoredFilter;
+
+  await replayLiveSubscriptions({
+    subscriptions,
+    now: 2_000,
+    sendRaw: async (payload) => {
+      restoredFilter = payload[2];
+      subscription.resolveReconnectEose?.();
+    },
+    requestHistory: async () => [],
+  });
+
+  const delayedEvent = event("delayed", 950);
+  if (
+    restoredFilter.since === undefined ||
+    delayedEvent.created_at >= restoredFilter.since
+  ) {
+    subscription.onEvent(delayedEvent);
+  }
+
+  assert.equal(restoredFilter.since, 900);
+  assert.deepEqual(delivered, ["delayed"]);
+});
+
+test("reconnect replay rejects instead of hanging when EOSE is missing", async () => {
+  const subscription = {
+    mode: "live",
+    filter: buildChannelFilter("channel-1", 50),
+    onEvent: () => {},
+    lastSeenCreatedAt: 1_000,
+  };
+  const subscriptions = new Map([["live-1", subscription]]);
+
+  const outcome = await Promise.race([
+    replayLiveSubscriptions({
+      subscriptions,
+      now: 2_000,
+      eoseTimeoutMs: 5,
+      sendRaw: async () => {},
+      requestHistory: () => new Promise(() => {}),
+    }).then(
+      () => "resolved",
+      (error) => error,
+    ),
+    new Promise((resolve) => setTimeout(() => resolve("still-pending"), 50)),
+  ]);
+
+  assert.equal(outcome instanceof Error, true);
+  assert.match(outcome.message, /EOSE/);
+  assert.equal(subscription.resolveReconnectEose, undefined);
+});
+
+test("reconnect replay refreshes the EOSE deadline while restored events arrive", async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let nowMs = 0;
+  let nextId = 1;
+  const timers = new Map();
+  globalThis.setTimeout = (callback, ms) => {
+    const id = nextId++;
+    timers.set(id, { callback, fireAt: nowMs + ms });
+    return id;
+  };
+  globalThis.clearTimeout = (id) => {
+    timers.delete(id);
+  };
+  const tickToMs = (nextMs) => {
+    nowMs = nextMs;
+    for (const [id, timer] of [...timers.entries()].sort(
+      (left, right) => left[1].fireAt - right[1].fireAt,
+    )) {
+      if (timer.fireAt <= nowMs) {
+        timers.delete(id);
+        timer.callback();
+      }
+    }
+  };
+
+  try {
+    const subscription = {
+      mode: "live",
+      filter: buildChannelFilter("channel-1", 50),
+      onEvent: () => {},
+      lastSeenCreatedAt: 1_000,
+    };
+    const subscriptions = new Map([["live-1", subscription]]);
+    const replayOutcome = replayLiveSubscriptions({
+      subscriptions,
+      now: 2_000,
+      eoseTimeoutMs: 10,
+      sendRaw: async () => {},
+      requestHistory: async () => [],
+    }).then(
+      () => "resolved",
+      (error) => error,
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    tickToMs(9);
+    prepareSubscriptionEvent(subscription, event("restored-1", 1_001));
+    tickToMs(18);
+    prepareSubscriptionEvent(subscription, event("restored-2", 1_002));
+    tickToMs(27);
+
+    subscription.resolveReconnectEose();
+    assert.equal(await replayOutcome, "resolved");
+    assert.equal(subscription.refreshReconnectEoseTimeout, undefined);
+    assert.equal(timers.size, 0);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
 });
 
 test("reconnect replay starts live REQs in parallel and preserves per-sub page order", async () => {
@@ -477,7 +704,10 @@ test("reconnect replay starts live REQs in parallel and preserves per-sub page o
     sendRaw: (payload) => {
       sentPayloads.push(payload);
       return new Promise((resolve) => {
-        sendResolvers.push(resolve);
+        sendResolvers.push(() => {
+          resolve();
+          subscriptions.get(payload[1])?.resolveReconnectEose?.();
+        });
       });
     },
     requestHistory: async (filter) => {
@@ -539,6 +769,7 @@ test("batch-1 arms gate mid-replay: batch-2 is withheld until gate expires", asy
     subscriptions,
     sendRaw: async (payload) => {
       sentAtMs.push({ id: payload[1], ms: fakeNow });
+      subscriptions.get(payload[1])?.resolveReconnectEose?.();
       // After the first full batch is sent, arm the gate for 5 s.
       // This simulates the relay responding to batch-1 traffic with back-pressure.
       if (sentAtMs.length === BATCH) {

--- a/desktop/src/shared/api/relayReconnectReplay.ts
+++ b/desktop/src/shared/api/relayReconnectReplay.ts
@@ -9,9 +9,10 @@ import {
   waitForRateLimit,
 } from "@/shared/api/relayRateLimitGate";
 
-const RECONNECT_REPLAY_SKEW_SECS = 5;
+export const RECONNECT_REPLAY_SKEW_SECS = 5;
 export const RECONNECT_REPLAY_PAGE_LIMIT = 500;
 export const RECONNECT_REPLAY_PAGE_CONCURRENCY = 4;
+export const RECONNECT_EOSE_TIMEOUT_MS = 8_000;
 
 /**
  * Maximum live subscriptions sent per relay REQ burst during reconnect.
@@ -78,6 +79,14 @@ export function shouldPageReconnectReplay(filter: RelaySubscriptionFilter) {
   );
 }
 
+export function reconnectReplaySince(
+  subscription: Extract<RelaySubscription, { mode: "live" }>,
+) {
+  return subscription.lastSeenCreatedAt === undefined
+    ? undefined
+    : Math.max(0, subscription.lastSeenCreatedAt - RECONNECT_REPLAY_SKEW_SECS);
+}
+
 export async function replayReconnectHistoryPages({
   subscription,
   since,
@@ -130,6 +139,7 @@ export async function replayLiveSubscriptions({
   setTimeoutFn = (fn: () => void, ms: number) =>
     window.setTimeout(fn, ms) as unknown as number,
   isActive = () => true,
+  eoseTimeoutMs = RECONNECT_EOSE_TIMEOUT_MS,
 }: {
   subscriptions: Map<string, RelaySubscription>;
   sendRaw: (payload: unknown[]) => Promise<void>;
@@ -150,15 +160,8 @@ export async function replayLiveSubscriptions({
    * must not double-send REQs on the live socket.
    */
   isActive?: () => boolean;
+  eoseTimeoutMs?: number;
 }) {
-  // If the relay has signalled back-pressure, wait for the gate to clear
-  // before blasting a full set of REQs that would immediately be rate-limited.
-  if (isRateLimited()) await waitForRateLimit();
-
-  // A newer connection may have replayed while this one was suspended at the
-  // gate — abort silently to avoid double-sending every REQ on the live socket.
-  if (!isActive()) return;
-
   const replayRequests = Array.from(subscriptions.entries())
     .filter(
       (
@@ -167,83 +170,184 @@ export async function replayLiveSubscriptions({
         entry[1].mode === "live",
     )
     .map(([subId, subscription]) => {
-      const replaySince =
-        subscription.lastSeenCreatedAt === undefined
-          ? undefined
-          : Math.max(
-              0,
-              subscription.lastSeenCreatedAt - RECONNECT_REPLAY_SKEW_SECS,
-            );
+      const replaySince = reconnectReplaySince(subscription);
       const shouldPageReplay =
         replaySince !== undefined &&
         shouldPageReconnectReplay(subscription.filter);
 
-      return { subId, subscription, replaySince, shouldPageReplay };
+      let resolvePromise = () => {};
+      let rejectPromise = (_error: Error) => {};
+      const reconnectEose = new Promise<void>((resolve, reject) => {
+        resolvePromise = resolve;
+        rejectPromise = reject;
+      });
+      let settled = false;
+      let timeoutArmed = false;
+      let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
+      const clearSubscriptionWaiter = () => {
+        if (subscription.resolveReconnectEose === resolveReconnectEose) {
+          subscription.resolveReconnectEose = undefined;
+        }
+        if (
+          subscription.refreshReconnectEoseTimeout ===
+          refreshReconnectEoseTimeout
+        ) {
+          subscription.refreshReconnectEoseTimeout = undefined;
+        }
+      };
+      const settle = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        timeoutArmed = false;
+        if (timeout !== undefined) {
+          globalThis.clearTimeout(timeout);
+          timeout = undefined;
+        }
+        clearSubscriptionWaiter();
+        if (error) {
+          rejectPromise(error);
+        } else {
+          resolvePromise();
+        }
+      };
+      const resolveReconnectEose = () => settle();
+      const rejectReconnectEose = (error: Error) => settle(error);
+      const refreshReconnectEoseTimeout = () => {
+        if (settled || !timeoutArmed) return;
+        if (timeout !== undefined) {
+          globalThis.clearTimeout(timeout);
+        }
+        timeout = globalThis.setTimeout(() => {
+          rejectReconnectEose(
+            new Error(
+              `Timed out waiting for relay EOSE while restoring subscription ${subId}.`,
+            ),
+          );
+        }, eoseTimeoutMs);
+      };
+      const armReconnectEoseTimeout = () => {
+        if (settled || timeoutArmed) return;
+        timeoutArmed = true;
+        refreshReconnectEoseTimeout();
+      };
+      subscription.resolveReconnectEose = resolveReconnectEose;
+      subscription.refreshReconnectEoseTimeout = refreshReconnectEoseTimeout;
+
+      return {
+        subId,
+        subscription,
+        replaySince,
+        shouldPageReplay,
+        reconnectEose,
+        resolveReconnectEose,
+        armReconnectEoseTimeout,
+      };
     });
 
-  // Sort the visible channel's subscriptions first so the user sees their
-  // active channel recover before others on degraded networks.
-  if (visibleChannelId !== null) {
-    replayRequests.sort((a, b) => {
-      const aVis =
-        (a.subscription.filter["#h"] as string[] | undefined)?.includes(
-          visibleChannelId,
-        ) ?? false;
-      const bVis =
-        (b.subscription.filter["#h"] as string[] | undefined)?.includes(
-          visibleChannelId,
-        ) ?? false;
-      if (aVis === bVis) return 0;
-      return aVis ? -1 : 1;
-    });
-  }
+  try {
+    for (const { subscription } of replayRequests) {
+      subscription.onClosedRecoveryStateChange?.(true);
+    }
 
-  // Send live REQs in capped batches with inter-batch delays to avoid
-  // triggering per-pubkey admission control on degraded/recovering connections.
-  for (let i = 0; i < replayRequests.length; i += replayBatchSize) {
-    // Re-check the gate before every batch: a previous batch may have triggered
-    // admission control and armed the gate mid-replay. Wait for it to clear,
-    // then verify the connection is still current — a newer connection may have
-    // replayed while we were suspended.
+    // If the relay has signalled back-pressure, wait for the gate to clear
+    // before blasting a full set of REQs that would immediately be rate-limited.
     if (isRateLimited()) await waitForRateLimit();
+
+    // A newer connection may have replayed while this one was suspended at the
+    // gate — abort silently to avoid double-sending every REQ on the live socket.
     if (!isActive()) return;
-    const batch = replayRequests.slice(i, i + replayBatchSize);
-    await Promise.all(
-      batch.map(({ subId, subscription, replaySince, shouldPageReplay }) =>
-        sendRaw([
-          "REQ",
-          subId,
-          shouldPageReplay
-            ? subscription.filter
-            : buildReconnectReplayFilter(subscription.filter, replaySince),
-        ]),
-      ),
-    );
-    if (i + replayBatchSize < replayRequests.length) {
-      await new Promise<void>((resolve) =>
-        setTimeoutFn(resolve, interBatchDelayMs),
+
+    // Sort the visible channel's subscriptions first so the user sees their
+    // active channel recover before others on degraded networks.
+    if (visibleChannelId !== null) {
+      replayRequests.sort((a, b) => {
+        const aVis =
+          (a.subscription.filter["#h"] as string[] | undefined)?.includes(
+            visibleChannelId,
+          ) ?? false;
+        const bVis =
+          (b.subscription.filter["#h"] as string[] | undefined)?.includes(
+            visibleChannelId,
+          ) ?? false;
+        if (aVis === bVis) return 0;
+        return aVis ? -1 : 1;
+      });
+    }
+
+    // Send live REQs in capped batches with inter-batch delays to avoid
+    // triggering per-pubkey admission control on degraded/recovering connections.
+    for (let i = 0; i < replayRequests.length; i += replayBatchSize) {
+      // Re-check the gate before every batch: a previous batch may have triggered
+      // admission control and armed the gate mid-replay. Wait for it to clear,
+      // then verify the connection is still current — a newer connection may have
+      // replayed while we were suspended.
+      if (isRateLimited()) await waitForRateLimit();
+      if (!isActive()) return;
+      const batch = replayRequests.slice(i, i + replayBatchSize);
+      await Promise.all(
+        batch.map(
+          async ({
+            subId,
+            subscription,
+            replaySince,
+            shouldPageReplay,
+            resolveReconnectEose,
+            armReconnectEoseTimeout,
+          }) => {
+            await sendRaw([
+              "REQ",
+              subId,
+              shouldPageReplay
+                ? subscription.filter
+                : buildReconnectReplayFilter(subscription.filter, replaySince),
+            ]);
+            if (!isActive() || subscriptions.get(subId) !== subscription) {
+              resolveReconnectEose();
+              return;
+            }
+            armReconnectEoseTimeout();
+          },
+        ),
       );
+      if (!isActive()) return;
+      if (i + replayBatchSize < replayRequests.length) {
+        await new Promise<void>((resolve) =>
+          setTimeoutFn(resolve, interBatchDelayMs),
+        );
+      }
+    }
+
+    await Promise.all([
+      runWithConcurrency(
+        replayRequests.filter(
+          (
+            request,
+          ): request is typeof request & {
+            replaySince: number;
+            shouldPageReplay: true;
+          } => request.shouldPageReplay && request.replaySince !== undefined,
+        ),
+        pageReplayConcurrency,
+        async ({ subId, subscription, replaySince }) => {
+          await replayReconnectHistoryPages({
+            subscription,
+            since: replaySince,
+            until: now,
+            isActive: () =>
+              isActive() && subscriptions.get(subId) === subscription,
+            requestHistory,
+          });
+        },
+      ),
+      Promise.all(replayRequests.map(({ reconnectEose }) => reconnectEose)),
+    ]);
+  } finally {
+    for (const { subscription, resolveReconnectEose } of replayRequests) {
+      if (subscription.resolveReconnectEose === resolveReconnectEose) {
+        subscription.resolveReconnectEose = undefined;
+      }
+      resolveReconnectEose();
+      subscription.onClosedRecoveryStateChange?.(false);
     }
   }
-
-  await runWithConcurrency(
-    replayRequests.filter(
-      (
-        request,
-      ): request is typeof request & {
-        replaySince: number;
-        shouldPageReplay: true;
-      } => request.shouldPageReplay && request.replaySince !== undefined,
-    ),
-    pageReplayConcurrency,
-    async ({ subId, subscription, replaySince }) => {
-      await replayReconnectHistoryPages({
-        subscription,
-        since: replaySince,
-        until: now,
-        isActive: () => subscriptions.get(subId) === subscription,
-        requestHistory,
-      });
-    },
-  );
 }


### PR DESCRIPTION
## Why
Reconnect catch-up re-delivers already-seen thread replies through the live handler, causing macOS notifications to replay after laptop sleep, network changes, or retryable subscription recovery.

## What
- Persist every observed external non-DM thread-reply ID per user/channel before mutable mute, follow, participation, or active-channel eligibility checks
- Reconcile persisted records and replay floors to active and provisionally pending broad subscriptions before cap eviction; narrow to successful subscriptions after setup so same-second boundary IDs survive remounts
- Recreate broad subscriptions when notification-dedupe ownership changes, preventing retryable `CLOSED` recovery callbacks from remaining bound to a retired identity
- Assign each broad-subscription sync a monotonic generation and guard post-await insertion/reconciliation, preventing canceled syncs from overwriting replacement state
- Coalesce durable storage during replay while keeping in-memory dedupe immediate; flush one pruned/capped snapshot on replay completion or lifecycle handoff, and stop repeat serialization after a storage failure
- Keep the five-second watermark floor on finite HTTP catch-up while preserving each original long-lived live filter across reconnect and retryable `CLOSED`
- Track retryable `CLOSED` recovery per live subscription from scheduling through recovered EOSE buffer drain, suspending cap eviction and persistence until every overlapping socket/subscription replay completes
- Acquire socket replay ownership at `stalled` before reset releases subscription recovery, eliminating a cap/flush gap before reconnect begins
- Give standalone retryable-`CLOSED` recovery one non-extendable eight-second EOSE deadline that resets into socket reconnect while recovery ownership is still held
- Reset CLOSED retry backoff when recovery is released into a new socket, so each connection generation starts with the base one-second retry inside its fresh eight-second deadline
- Retain notification IDs for each channel subscription's actual session-start replay window, with a 2,000-item oldest-first safety cap
- Cover persisted remount boundaries, superseding pending sync, identity handoff before/during recovery, CLOSED-to-stalled transfer, missing standalone EOSE, socket-generation retry reset, full-cap newest-first CLOSED replay, overlapping socket/subscription recovery, newest-first HTTP/live replay, delayed old-timestamp events, mutable eligibility changes, active-channel navigation, departed-channel cleanup, startup cap pressure, canceled-sync ordering, replay write coalescing, final persisted cap, and storage quota failure

## Risk Assessment
Medium-low — notification dedupe remains isolated to thread replies. Shared desktop recovery preserves long-lived filter semantics, bounds socket and standalone subscription EOSE waits, and exposes an idempotent recovery lifecycle only to broad channel subscriptions. Identity handoff recreates those subscriptions; subscription removal, terminal `CLOSED`, stalled/socket reset, and timeout all settle recovery state. The global cap remains a bounded-storage tradeoff among currently active subscriptions.

## References
- Focused reconnect/recovery/dedupe tests: 37 passed
- Complete desktop unit suite: 3,265 passed
- TypeScript, Biome/static checks, file-size guard, commit hooks, and full repository pre-push gate passed

Generated with Codex
