### PR TITLE
chore(lefthook): add CI-style path filtering to hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,19 +1,36 @@
+# Glob patterns below mirror the `changes` job's dorny/paths-filter groups in
+# .github/workflows/ci.yml — keep the two in sync. Deliberate deviations:
+# - The `.github/workflows/ci.yml` path CI adds to its `rust`/`mobile` filters
+#   is omitted; a CI-workflow-only edit doesn't need a local test run.
+# - `desktop-check`/`desktop-test` don't trigger on `rust` changes, though CI's
+#   Desktop Core job does. Those commands are pure TS (biome + node:test) with
+#   no Rust dependency, so the extra trigger would be spurious locally.
+# - Deletion-only surface changes do not trigger local hooks: lefthook 2.1.x
+#   drops deleted paths from push-file discovery (`extractFiles` existence
+#   check, repository.go). CI's dorny/paths-filter catches deletions.
+#   Deliberate — accepted, not worked around.
 pre-commit:
   parallel: true
   commands:
     rust-fmt:
+      glob: ["crates/**", "examples/countdown-bot/**"]
       run: just fmt
       stage_fixed: true
     desktop-tauri-fmt:
+      glob: ["desktop/src-tauri/**"]
       run: just desktop-tauri-fmt
       stage_fixed: true
     desktop-fix:
+      glob: ["desktop/**", "pnpm-lock.yaml"]
+      exclude: ["desktop/src-tauri/**"]
       run: just desktop-fix
       stage_fixed: true
     web-fix:
+      glob: ["web/**", "pnpm-lock.yaml"]
       run: just web-fix
       stage_fixed: true
     mobile-fix:
+      glob: ["mobile/**"]
       run: just mobile-fix
       stage_fixed: true
 
@@ -23,12 +40,22 @@ pre-push:
     branch-skew:
       run: ./scripts/check-branch-skew.sh
     rust-tests:
+      glob: ["crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
       run: just test-unit
     desktop-check:
+      glob: ["desktop/**", "pnpm-lock.yaml"]
+      exclude: ["desktop/src-tauri/**"]
       run: just desktop-check
     desktop-test:
+      glob: ["desktop/**", "pnpm-lock.yaml"]
+      exclude: ["desktop/src-tauri/**"]
       run: just desktop-test
     desktop-tauri-test:
+      # ci.yml:113 — Desktop Core triggers on `rust` OR `desktop-rust`;
+      # desktop/src-tauri path-depends on crates/buzz-core, buzz-persona,
+      # buzz-sdk, buzz-agent (desktop/src-tauri/Cargo.toml:88-91).
+      glob: ["desktop/src-tauri/**", "crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
       run: just desktop-tauri-test
     mobile-test:
+      glob: ["mobile/**"]
       run: just mobile-test


### PR DESCRIPTION
Every lefthook command ran unconditionally on every commit/push, regardless of which surface the change touched. This meant a rust-only push always ran `flutter analyze`, a mobile-only push always ran `cargo test`, etc.

Add `glob:` (and `exclude:` for desktop vs desktop-tauri) to each command so lefthook skips commands whose surface the push diff doesn't touch. The mechanism is lefthook's built-in push-range filtering (`git diff --name-only HEAD @{push}`) for pre-push and staged-file filtering for pre-commit — the same information CI's `dorny/paths-filter` `changes` job uses for PR diffs.

## What changed

```
pre-commit:
  rust-fmt          → glob: ["crates/**", "examples/countdown-bot/**"]
  desktop-tauri-fmt → glob: ["desktop/src-tauri/**"]
  desktop-fix       → glob: ["desktop/**", "pnpm-lock.yaml"], exclude: ["desktop/src-tauri/**"]
  web-fix           → glob: ["web/**", "pnpm-lock.yaml"]
  mobile-fix        → glob: ["mobile/**"]

pre-push:
  branch-skew        → no glob (always runs)
  rust-tests         → glob: ["crates/**", "migrations/**", "schema/**", "Cargo.toml", ...]
  desktop-check      → glob: ["desktop/**", "pnpm-lock.yaml"], exclude: ["desktop/src-tauri/**"]
  desktop-test       → glob: ["desktop/**", "pnpm-lock.yaml"], exclude: ["desktop/src-tauri/**"]
  desktop-tauri-test → glob: ["desktop/src-tauri/**"] UNION [rust filter] (mirrors ci.yml:113)
  mobile-test        → glob: ["mobile/**"]
```

A header comment in `lefthook.yml` states that these globs mirror `ci.yml`'s `changes` job filters and must be kept in sync.

## Deliberate deviations from ci.yml

1. **Workflow-file path omitted** — CI adds `.github/workflows/ci.yml` to its `rust`/`mobile` filters; a CI-config-only edit doesn't need a local test run.
2. **`desktop-check`/`desktop-test` don't union `rust`** — CI's Desktop Core job triggers on `rust` OR `desktop-rust`, but those commands are pure TS (biome + node:test) with no Rust dependency. Triggering them on rust changes would be spurious locally.
3. **Deletion-only pushes don't trigger local hooks** — lefthook 2.1.x drops deleted paths from push-file discovery (`extractFiles` existence check in `repository.go`). CI's `dorny/paths-filter` remains the gate for deletion-only surface changes. Deliberate: accepted, not worked around.

## Semantics to note

lefthook pre-push diffs against the remote branch tip (`HEAD @{push}`), not the full PR history. This means a later unrelated push won't re-run an earlier surface's tests even if that surface has commits earlier in the branch. This is coherent — each surface was gated when it was pushed — but it differs from CI which diffs the whole PR against main.

## Verification matrix (LEFTHOOK_VERBOSE=1)

| Scenario | Runs | Skips |
|---|---|---|
| `crates/buzz-core/src/lib.rs` | `rust-tests`, `desktop-tauri-test` ✅ | `desktop-check`, `desktop-test`, `mobile-test` — all "no matching push files" |
| `mobile/lib/main.dart` | `mobile-test` ✅ | `rust-tests`, `desktop-tauri-test`, `desktop-check`, `desktop-test` — all "no matching push files" |
| `desktop/src/App.ts` | `desktop-check`, `desktop-test` ✅ | `rust-tests`, `desktop-tauri-test`, `mobile-test` — all "no matching push files" |
| `README.md` (any file) | `branch-skew` ✅ | everything else skipped |

Skip message in each case: `(skip) no matching push files`
