### PR TITLE
fix(desktop): keep machine onboarding for unrecognized identities after reset

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -375,7 +375,10 @@ const overrides = new Map([
   // queued to split when ProfileSettingsCard is broken into sub-components.
   // +20 lines: scroll-position save/restore across avatar editor open/close
   // to prevent layout shift from the Sign Out section causing a viewport jump.
-  ["src/features/settings/ui/ProfileSettingsCard.tsx", 1033],
+  // +11 lines: signout-dev-webview-state — clear localStorage/sessionStorage
+  // on successful signOut() resolve so dev-build webview state doesn't survive
+  // a reset and vouch for the fresh key. Comment explains the race/redundancy.
+  ["src/features/settings/ui/ProfileSettingsCard.tsx", 1044],
   // keyring-dev-isolation: keyring_service() fn (7 lines) replaces the const
   // to return "buzz-desktop-dev" in debug builds. Load-bearing isolation fix.
   // +10 (1042 -> 1052): media_fetch_client with redirect::Policy::none() so a

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -494,7 +494,9 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
   const { activeCommunity } = useCommunities();
   const communityOnboarding = useCommunityOnboarding();
   const machine = useMachineOnboardingState({
-    hasConfiguredCommunity: activeCommunity !== null,
+    activeCommunityPubkey: activeCommunity
+      ? (activeCommunity.pubkey ?? null)
+      : undefined,
     isSharedIdentity: sharedIdentity,
   });
   const [machineInitialPage, setMachineInitialPage] =

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -259,9 +259,11 @@ function AppReady({
 }
 
 function CommunityApp({
+  currentPubkey,
   onBackToMachineConfig,
   sharedIdentity,
 }: {
+  currentPubkey: string | null;
   onBackToMachineConfig: () => void;
   sharedIdentity: boolean;
 }) {
@@ -325,6 +327,7 @@ function CommunityApp({
       relayUrl: transaction.relayUrl,
       token: transaction.token,
       reposDir: transaction.reposDir,
+      pubkey: currentPubkey ?? undefined,
       addedAt: new Date().toISOString(),
     });
     communityOnboarding.update({
@@ -340,6 +343,7 @@ function CommunityApp({
     addCommunity,
     communities,
     communityOnboarding,
+    currentPubkey,
     reconnectCommunity,
     switchCommunity,
   ]);
@@ -550,6 +554,7 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
   if (machine.stage === "ready") {
     return (
       <CommunityApp
+        currentPubkey={machine.currentPubkey}
         onBackToMachineConfig={reopenMachineConfig}
         sharedIdentity={sharedIdentity}
       />

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -789,7 +789,11 @@ export function AppShell() {
                           isCreateChannelOpen={isCreateChannelOpen}
                           isPresencePending={presenceSession.isPending}
                           onAddCommunity={(community) => {
-                            const id = communitiesHook.addCommunity(community);
+                            const id = communitiesHook.addCommunity({
+                              ...community,
+                              pubkey:
+                                community.pubkey ?? identityQuery.data?.pubkey,
+                            });
                             handleSwitchCommunity(id);
                           }}
                           onAddCommunityOpenChange={

--- a/desktop/src/features/onboarding/machineOnboarding.test.mjs
+++ b/desktop/src/features/onboarding/machineOnboarding.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  migrateMachineOnboardingCompletion,
+  readMachineOnboardingCompletion,
+} from "./machineOnboarding.ts";
+
+// machineOnboarding.ts reads/writes window.localStorage directly, so we inject
+// a minimal in-memory storage into globalThis.window before each test and
+// restore it afterward.
+
+function createMemoryStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+    clear: () => values.clear(),
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    get length() {
+      return values.size;
+    },
+  };
+}
+
+function withFakeWindow(initial, fn) {
+  const prev = globalThis.window;
+  const storage = createMemoryStorage(initial);
+  globalThis.window = {
+    localStorage: storage,
+    // location.href without a machineOnboarding=1 param → forceMachineOnboarding() returns false
+    location: { href: "http://localhost/" },
+  };
+  try {
+    return fn(storage);
+  } finally {
+    globalThis.window = prev;
+  }
+}
+
+const PUBKEY_A =
+  "aaaaaa1111112222223333334444445555556666667777778888889999990000aa";
+const PUBKEY_B =
+  "bbbbbb1111112222223333334444445555556666667777778888889999990000bb";
+const LEGACY_KEY = `buzz-onboarding-complete.v1:${PUBKEY_A}`;
+const V2_KEY = `buzz-machine-onboarding-complete.v2:${PUBKEY_A}`;
+
+// ── Fix A regression case ────────────────────────────────────────────────────
+
+test("migrate_mismatched_community_pubkey_does_not_vouch_for_current_key", () => {
+  // Community pubkey is PUBKEY_B (stale from a previous identity); current
+  // pubkey is PUBKEY_A (freshly generated after a dev reset). The mismatch
+  // must NOT grant completion.
+  withFakeWindow({}, (storage) => {
+    const result = migrateMachineOnboardingCompletion(
+      PUBKEY_A,
+      PUBKEY_B, // activeCommunityPubkey — a different identity's community
+      false,
+    );
+    assert.equal(result, false, "mismatched pubkey must not vouch");
+    assert.equal(
+      storage.getItem(V2_KEY),
+      null,
+      "completion must not be written to storage",
+    );
+    assert.equal(
+      readMachineOnboardingCompletion(PUBKEY_A),
+      false,
+      "readMachineOnboardingCompletion must return false",
+    );
+  });
+});
+
+// ── Matching pubkey vouches ──────────────────────────────────────────────────
+
+test("migrate_matching_community_pubkey_vouches_for_current_key", () => {
+  // Community pubkey matches current pubkey → legitimate veteran, grant.
+  withFakeWindow({}, (storage) => {
+    const result = migrateMachineOnboardingCompletion(
+      PUBKEY_A,
+      PUBKEY_A, // same pubkey — community belongs to this identity
+      false,
+    );
+    assert.equal(result, true, "matching pubkey must vouch");
+    assert.equal(storage.getItem(V2_KEY), "true");
+    assert.equal(readMachineOnboardingCompletion(PUBKEY_A), true);
+  });
+});
+
+// ── Absent community pubkey (legacy entry) ───────────────────────────────────
+
+test("migrate_absent_community_pubkey_vouches_for_current_key", () => {
+  // Community exists but has no pubkey field (pre-field legacy entry).
+  // `null` represents absent → treated as a match to preserve the
+  // veteran-upgrade path.
+  withFakeWindow({}, (storage) => {
+    const result = migrateMachineOnboardingCompletion(
+      PUBKEY_A,
+      null, // absent pubkey on a community that does exist
+      false,
+    );
+    assert.equal(
+      result,
+      true,
+      "absent pubkey must vouch (legacy compatibility)",
+    );
+    assert.equal(storage.getItem(V2_KEY), "true");
+  });
+});
+
+// ── No community configured ──────────────────────────────────────────────────
+
+test("migrate_no_community_does_not_vouch_for_current_key", () => {
+  // `undefined` = no active community at all.
+  withFakeWindow({}, (storage) => {
+    const result = migrateMachineOnboardingCompletion(
+      PUBKEY_A,
+      undefined, // no community
+      false,
+    );
+    assert.equal(result, false, "no community must not vouch");
+    assert.equal(storage.getItem(V2_KEY), null);
+  });
+});
+
+// ── Legacy onboarding completion still grants (pubkey-scoped) ───────────────
+
+test("migrate_legacy_completion_key_still_grants_migration", () => {
+  withFakeWindow({ [LEGACY_KEY]: "true" }, (storage) => {
+    const result = migrateMachineOnboardingCompletion(
+      PUBKEY_A,
+      undefined, // no community — but legacy key is present
+      false,
+    );
+    assert.equal(result, true, "legacy completion key must grant migration");
+    assert.equal(storage.getItem(V2_KEY), "true");
+  });
+});
+
+// ── Shared identity grants regardless of community ───────────────────────────
+
+test("migrate_shared_identity_grants_regardless_of_community", () => {
+  withFakeWindow({}, () => {
+    const result = migrateMachineOnboardingCompletion(
+      PUBKEY_A,
+      undefined, // no community
+      true, // isSharedIdentity
+    );
+    assert.equal(result, true, "shared identity must always grant");
+  });
+});
+
+// ── Already-completed v2 key returns true without re-writing ─────────────────
+
+test("migrate_already_completed_pubkey_returns_true_immediately", () => {
+  withFakeWindow({ [V2_KEY]: "true" }, (storage) => {
+    // Pass mismatched community to prove early-exit, not community vouching.
+    const result = migrateMachineOnboardingCompletion(
+      PUBKEY_A,
+      PUBKEY_B,
+      false,
+    );
+    assert.equal(result, true, "already-completed pubkey must return true");
+    // Value was already there; the function should not have touched it
+    // (but a redundant write is also acceptable — just verify it's still true).
+    assert.equal(storage.getItem(V2_KEY), "true");
+  });
+});

--- a/desktop/src/features/onboarding/machineOnboarding.test.mjs
+++ b/desktop/src/features/onboarding/machineOnboarding.test.mjs
@@ -88,24 +88,29 @@ test("migrate_matching_community_pubkey_vouches_for_current_key", () => {
   });
 });
 
-// ── Absent community pubkey (legacy entry) ───────────────────────────────────
+// ── Absent community pubkey — regression case (Thufir pass 1) ───────────────
 
-test("migrate_absent_community_pubkey_vouches_for_current_key", () => {
-  // Community exists but has no pubkey field (pre-field legacy entry).
-  // `null` represents absent → treated as a match to preserve the
-  // veteran-upgrade path.
+test("migrate_absent_community_pubkey_does_not_vouch_for_fresh_identity", () => {
+  // Stale current-format community with no pubkey stamp (created before the
+  // stamp was added, or from an older build) + freshly generated identity
+  // after a dev reset. The absent pubkey must NOT vouch — this was the
+  // reachable producer of the half-onboarded state.
   withFakeWindow({}, (storage) => {
     const result = migrateMachineOnboardingCompletion(
       PUBKEY_A,
-      null, // absent pubkey on a community that does exist
+      null, // absent pubkey — could be legacy OR an unstamped modern entry
       false,
     );
     assert.equal(
       result,
-      true,
-      "absent pubkey must vouch (legacy compatibility)",
+      false,
+      "absent pubkey must not vouch for a fresh identity",
     );
-    assert.equal(storage.getItem(V2_KEY), "true");
+    assert.equal(
+      storage.getItem(V2_KEY),
+      null,
+      "completion must not be written to storage",
+    );
   });
 });
 

--- a/desktop/src/features/onboarding/machineOnboarding.ts
+++ b/desktop/src/features/onboarding/machineOnboarding.ts
@@ -47,14 +47,14 @@ export function migrateMachineOnboardingCompletion(
   pubkey: string,
   /**
    * The `pubkey` field of the active community from localStorage, or
-   * `undefined` if no community is configured. When a community is present
-   * but its `pubkey` field is absent (legacy entries predating the field),
-   * pass `null` — absent is treated as a match so the veteran-upgrade path
-   * is preserved. Pass `undefined` when there is no active community at all.
+   * `undefined` if no community is configured. Community-creation paths stamp
+   * the current identity's pubkey on write; absent pubkey (`null`) therefore
+   * indicates a legacy entry that pre-dates the stamp and is NOT treated as a
+   * voucher. Pass `undefined` when there is no active community at all.
    *
-   * Using the community's own pubkey rather than a bare boolean prevents a
-   * freshly generated post-reset key from being vouched for by a stale
-   * community entry that survived the webview wipe.
+   * Using the community's own pubkey prevents a freshly generated post-reset
+   * key from being vouched for by a stale community entry that survived the
+   * webview wipe.
    */
   activeCommunityPubkey: string | null | undefined,
   isSharedIdentity: boolean,
@@ -68,10 +68,14 @@ export function migrateMachineOnboardingCompletion(
     ) === "true";
 
   // A community entry vouches for the current pubkey only when its recorded
-  // pubkey matches (or is absent — legacy entries predate the field).
+  // pubkey matches. Absent pubkey (legacy entries predating the stamp) and
+  // no community at all (undefined) do not vouch — after community creation
+  // paths stamp pubkey on write, absent means the entry pre-dates the stamp
+  // and cannot be trusted to identify which identity created it.
   const communityVouchesForPubkey =
     activeCommunityPubkey !== undefined &&
-    (activeCommunityPubkey === null || activeCommunityPubkey === pubkey);
+    activeCommunityPubkey !== null &&
+    activeCommunityPubkey === pubkey;
 
   if (
     !completedLegacyOnboarding &&

--- a/desktop/src/features/onboarding/machineOnboarding.ts
+++ b/desktop/src/features/onboarding/machineOnboarding.ts
@@ -36,15 +36,27 @@ function clearMachineOnboardingCompletion(pubkey: string | null) {
 }
 
 function forceMachineOnboarding() {
-  if (!import.meta.env.DEV || typeof window === "undefined") return false;
+  if (!import.meta.env?.DEV || typeof window === "undefined") return false;
   return (
     new URL(window.location.href).searchParams.get("machineOnboarding") === "1"
   );
 }
 
-function migrateMachineOnboardingCompletion(
+/** @internal Exported for unit testing only. */
+export function migrateMachineOnboardingCompletion(
   pubkey: string,
-  hasConfiguredCommunity: boolean,
+  /**
+   * The `pubkey` field of the active community from localStorage, or
+   * `undefined` if no community is configured. When a community is present
+   * but its `pubkey` field is absent (legacy entries predating the field),
+   * pass `null` — absent is treated as a match so the veteran-upgrade path
+   * is preserved. Pass `undefined` when there is no active community at all.
+   *
+   * Using the community's own pubkey rather than a bare boolean prevents a
+   * freshly generated post-reset key from being vouched for by a stale
+   * community entry that survived the webview wipe.
+   */
+  activeCommunityPubkey: string | null | undefined,
   isSharedIdentity: boolean,
 ) {
   if (forceMachineOnboarding()) return false;
@@ -54,9 +66,16 @@ function migrateMachineOnboardingCompletion(
     window.localStorage.getItem(
       completionKey(LEGACY_ONBOARDING_COMPLETION_STORAGE_KEY, pubkey),
     ) === "true";
+
+  // A community entry vouches for the current pubkey only when its recorded
+  // pubkey matches (or is absent — legacy entries predate the field).
+  const communityVouchesForPubkey =
+    activeCommunityPubkey !== undefined &&
+    (activeCommunityPubkey === null || activeCommunityPubkey === pubkey);
+
   if (
     !completedLegacyOnboarding &&
-    !hasConfiguredCommunity &&
+    !communityVouchesForPubkey &&
     !isSharedIdentity
   ) {
     return false;
@@ -74,10 +93,10 @@ function identitySettled(status: QueryStatus, isFetching: boolean) {
 }
 
 export function useMachineOnboardingState({
-  hasConfiguredCommunity,
+  activeCommunityPubkey,
   isSharedIdentity,
 }: {
-  hasConfiguredCommunity: boolean;
+  activeCommunityPubkey: string | null | undefined;
   isSharedIdentity: boolean;
 }) {
   const queryClient = useQueryClient();
@@ -130,7 +149,7 @@ export function useMachineOnboardingState({
     if (
       migrateMachineOnboardingCompletion(
         currentPubkey,
-        hasConfiguredCommunity,
+        activeCommunityPubkey,
         isSharedIdentity,
       )
     ) {
@@ -139,7 +158,7 @@ export function useMachineOnboardingState({
     setEvaluatedPubkey(currentPubkey);
   }, [
     currentPubkey,
-    hasConfiguredCommunity,
+    activeCommunityPubkey,
     identityLost,
     identityQuery.status,
     isSharedIdentity,

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -1009,13 +1009,27 @@ export function ProfileSettingsCard({
                 onClick={() => {
                   setIsSignOutPending(true);
                   // Keep the pending state if signOut() resolves before restart.
-                  signOut().catch((err: unknown) => {
-                    setIsSignOutPending(false);
-                    setIsSignOutOpen(false);
-                    toast.error(
-                      err instanceof Error ? err.message : "Sign out failed.",
-                    );
-                  });
+                  signOut()
+                    .then(() => {
+                      // Clear web storage for this origin on the success path
+                      // only. This covers dev builds where the Rust webview wipe
+                      // targets the .app-bundle WebKit dir (missing in `tauri
+                      // dev`), preventing stale community config from vouching
+                      // for the fresh key on next boot. In production the Rust
+                      // wipe already handles this; the clear here is redundant
+                      // but harmless. The restart may race this clear — that is
+                      // acceptable; Fix A (pubkey-scoped heuristic) is the
+                      // correctness gate.
+                      window.localStorage.clear();
+                      window.sessionStorage.clear();
+                    })
+                    .catch((err: unknown) => {
+                      setIsSignOutPending(false);
+                      setIsSignOutOpen(false);
+                      toast.error(
+                        err instanceof Error ? err.message : "Sign out failed.",
+                      );
+                    });
                 }}
               >
                 {isSignOutPending ? "Signing out…" : "Delete My Data"}

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -590,11 +590,28 @@ async function seedDefaultCommunity(
       // If seedActiveIdentity() ran before this script (the normal ordering),
       // use its pubkey so the community matches the active identity and
       // migrateMachineOnboardingCompletion's strict voucher accepts it.
-      const overrideRaw = window.localStorage.getItem(identityOverrideKey);
-      const overridePubkey =
-        overrideRaw !== null
-          ? (JSON.parse(overrideRaw) as { pubkey?: string }).pubkey
-          : undefined;
+      // Mirror readStoredIdentityOverride()'s shape validation: require all
+      // three fields to be non-empty strings; fall through to fallback on
+      // malformed JSON, stored null, or partial objects.
+      let overridePubkey: string | undefined;
+      try {
+        const overrideRaw = window.localStorage.getItem(identityOverrideKey);
+        if (overrideRaw !== null) {
+          const parsed: unknown = JSON.parse(overrideRaw);
+          if (
+            parsed !== null &&
+            typeof parsed === "object" &&
+            typeof (parsed as Record<string, unknown>).pubkey === "string" &&
+            typeof (parsed as Record<string, unknown>).privateKey ===
+              "string" &&
+            typeof (parsed as Record<string, unknown>).username === "string"
+          ) {
+            overridePubkey = (parsed as { pubkey: string }).pubkey;
+          }
+        }
+      } catch {
+        // malformed entry — fall through to fallback
+      }
       const communityId = "e2e-default-community";
       const community = {
         id: communityId,

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -580,14 +580,19 @@ async function seedOnboardingCompletionForKnownIdentities(
   );
 }
 
-async function seedDefaultCommunity(page: Page, relayWsUrl?: string) {
+async function seedDefaultCommunity(
+  page: Page,
+  activePubkey: string,
+  relayWsUrl?: string,
+) {
   await page.addInitScript(
-    ({ relayUrl }) => {
+    ({ pubkey, relayUrl }) => {
       const communityId = "e2e-default-community";
       const community = {
         id: communityId,
         name: "E2E Test",
         relayUrl,
+        pubkey,
         addedAt: new Date().toISOString(),
       };
       window.localStorage.setItem(
@@ -596,7 +601,7 @@ async function seedDefaultCommunity(page: Page, relayWsUrl?: string) {
       );
       window.localStorage.setItem("buzz-active-community-id", communityId);
     },
-    { relayUrl: relayWsUrl ?? DEFAULT_RELAY_WS_URL },
+    { pubkey: activePubkey, relayUrl: relayWsUrl ?? DEFAULT_RELAY_WS_URL },
   );
 }
 
@@ -619,8 +624,11 @@ export async function installBridge(page: Page, options: BridgeOptions) {
 
   // Most specs seed a community so useCommunityInit doesn't show WelcomeSetup.
   // skipOnboardingSeed only controls the onboarding-completion flag.
+  // The community is stamped with the active identity's pubkey so the strict
+  // migrateMachineOnboardingCompletion voucher recognises it.
   if (!options.skipCommunitySeed) {
-    await seedDefaultCommunity(page, options.relayWsUrl);
+    const activePubkey = identity?.pubkey ?? DEFAULT_MOCK_PUBKEY;
+    await seedDefaultCommunity(page, activePubkey, options.relayWsUrl);
   }
   if (!options.skipOnboardingSeed) {
     await seedOnboardingCompletionForKnownIdentities(page, options.relayWsUrl);

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -582,17 +582,25 @@ async function seedOnboardingCompletionForKnownIdentities(
 
 async function seedDefaultCommunity(
   page: Page,
-  activePubkey: string,
+  fallbackPubkey: string,
   relayWsUrl?: string,
 ) {
   await page.addInitScript(
-    ({ pubkey, relayUrl }) => {
+    ({ fallback, identityOverrideKey, relayUrl }) => {
+      // If seedActiveIdentity() ran before this script (the normal ordering),
+      // use its pubkey so the community matches the active identity and
+      // migrateMachineOnboardingCompletion's strict voucher accepts it.
+      const overrideRaw = window.localStorage.getItem(identityOverrideKey);
+      const overridePubkey =
+        overrideRaw !== null
+          ? (JSON.parse(overrideRaw) as { pubkey?: string }).pubkey
+          : undefined;
       const communityId = "e2e-default-community";
       const community = {
         id: communityId,
         name: "E2E Test",
         relayUrl,
-        pubkey,
+        pubkey: overridePubkey ?? fallback,
         addedAt: new Date().toISOString(),
       };
       window.localStorage.setItem(
@@ -601,7 +609,11 @@ async function seedDefaultCommunity(
       );
       window.localStorage.setItem("buzz-active-community-id", communityId);
     },
-    { pubkey: activePubkey, relayUrl: relayWsUrl ?? DEFAULT_RELAY_WS_URL },
+    {
+      fallback: fallbackPubkey,
+      identityOverrideKey: "buzz:e2e-identity-override.v1",
+      relayUrl: relayWsUrl ?? DEFAULT_RELAY_WS_URL,
+    },
   );
 }
 
@@ -625,7 +637,9 @@ export async function installBridge(page: Page, options: BridgeOptions) {
   // Most specs seed a community so useCommunityInit doesn't show WelcomeSetup.
   // skipOnboardingSeed only controls the onboarding-completion flag.
   // The community is stamped with the active identity's pubkey so the strict
-  // migrateMachineOnboardingCompletion voucher recognises it.
+  // migrateMachineOnboardingCompletion voucher recognises it. The init script
+  // reads the seedActiveIdentity override key (if present) and falls back to
+  // the bridge identity's pubkey or DEFAULT_MOCK_PUBKEY for mock mode.
   if (!options.skipCommunitySeed) {
     const activePubkey = identity?.pubkey ?? DEFAULT_MOCK_PUBKEY;
     await seedDefaultCommunity(page, activePubkey, options.relayWsUrl);


### PR DESCRIPTION
After a dev-build sign-out+reset, the Rust webview wipe renames `~/Library/WebKit/<bundle_id>` — the correct path for installed .app builds. In `tauri dev` builds WebKit keys storage by process name (`buzz-desktop/`), so this wipe is a no-op and the frontend's `localStorage` survives the reset. The `migrateMachineOnboardingCompletion` heuristic added in #1936 then sees the stale active-community entry and auto-marks the freshly generated key as onboarded, skipping the machine-onboarding screen entirely — including the "Use an existing key" button.

## Fix A — pubkey-sound completion heuristic

`migrateMachineOnboardingCompletion` in `machineOnboarding.ts` now accepts `activeCommunityPubkey: string | null | undefined` instead of a bare `hasConfiguredCommunity: boolean`. The community arm grants only when the recorded pubkey **exactly matches** the current pubkey — both absent pubkey (`null`) and no community (`undefined`) do not vouch.

Community-creation paths now stamp `pubkey` at write time so that absent means genuinely pre-stamp:
- `App.tsx` first-community flow (`handleCommunityOnboardingConnect`): stamps `pubkey: currentPubkey ?? undefined`, where `currentPubkey` is threaded down from `MachineBootstrap`.
- `AppShell.tsx` `onAddCommunity` callback: stamps `community.pubkey ?? identityQuery.data?.pubkey`. Note: `AddCommunityDialog` never calls its `onSubmit` prop — it routes all submissions through `communityOnboarding.start` — so this callback is currently unreachable. The stamp is correct if the dead prop is ever wired up; it costs nothing now.

The other two migration arms (`completedLegacyOnboarding` — already pubkey-scoped — and `isSharedIdentity`) are unchanged. Sprout-era veterans are safe: `legacyCommunityStorage.ts` migrates `sprout-onboarding-complete.v1:<pubkey>` → `buzz-onboarding-complete.v1:<pubkey>` on first Buzz launch, and the v1 key predates community storage (#386 vs #409), so every legacy community's creator already holds a pubkey-scoped v1 entry.

Files: `machineOnboarding.ts`, `App.tsx`, `AppShell.tsx`

## Fix B — sign-out clears origin web storage on success

The confirm handler for "Delete My Data" in `ProfileSettingsCard.tsx` now calls `window.localStorage.clear()` + `window.sessionStorage.clear()` immediately after `signOut()` resolves. This closes the dev-build gap directly at the sign-out call site.

- Clears on the **resolve path only** — a failed sign-out must not wipe a still-running app.
- In production the Rust wipe already handles this; the clear is redundant but harmless.
- The restart may race the clear — acceptable. Fix A is the correctness gate; Fix B is belt-and-braces.

Files: `ProfileSettingsCard.tsx`

## E2E fixture fix — seedDefaultCommunity pubkey stamp

`seedDefaultCommunity` in `desktop/tests/helpers/bridge.ts` now stamps `pubkey` on the fixture community. The init script reads `buzz:e2e-identity-override.v1` from localStorage (written by `seedActiveIdentity`, which always runs before `installMockBridge` across all affected specs), validates its shape against the same three-field check as `readStoredIdentityOverride()` (`privateKey`, `pubkey`, and `username` must all be strings), and uses the override pubkey when valid. Malformed JSON, stored `null`, and partial objects fall through to the fallback pubkey (`identity?.pubkey ?? DEFAULT_MOCK_PUBKEY`). This ensures the fixture community's provenance matches the active identity the strict voucher checks.

Six previously-failing smoke specs now pass: `onboarding-avatar-skip.spec.ts` (×5) and `onboarding-docked-cta-screenshots.spec.ts` (×1). These specs seed `BLANK_TYLER_IDENTITY` via `seedActiveIdentity` + `skipOnboardingSeed: true`, so the default community was their only voucher.

Files: `desktop/tests/helpers/bridge.ts`

## Tests

Seven unit tests in `machineOnboarding.test.mjs`:

- Mismatched community pubkey → NOT vouched (original regression case)
- Matching community pubkey → vouched
- Absent community pubkey (`null`) → NOT vouched (stale current-format community + no stamp + fresh identity)
- No community (`undefined`) → NOT vouched
- Legacy `v1` completion key → granted
- Shared identity → always granted
- Already-completed v2 key → returns true immediately

Playwright coverage: `onboarding-avatar-skip.spec.ts` (5/5), `onboarding-docked-cta-screenshots.spec.ts` (3/3), `onboarding.spec.ts` (57/57), `deep-link-invite.spec.ts` (included in combined run above, no regressions).

## `import.meta.env` guard

`forceMachineOnboarding()` reads `import.meta.env.DEV` — Vite inlines this at bundle time, but the Node test runner has no `import.meta.env`. Added `?.DEV` optional chain so the function returns `false` in test context. No behavior change in any built artifact.
