### PR TITLE
fix(ci): stop moving protected Sprig rolling tag

### DIFF
--- a/.github/workflows/sprig.yml
+++ b/.github/workflows/sprig.yml
@@ -139,27 +139,10 @@ jobs:
           TITLE="Sprig (rolling)"
           NOTES="Rolling Linux build of Sprig (all-in-one buzz-acp + buzz-agent + buzz-dev-mcp), tracking \`main\` (\`${SHA}\`)."
 
-          if gh api "repos/${REPO}/git/refs/tags/${TAG}" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/${REPO}/git/refs/tags/${TAG}" \
-              -f sha="${SHA}" -F force=true >/dev/null
-          else
-            gh api -X POST "repos/${REPO}/git/refs" \
-              -f ref="refs/tags/${TAG}" -f sha="${SHA}" >/dev/null
-          fi
-
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" \
-              --prerelease \
-              --target "${SHA}" \
-              --title "$TITLE" \
-              --notes "$NOTES"
-          else
-            gh release edit "$TAG" \
-              --prerelease \
-              --target "${SHA}" \
-              --title "$TITLE" \
-              --notes "$NOTES"
-          fi
+          gh release edit "$TAG" \
+            --prerelease \
+            --title "$TITLE" \
+            --notes "$NOTES"
           gh release upload "$TAG" dist/* --clobber
 
   publish-tag:


### PR DESCRIPTION
## Summary
- stop force-moving the protected `sprig-latest` tag on every `main` build
- keep the stable rolling release URL while replacing its assets and metadata
- remove the now-unreachable release-creation path because `sprig-latest` already exists

## Root cause
The Release repository ruleset began protecting all tags. The Sprig rolling publish job calls the Git refs API with `force=true`, so every `main` run since 2026-07-20 21:39 UTC has failed with HTTP 422 (`Cannot update this protected ref`).

## Validation
- Ruby YAML parse
- extracted publish-step shell passes `bash -n`
- `git diff --check`
- confirmed `sprig-latest` release and its four expected assets exist
- confirmed the current failure is isolated to the protected-ref PATCH; both target builds and normal CI pass on current `main`

The publish behavior itself is validated by CI after merge because PR runs intentionally do not publish releases.
