### PR TITLE
fix(desktop): allow shared remote agents in mentions

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,6 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -244,9 +243,6 @@ export function useMentions(
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
       if (isArchivedDiscovery(pubkey)) {
-        return;
-      }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
         return;
       }
       if (


### PR DESCRIPTION
## Summary
- stop discarding remote relay agents solely because they are not desktop-managed
- preserve the existing invocability/directory filter in `shouldHideAgentFromMentions`
- keep the managed-only filter in the add-member flow unchanged

## Root cause
`useMentions` rejected non-managed agent identities before `shouldHideAgentFromMentions` could apply the existing shared relay-agent eligibility logic. Remote ACP agents could therefore be channel members and invocable but never appear in `@` autocomplete.

## Verification
- `pnpm test`: 3268 passed, 0 failed
- `pnpm typecheck`: blocked by pre-existing `TimelineMessageList.tsx:705` estimateSize type error unrelated to this diff