### PR TITLE
fix(desktop): keep onboarding runtime installs independent

### DIFF
--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -42,13 +42,6 @@ type SetupStepContentProps = SetupStepProps & {
   state: SetupStepState;
 };
 
-type InstallResultState = {
-  error: string | null;
-  success: boolean;
-};
-
-type InstallResultsState = Record<string, InstallResultState>;
-
 function useSetupStepState(): SetupStepState {
   const runtimesQuery = useAcpRuntimesQuery();
   const items = runtimesQuery.data ?? [];
@@ -462,19 +455,27 @@ function RuntimeAuthError({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
   return null;
 }
 
-function RuntimeCard({
-  installError,
-  isInstalling,
-  onInstall,
-  runtime,
-}: {
-  installError: string | null;
-  isInstalling: boolean;
-  onInstall: () => void;
-  runtime: AcpRuntimeCatalogEntry;
-}) {
+function RuntimeCard({ runtime }: { runtime: AcpRuntimeCatalogEntry }) {
+  const installMutation = useInstallAcpRuntimeMutation();
+  const [installError, setInstallError] = React.useState<string | null>(null);
   const isAvailable = runtime.availability === "available";
   const isReady = runtimeIsReadyForOnboarding(runtime);
+
+  function handleInstall() {
+    setInstallError(null);
+    installMutation.mutate(runtime.id, {
+      onSuccess: (result) => {
+        setInstallError(
+          result.success ? null : getInstallErrorMessage(result.steps),
+        );
+      },
+      onError: (error) => {
+        setInstallError(
+          error instanceof Error ? error.message : "Install failed.",
+        );
+      },
+    });
+  }
 
   return (
     <Card
@@ -498,8 +499,8 @@ function RuntimeCard({
         </div>
         <RuntimeStatus
           installError={installError}
-          isInstalling={isInstalling}
-          onInstall={onInstall}
+          isInstalling={installMutation.isPending}
+          onInstall={handleInstall}
           runtime={runtime}
         />
         {!isAvailable && runtimeDetailText(runtime) ? (
@@ -548,46 +549,12 @@ function RuntimeProvidersLoadingState() {
 }
 
 function RuntimeProvidersSection({
-  installResults,
-  onInstallResultsChange,
   runtimeProviders,
 }: {
-  installResults: InstallResultsState;
-  onInstallResultsChange: React.Dispatch<
-    React.SetStateAction<InstallResultsState>
-  >;
   runtimeProviders: SetupStepState["runtimeProviders"];
 }) {
   const { errorMessage, isChecking, items } = runtimeProviders;
   const orderedItems = getVisibleOnboardingRuntimes(items);
-  const installMutation = useInstallAcpRuntimeMutation();
-
-  function handleInstall(runtimeId: string) {
-    onInstallResultsChange((current) => ({
-      ...current,
-      [runtimeId]: { error: null, success: false },
-    }));
-
-    installMutation.mutate(runtimeId, {
-      onSuccess: (result) => {
-        onInstallResultsChange((current) => ({
-          ...current,
-          [runtimeId]: result.success
-            ? { error: null, success: true }
-            : { error: getInstallErrorMessage(result.steps), success: false },
-        }));
-      },
-      onError: (error) => {
-        onInstallResultsChange((current) => ({
-          ...current,
-          [runtimeId]: {
-            error: error instanceof Error ? error.message : "Install failed.",
-            success: false,
-          },
-        }));
-      },
-    });
-  }
 
   return (
     <section className="flex min-h-full w-full flex-col items-center">
@@ -605,16 +572,7 @@ function RuntimeProvidersSection({
         {orderedItems.length > 0 ? (
           <div className="grid min-w-0 w-full max-w-[592px] grid-cols-1 gap-4 md:grid-cols-2">
             {orderedItems.map((runtime) => (
-              <RuntimeCard
-                installError={installResults[runtime.id]?.error ?? null}
-                isInstalling={
-                  installMutation.isPending &&
-                  installMutation.variables === runtime.id
-                }
-                key={runtime.id}
-                onInstall={() => handleInstall(runtime.id)}
-                runtime={runtime}
-              />
+              <RuntimeCard key={runtime.id} runtime={runtime} />
             ))}
           </div>
         ) : isChecking ? (
@@ -646,8 +604,6 @@ function SetupStepContent({
   state,
 }: SetupStepContentProps) {
   const { runtimeProviders } = state;
-  const [installResults, setInstallResults] =
-    React.useState<InstallResultsState>({});
   const readyRuntimeIds = React.useMemo(
     () =>
       getReadyOnboardingRuntimes(runtimeProviders.items).map(
@@ -670,11 +626,7 @@ function SetupStepContent({
       direction={direction}
       transitionKey={`setup-${direction}`}
     >
-      <RuntimeProvidersSection
-        installResults={installResults}
-        onInstallResultsChange={setInstallResults}
-        runtimeProviders={runtimeProviders}
-      />
+      <RuntimeProvidersSection runtimeProviders={runtimeProviders} />
 
       <OnboardingFooter>
         <Button

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -35,6 +35,22 @@ function runtime(
   };
 }
 
+function installResult(runtimeId: string, success: boolean) {
+  return {
+    success,
+    steps: [
+      {
+        step: "adapter",
+        command: `mock install ${runtimeId}`,
+        success,
+        stdout: success ? "installed" : "",
+        stderr: success ? "" : `mock ${runtimeId} install failed`,
+        exit_code: success ? 0 : 1,
+      },
+    ],
+  };
+}
+
 async function navigateToSetupPage(
   page: Parameters<typeof installMockBridge>[0],
 ) {
@@ -322,6 +338,79 @@ test("failed install can be retried without shifting card content", async ({
   await expect(page.getByTestId("onboarding-runtime-ready-claude")).toHaveText(
     "READY",
   );
+});
+
+test("runtime installs progress, resolve, and retry independently", async ({
+  page,
+}) => {
+  const claudeMissing = runtime("claude", "adapter_missing", {
+    status: "unknown",
+  });
+  const codexMissing = runtime("codex", "adapter_missing", {
+    status: "unknown",
+  });
+  const claudeReady = runtime("claude", "available", {
+    status: "logged_in",
+  });
+  const codexReady = runtime("codex", "available", {
+    status: "logged_in",
+  });
+
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [claudeMissing, codexMissing],
+      acpRuntimesCatalogAfterInstallSequence: [
+        [claudeMissing, codexReady],
+        [claudeReady, codexReady],
+      ],
+      installAcpRuntimeDelayMs: 500,
+      installAcpRuntimeResults: [
+        installResult("claude", false),
+        installResult("codex", true),
+        installResult("claude", true),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  const claude = page.getByTestId("onboarding-runtime-claude");
+  const codex = page.getByTestId("onboarding-runtime-codex");
+  const claudeInstall = claude.getByTestId("onboarding-runtime-install-claude");
+  const codexInstall = codex.getByTestId("onboarding-runtime-install-codex");
+
+  await claudeInstall.click();
+  await codexInstall.click();
+  await expect(
+    claude.getByRole("status", { name: "Installing Claude Code" }),
+  ).toBeVisible();
+  await expect(
+    codex.getByRole("status", { name: "Installing Codex" }),
+  ).toBeVisible();
+
+  await expect(
+    claude.getByTestId("onboarding-runtime-error-claude"),
+  ).toBeVisible();
+  await expect(claudeInstall).toHaveText("RETRY INSTALL");
+  await expect(codex.getByTestId("onboarding-runtime-ready-codex")).toHaveText(
+    "READY",
+  );
+  await expect(codex.getByTestId("onboarding-runtime-error-codex")).toHaveCount(
+    0,
+  );
+
+  await claudeInstall.click();
+  await expect(
+    claude.getByRole("status", { name: "Installing Claude Code" }),
+  ).toBeVisible();
+  await expect(codex.getByTestId("onboarding-runtime-ready-codex")).toHaveText(
+    "READY",
+  );
+  await expect(
+    claude.getByTestId("onboarding-runtime-ready-claude"),
+  ).toHaveText("READY");
 });
 
 test("install transitions through Sign in to Ready", async ({ page }) => {


### PR DESCRIPTION
## Summary

- give each onboarding runtime card an independent install mutation and error state
- preserve per-runtime progress, completion, failure, and retry behavior during concurrent installs
- add regression coverage for overlapping Claude Code and Codex setup operations

## Root cause

All runtime cards shared one TanStack Query mutation observer. Starting another install replaced the observer callbacks and visible state associated with the earlier operation, even though the native installs continued concurrently.

## Scope

This is isolated to runtime installation state in the desktop onboarding setup step and its focused Playwright coverage.

## Testing

- `pnpm typecheck`
- `pnpm check`
- `pnpm build`
- `pnpm test` — 3,367 passed
- focused onboarding Playwright regression — 1 passed