### PR TITLE
fix(mobile): resolve Android dependencies through Artifactory

### DIFF
--- a/mobile/android/build.gradle.kts
+++ b/mobile/android/build.gradle.kts
@@ -1,7 +1,7 @@
 allprojects {
     repositories {
         google()
-        mavenCentral()
+        maven(url = "https://global.block-artifacts.com/artifactory/square-public")
     }
 }
 

--- a/mobile/android/settings.gradle.kts
+++ b/mobile/android/settings.gradle.kts
@@ -12,8 +12,7 @@ pluginManagement {
 
     repositories {
         google()
-        mavenCentral()
-        gradlePluginPortal()
+        maven(url = "https://global.block-artifacts.com/artifactory/square-public")
     }
 }
 


### PR DESCRIPTION
### What changed?

Buzz Android now resolves Maven Central and Gradle Plugin Portal dependencies through Block Artifactory's `square-public` repository. Google-hosted Android dependencies continue to use `google()`.

### Why?

Shared CI egress is currently rate-limited by Maven Central with HTTP 429 responses, blocking signed Android release bundles. Using Block's mirror removes that direct dependency while keeping the resolved artifacts unchanged.

### How is it tested?

- Clean Gradle dependency resolution through Artifactory
- Full mobile analysis and test suite
- Full pre-push validation

*🤖 This PR was authored [with an agent](buzz://message?channel=48f30bdb-609f-4390-a38c-aae7ac03dbb3&id=7bab485eed1c91e5bab4e187939d19376d5dcdcfd5020824ecc3c4c224feab2e).*
