### PR TITLE
fix(relay): tombstone kind:30620 event row on NIP-09 a-tag workflow deletion

### DIFF
--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -1989,6 +1989,20 @@ async fn handle_a_tag_deletion(
             tracing::debug!(d_tag, "NIP-09 deletion ignored for push lease");
         }
         buzz_core::kind::KIND_WORKFLOW_DEF => {
+            // The a-tag coordinate (`30620:<pubkey>:<d>`) names the authoring
+            // event row. Deleting only the `workflows` projection leaves that
+            // row live, so REQs for kind:30620 keep returning the deleted def
+            // (issue #717). Tombstone the event row alongside the projection.
+            // `handle_workflow_def` requires `d` = workflow UUID, so the event
+            // row's NIP-33 d-tag is always the workflow id string.
+            let def_author_bytes = match hex::decode(pubkey_hex) {
+                Ok(b) => b,
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "invalid pubkey hex in a-tag {pubkey_hex}: {e}"
+                    ));
+                }
+            };
             // Try UUID first (workflow_id); fall back to name-based lookup.
             if let Ok(wf_id) = uuid::Uuid::parse_str(d_tag) {
                 let channel_id = state
@@ -2002,6 +2016,9 @@ async fn handle_a_tag_deletion(
                         .invalidate_channel_workflows(tenant.community(), channel_id);
                 }
                 tracing::info!(workflow_id = %wf_id, "Workflow deleted via NIP-09 a-tag (UUID)");
+                // Unconditional: also heals rows whose projection is already
+                // gone but whose event row stayed live (pre-fix deletions).
+                tombstone_workflow_def_event(tenant, state, &def_author_bytes, d_tag).await?;
             } else {
                 // Name-based lookup
                 match state
@@ -2023,6 +2040,15 @@ async fn handle_a_tag_deletion(
                                 .invalidate_channel_workflows(tenant.community(), channel_id);
                         }
                         tracing::info!(workflow_id = %wf.id, name = d_tag, "Workflow deleted via NIP-09 a-tag (name)");
+                        // The a-tag d-value here is a *name*, not the event
+                        // coordinate — tombstone by the resolved workflow id.
+                        tombstone_workflow_def_event(
+                            tenant,
+                            state,
+                            &def_author_bytes,
+                            &wf.id.to_string(),
+                        )
+                        .await?;
                     }
                     Ok(None) => {
                         tracing::warn!(
@@ -2086,6 +2112,50 @@ async fn handle_a_tag_deletion(
         }
     }
 
+    Ok(())
+}
+
+/// Soft-delete the live kind:30620 event row for a workflow-def coordinate.
+///
+/// The `workflows` table is a projection the workflow engine reads; the
+/// `events` row is what REQ subscribers (e.g. `buzz workflows list`) see.
+/// `handle_workflow_def` stores the def event with `d` = workflow UUID, so
+/// the NIP-33 coordinate is `(KIND_WORKFLOW_DEF, def author, workflow id)`.
+/// Audit lookups use `get_event_by_id_including_deleted` and are unaffected.
+///
+/// Logs at `info` when a live row was tombstoned, `debug` when no live row
+/// matched (already deleted, or a legacy row whose d-tag predates the
+/// id-as-d-tag invariant — those need the reconciliation path from #1593).
+async fn tombstone_workflow_def_event(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+    def_author_bytes: &[u8],
+    event_d_tag: &str,
+) -> anyhow::Result<()> {
+    // Safe cast: KIND_WORKFLOW_DEF is 30620, well within i32.
+    let deleted = state
+        .db
+        .soft_delete_by_coordinate(
+            tenant.community(),
+            buzz_core::kind::KIND_WORKFLOW_DEF as i32,
+            def_author_bytes,
+            event_d_tag,
+        )
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!("failed to soft-delete workflow def event {event_d_tag}: {e}")
+        })?;
+    if deleted {
+        tracing::info!(
+            d_tag = event_d_tag,
+            "NIP-09 a-tag deletion: soft-deleted workflow def event"
+        );
+    } else {
+        tracing::debug!(
+            d_tag = event_d_tag,
+            "NIP-09 a-tag deletion: no live workflow def event matched coordinate"
+        );
+    }
     Ok(())
 }
 

