### PR TITLE
fix(desktop): keep model settings populated when onboarding reopens

### DIFF
--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -120,17 +120,25 @@ function AgentDefaultsSection({
 
   const selectedRuntimes = React.useMemo(() => {
     const catalog = runtimesQuery.data ?? [];
-    if (selectedRuntimeIds.length > 0) {
-      return sortSelectedRuntimes(catalog, selectedRuntimeIds);
+    const storedSelection = sortSelectedRuntimes(catalog, selectedRuntimeIds);
+    if (storedSelection.length > 0) {
+      return storedSelection;
     }
-    // Reopening onboarding on this page can land here with no recorded
-    // harness selection (installs that predate selection persistence). Fall
-    // back to every installed harness rather than an empty dropdown.
-    return sortSelectedRuntimes(
-      catalog,
-      catalog.filter(runtimeIsInstalled).map((runtime) => runtime.id),
-    );
-  }, [runtimesQuery.data, selectedRuntimeIds]);
+    // Reopening onboarding on this page can land here with no usable harness
+    // selection — none was recorded (installs that predate selection
+    // persistence), or every recorded id has since left the catalog. Fall
+    // back to every installed harness rather than an empty dropdown, keeping
+    // the persisted preferred runtime listed even when it is no longer
+    // installed (e.g. logged out since onboarding) so the reconcile effect
+    // below resolves it as selected instead of rewriting the saved config.
+    const fallbackRuntimeIds = catalog
+      .filter(runtimeIsInstalled)
+      .map((runtime) => runtime.id);
+    if (config.preferred_runtime) {
+      fallbackRuntimeIds.push(config.preferred_runtime);
+    }
+    return sortSelectedRuntimes(catalog, fallbackRuntimeIds);
+  }, [config.preferred_runtime, runtimesQuery.data, selectedRuntimeIds]);
   const selectedRuntime = React.useMemo(() => {
     const preferredRuntime = selectedRuntimes.find(
       (runtime) => runtime.id === config.preferred_runtime,

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -25,7 +25,10 @@ import {
   type OnboardingTransitionDirection,
   OnboardingSlideTransition,
 } from "./OnboardingSlideTransition";
-import { ONBOARDING_RUNTIME_ORDER } from "./onboardingRuntimeSelection";
+import {
+  ONBOARDING_RUNTIME_ORDER,
+  runtimeIsInstalled,
+} from "./onboardingRuntimeSelection";
 import type { DefaultConfigStepActions } from "./types";
 
 type DefaultConfigStepProps = {
@@ -115,10 +118,19 @@ function AgentDefaultsSection({
     };
   }, []);
 
-  const selectedRuntimes = React.useMemo(
-    () => sortSelectedRuntimes(runtimesQuery.data ?? [], selectedRuntimeIds),
-    [runtimesQuery.data, selectedRuntimeIds],
-  );
+  const selectedRuntimes = React.useMemo(() => {
+    const catalog = runtimesQuery.data ?? [];
+    if (selectedRuntimeIds.length > 0) {
+      return sortSelectedRuntimes(catalog, selectedRuntimeIds);
+    }
+    // Reopening onboarding on this page can land here with no recorded
+    // harness selection (installs that predate selection persistence). Fall
+    // back to every installed harness rather than an empty dropdown.
+    return sortSelectedRuntimes(
+      catalog,
+      catalog.filter(runtimeIsInstalled).map((runtime) => runtime.id),
+    );
+  }, [runtimesQuery.data, selectedRuntimeIds]);
   const selectedRuntime = React.useMemo(() => {
     const preferredRuntime = selectedRuntimes.find(
       (runtime) => runtime.id === config.preferred_runtime,
@@ -129,10 +141,7 @@ function AgentDefaultsSection({
     selectedRuntime?.id ?? config.preferred_runtime ?? "";
   const configSurfaceLoading = isLoading || runtimesQuery.isLoading;
   const configSurfaceError =
-    runtimesQuery.isError ||
-    (!configSurfaceLoading &&
-      selectedRuntimeIds.length > 0 &&
-      !selectedRuntime);
+    runtimesQuery.isError || (!configSurfaceLoading && !selectedRuntime);
   const harnessOptions = React.useMemo(
     () =>
       selectedRuntimes.map((runtime) => ({

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -25,7 +25,9 @@ import {
 import { OnboardingFooterProvider } from "./OnboardingFooter";
 import {
   getPreferredRuntimeIdForSelection,
+  loadStoredOnboardingRuntimeSelection,
   runtimeSelectionNeedsDefaultsStep,
+  storeOnboardingRuntimeSelection,
 } from "./onboardingRuntimeSelection";
 import { OnboardingSlideTransition } from "./OnboardingSlideTransition";
 import { SetupStep } from "./SetupStep";
@@ -60,7 +62,11 @@ export function MachineOnboardingFlow({
     null,
   );
   const [selectedRuntimeIds, setSelectedRuntimeIds] = React.useState<string[]>(
-    [],
+    // Reopening onboarding directly on the config page (Back from the
+    // first-community screen) skips the setup step that normally populates
+    // the selection — restore the one the setup step last saved.
+    () =>
+      initialPage === "config" ? loadStoredOnboardingRuntimeSelection() : [],
   );
   const [isRuntimeSelectionSaving, setIsRuntimeSelectionSaving] =
     React.useState(false);
@@ -78,6 +84,7 @@ export function MachineOnboardingFlow({
       const sequence = runtimeSaveSequence.current + 1;
       runtimeSaveSequence.current = sequence;
       setSelectedRuntimeIds(nextRuntimeIds);
+      storeOnboardingRuntimeSelection(nextRuntimeIds);
       setRuntimeSelectionError(null);
       setIsRuntimeSelectionSaving(true);
 

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -22,6 +22,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import {
   runtimeCanAdvanceOnboarding,
   runtimeCanBeSelected,
+  runtimeIsInstalled,
 } from "./onboardingRuntimeSelection";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { RuntimeErrorTooltip } from "./RuntimeErrorTooltip";
@@ -102,10 +103,6 @@ function RuntimeSelectionIndicator({
       />
     </span>
   );
-}
-
-function runtimeIsInstalled(runtime: AcpRuntimeCatalogEntry) {
-  return runtimeCanBeSelected(runtime) && runtimeCanAdvanceOnboarding(runtime);
 }
 
 function useSetupFlashState(setupFlashToken: number) {

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -4,14 +4,31 @@ import test from "node:test";
 import {
   getDefaultModelConfigRuntimeId,
   getPreferredRuntimeIdForSelection,
+  loadStoredOnboardingRuntimeSelection,
   runtimeCanAdvanceOnboarding,
   runtimeCanBeSelected,
+  runtimeIsInstalled,
   runtimeSelectionNeedsDefaultModelConfig,
   runtimeSelectionNeedsDefaultsStep,
+  storeOnboardingRuntimeSelection,
 } from "./onboardingRuntimeSelection.ts";
 
 function runtime(id, availability, status) {
   return { id, availability, authStatus: { status } };
+}
+
+function createMemoryStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+    clear: () => values.clear(),
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    get length() {
+      return values.size;
+    },
+  };
 }
 
 test("known onboarding harnesses can be selected regardless of setup state", () => {
@@ -132,4 +149,72 @@ test("any harness selection drives the defaults step", () => {
   assert.equal(runtimeSelectionNeedsDefaultsStep(["codex"]), true);
   assert.equal(runtimeSelectionNeedsDefaultsStep(["claude", "codex"]), true);
   assert.equal(runtimeSelectionNeedsDefaultsStep(["goose"]), true);
+});
+
+test("installed means selectable and set up", () => {
+  assert.equal(
+    runtimeIsInstalled(runtime("claude", "available", "logged_in")),
+    true,
+  );
+  assert.equal(
+    runtimeIsInstalled(runtime("claude", "available", "logged_out")),
+    false,
+  );
+  assert.equal(
+    runtimeIsInstalled(runtime("custom", "available", "logged_in")),
+    false,
+  );
+});
+
+test("runtime selection round-trips through storage", () => {
+  const storage = createMemoryStorage();
+  storeOnboardingRuntimeSelection(["claude", "buzz-agent"], storage);
+  assert.deepEqual(loadStoredOnboardingRuntimeSelection(storage), [
+    "claude",
+    "buzz-agent",
+  ]);
+});
+
+test("storing overwrites the previous runtime selection", () => {
+  const storage = createMemoryStorage();
+  storeOnboardingRuntimeSelection(["claude", "codex"], storage);
+  storeOnboardingRuntimeSelection(["goose"], storage);
+  assert.deepEqual(loadStoredOnboardingRuntimeSelection(storage), ["goose"]);
+});
+
+test("loading with nothing stored returns an empty selection", () => {
+  assert.deepEqual(
+    loadStoredOnboardingRuntimeSelection(createMemoryStorage()),
+    [],
+  );
+});
+
+test("corrupt or non-array stored selections are treated as empty", () => {
+  assert.deepEqual(
+    loadStoredOnboardingRuntimeSelection(
+      createMemoryStorage({
+        "buzz-machine-onboarding-runtime-selection.v1": "{not json",
+      }),
+    ),
+    [],
+  );
+  assert.deepEqual(
+    loadStoredOnboardingRuntimeSelection(
+      createMemoryStorage({
+        "buzz-machine-onboarding-runtime-selection.v1": '{"claude":true}',
+      }),
+    ),
+    [],
+  );
+});
+
+test("non-string entries are dropped from a stored selection", () => {
+  const storage = createMemoryStorage({
+    "buzz-machine-onboarding-runtime-selection.v1":
+      '["claude", 7, null, "goose"]',
+  });
+  assert.deepEqual(loadStoredOnboardingRuntimeSelection(storage), [
+    "claude",
+    "goose",
+  ]);
 });

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -1,3 +1,4 @@
+import { setLocalStorageItemWithRecovery } from "@/shared/lib/localStorageQuota";
 import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
 
 export const ONBOARDING_RUNTIME_ORDER = [
@@ -6,6 +7,43 @@ export const ONBOARDING_RUNTIME_ORDER = [
   "goose",
   "buzz-agent",
 ];
+
+const RUNTIME_SELECTION_STORAGE_KEY =
+  "buzz-machine-onboarding-runtime-selection.v1";
+
+/**
+ * Restores the harness selection saved by the setup step. Machine onboarding
+ * can be reopened directly on the config page (Back from the first-community
+ * screen), which skips the setup step that normally populates the selection.
+ */
+export function loadStoredOnboardingRuntimeSelection(
+  storage: Storage = localStorage,
+): string[] {
+  try {
+    const raw = storage.getItem(RUNTIME_SELECTION_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (runtimeId): runtimeId is string => typeof runtimeId === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Persists the setup step's harness selection for config-page reopens. */
+export function storeOnboardingRuntimeSelection(
+  runtimeIds: readonly string[],
+  storage: Storage = localStorage,
+): void {
+  const serialized = JSON.stringify(runtimeIds);
+  if (typeof localStorage !== "undefined" && storage === localStorage) {
+    setLocalStorageItemWithRecovery(RUNTIME_SELECTION_STORAGE_KEY, serialized);
+  } else {
+    storage.setItem(RUNTIME_SELECTION_STORAGE_KEY, serialized);
+  }
+}
 
 const KNOWN_ONBOARDING_RUNTIME_IDS = new Set<string>(ONBOARDING_RUNTIME_ORDER);
 
@@ -65,4 +103,8 @@ export function runtimeCanAdvanceOnboarding(runtime: AcpRuntimeCatalogEntry) {
     (runtime.authStatus.status === "logged_in" ||
       runtime.authStatus.status === "not_applicable")
   );
+}
+
+export function runtimeIsInstalled(runtime: AcpRuntimeCatalogEntry) {
+  return runtimeCanBeSelected(runtime) && runtimeCanAdvanceOnboarding(runtime);
 }

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -1349,6 +1349,117 @@ test("returning to agent defaults without a stored selection lists installed har
   await page.keyboard.press("Escape");
 });
 
+test("fallback keeps a no-longer-installed preferred harness without rewriting the saved config", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        availableRuntime("claude", { status: "logged_out" }),
+        availableRuntime("goose", { status: "not_applicable" }),
+        availableRuntime("buzz-agent", { status: "not_applicable" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+
+  await navigateToConfigPage(page);
+  await page.getByTestId("onboarding-finish").click();
+  await expect(page.getByText("Join or create a community")).toBeVisible();
+
+  // Simulate an install that predates selection persistence and whose saved
+  // preference is a harness that is no longer installed (Claude logged out
+  // since onboarding).
+  await page.evaluate(async () => {
+    window.localStorage.removeItem(
+      "buzz-machine-onboarding-runtime-selection.v1",
+    );
+    await (
+      window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+          command: string,
+          payload: unknown,
+        ) => Promise<unknown>;
+      }
+    ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("set_global_agent_config", {
+      config: {
+        env_vars: {},
+        provider: null,
+        // A model the mock's Claude catalog knows, so onboarding's
+        // stale-model healing (a separate, intended cleanup) stays inert and
+        // any config write observed below is the reconcile-effect rewrite.
+        model: "claude-opus-4-20250514",
+        preferred_runtime: "claude",
+      },
+    });
+  });
+
+  await page.getByTestId("welcome-setup-back").click();
+  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+
+  // The persisted preferred harness stays listed and selected even though it
+  // is no longer installed — resolving to another harness here would make the
+  // reconcile effect silently rewrite the saved config on open.
+  const harnessSelect = page.getByTestId("global-agent-default-harness");
+  await expect(harnessSelect).toHaveText("Claude");
+  await harnessSelect.click();
+  await expect(
+    page.getByTestId("global-agent-default-harness-option-claude"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("global-agent-default-harness-option-buzz-agent"),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  const savedConfig = await readSavedConfig(page);
+  expect(savedConfig?.preferred_runtime).toBe("claude");
+  expect(savedConfig?.model).toBe("claude-opus-4-20250514");
+});
+
+test("stored selection whose harnesses left the catalog falls back instead of erroring", async ({
+  page,
+}) => {
+  await installMockBridge(page, undefined, {
+    skipCommunitySeed: true,
+    skipOnboardingSeed: true,
+  });
+  await page.goto("/");
+
+  await navigateToConfigPage(page);
+  await page.getByTestId("onboarding-finish").click();
+  await expect(page.getByText("Join or create a community")).toBeVisible();
+
+  // A stored selection can go stale — every recorded harness id has since
+  // dropped out of the runtime catalog (e.g. uninstalled between sessions).
+  await page.evaluate(() =>
+    window.localStorage.setItem(
+      "buzz-machine-onboarding-runtime-selection.v1",
+      JSON.stringify(["retired-harness"]),
+    ),
+  );
+
+  await page.getByTestId("welcome-setup-back").click();
+  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+
+  // The stale selection behaves like a missing one: installed harnesses are
+  // listed instead of the error surface.
+  await expect(
+    page.getByText("Couldn't load harness settings. Go back and try again."),
+  ).toHaveCount(0);
+  const harnessSelect = page.getByTestId("global-agent-default-harness");
+  await expect(harnessSelect).toHaveText("Buzz");
+  await harnessSelect.click();
+  await expect(
+    page.getByTestId("global-agent-default-harness-option-buzz-agent"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("global-agent-default-harness-option-goose"),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+});
+
 // ---------------------------------------------------------------------------
 // B1 regression: rapid consecutive edits must not lose the later change
 // ---------------------------------------------------------------------------

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -1289,6 +1289,64 @@ test("community setup back button returns to agent defaults", async ({
 
   await page.getByTestId("welcome-setup-back").click();
   await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+
+  // Regression: reopening remounts the onboarding flow, which used to lose
+  // the setup step's harness selection — both dropdowns came back empty.
+  const harnessSelect = page.getByTestId("global-agent-default-harness");
+  await expect(harnessSelect).toHaveText("Buzz");
+  await harnessSelect.click();
+  await expect(
+    page.getByTestId("global-agent-default-harness-option-buzz-agent"),
+  ).toBeVisible();
+  // The restored selection is exact — installed-but-unselected harnesses
+  // (the fallback list) must not appear.
+  await expect(
+    page.getByTestId("global-agent-default-harness-option-goose"),
+  ).toHaveCount(0);
+  await page.keyboard.press("Escape");
+  await expect(page.locator("#global-agent-provider")).toBeVisible();
+  await expect(page.locator("#global-agent-model")).toBeVisible();
+});
+
+test("returning to agent defaults without a stored selection lists installed harnesses", async ({
+  page,
+}) => {
+  await installMockBridge(page, undefined, {
+    skipCommunitySeed: true,
+    skipOnboardingSeed: true,
+  });
+  await page.goto("/");
+
+  await navigateToConfigPage(page);
+  await page.getByTestId("onboarding-finish").click();
+  await expect(page.getByText("Join or create a community")).toBeVisible();
+
+  // Installs that completed onboarding before selection persistence shipped
+  // have no stored selection to restore.
+  await page.evaluate(() =>
+    window.localStorage.removeItem(
+      "buzz-machine-onboarding-runtime-selection.v1",
+    ),
+  );
+
+  await page.getByTestId("welcome-setup-back").click();
+  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+
+  // Falls back to every installed harness instead of an empty dropdown; the
+  // persisted preferred runtime stays selected.
+  const harnessSelect = page.getByTestId("global-agent-default-harness");
+  await expect(harnessSelect).toHaveText("Buzz");
+  await harnessSelect.click();
+  await expect(
+    page.getByTestId("global-agent-default-harness-option-buzz-agent"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("global-agent-default-harness-option-goose"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("global-agent-default-harness-option-claude"),
+  ).toHaveCount(0);
+  await page.keyboard.press("Escape");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reopening machine onboarding directly on the config page (Back from the first-community screen) remounts the onboarding flow, which lost the setup step's harness selection — the harness and model dropdowns came back empty.

- Persist the setup step's harness selection to localStorage (`buzz-machine-onboarding-runtime-selection.v1`, written via the quota-recovery helper) and restore it when `MachineOnboardingFlow` mounts directly on the config page.
- When no stored selection exists (installs that completed onboarding before selection persistence shipped), `DefaultConfigStep` now falls back to listing every installed harness instead of rendering an empty dropdown, and the error state accounts for the fallback.
- Move `runtimeIsInstalled` out of `SetupStep` into `onboardingRuntimeSelection.ts` so both steps share it.

## Testing

- Unit tests for the storage round-trip (overwrite, missing, corrupt/non-array payloads, non-string entries) and `runtimeIsInstalled`.
- Playwright e2e coverage for both paths: reopening restores the exact stored selection (unselected harnesses excluded), and reopening with no stored selection lists installed harnesses while keeping the persisted preferred runtime selected.
- Full local gate passed on push (desktop check/test, Tauri tests, Rust tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

Full flow on this branch: pick a harness → provider/model auto-populate on the config page → **Finish** → **Back** from the first-community screen. Before this fix, the reopened config page lost the setup step's harness selection — the default-harness dropdown had no value or options and the model fields were blank. It now restores the saved selection with all fields intact.

![Onboarding model settings persist when the config page reopens](https://d24qwcpro867f5.cloudfront.net/repos/block/buzz/prs/2249/onboarding-model-settings-demo.gif)

<sub>Recorded against the e2e mock bridge. [MP4 version](https://d24qwcpro867f5.cloudfront.net/repos/block/buzz/prs/2249/onboarding-model-settings-demo.mp4)</sub>
