### PR TITLE
fix(desktop): emit singular "mention" feed item category from native get_feed

### DIFF
--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -41,6 +41,14 @@ const TIMELINE_KINDS: [u32; 11] = [
     buzz_core_pkg::kind::KIND_HUDDLE_STARTED,
 ];
 
+/// Per-item feed `category` values — the frontend `FeedItemCategory` union
+/// (desktop/src/shared/api/tauri.ts) declares the singular "mention", while
+/// the `FeedSections` JSON key stays plural ("mentions"). Every frontend
+/// consumer compares `category === "mention"`, so emitting the plural here
+/// misclassifies native mention items (wrong toast title, inbox grouping).
+const FEED_CATEGORY_MENTION: &str = "mention";
+const FEED_CATEGORY_NEEDS_ACTION: &str = "needs_action";
+
 #[tauri::command]
 pub async fn get_feed(
     since: Option<i64>,
@@ -102,11 +110,11 @@ pub async fn get_feed(
 
     let mentions: Vec<FeedItemInfo> = mention_events
         .iter()
-        .map(|ev| feed_item_from_event(ev, "mentions"))
+        .map(|ev| feed_item_from_event(ev, FEED_CATEGORY_MENTION))
         .collect();
     let needs_action: Vec<FeedItemInfo> = approval_events
         .iter()
-        .map(|ev| feed_item_from_event(ev, "needs_action"))
+        .map(|ev| feed_item_from_event(ev, FEED_CATEGORY_NEEDS_ACTION))
         .collect();
 
     let total = (mentions.len() + needs_action.len()) as u64;

--- a/desktop/src-tauri/src/commands/messages_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_tests.rs
@@ -159,6 +159,28 @@ fn thread_replies_filter_pages_with_composite_cursor() {
 }
 
 #[test]
+fn feed_item_categories_match_the_frontend_union() {
+    // The frontend `FeedItemCategory` union (desktop/src/shared/api/tauri.ts)
+    // and every consumer (`notificationTitle`, inbox grouping, sound slots)
+    // compare `category === "mention"` — singular. The sections object key is
+    // plural ("mentions"), and emitting the plural as the per-item category
+    // made native mention items fall through every match arm (block/buzz#2106:
+    // "X mentioned you" toasts rendered as "Needs Action"). The e2e bridge
+    // emits the singular, so relay-mode tests never see the native shape —
+    // this unit test is the only guard against the contract drifting again.
+    assert_eq!(FEED_CATEGORY_MENTION, "mention");
+    assert_eq!(FEED_CATEGORY_NEEDS_ACTION, "needs_action");
+
+    let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "hey @you")
+        .tags([nostr::Tag::parse(["h", "channel-1"]).expect("valid tag")])
+        .sign_with_keys(&Keys::generate())
+        .expect("event should sign");
+    let item = feed_item_from_event(&event, FEED_CATEGORY_MENTION);
+    assert_eq!(item.category, "mention");
+    assert_eq!(item.channel_id.as_deref(), Some("channel-1"));
+}
+
+#[test]
 fn stored_managed_agent_auth_tag_trims_blank_values() {
     assert_eq!(
         stored_managed_agent_auth_tag(Some("  [\"auth\",\"owner\",\"\",\"sig\"]  ")),


### PR DESCRIPTION
Fixes #2106

## Problem

Native `get_feed` emitted feed items with `category: "mentions"` (plural), but the declared `FeedItemCategory` union (`desktop/src/shared/api/tauri.ts`) and every frontend consumer compare the singular `"mention"`:

- `notificationTitle` (`desktop/src/features/notifications/lib/feed.ts`) — native mention items fell through to the fallback, so mention toasts rendered as "Needs Action in #channel" instead of "X mentioned you in #channel".
- Inbox labeling, grouping priority, and mention-specific handling (`desktop/src/features/home/lib/inbox.ts`).
- Sound slot selection (`desktop/src/features/notifications/lib/sound.ts`) and other `category === "mention"` consumers.

The e2e bridge emits the singular, so relay-mode tests never exercised the native shape — the mismatch only surfaced in native mode.

## Fix

- `get_feed` now emits the singular `"mention"` per-item category via named constants (`FEED_CATEGORY_MENTION`, `FEED_CATEGORY_NEEDS_ACTION`), with a comment documenting the contract: per-item categories are singular, while the `FeedSections` JSON keys (and the `types` request filter) stay plural.
- Added a unit test pinning the category values against the frontend union, since no e2e path can catch this drift (the mock bridge reimplements the feed in JS).

The `types` request-filter parsing (`"mentions,needs_action"`) is untouched — that is the section-name contract and the frontend sends plurals there (`desktop/src/features/home/hooks.ts`).

## Testing

- `just desktop-tauri-test` — 1528 passed, 0 failed (includes the new `feed_item_categories_match_the_frontend_union`).
- `just desktop-tauri-clippy` and `cargo fmt --check` clean.
- Verified no consumer in desktop/web/mobile compares against the plural per-item value.