--- a/crates/buzz-test-client/tests/e2e_workflow_def_deletion.rs
+++ b/crates/buzz-test-client/tests/e2e_workflow_def_deletion.rs
@@ -1,0 +1,266 @@
+//! End-to-end tests for NIP-09 a-tag deletion of workflow definitions
+//! (kind:30620).
+//!
+//! Regression coverage for issue #717 — before the fix,
+//! `handle_a_tag_deletion`'s workflow branch deleted the `workflows`
+//! projection row but never tombstoned the underlying kind:30620 event row,
+//! so REQ subscribers kept receiving the deleted definition.
+//!
+//! These tests require a running relay instance. By default they are marked
+//! `#[ignore]` so that `cargo test` does not fail in CI when the relay is not
+//! available.
+//!
+//! # Running
+//!
+//! Start the relay, then run:
+//!
+//! ```text
+//! cargo test --test e2e_workflow_def_deletion -- --ignored
+//! ```
+//!
+//! Override the relay URL with the `RELAY_URL` environment variable.
+
+use std::time::Duration;
+
+use buzz_test_client::BuzzTestClient;
+use nostr::{Alphabet, EventBuilder, Filter, Keys, Kind, SingleLetterTag, Tag};
+
+const KIND_WORKFLOW_DEF: u16 = 30620;
+
+fn relay_url() -> String {
+    std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string())
+}
+
+fn relay_http_url() -> String {
+    relay_url()
+        .replace("wss://", "https://")
+        .replace("ws://", "http://")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn sub_id(name: &str) -> String {
+    format!("e2e-{name}-{}", uuid::Uuid::new_v4())
+}
+
+/// Minimal valid workflow YAML. `handle_workflow_def` parses this before
+/// persisting, and injects a webhook secret for webhook triggers.
+fn workflow_yaml(name: &str) -> String {
+    format!(
+        "name: {name}\n\
+         description: e2e deletion probe\n\
+         trigger:\n\
+         \x20 on: webhook\n\
+         steps:\n\
+         \x20 - id: step1\n\
+         \x20   name: Notify\n\
+         \x20   action: send_message\n\
+         \x20   text: \"e2e\"\n"
+    )
+}
+
+/// Create an `open` channel (kind:9007) via POST /events. The h-tag UUID
+/// takes the `create_channel_with_id` path, which bootstraps the creator as
+/// owner-member — the membership `handle_workflow_def` requires. Returns the
+/// channel UUID string.
+async fn create_test_channel(keys: &Keys) -> String {
+    let client = reqwest::Client::new();
+    let channel_uuid = uuid::Uuid::new_v4();
+
+    let event = EventBuilder::new(Kind::Custom(9007), "")
+        .tags(vec![
+            Tag::parse(["h", &channel_uuid.to_string()]).unwrap(),
+            Tag::parse(["name", &format!("e2e-wf-del-{channel_uuid}")]).unwrap(),
+            Tag::parse(["channel_type", "stream"]).unwrap(),
+            Tag::parse(["visibility", "open"]).unwrap(),
+        ])
+        .sign_with_keys(keys)
+        .unwrap();
+
+    let resp = client
+        .post(format!("{}/events", relay_http_url()))
+        .header("X-Pubkey", keys.public_key().to_hex())
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(&event).unwrap())
+        .send()
+        .await
+        .expect("submit create-channel event");
+    assert!(
+        resp.status().is_success(),
+        "channel creation event failed: {}",
+        resp.status()
+    );
+    let body: serde_json::Value = resp.json().await.expect("parse event response");
+    assert!(
+        body["accepted"].as_bool().unwrap_or(false),
+        "channel creation not accepted: {body}"
+    );
+
+    channel_uuid.to_string()
+}
+
+/// Publish a workflow definition (kind:30620, `d` = workflow UUID, `h` =
+/// channel) and assert acceptance. Returns the workflow UUID string — which
+/// is also the event row's NIP-33 d-tag (create-path invariant).
+async fn define_workflow(
+    client: &mut BuzzTestClient,
+    keys: &Keys,
+    channel_id: &str,
+) -> (String, nostr::EventId) {
+    let workflow_id = uuid::Uuid::new_v4().to_string();
+    let name = format!("e2e-doomed-wf-{}", uuid::Uuid::new_v4().simple());
+    let event = EventBuilder::new(Kind::Custom(KIND_WORKFLOW_DEF), workflow_yaml(&name))
+        .tags(vec![
+            Tag::parse(["d", &workflow_id]).unwrap(),
+            Tag::parse(["h", channel_id]).unwrap(),
+        ])
+        .sign_with_keys(keys)
+        .unwrap();
+    let event_id = event.id;
+
+    let ok = client.send_event(event).await.expect("send workflow def");
+    assert!(
+        ok.accepted,
+        "workflow def should be accepted: {}",
+        ok.message
+    );
+
+    (workflow_id, event_id)
+}
+
+/// REQ the live kind:30620 row for `(author, d-tag)`.
+async fn query_def_events(
+    client: &mut BuzzTestClient,
+    keys: &Keys,
+    workflow_id: &str,
+    label: &str,
+) -> Vec<nostr::Event> {
+    let sid = sub_id(label);
+    let filter = Filter::new()
+        .kind(Kind::Custom(KIND_WORKFLOW_DEF))
+        .author(keys.public_key())
+        .custom_tag(SingleLetterTag::lowercase(Alphabet::D), workflow_id);
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe");
+    client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("collect")
+}
+
+/// A kind:5 deletion carrying `["a", "30620:<pk>:<workflow_id>"]` removes the
+/// workflow AND tombstones the underlying kind:30620 event row, so REQs stop
+/// returning the deleted definition.
+///
+/// Regression test for issue #717.
+#[tokio::test]
+#[ignore]
+async fn test_workflow_def_a_tag_deletion_by_uuid_tombstones_event() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let channel_id = create_test_channel(&keys).await;
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let (workflow_id, def_event_id) = define_workflow(&mut client, &keys, &channel_id).await;
+
+    // Sanity: the def event is queryable before deletion — this is the exact
+    // surface `buzz workflows list` reads.
+    let pre = query_def_events(&mut client, &keys, &workflow_id, "wf-del-pre").await;
+    assert!(
+        pre.iter().any(|e| e.id == def_event_id),
+        "workflow def event should be queryable before deletion"
+    );
+
+    // NIP-09 a-tag deletion of the workflow coordinate.
+    let a_coord = format!(
+        "{}:{}:{}",
+        KIND_WORKFLOW_DEF,
+        keys.public_key().to_hex(),
+        workflow_id
+    );
+    let del = EventBuilder::new(Kind::EventDeletion, "")
+        .tags(vec![Tag::parse(["a", &a_coord]).unwrap()])
+        .sign_with_keys(&keys)
+        .unwrap();
+    let ok_del = client.send_event(del).await.expect("send deletion");
+    assert!(
+        ok_del.accepted,
+        "a-tag deletion should be accepted: {}",
+        ok_del.message
+    );
+
+    // The kind:30620 event row must be gone from REQ results.
+    let post = query_def_events(&mut client, &keys, &workflow_id, "wf-del-post").await;
+    assert!(
+        post.is_empty(),
+        "a-tag deletion must tombstone the workflow def event (got {} events)",
+        post.len()
+    );
+
+    client.disconnect().await.expect("disconnect");
+}
+
+/// The name-fallback deletion path (`d` = workflow name, not UUID) resolves
+/// the workflow row and tombstones the event row by the resolved id.
+#[tokio::test]
+#[ignore]
+async fn test_workflow_def_a_tag_deletion_by_name_tombstones_event() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let channel_id = create_test_channel(&keys).await;
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    // Publish with a `name` tag so the row name is human-stable.
+    let workflow_id = uuid::Uuid::new_v4().to_string();
+    let name = format!("e2e-named-wf-{}", uuid::Uuid::new_v4().simple());
+    let event = EventBuilder::new(Kind::Custom(KIND_WORKFLOW_DEF), workflow_yaml(&name))
+        .tags(vec![
+            Tag::parse(["d", &workflow_id]).unwrap(),
+            Tag::parse(["h", &channel_id]).unwrap(),
+            Tag::parse(["name", &name]).unwrap(),
+        ])
+        .sign_with_keys(&keys)
+        .unwrap();
+    let def_event_id = event.id;
+    let ok = client.send_event(event).await.expect("send workflow def");
+    assert!(
+        ok.accepted,
+        "workflow def should be accepted: {}",
+        ok.message
+    );
+
+    let pre = query_def_events(&mut client, &keys, &workflow_id, "wf-name-pre").await;
+    assert!(
+        pre.iter().any(|e| e.id == def_event_id),
+        "workflow def event should be queryable before deletion"
+    );
+
+    // a-tag d-value is the workflow *name* — not a UUID, not the event d-tag.
+    let a_coord = format!(
+        "{}:{}:{}",
+        KIND_WORKFLOW_DEF,
+        keys.public_key().to_hex(),
+        name
+    );
+    let del = EventBuilder::new(Kind::EventDeletion, "")
+        .tags(vec![Tag::parse(["a", &a_coord]).unwrap()])
+        .sign_with_keys(&keys)
+        .unwrap();
+    let ok_del = client.send_event(del).await.expect("send name deletion");
+    assert!(
+        ok_del.accepted,
+        "name-based a-tag deletion should be accepted: {}",
+        ok_del.message
+    );
+
+    let post = query_def_events(&mut client, &keys, &workflow_id, "wf-name-post").await;
+    assert!(
+        post.is_empty(),
+        "name-based deletion must tombstone the workflow def event (got {} events)",
+        post.len()
+    );
+
+    client.disconnect().await.expect("disconnect");
+}


