### PR TITLE
fix(desktop): place onboarding harness actions below descriptions

### DIFF
--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -496,12 +496,6 @@ function RuntimeCard({
             {getRuntimeDisplayLabel(runtime)}
           </h2>
         </div>
-        <RuntimeStatus
-          installError={installError}
-          isInstalling={isInstalling}
-          onInstall={onInstall}
-          runtime={runtime}
-        />
         {!isAvailable && runtimeDetailText(runtime) ? (
           <p
             aria-hidden={installError ? "true" : undefined}
@@ -513,6 +507,12 @@ function RuntimeCard({
             {runtimeDetailText(runtime)}
           </p>
         ) : null}
+        <RuntimeStatus
+          installError={installError}
+          isInstalling={isInstalling}
+          onInstall={onInstall}
+          runtime={runtime}
+        />
       </div>
       {installError ? (
         <RuntimeErrorTooltip


### PR DESCRIPTION
## What

In desktop onboarding’s “Set up your agent harnesses” stage, switch the description and setup action in each provider card so the description appears above the Install button.

## Why

Provider cards currently follow a title → button → description pattern, which makes the Install button read more like a status pill.

Grouping the title with its description creates a familiar text block followed by a distinct action, making it immediately clearer that Install is interactive.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/c25bb1b4-283b-401b-9220-943bb67b3c16" />
