### PR TITLE
feat(agents): add Pi ACP runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Agents are part of the room, not haunted cron jobs.
 |---|---|---|
 | Relay, channels, threads, DMs, canvases, media, search, audit log | Mobile clients (iOS + Android, Flutter) | Web-of-trust reputation across relays |
 | Desktop app (Tauri + React) | Workflow approval gates (infra exists, glue still drying) | Push notifications |
-| `buzz-cli` (agent-first, JSON in / JSON out) + ACP harness (Goose, Codex, Claude Code) | Huddle lifecycle events | Culture features |
+| `buzz-cli` (agent-first, JSON in / JSON out) + ACP harness (Goose, Codex, Claude Code, Pi) | Huddle lifecycle events | Culture features |
 | YAML workflows: message / reaction / schedule / webhook triggers | | |
 | Git events (NIP-34: patches, repo announcements, status) | | |
 | Git hosting backend | | |
@@ -174,7 +174,7 @@ If you'd rather point buzz at a different bash-compatible shell, set `BUZZ_SHELL
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                             Clients                                     │
 │  Human client         AI agent              CLI / scripts               │
-│  (Buzz desktop)       (Goose, Codex, ...)   (buzz-cli, agents)          │
+│  (Buzz desktop)       (Goose, Pi, ...)      (buzz-cli, agents)          │
 │       │               ┌──────────────┐               │                  │
 │       │               │  buzz-acp  │                 │                  │
 │       │               │  (ACP ↔ MCP) │               │                  │
