### PR TITLE
fix(desktop,acp): Codex model discovery timeout UX + 45s probe budget

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -58,7 +58,12 @@ fn is_subcommand(name: &str) -> bool {
 }
 
 /// Timeout for lightweight helper subcommands (spawn + initialize + model/method probes).
-const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
+///
+/// Codex ACP cold-starts the Codex App Server on every `models` probe; on
+/// Windows this commonly takes ~15–25s (see #2261). 10s was too short and
+/// produced empty model lists with opaque failures. Keep this well above the
+/// observed cold path so UI retry + progressive loading can succeed.
+const MODELS_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Timeout for `buzz-acp authenticate`. Browser-based vendor auth can require
 /// human interaction, so it must not share the short probe timeout.

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -53,15 +53,25 @@ with a TypeScript lookup table or an id comparison in a component.
 6. **One canonical behavior, disclosure presets for visibility.** Behavior
    flags were deliberately killed in #2148 (`CANONICAL_CONFIG_BEHAVIORS`).
    Surface differences are expressed via the `disclosure` preset, not new
-   boolean props.  **Exception:** `onboarding-essential` hides happy-path
-   helper copy (provider/model descriptions) but a non-null model-discovery
-   status always bypasses the preset and renders the status line — enforced
-   via `shouldShowModelStatusMessage()` (`AgentConfigFields.tsx`).
+   boolean props.  **Exception (#2246, extended #2261):** `onboarding-essential`
+   hides happy-path helper copy (provider/model descriptions) but
+   `shouldShowModelStatusMessage(showDescriptions, status, loadingMessage)`
+   surfaces the status line when `status !== null` **or** the slow-phase
+   under-field note is non-null (`loadingMessage`). Early loading (control
+   only) does not force the under-field line. Quiet happy path stays hidden
+   in onboarding.
    Additionally, a successful discovery response that yields no usable options
-   (`supportsSwitching:false` or empty model list) synthesizes a warning status
-   via `synthesizeEmptyDiscoveryStatus()` and is intentionally **not cached**
-   so that closing → reopening the dialog re-runs discovery after the user
-   installs or signs into the CLI (`isCacheableDiscoveryResponse()`).
+   (`supportsSwitching:false` or empty model list) synthesizes a **retryable**
+   warning via `synthesizeEmptyDiscoveryStatus()` and is intentionally **not
+   cached** so Retry / close→reopen re-runs discovery after the user installs
+   or signs into the CLI (`isCacheableDiscoveryResponse()`). Timeouts and
+   path failures also set `retryable: true` and wire `retryModelDiscovery()`
+   (clears the in-memory cache key and re-probes). Loading UX: the control
+   always shows short `MODEL_DISCOVERY_LOADING_SHORT`. The long under-field
+   note (`formatModelDiscoveryLoadingMessage`) is **null until**
+   `MODEL_DISCOVERY_SLOW_MS` (10s), then appears only under the field via
+   `ModelDiscoveryStatusLine` (never in the pill). One-shot timeout, not a
+   polling ticker.
 7. **Onboarding setup detects readiness; it does not select defaults.** The
    setup page derives visible and ready harnesses from the runtime catalog and
    only offers install or sign-in actions. The following defaults page is the
@@ -74,11 +84,13 @@ with a TypeScript lookup table or an id comparison in a component.
 - `lib/agentConfigCore.test.mjs` — field model per harness × scope, clearing
   policy. Update when the capability model changes.
 - `ui/agentConfigFieldsContract.test.mjs` — canonical behaviors + disclosure
-  presets + `shouldShowModelStatusMessage` status-bypass rule. If this fails,
-  you probably reintroduced a per-surface flag or broke the status-bypass.
+  presets + `shouldShowModelStatusMessage` status/loading bypass. If this
+  fails, you probably reintroduced a per-surface flag or broke the bypass.
 - `ui/usePersonaModelDiscovery.test.mjs` — `synthesizeEmptyDiscoveryStatus`,
-  `isCacheableDiscoveryResponse`, `deriveModelDiscoveryPending`. If the
-  "reopen to retry" copy becomes inert again, these tests will catch it.
+  `isCacheableDiscoveryResponse`, `deriveModelDiscoveryPending`, retryable
+  empty status. If empty catalogs get cached or lose Retry, these fail.
+- `ui/personaModelDiscoveryStatus.test.mjs` — timeout / PATH / credential
+  status mapping + progressive loading copy.
 - `desktop/tests/e2e/onboarding-agent-defaults.spec.ts` — onboarding behavior
   acceptance coverage for readiness, failure states, defaults, navigation, and
   persistence races.

--- a/desktop/src/features/agents/ui/AgentConfigFields.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigFields.tsx
@@ -113,16 +113,23 @@ export function resolveDisclosure(disclosure: "full" | "onboarding-essential") {
 /**
  * Determines whether the status line beneath the Model field should render.
  *
- * Discovery warnings bypass the `onboarding-essential` preset so that a
- * first-run failure is never silently invisible.  On the happy path
- * (`status === null`) the status line stays hidden in onboarding, keeping
- * the page clean.
+ * Discovery warnings and the **slow-phase** loading note bypass the
+ * `onboarding-essential` preset so first-run failures / long Codex cold
+ * starts are never invisible. Early loading (control shows "Loading
+ * models…") does not force the under-field line — only
+ * `loadingMessage !== null` or a non-null status does. Quiet happy path
+ * stays hidden in onboarding.
+ *
+ * @param loadingMessage - progressive under-field copy; null until slow phase
  */
 export function shouldShowModelStatusMessage(
   showDescriptions: boolean,
   status: { message: string; tone: string } | null,
+  loadingMessage: string | null = null,
 ): boolean {
-  return showDescriptions || status !== null;
+  return (
+    showDescriptions || status !== null || (loadingMessage?.trim() ?? "") !== ""
+  );
 }
 
 export type AgentConfigFieldsProps = {
@@ -276,7 +283,9 @@ export function AgentConfigFields({
   const {
     discoveredModelOptions,
     modelDiscoveryLoading,
+    modelDiscoveryLoadingMessage,
     modelDiscoveryStatus,
+    retryModelDiscovery,
   } = usePersonaModelDiscovery({
     envVars: config.env_vars,
     isCustomProviderEditing: isCustomProvider,
@@ -685,11 +694,17 @@ export function AgentConfigFields({
           modelDiscoveryLoading={
             dependentFieldsDisabled ? false : modelDiscoveryLoading
           }
+          modelDiscoveryLoadingMessage={
+            dependentFieldsDisabled ? null : modelDiscoveryLoadingMessage
+          }
           modelDiscoveryStatus={
             dependentFieldsDisabled ? null : modelDiscoveryStatus
           }
           onIsCustomModelEditingChange={onCustomModelEditingChange}
           onModelChange={handleModelChange}
+          onRetryModelDiscovery={
+            dependentFieldsDisabled ? undefined : retryModelDiscovery
+          }
           placeholderClassName={placeholderClassName}
           placeholder="Select a model"
           provider={providerForDiscovery}
@@ -700,6 +715,7 @@ export function AgentConfigFields({
           showStatusMessage={shouldShowModelStatusMessage(
             showDescriptions,
             modelDiscoveryStatus,
+            dependentFieldsDisabled ? null : modelDiscoveryLoadingMessage,
           )}
           testId="global-agent-model"
           useCustomSelect={useCustomSelect}

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -598,11 +598,13 @@ export function AgentDefinitionDialog({
       })),
     { label: "Custom provider...", value: CUSTOM_PROVIDER_DROPDOWN_VALUE },
   ];
+  const controlShowsModelLoading =
+    modelDiscoveryLoading && discoveredModelOptions === null;
   const modelDropdownOptions: PersonaDropdownOption[] =
     buildModelDropdownOptions({
       allowCustom: !isRelayMesh,
       globalModel: undefined,
-      loading: modelDiscoveryLoading && discoveredModelOptions === null,
+      loading: controlShowsModelLoading,
       loadingValue: MODEL_DISCOVERY_LOADING_VALUE,
       options: modelOptions,
     })
@@ -614,6 +616,11 @@ export function AgentDefinitionDialog({
           ? { ...option, label: "Automatic" }
           : option,
       );
+  // Force short loading sentinel on the control while probing (same as
+  // AgentModelField / instance edit — closed trigger must not look stuck).
+  const modelControlValue = controlShowsModelLoading
+    ? MODEL_DISCOVERY_LOADING_VALUE
+    : modelSelectValue;
   const previewLabel = displayName.trim() || "Agent name";
   const previewAvatarUrl = avatarUrl.trim() || null;
   const runtimeWarning =
@@ -943,7 +950,7 @@ export function AgentDefinitionDialog({
                   modelDiscoveryLoadingMessage={modelDiscoveryLoadingMessage}
                   modelDiscoveryStatus={modelDiscoveryStatus}
                   modelDropdownOptions={modelDropdownOptions}
-                  modelSelectValue={modelSelectValue}
+                  modelSelectValue={modelControlValue}
                   onCustomModelChange={setModel}
                   onRetryModelDiscovery={retryModelDiscovery}
                   showSharedComputeAutoHint={

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -496,7 +496,9 @@ export function AgentDefinitionDialog({
   const {
     discoveredModelOptions,
     modelDiscoveryLoading,
+    modelDiscoveryLoadingMessage,
     modelDiscoveryStatus,
+    retryModelDiscovery,
   } = usePersonaModelDiscovery({
     envVars: envVarsForDiscovery,
     isCustomProviderEditing,
@@ -937,10 +939,13 @@ export function AgentDefinitionDialog({
                   disabled={isPending}
                   isExplicitModelRequired={isExplicitModelRequired}
                   model={model}
+                  modelDiscoveryLoading={modelDiscoveryLoading}
+                  modelDiscoveryLoadingMessage={modelDiscoveryLoadingMessage}
                   modelDiscoveryStatus={modelDiscoveryStatus}
                   modelDropdownOptions={modelDropdownOptions}
                   modelSelectValue={modelSelectValue}
                   onCustomModelChange={setModel}
+                  onRetryModelDiscovery={retryModelDiscovery}
                   showSharedComputeAutoHint={
                     isRelayMesh &&
                     modelSelectValue === AUTO_MODEL_DROPDOWN_VALUE

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -80,6 +80,7 @@ import { getProviderApiKeyEnvVar } from "./agentConfigOptions";
 import { useAgentDialogDefaults } from "./useAgentDialogDefaults";
 import { AgentAiDefaultsNotice } from "./AgentAiDefaults";
 import { AgentDefaultsDialog } from "./AgentDefaultsDialog";
+import { ModelDiscoveryStatusLine } from "./ModelDiscoveryStatusLine";
 import { useProviderApiKeyFieldState } from "./providerApiKeyFieldState";
 
 const ADVANCED_FIELDS_MOTION_TRANSITION = {
@@ -410,7 +411,9 @@ export function AgentInstanceEditDialog({
   const {
     discoveredModelOptions,
     modelDiscoveryLoading,
+    modelDiscoveryLoadingMessage,
     modelDiscoveryStatus,
+    retryModelDiscovery,
   } = usePersonaModelDiscovery({
     envVars: envVarsForDiscovery,
     isCustomProviderEditing,
@@ -1079,15 +1082,22 @@ export function AgentInstanceEditDialog({
                   />
                 </div>
               ) : null}
-              <p className="text-xs text-muted-foreground">
-                {modelDiscoveryLoading
-                  ? "Loading models..."
-                  : modelDiscoveryStatus !== null
-                    ? modelDiscoveryStatus.message
-                    : discoveredModelOptions !== null
-                      ? "Saved changes take effect on the next start."
-                      : "Select a provider above to see available models."}
-              </p>
+              {modelDiscoveryLoadingMessage ||
+              modelDiscoveryStatus !== null ? (
+                <ModelDiscoveryStatusLine
+                  disabled={updateMutation.isPending}
+                  loading={modelDiscoveryLoading}
+                  loadingMessage={modelDiscoveryLoadingMessage}
+                  onRetry={retryModelDiscovery}
+                  status={modelDiscoveryStatus}
+                />
+              ) : modelDiscoveryLoading ? null : (
+                <p className="text-xs text-muted-foreground">
+                  {discoveredModelOptions !== null
+                    ? "Saved changes take effect on the next start."
+                    : "Select a provider above to see available models."}
+                </p>
+              )}
             </div>
 
             <AgentAiDefaultsNotice

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -788,14 +788,22 @@ export function AgentInstanceEditDialog({
     model,
     provider: providerForDiscovery,
   });
+  // Match AgentModelField: while probing with no catalog yet, force the
+  // control onto the short loading sentinel so the closed trigger does not
+  // keep showing a stale default/previous model with no loading cue (#2261).
+  const controlShowsModelLoading =
+    modelDiscoveryLoading && discoveredModelOptions === null;
   const modelDropdownOptions = buildModelDropdownOptions({
     allowCustom: !isRelayMesh,
     globalModel: isRelayMesh ? undefined : inheritedModelDefault.value,
     globalModelLabel: isRelayMesh ? undefined : inheritedModelLabel,
-    loading: modelDiscoveryLoading && discoveredModelOptions === null,
+    loading: controlShowsModelLoading,
     loadingValue: MODEL_DISCOVERY_LOADING_VALUE,
     options: effectiveModelOptions,
   });
+  const modelControlValue = controlShowsModelLoading
+    ? MODEL_DISCOVERY_LOADING_VALUE
+    : modelSelectValue;
 
   // Provider field derived state
   const trimmedProvider = provider.trim();
@@ -1058,7 +1066,7 @@ export function AgentInstanceEditDialog({
                 onValueChange={handleModelDropdownChange}
                 options={modelDropdownOptions}
                 placeholder="Default model"
-                value={modelSelectValue}
+                value={modelControlValue}
               />
               {showCustomModelInput ? (
                 <div

--- a/desktop/src/features/agents/ui/ModelDiscoveryStatusLine.tsx
+++ b/desktop/src/features/agents/ui/ModelDiscoveryStatusLine.tsx
@@ -1,0 +1,73 @@
+import { cn } from "@/shared/lib/cn";
+
+import type { PersonaModelDiscoveryStatus } from "./personaModelDiscoveryStatus";
+
+/**
+ * Status line under the Model control: progressive loading, failure copy,
+ * and optional Retry. Shared by onboarding (`AgentModelField`), create
+ * (`PersonaModelField`), and instance edit so surfaces do not fork markup.
+ */
+export function ModelDiscoveryStatusLine({
+  disabled = false,
+  loading,
+  loadingMessage,
+  onRetry,
+  status,
+  testId = "model-discovery-status",
+}: {
+  disabled?: boolean;
+  loading: boolean;
+  /** Full progressive copy for the status line (may be long). */
+  loadingMessage?: string | null;
+  onRetry?: () => void;
+  status: PersonaModelDiscoveryStatus | null;
+  testId?: string;
+}) {
+  if (loading) {
+    // Only render once progressive copy is ready (after MODEL_DISCOVERY_SLOW_MS).
+    // Early loading is communicated solely by the control's short label.
+    const text = loadingMessage?.trim();
+    if (!text) return null;
+    return (
+      <p
+        aria-live="polite"
+        className="text-xs text-muted-foreground"
+        data-testid={testId}
+      >
+        {text}
+      </p>
+    );
+  }
+
+  if (status === null) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flex flex-wrap items-start gap-x-3 gap-y-1"
+      data-testid={testId}
+    >
+      <p
+        aria-live="polite"
+        className={cn(
+          "min-w-0 flex-1 text-xs",
+          status.tone === "warning" ? "text-warning" : "text-muted-foreground",
+        )}
+      >
+        {status.message}
+      </p>
+      {status.retryable && onRetry ? (
+        <button
+          className="shrink-0 text-xs font-medium text-foreground underline-offset-2 hover:underline disabled:opacity-50"
+          data-testid="model-discovery-retry"
+          disabled={disabled}
+          onClick={onRetry}
+          type="button"
+        >
+          Retry
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/PersonaModelField.tsx
+++ b/desktop/src/features/agents/ui/PersonaModelField.tsx
@@ -3,6 +3,7 @@ import { motion } from "motion/react";
 
 import { cn } from "@/shared/lib/cn";
 import { Input } from "@/shared/ui/input";
+import { ModelDiscoveryStatusLine } from "./ModelDiscoveryStatusLine";
 import { PersonaModelCombobox } from "./PersonaModelCombobox";
 import type { PersonaModelDiscoveryStatus } from "./personaModelDiscoveryStatus";
 import {
@@ -16,12 +17,18 @@ type PersonaModelFieldProps = {
   disabled: boolean;
   isExplicitModelRequired: boolean;
   model: string;
+  /** True while discovery is in flight (#2261). */
+  modelDiscoveryLoading?: boolean;
+  /** Progressive status-line copy only (not the control). */
+  modelDiscoveryLoadingMessage?: string | null;
   modelDiscoveryStatus: PersonaModelDiscoveryStatus | null;
   modelDropdownOptions: readonly PersonaDropdownOption[];
   showSharedComputeAutoHint: boolean;
   modelSelectValue: string;
   onCustomModelChange: (value: string) => void;
   onModelValueChange: (value: string) => void;
+  /** Re-run discovery after timeout / empty / path failure (#2261). */
+  onRetryModelDiscovery?: () => void;
   showCustomModelInput: boolean;
   transition: React.ComponentProps<typeof motion.div>["transition"];
 };
@@ -30,12 +37,15 @@ export function PersonaModelField({
   disabled,
   isExplicitModelRequired,
   model,
+  modelDiscoveryLoading = false,
+  modelDiscoveryLoadingMessage = null,
   modelDiscoveryStatus,
   modelDropdownOptions,
   modelSelectValue,
   showSharedComputeAutoHint,
   onCustomModelChange,
   onModelValueChange,
+  onRetryModelDiscovery,
   showCustomModelInput,
   transition,
 }: PersonaModelFieldProps) {
@@ -95,19 +105,15 @@ export function PersonaModelField({
             Buzz will choose an available shared model when the agent starts.
           </p>
         ) : null}
-        {modelDiscoveryStatus ? (
-          <p
-            aria-live="polite"
-            className={cn(
-              "text-xs",
-              modelDiscoveryStatus.tone === "warning"
-                ? "text-warning"
-                : "text-muted-foreground",
-            )}
-            data-testid="persona-model-discovery-status"
-          >
-            {modelDiscoveryStatus.message}
-          </p>
+        {modelDiscoveryLoadingMessage || modelDiscoveryStatus ? (
+          <ModelDiscoveryStatusLine
+            disabled={disabled}
+            loading={modelDiscoveryLoading}
+            loadingMessage={modelDiscoveryLoadingMessage}
+            onRetry={onRetryModelDiscovery}
+            status={modelDiscoveryStatus}
+            testId="persona-model-discovery-status"
+          />
         ) : null}
       </div>
     </motion.div>

--- a/desktop/src/features/agents/ui/agentConfigControls.tsx
+++ b/desktop/src/features/agents/ui/agentConfigControls.tsx
@@ -24,7 +24,11 @@ import {
   type PersonaModelOption,
 } from "./agentConfigOptions";
 import { MODEL_DISCOVERY_LOADING_VALUE } from "./usePersonaModelDiscovery";
-import type { PersonaModelDiscoveryStatus } from "./personaModelDiscoveryStatus";
+import {
+  MODEL_DISCOVERY_LOADING_SHORT,
+  type PersonaModelDiscoveryStatus,
+} from "./personaModelDiscoveryStatus";
+import { ModelDiscoveryStatusLine } from "./ModelDiscoveryStatusLine";
 
 export const MODEL_NO_MODELS_VALUE = "__no_models__";
 
@@ -283,9 +287,11 @@ export function AgentModelField({
   isRequired,
   model,
   modelDiscoveryLoading,
+  modelDiscoveryLoadingMessage = null,
   modelDiscoveryStatus,
   onIsCustomModelEditingChange,
   onModelChange,
+  onRetryModelDiscovery,
   placeholder = "Select model",
   placeholderClassName,
   provider,
@@ -318,9 +324,13 @@ export function AgentModelField({
   isRequired: boolean;
   model: string;
   modelDiscoveryLoading: boolean;
+  /** Progressive loading copy from {@link usePersonaModelDiscovery}. */
+  modelDiscoveryLoadingMessage?: string | null;
   modelDiscoveryStatus: PersonaModelDiscoveryStatus | null;
   onIsCustomModelEditingChange: (value: boolean) => void;
   onModelChange: (value: string) => void;
+  /** Re-run discovery after a timeout / empty / path failure. */
+  onRetryModelDiscovery?: () => void;
   /** Trigger placeholder shown when there is no selected model option. */
   placeholder?: string;
   /** Optional class override for placeholder text. */
@@ -425,16 +435,22 @@ export function AgentModelField({
     onModelChange(nextValue);
   };
 
+  // Discovery in flight with no catalog yet: force SHORT label on the control
+  // (trigger + option). The long progressive sentence must never enter the
+  // pill — it truncates and duplicated the under-field note (#2261 screenshot).
+  const controlShowsLoading =
+    modelDiscoveryLoading && discoveredModelOptions === null;
+
   const modelOptions: AgentDropdownOption[] = [
     ...effectiveModelOptions.map((option) => ({
       label: option.label,
       value: option.id || AUTO_MODEL_DROPDOWN_VALUE,
     })),
-    ...(modelDiscoveryLoading && discoveredModelOptions === null
+    ...(controlShowsLoading
       ? [
           {
             disabled: true,
-            label: "Loading models...",
+            label: MODEL_DISCOVERY_LOADING_SHORT,
             value: MODEL_DISCOVERY_LOADING_VALUE,
           },
         ]
@@ -454,16 +470,15 @@ export function AgentModelField({
     trimmedModel.length > 0
       ? trimmedModel
       : undefined;
-  // While discovery is in flight with nothing selected, the closed field
-  // reads "Loading models…" instead of a select-prompt — the field isn't
-  // waiting on the user, it's waiting on the harness.
-  const restingPlaceholder =
-    modelDiscoveryLoading &&
-    discoveredModelOptions === null &&
-    trimmedModel.length === 0 &&
-    !isCustomModelEditing
-      ? "Loading models..."
-      : placeholder;
+
+  // Closed trigger: while loading, always SHORT — do not fall through to
+  // selectedOption.label / selectedLabel, which could surface longer copy.
+  const controlSelectedLabel = controlShowsLoading
+    ? MODEL_DISCOVERY_LOADING_SHORT
+    : stableSelectedModelLabel;
+  const controlPlaceholder = controlShowsLoading
+    ? MODEL_DISCOVERY_LOADING_SHORT
+    : placeholder;
 
   const modelSelect = useCustomSelect ? (
     <AgentDropdownSelect
@@ -473,12 +488,16 @@ export function AgentModelField({
       id={id}
       onValueChange={handleModelSelectChange}
       options={modelOptions}
-      placeholder={restingPlaceholder}
+      placeholder={controlPlaceholder}
       placeholderClassName={placeholderClassName}
       searchable
-      selectedLabel={stableSelectedModelLabel}
+      selectedLabel={controlSelectedLabel}
       testId={testId ?? id}
-      value={modelSelectValue}
+      value={
+        controlShowsLoading && trimmedModel.length === 0 && !isCustomModelEditing
+          ? MODEL_DISCOVERY_LOADING_VALUE
+          : modelSelectValue
+      }
     />
   ) : (
     <select
@@ -491,7 +510,11 @@ export function AgentModelField({
       disabled={selectDisabled}
       id={id}
       onChange={(event) => handleModelSelectChange(event.target.value)}
-      value={modelSelectValue}
+      value={
+        controlShowsLoading && trimmedModel.length === 0 && !isCustomModelEditing
+          ? MODEL_DISCOVERY_LOADING_VALUE
+          : modelSelectValue
+      }
     >
       {modelOptions.map((option) => (
         <option
@@ -536,15 +559,21 @@ export function AgentModelField({
         />
       ) : null}
       {showStatusMessage ? (
-        <p className="text-xs text-muted-foreground">
-          {modelDiscoveryLoading
-            ? "Loading models..."
-            : modelDiscoveryStatus !== null
-              ? modelDiscoveryStatus.message
-              : discoveredModelOptions !== null
-                ? "Saved changes take effect on the next start."
-                : "Select a provider above to see available models."}
-        </p>
+        modelDiscoveryLoadingMessage || modelDiscoveryStatus !== null ? (
+          <ModelDiscoveryStatusLine
+            disabled={disabled}
+            loading={modelDiscoveryLoading}
+            loadingMessage={modelDiscoveryLoadingMessage}
+            onRetry={onRetryModelDiscovery}
+            status={modelDiscoveryStatus}
+          />
+        ) : modelDiscoveryLoading ? null : (
+          <p className="text-xs text-muted-foreground">
+            {discoveredModelOptions !== null
+              ? "Saved changes take effect on the next start."
+              : "Select a provider above to see available models."}
+          </p>
+        )
       ) : null}
     </div>
   );

--- a/desktop/src/features/agents/ui/agentConfigFieldsContract.test.mjs
+++ b/desktop/src/features/agents/ui/agentConfigFieldsContract.test.mjs
@@ -61,7 +61,8 @@ test("onboarding-essential hides power tools but never the effort field", () => 
 
 // ── shouldShowModelStatusMessage ──────────────────────────────────────────────
 // The onboarding-essential preset sets showDescriptions=false.  Discovery
-// warnings must bypass the preset so first-run failures are never invisible.
+// warnings (#2246) and the slow-phase loading note (#2261) must bypass the
+// preset so first-run failures / long cold starts are never invisible.
 
 test("shouldShowModelStatusMessage_fullDisclosure_nullStatus_showsMessage", () => {
   // Full disclosure always shows the status line regardless of status.
@@ -69,9 +70,13 @@ test("shouldShowModelStatusMessage_fullDisclosure_nullStatus_showsMessage", () =
 });
 
 test("shouldShowModelStatusMessage_onboardingPreset_nullStatus_hidesMessage", () => {
-  // Happy path: no status → status line hidden in onboarding.
+  // Happy path: no status, no slow-phase note → status line hidden.
   const { showDescriptions } = resolveDisclosure("onboarding-essential");
   assert.equal(shouldShowModelStatusMessage(showDescriptions, null), false);
+  assert.equal(
+    shouldShowModelStatusMessage(showDescriptions, null, null),
+    false,
+  );
 });
 
 test("shouldShowModelStatusMessage_onboardingPreset_warningStatus_showsMessage", () => {
@@ -82,4 +87,26 @@ test("shouldShowModelStatusMessage_onboardingPreset_warningStatus_showsMessage",
     tone: "warning",
   };
   assert.equal(shouldShowModelStatusMessage(showDescriptions, warning), true);
+});
+
+test("shouldShowModelStatusMessage_onboardingPreset_earlyLoading_hidesMessage", () => {
+  // First 10s: control alone shows "Loading models…" — no under-field line.
+  const { showDescriptions } = resolveDisclosure("onboarding-essential");
+  assert.equal(
+    shouldShowModelStatusMessage(showDescriptions, null, null),
+    false,
+  );
+});
+
+test("shouldShowModelStatusMessage_onboardingPreset_slowLoading_showsMessage", () => {
+  // After MODEL_DISCOVERY_SLOW_MS the long note must not be hidden.
+  const { showDescriptions } = resolveDisclosure("onboarding-essential");
+  assert.equal(
+    shouldShowModelStatusMessage(
+      showDescriptions,
+      null,
+      "Still loading models… first launch of some harnesses (especially Codex) can take 20–60 seconds.",
+    ),
+    true,
+  );
 });

--- a/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
+++ b/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
@@ -244,5 +244,12 @@ test("formatModelDiscoveryErrorStatus returns a non-null status for runtime unav
     );
     assert.ok(typeof status?.message === "string", "status has a message");
     assert.ok(typeof status?.tone === "string", "status has a tone");
+    // No discoverAgentModels call is possible until availability flips —
+    // Retry must not be offered (would no-op).
+    assert.equal(
+      status?.retryable,
+      undefined,
+      `availability=${availability} must not be retryable`,
+    );
   }
 });

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { formatModelDiscoveryErrorStatus } from "./personaModelDiscoveryStatus.ts";
+import {
+  formatModelDiscoveryErrorStatus,
+  formatModelDiscoveryLoadingMessage,
+  isModelDiscoveryTimeoutError,
+  MODEL_DISCOVERY_SLOW_MS,
+} from "./personaModelDiscoveryStatus.ts";
 
 test("model discovery status names missing Anthropic credentials", () => {
   const status = formatModelDiscoveryErrorStatus(
@@ -12,6 +17,8 @@ test("model discovery status names missing Anthropic credentials", () => {
   assert.equal(status?.tone, "warning");
   assert.match(status?.message ?? "", /Anthropic API key/);
   assert.match(status?.message ?? "", /Anthropic models/);
+  // Credential gaps need user input — not a Retry-only fix.
+  assert.equal(status?.retryable, undefined);
 });
 
 test("model discovery status names missing OpenAI-compatible credentials", () => {
@@ -23,6 +30,7 @@ test("model discovery status names missing OpenAI-compatible credentials", () =>
   assert.equal(status?.tone, "warning");
   assert.match(status?.message ?? "", /OpenAI API key/);
   assert.match(status?.message ?? "", /OpenAI models/);
+  assert.equal(status?.retryable, undefined);
 });
 
 test("Buzz shared compute names the empty state and next action", () => {
@@ -34,6 +42,7 @@ test("Buzz shared compute names the empty state and next action", () => {
   assert.equal(status?.tone, "warning");
   assert.match(status?.message ?? "", /No members are sharing compute/);
   assert.match(status?.message ?? "", /Settings > Compute/);
+  assert.equal(status?.retryable, true);
 });
 
 test("Buzz shared compute distinguishes relay lookup failures", () => {
@@ -45,6 +54,7 @@ test("Buzz shared compute distinguishes relay lookup failures", () => {
   assert.equal(status?.tone, "warning");
   assert.match(status?.message ?? "", /couldn't check shared compute/);
   assert.match(status?.message ?? "", /relay connection/);
+  assert.equal(status?.retryable, true);
 });
 
 test("Buzz shared compute names a missing relay member roster", () => {
@@ -57,6 +67,7 @@ test("Buzz shared compute names a missing relay member roster", () => {
   assert.match(status?.message ?? "", /waiting for the relay's member roster/);
   assert.match(status?.message ?? "", /membership configuration/);
   assert.doesNotMatch(status?.message ?? "", /relay connection/);
+  assert.equal(status?.retryable, true);
 });
 
 test("model discovery status stays quiet for missing Databricks defaults", () => {
@@ -66,4 +77,59 @@ test("model discovery status stays quiet for missing Databricks defaults", () =>
   );
 
   assert.equal(status, null);
+});
+
+// ── #2261 timeout / PATH / progressive loading ────────────────────────────────
+
+test("isModelDiscoveryTimeoutError matches buzz-acp probe timeout text", () => {
+  assert.equal(
+    isModelDiscoveryTimeoutError("error: agent timed out (10s)"),
+    true,
+  );
+  assert.equal(
+    isModelDiscoveryTimeoutError(
+      "buzz-acp models failed (exit 1): error: agent timed out (45s)",
+    ),
+    true,
+  );
+  assert.equal(
+    isModelDiscoveryTimeoutError("config: ANTHROPIC_API_KEY required"),
+    false,
+  );
+});
+
+test("formatModelDiscoveryErrorStatus_timeout_isRetryableWithClearCopy", () => {
+  const status = formatModelDiscoveryErrorStatus(
+    new Error("error: agent timed out (10s)"),
+    "",
+  );
+  assert.equal(status?.tone, "warning");
+  assert.equal(status?.retryable, true);
+  assert.match(status?.message ?? "", /timed out/i);
+  assert.match(status?.message ?? "", /retry/i);
+  assert.match(status?.message ?? "", /Codex|20–60|20-60/i);
+});
+
+test("formatModelDiscoveryErrorStatus_programNotFound_isRetryable", () => {
+  const status = formatModelDiscoveryErrorStatus(
+    new Error("failed to spawn agent: program not found"),
+    "codex",
+  );
+  assert.equal(status?.tone, "warning");
+  assert.equal(status?.retryable, true);
+  assert.match(status?.message ?? "", /PATH/i);
+});
+
+test("formatModelDiscoveryLoadingMessage is null until slow phase", () => {
+  assert.equal(formatModelDiscoveryLoadingMessage(false), null);
+});
+
+test("formatModelDiscoveryLoadingMessage returns long note only when slow", () => {
+  const message = formatModelDiscoveryLoadingMessage(true);
+  assert.match(message ?? "", /Still loading/i);
+  assert.match(message ?? "", /Codex/i);
+});
+
+test("MODEL_DISCOVERY_SLOW_MS is 10s before under-field note appears", () => {
+  assert.equal(MODEL_DISCOVERY_SLOW_MS, 10_000);
 });

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
@@ -79,6 +79,17 @@ test("model discovery status stays quiet for missing Databricks defaults", () =>
   assert.equal(status, null);
 });
 
+test("runtime unavailable is not retryable (Retry would be a no-op)", () => {
+  const status = formatModelDiscoveryErrorStatus(
+    new Error("Runtime not available: not_installed"),
+    "anthropic",
+  );
+  assert.equal(status?.tone, "warning");
+  assert.equal(status?.retryable, undefined);
+  assert.match(status?.message ?? "", /not available/i);
+  assert.match(status?.message ?? "", /Settings/i);
+});
+
 // ── #2261 timeout / PATH / progressive loading ────────────────────────────────
 
 test("isModelDiscoveryTimeoutError matches buzz-acp probe timeout text", () => {

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -172,6 +172,17 @@ export function formatModelDiscoveryErrorStatus(
     return null;
   }
 
+  // Hook synthesizes this when availability !== "available". Discovery is
+  // never attempted (no modelDiscoveryKey), so Retry would be a no-op —
+  // point the user at install/settings instead of offering Retry (#2267).
+  if (message.toLowerCase().includes("runtime not available")) {
+    return {
+      message:
+        "This agent runtime is not available. Install or reinstall it in Settings > Agents.",
+      tone: "warning",
+    };
+  }
+
   if (isModelDiscoveryTimeoutError(message)) {
     return {
       message:

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -1,7 +1,41 @@
 export type PersonaModelDiscoveryStatus = {
   message: string;
   tone: "muted" | "warning";
+  /**
+   * When true, the model field should offer a Retry control that re-runs
+   * discovery (timeouts, empty catalogs, path failures). Credential-missing
+   * states stay non-retryable — the user needs to fill a field first.
+   */
+  retryable?: boolean;
 };
+
+/**
+ * After this many ms of discovery, surface the long status-line note under
+ * the Model field. Until then the control alone shows
+ * {@link MODEL_DISCOVERY_LOADING_SHORT} — no duplicate under-field copy.
+ * See #2261.
+ */
+export const MODEL_DISCOVERY_SLOW_MS = 10_000;
+
+/**
+ * Short label for the model **control** (closed trigger / disabled option).
+ * Never put the long progressive sentence in the control — it truncates.
+ */
+export const MODEL_DISCOVERY_LOADING_SHORT = "Loading models…";
+
+/**
+ * Long status-line copy for a slow model probe, or `null` before the
+ * slow phase so the under-field line stays empty (control already shows
+ * {@link MODEL_DISCOVERY_LOADING_SHORT}).
+ *
+ * @param slow - true once discovery has been in flight ≥ {@link MODEL_DISCOVERY_SLOW_MS}
+ */
+export function formatModelDiscoveryLoadingMessage(
+  slow: boolean,
+): string | null {
+  if (!slow) return null;
+  return "Still loading models… first launch of some harnesses (especially Codex) can take 20–60 seconds.";
+}
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -41,6 +75,31 @@ function isEmptySharedComputeError(message: string): boolean {
   );
 }
 
+/** True when stderr/IPC text indicates the ACP models probe hit its budget. */
+export function isModelDiscoveryTimeoutError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  // buzz-acp: `error: agent timed out (10s)` / `(45s)`
+  // desktop: `buzz-acp models failed (exit N): ... timed out ...`
+  if (normalized.includes("timed out")) return true;
+  if (normalized.includes("timeout") && normalized.includes("agent")) {
+    return true;
+  }
+  return false;
+}
+
+function isProgramNotFoundError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("program not found") ||
+    normalized.includes("the system cannot find the file") ||
+    normalized.includes("enoent") ||
+    (normalized.includes("not found") &&
+      (normalized.includes("codex") ||
+        normalized.includes("claude") ||
+        normalized.includes("agent")))
+  );
+}
+
 export function formatModelDiscoveryErrorStatus(
   error: unknown,
   provider: string,
@@ -53,6 +112,7 @@ export function formatModelDiscoveryErrorStatus(
         message:
           "Buzz is waiting for the relay's member roster. Try again shortly; if this persists, check the relay's membership configuration.",
         tone: "warning",
+        retryable: true,
       };
     }
 
@@ -61,6 +121,7 @@ export function formatModelDiscoveryErrorStatus(
         message:
           "No members are sharing compute right now. On a member machine, open Settings > Compute, choose a model, and turn on Share this machine.",
         tone: "warning",
+        retryable: true,
       };
     }
 
@@ -77,6 +138,7 @@ export function formatModelDiscoveryErrorStatus(
         message:
           "Buzz received an invalid shared compute status. Check the member machine, then try again.",
         tone: "warning",
+        retryable: true,
       };
     }
 
@@ -84,6 +146,7 @@ export function formatModelDiscoveryErrorStatus(
       message:
         "Buzz couldn't check shared compute through the relay. Check your relay connection and try again.",
       tone: "warning",
+      retryable: true,
     };
   }
 
@@ -109,10 +172,29 @@ export function formatModelDiscoveryErrorStatus(
     return null;
   }
 
+  if (isModelDiscoveryTimeoutError(message)) {
+    return {
+      message:
+        "Model discovery timed out. Codex and some other harnesses can take 20–60 seconds to start the first time — retry, or wait a moment and try again.",
+      tone: "warning",
+      retryable: true,
+    };
+  }
+
+  if (isProgramNotFoundError(message)) {
+    return {
+      message:
+        "Could not find the agent harness on PATH. Install or reinstall it, ensure its install directory is on PATH, then retry.",
+      tone: "warning",
+      retryable: true,
+    };
+  }
+
   return {
     message: `Using built-in model options. Could not load live models for ${providerObjectLabel(
       provider,
     )}.`,
     tone: "warning",
+    retryable: true,
   };
 }

--- a/desktop/src/features/agents/ui/relayMeshModelPicker.ts
+++ b/desktop/src/features/agents/ui/relayMeshModelPicker.ts
@@ -7,6 +7,7 @@ import {
   type PersonaDropdownOption,
   type PersonaModelOption,
 } from "./agentConfigOptions";
+import { MODEL_DISCOVERY_LOADING_SHORT } from "./personaModelDiscoveryStatus";
 
 function withSharedComputeAutoOption(
   options: readonly PersonaModelOption[],
@@ -87,7 +88,14 @@ export function modelDropdownOptions({
   return [
     ...modelOptions,
     ...(loading
-      ? [{ disabled: true, label: "Loading models...", value: loadingValue }]
+      ? [
+          {
+            disabled: true,
+            // Keep short — long progressive copy is under-field only (#2261).
+            label: MODEL_DISCOVERY_LOADING_SHORT,
+            value: loadingValue,
+          },
+        ]
       : []),
     ...(allowCustom
       ? [{ label: "Custom model...", value: CUSTOM_MODEL_DROPDOWN_VALUE }]

--- a/desktop/src/features/agents/ui/usePersonaModelDiscovery.test.mjs
+++ b/desktop/src/features/agents/ui/usePersonaModelDiscovery.test.mjs
@@ -126,6 +126,9 @@ test("synthesizeEmptyDiscoveryStatus_emptyModels_producesWarningStatus", () => {
   assert.equal(status?.tone, "warning");
   assert.match(status?.message ?? "", /Claude Code/);
   assert.match(status?.message ?? "", /reported no models/);
+  // #2261: empty catalog is retryable (Retry control), not "reopen only".
+  assert.equal(status?.retryable, true);
+  assert.match(status?.message ?? "", /retry/i);
 });
 
 test("synthesizeEmptyDiscoveryStatus_supportsSwitchingFalse_producesWarningStatus", () => {

--- a/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
+++ b/desktop/src/features/agents/ui/usePersonaModelDiscovery.ts
@@ -8,6 +8,8 @@ import type {
 import type { EnvVarsValue } from "./EnvVarsEditor";
 import {
   formatModelDiscoveryErrorStatus,
+  formatModelDiscoveryLoadingMessage,
+  MODEL_DISCOVERY_SLOW_MS,
   type PersonaModelDiscoveryStatus,
 } from "./personaModelDiscoveryStatus";
 import type { PersonaModelOption } from "./agentConfigOptions";
@@ -97,8 +99,9 @@ export function synthesizeEmptyDiscoveryStatus(
   }
   const agentLabel = response.agentName.trim() || "This agent";
   return {
-    message: `${agentLabel} reported no models. Check that the CLI is installed and signed in, then reopen this screen.`,
+    message: `${agentLabel} reported no models. Check that the CLI is installed and signed in, then retry.`,
     tone: "warning",
+    retryable: true,
   };
 }
 
@@ -166,6 +169,10 @@ export function usePersonaModelDiscovery({
   >(null);
   const [modelDiscoveryLoading, setModelDiscoveryLoading] =
     React.useState(false);
+  /** Bumped by {@link retryModelDiscovery} to force a re-probe (and skip cache). */
+  const [discoveryRetryNonce, setDiscoveryRetryNonce] = React.useState(0);
+  /** True once the current probe has been in flight past MODEL_DISCOVERY_SLOW_MS. */
+  const [discoveryLoadingSlow, setDiscoveryLoadingSlow] = React.useState(false);
   const modelDiscoveryCacheRef = React.useRef(
     new Map<string, AgentModelsResponse>(),
   );
@@ -261,6 +268,7 @@ export function usePersonaModelDiscovery({
     setModelDiscoveryStatus(null);
     setModelDiscoveryStatusKey(activeModelDiscoveryKey);
     setModelDiscoveryLoading(true);
+    setDiscoveryLoadingSlow(false);
     function runModelDiscovery() {
       void discoverAgentModels({
         agentCommand: activeAgentCommand,
@@ -273,9 +281,9 @@ export function usePersonaModelDiscovery({
             return;
           }
           // Only cache responses that yielded usable model options.  An
-          // empty/no-switching result gets the "reopen this screen" warning,
-          // and closing → reopening the dialog must re-run discovery so the
-          // user's CLI-install/sign-in is actually reflected.
+          // empty/no-switching result gets a retryable warning, and closing →
+          // reopening (or Retry) must re-run discovery so CLI install/sign-in
+          // is reflected.
           if (isCacheableDiscoveryResponse(response, trimmedProvider)) {
             modelDiscoveryCacheRef.current.set(
               activeModelDiscoveryKey,
@@ -326,6 +334,7 @@ export function usePersonaModelDiscovery({
     };
   }, [
     discoveryAgentCommand,
+    discoveryRetryNonce,
     envVars,
     modelDiscoveryKey,
     selectedRuntimeAvailability,
@@ -333,6 +342,29 @@ export function usePersonaModelDiscovery({
     shouldDebounceModelDiscovery,
     trimmedProvider,
   ]);
+
+  // One-shot slow-phase flip for status-line copy (#2261). Prefer a single
+  // timeout over a 500ms elapsed ticker that re-renders the tree for no gain.
+  React.useEffect(() => {
+    if (!modelDiscoveryLoading) {
+      setDiscoveryLoadingSlow(false);
+      return;
+    }
+    setDiscoveryLoadingSlow(false);
+    const timeout = window.setTimeout(() => {
+      setDiscoveryLoadingSlow(true);
+    }, MODEL_DISCOVERY_SLOW_MS);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [modelDiscoveryLoading, discoveryRetryNonce, modelDiscoveryKey]);
+
+  const retryModelDiscovery = React.useCallback(() => {
+    if (modelDiscoveryKey !== null) {
+      modelDiscoveryCacheRef.current.delete(modelDiscoveryKey);
+    }
+    setDiscoveryRetryNonce((nonce) => nonce + 1);
+  }, [modelDiscoveryKey]);
 
   const activeModelDiscoveryData =
     modelDiscoveryKey !== null && modelDiscoveryDataKey === modelDiscoveryKey
@@ -359,12 +391,21 @@ export function usePersonaModelDiscovery({
     activeModelDiscoveryStatus,
   });
 
+  // null until slow phase — under-field line stays empty for the first
+  // MODEL_DISCOVERY_SLOW_MS; control already shows the short label.
+  const modelDiscoveryLoadingMessage =
+    modelDiscoveryPending && discoveryLoadingSlow
+      ? formatModelDiscoveryLoadingMessage(true)
+      : null;
+
   return {
     discoveredModelOptions,
     modelDiscoveryLoading: modelDiscoveryPending,
+    modelDiscoveryLoadingMessage,
     modelDiscoveryStatus:
       modelDiscoveryPending || discoveredModelOptions !== null
         ? null
         : activeModelDiscoveryStatus,
+    retryModelDiscovery,
   };
 }


### PR DESCRIPTION
## Summary

- Raise `buzz-acp models` `MODELS_TIMEOUT` from **10s → 45s** so Windows Codex ACP cold starts (~15–25s) can finish instead of returning empty models.
- Progressive loading: control keeps short **Loading models…**; after **10s**, under-field note only (never in the pill — avoids double/truncated copy).
- Clear timeout / PATH discovery errors with **Retry** (`retryable` + shared `ModelDiscoveryStatusLine`).
- Builds on **#2246** (status bypass, empty non-cache); empty catalogs remain uncached and are retryable.

Fixes #2261.

## Context

Codex ACP boots the Codex App Server on each `models` probe. Product assumed ~2–5s; Windows cold path often exceeds the old 10s budget. Related install/PATH work remains separate (#2238).

## Test plan

- [ ] On Windows with Codex installed: open onboarding defaults / agent model field — pill shows short loading only; after ~10s long note appears under field only.
- [ ] With slow/unavailable adapter: timeout message + Retry re-runs discovery.
- [ ] Empty catalog: warning + Retry; response still not cached (#2246).
- [ ] Credential-missing paths remain non-retryable (enter key, not Retry).
- [ ] Unit: `personaModelDiscoveryStatus`, `usePersonaModelDiscovery`, `agentConfigFieldsContract`, `agentConfigControls` tests.
- [ ] Smoke: Claude discovery still works; happy path onboarding stays quiet when not loading/error.

## Notes

- No conflict with recent main (#2246 already base; no newer MODELS_TIMEOUT / discovery UX fix on main).