### PR TITLE
fix(desktop): hide sidebar top fade at scroll origin

### DIFF
--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -243,8 +243,16 @@ export function AppSidebar({
   const showSidebarUpdateCard =
     canShowSidebarUpdateCard && !isSidebarUpdateCardDismissed;
   const [dmActionsMenuOpen, setDmActionsMenuOpen] = React.useState(false);
+  const [hasScrolledFromTop, setHasScrolledFromTop] = React.useState(false);
   const scrollRef = React.useRef<HTMLDivElement>(null);
   useSidebarScrollLock(scrollRef);
+
+  const handleSidebarScroll = React.useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      setHasScrolledFromTop(event.currentTarget.scrollTop > 0);
+    },
+    [],
+  );
 
   React.useEffect(() => {
     const scrollElement = scrollRef.current;
@@ -549,6 +557,7 @@ export function AppSidebar({
     <Sidebar
       className="!border-r-0"
       collapsible="offcanvas"
+      data-scrolled-from-top={hasScrolledFromTop}
       data-testid="app-sidebar"
       variant="sidebar"
     >
@@ -585,6 +594,7 @@ export function AppSidebar({
 
           <SidebarContent
             className="buzz-sidebar-scrollbar overscroll-none"
+            onScroll={handleSidebarScroll}
             ref={scrollRef}
           >
             <div

--- a/desktop/src/shared/styles/globals/components.css
+++ b/desktop/src/shared/styles/globals/components.css
@@ -37,7 +37,13 @@
     bottom: calc(var(--buzz-sidebar-edge-fade-size) * -1);
     height: var(--buzz-sidebar-edge-fade-size);
     left: 0;
+    opacity: 0;
     right: 0;
+  }
+
+  [data-testid="app-sidebar"][data-scrolled-from-top="true"]
+    [data-testid="sidebar-pinned-header"]::before {
+    opacity: 1;
   }
 
   [data-testid="app-sidebar"] [data-sidebar="footer"]::before {

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -22,6 +22,54 @@ async function storedSidebarWidth(page: Page) {
   );
 }
 
+async function topEdgeFadeOpacity(page: Page) {
+  return page
+    .getByTestId("sidebar-pinned-header")
+    .evaluate((element) => getComputedStyle(element, "::before").opacity);
+}
+
+async function expectTopEdgeFadeTracksSidebarScroll(page: Page) {
+  const scroller = page
+    .getByTestId("app-sidebar")
+    .locator('[data-sidebar="content"]');
+  const pinnedHeader = page.getByTestId("sidebar-pinned-header");
+  const inbox = page
+    .getByTestId("sidebar-primary-menu")
+    .getByRole("button", { name: "Inbox" });
+  const scrollContent = page.getByTestId("sidebar-scroll-content");
+
+  await expect(scroller).toBeVisible();
+  await expect(inbox).toBeVisible();
+  const [headerBottom, inboxTop] = await Promise.all([
+    pinnedHeader.evaluate((element) => element.getBoundingClientRect().bottom),
+    inbox.evaluate((element) => element.getBoundingClientRect().top),
+  ]);
+  expect(inboxTop).toBeCloseTo(headerBottom);
+  await expect(scrollContent).toHaveCSS("padding-top", "0px");
+  await expect.poll(() => topEdgeFadeOpacity(page)).toBe("0");
+
+  await scroller.evaluate((element) => {
+    element.scrollTop = 24;
+  });
+  await expect
+    .poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0);
+  await expect.poll(() => topEdgeFadeOpacity(page)).toBe("1");
+
+  await scroller.evaluate((element) => {
+    element.scrollTop = 0;
+  });
+  await expect
+    .poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBe(0);
+  await expect.poll(() => topEdgeFadeOpacity(page)).toBe("0");
+  await expect
+    .poll(() =>
+      inbox.evaluate((element) => element.getBoundingClientRect().top),
+    )
+    .toBeCloseTo(headerBottom);
+}
+
 // Regression guard for the "Leave channel" lockup: with two bundled copies of
 // @radix-ui/react-dismissable-layer, opening a modal AlertDialog from a modal
 // Radix ContextMenu left `pointer-events: none` stuck on <body> after the
@@ -324,6 +372,19 @@ test("fades the pinned sidebar chrome edges outside the Buzz theme", async ({
   expect(fadeStyles.footerZIndex).toBe("5");
   expect(fadeStyles.channelBeforeBackground).toBe("none");
   expect(fadeStyles.channelAfterBackground).toBe("none");
+
+  await expectTopEdgeFadeTracksSidebarScroll(page);
+});
+
+test("shows the dark-theme header fade only after the sidebar scrolls", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("buzz-theme", "github-dark");
+  });
+  await page.goto("/");
+
+  await expectTopEdgeFadeTracksSidebarScroll(page);
 });
 
 test("aligns the sidebar search with the channel title outside the Buzz theme", async ({


### PR DESCRIPTION
## What changed

The top sidebar gradient was visible even when the sidebar was already at the top. In light and dark themes, that put the fade over the Inbox button.

The sidebar now shows the top gradient only after its content has scrolled. The footer fade is unchanged, and the fix does not add spacing or move any sidebar content.

## Testing

- `just ci`
- `cd desktop && pnpm exec playwright test tests/e2e/sidebar.spec.ts --project=integration` (13 passed)
- Added regression coverage for the initial, scrolled, and returned-to-top states in light and dark themes
