### PR TITLE
Hide bundled harnesses from onboarding

### DIFF
--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -54,8 +54,12 @@ with a TypeScript lookup table or an id comparison in a component.
    flags were deliberately killed in #2148 (`CANONICAL_CONFIG_BEHAVIORS`).
    Surface differences are expressed via the `disclosure` preset, not new
    boolean props.
-7. **Onboarding does not change.** `onboarding-agent-defaults.spec.ts` is the
-   acceptance gate for anything touching the shared renderer.
+7. **Onboarding setup detects readiness; it does not select defaults.** The
+   setup page derives visible and ready harnesses from the runtime catalog and
+   only offers install or sign-in actions. The following defaults page is the
+   sole onboarding surface that chooses and persists `preferred_runtime`.
+   `onboarding-agent-defaults.spec.ts` is the acceptance gate for anything
+   touching this flow or the shared renderer.
 
 ## The tests that enforce this
 

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -68,7 +68,8 @@ with a TypeScript lookup table or an id comparison in a component.
 - `ui/agentConfigFieldsContract.test.mjs` — canonical behaviors + disclosure
   presets. If this fails, you probably reintroduced a per-surface flag.
 - `desktop/tests/e2e/onboarding-agent-defaults.spec.ts` — onboarding behavior
-  pin (35 tests).
+  acceptance coverage for readiness, failure states, defaults, navigation, and
+  persistence races.
 - Rust: `runtime_metadata_env_vars` tests pin spawn-time key application.
 
 ## Keep this file true

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -40,10 +40,13 @@ function formatHarnessLabel(runtime: AcpRuntimeCatalogEntry | undefined) {
 }
 
 function AgentDefaultsSection({
-  onHasDefaultRuntimeChange,
+  onPersistenceStateChange,
   readyRuntimeIds,
 }: {
-  onHasDefaultRuntimeChange: (hasDefaultRuntime: boolean) => void;
+  onPersistenceStateChange: (state: {
+    canComplete: boolean;
+    flush: () => Promise<void>;
+  }) => void;
   readyRuntimeIds: readonly string[];
 }) {
   const runtimesQuery = useAcpRuntimesQuery();
@@ -55,8 +58,10 @@ function AgentDefaultsSection({
   const [bakedEnv, setBakedEnv] = React.useState<BakedEnvEntry[]>([]);
   const coalescerRef = React.useRef<{
     enqueue: (value: GlobalAgentConfig) => void;
+    flush: () => Promise<void>;
     cancel: () => void;
   } | null>(null);
+  const [isSaving, setIsSaving] = React.useState(false);
 
   React.useEffect(() => {
     let unmounted = false;
@@ -87,7 +92,9 @@ function AgentDefaultsSection({
       // set_global_agent_config returns a save result (config + restart
       // counts); the coalescer round-trips the persisted config only.
       async (next) => (await setGlobalAgentConfig(next)).config,
-      () => undefined, // saving state not surfaced in this autosave UX
+      (saving) => {
+        if (!unmounted) setIsSaving(saving);
+      },
       (saved) => {
         if (!unmounted) setConfig(saved);
       },
@@ -157,9 +164,16 @@ function AgentDefaultsSection({
     selectedRuntimeId,
   ]);
 
+  const flushPersistence = React.useCallback(
+    () => coalescerRef.current?.flush() ?? Promise.resolve(),
+    [],
+  );
   React.useEffect(() => {
-    onHasDefaultRuntimeChange(selectedRuntimeId.length > 0);
-  }, [onHasDefaultRuntimeChange, selectedRuntimeId]);
+    onPersistenceStateChange({
+      canComplete: selectedRuntimeId.length > 0 && !isSaving,
+      flush: flushPersistence,
+    });
+  }, [flushPersistence, isSaving, onPersistenceStateChange, selectedRuntimeId]);
 
   return (
     <section className="w-full space-y-4 text-left text-sm">
@@ -230,7 +244,26 @@ export function DefaultConfigStep({
   direction,
   readyRuntimeIds,
 }: DefaultConfigStepProps) {
-  const [hasDefaultRuntime, setHasDefaultRuntime] = React.useState(false);
+  const [persistenceState, setPersistenceState] = React.useState<{
+    canComplete: boolean;
+    flush: () => Promise<void>;
+  }>({ canComplete: false, flush: () => Promise.resolve() });
+  const [completionError, setCompletionError] = React.useState<string | null>(
+    null,
+  );
+  const [isCompleting, setIsCompleting] = React.useState(false);
+
+  const handleComplete = React.useCallback(async () => {
+    setIsCompleting(true);
+    setCompletionError(null);
+    try {
+      await persistenceState.flush();
+      actions.complete();
+    } catch {
+      setCompletionError("Couldn't save your default harness. Try again.");
+      setIsCompleting(false);
+    }
+  }, [actions, persistenceState]);
 
   return (
     <OnboardingSlideTransition
@@ -253,9 +286,17 @@ export function DefaultConfigStep({
       <div className="flex w-full flex-1 items-center justify-center py-10">
         <div className="w-full max-w-[328px]">
           <AgentDefaultsSection
-            onHasDefaultRuntimeChange={setHasDefaultRuntime}
+            onPersistenceStateChange={setPersistenceState}
             readyRuntimeIds={readyRuntimeIds}
           />
+          {completionError ? (
+            <p
+              className="mt-3 text-center text-xs text-destructive"
+              role="alert"
+            >
+              {completionError}
+            </p>
+          ) : null}
         </div>
       </div>
 
@@ -263,8 +304,8 @@ export function DefaultConfigStep({
         <Button
           className={`${ONBOARDING_PRIMARY_CTA_CLASS} text-sm`}
           data-testid="onboarding-finish"
-          disabled={!hasDefaultRuntime}
-          onClick={actions.complete}
+          disabled={!persistenceState.canComplete || isCompleting}
+          onClick={() => void handleComplete()}
           type="button"
         >
           Next

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -25,7 +25,10 @@ import {
   type OnboardingTransitionDirection,
   OnboardingSlideTransition,
 } from "./OnboardingSlideTransition";
-import { getVisibleOnboardingRuntimes } from "./onboardingRuntimeSelection";
+import {
+  getReadyOnboardingRuntimes,
+  getVisibleOnboardingRuntimes,
+} from "./onboardingRuntimeSelection";
 import type { DefaultConfigStepActions } from "./types";
 
 type DefaultConfigStepProps = {
@@ -107,9 +110,18 @@ function AgentDefaultsSection({
     };
   }, []);
 
+  const effectiveReadyRuntimeIds = React.useMemo(
+    () =>
+      readyRuntimeIds.length > 0
+        ? readyRuntimeIds
+        : getReadyOnboardingRuntimes(runtimesQuery.data ?? []).map(
+            (runtime) => runtime.id,
+          ),
+    [readyRuntimeIds, runtimesQuery.data],
+  );
   const readyRuntimeIdSet = React.useMemo(
-    () => new Set(readyRuntimeIds),
-    [readyRuntimeIds],
+    () => new Set(effectiveReadyRuntimeIds),
+    [effectiveReadyRuntimeIds],
   );
   // Setup already confirmed readiness. Re-filter only for onboarding
   // visibility here; a transient auth recheck must not invalidate that handoff.
@@ -131,7 +143,7 @@ function AgentDefaultsSection({
   const configSurfaceError =
     runtimesQuery.isError ||
     (!configSurfaceLoading &&
-      readyRuntimeIds.length > 0 &&
+      effectiveReadyRuntimeIds.length > 0 &&
       readyRuntimes.length === 0);
   const harnessOptions = React.useMemo(
     () =>

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -25,7 +25,7 @@ import {
   type OnboardingTransitionDirection,
   OnboardingSlideTransition,
 } from "./OnboardingSlideTransition";
-import { getReadyOnboardingRuntimes } from "./onboardingRuntimeSelection";
+import { getVisibleOnboardingRuntimes } from "./onboardingRuntimeSelection";
 import type { DefaultConfigStepActions } from "./types";
 
 type DefaultConfigStepProps = {
@@ -104,9 +104,11 @@ function AgentDefaultsSection({
     () => new Set(readyRuntimeIds),
     [readyRuntimeIds],
   );
+  // Setup already confirmed readiness. Re-filter only for onboarding
+  // visibility here; a transient auth recheck must not invalidate that handoff.
   const readyRuntimes = React.useMemo(
     () =>
-      getReadyOnboardingRuntimes(runtimesQuery.data ?? []).filter((runtime) =>
+      getVisibleOnboardingRuntimes(runtimesQuery.data ?? []).filter((runtime) =>
         readyRuntimeIdSet.has(runtime.id),
       ),
     [readyRuntimeIdSet, runtimesQuery.data],

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -121,9 +121,6 @@ function AgentDefaultsSection({
   const selectedRuntimeId = selectedRuntime?.id ?? "";
   const configSurfaceLoading = isLoading || runtimesQuery.isLoading;
 
-  React.useEffect(() => {
-    onHasDefaultRuntimeChange(selectedRuntimeId.length > 0);
-  }, [onHasDefaultRuntimeChange, selectedRuntimeId]);
   const configSurfaceError =
     runtimesQuery.isError ||
     (!configSurfaceLoading &&
@@ -148,6 +145,21 @@ function AgentDefaultsSection({
     },
     [config],
   );
+
+  React.useEffect(() => {
+    if (configSurfaceLoading || selectedRuntimeId) return;
+    if (readyRuntimes.length !== 1) return;
+    handleHarnessChange(readyRuntimes[0].id);
+  }, [
+    configSurfaceLoading,
+    handleHarnessChange,
+    readyRuntimes,
+    selectedRuntimeId,
+  ]);
+
+  React.useEffect(() => {
+    onHasDefaultRuntimeChange(selectedRuntimeId.length > 0);
+  }, [onHasDefaultRuntimeChange, selectedRuntimeId]);
 
   return (
     <section className="w-full space-y-4 text-left text-sm">

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -124,7 +124,9 @@ function AgentDefaultsSection({
   }, [onHasDefaultRuntimeChange, selectedRuntimeId]);
   const configSurfaceError =
     runtimesQuery.isError ||
-    (!configSurfaceLoading && readyRuntimeIds.length > 0 && !selectedRuntime);
+    (!configSurfaceLoading &&
+      readyRuntimeIds.length > 0 &&
+      readyRuntimes.length === 0);
   const harnessOptions = React.useMemo(
     () =>
       readyRuntimes.map((runtime) => ({

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -25,13 +25,13 @@ import {
   type OnboardingTransitionDirection,
   OnboardingSlideTransition,
 } from "./OnboardingSlideTransition";
-import { ONBOARDING_RUNTIME_ORDER } from "./onboardingRuntimeSelection";
+import { getReadyOnboardingRuntimes } from "./onboardingRuntimeSelection";
 import type { DefaultConfigStepActions } from "./types";
 
 type DefaultConfigStepProps = {
   actions: DefaultConfigStepActions;
   direction: OnboardingTransitionDirection;
-  selectedRuntimeIds: readonly string[];
+  readyRuntimeIds: readonly string[];
 };
 
 function formatHarnessLabel(runtime: AcpRuntimeCatalogEntry | undefined) {
@@ -39,27 +39,12 @@ function formatHarnessLabel(runtime: AcpRuntimeCatalogEntry | undefined) {
   return runtime.id === "buzz-agent" ? "Buzz" : runtime.label;
 }
 
-function sortSelectedRuntimes(
-  runtimes: readonly AcpRuntimeCatalogEntry[],
-  selectedRuntimeIds: readonly string[],
-) {
-  const selectedRuntimeIdSet = new Set(selectedRuntimeIds);
-  return runtimes
-    .filter((runtime) => selectedRuntimeIdSet.has(runtime.id))
-    .sort((left, right) => {
-      const leftIndex = ONBOARDING_RUNTIME_ORDER.indexOf(left.id);
-      const rightIndex = ONBOARDING_RUNTIME_ORDER.indexOf(right.id);
-      return (
-        (leftIndex === -1 ? ONBOARDING_RUNTIME_ORDER.length : leftIndex) -
-        (rightIndex === -1 ? ONBOARDING_RUNTIME_ORDER.length : rightIndex)
-      );
-    });
-}
-
 function AgentDefaultsSection({
-  selectedRuntimeIds,
+  onHasDefaultRuntimeChange,
+  readyRuntimeIds,
 }: {
-  selectedRuntimeIds: readonly string[];
+  onHasDefaultRuntimeChange: (hasDefaultRuntime: boolean) => void;
+  readyRuntimeIds: readonly string[];
 }) {
   const runtimesQuery = useAcpRuntimesQuery();
   const [config, setConfig] =
@@ -115,31 +100,38 @@ function AgentDefaultsSection({
     };
   }, []);
 
-  const selectedRuntimes = React.useMemo(
-    () => sortSelectedRuntimes(runtimesQuery.data ?? [], selectedRuntimeIds),
-    [runtimesQuery.data, selectedRuntimeIds],
+  const readyRuntimeIdSet = React.useMemo(
+    () => new Set(readyRuntimeIds),
+    [readyRuntimeIds],
   );
-  const selectedRuntime = React.useMemo(() => {
-    const preferredRuntime = selectedRuntimes.find(
-      (runtime) => runtime.id === config.preferred_runtime,
-    );
-    return preferredRuntime ?? selectedRuntimes[0];
-  }, [config.preferred_runtime, selectedRuntimes]);
-  const selectedRuntimeId =
-    selectedRuntime?.id ?? config.preferred_runtime ?? "";
+  const readyRuntimes = React.useMemo(
+    () =>
+      getReadyOnboardingRuntimes(runtimesQuery.data ?? []).filter((runtime) =>
+        readyRuntimeIdSet.has(runtime.id),
+      ),
+    [readyRuntimeIdSet, runtimesQuery.data],
+  );
+  const selectedRuntime = React.useMemo(
+    () =>
+      readyRuntimes.find((runtime) => runtime.id === config.preferred_runtime),
+    [config.preferred_runtime, readyRuntimes],
+  );
+  const selectedRuntimeId = selectedRuntime?.id ?? "";
   const configSurfaceLoading = isLoading || runtimesQuery.isLoading;
+
+  React.useEffect(() => {
+    onHasDefaultRuntimeChange(selectedRuntimeId.length > 0);
+  }, [onHasDefaultRuntimeChange, selectedRuntimeId]);
   const configSurfaceError =
     runtimesQuery.isError ||
-    (!configSurfaceLoading &&
-      selectedRuntimeIds.length > 0 &&
-      !selectedRuntime);
+    (!configSurfaceLoading && readyRuntimeIds.length > 0 && !selectedRuntime);
   const harnessOptions = React.useMemo(
     () =>
-      selectedRuntimes.map((runtime) => ({
+      readyRuntimes.map((runtime) => ({
         label: formatHarnessLabel(runtime),
         value: runtime.id,
       })),
-    [selectedRuntimes],
+    [readyRuntimes],
   );
 
   const handleHarnessChange = React.useCallback(
@@ -152,22 +144,6 @@ function AgentDefaultsSection({
     },
     [config],
   );
-
-  React.useEffect(() => {
-    if (isLoading || !selectedRuntimeId) return;
-    if (config.preferred_runtime === selectedRuntimeId) return;
-
-    // The user can go Back, change which harnesses are selected, then return to
-    // this page without using this page's own harness dropdown. Reconcile that
-    // effective harness change through the same reset path so a Codex model
-    // never survives into Claude Code as a custom model (or vice versa).
-    handleHarnessChange(selectedRuntimeId);
-  }, [
-    config.preferred_runtime,
-    handleHarnessChange,
-    isLoading,
-    selectedRuntimeId,
-  ]);
 
   return (
     <section className="w-full space-y-4 text-left text-sm">
@@ -236,8 +212,10 @@ function AgentDefaultsSection({
 export function DefaultConfigStep({
   actions,
   direction,
-  selectedRuntimeIds,
+  readyRuntimeIds,
 }: DefaultConfigStepProps) {
+  const [hasDefaultRuntime, setHasDefaultRuntime] = React.useState(false);
+
   return (
     <OnboardingSlideTransition
       className="flex min-h-full w-full flex-col items-center"
@@ -258,7 +236,10 @@ export function DefaultConfigStep({
 
       <div className="flex w-full flex-1 items-center justify-center py-10">
         <div className="w-full max-w-[328px]">
-          <AgentDefaultsSection selectedRuntimeIds={selectedRuntimeIds} />
+          <AgentDefaultsSection
+            onHasDefaultRuntimeChange={setHasDefaultRuntime}
+            readyRuntimeIds={readyRuntimeIds}
+          />
         </div>
       </div>
 
@@ -266,6 +247,7 @@ export function DefaultConfigStep({
         <Button
           className={`${ONBOARDING_PRIMARY_CTA_CLASS} text-sm`}
           data-testid="onboarding-finish"
+          disabled={!hasDefaultRuntime}
           onClick={actions.complete}
           type="button"
         >

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -2,15 +2,10 @@ import * as React from "react";
 import type { QueryClient } from "@tanstack/react-query";
 
 import {
-  getGlobalAgentConfig,
-  setGlobalAgentConfig,
-} from "@/shared/api/tauriGlobalAgentConfig";
-import {
   getIdentity,
   importIdentity,
   persistCurrentIdentity,
 } from "@/shared/api/tauriIdentity";
-import { resetConfigForHarnessChange } from "@/features/agents/ui/agentConfigOptions";
 import { Button } from "@/shared/ui/button";
 import { StartupWindowDragRegion } from "@/shared/ui/StartupWindowDragRegion";
 import { BackupStep } from "./BackupStep";
@@ -23,10 +18,6 @@ import {
   OnboardingChrome,
 } from "./OnboardingChrome";
 import { OnboardingFooterProvider } from "./OnboardingFooter";
-import {
-  getPreferredRuntimeIdForSelection,
-  runtimeSelectionNeedsDefaultsStep,
-} from "./onboardingRuntimeSelection";
 import { OnboardingSlideTransition } from "./OnboardingSlideTransition";
 import { SetupStep } from "./SetupStep";
 
@@ -59,63 +50,10 @@ export function MachineOnboardingFlow({
   const [selectedPubkey, setSelectedPubkey] = React.useState<string | null>(
     null,
   );
-  const [selectedRuntimeIds, setSelectedRuntimeIds] = React.useState<string[]>(
-    [],
-  );
-  const [isRuntimeSelectionSaving, setIsRuntimeSelectionSaving] =
-    React.useState(false);
-  const [runtimeSelectionError, setRuntimeSelectionError] = React.useState<
-    string | null
-  >(null);
-  const runtimeSaveSequence = React.useRef(0);
-  const runtimeSaveChain = React.useRef<Promise<void>>(Promise.resolve());
-
-  const persistHarnessSelection = React.useCallback(
+  const [readyRuntimeIds, setReadyRuntimeIds] = React.useState<string[]>([]);
+  const handleReadyRuntimeIdsChange = React.useCallback(
     (runtimeIds: readonly string[]) => {
-      const nextRuntimeIds = Array.from(new Set(runtimeIds));
-      const preferredRuntimeId =
-        getPreferredRuntimeIdForSelection(nextRuntimeIds);
-      const sequence = runtimeSaveSequence.current + 1;
-      runtimeSaveSequence.current = sequence;
-      setSelectedRuntimeIds(nextRuntimeIds);
-      setRuntimeSelectionError(null);
-      setIsRuntimeSelectionSaving(true);
-
-      const save = runtimeSaveChain.current.then(async () => {
-        const current = await getGlobalAgentConfig();
-        const selectedHarnessChanged =
-          current.preferred_runtime !== preferredRuntimeId;
-        if (!selectedHarnessChanged) {
-          await setGlobalAgentConfig({
-            ...current,
-            preferred_runtime: preferredRuntimeId,
-          });
-          return;
-        }
-
-        await setGlobalAgentConfig(
-          resetConfigForHarnessChange(current, preferredRuntimeId ?? ""),
-        );
-      });
-      runtimeSaveChain.current = save.then(
-        () => undefined,
-        () => undefined,
-      );
-      void save
-        .catch((cause) => {
-          if (runtimeSaveSequence.current === sequence) {
-            setRuntimeSelectionError(
-              cause instanceof Error
-                ? cause.message
-                : "Couldn’t save your harness selection.",
-            );
-          }
-        })
-        .finally(() => {
-          if (runtimeSaveSequence.current === sequence) {
-            setIsRuntimeSelectionSaving(false);
-          }
-        });
+      setReadyRuntimeIds(Array.from(new Set(runtimeIds)));
     },
     [],
   );
@@ -277,21 +215,11 @@ export function MachineOnboardingFlow({
                 back: () =>
                   setPage(identityWasImported ? "key-import" : "backup"),
                 next: () => {
-                  if (selectedRuntimeIds.length === 0) return;
-                  if (!runtimeSelectionNeedsDefaultsStep(selectedRuntimeIds)) {
-                    complete(selectedPubkey ?? undefined);
-                    return;
-                  }
-                  setPage("config");
+                  if (readyRuntimeIds.length > 0) setPage("config");
                 },
               }}
               direction="forward"
-              isSelectionSaving={isRuntimeSelectionSaving}
-              onSelectedRuntimeIdsChange={(runtimeIds) => {
-                void persistHarnessSelection(runtimeIds);
-              }}
-              selectionError={runtimeSelectionError}
-              selectedRuntimeIds={selectedRuntimeIds}
+              onReadyRuntimeIdsChange={handleReadyRuntimeIdsChange}
             />
           ) : (
             <DefaultConfigStep
@@ -300,7 +228,7 @@ export function MachineOnboardingFlow({
                 complete: () => complete(selectedPubkey ?? undefined),
               }}
               direction="forward"
-              selectedRuntimeIds={selectedRuntimeIds}
+              readyRuntimeIds={readyRuntimeIds}
             />
           )}
         </div>

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -214,8 +214,9 @@ export function MachineOnboardingFlow({
               actions={{
                 back: () =>
                   setPage(identityWasImported ? "key-import" : "backup"),
-                next: () => {
-                  if (readyRuntimeIds.length > 0) setPage("config");
+                next: (runtimeIds) => {
+                  setReadyRuntimeIds(Array.from(runtimeIds));
+                  setPage("config");
                 },
               }}
               direction="forward"

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -18,10 +18,9 @@ import { FlappingBee } from "@/shared/ui/buzz-logo/FlappingBee";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import {
-  ONBOARDING_RUNTIME_ORDER,
-  runtimeCanAdvanceOnboarding,
-  runtimeCanBeSelected,
-  runtimeIsOnboardingChoice,
+  getReadyOnboardingRuntimes,
+  getVisibleOnboardingRuntimes,
+  runtimeIsReadyForOnboarding,
 } from "./onboardingRuntimeSelection";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { RuntimeErrorTooltip } from "./RuntimeErrorTooltip";
@@ -36,19 +35,10 @@ import type { SetupStepActions, SetupStepState } from "./types";
 type SetupStepProps = {
   actions: SetupStepActions;
   direction: OnboardingTransitionDirection;
-  isSelectionSaving: boolean;
-  onSelectedRuntimeIdsChange: (runtimeIds: readonly string[]) => void;
-  selectionError: string | null;
-  selectedRuntimeIds: readonly string[];
+  onReadyRuntimeIdsChange: (runtimeIds: readonly string[]) => void;
 };
 
-type SetupStepContentProps = {
-  actions: SetupStepActions;
-  direction: OnboardingTransitionDirection;
-  isSelectionSaving: boolean;
-  onSelectedRuntimeIdsChange: (runtimeIds: readonly string[]) => void;
-  selectionError: string | null;
-  selectedRuntimeIds: readonly string[];
+type SetupStepContentProps = SetupStepProps & {
   state: SetupStepState;
 };
 
@@ -75,28 +65,23 @@ function useSetupStepState(): SetupStepState {
   };
 }
 
-function RuntimeSelectionIndicator({
+function RuntimeReadinessIndicator({
   runtime,
-  selected,
+  ready,
 }: {
   runtime: AcpRuntimeCatalogEntry;
-  selected: boolean;
+  ready: boolean;
 }) {
+  if (!ready) return null;
+
   return (
     <span
       aria-hidden="true"
-      className={cn(
-        "pointer-events-none absolute right-8 top-8 flex h-8 w-8 scale-90 items-center justify-center rounded-full border border-[var(--buzz-welcome-chartreuse)] bg-white/75 opacity-0 transition-[background-color,opacity,transform] duration-200 ease-out group-hover:scale-100 group-hover:opacity-100 group-focus-visible:scale-100 group-focus-visible:opacity-100",
-        selected &&
-          "scale-100 bg-[var(--buzz-welcome-chartreuse)] opacity-100 group-hover:opacity-100",
-      )}
+      className="pointer-events-none absolute right-8 top-8 flex h-8 w-8 items-center justify-center rounded-full border border-[var(--buzz-welcome-chartreuse)] bg-[var(--buzz-welcome-chartreuse)]"
       data-testid={`onboarding-runtime-check-${runtime.id}`}
     >
       <Check
-        className={cn(
-          "h-4 w-4 text-foreground transition-[opacity,transform] duration-150 ease-out",
-          selected ? "scale-100 opacity-100" : "scale-50 opacity-0",
-        )}
+        className="h-4 w-4 text-foreground"
         data-testid={`onboarding-runtime-checkmark-${runtime.id}`}
         strokeWidth={3}
       />
@@ -104,51 +89,17 @@ function RuntimeSelectionIndicator({
   );
 }
 
-function runtimeIsInstalled(runtime: AcpRuntimeCatalogEntry) {
-  return runtimeCanBeSelected(runtime) && runtimeCanAdvanceOnboarding(runtime);
-}
-
-function useSetupFlashState(setupFlashToken: number) {
-  const [isFlashing, setIsFlashing] = React.useState(false);
-
-  React.useEffect(() => {
-    if (setupFlashToken === 0) return;
-
-    setIsFlashing(false);
-    const frame = window.requestAnimationFrame(() => {
-      setIsFlashing(true);
-    });
-    const timeout = window.setTimeout(() => {
-      setIsFlashing(false);
-    }, 650);
-
-    return () => {
-      window.cancelAnimationFrame(frame);
-      window.clearTimeout(timeout);
-    };
-  }, [setupFlashToken]);
-
-  return isFlashing;
-}
-
 function RuntimeStatus({
   installError,
-  installSuccess,
   isInstalling,
   onInstall,
-  onSelect,
   runtime,
-  setupFlashToken,
 }: {
   installError: string | null;
-  installSuccess: boolean;
   isInstalling: boolean;
   onInstall: () => void;
-  onSelect: () => void;
   runtime: AcpRuntimeCatalogEntry;
-  setupFlashToken: number;
 }) {
-  const isSetupFlashing = useSetupFlashState(setupFlashToken);
   const methodsQuery = useAcpAuthMethodsQuery(runtime.id, {
     enabled:
       runtime.availability === "available" &&
@@ -161,43 +112,31 @@ function RuntimeStatus({
     methodsQuery.data?.methods ?? [],
   );
   const authMethod = authMethods[0] ?? null;
-  const shouldRunAuthSetup =
+  const shouldSignIn =
     runtime.availability === "available" &&
     runtime.authStatus.status === "logged_out";
 
-  if (shouldRunAuthSetup) {
+  if (shouldSignIn) {
     return (
       <div className="flex flex-col items-center gap-1.5">
         <Button
-          aria-label={`Set up ${runtime.label}`}
+          aria-label={`Sign in to ${runtime.label}`}
           className="buzz-onboarding-runtime-setup h-5 rounded-full bg-[var(--buzz-welcome-chartreuse)]/30 px-2.5 font-mono !text-badge font-normal uppercase text-foreground hover:bg-[var(--buzz-welcome-chartreuse)]/40"
-          data-setup-flash={isSetupFlashing ? "true" : undefined}
           data-testid={`onboarding-runtime-instructions-${runtime.id}`}
-          onClick={(event) => {
-            event.stopPropagation();
-            onSelect();
+          onClick={() => {
             if (!authMethod) {
               void methodsQuery.refetch();
               return;
             }
-            connectMutation.mutate(
-              {
-                methodId: authMethod.id,
-                runtimeId: runtime.id,
-              },
-              {
-                onSuccess: () => {
-                  if (runtime.id === "claude" || runtime.id === "codex") {
-                    onSelect();
-                  }
-                },
-              },
-            );
+            connectMutation.mutate({
+              methodId: authMethod.id,
+              runtimeId: runtime.id,
+            });
           }}
           type="button"
           variant="ghost"
         >
-          SET UP
+          SIGN IN
         </Button>
         {methodsQuery.error instanceof Error ? (
           <RuntimeErrorTooltip
@@ -230,6 +169,27 @@ function RuntimeStatus({
     );
   }
 
+  if (runtimeIsReadyForOnboarding(runtime)) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex h-5 cursor-default items-center rounded-full bg-[#EBEFEF] px-2.5 font-mono text-badge font-normal uppercase text-foreground"
+            data-testid={`onboarding-runtime-ready-${runtime.id}`}
+          >
+            READY
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          className="max-w-80 bg-black text-left text-xs text-white shadow-sm"
+          side="top"
+        >
+          <RuntimeDetails runtime={runtime} />
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
   if (
     runtime.availability === "available" &&
     runtime.authStatus.status === "unknown"
@@ -239,10 +199,7 @@ function RuntimeStatus({
         aria-label={`Check ${runtime.label} again`}
         className="buzz-onboarding-runtime-setup h-5 rounded-full bg-[var(--buzz-welcome-chartreuse)]/30 px-2.5 font-mono !text-badge font-normal uppercase text-foreground hover:bg-[var(--buzz-welcome-chartreuse)]/40"
         disabled={runtimesQuery.isFetching}
-        onClick={(event) => {
-          event.stopPropagation();
-          void runtimesQuery.refetch();
-        }}
+        onClick={() => void runtimesQuery.refetch()}
         type="button"
         variant="ghost"
       >
@@ -251,88 +208,32 @@ function RuntimeStatus({
     );
   }
 
-  if (installError && runtime.canAutoInstall) {
-    return (
-      <Button
-        aria-label={`Retry ${runtime.label} setup`}
-        className="buzz-onboarding-runtime-setup h-5 rounded-full bg-[var(--buzz-welcome-chartreuse)]/30 px-2.5 font-mono !text-badge font-normal uppercase text-foreground hover:bg-[var(--buzz-welcome-chartreuse)]/40"
-        data-setup-flash={isSetupFlashing ? "true" : undefined}
-        data-testid={`onboarding-runtime-install-${runtime.id}`}
-        onClick={(event) => {
-          event.stopPropagation();
-          onSelect();
-          onInstall();
-        }}
-        type="button"
-        variant="ghost"
-      >
-        SET UP
-      </Button>
-    );
-  }
-
-  if (runtimeIsInstalled(runtime) || installSuccess) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            aria-label={`${runtime.label} installed`}
-            className="inline-flex h-5 cursor-default items-center rounded-full bg-[#EBEFEF] px-2.5 font-mono text-badge font-normal uppercase text-foreground"
-            data-testid={`onboarding-runtime-installed-${runtime.id}`}
-            role="img"
-          >
-            INSTALLED
-          </span>
-        </TooltipTrigger>
-        <TooltipContent
-          className="max-w-80 bg-black text-left text-xs text-white shadow-sm"
-          side="top"
-        >
-          {runtimeIsInstalled(runtime) ? (
-            <RuntimeDetails runtime={runtime} />
-          ) : (
-            <p className="text-xs leading-4 text-white">Setup completed.</p>
-          )}
-        </TooltipContent>
-      </Tooltip>
-    );
-  }
-
+  const installLabel = installError ? "RETRY INSTALL" : "INSTALL";
   if (runtime.canAutoInstall) {
     return (
       <Button
-        aria-label={`Install ${runtime.label}`}
+        aria-label={`${installError ? "Retry installing" : "Install"} ${runtime.label}`}
         className="buzz-onboarding-runtime-setup h-5 rounded-full bg-[var(--buzz-welcome-chartreuse)]/30 px-2.5 font-mono !text-badge font-normal uppercase text-foreground hover:bg-[var(--buzz-welcome-chartreuse)]/40"
-        data-setup-flash={isSetupFlashing ? "true" : undefined}
         data-testid={`onboarding-runtime-install-${runtime.id}`}
-        onClick={(event) => {
-          event.stopPropagation();
-          onSelect();
-          onInstall();
-        }}
+        onClick={onInstall}
         type="button"
         variant="ghost"
       >
-        SET UP
+        {installLabel}
       </Button>
     );
   }
 
   return (
     <Button
-      aria-label={`View ${runtime.label} setup instructions`}
+      aria-label={`View ${runtime.label} install instructions`}
       className="buzz-onboarding-runtime-setup h-5 rounded-full bg-[var(--buzz-welcome-chartreuse)]/30 px-2.5 font-mono !text-badge font-normal uppercase text-foreground hover:bg-[var(--buzz-welcome-chartreuse)]/40"
-      data-setup-flash={isSetupFlashing ? "true" : undefined}
       data-testid={`onboarding-runtime-instructions-${runtime.id}`}
-      onClick={(event) => {
-        event.stopPropagation();
-        onSelect();
-        void openUrl(runtime.installInstructionsUrl);
-      }}
+      onClick={() => void openUrl(runtime.installInstructionsUrl)}
       type="button"
       variant="ghost"
     >
-      SET UP
+      INSTALL
     </Button>
   );
 }
@@ -519,52 +420,30 @@ function RuntimeAuthError({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
 
 function RuntimeCard({
   installError,
-  installSuccess,
   isInstalling,
   onInstall,
-  onSelect,
-  onToggle,
   runtime,
-  selected,
-  setupFlashToken,
 }: {
   installError: string | null;
-  installSuccess: boolean;
   isInstalling: boolean;
   onInstall: () => void;
-  onSelect: () => void;
-  onToggle: () => void;
   runtime: AcpRuntimeCatalogEntry;
-  selected: boolean;
-  setupFlashToken: number;
 }) {
-  const isAvailable = runtime.availability === "available" || installSuccess;
-  const canSelect = runtimeCanBeSelected(runtime);
+  const isAvailable = runtime.availability === "available";
+  const isReady = runtimeIsReadyForOnboarding(runtime);
 
   return (
     <Card
-      aria-checked={selected}
-      aria-disabled={!canSelect}
       className={cn(
-        "group h-[224px] w-full max-w-[288px] select-none items-center px-3 py-1.5 text-center outline-none transition-[filter] duration-150 ease-out hover:brightness-[0.98] active:brightness-[0.96] focus-visible:ring-2 focus-visible:ring-foreground/40",
+        "group h-[224px] w-full max-w-[288px] select-none items-center px-3 py-1.5 text-center",
         installError && "ring-1 ring-destructive/40",
-        selected && "brightness-[0.98] hover:brightness-[0.98]",
-        canSelect ? "cursor-pointer" : "cursor-default",
+        isReady && "brightness-[0.98]",
       )}
+      data-ready={isReady ? "true" : "false"}
       data-testid={`onboarding-runtime-${runtime.id}`}
-      onClick={canSelect ? onToggle : undefined}
-      onKeyDown={(event) => {
-        if (event.target !== event.currentTarget) return;
-        if (canSelect && (event.key === "Enter" || event.key === " ")) {
-          event.preventDefault();
-          onToggle();
-        }
-      }}
-      role="checkbox"
-      tabIndex={canSelect ? 0 : -1}
       variant="textured"
     >
-      <RuntimeSelectionIndicator runtime={runtime} selected={selected} />
+      <RuntimeReadinessIndicator ready={isReady} runtime={runtime} />
 
       <div className="flex min-w-0 flex-col items-center gap-2.5">
         <div className="flex min-w-0 items-center justify-center gap-3">
@@ -575,12 +454,9 @@ function RuntimeCard({
         </div>
         <RuntimeStatus
           installError={installError}
-          installSuccess={installSuccess}
           isInstalling={isInstalling}
           onInstall={onInstall}
-          onSelect={onSelect}
           runtime={runtime}
-          setupFlashToken={setupFlashToken}
         />
         {!isAvailable && runtimeDetailText(runtime) ? (
           <p
@@ -597,8 +473,8 @@ function RuntimeCard({
       {installError ? (
         <RuntimeErrorTooltip
           className="absolute inset-x-3 bottom-2 flex min-w-0 items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap text-xs leading-4 text-destructive"
-          detail="Setup couldn’t be completed. Try again."
-          label="Setup failed"
+          detail="Installation couldn’t be completed. Try again."
+          label="Installation failed"
           showIcon
           testId={`onboarding-runtime-error-${runtime.id}`}
         />
@@ -630,54 +506,17 @@ function RuntimeProvidersLoadingState() {
 function RuntimeProvidersSection({
   installResults,
   onInstallResultsChange,
-  onSelectedRuntimeIdsChange,
   runtimeProviders,
-  setupFlashToken,
-  setupRequiredRuntimeIds,
-  selectedRuntimeIds,
 }: {
   installResults: InstallResultsState;
   onInstallResultsChange: React.Dispatch<
     React.SetStateAction<InstallResultsState>
   >;
-  onSelectedRuntimeIdsChange: (runtimeIds: readonly string[]) => void;
   runtimeProviders: SetupStepState["runtimeProviders"];
-  setupFlashToken: number;
-  setupRequiredRuntimeIds: readonly string[];
-  selectedRuntimeIds: readonly string[];
 }) {
   const { errorMessage, isChecking, items } = runtimeProviders;
-  const orderedItems = items
-    .filter((runtime) => runtimeIsOnboardingChoice(runtime.id))
-    .sort(
-      (left, right) =>
-        ONBOARDING_RUNTIME_ORDER.indexOf(left.id) -
-        ONBOARDING_RUNTIME_ORDER.indexOf(right.id),
-    );
+  const orderedItems = getVisibleOnboardingRuntimes(items);
   const installMutation = useInstallAcpRuntimeMutation();
-  const selectedRuntimeIdSet = React.useMemo(
-    () => new Set(selectedRuntimeIds),
-    [selectedRuntimeIds],
-  );
-  const setupRequiredRuntimeIdSet = React.useMemo(
-    () => new Set(setupRequiredRuntimeIds),
-    [setupRequiredRuntimeIds],
-  );
-
-  function handleRuntimeToggle(runtimeId: string) {
-    if (selectedRuntimeIdSet.has(runtimeId)) {
-      onSelectedRuntimeIdsChange(
-        selectedRuntimeIds.filter((selectedId) => selectedId !== runtimeId),
-      );
-      return;
-    }
-    onSelectedRuntimeIdsChange([...selectedRuntimeIds, runtimeId]);
-  }
-
-  function handleRuntimeSelect(runtimeId: string) {
-    if (selectedRuntimeIdSet.has(runtimeId)) return;
-    onSelectedRuntimeIdsChange([...selectedRuntimeIds, runtimeId]);
-  }
 
   function handleInstall(runtimeId: string) {
     onInstallResultsChange((current) => ({
@@ -710,45 +549,30 @@ function RuntimeProvidersSection({
     <section className="flex min-h-full w-full flex-col items-center">
       <div className="w-full max-w-[820px] text-center">
         <h1 className="text-title font-normal text-foreground">
-          Use the models that fit the task
+          Set up your agent harnesses
         </h1>
         <p className="mx-auto mt-3 max-w-[760px] text-sm leading-6 text-foreground/90">
-          <span>
-            Connect your model providers here. Each agent can use the one that’s
-            best for their work.
-          </span>
-          <span className="mt-1 block">
-            Choose at least one to start using Buzz.
-          </span>
+          Buzz detected the harnesses available on this machine. Install or sign
+          in to at least one to continue.
         </p>
       </div>
 
       <div className="flex w-full flex-1 flex-col items-center justify-center gap-8 py-10">
         {orderedItems.length > 0 ? (
-          <fieldset className="grid min-w-0 w-full max-w-[592px] grid-cols-1 gap-4 border-0 p-0 md:grid-cols-2">
-            <legend className="sr-only">Agent harnesses</legend>
+          <div className="grid min-w-0 w-full max-w-[592px] grid-cols-1 gap-4 md:grid-cols-2">
             {orderedItems.map((runtime) => (
               <RuntimeCard
                 installError={installResults[runtime.id]?.error ?? null}
-                installSuccess={installResults[runtime.id]?.success ?? false}
                 isInstalling={
                   installMutation.isPending &&
                   installMutation.variables === runtime.id
                 }
                 key={runtime.id}
                 onInstall={() => handleInstall(runtime.id)}
-                onSelect={() => handleRuntimeSelect(runtime.id)}
-                onToggle={() => handleRuntimeToggle(runtime.id)}
                 runtime={runtime}
-                selected={selectedRuntimeIdSet.has(runtime.id)}
-                setupFlashToken={
-                  setupRequiredRuntimeIdSet.has(runtime.id)
-                    ? setupFlashToken
-                    : 0
-                }
               />
             ))}
-          </fieldset>
+          </div>
         ) : isChecking ? (
           <RuntimeProvidersLoadingState />
         ) : errorMessage ? null : (
@@ -756,8 +580,8 @@ function RuntimeProvidersSection({
             className="max-w-[560px] rounded-2xl bg-white/70 px-6 py-6 text-sm text-muted-foreground"
             data-testid="onboarding-acp-empty"
           >
-            No compatible agent runtimes detected yet. You can finish setup now
-            and come back later in Settings &gt; Agents.
+            No supported agent harnesses were detected yet. Install Claude Code
+            or Codex, then check again.
           </p>
         )}
 
@@ -774,57 +598,22 @@ function RuntimeProvidersSection({
 function SetupStepContent({
   actions,
   direction,
-  isSelectionSaving,
-  onSelectedRuntimeIdsChange,
-  selectionError,
-  selectedRuntimeIds,
+  onReadyRuntimeIdsChange,
   state,
 }: SetupStepContentProps) {
   const { runtimeProviders } = state;
   const [installResults, setInstallResults] =
     React.useState<InstallResultsState>({});
-  const [setupFlashToken, setSetupFlashToken] = React.useState(0);
-  const [setupRequiredHintKey, setSetupRequiredHintKey] = React.useState<
-    string | null
-  >(null);
-  const runtimeById = React.useMemo(
+  const readyRuntimeIds = React.useMemo(
     () =>
-      new Map(runtimeProviders.items.map((runtime) => [runtime.id, runtime])),
+      getReadyOnboardingRuntimes(runtimeProviders.items).map(
+        (runtime) => runtime.id,
+      ),
     [runtimeProviders.items],
   );
-  const setupRequiredRuntimeIds = React.useMemo(
-    () =>
-      selectedRuntimeIds.filter((runtimeId) => {
-        const runtime = runtimeById.get(runtimeId);
-        if (!runtime) return false;
-        return !runtimeCanAdvanceOnboarding(runtime);
-      }),
-    [runtimeById, selectedRuntimeIds],
-  );
-  const hasSetupRequiredSelection = setupRequiredRuntimeIds.length > 0;
-  const setupRequiredRuntimeIdsKey = setupRequiredRuntimeIds.join("\0");
-  const showSetupRequiredHint =
-    hasSetupRequiredSelection &&
-    setupRequiredHintKey === setupRequiredRuntimeIdsKey;
-
   React.useEffect(() => {
-    if (
-      setupRequiredHintKey !== null &&
-      setupRequiredHintKey !== setupRequiredRuntimeIdsKey
-    ) {
-      setSetupRequiredHintKey(null);
-    }
-  }, [setupRequiredHintKey, setupRequiredRuntimeIdsKey]);
-
-  function handleNext() {
-    if (selectedRuntimeIds.length === 0 || isSelectionSaving) return;
-    if (hasSetupRequiredSelection) {
-      setSetupRequiredHintKey(setupRequiredRuntimeIdsKey);
-      setSetupFlashToken((current) => current + 1);
-      return;
-    }
-    actions.next();
-  }
+    onReadyRuntimeIdsChange(readyRuntimeIds);
+  }, [onReadyRuntimeIdsChange, readyRuntimeIds]);
 
   return (
     <OnboardingSlideTransition
@@ -836,41 +625,15 @@ function SetupStepContent({
       <RuntimeProvidersSection
         installResults={installResults}
         onInstallResultsChange={setInstallResults}
-        onSelectedRuntimeIdsChange={onSelectedRuntimeIdsChange}
         runtimeProviders={runtimeProviders}
-        setupFlashToken={setupFlashToken}
-        setupRequiredRuntimeIds={setupRequiredRuntimeIds}
-        selectedRuntimeIds={selectedRuntimeIds}
       />
 
       <OnboardingFooter>
-        {selectionError ? (
-          <p
-            className="max-w-sm text-center text-xs text-destructive"
-            role="alert"
-          >
-            {selectionError}
-          </p>
-        ) : null}
-        {hasSetupRequiredSelection && showSetupRequiredHint ? (
-          <p
-            className="-mb-1 text-center text-xs leading-4 text-foreground/60"
-            data-testid="onboarding-setup-next-hint"
-          >
-            Please finish set up
-          </p>
-        ) : null}
         <Button
-          className={cn(
-            ONBOARDING_PRIMARY_CTA_CLASS,
-            "text-sm",
-            hasSetupRequiredSelection &&
-              "cursor-default opacity-50 hover:opacity-50",
-          )}
-          data-soft-disabled={hasSetupRequiredSelection ? "true" : undefined}
+          className={`${ONBOARDING_PRIMARY_CTA_CLASS} text-sm`}
           data-testid="onboarding-setup-next"
-          disabled={selectedRuntimeIds.length === 0 || isSelectionSaving}
-          onClick={handleNext}
+          disabled={readyRuntimeIds.length === 0}
+          onClick={actions.next}
           type="button"
         >
           Next
@@ -893,10 +656,7 @@ function SetupStepContent({
 export function SetupStep({
   actions,
   direction,
-  isSelectionSaving,
-  onSelectedRuntimeIdsChange,
-  selectionError,
-  selectedRuntimeIds,
+  onReadyRuntimeIdsChange,
 }: SetupStepProps) {
   const state = useSetupStepState();
 
@@ -904,10 +664,7 @@ export function SetupStep({
     <SetupStepContent
       actions={actions}
       direction={direction}
-      isSelectionSaving={isSelectionSaving}
-      onSelectedRuntimeIdsChange={onSelectedRuntimeIdsChange}
-      selectionError={selectionError}
-      selectedRuntimeIds={selectedRuntimeIds}
+      onReadyRuntimeIdsChange={onReadyRuntimeIdsChange}
       state={state}
     />
   );

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -72,7 +72,9 @@ function RuntimeReadinessIndicator({
   runtime: AcpRuntimeCatalogEntry;
   ready: boolean;
 }) {
-  if (!ready) return null;
+  // Checkmark temporarily hidden; flip to true to restore it.
+  const showReadinessCheckmark = false;
+  if (!ready || !showReadinessCheckmark) return null;
 
   return (
     <span

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -110,6 +110,15 @@ function RuntimeStatus({
   const connectMutation = useConnectAcpRuntimeMutation();
   const runtimesQuery = useAcpRuntimesQuery();
   const [isWaitingForSignIn, setIsWaitingForSignIn] = React.useState(false);
+  const [didSignInCheckTimeOut, setDidSignInCheckTimeOut] =
+    React.useState(false);
+  const isReady = runtimeIsReadyForOnboarding(runtime);
+
+  React.useEffect(() => {
+    if (!isWaitingForSignIn || !isReady) return;
+    setIsWaitingForSignIn(false);
+    setDidSignInCheckTimeOut(false);
+  }, [isReady, isWaitingForSignIn]);
 
   React.useEffect(() => {
     if (!isWaitingForSignIn) return;
@@ -119,6 +128,7 @@ function RuntimeStatus({
     }, 2_000);
     const timeout = window.setTimeout(() => {
       setIsWaitingForSignIn(false);
+      setDidSignInCheckTimeOut(true);
     }, 120_000);
 
     return () => {
@@ -143,6 +153,12 @@ function RuntimeStatus({
           className="buzz-onboarding-runtime-setup h-5 rounded-full bg-[var(--buzz-welcome-chartreuse)]/30 px-2.5 font-mono !text-badge font-normal uppercase text-foreground hover:bg-[var(--buzz-welcome-chartreuse)]/40"
           data-testid={`onboarding-runtime-instructions-${runtime.id}`}
           onClick={() => {
+            if (didSignInCheckTimeOut) {
+              setDidSignInCheckTimeOut(false);
+              setIsWaitingForSignIn(true);
+              void runtimesQuery.refetch();
+              return;
+            }
             if (!authMethod) {
               void methodsQuery.refetch();
               return;
@@ -160,7 +176,11 @@ function RuntimeStatus({
           type="button"
           variant="ghost"
         >
-          {isWaitingForSignIn ? "CHECKING…" : "SIGN IN"}
+          {isWaitingForSignIn
+            ? "CHECKING…"
+            : didSignInCheckTimeOut
+              ? "CHECK AGAIN"
+              : "SIGN IN"}
         </Button>
         {methodsQuery.error instanceof Error ? (
           <RuntimeErrorTooltip

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -107,6 +107,23 @@ function RuntimeStatus({
   });
   const connectMutation = useConnectAcpRuntimeMutation();
   const runtimesQuery = useAcpRuntimesQuery();
+  const [isWaitingForSignIn, setIsWaitingForSignIn] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!isWaitingForSignIn) return;
+
+    const interval = window.setInterval(() => {
+      void runtimesQuery.refetch();
+    }, 2_000);
+    const timeout = window.setTimeout(() => {
+      setIsWaitingForSignIn(false);
+    }, 120_000);
+
+    return () => {
+      window.clearInterval(interval);
+      window.clearTimeout(timeout);
+    };
+  }, [isWaitingForSignIn, runtimesQuery.refetch]);
   const authMethods = getOnboardingAuthMethods(
     runtime,
     methodsQuery.data?.methods ?? [],
@@ -128,15 +145,20 @@ function RuntimeStatus({
               void methodsQuery.refetch();
               return;
             }
-            connectMutation.mutate({
-              methodId: authMethod.id,
-              runtimeId: runtime.id,
-            });
+            connectMutation.mutate(
+              {
+                methodId: authMethod.id,
+                runtimeId: runtime.id,
+              },
+              {
+                onSuccess: () => setIsWaitingForSignIn(true),
+              },
+            );
           }}
           type="button"
           variant="ghost"
         >
-          SIGN IN
+          {isWaitingForSignIn ? "CHECKING…" : "SIGN IN"}
         </Button>
         {methodsQuery.error instanceof Error ? (
           <RuntimeErrorTooltip
@@ -611,9 +633,13 @@ function SetupStepContent({
       ),
     [runtimeProviders.items],
   );
+  const readyRuntimeIdsKey = readyRuntimeIds.join("\0");
+  // The key prevents catalog object refreshes from creating an effect loop
+  // when the detected ready IDs have not changed.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed by ID content
   React.useEffect(() => {
     onReadyRuntimeIdsChange(readyRuntimeIds);
-  }, [onReadyRuntimeIdsChange, readyRuntimeIds]);
+  }, [onReadyRuntimeIdsChange, readyRuntimeIdsKey]);
 
   return (
     <OnboardingSlideTransition
@@ -633,7 +659,7 @@ function SetupStepContent({
           className={`${ONBOARDING_PRIMARY_CTA_CLASS} text-sm`}
           data-testid="onboarding-setup-next"
           disabled={readyRuntimeIds.length === 0}
-          onClick={actions.next}
+          onClick={() => actions.next(readyRuntimeIds)}
           type="button"
         >
           Next

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -1,27 +1,27 @@
 import * as React from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { AlertTriangle, Check, ExternalLink } from "lucide-react";
+import { Check } from "lucide-react";
 
 import {
   useAcpAuthMethodsQuery,
   useAcpRuntimesQuery,
   useConnectAcpRuntimeMutation,
   useInstallAcpRuntimeMutation,
-  useGitBashPrerequisiteQuery,
 } from "@/features/agents/hooks";
 import { describeResolvedCommand } from "@/features/agents/ui/agentUi";
 import type { AcpAuthMethod, AcpRuntimeCatalogEntry } from "@/shared/api/types";
 import { getInstallErrorMessage } from "@/shared/lib/installError";
 import { cn } from "@/shared/lib/cn";
-import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { Card } from "@/shared/ui/card";
 import { FlappingBee } from "@/shared/ui/buzz-logo/FlappingBee";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import {
+  ONBOARDING_RUNTIME_ORDER,
   runtimeCanAdvanceOnboarding,
   runtimeCanBeSelected,
+  runtimeIsOnboardingChoice,
 } from "./onboardingRuntimeSelection";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { RuntimeErrorTooltip } from "./RuntimeErrorTooltip";
@@ -609,62 +609,6 @@ function RuntimeCard({
   );
 }
 
-function GitBashPrerequisiteCard() {
-  const query = useGitBashPrerequisiteQuery();
-  const prerequisite = query.data;
-  if (!prerequisite) return null;
-
-  return (
-    <div
-      className={cn(
-        "mx-auto w-full max-w-[560px] rounded-2xl bg-white/75 p-3 text-left sm:p-4",
-        !prerequisite.available && "ring-1 ring-amber-500/40",
-      )}
-      data-testid="onboarding-git-bash"
-    >
-      <div className="flex items-center gap-2">
-        {prerequisite.available ? (
-          <Check className="h-4 w-4 text-primary" />
-        ) : (
-          <AlertTriangle className="h-4 w-4 text-warning" />
-        )}
-        <h2 className="text-base font-medium">Git Bash</h2>
-        {prerequisite.available ? (
-          <Badge
-            className="border border-primary/20 bg-primary/10 text-primary"
-            variant="outline"
-          >
-            Installed
-          </Badge>
-        ) : null}
-      </div>
-      {prerequisite.available ? (
-        <p className="mt-2 break-all font-mono text-xs text-muted-foreground">
-          {prerequisite.path}
-        </p>
-      ) : (
-        <>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Required for buzz-agent shell tools on Windows.
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground/80">
-            {prerequisite.installHint}
-          </p>
-          <Button
-            className="mt-3"
-            onClick={() => void openUrl(prerequisite.installInstructionsUrl)}
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            <ExternalLink className="h-4 w-4" /> Install Git for Windows
-          </Button>
-        </>
-      )}
-    </div>
-  );
-}
-
 function RuntimeProvidersLoadingState() {
   return (
     <div
@@ -703,15 +647,13 @@ function RuntimeProvidersSection({
   selectedRuntimeIds: readonly string[];
 }) {
   const { errorMessage, isChecking, items } = runtimeProviders;
-  const runtimeOrder = ["claude", "codex", "goose", "buzz-agent"];
-  const orderedItems = [...items].sort((left, right) => {
-    const leftIndex = runtimeOrder.indexOf(left.id);
-    const rightIndex = runtimeOrder.indexOf(right.id);
-    return (
-      (leftIndex === -1 ? runtimeOrder.length : leftIndex) -
-      (rightIndex === -1 ? runtimeOrder.length : rightIndex)
+  const orderedItems = items
+    .filter((runtime) => runtimeIsOnboardingChoice(runtime.id))
+    .sort(
+      (left, right) =>
+        ONBOARDING_RUNTIME_ORDER.indexOf(left.id) -
+        ONBOARDING_RUNTIME_ORDER.indexOf(right.id),
     );
-  });
   const installMutation = useInstallAcpRuntimeMutation();
   const selectedRuntimeIdSet = React.useMemo(
     () => new Set(selectedRuntimeIds),
@@ -782,9 +724,7 @@ function RuntimeProvidersSection({
       </div>
 
       <div className="flex w-full flex-1 flex-col items-center justify-center gap-8 py-10">
-        <GitBashPrerequisiteCard />
-
-        {items.length > 0 ? (
+        {orderedItems.length > 0 ? (
           <fieldset className="grid min-w-0 w-full max-w-[592px] grid-cols-1 gap-4 border-0 p-0 md:grid-cols-2">
             <legend className="sr-only">Agent harnesses</legend>
             {orderedItems.map((runtime) => (

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -2,127 +2,69 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  getDefaultModelConfigRuntimeId,
-  getPreferredRuntimeIdForSelection,
-  runtimeCanAdvanceOnboarding,
-  runtimeCanBeSelected,
-  runtimeIsOnboardingChoice,
-  runtimeSelectionNeedsDefaultModelConfig,
-  runtimeSelectionNeedsDefaultsStep,
+  getReadyOnboardingRuntimes,
+  getVisibleOnboardingRuntimes,
+  runtimeIsReadyForOnboarding,
+  runtimeIsVisibleInOnboarding,
 } from "./onboardingRuntimeSelection.ts";
 
 function runtime(id, availability, status) {
   return { id, availability, authStatus: { status } };
 }
 
-test("known onboarding harnesses can be selected regardless of setup state", () => {
-  for (const id of ["claude", "codex"]) {
-    assert.equal(
-      runtimeCanBeSelected(runtime(id, "available", "logged_in")),
-      true,
-    );
-    assert.equal(
-      runtimeCanBeSelected(runtime(id, "available", "not_applicable")),
-      true,
-    );
-    assert.equal(
-      runtimeCanBeSelected(runtime(id, "available", "logged_out")),
-      true,
-    );
-    assert.equal(
-      runtimeCanBeSelected(runtime(id, "available", "config_invalid")),
-      true,
-    );
-    assert.equal(
-      runtimeCanBeSelected(runtime(id, "available", "unknown")),
-      true,
-    );
-    assert.equal(
-      runtimeCanBeSelected(runtime(id, "not_installed", "logged_out")),
-      true,
-    );
-  }
+test("only Claude Code and Codex are visible in onboarding", () => {
+  assert.equal(runtimeIsVisibleInOnboarding("claude"), true);
+  assert.equal(runtimeIsVisibleInOnboarding("codex"), true);
+  assert.equal(runtimeIsVisibleInOnboarding("goose"), false);
+  assert.equal(runtimeIsVisibleInOnboarding("buzz-agent"), false);
+  assert.equal(runtimeIsVisibleInOnboarding("custom"), false);
 });
 
-test("Buzz, Goose, and unknown runtimes are not onboarding choices", () => {
-  for (const id of ["buzz-agent", "goose", "custom"]) {
-    assert.equal(runtimeIsOnboardingChoice(id), false);
-    assert.equal(
-      runtimeCanBeSelected(runtime(id, "available", "logged_in")),
-      false,
-    );
-  }
+test("visible onboarding runtimes use the product order", () => {
+  const runtimes = [
+    runtime("buzz-agent", "available", "not_applicable"),
+    runtime("codex", "available", "logged_in"),
+    runtime("goose", "available", "not_applicable"),
+    runtime("claude", "available", "logged_in"),
+  ];
+
+  assert.deepEqual(
+    getVisibleOnboardingRuntimes(runtimes).map(({ id }) => id),
+    ["claude", "codex"],
+  );
 });
 
-test("selected runtimes can advance only after setup is complete", () => {
+test("readiness requires an available and authenticated runtime", () => {
   assert.equal(
-    runtimeCanAdvanceOnboarding(runtime("claude", "available", "logged_in")),
+    runtimeIsReadyForOnboarding(runtime("claude", "available", "logged_in")),
     true,
   );
   assert.equal(
-    runtimeCanAdvanceOnboarding(
-      runtime("buzz-agent", "available", "not_applicable"),
+    runtimeIsReadyForOnboarding(
+      runtime("codex", "available", "not_applicable"),
     ),
     true,
   );
   assert.equal(
-    runtimeCanAdvanceOnboarding(runtime("claude", "available", "logged_out")),
+    runtimeIsReadyForOnboarding(runtime("claude", "available", "logged_out")),
     false,
   );
   assert.equal(
-    runtimeCanAdvanceOnboarding(runtime("codex", "not_installed", "unknown")),
-    false,
-  );
-  assert.equal(
-    runtimeCanAdvanceOnboarding(
-      runtime("claude", "adapter_missing", "unknown"),
-    ),
+    runtimeIsReadyForOnboarding(runtime("codex", "not_installed", "logged_in")),
     false,
   );
 });
 
-test("provider-backed selections drive the default model config step", () => {
-  assert.equal(
-    runtimeSelectionNeedsDefaultModelConfig(["claude", "codex"]),
-    false,
-  );
-  assert.equal(
-    runtimeSelectionNeedsDefaultModelConfig(["claude", "goose"]),
-    true,
-  );
-  assert.equal(
-    getDefaultModelConfigRuntimeId(["claude", "codex", "goose", "buzz-agent"]),
-    "buzz-agent",
-  );
-});
+test("ready onboarding runtimes exclude hidden ready harnesses", () => {
+  const runtimes = [
+    runtime("goose", "available", "not_applicable"),
+    runtime("codex", "available", "logged_out"),
+    runtime("buzz-agent", "available", "not_applicable"),
+    runtime("claude", "available", "logged_in"),
+  ];
 
-test("onboarding display order drives the preferred runtime", () => {
-  assert.equal(
-    getPreferredRuntimeIdForSelection([
-      "buzz-agent",
-      "goose",
-      "codex",
-      "claude",
-    ]),
-    "claude",
+  assert.deepEqual(
+    getReadyOnboardingRuntimes(runtimes).map(({ id }) => id),
+    ["claude"],
   );
-  assert.equal(
-    getPreferredRuntimeIdForSelection(["buzz-agent", "goose", "codex"]),
-    "codex",
-  );
-  assert.equal(
-    getPreferredRuntimeIdForSelection(["buzz-agent", "goose"]),
-    "goose",
-  );
-  assert.equal(getPreferredRuntimeIdForSelection(["buzz-agent"]), "buzz-agent");
-  assert.equal(getPreferredRuntimeIdForSelection(["custom"]), "custom");
-  assert.equal(getPreferredRuntimeIdForSelection([]), null);
-});
-
-test("any harness selection drives the defaults step", () => {
-  assert.equal(runtimeSelectionNeedsDefaultsStep([]), false);
-  assert.equal(runtimeSelectionNeedsDefaultsStep(["claude"]), true);
-  assert.equal(runtimeSelectionNeedsDefaultsStep(["codex"]), true);
-  assert.equal(runtimeSelectionNeedsDefaultsStep(["claude", "codex"]), true);
-  assert.equal(runtimeSelectionNeedsDefaultsStep(["goose"]), true);
 });

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -6,6 +6,7 @@ import {
   getPreferredRuntimeIdForSelection,
   runtimeCanAdvanceOnboarding,
   runtimeCanBeSelected,
+  runtimeIsOnboardingChoice,
   runtimeSelectionNeedsDefaultModelConfig,
   runtimeSelectionNeedsDefaultsStep,
 } from "./onboardingRuntimeSelection.ts";
@@ -41,24 +42,16 @@ test("known onboarding harnesses can be selected regardless of setup state", () 
       true,
     );
   }
-
-  for (const id of ["buzz-agent", "goose"]) {
-    assert.equal(
-      runtimeCanBeSelected(runtime(id, "available", "not_applicable")),
-      true,
-    );
-    assert.equal(
-      runtimeCanBeSelected(runtime(id, "not_installed", "not_applicable")),
-      true,
-    );
-  }
 });
 
-test("unknown runtimes are not onboarding choices", () => {
-  assert.equal(
-    runtimeCanBeSelected(runtime("custom", "available", "logged_in")),
-    false,
-  );
+test("Buzz, Goose, and unknown runtimes are not onboarding choices", () => {
+  for (const id of ["buzz-agent", "goose", "custom"]) {
+    assert.equal(runtimeIsOnboardingChoice(id), false);
+    assert.equal(
+      runtimeCanBeSelected(runtime(id, "available", "logged_in")),
+      false,
+    );
+  }
 });
 
 test("selected runtimes can advance only after setup is complete", () => {

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -1,13 +1,12 @@
 import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
 
-export const ONBOARDING_RUNTIME_ORDER = [
-  "claude",
-  "codex",
-  "goose",
-  "buzz-agent",
-];
+export const ONBOARDING_RUNTIME_ORDER = ["claude", "codex"];
 
 const KNOWN_ONBOARDING_RUNTIME_IDS = new Set<string>(ONBOARDING_RUNTIME_ORDER);
+
+export function runtimeIsOnboardingChoice(runtimeId: string) {
+  return KNOWN_ONBOARDING_RUNTIME_IDS.has(runtimeId);
+}
 
 export function runtimeUsesDefaultModelConfig(runtimeId: string) {
   return runtimeId === "buzz-agent" || runtimeId === "goose";
@@ -47,16 +46,7 @@ export function runtimeSelectionNeedsDefaultsStep(
 }
 
 export function runtimeCanBeSelected(runtime: AcpRuntimeCatalogEntry) {
-  if (KNOWN_ONBOARDING_RUNTIME_IDS.has(runtime.id)) return true;
-  if (runtime.availability !== "available") return false;
-  if (runtime.id === "claude" || runtime.id === "codex") {
-    return (
-      runtime.authStatus.status === "logged_in" ||
-      runtime.authStatus.status === "not_applicable" ||
-      runtime.authStatus.status === "logged_out"
-    );
-  }
-  return runtime.id === "buzz-agent" || runtime.id === "goose";
+  return runtimeIsOnboardingChoice(runtime.id);
 }
 
 export function runtimeCanAdvanceOnboarding(runtime: AcpRuntimeCatalogEntry) {

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -2,57 +2,38 @@ import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
 
 export const ONBOARDING_RUNTIME_ORDER = ["claude", "codex"];
 
-const KNOWN_ONBOARDING_RUNTIME_IDS = new Set<string>(ONBOARDING_RUNTIME_ORDER);
+const VISIBLE_ONBOARDING_RUNTIME_IDS = new Set<string>(
+  ONBOARDING_RUNTIME_ORDER,
+);
 
-export function runtimeIsOnboardingChoice(runtimeId: string) {
-  return KNOWN_ONBOARDING_RUNTIME_IDS.has(runtimeId);
+export function runtimeIsVisibleInOnboarding(runtimeId: string) {
+  return VISIBLE_ONBOARDING_RUNTIME_IDS.has(runtimeId);
 }
 
-export function runtimeUsesDefaultModelConfig(runtimeId: string) {
-  return runtimeId === "buzz-agent" || runtimeId === "goose";
-}
-
-export function getDefaultModelConfigRuntimeId(runtimeIds: readonly string[]) {
-  return (
-    runtimeIds.find((runtimeId) => runtimeId === "buzz-agent") ??
-    runtimeIds.find((runtimeId) => runtimeId === "goose") ??
-    null
-  );
-}
-
-export function getPreferredRuntimeIdForSelection(
-  runtimeIds: readonly string[],
-) {
-  const selectedRuntimeIds = new Set(runtimeIds);
-  return (
-    ONBOARDING_RUNTIME_ORDER.find((runtimeId) =>
-      selectedRuntimeIds.has(runtimeId),
-    ) ??
-    runtimeIds[0] ??
-    null
-  );
-}
-
-export function runtimeSelectionNeedsDefaultModelConfig(
-  runtimeIds: readonly string[],
-) {
-  return runtimeIds.some(runtimeUsesDefaultModelConfig);
-}
-
-export function runtimeSelectionNeedsDefaultsStep(
-  runtimeIds: readonly string[],
-) {
-  return runtimeIds.length > 0;
-}
-
-export function runtimeCanBeSelected(runtime: AcpRuntimeCatalogEntry) {
-  return runtimeIsOnboardingChoice(runtime.id);
-}
-
-export function runtimeCanAdvanceOnboarding(runtime: AcpRuntimeCatalogEntry) {
+export function runtimeIsReadyForOnboarding(runtime: AcpRuntimeCatalogEntry) {
   return (
     runtime.availability === "available" &&
     (runtime.authStatus.status === "logged_in" ||
       runtime.authStatus.status === "not_applicable")
+  );
+}
+
+export function getVisibleOnboardingRuntimes(
+  runtimes: readonly AcpRuntimeCatalogEntry[],
+) {
+  return runtimes
+    .filter((runtime) => runtimeIsVisibleInOnboarding(runtime.id))
+    .sort(
+      (left, right) =>
+        ONBOARDING_RUNTIME_ORDER.indexOf(left.id) -
+        ONBOARDING_RUNTIME_ORDER.indexOf(right.id),
+    );
+}
+
+export function getReadyOnboardingRuntimes(
+  runtimes: readonly AcpRuntimeCatalogEntry[],
+) {
+  return getVisibleOnboardingRuntimes(runtimes).filter(
+    runtimeIsReadyForOnboarding,
   );
 }

--- a/desktop/src/features/onboarding/ui/saveCoalescer.test.mjs
+++ b/desktop/src/features/onboarding/ui/saveCoalescer.test.mjs
@@ -145,6 +145,47 @@ test("saveCoalescer_isSaving_transitions_true_then_false", async () => {
   assert.deepEqual(states, [true, false]);
 });
 
+test("saveCoalescer_flush_waits_for_the_latest_pending_save", async () => {
+  const d = deferred();
+  const persisted = [];
+
+  const coalescer = createSaveCoalescer(
+    async (v) => {
+      if (v.n === 0) await d.promise;
+      persisted.push(v.n);
+      return v;
+    },
+    () => {},
+    () => {},
+  );
+
+  coalescer.enqueue({ n: 0 });
+  coalescer.enqueue({ n: 1 });
+  let flushed = false;
+  const flush = coalescer.flush().then(() => {
+    flushed = true;
+  });
+  await tick();
+  assert.equal(flushed, false);
+
+  d.resolve();
+  await flush;
+  assert.deepEqual(persisted, [0, 1]);
+});
+
+test("saveCoalescer_flush_rejects_when_the_final_save_fails", async () => {
+  const coalescer = createSaveCoalescer(
+    async () => {
+      throw new Error("save failed");
+    },
+    () => {},
+    () => {},
+  );
+
+  coalescer.enqueue({ n: 0 });
+  await assert.rejects(coalescer.flush(), /save failed/);
+});
+
 test("saveCoalescer_cancel_prevents_onSaved_and_onSaving_false", async () => {
   const d = deferred();
   const states = [];

--- a/desktop/src/features/onboarding/ui/saveCoalescer.ts
+++ b/desktop/src/features/onboarding/ui/saveCoalescer.ts
@@ -7,17 +7,36 @@
  * recent local change.
  *
  * Lifecycle: call cancel() on unmount so in-flight saves do not invoke
- * the onSaving / onSaved callbacks after the owning component is gone.
+ * callbacks after the owning component is gone. Call flush() before leaving
+ * a surface that must guarantee its latest optimistic value was persisted.
  */
 export function createSaveCoalescer<T>(
   save: (value: T) => Promise<T>,
   onSaving: (isSaving: boolean) => void,
   onSaved: (value: T) => void,
-): { enqueue: (value: T) => void; cancel: () => void } {
+): {
+  enqueue: (value: T) => void;
+  flush: () => Promise<void>;
+  cancel: () => void;
+} {
   let pending: T | undefined;
   let hasPending = false;
   let running = false;
   let cancelled = false;
+  let finalError: unknown;
+  let flushWaiters: Array<{
+    resolve: () => void;
+    reject: (error: unknown) => void;
+  }> = [];
+
+  function settleFlushWaiters() {
+    const waiters = flushWaiters;
+    flushWaiters = [];
+    for (const waiter of waiters) {
+      if (finalError === undefined) waiter.resolve();
+      else waiter.reject(finalError);
+    }
+  }
 
   async function drain() {
     while (hasPending) {
@@ -26,17 +45,21 @@ export function createSaveCoalescer<T>(
       pending = undefined;
       try {
         const saved = await save(toSave);
+        finalError = undefined;
         // Apply backend response only when no newer local edit is pending —
         // a stale response must never overwrite fresher optimistic state.
         if (!cancelled && !hasPending) {
           onSaved(saved);
         }
-      } catch {
-        // Non-fatal — optimistic local state is retained; user can retry.
+      } catch (error) {
+        finalError = error;
       }
     }
     running = false;
-    if (!cancelled) onSaving(false);
+    if (!cancelled) {
+      onSaving(false);
+      settleFlushWaiters();
+    }
   }
 
   return {
@@ -45,13 +68,29 @@ export function createSaveCoalescer<T>(
       hasPending = true;
       if (running) return;
       running = true;
+      finalError = undefined;
       onSaving(true);
       void drain();
+    },
+    flush() {
+      if (!running) {
+        return finalError === undefined
+          ? Promise.resolve()
+          : Promise.reject(finalError);
+      }
+      return new Promise<void>((resolve, reject) => {
+        flushWaiters.push({ resolve, reject });
+      });
     },
     cancel() {
       cancelled = true;
       hasPending = false;
       pending = undefined;
+      const waiters = flushWaiters;
+      flushWaiters = [];
+      for (const waiter of waiters) {
+        waiter.reject(new Error("Save cancelled"));
+      }
     },
   };
 }

--- a/desktop/src/features/onboarding/ui/types.ts
+++ b/desktop/src/features/onboarding/ui/types.ts
@@ -58,7 +58,7 @@ export type ProfileStepActions = {
 
 export type SetupStepActions = {
   back: () => void;
-  next: () => void;
+  next: (readyRuntimeIds: readonly string[]) => void;
 };
 
 export type DefaultConfigStepActions = {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -158,6 +158,12 @@ type E2eConfig = {
       archived_at?: string | null;
     };
     acpRuntimesCatalog?: RawAcpRuntimeCatalogEntry[];
+    /** Catalog returned after a successful mocked install. */
+    acpRuntimesCatalogAfterInstall?: RawAcpRuntimeCatalogEntry[];
+    /** Catalog responses after install for testing later sign-in completion. */
+    acpRuntimesCatalogAfterInstallSequence?: RawAcpRuntimeCatalogEntry[][];
+    /** Catalog responses for successive discovery calls. The final response repeats. */
+    acpRuntimesCatalogSequence?: RawAcpRuntimeCatalogEntry[][];
     acpRuntimesDelayMs?: number;
     acpAuthMethods?: Record<string, RawAcpAuthMethodsResult>;
     acpAuthMethodsErrors?: Record<string, string>;
@@ -6785,6 +6791,9 @@ function withMockRuntimeConfigMetadata(
   };
 }
 
+let runtimeCatalogDiscoveryCount = 0;
+let mockInstallCompleted = false;
+
 async function handleDiscoverAcpRuntimes(
   config: E2eConfig | undefined,
 ): Promise<RawAcpRuntimeCatalogEntry[]> {
@@ -6795,6 +6804,26 @@ async function handleDiscoverAcpRuntimes(
     });
   }
 
+  const afterInstallSequence =
+    config?.mock?.acpRuntimesCatalogAfterInstallSequence;
+  if (mockInstallCompleted && afterInstallSequence?.length) {
+    const index = Math.min(
+      runtimeCatalogDiscoveryCount,
+      afterInstallSequence.length - 1,
+    );
+    runtimeCatalogDiscoveryCount += 1;
+    return afterInstallSequence[index].map(withMockRuntimeConfigMetadata);
+  }
+  const afterInstall = config?.mock?.acpRuntimesCatalogAfterInstall;
+  if (mockInstallCompleted && afterInstall) {
+    return afterInstall.map(withMockRuntimeConfigMetadata);
+  }
+  const sequence = config?.mock?.acpRuntimesCatalogSequence;
+  if (sequence && sequence.length > 0) {
+    const index = Math.min(runtimeCatalogDiscoveryCount, sequence.length - 1);
+    runtimeCatalogDiscoveryCount += 1;
+    return sequence[index].map(withMockRuntimeConfigMetadata);
+  }
   const configured = config?.mock?.acpRuntimesCatalog;
   if (configured) {
     return configured.map(withMockRuntimeConfigMetadata);
@@ -6940,12 +6969,16 @@ async function handleInstallAcpRuntime(
   if (sequence && sequence.length > 0) {
     const idx = Math.min(installCallCount, sequence.length - 1);
     installCallCount++;
-    return sequence[idx];
+    const result = sequence[idx];
+    if (result.success) mockInstallCompleted = true;
+    return result;
   }
   const configured = config?.mock?.installAcpRuntimeResult;
   if (configured) {
+    if (configured.success) mockInstallCompleted = true;
     return configured;
   }
+  mockInstallCompleted = true;
   return {
     success: true,
     steps: [

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -1,15 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { installMockBridge } from "../helpers/bridge";
-import { waitForAnimations } from "../helpers/animations";
 import { passThroughBackupStep } from "../helpers/onboarding";
 
-const SHOTS = "test-results/screenshots-onboarding";
-
-function availableRuntime(
+function runtime(
   id: "buzz-agent" | "claude" | "codex" | "goose",
-  authStatus:
-    | { status: "config_invalid"; diagnostic: string }
-    | { status: "logged_in" | "logged_out" | "not_applicable" | "unknown" },
+  availability: string,
+  authStatus: Record<string, unknown>,
   overrides: Record<string, unknown> = {},
 ) {
   return {
@@ -18,19 +14,19 @@ function availableRuntime(
       id === "buzz-agent"
         ? "Buzz Agent"
         : id === "claude"
-          ? "Claude"
+          ? "Claude Code"
           : id === "codex"
             ? "Codex"
             : "Goose",
     avatar_url: "",
-    availability: "available",
-    command: id,
-    binary_path: `/usr/local/bin/${id}`,
+    availability,
+    command: availability === "available" ? id : null,
+    binary_path: availability === "available" ? `/usr/local/bin/${id}` : null,
     default_args: [],
     mcp_command: null,
-    install_hint: "",
+    install_hint: `Install ${id}`,
     install_instructions_url: "https://example.com",
-    can_auto_install: false,
+    can_auto_install: true,
     underlying_cli_path: null,
     node_required: false,
     auth_status: authStatus,
@@ -39,7 +35,6 @@ function availableRuntime(
   };
 }
 
-/** Drive to the harness setup page (page 3) via the full onboarding flow. */
 async function navigateToSetupPage(
   page: Parameters<typeof installMockBridge>[0],
 ) {
@@ -48,154 +43,91 @@ async function navigateToSetupPage(
   await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
 }
 
-/** Drive to the default config page (page 4), past the harness page. */
-async function navigateToConfigPage(
-  page: Parameters<typeof installMockBridge>[0],
-) {
-  await navigateToSetupPage(page);
-  await page.getByTestId("onboarding-runtime-buzz-agent").click();
-  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
-  await page.getByTestId("onboarding-setup-next").click();
-  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-}
-
-async function chooseConfigDropdownOption(
-  page: Parameters<typeof installMockBridge>[0],
-  triggerTestId: string,
-  value: string,
-) {
-  await page.getByTestId(triggerTestId).click();
-  await page.getByTestId(`${triggerTestId}-option-${value || "empty"}`).click();
-}
-
-async function readSavedConfig(page: Parameters<typeof installMockBridge>[0]) {
-  return await page.evaluate(() =>
-    (
+async function readSavedRuntime(page: Parameters<typeof installMockBridge>[0]) {
+  return await page.evaluate(async () => {
+    const result = await (
       window as Window & {
         __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
           command: string,
           payload: unknown,
-        ) => Promise<{
-          model?: string | null;
-          preferred_runtime?: string | null;
-        }>;
+        ) => Promise<{ preferred_runtime?: string | null }>;
       }
-    ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("get_global_agent_config", null),
-  );
+    ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("get_global_agent_config", null);
+    return result?.preferred_runtime ?? null;
+  });
 }
 
-async function readSavedRuntime(page: Parameters<typeof installMockBridge>[0]) {
-  const savedConfig = await readSavedConfig(page);
-  return savedConfig?.preferred_runtime ?? null;
-}
-
-test("requires a runtime selection and routes Buzz Agent to config", async ({
+test("setup shows only Claude Code and Codex as detected harnesses", async ({
   page,
 }) => {
   await installMockBridge(
     page,
     {
       acpRuntimesCatalog: [
-        availableRuntime("buzz-agent", { status: "not_applicable" }),
+        runtime("buzz-agent", "available", { status: "not_applicable" }),
+        runtime("goose", "available", { status: "not_applicable" }),
+        runtime("codex", "available", { status: "logged_in" }),
+        runtime("claude", "available", { status: "logged_in" }),
       ],
-      setGlobalAgentConfigDelayMs: 200,
     },
     { skipCommunitySeed: true, skipOnboardingSeed: true },
   );
   await page.goto("/");
   await navigateToSetupPage(page);
 
-  const next = page.getByTestId("onboarding-setup-next");
-  const card = page.getByTestId("onboarding-runtime-buzz-agent");
-  await expect(next).toBeDisabled();
-  await expect(card.getByText("Preferred")).toHaveCount(0);
-
-  await card.click();
-  await expect(next).toHaveText("Next");
-  await expect(card).toHaveAttribute("aria-checked", "true");
-  await expect(next).toBeEnabled();
-  await next.click();
-  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-  expect(await readSavedRuntime(page)).toBe("buzz-agent");
+  await expect(page.getByTestId("onboarding-runtime-claude")).toBeVisible();
+  await expect(page.getByTestId("onboarding-runtime-codex")).toBeVisible();
+  await expect(page.getByTestId("onboarding-runtime-goose")).toHaveCount(0);
+  await expect(page.getByTestId("onboarding-runtime-buzz-agent")).toHaveCount(
+    0,
+  );
+  await expect(page.getByRole("checkbox")).toHaveCount(0);
 });
 
-test("rapid harness toggles serialize the prioritized preferred runtime", async ({
+test("ready state is detected, checked, and enables Next without persisting a default", async ({
   page,
 }) => {
   await installMockBridge(
     page,
     {
       acpRuntimesCatalog: [
-        availableRuntime("goose", { status: "not_applicable" }),
-        availableRuntime("buzz-agent", { status: "not_applicable" }),
+        runtime("claude", "available", { status: "logged_in" }),
+        runtime("codex", "available", { status: "logged_out" }),
       ],
-      setGlobalAgentConfigDelayMs: 200,
     },
     { skipCommunitySeed: true, skipOnboardingSeed: true },
   );
   await page.goto("/");
   await navigateToSetupPage(page);
 
-  await page.getByTestId("onboarding-runtime-goose").click();
-  await page.getByTestId("onboarding-runtime-buzz-agent").click();
-  const next = page.getByTestId("onboarding-setup-next");
-  await expect(next).toBeDisabled();
-  await page.waitForTimeout(300);
-  await expect(next).toBeDisabled();
-  await expect(next).toBeEnabled({ timeout: 700 });
-  expect(await readSavedRuntime(page)).toBe("goose");
-});
-
-test("authenticated Claude saves the selected runtime and routes to defaults", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [availableRuntime("claude", { status: "logged_in" })],
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  await expect(page.getByTestId("onboarding-runtime-ready-claude")).toHaveText(
+    "READY",
   );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  await page.getByTestId("onboarding-runtime-claude").click();
-  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
-  await page.getByTestId("onboarding-setup-next").click();
-  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
-    "Claude",
-  );
-  // Claude Code effort is real, but it is exposed as a Claude ACP-native
-  // config option, not Buzz Agent's generic effort env var. Hide the generic
-  // control until the config core can render that native option.
   await expect(
-    page.getByTestId("global-agent-thinking-effort-select"),
+    page.getByTestId("onboarding-runtime-checkmark-claude"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("onboarding-runtime-checkmark-codex"),
   ).toHaveCount(0);
-  expect(await readSavedRuntime(page)).toBe("claude");
+  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
+  expect(await readSavedRuntime(page)).toBeNull();
 });
 
-test("successful Claude sign-in selects the card without extra status copy", async ({
+test("sign in stays pending until catalog detection confirms Ready", async ({
   page,
 }) => {
+  const loggedOut = runtime("claude", "available", { status: "logged_out" });
+  const loggedIn = runtime("claude", "available", { status: "logged_in" });
   await installMockBridge(
     page,
     {
-      acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_out" }),
-      ],
+      acpRuntimesCatalogSequence: [[loggedOut], [loggedOut], [loggedIn]],
       acpAuthMethods: {
         claude: {
           methods: [
             {
-              id: "claude-subscription",
-              name: "Claude Subscription",
-              description: null,
-              type: "terminal",
-            },
-            {
-              id: "anthropic-console",
-              name: "Anthropic Console",
+              id: "subscription",
+              name: "Claude.ai subscription",
               description: null,
               type: "terminal",
             },
@@ -207,53 +139,40 @@ test("successful Claude sign-in selects the card without extra status copy", asy
   );
   await page.goto("/");
   await navigateToSetupPage(page);
-  await waitForAnimations(page);
 
-  const card = page.getByTestId("onboarding-runtime-claude");
-  await expect(
-    card.getByRole("button", { name: "Claude Subscription" }),
-  ).toHaveCount(0);
-  await expect(
-    card.getByRole("button", { name: "Anthropic Console" }),
-  ).toHaveCount(0);
-  await expect(
-    card.getByRole("button", { name: "Log in to Claude" }),
-  ).toHaveCount(0);
-  await expect(
-    card.getByTestId("onboarding-runtime-instructions-claude"),
-  ).toBeVisible();
-  await card.getByTestId("onboarding-runtime-instructions-claude").click();
-
-  await expect(card).toHaveAttribute("aria-checked", "true");
-  await expect(card.getByText("Preferred")).toHaveCount(0);
-  await expect(
-    page.getByTestId("onboarding-runtime-checkmark-claude"),
-  ).toHaveCSS("opacity", "1");
+  const signIn = page.getByRole("button", { name: "Sign in to Claude Code" });
+  await expect(signIn).toHaveText("SIGN IN");
+  await expect(page.getByTestId("onboarding-setup-next")).toBeDisabled();
+  await signIn.click();
+  await expect(signIn).toHaveText("CHECKING…");
+  await expect(page.getByTestId("onboarding-setup-next")).toBeDisabled();
+  await expect(page.getByTestId("onboarding-runtime-ready-claude")).toHaveText(
+    "READY",
+    { timeout: 5_000 },
+  );
   await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
-  expect(await readSavedRuntime(page)).toBe("claude");
 });
 
-test("successful Codex sign-in hides API key auth and selects the card", async ({
-  page,
-}) => {
+test("install transitions through Sign in to Ready", async ({ page }) => {
+  const notInstalled = runtime("claude", "adapter_missing", {
+    status: "unknown",
+  });
+  const loggedOut = runtime("claude", "available", { status: "logged_out" });
+  const loggedIn = runtime("claude", "available", { status: "logged_in" });
   await installMockBridge(
     page,
     {
-      acpRuntimesCatalog: [availableRuntime("codex", { status: "logged_out" })],
+      acpRuntimesCatalog: [notInstalled],
+      acpRuntimesCatalogAfterInstallSequence: [[loggedOut], [loggedIn]],
+      installAcpRuntimeDelayMs: 500,
       acpAuthMethods: {
-        codex: {
+        claude: {
           methods: [
             {
-              id: "api-key",
-              name: "Use API key",
+              id: "subscription",
+              name: "Claude.ai subscription",
               description: null,
-              type: "input",
-            },
-            {
-              id: "chat-gpt",
-              name: "Sign in with ChatGPT",
-              description: null,
-              type: "browser",
+              type: "terminal",
             },
           ],
         },
@@ -263,340 +182,54 @@ test("successful Codex sign-in hides API key auth and selects the card", async (
   );
   await page.goto("/");
   await navigateToSetupPage(page);
-  await waitForAnimations(page);
 
-  const card = page.getByTestId("onboarding-runtime-codex");
-  await expect(card.getByRole("button", { name: "Use API key" })).toHaveCount(
-    0,
+  const install = page.getByTestId("onboarding-runtime-install-claude");
+  await expect(install).toHaveText("INSTALL");
+  await install.click();
+
+  const signIn = page.getByRole("button", { name: "Sign in to Claude Code" });
+  await expect(signIn).toHaveText("SIGN IN");
+  await expect(page.getByTestId("onboarding-setup-next")).toBeDisabled();
+  await signIn.click();
+  await expect(page.getByTestId("onboarding-runtime-ready-claude")).toHaveText(
+    "READY",
+    { timeout: 5_000 },
   );
   await expect(
-    card.getByRole("button", { name: "Sign in with ChatGPT" }),
-  ).toHaveCount(0);
-
-  await expect(card.getByRole("button", { name: "Log in" })).toHaveCount(0);
-  await expect(
-    card.getByTestId("onboarding-runtime-instructions-codex"),
-  ).toBeVisible();
-  await card.getByTestId("onboarding-runtime-instructions-codex").click();
-  await expect(card).toHaveAttribute("aria-checked", "true");
-  await expect(card.getByText("Preferred")).toHaveCount(0);
-  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
-  expect(await readSavedRuntime(page)).toBe("codex");
-});
-
-test("setup-needed runtimes remain selectable", async ({ page }) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_out" }),
-        availableRuntime("codex", { status: "logged_out" }),
-      ],
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  await expect(page.getByTestId("onboarding-runtime-claude")).toHaveAttribute(
-    "aria-disabled",
-    "false",
-  );
-  await expect(page.getByTestId("onboarding-runtime-codex")).toHaveAttribute(
-    "aria-disabled",
-    "false",
-  );
-  await page.getByTestId("onboarding-runtime-claude").click();
-  await expect(page.getByTestId("onboarding-runtime-claude")).toHaveAttribute(
-    "aria-checked",
-    "true",
-  );
-  await page.getByTestId("onboarding-runtime-codex").click();
-  await expect(page.getByTestId("onboarding-runtime-codex")).toHaveAttribute(
-    "aria-checked",
-    "true",
-  );
-});
-
-test("Next flashes selected setup-needed runtimes instead of advancing", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_out" }),
-        availableRuntime("buzz-agent", { status: "not_applicable" }),
-      ],
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  const next = page.getByTestId("onboarding-setup-next");
-  const claudeCard = page.getByTestId("onboarding-runtime-claude");
-  const buzzCard = page.getByTestId("onboarding-runtime-buzz-agent");
-  const claudeSetup = claudeCard.getByTestId(
-    "onboarding-runtime-instructions-claude",
-  );
-
-  await claudeCard.click();
-  await buzzCard.click();
-  await expect(claudeCard).toHaveAttribute("aria-checked", "true");
-  await expect(buzzCard).toHaveAttribute("aria-checked", "true");
-  await expect(next).toHaveAttribute("data-soft-disabled", "true");
-  await expect(next).toBeEnabled();
-  await expect(page.getByTestId("onboarding-setup-next-hint")).toHaveCount(0);
-  await expect(next).toHaveCSS("cursor", "default");
-
-  await next.click();
-  await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
-  await expect(page.getByTestId("onboarding-page-config")).toHaveCount(0);
-  await expect(page.getByTestId("onboarding-setup-next-hint")).toHaveText(
-    "Please finish set up",
-  );
-  await expect(claudeSetup).toHaveAttribute("data-setup-flash", "true");
-  await expect(
-    page.getByTestId("onboarding-runtime-installed-buzz-agent"),
-  ).not.toHaveAttribute("data-setup-flash", "true");
-});
-
-test("logged-out CLI runtimes can be selected and keep setup visible", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_out" }),
-        availableRuntime("codex", { status: "logged_out" }),
-      ],
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  for (const runtimeId of ["claude", "codex"]) {
-    const card = page.getByTestId(`onboarding-runtime-${runtimeId}`);
-    await expect(
-      card.getByTestId(`onboarding-runtime-instructions-${runtimeId}`),
-    ).toBeVisible();
-    await expect(
-      page.getByTestId(`onboarding-runtime-installed-${runtimeId}`),
-    ).toHaveCount(0);
-
-    await card.click();
-    await expect(card).toHaveAttribute("aria-checked", "true");
-    await expect(
-      card.getByTestId(`onboarding-runtime-instructions-${runtimeId}`),
-    ).toBeVisible();
-    await expect(
-      page.getByTestId(`onboarding-runtime-installed-${runtimeId}`),
-    ).toHaveCount(0);
-  }
-});
-
-test("runtime cards use the selected onboarding order", async ({ page }) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("buzz-agent", { status: "not_applicable" }),
-        availableRuntime("goose", { status: "not_applicable" }),
-        availableRuntime("codex", { status: "logged_in" }),
-        availableRuntime("claude", { status: "logged_in" }),
-      ],
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  const runtimeOrder = await page
-    .getByRole("checkbox")
-    .evaluateAll((cards) =>
-      cards.map((card) => card.getAttribute("data-testid")),
-    );
-  expect(runtimeOrder).toEqual([
-    "onboarding-runtime-claude",
-    "onboarding-runtime-codex",
-    "onboarding-runtime-goose",
-    "onboarding-runtime-buzz-agent",
-  ]);
-  await expect(
-    page.getByTestId("onboarding-runtime-buzz-agent").getByRole("heading", {
-      name: "Buzz",
-    }),
+    page.getByTestId("onboarding-runtime-checkmark-claude"),
   ).toBeVisible();
 });
 
-test("runtime cards allow multiple harness selections", async ({ page }) => {
-  await installMockBridge(page, undefined, {
-    skipCommunitySeed: true,
-    skipOnboardingSeed: true,
-  });
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  const next = page.getByTestId("onboarding-setup-next");
-  const gooseCard = page.getByTestId("onboarding-runtime-goose");
-  const buzzCard = page.getByTestId("onboarding-runtime-buzz-agent");
-
-  await expect(next).toBeDisabled();
-
-  await gooseCard.click();
-  await expect(gooseCard).toHaveAttribute("aria-checked", "true");
-  await expect(next).toBeEnabled();
-
-  await buzzCard.click();
-  await expect(gooseCard).toHaveAttribute("aria-checked", "true");
-  await expect(buzzCard).toHaveAttribute("aria-checked", "true");
-  await expect(next).toBeEnabled();
-
-  await gooseCard.click();
-  await expect(gooseCard).toHaveAttribute("aria-checked", "false");
-  await expect(buzzCard).toHaveAttribute("aria-checked", "true");
-  await expect(next).toBeEnabled();
-  expect(await readSavedRuntime(page)).toBe("buzz-agent");
-});
-
-test("multiple CLI harnesses route to default harness selection", async ({
+test("defaults includes every ready visible harness and persists the user's choice there", async ({
   page,
 }) => {
   await installMockBridge(
     page,
     {
       acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_in" }),
-        availableRuntime("codex", { status: "logged_in" }),
-      ],
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  await page.getByTestId("onboarding-runtime-claude").click();
-  await page.getByTestId("onboarding-runtime-codex").click();
-  await page.getByTestId("onboarding-setup-next").click();
-
-  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
-    "Claude",
-  );
-  await chooseConfigDropdownOption(
-    page,
-    "global-agent-default-harness",
-    "codex",
-  );
-  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
-    "Codex",
-  );
-  await expect.poll(() => readSavedRuntime(page)).toBe("codex");
-  await expect(page.getByTestId("global-agent-provider")).toHaveCount(0);
-  const modelSelect = page.getByTestId("global-agent-model");
-  await expect(modelSelect).toBeVisible();
-  // Codex model ids can encode effort (for example, `gpt-5.5[low]`). Until the
-  // config core models Codex-native options directly, don't show Buzz Agent's
-  // generic effort field beside Codex's model catalog.
-  await expect(
-    page.getByTestId("global-agent-thinking-effort-select"),
-  ).toHaveCount(0);
-  await expect(modelSelect).toHaveText("Default model (gpt-5.5[high])");
-  await modelSelect.click();
-  await expect(
-    page.getByTestId("global-agent-model-option-gpt-5.5[low]"),
-  ).toBeVisible();
-  await page.keyboard.press("Escape");
-});
-
-test("changing setup-page harness clears an incompatible saved model", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_in" }),
-        availableRuntime("codex", { status: "logged_in" }),
-      ],
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  await page.getByTestId("onboarding-runtime-codex").click();
-  await page.getByTestId("onboarding-setup-next").click();
-  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-
-  await chooseConfigDropdownOption(page, "global-agent-model", "gpt-5.5[low]");
-  await expect(page.getByTestId("global-agent-model")).toHaveText(
-    "gpt-5.5[low]",
-  );
-
-  await page.getByTestId("onboarding-back").click();
-  await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
-  await page.getByTestId("onboarding-runtime-codex").click();
-  await page.getByTestId("onboarding-runtime-claude").click();
-  await page.getByTestId("onboarding-setup-next").click();
-  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-
-  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
-    "Claude",
-  );
-  await expect(page.getByTestId("global-agent-model")).not.toHaveText(
-    "Custom model...",
-  );
-  await expect(page.getByLabel("Custom model ID")).toHaveCount(0);
-  await expect
-    .poll(async () => (await readSavedConfig(page))?.model)
-    .toBeNull();
-  await expect.poll(() => readSavedRuntime(page)).toBe("claude");
-});
-
-test("selecting all harnesses prioritizes Claude for defaults", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_in" }),
-        availableRuntime("codex", { status: "logged_in" }),
-        availableRuntime("goose", { status: "not_applicable" }),
-        availableRuntime("buzz-agent", { status: "not_applicable" }),
+        runtime("buzz-agent", "available", { status: "not_applicable" }),
+        runtime("goose", "available", { status: "not_applicable" }),
+        runtime("claude", "available", { status: "logged_in" }),
+        runtime("codex", "available", { status: "logged_in" }),
       ],
       globalAgentConfig: {
-        env_vars: {
-          OPENAI_COMPAT_API_KEY: "sk-test",
-        },
+        env_vars: {},
         provider: null,
         model: null,
+        preferred_runtime: null,
       },
     },
     { skipCommunitySeed: true, skipOnboardingSeed: true },
   );
   await page.goto("/");
   await navigateToSetupPage(page);
-
-  for (const runtimeId of ["claude", "codex", "goose", "buzz-agent"]) {
-    await page.getByTestId(`onboarding-runtime-${runtimeId}`).click();
-    await expect(
-      page.getByTestId(`onboarding-runtime-${runtimeId}`),
-    ).toHaveAttribute("aria-checked", "true");
-  }
-
-  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
   await page.getByTestId("onboarding-setup-next").click();
   await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-  expect(await readSavedRuntime(page)).toBe("claude");
 
-  const harnessSelect = page.getByTestId("global-agent-default-harness");
-  await expect(harnessSelect).toHaveText("Claude");
-  await harnessSelect.click();
+  const harness = page.getByTestId("global-agent-default-harness");
+  await expect(harness).toHaveText("Select a harness");
+  await expect(page.getByTestId("onboarding-finish")).toBeDisabled();
+  await harness.click();
   await expect(
     page.getByTestId("global-agent-default-harness-option-claude"),
   ).toBeVisible();
@@ -605,888 +238,12 @@ test("selecting all harnesses prioritizes Claude for defaults", async ({
   ).toBeVisible();
   await expect(
     page.getByTestId("global-agent-default-harness-option-goose"),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(
     page.getByTestId("global-agent-default-harness-option-buzz-agent"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-default-harness-option-codex"),
-  ).toHaveCSS("opacity", "1");
+  ).toHaveCount(0);
   await page.getByTestId("global-agent-default-harness-option-codex").click();
-  await expect(harnessSelect).toHaveAttribute("data-value", "codex");
+  await expect(harness).toHaveText("Codex");
+  await expect(page.getByTestId("onboarding-finish")).toBeEnabled();
   await expect.poll(() => readSavedRuntime(page)).toBe("codex");
-  await expect(page.getByTestId("global-agent-provider")).toHaveCount(0);
-  await expect(page.getByTestId("global-agent-model")).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-thinking-effort-select"),
-  ).toHaveCount(0);
-
-  await chooseConfigDropdownOption(
-    page,
-    "global-agent-default-harness",
-    "goose",
-  );
-  await expect(harnessSelect).toHaveAttribute("data-value", "goose");
-  await chooseConfigDropdownOption(page, "global-agent-provider", "openai");
-  await expect(page.getByTestId("global-agent-model")).toHaveAttribute(
-    "data-value",
-    "gpt-5.5",
-  );
-  await page.getByTestId("global-agent-model").click();
-  await expect(page.getByTestId("global-agent-model-option-gpt-5.5")).toHaveCSS(
-    "color",
-    "rgb(0, 0, 0)",
-  );
-  await expect(page.getByTestId("global-agent-model-option-gpt-5.5")).toHaveCSS(
-    "opacity",
-    "1",
-  );
-  await page.keyboard.press("Escape");
-
-  await chooseConfigDropdownOption(
-    page,
-    "global-agent-default-harness",
-    "buzz-agent",
-  );
-  await chooseConfigDropdownOption(page, "global-agent-provider", "openai");
-  await expect(page.getByTestId("global-agent-model")).toHaveAttribute(
-    "data-value",
-    "gpt-5.5",
-  );
-});
-
-for (const authStatus of [
-  { status: "logged_out" as const },
-  { status: "unknown" as const },
-  { status: "config_invalid" as const, diagnostic: "Fix Claude config" },
-]) {
-  test(`Claude ${authStatus.status} state can be selected before setup`, async ({
-    page,
-  }) => {
-    await installMockBridge(
-      page,
-      {
-        acpRuntimesCatalog: [availableRuntime("claude", authStatus)],
-        acpAuthMethods: {
-          claude: {
-            methods: [
-              {
-                id: "login",
-                name: "Sign in",
-                description: null,
-                type: "terminal",
-              },
-            ],
-          },
-        },
-      },
-      { skipCommunitySeed: true, skipOnboardingSeed: true },
-    );
-    await page.goto("/");
-    await navigateToSetupPage(page);
-
-    const card = page.getByTestId("onboarding-runtime-claude");
-    await expect(card).toHaveAttribute("aria-disabled", "false");
-    const setupButton = card.getByTestId(
-      "onboarding-runtime-instructions-claude",
-    );
-    if (authStatus.status === "logged_out") {
-      await expect(setupButton).toBeVisible();
-      await expect(
-        card.getByRole("button", { name: "Log in to Claude" }),
-      ).toHaveCount(0);
-      await setupButton.click();
-      await expect(card).toHaveAttribute("aria-checked", "true");
-    } else if (authStatus.status === "unknown") {
-      const error = card.getByRole("status", {
-        name: /Status unavailable/,
-      });
-      await expect(error).toBeVisible();
-      await expect(error).toHaveCSS("font-size", "12px");
-      await expect(error).toHaveCSS("position", "absolute");
-      await error.hover();
-      await expect(page.getByRole("tooltip")).toHaveText(
-        "Couldn’t verify authentication.",
-      );
-      await expect(
-        card.getByRole("button", { name: "Check Claude again" }),
-      ).toHaveText("CHECK AGAIN");
-      await card.click();
-      await expect(card).toHaveAttribute("aria-checked", "true");
-    } else {
-      const error = card.getByRole("status", {
-        name: /Configuration invalid/,
-      });
-      await expect(error).toBeVisible();
-      await expect(error).toHaveCSS("font-size", "12px");
-      await expect(error).toHaveCSS("position", "absolute");
-      await error.hover();
-      await expect(page.getByRole("tooltip")).toHaveText(
-        "Check this runtime’s configuration and try again.",
-      );
-      await expect(page.getByRole("tooltip")).not.toContainText(
-        "Fix Claude config",
-      );
-      await card.click();
-      await expect(card).toHaveAttribute("aria-checked", "true");
-    }
-  });
-}
-
-test("setup cards only show checks after user selection", async ({ page }) => {
-  await installMockBridge(page, undefined, {
-    skipCommunitySeed: true,
-    skipOnboardingSeed: true,
-  });
-  await page.goto("/");
-
-  await navigateToSetupPage(page);
-
-  const gooseCard = page.getByTestId("onboarding-runtime-goose");
-  const gooseCheck = page.getByTestId("onboarding-runtime-check-goose");
-  const gooseCheckmark = page.getByTestId("onboarding-runtime-checkmark-goose");
-
-  await expect(gooseCard).toHaveAttribute("aria-checked", "false");
-  await expect(gooseCheckmark).toHaveCSS("opacity", "0");
-  await expect(gooseCheck).toHaveCSS("opacity", "0");
-
-  await gooseCard.hover();
-  await expect(gooseCheck).toHaveCSS("opacity", "1");
-  await expect(gooseCheckmark).toHaveCSS("opacity", "0");
-
-  await gooseCard.click();
-  await expect(gooseCard).toHaveAttribute("aria-checked", "true");
-  await expect(gooseCheckmark).toHaveCSS("opacity", "1");
-  await expect(
-    page.getByTestId("onboarding-runtime-installed-goose"),
-  ).toHaveText("INSTALLED");
-});
-
-test("unavailable sign-in options use the compact error and tooltip pattern", async ({
-  page,
-}) => {
-  const discoveryError = "Auth discovery failed with sensitive details";
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_out" }),
-      ],
-      acpAuthMethodsError: discoveryError,
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  const card = page.getByTestId("onboarding-runtime-claude");
-  const setupButton = card.getByTestId(
-    "onboarding-runtime-instructions-claude",
-  );
-  const error = card.getByRole("status", { name: /Sign-in unavailable/ });
-  await expect(error).toBeVisible();
-  await expect(error).toHaveCSS("font-size", "12px");
-  await expect(error).toHaveCSS("position", "absolute");
-  await expect(error).toHaveCSS("white-space", "nowrap");
-  await expect(error).not.toHaveAttribute("title");
-  await error.hover();
-  await expect(page.getByRole("tooltip")).toHaveText(
-    "Couldn’t load sign-in options.",
-  );
-  await expect(page.getByRole("tooltip")).not.toContainText(discoveryError);
-  await expect(setupButton).toBeVisible();
-  await expect(setupButton).toHaveText("SET UP");
-});
-
-test("failed sign-in uses the compact error and tooltip pattern", async ({
-  page,
-}) => {
-  const connectionError = "Terminal launch failed with sensitive details";
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("claude", { status: "logged_out" }),
-      ],
-      acpAuthMethods: {
-        claude: {
-          methods: [
-            {
-              id: "login",
-              name: "Sign in",
-              description: null,
-              type: "terminal",
-            },
-          ],
-        },
-      },
-      connectAcpRuntimeError: connectionError,
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  const card = page.getByTestId("onboarding-runtime-claude");
-  const setupButton = card.getByTestId(
-    "onboarding-runtime-instructions-claude",
-  );
-  const heading = card.getByRole("heading", { name: "Claude" });
-  const headingTopBefore = await heading.evaluate(
-    (element) => element.getBoundingClientRect().top,
-  );
-  const setupTopBefore = await setupButton.evaluate(
-    (element) => element.getBoundingClientRect().top,
-  );
-
-  await setupButton.click();
-
-  const error = card.getByRole("status", { name: /Sign-in failed/ });
-  await expect(error).toBeVisible();
-  await expect(error).toHaveCSS("font-size", "12px");
-  await expect(error).toHaveCSS("position", "absolute");
-  await expect(error).toHaveCSS("white-space", "nowrap");
-  await expect(error).not.toHaveAttribute("title");
-  await error.hover();
-  await expect(page.getByRole("tooltip")).toHaveText(
-    "Couldn’t start sign-in. Try again.",
-  );
-  await expect(page.getByRole("tooltip")).not.toContainText(connectionError);
-  await page.keyboard.press("Escape");
-  await expect(page.getByRole("tooltip")).toBeHidden();
-  await error.focus();
-  const tooltip = page.getByRole("tooltip");
-  await expect(tooltip).toHaveText("Couldn’t start sign-in. Try again.");
-  await expect(error).toHaveAccessibleName(
-    "Sign-in failed. Couldn’t start sign-in. Try again.",
-  );
-  const [cardBox, setupBox, tooltipBox] = await Promise.all([
-    card.boundingBox(),
-    setupButton.boundingBox(),
-    tooltip.boundingBox(),
-  ]);
-  expect(cardBox).not.toBeNull();
-  expect(setupBox).not.toBeNull();
-  expect(tooltipBox).not.toBeNull();
-  expect(tooltipBox?.y).toBeGreaterThanOrEqual(
-    (cardBox?.y ?? 0) + (cardBox?.height ?? 0),
-  );
-  expect(tooltipBox?.y).toBeGreaterThanOrEqual(
-    (setupBox?.y ?? 0) + (setupBox?.height ?? 0),
-  );
-  await expect(setupButton).toBeVisible();
-  expect(
-    await heading.evaluate((element) => element.getBoundingClientRect().top),
-  ).toBe(headingTopBefore);
-  expect(
-    await setupButton.evaluate(
-      (element) => element.getBoundingClientRect().top,
-    ),
-  ).toBe(setupTopBefore);
-});
-
-test("failed install pins a single-line 12px error without moving card content", async ({
-  page,
-}) => {
-  const installError = "Install already in progress with additional details";
-  await installMockBridge(
-    page,
-    {
-      installAcpRuntimeResult: {
-        success: false,
-        steps: [
-          {
-            step: "Install adapter",
-            command: "npm install adapter",
-            success: false,
-            stdout: "",
-            stderr: installError,
-            exit_code: 1,
-          },
-        ],
-      },
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-
-  const card = page.getByTestId("onboarding-runtime-claude");
-  const setupButton = page.getByTestId("onboarding-runtime-install-claude");
-  const heading = card.getByRole("heading", { name: "Claude" });
-  const headingTopBefore = await heading.evaluate(
-    (element) => element.getBoundingClientRect().top,
-  );
-  const detail = card.getByText("CLI detected; ACP adapter missing.");
-  const detailTopBefore = await detail.evaluate(
-    (element) => element.getBoundingClientRect().top,
-  );
-  const setupTopBefore = await setupButton.evaluate(
-    (element) => element.getBoundingClientRect().top,
-  );
-
-  await setupButton.click();
-
-  const error = page.getByTestId("onboarding-runtime-error-claude");
-  await expect(error).toBeVisible();
-  await expect(error).toHaveText(/Setup failed/);
-  await expect(error).not.toHaveAttribute("title");
-  await expect(setupButton).toBeVisible();
-  await expect(setupButton).toHaveText("SET UP");
-  await expect(error).toHaveCSS("font-size", "12px");
-  await expect(error).toHaveCSS("position", "absolute");
-  await expect(error).toHaveCSS("white-space", "nowrap");
-  await expect(error.locator("span")).toHaveCSS("text-overflow", "ellipsis");
-  await error.hover();
-  await expect(page.getByRole("tooltip")).toHaveText(
-    "Setup couldn’t be completed. Try again.",
-  );
-  await expect(page.getByRole("tooltip")).not.toContainText(installError);
-  expect(
-    await heading.evaluate((element) => element.getBoundingClientRect().top),
-  ).toBe(headingTopBefore);
-  expect(
-    await detail.evaluate((element) => element.getBoundingClientRect().top),
-  ).toBe(detailTopBefore);
-  expect(
-    await setupButton.evaluate(
-      (element) => element.getBoundingClientRect().top,
-    ),
-  ).toBe(setupTopBefore);
-});
-
-test("successful install still waits for refreshed runtime readiness", async ({
-  page,
-}) => {
-  await installMockBridge(page, undefined, {
-    skipCommunitySeed: true,
-    skipOnboardingSeed: true,
-  });
-  await page.goto("/");
-
-  await navigateToSetupPage(page);
-
-  const claudeCard = page.getByTestId("onboarding-runtime-claude");
-  const setupButton = page.getByTestId("onboarding-runtime-install-claude");
-  await expect(setupButton).toHaveText("SET UP");
-  await expect(claudeCard).toHaveAttribute("aria-checked", "false");
-
-  await setupButton.focus();
-  await page.keyboard.press("Enter");
-  await expect(
-    page.getByTestId("onboarding-runtime-installed-claude"),
-  ).toHaveText("INSTALLED");
-  const next = page.getByTestId("onboarding-setup-next");
-  await expect(next).toBeEnabled();
-  await expect(next).toHaveAttribute("data-soft-disabled", "true");
-  await next.click();
-  await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
-  await expect(page.getByTestId("onboarding-page-config")).toHaveCount(0);
-  await expect(page.getByTestId("onboarding-setup-next-hint")).toHaveText(
-    "Please finish set up",
-  );
-});
-
-test("config page shows Agent defaults form", async ({ page }) => {
-  await installMockBridge(page, undefined, {
-    skipCommunitySeed: true,
-    skipOnboardingSeed: true,
-  });
-  await page.goto("/");
-
-  await navigateToConfigPage(page);
-
-  // The defaults form is the page's content; no readiness badge is shown.
-  await expect(page.locator("#global-agent-default-harness")).toBeVisible();
-  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
-    "Buzz",
-  );
-  await expect(page.getByText("Default harness")).toBeVisible();
-  await expect(page.getByText("Provider", { exact: true })).toBeVisible();
-  await expect(page.locator("#global-agent-provider")).toBeVisible();
-  await expect(page.locator("#global-agent-model")).toBeVisible();
-  await expect(page.getByText("Default LLM provider")).toHaveCount(0);
-  await expect(page.getByText("Select provider")).toHaveCount(0);
-  await expect(page.getByTestId("global-agent-provider")).toHaveText(
-    "Select a provider",
-  );
-  const modelSelect = page.getByTestId("global-agent-model");
-  const effortSelect = page.getByTestId("global-agent-thinking-effort-select");
-  await expect(modelSelect).toHaveText("Select a model");
-  await expect(modelSelect).toBeDisabled();
-  await expect(effortSelect).toHaveText("Select effort level");
-  await expect(effortSelect).toBeDisabled();
-  await page.getByTestId("global-agent-provider").click();
-  await expect(
-    page.getByTestId("global-agent-provider-option-anthropic"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-provider-option-openai"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-provider-option-__custom_provider__"),
-  ).toHaveCount(0);
-  await page.keyboard.press("Escape");
-  await expect(page.getByText("Applies to all agents")).toHaveCount(0);
-  await expect(page.getByLabel("OpenAI API Key")).toHaveCount(0);
-  await expect(effortSelect).toBeVisible();
-  await expect(
-    page.getByText(
-      "This will be set as your default model configuration across Buzz. You can always change this in your Settings or give specific agents a different configuration.",
-      { exact: true },
-    ),
-  ).toBeVisible();
-  await expect(page.getByTestId("agent-readiness-badge")).toHaveCount(0);
-
-  await waitForAnimations(page);
-  const configPage = page.locator('[data-testid="onboarding-page-config"]');
-  await configPage.screenshot({
-    path: `${SHOTS}/04-config-defaults-form.png`,
-  });
-});
-
-test("config page gates stale saved model and effort until provider selection", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      globalAgentConfig: {
-        env_vars: {
-          BUZZ_AGENT_THINKING_EFFORT: "high",
-          OPENAI_COMPAT_API_KEY: "sk-test",
-        },
-        provider: null,
-        model: "claude-sonnet-4-6",
-      },
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-
-  await navigateToConfigPage(page);
-
-  const modelSelect = page.getByTestId("global-agent-model");
-  const effortSelect = page.getByTestId("global-agent-thinking-effort-select");
-  await expect(page.getByTestId("global-agent-provider")).toHaveText(
-    "Select a provider",
-  );
-  await expect(modelSelect).toHaveText("Select a model");
-  await expect(modelSelect).toBeDisabled();
-  await expect(effortSelect).toHaveText("Select effort level");
-  await expect(effortSelect).toBeDisabled();
-
-  await chooseConfigDropdownOption(page, "global-agent-provider", "openai");
-
-  await expect(modelSelect).toBeEnabled();
-  await expect(modelSelect).toHaveAttribute("data-value", "gpt-5.5");
-  await expect(effortSelect).toBeEnabled();
-  await expect(effortSelect).toHaveText("Select effort level");
-});
-
-test("config page model dropdown filters options via search", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      globalAgentConfig: {
-        env_vars: { OPENAI_COMPAT_API_KEY: "sk-test" },
-        provider: "openai",
-        model: null,
-      },
-    },
-    {
-      skipCommunitySeed: true,
-      skipOnboardingSeed: true,
-    },
-  );
-  await page.goto("/");
-
-  await navigateToConfigPage(page);
-
-  const modelSelect = page.getByTestId("global-agent-model");
-  await expect(modelSelect).toBeEnabled();
-  await modelSelect.click();
-  const search = page.getByTestId("global-agent-model-search");
-  await expect(search).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-model-option-gpt-5.5"),
-  ).toBeVisible();
-  await search.fill("mini");
-  await expect(
-    page.getByTestId("global-agent-model-option-gpt-5.4-mini"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-model-option-gpt-5.5"),
-  ).toHaveCount(0);
-  await search.fill("zzz-no-such-model");
-  await expect(page.getByText("No matches")).toBeVisible();
-  await search.fill("");
-  await page.getByTestId("global-agent-model-option-gpt-5.4-nano").click();
-  await expect(modelSelect).toHaveAttribute("data-value", "gpt-5.4-nano");
-});
-
-test("config page defaults model after provider selection", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      globalAgentConfig: {
-        env_vars: { OPENAI_COMPAT_API_KEY: "sk-test" },
-        provider: null,
-        model: null,
-      },
-    },
-    {
-      skipCommunitySeed: true,
-      skipOnboardingSeed: true,
-    },
-  );
-  await page.goto("/");
-
-  await navigateToConfigPage(page);
-
-  const modelSelect = page.getByTestId("global-agent-model");
-  const effortSelect = page.getByTestId("global-agent-thinking-effort-select");
-  await expect(modelSelect).toHaveText("Select a model");
-  await expect(modelSelect).toBeDisabled();
-  await expect(effortSelect).toBeDisabled();
-
-  await chooseConfigDropdownOption(page, "global-agent-provider", "openai");
-
-  await expect(page.getByTestId("global-agent-provider")).toHaveAttribute(
-    "data-value",
-    "openai",
-  );
-  await expect(modelSelect).toBeEnabled();
-  await expect(modelSelect).toHaveAttribute("data-value", "gpt-5.5");
-  await expect(modelSelect).toHaveText("gpt-5.5");
-  await expect(effortSelect).toBeEnabled();
-  await effortSelect.click();
-  await expect(
-    page.getByTestId("global-agent-thinking-effort-select-option-none"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-thinking-effort-select-option-minimal"),
-  ).toHaveCount(0);
-  await expect(
-    page.getByTestId("global-agent-thinking-effort-select-option-max"),
-  ).toHaveCount(0);
-  await page.keyboard.press("Escape");
-  await modelSelect.click();
-  await expect(
-    page.getByTestId("global-agent-model-option-__custom_model__"),
-  ).toHaveCount(0);
-  await page.keyboard.press("Escape");
-});
-
-test("config page waits for baked defaults before showing provider dropdown", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      bakedBuildEnv: [
-        { key: "BUZZ_AGENT_PROVIDER", masked: false, value: "anthropic" },
-        { key: "BUZZ_AGENT_MODEL", masked: false, value: "claude-sonnet-4" },
-        { key: "ANTHROPIC_API_KEY", masked: true, value: "••••••" },
-      ],
-      bakedBuildEnvDelayMs: 1_000,
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-
-  await navigateToConfigPage(page);
-
-  await expect(page.getByText("Loading…")).toBeVisible();
-  const providerSelect = page.getByTestId("global-agent-provider");
-  await expect(providerSelect).toHaveText("Anthropic");
-  await expect(page.getByText("Select provider")).toHaveCount(0);
-});
-
-test("setup page shows provider discovery loading state", async ({ page }) => {
-  await installMockBridge(
-    page,
-    { acpRuntimesDelayMs: 1_000 },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-
-  await navigateToSetupPage(page);
-
-  await expect(page.getByTestId("onboarding-runtime-loading")).toBeVisible();
-  await expect(page.getByText("Finding your providers...")).toBeVisible();
-
-  await expect(page.getByTestId("onboarding-runtime-goose")).toBeVisible();
-  await expect(page.getByTestId("onboarding-runtime-loading")).toHaveCount(0);
-});
-
-test("config page stays compact when Buzz Agent model config is available", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("buzz-agent", { status: "not_applicable" }),
-      ],
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-
-  await navigateToConfigPage(page);
-
-  // The compact onboarding form stays bare; readiness copy belongs in Settings.
-  await expect(
-    page.getByText("You can finish now and configure agents later in Settings"),
-  ).toHaveCount(0);
-
-  await waitForAnimations(page);
-  const configPage = page.locator('[data-testid="onboarding-page-config"]');
-  await configPage.screenshot({
-    path: `${SHOTS}/05-config-compact.png`,
-  });
-});
-
-test("Finish button is always enabled on config page regardless of readiness", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("buzz-agent", { status: "not_applicable" }),
-      ],
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-
-  await navigateToConfigPage(page);
-
-  const finishBtn = page.getByTestId("onboarding-finish");
-  await expect(finishBtn).toBeVisible();
-  await expect(finishBtn).toBeEnabled();
-});
-
-test("community setup back button returns to agent defaults", async ({
-  page,
-}) => {
-  await installMockBridge(page, undefined, {
-    skipCommunitySeed: true,
-    skipOnboardingSeed: true,
-  });
-  await page.goto("/");
-
-  await navigateToConfigPage(page);
-  await page.getByTestId("onboarding-finish").click();
-
-  await expect(page.getByText("Join or create a community")).toBeVisible();
-
-  await page.getByTestId("welcome-setup-back").click();
-  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-});
-
-// ---------------------------------------------------------------------------
-// B1 regression: rapid consecutive edits must not lose the later change
-// ---------------------------------------------------------------------------
-
-test("Goose config page discovers models through the selected Goose runtime", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("goose", { status: "not_applicable" }),
-      ],
-      globalAgentConfig: {
-        env_vars: {
-          OPENAI_COMPAT_API_KEY: "sk-test",
-        },
-        provider: null,
-        model: null,
-      },
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-  await page.getByTestId("onboarding-runtime-goose").click();
-  await page.getByTestId("onboarding-setup-next").click();
-  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-
-  await chooseConfigDropdownOption(page, "global-agent-provider", "openai");
-  await page.getByTestId("global-agent-model").click();
-  await expect(
-    page.getByTestId("global-agent-model-option-gpt-5.5"),
-  ).toBeVisible();
-  await page.keyboard.press("Escape");
-});
-
-test("Goose provider dropdown offers setup providers before credentials exist", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("goose", { status: "not_applicable" }),
-      ],
-      globalAgentConfig: {
-        env_vars: {},
-        provider: null,
-        model: null,
-      },
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-  await navigateToSetupPage(page);
-  await page.getByTestId("onboarding-runtime-goose").click();
-  await page.getByTestId("onboarding-setup-next").click();
-  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
-
-  await page.getByTestId("global-agent-provider").click();
-  await expect(
-    page.getByTestId("global-agent-provider-option-anthropic"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-provider-option-openai"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-provider-option-relay-mesh"),
-  ).toHaveCount(0);
-});
-
-test("compact default config still persists rapid provider edits", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      globalAgentConfig: {
-        env_vars: {
-          ANTHROPIC_API_KEY: "sk-test",
-          OPENAI_COMPAT_API_KEY: "sk-test",
-        },
-        provider: null,
-        model: null,
-      },
-    },
-    {
-      skipCommunitySeed: true,
-      skipOnboardingSeed: true,
-    },
-  );
-  await page.goto("/");
-  await navigateToConfigPage(page);
-
-  const providerSelect = page.getByTestId("global-agent-provider");
-  await chooseConfigDropdownOption(page, "global-agent-provider", "openai");
-  await expect(providerSelect).toHaveAttribute("data-value", "openai");
-
-  await chooseConfigDropdownOption(
-    page,
-    "global-agent-provider",
-    "openai-compat",
-  );
-  await expect(providerSelect).toHaveAttribute("data-value", "openai-compat");
-
-  await chooseConfigDropdownOption(page, "global-agent-provider", "anthropic");
-  await expect(providerSelect).toHaveAttribute("data-value", "anthropic");
-
-  await expect(page.getByLabel("Anthropic API Key")).toBeVisible();
-  await expect(page.getByLabel("OpenAI API Key")).toHaveCount(0);
-  await expect(page.getByLabel("Value for DATABRICKS_HOST")).toHaveCount(0);
-});
-
-test("compact default config keeps credential-backed providers after selecting Buzz", async ({
-  page,
-}) => {
-  await installMockBridge(
-    page,
-    {
-      globalAgentConfig: {
-        env_vars: {
-          ANTHROPIC_API_KEY: "sk-test",
-          OPENAI_COMPAT_API_KEY: "sk-test",
-        },
-        provider: null,
-        model: null,
-      },
-    },
-    {
-      skipCommunitySeed: true,
-      skipOnboardingSeed: true,
-    },
-  );
-  await page.goto("/");
-  await navigateToConfigPage(page);
-
-  const providerSelect = page.getByTestId("global-agent-provider");
-  await chooseConfigDropdownOption(page, "global-agent-provider", "openai");
-  await expect(providerSelect).toHaveAttribute("data-value", "openai");
-
-  await chooseConfigDropdownOption(page, "global-agent-provider", "relay-mesh");
-  await expect(providerSelect).toHaveAttribute("data-value", "relay-mesh");
-
-  await providerSelect.click();
-  await expect(
-    page.getByTestId("global-agent-provider-option-anthropic"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("global-agent-provider-option-openai"),
-  ).toBeVisible();
-  await page.getByTestId("global-agent-provider-option-anthropic").click();
-  await expect(providerSelect).toHaveAttribute("data-value", "anthropic");
-});
-
-test("rapid consecutive provider changes both survive — later change wins", async ({
-  page,
-}) => {
-  // Hold each set_global_agent_config request for 300 ms so the test can
-  // make a second edit before the first response arrives.
-  await installMockBridge(
-    page,
-    {
-      acpRuntimesCatalog: [
-        availableRuntime("buzz-agent", { status: "not_applicable" }),
-      ],
-      globalAgentConfig: {
-        env_vars: {
-          ANTHROPIC_API_KEY: "sk-test",
-          OPENAI_COMPAT_API_KEY: "sk-test",
-        },
-        provider: null,
-        model: null,
-      },
-      setGlobalAgentConfigDelayMs: 300,
-    },
-    { skipCommunitySeed: true, skipOnboardingSeed: true },
-  );
-  await page.goto("/");
-
-  await navigateToConfigPage(page);
-
-  const providerSelect = page.getByTestId("global-agent-provider");
-  await expect(providerSelect).toBeVisible();
-
-  // First edit: select OpenAI — save starts, held open for 300 ms.
-  await chooseConfigDropdownOption(page, "global-agent-provider", "openai");
-
-  // Second edit before first response: select Anthropic. The coalescer must
-  // persist this as the trailing save, and it must survive in the UI.
-  await chooseConfigDropdownOption(page, "global-agent-provider", "anthropic");
-
-  // Wait long enough for both saves to complete (2 × 300 ms + margin).
-  await page.waitForTimeout(800);
-
-  // The final provider shown must be Anthropic — neither save must overwrite
-  // the later optimistic state with a stale response.
-  await expect(providerSelect).toHaveAttribute("data-value", "anthropic");
 });

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -200,7 +200,40 @@ test("install transitions through Sign in to Ready", async ({ page }) => {
   ).toHaveCount(0);
 });
 
-test("defaults trusts setup readiness and persists the user's visible harness choice", async ({
+test("defaults auto-selects the only ready visible harness", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("buzz-agent", "available", { status: "not_applicable" }),
+        runtime("goose", "available", { status: "not_applicable" }),
+        runtime("claude", "available", { status: "logged_in" }),
+        runtime("codex", "available", { status: "logged_out" }),
+      ],
+      globalAgentConfig: {
+        env_vars: {},
+        provider: null,
+        model: null,
+        preferred_runtime: null,
+      },
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+  await page.getByTestId("onboarding-setup-next").click();
+  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+
+  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
+    "Claude Code",
+  );
+  await expect(page.getByTestId("onboarding-finish")).toBeEnabled();
+  await expect.poll(() => readSavedRuntime(page)).toBe("claude");
+});
+
+test("defaults requires a choice when multiple visible harnesses are ready", async ({
   page,
 }) => {
   await installMockBridge(

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -113,6 +113,110 @@ test("ready state is detected and enables Next without persisting a default", as
   expect(await readSavedRuntime(page)).toBeNull();
 });
 
+test("setup shows runtime discovery loading before rendering harnesses", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "available", { status: "logged_in" }),
+      ],
+      acpRuntimesDelayMs: 500,
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  await expect(page.getByTestId("onboarding-runtime-loading")).toBeVisible();
+  await expect(page.getByTestId("onboarding-runtime-claude")).toBeVisible();
+  await expect(page.getByTestId("onboarding-runtime-loading")).toHaveCount(0);
+});
+
+test("unknown authentication can be checked again", async ({ page }) => {
+  const unknown = runtime("claude", "available", { status: "unknown" });
+  const loggedIn = runtime("claude", "available", { status: "logged_in" });
+  await installMockBridge(
+    page,
+    { acpRuntimesCatalogSequence: [[unknown], [loggedIn]] },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const checkAgain = page.getByRole("button", {
+    name: "Check Claude Code again",
+  });
+  await expect(checkAgain).toHaveText("CHECK AGAIN");
+  await checkAgain.click();
+  await expect(page.getByTestId("onboarding-runtime-ready-claude")).toHaveText(
+    "READY",
+  );
+});
+
+test("auth discovery failure stays actionable without exposing internals", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "available", { status: "logged_out" }),
+      ],
+      acpAuthMethodsError: "sensitive auth discovery details",
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const card = page.getByTestId("onboarding-runtime-claude");
+  await expect(
+    card.getByRole("status", { name: /Sign-in unavailable/ }),
+  ).toBeVisible();
+  await expect(
+    card.getByTestId("onboarding-runtime-instructions-claude"),
+  ).toHaveText("SIGN IN");
+  await expect(card).not.toContainText("sensitive auth discovery details");
+});
+
+test("terminal launch failure keeps Sign in available", async ({ page }) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "available", { status: "logged_out" }),
+      ],
+      acpAuthMethods: {
+        claude: {
+          methods: [
+            {
+              id: "subscription",
+              name: "Claude.ai subscription",
+              description: null,
+              type: "terminal",
+            },
+          ],
+        },
+      },
+      connectAcpRuntimeError: "sensitive launch details",
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const card = page.getByTestId("onboarding-runtime-claude");
+  const signIn = card.getByRole("button", { name: "Sign in to Claude Code" });
+  await signIn.click();
+  await expect(
+    card.getByRole("status", { name: /Sign-in failed/ }),
+  ).toBeVisible();
+  await expect(signIn).toHaveText("SIGN IN");
+  await expect(card).not.toContainText("sensitive launch details");
+});
+
 test("sign in stays pending until catalog detection confirms Ready", async ({
   page,
 }) => {
@@ -151,6 +255,73 @@ test("sign in stays pending until catalog detection confirms Ready", async ({
     { timeout: 5_000 },
   );
   await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
+});
+
+test("failed install can be retried without shifting card content", async ({
+  page,
+}) => {
+  const notInstalled = runtime("claude", "adapter_missing", {
+    status: "unknown",
+  });
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [notInstalled],
+      installAcpRuntimeResults: [
+        {
+          success: false,
+          steps: [
+            {
+              step: "adapter",
+              command: "mock install claude",
+              success: false,
+              stdout: "",
+              stderr: "sensitive install details",
+              exit_code: 1,
+            },
+          ],
+        },
+        {
+          success: true,
+          steps: [
+            {
+              step: "adapter",
+              command: "mock install claude",
+              success: true,
+              stdout: "installed",
+              stderr: "",
+              exit_code: 0,
+            },
+          ],
+        },
+      ],
+      acpRuntimesCatalogAfterInstall: [
+        runtime("claude", "available", { status: "logged_in" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const card = page.getByTestId("onboarding-runtime-claude");
+  const heading = card.getByRole("heading", { name: "Claude Code" });
+  const headingTop = await heading.evaluate(
+    (element) => element.getBoundingClientRect().top,
+  );
+  const install = page.getByTestId("onboarding-runtime-install-claude");
+  await install.click();
+  const error = page.getByTestId("onboarding-runtime-error-claude");
+  await expect(error).toBeVisible();
+  await expect(install).toHaveText("RETRY INSTALL");
+  await expect(error).not.toContainText("sensitive install details");
+  expect(
+    await heading.evaluate((element) => element.getBoundingClientRect().top),
+  ).toBe(headingTop);
+  await install.click();
+  await expect(page.getByTestId("onboarding-runtime-ready-claude")).toHaveText(
+    "READY",
+  );
 });
 
 test("install transitions through Sign in to Ready", async ({ page }) => {
@@ -200,6 +371,83 @@ test("install transitions through Sign in to Ready", async ({ page }) => {
   ).toHaveCount(0);
 });
 
+test("defaults waits for baked configuration before rendering fields", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "available", { status: "logged_in" }),
+      ],
+      bakedBuildEnv: [
+        { key: "ANTHROPIC_API_KEY", masked: true, value: "••••••" },
+      ],
+      bakedBuildEnvDelayMs: 500,
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+  await page.getByTestId("onboarding-setup-next").click();
+
+  await expect(page.getByText("Loading…")).toBeVisible();
+  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
+    "Claude Code",
+  );
+});
+
+test("defaults renders only fields supported by the selected harness", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "available", { status: "logged_in" }),
+      ],
+      globalAgentConfig: {
+        env_vars: { BUZZ_AGENT_THINKING_EFFORT: "high" },
+        provider: null,
+        model: "stale-model",
+        preferred_runtime: null,
+      },
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+  await page.getByTestId("onboarding-setup-next").click();
+
+  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
+    "Claude Code",
+  );
+  await expect(page.getByTestId("global-agent-provider")).toHaveCount(0);
+  await expect(page.getByTestId("global-agent-model")).toHaveText(
+    "Default model",
+  );
+  await expect(
+    page.getByTestId("global-agent-thinking-effort-select"),
+  ).toHaveCount(0);
+});
+
+test("defaults Back returns to harness setup", async ({ page }) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "available", { status: "logged_in" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+  await page.getByTestId("onboarding-setup-next").click();
+  await page.getByTestId("onboarding-back").click();
+  await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
+});
+
 test("defaults auto-selects the only ready visible harness", async ({
   page,
 }) => {
@@ -231,6 +479,43 @@ test("defaults auto-selects the only ready visible harness", async ({
   );
   await expect(page.getByTestId("onboarding-finish")).toBeEnabled();
   await expect.poll(() => readSavedRuntime(page)).toBe("claude");
+});
+
+test("Finish waits for the latest rapid harness choice to persist", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "available", { status: "logged_in" }),
+        runtime("codex", "available", { status: "logged_in" }),
+      ],
+      globalAgentConfig: {
+        env_vars: {},
+        provider: null,
+        model: null,
+        preferred_runtime: null,
+      },
+      setGlobalAgentConfigDelayMs: 300,
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+  await page.getByTestId("onboarding-setup-next").click();
+
+  const harness = page.getByTestId("global-agent-default-harness");
+  await harness.click();
+  await page.getByTestId("global-agent-default-harness-option-claude").click();
+  await harness.click();
+  await page.getByTestId("global-agent-default-harness-option-codex").click();
+  const finish = page.getByTestId("onboarding-finish");
+  await expect(finish).toBeDisabled();
+  await expect(finish).toBeEnabled({ timeout: 2_000 });
+  await finish.click();
+  await expect(page.getByText("Join or create a community")).toBeVisible();
+  expect(await readSavedRuntime(page)).toBe("codex");
 });
 
 test("defaults requires a choice when multiple visible harnesses are ready", async ({

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -84,7 +84,7 @@ test("setup shows only Claude Code and Codex as detected harnesses", async ({
   await expect(page.getByRole("checkbox")).toHaveCount(0);
 });
 
-test("ready state is detected, checked, and enables Next without persisting a default", async ({
+test("ready state is detected and enables Next without persisting a default", async ({
   page,
 }) => {
   await installMockBridge(
@@ -105,7 +105,7 @@ test("ready state is detected, checked, and enables Next without persisting a de
   );
   await expect(
     page.getByTestId("onboarding-runtime-checkmark-claude"),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(
     page.getByTestId("onboarding-runtime-checkmark-codex"),
   ).toHaveCount(0);
@@ -197,7 +197,7 @@ test("install transitions through Sign in to Ready", async ({ page }) => {
   );
   await expect(
     page.getByTestId("onboarding-runtime-checkmark-claude"),
-  ).toBeVisible();
+  ).toHaveCount(0);
 });
 
 test("defaults trusts setup readiness and persists the user's visible harness choice", async ({

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -200,7 +200,7 @@ test("install transitions through Sign in to Ready", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("defaults includes every ready visible harness and persists the user's choice there", async ({
+test("defaults trusts setup readiness and persists the user's visible harness choice", async ({
   page,
 }) => {
   await installMockBridge(

--- a/desktop/tests/e2e/onboarding-docked-cta-screenshots.spec.ts
+++ b/desktop/tests/e2e/onboarding-docked-cta-screenshots.spec.ts
@@ -67,7 +67,7 @@ test("machine onboarding: landing, backup, setup docked CTAs", async ({
 
   await page.getByTestId("onboarding-next").click();
   await expect(
-    page.getByRole("heading", { name: "Use the models that fit the task" }),
+    page.getByRole("heading", { name: "Set up your agent harnesses" }),
   ).toBeVisible();
   await waitForAnimations(page);
   await page.screenshot({ path: `${SHOT_DIR}/03-setup.png` });

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -1042,11 +1042,35 @@ test("first-community shows the scenario cards for localhost", async ({
       "true",
     );
   }, BLANK_TYLER_IDENTITY.pubkey);
-  await installMockBridge(page, undefined, {
-    relayWsUrl: "ws://localhost:3000",
-    skipOnboardingSeed: true,
-    skipCommunitySeed: true,
-  });
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        {
+          id: "claude",
+          label: "Claude Code",
+          avatar_url: "",
+          availability: "available",
+          command: "claude",
+          binary_path: "/usr/local/bin/claude",
+          default_args: [],
+          mcp_command: null,
+          install_hint: "Install Claude Code",
+          install_instructions_url: "https://example.com",
+          can_auto_install: true,
+          underlying_cli_path: null,
+          node_required: false,
+          auth_status: { status: "logged_in" },
+          login_hint: "Sign in to Claude Code",
+        },
+      ],
+    },
+    {
+      relayWsUrl: "ws://localhost:3000",
+      skipOnboardingSeed: true,
+      skipCommunitySeed: true,
+    },
+  );
   await page.goto("/");
 
   await expect(
@@ -1068,6 +1092,10 @@ test("first-community shows the scenario cards for localhost", async ({
       name: "Configure your default model settings",
     }),
   ).toBeVisible();
+  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
+    "Claude Code",
+  );
+  await expect(page.getByTestId("onboarding-finish")).toBeEnabled();
 });
 
 test("first-community direct join reaches profile", async ({ page }) => {

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -144,6 +144,12 @@ type MockBridgeOptions = {
     archived_at?: string | null;
   }>;
   acpRuntimesCatalog?: Record<string, unknown>[];
+  /** Catalog returned after a successful mocked install. */
+  acpRuntimesCatalogAfterInstall?: Record<string, unknown>[];
+  /** Catalog responses after install for testing later sign-in completion. */
+  acpRuntimesCatalogAfterInstallSequence?: Record<string, unknown>[][];
+  /** Catalog responses for successive discovery calls. The final response repeats. */
+  acpRuntimesCatalogSequence?: Record<string, unknown>[][];
   acpRuntimesDelayMs?: number;
   acpAuthMethods?: Record<string, { methods: Record<string, unknown>[] }>;
   acpAuthMethodsError?: string;


### PR DESCRIPTION
## Summary

- show only Claude Code and Codex during onboarding; Buzz Agent and Goose remain available elsewhere in the app
- treat harness cards as detected machine states instead of manual selections
- guide each harness through **Install → Sign in → Ready**, with a Ready pill as the completion indicator
- stop sign-in polling as soon as readiness is detected and offer **Check again** after a slow authentication timeout
- automatically pass every ready, visible harness to the defaults page
- auto-select the default when exactly one harness is ready; require an explicit choice when multiple are ready
- make the defaults page the only onboarding surface where a preferred harness is chosen and persisted
- wait for the latest default configuration to persist before completing onboarding
- centralize onboarding harness visibility so hidden harnesses can be restored later in one place

## Testing

- `pnpm typecheck`
- `pnpm build:e2e`
- `pnpm exec playwright test tests/e2e/onboarding-agent-defaults.spec.ts --project=smoke` — 15 passed
- `node --import ./test-loader.mjs --experimental-strip-types --test src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs` — 4 passed
- `node --import ./test-loader.mjs --experimental-strip-types --test src/features/onboarding/ui/saveCoalescer.test.mjs` — 9 passed
- `pnpm exec playwright test tests/e2e/onboarding-docked-cta-screenshots.spec.ts --project=smoke` — 3 passed
- targeted Biome checks passed
