### PR TITLE
fix(desktop): clarify data deletion action

### DIFF
--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -1018,7 +1018,7 @@ export function ProfileSettingsCard({
                   });
                 }}
               >
-                {isSignOutPending ? "Signing out…" : "Sign Out"}
+                {isSignOutPending ? "Signing out…" : "Delete My Data"}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/desktop/tests/e2e/signout-screenshots.spec.ts
+++ b/desktop/tests/e2e/signout-screenshots.spec.ts
@@ -58,6 +58,9 @@ test.describe("signout screenshots", () => {
     const dialog = page.getByRole("alertdialog");
     await expect(dialog).toBeVisible({ timeout: 5_000 });
     await expect(dialog.getByText("Sign out and wipe all data?")).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: "Delete My Data" }),
+    ).toBeVisible();
 
     // Settle animations before capture.
     await page.evaluate(() =>


### PR DESCRIPTION
## Why
The sign-out confirmation permanently removes the user's identity key and local app data, but its action was labeled only “Sign Out.” Name the destructive action explicitly before the user confirms it.

## What
- Rename the confirmation action to “Delete My Data”
- Assert the destructive label in the sign-out dialog E2E coverage

## Risk Assessment
Low — this changes one confirmation-dialog label and its test without changing sign-out behavior.

## References
- `just desktop-check` passed
- `just desktop-test` passed (1,943 tests)
- Sign-out Playwright coverage passed (2 tests)
- Full pre-push suites passed except five unrelated Tauri Codex adapter discovery tests; 1,490 Tauri tests passed

Generated with Fizz
