### PR TITLE
fix(cli): install rustls ring CryptoProvider at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "nostr",
  "rand 0.10.1",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/buzz-cli/Cargo.toml
+++ b/crates/buzz-cli/Cargo.toml
@@ -19,6 +19,9 @@ path = "src/main.rs"
 # CLI argument parsing — derive macros + env var support (BUZZ_API_TOKEN auto-wired)
 clap = { version = "4", features = ["derive", "env"] }
 
+# Explicit rustls dep so the CLI can install the ring CryptoProvider at startup
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+
 # HTTP client — async REST calls to the relay
 reqwest = { workspace = true, features = ["json"] }
 

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -25,6 +25,11 @@ where
     I: IntoIterator<Item = S>,
     S: Into<std::ffi::OsString> + Clone,
 {
+    // Install the ring CryptoProvider for rustls. The workspace enables more
+    // than one rustls crypto backend, so rustls cannot auto-select a
+    // process-level provider and panics on the first TLS-capable connection
+    // without this.
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let cli = match Cli::try_parse_from(args) {
         Ok(cli) => cli,
         Err(e) => {


### PR DESCRIPTION
## Problem

`buzz agents draft-create` (and any other CLI path that opens a TLS-capable connection) panics:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features
```

The workspace enables more than one rustls crypto backend (ring via some deps, aws-lc via others), so rustls 0.23 cannot auto-select a process-level provider. `buzz-relay`, `buzz-admin`, `buzz-acp`, and `buzz-dev-mcp` all install the ring provider explicitly at startup — `buzz-cli` was the one binary missing it.

## Fix

Install the ring provider at the top of `run_from_args`, matching the pattern used by the other workspace binaries, and add the explicit `rustls` dependency to `buzz-cli` (same feature set as `buzz-acp`).

## Verification

- Reproduced the panic with the pre-fix binary (agent-invoked `agents draft-create` against a local relay); rebuilt with the fix and the command completes.
- `cargo fmt --check`, `cargo clippy -p buzz-cli`, and `cargo test -p buzz-cli` (250 tests) all pass.
- Note: `buzz-db`'s `replica_fence::tests::fence_starts_closed_and_opens_on_advance` fails in my environment, but it fails identically on upstream `main` without this change — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)