### PR TITLE
fix(test): restore workflow tenant-isolation conformance row (d-tag = workflow UUID)

### DIFF
--- a/crates/buzz-test-client/tests/conformance_multitenant.rs
+++ b/crates/buzz-test-client/tests/conformance_multitenant.rs
@@ -1741,19 +1741,17 @@ mod workflows {
     }
 
     /// Define a workflow in `channel_id` on `http_base`'s community (kind:30620,
-    /// `h`=channel, content=YAML). Returns the **server-generated** workflow id,
-    /// parsed out of the OK message (`response:{"workflow_id":"…"}`). This id is
-    /// the tenant-scoped handle the trigger door confines: defined under A, it
-    /// only resolves under A.
+    /// `h`=channel, `d`=workflow UUID, content=YAML). `handle_workflow_def`
+    /// requires the NIP-33 d-tag to BE the workflow UUID — the workflow row id
+    /// and the event d-tag are the same string — so the client supplies it and
+    /// the OK message (`response:{"workflow_id":"…"}`) echoes it back. This id
+    /// is the tenant-scoped handle the trigger door confines: defined under A,
+    /// it only resolves under A.
     async fn define_workflow(http_base: &str, keys: &Keys, channel_id: &str, name: &str) -> String {
-        // `h` binds the channel; `name` is required by `handle_workflow_def`
-        // (it rejects "missing workflow name" before parsing YAML). We use the
-        // `name` tag, not `d`: the server *generates* the workflow id, and that
-        // generated id — not any client-supplied `d` — is the handle this row
-        // confines. A `d` tag here would falsely imply the trigger resolves by
-        // client key.
+        let workflow_id = uuid::Uuid::new_v4().to_string();
         let event = EventBuilder::new(Kind::Custom(KIND_WORKFLOW_DEF), workflow_yaml(name))
             .tags(vec![
+                Tag::parse(["d", &workflow_id]).unwrap(),
                 Tag::parse(["h", channel_id]).unwrap(),
                 Tag::parse(["name", name]).unwrap(),
             ])


### PR DESCRIPTION
## Problem

`workflows::workflow_trigger_is_community_confined` in the multi-tenant
conformance suite hard-fails with `HTTP 400: invalid: missing d tag
(workflow_id)`. Its `define_workflow` helper emits a name-tag-only kind:30620
definition, but `handle_workflow_def` now requires the NIP-33 d-tag to BE the
workflow UUID — so every workflow row in the suite, including this
tenant-isolation gate, has been silently untestable.

## Fix

The helper supplies `d` = a fresh workflow UUID (the id the OK response echoes
back), matching the create-path invariant (workflow row id == event d-tag), and
the stale comment claiming the server generates the id is corrected.

Test-harness only; no relay behavior change.

## Testing

Verified against a local two-host relay (`a.localhost` + `b.localhost` on one
process/Postgres/Redis):

- `workflows::workflow_trigger_is_community_confined`: **PASS** (was HTTP 400)
- Full `conformance_multitenant`: 9 pass / 9 fail — remaining failures are the
  8 `todo!()` lane stubs (unchanged) plus the pre-existing NIP-11 `origin`
  invariant failure (unrelated to this change)
- `cargo fmt --check` + `cargo clippy -p buzz-test-client --all-targets -- -D warnings`: clean
