### PR TITLE
fix(desktop): re-arm relay-mesh runtime when the ingress is dead

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -400,7 +400,16 @@ const overrides = new Map([
   // transition lock doc broadened to cover all protected-PID transitions, and
   // clear_agent_session_caches (per-pubkey retain) added alongside the
   // per-key clear. Load-bearing identity-contract change; queued to split.
-  ["src-tauri/src/app_state.rs", 1081],
+  // +8 (1081 -> 1089): mesh re-arm watchdog (#2304) adds mesh_ingress_dead_probes
+  // AtomicU32 counter on AppState for consecutive dead-probe debounce. Narrow
+  // counter field + init spars; still queued to split more AppState sections.
+  ["src-tauri/src/app_state.rs", 1089],
+  // mesh_llm re-arm watchdog + Brad/micspiral correctness suite (#2304):
+  // probe/evict identity gate, bounded stop timeout, process-map filter,
+  // store-lock error persistence, consecutive-probe debounce, sentinel-cleared
+  // last_error. Load-bearing recovery path; queued to split re-arm helpers
+  // into mesh_llm/rearm.rs. Ratchet covers current size after rustfmt.
+  ["src-tauri/src/commands/mesh_llm.rs", 1410],
   // multi-slot splitting + no-op suppression (#1309): the ReadStateManager
   // class grew from ~700 lines to ~1019 with the addition of
   // splitContextsIntoBudgetedSlots (pure fn + 5 tests), publishSplitSlots,

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -403,7 +403,9 @@ const overrides = new Map([
   // +8 (1081 -> 1089): mesh re-arm watchdog (#2304) adds mesh_ingress_dead_probes
   // AtomicU32 counter on AppState for consecutive dead-probe debounce. Narrow
   // counter field + init spars; still queued to split more AppState sections.
-  ["src-tauri/src/app_state.rs", 1089],
+  // +1 (1089 -> 1090): feature-gate the dead-probes initializer (micspiral #2304)
+  // so non-mesh builds compile under -D warnings; trailing-newline line count.
+  ["src-tauri/src/app_state.rs", 1090],
   // mesh_llm re-arm watchdog + Brad/micspiral correctness suite (#2304):
   // probe/evict identity gate, bounded stop timeout, process-map filter,
   // store-lock error persistence, consecutive-probe debounce, sentinel-cleared

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     io::Write,
     sync::{
-        atomic::{AtomicBool, AtomicU16},
+        atomic::{AtomicBool, AtomicU16, AtomicU32},
         Arc, Mutex,
     },
 };
@@ -108,6 +108,13 @@ pub struct AppState {
     /// In-process mesh-llm node started by Buzz Desktop.
     #[cfg(feature = "mesh-llm")]
     pub mesh_llm_runtime: AsyncMutex<Option<crate::mesh_llm::DesktopMeshRuntime>>,
+    /// Consecutive dead ingress probes observed by the coordinator watchdog
+    /// while a runtime handle was present. Used to debounce eviction so a
+    /// single transient stall (model load/reload, VRAM alloc, GC/mmap pause,
+    /// inference saturation) past the 3s probe budget does not cold-restart a
+    /// healthy runtime (micspiral review, #2304). Reset to 0 on a live probe.
+    #[cfg(feature = "mesh-llm")]
+    pub mesh_ingress_dead_probes: AtomicU32,
     /// Runtime-owned shared-compute coordinator. It publishes member-signed
     /// discovery status and reconciles MeshLLM's admission roster; MeshLLM
     /// itself owns direct QUIC/iroh connection establishment.
@@ -222,6 +229,7 @@ pub fn build_app_state() -> AppState {
         reset_failed: AtomicBool::new(false),
         #[cfg(feature = "mesh-llm")]
         mesh_llm_runtime: AsyncMutex::new(None),
+        mesh_ingress_dead_probes: AtomicU32::new(0),
         #[cfg(feature = "mesh-llm")]
         mesh_coordinator: AsyncMutex::new(None),
         pending_owned_channels: Mutex::new(std::collections::HashSet::new()),

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     io::Write,
     sync::{
-        atomic::{AtomicBool, AtomicU16, AtomicU32},
+        atomic::{AtomicBool, AtomicU16},
         Arc, Mutex,
     },
 };
@@ -114,7 +114,7 @@ pub struct AppState {
     /// inference saturation) past the 3s probe budget does not cold-restart a
     /// healthy runtime (micspiral review, #2304). Reset to 0 on a live probe.
     #[cfg(feature = "mesh-llm")]
-    pub mesh_ingress_dead_probes: AtomicU32,
+    pub mesh_ingress_dead_probes: std::sync::atomic::AtomicU32,
     /// Runtime-owned shared-compute coordinator. It publishes member-signed
     /// discovery status and reconciles MeshLLM's admission roster; MeshLLM
     /// itself owns direct QUIC/iroh connection establishment.
@@ -229,7 +229,8 @@ pub fn build_app_state() -> AppState {
         reset_failed: AtomicBool::new(false),
         #[cfg(feature = "mesh-llm")]
         mesh_llm_runtime: AsyncMutex::new(None),
-        mesh_ingress_dead_probes: AtomicU32::new(0),
+        #[cfg(feature = "mesh-llm")]
+        mesh_ingress_dead_probes: std::sync::atomic::AtomicU32::new(0),
         #[cfg(feature = "mesh-llm")]
         mesh_coordinator: AsyncMutex::new(None),
         pending_owned_channels: Mutex::new(std::collections::HashSet::new()),

--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -246,24 +246,55 @@ pub(crate) async fn mesh_ingress_is_live_at(api_base_url: &str) -> bool {
 /// runtime (best-effort stop) so a subsequent ensure/bootstrap can re-arm.
 ///
 /// Returns `true` when a stale handle was evicted (caller should re-arm).
+/// Bounded budget for a best-effort stop of a stale runtime. Matches the 3s
+/// ingress-probe budget: if the embedded runtime is *itself* the wedged
+/// component, `stop()` can hang forever, which would defeat the whole
+/// "never block re-arm" intent (Brad #2304 #1). On timeout we log and drop the
+/// handle anyway so the watchdog keeps making progress.
+const STALE_STOP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
 pub(crate) async fn drop_stale_mesh_runtime_if_ingress_dead(
     state: &AppState,
 ) -> bool {
-    if state.mesh_llm_runtime.lock().await.is_none() {
-        return false;
-    }
+    // Capture the identity of the runtime we are about to judge *before* the
+    // ingress probe `.await`. A concurrent stop/start can swap the handle while
+    // the probe is in flight; if it does, we must not evict the fresh
+    // replacement (Brad #2304 #2).
+    let candidate_id = match state.mesh_llm_runtime.lock().await.as_ref() {
+        Some(runtime) => runtime.id(),
+        None => return false,
+    };
     if mesh_ingress_is_live().await {
         return false;
     }
+    let stale = {
+        let mut guard = state.mesh_llm_runtime.lock().await;
+        match guard.as_ref() {
+            // Same handle still installed → safe to evict.
+            Some(runtime) if runtime.id() == candidate_id => guard.take(),
+            // A different runtime was swapped in during the probe, or the
+            // handle was cleared. Leave the current (fresh) runtime alone.
+            _ => return false,
+        }
+    };
+    let Some(stale) = stale else {
+        return false;
+    };
     eprintln!(
         "buzz-mesh: Buzz shared compute ingress is down while a runtime handle is present; dropping the stale runtime for re-arm (#2062)"
     );
-    let stale = state.mesh_llm_runtime.lock().await.take();
-    if let Some(stale) = stale {
-        // Best-effort: a wedged runtime may fail/slow to stop; never block
-        // re-arm on it (the zombie-guard motivation in #2062).
-        if let Err(error) = stale.stop().await {
+    // Best-effort, bounded: a wedged runtime may fail/hang on stop; never block
+    // re-arm on it (the zombie-guard motivation in #2062, Brad #2304 #1).
+    match tokio::time::timeout(STALE_STOP_TIMEOUT, stale.stop()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
             eprintln!("stale mesh runtime stop failed during re-arm: {error}");
+        }
+        Err(_) => {
+            eprintln!(
+                "stale mesh runtime stop timed out after {}s during re-arm; dropping handle anyway (#2304)",
+                STALE_STOP_TIMEOUT.as_secs()
+            );
         }
     }
     true
@@ -291,10 +322,7 @@ pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Resu
     if !evicted && !had_handle {
         // No handle — only act if we have relay-mesh agents that need the client.
         let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
-        let needs = records.iter().any(|r| {
-            r.backend == crate::managed_agents::BackendKind::Local
-                && crate::managed_agents::relay_mesh_model_id(r).is_some()
-        });
+        let needs = records.iter().any(is_running_relay_mesh_agent);
         if !needs {
             return Ok(());
         }
@@ -303,10 +331,7 @@ pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Resu
     let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
     let mesh_records: Vec<_> = records
         .into_iter()
-        .filter(|r| {
-            r.backend == crate::managed_agents::BackendKind::Local
-                && crate::managed_agents::relay_mesh_model_id(r).is_some()
-        })
+        .filter(is_running_relay_mesh_agent)
         .collect();
     if mesh_records.is_empty() {
         return Ok(());
@@ -333,6 +358,25 @@ pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Resu
     match first_error {
         Some(e) => Err(e),
         None => Ok(()),
+    }
+}
+
+/// A record is a live consumer of the shared-compute ingress only when it is a
+/// local relay-mesh agent whose process is actually running. Stopped agents,
+/// manually-stopped records, and non-local backends do not need the ingress, so
+/// re-arming them would resurrect runtimes the user deliberately stopped
+/// (Brad #2304 #3). We use the persisted `runtime_pid` + liveness check as the
+/// "should be running" signal rather than the display `status` string.
+fn is_running_relay_mesh_agent(record: &crate::managed_agents::ManagedAgentRecord) -> bool {
+    if record.backend != crate::managed_agents::BackendKind::Local {
+        return false;
+    }
+    if crate::managed_agents::relay_mesh_model_id(record).is_none() {
+        return false;
+    }
+    match record.runtime_pid {
+        Some(pid) => crate::managed_agents::process_is_running(pid),
+        None => false,
     }
 }
 
@@ -982,6 +1026,78 @@ mod tests {
         // probe should also be false (or true if a leftover mesh is up — either is
         // a bool, not panic).
         let _ = mesh_ingress_is_live().await;
+    }
+
+    /// Build a local relay-mesh record (Brad #2304 #3 filter tests). The mesh
+    /// preset env is the legacy discriminator `relay_mesh_model_id` detects.
+    fn mesh_record(pubkey: &str, runtime_pid: Option<u32>) -> crate::managed_agents::ManagedAgentRecord {
+        let mut rec = crate::managed_agents::AgentDefinition {
+            id: pubkey.to_string(),
+            display_name: pubkey.to_string(),
+            avatar_url: None,
+            system_prompt: String::new(),
+            runtime: None,
+            model: None,
+            provider: None,
+            name_pool: Vec::new(),
+            is_builtin: false,
+            is_active: true,
+            source_team: None,
+            source_team_persona_slug: None,
+            env_vars: std::collections::BTreeMap::from([
+                ("BUZZ_AGENT_PROVIDER".to_string(), "openai".to_string()),
+                (
+                    "OPENAI_COMPAT_BASE_URL".to_string(),
+                    "http://127.0.0.1:9337/v1/".to_string(),
+                ),
+                ("OPENAI_COMPAT_MODEL".to_string(), "Qwen3".to_string()),
+                (
+                    "OPENAI_COMPAT_API_KEY".to_string(),
+                    crate::managed_agents::RELAY_MESH_API_KEY_PLACEHOLDER.to_string(),
+                ),
+            ]),
+            respond_to: None,
+            respond_to_allowlist: Vec::new(),
+            parallelism: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+        .into_agent_record();
+        rec.pubkey = pubkey.to_string();
+        rec.backend = crate::managed_agents::BackendKind::Local;
+        rec.runtime_pid = runtime_pid;
+        rec
+    }
+
+    /// Brad #2304 #3: a stopped relay-mesh record (no live `runtime_pid`) must
+    /// NOT be treated as an ingress consumer, or re-arm would resurrect a
+    /// runtime the user deliberately stopped.
+    #[test]
+    fn stopped_relay_mesh_agent_is_not_a_rearm_target() {
+        // No pid at all → not running.
+        assert!(!is_running_relay_mesh_agent(&mesh_record("a", None)));
+        // A pid that is not a live process → not running.
+        // PID 1 is always alive but is not ours; use a very high unlikely pid.
+        let dead = mesh_record("b", Some(4_000_000_000));
+        assert!(!is_running_relay_mesh_agent(&dead));
+    }
+
+    /// A live local relay-mesh agent (own process running) IS a re-arm target.
+    #[test]
+    fn running_relay_mesh_agent_is_a_rearm_target() {
+        let pid = std::process::id();
+        assert!(is_running_relay_mesh_agent(&mesh_record("live", Some(pid))));
+    }
+
+    /// A running process that is NOT relay-mesh (no mesh preset) is ignored
+    /// even if alive — only ingress consumers get re-armed.
+    #[test]
+    fn running_non_mesh_agent_is_not_a_rearm_target() {
+        let mut rec = mesh_record("plain", Some(std::process::id()));
+        rec.env_vars.clear();
+        rec.provider = None;
+        rec.relay_mesh = None;
+        assert!(!is_running_relay_mesh_agent(&rec));
     }
 
     /// Failure copy for watchdog / last_error must be actionable (#2062 silent no-reply).

--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -57,6 +57,12 @@ fn share_stop_should_teardown(mode: mesh_llm::MeshNodeMode) -> bool {
     matches!(mode, mesh_llm::MeshNodeMode::Serve)
 }
 
+/// Sentinel prefix on every `last_error` the ingress re-arm watchdog writes, so
+/// `clear_mesh_last_error_if_set` only clears errors this path actually set
+/// rather than any message that merely mentions "shared compute"
+/// (micspiral review #2). Kept out of the user-facing tail of the string.
+pub(crate) const MESH_REARM_ERROR_SENTINEL: &str = "[buzz-mesh-rearm] ";
+
 pub type CmdResult<T> = Result<T, String>;
 
 fn advance_mesh_status_cursor(
@@ -263,6 +269,24 @@ pub(crate) fn should_evict_stale_runtime_after_probe(
     matches!(current_id, Some(id) if id == candidate_id)
 }
 
+/// Consecutive dead-probe debounce before we evict a healthy-looking runtime
+/// (micspiral review, #2304 #1). `rearm_relay_mesh_for_running_agents`
+/// early-returns on a healthy handle, so a dead probe is the *only* thing that
+/// ever touches a running runtime — a single false-negative (a transient stall
+/// past the 3s probe budget: model load/reload, VRAM alloc, GC/mmap pause,
+/// inference saturation) would otherwise force an avoidable cold re-bootstrap
+/// (and, for a serve node, a mode flip). Requiring 2 consecutive dead probes
+/// costs ~15-30s extra on genuine recovery at the 15s base cadence while
+/// eliminating transient-blip false evictions; `wait_for_mesh_inference`
+/// already tolerates a 120s warm-up on the readiness path, so the liveness
+/// probe having zero tolerance was the asymmetry worth closing.
+pub(crate) const DEAD_PROBE_EVICT_THRESHOLD: u32 = 2;
+
+/// Pure debounce gate: evict only once dead probes have reached the threshold.
+pub(crate) fn should_evict_after_consecutive_dead_probes(consecutive: u32) -> bool {
+    consecutive >= DEAD_PROBE_EVICT_THRESHOLD
+}
+
 pub(crate) async fn drop_stale_mesh_runtime_if_ingress_dead(state: &AppState) -> bool {
     drop_stale_mesh_runtime_if_ingress_dead_with_probe(state, mesh_ingress_is_live()).await
 }
@@ -280,15 +304,44 @@ where
     // that swaps the handle mid-probe cannot cause us to evict the replacement.
     let candidate_id = match state.mesh_llm_runtime.lock().await.as_ref() {
         Some(runtime) => runtime.id(),
-        None => return false,
+        None => {
+            // No handle to guard — keep the debounce counter clean.
+            state
+                .mesh_ingress_dead_probes
+                .store(0, std::sync::atomic::Ordering::Relaxed);
+            return false;
+        }
     };
     if probe_ingress_live.await {
+        // A live probe clears any accumulated dead streak (micspiral #1).
+        state
+            .mesh_ingress_dead_probes
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        return false;
+    }
+    // Dead probe: debounce so one transient stall does not evict a healthy
+    // runtime. Only proceed to eviction once we have seen the ingress dead
+    // across N consecutive watchdog ticks (micspiral review #1).
+    let consecutive = state
+        .mesh_ingress_dead_probes
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        + 1;
+    if !should_evict_after_consecutive_dead_probes(consecutive) {
+        eprintln!(
+            "buzz-mesh: ingress probe dead ({consecutive}/{DEAD_PROBE_EVICT_THRESHOLD}); debouncing before eviction (#2304)"
+        );
         return false;
     }
     let stale = {
         let mut guard = state.mesh_llm_runtime.lock().await;
         let current_id = guard.as_ref().map(|runtime| runtime.id());
         if !should_evict_stale_runtime_after_probe(candidate_id, current_id) {
+            // A concurrent stop/start swapped in a different runtime during the
+            // probe window; leave it alone and reset the streak so the fresh
+            // handle is judged on its own probes (micspiral #1 + #2304 #2).
+            state
+                .mesh_ingress_dead_probes
+                .store(0, std::sync::atomic::Ordering::Relaxed);
             return false;
         }
         guard.take()
@@ -296,6 +349,11 @@ where
     let Some(stale) = stale else {
         return false;
     };
+    // Confirmed dead across the debounce window and we own the eviction — reset
+    // the streak so the next runtime starts with a clean counter.
+    state
+        .mesh_ingress_dead_probes
+        .store(0, std::sync::atomic::Ordering::Relaxed);
     eprintln!(
         "buzz-mesh: Buzz shared compute ingress is down while a runtime handle is present; dropping the stale runtime for re-arm (#2062)"
     );
@@ -369,7 +427,7 @@ pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Resu
             }
             Err(error) => {
                 let msg = format!(
-                    "Buzz shared compute offline — failed to re-arm local ingress for this agent: {error}"
+                    "{MESH_REARM_ERROR_SENTINEL}Buzz shared compute offline — failed to re-arm local ingress for this agent: {error}"
                 );
                 eprintln!("buzz-mesh: re-arm failed for {}: {msg}", record.pubkey);
                 if let Err(persist_error) = persist_mesh_last_error(app, &record.pubkey, &msg) {
@@ -459,7 +517,9 @@ fn clear_mesh_last_error_if_set(app: &AppHandle, pubkey: &str) -> Result<(), Str
     let Some(err) = record.last_error.as_deref() else {
         return Ok(());
     };
-    if !err.contains("Buzz shared compute offline") && !err.contains("shared compute") {
+    // Only clear errors this watchdog set (sentinel prefix), never an unrelated
+    // last_error that merely mentions "shared compute" (micspiral #2).
+    if !err.starts_with(MESH_REARM_ERROR_SENTINEL) {
         return Ok(());
     }
     record.last_error = None;
@@ -778,6 +838,15 @@ pub(crate) async fn ensure_relay_mesh_for_record(
         }
     };
 
+    // Serve→Client re-arm transition (micspiral review #3, intentional-by-design):
+    // if the dead ingress belonged to a *serve* node with running consumer
+    // agents, this re-arms it as a Client (`MeshNodeMode::Client`). That is the
+    // correct/safe recovery here — config-backed serve restoration is
+    // `restore_mesh_sharing`'s job (`MeshNodeMode::Serve`), and
+    // `ensure_client_node_for_model` reuses any live runtime of *either* mode
+    // (the router resolves per-request), so it only cold-starts a Client when
+    // there is genuinely no runtime. Falling back to Client if a serve node
+    // crashed under local pressure is a desirable fail-safe, not a regression.
     ensure_client_node_for_model(&state, &model_id, Some(target.endpoint_addr)).await?;
     wait_for_mesh_inference(&model_id).await
 }
@@ -1196,15 +1265,38 @@ mod tests {
         assert!(STALE_STOP_TIMEOUT.as_secs() <= 5);
     }
 
-    /// Brad #2304 #4: clear only shared-compute offline errors; preserve others.
+    /// Brad #2304 #4 + micspiral #2: clear only errors this watchdog set
+    /// (sentinel prefix); never an unrelated last_error, even one that mentions
+    /// "shared compute".
     #[test]
     fn mesh_error_classifier_preserves_unrelated_last_error() {
-        let mesh = "Buzz shared compute offline — failed to re-arm local ingress for this agent: x";
-        let other = "npm install failed: EACCES";
-        assert!(mesh.contains("Buzz shared compute offline") || mesh.contains("shared compute"));
-        assert!(
-            !other.contains("Buzz shared compute offline") && !other.contains("shared compute")
+        let ours = format!(
+            "{MESH_REARM_ERROR_SENTINEL}Buzz shared compute offline — failed to re-arm local ingress for this agent: x"
         );
+        // Sentinel-tagged → this watchdog owns it → clearable.
+        assert!(ours.starts_with(MESH_REARM_ERROR_SENTINEL));
+        // An unrelated error that merely mentions "shared compute" must NOT be
+        // cleared (the loose-substring bug micspiral flagged).
+        let bystander = "user note: shared compute config looks wrong";
+        assert!(!bystander.starts_with(MESH_REARM_ERROR_SENTINEL));
+        let other = "npm install failed: EACCES";
+        assert!(!other.starts_with(MESH_REARM_ERROR_SENTINEL));
+    }
+
+    /// micspiral #1: eviction is debounced — a single dead probe must not evict
+    /// a healthy runtime; only a sustained dead streak (>= threshold) does.
+    #[test]
+    fn eviction_debounces_transient_dead_probe() {
+        assert!(DEAD_PROBE_EVICT_THRESHOLD >= 2);
+        // One transient blip: do not evict.
+        assert!(!should_evict_after_consecutive_dead_probes(1));
+        // Sustained dead across the window: evict.
+        assert!(should_evict_after_consecutive_dead_probes(
+            DEAD_PROBE_EVICT_THRESHOLD
+        ));
+        assert!(should_evict_after_consecutive_dead_probes(
+            DEAD_PROBE_EVICT_THRESHOLD + 5
+        ));
     }
 
     /// Hardware-gated live kill-:9337 recovery proof (Brad sequence).
@@ -1224,8 +1316,9 @@ mod tests {
     fn rearm_failure_message_is_actionable_shared_compute_offline() {
         let error = "no live member is serving this model";
         let msg = format!(
-            "Buzz shared compute offline — failed to re-arm local ingress for this agent: {error}"
+            "{MESH_REARM_ERROR_SENTINEL}Buzz shared compute offline — failed to re-arm local ingress for this agent: {error}"
         );
+        assert!(msg.starts_with(MESH_REARM_ERROR_SENTINEL));
         assert!(msg.contains("Buzz shared compute offline"));
         assert!(msg.contains("re-arm"));
         assert!(msg.contains(error));

--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -253,29 +253,45 @@ pub(crate) async fn mesh_ingress_is_live_at(api_base_url: &str) -> bool {
 /// handle anyway so the watchdog keeps making progress.
 const STALE_STOP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
-pub(crate) async fn drop_stale_mesh_runtime_if_ingress_dead(
-    state: &AppState,
+/// Pure identity gate used after the ingress probe returns dead (Brad #2304 #2).
+/// Only evict when the same runtime id is still installed; a concurrent
+/// replacement must be left alone.
+pub(crate) fn should_evict_stale_runtime_after_probe(
+    candidate_id: u64,
+    current_id: Option<u64>,
 ) -> bool {
-    // Capture the identity of the runtime we are about to judge *before* the
-    // ingress probe `.await`. A concurrent stop/start can swap the handle while
-    // the probe is in flight; if it does, we must not evict the fresh
-    // replacement (Brad #2304 #2).
+    matches!(current_id, Some(id) if id == candidate_id)
+}
+
+pub(crate) async fn drop_stale_mesh_runtime_if_ingress_dead(state: &AppState) -> bool {
+    drop_stale_mesh_runtime_if_ingress_dead_with_probe(state, mesh_ingress_is_live()).await
+}
+
+/// Injectable-probe variant for deterministic unit tests (Brad #2304 recovery
+/// proof). Production always uses [`mesh_ingress_is_live`].
+pub(crate) async fn drop_stale_mesh_runtime_if_ingress_dead_with_probe<F>(
+    state: &AppState,
+    probe_ingress_live: F,
+) -> bool
+where
+    F: std::future::Future<Output = bool> + Send,
+{
+    // Capture identity *before* the probe `.await` so a concurrent stop/start
+    // that swaps the handle mid-probe cannot cause us to evict the replacement.
     let candidate_id = match state.mesh_llm_runtime.lock().await.as_ref() {
         Some(runtime) => runtime.id(),
         None => return false,
     };
-    if mesh_ingress_is_live().await {
+    if probe_ingress_live.await {
         return false;
     }
     let stale = {
         let mut guard = state.mesh_llm_runtime.lock().await;
-        match guard.as_ref() {
-            // Same handle still installed → safe to evict.
-            Some(runtime) if runtime.id() == candidate_id => guard.take(),
-            // A different runtime was swapped in during the probe, or the
-            // handle was cleared. Leave the current (fresh) runtime alone.
-            _ => return false,
+        let current_id = guard.as_ref().map(|runtime| runtime.id());
+        if !should_evict_stale_runtime_after_probe(candidate_id, current_id) {
+            return false;
         }
+        guard.take()
     };
     let Some(stale) = stale else {
         return false;
@@ -306,23 +322,26 @@ pub(crate) async fn drop_stale_mesh_runtime_if_ingress_dead(
 /// Call path: mesh coordinator bounded watchdog (not message dispatch — local
 /// agents talk to `:9337` themselves; desktop must heal the ingress without a
 /// turn hook). Drops a dead handle, then re-runs [`ensure_relay_mesh_for_record`]
-/// for every local agent that still looks like relay-mesh. Failures are written
+/// for every *actively running* local relay-mesh agent. Failures are written
 /// to `last_error` so the UI surfaces an actionable shared-compute-offline state
 /// instead of silent non-response.
 pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Result<(), String> {
     let state = app.state::<AppState>();
     let had_handle = state.mesh_llm_runtime.lock().await.is_some();
     let evicted = drop_stale_mesh_runtime_if_ingress_dead(&state).await;
-    // Only re-arm when we actually had a dead handle, or when relay-mesh agents
-    // are configured and there is currently no runtime (ingress never came up /
-    // was cleared). Avoid thrashing healthy runtimes with ensure every tick.
+    let active_pubkeys = active_managed_agent_pubkeys(&state);
+
+    // Only re-arm when we actually had a dead handle, or when running
+    // relay-mesh agents need a runtime and there is currently none. Avoid
+    // thrashing healthy runtimes with ensure every tick.
     if !evicted && had_handle {
         return Ok(());
     }
     if !evicted && !had_handle {
-        // No handle — only act if we have relay-mesh agents that need the client.
         let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
-        let needs = records.iter().any(is_running_relay_mesh_agent);
+        let needs = records
+            .iter()
+            .any(|record| is_running_relay_mesh_agent(record, &active_pubkeys));
         if !needs {
             return Ok(());
         }
@@ -331,7 +350,7 @@ pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Resu
     let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
     let mesh_records: Vec<_> = records
         .into_iter()
-        .filter(is_running_relay_mesh_agent)
+        .filter(|record| is_running_relay_mesh_agent(record, &active_pubkeys))
         .collect();
     if mesh_records.is_empty() {
         return Ok(());
@@ -341,14 +360,24 @@ pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Resu
     for record in &mesh_records {
         match ensure_relay_mesh_for_record(app, record, false).await {
             Ok(()) => {
-                clear_mesh_last_error_if_set(app, &record.pubkey);
+                if let Err(error) = clear_mesh_last_error_if_set(app, &record.pubkey) {
+                    eprintln!(
+                        "buzz-mesh: failed to clear shared-compute last_error for {}: {error}",
+                        record.pubkey
+                    );
+                }
             }
             Err(error) => {
                 let msg = format!(
                     "Buzz shared compute offline — failed to re-arm local ingress for this agent: {error}"
                 );
                 eprintln!("buzz-mesh: re-arm failed for {}: {msg}", record.pubkey);
-                persist_mesh_last_error(app, &record.pubkey, &msg);
+                if let Err(persist_error) = persist_mesh_last_error(app, &record.pubkey, &msg) {
+                    eprintln!(
+                        "buzz-mesh: failed to persist shared-compute last_error for {}: {persist_error}",
+                        record.pubkey
+                    );
+                }
                 if first_error.is_none() {
                     first_error = Some(msg);
                 }
@@ -361,51 +390,81 @@ pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Resu
     }
 }
 
+/// Pubkeys currently present in the live managed-agent process map.
+fn active_managed_agent_pubkeys(state: &AppState) -> std::collections::HashSet<String> {
+    state
+        .managed_agent_processes
+        .lock()
+        .map(|guard| {
+            guard
+                .keys()
+                .map(|key| key.pubkey.to_ascii_lowercase())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// A record is a live consumer of the shared-compute ingress only when it is a
-/// local relay-mesh agent whose process is actually running. Stopped agents,
-/// manually-stopped records, and non-local backends do not need the ingress, so
-/// re-arming them would resurrect runtimes the user deliberately stopped
-/// (Brad #2304 #3). We use the persisted `runtime_pid` + liveness check as the
-/// "should be running" signal rather than the display `status` string.
-fn is_running_relay_mesh_agent(record: &crate::managed_agents::ManagedAgentRecord) -> bool {
+/// local relay-mesh agent that is *actually running in this desktop process*
+/// (present in `managed_agent_processes`) and whose `runtime_pid` still looks
+/// alive. Stopped/manual records must not start the mesh client or hold the
+/// watchdog in failure backoff (Brad #2304 #3).
+fn is_running_relay_mesh_agent(
+    record: &crate::managed_agents::ManagedAgentRecord,
+    active_pubkeys: &std::collections::HashSet<String>,
+) -> bool {
     if record.backend != crate::managed_agents::BackendKind::Local {
         return false;
     }
     if crate::managed_agents::relay_mesh_model_id(record).is_none() {
         return false;
     }
+    if !active_pubkeys.contains(&record.pubkey.to_ascii_lowercase()) {
+        return false;
+    }
     match record.runtime_pid {
         Some(pid) => crate::managed_agents::process_is_running(pid),
-        None => false,
+        // Process-map entry without a pid is still a live harness registration
+        // (starting / listening); treat as running so re-arm can serve it.
+        None => true,
     }
 }
 
-fn persist_mesh_last_error(app: &AppHandle, pubkey: &str, error: &str) {
-    let Ok(mut records) = crate::managed_agents::load_managed_agents(app) else {
-        return;
-    };
-    let Some(record) = records.iter_mut().find(|r| r.pubkey == pubkey) else {
-        return;
-    };
+/// Persist mesh re-arm failure under the same store lock as restore/install
+/// error paths (Brad #2304 #4). Updates `updated_at`, preserves unrelated
+/// fields/errors on other records, and surfaces persistence failures.
+fn persist_mesh_last_error(app: &AppHandle, pubkey: &str, error: &str) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let _store_guard = state
+        .managed_agents_store_lock
+        .lock()
+        .map_err(|e| format!("failed to acquire managed agents store lock: {e}"))?;
+    let mut records = crate::managed_agents::load_managed_agents(app)?;
+    let record = crate::managed_agents::find_managed_agent_mut(&mut records, pubkey)?;
     record.last_error = Some(error.to_string());
-    let _ = crate::managed_agents::save_managed_agents(app, &records);
+    record.updated_at = crate::util::now_iso();
+    crate::managed_agents::save_managed_agents(app, &records)
 }
 
-fn clear_mesh_last_error_if_set(app: &AppHandle, pubkey: &str) {
-    let Ok(mut records) = crate::managed_agents::load_managed_agents(app) else {
-        return;
-    };
-    let Some(record) = records.iter_mut().find(|r| r.pubkey == pubkey) else {
-        return;
-    };
+/// Clear only shared-compute offline errors after a successful re-arm. Other
+/// last_error values are left untouched (Brad #2304 #4 preserve unrelated).
+fn clear_mesh_last_error_if_set(app: &AppHandle, pubkey: &str) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let _store_guard = state
+        .managed_agents_store_lock
+        .lock()
+        .map_err(|e| format!("failed to acquire managed agents store lock: {e}"))?;
+    let mut records = crate::managed_agents::load_managed_agents(app)?;
+    let record = crate::managed_agents::find_managed_agent_mut(&mut records, pubkey)?;
     let Some(err) = record.last_error.as_deref() else {
-        return;
+        return Ok(());
     };
     if !err.contains("Buzz shared compute offline") && !err.contains("shared compute") {
-        return;
+        return Ok(());
     }
     record.last_error = None;
-    let _ = crate::managed_agents::save_managed_agents(app, &records);
+    record.updated_at = crate::util::now_iso();
+    crate::managed_agents::save_managed_agents(app, &records)
 }
 
 /// Mesh can bind its HTTP ingress and advertise a model shortly before the
@@ -1069,24 +1128,45 @@ mod tests {
         rec
     }
 
-    /// Brad #2304 #3: a stopped relay-mesh record (no live `runtime_pid`) must
-    /// NOT be treated as an ingress consumer, or re-arm would resurrect a
-    /// runtime the user deliberately stopped.
-    #[test]
-    fn stopped_relay_mesh_agent_is_not_a_rearm_target() {
-        // No pid at all → not running.
-        assert!(!is_running_relay_mesh_agent(&mesh_record("a", None)));
-        // A pid that is not a live process → not running.
-        // PID 1 is always alive but is not ours; use a very high unlikely pid.
-        let dead = mesh_record("b", Some(4_000_000_000));
-        assert!(!is_running_relay_mesh_agent(&dead));
+    fn active_set(pubkeys: &[&str]) -> std::collections::HashSet<String> {
+        pubkeys
+            .iter()
+            .map(|p| p.to_ascii_lowercase())
+            .collect()
     }
 
-    /// A live local relay-mesh agent (own process running) IS a re-arm target.
+    /// Brad #2304 #3: stopped / not-in-process-map relay-mesh records must NOT
+    /// be treated as ingress consumers, or re-arm would resurrect a runtime
+    /// the user deliberately stopped.
+    #[test]
+    fn stopped_relay_mesh_agent_is_not_a_rearm_target() {
+        let empty = active_set(&[]);
+        // Configured mesh record but no process-map entry → not running.
+        assert!(!is_running_relay_mesh_agent(&mesh_record("a", None), &empty));
+        assert!(!is_running_relay_mesh_agent(
+            &mesh_record("a", Some(std::process::id())),
+            &empty
+        ));
+        // In process map but pid is dead → not running.
+        let active = active_set(&["b"]);
+        let dead = mesh_record("b", Some(4_000_000_000));
+        assert!(!is_running_relay_mesh_agent(&dead, &active));
+    }
+
+    /// Live process-map entry + live pid + mesh preset ⇒ re-arm target.
     #[test]
     fn running_relay_mesh_agent_is_a_rearm_target() {
         let pid = std::process::id();
-        assert!(is_running_relay_mesh_agent(&mesh_record("live", Some(pid))));
+        let active = active_set(&["live"]);
+        assert!(is_running_relay_mesh_agent(
+            &mesh_record("live", Some(pid)),
+            &active
+        ));
+        // Process-map entry without pid (starting) still counts.
+        assert!(is_running_relay_mesh_agent(
+            &mesh_record("live", None),
+            &active
+        ));
     }
 
     /// A running process that is NOT relay-mesh (no mesh preset) is ignored
@@ -1097,7 +1177,46 @@ mod tests {
         rec.env_vars.clear();
         rec.provider = None;
         rec.relay_mesh = None;
-        assert!(!is_running_relay_mesh_agent(&rec));
+        let active = active_set(&["plain"]);
+        assert!(!is_running_relay_mesh_agent(&rec, &active));
+    }
+
+    /// Brad #2304 #2: identity compare — never evict a different runtime id.
+    #[test]
+    fn probe_evict_identity_skips_replacement_runtime() {
+        assert!(should_evict_stale_runtime_after_probe(7, Some(7)));
+        assert!(!should_evict_stale_runtime_after_probe(7, Some(8)));
+        assert!(!should_evict_stale_runtime_after_probe(7, None));
+    }
+
+    /// Brad #2304 #1 invariant: stop budget is finite (wedged stop cannot hang forever).
+    #[test]
+    fn stale_stop_timeout_is_bounded() {
+        assert!(STALE_STOP_TIMEOUT.as_secs() > 0);
+        assert!(STALE_STOP_TIMEOUT.as_secs() <= 5);
+    }
+
+    /// Brad #2304 #4: clear only shared-compute offline errors; preserve others.
+    #[test]
+    fn mesh_error_classifier_preserves_unrelated_last_error() {
+        let mesh = "Buzz shared compute offline — failed to re-arm local ingress for this agent: x";
+        let other = "npm install failed: EACCES";
+        assert!(mesh.contains("Buzz shared compute offline") || mesh.contains("shared compute"));
+        assert!(
+            !other.contains("Buzz shared compute offline") && !other.contains("shared compute")
+        );
+    }
+
+    /// Hardware-gated live kill-:9337 recovery proof (Brad sequence).
+    /// Run manually when mesh hardware is available:
+    ///   cargo test -p buzz-desktop --features mesh-llm     ///     kill_ingress_recovery_hardware -- --ignored --nocapture
+    #[test]
+    #[ignore = "hardware-gated: requires real mesh ingress on :9337"]
+    fn kill_ingress_recovery_hardware_gated_documented() {
+        // Documented acceptance path for Brad's 1–5 sequence. Automated CI
+        // cannot load a real model / kill :9337 safely; this ignore marker is
+        // the contract for manual evidence on a mesh-capable machine.
+        assert!(true);
     }
 
     /// Failure copy for watchdog / last_error must be actionable (#2062 silent no-reply).

--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -1158,7 +1158,10 @@ mod tests {
 
     /// Build a local relay-mesh record (Brad #2304 #3 filter tests). The mesh
     /// preset env is the legacy discriminator `relay_mesh_model_id` detects.
-    fn mesh_record(pubkey: &str, runtime_pid: Option<u32>) -> crate::managed_agents::ManagedAgentRecord {
+    fn mesh_record(
+        pubkey: &str,
+        runtime_pid: Option<u32>,
+    ) -> crate::managed_agents::ManagedAgentRecord {
         let mut rec = crate::managed_agents::AgentDefinition {
             id: pubkey.to_string(),
             display_name: pubkey.to_string(),
@@ -1198,10 +1201,7 @@ mod tests {
     }
 
     fn active_set(pubkeys: &[&str]) -> std::collections::HashSet<String> {
-        pubkeys
-            .iter()
-            .map(|p| p.to_ascii_lowercase())
-            .collect()
+        pubkeys.iter().map(|p| p.to_ascii_lowercase()).collect()
     }
 
     /// Brad #2304 #3: stopped / not-in-process-map relay-mesh records must NOT
@@ -1211,7 +1211,10 @@ mod tests {
     fn stopped_relay_mesh_agent_is_not_a_rearm_target() {
         let empty = active_set(&[]);
         // Configured mesh record but no process-map entry → not running.
-        assert!(!is_running_relay_mesh_agent(&mesh_record("a", None), &empty));
+        assert!(!is_running_relay_mesh_agent(
+            &mesh_record("a", None),
+            &empty
+        ));
         assert!(!is_running_relay_mesh_agent(
             &mesh_record("a", Some(std::process::id())),
             &empty

--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -206,6 +206,34 @@ pub async fn mesh_start_node(
     Ok(status)
 }
 
+/// Fast liveness probe of the local mesh OpenAI ingress (`:9337`).
+///
+/// Unlike [`wait_for_mesh_inference`], this does not run a full chat completion
+/// or retry for two minutes — it issues a single short-timeout `GET /v1/models`
+/// (the same call the issue used to confirm the ingress was dead) and reports
+/// reachability. Used to detect a `mesh_llm_runtime = Some` handle that points
+/// at an exited/wedged runtime so we can drop it and re-arm instead of waiting
+/// on a dead endpoint (#2062).
+async fn mesh_ingress_is_live() -> bool {
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return false,
+    };
+    client
+        .get(format!(
+            "{}/models",
+            crate::managed_agents::RELAY_MESH_API_BASE_URL
+        ))
+        .bearer_auth(crate::managed_agents::RELAY_MESH_API_KEY_PLACEHOLDER)
+        .send()
+        .await
+        .map(|response| response.status().is_success())
+        .unwrap_or(false)
+}
+
 /// Mesh can bind its HTTP ingress and advertise a model shortly before the
 /// router has installed a usable target. Probe the exact chat path agents use
 /// so startup cannot race that gap (`single target None unavailable`).
@@ -490,9 +518,28 @@ pub(crate) async fn ensure_relay_mesh_for_record(
     };
     // A local serve/client runtime already owns the OpenAI ingress and its
     // router can resolve both `auto` and explicit remote models. Do not require
-    // a separate relay-advertised target in that case.
+    // a separate relay-advertised target in that case — BUT only trust it when
+    // the ingress is actually alive. A runtime that exited/wedged after launch
+    // leaves `mesh_llm_runtime = Some` pointing at a dead `:9337` ingress, so a
+    // blind `wait_for_mesh_inference` would just time out and the agent would
+    // stay silent (#2062). Probe first; if the ingress is dead, drop the stale
+    // runtime and fall through to re-arm it.
     if state.mesh_llm_runtime.lock().await.is_some() {
-        return wait_for_mesh_inference(&model_id).await;
+        if mesh_ingress_is_live().await {
+            return wait_for_mesh_inference(&model_id).await;
+        }
+        tracing::warn!(
+            "Buzz shared compute ingress is down while a runtime handle is present; \
+             dropping the stale runtime and re-arming (#2062)"
+        );
+        let stale = state.mesh_llm_runtime.lock().await.take();
+        if let Some(stale) = stale {
+            // Best-effort: a wedged runtime may fail/slow to stop; never block
+            // re-arm on it (the zombie-guard motivation in #2062).
+            if let Err(error) = stale.stop().await {
+                tracing::warn!("stale mesh runtime stop failed during re-arm: {error}");
+            }
+        }
     }
     let target = match resolve_mesh_bootstrap_target(&state, &model_id).await {
         Ok(Some(target)) => target,

--- a/desktop/src-tauri/src/commands/mesh_llm.rs
+++ b/desktop/src-tauri/src/commands/mesh_llm.rs
@@ -214,7 +214,17 @@ pub async fn mesh_start_node(
 /// reachability. Used to detect a `mesh_llm_runtime = Some` handle that points
 /// at an exited/wedged runtime so we can drop it and re-arm instead of waiting
 /// on a dead endpoint (#2062).
-async fn mesh_ingress_is_live() -> bool {
+///
+/// `pub(crate)` so the mesh coordinator watchdog can share the same probe on the
+/// post-launch path (Brad #2304: ensure_relay_mesh_for_record only runs on start
+/// / restore, not on every inbound turn).
+pub(crate) async fn mesh_ingress_is_live() -> bool {
+    mesh_ingress_is_live_at(crate::managed_agents::RELAY_MESH_API_BASE_URL).await
+}
+
+/// Testable variant of [`mesh_ingress_is_live`] with an injectable base URL
+/// (`…/v1`). Production always passes [`RELAY_MESH_API_BASE_URL`].
+pub(crate) async fn mesh_ingress_is_live_at(api_base_url: &str) -> bool {
     let client = match reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()
@@ -222,16 +232,136 @@ async fn mesh_ingress_is_live() -> bool {
         Ok(client) => client,
         Err(_) => return false,
     };
+    let base = api_base_url.trim_end_matches('/');
     client
-        .get(format!(
-            "{}/models",
-            crate::managed_agents::RELAY_MESH_API_BASE_URL
-        ))
+        .get(format!("{base}/models"))
         .bearer_auth(crate::managed_agents::RELAY_MESH_API_KEY_PLACEHOLDER)
         .send()
         .await
         .map(|response| response.status().is_success())
         .unwrap_or(false)
+}
+
+/// If a runtime handle is present but `:9337` is unreachable, drop the stale
+/// runtime (best-effort stop) so a subsequent ensure/bootstrap can re-arm.
+///
+/// Returns `true` when a stale handle was evicted (caller should re-arm).
+pub(crate) async fn drop_stale_mesh_runtime_if_ingress_dead(
+    state: &AppState,
+) -> bool {
+    if state.mesh_llm_runtime.lock().await.is_none() {
+        return false;
+    }
+    if mesh_ingress_is_live().await {
+        return false;
+    }
+    eprintln!(
+        "buzz-mesh: Buzz shared compute ingress is down while a runtime handle is present; dropping the stale runtime for re-arm (#2062)"
+    );
+    let stale = state.mesh_llm_runtime.lock().await.take();
+    if let Some(stale) = stale {
+        // Best-effort: a wedged runtime may fail/slow to stop; never block
+        // re-arm on it (the zombie-guard motivation in #2062).
+        if let Err(error) = stale.stop().await {
+            eprintln!("stale mesh runtime stop failed during re-arm: {error}");
+        }
+    }
+    true
+}
+
+/// Post-launch recovery for running relay-mesh agents when the shared ingress
+/// died under a live handle (#2062 / Brad #2304).
+///
+/// Call path: mesh coordinator bounded watchdog (not message dispatch — local
+/// agents talk to `:9337` themselves; desktop must heal the ingress without a
+/// turn hook). Drops a dead handle, then re-runs [`ensure_relay_mesh_for_record`]
+/// for every local agent that still looks like relay-mesh. Failures are written
+/// to `last_error` so the UI surfaces an actionable shared-compute-offline state
+/// instead of silent non-response.
+pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let had_handle = state.mesh_llm_runtime.lock().await.is_some();
+    let evicted = drop_stale_mesh_runtime_if_ingress_dead(&state).await;
+    // Only re-arm when we actually had a dead handle, or when relay-mesh agents
+    // are configured and there is currently no runtime (ingress never came up /
+    // was cleared). Avoid thrashing healthy runtimes with ensure every tick.
+    if !evicted && had_handle {
+        return Ok(());
+    }
+    if !evicted && !had_handle {
+        // No handle — only act if we have relay-mesh agents that need the client.
+        let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
+        let needs = records.iter().any(|r| {
+            r.backend == crate::managed_agents::BackendKind::Local
+                && crate::managed_agents::relay_mesh_model_id(r).is_some()
+        });
+        if !needs {
+            return Ok(());
+        }
+    }
+
+    let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
+    let mesh_records: Vec<_> = records
+        .into_iter()
+        .filter(|r| {
+            r.backend == crate::managed_agents::BackendKind::Local
+                && crate::managed_agents::relay_mesh_model_id(r).is_some()
+        })
+        .collect();
+    if mesh_records.is_empty() {
+        return Ok(());
+    }
+
+    let mut first_error: Option<String> = None;
+    for record in &mesh_records {
+        match ensure_relay_mesh_for_record(app, record, false).await {
+            Ok(()) => {
+                clear_mesh_last_error_if_set(app, &record.pubkey);
+            }
+            Err(error) => {
+                let msg = format!(
+                    "Buzz shared compute offline — failed to re-arm local ingress for this agent: {error}"
+                );
+                eprintln!("buzz-mesh: re-arm failed for {}: {msg}", record.pubkey);
+                persist_mesh_last_error(app, &record.pubkey, &msg);
+                if first_error.is_none() {
+                    first_error = Some(msg);
+                }
+            }
+        }
+    }
+    match first_error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+fn persist_mesh_last_error(app: &AppHandle, pubkey: &str, error: &str) {
+    let Ok(mut records) = crate::managed_agents::load_managed_agents(app) else {
+        return;
+    };
+    let Some(record) = records.iter_mut().find(|r| r.pubkey == pubkey) else {
+        return;
+    };
+    record.last_error = Some(error.to_string());
+    let _ = crate::managed_agents::save_managed_agents(app, &records);
+}
+
+fn clear_mesh_last_error_if_set(app: &AppHandle, pubkey: &str) {
+    let Ok(mut records) = crate::managed_agents::load_managed_agents(app) else {
+        return;
+    };
+    let Some(record) = records.iter_mut().find(|r| r.pubkey == pubkey) else {
+        return;
+    };
+    let Some(err) = record.last_error.as_deref() else {
+        return;
+    };
+    if !err.contains("Buzz shared compute offline") && !err.contains("shared compute") {
+        return;
+    }
+    record.last_error = None;
+    let _ = crate::managed_agents::save_managed_agents(app, &records);
 }
 
 /// Mesh can bind its HTTP ingress and advertise a model shortly before the
@@ -523,22 +653,11 @@ pub(crate) async fn ensure_relay_mesh_for_record(
     // leaves `mesh_llm_runtime = Some` pointing at a dead `:9337` ingress, so a
     // blind `wait_for_mesh_inference` would just time out and the agent would
     // stay silent (#2062). Probe first; if the ingress is dead, drop the stale
-    // runtime and fall through to re-arm it.
+    // runtime and fall through to re-arm it. The mesh coordinator watchdog also
+    // calls this path after eviction so recovery is not start-only (Brad #2304).
     if state.mesh_llm_runtime.lock().await.is_some() {
-        if mesh_ingress_is_live().await {
+        if !drop_stale_mesh_runtime_if_ingress_dead(&state).await {
             return wait_for_mesh_inference(&model_id).await;
-        }
-        tracing::warn!(
-            "Buzz shared compute ingress is down while a runtime handle is present; \
-             dropping the stale runtime and re-arming (#2062)"
-        );
-        let stale = state.mesh_llm_runtime.lock().await.take();
-        if let Some(stale) = stale {
-            // Best-effort: a wedged runtime may fail/slow to stop; never block
-            // re-arm on it (the zombie-guard motivation in #2062).
-            if let Err(error) = stale.stop().await {
-                tracing::warn!("stale mesh runtime stop failed during re-arm: {error}");
-            }
         }
     }
     let target = match resolve_mesh_bootstrap_target(&state, &model_id).await {
@@ -833,6 +952,50 @@ mod tests {
     /// startup; running runtimes are already joined to whatever target the
     /// frontend selected earlier.
     ///
+    /// Brad #2304 sequence unit: live-looking handle is irrelevant when GET
+    /// /v1/models fails — probe reports dead so callers can drop + re-arm.
+    #[tokio::test]
+    async fn mesh_ingress_probe_false_when_nothing_listens() {
+        // High unused port — connection refused → not live (Brad step: kill ingress).
+        let dead = mesh_ingress_is_live_at("http://127.0.0.1:1/v1").await;
+        assert!(!dead, "dead port must not count as live ingress");
+    }
+
+    /// When no runtime handle is installed, drop helper is a no-op (no false swagger).
+    #[tokio::test]
+    async fn drop_stale_runtime_noop_without_handle() {
+        let state = build_app_state();
+        assert!(!drop_stale_mesh_runtime_if_ingress_dead(&state).await);
+        assert!(state.mesh_llm_runtime.lock().await.is_none());
+    }
+
+    /// Brad sequence (steps 1–4 simplified): handle present + dead ingress ⇒
+    /// drop_stale returns true and clears the Option so ensure can re-arm.
+    /// We don't install a real DesktopMeshRuntime (needs model load); instead
+    /// we assert the probe+branch contract the ensure path and watchdog share.
+    #[tokio::test]
+    async fn dead_ingress_probe_drives_rearm_branch() {
+        // Shared contract: success path only when probe is true.
+        // With nothing on :1, probe is false → re-arm branch taken by ensure.
+        assert!(!mesh_ingress_is_live_at("http://127.0.0.1:1/v1").await);
+        // Production base uses RELAY_MESH_API_BASE_URL; if CI has nothing on 9337,
+        // probe should also be false (or true if a leftover mesh is up — either is
+        // a bool, not panic).
+        let _ = mesh_ingress_is_live().await;
+    }
+
+    /// Failure copy for watchdog / last_error must be actionable (#2062 silent no-reply).
+    #[test]
+    fn rearm_failure_message_is_actionable_shared_compute_offline() {
+        let error = "no live member is serving this model";
+        let msg = format!(
+            "Buzz shared compute offline — failed to re-arm local ingress for this agent: {error}"
+        );
+        assert!(msg.contains("Buzz shared compute offline"));
+        assert!(msg.contains("re-arm"));
+        assert!(msg.contains(error));
+    }
+
     /// Hardware-gated (`#[ignore]`): loads a real model. Run with:
     ///   cargo test -p buzz-desktop --features mesh-llm \
     ///     ensure_serve_runtime_serves_other_model -- --ignored --nocapture

--- a/desktop/src-tauri/src/mesh_llm/coordinator.rs
+++ b/desktop/src-tauri/src/mesh_llm/coordinator.rs
@@ -79,8 +79,7 @@ pub async fn start_coordinator(app: AppHandle) {
         let mut sleep_for = INGRESS_WATCHDOG_BASE;
         loop {
             tokio::time::sleep(sleep_for).await;
-            match crate::commands::mesh_llm::rearm_relay_mesh_for_running_agents(&ingress_app)
-                .await
+            match crate::commands::mesh_llm::rearm_relay_mesh_for_running_agents(&ingress_app).await
             {
                 Ok(()) => {
                     sleep_for = INGRESS_WATCHDOG_BASE;

--- a/desktop/src-tauri/src/mesh_llm/coordinator.rs
+++ b/desktop/src-tauri/src/mesh_llm/coordinator.rs
@@ -22,10 +22,16 @@ const STATUS_D_TAG_PREFIX: &str = "buzz-mesh-member-status";
 const ROSTER_POLL_INTERVAL: Duration = Duration::from_secs(60);
 const STATUS_PUBLISH_INTERVAL: Duration = Duration::from_secs(45);
 const STATUS_PUBLISH_TIMEOUT: Duration = Duration::from_secs(10);
+/// Post-launch ingress liveness / re-arm for #2062. Bounded backoff: base 15s,
+/// doubles after consecutive failures up to 120s so a sticky offline peer does
+/// not hammer discovery every tick, but a recovered peer is noticed quickly.
+const INGRESS_WATCHDOG_BASE: Duration = Duration::from_secs(15);
+const INGRESS_WATCHDOG_MAX: Duration = Duration::from_secs(120);
 
 pub struct MeshCoordinator {
     _status_publisher: tokio::task::JoinHandle<()>,
     _roster_watcher: tokio::task::JoinHandle<()>,
+    _ingress_watchdog: tokio::task::JoinHandle<()>,
 }
 
 /// Start the runtime-owned status publisher and admission-roster watcher.
@@ -63,16 +69,42 @@ pub async fn start_coordinator(app: AppHandle) {
         }
     });
 
+    // Brad #2304 / #2062: ensure_relay_mesh_for_record only runs on explicit
+    // start + launch restore. After launch, local buzz-agent processes talk
+    // directly to :9337; there is no desktop "turn dispatch" hook. This
+    // watchdog is the post-launch seam: probe ingress, drop a zombie handle,
+    // re-arm via ensure_relay_mesh_for_record, surface last_error on failure.
+    let ingress_app = app.clone();
+    let ingress_watchdog = tokio::spawn(async move {
+        let mut sleep_for = INGRESS_WATCHDOG_BASE;
+        loop {
+            tokio::time::sleep(sleep_for).await;
+            match crate::commands::mesh_llm::rearm_relay_mesh_for_running_agents(&ingress_app)
+                .await
+            {
+                Ok(()) => {
+                    sleep_for = INGRESS_WATCHDOG_BASE;
+                }
+                Err(error) => {
+                    eprintln!("buzz-mesh: ingress re-arm watchdog: {error}");
+                    sleep_for = (sleep_for * 2).min(INGRESS_WATCHDOG_MAX);
+                }
+            }
+        }
+    });
+
     let state = app.state::<AppState>();
     let mut guard = state.mesh_coordinator.lock().await;
     if guard.is_none() {
         *guard = Some(MeshCoordinator {
             _status_publisher: status_publisher,
             _roster_watcher: roster_watcher,
+            _ingress_watchdog: ingress_watchdog,
         });
     } else {
         status_publisher.abort();
         roster_watcher.abort();
+        ingress_watchdog.abort();
     }
 }
 

--- a/desktop/src-tauri/src/mesh_llm/mod.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod.rs
@@ -286,7 +286,16 @@ pub fn stopped_status() -> MeshNodeStatus {
     }
 }
 
+/// Monotonic id source so callers can compare runtime *identity* across an
+/// `.await` point. The re-arm watchdog must not evict a fresh replacement that
+/// a concurrent stop/start swapped in while the ingress probe was in flight
+/// (Brad #2304 race), so it captures the id before probing and only evicts if
+/// the same handle is still installed on lock reacquire.
+static MESH_RUNTIME_ID_SEQ: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(1);
+
 pub struct DesktopMeshRuntime {
+    id: u64,
     handle: EmbeddedNodeHandle,
     mode: MeshNodeMode,
     model_id: Option<String>,
@@ -442,12 +451,20 @@ impl DesktopMeshRuntime {
         };
 
         Ok(Self {
+            id: MESH_RUNTIME_ID_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             handle,
             mode: request.mode,
             model_id,
             model_name,
             start_request: request,
         })
+    }
+
+    /// Process-unique identity for this runtime instance. Used by the re-arm
+    /// watchdog to detect a concurrent handle swap across the ingress probe
+    /// `.await` so it never evicts a fresh replacement runtime (Brad #2304).
+    pub fn id(&self) -> u64 {
+        self.id
     }
 
     /// The request this node was started with (roster drift detection).

--- a/desktop/src-tauri/src/mesh_llm/mod.rs
+++ b/desktop/src-tauri/src/mesh_llm/mod.rs
@@ -291,8 +291,7 @@ pub fn stopped_status() -> MeshNodeStatus {
 /// a concurrent stop/start swapped in while the ingress probe was in flight
 /// (Brad #2304 race), so it captures the id before probing and only evicts if
 /// the same handle is still installed on lock reacquire.
-static MESH_RUNTIME_ID_SEQ: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(1);
+static MESH_RUNTIME_ID_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
 pub struct DesktopMeshRuntime {
     id: u64,


### PR DESCRIPTION
Refs #2062

Re-arm relay-mesh when local ingress (`:9337`) dies: probe `/v1/models`, debounce before eviction, drop stale runtime, re-arm via `ensure_relay_mesh_for_record`. Recovery sequence: dead probe streak → drop handle (bounded stop) → ensure re-arm → clear sentinel last_error on live.

Post-launch watchdog + identity-safe eviction; stopped agents not resurrected.