### PR TITLE
fix(ci): don't rebuild relay tests on every run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
   desktop-e2e-relay:
     name: Desktop E2E Relay
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: [changes]
     if: github.event_name == 'push' || needs.changes.outputs.desktop == 'true' || needs.changes.outputs.desktop-rust == 'true' || needs.changes.outputs.rust == 'true'
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
   desktop-e2e-relay:
     name: Desktop E2E Relay
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [changes]
     if: github.event_name == 'push' || needs.changes.outputs.desktop == 'true' || needs.changes.outputs.desktop-rust == 'true' || needs.changes.outputs.rust == 'true'
     permissions:
@@ -293,44 +293,60 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
-      # Reuse the compiled relay when no input that reaches the binary changed
-      # (desktop-only PRs hit this every time). Key must cover everything the
-      # binary embeds: crates/** plus migrations/** (sqlx migrate! in buzz-db).
-      - name: Restore relay binary cache
-        id: relay-bin-cache
+      # Reuse the relay binaries and backend test archive when none of their
+      # inputs changed (desktop-only PRs hit this every time). The key covers
+      # everything they embed, including migrations via sqlx migrate!.
+      - name: Restore relay artifacts cache
+        id: relay-artifacts-cache
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             target/ci/buzz-relay
             target/ci/git-credential-nostr
-          key: relay-bin-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
+            target/ci/backend-integration-tests.tar.zst
+          key: relay-artifacts-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-        if: steps.relay-bin-cache.outputs.cache-hit != 'true'
+        if: steps.relay-artifacts-cache.outputs.cache-hit != 'true'
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: steps.relay-bin-cache.outputs.cache-hit != 'true'
+        if: steps.relay-artifacts-cache.outputs.cache-hit != 'true'
         with:
           workspaces: |
             .
             desktop/src-tauri
           save-if: ${{ github.event_name != 'pull_request' }}
-      - name: Build relay
-        if: steps.relay-bin-cache.outputs.cache-hit != 'true'
-        run: cargo build --profile ci -p buzz-relay -p git-credential-nostr
-      - name: Save relay binary cache
-        if: steps.relay-bin-cache.outputs.cache-hit != 'true'
+      - name: Install cargo-nextest
+        if: steps.relay-artifacts-cache.outputs.cache-hit != 'true'
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2 # v2.79.15
+        with:
+          tool: cargo-nextest@0.9.136
+      - name: Build relay artifacts
+        if: steps.relay-artifacts-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo build --profile ci -p buzz-relay -p git-credential-nostr
+          cargo nextest archive \
+            --cargo-profile ci \
+            -p buzz-relay \
+            -p buzz-test-client \
+            --lib \
+            --test e2e_event_reminder \
+            --archive-file target/ci/backend-integration-tests.tar.zst
+      - name: Save relay artifacts cache
+        if: steps.relay-artifacts-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             target/ci/buzz-relay
             target/ci/git-credential-nostr
-          key: relay-bin-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
-      - name: Upload relay binary
+            target/ci/backend-integration-tests.tar.zst
+          key: relay-artifacts-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
+      - name: Upload relay artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: desktop-e2e-relay
           path: |
             target/ci/buzz-relay
             target/ci/git-credential-nostr
+            target/ci/backend-integration-tests.tar.zst
           if-no-files-found: error
           retention-days: 1
 
@@ -538,10 +554,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2 # v2.79.15
         with:
-          save-if: ${{ github.event_name != 'pull_request' }}
+          tool: cargo-nextest@0.9.136
       - name: Start integration services
         run: |
           for attempt in 1 2 3; do
@@ -574,7 +590,7 @@ jobs:
           wait_healthy "Postgres" "buzz-postgres"
           wait_healthy "Redis" "buzz-redis"
           wait_healthy "MinIO" "buzz-minio"
-      - name: Download relay binary
+      - name: Download relay artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: desktop-e2e-relay
@@ -642,7 +658,10 @@ jobs:
           exit 1
       - name: Invite claim security tests
         run: |
-          cargo test --profile ci -p buzz-relay claim_ -- --ignored --nocapture
+          cargo nextest run \
+            --archive-file target/ci/backend-integration-tests.tar.zst \
+            -E 'test(claim_)' \
+            --run-ignored ignored-only
         env:
           DATABASE_URL: postgres://buzz:${{ env.BUZZ_TEST_POSTGRES_PASSWORD }}@localhost:5432/buzz
       - name: NIP-ER reminder e2e
@@ -650,7 +669,11 @@ jobs:
         # validation, author-only read filtering, and scheduler delivery against
         # a live relay. The schema-drift / migration-version guarantee is owned
         # by the buzz-db migration.rs unit tests, not this suite.
-        run: cargo test --profile ci -p buzz-test-client --test e2e_event_reminder -- --ignored
+        run: |
+          cargo nextest run \
+            --archive-file target/ci/backend-integration-tests.tar.zst \
+            -E 'binary(e2e_event_reminder)' \
+            --run-ignored ignored-only
         env:
           RELAY_URL: ws://localhost:3000
       - name: Upload relay log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
             target/ci/buzz-relay
             target/ci/git-credential-nostr
             target/ci/backend-integration-tests.tar.zst
-          key: relay-artifacts-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
+          key: relay-artifacts-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Dockerfile', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
         if: steps.relay-artifacts-cache.outputs.cache-hit != 'true'
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -338,7 +338,7 @@ jobs:
             target/ci/buzz-relay
             target/ci/git-credential-nostr
             target/ci/backend-integration-tests.tar.zst
-          key: relay-artifacts-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
+          key: relay-artifacts-${{ runner.os }}-${{ hashFiles('crates/**', 'migrations/**', 'Dockerfile', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml', '.github/workflows/ci.yml') }}
       - name: Upload relay artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,7 +660,7 @@ jobs:
         run: |
           cargo nextest run \
             --archive-file target/ci/backend-integration-tests.tar.zst \
-            -E 'test(claim_)' \
+            -E 'package(buzz-relay) and test(claim_)' \
             --run-ignored ignored-only
         env:
           DATABASE_URL: postgres://buzz:${{ env.BUZZ_TEST_POSTGRES_PASSWORD }}@localhost:5432/buzz


### PR DESCRIPTION
### What changed?

The Desktop E2E Relay job now builds, caches, and uploads a nextest archive with the relay invite-claim tests and NIP-ER reminder suite. Backend Integration downloads that archive and runs both suites without compiling them again.

### Why?

Backend Integration currently spends 12-17 minutes compiling four invite-claim tests that run in under a second, on every run.

This caching saves 12-17 minutes of total CI time on nearly every CI run, or roughly 10 minutes of wall clock time.

### How is it tested?

- Generated the combined archive with the CI Cargo profile
- Verified the archive contains the same 4 ignored invite-claim tests and all 29 ignored NIP-ER reminder tests
- Ran the 4 invite-claim tests from the archive: all passed
- Workflow YAML and actionlint validation passed
- Full pre-push Rust, desktop, Tauri, and mobile test hooks passed