### PR TITLE
fix(cli): install rustls CryptoProvider so wss:// draft publish can't panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "nostr",
  "rand 0.10.1",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/buzz-cli/Cargo.toml
+++ b/crates/buzz-cli/Cargo.toml
@@ -76,6 +76,8 @@ dirs = "6"
 # WebSocket client — ephemeral event publish (kind:20001 is WS-only on the relay)
 buzz-ws-client = { path = "../buzz-ws-client" }
 
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std"] }
+
 # Random number generation — full jitter for exponential backoff in with_retry
 rand = { workspace = true }
 

--- a/crates/buzz-cli/src/main.rs
+++ b/crates/buzz-cli/src/main.rs
@@ -1,4 +1,6 @@
 #[tokio::main]
 async fn main() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     std::process::exit(buzz_cli::run_from_args(std::env::args()).await);
 }


### PR DESCRIPTION
## Problem

`buzz agents draft-create` / `draft-update` panic before opening the draft when the relay is `wss://`:

```
rustls-0.23.42/src/crypto/mod.rs:249: Could not automatically determine the
process-level CryptoProvider from Rustls crate features.
```

These subcommands publish an ephemeral event (kind:20001 is WS-only on the relay) over WebSocket. Against a `wss://` relay, tokio-tungstenite's `connect_async` builds a rustls `ClientConfig` whose builder auto-selects a crypto provider from the enabled crate features. Released CLI builds compile in **both** aws-lc-rs (via reqwest) and ring (transitively), so the auto-selection is ambiguous and rustls panics on the first `wss://` connection.

Every other Buzz binary already installs a provider explicitly at startup (relay, admin, acp, dev-mcp, the desktop WS client). `buzz-cli` was the only one relying on fragile auto-detection — so `messages send` / `users get` (which use reqwest over HTTPS, not tungstenite) work fine, while the WS-only draft path crashes.

## Fix

Install `aws-lc-rs` (already pulled in by reqwest) as the process-default `CryptoProvider` at the top of `main()`, mirroring the desktop WS client:

```rust
let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
```

`let _` because a re-install returning `Err` is harmless — it just means a provider is already set.

The `rustls` dependency is added with `default-features = false, features = ["aws_lc_rs", "std"]` so only the aws-lc-rs backend is pulled, matching the provider installed above.

## Verification

- Reproduced locally by compiling both providers into buzz-cli: the panic occurs without the install and disappears with it (draft publish returns `accepted: true`).
- `cargo fmt` + `cargo clippy` clean.
- 250 buzz-cli unit tests pass.

## Note

Per review feedback, the inline explanatory comments were removed from the code — the rationale lives here in the PR description instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
