### PR TITLE
fix(desktop): surface relay profile-sync failure on agent rename

### DIFF
--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -706,6 +706,17 @@ export function AgentInstanceEditDialog({
           autoRestartOnConfigChange,
         );
       }
+      if (result.profileSyncError) {
+        // The local save (disk + AGENTS.md) already succeeded, but the relay
+        // still has the old kind:0 profile (e.g. old @mention name). Surface
+        // it instead of silently closing — otherwise the dialog closes as if
+        // the rename fully succeeded and the user never learns the relay is
+        // stale (#1822). Matches the create/persona flows, which already toast
+        // profileSyncError.
+        toast.warning(
+          `${result.agent.name} saved locally, but relay profile sync failed: ${result.profileSyncError}`,
+        );
+      }
       handleOpenChange(false);
       onUpdated?.(result.agent);
       // The auto-restart policy deliberately never fires for a stopped or


### PR DESCRIPTION
Refs #1822

When agent rename local-save succeeds but relay kind:0 profile sync fails, surface a warning toast (same pattern as create/persona) instead of only `console.warn` and a quiet close.