### PR DESCRIPTION
## Problem

`handle_a_tag_deletion`'s `KIND_WORKFLOW_DEF` branch deletes the `workflows`
projection row but never tombstones the underlying kind:30620 event row, so
REQ subscribers (e.g. `buzz workflows list`) keep receiving the deleted
definition. Fixes #717 — same bug shape as #714, scoped to the workflow kind
(the generic NIP-33 arm added for #714 intentionally excluded it).

## Implementation

Tombstone the event row via `soft_delete_by_coordinate` on both deletion paths:

- **UUID path**: the a-tag d-value is the workflow id, which is also the event
  row's d-tag (`handle_workflow_def` requires `d` = workflow UUID).
- **Name path**: the a-tag d-value is a *name*, not the event coordinate, so we
  resolve the workflow row first and tombstone by its id.
- The UUID-path tombstone is unconditional, which also heals pre-fix rows whose
  projection is already gone but whose event row stayed live (re-sending the
  deletion now converges them).

The coordinate uses the a-tag's pubkey — the NIP-33 author — matching what
`validate_standard_deletion_event` authorized.

Verified nothing operational relies on the row staying live: the workflow
engine and the webhook bridge load definitions from the `workflows` table
(never the events row), and audit lookups go through
`get_event_by_id_including_deleted`, which is tombstone-tolerant by design.

Composes with #2242 (same function, different concern: that PR aligns *who*
the projection delete targets; this one adds the missing event tombstone).
Happy to rebase over whichever lands first.

## Testing

New `crates/buzz-test-client/tests/e2e_workflow_def_deletion.rs` (2 tests:
UUID deletion, name deletion). Verified against a local relay
(postgres/redis/minio via docker compose):

- against unfixed `main`: both tests FAIL (deleted def still served)
- with this change: both PASS
- `e2e_long_form` suite (the #714 generic NIP-33 arm): 8/8 PASS
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

`just ci` not run end-to-end locally (desktop/mobile toolchain versions on
this machine); no desktop or mobile files touched — relying on GitHub CI for
those legs.

## Checklist

- [x] `cargo fmt` + `clippy -D warnings` clean
- [x] Regression test included (fails without the fix)
- [x] No new `unwrap()` in production code paths
- [x] No new `unsafe` blocks
