### PR TITLE
feat(media): preserve text-family MIME on uploads (.md, .txt, .csv, .json)

### DIFF
--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -61,19 +61,84 @@ pub fn build_imeta_tag(d: &BlobDescriptor) -> Vec<String> {
 }
 
 /// MIME types accepted for upload.
+///
+/// This mirrors what the relay's upload pipelines actually accept:
+///   - image and video paths — canonical media MIMEs.
+///   - generic-file path — documents, archives, and text-family types that
+///     the relay stores as attachments served with `nosniff` +
+///     `Content-Disposition: attachment` + `CSP: default-src 'none'`.
+///
+/// The CLI treats this list as a friendly pre-flight; the relay remains the
+/// authoritative validator.
 const ALLOWED_MIMES: &[&str] = &[
+    // Images (thumbnailed path).
     "image/jpeg",
     "image/png",
     "image/gif",
     "image/webp",
+    // Video (streaming path).
     "video/mp4",
+    // Documents.
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.oasis.opendocument.text",
+    "application/vnd.oasis.opendocument.spreadsheet",
+    "application/vnd.oasis.opendocument.presentation",
+    "application/rtf",
+    "application/epub+zip",
+    // Archives.
+    "application/zip",
+    "application/gzip",
+    "application/x-tar",
+    "application/x-7z-compressed",
+    "application/x-rar-compressed",
+    "application/vnd.rar",
+    "application/x-bzip2",
+    "application/x-xz",
+    "application/zstd",
+    // Text-family — no magic bytes, resolved from file extension.
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "application/json",
 ];
+
+/// Text-family MIMEs — no magic bytes; resolved from file extension.
+///
+/// This is the CLI-side mirror of the relay's text-family hint allowlist
+/// (`buzz-media::validation::hinted_text_family_mime`). If you extend one,
+/// extend the other — the relay only honors these four MIMEs as `Content-Type`
+/// hints, and anything else will be flattened to `application/octet-stream`
+/// server-side.
+///
+/// `.md` maps to `text/markdown` per RFC 7763.
+fn mime_from_extension(path: &std::path::Path) -> Option<&'static str> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    Some(match ext.as_str() {
+        "md" | "markdown" => "text/markdown",
+        "txt" | "log" => "text/plain",
+        "csv" => "text/csv",
+        "json" => "application/json",
+        _ => return None,
+    })
+}
 
 /// Maximum file size for image uploads (50 MB).
 const MAX_IMAGE_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Maximum file size for video uploads (500 MB).
 const MAX_VIDEO_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Maximum file size for generic (non-image, non-video) uploads (100 MB).
+///
+/// Mirrors the relay's `MediaConfig::max_file_bytes` default. The relay
+/// enforces the authoritative cap.
+const MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
 
 /// Sign a NIP-98 HTTP auth event (kind:27235) and return the Authorization header value.
 ///
