### PR TITLE
fix(desktop): normalize feed item category contract to singular mention (#2106)

### DIFF
--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -102,7 +102,7 @@ pub async fn get_feed(
 
     let mentions: Vec<FeedItemInfo> = mention_events
         .iter()
-        .map(|ev| feed_item_from_event(ev, "mentions"))
+        .map(|ev| feed_item_from_event(ev, "mention"))
         .collect();
     let needs_action: Vec<FeedItemInfo> = approval_events
         .iter()

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -325,7 +325,12 @@ export function fromRawFeedItem(item: RawFeedItem) {
     // notification filter both key off `=== undefined`).
     channelType: item.channel_type ?? undefined,
     tags: item.tags,
-    category: item.category,
+    // Canonicalize the wire plural "mentions" to singular "mention" so
+    // FeedItemCategory union expectations hold regardless of wire payload.
+    category:
+      (item.category as string) === "mentions"
+        ? "mention"
+        : (item.category as FeedItemCategory),
   };
 }
 

--- a/desktop/src/shared/api/tauriFeed.test.mjs
+++ b/desktop/src/shared/api/tauriFeed.test.mjs
@@ -33,3 +33,16 @@ test("passes a present channel_type through unchanged", () => {
 
   assert.equal(item.channelType, "dm");
 });
+
+test("canonicalizes plural mentions category to singular mention", () => {
+  const item = fromRawFeedItem(rawFeedItem({ category: "mentions" }));
+
+  assert.equal(item.category, "mention");
+});
+
+test("passes a singular mention category through unchanged", () => {
+  const item = fromRawFeedItem(rawFeedItem({ category: "mention" }));
+
+  assert.equal(item.category, "mention");
+});
+


### PR DESCRIPTION
Fixes #2106

## 🐛 What was the issue?
Native `get_feed` (in `desktop/src-tauri/src/commands/messages.rs`) was emitting feed items with `category: "mentions"` (plural), while the declared TypeScript `FeedItemCategory` union value (`types.ts`) and every frontend consumer (`feed.ts`, `inbox.ts`) checked against singular `"mention"`. 
As a result, in native mode, mention feed items fell through to generic notification fallbacks ("Needs Action in #channel" instead of "@Mention") and missed mention-specific inbox classification/labeling.

## 🛠️ What did we fix?
- **Tauri Native Backend**: Updated `get_feed` in `desktop/src-tauri/src/commands/messages.rs` so `feed_item_from_event` receives singular `"mention"` instead of `"mentions"`.
- **Frontend API Boundary**: Updated `fromRawFeedItem` in `desktop/src/shared/api/tauri.ts` to canonicalize wire `"mentions"` to `"mention"` as a defensive guard.
- **Unit Tests**: Added unit tests in `desktop/src/shared/api/tauriFeed.test.mjs` verifying category normalization.

## 🧪 Testing & Verification
- Added unit tests in `tauriFeed.test.mjs` asserting that `fromRawFeedItem` canonicalizes `"mentions"` to `"mention"` and preserves `"mention"`.
- Verified category contract alignment across Rust models and TypeScript types.
