### PR TITLE
test(db): make replica_fence boundary assertions clock-resolution portable

### DIFF
--- a/crates/buzz-db/src/replica_fence.rs
+++ b/crates/buzz-db/src/replica_fence.rs
@@ -523,9 +523,20 @@ mod tests {
 
         let ts = Utc::now();
         fence.advance(ts);
-        assert_eq!(fence.verified_through(), Some(ts));
+        // advance() normalizes to Postgres timestamptz resolution (micros);
+        // compare at that resolution so the assertion is clock-precision
+        // portable (Utc::now() yields nanos on Linux, micros elsewhere).
+        assert_eq!(
+            fence.verified_through(),
+            DateTime::from_timestamp_micros(ts.timestamp_micros())
+        );
         assert!(fence.covers(ts - chrono::Duration::seconds(1)));
-        assert!(fence.covers(ts), "boundary is inclusive");
+        // Inclusive boundary at the fence's resolution: the exact micros
+        // watermark is covered (raw nanos `ts` is strictly past it).
+        assert!(
+            fence.covers(DateTime::from_timestamp_micros(ts.timestamp_micros()).unwrap()),
+            "boundary is inclusive"
+        );
         assert!(!fence.covers(ts + chrono::Duration::seconds(1)));
 
         fence.close();


### PR DESCRIPTION
## Problem

`replica_fence::tests::fence_starts_closed_and_opens_on_advance` fails on
hosts whose wall clock returns nanoseconds (e.g. Linux):

- `verified_through()` returns the fence at Postgres timestamptz resolution
  (`advance()` stores `timestamp_micros()`), but the test asserted equality
  with `Utc::now()` (nanos) — mismatch on any sub-microsecond reading.
- `covers(ts)` compared nanos `ts` against the micros fence, so `ts` was
  strictly *past* the fence and the "boundary is inclusive" assertion failed.

Production behavior is unchanged — micros normalization is correct for
Postgres. The test compared across resolutions.

## Fix

Compare at the fence's resolution via
`DateTime::from_timestamp_micros(ts.timestamp_micros())`.

## Testing

`cargo test -p buzz-db --lib`: 81/82 → 82/82 on Linux.
`cargo clippy -p buzz-db --all-targets -- -D warnings`, `cargo fmt --check`: clean.
