### PR TITLE
fix(desktop): align data deletion labels

### DIFF
--- a/desktop/src/features/settings/ui/SignOutSection.tsx
+++ b/desktop/src/features/settings/ui/SignOutSection.tsx
@@ -151,7 +151,7 @@ export function SignOutSection() {
           {isPending ? (
             <Spinner aria-label="Signing out" className="h-4 w-4 border-2" />
           ) : null}
-          {isPending ? "Signing out…" : "Sign Out"}
+          {isPending ? "Signing out…" : "Delete my data"}
         </Button>
       </div>
       <AlertDialog
@@ -257,7 +257,7 @@ export function SignOutSection() {
                   className="h-4 w-4 border-2"
                 />
               ) : null}
-              {isPending ? "Signing out…" : "Delete My Data"}
+              {isPending ? "Signing out…" : "Delete my data"}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/desktop/tests/e2e/signout-screenshots.spec.ts
+++ b/desktop/tests/e2e/signout-screenshots.spec.ts
@@ -23,7 +23,7 @@ test.describe("signout screenshots", () => {
     });
   });
 
-  test("signout-section — Sign Out card in Settings › Profile", async ({
+  test("signout-section — data deletion card in Settings › Profile", async ({
     page,
   }) => {
     await installMockBridge(page);
@@ -32,6 +32,9 @@ test.describe("signout screenshots", () => {
 
     const section = page.getByTestId("settings-signout");
     await section.scrollIntoViewIfNeeded();
+    await expect(
+      section.getByRole("button", { name: "Delete my data" }),
+    ).toBeVisible();
 
     // Settle animations before capture.
     await page.evaluate(() =>
@@ -59,7 +62,7 @@ test.describe("signout screenshots", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
     await expect(dialog.getByText("Sign out and wipe all data?")).toBeVisible();
     await expect(
-      dialog.getByRole("button", { name: "Delete My Data" }),
+      dialog.getByRole("button", { name: "Delete my data" }),
     ).toBeVisible();
 
     // Settle animations before capture.


### PR DESCRIPTION
## Why

The Profile settings action still says “Sign Out,” while its confirmation action says “Delete My Data.” Both buttons trigger the same destructive local-data wipe and should name it consistently.

## What

- Label both destructive actions “Delete my data”
- Assert the matching section and confirmation labels in the existing Playwright coverage

## Risk Assessment

Low — copy and test assertions only; sign-out behavior is unchanged.

## References

- Follow-up to #2208
- #2216 also touches this copy and should preserve “Delete my data” when rebased
- `just desktop-check`
- `just desktop-test` (3,275 tests)
- Desktop E2E build and sign-out Playwright spec (2 tests)

Generated with Codex