@@ -1108,20 +1173,33 @@ impl BuzzClient {
         let bytes = std::fs::read(file_path)
             .map_err(|e| CliError::Other(format!("failed to read {file_path}: {e}")))?;
 
-        // 2. Detect MIME from magic bytes
+        // 2. Detect MIME. Magic bytes first (authoritative); fall back to the
+        //    file extension for text-family types that have no signature
+        //    (.md, .txt, .csv, .json). Anything still unknown is rejected
+        //    early — the relay would flatten it to application/octet-stream
+        //    anyway, and refusing here gives a clearer error.
         let mime = infer::get(&bytes)
             .map(|t| t.mime_type().to_string())
-            .unwrap_or_else(|| "application/octet-stream".to_string());
+            .or_else(|| {
+                mime_from_extension(std::path::Path::new(file_path)).map(str::to_string)
+            })
+            .ok_or_else(|| {
+                CliError::Usage(format!(
+                    "cannot determine MIME type for {file_path}: no magic bytes and unrecognised extension"
+                ))
+            })?;
 
         if !ALLOWED_MIMES.contains(&mime.as_str()) {
             return Err(CliError::Usage(format!("unsupported file type: {mime}")));
         }
 
-        // 3. Size check
+        // 3. Size check — pick the cap that matches the destination pipeline.
         let max = if mime.starts_with("video/") {
             MAX_VIDEO_BYTES
-        } else {
+        } else if mime.starts_with("image/") {
             MAX_IMAGE_BYTES
+        } else {
+            MAX_FILE_BYTES
         };
         if bytes.len() as u64 > max {
             return Err(CliError::Usage(format!(
@@ -2297,9 +2375,11 @@ mod retry_policy_tests {
 #[cfg(test)]
 mod tests {
     use super::{
-        advance_query_cursor, create_response_with_id, extract_relay_response_field, BuzzClient,
+        advance_query_cursor, create_response_with_id, extract_relay_response_field,
+        mime_from_extension, BuzzClient,
     };
     use nostr::{EventBuilder, Keys, Kind, Tag};
+    use std::path::Path;
 
     #[test]
     fn query_cursor_uses_last_events_composite_sort_key() {
@@ -2327,6 +2407,64 @@ mod tests {
             &[serde_json::json!({"id": "not-an-event-id", "created_at": 10})]
         )
         .is_err());
+    }
+
+    #[test]
+    fn mime_from_extension_maps_markdown() {
+        assert_eq!(
+            mime_from_extension(Path::new("plan.md")),
+            Some("text/markdown")
+        );
+        assert_eq!(
+            mime_from_extension(Path::new("plan.markdown")),
+            Some("text/markdown")
+        );
+    }
+
+    #[test]
+    fn mime_from_extension_maps_text_family() {
+        assert_eq!(
+            mime_from_extension(Path::new("notes.txt")),
+            Some("text/plain")
+        );
+        assert_eq!(
+            mime_from_extension(Path::new("run.log")),
+            Some("text/plain")
+        );
+        assert_eq!(mime_from_extension(Path::new("rows.csv")), Some("text/csv"));
+        assert_eq!(
+            mime_from_extension(Path::new("blob.json")),
+            Some("application/json")
+        );
+    }
+
+    #[test]
+    fn mime_from_extension_is_case_insensitive() {
+        assert_eq!(
+            mime_from_extension(Path::new("PLAN.MD")),
+            Some("text/markdown")
+        );
+        assert_eq!(
+            mime_from_extension(Path::new("Data.JSON")),
+            Some("application/json")
+        );
+    }
+
+    #[test]
+    fn mime_from_extension_ignores_unrelated_extensions() {
+        assert_eq!(mime_from_extension(Path::new("plan.exe")), None);
+        assert_eq!(mime_from_extension(Path::new("plan.html")), None);
+        assert_eq!(mime_from_extension(Path::new("plan")), None);
+        // A leading dot is not an extension per std::path::Path.
+        assert_eq!(mime_from_extension(Path::new(".hidden")), None);
+    }
+
+    #[test]
+    fn mime_from_extension_handles_multiple_dots() {
+        assert_eq!(
+            mime_from_extension(Path::new("archive.tar.md")),
+            Some("text/markdown")
+        );
     }
 
     #[test]

--- a/crates/buzz-media/src/upload.rs
+++ b/crates/buzz-media/src/upload.rs
@@ -240,6 +240,13 @@ pub async fn process_upload(
 /// transport layer), validated against the deny-list + size cap, stored, and
 /// recorded in a minimal sidecar. No thumbnail, dimensions, or duration.
 ///
+/// `content_type_hint` is the caller's declared `Content-Type` header. It is
+/// consulted only when magic-byte sniffing produces no signature, and only
+/// against a small text-family allowlist (see `hinted_text_family_mime`). It
+/// exists so text formats without magic bytes — `.md`, `.txt`, `.json`, `.csv`
+/// — round-trip as their real MIME instead of being flattened to
+/// `application/octet-stream`.
+///
 /// The resulting blob is served with `Content-Disposition: attachment`, so the
 /// client always downloads it rather than rendering it inline.
 pub async fn process_file_upload(
@@ -249,6 +256,7 @@ pub async fn process_file_upload(
     auth_event: &nostr::Event,
     body: Bytes,
     attribution: Option<UploadAttribution>,
+    content_type_hint: Option<String>,
 ) -> Result<BlobDescriptor, MediaError> {
     process_buffered_upload(
         BufferedUploadInput {
@@ -259,7 +267,7 @@ pub async fn process_file_upload(
             body,
             attribution,
         },
-        |bytes, cfg| validate_file_content(bytes, cfg),
+        move |bytes, cfg| validate_file_content(bytes, cfg, content_type_hint.as_deref()),
         |input| async move {
             // Minimal sidecar — no thumbnail/dim/blurhash/duration for generic files.
             let meta = BlobMeta {

--- a/crates/buzz-media/src/validation.rs
+++ b/crates/buzz-media/src/validation.rs
@@ -135,10 +135,42 @@ fn file_mime_to_ext(mime: &str) -> Option<&'static str> {
         // Data / text
         "application/json" => "json",
         "text/csv" => "csv",
+        "text/markdown" => "md",
         "text/plain" => "txt",
         _ => return None,
     };
     Some(ext)
+}
+
+/// Text-family MIME types the generic-file path will accept as a hint from the
+/// caller's `Content-Type` when magic-byte sniffing produces no signature.
+///
+/// These are formats that legitimately lack magic bytes (plain text, markdown,
+/// CSV, JSON) but that we still want to preserve as their declared MIME rather
+/// than flatten to `application/octet-stream`. All are safe to store under this
+/// path because:
+///   1. `X-Content-Type-Options: nosniff` prevents browsers from re-sniffing
+///      them into active content on serve.
+///   2. `Content-Disposition: attachment` forces a download.
+///   3. `Content-Security-Policy: default-src 'none'` neutralises any residual
+///      execution surface.
+///
+/// The list is intentionally small. `text/html`, `image/svg+xml`, and
+/// `application/xhtml+xml` are the classic stored-XSS carriers and are already
+/// on the deny list; we do not admit them here even if the caller hints them.
+///
+/// Callers pass the raw header value; this fn strips any `; charset=...`
+/// parameter and lower-cases the type/subtype before matching.
+fn hinted_text_family_mime(hint: &str) -> Option<&'static str> {
+    // Strip parameters like `; charset=utf-8`, trim, lower-case.
+    let base = hint.split(';').next()?.trim().to_ascii_lowercase();
+    match base.as_str() {
+        "text/markdown" => Some("text/markdown"),
+        "text/plain" => Some("text/plain"),
+        "text/csv" => Some("text/csv"),
+        "application/json" => Some("application/json"),
+        _ => None,
+    }
 }
 
 /// Validate uploaded bytes for the **generic file** upload path.
@@ -151,14 +183,22 @@ fn file_mime_to_ext(mime: &str) -> Option<&'static str> {
 ///   3. Magic-byte sniffing where possible.
 ///
 /// Files with no detectable signature (plain text, CSV, source code, JSON —
-/// none of which have magic bytes) are accepted as `application/octet-stream`.
-/// They are always served as downloads, so an un-sniffable file can never
-/// execute in the app.
+/// none of which have magic bytes) fall back to the caller's `content_type_hint`
+/// when it names a safe text-family MIME (see [`hinted_text_family_mime`]).
+/// Anything else lands as `application/octet-stream`. Either way the served
+/// blob carries `Content-Disposition: attachment`, `nosniff`, and
+/// `CSP: default-src 'none'`, so an un-sniffable file cannot execute in the app.
+///
+/// `content_type_hint` is the caller's raw `Content-Type` header (or the
+/// equivalent). It is only consulted when magic-byte sniffing yields nothing;
+/// it never overrides a positive sniff and it never admits a MIME outside the
+/// small text-family allowlist.
 ///
 /// Returns `(mime, ext)`.
 pub fn validate_file_content(
     bytes: &[u8],
     config: &MediaConfig,
+    content_type_hint: Option<&str>,
 ) -> Result<(String, String), MediaError> {
     // 1. Size cap.
     if bytes.len() as u64 > config.max_file_bytes {
@@ -179,7 +219,8 @@ pub fn validate_file_content(
     }
 
     // 2. Sniff. `None` means no magic signature (text/csv/json/source) — that's
-    //    fine for the generic path; treat as opaque binary served as a download.
+    //    fine for the generic path; treat as opaque binary served as a download,
+    //    unless the caller hinted a safe text-family MIME.
     match infer::get(bytes) {
         Some(kind) => {
             let mime = kind.mime_type().to_string();
@@ -202,7 +243,17 @@ pub fn validate_file_content(
                 .unwrap_or_else(|| kind.extension().to_string());
             Ok((mime, ext))
         }
-        None => Ok(("application/octet-stream".to_string(), "bin".to_string())),
+        None => match content_type_hint.and_then(hinted_text_family_mime) {
+            Some(hinted) => {
+                // Safe by construction — hinted_text_family_mime only returns
+                // MIMEs whose `file_mime_to_ext` mapping is defined.
+                let ext = file_mime_to_ext(hinted)
+                    .expect("hinted_text_family_mime returned an unmapped MIME")
+                    .to_string();
+                Ok((hinted.to_string(), ext))
+            }
+            None => Ok(("application/octet-stream".to_string(), "bin".to_string())),
+        },
     }
 }
 
@@ -1333,10 +1384,10 @@ mod tests {
     fn test_generic_file_path_cannot_bypass_media_validation() {
         let config = test_config();
         assert!(
-            matches!(validate_file_content(TINY_JPEG, &config), Err(MediaError::DisallowedContentType(m)) if m == "image/jpeg")
+            matches!(validate_file_content(TINY_JPEG, &config, None), Err(MediaError::DisallowedContentType(m)) if m == "image/jpeg")
         );
         assert!(
-            matches!(validate_file_content(MP4_FTYP_MAGIC, &config), Err(MediaError::DisallowedContentType(m)) if m == "video/mp4")
+            matches!(validate_file_content(MP4_FTYP_MAGIC, &config, None), Err(MediaError::DisallowedContentType(m)) if m == "video/mp4")
         );
 
         let proprietary_major = b"\x00\x00\x00\x18ftypPRIV\x00\x00\x00\x00isommp42";
@@ -1344,7 +1395,7 @@ mod tests {
         assert!(looks_like_iso_bmff(proprietary_major));
         assert!(looks_like_mp4_iso_bmff(proprietary_major));
         assert!(
-            matches!(validate_file_content(proprietary_major, &config), Err(MediaError::DisallowedContentType(m)) if m == "application/iso-bmff")
+            matches!(validate_file_content(proprietary_major, &config, None), Err(MediaError::DisallowedContentType(m)) if m == "application/iso-bmff")
         );
     }
 
@@ -1370,7 +1421,7 @@ mod tests {
             );
             assert!(
                 matches!(
-                    validate_file_content(bytes, &config),
+                    validate_file_content(bytes, &config, None),
                     Err(MediaError::DisallowedContentType(mime)) if mime.starts_with("audio/")
                 ),
                 "generic path accepted {name}"
@@ -2360,7 +2411,7 @@ mod tests {
     #[test]
     fn test_validate_file_pdf_accepted() {
         let config = test_config();
-        let (mime, ext) = validate_file_content(TINY_PDF, &config).unwrap();
+        let (mime, ext) = validate_file_content(TINY_PDF, &config, None).unwrap();
         assert_eq!(mime, "application/pdf");
         assert_eq!(ext, "pdf");
     }
@@ -2368,7 +2419,7 @@ mod tests {
     #[test]
     fn test_validate_file_zip_accepted() {
         let config = test_config();
-        let (mime, ext) = validate_file_content(TINY_ZIP, &config).unwrap();
+        let (mime, ext) = validate_file_content(TINY_ZIP, &config, None).unwrap();
         assert_eq!(mime, "application/zip");
         assert_eq!(ext, "zip");
     }
@@ -2379,7 +2430,8 @@ mod tests {
         // accepts it as opaque binary served as a download (the common Slack
         // case: .txt, .csv, .md, source code).
         let config = test_config();
-        let (mime, ext) = validate_file_content(b"hello, this is a text file\n", &config).unwrap();
+        let (mime, ext) =
+            validate_file_content(b"hello, this is a text file\n", &config, None).unwrap();
         assert_eq!(mime, "application/octet-stream");
         assert_eq!(ext, "bin");
     }
@@ -2389,7 +2441,7 @@ mod tests {
         // HTML is a stored-XSS carrier — blocked even though headers neutralise it.
         let config = test_config();
         let html = b"<!DOCTYPE html><html><body><script>alert(1)</script></body></html>";
-        let result = validate_file_content(html, &config);
+        let result = validate_file_content(html, &config, None);
         assert!(
             matches!(result, Err(MediaError::DisallowedContentType(ref m)) if m == "text/html"),
             "expected DisallowedContentType(text/html), got {result:?}"
@@ -2400,7 +2452,7 @@ mod tests {
     fn test_validate_file_too_large_rejected() {
         let mut config = test_config();
         config.max_file_bytes = 10;
-        let result = validate_file_content(TINY_PDF, &config);
+        let result = validate_file_content(TINY_PDF, &config, None);
         assert!(matches!(result, Err(MediaError::FileTooLarge { .. })));
     }
 
@@ -2415,5 +2467,95 @@ mod tests {
         assert!(!serve_inline("application/octet-stream"));
         assert!(!serve_inline("audio/mpeg"));
         assert!(!serve_inline("text/plain"));
+    }
+
+    #[test]
+    fn test_validate_file_markdown_hint_accepted() {
+        // .md files have no magic bytes — infer returns None. With a
+        // Content-Type hint of `text/markdown`, the generic path should
+        // preserve the declared MIME (and the `md` extension) instead of
+        // flattening to application/octet-stream.
+        let config = test_config();
+        let md = b"# Design Doc\n\nHello, world.\n";
+        assert!(infer::get(md).is_none(), "sanity: markdown has no magic");
+        let (mime, ext) = validate_file_content(md, &config, Some("text/markdown")).unwrap();
+        assert_eq!(mime, "text/markdown");
+        assert_eq!(ext, "md");
+    }
+
+    #[test]
+    fn test_validate_file_text_family_hints_accepted() {
+        let config = test_config();
+        let body = b"col1,col2\n1,2\n";
+        for (hint, expected_mime, expected_ext) in [
+            ("text/plain", "text/plain", "txt"),
+            ("text/markdown", "text/markdown", "md"),
+            ("text/csv", "text/csv", "csv"),
+            ("application/json", "application/json", "json"),
+        ] {
+            let (mime, ext) = validate_file_content(body, &config, Some(hint)).unwrap();
+            assert_eq!(mime, expected_mime, "for hint {hint}");
+            assert_eq!(ext, expected_ext, "for hint {hint}");
+        }
+    }
+
+    #[test]
+    fn test_validate_file_hint_tolerates_charset_parameter() {
+        // RFC 7231 permits a `charset=...` parameter — accept it.
+        let config = test_config();
+        let (mime, ext) =
+            validate_file_content(b"hello\n", &config, Some("text/markdown; charset=utf-8"))
+                .unwrap();
+        assert_eq!(mime, "text/markdown");
+        assert_eq!(ext, "md");
+    }
+
+    #[test]
+    fn test_validate_file_hint_case_insensitive() {
+        let config = test_config();
+        let (mime, ext) =
+            validate_file_content(b"hello\n", &config, Some("TEXT/Markdown")).unwrap();
+        assert_eq!(mime, "text/markdown");
+        assert_eq!(ext, "md");
+    }
+
+    #[test]
+    fn test_validate_file_hint_ignored_when_sniff_succeeds() {
+        // A caller lying about a PDF being markdown must not change what we
+        // store — the hint is consulted only when sniffing yields nothing.
+        let config = test_config();
+        let (mime, ext) = validate_file_content(TINY_PDF, &config, Some("text/markdown")).unwrap();
+        assert_eq!(mime, "application/pdf");
+        assert_eq!(ext, "pdf");
+    }
+
+    #[test]
+    fn test_validate_file_unrecognised_hint_falls_back_to_octet_stream() {
+        // A hint that isn't in the text-family allowlist is silently ignored.
+        // The file lands as application/octet-stream — no way to smuggle
+        // text/html, image/svg+xml, etc. onto the generic path via the hint.
+        let config = test_config();
+        let (mime, ext) = validate_file_content(b"anything\n", &config, Some("text/html")).unwrap();
+        assert_eq!(mime, "application/octet-stream");
+        assert_eq!(ext, "bin");
+
+        let (mime, ext) =
+            validate_file_content(b"anything\n", &config, Some("image/svg+xml")).unwrap();
+        assert_eq!(mime, "application/octet-stream");
+        assert_eq!(ext, "bin");
+    }
+
+    #[test]
+    fn test_validate_file_hint_does_not_bypass_deny_list_for_sniffed_types() {
+        // Even a plausible text hint cannot rescue a file whose magic bytes
+        // sniff as denied active-content (defence in depth for sniff-based
+        // rejection).
+        let config = test_config();
+        let html = b"<!DOCTYPE html><html><body></body></html>";
+        let result = validate_file_content(html, &config, Some("text/markdown"));
+        assert!(
+            matches!(result, Err(MediaError::DisallowedContentType(ref m)) if m == "text/html"),
+            "expected DisallowedContentType(text/html), got {result:?}"
+        );
     }
 }

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -295,8 +295,12 @@ async fn upload_attribution(
 /// Expects:
 ///   - `Authorization: Nostr <base64(kind:24242 event)>` — Blossom auth
 ///   - `X-SHA-256: <hex>` — Required per BUD-11
-///   - `Content-Type` is advisory only; a bounded body prefix selects the
-///     streaming video path from actual bytes
+///   - `Content-Type` is advisory only. Pipeline selection is driven by a
+///     bounded body prefix, not the header. On the generic-file path the
+///     header is consulted as a *hint* — and only when magic-byte sniffing
+///     yields nothing — against a small text-family allowlist
+///     (`text/markdown`, `text/plain`, `text/csv`, `application/json`) so
+///     magic-less text formats round-trip as their declared MIME.
 ///   - Raw binary body (the file bytes)
 ///
 /// Returns a [`BlobDescriptor`] JSON on success.
@@ -387,6 +391,10 @@ pub async fn upload_blob(
                 .unwrap_or_else(|| "application/octet-stream".to_string());
             return Err(MediaError::DisallowedContentType(mime));
         } else {
+            let content_type_hint = headers
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_owned());
             buzz_media::process_file_upload(
                 &state.media_storage,
                 &state.config.media,
@@ -394,6 +402,7 @@ pub async fn upload_blob(
                 &auth.auth_event,
                 bytes,
                 attribution,
+                content_type_hint,
             )
             .await?
         }


### PR DESCRIPTION
## Summary

`buzz upload file` currently rejects Markdown, plain text, JSON, and CSV files with `unsupported file type: application/octet-stream`. Root cause: the CLI uses [`infer`](https://docs.rs/infer) for MIME detection, which is magic-byte-based and returns `None` for text-family formats (they have no magic bytes). The CLI then falls back to `application/octet-stream`, which its allowlist rejects.

The relay's generic-file path already accepts these files, but it stores/serves them as `application/octet-stream` because it also relies on magic-byte sniffing and ignores the client's `Content-Type` header.

This PR fixes both layers so `.md`, `.txt`, `.log`, `.csv`, and `.json` uploads round-trip with their proper MIME type and file-extension URL suffix.

## Changes

### CLI (`crates/buzz-cli/src/client.rs`)

- New `mime_from_extension()` helper — extension→MIME fallback used when `infer::get` returns `None`.
- Broadens `ALLOWED_MIMES` to include the generic-file types the relay already accepts (`application/pdf`, `text/plain`, `text/markdown`, `text/csv`, `application/json`, common archives, audio).
- Raises the CLI-side size cap for non-image/non-video uploads to 100 MB (matches relay generic-file limit).

### Media validation (`crates/buzz-media/src/validation.rs`)

- `validate_file_content` now accepts an optional `content_type_hint`.
- When `infer` can't sniff, and the hint is in a narrow text-family allowlist (`text/markdown`, `text/plain`, `text/csv`, `application/json`), the hint is trusted for storage.
- Files remain served with `Content-Disposition: attachment` and `X-Content-Type-Options: nosniff`, so no browser can be tricked into executing them regardless of the stored MIME.

### Media upload pipeline (`crates/buzz-media/src/upload.rs`)

- Threads the hint through `process_file_upload`.

### Relay HTTP layer (`crates/buzz-relay/src/api/media.rs`)

- Reads the incoming request `Content-Type` and forwards it as the hint.

## Security

The hint is only consulted when `infer` finds no magic bytes. It is restricted to a fixed allowlist of inert text formats — nothing that a browser sniffer could turn into executable content is admissible. Downloads remain forced (`Content-Disposition: attachment`) with `X-Content-Type-Options: nosniff`.

## Tests

- 7 new tests in `buzz-media` covering the hint allowlist, hint-with-no-sniff, hint-conflicts-with-sniff, and disallowed-hint cases.
- 5 new tests in `buzz-cli` covering `mime_from_extension` for markdown, text family, case handling, unrelated extensions, and multi-dot filenames.
- Full `buzz-media` (87) and `buzz-cli` (255) suites pass.
- `cargo clippy -- -D warnings` clean on `buzz-cli`, `buzz-media`, `buzz-relay`.
- `cargo fmt --all --check` clean.
- Pre-push hooks (rust-tests, desktop-tauri-test, check-push-org, branch-skew) all green.

## Manual verification

Before:
```
$ buzz upload file plan.md
{"error":"user_error","message":"unsupported file type: application/octet-stream"}
```

After: `.md` uploads succeed, land on the relay stored as `text/markdown`, and are served with a `.md` URL suffix.
