### PR TITLE
fix(desktop): explain macOS local network access

### DIFF
--- a/desktop/src-tauri/Info.plist
+++ b/desktop/src-tauri/Info.plist
@@ -10,5 +10,7 @@
     <string>Buzz needs microphone access for voice huddles.</string>
     <key>NSCameraUsageDescription</key>
     <string>Buzz needs camera access to record animated avatars.</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Buzz uses your local network for optional Share Compute and local relay connections. Remote messaging does not require this access.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- add a macOS local-network purpose string
- explain that LAN access is for optional Share Compute and local relay connections
- clarify that messaging through a remote relay does not need it

## Context

macOS currently falls back to its generic Local Network prompt because Buzz's `Info.plist` has no `NSLocalNetworkUsageDescription`. The alert says Buzz can find and collect data from devices without explaining which Buzz features use that capability, which makes an optional feature feel invasive.

Buzz can intentionally make local-network connections for Share Compute peers and user-configured local relays. Ordinary messaging through a remote relay does not require that access.

Apple recommends that any app using the local network directly or indirectly include `NSLocalNetworkUsageDescription`:
https://developer.apple.com/documentation/bundleresources/information-property-list/nslocalnetworkusagedescription

This PR improves the disclosure only. It does not change when macOS asks. The exact unexpected trigger should be handled separately once it can be reproduced and attributed.

## Verification

- `plutil -lint desktop/src-tauri/Info.plist`
- built a debug macOS `.app` bundle and confirmed its final `Info.plist` contains the exact purpose string
- `just ci`
