### PR TITLE
fix(justfile): use Hermit-pinned lefthook in hooks recipe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ unacceptable behavior to **conduct@buzz-relay.org**.
 | Flutter | 3.41+ | Required for mobile app — install via [flutter.dev](https://docs.flutter.dev/get-started/install) |
 | Docker | 24+ | For Postgres, Redis, MinIO |
 | `just` | latest | Task runner — `cargo install just` |
-| `lefthook` | latest | Optional; run `lefthook install` for local Git hooks |
+| `lefthook` | 2.1.3 (Hermit-pinned) | Auto-installed by `just hooks` — no manual install needed |
 | `sqlx` migrations | workspace crate | `just migrate` applies embedded migrations from `migrations/` |
 
 This repo uses [Hermit](https://cashapp.github.io/hermit/) for toolchain

--- a/Justfile
+++ b/Justfile
@@ -52,6 +52,10 @@ setup: bootstrap
 hooks:
     #!/usr/bin/env bash
     set -euo pipefail
+    # Use the Hermit-pinned lefthook (bin/lefthook self-downloads on first use):
+    # works with no pre-installed lefthook and guarantees the pinned version
+    # rather than whatever happens to be on PATH.
+    export PATH="{{justfile_directory()}}/bin:$PATH"
     # --path-format=absolute guarantees an absolute path from every invocation context:
     # without it, --git-common-dir returns ".git" from the main checkout and a
     # relative hooksPath would break linked-worktree dispatch just like .hooks did.


### PR DESCRIPTION
The `hooks` recipe called bare `lefthook`, which resolves from the shell PATH. Two failure modes:

1. **No system lefthook installed** → `command not found`, hooks silently never installed.
2. **System lefthook present but wrong version** (e.g. Homebrew 2.1.10 on this machine) → installed dispatcher bakes in a version-mismatched fallback path, causing subtle behavioral differences.

## Fix

Prepend `bin/` to PATH before invoking `lefthook`. The Hermit stub at `bin/lefthook` self-downloads the pinned 2.1.3 binary on first invocation — same pattern already used by `just bootstrap`. Zero new dependencies; Hermit handles macOS/Linux per-arch download automatically.

This is strictly better than package-manager detection (brew/apt): that approach would un-pin the version and add per-OS branches, while the Hermit path guarantees the exact pinned version on every platform.

## Changes

- **`Justfile`** — add `export PATH="{{justfile_directory()}}/bin:$PATH"` before the `lefthook install --force` call, with an explanatory comment.
- **`CONTRIBUTING.md`** — update the prerequisites table to reflect that `lefthook` is now auto-installed by `just hooks` and no manual install is needed.

## Verification

```
# Step 1: simulate no system lefthook, no Hermit activation
env PATH=/usr/bin:/bin:<worktree>/bin just hooks
→ succeeds; hooks/pre-push is a lefthook dispatcher ✅

# Step 2: PATH-order check
which lefthook  →  /opt/homebrew/bin/lefthook (2.1.10)
env PATH="<worktree>/bin:$PATH" lefthook version  →  2.1.3 ✅
# Recipe uses bin/lefthook (2.1.3), not the Homebrew 2.1.10

# Step 3: restore real install
just hooks  →  sync hooks: ✔️ (pre-commit, pre-push) ✅
```
