### PR TITLE
desktop: show where relay-mesh inference runs in the activity panel

### DIFF
--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -436,6 +436,18 @@ pub async fn mesh_node_status(state: State<'_, AppState>) -> CmdResult<mesh_llm:
     }
 }
 
+/// Current Buzz shared compute availability as gossiped on this relay:
+/// member-verified, freshness-filtered serve targets and their models. Read
+/// path only — used by the UI to tell the user where relay-mesh inference
+/// actually runs (which models, how many live serving nodes).
+#[tauri::command]
+pub async fn mesh_availability(
+    state: State<'_, AppState>,
+) -> CmdResult<mesh_llm::MeshAvailability> {
+    let events = query_mesh_discovery_events(&state).await?;
+    Ok(mesh_llm::availability_from_events(events))
+}
+
 #[tauri::command]
 pub async fn mesh_installed_models(
     state: State<'_, AppState>,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -785,6 +785,7 @@ pub fn run() {
             mesh_node_status,
             mesh_installed_models,
             mesh_model_catalog,
+            mesh_availability,
             update_managed_agent,
             discover_backend_providers,
             probe_backend_provider,

--- a/desktop/src-tauri/src/mesh_llm_stubs.rs
+++ b/desktop/src-tauri/src/mesh_llm_stubs.rs
@@ -37,3 +37,8 @@ pub async fn mesh_installed_models(
 pub async fn mesh_model_catalog() -> CmdResult<serde_json::Value> {
     Err("mesh-llm feature not enabled".to_string())
 }
+
+#[tauri::command]
+pub async fn mesh_availability(_state: State<'_, AppState>) -> CmdResult<serde_json::Value> {
+    Err("mesh-llm feature not enabled".to_string())
+}

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -18,6 +18,7 @@ import {
 import { deriveTranscriptBlockIds } from "@/features/agents/ui/agentSessionTranscriptGrouping";
 import type { ObserverEvent } from "@/features/agents/ui/agentSessionTypes";
 import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
+import { useMeshInferenceLocation } from "@/features/mesh-compute/hooks/useMeshInferenceLocation";
 import {
   useArchivedChannelEvents,
   useObserverEvents,
@@ -239,6 +240,9 @@ export function AgentSessionThreadPanel({
     : "All channels";
   const animateActivity = useTranscriptAnimationEnabled();
   const showTimestamps = useTranscriptTimestampsEnabled();
+  // Non-null only for relay-mesh (Buzz shared compute) agents: tells the user
+  // where this agent's inference actually runs, e.g. "Qwen3 8B · 3 nodes".
+  const meshInferenceLocation = useMeshInferenceLocation(agent.pubkey);
   async function handleInterruptTurn() {
     if (!channel) {
       return;
@@ -430,6 +434,17 @@ export function AgentSessionThreadPanel({
         >
           {scopeLabel}
         </span>
+        {meshInferenceLocation ? (
+          // Where inference runs: only for Buzz shared compute agents, and
+          // only once availability is known — never a guess.
+          <span
+            className="min-w-0 shrink truncate text-xs text-muted-foreground"
+            data-testid="agent-session-mesh-inference-location"
+            title={meshInferenceLocation.title}
+          >
+            {meshInferenceLocation.label}
+          </span>
+        ) : null}
       </AuxiliaryPanelHeaderGroup>
       {agentHeaderActions}
     </>

--- a/desktop/src/features/mesh-compute/hooks/useMeshInferenceLocation.ts
+++ b/desktop/src/features/mesh-compute/hooks/useMeshInferenceLocation.ts
@@ -1,0 +1,54 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { useManagedAgentsQuery } from "@/features/agents/hooks";
+import { meshAvailability } from "@/shared/api/tauriMesh";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import {
+  describeMeshInferenceLocation,
+  type MeshInferenceLocation,
+} from "../meshInferenceLocation";
+
+/** Serve targets refresh on the relay every 45s; poll a little slower. */
+const MESH_AVAILABILITY_REFETCH_MS = 60_000;
+
+export const meshAvailabilityQueryKey = ["mesh-availability"] as const;
+
+/**
+ * Where does this agent's inference actually run?
+ *
+ * Resolves the managed agent record for `agentPubkey`; when its provider is
+ * Buzz shared compute (`relay-mesh`), polls live availability and derives a
+ * human-readable location ("running Qwen3 8B on 3 nodes on this relay").
+ *
+ * Returns `null` for non-mesh agents and while availability is still
+ * unknown — callers render nothing rather than a guess.
+ */
+export function useMeshInferenceLocation(
+  agentPubkey: string | null,
+): MeshInferenceLocation | null {
+  const agentsQuery = useManagedAgentsQuery({ enabled: agentPubkey !== null });
+  const agent =
+    agentPubkey === null
+      ? undefined
+      : agentsQuery.data?.find(
+          (candidate) =>
+            normalizePubkey(candidate.pubkey) === normalizePubkey(agentPubkey),
+        );
+  const isRelayMesh = agent?.provider?.trim() === "relay-mesh";
+
+  const availabilityQuery = useQuery({
+    enabled: isRelayMesh,
+    queryKey: meshAvailabilityQueryKey,
+    queryFn: meshAvailability,
+    refetchInterval: MESH_AVAILABILITY_REFETCH_MS,
+    staleTime: MESH_AVAILABILITY_REFETCH_MS / 2,
+  });
+
+  if (!isRelayMesh || agent === undefined) {
+    return null;
+  }
+  return describeMeshInferenceLocation({
+    availability: availabilityQuery.data ?? null,
+    model: agent.model,
+  });
+}

--- a/desktop/src/features/mesh-compute/meshInferenceLocation.test.mjs
+++ b/desktop/src/features/mesh-compute/meshInferenceLocation.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeMeshInferenceLocation } from "./meshInferenceLocation.ts";
+
+const target = (overrides = {}) => ({
+  modelId: "org/qwen3-8b:q4",
+  modelName: "Qwen3 8B",
+  endpointAddr: "addr-a",
+  nodeName: null,
+  capacity: null,
+  endpointId: "endpoint-a",
+  deviceId: "device-a",
+  deviceName: "Mac Studio",
+  ...overrides,
+});
+
+const availability = (targets, models = []) => ({
+  reason: null,
+  models,
+  serveTargets: targets,
+});
+
+test("null availability (loading/error) renders nothing", () => {
+  assert.equal(
+    describeMeshInferenceLocation({ availability: null, model: "auto" }),
+    null,
+  );
+});
+
+test("explicit model counts only nodes serving that model", () => {
+  const result = describeMeshInferenceLocation({
+    availability: availability([
+      target(),
+      target({ deviceId: "device-b", endpointAddr: "addr-b" }),
+      target({
+        modelId: "org/other:q4",
+        modelName: "Other",
+        deviceId: "device-c",
+      }),
+    ]),
+    model: "org/qwen3-8b:q4",
+  });
+  assert.equal(result.nodeCount, 2);
+  assert.equal(result.label, "Shared compute · Qwen3 8B · 2 nodes");
+  assert.match(result.title, /Qwen3 8B on 2 nodes serving on this relay/);
+});
+
+test("model matching drops the implicit @main revision (Rust parity)", () => {
+  const result = describeMeshInferenceLocation({
+    availability: availability([target({ modelId: "org/qwen3-8b@main:q4" })]),
+    model: "org/qwen3-8b:q4",
+  });
+  assert.equal(result.nodeCount, 1);
+});
+
+test("auto model counts every distinct serving node", () => {
+  const result = describeMeshInferenceLocation({
+    availability: availability([
+      target(),
+      target({ modelId: "org/other:q4", deviceId: "device-b" }),
+    ]),
+    model: "auto",
+  });
+  assert.equal(result.nodeCount, 2);
+  assert.equal(result.label, "Shared compute · auto-routed · 2 nodes");
+});
+
+test("empty model behaves like auto", () => {
+  const result = describeMeshInferenceLocation({
+    availability: availability([target()]),
+    model: null,
+  });
+  assert.equal(result.label, "Shared compute · auto-routed · 1 node");
+});
+
+test("same node advertising two models is one node, not two", () => {
+  const result = describeMeshInferenceLocation({
+    availability: availability([target(), target({ modelId: "org/other:q4" })]),
+    model: "auto",
+  });
+  assert.equal(result.nodeCount, 1);
+});
+
+test("falls back to endpoint identity when deviceId is absent", () => {
+  const result = describeMeshInferenceLocation({
+    availability: availability([
+      target({ deviceId: null, endpointId: null }),
+      target({ deviceId: null, endpointId: null, endpointAddr: "addr-b" }),
+    ]),
+    model: "auto",
+  });
+  assert.equal(result.nodeCount, 2);
+});
+
+test("no live nodes yields the explicit none-live state", () => {
+  const result = describeMeshInferenceLocation({
+    availability: availability([]),
+    model: "org/qwen3-8b:q4",
+  });
+  assert.equal(result.nodeCount, 0);
+  assert.equal(result.label, "Shared compute · no live serving nodes");
+});
+
+test("model without a display name falls back to the ref", () => {
+  const result = describeMeshInferenceLocation({
+    availability: availability([target({ modelName: null })]),
+    model: "org/qwen3-8b:q4",
+  });
+  assert.equal(result.label, "Shared compute · org/qwen3-8b:q4 · 1 node");
+});

--- a/desktop/src/features/mesh-compute/meshInferenceLocation.ts
+++ b/desktop/src/features/mesh-compute/meshInferenceLocation.ts
@@ -1,0 +1,89 @@
+import type { MeshAvailability } from "@/shared/api/tauriMesh";
+
+/**
+ * Presentation-ready description of where a relay-mesh agent's inference
+ * actually runs: which model, and how many live serving nodes on this relay
+ * currently host it.
+ */
+export type MeshInferenceLocation = {
+  /** Compact label for inline display (header/trace chrome). */
+  label: string;
+  /** Full sentence for the tooltip. */
+  title: string;
+  /** Distinct live serving nodes for the agent's model (0 = none live). */
+  nodeCount: number;
+};
+
+/**
+ * Mirror of the Rust-side canonical model matching in
+ * `pick_serve_target_for_model` (commands/mesh_llm.rs): trim and drop the
+ * implicit `@main` revision so `org/model@main:q4` matches `org/model:q4`.
+ */
+function canonicalModelId(value: string): string {
+  return value.trim().replace("@main", "");
+}
+
+function distinctNodeCount(targets: MeshAvailability["serveTargets"]): number {
+  const nodes = new Set<string>();
+  for (const target of targets) {
+    nodes.add(target.deviceId ?? target.endpointId ?? target.endpointAddr);
+  }
+  return nodes.size;
+}
+
+/**
+ * Derive the inference-location description for a relay-mesh agent.
+ *
+ * `model` is the agent record's model ref (`"auto"`/empty = mesh router
+ * picks per request). Returns `null` while availability is unknown
+ * (loading/error) — the indicator renders nothing rather than guessing.
+ */
+export function describeMeshInferenceLocation({
+  availability,
+  model,
+}: {
+  availability: MeshAvailability | null;
+  model: string | null;
+}): MeshInferenceLocation | null {
+  if (availability === null) {
+    return null;
+  }
+
+  const trimmedModel = (model ?? "").trim();
+  const isAuto = trimmedModel === "" || trimmedModel === "auto";
+
+  const targets = isAuto
+    ? availability.serveTargets
+    : availability.serveTargets.filter(
+        (target) =>
+          canonicalModelId(target.modelId) === canonicalModelId(trimmedModel),
+      );
+  const nodeCount = distinctNodeCount(targets);
+
+  if (nodeCount === 0) {
+    return {
+      label: "Shared compute · no live serving nodes",
+      title:
+        "This agent runs inference on Buzz shared compute, but no member is currently serving its model on this relay.",
+      nodeCount,
+    };
+  }
+
+  const nodesPhrase = `${nodeCount} node${nodeCount === 1 ? "" : "s"}`;
+  if (isAuto) {
+    return {
+      label: `Shared compute · auto-routed · ${nodesPhrase}`,
+      title: `This agent runs inference on Buzz shared compute, auto-routed across ${nodesPhrase} serving on this relay.`,
+      nodeCount,
+    };
+  }
+
+  const displayName =
+    targets.find((target) => target.modelName?.trim())?.modelName?.trim() ??
+    trimmedModel;
+  return {
+    label: `Shared compute · ${displayName} · ${nodesPhrase}`,
+    title: `This agent runs inference with ${displayName} on ${nodesPhrase} serving on this relay via Buzz shared compute.`,
+    nodeCount,
+  };
+}

--- a/desktop/src/shared/api/tauriMesh.ts
+++ b/desktop/src/shared/api/tauriMesh.ts
@@ -56,6 +56,32 @@ export async function meshInstalledModels(): Promise<MeshModelOption[]> {
   return await invokeTauri<MeshModelOption[]>("mesh_installed_models");
 }
 
+export type MeshServeTarget = {
+  modelId: string;
+  modelName: string | null;
+  endpointAddr: string;
+  nodeName: string | null;
+  capacity: { vramGb: number | null } | null;
+  endpointId?: string | null;
+  deviceId?: string | null;
+  deviceName?: string | null;
+};
+
+export type MeshAvailability = {
+  reason: string | null;
+  models: MeshModelOption[];
+  serveTargets: MeshServeTarget[];
+};
+
+/**
+ * Live Buzz shared compute availability on this relay: member-verified,
+ * freshness-filtered serve targets and the models they host. Read-only — used
+ * to tell the user where relay-mesh inference actually runs.
+ */
+export async function meshAvailability(): Promise<MeshAvailability> {
+  return await invokeTauri<MeshAvailability>("mesh_availability");
+}
+
 export type MeshModelFit = "comfortable" | "tight" | "tradeoff" | "too_large";
 
 export type MeshCatalogEntry = {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -8985,6 +8985,29 @@ export function maybeInstallE2eTauriMocks() {
       }
       case "mesh_installed_models":
         return mockMeshState.models;
+      case "mesh_availability":
+        // Mirrors the Rust MeshAvailability shape: when admitted, every mock
+        // model is served by one mock node; otherwise no live targets.
+        return mockMeshState.admitted
+          ? {
+              reason: null,
+              models: mockMeshState.models,
+              serveTargets: mockMeshState.models.map((model) => ({
+                modelId: model.id,
+                modelName: model.name,
+                endpointAddr: "mock-endpoint-addr",
+                nodeName: "Mock desktop",
+                capacity: null,
+                endpointId: "mock-endpoint-id",
+                deviceId: "mock-endpoint-id",
+                deviceName: "Mock desktop",
+              })),
+            }
+          : {
+              reason: mockMeshState.denyReason,
+              models: [],
+              serveTargets: [],
+            };
       case "mesh_node_status":
         return meshNodeStatus(mockMeshState.nodeState, mockMeshState.nodeMode);
       case "mesh_start_node": {


### PR DESCRIPTION
## What

Buzz shared compute (relay-mesh) agents gave no indication of where their inference actually executes. This adds a small indicator to the **Activity panel header**, next to the scope label:

```
←  Activity   #agents   Shared compute · Qwen3 8B · 3 nodes   ⚙
```

Hovering shows the full sentence: *"This agent runs inference with Qwen3 8B on 3 nodes serving on this relay via Buzz shared compute."*

States:

| State | Label |
|---|---|
| Explicit model | `Shared compute · Qwen3 8B · 3 nodes` |
| Auto (mesh router picks) | `Shared compute · auto-routed · 2 nodes` |
| Nothing live | `Shared compute · no live serving nodes` |

Non-mesh agents render nothing; while availability is loading it also renders nothing rather than guessing.

## How

- **New read-only `mesh_availability` Tauri command** — exposes the existing member-verified, freshness-filtered `MeshAvailability` (serve targets + models) that discovery already computes for routing. No new trust surface. Stubbed for non-`mesh-llm` builds.
- **`meshInferenceLocation.ts`** — pure derivation from availability + the agent's model ref. Counts *distinct* nodes (by `deviceId`/`endpointId`, so one node serving two models counts once) and mirrors the Rust `@main`-revision canonical model matching from `pick_serve_target_for_model`.
- **`useMeshInferenceLocation`** — resolves the managed agent record; polls availability (60s, vs the 45s relay status heartbeat) only when the provider is `relay-mesh`.
- **E2E mock bridge** answers `mesh_availability` with the matching shape.

## Testing

- 9 new unit tests for the derivation (`meshInferenceLocation.test.mjs`); full desktop suite 3259 pass
- `tsc --noEmit`, biome, `cargo clippy --features mesh-llm` clean
- Both Rust feature paths compile (stub + `mesh-llm`); all 60 mesh Rust tests pass
