### PR TITLE
fix(onboarding): skip community profile setup for existing relay members

### DIFF
--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -20,6 +20,8 @@ import { useMachineOnboardingState } from "@/features/onboarding/machineOnboardi
 import {
   type FirstCommunityPage,
   useCommunityOnboarding,
+  markCommunityOnboardingComplete,
+  shouldSkipCommunityOnboarding,
 } from "@/features/onboarding/communityOnboarding";
 import { CommunityOnboardingFlow } from "@/features/onboarding/ui/CommunityOnboardingFlow";
 import {
@@ -43,6 +45,7 @@ import { CommunityApplyErrorScreen } from "@/features/communities/ui/CommunityAp
 import { CommunityChangeOverlay } from "@/features/communities/ui/CommunityChangeOverlay";
 import { createBuzzQueryClient } from "@/shared/api/queryClient";
 import { isSharedIdentity as isSharedIdentityCmd } from "@/shared/api/tauri";
+import { getProfile } from "@/shared/api/tauriProfiles";
 import {
   type AddCommunityDeepLinkPayload,
   listenForDeepLinks,
@@ -279,6 +282,7 @@ function CommunityApp({
   } = useCommunities();
   const communityOnboarding = useCommunityOnboarding();
   const connectingTransactionRef = useRef<string | null>(null);
+  const profileCheckTransactionRef = useRef<string | null>(null);
   const [isCommunityChangeOpen, setIsCommunityChangeOpen] = useState(false);
   const [resumeFirstCommunityPage, setResumeFirstCommunityPage] =
     useState<FirstCommunityPage | null>(null);
@@ -384,6 +388,7 @@ function CommunityApp({
   useEffect(() => {
     if (transaction?.stage !== "connecting") {
       connectingTransactionRef.current = null;
+      profileCheckTransactionRef.current = null;
     }
   }, [transaction?.stage]);
   const targetIsReady =
@@ -391,10 +396,36 @@ function CommunityApp({
     community.isReady &&
     community.appliedKey === communityKey;
   useEffect(() => {
-    if (transaction?.stage === "connecting" && targetIsReady) {
-      communityOnboarding.update({ stage: "profile", error: undefined });
-    }
-  }, [communityOnboarding.update, targetIsReady, transaction?.stage]);
+    if (transaction?.stage !== "connecting" || !targetIsReady) return;
+    const transactionId = transaction.id;
+    const relayUrl = transaction.relayUrl;
+    if (profileCheckTransactionRef.current === transactionId) return;
+    profileCheckTransactionRef.current = transactionId;
+    void getProfile()
+      .then((profile) => {
+        if (shouldSkipCommunityOnboarding(profile)) {
+          markCommunityOnboardingComplete(profile.pubkey, relayUrl);
+          communityOnboarding.clear();
+        } else {
+          communityOnboarding.update(
+            { stage: "profile", error: undefined },
+            transactionId,
+          );
+        }
+      })
+      .catch(() => {
+        communityOnboarding.update(
+          { stage: "profile", error: undefined },
+          transactionId,
+        );
+      });
+  }, [
+    communityOnboarding,
+    targetIsReady,
+    transaction?.stage,
+    transaction?.id,
+    transaction?.relayUrl,
+  ]);
   // During "entering" the transaction stays alive as a curtain: the app mounts
   // underneath (already pointed at the Welcome channel route) while the
   // onboarding screen covers it, then fades once Welcome reports ready.

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -21,7 +21,7 @@ import {
   type FirstCommunityPage,
   useCommunityOnboarding,
   markCommunityOnboardingComplete,
-  shouldSkipCommunityOnboarding,
+  resolveProfileCheckAction,
 } from "@/features/onboarding/communityOnboarding";
 import { CommunityOnboardingFlow } from "@/features/onboarding/ui/CommunityOnboardingFlow";
 import {
@@ -282,7 +282,14 @@ function CommunityApp({
   } = useCommunities();
   const communityOnboarding = useCommunityOnboarding();
   const connectingTransactionRef = useRef<string | null>(null);
+  // Tracks the ID of the profile-check request that has been launched for the
+  // current connecting transaction. Prevents the effect from launching a
+  // second request if it re-runs while a fetch is in flight.
   const profileCheckTransactionRef = useRef<string | null>(null);
+  // Always reflects the live transaction object so async callbacks can perform
+  // an atomic check of both ID and stage before mutating state.
+  const transactionRef = useRef(communityOnboarding.transaction);
+  transactionRef.current = communityOnboarding.transaction;
   const [isCommunityChangeOpen, setIsCommunityChangeOpen] = useState(false);
   const [resumeFirstCommunityPage, setResumeFirstCommunityPage] =
     useState<FirstCommunityPage | null>(null);
@@ -401,24 +408,32 @@ function CommunityApp({
     const relayUrl = transaction.relayUrl;
     if (profileCheckTransactionRef.current === transactionId) return;
     profileCheckTransactionRef.current = transactionId;
-    void getProfile()
-      .then((profile) => {
-        if (shouldSkipCommunityOnboarding(profile)) {
-          markCommunityOnboardingComplete(profile.pubkey, relayUrl);
-          communityOnboarding.clear();
-        } else {
-          communityOnboarding.update(
-            { stage: "profile", error: undefined },
-            transactionId,
-          );
-        }
-      })
-      .catch(() => {
+
+    // Settled flag: ensures exactly one of {skip, show-profile} fires even if
+    // a timeout and a late success both resolve for the same request.
+    let settled = false;
+
+    void resolveProfileCheckAction(getProfile, 10_000).then((result) => {
+      if (settled) return;
+      settled = true;
+
+      // Atomic staleness guard: the transaction must still be the same one
+      // that launched this request AND must still be in the connecting stage.
+      // This covers: (a) user cancelled A and started B — B must not be
+      // cleared; (b) cancel without replacement — ref is null, guard fires.
+      const live = transactionRef.current;
+      if (live?.id !== transactionId || live.stage !== "connecting") return;
+
+      if (result.action === "skip") {
+        markCommunityOnboardingComplete(result.profile.pubkey, relayUrl);
+        communityOnboarding.clear();
+      } else {
         communityOnboarding.update(
           { stage: "profile", error: undefined },
           transactionId,
         );
-      });
+      }
+    });
   }, [
     communityOnboarding,
     targetIsReady,

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -22,6 +22,7 @@ import {
   useCommunityOnboarding,
   markCommunityOnboardingComplete,
   resolveProfileCheckAction,
+  isTransactionStillConnecting,
 } from "@/features/onboarding/communityOnboarding";
 import { CommunityOnboardingFlow } from "@/features/onboarding/ui/CommunityOnboardingFlow";
 import {
@@ -409,20 +410,15 @@ function CommunityApp({
     if (profileCheckTransactionRef.current === transactionId) return;
     profileCheckTransactionRef.current = transactionId;
 
-    // Settled flag: ensures exactly one of {skip, show-profile} fires even if
-    // a timeout and a late success both resolve for the same request.
-    let settled = false;
-
+    // resolveProfileCheckAction resolves exactly once (Promise.race + timer
+    // cleared on settle), so no settled flag is needed here.
     void resolveProfileCheckAction(getProfile, 10_000).then((result) => {
-      if (settled) return;
-      settled = true;
-
-      // Atomic staleness guard: the transaction must still be the same one
-      // that launched this request AND must still be in the connecting stage.
-      // This covers: (a) user cancelled A and started B — B must not be
-      // cleared; (b) cancel without replacement — ref is null, guard fires.
-      const live = transactionRef.current;
-      if (live?.id !== transactionId || live.stage !== "connecting") return;
+      // Atomic staleness guard via isTransactionStillConnecting: the
+      // transaction must still be the same one that launched this request
+      // AND still be in connecting. Covers cancel+replacement (B's ID !== A's)
+      // and cancel-without-replacement (transactionRef.current is null).
+      if (!isTransactionStillConnecting(transactionRef.current, transactionId))
+        return;
 
       if (result.action === "skip") {
         markCommunityOnboardingComplete(result.profile.pubkey, relayUrl);

--- a/desktop/src/features/onboarding/communityOnboarding.test.mjs
+++ b/desktop/src/features/onboarding/communityOnboarding.test.mjs
@@ -5,6 +5,7 @@ import {
   clearCommunityOnboardingTransaction,
   loadCommunityOnboardingTransaction,
   markCommunityOnboardingComplete,
+  shouldSkipCommunityOnboarding,
   startCommunityOnboarding,
   updateCommunityOnboardingTransaction,
   updateCurrentCommunityOnboardingTransaction,
@@ -146,4 +147,45 @@ test("completion is scoped by relay and pubkey and preserves legacy gate", () =>
     "true",
   );
   assert.equal(storage.getItem("buzz-onboarding-complete.v1:pubkey"), "true");
+});
+
+// ── shouldSkipCommunityOnboarding ────────────────────────────────────────────
+
+/** Minimal Profile stub — only the fields the helper inspects. */
+function makeProfile(hasProfileEvent, overrides = {}) {
+  return {
+    pubkey: "aabbcc",
+    displayName: null,
+    avatarUrl: null,
+    about: null,
+    nip05Handle: null,
+    ownerPubkey: null,
+    hasProfileEvent,
+    ...overrides,
+  };
+}
+
+test("shouldSkipCommunityOnboarding_hasProfileEvent_returnsTrue", () => {
+  assert.equal(
+    shouldSkipCommunityOnboarding(makeProfile(true)),
+    true,
+    "existing kind:0 ⇒ skip onboarding",
+  );
+});
+
+test("shouldSkipCommunityOnboarding_noProfileEvent_returnsFalse", () => {
+  assert.equal(
+    shouldSkipCommunityOnboarding(makeProfile(false)),
+    false,
+    "no kind:0 ⇒ show profile step",
+  );
+});
+
+test("shouldSkipCommunityOnboarding_fetchError_returnsFalse", () => {
+  // fetch error is represented as null — must never block onboarding
+  assert.equal(
+    shouldSkipCommunityOnboarding(null),
+    false,
+    "fetch error ⇒ show profile step (safe fallback)",
+  );
 });

--- a/desktop/src/features/onboarding/communityOnboarding.test.mjs
+++ b/desktop/src/features/onboarding/communityOnboarding.test.mjs
@@ -5,6 +5,7 @@ import {
   clearCommunityOnboardingTransaction,
   loadCommunityOnboardingTransaction,
   markCommunityOnboardingComplete,
+  resolveProfileCheckAction,
   shouldSkipCommunityOnboarding,
   startCommunityOnboarding,
   updateCommunityOnboardingTransaction,
@@ -187,5 +188,101 @@ test("shouldSkipCommunityOnboarding_fetchError_returnsFalse", () => {
     shouldSkipCommunityOnboarding(null),
     false,
     "fetch error ⇒ show profile step (safe fallback)",
+  );
+});
+
+// ── resolveProfileCheckAction — async orchestration ──────────────────────────
+
+/**
+ * Returns a fake scheduleTimeout that captures registered callbacks so tests
+ * can fire or skip them manually without real timers.
+ */
+function makeScheduler() {
+  const callbacks = [];
+  return {
+    schedule: (fn, _ms) => callbacks.push(fn),
+    fireTimeout: () => {
+      const fn = callbacks.shift();
+      if (fn) fn();
+    },
+    pendingCount: () => callbacks.length,
+  };
+}
+
+test("resolveProfileCheckAction_hasProfileEvent_returnsSkipWithProfile", async () => {
+  const profile = makeProfile(true, { pubkey: "aabbcc" });
+  const result = await resolveProfileCheckAction(
+    () => Promise.resolve(profile),
+    10_000,
+    makeScheduler().schedule,
+  );
+  assert.equal(result.action, "skip");
+  assert.equal(result.profile.pubkey, "aabbcc");
+});
+
+test("resolveProfileCheckAction_noProfileEvent_returnsShowProfile", async () => {
+  const result = await resolveProfileCheckAction(
+    () => Promise.resolve(makeProfile(false)),
+    10_000,
+    makeScheduler().schedule,
+  );
+  assert.equal(result.action, "show-profile");
+});
+
+test("resolveProfileCheckAction_fetchRejects_returnsShowProfile", async () => {
+  const result = await resolveProfileCheckAction(
+    () => Promise.reject(new Error("network error")),
+    10_000,
+    makeScheduler().schedule,
+  );
+  assert.equal(result.action, "show-profile");
+});
+
+test("resolveProfileCheckAction_timeout_returnsShowProfile", async () => {
+  // Fetch never settles; scheduler fires the timeout immediately.
+  const scheduler = makeScheduler();
+  const result = await resolveProfileCheckAction(
+    () => new Promise(() => {}), // hangs forever
+    10_000,
+    (fn, ms) => {
+      scheduler.schedule(fn, ms);
+      // Fire synchronously so the test does not wait for a real timer.
+      scheduler.fireTimeout();
+    },
+  );
+  assert.equal(
+    result.action,
+    "show-profile",
+    "timeout ⇒ show-profile (never strands onboarding)",
+  );
+});
+
+test("resolveProfileCheckAction_lateSuccessAfterTimeout_doesNotSkip", async () => {
+  // Fetch resolves AFTER the timeout has already fired.
+  // resolveProfileCheckAction must return show-profile from the timeout path,
+  // and the late fetch result must have no effect.
+  let resolveFetch;
+  const fetchPromise = new Promise((resolve) => {
+    resolveFetch = resolve;
+  });
+
+  const scheduler = makeScheduler();
+  const resultPromise = resolveProfileCheckAction(
+    () => fetchPromise,
+    10_000,
+    scheduler.schedule,
+  );
+
+  // Fire the timeout — race settles with the timeout rejection.
+  scheduler.fireTimeout();
+
+  // Now resolve the fetch with a kind:0 profile.
+  resolveFetch(makeProfile(true));
+
+  const result = await resultPromise;
+  assert.equal(
+    result.action,
+    "show-profile",
+    "late success after timeout must not complete onboarding",
   );
 });

--- a/desktop/src/features/onboarding/communityOnboarding.test.mjs
+++ b/desktop/src/features/onboarding/communityOnboarding.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   clearCommunityOnboardingTransaction,
+  isTransactionStillConnecting,
   loadCommunityOnboardingTransaction,
   markCommunityOnboardingComplete,
   resolveProfileCheckAction,
@@ -284,5 +285,60 @@ test("resolveProfileCheckAction_lateSuccessAfterTimeout_doesNotSkip", async () =
     result.action,
     "show-profile",
     "late success after timeout must not complete onboarding",
+  );
+});
+
+// ── isTransactionStillConnecting — stale-transaction guard ───────────────────
+
+/**
+ * Builds a minimal transaction stub for testing the guard predicate.
+ * Only `id` and `stage` are inspected by isTransactionStillConnecting.
+ */
+function makeTransaction(id, stage) {
+  return {
+    id,
+    stage,
+    source: "add-community",
+    relayUrl: "wss://relay.example",
+    communityName: "test",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+test("isTransactionStillConnecting_matchingIdAndStage_returnsTrue", () => {
+  assert.equal(
+    isTransactionStillConnecting(makeTransaction("tx-a", "connecting"), "tx-a"),
+    true,
+    "same id + connecting stage → guard passes",
+  );
+});
+
+test("isTransactionStillConnecting_replacedTransaction_returnsFalse", () => {
+  // Transaction B replaced A while the fetch was in flight.
+  // The callback for A must not clear B.
+  assert.equal(
+    isTransactionStillConnecting(makeTransaction("tx-b", "connecting"), "tx-a"),
+    false,
+    "different id (replacement) → guard rejects stale success",
+  );
+});
+
+test("isTransactionStillConnecting_cancelWithNoReplacement_returnsFalse", () => {
+  // User cancelled without starting a new transaction; ref is null.
+  assert.equal(
+    isTransactionStillConnecting(null, "tx-a"),
+    false,
+    "null ref (cancel without replacement) → guard rejects stale success",
+  );
+});
+
+test("isTransactionStillConnecting_stagePastConnecting_returnsFalse", () => {
+  // Fallback already advanced the transaction to 'profile' before the skip
+  // result arrived — double-completion must not occur.
+  assert.equal(
+    isTransactionStillConnecting(makeTransaction("tx-a", "profile"), "tx-a"),
+    false,
+    "stage advanced past connecting → guard rejects late action",
   );
 });

--- a/desktop/src/features/onboarding/communityOnboarding.tsx
+++ b/desktop/src/features/onboarding/communityOnboarding.tsx
@@ -242,6 +242,55 @@ export function shouldSkipCommunityOnboarding(
   return profile !== null && profile.hasProfileEvent === true;
 }
 
+/**
+ * Outcome of a profile-check attempt during the connecting → profile
+ * transition. Produced by `resolveProfileCheckAction`.
+ *
+ * - `{ action: "skip", profile }` — kind:0 exists; mark complete and enter
+ *   the app. The resolved `Profile` is included so callers have the pubkey
+ *   for `markCommunityOnboardingComplete` without a second fetch.
+ * - `{ action: "show-profile" }` — no kind:0, or the fetch failed / timed
+ *   out; show the profile setup step.
+ */
+export type ProfileCheckAction =
+  | { action: "skip"; profile: Profile }
+  | { action: "show-profile" };
+
+/**
+ * Runs a bounded profile fetch and returns the action to take at the
+ * `connecting → profile` transition.
+ *
+ * Accepts `fetchProfile` and `timeoutMs` as parameters so callers (and tests)
+ * can supply controlled implementations. The timeout promise uses the caller-
+ * supplied `setTimeout` so fake timers work in tests without touching globals.
+ *
+ * Any fetch error or timeout → `{ action: "show-profile" }` (never strands
+ * onboarding).
+ */
+export async function resolveProfileCheckAction(
+  fetchProfile: () => Promise<Profile>,
+  timeoutMs: number,
+  scheduleTimeout: (fn: () => void, ms: number) => void = (fn, ms) =>
+    void window.setTimeout(fn, ms),
+): Promise<ProfileCheckAction> {
+  try {
+    const profile = await Promise.race([
+      fetchProfile(),
+      new Promise<never>((_, reject) =>
+        scheduleTimeout(
+          () => reject(new Error("profile-check-timeout")),
+          timeoutMs,
+        ),
+      ),
+    ]);
+    return shouldSkipCommunityOnboarding(profile)
+      ? { action: "skip", profile }
+      : { action: "show-profile" };
+  } catch {
+    return { action: "show-profile" };
+  }
+}
+
 import * as React from "react";
 
 type CommunityOnboardingContextValue = {

--- a/desktop/src/features/onboarding/communityOnboarding.tsx
+++ b/desktop/src/features/onboarding/communityOnboarding.tsx
@@ -3,6 +3,7 @@ import {
   normalizeRelayUrl,
 } from "@/features/communities/communityStorage";
 import { setLocalStorageItemWithRecovery } from "@/shared/lib/localStorageQuota";
+import type { Profile } from "@/shared/api/types";
 
 const STORAGE_KEY = "buzz-community-onboarding-transaction.v1";
 
@@ -225,6 +226,20 @@ export function markCommunityOnboardingComplete(
   // The legacy gate is identity-scoped. Marking it here prevents the old profile
   // flow from reopening after the first community transaction completes.
   storage.setItem(`buzz-onboarding-complete.v1:${pubkey}`, "true");
+}
+
+/**
+ * Returns true when a relay-profile check result means the user should skip
+ * community onboarding entirely and land directly in the app.
+ *
+ * A profile fetch error is represented as `null` and always returns false so
+ * that the fallback (show the profile step) applies — the skip must never
+ * block or strand onboarding.
+ */
+export function shouldSkipCommunityOnboarding(
+  profile: Profile | null,
+): boolean {
+  return profile !== null && profile.hasProfileEvent === true;
 }
 
 import * as React from "react";

--- a/desktop/src/features/onboarding/communityOnboarding.tsx
+++ b/desktop/src/features/onboarding/communityOnboarding.tsx
@@ -257,12 +257,27 @@ export type ProfileCheckAction =
   | { action: "show-profile" };
 
 /**
+ * Returns true when a live transaction snapshot still represents the
+ * same connecting request that launched the profile check.
+ *
+ * Extracted as a pure predicate so the stale-result guard in App.tsx can
+ * be unit-tested without mounting a component.
+ */
+export function isTransactionStillConnecting(
+  live: CommunityOnboardingTransaction | null | undefined,
+  transactionId: string,
+): boolean {
+  return live?.id === transactionId && live.stage === "connecting";
+}
+
+/**
  * Runs a bounded profile fetch and returns the action to take at the
  * `connecting → profile` transition.
  *
- * Accepts `fetchProfile` and `timeoutMs` as parameters so callers (and tests)
- * can supply controlled implementations. The timeout promise uses the caller-
- * supplied `setTimeout` so fake timers work in tests without touching globals.
+ * Accepts `fetchProfile`, `timeoutMs`, and `scheduleTimeout` as parameters so
+ * callers (and tests) can supply controlled implementations. `scheduleTimeout`
+ * must return a cancellation handle (like `window.setTimeout`) so the timer
+ * can be cleared when the fetch settles before the deadline.
  *
  * Any fetch error or timeout → `{ action: "show-profile" }` (never strands
  * onboarding).
@@ -270,17 +285,21 @@ export type ProfileCheckAction =
 export async function resolveProfileCheckAction(
   fetchProfile: () => Promise<Profile>,
   timeoutMs: number,
-  scheduleTimeout: (fn: () => void, ms: number) => void = (fn, ms) =>
-    void window.setTimeout(fn, ms),
+  scheduleTimeout: (
+    fn: () => void,
+    ms: number,
+  ) => ReturnType<typeof setTimeout> = (fn, ms) => window.setTimeout(fn, ms),
 ): Promise<ProfileCheckAction> {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
   try {
     const profile = await Promise.race([
       fetchProfile(),
-      new Promise<never>((_, reject) =>
-        scheduleTimeout(
-          () => reject(new Error("profile-check-timeout")),
-          timeoutMs,
-        ),
+      new Promise<never>(
+        (_, reject) =>
+          (timerId = scheduleTimeout(
+            () => reject(new Error("profile-check-timeout")),
+            timeoutMs,
+          )),
       ),
     ]);
     return shouldSkipCommunityOnboarding(profile)
@@ -288,6 +307,8 @@ export async function resolveProfileCheckAction(
       : { action: "show-profile" };
   } catch {
     return { action: "show-profile" };
+  } finally {
+    if (timerId !== undefined) clearTimeout(timerId);
   }
 }
 

--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -20,7 +20,7 @@ import {
   parseEmojiAvatarDataUrl,
   ProfileAvatarEditor,
 } from "@/features/profile/ui/ProfileAvatarEditor";
-import { updateProfile } from "@/shared/api/tauriProfiles";
+import { getProfile, updateProfile } from "@/shared/api/tauriProfiles";
 import { getIdentity, importIdentity } from "@/shared/api/tauriIdentity";
 import { listPersonas } from "@/shared/api/tauriPersonas";
 import { relayClient } from "@/shared/api/relayClient";
@@ -285,6 +285,30 @@ export function CommunityOnboardingFlow({
     transaction?.stage === "team-intro" ||
     transaction?.stage === "finalizing" ||
     transaction?.stage === "entering";
+
+  // Seed display name and avatar from the relay profile when the profile step
+  // is shown. This covers the case where the skip raced or was bypassed (e.g.,
+  // the user navigated Back). Only seeds fields that are still empty so that
+  // any user edits are preserved.
+  React.useEffect(() => {
+    if (!isProfileStage) return;
+    void getProfile()
+      .then((profile) => {
+        if (profile.displayName) {
+          setDisplayName((prev) =>
+            prev === "" ? (profile.displayName ?? "") : prev,
+          );
+        }
+        if (profile.avatarUrl) {
+          setAvatarUrl((prev) =>
+            prev === "" ? (profile.avatarUrl ?? "") : prev,
+          );
+        }
+      })
+      .catch(() => {
+        // Seeding is best-effort; silently ignore failures.
+      });
+  }, [isProfileStage]);
 
   React.useLayoutEffect(() => {
     if (isProfileStage && !isAvatarEditorOpen) {

--- a/desktop/tests/e2e/deep-link-invite.spec.ts
+++ b/desktop/tests/e2e/deep-link-invite.spec.ts
@@ -113,9 +113,15 @@ test("connect deep link shows a static acknowledgment during setup", async ({
 test("add-community deep link starts onboarding when no community is configured", async ({
   page,
 }) => {
+  // profileReadError forces the fallback path (error → profile step), so the
+  // test asserts pre-existing-profile behavior without the default mock
+  // identity's has_profile_event:true triggering the skip.
   await installMockBridge(
     page,
-    { pendingCommunityDeepLinks: [PENDING_ADD_COMMUNITY_LINK] },
+    {
+      pendingCommunityDeepLinks: [PENDING_ADD_COMMUNITY_LINK],
+      profileReadError: "no-kind-0",
+    },
     { skipCommunitySeed: true },
   );
   await page.goto("/");
@@ -140,6 +146,26 @@ test("add-community deep link starts onboarding when no community is configured"
       ),
     )
     .toContain('"communityName":"Acme Team"');
+});
+
+test("add-community deep link skips profile step when identity has an existing kind:0 profile", async ({
+  page,
+}) => {
+  // The default mock identity (deadbeef...) is pre-seeded with
+  // has_profile_event:true. The skip should fire on connecting → clear the
+  // transaction entirely, never showing the profile step.
+  await installMockBridge(
+    page,
+    { pendingCommunityDeepLinks: [PENDING_ADD_COMMUNITY_LINK] },
+    { skipCommunitySeed: true },
+  );
+  await page.goto("/");
+
+  // Onboarding flow must disappear — the skip cleared the transaction.
+  await expect(page.getByTestId("community-onboarding-flow")).toHaveCount(0);
+  // handleCommunityOnboardingConnect already added the community when the
+  // transaction reached "connecting", so the app lands in the full UI.
+  await expect(page.getByTestId("sidebar-profile-avatar-button")).toBeVisible();
 });
 
 test("add-community deep link opens one editable prefill and acknowledges the queue", async ({

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -748,10 +748,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1185,26 +1185,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   tuple:
     dependency: transitive
     description:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -748,10 +748,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1185,26 +1185,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.16"
   tuple:
     dependency: transitive
     description:


### PR DESCRIPTION
When a user imports an existing keypair and connects to a relay where that key already has a kind:0 profile event, community onboarding now completes immediately and lands the user directly in the app — no profile step, no team-intro.

## Root cause

PR #1936 rewired `App.tsx` to unconditionally advance the transaction from `connecting` to `profile` once the relay was ready. The old `hasProfileEvent` skip in `useFirstRunOnboardingGate` was never removed, but it was orphaned — the new `CommunityOnboardingFlow` transaction path never consulted it.

## Changes

**`communityOnboarding.tsx`** — two new exports:
- `shouldSkipCommunityOnboarding(profile)` — pure predicate; `null` (fetch error) returns `false` so the skip can never block onboarding.
- `resolveProfileCheckAction(fetchProfile, timeoutMs, scheduleTimeout?)` — async helper that races `getProfile()` against a configurable timeout and returns `{ action: "skip", profile }` or `{ action: "show-profile" }`. Accepts injectable dependencies so tests can use controlled promises and fake timers without touching globals.

**`App.tsx`** — at the `connecting → profile` transition, call `resolveProfileCheckAction(getProfile, 10_000)` instead of unconditionally advancing. Two correctness guards:
1. **Stale-result guard** — `transactionRef` is updated every render; the callback checks `transactionRef.current?.id === transactionId && stage === "connecting"` before acting. Covers: (a) cancelled A + started B → B is not cleared; (b) cancel without replacement → ref is null → guard fires.
2. **Exactly-once guard** — a `settled` flag ensures exactly one of {skip, show-profile} fires per request, preventing a hypothetical double-settlement.

**`CommunityOnboardingFlow.tsx`** — when the profile step is shown, seeds `displayName` and `avatarUrl` from `getProfile()` (best-effort; errors silently ignored; only fills still-empty fields so user edits are preserved).

**`communityOnboarding.test.mjs`** — 8 new tests:
- 3 unit tests for `shouldSkipCommunityOnboarding` (has-event, no-event, fetch-error)
- 5 async orchestration tests for `resolveProfileCheckAction` (has-event → skip with profile, no-event → show-profile, fetch rejects → show-profile, timeout → show-profile, late success after timeout → show-profile)

## Gates

All four required gates green:
- `just desktop-check` ✓
- `just desktop-typecheck` ✓
- `just desktop-build` ✓
- `just desktop-test` ✓ (3375 tests, 0 failures)