### PR TITLE
feat(desktop): reverse agent activity list order (newest first)

### DIFF
--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -153,7 +153,7 @@ export function AgentSessionTranscriptList({
   );
 
   const displayBlocks = React.useMemo(
-    () => buildTranscriptDisplayBlocks(items, latestLiveSessionId),
+    () => buildTranscriptDisplayBlocks(items, latestLiveSessionId).reverse(),
     [items, latestLiveSessionId],
   );
   // Derive the same block keys the DOM renders as `data-message-id` so

--- a/desktop/src/features/agents/ui/RawEventRail.tsx
+++ b/desktop/src/features/agents/ui/RawEventRail.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import type { ObserverEvent } from "./agentSessionTypes";
 import { describeRawEvent } from "./agentSessionTranscript";
 import { observerEventScrollId } from "./agentSessionPanelLayout";
@@ -6,17 +7,18 @@ import { useTranscriptTimestampsEnabled } from "./transcriptTimestampPreference"
 
 export function RawEventRail({ events }: { events: ObserverEvent[] }) {
   const showTimestamps = useTranscriptTimestampsEnabled();
+  const displayEvents = React.useMemo(() => [...events].reverse(), [events]);
 
   return (
     <section className="flex min-h-0 w-full flex-col text-foreground">
       <div className="min-h-0 flex-1">
-        {events.length === 0 ? (
+        {displayEvents.length === 0 ? (
           <p className="py-8 text-center text-sm text-muted-foreground">
             No raw events yet.
           </p>
         ) : (
           <div className="space-y-2">
-            {events.map((event) => (
+            {displayEvents.map((event) => (
               <details
                 className="group rounded-md border border-border/55 bg-muted/25 px-2.5 py-1.5 transition-colors open:bg-muted/35"
                 data-message-id={observerEventScrollId(event)}

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildTranscriptDisplayBlocks,
+  deriveTranscriptBlockIds,
   flattenDisplayBlocks,
   formatTurnSetupLabel,
   getDisplayBlockKey,
@@ -1872,4 +1873,59 @@ test("getDisplayBlockKey_firstTurnReorder_keysStableAcrossReorder", () => {
     fullKeys,
     "block key identities must be identical before and after session_resolved seals the open batch (order may differ)",
   );
+});
+
+test("deriveTranscriptBlockIds returns block keys in reverse chronological order (newest first)", () => {
+  const events = [
+    {
+      seq: 1,
+      timestamp: "2026-07-08T00:00:01.000Z",
+      kind: "acp_read",
+      agentIndex: 0,
+      channelId: "chan-1",
+      sessionId: "sess-1",
+      turnId: "turn-1",
+      payload: {
+        method: "session/update",
+        params: {
+          sessionId: "sess-1",
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "call-1",
+            toolName: "tool-1",
+            status: "completed",
+            args: "{}",
+            result: "ok",
+          },
+        },
+      },
+    },
+    {
+      seq: 2,
+      timestamp: "2026-07-08T00:00:02.000Z",
+      kind: "acp_read",
+      agentIndex: 0,
+      channelId: "chan-1",
+      sessionId: "sess-1",
+      turnId: "turn-2",
+      payload: {
+        method: "session/update",
+        params: {
+          sessionId: "sess-1",
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "call-2",
+            toolName: "tool-2",
+            status: "completed",
+            args: "{}",
+            result: "ok",
+          },
+        },
+      },
+    },
+  ];
+
+  const ids = deriveTranscriptBlockIds(events);
+  // Turn 2 (newest) must come before Turn 1 (oldest) in reverse activity order
+  assert.deepEqual(ids, ["turn:turn-2", "turn:turn-1"]);
 });

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -780,7 +780,7 @@ export function deriveTranscriptBlockIds(
 ): string[] {
   const items = buildTranscriptState(events).items;
   const blocks = buildTranscriptDisplayBlocks(items);
-  return blocks.map(getDisplayBlockKey);
+  return blocks.map(getDisplayBlockKey).reverse();
 }
 
 /** Human-readable labels for a collapsed turn setup row. */


### PR DESCRIPTION
### Summary
Reverses the Agent Activity List (session transcript / observer feed) rendering order so that the **newest communications appear at the top**.

### UX Argumentation & Rationale
- **Top-of-Mind Focus**: Users monitoring agent activity need to see real-time progress and tool invocations immediately without scrolling to the bottom of long transcripts.
- **Consistent Operational Hierarchy**: Aligns with modern operational logs, dev tools, and activity streams where current state is placed at the top.
- **Preserved In-Turn Narrative**: Multi-step operations within individual turn blocks (Prompt -> Tool Executions -> Results) remain top-to-bottom for natural human reading order.

### Changes Made
- `AgentSessionTranscriptList.tsx`: Reversed display block order.
- `RawEventRail.tsx`: Reversed raw JSON-RPC event list.
- `agentSessionTranscriptGrouping.ts`: Updated `deriveTranscriptBlockIds` sequence for 1:1 scroll anchoring.
- `agentSessionTranscriptGrouping.test.mjs`: Added unit test coverage for reversed block ID order.

### Verification
- Executed `pnpm test` in `desktop/`: 184 unit tests passed cleanly.