### PR TITLE
docs(cli): remove stale phase-4 TODO comment in users.rs

### DIFF
--- a/crates/buzz-cli/src/commands/users.rs
+++ b/crates/buzz-cli/src/commands/users.rs
@@ -2,8 +2,6 @@ use crate::client::{normalize_write_response, BuzzClient};
 use crate::error::CliError;
 use crate::validate::validate_hex64;
 
-// TODO(phase-4): Replace raw nostr::EventBuilder usage in cmd_set_presence with buzz-sdk builder
-
 /// Get user profiles (kind:0 metadata events).
 ///
 /// - 0 pubkeys, no name → query our own profile


### PR DESCRIPTION
## What this does
Removes a stale TODO comment in `crates/buzz-cli/src/commands/users.rs`
that said `cmd_set_presence` still needed to be migrated from raw
`nostr::EventBuilder` to a `buzz-sdk` builder function.

## Why
That migration is already done — `cmd_set_presence` already calls
`buzz_sdk::build_presence_update(...)`, and there is no remaining
`nostr::EventBuilder` usage anywhere in this file. The comment was
just never cleaned up after the refactor landed.

## How to verify
`grep -n "EventBuilder" crates/buzz-cli/src/commands/users.rs` returns
no matches — confirming there's no remaining raw usage to migrate.

## Testing
Comment-only change, no code logic affected.