@@ -204,7 +204,7 @@ A Rust workspace of focused crates. Single source of truth: the relay. See [ARCH
 
 **Services** — `buzz-db` (Postgres) · `buzz-auth` (NIP-42/98 Schnorr auth, rate limiting) · `buzz-pubsub` (Redis, presence, typing) · `buzz-search` (Postgres FTS) · `buzz-audit` (hash-chain log). Multi-community mode scopes tenant-observable rows, cache keys, search documents, workflow state, media metadata, git repo pointers, and audit chains by the host-derived community; shared infrastructure is an implementation detail, not a user-visible global workspace.
 
-**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (ACP harness for Goose/Codex/Claude Code) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
+**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (ACP harness for Goose/Codex/Claude Code/Pi) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
 
 **Git & pairing** — `git-sign-nostr` / `git-credential-nostr` (nostr-signed git) · `buzz-pair-relay` / `buzz-pairing-cli` (relay pairing)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -179,7 +179,7 @@ header fallback. There is no REST API for fetching message threads — use
 
 ## ACP Harness (optional, end-to-end with a real agent)
 
-`buzz-acp` connects an ACP-speaking agent (goose, codex, claude code,
+`buzz-acp` connects an ACP-speaking agent (goose, codex, claude code, Pi,
 buzz-agent) to the relay. The harness listens for events, drives the
 agent over stdio, and the agent replies through MCP tools.
 
@@ -222,7 +222,7 @@ buzz-acp                                    # foreground; logs to stdout (run in
 
 > **Using a different ACP agent?** The default recipe assumes `goose` is on
 > `$PATH` and configured (`goose --version` should print). For codex / claude
-> code / buzz-agent, set `BUZZ_ACP_AGENT_COMMAND` and `BUZZ_ACP_AGENT_ARGS`
+> code / Pi / buzz-agent, set `BUZZ_ACP_AGENT_COMMAND` and `BUZZ_ACP_AGENT_ARGS`
 > accordingly — see `crates/buzz-acp/README.md`. Without these, buzz-acp
 > will fail to spawn the agent subprocess on startup.
 

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -9,7 +9,7 @@ Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
                                        (send_message, etc.)
 ```
 
-Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
+Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)), and **Pi** (via [pi-acp](https://github.com/svkozak/pi-acp)).
 
 ## Prerequisites
 
@@ -70,6 +70,22 @@ buzz-acp
 ```
 
 > **API key note:** `codex-acp` always attempts a ChatGPT WebSocket login first, which logs a `426 Upgrade Required` error. This is expected and non-fatal — it falls back to `OPENAI_API_KEY` automatically. Set `OPENAI_API_KEY` to ensure it has a working fallback.
+
+## Running with Pi
+
+[pi-acp](https://github.com/svkozak/pi-acp) exposes Pi over ACP while preserving Pi's models, credentials, skills, extensions, and project context.
+
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+npm install -g pi-acp
+
+# Configure credentials once if needed.
+pi
+# Then select pi-acp in Buzz, or launch the harness directly:
+BUZZ_ACP_AGENT_COMMAND=pi-acp buzz-acp
+```
+
+Pi discovers Buzz's generated `buzz-cli` skill from the canonical `.agents/skills` directory, so no Pi-specific skill copy is needed.
 
 ## Running with Claude Code
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -612,7 +612,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "pi" | "pi-acp" | "buzz-agent" => Some(Vec::new()),
         _ => None,
     }
 }
@@ -1433,7 +1433,7 @@ mod tests {
     }
 
     #[test]
-    fn normalizes_codex_and_claude_args_to_empty() {
+    fn normalizes_zero_arg_adapters_to_empty() {
         assert_eq!(
             normalize_agent_args("codex-acp", Vec::new()),
             Vec::<String>::new()
@@ -1456,6 +1456,10 @@ mod tests {
         );
         assert_eq!(
             normalize_agent_args("claude-agent-acp", vec!["acp".into()]),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            normalize_agent_args("pi-acp", vec!["acp".into()]),
             Vec::<String>::new()
         );
     }

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -16,6 +16,7 @@ pub(crate) use runtime_metadata::KnownAcpRuntime;
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const PI_AVATAR_URL: &str = "https://pi.dev/logo-auto.svg";
 const BUZZ_AGENT_AVATAR_URL: &str =
     "https://raw.githubusercontent.com/block/buzz/refs/heads/main/crates/buzz-agent/buzz-agent.png";
 
@@ -156,6 +157,38 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+    },
+    KnownAcpRuntime {
+        id: "pi",
+        label: "Pi",
+        commands: &["pi-acp"],
+        aliases: &["pi-acp"],
+        avatar_url: PI_AVATAR_URL,
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: Some("pi"),
+        cli_install_commands: &["curl -fsSL https://pi.dev/install.sh | sh"],
+        cli_install_commands_windows: &["npm install -g @earendil-works/pi-coding-agent --ignore-scripts"],
+        adapter_install_commands: &["npm install -g pi-acp"],
+        install_instructions_url: "https://github.com/svkozak/pi-acp",
+        cli_install_hint: "Install Pi via the official installer.",
+        adapter_install_hint: "Install the Pi ACP adapter via npm.",
+        // Pi discovers the canonical `.agents/skills` directory directly.
+        skill_dir: None,
+        supports_acp_model_switching: true,
+        model_env_var: None,
+        provider_env_var: None,
+        provider_locked: false,
+        default_env: &[],
+        config_file_path: Some("~/.pi/agent/settings.json"),
+        config_file_format: Some("json"),
+        supports_acp_native_config: false,
+        thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
+        required_normalized_fields: &[],
+        login_hint: None,
+        auth_probe_args: None,
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -344,7 +377,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "pi" | "pi-acp" | "buzz-agent" => Some(Vec::new()),
         _ => None,
     }
 }
@@ -1315,5 +1348,7 @@ pub fn managed_agent_avatar_url(command: &str) -> Option<String> {
     Some(runtime.avatar_url.to_string())
 }
 
+#[cfg(test)]
+mod pi_tests;
 #[cfg(test)]
 mod tests;

--- a/desktop/src-tauri/src/managed_agents/discovery/pi_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/pi_tests.rs
@@ -1,0 +1,31 @@
+use super::{
+    known_acp_runtime_exact, managed_agent_avatar_url, normalize_agent_args, PI_AVATAR_URL,
+};
+
+#[test]
+fn resolves_pi_avatar_for_adapter_path() {
+    assert_eq!(
+        managed_agent_avatar_url("/usr/local/bin/pi-acp"),
+        Some(PI_AVATAR_URL.to_string())
+    );
+}
+
+#[test]
+fn normalizes_pi_args_to_empty() {
+    assert_eq!(
+        normalize_agent_args("pi-acp", Vec::new()),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        normalize_agent_args("pi-acp", vec!["acp".into()]),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn pi_runtime_has_install_commands() {
+    let pi = known_acp_runtime_exact("pi").unwrap();
+    assert!(!pi.cli_install_commands.is_empty());
+    assert_eq!(pi.commands, &["pi-acp"]);
+    assert_eq!(pi.adapter_install_commands, &["npm install -g pi-acp"]);
+}

--- a/desktop/src-tauri/src/managed_agents/managed_node_paths.rs
+++ b/desktop/src-tauri/src/managed_agents/managed_node_paths.rs
@@ -46,7 +46,7 @@ pub(crate) fn buzz_managed_command_path(command: &str, basename: &str) -> Option
     if command.contains(std::path::MAIN_SEPARATOR)
         || !matches!(
             command,
-            "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "node" | "npm"
+            "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "pi-acp" | "pi" | "node" | "npm"
         )
     {
         return None;

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -38,6 +38,9 @@ pub(crate) const KNOWN_AGENT_BINARIES: &[&str] = &[
     "claude_code_acp",
     "codex-acp",
     "codex_acp",
+    "pi-acp",
+    "pi_acp",
+    "pi",
     "goose",
     // buzz-dev-mcp's multicall personalities (rg, tree, buzz,
     // git-credential-nostr, git-sign-nostr) are short-lived per-tool-call

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -20,6 +20,7 @@ import { FlappingBee } from "@/shared/ui/buzz-logo/FlappingBee";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import {
+  ONBOARDING_RUNTIME_ORDER,
   runtimeCanAdvanceOnboarding,
   runtimeCanBeSelected,
 } from "./onboardingRuntimeSelection";
@@ -703,13 +704,12 @@ function RuntimeProvidersSection({
   selectedRuntimeIds: readonly string[];
 }) {
   const { errorMessage, isChecking, items } = runtimeProviders;
-  const runtimeOrder = ["claude", "codex", "goose", "buzz-agent"];
   const orderedItems = [...items].sort((left, right) => {
-    const leftIndex = runtimeOrder.indexOf(left.id);
-    const rightIndex = runtimeOrder.indexOf(right.id);
+    const leftIndex = ONBOARDING_RUNTIME_ORDER.indexOf(left.id);
+    const rightIndex = ONBOARDING_RUNTIME_ORDER.indexOf(right.id);
     return (
-      (leftIndex === -1 ? runtimeOrder.length : leftIndex) -
-      (rightIndex === -1 ? runtimeOrder.length : rightIndex)
+      (leftIndex === -1 ? ONBOARDING_RUNTIME_ORDER.length : leftIndex) -
+      (rightIndex === -1 ? ONBOARDING_RUNTIME_ORDER.length : rightIndex)
     );
   });
   const installMutation = useInstallAcpRuntimeMutation();

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -42,7 +42,7 @@ test("known onboarding harnesses can be selected regardless of setup state", () 
     );
   }
 
-  for (const id of ["buzz-agent", "goose"]) {
+  for (const id of ["buzz-agent", "goose", "pi"]) {
     assert.equal(
       runtimeCanBeSelected(runtime(id, "available", "not_applicable")),
       true,
@@ -98,7 +98,13 @@ test("provider-backed selections drive the default model config step", () => {
     true,
   );
   assert.equal(
-    getDefaultModelConfigRuntimeId(["claude", "codex", "goose", "buzz-agent"]),
+    getDefaultModelConfigRuntimeId([
+      "claude",
+      "codex",
+      "goose",
+      "pi",
+      "buzz-agent",
+    ]),
     "buzz-agent",
   );
 });
@@ -108,19 +114,21 @@ test("onboarding display order drives the preferred runtime", () => {
     getPreferredRuntimeIdForSelection([
       "buzz-agent",
       "goose",
+      "pi",
       "codex",
       "claude",
     ]),
     "claude",
   );
   assert.equal(
-    getPreferredRuntimeIdForSelection(["buzz-agent", "goose", "codex"]),
+    getPreferredRuntimeIdForSelection(["buzz-agent", "pi", "goose", "codex"]),
     "codex",
   );
   assert.equal(
     getPreferredRuntimeIdForSelection(["buzz-agent", "goose"]),
     "goose",
   );
+  assert.equal(getPreferredRuntimeIdForSelection(["buzz-agent", "pi"]), "pi");
   assert.equal(getPreferredRuntimeIdForSelection(["buzz-agent"]), "buzz-agent");
   assert.equal(getPreferredRuntimeIdForSelection(["custom"]), "custom");
   assert.equal(getPreferredRuntimeIdForSelection([]), null);
@@ -132,4 +140,5 @@ test("any harness selection drives the defaults step", () => {
   assert.equal(runtimeSelectionNeedsDefaultsStep(["codex"]), true);
   assert.equal(runtimeSelectionNeedsDefaultsStep(["claude", "codex"]), true);
   assert.equal(runtimeSelectionNeedsDefaultsStep(["goose"]), true);
+  assert.equal(runtimeSelectionNeedsDefaultsStep(["pi"]), true);
 });

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -4,6 +4,7 @@ export const ONBOARDING_RUNTIME_ORDER = [
   "claude",
   "codex",
   "goose",
+  "pi",
   "buzz-agent",
 ];
 
@@ -56,7 +57,9 @@ export function runtimeCanBeSelected(runtime: AcpRuntimeCatalogEntry) {
       runtime.authStatus.status === "logged_out"
     );
   }
-  return runtime.id === "buzz-agent" || runtime.id === "goose";
+  return (
+    runtime.id === "buzz-agent" || runtime.id === "goose" || runtime.id === "pi"
+  );
 }
 
 export function runtimeCanAdvanceOnboarding(runtime: AcpRuntimeCatalogEntry) {

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -405,6 +405,7 @@ test("runtime cards use the selected onboarding order", async ({ page }) => {
       acpRuntimesCatalog: [
         availableRuntime("buzz-agent", { status: "not_applicable" }),
         availableRuntime("goose", { status: "not_applicable" }),
+        availableRuntime("pi", { status: "not_applicable" }),
         availableRuntime("codex", { status: "logged_in" }),
         availableRuntime("claude", { status: "logged_in" }),
       ],
@@ -423,6 +424,7 @@ test("runtime cards use the selected onboarding order", async ({ page }) => {
     "onboarding-runtime-claude",
     "onboarding-runtime-codex",
     "onboarding-runtime-goose",
+    "onboarding-runtime-pi",
     "onboarding-runtime-buzz-agent",
   ]);
   await expect(


### PR DESCRIPTION
## Summary

Adds [Pi](https://pi.dev) as a first-class managed agent runtime through [`pi-acp`](https://github.com/svkozak/pi-acp).

Closes #2256.

## Why

Pi already speaks ACP through an adapter, but Buzz users currently have to configure it as a custom command. That bypasses Buzz's runtime discovery, guided setup, onboarding, model switching, and process management.

## What changed

- adds Pi metadata to the desktop ACP runtime catalog
- discovers `pi` and `pi-acp` and offers guided installation
- launches `pi-acp` with the correct zero-argument ACP convention
- exposes Pi in onboarding and keeps the display order in one shared constant
- allows Buzz's managed Node prefix to resolve Pi binaries
- includes Pi processes in managed-agent cleanup
- relies on Pi's native `.agents/skills` discovery for the generated `buzz-cli` skill
- documents direct Pi usage with `buzz-acp`
- adds focused Rust, frontend, and Playwright coverage

## Key decisions

- Uses the small `pi-acp` adapter rather than changing Buzz's ACP harness protocol.
- Keeps Pi's existing credentials, model configuration, extensions, and project context intact.
- Does not add a Pi-specific skill copy because Pi already discovers Buzz's canonical `.agents/skills` bridge.

## Validation

- [x] `just ci`
- [x] `just test`
- [x] targeted onboarding Playwright test
- [x] `buzz-acp models` successfully completed an ACP model-discovery handshake with `pi-acp@0.0.31`
- [x] live local relay test:
  1. started `buzz-relay`
  2. connected `buzz-acp` with `BUZZ_ACP_AGENT_COMMAND=pi-acp`
  3. mentioned the Pi agent in a private channel
  4. confirmed the Pi-owned identity posted the exact reply `PI_BUZZ_E2E_OK` through `buzz-cli`

## Checklist

- [x] New behavior has tests
- [x] User-facing setup is documented
- [x] No new `unwrap()` in production code
- [x] No unsafe code
