### PR TITLE
fix(desktop): refresh cached channel member names

### DIFF
--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use tauri::{AppHandle, State};
 
 use super::agent_model_process::run_agent_models_command;
+use super::agent_update_rollback::{rollback_failed_agent_update, AgentUpdateRollback};
 
 use crate::{
     app_state::AppState,
@@ -778,7 +779,7 @@ pub async fn update_managed_agent(
     state: State<'_, AppState>,
 ) -> Result<UpdateManagedAgentResponse, String> {
     // Phase 1: local save (synchronous, under lock)
-    let (summary, sync_params) = {
+    let (summary, sync_params, rollback) = {
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -795,6 +796,7 @@ pub async fn update_managed_agent(
         }
 
         let record = find_managed_agent_mut(&mut records, &input.pubkey)?;
+        let previous_record = record.clone();
 
         let mut name_changed = false;
         if let Some(name_update) = input.name {
@@ -938,37 +940,39 @@ pub async fn update_managed_agent(
             let personas = load_personas(&app).unwrap_or_default();
             build_managed_agent_summary(&app, record, &runtimes, &personas)?
         };
-        (summary, sync_params)
+        let rollback = name_changed.then(|| AgentUpdateRollback::new(previous_record, record));
+        (summary, sync_params, rollback)
     }; // lock dropped here
 
     try_regenerate_nest(&app);
 
-    // Phase 2: relay profile sync (async, best-effort, outside lock)
-    let profile_sync_error =
-        if let Some((agent_keys, relay_url, display_name, avatar_url, auth_tag)) = sync_params {
-            match sync_managed_agent_profile(
-                &state,
-                &relay_url,
-                &agent_keys,
-                &display_name,
-                avatar_url.as_deref(),
-                auth_tag.as_deref(),
-            )
-            .await
-            {
-                Ok(()) => None,
-                Err(e) => {
-                    eprintln!("buzz-desktop: relay profile sync failed after rename: {e}");
-                    Some(e)
-                }
-            }
-        } else {
-            None
-        };
+    // Phase 2: relay profile sync (async, outside lock). A rename is committed
+    // only when this succeeds; otherwise restore the complete pre-edit record
+    // so Desktop and the relay keep one authoritative name.
+    if let Some((agent_keys, relay_url, display_name, avatar_url, auth_tag)) = sync_params {
+        if let Err(sync_error) = sync_managed_agent_profile(
+            &state,
+            &relay_url,
+            &agent_keys,
+            &display_name,
+            avatar_url.as_deref(),
+            auth_tag.as_deref(),
+        )
+        .await
+        {
+            let rollback = rollback.ok_or_else(|| {
+                "missing local rollback state after relay profile sync failure".to_string()
+            })?;
+            rollback_failed_agent_update(&app, &state, &summary.pubkey, rollback)?;
+            return Err(format!(
+                "Agent rename failed because its relay profile could not be updated. No changes were saved: {sync_error}"
+            ));
+        }
+    }
 
     Ok(UpdateManagedAgentResponse {
         agent: summary,
-        profile_sync_error,
+        profile_sync_error: None,
     })
 }
 

--- a/desktop/src-tauri/src/commands/agent_update_rollback.rs
+++ b/desktop/src-tauri/src/commands/agent_update_rollback.rs
@@ -1,0 +1,197 @@
+use tauri::AppHandle;
+
+use crate::{
+    app_state::AppState,
+    managed_agents::{
+        load_managed_agents, save_managed_agents, try_regenerate_nest, ManagedAgentRecord,
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct AgentUpdateRollback {
+    attempted_record: ManagedAgentRecord,
+    previous_record: ManagedAgentRecord,
+}
+
+impl AgentUpdateRollback {
+    pub(super) fn new(previous_record: ManagedAgentRecord, attempted: &ManagedAgentRecord) -> Self {
+        Self {
+            attempted_record: attempted.clone(),
+            previous_record,
+        }
+    }
+}
+
+fn copy_runtime_state(from: &ManagedAgentRecord, to: &mut ManagedAgentRecord) {
+    to.runtime_pid = from.runtime_pid;
+    to.backend = from.backend.clone();
+    to.backend_agent_id.clone_from(&from.backend_agent_id);
+    to.provider_binary_path
+        .clone_from(&from.provider_binary_path);
+    to.last_started_at.clone_from(&from.last_started_at);
+    to.last_stopped_at.clone_from(&from.last_stopped_at);
+    to.last_exit_code = from.last_exit_code;
+    to.last_error.clone_from(&from.last_error);
+    to.last_error_code = from.last_error_code;
+}
+
+fn same_configuration(left: &ManagedAgentRecord, right: &ManagedAgentRecord) -> bool {
+    let mut normalized_left = left.clone();
+    copy_runtime_state(right, &mut normalized_left);
+    normalized_left.updated_at.clone_from(&right.updated_at);
+    normalized_left == *right
+}
+
+fn restore_agent_update(
+    records: &mut [ManagedAgentRecord],
+    pubkey: &str,
+    rollback: AgentUpdateRollback,
+) -> Result<(), String> {
+    let current = records
+        .iter_mut()
+        .find(|record| record.pubkey == pubkey)
+        .ok_or_else(|| format!("agent {pubkey} not found while rolling back failed rename"))?;
+
+    if !same_configuration(current, &rollback.attempted_record) {
+        return Err(format!(
+            "agent {pubkey} changed again before the failed rename could be rolled back"
+        ));
+    }
+
+    let runtime_changed = {
+        let mut attempted_with_current_runtime = rollback.attempted_record.clone();
+        copy_runtime_state(current, &mut attempted_with_current_runtime);
+        attempted_with_current_runtime != rollback.attempted_record
+    };
+    let mut restored = rollback.previous_record;
+    copy_runtime_state(current, &mut restored);
+    if runtime_changed {
+        restored.updated_at.clone_from(&current.updated_at);
+    }
+    *current = restored;
+    Ok(())
+}
+
+pub(super) fn rollback_failed_agent_update(
+    app: &AppHandle,
+    state: &AppState,
+    pubkey: &str,
+    rollback: AgentUpdateRollback,
+) -> Result<(), String> {
+    {
+        let _store_guard = state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|error| error.to_string())?;
+        let mut records = load_managed_agents(app)?;
+        restore_agent_update(&mut records, pubkey, rollback)?;
+        save_managed_agents(app, &records)?;
+        let restored = records
+            .iter()
+            .find(|record| record.pubkey == pubkey)
+            .ok_or_else(|| format!("agent {pubkey} not found after failed rename rollback"))?;
+        super::agents::retain_managed_agent_pending(app, state, restored);
+    }
+    try_regenerate_nest(app);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(name: &str, updated_at: &str) -> ManagedAgentRecord {
+        let mut record: ManagedAgentRecord = serde_json::from_str(
+            r#"{
+                "pubkey": "abcd1234",
+                "name": "test-agent",
+                "private_key_nsec": "nsec1fake",
+                "relay_url": "wss://localhost:3000",
+                "acp_command": "buzz-acp",
+                "agent_command": "goose",
+                "agent_args": [],
+                "mcp_command": "",
+                "turn_timeout_seconds": 320,
+                "system_prompt": null,
+                "model": null,
+                "provider": null,
+                "env_vars": {},
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "last_started_at": null,
+                "last_stopped_at": null,
+                "last_exit_code": null,
+                "last_error": null
+            }"#,
+        )
+        .expect("sample managed agent record");
+        record.name = name.to_string();
+        record.updated_at = updated_at.to_string();
+        record
+    }
+
+    #[test]
+    fn failed_profile_sync_restores_the_entire_agent_update() {
+        let previous = record("Old name", "before");
+        let mut attempted = previous.clone();
+        attempted.name = "New name".to_string();
+        attempted.model = Some("new-model".to_string());
+        attempted.updated_at = "attempt".to_string();
+        let rollback = AgentUpdateRollback::new(previous, &attempted);
+        let mut records = vec![attempted];
+
+        restore_agent_update(&mut records, "abcd1234", rollback)
+            .expect("matching attempted update rolls back");
+
+        assert_eq!(records[0].name, "Old name");
+        assert_eq!(records[0].model, None);
+        assert_eq!(records[0].updated_at, "before");
+    }
+
+    #[test]
+    fn failed_profile_sync_does_not_overwrite_a_newer_agent_update() {
+        let previous = record("Old name", "before");
+        let mut attempted = previous.clone();
+        attempted.name = "New name".to_string();
+        attempted.updated_at = "attempt".to_string();
+        let rollback = AgentUpdateRollback::new(previous, &attempted);
+        let mut newer = attempted;
+        newer.name = "Newest name".to_string();
+        newer.updated_at = "newer".to_string();
+        let mut records = vec![newer];
+
+        let error = restore_agent_update(&mut records, "abcd1234", rollback)
+            .expect_err("a concurrent update must not be overwritten");
+
+        assert!(error.contains("changed again"));
+        assert_eq!(records[0].name, "Newest name");
+        assert_eq!(records[0].updated_at, "newer");
+    }
+
+    #[test]
+    fn failed_profile_sync_preserves_runtime_churn_while_restoring_configuration() {
+        let previous = record("Old name", "before");
+        let mut attempted = previous.clone();
+        attempted.name = "New name".to_string();
+        attempted.model = Some("new-model".to_string());
+        attempted.updated_at = "attempt".to_string();
+        let rollback = AgentUpdateRollback::new(previous, &attempted);
+        let mut churned = attempted;
+        churned.runtime_pid = None;
+        churned.last_stopped_at = Some("stopped".to_string());
+        churned.last_exit_code = Some(1);
+        churned.last_error = Some("harness exited".to_string());
+        churned.updated_at = "runtime-change".to_string();
+        let mut records = vec![churned];
+
+        restore_agent_update(&mut records, "abcd1234", rollback)
+            .expect("runtime-only churn must not prevent rollback");
+
+        assert_eq!(records[0].name, "Old name");
+        assert_eq!(records[0].model, None);
+        assert_eq!(records[0].last_stopped_at.as_deref(), Some("stopped"));
+        assert_eq!(records[0].last_exit_code, Some(1));
+        assert_eq!(records[0].last_error.as_deref(), Some("harness exited"));
+        assert_eq!(records[0].updated_at, "runtime-change");
+    }
+}

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod agent_model_process;
 mod agent_models;
 mod agent_providers;
 mod agent_settings;
+mod agent_update_rollback;
 mod agents;
 mod canvas;
 mod channel_templates;

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -188,7 +188,7 @@ pub struct RelayAgentInfo {
     #[serde(default)]
     pub respond_to_allowlist: Vec<String>,
 }
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ManagedAgentRecord {
     pub pubkey: String,
     pub name: String,

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -441,7 +441,7 @@ pub async fn sync_managed_agent_profile(
     if !response.status().is_success() {
         let msg = relay_error_message(response).await;
         return Err(format!(
-            "Created the agent, but could not sync its profile metadata: {msg}"
+            "Could not sync the agent's profile metadata: {msg}"
         ));
     }
 

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -16,6 +16,7 @@ import {
   channelsQueryKey,
   upsertCachedChannelMember,
 } from "@/features/channels/hooks";
+import { updateCachedChannelMemberDisplayName } from "@/features/channels/channelMemberProfileCache";
 import { evictUsersBatchEntries } from "@/features/profile/hooks";
 import {
   createManagedAgent,
@@ -359,7 +360,7 @@ export function useUpdateManagedAgentMutation() {
 
   return useMutation({
     mutationFn: (input: UpdateManagedAgentInput) => updateManagedAgent(input),
-    onSuccess: (result) => {
+    onSuccess: async (result, variables) => {
       queryClient.setQueryData<ManagedAgent[]>(
         managedAgentsQueryKey,
         (current) => {
@@ -369,6 +370,14 @@ export function useUpdateManagedAgentMutation() {
           );
         },
       );
+
+      if (variables.name !== undefined && !result.profileSyncError) {
+        await updateCachedChannelMemberDisplayName(
+          queryClient,
+          result.agent.pubkey,
+          result.agent.name,
+        );
+      }
     },
     onSettled: async (_data, _error, variables) => {
       // Backend republishes kind:0 on a name change (sync_managed_agent_profile),

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -726,9 +726,6 @@ export function AgentInstanceEditDialog({
           autoRestartOnConfigChange,
         );
       }
-      if (result.profileSyncError) {
-        console.warn("Relay profile sync failed:", result.profileSyncError);
-      }
       handleOpenChange(false);
       onUpdated?.(result.agent);
       // The auto-restart policy deliberately never fires for a stopped or

--- a/desktop/src/features/channels/channelMemberProfileCache.test.mjs
+++ b/desktop/src/features/channels/channelMemberProfileCache.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+
+import { updateCachedChannelMemberDisplayName } from "./channelMemberProfileCache.ts";
+
+function member(pubkey, displayName, overrides = {}) {
+  return {
+    pubkey,
+    role: "bot",
+    isAgent: true,
+    joinedAt: null,
+    displayName,
+    ...overrides,
+  };
+}
+
+test("updateCachedChannelMemberDisplayName_updatesOnlyMatchingMemberQueries", async () => {
+  const queryClient = new QueryClient();
+  const matchingKey = ["channels", "general", "members"];
+  const unrelatedMembersKey = ["channels", "random", "members"];
+  const detailKey = ["channels", "general", "detail"];
+
+  queryClient.setQueryData(matchingKey, [
+    member("AABB", "Old name"),
+    member("ccdd", "Someone else", { role: "member", isAgent: false }),
+  ]);
+  queryClient.setQueryData(unrelatedMembersKey, [member("eeff", "Other")]);
+  queryClient.setQueryData(detailKey, { name: "General" });
+
+  await updateCachedChannelMemberDisplayName(queryClient, "aabb", "New name");
+
+  assert.deepEqual(queryClient.getQueryData(matchingKey), [
+    member("AABB", "New name"),
+    member("ccdd", "Someone else", { role: "member", isAgent: false }),
+  ]);
+  assert.deepEqual(queryClient.getQueryData(unrelatedMembersKey), [
+    member("eeff", "Other"),
+  ]);
+  assert.deepEqual(queryClient.getQueryData(detailKey), { name: "General" });
+  assert.equal(queryClient.getQueryState(matchingKey)?.isInvalidated, true);
+  assert.equal(
+    queryClient.getQueryState(unrelatedMembersKey)?.isInvalidated,
+    false,
+  );
+  assert.equal(queryClient.getQueryState(detailKey)?.isInvalidated, false);
+});
+
+test("updateCachedChannelMemberDisplayName_doesNotRefetchMatchingQueries", async () => {
+  let fetchCount = 0;
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        queryFn: async () => {
+          fetchCount += 1;
+          return [member("aabb", "Relay name")];
+        },
+      },
+    },
+  });
+  const matchingKey = ["channels", "general", "members"];
+  queryClient.setQueryData(matchingKey, [member("aabb", "Old name")]);
+
+  await updateCachedChannelMemberDisplayName(queryClient, "aabb", "New name");
+
+  assert.equal(fetchCount, 0);
+  assert.equal(
+    queryClient.getQueryData(matchingKey)[0].displayName,
+    "New name",
+  );
+});
+
+test("updateCachedChannelMemberDisplayName_cancelsStaleInFlightFetches", async () => {
+  const queryClient = new QueryClient();
+  const matchingKey = ["channels", "general", "members"];
+  let resolveFetch;
+
+  queryClient.setQueryData(matchingKey, [member("aabb", "Old name")]);
+  const fetch = queryClient.fetchQuery({
+    queryKey: matchingKey,
+    queryFn: () =>
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+  });
+
+  await updateCachedChannelMemberDisplayName(queryClient, "aabb", "New name");
+  resolveFetch([member("aabb", "Stale relay name")]);
+  await fetch.catch(() => undefined);
+
+  assert.equal(
+    queryClient.getQueryData(matchingKey)[0].displayName,
+    "New name",
+  );
+});
+
+test("updateCachedChannelMemberDisplayName_restartsFirstLoadMemberFetches", async () => {
+  const queryClient = new QueryClient();
+  const matchingKey = ["channels", "general", "members"];
+  const fetchResolvers = [];
+  const observer = new QueryObserver(queryClient, {
+    queryKey: matchingKey,
+    queryFn: () =>
+      new Promise((resolve) => {
+        fetchResolvers.push(resolve);
+      }),
+  });
+  let resolveObservedData;
+  const observedData = new Promise((resolve) => {
+    resolveObservedData = resolve;
+  });
+  const unsubscribe = observer.subscribe((result) => {
+    if (result.data) {
+      resolveObservedData();
+    }
+  });
+
+  assert.equal(fetchResolvers.length, 1);
+  await updateCachedChannelMemberDisplayName(queryClient, "aabb", "New name");
+
+  assert.equal(fetchResolvers.length, 2);
+  fetchResolvers[1]([member("aabb", "New name")]);
+  fetchResolvers[0]([member("aabb", "Stale relay name")]);
+  await observedData;
+
+  assert.equal(
+    queryClient.getQueryData(matchingKey)[0].displayName,
+    "New name",
+  );
+  unsubscribe();
+});

--- a/desktop/src/features/channels/channelMemberProfileCache.ts
+++ b/desktop/src/features/channels/channelMemberProfileCache.ts
@@ -1,0 +1,93 @@
+import type { Query, QueryClient } from "@tanstack/react-query";
+
+import type { ChannelMember } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+function isChannelMembersQuery(query: Query): boolean {
+  const { queryKey } = query;
+  return (
+    queryKey.length === 3 &&
+    queryKey[0] === "channels" &&
+    typeof queryKey[1] === "string" &&
+    queryKey[2] === "members"
+  );
+}
+
+function queryContainsMember(query: Query, normalizedPubkey: string): boolean {
+  if (!isChannelMembersQuery(query) || !Array.isArray(query.state.data)) {
+    return false;
+  }
+
+  return (query.state.data as ChannelMember[]).some(
+    (member) => normalizePubkey(member.pubkey) === normalizedPubkey,
+  );
+}
+
+/**
+ * Applies a profile rename to every cached channel-member row for one pubkey.
+ * Matching queries are marked stale without refetching, so active channels
+ * update immediately while a rename never fans out into one relay query per
+ * cached channel.
+ */
+export async function updateCachedChannelMemberDisplayName(
+  queryClient: QueryClient,
+  pubkey: string,
+  displayName: string | null,
+): Promise<void> {
+  const normalizedPubkey = normalizePubkey(pubkey);
+  const matchingMemberPredicate = (query: Query) =>
+    queryContainsMember(query, normalizedPubkey);
+  const matchingMemberQueryHashes = new Set(
+    queryClient
+      .getQueryCache()
+      .findAll({ predicate: matchingMemberPredicate })
+      .map((query) => query.queryHash),
+  );
+  const fetchingMemberQueryHashes = new Set(
+    queryClient
+      .getQueryCache()
+      .findAll({
+        predicate: (query) =>
+          isChannelMembersQuery(query) &&
+          query.state.fetchStatus === "fetching",
+      })
+      .map((query) => query.queryHash),
+  );
+
+  // A first-load query has no rows to inspect yet, so cancel every member
+  // fetch already in flight. Restart only requests without a matching cached
+  // row after applying the local rename; this bounds network work to requests
+  // that were already underway while preventing pre-rename snapshots from
+  // winning.
+  await queryClient.cancelQueries({
+    predicate: (query) => fetchingMemberQueryHashes.has(query.queryHash),
+  });
+
+  queryClient.setQueriesData<ChannelMember[]>(
+    { predicate: matchingMemberPredicate },
+    (current) => {
+      if (!current) {
+        return current;
+      }
+
+      return current.map((member) =>
+        normalizePubkey(member.pubkey) === normalizedPubkey &&
+        member.displayName !== displayName
+          ? { ...member, displayName }
+          : member,
+      );
+    },
+  );
+
+  await queryClient.invalidateQueries({
+    predicate: matchingMemberPredicate,
+    refetchType: "none",
+  });
+
+  void queryClient.refetchQueries({
+    predicate: (query) =>
+      fetchingMemberQueryHashes.has(query.queryHash) &&
+      !matchingMemberQueryHashes.has(query.queryHash),
+    type: "all",
+  });
+}

--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -42,6 +42,7 @@ import {
   resolveAvatarDataUrl,
 } from "@/features/profile/lib/selfProfileStorage";
 import { useCommunities } from "@/features/communities/useCommunities";
+import { updateCachedChannelMemberDisplayName } from "@/features/channels/channelMemberProfileCache";
 
 export const profileQueryKey = ["profile"] as const;
 export const contactListQueryKey = (pubkey: string) =>
@@ -511,6 +512,12 @@ export function useUpdateProfileMutation() {
         void persistSelfProfile(relayUrl, pubkey, profile);
       }
       if (pubkey) {
+        await updateCachedChannelMemberDisplayName(
+          queryClient,
+          pubkey,
+          profile.displayName,
+        );
+
         // Own author labels/avatars render through the users-batch delta
         // cache too — evict so the next batch run picks up the new profile
         // instead of the fresh-looking stale entry, then poke the aggregates.


### PR DESCRIPTION
🤖

## Summary

- Fix agent and user renames continuing to show the previous name in channel member lists.
- Keep the visible name current without issuing one relay request per cached channel.
- Make managed-agent renames succeed consistently or fail without leaving a partially applied edit.

## Details

Channel membership is stored by public key, but the desktop's channel-member query also includes the display name resolved from that member's relay profile. Renaming a profile refreshed the profile caches but not those channel-member results, so channels that were already loaded could continue rendering the old name.

After a successful managed-agent rename or self-profile update, the desktop now replaces that public key's display name in every matching local channel-member result. It marks those results stale without eagerly refetching inactive channels, so the work scales with local cache entries instead of the total number of channels containing the member.

Member requests that were already in flight are canceled before the local update. Requests doing their first load are restarted so an older relay response cannot overwrite the new name, while previously cached channels keep the corrected local value and refresh naturally later.

For managed agents, a rename is now committed only after the new relay profile publishes successfully. If publication fails, the backend restores the complete pre-edit agent configuration, refreshes the retained local event, and rejects the save so the edit dialog stays open with an error. Runtime status changes that happen while publication is in flight are preserved, while a newer concurrent configuration edit is never overwritten.

This gives the rename one user-visible outcome: either the local record, relay profile, and channel caches move to the new name together, or the prior local configuration remains authoritative. Existing startup reconciliation remains a safety net for an ambiguous network failure where the relay accepted a publish but the client did not receive confirmation.

## Scope

Agent reuse behavior is unchanged. Adding an existing agent identity to another channel keeps that identity's current name; it does not silently rename the identity everywhere it appears.
